### PR TITLE
feat(conversations): Phase 2B — Mode C Ask (RAG with citations)

### DIFF
--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -226,6 +226,77 @@ fn default_server_url() -> String {
     "https://mur-server.fly.dev".to_string()
 }
 
+// ── Ask config (Phase 2B, Task 18) ───────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AskConfig {
+    #[serde(default = "ask_default_model")]
+    pub model: String,
+    #[serde(default = "compact_default_ollama_endpoint")]
+    pub ollama_endpoint: String,
+    #[serde(default = "ask_default_k_summary")]
+    pub k_summary: u32,
+    #[serde(default = "ask_default_k_raw")]
+    pub k_raw: u32,
+    #[serde(default = "ask_default_esc")]
+    pub escalation_threshold: f64,
+    #[serde(default = "ask_default_mmr")]
+    pub mmr_threshold: f64,
+    #[serde(default = "ask_default_max_ctx")]
+    pub max_context_tokens: u32,
+    #[serde(default = "ask_default_resp_tok")]
+    pub response_tokens: u32,
+    #[serde(default = "ask_default_timeout")]
+    pub timeout_secs: u32,
+    #[serde(default = "ask_default_min_score")]
+    pub min_score: f64,
+}
+
+impl Default for AskConfig {
+    fn default() -> Self {
+        Self {
+            model: ask_default_model(),
+            ollama_endpoint: compact_default_ollama_endpoint(),
+            k_summary: ask_default_k_summary(),
+            k_raw: ask_default_k_raw(),
+            escalation_threshold: ask_default_esc(),
+            mmr_threshold: ask_default_mmr(),
+            max_context_tokens: ask_default_max_ctx(),
+            response_tokens: ask_default_resp_tok(),
+            timeout_secs: ask_default_timeout(),
+            min_score: ask_default_min_score(),
+        }
+    }
+}
+
+fn ask_default_model() -> String {
+    "qwen3:14b".into()
+}
+fn ask_default_k_summary() -> u32 {
+    5
+}
+fn ask_default_k_raw() -> u32 {
+    10
+}
+fn ask_default_esc() -> f64 {
+    0.5
+}
+fn ask_default_mmr() -> f64 {
+    0.85
+}
+fn ask_default_max_ctx() -> u32 {
+    6000
+}
+fn ask_default_resp_tok() -> u32 {
+    1024
+}
+fn ask_default_timeout() -> u32 {
+    120
+}
+fn ask_default_min_score() -> f64 {
+    0.35
+}
+
 // ── Conversations archive config (Task 23) ────────────────────────────────────
 
 /// Phase 1 conversations archive config (Task 23).
@@ -248,6 +319,8 @@ pub struct ConversationsConfig {
     pub filter: ConversationsFilter,
     #[serde(default)]
     pub compact: CompactConfig,
+    #[serde(default)]
+    pub ask: AskConfig,
 }
 
 impl Default for ConversationsConfig {
@@ -259,6 +332,7 @@ impl Default for ConversationsConfig {
             sources: ConversationsSources::default(),
             filter: ConversationsFilter::default(),
             compact: CompactConfig::default(),
+            ask: AskConfig::default(),
         }
     }
 }
@@ -494,5 +568,20 @@ conversations:
         assert_eq!(conv.compact.extractive_model, "qwen3:4b");
         assert!(conv.compact.enabled_in_daemon); // default preserved
         assert_eq!(conv.compact.abstractive_model, "qwen3:14b"); // default preserved
+    }
+
+    #[test]
+    fn ask_config_defaults() {
+        let c = AskConfig::default();
+        assert_eq!(c.model, "qwen3:14b");
+        assert_eq!(c.ollama_endpoint, "http://localhost:11434");
+        assert_eq!(c.k_summary, 5);
+        assert_eq!(c.k_raw, 10);
+        assert_eq!(c.escalation_threshold, 0.5);
+        assert_eq!(c.mmr_threshold, 0.85);
+        assert_eq!(c.max_context_tokens, 6000);
+        assert_eq!(c.response_tokens, 1024);
+        assert_eq!(c.timeout_secs, 120);
+        assert_eq!(c.min_score, 0.35);
     }
 }

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -39,6 +39,7 @@ lancedb = "0.26"
 arrow-array = "57"
 arrow-schema = "57"
 futures = "0.3"
+async-stream = "0.3"
 tokio-util = "0.7"
 
 # Phase 0: local API server (optional, behind "server" feature)

--- a/mur-core/src/cmd/conversations_cmd.rs
+++ b/mur-core/src/cmd/conversations_cmd.rs
@@ -455,6 +455,19 @@ pub struct CompactArgs {
     pub debug_prompt: bool,
 }
 
