### PR TITLE
feat(drafts): mur drafts CLI — list/show/accept/reject pending pattern drafts

### DIFF
--- a/mur-core/src/auth.rs
+++ b/mur-core/src/auth.rs
@@ -48,6 +48,17 @@ pub struct ErrorResponse {
 }
 
 fn auth_path() -> PathBuf {
+    // Honor MUR_HOME (authoritative, cross-platform) the same way
+    // `store::config::config_path` and `conversations::paths::mur_root` do.
+    // On Windows, `dirs::home_dir()` calls `SHGetKnownFolderPath` and
+    // ignores `HOME`/`USERPROFILE` env overrides, so integration tests
+    // (and users relocating their mur root) need MUR_HOME to redirect
+    // `auth.json` as well.
+    if let Ok(p) = std::env::var("MUR_HOME")
+        && !p.is_empty()
+    {
+        return PathBuf::from(p).join("auth.json");
+    }
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("~"))
         .join(".mur")

--- a/mur-core/src/auth.rs
+++ b/mur-core/src/auth.rs
@@ -48,21 +48,14 @@ pub struct ErrorResponse {
 }
 
 fn auth_path() -> PathBuf {
-    // Honor MUR_HOME (authoritative, cross-platform) the same way
-    // `store::config::config_path` and `conversations::paths::mur_root` do.
-    // On Windows, `dirs::home_dir()` calls `SHGetKnownFolderPath` and
-    // ignores `HOME`/`USERPROFILE` env overrides, so integration tests
-    // (and users relocating their mur root) need MUR_HOME to redirect
-    // `auth.json` as well.
-    if let Ok(p) = std::env::var("MUR_HOME")
-        && !p.is_empty()
-    {
-        return PathBuf::from(p).join("auth.json");
-    }
-    dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("~"))
-        .join(".mur")
-        .join("auth.json")
+    // Route through `crate::paths::mur_root` (added in Phase 1 of the
+    // Windows CI hardening effort, PR #26). That helper honors `MUR_HOME`
+    // authoritatively — needed on Windows because `dirs::home_dir()` uses
+    // `SHGetKnownFolderPath` and ignores `HOME` / `USERPROFILE`. Without
+    // it, integration tests (and users who relocate their mur root) hit
+    // the host profile's `~/.mur/auth.json` and `load_tokens()` returns
+    // `None`.
+    crate::paths::mur_root(None).join("auth.json")
 }
 
 /// Load stored auth tokens, if any.

