### PR TITLE
fix: Windows CI hardening Phase 1 — write_summary --force + compact_missing threading + regression test + crate::paths::mur_root groundwork

### DIFF
--- a/docs/superpowers/plans/2026-04-23-mur-windows-ci-hardening-p1.md
+++ b/docs/superpowers/plans/2026-04-23-mur-windows-ci-hardening-p1.md
@@ -1,0 +1,507 @@
+# mur Windows CI Hardening — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the `write_summary` `force` bypass that mirrors Phase 3.5's `write_rollup` fix, add an adversarial CLI regression test that locks the byte-equality-swallows-`--force` bug class, and introduce a crate-level `paths::mur_root` helper that Phase 2 of the hardening effort will use to sweep ~35 `dirs::home_dir()` direct callers.
+
+**Architecture:** Three independent pieces, each small. (1) A new `mur-core/src/paths.rs` with a single `mur_root(override) -> PathBuf` primitive + 3 unit tests. (2) A `force: bool` parameter threaded through `write_summary` (signature change + one non-test caller update + update to 9 test call sites + 1 new unit test). (3) A new CLI integration test in `cli_conversations.rs` that drives `mur conversations compact` twice back-to-back with `--force` and asserts `.history/` gets an archived entry. Zero changes to existing Phase 3.5 or Phase 3.5.1 surface.
+
+**Tech Stack:** Rust 2024 edition, tokio, chrono, tempfile, serde_json, existing mur tooling.
+
+**Base directory:** `/Volumes/Firecuda4tb/Projects/mur/.worktrees/windows-ci-hardening-p1`. Branch: `fix/windows-ci-hardening-p1`. Spec: `docs/superpowers/specs/2026-04-23-mur-windows-ci-hardening-p1-design.md`.
+
+---
+
+## Task 1: `crate::paths::mur_root` helper
+
+**Files:**
+- Create: `mur-core/src/paths.rs`
+- Modify: `mur-core/src/lib.rs` — add `pub mod paths;` in alphabetical order
+
+### Step 1: Write the new module with its 3 unit tests
+
+Create `mur-core/src/paths.rs` with the following contents (production code + tests in one file per Rust convention):
+
+```rust
+//! Crate-level path helpers.
+//!
+//! Use `mur_root` when you need the `.mur` data directory from code outside
+//! `conversations/`. Respects `MUR_HOME` as an authoritative override — on
+//! Windows, `dirs::home_dir()` calls `SHGetKnownFolderPath` and ignores
+//! `HOME`/`USERPROFILE` env overrides, so tests that redirect via env vars
+//! need this escape hatch.
+//!
+//! Semantics are identical to `conversations::paths::mur_root`; Phase 2 of
+//! the Windows CI hardening effort will sweep the ~35
+//! `dirs::home_dir().join(".mur")` direct callers in the crate to use this
+//! one-line helper.
+
+use std::path::PathBuf;
+
+pub fn mur_root(override_path: Option<&str>) -> PathBuf {
+    if let Some(p) = override_path {
+        return PathBuf::from(p);
+    }
+    if let Ok(p) = std::env::var("MUR_HOME")
+        && !p.is_empty()
+    {
+        return PathBuf::from(p);
+    }
+    dirs::home_dir().expect("no home dir").join(".mur")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mur_root_uses_explicit_override_first() {
+        let p = mur_root(Some("/tmp/fake-mur"));
+        assert_eq!(p, PathBuf::from("/tmp/fake-mur"));
+    }
+
+    #[test]
+    fn mur_root_honors_mur_home_env_when_no_override() {
+        // Serialize via the crate-local env-mutex so this test does not race
+        // against `conversations` tests that also mutate MUR_HOME.
+        let _g = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_HOME", "/tmp/via-env") };
+        assert_eq!(mur_root(None), PathBuf::from("/tmp/via-env"));
+        unsafe { std::env::remove_var("MUR_HOME") };
+    }
+
+    #[test]
+    fn mur_root_falls_back_to_home_dir_when_env_empty() {
+        let _g = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_HOME", "") };
+        let p = mur_root(None);
+        assert!(p.ends_with(".mur"), "expected .../.mur, got: {p:?}");
+        unsafe { std::env::remove_var("MUR_HOME") };
+    }
+}
+```
+
+### Step 2: Register the module in `lib.rs`
+
+In `mur-core/src/lib.rs`, insert `pub mod paths;` in alphabetical order — specifically between `pub mod llm;` and `pub mod retrieve;` (i.e. after line that declares `llm` and before the line that declares `retrieve`).
+
+Current layout of the relevant lines in `lib.rs`:
+```rust
+pub mod llm;
+pub mod retrieve;
+```
+
+After edit:
+```rust
+pub mod llm;
+pub mod paths;
+pub mod retrieve;
+```
+
+### Step 3: Run the tests
+
+Run: `cargo test -p mur-core paths::tests --quiet -- --test-threads=1`
+
+Expected:
+```
+test result: ok. 3 passed; 0 failed; 0 ignored
+```
+
+Use `--test-threads=1` to avoid env-var races with the conversations tests. Expect all 3 tests to pass.
+
+Also run the full mur-core suite to confirm no regressions from adding the module:
+
+Run: `cargo test -p mur-core`
+
+Expected: all pass. Adding a new module with `#[cfg(test)] mod tests` cannot break other tests, but we verify.
+
+### Step 4: fmt + clippy clean
+
+Run: `cargo fmt -p mur-core && cargo clippy -p mur-core --all-targets -- -D warnings`
+
+Expected: zero diff, zero warnings.
+
+### Step 5: Commit
+
+```bash
+git add mur-core/src/paths.rs mur-core/src/lib.rs
+git commit -m "feat: Windows CI hardening P1 Task 1 — crate::paths::mur_root helper"
+```
+
+---
+
+## Task 2: `write_summary` force bypass
+
+**Files:**
+- Modify: `mur-core/src/conversations/summarize/writer.rs:49-144` (signature + byte-equality guard)
+- Modify: `mur-core/src/conversations/summarize/writer.rs` test module at bottom — 1 new unit test + update existing call sites
+- Modify: `mur-core/src/conversations/summarize/mod.rs:244` (one-line production call-site update)
+
+### Step 1: Write the failing unit test
+
+In `mur-core/src/conversations/summarize/writer.rs`, find the test module (starts near line 600). Locate the existing `dummy_doc(date: NaiveDate) -> SummaryDoc` helper at line ~605 and the existing `write_rollup_force_bypasses_idempotency` test (search for that name) as the template.
+
+Append a new test, placed right after `write_rollup_force_bypasses_idempotency`:
+
+```rust
+    #[tokio::test]
+    async fn write_summary_force_bypasses_idempotency() {
+        // Windows CI Hardening Phase 1 — mirrors `write_rollup_force_bypasses_idempotency`.
+        // Two consecutive writes with byte-identical bodies (same date, same
+        // `generated_at` second) must NOT noop when force=true; must archive
+        // the prior and rewrite. Guards the bug class Phase 3.5 fixed for
+        // `write_rollup` from reappearing in `write_summary`.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 4, 20).unwrap();
+        let doc = dummy_doc(date);
+        let _ = write_summary(&doc, vec![0.0; 16], vec![], false, Some(root))
+            .await
+            .unwrap();
+        let r2 = write_summary(&doc, vec![0.0; 16], vec![], true, Some(root))
+            .await
+            .unwrap();
+        assert!(!r2.noop, "force=true must NOT noop on identical content");
+        assert!(r2.archived.is_some(), "force=true must archive the prior");
+    }
+```
+
+### Step 2: Run the test to verify it fails
+
+Run: `cargo test -p mur-core write_summary_force_bypasses_idempotency`
+
+Expected: compile-fail — the new `force` argument position doesn't exist on `write_summary` yet. This is the correct red state.
+
+### Step 3: Change the `write_summary` signature and add the `!force` guard
+
+In `mur-core/src/conversations/summarize/writer.rs`, locate the signature near line 49. Replace:
+
+```rust
+pub async fn write_summary(
+    doc: &SummaryDoc,
+    summary_embedding: Vec<f32>,
+    span_embeddings: Vec<Vec<f32>>,
+    root_override: Option<&str>,
+) -> Result<WriteResult> {
+```
+
+with:
+
+```rust
+pub async fn write_summary(
+    doc: &SummaryDoc,
+    summary_embedding: Vec<f32>,
+    span_embeddings: Vec<Vec<f32>>,
+    force: bool,
+    root_override: Option<&str>,
+) -> Result<WriteResult> {
+```
+
+Then in the body, locate the byte-equality noop block. Current code (near line 65):
+
+```rust
+    if prior_exists {
+        let existing = std::fs::read_to_string(&md_path)?;
+        if existing == new_body {
+            return Ok(WriteResult {
+                path: md_path,
+                archived: None,
+                noop: true,
+            });
+        }
+```
+
+Replace with:
+
+```rust
+    if prior_exists {
+        let existing = std::fs::read_to_string(&md_path)?;
+        // Byte-equality short-circuit is a best-effort optimization for the
+        // "rerun with same inputs" path. `--force` bypasses it — users who
+        // pass --force explicitly want a fresh archive + rewrite regardless
+        // of whether the body happens to be byte-identical (e.g. two runs
+        // in the same wall-clock second producing the same generated_at).
+        // Mirrors the fix in `write_rollup` (Phase 3.5 post-review).
+        if !force && existing == new_body {
+            return Ok(WriteResult {
+                path: md_path,
+                archived: None,
+                noop: true,
+            });
+        }
+```
+
+No other changes in the body. The archive + rewrite branch is unchanged.
+
+### Step 4: Update the non-test call site in `summarize/mod.rs`
+
+In `mur-core/src/conversations/summarize/mod.rs`, line 244 currently reads:
+
+```rust
+    match writer::write_summary(&doc, summary_embedding, span_embeddings, root_override).await {
+```
+
+Replace with:
+
+```rust
+    match writer::write_summary(&doc, summary_embedding, span_embeddings, force, root_override).await {
+```
+
+Verify `force` is in scope at this call site — `compact_day` takes `force: bool` as a parameter, so it should be. If it's not (the variable might be named differently in the enclosing fn), grep the enclosing function signature. The spec confirmed `compact_day` already has `force: bool`, so this should be a one-line drop-in.
+
+### Step 5: Update the 9 existing test call sites in `writer.rs`
+
+The test module in `writer.rs` has 9 call sites of `write_summary` that now need the new `false` arg between `span_embeddings` and `root_override`. They are at approximate lines 642, 662, 665, 679, 684, 699, 937, 963 (and one may be in a test helper). Use `grep -n "write_summary(" mur-core/src/conversations/summarize/writer.rs` to get the exact current line numbers, then update each one.
+
+Example transformation — BEFORE:
+```rust
+        let r = write_summary(&doc, vec![0.0; 16], vec![], Some(root))
+            .await
+            .unwrap();
+```
+
+AFTER:
+```rust
+        let r = write_summary(&doc, vec![0.0; 16], vec![], false, Some(root))
+            .await
+            .unwrap();
+```
+
+All 9 existing test sites use `Some(root)` as the current last argument. The mechanical change is: insert `false,` immediately before `Some(root)` (preserving any `.await.unwrap()` suffix).
+
+Double-check the 9 call sites include the `write_summary_force_bypasses_idempotency` test you added in Step 1. That test uses `false` and `true` values explicitly — don't reduce them to `false` during the bulk edit.
+
+### Step 6: Compile-check and run
+
+Run: `cargo build -p mur-core`
+
+Expected: clean build. If the compiler complains about `missing argument force` anywhere you haven't covered, fix that call site (grep again if needed).
+
+Run: `cargo test -p mur-core write_summary_force_bypasses_idempotency`
+
+Expected: PASS.
+
+Also run the broader summarize + writer tests to confirm no regressions:
+
+Run: `cargo test -p mur-core summarize::`
+
+Expected: all pass.
+
+### Step 7: Full suite + fmt + clippy
+
+Run:
+```bash
+cargo test -p mur-core
+cargo fmt -p mur-core
+cargo clippy -p mur-core --all-targets -- -D warnings
+```
+
+Expected: all tests pass, zero fmt diff, zero clippy warnings.
+
+### Step 8: Commit
+
+```bash
+git add mur-core/src/conversations/summarize/writer.rs mur-core/src/conversations/summarize/mod.rs
+git commit -m "fix(summarize): Windows CI hardening P1 Task 2 — write_summary force bypass"
+```
+
+---
+
+## Task 3: CLI adversarial regression test
+
+**Files:**
+- Modify: `mur-core/tests/cli_conversations.rs` — append 1 new test at the bottom
+
+### Step 1: Locate the insertion point
+
+Read the bottom of `mur-core/tests/cli_conversations.rs` and identify where the Phase 3.2.1 `mur_conversations_rollup_force_still_regenerates` test ends. The new test pairs with it — rollup-force for the rollup path, compact-force for the daily-summary path.
+
+### Step 2: Write the adversarial integration test
+
+Append to `mur-core/tests/cli_conversations.rs`:
+
+```rust
+/// Windows CI Hardening Phase 1 — adversarial regression guard for the
+/// "same-wall-clock-second byte-equality swallows --force" bug class.
+///
+/// Phase 3.5 fixed this for `write_rollup` after it flaked on Windows;
+/// Phase 1 of the hardening effort fixes the matching shape in
+/// `write_summary` and locks the invariant with this test. Fails if any
+/// future writer reintroduces the byte-equality noop short-circuit without
+/// a `!force` guard.
+///
+/// Pairs with `mur_conversations_rollup_force_still_regenerates` (Phase 3.2.1).
+#[test]
+fn mur_conversations_compact_force_unconditionally_archives() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mur_home = tmp.path().join(".mur");
+    let yesterday = (chrono::Utc::now().date_naive() - chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+
+    // Seed one raw JSONL line so compact has something to do.
+    let raw = mur_home
+        .join("conversations")
+        .join("raw")
+        .join(&yesterday);
+    std::fs::create_dir_all(&raw).unwrap();
+    let line = serde_json::json!({
+        "v": 1,
+        "ts": format!("{yesterday}T10:00:00Z"),
+        "src": "claude-code",
+        "conv": "c1",
+        "role": "user",
+        "content": {"t": "text", "v": "seed content for force-archive test"},
+        "meta": {},
+        "refs": []
+    });
+    std::fs::write(
+        raw.join("cc_c1.jsonl"),
+        serde_json::to_string(&line).unwrap() + "\n",
+    )
+    .unwrap();
+
+    // First compact — produces .md under summary/<date>.md.
+    let out1 = Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args(["conversations", "compact"])
+        .env("MUR_HOME", &mur_home)
+        .env("HOME", tmp.path())
+        .env("USERPROFILE", tmp.path())
+        .env("MUR_OLLAMA_MOCK", "1")
+        .output()
+        .expect("first compact");
+    assert!(
+        out1.status.success(),
+        "first compact failed: {}",
+        String::from_utf8_lossy(&out1.stderr)
+    );
+
+    // Immediately re-compact with --force. Same wall-clock second is
+    // possible on a fast runner. Pre-fix, the byte-equality short-circuit
+    // in `write_summary` swallows --force silently. Post-fix, the !force
+    // guard archives the prior md unconditionally.
+    let out2 = Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args(["conversations", "compact", "--force"])
+        .env("MUR_HOME", &mur_home)
+        .env("HOME", tmp.path())
+        .env("USERPROFILE", tmp.path())
+        .env("MUR_OLLAMA_MOCK", "1")
+        .output()
+        .expect("second compact --force");
+    assert!(
+        out2.status.success(),
+        "second compact --force failed: {}",
+        String::from_utf8_lossy(&out2.stderr)
+    );
+
+    // Assertion: .history/ exists with ≥1 archived entry.
+    let hist = mur_home
+        .join("conversations")
+        .join("summary")
+        .join(".history");
+    assert!(
+        hist.exists(),
+        ".history/ must exist after --force triggered an archive; \
+         stdout of --force call:\n{}",
+        String::from_utf8_lossy(&out2.stdout)
+    );
+    let archived = std::fs::read_dir(&hist)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .count();
+    assert!(
+        archived >= 1,
+        "Phase 1 hardening: compact --force must unconditionally archive \
+         the prior md even when the body is byte-identical. Found \
+         {archived} archived files; expected ≥1. stdout:\n{}",
+        String::from_utf8_lossy(&out2.stdout)
+    );
+}
+```
+
+### Step 3: Verify the test compiles and determine whether `mur conversations compact --force` works end-to-end
+
+Run: `cargo build -p mur-core --tests`
+
+Expected: clean build.
+
+Run: `cargo test -p mur-core --test cli_conversations mur_conversations_compact_force_unconditionally_archives -- --test-threads=1`
+
+Expected: PASS.
+
+**If the test FAILS on the `.history/ must exist` assertion:** this indicates Task 2's `!force` guard didn't take effect end-to-end (most likely `compact_day` isn't threading `force` into `write_summary` correctly). Go back to Task 2 Step 4 and verify the call-site edit landed. Do NOT weaken the assertion to make the test pass.
+
+**If the test FAILS on the first `compact` call:** verify `mur conversations compact` supports the `--force` CLI flag. Run `cargo run -p mur-core -- conversations compact --help` to confirm — it should be listed. If not, then `force` isn't plumbed from CLI to `compact_day` and Task 2's fix is incomplete. Escalate.
+
+### Step 4: Run the full cli_conversations suite to confirm no regression
+
+Run: `cargo test -p mur-core --test cli_conversations -- --test-threads=1`
+
+Expected: all tests pass, including the existing Phase 3.2.1 `mur_conversations_rollup_force_still_regenerates`, Phase 3.5 `mur_ask_stage_1b_*`, Phase 3.5.1 `mur_ask_cli_*`, and this new test.
+
+### Step 5: Full workspace suite
+
+Run: `cargo test --workspace`
+
+Expected: all pass.
+
+### Step 6: fmt + clippy clean
+
+Run: `cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings`
+
+Expected: zero diff, zero warnings.
+
+### Step 7: Commit
+
+```bash
+git add mur-core/tests/cli_conversations.rs
+git commit -m "test: Windows CI hardening P1 Task 3 — adversarial compact --force archive test"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Step 1: Full suite + lint**
+
+Run:
+```bash
+cargo fmt --check --all
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+Expected: zero format diff, zero clippy warnings, all tests pass — including:
+- 3 new `paths::tests::*` unit tests
+- `write_summary_force_bypasses_idempotency` unit test
+- `mur_conversations_compact_force_unconditionally_archives` integration test
+- All existing tests (Phase 3.5 rollup-force test still passing under existing fix)
+
+- [ ] **Step 2: Spec cross-check**
+
+Re-read `docs/superpowers/specs/2026-04-23-mur-windows-ci-hardening-p1-design.md` §11 "Success criteria". Verify each item:
+
+1. `write_summary_force_bypasses_idempotency` passes — ✅ Task 2.
+2. `mur_conversations_compact_force_unconditionally_archives` passes — ✅ Task 3.
+3. `cargo test --workspace` green across platforms — ✅ Final Verification Step 1.
+4. `cargo clippy` clean — ✅ Final Verification Step 1.
+5. `cargo fmt --check` clean — ✅ Final Verification Step 1.
+6. `crate::paths::mur_root` resolvable from any `mur-core` module — ✅ Task 1 (registered in `lib.rs`).
+7. Phase 2 follow-up issue/section in PR description — handled when opening the PR (not a code task).
+
+- [ ] **Step 3: Confirm zero regression on cold paths**
+
+Run: `cargo test --workspace 2>&1 | grep -E "test result:|FAILED"`
+
+Expected: zero `FAILED` lines. All `test result:` lines end with `0 failed`.
+
+---
+
+## Notes for the implementing agent
+
+1. **Spec is source of truth.** When in doubt between plan and spec, spec wins. Flag the discrepancy back to the controller so the plan gets updated.
+2. **Task 2's 9 test call sites is approximate** — use `grep -n "write_summary(" mur-core/src/conversations/summarize/writer.rs` to get the authoritative list for your branch state. The compiler will reject any missed site with a clear error — trust it.
+3. **The force arg position matters** — `write_summary(doc, summary_vec, span_vec, force, root_override)`. Same position as `write_rollup(doc, vec, force, root_override)`, so the two `write_*` functions stay shape-aligned.
+4. **Don't touch Pattern A callers in this PR.** The spec is explicit: Phase 2 of the hardening effort sweeps those. If you accidentally start editing `dirs::home_dir()` sites, stop and commit only Task 1/2/3 scope.
+5. **Windows parity unverified locally** — macOS/Linux contributors cannot directly verify the Windows-specific behavior. Rely on CI. The test is designed to catch the bug class on any platform where two back-to-back compacts can share a wall-clock second, which is nearly always.
+6. **`ENV_LOCK` is `pub(crate)`** — the Task 1 test reference `crate::conversations::ENV_LOCK` is verified reachable.

--- a/docs/superpowers/specs/2026-04-23-mur-windows-ci-hardening-p1-design.md
+++ b/docs/superpowers/specs/2026-04-23-mur-windows-ci-hardening-p1-design.md
@@ -1,0 +1,367 @@
+# mur Windows CI Hardening — Phase 1 (Defensive + Groundwork)
+
+**Status:** Design approved 2026-04-23. Ready for plan.
+**Depends on:** Phase 3.5 shipped (merge `0ebab7d`) + Phase 3.5.1 shipped (merge `cdea3a2`).
+**Branch:** `fix/windows-ci-hardening-p1`, worktree at `/Volumes/Firecuda4tb/Projects/mur/.worktrees/windows-ci-hardening-p1`.
+
+---
+
+## 1. Goal
+
+Phase 3.5 uncovered two Windows-only bug shapes that both existed since Phase 2 but only surfaced under Phase 3.5's new test exposure:
+
+1. **Pattern A** — `dirs::home_dir()` direct callers ignoring `MUR_HOME`. `SHGetKnownFolderPath` on Windows bypasses `HOME`/`USERPROFILE` env overrides that macOS and Linux respect, so integration tests setting `MUR_HOME + HOME + USERPROFILE` silently read the host's real `~/.mur/`. Fixed in Phase 3.5 for `store::config::config_path()` only; ~35 more callers remain across the crate.
+2. **Pattern B** — Second-precision `generated_at` timestamps paired with byte-equality idempotency checks. Two fast back-to-back writes share the same second → same bytes → the idempotency short-circuit silently swallows `--force`. Fixed in Phase 3.5 for `write_rollup`; `write_summary` has the identical shape still unfixed.
+
+**Phase 1 of the hardening effort** lands the remaining Pattern B fix, adds a test that guards the whole pattern class (not just the specific bug), and builds the crate-level infrastructure (`crate::paths::mur_root` helper) that Phase 2 will use to sweep the ~35 Pattern A callers. Phase 1 deliberately does NOT touch those callers — small PR, clear concern separation, revertable in isolation.
+
+## 2. Non-goals
+
+- **Sweeping Pattern A callers** — deferred to Phase 2 of the hardening effort (tracked in the PR description). This Phase 1 only provides the helper they'll use.
+- **Touching C2 paths** — `~/Library/LaunchAgents` / `dirs::config_dir()` / systemd service dirs. These legitimately need platform-native paths; `dirs::` is correct there.
+- **Schema changes** — no `AskConfig` / `RollupConfig` / `SummaryDoc` / `RollupDoc` changes.
+- **Sub-second `generated_at` precision** — considered but rejected. Would change `.md` frontmatter serialization format, breaking byte-equality against existing user files (every existing `.md` would be re-archived on upgrade). `force` flag is the idempotency-preserving fix.
+- **Re-pointing `store::config::config_path()` to the new helper** — Phase 3.5 already inlined MUR_HOME handling there; re-routing is non-essential churn and belongs to Phase 2's sweep.
+- **CLI flag surface changes** — no new `mur` flags.
+
+## 3. Architecture
+
+Three independent components, each small:
+
+```
+mur-core/src/paths.rs           (new, ~15 LOC)
+  └── pub fn mur_root(override_path: Option<&str>) -> PathBuf
+
+mur-core/src/conversations/summarize/writer.rs  (modify)
+  └── pub async fn write_summary(..., force: bool, ...)  // new param
+      └── if !force && existing == new_body { ... noop ... }
+
+mur-core/tests/cli_conversations.rs  (modify)
+  └── fn mur_conversations_compact_force_unconditionally_archives
+         (adversarial — locks the bug class)
+```
+
+No cross-cutting refactor. `paths::mur_root` is a new primitive; nothing is re-pointed at it in this phase. `write_summary`'s new `force` param is threaded one-call-deep through `compact_day` (already has `force: bool`). The integration test exercises the whole chain end-to-end through the CLI binary.
+
+## 4. Locked design choices
+
+| # | Question | Choice |
+|---|---|---|
+| D1 | Pattern B fix style — `force` flag vs. higher timestamp precision | **`force` flag.** Matches Phase 3.5's `write_rollup` precedent, keeps `.md` format byte-identical with existing on-disk files (no mass re-archive on upgrade). |
+| D2 | Helper name + module placement | **`crate::paths::mur_root(override: Option<&str>)`** in a new `mur-core/src/paths.rs`. Mirrors `crate::conversations::paths::mur_root`'s existing signature exactly (drop-in replacement for Phase 2's sweep). |
+| D3 | Compatibility of existing `conversations::paths::mur_root` | **Keep as-is for this PR.** Phase 2's sweep can decide whether to delete it (pointing callers at the new location) or leave it as a module-local re-export. Not Phase 1's concern. |
+| D4 | Scope: Phase 1 alone, or bundle with Phase 2 sweep | **Phase 1 alone.** Reviewer surface separation — one PR per concern. |
+| D5 | Regression test style — unit, integration, or both | **Both.** A unit test on `write_summary` asserts the force-bypass. An adversarial CLI integration test drives `mur conversations compact --force` end-to-end, assertions on `.history/` contents. The CLI one is the load-bearing guard for the bug class. |
+| D6 | Integration test timing strategy | **Run two compacts back-to-back (no sleep).** The point is to catch the same-wall-clock-second race. If the test flakes under parallel test execution, add `--test-threads=1` hint in the PR description; don't add sleeps to mask the race. |
+
+## 5. Pattern B — `write_summary` force bypass
+
+### 5.1 Signature change
+
+```rust
+// mur-core/src/conversations/summarize/writer.rs
+
+pub async fn write_summary(
+    doc: &SummaryDoc,
+    summary_embedding: Vec<f32>,
+    span_embeddings: Vec<Vec<f32>>,
+    force: bool,                          // ← new, positioned before root_override
+    root_override: Option<&str>,
+) -> Result<WriteResult> {
+    // ... (existing head unchanged) ...
+
+    if prior_exists {
+        let existing = std::fs::read_to_string(&md_path)?;
+        // Byte-equality short-circuit is a best-effort optimization for the
+        // "rerun with same inputs" path. `--force` bypasses it — users who
+        // pass --force explicitly want a fresh archive + rewrite regardless
+        // of whether the body happens to be byte-identical (e.g. two runs
+        // in the same wall-clock second producing the same generated_at).
+        // Mirrors the fix in `write_rollup` (Phase 3.5 post-review).
+        if !force && existing == new_body {
+            return Ok(WriteResult {
+                path: md_path,
+                archived: None,
+                noop: true,
+            });
+        }
+        archived = Some(archive_prior(&md_path, root_override)?);
+        let retain = crate::store::config::load_config()
+            .map(|c| c.conversations.compact.history_retain)
+            .unwrap_or(5);
+        let _ = prune_history(root_override, doc.date, retain);
+        noop = false;
+    } else {
+        // ... (unchanged) ...
+    }
+    // ... (tail unchanged) ...
+}
+```
+
+The `force` param goes between `span_embeddings` and `root_override` to match `write_rollup(doc, vec, force, root_override)` positional order.
+
+### 5.2 Caller wiring
+
+Exactly one non-test caller: `mur-core/src/conversations/summarize/mod.rs`. Grep produced one line:
+
+```rust
+match writer::write_summary(&doc, summary_embedding, span_embeddings, root_override).await {
+```
+
+Becomes:
+
+```rust
+match writer::write_summary(&doc, summary_embedding, span_embeddings, force, root_override).await {
+```
+
+`compact_day` already accepts `force: bool` so the variable name is already in scope at that call site.
+
+### 5.3 Test callers
+
+`write_summary` has ~6 test call sites in `writer.rs`. Each needs to add `false` (the no-force default) as the new arg. New `write_summary_force_bypasses_idempotency` test asserts the `true` path.
+
+## 6. Regression test — adversarial pattern guard
+
+### 6.1 New integration test
+
+Placed at the bottom of `mur-core/tests/cli_conversations.rs`, alongside the Phase 3.2.1 `mur_conversations_rollup_force_still_regenerates` test:
+
+```rust
+/// Windows CI Hardening Phase 1 — adversarial regression guard for the
+/// "same-wall-clock-second byte-equality swallows --force" bug class.
+///
+/// Phase 3.5 fixed the bug for `write_rollup` after it flaked on Windows;
+/// Phase 1 of the hardening effort fixes the matching shape in
+/// `write_summary` and locks the invariant with this test. Fails if any
+/// future writer reintroduces the byte-equality noop short-circuit without
+/// a `!force` guard.
+#[test]
+fn mur_conversations_compact_force_unconditionally_archives() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mur_home = tmp.path().join(".mur");
+    let yesterday = (chrono::Utc::now().date_naive() - chrono::Duration::days(1))
+        .format("%Y-%m-%d").to_string();
+
+    // Seed one raw JSONL line.
+    let raw = mur_home.join("conversations").join("raw").join(&yesterday);
+    std::fs::create_dir_all(&raw).unwrap();
+    std::fs::write(
+        raw.join("cc_c1.jsonl"),
+        serde_json::to_string(&serde_json::json!({
+            "v": 1, "ts": format!("{yesterday}T10:00:00Z"),
+            "src": "claude-code", "conv": "c1", "role": "user",
+            "content": {"t": "text", "v": "seed content for force-archive test"},
+            "meta": {}, "refs": []
+        })).unwrap() + "\n",
+    ).unwrap();
+
+    // First compact — produces .md.
+    let out1 = Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args(["conversations", "compact"])
+        .env("MUR_HOME", &mur_home).env("HOME", tmp.path())
+        .env("USERPROFILE", tmp.path()).env("MUR_OLLAMA_MOCK", "1")
+        .output().expect("first compact");
+    assert!(
+        out1.status.success(),
+        "first compact failed: {}",
+        String::from_utf8_lossy(&out1.stderr)
+    );
+
+    // Immediately re-compact with --force. Same wall-clock second is
+    // possible → pre-fix, byte-equality would swallow --force. Post-fix,
+    // the `!force` guard archives the prior md unconditionally.
+    let out2 = Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args(["conversations", "compact", "--force"])
+        .env("MUR_HOME", &mur_home).env("HOME", tmp.path())
+        .env("USERPROFILE", tmp.path()).env("MUR_OLLAMA_MOCK", "1")
+        .output().expect("second compact --force");
+    assert!(
+        out2.status.success(),
+        "second compact --force failed: {}",
+        String::from_utf8_lossy(&out2.stderr)
+    );
+
+    // Assertion: .history/ exists with ≥1 archived entry.
+    let hist = mur_home
+        .join("conversations").join("summary").join(".history");
+    assert!(
+        hist.exists(),
+        "history dir must exist after --force archive"
+    );
+    let archived = std::fs::read_dir(&hist).unwrap().filter_map(|e| e.ok()).count();
+    assert!(
+        archived >= 1,
+        "Phase 1 hardening: compact --force must unconditionally archive the \
+         prior md even when the body is byte-identical. Got {archived} \
+         archived files. stdout of --force call:\n{}",
+        String::from_utf8_lossy(&out2.stdout)
+    );
+}
+```
+
+### 6.2 Unit test
+
+In `writer.rs` tests, alongside `write_rollup_force_bypasses_idempotency`:
+
+```rust
+#[tokio::test]
+async fn write_summary_force_bypasses_idempotency() {
+    // Mirrors write_rollup_force_bypasses_idempotency. Same wall-clock
+    // second produces byte-identical bodies; `force=true` must archive + rewrite
+    // anyway. `dummy_doc(date)` is the existing helper in this test module.
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().to_str().unwrap();
+    let date = chrono::NaiveDate::from_ymd_opt(2026, 4, 20).unwrap();
+    let doc = dummy_doc(date);
+    let _ = write_summary(&doc, vec![0.0; 16], vec![], false, Some(root))
+        .await
+        .unwrap();
+    let r2 = write_summary(&doc, vec![0.0; 16], vec![], true, Some(root))
+        .await
+        .unwrap();
+    assert!(!r2.noop, "force=true must NOT noop on identical content");
+    assert!(r2.archived.is_some(), "force=true must archive the prior");
+}
+```
+
+### 6.3 Test precedence commitment
+
+The CLI integration test is the primary guard. If someone deletes the unit test but keeps the CLI test, the bug is still caught. If someone deletes the CLI test, the unit test still catches the direct regression but not a compact-pipeline regression. Both together cover the bug class robustly.
+
+## 7. Crate-level `paths::mur_root` helper
+
+### 7.1 New file
+
+```rust
+// mur-core/src/paths.rs
+
+//! Crate-level path helpers.
+//!
+//! Use `mur_root` when you need the `.mur` data directory from code outside
+//! `conversations/`. Respects `MUR_HOME` as an authoritative override — on
+//! Windows, `dirs::home_dir()` calls `SHGetKnownFolderPath` and ignores
+//! `HOME`/`USERPROFILE` env overrides, so tests that redirect via env vars
+//! need this escape hatch.
+//!
+//! Semantics are identical to `conversations::paths::mur_root`; Phase 2 of
+//! Windows CI hardening will sweep the ~35 `dirs::home_dir().join(".mur")`
+//! direct callers in the crate to use this one-line helper.
+
+use std::path::PathBuf;
+
+pub fn mur_root(override_path: Option<&str>) -> PathBuf {
+    if let Some(p) = override_path {
+        return PathBuf::from(p);
+    }
+    if let Ok(p) = std::env::var("MUR_HOME")
+        && !p.is_empty()
+    {
+        return PathBuf::from(p);
+    }
+    dirs::home_dir().expect("no home dir").join(".mur")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mur_root_uses_explicit_override_first() {
+        let p = mur_root(Some("/tmp/fake-mur"));
+        assert_eq!(p, PathBuf::from("/tmp/fake-mur"));
+    }
+
+    #[test]
+    fn mur_root_honors_mur_home_env_when_no_override() {
+        // Serialize via a module-local mutex to avoid clashing with other
+        // env-var tests in the crate (see `conversations::ENV_LOCK`).
+        let _g = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_HOME", "/tmp/via-env") };
+        assert_eq!(mur_root(None), PathBuf::from("/tmp/via-env"));
+        unsafe { std::env::remove_var("MUR_HOME") };
+    }
+
+    #[test]
+    fn mur_root_falls_back_to_home_dir_when_env_empty() {
+        let _g = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_HOME", "") };
+        // Must be $HOME/.mur on the current host. On a CI runner the
+        // concrete path is `/home/runner/.mur` etc — we just assert the
+        // shape, not the literal path.
+        let p = mur_root(None);
+        assert!(p.ends_with(".mur"), "expected .../.mur, got: {p:?}");
+        unsafe { std::env::remove_var("MUR_HOME") };
+    }
+}
+```
+
+### 7.2 `lib.rs` registration
+
+`mur-core/src/lib.rs` grows one line, in alphabetical order between `inject` and `retrieve`:
+
+```rust
+pub mod paths;
+```
+
+### 7.3 Backward compatibility
+
+`mur-core/src/conversations/paths.rs::mur_root` is untouched. Phase 2 will decide whether to make it a re-export of `crate::paths::mur_root` or sweep all conversations callers to the new location first and then delete the old one. Phase 1's commitment: no behavior change to existing callers.
+
+## 8. Test matrix
+
+| Test | Location | Asserts |
+|---|---|---|
+| `mur_root_uses_explicit_override_first` | `mur-core/src/paths.rs` | `Some(p)` short-circuits env + fallback |
+| `mur_root_honors_mur_home_env_when_no_override` | `mur-core/src/paths.rs` | `MUR_HOME` set → returned |
+| `mur_root_falls_back_to_home_dir_when_env_empty` | `mur-core/src/paths.rs` | Empty or missing `MUR_HOME` → `dirs::home_dir()/.mur` shape |
+| `write_summary_force_bypasses_idempotency` | `mur-core/src/conversations/summarize/writer.rs` | `force=true` on byte-equal content archives + rewrites |
+| `mur_conversations_compact_force_unconditionally_archives` | `mur-core/tests/cli_conversations.rs` | CLI `compact --force` produces `.history/` entry back-to-back |
+
+Plus: existing `write_summary` test callers updated to pass `false` for the new `force` arg (mechanical — the compiler will guide).
+
+## 9. File-change summary
+
+| File | Change | LOC |
+|---|---|---|
+| `mur-core/src/paths.rs` | **new** — `mur_root` fn + 3 unit tests | +50 |
+| `mur-core/src/lib.rs` | add `pub mod paths;` | +1 |
+| `mur-core/src/conversations/summarize/writer.rs` | `write_summary` +`force` param; `!force` guard on byte-equality; +1 unit test; ~6 existing test call-sites updated | +25 |
+| `mur-core/src/conversations/summarize/mod.rs` | `compact_day` threads `force` into `write_summary` call | +1 |
+| `mur-core/tests/cli_conversations.rs` | `mur_conversations_compact_force_unconditionally_archives` | +60 |
+| Spec doc (this file) | — | +spec |
+
+Total production LOC: ~30. Test LOC: ~120. Total: ~150 LOC across 5 source files (+ spec + plan docs).
+
+## 10. Error handling
+
+- **`paths::mur_root`**: `dirs::home_dir()` returns `None` on exotic platforms without a home dir. The helper `.expect("no home dir")` — consistent with `conversations::paths::mur_root`'s current behavior. Panicking here is acceptable because the same panic exists in the non-test path today.
+- **`write_summary` with `force=true`**: archive + rewrite paths unchanged. If archive fails (disk full, permission), error propagates as before. `force` only changes whether the byte-equality short-circuit fires; downstream I/O is identical.
+- **Integration test timing**: if two `compact` invocations cross a wall-clock second boundary on a slow runner, the byte-equality check naturally produces different bodies (different `generated_at` second) and the test's `--force` still archives via the "content differs" path. The test is correct under both fast and slow runners; `--force` is the load-bearing guarantee.
+
+## 11. Success criteria
+
+1. `write_summary_force_bypasses_idempotency` passes — unit-level proof of `!force` guard.
+2. `mur_conversations_compact_force_unconditionally_archives` passes — end-to-end proof that `compact --force` archives even under identical-body conditions.
+3. `cargo test --workspace` green on macOS/Linux/Windows CI — no regression in Phase 3.5 `mur_conversations_rollup_force_still_regenerates` (still passing from the Phase 3.5 fix).
+4. `cargo clippy --workspace --all-targets -- -D warnings` clean.
+5. `cargo fmt --check --all` clean.
+6. `crate::paths::mur_root` resolvable from any `mur-core` module (compile test — a subsequent Phase 2 commit will import it).
+7. Phase 2 follow-up issue/section created in PR description listing all 35 C1 call sites.
+
+## 12. PR 2 follow-up (tracked in PR description, not this phase)
+
+Sweep the following files' `dirs::home_dir()` C1 callers to `crate::paths::mur_root`:
+
+- `mur-core/src/cmd/session.rs` (7 sites — session recording paths)
+- `mur-core/src/cmd/source_cmd.rs` (~10 sites — index, tantivy, excluding the `dirs::config_dir()` C2 site)
+- `mur-core/src/cmd/sync_cmd.rs` (3 sites)
+- `mur-core/src/cmd/system_schedule.rs` (~1 C1 site; `~/Library/LaunchAgents` + systemd paths are C2, leave alone)
+- `mur-core/src/main.rs` (3 sites)
+- `mur-core/src/cmd/{pattern,community_cmd,inject_cmd,reindex,server_cmd,conversations_cmd,misc}.rs` (~1-2 each)
+- `mur-core/src/{auth,dashboard,extract_llm,interactive,verify}.rs` (1 each)
+
+Total: ~35 sites. Purely mechanical replacement — suitable for subagent batch execution, one file per task.
+
+---
+
+_Spec approved for plan. Next: `docs/superpowers/plans/2026-04-23-mur-windows-ci-hardening-p1.md` via `superpowers:writing-plans`._

