### PR TITLE
fix(conversations): Phase 3.3 code-review follow-ups (H3 + M1-M4 + L1)

### DIFF
--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -339,6 +339,13 @@ pub struct AskConfig {
     pub min_score: f64,
     #[serde(default = "ask_default_continue_history_turns")]
     pub continue_history_turns: u32,
+    /// Separate, shorter timeout for the rewriter LLM call (Phase 3.3).
+    /// Rewriter output is small (~80 tokens) and falling back to the raw
+    /// question on failure is non-fatal, so we don't want to burn the full
+    /// `timeout_secs` budget waiting on a slow/unreachable Ollama before
+    /// the user sees any response.
+    #[serde(default = "ask_default_rewriter_timeout")]
+    pub rewriter_timeout_secs: u32,
     #[serde(default = "ask_default_compress_hits_enabled")]
     pub compress_hits_enabled: bool,
     #[serde(default = "ask_default_summarize_hits_enabled")]
@@ -361,6 +368,7 @@ impl Default for AskConfig {
             timeout_secs: ask_default_timeout(),
             min_score: ask_default_min_score(),
             continue_history_turns: ask_default_continue_history_turns(),
+            rewriter_timeout_secs: ask_default_rewriter_timeout(),
             compress_hits_enabled: ask_default_compress_hits_enabled(),
             summarize_hits_enabled: ask_default_summarize_hits_enabled(),
             summarize_model: None,
@@ -394,6 +402,9 @@ fn ask_default_timeout() -> u32 {
 }
 fn ask_default_min_score() -> f64 {
     0.35
+}
+fn ask_default_rewriter_timeout() -> u32 {
+    8
 }
 fn ask_default_continue_history_turns() -> u32 {
     3

--- a/mur-core/src/cmd/conversations_cmd.rs
+++ b/mur-core/src/cmd/conversations_cmd.rs
@@ -1121,12 +1121,20 @@ pub async fn cmd_ask(args: AskArgs) -> Result<()> {
         ask::session::SessionStore::archive_and_new(None, history_retain)?
     };
 
-    // Rewriter call (only if continuing + we have prior turns)
+    // Rewriter call (only if continuing + we have prior turns).
+    // Separate shorter timeout (ask_cfg.rewriter_timeout_secs, default 8s)
+    // so a slow/unreachable Ollama doesn't burn the full generate budget
+    // before the user sees a response — we fall back to the raw question
+    // on timeout. The main generation path still uses its own client with
+    // the full ask_cfg.timeout_secs budget (plumbed via ask_stream).
     let prior_slice = session.last_n(history_turns);
     let model = args.model.clone().unwrap_or_else(|| ask_cfg.model.clone());
-    let client = OllamaClient::new(&ask_cfg.ollama_endpoint, std::time::Duration::from_secs(30));
+    let rewriter_client = OllamaClient::new(
+        &ask_cfg.ollama_endpoint,
+        std::time::Duration::from_secs(ask_cfg.rewriter_timeout_secs as u64),
+    );
     let rewrite = ask::rewriter::rewrite(
-        &client,
+        &rewriter_client,
         &model,
         ask::rewriter::RewriteInput {
             prior_turns: prior_slice,

--- a/mur-core/src/conversations/ask/prompt.rs
+++ b/mur-core/src/conversations/ask/prompt.rs
@@ -542,6 +542,40 @@ mod tests {
         unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
     }
 
+    /// M2 (phase 3.3 review follow-up): render must terminate with a sane
+    /// output even when the budget is unachievably tight — specifically
+    /// `max_context_tokens = 0`. Exercises the overflow-loop exit guards
+    /// (Stage 2 stops when history_cursor reaches prior_turns.len(); Stage 3
+    /// stops when trimmed_hits > 1 becomes false). No infinite loop.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn render_terminates_on_zero_budget() {
+        use crate::conversations::ENV_LOCK;
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let hits = vec![hit_raw("a", "answer one"), hit_raw("b", "answer two")];
+        let r = super::render(
+            "what happened?",
+            &[],
+            hits,
+            /* max_context_tokens = */ 0,
+            100,
+            false,
+            false,
+            None,
+        )
+        .await;
+        // Function returns; assertions confirm we exited the loops cleanly
+        // and kept at least one hit (Stage 3 guard: trimmed_hits > 1).
+        assert_eq!(
+            r.final_hits.len(),
+            1,
+            "stage-3 guard should leave exactly 1 hit on zero-budget"
+        );
+        assert!(!r.user.is_empty(), "user prompt should not be empty");
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn render_stage_1b_none_when_disabled() {

--- a/mur-core/src/conversations/ask/rewriter.rs
+++ b/mur-core/src/conversations/ask/rewriter.rs
@@ -62,7 +62,7 @@ fn truncate_chars(s: &str, max: usize) -> String {
 ///
 /// Short-circuits to `Skipped` when `prior_turns` is empty — no LLM call.
 /// On Ollama error, returns `FailedFellBackToRaw`. On identity echo
-/// (trimmed, case-insensitive), returns `NoRewriteNeeded`.
+/// (trimmed, case-insensitive, ignoring trailing `?!.`), returns `NoRewriteNeeded`.
 pub async fn rewrite(client: &OllamaClient, model: &str, input: RewriteInput<'_>) -> RewriteResult {
     if input.prior_turns.is_empty() {
         return RewriteResult {
@@ -108,7 +108,9 @@ pub async fn rewrite(client: &OllamaClient, model: &str, input: RewriteInput<'_>
                     status: RewriterStatus::FailedFellBackToRaw,
                 };
             }
-            let status = if trimmed.to_lowercase() == input.raw_question.trim().to_lowercase() {
+            let status = if normalize_for_compare(&trimmed)
+                == normalize_for_compare(input.raw_question)
+            {
                 RewriterStatus::NoRewriteNeeded
             } else {
                 RewriterStatus::Rewrote
@@ -123,6 +125,16 @@ pub async fn rewrite(client: &OllamaClient, model: &str, input: RewriteInput<'_>
             }
         }
     }
+}
+
+/// Lowercase + strip trailing `?!.` + whitespace. Used so a rewriter that
+/// echoes back a question with different trailing punctuation still resolves
+/// to `NoRewriteNeeded` rather than being mislabelled as `Rewrote`.
+fn normalize_for_compare(s: &str) -> String {
+    s.trim()
+        .trim_end_matches(['?', '!', '.'])
+        .trim()
+        .to_lowercase()
 }
 
 #[cfg(test)]

--- a/mur-core/src/conversations/ask/rewriter.rs
+++ b/mur-core/src/conversations/ask/rewriter.rs
@@ -108,13 +108,12 @@ pub async fn rewrite(client: &OllamaClient, model: &str, input: RewriteInput<'_>
                     status: RewriterStatus::FailedFellBackToRaw,
                 };
             }
-            let status = if normalize_for_compare(&trimmed)
-                == normalize_for_compare(input.raw_question)
-            {
-                RewriterStatus::NoRewriteNeeded
-            } else {
-                RewriterStatus::Rewrote
-            };
+            let status =
+                if normalize_for_compare(&trimmed) == normalize_for_compare(input.raw_question) {
+                    RewriterStatus::NoRewriteNeeded
+                } else {
+                    RewriterStatus::Rewrote
+                };
             RewriteResult {
                 rewritten: if status == RewriterStatus::NoRewriteNeeded {
                     input.raw_question.to_string()

--- a/mur-core/src/conversations/ask/session.rs
+++ b/mur-core/src/conversations/ask/session.rs
@@ -189,7 +189,9 @@ fn prune_history(hist_dir: &std::path::Path, retain: u32) -> Result<()> {
     entries.sort();
     let drop_count = entries.len() - retain as usize;
     for p in entries.into_iter().take(drop_count) {
-        let _ = std::fs::remove_file(&p);
+        if let Err(e) = std::fs::remove_file(&p) {
+            tracing::warn!("prune_history: failed to remove {:?}: {}", p, e);
+        }
     }
     Ok(())
 }
@@ -377,5 +379,57 @@ mod tests {
         );
         assert_eq!(session.turns[0].turn_id, 1);
         assert_eq!(session.turns[1].turn_id, 2);
+    }
+
+    /// M2 (phase 3.3 review follow-up): after `archive_and_new`, the returned
+    /// `Session` should behave like a fresh store — subsequent `append_turn`
+    /// creates a NEW active file (not resurrecting the archived content) and
+    /// `load_latest` should see only the new turns. Regression guard against
+    /// anyone accidentally leaving the old path reference in the returned
+    /// Session.
+    #[test]
+    fn append_after_archive_starts_fresh_active_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+
+        // Seed a session with 2 turns.
+        let mut first = SessionStore::load_latest(Some(root)).unwrap();
+        SessionStore::append_turn(&mut first, dummy_turn(1, "old-q1")).unwrap();
+        SessionStore::append_turn(&mut first, dummy_turn(2, "old-q2")).unwrap();
+        assert_eq!(first.turns.len(), 2);
+
+        // Archive it, get a new Session.
+        let mut second = SessionStore::archive_and_new(Some(root), 5).unwrap();
+        assert!(
+            second.turns.is_empty(),
+            "new Session should be empty after archive"
+        );
+
+        // Append to the new Session.
+        SessionStore::append_turn(&mut second, dummy_turn(1, "new-q1")).unwrap();
+        assert_eq!(second.turns.len(), 1);
+        assert_eq!(second.turns[0].question, "new-q1");
+
+        // A fresh load_latest must also see ONLY the new turn (the archived
+        // file lives under .history/ and is not picked up by load_latest).
+        let reloaded = SessionStore::load_latest(Some(root)).unwrap();
+        assert_eq!(
+            reloaded.turns.len(),
+            1,
+            "load_latest should see only the post-archive turn"
+        );
+        assert_eq!(reloaded.turns[0].question, "new-q1");
+
+        // And the archived file must exist separately.
+        let hist = crate::conversations::paths::ask_session_history_dir(Some(root));
+        let archived: Vec<_> = std::fs::read_dir(&hist)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(
+            archived.len(),
+            1,
+            "exactly one archived session file expected"
+        );
     }
 }

--- a/mur-core/src/conversations/ollama.rs
+++ b/mur-core/src/conversations/ollama.rs
@@ -303,7 +303,10 @@ fn mock_generate(req: &GenerateRequest<'_>) -> GenerateResponse {
         } else {
             "Mock narrative: today the developer explored mock compression.".to_string()
         }
-    } else if req.prompt.contains("Standalone question:") {
+    } else if req.prompt.trim_end().ends_with("Standalone question:") {
+        // Match only CONDENSE prompts that END with this marker (the real
+        // prompt template places it as the final line). `contains` would
+        // mis-route any user question that happens to include the phrase.
         extract_latest_question_from_condense_prompt(req.prompt)
     } else if req.prompt.contains("[cit:") {
         "Mock answer about the archive [cit: 2026-04-19 claude-code/mock:L1].".to_string()

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -382,7 +382,7 @@ enum Commands {
         new_flag: bool,
         /// Print current session path, turn count, last turn time.
         /// Ignores question if given; no LLM calls.
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["continue_flag", "new_flag"])]
         show_session: bool,
     },
     #[cfg(feature = "sources")]


### PR DESCRIPTION
## Why

Second-pass of the Phase 3.3 deep code review. PR #19 closed the Critical + durability-High findings (JSON path persistence, parent-dir fsync, concurrent-writer atomicity). This PR knocks out the remaining items except **L4** (evaluated + deferred — see below).

## What

**H3 — separate, shorter rewriter timeout** (\`mur-common/config.rs\`, \`cmd/conversations_cmd.rs\`)
Before: rewriter + generate shared a 30s-capped \`OllamaClient\`. A slow/unreachable Ollama burned 30s before falling back to the raw question — not proportionate to rewriter output size (~80 tokens) and non-fatality. Now \`AskConfig\` has a \`rewriter_timeout_secs\` (default **8s**); cmd_ask builds a dedicated \`rewriter_client\` with that budget.

**M1 — clap mutex on \`--show-session\`** (\`main.rs\`)
\`--show-session\` now \`conflicts_with_all = [\"continue_flag\", \"new_flag\"]\`. \`mur ask --show-session --continue \"q\"\` errors explicitly instead of silently ignoring.

**M2 — 2 new edge-case tests**
- \`session::tests::append_after_archive_starts_fresh_active_file\` — proves post-\`archive_and_new\` Session writes fresh, \`load_latest\` sees only the new turn, archive exists under \`.history/\`.
- \`prompt::tests::render_terminates_on_zero_budget\` — regression guard for the Stage-3 exit condition (\`trimmed_hits > 1\`) under \`max_context_tokens = 0\`.

The other two tests the review listed (rewriter-timeout integration, \`--show-session\` mid-turn) need disproportionate scaffolding — \"accept-but-never-respond\" mock server, no external \"mid-turn\" state exists — not added.

**M3 — robust \`NoRewriteNeeded\` discriminator** (\`rewriter.rs\`)
New \`normalize_for_compare\` helper: trim → strip trailing \`?!.\` → lowercase. A rewriter that echoes a question with different trailing punctuation now correctly resolves to \`NoRewriteNeeded\`.

**M4 — mock \`Standalone question:\` sentinel hardened** (\`ollama.rs\`)
\`req.prompt.trim_end().ends_with(\"Standalone question:\")\` instead of \`contains(...)\`. A user question containing the phrase no longer misroutes into the identity-rewriter branch when \`MUR_OLLAMA_MOCK=1\`.

**L1 — \`prune_history\` logs on failure** (\`session.rs\`)
\`let _ = remove_file(&p);\` → \`if let Err(e) = remove_file(&p) { tracing::warn!(...) }\`. Consistent with the rest of the module's warn-on-non-fatal pattern.

## Deferred

**L4 — O(n²) history re-render** in the prompt trim loop. Evaluated. Practical hot path is the default 3-turn history (9 iterations worst case). Fix would require splitting \`render_ctx_and_user\` into \`build_ctx\` + \`assemble_user\` and threading a cached ctx string through both overflow stages — a net readability loss for sub-millisecond gain. File follow-up if someone pushes history_turns > 20 and hits a budget overflow.

**L3** (plan doc typo \`new_flag\` vs \`new\`) — nothing to ship.
**L2** (\`Session.path\` private-but-unused) — the reviewer's claim is incorrect; \`path\` IS used via \`append_turn\` + \`archive_and_new\`. Skipped.

## Diff stats

7 files changed, 130 insertions(+), 8 deletions(-)

## Test plan

- [x] \`cargo test -p mur-core --lib conversations::ask\` — 100 passed
- [x] \`cargo test --workspace\` — 798 + 806 + 21 + 6 misc, 0 fail
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] CI: Test × ubuntu/macos/windows + Clippy + Format all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)