### PR TITLE
feat(sources): P1.1 foundation + P1.2 Obsidian adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ capture/ → store/ → retrieve/ → inject/
             evolve/
 ```
 
-**Sources pipeline (P1.1 foundation in place; adapters arrive P1.2+):** An alternate input to `store/` lives in `mur-core/src/sources/` — `KnowledgeSource` adapters pull documents from external note apps (Obsidian, Notion, Joplin) into the same retrieve pipeline as patterns. The vector store is abstracted behind `store::vector::VectorStore` (impls: `LanceDbStore` now; `QdrantStore` P1.3). See `docs/superpowers/specs/2026-04-20-mur-sources-integration-design.md`.
+**Sources pipeline (P1.2 — Obsidian adapter shipped; Notion/Joplin arrive P1.4):** An alternate input to `store/` lives in `mur-core/src/sources/` — `KnowledgeSource` adapters pull documents from external note apps (Obsidian, Notion, Joplin) into the same retrieve pipeline as patterns. The vector store is abstracted behind `store::vector::VectorStore` (impls: `LanceDbStore` now; `QdrantStore` P1.3). See `docs/superpowers/specs/2026-04-20-mur-sources-integration-design.md`.
 
 - **`capture/`** — Noise filter, significance scoring, emergence detection, feedback extraction from session transcripts
 - **`store/`** — `YamlStore` (source of truth, atomic writes), `LanceDbStore` (vector index, always rebuildable), `WorkflowYamlStore`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ capture/ → store/ → retrieve/ → inject/
             evolve/
 ```
 
+**Sources pipeline (P1.1 foundation in place; adapters arrive P1.2+):** An alternate input to `store/` lives in `mur-core/src/sources/` — `KnowledgeSource` adapters pull documents from external note apps (Obsidian, Notion, Joplin) into the same retrieve pipeline as patterns. The vector store is abstracted behind `store::vector::VectorStore` (impls: `LanceDbStore` now; `QdrantStore` P1.3). See `docs/superpowers/specs/2026-04-20-mur-sources-integration-design.md`.
+
 - **`capture/`** — Noise filter, significance scoring, emergence detection, feedback extraction from session transcripts
 - **`store/`** — `YamlStore` (source of truth, atomic writes), `LanceDbStore` (vector index, always rebuildable), `WorkflowYamlStore`
 - **`retrieve/`** — Multi-signal scoring: `score_and_rank_hybrid()` combines vector similarity (0.7) + keyword BM25 (0.3), then applies weights for recency, effectiveness, importance, time decay, and length normalization

