### PR TITLE
feat(conversations): Phase 2C — hardening (history retention, strict citations, preflight, smoke tests)

### DIFF
--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -62,6 +62,7 @@ sysinfo = "0.30"
 default = ["cli", "server"]
 cli = ["dialoguer", "console", "clap"]
 server = ["axum", "tower-http", "rust-embed"]
+ollama-live-smoke = []
 
 [dev-dependencies]
 tempfile = "3"

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -56,6 +56,7 @@ dotenvy = "0.15"
 shellexpand = "3"
 urlencoding = "2"
 rusqlite = { version = "0.32", features = ["bundled"] }
+sysinfo = "0.30"
 
 [features]
 default = ["cli", "server"]

--- a/mur-core/src/cmd/conversations_cmd.rs
+++ b/mur-core/src/cmd/conversations_cmd.rs
@@ -466,6 +466,7 @@ pub struct AskArgs {
     pub json: bool,
     pub no_escalate: bool,
     pub debug_prompt: bool,
+    pub strict_citations: bool,
 }
 
 pub async fn cmd_conversations_compact(args: CompactArgs) -> Result<()> {
@@ -566,6 +567,7 @@ pub async fn cmd_ask(args: AskArgs) -> Result<()> {
         timeout: std::time::Duration::from_secs(ask_cfg.timeout_secs as u64),
         no_escalate: args.no_escalate,
         debug_prompt: args.debug_prompt,
+        strict_citations: args.strict_citations,
     };
 
     if args.json {

--- a/mur-core/src/cmd/conversations_cmd.rs
+++ b/mur-core/src/cmd/conversations_cmd.rs
@@ -280,6 +280,38 @@ pub async fn cmd_conversations_doctor() -> Result<()> {
         println!("  · Ollama not reachable at {endpoint} (compact + ask will degrade)");
     }
 
+    // Phase 2C: .history/ coverage — how many archived summary revisions + total bytes.
+    let history_dir = conversations::paths::summary_history_dir(None);
+    let (hist_count, hist_bytes) = if history_dir.exists() {
+        std::fs::read_dir(&history_dir)
+            .ok()
+            .map(|rd| {
+                rd.flatten()
+                    .filter(|e| {
+                        e.path()
+                            .extension()
+                            .and_then(|s| s.to_str())
+                            .map(|s| s == "md")
+                            .unwrap_or(false)
+                    })
+                    .fold((0u64, 0u64), |(n, bytes), e| {
+                        let sz = std::fs::metadata(e.path()).map(|m| m.len()).unwrap_or(0);
+                        (n + 1, bytes + sz)
+                    })
+            })
+            .unwrap_or((0, 0))
+    } else {
+        (0, 0)
+    };
+    if hist_count == 0 {
+        println!("  · .history/: empty (no summary rewrites yet)");
+    } else {
+        println!(
+            "  ✓ .history/: {hist_count} archived revisions, {:.1} KB",
+            hist_bytes as f64 / 1024.0
+        );
+    }
+
     Ok(())
 }
 

--- a/mur-core/src/cmd/conversations_cmd.rs
+++ b/mur-core/src/cmd/conversations_cmd.rs
@@ -284,7 +284,8 @@ pub async fn cmd_conversations_doctor() -> Result<()> {
 }
 
 /// BP1 amendment: dedicated preflight check bundle (daemon, disk, staging, audit presence).
-pub fn cmd_conversations_preflight() -> Result<()> {
+/// Phase 2C: extends with Ollama reachability, model-pull checks, pattern dir, free memory.
+pub async fn cmd_conversations_preflight() -> Result<()> {
     use crate::conversations::migrate;
     let plan = migrate::dry_run(None)?;
 
@@ -333,6 +334,109 @@ pub fn cmd_conversations_preflight() -> Result<()> {
     } else {
         println!("  · no commander audit; migration will bridge from ZERO_HASH");
     }
+
+    // ── Phase 2C probes ───────────────────────────────────────────────────
+
+    // Load config once for Ollama endpoint + model names.
+    let cfg = crate::store::config::load_config().unwrap_or_default();
+    let endpoint = cfg.conversations.compact.ollama_endpoint.clone();
+    let models_needed: Vec<String> = {
+        let mut v = vec![
+            cfg.conversations.compact.extractive_model.clone(),
+            cfg.conversations.compact.abstractive_model.clone(),
+            cfg.conversations.ask.model.clone(),
+        ];
+        v.sort();
+        v.dedup();
+        v.retain(|m| !m.is_empty());
+        v
+    };
+
+    // Ollama reachability + /api/tags probe (2s timeout; non-fatal).
+    let url = format!("{}/api/tags", endpoint.trim_end_matches('/'));
+    let tags_body: Option<String> =
+        match tokio::time::timeout(std::time::Duration::from_secs(2), reqwest::get(&url)).await {
+            Ok(Ok(resp)) if resp.status().is_success() => {
+                println!("  ✓ Ollama reachable at {endpoint}");
+                resp.text().await.ok()
+            }
+            Ok(Ok(resp)) => {
+                println!("  ✗ Ollama at {endpoint} returned {}", resp.status());
+                ok = false;
+                None
+            }
+            Ok(Err(e)) => {
+                println!("  ✗ Ollama at {endpoint} unreachable: {e}");
+                ok = false;
+                None
+            }
+            Err(_) => {
+                println!("  ✗ Ollama at {endpoint} timed out (2s)");
+                ok = false;
+                None
+            }
+        };
+
+    // Model-pull check — only if we got a tags response.
+    if let Some(body) = &tags_body {
+        let installed: Vec<String> = serde_json::from_str::<serde_json::Value>(body)
+            .ok()
+            .and_then(|v| v.get("models").cloned())
+            .and_then(|m| m.as_array().cloned())
+            .map(|arr| {
+                arr.into_iter()
+                    .filter_map(|e| e.get("name").and_then(|n| n.as_str()).map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        for m in &models_needed {
+            if installed.iter().any(|n| n == m) {
+                println!("  ✓ model {m} pulled");
+            } else {
+                println!("  ✗ model {m} missing — run: ollama pull {m}");
+                ok = false;
+            }
+        }
+    } else if !models_needed.is_empty() {
+        println!(
+            "  · skipped model check ({} models wanted; Ollama unreachable)",
+            models_needed.len()
+        );
+    }
+
+    // Pattern dir readable.
+    let patterns_dir = home.join(".mur/patterns");
+    if patterns_dir.exists() {
+        match std::fs::read_dir(&patterns_dir) {
+            Ok(_) => println!("  ✓ patterns dir readable at {}", patterns_dir.display()),
+            Err(e) => {
+                println!(
+                    "  ✗ patterns dir at {} unreadable: {e}",
+                    patterns_dir.display()
+                );
+                ok = false;
+            }
+        }
+    } else {
+        println!(
+            "  · patterns dir {} missing (pattern refs will be a no-op)",
+            patterns_dir.display()
+        );
+    }
+
+    // Free memory check (informational).
+    match system_free_memory_mb() {
+        Some(mb) if mb < 4096 => {
+            println!("  · free mem: {mb} MB (< 4 GB — LLM calls may swap)");
+        }
+        Some(mb) => {
+            println!("  ✓ free mem: {mb} MB");
+        }
+        None => {
+            println!("  · free mem: unknown (sysinfo probe skipped)");
+        }
+    }
+
     if ok {
         println!("\n→ preflight passed");
     } else {
@@ -621,4 +725,16 @@ pub async fn cmd_ask(args: AskArgs) -> Result<()> {
         );
     }
     Ok(())
+}
+
+fn system_free_memory_mb() -> Option<u64> {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    // sysinfo reports in KiB; convert to MiB.
+    let avail_kib = sys.available_memory();
+    if avail_kib == 0 {
+        None
+    } else {
+        Some(avail_kib / 1024)
+    }
 }

--- a/mur-core/src/conversations/ask/cite.rs
+++ b/mur-core/src/conversations/ask/cite.rs
@@ -3,7 +3,9 @@
 
 pub struct GroundingFilter {
     valid: std::collections::HashSet<String>,
-    buffer: String, // tail buffer to detect brackets across chunk boundaries
+    buffer: String,        // tail buffer to detect brackets across chunk boundaries
+    strict: bool,          // enforce citation coverage when true
+    forwarded_all: String, // accumulates all forwarded text for coverage_check
 }
 
 pub struct FilterOutput {
@@ -16,6 +18,17 @@ impl GroundingFilter {
         Self {
             valid: valid.into_iter().collect(),
             buffer: String::new(),
+            strict: false,
+            forwarded_all: String::new(),
+        }
+    }
+
+    pub fn new_strict(valid: Vec<String>) -> Self {
+        Self {
+            valid: valid.into_iter().collect(),
+            buffer: String::new(),
+            strict: true,
+            forwarded_all: String::new(),
         }
     }
 
@@ -61,6 +74,7 @@ impl GroundingFilter {
                 }
             }
         }
+        self.forwarded_all.push_str(&forwarded);
         FilterOutput {
             forwarded,
             stripped,
@@ -71,8 +85,31 @@ impl GroundingFilter {
         let mut out = self.feed("");
         // Drain remaining buffer (no more input coming)
         out.forwarded.push_str(&self.buffer);
+        self.forwarded_all.push_str(&self.buffer);
         self.buffer.clear();
         out
+    }
+
+    /// Under strict mode, return Err if any claim sentence in the forwarded
+    /// text lacks an adjacent [cit: ...] anchor. Returns Ok(()) under
+    /// non-strict mode or when coverage is satisfied.
+    pub fn coverage_check(&self) -> Result<(), String> {
+        if !self.strict {
+            return Ok(());
+        }
+        for sentence in split_sentences(&self.forwarded_all) {
+            let words = sentence.split_whitespace().count();
+            if words < 8 {
+                continue;
+            }
+            if !sentence.contains("[cit:") {
+                return Err(format!(
+                    "strict citations: un-cited claim: \"{}\"",
+                    sentence.chars().take(120).collect::<String>()
+                ));
+            }
+        }
+        Ok(())
     }
 }
 
@@ -82,6 +119,37 @@ fn find_char_boundary(s: &str, target: usize) -> usize {
         b -= 1;
     }
     b
+}
+
+fn split_sentences(text: &str) -> Vec<&str> {
+    // Keep it simple: split on '.', '!', '?' followed by whitespace/EOF.
+    // Phase 2C heuristic — not a full NLP sentence splitter.
+    let mut out = Vec::new();
+    let mut start = 0;
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == b'.' || c == b'!' || c == b'?' {
+            let end = i + 1;
+            let after = bytes.get(end).copied().unwrap_or(b' ');
+            if after.is_ascii_whitespace() || end == bytes.len() {
+                let seg = text[start..end].trim();
+                if !seg.is_empty() {
+                    out.push(seg);
+                }
+                start = end;
+            }
+        }
+        i += 1;
+    }
+    if start < bytes.len() {
+        let tail = text[start..].trim();
+        if !tail.is_empty() {
+            out.push(tail);
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -116,5 +184,39 @@ mod tests {
         combined.push_str(&f.feed(":L1] end").forwarded);
         combined.push_str(&f.flush().forwarded);
         assert!(combined.contains("[cit: 2026-04-19 cc/a:L1]"));
+    }
+
+    #[test]
+    fn strict_accepts_fully_cited_text() {
+        let mut f = GroundingFilter::new_strict(vec!["[cit: 2026-04-19 cc/a:L1]".into()]);
+        f.feed("The user decided to refactor the pipeline [cit: 2026-04-19 cc/a:L1]. Done.");
+        f.flush();
+        assert!(f.coverage_check().is_ok());
+    }
+
+    #[test]
+    fn strict_rejects_uncited_claim() {
+        let mut f = GroundingFilter::new_strict(vec!["[cit: 2026-04-19 cc/a:L1]".into()]);
+        f.feed("The user decided to refactor everything at once without testing. End.");
+        f.flush();
+        let r = f.coverage_check();
+        assert!(r.is_err(), "expected strict rejection, got {:?}", r);
+    }
+
+    #[test]
+    fn strict_ignores_short_sentences() {
+        let mut f = GroundingFilter::new_strict(vec!["[cit: 2026-04-19 cc/a:L1]".into()]);
+        f.feed("Yes. Done. Works [cit: 2026-04-19 cc/a:L1].");
+        f.flush();
+        // Short sentences "Yes." and "Done." are skipped; the longer one is cited.
+        assert!(f.coverage_check().is_ok());
+    }
+
+    #[test]
+    fn non_strict_mode_never_fails() {
+        let mut f = GroundingFilter::new(vec!["[cit: 2026-04-19 cc/a:L1]".into()]);
+        f.feed("Long uncited claim about many things we built yesterday morning.");
+        f.flush();
+        assert!(f.coverage_check().is_ok()); // non-strict — no coverage enforcement
     }
 }

--- a/mur-core/src/conversations/ask/mod.rs
+++ b/mur-core/src/conversations/ask/mod.rs
@@ -40,6 +40,7 @@ pub struct AskRequest {
     pub timeout: Duration,
     pub no_escalate: bool,
     pub debug_prompt: bool,
+    pub strict_citations: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -173,7 +174,11 @@ pub async fn ask_stream(
     // 4. Generate (streaming) with grounding filter
     let endpoint = req.endpoint.clone();
     let model = req.model.clone();
-    let filter = cite::GroundingFilter::new(prompt.valid_citations.clone());
+    let filter = if req.strict_citations {
+        cite::GroundingFilter::new_strict(prompt.valid_citations.clone())
+    } else {
+        cite::GroundingFilter::new(prompt.valid_citations.clone())
+    };
     let tokens_in = prompt.tokens_est;
 
     let stream = match generate::stream_answer(
@@ -232,6 +237,9 @@ pub async fn ask_stream(
                 }
             }
             yield AskEvent::Token(drained.forwarded);
+        }
+        if let Err(e) = filter.coverage_check() {
+            yield AskEvent::Error(e);
         }
         yield AskEvent::Done {
             tokens_in,
@@ -382,6 +390,7 @@ mod tests {
             timeout: Duration::from_secs(5),
             no_escalate: false,
             debug_prompt: false,
+            strict_citations: false,
         };
         // Empty index → should yield the "don't cover that" fallback.
         let resp = ask(req, Some(root)).await.unwrap();

--- a/mur-core/src/conversations/summarize/writer.rs
+++ b/mur-core/src/conversations/summarize/writer.rs
@@ -71,6 +71,12 @@ pub async fn write_summary(
             });
         }
         archived = Some(archive_prior(&md_path, root_override)?);
+        // Phase 2C: keep at most `history_retain` versions per day. Config load
+        // failure is non-fatal; fall back to a sane default (5).
+        let retain = crate::store::config::load_config()
+            .map(|c| c.conversations.compact.history_retain)
+            .unwrap_or(5);
+        let _ = prune_history(root_override, doc.date, retain);
         noop = false;
     } else {
         archived = None;
@@ -152,6 +158,52 @@ fn archive_prior(md_path: &Path, root_override: Option<&str>) -> Result<PathBuf>
     let dest = hist.join(format!("{stem}.{now}.md"));
     std::fs::rename(md_path, &dest).with_context(|| format!("archive {md_path:?} → {dest:?}"))?;
     Ok(dest)
+}
+
+/// Drop oldest `.history/<date>.*` entries beyond `retain`. Returns bytes freed.
+/// Filename format (from archive_prior): `<date>.<ISO>.md` — ISO-8601 seconds
+/// sort chronologically when ordered lexically, so .sort() + drop-first N gives
+/// the oldest.
+fn prune_history(root_override: Option<&str>, date: NaiveDate, retain: u32) -> Result<u64> {
+    let hist = summary_history_dir(root_override);
+    if !hist.exists() {
+        return Ok(0);
+    }
+    let stem = date.format("%Y-%m-%d").to_string();
+    let mut matches: Vec<std::path::PathBuf> = std::fs::read_dir(&hist)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.starts_with(&stem))
+                .unwrap_or(false)
+        })
+        .collect();
+    if matches.len() <= retain as usize {
+        return Ok(0);
+    }
+    matches.sort();
+    let drop_count = matches.len() - retain as usize;
+    let mut freed = 0u64;
+    for p in matches.into_iter().take(drop_count) {
+        if let Ok(meta) = std::fs::metadata(&p) {
+            freed += meta.len();
+        }
+        std::fs::remove_file(&p)?;
+    }
+    if freed > 0 {
+        let audit_log = audit::Audit::open(root_override)?;
+        let _ = audit_log.append(
+            AuditAction::Delete {
+                target: hist.to_string_lossy().into_owned(),
+                reason: "history.rotate".into(),
+                bytes_freed: freed,
+            },
+            String::new(),
+        );
+    }
+    Ok(freed)
 }
 
 fn render(doc: &SummaryDoc) -> String {
@@ -359,5 +411,49 @@ mod tests {
             .filter(|l| !l.trim().is_empty())
             .any(|l| l.contains("\"kind\":\"summarize\""));
         assert!(has_summarize, "audit file must record a Summarize entry");
+    }
+
+    #[tokio::test]
+    async fn history_retention_prunes_to_retain_limit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+
+        // Seed 7 pre-existing .history/ entries directly (bypassing write_summary
+        // to avoid waiting 7 seconds between ISO-second timestamps).
+        let hist = summary_history_dir(Some(root));
+        std::fs::create_dir_all(&hist).unwrap();
+        for i in 0..7 {
+            let iso = format!("2026-04-19T00-00-0{i}Z");
+            std::fs::write(
+                hist.join(format!("2026-04-19.{iso}.md")),
+                format!("version {i}"),
+            )
+            .unwrap();
+        }
+        assert_eq!(std::fs::read_dir(&hist).unwrap().count(), 7);
+
+        let freed = prune_history(Some(root), date, 3).unwrap();
+        assert!(freed > 0, "prune should have freed bytes");
+        let remaining: Vec<_> = std::fs::read_dir(&hist)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(remaining.len(), 3, "expected 3 retained, got {remaining:?}");
+        // Remaining should be the 3 newest (highest ISO suffix).
+        assert!(remaining.iter().any(|n| n.contains("T00-00-06Z")));
+        assert!(remaining.iter().any(|n| n.contains("T00-00-05Z")));
+        assert!(remaining.iter().any(|n| n.contains("T00-00-04Z")));
+    }
+
+    #[test]
+    fn history_retention_empty_dir_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
+        // prune_history on non-existent .history dir must not error
+        let freed = prune_history(Some(root), date, 5).unwrap();
+        assert_eq!(freed, 0);
     }
 }

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -1081,7 +1081,7 @@ async fn async_main() -> Result<()> {
                 cmd::conversations_cmd::cmd_conversations_doctor().await?
             }
             ConversationsAction::Preflight => {
-                cmd::conversations_cmd::cmd_conversations_preflight()?
+                cmd::conversations_cmd::cmd_conversations_preflight().await?
             }
             ConversationsAction::Migrate {
                 run,

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -346,6 +346,8 @@ enum Commands {
         no_escalate: bool,
         #[arg(long)]
         debug_prompt: bool,
+        #[arg(long)]
+        strict_citations: bool,
     },
 }
 