--- a/mur-core/src/cmd/drafts.rs
+++ b/mur-core/src/cmd/drafts.rs
@@ -1,0 +1,271 @@
+//! `mur drafts` — list / show / accept / reject pending pattern drafts.
+//!
+//! Drafts are server-side proposals (Channel 2/3) created from Signals whose
+//! target is `NewDraftPattern`. Unlike signals, drafts are NOT routed through
+//! the shared Inbox; they are queried on-demand via this subcommand tree.
+//!
+//! Endpoints:
+//! - `GET  /api/v1/core/drafts/pending?since=&limit=`
+//! - `POST /api/v1/core/drafts/{id}/reject`
+//!
+//! See also: `sync/client.rs` for `fetch_drafts` / `reject_draft`.
+
+use anyhow::{Context, Result, anyhow};
+use chrono::{Duration, Utc};
+use mur_common::pattern::Pattern;
+
+use crate::store::yaml::YamlStore;
+use crate::sync::{DraftRecord, SyncClient};
+
+/// Page size for `fetch_drafts` pagination. Chosen so a typical user can
+/// dump a month of inbox in 1–2 round trips.
+const DEFAULT_PAGE_LIMIT: u32 = 100;
+
+fn client_from_env() -> Result<SyncClient> {
+    let tokens =
+        crate::auth::load_tokens().ok_or_else(|| anyhow!("not logged in (run `mur login`)"))?;
+    let url = crate::auth::server_url();
+    SyncClient::new(url, tokens.access_token)
+}
+
+/// Fetch all pending drafts, paginating via `next_cursor` until exhausted
+/// or the server returns an empty page. Optionally filter to drafts created
+/// within the last `since_days` days (client-side; server currently returns
+/// all pending regardless of cursor age).
+async fn fetch_all_pending(client: &SyncClient, since_days: u32) -> Result<Vec<DraftRecord>> {
+    let cutoff = Utc::now() - Duration::days(since_days as i64);
+    let mut out: Vec<DraftRecord> = Vec::new();
+    let mut cursor: Option<String> = None;
+    loop {
+        let resp = client
+            .fetch_drafts(cursor.as_deref(), DEFAULT_PAGE_LIMIT)
+            .await
+            .context("fetch_drafts")?;
+        let got = resp.drafts.len();
+        for d in resp.drafts {
+            if d.created_at >= cutoff {
+                out.push(d);
+            }
+        }
+        match resp.next_cursor {
+            Some(c) if !c.is_empty() && got > 0 => cursor = Some(c),
+            _ => break,
+        }
+    }
+    Ok(out)
+}
+
+/// Render the short prefix of a uuid used in the table / prefix-match.
+fn short_id(u: &uuid::Uuid) -> String {
+    u.to_string().chars().take(8).collect()
+}
+
+/// Render the scope field compactly for table output.
+fn scope_label(scope: &mur_common::Scope) -> String {
+    match scope {
+        mur_common::Scope::Personal => "personal".to_string(),
+        mur_common::Scope::Team { team_id } => format!("team:{team_id}"),
+        mur_common::Scope::Community { pack_id } => match pack_id {
+            Some(p) => format!("community:{p}"),
+            None => "community".to_string(),
+        },
+    }
+}
+
+/// `mur drafts list [--since DAYS]`
+pub(crate) async fn cmd_drafts_list(since_days: u32) -> Result<()> {
+    let client = client_from_env()?;
+    let drafts = fetch_all_pending(&client, since_days).await?;
+
+    if drafts.is_empty() {
+        println!("no drafts");
+        return Ok(());
+    }
+
+    println!(
+        "{:<10} {:<20} {:<16} {:<8} {:<10} NAME",
+        "ID", "CREATED", "SCOPE", "STATUS", "CONFIDENCE"
+    );
+    for d in &drafts {
+        println!(
+            "{:<10} {:<20} {:<16} {:<8} {:<10.2} {}",
+            short_id(&d.id),
+            d.created_at.format("%Y-%m-%d %H:%M:%S"),
+            scope_label(&d.scope),
+            d.status,
+            d.confidence,
+            d.payload.name
+        );
+    }
+    Ok(())
+}
+
+/// Resolve a user-supplied id prefix against a slice of drafts.
+/// Ambiguity or no-match is a hard error (stable messages so integration
+/// tests + docs can match on them).
+fn resolve_prefix<'a>(prefix: &str, drafts: &'a [DraftRecord]) -> Result<&'a DraftRecord> {
+    let matches: Vec<&DraftRecord> = drafts
+        .iter()
+        .filter(|d| d.id.to_string().starts_with(prefix))
+        .collect();
+    match matches.len() {
+        0 => Err(anyhow!("no pending draft with id prefix '{prefix}'")),
+        1 => Ok(matches[0]),
+        n => Err(anyhow!(
+            "ambiguous id prefix '{prefix}' — matched {n} drafts"
+        )),
+    }
+}
+
+/// `mur drafts show <id-prefix>`
+pub(crate) async fn cmd_drafts_show(prefix: &str) -> Result<()> {
+    let client = client_from_env()?;
+    let drafts = fetch_all_pending(&client, 365).await?; // wide net for show
+    let d = resolve_prefix(prefix, &drafts)?;
+
+    println!("id:             {}", d.id);
+    println!("created_at:     {}", d.created_at);
+    println!("status:         {}", d.status);
+    println!("scope:          {}", scope_label(&d.scope));
+    println!("confidence:     {:.2}", d.confidence);
+    println!("origin_context: {}", d.origin_context);
+    println!();
+    println!("---  pattern payload  ---");
+    println!(
+        "{}",
+        serde_yaml::to_string(&d.payload).context("serialize pattern")?
+    );
+    Ok(())
+}
+
+/// `mur drafts accept <id-prefix> [--as-tier <tier>]`
+///
+/// Takes the embedded Pattern, promotes its maturity to `Emerging` (the
+/// acceptance itself is the human gate), optionally overrides tier, saves
+/// to `~/.mur/patterns/<name>.yaml` via [`YamlStore`], and prints a hint
+/// to run `mur reindex`.
+///
+/// **Known limitation (MVP):** accept does NOT notify the server. The next
+/// `mur drafts list` call will still surface this draft as pending. Use
+/// `mur drafts reject --reason accepted_locally` to hide it, or wait for
+/// a follow-up that adds a server-side accept endpoint.
+pub(crate) async fn cmd_drafts_accept(prefix: &str, as_tier: Option<&str>) -> Result<()> {
+    let client = client_from_env()?;
+    let drafts = fetch_all_pending(&client, 365).await?;
+    let d = resolve_prefix(prefix, &drafts)?;
+
+    let mut pattern: Pattern = d.payload.clone();
+    pattern.base.maturity = mur_common::knowledge::Maturity::Emerging;
+
+    if let Some(t) = as_tier {
+        pattern.base.tier = match t {
+            "session" => mur_common::pattern::Tier::Session,
+            "project" => mur_common::pattern::Tier::Project,
+            "core" => mur_common::pattern::Tier::Core,
+            other => {
+                return Err(anyhow!(
+                    "unknown tier '{other}' (want session|project|core)"
+                ));
+            }
+        };
+    }
+
+    let store = YamlStore::default_store()?;
+    store.save(&pattern).context("save accepted pattern")?;
+
+    println!(
+        "accepted draft {} -> ~/.mur/patterns/{}.yaml (maturity=emerging)",
+        short_id(&d.id),
+        pattern.name
+    );
+    println!("run `mur reindex` to update the vector index");
+    // TODO: once the server grows an /accept endpoint (or we repurpose
+    // reject with a sentinel reason), notify the server so this draft
+    // stops appearing in `drafts list`. For now accept is local-only.
+    Ok(())
+}
+
+/// `mur drafts reject <id-prefix> [--reason "..."]`
+pub(crate) async fn cmd_drafts_reject(prefix: &str, reason: Option<&str>) -> Result<()> {
+    let client = client_from_env()?;
+    let drafts = fetch_all_pending(&client, 365).await?;
+    let d = resolve_prefix(prefix, &drafts)?;
+    client
+        .reject_draft(d.id, reason)
+        .await
+        .context("reject_draft")?;
+    println!("rejected draft {}", short_id(&d.id));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_draft(id_hex: &str, name: &str) -> DraftRecord {
+        let id = uuid::Uuid::parse_str(id_hex).unwrap();
+        DraftRecord {
+            id,
+            scope: mur_common::Scope::Personal,
+            payload: Pattern {
+                base: mur_common::knowledge::KnowledgeBase {
+                    name: name.into(),
+                    description: "x".into(),
+                    content: mur_common::pattern::Content::Plain("x".into()),
+                    ..Default::default()
+                },
+                kind: None,
+                origin: None,
+                attachments: vec![],
+            },
+            origin_context: "".into(),
+            confidence: 1.0,
+            status: "pending".into(),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn resolve_prefix_unique_match() {
+        let drafts = vec![
+            make_draft("11111111-1111-1111-1111-111111111111", "a"),
+            make_draft("22222222-2222-2222-2222-222222222222", "b"),
+        ];
+        let r = resolve_prefix("1111", &drafts).unwrap();
+        assert_eq!(r.payload.name, "a");
+    }
+
+    #[test]
+    fn resolve_prefix_ambiguous_errors() {
+        let drafts = vec![
+            make_draft("11111111-1111-1111-1111-111111111111", "a"),
+            make_draft("11112222-2222-2222-2222-222222222222", "b"),
+        ];
+        let err = resolve_prefix("1111", &drafts).unwrap_err();
+        assert!(format!("{err}").contains("ambiguous"));
+    }
+
+    #[test]
+    fn resolve_prefix_no_match_errors() {
+        let drafts = vec![make_draft("11111111-1111-1111-1111-111111111111", "a")];
+        let err = resolve_prefix("abcd", &drafts).unwrap_err();
+        assert!(format!("{err}").contains("no pending draft"));
+    }
+
+    #[test]
+    fn scope_label_matches_expected_formats() {
+        assert_eq!(scope_label(&mur_common::Scope::Personal), "personal");
+        assert_eq!(
+            scope_label(&mur_common::Scope::Team {
+                team_id: "ops".into()
+            }),
+            "team:ops"
+        );
+        assert_eq!(
+            scope_label(&mur_common::Scope::Community {
+                pack_id: Some("rs".into())
+            }),
+            "community:rs"
+        );
+    }
+}

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod community_cmd;
 pub(crate) mod context;
 pub(crate) mod conversations_cmd;
 pub(crate) mod deploy;
+pub(crate) mod drafts;
 pub(crate) mod evolve_cmd;
 pub(crate) mod init;
 pub(crate) mod inject_cmd;

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -326,6 +326,11 @@ enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+    /// List / show / accept / reject pending pattern drafts (Channel 2/3 proposals).
+    Drafts {
+        #[command(subcommand)]
+        action: DraftsAction,
+    },
     /// Stop recording without export (alias: quit)
     Exit,
     /// Stop recording without export (alias: exit)
@@ -837,6 +842,38 @@ enum ConversationsAction {
 }
 
 #[derive(Subcommand)]
+enum DraftsAction {
+    /// List pending pattern drafts in a compact table.
+    List {
+        /// Only include drafts created within the last N days (default 30).
+        #[arg(long, default_value_t = 30)]
+        since: u32,
+    },
+    /// Show the full YAML + metadata for a single draft by id-prefix.
+    Show {
+        /// Unambiguous prefix of the draft's uuid (e.g. first 8 chars).
+        id: String,
+    },
+    /// Accept a draft locally: saves the embedded Pattern to ~/.mur/patterns/
+    /// with maturity=emerging. Does NOT yet notify the server (MVP).
+    Accept {
+        /// Unambiguous prefix of the draft's uuid.
+        id: String,
+        /// Override tier: session | project | core.
+        #[arg(long = "as-tier")]
+        as_tier: Option<String>,
+    },
+    /// Reject a draft server-side with an optional reason.
+    Reject {
+        /// Unambiguous prefix of the draft's uuid.
+        id: String,
+        /// Optional human-readable reason recorded on the draft.
+        #[arg(long)]
+        reason: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
 enum DeployAction {
     /// Start services (docker compose up)
     Up {
@@ -1171,6 +1208,16 @@ async fn async_main() -> Result<()> {
             let config = crate::store::config::load_config()?;
             cmd::sync_cmd::run_fetch(&config.server.url, dry_run).await?;
         }
+        Commands::Drafts { action } => match action {
+            DraftsAction::List { since } => cmd::drafts::cmd_drafts_list(since).await?,
+            DraftsAction::Show { id } => cmd::drafts::cmd_drafts_show(&id).await?,
+            DraftsAction::Accept { id, as_tier } => {
+                cmd::drafts::cmd_drafts_accept(&id, as_tier.as_deref()).await?
+            }
+            DraftsAction::Reject { id, reason } => {
+                cmd::drafts::cmd_drafts_reject(&id, reason.as_deref()).await?
+            }
+        },
         Commands::Exit | Commands::Quit => cmd::session::cmd_session_exit()?,
         Commands::Chat { action } => match action {
             ChatAction::List { since, src } => cmd::conversations_cmd::cmd_chat_list(since, src)?,

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -17,6 +17,7 @@ mod gep;
 mod inject;
 mod interactive;
 mod llm;
+mod paths;
 mod retrieve;
 mod server;
 mod session;

--- a/mur-core/src/sync/client.rs
+++ b/mur-core/src/sync/client.rs
@@ -4,9 +4,11 @@
 //! `mur fetch` (calls `fetch_pending` → writes to Inbox → `ack`).
 
 use anyhow::{Context, Result};
-use mur_common::Signal;
-use reqwest::Client;
+use chrono::{DateTime, Utc};
+use mur_common::{Pattern, Scope, Signal};
+use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// HTTP client for the mur-server sync API. Carries a bearer token.
 pub struct SyncClient {
@@ -41,6 +43,39 @@ pub struct RejectedSignal {
 pub struct PendingResponse {
     pub signals: Vec<Signal>,
     pub next_cursor: Option<String>,
+}
+
+/// One draft as returned by `GET /api/v1/core/drafts/pending`.
+///
+/// Mirrors a subset of `models.PatternDraft` (server-side). We use the
+/// server's JSON tag names verbatim; fields we don't need on the client
+/// (`signal_id`, `source_actor`, `reject_reason`, `reviewed_at`) are
+/// intentionally omitted — `serde` ignores unknown keys.
+#[derive(Debug, Deserialize, Clone)]
+pub struct DraftRecord {
+    pub id: Uuid,
+    pub scope: Scope,
+    pub payload: Pattern,
+    #[serde(default)]
+    pub origin_context: String,
+    #[serde(default)]
+    pub confidence: f64,
+    #[serde(default)]
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Response body of `GET /api/v1/core/drafts/pending`.
+#[derive(Debug, Deserialize, Clone)]
+pub struct DraftsPendingResponse {
+    pub drafts: Vec<DraftRecord>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RejectDraftRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'a str>,
 }
 
 impl SyncClient {
@@ -94,6 +129,57 @@ impl SyncClient {
         resp.json::<PendingResponse>()
             .await
             .context("decode PendingResponse")
+    }
+
+    /// Fetch a page of pending drafts for the caller. The server paginates via
+    /// an opaque `next_cursor` string — passing it back as `cursor` retrieves
+    /// the next page. `limit` is passed as the `limit` query param.
+    pub async fn fetch_drafts(
+        &self,
+        cursor: Option<&str>,
+        limit: u32,
+    ) -> Result<DraftsPendingResponse> {
+        let mut url = format!(
+            "{}/api/v1/core/drafts/pending?limit={}",
+            self.base_url, limit
+        );
+        if let Some(c) = cursor {
+            url.push_str("&since=");
+            url.push_str(&urlencoding::encode(c));
+        }
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .with_context(|| format!("GET {url}"))?
+            .error_for_status()
+            .with_context(|| "fetch_drafts non-2xx")?;
+        resp.json::<DraftsPendingResponse>()
+            .await
+            .context("decode DraftsPendingResponse")
+    }
+
+    /// Reject a pending draft. Returns `Ok(())` on any 2xx (server returns
+    /// 204 No Content on success). Maps 403 → "not owned by you" and 404 →
+    /// "not found" with the draft id in the message.
+    pub async fn reject_draft(&self, id: Uuid, reason: Option<&str>) -> Result<()> {
+        let url = format!("{}/api/v1/core/drafts/{}/reject", self.base_url, id);
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.token)
+            .json(&RejectDraftRequest { reason })
+            .send()
+            .await
+            .with_context(|| format!("POST {url}"))?;
+        match resp.status() {
+            s if s.is_success() => Ok(()),
+            StatusCode::FORBIDDEN => Err(anyhow::anyhow!("draft {id} not owned by you")),
+            StatusCode::NOT_FOUND => Err(anyhow::anyhow!("draft {id} not found")),
+            other => Err(anyhow::anyhow!("reject_draft {id} failed: HTTP {other}")),
+        }
     }
 
     pub async fn ack(&self, signal_ids: &[String]) -> Result<()> {
@@ -298,5 +384,124 @@ mod tests {
             .await
             .unwrap();
         assert!(r.signals.is_empty());
+    }
+
+    // ─── Draft API tests ─────────────────────────────────────────
+
+    fn sample_draft_json(id: Uuid, name: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "signal_id": Uuid::new_v4(),
+            "actor_user_id": Uuid::new_v4(),
+            "scope": {"kind": "personal"},
+            "source_actor": {
+                "source": "Slack",
+                "native_id": "U1",
+                "display_name": null,
+                "resolved_user_id": null
+            },
+            "payload": {
+                "schema": 2,
+                "name": name,
+                "description": "A draft pattern",
+                "content": "use pnpm not npm",
+                "tier": "project"
+            },
+            "origin_context": "#eng chat",
+            "confidence": 0.87,
+            "status": "pending",
+            "created_at": "2026-04-22T10:30:00Z",
+            "reviewed_at": null
+        })
+    }
+
+    #[tokio::test]
+    async fn fetch_drafts_happy_path_parses_payload() {
+        let server = MockServer::start().await;
+        let id = Uuid::new_v4();
+        Mock::given(method("GET"))
+            .and(path("/api/v1/core/drafts/pending"))
+            .and(query_param("limit", "50"))
+            .and(header("authorization", "Bearer TOK"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "drafts": [sample_draft_json(id, "use-pnpm-not-npm")],
+                "next_cursor": null
+            })))
+            .mount(&server)
+            .await;
+
+        let c = SyncClient::new(server.uri(), "TOK").unwrap();
+        let r = c.fetch_drafts(None, 50).await.unwrap();
+        assert_eq!(r.drafts.len(), 1);
+        assert_eq!(r.drafts[0].id, id);
+        assert_eq!(r.drafts[0].payload.name, "use-pnpm-not-npm");
+        assert_eq!(r.drafts[0].scope, Scope::Personal);
+        assert!(r.next_cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_drafts_passes_since_cursor() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/core/drafts/pending"))
+            .and(query_param("limit", "10"))
+            .and(query_param("since", "cur1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "drafts": [],
+                "next_cursor": "cur2"
+            })))
+            .mount(&server)
+            .await;
+
+        let c = SyncClient::new(server.uri(), "TOK").unwrap();
+        let r = c.fetch_drafts(Some("cur1"), 10).await.unwrap();
+        assert_eq!(r.next_cursor.as_deref(), Some("cur2"));
+    }
+
+    #[tokio::test]
+    async fn reject_draft_happy_path_sends_reason() {
+        let server = MockServer::start().await;
+        let id = Uuid::new_v4();
+        Mock::given(method("POST"))
+            .and(path(format!("/api/v1/core/drafts/{id}/reject")))
+            .and(header("authorization", "Bearer TOK"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let c = SyncClient::new(server.uri(), "TOK").unwrap();
+        c.reject_draft(id, Some("not useful")).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reject_draft_forbidden_maps_to_owner_error() {
+        let server = MockServer::start().await;
+        let id = Uuid::new_v4();
+        Mock::given(method("POST"))
+            .and(path(format!("/api/v1/core/drafts/{id}/reject")))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        let c = SyncClient::new(server.uri(), "TOK").unwrap();
+        let err = c.reject_draft(id, None).await.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("not owned by you"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn reject_draft_not_found_maps_to_not_found_error() {
+        let server = MockServer::start().await;
+        let id = Uuid::new_v4();
+        Mock::given(method("POST"))
+            .and(path(format!("/api/v1/core/drafts/{id}/reject")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let c = SyncClient::new(server.uri(), "TOK").unwrap();
+        let err = c.reject_draft(id, None).await.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("not found"), "got: {msg}");
     }
 }

--- a/mur-core/src/sync/mod.rs
+++ b/mur-core/src/sync/mod.rs
@@ -11,7 +11,8 @@ pub mod cursor;
 pub mod inbox;
 pub mod outbox;
 
-pub use client::SyncClient;
+#[allow(unused_imports)]
+pub use client::{DraftRecord, DraftsPendingResponse, SyncClient};
 pub use cursor::{CursorStore, FetchCursor};
 pub use inbox::Inbox;
 pub use outbox::Outbox;

--- a/mur-core/tests/cli_drafts.rs
+++ b/mur-core/tests/cli_drafts.rs
@@ -1,0 +1,245 @@
+//! Integration tests for the `mur drafts` subcommand tree.
+//!
+//! These tests spin up a local wiremock server, write a fake `auth.json`
+//! under a tmp `$HOME`, and drive the CLI end-to-end. They do NOT assert
+//! the full wire format of outgoing requests (those are unit-tested in
+//! `mur-core/src/sync/client.rs`); here we verify the plumbing:
+//! env → CLI → SyncClient → server → stdout.
+
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::json;
+use uuid::Uuid;
+use wiremock::matchers::{method, path, query_param, query_param_is_missing};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Tmp-rooted env shared by every test: pins `MUR_HOME`, `HOME`,
+/// `USERPROFILE`, and `MUR_SERVER_URL`. Also writes a fake `auth.json`
+/// so `crate::auth::load_tokens()` returns `Some`.
+fn setup_env(tmp: &Path, server_url: &str) {
+    let mur_home = tmp.join(".mur");
+    std::fs::create_dir_all(&mur_home).expect("mkdir .mur");
+    std::fs::write(
+        mur_home.join("auth.json"),
+        json!({
+            "access_token": "TEST-TOKEN",
+            "refresh_token": "",
+            "token_type": "Bearer",
+            "expires_in": 86400,
+            "user_id": "test-user"
+        })
+        .to_string(),
+    )
+    .expect("write auth.json");
+    // Also write a minimal config.yaml pointing server.url at the mock —
+    // some code paths (not the drafts client, but dependencies) still read
+    // config. auth::server_url() prefers MUR_SERVER_URL so we don't strictly
+    // need this, but it keeps the test hermetic.
+    std::fs::write(
+        mur_home.join("config.yaml"),
+        format!("server:\n  url: {server_url}\n"),
+    )
+    .expect("write config.yaml");
+}
+
+/// Attach pinned env vars to a Command. Mirrors `with_mur_home` in
+/// cli_conversations.rs but also sets `MUR_SERVER_URL`.
+fn mur_cmd(tmp: &Path, server_url: &str, args: &[&str]) -> Command {
+    let mur_home = tmp.join(".mur");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_mur"));
+    cmd.args(args)
+        .env("MUR_HOME", &mur_home)
+        .env("HOME", tmp)
+        .env("USERPROFILE", tmp)
+        .env("MUR_SERVER_URL", server_url);
+    cmd
+}
+
+fn sample_draft_json(id: Uuid, name: &str) -> serde_json::Value {
+    json!({
+        "id": id,
+        "signal_id": Uuid::new_v4(),
+        "actor_user_id": Uuid::new_v4(),
+        "scope": {"kind": "team", "team_id": "ops"},
+        "source_actor": {
+            "source": "Slack",
+            "native_id": "U1",
+            "display_name": null,
+            "resolved_user_id": null
+        },
+        "payload": {
+            "schema": 2,
+            "name": name,
+            "description": "draft description",
+            "content": "do X when Y",
+            "tier": "project"
+        },
+        "origin_context": "#eng thread",
+        "confidence": 0.87,
+        "status": "pending",
+        "created_at": "2026-04-22T10:30:00Z",
+        "reviewed_at": null
+    })
+}
+
+#[tokio::test]
+async fn mur_drafts_list_empty_prints_no_drafts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+    setup_env(tmp.path(), &server.uri());
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/core/drafts/pending"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "drafts": [],
+            "next_cursor": null
+        })))
+        .mount(&server)
+        .await;
+
+    let out = mur_cmd(tmp.path(), &server.uri(), &["drafts", "list"])
+        .output()
+        .expect("run mur drafts list");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("no drafts"),
+        "expected 'no drafts'; got: {stdout}"
+    );
+}
+
+#[tokio::test]
+async fn mur_drafts_list_paginates_across_cursor_boundary() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+    setup_env(tmp.path(), &server.uri());
+
+    let id1 = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    let id2 = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+
+    // Page 1: no `since` → 2 drafts + next_cursor=foo. We must explicitly
+    // require the `since` query param to be absent — otherwise this mock
+    // also matches the page-2 request (which has both limit=100 AND
+    // since=foo) and the client loops forever because every page hands
+    // back next_cursor=foo.
+    Mock::given(method("GET"))
+        .and(path("/api/v1/core/drafts/pending"))
+        .and(query_param("limit", "100"))
+        .and(query_param_is_missing("since"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "drafts": [sample_draft_json(id1, "pat-one"), sample_draft_json(id2, "pat-two")],
+            "next_cursor": "foo"
+        })))
+        .mount(&server)
+        .await;
+
+    // Page 2: since=foo → empty + next_cursor=null
+    Mock::given(method("GET"))
+        .and(path("/api/v1/core/drafts/pending"))
+        .and(query_param("since", "foo"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "drafts": [],
+            "next_cursor": null
+        })))
+        .mount(&server)
+        .await;
+
+    // Use a very generous --since so the 2026-04-22 fixture isn't filtered.
+    let out = mur_cmd(
+        tmp.path(),
+        &server.uri(),
+        &["drafts", "list", "--since", "3650"],
+    )
+    .output()
+    .expect("run mur drafts list");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("pat-one"), "stdout: {stdout}");
+    assert!(stdout.contains("pat-two"), "stdout: {stdout}");
+    assert!(stdout.contains("team:ops"), "stdout: {stdout}");
+}
+
+#[tokio::test]
+async fn mur_drafts_reject_happy_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+    setup_env(tmp.path(), &server.uri());
+
+    let id = Uuid::parse_str("abc12345-0000-0000-0000-000000000000").unwrap();
+    Mock::given(method("GET"))
+        .and(path("/api/v1/core/drafts/pending"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "drafts": [sample_draft_json(id, "use-pnpm")],
+            "next_cursor": null
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/api/v1/core/drafts/{id}/reject")))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let out = mur_cmd(
+        tmp.path(),
+        &server.uri(),
+        &["drafts", "reject", "abc12345", "--reason", "not useful"],
+    )
+    .output()
+    .expect("run mur drafts reject");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("rejected draft"),
+        "expected confirmation; got: {stdout}"
+    );
+}
+
+#[tokio::test]
+async fn mur_drafts_show_resolves_prefix() {
+    let tmp = tempfile::tempdir().unwrap();
+    let server = MockServer::start().await;
+    setup_env(tmp.path(), &server.uri());
+
+    let id = Uuid::parse_str("abc12345-0000-0000-0000-000000000000").unwrap();
+    Mock::given(method("GET"))
+        .and(path("/api/v1/core/drafts/pending"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "drafts": [sample_draft_json(id, "use-pnpm")],
+            "next_cursor": null
+        })))
+        .mount(&server)
+        .await;
+
+    let out = mur_cmd(tmp.path(), &server.uri(), &["drafts", "show", "abc1"])
+        .output()
+        .expect("run mur drafts show");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // The full id and the name from the embedded Pattern payload must both
+    // appear (we pretty-print the YAML).
+    assert!(stdout.contains(&id.to_string()), "stdout: {stdout}");
+    assert!(
+        stdout.contains("name: use-pnpm"),
+        "expected Pattern YAML; got: {stdout}"
+    );
+    assert!(stdout.contains("origin_context"), "stdout: {stdout}");
+}