+pub struct AskArgs {
+    pub question: String,
+    pub src: Option<String>,
+    pub since: Option<String>,
+    pub until: Option<String>,
+    pub k: usize,
+    pub model: Option<String>,
+    pub min_score: Option<f64>,
+    pub json: bool,
+    pub no_escalate: bool,
+    pub debug_prompt: bool,
+}
+
 pub async fn cmd_conversations_compact(args: CompactArgs) -> Result<()> {
     use crate::conversations::summarize;
     use chrono::NaiveDate;
@@ -504,5 +517,106 @@ pub async fn cmd_conversations_compact(args: CompactArgs) -> Result<()> {
         "done: {} ok, {} failed, {} skipped",
         report.ok, report.err, report.skipped
     );
+    Ok(())
+}
+
+pub async fn cmd_ask(args: AskArgs) -> Result<()> {
+    use crate::conversations::ask;
+    use chrono::NaiveDate;
+    use futures::StreamExt;
+    use std::io::Write;
+
+    let cfg = crate::store::config::load_config().unwrap_or_default();
+    let ask_cfg = cfg.conversations.ask.clone();
+    let model = args.model.unwrap_or_else(|| ask_cfg.model.clone());
+
+    let sources = args.src.as_deref().map(parse_sources).unwrap_or_default();
+
+    let filters = ask::Filters {
+        source: sources,
+        since: args
+            .since
+            .as_deref()
+            .map(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d"))
+            .transpose()?,
+        until: args
+            .until
+            .as_deref()
+            .map(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d"))
+            .transpose()?,
+        min_score: args.min_score.unwrap_or(ask_cfg.min_score),
+    };
+
+    let req = ask::AskRequest {
+        question: args.question.clone(),
+        filters,
+        k_summary: args.k,
+        k_raw: args.k * 2,
+        escalation_threshold: ask_cfg.escalation_threshold,
+        mmr_threshold: ask_cfg.mmr_threshold,
+        model,
+        endpoint: ask_cfg.ollama_endpoint.clone(),
+        format: if args.json {
+            ask::Format::Json
+        } else {
+            ask::Format::Plain
+        },
+        max_context_tokens: ask_cfg.max_context_tokens as usize,
+        response_tokens: ask_cfg.response_tokens as usize,
+        timeout: std::time::Duration::from_secs(ask_cfg.timeout_secs as u64),
+        no_escalate: args.no_escalate,
+        debug_prompt: args.debug_prompt,
+    };
+
+    if args.json {
+        let resp = ask::ask(req, None).await?;
+        println!("{}", serde_json::to_string_pretty(&resp)?);
+    } else {
+        let mut stream = ask::ask_stream(req, None).await?;
+        let mut citations = Vec::new();
+        let mut degraded = false;
+        let mut tokens_in = 0;
+        let mut tokens_out = 0;
+        let mut duration = 0;
+        while let Some(evt) = stream.next().await {
+            match evt? {
+                ask::AskEvent::Token(t) => {
+                    print!("{t}");
+                    std::io::stdout().flush()?;
+                }
+                ask::AskEvent::Citation(c) => citations.push(c),
+                ask::AskEvent::HitInfo(_) => {}
+                ask::AskEvent::Done {
+                    tokens_in: ti,
+                    tokens_out: to,
+                    degraded: d,
+                    duration_ms,
+                } => {
+                    tokens_in = ti;
+                    tokens_out = to;
+                    degraded = d;
+                    duration = duration_ms;
+                }
+                ask::AskEvent::Error(e) => {
+                    eprintln!("\nerror: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        println!();
+        print!(
+            "{}{}",
+            crate::conversations::ask::format::render_citations_block(&citations),
+            crate::conversations::ask::format::render_footer(&ask::AskResponse {
+                answer: String::new(),
+                citations: citations.clone(),
+                hits_used: vec![],
+                degraded_to_mode_b: degraded,
+                tokens_in,
+                tokens_out,
+                duration_ms: duration,
+            }),
+        );
+    }
     Ok(())
 }

--- a/mur-core/src/conversations/ask/cite.rs
+++ b/mur-core/src/conversations/ask/cite.rs
@@ -1,0 +1,120 @@
+//! Grounding + coverage checks (spec §5.5).
+//! Strips unknown [cit: ...] from streaming tokens (prevents hallucination).
+
+pub struct GroundingFilter {
+    valid: std::collections::HashSet<String>,
+    buffer: String, // tail buffer to detect brackets across chunk boundaries
+}
+
+pub struct FilterOutput {
+    pub forwarded: String,
+    pub stripped: Vec<String>,
+}
+
+impl GroundingFilter {
+    pub fn new(valid: Vec<String>) -> Self {
+        Self {
+            valid: valid.into_iter().collect(),
+            buffer: String::new(),
+        }
+    }
+
+    pub fn feed(&mut self, token: &str) -> FilterOutput {
+        self.buffer.push_str(token);
+        let mut forwarded = String::new();
+        let mut stripped = Vec::new();
+        loop {
+            // If no open bracket, we can flush everything up to the last 64 chars
+            // (hold those back in case an opening bracket arrives split across tokens).
+            match self.buffer.find("[cit:") {
+                None => {
+                    if self.buffer.len() > 64 {
+                        let flush_upto = self.buffer.len() - 64;
+                        let boundary = find_char_boundary(&self.buffer, flush_upto);
+                        forwarded.push_str(&self.buffer[..boundary]);
+                        self.buffer.drain(..boundary);
+                    }
+                    break;
+                }
+                Some(start) => {
+                    // Flush prefix before the bracket.
+                    if start > 0 {
+                        forwarded.push_str(&self.buffer[..start]);
+                        self.buffer.drain(..start);
+                    }
+                    // Look for the closing ']'.
+                    match self.buffer.find(']') {
+                        None => {
+                            // Bracket incomplete — wait for more input.
+                            break;
+                        }
+                        Some(end) => {
+                            let candidate = &self.buffer[..=end];
+                            if self.valid.contains(candidate) {
+                                forwarded.push_str(candidate);
+                            } else {
+                                stripped.push(candidate.to_string());
+                            }
+                            self.buffer.drain(..=end);
+                        }
+                    }
+                }
+            }
+        }
+        FilterOutput {
+            forwarded,
+            stripped,
+        }
+    }
+
+    pub fn flush(&mut self) -> FilterOutput {
+        let mut out = self.feed("");
+        // Drain remaining buffer (no more input coming)
+        out.forwarded.push_str(&self.buffer);
+        self.buffer.clear();
+        out
+    }
+}
+
+fn find_char_boundary(s: &str, target: usize) -> usize {
+    let mut b = target;
+    while b > 0 && !s.is_char_boundary(b) {
+        b -= 1;
+    }
+    b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_known_citation_verbatim() {
+        let mut f = GroundingFilter::new(vec!["[cit: 2026-04-19 cc/a:L1]".into()]);
+        let out = f.feed("Answer [cit: 2026-04-19 cc/a:L1] done.");
+        let drain = f.flush();
+        assert!((out.forwarded + &drain.forwarded).contains("[cit: 2026-04-19 cc/a:L1]"));
+        assert!(out.stripped.is_empty() && drain.stripped.is_empty());
+    }
+
+    #[test]
+    fn strips_unknown_citation() {
+        let mut f = GroundingFilter::new(vec!["[cit: 2026-04-19 cc/a:L1]".into()]);
+        let out = f.feed("Claim [cit: 2099-01-01 fake:L0] done.");
+        let drain = f.flush();
+        let combined = out.forwarded + &drain.forwarded;
+        assert!(!combined.contains("[cit: 2099-01-01 fake:L0]"));
+        assert_eq!(out.stripped.len() + drain.stripped.len(), 1);
+    }
+
+    #[test]
+    fn handles_bracket_split_across_tokens() {
+        let mut f = GroundingFilter::new(vec!["[cit: 2026-04-19 cc/a:L1]".into()]);
+        let mut combined = String::new();
+        combined.push_str(&f.feed("start [c").forwarded);
+        combined.push_str(&f.feed("it: 2026-04-19 cc/a").forwarded);
+        combined.push_str(&f.feed(":L1] end").forwarded);
+        combined.push_str(&f.flush().forwarded);
+        assert!(combined.contains("[cit: 2026-04-19 cc/a:L1]"));
+    }
+}

--- a/mur-core/src/conversations/ask/format.rs
+++ b/mur-core/src/conversations/ask/format.rs
@@ -1,0 +1,96 @@
+//! Output formatting for ask (spec §5.6).
+//! Plain: streaming answer + trailing citation block + runtime footer.
+//! JSON: buffered AskResponse emitted once at end.
+
+use super::{AskResponse, Citation};
+
+pub fn render_citations_block(citations: &[Citation]) -> String {
+    let mut out = String::new();
+    if citations.is_empty() {
+        return out;
+    }
+    out.push_str("\nCitations:\n");
+    for c in citations {
+        let anchor = match (c.line_hint, c.span_index_in_summary) {
+            (_, Some(idx)) => format!(
+                "[cit: {} {}/{} @summary-span-{}]",
+                c.date, c.source, c.conv_id, idx
+            ),
+            (Some(line), _) => format!("[cit: {} {}/{}:L{}]", c.date, c.source, c.conv_id, line),
+            _ => format!("[cit: {} {}/{}]", c.date, c.source, c.conv_id),
+        };
+        let preview: String = c.snippet.chars().take(120).collect();
+        out.push_str(&format!("  {anchor}\n    — {preview}\n"));
+    }
+    out
+}
+
+pub fn render_footer(resp: &AskResponse) -> String {
+    let tag = if resp.degraded_to_mode_b {
+        " · Mode B fallback"
+    } else {
+        ""
+    };
+    format!(
+        "({} hits · {}ms · {}→{} tokens{})\n",
+        resp.citations.len(),
+        resp.duration_ms,
+        resp.tokens_in,
+        resp.tokens_out,
+        tag,
+    )
+}
+
+pub fn render_json(resp: &AskResponse) -> String {
+    serde_json::to_string_pretty(resp).unwrap_or_else(|_| "{}".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_resp() -> AskResponse {
+        AskResponse {
+            answer: "Mock answer [cit: 2026-04-19 cc/a:L1]".into(),
+            citations: vec![Citation {
+                id: 1,
+                date: chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(),
+                source: "cc".into(),
+                conv_id: "a".into(),
+                line_hint: Some(1),
+                span_index_in_summary: None,
+                snippet: "sample snippet text".into(),
+                score: 0.87,
+            }],
+            hits_used: vec![],
+            degraded_to_mode_b: false,
+            tokens_in: 100,
+            tokens_out: 20,
+            duration_ms: 500,
+        }
+    }
+
+    #[test]
+    fn citations_block_contains_anchor_and_preview() {
+        let r = sample_resp();
+        let block = render_citations_block(&r.citations);
+        assert!(block.contains("[cit: 2026-04-19 cc/a:L1]"));
+        assert!(block.contains("sample snippet text"));
+    }
+
+    #[test]
+    fn footer_shows_mode_b_tag_when_degraded() {
+        let mut r = sample_resp();
+        r.degraded_to_mode_b = true;
+        let f = render_footer(&r);
+        assert!(f.contains("Mode B fallback"));
+    }
+
+    #[test]
+    fn json_roundtrip() {
+        let r = sample_resp();
+        let s = render_json(&r);
+        assert!(s.contains("\"answer\""));
+        assert!(s.contains("\"citations\""));
+    }
+}

--- a/mur-core/src/conversations/ask/generate.rs
+++ b/mur-core/src/conversations/ask/generate.rs
@@ -1,0 +1,62 @@
+//! Streaming Ollama generation for ask. Thin adapter over conversations::ollama.
+
+use anyhow::Result;
+use futures::stream::Stream;
+use std::pin::Pin;
+use std::time::Duration;
+
+use super::super::ollama::{GenerateOptions, GenerateRequest, OllamaClient};
+
+pub async fn stream_answer(
+    endpoint: &str,
+    model: &str,
+    system: &str,
+    user: &str,
+    response_tokens: u32,
+    timeout: Duration,
+) -> Result<Pin<Box<dyn Stream<Item = Result<String>> + Send>>> {
+    let client = OllamaClient::new(endpoint, timeout);
+    client
+        .generate_stream(GenerateRequest {
+            model,
+            prompt: user,
+            system: Some(system),
+            stream: true,
+            options: GenerateOptions {
+                temperature: Some(0.1),
+                top_p: Some(0.9),
+                num_predict: Some(response_tokens),
+                stop: vec!["\n\nQ:".into(), "\n\nQuestion:".into()],
+            },
+        })
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn mock_stream_yields_tokens() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let mut s = stream_answer(
+            "http://unused",
+            "qwen3:14b",
+            "system",
+            "ask about [cit:",
+            256,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        let mut combined = String::new();
+        while let Some(chunk) = s.next().await {
+            combined.push_str(&chunk.unwrap());
+        }
+        assert!(combined.contains("[cit: 2026-04-19 claude-code/mock:L1]"));
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+}

--- a/mur-core/src/conversations/ask/mod.rs
+++ b/mur-core/src/conversations/ask/mod.rs
@@ -33,6 +33,7 @@ pub struct AskRequest {
     pub escalation_threshold: f64,
     pub mmr_threshold: f64,
     pub model: String,
+    pub endpoint: String,
     pub format: Format,
     pub max_context_tokens: usize,
     pub response_tokens: usize,
@@ -87,6 +88,258 @@ pub enum AskEvent {
     Error(String),
 }
 
+use anyhow::Result;
+use futures::stream::{Stream, StreamExt};
+use std::pin::Pin;
+use std::time::Instant;
+
+pub async fn ask_stream(
+    req: AskRequest,
+    root_override: Option<&str>,
+) -> Result<Pin<Box<dyn Stream<Item = Result<AskEvent>> + Send>>> {
+    use async_stream::try_stream;
+
+    let start = Instant::now();
+
+    // 1. Embed
+    let query_embedding = match embed_query(&req.question).await {
+        Ok(v) => v,
+        Err(e) => {
+            return Ok(Box::pin(try_stream! {
+                yield AskEvent::Error(format!("embed failed: {e:#}"));
+                yield AskEvent::Done {
+                    tokens_in: 0,
+                    tokens_out: 0,
+                    degraded: false,
+                    duration_ms: start.elapsed().as_millis() as u64,
+                };
+            }));
+        }
+    };
+
+    // 2. Retrieve
+    let hits = match retrieve::gather_hits(retrieve::RetrieveArgs {
+        query_embedding,
+        filters: &req.filters,
+        k_summary: req.k_summary,
+        k_raw: req.k_raw,
+        escalation_threshold: req.escalation_threshold,
+        mmr_threshold: req.mmr_threshold,
+        no_escalate: req.no_escalate,
+        max_context_tokens: req.max_context_tokens,
+        root_override,
+    })
+    .await
+    {
+        Ok(h) => h,
+        Err(e) => {
+            return Ok(Box::pin(try_stream! {
+                yield AskEvent::Error(format!("retrieve failed: {e:#}"));
+                yield AskEvent::Done {
+                    tokens_in: 0,
+                    tokens_out: 0,
+                    degraded: false,
+                    duration_ms: start.elapsed().as_millis() as u64,
+                };
+            }));
+        }
+    };
+
+    if hits.is_empty() {
+        return Ok(Box::pin(try_stream! {
+            yield AskEvent::Token("The conversations I have access to don't cover that.".into());
+            yield AskEvent::Done {
+                tokens_in: 0,
+                tokens_out: 0,
+                degraded: false,
+                duration_ms: start.elapsed().as_millis() as u64,
+            };
+        }));
+    }
+
+    // 3. Build prompt
+    let prompt = prompt::render(
+        &req.question,
+        &hits,
+        req.max_context_tokens,
+        req.response_tokens,
+    );
+
+    let hit_events: Vec<AskEvent> = hits
+        .iter()
+        .map(|h| AskEvent::HitInfo(h.info.clone()))
+        .collect();
+
+    // 4. Generate (streaming) with grounding filter
+    let endpoint = req.endpoint.clone();
+    let model = req.model.clone();
+    let filter = cite::GroundingFilter::new(prompt.valid_citations.clone());
+    let tokens_in = prompt.tokens_est;
+
+    let stream = match generate::stream_answer(
+        &endpoint,
+        &model,
+        &prompt.system,
+        &prompt.user,
+        req.response_tokens as u32,
+        req.timeout,
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            let mode_b = hits_as_mode_b(&hits);
+            return Ok(Box::pin(try_stream! {
+                for evt in hit_events { yield evt; }
+                yield AskEvent::Token(mode_b);
+                yield AskEvent::Done {
+                    tokens_in,
+                    tokens_out: 0,
+                    degraded: true,
+                    duration_ms: start.elapsed().as_millis() as u64,
+                };
+                yield AskEvent::Error(format!("ollama unavailable: {e:#}"));
+            }));
+        }
+    };
+
+    let citation_events_by_anchor = citations_map(&hits);
+    let out_stream = try_stream! {
+        for evt in hit_events { yield evt; }
+        let mut stream = stream;
+        let mut filter = filter;
+        let mut tokens_out = 0usize;
+        let mut emitted_citations = std::collections::HashSet::new();
+        while let Some(next) = stream.next().await {
+            let tok = next?;
+            let filtered = filter.feed(&tok);
+            if !filtered.forwarded.is_empty() {
+                tokens_out += filtered.forwarded.len() / 4 + 1;
+                for c in citations_fired_in(&filtered.forwarded, &citation_events_by_anchor) {
+                    if emitted_citations.insert(c.id) {
+                        yield AskEvent::Citation(c.clone());
+                    }
+                }
+                yield AskEvent::Token(filtered.forwarded);
+            }
+        }
+        let drained = filter.flush();
+        if !drained.forwarded.is_empty() {
+            tokens_out += drained.forwarded.len() / 4 + 1;
+            for c in citations_fired_in(&drained.forwarded, &citation_events_by_anchor) {
+                if emitted_citations.insert(c.id) {
+                    yield AskEvent::Citation(c.clone());
+                }
+            }
+            yield AskEvent::Token(drained.forwarded);
+        }
+        yield AskEvent::Done {
+            tokens_in,
+            tokens_out,
+            degraded: false,
+            duration_ms: start.elapsed().as_millis() as u64,
+        };
+    };
+    Ok(Box::pin(out_stream))
+}
+
+pub async fn ask(req: AskRequest, root_override: Option<&str>) -> Result<AskResponse> {
+    let mut stream = ask_stream(req, root_override).await?;
+    let mut answer = String::new();
+    let mut citations = Vec::new();
+    let mut hits_used = Vec::new();
+    let mut degraded = false;
+    let mut tokens_in = 0;
+    let mut tokens_out = 0;
+    let mut duration_ms = 0;
+    while let Some(evt) = stream.next().await {
+        match evt? {
+            AskEvent::Token(t) => answer.push_str(&t),
+            AskEvent::Citation(c) => citations.push(c),
+            AskEvent::HitInfo(h) => hits_used.push(h),
+            AskEvent::Done {
+                tokens_in: ti,
+                tokens_out: to,
+                degraded: d,
+                duration_ms: ms,
+            } => {
+                tokens_in = ti;
+                tokens_out = to;
+                degraded = d;
+                duration_ms = ms;
+            }
+            AskEvent::Error(e) => return Err(anyhow::anyhow!(e)),
+        }
+    }
+    Ok(AskResponse {
+        answer,
+        citations,
+        hits_used,
+        degraded_to_mode_b: degraded,
+        tokens_in,
+        tokens_out,
+        duration_ms,
+    })
+}
+
+async fn embed_query(q: &str) -> Result<Vec<f32>> {
+    if super::ollama::OllamaClient::mock_from_env() {
+        return Ok(vec![0.1; 1024]);
+    }
+    let cfg = crate::store::config::load_config().unwrap_or_default();
+    let embed_cfg = crate::store::embedding::EmbeddingConfig::from_config(&cfg);
+    crate::store::embedding::embed(q, &embed_cfg).await
+}
+
+fn hits_as_mode_b(hits: &[retrieve::ResolvedHit]) -> String {
+    let mut out = String::from("[LLM unavailable] Here are the top relevant excerpts:\n\n");
+    for (i, h) in hits.iter().enumerate().take(5) {
+        out.push_str(&format!(
+            "{}. [cit: {} {}/{}] — {}\n",
+            i + 1,
+            h.info.date,
+            h.info.source,
+            h.info.conv_id,
+            h.snippet
+        ));
+    }
+    out
+}
+
+fn citations_map(hits: &[retrieve::ResolvedHit]) -> std::collections::HashMap<String, Citation> {
+    let mut m = std::collections::HashMap::new();
+    for (i, h) in hits.iter().enumerate() {
+        let anchor = prompt::cite_anchor(h);
+        m.insert(
+            anchor.clone(),
+            Citation {
+                id: (i + 1) as u32,
+                date: h.info.date,
+                source: h.info.source.clone(),
+                conv_id: h.info.conv_id.clone(),
+                line_hint: h.line_hint,
+                span_index_in_summary: h.span_index_in_summary,
+                snippet: h.snippet.clone(),
+                score: h.info.score,
+            },
+        );
+    }
+    m
+}
+
+fn citations_fired_in(
+    text: &str,
+    map: &std::collections::HashMap<String, Citation>,
+) -> Vec<Citation> {
+    let mut out = Vec::new();
+    for (anchor, cite) in map {
+        if text.contains(anchor.as_str()) {
+            out.push(cite.clone());
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -100,5 +353,41 @@ mod tests {
             min_score: 0.35,
         };
         assert_eq!(f.min_score, 0.35);
+    }
+
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn ask_end_to_end_mock_empty_hits() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let req = AskRequest {
+            question: "What did we do yesterday?".into(),
+            filters: Filters {
+                source: vec![],
+                since: None,
+                until: None,
+                min_score: 0.35,
+            },
+            k_summary: 5,
+            k_raw: 10,
+            escalation_threshold: 0.5,
+            mmr_threshold: 0.85,
+            model: "qwen3:14b".into(),
+            endpoint: "http://unused".into(),
+            format: Format::Plain,
+            max_context_tokens: 6000,
+            response_tokens: 256,
+            timeout: Duration::from_secs(5),
+            no_escalate: false,
+            debug_prompt: false,
+        };
+        // Empty index → should yield the "don't cover that" fallback.
+        let resp = ask(req, Some(root)).await.unwrap();
+        assert!(resp.answer.contains("don't cover that"));
+        assert!(resp.citations.is_empty());
+        assert!(!resp.degraded_to_mode_b);
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
     }
 }

--- a/mur-core/src/conversations/ask/mod.rs
+++ b/mur-core/src/conversations/ask/mod.rs
@@ -5,10 +5,10 @@ use mur_common::Source;
 use std::time::Duration;
 
 pub mod cite;
+pub mod format;
 pub mod generate;
 pub mod prompt;
 pub mod retrieve;
-// Later tasks add: pub mod format;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Format {

--- a/mur-core/src/conversations/ask/mod.rs
+++ b/mur-core/src/conversations/ask/mod.rs
@@ -4,8 +4,9 @@
 use mur_common::Source;
 use std::time::Duration;
 
+pub mod prompt;
 pub mod retrieve;
-// Later tasks add: pub mod prompt; pub mod generate; pub mod cite; pub mod format;
+// Later tasks add: pub mod generate; pub mod cite; pub mod format;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Format {

--- a/mur-core/src/conversations/ask/mod.rs
+++ b/mur-core/src/conversations/ask/mod.rs
@@ -4,9 +4,10 @@
 use mur_common::Source;
 use std::time::Duration;
 
+pub mod generate;
 pub mod prompt;
 pub mod retrieve;
-// Later tasks add: pub mod generate; pub mod cite; pub mod format;
+// Later tasks add: pub mod cite; pub mod format;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Format {

--- a/mur-core/src/conversations/ask/mod.rs
+++ b/mur-core/src/conversations/ask/mod.rs
@@ -1,0 +1,101 @@
+//! Mode C — Ask: local-only RAG with inline citations. See spec §5.
+#![allow(dead_code)] // filled progressively across Tasks 19-25
+
+use mur_common::Source;
+use std::time::Duration;
+
+pub mod retrieve;
+// Later tasks add: pub mod prompt; pub mod generate; pub mod cite; pub mod format;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Format {
+    Plain,
+    Json,
+}
+
+#[derive(Debug, Clone)]
+pub struct Filters {
+    pub source: Vec<Source>,
+    pub since: Option<chrono::NaiveDate>,
+    pub until: Option<chrono::NaiveDate>,
+    pub min_score: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct AskRequest {
+    pub question: String,
+    pub filters: Filters,
+    pub k_summary: usize,
+    pub k_raw: usize,
+    pub escalation_threshold: f64,
+    pub mmr_threshold: f64,
+    pub model: String,
+    pub format: Format,
+    pub max_context_tokens: usize,
+    pub response_tokens: usize,
+    pub timeout: Duration,
+    pub no_escalate: bool,
+    pub debug_prompt: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Citation {
+    pub id: u32,
+    pub date: chrono::NaiveDate,
+    pub source: String, // file_prefix
+    pub conv_id: String,
+    pub line_hint: Option<u32>,
+    pub span_index_in_summary: Option<u32>,
+    pub snippet: String,
+    pub score: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct HitInfo {
+    pub layer: i8,
+    pub source: String,
+    pub conv_id: String,
+    pub date: chrono::NaiveDate,
+    pub score: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AskResponse {
+    pub answer: String,
+    pub citations: Vec<Citation>,
+    pub hits_used: Vec<HitInfo>,
+    pub degraded_to_mode_b: bool,
+    pub tokens_in: usize,
+    pub tokens_out: usize,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+pub enum AskEvent {
+    Token(String),
+    Citation(Citation),
+    HitInfo(HitInfo),
+    Done {
+        tokens_in: usize,
+        tokens_out: usize,
+        degraded: bool,
+        duration_ms: u64,
+    },
+    Error(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filters_default_shape() {
+        let f = Filters {
+            source: vec![],
+            since: None,
+            until: None,
+            min_score: 0.35,
+        };
+        assert_eq!(f.min_score, 0.35);
+    }
+}

--- a/mur-core/src/conversations/ask/mod.rs
+++ b/mur-core/src/conversations/ask/mod.rs
@@ -4,10 +4,11 @@
 use mur_common::Source;
 use std::time::Duration;
 
+pub mod cite;
 pub mod generate;
 pub mod prompt;
 pub mod retrieve;
-// Later tasks add: pub mod cite; pub mod format;
+// Later tasks add: pub mod format;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Format {

--- a/mur-core/src/conversations/ask/prompt.rs
+++ b/mur-core/src/conversations/ask/prompt.rs
@@ -1,0 +1,151 @@
+//! System prompt + context assembly (spec §5.3).
+
+use super::retrieve::ResolvedHit;
+
+pub const SYSTEM_PROMPT: &str = "You answer questions about the user's past AI-assistant conversations, using ONLY the excerpts provided below under \"Context\". Never invent facts not present in the excerpts.
+
+Every factual claim in your answer MUST be followed by an inline citation in the form [cit: <date> <source>/<conv_id>:L<line>]. Use only the citations enumerated in the Context section — one citation per claim. You may use the same citation multiple times.
+
+If the excerpts are insufficient to answer, say so plainly: \"The conversations I have access to don't cover that.\" Do not speculate. Do not use training knowledge to fill gaps.
+
+Format: clear prose, 2-6 sentences per idea, Markdown bullets when listing. Be direct. Don't repeat the question. Don't apologize for not knowing.
+
+When the user mentions a pattern name wrapped in {{pattern: name}} in the excerpts, that refers to a reusable artifact at ~/.mur/patterns/<name>.yaml; you may mention the pattern by name in your answer but do not expand it.";
+
+pub struct RenderedPrompt {
+    pub system: String,
+    pub user: String,
+    pub tokens_est: usize,
+    pub valid_citations: Vec<String>, // normalized citation anchors for grounding
+}
+
+pub fn render(
+    question: &str,
+    hits: &[ResolvedHit],
+    max_context_tokens: usize,
+    response_tokens: usize,
+) -> RenderedPrompt {
+    let system = SYSTEM_PROMPT.to_string();
+
+    let mut ctx = String::new();
+    let mut valid_citations = Vec::new();
+    for h in hits.iter() {
+        let anchor = cite_anchor(h);
+        valid_citations.push(anchor.clone());
+        ctx.push_str(&anchor);
+        ctx.push('\n');
+        ctx.push_str("> ");
+        ctx.push_str(&h.snippet.replace('\n', "\n> "));
+        ctx.push_str("\n\n");
+    }
+
+    let truncated_question = truncate_chars(question, 2000);
+    let mut user = format!("Context:\n{ctx}\nQuestion: {truncated_question}");
+    let tokens_est = (system.len() + user.len()) / 4 + response_tokens + 120;
+
+    // If we overflow, drop hits from the tail until we fit.
+    let mut trimmed_hits = hits.len();
+    while tokens_est > max_context_tokens && trimmed_hits > 1 {
+        trimmed_hits -= 1;
+        let mut ctx2 = String::new();
+        valid_citations.clear();
+        for h in hits.iter().take(trimmed_hits) {
+            let anchor = cite_anchor(h);
+            valid_citations.push(anchor.clone());
+            ctx2.push_str(&anchor);
+            ctx2.push('\n');
+            ctx2.push_str("> ");
+            ctx2.push_str(&h.snippet.replace('\n', "\n> "));
+            ctx2.push_str("\n\n");
+        }
+        user = format!("Context:\n{ctx2}\nQuestion: {truncated_question}");
+    }
+
+    RenderedPrompt {
+        system,
+        user,
+        tokens_est,
+        valid_citations,
+    }
+}
+
+pub fn cite_anchor(h: &ResolvedHit) -> String {
+    match (h.layer, h.line_hint, h.span_index_in_summary) {
+        (1, _, Some(idx)) => format!(
+            "[cit: {} {}/{} @summary-span-{}]",
+            h.info.date, h.info.source, h.info.conv_id, idx
+        ),
+        (_, Some(line), _) => format!(
+            "[cit: {} {}/{}:L{}]",
+            h.info.date, h.info.source, h.info.conv_id, line
+        ),
+        _ => format!(
+            "[cit: {} {}/{}]",
+            h.info.date, h.info.source, h.info.conv_id
+        ),
+    }
+}
+
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        s.chars().take(max).collect::<String>() + "…"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::HitInfo;
+    use super::*;
+
+    fn hit_raw(conv: &str, text: &str) -> ResolvedHit {
+        ResolvedHit {
+            layer: 0,
+            info: HitInfo {
+                layer: 0,
+                source: "cc".into(),
+                conv_id: conv.into(),
+                date: chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(),
+                score: 0.9,
+            },
+            snippet: text.into(),
+            line_hint: Some(42),
+            span_index_in_summary: None,
+        }
+    }
+
+    #[test]
+    fn cite_anchor_raw_layer() {
+        let h = hit_raw("abc", "hi");
+        assert_eq!(cite_anchor(&h), "[cit: 2026-04-19 cc/abc:L42]");
+    }
+
+    #[test]
+    fn cite_anchor_summary_layer() {
+        let mut h = hit_raw("abc", "hi");
+        h.layer = 1;
+        h.span_index_in_summary = Some(3);
+        h.line_hint = None;
+        assert_eq!(cite_anchor(&h), "[cit: 2026-04-19 cc/abc @summary-span-3]");
+    }
+
+    #[test]
+    fn render_shrinks_hits_on_overflow() {
+        let hits = (0..20)
+            .map(|i| hit_raw(&format!("c{i}"), &"x".repeat(3000)))
+            .collect::<Vec<_>>();
+        let r = render("question?", &hits, 6000, 1024);
+        assert!(r.valid_citations.len() < hits.len());
+        assert!(!r.valid_citations.is_empty());
+    }
+
+    #[test]
+    fn render_lists_valid_citations_in_order() {
+        let hits = vec![hit_raw("a", "one"), hit_raw("b", "two")];
+        let r = render("q?", &hits, 6000, 1024);
+        assert_eq!(r.valid_citations.len(), 2);
+        assert!(r.user.contains("one"));
+        assert!(r.user.contains("two"));
+    }
+}

--- a/mur-core/src/conversations/ask/retrieve.rs
+++ b/mur-core/src/conversations/ask/retrieve.rs
@@ -1,3 +1,253 @@
-//! Tiered retrieval for Mode C — layer=1 (summary) first, escalate to
-//! layer=0 (raw) when top score < threshold. Filled in Task 20.
-#![allow(dead_code)]
+//! Tiered retrieval (spec §5.2).
+//! Stages: embed → layer=1 search → escalate to layer=0 if top score low
+//! → MMR dedupe → per-hit snippet resolution → token-budget cap.
+
+use anyhow::Result;
+
+use super::super::index::{ConversationIndex, SearchHit};
+use super::super::summarize;
+use super::{Filters, HitInfo};
+
+#[derive(Debug, Clone)]
+pub struct ResolvedHit {
+    pub layer: i8,
+    pub info: HitInfo,
+    pub snippet: String,
+    pub line_hint: Option<u32>,
+    pub span_index_in_summary: Option<u32>,
+}
+
+pub struct RetrieveArgs<'a> {
+    pub query_embedding: Vec<f32>,
+    pub filters: &'a Filters,
+    pub k_summary: usize,
+    pub k_raw: usize,
+    pub escalation_threshold: f64,
+    pub mmr_threshold: f64,
+    pub no_escalate: bool,
+    pub max_context_tokens: usize,
+    pub root_override: Option<&'a str>,
+}
+
+/// LanceDB cosine distance = 1 - cosine_similarity.
+/// Converts to similarity (higher = better, range 0..1).
+fn similarity_of(h: &SearchHit) -> f64 {
+    (1.0 - h.distance as f64).clamp(0.0, 1.0)
+}
+
+pub async fn gather_hits(args: RetrieveArgs<'_>) -> Result<Vec<ResolvedHit>> {
+    let dims = args.query_embedding.len() as i32;
+    let idx = ConversationIndex::open(dims, args.root_override).await?;
+    let primary_src = args.filters.source.first().copied();
+
+    // Layer 1 (summaries)
+    let l1 = idx
+        .search(&args.query_embedding, args.k_summary, primary_src, Some(1))
+        .await?;
+    let top_score = l1.first().map(similarity_of).unwrap_or(0.0);
+
+    // Escalate?
+    let l0 = if !args.no_escalate && (top_score < args.escalation_threshold || l1.is_empty()) {
+        idx.search(&args.query_embedding, args.k_raw, primary_src, Some(0))
+            .await?
+    } else {
+        Vec::new()
+    };
+
+    // Filter by since/until/min_score
+    let filtered_l1: Vec<_> = l1.into_iter().filter(|h| passes(h, args.filters)).collect();
+    let filtered_l0: Vec<_> = l0.into_iter().filter(|h| passes(h, args.filters)).collect();
+
+    // Resolve snippets
+    let mut resolved = Vec::new();
+    for h in filtered_l1 {
+        resolved.push(resolve_summary_hit(h, args.root_override)?);
+    }
+    for h in filtered_l0 {
+        resolved.push(resolve_raw_hit(h));
+    }
+
+    // MMR dedupe on snippet text (simple word-jaccard; reuses Phase 1 filter threshold config by default)
+    let deduped = mmr_dedupe(resolved, args.mmr_threshold);
+
+    // Token-budget cap
+    let budget = (args.max_context_tokens * 9 / 10).max(400);
+    let capped = cap_by_budget(deduped, budget);
+    Ok(capped)
+}
+
+fn passes(h: &SearchHit, f: &Filters) -> bool {
+    if similarity_of(h) < f.min_score {
+        return false;
+    }
+    if let Some(s) = f.since
+        && chrono::DateTime::from_timestamp(h.ts, 0)
+            .map(|dt| dt.date_naive() < s)
+            .unwrap_or(false)
+    {
+        return false;
+    }
+    if let Some(u) = f.until
+        && chrono::DateTime::from_timestamp(h.ts, 0)
+            .map(|dt| dt.date_naive() > u)
+            .unwrap_or(false)
+    {
+        return false;
+    }
+    true
+}
+
+fn resolve_summary_hit(h: SearchHit, root_override: Option<&str>) -> Result<ResolvedHit> {
+    // Read summary file for h.date, pick the first extractive span's text.
+    // (Phase 2B simplification; Phase 3 RAPTOR improves this.)
+    let date = chrono::DateTime::from_timestamp(h.ts, 0)
+        .map(|d| d.date_naive())
+        .unwrap_or_else(|| chrono::Utc::now().date_naive());
+    let (md_path, _) = super::super::paths::summary_paths_for(date, root_override);
+    let (snippet, line_hint, span_idx) = if md_path.exists() {
+        let body = std::fs::read_to_string(&md_path).unwrap_or_default();
+        if let Ok(parsed) = summarize::parse_summary(&body) {
+            parsed.extractive.first().map_or_else(
+                || (String::new(), None, None),
+                |s| (s.text.clone(), Some(s.line_hint), Some(s.span_index)),
+            )
+        } else {
+            (String::new(), None, None)
+        }
+    } else {
+        (String::new(), None, None)
+    };
+    Ok(ResolvedHit {
+        layer: 1,
+        info: HitInfo {
+            layer: 1,
+            source: h.source.file_prefix().to_string(),
+            conv_id: h.conv_id.clone(),
+            date,
+            score: similarity_of(&h),
+        },
+        snippet,
+        line_hint,
+        span_index_in_summary: span_idx,
+    })
+}
+
+fn resolve_raw_hit(h: SearchHit) -> ResolvedHit {
+    let date = chrono::DateTime::from_timestamp(h.ts, 0)
+        .map(|d| d.date_naive())
+        .unwrap_or_else(|| chrono::Utc::now().date_naive());
+    ResolvedHit {
+        layer: 0,
+        info: HitInfo {
+            layer: 0,
+            source: h.source.file_prefix().to_string(),
+            conv_id: h.conv_id.clone(),
+            date,
+            score: similarity_of(&h),
+        },
+        snippet: h.content.clone(),
+        line_hint: None, // raw hits don't carry line hints; extensible in Phase 3
+        span_index_in_summary: None,
+    }
+}
+
+fn mmr_dedupe(hits: Vec<ResolvedHit>, threshold: f64) -> Vec<ResolvedHit> {
+    let mut kept: Vec<ResolvedHit> = Vec::new();
+    for h in hits {
+        let dup = kept
+            .iter()
+            .any(|k| word_jaccard(&k.snippet, &h.snippet) > threshold);
+        if !dup {
+            kept.push(h);
+        }
+    }
+    kept
+}
+
+fn word_jaccard(a: &str, b: &str) -> f64 {
+    use std::collections::HashSet;
+    let sa: HashSet<&str> = a.split_whitespace().collect();
+    let sb: HashSet<&str> = b.split_whitespace().collect();
+    if sa.is_empty() && sb.is_empty() {
+        return 1.0;
+    }
+    let inter = sa.intersection(&sb).count() as f64;
+    let union = sa.union(&sb).count() as f64;
+    if union == 0.0 { 0.0 } else { inter / union }
+}
+
+fn cap_by_budget(hits: Vec<ResolvedHit>, budget_tokens: usize) -> Vec<ResolvedHit> {
+    let mut out = Vec::new();
+    let mut used = 0usize;
+    for h in hits {
+        let est = (h.snippet.len() + 80) / 4 + 1;
+        if used + est > budget_tokens && !out.is_empty() {
+            break;
+        }
+        used += est;
+        out.push(h);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn word_jaccard_identical_is_one() {
+        assert_eq!(word_jaccard("a b c", "a b c"), 1.0);
+    }
+
+    #[test]
+    fn word_jaccard_disjoint_is_zero() {
+        assert_eq!(word_jaccard("a b c", "d e f"), 0.0);
+    }
+
+    #[test]
+    fn mmr_dedupe_drops_duplicate() {
+        let h1 = ResolvedHit {
+            layer: 0,
+            info: HitInfo {
+                layer: 0,
+                source: "cc".into(),
+                conv_id: "a".into(),
+                date: chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(),
+                score: 0.9,
+            },
+            snippet: "the quick brown fox jumps".into(),
+            line_hint: None,
+            span_index_in_summary: None,
+        };
+        let h2 = ResolvedHit {
+            snippet: "the quick brown fox jumps".into(),
+            info: HitInfo {
+                source: "cc".into(),
+                conv_id: "b".into(),
+                ..h1.info.clone()
+            },
+            ..h1.clone()
+        };
+        let out = mmr_dedupe(vec![h1, h2], 0.85);
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn cap_by_budget_keeps_at_least_one() {
+        let giant = ResolvedHit {
+            layer: 0,
+            info: HitInfo {
+                layer: 0,
+                source: "cc".into(),
+                conv_id: "a".into(),
+                date: chrono::NaiveDate::from_ymd_opt(2026, 4, 19).unwrap(),
+                score: 0.9,
+            },
+            snippet: "x".repeat(40_000),
+            line_hint: None,
+            span_index_in_summary: None,
+        };
+        let out = cap_by_budget(vec![giant], 100);
+        assert_eq!(out.len(), 1, "must keep at least one hit even over budget");
+    }
+}

--- a/mur-core/src/conversations/ask/retrieve.rs
+++ b/mur-core/src/conversations/ask/retrieve.rs
@@ -1,0 +1,3 @@
+//! Tiered retrieval for Mode C — layer=1 (summary) first, escalate to
+//! layer=0 (raw) when top score < threshold. Filled in Task 20.
+#![allow(dead_code)]

--- a/mur-core/src/conversations/mod.rs
+++ b/mur-core/src/conversations/mod.rs
@@ -3,6 +3,7 @@
 //!
 //! See `docs/superpowers/specs/2026-04-19-mur-conversations-design.md`.
 
+pub mod ask;
 pub mod audit;
 pub mod blob;
 pub mod index;

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -325,6 +325,28 @@ enum Commands {
         #[command(subcommand)]
         action: ConversationsAction,
     },
+    /// Ask a natural-language question about your conversation archive (Mode C).
+    Ask {
+        question: String,
+        #[arg(long)]
+        src: Option<String>,
+        #[arg(long)]
+        since: Option<String>,
+        #[arg(long)]
+        until: Option<String>,
+        #[arg(long, default_value = "5")]
+        k: usize,
+        #[arg(long)]
+        model: Option<String>,
+        #[arg(long)]
+        min_score: Option<f64>,
+        #[arg(long)]
+        json: bool,
+        #[arg(long)]
+        no_escalate: bool,
+        #[arg(long)]
+        debug_prompt: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1110,6 +1132,32 @@ async fn async_main() -> Result<()> {
             } => cmd::deploy::cmd_deploy_logs(file.as_deref(), service.as_deref(), follow)?,
             DeployAction::Build { file } => cmd::deploy::cmd_deploy_build(file.as_deref())?,
         },
+        Commands::Ask {
+            question,
+            src,
+            since,
+            until,
+            k,
+            model,
+            min_score,
+            json,
+            no_escalate,
+            debug_prompt,
+        } => {
+            cmd::conversations_cmd::cmd_ask(cmd::conversations_cmd::AskArgs {
+                question,
+                src,
+                since,
+                until,
+                k,
+                model,
+                min_score,
+                json,
+                no_escalate,
+                debug_prompt,
+            })
+            .await?
+        }
     }
 
     Ok(())

--- a/mur-core/tests/cli_conversations.rs
+++ b/mur-core/tests/cli_conversations.rs
@@ -101,3 +101,24 @@ fn mur_conversations_compact_on_seeded_day_produces_summary() {
     assert!(body.contains("## Extractive spans"));
     assert!(body.contains("## Abstractive narrative"));
 }
+
+#[test]
+fn mur_ask_on_empty_archive_returns_fallback() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mur"));
+    let (cmd, _mur_home) = with_mur_home(
+        cmd.args(["ask", "What did we build yesterday?"]),
+        tmp.path(),
+    );
+    let out = cmd.env("MUR_OLLAMA_MOCK", "1").output().expect("run mur");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("don't cover that"),
+        "expected fallback text, got: {stdout}"
+    );
+}

--- a/scripts/golden-path-conversations.sh
+++ b/scripts/golden-path-conversations.sh
@@ -96,5 +96,37 @@ printf -- '---\ndate: %s\n---\n# old\n' "$OLD" > "$TMPHOME/.mur/conversations/su
 grep -q "deleted 1" /tmp/gp-out-8.txt || { echo "FAIL: cleanup should have deleted old day"; exit 1; }
 [[ ! -d "$TMPHOME/.mur/conversations/raw/$OLD" ]] || { echo "FAIL: old raw dir still exists"; exit 1; }
 
+# ── Step 9: compact ───────────────────────────────────────────────────────
+# Seed yesterday's raw so compact has something to process
+# (compact_missing only scans days < today per design).
+YDAY="$(date -u -v-1d +%Y-%m-%d 2>/dev/null || date -u -d 'yesterday' +%Y-%m-%d)"
+mkdir -p "$TMPHOME/.mur/conversations/raw/$YDAY"
+cat > "$TMPHOME/.mur/conversations/raw/$YDAY/cc_yd.jsonl" <<JSONL
+{"v":1,"ts":"${YDAY}T10:00:00Z","src":"claude-code","conv":"yd","role":"user","content":{"t":"text","v":"mock extractive span seeded for compact golden-path"},"meta":{},"refs":[]}
+JSONL
+
+echo "--- step 9: mur conversations compact ---"
+MUR_OLLAMA_MOCK=1 "$MUR" conversations compact | tee /tmp/gp-out-9.txt
+test -f "$TMPHOME/.mur/conversations/summary/${YDAY}.md" \
+  || { echo "FAIL step 9: no summary/${YDAY}.md"; exit 1; }
+grep -q "## Extractive spans" "$TMPHOME/.mur/conversations/summary/${YDAY}.md" \
+  || { echo "FAIL step 9: summary missing Extractive section"; exit 1; }
+grep -q "## Abstractive narrative" "$TMPHOME/.mur/conversations/summary/${YDAY}.md" \
+  || { echo "FAIL step 9: summary missing Narrative section"; exit 1; }
+
+# ── Step 10: ask ──────────────────────────────────────────────────────────
+echo "--- step 10: mur ask --json ---"
+MUR_OLLAMA_MOCK=1 "$MUR" ask "what compression techniques did I discuss" --json > /tmp/gp-step-10.json
+cat /tmp/gp-step-10.json
+# The mock ollama answer contains a [cit: 2026-04-19 claude-code/mock:L1] anchor
+# that the grounding filter will strip (it's not one of the real valid anchors
+# from prompt::render). So we verify:
+#   - the command succeeded and wrote JSON
+#   - the response has at least one HitInfo (real retrieval happened)
+jq -e '.hits_used | length >= 1' /tmp/gp-step-10.json \
+  || { echo "FAIL step 10: no hits_used — retrieval did not fire"; exit 1; }
+jq -e '.answer | type == "string"' /tmp/gp-step-10.json \
+  || { echo "FAIL step 10: missing or non-string .answer"; exit 1; }
+
 echo ""
-echo "=== ALL 8 STEPS GREEN ==="
+echo "=== ALL 10 STEPS GREEN ==="


### PR DESCRIPTION
## Summary

Phase 2B of the mur conversations archive: **Mode C — `mur ask <question>`** — local-only RAG with Perplexity-style inline citations, streaming tokens, and Mode B fallback when Ollama is unreachable.

Paired with the merged Phase 2A PR [#6](https://github.com/mur-run/mur/pull/6). This PR adds the Ask side on top of the compact pipeline.

**Spec:** `docs/superpowers/specs/2026-04-20-mur-conversations-phase-2-design.md` §5
**Plan:** `docs/superpowers/plans/2026-04-20-mur-conversations-phase-2.md` Tasks 18-27

## What ships

- `AskConfig` in `mur-common::config` — 10 fields (model, endpoint, k_summary, k_raw, escalation_threshold, mmr_threshold, max_context_tokens, response_tokens, timeout_secs, min_score) with serde defaults per spec §6.2
- `ask::mod` public types — `Format`, `Filters`, `AskRequest`, `Citation`, `HitInfo`, `AskResponse`, `AskEvent`
- `ask::retrieve` tiered retrieval — embed → layer=1 search → escalate to layer=0 on low score → MMR dedupe (word-Jaccard) → token-budget cap. LanceDB `distance` correctly converted to similarity
- `ask::prompt` — system prompt + context assembly with citation-anchor enumeration (summary: `[cit: <date> <src>/<conv> @summary-span-<N>]`; raw: `[cit: <date> <src>/<conv>:L<line>]`) + overflow-shrink retry
- `ask::generate` — thin streaming wrapper over `conversations::ollama::generate_stream` with ask defaults (temp=0.1, top_p=0.9, stop on `Q:` / `Question:`)
- `ask::cite` — stream-aware `GroundingFilter` that buffers 64 tail chars, detects `[cit: ...]` anchors across token boundaries, strips unknowns
- `ask::format` — plain citation block + `Mode B fallback` footer tag + `render_json`
- `ask::{ask_stream, ask}` — the end-to-end pipeline (8 stages) with:
  - Empty-hits short-circuit → `"The conversations I have access to don't cover that."`
  - Ollama failure → Mode B fallback (excerpts as tokens, `degraded_to_mode_b=true`)
  - `AskEvent::{Token, Citation, HitInfo, Done, Error}` streaming events
- `mur ask <question>` top-level CLI with flags: `--src / --since / --until / --k / --model / --min-score / --json / --no-escalate / --debug-prompt`

## Test plan
- [x] 620 mur-core lib tests pass under default parallelism (`cargo test -p mur-core`)
- [x] 5 cli_conversations integration tests pass (new: `mur_ask_on_empty_archive_returns_fallback`)
- [x] `./scripts/golden-path-conversations.sh` — all 10 steps green (new: Step 9 compact + Step 10 ask)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] MUR_OLLAMA_MOCK=1 path verified end-to-end (deterministic mock responses, ENV_LOCK serialization prevents cross-module races)
- [ ] Review on Windows CI (MUR_HOME override from Phase 2A carries forward — should keep tests isolated)
- [ ] Real-Ollama smoke test — Phase 2C (Task 31, feature-gated)

## Known deferrals to Phase 2C

- `.history/` retention cleanup in writer (Task 28)
- `--strict-citations` reject mode (Task 29)
- `conversations preflight` model-availability + free-mem checks (Task 30)
- Real-Ollama smoke test harness (Task 31)
- `.history/` rotation audit + doctor coverage report (Task 32)

## Plan deviations

Documented in commit bodies; the two recurring ones:
- `mur_common::config::Config::load()` doesn't exist → `crate::store::config::load_config()` (same pattern used in every 2A CLI task)
- `crate::store::embedding::embed_text` doesn't exist → `EmbeddingConfig::from_config(&cfg)` + `embed(q, &cfg)`

Plus `AskRequest` gained an `endpoint: String` field so the CLI layer (not the pipeline) controls the Ollama URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)