@@ -1143,6 +1145,7 @@ async fn async_main() -> Result<()> {
             json,
             no_escalate,
             debug_prompt,
+            strict_citations,
         } => {
             cmd::conversations_cmd::cmd_ask(cmd::conversations_cmd::AskArgs {
                 question,
@@ -1155,6 +1158,7 @@ async fn async_main() -> Result<()> {
                 json,
                 no_escalate,
                 debug_prompt,
+                strict_citations,
             })
             .await?
         }

--- a/mur-core/tests/cli_conversations.rs
+++ b/mur-core/tests/cli_conversations.rs
@@ -122,3 +122,18 @@ fn mur_ask_on_empty_archive_returns_fallback() {
         "expected fallback text, got: {stdout}"
     );
 }
+
+#[test]
+fn mur_conversations_preflight_runs_without_ollama() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mur"));
+    let (cmd, _mur_home) = with_mur_home(cmd.args(["conversations", "preflight"]), tmp.path());
+    let out = cmd.output().expect("run mur");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Preflight may exit non-zero when Ollama is unreachable (CI has no Ollama).
+    // What we assert: the new probes ran and reported lines for them.
+    assert!(
+        stdout.contains("Ollama") && stdout.contains("free mem"),
+        "expected Phase 2C probes in output. stdout: {stdout}"
+    );
+}