### PR DESCRIPTION
## Summary

Implements the Phase 2 Channel 2/3 human-review entrypoint per spec §2
(`docs/superpowers/specs/2026-04-19-mur-commander-memory-sync-phase-2.md`).

Four subcommands, all uuid-prefix resolved:

- `mur drafts list [--since DAYS]` — compact table of pending drafts
- `mur drafts show <prefix>` — full YAML + metadata
- `mur drafts accept <prefix> [--as-tier session|project|core]` —
  writes the embedded Pattern to `~/.mur/patterns/<name>.yaml` with
  `maturity=Emerging`. **Local-only for MVP** — does not yet notify
  the server (see inline TODO).
- `mur drafts reject <prefix> [--reason "..."]` —
  `POST /api/v1/core/drafts/{id}/reject`

## What changed

| File | Purpose |
|---|---|
| `mur-core/src/sync/client.rs` | `DraftRecord`, `DraftsPendingResponse`, `fetch_drafts()`, `reject_draft()` + 5 wiremock unit tests |
| `mur-core/src/cmd/drafts.rs` | Four subcommand impls + 3 unit tests (prefix resolution, scope label) |
| `mur-core/tests/cli_drafts.rs` | 4 end-to-end wiremock tests pinning `MUR_HOME`/`HOME`/`MUR_SERVER_URL` |
| `mur-core/src/main.rs` + `cmd/mod.rs` + `sync/mod.rs` | clap wiring + module registration |

## Known limitation

`accept` is local-only: the server is not notified, so the draft keeps
surfacing in `mur drafts list`. Two workarounds until a server `/accept`
endpoint lands: `mur drafts reject --reason accepted_locally`, or ignore
and filter client-side.

## Test plan

- [x] `cargo test -p mur-core --test cli_drafts` → 4/4 pass
- [x] `cargo test -p mur-core sync::client::tests` → 5/5 pass (fetch_drafts + reject_draft)
- [x] `cargo clippy -p mur-core --tests -- -D warnings` → clean
- [x] `cargo fmt --check` → clean
- [ ] Manual: against staging server, run `mur drafts list` after seeding a Signal with `NewDraftPattern`
- [ ] Manual: `mur drafts reject <id> --reason "..."` returns 204
- [ ] Manual: `mur drafts accept <id>` writes the expected YAML + `mur reindex` picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)