### PR TITLE
fix(conversations): Phase 3.3 follow-ups — JSON path persistence + dir fsync

### DIFF
--- a/mur-core/src/cmd/conversations_cmd.rs
+++ b/mur-core/src/cmd/conversations_cmd.rs
@@ -1182,13 +1182,40 @@ pub async fn cmd_ask(args: AskArgs) -> Result<()> {
     };
 
     // Generate + collect response
-    // streaming_error is set if the streaming branch sees an AskEvent::Error;
-    // surfaced after persistence so degraded turns still write to the JSONL.
+    // streaming_error is set if the streaming branch sees an AskEvent::Error
+    // *or* the JSON branch's `ask::ask` call returns Err. In either case the
+    // error is surfaced after persistence so degraded turns still write to
+    // the JSONL — mirroring the streaming fix in PR #15.
     let mut streaming_error: Option<String> = None;
     let resp = if args.json {
-        let r = ask::ask(req, None).await?;
-        println!("{}", serde_json::to_string_pretty(&r)?);
-        r
+        match ask::ask(req, None).await {
+            Ok(r) => {
+                println!("{}", serde_json::to_string_pretty(&r)?);
+                r
+            }
+            Err(e) => {
+                streaming_error = Some(e.to_string());
+                // Build a degraded AskResponse so the turn still persists with
+                // the question + rewriter context. answer/hits/citations are
+                // empty; degraded_to_mode_b is true so --show-session and
+                // downstream analytics can count it.
+                ask::AskResponse {
+                    answer: String::new(),
+                    citations: Vec::new(),
+                    hits_used: Vec::new(),
+                    degraded_to_mode_b: true,
+                    tokens_in: 0,
+                    tokens_out: 0,
+                    duration_ms: 0,
+                    rewritten_question: match rewriter_status {
+                        ask::session::RewriterStatus::Skipped => None,
+                        _ => Some(rewrite.rewritten.clone()),
+                    },
+                    rewriter_status,
+                    stage_1b: None,
+                }
+            }
+        }
     } else {
         let mut stream = ask::ask_stream(req, None).await?;
         let mut answer = String::new();

--- a/mur-core/src/conversations/ask/session.rs
+++ b/mur-core/src/conversations/ask/session.rs
@@ -109,20 +109,40 @@ impl SessionStore {
 
     /// Append a turn to the session file + update the in-memory turns vec.
     /// Creates the file (and parent dir) if missing.
-    /// `sync_all()` before return to guarantee crash durability of the line.
+    /// `sync_all()` on the file (for content) *and* on the parent directory
+    /// (for the dirent) before return, so the line is crash-durable even on
+    /// the first call that creates the file. Dir fsync is best-effort — some
+    /// filesystems (notably certain network mounts) return EINVAL on
+    /// `fsync(dirfd)`; we log and proceed rather than failing the turn.
     pub fn append_turn(session: &mut Session, turn: TurnRecord) -> Result<()> {
         if let Some(parent) = session.path.parent() {
             std::fs::create_dir_all(parent)?;
         }
         let line = serde_json::to_string(&turn).context("serialize TurnRecord")?;
+        // Single write of "{json}\n" — two separate write_all calls could
+        // interleave across concurrent appenders under O_APPEND. Still not
+        // a proper cross-process lock, but at least each line is atomic.
+        let mut buf = line.into_bytes();
+        buf.push(b'\n');
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
             .open(&session.path)
             .with_context(|| format!("open session for append {:?}", session.path))?;
-        file.write_all(line.as_bytes())?;
-        file.write_all(b"\n")?;
+        file.write_all(&buf)?;
         file.sync_all()?;
+        if let Some(parent) = session.path.parent() {
+            match std::fs::File::open(parent) {
+                Ok(dir) => {
+                    if let Err(e) = dir.sync_all() {
+                        tracing::warn!("fsync parent dir {:?} failed: {}", parent, e);
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("open parent dir {:?} for fsync failed: {}", parent, e);
+                }
+            }
+        }
         session.turns.push(turn);
         Ok(())
     }


### PR DESCRIPTION
## Why

Three durability corrections flagged by a deep code review of the Phase 3.3 merge (\`b860305\` + #15 \`3844b4f\`). All related to multi-turn session-JSONL persistence.

## What

1. **C1 — \`--json\` path lost the turn on \`ask::ask()\` error.**
   PR #15 fixed the streaming path to persist a degraded \`TurnRecord\` before exit-1 when Ollama fails mid-stream. The \`--json\` branch still used \`?\` on \`ask::ask(req, None).await?\` and short-circuited before \`append_turn\`. Now mirrors #15: \`match\` the Result, on \`Err\` capture the message into \`streaming_error\` and construct a degraded \`AskResponse\` (empty answer/hits/citations, \`degraded_to_mode_b=true\`). The existing post-persist handler reports the error + exits 1.

2. **H1 — \`append_turn\` wasn't crash-durable on first write.**
   POSIX: a new file's dirent isn't durable until the parent directory is fsynced. Previously only \`file.sync_all()\` ran, so a power loss between write and reboot could lose the brand-new \`ask-session.jsonl\`. Added a best-effort parent-dir fsync after the content fsync. On macOS this is a no-op; on Linux it fulfils the plan's \"atomic + fsync\" contract. Errors logged via \`tracing::warn!\` rather than failing the turn (some network filesystems return EINVAL on dir-fsync).

3. **H2 — two-call write was interleaveable across concurrent processes.**
   Under \`O_APPEND\`, \`write_all(line.as_bytes())\` + \`write_all(b\"\\n\")\` as two separate syscalls could interleave between two \`mur ask\` invocations, producing corrupt JSONL. Concatenate line + newline into one buffer and issue a single \`write_all\`. Still single-writer-advised — no cross-process lock added — but each individual line is now atomic at the syscall layer.

## Scope notes

- **No integration test for C1.** Forcing the JSON branch's \`ask::ask\` to fail requires a populated LanceDB fixture AND an unreachable Ollama URL — too much setup for a 20-line fix. The change is a direct mirror of the streaming fix in PR #15, whose test (\`mur_ask_persists_turn_on_empty_archive_path\`) exercises the analogous persist path. Code review signs off the type shape.
- **Deferred to a future session** (per the original review's classification): H3 (shared 30s rewriter+generate timeout), M1–M4 (\`--show-session\` flag conflicts, missing edge-case tests, \`NoRewriteNeeded\` whitespace sensitivity, mock sentinel spoofability), and L1–L4 (style/naming).

## Test plan

- [x] \`cargo test -p mur-core\` — 796 + 804 + 21 + 6 misc all pass, 0 fail
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] CI: Test × ubuntu/macos/windows + Clippy + Format all green

## Diff stats

2 files changed, 55 insertions(+), 8 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)