### PR TITLE
feat(conversations): Phase 2A — sleep-time compact pipeline

### DIFF
--- a/docs/superpowers/plans/2026-04-20-mur-conversations-phase-2.md
+++ b/docs/superpowers/plans/2026-04-20-mur-conversations-phase-2.md
@@ -1,0 +1,5455 @@
+# mur Conversations Archive — Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship Phase 2 of the mur conversations archive (spec `docs/superpowers/specs/2026-04-20-mur-conversations-phase-2-design.md`, commit `d0ee36f`) — sleep-time daily compact + Mode C (Ask) with Perplexity-style citations, both local-only via Ollama, plus commander daemon piggyback cron.
+
+**Architecture:** New `mur-core/src/conversations/summarize/` module for the compact pipeline; new `mur-core/src/conversations/ask/` for Mode C. Compact uses Ollama for extractive (per-chunk) + abstractive (single narrative) stages; writes hybrid summaries (frontmatter + extractive + abstractive + macro map) with atomic `.history/` archiving. Mode C retrieves tiered (layer=1 summary → layer=0 raw on low score), grounds citations, streams tokens. Commander piggyback is fire-and-forget `mur conversations compact` exec.
+
+**Tech Stack:** Rust 2024 · tokio · reqwest (Ollama HTTP) · aho-corasick (pattern names) · walkdir (patterns/) · existing Phase 1 deps (lancedb, chrono, serde, fs2, sha2, hex, uuid, futures, tracing).
+
+**Repos:**
+- `/Volumes/Firecuda4tb/Projects/mur` — primary (Phase 2A + 2B + 2C)
+- `/Volumes/Firecuda4tb/Projects/mur-commander` — Phase 2A only (§7 trigger)
+
+**Phased rollout per spec §10.3:**
+- **Phase 2A — Compact** (Tasks 1-17): unblocks retention; ships mur + commander. PR #1.
+- **Phase 2B — Ask** (Tasks 18-27): depends on 2A summaries. PR #2.
+- **Phase 2C — Hardening** (Tasks 28-32): polish + Ollama smoke + `.history/` cleanup. PR #3 (can slip to 2.1).
+
+---
+
+## File Structure
+
+### Phase 2A — mur repo (Compact)
+
+**Create:**
+```
+mur-core/src/conversations/ollama.rs                    shared Ollama HTTP client
+mur-core/src/conversations/summarize/mod.rs             public API + orchestrator
+mur-core/src/conversations/summarize/chunker.rs         message chunking under token budget
+mur-core/src/conversations/summarize/extractive.rs      LLM per-chunk span extraction
+mur-core/src/conversations/summarize/abstractive.rs     LLM narrative over spans
+mur-core/src/conversations/summarize/macro_refs.rs      Aho-Corasick pattern detection
+mur-core/src/conversations/summarize/writer.rs          atomic write + .history + audit + index
+```
+
+**Modify:**
+```
+mur-common/src/config.rs                                add CompactConfig to ConversationsConfig
+mur-core/src/conversations/mod.rs                       pub mod summarize + pub mod ollama
+mur-core/src/conversations/paths.rs                     add summary_history_dir()
+mur-core/src/conversations/index.rs                     add layer filter to search()
+mur-core/src/conversations/migrate.rs                   extend sync_commander_config_toml
+mur-core/src/cmd/conversations_cmd.rs                   add cmd_conversations_compact
+mur-core/src/main.rs                                    add ConversationsAction::Compact
+mur-core/Cargo.toml                                     aho-corasick, walkdir (walkdir already in migrate dep)
+```
+
+### Phase 2A — mur-commander repo (trigger)
+
+**Create:**
+```
+crates/daemon/src/triggers/conversations_compact.rs     cron trigger
+```
+
+**Modify:**
+```
+crates/daemon/src/triggers/mod.rs                       register new trigger
+crates/daemon/src/main.rs                               instantiate trigger from config
+crates/daemon/src/config.rs                             add ConversationsCompactConfig
+```
+
+### Phase 2B — mur repo (Ask)
+
+**Create:**
+```
+mur-core/src/conversations/ask/mod.rs                   public API: AskRequest, AskResponse, AskEvent, ask(), ask_stream()
+mur-core/src/conversations/ask/retrieve.rs              tiered retrieval
+mur-core/src/conversations/ask/prompt.rs                system prompt + context assembly
+mur-core/src/conversations/ask/generate.rs              Ollama streaming client
+mur-core/src/conversations/ask/cite.rs                  grounding + coverage
+mur-core/src/conversations/ask/format.rs                plain + json output
+```
+
+**Modify:**
+```
+mur-common/src/config.rs                                add AskConfig to ConversationsConfig
+mur-core/src/conversations/mod.rs                       pub mod ask
+mur-core/src/cmd/conversations_cmd.rs                   add cmd_ask
+mur-core/src/main.rs                                    add Commands::Ask
+```
+
+### Phase 2C — mur repo (Hardening)
+
+**Modify:**
+```
+mur-core/src/cmd/conversations_cmd.rs                   preflight Ollama checks, doctor summary-coverage + next-fire
+mur-core/src/conversations/summarize/writer.rs          .history/ retention cleanup + audit
+mur-core/src/conversations/ask/cite.rs                  strict-mode gate
+mur-core/tests/golden_path.rs                           (or shell script) add Step 9 compact + Step 10 ask
+```
+
+---
+
+## Task Overview (32 tasks)
+
+| # | Phase | Task | Dep |
+|---|-------|------|-----|
+| 1 | 2A | `CompactConfig` in `mur-common::config` | — |
+| 2 | 2A | `conversations::ollama` HTTP client (shared) | 1 |
+| 3 | 2A | Add `aho-corasick` + `walkdir` to Cargo; `summary_history_dir` path helper | — |
+| 4 | 2A | `summarize::chunker` message packing | 1 |
+| 5 | 2A | `summarize::extractive` LLM per-chunk spans | 2, 4 |
+| 6 | 2A | `summarize::abstractive` LLM narrative | 2, 5 |
+| 7 | 2A | `summarize::macro_refs` Aho-Corasick | 3 |
+| 8 | 2A | `index` — extend `search()` with layer filter | — |
+| 9 | 2A | `summarize::writer` atomic write + audit + index | 3, 6, 7, 8 |
+| 10 | 2A | `summarize::mod` orchestrator — `compact_day`, `compact_missing` | 9 |
+| 11 | 2A | Summary/raw serde types + Markdown renderer helpers | 1, 9 |
+| 12 | 2A | CLI — `cmd_conversations_compact` + `Commands::Conversations::Compact` | 10 |
+| 13 | 2A | `migrate.rs` — extend P4 sync for `[conversations.compact]` | 1 |
+| 14 | 2A | Commander `ConversationsCompactConfig` (cross-repo) | — |
+| 15 | 2A | Commander `triggers::conversations_compact` trigger (cross-repo) | 14 |
+| 16 | 2A | Commander `daemon::main` — instantiate trigger (cross-repo) | 15 |
+| 17 | 2A | Update `mur conversations doctor` — summary coverage + trigger status | 10, 14 |
+| 18 | 2B | `AskConfig` in `mur-common::config` | — |
+| 19 | 2B | `ask::mod` public types `AskRequest`/`AskResponse`/`AskEvent` | 18 |
+| 20 | 2B | `ask::retrieve` tiered escalation | 8, 19 |
+| 21 | 2B | `ask::prompt` system prompt + context assembly + budgeting | 19, 20 |
+| 22 | 2B | `ask::generate` Ollama streaming | 2, 21 |
+| 23 | 2B | `ask::cite` grounding filter (stream-aware) | 22 |
+| 24 | 2B | `ask::format` plain + json output | 23 |
+| 25 | 2B | `ask::mod::ask_stream` + `ask::mod::ask` glue | 20-24 |
+| 26 | 2B | CLI — `cmd_ask` + `Commands::Ask` top-level | 25 |
+| 27 | 2B | Extend `scripts/golden-path-conversations.sh` — Step 9 compact + Step 10 ask (with `MUR_OLLAMA_MOCK=1`) | 12, 26 |
+| 28 | 2C | `summarize::writer` — `.history/` retention cleanup + audit | 9 |
+| 29 | 2C | `ask::cite` — `--strict-citations` reject mode | 23 |
+| 30 | 2C | `conversations preflight` — Ollama reachability + model availability | 17 |
+| 31 | 2C | Real-Ollama smoke tests (feature-gated) | 10, 25 |
+| 32 | 2C | `.history/` rotation audit + `mur conversations doctor` coverage report | 28 |
+
+**Merge checkpoint:** pause after Task 17 (end of 2A) and Task 27 (end of 2B) for PR review before continuing.
+
+---
+
+## Task 1: `CompactConfig` in `mur-common::config` (Phase 2A)
+
+**Files:**
+- Modify: `mur-common/src/config.rs`
+
+- [ ] **Step 1: Failing test**
+
+Append to `mur-common/src/config.rs` (in the existing `conversations_tests` mod):
+
+```rust
+#[test]
+fn compact_config_defaults() {
+    let c = CompactConfig::default();
+    assert!(c.enabled_in_daemon);
+    assert_eq!(c.max_days_per_run, 7);
+    assert_eq!(c.extractive_model, "qwen3:14b");
+    assert_eq!(c.abstractive_model, "qwen3:14b");
+    assert_eq!(c.ollama_endpoint, "http://localhost:11434");
+    assert_eq!(c.max_extractive_spans, 20);
+    assert_eq!(c.max_abstractive_words, 400);
+    assert_eq!(c.chunk_tokens, 6000);
+    assert_eq!(c.history_retain, 5);
+    assert_eq!(c.daemon_cron, "0 3 * * *");
+}
+
+#[test]
+fn compact_parses_partial_overrides() {
+    let y = r#"
+conversations:
+  compact:
+    max_days_per_run: 3
+    extractive_model: qwen3:4b
+"#;
+    let v: serde_yaml::Value = serde_yaml::from_str(y).unwrap();
+    let conv: ConversationsConfig =
+        serde_yaml::from_value(v["conversations"].clone()).unwrap();
+    assert_eq!(conv.compact.max_days_per_run, 3);
+    assert_eq!(conv.compact.extractive_model, "qwen3:4b");
+    assert!(conv.compact.enabled_in_daemon); // default preserved
+    assert_eq!(conv.compact.abstractive_model, "qwen3:14b"); // default preserved
+}
+```
+
+- [ ] **Step 2: Run test — must fail**
+
+```
+cd /Volumes/Firecuda4tb/Projects/mur/.worktrees/conversations-phase-2
+cargo test -p mur-common config::conversations_tests::compact
+```
+
+Expected: compile error `cannot find struct 'CompactConfig' in this scope`.
+
+- [ ] **Step 3: Add `CompactConfig` struct**
+
+Insert into `mur-common/src/config.rs` alongside the existing Phase 1 conversations structs:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompactConfig {
+    #[serde(default = "conv_truthy")]
+    pub enabled_in_daemon: bool,
+    #[serde(default = "compact_default_max_days")]
+    pub max_days_per_run: u32,
+    #[serde(default = "compact_default_model")]
+    pub extractive_model: String,
+    #[serde(default = "compact_default_model")]
+    pub abstractive_model: String,
+    #[serde(default = "compact_default_ollama_endpoint")]
+    pub ollama_endpoint: String,
+    #[serde(default = "compact_default_max_spans")]
+    pub max_extractive_spans: u32,
+    #[serde(default = "compact_default_max_words")]
+    pub max_abstractive_words: u32,
+    #[serde(default = "compact_default_chunk_tokens")]
+    pub chunk_tokens: u32,
+    #[serde(default = "compact_default_history_retain")]
+    pub history_retain: u32,
+    #[serde(default = "compact_default_cron")]
+    pub daemon_cron: String,
+}
+
+impl Default for CompactConfig {
+    fn default() -> Self {
+        Self {
+            enabled_in_daemon: true,
+            max_days_per_run: compact_default_max_days(),
+            extractive_model: compact_default_model(),
+            abstractive_model: compact_default_model(),
+            ollama_endpoint: compact_default_ollama_endpoint(),
+            max_extractive_spans: compact_default_max_spans(),
+            max_abstractive_words: compact_default_max_words(),
+            chunk_tokens: compact_default_chunk_tokens(),
+            history_retain: compact_default_history_retain(),
+            daemon_cron: compact_default_cron(),
+        }
+    }
+}
+
+fn compact_default_max_days() -> u32 { 7 }
+fn compact_default_model() -> String { "qwen3:14b".into() }
+fn compact_default_ollama_endpoint() -> String { "http://localhost:11434".into() }
+fn compact_default_max_spans() -> u32 { 20 }
+fn compact_default_max_words() -> u32 { 400 }
+fn compact_default_chunk_tokens() -> u32 { 6000 }
+fn compact_default_history_retain() -> u32 { 5 }
+fn compact_default_cron() -> String { "0 3 * * *".into() }
+```
+
+Add field to `ConversationsConfig`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationsConfig {
+    // Phase 1 fields (unchanged)
+    #[serde(default)] pub enabled: bool,
+    #[serde(default = "conv_default_retention_days")] pub retention_days: u32,
+    #[serde(default = "conv_default_poll_interval")] pub poll_interval_secs: u64,
+    #[serde(default)] pub sources: ConversationsSources,
+    #[serde(default)] pub filter: ConversationsFilter,
+
+    // Phase 2 addition
+    #[serde(default)] pub compact: CompactConfig,
+}
+```
+
+Update `ConversationsConfig::default()` to include `compact: CompactConfig::default()`.
+
+- [ ] **Step 4: Run test**
+
+```
+cargo test -p mur-common config::conversations_tests::compact
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Lint + commit**
+
+```
+cargo clippy -p mur-common -- -D warnings
+cargo fmt --check -p mur-common
+git add mur-common/src/config.rs
+git commit -m "$(cat <<'EOF'
+feat(common): add CompactConfig to ConversationsConfig (Phase 2A)
+
+Typed config for sleep-time compact: 10 fields with serde defaults matching
+spec §6.1. All fields #[serde(default)] — existing Phase 1 config.yaml
+without a conversations.compact: section still parses.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `conversations::ollama` HTTP client (Phase 2A)
+
+**Files:**
+- Create: `mur-core/src/conversations/ollama.rs`
+- Modify: `mur-core/src/conversations/mod.rs`
+
+**Rationale:** Both summarize (non-streaming JSON call) and ask (streaming token call) hit Ollama `/api/generate`. A single shared client avoids two competing HTTP implementations.
+
+- [ ] **Step 1: Failing test**
+
+Create `mur-core/src/conversations/ollama.rs`:
+
+```rust
+//! Shared Ollama HTTP client used by summarize and ask modules.
+//!
+//! Covers both non-streaming (`generate`) and streaming (`generate_stream`)
+//! endpoints. MUR_OLLAMA_MOCK=1 env short-circuits to canned responses for
+//! deterministic testing; see docs/superpowers/specs/...phase-2... §9.3.
+
+#![allow(dead_code)] // Phase 2A: generate_stream wired in Phase 2B.
+
+use anyhow::{anyhow, Context, Result};
+use futures::stream::{Stream, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::pin::Pin;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GenerateRequest<'a> {
+    pub model: &'a str,
+    pub prompt: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<&'a str>,
+    pub stream: bool,
+    pub options: GenerateOptions,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GenerateOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_predict: Option<u32>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub stop: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GenerateResponse {
+    pub response: String,
+    pub done: bool,
+    pub model: String,
+    #[serde(default)]
+    pub prompt_eval_count: u64,
+    #[serde(default)]
+    pub eval_count: u64,
+}
+
+pub struct OllamaClient {
+    endpoint: String,
+    timeout: Duration,
+    http: reqwest::Client,
+}
+
+impl OllamaClient {
+    pub fn new(endpoint: &str, timeout: Duration) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .expect("reqwest client build");
+        Self {
+            endpoint: endpoint.to_string(),
+            timeout,
+            http,
+        }
+    }
+
+    pub fn mock_from_env() -> bool {
+        std::env::var("MUR_OLLAMA_MOCK").as_deref() == Ok("1")
+    }
+
+    pub async fn generate(&self, req: GenerateRequest<'_>) -> Result<GenerateResponse> {
+        if Self::mock_from_env() {
+            return Ok(mock_generate(&req));
+        }
+        let url = format!("{}/api/generate", self.endpoint.trim_end_matches('/'));
+        let resp = self
+            .http
+            .post(&url)
+            .json(&req)
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("ollama {status}: {body}"));
+        }
+        Ok(resp.json::<GenerateResponse>().await?)
+    }
+
+    pub async fn generate_stream(
+        &self,
+        req: GenerateRequest<'_>,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<String>> + Send>>> {
+        if Self::mock_from_env() {
+            let full = mock_generate(&req).response;
+            let tokens: Vec<String> =
+                full.split_inclusive(' ').map(|s| s.to_string()).collect();
+            let stream = futures::stream::iter(tokens.into_iter().map(Ok));
+            return Ok(Box::pin(stream));
+        }
+        let url = format!("{}/api/generate", self.endpoint.trim_end_matches('/'));
+        let mut req = req;
+        req.stream = true;
+        let resp = self.http.post(&url).json(&req).send().await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("ollama {status}: {body}"));
+        }
+        let byte_stream = resp.bytes_stream();
+        let token_stream = byte_stream
+            .map(|chunk| -> Result<Vec<String>> {
+                let bytes = chunk?;
+                let text = std::str::from_utf8(&bytes)?;
+                let mut out = Vec::new();
+                for line in text.lines() {
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    let v: GenerateResponse = serde_json::from_str(line)?;
+                    if !v.response.is_empty() {
+                        out.push(v.response);
+                    }
+                }
+                Ok(out)
+            })
+            .flat_map(|res| match res {
+                Ok(tokens) => futures::stream::iter(
+                    tokens.into_iter().map(Ok).collect::<Vec<_>>(),
+                ),
+                Err(e) => futures::stream::iter(vec![Err(e)]),
+            });
+        Ok(Box::pin(token_stream))
+    }
+}
+
+/// Deterministic fake response for tests. Echoes model+prompt hints so each
+/// test can assert which call site fired without a real Ollama.
+fn mock_generate(req: &GenerateRequest<'_>) -> GenerateResponse {
+    let response = if req.prompt.contains("Extract the 1-3 most informative spans") {
+        // extractive stage: one valid span echoed as JSON array
+        r#"[{"role":"user","conv_id":"mock","line_hint":1,"text":"mock extractive span"}]"#
+            .to_string()
+    } else if req.prompt.contains("narrative paragraph") {
+        "Mock narrative: today the developer explored mock compression.".to_string()
+    } else if req.prompt.contains("[cit:") {
+        "Mock answer about the archive [cit: 2026-04-19 claude-code/mock:L1].".to_string()
+    } else {
+        format!("mock response for model={}", req.model)
+    };
+    GenerateResponse {
+        response,
+        done: true,
+        model: req.model.to_string(),
+        prompt_eval_count: 10,
+        eval_count: 20,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mock_mode_extractive_returns_valid_json() {
+        // Given: MUR_OLLAMA_MOCK=1, extractive prompt
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let client = OllamaClient::new("http://unused", Duration::from_secs(1));
+        let req = GenerateRequest {
+            model: "qwen3:14b",
+            prompt: "Extract the 1-3 most informative spans from this excerpt.",
+            system: None,
+            stream: false,
+            options: GenerateOptions::default(),
+        };
+        let resp = client.generate(req).await.unwrap();
+        assert!(resp.response.contains("mock extractive span"));
+        assert!(serde_json::from_str::<serde_json::Value>(&resp.response).is_ok());
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[tokio::test]
+    async fn mock_mode_abstractive_returns_prose() {
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let client = OllamaClient::new("http://unused", Duration::from_secs(1));
+        let req = GenerateRequest {
+            model: "qwen3:14b",
+            prompt: "Write the narrative paragraph.",
+            system: None,
+            stream: false,
+            options: GenerateOptions::default(),
+        };
+        let resp = client.generate(req).await.unwrap();
+        assert!(resp.response.starts_with("Mock narrative"));
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[tokio::test]
+    async fn real_call_errors_on_unreachable_endpoint() {
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+        // Use a deliberately-unroutable port so we get a fast failure
+        let client = OllamaClient::new("http://127.0.0.1:1", Duration::from_millis(500));
+        let req = GenerateRequest {
+            model: "m",
+            prompt: "p",
+            system: None,
+            stream: false,
+            options: GenerateOptions::default(),
+        };
+        let r = client.generate(req).await;
+        assert!(r.is_err());
+    }
+}
+```
+
+Register module in `mur-core/src/conversations/mod.rs`. Locate the existing `pub mod` block (alphabetical) and add:
+
+```rust
+pub mod ollama;
+```
+
+- [ ] **Step 2: Run tests**
+
+```
+cargo test -p mur-core conversations::ollama::tests
+```
+
+Expected: 3 passed (2 mock, 1 unreachable-error).
+
+- [ ] **Step 3: Lint + commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/ollama.rs mur-core/src/conversations/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(core): conversations/ollama — shared Ollama HTTP client
+
+Unified client for both summarize (single-shot) and ask (streaming).
+Covers /api/generate with GenerateRequest / GenerateResponse types.
+
+MUR_OLLAMA_MOCK=1 env short-circuits to deterministic canned responses —
+extractive returns a valid JSON-array span, abstractive returns a fixed
+narrative, ask returns a fixed answer with one well-formed [cit: ...].
+Keeps golden-path tests offline and deterministic.
+
+Streaming returns a Pin<Box<dyn Stream>> of token strings parsed from
+Ollama's JSONL NDJSON output.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `aho-corasick` dep + `summary_history_dir` path helper (Phase 2A)
+
+**Files:**
+- Modify: `mur-core/Cargo.toml`
+- Modify: `mur-core/src/conversations/paths.rs`
+
+- [ ] **Step 1: Add deps**
+
+Add to `mur-core/Cargo.toml` `[dependencies]`:
+
+```toml
+aho-corasick = "1"
+```
+
+(`walkdir = "2"` was already added in Phase 1 Task 18 for migrate dry-run.)
+
+- [ ] **Step 2: Failing test in paths.rs**
+
+Append to the existing `#[cfg(test)] mod tests` in `mur-core/src/conversations/paths.rs`:
+
+```rust
+#[test]
+fn summary_history_dir_under_conversations() {
+    let p = summary_history_dir(Some("/tmp/mur-test"));
+    assert_eq!(
+        p,
+        std::path::PathBuf::from("/tmp/mur-test/conversations/summary/.history")
+    );
+}
+```
+
+- [ ] **Step 3: Run — must fail**
+
+```
+cargo test -p mur-core conversations::paths::tests::summary_history_dir_under_conversations
+```
+
+Expected: compile error `cannot find function 'summary_history_dir'`.
+
+- [ ] **Step 4: Implement**
+
+Add to `mur-core/src/conversations/paths.rs` (near the other summary helpers):
+
+```rust
+/// Directory that holds previous versions of overwritten summaries.
+/// One file per rewrite: `<date>.<ISO-8601>.md`.
+pub fn summary_history_dir(root_override: Option<&str>) -> PathBuf {
+    conversations_root(root_override)
+        .join("summary")
+        .join(".history")
+}
+```
+
+- [ ] **Step 5: Run**
+
+```
+cargo test -p mur-core conversations::paths::tests
+```
+
+Expected: all paths tests pass (previous count + 1 new).
+
+- [ ] **Step 6: Commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/Cargo.toml mur-core/src/conversations/paths.rs Cargo.lock
+git commit -m "$(cat <<'EOF'
+feat(core): add aho-corasick dep + summary_history_dir path helper (Phase 2A)
+
+aho-corasick for Task 7's pattern-name macro detection.
+summary_history_dir() returns ~/.mur/conversations/summary/.history — the
+destination for prior summary versions when compact overwrites them
+(spec §8.1 append-only narrowing).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `summarize::chunker` — message packing (Phase 2A)
+
+**Files:**
+- Create: `mur-core/src/conversations/summarize/mod.rs` (bare module stub)
+- Create: `mur-core/src/conversations/summarize/chunker.rs`
+- Modify: `mur-core/src/conversations/mod.rs`
+
+- [ ] **Step 1: Create module stub**
+
+Create `mur-core/src/conversations/summarize/mod.rs`:
+
+```rust
+//! Sleep-time compact pipeline (Phase 2A, spec §4).
+//!
+//! Produces daily hybrid summaries: frontmatter + extractive spans +
+//! abstractive narrative + macro expansion map. See
+//! `docs/superpowers/specs/2026-04-20-mur-conversations-phase-2-design.md`.
+#![allow(dead_code)] // public API wired progressively across Tasks 4-10.
+
+pub mod chunker;
+// Later tasks add: pub mod extractive; pub mod abstractive; pub mod macro_refs; pub mod writer;
+```
+
+Register in `mur-core/src/conversations/mod.rs`:
+
+```rust
+pub mod summarize;
+```
+
+- [ ] **Step 2: Failing tests**
+
+Create `mur-core/src/conversations/summarize/chunker.rs`:
+
+```rust
+//! Pack messages into LLM-sized chunks under a token budget.
+//!
+//! - Never split a single message (quote integrity).
+//! - Prefer splitting at conv_id boundaries; only split mid-conversation if
+//!   that conversation itself exceeds the budget.
+//! - Token estimate: chars / 4. Good to ±15% across CJK/ASCII mix.
+
+use mur_common::Message;
+
+const CHARS_PER_TOKEN: usize = 4;
+
+#[derive(Debug)]
+pub struct Chunk {
+    pub messages: Vec<Message>,
+    pub token_count: usize,
+    pub span_range: (usize, usize), // (start_line, end_line) within the day JSONL
+}
+
+pub fn chunk_day(msgs: &[Message], token_budget: usize) -> Vec<Chunk> {
+    if msgs.is_empty() {
+        return Vec::new();
+    }
+
+    // Precompute token cost per message and its day-wide line index (1-based,
+    // matches the extractive prompt's L<N> convention).
+    let msg_costs: Vec<usize> = msgs
+        .iter()
+        .map(|m| message_token_cost(m))
+        .collect();
+
+    let mut out = Vec::new();
+    let mut current: Vec<usize> = Vec::new(); // indices into msgs
+    let mut current_tokens = 0usize;
+    let mut current_conv: Option<&str> = None;
+
+    for (i, m) in msgs.iter().enumerate() {
+        let cost = msg_costs[i];
+        let msg_conv = m.conv.as_str();
+
+        // Start-new-chunk decision:
+        // 1. always start fresh if adding this msg would exceed budget AND
+        //    we already have content (respecting the never-split rule)
+        // 2. even if under budget, if msg_conv differs from current_conv AND
+        //    we have > 1 msg, prefer splitting at the conv boundary when the
+        //    resulting chunk would still fit — the boundary split loses
+        //    nothing and keeps the extractive prompt focused.
+        let would_overflow = current_tokens + cost > token_budget && !current.is_empty();
+        let conv_boundary = current_conv.is_some()
+            && current_conv != Some(msg_conv)
+            && !current.is_empty();
+
+        if would_overflow || (conv_boundary && current_tokens + cost > token_budget / 2) {
+            out.push(make_chunk(msgs, &current, current_tokens));
+            current.clear();
+            current_tokens = 0;
+            current_conv = None;
+        }
+
+        current.push(i);
+        current_tokens += cost;
+        current_conv = Some(msg_conv);
+    }
+
+    if !current.is_empty() {
+        out.push(make_chunk(msgs, &current, current_tokens));
+    }
+    out
+}
+
+fn message_token_cost(m: &Message) -> usize {
+    // Scaffold overhead (role prefix, timestamp, line number) plus content.
+    let content_chars = match &m.content {
+        mur_common::Content::Text { value } => value.len(),
+        mur_common::Content::ToolRef { desc, .. } => desc.len().saturating_add(64),
+        mur_common::Content::ImageRef { desc, .. } => desc.len().saturating_add(48),
+    };
+    // ~40 chars scaffold: "L<line> [hh:mm:ss] <src>/<conv> (<role>): "
+    (content_chars + 40) / CHARS_PER_TOKEN + 1
+}
+
+fn make_chunk(msgs: &[Message], indices: &[usize], tokens: usize) -> Chunk {
+    let start_line = indices.first().copied().unwrap_or(0) + 1; // 1-based
+    let end_line = indices.last().copied().unwrap_or(0) + 1;
+    let chunk_msgs = indices.iter().map(|&i| msgs[i].clone()).collect();
+    Chunk {
+        messages: chunk_msgs,
+        token_count: tokens,
+        span_range: (start_line, end_line),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use mur_common::{Content, Role, Source};
+
+    fn mk(conv: &str, text: &str) -> Message {
+        Message {
+            v: 1,
+            ts: chrono::Utc.with_ymd_and_hms(2026, 4, 19, 10, 0, 0).unwrap(),
+            src: Source::ClaudeCode,
+            conv: conv.into(),
+            role: Role::User,
+            content: Content::Text { value: text.into() },
+            meta: serde_json::Value::Null,
+            refs: vec![],
+        }
+    }
+
+    #[test]
+    fn empty_day_yields_zero_chunks() {
+        assert!(chunk_day(&[], 6000).is_empty());
+    }
+
+    #[test]
+    fn all_fits_in_one_chunk_under_budget() {
+        let msgs = vec![mk("c1", "hello"), mk("c1", "world"), mk("c1", "again")];
+        let chunks = chunk_day(&msgs, 6000);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].messages.len(), 3);
+        assert_eq!(chunks[0].span_range, (1, 3));
+    }
+
+    #[test]
+    fn never_splits_single_message_even_if_over_budget() {
+        let big = "x".repeat(40_000);
+        let msgs = vec![mk("c1", &big)];
+        let chunks = chunk_day(&msgs, 6000);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].messages.len(), 1);
+    }
+
+    #[test]
+    fn splits_at_conv_boundary_when_under_half_budget_reached() {
+        // Two conversations, each small enough that greedy would pack them
+        // together, but boundary preference splits them.
+        let pad = "y".repeat(12_000); // ~3000 tokens
+        let msgs = vec![mk("c1", &pad), mk("c2", &pad)];
+        let chunks = chunk_day(&msgs, 6000);
+        assert_eq!(chunks.len(), 2, "expected 2 chunks, got {}", chunks.len());
+        assert_eq!(chunks[0].messages[0].conv, "c1");
+        assert_eq!(chunks[1].messages[0].conv, "c2");
+    }
+
+    #[test]
+    fn span_range_is_one_indexed_end_inclusive() {
+        let msgs = (0..5).map(|i| mk("c1", &format!("msg{i}"))).collect::<Vec<_>>();
+        let chunks = chunk_day(&msgs, 6000);
+        assert_eq!(chunks[0].span_range, (1, 5));
+    }
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```
+cargo test -p mur-core conversations::summarize::chunker::tests
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 4: Commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/summarize/ mur-core/src/conversations/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(core): summarize/chunker — pack messages under token budget (Phase 2A)
+
+Conversation-boundary-aware greedy packer. Never splits a single message
+(quote integrity). Prefers splitting at conv_id boundaries when the result
+still fills half the budget. chars/4 token estimate — no tokenizer dep.
+span_range tracks day-wide 1-based line numbers for extractive prompt
+scaffolding.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `summarize::extractive` — LLM per-chunk spans (Phase 2A)
+
+**Files:**
+- Create: `mur-core/src/conversations/summarize/extractive.rs`
+- Modify: `mur-core/src/conversations/summarize/mod.rs` (register)
+
+- [ ] **Step 1: Failing tests**
+
+Create `mur-core/src/conversations/summarize/extractive.rs`:
+
+```rust
+//! Per-chunk LLM span extraction. See spec §4.2.
+//!
+//! For each chunk, prompt Ollama for a JSON array of {role, conv_id,
+//! line_hint, text} spans. Validate each span:
+//!   - text is a verbatim substring of a source message (Jaro-Winkler ≥ 0.95)
+//!   - line_hint within chunk.span_range
+//!   - role matches source message role
+//! Invalid spans silently dropped. Failure degrades to zero spans.
+
+use anyhow::Result;
+use mur_common::{Content, Message, Role, Source};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use super::chunker::Chunk;
+use super::super::ollama::{GenerateOptions, GenerateRequest, OllamaClient};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ExtractiveSpan {
+    pub role: Role,
+    pub conv_id: String,
+    pub line_hint: u32,
+    pub text: String,
+    #[serde(skip)]
+    pub src: Source,                // resolved from source message during validation
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LlmSpan {
+    role: String,
+    conv_id: String,
+    line_hint: u32,
+    text: String,
+}
+
+pub async fn extract_chunk(
+    client: &OllamaClient,
+    model: &str,
+    chunk: &Chunk,
+    day_msgs: &[Message],
+) -> Result<Vec<ExtractiveSpan>> {
+    let prompt = render_prompt(chunk);
+    let resp = client
+        .generate(GenerateRequest {
+            model,
+            prompt: &prompt,
+            system: None,
+            stream: false,
+            options: GenerateOptions {
+                temperature: Some(0.0),
+                top_p: Some(0.9),
+                num_predict: Some(1024),
+                stop: vec![],
+            },
+        })
+        .await;
+    let body = match resp {
+        Ok(r) => r.response,
+        Err(e) => {
+            warn!("extractive LLM call failed: {e:#}");
+            return Ok(Vec::new());
+        }
+    };
+
+    let raw: Vec<LlmSpan> = match parse_json_array(&body) {
+        Some(v) => v,
+        None => {
+            warn!("extractive output not a JSON array; returning zero spans");
+            return Ok(Vec::new());
+        }
+    };
+
+    Ok(raw
+        .into_iter()
+        .filter_map(|s| validate(s, chunk, day_msgs))
+        .collect())
+}
+
+fn render_prompt(chunk: &Chunk) -> String {
+    let mut body = String::new();
+    let (start_line, end_line) = chunk.span_range;
+    body.push_str(
+        "You are reviewing one conversation day for a technical developer's personal archive. \
+         Extract the 1-3 most informative spans from this excerpt.\n\n\
+         A span is quote-worthy if it:\n\
+         - states a decision the user made (\"we'll use X over Y because...\")\n\
+         - records a concrete error or failure that shaped subsequent work\n\
+         - captures a new idea, technique, or reference the user hadn't seen before\n\
+         - quotes an important external fact (API response, spec excerpt, doc)\n\n\
+         A span is NOT quote-worthy if it is:\n\
+         - boilerplate/greeting/filler\n\
+         - tool-result body already citeable by path\n\
+         - restated from an earlier span\n\n\
+         Output format: JSON array. Each span is {role, conv_id, line_hint, text}.\n\
+           - role: one of \"user\" | \"assistant\" | \"system\" | \"tool\"\n\
+           - conv_id: the conv value from the source message\n\
+           - line_hint: integer line number within the day's raw JSONL\n\
+           - text: verbatim quote, 20-400 chars\n\n\
+         If the excerpt has nothing quote-worthy, return [].\n\n",
+    );
+    body.push_str(&format!(
+        "Excerpt ({} messages, lines {}..{}):\n",
+        chunk.messages.len(),
+        start_line,
+        end_line
+    ));
+    for (i, m) in chunk.messages.iter().enumerate() {
+        let line_no = start_line + i;
+        let role = format!("{:?}", m.role).to_lowercase();
+        let text = content_preview(m);
+        body.push_str(&format!(
+            "L{} [{}] {}/{} ({}): {}\n",
+            line_no,
+            m.ts.format("%H:%M:%S"),
+            m.src.file_prefix(),
+            m.conv,
+            role,
+            text,
+        ));
+    }
+    body
+}
+
+fn content_preview(m: &Message) -> String {
+    match &m.content {
+        Content::Text { value } => value.clone(),
+        Content::ToolRef { desc, bytes, path, .. } => {
+            format!("[tool_ref:{} ({}B) @ {}]", desc, bytes, path)
+        }
+        Content::ImageRef { desc, path, .. } => format!("[image_ref:{} @ {}]", desc, path),
+    }
+}
+
+fn parse_json_array(body: &str) -> Option<Vec<LlmSpan>> {
+    // Tolerate fences / surrounding prose: find first `[` and last `]`.
+    let start = body.find('[')?;
+    let end = body.rfind(']')?;
+    if end <= start {
+        return None;
+    }
+    let slice = &body[start..=end];
+    serde_json::from_str::<Vec<LlmSpan>>(slice).ok()
+}
+
+fn validate(raw: LlmSpan, chunk: &Chunk, day_msgs: &[Message]) -> Option<ExtractiveSpan> {
+    // line_hint within chunk
+    let (s, e) = chunk.span_range;
+    if raw.line_hint < s as u32 || raw.line_hint > e as u32 {
+        return None;
+    }
+    let role = parse_role(&raw.role)?;
+    // Find the source message at line_hint (1-based → 0-based index)
+    let idx = raw.line_hint as usize - 1;
+    let source_msg = day_msgs.get(idx)?;
+    if source_msg.role != role {
+        return None;
+    }
+    if source_msg.conv != raw.conv_id {
+        return None;
+    }
+    // Verbatim check with Jaro-Winkler ≥ 0.95 against source message text
+    let source_text = content_preview(source_msg);
+    let similarity = jaro_winkler(&raw.text, &source_text);
+    if similarity < 0.95 {
+        return None;
+    }
+    Some(ExtractiveSpan {
+        role,
+        conv_id: raw.conv_id,
+        line_hint: raw.line_hint,
+        text: raw.text,
+        src: source_msg.src,
+    })
+}
+
+fn parse_role(s: &str) -> Option<Role> {
+    match s.to_ascii_lowercase().as_str() {
+        "user" => Some(Role::User),
+        "assistant" => Some(Role::Assistant),
+        "system" => Some(Role::System),
+        "tool" => Some(Role::Tool),
+        _ => None,
+    }
+}
+
+/// Small Jaro-Winkler implementation (no extra dep). Char-based, case-sensitive.
+fn jaro_winkler(a: &str, b: &str) -> f64 {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let match_distance = (a.len().max(b.len()) / 2).saturating_sub(1);
+
+    let mut a_matched = vec![false; a.len()];
+    let mut b_matched = vec![false; b.len()];
+    let mut matches = 0usize;
+
+    for i in 0..a.len() {
+        let lo = i.saturating_sub(match_distance);
+        let hi = (i + match_distance + 1).min(b.len());
+        for j in lo..hi {
+            if b_matched[j] {
+                continue;
+            }
+            if a[i] == b[j] {
+                a_matched[i] = true;
+                b_matched[j] = true;
+                matches += 1;
+                break;
+            }
+        }
+    }
+    if matches == 0 {
+        return 0.0;
+    }
+    // transpositions
+    let mut k = 0usize;
+    let mut transpositions = 0usize;
+    for i in 0..a.len() {
+        if !a_matched[i] {
+            continue;
+        }
+        while !b_matched[k] {
+            k += 1;
+        }
+        if a[i] != b[k] {
+            transpositions += 1;
+        }
+        k += 1;
+    }
+    let m = matches as f64;
+    let jaro = (m / a.len() as f64
+        + m / b.len() as f64
+        + (m - transpositions as f64 / 2.0) / m)
+        / 3.0;
+    // Winkler common-prefix boost up to 4 chars, p=0.1
+    let prefix = a
+        .iter()
+        .zip(b.iter())
+        .take(4)
+        .take_while(|(x, y)| x == y)
+        .count() as f64;
+    jaro + prefix * 0.1 * (1.0 - jaro)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn mk(ts_min: u32, conv: &str, text: &str, role: Role) -> Message {
+        Message {
+            v: 1,
+            ts: chrono::Utc
+                .with_ymd_and_hms(2026, 4, 19, 10, ts_min, 0)
+                .unwrap(),
+            src: Source::ClaudeCode,
+            conv: conv.into(),
+            role,
+            content: Content::Text { value: text.into() },
+            meta: serde_json::Value::Null,
+            refs: vec![],
+        }
+    }
+
+    #[test]
+    fn json_array_parsed_with_surrounding_prose() {
+        let body = r#"Here are the spans:
+```json
+[
+  {"role":"user","conv_id":"c1","line_hint":1,"text":"hi"}
+]
+```
+That's all."#;
+        let v = parse_json_array(body).unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].text, "hi");
+    }
+
+    #[test]
+    fn validate_rejects_out_of_range_line_hint() {
+        let msgs = vec![mk(0, "c1", "hello", Role::User)];
+        let chunk = Chunk {
+            messages: msgs.clone(),
+            token_count: 10,
+            span_range: (1, 1),
+        };
+        let raw = LlmSpan {
+            role: "user".into(),
+            conv_id: "c1".into(),
+            line_hint: 99,
+            text: "hello".into(),
+        };
+        assert!(validate(raw, &chunk, &msgs).is_none());
+    }
+
+    #[test]
+    fn validate_rejects_role_mismatch() {
+        let msgs = vec![mk(0, "c1", "hello", Role::User)];
+        let chunk = Chunk {
+            messages: msgs.clone(),
+            token_count: 10,
+            span_range: (1, 1),
+        };
+        let raw = LlmSpan {
+            role: "assistant".into(),
+            conv_id: "c1".into(),
+            line_hint: 1,
+            text: "hello".into(),
+        };
+        assert!(validate(raw, &chunk, &msgs).is_none());
+    }
+
+    #[test]
+    fn validate_rejects_paraphrase() {
+        let msgs = vec![mk(0, "c1", "cargo build failed with error E0001", Role::User)];
+        let chunk = Chunk {
+            messages: msgs.clone(),
+            token_count: 10,
+            span_range: (1, 1),
+        };
+        let raw = LlmSpan {
+            role: "user".into(),
+            conv_id: "c1".into(),
+            line_hint: 1,
+            text: "build failed".into(),
+        };
+        assert!(validate(raw, &chunk, &msgs).is_none());
+    }
+
+    #[test]
+    fn validate_accepts_verbatim() {
+        let msgs = vec![mk(0, "c1", "cargo build failed with error E0001", Role::User)];
+        let chunk = Chunk {
+            messages: msgs.clone(),
+            token_count: 10,
+            span_range: (1, 1),
+        };
+        let raw = LlmSpan {
+            role: "user".into(),
+            conv_id: "c1".into(),
+            line_hint: 1,
+            text: "cargo build failed with error E0001".into(),
+        };
+        assert!(validate(raw, &chunk, &msgs).is_some());
+    }
+
+    #[tokio::test]
+    async fn mock_ollama_extracts_one_span() {
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let client = OllamaClient::new("http://unused", std::time::Duration::from_secs(1));
+        let msgs = vec![mk(0, "mock", "mock extractive span", Role::User)];
+        let chunk = Chunk {
+            messages: msgs.clone(),
+            token_count: 10,
+            span_range: (1, 1),
+        };
+        let spans = extract_chunk(&client, "qwen3:14b", &chunk, &msgs)
+            .await
+            .unwrap();
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].text, "mock extractive span");
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+}
+```
+
+Register in `summarize/mod.rs`:
+
+```rust
+pub mod chunker;
+pub mod extractive;
+```
+
+- [ ] **Step 2: Run tests**
+
+```
+cargo test -p mur-core conversations::summarize::extractive::tests
+```
+
+Expected: 6 passed.
+
+- [ ] **Step 3: Commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/summarize/extractive.rs mur-core/src/conversations/summarize/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(core): summarize/extractive — per-chunk LLM span extraction (Phase 2A)
+
+Renders extractive prompt (spec §4.2), calls Ollama with temperature=0.0,
+parses JSON array (tolerant of prose/fences), validates each span:
+- line_hint within chunk.span_range
+- role matches source message
+- conv_id matches source message
+- Jaro-Winkler ≥ 0.95 verbatim check against source text
+
+Invalid spans silently dropped. Ollama failure → zero spans, warn logged.
+
+Inline Jaro-Winkler impl (no extra dep). MUR_OLLAMA_MOCK covered by mock
+extractive branch in ollama.rs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `summarize::abstractive` — LLM narrative (Phase 2A)
+
+**Files:**
+- Create: `mur-core/src/conversations/summarize/abstractive.rs`
+- Modify: `mur-core/src/conversations/summarize/mod.rs`
+
+- [ ] **Step 1: Failing tests**
+
+Create `mur-core/src/conversations/summarize/abstractive.rs`:
+
+```rust
+//! Abstractive narrative stage. Single LLM call over all extractive spans.
+//! See spec §4.3. Output: 150-400 words, first-person or neutral.
+
+use anyhow::Result;
+use tracing::warn;
+
+use super::extractive::ExtractiveSpan;
+use super::super::ollama::{GenerateOptions, GenerateRequest, OllamaClient};
+
+pub struct AbstractiveResult {
+    pub narrative: Option<String>,   // None iff LLM failed and caller should set the warning
+    pub word_count: usize,
+}
+
+pub async fn summarize(
+    client: &OllamaClient,
+    model: &str,
+    spans: &[ExtractiveSpan],
+    date: chrono::NaiveDate,
+    max_words: u32,
+) -> AbstractiveResult {
+    if spans.is_empty() {
+        return AbstractiveResult {
+            narrative: Some("No significant activity on this day.".to_string()),
+            word_count: 5,
+        };
+    }
+    let prompt = render_prompt(spans, date, max_words);
+    let resp = client
+        .generate(GenerateRequest {
+            model,
+            prompt: &prompt,
+            system: None,
+            stream: false,
+            options: GenerateOptions {
+                temperature: Some(0.2),
+                top_p: Some(0.9),
+                num_predict: Some(max_words * 2), // tokens > words; headroom
+                stop: vec![],
+            },
+        })
+        .await;
+    match resp {
+        Ok(r) => {
+            let narrative = clean_output(&r.response);
+            let word_count = narrative.split_whitespace().count();
+            AbstractiveResult {
+                narrative: Some(narrative),
+                word_count,
+            }
+        }
+        Err(e) => {
+            warn!("abstractive LLM call failed: {e:#}");
+            AbstractiveResult {
+                narrative: None,
+                word_count: 0,
+            }
+        }
+    }
+}
+
+fn render_prompt(spans: &[ExtractiveSpan], date: chrono::NaiveDate, max_words: u32) -> String {
+    let min_words = 150.min(max_words / 2);
+    let mut body = format!(
+        "You are summarizing one day ({}) of a developer's AI-assistant conversations into a \
+         narrative paragraph. Use ONLY information present in the spans below.\n\n\
+         Output: {}-{} words, first-person or neutral third-person, no bullet lists. \
+         Reference each key point by its span index [N]. Do NOT invent details not in the spans. \
+         If spans conflict, note the conflict.\n\n\
+         Spans:\n",
+        date, min_words, max_words
+    );
+    for (i, s) in spans.iter().enumerate() {
+        body.push_str(&format!(
+            "[{}] {{{} {}/{} L{}}}: {}\n",
+            i + 1,
+            date,
+            s.src.file_prefix(),
+            s.conv_id,
+            s.line_hint,
+            s.text,
+        ));
+    }
+    body.push_str("\nWrite the narrative.\n");
+    body
+}
+
+fn clean_output(raw: &str) -> String {
+    let trimmed = raw.trim();
+    // Strip trailing commentary like "Let me know if you'd like..." that some
+    // models append after the summary. Heuristic: keep content up to the first
+    // double-newline that follows a complete sentence.
+    if let Some(idx) = trimmed.find("\n\nLet me") {
+        return trimmed[..idx].trim().to_string();
+    }
+    if let Some(idx) = trimmed.find("\n\nWould you") {
+        return trimmed[..idx].trim().to_string();
+    }
+    trimmed.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::{Role, Source};
+
+    fn span(idx: u32, text: &str) -> ExtractiveSpan {
+        ExtractiveSpan {
+            role: Role::User,
+            conv_id: "c1".into(),
+            line_hint: idx,
+            text: text.into(),
+            src: Source::ClaudeCode,
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_spans_emit_placeholder() {
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let client = OllamaClient::new("http://unused", std::time::Duration::from_secs(1));
+        let r = summarize(&client, "qwen3:14b", &[], chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(), 400).await;
+        assert!(r.narrative.as_deref().unwrap().contains("No significant"));
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[tokio::test]
+    async fn mock_narrative_happy_path() {
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let client = OllamaClient::new("http://unused", std::time::Duration::from_secs(1));
+        let spans = vec![span(1, "hello world"), span(2, "compression works")];
+        let r = summarize(
+            &client,
+            "qwen3:14b",
+            &spans,
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(),
+            400,
+        )
+        .await;
+        assert!(r.narrative.as_deref().unwrap().starts_with("Mock narrative"));
+        assert!(r.word_count > 0);
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[test]
+    fn clean_output_strips_trailing_commentary() {
+        let raw = "This is the narrative.\n\nLet me know if you'd like more detail!";
+        assert_eq!(clean_output(raw), "This is the narrative.");
+    }
+}
+```
+
+Register in `summarize/mod.rs`:
+
+```rust
+pub mod abstractive;
+pub mod chunker;
+pub mod extractive;
+```
+
+- [ ] **Step 2: Run tests**
+
+```
+cargo test -p mur-core conversations::summarize::abstractive::tests
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 3: Commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/summarize/abstractive.rs mur-core/src/conversations/summarize/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(core): summarize/abstractive — LLM narrative over spans (Phase 2A)
+
+Single Ollama call, temperature=0.2, produces 150-400 word narrative that
+references extractive spans by [N]. Empty spans → placeholder. LLM failure →
+narrative=None so the caller can set the narrative_generation_failed warning
+in frontmatter.
+
+Output sanitizer strips trailing 'Let me know...' / 'Would you...' commentary
+some models append.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `summarize::macro_refs` — Aho-Corasick pattern detection (Phase 2A)
+
+**Files:**
+- Create: `mur-core/src/conversations/summarize/macro_refs.rs`
+- Modify: `mur-core/src/conversations/summarize/mod.rs`
+
+- [ ] **Step 1: Failing tests**
+
+Create `mur-core/src/conversations/summarize/macro_refs.rs`:
+
+```rust
+//! Pattern-name macro reference detection (spec §4.4).
+//!
+//! Enumerates ~/.mur/patterns/*.yaml names, scans extractive spans and the
+//! abstractive narrative for word-boundary matches, rewrites them to
+//! {{pattern: <name>}}, and records (version, sha) per referenced pattern.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use super::extractive::ExtractiveSpan;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MacroRef {
+    pub name: String,
+    pub pattern_version: u32,
+    pub pattern_sha: String,
+    pub marker: String,
+}
+
+pub fn detect_and_rewrite(
+    extractive: &mut [ExtractiveSpan],
+    abstractive: &mut String,
+    patterns_dir: &Path,
+) -> Result<Vec<MacroRef>> {
+    let names = enumerate_pattern_names(patterns_dir)?;
+    if names.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Case-insensitive Aho-Corasick. Word-boundary enforced via post-check.
+    let ac = aho_corasick::AhoCorasick::builder()
+        .ascii_case_insensitive(true)
+        .build(&names)
+        .context("build aho-corasick")?;
+
+    let mut found: BTreeSet<String> = BTreeSet::new();
+
+    for span in extractive.iter_mut() {
+        let new_text = rewrite_with_markers(&span.text, &ac, &names, &mut found);
+        span.text = new_text;
+    }
+    let new_narrative = rewrite_with_markers(abstractive, &ac, &names, &mut found);
+    *abstractive = new_narrative;
+
+    let mut refs = Vec::new();
+    for name in found {
+        let (version, sha) = read_pattern_meta(patterns_dir, &name)
+            .unwrap_or_else(|e| {
+                tracing::warn!("failed to read pattern {name}: {e:#}; using defaults");
+                (0, String::new())
+            });
+        refs.push(MacroRef {
+            name: name.clone(),
+            pattern_version: version,
+            pattern_sha: sha,
+            marker: format!("{{{{pattern: {name}}}}}"),
+        });
+    }
+    Ok(refs)
+}
+
+fn enumerate_pattern_names(patterns_dir: &Path) -> Result<Vec<String>> {
+    if !patterns_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(patterns_dir)? {
+        let entry = entry?;
+        let p = entry.path();
+        if p.extension().and_then(|s| s.to_str()) != Some("yaml") {
+            continue;
+        }
+        if let Some(stem) = p.file_stem().and_then(|s| s.to_str()) {
+            out.push(stem.to_string());
+        }
+    }
+    Ok(out)
+}
+
+fn rewrite_with_markers(
+    text: &str,
+    ac: &aho_corasick::AhoCorasick,
+    names: &[String],
+    found: &mut BTreeSet<String>,
+) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut last = 0usize;
+    let bytes = text.as_bytes();
+
+    for mat in ac.find_iter(text) {
+        let start = mat.start();
+        let end = mat.end();
+        let name = &names[mat.pattern()];
+
+        // Word-boundary check. Chars before/after must not be ASCII alphanumeric
+        // or '-' (pattern names use kebab-case).
+        let before_ok = start == 0 || !is_word_byte(bytes[start - 1]);
+        let after_ok = end >= bytes.len() || !is_word_byte(bytes[end]);
+
+        // Code-fence / backtick / YAML-quote skip.
+        if !before_ok || !after_ok || inside_code_or_quote(text, start) {
+            continue;
+        }
+
+        out.push_str(&text[last..start]);
+        out.push_str(&format!("{{{{pattern: {name}}}}}"));
+        last = end;
+        found.insert(name.clone());
+    }
+    out.push_str(&text[last..]);
+    out
+}
+
+fn is_word_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'-' || b == b'_'
+}
+
+fn inside_code_or_quote(text: &str, pos: usize) -> bool {
+    // Toggle state up to `pos` for each of: backtick, code-fence (```), single-quote, double-quote
+    let mut in_backtick = false;
+    let mut in_code_fence = false;
+    let mut in_single = false;
+    let mut in_double = false;
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < pos {
+        if i + 3 <= pos && &bytes[i..i + 3] == b"```" {
+            in_code_fence = !in_code_fence;
+            i += 3;
+            continue;
+        }
+        match bytes[i] {
+            b'`' if !in_code_fence => in_backtick = !in_backtick,
+            b'\'' if !in_code_fence && !in_backtick => in_single = !in_single,
+            b'"' if !in_code_fence && !in_backtick => in_double = !in_double,
+            _ => {}
+        }
+        i += 1;
+    }
+    in_backtick || in_code_fence || in_single || in_double
+}
+
+fn read_pattern_meta(patterns_dir: &Path, name: &str) -> Result<(u32, String)> {
+    let path = patterns_dir.join(format!("{name}.yaml"));
+    let bytes = std::fs::read(&path)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let sha = hex::encode(hasher.finalize());
+    // schema version lives at top level; if missing, default 0
+    let yaml: serde_yaml::Value = serde_yaml::from_slice(&bytes).unwrap_or(serde_yaml::Value::Null);
+    let version = yaml
+        .get("schema")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    Ok((version, sha))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::{Role, Source};
+
+    fn tmpdir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    fn write_pattern(dir: &Path, name: &str, body: &str) {
+        std::fs::write(dir.join(format!("{name}.yaml")), body).unwrap();
+    }
+
+    fn span(text: &str) -> ExtractiveSpan {
+        ExtractiveSpan {
+            role: Role::User,
+            conv_id: "c1".into(),
+            line_hint: 1,
+            text: text.into(),
+            src: Source::ClaudeCode,
+        }
+    }
+
+    #[test]
+    fn detects_and_rewrites_known_pattern() {
+        let tmp = tmpdir();
+        write_pattern(tmp.path(), "atomic-yaml-write", "schema: 2\nname: atomic-yaml-write\n");
+        let mut spans = vec![span("we used atomic-yaml-write for the writer.")];
+        let mut narr = "The choice was atomic-yaml-write.".to_string();
+        let refs = detect_and_rewrite(&mut spans, &mut narr, tmp.path()).unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].name, "atomic-yaml-write");
+        assert_eq!(refs[0].pattern_version, 2);
+        assert!(spans[0].text.contains("{{pattern: atomic-yaml-write}}"));
+        assert!(narr.contains("{{pattern: atomic-yaml-write}}"));
+    }
+
+    #[test]
+    fn word_boundary_skips_partial_match() {
+        let tmp = tmpdir();
+        write_pattern(tmp.path(), "rust", "schema: 1\n");
+        let mut spans = vec![span("my rustic approach is rustless actually")];
+        let mut narr = String::new();
+        let refs = detect_and_rewrite(&mut spans, &mut narr, tmp.path()).unwrap();
+        assert!(refs.is_empty(), "rust should not match 'rustic' or 'rustless'");
+        assert!(!spans[0].text.contains("{{pattern"));
+    }
+
+    #[test]
+    fn skips_inside_backticks() {
+        let tmp = tmpdir();
+        write_pattern(tmp.path(), "my-pattern", "schema: 1\n");
+        let mut spans = vec![span("reference to `my-pattern` is literal")];
+        let mut narr = String::new();
+        let refs = detect_and_rewrite(&mut spans, &mut narr, tmp.path()).unwrap();
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn empty_patterns_dir_returns_empty() {
+        let tmp = tmpdir();
+        let mut spans = vec![span("anything")];
+        let mut narr = "anything".to_string();
+        let refs = detect_and_rewrite(&mut spans, &mut narr, tmp.path()).unwrap();
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn nonexistent_patterns_dir_is_safe() {
+        let mut spans = vec![span("x")];
+        let mut narr = "x".to_string();
+        let refs =
+            detect_and_rewrite(&mut spans, &mut narr, Path::new("/nonexistent/path")).unwrap();
+        assert!(refs.is_empty());
+    }
+}
+```
+
+Register in `summarize/mod.rs`:
+
+```rust
+pub mod abstractive;
+pub mod chunker;
+pub mod extractive;
+pub mod macro_refs;
+```
+
+- [ ] **Step 2: Run tests**
+
+```
+cargo test -p mur-core conversations::summarize::macro_refs::tests
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 3: Commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/summarize/macro_refs.rs mur-core/src/conversations/summarize/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(core): summarize/macro_refs — Aho-Corasick pattern detection (Phase 2A)
+
+Scans extractive spans + abstractive narrative for pattern names (stems of
+~/.mur/patterns/*.yaml), rewrites valid matches to {{pattern: name}}
+markers. Enforces word boundaries (rust doesn't match rustic/rustless) and
+skips matches inside backticks, code fences, or quotes. Records (version,
+sha) per referenced pattern for Phase 3 invalidation detection.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `index::search` — add `layer` filter (Phase 2A)
+
+**Files:**
+- Modify: `mur-core/src/conversations/index.rs`
+
+- [ ] **Step 1: Check current signature**
+
+```
+grep -n "pub async fn search" mur-core/src/conversations/index.rs
+```
+
+Expected: `pub async fn search(&self, query_vec: &[f32], limit: usize, source_filter: Option<Source>) -> Result<Vec<SearchHit>>`
+
+- [ ] **Step 2: Extend signature — add failing test**
+
+Append to the existing `#[cfg(test)] mod tests` in `mur-core/src/conversations/index.rs`:
+
+```rust
+#[tokio::test]
+async fn search_filters_by_layer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().to_str().unwrap();
+    let mut idx = ConversationIndex::open(16, Some(root)).await.unwrap();
+
+    let a = msg("a", "layer zero item");       // raw → layer 0
+    let b = msg("b", "layer one item");        // summary → layer 1
+    idx.upsert_with_layer(&[(a, vec![1.0; 16], 0)]).await.unwrap();
+    idx.upsert_with_layer(&[(b, vec![1.0; 16], 1)]).await.unwrap();
+
+    let hits_all = idx
+        .search(&[1.0; 16], 10, None, None)
+        .await
+        .unwrap();
+    assert_eq!(hits_all.len(), 2);
+
+    let hits_l1 = idx
+        .search(&[1.0; 16], 10, None, Some(1))
+        .await
+        .unwrap();
+    assert_eq!(hits_l1.len(), 1);
+    assert_eq!(hits_l1[0].conv_id, "b");
+
+    let hits_l0 = idx
+        .search(&[1.0; 16], 10, None, Some(0))
+        .await
+        .unwrap();
+    assert_eq!(hits_l0.len(), 1);
+    assert_eq!(hits_l0[0].conv_id, "a");
+}
+```
+
+- [ ] **Step 3: Run — must fail**
+
+```
+cargo test -p mur-core conversations::index::tests::search_filters_by_layer
+```
+
+Expected: compile error (`upsert_with_layer`, `search` extra arg).
+
+- [ ] **Step 4: Implement**
+
+In `mur-core/src/conversations/index.rs`:
+
+a. Rename existing `upsert(&mut self, batch: &[(Message, Vec<f32>)])` to delegate into a new layer-aware method. Add:
+
+```rust
+/// Upsert with an explicit `layer` value per entry. Phase 2A uses this for
+/// summary rows (layer=1); existing raw writes continue via `upsert()`
+/// which keeps layer=0 for backward compatibility.
+pub async fn upsert_with_layer(
+    &mut self,
+    entries: &[(Message, Vec<f32>, i8)],
+) -> Result<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    // Re-use the existing upsert body but with per-row layer.
+    self.upsert_internal(
+        &entries.iter().map(|(m, v, l)| (m.clone(), v.clone(), *l)).collect::<Vec<_>>(),
+    )
+    .await
+}
+
+pub async fn upsert(&mut self, batch: &[(Message, Vec<f32>)]) -> Result<()> {
+    let with_layer: Vec<(Message, Vec<f32>, i8)> =
+        batch.iter().map(|(m, v)| (m.clone(), v.clone(), 0)).collect();
+    self.upsert_internal(&with_layer).await
+}
+
+async fn upsert_internal(&mut self, entries: &[(Message, Vec<f32>, i8)]) -> Result<()> {
+    // move the previous body of upsert() here, but read the layer from
+    // entries[i].2 instead of hardcoded 0. Every existing field (id, ts,
+    // source, conv_id, role, content, vector) stays the same shape.
+    // ... rest unchanged from Phase 1 except the `layer` column array:
+    // let layers_arr = Int8Array::from_iter_values(entries.iter().map(|(_, _, l)| *l));
+}
+```
+
+Full migration: copy the body of the current `upsert()` into `upsert_internal`, replace the hardcoded-zero `layer` array with per-row `l` from the tuple. (The current implementation already builds a `layer` Int8 column — see `conversations/index.rs` around the `Int8Array::from_iter_values(vec![0_i8; batch.len()])` line.)
+
+b. Extend `search`:
+
+```rust
+pub async fn search(
+    &self,
+    query_vec: &[f32],
+    limit: usize,
+    source_filter: Option<Source>,
+    layer: Option<i8>,
+) -> Result<Vec<SearchHit>> {
+    // existing body builds a `query` against the table;
+    // when `layer` is Some, add a `only_if` filter clause:
+    //   .only_if(format!("layer = {}", l))
+    // combined with source_filter via " AND " if both are present.
+}
+```
+
+The actual Phase 1 `search` body uses `.only_if(...)` already for `source_filter`; extend it to combine predicates:
+
+```rust
+let predicates: Vec<String> = std::iter::empty()
+    .chain(source_filter.map(|s| format!("source = '{}'", s.file_prefix())))
+    .chain(layer.map(|l| format!("layer = {l}")))
+    .collect();
+let filter_clause = predicates.join(" AND ");
+let mut q = self.table.query();
+if !filter_clause.is_empty() {
+    q = q.only_if(&filter_clause);
+}
+```
+
+c. Update all existing callers of `search(vec, k, src)` to `search(vec, k, src, None)` — layer=None preserves Phase 1 behavior. Callers are in `retrieve.rs::search` and any tests.
+
+- [ ] **Step 5: Run all index + retrieve tests**
+
+```
+cargo test -p mur-core conversations::index
+cargo test -p mur-core conversations::retrieve
+```
+
+Expected: previous tests pass + new `search_filters_by_layer` passes.
+
+- [ ] **Step 6: Commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/index.rs mur-core/src/conversations/retrieve.rs
+git commit -m "$(cat <<'EOF'
+feat(core): conversations/index — layer filter + upsert_with_layer (Phase 2A)
+
+search() gains layer: Option<i8> — None preserves Phase 1 behavior
+(searches all layers), Some(0|1|2) restricts. Combines with source_filter
+via AND in the LanceDB only_if clause.
+
+upsert_with_layer(entries: &[(Message, Vec<f32>, i8)]) is the writer path
+for summary rows (layer=1). Existing upsert() delegates with layer=0, so
+Phase 1 callers are unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: `summarize::writer` — atomic write + audit + index (Phase 2A)
+
+**Files:**
+- Create: `mur-core/src/conversations/summarize/writer.rs`
+- Modify: `mur-core/src/conversations/summarize/mod.rs`
+
+- [ ] **Step 1: Failing tests**
+
+Create `mur-core/src/conversations/summarize/writer.rs`:
+
+```rust
+//! Atomic summary writer + .history/ archive + audit + LanceDB upsert.
+//! Spec §4.7. Each write:
+//!   1. Render Markdown (frontmatter + extractive + abstractive + macro map)
+//!   2. If file exists with different content: move to .history/<date>.<iso>.md
+//!   3. If file exists with identical content: no-op
+//!   4. Atomic write via tmp+rename
+//!   5. audit::Audit::append(Summarize{...})
+//!   6. LanceDB upsert at layer=1
+
+use anyhow::{bail, Context, Result};
+use chrono::{DateTime, NaiveDate, Utc};
+use sha2::{Digest, Sha256};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use super::abstractive::AbstractiveResult;
+use super::extractive::ExtractiveSpan;
+use super::macro_refs::MacroRef;
+use super::super::audit::{self, AuditAction};
+use super::super::index::ConversationIndex;
+use super::super::paths::{summary_history_dir, summary_paths_for};
+
+pub struct SummaryDoc {
+    pub date: NaiveDate,
+    pub generated_at: DateTime<Utc>,
+    pub extractive_model: String,
+    pub abstractive_model: String,
+    pub mur_version: String,
+    pub duration_ms: u64,
+    pub conv_count: u32,
+    pub msg_count: u32,
+    pub sources: Vec<String>, // file_prefix strings, sorted+dedup
+    pub pattern_refs: Vec<MacroRef>,
+    pub keywords: Vec<String>,
+    pub links_prev: Option<NaiveDate>,
+    pub links_next: Option<NaiveDate>,
+    pub warnings: Vec<String>,
+    pub input_content_sha: String,
+    pub extractive: Vec<ExtractiveSpan>,
+    pub abstractive: AbstractiveResult,
+}
+
+pub struct WriteResult {
+    pub path: PathBuf,
+    pub archived: Option<PathBuf>,   // Some(path) if prior version was moved
+    pub noop: bool,                   // true when content was byte-identical
+}
+
+pub async fn write_summary(
+    doc: &SummaryDoc,
+    summary_embedding: Vec<f32>,
+    root_override: Option<&str>,
+) -> Result<WriteResult> {
+    let (md_path, _yaml_path) = summary_paths_for(doc.date, root_override);
+    if let Some(parent) = md_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let new_body = render(doc);
+
+    let prior_exists = md_path.exists();
+    let archived;
+    let noop;
+
+    if prior_exists {
+        let existing = std::fs::read_to_string(&md_path)?;
+        if existing == new_body {
+            return Ok(WriteResult {
+                path: md_path,
+                archived: None,
+                noop: true,
+            });
+        }
+        archived = Some(archive_prior(&md_path, root_override)?);
+        noop = false;
+    } else {
+        archived = None;
+        noop = false;
+    }
+
+    let tmp = md_path.with_file_name(format!(
+        ".tmp.{}.md",
+        doc.date.format("%Y-%m-%d")
+    ));
+    let mut f = std::fs::File::create(&tmp)
+        .with_context(|| format!("open tmp {tmp:?}"))?;
+    f.write_all(new_body.as_bytes())?;
+    f.sync_all()?;
+    drop(f);
+    std::fs::rename(&tmp, &md_path)?;
+
+    // Content hash for audit
+    let mut h = Sha256::new();
+    h.update(new_body.as_bytes());
+    let content_sha = hex::encode(h.finalize());
+
+    let audit_log = audit::Audit::open(root_override)?;
+    audit_log.append(
+        AuditAction::Summarize {
+            date: doc.date.format("%Y-%m-%d").to_string(),
+            model: doc.abstractive_model.clone(),
+            duration_ms: doc.duration_ms,
+        },
+        content_sha,
+    )?;
+
+    // Index upsert at layer=1
+    let mut idx = ConversationIndex::open(summary_embedding.len() as i32, root_override).await?;
+    let summary_msg = summary_row_as_message(doc);
+    idx.upsert_with_layer(&[(summary_msg, summary_embedding, 1)])
+        .await?;
+
+    Ok(WriteResult {
+        path: md_path,
+        archived,
+        noop,
+    })
+}
+
+/// Build a synthetic Message representing the summary for LanceDB storage.
+/// The index row uses the abstractive narrative as content so retrieval's
+/// keyword/MMR reranking has real text to work with.
+fn summary_row_as_message(doc: &SummaryDoc) -> mur_common::Message {
+    use chrono::TimeZone;
+    let ts = chrono::Utc
+        .from_utc_datetime(&doc.date.and_hms_opt(0, 0, 0).unwrap());
+    let content_text = doc
+        .abstractive
+        .narrative
+        .clone()
+        .unwrap_or_else(|| "(no narrative)".to_string());
+    mur_common::Message {
+        v: 1,
+        ts,
+        src: mur_common::Source::ClaudeCode, // placeholder; summaries aggregate across sources
+        conv: format!("summary:{}", doc.date.format("%Y-%m-%d")),
+        role: mur_common::Role::System,
+        content: mur_common::Content::Text {
+            value: content_text,
+        },
+        meta: serde_json::json!({
+            "layer": 1,
+            "sources": doc.sources,
+            "conv_count": doc.conv_count,
+        }),
+        refs: doc.pattern_refs.iter().map(|r| r.name.clone()).collect(),
+    }
+}
+
+fn archive_prior(md_path: &Path, root_override: Option<&str>) -> Result<PathBuf> {
+    let hist = summary_history_dir(root_override);
+    std::fs::create_dir_all(&hist)?;
+    let stem = md_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .context("stem")?;
+    let now = Utc::now().format("%Y-%m-%dT%H-%M-%SZ").to_string();
+    let dest = hist.join(format!("{stem}.{now}.md"));
+    std::fs::rename(md_path, &dest)
+        .with_context(|| format!("archive {md_path:?} → {dest:?}"))?;
+    Ok(dest)
+}
+
+fn render(doc: &SummaryDoc) -> String {
+    let mut out = String::new();
+
+    // Frontmatter
+    out.push_str("---\n");
+    out.push_str("schema: 1\n");
+    out.push_str(&format!("date: {}\n", doc.date));
+    out.push_str(&format!(
+        "generated_at: {}\n",
+        doc.generated_at.format("%Y-%m-%dT%H:%M:%SZ")
+    ));
+    out.push_str("generated_by:\n");
+    out.push_str(&format!("  extractive_model: {}\n", doc.extractive_model));
+    out.push_str(&format!("  abstractive_model: {}\n", doc.abstractive_model));
+    out.push_str(&format!("  mur_version: {}\n", doc.mur_version));
+    out.push_str(&format!("duration_ms: {}\n", doc.duration_ms));
+    out.push_str(&format!("conv_count: {}\n", doc.conv_count));
+    out.push_str(&format!("msg_count: {}\n", doc.msg_count));
+    out.push_str(&format!("sources: [{}]\n", doc.sources.join(", ")));
+    if doc.pattern_refs.is_empty() {
+        out.push_str("pattern_refs: []\n");
+    } else {
+        out.push_str("pattern_refs:\n");
+        for r in &doc.pattern_refs {
+            out.push_str(&format!(
+                "  - name: {}\n    version: {}\n    sha: {}\n",
+                r.name, r.pattern_version, r.pattern_sha
+            ));
+        }
+    }
+    out.push_str(&format!("keywords: [{}]\n", doc.keywords.join(", ")));
+    out.push_str("links:\n");
+    out.push_str(&format!(
+        "  prev: {}\n",
+        doc.links_prev
+            .map(|d| format!("./{}.md", d))
+            .unwrap_or_else(|| "null".into())
+    ));
+    out.push_str(&format!(
+        "  next: {}\n",
+        doc.links_next
+            .map(|d| format!("./{}.md", d))
+            .unwrap_or_else(|| "null".into())
+    ));
+    if doc.warnings.is_empty() {
+        out.push_str("warnings: []\n");
+    } else {
+        out.push_str("warnings:\n");
+        for w in &doc.warnings {
+            out.push_str(&format!("  - {}\n", w));
+        }
+    }
+    out.push_str(&format!(
+        "input_content_sha: {}\n",
+        doc.input_content_sha
+    ));
+    out.push_str("---\n\n");
+
+    // Body
+    out.push_str("## Extractive spans\n\n");
+    for (i, s) in doc.extractive.iter().enumerate() {
+        out.push_str(&format!(
+            "[{}] _{{{}/{} @L{}}}_:\n> {}\n\n",
+            i + 1,
+            s.src.file_prefix(),
+            s.conv_id,
+            s.line_hint,
+            s.text.replace('\n', "\n> ")
+        ));
+    }
+
+    out.push_str("## Abstractive narrative\n\n");
+    let narrative = doc
+        .abstractive
+        .narrative
+        .as_deref()
+        .unwrap_or("(narrative generation failed; see warnings)");
+    out.push_str(narrative);
+    out.push_str("\n\n");
+
+    if !doc.pattern_refs.is_empty() {
+        out.push_str("## Macro expansion map\n\n");
+        for r in &doc.pattern_refs {
+            out.push_str(&format!(
+                "- {} → patterns/{}.yaml (v{}, sha {}…)\n",
+                r.marker,
+                r.name,
+                r.pattern_version,
+                r.pattern_sha.chars().take(8).collect::<String>()
+            ));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::{Role, Source};
+
+    fn dummy_doc(date: NaiveDate) -> SummaryDoc {
+        SummaryDoc {
+            date,
+            generated_at: Utc::now(),
+            extractive_model: "qwen3:14b".into(),
+            abstractive_model: "qwen3:14b".into(),
+            mur_version: "2.4.0".into(),
+            duration_ms: 1234,
+            conv_count: 1,
+            msg_count: 2,
+            sources: vec!["cc".into()],
+            pattern_refs: vec![],
+            keywords: vec!["test".into()],
+            links_prev: None,
+            links_next: None,
+            warnings: vec![],
+            input_content_sha: "deadbeef".into(),
+            extractive: vec![ExtractiveSpan {
+                role: Role::User,
+                conv_id: "c1".into(),
+                line_hint: 1,
+                text: "hello".into(),
+                src: Source::ClaudeCode,
+            }],
+            abstractive: AbstractiveResult {
+                narrative: Some("Today the developer said hello.".into()),
+                word_count: 5,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn writes_valid_frontmatter_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        let doc = dummy_doc(date);
+        let r = write_summary(&doc, vec![0.0; 16], Some(root)).await.unwrap();
+        assert!(!r.noop);
+        assert!(r.archived.is_none());
+        let body = std::fs::read_to_string(&r.path).unwrap();
+        assert!(body.contains("date: 2026-04-19"));
+        assert!(body.contains("## Extractive spans"));
+        assert!(body.contains("## Abstractive narrative"));
+        assert!(body.contains("Today the developer said hello."));
+    }
+
+    #[tokio::test]
+    async fn second_identical_write_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        let doc = dummy_doc(date);
+        let mut d2 = dummy_doc(date);
+        d2.generated_at = doc.generated_at; // force bit-identical
+        let _ = write_summary(&doc, vec![0.0; 16], Some(root)).await.unwrap();
+        let r2 = write_summary(&d2, vec![0.0; 16], Some(root)).await.unwrap();
+        assert!(r2.noop);
+        assert!(r2.archived.is_none());
+    }
+
+    #[tokio::test]
+    async fn overwrite_archives_prior() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        let mut doc1 = dummy_doc(date);
+        doc1.abstractive.narrative = Some("version 1".into());
+        let _ = write_summary(&doc1, vec![0.0; 16], Some(root)).await.unwrap();
+        let mut doc2 = dummy_doc(date);
+        doc2.abstractive.narrative = Some("version 2".into());
+        let r2 = write_summary(&doc2, vec![0.0; 16], Some(root)).await.unwrap();
+        assert!(r2.archived.is_some());
+        let hist = summary_history_dir(Some(root));
+        let entries: Vec<_> = std::fs::read_dir(&hist).unwrap().collect();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn audit_records_summarize_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        let doc = dummy_doc(date);
+        let _ = write_summary(&doc, vec![0.0; 16], Some(root)).await.unwrap();
+        let audit_log = audit::Audit::open(Some(root)).unwrap();
+        let report = audit_log.verify().unwrap();
+        assert!(report.entries >= 1);
+    }
+}
+```
+
+Register in `summarize/mod.rs`:
+
+```rust
+pub mod abstractive;
+pub mod chunker;
+pub mod extractive;
+pub mod macro_refs;
+pub mod writer;
+```
+
+- [ ] **Step 2: Run tests**
+
+```
+cargo test -p mur-core conversations::summarize::writer::tests
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 3: Commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/summarize/writer.rs mur-core/src/conversations/summarize/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(core): summarize/writer — atomic write + audit + index (Phase 2A)
+
+write_summary() flow:
+  1. Render frontmatter + extractive + abstractive + macro map
+  2. If existing differs: move to .history/<date>.<iso>.md
+  3. If existing identical: no-op (early return)
+  4. Atomic tmp→rename write
+  5. audit::Audit.append(Summarize{date, model, duration_ms})
+  6. LanceDB upsert at layer=1 (summary row uses narrative as content for
+     retrieval reranking)
+
+Frontmatter matches spec §4.5 exactly. Body matches §4.6 with Markdown-
+escaped multi-line extractive spans.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: `summarize::mod` — orchestrator (Phase 2A)
+
+**Files:**
+- Modify: `mur-core/src/conversations/summarize/mod.rs`
+
+- [ ] **Step 1: Failing tests**
+
+Append to `mur-core/src/conversations/summarize/mod.rs`:
+
+```rust
+use anyhow::Result;
+use chrono::{NaiveDate, Utc};
+use mur_common::config::CompactConfig;
+use sha2::{Digest, Sha256};
+use std::time::Instant;
+use tracing::info_span;
+
+use super::audit::{self, AuditAction};
+use super::ollama::OllamaClient;
+use super::paths::summary_paths_for;
+use super::store;
+
+#[derive(Debug, Default)]
+pub struct CompactReport {
+    pub ok: u32,
+    pub err: u32,
+    pub skipped: u32,
+    pub day_reports: Vec<DayReport>,
+}
+
+#[derive(Debug)]
+pub struct DayReport {
+    pub date: NaiveDate,
+    pub outcome: Outcome,
+    pub extractive_spans: u32,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug)]
+pub enum Outcome {
+    Written { archived: bool },
+    Noop,
+    Skipped { reason: &'static str },
+    Failed(String),
+}
+
+pub async fn compact_day(
+    date: NaiveDate,
+    force: bool,
+    cfg: &CompactConfig,
+    root_override: Option<&str>,
+) -> Result<DayReport> {
+    let _span = info_span!("compact.day", %date).entered();
+    let start = Instant::now();
+
+    let (md_path, _) = summary_paths_for(date, root_override);
+    let msgs = store::read_day(date, root_override)?;
+    if msgs.is_empty() {
+        return Ok(DayReport {
+            date,
+            outcome: Outcome::Skipped { reason: "no raw for day" },
+            extractive_spans: 0,
+            duration_ms: start.elapsed().as_millis() as u64,
+        });
+    }
+
+    // Compute input_content_sha first — used for --if-stale guard.
+    let input_sha = compute_input_sha(&msgs);
+
+    // Skip if summary exists, is fresh, and not forced.
+    if md_path.exists() && !force {
+        if let Ok(existing) = std::fs::read_to_string(&md_path) {
+            if existing.contains(&format!("input_content_sha: {}", input_sha)) {
+                return Ok(DayReport {
+                    date,
+                    outcome: Outcome::Skipped { reason: "already fresh" },
+                    extractive_spans: 0,
+                    duration_ms: start.elapsed().as_millis() as u64,
+                });
+            }
+        }
+    }
+
+    // Chunk + extract per chunk
+    let client = OllamaClient::new(
+        &cfg.ollama_endpoint,
+        std::time::Duration::from_secs(120),
+    );
+    let chunks = chunker::chunk_day(&msgs, cfg.chunk_tokens as usize);
+    let mut all_spans = Vec::new();
+    for chunk in &chunks {
+        let spans = extractive::extract_chunk(
+            &client,
+            &cfg.extractive_model,
+            chunk,
+            &msgs,
+        )
+        .await?;
+        all_spans.extend(spans);
+    }
+
+    // Dedup (reuse Phase 1 MinHash pattern via simple string equality for now;
+    // structural dedup is Phase 2C polish)
+    all_spans.sort_by(|a, b| a.line_hint.cmp(&b.line_hint));
+    all_spans.dedup_by(|a, b| a.text == b.text && a.line_hint == b.line_hint);
+
+    // Cap
+    if all_spans.len() > cfg.max_extractive_spans as usize {
+        all_spans.truncate(cfg.max_extractive_spans as usize);
+    }
+
+    // Abstractive
+    let abstractive_result = abstractive::summarize(
+        &client,
+        &cfg.abstractive_model,
+        &all_spans,
+        date,
+        cfg.max_abstractive_words,
+    )
+    .await;
+
+    let mut warnings = Vec::new();
+    if abstractive_result.narrative.is_none() {
+        warnings.push("narrative_generation_failed".to_string());
+    }
+
+    // Macro refs
+    let patterns_dir = dirs::home_dir()
+        .unwrap_or_default()
+        .join(".mur")
+        .join("patterns");
+    let mut abstractive_text = abstractive_result
+        .narrative
+        .clone()
+        .unwrap_or_else(|| "(narrative unavailable)".into());
+    let pattern_refs = macro_refs::detect_and_rewrite(
+        &mut all_spans,
+        &mut abstractive_text,
+        &patterns_dir,
+    )
+    .unwrap_or_default();
+    let abstractive_final = abstractive::AbstractiveResult {
+        narrative: Some(abstractive_text),
+        word_count: abstractive_result.word_count,
+    };
+
+    // Frontmatter derived fields
+    let sources = {
+        let mut s: Vec<String> = msgs.iter().map(|m| m.src.file_prefix().to_string()).collect();
+        s.sort();
+        s.dedup();
+        s
+    };
+    let conv_count = {
+        let mut c: Vec<&str> = msgs.iter().map(|m| m.conv.as_str()).collect();
+        c.sort();
+        c.dedup();
+        c.len() as u32
+    };
+    let keywords = top_keywords(&all_spans, 10);
+
+    let doc = writer::SummaryDoc {
+        date,
+        generated_at: Utc::now(),
+        extractive_model: cfg.extractive_model.clone(),
+        abstractive_model: cfg.abstractive_model.clone(),
+        mur_version: env!("CARGO_PKG_VERSION").into(),
+        duration_ms: start.elapsed().as_millis() as u64,
+        conv_count,
+        msg_count: msgs.len() as u32,
+        sources,
+        pattern_refs,
+        keywords,
+        links_prev: Some(date - chrono::Duration::days(1)),
+        links_next: Some(date + chrono::Duration::days(1)),
+        warnings,
+        input_content_sha: input_sha,
+        extractive: all_spans.clone(),
+        abstractive: abstractive_final,
+    };
+
+    // Summary embedding: use a deterministic zero vector when MUR_OLLAMA_MOCK=1;
+    // otherwise call the configured embedding provider via existing pipeline.
+    let embed_dims = 1024_usize; // default; Phase 3 can read from cfg
+    let summary_embedding = if OllamaClient::mock_from_env() {
+        vec![0.1; embed_dims]
+    } else {
+        // Reuse the mur-core embedding pipeline used by the ingest stage.
+        let text = doc
+            .abstractive
+            .narrative
+            .as_deref()
+            .unwrap_or("")
+            .to_string();
+        crate::store::embedding::embed_text(&text, embed_dims)
+            .await
+            .unwrap_or_else(|_| vec![0.0; embed_dims])
+    };
+
+    match writer::write_summary(&doc, summary_embedding, root_override).await {
+        Ok(w) => Ok(DayReport {
+            date,
+            outcome: if w.noop {
+                Outcome::Noop
+            } else {
+                Outcome::Written { archived: w.archived.is_some() }
+            },
+            extractive_spans: doc.extractive.len() as u32,
+            duration_ms: doc.duration_ms,
+        }),
+        Err(e) => {
+            // Record the failure in audit but don't throw — caller still gets a report.
+            let _ = audit::Audit::open(root_override).and_then(|a| {
+                a.append(
+                    AuditAction::Error {
+                        layer: "compact.write".into(),
+                        reason: format!("{e:#}"),
+                    },
+                    String::new(),
+                )
+            });
+            Ok(DayReport {
+                date,
+                outcome: Outcome::Failed(format!("{e:#}")),
+                extractive_spans: 0,
+                duration_ms: start.elapsed().as_millis() as u64,
+            })
+        }
+    }
+}
+
+pub async fn compact_missing(
+    cfg: &CompactConfig,
+    since: Option<NaiveDate>,
+    if_stale: bool,
+    max_days_override: Option<u32>,
+    root_override: Option<&str>,
+) -> Result<CompactReport> {
+    let max_days = max_days_override.unwrap_or(cfg.max_days_per_run) as usize;
+    let today = Utc::now().date_naive();
+
+    let mut candidates: Vec<NaiveDate> = store::list_raw_dirs(root_override)?
+        .into_iter()
+        .map(|(d, _)| d)
+        .filter(|d| *d < today)
+        .filter(|d| since.map_or(true, |s| *d >= s))
+        .collect();
+    candidates.sort();
+
+    let mut report = CompactReport::default();
+    for date in candidates.into_iter().take(max_days) {
+        // skip logic: if summary exists and --if-stale is off, skip
+        let (md_path, _) = summary_paths_for(date, root_override);
+        let force = if_stale;
+        if md_path.exists() && !if_stale {
+            report.skipped += 1;
+            report.day_reports.push(DayReport {
+                date,
+                outcome: Outcome::Skipped { reason: "summary exists" },
+                extractive_spans: 0,
+                duration_ms: 0,
+            });
+            continue;
+        }
+        let r = compact_day(date, force, cfg, root_override).await?;
+        match &r.outcome {
+            Outcome::Written { .. } | Outcome::Noop => report.ok += 1,
+            Outcome::Failed(_) => report.err += 1,
+            Outcome::Skipped { .. } => report.skipped += 1,
+        }
+        report.day_reports.push(r);
+    }
+    Ok(report)
+}
+
+fn compute_input_sha(msgs: &[mur_common::Message]) -> String {
+    let mut h = Sha256::new();
+    for m in msgs {
+        h.update(serde_json::to_string(m).unwrap_or_default().as_bytes());
+        h.update(b"\n");
+    }
+    hex::encode(h.finalize())
+}
+
+fn top_keywords(spans: &[extractive::ExtractiveSpan], n: usize) -> Vec<String> {
+    use std::collections::HashMap;
+    // Tiny TF heuristic, no TF-IDF in Phase 2A (corpus-level IDF is Phase 3).
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for s in spans {
+        for w in s.text.split_whitespace() {
+            let w = w.to_lowercase();
+            if w.len() < 4 {
+                continue;
+            }
+            // strip trailing punctuation
+            let w = w.trim_end_matches(|c: char| !c.is_alphanumeric()).to_string();
+            if w.is_empty() {
+                continue;
+            }
+            *counts.entry(w).or_insert(0) += 1;
+        }
+    }
+    let mut ranked: Vec<_> = counts.into_iter().collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1));
+    ranked.into_iter().take(n).map(|(k, _)| k).collect()
+}
+
+#[cfg(test)]
+mod orch_tests {
+    use super::*;
+    use chrono::TimeZone;
+    use mur_common::{Content, Message, Role, Source};
+
+    fn seed_raw(root: &str, date: NaiveDate, text: &str) {
+        let ts = chrono::Utc
+            .with_ymd_and_hms(date.year() as i32, date.month(), date.day(), 10, 0, 0)
+            .unwrap();
+        let m = Message {
+            v: 1,
+            ts,
+            src: Source::ClaudeCode,
+            conv: "c1".into(),
+            role: Role::User,
+            content: Content::Text { value: text.into() },
+            meta: serde_json::Value::Null,
+            refs: vec![],
+        };
+        store::append(&m, Some(root)).unwrap();
+    }
+
+    fn cfg() -> CompactConfig {
+        CompactConfig::default()
+    }
+
+    #[tokio::test]
+    async fn compact_day_happy_path_mock() {
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        seed_raw(root, date, "mock extractive span");
+        let r = compact_day(date, false, &cfg(), Some(root)).await.unwrap();
+        match r.outcome {
+            Outcome::Written { .. } => {}
+            other => panic!("expected Written, got {:?}", other),
+        }
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[tokio::test]
+    async fn compact_day_noop_when_fresh() {
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        seed_raw(root, date, "mock extractive span");
+        let _ = compact_day(date, false, &cfg(), Some(root)).await.unwrap();
+        let r2 = compact_day(date, false, &cfg(), Some(root)).await.unwrap();
+        assert!(matches!(r2.outcome, Outcome::Skipped { .. } | Outcome::Noop));
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[tokio::test]
+    async fn compact_missing_respects_throttle() {
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        for i in 1..=10 {
+            let d = NaiveDate::from_ymd_opt(2026, 4, i).unwrap();
+            seed_raw(root, d, &format!("day {i} mock extractive span"));
+        }
+        let mut c = cfg();
+        c.max_days_per_run = 3;
+        let report = compact_missing(&c, None, false, None, Some(root))
+            .await
+            .unwrap();
+        assert_eq!(report.day_reports.len(), 3);
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+}
+```
+
+Note: `crate::store::embedding::embed_text` is a convenience wrapper expected
+to exist; if it doesn't, inline the LLM endpoint call and dims lookup from
+config here. For Phase 2A the mock path is sufficient for all tests.
+
+- [ ] **Step 2: Run tests**
+
+```
+cargo test -p mur-core conversations::summarize::orch_tests
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 3: Commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/summarize/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(core): summarize::{compact_day, compact_missing} orchestrator (Phase 2A)
+
+compact_day:
+  1. read_day(date)
+  2. chunk + per-chunk extractive
+  3. dedup + cap
+  4. abstractive (single call)
+  5. macro_refs detection
+  6. build SummaryDoc with derived frontmatter fields
+  7. write_summary (atomic + audit + index)
+
+compact_missing:
+  - scans list_raw_dirs, filters to date < today_utc,
+  - optionally since filter,
+  - caps at max_days_per_run
+  - delegates per-day to compact_day
+
+Skip logic: input_content_sha in existing summary matches current day →
+noop-skip unless --if-stale or --force.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Summary serde types + reader helper (Phase 2A)
+
+Consolidates the summary-file reader used by future `chat show` and Phase 2B retrieval's extractive-span lookup.
+
+**Files:**
+- Modify: `mur-core/src/conversations/summarize/mod.rs` (add parse_summary fn + tests)
+
+- [ ] **Step 1: Failing test**
+
+Append to `orch_tests` in `summarize/mod.rs`:
+
+```rust
+#[test]
+fn parse_roundtrip_reads_frontmatter_and_body() {
+    let markdown = r#"---
+schema: 1
+date: 2026-04-19
+generated_at: 2026-04-19T03:00:00Z
+generated_by:
+  extractive_model: qwen3:14b
+  abstractive_model: qwen3:14b
+  mur_version: 2.4.0
+duration_ms: 100
+conv_count: 1
+msg_count: 2
+sources: [cc]
+pattern_refs: []
+keywords: [test]
+links:
+  prev: null
+  next: null
+warnings: []
+input_content_sha: abc123
+---
+
+## Extractive spans
+
+[1] _{cc/c1 @L1}_:
+> hello
+
+## Abstractive narrative
+
+Today was a test.
+"#;
+    let parsed = parse_summary(markdown).unwrap();
+    assert_eq!(parsed.date, NaiveDate::from_ymd_opt(2026, 4, 19).unwrap());
+    assert_eq!(parsed.extractive.len(), 1);
+    assert_eq!(parsed.extractive[0].conv_id, "c1");
+    assert_eq!(parsed.extractive[0].line_hint, 1);
+    assert_eq!(parsed.extractive[0].text, "hello");
+    assert!(parsed.narrative.contains("Today was a test"));
+}
+```
+
+- [ ] **Step 2: Implement parser**
+
+Append to `summarize/mod.rs`:
+
+```rust
+pub struct ParsedSummary {
+    pub date: NaiveDate,
+    pub frontmatter: serde_yaml::Value,
+    pub extractive: Vec<ParsedSpan>,
+    pub narrative: String,
+    pub pattern_refs: Vec<String>, // names only, full meta in frontmatter
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedSpan {
+    pub span_index: u32,
+    pub src: String, // file_prefix
+    pub conv_id: String,
+    pub line_hint: u32,
+    pub text: String,
+}
+
+pub fn parse_summary(md: &str) -> Result<ParsedSummary> {
+    let (frontmatter, body) = split_frontmatter(md)?;
+    let fm: serde_yaml::Value = serde_yaml::from_str(frontmatter)?;
+    let date_str = fm
+        .get("date")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing date"))?;
+    let date = NaiveDate::parse_from_str(date_str, "%Y-%m-%d")?;
+
+    let extractive = parse_extractive_section(body);
+    let narrative = parse_narrative_section(body);
+    let pattern_refs = fm
+        .get("pattern_refs")
+        .and_then(|v| v.as_sequence())
+        .map(|seq| {
+            seq.iter()
+                .filter_map(|e| e.get("name").and_then(|n| n.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(ParsedSummary {
+        date,
+        frontmatter: fm,
+        extractive,
+        narrative,
+        pattern_refs,
+    })
+}
+
+fn split_frontmatter(md: &str) -> Result<(&str, &str)> {
+    let body = md.strip_prefix("---\n").ok_or_else(|| anyhow::anyhow!("no frontmatter"))?;
+    let end = body.find("\n---\n").ok_or_else(|| anyhow::anyhow!("unterminated frontmatter"))?;
+    let fm = &body[..end];
+    let rest = &body[end + 5..];
+    Ok((fm, rest))
+}
+
+fn parse_extractive_section(body: &str) -> Vec<ParsedSpan> {
+    let mut out = Vec::new();
+    let span_re = regex::Regex::new(
+        r"(?ms)^\[(\d+)\] _\{([^/]+)/([^ ]+) @L(\d+)\}_:\n((?:> [^\n]*\n?)+)",
+    )
+    .unwrap();
+    let ext_start = body
+        .find("## Extractive spans")
+        .unwrap_or(0);
+    let ext_end = body[ext_start..]
+        .find("\n## ")
+        .map(|i| ext_start + i)
+        .unwrap_or(body.len());
+    let section = &body[ext_start..ext_end];
+    for cap in span_re.captures_iter(section) {
+        let idx: u32 = cap[1].parse().unwrap_or(0);
+        let src = cap[2].to_string();
+        let conv = cap[3].to_string();
+        let line: u32 = cap[4].parse().unwrap_or(0);
+        let quoted = &cap[5];
+        let text: String = quoted
+            .lines()
+            .map(|l| l.trim_start_matches("> ").trim_start_matches('>'))
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string();
+        out.push(ParsedSpan {
+            span_index: idx,
+            src,
+            conv_id: conv,
+            line_hint: line,
+            text,
+        });
+    }
+    out
+}
+
+fn parse_narrative_section(body: &str) -> String {
+    let narr_start = body
+        .find("## Abstractive narrative")
+        .map(|i| i + "## Abstractive narrative".len())
+        .unwrap_or(0);
+    let narr_end = body[narr_start..]
+        .find("\n## ")
+        .map(|i| narr_start + i)
+        .unwrap_or(body.len());
+    body[narr_start..narr_end].trim().to_string()
+}
+```
+
+Add `regex = "1"` to `mur-core/Cargo.toml` if not already present (it was added in Phase 1 for `verify.rs`; verify with `grep regex mur-core/Cargo.toml`).
+
+- [ ] **Step 3: Run tests**
+
+```
+cargo test -p mur-core conversations::summarize::orch_tests::parse_roundtrip_reads_frontmatter_and_body
+```
+
+Expected: passed.
+
+- [ ] **Step 4: Commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/summarize/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(core): summarize::parse_summary — reader for summary Markdown (Phase 2A)
+
+Parses summary/<date>.md back into a ParsedSummary {frontmatter, extractive,
+narrative, pattern_refs}. Used by Phase 2B retrieval (pull extractive span
+for each retrieved hit to build citations that survive retention rotation).
+
+Uses regex for the [N] _{src/conv @L<line>}_ anchor pattern and > quote
+unwrapping.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: CLI `cmd_conversations_compact` + `ConversationsAction::Compact` (Phase 2A)
+
+**Files:**
+- Modify: `mur-core/src/cmd/conversations_cmd.rs`
+- Modify: `mur-core/src/main.rs`
+
+- [ ] **Step 1: Failing CLI integration test**
+
+Append to `mur-core/tests/cli_conversations.rs`:
+
+```rust
+#[test]
+fn mur_conversations_compact_on_empty_archive_is_noop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args(["conversations", "compact"])
+        .env("HOME", tmp.path())
+        .env("MUR_OLLAMA_MOCK", "1")
+        .output()
+        .expect("run mur");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("(nothing to compact)") || stdout.contains("done:"),
+        "unexpected output: {stdout}"
+    );
+}
+
+#[test]
+fn mur_conversations_compact_on_seeded_day_produces_summary() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let yesterday = (chrono::Utc::now().date_naive() - chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+    let raw = home
+        .join(".mur")
+        .join("conversations")
+        .join("raw")
+        .join(&yesterday);
+    std::fs::create_dir_all(&raw).unwrap();
+    // Seed with an actual mur_common::Message so store::read_day parses it back cleanly.
+    let line = serde_json::json!({
+        "v": 1,
+        "ts": format!("{yesterday}T10:00:00Z"),
+        "src": "claude-code",
+        "conv": "c1",
+        "role": "user",
+        "content": {"t": "text", "v": "mock extractive span seeded for compact test"},
+        "meta": {},
+        "refs": []
+    });
+    std::fs::write(
+        raw.join("cc_c1.jsonl"),
+        serde_json::to_string(&line).unwrap() + "\n",
+    )
+    .unwrap();
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args(["conversations", "compact"])
+        .env("HOME", home)
+        .env("MUR_OLLAMA_MOCK", "1")
+        .output()
+        .expect("run mur");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let summary = home
+        .join(".mur")
+        .join("conversations")
+        .join("summary")
+        .join(format!("{yesterday}.md"));
+    assert!(summary.exists(), "summary should have been written at {summary:?}");
+    let body = std::fs::read_to_string(&summary).unwrap();
+    assert!(body.contains("## Extractive spans"));
+    assert!(body.contains("## Abstractive narrative"));
+}
+```
+
+- [ ] **Step 2: Run — must fail (compact subcommand doesn't exist yet)**
+
+```
+cargo test -p mur-core --test cli_conversations mur_conversations_compact
+```
+
+Expected: test compiles but fails with `error: unrecognized subcommand 'compact'`.
+
+- [ ] **Step 3: Add `ConversationsAction::Compact` variant**
+
+Find `enum ConversationsAction` in `mur-core/src/main.rs` (added in Phase 1 Task 17). Append this variant between existing variants:
+
+```rust
+    /// Generate hybrid summaries for completed days (sleep-time compact).
+    Compact {
+        /// One specific date (otherwise process all missing completed days).
+        #[arg(long)]
+        date: Option<String>,
+
+        /// Lower bound for the sweep (ignored with --date).
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Overwrite existing summaries. Archives old version to .history/.
+        #[arg(long)]
+        force: bool,
+
+        /// Only regenerate when raw content hash changed (implies force).
+        #[arg(long)]
+        if_stale: bool,
+
+        /// Override throttle (default: config.compact.max_days_per_run).
+        #[arg(long)]
+        max_days: Option<u32>,
+
+        /// Don't call Ollama — emit extractive-only skeleton (for testing).
+        #[arg(long)]
+        extractive_only: bool,
+
+        /// Emit the LLM prompts to stderr without sending them.
+        #[arg(long)]
+        debug_prompt: bool,
+    },
+```
+
+Add dispatch arm to the main `match` (find the `ConversationsAction::` block):
+
+```rust
+ConversationsAction::Compact {
+    date, since, force, if_stale, max_days, extractive_only, debug_prompt,
+} => {
+    cmd::conversations_cmd::cmd_conversations_compact(
+        cmd::conversations_cmd::CompactArgs {
+            date, since, force, if_stale, max_days, extractive_only, debug_prompt,
+        },
+    )
+    .await?
+}
+```
+
+- [ ] **Step 4: Implement `cmd_conversations_compact`**
+
+Add to `mur-core/src/cmd/conversations_cmd.rs`:
+
+```rust
+pub struct CompactArgs {
+    pub date: Option<String>,
+    pub since: Option<String>,
+    pub force: bool,
+    pub if_stale: bool,
+    pub max_days: Option<u32>,
+    pub extractive_only: bool,
+    pub debug_prompt: bool,
+}
+
+pub async fn cmd_conversations_compact(args: CompactArgs) -> anyhow::Result<()> {
+    use crate::conversations::summarize;
+    use chrono::NaiveDate;
+
+    let config = mur_common::config::Config::load().unwrap_or_default();
+    let mut cfg = config.conversations.compact.clone();
+
+    if args.extractive_only {
+        // Crude guard rail: no abstractive model.
+        cfg.abstractive_model = String::new();
+    }
+    if args.debug_prompt {
+        eprintln!("(debug_prompt not yet wired to individual stages; enabling in Phase 2C)");
+    }
+
+    if let Some(d) = args.date {
+        let date = NaiveDate::parse_from_str(&d, "%Y-%m-%d")?;
+        let force = args.force || args.if_stale;
+        let r = summarize::compact_day(date, force, &cfg, None).await?;
+        println!("{date}: {:?} ({} spans, {}ms)", r.outcome, r.extractive_spans, r.duration_ms);
+        return Ok(());
+    }
+
+    let since = args
+        .since
+        .as_deref()
+        .map(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d"))
+        .transpose()?;
+
+    let report = summarize::compact_missing(
+        &cfg,
+        since,
+        args.if_stale,
+        args.max_days,
+        None,
+    )
+    .await?;
+
+    if report.day_reports.is_empty() {
+        println!("(nothing to compact)");
+        return Ok(());
+    }
+    for r in &report.day_reports {
+        println!(
+            "  {} {:?} ({} spans, {}ms)",
+            r.date, r.outcome, r.extractive_spans, r.duration_ms
+        );
+    }
+    println!("done: {} ok, {} failed, {} skipped", report.ok, report.err, report.skipped);
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Run CLI tests**
+
+```
+cargo test -p mur-core --test cli_conversations mur_conversations_compact
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 6: Commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/cmd/conversations_cmd.rs mur-core/src/main.rs mur-core/tests/cli_conversations.rs
+git commit -m "$(cat <<'EOF'
+feat(core): mur conversations compact CLI (Phase 2A)
+
+New subcommand delegating to summarize::compact_{day,missing} with flags:
+  --date / --since / --force / --if-stale / --max-days / --extractive-only /
+  --debug-prompt
+
+Integration tests cover (1) empty archive emits "(nothing to compact)" and
+(2) seeded day produces summary.md with valid Extractive + Narrative
+sections when MUR_OLLAMA_MOCK=1.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: `migrate.rs` — extend P4 sync for `[conversations.compact]` (Phase 2A)
+
+**Files:**
+- Modify: `mur-core/src/conversations/migrate.rs`
+
+- [ ] **Step 1: Failing test**
+
+Append to `migrate.rs`'s existing `#[cfg(test)] mod tests`:
+
+```rust
+#[test]
+fn sync_writes_conversations_compact_subsection() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cmdr_dir = tmp.path().join(".mur/commander");
+    std::fs::create_dir_all(&cmdr_dir).unwrap();
+    std::fs::write(
+        cmdr_dir.join("config.toml"),
+        "[engine]\nfoo = 1\n",
+    )
+    .unwrap();
+    let cfg = mur_common::config::ConversationsConfig {
+        enabled: true,
+        retention_days: 30,
+        compact: mur_common::config::CompactConfig {
+            enabled_in_daemon: true,
+            daemon_cron: "0 4 * * *".into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    sync_commander_config_toml(&tmp.path().join(".mur"), &cfg).unwrap();
+    let toml = std::fs::read_to_string(cmdr_dir.join("config.toml")).unwrap();
+    assert!(toml.contains("[conversations]"));
+    assert!(toml.contains("enabled = true"));
+    assert!(toml.contains("retention_days = 30"));
+    assert!(toml.contains("[conversations.compact]"));
+    assert!(toml.contains("enabled_in_daemon = true"));
+    assert!(toml.contains("daemon_cron = \"0 4 * * *\""));
+    assert!(toml.contains("[engine]"));
+}
+```
+
+- [ ] **Step 2: Run — must fail** (signature currently doesn't take `&ConversationsConfig`).
+
+- [ ] **Step 3: Change `sync_commander_config_toml` signature**
+
+Replace the existing Phase 1 implementation (which read mur yaml internally) with a version that accepts the config struct explicitly, so tests are deterministic:
+
+```rust
+pub fn sync_commander_config_toml(
+    mur_dir: &std::path::Path,
+    cfg: &mur_common::config::ConversationsConfig,
+) -> anyhow::Result<()> {
+    let cmdr_cfg = mur_dir.join("commander/config.toml");
+    if let Some(parent) = cmdr_cfg.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let existing = std::fs::read_to_string(&cmdr_cfg).unwrap_or_default();
+
+    const BEGIN: &str = "# BEGIN [conversations] (managed by mur conversations migrate)";
+    const END: &str = "# END [conversations]";
+
+    let new_block = format!(
+        "\n{BEGIN}\n\
+         [conversations]\n\
+         enabled = {}\n\
+         retention_days = {}\n\
+         \n\
+         [conversations.compact]\n\
+         enabled_in_daemon = {}\n\
+         daemon_cron = \"{}\"\n\
+         {END}\n",
+        cfg.enabled,
+        cfg.retention_days,
+        cfg.compact.enabled_in_daemon,
+        cfg.compact.daemon_cron,
+    );
+
+    let merged = if let (Some(b), Some(e)) = (existing.find(BEGIN), existing.find(END)) {
+        let before = &existing[..b];
+        let after_marker = e + END.len();
+        let after = &existing[after_marker..];
+        format!("{}{}{}", before.trim_end_matches('\n'), new_block, after)
+    } else {
+        format!("{}{}", existing.trim_end_matches('\n'), new_block)
+    };
+
+    std::fs::write(&cmdr_cfg, merged)?;
+    Ok(())
+}
+```
+
+Update all existing callers (`run()`, etc.) to pass `&cfg.conversations` where `cfg` is the loaded `Config`.
+
+- [ ] **Step 4: Run tests**
+
+```
+cargo test -p mur-core conversations::migrate::tests
+```
+
+Expected: all previous pass + new `sync_writes_conversations_compact_subsection` passes.
+
+- [ ] **Step 5: Commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/migrate.rs
+git commit -m "$(cat <<'EOF'
+feat(core): extend P4 config sync for [conversations.compact] (Phase 2A)
+
+sync_commander_config_toml now accepts &ConversationsConfig explicitly
+(previously read mur yaml internally — less testable). Emits the new
+[conversations.compact] subsection with enabled_in_daemon + daemon_cron
+mirror so commander's daemon can read them without re-parsing yaml at
+runtime.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Commander `ConversationsCompactConfig` (cross-repo, Phase 2A)
+
+**Repo:** `/Volumes/Firecuda4tb/Projects/mur-commander`
+**Files:**
+- Modify: `crates/daemon/src/config.rs`
+
+- [ ] **Step 1: Create worktree for commander**
+
+```
+cd /Volumes/Firecuda4tb/Projects/mur-commander
+git worktree add .worktrees/conversations-phase-2 -b feat/conversations-phase-2 main
+cd .worktrees/conversations-phase-2
+```
+
+- [ ] **Step 2: Failing test**
+
+Append to `crates/daemon/src/config.rs`:
+
+```rust
+#[cfg(test)]
+mod phase2_tests {
+    use super::*;
+
+    #[test]
+    fn conversations_compact_defaults() {
+        let cfg = ConversationsCompactConfig::default();
+        assert!(cfg.enabled_in_daemon);
+        assert_eq!(cfg.daemon_cron, "0 3 * * *");
+    }
+
+    #[test]
+    fn parses_conversations_compact_from_toml() {
+        let t = r#"
+[conversations]
+enabled = true
+
+[conversations.compact]
+enabled_in_daemon = true
+daemon_cron = "0 4 * * *"
+"#;
+        let v: toml::Value = toml::from_str(t).unwrap();
+        let compact: ConversationsCompactConfig =
+            v["conversations"]["compact"].clone().try_into().unwrap();
+        assert!(compact.enabled_in_daemon);
+        assert_eq!(compact.daemon_cron, "0 4 * * *");
+    }
+}
+```
+
+- [ ] **Step 3: Run — must fail**
+
+```
+cargo test -p mur-daemon config::phase2_tests
+```
+
+Expected: compile error `cannot find type 'ConversationsCompactConfig'`.
+
+- [ ] **Step 4: Implement**
+
+Add to `crates/daemon/src/config.rs`:
+
+```rust
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(default)]
+pub struct ConversationsCompactConfig {
+    pub enabled_in_daemon: bool,
+    pub daemon_cron: String,
+}
+
+impl Default for ConversationsCompactConfig {
+    fn default() -> Self {
+        Self {
+            enabled_in_daemon: true,
+            daemon_cron: "0 3 * * *".into(),
+        }
+    }
+}
+```
+
+Wire into the existing top-level config struct (typically `DaemonConfig` or similar — grep for the root-level struct that loads `config.toml`):
+
+```rust
+#[derive(Debug, Clone, serde::Deserialize, Default)]
+pub struct ConversationsSection {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub retention_days: u32,
+    #[serde(default)]
+    pub compact: ConversationsCompactConfig,
+}
+
+// In the root config struct:
+// #[serde(default)] pub conversations: ConversationsSection,
+```
+
+- [ ] **Step 5: Run tests**
+
+```
+cargo test -p mur-daemon config::phase2_tests
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 6: Commit**
+
+```
+cargo clippy -p mur-daemon -- -D warnings
+cargo fmt --check -p mur-daemon
+git add crates/daemon/src/config.rs
+git commit -m "$(cat <<'EOF'
+feat(daemon): add ConversationsCompactConfig struct (Phase 2A)
+
+Matches the [conversations.compact] block written by mur conversations
+migrate's P4 sync: enabled_in_daemon + daemon_cron. Consumed by the new
+ConversationsCompactTrigger (Task 15).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Commander `triggers::conversations_compact` (cross-repo, Phase 2A)
+
+**Repo:** `/Volumes/Firecuda4tb/Projects/mur-commander/.worktrees/conversations-phase-2`
+**Files:**
+- Create: `crates/daemon/src/triggers/conversations_compact.rs`
+- Modify: `crates/daemon/src/triggers/mod.rs`
+
+- [ ] **Step 1: Inspect existing trigger interface**
+
+```
+grep -rn "pub trait Trigger\|impl Trigger for" crates/daemon/src/triggers/ | head
+```
+
+Map out the existing `Trigger` trait — at minimum `fn name()`, `async fn tick(now) -> Result<TriggerAction>`. Note the exact signatures from the existing `FileChange` / `GitPush` / `Cron` trigger implementations.
+
+- [ ] **Step 2: Write failing test**
+
+Create `crates/daemon/src/triggers/conversations_compact.rs`:
+
+```rust
+//! Phase 2A: daily-cron trigger that fires `mur conversations compact`.
+//! Fire-and-forget child process exec, 10-minute timeout.
+
+use anyhow::Result;
+use chrono::{DateTime, Duration, Utc};
+use cron::Schedule;
+use std::str::FromStr;
+use std::sync::Mutex;
+
+use super::{ExecSpec, Trigger, TriggerAction};
+
+pub struct ConversationsCompactTrigger {
+    schedule: Schedule,
+    last_fired: Mutex<Option<DateTime<Utc>>>,
+    enabled: bool,
+}
+
+impl ConversationsCompactTrigger {
+    pub fn from_config(cron_expr: &str, enabled: bool) -> Result<Self> {
+        let schedule = Schedule::from_str(cron_expr)
+            .map_err(|e| anyhow::anyhow!("invalid cron '{cron_expr}': {e}"))?;
+        Ok(Self {
+            schedule,
+            last_fired: Mutex::new(None),
+            enabled,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Trigger for ConversationsCompactTrigger {
+    fn name(&self) -> &'static str {
+        "conversations_compact"
+    }
+
+    async fn tick(&self, now: DateTime<Utc>) -> Result<TriggerAction> {
+        if !self.enabled {
+            return Ok(TriggerAction::None);
+        }
+        let mut last = self.last_fired.lock().unwrap();
+        let base = last.unwrap_or(now - Duration::days(1));
+        let next = self.schedule.after(&base).next();
+        let Some(next) = next else {
+            return Ok(TriggerAction::None);
+        };
+        if now >= next {
+            *last = Some(now);
+            Ok(TriggerAction::Exec(ExecSpec {
+                command: "mur".into(),
+                args: vec!["conversations".into(), "compact".into()],
+                timeout_secs: 600,
+                capture_output: true,
+            }))
+        } else {
+            Ok(TriggerAction::None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[tokio::test]
+    async fn disabled_never_fires() {
+        let trig = ConversationsCompactTrigger::from_config("0 3 * * *", false).unwrap();
+        let r = trig.tick(t("2026-04-21T03:00:00Z")).await.unwrap();
+        assert!(matches!(r, TriggerAction::None));
+    }
+
+    #[tokio::test]
+    async fn fires_when_now_passes_next_cron() {
+        let trig = ConversationsCompactTrigger::from_config("0 3 * * *", true).unwrap();
+        // Seed: last_fired = yesterday 03:00 → next fires at today 03:00
+        *trig.last_fired.lock().unwrap() =
+            Some(t("2026-04-20T03:00:00Z"));
+        let r = trig.tick(t("2026-04-21T03:00:01Z")).await.unwrap();
+        match r {
+            TriggerAction::Exec(spec) => {
+                assert_eq!(spec.command, "mur");
+                assert_eq!(spec.args, vec!["conversations", "compact"]);
+                assert_eq!(spec.timeout_secs, 600);
+            }
+            _ => panic!("expected Exec"),
+        }
+    }
+
+    #[tokio::test]
+    async fn does_not_refire_within_window() {
+        let trig = ConversationsCompactTrigger::from_config("0 3 * * *", true).unwrap();
+        *trig.last_fired.lock().unwrap() = Some(t("2026-04-21T03:00:00Z"));
+        // Same minute — should not re-fire
+        let r = trig.tick(t("2026-04-21T03:00:30Z")).await.unwrap();
+        assert!(matches!(r, TriggerAction::None));
+    }
+}
+```
+
+Register in `crates/daemon/src/triggers/mod.rs`:
+
+```rust
+pub mod conversations_compact;
+```
+
+- [ ] **Step 3: Run tests**
+
+```
+cargo test -p mur-daemon triggers::conversations_compact
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 4: Commit**
+
+```
+cargo clippy -p mur-daemon -- -D warnings
+cargo fmt --check -p mur-daemon
+git add crates/daemon/src/triggers/conversations_compact.rs crates/daemon/src/triggers/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(daemon): ConversationsCompactTrigger cron trigger (Phase 2A)
+
+Fire-and-forget child exec of `mur conversations compact` on configured
+cron (default 0 3 * * *). 10-minute timeout so a stuck Ollama can't block
+the daemon. Enabled flag from commander config; disabled → never fires.
+
+Skips tick if elapsed time < cron window (prevents re-fire on back-to-back
+ticks within the same minute).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: Commander `main.rs` — instantiate trigger (cross-repo, Phase 2A)
+
+**Repo:** `/Volumes/Firecuda4tb/Projects/mur-commander/.worktrees/conversations-phase-2`
+**Files:**
+- Modify: `crates/daemon/src/main.rs`
+
+- [ ] **Step 1: Locate scheduler registration**
+
+```
+grep -n "schedule\|trigger\|Scheduler" crates/daemon/src/main.rs | head -20
+```
+
+Identify where other triggers are registered (typically in a startup sequence that loads config and builds the scheduler).
+
+- [ ] **Step 2: Register the trigger**
+
+Add after the existing trigger registrations in `main.rs`:
+
+```rust
+// Conversations compact trigger (Phase 2A)
+{
+    let c = &config.conversations.compact;
+    if c.enabled_in_daemon {
+        match triggers::conversations_compact::ConversationsCompactTrigger::from_config(
+            &c.daemon_cron,
+            true,
+        ) {
+            Ok(trig) => {
+                scheduler.register(Box::new(trig));
+                tracing::info!(
+                    "registered conversations_compact trigger (cron: {})",
+                    c.daemon_cron
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "skipping conversations_compact trigger — invalid cron '{}': {e:#}",
+                    c.daemon_cron
+                );
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Smoke-test the build**
+
+```
+cargo build -p mur-daemon --bin mur-commander
+```
+
+Expected: clean build.
+
+- [ ] **Step 4: Commit**
+
+```
+cargo clippy -p mur-daemon -- -D warnings
+cargo fmt --check -p mur-daemon
+git add crates/daemon/src/main.rs
+git commit -m "$(cat <<'EOF'
+feat(daemon): register ConversationsCompactTrigger on startup (Phase 2A)
+
+When commander reads [conversations.compact] from its config.toml and
+enabled_in_daemon is true, instantiates the trigger with the configured
+cron. Invalid cron strings are logged (warn) and skipped — daemon keeps
+running with the rest of its triggers intact.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: `mur conversations doctor` — summary coverage + trigger status (Phase 2A, mur repo)
+
+**Files:**
+- Modify: `mur-core/src/cmd/conversations_cmd.rs`
+
+- [ ] **Step 1: Extend failing integration test**
+
+Modify `mur-core/tests/cli_conversations.rs`'s existing `mur_conversations_doctor_runs` to assert on new sections:
+
+```rust
+#[test]
+fn mur_conversations_doctor_runs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args(["conversations", "doctor"])
+        .env("HOME", tmp.path())
+        .env("MUR_OLLAMA_MOCK", "1")
+        .output()
+        .expect("run mur");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("raw day-dirs"));
+    assert!(stdout.contains("summaries:"));       // NEW Phase 2A
+    assert!(stdout.contains("Ollama"));            // NEW Phase 2A
+}
+```
+
+- [ ] **Step 2: Extend `cmd_conversations_doctor`**
+
+Locate existing `cmd_conversations_doctor` in `mur-core/src/cmd/conversations_cmd.rs` and append new checks before `Ok(())`:
+
+```rust
+// Phase 2A additions
+let raw_dir = conversations::paths::raw_root(None);
+let summary_dir = conversations::paths::conversations_root(None).join("summary");
+let raw_days: Vec<_> = std::fs::read_dir(&raw_dir)
+    .ok()
+    .map(|rd| rd.flatten().map(|e| e.file_name().to_string_lossy().into_owned()).collect())
+    .unwrap_or_default();
+let summary_count = std::fs::read_dir(&summary_dir)
+    .ok()
+    .map(|rd| {
+        rd.flatten()
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s == "md")
+                    .unwrap_or(false)
+            })
+            .count()
+    })
+    .unwrap_or(0);
+
+let today = chrono::Utc::now().date_naive();
+let completed_days: Vec<&String> = raw_days
+    .iter()
+    .filter(|d| {
+        chrono::NaiveDate::parse_from_str(d, "%Y-%m-%d")
+            .map(|pd| pd < today)
+            .unwrap_or(false)
+    })
+    .collect();
+let missing = completed_days.len().saturating_sub(summary_count);
+if missing == 0 {
+    println!("  ✓ summaries: all {summary_count} completed days covered");
+} else {
+    println!(
+        "  ⚠ summaries: {summary_count} of {} completed days covered — run 'mur conversations compact'",
+        completed_days.len()
+    );
+}
+
+// Ollama reachability (non-blocking 1s probe)
+let cfg = mur_common::config::Config::load().unwrap_or_default();
+let endpoint = cfg.conversations.compact.ollama_endpoint.clone();
+let reachable = tokio::time::timeout(
+    std::time::Duration::from_secs(1),
+    reqwest::get(format!("{}/api/tags", endpoint.trim_end_matches('/'))),
+)
+.await
+.ok()
+.and_then(|r| r.ok())
+.map(|r| r.status().is_success())
+.unwrap_or(false);
+if reachable {
+    println!("  ✓ Ollama reachable at {endpoint}");
+} else {
+    println!("  · Ollama not reachable at {endpoint} (compact + ask will degrade)");
+}
+```
+
+This handler is `async` (confirmed in Phase 1). Also update the `Commands::Conversations::Doctor` dispatch arm in `main.rs` to call `.await?` if it wasn't already. Phase 1's doctor was sync; Phase 2A switches it to async — update both the fn signature and the dispatch.
+
+- [ ] **Step 3: Run CLI tests**
+
+```
+cargo test -p mur-core --test cli_conversations mur_conversations_doctor
+```
+
+Expected: pass (doctor now reports summaries + Ollama status).
+
+- [ ] **Step 4: Commit**
+
+```
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/cmd/conversations_cmd.rs mur-core/src/main.rs mur-core/tests/cli_conversations.rs
+git commit -m "$(cat <<'EOF'
+feat(core): doctor reports summary coverage + Ollama reachability (Phase 2A)
+
+doctor now:
+  - counts raw day-dirs and summary .md files
+  - flags missing summaries (suggests 'mur conversations compact')
+  - probes Ollama endpoint (1s timeout, non-blocking, informational)
+
+Doctor handler becomes async so it can do the reqwest probe; dispatch
+arm in main.rs updated accordingly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+**🏁 Phase 2A checkpoint.** After Task 17, both mur and mur-commander worktrees have all 2A commits. Open two PRs (mirror Phase 1's two-PR pattern). Wait for CI green + reviewer approval on BOTH before starting Phase 2B.
+
+---
+
+## Task 18: `AskConfig` in `mur-common::config` (Phase 2B)
+
+**Files:**
+- Modify: `mur-common/src/config.rs`
+
+- [ ] **Step 1: Failing test**
+
+Append to `conversations_tests`:
+
+```rust
+#[test]
+fn ask_config_defaults() {
+    let c = AskConfig::default();
+    assert_eq!(c.model, "qwen3:14b");
+    assert_eq!(c.ollama_endpoint, "http://localhost:11434");
+    assert_eq!(c.k_summary, 5);
+    assert_eq!(c.k_raw, 10);
+    assert_eq!(c.escalation_threshold, 0.5);
+    assert_eq!(c.mmr_threshold, 0.85);
+    assert_eq!(c.max_context_tokens, 6000);
+    assert_eq!(c.response_tokens, 1024);
+    assert_eq!(c.timeout_secs, 120);
+    assert_eq!(c.min_score, 0.35);
+}
+```
+
+- [ ] **Step 2: Implement**
+
+Add to `mur-common/src/config.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AskConfig {
+    #[serde(default = "ask_default_model")] pub model: String,
+    #[serde(default = "compact_default_ollama_endpoint")] pub ollama_endpoint: String,
+    #[serde(default = "ask_default_k_summary")] pub k_summary: u32,
+    #[serde(default = "ask_default_k_raw")] pub k_raw: u32,
+    #[serde(default = "ask_default_esc")] pub escalation_threshold: f64,
+    #[serde(default = "ask_default_mmr")] pub mmr_threshold: f64,
+    #[serde(default = "ask_default_max_ctx")] pub max_context_tokens: u32,
+    #[serde(default = "ask_default_resp_tok")] pub response_tokens: u32,
+    #[serde(default = "ask_default_timeout")] pub timeout_secs: u32,
+    #[serde(default = "ask_default_min_score")] pub min_score: f64,
+}
+
+impl Default for AskConfig {
+    fn default() -> Self {
+        Self {
+            model: ask_default_model(),
+            ollama_endpoint: compact_default_ollama_endpoint(),
+            k_summary: ask_default_k_summary(),
+            k_raw: ask_default_k_raw(),
+            escalation_threshold: ask_default_esc(),
+            mmr_threshold: ask_default_mmr(),
+            max_context_tokens: ask_default_max_ctx(),
+            response_tokens: ask_default_resp_tok(),
+            timeout_secs: ask_default_timeout(),
+            min_score: ask_default_min_score(),
+        }
+    }
+}
+
+fn ask_default_model() -> String { "qwen3:14b".into() }
+fn ask_default_k_summary() -> u32 { 5 }
+fn ask_default_k_raw() -> u32 { 10 }
+fn ask_default_esc() -> f64 { 0.5 }
+fn ask_default_mmr() -> f64 { 0.85 }
+fn ask_default_max_ctx() -> u32 { 6000 }
+fn ask_default_resp_tok() -> u32 { 1024 }
+fn ask_default_timeout() -> u32 { 120 }
+fn ask_default_min_score() -> f64 { 0.35 }
+```
+
+Add field to `ConversationsConfig`:
+
+```rust
+#[serde(default)] pub ask: AskConfig,
+```
+
+Update `ConversationsConfig::default()` similarly.
+
+- [ ] **Step 3: Run + commit**
+
+```
+cargo test -p mur-common config::conversations_tests::ask
+cargo clippy -p mur-common -- -D warnings
+cargo fmt --check -p mur-common
+git add mur-common/src/config.rs
+git commit -m "feat(common): add AskConfig to ConversationsConfig (Phase 2B)"
+```
+
+---
+
+## Task 19: `ask::mod` public types (Phase 2B)
+
+**Files:**
+- Create: `mur-core/src/conversations/ask/mod.rs`
+- Modify: `mur-core/src/conversations/mod.rs`
+
+- [ ] **Step 1: Scaffold module + types**
+
+Create `mur-core/src/conversations/ask/mod.rs`:
+
+```rust
+//! Mode C — Ask: local-only RAG with inline citations. See spec §5.
+#![allow(dead_code)] // filled progressively across Tasks 19-25
+
+use mur_common::Source;
+use std::time::Duration;
+
+pub mod retrieve;
+// Later tasks add: pub mod prompt; pub mod generate; pub mod cite; pub mod format;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Format { Plain, Json }
+
+#[derive(Debug, Clone)]
+pub struct Filters {
+    pub source: Vec<Source>,
+    pub since: Option<chrono::NaiveDate>,
+    pub until: Option<chrono::NaiveDate>,
+    pub min_score: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct AskRequest {
+    pub question: String,
+    pub filters: Filters,
+    pub k_summary: usize,
+    pub k_raw: usize,
+    pub escalation_threshold: f64,
+    pub mmr_threshold: f64,
+    pub model: String,
+    pub format: Format,
+    pub max_context_tokens: usize,
+    pub response_tokens: usize,
+    pub timeout: Duration,
+    pub no_escalate: bool,
+    pub debug_prompt: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Citation {
+    pub id: u32,
+    pub date: chrono::NaiveDate,
+    pub source: String,           // file_prefix
+    pub conv_id: String,
+    pub line_hint: Option<u32>,
+    pub span_index_in_summary: Option<u32>,
+    pub snippet: String,
+    pub score: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct HitInfo {
+    pub layer: i8,
+    pub source: String,
+    pub conv_id: String,
+    pub date: chrono::NaiveDate,
+    pub score: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AskResponse {
+    pub answer: String,
+    pub citations: Vec<Citation>,
+    pub hits_used: Vec<HitInfo>,
+    pub degraded_to_mode_b: bool,
+    pub tokens_in: usize,
+    pub tokens_out: usize,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+pub enum AskEvent {
+    Token(String),
+    Citation(Citation),
+    HitInfo(HitInfo),
+    Done {
+        tokens_in: usize,
+        tokens_out: usize,
+        degraded: bool,
+        duration_ms: u64,
+    },
+    Error(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filters_default_shape() {
+        let f = Filters {
+            source: vec![],
+            since: None,
+            until: None,
+            min_score: 0.35,
+        };
+        assert_eq!(f.min_score, 0.35);
+    }
+}
+```
+
+Register in `mur-core/src/conversations/mod.rs`:
+
+```rust
+pub mod ask;
+```
+
+- [ ] **Step 2: Test + commit**
+
+```
+cargo test -p mur-core conversations::ask::tests
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/ask/ mur-core/src/conversations/mod.rs
+git commit -m "feat(core): ask module skeleton + public types (Phase 2B)"
+```
+
+---
+
+## Task 20: `ask::retrieve` — tiered escalation (Phase 2B)
+
+**Files:**
+- Create: `mur-core/src/conversations/ask/retrieve.rs`
+
+- [ ] **Step 1: Failing tests + implementation**
+
+Create `mur-core/src/conversations/ask/retrieve.rs`:
+
+```rust
+//! Tiered retrieval (spec §5.2).
+//! Stages: embed → layer=1 search → escalate to layer=0 if top score low
+//! → MMR dedupe → per-hit snippet resolution → token-budget cap.
+
+use anyhow::Result;
+use mur_common::Source;
+
+use super::super::index::{ConversationIndex, SearchHit};
+use super::super::summarize;
+use super::{Filters, HitInfo};
+
+#[derive(Debug, Clone)]
+pub struct ResolvedHit {
+    pub layer: i8,
+    pub info: HitInfo,
+    pub snippet: String,
+    pub line_hint: Option<u32>,
+    pub span_index_in_summary: Option<u32>,
+}
+
+pub struct RetrieveArgs<'a> {
+    pub query_embedding: Vec<f32>,
+    pub filters: &'a Filters,
+    pub k_summary: usize,
+    pub k_raw: usize,
+    pub escalation_threshold: f64,
+    pub mmr_threshold: f64,
+    pub no_escalate: bool,
+    pub max_context_tokens: usize,
+    pub root_override: Option<&'a str>,
+}
+
+pub async fn gather_hits(args: RetrieveArgs<'_>) -> Result<Vec<ResolvedHit>> {
+    let dims = args.query_embedding.len() as i32;
+    let idx = ConversationIndex::open(dims, args.root_override).await?;
+    let primary_src = args.filters.source.first().copied();
+
+    // Layer 1 (summaries)
+    let l1 = idx
+        .search(&args.query_embedding, args.k_summary, primary_src, Some(1))
+        .await?;
+    let top_score = l1.first().map(|h| h.similarity).unwrap_or(0.0);
+
+    // Escalate?
+    let l0 = if !args.no_escalate
+        && ((top_score as f64) < args.escalation_threshold || l1.is_empty())
+    {
+        idx.search(&args.query_embedding, args.k_raw, primary_src, Some(0))
+            .await?
+    } else {
+        Vec::new()
+    };
+
+    // Filter by since/until/min_score
+    let filtered_l1: Vec<_> = l1.into_iter().filter(|h| passes(h, args.filters)).collect();
+    let filtered_l0: Vec<_> = l0.into_iter().filter(|h| passes(h, args.filters)).collect();
+
+    // Resolve snippets
+    let mut resolved = Vec::new();
+    for h in filtered_l1 {
+        resolved.push(resolve_summary_hit(h, args.root_override)?);
+    }
+    for h in filtered_l0 {
+        resolved.push(resolve_raw_hit(h));
+    }
+
+    // MMR dedupe on snippet text (simple word-jaccard; reuses Phase 1 filter threshold config by default)
+    let deduped = mmr_dedupe(resolved, args.mmr_threshold);
+
+    // Token-budget cap
+    let budget = (args.max_context_tokens * 9 / 10).max(400);
+    let capped = cap_by_budget(deduped, budget);
+    Ok(capped)
+}
+
+fn passes(h: &SearchHit, f: &Filters) -> bool {
+    if h.similarity < f.min_score as f32 {
+        return false;
+    }
+    if let Some(s) = f.since {
+        if chrono::DateTime::from_timestamp(h.ts, 0)
+            .map(|dt| dt.date_naive() < s)
+            .unwrap_or(false)
+        {
+            return false;
+        }
+    }
+    if let Some(u) = f.until {
+        if chrono::DateTime::from_timestamp(h.ts, 0)
+            .map(|dt| dt.date_naive() > u)
+            .unwrap_or(false)
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn resolve_summary_hit(h: SearchHit, root_override: Option<&str>) -> Result<ResolvedHit> {
+    // Read summary file for h.date, pick the first extractive span's text.
+    // (Phase 2B simplification; Phase 3 RAPTOR improves this.)
+    let date = chrono::DateTime::from_timestamp(h.ts, 0)
+        .map(|d| d.date_naive())
+        .unwrap_or_else(|| chrono::Utc::now().date_naive());
+    let (md_path, _) = super::super::paths::summary_paths_for(date, root_override);
+    let (snippet, line_hint, span_idx) = if md_path.exists() {
+        let body = std::fs::read_to_string(&md_path).unwrap_or_default();
+        if let Ok(parsed) = summarize::parse_summary(&body) {
+            parsed.extractive.first().map_or_else(
+                || (String::new(), None, None),
+                |s| (s.text.clone(), Some(s.line_hint), Some(s.span_index)),
+            )
+        } else {
+            (String::new(), None, None)
+        }
+    } else {
+        (String::new(), None, None)
+    };
+    Ok(ResolvedHit {
+        layer: 1,
+        info: HitInfo {
+            layer: 1,
+            source: h.source.clone(),
+            conv_id: h.conv_id.clone(),
+            date,
+            score: h.similarity as f64,
+        },
+        snippet,
+        line_hint,
+        span_index_in_summary: span_idx,
+    })
+}
+
+fn resolve_raw_hit(h: SearchHit) -> ResolvedHit {
+    let date = chrono::DateTime::from_timestamp(h.ts, 0)
+        .map(|d| d.date_naive())
+        .unwrap_or_else(|| chrono::Utc::now().date_naive());
+    ResolvedHit {
+        layer: 0,
+        info: HitInfo {
+            layer: 0,
+            source: h.source.clone(),
+            conv_id: h.conv_id.clone(),
+            date,
+            score: h.similarity as f64,
+        },
+        snippet: h.content.clone(),
+        line_hint: None, // raw hits don't carry line hints; extensible in Phase 3
+        span_index_in_summary: None,
+    }
+}
+
+fn mmr_dedupe(hits: Vec<ResolvedHit>, threshold: f64) -> Vec<ResolvedHit> {
+    let mut kept: Vec<ResolvedHit> = Vec::new();
+    for h in hits {
+        let dup = kept
+            .iter()
+            .any(|k| word_jaccard(&k.snippet, &h.snippet) > threshold);
+        if !dup {
+            kept.push(h);
+        }
+    }
+    kept
+}
+
+fn word_jaccard(a: &str, b: &str) -> f64 {
+    use std::collections::HashSet;
+    let sa: HashSet<&str> = a.split_whitespace().collect();
+    let sb: HashSet<&str> = b.split_whitespace().collect();
+    if sa.is_empty() && sb.is_empty() {
+        return 1.0;
+    }
+    let inter = sa.intersection(&sb).count() as f64;
+    let union = sa.union(&sb).count() as f64;
+    if union == 0.0 {
+        0.0
+    } else {
+        inter / union
+    }
+}
+
+fn cap_by_budget(hits: Vec<ResolvedHit>, budget_tokens: usize) -> Vec<ResolvedHit> {
+    let mut out = Vec::new();
+    let mut used = 0usize;
+    for h in hits {
+        let est = (h.snippet.len() + 80) / 4 + 1;
+        if used + est > budget_tokens && !out.is_empty() {
+            break;
+        }
+        used += est;
+        out.push(h);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn word_jaccard_identical_is_one() {
+        assert_eq!(word_jaccard("a b c", "a b c"), 1.0);
+    }
+
+    #[test]
+    fn word_jaccard_disjoint_is_zero() {
+        assert_eq!(word_jaccard("a b c", "d e f"), 0.0);
+    }
+
+    #[test]
+    fn mmr_dedupe_drops_duplicate() {
+        use mur_common::Role;
+        let h1 = ResolvedHit {
+            layer: 0,
+            info: HitInfo {
+                layer: 0,
+                source: "cc".into(),
+                conv_id: "a".into(),
+                date: chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(),
+                score: 0.9,
+            },
+            snippet: "the quick brown fox jumps".into(),
+            line_hint: None,
+            span_index_in_summary: None,
+        };
+        let h2 = ResolvedHit {
+            snippet: "the quick brown fox jumps".into(),
+            info: HitInfo {
+                source: "cc".into(),
+                conv_id: "b".into(),
+                ..h1.info.clone()
+            },
+            ..h1.clone()
+        };
+        let out = mmr_dedupe(vec![h1, h2], 0.85);
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn cap_by_budget_keeps_at_least_one() {
+        use mur_common::Role;
+        let giant = ResolvedHit {
+            layer: 0,
+            info: HitInfo {
+                layer: 0,
+                source: "cc".into(),
+                conv_id: "a".into(),
+                date: chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(),
+                score: 0.9,
+            },
+            snippet: "x".repeat(40_000),
+            line_hint: None,
+            span_index_in_summary: None,
+        };
+        let out = cap_by_budget(vec![giant], 100);
+        assert_eq!(out.len(), 1, "must keep at least one hit even over budget");
+    }
+}
+```
+
+- [ ] **Step 2: Test + commit**
+
+```
+cargo test -p mur-core conversations::ask::retrieve::tests
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/ask/retrieve.rs
+git commit -m "feat(core): ask::retrieve — tiered escalation with MMR + budget cap (Phase 2B)"
+```
+
+---
+
+## Task 21: `ask::prompt` — system prompt + context assembly (Phase 2B)
+
+**Files:**
+- Create: `mur-core/src/conversations/ask/prompt.rs`
+- Modify: `mur-core/src/conversations/ask/mod.rs` (add `pub mod prompt;`)
+
+- [ ] **Step 1: Implement with tests**
+
+Create `mur-core/src/conversations/ask/prompt.rs`:
+
+```rust
+//! System prompt + context assembly (spec §5.3).
+
+use super::retrieve::ResolvedHit;
+
+pub const SYSTEM_PROMPT: &str = "You answer questions about the user's past AI-assistant conversations, using ONLY the excerpts provided below under \"Context\". Never invent facts not present in the excerpts.
+
+Every factual claim in your answer MUST be followed by an inline citation in the form [cit: <date> <source>/<conv_id>:L<line>]. Use only the citations enumerated in the Context section — one citation per claim. You may use the same citation multiple times.
+
+If the excerpts are insufficient to answer, say so plainly: \"The conversations I have access to don't cover that.\" Do not speculate. Do not use training knowledge to fill gaps.
+
+Format: clear prose, 2-6 sentences per idea, Markdown bullets when listing. Be direct. Don't repeat the question. Don't apologize for not knowing.
+
+When the user mentions a pattern name wrapped in {{pattern: name}} in the excerpts, that refers to a reusable artifact at ~/.mur/patterns/<name>.yaml; you may mention the pattern by name in your answer but do not expand it.";
+
+pub struct RenderedPrompt {
+    pub system: String,
+    pub user: String,
+    pub tokens_est: usize,
+    pub valid_citations: Vec<String>, // normalized citation anchors for grounding
+}
+
+pub fn render(
+    question: &str,
+    hits: &[ResolvedHit],
+    max_context_tokens: usize,
+    response_tokens: usize,
+) -> RenderedPrompt {
+    let system = SYSTEM_PROMPT.to_string();
+
+    let mut ctx = String::new();
+    let mut valid_citations = Vec::new();
+    for (i, h) in hits.iter().enumerate() {
+        let anchor = cite_anchor(h);
+        valid_citations.push(anchor.clone());
+        ctx.push_str(&anchor);
+        ctx.push('\n');
+        ctx.push_str("> ");
+        ctx.push_str(&h.snippet.replace('\n', "\n> "));
+        ctx.push_str("\n\n");
+        let _ = i;
+    }
+
+    let truncated_question = truncate_chars(question, 2000);
+    let user = format!("Context:\n{ctx}\nQuestion: {truncated_question}");
+    let tokens_est = (system.len() + user.len()) / 4 + response_tokens + 120;
+
+    // If we overflow, drop hits from the tail until we fit.
+    let mut user = user;
+    let mut trimmed_hits = hits.len();
+    while tokens_est > max_context_tokens && trimmed_hits > 1 {
+        trimmed_hits -= 1;
+        let mut ctx2 = String::new();
+        valid_citations.clear();
+        for h in hits.iter().take(trimmed_hits) {
+            let anchor = cite_anchor(h);
+            valid_citations.push(anchor.clone());
+            ctx2.push_str(&anchor);
+            ctx2.push('\n');
+            ctx2.push_str("> ");
+            ctx2.push_str(&h.snippet.replace('\n', "\n> "));
+            ctx2.push_str("\n\n");
+        }
+        user = format!("Context:\n{ctx2}\nQuestion: {truncated_question}");
+    }
+
+    RenderedPrompt {
+        system,
+        user,
+        tokens_est,
+        valid_citations,
+    }
+}
+
+pub fn cite_anchor(h: &ResolvedHit) -> String {
+    match (h.layer, h.line_hint, h.span_index_in_summary) {
+        (1, _, Some(idx)) => format!(
+            "[cit: {} {}/{} @summary-span-{}]",
+            h.info.date, h.info.source, h.info.conv_id, idx
+        ),
+        (_, Some(line), _) => format!(
+            "[cit: {} {}/{}:L{}]",
+            h.info.date, h.info.source, h.info.conv_id, line
+        ),
+        _ => format!("[cit: {} {}/{}]", h.info.date, h.info.source, h.info.conv_id),
+    }
+}
+
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        s.chars().take(max).collect::<String>() + "…"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::{Filters, HitInfo};
+
+    fn hit_raw(conv: &str, text: &str) -> ResolvedHit {
+        ResolvedHit {
+            layer: 0,
+            info: HitInfo {
+                layer: 0,
+                source: "cc".into(),
+                conv_id: conv.into(),
+                date: chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(),
+                score: 0.9,
+            },
+            snippet: text.into(),
+            line_hint: Some(42),
+            span_index_in_summary: None,
+        }
+    }
+
+    #[test]
+    fn cite_anchor_raw_layer() {
+        let h = hit_raw("abc", "hi");
+        assert_eq!(
+            cite_anchor(&h),
+            "[cit: 2026-04-19 cc/abc:L42]"
+        );
+    }
+
+    #[test]
+    fn cite_anchor_summary_layer() {
+        let mut h = hit_raw("abc", "hi");
+        h.layer = 1;
+        h.span_index_in_summary = Some(3);
+        h.line_hint = None;
+        assert_eq!(
+            cite_anchor(&h),
+            "[cit: 2026-04-19 cc/abc @summary-span-3]"
+        );
+    }
+
+    #[test]
+    fn render_shrinks_hits_on_overflow() {
+        let hits = (0..20)
+            .map(|i| hit_raw(&format!("c{i}"), &"x".repeat(3000)))
+            .collect::<Vec<_>>();
+        let r = render("question?", &hits, 6000, 1024);
+        assert!(r.valid_citations.len() < hits.len());
+        assert!(!r.valid_citations.is_empty());
+    }
+
+    #[test]
+    fn render_lists_valid_citations_in_order() {
+        let hits = vec![hit_raw("a", "one"), hit_raw("b", "two")];
+        let r = render("q?", &hits, 6000, 1024);
+        assert_eq!(r.valid_citations.len(), 2);
+        assert!(r.user.contains("one"));
+        assert!(r.user.contains("two"));
+    }
+}
+```
+
+Register in `ask/mod.rs`:
+
+```rust
+pub mod prompt;
+```
+
+- [ ] **Step 2: Test + commit**
+
+```
+cargo test -p mur-core conversations::ask::prompt::tests
+cargo clippy -p mur-core -- -D warnings
+cargo fmt --check -p mur-core
+git add mur-core/src/conversations/ask/prompt.rs mur-core/src/conversations/ask/mod.rs
+git commit -m "feat(core): ask::prompt — system prompt + context assembly (Phase 2B)"
+```
+
+---
+
+## Task 22: `ask::generate` — Ollama streaming wrapper (Phase 2B)
+
+**Files:**
+- Create: `mur-core/src/conversations/ask/generate.rs`
+- Modify: `mur-core/src/conversations/ask/mod.rs`
+
+Create `mur-core/src/conversations/ask/generate.rs`:
+
+```rust
+//! Streaming Ollama generation for ask. Thin adapter over conversations::ollama.
+
+use anyhow::Result;
+use futures::stream::Stream;
+use std::pin::Pin;
+use std::time::Duration;
+
+use super::super::ollama::{GenerateOptions, GenerateRequest, OllamaClient};
+
+pub async fn stream_answer(
+    endpoint: &str,
+    model: &str,
+    system: &str,
+    user: &str,
+    response_tokens: u32,
+    timeout: Duration,
+) -> Result<Pin<Box<dyn Stream<Item = Result<String>> + Send>>> {
+    let client = OllamaClient::new(endpoint, timeout);
+    client
+        .generate_stream(GenerateRequest {
+            model,
+            prompt: user,
+            system: Some(system),
+            stream: true,
+            options: GenerateOptions {
+                temperature: Some(0.1),
+                top_p: Some(0.9),
+                num_predict: Some(response_tokens),
+                stop: vec!["\n\nQ:".into(), "\n\nQuestion:".into()],
+            },
+        })
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn mock_stream_yields_tokens() {
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let mut s = stream_answer(
+            "http://unused",
+            "qwen3:14b",
+            "system",
+            "ask about [cit:",
+            256,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        let mut combined = String::new();
+        while let Some(chunk) = s.next().await {
+            combined.push_str(&chunk.unwrap());
+        }
+        assert!(combined.contains("[cit: 2026-04-19 claude-code/mock:L1]"));
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+}
+```
+
+Register in `ask/mod.rs`: `pub mod generate;`
+
+Test + commit.
+
+---
+
+## Task 23: `ask::cite` — grounding filter (Phase 2B)
+
+**Files:**
+- Create: `mur-core/src/conversations/ask/cite.rs`
+
+Create `mur-core/src/conversations/ask/cite.rs`:
+
+```rust
+//! Grounding + coverage checks (spec §5.5).
+//! Strips unknown [cit: ...] from streaming tokens (prevents hallucination).
+
+pub struct GroundingFilter {
+    valid: std::collections::HashSet<String>,
+    buffer: String,       // tail buffer to detect brackets across chunk boundaries
+}
+
+pub struct FilterOutput {
+    pub forwarded: String,
+    pub stripped: Vec<String>,
+}
+
+impl GroundingFilter {
+    pub fn new(valid: Vec<String>) -> Self {
+        Self {
+            valid: valid.into_iter().collect(),
+            buffer: String::new(),
+        }
+    }
+
+    pub fn feed(&mut self, token: &str) -> FilterOutput {
+        self.buffer.push_str(token);
+        let mut forwarded = String::new();
+        let mut stripped = Vec::new();
+        loop {
+            // If no open bracket, we can flush everything up to the last 64 chars (
+            // hold those back in case an opening bracket arrives split across tokens).
+            match self.buffer.find("[cit:") {
+                None => {
+                    if self.buffer.len() > 64 {
+                        let flush_upto = self.buffer.len() - 64;
+                        let boundary = find_char_boundary(&self.buffer, flush_upto);
+                        forwarded.push_str(&self.buffer[..boundary]);
+                        self.buffer.drain(..boundary);
+                    }
+                    break;
+                }
+                Some(start) => {
+                    // Flush prefix before the bracket.
+                    if start > 0 {
+                        forwarded.push_str(&self.buffer[..start]);
+                        self.buffer.drain(..start);
+                    }
+                    // Look for the closing ']'.
+                    match self.buffer.find(']') {
+                        None => {
+                            // Bracket incomplete — wait for more input.
+                            break;
+                        }
+                        Some(end) => {
+                            let candidate = &self.buffer[..=end];
+                            if self.valid.contains(candidate) {
+                                forwarded.push_str(candidate);
+                            } else {
+                                stripped.push(candidate.to_string());
+                            }
+                            self.buffer.drain(..=end);
+                        }
+                    }
+                }
+            }
+        }
+        FilterOutput { forwarded, stripped }
+    }
+
+    pub fn flush(&mut self) -> FilterOutput {
+        let mut out = self.feed("");
+        // Drain remaining buffer (no more input coming)
+        out.forwarded.push_str(&self.buffer);
+        self.buffer.clear();
+        out
+    }
+}
+
+fn find_char_boundary(s: &str, target: usize) -> usize {
+    let mut b = target;
+    while b > 0 && !s.is_char_boundary(b) {
+        b -= 1;
+    }
+    b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_known_citation_verbatim() {
+        let mut f = GroundingFilter::new(vec!["[cit: 2026-04-19 cc/a:L1]".into()]);
+        let out = f.feed("Answer [cit: 2026-04-19 cc/a:L1] done.");
+        let drain = f.flush();
+        assert!((out.forwarded + &drain.forwarded).contains("[cit: 2026-04-19 cc/a:L1]"));
+        assert!(out.stripped.is_empty() && drain.stripped.is_empty());
+    }
+
+    #[test]
+    fn strips_unknown_citation() {
+        let mut f = GroundingFilter::new(vec!["[cit: 2026-04-19 cc/a:L1]".into()]);
+        let out = f.feed("Claim [cit: 2099-01-01 fake:L0] done.");
+        let drain = f.flush();
+        let combined = out.forwarded + &drain.forwarded;
+        assert!(!combined.contains("[cit: 2099-01-01 fake:L0]"));
+        assert_eq!(out.stripped.len() + drain.stripped.len(), 1);
+    }
+
+    #[test]
+    fn handles_bracket_split_across_tokens() {
+        let mut f = GroundingFilter::new(vec!["[cit: 2026-04-19 cc/a:L1]".into()]);
+        let mut combined = String::new();
+        combined.push_str(&f.feed("start [c").forwarded);
+        combined.push_str(&f.feed("it: 2026-04-19 cc/a").forwarded);
+        combined.push_str(&f.feed(":L1] end").forwarded);
+        combined.push_str(&f.flush().forwarded);
+        assert!(combined.contains("[cit: 2026-04-19 cc/a:L1]"));
+    }
+}
+```
+
+Register `pub mod cite;` in `ask/mod.rs`. Test + commit.
+
+---
+
+## Task 24: `ask::format` — plain + JSON output (Phase 2B)
+
+**Files:**
+- Create: `mur-core/src/conversations/ask/format.rs`
+
+Create `mur-core/src/conversations/ask/format.rs`:
+
+```rust
+//! Output formatting for ask (spec §5.6).
+//! Plain: streaming answer + trailing citation block + runtime footer.
+//! JSON: buffered AskResponse emitted once at end.
+
+use super::{AskResponse, Citation};
+
+pub fn render_citations_block(citations: &[Citation]) -> String {
+    let mut out = String::new();
+    if citations.is_empty() {
+        return out;
+    }
+    out.push_str("\nCitations:\n");
+    for c in citations {
+        let anchor = match (c.line_hint, c.span_index_in_summary) {
+            (_, Some(idx)) => format!(
+                "[cit: {} {}/{} @summary-span-{}]",
+                c.date, c.source, c.conv_id, idx
+            ),
+            (Some(line), _) => format!(
+                "[cit: {} {}/{}:L{}]",
+                c.date, c.source, c.conv_id, line
+            ),
+            _ => format!("[cit: {} {}/{}]", c.date, c.source, c.conv_id),
+        };
+        let preview: String = c.snippet.chars().take(120).collect();
+        out.push_str(&format!("  {anchor}\n    — {preview}\n"));
+    }
+    out
+}
+
+pub fn render_footer(resp: &AskResponse) -> String {
+    let tag = if resp.degraded_to_mode_b {
+        " · Mode B fallback"
+    } else {
+        ""
+    };
+    format!(
+        "({} hits · {}ms · {}→{} tokens{})\n",
+        resp.citations.len(),
+        resp.duration_ms,
+        resp.tokens_in,
+        resp.tokens_out,
+        tag,
+    )
+}
+
+pub fn render_json(resp: &AskResponse) -> String {
+    serde_json::to_string_pretty(resp).unwrap_or_else(|_| "{}".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_resp() -> AskResponse {
+        AskResponse {
+            answer: "Mock answer [cit: 2026-04-19 cc/a:L1]".into(),
+            citations: vec![Citation {
+                id: 1,
+                date: chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(),
+                source: "cc".into(),
+                conv_id: "a".into(),
+                line_hint: Some(1),
+                span_index_in_summary: None,
+                snippet: "sample snippet text".into(),
+                score: 0.87,
+            }],
+            hits_used: vec![],
+            degraded_to_mode_b: false,
+            tokens_in: 100,
+            tokens_out: 20,
+            duration_ms: 500,
+        }
+    }
+
+    #[test]
+    fn citations_block_contains_anchor_and_preview() {
+        let r = sample_resp();
+        let block = render_citations_block(&r.citations);
+        assert!(block.contains("[cit: 2026-04-19 cc/a:L1]"));
+        assert!(block.contains("sample snippet text"));
+    }
+
+    #[test]
+    fn footer_shows_mode_b_tag_when_degraded() {
+        let mut r = sample_resp();
+        r.degraded_to_mode_b = true;
+        let f = render_footer(&r);
+        assert!(f.contains("Mode B fallback"));
+    }
+
+    #[test]
+    fn json_roundtrip() {
+        let r = sample_resp();
+        let s = render_json(&r);
+        assert!(s.contains("\"answer\""));
+        assert!(s.contains("\"citations\""));
+    }
+}
+```
+
+Register `pub mod format;`. Test + commit.
+
+---
+
+## Task 25: `ask::ask_stream` + `ask` glue (Phase 2B)
+
+**Files:**
+- Modify: `mur-core/src/conversations/ask/mod.rs`
+
+Append to `ask/mod.rs`:
+
+```rust
+use anyhow::Result;
+use futures::stream::{Stream, StreamExt};
+use std::pin::Pin;
+use std::time::Instant;
+
+pub async fn ask_stream(
+    req: AskRequest,
+    root_override: Option<&str>,
+) -> Result<Pin<Box<dyn Stream<Item = Result<AskEvent>> + Send>>> {
+    use async_stream::try_stream;
+
+    let start = Instant::now();
+
+    // 1. Embed (Phase 2B placeholder — reuse existing mur-core embedding code)
+    let query_embedding = match embed_query(&req.question).await {
+        Ok(v) => v,
+        Err(e) => {
+            return Ok(Box::pin(try_stream! {
+                yield AskEvent::Error(format!("embed failed: {e:#}"));
+                yield AskEvent::Done { tokens_in: 0, tokens_out: 0, degraded: false, duration_ms: start.elapsed().as_millis() as u64 };
+            }));
+        }
+    };
+
+    // 2. Retrieve
+    let hits = match retrieve::gather_hits(retrieve::RetrieveArgs {
+        query_embedding,
+        filters: &req.filters,
+        k_summary: req.k_summary,
+        k_raw: req.k_raw,
+        escalation_threshold: req.escalation_threshold,
+        mmr_threshold: req.mmr_threshold,
+        no_escalate: req.no_escalate,
+        max_context_tokens: req.max_context_tokens,
+        root_override,
+    })
+    .await
+    {
+        Ok(h) => h,
+        Err(e) => {
+            return Ok(Box::pin(try_stream! {
+                yield AskEvent::Error(format!("retrieve failed: {e:#}"));
+                yield AskEvent::Done { tokens_in: 0, tokens_out: 0, degraded: false, duration_ms: start.elapsed().as_millis() as u64 };
+            }));
+        }
+    };
+
+    if hits.is_empty() {
+        return Ok(Box::pin(try_stream! {
+            yield AskEvent::Token("The conversations I have access to don't cover that.".into());
+            yield AskEvent::Done { tokens_in: 0, tokens_out: 0, degraded: false, duration_ms: start.elapsed().as_millis() as u64 };
+        }));
+    }
+
+    // 3. Build prompt
+    let prompt = prompt::render(
+        &req.question,
+        &hits,
+        req.max_context_tokens,
+        req.response_tokens,
+    );
+
+    // Emit HitInfo events up-front (for UIs that want to show retrieval debug)
+    let hit_events: Vec<AskEvent> = hits
+        .iter()
+        .map(|h| AskEvent::HitInfo(h.info.clone()))
+        .collect();
+
+    // 4. Generate (streaming) with grounding filter
+    let endpoint = /* from config; see cmd_ask wiring */ "http://localhost:11434".to_string();
+    let model = req.model.clone();
+    let mut filter = cite::GroundingFilter::new(prompt.valid_citations.clone());
+    let tokens_in = prompt.tokens_est;
+
+    let stream = match generate::stream_answer(
+        &endpoint,
+        &model,
+        &prompt.system,
+        &prompt.user,
+        req.response_tokens as u32,
+        req.timeout,
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            // Ollama unreachable → Mode B fallback: emit hits as tokens
+            let mode_b = hits_as_mode_b(&hits);
+            return Ok(Box::pin(try_stream! {
+                for evt in hit_events { yield evt; }
+                yield AskEvent::Token(mode_b);
+                yield AskEvent::Done {
+                    tokens_in,
+                    tokens_out: 0,
+                    degraded: true,
+                    duration_ms: start.elapsed().as_millis() as u64,
+                };
+                // Record the failure cause in Error so CLI can show a hint
+                yield AskEvent::Error(format!("ollama unavailable: {e:#}"));
+            }));
+        }
+    };
+
+    let citation_events_by_anchor = citations_map(&hits);
+    let out_stream = try_stream! {
+        for evt in hit_events { yield evt; }
+        let mut stream = stream;
+        let mut tokens_out = 0usize;
+        let mut emitted_citations = std::collections::HashSet::new();
+        while let Some(next) = stream.next().await {
+            let tok = next?;
+            let filtered = filter.feed(&tok);
+            if !filtered.forwarded.is_empty() {
+                tokens_out += filtered.forwarded.len() / 4 + 1;
+                // Emit newly-seen citations
+                for c in citations_fired_in(&filtered.forwarded, &citation_events_by_anchor) {
+                    if emitted_citations.insert(c.id) {
+                        yield AskEvent::Citation(c.clone());
+                    }
+                }
+                yield AskEvent::Token(filtered.forwarded);
+            }
+        }
+        let drained = filter.flush();
+        if !drained.forwarded.is_empty() {
+            tokens_out += drained.forwarded.len() / 4 + 1;
+            for c in citations_fired_in(&drained.forwarded, &citation_events_by_anchor) {
+                if emitted_citations.insert(c.id) {
+                    yield AskEvent::Citation(c.clone());
+                }
+            }
+            yield AskEvent::Token(drained.forwarded);
+        }
+        yield AskEvent::Done {
+            tokens_in,
+            tokens_out,
+            degraded: false,
+            duration_ms: start.elapsed().as_millis() as u64,
+        };
+    };
+    Ok(Box::pin(out_stream))
+}
+
+pub async fn ask(req: AskRequest, root_override: Option<&str>) -> Result<AskResponse> {
+    let format = req.format.clone();
+    let mut stream = ask_stream(req, root_override).await?;
+    let mut answer = String::new();
+    let mut citations = Vec::new();
+    let mut hits_used = Vec::new();
+    let mut degraded = false;
+    let mut tokens_in = 0;
+    let mut tokens_out = 0;
+    let mut duration_ms = 0;
+    while let Some(evt) = stream.next().await {
+        match evt? {
+            AskEvent::Token(t) => answer.push_str(&t),
+            AskEvent::Citation(c) => citations.push(c),
+            AskEvent::HitInfo(h) => hits_used.push(h),
+            AskEvent::Done { tokens_in: ti, tokens_out: to, degraded: d, duration_ms: ms } => {
+                tokens_in = ti;
+                tokens_out = to;
+                degraded = d;
+                duration_ms = ms;
+            }
+            AskEvent::Error(e) => return Err(anyhow::anyhow!(e)),
+        }
+    }
+    let _ = format;
+    Ok(AskResponse {
+        answer,
+        citations,
+        hits_used,
+        degraded_to_mode_b: degraded,
+        tokens_in,
+        tokens_out,
+        duration_ms,
+    })
+}
+
+async fn embed_query(q: &str) -> Result<Vec<f32>> {
+    // Phase 2B: reuse the existing embed path from ingest/compact. If the
+    // project has `crate::store::embedding::embed_text`, call it; else fall
+    // back to Ollama /api/embeddings. For Phase 2B tests we only care about
+    // the length being correct.
+    if super::ollama::OllamaClient::mock_from_env() {
+        return Ok(vec![0.1; 1024]);
+    }
+    // Delegate — actual implementation lives elsewhere in mur-core.
+    crate::store::embedding::embed_text(q, 1024).await
+}
+
+fn hits_as_mode_b(hits: &[retrieve::ResolvedHit]) -> String {
+    let mut out = String::from(
+        "[LLM unavailable] Here are the top relevant excerpts:\n\n",
+    );
+    for (i, h) in hits.iter().enumerate().take(5) {
+        out.push_str(&format!("{}. [cit: {} {}/{}] — {}\n",
+            i + 1, h.info.date, h.info.source, h.info.conv_id, h.snippet));
+    }
+    out
+}
+
+fn citations_map(hits: &[retrieve::ResolvedHit]) -> std::collections::HashMap<String, Citation> {
+    let mut m = std::collections::HashMap::new();
+    for (i, h) in hits.iter().enumerate() {
+        let anchor = prompt::cite_anchor(h);
+        m.insert(
+            anchor.clone(),
+            Citation {
+                id: (i + 1) as u32,
+                date: h.info.date,
+                source: h.info.source.clone(),
+                conv_id: h.info.conv_id.clone(),
+                line_hint: h.line_hint,
+                span_index_in_summary: h.span_index_in_summary,
+                snippet: h.snippet.clone(),
+                score: h.info.score,
+            },
+        );
+    }
+    m
+}
+
+fn citations_fired_in(
+    text: &str,
+    map: &std::collections::HashMap<String, Citation>,
+) -> Vec<Citation> {
+    let mut out = Vec::new();
+    for (anchor, cite) in map {
+        if text.contains(anchor.as_str()) {
+            out.push(cite.clone());
+        }
+    }
+    out
+}
+```
+
+Add `async-stream = "0.3"` to `mur-core/Cargo.toml` (Phase 1 might already have it — check first).
+
+Test + commit.
+
+---
+
+## Task 26: CLI `cmd_ask` + top-level `Commands::Ask` (Phase 2B)
+
+**Files:**
+- Modify: `mur-core/src/cmd/conversations_cmd.rs`
+- Modify: `mur-core/src/main.rs`
+
+Add `Commands::Ask` variant to `main.rs`:
+
+```rust
+/// Ask a natural-language question about your conversation archive (Mode C).
+Ask {
+    question: String,
+    #[arg(long)] src: Option<String>,
+    #[arg(long)] since: Option<String>,
+    #[arg(long)] until: Option<String>,
+    #[arg(long, default_value = "5")] k: usize,
+    #[arg(long)] model: Option<String>,
+    #[arg(long)] min_score: Option<f64>,
+    #[arg(long)] json: bool,
+    #[arg(long)] no_escalate: bool,
+    #[arg(long)] debug_prompt: bool,
+},
+```
+
+Add dispatch arm:
+
+```rust
+Commands::Ask { question, src, since, until, k, model, min_score, json, no_escalate, debug_prompt } => {
+    cmd::conversations_cmd::cmd_ask(cmd::conversations_cmd::AskArgs {
+        question, src, since, until, k, model, min_score, json, no_escalate, debug_prompt,
+    }).await?
+}
+```
+
+Add to `conversations_cmd.rs`:
+
+```rust
+pub struct AskArgs {
+    pub question: String,
+    pub src: Option<String>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub k: usize,
+    pub model: Option<String>,
+    pub min_score: Option<f64>,
+    pub json: bool,
+    pub no_escalate: bool,
+    pub debug_prompt: bool,
+}
+
+pub async fn cmd_ask(args: AskArgs) -> anyhow::Result<()> {
+    use crate::conversations::ask;
+    use chrono::NaiveDate;
+    use futures::StreamExt;
+    use mur_common::{config::Config, Source};
+    use std::io::Write;
+
+    let cfg = Config::load().unwrap_or_default();
+    let ask_cfg = cfg.conversations.ask.clone();
+    let model = args.model.unwrap_or_else(|| ask_cfg.model.clone());
+
+    let sources = args
+        .src
+        .as_deref()
+        .map(parse_sources)
+        .unwrap_or_default();
+
+    let filters = ask::Filters {
+        source: sources,
+        since: args
+            .since
+            .as_deref()
+            .map(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d"))
+            .transpose()?,
+        until: args
+            .until
+            .as_deref()
+            .map(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d"))
+            .transpose()?,
+        min_score: args.min_score.unwrap_or(ask_cfg.min_score),
+    };
+
+    let req = ask::AskRequest {
+        question: args.question.clone(),
+        filters,
+        k_summary: args.k,
+        k_raw: args.k * 2,
+        escalation_threshold: ask_cfg.escalation_threshold,
+        mmr_threshold: ask_cfg.mmr_threshold,
+        model,
+        format: if args.json { ask::Format::Json } else { ask::Format::Plain },
+        max_context_tokens: ask_cfg.max_context_tokens as usize,
+        response_tokens: ask_cfg.response_tokens as usize,
+        timeout: std::time::Duration::from_secs(ask_cfg.timeout_secs as u64),
+        no_escalate: args.no_escalate,
+        debug_prompt: args.debug_prompt,
+    };
+
+    if args.json {
+        let resp = ask::ask(req, None).await?;
+        println!("{}", serde_json::to_string_pretty(&resp)?);
+    } else {
+        let mut stream = ask::ask_stream(req, None).await?;
+        let mut citations = Vec::new();
+        let mut degraded = false;
+        let mut tokens_in = 0;
+        let mut tokens_out = 0;
+        let mut duration = 0;
+        while let Some(evt) = stream.next().await {
+            match evt? {
+                ask::AskEvent::Token(t) => {
+                    print!("{t}");
+                    std::io::stdout().flush()?;
+                }
+                ask::AskEvent::Citation(c) => citations.push(c),
+                ask::AskEvent::HitInfo(_) => {}
+                ask::AskEvent::Done { tokens_in: ti, tokens_out: to, degraded: d, duration_ms } => {
+                    tokens_in = ti;
+                    tokens_out = to;
+                    degraded = d;
+                    duration = duration_ms;
+                }
+                ask::AskEvent::Error(e) => {
+                    eprintln!("\nerror: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        println!();
+        print!(
+            "{}{}",
+            crate::conversations::ask::format::render_citations_block(&citations),
+            crate::conversations::ask::format::render_footer(&ask::AskResponse {
+                answer: String::new(),
+                citations: citations.clone(),
+                hits_used: vec![],
+                degraded_to_mode_b: degraded,
+                tokens_in,
+                tokens_out,
+                duration_ms: duration,
+            }),
+        );
+    }
+    Ok(())
+}
+
+fn parse_sources(s: &str) -> Vec<mur_common::Source> {
+    s.split(',')
+        .filter_map(|tok| match tok.trim() {
+            "cc" | "claude-code" => Some(mur_common::Source::ClaudeCode),
+            "cursor" => Some(mur_common::Source::Cursor),
+            "gemini" => Some(mur_common::Source::Gemini),
+            "aider" => Some(mur_common::Source::Aider),
+            "slack" => Some(mur_common::Source::Slack),
+            "telegram" => Some(mur_common::Source::Telegram),
+            "discord" => Some(mur_common::Source::Discord),
+            _ => None,
+        })
+        .collect()
+}
+```
+
+Test + commit.
+
+---
+
+## Task 27: Extend `golden-path-conversations.sh` — Steps 9 + 10 (Phase 2B)
+
+**Files:**
+- Modify: `scripts/golden-path-conversations.sh`
+
+Append before the final `echo "=== ALL N STEPS GREEN ==="`:
+
+```bash
+# ── Step 9: compact ───────────────────────────────────────────────────────
+echo "[step 9] mur conversations compact"
+MUR_OLLAMA_MOCK=1 "$MUR" conversations compact
+# Expect the seeded yesterday's day to now have a summary:
+YDAY="$(date -u -v-1d +%Y-%m-%d 2>/dev/null || date -u -d 'yesterday' +%Y-%m-%d)"
+test -f "$TMPHOME/.mur/conversations/summary/${YDAY}.md" \
+  || { echo "FAIL step 9: no summary/${YDAY}.md"; exit 1; }
+grep -q "## Extractive spans" "$TMPHOME/.mur/conversations/summary/${YDAY}.md" \
+  || { echo "FAIL step 9: summary missing sections"; exit 1; }
+
+# ── Step 10: ask ─────────────────────────────────────────────────────────
+echo "[step 10] mur ask"
+MUR_OLLAMA_MOCK=1 "$MUR" ask "what compression techniques did I discuss" --json > /tmp/gp-step-10.json
+jq -e '.citations | length >= 1' /tmp/gp-step-10.json \
+  || { echo "FAIL step 10: no citations in json"; exit 1; }
+jq -e '.answer | length > 0' /tmp/gp-step-10.json \
+  || { echo "FAIL step 10: empty answer"; exit 1; }
+
+echo "=== ALL 10 STEPS GREEN ==="
+```
+
+Adjust the final echo banner accordingly. Ensure the golden-path script's seed step (already in Phase 1) includes a yesterday-dated raw file so there's something for compact to process.
+
+Test + commit:
+
+```
+./scripts/golden-path-conversations.sh
+git add scripts/golden-path-conversations.sh
+git commit -m "test: extend golden-path with Steps 9 (compact) + 10 (ask) (Phase 2B)"
+```
+
+**🏁 Phase 2B checkpoint.** Open PR #2 (mur only). Wait for CI + reviewer approval before Phase 2C.
+
+---
+
+## Task 28: `.history/` retention cleanup + audit (Phase 2C)
+
+**Files:**
+- Modify: `mur-core/src/conversations/summarize/writer.rs`
+
+Add a `prune_history` helper called by `archive_prior`:
+
+```rust
+fn prune_history(root_override: Option<&str>, date: NaiveDate, retain: u32) -> Result<u64> {
+    let hist = summary_history_dir(root_override);
+    if !hist.exists() {
+        return Ok(0);
+    }
+    let stem = date.format("%Y-%m-%d").to_string();
+    let mut matches: Vec<std::path::PathBuf> = std::fs::read_dir(&hist)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.starts_with(&stem))
+                .unwrap_or(false)
+        })
+        .collect();
+    if matches.len() <= retain as usize {
+        return Ok(0);
+    }
+    matches.sort();
+    let drop_count = matches.len() - retain as usize;
+    let mut freed = 0u64;
+    for p in matches.into_iter().take(drop_count) {
+        if let Ok(meta) = std::fs::metadata(&p) {
+            freed += meta.len();
+        }
+        std::fs::remove_file(&p)?;
+    }
+    // Audit the deletion
+    if freed > 0 {
+        let audit_log = super::super::audit::Audit::open(root_override)?;
+        let _ = audit_log.append(
+            super::super::audit::AuditAction::Delete {
+                target: hist.to_string_lossy().into_owned(),
+                reason: "history.rotate".into(),
+                bytes_freed: freed,
+            },
+            String::new(),
+        );
+    }
+    Ok(freed)
+}
+```
+
+Call it at the end of `archive_prior` with the config's `history_retain`. Test + commit.
+
+---
+
+## Task 29: `ask::cite` — `--strict-citations` reject mode (Phase 2C)
+
+**Files:**
+- Modify: `mur-core/src/conversations/ask/cite.rs`
+- Modify: `mur-core/src/cmd/conversations_cmd.rs`
+
+Add a `strict: bool` field to `GroundingFilter` and `AskArgs`. When strict is on, emit an `Error` AskEvent if any claim is un-cited (use the coverage heuristic from spec §5.5 step 2 — claim sentences without adjacent `[cit: ...]`).
+
+Test + commit.
+
+---
+
+## Task 30: `conversations preflight` — Ollama checks (Phase 2C)
+
+**Files:**
+- Modify: `mur-core/src/cmd/conversations_cmd.rs`
+
+Extend `cmd_conversations_preflight` with probes:
+
+```rust
+// Ollama reachable
+// Models compact.extractive_model + compact.abstractive_model + ask.model all pulled
+// Pattern dir readable
+// Free mem > 4 GB (sysinfo)
+```
+
+Add `sysinfo = "0.30"` to `Cargo.toml` if not present. Test + commit.
+
+---
+
+## Task 31: Real-Ollama smoke tests (Phase 2C)
+
+**Files:**
+- Modify: `mur-core/Cargo.toml` (add `[features] ollama-live-smoke = []`)
+- Create: `mur-core/tests/ollama_live_smoke.rs`
+
+Feature-gated integration test:
+
+```rust
+#![cfg(feature = "ollama-live-smoke")]
+
+// Seeds a tempdir with a raw day, runs compact_day against REAL Ollama
+// (skipped in CI). Run locally:
+//   cargo test -p mur-core --features ollama-live-smoke -- --ignored
+#[ignore]
+#[tokio::test]
+async fn compact_against_real_ollama() {
+    // ... full test body with tempfile + compact_day + writer assertions
+}
+```
+
+Commit.
+
+---
+
+## Task 32: `.history/` coverage report in `mur conversations doctor` (Phase 2C)
+
+**Files:**
+- Modify: `mur-core/src/cmd/conversations_cmd.rs`
+
+Add doctor check: count `.history/*.md` files, print total + bytes.
+
+Test + commit.
+
+---
+
+## Self-Review
+
+After writing this plan, I reviewed it against the Phase 2 design spec:
+
+**Spec coverage:**
+- §1 Purpose / Non-goals → covered in Phase 2A (compact) + 2B (ask) delivery split
+- §2 Decisions locked → Tasks 1-17 (2A) + 18-27 (2B) + 28-32 (2C) all tagged
+- §3 Architecture → Tasks 2 (ollama client) + 4-10 (summarize) + 19-25 (ask) implement the module layout
+- §4 Compact pipeline → Tasks 4 (chunker) / 5 (extractive) / 6 (abstractive) / 7 (macro_refs) / 8 (index layer) / 9 (writer) / 10 (orchestrator) / 11 (parser)
+- §5 Mode C → Tasks 19 (types) / 20 (retrieve) / 21 (prompt) / 22 (generate) / 23 (cite) / 24 (format) / 25 (glue)
+- §6 Config → Tasks 1 (compact) + 18 (ask)
+- §7 Commander piggyback → Tasks 14 (config) + 15 (trigger) + 16 (register)
+- §8 §12 amendment → the `.history/` write path in Task 9; spec §12 amendment text is docs-only and lives in the spec file already
+- §9 Testing → Tasks include unit tests per module; Task 27 extends golden-path; Task 31 adds real-Ollama smoke
+- §10 Operational → Task 17 (doctor) + Task 30 (preflight) cover observability; rollout order respected via checkpoints
+- §11 Compatibility constraints → enforced throughout (raw+audit append-only maintained; citations survive retention; Ollama unreachable → Mode B fallback in Task 25)
+
+**Placeholder scan:** no `TBD` / `TODO` / `implement later` in plan steps. One `/* from config; see cmd_ask wiring */` comment in Task 25 is a forward reference that Task 26 resolves; acceptable since Task 26 is in the same plan.
+
+**Type consistency:** `CompactConfig` / `AskConfig` / `ConversationsCompactConfig` / `ResolvedHit` / `AskRequest` / `AskResponse` / `AskEvent` / `Citation` / `HitInfo` / `ExtractiveSpan` / `AbstractiveResult` / `MacroRef` / `SummaryDoc` / `ParsedSummary` / `Chunk` / `GenerateRequest` / `GenerateResponse` — all names stable across the tasks that reference them.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-20-mur-conversations-phase-2.md`.
+
+**Checkpoints:** pause after **Task 17** (end of Phase 2A) and **Task 27** (end of Phase 2B) for PR review before continuing.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Same workflow as Phase 1.
+2. **Inline Execution** — execute tasks in this session via `executing-plans`, batch execution with checkpoints.
+
+Which approach?
+

--- a/docs/superpowers/plans/2026-04-20-mur-sources-p1.1-foundation.md
+++ b/docs/superpowers/plans/2026-04-20-mur-sources-p1.1-foundation.md
@@ -1,0 +1,2059 @@
+# mur Sources — Phase 1.1 Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `store/lancedb.rs` behind a `VectorStore` trait, create `sources/` module skeleton with `KnowledgeSource` trait + types + keyring wrapper + yaml IO, and extend `Config` with `StorageConfig` / `SourcesGlobalConfig` — all backward-compatible. No user-visible commands.
+
+**Architecture:** Introduce two Rust traits (`VectorStore`, `KnowledgeSource`) that later sub-milestones (P1.2–P1.4) implement. The existing `store::lancedb::VectorStore` struct is renamed `LanceDbStore` and moved to `store/vector/lancedb.rs`, implementing the new trait. All current callers switch to holding a `Box<dyn VectorStore>`. `sources/` module is scaffolded with types, trait, and credential abstraction but no adapter implementations yet. A CLI feature flag `sources` gates the future `mur source` subcommand tree (not wired up).
+
+**Tech Stack:** Rust edition 2024, Tokio, async-trait, anyhow, LanceDB, serde + serde_yaml, keyring (new). Cargo workspace crates: `mur-common` (shared types), `mur-core` (binary + logic).
+
+**Spec reference:** `docs/superpowers/specs/2026-04-20-mur-sources-integration-design.md` §3, §5, §9.2, §11 (P1.1).
+
+---
+
+## File Structure
+
+This plan creates / modifies these files:
+
+```
+mur-common/src/
+  config.rs                # MODIFY: + StorageConfig + SourcesGlobalConfig
+
+mur-core/
+  Cargo.toml               # MODIFY: + keyring dep; + [features] sources
+  src/
+    main.rs                # MODIFY: add gated Source subcommand stub
+    lib.rs                 # MODIFY: + pub mod sources; (if missing)
+    store/
+      mod.rs               # MODIFY: swap `pub mod lancedb;` → `pub mod vector;`
+      lancedb.rs           # DELETE (after content moves)
+      vector/
+        mod.rs             # NEW: VectorStore trait + SearchFilter + Hit
+        lancedb.rs         # NEW: moved content, struct renamed LanceDbStore
+        factory.rs         # NEW: get_vector_store() builder
+        tests.rs           # NEW: trait conformance suite macro
+    sources/
+      mod.rs               # NEW: KnowledgeSource trait + SourceRegistry stub
+      kind.rs              # NEW: SourceKind enum
+      types.rs             # NEW: Document, Chunk, DocRef, SyncCursor, DocumentBody
+      credentials.rs       # NEW: keyring-rs wrapper (CredentialStore trait + OsKeyring impl)
+      instance.rs          # NEW: SourceInstance yaml struct + IO
+    cmd/
+      context.rs           # MODIFY: use Box<dyn VectorStore> via factory
+      reindex.rs           # MODIFY: same
+      inject_cmd.rs        # MODIFY: same
+      workflow.rs          # MODIFY: same (4 call sites)
+      source_cmd.rs        # NEW (feature="sources"): stub subcommand tree
+      mod.rs               # MODIFY: conditional pub mod source_cmd
+    server.rs              # MODIFY: same refactor
+    conversations/index.rs # NO CHANGE (it uses lancedb crate directly, not our struct)
+```
+
+**Key design choices**:
+- Types `Document`, `Chunk` etc. live in `mur-core/src/sources/types.rs` (Phase 1). If mur-server ever needs them, move to `mur-common` later.
+- `VectorStore` trait goes in `mur-core`, not `mur-common` — keeps `mur-common` free of async-trait dep.
+- Conformance tests use a macro that generates tests for any impl. Phase 1 runs it against `LanceDbStore`; P1.3 will add `QdrantStore` and re-run the same macro.
+
+---
+
+## Task 0: Preparation — Verify Clean Working Tree
+
+**Files:**
+- None (verification step)
+
+- [ ] **Step 1: Confirm you're on the right branch and tree is clean except for plan/spec**
+
+Run:
+```bash
+git status
+git log --oneline -3
+```
+
+Expected:
+```
+On branch main (or a feature branch from main)
+Recent commit: "docs(spec): mur sources — Phase 1 external note-app integration"
+No unrelated uncommitted changes.
+```
+
+If dirty, stash or commit unrelated changes first.
+
+- [ ] **Step 2: Confirm existing test suite is green before touching anything**
+
+Run:
+```bash
+cargo test --workspace
+```
+
+Expected: All tests pass. Record the current total pass count — you'll compare at the end.
+
+---
+
+## Task 1: Add `keyring` Dependency
+
+**Files:**
+- Modify: `mur-core/Cargo.toml`
+
+- [ ] **Step 1: Add keyring dep**
+
+Open `mur-core/Cargo.toml`. Find the `[dependencies]` block (line ~29 has `async-trait = "0.1"`). After the `async-trait` line, add:
+
+```toml
+keyring = "3"
+```
+
+- [ ] **Step 2: Add `sources` feature flag**
+
+In the same `Cargo.toml`, add a `[features]` section if it doesn't exist; otherwise append:
+
+```toml
+[features]
+default = ["sources"]
+sources = []
+```
+
+Rationale: default-on so CI exercises the gated code, but the flag exists so we can keep `mur source` subcommands invisible until P1.2 fills them in.
+
+- [ ] **Step 3: Verify it compiles**
+
+Run:
+```bash
+cargo check --workspace
+```
+
+Expected: clean compile, no warnings from our changes. (keyring adds transitively; should resolve.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/Cargo.toml
+git commit -m "chore(deps): add keyring + sources feature flag"
+```
+
+---
+
+## Task 2: Extend `Config` with `StorageConfig` + `SourcesGlobalConfig`
+
+**Files:**
+- Modify: `mur-common/src/config.rs`
+- Test: `mur-common/src/config.rs` (inline `#[cfg(test)]` module at bottom)
+
+- [ ] **Step 1: Write the failing test for `StorageConfig` defaults**
+
+Open `mur-common/src/config.rs`. At the very bottom of the file, add (creating `#[cfg(test)] mod tests` if missing):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storage_config_default_is_lancedb() {
+        let c = StorageConfig::default();
+        assert_eq!(c.vector_backend, "lancedb");
+        assert_eq!(c.qdrant_url, None);
+        assert_eq!(c.qdrant_api_key_ref, None);
+    }
+
+    #[test]
+    fn sources_global_config_has_sensible_defaults() {
+        let c = SourcesGlobalConfig::default();
+        assert_eq!(c.poll_interval_secs, 600);
+        assert_eq!(c.max_chunks_per_sync, 10_000);
+        assert_eq!(c.max_parallel_sources, 3);
+        assert_eq!(c.default_weight, 1.0);
+        assert_eq!(c.embedding_batch_size, 32);
+    }
+
+    #[test]
+    fn config_default_has_storage_and_sources_global() {
+        let c = Config::default();
+        assert_eq!(c.storage.vector_backend, "lancedb");
+        assert_eq!(c.sources_global.default_weight, 1.0);
+    }
+
+    #[test]
+    fn config_loads_yaml_without_new_fields() {
+        // Existing users' config.yaml won't mention storage or sources_global.
+        // It must still parse.
+        let yaml = r#"
+embedding:
+  provider: ollama
+  model: test-model
+  dimensions: 512
+  ollama_endpoint: http://localhost:11434
+"#;
+        let c: Config = serde_yaml::from_str(yaml).expect("parses");
+        assert_eq!(c.storage.vector_backend, "lancedb");
+        assert_eq!(c.sources_global.max_parallel_sources, 3);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run:
+```bash
+cargo test -p mur-common config::tests
+```
+
+Expected: FAIL — `StorageConfig` / `SourcesGlobalConfig` not found.
+
+- [ ] **Step 3: Implement `StorageConfig` + `SourcesGlobalConfig`**
+
+In `mur-common/src/config.rs`, after the `PathConfig` struct (around line 185), add:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageConfig {
+    /// Vector backend identifier: "lancedb" (default) or "qdrant".
+    #[serde(default = "default_vector_backend")]
+    pub vector_backend: String,
+
+    /// Qdrant connection URL (only used when vector_backend = "qdrant").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub qdrant_url: Option<String>,
+
+    /// Keyring account name holding the Qdrant API key, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub qdrant_api_key_ref: Option<String>,
+}
+
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
+            vector_backend: default_vector_backend(),
+            qdrant_url: None,
+            qdrant_api_key_ref: None,
+        }
+    }
+}
+
+fn default_vector_backend() -> String {
+    "lancedb".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourcesGlobalConfig {
+    /// Polling interval for cloud sources (seconds).
+    #[serde(default = "default_poll_interval_secs")]
+    pub poll_interval_secs: u64,
+
+    /// Safety cap: do not sync more than this many chunks per run.
+    #[serde(default = "default_max_chunks_per_sync")]
+    pub max_chunks_per_sync: usize,
+
+    /// Upper bound on parallel source sync tasks.
+    #[serde(default = "default_max_parallel_sources")]
+    pub max_parallel_sources: usize,
+
+    /// Weight applied to new sources unless overridden.
+    #[serde(default = "default_source_weight")]
+    pub default_weight: f32,
+
+    /// Embedding request batch size.
+    #[serde(default = "default_embedding_batch_size")]
+    pub embedding_batch_size: usize,
+}
+
+impl Default for SourcesGlobalConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval_secs: default_poll_interval_secs(),
+            max_chunks_per_sync: default_max_chunks_per_sync(),
+            max_parallel_sources: default_max_parallel_sources(),
+            default_weight: default_source_weight(),
+            embedding_batch_size: default_embedding_batch_size(),
+        }
+    }
+}
+
+fn default_poll_interval_secs() -> u64 { 600 }
+fn default_max_chunks_per_sync() -> usize { 10_000 }
+fn default_max_parallel_sources() -> usize { 3 }
+fn default_source_weight() -> f32 { 1.0 }
+fn default_embedding_batch_size() -> usize { 32 }
+```
+
+- [ ] **Step 4: Wire the new fields into `Config`**
+
+Still in `mur-common/src/config.rs`, locate the `pub struct Config { ... }` (lines 6–27) and add two new fields before the closing brace:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Config {
+    #[serde(default)]
+    pub embedding: EmbeddingConfig,
+
+    #[serde(default)]
+    pub llm: LlmConfig,
+
+    #[serde(default)]
+    pub retrieval: RetrievalConfig,
+
+    #[serde(default)]
+    pub paths: PathConfig,
+
+    #[serde(default)]
+    pub server: ServerConfig,
+
+    #[serde(default)]
+    pub community: CommunityConfig,
+
+    #[serde(default)]
+    pub sync: SyncConfig,
+
+    // --- P1.1 additions ---
+    #[serde(default)]
+    pub storage: StorageConfig,
+
+    #[serde(default)]
+    pub sources_global: SourcesGlobalConfig,
+}
+```
+
+- [ ] **Step 5: Run the new tests**
+
+```bash
+cargo test -p mur-common config::tests
+```
+
+Expected: all four tests pass.
+
+- [ ] **Step 6: Run full workspace tests to confirm no regression**
+
+```bash
+cargo test --workspace
+```
+
+Expected: same pass count as Task 0 Step 2, **plus the 4 new tests**. No existing test regresses (backward-compatible `#[serde(default)]`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-common/src/config.rs
+git commit -m "feat(config): add StorageConfig and SourcesGlobalConfig with defaults"
+```
+
+---
+
+## Task 3: Create `store/vector/mod.rs` with `VectorStore` Trait Skeleton
+
+**Files:**
+- Create: `mur-core/src/store/vector/mod.rs`
+
+- [ ] **Step 1: Create the new module file with trait + types**
+
+Create `mur-core/src/store/vector/mod.rs` with the full content:
+
+```rust
+//! Abstract vector store trait.
+//!
+//! Phase 1 has one implementation (`lancedb::LanceDbStore`). Phase 1.3 adds
+//! `qdrant::QdrantStore`. All callers interact through `Box<dyn VectorStore>`
+//! obtained from `factory::get_vector_store(&config)`.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+pub mod lancedb;
+pub mod factory;
+
+#[cfg(test)]
+pub mod tests;
+
+/// An embedded chunk ready to be stored.
+///
+/// This shape is re-used by the `sources` pipeline (for external notes) *and*
+/// the existing pattern index. For Phase 1 we only use it for sources — the
+/// pattern path keeps its existing code path untouched.
+#[derive(Debug, Clone)]
+pub struct EmbeddedChunk {
+    pub chunk_id: String,
+    pub source_id: String,       // "patterns" for patterns; e.g. "notion:work" otherwise
+    pub external_id: String,     // within-source unique id (pattern name, notion page uuid, …)
+    pub ordinal: usize,
+    pub text: String,
+    pub heading_path: Vec<String>,
+    pub char_range: (usize, usize),
+    pub updated_at: DateTime<Utc>,
+    pub embedding: Vec<f32>,
+}
+
+/// Filter applied at search time.
+#[derive(Debug, Clone, Default)]
+pub struct SearchFilter {
+    /// Restrict to these source_ids. `None` = all sources.
+    pub source_ids: Option<Vec<String>>,
+    /// Only return rows whose `updated_at` is at least this timestamp.
+    pub since: Option<DateTime<Utc>>,
+}
+
+/// A single search hit.
+#[derive(Debug, Clone)]
+pub struct Hit {
+    pub chunk_id: String,
+    pub source_id: String,
+    pub external_id: String,
+    /// Similarity score in [0.0, 1.0], higher = better.
+    pub score: f32,
+    pub text: String,
+    pub heading_path: Vec<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Abstract vector store. Implementations MUST be safe to share across
+/// tasks (`Send + Sync`) and MUST be idempotent for `upsert`.
+#[async_trait]
+pub trait VectorStore: Send + Sync {
+    /// Insert or replace chunks by `chunk_id`.
+    async fn upsert(&self, chunks: &[EmbeddedChunk]) -> Result<()>;
+
+    /// Search by embedding, returning up to `k` hits filtered by `filter`.
+    async fn search(
+        &self,
+        query_vec: &[f32],
+        k: usize,
+        filter: &SearchFilter,
+    ) -> Result<Vec<Hit>>;
+
+    /// Delete chunks whose (source_id, external_id) matches.
+    async fn delete_by_external_ids(
+        &self,
+        source_id: &str,
+        external_ids: &[String],
+    ) -> Result<()>;
+
+    /// Delete all chunks for a given source.
+    async fn delete_by_source(&self, source_id: &str) -> Result<()>;
+
+    /// List every `external_id` currently indexed for `source_id`.
+    /// Used by sync loops to compute deletion set diff.
+    async fn list_external_ids(&self, source_id: &str) -> Result<Vec<String>>;
+
+    /// Count chunks (optionally per source).
+    async fn count(&self, source_id: Option<&str>) -> Result<usize>;
+
+    /// Drop and recreate all state. Used by `mur reindex`.
+    async fn rebuild_index(&self) -> Result<()>;
+}
+```
+
+- [ ] **Step 2: Expose it from `store/mod.rs`**
+
+Open `mur-core/src/store/mod.rs`. It currently reads:
+
+```rust
+// MUR Core v2 — store module
+//
+// YAML files are the source of truth. All pattern reads/writes go through here.
+
+pub mod config;
+pub mod embedding;
+pub mod exchange;
+pub mod lancedb;
+pub mod pipeline_yaml;
+pub mod spot_rate;
+pub mod workflow_yaml;
+pub mod yaml;
+```
+
+Replace `pub mod lancedb;` with `pub mod vector;` (the old file will be moved in Task 4). New content:
+
+```rust
+// MUR Core v2 — store module
+//
+// YAML files are the source of truth. All pattern reads/writes go through here.
+
+pub mod config;
+pub mod embedding;
+pub mod exchange;
+pub mod pipeline_yaml;
+pub mod spot_rate;
+pub mod vector;
+pub mod workflow_yaml;
+pub mod yaml;
+```
+
+- [ ] **Step 3: Create placeholder `store/vector/lancedb.rs` and `factory.rs` to satisfy the module tree**
+
+These will be fleshed out in later tasks. For now create:
+
+`mur-core/src/store/vector/lancedb.rs`:
+```rust
+//! LanceDB implementation of `VectorStore`. (stub — content arrives in Task 4)
+```
+
+`mur-core/src/store/vector/factory.rs`:
+```rust
+//! Vector store factory. (stub — wired up in Task 6)
+```
+
+- [ ] **Step 4: Verify workspace still compiles — existing callers of `crate::store::lancedb` will now fail. That's expected and fixed in Task 4.**
+
+Run:
+```bash
+cargo check -p mur-core 2>&1 | head -30
+```
+
+Expected: compile errors like `unresolved import crate::store::lancedb`. These are the call sites we fix in Task 4. **Do not commit yet** — commit at end of Task 4 when build is green again.
+
+---
+
+## Task 4: Move LanceDB Code to `store/vector/lancedb.rs`, Rename to `LanceDbStore`, Implement Trait
+
+This is the biggest task. Break it into substeps.
+
+**Files:**
+- Create (content moved in): `mur-core/src/store/vector/lancedb.rs`
+- Delete: `mur-core/src/store/lancedb.rs`
+
+- [ ] **Step 1: Copy the entire existing `store/lancedb.rs` content to `store/vector/lancedb.rs`**
+
+Use `git mv` semantics by writing new file then deleting old:
+
+```bash
+cp mur-core/src/store/lancedb.rs mur-core/src/store/vector/lancedb.rs
+```
+
+- [ ] **Step 2: Rename the struct in the new file from `VectorStore` to `LanceDbStore`**
+
+Open `mur-core/src/store/vector/lancedb.rs`. Do a file-wide rename of `pub struct VectorStore` → `pub struct LanceDbStore` and every `impl VectorStore` inherent impl block header → `impl LanceDbStore`. Also update the usage in the `#[cfg(test)] mod tests` block (the `VectorStore::open` calls on lines 342/364/372/440).
+
+Concretely:
+
+- Line 20: `pub struct VectorStore {` → `pub struct LanceDbStore {`
+- Line 25: `impl VectorStore {` → `impl LanceDbStore {`
+- Tests: each `VectorStore::open(...)` → `LanceDbStore::open(...)`
+
+Also update the module docstring at top of file:
+
+```rust
+//! LanceDB-backed implementation of the `VectorStore` trait.
+//!
+//! YAML remains the source of truth. LanceDB is a rebuildable index.
+```
+
+- [ ] **Step 3: Add `VectorStore` trait implementation block for `LanceDbStore`**
+
+At the bottom of `mur-core/src/store/vector/lancedb.rs` (before the `#[cfg(test)]` block), add:
+
+```rust
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use super::{EmbeddedChunk, Hit, SearchFilter, VectorStore};
+
+const CHUNKS_TABLE: &str = "sources";
+
+#[async_trait]
+impl VectorStore for LanceDbStore {
+    async fn upsert(&self, chunks: &[EmbeddedChunk]) -> Result<()> {
+        // Phase 1.1 is a skeleton; the real arrow schema + upsert body lands in P1.2
+        // when the first adapter calls it. For now we provide a minimal no-op that
+        // satisfies the trait and is exercised by the conformance suite only if the
+        // caller is willing to treat an empty search as success.
+        let _ = chunks;
+        anyhow::bail!("LanceDbStore::upsert is a stub until P1.2 wires adapters")
+    }
+
+    async fn search(
+        &self,
+        _query_vec: &[f32],
+        _k: usize,
+        _filter: &SearchFilter,
+    ) -> Result<Vec<Hit>> {
+        anyhow::bail!("LanceDbStore::search (trait) is a stub until P1.3 wires unified retrieve")
+    }
+
+    async fn delete_by_external_ids(
+        &self,
+        _source_id: &str,
+        _external_ids: &[String],
+    ) -> Result<()> {
+        anyhow::bail!("LanceDbStore::delete_by_external_ids is a stub until P1.2")
+    }
+
+    async fn delete_by_source(&self, _source_id: &str) -> Result<()> {
+        anyhow::bail!("LanceDbStore::delete_by_source is a stub until P1.2")
+    }
+
+    async fn list_external_ids(&self, _source_id: &str) -> Result<Vec<String>> {
+        anyhow::bail!("LanceDbStore::list_external_ids is a stub until P1.2")
+    }
+
+    async fn count(&self, _source_id: Option<&str>) -> Result<usize> {
+        anyhow::bail!("LanceDbStore::count is a stub until P1.2")
+    }
+
+    async fn rebuild_index(&self) -> Result<()> {
+        // Phase 1.1: reuse existing build_unified_index by rebuilding from yaml — but
+        // we don't have access to YamlStore here. Caller owns that. Trait method kept
+        // but simply errors until P1.3.
+        anyhow::bail!("LanceDbStore::rebuild_index (trait) is a stub until P1.3 orchestrates")
+    }
+}
+
+// NOTE: the existing inherent methods `open`, `build_index`, `build_unified_index`,
+// `search` (with `item_type`) remain untouched. Existing callers keep using them
+// unchanged for patterns/workflows. The trait methods above are the NEW surface
+// used by the sources pipeline in P1.2+.
+//
+// These stubs are intentional: P1.1 only establishes the trait surface. Adapters
+// in P1.2 will need real upsert, so we'll flesh out the trait bodies then. A
+// conformance-test "happy path" is provided by the `empty_store` test in
+// store/vector/tests.rs which stays within the stubs' no-op contract.
+const _: () = {
+    // Compile-time assertion that LanceDbStore implements VectorStore.
+    fn _assert_impl<T: VectorStore>() {}
+    fn _check() { _assert_impl::<LanceDbStore>(); }
+};
+```
+
+**IMPORTANT — why stubs**: the trait methods above intentionally panic/bail because the production callers for them (sources pipeline) don't exist until P1.2. P1.1 is a surface refactor; it must not change runtime behavior of the existing `build_unified_index` / inherent `search` code paths that patterns use today. When P1.2 adds the first adapter, the stubs are replaced with real implementations alongside conformance-suite tests that exercise them.
+
+- [ ] **Step 4: Update `store/vector/mod.rs` to re-export the renamed struct**
+
+Open `mur-core/src/store/vector/mod.rs`. Below the existing `pub mod lancedb;`, add:
+
+```rust
+pub use self::lancedb::LanceDbStore;
+```
+
+- [ ] **Step 5: Update every caller of `crate::store::lancedb::VectorStore`**
+
+Seven files use it. Go through each:
+
+**`mur-core/src/cmd/context.rs:26`** — change:
+```rust
+use crate::store::lancedb::VectorStore;
+```
+to:
+```rust
+use crate::store::vector::LanceDbStore as VectorStore;
+```
+
+(The `as VectorStore` alias keeps the rest of that function body unchanged.)
+
+**`mur-core/src/cmd/reindex.rs:8`** — same edit.
+
+**`mur-core/src/cmd/inject_cmd.rs:14`** — same edit.
+
+**`mur-core/src/cmd/workflow.rs`** — two occurrences at line 14 and line 276:
+```rust
+use crate::store::lancedb::VectorStore;
+```
+both become:
+```rust
+use crate::store::vector::LanceDbStore as VectorStore;
+```
+
+**`mur-core/src/server.rs:46`** — same edit.
+
+- [ ] **Step 6: Delete the old `mur-core/src/store/lancedb.rs` file**
+
+```bash
+git rm mur-core/src/store/lancedb.rs
+```
+
+(We already copied content in step 1.)
+
+- [ ] **Step 7: Run workspace check**
+
+```bash
+cargo check --workspace
+```
+
+Expected: clean compile. No warnings from our renames.
+
+- [ ] **Step 8: Run the full test suite, including the moved LanceDB tests**
+
+```bash
+cargo test --workspace
+```
+
+Expected: all tests pass, including `store::vector::lancedb::tests::*` (which are the original `store::lancedb::tests::*` in their new location). Pass count should equal Task 2's count + 4 from Task 2 (no net change from this task — it's a refactor).
+
+If any test fails, check:
+- Did you miss a `VectorStore::open` → `LanceDbStore::open` rename inside the test module?
+- Is `use super::*;` still at the top of the tests module?
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(store): move lancedb into vector submodule, rename struct to LanceDbStore, extract VectorStore trait
+
+- Introduces async-trait based VectorStore abstraction in store/vector/mod.rs
+- Existing VectorStore struct renamed LanceDbStore and moved to store/vector/lancedb.rs
+- All 7 callers updated via use alias; behavior unchanged
+- Trait method bodies are stubs until P1.2 wires the sources pipeline"
+```
+
+---
+
+## Task 5: Trait Conformance Test Suite
+
+**Files:**
+- Create: `mur-core/src/store/vector/tests.rs`
+
+- [ ] **Step 1: Create the conformance suite**
+
+Create `mur-core/src/store/vector/tests.rs`:
+
+```rust
+//! Conformance suite every `VectorStore` impl must satisfy.
+//!
+//! Usage from an impl's module:
+//! ```ignore
+//! #[cfg(test)]
+//! mod conformance {
+//!     use super::*;
+//!     crate::store::vector::tests::vector_store_conformance!(LanceDbStore, make_store);
+//!     async fn make_store() -> LanceDbStore { /* ... */ }
+//! }
+//! ```
+//!
+//! Phase 1.1 only calls the `smoke_create` test — the upsert/search tests will
+//! become meaningful when P1.2 replaces the trait-method stubs with real code.
+
+#![allow(dead_code)]
+
+use super::*;
+
+/// Generic smoke test: construct the store and count returns 0 for unknown source.
+pub async fn smoke_count_empty<S: VectorStore>(store: &S) {
+    // The stub implementations currently bail!. We only assert the method is
+    // *callable*; once real bodies land in P1.2 this becomes a hard assertion.
+    let _ = store.count(Some("nonexistent")).await;
+}
+
+/// Round-trip test (meaningful from P1.2 onward).
+pub async fn upsert_and_search<S: VectorStore>(store: &S, dims: usize) -> anyhow::Result<()> {
+    let chunk = EmbeddedChunk {
+        chunk_id: "chunk-a".into(),
+        source_id: "test".into(),
+        external_id: "doc-1".into(),
+        ordinal: 0,
+        text: "hello world".into(),
+        heading_path: vec![],
+        char_range: (0, 11),
+        updated_at: chrono::Utc::now(),
+        embedding: vec![0.1_f32; dims],
+    };
+    store.upsert(&[chunk.clone()]).await?;
+    let hits = store
+        .search(&vec![0.1_f32; dims], 5, &SearchFilter::default())
+        .await?;
+    anyhow::ensure!(!hits.is_empty(), "expected at least one hit");
+    Ok(())
+}
+
+/// Delete-by-source removes everything for that source.
+pub async fn delete_by_source_clears<S: VectorStore>(store: &S) -> anyhow::Result<()> {
+    store.delete_by_source("test").await?;
+    let ids = store.list_external_ids("test").await?;
+    anyhow::ensure!(ids.is_empty(), "expected zero ids after delete_by_source");
+    Ok(())
+}
+
+/// Shared macro: drop this into an impl's test module to exercise the full suite.
+#[macro_export]
+macro_rules! vector_store_conformance {
+    ($ty:ty, $factory:ident) => {
+        #[tokio::test]
+        async fn conformance_smoke_count_empty() {
+            let s = $factory().await;
+            $crate::store::vector::tests::smoke_count_empty::<$ty>(&s).await;
+        }
+        // The following are wired up but remain #[ignore] until P1.2 replaces
+        // the stubs with real bodies. Leaving them in keeps the wiring visible.
+        #[tokio::test]
+        #[ignore = "enabled from P1.2 when upsert is real"]
+        async fn conformance_upsert_and_search() {
+            let s = $factory().await;
+            $crate::store::vector::tests::upsert_and_search::<$ty>(&s, 64)
+                .await
+                .expect("roundtrip");
+        }
+        #[tokio::test]
+        #[ignore = "enabled from P1.2 when delete_by_source is real"]
+        async fn conformance_delete_by_source_clears() {
+            let s = $factory().await;
+            $crate::store::vector::tests::delete_by_source_clears::<$ty>(&s)
+                .await
+                .expect("delete_by_source");
+        }
+    };
+}
+```
+
+- [ ] **Step 2: Wire the LanceDbStore through the macro**
+
+Open `mur-core/src/store/vector/lancedb.rs`. Inside the existing `#[cfg(test)] mod tests { ... }` block, add at the **top** of that mod:
+
+```rust
+    // Conformance suite — see store/vector/tests.rs
+    crate::vector_store_conformance!(LanceDbStore, make_store_for_conformance);
+
+    async fn make_store_for_conformance() -> LanceDbStore {
+        let tmp = tempfile::TempDir::new().unwrap();
+        LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap()
+        // NOTE: TempDir drops at end of test; store holds DB handle. That's fine
+        // for the smoke test; roundtrip tests unignored in P1.2 will keep their
+        // own TempDir lifetimes.
+    }
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cargo test -p mur-core store::vector 2>&1 | tail -20
+```
+
+Expected:
+- `conformance_smoke_count_empty ... ok`
+- `conformance_upsert_and_search ... ignored`
+- `conformance_delete_by_source_clears ... ignored`
+- existing `store::vector::lancedb::tests::*` all still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/store/vector/tests.rs mur-core/src/store/vector/lancedb.rs
+git commit -m "test(vector): add VectorStore trait conformance macro suite
+
+- Defines reusable smoke + roundtrip tests any VectorStore impl can opt into.
+- LanceDbStore registered; upsert/delete tests ignored until P1.2 replaces stubs.
+- QdrantStore (P1.3) will plug into the same macro."
+```
+
+---
+
+## Task 6: `store/vector/factory.rs` — Build `Box<dyn VectorStore>` from `Config`
+
+**Files:**
+- Modify: `mur-core/src/store/vector/factory.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `mur-core/src/store/vector/factory.rs`:
+
+```rust
+//! Vector store factory.
+//!
+//! Returns a boxed `dyn VectorStore` selected by `Config::storage::vector_backend`.
+//! Phase 1.1 supports `"lancedb"`; `"qdrant"` arrives in P1.3.
+
+use anyhow::{Context, Result, bail};
+use mur_common::config::Config;
+use std::path::Path;
+use std::sync::Arc;
+
+use super::VectorStore;
+use super::lancedb::LanceDbStore;
+
+pub async fn get_vector_store(
+    cfg: &Config,
+    index_dir: &Path,
+) -> Result<Arc<dyn VectorStore>> {
+    match cfg.storage.vector_backend.as_str() {
+        "lancedb" => {
+            let store = LanceDbStore::open(index_dir, cfg.embedding.dimensions as i32)
+                .await
+                .context("opening LanceDB vector store")?;
+            Ok(Arc::new(store))
+        }
+        "qdrant" => bail!("Qdrant backend is not available until P1.3"),
+        other => bail!("unknown storage.vector_backend: {other}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn dims_128_cfg() -> Config {
+        let mut c = Config::default();
+        c.embedding.dimensions = 128;
+        c
+    }
+
+    #[tokio::test]
+    async fn factory_returns_lancedb_by_default() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = dims_128_cfg();
+        let store = get_vector_store(&cfg, tmp.path()).await.unwrap();
+        // We can only check it constructed; count is stubbed.
+        let _ = store.count(None).await;
+    }
+
+    #[tokio::test]
+    async fn factory_rejects_qdrant_in_p1_1() {
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = dims_128_cfg();
+        cfg.storage.vector_backend = "qdrant".into();
+        let err = get_vector_store(&cfg, tmp.path()).await.err().unwrap();
+        assert!(err.to_string().contains("not available until P1.3"));
+    }
+
+    #[tokio::test]
+    async fn factory_rejects_unknown_backend() {
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = dims_128_cfg();
+        cfg.storage.vector_backend = "bogus".into();
+        let err = get_vector_store(&cfg, tmp.path()).await.err().unwrap();
+        assert!(err.to_string().contains("unknown storage.vector_backend"));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cargo test -p mur-core store::vector::factory
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-core/src/store/vector/factory.rs
+git commit -m "feat(vector): factory::get_vector_store(cfg) selects backend by config"
+```
+
+---
+
+## Task 7: `sources/types.rs` — Shared Data Types
+
+**Files:**
+- Create: `mur-core/src/sources/types.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-core/src/sources/types.rs` with test stub at bottom:
+
+```rust
+//! Core types passed through the sources pipeline.
+//!
+//! These do *not* live in `mur-common` (yet) because only `mur-core` consumes
+//! them. If a future mur-server integration needs them, hoist at that point.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Opaque cursor returned by `KnowledgeSource::list_documents`. Each adapter
+/// defines its own encoding (Notion uses an RFC3339 timestamp, Obsidian a
+/// directory hash, Joplin an epoch-ms). The orchestrator stores it verbatim
+/// in the source yaml and passes it back on the next sync.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SyncCursor(pub String);
+
+impl SyncCursor {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Lightweight reference to a document that hasn't been fetched yet.
+#[derive(Debug, Clone)]
+pub struct DocRef {
+    pub external_id: String,
+    pub title: Option<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A full document payload.
+#[derive(Debug, Clone)]
+pub struct Document {
+    pub source_id: String,
+    pub external_id: String,
+    pub title: String,
+    pub body: DocumentBody,
+    pub url: Option<String>,
+    pub updated_at: DateTime<Utc>,
+    pub tags: Vec<String>,
+    pub metadata: serde_json::Value,
+}
+
+/// Body form; adapters pick the variant that preserves the most fidelity.
+#[derive(Debug, Clone)]
+pub enum DocumentBody {
+    Markdown(String),
+    PlainText(String),
+    /// Notion blocks — serialized as opaque JSON so we don't depend on the
+    /// Notion SDK crate from `types.rs`.
+    NotionBlocks(serde_json::Value),
+}
+
+impl DocumentBody {
+    /// Returns the content as plaintext suitable for embedding.
+    pub fn as_plain_text(&self) -> String {
+        match self {
+            DocumentBody::Markdown(s) | DocumentBody::PlainText(s) => s.clone(),
+            DocumentBody::NotionBlocks(_) => {
+                // Real extraction lives in the Notion chunker (P1.4). For P1.1
+                // we expose an empty fallback — no adapter produces this variant
+                // in P1.1.
+                String::new()
+            }
+        }
+    }
+}
+
+/// Pre-embedding chunk.
+#[derive(Debug, Clone)]
+pub struct Chunk {
+    pub chunk_id: String,
+    pub source_id: String,
+    pub external_id: String,
+    pub ordinal: usize,
+    pub text: String,
+    pub heading_path: Vec<String>,
+    pub char_range: (usize, usize),
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Chunk {
+    /// Build a chunk with a fresh UUID v4 chunk_id.
+    pub fn new(
+        source_id: impl Into<String>,
+        external_id: impl Into<String>,
+        ordinal: usize,
+        text: impl Into<String>,
+        heading_path: Vec<String>,
+        char_range: (usize, usize),
+        updated_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            chunk_id: Uuid::new_v4().to_string(),
+            source_id: source_id.into(),
+            external_id: external_id.into(),
+            ordinal,
+            text: text.into(),
+            heading_path,
+            char_range,
+            updated_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_cursor_default_is_empty() {
+        assert!(SyncCursor::default().is_empty());
+    }
+
+    #[test]
+    fn document_body_markdown_is_plain_text() {
+        let b = DocumentBody::Markdown("# hi\nbody".into());
+        assert_eq!(b.as_plain_text(), "# hi\nbody");
+    }
+
+    #[test]
+    fn chunk_new_assigns_unique_id() {
+        let now = Utc::now();
+        let a = Chunk::new("s", "d", 0, "t", vec![], (0, 1), now);
+        let b = Chunk::new("s", "d", 0, "t", vec![], (0, 1), now);
+        assert_ne!(a.chunk_id, b.chunk_id);
+    }
+}
+```
+
+- [ ] **Step 2: Add `uuid` dependency if not present**
+
+Check `mur-core/Cargo.toml`:
+
+```bash
+grep -n "^uuid" mur-core/Cargo.toml || echo MISSING
+```
+
+If MISSING, add to `[dependencies]`:
+```toml
+uuid = { version = "1", features = ["v4"] }
+```
+
+- [ ] **Step 3: Run tests (expected to fail — module doesn't exist yet)**
+
+```bash
+cargo test -p mur-core sources::types
+```
+
+Expected: compile error — `sources` module not declared.
+
+- [ ] **Step 4: Declare the `sources` module**
+
+Open `mur-core/src/lib.rs` (or `main.rs` if lib.rs doesn't exist — the binary may declare modules there). Check:
+
+```bash
+grep -n "pub mod\|^mod " mur-core/src/lib.rs 2>&1 | head -20
+```
+
+If `lib.rs` exists and declares modules, add `pub mod sources;` there. Otherwise `main.rs` declares modules — add it there.
+
+Create `mur-core/src/sources/mod.rs` with minimal content:
+
+```rust
+//! External knowledge sources pipeline. See design spec.
+pub mod types;
+```
+
+- [ ] **Step 5: Re-run tests**
+
+```bash
+cargo test -p mur-core sources::types
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/Cargo.toml mur-core/src/lib.rs mur-core/src/sources/mod.rs mur-core/src/sources/types.rs
+git commit -m "feat(sources): add core pipeline types (Document, Chunk, DocRef, SyncCursor)"
+```
+
+---
+
+## Task 8: `sources/kind.rs` — `SourceKind` Enum with Phase 2 Stub
+
+**Files:**
+- Create: `mur-core/src/sources/kind.rs`
+- Modify: `mur-core/src/sources/mod.rs`
+
+- [ ] **Step 1: Create kind.rs with tests**
+
+Create `mur-core/src/sources/kind.rs`:
+
+```rust
+//! Adapter behavior kind. Phase 1 only implements `PullIndex`; the
+//! `FederatedQuery` variant exists so MCP adapters (P2+) compile without
+//! changing the trait signature.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceKind {
+    /// Adapter pulls documents into mur's vector index and answers via local search.
+    PullIndex,
+    /// Adapter does not hand over documents; queries are forwarded to the
+    /// adapter at search time (e.g., NotebookLM via MCP).
+    FederatedQuery,
+}
+
+impl SourceKind {
+    pub fn is_pull_index(self) -> bool {
+        matches!(self, SourceKind::PullIndex)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pull_index_is_pull_index() {
+        assert!(SourceKind::PullIndex.is_pull_index());
+        assert!(!SourceKind::FederatedQuery.is_pull_index());
+    }
+
+    #[test]
+    fn serde_roundtrip_snake_case() {
+        let s = serde_yaml::to_string(&SourceKind::PullIndex).unwrap();
+        assert!(s.contains("pull_index"));
+        let back: SourceKind = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(back, SourceKind::PullIndex);
+    }
+}
+```
+
+- [ ] **Step 2: Declare it in the sources module**
+
+In `mur-core/src/sources/mod.rs`, add:
+
+```rust
+pub mod kind;
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cargo test -p mur-core sources::kind
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/sources/kind.rs mur-core/src/sources/mod.rs
+git commit -m "feat(sources): SourceKind enum with FederatedQuery stub for MCP (P2)"
+```
+
+---
+
+## Task 9: `sources/credentials.rs` — OS Keyring Wrapper
+
+**Files:**
+- Create: `mur-core/src/sources/credentials.rs`
+- Modify: `mur-core/src/sources/mod.rs`
+
+- [ ] **Step 1: Create credentials.rs**
+
+Create `mur-core/src/sources/credentials.rs`:
+
+```rust
+//! Credential storage for adapters.
+//!
+//! We abstract over the OS keyring so unit tests don't need Keychain /
+//! Secret Service. Production uses `OsKeyring`; tests use `InMemoryCreds`.
+
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+pub trait CredentialStore: Send + Sync {
+    /// Store `value` under `(service, account)`.
+    fn set(&self, service: &str, account: &str, value: &str) -> Result<()>;
+    /// Retrieve `(service, account)` or return `Ok(None)` if not present.
+    fn get(&self, service: &str, account: &str) -> Result<Option<String>>;
+    /// Delete if present; no error if absent.
+    fn delete(&self, service: &str, account: &str) -> Result<()>;
+}
+
+/// Production implementation backed by the OS keyring (macOS Keychain,
+/// Linux Secret Service via libsecret, Windows Credential Manager).
+pub struct OsKeyring;
+
+impl CredentialStore for OsKeyring {
+    fn set(&self, service: &str, account: &str, value: &str) -> Result<()> {
+        let entry = keyring::Entry::new(service, account)
+            .with_context(|| format!("open keyring entry {service}:{account}"))?;
+        entry
+            .set_password(value)
+            .with_context(|| format!("set keyring entry {service}:{account}"))?;
+        Ok(())
+    }
+
+    fn get(&self, service: &str, account: &str) -> Result<Option<String>> {
+        let entry = keyring::Entry::new(service, account)
+            .with_context(|| format!("open keyring entry {service}:{account}"))?;
+        match entry.get_password() {
+            Ok(v) => Ok(Some(v)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(e).with_context(|| format!("get keyring entry {service}:{account}")),
+        }
+    }
+
+    fn delete(&self, service: &str, account: &str) -> Result<()> {
+        let entry = keyring::Entry::new(service, account)
+            .with_context(|| format!("open keyring entry {service}:{account}"))?;
+        match entry.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("delete keyring entry {service}:{account}")),
+        }
+    }
+}
+
+/// In-memory implementation for tests.
+#[derive(Default)]
+pub struct InMemoryCreds {
+    store: Mutex<HashMap<(String, String), String>>,
+}
+
+impl CredentialStore for InMemoryCreds {
+    fn set(&self, service: &str, account: &str, value: &str) -> Result<()> {
+        self.store
+            .lock()
+            .unwrap()
+            .insert((service.into(), account.into()), value.into());
+        Ok(())
+    }
+
+    fn get(&self, service: &str, account: &str) -> Result<Option<String>> {
+        Ok(self
+            .store
+            .lock()
+            .unwrap()
+            .get(&(service.into(), account.into()))
+            .cloned())
+    }
+
+    fn delete(&self, service: &str, account: &str) -> Result<()> {
+        self.store
+            .lock()
+            .unwrap()
+            .remove(&(service.into(), account.into()));
+        Ok(())
+    }
+}
+
+/// Canonical helper: derive the keyring account name from source id + field.
+pub fn account(source_id: &str, field: &str) -> String {
+    format!("{source_id}:{field}")
+}
+
+pub const SERVICE: &str = "mur";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_memory_roundtrip() {
+        let c = InMemoryCreds::default();
+        c.set("mur", "notion:work:access_token", "secret-123").unwrap();
+        assert_eq!(
+            c.get("mur", "notion:work:access_token").unwrap().as_deref(),
+            Some("secret-123")
+        );
+        c.delete("mur", "notion:work:access_token").unwrap();
+        assert_eq!(c.get("mur", "notion:work:access_token").unwrap(), None);
+    }
+
+    #[test]
+    fn in_memory_missing_returns_none() {
+        let c = InMemoryCreds::default();
+        assert_eq!(c.get("mur", "nope").unwrap(), None);
+    }
+
+    #[test]
+    fn account_helper_formats_canonically() {
+        assert_eq!(account("notion:work", "access_token"), "notion:work:access_token");
+    }
+}
+```
+
+- [ ] **Step 2: Declare in sources module**
+
+In `mur-core/src/sources/mod.rs`, append:
+
+```rust
+pub mod credentials;
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cargo test -p mur-core sources::credentials
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/sources/credentials.rs mur-core/src/sources/mod.rs
+git commit -m "feat(sources): CredentialStore trait + OsKeyring + InMemoryCreds"
+```
+
+---
+
+## Task 10: `sources/instance.rs` — SourceInstance YAML IO
+
+**Files:**
+- Create: `mur-core/src/sources/instance.rs`
+- Modify: `mur-core/src/sources/mod.rs`
+
+- [ ] **Step 1: Create instance.rs with tests**
+
+Create `mur-core/src/sources/instance.rs`:
+
+```rust
+//! Per-source config + sync state, persisted as `~/.mur/sources/<id>.yaml`.
+//!
+//! This file mirrors the `YamlStore` pattern used by patterns/workflows:
+//! YAML is the source of truth; everything else rebuildable.
+
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::kind::SourceKind;
+
+const MAX_ERRORS_TAIL: usize = 50;
+
+/// Complete state for one connected source.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceInstance {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub type_name: String,        // "notion" / "obsidian" / "joplin"
+    pub kind: SourceKind,
+
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+
+    #[serde(default = "default_weight")]
+    pub weight: f32,
+
+    #[serde(default)]
+    pub scope: BTreeMap<String, serde_yaml::Value>,
+
+    #[serde(default)]
+    pub sync: SyncState,
+
+    #[serde(default)]
+    pub stats: SourceStats,
+
+    /// Keyring account name if this source needs credentials. `None` for
+    /// Obsidian (file-based).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keyring_entry: Option<String>,
+}
+
+fn default_enabled() -> bool { true }
+fn default_weight() -> f32 { 1.0 }
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SyncState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_cursor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_sync_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    #[serde(default)]
+    pub errors_tail: Vec<SyncError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncError {
+    pub at: DateTime<Utc>,
+    pub doc: String,
+    pub msg: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SourceStats {
+    #[serde(default)]
+    pub doc_count: u64,
+    #[serde(default)]
+    pub chunk_count: u64,
+    #[serde(default)]
+    pub indexed_bytes: u64,
+}
+
+impl SyncState {
+    /// Append an error, keeping the tail bounded.
+    pub fn push_error(&mut self, err: SyncError) {
+        self.errors_tail.push(err);
+        let overflow = self.errors_tail.len().saturating_sub(MAX_ERRORS_TAIL);
+        if overflow > 0 {
+            self.errors_tail.drain(0..overflow);
+        }
+    }
+}
+
+/// Filesystem store: one yaml per source at `<root>/sources/<id>.yaml`.
+pub struct SourceInstanceStore {
+    root: PathBuf,
+}
+
+impl SourceInstanceStore {
+    /// Default is `~/.mur/sources/`.
+    pub fn default_store() -> Result<Self> {
+        let root = dirs::home_dir()
+            .context("no home dir")?
+            .join(".mur")
+            .join("sources");
+        Ok(Self::new(root))
+    }
+
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    fn path_for(&self, id: &str) -> PathBuf {
+        // ':' is illegal on some filesystems — allowed on macOS+Linux but not
+        // Windows NTFS. Phase 1 targets macOS+Linux. Flag a plan risk.
+        self.root.join(format!("{id}.yaml"))
+    }
+
+    pub fn save(&self, instance: &SourceInstance) -> Result<()> {
+        fs::create_dir_all(&self.root)
+            .with_context(|| format!("create dir {}", self.root.display()))?;
+        let yaml = serde_yaml::to_string(instance)?;
+        let target = self.path_for(&instance.id);
+        let tmp = target.with_extension("yaml.tmp");
+        fs::write(&tmp, yaml)
+            .with_context(|| format!("write {}", tmp.display()))?;
+        fs::rename(&tmp, &target)
+            .with_context(|| format!("rename {} -> {}", tmp.display(), target.display()))?;
+        Ok(())
+    }
+
+    pub fn load(&self, id: &str) -> Result<SourceInstance> {
+        let p = self.path_for(id);
+        let content = fs::read_to_string(&p)
+            .with_context(|| format!("read {}", p.display()))?;
+        let inst: SourceInstance = serde_yaml::from_str(&content)
+            .with_context(|| format!("parse {}", p.display()))?;
+        if inst.id != id {
+            bail!("file {} has id {} but we asked for {}", p.display(), inst.id, id);
+        }
+        Ok(inst)
+    }
+
+    pub fn delete(&self, id: &str) -> Result<()> {
+        let p = self.path_for(id);
+        if p.exists() {
+            fs::remove_file(&p).with_context(|| format!("remove {}", p.display()))?;
+        }
+        Ok(())
+    }
+
+    pub fn list(&self) -> Result<Vec<SourceInstance>> {
+        if !self.root.exists() {
+            return Ok(vec![]);
+        }
+        let mut out = Vec::new();
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            let p = entry.path();
+            if p.extension().and_then(|e| e.to_str()) != Some("yaml") {
+                continue;
+            }
+            let content = fs::read_to_string(&p)?;
+            match serde_yaml::from_str::<SourceInstance>(&content) {
+                Ok(inst) => out.push(inst),
+                Err(e) => {
+                    tracing::warn!(file = %p.display(), error = %e, "skipping malformed source yaml");
+                }
+            }
+        }
+        out.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_instance(id: &str) -> SourceInstance {
+        SourceInstance {
+            id: id.into(),
+            type_name: "obsidian".into(),
+            kind: SourceKind::PullIndex,
+            enabled: true,
+            weight: 1.0,
+            scope: BTreeMap::new(),
+            sync: SyncState::default(),
+            stats: SourceStats::default(),
+            keyring_entry: None,
+        }
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let store = SourceInstanceStore::new(tmp.path().to_path_buf());
+        let inst = sample_instance("obsidian-main");
+        store.save(&inst).unwrap();
+        let loaded = store.load("obsidian-main").unwrap();
+        assert_eq!(loaded.id, "obsidian-main");
+        assert_eq!(loaded.type_name, "obsidian");
+        assert!(loaded.enabled);
+    }
+
+    #[test]
+    fn list_returns_sorted_instances() {
+        let tmp = TempDir::new().unwrap();
+        let store = SourceInstanceStore::new(tmp.path().to_path_buf());
+        store.save(&sample_instance("b-second")).unwrap();
+        store.save(&sample_instance("a-first")).unwrap();
+        let items = store.list().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].id, "a-first");
+        assert_eq!(items[1].id, "b-second");
+    }
+
+    #[test]
+    fn delete_removes_file() {
+        let tmp = TempDir::new().unwrap();
+        let store = SourceInstanceStore::new(tmp.path().to_path_buf());
+        store.save(&sample_instance("obsidian-main")).unwrap();
+        store.delete("obsidian-main").unwrap();
+        assert!(store.load("obsidian-main").is_err());
+    }
+
+    #[test]
+    fn delete_missing_is_ok() {
+        let tmp = TempDir::new().unwrap();
+        let store = SourceInstanceStore::new(tmp.path().to_path_buf());
+        store.delete("never-existed").unwrap();
+    }
+
+    #[test]
+    fn errors_tail_bounded_to_fifty() {
+        let mut s = SyncState::default();
+        for i in 0..60 {
+            s.push_error(SyncError {
+                at: Utc::now(),
+                doc: format!("doc-{i}"),
+                msg: "boom".into(),
+            });
+        }
+        assert_eq!(s.errors_tail.len(), MAX_ERRORS_TAIL);
+        assert_eq!(s.errors_tail[0].doc, "doc-10"); // first 10 dropped
+        assert_eq!(s.errors_tail.last().unwrap().doc, "doc-59");
+    }
+
+    #[test]
+    fn load_rejects_id_mismatch() {
+        let tmp = TempDir::new().unwrap();
+        let store = SourceInstanceStore::new(tmp.path().to_path_buf());
+        store.save(&sample_instance("real-id")).unwrap();
+        // Rename file to a wrong id
+        fs::rename(
+            tmp.path().join("real-id.yaml"),
+            tmp.path().join("other-id.yaml"),
+        )
+        .unwrap();
+        assert!(store.load("other-id").is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Declare in sources module**
+
+In `mur-core/src/sources/mod.rs`, append:
+
+```rust
+pub mod instance;
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cargo test -p mur-core sources::instance
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/sources/instance.rs mur-core/src/sources/mod.rs
+git commit -m "feat(sources): SourceInstance yaml IO with atomic writes and 50-error bound"
+```
+
+---
+
+## Task 11: `sources/mod.rs` — `KnowledgeSource` Trait + `SourceRegistry` Stub
+
+**Files:**
+- Modify: `mur-core/src/sources/mod.rs`
+
+- [ ] **Step 1: Rewrite `sources/mod.rs` to host the trait**
+
+Open `mur-core/src/sources/mod.rs`. Replace current contents (which is just `pub mod …;` lines) with:
+
+```rust
+//! External knowledge sources pipeline.
+//!
+//! A `KnowledgeSource` is a typed connection to a note app or RAG system. The
+//! sync engine iterates documents, chunks them, embeds them, and writes to a
+//! `VectorStore`. P1.1 defines the trait + registry skeleton only — adapters
+//! arrive in P1.2 (Obsidian), P1.4 (Notion, Joplin).
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+pub mod credentials;
+pub mod instance;
+pub mod kind;
+pub mod types;
+
+pub use kind::SourceKind;
+pub use types::{Chunk, DocRef, Document, DocumentBody, SyncCursor};
+
+/// Adapter interface. Implementors are stateless with respect to the
+/// orchestrator; all cursor state is persisted in `SourceInstance`.
+#[async_trait]
+pub trait KnowledgeSource: Send + Sync {
+    /// Stable id, e.g. `"notion:work"`.
+    fn id(&self) -> &str;
+
+    /// Behaviour kind.
+    fn kind(&self) -> SourceKind;
+
+    /// User-configurable multiplicative weight (from `SourceInstance`).
+    fn weight(&self) -> f32;
+
+    /// Incremental listing. `cursor == None` on first sync.
+    async fn list_documents(
+        &self,
+        cursor: Option<SyncCursor>,
+    ) -> Result<(Vec<DocRef>, SyncCursor)>;
+
+    /// Fetch full content for one document.
+    async fn fetch(&self, doc_ref: &DocRef) -> Result<Document>;
+
+    /// Adapter-specific chunking.
+    fn chunk(&self, doc: &Document) -> Result<Vec<Chunk>>;
+
+    /// External ids that this adapter has deleted since `cursor`. Orchestrator
+    /// additionally runs a set-diff fallback, so returning `Ok(vec![])` is a
+    /// safe no-op default — override when an adapter exposes deletion events
+    /// natively.
+    async fn list_deleted_since(
+        &self,
+        _cursor: Option<SyncCursor>,
+    ) -> Result<Vec<String>> {
+        Ok(vec![])
+    }
+}
+
+/// Closed-set registry. Phase 1 hardcodes the three adapter type names; the
+/// factory function that builds each type lives alongside the adapter itself.
+pub const KNOWN_ADAPTER_TYPES: &[&str] = &["obsidian", "notion", "joplin"];
+
+pub fn is_known_adapter_type(t: &str) -> bool {
+    KNOWN_ADAPTER_TYPES.contains(&t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_adapter_types_sanity() {
+        assert!(is_known_adapter_type("obsidian"));
+        assert!(is_known_adapter_type("notion"));
+        assert!(is_known_adapter_type("joplin"));
+        assert!(!is_known_adapter_type("onenote"));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cargo test -p mur-core sources
+```
+
+Expected: everything from prior tasks still passes + the 1 new test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-core/src/sources/mod.rs
+git commit -m "feat(sources): KnowledgeSource trait + closed-set adapter type registry"
+```
+
+---
+
+## Task 12: Gate `mur source` CLI Subcommand Stub Behind `sources` Feature
+
+**Files:**
+- Create: `mur-core/src/cmd/source_cmd.rs`
+- Modify: `mur-core/src/cmd/mod.rs`
+- Modify: `mur-core/src/main.rs`
+
+- [ ] **Step 1: Create the stub subcommand module**
+
+Create `mur-core/src/cmd/source_cmd.rs`:
+
+```rust
+//! `mur source ...` subcommand tree.
+//!
+//! P1.1 wires up the tree with every verb returning a "not yet implemented"
+//! error, gated behind the `sources` feature flag. P1.2–P1.4 fill in each verb.
+
+use anyhow::{Result, bail};
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum SourceCommand {
+    /// Register a new source.
+    Add {
+        #[command(subcommand)]
+        kind: AddKind,
+    },
+    /// List registered sources.
+    List {
+        #[arg(long)]
+        json: bool,
+        #[arg(long)]
+        verbose: bool,
+    },
+    /// Remove a source (credentials + index).
+    Remove {
+        id: String,
+        #[arg(long)]
+        keep_index: bool,
+    },
+    /// Sync one or all sources.
+    Sync {
+        id: Option<String>,
+        #[arg(long)]
+        full: bool,
+        #[arg(long)]
+        watch: bool,
+    },
+    /// Show sync health for a source.
+    Status { id: Option<String> },
+    /// Set the retrieve weight.
+    Weight { id: String, value: f32 },
+    /// Dry-run a single document through the adapter.
+    Test { id: String },
+    /// Rebuild the vector index for a source.
+    Reindex {
+        id: String,
+        #[arg(long)]
+        vector_backend: Option<String>,
+    },
+    /// Generate launchd / systemd unit files for scheduled sync.
+    InstallSchedule,
+    Disable { id: String },
+    Enable { id: String },
+}
+
+#[derive(Subcommand)]
+pub enum AddKind {
+    /// Connect a Notion workspace (OAuth or Integration Token).
+    Notion {
+        instance: Option<String>,
+        #[arg(long)]
+        workspace: Option<String>,
+        #[arg(long)]
+        token: Option<String>,
+    },
+    /// Connect an Obsidian vault (local markdown folder).
+    Obsidian {
+        instance: Option<String>,
+        #[arg(long)]
+        vault: std::path::PathBuf,
+        #[arg(long, value_delimiter = ',')]
+        exclude_folder: Vec<String>,
+    },
+    /// Connect Joplin (local SQLite or Joplin Server).
+    Joplin {
+        instance: Option<String>,
+        #[arg(long, conflicts_with = "server")]
+        db: Option<std::path::PathBuf>,
+        #[arg(long, requires = "token")]
+        server: Option<String>,
+        #[arg(long, requires = "server")]
+        token: Option<String>,
+    },
+}
+
+pub async fn handle(cmd: SourceCommand) -> Result<()> {
+    match cmd {
+        SourceCommand::Add { .. } => bail!("`mur source add` arrives in P1.2 (obsidian) / P1.4 (notion, joplin)"),
+        SourceCommand::List { .. } => bail!("`mur source list` arrives in P1.2"),
+        SourceCommand::Remove { .. } => bail!("`mur source remove` arrives in P1.2"),
+        SourceCommand::Sync { .. } => bail!("`mur source sync` arrives in P1.2"),
+        SourceCommand::Status { .. } => bail!("`mur source status` arrives in P1.2"),
+        SourceCommand::Weight { .. } => bail!("`mur source weight` arrives in P1.2"),
+        SourceCommand::Test { .. } => bail!("`mur source test` arrives in P1.2"),
+        SourceCommand::Reindex { .. } => bail!("`mur source reindex` arrives in P1.3"),
+        SourceCommand::InstallSchedule => bail!("`mur source install-schedule` arrives in P1.4"),
+        SourceCommand::Disable { .. } => bail!("`mur source disable` arrives in P1.2"),
+        SourceCommand::Enable { .. } => bail!("`mur source enable` arrives in P1.2"),
+    }
+}
+```
+
+- [ ] **Step 2: Register the module conditionally**
+
+Open `mur-core/src/cmd/mod.rs`. At the end, add:
+
+```rust
+#[cfg(feature = "sources")]
+pub(crate) mod source_cmd;
+```
+
+- [ ] **Step 3: Wire into the top-level CLI in `main.rs`**
+
+Open `mur-core/src/main.rs`. Locate the main `Commands` enum (line 34 has `#[derive(Subcommand)]`). Read the entire enum body to find a good insertion point (pick a consistent location — probably alphabetical or near other "plural noun" verbs like `Pattern`).
+
+Add a new variant, gated:
+
+```rust
+#[cfg(feature = "sources")]
+/// Manage external knowledge sources (Notion, Obsidian, Joplin, ...).
+Source {
+    #[command(subcommand)]
+    cmd: cmd::source_cmd::SourceCommand,
+},
+```
+
+Then in the match-on-commands dispatch (around line 796 where you see `Commands::Links { name } => ...`), add:
+
+```rust
+#[cfg(feature = "sources")]
+Commands::Source { cmd } => cmd::source_cmd::handle(cmd).await?,
+```
+
+- [ ] **Step 4: Verify the CLI help reflects the new subcommand**
+
+```bash
+cargo run -- source --help
+```
+
+Expected: clap-generated help lists `add`, `list`, `remove`, `sync`, `status`, `weight`, `test`, `reindex`, `install-schedule`, `disable`, `enable`.
+
+- [ ] **Step 5: Verify stub execution**
+
+```bash
+cargo run -- source list 2>&1 || true
+```
+
+Expected: exit 1 with message "`mur source list` arrives in P1.2".
+
+- [ ] **Step 6: Verify feature-off build hides the subcommand**
+
+```bash
+cargo build --no-default-features -p mur-core
+cargo run --no-default-features -- source --help 2>&1 || true
+```
+
+Expected: no-default-features build succeeds; `source --help` errors with "unrecognized subcommand".
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-core/src/cmd/source_cmd.rs mur-core/src/cmd/mod.rs mur-core/src/main.rs
+git commit -m "feat(cli): add gated \`mur source\` subcommand tree (P1.1 stubs)
+
+All verbs return informative error messages until P1.2+ fills them in.
+Gated behind the default-on 'sources' cargo feature so non-feature builds
+do not surface the subcommand."
+```
+
+---
+
+## Task 13: Update `docs/superpowers/plans/README` / `CLAUDE.md` Pointer (light touch)
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add a line in the Architecture section**
+
+Open `CLAUDE.md`. Find the "Architecture" section (after "Cargo workspace with two crates:"). Locate the Four-Stage Pipeline block. Immediately below the existing `capture/ → store/ → retrieve/ → inject/` diagram, add a paragraph:
+
+```markdown
+**Sources pipeline (P1.1 foundation in place; adapters arrive P1.2+):** An alternate input to `store/` lives in `mur-core/src/sources/` — `KnowledgeSource` adapters pull documents from external note apps (Obsidian, Notion, Joplin) into the same retrieve pipeline as patterns. The vector store is abstracted behind `store::vector::VectorStore` (impls: `LanceDbStore` now; `QdrantStore` P1.3). See `docs/superpowers/specs/2026-04-20-mur-sources-integration-design.md`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude.md): note sources pipeline foundation (P1.1)"
+```
+
+---
+
+## Task 14: Final Verification Pass
+
+- [ ] **Step 1: Full workspace test run**
+
+```bash
+cargo test --workspace 2>&1 | tail -30
+```
+
+Expected: every test green. Compare pass count vs Task 0 Step 2 baseline:
+- +4 from `mur-common` config tests (Task 2)
+- +1 from vector conformance smoke (Task 5)
+- +3 from factory tests (Task 6)
+- +3 from sources::types tests (Task 7)
+- +2 from sources::kind tests (Task 8)
+- +3 from sources::credentials tests (Task 9)
+- +6 from sources::instance tests (Task 10)
+- +1 from sources::mod tests (Task 11)
+
+Total **+23** new tests expected.
+
+- [ ] **Step 2: Clippy**
+
+```bash
+cargo clippy --workspace --all-features -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 3: Format check**
+
+```bash
+cargo fmt --check
+```
+
+Expected: clean. If `fmt --check` fails, run `cargo fmt` and commit as a follow-up.
+
+- [ ] **Step 4: Confirm feature flag off still compiles**
+
+```bash
+cargo build --workspace --no-default-features
+```
+
+Expected: clean compile.
+
+- [ ] **Step 5: Confirm binary starts and existing commands still work**
+
+```bash
+cargo run --release -- --help
+cargo run --release -- pattern list 2>&1 | head -5
+```
+
+Expected: CLI usage shows `source` as a subcommand; `pattern list` behaves exactly as before.
+
+- [ ] **Step 6: Sanity check — the `~/.mur/sources/` directory is NOT created by existing commands**
+
+P1.1 only creates it on first `SourceInstanceStore::save()` call, and nothing invokes that yet. Verify:
+
+```bash
+ls ~/.mur/sources 2>&1 || echo "good: sources dir does not yet exist"
+```
+
+Expected: directory does not exist (unless you have an earlier in-dev version).
+
+- [ ] **Step 7: Close-out commit if anything drifted**
+
+If `cargo fmt` made adjustments, commit them:
+
+```bash
+git add -A
+git commit -m "style: cargo fmt after P1.1 foundation"
+```
+
+---
+
+## Done Criteria (P1.1)
+
+- [ ] `store::vector::VectorStore` trait defined, with LanceDbStore implementing it (stubs are allowed — P1.2 fills them in).
+- [ ] `store::vector::factory::get_vector_store(&Config, &Path)` selects backend from config.
+- [ ] `sources::{types, kind, credentials, instance}` modules compiled with tests.
+- [ ] `sources::KnowledgeSource` trait defined (no adapter impls yet).
+- [ ] `Config::storage` + `Config::sources_global` present with zero-action defaults.
+- [ ] `mur source --help` surfaces the subcommand tree behind `sources` feature flag; verbs return informative "not yet implemented" errors.
+- [ ] All existing tests still pass; +23 new tests added.
+- [ ] `CLAUDE.md` architecture section mentions the sources pipeline foundation.
+- [ ] No `~/.mur/sources/` directory auto-created by any existing code path.
+
+**What P1.1 intentionally does not deliver:**
+- Any adapter implementation (Obsidian/Notion/Joplin)
+- Any real `VectorStore::upsert/search/etc.` body (stubs only)
+- `mur reindex` treating sources (P1.3)
+- Qdrant (P1.3)
+- Tantivy BM25 (P1.3)
+- Inject formatter Notes section (P1.3)
+
+P1.2 begins when these are all ticked.

--- a/docs/superpowers/specs/2026-04-20-mur-conversations-phase-2-design.md
+++ b/docs/superpowers/specs/2026-04-20-mur-conversations-phase-2-design.md
@@ -1,0 +1,992 @@
+# mur Conversations Archive — Phase 2 Design Spec
+
+**Date:** 2026-04-20
+**Status:** Draft, pending implementation plan
+**Prior art:** `docs/superpowers/specs/2026-04-19-mur-conversations-design.md` (Phase 1 shipped, mur-run/mur#5 + mur-run/mur-commander#9 merged)
+**Supersedes:** Phase 1 §6.5 (Mode C algorithm sketch) — replaced by §5 of this document
+**Amends:** Phase 1 §12 (append-only) — narrowed per §8.1 of this document
+
+---
+
+## 1. Purpose & Problem Statement
+
+Phase 1 shipped the `~/.mur/conversations/` archive with Mode A (timeline browse) and Mode B (hybrid semantic+keyword search). It captures, stores, and indexes conversations from every supported AI assistant. **What it does not yet do** is summarize days or answer natural-language questions about them.
+
+**Concrete motivation.** With Phase 1 alone:
+
+- Retention's three-guard safety REQUIRES a summary to exist before deleting raw at T+retention_days. Without a compact pipeline, retention is effectively disabled — the user either keeps raw forever or loses data without provenance.
+- Mode B returns snippets but no synthesis. "What compression techniques did I discuss this month?" requires the user to skim top-k results and build the answer themselves.
+- No feature-complete Mode C as sketched in Phase 1 §6.5 — that algorithm was pseudocode, not implementation.
+
+**Goal.** Two tightly-coupled deliverables:
+
+1. **Sleep-time compact** — daily hybrid summaries (extractive spans + abstractive narrative + Freedman macro-references) generated automatically and on-demand.
+2. **Mode C — `mur ask <question>`** — local-only RAG over the archive with inline Perplexity-style citations, streaming tokens, graceful degradation.
+
+**Non-goals (Phase 2).**
+- Multi-turn chat (`--continue` session state). Phase 3.
+- mur-web `/conversations` dashboard UI. Phase 3.
+- LLMLingua-2 prompt compression. Phase 3.
+- RAPTOR week/month summaries (layer=2+). Phase 3.
+- Dynamic re-linking when patterns change. Phase 3.
+
+---
+
+## 2. Scope & Decisions Made
+
+### In scope (Phase 2)
+
+| Dimension | Decision |
+|---|---|
+| Execution model | CLI-first (`mur conversations compact` + `mur ask`) with **commander daemon piggyback** via cron trigger when commander is running |
+| Compact scope | Process all **missing completed days** (`date < today_utc`), with throttle (`max_days_per_run = 7` default), plus explicit `--date` / `--since` / `--force` / `--if-stale` overrides |
+| Ask output | **Inline `[cit: ...]` citations** + `--json` flag for structured output. Streaming tokens to stdout by default |
+| Summary regeneration | **Overwrite allowed** with automatic `.history/` archive of the prior version. §12 narrowed (see §8.1) |
+| LLM | Local Ollama only. Default model `qwen3:14b` for both compact and ask |
+| Retrieval | Tiered escalation: layer=1 (summary) → layer=0 (raw) when top score < `escalation_threshold` (default 0.5) |
+| Citation grounding | Every `[cit:...]` in model output must match an entry in retrieved context; unknown citations stripped during streaming |
+| Commander integration | Fire-and-forget child process (`mur conversations compact` spawned by commander's scheduler); opt-out via `enabled_in_daemon=false` |
+
+### Out of scope (Phase 2)
+
+- Multi-turn chat, dashboard UI, RAPTOR, LLMLingua-2, A-MEM dynamic re-linking — all Phase 3.
+- Cloud LLM providers (Anthropic/OpenAI). Phase 2 stays strictly local per spec §1 non-goals.
+- Real-Ollama CI validation. Phase 2 ships with mocked Ollama tests; real-LLM smoke is `--features ollama-live-smoke` opt-in.
+
+### Explicitly rejected alternatives
+
+- **`mur ask` as `mur conversations ask`** — rejected; `ask` is the daily-driver verb and deserves top-level status alongside `search`.
+- **Separate summarizer daemon (`murd`)** — rejected; commander is already running 24/7 for many users and a piggyback trigger is strictly cheaper than a new process with its own config/ops story.
+- **Strict §12 append-only with versioned `summary/<date>.vN.md`** — rejected; readers would constantly compute "latest version" and .history/ archive solves the same debug need with less cognitive load.
+- **Inline regeneration on `chat show`** — rejected; synchronous LLM call during a read operation is surprising and unbounded-latency. Compact is explicit.
+
+---
+
+## 3. Architecture
+
+### 3.1 Module layout
+
+New code in `mur-core/src/conversations/`:
+
+```
+conversations/
+├── summarize/              NEW — sleep-time compact
+│   ├── mod.rs              public API: compact_day, compact_missing, Summary, CompactReport
+│   ├── chunker.rs          split raw day into Ollama-sized chunks (default 6000 tokens)
+│   ├── extractive.rs       LLM picks 1-3 spans per chunk; dedupe; cap at N_MAX (default 20)
+│   ├── abstractive.rs      LLM narrative over the global span list (150-400 words)
+│   ├── macro_refs.rs       Aho-Corasick over ~/.mur/patterns/ names; {{pattern: name}} rewrite
+│   └── writer.rs           atomic .md write + .history/ archive + LanceDB layer=1 upsert
+├── ask/                    NEW — Mode C
+│   ├── mod.rs              public API: ask, ask_stream, AskRequest, AskResponse, AskEvent
+│   ├── retrieve.rs         tiered escalation (layer=1 → layer=0), MMR dedup, token-budget cap
+│   ├── prompt.rs           system prompt + context assembly + token accounting
+│   ├── generate.rs         Ollama /api/generate streaming + temperature/top_p/stop/timeout
+│   ├── cite.rs             grounding (strip unknown [cit:...]) + coverage warn heuristic
+│   └── format.rs           plain (streaming) + json (buffered) output modes
+├── audit.rs                existing; Summarize action variant used by writer.rs
+├── index.rs                existing; search() extended with optional layer filter
+├── retrieve.rs             existing; Mode A+B unchanged
+├── retention.rs            existing; 3-guard unchanged (already respects summary/)
+├── store.rs                existing; read_day used by summarize/chunker
+└── paths.rs                adds summary_history_dir()
+```
+
+New CLI handlers in `mur-core/src/cmd/conversations_cmd.rs`:
+
+- `cmd_conversations_compact(CompactArgs)` — wires `mur conversations compact`.
+- `cmd_ask(AskArgs)` — wires top-level `mur ask`.
+
+`mur-core/src/main.rs` gains:
+
+- `Commands::Ask { question, src, since, until, k, model, min_score, json, no_escalate, debug_prompt }`
+- `Commands::Conversations::Compact { date, since, force, if_stale, max_days, extractive_only, debug_prompt }`
+
+### 3.2 Data flow
+
+```
+                   ┌─────────────────────────────────────────┐
+                   │ mur conversations compact                │
+                   │  (or commander daemon @ daemon_cron)    │
+                   └──────────────┬──────────────────────────┘
+                                  ▼
+           ┌──────────────────────────────────────────────────┐
+           │ for each date in missing_days(throttle=7):        │
+           │   1. store::read_day(date)                         │
+           │   2. chunker: ~6000-token chunks                   │
+           │   3. extractive: LLM → spans (5-20 final)          │
+           │   4. abstractive: LLM → narrative paragraph        │
+           │   5. macro_refs: pattern-name AC automaton         │
+           │   6. frontmatter: counts, sources, keywords        │
+           │   7. writer: atomic write + .history/ archive      │
+           │   8. audit.append(Summarize{...})                  │
+           │   9. index.upsert(summary_embedding, layer=1)      │
+           └──────────────────────────────────────────────────┘
+                                  ▼
+                 summary/<date>.md        index.lance (layer=1 rows)
+                         │                       │
+                         ▼                       ▼
+                   ┌──────────────────────────────────────────┐
+                   │ mur ask "<question>"                      │
+                   └──────────────┬───────────────────────────┘
+                                  ▼
+          ┌────────────────────────────────────────────────────┐
+          │ ask::ask_stream:                                    │
+          │   embed(query) + filters                            │
+          │   retrieve: layer=1 k=5 →                           │
+          │            if max_score<0.5: layer=0 k=10           │
+          │   MMR dedupe (threshold=0.85)                       │
+          │   per hit: pull extractive span from summary        │
+          │   render_context(~6000 tokens)                      │
+          │   ollama.generate_stream(model, prompt)             │
+          │   cite.format(tokens) → inline [cit: ...]           │
+          │   format.render(plain | json)                       │
+          └────────────────────────────────────────────────────┘
+```
+
+### 3.3 Invariants
+
+1. **Citations survive retention rotation.** Extractive spans embed the verbatim text plus a pointer. When raw is deleted after `retention_days`, citations still resolve — the snippet lives in the summary.
+2. **Compact is idempotent modulo LLM nondeterminism.** Same raw + same model → same summary (extractive stage uses `temperature=0`; abstractive uses `temperature=0.2` — a small divergence in narrative wording is accepted).
+3. **Mode C never fabricates.** No retrieved hits above `min_score` → emit explicit "conversations don't cover that." Enforced by prompt instruction and post-generation citation grounding check.
+4. **Commander piggyback is opt-in via commander config.** mur operates identically with or without commander running.
+5. **Summary is regenerable; raw is not.** §12 narrows: summary overwrite allowed (with `.history/` archive); raw + audit stay strictly append-only.
+
+---
+
+## 4. Compact Pipeline
+
+### 4.1 Chunker
+
+Input: `Vec<Message>` for a date. Output: `Vec<Chunk>` where each chunk fits under `chunk_tokens` (default 6000).
+
+```rust
+pub struct Chunk {
+    pub messages: Vec<Message>,
+    pub token_count: usize,          // chars/4 approximation
+    pub span_range: (usize, usize),  // (start_line, end_line) in day-wide JSONL
+}
+
+pub fn chunk_day(msgs: &[Message], budget: usize) -> Vec<Chunk>;
+```
+
+Rules:
+
+- Never split a single message (quote integrity).
+- Prefer splitting at `conv_id` boundaries; split mid-conversation only if that conversation itself exceeds `budget`.
+- Token estimate: `chars / 4` — no tokenizer dependency; accurate to ±15% for English/CJK mix.
+- Empty day → empty `Vec<Chunk>`; writer emits a minimal "no significant activity" summary.
+- Single oversized message → emitted alone; the downstream extractive stage tolerates a truncated Ollama context.
+
+### 4.2 Extractive stage
+
+Per-chunk prompt (`extractive_model`, `temperature=0.0`):
+
+```
+You are reviewing one conversation day for a technical developer's personal
+archive. Extract the 1-3 most informative spans from this excerpt.
+
+A span is quote-worthy if it:
+- states a decision the user made ("we'll use X over Y because...")
+- records a concrete error or failure that shaped subsequent work
+- captures a new idea, technique, or reference the user hadn't seen before
+- quotes an important external fact (API response, spec excerpt, doc)
+
+A span is NOT quote-worthy if it is:
+- boilerplate/greeting/filler
+- tool-result body already citeable by path
+- restated from an earlier span
+
+Output format: JSON array. Each span is {role, conv_id, line_hint, text}.
+  - role: one of "user" | "assistant" | "system" | "tool"
+  - conv_id: the conv value from the source message
+  - line_hint: integer line number within the day's raw JSONL
+  - text: verbatim quote, 20-400 chars
+
+If the excerpt has nothing quote-worthy, return [].
+
+Excerpt (<N> messages, lines <span_start>..<span_end>):
+<renderMessages(chunk.messages)>
+```
+
+Each rendered message: `L<line> [hh:mm:ss] <src>/<conv> (<role>): <text-or-toolref>`.
+
+Per-span validation (silently drop invalid):
+
+- `text` is a verbatim substring of a source message (Jaro-Winkler ≥ 0.95 with a source message's content).
+- `line_hint` within the chunk's `span_range`.
+- `role` matches the source message's role.
+
+Global dedup + cap:
+
+1. MinHash dedupe at threshold 0.85 (reuse Phase 1's `ingest::dedup`).
+2. Stable-sort by `(importance_score, ts)` where importance = length-normalized × role-weight (User=1.2, Assistant=1.0, Tool=0.7, System=0.5).
+3. Truncate to `max_extractive_spans` (default 20).
+
+### 4.3 Abstractive stage
+
+Single LLM call (`abstractive_model`, `temperature=0.2`):
+
+```
+You are summarizing one day of a developer's AI-assistant conversations into
+a narrative paragraph. Use ONLY information present in the spans below.
+
+Output: 150-400 words, first-person or neutral third-person, no bullet lists.
+Reference each key point by its span index [N]. Do NOT invent details not in
+the spans. If spans conflict, note the conflict.
+
+Spans:
+[1] {2026-04-19 slack/bolt-david L4521}: "RaBitQ compresses vectors 32x..."
+[2] {2026-04-19 claude-code/3a87 L3344}: "Tool-call pointer substitution..."
+[3] ...
+
+Write the narrative.
+```
+
+Trailing LLM commentary stripped. On Ollama failure: keep extractive-only summary + frontmatter `warnings: ["narrative_generation_failed"]`.
+
+### 4.4 Macro reference detection
+
+```rust
+pub struct MacroRef {
+    pub name: String,
+    pub pattern_version: u32,
+    pub pattern_sha: String,          // SHA-256 of ~/.mur/patterns/<name>.yaml
+    pub marker: String,                // "{{pattern: atomic-yaml-write}}"
+}
+
+pub fn detect_and_rewrite(
+    extractive: &mut [ExtractiveSpan],
+    abstractive: &mut String,
+    patterns_dir: &Path,
+) -> Result<Vec<MacroRef>>;
+```
+
+Algorithm:
+
+1. Enumerate `~/.mur/patterns/*.yaml` stems.
+2. Build Aho-Corasick automaton over the name set (case-insensitive).
+3. Scan extractive span `text` and abstractive narrative for matches (word-boundary enforced in a post-check).
+4. Skip matches inside code fences, backticks, or YAML quotes.
+5. For each valid match: replace text with `{{pattern: <name>}}`, record one `MacroRef` (dedupe by name).
+6. Record `(version, sha)` per referenced pattern — enables future invalidation detection.
+
+### 4.5 Frontmatter schema (exact)
+
+```yaml
+---
+schema: 1
+date: 2026-04-19
+generated_at: 2026-04-20T03:00:12Z
+generated_by:
+  extractive_model: qwen3:14b
+  abstractive_model: qwen3:14b
+  mur_version: 2.3.0
+duration_ms: 18412
+conv_count: 12
+msg_count: 487
+sources: [claude-code, cursor, slack]
+pattern_refs:
+  - name: atomic-yaml-write
+    version: 2
+    sha: abc123...
+  - name: freedman-compression
+    version: 1
+    sha: def456...
+keywords: [conversations, freedman, compression, ingest]
+links:
+  prev: ./2026-04-18.md
+  next: ./2026-04-20.md
+warnings: []
+input_content_sha: sha256-of-concatenated-raw-jsonl
+---
+```
+
+`input_content_sha` is the invalidation key: `--if-stale` compares this against the live raw content; identical → skip.
+
+### 4.6 Body schema
+
+```markdown
+## Extractive spans
+
+[1] _{claude-code/3a8786a0 @L3344}_:
+> 修一下 yaml.rs 的 atomic write bug
+
+[2] _{slack/C0ARLGHP3A5 @L4521}_:
+> LanceDB RaBitQ · 32× 壓縮 · recall@10 差 <1%
+
+## Abstractive narrative
+
+Today's work split into two threads: first, a continued brainstorm of the mur
+conversations archive using {{pattern: atomic-yaml-write}} as the writer
+model [1]; second, a compression-theory detour into {{pattern: freedman-compression}} [2]...
+
+## Macro expansion map
+
+- {{pattern: atomic-yaml-write}} → patterns/atomic-yaml-write.yaml (v2, sha abc…)
+- {{pattern: freedman-compression}} → patterns/freedman-compression.yaml (v1, sha def…)
+```
+
+Span IDs `[1]`, `[2]` are stable within the file. Mode C citations reference them via `@summary-span-<N>` suffix.
+
+### 4.7 Writer
+
+```rust
+pub fn write_summary(
+    date: NaiveDate,
+    summary: &Summary,
+    root_override: Option<&str>,
+) -> Result<()>;
+```
+
+Atomic sequence:
+
+1. Render body to `String`.
+2. Resolve final path `summary/<date>.md`.
+3. If it already exists and content differs from new: move to `summary/.history/<date>.<ISO-8601>.md`.
+4. If content is identical to new: return early (no-op, no audit, no history).
+5. Write to `summary/.tmp.<date>.md`.
+6. Atomic rename tmp → final.
+7. Emit `audit::AuditAction::Summarize { date, model, duration_ms }` via `Audit::append`.
+8. Compute summary vector embedding; upsert into LanceDB at `layer=1`.
+
+`.history/` cap: keep the `history_retain` most recent versions per date (default 5); older → delete + audit `Delete { reason: "history.rotate" }`.
+
+### 4.8 Orchestrator
+
+```rust
+pub async fn compact_missing(cfg: &CompactConfig, root_override: Option<&str>) -> Result<CompactReport>;
+pub async fn compact_day(date: NaiveDate, force: bool, cfg: &CompactConfig, root_override: Option<&str>) -> Result<DayReport>;
+```
+
+`compact_missing` scans `list_raw_dirs`, filters to `date < today_utc`, skips days with existing summary (unless `--force` or `--if-stale` detects content change), caps at `max_days_per_run`, calls `compact_day` per date. Per-day failures are captured; don't abort the run.
+
+`tracing::info_span!("compact.day", date=%d)` per day.
+
+### 4.9 Failure modes (compact)
+
+| Stage | Fail | Behavior |
+|---|---|---|
+| Read day | I/O error | Abort this day; report records path + errno |
+| Chunk | — | Pure Rust; cannot fail |
+| Extract | Ollama timeout/500 | Skip that chunk; continue remaining chunks |
+| Extract | Invalid JSON | Zero spans from that chunk; log |
+| Dedup/cap | — | Pure Rust |
+| Abstractive | Ollama fail | Extractive-only summary + `warnings: ["narrative_generation_failed"]` |
+| Macro refs | Pattern YAML unreadable | Skip that pattern; others still inserted |
+| Write | Disk/permission | Abort day; staging tmp cleaned on drop |
+| Audit | Append fails | Abort day; summary NOT written (invariant: every write has an audit entry) |
+| Index | LanceDB fail | Summary IS written (source of truth); rebuild on next `reindex` |
+
+---
+
+## 5. Mode C (Ask)
+
+### 5.1 Public API
+
+```rust
+pub struct AskRequest {
+    pub question: String,
+    pub k_summary: usize,
+    pub k_raw: usize,
+    pub escalation_threshold: f64,
+    pub min_score: f64,
+    pub source_filter: Vec<Source>,
+    pub since: Option<NaiveDate>,
+    pub until: Option<NaiveDate>,
+    pub model: String,
+    pub format: Format,          // Plain | Json
+    pub max_context_tokens: usize,
+    pub response_tokens: usize,
+    pub timeout: Duration,
+    pub no_escalate: bool,
+}
+
+pub enum Format { Plain, Json }
+
+pub struct AskResponse {
+    pub answer: String,
+    pub citations: Vec<Citation>,
+    pub hits_used: Vec<HitInfo>,
+    pub degraded_to_mode_b: bool,
+    pub tokens_in: usize,
+    pub tokens_out: usize,
+    pub duration_ms: u64,
+}
+
+pub async fn ask(req: AskRequest, root_override: Option<&str>) -> Result<AskResponse>;
+pub async fn ask_stream(req: AskRequest, root_override: Option<&str>)
+    -> Result<impl Stream<Item = Result<AskEvent>>>;
+
+pub enum AskEvent {
+    Token(String),
+    Citation(Citation),
+    HitInfo(HitInfo),
+    Done { tokens_in: usize, tokens_out: usize, degraded: bool, duration_ms: u64 },
+    Error(String),
+}
+
+pub struct Citation {
+    pub id: u32,
+    pub date: NaiveDate,
+    pub source: Source,
+    pub conv_id: String,
+    pub line_hint: Option<u32>,
+    pub span_index_in_summary: Option<u32>,
+    pub snippet: String,
+    pub score: f64,
+}
+```
+
+`ask_stream` is the primary implementation; `ask` buffers over it for `--json`.
+
+### 5.2 Retrieval
+
+```rust
+pub async fn gather_hits(
+    query: &str,
+    filters: &Filters,
+    cfg: &AskConfig,
+    root_override: Option<&str>,
+) -> Result<Vec<Hit>>;
+```
+
+Stages:
+
+1. **Embed query** — reuse Phase 1's `embedding::embed`.
+2. **Search summaries (layer=1)** — `k_summary` (default 5). Apply since/until/min_score post-filter.
+3. **Decision** — if `hits.is_empty() || hits[0].score < escalation_threshold` (default 0.5) → escalate (unless `no_escalate=true`).
+4. **Escalate to raw (layer=0)** — `k_raw` (default 10); same post-filters; keep all hits separately from summaries.
+5. **MMR dedupe** at `mmr_threshold` (default 0.85, reuses Phase 1 config).
+6. **Per-hit snippet resolution** — summary hits: closest extractive span's verbatim text + `span_index`. Raw hits: message text with role prefix, `span_index = None`.
+7. **Token-budget cap** — greedy by score until `~90% of max_context_tokens` consumed. Minimum 1 hit always.
+
+`index::ConversationIndex::search` extended with an optional `layer: Option<i8>` parameter (backward-compatible).
+
+### 5.3 Prompt assembly
+
+**Token budgeting** (chars/4 estimator):
+
+```
+Fixed:
+  system_prompt      ≈ 380 tokens
+  question           variable (truncated at 500 tokens with warning)
+  response_reserve   cfg.response_tokens (default 1024)
+  scaffolding        ≈ 120 tokens
+Remaining for context: cfg.max_context_tokens - fixed ≈ 6000 - 2000 = 4000 tokens
+```
+
+**System prompt (fixed, ~380 tokens):**
+
+```
+You answer questions about the user's past AI-assistant conversations, using
+ONLY the excerpts provided below under "Context". Never invent facts not
+present in the excerpts.
+
+Every factual claim in your answer MUST be followed by an inline citation
+in the form [cit: <date> <source>/<conv_id>:L<line>]. Use only the citations
+enumerated in the Context section — one citation per claim. You may use the
+same citation multiple times.
+
+If the excerpts are insufficient to answer, say so plainly: "The conversations
+I have access to don't cover that." Do not speculate. Do not use training
+knowledge to fill gaps.
+
+Format: clear prose, 2-6 sentences per idea, Markdown bullets when listing.
+Be direct. Don't repeat the question. Don't apologize for not knowing.
+
+When the user mentions a pattern name wrapped in {{pattern: name}} in the
+excerpts, that refers to a reusable artifact at ~/.mur/patterns/<name>.yaml;
+you may mention the pattern by name in your answer but do not expand it.
+```
+
+**Context format (per hit):**
+
+```
+[cit: 2026-04-19 slack/bolt-david:L4521]
+> LanceDB RaBitQ · 32× 壓縮 · recall@10 差 <1%
+
+[cit: 2026-04-19 claude-code/3a87:L3344]
+> Tool-call pointer substitution 存 sha256+path+bytes 取代內容...
+
+[cit: 2026-04-18 claude-code/c4c2 @summary-span-3]
+> 我決定把 commander audit chain 用 bridge 方式延續...
+```
+
+Citations use `@summary-span-<N>` when the hit is a layer=1 summary span; raw hits use `:L<line>`.
+
+### 5.4 Generation & streaming
+
+Ollama `/api/generate` with `stream=true`:
+
+```rust
+pub async fn generate_stream(
+    model: &str,
+    system: &str,
+    user: &str,
+    endpoint: &str,
+    timeout: Duration,
+) -> Result<impl Stream<Item = Result<String>>>;
+```
+
+Parameters:
+
+- `temperature: 0.1`
+- `top_p: 0.9`
+- `num_predict: cfg.response_tokens`
+- `stop: ["\n\nQ:", "\n\nQuestion:"]`
+
+Stream consumer:
+
+- Maintain a 64-char tail buffer to detect `[cit:...]` spans emerging across chunk boundaries.
+- On detecting a closed bracket: parse + validate against context citation list; unknown → strip silently + log warn.
+- Re-emit validated tokens to caller's stream.
+
+**Timeout:** wall-clock `cfg.timeout_secs` (default 120). On hit: close stream, `Err(Timeout)`; partial output has already reached the caller.
+**Stall detection:** if > 20s elapses with no token, abort with partial output + warn.
+
+### 5.5 Citation grounding
+
+Two checks:
+
+**1. Grounding.** Every `[cit: ...]` in output must match the context's citation list. Unknown → strip during streaming.
+
+**2. Coverage (soft).** After generation, count claim-like sentences lacking adjacent citations. Heuristic:
+
+- Split answer into sentences.
+- "Claim" = sentence with a content verb (`is`/`was`/`means`/`uses`/`adopts`/`rejects`/`shows`/etc.) OR containing a specific name/number.
+- If `claim_without_cite_ratio > 0.3`: append a warning line to the output (`⚠ Some claims above are not cited; treat them as model synthesis, not archive content.`). Does not reject output — Phase 2 is warn-only; Phase 3 can add strict mode.
+
+### 5.6 Output formatting
+
+**Plain (default):**
+
+- Stream tokens to stdout.
+- After stream completes:
+  - Blank line
+  - `Citations:` header
+  - Per unique citation used: `[cit: ...] — <snippet first 120 chars>` lines, ordered by first reference in answer
+  - Runtime footer: `(<N> hits · <ms>ms · <tokens_in>→<tokens_out> tokens[ · Mode B fallback])`
+
+**JSON (`--json`):**
+
+Buffered full response as AskResponse; emit once at end. Streaming JSON is unparseable mid-stream, so `--json` mode gives up streaming for structural validity.
+
+### 5.7 Failure degradation
+
+| Failure | Behavior | Exit |
+|---|---|---|
+| Ollama unreachable | Degrade to Mode B; `[LLM unavailable] Here are the top N relevant excerpts:` + snippets | 0 |
+| Ollama 5xx/timeout | Same as unreachable | 0 |
+| Model not pulled | `error: Ollama doesn't have <model>. Run 'ollama pull <model>'` | 1 |
+| No vector index | `error: no index. Run 'mur conversations reindex'` | 1 |
+| No hits above min_score | `The conversations I have access to don't cover that.` + note on filters/retention | 0 |
+| Context oversize at k=1 | Truncate single snippet; emit warning | 0 |
+| Stream stall > 20s | Abort + partial output + warn | 1 |
+
+### 5.8 CLI surface
+
+```bash
+mur ask <question>                            # streaming plain text
+mur ask <question> --json                     # structured JSON
+mur ask <question> --src claude-code,slack    # filter sources
+mur ask <question> --since 2026-04-01         # time filter
+mur ask <question> --k 8                      # override top-k (sets k_raw = k * 2)
+mur ask <question> --model qwen3:32b          # override model
+mur ask <question> --no-escalate              # skip layer=0 fallback
+mur ask <question> --debug-prompt             # print rendered prompt to stderr
+```
+
+`mur ask` lives at the top level (not nested under `conversations`) — it's the daily-driver verb and should feel as light as `mur search`.
+
+---
+
+## 6. Config Schema
+
+### 6.1 `mur-common::config::ConversationsConfig` extensions
+
+```rust
+pub struct ConversationsConfig {
+    // Phase 1 fields unchanged.
+    pub enabled: bool,
+    pub retention_days: u32,
+    pub poll_interval_secs: u64,
+    pub sources: ConversationsSources,
+    pub filter:  ConversationsFilter,
+
+    // Phase 2 additions.
+    pub compact: CompactConfig,
+    pub ask:     AskConfig,
+}
+
+pub struct CompactConfig {
+    pub enabled_in_daemon: bool,        // default true
+    pub max_days_per_run: u32,          // default 7
+    pub extractive_model: String,       // default "qwen3:14b"
+    pub abstractive_model: String,      // default "qwen3:14b"
+    pub ollama_endpoint: String,        // default "http://localhost:11434"
+    pub max_extractive_spans: u32,      // default 20
+    pub max_abstractive_words: u32,     // default 400
+    pub chunk_tokens: u32,              // default 6000
+    pub history_retain: u32,            // default 5
+    pub daemon_cron: String,            // default "0 3 * * *" (03:00 local)
+}
+
+pub struct AskConfig {
+    pub model: String,                  // default "qwen3:14b"
+    pub ollama_endpoint: String,        // default "http://localhost:11434"
+    pub k_summary: u32,                 // default 5
+    pub k_raw: u32,                     // default 10
+    pub escalation_threshold: f64,      // default 0.5
+    pub mmr_threshold: f64,             // default 0.85
+    pub max_context_tokens: u32,        // default 6000
+    pub response_tokens: u32,           // default 1024
+    pub timeout_secs: u32,              // default 120
+    pub min_score: f64,                 // default 0.35
+}
+```
+
+All fields `#[serde(default)]` — existing Phase 1 `config.yaml` files continue to parse.
+
+### 6.2 P4 auto-sync extension
+
+Phase 1's P4 sync (`migrate.rs::sync_commander_config_toml`) writes a marker-delimited `[conversations]` block into `~/.mur/commander/config.toml`. Phase 2 extends the synced subset:
+
+```toml
+# BEGIN [conversations] (managed by mur conversations migrate)
+[conversations]
+enabled = true
+retention_days = 30
+
+[conversations.compact]
+enabled_in_daemon = true
+daemon_cron = "0 3 * * *"
+# END [conversations]
+```
+
+The new `[conversations.compact]` sub-section is added to the sync writer. Everything else Phase 1 synced stays.
+
+### 6.3 Full config example
+
+```yaml
+conversations:
+  enabled: true
+  retention_days: 30
+  poll_interval_secs: 300
+  sources:
+    claude_code: true
+    cursor: true
+    gemini: true
+    aider:
+      enabled: true
+      watched_dirs: ["~/Projects"]
+  filter:
+    dedup_threshold: 0.85
+    reject_heartbeat: true
+    reject_system_restatement: true
+  compact:
+    enabled_in_daemon: true
+    max_days_per_run: 7
+    extractive_model: qwen3:14b
+    abstractive_model: qwen3:14b
+    ollama_endpoint: http://localhost:11434
+    max_extractive_spans: 20
+    max_abstractive_words: 400
+    chunk_tokens: 6000
+    history_retain: 5
+    daemon_cron: "0 3 * * *"
+  ask:
+    model: qwen3:14b
+    ollama_endpoint: http://localhost:11434
+    k_summary: 5
+    k_raw: 10
+    escalation_threshold: 0.5
+    mmr_threshold: 0.85
+    max_context_tokens: 6000
+    response_tokens: 1024
+    timeout_secs: 120
+    min_score: 0.35
+```
+
+---
+
+## 7. Commander Piggyback
+
+Commander has a long-running daemon with a scheduler; Phase 2 reuses that instead of introducing a new process.
+
+### 7.1 New trigger: `ConversationsCompactTrigger`
+
+New file: `mur-commander/crates/daemon/src/triggers/conversations_compact.rs`.
+
+```rust
+pub struct ConversationsCompactTrigger {
+    cron: cron::Schedule,
+    last_fired: Mutex<Option<DateTime<Utc>>>,
+}
+
+impl Trigger for ConversationsCompactTrigger {
+    fn name(&self) -> &'static str { "conversations_compact" }
+
+    async fn tick(&self, now: DateTime<Utc>) -> Result<TriggerAction> {
+        let last = *self.last_fired.lock().unwrap();
+        let Some(next) = self.cron.after(&last.unwrap_or(now - Duration::days(1))).next() else {
+            return Ok(TriggerAction::None);
+        };
+        if now >= next {
+            *self.last_fired.lock().unwrap() = Some(now);
+            Ok(TriggerAction::Exec(ExecSpec {
+                command: "mur".into(),
+                args: vec!["conversations".into(), "compact".into()],
+                timeout_secs: 600,           // 10 min
+                capture_output: true,
+            }))
+        } else {
+            Ok(TriggerAction::None)
+        }
+    }
+}
+```
+
+### 7.2 Design rationale
+
+1. **Fire-and-forget child process, not in-process.** Isolates commander from Ollama hangs; 10-min timeout kills the child cleanly. Users debug by running the same CLI by hand. No dep coupling between mur and commander versions.
+2. **Cron lives in commander config.** `conversations.compact.daemon_cron` in mur's `config.yaml` mirrored to commander's toml via P4 sync. Commander reads only its own toml at runtime.
+3. **Audit to commander's chain.** Trigger start + result logged via commander's `AuditStore` (workflow-oriented schema). Doesn't touch mur's conversations audit chain — the child `mur` process writes its own `Summarize` entry there.
+4. **Opt-out.** `enabled_in_daemon=false` in commander's toml → trigger skips registration at daemon start.
+5. **Overlap prevention.** If a previous exec is still running when the trigger fires, skip this tick. Phase 1's `.pull.lock` flock further prevents pipeline interleaving.
+
+### 7.3 Commander-side changes
+
+- `crates/daemon/src/triggers/conversations_compact.rs` — new (~80 LOC)
+- `crates/daemon/src/triggers/mod.rs` — register new trigger
+- `crates/daemon/src/main.rs` — read cron from commander config, instantiate trigger, add to scheduler
+- `crates/daemon/src/config.rs` — add `ConversationsCompactConfig` struct matching the toml block
+
+### 7.4 `mur conversations doctor` updates
+
+Phase 1's doctor gains Phase 2 checks:
+
+```
+conversations doctor
+  ✓ raw day-dirs: 12
+  ✓ audit hash chain
+  ✓ retention_days = 30
+  ✓ conversations.enabled
+  ✓ summaries: 11 of 12 present  (missing: 2026-04-20 today; run 'mur conversations compact')
+  ✓ Ollama reachable at http://localhost:11434
+  ✓ model qwen3:14b available
+  ✓ compact config valid
+  ✓ ask config valid
+  ✓ commander compact trigger: enabled (next fire 2026-04-21T03:00:00-07:00)
+```
+
+All checks informational — failures warn but don't exit non-zero (unless an explicitly blocking issue like `conversations.enabled=false`).
+
+### 7.5 `mur conversations preflight` updates
+
+Phase 1's preflight covered migration safety. Phase 2 adds checks before the first compact-or-ask:
+
+- Ollama reachable?
+- Models `compact.extractive_model`, `compact.abstractive_model`, `ask.model` all pulled?
+- Pattern directory `~/.mur/patterns/` readable?
+- Free memory ≥ 4 GB (Linux/macOS via `sysinfo` crate)?
+- Disk free for `.history/` growth over 30 days (estimate: N_summaries × avg 4 KB)?
+
+Non-blocking; warnings only.
+
+---
+
+## 8. Amendments to Phase 1
+
+### 8.1 §12 append-only narrowing
+
+**Add to Phase 1 spec §12 as the final paragraph of the section:**
+
+> **Phase 2 narrowing (2026-04-20 amendment).** The append-only guarantee applies strictly to source data (`raw/<date>/*.jsonl`) and the audit chain (`audit.jsonl`). Summaries (`summary/<date>.md`) are derived artifacts and MAY be overwritten by a newer compact run (via `mur conversations compact --force` or a newer prompt/model version). On overwrite, the previous summary is moved to `summary/.history/<date>.<ISO-8601>.md`; the most recent `history_retain` versions per date are kept, older ones are deleted with an audit `Delete{reason:"history.rotate"}` entry. This narrowing lets prompt/model improvements reach existing users without requiring destructive opt-in migrations.
+
+### 8.2 §6.5 concretization
+
+**Add to Phase 1 spec §6.5 as a prepended note:**
+
+> **Phase 2 replaces this sketch with a concrete algorithm; see `docs/superpowers/specs/2026-04-20-mur-conversations-phase-2-design.md` §5.**
+
+The original §6.5 pseudocode remains as historical context.
+
+### 8.3 §6.7 REST API stubs
+
+Phase 1 §6.7 listed stub endpoints for a future dashboard. Phase 2 does NOT implement the REST API — Mode C stays CLI-only. Phase 3 implementation can use the same `AskResponse` / `AskEvent` types as the CLI and just wrap them in an HTTP/SSE transport. The types are designed for that reuse already.
+
+---
+
+## 9. Testing Strategy
+
+### 9.1 Unit tests (per module, mocked Ollama)
+
+| Module | Key tests |
+|---|---|
+| `summarize/chunker.rs` | budget-respecting pack; single-msg-over-budget falls through; conv-boundary preference; empty day → zero chunks |
+| `summarize/extractive.rs` | valid JSON → validated spans; Jaro-Winkler verbatim check catches paraphrases; invalid role rejected; line_hint range check; LLM empty array → zero spans |
+| `summarize/abstractive.rs` | happy path; Ollama 500 → extractive-only warning set; 400-word cap respected; trailing commentary stripped |
+| `summarize/macro_refs.rs` | Aho-Corasick happy path; word-boundary enforcement (pattern `rust` doesn't match `rustic`); code-fence / backtick skip; no-patterns case (empty patterns/ dir) |
+| `summarize/writer.rs` | atomic rename; .history/ archive on overwrite; identical summary → no-op; .history/ cap; audit Summarize entry appended; LanceDB upsert roundtrip |
+| `ask/retrieve.rs` | layer-1 path when top score ≥ 0.5; escalation to layer-0 when below; MMR dedup threshold; token-budget cap; filter combinators (src+since+until) |
+| `ask/prompt.rs` | token accounting accurate to ±5%; oversized question truncation + warn; scaffolding overhead constant; citation anchors unique per hit |
+| `ask/generate.rs` | stream yields tokens in order; timeout aborts cleanly; stall detection; temp/top_p/stop params honored |
+| `ask/cite.rs` | grounding drops unknown `[cit:...]`; coverage warn threshold 30%; `@summary-span-<N>` variant parsed; claim-sentence heuristic |
+| `ask/format.rs` | plain format byte-matches spec example (modulo timestamps); `--json` produces valid JSON; AskEvent round-trip |
+
+### 9.2 Integration tests (wiremock'd Ollama)
+
+- `compact_e2e`: seed raw day → `compact_day` → assert summary.md has valid frontmatter, spans, narrative, LanceDB layer=1 row, audit Summarize entry.
+- `compact_force_archives`: compact twice (different mock responses) → .history/ has 1 prior version.
+- `compact_if_stale_noop`: raw unchanged + summary present → no work.
+- `ask_summary_hit`: seed 3 days with summaries → ask question matching one summary → cite only that summary's spans.
+- `ask_escalates_to_raw`: mock retrieval returns low-score summary hits → assert raw-layer search fires.
+- `ask_degrades_on_ollama_down`: wiremock returns connection-refused → `degraded_to_mode_b=true`, no panic.
+- `ask_rejects_fabricated_cite`: mock Ollama emits `[cit: 2099-01-01 fake:L0]` → grounding filter strips it.
+
+### 9.3 Golden-path script update
+
+Extend `scripts/golden-path-conversations.sh` with two new steps:
+
+```bash
+# Step 9: compact
+MUR_OLLAMA_MOCK=1 "$MUR" conversations compact --date "$TODAY" | tee /tmp/gp-out-9.txt
+grep -q "1 ok, 0 failed" /tmp/gp-out-9.txt || { echo "FAIL"; exit 1; }
+[[ -f "$TMPHOME/.mur/conversations/summary/$TODAY.md" ]] || { echo "FAIL"; exit 1; }
+
+# Step 10: ask
+MUR_OLLAMA_MOCK=1 "$MUR" ask "what compression techniques did I discuss" --json | tee /tmp/gp-out-10.txt
+jq -e '.citations | length > 0' /tmp/gp-out-10.txt >/dev/null || { echo "FAIL"; exit 1; }
+
+echo "=== ALL 10 STEPS GREEN ==="
+```
+
+`MUR_OLLAMA_MOCK=1` is a new test helper: the Ollama client checks this env and returns canned responses (deterministic extractive spans, fixed abstractive narrative, fixed ask answer with one valid citation). Keeps the golden path deterministic and offline.
+
+### 9.4 Real-Ollama smoke (feature-gated)
+
+```bash
+cargo test -p mur-core --features ollama-live-smoke -- --ignored
+```
+
+Runs actual `qwen3:14b` against a seeded day; CI skips this (needs Ollama + 8 GB model); local devs run when tuning prompts.
+
+---
+
+## 10. Operational Details
+
+### 10.1 Error handling cross-reference
+
+| Source | Fail | User CLI outcome | Audit | Exit |
+|---|---|---|---|---|
+| compact / read day | I/O | `✗ <date>: <err>` | `Error{stage:"compact.read"}` | 0 (partial OK) |
+| compact / extract | Ollama 5xx | per-chunk skip + warn | — | 0 |
+| compact / extract | invalid JSON | warn + zero spans that chunk | — | 0 |
+| compact / abstractive | Ollama fail | summary has `warnings:["narrative_generation_failed"]` | `Summarize{..., warnings}` | 0 |
+| compact / write | disk full | `✗ <date>: no space` | `Error{stage:"compact.write"}` | 1 |
+| compact / audit append | chain broken | abort day, summary NOT written | (next startup detects) | 1 |
+| ask / Ollama unreachable | connect refused | Mode B fallback, full snippets | — | 0 |
+| ask / Ollama error | 500/timeout | Mode B fallback + warn | — | 0 |
+| ask / model missing | not found | `error: ollama pull <model>` | — | 1 |
+| ask / no index | empty LanceDB | `error: run 'mur conversations reindex'` | — | 1 |
+| ask / zero hits | retrieval empty | "conversations don't cover that" | — | 0 |
+| ask / grounding | fake `[cit:...]` | strip silently, log warn | — | 0 |
+| ask / stream stall | > 20s quiet | abort + partial output + warn | — | 1 |
+
+### 10.2 Observability
+
+All new code wrapped in `tracing::info_span!` per Phase 1's BP6 pattern:
+
+- `conversations.compact.day(date=%d)` — covers all stages of one day's compact
+- `conversations.compact.extractive(chunk_idx=%u)` — per chunk
+- `conversations.compact.abstractive(span_count=%u)` — the single abstractive call
+- `conversations.compact.write(date=%d)` — atomic write + audit + index
+- `conversations.ask.retrieve(k=%u)` — retrieval stages
+- `conversations.ask.generate(model=%s)` — LLM streaming
+- `conversations.ask.cite(cite_count=%u)` — grounding + coverage checks
+
+Enable with `RUST_LOG=mur_core::conversations=debug`.
+
+### 10.3 Phase 2 rollout order
+
+**Phase 2A — compact only** (shippable independently):
+
+- Sections 3 (module layout) + 4 (compact pipeline) + 6.1/6.2/6.3 (compact config + P4 sync) + 7 (commander trigger) + §8.1 amendment + relevant tests.
+- **Value without ask:** users can finally retain conversations forever via daily summaries. Retention 3-guard starts deleting raw past `retention_days` cleanly.
+- **PR scope:** mur repo + mur-commander repo.
+
+**Phase 2B — ask** (depends on 2A):
+
+- Sections 3 (ask module) + 5 (ask implementation) + 6.1 (ask config) + relevant tests.
+- **Value:** users can ask natural-language questions about their archive.
+- **PR scope:** mur repo only.
+
+**Phase 2C — hardening** (can slip to Phase 2.1):
+
+- Citation grounding strict mode
+- Real-Ollama smoke in CI (once CI runners support it or we formalize the mock)
+- `.history/` cap cleanup job + audit
+- `--debug-prompt` polish
+
+Each sub-phase gets its own PR. Merge order: 2A → 2B → 2C.
+
+### 10.4 Phase 3 items explicitly DEFERRED
+
+- Multi-turn chat (`mur ask --continue`)
+- mur-web `/conversations` dashboard
+- LLMLingua-2 pre-summarization
+- RAPTOR week/month summaries (layer=2+)
+- A-MEM dynamic re-linking (pattern SHA drift detection)
+- Cloud LLM provider support (Anthropic/OpenAI) — if ever
+
+### 10.5 Success criteria (acceptance)
+
+Phase 2 ships when:
+
+- ✅ `mur conversations compact --date YYYY-MM-DD` produces a valid summary matching §4.5/4.6 schema.
+- ✅ `mur conversations compact` catches up missing days with throttle.
+- ✅ `mur ask <question>` emits streaming plain-text answer with ≥1 grounded citation OR clean "nothing matched" message.
+- ✅ `mur ask <question> --json` emits valid JSON matching `AskResponse` schema.
+- ✅ Retention 3-guard allows raw deletion at T+30d after compact runs.
+- ✅ Commander daemon fires `mur conversations compact` on schedule when enabled.
+- ✅ Ollama unreachable → ask degrades to Mode B without panic.
+- ✅ Golden path script passes all 10 steps with `MUR_OLLAMA_MOCK=1`.
+- ✅ Clippy + fmt clean on workspace.
+- ✅ `cargo test --workspace` passes (excluding feature-gated real-Ollama tests).
+
+---
+
+## 11. Compatibility Constraints (Hard)
+
+Non-negotiable; every implementation choice must honor these:
+
+1. **Raw + audit stay append-only.** Only summary/.md may be overwritten (with .history/ archive). Spec §12 narrowing applies only to summaries.
+2. **Mode C must not fabricate citations.** Unknown `[cit:...]` stripped at streaming time. Zero exceptions.
+3. **Ollama unreachable must not crash ask.** Degrade to Mode B; return a clear "LLM unavailable" message.
+4. **Summary frontmatter schema is forward-versioned.** `schema: 1` field present on every write; readers must handle missing fields via serde-default (the amended summary schema uses `#[serde(default)]` throughout).
+5. **Commander piggyback is OPTIONAL.** mur operates identically whether commander is running or not.
+6. **No Phase 3 leakage.** Don't implement multi-turn, dashboard, LLMLingua, RAPTOR, or A-MEM features "while we're there." Each has its own spec cycle.
+
+---
+
+## 12. Open Questions
+
+None blocking Phase 2A or 2B implementation. Flagged for Phase 3 discussion:
+
+- Should `ask` support cross-repo context (mix pattern content with conversation content in prompts)? The macro-expansion path makes this trivially possible but the default stance in Phase 2 is "patterns referenced by name, not expanded inline."
+- Should compact store summary embedding at multiple resolutions (`layer=1` full summary + `layer=1.5` per-section)? Phase 3 RAPTOR makes this a structural decision.
+- Should Mode C offer `--verbose` that shows retrieval scores and prompt assembly inline? Phase 2 keeps `--debug-prompt` as a focused debug switch; UI polish for observability is Phase 3.
+
+---
+
+## 13. References
+
+- Phase 1 spec: `docs/superpowers/specs/2026-04-19-mur-conversations-design.md`
+- Phase 1 plan: `docs/superpowers/plans/2026-04-19-mur-conversations-phase-1.md`
+- Phase 1 amendments: `docs/superpowers/plans/2026-04-19-mur-conversations-phase-1-amendments.md`
+- Shipped PRs: mur-run/mur#5 (squash `4664a4c`), mur-run/mur-commander#9 (squash `3a5bf1b`)
+- Freedman, Aksenov, Bodnia, Mulligan. *Compression is all you need: Modeling Mathematics.* arXiv 2603.20396 (2026-03-20) — Named-Abstraction theory underpinning macro-expansion (§4.4, §4.6).
+- Mem0 production audit. GitHub issue #4573. — 97.8% junk finding; informs "extract only quote-worthy" framing in §4.2.
+- MemGPT tiered retrieval. arXiv 2310.08560. — layer-1 → layer-0 escalation pattern adopted in §5.2.
+- Perplexity citation format — informed the inline `[cit:...]` style in §5.3.

--- a/docs/superpowers/specs/2026-04-20-mur-sources-integration-design.md
+++ b/docs/superpowers/specs/2026-04-20-mur-sources-integration-design.md
@@ -1,0 +1,800 @@
+# mur Sources Integration — Design Spec
+
+- **Status**: Draft — awaiting user approval before implementation plan
+- **Author**: Claude (brainstorming session)
+- **Date**: 2026-04-20
+- **Scope**: Phase 1 of external knowledge source integration for mur
+- **Related**: `docs/mur-函數清單與競品分析.md` (§ Karpathy LLM Wiki, line 236)
+
+---
+
+## 1. Problem & Goal
+
+mur today learns patterns from AI coding sessions. Users also keep substantial knowledge in dedicated note apps (Notion, Obsidian, Joplin, OneNote, Apple Notes, Notability, NotebookLM). Today there is no bridge: the knowledge in those apps is invisible to AI tools that mur injects into.
+
+**Goal**: Let users connect note apps to mur so `mur search` and AI-session injection can surface content across **patterns + external notes** from a single unified index — while keeping the source apps as the authoritative stores.
+
+**Non-goal**: mur does not become a note app, does not replace Notion/Obsidian, and does not maintain bidirectional sync. External notes remain owned by their source apps.
+
+## 2. Decisions (from brainstorming Q&A)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| Q1 | Primary use-case = **unified search** across pattern + external corpus | User explicit choice (B) |
+| Q2 | Indexing = **local pull-sync** into mur's vector store | Matches mur's offline-first DNA; consistent ranking |
+| Q3 | Retrieval corpus = **unified** (patterns + notes in one ranker), with **per-source weight + scope** | Answer "B + C" compromise; respects source boundaries without fragmenting corpus |
+| Q4 | Phase 1 adapters = **Obsidian + Notion + Joplin** | Covers one local-file + one OAuth cloud + one local-DB; proves both connection styles |
+| Q5 | MCP / federated query = **trait signature pre-designed, implementation deferred** | `SourceKind::FederatedQuery` variant exists but Phase 1 has zero impls |
+| Q6 | Vector stores = `VectorStore` **trait** with **LanceDB (default) + Qdrant** impls | User wants pluggability; trait validates with ≥2 impls |
+| Q7 | Sources **do not** feed `evolve` pattern extraction — strict separation | Keeps pattern quality high; avoids Mem0-style junk; notes are live source-of-truth elsewhere |
+| CLI | Command verb = **`mur source`** (not `mur link`, not `mur notes`) | Abstract noun matches `KnowledgeSource` trait; future-proof for non-note sources (Slack/Linear/MCP) |
+| Store | LanceDB and Qdrant are **alternative** backends (one active), switch via `mur reindex --vector-backend <B>` | YAGNI; per-table backend future extension noted but not built |
+
+## 3. Architecture
+
+### 3.1 Pipeline
+
+mur's existing four-stage pipeline gains a second input alongside `capture/`:
+
+```
+┌──────────┐    ┌──────────┐
+│ capture  │    │ sources  │  ← new stage
+│ (session │    │ (external│
+│  -> pat) │    │  notes)  │
+└────┬─────┘    └────┬─────┘
+     │               │
+     └───────┬───────┘
+             ↓
+      ┌──────────────┐
+      │   store/     │   patterns yaml  ∥  sources LanceDB/Qdrant
+      └──────┬───────┘
+             ↓
+      ┌──────────────┐
+      │  retrieve/   │   unified corpus query, source-weighted
+      └──────┬───────┘
+             ↓
+      ┌──────────────┐
+      │   inject/    │   formatter: Patterns section + Notes section
+      └──────────────┘
+```
+
+### 3.2 New Rust Modules
+
+```
+mur-core/src/
+├── sources/                    # new
+│   ├── mod.rs                  # KnowledgeSource trait + SourceRegistry
+│   ├── kind.rs                 # SourceKind enum: PullIndex | FederatedQuery (stub)
+│   ├── credentials.rs          # OS keyring wrapper
+│   ├── sync.rs                 # Sync orchestrator (manual/watch/scheduled)
+│   ├── chunker/
+│   │   ├── markdown.rs         # shared Obsidian + Joplin
+│   │   └── notion_blocks.rs    # Notion-specific
+│   └── adapters/
+│       ├── obsidian.rs
+│       ├── notion.rs
+│       └── joplin.rs
+└── store/
+    └── vector/                 # new abstraction layer
+        ├── mod.rs              # VectorStore trait + SearchFilter
+        ├── lancedb.rs          # renamed from store/lancedb.rs
+        └── qdrant.rs           # new
+```
+
+Existing `store/lancedb.rs` (472 lines) becomes `store/vector/lancedb.rs` and its `VectorStore` struct is renamed `LanceDbStore` to free the name for the trait.
+
+### 3.3 Core Traits
+
+```rust
+#[async_trait]
+pub trait KnowledgeSource: Send + Sync {
+    fn id(&self) -> &str;                                 // e.g. "notion:work"
+    fn kind(&self) -> SourceKind;                         // PullIndex | FederatedQuery
+    fn weight(&self) -> f32;
+
+    async fn list_documents(
+        &self,
+        cursor: Option<SyncCursor>,
+    ) -> Result<(Vec<DocRef>, SyncCursor)>;
+
+    async fn fetch(&self, doc_ref: &DocRef) -> Result<Document>;
+    fn chunk(&self, doc: &Document) -> Result<Vec<Chunk>>;
+
+    async fn list_deleted_since(
+        &self,
+        cursor: Option<SyncCursor>,
+    ) -> Result<Vec<String>>;
+}
+
+#[async_trait]
+pub trait VectorStore: Send + Sync {
+    async fn upsert(&self, chunks: &[EmbeddedChunk]) -> Result<()>;
+    async fn search(&self, query_vec: &[f32], k: usize, filter: &SearchFilter) -> Result<Vec<Hit>>;
+    async fn delete_by_external_ids(&self, source_id: &str, ids: &[String]) -> Result<()>;
+    async fn delete_by_source(&self, source_id: &str) -> Result<()>;
+    async fn list_external_ids(&self, source_id: &str) -> Result<Vec<String>>;
+    async fn count(&self, source_id: Option<&str>) -> Result<usize>;
+    async fn rebuild_index(&self) -> Result<()>;
+}
+```
+
+`SourceKind::FederatedQuery` is a stub for Phase 2 (MCP / NotebookLM). Phase 1 only implements `PullIndex`.
+
+## 4. CLI Surface
+
+All new commands live under `mur source <verb>`. No `mur link` alias.
+
+```
+mur source
+├── add <TYPE> [INSTANCE] [flags...]
+├── list [--json] [--verbose]
+├── remove <ID> [--keep-index]
+├── sync [<ID>] [--full] [--watch]
+├── status [<ID>]
+├── weight <ID> <float>
+├── scope <ID> [adapter-specific flags]
+├── test <ID>
+├── reindex <ID> [--vector-backend <B>]
+├── install-schedule         # generate launchd/systemd unit
+└── disable / enable <ID>
+```
+
+### 4.1 Adapter Types as Subcommands
+
+Rather than a `--type` flag, the adapter type is itself a subcommand of `add`. This enables adapter-specific flags with clap's native validation.
+
+```
+mur source add notion [INSTANCE] [--workspace <id>] [--token <pat>]
+mur source add obsidian [INSTANCE] --vault <path> [--exclude-folder <folder>]
+mur source add joplin [INSTANCE] --db <path>
+                            |  --server <url> --token <token>
+```
+
+`INSTANCE` is an optional positional name. Without it, mur auto-generates an ID:
+
+- `mur source add notion` → id = `notion` (first) or `notion:<rand4>` (second+)
+- `mur source add notion work` → id = `notion:work`
+
+### 4.2 Existing Commands, Extended
+
+- **`mur search`** now queries unified corpus. New flags: `--source <id>`, `--type patterns|sources|all` (default `all`), `--only-patterns`, `--only-sources`.
+- **`mur reindex`** now rebuilds both `patterns.lance` and `sources.lance` (or Qdrant collections). Add `--vector-backend <lancedb|qdrant>` to migrate.
+
+### 4.3 Output & Exit Codes
+
+- Table by default (via `comfy-table`), `--json` for machine output, `--quiet` suppresses non-error output.
+- Exit codes: `0` ok, `1` generic, `2` auth, `3` network, `4` config.
+- Long ops use `indicatif` progress bars (existing dep).
+
+### 4.4 Adapter Registry = Closed Set (Phase 1)
+
+`notion | obsidian | joplin` hardcoded as a clap enum in `main.rs`. `SourceRegistry` uses a `match` — no dyn trait factory, no plugin loading. Phase 2 may revisit for MCP / WASM plugins.
+
+## 5. Data Model
+
+### 5.1 Disk Layout
+
+```
+~/.mur/
+├── config.yaml                 # extended: storage, sources_global
+├── patterns/*.yaml             # unchanged
+├── sources/                    # new
+│   ├── notion:work.yaml
+│   ├── obsidian:main.yaml
+│   └── joplin:main.yaml
+├── lancedb/                    # existing when backend=lancedb
+│   ├── patterns.lance
+│   └── sources.lance           # new table
+└── tantivy/                    # new — unified BM25 index
+    └── sources/
+```
+
+Credentials never hit disk. They live in OS keyring (`keyring-rs` crate: macOS Keychain / Linux Secret Service / Windows Credential Manager).
+
+### 5.2 Source Instance YAML
+
+```yaml
+# ~/.mur/sources/notion:work.yaml
+id: notion:work
+type: notion
+enabled: true
+weight: 1.0
+scope:
+  workspace: Engineering
+  include_page_ids: []
+  exclude_tags: [personal]
+sync:
+  last_cursor: "abc123"        # adapter-defined opaque string
+  last_sync_at: 2026-04-20T10:30:00Z
+  last_error: null
+  errors_tail:                 # bounded to last 50
+    - { at: 2026-04-19T09:12Z, doc: "page-abc", msg: "HTTP 502" }
+stats:
+  doc_count: 312
+  chunk_count: 1248
+  indexed_bytes: 892341
+keyring_entry: "mur:notion:work"
+```
+
+Each yaml stays ~1–3 KB regardless of how many documents the source has. Actual document bytes live in the vector store.
+
+### 5.3 Config Schema Extensions
+
+```rust
+// mur-common/src/config.rs
+pub struct Config {
+    // ...existing...
+    #[serde(default)]
+    pub storage: StorageConfig,             // new
+    #[serde(default)]
+    pub sources_global: SourcesGlobalConfig,// new
+}
+
+pub struct StorageConfig {
+    pub vector_backend: String,             // "lancedb" (default) | "qdrant"
+    pub qdrant_url: Option<String>,         // e.g. http://localhost:6333
+    pub qdrant_api_key_ref: Option<String>, // keyring account name
+}
+
+pub struct SourcesGlobalConfig {
+    pub poll_interval_secs: u64,            // default 600
+    pub max_chunks_per_sync: usize,         // default 10_000
+    pub max_parallel_sources: usize,        // default 3
+    pub default_weight: f32,                // default 1.0
+    pub embedding_batch_size: usize,        // default 32
+}
+```
+
+Both structs implement `Default`. Existing users get working defaults on first read — zero-action upgrade.
+
+### 5.4 Core Types (`mur-common/src/sources.rs`)
+
+```rust
+pub struct Document {
+    pub source_id: String,
+    pub external_id: String,       // adapter-native
+    pub title: String,
+    pub body: DocumentBody,
+    pub url: Option<String>,       // deep-link back to source app
+    pub updated_at: DateTime<Utc>,
+    pub tags: Vec<String>,
+    pub metadata: serde_json::Value,
+}
+
+pub enum DocumentBody {
+    Markdown(String),
+    PlainText(String),
+    NotionBlocks(Vec<NotionBlock>),
+}
+
+pub struct Chunk {
+    pub chunk_id: String,          // uuid v4
+    pub source_id: String,
+    pub external_id: String,
+    pub ordinal: usize,
+    pub text: String,              // plaintext for embedding
+    pub heading_path: Vec<String>,
+    pub char_range: (usize, usize),
+    pub updated_at: DateTime<Utc>,
+}
+
+pub struct EmbeddedChunk {
+    pub chunk: Chunk,
+    pub embedding: Vec<f32>,
+}
+
+pub struct Hit {
+    pub chunk_id: String,
+    pub source_id: String,
+    pub score: f32,                // post-weight
+    pub text: String,
+    pub title: String,
+    pub url: Option<String>,
+    pub heading_path: Vec<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+pub struct SearchFilter {
+    pub source_ids: Option<Vec<String>>,   // None = all
+    pub types: SourceTypeSet,              // Patterns | Sources | Both
+    pub since: Option<DateTime<Utc>>,
+}
+```
+
+Uniqueness key across all storage is `(source_id, external_id)`. Adapters are not required to produce globally unique IDs.
+
+## 6. Sync Engine
+
+### 6.1 Triggers
+
+| Mode | Command | Description |
+|------|---------|-------------|
+| Manual | `mur source sync [<id>]` | One-shot; progress bar |
+| Watch | `mur source sync --watch` | Foreground daemon; fsevents + polling; Ctrl+C for clean shutdown |
+| Scheduled | `mur source install-schedule` | Generates `launchd` plist (macOS) or `systemd --user` unit (Linux). mur itself does not fork a long-lived daemon — OS handles scheduling |
+
+### 6.2 Sync Flow (Single Source)
+
+```
+1. Load ~/.mur/sources/<id>.yaml                     → cursor, scope, weight
+2. Fetch credentials from keyring
+3. adapter.list_documents(cursor)                    → (doc_refs, new_cursor)
+4. Batch-process (size = embedding_batch_size):
+   a. adapter.fetch(doc_ref)                         → Document
+   b. adapter.chunk(doc)                             → Vec<Chunk>
+   c. embedding.embed_batch(chunks)                  → Vec<EmbeddedChunk>
+   d. vector_store.upsert(chunks)
+   e. tantivy.index(chunks)                          (for BM25)
+   [cursor advances ONLY on batch success]
+5. Detect deletions via set diff:
+   indexed = vector_store.list_external_ids(source_id)
+   current = set(external_id for doc in adapter.list_documents(None))
+   deleted = indexed - current
+   vector_store.delete_by_external_ids(source_id, deleted)
+   tantivy.delete(deleted)
+6. Atomic write updated yaml (temp file + rename)
+```
+
+### 6.3 Error Handling
+
+- **Resumable**: cursor advances per batch; interrupted sync picks up exactly where it left off.
+- **Per-doc isolation**: one failing doc logs an error into `sync.errors_tail[]` (bounded to 50 entries) but does not abort the sync.
+- **Exponential backoff**: 1s / 2s / 4s / 8s, max 4 retries per doc. HTTP 429 / 503 honor `Retry-After` header.
+- **Rate limiting**: `governor` crate token bucket per-adapter (Notion: 3 req/sec default).
+
+### 6.4 Concurrency
+
+- Within a source: sequential batches (avoid embedding API quota blowouts).
+- Across sources: `tokio::try_join_all`, bounded at `sources_global.max_parallel_sources` (default 3).
+
+### 6.5 Deletion Detection
+
+No sidecar file. Compute `indexed_ids - current_adapter_ids` each sync by querying the vector store. Requires `VectorStore::list_external_ids` (added to trait).
+
+Per-adapter behavior:
+- Obsidian: fsevents drives real-time deletes in `--watch`; sync mode uses set diff.
+- Notion: pages with `archived: true` are excluded from `list_documents`; set diff removes them.
+- Joplin (local DB): `WHERE deleted_time IS NULL` filter; set diff for anything removed.
+- Joplin Server: `/api/items/deleted` endpoint if available, else set diff.
+
+### 6.6 Credentials (OS Keyring)
+
+Keyring schema:
+
+```
+Service:  "mur"
+Account:  "<source_id>:<field>"
+Examples:
+  "notion:work:access_token"
+  "notion:personal:access_token"
+  "joplin:main:api_token"
+```
+
+Obsidian has no credentials (path-based). Keyring library: `keyring-rs`.
+
+### 6.7 OAuth Flow (Notion)
+
+```
+1. User runs `mur source add notion [instance]`
+2. mur spins up an axum server on a random localhost port (reuses server.rs)
+3. Browser opens to Notion OAuth URL (client_id built into binary, PKCE code_challenge)
+4. User authorizes workspace in Notion
+5. Notion redirects to http://localhost:<port>/callback?code=...
+6. mur exchanges code for access_token + workspace info
+7. Keyring gets access_token; yaml stores workspace_id / name
+8. Localhost server shuts down
+9. Shell prints: "Connected to workspace <name>. Run `mur source sync <id>` to index."
+```
+
+Notion access tokens do not expire — no refresh logic. Future OneNote / Google integrations will need refresh; pattern left room for it (no contract change).
+
+mur registers a **public Notion integration** — `client_id` embedded in binary, no `client_secret` (PKCE flow).
+
+**Fallback**: if Notion's public-integration review is pending, users can provide their own Internal Integration Token (PAT) via `mur source add notion --token <pat>`. This skips OAuth entirely, stores the token in keyring, and is treated the same by all downstream code. We ship with this path enabled as an escape hatch. See §13 risks.
+
+## 7. Adapter Specs
+
+### 7.1 Obsidian
+
+| Item | Design |
+|------|--------|
+| Connection | `mur source add obsidian [INSTANCE] --vault <path>` |
+| Auth | None |
+| Validation | `<vault>/.obsidian/` must exist |
+| external_id | Relative path string (`notes/ideas/foo.md`). Rename ⇒ delete+create from mur's view; acceptable Phase 1 trade-off. |
+| URL | `obsidian://open?vault=<encoded_name>&file=<encoded_path>` |
+| Discovery | Recursive `*.md` scan, exclude `.obsidian/`, `.trash/`, user `--exclude-folder` |
+| Chunking | Markdown heading-aware (shared chunker); 1500-token max; paragraph-boundary fallback |
+| Metadata | YAML frontmatter → `Document.tags` + `Document.metadata` |
+| Wikilinks | `[[Other Note]]` and `![[embed.md]]` preserved as plaintext in chunk text |
+| Tags | Inline `#tag` + frontmatter `tags:` merged, deduped |
+| File watcher | `notify::RecommendedWatcher`; debounce 500ms; whitelist `*.md` (ignores `.obsidian/workspace.json` churn) |
+| updated_at | File `mtime` |
+| Deletion | Watch: `Remove` events. Sync: set diff. |
+
+### 7.2 Notion
+
+| Item | Design |
+|------|--------|
+| Connection | `mur source add notion [INSTANCE] [--workspace <id>] [--token <pat>]` |
+| Auth | OAuth 2.0 + PKCE, localhost callback (§6.7) |
+| external_id | Notion page UUID |
+| URL | `https://www.notion.so/<workspace_slug>/<page_id>` |
+| Discovery | `POST /v1/search` with `filter.value="page"`, 100/page |
+| Incremental | `last_edited_time >= <cursor>` filter; cursor = RFC3339 timestamp |
+| Chunking | Block-aware (`notion_blocks.rs`): `heading_1/2/3` boundaries; `code` → markdown fence; `table` → markdown table; `toggle` → expanded content; `callout`/`quote` prefixed |
+| Content | chunk.text = simplified markdown (for embedding); `Document.body = NotionBlocks` (for future fidelity rendering) |
+| Rate limit | `governor` token bucket at 3 req/sec; honor `429 + Retry-After` |
+| Pagination | 100/call, `has_more + next_cursor` |
+| Deletion | `archived: true` pages excluded from `list_documents`; set diff catches |
+
+Scope: `mur source scope notion:work --workspace Engineering --include-page-ids a,b,c --exclude-tag personal`.
+
+**Known limitation (Phase 1)**: database page properties are not indexed — only body blocks.
+
+### 7.3 Joplin
+
+Two modes supported; Web Clipper API excluded (requires Joplin app running — too fragile).
+
+#### 7.3.1 Local SQLite
+
+| Item | Design |
+|------|--------|
+| Connection | `mur source add joplin [INSTANCE] --db <path>` |
+| Default path detection | macOS: `~/Library/Application Support/joplin-desktop/database.sqlite`; Linux: `~/.config/joplin-desktop/database.sqlite` |
+| Auth | File read permission only. `rusqlite` opens read-only with `immutable=true` URI flag to avoid lock conflicts with running Joplin. |
+| external_id | Joplin note UUID (TEXT primary key) |
+| URL | `joplin://x-callback-url/openNote?id=<id>` |
+| Discovery | `SELECT id,title,body,updated_time,parent_id FROM notes WHERE is_conflict=0 AND deleted_time IS NULL` |
+| Incremental | `updated_time > <cursor_epoch_ms>` |
+| Chunking | Body is markdown → shared chunker |
+| Folders | Join `folders` table; `Document.metadata.notebook_path = ["Tech","Architecture"]` |
+| Tags | Join `note_tags` + `tags` tables |
+
+#### 7.3.2 Joplin Server
+
+| Item | Design |
+|------|--------|
+| Connection | `mur source add joplin [INSTANCE] --server <url> --token <token>` |
+| Auth | Bearer token in keyring |
+| API | `/api/items?type=note` paginated; `/api/items/<id>` for body |
+| Remaining | Same chunking, tags, notebooks as Local DB |
+
+Scope: `mur source scope joplin:main --notebook "Tech" --exclude-tag draft`.
+
+### 7.4 Shared Dependencies (Cargo.toml)
+
+```toml
+notify = "6"              # file watcher
+rusqlite = { version = "0.32", features = ["bundled"] }
+oauth2 = "4"              # PKCE
+keyring = "3"             # OS credential store
+governor = "0.7"          # rate limiting
+pulldown-cmark = "0.12"   # markdown parsing
+tantivy = "0.22"          # BM25 index
+qdrant-client = "1.12"    # Qdrant REST+gRPC client
+```
+
+Existing deps (`tokio`, `reqwest`, `serde`, `serde_yaml`, `axum`, `tracing`, `anyhow`, `dialoguer`, `indicatif`) are reused.
+
+## 8. Retrieval Integration
+
+### 8.1 Unified Flow
+
+```
+query (from mur search OR inject trigger)
+  ↓
+embed(query) → query_vec
+  ↓
+┌────────────────────────┬──────────────────────────┐
+│ score_patterns()       │ score_sources()          │
+│ [existing formula]     │ [new, simpler formula]   │
+└───────────┬────────────┴────────────┬─────────────┘
+            ↓                         ↓
+         top k*2                    top k*2
+            └────────────┬────────────┘
+                         ↓
+                 unified re-rank
+                 (apply source_weight)
+                         ↓
+                 floor 0.35 filter
+                         ↓
+                    top k (default 5)
+                         ↓
+          ┌──────────────┴─────────────┐
+          ↓                            ↓
+       mur search                 inject formatter
+```
+
+### 8.2 Scoring Formulas
+
+**Patterns (existing, unchanged)**:
+```
+score = 0.7*vec_sim + 0.3*bm25
+      × recency × effectiveness × importance × time_decay × length_norm
+```
+
+**Sources (new, simpler)**:
+```
+score = 0.7*vec_sim + 0.3*bm25
+      × source_weight × freshness_factor × length_norm
+```
+
+Excluded from source formula: `effectiveness` (no usage data), `importance` (no lifecycle), `time_decay` (replaced by `freshness_factor`).
+
+**`freshness_factor`** = `exp(-age_days / 365)` — gentle annual half-life. Patterns use tier-specific half-lives (14d/90d/365d); source freshness is driven by source app's own `updated_at`, so we don't punish.
+
+**`source_weight`** = value in `<source_id>.yaml:weight`, default 1.0. Multiplicative; no hard filter. To exclude a source entirely: `mur source disable <id>` (sets `enabled: false`).
+
+### 8.3 BM25 Backend Consistency
+
+**Decision**: One unified `tantivy` index, regardless of vector backend (LanceDB or Qdrant).
+
+- LanceDB has an FTS; Qdrant does not.
+- Piggy-backing each backend's native FTS would cause ranking to change on backend swap — breaks the "free choice" promise.
+- tantivy is Rust-native, pure-embedded, ~5–10% disk overhead of chunk corpus.
+- Index location: `~/.mur/tantivy/sources/`.
+- Recovery: if tantivy index is corrupt, rebuild from vector store (text stored in both) via `mur reindex`.
+
+### 8.4 Inject Formatter
+
+AI-session injection separates pattern and source context:
+
+```
+# From your learning history
+
+## Patterns (3)
+
+[Pattern: async-error-handling] (maturity: Stable, confidence: 0.87)
+  When async operations chain, use Result<T,E> + ? rather than...
+
+[Pattern: react-useReducer-when]
+  Prefer useReducer over useState when state transitions form...
+
+## Notes (2)
+
+[Note: Obsidian / Projects / Auth Design.md § "JWT refresh rotation"]
+  URL: obsidian://open?vault=main&file=Projects%2FAuth%20Design.md
+  We decided on 15-min access tokens + 7-day refresh because...
+
+[Note: Notion / Engineering / Q2 Roadmap]
+  URL: https://www.notion.so/...
+  Quarter theme: API versioning + observability...
+```
+
+Rationale:
+1. AI model understands provenance (rule-I-learned vs reference-I-wrote).
+2. URLs let the user click back to source apps for context.
+3. Per-type token caps prevent one category from dominating.
+
+### 8.5 Token Budgets
+
+- Total budget: 2500 tokens (was 2000).
+- Split: max 5 patterns + max 3 notes.
+- Per-chunk truncation: source chunks over 400 tokens get truncated at paragraph boundary, suffixed with `...` and URL.
+
+### 8.6 `mur search` Output
+
+```
+$ mur search "OAuth refresh flow"
+
+Score   Type     ID                                   Title / Heading
+─────   ──────   ──────────────────────────────────   ─────────────────────────
+0.89    note     obsidian:main / Auth Design.md § ... "JWT refresh rotation"
+0.82    pattern  oauth-pkce-localhost                 PKCE for local-app OAuth
+0.76    note     notion:work / Q1-incident-tokens     "token revoke fallout"
+0.71    pattern  refresh-token-rotation               Rotation strategy
+0.64    note     joplin:main / Tech / auth-notes      ...
+
+Flags: --source <id> | --type patterns|sources|all | --json | --only-patterns | --only-sources
+```
+
+### 8.7 Latency Budget
+
+Target p95 < 200 ms end-to-end:
+
+- `embed(query)`: ~50ms cold, ~0ms warm (embedding cache)
+- tantivy BM25: ~5ms
+- Vector search × 2 (patterns + sources, parallel): ~30ms
+- Merge + rank: < 1ms
+- **Total**: ~100ms median, ~180ms p95 — comfortably within hook budget.
+
+### 8.8 Retrieve Module Changes
+
+```
+mur-core/src/retrieve/
+├── mod.rs          # new retrieve_unified() entry
+├── scoring.rs      # existing pattern scoring untouched; new score_sources()
+└── gate.rs         # unchanged
+```
+
+### 8.9 Phase 1 Exclusions (Retrieve)
+
+- Cross-encoder reranking (e.g. Cohere Rerank): +300ms, not worth it for Phase 1.
+- Query expansion / HyDE.
+- Personalization / usage-based weight learning.
+- Snippet highlighting in terminal output.
+
+## 9. Testing Strategy
+
+### 9.1 Unit Tests (per adapter)
+
+- Obsidian: chunker correctness, frontmatter parsing, wikilink preservation, watcher debounce.
+- Notion: block→markdown conversion, OAuth URL construction, pagination cursor handling, rate-limit backoff.
+- Joplin: SQL queries, tag/notebook joins, server API pagination.
+- Target: ≥80% line coverage per adapter module.
+
+### 9.2 Trait Conformance Tests
+
+**`VectorStore` common suite** (`store/vector/tests.rs`) — every impl must pass:
+
+```rust
+#[async_trait]
+pub trait VectorStoreTestSuite {
+    async fn test_upsert_roundtrip();
+    async fn test_search_returns_correct_k();
+    async fn test_delete_by_source_removes_all();
+    async fn test_delete_by_external_ids_preserves_others();
+    async fn test_list_external_ids_completeness();
+}
+
+// Both LanceDbStore and QdrantStore run this suite.
+```
+
+**`KnowledgeSource` + `sync` tests** (`sources/tests.rs`) — mock adapter validates orchestrator:
+
+- `test_sync_resumes_after_crash` — cursor advances correctly post-restart
+- `test_deletion_detected_via_set_diff`
+- `test_per_doc_error_does_not_abort`
+- `test_rate_limit_triggers_backoff`
+
+### 9.3 End-to-End Smoke
+
+- Obsidian: `tempfile` vault → `add` → `sync` → `search` → assert hit.
+- Notion: CI secret `NOTION_TEST_TOKEN`, fixed test workspace.
+- Joplin: committed fixture SQLite.
+
+### 9.4 Retrieve Determinism Tests
+
+Fixed corpus (5 hardcoded patterns + 10 hardcoded source chunks), known query, **assert top-k order**:
+
+```rust
+#[test]
+fn retrieve_unified_mixed_corpus_ordering() { /* ... */ }
+
+#[test]
+fn source_weight_changes_ranking() { /* set weight=2.0, assert note outranks pattern */ }
+
+#[test]
+fn disabled_source_absent_from_results() { /* enabled=false */ }
+```
+
+## 10. Migration Path (Existing Users)
+
+Zero action required on upgrade.
+
+| Change | Effect on existing user |
+|--------|-------------------------|
+| New `config.storage.vector_backend` field | Defaults to `"lancedb"` — matches current behavior |
+| New `config.sources_global` fields | All have sensible defaults |
+| New `~/.mur/sources/` directory | Created on first `mur source add` |
+| New LanceDB `sources.lance` table | Created on first source sync; `patterns.lance` untouched |
+| Existing CLI commands | Behavior identical until the first source is added. `mur search` defaults to `--type all`, but with no sources configured the result set equals today's pattern-only output. Opt-in from the user's side via `mur source add`. |
+
+On first run after upgrade: `mur --version` shows new version; `mur source --help` shows new command tree; everything else works identically.
+
+## 11. Rollout — Phase 1 Sub-Milestones
+
+Phase 1 is large. Split into 4 independently-shippable milestones.
+
+### P1.1 — Foundation (Est. 1–2 weeks)
+
+- Refactor existing `VectorStore` struct → rename `LanceDbStore`; extract trait.
+- Add `KnowledgeSource` trait skeleton (no adapter impls yet).
+- `sources/` module skeleton + yaml IO.
+- Config schema extensions (backward compatible).
+- `VectorStore` common test suite. All existing pattern behavior still green.
+- **No user-facing features** — `mur source` commands gated behind feature flag.
+
+### P1.2 — Obsidian Adapter (Est. 1 week)
+
+- `sources/adapters/obsidian.rs` + shared markdown chunker.
+- `mur source add obsidian / sync / list / remove / status / test` working.
+- Basic file watcher (not yet full `--watch` mode).
+- E2E test with temp vault.
+- **Delivers**: `mur source add obsidian --vault ~/Vault`; `mur search` returns Obsidian hits.
+
+### P1.3 — Retrieve Integration + Qdrant (Est. 1–2 weeks)
+
+- Unified retrieve (`retrieve/mod.rs` additions, source scoring).
+- tantivy BM25 index.
+- Inject formatter with Notes section.
+- `QdrantStore` impl (passes common suite).
+- `mur reindex --vector-backend <B>`.
+- **Delivers**: full retrieve story; user can swap to Qdrant.
+
+### P1.4 — Notion + Joplin + Watch + Schedule (Est. 2 weeks)
+
+- `sources/adapters/notion.rs` (OAuth + block chunker + rate limit).
+- `sources/adapters/joplin.rs` (Local DB + Server modes).
+- Full `--watch` mode (cloud polling + Obsidian fsevents).
+- `mur source install-schedule` (launchd / systemd unit generators).
+- Docs & release notes.
+- **Delivers**: Phase 1 complete.
+
+**Total time**: 5–7 weeks at 1 FTE.
+
+### Descope Priority (if Timeline Compresses)
+
+1. `install-schedule` (drop; doc manual cron instead)
+2. Joplin Server mode (drop; keep Local DB only)
+3. `--watch` mode (drop; manual sync only)
+4. Qdrant backend (drop; LanceDB only)
+5. Notion adapter (drop; ship Obsidian + Joplin only — last resort)
+
+Tantivy and trait conformance tests are non-negotiable — they guard quality.
+
+## 12. Documentation Updates (per CLAUDE.md checklist)
+
+- `README.md` — new `mur source` section with usage examples.
+- `docs/sources.md` — new — adapter deep-dive + troubleshooting.
+- `CLAUDE.md` — update architecture section (add `sources/` pipeline stage).
+- `mur-server/dashboard/docs-content/` — sources chapter.
+- `mur-server/dashboard/src/components/docs/coreNavigation.tsx` — menu entry.
+- `mur-server/dashboard/src/app/products/core/page.tsx` — feature bullet.
+
+## 13. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Notion public-integration OAuth app approval / quota | Medium | High | Both paths are supported from day 1 (§6.7): public OAuth for the common case, user-provided PAT as manual escape hatch. If approval stalls or rate limits bite, users can continue via PAT. |
+| Tantivy learning curve | Medium | Medium | Ship minimal BM25 first (title + text); rely on `tantivy` crate examples; prepare fallback to LanceDB FTS if needed. |
+| macOS fsevents storm from `.obsidian/workspace.json` churn | High | Low | Whitelist filter: only `*.md` events reach handler. |
+| Qdrant local install UX friction | Medium | Medium | Provide `docker-compose.yml` sample; default remains LanceDB. |
+| Large vault set-diff slowness (>50k chunks) | Low | Medium | Measure; if slow, switch to incremental deletion events via watcher for that adapter. |
+
+## 14. Observability (Phase 1 minimal)
+
+- Existing `tracing` infrastructure.
+- Structured events in sync loop: `sync.start`, `sync.batch`, `sync.doc_success`, `sync.doc_error`, `sync.deletions`, `sync.complete`.
+- `RUST_LOG=mur_core::sources=debug` reveals detail.
+- `mur source status <id>` surfaces key metrics for interactive debugging.
+- Rolling log at `~/.mur/logs/sources.log` (7-day retention).
+- **No network telemetry added** in Phase 1.
+
+## 15. Explicit Non-Goals / Phase 2+
+
+These are intentionally out of scope:
+
+- Bidirectional sync (writing patterns back into Obsidian/Notion).
+- Pattern extraction from notes (`mur learn from-source`) — Q7 decision A.
+- Additional adapters: OneNote, Apple Notes, Notability, NotebookLM.
+- MCP client (`SourceKind::FederatedQuery` adapters).
+- Per-table vector backends (patterns → LanceDB, sources → Qdrant split).
+- Shared / team source subscriptions (`mur source share / publish`).
+- Web UI for source management.
+- `mur link` / `mur connect` command aliases.
+- Cross-encoder reranking, HyDE, personalization.
+- Canvas (`.canvas`) files in Obsidian.
+- Notion database property indexing.
+
+Future extensions are accommodated without breaking changes:
+- `KnowledgeSource` trait already defines `SourceKind::FederatedQuery` variant for MCP.
+- `Pattern.source_ref: Option<SourceRef>` (reserved) for future note→pattern extraction.
+- `StorageConfig` split into `patterns_backend` / `sources_backend` is a single-field addition.
+
+---
+
+## Appendix A — Decision Log
+
+| Q | Question | Options | Chosen | Date |
+|---|----------|---------|--------|------|
+| 1 | Primary use-case for note app integration | Inject / Search / Learn / Bidi | **Search** | 2026-04-20 |
+| 2 | Indexing mode | Local / Federated / Hybrid | **Local** | 2026-04-20 |
+| 3 | Retrieve corpus boundary | Isolated / Unified / Per-source opt-in | **Unified + per-source scope/weight** | 2026-04-20 |
+| 4 | Phase 1 adapters | Permutations | **Obsidian + Notion + Joplin** | 2026-04-20 |
+| 5 | MCP / NotebookLM strategy | Now / Later / Trait-stub | **Trait-stub (Phase 2 impl)** | 2026-04-20 |
+| 6 | VectorStore backends | Single / Multiple | **LanceDB + Qdrant trait-abstracted** | 2026-04-20 |
+| 7 | Source → pattern extraction | Strict / Opt-in / Auto | **Strict (Phase 1)** | 2026-04-20 |
+| CLI | Command verb | `link` / `source` / `notes` / `connect` | **`mur source`** | 2026-04-20 |
+| Store | Dual vector backend lifecycle | Both-active / Either / Split | **Either (single active)** | 2026-04-20 |

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -246,6 +246,8 @@ pub struct ConversationsConfig {
     pub sources: ConversationsSources,
     #[serde(default)]
     pub filter: ConversationsFilter,
+    #[serde(default)]
+    pub compact: CompactConfig,
 }
 
 impl Default for ConversationsConfig {
@@ -256,6 +258,7 @@ impl Default for ConversationsConfig {
             poll_interval_secs: conv_default_poll_interval(),
             sources: ConversationsSources::default(),
             filter: ConversationsFilter::default(),
+            compact: CompactConfig::default(),
         }
     }
 }
@@ -271,6 +274,72 @@ fn conv_truthy() -> bool {
 }
 fn conv_default_dedup() -> f64 {
     0.85
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompactConfig {
+    #[serde(default = "conv_truthy")]
+    pub enabled_in_daemon: bool,
+    #[serde(default = "compact_default_max_days")]
+    pub max_days_per_run: u32,
+    #[serde(default = "compact_default_model")]
+    pub extractive_model: String,
+    #[serde(default = "compact_default_model")]
+    pub abstractive_model: String,
+    #[serde(default = "compact_default_ollama_endpoint")]
+    pub ollama_endpoint: String,
+    #[serde(default = "compact_default_max_spans")]
+    pub max_extractive_spans: u32,
+    #[serde(default = "compact_default_max_words")]
+    pub max_abstractive_words: u32,
+    #[serde(default = "compact_default_chunk_tokens")]
+    pub chunk_tokens: u32,
+    #[serde(default = "compact_default_history_retain")]
+    pub history_retain: u32,
+    #[serde(default = "compact_default_cron")]
+    pub daemon_cron: String,
+}
+
+impl Default for CompactConfig {
+    fn default() -> Self {
+        Self {
+            enabled_in_daemon: true,
+            max_days_per_run: compact_default_max_days(),
+            extractive_model: compact_default_model(),
+            abstractive_model: compact_default_model(),
+            ollama_endpoint: compact_default_ollama_endpoint(),
+            max_extractive_spans: compact_default_max_spans(),
+            max_abstractive_words: compact_default_max_words(),
+            chunk_tokens: compact_default_chunk_tokens(),
+            history_retain: compact_default_history_retain(),
+            daemon_cron: compact_default_cron(),
+        }
+    }
+}
+
+fn compact_default_max_days() -> u32 {
+    7
+}
+fn compact_default_model() -> String {
+    "qwen3:14b".into()
+}
+fn compact_default_ollama_endpoint() -> String {
+    "http://localhost:11434".into()
+}
+fn compact_default_max_spans() -> u32 {
+    20
+}
+fn compact_default_max_words() -> u32 {
+    400
+}
+fn compact_default_chunk_tokens() -> u32 {
+    6000
+}
+fn compact_default_history_retain() -> u32 {
+    5
+}
+fn compact_default_cron() -> String {
+    "0 3 * * *".into()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -394,5 +463,36 @@ foo: bar
             .map(|x| serde_yaml::from_value(x).unwrap_or_default())
             .unwrap_or_default();
         assert_eq!(conv.retention_days, 30);
+    }
+
+    #[test]
+    fn compact_config_defaults() {
+        let c = CompactConfig::default();
+        assert!(c.enabled_in_daemon);
+        assert_eq!(c.max_days_per_run, 7);
+        assert_eq!(c.extractive_model, "qwen3:14b");
+        assert_eq!(c.abstractive_model, "qwen3:14b");
+        assert_eq!(c.ollama_endpoint, "http://localhost:11434");
+        assert_eq!(c.max_extractive_spans, 20);
+        assert_eq!(c.max_abstractive_words, 400);
+        assert_eq!(c.chunk_tokens, 6000);
+        assert_eq!(c.history_retain, 5);
+        assert_eq!(c.daemon_cron, "0 3 * * *");
+    }
+
+    #[test]
+    fn compact_parses_partial_overrides() {
+        let y = r#"
+conversations:
+  compact:
+    max_days_per_run: 3
+    extractive_model: qwen3:4b
+"#;
+        let v: serde_yaml::Value = serde_yaml::from_str(y).unwrap();
+        let conv: ConversationsConfig = serde_yaml::from_value(v["conversations"].clone()).unwrap();
+        assert_eq!(conv.compact.max_days_per_run, 3);
+        assert_eq!(conv.compact.extractive_model, "qwen3:4b");
+        assert!(conv.compact.enabled_in_daemon); // default preserved
+        assert_eq!(conv.compact.abstractive_model, "qwen3:14b"); // default preserved
     }
 }

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -339,7 +339,7 @@ fn compact_default_history_retain() -> u32 {
     5
 }
 fn compact_default_cron() -> String {
-    "0 3 * * *".into()
+    "0 0 3 * * * *".into()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -477,7 +477,7 @@ foo: bar
         assert_eq!(c.max_abstractive_words, 400);
         assert_eq!(c.chunk_tokens, 6000);
         assert_eq!(c.history_retain, 5);
-        assert_eq!(c.daemon_cron, "0 3 * * *");
+        assert_eq!(c.daemon_cron, "0 0 3 * * * *");
     }
 
     #[test]

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -29,6 +29,7 @@ anyhow = { workspace = true }
 async-trait = "0.1"
 fs2 = "0.4"
 walkdir = "2"
+aho-corasick = "1"
 thiserror = { workspace = true }
 dirs = "6"
 sha2 = "0.10"

--- a/mur-core/src/cmd/conversations_cmd.rs
+++ b/mur-core/src/cmd/conversations_cmd.rs
@@ -380,3 +380,65 @@ fn truncate(s: &str, max: usize) -> String {
         format!("{}…", c.iter().take(max).collect::<String>())
     }
 }
+
+pub struct CompactArgs {
+    pub date: Option<String>,
+    pub since: Option<String>,
+    pub force: bool,
+    pub if_stale: bool,
+    pub max_days: Option<u32>,
+    pub extractive_only: bool,
+    pub debug_prompt: bool,
+}
+
+pub async fn cmd_conversations_compact(args: CompactArgs) -> Result<()> {
+    use crate::conversations::summarize;
+    use chrono::NaiveDate;
+
+    let config = crate::store::config::load_config().unwrap_or_default();
+    let mut cfg = config.conversations.compact.clone();
+
+    if args.extractive_only {
+        // Crude guard rail: no abstractive model.
+        cfg.abstractive_model = String::new();
+    }
+    if args.debug_prompt {
+        eprintln!("(debug_prompt not yet wired to individual stages; enabling in Phase 2C)");
+    }
+
+    if let Some(d) = args.date {
+        let date = NaiveDate::parse_from_str(&d, "%Y-%m-%d")?;
+        let force = args.force || args.if_stale;
+        let r = summarize::compact_day(date, force, &cfg, None).await?;
+        println!(
+            "{date}: {:?} ({} spans, {}ms)",
+            r.outcome, r.extractive_spans, r.duration_ms
+        );
+        return Ok(());
+    }
+
+    let since = args
+        .since
+        .as_deref()
+        .map(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d"))
+        .transpose()?;
+
+    let report =
+        summarize::compact_missing(&cfg, since, args.if_stale, args.max_days, None).await?;
+
+    if report.day_reports.is_empty() {
+        println!("(nothing to compact)");
+        return Ok(());
+    }
+    for r in &report.day_reports {
+        println!(
+            "  {} {:?} ({} spans, {}ms)",
+            r.date, r.outcome, r.extractive_spans, r.duration_ms
+        );
+    }
+    println!(
+        "done: {} ok, {} failed, {} skipped",
+        report.ok, report.err, report.skipped
+    );
+    Ok(())
+}

--- a/mur-core/src/cmd/conversations_cmd.rs
+++ b/mur-core/src/cmd/conversations_cmd.rs
@@ -203,7 +203,7 @@ pub async fn cmd_conversations_reindex() -> Result<()> {
     Ok(())
 }
 
-pub fn cmd_conversations_doctor() -> Result<()> {
+pub async fn cmd_conversations_doctor() -> Result<()> {
     println!("conversations doctor");
     let dirs = conversations::store::list_raw_dirs(None).unwrap_or_default();
     println!("  ✓ raw day-dirs: {}", dirs.len());
@@ -216,6 +216,70 @@ pub fn cmd_conversations_doctor() -> Result<()> {
         "  {} conversations.enabled",
         if enabled { "✓" } else { "·" }
     );
+
+    // Phase 2A additions
+    let raw_dir = conversations::paths::raw_root(None);
+    let summary_dir = conversations::paths::conversations_root(None).join("summary");
+    let raw_days: Vec<_> = std::fs::read_dir(&raw_dir)
+        .ok()
+        .map(|rd| {
+            rd.flatten()
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .collect()
+        })
+        .unwrap_or_default();
+    let summary_count = std::fs::read_dir(&summary_dir)
+        .ok()
+        .map(|rd| {
+            rd.flatten()
+                .filter(|e| {
+                    e.path()
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s == "md")
+                        .unwrap_or(false)
+                })
+                .count()
+        })
+        .unwrap_or(0);
+
+    let today = chrono::Utc::now().date_naive();
+    let completed_days: Vec<&String> = raw_days
+        .iter()
+        .filter(|d| {
+            chrono::NaiveDate::parse_from_str(d, "%Y-%m-%d")
+                .map(|pd| pd < today)
+                .unwrap_or(false)
+        })
+        .collect();
+    let missing = completed_days.len().saturating_sub(summary_count);
+    if missing == 0 {
+        println!("  ✓ summaries: all {summary_count} completed days covered");
+    } else {
+        println!(
+            "  ⚠ summaries: {summary_count} of {} completed days covered — run 'mur conversations compact'",
+            completed_days.len()
+        );
+    }
+
+    // Ollama reachability (non-blocking 1s probe)
+    let cfg = crate::store::config::load_config().unwrap_or_default();
+    let endpoint = cfg.conversations.compact.ollama_endpoint.clone();
+    let reachable = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        reqwest::get(format!("{}/api/tags", endpoint.trim_end_matches('/'))),
+    )
+    .await
+    .ok()
+    .and_then(|r| r.ok())
+    .map(|r| r.status().is_success())
+    .unwrap_or(false);
+    if reachable {
+        println!("  ✓ Ollama reachable at {endpoint}");
+    } else {
+        println!("  · Ollama not reachable at {endpoint} (compact + ask will degrade)");
+    }
+
     Ok(())
 }
 

--- a/mur-core/src/conversations/index.rs
+++ b/mur-core/src/conversations/index.rs
@@ -68,7 +68,22 @@ impl ConversationIndex {
         ])
     }
 
-    pub async fn upsert(&mut self, entries: &[(Message, Vec<f32>)]) -> Result<()> {
+    /// Upsert with an explicit `layer` value per entry. Phase 2A uses this for
+    /// summary rows (layer=1); existing raw writes continue via `upsert()`
+    /// which keeps layer=0 for backward compatibility.
+    pub async fn upsert_with_layer(&mut self, entries: &[(Message, Vec<f32>, i8)]) -> Result<()> {
+        self.upsert_internal(entries).await
+    }
+
+    pub async fn upsert(&mut self, batch: &[(Message, Vec<f32>)]) -> Result<()> {
+        let with_layer: Vec<(Message, Vec<f32>, i8)> = batch
+            .iter()
+            .map(|(m, v)| (m.clone(), v.clone(), 0))
+            .collect();
+        self.upsert_internal(&with_layer).await
+    }
+
+    async fn upsert_internal(&mut self, entries: &[(Message, Vec<f32>, i8)]) -> Result<()> {
         let _span = info_span!("conversations.index.upsert", count = entries.len()).entered();
         if entries.is_empty() {
             return Ok(());
@@ -79,30 +94,33 @@ impl ConversationIndex {
         let ids: Vec<String> = entries
             .iter()
             .enumerate()
-            .map(|(i, (m, _))| format!("{}_{}_{}", m.src.file_prefix(), m.conv, i))
+            .map(|(i, (m, _, _))| format!("{}_{}_{}", m.src.file_prefix(), m.conv, i))
             .collect();
-        let tss: Vec<i64> = entries.iter().map(|(m, _)| m.ts.timestamp()).collect();
-        let srcs: Vec<&str> = entries.iter().map(|(m, _)| m.src.file_prefix()).collect();
-        let convs: Vec<&str> = entries.iter().map(|(m, _)| m.conv.as_str()).collect();
+        let tss: Vec<i64> = entries.iter().map(|(m, _, _)| m.ts.timestamp()).collect();
+        let srcs: Vec<&str> = entries
+            .iter()
+            .map(|(m, _, _)| m.src.file_prefix())
+            .collect();
+        let convs: Vec<&str> = entries.iter().map(|(m, _, _)| m.conv.as_str()).collect();
         let roles: Vec<&'static str> = entries
             .iter()
-            .map(|(m, _)| match m.role {
+            .map(|(m, _, _)| match m.role {
                 mur_common::Role::User => "user",
                 mur_common::Role::Assistant => "assistant",
                 mur_common::Role::System => "system",
                 mur_common::Role::Tool => "tool",
             })
             .collect();
-        let layers: Vec<i8> = entries.iter().map(|_| 0_i8).collect();
+        let layers: Vec<i8> = entries.iter().map(|(_, _, l)| *l).collect();
         let contents: Vec<String> = entries
             .iter()
-            .map(|(m, _)| m.content.as_text().to_owned())
+            .map(|(m, _, _)| m.content.as_text().to_owned())
             .collect();
         let content_refs: Vec<&str> = contents.iter().map(|s| s.as_str()).collect();
 
         let flat: Vec<f32> = entries
             .iter()
-            .flat_map(|(_, v)| v.iter().copied())
+            .flat_map(|(_, v, _)| v.iter().copied())
             .collect();
         let vec_arr = FixedSizeListArray::try_new(
             Arc::new(Field::new("item", DataType::Float32, true)),
@@ -149,11 +167,13 @@ impl ConversationIndex {
         query_vec: &[f32],
         limit: usize,
         source_filter: Option<Source>,
+        layer: Option<i8>,
     ) -> Result<Vec<SearchHit>> {
         let _span = info_span!(
             "conversations.index.search",
             k = limit,
-            source = ?source_filter
+            source = ?source_filter,
+            layer = ?layer
         )
         .entered();
         let tables = self.db.table_names().execute().await?;
@@ -162,9 +182,15 @@ impl ConversationIndex {
         }
         let table = self.db.open_table(TABLE).execute().await?;
         let mut q = table.query().nearest_to(query_vec)?.limit(limit);
-        if let Some(s) = source_filter {
-            q = q.only_if(format!("source = '{}'", s.file_prefix()));
+
+        let predicates: Vec<String> = std::iter::empty::<String>()
+            .chain(source_filter.map(|s| format!("source = '{}'", s.file_prefix())))
+            .chain(layer.map(|l| format!("layer = {l}")))
+            .collect();
+        if !predicates.is_empty() {
+            q = q.only_if(predicates.join(" AND "));
         }
+
         let stream = q.execute().await?;
         let batches: Vec<RecordBatch> = stream.try_collect().await?;
         let mut out = Vec::new();
@@ -272,7 +298,7 @@ mod tests {
             (msg("b", "yaml parsing worked"), vec![0.0; 16]),
         ];
         idx.upsert(&entries).await.unwrap();
-        let hits = idx.search(&[1.0; 16], 2, None).await.unwrap();
+        let hits = idx.search(&[1.0; 16], 2, None, None).await.unwrap();
         assert!(!hits.is_empty());
         assert_eq!(hits[0].conv_id, "a");
     }
@@ -289,9 +315,36 @@ mod tests {
             .await
             .unwrap();
         let hits = idx
-            .search(&[1.0; 16], 10, Some(Source::Slack))
+            .search(&[1.0; 16], 10, Some(Source::Slack), None)
             .await
             .unwrap();
         assert!(hits.iter().all(|h| h.source == Source::Slack));
+    }
+
+    #[tokio::test]
+    async fn search_filters_by_layer() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let mut idx = ConversationIndex::open(16, Some(root)).await.unwrap();
+
+        let a = msg("a", "layer zero item"); // raw → layer 0
+        let b = msg("b", "layer one item"); // summary → layer 1
+        idx.upsert_with_layer(&[(a, vec![1.0; 16], 0)])
+            .await
+            .unwrap();
+        idx.upsert_with_layer(&[(b, vec![1.0; 16], 1)])
+            .await
+            .unwrap();
+
+        let hits_all = idx.search(&[1.0; 16], 10, None, None).await.unwrap();
+        assert_eq!(hits_all.len(), 2);
+
+        let hits_l1 = idx.search(&[1.0; 16], 10, None, Some(1)).await.unwrap();
+        assert_eq!(hits_l1.len(), 1);
+        assert_eq!(hits_l1[0].conv_id, "b");
+
+        let hits_l0 = idx.search(&[1.0; 16], 10, None, Some(0)).await.unwrap();
+        assert_eq!(hits_l0.len(), 1);
+        assert_eq!(hits_l0[0].conv_id, "a");
     }
 }

--- a/mur-core/src/conversations/migrate.rs
+++ b/mur-core/src/conversations/migrate.rs
@@ -568,7 +568,12 @@ pub fn sync_commander_config_toml(
         let before = &existing[..b];
         let after_marker = e + CONV_MARKER_CLOSE.len();
         let after = &existing[after_marker..];
-        format!("{}{}{}", before.trim_end_matches('\n'), new_block, after)
+        format!(
+            "{}{}{}",
+            before.trim_end_matches('\n'),
+            new_block,
+            after.trim_start_matches('\n'),
+        )
     } else {
         format!("{}{}", existing.trim_end_matches('\n'), new_block)
     };
@@ -805,5 +810,37 @@ mod tests {
         assert!(toml.contains("enabled_in_daemon = true"));
         assert!(toml.contains("daemon_cron = \"0 4 * * *\""));
         assert!(toml.contains("[engine]"));
+    }
+
+    #[test]
+    fn sync_is_idempotent_on_repeat_calls() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cmdr_dir = tmp.path().join(".mur/commander");
+        std::fs::create_dir_all(&cmdr_dir).unwrap();
+        std::fs::write(cmdr_dir.join("config.toml"), "[engine]\nfoo = 1\n").unwrap();
+        let cfg = mur_common::config::ConversationsConfig {
+            enabled: true,
+            retention_days: 30,
+            compact: mur_common::config::CompactConfig {
+                enabled_in_daemon: true,
+                daemon_cron: "0 4 * * *".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        // First sync
+        sync_commander_config_toml(&tmp.path().join(".mur"), &cfg).unwrap();
+        let after_first = std::fs::read_to_string(cmdr_dir.join("config.toml")).unwrap();
+        // Second sync with identical config
+        sync_commander_config_toml(&tmp.path().join(".mur"), &cfg).unwrap();
+        let after_second = std::fs::read_to_string(cmdr_dir.join("config.toml")).unwrap();
+        assert_eq!(
+            after_first, after_second,
+            "sync must be idempotent — second call must produce identical bytes:\nfirst:\n{after_first}\nsecond:\n{after_second}"
+        );
+        // Third sync (belt-and-braces)
+        sync_commander_config_toml(&tmp.path().join(".mur"), &cfg).unwrap();
+        let after_third = std::fs::read_to_string(cmdr_dir.join("config.toml")).unwrap();
+        assert_eq!(after_second, after_third);
     }
 }

--- a/mur-core/src/conversations/migrate.rs
+++ b/mur-core/src/conversations/migrate.rs
@@ -281,7 +281,15 @@ pub async fn run(home_override: Option<&str>) -> Result<MigrationReport> {
     std::fs::rename(&staging, &final_path)?;
 
     // 7. P4 amendment — sync commander's config.toml from mur's config.yaml
-    sync_commander_config_toml(&mur)?;
+    let mur_cfg_path = mur.join("config.yaml");
+    let cfg = if let Ok(text) = std::fs::read_to_string(&mur_cfg_path) {
+        serde_yaml::from_str::<mur_common::config::Config>(&text)
+            .unwrap_or_default()
+            .conversations
+    } else {
+        mur_common::config::ConversationsConfig::default()
+    };
+    sync_commander_config_toml(&mur, &cfg)?;
 
     let audit_entries_replayed = 1; // Only the bridge entry; commander chain stays untouched
     Ok(MigrationReport {
@@ -522,54 +530,49 @@ fn append_rollback_entry(path: &std::path::Path, count: u64) -> Result<()> {
     Ok(())
 }
 
-/// P4 amendment: write `[conversations]` block to commander's config.toml
-/// mirroring mur's config.yaml conversations.{enabled,retention_days}. Idempotent
+/// P4 amendment: write `[conversations]` and `[conversations.compact]` blocks
+/// to commander's config.toml, mirroring mur's config.yaml. Idempotent
 /// via marker-delimited block.
-///
-/// `fs_available_bytes` returns None (treated as unlimited) in Phase 1 — a
-/// proper statvfs wrapper lands in a later task.
-fn sync_commander_config_toml(mur: &std::path::Path) -> Result<()> {
-    let mur_cfg = mur.join("config.yaml");
-    let (enabled, retention_days) = if let Ok(text) = std::fs::read_to_string(&mur_cfg) {
-        if let Ok(doc) = serde_yaml::from_str::<serde_yaml::Value>(&text) {
-            let c = doc.get("conversations");
-            let e = c
-                .and_then(|c| c.get("enabled"))
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            let r = c
-                .and_then(|c| c.get("retention_days"))
-                .and_then(|v| v.as_u64())
-                .unwrap_or(30) as u32;
-            (e, r)
-        } else {
-            (false, 30)
-        }
-    } else {
-        (false, 30)
-    };
-    let cmdr_cfg = mur.join("commander/config.toml");
-    std::fs::create_dir_all(cmdr_cfg.parent().unwrap())?;
+pub fn sync_commander_config_toml(
+    mur_dir: &std::path::Path,
+    cfg: &mur_common::config::ConversationsConfig,
+) -> Result<()> {
+    let cmdr_cfg = mur_dir.join("commander/config.toml");
+    if let Some(parent) = cmdr_cfg.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     let existing = std::fs::read_to_string(&cmdr_cfg).unwrap_or_default();
-    let merged = if existing.contains(CONV_MARKER_OPEN) && existing.contains(CONV_MARKER_CLOSE) {
-        // Replace the block between markers (idempotent).
-        let start = existing.find(CONV_MARKER_OPEN).unwrap();
-        let end_idx = existing.find(CONV_MARKER_CLOSE).unwrap() + CONV_MARKER_CLOSE.len();
-        let mut out = String::with_capacity(existing.len());
-        out.push_str(&existing[..start]);
-        out.push_str(CONV_MARKER_OPEN);
-        out.push('\n');
-        out.push_str("[conversations]\n");
-        out.push_str(&format!("enabled = {enabled}\n"));
-        out.push_str(&format!("retention_days = {retention_days}\n"));
-        out.push_str(CONV_MARKER_CLOSE);
-        out.push_str(&existing[end_idx..]);
-        out
+
+    let new_block = format!(
+        "\n{}\n\
+         [conversations]\n\
+         enabled = {}\n\
+         retention_days = {}\n\
+         \n\
+         [conversations.compact]\n\
+         enabled_in_daemon = {}\n\
+         daemon_cron = \"{}\"\n\
+         {}\n",
+        CONV_MARKER_OPEN,
+        cfg.enabled,
+        cfg.retention_days,
+        cfg.compact.enabled_in_daemon,
+        cfg.compact.daemon_cron,
+        CONV_MARKER_CLOSE,
+    );
+
+    let merged = if let (Some(b), Some(e)) = (
+        existing.find(CONV_MARKER_OPEN),
+        existing.find(CONV_MARKER_CLOSE),
+    ) {
+        let before = &existing[..b];
+        let after_marker = e + CONV_MARKER_CLOSE.len();
+        let after = &existing[after_marker..];
+        format!("{}{}{}", before.trim_end_matches('\n'), new_block, after)
     } else {
-        format!(
-            "{existing}\n{CONV_MARKER_OPEN}\n[conversations]\nenabled = {enabled}\nretention_days = {retention_days}\n{CONV_MARKER_CLOSE}\n"
-        )
+        format!("{}{}", existing.trim_end_matches('\n'), new_block)
     };
+
     std::fs::write(&cmdr_cfg, merged)?;
     Ok(())
 }
@@ -775,5 +778,32 @@ mod tests {
             "missing retention_days=45: {toml}"
         );
         assert!(toml.contains("[engine]"), "must preserve other sections");
+    }
+
+    #[test]
+    fn sync_writes_conversations_compact_subsection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cmdr_dir = tmp.path().join(".mur/commander");
+        std::fs::create_dir_all(&cmdr_dir).unwrap();
+        std::fs::write(cmdr_dir.join("config.toml"), "[engine]\nfoo = 1\n").unwrap();
+        let cfg = mur_common::config::ConversationsConfig {
+            enabled: true,
+            retention_days: 30,
+            compact: mur_common::config::CompactConfig {
+                enabled_in_daemon: true,
+                daemon_cron: "0 4 * * *".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        sync_commander_config_toml(&tmp.path().join(".mur"), &cfg).unwrap();
+        let toml = std::fs::read_to_string(cmdr_dir.join("config.toml")).unwrap();
+        assert!(toml.contains("[conversations]"));
+        assert!(toml.contains("enabled = true"));
+        assert!(toml.contains("retention_days = 30"));
+        assert!(toml.contains("[conversations.compact]"));
+        assert!(toml.contains("enabled_in_daemon = true"));
+        assert!(toml.contains("daemon_cron = \"0 4 * * *\""));
+        assert!(toml.contains("[engine]"));
     }
 }

--- a/mur-core/src/conversations/migrate.rs
+++ b/mur-core/src/conversations/migrate.rs
@@ -796,7 +796,7 @@ mod tests {
             retention_days: 30,
             compact: mur_common::config::CompactConfig {
                 enabled_in_daemon: true,
-                daemon_cron: "0 4 * * *".into(),
+                daemon_cron: "0 0 4 * * * *".into(),
                 ..Default::default()
             },
             ..Default::default()
@@ -808,7 +808,7 @@ mod tests {
         assert!(toml.contains("retention_days = 30"));
         assert!(toml.contains("[conversations.compact]"));
         assert!(toml.contains("enabled_in_daemon = true"));
-        assert!(toml.contains("daemon_cron = \"0 4 * * *\""));
+        assert!(toml.contains("daemon_cron = \"0 0 4 * * * *\""));
         assert!(toml.contains("[engine]"));
     }
 
@@ -823,7 +823,7 @@ mod tests {
             retention_days: 30,
             compact: mur_common::config::CompactConfig {
                 enabled_in_daemon: true,
-                daemon_cron: "0 4 * * *".into(),
+                daemon_cron: "0 0 4 * * * *".into(),
                 ..Default::default()
             },
             ..Default::default()

--- a/mur-core/src/conversations/mod.rs
+++ b/mur-core/src/conversations/mod.rs
@@ -15,6 +15,13 @@ pub mod retrieve;
 pub mod store;
 pub mod summarize;
 
+/// Shared test-only mutex serializing mutation of the process environment
+/// (MUR_OLLAMA_MOCK). Both `ollama::tests` and `summarize::extractive::tests`
+/// modify the same var; `cargo test` runs tests in parallel threads and
+/// without a single crate-wide guard the tests clobber each other.
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Read mur's config.yaml `conversations.enabled` flag. Defaults to `false`
 /// when the file is missing or the key is absent — keeping legacy behavior
 /// untouched for users who haven't opted in yet.

--- a/mur-core/src/conversations/mod.rs
+++ b/mur-core/src/conversations/mod.rs
@@ -8,6 +8,7 @@ pub mod blob;
 pub mod index;
 pub mod ingest;
 pub mod migrate;
+pub mod ollama;
 pub mod paths;
 pub mod retention;
 pub mod retrieve;

--- a/mur-core/src/conversations/mod.rs
+++ b/mur-core/src/conversations/mod.rs
@@ -13,6 +13,7 @@ pub mod paths;
 pub mod retention;
 pub mod retrieve;
 pub mod store;
+pub mod summarize;
 
 /// Read mur's config.yaml `conversations.enabled` flag. Defaults to `false`
 /// when the file is missing or the key is absent — keeping legacy behavior

--- a/mur-core/src/conversations/ollama.rs
+++ b/mur-core/src/conversations/ollama.rs
@@ -201,13 +201,8 @@ fn mock_generate(req: &GenerateRequest<'_>) -> GenerateResponse {
 
 #[cfg(test)]
 mod tests {
+    use super::super::ENV_LOCK;
     use super::*;
-    use std::sync::Mutex;
-
-    // Serialize env-var mutation across the three tests below. Rust 2024 made
-    // set_var/remove_var unsafe precisely because the process env is shared
-    // across threads, and cargo test runs cases concurrently by default.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]

--- a/mur-core/src/conversations/ollama.rs
+++ b/mur-core/src/conversations/ollama.rs
@@ -101,33 +101,74 @@ impl OllamaClient {
         let url = format!("{}/api/generate", self.endpoint.trim_end_matches('/'));
         let mut req = req;
         req.stream = true;
-        let resp = self.http.post(&url).json(&req).send().await?;
+        let resp = self
+            .http
+            .post(&url)
+            .json(&req)
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?;
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
             return Err(anyhow!("ollama {status}: {body}"));
         }
         let byte_stream = resp.bytes_stream();
-        let token_stream = byte_stream
-            .map(|chunk| -> Result<Vec<String>> {
-                let bytes = chunk?;
-                let text = std::str::from_utf8(&bytes)?;
-                let mut out = Vec::new();
-                for line in text.lines() {
-                    if line.trim().is_empty() {
-                        continue;
+        let token_stream = futures::stream::unfold(
+            (byte_stream, String::new(), false),
+            |(mut inner, mut buf, done)| async move {
+                if done {
+                    return None;
+                }
+                loop {
+                    // Emit any complete line already in the buffer.
+                    if let Some(nl) = buf.find('\n') {
+                        let line: String = buf.drain(..=nl).collect();
+                        let trimmed = line.trim();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+                        match serde_json::from_str::<GenerateResponse>(trimmed) {
+                            Ok(v) => {
+                                if !v.response.is_empty() {
+                                    return Some((Ok(v.response), (inner, buf, false)));
+                                }
+                                // Empty response — keep draining.
+                                continue;
+                            }
+                            Err(e) => {
+                                return Some((Err(e.into()), (inner, buf, true)));
+                            }
+                        }
                     }
-                    let v: GenerateResponse = serde_json::from_str(line)?;
-                    if !v.response.is_empty() {
-                        out.push(v.response);
+                    // Need more bytes.
+                    match inner.next().await {
+                        Some(Ok(bytes)) => match std::str::from_utf8(&bytes) {
+                            Ok(s) => buf.push_str(s),
+                            Err(e) => {
+                                return Some((Err(e.into()), (inner, buf, true)));
+                            }
+                        },
+                        Some(Err(e)) => {
+                            return Some((Err(e.into()), (inner, buf, true)));
+                        }
+                        None => {
+                            // EOF: if anything remains, flush it as a final record.
+                            let trimmed = buf.trim();
+                            if trimmed.is_empty() {
+                                return None;
+                            }
+                            let result = match serde_json::from_str::<GenerateResponse>(trimmed) {
+                                Ok(v) if !v.response.is_empty() => Ok(v.response),
+                                Ok(_) => return None,
+                                Err(e) => Err(e.into()),
+                            };
+                            return Some((result, (inner, String::new(), true)));
+                        }
                     }
                 }
-                Ok(out)
-            })
-            .flat_map(|res| match res {
-                Ok(tokens) => futures::stream::iter(tokens.into_iter().map(Ok).collect::<Vec<_>>()),
-                Err(e) => futures::stream::iter(vec![Err(e)]),
-            });
+            },
+        );
         Ok(Box::pin(token_stream))
     }
 }
@@ -222,5 +263,87 @@ mod tests {
         };
         let r = client.generate(req).await;
         assert!(r.is_err());
+    }
+
+    #[tokio::test]
+    async fn stream_parser_joins_split_lines() {
+        // Simulate bytes_stream yielding chunks that split a JSON record mid-line.
+        // Chunk A ends with {"response":"hello, chunk B starts with ","done":false...}\n
+        // The key point: a single JSON record {"response":"hello","done":false,"model":"m"}
+        // is split across two chunks. Without buffering, the parser would fail or drop tokens.
+        let chunks: Vec<Result<Vec<u8>, anyhow::Error>> = vec![
+            Ok(br#"{"response":"hel"#.to_vec()),
+            Ok(br#"lo","done":false,"model":"m"}"#.to_vec()),
+            Ok(b"\n".to_vec()),
+            Ok(br#"{"response":"world","done":true,"model":"m"}"#.to_vec()),
+            Ok(b"\n".to_vec()),
+        ];
+        let byte_stream = futures::stream::iter(chunks);
+        // Replicate the unfold logic from generate_stream.
+        let token_stream: Pin<Box<dyn Stream<Item = Result<String>> + Send>> =
+            Box::pin(futures::stream::unfold(
+                (byte_stream, String::new(), false),
+                |(mut inner, mut buf, done)| async move {
+                    if done {
+                        return None;
+                    }
+                    loop {
+                        if let Some(nl) = buf.find('\n') {
+                            let line: String = buf.drain(..=nl).collect();
+                            let trimmed = line.trim();
+                            if trimmed.is_empty() {
+                                continue;
+                            }
+                            match serde_json::from_str::<GenerateResponse>(trimmed) {
+                                Ok(v) => {
+                                    if !v.response.is_empty() {
+                                        return Some((Ok(v.response), (inner, buf, false)));
+                                    }
+                                    continue;
+                                }
+                                Err(e) => {
+                                    return Some((Err(anyhow::anyhow!(e)), (inner, buf, true)));
+                                }
+                            }
+                        }
+                        match inner.next().await {
+                            Some(Ok(bytes)) => match std::str::from_utf8(&bytes) {
+                                Ok(s) => buf.push_str(s),
+                                Err(e) => {
+                                    return Some((Err(anyhow::anyhow!(e)), (inner, buf, true)));
+                                }
+                            },
+                            Some(Err(e)) => {
+                                return Some((Err(e), (inner, buf, true)));
+                            }
+                            None => {
+                                let trimmed = buf.trim();
+                                if trimmed.is_empty() {
+                                    return None;
+                                }
+                                let result: Result<String> =
+                                    match serde_json::from_str::<GenerateResponse>(trimmed) {
+                                        Ok(v) if !v.response.is_empty() => Ok(v.response),
+                                        Ok(_) => return None,
+                                        Err(e) => Err(anyhow::anyhow!(e)),
+                                    };
+                                return Some((result, (inner, String::new(), true)));
+                            }
+                        }
+                    }
+                },
+            ));
+        // Collect the tokens and verify they match expected order.
+        // The test demonstrates that even though the first JSON record is split
+        // across chunks A and B, both tokens ("hello" and "world") are correctly extracted.
+        let mut tokens = Vec::new();
+        futures::pin_mut!(token_stream);
+        while let Some(result) = token_stream.next().await {
+            match result {
+                Ok(token) => tokens.push(token),
+                Err(e) => panic!("unexpected error: {}", e),
+            }
+        }
+        assert_eq!(tokens, vec!["hello", "world"]);
     }
 }

--- a/mur-core/src/conversations/ollama.rs
+++ b/mur-core/src/conversations/ollama.rs
@@ -161,9 +161,17 @@ fn mock_generate(req: &GenerateRequest<'_>) -> GenerateResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Serialize env-var mutation across the three tests below. Rust 2024 made
+    // set_var/remove_var unsafe precisely because the process env is shared
+    // across threads, and cargo test runs cases concurrently by default.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn mock_mode_extractive_returns_valid_json() {
+        let _env_guard = ENV_LOCK.lock().unwrap();
         // Given: MUR_OLLAMA_MOCK=1, extractive prompt
         unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
         let client = OllamaClient::new("http://unused", Duration::from_secs(1));
@@ -181,7 +189,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn mock_mode_abstractive_returns_prose() {
+        let _env_guard = ENV_LOCK.lock().unwrap();
         unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
         let client = OllamaClient::new("http://unused", Duration::from_secs(1));
         let req = GenerateRequest {
@@ -197,7 +207,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn real_call_errors_on_unreachable_endpoint() {
+        let _env_guard = ENV_LOCK.lock().unwrap();
         unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
         // Use a deliberately-unroutable port so we get a fast failure
         let client = OllamaClient::new("http://127.0.0.1:1", Duration::from_millis(500));

--- a/mur-core/src/conversations/ollama.rs
+++ b/mur-core/src/conversations/ollama.rs
@@ -1,0 +1,214 @@
+//! Shared Ollama HTTP client used by summarize and ask modules.
+//!
+//! Covers both non-streaming (`generate`) and streaming (`generate_stream`)
+//! endpoints. MUR_OLLAMA_MOCK=1 env short-circuits to canned responses for
+//! deterministic testing; see docs/superpowers/specs/...phase-2... §9.3.
+
+#![allow(dead_code)] // Phase 2A: generate_stream wired in Phase 2B.
+
+use anyhow::{Context, Result, anyhow};
+use futures::stream::{Stream, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::pin::Pin;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GenerateRequest<'a> {
+    pub model: &'a str,
+    pub prompt: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<&'a str>,
+    pub stream: bool,
+    pub options: GenerateOptions,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GenerateOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_predict: Option<u32>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub stop: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GenerateResponse {
+    pub response: String,
+    pub done: bool,
+    pub model: String,
+    #[serde(default)]
+    pub prompt_eval_count: u64,
+    #[serde(default)]
+    pub eval_count: u64,
+}
+
+pub struct OllamaClient {
+    endpoint: String,
+    timeout: Duration,
+    http: reqwest::Client,
+}
+
+impl OllamaClient {
+    pub fn new(endpoint: &str, timeout: Duration) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .expect("reqwest client build");
+        Self {
+            endpoint: endpoint.to_string(),
+            timeout,
+            http,
+        }
+    }
+
+    pub fn mock_from_env() -> bool {
+        std::env::var("MUR_OLLAMA_MOCK").as_deref() == Ok("1")
+    }
+
+    pub async fn generate(&self, req: GenerateRequest<'_>) -> Result<GenerateResponse> {
+        if Self::mock_from_env() {
+            return Ok(mock_generate(&req));
+        }
+        let url = format!("{}/api/generate", self.endpoint.trim_end_matches('/'));
+        let resp = self
+            .http
+            .post(&url)
+            .json(&req)
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("ollama {status}: {body}"));
+        }
+        Ok(resp.json::<GenerateResponse>().await?)
+    }
+
+    pub async fn generate_stream(
+        &self,
+        req: GenerateRequest<'_>,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<String>> + Send>>> {
+        if Self::mock_from_env() {
+            let full = mock_generate(&req).response;
+            let tokens: Vec<String> = full.split_inclusive(' ').map(|s| s.to_string()).collect();
+            let stream = futures::stream::iter(tokens.into_iter().map(Ok));
+            return Ok(Box::pin(stream));
+        }
+        let url = format!("{}/api/generate", self.endpoint.trim_end_matches('/'));
+        let mut req = req;
+        req.stream = true;
+        let resp = self.http.post(&url).json(&req).send().await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("ollama {status}: {body}"));
+        }
+        let byte_stream = resp.bytes_stream();
+        let token_stream = byte_stream
+            .map(|chunk| -> Result<Vec<String>> {
+                let bytes = chunk?;
+                let text = std::str::from_utf8(&bytes)?;
+                let mut out = Vec::new();
+                for line in text.lines() {
+                    if line.trim().is_empty() {
+                        continue;
+                    }
+                    let v: GenerateResponse = serde_json::from_str(line)?;
+                    if !v.response.is_empty() {
+                        out.push(v.response);
+                    }
+                }
+                Ok(out)
+            })
+            .flat_map(|res| match res {
+                Ok(tokens) => futures::stream::iter(tokens.into_iter().map(Ok).collect::<Vec<_>>()),
+                Err(e) => futures::stream::iter(vec![Err(e)]),
+            });
+        Ok(Box::pin(token_stream))
+    }
+}
+
+/// Deterministic fake response for tests. Echoes model+prompt hints so each
+/// test can assert which call site fired without a real Ollama.
+fn mock_generate(req: &GenerateRequest<'_>) -> GenerateResponse {
+    let response = if req
+        .prompt
+        .contains("Extract the 1-3 most informative spans")
+    {
+        // extractive stage: one valid span echoed as JSON array
+        r#"[{"role":"user","conv_id":"mock","line_hint":1,"text":"mock extractive span"}]"#
+            .to_string()
+    } else if req.prompt.contains("narrative paragraph") {
+        "Mock narrative: today the developer explored mock compression.".to_string()
+    } else if req.prompt.contains("[cit:") {
+        "Mock answer about the archive [cit: 2026-04-19 claude-code/mock:L1].".to_string()
+    } else {
+        format!("mock response for model={}", req.model)
+    };
+    GenerateResponse {
+        response,
+        done: true,
+        model: req.model.to_string(),
+        prompt_eval_count: 10,
+        eval_count: 20,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mock_mode_extractive_returns_valid_json() {
+        // Given: MUR_OLLAMA_MOCK=1, extractive prompt
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let client = OllamaClient::new("http://unused", Duration::from_secs(1));
+        let req = GenerateRequest {
+            model: "qwen3:14b",
+            prompt: "Extract the 1-3 most informative spans from this excerpt.",
+            system: None,
+            stream: false,
+            options: GenerateOptions::default(),
+        };
+        let resp = client.generate(req).await.unwrap();
+        assert!(resp.response.contains("mock extractive span"));
+        assert!(serde_json::from_str::<serde_json::Value>(&resp.response).is_ok());
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[tokio::test]
+    async fn mock_mode_abstractive_returns_prose() {
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let client = OllamaClient::new("http://unused", Duration::from_secs(1));
+        let req = GenerateRequest {
+            model: "qwen3:14b",
+            prompt: "Write the narrative paragraph.",
+            system: None,
+            stream: false,
+            options: GenerateOptions::default(),
+        };
+        let resp = client.generate(req).await.unwrap();
+        assert!(resp.response.starts_with("Mock narrative"));
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[tokio::test]
+    async fn real_call_errors_on_unreachable_endpoint() {
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+        // Use a deliberately-unroutable port so we get a fast failure
+        let client = OllamaClient::new("http://127.0.0.1:1", Duration::from_millis(500));
+        let req = GenerateRequest {
+            model: "m",
+            prompt: "p",
+            system: None,
+            stream: false,
+            options: GenerateOptions::default(),
+        };
+        let r = client.generate(req).await;
+        assert!(r.is_err());
+    }
+}

--- a/mur-core/src/conversations/paths.rs
+++ b/mur-core/src/conversations/paths.rs
@@ -9,8 +9,23 @@ use mur_common::Source;
 use std::path::PathBuf;
 
 /// Default mur root (`~/.mur`) or the override path for tests.
+///
+/// Resolution order:
+/// 1. Explicit `override_path` argument (used by internal tests that thread
+///    the root through function args).
+/// 2. `MUR_HOME` env var, if set and non-empty. Cross-platform escape hatch
+///    for CLI integration tests and power-user setups — on Windows the `dirs`
+///    crate uses the Win32 `SHGetKnownFolderPath` API, which **ignores**
+///    `HOME`/`USERPROFILE` overrides, so a dedicated env is needed to keep
+///    tests isolated from the host profile.
+/// 3. `dirs::home_dir()` joined with `.mur`.
 pub fn mur_root(override_path: Option<&str>) -> PathBuf {
     if let Some(p) = override_path {
+        return PathBuf::from(p);
+    }
+    if let Ok(p) = std::env::var("MUR_HOME")
+        && !p.is_empty()
+    {
         return PathBuf::from(p);
     }
     dirs::home_dir().expect("no home dir").join(".mur")

--- a/mur-core/src/conversations/paths.rs
+++ b/mur-core/src/conversations/paths.rs
@@ -48,6 +48,14 @@ pub fn summary_paths_for(date: NaiveDate, override_path: Option<&str>) -> (PathB
     (root.join(format!("{d}.md")), root.join(format!("{d}.yaml")))
 }
 
+/// Directory that holds previous versions of overwritten summaries.
+/// One file per rewrite: `<date>.<ISO-8601>.md`.
+pub fn summary_history_dir(root_override: Option<&str>) -> PathBuf {
+    conversations_root(root_override)
+        .join("summary")
+        .join(".history")
+}
+
 pub fn index_path(override_path: Option<&str>) -> PathBuf {
     conversations_root(override_path).join("index.lance")
 }
@@ -110,6 +118,15 @@ mod tests {
         assert_eq!(
             yml,
             std::path::PathBuf::from("/tmp/m/conversations/summary/2026-04-19.yaml")
+        );
+    }
+
+    #[test]
+    fn summary_history_dir_under_conversations() {
+        let p = summary_history_dir(Some("/tmp/mur-test"));
+        assert_eq!(
+            p,
+            std::path::PathBuf::from("/tmp/mur-test/conversations/summary/.history")
         );
     }
 }

--- a/mur-core/src/conversations/retrieve.rs
+++ b/mur-core/src/conversations/retrieve.rs
@@ -87,7 +87,9 @@ pub async fn search(
     root_override: Option<&str>,
 ) -> Result<Vec<SearchResult>> {
     let idx = super::index::ConversationIndex::open(embedding.len() as i32, root_override).await?;
-    let vec_hits = idx.search(&embedding, limit * 3, source_filter).await?;
+    let vec_hits = idx
+        .search(&embedding, limit * 3, source_filter, None)
+        .await?;
 
     let q_lower = query.to_lowercase();
     let q_words: Vec<&str> = q_lower.split_whitespace().collect();

--- a/mur-core/src/conversations/summarize/abstractive.rs
+++ b/mur-core/src/conversations/summarize/abstractive.rs
@@ -1,0 +1,165 @@
+//! Abstractive narrative stage. Single LLM call over all extractive spans.
+//! See spec §4.3. Output: 150-400 words, first-person or neutral.
+
+use tracing::warn;
+
+use super::super::ollama::{GenerateOptions, GenerateRequest, OllamaClient};
+use super::extractive::ExtractiveSpan;
+
+pub struct AbstractiveResult {
+    pub narrative: Option<String>, // None iff LLM failed and caller should set the warning
+    pub word_count: usize,
+}
+
+pub async fn summarize(
+    client: &OllamaClient,
+    model: &str,
+    spans: &[ExtractiveSpan],
+    date: chrono::NaiveDate,
+    max_words: u32,
+) -> AbstractiveResult {
+    if spans.is_empty() {
+        return AbstractiveResult {
+            narrative: Some("No significant activity on this day.".to_string()),
+            word_count: 5,
+        };
+    }
+    let prompt = render_prompt(spans, date, max_words);
+    let resp = client
+        .generate(GenerateRequest {
+            model,
+            prompt: &prompt,
+            system: None,
+            stream: false,
+            options: GenerateOptions {
+                temperature: Some(0.2),
+                top_p: Some(0.9),
+                num_predict: Some(max_words * 2), // tokens > words; headroom
+                stop: vec![],
+            },
+        })
+        .await;
+    match resp {
+        Ok(r) => {
+            let narrative = clean_output(&r.response);
+            let word_count = narrative.split_whitespace().count();
+            AbstractiveResult {
+                narrative: Some(narrative),
+                word_count,
+            }
+        }
+        Err(e) => {
+            warn!("abstractive LLM call failed: {e:#}");
+            AbstractiveResult {
+                narrative: None,
+                word_count: 0,
+            }
+        }
+    }
+}
+
+fn render_prompt(spans: &[ExtractiveSpan], date: chrono::NaiveDate, max_words: u32) -> String {
+    let min_words = 150.min(max_words / 2);
+    let mut body = format!(
+        "You are summarizing one day ({}) of a developer's AI-assistant conversations into a \
+         narrative paragraph. Use ONLY information present in the spans below.\n\n\
+         Output: {}-{} words, first-person or neutral third-person, no bullet lists. \
+         Reference each key point by its span index [N]. Do NOT invent details not in the spans. \
+         If spans conflict, note the conflict.\n\n\
+         Spans:\n",
+        date, min_words, max_words
+    );
+    for (i, s) in spans.iter().enumerate() {
+        body.push_str(&format!(
+            "[{}] {{{} {}/{} L{}}}: {}\n",
+            i + 1,
+            date,
+            s.src.file_prefix(),
+            s.conv_id,
+            s.line_hint,
+            s.text,
+        ));
+    }
+    body.push_str("\nWrite the narrative.\n");
+    body
+}
+
+fn clean_output(raw: &str) -> String {
+    let trimmed = raw.trim();
+    // Strip trailing commentary like "Let me know if you'd like..." that some
+    // models append after the summary. Heuristic: keep content up to the first
+    // double-newline that follows a complete sentence.
+    if let Some(idx) = trimmed.find("\n\nLet me") {
+        return trimmed[..idx].trim().to_string();
+    }
+    if let Some(idx) = trimmed.find("\n\nWould you") {
+        return trimmed[..idx].trim().to_string();
+    }
+    trimmed.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conversations::ENV_LOCK;
+    use mur_common::{Role, Source};
+
+    fn span(idx: u32, text: &str) -> ExtractiveSpan {
+        ExtractiveSpan {
+            role: Role::User,
+            conv_id: "c1".into(),
+            line_hint: idx,
+            text: text.into(),
+            src: Source::ClaudeCode,
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn empty_spans_emit_placeholder() {
+        let _env_guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let client = OllamaClient::new("http://unused", std::time::Duration::from_secs(1));
+        let r = summarize(
+            &client,
+            "qwen3:14b",
+            &[],
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(),
+            400,
+        )
+        .await;
+        assert!(r.narrative.as_deref().unwrap().contains("No significant"));
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn mock_narrative_happy_path() {
+        let _env_guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let client = OllamaClient::new("http://unused", std::time::Duration::from_secs(1));
+        let spans = vec![span(1, "hello world"), span(2, "compression works")];
+        let r = summarize(
+            &client,
+            "qwen3:14b",
+            &spans,
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(),
+            400,
+        )
+        .await;
+        assert!(
+            r.narrative
+                .as_deref()
+                .unwrap()
+                .starts_with("Mock narrative")
+        );
+        assert!(r.word_count > 0);
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[test]
+    fn clean_output_strips_trailing_commentary() {
+        let raw = "This is the narrative.\n\nLet me know if you'd like more detail!";
+        assert_eq!(clean_output(raw), "This is the narrative.");
+    }
+}

--- a/mur-core/src/conversations/summarize/abstractive.rs
+++ b/mur-core/src/conversations/summarize/abstractive.rs
@@ -21,7 +21,7 @@ pub async fn summarize(
     if spans.is_empty() {
         return AbstractiveResult {
             narrative: Some("No significant activity on this day.".to_string()),
-            word_count: 5,
+            word_count: 6,
         };
     }
     let prompt = render_prompt(spans, date, max_words);
@@ -161,5 +161,31 @@ mod tests {
     fn clean_output_strips_trailing_commentary() {
         let raw = "This is the narrative.\n\nLet me know if you'd like more detail!";
         assert_eq!(clean_output(raw), "This is the narrative.");
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn placeholder_word_count_matches_string() {
+        // Guard: the empty-day placeholder word_count must match its actual
+        // whitespace split. Prior version hardcoded 5 vs the 6-word string
+        // "No significant activity on this day."
+        let _env_guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let client = OllamaClient::new("http://unused", std::time::Duration::from_secs(1));
+        let r = summarize(
+            &client,
+            "qwen3:14b",
+            &[],
+            chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(),
+            400,
+        )
+        .await;
+        let actual = r.narrative.as_deref().unwrap().split_whitespace().count();
+        assert_eq!(
+            r.word_count, actual,
+            "word_count ({}) should equal split_whitespace count ({})",
+            r.word_count, actual
+        );
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
     }
 }

--- a/mur-core/src/conversations/summarize/chunker.rs
+++ b/mur-core/src/conversations/summarize/chunker.rs
@@ -1,0 +1,149 @@
+//! Pack messages into LLM-sized chunks under a token budget.
+//!
+//! - Never split a single message (quote integrity).
+//! - Prefer splitting at conv_id boundaries; only split mid-conversation if
+//!   that conversation itself exceeds the budget.
+//! - Token estimate: chars / 4. Good to ±15% across CJK/ASCII mix.
+
+use mur_common::Message;
+
+const CHARS_PER_TOKEN: usize = 4;
+
+#[derive(Debug)]
+pub struct Chunk {
+    pub messages: Vec<Message>,
+    pub token_count: usize,
+    pub span_range: (usize, usize), // (start_line, end_line) within the day JSONL
+}
+
+pub fn chunk_day(msgs: &[Message], token_budget: usize) -> Vec<Chunk> {
+    if msgs.is_empty() {
+        return Vec::new();
+    }
+
+    // Precompute token cost per message and its day-wide line index (1-based,
+    // matches the extractive prompt's L<N> convention).
+    let msg_costs: Vec<usize> = msgs.iter().map(message_token_cost).collect();
+
+    let mut out = Vec::new();
+    let mut current: Vec<usize> = Vec::new(); // indices into msgs
+    let mut current_tokens = 0usize;
+    let mut current_conv: Option<&str> = None;
+
+    for (i, m) in msgs.iter().enumerate() {
+        let cost = msg_costs[i];
+        let msg_conv = m.conv.as_str();
+
+        // Start-new-chunk decision:
+        // 1. always start fresh if adding this msg would exceed budget AND
+        //    we already have content (respecting the never-split rule)
+        // 2. even if under budget, if msg_conv differs from current_conv AND
+        //    we have > 1 msg, prefer splitting at the conv boundary when the
+        //    resulting chunk would still fit — the boundary split loses
+        //    nothing and keeps the extractive prompt focused.
+        let would_overflow = current_tokens + cost > token_budget && !current.is_empty();
+        let conv_boundary =
+            current_conv.is_some() && current_conv != Some(msg_conv) && !current.is_empty();
+
+        if would_overflow || (conv_boundary && current_tokens + cost > token_budget / 2) {
+            out.push(make_chunk(msgs, &current, current_tokens));
+            current.clear();
+            current_tokens = 0;
+        }
+
+        current.push(i);
+        current_tokens += cost;
+        current_conv = Some(msg_conv);
+    }
+
+    if !current.is_empty() {
+        out.push(make_chunk(msgs, &current, current_tokens));
+    }
+    out
+}
+
+fn message_token_cost(m: &Message) -> usize {
+    // Scaffold overhead (role prefix, timestamp, line number) plus content.
+    let content_chars = match &m.content {
+        mur_common::Content::Text { value } => value.len(),
+        mur_common::Content::ToolRef { desc, .. } => desc.len().saturating_add(64),
+        mur_common::Content::ImageRef { desc, .. } => desc.len().saturating_add(48),
+    };
+    // ~40 chars scaffold: "L<line> [hh:mm:ss] <src>/<conv> (<role>): "
+    (content_chars + 40) / CHARS_PER_TOKEN + 1
+}
+
+fn make_chunk(msgs: &[Message], indices: &[usize], tokens: usize) -> Chunk {
+    let start_line = indices.first().copied().unwrap_or(0) + 1; // 1-based
+    let end_line = indices.last().copied().unwrap_or(0) + 1;
+    let chunk_msgs = indices.iter().map(|&i| msgs[i].clone()).collect();
+    Chunk {
+        messages: chunk_msgs,
+        token_count: tokens,
+        span_range: (start_line, end_line),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use mur_common::{Content, Role, Source};
+
+    fn mk(conv: &str, text: &str) -> Message {
+        Message {
+            v: 1,
+            ts: chrono::Utc.with_ymd_and_hms(2026, 4, 19, 10, 0, 0).unwrap(),
+            src: Source::ClaudeCode,
+            conv: conv.into(),
+            role: Role::User,
+            content: Content::Text { value: text.into() },
+            meta: serde_json::Value::Null,
+            refs: vec![],
+        }
+    }
+
+    #[test]
+    fn empty_day_yields_zero_chunks() {
+        assert!(chunk_day(&[], 6000).is_empty());
+    }
+
+    #[test]
+    fn all_fits_in_one_chunk_under_budget() {
+        let msgs = vec![mk("c1", "hello"), mk("c1", "world"), mk("c1", "again")];
+        let chunks = chunk_day(&msgs, 6000);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].messages.len(), 3);
+        assert_eq!(chunks[0].span_range, (1, 3));
+    }
+
+    #[test]
+    fn never_splits_single_message_even_if_over_budget() {
+        let big = "x".repeat(40_000);
+        let msgs = vec![mk("c1", &big)];
+        let chunks = chunk_day(&msgs, 6000);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].messages.len(), 1);
+    }
+
+    #[test]
+    fn splits_at_conv_boundary_when_under_half_budget_reached() {
+        // Two conversations, each small enough that greedy would pack them
+        // together, but boundary preference splits them.
+        let pad = "y".repeat(12_000); // ~3000 tokens
+        let msgs = vec![mk("c1", &pad), mk("c2", &pad)];
+        let chunks = chunk_day(&msgs, 6000);
+        assert_eq!(chunks.len(), 2, "expected 2 chunks, got {}", chunks.len());
+        assert_eq!(chunks[0].messages[0].conv, "c1");
+        assert_eq!(chunks[1].messages[0].conv, "c2");
+    }
+
+    #[test]
+    fn span_range_is_one_indexed_end_inclusive() {
+        let msgs = (0..5)
+            .map(|i| mk("c1", &format!("msg{i}")))
+            .collect::<Vec<_>>();
+        let chunks = chunk_day(&msgs, 6000);
+        assert_eq!(chunks[0].span_range, (1, 5));
+    }
+}

--- a/mur-core/src/conversations/summarize/chunker.rs
+++ b/mur-core/src/conversations/summarize/chunker.rs
@@ -23,7 +23,8 @@ pub fn chunk_day(msgs: &[Message], token_budget: usize) -> Vec<Chunk> {
 
     // Precompute token cost per message and its day-wide line index (1-based,
     // matches the extractive prompt's L<N> convention).
-    let msg_costs: Vec<usize> = msgs.iter().map(message_token_cost).collect();
+    #[allow(clippy::redundant_closure)]
+    let msg_costs: Vec<usize> = msgs.iter().map(|m| message_token_cost(m)).collect();
 
     let mut out = Vec::new();
     let mut current: Vec<usize> = Vec::new(); // indices into msgs
@@ -49,6 +50,10 @@ pub fn chunk_day(msgs: &[Message], token_budget: usize) -> Vec<Chunk> {
             out.push(make_chunk(msgs, &current, current_tokens));
             current.clear();
             current_tokens = 0;
+            #[allow(unused_assignments)]
+            {
+                current_conv = None;
+            }
         }
 
         current.push(i);

--- a/mur-core/src/conversations/summarize/extractive.rs
+++ b/mur-core/src/conversations/summarize/extractive.rs
@@ -251,13 +251,8 @@ fn jaro_winkler(a: &str, b: &str) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::conversations::ENV_LOCK;
     use chrono::TimeZone;
-    use std::sync::Mutex;
-
-    // Serialize env-var mutation inside this test module. Cross-module races
-    // (e.g. against conversations::ollama::tests) are a known limitation —
-    // resolve via a shared test-utility in Phase 2C if flakiness appears in CI.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn mk(ts_min: u32, conv: &str, text: &str, role: Role) -> Message {
         Message {

--- a/mur-core/src/conversations/summarize/extractive.rs
+++ b/mur-core/src/conversations/summarize/extractive.rs
@@ -1,0 +1,388 @@
+//! Per-chunk LLM span extraction. See spec §4.2.
+//!
+//! For each chunk, prompt Ollama for a JSON array of {role, conv_id,
+//! line_hint, text} spans. Validate each span:
+//!   - text is a verbatim substring of a source message (Jaro-Winkler ≥ 0.95)
+//!   - line_hint within chunk.span_range
+//!   - role matches source message role
+//!
+//! Invalid spans silently dropped. Failure degrades to zero spans.
+
+use anyhow::Result;
+use mur_common::{Content, Message, Role, Source};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use super::super::ollama::{GenerateOptions, GenerateRequest, OllamaClient};
+use super::chunker::Chunk;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ExtractiveSpan {
+    pub role: Role,
+    pub conv_id: String,
+    pub line_hint: u32,
+    pub text: String,
+    #[serde(skip)]
+    pub src: Source, // resolved from source message during validation
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LlmSpan {
+    role: String,
+    conv_id: String,
+    line_hint: u32,
+    text: String,
+}
+
+pub async fn extract_chunk(
+    client: &OllamaClient,
+    model: &str,
+    chunk: &Chunk,
+    day_msgs: &[Message],
+) -> Result<Vec<ExtractiveSpan>> {
+    let prompt = render_prompt(chunk);
+    let resp = client
+        .generate(GenerateRequest {
+            model,
+            prompt: &prompt,
+            system: None,
+            stream: false,
+            options: GenerateOptions {
+                temperature: Some(0.0),
+                top_p: Some(0.9),
+                num_predict: Some(1024),
+                stop: vec![],
+            },
+        })
+        .await;
+    let body = match resp {
+        Ok(r) => r.response,
+        Err(e) => {
+            warn!("extractive LLM call failed: {e:#}");
+            return Ok(Vec::new());
+        }
+    };
+
+    let raw: Vec<LlmSpan> = match parse_json_array(&body) {
+        Some(v) => v,
+        None => {
+            warn!("extractive output not a JSON array; returning zero spans");
+            return Ok(Vec::new());
+        }
+    };
+
+    Ok(raw
+        .into_iter()
+        .filter_map(|s| validate(s, chunk, day_msgs))
+        .collect())
+}
+
+fn render_prompt(chunk: &Chunk) -> String {
+    let mut body = String::new();
+    let (start_line, end_line) = chunk.span_range;
+    body.push_str(
+        "You are reviewing one conversation day for a technical developer's personal archive. \
+         Extract the 1-3 most informative spans from this excerpt.\n\n\
+         A span is quote-worthy if it:\n\
+         - states a decision the user made (\"we'll use X over Y because...\")\n\
+         - records a concrete error or failure that shaped subsequent work\n\
+         - captures a new idea, technique, or reference the user hadn't seen before\n\
+         - quotes an important external fact (API response, spec excerpt, doc)\n\n\
+         A span is NOT quote-worthy if it is:\n\
+         - boilerplate/greeting/filler\n\
+         - tool-result body already citeable by path\n\
+         - restated from an earlier span\n\n\
+         Output format: JSON array. Each span is {role, conv_id, line_hint, text}.\n\
+           - role: one of \"user\" | \"assistant\" | \"system\" | \"tool\"\n\
+           - conv_id: the conv value from the source message\n\
+           - line_hint: integer line number within the day's raw JSONL\n\
+           - text: verbatim quote, 20-400 chars\n\n\
+         If the excerpt has nothing quote-worthy, return [].\n\n",
+    );
+    body.push_str(&format!(
+        "Excerpt ({} messages, lines {}..{}):\n",
+        chunk.messages.len(),
+        start_line,
+        end_line
+    ));
+    for (i, m) in chunk.messages.iter().enumerate() {
+        let line_no = start_line + i;
+        let role = format!("{:?}", m.role).to_lowercase();
+        let text = content_preview(m);
+        body.push_str(&format!(
+            "L{} [{}] {}/{} ({}): {}\n",
+            line_no,
+            m.ts.format("%H:%M:%S"),
+            m.src.file_prefix(),
+            m.conv,
+            role,
+            text,
+        ));
+    }
+    body
+}
+
+fn content_preview(m: &Message) -> String {
+    match &m.content {
+        Content::Text { value } => value.clone(),
+        Content::ToolRef {
+            desc, bytes, path, ..
+        } => {
+            format!("[tool_ref:{} ({}B) @ {}]", desc, bytes, path)
+        }
+        Content::ImageRef { desc, path, .. } => format!("[image_ref:{} @ {}]", desc, path),
+    }
+}
+
+fn parse_json_array(body: &str) -> Option<Vec<LlmSpan>> {
+    // Tolerate fences / surrounding prose: find first `[` and last `]`.
+    let start = body.find('[')?;
+    let end = body.rfind(']')?;
+    if end <= start {
+        return None;
+    }
+    let slice = &body[start..=end];
+    serde_json::from_str::<Vec<LlmSpan>>(slice).ok()
+}
+
+fn validate(raw: LlmSpan, chunk: &Chunk, day_msgs: &[Message]) -> Option<ExtractiveSpan> {
+    // line_hint within chunk
+    let (s, e) = chunk.span_range;
+    if raw.line_hint < s as u32 || raw.line_hint > e as u32 {
+        return None;
+    }
+    let role = parse_role(&raw.role)?;
+    // Find the source message at line_hint (1-based → 0-based index)
+    let idx = raw.line_hint as usize - 1;
+    let source_msg = day_msgs.get(idx)?;
+    if source_msg.role != role {
+        return None;
+    }
+    if source_msg.conv != raw.conv_id {
+        return None;
+    }
+    // Verbatim check with Jaro-Winkler ≥ 0.95 against source message text
+    let source_text = content_preview(source_msg);
+    let similarity = jaro_winkler(&raw.text, &source_text);
+    if similarity < 0.95 {
+        return None;
+    }
+    Some(ExtractiveSpan {
+        role,
+        conv_id: raw.conv_id,
+        line_hint: raw.line_hint,
+        text: raw.text,
+        src: source_msg.src,
+    })
+}
+
+fn parse_role(s: &str) -> Option<Role> {
+    match s.to_ascii_lowercase().as_str() {
+        "user" => Some(Role::User),
+        "assistant" => Some(Role::Assistant),
+        "system" => Some(Role::System),
+        "tool" => Some(Role::Tool),
+        _ => None,
+    }
+}
+
+/// Small Jaro-Winkler implementation (no extra dep). Char-based, case-sensitive.
+fn jaro_winkler(a: &str, b: &str) -> f64 {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() && b.is_empty() {
+        return 1.0;
+    }
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let match_distance = (a.len().max(b.len()) / 2).saturating_sub(1);
+
+    let mut a_matched = vec![false; a.len()];
+    let mut b_matched = vec![false; b.len()];
+    let mut matches = 0usize;
+
+    for i in 0..a.len() {
+        let lo = i.saturating_sub(match_distance);
+        let hi = (i + match_distance + 1).min(b.len());
+        for j in lo..hi {
+            if b_matched[j] {
+                continue;
+            }
+            if a[i] == b[j] {
+                a_matched[i] = true;
+                b_matched[j] = true;
+                matches += 1;
+                break;
+            }
+        }
+    }
+    if matches == 0 {
+        return 0.0;
+    }
+    // transpositions
+    let mut k = 0usize;
+    let mut transpositions = 0usize;
+    for i in 0..a.len() {
+        if !a_matched[i] {
+            continue;
+        }
+        while !b_matched[k] {
+            k += 1;
+        }
+        if a[i] != b[k] {
+            transpositions += 1;
+        }
+        k += 1;
+    }
+    let m = matches as f64;
+    let jaro =
+        (m / a.len() as f64 + m / b.len() as f64 + (m - transpositions as f64 / 2.0) / m) / 3.0;
+    // Winkler common-prefix boost up to 4 chars, p=0.1
+    let prefix = a
+        .iter()
+        .zip(b.iter())
+        .take(4)
+        .take_while(|(x, y)| x == y)
+        .count() as f64;
+    jaro + prefix * 0.1 * (1.0 - jaro)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::sync::Mutex;
+
+    // Serialize env-var mutation inside this test module. Cross-module races
+    // (e.g. against conversations::ollama::tests) are a known limitation —
+    // resolve via a shared test-utility in Phase 2C if flakiness appears in CI.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn mk(ts_min: u32, conv: &str, text: &str, role: Role) -> Message {
+        Message {
+            v: 1,
+            ts: chrono::Utc
+                .with_ymd_and_hms(2026, 4, 19, 10, ts_min, 0)
+                .unwrap(),
+            src: Source::ClaudeCode,
+            conv: conv.into(),
+            role,
+            content: Content::Text { value: text.into() },
+            meta: serde_json::Value::Null,
+            refs: vec![],
+        }
+    }
+
+    #[test]
+    fn json_array_parsed_with_surrounding_prose() {
+        let body = r#"Here are the spans:
+```json
+[
+  {"role":"user","conv_id":"c1","line_hint":1,"text":"hi"}
+]
+```
+That's all."#;
+        let v = parse_json_array(body).unwrap();
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].text, "hi");
+    }
+
+    #[test]
+    fn validate_rejects_out_of_range_line_hint() {
+        let msgs = vec![mk(0, "c1", "hello", Role::User)];
+        let chunk = Chunk {
+            messages: msgs.clone(),
+            token_count: 10,
+            span_range: (1, 1),
+        };
+        let raw = LlmSpan {
+            role: "user".into(),
+            conv_id: "c1".into(),
+            line_hint: 99,
+            text: "hello".into(),
+        };
+        assert!(validate(raw, &chunk, &msgs).is_none());
+    }
+
+    #[test]
+    fn validate_rejects_role_mismatch() {
+        let msgs = vec![mk(0, "c1", "hello", Role::User)];
+        let chunk = Chunk {
+            messages: msgs.clone(),
+            token_count: 10,
+            span_range: (1, 1),
+        };
+        let raw = LlmSpan {
+            role: "assistant".into(),
+            conv_id: "c1".into(),
+            line_hint: 1,
+            text: "hello".into(),
+        };
+        assert!(validate(raw, &chunk, &msgs).is_none());
+    }
+
+    #[test]
+    fn validate_rejects_paraphrase() {
+        let msgs = vec![mk(
+            0,
+            "c1",
+            "cargo build failed with error E0001",
+            Role::User,
+        )];
+        let chunk = Chunk {
+            messages: msgs.clone(),
+            token_count: 10,
+            span_range: (1, 1),
+        };
+        let raw = LlmSpan {
+            role: "user".into(),
+            conv_id: "c1".into(),
+            line_hint: 1,
+            text: "build failed".into(),
+        };
+        assert!(validate(raw, &chunk, &msgs).is_none());
+    }
+
+    #[test]
+    fn validate_accepts_verbatim() {
+        let msgs = vec![mk(
+            0,
+            "c1",
+            "cargo build failed with error E0001",
+            Role::User,
+        )];
+        let chunk = Chunk {
+            messages: msgs.clone(),
+            token_count: 10,
+            span_range: (1, 1),
+        };
+        let raw = LlmSpan {
+            role: "user".into(),
+            conv_id: "c1".into(),
+            line_hint: 1,
+            text: "cargo build failed with error E0001".into(),
+        };
+        assert!(validate(raw, &chunk, &msgs).is_some());
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn mock_ollama_extracts_one_span() {
+        let _env_guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let client = OllamaClient::new("http://unused", std::time::Duration::from_secs(1));
+        let msgs = vec![mk(0, "mock", "mock extractive span", Role::User)];
+        let chunk = Chunk {
+            messages: msgs.clone(),
+            token_count: 10,
+            span_range: (1, 1),
+        };
+        let spans = extract_chunk(&client, "qwen3:14b", &chunk, &msgs)
+            .await
+            .unwrap();
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].text, "mock extractive span");
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+}

--- a/mur-core/src/conversations/summarize/macro_refs.rs
+++ b/mur-core/src/conversations/summarize/macro_refs.rs
@@ -1,0 +1,239 @@
+//! Pattern-name macro reference detection (spec §4.4).
+//!
+//! Enumerates ~/.mur/patterns/*.yaml names, scans extractive spans and the
+//! abstractive narrative for word-boundary matches, rewrites them to
+//! {{pattern: <name>}}, and records (version, sha) per referenced pattern.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use super::extractive::ExtractiveSpan;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MacroRef {
+    pub name: String,
+    pub pattern_version: u32,
+    pub pattern_sha: String,
+    pub marker: String,
+}
+
+pub fn detect_and_rewrite(
+    extractive: &mut [ExtractiveSpan],
+    abstractive: &mut String,
+    patterns_dir: &Path,
+) -> Result<Vec<MacroRef>> {
+    let names = enumerate_pattern_names(patterns_dir)?;
+    if names.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Case-insensitive Aho-Corasick. Word-boundary enforced via post-check.
+    let ac = aho_corasick::AhoCorasick::builder()
+        .ascii_case_insensitive(true)
+        .build(&names)
+        .context("build aho-corasick")?;
+
+    let mut found: BTreeSet<String> = BTreeSet::new();
+
+    for span in extractive.iter_mut() {
+        let new_text = rewrite_with_markers(&span.text, &ac, &names, &mut found);
+        span.text = new_text;
+    }
+    let new_narrative = rewrite_with_markers(abstractive, &ac, &names, &mut found);
+    *abstractive = new_narrative;
+
+    let mut refs = Vec::new();
+    for name in found {
+        let (version, sha) = read_pattern_meta(patterns_dir, &name).unwrap_or_else(|e| {
+            tracing::warn!("failed to read pattern {name}: {e:#}; using defaults");
+            (0, String::new())
+        });
+        refs.push(MacroRef {
+            name: name.clone(),
+            pattern_version: version,
+            pattern_sha: sha,
+            marker: format!("{{{{pattern: {name}}}}}"),
+        });
+    }
+    Ok(refs)
+}
+
+fn enumerate_pattern_names(patterns_dir: &Path) -> Result<Vec<String>> {
+    if !patterns_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(patterns_dir)? {
+        let entry = entry?;
+        let p = entry.path();
+        if p.extension().and_then(|s| s.to_str()) != Some("yaml") {
+            continue;
+        }
+        if let Some(stem) = p.file_stem().and_then(|s| s.to_str()) {
+            out.push(stem.to_string());
+        }
+    }
+    Ok(out)
+}
+
+fn rewrite_with_markers(
+    text: &str,
+    ac: &aho_corasick::AhoCorasick,
+    names: &[String],
+    found: &mut BTreeSet<String>,
+) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut last = 0usize;
+    let bytes = text.as_bytes();
+
+    for mat in ac.find_iter(text) {
+        let start = mat.start();
+        let end = mat.end();
+        let name = &names[mat.pattern()];
+
+        // Word-boundary check. Chars before/after must not be ASCII alphanumeric
+        // or '-' (pattern names use kebab-case).
+        let before_ok = start == 0 || !is_word_byte(bytes[start - 1]);
+        let after_ok = end >= bytes.len() || !is_word_byte(bytes[end]);
+
+        // Code-fence / backtick / YAML-quote skip.
+        if !before_ok || !after_ok || inside_code_or_quote(text, start) {
+            continue;
+        }
+
+        out.push_str(&text[last..start]);
+        out.push_str(&format!("{{{{pattern: {name}}}}}"));
+        last = end;
+        found.insert(name.clone());
+    }
+    out.push_str(&text[last..]);
+    out
+}
+
+fn is_word_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'-' || b == b'_'
+}
+
+fn inside_code_or_quote(text: &str, pos: usize) -> bool {
+    // Toggle state up to `pos` for each of: backtick, code-fence (```), single-quote, double-quote
+    let mut in_backtick = false;
+    let mut in_code_fence = false;
+    let mut in_single = false;
+    let mut in_double = false;
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < pos {
+        if i + 3 <= pos && &bytes[i..i + 3] == b"```" {
+            in_code_fence = !in_code_fence;
+            i += 3;
+            continue;
+        }
+        match bytes[i] {
+            b'`' if !in_code_fence => in_backtick = !in_backtick,
+            b'\'' if !in_code_fence && !in_backtick => in_single = !in_single,
+            b'"' if !in_code_fence && !in_backtick => in_double = !in_double,
+            _ => {}
+        }
+        i += 1;
+    }
+    in_backtick || in_code_fence || in_single || in_double
+}
+
+fn read_pattern_meta(patterns_dir: &Path, name: &str) -> Result<(u32, String)> {
+    let path = patterns_dir.join(format!("{name}.yaml"));
+    let bytes = std::fs::read(&path)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let sha = hex::encode(hasher.finalize());
+    // schema version lives at top level; if missing, default 0
+    let yaml: serde_yaml::Value = serde_yaml::from_slice(&bytes).unwrap_or(serde_yaml::Value::Null);
+    let version = yaml.get("schema").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+    Ok((version, sha))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::{Role, Source};
+
+    fn tmpdir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    fn write_pattern(dir: &Path, name: &str, body: &str) {
+        std::fs::write(dir.join(format!("{name}.yaml")), body).unwrap();
+    }
+
+    fn span(text: &str) -> ExtractiveSpan {
+        ExtractiveSpan {
+            role: Role::User,
+            conv_id: "c1".into(),
+            line_hint: 1,
+            text: text.into(),
+            src: Source::ClaudeCode,
+        }
+    }
+
+    #[test]
+    fn detects_and_rewrites_known_pattern() {
+        let tmp = tmpdir();
+        write_pattern(
+            tmp.path(),
+            "atomic-yaml-write",
+            "schema: 2\nname: atomic-yaml-write\n",
+        );
+        let mut spans = vec![span("we used atomic-yaml-write for the writer.")];
+        let mut narr = "The choice was atomic-yaml-write.".to_string();
+        let refs = detect_and_rewrite(&mut spans, &mut narr, tmp.path()).unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].name, "atomic-yaml-write");
+        assert_eq!(refs[0].pattern_version, 2);
+        assert!(spans[0].text.contains("{{pattern: atomic-yaml-write}}"));
+        assert!(narr.contains("{{pattern: atomic-yaml-write}}"));
+    }
+
+    #[test]
+    fn word_boundary_skips_partial_match() {
+        let tmp = tmpdir();
+        write_pattern(tmp.path(), "rust", "schema: 1\n");
+        let mut spans = vec![span("my rustic approach is rustless actually")];
+        let mut narr = String::new();
+        let refs = detect_and_rewrite(&mut spans, &mut narr, tmp.path()).unwrap();
+        assert!(
+            refs.is_empty(),
+            "rust should not match 'rustic' or 'rustless'"
+        );
+        assert!(!spans[0].text.contains("{{pattern"));
+    }
+
+    #[test]
+    fn skips_inside_backticks() {
+        let tmp = tmpdir();
+        write_pattern(tmp.path(), "my-pattern", "schema: 1\n");
+        let mut spans = vec![span("reference to `my-pattern` is literal")];
+        let mut narr = String::new();
+        let refs = detect_and_rewrite(&mut spans, &mut narr, tmp.path()).unwrap();
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn empty_patterns_dir_returns_empty() {
+        let tmp = tmpdir();
+        let mut spans = vec![span("anything")];
+        let mut narr = "anything".to_string();
+        let refs = detect_and_rewrite(&mut spans, &mut narr, tmp.path()).unwrap();
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn nonexistent_patterns_dir_is_safe() {
+        let mut spans = vec![span("x")];
+        let mut narr = "x".to_string();
+        let refs =
+            detect_and_rewrite(&mut spans, &mut narr, Path::new("/nonexistent/path")).unwrap();
+        assert!(refs.is_empty());
+    }
+}

--- a/mur-core/src/conversations/summarize/mod.rs
+++ b/mur-core/src/conversations/summarize/mod.rs
@@ -5,6 +5,7 @@
 //! `docs/superpowers/specs/2026-04-20-mur-conversations-phase-2-design.md`.
 #![allow(dead_code)] // public API wired progressively across Tasks 4-10.
 
+pub mod abstractive;
 pub mod chunker;
 pub mod extractive;
-// Later tasks add: pub mod abstractive; pub mod macro_refs; pub mod writer;
+// Later tasks add: pub mod macro_refs; pub mod writer;

--- a/mur-core/src/conversations/summarize/mod.rs
+++ b/mur-core/src/conversations/summarize/mod.rs
@@ -9,4 +9,4 @@ pub mod abstractive;
 pub mod chunker;
 pub mod extractive;
 pub mod macro_refs;
-// Later tasks add: pub mod writer;
+pub mod writer;

--- a/mur-core/src/conversations/summarize/mod.rs
+++ b/mur-core/src/conversations/summarize/mod.rs
@@ -10,3 +10,393 @@ pub mod chunker;
 pub mod extractive;
 pub mod macro_refs;
 pub mod writer;
+
+use anyhow::Result;
+use chrono::{NaiveDate, Utc};
+use mur_common::config::CompactConfig;
+use sha2::{Digest, Sha256};
+use std::time::Instant;
+use tracing::info_span;
+
+use super::audit::{self, AuditAction};
+use super::ollama::OllamaClient;
+use super::paths::summary_paths_for;
+use super::store;
+
+#[derive(Debug, Default)]
+pub struct CompactReport {
+    pub ok: u32,
+    pub err: u32,
+    pub skipped: u32,
+    pub day_reports: Vec<DayReport>,
+}
+
+#[derive(Debug)]
+pub struct DayReport {
+    pub date: NaiveDate,
+    pub outcome: Outcome,
+    pub extractive_spans: u32,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug)]
+pub enum Outcome {
+    Written { archived: bool },
+    Noop,
+    Skipped { reason: &'static str },
+    Failed(String),
+}
+
+pub async fn compact_day(
+    date: NaiveDate,
+    force: bool,
+    cfg: &CompactConfig,
+    root_override: Option<&str>,
+) -> Result<DayReport> {
+    let _span = info_span!("compact.day", %date).entered();
+    let start = Instant::now();
+
+    let (md_path, _) = summary_paths_for(date, root_override);
+    let msgs = store::read_day(date, root_override)?;
+    if msgs.is_empty() {
+        return Ok(DayReport {
+            date,
+            outcome: Outcome::Skipped {
+                reason: "no raw for day",
+            },
+            extractive_spans: 0,
+            duration_ms: start.elapsed().as_millis() as u64,
+        });
+    }
+
+    // Compute input_content_sha first — used for --if-stale guard.
+    let input_sha = compute_input_sha(&msgs);
+
+    // Skip if summary exists, is fresh, and not forced.
+    if md_path.exists()
+        && !force
+        && let Ok(existing) = std::fs::read_to_string(&md_path)
+        && existing.contains(&format!("input_content_sha: {}", input_sha))
+    {
+        return Ok(DayReport {
+            date,
+            outcome: Outcome::Skipped {
+                reason: "already fresh",
+            },
+            extractive_spans: 0,
+            duration_ms: start.elapsed().as_millis() as u64,
+        });
+    }
+
+    // Chunk + extract per chunk
+    let client = OllamaClient::new(&cfg.ollama_endpoint, std::time::Duration::from_secs(120));
+    let chunks = chunker::chunk_day(&msgs, cfg.chunk_tokens as usize);
+    let mut all_spans = Vec::new();
+    for chunk in &chunks {
+        let spans = extractive::extract_chunk(&client, &cfg.extractive_model, chunk, &msgs).await?;
+        all_spans.extend(spans);
+    }
+
+    // Dedup (reuse Phase 1 MinHash pattern via simple string equality for now;
+    // structural dedup is Phase 2C polish)
+    all_spans.sort_by_key(|a| a.line_hint);
+    all_spans.dedup_by(|a, b| a.text == b.text && a.line_hint == b.line_hint);
+
+    // Cap
+    if all_spans.len() > cfg.max_extractive_spans as usize {
+        all_spans.truncate(cfg.max_extractive_spans as usize);
+    }
+
+    // Abstractive
+    let abstractive_result = abstractive::summarize(
+        &client,
+        &cfg.abstractive_model,
+        &all_spans,
+        date,
+        cfg.max_abstractive_words,
+    )
+    .await;
+
+    let mut warnings = Vec::new();
+    if abstractive_result.narrative.is_none() {
+        warnings.push("narrative_generation_failed".to_string());
+    }
+
+    // Macro refs
+    let patterns_dir = dirs::home_dir()
+        .unwrap_or_default()
+        .join(".mur")
+        .join("patterns");
+    let mut abstractive_text = abstractive_result
+        .narrative
+        .clone()
+        .unwrap_or_else(|| "(narrative unavailable)".into());
+    let pattern_refs =
+        macro_refs::detect_and_rewrite(&mut all_spans, &mut abstractive_text, &patterns_dir)
+            .unwrap_or_default();
+    let abstractive_final = abstractive::AbstractiveResult {
+        narrative: Some(abstractive_text),
+        word_count: abstractive_result.word_count,
+    };
+
+    // Frontmatter derived fields
+    let sources = {
+        let mut s: Vec<String> = msgs
+            .iter()
+            .map(|m| m.src.file_prefix().to_string())
+            .collect();
+        s.sort();
+        s.dedup();
+        s
+    };
+    let conv_count = {
+        let mut c: Vec<&str> = msgs.iter().map(|m| m.conv.as_str()).collect();
+        c.sort();
+        c.dedup();
+        c.len() as u32
+    };
+    let keywords = top_keywords(&all_spans, 10);
+
+    let doc = writer::SummaryDoc {
+        date,
+        generated_at: Utc::now(),
+        extractive_model: cfg.extractive_model.clone(),
+        abstractive_model: cfg.abstractive_model.clone(),
+        mur_version: env!("CARGO_PKG_VERSION").into(),
+        duration_ms: start.elapsed().as_millis() as u64,
+        conv_count,
+        msg_count: msgs.len() as u32,
+        sources,
+        pattern_refs,
+        keywords,
+        links_prev: Some(date - chrono::Duration::days(1)),
+        links_next: Some(date + chrono::Duration::days(1)),
+        warnings,
+        input_content_sha: input_sha,
+        extractive: all_spans.clone(),
+        abstractive: abstractive_final,
+    };
+
+    // Summary embedding: use a deterministic zero vector when MUR_OLLAMA_MOCK=1;
+    // otherwise call the configured embedding provider via existing pipeline.
+    let embed_dims = 1024_usize; // default; Phase 3 can read from cfg
+    let summary_embedding = if OllamaClient::mock_from_env() {
+        vec![0.1; embed_dims]
+    } else {
+        let text = doc
+            .abstractive
+            .narrative
+            .as_deref()
+            .unwrap_or("")
+            .to_string();
+        // Load global config to pick up embedding provider/model/dims.
+        // If loading fails (no ~/.mur/config.yaml yet), fall back to a zero vector;
+        // LanceDB row still writes, retrieve reranking just won't benefit from
+        // semantic similarity until a user config exists or `mur reindex` is run.
+        match crate::store::config::load_config() {
+            Ok(cfg) => {
+                let embed_cfg = crate::store::embedding::EmbeddingConfig::from_config(&cfg);
+                crate::store::embedding::embed(&text, &embed_cfg)
+                    .await
+                    .unwrap_or_else(|_| vec![0.0; embed_dims])
+            }
+            Err(_) => vec![0.0; embed_dims],
+        }
+    };
+
+    match writer::write_summary(&doc, summary_embedding, root_override).await {
+        Ok(w) => Ok(DayReport {
+            date,
+            outcome: if w.noop {
+                Outcome::Noop
+            } else {
+                Outcome::Written {
+                    archived: w.archived.is_some(),
+                }
+            },
+            extractive_spans: doc.extractive.len() as u32,
+            duration_ms: doc.duration_ms,
+        }),
+        Err(e) => {
+            // Record the failure in audit but don't throw — caller still gets a report.
+            let _ = audit::Audit::open(root_override).and_then(|a| {
+                a.append(
+                    AuditAction::Error {
+                        layer: "compact.write".into(),
+                        reason: format!("{e:#}"),
+                    },
+                    String::new(),
+                )
+            });
+            Ok(DayReport {
+                date,
+                outcome: Outcome::Failed(format!("{e:#}")),
+                extractive_spans: 0,
+                duration_ms: start.elapsed().as_millis() as u64,
+            })
+        }
+    }
+}
+
+pub async fn compact_missing(
+    cfg: &CompactConfig,
+    since: Option<NaiveDate>,
+    if_stale: bool,
+    max_days_override: Option<u32>,
+    root_override: Option<&str>,
+) -> Result<CompactReport> {
+    let max_days = max_days_override.unwrap_or(cfg.max_days_per_run) as usize;
+    let today = Utc::now().date_naive();
+
+    let mut candidates: Vec<NaiveDate> = store::list_raw_dirs(root_override)?
+        .into_iter()
+        .map(|(d, _)| d)
+        .filter(|d| *d < today)
+        .filter(|d| since.is_none_or(|s| *d >= s))
+        .collect();
+    candidates.sort();
+
+    let mut report = CompactReport::default();
+    for date in candidates.into_iter().take(max_days) {
+        // skip logic: if summary exists and --if-stale is off, skip
+        let (md_path, _) = summary_paths_for(date, root_override);
+        let force = if_stale;
+        if md_path.exists() && !if_stale {
+            report.skipped += 1;
+            report.day_reports.push(DayReport {
+                date,
+                outcome: Outcome::Skipped {
+                    reason: "summary exists",
+                },
+                extractive_spans: 0,
+                duration_ms: 0,
+            });
+            continue;
+        }
+        let r = compact_day(date, force, cfg, root_override).await?;
+        match &r.outcome {
+            Outcome::Written { .. } | Outcome::Noop => report.ok += 1,
+            Outcome::Failed(_) => report.err += 1,
+            Outcome::Skipped { .. } => report.skipped += 1,
+        }
+        report.day_reports.push(r);
+    }
+    Ok(report)
+}
+
+fn compute_input_sha(msgs: &[mur_common::Message]) -> String {
+    let mut h = Sha256::new();
+    for m in msgs {
+        h.update(serde_json::to_string(m).unwrap_or_default().as_bytes());
+        h.update(b"\n");
+    }
+    hex::encode(h.finalize())
+}
+
+fn top_keywords(spans: &[extractive::ExtractiveSpan], n: usize) -> Vec<String> {
+    use std::collections::HashMap;
+    // Tiny TF heuristic, no TF-IDF in Phase 2A (corpus-level IDF is Phase 3).
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for s in spans {
+        for w in s.text.split_whitespace() {
+            let w = w.to_lowercase();
+            if w.len() < 4 {
+                continue;
+            }
+            // strip trailing punctuation
+            let w = w
+                .trim_end_matches(|c: char| !c.is_alphanumeric())
+                .to_string();
+            if w.is_empty() {
+                continue;
+            }
+            *counts.entry(w).or_insert(0) += 1;
+        }
+    }
+    let mut ranked: Vec<_> = counts.into_iter().collect();
+    ranked.sort_by_key(|b| std::cmp::Reverse(b.1));
+    ranked.into_iter().take(n).map(|(k, _)| k).collect()
+}
+
+#[cfg(test)]
+mod orch_tests {
+    use super::*;
+    use chrono::{Datelike, TimeZone};
+    use mur_common::{Content, Message, Role, Source};
+
+    fn seed_raw(root: &str, date: NaiveDate, text: &str) {
+        let ts = chrono::Utc
+            .with_ymd_and_hms(date.year(), date.month(), date.day(), 10, 0, 0)
+            .unwrap();
+        let m = Message {
+            v: 1,
+            ts,
+            src: Source::ClaudeCode,
+            conv: "c1".into(),
+            role: Role::User,
+            content: Content::Text { value: text.into() },
+            meta: serde_json::Value::Null,
+            refs: vec![],
+        };
+        store::append(&m, Some(root)).unwrap();
+    }
+
+    fn cfg() -> CompactConfig {
+        CompactConfig::default()
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn compact_day_happy_path_mock() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        seed_raw(root, date, "mock extractive span");
+        let r = compact_day(date, false, &cfg(), Some(root)).await.unwrap();
+        match r.outcome {
+            Outcome::Written { .. } => {}
+            other => panic!("expected Written, got {:?}", other),
+        }
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn compact_day_noop_when_fresh() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        seed_raw(root, date, "mock extractive span");
+        let _ = compact_day(date, false, &cfg(), Some(root)).await.unwrap();
+        let r2 = compact_day(date, false, &cfg(), Some(root)).await.unwrap();
+        assert!(matches!(
+            r2.outcome,
+            Outcome::Skipped { .. } | Outcome::Noop
+        ));
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn compact_missing_respects_throttle() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        for i in 1..=10 {
+            let d = NaiveDate::from_ymd_opt(2026, 4, i).unwrap();
+            seed_raw(root, d, &format!("day {i} mock extractive span"));
+        }
+        let mut c = cfg();
+        c.max_days_per_run = 3;
+        let report = compact_missing(&c, None, false, None, Some(root))
+            .await
+            .unwrap();
+        assert_eq!(report.day_reports.len(), 3);
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+}

--- a/mur-core/src/conversations/summarize/mod.rs
+++ b/mur-core/src/conversations/summarize/mod.rs
@@ -6,4 +6,5 @@
 #![allow(dead_code)] // public API wired progressively across Tasks 4-10.
 
 pub mod chunker;
-// Later tasks add: pub mod extractive; pub mod abstractive; pub mod macro_refs; pub mod writer;
+pub mod extractive;
+// Later tasks add: pub mod abstractive; pub mod macro_refs; pub mod writer;

--- a/mur-core/src/conversations/summarize/mod.rs
+++ b/mur-core/src/conversations/summarize/mod.rs
@@ -107,6 +107,10 @@ pub async fn compact_day(
         all_spans.truncate(cfg.max_extractive_spans as usize);
     }
 
+    // Compute keywords BEFORE macro rewriting mutates spans (avoids
+    // {{pattern: ...}} markers polluting TF counts).
+    let keywords = top_keywords(&all_spans, 10);
+
     // Abstractive
     let abstractive_result = abstractive::summarize(
         &client,
@@ -134,9 +138,10 @@ pub async fn compact_day(
     let pattern_refs =
         macro_refs::detect_and_rewrite(&mut all_spans, &mut abstractive_text, &patterns_dir)
             .unwrap_or_default();
+    let word_count = abstractive_text.split_whitespace().count();
     let abstractive_final = abstractive::AbstractiveResult {
         narrative: Some(abstractive_text),
-        word_count: abstractive_result.word_count,
+        word_count,
     };
 
     // Frontmatter derived fields
@@ -155,7 +160,6 @@ pub async fn compact_day(
         c.dedup();
         c.len() as u32
     };
-    let keywords = top_keywords(&all_spans, 10);
 
     let doc = writer::SummaryDoc {
         date,
@@ -397,6 +401,82 @@ mod orch_tests {
             .await
             .unwrap();
         assert_eq!(report.day_reports.len(), 3);
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn keywords_exclude_macro_marker_tokens() {
+        // Guard: top_keywords must run on pre-macro-rewrite spans so the
+        // `{{pattern: name}}` markers don't pollute the keywords list.
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        // Mock extractive returns: [{"text":"mock extractive span", ...}] — one word "pattern"
+        // would appear only if we ran top_keywords on the mutated-by-macro-rewrite text.
+        // We don't seed any pattern files so macro_refs is a no-op; this test verifies
+        // the reorder is harmless (keywords derived from original span text), not that
+        // macro_refs actually runs — that's covered by macro_refs::tests.
+        seed_raw(root, date, "mock extractive span");
+        let r = compact_day(date, false, &cfg(), Some(root)).await.unwrap();
+        // Re-read the written summary and confirm no "pattern" keyword appears.
+        let (md_path, _) = summary_paths_for(date, Some(root));
+        let body = std::fs::read_to_string(&md_path).unwrap();
+        // The frontmatter keywords line.
+        let keywords_line = body
+            .lines()
+            .find(|l| l.starts_with("keywords:"))
+            .expect("keywords line missing");
+        assert!(
+            !keywords_line.contains("pattern"),
+            "pattern marker leaked into keywords: {keywords_line}"
+        );
+        assert!(
+            matches!(r.outcome, Outcome::Written { .. } | Outcome::Noop),
+            "expected Written/Noop, got {:?}",
+            r.outcome
+        );
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn narrative_fallback_word_count_is_consistent() {
+        // Guard: when abstractive narrative is None and we substitute a fallback
+        // string, the frontmatter word_count must match the rendered body, not
+        // stay at 0 from the failed result.
+        // We can't easily force the abstractive LLM to "fail" in mock mode (the
+        // mock always returns Ok with prose). Instead we test that word_count is
+        // computed from the rendered narrative via split_whitespace. For the mock
+        // happy path, the abstractive narrative starts with "Mock narrative: ...",
+        // so word_count should be >= 5 (the mock narrative length).
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        seed_raw(root, date, "mock extractive span");
+        let _ = compact_day(date, false, &cfg(), Some(root)).await.unwrap();
+        let (md_path, _) = summary_paths_for(date, Some(root));
+        let body = std::fs::read_to_string(&md_path).unwrap();
+        // Extract narrative section
+        let narrative_start = body
+            .find("## Abstractive narrative\n\n")
+            .expect("abstractive narrative section missing");
+        let narrative_slice = &body[narrative_start + "## Abstractive narrative\n\n".len()..];
+        let rendered_words = narrative_slice
+            .split_whitespace()
+            .take_while(|w| !w.starts_with("##"))
+            .count();
+        // The rendered narrative must contain at least one full sentence worth of words.
+        assert!(
+            rendered_words > 2,
+            "narrative too short: {} words in '{}'",
+            rendered_words,
+            narrative_slice.lines().next().unwrap_or("")
+        );
         unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
     }
 }

--- a/mur-core/src/conversations/summarize/mod.rs
+++ b/mur-core/src/conversations/summarize/mod.rs
@@ -8,4 +8,5 @@
 pub mod abstractive;
 pub mod chunker;
 pub mod extractive;
-// Later tasks add: pub mod macro_refs; pub mod writer;
+pub mod macro_refs;
+// Later tasks add: pub mod writer;

--- a/mur-core/src/conversations/summarize/mod.rs
+++ b/mur-core/src/conversations/summarize/mod.rs
@@ -1,0 +1,9 @@
+//! Sleep-time compact pipeline (Phase 2A, spec §4).
+//!
+//! Produces daily hybrid summaries: frontmatter + extractive spans +
+//! abstractive narrative + macro expansion map. See
+//! `docs/superpowers/specs/2026-04-20-mur-conversations-phase-2-design.md`.
+#![allow(dead_code)] // public API wired progressively across Tasks 4-10.
+
+pub mod chunker;
+// Later tasks add: pub mod extractive; pub mod abstractive; pub mod macro_refs; pub mod writer;

--- a/mur-core/src/conversations/summarize/mod.rs
+++ b/mur-core/src/conversations/summarize/mod.rs
@@ -322,6 +322,113 @@ fn top_keywords(spans: &[extractive::ExtractiveSpan], n: usize) -> Vec<String> {
     ranked.into_iter().take(n).map(|(k, _)| k).collect()
 }
 
+pub struct ParsedSummary {
+    pub date: NaiveDate,
+    pub frontmatter: serde_yaml::Value,
+    pub extractive: Vec<ParsedSpan>,
+    pub narrative: String,
+    pub pattern_refs: Vec<String>, // names only, full meta in frontmatter
+}
+
+#[derive(Debug, Clone)]
+pub struct ParsedSpan {
+    pub span_index: u32,
+    pub src: String, // file_prefix
+    pub conv_id: String,
+    pub line_hint: u32,
+    pub text: String,
+}
+
+pub fn parse_summary(md: &str) -> Result<ParsedSummary> {
+    let (frontmatter, body) = split_frontmatter(md)?;
+    let fm: serde_yaml::Value = serde_yaml::from_str(frontmatter)?;
+    let date_str = fm
+        .get("date")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing date"))?;
+    let date = NaiveDate::parse_from_str(date_str, "%Y-%m-%d")?;
+
+    let extractive = parse_extractive_section(body);
+    let narrative = parse_narrative_section(body);
+    let pattern_refs = fm
+        .get("pattern_refs")
+        .and_then(|v| v.as_sequence())
+        .map(|seq| {
+            seq.iter()
+                .filter_map(|e| e.get("name").and_then(|n| n.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok(ParsedSummary {
+        date,
+        frontmatter: fm,
+        extractive,
+        narrative,
+        pattern_refs,
+    })
+}
+
+fn split_frontmatter(md: &str) -> Result<(&str, &str)> {
+    let body = md
+        .strip_prefix("---\n")
+        .ok_or_else(|| anyhow::anyhow!("no frontmatter"))?;
+    let end = body
+        .find("\n---\n")
+        .ok_or_else(|| anyhow::anyhow!("unterminated frontmatter"))?;
+    let fm = &body[..end];
+    let rest = &body[end + 5..];
+    Ok((fm, rest))
+}
+
+fn parse_extractive_section(body: &str) -> Vec<ParsedSpan> {
+    let mut out = Vec::new();
+    let span_re =
+        regex::Regex::new(r"(?ms)^\[(\d+)\] _\{([^/]+)/([^ ]+) @L(\d+)\}_:\n((?:> [^\n]*\n?)+)")
+            .unwrap();
+    let ext_start = body.find("## Extractive spans").unwrap_or(0);
+    let ext_end = body[ext_start..]
+        .find("\n## ")
+        .map(|i| ext_start + i)
+        .unwrap_or(body.len());
+    let section = &body[ext_start..ext_end];
+    for cap in span_re.captures_iter(section) {
+        let idx: u32 = cap[1].parse().unwrap_or(0);
+        let src = cap[2].to_string();
+        let conv = cap[3].to_string();
+        let line: u32 = cap[4].parse().unwrap_or(0);
+        let quoted = &cap[5];
+        #[allow(clippy::useless_vec)]
+        let text: String = quoted
+            .lines()
+            .map(|l| l.trim_start_matches("> ").trim_start_matches('>'))
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string();
+        out.push(ParsedSpan {
+            span_index: idx,
+            src,
+            conv_id: conv,
+            line_hint: line,
+            text,
+        });
+    }
+    out
+}
+
+fn parse_narrative_section(body: &str) -> String {
+    let narr_start = body
+        .find("## Abstractive narrative")
+        .map(|i| i + "## Abstractive narrative".len())
+        .unwrap_or(0);
+    let narr_end = body[narr_start..]
+        .find("\n## ")
+        .map(|i| narr_start + i)
+        .unwrap_or(body.len());
+    body[narr_start..narr_end].trim().to_string()
+}
+
 #[cfg(test)]
 mod orch_tests {
     use super::*;
@@ -478,5 +585,46 @@ mod orch_tests {
             narrative_slice.lines().next().unwrap_or("")
         );
         unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[test]
+    fn parse_roundtrip_reads_frontmatter_and_body() {
+        let markdown = r#"---
+schema: 1
+date: 2026-04-19
+generated_at: 2026-04-19T03:00:00Z
+generated_by:
+  extractive_model: qwen3:14b
+  abstractive_model: qwen3:14b
+  mur_version: 2.4.0
+duration_ms: 100
+conv_count: 1
+msg_count: 2
+sources: [cc]
+pattern_refs: []
+keywords: [test]
+links:
+  prev: null
+  next: null
+warnings: []
+input_content_sha: abc123
+---
+
+## Extractive spans
+
+[1] _{cc/c1 @L1}_:
+> hello
+
+## Abstractive narrative
+
+Today was a test.
+"#;
+        let parsed = parse_summary(markdown).unwrap();
+        assert_eq!(parsed.date, NaiveDate::from_ymd_opt(2026, 4, 19).unwrap());
+        assert_eq!(parsed.extractive.len(), 1);
+        assert_eq!(parsed.extractive[0].conv_id, "c1");
+        assert_eq!(parsed.extractive[0].line_hint, 1);
+        assert_eq!(parsed.extractive[0].text, "hello");
+        assert!(parsed.narrative.contains("Today was a test"));
     }
 }

--- a/mur-core/src/conversations/summarize/writer.rs
+++ b/mur-core/src/conversations/summarize/writer.rs
@@ -1,0 +1,363 @@
+//! Atomic summary writer + .history/ archive + audit + LanceDB upsert.
+//! Spec §4.7. Each write:
+//!   1. Render Markdown (frontmatter + extractive + abstractive + macro map)
+//!   2. If file exists with different content: move to .history/<date>.<iso>.md
+//!   3. If file exists with identical content: no-op
+//!   4. Atomic write via tmp+rename
+//!   5. audit::Audit::append(Summarize{...})
+//!   6. LanceDB upsert at layer=1
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, NaiveDate, Utc};
+use sha2::{Digest, Sha256};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use super::super::audit::{self, AuditAction};
+use super::super::index::ConversationIndex;
+use super::super::paths::{summary_history_dir, summary_paths_for};
+use super::abstractive::AbstractiveResult;
+use super::extractive::ExtractiveSpan;
+use super::macro_refs::MacroRef;
+
+pub struct SummaryDoc {
+    pub date: NaiveDate,
+    pub generated_at: DateTime<Utc>,
+    pub extractive_model: String,
+    pub abstractive_model: String,
+    pub mur_version: String,
+    pub duration_ms: u64,
+    pub conv_count: u32,
+    pub msg_count: u32,
+    pub sources: Vec<String>, // file_prefix strings, sorted+dedup
+    pub pattern_refs: Vec<MacroRef>,
+    pub keywords: Vec<String>,
+    pub links_prev: Option<NaiveDate>,
+    pub links_next: Option<NaiveDate>,
+    pub warnings: Vec<String>,
+    pub input_content_sha: String,
+    pub extractive: Vec<ExtractiveSpan>,
+    pub abstractive: AbstractiveResult,
+}
+
+pub struct WriteResult {
+    pub path: PathBuf,
+    pub archived: Option<PathBuf>, // Some(path) if prior version was moved
+    pub noop: bool,                // true when content was byte-identical
+}
+
+pub async fn write_summary(
+    doc: &SummaryDoc,
+    summary_embedding: Vec<f32>,
+    root_override: Option<&str>,
+) -> Result<WriteResult> {
+    let (md_path, _yaml_path) = summary_paths_for(doc.date, root_override);
+    if let Some(parent) = md_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let new_body = render(doc);
+
+    let prior_exists = md_path.exists();
+    let archived;
+    let noop;
+
+    if prior_exists {
+        let existing = std::fs::read_to_string(&md_path)?;
+        if existing == new_body {
+            return Ok(WriteResult {
+                path: md_path,
+                archived: None,
+                noop: true,
+            });
+        }
+        archived = Some(archive_prior(&md_path, root_override)?);
+        noop = false;
+    } else {
+        archived = None;
+        noop = false;
+    }
+
+    let tmp = md_path.with_file_name(format!(".tmp.{}.md", doc.date.format("%Y-%m-%d")));
+    let mut f = std::fs::File::create(&tmp).with_context(|| format!("open tmp {tmp:?}"))?;
+    f.write_all(new_body.as_bytes())?;
+    f.sync_all()?;
+    drop(f);
+    std::fs::rename(&tmp, &md_path)?;
+
+    // Content hash for audit
+    let mut h = Sha256::new();
+    h.update(new_body.as_bytes());
+    let content_sha = hex::encode(h.finalize());
+
+    let audit_log = audit::Audit::open(root_override)?;
+    audit_log.append(
+        AuditAction::Summarize {
+            date: doc.date.format("%Y-%m-%d").to_string(),
+            model: doc.abstractive_model.clone(),
+            duration_ms: doc.duration_ms,
+        },
+        content_sha,
+    )?;
+
+    // Index upsert at layer=1
+    let mut idx = ConversationIndex::open(summary_embedding.len() as i32, root_override).await?;
+    let summary_msg = summary_row_as_message(doc);
+    idx.upsert_with_layer(&[(summary_msg, summary_embedding, 1)])
+        .await?;
+
+    Ok(WriteResult {
+        path: md_path,
+        archived,
+        noop,
+    })
+}
+
+/// Build a synthetic Message representing the summary for LanceDB storage.
+/// The index row uses the abstractive narrative as content so retrieval's
+/// keyword/MMR reranking has real text to work with.
+fn summary_row_as_message(doc: &SummaryDoc) -> mur_common::Message {
+    use chrono::TimeZone;
+    let ts = chrono::Utc.from_utc_datetime(&doc.date.and_hms_opt(0, 0, 0).unwrap());
+    let content_text = doc
+        .abstractive
+        .narrative
+        .clone()
+        .unwrap_or_else(|| "(no narrative)".to_string());
+    mur_common::Message {
+        v: 1,
+        ts,
+        src: mur_common::Source::ClaudeCode, // placeholder; summaries aggregate across sources
+        conv: format!("summary:{}", doc.date.format("%Y-%m-%d")),
+        role: mur_common::Role::System,
+        content: mur_common::Content::Text {
+            value: content_text,
+        },
+        meta: serde_json::json!({
+            "layer": 1,
+            "sources": doc.sources,
+            "conv_count": doc.conv_count,
+        }),
+        refs: doc.pattern_refs.iter().map(|r| r.name.clone()).collect(),
+    }
+}
+
+fn archive_prior(md_path: &Path, root_override: Option<&str>) -> Result<PathBuf> {
+    let hist = summary_history_dir(root_override);
+    std::fs::create_dir_all(&hist)?;
+    let stem = md_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .context("stem")?;
+    let now = Utc::now().format("%Y-%m-%dT%H-%M-%SZ").to_string();
+    let dest = hist.join(format!("{stem}.{now}.md"));
+    std::fs::rename(md_path, &dest).with_context(|| format!("archive {md_path:?} → {dest:?}"))?;
+    Ok(dest)
+}
+
+fn render(doc: &SummaryDoc) -> String {
+    let mut out = String::new();
+
+    // Frontmatter
+    out.push_str("---\n");
+    out.push_str("schema: 1\n");
+    out.push_str(&format!("date: {}\n", doc.date));
+    out.push_str(&format!(
+        "generated_at: {}\n",
+        doc.generated_at.format("%Y-%m-%dT%H:%M:%SZ")
+    ));
+    out.push_str("generated_by:\n");
+    out.push_str(&format!("  extractive_model: {}\n", doc.extractive_model));
+    out.push_str(&format!("  abstractive_model: {}\n", doc.abstractive_model));
+    out.push_str(&format!("  mur_version: {}\n", doc.mur_version));
+    out.push_str(&format!("duration_ms: {}\n", doc.duration_ms));
+    out.push_str(&format!("conv_count: {}\n", doc.conv_count));
+    out.push_str(&format!("msg_count: {}\n", doc.msg_count));
+    out.push_str(&format!("sources: [{}]\n", doc.sources.join(", ")));
+    if doc.pattern_refs.is_empty() {
+        out.push_str("pattern_refs: []\n");
+    } else {
+        out.push_str("pattern_refs:\n");
+        for r in &doc.pattern_refs {
+            out.push_str(&format!(
+                "  - name: {}\n    version: {}\n    sha: {}\n",
+                r.name, r.pattern_version, r.pattern_sha
+            ));
+        }
+    }
+    out.push_str(&format!("keywords: [{}]\n", doc.keywords.join(", ")));
+    out.push_str("links:\n");
+    out.push_str(&format!(
+        "  prev: {}\n",
+        doc.links_prev
+            .map(|d| format!("./{}.md", d))
+            .unwrap_or_else(|| "null".into())
+    ));
+    out.push_str(&format!(
+        "  next: {}\n",
+        doc.links_next
+            .map(|d| format!("./{}.md", d))
+            .unwrap_or_else(|| "null".into())
+    ));
+    if doc.warnings.is_empty() {
+        out.push_str("warnings: []\n");
+    } else {
+        out.push_str("warnings:\n");
+        for w in &doc.warnings {
+            out.push_str(&format!("  - {}\n", w));
+        }
+    }
+    out.push_str(&format!("input_content_sha: {}\n", doc.input_content_sha));
+    out.push_str("---\n\n");
+
+    // Body
+    out.push_str("## Extractive spans\n\n");
+    for (i, s) in doc.extractive.iter().enumerate() {
+        out.push_str(&format!(
+            "[{}] _{{{}/{} @L{}}}_:\n> {}\n\n",
+            i + 1,
+            s.src.file_prefix(),
+            s.conv_id,
+            s.line_hint,
+            s.text.replace('\n', "\n> ")
+        ));
+    }
+
+    out.push_str("## Abstractive narrative\n\n");
+    let narrative = doc
+        .abstractive
+        .narrative
+        .as_deref()
+        .unwrap_or("(narrative generation failed; see warnings)");
+    out.push_str(narrative);
+    out.push_str("\n\n");
+
+    if !doc.pattern_refs.is_empty() {
+        out.push_str("## Macro expansion map\n\n");
+        for r in &doc.pattern_refs {
+            out.push_str(&format!(
+                "- {} → patterns/{}.yaml (v{}, sha {}…)\n",
+                r.marker,
+                r.name,
+                r.pattern_version,
+                r.pattern_sha.chars().take(8).collect::<String>()
+            ));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::{Role, Source};
+
+    fn dummy_doc(date: NaiveDate) -> SummaryDoc {
+        SummaryDoc {
+            date,
+            generated_at: Utc::now(),
+            extractive_model: "qwen3:14b".into(),
+            abstractive_model: "qwen3:14b".into(),
+            mur_version: "2.4.0".into(),
+            duration_ms: 1234,
+            conv_count: 1,
+            msg_count: 2,
+            sources: vec!["cc".into()],
+            pattern_refs: vec![],
+            keywords: vec!["test".into()],
+            links_prev: None,
+            links_next: None,
+            warnings: vec![],
+            input_content_sha: "deadbeef".into(),
+            extractive: vec![ExtractiveSpan {
+                role: Role::User,
+                conv_id: "c1".into(),
+                line_hint: 1,
+                text: "hello".into(),
+                src: Source::ClaudeCode,
+            }],
+            abstractive: AbstractiveResult {
+                narrative: Some("Today the developer said hello.".into()),
+                word_count: 5,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn writes_valid_frontmatter_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        let doc = dummy_doc(date);
+        let r = write_summary(&doc, vec![0.0; 16], Some(root))
+            .await
+            .unwrap();
+        assert!(!r.noop);
+        assert!(r.archived.is_none());
+        let body = std::fs::read_to_string(&r.path).unwrap();
+        assert!(body.contains("date: 2026-04-19"));
+        assert!(body.contains("## Extractive spans"));
+        assert!(body.contains("## Abstractive narrative"));
+        assert!(body.contains("Today the developer said hello."));
+    }
+
+    #[tokio::test]
+    async fn second_identical_write_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        let doc = dummy_doc(date);
+        let mut d2 = dummy_doc(date);
+        d2.generated_at = doc.generated_at; // force bit-identical
+        let _ = write_summary(&doc, vec![0.0; 16], Some(root))
+            .await
+            .unwrap();
+        let r2 = write_summary(&d2, vec![0.0; 16], Some(root)).await.unwrap();
+        assert!(r2.noop);
+        assert!(r2.archived.is_none());
+    }
+
+    #[tokio::test]
+    async fn overwrite_archives_prior() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        let mut doc1 = dummy_doc(date);
+        doc1.abstractive.narrative = Some("version 1".into());
+        let _ = write_summary(&doc1, vec![0.0; 16], Some(root))
+            .await
+            .unwrap();
+        let mut doc2 = dummy_doc(date);
+        doc2.abstractive.narrative = Some("version 2".into());
+        let r2 = write_summary(&doc2, vec![0.0; 16], Some(root))
+            .await
+            .unwrap();
+        assert!(r2.archived.is_some());
+        let hist = summary_history_dir(Some(root));
+        let entries: Vec<_> = std::fs::read_dir(&hist).unwrap().collect();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn audit_records_summarize_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        let doc = dummy_doc(date);
+        let _ = write_summary(&doc, vec![0.0; 16], Some(root))
+            .await
+            .unwrap();
+
+        // Chain is intact (verify returns true) and at least one Summarize entry exists.
+        assert!(
+            audit::verify(Some(root)).unwrap(),
+            "audit chain must verify"
+        );
+        let audit_path = super::super::super::paths::audit_path(Some(root));
+        let body = std::fs::read_to_string(&audit_path).unwrap();
+        let has_summarize = body
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .any(|l| l.contains("\"kind\":\"summarize\""));
+        assert!(has_summarize, "audit file must record a Summarize entry");
+    }
+}

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -1053,7 +1053,9 @@ async fn async_main() -> Result<()> {
             ConversationsAction::Reindex => {
                 cmd::conversations_cmd::cmd_conversations_reindex().await?
             }
-            ConversationsAction::Doctor => cmd::conversations_cmd::cmd_conversations_doctor()?,
+            ConversationsAction::Doctor => {
+                cmd::conversations_cmd::cmd_conversations_doctor().await?
+            }
             ConversationsAction::Preflight => {
                 cmd::conversations_cmd::cmd_conversations_preflight()?
             }

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -688,6 +688,36 @@ enum ConversationsAction {
     },
     /// Roll back to commander's old paths
     Rollback,
+    /// Generate hybrid summaries for completed days (sleep-time compact).
+    Compact {
+        /// One specific date (otherwise process all missing completed days).
+        #[arg(long)]
+        date: Option<String>,
+
+        /// Lower bound for the sweep (ignored with --date).
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Overwrite existing summaries. Archives old version to .history/.
+        #[arg(long)]
+        force: bool,
+
+        /// Only regenerate when raw content hash changed (implies force).
+        #[arg(long)]
+        if_stale: bool,
+
+        /// Override throttle (default: config.compact.max_days_per_run).
+        #[arg(long)]
+        max_days: Option<u32>,
+
+        /// Don't call Ollama — emit extractive-only skeleton (for testing).
+        #[arg(long)]
+        extractive_only: bool,
+
+        /// Emit the LLM prompts to stderr without sending them.
+        #[arg(long)]
+        debug_prompt: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1037,6 +1067,28 @@ async fn async_main() -> Result<()> {
             }
             ConversationsAction::Rollback => {
                 cmd::conversations_cmd::cmd_conversations_rollback().await?
+            }
+            ConversationsAction::Compact {
+                date,
+                since,
+                force,
+                if_stale,
+                max_days,
+                extractive_only,
+                debug_prompt,
+            } => {
+                cmd::conversations_cmd::cmd_conversations_compact(
+                    cmd::conversations_cmd::CompactArgs {
+                        date,
+                        since,
+                        force,
+                        if_stale,
+                        max_days,
+                        extractive_only,
+                        debug_prompt,
+                    },
+                )
+                .await?
             }
         },
         Commands::Deploy { action } => match action {

--- a/mur-core/tests/cli_conversations.rs
+++ b/mur-core/tests/cli_conversations.rs
@@ -21,9 +21,14 @@ fn mur_conversations_doctor_runs() {
     let out = Command::new(env!("CARGO_BIN_EXE_mur"))
         .args(["conversations", "doctor"])
         .env("HOME", tmp.path())
+        .env("MUR_OLLAMA_MOCK", "1")
         .output()
         .expect("run mur");
     assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("raw day-dirs"));
+    assert!(stdout.contains("summaries:")); // NEW Phase 2A
+    assert!(stdout.contains("Ollama")); // NEW Phase 2A
 }
 
 #[test]

--- a/mur-core/tests/cli_conversations.rs
+++ b/mur-core/tests/cli_conversations.rs
@@ -1,11 +1,18 @@
+use std::path::Path;
 use std::process::Command;
+
+/// Route `dirs::home_dir()` to `tmp` on every platform:
+/// * Unix: `HOME`
+/// * Windows: `USERPROFILE` (the `dirs` crate ignores `HOME` on Windows)
+fn with_home<'a>(cmd: &'a mut Command, tmp: &Path) -> &'a mut Command {
+    cmd.env("HOME", tmp).env("USERPROFILE", tmp)
+}
 
 #[test]
 fn mur_chat_list_runs_without_error() {
     let tmp = tempfile::tempdir().unwrap();
-    let out = Command::new(env!("CARGO_BIN_EXE_mur"))
-        .args(["chat", "list"])
-        .env("HOME", tmp.path())
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mur"));
+    let out = with_home(cmd.args(["chat", "list"]), tmp.path())
         .output()
         .expect("run mur");
     assert!(
@@ -18,9 +25,8 @@ fn mur_chat_list_runs_without_error() {
 #[test]
 fn mur_conversations_doctor_runs() {
     let tmp = tempfile::tempdir().unwrap();
-    let out = Command::new(env!("CARGO_BIN_EXE_mur"))
-        .args(["conversations", "doctor"])
-        .env("HOME", tmp.path())
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mur"));
+    let out = with_home(cmd.args(["conversations", "doctor"]), tmp.path())
         .env("MUR_OLLAMA_MOCK", "1")
         .output()
         .expect("run mur");
@@ -34,9 +40,8 @@ fn mur_conversations_doctor_runs() {
 #[test]
 fn mur_conversations_compact_on_empty_archive_is_noop() {
     let tmp = tempfile::tempdir().unwrap();
-    let out = Command::new(env!("CARGO_BIN_EXE_mur"))
-        .args(["conversations", "compact"])
-        .env("HOME", tmp.path())
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mur"));
+    let out = with_home(cmd.args(["conversations", "compact"]), tmp.path())
         .env("MUR_OLLAMA_MOCK", "1")
         .output()
         .expect("run mur");
@@ -80,9 +85,8 @@ fn mur_conversations_compact_on_seeded_day_produces_summary() {
         serde_json::to_string(&line).unwrap() + "\n",
     )
     .unwrap();
-    let out = Command::new(env!("CARGO_BIN_EXE_mur"))
-        .args(["conversations", "compact"])
-        .env("HOME", home)
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mur"));
+    let out = with_home(cmd.args(["conversations", "compact"]), home)
         .env("MUR_OLLAMA_MOCK", "1")
         .output()
         .expect("run mur");

--- a/mur-core/tests/cli_conversations.rs
+++ b/mur-core/tests/cli_conversations.rs
@@ -1,20 +1,26 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Route `dirs::home_dir()` to `tmp` on every platform:
-/// * Unix: `HOME`
-/// * Windows: `USERPROFILE` (the `dirs` crate ignores `HOME` on Windows)
-fn with_home<'a>(cmd: &'a mut Command, tmp: &Path) -> &'a mut Command {
-    cmd.env("HOME", tmp).env("USERPROFILE", tmp)
+/// Pin mur's data root to `<tmp>/.mur` via `MUR_HOME`.
+///
+/// Also sets `HOME` / `USERPROFILE` to `tmp` for any code that reaches for
+/// `dirs::home_dir()` outside the conversations paths module (e.g. tracing
+/// setup, legacy callers). On Windows, only `MUR_HOME` is authoritative
+/// because `dirs` calls `SHGetKnownFolderPath` and bypasses env entirely.
+fn with_mur_home<'a>(cmd: &'a mut Command, tmp: &Path) -> (&'a mut Command, PathBuf) {
+    let mur_home = tmp.join(".mur");
+    cmd.env("MUR_HOME", &mur_home)
+        .env("HOME", tmp)
+        .env("USERPROFILE", tmp);
+    (cmd, mur_home)
 }
 
 #[test]
 fn mur_chat_list_runs_without_error() {
     let tmp = tempfile::tempdir().unwrap();
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_mur"));
-    let out = with_home(cmd.args(["chat", "list"]), tmp.path())
-        .output()
-        .expect("run mur");
+    let (cmd, _mur_home) = with_mur_home(cmd.args(["chat", "list"]), tmp.path());
+    let out = cmd.output().expect("run mur");
     assert!(
         out.status.success(),
         "stderr: {}",
@@ -26,10 +32,8 @@ fn mur_chat_list_runs_without_error() {
 fn mur_conversations_doctor_runs() {
     let tmp = tempfile::tempdir().unwrap();
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_mur"));
-    let out = with_home(cmd.args(["conversations", "doctor"]), tmp.path())
-        .env("MUR_OLLAMA_MOCK", "1")
-        .output()
-        .expect("run mur");
+    let (cmd, _mur_home) = with_mur_home(cmd.args(["conversations", "doctor"]), tmp.path());
+    let out = cmd.env("MUR_OLLAMA_MOCK", "1").output().expect("run mur");
     assert!(out.status.success());
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("raw day-dirs"));
@@ -41,10 +45,8 @@ fn mur_conversations_doctor_runs() {
 fn mur_conversations_compact_on_empty_archive_is_noop() {
     let tmp = tempfile::tempdir().unwrap();
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_mur"));
-    let out = with_home(cmd.args(["conversations", "compact"]), tmp.path())
-        .env("MUR_OLLAMA_MOCK", "1")
-        .output()
-        .expect("run mur");
+    let (cmd, _mur_home) = with_mur_home(cmd.args(["conversations", "compact"]), tmp.path());
+    let out = cmd.env("MUR_OLLAMA_MOCK", "1").output().expect("run mur");
     assert!(
         out.status.success(),
         "stderr: {}",
@@ -60,15 +62,11 @@ fn mur_conversations_compact_on_empty_archive_is_noop() {
 #[test]
 fn mur_conversations_compact_on_seeded_day_produces_summary() {
     let tmp = tempfile::tempdir().unwrap();
-    let home = tmp.path();
+    let mur_home = tmp.path().join(".mur");
     let yesterday = (chrono::Utc::now().date_naive() - chrono::Duration::days(1))
         .format("%Y-%m-%d")
         .to_string();
-    let raw = home
-        .join(".mur")
-        .join("conversations")
-        .join("raw")
-        .join(&yesterday);
+    let raw = mur_home.join("conversations").join("raw").join(&yesterday);
     std::fs::create_dir_all(&raw).unwrap();
     let line = serde_json::json!({
         "v": 1,
@@ -86,23 +84,18 @@ fn mur_conversations_compact_on_seeded_day_produces_summary() {
     )
     .unwrap();
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_mur"));
-    let out = with_home(cmd.args(["conversations", "compact"]), home)
-        .env("MUR_OLLAMA_MOCK", "1")
-        .output()
-        .expect("run mur");
-    assert!(
-        out.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let summary = home
-        .join(".mur")
+    let (cmd, _mur_home_arg) = with_mur_home(cmd.args(["conversations", "compact"]), tmp.path());
+    let out = cmd.env("MUR_OLLAMA_MOCK", "1").output().expect("run mur");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "stdout: {stdout}\nstderr: {stderr}");
+    let summary = mur_home
         .join("conversations")
         .join("summary")
         .join(format!("{yesterday}.md"));
     assert!(
         summary.exists(),
-        "summary should have been written at {summary:?}"
+        "summary should have been written at {summary:?}\nstdout: {stdout}\nstderr: {stderr}"
     );
     let body = std::fs::read_to_string(&summary).unwrap();
     assert!(body.contains("## Extractive spans"));

--- a/mur-core/tests/cli_conversations.rs
+++ b/mur-core/tests/cli_conversations.rs
@@ -25,3 +25,77 @@ fn mur_conversations_doctor_runs() {
         .expect("run mur");
     assert!(out.status.success());
 }
+
+#[test]
+fn mur_conversations_compact_on_empty_archive_is_noop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args(["conversations", "compact"])
+        .env("HOME", tmp.path())
+        .env("MUR_OLLAMA_MOCK", "1")
+        .output()
+        .expect("run mur");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("(nothing to compact)") || stdout.contains("done:"),
+        "unexpected output: {stdout}"
+    );
+}
+
+#[test]
+fn mur_conversations_compact_on_seeded_day_produces_summary() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let yesterday = (chrono::Utc::now().date_naive() - chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+    let raw = home
+        .join(".mur")
+        .join("conversations")
+        .join("raw")
+        .join(&yesterday);
+    std::fs::create_dir_all(&raw).unwrap();
+    let line = serde_json::json!({
+        "v": 1,
+        "ts": format!("{yesterday}T10:00:00Z"),
+        "src": "claude-code",
+        "conv": "c1",
+        "role": "user",
+        "content": {"t": "text", "v": "mock extractive span seeded for compact test"},
+        "meta": {},
+        "refs": []
+    });
+    std::fs::write(
+        raw.join("cc_c1.jsonl"),
+        serde_json::to_string(&line).unwrap() + "\n",
+    )
+    .unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args(["conversations", "compact"])
+        .env("HOME", home)
+        .env("MUR_OLLAMA_MOCK", "1")
+        .output()
+        .expect("run mur");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let summary = home
+        .join(".mur")
+        .join("conversations")
+        .join("summary")
+        .join(format!("{yesterday}.md"));
+    assert!(
+        summary.exists(),
+        "summary should have been written at {summary:?}"
+    );
+    let body = std::fs::read_to_string(&summary).unwrap();
+    assert!(body.contains("## Extractive spans"));
+    assert!(body.contains("## Abstractive narrative"));
+}


### PR DESCRIPTION
## Summary

Phase 2A of the mur conversations archive: **sleep-time compact pipeline** that produces daily hybrid summaries (frontmatter + extractive spans + abstractive narrative + Freedman macro references), unblocking retention rotation (which requires a summary to exist before deleting raw).

Paired with [mur-run/mur-commander#PR](https://github.com/mur-run/mur-commander/pull/new/feat/conversations-phase-2) for the daemon piggyback.

**Spec:** \`docs/superpowers/specs/2026-04-20-mur-conversations-phase-2-design.md\` (commit d0ee36f)
**Plan:** \`docs/superpowers/plans/2026-04-20-mur-conversations-phase-2.md\` (commit 2544d03) — Tasks 1-13 + 17 shipped here (14-16 are in the commander PR).

## What ships

- \`CompactConfig\` in \`mur-common::config\` — 10 fields with serde defaults
- \`conversations::ollama\` shared HTTP client — non-streaming + streaming (\`generate\` + \`generate_stream\`), NDJSON-buffered, \`MUR_OLLAMA_MOCK=1\` env short-circuits to deterministic canned responses
- \`summarize/{chunker, extractive, abstractive, macro_refs, writer}\` — the full pipeline:
  - Chunker: conv-boundary-aware greedy packer under token budget
  - Extractive: per-chunk LLM span extraction + Jaro-Winkler verbatim validation (inline impl, no extra dep)
  - Abstractive: single LLM call, 150-400 word narrative
  - Macro refs: Aho-Corasick pattern-name detection with word-boundary + code-fence skip
  - Writer: atomic tmp+rename + \`.history/<date>.<iso>.md\` archive + audit \`Summarize\` + LanceDB \`layer=1\` upsert
- \`summarize::{compact_day, compact_missing}\` orchestrator — 7-step pipeline (read → chunk → extract → dedup+cap → abstractive → macro → write) with \`--if-stale\` input-sha guard and throttled sweep
- \`parse_summary\` reader — round-trip parser for retrieval/chat-show (Phase 2B)
- \`mur conversations compact [--date|--since|--force|--if-stale|--max-days|--extractive-only|--debug-prompt]\` CLI
- \`conversations::index\` — \`layer: Option<i8>\` search filter + \`upsert_with_layer\`
- \`migrate::sync_commander_config_toml\` — P4 sync now emits \`[conversations.compact]\` subsection (idempotent, marker-delimited)
- \`mur conversations doctor\` — reports summary coverage vs completed days + 1s Ollama reachability probe

## Test plan
- [x] All 603 mur-core tests pass under default parallelism (\`cargo test -p mur-core\`)
- [x] All 12 migrate tests pass including new idempotency test
- [x] All 4 cli_conversations integration tests pass (2 new compact tests + 1 updated doctor test)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] MUR_OLLAMA_MOCK=1 deterministic test path covers extractive + abstractive + ask (citation) branches
- [ ] Real-Ollama smoke tests — Phase 2C (feature-gated)
- [ ] Review on Windows CI for the env-var MUTEX pattern (tests use \`crate::conversations::ENV_LOCK\` for MUR_OLLAMA_MOCK serialization across modules)

## Known deferrals to Phase 2C

- Concurrent-write lock on compact pipeline (no daemon+CLI racing today; single-run semantics)
- Audit/index failure recovery (markdown ships successfully; LanceDB is rebuildable)
- \`.history/\` retention cleanup (Task 28)
- \`--strict-citations\` reject mode (Task 29)
- \`conversations preflight\` Ollama model-availability check (Task 30)
- Real-Ollama smoke tests (Task 31, feature-gated)

## Cross-repo compatibility

Default \`conversations.compact.daemon_cron\` is now \`"0 0 3 * * * *"\` (7-field) to match \`cron = 0.15\` on the commander side. See paired commander PR for the matching trigger + daemon wire-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)