--- a/docs/superpowers/plans/2026-04-20-mur-sources-p1.2-obsidian.md
+++ b/docs/superpowers/plans/2026-04-20-mur-sources-p1.2-obsidian.md
@@ -1,0 +1,2859 @@
+# mur Sources — Phase 1.2 Obsidian Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first real `KnowledgeSource` adapter (Obsidian), replace the P1.1 stubs in `LanceDbStore` with working `upsert` / `search` / `delete` / `list_external_ids` / `count`, and deliver a minimum-viable end-to-end loop: `mur source add obsidian` → `mur source sync` → `mur source search` returns hits from the vault.
+
+**Architecture:** Obsidian adapter walks the user's vault (`*.md` files, `.obsidian/` + `.trash/` + user-excluded folders skipped), reads each file, parses YAML frontmatter, emits markdown-heading-aware chunks, and the sync orchestrator embeds them and upserts into a new LanceDB `sources` table. Deletion is detected each sync via a set-diff between the adapter's current `external_id` set and `VectorStore::list_external_ids(source_id)`. Unified retrieve across patterns + sources is deferred to P1.3; P1.2 adds only a minimal `mur source search` command that directly queries the sources table.
+
+**Tech Stack:** Rust edition 2024, Tokio, async-trait, anyhow, LanceDB (existing), pulldown-cmark (new, markdown parser), walkdir (existing), serde_yaml (existing), tracing (existing). File watcher is NOT in scope for P1.2 (deferred to P1.4).
+
+**Spec reference:** `docs/superpowers/specs/2026-04-20-mur-sources-integration-design.md` §6, §7.1, §8 (scoping wider), §11 (P1.2 line), §9.1 (per-adapter tests).
+
+**Depends on:** P1.1 foundation branch (`feat/sources-p1.1`). Start P1.2 from P1.1 HEAD (post-merge to main, or branch off P1.1).
+
+---
+
+## File Structure
+
+P1.2 touches these files:
+
+```
+mur-core/
+  Cargo.toml                                # MODIFY: + pulldown-cmark
+  src/
+    store/vector/
+      lancedb.rs                            # MODIFY: replace 5 trait stubs with real impls; add sources-table helpers
+    store/vector/tests.rs                   # MODIFY: un-ignore upsert/delete conformance tests
+    sources/
+      mod.rs                                # MODIFY: + pub mod adapters; + pub mod chunker; + pub mod sync;
+      chunker/
+        mod.rs                              # NEW: chunker namespace
+        markdown.rs                         # NEW: heading-aware markdown chunker
+      adapters/
+        mod.rs                              # NEW: adapter namespace
+        obsidian.rs                         # NEW: ObsidianAdapter impl of KnowledgeSource
+      sync.rs                               # NEW: sync orchestrator (sync_source + types)
+    cmd/
+      source_cmd.rs                         # MODIFY: replace every `bail!` with real handler
+      mod.rs                                # NO CHANGE (source_cmd already registered in P1.1)
+  tests/
+    obsidian_e2e.rs                         # NEW: end-to-end integration test
+```
+
+**Design choices**:
+- LanceDB `sources` table lives alongside `patterns` inside the same `~/.mur/index/` connection. Table name is the string `"sources"` — distinct from the pattern table `"patterns"` (existing).
+- Upsert strategy is **delete-by-chunk_id then insert** (simpler than `merge_insert`; the difference is micro-performance not correctness).
+- Cursor for Obsidian is an **RFC3339 timestamp string** stored in `SourceInstance.sync.last_cursor`. First sync uses `None`, subsequent sync uses `max(updated_at)` of the previous run's returned docs.
+- `external_id` for Obsidian is the **relative path from vault root** (`notes/ideas/foo.md`).
+- The MVP sources-only search goes under `mur source search <query>` (a new verb). It does NOT touch the existing `mur search` code path — that integration is P1.3.
+
+---
+
+## Task 0: Prep — Verify Baseline
+
+**Files:** None (verification).
+
+- [ ] **Step 1: Confirm worktree/branch state**
+
+```bash
+cd /Volumes/Firecuda4tb/Projects/mur/.worktrees/sources-p1.1 || cd <wherever-p1.1-branch-lives>
+git branch --show-current
+git log --oneline -3
+```
+
+If P1.1 has been merged to main, branch from main:
+```bash
+git checkout main
+git pull
+git worktree add .worktrees/sources-p1.2 -b feat/sources-p1.2 main
+cd .worktrees/sources-p1.2
+```
+
+Otherwise continue on `feat/sources-p1.1` (P1.2 builds directly on P1.1 commits).
+
+- [ ] **Step 2: Baseline green**
+
+```bash
+cargo test --workspace 2>&1 | grep -E "^test result:"
+```
+
+Record counts. P1.1 baseline was 1246 passing. Everything at the start of P1.2 should pass. If tests fail, STOP and investigate.
+
+---
+
+## Task 1: LanceDB `sources` Table Schema + Openers
+
+**Files:**
+- Modify: `mur-core/src/store/vector/lancedb.rs`
+
+- [ ] **Step 1: Write a failing test asserting the sources table can be opened/created**
+
+Inside the existing `#[cfg(test)] mod tests { ... }` block at the bottom of `mur-core/src/store/vector/lancedb.rs`, APPEND:
+
+```rust
+    #[tokio::test]
+    async fn open_or_create_sources_table_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        // First call creates
+        store.ensure_sources_table().await.unwrap();
+        // Second call is a no-op
+        store.ensure_sources_table().await.unwrap();
+        // Row count zero
+        let c = <LanceDbStore as VectorStore>::count(&store, None).await.unwrap();
+        assert_eq!(c, 0);
+    }
+```
+
+- [ ] **Step 2: Run to confirm it fails**
+
+```bash
+cargo test -p mur-core store::vector::lancedb::tests::open_or_create_sources_table_is_idempotent
+```
+
+Expected: compile error (`ensure_sources_table` not found).
+
+- [ ] **Step 3: Add the schema and helper methods**
+
+Still in `mur-core/src/store/vector/lancedb.rs`, inside the `impl LanceDbStore { ... }` inherent block (NOT the trait impl), ADD these methods. Place after the existing `search(..., item_type)` method and before the `fn schema(...)` helper:
+
+```rust
+/// Name of the LanceDB table that stores source chunks (separate from `patterns`).
+pub const SOURCES_TABLE: &str = "sources";
+
+/// Arrow schema for the sources table.
+pub fn sources_schema(dimensions: i32) -> Schema {
+    Schema::new(vec![
+        Field::new("chunk_id", DataType::Utf8, false),
+        Field::new("source_id", DataType::Utf8, false),
+        Field::new("external_id", DataType::Utf8, false),
+        Field::new("ordinal", DataType::UInt64, false),
+        Field::new("text", DataType::Utf8, false),
+        Field::new("heading_path", DataType::Utf8, false), // JSON-encoded array
+        Field::new("char_start", DataType::UInt64, false),
+        Field::new("char_end", DataType::UInt64, false),
+        Field::new("updated_at_ms", DataType::Int64, false),
+        Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                dimensions,
+            ),
+            false,
+        ),
+    ])
+}
+
+impl LanceDbStore {
+    /// Create the `sources` table if it doesn't exist. Idempotent.
+    pub async fn ensure_sources_table(&self) -> Result<()> {
+        let tables = self.db.table_names().execute().await?;
+        if tables.contains(&SOURCES_TABLE.to_string()) {
+            return Ok(());
+        }
+        let schema = sources_schema(self.dimensions);
+        // Empty RecordBatchIterator to create a table with the schema.
+        let empty: Vec<std::result::Result<RecordBatch, arrow_schema::ArrowError>> = Vec::new();
+        let reader = RecordBatchIterator::new(empty, Arc::new(schema));
+        self.db
+            .create_table(SOURCES_TABLE, Box::new(reader) as Box<dyn arrow_array::RecordBatchReader + Send>)
+            .execute()
+            .await
+            .context("creating sources table")?;
+        Ok(())
+    }
+}
+```
+
+**IMPORTANT**: the `sources_schema` function + `SOURCES_TABLE` constant are file-level items (not inside any `impl`). `ensure_sources_table` lives in the same `impl LanceDbStore { ... }` block that already holds `open`, `build_index`, etc.
+
+If the `RecordBatchIterator::new(empty, schema)` call fails to typecheck (e.g. generic inference issues with empty `Vec`), annotate the element type explicitly — the turbofish form `Vec::<std::result::Result<RecordBatch, arrow_schema::ArrowError>>::new()` should satisfy the inference.
+
+- [ ] **Step 4: Run the test**
+
+```bash
+cargo test -p mur-core store::vector::lancedb::tests::open_or_create_sources_table_is_idempotent
+```
+
+Expected: PASS.
+
+Also run the full store::vector test module to confirm no regression:
+```bash
+cargo test -p mur-core store::vector
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/store/vector/lancedb.rs
+git commit -m "feat(vector): LanceDB sources table schema + ensure_sources_table helper"
+```
+
+---
+
+## Task 2: `LanceDbStore::upsert` Real Implementation
+
+**Files:**
+- Modify: `mur-core/src/store/vector/lancedb.rs`
+
+Strategy: delete-then-insert. For each batch of chunks, we (a) delete any rows with the same `chunk_id`, then (b) append the new rows. `chunk_id` is UUIDv4 so collisions on re-upsert are rare; the delete step handles the re-sync case where the adapter recomputes chunks for a modified document (different `chunk_id` but same `external_id` — the `external_id`-level reconciliation happens in `delete_by_external_ids` called BEFORE upsert in the sync flow).
+
+- [ ] **Step 1: Write failing roundtrip test**
+
+At the bottom of the existing tests module in `mur-core/src/store/vector/lancedb.rs`, APPEND:
+
+```rust
+    #[tokio::test]
+    async fn sources_upsert_and_search_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        store.ensure_sources_table().await.unwrap();
+
+        let now = chrono::Utc::now();
+        let mk_chunk = |id: &str, ext: &str, text: &str, embed: Vec<f32>| -> super::EmbeddedChunk {
+            super::EmbeddedChunk {
+                chunk_id: id.into(),
+                source_id: "obsidian:test".into(),
+                external_id: ext.into(),
+                ordinal: 0,
+                text: text.into(),
+                heading_path: vec!["Section".into()],
+                char_range: (0, text.len()),
+                updated_at: now,
+                embedding: embed,
+            }
+        };
+
+        let v_a: Vec<f32> = (0..TEST_DIM as usize).map(|i| (i as f32 * 0.01).sin()).collect();
+        let v_b: Vec<f32> = (0..TEST_DIM as usize).map(|i| (i as f32 * 0.01).cos()).collect();
+
+        <LanceDbStore as super::VectorStore>::upsert(
+            &store,
+            &[mk_chunk("c1", "doc-a", "alpha text", v_a.clone())],
+        )
+        .await
+        .unwrap();
+        <LanceDbStore as super::VectorStore>::upsert(
+            &store,
+            &[mk_chunk("c2", "doc-b", "bravo text", v_b.clone())],
+        )
+        .await
+        .unwrap();
+
+        // Search by v_a should return c1 (closer) first.
+        let hits = <LanceDbStore as super::VectorStore>::search(
+            &store,
+            &v_a,
+            5,
+            &super::SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+        assert!(!hits.is_empty(), "expected hits");
+        assert_eq!(hits[0].chunk_id, "c1");
+        assert_eq!(hits[0].source_id, "obsidian:test");
+        assert_eq!(hits[0].external_id, "doc-a");
+        assert_eq!(hits[0].heading_path, vec!["Section".to_string()]);
+    }
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cargo test -p mur-core store::vector::lancedb::tests::sources_upsert_and_search_roundtrip
+```
+
+Expected: PANIC / bail — `LanceDbStore::upsert is a stub` (because the trait method still bails).
+
+- [ ] **Step 3: Replace the `upsert` stub with a real implementation**
+
+In the `#[async_trait] impl VectorStore for LanceDbStore { ... }` block, REPLACE the entire `upsert` method body with:
+
+```rust
+    async fn upsert(&self, chunks: &[EmbeddedChunk]) -> Result<()> {
+        if chunks.is_empty() {
+            return Ok(());
+        }
+        self.ensure_sources_table().await?;
+
+        // Delete any existing rows with these chunk_ids (idempotent upsert).
+        let ids: Vec<String> = chunks.iter().map(|c| format!("'{}'", c.chunk_id.replace('\'', "''"))).collect();
+        let predicate = format!("chunk_id IN ({})", ids.join(","));
+        let table = self.db.open_table(SOURCES_TABLE).execute().await?;
+        // `delete` is OK to call even when no rows match; it won't error.
+        let _ = table.delete(&predicate).await;
+
+        // Build the columns.
+        let chunk_ids: Vec<&str> = chunks.iter().map(|c| c.chunk_id.as_str()).collect();
+        let source_ids: Vec<&str> = chunks.iter().map(|c| c.source_id.as_str()).collect();
+        let external_ids: Vec<&str> = chunks.iter().map(|c| c.external_id.as_str()).collect();
+        let ordinals: Vec<u64> = chunks.iter().map(|c| c.ordinal as u64).collect();
+        let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
+        let heading_paths: Vec<String> = chunks
+            .iter()
+            .map(|c| serde_json::to_string(&c.heading_path).unwrap_or_else(|_| "[]".into()))
+            .collect();
+        let heading_path_refs: Vec<&str> = heading_paths.iter().map(|s| s.as_str()).collect();
+        let char_starts: Vec<u64> = chunks.iter().map(|c| c.char_range.0 as u64).collect();
+        let char_ends: Vec<u64> = chunks.iter().map(|c| c.char_range.1 as u64).collect();
+        let updated_at_ms: Vec<i64> = chunks
+            .iter()
+            .map(|c| c.updated_at.timestamp_millis())
+            .collect();
+
+        // Build FixedSizeList of vectors.
+        let all_vectors: Vec<f32> = chunks.iter().flat_map(|c| c.embedding.clone()).collect();
+        let values = Float32Array::from(all_vectors);
+        let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let vector_array =
+            FixedSizeListArray::new(item_field, self.dimensions, Arc::new(values), None);
+
+        let schema = sources_schema(self.dimensions);
+        use arrow_array::{Int64Array, UInt64Array};
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(StringArray::from(chunk_ids)),
+                Arc::new(StringArray::from(source_ids)),
+                Arc::new(StringArray::from(external_ids)),
+                Arc::new(UInt64Array::from(ordinals)),
+                Arc::new(StringArray::from(texts)),
+                Arc::new(StringArray::from(heading_path_refs)),
+                Arc::new(UInt64Array::from(char_starts)),
+                Arc::new(UInt64Array::from(char_ends)),
+                Arc::new(Int64Array::from(updated_at_ms)),
+                Arc::new(vector_array),
+            ],
+        )?;
+
+        let batches = RecordBatchIterator::new(vec![Ok(batch)], Arc::new(schema));
+        let reader: Box<dyn arrow_array::RecordBatchReader + Send> = Box::new(batches);
+        table.add(reader).execute().await?;
+        Ok(())
+    }
+```
+
+You may need to tweak imports at the top of the file:
+- Ensure `arrow_array::{Int64Array, UInt64Array, FixedSizeListArray, Float32Array, RecordBatch, RecordBatchIterator, StringArray}` are all imported.
+- `arrow_schema::{DataType, Field, Schema}` should already be imported.
+
+If LanceDB's `table.delete(predicate)` signature doesn't match (the 0.26.x API may have changed), consult the `lancedb` crate source and adapt. The conventional signature is `async fn delete(&self, predicate: &str) -> Result<()>`.
+
+- [ ] **Step 4: Run the test**
+
+```bash
+cargo test -p mur-core store::vector::lancedb::tests::sources_upsert_and_search_roundtrip
+```
+
+Expected: will still FAIL because `search` is also a stub. That's OK — the upsert half works, the assertion trips on `search`. Move on to Task 3.
+
+To verify upsert alone succeeds, run:
+```bash
+cargo test -p mur-core store::vector::lancedb::tests::open_or_create_sources_table_is_idempotent
+```
+Still passes. Good.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/store/vector/lancedb.rs
+git commit -m "feat(vector): LanceDbStore::upsert real impl (delete-then-insert)"
+```
+
+---
+
+## Task 3: `LanceDbStore::search` (trait method) Real Implementation
+
+**Files:**
+- Modify: `mur-core/src/store/vector/lancedb.rs`
+
+- [ ] **Step 1: Replace the `search` trait-method stub**
+
+In the `impl VectorStore for LanceDbStore` block, REPLACE the `search` method body with:
+
+```rust
+    async fn search(
+        &self,
+        query_vec: &[f32],
+        k: usize,
+        filter: &SearchFilter,
+    ) -> Result<Vec<Hit>> {
+        use futures::TryStreamExt;
+        use lancedb::query::{ExecutableQuery, QueryBase};
+
+        let tables = self.db.table_names().execute().await?;
+        if !tables.contains(&SOURCES_TABLE.to_string()) {
+            return Ok(vec![]);
+        }
+        let table = self.db.open_table(SOURCES_TABLE).execute().await?;
+
+        let mut query = table.vector_search(query_vec.to_vec()).context("vector_search")?;
+
+        // Build WHERE predicate from filter.
+        let mut predicates: Vec<String> = Vec::new();
+        if let Some(ids) = &filter.source_ids
+            && !ids.is_empty()
+        {
+            let escaped: Vec<String> = ids
+                .iter()
+                .map(|s| format!("'{}'", s.replace('\'', "''")))
+                .collect();
+            predicates.push(format!("source_id IN ({})", escaped.join(",")));
+        }
+        if let Some(since) = filter.since {
+            predicates.push(format!("updated_at_ms >= {}", since.timestamp_millis()));
+        }
+        if !predicates.is_empty() {
+            query = query.only_if(predicates.join(" AND "));
+        }
+
+        let results = query
+            .limit(k)
+            .execute()
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let mut hits: Vec<Hit> = Vec::new();
+        for batch in &results {
+            use arrow_array::{Int64Array, StringArray};
+            let chunk_ids = batch
+                .column_by_name("chunk_id")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .context("column chunk_id missing or wrong type")?;
+            let source_ids = batch
+                .column_by_name("source_id")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .context("column source_id missing")?;
+            let external_ids = batch
+                .column_by_name("external_id")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .context("column external_id missing")?;
+            let texts = batch
+                .column_by_name("text")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .context("column text missing")?;
+            let heading_paths = batch
+                .column_by_name("heading_path")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .context("column heading_path missing")?;
+            let updated_at_ms = batch
+                .column_by_name("updated_at_ms")
+                .and_then(|c| c.as_any().downcast_ref::<Int64Array>())
+                .context("column updated_at_ms missing")?;
+            let distances = batch
+                .column_by_name("_distance")
+                .and_then(|c| c.as_any().downcast_ref::<Float32Array>())
+                .context("column _distance missing")?;
+
+            for i in 0..batch.num_rows() {
+                let d = distances.value(i);
+                // LanceDB default distance is L2 squared; similarity = 1/(1+d).
+                let score = 1.0 / (1.0 + d);
+                let hp: Vec<String> = serde_json::from_str(heading_paths.value(i)).unwrap_or_default();
+                let ms = updated_at_ms.value(i);
+                let ts = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms)
+                    .unwrap_or_else(|| chrono::Utc::now());
+                hits.push(Hit {
+                    chunk_id: chunk_ids.value(i).to_string(),
+                    source_id: source_ids.value(i).to_string(),
+                    external_id: external_ids.value(i).to_string(),
+                    score,
+                    text: texts.value(i).to_string(),
+                    heading_path: hp,
+                    updated_at: ts,
+                });
+            }
+        }
+        Ok(hits)
+    }
+```
+
+This uses Rust 2024's `let ... && ...` chained conditions which are already used elsewhere in this crate.
+
+- [ ] **Step 2: Run the roundtrip test**
+
+```bash
+cargo test -p mur-core store::vector::lancedb::tests::sources_upsert_and_search_roundtrip
+```
+
+Expected: PASS. The inserted `c1` chunk with vector `v_a` should be the top hit when searched with `v_a`.
+
+- [ ] **Step 3: Also verify conformance smoke still passes**
+
+```bash
+cargo test -p mur-core store::vector
+```
+
+Expected: all non-ignored tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/store/vector/lancedb.rs
+git commit -m "feat(vector): LanceDbStore::search real impl with source_id/since filter"
+```
+
+---
+
+## Task 4: `LanceDbStore::list_external_ids` + `count` Real Implementations
+
+**Files:**
+- Modify: `mur-core/src/store/vector/lancedb.rs`
+
+- [ ] **Step 1: Failing test**
+
+Append to the tests module:
+
+```rust
+    #[tokio::test]
+    async fn sources_list_external_ids_and_count_work() {
+        let tmp = TempDir::new().unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        let now = chrono::Utc::now();
+        let zeros = vec![0.0_f32; TEST_DIM as usize];
+
+        let chunks: Vec<super::EmbeddedChunk> = (0..3)
+            .map(|i| super::EmbeddedChunk {
+                chunk_id: format!("cid-{i}"),
+                source_id: "obsidian:test".into(),
+                external_id: format!("doc-{i}"),
+                ordinal: 0,
+                text: "x".into(),
+                heading_path: vec![],
+                char_range: (0, 1),
+                updated_at: now,
+                embedding: zeros.clone(),
+            })
+            .collect();
+
+        <LanceDbStore as super::VectorStore>::upsert(&store, &chunks).await.unwrap();
+
+        let ids = <LanceDbStore as super::VectorStore>::list_external_ids(&store, "obsidian:test")
+            .await
+            .unwrap();
+        let mut sorted = ids.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec!["doc-0", "doc-1", "doc-2"]);
+
+        let all = <LanceDbStore as super::VectorStore>::count(&store, None).await.unwrap();
+        assert_eq!(all, 3);
+
+        let scoped = <LanceDbStore as super::VectorStore>::count(&store, Some("obsidian:test"))
+            .await
+            .unwrap();
+        assert_eq!(scoped, 3);
+
+        let other =
+            <LanceDbStore as super::VectorStore>::count(&store, Some("nope")).await.unwrap();
+        assert_eq!(other, 0);
+    }
+```
+
+- [ ] **Step 2: Run to confirm FAIL (bail)**
+
+```bash
+cargo test -p mur-core store::vector::lancedb::tests::sources_list_external_ids_and_count_work
+```
+
+- [ ] **Step 3: Replace `list_external_ids` body**
+
+In `impl VectorStore for LanceDbStore`, REPLACE `list_external_ids` body:
+
+```rust
+    async fn list_external_ids(&self, source_id: &str) -> Result<Vec<String>> {
+        use futures::TryStreamExt;
+        use lancedb::query::{ExecutableQuery, QueryBase};
+
+        let tables = self.db.table_names().execute().await?;
+        if !tables.contains(&SOURCES_TABLE.to_string()) {
+            return Ok(vec![]);
+        }
+        let table = self.db.open_table(SOURCES_TABLE).execute().await?;
+        let batches = table
+            .query()
+            .only_if(format!(
+                "source_id = '{}'",
+                source_id.replace('\'', "''")
+            ))
+            .select(lancedb::query::Select::Columns(vec!["external_id".to_string()]))
+            .execute()
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        use arrow_array::StringArray;
+        let mut set: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for batch in &batches {
+            let col = batch
+                .column_by_name("external_id")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .context("column external_id missing")?;
+            for i in 0..batch.num_rows() {
+                set.insert(col.value(i).to_string());
+            }
+        }
+        Ok(set.into_iter().collect())
+    }
+```
+
+- [ ] **Step 4: Replace `count` body**
+
+```rust
+    async fn count(&self, source_id: Option<&str>) -> Result<usize> {
+        let tables = self.db.table_names().execute().await?;
+        if !tables.contains(&SOURCES_TABLE.to_string()) {
+            return Ok(0);
+        }
+        let table = self.db.open_table(SOURCES_TABLE).execute().await?;
+        let total = match source_id {
+            None => table.count_rows(None).await?,
+            Some(sid) => {
+                table
+                    .count_rows(Some(format!(
+                        "source_id = '{}'",
+                        sid.replace('\'', "''")
+                    )))
+                    .await?
+            }
+        };
+        Ok(total)
+    }
+```
+
+**Note**: if `Table::count_rows` takes a different arg shape in lancedb 0.26.x (e.g. `count_rows(&self, predicate: Option<String>)` vs `Option<&str>`), adjust to the actual signature. The conventional form accepts `Option<String>` for a predicate; a `None` counts all rows.
+
+- [ ] **Step 5: Run test**
+
+```bash
+cargo test -p mur-core store::vector::lancedb::tests::sources_list_external_ids_and_count_work
+```
+
+Expected: PASS.
+
+Also re-run the full store::vector module to catch regressions:
+```bash
+cargo test -p mur-core store::vector
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/store/vector/lancedb.rs
+git commit -m "feat(vector): LanceDbStore::list_external_ids and count real impls"
+```
+
+---
+
+## Task 5: `LanceDbStore::delete_by_external_ids` + `delete_by_source` Real Implementations
+
+**Files:**
+- Modify: `mur-core/src/store/vector/lancedb.rs`
+
+- [ ] **Step 1: Failing test**
+
+Append:
+
+```rust
+    #[tokio::test]
+    async fn sources_delete_operations_work() {
+        let tmp = TempDir::new().unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        let now = chrono::Utc::now();
+        let zeros = vec![0.0_f32; TEST_DIM as usize];
+
+        let chunks: Vec<super::EmbeddedChunk> = (0..4)
+            .map(|i| super::EmbeddedChunk {
+                chunk_id: format!("cid-{i}"),
+                source_id: if i < 2 { "src:a".into() } else { "src:b".into() },
+                external_id: format!("doc-{i}"),
+                ordinal: 0,
+                text: "x".into(),
+                heading_path: vec![],
+                char_range: (0, 1),
+                updated_at: now,
+                embedding: zeros.clone(),
+            })
+            .collect();
+
+        <LanceDbStore as super::VectorStore>::upsert(&store, &chunks).await.unwrap();
+
+        // Delete one doc from src:a
+        <LanceDbStore as super::VectorStore>::delete_by_external_ids(
+            &store,
+            "src:a",
+            &["doc-0".to_string()],
+        )
+        .await
+        .unwrap();
+        let remaining_a = <LanceDbStore as super::VectorStore>::list_external_ids(&store, "src:a")
+            .await
+            .unwrap();
+        assert_eq!(remaining_a, vec!["doc-1"]);
+
+        // delete_by_source removes all src:b rows
+        <LanceDbStore as super::VectorStore>::delete_by_source(&store, "src:b").await.unwrap();
+        let remaining_b = <LanceDbStore as super::VectorStore>::list_external_ids(&store, "src:b")
+            .await
+            .unwrap();
+        assert!(remaining_b.is_empty());
+
+        // src:a is untouched
+        let still_a = <LanceDbStore as super::VectorStore>::list_external_ids(&store, "src:a")
+            .await
+            .unwrap();
+        assert_eq!(still_a, vec!["doc-1"]);
+    }
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+cargo test -p mur-core store::vector::lancedb::tests::sources_delete_operations_work
+```
+
+- [ ] **Step 3: Replace both delete method bodies**
+
+```rust
+    async fn delete_by_external_ids(
+        &self,
+        source_id: &str,
+        external_ids: &[String],
+    ) -> Result<()> {
+        if external_ids.is_empty() {
+            return Ok(());
+        }
+        let tables = self.db.table_names().execute().await?;
+        if !tables.contains(&SOURCES_TABLE.to_string()) {
+            return Ok(());
+        }
+        let table = self.db.open_table(SOURCES_TABLE).execute().await?;
+        let escaped: Vec<String> = external_ids
+            .iter()
+            .map(|e| format!("'{}'", e.replace('\'', "''")))
+            .collect();
+        let predicate = format!(
+            "source_id = '{}' AND external_id IN ({})",
+            source_id.replace('\'', "''"),
+            escaped.join(",")
+        );
+        table.delete(&predicate).await?;
+        Ok(())
+    }
+
+    async fn delete_by_source(&self, source_id: &str) -> Result<()> {
+        let tables = self.db.table_names().execute().await?;
+        if !tables.contains(&SOURCES_TABLE.to_string()) {
+            return Ok(());
+        }
+        let table = self.db.open_table(SOURCES_TABLE).execute().await?;
+        let predicate = format!("source_id = '{}'", source_id.replace('\'', "''"));
+        table.delete(&predicate).await?;
+        Ok(())
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p mur-core store::vector::lancedb
+```
+
+Expected: all new tests pass, including `sources_delete_operations_work`. Existing patterns tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/store/vector/lancedb.rs
+git commit -m "feat(vector): LanceDbStore::delete_by_external_ids and delete_by_source"
+```
+
+---
+
+## Task 6: Un-ignore the Conformance Macro Tests
+
+The P1.1 conformance macro left `conformance_upsert_and_search` and `conformance_delete_by_source_clears` marked `#[ignore]`. Now that the impls are real, remove those markers.
+
+**Files:**
+- Modify: `mur-core/src/store/vector/tests.rs`
+
+- [ ] **Step 1: Remove the two `#[ignore = "..."]` lines**
+
+Open `mur-core/src/store/vector/tests.rs`. In the `#[macro_export] macro_rules! vector_store_conformance` block, delete the lines:
+
+```rust
+        #[ignore = "enabled from P1.2 when upsert is real"]
+```
+and
+```rust
+        #[ignore = "enabled from P1.2 when delete_by_source is real"]
+```
+
+The surrounding `#[tokio::test]` and method bodies stay intact.
+
+- [ ] **Step 2: Before the conformance tests run, the LanceDbStore factory used by the macro needs to call `ensure_sources_table` — otherwise search returns empty and upsert fails silently.**
+
+In `mur-core/src/store/vector/lancedb.rs`, update `make_store_for_conformance` to ensure the table:
+
+```rust
+    async fn make_store_for_conformance() -> LanceDbStore {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        // LanceDB tables are lazy — upsert calls ensure_sources_table internally,
+        // but the delete_by_source conformance test runs before any upsert.
+        store.ensure_sources_table().await.unwrap();
+        store
+        // NOTE: TempDir drops at end of function. In practice the conformance tests
+        // don't need long-lived TempDirs because the LanceDB connection holds the
+        // path open until the store handle itself is dropped.
+    }
+```
+
+**WAIT — this is a bug pattern**: `tmp` drops at function end; if the test takes a Mutex or awaits elsewhere, the LanceDB directory vanishes mid-test. Fix by leaking the TempDir OR by returning `(LanceDbStore, TempDir)` — which requires changing the macro. Simpler: use `std::mem::forget(tmp);` to deliberately leak (conformance tests are rare).
+
+Replace the factory body with:
+
+```rust
+    async fn make_store_for_conformance() -> LanceDbStore {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        store.ensure_sources_table().await.unwrap();
+        // Intentionally leak the TempDir: the LanceDB connection holds an open
+        // handle and expects the directory to persist for the lifetime of the
+        // `store` (which outlives this function). Conformance tests are few and
+        // short-lived; leaked temp dirs get cleaned up by the OS at reboot.
+        std::mem::forget(tmp);
+        store
+    }
+```
+
+- [ ] **Step 3: Run conformance suite**
+
+```bash
+cargo test -p mur-core store::vector::lancedb::tests::conformance_
+```
+
+Expected: three tests now all `ok` (no more ignored):
+- `conformance_smoke_count_empty ... ok`
+- `conformance_upsert_and_search ... ok`
+- `conformance_delete_by_source_clears ... ok`
+
+- [ ] **Step 4: Full workspace regression**
+
+```bash
+cargo test --workspace 2>&1 | grep -E "^test result:"
+```
+
+Record counts.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/store/vector/tests.rs mur-core/src/store/vector/lancedb.rs
+git commit -m "test(vector): un-ignore upsert/delete conformance tests now that impls are real"
+```
+
+---
+
+## Task 7: Shared Markdown Chunker (heading-aware)
+
+**Files:**
+- Modify: `mur-core/Cargo.toml` (add `pulldown-cmark`)
+- Create: `mur-core/src/sources/chunker/mod.rs`
+- Create: `mur-core/src/sources/chunker/markdown.rs`
+- Modify: `mur-core/src/sources/mod.rs`
+
+- [ ] **Step 1: Add pulldown-cmark dep**
+
+Open `mur-core/Cargo.toml`. In `[dependencies]`, add:
+
+```toml
+pulldown-cmark = "0.12"
+```
+
+Keep alphabetical order where the file already has one, otherwise just append.
+
+- [ ] **Step 2: Create `sources/chunker/mod.rs`**
+
+```rust
+//! Text chunking utilities shared across adapters.
+//!
+//! `markdown::chunk_markdown` is used by the Obsidian and (later) Joplin
+//! adapters. Notion uses a block-aware chunker that will live as a sibling
+//! module in P1.4 (`notion_blocks.rs`).
+
+pub mod markdown;
+```
+
+- [ ] **Step 3: Create `sources/chunker/markdown.rs`**
+
+```rust
+//! Markdown heading-aware chunker.
+//!
+//! Splits a document into chunks by H1/H2/H3 boundaries and, within a chunk,
+//! by paragraph boundaries if the byte budget is exceeded. Retains heading
+//! path (list of current headings at ≤3 levels) for provenance.
+
+use pulldown_cmark::{Event, HeadingLevel, Parser, Tag, TagEnd};
+
+/// A chunk of markdown text with provenance.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MarkdownChunk {
+    /// Hierarchy of headings at the chunk's start (e.g. ["Design", "Error handling"]).
+    pub heading_path: Vec<String>,
+    /// Inclusive character offsets in the ORIGINAL body.
+    pub char_range: (usize, usize),
+    /// Plaintext content (markdown syntax stripped to embedding-friendly form).
+    pub text: String,
+}
+
+/// Chunk a markdown body.
+///
+/// - `title` prepends the chunker's notion of a "document title" into the heading
+///   path of every chunk (so searches over titles + sections work).
+/// - `max_chars` is a soft byte budget: chunks exceeding it are split at the
+///   nearest paragraph boundary.
+pub fn chunk_markdown(title: &str, body: &str, max_chars: usize) -> Vec<MarkdownChunk> {
+    let mut out: Vec<MarkdownChunk> = Vec::new();
+    let mut heading_stack: Vec<(u8, String)> = Vec::new(); // (level, heading text)
+    let mut cur_buf = String::new();
+    let mut cur_start: usize = 0;
+    let mut in_heading: Option<HeadingLevel> = None;
+    let mut heading_text_buf = String::new();
+
+    let flush = |heading_stack: &Vec<(u8, String)>,
+                 cur_buf: &mut String,
+                 cur_start: &mut usize,
+                 next_start: usize,
+                 out: &mut Vec<MarkdownChunk>| {
+        let text = std::mem::take(cur_buf).trim().to_string();
+        if !text.is_empty() {
+            let hp: Vec<String> = Some(title.to_string())
+                .into_iter()
+                .chain(heading_stack.iter().map(|(_, h)| h.clone()))
+                .filter(|s| !s.is_empty())
+                .collect();
+            out.push(MarkdownChunk {
+                heading_path: hp,
+                char_range: (*cur_start, next_start),
+                text,
+            });
+        }
+        *cur_start = next_start;
+    };
+
+    // pulldown-cmark offset iterator yields (Event, byte-range) tuples.
+    let offset_iter = Parser::new(body).into_offset_iter();
+
+    for (event, range) in offset_iter {
+        match event {
+            Event::Start(Tag::Heading { level, .. }) => {
+                // Flush what we had before the heading
+                let next_start = range.start;
+                flush(&heading_stack, &mut cur_buf, &mut cur_start, next_start, &mut out);
+                in_heading = Some(level);
+                heading_text_buf.clear();
+            }
+            Event::End(TagEnd::Heading(level)) => {
+                let text = std::mem::take(&mut heading_text_buf).trim().to_string();
+                let depth = heading_level_to_u8(level);
+                // Pop stack to the new depth - 1; then push.
+                while let Some(&(d, _)) = heading_stack.last() {
+                    if d >= depth {
+                        heading_stack.pop();
+                    } else {
+                        break;
+                    }
+                }
+                if !text.is_empty() {
+                    heading_stack.push((depth, text));
+                }
+                in_heading = None;
+                // Reset cursor for the NEXT chunk's starting offset.
+                cur_start = range.end;
+            }
+            Event::Text(t) => {
+                if in_heading.is_some() {
+                    heading_text_buf.push_str(&t);
+                } else {
+                    cur_buf.push_str(&t);
+                }
+            }
+            Event::SoftBreak | Event::HardBreak => {
+                if in_heading.is_none() {
+                    cur_buf.push('\n');
+                }
+            }
+            Event::End(TagEnd::Paragraph) => {
+                cur_buf.push_str("\n\n");
+                // Soft split if over budget.
+                if cur_buf.len() > max_chars {
+                    flush(
+                        &heading_stack,
+                        &mut cur_buf,
+                        &mut cur_start,
+                        range.end,
+                        &mut out,
+                    );
+                }
+            }
+            Event::Code(c) => {
+                if in_heading.is_none() {
+                    cur_buf.push_str(&format!("`{c}`"));
+                }
+            }
+            Event::Start(Tag::CodeBlock(_)) => {
+                cur_buf.push_str("\n```\n");
+            }
+            Event::End(TagEnd::CodeBlock) => {
+                cur_buf.push_str("\n```\n");
+            }
+            _ => {}
+        }
+    }
+
+    // Final flush.
+    flush(
+        &heading_stack,
+        &mut cur_buf,
+        &mut cur_start,
+        body.len(),
+        &mut out,
+    );
+
+    out
+}
+
+fn heading_level_to_u8(l: HeadingLevel) -> u8 {
+    match l {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_body_returns_no_chunks() {
+        let chunks = chunk_markdown("T", "", 1000);
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn single_paragraph_single_chunk() {
+        let chunks = chunk_markdown("T", "Hello world.", 1000);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].heading_path, vec!["T".to_string()]);
+        assert!(chunks[0].text.contains("Hello world"));
+    }
+
+    #[test]
+    fn h1_h2_chunks_track_heading_path() {
+        let body = "# Design\n\nintro para\n\n## Error handling\n\nsecond para\n";
+        let chunks = chunk_markdown("Doc", body, 1000);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].heading_path, vec!["Doc".to_string(), "Design".to_string()]);
+        assert!(chunks[0].text.contains("intro para"));
+        assert_eq!(
+            chunks[1].heading_path,
+            vec![
+                "Doc".to_string(),
+                "Design".to_string(),
+                "Error handling".to_string()
+            ]
+        );
+        assert!(chunks[1].text.contains("second para"));
+    }
+
+    #[test]
+    fn oversized_chunk_splits_on_paragraph() {
+        let big = "x".repeat(200);
+        let body = format!("{big}\n\n{big}\n\n{big}");
+        let chunks = chunk_markdown("T", &body, 150);
+        // Each of the three paragraphs should land in its own chunk (each > 150 chars).
+        assert!(chunks.len() >= 3);
+    }
+
+    #[test]
+    fn sibling_h2_does_not_leak_previous_h2() {
+        let body = "## A\n\npara A\n\n## B\n\npara B\n";
+        let chunks = chunk_markdown("Doc", body, 1000);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(
+            chunks[0].heading_path,
+            vec!["Doc".to_string(), "A".to_string()]
+        );
+        assert_eq!(
+            chunks[1].heading_path,
+            vec!["Doc".to_string(), "B".to_string()]
+        );
+    }
+
+    #[test]
+    fn char_range_covers_body() {
+        let body = "one\n\ntwo";
+        let chunks = chunk_markdown("T", body, 1000);
+        // Last char_range end should be body length.
+        let last = chunks.last().unwrap();
+        assert_eq!(last.char_range.1, body.len());
+    }
+}
+```
+
+- [ ] **Step 4: Declare modules**
+
+Append to `mur-core/src/sources/mod.rs`:
+
+```rust
+pub mod chunker;
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo test -p mur-core sources::chunker
+```
+
+Expected: 6 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/Cargo.toml mur-core/src/sources/mod.rs mur-core/src/sources/chunker/
+git commit -m "feat(sources): markdown heading-aware chunker (shared Obsidian/Joplin)"
+```
+
+---
+
+## Task 8: ObsidianAdapter Skeleton + `list_documents`
+
+**Files:**
+- Create: `mur-core/src/sources/adapters/mod.rs`
+- Create: `mur-core/src/sources/adapters/obsidian.rs`
+- Modify: `mur-core/src/sources/mod.rs`
+
+- [ ] **Step 1: Create `sources/adapters/mod.rs`**
+
+```rust
+//! `KnowledgeSource` implementations for each supported external app.
+
+pub mod obsidian;
+```
+
+- [ ] **Step 2: Declare in sources module**
+
+Append to `mur-core/src/sources/mod.rs`:
+
+```rust
+pub mod adapters;
+```
+
+- [ ] **Step 3: Create `obsidian.rs` with struct, constructor, list_documents (TDD — tests first)**
+
+Create `mur-core/src/sources/adapters/obsidian.rs`:
+
+```rust
+//! Obsidian vault adapter.
+//!
+//! Treats a local folder containing markdown files as a pull-index source.
+//! Excludes `.obsidian/` (app state), `.trash/`, and any user-configured
+//! folders via `SourceInstance.scope.exclude_folders`.
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::path::{Path, PathBuf};
+
+use crate::sources::chunker::markdown as md;
+use crate::sources::instance::SourceInstance;
+use crate::sources::kind::SourceKind;
+use crate::sources::types::{Chunk, DocRef, Document, DocumentBody, SyncCursor};
+use crate::sources::KnowledgeSource;
+
+const EXCLUDED_SEGMENTS: &[&str] = &[".obsidian", ".trash"];
+const CHUNK_MAX_CHARS: usize = 6000; // roughly 1500 tokens
+
+/// Obsidian vault adapter.
+pub struct ObsidianAdapter {
+    id: String,
+    vault_path: PathBuf,
+    weight: f32,
+    exclude_folders: Vec<String>,
+}
+
+impl ObsidianAdapter {
+    /// Build from a `SourceInstance` (expects `type_name == "obsidian"` and the
+    /// `scope.vault` value set to an absolute path).
+    pub fn from_instance(instance: &SourceInstance) -> Result<Self> {
+        if instance.type_name != "obsidian" {
+            bail!(
+                "expected type_name 'obsidian', got '{}'",
+                instance.type_name
+            );
+        }
+        let vault_val = instance
+            .scope
+            .get("vault")
+            .context("source instance missing scope.vault")?;
+        let vault_str: String = match vault_val {
+            serde_yaml::Value::String(s) => s.clone(),
+            _ => bail!("scope.vault must be a string"),
+        };
+        let vault_path = PathBuf::from(&vault_str);
+        if !vault_path.is_dir() {
+            bail!("vault path does not exist or is not a directory: {vault_str}");
+        }
+        // Warn — not fatal — if .obsidian isn't present.
+        if !vault_path.join(".obsidian").exists() {
+            tracing::warn!(
+                "vault {} has no .obsidian/ subdir — proceeding anyway",
+                vault_path.display()
+            );
+        }
+
+        let exclude_folders: Vec<String> = instance
+            .scope
+            .get("exclude_folders")
+            .and_then(|v| v.as_sequence())
+            .map(|seq| {
+                seq.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(Self {
+            id: instance.id.clone(),
+            vault_path,
+            weight: instance.weight,
+            exclude_folders,
+        })
+    }
+
+    fn is_excluded(&self, rel: &Path) -> bool {
+        for seg in rel.components() {
+            if let Some(s) = seg.as_os_str().to_str() {
+                if EXCLUDED_SEGMENTS.iter().any(|x| *x == s) {
+                    return true;
+                }
+                if self.exclude_folders.iter().any(|e| e == s) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+#[async_trait]
+impl KnowledgeSource for ObsidianAdapter {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn kind(&self) -> SourceKind {
+        SourceKind::PullIndex
+    }
+
+    fn weight(&self) -> f32 {
+        self.weight
+    }
+
+    async fn list_documents(
+        &self,
+        cursor: Option<SyncCursor>,
+    ) -> Result<(Vec<DocRef>, SyncCursor)> {
+        let threshold: Option<DateTime<Utc>> = cursor.and_then(|c| {
+            if c.is_empty() {
+                None
+            } else {
+                DateTime::parse_from_rfc3339(&c.0).ok().map(|dt| dt.with_timezone(&Utc))
+            }
+        });
+
+        let mut docs: Vec<DocRef> = Vec::new();
+        let mut max_ts: Option<DateTime<Utc>> = None;
+
+        for entry in walkdir::WalkDir::new(&self.vault_path)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let path = entry.path();
+            if path.extension().and_then(|x| x.to_str()) != Some("md") {
+                continue;
+            }
+            let rel = path
+                .strip_prefix(&self.vault_path)
+                .ok()
+                .map(|r| r.to_path_buf())
+                .unwrap_or_else(|| path.to_path_buf());
+            if self.is_excluded(&rel) {
+                continue;
+            }
+            let meta = entry.metadata().context("stat vault file")?;
+            let modified = meta.modified().context("no mtime on vault file")?;
+            let updated_at: DateTime<Utc> = modified.into();
+
+            if let Some(t) = threshold
+                && updated_at <= t
+            {
+                continue;
+            }
+            if max_ts.map_or(true, |m| updated_at > m) {
+                max_ts = Some(updated_at);
+            }
+            let external_id = rel
+                .to_str()
+                .context("vault path is not valid UTF-8")?
+                .to_string();
+            let title = rel
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string());
+            docs.push(DocRef {
+                external_id,
+                title,
+                updated_at,
+            });
+        }
+
+        // Cursor semantics: advance to max(updated_at) of returned docs; if no
+        // docs were returned, keep the previous cursor (preserves threshold).
+        let cursor_out = match max_ts {
+            Some(t) => SyncCursor(t.to_rfc3339()),
+            None => SyncCursor(threshold.map(|t| t.to_rfc3339()).unwrap_or_default()),
+        };
+
+        Ok((docs, cursor_out))
+    }
+
+    async fn fetch(&self, _doc_ref: &DocRef) -> Result<Document> {
+        anyhow::bail!("ObsidianAdapter::fetch arrives in Task 9")
+    }
+
+    fn chunk(&self, _doc: &Document) -> Result<Vec<Chunk>> {
+        anyhow::bail!("ObsidianAdapter::chunk arrives in Task 10")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_vault() -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join(".obsidian")).unwrap();
+        fs::write(tmp.path().join("note-a.md"), "# A\n\ncontent a").unwrap();
+        fs::create_dir_all(tmp.path().join("folder")).unwrap();
+        fs::write(tmp.path().join("folder").join("note-b.md"), "# B\n\ncontent b").unwrap();
+        fs::create_dir_all(tmp.path().join(".trash")).unwrap();
+        fs::write(tmp.path().join(".trash").join("deleted.md"), "# D").unwrap();
+        tmp
+    }
+
+    fn make_instance(id: &str, vault: &Path) -> SourceInstance {
+        let mut scope = BTreeMap::new();
+        scope.insert(
+            "vault".into(),
+            serde_yaml::Value::String(vault.to_string_lossy().to_string()),
+        );
+        SourceInstance {
+            id: id.into(),
+            type_name: "obsidian".into(),
+            kind: SourceKind::PullIndex,
+            enabled: true,
+            weight: 1.0,
+            scope,
+            sync: crate::sources::instance::SyncState::default(),
+            stats: crate::sources::instance::SourceStats::default(),
+            keyring_entry: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn from_instance_validates_vault_exists() {
+        let inst = {
+            let mut i = make_instance("obsidian-x", Path::new("/nonexistent/path/xyz"));
+            i.scope.insert(
+                "vault".into(),
+                serde_yaml::Value::String("/nonexistent/path/xyz".into()),
+            );
+            i
+        };
+        assert!(ObsidianAdapter::from_instance(&inst).is_err());
+    }
+
+    #[tokio::test]
+    async fn list_documents_finds_md_files_excluding_hidden() {
+        let tmp = make_vault();
+        let inst = make_instance("obsidian-main", tmp.path());
+        let adapter = ObsidianAdapter::from_instance(&inst).unwrap();
+        let (docs, _cursor) = adapter.list_documents(None).await.unwrap();
+        let mut ids: Vec<String> = docs.iter().map(|d| d.external_id.clone()).collect();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["folder/note-b.md".to_string(), "note-a.md".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn exclude_folder_is_honoured() {
+        let tmp = make_vault();
+        let mut inst = make_instance("obsidian-main", tmp.path());
+        inst.scope.insert(
+            "exclude_folders".into(),
+            serde_yaml::Value::Sequence(vec![serde_yaml::Value::String("folder".into())]),
+        );
+        let adapter = ObsidianAdapter::from_instance(&inst).unwrap();
+        let (docs, _) = adapter.list_documents(None).await.unwrap();
+        let ids: Vec<String> = docs.iter().map(|d| d.external_id.clone()).collect();
+        assert_eq!(ids, vec!["note-a.md".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn cursor_filters_older_files() {
+        let tmp = make_vault();
+        let inst = make_instance("obsidian-main", tmp.path());
+        let adapter = ObsidianAdapter::from_instance(&inst).unwrap();
+        let future = chrono::Utc::now() + chrono::Duration::days(365);
+        let (docs, _) = adapter
+            .list_documents(Some(SyncCursor(future.to_rfc3339())))
+            .await
+            .unwrap();
+        assert!(docs.is_empty());
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p mur-core sources::adapters::obsidian
+```
+
+Expected: 4 tests pass (one validates error on bad vault, three test discovery).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/sources/
+git commit -m "feat(sources): ObsidianAdapter skeleton + list_documents"
+```
+
+---
+
+## Task 9: ObsidianAdapter::fetch (read file + frontmatter)
+
+**Files:**
+- Modify: `mur-core/src/sources/adapters/obsidian.rs`
+
+- [ ] **Step 1: Failing test**
+
+Append inside the `#[cfg(test)] mod tests` block of `obsidian.rs`:
+
+```rust
+    #[tokio::test]
+    async fn fetch_reads_file_and_parses_frontmatter() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join(".obsidian")).unwrap();
+        fs::write(
+            tmp.path().join("spec.md"),
+            "---\ntags: [design, oauth]\nstatus: draft\n---\n\n# Auth spec\n\nbody.",
+        )
+        .unwrap();
+
+        let inst = make_instance("obsidian-main", tmp.path());
+        let adapter = ObsidianAdapter::from_instance(&inst).unwrap();
+        let (docs, _) = adapter.list_documents(None).await.unwrap();
+        let doc_ref = docs.iter().find(|d| d.external_id == "spec.md").unwrap();
+        let doc = adapter.fetch(doc_ref).await.unwrap();
+        assert_eq!(doc.source_id, "obsidian-main");
+        assert_eq!(doc.external_id, "spec.md");
+        assert!(doc.tags.contains(&"design".to_string()));
+        assert!(doc.tags.contains(&"oauth".to_string()));
+        // Body stripped of frontmatter
+        match &doc.body {
+            DocumentBody::Markdown(s) => {
+                assert!(s.starts_with("# Auth spec"));
+                assert!(!s.contains("---"));
+            }
+            _ => panic!("expected markdown body"),
+        }
+        // metadata retains arbitrary fields
+        assert_eq!(doc.metadata.get("status").and_then(|v| v.as_str()), Some("draft"));
+    }
+```
+
+- [ ] **Step 2: Run — expect FAIL (bail from Task 8 stub)**
+
+```bash
+cargo test -p mur-core sources::adapters::obsidian::tests::fetch_reads_file_and_parses_frontmatter
+```
+
+- [ ] **Step 3: Replace the `fetch` body**
+
+Replace the `fetch` method's body with:
+
+```rust
+    async fn fetch(&self, doc_ref: &DocRef) -> Result<Document> {
+        let full_path = self.vault_path.join(&doc_ref.external_id);
+        let raw = tokio::fs::read_to_string(&full_path)
+            .await
+            .with_context(|| format!("read vault file {}", full_path.display()))?;
+        let (frontmatter, body_without_fm) = strip_frontmatter(&raw);
+
+        let (tags, metadata) = frontmatter
+            .as_ref()
+            .map(parse_frontmatter)
+            .unwrap_or_else(|| (Vec::new(), serde_json::Value::Object(Default::default())));
+
+        let title = doc_ref
+            .title
+            .clone()
+            .unwrap_or_else(|| doc_ref.external_id.clone());
+
+        // Deep-link back to the vault via Obsidian URL scheme.
+        let url = {
+            let vault_name = self
+                .vault_path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("vault");
+            Some(format!(
+                "obsidian://open?vault={}&file={}",
+                urlencoding::encode(vault_name),
+                urlencoding::encode(&doc_ref.external_id)
+            ))
+        };
+
+        Ok(Document {
+            source_id: self.id.clone(),
+            external_id: doc_ref.external_id.clone(),
+            title,
+            body: DocumentBody::Markdown(body_without_fm.to_string()),
+            url,
+            updated_at: doc_ref.updated_at,
+            tags,
+            metadata,
+        })
+    }
+```
+
+- [ ] **Step 4: Add helper functions at the bottom of `obsidian.rs` (outside any impl / mod):**
+
+```rust
+/// Strip the YAML frontmatter block if present. Returns `(Some(fm_text), body)`
+/// or `(None, body)`. Frontmatter must start at character 0 and be delimited
+/// by `---\n` ... `\n---\n` (or `\r\n` variants).
+fn strip_frontmatter(raw: &str) -> (Option<&str>, &str) {
+    let mut lines = raw.split_inclusive('\n');
+    let first = match lines.next() {
+        Some(l) => l.trim_end_matches(['\r', '\n']),
+        None => return (None, raw),
+    };
+    if first != "---" {
+        return (None, raw);
+    }
+    // Find the closing "---" line.
+    let mut acc_len = first.len() + 1; // include newline
+    let mut end_at: Option<usize> = None;
+    for line in lines {
+        acc_len += line.len();
+        if line.trim_end_matches(['\r', '\n']) == "---" {
+            end_at = Some(acc_len);
+            break;
+        }
+    }
+    match end_at {
+        Some(idx) => {
+            let fm = &raw[..idx];
+            let body = raw[idx..].trim_start_matches('\n').trim_start_matches('\r');
+            // Drop leading/trailing `---\n` lines from fm for cleaner parse
+            let fm_inner = fm
+                .trim_start_matches("---")
+                .trim_start_matches(['\r', '\n'])
+                .trim_end_matches("---\n")
+                .trim_end_matches("---\r\n")
+                .trim_end_matches("---");
+            (Some(fm_inner), body)
+        }
+        None => (None, raw),
+    }
+}
+
+/// Parse frontmatter YAML into (tags, metadata).
+///
+/// `tags` is the value of the `tags` key if it is a sequence of strings.
+/// `metadata` is the full frontmatter as a JSON-compatible value, useful for
+/// downstream `Document.metadata`.
+fn parse_frontmatter(fm: &&str) -> (Vec<String>, serde_json::Value) {
+    let parsed: serde_yaml::Value = serde_yaml::from_str(fm).unwrap_or(serde_yaml::Value::Null);
+    let tags = parsed
+        .get("tags")
+        .and_then(|v| v.as_sequence())
+        .map(|seq| {
+            seq.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let metadata = yaml_to_json(&parsed);
+    (tags, metadata)
+}
+
+fn yaml_to_json(v: &serde_yaml::Value) -> serde_json::Value {
+    use serde_yaml::Value as Y;
+    match v {
+        Y::Null => serde_json::Value::Null,
+        Y::Bool(b) => serde_json::Value::Bool(*b),
+        Y::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                serde_json::Value::Number(i.into())
+            } else if let Some(f) = n.as_f64() {
+                serde_json::Number::from_f64(f)
+                    .map(serde_json::Value::Number)
+                    .unwrap_or(serde_json::Value::Null)
+            } else {
+                serde_json::Value::Null
+            }
+        }
+        Y::String(s) => serde_json::Value::String(s.clone()),
+        Y::Sequence(s) => serde_json::Value::Array(s.iter().map(yaml_to_json).collect()),
+        Y::Mapping(m) => {
+            let mut obj = serde_json::Map::new();
+            for (k, val) in m {
+                if let Some(ks) = k.as_str() {
+                    obj.insert(ks.to_string(), yaml_to_json(val));
+                }
+            }
+            serde_json::Value::Object(obj)
+        }
+        Y::Tagged(t) => yaml_to_json(&t.value),
+    }
+}
+```
+
+- [ ] **Step 5: Ensure `urlencoding` dep exists or add it**
+
+```bash
+grep -n "^urlencoding" mur-core/Cargo.toml
+```
+
+If missing, add `urlencoding = "2"` to `[dependencies]`.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+cargo test -p mur-core sources::adapters::obsidian
+```
+
+Expected: all 5 tests pass (4 from Task 8 + `fetch_reads_file_and_parses_frontmatter`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-core/Cargo.toml mur-core/src/sources/adapters/obsidian.rs
+git commit -m "feat(sources/obsidian): fetch file with frontmatter stripping + tag extraction"
+```
+
+---
+
+## Task 10: ObsidianAdapter::chunk (delegate to markdown chunker)
+
+**Files:**
+- Modify: `mur-core/src/sources/adapters/obsidian.rs`
+
+- [ ] **Step 1: Failing test**
+
+Append:
+
+```rust
+    #[tokio::test]
+    async fn chunk_emits_multiple_chunks_with_heading_path() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join(".obsidian")).unwrap();
+        let body = "# H1\n\npara under h1.\n\n## H2\n\npara under h2.\n\n## H2-b\n\npara under h2-b.\n";
+        fs::write(tmp.path().join("multi.md"), body).unwrap();
+
+        let inst = make_instance("obsidian-main", tmp.path());
+        let adapter = ObsidianAdapter::from_instance(&inst).unwrap();
+        let (docs, _) = adapter.list_documents(None).await.unwrap();
+        let doc_ref = docs.iter().find(|d| d.external_id == "multi.md").unwrap();
+        let doc = adapter.fetch(doc_ref).await.unwrap();
+        let chunks = adapter.chunk(&doc).unwrap();
+        assert!(chunks.len() >= 3, "expected >=3 chunks, got {}", chunks.len());
+        for c in &chunks {
+            assert_eq!(c.source_id, "obsidian-main");
+            assert_eq!(c.external_id, "multi.md");
+            assert!(!c.chunk_id.is_empty());
+            assert!(!c.text.is_empty());
+        }
+        // Ordinals are 0-indexed and strictly increasing
+        let ords: Vec<usize> = chunks.iter().map(|c| c.ordinal).collect();
+        assert_eq!(ords, (0..chunks.len()).collect::<Vec<_>>());
+    }
+```
+
+- [ ] **Step 2: Run — expect FAIL (bail stub)**
+
+```bash
+cargo test -p mur-core sources::adapters::obsidian::tests::chunk_emits_multiple_chunks_with_heading_path
+```
+
+- [ ] **Step 3: Replace `chunk` body**
+
+```rust
+    fn chunk(&self, doc: &Document) -> Result<Vec<Chunk>> {
+        let body = match &doc.body {
+            DocumentBody::Markdown(s) | DocumentBody::PlainText(s) => s.clone(),
+            DocumentBody::NotionBlocks(_) => bail!("obsidian adapter does not handle notion blocks"),
+        };
+        let raw_chunks = md::chunk_markdown(&doc.title, &body, CHUNK_MAX_CHARS);
+        let mut out = Vec::with_capacity(raw_chunks.len());
+        for (i, c) in raw_chunks.into_iter().enumerate() {
+            out.push(Chunk::new(
+                doc.source_id.clone(),
+                doc.external_id.clone(),
+                i,
+                c.text,
+                c.heading_path,
+                c.char_range,
+                doc.updated_at,
+            ));
+        }
+        Ok(out)
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p mur-core sources::adapters::obsidian
+```
+
+Expected: all 6 obsidian tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/sources/adapters/obsidian.rs
+git commit -m "feat(sources/obsidian): chunk via shared markdown chunker"
+```
+
+---
+
+## Task 11: Sync Orchestrator — Single-Source Sync Flow
+
+**Files:**
+- Create: `mur-core/src/sources/sync.rs`
+- Modify: `mur-core/src/sources/mod.rs`
+
+- [ ] **Step 1: Create `sources/sync.rs` with tests**
+
+Create `mur-core/src/sources/sync.rs`:
+
+```rust
+//! Sync orchestrator.
+//!
+//! Drives one adapter through list → fetch → chunk → embed → upsert, updates
+//! the `SourceInstance` yaml cursor/stats, and detects deletions via a
+//! set-diff against the vector store. P1.2 is single-source / sequential /
+//! manual — `--watch` and cross-source parallelism arrive in P1.4.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use std::sync::Arc;
+
+use crate::sources::instance::{SourceInstance, SourceInstanceStore, SyncError};
+use crate::sources::types::SyncCursor;
+use crate::sources::KnowledgeSource;
+use crate::store::embedding::{EmbeddingConfig, embed};
+use crate::store::vector::{EmbeddedChunk, VectorStore};
+
+/// High-level summary returned by `sync_source`.
+#[derive(Debug, Default)]
+pub struct SyncReport {
+    pub docs_synced: usize,
+    pub chunks_emitted: usize,
+    pub docs_deleted: usize,
+    pub errors: Vec<String>,
+}
+
+/// Run one full sync cycle for a single source.
+pub async fn sync_source(
+    adapter: &dyn KnowledgeSource,
+    instance: &mut SourceInstance,
+    instance_store: &SourceInstanceStore,
+    vector_store: Arc<dyn VectorStore>,
+    embedding_cfg: &EmbeddingConfig,
+    full: bool,
+) -> Result<SyncReport> {
+    let source_id = adapter.id().to_string();
+    let cursor_in = if full {
+        None
+    } else {
+        instance
+            .sync
+            .last_cursor
+            .clone()
+            .map(SyncCursor)
+            .filter(|c| !c.is_empty())
+    };
+
+    tracing::info!(source_id = %source_id, full = full, "sync: start");
+
+    // Step 1: list documents
+    let (doc_refs, new_cursor) = adapter
+        .list_documents(cursor_in)
+        .await
+        .context("adapter.list_documents")?;
+
+    let mut report = SyncReport::default();
+    let mut successful_external_ids_from_list: std::collections::HashSet<String> =
+        doc_refs.iter().map(|d| d.external_id.clone()).collect();
+
+    for doc_ref in &doc_refs {
+        match fetch_chunk_embed_upsert(adapter, doc_ref, &*vector_store, embedding_cfg).await {
+            Ok(n_chunks) => {
+                report.docs_synced += 1;
+                report.chunks_emitted += n_chunks;
+            }
+            Err(e) => {
+                let msg = format!("{e:#}");
+                tracing::warn!(
+                    source_id = %source_id,
+                    doc = %doc_ref.external_id,
+                    error = %msg,
+                    "sync: doc error"
+                );
+                report.errors.push(msg.clone());
+                successful_external_ids_from_list.remove(&doc_ref.external_id);
+                instance.sync.push_error(SyncError {
+                    at: Utc::now(),
+                    doc: doc_ref.external_id.clone(),
+                    msg,
+                });
+            }
+        }
+    }
+
+    // Step 2: Deletion detection. If `full=true`, compare against the full
+    // adapter state; if incremental, we ONLY know what changed. For P1.2,
+    // deletion detection runs in `full` mode — incremental does not attempt it
+    // (may leave orphan chunks until next full sync or explicit `remove`).
+    if full {
+        let indexed = vector_store
+            .list_external_ids(&source_id)
+            .await
+            .context("list_external_ids")?;
+        let current: std::collections::HashSet<String> =
+            doc_refs.iter().map(|d| d.external_id.clone()).collect();
+        let deleted: Vec<String> = indexed.into_iter().filter(|id| !current.contains(id)).collect();
+        if !deleted.is_empty() {
+            vector_store
+                .delete_by_external_ids(&source_id, &deleted)
+                .await
+                .context("delete_by_external_ids")?;
+            report.docs_deleted = deleted.len();
+        }
+    }
+
+    // Step 3: Update instance yaml
+    instance.sync.last_cursor = if new_cursor.is_empty() {
+        None
+    } else {
+        Some(new_cursor.0)
+    };
+    instance.sync.last_sync_at = Some(Utc::now());
+    instance.sync.last_error = report.errors.last().cloned();
+    instance.stats.doc_count = report.docs_synced as u64;
+    instance.stats.chunk_count = report.chunks_emitted as u64;
+
+    instance_store
+        .save(instance)
+        .context("persist SourceInstance yaml")?;
+
+    tracing::info!(
+        source_id = %source_id,
+        docs = report.docs_synced,
+        chunks = report.chunks_emitted,
+        deleted = report.docs_deleted,
+        errors = report.errors.len(),
+        "sync: complete"
+    );
+
+    Ok(report)
+}
+
+async fn fetch_chunk_embed_upsert(
+    adapter: &dyn KnowledgeSource,
+    doc_ref: &crate::sources::types::DocRef,
+    vector_store: &dyn VectorStore,
+    embedding_cfg: &EmbeddingConfig,
+) -> Result<usize> {
+    let doc = adapter.fetch(doc_ref).await.context("adapter.fetch")?;
+    let chunks = adapter.chunk(&doc).context("adapter.chunk")?;
+    if chunks.is_empty() {
+        return Ok(0);
+    }
+    // Delete-by-external_id before upserting (handles the case where the same
+    // document's chunk set changed — old chunk_ids no longer valid).
+    vector_store
+        .delete_by_external_ids(&doc.source_id, &[doc.external_id.clone()])
+        .await
+        .context("delete old chunks for doc")?;
+    let mut embedded: Vec<EmbeddedChunk> = Vec::with_capacity(chunks.len());
+    for c in chunks {
+        let vec = embed(&c.text, embedding_cfg)
+            .await
+            .with_context(|| format!("embed chunk of doc {}", doc.external_id))?;
+        embedded.push(EmbeddedChunk {
+            chunk_id: c.chunk_id,
+            source_id: c.source_id,
+            external_id: c.external_id,
+            ordinal: c.ordinal,
+            text: c.text,
+            heading_path: c.heading_path,
+            char_range: c.char_range,
+            updated_at: c.updated_at,
+            embedding: vec,
+        });
+    }
+    let n = embedded.len();
+    vector_store
+        .upsert(&embedded)
+        .await
+        .context("vector_store.upsert")?;
+    Ok(n)
+}
+```
+
+- [ ] **Step 2: Declare in sources module**
+
+Append to `mur-core/src/sources/mod.rs`:
+
+```rust
+pub mod sync;
+```
+
+- [ ] **Step 3: Compile check**
+
+```bash
+cargo check -p mur-core 2>&1 | tail -15
+```
+
+Expected: clean. This task has no test of its own — the E2E test in Task 17 exercises it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/sources/mod.rs mur-core/src/sources/sync.rs
+git commit -m "feat(sources): sync orchestrator with per-doc isolation and full-mode deletion diff"
+```
+
+---
+
+## Task 12: CLI Handlers — `source add obsidian`, `source list`, `source status`
+
+**Files:**
+- Modify: `mur-core/src/cmd/source_cmd.rs`
+
+- [ ] **Step 1: Replace the `source_cmd.rs` file with a working dispatcher for three verbs**
+
+Open `/Volumes/Firecuda4tb/Projects/mur/.worktrees/sources-p1.1/mur-core/src/cmd/source_cmd.rs`. Keep the existing enum definitions (`SourceCommand`, `AddKind`) but REPLACE the `handle` function and ADD the three verb implementations.
+
+Replace the file's content from `pub async fn handle(cmd: SourceCommand) -> Result<()>` onward (inclusive) with:
+
+```rust
+pub async fn handle(cmd: SourceCommand) -> Result<()> {
+    match cmd {
+        SourceCommand::Add { kind } => match kind {
+            AddKind::Obsidian {
+                instance,
+                vault,
+                exclude_folder,
+            } => add_obsidian(instance, vault, exclude_folder).await,
+            AddKind::Notion { .. } => bail!("`mur source add notion` arrives in P1.4"),
+            AddKind::Joplin { .. } => bail!("`mur source add joplin` arrives in P1.4"),
+        },
+        SourceCommand::List { json, verbose } => list(json, verbose).await,
+        SourceCommand::Remove { id, keep_index } => remove(&id, keep_index).await,
+        SourceCommand::Sync { id, full, watch } => {
+            if watch {
+                bail!("`mur source sync --watch` arrives in P1.4");
+            }
+            sync(id.as_deref(), full).await
+        }
+        SourceCommand::Status { id } => status(id.as_deref()).await,
+        SourceCommand::Weight { id, value } => set_weight(&id, value).await,
+        SourceCommand::Test { id } => test_source(&id).await,
+        SourceCommand::Reindex { .. } => bail!("`mur source reindex` arrives in P1.3"),
+        SourceCommand::InstallSchedule => bail!("`mur source install-schedule` arrives in P1.4"),
+        SourceCommand::Disable { id } => set_enabled(&id, false).await,
+        SourceCommand::Enable { id } => set_enabled(&id, true).await,
+    }
+}
+```
+
+- [ ] **Step 2: Add the `add_obsidian` function at the bottom of the same file**
+
+```rust
+async fn add_obsidian(
+    instance: Option<String>,
+    vault: std::path::PathBuf,
+    exclude_folder: Vec<String>,
+) -> Result<()> {
+    use crate::sources::instance::{SourceInstance, SourceInstanceStore, SyncState, SourceStats};
+    use crate::sources::kind::SourceKind;
+    use std::collections::BTreeMap;
+
+    let store = SourceInstanceStore::default_store()?;
+    // Derive id: user-supplied instance OR auto (first "obsidian", then "obsidian:randXXXX")
+    let id = match instance {
+        Some(tag) if !tag.is_empty() => format!("obsidian:{tag}"),
+        _ => {
+            let existing: Vec<String> = store.list()?.into_iter().map(|i| i.id).collect();
+            if !existing.iter().any(|id| id == "obsidian") {
+                "obsidian".to_string()
+            } else {
+                // find a free obsidian:<rand>
+                let mut rng = rand::random::<u16>();
+                loop {
+                    let candidate = format!("obsidian:{rng:04x}");
+                    if !existing.contains(&candidate) {
+                        break candidate;
+                    }
+                    rng = rng.wrapping_add(1);
+                }
+            }
+        }
+    };
+
+    let abs_vault = std::fs::canonicalize(&vault)
+        .with_context(|| format!("resolve vault path {}", vault.display()))?;
+    if !abs_vault.is_dir() {
+        bail!("vault path is not a directory: {}", abs_vault.display());
+    }
+
+    let mut scope: BTreeMap<String, serde_yaml::Value> = BTreeMap::new();
+    scope.insert(
+        "vault".into(),
+        serde_yaml::Value::String(abs_vault.to_string_lossy().to_string()),
+    );
+    if !exclude_folder.is_empty() {
+        scope.insert(
+            "exclude_folders".into(),
+            serde_yaml::Value::Sequence(
+                exclude_folder.into_iter().map(serde_yaml::Value::String).collect(),
+            ),
+        );
+    }
+
+    let inst = SourceInstance {
+        id: id.clone(),
+        type_name: "obsidian".into(),
+        kind: SourceKind::PullIndex,
+        enabled: true,
+        weight: 1.0,
+        scope,
+        sync: SyncState::default(),
+        stats: SourceStats::default(),
+        keyring_entry: None,
+    };
+    store.save(&inst)?;
+    println!("✅ Connected vault {} as `{}`", abs_vault.display(), id);
+    println!("Run `mur source sync {id}` to index.");
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Add `list` and `status` functions**
+
+```rust
+async fn list(json: bool, verbose: bool) -> Result<()> {
+    use crate::sources::instance::SourceInstanceStore;
+    let store = SourceInstanceStore::default_store()?;
+    let items = store.list()?;
+    if json {
+        let j = serde_json::to_string_pretty(&items)?;
+        println!("{j}");
+        return Ok(());
+    }
+    if items.is_empty() {
+        println!("(no sources — use `mur source add obsidian --vault <path>`)");
+        return Ok(());
+    }
+    println!(
+        "{:<22} {:<10} {:<8} {:>7} {:>7} {:<24}",
+        "ID", "TYPE", "STATUS", "DOCS", "WEIGHT", "LAST SYNC"
+    );
+    for inst in &items {
+        let status = if !inst.enabled { "off" } else { "ok" };
+        let last = inst
+            .sync
+            .last_sync_at
+            .map(|t| t.to_rfc3339())
+            .unwrap_or_else(|| "never".into());
+        println!(
+            "{:<22} {:<10} {:<8} {:>7} {:>7.2} {:<24}",
+            inst.id,
+            inst.type_name,
+            status,
+            inst.stats.doc_count,
+            inst.weight,
+            last
+        );
+        if verbose {
+            println!("    scope: {:?}", inst.scope);
+            if let Some(err) = &inst.sync.last_error {
+                println!("    last_error: {err}");
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn status(id: Option<&str>) -> Result<()> {
+    use crate::sources::instance::SourceInstanceStore;
+    let store = SourceInstanceStore::default_store()?;
+    let items = match id {
+        Some(i) => vec![store.load(i)?],
+        None => store.list()?,
+    };
+    if items.is_empty() {
+        println!("(no sources)");
+        return Ok(());
+    }
+    for inst in items {
+        println!("─── {} ({}) ───", inst.id, inst.type_name);
+        println!("  enabled     : {}", inst.enabled);
+        println!("  weight      : {:.2}", inst.weight);
+        println!("  scope       : {:?}", inst.scope);
+        println!(
+            "  last_sync_at: {}",
+            inst.sync
+                .last_sync_at
+                .map(|t| t.to_rfc3339())
+                .unwrap_or_else(|| "never".into())
+        );
+        println!(
+            "  last_cursor : {}",
+            inst.sync.last_cursor.unwrap_or_else(|| "none".into())
+        );
+        println!("  docs        : {}", inst.stats.doc_count);
+        println!("  chunks      : {}", inst.stats.chunk_count);
+        if let Some(err) = &inst.sync.last_error {
+            println!("  last_error  : {err}");
+        }
+        if !inst.sync.errors_tail.is_empty() {
+            println!("  errors_tail : {} entries", inst.sync.errors_tail.len());
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Update imports at the top of `source_cmd.rs`**
+
+Ensure these are imported at the top:
+
+```rust
+use anyhow::{Context, Result, bail};
+use clap::Subcommand;
+```
+
+(Add `Context` if not already there.)
+
+- [ ] **Step 5: Add `rand` dep if not present**
+
+```bash
+grep -n "^rand" mur-core/Cargo.toml
+```
+
+If missing, add `rand = "0.8"` to `[dependencies]`. (If the workspace already provides `rand`, prefer `rand = { workspace = true }`.)
+
+- [ ] **Step 6: Compile**
+
+```bash
+cargo check --workspace 2>&1 | tail -10
+```
+
+- [ ] **Step 7: Smoke test the three commands against a temp vault**
+
+```bash
+# Create a temp vault
+T=$(mktemp -d)
+mkdir -p "$T/.obsidian"
+echo "# Hello" > "$T/hello.md"
+
+# Add it (this writes ~/.mur/sources/obsidian.yaml — delete after if you don't want it persisted)
+cargo run -- source add obsidian --vault "$T"
+
+# List
+cargo run -- source list
+
+# Status
+cargo run -- source status obsidian
+
+# Cleanup (optional — comment out if you want state to persist)
+rm -f ~/.mur/sources/obsidian.yaml
+rm -rf "$T"
+```
+
+Expected: `source add` prints "Connected vault …"; `source list` shows `obsidian` row; `source status` shows details with `docs: 0` (no sync yet).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mur-core/Cargo.toml mur-core/src/cmd/source_cmd.rs
+git commit -m "feat(cli): source add obsidian + source list + source status real handlers"
+```
+
+---
+
+## Task 13: CLI Handlers — `source sync`, `source remove`, `source test`
+
+**Files:**
+- Modify: `mur-core/src/cmd/source_cmd.rs`
+
+- [ ] **Step 1: Append the three handler functions**
+
+At the bottom of `source_cmd.rs`, add:
+
+```rust
+async fn sync(id: Option<&str>, full: bool) -> Result<()> {
+    use crate::sources::adapters::obsidian::ObsidianAdapter;
+    use crate::sources::instance::SourceInstanceStore;
+    use crate::sources::sync::sync_source;
+    use crate::store::embedding::EmbeddingConfig;
+    use crate::store::vector::factory::get_vector_store;
+
+    let cfg = crate::store::config::load_config()?;
+    let emb_cfg = EmbeddingConfig::from_config(&cfg);
+    let index_path = dirs::home_dir()
+        .context("no home dir")?
+        .join(".mur")
+        .join("index");
+    let vector_store = get_vector_store(&cfg, &index_path).await?;
+
+    let store = SourceInstanceStore::default_store()?;
+    let targets: Vec<crate::sources::instance::SourceInstance> = match id {
+        Some(i) => vec![store.load(i)?],
+        None => store.list()?.into_iter().filter(|inst| inst.enabled).collect(),
+    };
+    if targets.is_empty() {
+        println!("(no enabled sources to sync)");
+        return Ok(());
+    }
+
+    for mut inst in targets {
+        if inst.type_name != "obsidian" {
+            println!("⏭  {}: adapter `{}` arrives in a later sub-milestone", inst.id, inst.type_name);
+            continue;
+        }
+        let adapter = ObsidianAdapter::from_instance(&inst)?;
+        println!("↻ syncing {}{}", inst.id, if full { " (full)" } else { "" });
+        let report = sync_source(
+            &adapter,
+            &mut inst,
+            &store,
+            vector_store.clone(),
+            &emb_cfg,
+            full,
+        )
+        .await?;
+        println!(
+            "  synced {} docs ({} chunks), deleted {}, {} errors",
+            report.docs_synced,
+            report.chunks_emitted,
+            report.docs_deleted,
+            report.errors.len()
+        );
+        for e in report.errors.iter().take(3) {
+            println!("  ! {e}");
+        }
+    }
+    Ok(())
+}
+
+async fn remove(id: &str, keep_index: bool) -> Result<()> {
+    use crate::sources::instance::SourceInstanceStore;
+    use crate::store::vector::factory::get_vector_store;
+
+    let store = SourceInstanceStore::default_store()?;
+    // Fail if it doesn't exist — user should know
+    let _ = store.load(id).with_context(|| format!("source `{id}` not found"))?;
+
+    if !keep_index {
+        let cfg = crate::store::config::load_config()?;
+        let index_path = dirs::home_dir()
+            .context("no home dir")?
+            .join(".mur")
+            .join("index");
+        let vs = get_vector_store(&cfg, &index_path).await?;
+        vs.delete_by_source(id).await.context("delete source chunks")?;
+        println!("🗑  removed indexed chunks for {id}");
+    }
+    store.delete(id)?;
+    println!("🗑  removed yaml for {id}");
+    Ok(())
+}
+
+async fn test_source(id: &str) -> Result<()> {
+    use crate::sources::adapters::obsidian::ObsidianAdapter;
+    use crate::sources::instance::SourceInstanceStore;
+    use crate::store::embedding::{EmbeddingConfig, embed};
+    use std::time::Instant;
+
+    let store = SourceInstanceStore::default_store()?;
+    let inst = store.load(id)?;
+    if inst.type_name != "obsidian" {
+        bail!("test only supports obsidian in P1.2; got `{}`", inst.type_name);
+    }
+    let adapter = ObsidianAdapter::from_instance(&inst)?;
+
+    let t0 = Instant::now();
+    let (docs, _cursor) = adapter.list_documents(None).await?;
+    println!("→ list_documents: {} docs in {:?}", docs.len(), t0.elapsed());
+    if docs.is_empty() {
+        println!("   (no documents — nothing to test)");
+        return Ok(());
+    }
+    let doc_ref = &docs[0];
+    println!("→ sampling first doc: {}", doc_ref.external_id);
+    let t0 = Instant::now();
+    let doc = adapter.fetch(doc_ref).await?;
+    println!("  fetch: {} chars in {:?}", doc.body.as_plain_text().len(), t0.elapsed());
+
+    let t0 = Instant::now();
+    let chunks = adapter.chunk(&doc)?;
+    println!("  chunk: {} chunks in {:?}", chunks.len(), t0.elapsed());
+
+    let cfg = crate::store::config::load_config()?;
+    let emb_cfg = EmbeddingConfig::from_config(&cfg);
+    let sample = chunks.first().map(|c| c.text.clone()).unwrap_or_default();
+    let t0 = Instant::now();
+    let v = embed(&sample, &emb_cfg).await?;
+    println!("  embed: {} dims in {:?}", v.len(), t0.elapsed());
+
+    println!("✅ adapter working");
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Compile**
+
+```bash
+cargo check --workspace 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+T=$(mktemp -d)
+mkdir -p "$T/.obsidian"
+echo -e "# One\n\npara one\n\n## Sub\n\npara sub" > "$T/a.md"
+echo "# Two" > "$T/b.md"
+
+cargo run -- source add obsidian --vault "$T"
+cargo run -- source test obsidian                    # requires ollama or api key
+cargo run -- source sync obsidian --full             # requires embedding provider configured
+cargo run -- source list                             # docs should be > 0
+
+cargo run -- source remove obsidian                  # cleanup
+rm -rf "$T"
+```
+
+(If embedding provider is NOT configured locally, `source test` / `source sync` will fail — document this as "requires a working embedding provider" in the task report rather than a plan bug. E2E test in Task 17 uses a deterministic mock embedder to bypass this.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/cmd/source_cmd.rs
+git commit -m "feat(cli): source sync / remove / test real handlers"
+```
+
+---
+
+## Task 14: CLI Handlers — `source weight`, `source enable`, `source disable`
+
+**Files:**
+- Modify: `mur-core/src/cmd/source_cmd.rs`
+
+- [ ] **Step 1: Append the two handler functions**
+
+```rust
+async fn set_weight(id: &str, value: f32) -> Result<()> {
+    use crate::sources::instance::SourceInstanceStore;
+    if !(0.0..=2.0).contains(&value) {
+        bail!("weight must be in [0.0, 2.0], got {value}");
+    }
+    let store = SourceInstanceStore::default_store()?;
+    let mut inst = store.load(id)?;
+    inst.weight = value;
+    store.save(&inst)?;
+    println!("✏️  {id} weight set to {value:.2}");
+    Ok(())
+}
+
+async fn set_enabled(id: &str, enabled: bool) -> Result<()> {
+    use crate::sources::instance::SourceInstanceStore;
+    let store = SourceInstanceStore::default_store()?;
+    let mut inst = store.load(id)?;
+    inst.enabled = enabled;
+    store.save(&inst)?;
+    println!("✏️  {id} {}", if enabled { "enabled" } else { "disabled" });
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Compile**
+
+```bash
+cargo check --workspace 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+T=$(mktemp -d) && mkdir -p "$T/.obsidian"
+cargo run -- source add obsidian --vault "$T"
+cargo run -- source weight obsidian 0.5
+cargo run -- source status obsidian | grep weight    # expect 0.50
+cargo run -- source disable obsidian
+cargo run -- source status obsidian | grep enabled   # expect false
+cargo run -- source enable obsidian
+cargo run -- source remove obsidian
+rm -rf "$T"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/cmd/source_cmd.rs
+git commit -m "feat(cli): source weight / enable / disable handlers"
+```
+
+---
+
+## Task 15: Add `mur source search` Verb (Minimal Sources-only Search)
+
+P1.2's "visible value" deliverable. A new verb under `source` that queries the sources table directly. No interaction with the existing `mur search` patterns path. P1.3 will merge both under `mur search`.
+
+**Files:**
+- Modify: `mur-core/src/cmd/source_cmd.rs`
+
+- [ ] **Step 1: Add `Search` variant to `SourceCommand` enum**
+
+Inside the existing `pub enum SourceCommand { ... }`, after `Test { id: String },` add:
+
+```rust
+    /// Search indexed source chunks (minimal, sources-only — for P1.3 see `mur search`).
+    Search {
+        query: String,
+        #[arg(long, short = 'k', default_value_t = 5)]
+        limit: usize,
+        #[arg(long)]
+        source: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+```
+
+- [ ] **Step 2: Dispatch in `handle`**
+
+Inside the `match cmd` in `handle`, add a new arm (keeping ordering consistent):
+
+```rust
+        SourceCommand::Search {
+            query,
+            limit,
+            source,
+            json,
+        } => search(&query, limit, source.as_deref(), json).await,
+```
+
+- [ ] **Step 3: Implement the `search` handler**
+
+At the bottom of `source_cmd.rs`:
+
+```rust
+async fn search(query: &str, limit: usize, source: Option<&str>, json: bool) -> Result<()> {
+    use crate::store::embedding::{EmbeddingConfig, embed};
+    use crate::store::vector::{SearchFilter, factory::get_vector_store};
+
+    let cfg = crate::store::config::load_config()?;
+    let emb_cfg = EmbeddingConfig::from_config(&cfg);
+    let index_path = dirs::home_dir()
+        .context("no home dir")?
+        .join(".mur")
+        .join("index");
+    let vs = get_vector_store(&cfg, &index_path).await?;
+
+    let qvec = embed(query, &emb_cfg).await.context("embed query")?;
+
+    let filter = SearchFilter {
+        source_ids: source.map(|s| vec![s.to_string()]),
+        since: None,
+    };
+    let hits = vs.search(&qvec, limit, &filter).await?;
+
+    if json {
+        let j = serde_json::to_string_pretty(&hits.iter().map(|h| serde_json::json!({
+            "chunk_id": h.chunk_id,
+            "source_id": h.source_id,
+            "external_id": h.external_id,
+            "score": h.score,
+            "text": h.text,
+            "heading_path": h.heading_path,
+            "updated_at": h.updated_at.to_rfc3339(),
+        })).collect::<Vec<_>>())?;
+        println!("{j}");
+        return Ok(());
+    }
+    if hits.is_empty() {
+        println!("(no hits)");
+        return Ok(());
+    }
+    for h in &hits {
+        let hp = if h.heading_path.is_empty() {
+            String::new()
+        } else {
+            format!(" § {}", h.heading_path.join(" / "))
+        };
+        println!(
+            "[{:.3}] {} / {}{}",
+            h.score, h.source_id, h.external_id, hp
+        );
+        // First 180 chars of text
+        let preview: String = h.text.chars().take(180).collect();
+        println!("       {}", preview);
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: The `Hit` struct has no `Serialize` derive — serialize manually via `json!{}` (done above)**
+
+Verify the `use crate::store::vector::...` covers `SearchFilter` and that `Hit` is reachable (it is, via `search` return type).
+
+- [ ] **Step 5: Compile + smoke test**
+
+```bash
+cargo check --workspace 2>&1 | tail -5
+
+T=$(mktemp -d) && mkdir -p "$T/.obsidian"
+echo -e "# OAuth flow\n\nPKCE + localhost callback." > "$T/oauth.md"
+echo "# Unrelated" > "$T/x.md"
+cargo run -- source add obsidian --vault "$T"
+cargo run -- source sync obsidian --full
+cargo run -- source search "oauth pkce" -k 3
+
+cargo run -- source remove obsidian
+rm -rf "$T"
+```
+
+Expected: the `oauth.md` chunk appears in the top hits with a score > 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/cmd/source_cmd.rs
+git commit -m "feat(cli): source search — minimal sources-only query (P1.3 unifies)"
+```
+
+---
+
+## Task 16: End-to-End Integration Test
+
+**Files:**
+- Create: `mur-core/tests/obsidian_e2e.rs`
+
+- [ ] **Step 1: Decide on embedding for E2E**
+
+We can't depend on a running Ollama / OpenAI key during `cargo test`. Two options:
+
+(a) **Inject a deterministic in-process embedder** — would require adding a test hook to `sync_source` (e.g. generic over an embed-fn). Large refactor.
+
+(b) **Drive adapter + chunker + LanceDB directly**, bypassing `sync_source` (and therefore the real embed step), injecting precomputed fake embeddings.
+
+Go with (b) — it's a true end-to-end test of the library pieces that matter, without taking on a flag-infection refactor.
+
+- [ ] **Step 2: Write `mur-core/tests/obsidian_e2e.rs`**
+
+```rust
+//! End-to-end: ObsidianAdapter + chunker + LanceDbStore.
+//!
+//! Does not exercise the embedding step (uses zero vectors). Real embeddings
+//! are covered by manual smoke tests and the adapter unit tests.
+
+use chrono::Utc;
+use mur_core::sources::adapters::obsidian::ObsidianAdapter;
+use mur_core::sources::instance::{SourceInstance, SourceStats, SyncState};
+use mur_core::sources::kind::SourceKind;
+use mur_core::sources::KnowledgeSource;
+use mur_core::store::vector::{EmbeddedChunk, LanceDbStore, SearchFilter, VectorStore};
+use std::collections::BTreeMap;
+use std::fs;
+use tempfile::TempDir;
+
+fn make_instance(id: &str, vault: &std::path::Path) -> SourceInstance {
+    let mut scope = BTreeMap::new();
+    scope.insert(
+        "vault".into(),
+        serde_yaml::Value::String(vault.to_string_lossy().to_string()),
+    );
+    SourceInstance {
+        id: id.into(),
+        type_name: "obsidian".into(),
+        kind: SourceKind::PullIndex,
+        enabled: true,
+        weight: 1.0,
+        scope,
+        sync: SyncState::default(),
+        stats: SourceStats::default(),
+        keyring_entry: None,
+    }
+}
+
+const DIM: i32 = 8;
+
+fn zeros() -> Vec<f32> {
+    vec![0.0_f32; DIM as usize]
+}
+fn ones() -> Vec<f32> {
+    vec![1.0_f32; DIM as usize]
+}
+
+#[tokio::test]
+async fn obsidian_end_to_end_sync_then_search() {
+    let vault = TempDir::new().unwrap();
+    fs::create_dir_all(vault.path().join(".obsidian")).unwrap();
+    fs::write(
+        vault.path().join("design.md"),
+        "---\ntags: [design]\n---\n\n# Auth design\n\nJWT 15min access + 7d refresh.",
+    )
+    .unwrap();
+    fs::write(
+        vault.path().join("scratch.md"),
+        "# scratch\n\nnothing interesting",
+    )
+    .unwrap();
+
+    let inst = make_instance("obsidian:e2e", vault.path());
+    let adapter = ObsidianAdapter::from_instance(&inst).unwrap();
+
+    // List + fetch + chunk
+    let (refs, _cursor) = adapter.list_documents(None).await.unwrap();
+    assert_eq!(refs.len(), 2);
+
+    let index = TempDir::new().unwrap();
+    let store = LanceDbStore::open(index.path(), DIM).await.unwrap();
+    store.ensure_sources_table().await.unwrap();
+
+    let mut all_chunks: Vec<EmbeddedChunk> = Vec::new();
+    for r in &refs {
+        let doc = adapter.fetch(r).await.unwrap();
+        for c in adapter.chunk(&doc).unwrap() {
+            // Deterministic "embedding": 1.0s if external_id contains "design", else 0.0s.
+            let embed = if c.external_id.contains("design") {
+                ones()
+            } else {
+                zeros()
+            };
+            all_chunks.push(EmbeddedChunk {
+                chunk_id: c.chunk_id,
+                source_id: c.source_id,
+                external_id: c.external_id,
+                ordinal: c.ordinal,
+                text: c.text,
+                heading_path: c.heading_path,
+                char_range: c.char_range,
+                updated_at: c.updated_at,
+                embedding: embed,
+            });
+        }
+    }
+    store.upsert(&all_chunks).await.unwrap();
+
+    // Search with the "ones" vector — design.md chunks should come first.
+    let hits = store.search(&ones(), 5, &SearchFilter::default()).await.unwrap();
+    assert!(!hits.is_empty());
+    assert_eq!(hits[0].external_id, "design.md");
+
+    // list_external_ids / count
+    let ids = store.list_external_ids("obsidian:e2e").await.unwrap();
+    assert!(ids.contains(&"design.md".to_string()));
+    assert!(ids.contains(&"scratch.md".to_string()));
+
+    let c = store.count(Some("obsidian:e2e")).await.unwrap();
+    assert!(c >= 2);
+
+    // Delete one file, re-sync via delete_by_external_ids
+    fs::remove_file(vault.path().join("scratch.md")).unwrap();
+    let (refs_after, _) = adapter.list_documents(None).await.unwrap();
+    let current: std::collections::HashSet<String> =
+        refs_after.iter().map(|r| r.external_id.clone()).collect();
+    let indexed = store.list_external_ids("obsidian:e2e").await.unwrap();
+    let deleted: Vec<String> = indexed.into_iter().filter(|id| !current.contains(id)).collect();
+    assert_eq!(deleted, vec!["scratch.md".to_string()]);
+    store
+        .delete_by_external_ids("obsidian:e2e", &deleted)
+        .await
+        .unwrap();
+    let after = store.list_external_ids("obsidian:e2e").await.unwrap();
+    assert!(!after.contains(&"scratch.md".to_string()));
+    assert!(after.contains(&"design.md".to_string()));
+
+    // delete_by_source clears everything
+    store.delete_by_source("obsidian:e2e").await.unwrap();
+    let empty = store.list_external_ids("obsidian:e2e").await.unwrap();
+    assert!(empty.is_empty());
+
+    // Leak the LanceDB TempDir to avoid the handle-still-open race
+    std::mem::forget(index);
+    std::mem::forget(vault);
+}
+```
+
+- [ ] **Step 3: Run the E2E test**
+
+```bash
+cargo test --test obsidian_e2e 2>&1 | tail -20
+```
+
+Expected: single test passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/tests/obsidian_e2e.rs
+git commit -m "test(obsidian): end-to-end sync + search + delete integration test"
+```
+
+---
+
+## Task 17: Final Verification
+
+- [ ] **Step 1: Full workspace tests**
+
+```bash
+cargo test --workspace 2>&1 | grep -E "^test result:"
+```
+
+Expected: all `ok`, 0 failed. The `obsidian_e2e` adds 1 new test binary entry. Compared to the P1.1 baseline (1246 passing), P1.2 adds roughly:
+- Task 1 open_or_create_sources_table_is_idempotent: +1 lib test
+- Task 2 roundtrip: +1 lib test
+- Task 4 list/count: +1 lib test
+- Task 5 delete: +1 lib test
+- Task 6 un-ignored two conformance tests: +2 (from ignored → passing) on EACH of lib+bin harnesses = +4
+- Task 7 chunker: +6 lib tests
+- Task 8/9/10 obsidian: +6 lib tests (4 + 1 + 1)
+- Task 16 e2e: +1 integration test
+
+Expected delta: roughly **+20 passing tests** (exact count depends on harness propagation — only count trend, not exact number).
+
+- [ ] **Step 2: Clippy**
+
+```bash
+cargo clippy --workspace --all-features -- -D warnings 2>&1 | tail -20
+```
+
+Fix any warnings we introduced. Pre-existing warnings unrelated to P1.2 are acceptable but flag them in the final report.
+
+- [ ] **Step 3: fmt**
+
+```bash
+cargo fmt --check
+```
+
+If diffs, `cargo fmt` and commit as `style:` follow-up.
+
+- [ ] **Step 4: Feature matrix**
+
+```bash
+cargo build --workspace 2>&1 | tail -3
+cargo build --workspace --no-default-features --features "cli server" 2>&1 | tail -3
+```
+
+Both must succeed. The feature-off build should NOT include any `sources` code. If `source_cmd.rs` imports from `sources/*` without feature-gating, you'll see errors — fix by gating `source_cmd` itself behind `#[cfg(feature = "sources")]` (it already is from P1.1 Task 12, but the `sources` module declaration in `lib.rs` is NOT gated — that's fine because the module compiles regardless; it only matters that the CLI and factory paths used by the bin don't require it).
+
+If the feature-off build fails because the bin's `source_cmd` reaches into `sources::*` that requires transitive symbols, the fix is to also gate the lib's `pub mod sources;` behind `#[cfg(feature = "sources")]`. Use this ONLY if required.
+
+- [ ] **Step 5: Full CLI smoke on real machine**
+
+(Optional but recommended.) Against a small real vault of 10-20 notes and a working embedding provider:
+
+```bash
+cargo run --release -- source add obsidian --vault ~/some-notes
+cargo run --release -- source sync obsidian --full
+cargo run --release -- source search "whatever you expect to hit" -k 5
+cargo run --release -- source status
+cargo run --release -- source remove obsidian
+```
+
+- [ ] **Step 6: CLAUDE.md update**
+
+Open `CLAUDE.md`. Find the "Sources pipeline (P1.1 foundation in place; adapters arrive P1.2+)" paragraph added in P1.1, and REPLACE the status tag:
+
+```markdown
+**Sources pipeline (P1.2 — Obsidian adapter shipped; Notion/Joplin arrive P1.4):**
+```
+
+Keep the rest of the paragraph unchanged.
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude.md): mark P1.2 Obsidian adapter shipped"
+```
+
+- [ ] **Step 7: Summary commit log**
+
+```bash
+git log --oneline feat/sources-p1.1..HEAD  # or whatever the P1.2 base branch is
+```
+
+Expected: ~15 commits from P1.2.
+
+---
+
+## Done Criteria (P1.2)
+
+- [ ] LanceDB sources table created on demand (`ensure_sources_table`).
+- [ ] `LanceDbStore::upsert`, `search`, `list_external_ids`, `delete_by_external_ids`, `delete_by_source`, `count` are real — not stubs. `rebuild_index` stays stub (P1.3).
+- [ ] Conformance tests `conformance_upsert_and_search` + `conformance_delete_by_source_clears` pass (no longer `#[ignore]`).
+- [ ] `sources::chunker::markdown::chunk_markdown` emits heading-aware chunks; paragraph-boundary split on oversized.
+- [ ] `ObsidianAdapter` implements `KnowledgeSource` end-to-end: `list_documents` (walkdir + exclude + cursor), `fetch` (read file + strip frontmatter + tags), `chunk` (delegate to markdown chunker).
+- [ ] `sources::sync::sync_source` performs list → fetch → chunk → embed → upsert, full-mode deletion diff, per-doc error isolation, persists cursor + stats to yaml.
+- [ ] CLI verbs working for real: `source add obsidian`, `source list`, `source status`, `source sync [id] [--full]`, `source remove [id] [--keep-index]`, `source test`, `source weight`, `source enable`, `source disable`, `source search`.
+- [ ] CLI verbs still stubbed: `add notion/joplin`, `sync --watch`, `reindex`, `install-schedule` (all return clear "arrives in P1.x" errors).
+- [ ] E2E integration test covers list → fetch → chunk → upsert → search → delete flow.
+- [ ] Clippy clean, fmt clean, feature matrix green.
+- [ ] CLAUDE.md updated.
+
+**Out of scope for P1.2 (deferred):**
+- `sync --watch` + file watcher
+- Unified `mur search` (patterns + sources merged) — P1.3
+- tantivy BM25 — P1.3
+- inject formatter Notes section — P1.3
+- Qdrant backend — P1.3
+- Notion / Joplin adapters — P1.4
+- `install-schedule` — P1.4
+- Token truncation for oversized source chunks at retrieval time — P1.3
+- **Inline `#tag` extraction** in Obsidian — P1.2 only reads YAML-frontmatter `tags:`. Inline `#tag` parsing (`[A-Za-z_][A-Za-z0-9_/-]*`) is deferred; tags are metadata-only in P1.2 and don't drive retrieval.
+- Incremental-mode deletion detection — P1.2 only detects deletes in `--full` sync. Incremental syncs may leave orphan chunks until the next full run. Acceptable given the typical Obsidian workflow (weekly full sync).

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -27,6 +27,13 @@ pub struct Config {
 
     #[serde(default)]
     pub sync: SyncConfig,
+
+    // --- P1.1 additions ---
+    #[serde(default)]
+    pub storage: StorageConfig,
+
+    #[serde(default)]
+    pub sources_global: SourcesGlobalConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -183,6 +190,76 @@ impl Default for PathConfig {
         }
     }
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageConfig {
+    /// Vector backend identifier: "lancedb" (default) or "qdrant".
+    #[serde(default = "default_vector_backend")]
+    pub vector_backend: String,
+
+    /// Qdrant connection URL (only used when vector_backend = "qdrant").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub qdrant_url: Option<String>,
+
+    /// Keyring account name holding the Qdrant API key, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub qdrant_api_key_ref: Option<String>,
+}
+
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
+            vector_backend: default_vector_backend(),
+            qdrant_url: None,
+            qdrant_api_key_ref: None,
+        }
+    }
+}
+
+fn default_vector_backend() -> String {
+    "lancedb".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourcesGlobalConfig {
+    /// Polling interval for cloud sources (seconds).
+    #[serde(default = "default_poll_interval_secs")]
+    pub poll_interval_secs: u64,
+
+    /// Safety cap: do not sync more than this many chunks per run.
+    #[serde(default = "default_max_chunks_per_sync")]
+    pub max_chunks_per_sync: usize,
+
+    /// Upper bound on parallel source sync tasks.
+    #[serde(default = "default_max_parallel_sources")]
+    pub max_parallel_sources: usize,
+
+    /// Weight applied to new sources unless overridden.
+    #[serde(default = "default_source_weight")]
+    pub default_weight: f32,
+
+    /// Embedding request batch size.
+    #[serde(default = "default_embedding_batch_size")]
+    pub embedding_batch_size: usize,
+}
+
+impl Default for SourcesGlobalConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval_secs: default_poll_interval_secs(),
+            max_chunks_per_sync: default_max_chunks_per_sync(),
+            max_parallel_sources: default_max_parallel_sources(),
+            default_weight: default_source_weight(),
+            embedding_batch_size: default_embedding_batch_size(),
+        }
+    }
+}
+
+fn default_poll_interval_secs() -> u64 { 600 }
+fn default_max_chunks_per_sync() -> usize { 10_000 }
+fn default_max_parallel_sources() -> usize { 3 }
+fn default_source_weight() -> f32 { 1.0 }
+fn default_embedding_batch_size() -> usize { 32 }
 
 fn default_embedding_provider() -> String {
     "ollama".to_string()
@@ -594,5 +671,51 @@ conversations:
             "expected 0.88, got {}",
             c.mmr_threshold
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storage_config_default_is_lancedb() {
+        let c = StorageConfig::default();
+        assert_eq!(c.vector_backend, "lancedb");
+        assert_eq!(c.qdrant_url, None);
+        assert_eq!(c.qdrant_api_key_ref, None);
+    }
+
+    #[test]
+    fn sources_global_config_has_sensible_defaults() {
+        let c = SourcesGlobalConfig::default();
+        assert_eq!(c.poll_interval_secs, 600);
+        assert_eq!(c.max_chunks_per_sync, 10_000);
+        assert_eq!(c.max_parallel_sources, 3);
+        assert_eq!(c.default_weight, 1.0);
+        assert_eq!(c.embedding_batch_size, 32);
+    }
+
+    #[test]
+    fn config_default_has_storage_and_sources_global() {
+        let c = Config::default();
+        assert_eq!(c.storage.vector_backend, "lancedb");
+        assert_eq!(c.sources_global.default_weight, 1.0);
+    }
+
+    #[test]
+    fn config_loads_yaml_without_new_fields() {
+        // Existing users' config.yaml won't mention storage or sources_global.
+        // It must still parse.
+        let yaml = r#"
+embedding:
+  provider: ollama
+  model: test-model
+  dimensions: 512
+  ollama_endpoint: http://localhost:11434
+"#;
+        let c: Config = serde_yaml::from_str(yaml).expect("parses");
+        assert_eq!(c.storage.vector_backend, "lancedb");
+        assert_eq!(c.sources_global.max_parallel_sources, 3);
     }
 }

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -255,11 +255,21 @@ impl Default for SourcesGlobalConfig {
     }
 }
 
-fn default_poll_interval_secs() -> u64 { 600 }
-fn default_max_chunks_per_sync() -> usize { 10_000 }
-fn default_max_parallel_sources() -> usize { 3 }
-fn default_source_weight() -> f32 { 1.0 }
-fn default_embedding_batch_size() -> usize { 32 }
+fn default_poll_interval_secs() -> u64 {
+    600
+}
+fn default_max_chunks_per_sync() -> usize {
+    10_000
+}
+fn default_max_parallel_sources() -> usize {
+    3
+}
+fn default_source_weight() -> f32 {
+    1.0
+}
+fn default_embedding_batch_size() -> usize {
+    32
+}
 
 fn default_embedding_provider() -> String {
     "ollama".to_string()

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -27,6 +27,7 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 anyhow = { workspace = true }
 async-trait = "0.1"
+keyring = "3"
 fs2 = "0.4"
 walkdir = "2"
 aho-corasick = "1"
@@ -59,9 +60,10 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 sysinfo = "0.30"
 
 [features]
-default = ["cli", "server"]
+default = ["cli", "server", "sources"]
 cli = ["dialoguer", "console", "clap"]
 server = ["axum", "tower-http", "rust-embed"]
+sources = []
 ollama-live-smoke = []
 
 [dev-dependencies]

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -59,6 +59,7 @@ urlencoding = "2"
 rusqlite = { version = "0.32", features = ["bundled"] }
 sysinfo = "0.30"
 pulldown-cmark = "0.12"
+rand = "0.8"
 
 [features]
 default = ["cli", "server", "sources"]

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -58,6 +58,7 @@ shellexpand = "3"
 urlencoding = "2"
 rusqlite = { version = "0.32", features = ["bundled"] }
 sysinfo = "0.30"
+pulldown-cmark = "0.12"
 
 [features]
 default = ["cli", "server", "sources"]

--- a/mur-core/src/cmd/context.rs
+++ b/mur-core/src/cmd/context.rs
@@ -23,7 +23,7 @@ pub(crate) async fn cmd_context(
         ScopeContext, score_and_rank_hybrid_with_scope, score_and_rank_with_scope,
     };
     use crate::store::embedding::{EmbeddingConfig, embed};
-    use crate::store::lancedb::VectorStore;
+    use crate::store::vector::LanceDbStore as VectorStore;
     use std::collections::HashMap;
 
     // Auto-pull from device sync if configured

--- a/mur-core/src/cmd/inject_cmd.rs
+++ b/mur-core/src/cmd/inject_cmd.rs
@@ -11,7 +11,7 @@ pub(crate) async fn cmd_inject(query: &str) -> Result<()> {
     use crate::retrieve::gate::{GateDecision, evaluate_query};
     use crate::retrieve::scoring::{score_and_rank, score_and_rank_hybrid};
     use crate::store::embedding::{EmbeddingConfig, embed};
-    use crate::store::lancedb::VectorStore;
+    use crate::store::vector::LanceDbStore as VectorStore;
     use inject::hook::{HookTrigger, detect_trigger};
     use std::collections::HashMap;
 

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -18,6 +18,9 @@ pub(crate) mod var;
 pub(crate) mod verify;
 pub(crate) mod workflow;
 
+#[cfg(feature = "sources")]
+pub(crate) mod source_cmd;
+
 pub(crate) fn read_multiline() -> anyhow::Result<String> {
     let mut lines = Vec::new();
     loop {

--- a/mur-core/src/cmd/reindex.rs
+++ b/mur-core/src/cmd/reindex.rs
@@ -5,7 +5,7 @@ use crate::store::yaml::YamlStore;
 
 pub(crate) async fn cmd_reindex() -> Result<()> {
     use crate::store::embedding::{EmbeddingConfig, embed};
-    use crate::store::lancedb::VectorStore;
+    use crate::store::vector::LanceDbStore as VectorStore;
 
     let pattern_store = YamlStore::default_store()?;
     let patterns = pattern_store.list_all()?;

--- a/mur-core/src/cmd/source_cmd.rs
+++ b/mur-core/src/cmd/source_cmd.rs
@@ -53,6 +53,16 @@ pub enum SourceCommand {
         #[arg(long)]
         vector_backend: Option<String>,
     },
+    /// Search indexed source chunks (minimal, sources-only — for P1.3 see `mur search`).
+    Search {
+        query: String,
+        #[arg(long, short = 'k', default_value_t = 5)]
+        limit: usize,
+        #[arg(long)]
+        source: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
     /// Generate launchd / systemd unit files for scheduled sync.
     InstallSchedule,
     Disable {
@@ -115,6 +125,12 @@ pub async fn handle(cmd: SourceCommand) -> Result<()> {
         SourceCommand::Status { id } => status(id.as_deref()).await,
         SourceCommand::Weight { id, value } => set_weight(&id, value).await,
         SourceCommand::Test { id } => test_source(&id).await,
+        SourceCommand::Search {
+            query,
+            limit,
+            source,
+            json,
+        } => search(&query, limit, source.as_deref(), json).await,
         SourceCommand::Reindex { .. } => bail!("`mur source reindex` arrives in P1.3"),
         SourceCommand::InstallSchedule => bail!("`mur source install-schedule` arrives in P1.4"),
         SourceCommand::Disable { id } => set_enabled(&id, false).await,
@@ -431,5 +447,68 @@ async fn set_enabled(id: &str, enabled: bool) -> Result<()> {
     inst.enabled = enabled;
     store.save(&inst)?;
     println!("✏️  {id} {}", if enabled { "enabled" } else { "disabled" });
+    Ok(())
+}
+
+// ---------- Task 15 handlers ----------
+
+async fn search(query: &str, limit: usize, source: Option<&str>, json: bool) -> Result<()> {
+    use crate::store::embedding::{EmbeddingConfig, embed};
+    use crate::store::vector::{SearchFilter, factory::get_vector_store};
+    use anyhow::Context;
+
+    let cfg = crate::store::config::load_config()?;
+    let emb_cfg = EmbeddingConfig::from_config(&cfg);
+    let index_path = dirs::home_dir()
+        .context("no home dir")?
+        .join(".mur")
+        .join("index");
+    let vs = get_vector_store(&cfg, &index_path).await?;
+
+    let qvec = embed(query, &emb_cfg).await.context("embed query")?;
+
+    let filter = SearchFilter {
+        source_ids: source.map(|s| vec![s.to_string()]),
+        since: None,
+    };
+    let hits = vs.search(&qvec, limit, &filter).await?;
+
+    if json {
+        let j = serde_json::to_string_pretty(
+            &hits
+                .iter()
+                .map(|h| {
+                    serde_json::json!({
+                        "chunk_id": h.chunk_id,
+                        "source_id": h.source_id,
+                        "external_id": h.external_id,
+                        "score": h.score,
+                        "text": h.text,
+                        "heading_path": h.heading_path,
+                        "updated_at": h.updated_at.to_rfc3339(),
+                    })
+                })
+                .collect::<Vec<_>>(),
+        )?;
+        println!("{j}");
+        return Ok(());
+    }
+    if hits.is_empty() {
+        println!("(no hits)");
+        return Ok(());
+    }
+    for h in &hits {
+        let hp = if h.heading_path.is_empty() {
+            String::new()
+        } else {
+            format!(" § {}", h.heading_path.join(" / "))
+        };
+        println!(
+            "[{:.3}] {} / {}{}",
+            h.score, h.source_id, h.external_id, hp
+        );
+        let preview: String = h.text.chars().take(180).collect();
+        println!("       {}", preview);
+    }
     Ok(())
 }

--- a/mur-core/src/cmd/source_cmd.rs
+++ b/mur-core/src/cmd/source_cmd.rs
@@ -409,10 +409,27 @@ async fn test_source(id: &str) -> Result<()> {
     Ok(())
 }
 
-async fn set_weight(_id: &str, _value: f32) -> Result<()> {
-    bail!("`mur source weight` arrives in Task 14")
+// ---------- Task 14 handlers ----------
+
+async fn set_weight(id: &str, value: f32) -> Result<()> {
+    use crate::sources::instance::SourceInstanceStore;
+    if !(0.0..=2.0).contains(&value) {
+        bail!("weight must be in [0.0, 2.0], got {value}");
+    }
+    let store = SourceInstanceStore::default_store()?;
+    let mut inst = store.load(id)?;
+    inst.weight = value;
+    store.save(&inst)?;
+    println!("✏️  {id} weight set to {value:.2}");
+    Ok(())
 }
 
-async fn set_enabled(_id: &str, _enabled: bool) -> Result<()> {
-    bail!("`mur source enable/disable` arrives in Task 14")
+async fn set_enabled(id: &str, enabled: bool) -> Result<()> {
+    use crate::sources::instance::SourceInstanceStore;
+    let store = SourceInstanceStore::default_store()?;
+    let mut inst = store.load(id)?;
+    inst.enabled = enabled;
+    store.save(&inst)?;
+    println!("✏️  {id} {}", if enabled { "enabled" } else { "disabled" });
+    Ok(())
 }

--- a/mur-core/src/cmd/source_cmd.rs
+++ b/mur-core/src/cmd/source_cmd.rs
@@ -1,0 +1,99 @@
+//! `mur source ...` subcommand tree.
+//!
+//! P1.1 wires up the tree with every verb returning a "not yet implemented"
+//! error, gated behind the `sources` feature flag. P1.2–P1.4 fill in each verb.
+
+use anyhow::{Result, bail};
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum SourceCommand {
+    /// Register a new source.
+    Add {
+        #[command(subcommand)]
+        kind: AddKind,
+    },
+    /// List registered sources.
+    List {
+        #[arg(long)]
+        json: bool,
+        #[arg(long)]
+        verbose: bool,
+    },
+    /// Remove a source (credentials + index).
+    Remove {
+        id: String,
+        #[arg(long)]
+        keep_index: bool,
+    },
+    /// Sync one or all sources.
+    Sync {
+        id: Option<String>,
+        #[arg(long)]
+        full: bool,
+        #[arg(long)]
+        watch: bool,
+    },
+    /// Show sync health for a source.
+    Status { id: Option<String> },
+    /// Set the retrieve weight.
+    Weight { id: String, value: f32 },
+    /// Dry-run a single document through the adapter.
+    Test { id: String },
+    /// Rebuild the vector index for a source.
+    Reindex {
+        id: String,
+        #[arg(long)]
+        vector_backend: Option<String>,
+    },
+    /// Generate launchd / systemd unit files for scheduled sync.
+    InstallSchedule,
+    Disable { id: String },
+    Enable { id: String },
+}
+
+#[derive(Subcommand)]
+pub enum AddKind {
+    /// Connect a Notion workspace (OAuth or Integration Token).
+    Notion {
+        instance: Option<String>,
+        #[arg(long)]
+        workspace: Option<String>,
+        #[arg(long)]
+        token: Option<String>,
+    },
+    /// Connect an Obsidian vault (local markdown folder).
+    Obsidian {
+        instance: Option<String>,
+        #[arg(long)]
+        vault: std::path::PathBuf,
+        #[arg(long, value_delimiter = ',')]
+        exclude_folder: Vec<String>,
+    },
+    /// Connect Joplin (local SQLite or Joplin Server).
+    Joplin {
+        instance: Option<String>,
+        #[arg(long, conflicts_with = "server")]
+        db: Option<std::path::PathBuf>,
+        #[arg(long, requires = "token")]
+        server: Option<String>,
+        #[arg(long, requires = "server")]
+        token: Option<String>,
+    },
+}
+
+pub async fn handle(cmd: SourceCommand) -> Result<()> {
+    match cmd {
+        SourceCommand::Add { .. } => bail!("`mur source add` arrives in P1.2 (obsidian) / P1.4 (notion, joplin)"),
+        SourceCommand::List { .. } => bail!("`mur source list` arrives in P1.2"),
+        SourceCommand::Remove { .. } => bail!("`mur source remove` arrives in P1.2"),
+        SourceCommand::Sync { .. } => bail!("`mur source sync` arrives in P1.2"),
+        SourceCommand::Status { .. } => bail!("`mur source status` arrives in P1.2"),
+        SourceCommand::Weight { .. } => bail!("`mur source weight` arrives in P1.2"),
+        SourceCommand::Test { .. } => bail!("`mur source test` arrives in P1.2"),
+        SourceCommand::Reindex { .. } => bail!("`mur source reindex` arrives in P1.3"),
+        SourceCommand::InstallSchedule => bail!("`mur source install-schedule` arrives in P1.4"),
+        SourceCommand::Disable { .. } => bail!("`mur source disable` arrives in P1.2"),
+        SourceCommand::Enable { .. } => bail!("`mur source enable` arrives in P1.2"),
+    }
+}

--- a/mur-core/src/cmd/source_cmd.rs
+++ b/mur-core/src/cmd/source_cmd.rs
@@ -271,18 +271,142 @@ async fn status(id: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-// ---------- stubs until Task 13/14 ----------
+// ---------- Task 13 handlers ----------
 
-async fn sync(_id: Option<&str>, _full: bool) -> Result<()> {
-    bail!("`mur source sync` arrives in Task 13")
+async fn sync(id: Option<&str>, full: bool) -> Result<()> {
+    use crate::sources::adapters::obsidian::ObsidianAdapter;
+    use crate::sources::instance::SourceInstanceStore;
+    use crate::sources::sync::sync_source;
+    use crate::store::embedding::EmbeddingConfig;
+    use crate::store::vector::factory::get_vector_store;
+    use anyhow::Context;
+
+    let cfg = crate::store::config::load_config()?;
+    let emb_cfg = EmbeddingConfig::from_config(&cfg);
+    let index_path = dirs::home_dir()
+        .context("no home dir")?
+        .join(".mur")
+        .join("index");
+    let vector_store = get_vector_store(&cfg, &index_path).await?;
+
+    let store = SourceInstanceStore::default_store()?;
+    let targets: Vec<crate::sources::instance::SourceInstance> = match id {
+        Some(i) => vec![store.load(i)?],
+        None => store.list()?.into_iter().filter(|inst| inst.enabled).collect(),
+    };
+    if targets.is_empty() {
+        println!("(no enabled sources to sync)");
+        return Ok(());
+    }
+
+    for mut inst in targets {
+        if inst.type_name != "obsidian" {
+            println!(
+                "⏭  {}: adapter `{}` arrives in a later sub-milestone",
+                inst.id, inst.type_name
+            );
+            continue;
+        }
+        let adapter = ObsidianAdapter::from_instance(&inst)?;
+        println!("↻ syncing {}{}", inst.id, if full { " (full)" } else { "" });
+        let report = sync_source(
+            &adapter,
+            &mut inst,
+            &store,
+            vector_store.clone(),
+            &emb_cfg,
+            full,
+        )
+        .await?;
+        println!(
+            "  synced {} docs ({} chunks), deleted {}, {} errors",
+            report.docs_synced,
+            report.chunks_emitted,
+            report.docs_deleted,
+            report.errors.len()
+        );
+        for e in report.errors.iter().take(3) {
+            println!("  ! {e}");
+        }
+    }
+    Ok(())
 }
 
-async fn remove(_id: &str, _keep_index: bool) -> Result<()> {
-    bail!("`mur source remove` arrives in Task 13")
+async fn remove(id: &str, keep_index: bool) -> Result<()> {
+    use crate::sources::instance::SourceInstanceStore;
+    use crate::store::vector::factory::get_vector_store;
+    use anyhow::Context;
+
+    let store = SourceInstanceStore::default_store()?;
+    let _ = store
+        .load(id)
+        .with_context(|| format!("source `{id}` not found"))?;
+
+    if !keep_index {
+        let cfg = crate::store::config::load_config()?;
+        let index_path = dirs::home_dir()
+            .context("no home dir")?
+            .join(".mur")
+            .join("index");
+        let vs = get_vector_store(&cfg, &index_path).await?;
+        vs.delete_by_source(id)
+            .await
+            .context("delete source chunks")?;
+        println!("🗑  removed indexed chunks for {id}");
+    }
+    store.delete(id)?;
+    println!("🗑  removed yaml for {id}");
+    Ok(())
 }
 
-async fn test_source(_id: &str) -> Result<()> {
-    bail!("`mur source test` arrives in Task 13")
+async fn test_source(id: &str) -> Result<()> {
+    use crate::sources::adapters::obsidian::ObsidianAdapter;
+    use crate::sources::instance::SourceInstanceStore;
+    use crate::sources::types::DocumentBody;
+    use crate::sources::KnowledgeSource;
+    use crate::store::embedding::{embed, EmbeddingConfig};
+    use std::time::Instant;
+
+    let store = SourceInstanceStore::default_store()?;
+    let inst = store.load(id)?;
+    if inst.type_name != "obsidian" {
+        bail!(
+            "test only supports obsidian in P1.2; got `{}`",
+            inst.type_name
+        );
+    }
+    let adapter = ObsidianAdapter::from_instance(&inst)?;
+
+    let t0 = Instant::now();
+    let (docs, _cursor) = adapter.list_documents(None).await?;
+    println!("→ list_documents: {} docs in {:?}", docs.len(), t0.elapsed());
+    if docs.is_empty() {
+        println!("   (no documents — nothing to test)");
+        return Ok(());
+    }
+    let doc_ref = &docs[0];
+    println!("→ sampling first doc: {}", doc_ref.external_id);
+    let t0 = Instant::now();
+    let doc = adapter.fetch(doc_ref).await?;
+    let body_len = match &doc.body {
+        DocumentBody::Markdown(s) | DocumentBody::PlainText(s) => s.len(),
+        DocumentBody::NotionBlocks(_) => 0,
+    };
+    println!("  fetch: {} chars in {:?}", body_len, t0.elapsed());
+
+    let t0 = Instant::now();
+    let chunks = adapter.chunk(&doc)?;
+    println!("  chunk: {} chunks in {:?}", chunks.len(), t0.elapsed());
+
+    let cfg = crate::store::config::load_config()?;
+    let emb_cfg = EmbeddingConfig::from_config(&cfg);
+    let sample = chunks.first().map(|c| c.text.clone()).unwrap_or_default();
+    let t0 = Instant::now();
+    let v = embed(&sample, &emb_cfg).await?;
+    println!("  embed: {} dims in {:?}", v.len(), t0.elapsed());
+
+    println!("✅ adapter working");
+    Ok(())
 }
 
 async fn set_weight(_id: &str, _value: f32) -> Result<()> {

--- a/mur-core/src/cmd/source_cmd.rs
+++ b/mur-core/src/cmd/source_cmd.rs
@@ -95,18 +95,200 @@ pub enum AddKind {
 
 pub async fn handle(cmd: SourceCommand) -> Result<()> {
     match cmd {
-        SourceCommand::Add { .. } => {
-            bail!("`mur source add` arrives in P1.2 (obsidian) / P1.4 (notion, joplin)")
+        SourceCommand::Add { kind } => match kind {
+            AddKind::Obsidian {
+                instance,
+                vault,
+                exclude_folder,
+            } => add_obsidian(instance, vault, exclude_folder).await,
+            AddKind::Notion { .. } => bail!("`mur source add notion` arrives in P1.4"),
+            AddKind::Joplin { .. } => bail!("`mur source add joplin` arrives in P1.4"),
+        },
+        SourceCommand::List { json, verbose } => list(json, verbose).await,
+        SourceCommand::Remove { id, keep_index } => remove(&id, keep_index).await,
+        SourceCommand::Sync { id, full, watch } => {
+            if watch {
+                bail!("`mur source sync --watch` arrives in P1.4");
+            }
+            sync(id.as_deref(), full).await
         }
-        SourceCommand::List { .. } => bail!("`mur source list` arrives in P1.2"),
-        SourceCommand::Remove { .. } => bail!("`mur source remove` arrives in P1.2"),
-        SourceCommand::Sync { .. } => bail!("`mur source sync` arrives in P1.2"),
-        SourceCommand::Status { .. } => bail!("`mur source status` arrives in P1.2"),
-        SourceCommand::Weight { .. } => bail!("`mur source weight` arrives in P1.2"),
-        SourceCommand::Test { .. } => bail!("`mur source test` arrives in P1.2"),
+        SourceCommand::Status { id } => status(id.as_deref()).await,
+        SourceCommand::Weight { id, value } => set_weight(&id, value).await,
+        SourceCommand::Test { id } => test_source(&id).await,
         SourceCommand::Reindex { .. } => bail!("`mur source reindex` arrives in P1.3"),
         SourceCommand::InstallSchedule => bail!("`mur source install-schedule` arrives in P1.4"),
-        SourceCommand::Disable { .. } => bail!("`mur source disable` arrives in P1.2"),
-        SourceCommand::Enable { .. } => bail!("`mur source enable` arrives in P1.2"),
+        SourceCommand::Disable { id } => set_enabled(&id, false).await,
+        SourceCommand::Enable { id } => set_enabled(&id, true).await,
     }
+}
+
+// ---------- Task 12 handlers ----------
+
+async fn add_obsidian(
+    instance: Option<String>,
+    vault: std::path::PathBuf,
+    exclude_folder: Vec<String>,
+) -> Result<()> {
+    use crate::sources::instance::{SourceInstance, SourceInstanceStore, SourceStats, SyncState};
+    use crate::sources::kind::SourceKind;
+    use anyhow::Context;
+    use std::collections::BTreeMap;
+
+    let store = SourceInstanceStore::default_store()?;
+    let id = match instance {
+        Some(tag) if !tag.is_empty() => format!("obsidian:{tag}"),
+        _ => {
+            let existing: Vec<String> = store.list()?.into_iter().map(|i| i.id).collect();
+            if !existing.iter().any(|id| id == "obsidian") {
+                "obsidian".to_string()
+            } else {
+                let mut rng: u16 = rand::random();
+                loop {
+                    let candidate = format!("obsidian:{rng:04x}");
+                    if !existing.contains(&candidate) {
+                        break candidate;
+                    }
+                    rng = rng.wrapping_add(1);
+                }
+            }
+        }
+    };
+
+    let abs_vault = std::fs::canonicalize(&vault)
+        .with_context(|| format!("resolve vault path {}", vault.display()))?;
+    if !abs_vault.is_dir() {
+        bail!("vault path is not a directory: {}", abs_vault.display());
+    }
+
+    let mut scope: BTreeMap<String, serde_yaml::Value> = BTreeMap::new();
+    scope.insert(
+        "vault".into(),
+        serde_yaml::Value::String(abs_vault.to_string_lossy().to_string()),
+    );
+    if !exclude_folder.is_empty() {
+        scope.insert(
+            "exclude_folders".into(),
+            serde_yaml::Value::Sequence(
+                exclude_folder
+                    .into_iter()
+                    .map(serde_yaml::Value::String)
+                    .collect(),
+            ),
+        );
+    }
+
+    let inst = SourceInstance {
+        id: id.clone(),
+        type_name: "obsidian".into(),
+        kind: SourceKind::PullIndex,
+        enabled: true,
+        weight: 1.0,
+        scope,
+        sync: SyncState::default(),
+        stats: SourceStats::default(),
+        keyring_entry: None,
+    };
+    store.save(&inst)?;
+    println!("✅ Connected vault {} as `{}`", abs_vault.display(), id);
+    println!("Run `mur source sync {id}` to index.");
+    Ok(())
+}
+
+async fn list(json: bool, _verbose: bool) -> Result<()> {
+    use crate::sources::instance::SourceInstanceStore;
+    let store = SourceInstanceStore::default_store()?;
+    let items = store.list()?;
+    if json {
+        let j = serde_json::to_string_pretty(&items)?;
+        println!("{j}");
+        return Ok(());
+    }
+    if items.is_empty() {
+        println!("(no sources — use `mur source add obsidian --vault <path>`)");
+        return Ok(());
+    }
+    println!(
+        "{:<22} {:<10} {:<8} {:>7} {:>7} {:<24}",
+        "ID", "TYPE", "STATUS", "DOCS", "WEIGHT", "LAST SYNC"
+    );
+    for inst in &items {
+        let status_str = if !inst.enabled { "off" } else { "ok" };
+        let last = inst
+            .sync
+            .last_sync_at
+            .map(|t| t.to_rfc3339())
+            .unwrap_or_else(|| "never".into());
+        println!(
+            "{:<22} {:<10} {:<8} {:>7} {:>7.2} {:<24}",
+            inst.id, inst.type_name, status_str, inst.stats.doc_count, inst.weight, last
+        );
+        if _verbose {
+            println!("    scope: {:?}", inst.scope);
+            if let Some(err) = &inst.sync.last_error {
+                println!("    last_error: {err}");
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn status(id: Option<&str>) -> Result<()> {
+    use crate::sources::instance::SourceInstanceStore;
+    let store = SourceInstanceStore::default_store()?;
+    let items = match id {
+        Some(i) => vec![store.load(i)?],
+        None => store.list()?,
+    };
+    if items.is_empty() {
+        println!("(no sources)");
+        return Ok(());
+    }
+    for inst in items {
+        println!("─── {} ({}) ───", inst.id, inst.type_name);
+        println!("  enabled     : {}", inst.enabled);
+        println!("  weight      : {:.2}", inst.weight);
+        println!("  scope       : {:?}", inst.scope);
+        println!(
+            "  last_sync_at: {}",
+            inst.sync
+                .last_sync_at
+                .map(|t| t.to_rfc3339())
+                .unwrap_or_else(|| "never".into())
+        );
+        println!(
+            "  last_cursor : {}",
+            inst.sync.last_cursor.unwrap_or_else(|| "none".into())
+        );
+        println!("  docs        : {}", inst.stats.doc_count);
+        println!("  chunks      : {}", inst.stats.chunk_count);
+        if let Some(err) = &inst.sync.last_error {
+            println!("  last_error  : {err}");
+        }
+        if !inst.sync.errors_tail.is_empty() {
+            println!("  errors_tail : {} entries", inst.sync.errors_tail.len());
+        }
+    }
+    Ok(())
+}
+
+// ---------- stubs until Task 13/14 ----------
+
+async fn sync(_id: Option<&str>, _full: bool) -> Result<()> {
+    bail!("`mur source sync` arrives in Task 13")
+}
+
+async fn remove(_id: &str, _keep_index: bool) -> Result<()> {
+    bail!("`mur source remove` arrives in Task 13")
+}
+
+async fn test_source(_id: &str) -> Result<()> {
+    bail!("`mur source test` arrives in Task 13")
+}
+
+async fn set_weight(_id: &str, _value: f32) -> Result<()> {
+    bail!("`mur source weight` arrives in Task 14")
+}
+
+async fn set_enabled(_id: &str, _enabled: bool) -> Result<()> {
+    bail!("`mur source enable/disable` arrives in Task 14")
 }

--- a/mur-core/src/cmd/source_cmd.rs
+++ b/mur-core/src/cmd/source_cmd.rs
@@ -308,7 +308,11 @@ async fn sync(id: Option<&str>, full: bool) -> Result<()> {
     let store = SourceInstanceStore::default_store()?;
     let targets: Vec<crate::sources::instance::SourceInstance> = match id {
         Some(i) => vec![store.load(i)?],
-        None => store.list()?.into_iter().filter(|inst| inst.enabled).collect(),
+        None => store
+            .list()?
+            .into_iter()
+            .filter(|inst| inst.enabled)
+            .collect(),
     };
     if targets.is_empty() {
         println!("(no enabled sources to sync)");
@@ -376,11 +380,11 @@ async fn remove(id: &str, keep_index: bool) -> Result<()> {
 }
 
 async fn test_source(id: &str) -> Result<()> {
+    use crate::sources::KnowledgeSource;
     use crate::sources::adapters::obsidian::ObsidianAdapter;
     use crate::sources::instance::SourceInstanceStore;
     use crate::sources::types::DocumentBody;
-    use crate::sources::KnowledgeSource;
-    use crate::store::embedding::{embed, EmbeddingConfig};
+    use crate::store::embedding::{EmbeddingConfig, embed};
     use std::time::Instant;
 
     let store = SourceInstanceStore::default_store()?;
@@ -395,7 +399,11 @@ async fn test_source(id: &str) -> Result<()> {
 
     let t0 = Instant::now();
     let (docs, _cursor) = adapter.list_documents(None).await?;
-    println!("→ list_documents: {} docs in {:?}", docs.len(), t0.elapsed());
+    println!(
+        "→ list_documents: {} docs in {:?}",
+        docs.len(),
+        t0.elapsed()
+    );
     if docs.is_empty() {
         println!("   (no documents — nothing to test)");
         return Ok(());
@@ -503,10 +511,7 @@ async fn search(query: &str, limit: usize, source: Option<&str>, json: bool) -> 
         } else {
             format!(" § {}", h.heading_path.join(" / "))
         };
-        println!(
-            "[{:.3}] {} / {}{}",
-            h.score, h.source_id, h.external_id, hp
-        );
+        println!("[{:.3}] {} / {}{}", h.score, h.source_id, h.external_id, hp);
         let preview: String = h.text.chars().take(180).collect();
         println!("       {}", preview);
     }

--- a/mur-core/src/cmd/source_cmd.rs
+++ b/mur-core/src/cmd/source_cmd.rs
@@ -35,11 +35,18 @@ pub enum SourceCommand {
         watch: bool,
     },
     /// Show sync health for a source.
-    Status { id: Option<String> },
+    Status {
+        id: Option<String>,
+    },
     /// Set the retrieve weight.
-    Weight { id: String, value: f32 },
+    Weight {
+        id: String,
+        value: f32,
+    },
     /// Dry-run a single document through the adapter.
-    Test { id: String },
+    Test {
+        id: String,
+    },
     /// Rebuild the vector index for a source.
     Reindex {
         id: String,
@@ -48,8 +55,12 @@ pub enum SourceCommand {
     },
     /// Generate launchd / systemd unit files for scheduled sync.
     InstallSchedule,
-    Disable { id: String },
-    Enable { id: String },
+    Disable {
+        id: String,
+    },
+    Enable {
+        id: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -84,7 +95,9 @@ pub enum AddKind {
 
 pub async fn handle(cmd: SourceCommand) -> Result<()> {
     match cmd {
-        SourceCommand::Add { .. } => bail!("`mur source add` arrives in P1.2 (obsidian) / P1.4 (notion, joplin)"),
+        SourceCommand::Add { .. } => {
+            bail!("`mur source add` arrives in P1.2 (obsidian) / P1.4 (notion, joplin)")
+        }
         SourceCommand::List { .. } => bail!("`mur source list` arrives in P1.2"),
         SourceCommand::Remove { .. } => bail!("`mur source remove` arrives in P1.2"),
         SourceCommand::Sync { .. } => bail!("`mur source sync` arrives in P1.2"),

--- a/mur-core/src/cmd/workflow.rs
+++ b/mur-core/src/cmd/workflow.rs
@@ -11,7 +11,7 @@ use crate::store::yaml::YamlStore;
 /// Accepts exact name, semantic query, or pipeline expression (w1 | w2 && w3, w4).
 pub(crate) async fn cmd_workflow_run(query: &str, fail_fast: bool, prompt: bool) -> Result<()> {
     use crate::store::embedding::{EmbeddingConfig, embed};
-    use crate::store::lancedb::VectorStore;
+    use crate::store::vector::LanceDbStore as VectorStore;
     use mur_common::pipeline::{has_pipeline_syntax, parse_pipeline_expr};
 
     // Detect pipeline syntax and delegate to PipelineExecutor
@@ -273,7 +273,7 @@ pub(crate) fn cmd_workflow_show(name: &str, markdown: bool) -> Result<()> {
 /// Semantic search for workflows using LanceDB embeddings.
 pub(crate) async fn cmd_workflow_search(query: &str, limit: usize) -> Result<()> {
     use crate::store::embedding::{EmbeddingConfig, embed};
-    use crate::store::lancedb::VectorStore;
+    use crate::store::vector::LanceDbStore as VectorStore;
 
     let store = WorkflowYamlStore::default_store()?;
     let all_workflows = store.list_all()?;

--- a/mur-core/src/lib.rs
+++ b/mur-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod interactive;
 pub mod llm;
 pub mod retrieve;
 pub mod session;
+pub mod sources;
 pub mod store;
 pub mod sync;
 pub mod team;

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -349,6 +349,12 @@ enum Commands {
         #[arg(long)]
         strict_citations: bool,
     },
+    #[cfg(feature = "sources")]
+    /// Manage external knowledge sources (Notion, Obsidian, Joplin, ...).
+    Source {
+        #[command(subcommand)]
+        cmd: cmd::source_cmd::SourceCommand,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1178,6 +1184,8 @@ async fn async_main() -> Result<()> {
             })
             .await?
         }
+        #[cfg(feature = "sources")]
+        Commands::Source { cmd } => cmd::source_cmd::handle(cmd).await?,
     }
 
     Ok(())

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -20,6 +20,8 @@ mod llm;
 mod retrieve;
 mod server;
 mod session;
+#[cfg(feature = "sources")]
+mod sources;
 mod store;
 mod sync;
 mod team;

--- a/mur-core/src/server.rs
+++ b/mur-core/src/server.rs
@@ -43,9 +43,9 @@ use crate::executor::pipeline::PipelineExecutor;
 use crate::retrieve::scoring::{ScoredPattern, score_and_rank};
 use crate::store::config::load_config;
 use crate::store::embedding::{EmbeddingConfig, embed};
-use crate::store::vector::LanceDbStore as VectorStore;
 use crate::store::pipeline_yaml::{PipelineDef, PipelineYamlStore};
 use crate::store::spot_rate::{fetch_usd_rate, fetch_usd_rates};
+use crate::store::vector::LanceDbStore as VectorStore;
 use crate::store::workflow_yaml::WorkflowYamlStore;
 use crate::store::yaml::YamlStore;
 

--- a/mur-core/src/server.rs
+++ b/mur-core/src/server.rs
@@ -43,7 +43,7 @@ use crate::executor::pipeline::PipelineExecutor;
 use crate::retrieve::scoring::{ScoredPattern, score_and_rank};
 use crate::store::config::load_config;
 use crate::store::embedding::{EmbeddingConfig, embed};
-use crate::store::lancedb::VectorStore;
+use crate::store::vector::LanceDbStore as VectorStore;
 use crate::store::pipeline_yaml::{PipelineDef, PipelineYamlStore};
 use crate::store::spot_rate::{fetch_usd_rate, fetch_usd_rates};
 use crate::store::workflow_yaml::WorkflowYamlStore;

--- a/mur-core/src/sources/adapters/mod.rs
+++ b/mur-core/src/sources/adapters/mod.rs
@@ -1,0 +1,3 @@
+//! `KnowledgeSource` implementations for each supported external app.
+
+pub mod obsidian;

--- a/mur-core/src/sources/adapters/obsidian.rs
+++ b/mur-core/src/sources/adapters/obsidian.rs
@@ -10,14 +10,12 @@ use chrono::{DateTime, Utc};
 use std::path::{Path, PathBuf};
 
 use crate::sources::KnowledgeSource;
-#[allow(unused_imports)]
 use crate::sources::chunker::markdown as md;
 use crate::sources::instance::SourceInstance;
 use crate::sources::kind::SourceKind;
 use crate::sources::types::{Chunk, DocRef, Document, DocumentBody, SyncCursor};
 
 const EXCLUDED_SEGMENTS: &[&str] = &[".obsidian", ".trash"];
-#[allow(dead_code)]
 const CHUNK_MAX_CHARS: usize = 6000;
 
 /// Obsidian vault adapter.
@@ -217,8 +215,25 @@ impl KnowledgeSource for ObsidianAdapter {
         })
     }
 
-    fn chunk(&self, _doc: &Document) -> Result<Vec<Chunk>> {
-        anyhow::bail!("ObsidianAdapter::chunk arrives in Task 10")
+    fn chunk(&self, doc: &Document) -> Result<Vec<Chunk>> {
+        let body = match &doc.body {
+            DocumentBody::Markdown(s) | DocumentBody::PlainText(s) => s.clone(),
+            DocumentBody::NotionBlocks(_) => bail!("obsidian adapter does not handle notion blocks"),
+        };
+        let raw_chunks = md::chunk_markdown(&doc.title, &body, CHUNK_MAX_CHARS);
+        let mut out = Vec::with_capacity(raw_chunks.len());
+        for (i, c) in raw_chunks.into_iter().enumerate() {
+            out.push(Chunk::new(
+                doc.source_id.clone(),
+                doc.external_id.clone(),
+                i,
+                c.text,
+                c.heading_path,
+                c.char_range,
+                doc.updated_at,
+            ));
+        }
+        Ok(out)
     }
 }
 
@@ -421,5 +436,29 @@ mod tests {
             _ => panic!("expected markdown body"),
         }
         assert_eq!(doc.metadata.get("status").and_then(|v| v.as_str()), Some("draft"));
+    }
+
+    #[tokio::test]
+    async fn chunk_emits_multiple_chunks_with_heading_path() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join(".obsidian")).unwrap();
+        let body = "# H1\n\npara under h1.\n\n## H2\n\npara under h2.\n\n## H2-b\n\npara under h2-b.\n";
+        fs::write(tmp.path().join("multi.md"), body).unwrap();
+
+        let inst = make_instance("obsidian-main", tmp.path());
+        let adapter = ObsidianAdapter::from_instance(&inst).unwrap();
+        let (docs, _) = adapter.list_documents(None).await.unwrap();
+        let doc_ref = docs.iter().find(|d| d.external_id == "multi.md").unwrap();
+        let doc = adapter.fetch(doc_ref).await.unwrap();
+        let chunks = adapter.chunk(&doc).unwrap();
+        assert!(chunks.len() >= 3, "expected >=3 chunks, got {}", chunks.len());
+        for c in &chunks {
+            assert_eq!(c.source_id, "obsidian-main");
+            assert_eq!(c.external_id, "multi.md");
+            assert!(!c.chunk_id.is_empty());
+            assert!(!c.text.is_empty());
+        }
+        let ords: Vec<usize> = chunks.iter().map(|c| c.ordinal).collect();
+        assert_eq!(ords, (0..chunks.len()).collect::<Vec<_>>());
     }
 }

--- a/mur-core/src/sources/adapters/obsidian.rs
+++ b/mur-core/src/sources/adapters/obsidian.rs
@@ -113,7 +113,9 @@ impl KnowledgeSource for ObsidianAdapter {
             if c.is_empty() {
                 None
             } else {
-                DateTime::parse_from_rfc3339(&c.0).ok().map(|dt| dt.with_timezone(&Utc))
+                DateTime::parse_from_rfc3339(&c.0)
+                    .ok()
+                    .map(|dt| dt.with_timezone(&Utc))
             }
         });
 
@@ -220,7 +222,9 @@ impl KnowledgeSource for ObsidianAdapter {
     fn chunk(&self, doc: &Document) -> Result<Vec<Chunk>> {
         let body = match &doc.body {
             DocumentBody::Markdown(s) | DocumentBody::PlainText(s) => s.clone(),
-            DocumentBody::NotionBlocks(_) => bail!("obsidian adapter does not handle notion blocks"),
+            DocumentBody::NotionBlocks(_) => {
+                bail!("obsidian adapter does not handle notion blocks")
+            }
         };
         let raw_chunks = md::chunk_markdown(&doc.title, &body, CHUNK_MAX_CHARS);
         let mut out = Vec::with_capacity(raw_chunks.len());
@@ -332,7 +336,11 @@ mod tests {
         fs::create_dir_all(tmp.path().join(".obsidian")).unwrap();
         fs::write(tmp.path().join("note-a.md"), "# A\n\ncontent a").unwrap();
         fs::create_dir_all(tmp.path().join("folder")).unwrap();
-        fs::write(tmp.path().join("folder").join("note-b.md"), "# B\n\ncontent b").unwrap();
+        fs::write(
+            tmp.path().join("folder").join("note-b.md"),
+            "# B\n\ncontent b",
+        )
+        .unwrap();
         fs::create_dir_all(tmp.path().join(".trash")).unwrap();
         fs::write(tmp.path().join(".trash").join("deleted.md"), "# D").unwrap();
         tmp
@@ -437,14 +445,18 @@ mod tests {
             }
             _ => panic!("expected markdown body"),
         }
-        assert_eq!(doc.metadata.get("status").and_then(|v| v.as_str()), Some("draft"));
+        assert_eq!(
+            doc.metadata.get("status").and_then(|v| v.as_str()),
+            Some("draft")
+        );
     }
 
     #[tokio::test]
     async fn chunk_emits_multiple_chunks_with_heading_path() {
         let tmp = TempDir::new().unwrap();
         fs::create_dir_all(tmp.path().join(".obsidian")).unwrap();
-        let body = "# H1\n\npara under h1.\n\n## H2\n\npara under h2.\n\n## H2-b\n\npara under h2-b.\n";
+        let body =
+            "# H1\n\npara under h1.\n\n## H2\n\npara under h2.\n\n## H2-b\n\npara under h2-b.\n";
         fs::write(tmp.path().join("multi.md"), body).unwrap();
 
         let inst = make_instance("obsidian-main", tmp.path());
@@ -453,7 +465,11 @@ mod tests {
         let doc_ref = docs.iter().find(|d| d.external_id == "multi.md").unwrap();
         let doc = adapter.fetch(doc_ref).await.unwrap();
         let chunks = adapter.chunk(&doc).unwrap();
-        assert!(chunks.len() >= 3, "expected >=3 chunks, got {}", chunks.len());
+        assert!(
+            chunks.len() >= 3,
+            "expected >=3 chunks, got {}",
+            chunks.len()
+        );
         for c in &chunks {
             assert_eq!(c.source_id, "obsidian-main");
             assert_eq!(c.external_id, "multi.md");

--- a/mur-core/src/sources/adapters/obsidian.rs
+++ b/mur-core/src/sources/adapters/obsidian.rs
@@ -1,0 +1,278 @@
+//! Obsidian vault adapter.
+//!
+//! Treats a local folder containing markdown files as a pull-index source.
+//! Excludes `.obsidian/` (app state), `.trash/`, and any user-configured
+//! folders via `SourceInstance.scope.exclude_folders`.
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::path::{Path, PathBuf};
+
+use crate::sources::KnowledgeSource;
+#[allow(unused_imports)]
+use crate::sources::chunker::markdown as md;
+use crate::sources::instance::SourceInstance;
+use crate::sources::kind::SourceKind;
+#[allow(unused_imports)]
+use crate::sources::types::{Chunk, DocRef, Document, DocumentBody, SyncCursor};
+
+const EXCLUDED_SEGMENTS: &[&str] = &[".obsidian", ".trash"];
+#[allow(dead_code)]
+const CHUNK_MAX_CHARS: usize = 6000;
+
+/// Obsidian vault adapter.
+pub struct ObsidianAdapter {
+    id: String,
+    vault_path: PathBuf,
+    weight: f32,
+    exclude_folders: Vec<String>,
+}
+
+impl ObsidianAdapter {
+    /// Build from a `SourceInstance` (expects `type_name == "obsidian"` and the
+    /// `scope.vault` value set to an absolute path).
+    pub fn from_instance(instance: &SourceInstance) -> Result<Self> {
+        if instance.type_name != "obsidian" {
+            bail!(
+                "expected type_name 'obsidian', got '{}'",
+                instance.type_name
+            );
+        }
+        let vault_val = instance
+            .scope
+            .get("vault")
+            .context("source instance missing scope.vault")?;
+        let vault_str: String = match vault_val {
+            serde_yaml::Value::String(s) => s.clone(),
+            _ => bail!("scope.vault must be a string"),
+        };
+        let vault_path = PathBuf::from(&vault_str);
+        if !vault_path.is_dir() {
+            bail!("vault path does not exist or is not a directory: {vault_str}");
+        }
+        if !vault_path.join(".obsidian").exists() {
+            tracing::warn!(
+                "vault {} has no .obsidian/ subdir — proceeding anyway",
+                vault_path.display()
+            );
+        }
+
+        let exclude_folders: Vec<String> = instance
+            .scope
+            .get("exclude_folders")
+            .and_then(|v| v.as_sequence())
+            .map(|seq| {
+                seq.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        Ok(Self {
+            id: instance.id.clone(),
+            vault_path,
+            weight: instance.weight,
+            exclude_folders,
+        })
+    }
+
+    fn is_excluded(&self, rel: &Path) -> bool {
+        for seg in rel.components() {
+            if let Some(s) = seg.as_os_str().to_str() {
+                if EXCLUDED_SEGMENTS.iter().any(|x| *x == s) {
+                    return true;
+                }
+                if self.exclude_folders.iter().any(|e| e == s) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+#[async_trait]
+impl KnowledgeSource for ObsidianAdapter {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn kind(&self) -> SourceKind {
+        SourceKind::PullIndex
+    }
+
+    fn weight(&self) -> f32 {
+        self.weight
+    }
+
+    async fn list_documents(
+        &self,
+        cursor: Option<SyncCursor>,
+    ) -> Result<(Vec<DocRef>, SyncCursor)> {
+        let threshold: Option<DateTime<Utc>> = cursor.and_then(|c| {
+            if c.is_empty() {
+                None
+            } else {
+                DateTime::parse_from_rfc3339(&c.0).ok().map(|dt| dt.with_timezone(&Utc))
+            }
+        });
+
+        let mut docs: Vec<DocRef> = Vec::new();
+        let mut max_ts: Option<DateTime<Utc>> = None;
+
+        for entry in walkdir::WalkDir::new(&self.vault_path)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let path = entry.path();
+            if path.extension().and_then(|x| x.to_str()) != Some("md") {
+                continue;
+            }
+            let rel = path
+                .strip_prefix(&self.vault_path)
+                .ok()
+                .map(|r| r.to_path_buf())
+                .unwrap_or_else(|| path.to_path_buf());
+            if self.is_excluded(&rel) {
+                continue;
+            }
+            let meta = entry.metadata().context("stat vault file")?;
+            let modified = meta.modified().context("no mtime on vault file")?;
+            let updated_at: DateTime<Utc> = modified.into();
+
+            if let Some(t) = threshold
+                && updated_at <= t
+            {
+                continue;
+            }
+            if max_ts.map_or(true, |m| updated_at > m) {
+                max_ts = Some(updated_at);
+            }
+            let external_id = rel
+                .to_str()
+                .context("vault path is not valid UTF-8")?
+                .to_string();
+            let title = rel
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string());
+            docs.push(DocRef {
+                external_id,
+                title,
+                updated_at,
+            });
+        }
+
+        let cursor_out = match max_ts {
+            Some(t) => SyncCursor(t.to_rfc3339()),
+            None => SyncCursor(threshold.map(|t| t.to_rfc3339()).unwrap_or_default()),
+        };
+
+        Ok((docs, cursor_out))
+    }
+
+    async fn fetch(&self, _doc_ref: &DocRef) -> Result<Document> {
+        anyhow::bail!("ObsidianAdapter::fetch arrives in Task 9")
+    }
+
+    fn chunk(&self, _doc: &Document) -> Result<Vec<Chunk>> {
+        anyhow::bail!("ObsidianAdapter::chunk arrives in Task 10")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn make_vault() -> TempDir {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join(".obsidian")).unwrap();
+        fs::write(tmp.path().join("note-a.md"), "# A\n\ncontent a").unwrap();
+        fs::create_dir_all(tmp.path().join("folder")).unwrap();
+        fs::write(tmp.path().join("folder").join("note-b.md"), "# B\n\ncontent b").unwrap();
+        fs::create_dir_all(tmp.path().join(".trash")).unwrap();
+        fs::write(tmp.path().join(".trash").join("deleted.md"), "# D").unwrap();
+        tmp
+    }
+
+    fn make_instance(id: &str, vault: &Path) -> SourceInstance {
+        let mut scope = BTreeMap::new();
+        scope.insert(
+            "vault".into(),
+            serde_yaml::Value::String(vault.to_string_lossy().to_string()),
+        );
+        SourceInstance {
+            id: id.into(),
+            type_name: "obsidian".into(),
+            kind: SourceKind::PullIndex,
+            enabled: true,
+            weight: 1.0,
+            scope,
+            sync: crate::sources::instance::SyncState::default(),
+            stats: crate::sources::instance::SourceStats::default(),
+            keyring_entry: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn from_instance_validates_vault_exists() {
+        let inst = {
+            let mut i = make_instance("obsidian-x", Path::new("/nonexistent/path/xyz"));
+            i.scope.insert(
+                "vault".into(),
+                serde_yaml::Value::String("/nonexistent/path/xyz".into()),
+            );
+            i
+        };
+        assert!(ObsidianAdapter::from_instance(&inst).is_err());
+    }
+
+    #[tokio::test]
+    async fn list_documents_finds_md_files_excluding_hidden() {
+        let tmp = make_vault();
+        let inst = make_instance("obsidian-main", tmp.path());
+        let adapter = ObsidianAdapter::from_instance(&inst).unwrap();
+        let (docs, _cursor) = adapter.list_documents(None).await.unwrap();
+        let mut ids: Vec<String> = docs.iter().map(|d| d.external_id.clone()).collect();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["folder/note-b.md".to_string(), "note-a.md".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn exclude_folder_is_honoured() {
+        let tmp = make_vault();
+        let mut inst = make_instance("obsidian-main", tmp.path());
+        inst.scope.insert(
+            "exclude_folders".into(),
+            serde_yaml::Value::Sequence(vec![serde_yaml::Value::String("folder".into())]),
+        );
+        let adapter = ObsidianAdapter::from_instance(&inst).unwrap();
+        let (docs, _) = adapter.list_documents(None).await.unwrap();
+        let ids: Vec<String> = docs.iter().map(|d| d.external_id.clone()).collect();
+        assert_eq!(ids, vec!["note-a.md".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn cursor_filters_older_files() {
+        let tmp = make_vault();
+        let inst = make_instance("obsidian-main", tmp.path());
+        let adapter = ObsidianAdapter::from_instance(&inst).unwrap();
+        let future = chrono::Utc::now() + chrono::Duration::days(365);
+        let (docs, _) = adapter
+            .list_documents(Some(SyncCursor(future.to_rfc3339())))
+            .await
+            .unwrap();
+        assert!(docs.is_empty());
+    }
+}

--- a/mur-core/src/sources/adapters/obsidian.rs
+++ b/mur-core/src/sources/adapters/obsidian.rs
@@ -154,10 +154,12 @@ impl KnowledgeSource for ObsidianAdapter {
             if max_ts.is_none_or(|m| updated_at > m) {
                 max_ts = Some(updated_at);
             }
+            // Normalize to forward slashes so external_id is a stable, cross-platform key
+            // (Windows returns `folder\\note.md`; we store `folder/note.md` everywhere).
             let external_id = rel
                 .to_str()
                 .context("vault path is not valid UTF-8")?
-                .to_string();
+                .replace(std::path::MAIN_SEPARATOR, "/");
             let title = rel
                 .file_stem()
                 .and_then(|s| s.to_str())

--- a/mur-core/src/sources/adapters/obsidian.rs
+++ b/mur-core/src/sources/adapters/obsidian.rs
@@ -22,6 +22,8 @@ const CHUNK_MAX_CHARS: usize = 6000;
 pub struct ObsidianAdapter {
     id: String,
     vault_path: PathBuf,
+    // Applied at search-time by the P1.3+ orchestrator via KnowledgeSource::weight().
+    #[allow(dead_code)]
     weight: f32,
     exclude_folders: Vec<String>,
 }
@@ -77,7 +79,7 @@ impl ObsidianAdapter {
     fn is_excluded(&self, rel: &Path) -> bool {
         for seg in rel.components() {
             if let Some(s) = seg.as_os_str().to_str() {
-                if EXCLUDED_SEGMENTS.iter().any(|x| *x == s) {
+                if EXCLUDED_SEGMENTS.contains(&s) {
                     return true;
                 }
                 if self.exclude_folders.iter().any(|e| e == s) {
@@ -147,7 +149,7 @@ impl KnowledgeSource for ObsidianAdapter {
             {
                 continue;
             }
-            if max_ts.map_or(true, |m| updated_at > m) {
+            if max_ts.is_none_or(|m| updated_at > m) {
                 max_ts = Some(updated_at);
             }
             let external_id = rel

--- a/mur-core/src/sources/adapters/obsidian.rs
+++ b/mur-core/src/sources/adapters/obsidian.rs
@@ -14,7 +14,6 @@ use crate::sources::KnowledgeSource;
 use crate::sources::chunker::markdown as md;
 use crate::sources::instance::SourceInstance;
 use crate::sources::kind::SourceKind;
-#[allow(unused_imports)]
 use crate::sources::types::{Chunk, DocRef, Document, DocumentBody, SyncCursor};
 
 const EXCLUDED_SEGMENTS: &[&str] = &[".obsidian", ".trash"];
@@ -176,12 +175,131 @@ impl KnowledgeSource for ObsidianAdapter {
         Ok((docs, cursor_out))
     }
 
-    async fn fetch(&self, _doc_ref: &DocRef) -> Result<Document> {
-        anyhow::bail!("ObsidianAdapter::fetch arrives in Task 9")
+    async fn fetch(&self, doc_ref: &DocRef) -> Result<Document> {
+        let full_path = self.vault_path.join(&doc_ref.external_id);
+        let raw = tokio::fs::read_to_string(&full_path)
+            .await
+            .with_context(|| format!("read vault file {}", full_path.display()))?;
+        let (frontmatter, body_without_fm) = strip_frontmatter(&raw);
+
+        let (tags, metadata) = frontmatter
+            .as_ref()
+            .map(parse_frontmatter)
+            .unwrap_or_else(|| (Vec::new(), serde_json::Value::Object(Default::default())));
+
+        let title = doc_ref
+            .title
+            .clone()
+            .unwrap_or_else(|| doc_ref.external_id.clone());
+
+        let url = {
+            let vault_name = self
+                .vault_path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("vault");
+            Some(format!(
+                "obsidian://open?vault={}&file={}",
+                urlencoding::encode(vault_name),
+                urlencoding::encode(&doc_ref.external_id)
+            ))
+        };
+
+        Ok(Document {
+            source_id: self.id.clone(),
+            external_id: doc_ref.external_id.clone(),
+            title,
+            body: DocumentBody::Markdown(body_without_fm.to_string()),
+            url,
+            updated_at: doc_ref.updated_at,
+            tags,
+            metadata,
+        })
     }
 
     fn chunk(&self, _doc: &Document) -> Result<Vec<Chunk>> {
         anyhow::bail!("ObsidianAdapter::chunk arrives in Task 10")
+    }
+}
+
+/// Strip the YAML frontmatter block if present.
+fn strip_frontmatter(raw: &str) -> (Option<&str>, &str) {
+    let mut lines = raw.split_inclusive('\n');
+    let first = match lines.next() {
+        Some(l) => l.trim_end_matches(['\r', '\n']),
+        None => return (None, raw),
+    };
+    if first != "---" {
+        return (None, raw);
+    }
+    let mut acc_len = first.len() + 1;
+    let mut end_at: Option<usize> = None;
+    for line in lines {
+        acc_len += line.len();
+        if line.trim_end_matches(['\r', '\n']) == "---" {
+            end_at = Some(acc_len);
+            break;
+        }
+    }
+    match end_at {
+        Some(idx) => {
+            let fm = &raw[..idx];
+            let body = raw[idx..].trim_start_matches('\n').trim_start_matches('\r');
+            let fm_inner = fm
+                .trim_start_matches("---")
+                .trim_start_matches(['\r', '\n'])
+                .trim_end_matches("---\n")
+                .trim_end_matches("---\r\n")
+                .trim_end_matches("---");
+            (Some(fm_inner), body)
+        }
+        None => (None, raw),
+    }
+}
+
+fn parse_frontmatter(fm: &&str) -> (Vec<String>, serde_json::Value) {
+    let parsed: serde_yaml::Value = serde_yaml::from_str(fm).unwrap_or(serde_yaml::Value::Null);
+    let tags = parsed
+        .get("tags")
+        .and_then(|v| v.as_sequence())
+        .map(|seq| {
+            seq.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let metadata = yaml_to_json(&parsed);
+    (tags, metadata)
+}
+
+fn yaml_to_json(v: &serde_yaml::Value) -> serde_json::Value {
+    use serde_yaml::Value as Y;
+    match v {
+        Y::Null => serde_json::Value::Null,
+        Y::Bool(b) => serde_json::Value::Bool(*b),
+        Y::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                serde_json::Value::Number(i.into())
+            } else if let Some(f) = n.as_f64() {
+                serde_json::Number::from_f64(f)
+                    .map(serde_json::Value::Number)
+                    .unwrap_or(serde_json::Value::Null)
+            } else {
+                serde_json::Value::Null
+            }
+        }
+        Y::String(s) => serde_json::Value::String(s.clone()),
+        Y::Sequence(s) => serde_json::Value::Array(s.iter().map(yaml_to_json).collect()),
+        Y::Mapping(m) => {
+            let mut obj = serde_json::Map::new();
+            for (k, val) in m {
+                if let Some(ks) = k.as_str() {
+                    obj.insert(ks.to_string(), yaml_to_json(val));
+                }
+            }
+            serde_json::Value::Object(obj)
+        }
+        Y::Tagged(t) => yaml_to_json(&t.value),
     }
 }
 
@@ -274,5 +392,34 @@ mod tests {
             .await
             .unwrap();
         assert!(docs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_reads_file_and_parses_frontmatter() {
+        let tmp = TempDir::new().unwrap();
+        fs::create_dir_all(tmp.path().join(".obsidian")).unwrap();
+        fs::write(
+            tmp.path().join("spec.md"),
+            "---\ntags: [design, oauth]\nstatus: draft\n---\n\n# Auth spec\n\nbody.",
+        )
+        .unwrap();
+
+        let inst = make_instance("obsidian-main", tmp.path());
+        let adapter = ObsidianAdapter::from_instance(&inst).unwrap();
+        let (docs, _) = adapter.list_documents(None).await.unwrap();
+        let doc_ref = docs.iter().find(|d| d.external_id == "spec.md").unwrap();
+        let doc = adapter.fetch(doc_ref).await.unwrap();
+        assert_eq!(doc.source_id, "obsidian-main");
+        assert_eq!(doc.external_id, "spec.md");
+        assert!(doc.tags.contains(&"design".to_string()));
+        assert!(doc.tags.contains(&"oauth".to_string()));
+        match &doc.body {
+            DocumentBody::Markdown(s) => {
+                assert!(s.starts_with("# Auth spec"));
+                assert!(!s.contains("---"));
+            }
+            _ => panic!("expected markdown body"),
+        }
+        assert_eq!(doc.metadata.get("status").and_then(|v| v.as_str()), Some("draft"));
     }
 }

--- a/mur-core/src/sources/chunker/markdown.rs
+++ b/mur-core/src/sources/chunker/markdown.rs
@@ -86,10 +86,8 @@ pub fn chunk_markdown(title: &str, body: &str, max_chars: usize) -> Vec<Markdown
                     cur_buf.push_str(&t);
                 }
             }
-            Event::SoftBreak | Event::HardBreak => {
-                if in_heading.is_none() {
-                    cur_buf.push('\n');
-                }
+            Event::SoftBreak | Event::HardBreak if in_heading.is_none() => {
+                cur_buf.push('\n');
             }
             Event::End(TagEnd::Paragraph) => {
                 cur_buf.push_str("\n\n");
@@ -103,10 +101,8 @@ pub fn chunk_markdown(title: &str, body: &str, max_chars: usize) -> Vec<Markdown
                     );
                 }
             }
-            Event::Code(c) => {
-                if in_heading.is_none() {
-                    cur_buf.push_str(&format!("`{c}`"));
-                }
+            Event::Code(c) if in_heading.is_none() => {
+                cur_buf.push_str(&format!("`{c}`"));
             }
             Event::Start(Tag::CodeBlock(_)) => {
                 cur_buf.push_str("\n```\n");

--- a/mur-core/src/sources/chunker/markdown.rs
+++ b/mur-core/src/sources/chunker/markdown.rs
@@ -1,0 +1,209 @@
+//! Markdown heading-aware chunker.
+//!
+//! Splits a document into chunks by H1/H2/H3 boundaries and, within a chunk,
+//! by paragraph boundaries if the byte budget is exceeded. Retains heading
+//! path (list of current headings) for provenance.
+
+use pulldown_cmark::{Event, HeadingLevel, Parser, Tag, TagEnd};
+
+/// A chunk of markdown text with provenance.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MarkdownChunk {
+    /// Hierarchy of headings at the chunk's start (e.g. ["Design", "Error handling"]).
+    pub heading_path: Vec<String>,
+    /// Inclusive character offsets in the ORIGINAL body.
+    pub char_range: (usize, usize),
+    /// Plaintext content (markdown syntax stripped to embedding-friendly form).
+    pub text: String,
+}
+
+/// Chunk a markdown body.
+///
+/// - `title` prepends the chunker's notion of a "document title" into the heading
+///   path of every chunk (so searches over titles + sections work).
+/// - `max_chars` is a soft byte budget: chunks exceeding it are split at the
+///   nearest paragraph boundary.
+pub fn chunk_markdown(title: &str, body: &str, max_chars: usize) -> Vec<MarkdownChunk> {
+    let mut out: Vec<MarkdownChunk> = Vec::new();
+    let mut heading_stack: Vec<(u8, String)> = Vec::new(); // (level, heading text)
+    let mut cur_buf = String::new();
+    let mut cur_start: usize = 0;
+    let mut in_heading: Option<HeadingLevel> = None;
+    let mut heading_text_buf = String::new();
+
+    let flush = |heading_stack: &Vec<(u8, String)>,
+                 cur_buf: &mut String,
+                 cur_start: &mut usize,
+                 next_start: usize,
+                 out: &mut Vec<MarkdownChunk>| {
+        let text = std::mem::take(cur_buf).trim().to_string();
+        if !text.is_empty() {
+            let hp: Vec<String> = Some(title.to_string())
+                .into_iter()
+                .chain(heading_stack.iter().map(|(_, h)| h.clone()))
+                .filter(|s| !s.is_empty())
+                .collect();
+            out.push(MarkdownChunk {
+                heading_path: hp,
+                char_range: (*cur_start, next_start),
+                text,
+            });
+        }
+        *cur_start = next_start;
+    };
+
+    // pulldown-cmark offset iterator yields (Event, byte-range) tuples.
+    let offset_iter = Parser::new(body).into_offset_iter();
+
+    for (event, range) in offset_iter {
+        match event {
+            Event::Start(Tag::Heading { level, .. }) => {
+                let next_start = range.start;
+                flush(&heading_stack, &mut cur_buf, &mut cur_start, next_start, &mut out);
+                in_heading = Some(level);
+                heading_text_buf.clear();
+            }
+            Event::End(TagEnd::Heading(level)) => {
+                let text = std::mem::take(&mut heading_text_buf).trim().to_string();
+                let depth = heading_level_to_u8(level);
+                while let Some(&(d, _)) = heading_stack.last() {
+                    if d >= depth {
+                        heading_stack.pop();
+                    } else {
+                        break;
+                    }
+                }
+                if !text.is_empty() {
+                    heading_stack.push((depth, text));
+                }
+                in_heading = None;
+                cur_start = range.end;
+            }
+            Event::Text(t) => {
+                if in_heading.is_some() {
+                    heading_text_buf.push_str(&t);
+                } else {
+                    cur_buf.push_str(&t);
+                }
+            }
+            Event::SoftBreak | Event::HardBreak => {
+                if in_heading.is_none() {
+                    cur_buf.push('\n');
+                }
+            }
+            Event::End(TagEnd::Paragraph) => {
+                cur_buf.push_str("\n\n");
+                if cur_buf.len() > max_chars {
+                    flush(
+                        &heading_stack,
+                        &mut cur_buf,
+                        &mut cur_start,
+                        range.end,
+                        &mut out,
+                    );
+                }
+            }
+            Event::Code(c) => {
+                if in_heading.is_none() {
+                    cur_buf.push_str(&format!("`{c}`"));
+                }
+            }
+            Event::Start(Tag::CodeBlock(_)) => {
+                cur_buf.push_str("\n```\n");
+            }
+            Event::End(TagEnd::CodeBlock) => {
+                cur_buf.push_str("\n```\n");
+            }
+            _ => {}
+        }
+    }
+
+    flush(
+        &heading_stack,
+        &mut cur_buf,
+        &mut cur_start,
+        body.len(),
+        &mut out,
+    );
+
+    out
+}
+
+fn heading_level_to_u8(l: HeadingLevel) -> u8 {
+    match l {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_body_returns_no_chunks() {
+        let chunks = chunk_markdown("T", "", 1000);
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn single_paragraph_single_chunk() {
+        let chunks = chunk_markdown("T", "Hello world.", 1000);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].heading_path, vec!["T".to_string()]);
+        assert!(chunks[0].text.contains("Hello world"));
+    }
+
+    #[test]
+    fn h1_h2_chunks_track_heading_path() {
+        let body = "# Design\n\nintro para\n\n## Error handling\n\nsecond para\n";
+        let chunks = chunk_markdown("Doc", body, 1000);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].heading_path, vec!["Doc".to_string(), "Design".to_string()]);
+        assert!(chunks[0].text.contains("intro para"));
+        assert_eq!(
+            chunks[1].heading_path,
+            vec![
+                "Doc".to_string(),
+                "Design".to_string(),
+                "Error handling".to_string()
+            ]
+        );
+        assert!(chunks[1].text.contains("second para"));
+    }
+
+    #[test]
+    fn oversized_chunk_splits_on_paragraph() {
+        let big = "x".repeat(200);
+        let body = format!("{big}\n\n{big}\n\n{big}");
+        let chunks = chunk_markdown("T", &body, 150);
+        assert!(chunks.len() >= 3);
+    }
+
+    #[test]
+    fn sibling_h2_does_not_leak_previous_h2() {
+        let body = "## A\n\npara A\n\n## B\n\npara B\n";
+        let chunks = chunk_markdown("Doc", body, 1000);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(
+            chunks[0].heading_path,
+            vec!["Doc".to_string(), "A".to_string()]
+        );
+        assert_eq!(
+            chunks[1].heading_path,
+            vec!["Doc".to_string(), "B".to_string()]
+        );
+    }
+
+    #[test]
+    fn char_range_covers_body() {
+        let body = "one\n\ntwo";
+        let chunks = chunk_markdown("T", body, 1000);
+        let last = chunks.last().unwrap();
+        assert_eq!(last.char_range.1, body.len());
+    }
+}

--- a/mur-core/src/sources/chunker/markdown.rs
+++ b/mur-core/src/sources/chunker/markdown.rs
@@ -59,7 +59,13 @@ pub fn chunk_markdown(title: &str, body: &str, max_chars: usize) -> Vec<Markdown
         match event {
             Event::Start(Tag::Heading { level, .. }) => {
                 let next_start = range.start;
-                flush(&heading_stack, &mut cur_buf, &mut cur_start, next_start, &mut out);
+                flush(
+                    &heading_stack,
+                    &mut cur_buf,
+                    &mut cur_start,
+                    next_start,
+                    &mut out,
+                );
                 in_heading = Some(level);
                 heading_text_buf.clear();
             }
@@ -159,7 +165,10 @@ mod tests {
         let body = "# Design\n\nintro para\n\n## Error handling\n\nsecond para\n";
         let chunks = chunk_markdown("Doc", body, 1000);
         assert_eq!(chunks.len(), 2);
-        assert_eq!(chunks[0].heading_path, vec!["Doc".to_string(), "Design".to_string()]);
+        assert_eq!(
+            chunks[0].heading_path,
+            vec!["Doc".to_string(), "Design".to_string()]
+        );
         assert!(chunks[0].text.contains("intro para"));
         assert_eq!(
             chunks[1].heading_path,

--- a/mur-core/src/sources/chunker/mod.rs
+++ b/mur-core/src/sources/chunker/mod.rs
@@ -1,0 +1,7 @@
+//! Text chunking utilities shared across adapters.
+//!
+//! `markdown::chunk_markdown` is used by the Obsidian and (later) Joplin
+//! adapters. Notion uses a block-aware chunker that will live as a sibling
+//! module in P1.4 (`notion_blocks.rs`).
+
+pub mod markdown;

--- a/mur-core/src/sources/credentials.rs
+++ b/mur-core/src/sources/credentials.rs
@@ -2,11 +2,14 @@
 //!
 //! We abstract over the OS keyring so unit tests don't need Keychain /
 //! Secret Service. Production uses `OsKeyring`; tests use `InMemoryCreds`.
+//! Wired into the CLI in P1.3+ (Notion/Joplin OAuth flows).
 
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+// Entire module becomes live in P1.3+ when OAuth-backed adapters ship.
+#[allow(dead_code)]
 pub trait CredentialStore: Send + Sync {
     /// Store `value` under `(service, account)`.
     fn set(&self, service: &str, account: &str, value: &str) -> Result<()>;
@@ -18,6 +21,8 @@ pub trait CredentialStore: Send + Sync {
 
 /// Production implementation backed by the OS keyring (macOS Keychain,
 /// Linux Secret Service via libsecret, Windows Credential Manager).
+/// Instantiated by Notion/Joplin adapters in P1.3+.
+#[allow(dead_code)]
 pub struct OsKeyring;
 
 impl CredentialStore for OsKeyring {
@@ -52,6 +57,7 @@ impl CredentialStore for OsKeyring {
 }
 
 /// In-memory implementation for tests.
+#[allow(dead_code)]
 #[derive(Default)]
 pub struct InMemoryCreds {
     store: Mutex<HashMap<(String, String), String>>,
@@ -85,10 +91,14 @@ impl CredentialStore for InMemoryCreds {
 }
 
 /// Canonical helper: derive the keyring account name from source id + field.
+/// Used by Notion/Joplin adapters in P1.3+.
+#[allow(dead_code)]
 pub fn account(source_id: &str, field: &str) -> String {
     format!("{source_id}:{field}")
 }
 
+// Used by all credential calls in P1.3+ adapters.
+#[allow(dead_code)]
 pub const SERVICE: &str = "mur";
 
 #[cfg(test)]

--- a/mur-core/src/sources/credentials.rs
+++ b/mur-core/src/sources/credentials.rs
@@ -1,0 +1,120 @@
+//! Credential storage for adapters.
+//!
+//! We abstract over the OS keyring so unit tests don't need Keychain /
+//! Secret Service. Production uses `OsKeyring`; tests use `InMemoryCreds`.
+
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+pub trait CredentialStore: Send + Sync {
+    /// Store `value` under `(service, account)`.
+    fn set(&self, service: &str, account: &str, value: &str) -> Result<()>;
+    /// Retrieve `(service, account)` or return `Ok(None)` if not present.
+    fn get(&self, service: &str, account: &str) -> Result<Option<String>>;
+    /// Delete if present; no error if absent.
+    fn delete(&self, service: &str, account: &str) -> Result<()>;
+}
+
+/// Production implementation backed by the OS keyring (macOS Keychain,
+/// Linux Secret Service via libsecret, Windows Credential Manager).
+pub struct OsKeyring;
+
+impl CredentialStore for OsKeyring {
+    fn set(&self, service: &str, account: &str, value: &str) -> Result<()> {
+        let entry = keyring::Entry::new(service, account)
+            .with_context(|| format!("open keyring entry {service}:{account}"))?;
+        entry
+            .set_password(value)
+            .with_context(|| format!("set keyring entry {service}:{account}"))?;
+        Ok(())
+    }
+
+    fn get(&self, service: &str, account: &str) -> Result<Option<String>> {
+        let entry = keyring::Entry::new(service, account)
+            .with_context(|| format!("open keyring entry {service}:{account}"))?;
+        match entry.get_password() {
+            Ok(v) => Ok(Some(v)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(e).with_context(|| format!("get keyring entry {service}:{account}")),
+        }
+    }
+
+    fn delete(&self, service: &str, account: &str) -> Result<()> {
+        let entry = keyring::Entry::new(service, account)
+            .with_context(|| format!("open keyring entry {service}:{account}"))?;
+        match entry.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(e).with_context(|| format!("delete keyring entry {service}:{account}")),
+        }
+    }
+}
+
+/// In-memory implementation for tests.
+#[derive(Default)]
+pub struct InMemoryCreds {
+    store: Mutex<HashMap<(String, String), String>>,
+}
+
+impl CredentialStore for InMemoryCreds {
+    fn set(&self, service: &str, account: &str, value: &str) -> Result<()> {
+        self.store
+            .lock()
+            .unwrap()
+            .insert((service.into(), account.into()), value.into());
+        Ok(())
+    }
+
+    fn get(&self, service: &str, account: &str) -> Result<Option<String>> {
+        Ok(self
+            .store
+            .lock()
+            .unwrap()
+            .get(&(service.into(), account.into()))
+            .cloned())
+    }
+
+    fn delete(&self, service: &str, account: &str) -> Result<()> {
+        self.store
+            .lock()
+            .unwrap()
+            .remove(&(service.into(), account.into()));
+        Ok(())
+    }
+}
+
+/// Canonical helper: derive the keyring account name from source id + field.
+pub fn account(source_id: &str, field: &str) -> String {
+    format!("{source_id}:{field}")
+}
+
+pub const SERVICE: &str = "mur";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_memory_roundtrip() {
+        let c = InMemoryCreds::default();
+        c.set("mur", "notion:work:access_token", "secret-123").unwrap();
+        assert_eq!(
+            c.get("mur", "notion:work:access_token").unwrap().as_deref(),
+            Some("secret-123")
+        );
+        c.delete("mur", "notion:work:access_token").unwrap();
+        assert_eq!(c.get("mur", "notion:work:access_token").unwrap(), None);
+    }
+
+    #[test]
+    fn in_memory_missing_returns_none() {
+        let c = InMemoryCreds::default();
+        assert_eq!(c.get("mur", "nope").unwrap(), None);
+    }
+
+    #[test]
+    fn account_helper_formats_canonically() {
+        assert_eq!(account("notion:work", "access_token"), "notion:work:access_token");
+    }
+}

--- a/mur-core/src/sources/credentials.rs
+++ b/mur-core/src/sources/credentials.rs
@@ -98,7 +98,8 @@ mod tests {
     #[test]
     fn in_memory_roundtrip() {
         let c = InMemoryCreds::default();
-        c.set("mur", "notion:work:access_token", "secret-123").unwrap();
+        c.set("mur", "notion:work:access_token", "secret-123")
+            .unwrap();
         assert_eq!(
             c.get("mur", "notion:work:access_token").unwrap().as_deref(),
             Some("secret-123")
@@ -115,6 +116,9 @@ mod tests {
 
     #[test]
     fn account_helper_formats_canonically() {
-        assert_eq!(account("notion:work", "access_token"), "notion:work:access_token");
+        assert_eq!(
+            account("notion:work", "access_token"),
+            "notion:work:access_token"
+        );
     }
 }

--- a/mur-core/src/sources/instance.rs
+++ b/mur-core/src/sources/instance.rs
@@ -40,8 +40,12 @@ pub struct SourceInstance {
     pub keyring_entry: Option<String>,
 }
 
-fn default_enabled() -> bool { true }
-fn default_weight() -> f32 { 1.0 }
+fn default_enabled() -> bool {
+    true
+}
+fn default_weight() -> f32 {
+    1.0
+}
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SyncState {
@@ -114,8 +118,7 @@ impl SourceInstanceStore {
         let yaml = serde_yaml::to_string(instance)?;
         let target = self.path_for(&instance.id);
         let tmp = target.with_extension("yaml.tmp");
-        fs::write(&tmp, yaml)
-            .with_context(|| format!("write {}", tmp.display()))?;
+        fs::write(&tmp, yaml).with_context(|| format!("write {}", tmp.display()))?;
         fs::rename(&tmp, &target)
             .with_context(|| format!("rename {} -> {}", tmp.display(), target.display()))?;
         Ok(())
@@ -123,12 +126,16 @@ impl SourceInstanceStore {
 
     pub fn load(&self, id: &str) -> Result<SourceInstance> {
         let p = self.path_for(id);
-        let content = fs::read_to_string(&p)
-            .with_context(|| format!("read {}", p.display()))?;
-        let inst: SourceInstance = serde_yaml::from_str(&content)
-            .with_context(|| format!("parse {}", p.display()))?;
+        let content = fs::read_to_string(&p).with_context(|| format!("read {}", p.display()))?;
+        let inst: SourceInstance =
+            serde_yaml::from_str(&content).with_context(|| format!("parse {}", p.display()))?;
         if inst.id != id {
-            bail!("file {} has id {} but we asked for {}", p.display(), inst.id, id);
+            bail!(
+                "file {} has id {} but we asked for {}",
+                p.display(),
+                inst.id,
+                id
+            );
         }
         Ok(inst)
     }

--- a/mur-core/src/sources/instance.rs
+++ b/mur-core/src/sources/instance.rs
@@ -1,0 +1,254 @@
+//! Per-source config + sync state, persisted as `~/.mur/sources/<id>.yaml`.
+//!
+//! YAML is the source of truth, mirroring the pattern/workflow yaml stores.
+
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+use super::kind::SourceKind;
+
+const MAX_ERRORS_TAIL: usize = 50;
+
+/// Complete state for one connected source.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceInstance {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub type_name: String,
+    pub kind: SourceKind,
+
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+
+    #[serde(default = "default_weight")]
+    pub weight: f32,
+
+    #[serde(default)]
+    pub scope: BTreeMap<String, serde_yaml::Value>,
+
+    #[serde(default)]
+    pub sync: SyncState,
+
+    #[serde(default)]
+    pub stats: SourceStats,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub keyring_entry: Option<String>,
+}
+
+fn default_enabled() -> bool { true }
+fn default_weight() -> f32 { 1.0 }
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SyncState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_cursor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_sync_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    #[serde(default)]
+    pub errors_tail: Vec<SyncError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncError {
+    pub at: DateTime<Utc>,
+    pub doc: String,
+    pub msg: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SourceStats {
+    #[serde(default)]
+    pub doc_count: u64,
+    #[serde(default)]
+    pub chunk_count: u64,
+    #[serde(default)]
+    pub indexed_bytes: u64,
+}
+
+impl SyncState {
+    /// Append an error, keeping the tail bounded.
+    pub fn push_error(&mut self, err: SyncError) {
+        self.errors_tail.push(err);
+        let overflow = self.errors_tail.len().saturating_sub(MAX_ERRORS_TAIL);
+        if overflow > 0 {
+            self.errors_tail.drain(0..overflow);
+        }
+    }
+}
+
+/// Filesystem store: one yaml per source at `<root>/sources/<id>.yaml`.
+pub struct SourceInstanceStore {
+    root: PathBuf,
+}
+
+impl SourceInstanceStore {
+    /// Default is `~/.mur/sources/`.
+    pub fn default_store() -> Result<Self> {
+        let root = dirs::home_dir()
+            .context("no home dir")?
+            .join(".mur")
+            .join("sources");
+        Ok(Self::new(root))
+    }
+
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    fn path_for(&self, id: &str) -> PathBuf {
+        // NOTE: ':' is allowed on macOS+Linux filesystems. Windows NTFS is not
+        // a Phase 1 target; if we pivot to Windows, sanitize here.
+        self.root.join(format!("{id}.yaml"))
+    }
+
+    pub fn save(&self, instance: &SourceInstance) -> Result<()> {
+        fs::create_dir_all(&self.root)
+            .with_context(|| format!("create dir {}", self.root.display()))?;
+        let yaml = serde_yaml::to_string(instance)?;
+        let target = self.path_for(&instance.id);
+        let tmp = target.with_extension("yaml.tmp");
+        fs::write(&tmp, yaml)
+            .with_context(|| format!("write {}", tmp.display()))?;
+        fs::rename(&tmp, &target)
+            .with_context(|| format!("rename {} -> {}", tmp.display(), target.display()))?;
+        Ok(())
+    }
+
+    pub fn load(&self, id: &str) -> Result<SourceInstance> {
+        let p = self.path_for(id);
+        let content = fs::read_to_string(&p)
+            .with_context(|| format!("read {}", p.display()))?;
+        let inst: SourceInstance = serde_yaml::from_str(&content)
+            .with_context(|| format!("parse {}", p.display()))?;
+        if inst.id != id {
+            bail!("file {} has id {} but we asked for {}", p.display(), inst.id, id);
+        }
+        Ok(inst)
+    }
+
+    pub fn delete(&self, id: &str) -> Result<()> {
+        let p = self.path_for(id);
+        if p.exists() {
+            fs::remove_file(&p).with_context(|| format!("remove {}", p.display()))?;
+        }
+        Ok(())
+    }
+
+    pub fn list(&self) -> Result<Vec<SourceInstance>> {
+        if !self.root.exists() {
+            return Ok(vec![]);
+        }
+        let mut out = Vec::new();
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            let p = entry.path();
+            if p.extension().and_then(|e| e.to_str()) != Some("yaml") {
+                continue;
+            }
+            let content = fs::read_to_string(&p)?;
+            match serde_yaml::from_str::<SourceInstance>(&content) {
+                Ok(inst) => out.push(inst),
+                Err(e) => {
+                    tracing::warn!(file = %p.display(), error = %e, "skipping malformed source yaml");
+                }
+            }
+        }
+        out.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_instance(id: &str) -> SourceInstance {
+        SourceInstance {
+            id: id.into(),
+            type_name: "obsidian".into(),
+            kind: SourceKind::PullIndex,
+            enabled: true,
+            weight: 1.0,
+            scope: BTreeMap::new(),
+            sync: SyncState::default(),
+            stats: SourceStats::default(),
+            keyring_entry: None,
+        }
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let store = SourceInstanceStore::new(tmp.path().to_path_buf());
+        let inst = sample_instance("obsidian-main");
+        store.save(&inst).unwrap();
+        let loaded = store.load("obsidian-main").unwrap();
+        assert_eq!(loaded.id, "obsidian-main");
+        assert_eq!(loaded.type_name, "obsidian");
+        assert!(loaded.enabled);
+    }
+
+    #[test]
+    fn list_returns_sorted_instances() {
+        let tmp = TempDir::new().unwrap();
+        let store = SourceInstanceStore::new(tmp.path().to_path_buf());
+        store.save(&sample_instance("b-second")).unwrap();
+        store.save(&sample_instance("a-first")).unwrap();
+        let items = store.list().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].id, "a-first");
+        assert_eq!(items[1].id, "b-second");
+    }
+
+    #[test]
+    fn delete_removes_file() {
+        let tmp = TempDir::new().unwrap();
+        let store = SourceInstanceStore::new(tmp.path().to_path_buf());
+        store.save(&sample_instance("obsidian-main")).unwrap();
+        store.delete("obsidian-main").unwrap();
+        assert!(store.load("obsidian-main").is_err());
+    }
+
+    #[test]
+    fn delete_missing_is_ok() {
+        let tmp = TempDir::new().unwrap();
+        let store = SourceInstanceStore::new(tmp.path().to_path_buf());
+        store.delete("never-existed").unwrap();
+    }
+
+    #[test]
+    fn errors_tail_bounded_to_fifty() {
+        let mut s = SyncState::default();
+        for i in 0..60 {
+            s.push_error(SyncError {
+                at: Utc::now(),
+                doc: format!("doc-{i}"),
+                msg: "boom".into(),
+            });
+        }
+        assert_eq!(s.errors_tail.len(), MAX_ERRORS_TAIL);
+        assert_eq!(s.errors_tail[0].doc, "doc-10");
+        assert_eq!(s.errors_tail.last().unwrap().doc, "doc-59");
+    }
+
+    #[test]
+    fn load_rejects_id_mismatch() {
+        let tmp = TempDir::new().unwrap();
+        let store = SourceInstanceStore::new(tmp.path().to_path_buf());
+        store.save(&sample_instance("real-id")).unwrap();
+        fs::rename(
+            tmp.path().join("real-id.yaml"),
+            tmp.path().join("other-id.yaml"),
+        )
+        .unwrap();
+        assert!(store.load("other-id").is_err());
+    }
+}

--- a/mur-core/src/sources/kind.rs
+++ b/mur-core/src/sources/kind.rs
@@ -15,6 +15,9 @@ pub enum SourceKind {
 }
 
 impl SourceKind {
+    /// Used by the P1.3+ orchestrator to dispatch between local search and
+    /// federated query paths.
+    #[allow(dead_code)]
     pub fn is_pull_index(self) -> bool {
         matches!(self, SourceKind::PullIndex)
     }

--- a/mur-core/src/sources/kind.rs
+++ b/mur-core/src/sources/kind.rs
@@ -1,0 +1,40 @@
+//! Adapter behaviour kind. Phase 1 only implements `PullIndex`; the
+//! `FederatedQuery` variant exists so MCP adapters (P2+) compile without
+//! changing the trait signature.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceKind {
+    /// Adapter pulls documents into mur's vector index and answers via local search.
+    PullIndex,
+    /// Adapter does not hand over documents; queries are forwarded to the
+    /// adapter at search time (e.g., NotebookLM via MCP).
+    FederatedQuery,
+}
+
+impl SourceKind {
+    pub fn is_pull_index(self) -> bool {
+        matches!(self, SourceKind::PullIndex)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pull_index_is_pull_index() {
+        assert!(SourceKind::PullIndex.is_pull_index());
+        assert!(!SourceKind::FederatedQuery.is_pull_index());
+    }
+
+    #[test]
+    fn serde_roundtrip_snake_case() {
+        let s = serde_yaml::to_string(&SourceKind::PullIndex).unwrap();
+        assert!(s.contains("pull_index"));
+        let back: SourceKind = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(back, SourceKind::PullIndex);
+    }
+}

--- a/mur-core/src/sources/mod.rs
+++ b/mur-core/src/sources/mod.rs
@@ -17,7 +17,7 @@ pub mod sync;
 pub mod types;
 
 pub use kind::SourceKind;
-pub use types::{Chunk, DocRef, Document, DocumentBody, SyncCursor};
+pub use types::{Chunk, DocRef, Document, SyncCursor};
 
 /// Adapter interface. Implementors are stateless with respect to the
 /// orchestrator; all cursor state is persisted in `SourceInstance`.
@@ -26,10 +26,12 @@ pub trait KnowledgeSource: Send + Sync {
     /// Stable id, e.g. `"notion:work"`.
     fn id(&self) -> &str;
 
-    /// Behaviour kind.
+    /// Behaviour kind — used by the orchestrator router in P1.3+.
+    #[allow(dead_code)]
     fn kind(&self) -> SourceKind;
 
-    /// User-configurable multiplicative weight (from `SourceInstance`).
+    /// User-configurable multiplicative weight — applied at search-time in P1.3+.
+    #[allow(dead_code)]
     fn weight(&self) -> f32;
 
     /// Incremental listing. `cursor == None` on first sync.
@@ -42,8 +44,10 @@ pub trait KnowledgeSource: Send + Sync {
     /// Adapter-specific chunking.
     fn chunk(&self, doc: &Document) -> Result<Vec<Chunk>>;
 
-    /// External ids this adapter has deleted since `cursor`. The orchestrator
-    /// always runs a set-diff fallback, so returning `Ok(vec![])` is safe.
+    /// External ids deleted since `cursor` — used by the P1.3 orchestrator for
+    /// incremental deletes. Returning `Ok(vec![])` is safe; orchestrator does
+    /// set-diff fallback.
+    #[allow(dead_code)]
     async fn list_deleted_since(&self, _cursor: Option<SyncCursor>) -> Result<Vec<String>> {
         Ok(vec![])
     }
@@ -51,8 +55,12 @@ pub trait KnowledgeSource: Send + Sync {
 
 /// Closed-set registry. Phase 1 hardcodes the three adapter type names;
 /// each adapter's factory function lives alongside the adapter.
+// Used by CLI validation in P1.3+; test below keeps it exercised.
+#[allow(dead_code)]
 pub const KNOWN_ADAPTER_TYPES: &[&str] = &["obsidian", "notion", "joplin"];
 
+// Called by CLI `sources add` validation in P1.3+.
+#[allow(dead_code)]
 pub fn is_known_adapter_type(t: &str) -> bool {
     KNOWN_ADAPTER_TYPES.contains(&t)
 }

--- a/mur-core/src/sources/mod.rs
+++ b/mur-core/src/sources/mod.rs
@@ -2,3 +2,4 @@
 pub mod types;
 pub mod kind;
 pub mod credentials;
+pub mod instance;

--- a/mur-core/src/sources/mod.rs
+++ b/mur-core/src/sources/mod.rs
@@ -13,6 +13,7 @@ pub mod chunker;
 pub mod credentials;
 pub mod instance;
 pub mod kind;
+pub mod sync;
 pub mod types;
 
 pub use kind::SourceKind;

--- a/mur-core/src/sources/mod.rs
+++ b/mur-core/src/sources/mod.rs
@@ -30,10 +30,8 @@ pub trait KnowledgeSource: Send + Sync {
     fn weight(&self) -> f32;
 
     /// Incremental listing. `cursor == None` on first sync.
-    async fn list_documents(
-        &self,
-        cursor: Option<SyncCursor>,
-    ) -> Result<(Vec<DocRef>, SyncCursor)>;
+    async fn list_documents(&self, cursor: Option<SyncCursor>)
+    -> Result<(Vec<DocRef>, SyncCursor)>;
 
     /// Fetch full content for one document.
     async fn fetch(&self, doc_ref: &DocRef) -> Result<Document>;
@@ -43,10 +41,7 @@ pub trait KnowledgeSource: Send + Sync {
 
     /// External ids this adapter has deleted since `cursor`. The orchestrator
     /// always runs a set-diff fallback, so returning `Ok(vec![])` is safe.
-    async fn list_deleted_since(
-        &self,
-        _cursor: Option<SyncCursor>,
-    ) -> Result<Vec<String>> {
+    async fn list_deleted_since(&self, _cursor: Option<SyncCursor>) -> Result<Vec<String>> {
         Ok(vec![])
     }
 }

--- a/mur-core/src/sources/mod.rs
+++ b/mur-core/src/sources/mod.rs
@@ -1,2 +1,3 @@
 //! External knowledge sources pipeline. See design spec.
 pub mod types;
+pub mod kind;

--- a/mur-core/src/sources/mod.rs
+++ b/mur-core/src/sources/mod.rs
@@ -1,0 +1,2 @@
+//! External knowledge sources pipeline. See design spec.
+pub mod types;

--- a/mur-core/src/sources/mod.rs
+++ b/mur-core/src/sources/mod.rs
@@ -8,6 +8,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
+pub mod chunker;
 pub mod credentials;
 pub mod instance;
 pub mod kind;

--- a/mur-core/src/sources/mod.rs
+++ b/mur-core/src/sources/mod.rs
@@ -8,6 +8,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
+pub mod adapters;
 pub mod chunker;
 pub mod credentials;
 pub mod instance;

--- a/mur-core/src/sources/mod.rs
+++ b/mur-core/src/sources/mod.rs
@@ -1,3 +1,4 @@
 //! External knowledge sources pipeline. See design spec.
 pub mod types;
 pub mod kind;
+pub mod credentials;

--- a/mur-core/src/sources/mod.rs
+++ b/mur-core/src/sources/mod.rs
@@ -1,5 +1,73 @@
-//! External knowledge sources pipeline. See design spec.
-pub mod types;
-pub mod kind;
+//! External knowledge sources pipeline.
+//!
+//! A `KnowledgeSource` is a typed connection to a note app or RAG system. The
+//! sync engine iterates documents, chunks them, embeds them, and writes to a
+//! `VectorStore`. P1.1 defines the trait + registry skeleton only — adapters
+//! arrive in P1.2 (Obsidian) and P1.4 (Notion, Joplin).
+
+use anyhow::Result;
+use async_trait::async_trait;
+
 pub mod credentials;
 pub mod instance;
+pub mod kind;
+pub mod types;
+
+pub use kind::SourceKind;
+pub use types::{Chunk, DocRef, Document, DocumentBody, SyncCursor};
+
+/// Adapter interface. Implementors are stateless with respect to the
+/// orchestrator; all cursor state is persisted in `SourceInstance`.
+#[async_trait]
+pub trait KnowledgeSource: Send + Sync {
+    /// Stable id, e.g. `"notion:work"`.
+    fn id(&self) -> &str;
+
+    /// Behaviour kind.
+    fn kind(&self) -> SourceKind;
+
+    /// User-configurable multiplicative weight (from `SourceInstance`).
+    fn weight(&self) -> f32;
+
+    /// Incremental listing. `cursor == None` on first sync.
+    async fn list_documents(
+        &self,
+        cursor: Option<SyncCursor>,
+    ) -> Result<(Vec<DocRef>, SyncCursor)>;
+
+    /// Fetch full content for one document.
+    async fn fetch(&self, doc_ref: &DocRef) -> Result<Document>;
+
+    /// Adapter-specific chunking.
+    fn chunk(&self, doc: &Document) -> Result<Vec<Chunk>>;
+
+    /// External ids this adapter has deleted since `cursor`. The orchestrator
+    /// always runs a set-diff fallback, so returning `Ok(vec![])` is safe.
+    async fn list_deleted_since(
+        &self,
+        _cursor: Option<SyncCursor>,
+    ) -> Result<Vec<String>> {
+        Ok(vec![])
+    }
+}
+
+/// Closed-set registry. Phase 1 hardcodes the three adapter type names;
+/// each adapter's factory function lives alongside the adapter.
+pub const KNOWN_ADAPTER_TYPES: &[&str] = &["obsidian", "notion", "joplin"];
+
+pub fn is_known_adapter_type(t: &str) -> bool {
+    KNOWN_ADAPTER_TYPES.contains(&t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_adapter_types_sanity() {
+        assert!(is_known_adapter_type("obsidian"));
+        assert!(is_known_adapter_type("notion"));
+        assert!(is_known_adapter_type("joplin"));
+        assert!(!is_known_adapter_type("onenote"));
+    }
+}

--- a/mur-core/src/sources/sync.rs
+++ b/mur-core/src/sources/sync.rs
@@ -1,0 +1,165 @@
+//! Sync orchestrator.
+//!
+//! Drives one adapter through list → fetch → chunk → embed → upsert, updates
+//! the `SourceInstance` yaml cursor/stats, and detects deletions via a
+//! set-diff against the vector store. P1.2 is single-source / sequential /
+//! manual — `--watch` and cross-source parallelism arrive in P1.4.
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use std::sync::Arc;
+
+use crate::sources::KnowledgeSource;
+use crate::sources::instance::{SourceInstance, SourceInstanceStore, SyncError};
+use crate::sources::types::SyncCursor;
+use crate::store::embedding::{EmbeddingConfig, embed};
+use crate::store::vector::{EmbeddedChunk, VectorStore};
+
+/// High-level summary returned by `sync_source`.
+#[derive(Debug, Default)]
+pub struct SyncReport {
+    pub docs_synced: usize,
+    pub chunks_emitted: usize,
+    pub docs_deleted: usize,
+    pub errors: Vec<String>,
+}
+
+/// Run one full sync cycle for a single source.
+pub async fn sync_source(
+    adapter: &dyn KnowledgeSource,
+    instance: &mut SourceInstance,
+    instance_store: &SourceInstanceStore,
+    vector_store: Arc<dyn VectorStore>,
+    embedding_cfg: &EmbeddingConfig,
+    full: bool,
+) -> Result<SyncReport> {
+    let source_id = adapter.id().to_string();
+    let cursor_in = if full {
+        None
+    } else {
+        instance
+            .sync
+            .last_cursor
+            .clone()
+            .map(SyncCursor)
+            .filter(|c| !c.is_empty())
+    };
+
+    tracing::info!(source_id = %source_id, full = full, "sync: start");
+
+    let (doc_refs, new_cursor) = adapter
+        .list_documents(cursor_in)
+        .await
+        .context("adapter.list_documents")?;
+
+    let mut report = SyncReport::default();
+
+    for doc_ref in &doc_refs {
+        match fetch_chunk_embed_upsert(adapter, doc_ref, &*vector_store, embedding_cfg).await {
+            Ok(n_chunks) => {
+                report.docs_synced += 1;
+                report.chunks_emitted += n_chunks;
+            }
+            Err(e) => {
+                let msg = format!("{e:#}");
+                tracing::warn!(
+                    source_id = %source_id,
+                    doc = %doc_ref.external_id,
+                    error = %msg,
+                    "sync: doc error"
+                );
+                report.errors.push(msg.clone());
+                instance.sync.push_error(SyncError {
+                    at: Utc::now(),
+                    doc: doc_ref.external_id.clone(),
+                    msg,
+                });
+            }
+        }
+    }
+
+    // Deletion detection runs only in full mode.
+    if full {
+        let indexed = vector_store
+            .list_external_ids(&source_id)
+            .await
+            .context("list_external_ids")?;
+        let current: std::collections::HashSet<String> =
+            doc_refs.iter().map(|d| d.external_id.clone()).collect();
+        let deleted: Vec<String> = indexed.into_iter().filter(|id| !current.contains(id)).collect();
+        if !deleted.is_empty() {
+            vector_store
+                .delete_by_external_ids(&source_id, &deleted)
+                .await
+                .context("delete_by_external_ids")?;
+            report.docs_deleted = deleted.len();
+        }
+    }
+
+    instance.sync.last_cursor = if new_cursor.is_empty() {
+        None
+    } else {
+        Some(new_cursor.0)
+    };
+    instance.sync.last_sync_at = Some(Utc::now());
+    instance.sync.last_error = report.errors.last().cloned();
+    instance.stats.doc_count = report.docs_synced as u64;
+    instance.stats.chunk_count = report.chunks_emitted as u64;
+
+    instance_store
+        .save(instance)
+        .context("persist SourceInstance yaml")?;
+
+    tracing::info!(
+        source_id = %source_id,
+        docs = report.docs_synced,
+        chunks = report.chunks_emitted,
+        deleted = report.docs_deleted,
+        errors = report.errors.len(),
+        "sync: complete"
+    );
+
+    Ok(report)
+}
+
+async fn fetch_chunk_embed_upsert(
+    adapter: &dyn KnowledgeSource,
+    doc_ref: &crate::sources::types::DocRef,
+    vector_store: &dyn VectorStore,
+    embedding_cfg: &EmbeddingConfig,
+) -> Result<usize> {
+    let doc = adapter.fetch(doc_ref).await.context("adapter.fetch")?;
+    let chunks = adapter.chunk(&doc).context("adapter.chunk")?;
+    if chunks.is_empty() {
+        return Ok(0);
+    }
+    // Delete-by-external_id before upserting (handles the case where the same
+    // document's chunk set changed — old chunk_ids no longer valid).
+    vector_store
+        .delete_by_external_ids(&doc.source_id, &[doc.external_id.clone()])
+        .await
+        .context("delete old chunks for doc")?;
+    let mut embedded: Vec<EmbeddedChunk> = Vec::with_capacity(chunks.len());
+    for c in chunks {
+        let vec = embed(&c.text, embedding_cfg)
+            .await
+            .with_context(|| format!("embed chunk of doc {}", doc.external_id))?;
+        embedded.push(EmbeddedChunk {
+            chunk_id: c.chunk_id,
+            source_id: c.source_id,
+            external_id: c.external_id,
+            ordinal: c.ordinal,
+            text: c.text,
+            heading_path: c.heading_path,
+            char_range: c.char_range,
+            updated_at: c.updated_at,
+            embedding: vec,
+        });
+    }
+    let n = embedded.len();
+    vector_store
+        .upsert(&embedded)
+        .await
+        .context("vector_store.upsert")?;
+    Ok(n)
+}

--- a/mur-core/src/sources/sync.rs
+++ b/mur-core/src/sources/sync.rs
@@ -136,7 +136,7 @@ async fn fetch_chunk_embed_upsert(
     // Delete-by-external_id before upserting (handles the case where the same
     // document's chunk set changed — old chunk_ids no longer valid).
     vector_store
-        .delete_by_external_ids(&doc.source_id, &[doc.external_id.clone()])
+        .delete_by_external_ids(&doc.source_id, std::slice::from_ref(&doc.external_id))
         .await
         .context("delete old chunks for doc")?;
     let mut embedded: Vec<EmbeddedChunk> = Vec::with_capacity(chunks.len());

--- a/mur-core/src/sources/sync.rs
+++ b/mur-core/src/sources/sync.rs
@@ -86,7 +86,10 @@ pub async fn sync_source(
             .context("list_external_ids")?;
         let current: std::collections::HashSet<String> =
             doc_refs.iter().map(|d| d.external_id.clone()).collect();
-        let deleted: Vec<String> = indexed.into_iter().filter(|id| !current.contains(id)).collect();
+        let deleted: Vec<String> = indexed
+            .into_iter()
+            .filter(|id| !current.contains(id))
+            .collect();
         if !deleted.is_empty() {
             vector_store
                 .delete_by_external_ids(&source_id, &deleted)

--- a/mur-core/src/sources/types.rs
+++ b/mur-core/src/sources/types.rs
@@ -34,9 +34,13 @@ pub struct Document {
     pub external_id: String,
     pub title: String,
     pub body: DocumentBody,
+    // url, tags, metadata are surfaced in search results in P1.3+.
+    #[allow(dead_code)]
     pub url: Option<String>,
     pub updated_at: DateTime<Utc>,
+    #[allow(dead_code)]
     pub tags: Vec<String>,
+    #[allow(dead_code)]
     pub metadata: serde_json::Value,
 }
 
@@ -44,14 +48,18 @@ pub struct Document {
 #[derive(Debug, Clone)]
 pub enum DocumentBody {
     Markdown(String),
+    /// Used by plain-text sources (P1.3+).
+    #[allow(dead_code)]
     PlainText(String),
     /// Notion blocks — serialized as opaque JSON so we don't depend on the
-    /// Notion SDK crate from `types.rs`.
+    /// Notion SDK crate from `types.rs`. Constructed by Notion adapter (P1.4).
+    #[allow(dead_code)]
     NotionBlocks(serde_json::Value),
 }
 
 impl DocumentBody {
-    /// Returns the content as plaintext suitable for embedding.
+    /// Returns the content as plaintext for embedding. Called by chunkers in P1.3+.
+    #[allow(dead_code)]
     pub fn as_plain_text(&self) -> String {
         match self {
             DocumentBody::Markdown(s) | DocumentBody::PlainText(s) => s.clone(),

--- a/mur-core/src/sources/types.rs
+++ b/mur-core/src/sources/types.rs
@@ -1,0 +1,126 @@
+//! Core types passed through the sources pipeline.
+//!
+//! These live in `mur-core` (Phase 1). If a future mur-server integration
+//! needs them, hoist to `mur-common` then.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Opaque cursor returned by `KnowledgeSource::list_documents`. Each adapter
+/// defines its own encoding (e.g. Notion: RFC3339 timestamp, Joplin: epoch-ms).
+/// Orchestrator stores it verbatim in the source yaml and passes back next sync.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SyncCursor(pub String);
+
+impl SyncCursor {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// Lightweight reference to a document that hasn't been fetched yet.
+#[derive(Debug, Clone)]
+pub struct DocRef {
+    pub external_id: String,
+    pub title: Option<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A full document payload.
+#[derive(Debug, Clone)]
+pub struct Document {
+    pub source_id: String,
+    pub external_id: String,
+    pub title: String,
+    pub body: DocumentBody,
+    pub url: Option<String>,
+    pub updated_at: DateTime<Utc>,
+    pub tags: Vec<String>,
+    pub metadata: serde_json::Value,
+}
+
+/// Body form; adapters pick the variant that preserves the most fidelity.
+#[derive(Debug, Clone)]
+pub enum DocumentBody {
+    Markdown(String),
+    PlainText(String),
+    /// Notion blocks — serialized as opaque JSON so we don't depend on the
+    /// Notion SDK crate from `types.rs`.
+    NotionBlocks(serde_json::Value),
+}
+
+impl DocumentBody {
+    /// Returns the content as plaintext suitable for embedding.
+    pub fn as_plain_text(&self) -> String {
+        match self {
+            DocumentBody::Markdown(s) | DocumentBody::PlainText(s) => s.clone(),
+            DocumentBody::NotionBlocks(_) => {
+                // Real extraction lives in the Notion chunker (P1.4). For P1.1
+                // we expose an empty fallback — no adapter produces this variant yet.
+                String::new()
+            }
+        }
+    }
+}
+
+/// Pre-embedding chunk.
+#[derive(Debug, Clone)]
+pub struct Chunk {
+    pub chunk_id: String,
+    pub source_id: String,
+    pub external_id: String,
+    pub ordinal: usize,
+    pub text: String,
+    pub heading_path: Vec<String>,
+    pub char_range: (usize, usize),
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Chunk {
+    /// Build a chunk with a fresh UUID v4 chunk_id.
+    pub fn new(
+        source_id: impl Into<String>,
+        external_id: impl Into<String>,
+        ordinal: usize,
+        text: impl Into<String>,
+        heading_path: Vec<String>,
+        char_range: (usize, usize),
+        updated_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            chunk_id: Uuid::new_v4().to_string(),
+            source_id: source_id.into(),
+            external_id: external_id.into(),
+            ordinal,
+            text: text.into(),
+            heading_path,
+            char_range,
+            updated_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_cursor_default_is_empty() {
+        assert!(SyncCursor::default().is_empty());
+    }
+
+    #[test]
+    fn document_body_markdown_is_plain_text() {
+        let b = DocumentBody::Markdown("# hi\nbody".into());
+        assert_eq!(b.as_plain_text(), "# hi\nbody");
+    }
+
+    #[test]
+    fn chunk_new_assigns_unique_id() {
+        let now = Utc::now();
+        let a = Chunk::new("s", "d", 0, "t", vec![], (0, 1), now);
+        let b = Chunk::new("s", "d", 0, "t", vec![], (0, 1), now);
+        assert_ne!(a.chunk_id, b.chunk_id);
+    }
+}

--- a/mur-core/src/store/mod.rs
+++ b/mur-core/src/store/mod.rs
@@ -5,7 +5,7 @@
 pub mod config;
 pub mod embedding;
 pub mod exchange;
-pub mod lancedb;
+pub mod vector;
 pub mod pipeline_yaml;
 pub mod spot_rate;
 pub mod workflow_yaml;

--- a/mur-core/src/store/mod.rs
+++ b/mur-core/src/store/mod.rs
@@ -5,8 +5,8 @@
 pub mod config;
 pub mod embedding;
 pub mod exchange;
-pub mod vector;
 pub mod pipeline_yaml;
 pub mod spot_rate;
+pub mod vector;
 pub mod workflow_yaml;
 pub mod yaml;

--- a/mur-core/src/store/vector/factory.rs
+++ b/mur-core/src/store/vector/factory.rs
@@ -1,1 +1,67 @@
-//! Vector store factory. (fleshed out in Task 6)
+//! Vector store factory.
+//!
+//! Returns an `Arc<dyn VectorStore>` selected by `Config::storage::vector_backend`.
+//! Phase 1.1 supports `"lancedb"`; `"qdrant"` arrives in P1.3.
+
+use anyhow::{Context, Result, bail};
+use mur_common::config::Config;
+use std::path::Path;
+use std::sync::Arc;
+
+use super::VectorStore;
+use super::lancedb::LanceDbStore;
+
+pub async fn get_vector_store(
+    cfg: &Config,
+    index_dir: &Path,
+) -> Result<Arc<dyn VectorStore>> {
+    match cfg.storage.vector_backend.as_str() {
+        "lancedb" => {
+            let store = LanceDbStore::open(index_dir, cfg.embedding.dimensions as i32)
+                .await
+                .context("opening LanceDB vector store")?;
+            Ok(Arc::new(store))
+        }
+        "qdrant" => bail!("Qdrant backend is not available until P1.3"),
+        other => bail!("unknown storage.vector_backend: {other}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn dims_128_cfg() -> Config {
+        let mut c = Config::default();
+        c.embedding.dimensions = 128;
+        c
+    }
+
+    #[tokio::test]
+    async fn factory_returns_lancedb_by_default() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = dims_128_cfg();
+        let store = get_vector_store(&cfg, tmp.path()).await.unwrap();
+        // count() is stubbed (bail!s); we only assert the method is callable.
+        let _ = store.count(None).await;
+    }
+
+    #[tokio::test]
+    async fn factory_rejects_qdrant_in_p1_1() {
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = dims_128_cfg();
+        cfg.storage.vector_backend = "qdrant".into();
+        let err = get_vector_store(&cfg, tmp.path()).await.err().unwrap();
+        assert!(err.to_string().contains("not available until P1.3"));
+    }
+
+    #[tokio::test]
+    async fn factory_rejects_unknown_backend() {
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = dims_128_cfg();
+        cfg.storage.vector_backend = "bogus".into();
+        let err = get_vector_store(&cfg, tmp.path()).await.err().unwrap();
+        assert!(err.to_string().contains("unknown storage.vector_backend"));
+    }
+}

--- a/mur-core/src/store/vector/factory.rs
+++ b/mur-core/src/store/vector/factory.rs
@@ -11,10 +11,8 @@ use std::sync::Arc;
 use super::VectorStore;
 use super::lancedb::LanceDbStore;
 
-pub async fn get_vector_store(
-    cfg: &Config,
-    index_dir: &Path,
-) -> Result<Arc<dyn VectorStore>> {
+#[allow(dead_code)] // called by sources module in P1.2+; factory tests exercise it directly
+pub async fn get_vector_store(cfg: &Config, index_dir: &Path) -> Result<Arc<dyn VectorStore>> {
     match cfg.storage.vector_backend.as_str() {
         "lancedb" => {
             let store = LanceDbStore::open(index_dir, cfg.embedding.dimensions as i32)

--- a/mur-core/src/store/vector/factory.rs
+++ b/mur-core/src/store/vector/factory.rs
@@ -1,0 +1,1 @@
+//! Vector store factory. (fleshed out in Task 6)

--- a/mur-core/src/store/vector/lancedb.rs
+++ b/mur-core/src/store/vector/lancedb.rs
@@ -275,8 +275,8 @@ pub struct SearchResult {
     pub item_type: String,
 }
 
-use async_trait::async_trait;
 use super::{EmbeddedChunk, Hit, SearchFilter, VectorStore};
+use async_trait::async_trait;
 
 #[async_trait]
 impl VectorStore for LanceDbStore {
@@ -321,7 +321,9 @@ impl VectorStore for LanceDbStore {
 // Compile-time assertion that LanceDbStore implements VectorStore.
 const _: () = {
     fn _assert_impl<T: VectorStore>() {}
-    fn _check() { _assert_impl::<LanceDbStore>(); }
+    fn _check() {
+        _assert_impl::<LanceDbStore>();
+    }
 };
 
 #[cfg(test)]

--- a/mur-core/src/store/vector/lancedb.rs
+++ b/mur-core/src/store/vector/lancedb.rs
@@ -467,7 +467,7 @@ impl VectorStore for LanceDbStore {
                     serde_json::from_str(heading_paths.value(i)).unwrap_or_default();
                 let ms = updated_at_ms.value(i);
                 let ts = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms)
-                    .unwrap_or_else(|| chrono::Utc::now());
+                    .unwrap_or_else(chrono::Utc::now);
                 hits.push(Hit {
                     chunk_id: chunk_ids.value(i).to_string(),
                     source_id: source_ids.value(i).to_string(),

--- a/mur-core/src/store/vector/lancedb.rs
+++ b/mur-core/src/store/vector/lancedb.rs
@@ -484,14 +484,39 @@ impl VectorStore for LanceDbStore {
 
     async fn delete_by_external_ids(
         &self,
-        _source_id: &str,
-        _external_ids: &[String],
+        source_id: &str,
+        external_ids: &[String],
     ) -> Result<()> {
-        anyhow::bail!("LanceDbStore::delete_by_external_ids is a stub until P1.2")
+        if external_ids.is_empty() {
+            return Ok(());
+        }
+        let tables = self.db.table_names().execute().await?;
+        if !tables.contains(&SOURCES_TABLE.to_string()) {
+            return Ok(());
+        }
+        let table = self.db.open_table(SOURCES_TABLE).execute().await?;
+        let escaped: Vec<String> = external_ids
+            .iter()
+            .map(|e| format!("'{}'", e.replace('\'', "''")))
+            .collect();
+        let predicate = format!(
+            "source_id = '{}' AND external_id IN ({})",
+            source_id.replace('\'', "''"),
+            escaped.join(",")
+        );
+        table.delete(&predicate).await?;
+        Ok(())
     }
 
-    async fn delete_by_source(&self, _source_id: &str) -> Result<()> {
-        anyhow::bail!("LanceDbStore::delete_by_source is a stub until P1.2")
+    async fn delete_by_source(&self, source_id: &str) -> Result<()> {
+        let tables = self.db.table_names().execute().await?;
+        if !tables.contains(&SOURCES_TABLE.to_string()) {
+            return Ok(());
+        }
+        let table = self.db.open_table(SOURCES_TABLE).execute().await?;
+        let predicate = format!("source_id = '{}'", source_id.replace('\'', "''"));
+        table.delete(&predicate).await?;
+        Ok(())
     }
 
     async fn list_external_ids(&self, source_id: &str) -> Result<Vec<String>> {
@@ -836,6 +861,53 @@ mod tests {
         let other =
             <LanceDbStore as super::VectorStore>::count(&store, Some("nope")).await.unwrap();
         assert_eq!(other, 0);
+    }
+
+    #[tokio::test]
+    async fn sources_delete_operations_work() {
+        let tmp = TempDir::new().unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        let now = chrono::Utc::now();
+        let zeros = vec![0.0_f32; TEST_DIM as usize];
+
+        let chunks: Vec<super::EmbeddedChunk> = (0..4)
+            .map(|i| super::EmbeddedChunk {
+                chunk_id: format!("cid-{i}"),
+                source_id: if i < 2 { "src:a".into() } else { "src:b".into() },
+                external_id: format!("doc-{i}"),
+                ordinal: 0,
+                text: "x".into(),
+                heading_path: vec![],
+                char_range: (0, 1),
+                updated_at: now,
+                embedding: zeros.clone(),
+            })
+            .collect();
+
+        <LanceDbStore as super::VectorStore>::upsert(&store, &chunks).await.unwrap();
+
+        <LanceDbStore as super::VectorStore>::delete_by_external_ids(
+            &store,
+            "src:a",
+            &["doc-0".to_string()],
+        )
+        .await
+        .unwrap();
+        let remaining_a = <LanceDbStore as super::VectorStore>::list_external_ids(&store, "src:a")
+            .await
+            .unwrap();
+        assert_eq!(remaining_a, vec!["doc-1"]);
+
+        <LanceDbStore as super::VectorStore>::delete_by_source(&store, "src:b").await.unwrap();
+        let remaining_b = <LanceDbStore as super::VectorStore>::list_external_ids(&store, "src:b")
+            .await
+            .unwrap();
+        assert!(remaining_b.is_empty());
+
+        let still_a = <LanceDbStore as super::VectorStore>::list_external_ids(&store, "src:a")
+            .await
+            .unwrap();
+        assert_eq!(still_a, vec!["doc-1"]);
     }
 
     #[tokio::test]

--- a/mur-core/src/store/vector/lancedb.rs
+++ b/mur-core/src/store/vector/lancedb.rs
@@ -494,8 +494,38 @@ impl VectorStore for LanceDbStore {
         anyhow::bail!("LanceDbStore::delete_by_source is a stub until P1.2")
     }
 
-    async fn list_external_ids(&self, _source_id: &str) -> Result<Vec<String>> {
-        anyhow::bail!("LanceDbStore::list_external_ids is a stub until P1.2")
+    async fn list_external_ids(&self, source_id: &str) -> Result<Vec<String>> {
+        use futures::TryStreamExt;
+        use lancedb::query::{ExecutableQuery, QueryBase};
+
+        let tables = self.db.table_names().execute().await?;
+        if !tables.contains(&SOURCES_TABLE.to_string()) {
+            return Ok(vec![]);
+        }
+        let table = self.db.open_table(SOURCES_TABLE).execute().await?;
+        let batches = table
+            .query()
+            .only_if(format!(
+                "source_id = '{}'",
+                source_id.replace('\'', "''")
+            ))
+            .select(lancedb::query::Select::Columns(vec!["external_id".to_string()]))
+            .execute()
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let mut set: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for batch in &batches {
+            let col = batch
+                .column_by_name("external_id")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .context("column external_id missing")?;
+            for i in 0..batch.num_rows() {
+                set.insert(col.value(i).to_string());
+            }
+        }
+        Ok(set.into_iter().collect())
     }
 
     async fn count(&self, source_id: Option<&str>) -> Result<usize> {
@@ -763,6 +793,49 @@ mod tests {
         assert_eq!(hits[0].source_id, "obsidian:test");
         assert_eq!(hits[0].external_id, "doc-a");
         assert_eq!(hits[0].heading_path, vec!["Section".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn sources_list_external_ids_and_count_work() {
+        let tmp = TempDir::new().unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        let now = chrono::Utc::now();
+        let zeros = vec![0.0_f32; TEST_DIM as usize];
+
+        let chunks: Vec<super::EmbeddedChunk> = (0..3)
+            .map(|i| super::EmbeddedChunk {
+                chunk_id: format!("cid-{i}"),
+                source_id: "obsidian:test".into(),
+                external_id: format!("doc-{i}"),
+                ordinal: 0,
+                text: "x".into(),
+                heading_path: vec![],
+                char_range: (0, 1),
+                updated_at: now,
+                embedding: zeros.clone(),
+            })
+            .collect();
+
+        <LanceDbStore as super::VectorStore>::upsert(&store, &chunks).await.unwrap();
+
+        let ids = <LanceDbStore as super::VectorStore>::list_external_ids(&store, "obsidian:test")
+            .await
+            .unwrap();
+        let mut sorted = ids.clone();
+        sorted.sort();
+        assert_eq!(sorted, vec!["doc-0", "doc-1", "doc-2"]);
+
+        let all = <LanceDbStore as super::VectorStore>::count(&store, None).await.unwrap();
+        assert_eq!(all, 3);
+
+        let scoped = <LanceDbStore as super::VectorStore>::count(&store, Some("obsidian:test"))
+            .await
+            .unwrap();
+        assert_eq!(scoped, 3);
+
+        let other =
+            <LanceDbStore as super::VectorStore>::count(&store, Some("nope")).await.unwrap();
+        assert_eq!(other, 0);
     }
 
     #[tokio::test]

--- a/mur-core/src/store/vector/lancedb.rs
+++ b/mur-core/src/store/vector/lancedb.rs
@@ -16,6 +16,32 @@ use std::sync::Arc;
 
 const TABLE_NAME: &str = "patterns";
 
+/// Name of the LanceDB table that stores source chunks (separate from `patterns`).
+pub const SOURCES_TABLE: &str = "sources";
+
+/// Arrow schema for the sources table.
+pub fn sources_schema(dimensions: i32) -> Schema {
+    Schema::new(vec![
+        Field::new("chunk_id", DataType::Utf8, false),
+        Field::new("source_id", DataType::Utf8, false),
+        Field::new("external_id", DataType::Utf8, false),
+        Field::new("ordinal", DataType::UInt64, false),
+        Field::new("text", DataType::Utf8, false),
+        Field::new("heading_path", DataType::Utf8, false), // JSON-encoded array
+        Field::new("char_start", DataType::UInt64, false),
+        Field::new("char_end", DataType::UInt64, false),
+        Field::new("updated_at_ms", DataType::Int64, false),
+        Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                dimensions,
+            ),
+            false,
+        ),
+    ])
+}
+
 /// LanceDB-backed vector index for patterns and workflows.
 pub struct LanceDbStore {
     db: lancedb::Connection,
@@ -250,6 +276,23 @@ impl LanceDbStore {
             ),
         ])
     }
+
+    /// Create the `sources` table if it doesn't exist. Idempotent.
+    pub async fn ensure_sources_table(&self) -> Result<()> {
+        let tables = self.db.table_names().execute().await?;
+        if tables.contains(&SOURCES_TABLE.to_string()) {
+            return Ok(());
+        }
+        let schema = sources_schema(self.dimensions);
+        let empty: Vec<std::result::Result<RecordBatch, arrow_schema::ArrowError>> = Vec::new();
+        let reader = RecordBatchIterator::new(empty, Arc::new(schema));
+        self.db
+            .create_table(SOURCES_TABLE, Box::new(reader) as Box<dyn arrow_array::RecordBatchReader + Send>)
+            .execute()
+            .await
+            .context("creating sources table")?;
+        Ok(())
+    }
 }
 
 /// Build the content string for indexing, including attachment descriptions.
@@ -309,8 +352,24 @@ impl VectorStore for LanceDbStore {
         anyhow::bail!("LanceDbStore::list_external_ids is a stub until P1.2")
     }
 
-    async fn count(&self, _source_id: Option<&str>) -> Result<usize> {
-        anyhow::bail!("LanceDbStore::count is a stub until P1.2")
+    async fn count(&self, source_id: Option<&str>) -> Result<usize> {
+        let tables = self.db.table_names().execute().await?;
+        if !tables.contains(&SOURCES_TABLE.to_string()) {
+            return Ok(0);
+        }
+        let table = self.db.open_table(SOURCES_TABLE).execute().await?;
+        let total = match source_id {
+            None => table.count_rows(None).await?,
+            Some(sid) => {
+                table
+                    .count_rows(Some(format!(
+                        "source_id = '{}'",
+                        sid.replace('\'', "''")
+                    )))
+                    .await?
+            }
+        };
+        Ok(total)
     }
 
     async fn rebuild_index(&self) -> Result<()> {
@@ -493,6 +552,19 @@ mod tests {
         let text = super::content_with_attachment_descriptions(&p);
         // Should not add extra newlines for empty descriptions
         assert_eq!(text, "test content");
+    }
+
+    #[tokio::test]
+    async fn open_or_create_sources_table_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        // First call creates
+        store.ensure_sources_table().await.unwrap();
+        // Second call is a no-op
+        store.ensure_sources_table().await.unwrap();
+        // Row count zero
+        let c = <LanceDbStore as VectorStore>::count(&store, None).await.unwrap();
+        assert_eq!(c, 0);
     }
 
     #[tokio::test]

--- a/mur-core/src/store/vector/lancedb.rs
+++ b/mur-core/src/store/vector/lancedb.rs
@@ -388,11 +388,98 @@ impl VectorStore for LanceDbStore {
 
     async fn search(
         &self,
-        _query_vec: &[f32],
-        _k: usize,
-        _filter: &SearchFilter,
+        query_vec: &[f32],
+        k: usize,
+        filter: &SearchFilter,
     ) -> Result<Vec<Hit>> {
-        anyhow::bail!("LanceDbStore::search (trait) is a stub until P1.3 wires unified retrieve")
+        use futures::TryStreamExt;
+        use lancedb::query::{ExecutableQuery, QueryBase};
+
+        let tables = self.db.table_names().execute().await?;
+        if !tables.contains(&SOURCES_TABLE.to_string()) {
+            return Ok(vec![]);
+        }
+        let table = self.db.open_table(SOURCES_TABLE).execute().await?;
+
+        let mut query = table.vector_search(query_vec.to_vec()).context("vector_search")?;
+
+        // Build WHERE predicate from filter.
+        let mut predicates: Vec<String> = Vec::new();
+        if let Some(ids) = &filter.source_ids
+            && !ids.is_empty()
+        {
+            let escaped: Vec<String> = ids
+                .iter()
+                .map(|s| format!("'{}'", s.replace('\'', "''")))
+                .collect();
+            predicates.push(format!("source_id IN ({})", escaped.join(",")));
+        }
+        if let Some(since) = filter.since {
+            predicates.push(format!("updated_at_ms >= {}", since.timestamp_millis()));
+        }
+        if !predicates.is_empty() {
+            query = query.only_if(predicates.join(" AND "));
+        }
+
+        let results = query
+            .limit(k)
+            .execute()
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let mut hits: Vec<Hit> = Vec::new();
+        for batch in &results {
+            use arrow_array::{Int64Array, StringArray};
+            let chunk_ids = batch
+                .column_by_name("chunk_id")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .context("column chunk_id missing or wrong type")?;
+            let source_ids = batch
+                .column_by_name("source_id")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .context("column source_id missing")?;
+            let external_ids = batch
+                .column_by_name("external_id")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .context("column external_id missing")?;
+            let texts = batch
+                .column_by_name("text")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .context("column text missing")?;
+            let heading_paths = batch
+                .column_by_name("heading_path")
+                .and_then(|c| c.as_any().downcast_ref::<StringArray>())
+                .context("column heading_path missing")?;
+            let updated_at_ms = batch
+                .column_by_name("updated_at_ms")
+                .and_then(|c| c.as_any().downcast_ref::<Int64Array>())
+                .context("column updated_at_ms missing")?;
+            let distances = batch
+                .column_by_name("_distance")
+                .and_then(|c| c.as_any().downcast_ref::<Float32Array>())
+                .context("column _distance missing")?;
+
+            for i in 0..batch.num_rows() {
+                let d = distances.value(i);
+                let score = 1.0 / (1.0 + d);
+                let hp: Vec<String> =
+                    serde_json::from_str(heading_paths.value(i)).unwrap_or_default();
+                let ms = updated_at_ms.value(i);
+                let ts = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms)
+                    .unwrap_or_else(|| chrono::Utc::now());
+                hits.push(Hit {
+                    chunk_id: chunk_ids.value(i).to_string(),
+                    source_id: source_ids.value(i).to_string(),
+                    external_id: external_ids.value(i).to_string(),
+                    score,
+                    text: texts.value(i).to_string(),
+                    heading_path: hp,
+                    updated_at: ts,
+                });
+            }
+        }
+        Ok(hits)
     }
 
     async fn delete_by_external_ids(

--- a/mur-core/src/store/vector/lancedb.rs
+++ b/mur-core/src/store/vector/lancedb.rs
@@ -1,4 +1,4 @@
-//! LanceDB vector store for semantic search over patterns and workflows.
+//! LanceDB-backed implementation of the `VectorStore` trait.
 //!
 //! YAML remains the source of truth. LanceDB is a rebuildable index.
 
@@ -17,12 +17,12 @@ use std::sync::Arc;
 const TABLE_NAME: &str = "patterns";
 
 /// LanceDB-backed vector index for patterns and workflows.
-pub struct VectorStore {
+pub struct LanceDbStore {
     db: lancedb::Connection,
     dimensions: i32,
 }
 
-impl VectorStore {
+impl LanceDbStore {
     /// Open or create the LanceDB database at the given path.
     pub async fn open(db_path: &Path, dimensions: i32) -> Result<Self> {
         let db = lancedb::connect(db_path.to_str().unwrap())
@@ -275,6 +275,55 @@ pub struct SearchResult {
     pub item_type: String,
 }
 
+use async_trait::async_trait;
+use super::{EmbeddedChunk, Hit, SearchFilter, VectorStore};
+
+#[async_trait]
+impl VectorStore for LanceDbStore {
+    async fn upsert(&self, _chunks: &[EmbeddedChunk]) -> Result<()> {
+        anyhow::bail!("LanceDbStore::upsert is a stub until P1.2 wires adapters")
+    }
+
+    async fn search(
+        &self,
+        _query_vec: &[f32],
+        _k: usize,
+        _filter: &SearchFilter,
+    ) -> Result<Vec<Hit>> {
+        anyhow::bail!("LanceDbStore::search (trait) is a stub until P1.3 wires unified retrieve")
+    }
+
+    async fn delete_by_external_ids(
+        &self,
+        _source_id: &str,
+        _external_ids: &[String],
+    ) -> Result<()> {
+        anyhow::bail!("LanceDbStore::delete_by_external_ids is a stub until P1.2")
+    }
+
+    async fn delete_by_source(&self, _source_id: &str) -> Result<()> {
+        anyhow::bail!("LanceDbStore::delete_by_source is a stub until P1.2")
+    }
+
+    async fn list_external_ids(&self, _source_id: &str) -> Result<Vec<String>> {
+        anyhow::bail!("LanceDbStore::list_external_ids is a stub until P1.2")
+    }
+
+    async fn count(&self, _source_id: Option<&str>) -> Result<usize> {
+        anyhow::bail!("LanceDbStore::count is a stub until P1.2")
+    }
+
+    async fn rebuild_index(&self) -> Result<()> {
+        anyhow::bail!("LanceDbStore::rebuild_index (trait) is a stub until P1.3 orchestrates")
+    }
+}
+
+// Compile-time assertion that LanceDbStore implements VectorStore.
+const _: () = {
+    fn _assert_impl<T: VectorStore>() {}
+    fn _check() { _assert_impl::<LanceDbStore>(); }
+};
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,7 +388,7 @@ mod tests {
     #[tokio::test]
     async fn test_build_and_search() {
         let tmp = TempDir::new().unwrap();
-        let store = VectorStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
 
         let patterns = vec![
             (make_pattern("pattern-a"), random_embedding()),
@@ -361,7 +410,7 @@ mod tests {
     #[tokio::test]
     async fn test_empty_index() {
         let tmp = TempDir::new().unwrap();
-        let store = VectorStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
         let results = store.search(&random_embedding(), 5, None).await.unwrap();
         assert!(results.is_empty());
     }
@@ -369,7 +418,7 @@ mod tests {
     #[tokio::test]
     async fn test_rebuild_index() {
         let tmp = TempDir::new().unwrap();
-        let store = VectorStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
 
         let patterns = vec![(make_pattern("first"), random_embedding())];
         store.build_index(&patterns).await.unwrap();
@@ -437,7 +486,7 @@ mod tests {
     #[tokio::test]
     async fn test_unified_index() {
         let tmp = TempDir::new().unwrap();
-        let store = VectorStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
 
         let patterns = vec![(make_pattern("pat-a"), random_embedding())];
         let workflows = vec![(make_workflow("wf-a"), {

--- a/mur-core/src/store/vector/lancedb.rs
+++ b/mur-core/src/store/vector/lancedb.rs
@@ -332,6 +332,16 @@ mod tests {
 
     const TEST_DIM: i32 = 64;
 
+    // Conformance suite — see store/vector/tests.rs
+    crate::vector_store_conformance!(LanceDbStore, make_store_for_conformance);
+
+    async fn make_store_for_conformance() -> LanceDbStore {
+        // TempDir drops at end of test, but that's fine for the smoke test.
+        // Ignored roundtrip tests (enabled in P1.2) will own their own TempDir.
+        let tmp = tempfile::TempDir::new().unwrap();
+        LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap()
+    }
+
     fn make_pattern(name: &str) -> Pattern {
         Pattern {
             base: mur_common::knowledge::KnowledgeBase {

--- a/mur-core/src/store/vector/lancedb.rs
+++ b/mur-core/src/store/vector/lancedb.rs
@@ -287,7 +287,10 @@ impl LanceDbStore {
         let empty: Vec<std::result::Result<RecordBatch, arrow_schema::ArrowError>> = Vec::new();
         let reader = RecordBatchIterator::new(empty, Arc::new(schema));
         self.db
-            .create_table(SOURCES_TABLE, Box::new(reader) as Box<dyn arrow_array::RecordBatchReader + Send>)
+            .create_table(
+                SOURCES_TABLE,
+                Box::new(reader) as Box<dyn arrow_array::RecordBatchReader + Send>,
+            )
             .execute()
             .await
             .context("creating sources table")?;
@@ -386,12 +389,7 @@ impl VectorStore for LanceDbStore {
         Ok(())
     }
 
-    async fn search(
-        &self,
-        query_vec: &[f32],
-        k: usize,
-        filter: &SearchFilter,
-    ) -> Result<Vec<Hit>> {
+    async fn search(&self, query_vec: &[f32], k: usize, filter: &SearchFilter) -> Result<Vec<Hit>> {
         use futures::TryStreamExt;
         use lancedb::query::{ExecutableQuery, QueryBase};
 
@@ -401,7 +399,9 @@ impl VectorStore for LanceDbStore {
         }
         let table = self.db.open_table(SOURCES_TABLE).execute().await?;
 
-        let mut query = table.vector_search(query_vec.to_vec()).context("vector_search")?;
+        let mut query = table
+            .vector_search(query_vec.to_vec())
+            .context("vector_search")?;
 
         // Build WHERE predicate from filter.
         let mut predicates: Vec<String> = Vec::new();
@@ -482,11 +482,7 @@ impl VectorStore for LanceDbStore {
         Ok(hits)
     }
 
-    async fn delete_by_external_ids(
-        &self,
-        source_id: &str,
-        external_ids: &[String],
-    ) -> Result<()> {
+    async fn delete_by_external_ids(&self, source_id: &str, external_ids: &[String]) -> Result<()> {
         if external_ids.is_empty() {
             return Ok(());
         }
@@ -530,11 +526,10 @@ impl VectorStore for LanceDbStore {
         let table = self.db.open_table(SOURCES_TABLE).execute().await?;
         let batches = table
             .query()
-            .only_if(format!(
-                "source_id = '{}'",
-                source_id.replace('\'', "''")
-            ))
-            .select(lancedb::query::Select::Columns(vec!["external_id".to_string()]))
+            .only_if(format!("source_id = '{}'", source_id.replace('\'', "''")))
+            .select(lancedb::query::Select::Columns(vec![
+                "external_id".to_string(),
+            ]))
             .execute()
             .await?
             .try_collect::<Vec<_>>()
@@ -563,10 +558,7 @@ impl VectorStore for LanceDbStore {
             None => table.count_rows(None).await?,
             Some(sid) => {
                 table
-                    .count_rows(Some(format!(
-                        "source_id = '{}'",
-                        sid.replace('\'', "''")
-                    )))
+                    .count_rows(Some(format!("source_id = '{}'", sid.replace('\'', "''"))))
                     .await?
             }
         };
@@ -769,7 +761,9 @@ mod tests {
         // Second call is a no-op
         store.ensure_sources_table().await.unwrap();
         // Row count zero
-        let c = <LanceDbStore as VectorStore>::count(&store, None).await.unwrap();
+        let c = <LanceDbStore as VectorStore>::count(&store, None)
+            .await
+            .unwrap();
         assert_eq!(c, 0);
     }
 
@@ -794,8 +788,12 @@ mod tests {
             }
         };
 
-        let v_a: Vec<f32> = (0..TEST_DIM as usize).map(|i| (i as f32 * 0.01).sin()).collect();
-        let v_b: Vec<f32> = (0..TEST_DIM as usize).map(|i| (i as f32 * 0.01).cos()).collect();
+        let v_a: Vec<f32> = (0..TEST_DIM as usize)
+            .map(|i| (i as f32 * 0.01).sin())
+            .collect();
+        let v_b: Vec<f32> = (0..TEST_DIM as usize)
+            .map(|i| (i as f32 * 0.01).cos())
+            .collect();
 
         <LanceDbStore as super::VectorStore>::upsert(
             &store,
@@ -846,7 +844,9 @@ mod tests {
             })
             .collect();
 
-        <LanceDbStore as super::VectorStore>::upsert(&store, &chunks).await.unwrap();
+        <LanceDbStore as super::VectorStore>::upsert(&store, &chunks)
+            .await
+            .unwrap();
 
         let ids = <LanceDbStore as super::VectorStore>::list_external_ids(&store, "obsidian:test")
             .await
@@ -855,7 +855,9 @@ mod tests {
         sorted.sort();
         assert_eq!(sorted, vec!["doc-0", "doc-1", "doc-2"]);
 
-        let all = <LanceDbStore as super::VectorStore>::count(&store, None).await.unwrap();
+        let all = <LanceDbStore as super::VectorStore>::count(&store, None)
+            .await
+            .unwrap();
         assert_eq!(all, 3);
 
         let scoped = <LanceDbStore as super::VectorStore>::count(&store, Some("obsidian:test"))
@@ -863,8 +865,9 @@ mod tests {
             .unwrap();
         assert_eq!(scoped, 3);
 
-        let other =
-            <LanceDbStore as super::VectorStore>::count(&store, Some("nope")).await.unwrap();
+        let other = <LanceDbStore as super::VectorStore>::count(&store, Some("nope"))
+            .await
+            .unwrap();
         assert_eq!(other, 0);
     }
 
@@ -878,7 +881,11 @@ mod tests {
         let chunks: Vec<super::EmbeddedChunk> = (0..4)
             .map(|i| super::EmbeddedChunk {
                 chunk_id: format!("cid-{i}"),
-                source_id: if i < 2 { "src:a".into() } else { "src:b".into() },
+                source_id: if i < 2 {
+                    "src:a".into()
+                } else {
+                    "src:b".into()
+                },
                 external_id: format!("doc-{i}"),
                 ordinal: 0,
                 text: "x".into(),
@@ -889,7 +896,9 @@ mod tests {
             })
             .collect();
 
-        <LanceDbStore as super::VectorStore>::upsert(&store, &chunks).await.unwrap();
+        <LanceDbStore as super::VectorStore>::upsert(&store, &chunks)
+            .await
+            .unwrap();
 
         <LanceDbStore as super::VectorStore>::delete_by_external_ids(
             &store,
@@ -903,7 +912,9 @@ mod tests {
             .unwrap();
         assert_eq!(remaining_a, vec!["doc-1"]);
 
-        <LanceDbStore as super::VectorStore>::delete_by_source(&store, "src:b").await.unwrap();
+        <LanceDbStore as super::VectorStore>::delete_by_source(&store, "src:b")
+            .await
+            .unwrap();
         let remaining_b = <LanceDbStore as super::VectorStore>::list_external_ids(&store, "src:b")
             .await
             .unwrap();

--- a/mur-core/src/store/vector/lancedb.rs
+++ b/mur-core/src/store/vector/lancedb.rs
@@ -323,8 +323,67 @@ use async_trait::async_trait;
 
 #[async_trait]
 impl VectorStore for LanceDbStore {
-    async fn upsert(&self, _chunks: &[EmbeddedChunk]) -> Result<()> {
-        anyhow::bail!("LanceDbStore::upsert is a stub until P1.2 wires adapters")
+    async fn upsert(&self, chunks: &[EmbeddedChunk]) -> Result<()> {
+        if chunks.is_empty() {
+            return Ok(());
+        }
+        self.ensure_sources_table().await?;
+
+        // Delete any existing rows with these chunk_ids (idempotent upsert).
+        let ids: Vec<String> = chunks
+            .iter()
+            .map(|c| format!("'{}'", c.chunk_id.replace('\'', "''")))
+            .collect();
+        let predicate = format!("chunk_id IN ({})", ids.join(","));
+        let table = self.db.open_table(SOURCES_TABLE).execute().await?;
+        let _ = table.delete(&predicate).await;
+
+        // Build column arrays.
+        let chunk_ids: Vec<&str> = chunks.iter().map(|c| c.chunk_id.as_str()).collect();
+        let source_ids: Vec<&str> = chunks.iter().map(|c| c.source_id.as_str()).collect();
+        let external_ids: Vec<&str> = chunks.iter().map(|c| c.external_id.as_str()).collect();
+        let ordinals: Vec<u64> = chunks.iter().map(|c| c.ordinal as u64).collect();
+        let texts: Vec<&str> = chunks.iter().map(|c| c.text.as_str()).collect();
+        let heading_paths: Vec<String> = chunks
+            .iter()
+            .map(|c| serde_json::to_string(&c.heading_path).unwrap_or_else(|_| "[]".into()))
+            .collect();
+        let heading_path_refs: Vec<&str> = heading_paths.iter().map(|s| s.as_str()).collect();
+        let char_starts: Vec<u64> = chunks.iter().map(|c| c.char_range.0 as u64).collect();
+        let char_ends: Vec<u64> = chunks.iter().map(|c| c.char_range.1 as u64).collect();
+        let updated_at_ms: Vec<i64> = chunks
+            .iter()
+            .map(|c| c.updated_at.timestamp_millis())
+            .collect();
+
+        let all_vectors: Vec<f32> = chunks.iter().flat_map(|c| c.embedding.clone()).collect();
+        let values = Float32Array::from(all_vectors);
+        let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+        let vector_array =
+            FixedSizeListArray::new(item_field, self.dimensions, Arc::new(values), None);
+
+        let schema = sources_schema(self.dimensions);
+        use arrow_array::{Int64Array, UInt64Array};
+        let batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(StringArray::from(chunk_ids)),
+                Arc::new(StringArray::from(source_ids)),
+                Arc::new(StringArray::from(external_ids)),
+                Arc::new(UInt64Array::from(ordinals)),
+                Arc::new(StringArray::from(texts)),
+                Arc::new(StringArray::from(heading_path_refs)),
+                Arc::new(UInt64Array::from(char_starts)),
+                Arc::new(UInt64Array::from(char_ends)),
+                Arc::new(Int64Array::from(updated_at_ms)),
+                Arc::new(vector_array),
+            ],
+        )?;
+
+        let batches = RecordBatchIterator::new(vec![Ok(batch)], Arc::new(schema));
+        let reader: Box<dyn arrow_array::RecordBatchReader + Send> = Box::new(batches);
+        table.add(reader).execute().await?;
+        Ok(())
     }
 
     async fn search(
@@ -565,6 +624,58 @@ mod tests {
         // Row count zero
         let c = <LanceDbStore as VectorStore>::count(&store, None).await.unwrap();
         assert_eq!(c, 0);
+    }
+
+    #[tokio::test]
+    async fn sources_upsert_and_search_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        store.ensure_sources_table().await.unwrap();
+
+        let now = chrono::Utc::now();
+        let mk_chunk = |id: &str, ext: &str, text: &str, embed: Vec<f32>| -> super::EmbeddedChunk {
+            super::EmbeddedChunk {
+                chunk_id: id.into(),
+                source_id: "obsidian:test".into(),
+                external_id: ext.into(),
+                ordinal: 0,
+                text: text.into(),
+                heading_path: vec!["Section".into()],
+                char_range: (0, text.len()),
+                updated_at: now,
+                embedding: embed,
+            }
+        };
+
+        let v_a: Vec<f32> = (0..TEST_DIM as usize).map(|i| (i as f32 * 0.01).sin()).collect();
+        let v_b: Vec<f32> = (0..TEST_DIM as usize).map(|i| (i as f32 * 0.01).cos()).collect();
+
+        <LanceDbStore as super::VectorStore>::upsert(
+            &store,
+            &[mk_chunk("c1", "doc-a", "alpha text", v_a.clone())],
+        )
+        .await
+        .unwrap();
+        <LanceDbStore as super::VectorStore>::upsert(
+            &store,
+            &[mk_chunk("c2", "doc-b", "bravo text", v_b.clone())],
+        )
+        .await
+        .unwrap();
+
+        let hits = <LanceDbStore as super::VectorStore>::search(
+            &store,
+            &v_a,
+            5,
+            &super::SearchFilter::default(),
+        )
+        .await
+        .unwrap();
+        assert!(!hits.is_empty(), "expected hits");
+        assert_eq!(hits[0].chunk_id, "c1");
+        assert_eq!(hits[0].source_id, "obsidian:test");
+        assert_eq!(hits[0].external_id, "doc-a");
+        assert_eq!(hits[0].heading_path, vec!["Section".to_string()]);
     }
 
     #[tokio::test]

--- a/mur-core/src/store/vector/lancedb.rs
+++ b/mur-core/src/store/vector/lancedb.rs
@@ -598,10 +598,15 @@ mod tests {
     crate::vector_store_conformance!(LanceDbStore, make_store_for_conformance);
 
     async fn make_store_for_conformance() -> LanceDbStore {
-        // TempDir drops at end of test, but that's fine for the smoke test.
-        // Ignored roundtrip tests (enabled in P1.2) will own their own TempDir.
         let tmp = tempfile::TempDir::new().unwrap();
-        LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap()
+        let store = LanceDbStore::open(tmp.path(), TEST_DIM).await.unwrap();
+        store.ensure_sources_table().await.unwrap();
+        // Intentionally leak the TempDir: the LanceDB connection holds an open
+        // handle and expects the directory to persist for the lifetime of the
+        // `store` (which outlives this function). Conformance tests are few;
+        // leaked temp dirs get cleaned by the OS on reboot.
+        std::mem::forget(tmp);
+        store
     }
 
     fn make_pattern(name: &str) -> Pattern {

--- a/mur-core/src/store/vector/mod.rs
+++ b/mur-core/src/store/vector/mod.rs
@@ -21,6 +21,7 @@ pub use self::lancedb::LanceDbStore;
 /// This shape is re-used by the `sources` pipeline (external notes) and the
 /// pattern index. For P1.1 we only use it for sources — the pattern path
 /// keeps its existing `build_unified_index` code path untouched.
+#[allow(dead_code)] // used by P1.2+ adapter impls
 #[derive(Debug, Clone)]
 pub struct EmbeddedChunk {
     pub chunk_id: String,
@@ -35,6 +36,7 @@ pub struct EmbeddedChunk {
 }
 
 /// Filter applied at search time.
+#[allow(dead_code)] // used by P1.2+ adapter impls
 #[derive(Debug, Clone, Default)]
 pub struct SearchFilter {
     /// Restrict to these source_ids. `None` = all sources.
@@ -44,6 +46,7 @@ pub struct SearchFilter {
 }
 
 /// A single search hit from the new trait-based API.
+#[allow(dead_code)] // used by P1.2+ adapter impls
 #[derive(Debug, Clone)]
 pub struct Hit {
     pub chunk_id: String,
@@ -57,25 +60,17 @@ pub struct Hit {
 }
 
 /// Abstract vector store. Implementations MUST be `Send + Sync` and idempotent for `upsert`.
+#[allow(dead_code)] // consumed by P1.2+ adapters; factory tests exercise it via Arc<dyn VectorStore>
 #[async_trait]
 pub trait VectorStore: Send + Sync {
     /// Insert or replace chunks by `chunk_id`.
     async fn upsert(&self, chunks: &[EmbeddedChunk]) -> Result<()>;
 
     /// Search by embedding.
-    async fn search(
-        &self,
-        query_vec: &[f32],
-        k: usize,
-        filter: &SearchFilter,
-    ) -> Result<Vec<Hit>>;
+    async fn search(&self, query_vec: &[f32], k: usize, filter: &SearchFilter) -> Result<Vec<Hit>>;
 
     /// Delete chunks whose (source_id, external_id) matches.
-    async fn delete_by_external_ids(
-        &self,
-        source_id: &str,
-        external_ids: &[String],
-    ) -> Result<()>;
+    async fn delete_by_external_ids(&self, source_id: &str, external_ids: &[String]) -> Result<()>;
 
     /// Delete all chunks for a given source.
     async fn delete_by_source(&self, source_id: &str) -> Result<()>;

--- a/mur-core/src/store/vector/mod.rs
+++ b/mur-core/src/store/vector/mod.rs
@@ -1,0 +1,91 @@
+//! Abstract vector store trait.
+//!
+//! Phase 1 has one implementation (`lancedb::LanceDbStore`). Phase 1.3 adds
+//! `qdrant::QdrantStore`. Callers interact through `Arc<dyn VectorStore>`
+//! obtained from `factory::get_vector_store(&config, &index_dir)`.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+pub mod factory;
+pub mod lancedb;
+
+#[cfg(test)]
+pub mod tests;
+
+pub use self::lancedb::LanceDbStore;
+
+/// An embedded chunk ready to be stored.
+///
+/// This shape is re-used by the `sources` pipeline (external notes) and the
+/// pattern index. For P1.1 we only use it for sources — the pattern path
+/// keeps its existing `build_unified_index` code path untouched.
+#[derive(Debug, Clone)]
+pub struct EmbeddedChunk {
+    pub chunk_id: String,
+    pub source_id: String,
+    pub external_id: String,
+    pub ordinal: usize,
+    pub text: String,
+    pub heading_path: Vec<String>,
+    pub char_range: (usize, usize),
+    pub updated_at: DateTime<Utc>,
+    pub embedding: Vec<f32>,
+}
+
+/// Filter applied at search time.
+#[derive(Debug, Clone, Default)]
+pub struct SearchFilter {
+    /// Restrict to these source_ids. `None` = all sources.
+    pub source_ids: Option<Vec<String>>,
+    /// Only return rows whose `updated_at` is at least this timestamp.
+    pub since: Option<DateTime<Utc>>,
+}
+
+/// A single search hit from the new trait-based API.
+#[derive(Debug, Clone)]
+pub struct Hit {
+    pub chunk_id: String,
+    pub source_id: String,
+    pub external_id: String,
+    /// Similarity score in [0.0, 1.0], higher = better.
+    pub score: f32,
+    pub text: String,
+    pub heading_path: Vec<String>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Abstract vector store. Implementations MUST be `Send + Sync` and idempotent for `upsert`.
+#[async_trait]
+pub trait VectorStore: Send + Sync {
+    /// Insert or replace chunks by `chunk_id`.
+    async fn upsert(&self, chunks: &[EmbeddedChunk]) -> Result<()>;
+
+    /// Search by embedding.
+    async fn search(
+        &self,
+        query_vec: &[f32],
+        k: usize,
+        filter: &SearchFilter,
+    ) -> Result<Vec<Hit>>;
+
+    /// Delete chunks whose (source_id, external_id) matches.
+    async fn delete_by_external_ids(
+        &self,
+        source_id: &str,
+        external_ids: &[String],
+    ) -> Result<()>;
+
+    /// Delete all chunks for a given source.
+    async fn delete_by_source(&self, source_id: &str) -> Result<()>;
+
+    /// List every `external_id` currently indexed for `source_id`.
+    async fn list_external_ids(&self, source_id: &str) -> Result<Vec<String>>;
+
+    /// Count chunks (optionally per source).
+    async fn count(&self, source_id: Option<&str>) -> Result<usize>;
+
+    /// Drop and recreate all state.
+    async fn rebuild_index(&self) -> Result<()>;
+}

--- a/mur-core/src/store/vector/tests.rs
+++ b/mur-core/src/store/vector/tests.rs
@@ -1,0 +1,1 @@
+//! Integration tests for the vector store abstraction. (filled in P1.2)

--- a/mur-core/src/store/vector/tests.rs
+++ b/mur-core/src/store/vector/tests.rs
@@ -1,1 +1,90 @@
-//! Integration tests for the vector store abstraction. (filled in P1.2)
+//! Conformance suite every `VectorStore` impl must satisfy.
+//!
+//! Usage from an impl's module:
+//! ```ignore
+//! #[cfg(test)]
+//! mod conformance {
+//!     use super::*;
+//!     $crate::vector_store_conformance!(LanceDbStore, make_store_for_conformance);
+//!     async fn make_store_for_conformance() -> LanceDbStore { /* ... */ }
+//! }
+//! ```
+//!
+//! Phase 1.1 only runs the smoke test — upsert/search tests are `#[ignore]` until
+//! P1.2 replaces the trait-method stubs with real code.
+
+#![allow(dead_code)]
+
+use super::*;
+
+/// Generic smoke test: construct the store and prove `count` is callable.
+///
+/// `LanceDbStore::count` currently `bail!`s — this function only asserts the
+/// method is reachable via the trait (compile-time check passes, and runtime
+/// does not panic before the bail). Once P1.2 provides real implementations,
+/// this will be replaced with a real assertion.
+pub async fn smoke_count_empty<S: VectorStore>(store: &S) {
+    let _ = store.count(Some("nonexistent-source-id")).await;
+}
+
+/// Round-trip test (meaningful from P1.2 onward).
+pub async fn upsert_and_search<S: VectorStore>(store: &S, dims: usize) -> anyhow::Result<()> {
+    let chunk = EmbeddedChunk {
+        chunk_id: "chunk-a".into(),
+        source_id: "test".into(),
+        external_id: "doc-1".into(),
+        ordinal: 0,
+        text: "hello world".into(),
+        heading_path: vec![],
+        char_range: (0, 11),
+        updated_at: chrono::Utc::now(),
+        embedding: vec![0.1_f32; dims],
+    };
+    store.upsert(&[chunk.clone()]).await?;
+    let hits = store
+        .search(&vec![0.1_f32; dims], 5, &SearchFilter::default())
+        .await?;
+    anyhow::ensure!(!hits.is_empty(), "expected at least one hit");
+    Ok(())
+}
+
+/// Delete-by-source removes everything for that source.
+pub async fn delete_by_source_clears<S: VectorStore>(store: &S) -> anyhow::Result<()> {
+    store.delete_by_source("test").await?;
+    let ids = store.list_external_ids("test").await?;
+    anyhow::ensure!(ids.is_empty(), "expected zero ids after delete_by_source");
+    Ok(())
+}
+
+/// Drop this into an impl's test module to exercise the full suite.
+///
+/// Use `$crate::vector_store_conformance!(YourStore, your_factory)` — the macro
+/// is exported at the crate root via `#[macro_export]`.
+#[macro_export]
+macro_rules! vector_store_conformance {
+    ($ty:ty, $factory:ident) => {
+        #[tokio::test]
+        async fn conformance_smoke_count_empty() {
+            let s = $factory().await;
+            $crate::store::vector::tests::smoke_count_empty::<$ty>(&s).await;
+        }
+
+        #[tokio::test]
+        #[ignore = "enabled from P1.2 when upsert is real"]
+        async fn conformance_upsert_and_search() {
+            let s = $factory().await;
+            $crate::store::vector::tests::upsert_and_search::<$ty>(&s, 64)
+                .await
+                .expect("roundtrip");
+        }
+
+        #[tokio::test]
+        #[ignore = "enabled from P1.2 when delete_by_source is real"]
+        async fn conformance_delete_by_source_clears() {
+            let s = $factory().await;
+            $crate::store::vector::tests::delete_by_source_clears::<$ty>(&s)
+                .await
+                .expect("delete_by_source");
+        }
+    };
+}

--- a/mur-core/src/store/vector/tests.rs
+++ b/mur-core/src/store/vector/tests.rs
@@ -70,7 +70,6 @@ macro_rules! vector_store_conformance {
         }
 
         #[tokio::test]
-        #[ignore = "enabled from P1.2 when upsert is real"]
         async fn conformance_upsert_and_search() {
             let s = $factory().await;
             $crate::store::vector::tests::upsert_and_search::<$ty>(&s, 64)
@@ -79,7 +78,6 @@ macro_rules! vector_store_conformance {
         }
 
         #[tokio::test]
-        #[ignore = "enabled from P1.2 when delete_by_source is real"]
         async fn conformance_delete_by_source_clears() {
             let s = $factory().await;
             $crate::store::vector::tests::delete_by_source_clears::<$ty>(&s)

--- a/mur-core/tests/obsidian_e2e.rs
+++ b/mur-core/tests/obsidian_e2e.rs
@@ -1,0 +1,124 @@
+//! End-to-end: ObsidianAdapter + chunker + LanceDbStore.
+//!
+//! Does not exercise the embedding step (uses deterministic fake vectors).
+//! Real embeddings are covered by manual smoke tests and adapter unit tests.
+
+use mur_core::sources::KnowledgeSource;
+use mur_core::sources::adapters::obsidian::ObsidianAdapter;
+use mur_core::sources::instance::{SourceInstance, SourceStats, SyncState};
+use mur_core::sources::kind::SourceKind;
+use mur_core::store::vector::{EmbeddedChunk, LanceDbStore, SearchFilter, VectorStore};
+use std::collections::BTreeMap;
+use std::fs;
+use tempfile::TempDir;
+
+fn make_instance(id: &str, vault: &std::path::Path) -> SourceInstance {
+    let mut scope = BTreeMap::new();
+    scope.insert(
+        "vault".into(),
+        serde_yaml::Value::String(vault.to_string_lossy().to_string()),
+    );
+    SourceInstance {
+        id: id.into(),
+        type_name: "obsidian".into(),
+        kind: SourceKind::PullIndex,
+        enabled: true,
+        weight: 1.0,
+        scope,
+        sync: SyncState::default(),
+        stats: SourceStats::default(),
+        keyring_entry: None,
+    }
+}
+
+const DIM: i32 = 8;
+
+fn zeros() -> Vec<f32> {
+    vec![0.0_f32; DIM as usize]
+}
+fn ones() -> Vec<f32> {
+    vec![1.0_f32; DIM as usize]
+}
+
+#[tokio::test]
+async fn obsidian_end_to_end_sync_then_search() {
+    let vault = TempDir::new().unwrap();
+    fs::create_dir_all(vault.path().join(".obsidian")).unwrap();
+    fs::write(
+        vault.path().join("design.md"),
+        "---\ntags: [design]\n---\n\n# Auth design\n\nJWT 15min access + 7d refresh.",
+    )
+    .unwrap();
+    fs::write(
+        vault.path().join("scratch.md"),
+        "# scratch\n\nnothing interesting",
+    )
+    .unwrap();
+
+    let inst = make_instance("obsidian:e2e", vault.path());
+    let adapter = ObsidianAdapter::from_instance(&inst).unwrap();
+
+    let (refs, _cursor) = adapter.list_documents(None).await.unwrap();
+    assert_eq!(refs.len(), 2);
+
+    let index = TempDir::new().unwrap();
+    let store = LanceDbStore::open(index.path(), DIM).await.unwrap();
+    store.ensure_sources_table().await.unwrap();
+
+    let mut all_chunks: Vec<EmbeddedChunk> = Vec::new();
+    for r in &refs {
+        let doc = adapter.fetch(r).await.unwrap();
+        for c in adapter.chunk(&doc).unwrap() {
+            let embed = if c.external_id.contains("design") {
+                ones()
+            } else {
+                zeros()
+            };
+            all_chunks.push(EmbeddedChunk {
+                chunk_id: c.chunk_id,
+                source_id: c.source_id,
+                external_id: c.external_id,
+                ordinal: c.ordinal,
+                text: c.text,
+                heading_path: c.heading_path,
+                char_range: c.char_range,
+                updated_at: c.updated_at,
+                embedding: embed,
+            });
+        }
+    }
+    store.upsert(&all_chunks).await.unwrap();
+
+    let hits = <LanceDbStore as VectorStore>::search(&store, &ones(), 5, &SearchFilter::default()).await.unwrap();
+    assert!(!hits.is_empty());
+    assert_eq!(hits[0].external_id, "design.md");
+
+    let ids = store.list_external_ids("obsidian:e2e").await.unwrap();
+    assert!(ids.contains(&"design.md".to_string()));
+    assert!(ids.contains(&"scratch.md".to_string()));
+
+    let c = store.count(Some("obsidian:e2e")).await.unwrap();
+    assert!(c >= 2);
+
+    fs::remove_file(vault.path().join("scratch.md")).unwrap();
+    let (refs_after, _) = adapter.list_documents(None).await.unwrap();
+    let current: std::collections::HashSet<String> =
+        refs_after.iter().map(|r| r.external_id.clone()).collect();
+    let indexed = store.list_external_ids("obsidian:e2e").await.unwrap();
+    let deleted: Vec<String> = indexed.into_iter().filter(|id| !current.contains(id)).collect();
+    assert_eq!(deleted, vec!["scratch.md".to_string()]);
+    store
+        .delete_by_external_ids("obsidian:e2e", &deleted)
+        .await
+        .unwrap();
+    let after = store.list_external_ids("obsidian:e2e").await.unwrap();
+    assert!(!after.contains(&"scratch.md".to_string()));
+    assert!(after.contains(&"design.md".to_string()));
+
+    store.delete_by_source("obsidian:e2e").await.unwrap();
+    let empty = store.list_external_ids("obsidian:e2e").await.unwrap();
+    assert!(empty.is_empty());
+
+    std::mem::forget(index);
+    std::mem::forget(vault);
+}

--- a/mur-core/tests/obsidian_e2e.rs
+++ b/mur-core/tests/obsidian_e2e.rs
@@ -89,7 +89,9 @@ async fn obsidian_end_to_end_sync_then_search() {
     }
     store.upsert(&all_chunks).await.unwrap();
 
-    let hits = <LanceDbStore as VectorStore>::search(&store, &ones(), 5, &SearchFilter::default()).await.unwrap();
+    let hits = <LanceDbStore as VectorStore>::search(&store, &ones(), 5, &SearchFilter::default())
+        .await
+        .unwrap();
     assert!(!hits.is_empty());
     assert_eq!(hits[0].external_id, "design.md");
 
@@ -105,7 +107,10 @@ async fn obsidian_end_to_end_sync_then_search() {
     let current: std::collections::HashSet<String> =
         refs_after.iter().map(|r| r.external_id.clone()).collect();
     let indexed = store.list_external_ids("obsidian:e2e").await.unwrap();
-    let deleted: Vec<String> = indexed.into_iter().filter(|id| !current.contains(id)).collect();
+    let deleted: Vec<String> = indexed
+        .into_iter()
+        .filter(|id| !current.contains(id))
+        .collect();
     assert_eq!(deleted, vec!["scratch.md".to_string()]);
     store
         .delete_by_external_ids("obsidian:e2e", &deleted)


### PR DESCRIPTION
## Summary

Phase 1 of the external-sources initiative — introduces a `KnowledgeSource` adapter trait, `VectorStore` abstraction (LanceDB impl), and ships the first working adapter (Obsidian) with manual sync + sources-only search.

**Spec:** [docs/superpowers/specs/2026-04-20-mur-sources-integration-design.md](docs/superpowers/specs/2026-04-20-mur-sources-integration-design.md)

**P1.1 Foundation** (14 commits): `store::vector::VectorStore` trait + `LanceDbStore` rename; `sources/` module skeleton (`KnowledgeSource` trait, `Document`/`Chunk`/`DocRef` types, `SourceKind` enum, `SourceInstance` yaml IO, OS keyring wrapper); `StorageConfig` + `SourcesGlobalConfig` (zero-action for existing users); `mur source` CLI gated behind `sources` feature.

**P1.2 Obsidian** (19 commits): real `LanceDbStore` impls (`upsert`/`search`/`list_external_ids`/`delete_*`/`count`); heading-aware markdown chunker; `ObsidianAdapter` (`KnowledgeSource`); sync orchestrator with full-mode set-diff deletion + per-doc error isolation; real CLI handlers for `add obsidian`, `list`, `status`, `sync [id] [--full]`, `remove [--keep-index]`, `test`, `weight`, `enable`, `disable`, and a minimal `search` verb.

## What's working
- `mur source add obsidian --vault <path>` → OAuth-free local vault registration
- `mur source sync [--full]` → list → fetch → chunk → embed → upsert pipeline; deletion detection via vector-store set-diff
- `mur source search "query" [--source id] [--json]` → sources-only retrieval (unified retrieve with patterns is P1.3)
- All 10 CLI verbs; `add notion|joplin`, `sync --watch`, `reindex`, `install-schedule` still stubbed with "arrives in P1.x" messages

## Test Plan
- [x] `cargo test --workspace` → 1298 passed, 0 failed, 13 ignored
- [x] `cargo clippy --workspace --all-features -- -D warnings` → clean
- [x] `cargo fmt --check` → clean
- [x] `cargo build --workspace` → ok
- [x] `cargo build --workspace --no-default-features --features "cli server"` → ok (sources feature cleanly opt-outable)
- [x] End-to-end integration test (`tests/obsidian_e2e.rs`) covers adapter + chunker + LanceDB full flow
- [ ] Reviewer sanity check: run \`mur source add obsidian --vault ~/Obsidian\` + \`mur source sync --full\` + \`mur source search "<word>"\` against a real vault with embedding provider configured

## Deliberate Out-of-Scope (see spec §15 + P1.2 plan)
- Unified \`mur search\` merging patterns + sources → P1.3
- tantivy BM25 for cross-backend consistency → P1.3
- Inject formatter "Notes" section → P1.3
- Qdrant backend impl → P1.3
- Notion / Joplin adapters → P1.4
- \`sync --watch\` file watcher + \`install-schedule\` → P1.4
- Inline \`#tag\` parsing in Obsidian → future (YAML frontmatter \`tags:\` covered)
- Incremental-mode deletion detection → P1.4 (only \`--full\` detects deletes today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)