--- a/mur-core/tests/cli_conversations.rs
+++ b/mur-core/tests/cli_conversations.rs
@@ -39,6 +39,7 @@ fn mur_conversations_doctor_runs() {
     assert!(stdout.contains("raw day-dirs"));
     assert!(stdout.contains("summaries:")); // NEW Phase 2A
     assert!(stdout.contains("Ollama")); // NEW Phase 2A
+    assert!(stdout.contains(".history/")); // NEW Phase 2C
 }
 
 #[test]

--- a/mur-core/tests/ollama_live_smoke.rs
+++ b/mur-core/tests/ollama_live_smoke.rs
@@ -1,0 +1,76 @@
+//! Real-Ollama smoke test (Phase 2C). Requires a running Ollama on
+//! http://localhost:11434 with the configured extractive/abstractive models
+//! pulled. Run locally with:
+//!   cargo test -p mur-core --features ollama-live-smoke -- --ignored
+//! NOT run by default in CI — would flake without Ollama.
+#![cfg(feature = "ollama-live-smoke")]
+
+use std::process::Command;
+
+#[ignore]
+#[test]
+fn compact_against_real_ollama() {
+    let tmp = tempfile::tempdir().unwrap();
+    let yesterday = (chrono::Utc::now().date_naive() - chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+    let mur_home = tmp.path().join(".mur");
+    let raw = mur_home.join("conversations/raw").join(&yesterday);
+    std::fs::create_dir_all(&raw).unwrap();
+
+    // Seed a single message with substance — the extractive LLM should pick it.
+    let line = serde_json::json!({
+        "v": 1,
+        "ts": format!("{yesterday}T10:00:00Z"),
+        "src": "claude-code",
+        "conv": "smoke",
+        "role": "user",
+        "content": {"t": "text", "v": "We decided to use RaBitQ compression for the vector index because it achieves 32x reduction with under 1% recall loss at k=10."},
+        "meta": {},
+        "refs": []
+    });
+    std::fs::write(
+        raw.join("cc_smoke.jsonl"),
+        serde_json::to_string(&line).unwrap() + "\n",
+    )
+    .unwrap();
+
+    // Run real binary against real Ollama (no MUR_OLLAMA_MOCK).
+    let out = Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args(["conversations", "compact", "--date", &yesterday])
+        .env("MUR_HOME", &mur_home)
+        .output()
+        .expect("failed to run mur");
+
+    if !out.status.success() {
+        eprintln!(
+            "mur compact failed — is Ollama running with qwen3:14b + command-r:latest pulled?\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        panic!("mur compact did not exit successfully");
+    }
+
+    // Verify the written summary has real content.
+    let md = mur_home
+        .join("conversations/summary")
+        .join(format!("{yesterday}.md"));
+    assert!(md.exists(), "summary not written at {md:?}");
+    let body = std::fs::read_to_string(&md).unwrap();
+    assert!(
+        body.contains("## Extractive spans"),
+        "summary missing extractive spans section; got:\n{body}"
+    );
+    assert!(
+        body.contains("## Abstractive narrative"),
+        "summary missing abstractive narrative section; got:\n{body}"
+    );
+    // A real LLM narrative should mention RaBitQ (topic of the seeded span).
+    // This is a weak assertion — model output varies, but every reasonable
+    // summary of a "RaBitQ compression decision" should mention RaBitQ.
+    assert!(
+        body.to_lowercase().contains("rabitq")
+            || body.to_lowercase().contains("compression")
+            || body.to_lowercase().contains("vector"),
+        "narrative should reference the seeded topic (RaBitQ/compression/vector); got:\n{body}"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 2C hardening pass: the last five tasks from `docs/superpowers/plans/2026-04-20-mur-conversations-phase-2.md`. Builds on the merged Phase 2A (#6) + 2B (#7).

## What ships

- **Task 28** — `.history/` retention cleanup + audit: after `archive_prior` moves the prior summary, prune per-day entries beyond `config.compact.history_retain` (default 5). Deletions record as `AuditAction::Delete { reason: "history.rotate" }`.
- **Task 29** — `mur ask --strict-citations`: `GroundingFilter::new_strict` + `coverage_check()` enforce spec §5.5's citation-per-claim rule. Claim sentences (≥ 8 words) without an adjacent `[cit: ...]` anchor trigger an `AskEvent::Error` before `Done`.
- **Task 30** — `mur conversations preflight` Ollama + model + mem checks: probes `/api/tags` reachability (2s timeout), verifies each configured model (compact.extractive, compact.abstractive, ask.model) appears in installed models, checks `~/.mur/patterns/` readability, reports free memory via `sysinfo`.
- **Task 31** — feature-gated real-Ollama smoke test at `tests/ollama_live_smoke.rs`. Run with `cargo test -p mur-core --features ollama-live-smoke -- --ignored`. Not run by CI (no Ollama).
- **Task 32** — `mur conversations doctor` reports `.history/` archive count + total bytes (KB).

## Test plan
- [x] 626 mur-core lib tests pass (`cargo test -p mur-core`)
- [x] 6 cli_conversations integration tests pass (includes new `mur_conversations_preflight_runs_without_ollama` + extended `mur_conversations_doctor_runs` with `.history/` assertion)
- [x] 7 cite tests pass (3 existing + 4 new strict-mode)
- [x] 6 writer tests pass (4 existing + 2 new retention tests)
- [x] `cargo build -p mur-core --features ollama-live-smoke` compiles clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `./scripts/golden-path-conversations.sh` — all 10 steps still green
- [ ] Run real-Ollama smoke locally before release (manual, gated by user)

## Dependencies added

- `sysinfo = "0.30"` (preflight free-mem probe)

## Feature flags added

- `ollama-live-smoke` (for Task 31's `#[ignore] #[test]` against real Ollama)

## Closes out Phase 2

With this PR merged, the full spec §1-12 is delivered:
- Phase 2A (#6): compact pipeline, commander piggyback, shared Ollama client
- Phase 2B (#7): Mode C Ask, streaming, grounding filter, plain + JSON output
- Phase 2C (this PR): history retention, strict citations, preflight, smoke tests, doctor coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)