--- a/mur-core/src/cmd/conversations_cmd.rs
+++ b/mur-core/src/cmd/conversations_cmd.rs
@@ -1040,7 +1040,8 @@ pub async fn cmd_conversations_compact(args: CompactArgs) -> Result<()> {
         .transpose()?;
 
     let report =
-        summarize::compact_missing(&cfg, since, args.if_stale, args.max_days, None).await?;
+        summarize::compact_missing(&cfg, since, args.if_stale, args.force, args.max_days, None)
+            .await?;
 
     if report.day_reports.is_empty() {
         println!("(nothing to compact)");

--- a/mur-core/src/conversations/summarize/mod.rs
+++ b/mur-core/src/conversations/summarize/mod.rs
@@ -241,7 +241,15 @@ pub async fn compact_day(
         }
     };
 
-    match writer::write_summary(&doc, summary_embedding, span_embeddings, root_override).await {
+    match writer::write_summary(
+        &doc,
+        summary_embedding,
+        span_embeddings,
+        force,
+        root_override,
+    )
+    .await
+    {
         Ok(w) => Ok(DayReport {
             date,
             outcome: if w.noop {

--- a/mur-core/src/conversations/summarize/mod.rs
+++ b/mur-core/src/conversations/summarize/mod.rs
@@ -287,6 +287,7 @@ pub async fn compact_missing(
     cfg: &CompactConfig,
     since: Option<NaiveDate>,
     if_stale: bool,
+    force: bool,
     max_days_override: Option<u32>,
     root_override: Option<&str>,
 ) -> Result<CompactReport> {
@@ -301,12 +302,14 @@ pub async fn compact_missing(
         .collect();
     candidates.sort();
 
+    // --force implies --if-stale semantics plus unconditional archive in write_summary.
+    let effective_force = force || if_stale;
+
     let mut report = CompactReport::default();
     for date in candidates.into_iter().take(max_days) {
-        // skip logic: if summary exists and --if-stale is off, skip
+        // skip logic: if summary exists and neither --force nor --if-stale is set, skip
         let (md_path, _) = summary_paths_for(date, root_override);
-        let force = if_stale;
-        if md_path.exists() && !if_stale {
+        if md_path.exists() && !effective_force {
             report.skipped += 1;
             report.day_reports.push(DayReport {
                 date,
@@ -318,7 +321,7 @@ pub async fn compact_missing(
             });
             continue;
         }
-        let r = compact_day(date, force, cfg, root_override).await?;
+        let r = compact_day(date, effective_force, cfg, root_override).await?;
         match &r.outcome {
             Outcome::Written { .. } | Outcome::Noop => report.ok += 1,
             Outcome::Failed(_) => report.err += 1,
@@ -545,7 +548,7 @@ mod orch_tests {
         }
         let mut c = cfg();
         c.max_days_per_run = 3;
-        let report = compact_missing(&c, None, false, None, Some(root))
+        let report = compact_missing(&c, None, false, false, None, Some(root))
             .await
             .unwrap();
         assert_eq!(report.day_reports.len(), 3);

--- a/mur-core/src/conversations/summarize/writer.rs
+++ b/mur-core/src/conversations/summarize/writer.rs
@@ -50,6 +50,7 @@ pub async fn write_summary(
     doc: &SummaryDoc,
     summary_embedding: Vec<f32>,
     span_embeddings: Vec<Vec<f32>>,
+    force: bool,
     root_override: Option<&str>,
 ) -> Result<WriteResult> {
     let (md_path, _yaml_path) = summary_paths_for(doc.date, root_override);
@@ -64,7 +65,13 @@ pub async fn write_summary(
 
     if prior_exists {
         let existing = std::fs::read_to_string(&md_path)?;
-        if existing == new_body {
+        // Byte-equality short-circuit is a best-effort optimization for the
+        // "rerun with same inputs" path. `--force` bypasses it — users who
+        // pass --force explicitly want a fresh archive + rewrite regardless
+        // of whether the body happens to be byte-identical (e.g. two runs
+        // in the same wall-clock second producing the same generated_at).
+        // Mirrors the fix in `write_rollup` (Phase 3.5 post-review).
+        if !force && existing == new_body {
             return Ok(WriteResult {
                 path: md_path,
                 archived: None,
@@ -639,7 +646,7 @@ mod tests {
         let root = tmp.path().to_str().unwrap();
         let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
         let doc = dummy_doc(date);
-        let r = write_summary(&doc, vec![0.0; 16], vec![], Some(root))
+        let r = write_summary(&doc, vec![0.0; 16], vec![], false, Some(root))
             .await
             .unwrap();
         assert!(!r.noop);
@@ -659,10 +666,10 @@ mod tests {
         let doc = dummy_doc(date);
         let mut d2 = dummy_doc(date);
         d2.generated_at = doc.generated_at; // force bit-identical
-        let _ = write_summary(&doc, vec![0.0; 16], vec![], Some(root))
+        let _ = write_summary(&doc, vec![0.0; 16], vec![], false, Some(root))
             .await
             .unwrap();
-        let r2 = write_summary(&d2, vec![0.0; 16], vec![], Some(root))
+        let r2 = write_summary(&d2, vec![0.0; 16], vec![], false, Some(root))
             .await
             .unwrap();
         assert!(r2.noop);
@@ -676,12 +683,12 @@ mod tests {
         let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
         let mut doc1 = dummy_doc(date);
         doc1.abstractive.narrative = Some("version 1".into());
-        let _ = write_summary(&doc1, vec![0.0; 16], vec![], Some(root))
+        let _ = write_summary(&doc1, vec![0.0; 16], vec![], false, Some(root))
             .await
             .unwrap();
         let mut doc2 = dummy_doc(date);
         doc2.abstractive.narrative = Some("version 2".into());
-        let r2 = write_summary(&doc2, vec![0.0; 16], vec![], Some(root))
+        let r2 = write_summary(&doc2, vec![0.0; 16], vec![], false, Some(root))
             .await
             .unwrap();
         assert!(r2.archived.is_some());
@@ -696,7 +703,7 @@ mod tests {
         let root = tmp.path().to_str().unwrap();
         let date = NaiveDate::from_ymd_opt(2026, 4, 19).unwrap();
         let doc = dummy_doc(date);
-        let _ = write_summary(&doc, vec![0.0; 16], vec![], Some(root))
+        let _ = write_summary(&doc, vec![0.0; 16], vec![], false, Some(root))
             .await
             .unwrap();
 
@@ -841,6 +848,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn write_summary_force_bypasses_idempotency() {
+        // Windows CI Hardening Phase 1 — mirrors `write_rollup_force_bypasses_idempotency`.
+        // Two consecutive writes with byte-identical bodies (same date, same
+        // `generated_at` second) must NOT noop when force=true; must archive
+        // the prior and rewrite. Guards the bug class Phase 3.5 fixed for
+        // `write_rollup` from reappearing in `write_summary`.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_str().unwrap();
+        let date = chrono::NaiveDate::from_ymd_opt(2026, 4, 20).unwrap();
+        let doc = dummy_doc(date);
+        let _ = write_summary(&doc, vec![0.0; 16], vec![], false, Some(root))
+            .await
+            .unwrap();
+        let r2 = write_summary(&doc, vec![0.0; 16], vec![], true, Some(root))
+            .await
+            .unwrap();
+        assert!(!r2.noop, "force=true must NOT noop on identical content");
+        assert!(r2.archived.is_some(), "force=true must archive the prior");
+    }
+
+    #[tokio::test]
     async fn write_rollup_archives_prior_on_overwrite() {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path().to_str().unwrap();
@@ -934,7 +962,7 @@ mod tests {
         });
         let summary_vec = vec![0.1; 16];
         let span_vecs = vec![vec![0.2; 16], vec![0.3; 16], vec![0.4; 16]];
-        write_summary(&doc, summary_vec, span_vecs, Some(root))
+        write_summary(&doc, summary_vec, span_vecs, false, Some(root))
             .await
             .unwrap();
 
@@ -960,7 +988,7 @@ mod tests {
         let date = NaiveDate::from_ymd_opt(2026, 4, 21).unwrap();
         let mut doc = dummy_doc(date);
         doc.extractive.clear();
-        write_summary(&doc, vec![0.1; 16], vec![], Some(root))
+        write_summary(&doc, vec![0.1; 16], vec![], false, Some(root))
             .await
             .unwrap();
         let idx = index::ConversationIndex::open(16, Some(root))

--- a/mur-core/src/lib.rs
+++ b/mur-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod gep;
 pub mod inject;
 pub mod interactive;
 pub mod llm;
+pub mod paths;
 pub mod retrieve;
 pub mod session;
 pub mod sources;

--- a/mur-core/src/paths.rs
+++ b/mur-core/src/paths.rs
@@ -1,0 +1,56 @@
+//! Crate-level path helpers.
+//!
+//! Use `mur_root` when you need the `.mur` data directory from code outside
+//! `conversations/`. Respects `MUR_HOME` as an authoritative override — on
+//! Windows, `dirs::home_dir()` calls `SHGetKnownFolderPath` and ignores
+//! `HOME`/`USERPROFILE` env overrides, so tests that redirect via env vars
+//! need this escape hatch.
+//!
+//! Semantics are identical to `conversations::paths::mur_root`; Phase 2 of
+//! the Windows CI hardening effort will sweep the ~35
+//! `dirs::home_dir().join(".mur")` direct callers in the crate to use this
+//! one-line helper.
+
+use std::path::PathBuf;
+
+pub fn mur_root(override_path: Option<&str>) -> PathBuf {
+    if let Some(p) = override_path {
+        return PathBuf::from(p);
+    }
+    if let Ok(p) = std::env::var("MUR_HOME")
+        && !p.is_empty()
+    {
+        return PathBuf::from(p);
+    }
+    dirs::home_dir().expect("no home dir").join(".mur")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mur_root_uses_explicit_override_first() {
+        let p = mur_root(Some("/tmp/fake-mur"));
+        assert_eq!(p, PathBuf::from("/tmp/fake-mur"));
+    }
+
+    #[test]
+    fn mur_root_honors_mur_home_env_when_no_override() {
+        // Serialize via the crate-local env-mutex so this test does not race
+        // against `conversations` tests that also mutate MUR_HOME.
+        let _g = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_HOME", "/tmp/via-env") };
+        assert_eq!(mur_root(None), PathBuf::from("/tmp/via-env"));
+        unsafe { std::env::remove_var("MUR_HOME") };
+    }
+
+    #[test]
+    fn mur_root_falls_back_to_home_dir_when_env_empty() {
+        let _g = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_HOME", "") };
+        let p = mur_root(None);
+        assert!(p.ends_with(".mur"), "expected .../.mur, got: {p:?}");
+        unsafe { std::env::remove_var("MUR_HOME") };
+    }
+}

--- a/mur-core/tests/cli_conversations.rs
+++ b/mur-core/tests/cli_conversations.rs
@@ -1313,3 +1313,97 @@ fn mur_conversations_rollup_force_still_regenerates() {
         String::from_utf8_lossy(&out2.stdout)
     );
 }
+
+/// Windows CI Hardening Phase 1 — adversarial regression guard for the
+/// "same-wall-clock-second byte-equality swallows --force" bug class.
+///
+/// Phase 3.5 fixed this for `write_rollup` after it flaked on Windows;
+/// Phase 1 of the hardening effort fixes the matching shape in
+/// `write_summary` and locks the invariant with this test. Fails if any
+/// future writer reintroduces the byte-equality noop short-circuit without
+/// a `!force` guard.
+///
+/// Pairs with `mur_conversations_rollup_force_still_regenerates` (Phase 3.2.1).
+#[test]
+fn mur_conversations_compact_force_unconditionally_archives() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mur_home = tmp.path().join(".mur");
+    let yesterday = (chrono::Utc::now().date_naive() - chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+
+    // Seed one raw JSONL line so compact has something to do.
+    let raw = mur_home.join("conversations").join("raw").join(&yesterday);
+    std::fs::create_dir_all(&raw).unwrap();
+    let line = serde_json::json!({
+        "v": 1,
+        "ts": format!("{yesterday}T10:00:00Z"),
+        "src": "claude-code",
+        "conv": "c1",
+        "role": "user",
+        "content": {"t": "text", "v": "seed content for force-archive test"},
+        "meta": {},
+        "refs": []
+    });
+    std::fs::write(
+        raw.join("cc_c1.jsonl"),
+        serde_json::to_string(&line).unwrap() + "\n",
+    )
+    .unwrap();
+
+    // First compact — produces .md under summary/<date>.md.
+    let out1 = Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args(["conversations", "compact"])
+        .env("MUR_HOME", &mur_home)
+        .env("HOME", tmp.path())
+        .env("USERPROFILE", tmp.path())
+        .env("MUR_OLLAMA_MOCK", "1")
+        .output()
+        .expect("first compact");
+    assert!(
+        out1.status.success(),
+        "first compact failed: {}",
+        String::from_utf8_lossy(&out1.stderr)
+    );
+
+    // Immediately re-compact with --force. Same wall-clock second is
+    // possible on a fast runner. Pre-fix, the byte-equality short-circuit
+    // in `write_summary` swallows --force silently. Post-fix, the !force
+    // guard archives the prior md unconditionally.
+    let out2 = Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args(["conversations", "compact", "--force"])
+        .env("MUR_HOME", &mur_home)
+        .env("HOME", tmp.path())
+        .env("USERPROFILE", tmp.path())
+        .env("MUR_OLLAMA_MOCK", "1")
+        .output()
+        .expect("second compact --force");
+    assert!(
+        out2.status.success(),
+        "second compact --force failed: {}",
+        String::from_utf8_lossy(&out2.stderr)
+    );
+
+    // Assertion: .history/ exists with ≥1 archived entry.
+    let hist = mur_home
+        .join("conversations")
+        .join("summary")
+        .join(".history");
+    assert!(
+        hist.exists(),
+        ".history/ must exist after --force triggered an archive; \
+         stdout of --force call:\n{}",
+        String::from_utf8_lossy(&out2.stdout)
+    );
+    let archived = std::fs::read_dir(&hist)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .count();
+    assert!(
+        archived >= 1,
+        "Phase 1 hardening: compact --force must unconditionally archive \
+         the prior md even when the body is byte-identical. Found \
+         {archived} archived files; expected ≥1. stdout:\n{}",
+        String::from_utf8_lossy(&out2.stdout)
+    );
+}


### PR DESCRIPTION
## Summary

Preventative fix for a class of Windows CI flakes that hit Phase 3.5 twice. Three pieces, each small:

1. **`write_summary` `--force` bypass** — mirrors the Phase 3.5 fix in `write_rollup`. Two back-to-back `mur conversations compact` invocations in the same wall-clock second produced byte-identical bodies (because `generated_at` has second precision), and the existing byte-equality noop short-circuit silently swallowed `--force`. Now gated with `!force &&`.

2. **`compact_missing` `force` threading fix** — **surfaced by the new integration test in this PR**. `compact_missing()` had its own early-exit `if md_path.exists() && !if_stale` that checked only `if_stale`, never `force`. So `mur conversations compact --force` (without `--date`) was silently swallowed BEFORE reaching `compact_day → write_summary`. Now `effective_force = force || if_stale` threads through end-to-end. This is exactly the sort of upstream bug an adversarial integration test is designed to catch — Task 2's unit test on `write_summary` couldn't reach it because it called the fn directly.

3. **`crate::paths::mur_root` helper** — new primitive that respects `MUR_HOME` (authoritative on Windows where `SHGetKnownFolderPath` ignores `HOME`/`USERPROFILE`). **Does not modify any existing caller** — that's Phase 2 of the hardening effort. Phase 1 only creates the groundwork.

## Files changed

| File | Change |
|---|---|
| `mur-core/src/paths.rs` | **new** — `pub fn mur_root(override) -> PathBuf` + 3 unit tests |
| `mur-core/src/lib.rs` | +`pub mod paths;` |
| `mur-core/src/conversations/summarize/writer.rs` | `write_summary` +`force: bool`; `!force` guard; +1 unit test; 8 test call sites updated |
| `mur-core/src/conversations/summarize/mod.rs` | `compact_missing` +`force: bool`; `effective_force = force \|\| if_stale`; threads into `compact_day` |
| `mur-core/src/cmd/conversations_cmd.rs` | passes `args.force` into `compact_missing` (it was being dropped before reaching the day loop) |
| `mur-core/tests/cli_conversations.rs` | +`mur_conversations_compact_force_unconditionally_archives` adversarial regression test |

## Test Plan

- [x] **`cargo test --workspace`** — 1762 passed / 0 failed (6 new tests: 3 on `paths`, 1 unit on `write_summary`, 1 integration on `compact --force`, plus existing suites untouched).
- [x] **`cargo clippy --workspace --all-targets -- -D warnings`** — clean.
- [x] **`cargo fmt --check --all`** — clean.
- [x] **`mur_conversations_compact_force_unconditionally_archives`** — adversarial CLI regression test passes. Pairs with Phase 3.2.1's `mur_conversations_rollup_force_still_regenerates` to cover both write paths.
- [x] **`write_summary_force_bypasses_idempotency`** — unit proof of `!force` guard.
- [x] Existing Phase 3.2.1 `mur_conversations_rollup_force_still_regenerates` still passing — no regression on the Phase 3.5 rollup fix.
- [ ] CI green across macOS / Ubuntu / Windows.

## Follow-up: Phase 2 of Windows CI hardening (separate PR, not this one)

This PR deliberately did NOT modify any existing `dirs::home_dir()` caller — Phase 2 will sweep them using the new `crate::paths::mur_root` helper. Affected files (~35 call sites, grouped by heat):

**Hot paths (hit by existing CI tests):**
- `mur-core/src/cmd/session.rs` — 7 sites (session recording paths)
- `mur-core/src/cmd/source_cmd.rs` — ~10 sites (index, tantivy; excluding the `dirs::config_dir()` C2 site)
- `mur-core/src/cmd/sync_cmd.rs` — 3 sites
- `mur-core/src/main.rs` — 3 sites
- `mur-core/src/cmd/conversations_cmd.rs` — 2 sites

**Cold paths (less exercised but still C1 bugs):**
- `mur-core/src/cmd/system_schedule.rs` — ~1 C1 site (plus C2 `~/Library/LaunchAgents` + systemd paths which are correct as-is)
- `mur-core/src/cmd/{pattern,community_cmd,inject_cmd,reindex,server_cmd,misc}.rs` — 1-2 each
- `mur-core/src/{auth,dashboard,extract_llm,interactive,verify}.rs` — 1 each

Purely mechanical `dirs::home_dir().join(".mur")` → `crate::paths::mur_root(None)` replacement; suitable for subagent batch execution, one file per task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)