### PR TITLE
P0a.6 — mur agent rekey: M1-M6 (schema + attestation + CLI + agent-side rotation/grace cleanup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,33 @@ The per-agent supervisor lives in `mur-agent-runtime/`. Each agent has a directo
 - **Plan:** `docs/superpowers/plans/2026-04-23-murmur-p0a5-implementation-plan.md` (+ `-COMPLETE.md`)
 - **E2E runner:** `scripts/e2e/p0a5-full.sh` (wraps `p0a5-identity-handshake.sh` + `p0a5-commander-autoregister.sh`).
 
+### P0a.6 additions (`mur agent rekey` — identity rotation)
+
+Per-agent Ed25519 identity keys can now be rotated via:
+
+- **`mur agent rekey <name> [--reason scheduled|suspect-compromise|owner-change] [--yes]`** — normal rotation. Generates a new keypair, signs a `RotationAttestation` with the OLD private key, atomically rotates `identity.{key,pub}` to `.prev`, writes new keypair, appends to `rotations.jsonl`, updates `profile.yaml` (`key_version++`, `previous_pubkey`, `grace_expires_at = now + 30d`), SIGTERMs the running runtime so the symlink supervisor restarts it.
+- **`mur agent rekey <name> --emergency`** — used when the old key is unrecoverable. Writes an UNSIGNED attestation; commander will quarantine the agent with `pending_emergency_approval` until an admin runs `murc agent approve-rekey <uuid>` on the commander host (option-a FS-gated).
+- **`mur agent rekey-status <name> [--json]`** — show current/previous keys, grace remaining, rotation history count.
+
+Identity schema (`mur-common::agent::IdentityConfig`) gained `algorithm`, `key_version`, `created_at_key`, `previous_pubkey`, `previous_key_version`, `grace_expires_at`, `rotated_at`, `emergency_rekey_at` — all `#[serde(default)]`. Bootstrap rotation entries are written into `rotations.jsonl` at agent create time.
+
+`mur-common::identity` exports `RotationAttestation` (with sorted-key canonical JSON for signing) and `verify_chain` (M5.1) for end-to-end chain validation.
+
+On every supervisor startup, an expired `grace_expires_at` triggers `shred -u identity.key.prev` + clears `previous_*` from `profile.yaml` (M6.1).
+
+**mur-commander integration** (`feat/agent-rekey-commander`):
+- `engine::a2a::discovery::AgentRegistry::apply_rotation` — verifies attestation signature against the OLD pubkey before advancing the registry; handles idempotent replay; quarantines on `OldKeyMismatch`; refuses emergency until approved.
+- `approve_emergency_rotation` / `reject_emergency_rotation` — out-of-band gating for emergency rotations.
+- `sweep_grace_expiries` — hourly daemon job clears expired `previous_pubkey` entries (M6.2).
+- **Split-attestation detection** (M5.2) — when two diverging attestations claim the same `key_version` boundary with different `new_pubkey`, the agent is quarantined with a `split_attestation_vN_to_vN+1` marker.
+- **`murc agent approve-rekey <uuid>` / `reject-rekey <uuid>`** (M4.2) — FS-gated CLI on the commander host.
+
+**TcpConnector** (M3.2) — `dial_with_fallback(addr, identity, &[primary, prev])` lets peers retry a Noise handshake against either pubkey during the grace window. Agent Card (M3.1) publishes `previous_pubkey` + `grace_expires_at` while grace is active.
+
+- **Spec:** `docs/superpowers/specs/2026-04-24-murmur-agent-rekey-design.md`
+- **Plan:** `docs/superpowers/plans/2026-04-24-murmur-agent-rekey-plan.md` (+ `-COMPLETE.md`)
+- **PRs:** `mur-run/mur#30` (mur side: M1, M3, M4.1, M5.1, M6.1, M6.3) + `mur-run/mur-commander#12` (commander side: M2, M4.2/4.3, M5.2, M6.2)
+
 ## Development Notes
 
 - Rust edition 2024 — `let` chains are stable and used throughout (e.g., `if let … && let …`)

--- a/docs/superpowers/plans/2026-04-24-murmur-agent-rekey-plan-COMPLETE.md
+++ b/docs/superpowers/plans/2026-04-24-murmur-agent-rekey-plan-COMPLETE.md
@@ -1,0 +1,154 @@
+# murmur `mur agent rekey` — Implementation Complete
+
+**Status:** All 24 tasks shipped across 6 milestones in two repos.
+**Date:** 2026-04-25
+**Branches:**
+- `feat/agent-rekey` in `mur-run/mur` (off `feat/murmur-p0a`) — PR [#30](https://github.com/mur-run/mur/pull/30)
+- `feat/agent-rekey-commander` in `mur-run/mur-commander` (off `main`) — PR [#12](https://github.com/mur-run/mur-commander/pull/12)
+
+## Scope
+
+Add per-agent Ed25519 identity rotation as P0a.6, building on the P0a.5 identity foundation. Resolves Open Question Q-B from the fleet architecture spec.
+
+Implements:
+- **Normal rotation** — signed attestation chain rooted at agent create time; commander auto-applies; 30-day grace window.
+- **Emergency rotation** — when the old key is unrecoverable; written unsigned, must be explicitly approved on the commander host (option-a FS-gated).
+- **Split detection** — diverging attestations on the same `key_version` boundary quarantine the agent.
+- **Peer migration** — `TcpConnector::dial_with_fallback` accepts multiple candidate pubkeys; Agent Card publishes both during grace.
+- **Grace cleanup** — agent shreds `identity.key.prev` on supervisor startup; commander sweeps expired `previous_pubkey` hourly.
+
+## Phase roll-up
+
+### M1 — Schema + attestation primitives + `mur agent rekey` (mur)
+
+5 tasks. Key artefacts:
+
+- `mur-common::agent::IdentityConfig` — extended with `algorithm`, `key_version`, `created_at_key`, `previous_pubkey`, `previous_key_version`, `grace_expires_at`, `rotated_at`, `emergency_rekey_at`. Manual `Default` impl preserves `algorithm = "ed25519"`.
+- `mur-common::identity::RotationAttestation` — schema-1 attestation with sorted-key canonical JSON (`canonical_bytes`); `RotationReason` enum (Scheduled / SuspectCompromise / OwnerChange / Emergency); `sign()` + `verify()` + `verify_or_emergency()`; bootstrap entries skip verification.
+- `mur agent create` (M1.3) — writes a bootstrap rotation line into `<agent_dir>/rotations.jsonl` and populates the new IdentityConfig fields.
+- `mur agent rekey <name>` (M1.4) — CLI for normal rotation: signs an attestation with the OLD key, atomically rotates `identity.{key,pub}` to `.prev`, writes new keypair, appends to `rotations.jsonl`, updates `profile.yaml`, SIGTERMs the running runtime.
+- `--emergency` flag wired in M4.
+
+**Tests added (M1):** 11 profile_schema + 10 rotation_attestation + 4 agent_rekey_cli = 25 new tests.
+
+### M2 — Commander `apply_rotation` + grace registry (mur-commander)
+
+3 tasks. Key artefacts:
+
+- `engine::a2a::discovery::RegisteredAgent` — extended with `algorithm`, `key_version`, `previous_pubkey`, `previous_key_version`, `grace_expires_at`, `rotation_count`, `last_rotation_at`, `compromised_marker`. `CompromisedMarker` struct.
+- `engine::a2a::discovery::AgentRegistry::apply_rotation` — idempotent + signature-verified rotation entry point. Returns `RotationOutcome::{Applied, AlreadyApplied, Quarantined}` or `RotationError::{UnknownAgent, OldKeyMismatch, VersionMismatch, BadSignature, EmergencyRequiresApproval, Io}`. 30-day default grace.
+- `engine::remote::murmur_bridge` — when it sees `running.lock` change, also reads `identity.attestation.json` next to it and calls `apply_rotation` if `new_key_version > registry.key_version`.
+
+**Tests added (M2):** 1 new agent_registry_uuid + 8 apply_rotation + 1 murmur_bridge integration = 10 new tests.
+
+### M3 — Agent Card previous_pubkey + TcpConnector fallback (mur)
+
+3 tasks. Key artefacts:
+
+- `mur-agent-runtime::protocol::methods::card::CardHandler` — publishes `algorithm`, `key_version`, and (during grace) `previous_pubkey` + `previous_key_version` + `grace_expires_at`.
+- `mur-agent-runtime::transport::tcp::TcpConnector::dial_with_fallback` — iterates candidate pubkeys in order; first successful Noise XK handshake wins. Backward-compatible `dial` wrapper.
+
+**Tests added (M3):** 2 new card_extended + 3 new tcp_transport = 5 tests.
+
+### M4 — Emergency path + `murc agent approve-rekey` (both repos)
+
+4 tasks. Key artefacts:
+
+- `mur agent rekey --emergency` — interactive `I UNDERSTAND` prompt; writes unsigned attestation; sets `profile.identity.emergency_rekey_at`.
+- `engine::a2a::discovery::AgentRegistry::approve_emergency_rotation` — applies an unsigned emergency attestation (still validates `old_pubkey` + `old_key_version`); skips signature check; clears `compromised_marker`.
+- `reject_emergency_rotation` — clears `pending_emergency_approval` marker without applying.
+- `murmur_bridge` — on `EmergencyRequiresApproval`, sets `compromised_marker = pending_emergency_approval` and emits a high-priority audit log; agent's pubkey/key_version stay UNCHANGED.
+- `murc agent approve-rekey <uuid>` / `reject-rekey <uuid>` CLI — gated by FS write access to `~/.mur/commander/agents.json` (option-a per spec). Locates the unsigned attestation by scanning `<MUR_HOME>/agents/*/identity.attestation.json`.
+
+**Tests added (M4):** 2 new agent_rekey_cli (mur) + 4 new apply_rotation (commander) = 6 tests.
+
+### M5 — Split detection + chain verification (both repos)
+
+3 tasks. Key artefacts:
+
+- `mur-common::identity::verify_chain(chain, opts)` — walks an attestation chain top-to-bottom (bootstrap → v1 → v2 → ...). Validates `+1` succession, pubkey continuity, no duplicate versions, signature on each non-bootstrap step. `ChainOptions { allow_emergency }` controls whether emergency entries are accepted in-chain.
+- `engine::a2a::discovery::apply_rotation` (M5.2) — split-attestation detection: when an attestation arrives claiming the same `new_key_version` already in the registry but with a DIFFERENT `new_pubkey`, the agent is quarantined with `compromised_marker.reason = "split_attestation_vN_to_vN+1"` and the conflicting pubkeys are recorded.
+
+**Tests added (M5):** 11 identity_chain + 1 split-attestation = 12 tests.
+
+### M6 — Grace cleanup + `rekey-status` + docs (both repos)
+
+5 tasks. Key artefacts:
+
+- `mur-agent-runtime::supervisor::grace_cleanup_if_expired` — on every supervisor startup, if `grace_expires_at` has passed, shreds `identity.key.prev` (best-effort `shred -u`, falls back to overwrite + unlink) and clears `previous_*` fields from `profile.yaml`.
+- `engine::a2a::discovery::AgentRegistry::sweep_grace_expiries` — clears `previous_pubkey` / `previous_key_version` / `grace_expires_at` on every entry whose grace window has passed. Returns count swept.
+- `mur-commander/crates/daemon` — hourly task spawned at startup that calls `sweep_grace_expiries`.
+- `mur agent rekey-status <name> [--json]` — text or JSON dump of current/previous keys, algorithm, grace remaining (in days), rotation history line count, optional emergency marker.
+- This file + CLAUDE.md "P0a.6 additions" section.
+
+**Tests added (M6):** 3 grace_cleanup (agent) + 2 sweep tests + 2 rekey-status CLI = 7 tests.
+
+## Tests added across the rekey work
+
+| Crate | File | Count |
+|---|---|---|
+| mur-common | tests/profile_schema.rs (extended) | +3 |
+| mur-common | tests/rotation_attestation.rs | 10 |
+| mur-common | tests/identity_chain.rs | 11 |
+| mur-core | tests/agent_create_identity.rs (extended) | +1 |
+| mur-core | tests/agent_rekey_cli.rs | 7 |
+| mur-agent-runtime | tests/card_extended.rs (extended) | +2 |
+| mur-agent-runtime | tests/tcp_transport.rs (extended) | +3 |
+| mur-agent-runtime | tests/grace_cleanup.rs | 3 |
+| engine (commander) | tests/agent_registry_uuid.rs (extended) | +1 |
+| engine (commander) | tests/apply_rotation.rs | 15 |
+| engine (commander) | tests/murmur_bridge.rs (extended) | +1 |
+
+**Total: 57 new tests across the two repos**, all green. Pre-existing ~770 + ~777 lib tests still pass. Clippy + fmt clean for touched code.
+
+## Deviations from the plan (all benign)
+
+1. **mur-common chain verifier — `ChainOptions::default()` derived.** Plan specimen had a manual `impl Default`; clippy `derivable_impls` flagged it. Replaced with `#[derive(Default)]` since `bool::default()` is `false`.
+2. **mur-commander edition 2021 — nested `if let` not let-chains.** Same workaround as P0a.5: the commander workspace is on edition 2021 and let-chains are not stabilized; the rekey code uses nested `if let` blocks.
+3. **CLI `rekey_emergency_flag_errors_in_m1` test renamed.** The original M1.4 test asserted that `--emergency` errored; once M4.1 made it valid, the test was rewritten to assert the success path (`rekey_emergency_writes_unsigned_attestation`) and a new `rekey_emergency_aborts_without_confirmation_phrase` was added for the abort-without-`I UNDERSTAND` path.
+4. **`mur-common` workspace dep on commander side bumped twice.** First pin `rev = "1b1b013"` after M1.4 (RotationAttestation types); bumped to `rev = "2b51b1e"` after M5.1 (chain verifier). Both pins TODO'd to bounce back to a v2.x.x tag once mur cuts a release.
+5. **Single `Agent` subcommand group in commander CLI.** The plan reserved space for more agent-management commands later; for now `murc agent` only has `approve-rekey` and `reject-rekey`.
+
+## Commits (chronological)
+
+### mur (`feat/agent-rekey`)
+
+```
+a4e6ea2 feat(core): mur agent rekey-status (M6.3) — text + --json output
+82d9b81 fix(agent-runtime): collapse nested if let in shred_file (clippy)
+1bcc577 feat(agent-runtime): grace expiry shreds identity.key.prev + clears profile (M6.1)
+2b51b1e feat(common): RotationAttestation chain verifier (M5.1)
+f16e826 feat(core): mur agent rekey --emergency path (M4.1)
+d6a91c2 feat(agent-runtime): TcpConnector::dial_with_fallback for rekey grace migration (M3.2)
+2e0f552 feat(agent-runtime): Agent Card publishes previous_pubkey + key_version (M3.1)
+1b1b013 feat(core): mur agent rekey — normal rotation with attestation
+cfa1f8e feat(core): bootstrap rotation attestation on mur agent create
+506778c style: cargo fmt (pre-existing P0a.5 drift)
+b6baaef feat(common): RotationAttestation with Ed25519 sign/verify (canonical JSON)
+96f965e feat(common): IdentityConfig rekey extensions (algorithm, key_version, previous_pubkey, grace)
+9a8571c docs(spec): mur agent rekey — design + 6-milestone plan
+```
+
+(plus this docs commit + the M6.4 CLAUDE.md update.)
+
+### mur-commander (`feat/agent-rekey-commander`)
+
+```
+f2121ab feat(commander): hourly grace sweep clears expired previous_pubkey (M6.2)
+1927ea5 feat(engine): split-attestation detection with quarantine marker (M5.2) + bump mur-common to chain-verifier rev
+b2e3c0c feat(cli): murc agent approve-rekey / reject-rekey (M4.2 CLI, FS-gated)
+05695d8 feat(engine): murmur_bridge marks emergency rotations pending approval (M4.3)
+64c7ce0 feat(engine): approve_emergency_rotation + reject_emergency_rotation (M4.2 engine)
+8734e7a feat(engine): murmur_bridge applies rotation attestations from agent FS (M2.3)
+b8d7d40 feat(engine): AgentRegistry::apply_rotation with signature + grace TTL (M2.2)
+62cb09a feat(engine): RegisteredAgent rotation bookkeeping fields (M2.1)
+```
+
+## Open / non-blocking items
+
+- **Hub-side attestation chain federation** — commanders currently apply rotations independently; multi-commander gossip via the mur-run hub lands as part of P1's hub work. Per spec § 9, the design treats commanders/hubs as distribution mechanisms, not trust anchors — attestations self-verify, so no inter-commander trust is required for the federated path.
+- **Post-quantum** — schema has `algorithm` field; actual `ed25519+kyber768` hybrid signing waits for upstream Rust crate stability.
+- **Hardware-backed keys (YubiKey / TPM / Secure Enclave)** — out of scope; can be added as algorithm variants later.
+- **Key escrow / master recovery** — deliberately not supported per spec. Emergency rekey is the only recovery path.
+- **mur-common dep bounce** — once mur cuts `v2.4.0`, bump commander's `mur-common` pin from `rev = "2b51b1e"` to `tag = "v2.4.0"`.
+- **CI billing** — both PRs have CI-failed status due to GitHub Actions billing on the org. Local test/clippy/fmt all green.

--- a/mur-agent-runtime/src/protocol/methods/card.rs
+++ b/mur-agent-runtime/src/protocol/methods/card.rs
@@ -49,11 +49,16 @@ impl MethodHandler for CardHandler {
             }));
         }
 
-        Ok(json!({
+        // M3.1: include previous_pubkey + grace_expires_at when within grace.
+        // Peers use these to retry handshakes against either key during the
+        // grace window.
+        let mut card = json!({
             "protocolVersion": "a2a/0.3",
             "name": p.name,
             "id": p.id,
             "pubkey": p.identity.pubkey,
+            "algorithm": p.identity.algorithm,
+            "key_version": p.identity.key_version,
             "displayName": p.display_name,
             "version": p.version,
             "description": p.persona.description,
@@ -71,6 +76,24 @@ impl MethodHandler for CardHandler {
             },
             "skills": p.skills.iter().map(|s| json!({"id": s})).collect::<Vec<_>>(),
             "entitlements": p.entitlements,
-        }))
+        });
+
+        if let (Some(prev), Some(expires)) =
+            (&p.identity.previous_pubkey, &p.identity.grace_expires_at)
+        {
+            // Only advertise the previous key if grace is still active. We
+            // parse the timestamp lazily; if it's malformed we err on the
+            // side of *not* publishing it.
+            let still_in_grace = chrono::DateTime::parse_from_rfc3339(expires)
+                .map(|exp| exp > chrono::Utc::now())
+                .unwrap_or(false);
+            if still_in_grace {
+                card["previous_pubkey"] = json!(prev);
+                card["previous_key_version"] = json!(p.identity.previous_key_version);
+                card["grace_expires_at"] = json!(expires);
+            }
+        }
+
+        Ok(card)
     }
 }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -451,10 +451,10 @@ fn shred_file(path: &std::path::Path) -> anyhow::Result<()> {
         .arg("-u")
         .arg(path)
         .status();
-    if let Ok(s) = shred {
-        if s.success() {
-            return Ok(());
-        }
+    if let Ok(s) = shred
+        && s.success()
+    {
+        return Ok(());
     }
     // Fallback: overwrite with random bytes, then unlink.
     use std::io::Write as _;

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -100,6 +100,13 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         }
     });
 
+    // 3b. M6.1: grace-period cleanup. If profile.identity.grace_expires_at
+    //     has passed, shred identity.key.prev + clear the previous_pubkey
+    //     fields in profile.yaml. Best-effort; log warnings on failure.
+    if let Err(e) = grace_cleanup_if_expired(&agent_home, &profile.inner) {
+        warn!(error = %e, "grace-period cleanup failed");
+    }
+
     // 4. Spawn telemetry writer
     let (writer, notif_rx) = TelemetryWriter::new(
         agent_home.join("telemetry"),
@@ -387,5 +394,95 @@ pub fn validate_tcp_entitlement(
             "transport.tcp bound to :{port} but entitlements.network.inbound.ports does not allow it"
         )));
     }
+    Ok(())
+}
+
+/// M6.1: clean up the previous identity material if the grace period has
+/// passed. On Unix we attempt a best-effort `shred -u` on the private
+/// `identity.key.prev` first; if `shred` is not available we fall back to
+/// overwriting + removing.
+pub fn grace_cleanup_if_expired(
+    agent_home: &std::path::Path,
+    profile: &mur_common::agent::AgentProfile,
+) -> anyhow::Result<()> {
+    let Some(expires_str) = profile.identity.grace_expires_at.as_deref() else {
+        return Ok(());
+    };
+    let expires = match chrono::DateTime::parse_from_rfc3339(expires_str) {
+        Ok(t) => t,
+        Err(_) => return Ok(()),
+    };
+    if expires > chrono::Utc::now() {
+        return Ok(()); // still in grace
+    }
+
+    let key_prev = agent_home.join("identity.key.prev");
+    let pub_prev = agent_home.join("identity.pub.prev");
+
+    if key_prev.exists() {
+        shred_file(&key_prev)?;
+    }
+    if pub_prev.exists() {
+        let _ = std::fs::remove_file(&pub_prev);
+    }
+
+    // Rewrite profile.yaml without the previous_pubkey fields.
+    let profile_path = agent_home.join("profile.yaml");
+    let yaml = std::fs::read_to_string(&profile_path)?;
+    let mut p: mur_common::agent::AgentProfile = serde_yaml_ng::from_str(&yaml)?;
+    p.identity.previous_pubkey = None;
+    p.identity.previous_key_version = None;
+    p.identity.grace_expires_at = None;
+    p.updated_at = chrono::Utc::now().to_rfc3339();
+    let new_yaml = serde_yaml_ng::to_string(&p)?;
+    let tmp = profile_path.with_extension("tmp");
+    std::fs::write(&tmp, new_yaml.as_bytes())?;
+    std::fs::rename(&tmp, &profile_path)?;
+
+    tracing::info!("grace-period cleanup: shredded identity.key.prev + cleared previous_pubkey");
+    Ok(())
+}
+
+#[cfg(unix)]
+fn shred_file(path: &std::path::Path) -> anyhow::Result<()> {
+    // Try `shred -u` first (GNU coreutils — available on most Linux + macOS
+    // via `gshred` if installed). Fall back to overwrite + remove.
+    let shred = std::process::Command::new("shred")
+        .arg("-u")
+        .arg(path)
+        .status();
+    if let Ok(s) = shred {
+        if s.success() {
+            return Ok(());
+        }
+    }
+    // Fallback: overwrite with random bytes, then unlink.
+    use std::io::Write as _;
+    if let Ok(meta) = std::fs::metadata(path) {
+        let len = meta.len() as usize;
+        if let Ok(mut f) = std::fs::OpenOptions::new().write(true).open(path) {
+            // 32-byte private key — simple zero-fill is sufficient.
+            let zeros = vec![0u8; len.max(32)];
+            let _ = f.write_all(&zeros);
+            let _ = f.sync_all();
+        }
+    }
+    let _ = std::fs::remove_file(path);
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn shred_file(path: &std::path::Path) -> anyhow::Result<()> {
+    // Windows: best-effort overwrite + delete.
+    use std::io::Write as _;
+    if let Ok(meta) = std::fs::metadata(path) {
+        let len = meta.len() as usize;
+        if let Ok(mut f) = std::fs::OpenOptions::new().write(true).open(path) {
+            let zeros = vec![0u8; len.max(32)];
+            let _ = f.write_all(&zeros);
+            let _ = f.sync_all();
+        }
+    }
+    let _ = std::fs::remove_file(path);
     Ok(())
 }

--- a/mur-agent-runtime/src/transport/tcp.rs
+++ b/mur-agent-runtime/src/transport/tcp.rs
@@ -176,7 +176,46 @@ pub struct TcpConnector {
 }
 
 impl TcpConnector {
+    /// Dial with a single candidate pubkey. Convenience wrapper around
+    /// `dial_with_fallback` for the common case.
     pub async fn dial(
+        addr: &str,
+        identity: Arc<AgentIdentity>,
+        remote_static_pub: &[u8; 32],
+    ) -> io::Result<Self> {
+        Self::dial_with_fallback(addr, identity, &[*remote_static_pub]).await
+    }
+
+    /// Dial with a list of candidate pubkeys, tried in order. Used by peers
+    /// that have an ambiguous cached pubkey (e.g. mid-rotation grace period).
+    /// Returns on the first candidate whose handshake completes; returns the
+    /// last error if all candidates fail.
+    ///
+    /// Each candidate gets a fresh TCP connection — Noise XK handshakes
+    /// are not retryable on the same socket once they've started.
+    pub async fn dial_with_fallback(
+        addr: &str,
+        identity: Arc<AgentIdentity>,
+        candidates: &[[u8; 32]],
+    ) -> io::Result<Self> {
+        if candidates.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "dial_with_fallback: no candidate pubkeys",
+            ));
+        }
+        let mut last_err: Option<io::Error> = None;
+        for candidate in candidates {
+            match Self::try_dial_one(addr, identity.clone(), candidate).await {
+                Ok(conn) => return Ok(conn),
+                Err(e) => last_err = Some(e),
+            }
+        }
+        Err(last_err.unwrap_or_else(|| io::Error::other("dial_with_fallback exhausted candidates")))
+    }
+
+    /// One handshake attempt against a single candidate pubkey.
+    async fn try_dial_one(
         addr: &str,
         identity: Arc<AgentIdentity>,
         remote_static_pub: &[u8; 32],

--- a/mur-agent-runtime/tests/card_extended.rs
+++ b/mur-agent-runtime/tests/card_extended.rs
@@ -32,3 +32,141 @@ async fn card_includes_pubkey_endpoints_deployment() {
     assert_eq!(json["deployment"]["type"], "docker");
     assert_eq!(json["deployment"]["environment"], "prod");
 }
+
+// M3.1: previous_pubkey + grace_expires_at exposed during grace
+#[tokio::test]
+async fn card_includes_previous_pubkey_during_grace() {
+    use mur_agent_runtime::profile::Profile;
+    use mur_agent_runtime::protocol::a2a_server::MethodHandler;
+    use mur_agent_runtime::protocol::methods::card::CardHandler;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    let yaml_with_grace = r#"
+schema: 1
+id: 0192f5a1-28ab-7111-8000-000000000003
+name: agent_grace
+display_name: "Grace"
+version: "0.1.0"
+persona:
+  category: research
+  description: "Agent in grace"
+  traits: { tone: concise, risk: cautious, verbosity: low }
+sys_prompt_file: "sys_prompt.md"
+model: { provider: ollama, name: "m", params: {} }
+mcp_servers: []
+skills: []
+identity:
+  pubkey: zNEWKEY
+  owner: t@example.com
+  algorithm: ed25519
+  key_version: 2
+  previous_pubkey: zOLDKEY
+  previous_key_version: 1
+  grace_expires_at: "2099-04-25T10:00:00+08:00"
+  rotated_at: "2026-04-25T10:00:00+08:00"
+transport:
+  stdio: true
+  socket: { enabled: false, bind: "" }
+communication: { accepts_from: ["*"], sends_to: [] }
+capabilities: []
+entitlements:
+  network:
+    inbound: { ports: [] }
+    outbound: { mode: restricted, allow_hosts: [], protocols: ["tcp"], resolve_dns: { mode: system } }
+  filesystem: { read: [], write: [], deny: [] }
+  processes: { spawn: { mode: allowlist, allowed: [] } }
+  syscalls: { mode: default }
+  limits: { memory_mb: 512, file_descriptors: 1024, processes: 32 }
+notifications: { on_task_complete: [], on_error: [], on_shutdown: [] }
+retry:
+  llm: { max_retries: 3, backoff: exponential, initial_delay_ms: 1000, max_delay_ms: 30000, retry_on: ["rate_limit"] }
+  tool: { max_retries: 1, backoff: fixed, initial_delay_ms: 500 }
+lifecycle: { restart: on_failure, max_restarts: 3, restart_window_secs: 600, stop_timeout_secs: 15, mcp_required: true }
+created_at: "2026-04-22T10:00:00+08:00"
+updated_at: "2026-04-25T10:00:00+08:00"
+"#;
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join("agent_grace");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("profile.yaml"), yaml_with_grace).unwrap();
+    let profile = Profile::load(&dir).unwrap();
+    std::mem::forget(tmp);
+
+    let handler = CardHandler::new(Arc::new(profile));
+    let json = handler.handle(None).await.unwrap();
+    assert_eq!(json["pubkey"], "zNEWKEY");
+    assert_eq!(json["previous_pubkey"], "zOLDKEY");
+    assert_eq!(json["previous_key_version"], 1);
+    assert_eq!(json["key_version"], 2);
+    assert_eq!(json["algorithm"], "ed25519");
+    assert!(json.get("grace_expires_at").is_some());
+}
+
+#[tokio::test]
+async fn card_omits_previous_pubkey_after_grace() {
+    use mur_agent_runtime::profile::Profile;
+    use mur_agent_runtime::protocol::a2a_server::MethodHandler;
+    use mur_agent_runtime::protocol::methods::card::CardHandler;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    let yaml_post_grace = r#"
+schema: 1
+id: 0192f5a1-28ab-7111-8000-000000000004
+name: agent_post
+display_name: "Post"
+version: "0.1.0"
+persona:
+  category: research
+  description: "Agent post-grace"
+  traits: { tone: concise, risk: cautious, verbosity: low }
+sys_prompt_file: "sys_prompt.md"
+model: { provider: ollama, name: "m", params: {} }
+mcp_servers: []
+skills: []
+identity:
+  pubkey: zNEWKEY
+  owner: t@example.com
+  algorithm: ed25519
+  key_version: 2
+  previous_pubkey: zOLDKEY
+  previous_key_version: 1
+  grace_expires_at: "2020-01-01T00:00:00+00:00"
+transport:
+  stdio: true
+  socket: { enabled: false, bind: "" }
+communication: { accepts_from: ["*"], sends_to: [] }
+capabilities: []
+entitlements:
+  network:
+    inbound: { ports: [] }
+    outbound: { mode: restricted, allow_hosts: [], protocols: ["tcp"], resolve_dns: { mode: system } }
+  filesystem: { read: [], write: [], deny: [] }
+  processes: { spawn: { mode: allowlist, allowed: [] } }
+  syscalls: { mode: default }
+  limits: { memory_mb: 512, file_descriptors: 1024, processes: 32 }
+notifications: { on_task_complete: [], on_error: [], on_shutdown: [] }
+retry:
+  llm: { max_retries: 3, backoff: exponential, initial_delay_ms: 1000, max_delay_ms: 30000, retry_on: ["rate_limit"] }
+  tool: { max_retries: 1, backoff: fixed, initial_delay_ms: 500 }
+lifecycle: { restart: on_failure, max_restarts: 3, restart_window_secs: 600, stop_timeout_secs: 15, mcp_required: true }
+created_at: "2026-04-22T10:00:00+08:00"
+updated_at: "2026-04-25T10:00:00+08:00"
+"#;
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join("agent_post");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("profile.yaml"), yaml_post_grace).unwrap();
+    let profile = Profile::load(&dir).unwrap();
+    std::mem::forget(tmp);
+
+    let handler = CardHandler::new(Arc::new(profile));
+    let json = handler.handle(None).await.unwrap();
+    assert_eq!(json["pubkey"], "zNEWKEY");
+    assert!(
+        json.get("previous_pubkey").is_none(),
+        "expired grace must omit previous_pubkey"
+    );
+    assert!(json.get("grace_expires_at").is_none());
+}

--- a/mur-agent-runtime/tests/grace_cleanup.rs
+++ b/mur-agent-runtime/tests/grace_cleanup.rs
@@ -1,0 +1,134 @@
+//! M6.1 — agent-side grace expiry cleanup.
+
+use mur_agent_runtime::supervisor::grace_cleanup_if_expired;
+use mur_common::agent::AgentProfile;
+use std::os::unix::fs::PermissionsExt;
+use tempfile::TempDir;
+
+fn write_min_profile(dir: &std::path::Path, key_version: u32, grace: Option<&str>) {
+    let grace_line = grace
+        .map(|g| format!("\n  grace_expires_at: \"{g}\""))
+        .unwrap_or_default();
+    let yaml = format!(
+        r#"
+schema: 1
+id: 0192f5a1-28ab-7111-8000-000000000099
+name: agent_grace
+display_name: "Grace"
+version: "0.1.0"
+persona:
+  category: research
+  description: "Grace test"
+  traits: {{ tone: concise, risk: cautious, verbosity: low }}
+sys_prompt_file: "sys_prompt.md"
+model: {{ provider: ollama, name: "m", params: {{}} }}
+mcp_servers: []
+skills: []
+identity:
+  pubkey: zNEWKEY
+  algorithm: ed25519
+  key_version: {key_version}
+  previous_pubkey: zOLDKEY
+  previous_key_version: 0{grace_line}
+transport:
+  stdio: true
+  socket: {{ enabled: false, bind: "" }}
+communication: {{ accepts_from: ["*"], sends_to: [] }}
+capabilities: []
+entitlements:
+  network:
+    inbound: {{ ports: [] }}
+    outbound: {{ mode: restricted, allow_hosts: [], protocols: ["tcp"], resolve_dns: {{ mode: system }} }}
+  filesystem: {{ read: [], write: [], deny: [] }}
+  processes: {{ spawn: {{ mode: allowlist, allowed: [] }} }}
+  syscalls: {{ mode: default }}
+  limits: {{ memory_mb: 512, file_descriptors: 1024, processes: 32 }}
+notifications: {{ on_task_complete: [], on_error: [], on_shutdown: [] }}
+retry:
+  llm: {{ max_retries: 3, backoff: exponential, initial_delay_ms: 1000, max_delay_ms: 30000, retry_on: ["rate_limit"] }}
+  tool: {{ max_retries: 1, backoff: fixed, initial_delay_ms: 500 }}
+lifecycle: {{ restart: on_failure, max_restarts: 3, restart_window_secs: 600, stop_timeout_secs: 15, mcp_required: true }}
+created_at: "2026-04-22T10:00:00+08:00"
+updated_at: "2026-04-25T10:00:00+08:00"
+"#
+    );
+    std::fs::write(dir.join("profile.yaml"), yaml).unwrap();
+}
+
+fn write_prev_files(dir: &std::path::Path) {
+    std::fs::write(dir.join("identity.key.prev"), [0u8; 32]).unwrap();
+    let mut perms = std::fs::metadata(dir.join("identity.key.prev"))
+        .unwrap()
+        .permissions();
+    perms.set_mode(0o600);
+    std::fs::set_permissions(dir.join("identity.key.prev"), perms).unwrap();
+    std::fs::write(dir.join("identity.pub.prev"), b"zOLDKEY").unwrap();
+}
+
+#[test]
+fn cleanup_runs_when_grace_expired() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    write_min_profile(dir, 1, Some("2020-01-01T00:00:00+00:00"));
+    write_prev_files(dir);
+
+    let yaml = std::fs::read_to_string(dir.join("profile.yaml")).unwrap();
+    let profile: AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
+
+    grace_cleanup_if_expired(dir, &profile).expect("cleanup ok");
+
+    assert!(
+        !dir.join("identity.key.prev").exists(),
+        "expired grace must shred identity.key.prev"
+    );
+    assert!(
+        !dir.join("identity.pub.prev").exists(),
+        "expired grace must remove identity.pub.prev"
+    );
+
+    let yaml = std::fs::read_to_string(dir.join("profile.yaml")).unwrap();
+    assert!(
+        !yaml.contains("previous_pubkey:"),
+        "previous_pubkey must be cleared: {yaml}"
+    );
+    assert!(
+        !yaml.contains("grace_expires_at:"),
+        "grace_expires_at must be cleared: {yaml}"
+    );
+}
+
+#[test]
+fn cleanup_noop_when_grace_still_active() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    write_min_profile(dir, 1, Some("2099-01-01T00:00:00+00:00"));
+    write_prev_files(dir);
+
+    let yaml = std::fs::read_to_string(dir.join("profile.yaml")).unwrap();
+    let profile: AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
+    grace_cleanup_if_expired(dir, &profile).unwrap();
+
+    assert!(
+        dir.join("identity.key.prev").exists(),
+        "in-grace cleanup must NOT touch identity.key.prev"
+    );
+    assert!(dir.join("identity.pub.prev").exists());
+}
+
+#[test]
+fn cleanup_noop_when_no_grace_field() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    write_min_profile(dir, 0, None);
+
+    let yaml = std::fs::read_to_string(dir.join("profile.yaml")).unwrap();
+    let profile: AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
+    grace_cleanup_if_expired(dir, &profile).unwrap();
+
+    let yaml_after = std::fs::read_to_string(dir.join("profile.yaml")).unwrap();
+    assert_eq!(
+        yaml.trim(),
+        yaml_after.trim(),
+        "no-op when grace_expires_at absent"
+    );
+}

--- a/mur-agent-runtime/tests/tcp_transport.rs
+++ b/mur-agent-runtime/tests/tcp_transport.rs
@@ -66,3 +66,73 @@ async fn dialer_aborts_on_mitm_mismatch() {
     assert!(res.is_err(), "MITM-style mismatch must fail handshake");
     drop(tx);
 }
+
+#[tokio::test]
+async fn dial_with_fallback_picks_first_working_candidate() {
+    let server_id = Arc::new(AgentIdentity::generate());
+    let client_id = Arc::new(AgentIdentity::generate());
+    let bogus = [0u8; 32];
+
+    let handler = Arc::new(|p: Vec<u8>| async move { Ok::<_, std::io::Error>(p) });
+    let (tx, rx) = mpsc::channel(1);
+    let handle = spawn_tcp_listener(
+        TcpTransportConfig {
+            bind: "127.0.0.1:0".into(),
+        },
+        server_id.clone(),
+        handler,
+        rx,
+    )
+    .await
+    .unwrap();
+
+    let server_pub = x25519_dalek::PublicKey::from(&server_id.to_x25519_static_secret());
+    let candidates = [bogus, *server_pub.as_bytes()];
+
+    let mut conn =
+        TcpConnector::dial_with_fallback(&handle.local_addr().to_string(), client_id, &candidates)
+            .await
+            .expect("must succeed via fallback");
+
+    let payload = br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#.to_vec();
+    conn.send(&payload).await.unwrap();
+    let echo = conn.recv().await.unwrap();
+    assert_eq!(echo, payload);
+
+    drop(tx);
+    handle.await_shutdown().await;
+}
+
+#[tokio::test]
+async fn dial_with_fallback_all_bad_returns_last_error() {
+    let server_id = Arc::new(AgentIdentity::generate());
+    let client_id = Arc::new(AgentIdentity::generate());
+
+    let handler = Arc::new(|p: Vec<u8>| async move { Ok::<_, std::io::Error>(p) });
+    let (tx, rx) = mpsc::channel(1);
+    let handle = spawn_tcp_listener(
+        TcpTransportConfig {
+            bind: "127.0.0.1:0".into(),
+        },
+        server_id,
+        handler,
+        rx,
+    )
+    .await
+    .unwrap();
+
+    let candidates = [[0u8; 32], [1u8; 32], [2u8; 32]];
+    let res =
+        TcpConnector::dial_with_fallback(&handle.local_addr().to_string(), client_id, &candidates)
+            .await;
+    assert!(res.is_err(), "all-bad fallback must error");
+
+    drop(tx);
+}
+
+#[tokio::test]
+async fn dial_with_fallback_empty_candidates_errors() {
+    let client_id = Arc::new(AgentIdentity::generate());
+    let res = TcpConnector::dial_with_fallback("127.0.0.1:1", client_id, &[]).await;
+    assert!(res.is_err(), "empty candidates must be a hard error");
+}

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -39,7 +39,14 @@ pub struct AgentProfile {
     pub updated_at: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+fn default_algorithm() -> String {
+    "ed25519".into()
+}
+
+/// Algorithms the runtime can generate + verify.
+pub const SUPPORTED_ALGORITHMS: &[&str] = &["ed25519"];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IdentityConfig {
     /// Multibase-encoded Ed25519 public key (base58btc, `z` prefix).
     /// Empty string for legacy P0a profiles; filled on P0a.5 `mur agent create`.
@@ -48,6 +55,50 @@ pub struct IdentityConfig {
     /// Free-form owner identity (email / SSO sub). None for legacy profiles.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub owner: Option<String>,
+
+    // P0a.6 rekey extensions (all #[serde(default)] — back-compat)
+    /// Cryptographic algorithm for this key. Defaults to "ed25519".
+    #[serde(default = "default_algorithm")]
+    pub algorithm: String,
+    /// Monotonic version counter; 0 = initial create, increments on each rotation.
+    #[serde(default)]
+    pub key_version: u32,
+    /// RFC3339 timestamp of when this key was created.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at_key: Option<String>,
+    /// Previous public key (before most recent rotation). None if not rotated yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_pubkey: Option<String>,
+    /// Version of the previous key. None if not rotated yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub previous_key_version: Option<u32>,
+    /// RFC3339 timestamp when grace period expires and old key is fully retired.
+    /// Only set during rotation; cleared once grace period ends.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grace_expires_at: Option<String>,
+    /// RFC3339 timestamp of the most recent key rotation (normal, not emergency).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rotated_at: Option<String>,
+    /// RFC3339 timestamp of emergency key rotation (set only if emergency rekey occurred).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub emergency_rekey_at: Option<String>,
+}
+
+impl Default for IdentityConfig {
+    fn default() -> Self {
+        Self {
+            pubkey: String::new(),
+            owner: None,
+            algorithm: default_algorithm(),
+            key_version: 0,
+            created_at_key: None,
+            previous_pubkey: None,
+            previous_key_version: None,
+            grace_expires_at: None,
+            rotated_at: None,
+            emergency_rekey_at: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/mur-common/src/identity.rs
+++ b/mur-common/src/identity.rs
@@ -299,6 +299,153 @@ impl RotationAttestation {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Chain verification — M5.1
+// ---------------------------------------------------------------------------
+
+/// Per-call options for `verify_chain`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ChainOptions {
+    /// If true, accept emergency entries with empty signature (i.e. use
+    /// `verify_or_emergency` instead of strict `verify`). Commander code
+    /// that has out-of-band approval already should set this true; peer
+    /// code that is mirroring without approval should leave it false.
+    pub allow_emergency: bool,
+}
+
+/// Outcome of a successful chain verification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainOutcome {
+    /// Highest key_version observed.
+    pub head_key_version: u32,
+    /// Pubkey at head_key_version.
+    pub head_pubkey: String,
+    /// Total entries (including bootstrap).
+    pub length: usize,
+}
+
+/// Errors from `verify_chain`.
+#[derive(Debug)]
+pub enum ChainError {
+    /// Chain is empty or first entry is not a bootstrap.
+    MissingBootstrap,
+    /// Chain skipped a key_version (e.g. went 1 -> 3).
+    VersionSkip { expected: u32, got: u32 },
+    /// `a[i].old_pubkey` does not match `a[i-1].new_pubkey`.
+    PubkeyDiscontinuity { at_version: u32 },
+    /// Same `new_key_version` appears twice in the chain.
+    DuplicateVersion(u32),
+    /// Bad Ed25519 signature on a non-bootstrap, non-emergency entry.
+    BadSignature { at_version: u32, detail: String },
+    /// Emergency entry encountered with `allow_emergency = false`.
+    EmergencyDisallowed { at_version: u32 },
+}
+
+impl std::fmt::Display for ChainError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingBootstrap => {
+                write!(
+                    f,
+                    "chain must start with a bootstrap entry (bootstrap=true, key_version=0)"
+                )
+            }
+            Self::VersionSkip { expected, got } => {
+                write!(f, "version skip: expected {expected}, got {got}")
+            }
+            Self::PubkeyDiscontinuity { at_version } => {
+                write!(
+                    f,
+                    "pubkey discontinuity at key_version {at_version}: old_pubkey does not match prior new_pubkey"
+                )
+            }
+            Self::DuplicateVersion(v) => write!(f, "duplicate key_version {v}"),
+            Self::BadSignature { at_version, detail } => {
+                write!(f, "bad signature at key_version {at_version}: {detail}")
+            }
+            Self::EmergencyDisallowed { at_version } => {
+                write!(
+                    f,
+                    "emergency attestation at key_version {at_version} requires allow_emergency=true"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ChainError {}
+
+/// Walk the chain top-to-bottom and verify it forms a valid history.
+/// Returns the head pubkey + version on success.
+pub fn verify_chain(
+    chain: &[RotationAttestation],
+    opts: ChainOptions,
+) -> std::result::Result<ChainOutcome, ChainError> {
+    if chain.is_empty() {
+        return Err(ChainError::MissingBootstrap);
+    }
+    let first = &chain[0];
+    if !first.bootstrap || first.new_key_version != 0 {
+        return Err(ChainError::MissingBootstrap);
+    }
+
+    let mut prev_pubkey = first.new_pubkey.clone();
+    let mut prev_version = 0u32;
+    let mut seen_versions = std::collections::HashSet::new();
+    seen_versions.insert(0u32);
+
+    for (i, a) in chain.iter().enumerate().skip(1) {
+        // No duplicate versions
+        if !seen_versions.insert(a.new_key_version) {
+            return Err(ChainError::DuplicateVersion(a.new_key_version));
+        }
+        // Strict +1 succession
+        let expected = prev_version + 1;
+        if a.old_key_version != prev_version || a.new_key_version != expected {
+            return Err(ChainError::VersionSkip {
+                expected,
+                got: a.new_key_version,
+            });
+        }
+        // Pubkey continuity
+        if a.old_pubkey != prev_pubkey {
+            return Err(ChainError::PubkeyDiscontinuity {
+                at_version: a.new_key_version,
+            });
+        }
+        // Signature (or emergency allowance)
+        if a.reason == RotationReason::Emergency {
+            if !opts.allow_emergency {
+                return Err(ChainError::EmergencyDisallowed {
+                    at_version: a.new_key_version,
+                });
+            }
+            // Lenient verify: empty signature is fine for emergency
+            if let Err(e) = a.verify_or_emergency(&a.old_pubkey) {
+                return Err(ChainError::BadSignature {
+                    at_version: a.new_key_version,
+                    detail: e.to_string(),
+                });
+            }
+        } else if let Err(e) = a.verify(&a.old_pubkey) {
+            return Err(ChainError::BadSignature {
+                at_version: a.new_key_version,
+                detail: e.to_string(),
+            });
+        }
+
+        prev_pubkey = a.new_pubkey.clone();
+        prev_version = a.new_key_version;
+        let _ = i; // silence unused
+    }
+
+    Ok(ChainOutcome {
+        head_key_version: prev_version,
+        head_pubkey: prev_pubkey,
+        length: chain.len(),
+    })
+}
+
 /// Canonical JSON: sorted keys, no whitespace. Used so that signers and
 /// verifiers compute identical byte sequences regardless of language /
 /// serializer choices.

--- a/mur-common/src/identity.rs
+++ b/mur-common/src/identity.rs
@@ -147,3 +147,207 @@ pub fn decode_pubkey(text: &str) -> Result<[u8; 32], IdentityError> {
 pub fn default_dir(agent_home: &Path) -> PathBuf {
     agent_home.to_path_buf()
 }
+
+// ---------------------------------------------------------------------------
+// RotationAttestation — proof that a key rotation was authorized by the
+// holder of the prior identity key.
+// ---------------------------------------------------------------------------
+
+use serde::{Deserialize, Serialize};
+
+/// Why a rotation happened. Free-form audit hint; does not affect verification
+/// rules other than `Emergency`, which permits an empty signature.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RotationReason {
+    Scheduled,
+    SuspectCompromise,
+    OwnerChange,
+    Emergency,
+}
+
+/// Cryptographic proof of an identity-key rotation.
+///
+/// `signature` is multibase base58btc Ed25519 over `canonical_bytes()`
+/// (which serializes every field except `signature` itself).
+///
+/// For `reason = Emergency`, signature MAY be empty — those rotations
+/// require out-of-band admin approval to take effect.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RotationAttestation {
+    /// Schema version. Always 1 for now.
+    pub schema: u32,
+    /// Agent UUIDv7 — stable across rotations.
+    pub uuid: String,
+    /// Signing algorithm. "ed25519" for now.
+    pub algorithm: String,
+    /// Outgoing pubkey (multibase). Empty string for the bootstrap entry only.
+    pub old_pubkey: String,
+    /// Incoming pubkey (multibase). Always present.
+    pub new_pubkey: String,
+    pub old_key_version: u32,
+    /// = old_key_version + 1 for non-emergency rotations.
+    pub new_key_version: u32,
+    /// RFC3339 timestamp.
+    pub rotated_at: String,
+    pub reason: RotationReason,
+    /// Multibase Ed25519 signature over canonical_bytes(). Empty for
+    /// Emergency reason or for the bootstrap entry.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub signature: String,
+    /// True only for the create-time entry (no prior key existed).
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub bootstrap: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+impl RotationAttestation {
+    /// Build a new (unsigned) attestation.
+    pub fn new(
+        uuid: impl Into<String>,
+        old_pubkey: impl Into<String>,
+        new_pubkey: impl Into<String>,
+        old_key_version: u32,
+        new_key_version: u32,
+        rotated_at: impl Into<String>,
+        reason: RotationReason,
+    ) -> Self {
+        Self {
+            schema: 1,
+            uuid: uuid.into(),
+            algorithm: "ed25519".into(),
+            old_pubkey: old_pubkey.into(),
+            new_pubkey: new_pubkey.into(),
+            old_key_version,
+            new_key_version,
+            rotated_at: rotated_at.into(),
+            reason,
+            signature: String::new(),
+            bootstrap: false,
+        }
+    }
+
+    /// Mark this attestation as the bootstrap entry written at agent
+    /// create time. Bootstrap entries have empty `old_pubkey` and empty
+    /// `signature`; they exist only to anchor the rotation chain.
+    pub fn into_bootstrap(mut self) -> Self {
+        self.bootstrap = true;
+        self.old_pubkey = String::new();
+        self.signature = String::new();
+        self
+    }
+
+    /// Canonical bytes used for signing. Serializes every field of `self`
+    /// EXCEPT `signature` (which is being computed) using JSON with sorted
+    /// keys and no whitespace.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let mut clone = self.clone();
+        clone.signature = String::new();
+        canonical_json(&clone)
+    }
+
+    /// Compute the Ed25519 signature using the given signing key and store
+    /// it in `self.signature`. Idempotent.
+    pub fn sign(&mut self, signing: &ed25519_dalek::SigningKey) {
+        use ed25519_dalek::Signer;
+        let sig = signing.sign(&self.canonical_bytes());
+        self.signature = multibase::encode(multibase::Base::Base58Btc, sig.to_bytes());
+    }
+
+    /// Verify `self.signature` against the supplied multibase-encoded
+    /// `old_pubkey`. Returns `Ok(())` on a valid signature.
+    ///
+    /// Bootstrap entries (`bootstrap = true`) are accepted unconditionally —
+    /// they have nothing to verify against.
+    /// Emergency entries (`reason = Emergency`) with empty signature are
+    /// REJECTED here; callers must use `verify_or_emergency` if they want
+    /// the emergency-allowed semantics.
+    pub fn verify(&self, old_pubkey: &str) -> Result<(), IdentityError> {
+        if self.bootstrap {
+            return Ok(());
+        }
+        if self.signature.is_empty() {
+            return Err(IdentityError::InvalidKey(
+                "attestation signature is empty".into(),
+            ));
+        }
+        let pub_bytes = decode_pubkey(old_pubkey)?;
+        let verifying = ed25519_dalek::VerifyingKey::from_bytes(&pub_bytes)
+            .map_err(|e| IdentityError::InvalidKey(format!("verifying key: {e}")))?;
+        let (_base, sig_bytes) = multibase::decode(&self.signature)?;
+        let sig_arr: [u8; 64] = sig_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| IdentityError::InvalidKey("signature length != 64".into()))?;
+        let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
+        verifying
+            .verify_strict(&self.canonical_bytes(), &sig)
+            .map_err(|e| IdentityError::InvalidKey(format!("signature: {e}")))?;
+        Ok(())
+    }
+
+    /// Like `verify`, but accepts emergency rotations with empty signature.
+    /// Caller is responsible for the out-of-band approval check.
+    pub fn verify_or_emergency(&self, old_pubkey: &str) -> Result<(), IdentityError> {
+        if self.reason == RotationReason::Emergency && self.signature.is_empty() {
+            return Ok(());
+        }
+        self.verify(old_pubkey)
+    }
+}
+
+/// Canonical JSON: sorted keys, no whitespace. Used so that signers and
+/// verifiers compute identical byte sequences regardless of language /
+/// serializer choices.
+fn canonical_json<T: serde::Serialize>(value: &T) -> Vec<u8> {
+    // serde_json with a BTreeMap-like ordering. The simplest approach: round-trip
+    // through a `serde_json::Value`, then walk it depth-first emitting bytes.
+    let v: serde_json::Value =
+        serde_json::to_value(value).expect("serialize should not fail for our types");
+    let mut out = Vec::new();
+    write_canonical(&mut out, &v);
+    out
+}
+
+fn write_canonical(out: &mut Vec<u8>, v: &serde_json::Value) {
+    use serde_json::Value;
+    match v {
+        Value::Null => out.extend_from_slice(b"null"),
+        Value::Bool(b) => out.extend_from_slice(if *b { b"true" } else { b"false" }),
+        Value::Number(n) => out.extend_from_slice(n.to_string().as_bytes()),
+        Value::String(s) => {
+            // serde_json::to_string handles escaping for us
+            let escaped = serde_json::to_string(s).unwrap();
+            out.extend_from_slice(escaped.as_bytes());
+        }
+        Value::Array(arr) => {
+            out.push(b'[');
+            for (i, item) in arr.iter().enumerate() {
+                if i > 0 {
+                    out.push(b',');
+                }
+                write_canonical(out, item);
+            }
+            out.push(b']');
+        }
+        Value::Object(map) => {
+            // Sort keys for deterministic output
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            out.push(b'{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(b',');
+                }
+                let kesc = serde_json::to_string(k).unwrap();
+                out.extend_from_slice(kesc.as_bytes());
+                out.push(b':');
+                write_canonical(out, &map[*k]);
+            }
+            out.push(b'}');
+        }
+    }
+}

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -33,5 +33,6 @@ pub use agent::{
     ScheduleEntry,
 };
 pub use identity::{
-    AgentIdentity, IdentityError, RotationAttestation, RotationReason, decode_pubkey, encode_pubkey,
+    AgentIdentity, ChainError, ChainOptions, ChainOutcome, IdentityError, RotationAttestation,
+    RotationReason, decode_pubkey, encode_pubkey, verify_chain,
 };

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -32,4 +32,6 @@ pub use agent::{
     FileTransferConfig, IdentityConfig, LockFile, Persona, PersonaCategory, RetryPolicy,
     ScheduleEntry,
 };
-pub use identity::{AgentIdentity, IdentityError, decode_pubkey, encode_pubkey};
+pub use identity::{
+    AgentIdentity, IdentityError, RotationAttestation, RotationReason, decode_pubkey, encode_pubkey,
+};

--- a/mur-common/tests/fixtures/profile_p0a6_rotated.yaml
+++ b/mur-common/tests/fixtures/profile_p0a6_rotated.yaml
@@ -1,0 +1,50 @@
+schema: 1
+id: 01JQX4TM8Y9K7VQH6B2N3R5DPE
+name: agent_test
+display_name: "Test"
+version: "0.1.0"
+persona:
+  category: research
+  description: "test"
+  traits: { tone: concise, risk: cautious, verbosity: low }
+sys_prompt_file: "sys_prompt.md"
+model:
+  provider: ollama
+  name: "llama3.2:3b"
+  params: { temperature: 0.2, max_tokens: 4096 }
+mcp_servers: []
+skills: []
+transport:
+  stdio: true
+  socket:
+    enabled: true
+    bind: "unix:///tmp/agent.sock"
+communication:
+  accepts_from: ["*"]
+  sends_to: []
+capabilities: []
+entitlements:
+  network:
+    inbound: { ports: [] }
+    outbound: { mode: restricted, allow_hosts: [], protocols: [tcp], resolve_dns: { mode: system } }
+  filesystem: { read: [], write: [], deny: [] }
+  processes: { spawn: { mode: allowlist, allowed: [] } }
+  syscalls: { mode: default }
+  limits: { memory_mb: 512, file_descriptors: 1024, processes: 32 }
+notifications: { on_task_complete: [], on_error: [], on_shutdown: [] }
+retry:
+  llm: { max_retries: 3, backoff: exponential, initial_delay_ms: 1000, max_delay_ms: 30000, retry_on: [rate_limit] }
+  tool: { max_retries: 1, backoff: fixed, initial_delay_ms: 500 }
+lifecycle: { restart: on_failure, max_restarts: 3, restart_window_secs: 600, stop_timeout_secs: 15, mcp_required: true }
+identity:
+  pubkey: zNEWKEY
+  owner: david@twdd.com.tw
+  algorithm: ed25519
+  key_version: 2
+  created_at_key: "2026-04-24T10:00:00+08:00"
+  previous_pubkey: zOLDKEY
+  previous_key_version: 1
+  grace_expires_at: "2026-05-24T10:00:00+08:00"
+  rotated_at: "2026-04-24T10:00:00+08:00"
+created_at: "2026-04-22T10:00:00+08:00"
+updated_at: "2026-04-22T10:00:00+08:00"

--- a/mur-common/tests/identity_chain.rs
+++ b/mur-common/tests/identity_chain.rs
@@ -1,0 +1,233 @@
+use mur_common::identity::{
+    AgentIdentity, ChainError, ChainOptions, RotationAttestation, RotationReason, verify_chain,
+};
+
+const TEST_UUID: &str = "01JQX4TM8Y9K7VQH6B2N3R5DPE";
+
+fn bootstrap(pubkey: &str) -> RotationAttestation {
+    RotationAttestation::new(
+        TEST_UUID,
+        "",
+        pubkey,
+        0,
+        0,
+        "2026-04-25T10:00:00+08:00",
+        RotationReason::Scheduled,
+    )
+    .into_bootstrap()
+}
+
+fn signed_step(
+    old: &AgentIdentity,
+    new: &AgentIdentity,
+    old_v: u32,
+    new_v: u32,
+    reason: RotationReason,
+) -> RotationAttestation {
+    let mut a = RotationAttestation::new(
+        TEST_UUID,
+        old.pubkey_text(),
+        new.pubkey_text(),
+        old_v,
+        new_v,
+        format!("2026-04-25T11:0{old_v}:00+08:00"),
+        reason,
+    );
+    a.sign(old.signing_key());
+    a
+}
+
+#[test]
+fn empty_chain_is_missing_bootstrap() {
+    let err = verify_chain(&[], ChainOptions::default()).unwrap_err();
+    assert!(matches!(err, ChainError::MissingBootstrap));
+}
+
+#[test]
+fn chain_without_bootstrap_first_rejected() {
+    let id = AgentIdentity::generate();
+    let id2 = AgentIdentity::generate();
+    let chain = vec![signed_step(&id, &id2, 0, 1, RotationReason::Scheduled)];
+    let err = verify_chain(&chain, ChainOptions::default()).unwrap_err();
+    assert!(matches!(err, ChainError::MissingBootstrap));
+}
+
+#[test]
+fn single_bootstrap_chain_ok() {
+    let id = AgentIdentity::generate();
+    let chain = vec![bootstrap(&id.pubkey_text())];
+    let out = verify_chain(&chain, ChainOptions::default()).expect("ok");
+    assert_eq!(out.head_key_version, 0);
+    assert_eq!(out.head_pubkey, id.pubkey_text());
+    assert_eq!(out.length, 1);
+}
+
+#[test]
+fn five_step_chain_ok() {
+    let mut chain = vec![];
+    let mut prev = AgentIdentity::generate();
+    chain.push(bootstrap(&prev.pubkey_text()));
+    for v in 1..=5 {
+        let next = AgentIdentity::generate();
+        chain.push(signed_step(
+            &prev,
+            &next,
+            v - 1,
+            v,
+            RotationReason::Scheduled,
+        ));
+        prev = next;
+    }
+    let out = verify_chain(&chain, ChainOptions::default()).expect("ok");
+    assert_eq!(out.head_key_version, 5);
+    assert_eq!(out.head_pubkey, prev.pubkey_text());
+    assert_eq!(out.length, 6);
+}
+
+#[test]
+fn version_skip_rejected() {
+    let mut chain = vec![];
+    let prev = AgentIdentity::generate();
+    let next = AgentIdentity::generate();
+    let next2 = AgentIdentity::generate();
+    chain.push(bootstrap(&prev.pubkey_text()));
+    chain.push(signed_step(&prev, &next, 0, 1, RotationReason::Scheduled));
+    // skip key_version=2 → jump to 3
+    chain.push(signed_step(&next, &next2, 1, 3, RotationReason::Scheduled));
+
+    let err = verify_chain(&chain, ChainOptions::default()).unwrap_err();
+    assert!(matches!(
+        err,
+        ChainError::VersionSkip {
+            expected: 2,
+            got: 3
+        }
+    ));
+}
+
+#[test]
+fn pubkey_discontinuity_rejected() {
+    let prev = AgentIdentity::generate();
+    let next = AgentIdentity::generate();
+    let other = AgentIdentity::generate();
+    let mut chain = vec![bootstrap(&prev.pubkey_text())];
+    // Tamper: next step's old_pubkey is `other`, not `prev`
+    let mut step = signed_step(&prev, &next, 0, 1, RotationReason::Scheduled);
+    step.old_pubkey = other.pubkey_text();
+    // re-sign with `other` so signature would technically validate against
+    // `other`, but the chain check sees the discontinuity FIRST.
+    step.sign(other.signing_key());
+    chain.push(step);
+    let err = verify_chain(&chain, ChainOptions::default()).unwrap_err();
+    assert!(matches!(
+        err,
+        ChainError::PubkeyDiscontinuity { at_version: 1 }
+    ));
+}
+
+#[test]
+fn duplicate_version_rejected() {
+    let prev = AgentIdentity::generate();
+    let next = AgentIdentity::generate();
+    let next2 = AgentIdentity::generate();
+    let mut chain = vec![bootstrap(&prev.pubkey_text())];
+    chain.push(signed_step(&prev, &next, 0, 1, RotationReason::Scheduled));
+    // Second step claims to be ALSO key_version=1
+    let mut dup = signed_step(&next, &next2, 1, 1, RotationReason::Scheduled);
+    dup.new_key_version = 1; // belt and suspenders
+    chain.push(dup);
+    let err = verify_chain(&chain, ChainOptions::default()).unwrap_err();
+    // Either duplicate or version skip is acceptable — both flag the issue.
+    assert!(
+        matches!(
+            err,
+            ChainError::DuplicateVersion(1) | ChainError::VersionSkip { .. }
+        ),
+        "expected DuplicateVersion or VersionSkip, got {err:?}"
+    );
+}
+
+#[test]
+fn bad_signature_rejected() {
+    let prev = AgentIdentity::generate();
+    let next = AgentIdentity::generate();
+    let mut chain = vec![bootstrap(&prev.pubkey_text())];
+    let mut step = signed_step(&prev, &next, 0, 1, RotationReason::Scheduled);
+    // Tamper after signing
+    step.new_pubkey = AgentIdentity::generate().pubkey_text();
+    chain.push(step);
+    let err = verify_chain(&chain, ChainOptions::default()).unwrap_err();
+    assert!(matches!(
+        err,
+        ChainError::BadSignature { at_version: 1, .. }
+    ));
+}
+
+#[test]
+fn emergency_in_chain_rejected_by_default() {
+    let prev = AgentIdentity::generate();
+    let next = AgentIdentity::generate();
+    let mut chain = vec![bootstrap(&prev.pubkey_text())];
+    let emerg = RotationAttestation::new(
+        TEST_UUID,
+        prev.pubkey_text(),
+        next.pubkey_text(),
+        0,
+        1,
+        "2026-04-25T11:00:00+08:00",
+        RotationReason::Emergency,
+    );
+    // No signature, no allow_emergency
+    chain.push(emerg);
+    let err = verify_chain(&chain, ChainOptions::default()).unwrap_err();
+    assert!(matches!(
+        err,
+        ChainError::EmergencyDisallowed { at_version: 1 }
+    ));
+}
+
+#[test]
+fn emergency_in_chain_allowed_with_opt_in() {
+    let prev = AgentIdentity::generate();
+    let next = AgentIdentity::generate();
+    let mut chain = vec![bootstrap(&prev.pubkey_text())];
+    let emerg = RotationAttestation::new(
+        TEST_UUID,
+        prev.pubkey_text(),
+        next.pubkey_text(),
+        0,
+        1,
+        "2026-04-25T11:00:00+08:00",
+        RotationReason::Emergency,
+    );
+    chain.push(emerg);
+    let out = verify_chain(
+        &chain,
+        ChainOptions {
+            allow_emergency: true,
+        },
+    )
+    .expect("emergency-allowed must pass");
+    assert_eq!(out.head_key_version, 1);
+}
+
+#[test]
+fn hundred_step_chain() {
+    let mut chain = vec![];
+    let mut prev = AgentIdentity::generate();
+    chain.push(bootstrap(&prev.pubkey_text()));
+    for v in 1..=100u32 {
+        let next = AgentIdentity::generate();
+        chain.push(signed_step(
+            &prev,
+            &next,
+            v - 1,
+            v,
+            RotationReason::Scheduled,
+        ));
+        prev = next;
+    }
+    let out = verify_chain(&chain, ChainOptions::default()).expect("100-step ok");
+    assert_eq!(out.head_key_version, 100);
+    assert_eq!(out.length, 101);
+}

--- a/mur-common/tests/profile_schema.rs
+++ b/mur-common/tests/profile_schema.rs
@@ -84,3 +84,46 @@ fn deployment_defaults_to_laptop() {
     );
     assert_eq!(p.deployment.environment.as_deref(), Some("dev"));
 }
+
+#[test]
+fn identity_rekey_fields_default_when_absent() {
+    // Legacy P0a.5 profile (no rekey fields) should still deserialize
+    let yaml = include_str!("fixtures/profile_p0a5_with_identity.yaml");
+    let p: AgentProfile = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(p.identity.algorithm, "ed25519");
+    assert_eq!(p.identity.key_version, 0);
+    assert!(p.identity.previous_pubkey.is_none());
+    assert!(p.identity.grace_expires_at.is_none());
+    assert!(p.identity.rotated_at.is_none());
+    assert!(p.identity.emergency_rekey_at.is_none());
+}
+
+#[test]
+fn identity_rekey_fields_roundtrip() {
+    let yaml = include_str!("fixtures/profile_p0a6_rotated.yaml");
+    let p: AgentProfile = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(p.identity.pubkey, "zNEWKEY");
+    assert_eq!(p.identity.algorithm, "ed25519");
+    assert_eq!(p.identity.key_version, 2);
+    assert_eq!(p.identity.previous_pubkey.as_deref(), Some("zOLDKEY"));
+    assert_eq!(p.identity.previous_key_version, Some(1));
+    assert!(p.identity.grace_expires_at.is_some());
+    assert!(p.identity.rotated_at.is_some());
+    assert!(p.identity.created_at_key.is_some());
+
+    // Roundtrip
+    let emitted = serde_yaml_ng::to_string(&p).unwrap();
+    let p2: AgentProfile = serde_yaml_ng::from_str(&emitted).unwrap();
+    assert_eq!(p, p2);
+}
+
+#[test]
+fn identity_default_sets_algorithm_ed25519() {
+    use mur_common::agent::IdentityConfig;
+    let d = IdentityConfig::default();
+    assert_eq!(d.algorithm, "ed25519");
+    assert_eq!(d.key_version, 0);
+    assert!(d.pubkey.is_empty());
+    assert!(d.owner.is_none());
+    assert!(d.previous_pubkey.is_none());
+}

--- a/mur-common/tests/rotation_attestation.rs
+++ b/mur-common/tests/rotation_attestation.rs
@@ -1,0 +1,194 @@
+use mur_common::identity::{AgentIdentity, IdentityError, RotationAttestation, RotationReason};
+
+fn att(
+    old_v: u32,
+    new_v: u32,
+    reason: RotationReason,
+    old_pub: &str,
+    new_pub: &str,
+) -> RotationAttestation {
+    RotationAttestation::new(
+        "01JQX4TM8Y9K7VQH6B2N3R5DPE",
+        old_pub,
+        new_pub,
+        old_v,
+        new_v,
+        "2026-04-25T10:00:00+08:00",
+        reason,
+    )
+}
+
+#[test]
+fn sign_then_verify_roundtrip() {
+    let old = AgentIdentity::generate();
+    let new = AgentIdentity::generate();
+    let mut a = att(
+        1,
+        2,
+        RotationReason::Scheduled,
+        &old.pubkey_text(),
+        &new.pubkey_text(),
+    );
+    a.sign(old.signing_key());
+    a.verify(&old.pubkey_text()).expect("must verify");
+    assert!(
+        a.signature.starts_with('z'),
+        "signature should be multibase"
+    );
+}
+
+#[test]
+fn tampered_new_pubkey_fails_verify() {
+    let old = AgentIdentity::generate();
+    let new = AgentIdentity::generate();
+    let mut a = att(
+        1,
+        2,
+        RotationReason::Scheduled,
+        &old.pubkey_text(),
+        &new.pubkey_text(),
+    );
+    a.sign(old.signing_key());
+    a.new_pubkey = AgentIdentity::generate().pubkey_text();
+    let err = a.verify(&old.pubkey_text()).unwrap_err();
+    assert!(matches!(err, IdentityError::InvalidKey(_)));
+}
+
+#[test]
+fn wrong_old_pubkey_fails_verify() {
+    let old = AgentIdentity::generate();
+    let other = AgentIdentity::generate();
+    let new = AgentIdentity::generate();
+    let mut a = att(
+        1,
+        2,
+        RotationReason::Scheduled,
+        &old.pubkey_text(),
+        &new.pubkey_text(),
+    );
+    a.sign(old.signing_key());
+    let err = a.verify(&other.pubkey_text()).unwrap_err();
+    assert!(matches!(err, IdentityError::InvalidKey(_)));
+}
+
+#[test]
+fn empty_signature_rejected_by_strict_verify() {
+    let old = AgentIdentity::generate();
+    let new = AgentIdentity::generate();
+    let a = att(
+        1,
+        2,
+        RotationReason::Scheduled,
+        &old.pubkey_text(),
+        &new.pubkey_text(),
+    );
+    let err = a.verify(&old.pubkey_text()).unwrap_err();
+    assert!(matches!(err, IdentityError::InvalidKey(_)));
+}
+
+#[test]
+fn emergency_with_empty_signature_passes_lenient_verify() {
+    let old = AgentIdentity::generate();
+    let new = AgentIdentity::generate();
+    let a = att(
+        1,
+        2,
+        RotationReason::Emergency,
+        &old.pubkey_text(),
+        &new.pubkey_text(),
+    );
+    a.verify_or_emergency(&old.pubkey_text())
+        .expect("emergency must pass lenient");
+}
+
+#[test]
+fn emergency_with_signature_still_strictly_verifies() {
+    let old = AgentIdentity::generate();
+    let new = AgentIdentity::generate();
+    let mut a = att(
+        1,
+        2,
+        RotationReason::Emergency,
+        &old.pubkey_text(),
+        &new.pubkey_text(),
+    );
+    a.sign(old.signing_key());
+    a.verify_or_emergency(&old.pubkey_text())
+        .expect("signed emergency must verify");
+    a.verify(&old.pubkey_text())
+        .expect("signed emergency must verify under strict path too");
+}
+
+#[test]
+fn bootstrap_entry_skips_verification() {
+    let new = AgentIdentity::generate();
+    let mut a = att(0, 0, RotationReason::Scheduled, "", &new.pubkey_text());
+    a = a.into_bootstrap();
+    a.verify("anything-bogus")
+        .expect("bootstrap accepts any pubkey");
+    a.verify("").expect("bootstrap accepts empty pubkey");
+}
+
+#[test]
+fn canonical_bytes_excludes_signature_field() {
+    let old = AgentIdentity::generate();
+    let new = AgentIdentity::generate();
+    let mut a = att(
+        1,
+        2,
+        RotationReason::Scheduled,
+        &old.pubkey_text(),
+        &new.pubkey_text(),
+    );
+    let before = a.canonical_bytes();
+    a.signature = "zSPOOF".into();
+    let after = a.canonical_bytes();
+    assert_eq!(
+        before, after,
+        "signature field must not appear in canonical bytes"
+    );
+}
+
+#[test]
+fn canonical_bytes_keys_are_sorted() {
+    let old = AgentIdentity::generate();
+    let new = AgentIdentity::generate();
+    let a = att(
+        1,
+        2,
+        RotationReason::Scheduled,
+        &old.pubkey_text(),
+        &new.pubkey_text(),
+    );
+    let bytes = a.canonical_bytes();
+    let s = std::str::from_utf8(&bytes).unwrap();
+    // First two keys alphabetically: "algorithm" before "new_key_version" before "new_pubkey"...
+    let alg_idx = s.find("\"algorithm\"").unwrap();
+    let uuid_idx = s.find("\"uuid\"").unwrap();
+    let new_pub_idx = s.find("\"new_pubkey\"").unwrap();
+    assert!(
+        alg_idx < new_pub_idx,
+        "algorithm must precede new_pubkey alphabetically"
+    );
+    assert!(
+        new_pub_idx < uuid_idx,
+        "new_pubkey must precede uuid alphabetically"
+    );
+}
+
+#[test]
+fn serde_roundtrip() {
+    let old = AgentIdentity::generate();
+    let new = AgentIdentity::generate();
+    let mut a = att(
+        3,
+        4,
+        RotationReason::OwnerChange,
+        &old.pubkey_text(),
+        &new.pubkey_text(),
+    );
+    a.sign(old.signing_key());
+    let json = serde_json::to_string(&a).unwrap();
+    let back: RotationAttestation = serde_json::from_str(&json).unwrap();
+    assert_eq!(a, back);
+}

--- a/mur-core/src/cmd/agent.rs
+++ b/mur-core/src/cmd/agent.rs
@@ -110,6 +110,7 @@ pub fn cmd_create(
         identity: IdentityConfig {
             pubkey: identity.pubkey_text(),
             owner: std::env::var("USER").ok(),
+            ..Default::default()
         },
         file_transfer: FileTransferConfig::default(),
         deployment: DeploymentConfig::default(),

--- a/mur-core/src/cmd/agent.rs
+++ b/mur-core/src/cmd/agent.rs
@@ -43,6 +43,27 @@ pub fn cmd_create(
     let now = chrono::Utc::now().to_rfc3339();
     let id = uuid::Uuid::now_v7().to_string();
 
+    // M1.3: Bootstrap rotation attestation — anchors the rotation chain
+    // so future `mur agent rekey` calls have a verifiable starting point.
+    use mur_common::identity::{RotationAttestation, RotationReason};
+    let bootstrap_at = now.clone();
+    let bootstrap = RotationAttestation::new(
+        &id,
+        "",
+        identity.pubkey_text(),
+        0,
+        0,
+        &bootstrap_at,
+        RotationReason::Scheduled,
+    )
+    .into_bootstrap();
+    let bootstrap_line =
+        serde_json::to_string(&bootstrap).context("serialize bootstrap attestation")?;
+    let rotations_path = agent_home.join("rotations.jsonl");
+    fs::write(&rotations_path, format!("{bootstrap_line}\n"))
+        .with_context(|| format!("write {}", rotations_path.display()))?;
+    tracing::debug!(uuid = %id, "bootstrap rotation attestation written");
+
     let profile = AgentProfile {
         schema: 1,
         id,
@@ -110,6 +131,7 @@ pub fn cmd_create(
         identity: IdentityConfig {
             pubkey: identity.pubkey_text(),
             owner: std::env::var("USER").ok(),
+            created_at_key: Some(bootstrap_at.clone()),
             ..Default::default()
         },
         file_transfer: FileTransferConfig::default(),

--- a/mur-core/src/cmd/agent_rekey.rs
+++ b/mur-core/src/cmd/agent_rekey.rs
@@ -43,13 +43,15 @@ impl RekeyReason {
 }
 
 pub fn cmd_rekey(name: &str, reason: &str, yes: bool, emergency: bool) -> Result<()> {
-    if emergency {
-        bail!("--emergency lands in M4 — not yet supported");
-    }
-    let parsed_reason = RekeyReason::parse(reason)?;
-    if matches!(parsed_reason, RekeyReason::Emergency) {
-        bail!("--reason emergency requires --emergency flag (M4)");
-    }
+    let parsed_reason = if emergency {
+        RekeyReason::Emergency
+    } else {
+        let r = RekeyReason::parse(reason)?;
+        if matches!(r, RekeyReason::Emergency) {
+            bail!("--reason emergency requires --emergency flag");
+        }
+        r
+    };
 
     let mur_home = resolve_mur_home()?;
     let agent_dir = mur_home.join("agents").join(name);
@@ -57,21 +59,57 @@ pub fn cmd_rekey(name: &str, reason: &str, yes: bool, emergency: bool) -> Result
         bail!("agent '{name}' not found at {}", agent_dir.display());
     }
 
-    // Load current profile + identity
+    // Load current profile
     let profile_path = agent_dir.join("profile.yaml");
     let profile_yaml = fs::read_to_string(&profile_path)
         .with_context(|| format!("read {}", profile_path.display()))?;
     let mut profile: AgentProfile =
         serde_yaml_ng::from_str(&profile_yaml).context("parse profile.yaml")?;
-    let old_identity = AgentIdentity::load(&agent_dir)
-        .with_context(|| format!("load identity from {}", agent_dir.display()))?;
 
-    let old_pubkey = old_identity.pubkey_text();
+    // Load OLD identity for normal rekey; emergency may have lost it.
+    let old_identity_opt = if emergency {
+        AgentIdentity::load(&agent_dir).ok()
+    } else {
+        Some(
+            AgentIdentity::load(&agent_dir)
+                .with_context(|| format!("load identity from {}", agent_dir.display()))?,
+        )
+    };
+
+    let old_pubkey = old_identity_opt
+        .as_ref()
+        .map(|id| id.pubkey_text())
+        .unwrap_or_else(|| profile.identity.pubkey.clone());
     let old_key_version = profile.identity.key_version;
     let new_key_version = old_key_version + 1;
 
     // Interactive confirm
-    if !yes {
+    if emergency && !yes {
+        eprintln!();
+        eprintln!("\x1b[1;31m=== EMERGENCY REKEY — read carefully ===\x1b[0m");
+        eprintln!();
+        eprintln!("This rotation will be UNSIGNED. Other commanders / peers will");
+        eprintln!("REFUSE to trust the new key until an admin runs:");
+        eprintln!("    \x1b[1mmurc agent approve-rekey {}\x1b[0m", profile.id);
+        eprintln!("on the commander host.");
+        eprintln!();
+        eprintln!("Active Noise sessions to this agent will fail until that");
+        eprintln!("approval lands.");
+        eprintln!();
+        eprintln!("  agent name:        {name}");
+        eprintln!("  agent UUID:        {}", profile.id);
+        eprintln!("  current pubkey:    {old_pubkey}");
+        eprintln!("  key_version:       {old_key_version} -> {new_key_version}");
+        eprintln!();
+        eprint!("Type \x1b[1mI UNDERSTAND\x1b[0m to proceed: ");
+        std::io::stderr().flush().ok();
+        let mut buf = String::new();
+        std::io::stdin().read_line(&mut buf).ok();
+        if buf.trim() != "I UNDERSTAND" {
+            eprintln!("aborted (confirmation phrase not matched)");
+            return Ok(());
+        }
+    } else if !yes {
         eprintln!("About to rotate identity for agent '{name}':");
         eprintln!("  current key_version: {old_key_version}");
         eprintln!("  current pubkey:      {old_pubkey}");
@@ -92,7 +130,9 @@ pub fn cmd_rekey(name: &str, reason: &str, yes: bool, emergency: bool) -> Result
     let new_identity = AgentIdentity::generate();
     let new_pubkey = new_identity.pubkey_text();
 
-    // Build + sign attestation
+    // Build attestation. Normal rotations sign with the OLD key; emergency
+    // rotations leave signature empty and are gated by commander-side
+    // out-of-band approval.
     let now = chrono::Utc::now();
     let now_rfc = now.to_rfc3339();
     let mut attestation = RotationAttestation::new(
@@ -104,7 +144,12 @@ pub fn cmd_rekey(name: &str, reason: &str, yes: bool, emergency: bool) -> Result
         &now_rfc,
         parsed_reason.into_attestation(),
     );
-    attestation.sign(old_identity.signing_key());
+    if !emergency {
+        let old_id = old_identity_opt
+            .as_ref()
+            .expect("normal rekey requires old key");
+        attestation.sign(old_id.signing_key());
+    }
 
     // Atomic on-disk rotation
     rotate_files_atomic(&agent_dir, &new_identity, &attestation)?;
@@ -116,8 +161,11 @@ pub fn cmd_rekey(name: &str, reason: &str, yes: bool, emergency: bool) -> Result
     profile.identity.pubkey = new_pubkey.clone();
     profile.identity.key_version = new_key_version;
     profile.identity.created_at_key = Some(now_rfc.clone());
-    profile.identity.rotated_at = Some(now_rfc);
+    profile.identity.rotated_at = Some(now_rfc.clone());
     profile.identity.grace_expires_at = Some(grace_expires.to_rfc3339());
+    if emergency {
+        profile.identity.emergency_rekey_at = Some(now_rfc);
+    }
     profile.updated_at = chrono::Utc::now().to_rfc3339();
 
     let new_yaml = serde_yaml_ng::to_string(&profile).context("serialize updated profile.yaml")?;
@@ -130,10 +178,23 @@ pub fn cmd_rekey(name: &str, reason: &str, yes: bool, emergency: bool) -> Result
         std::thread::sleep(Duration::from_millis(500));
     }
 
-    println!("rekey ok: {name} key_version {old_key_version} -> {new_key_version}");
-    println!("  pubkey:              {new_pubkey}");
-    println!("  previous (in grace): {old_pubkey}");
-    println!("  grace expires:       {}", grace_expires.to_rfc3339());
+    if emergency {
+        println!(
+            "emergency rekey written: {name} key_version {old_key_version} -> {new_key_version}"
+        );
+        println!("  pubkey:              {new_pubkey}");
+        println!("  previous (in grace): {old_pubkey}");
+        println!();
+        println!(
+            "\x1b[1;33mPENDING APPROVAL\x1b[0m — peers will refuse trust until commander admin runs:"
+        );
+        println!("  murc agent approve-rekey {}", profile.id);
+    } else {
+        println!("rekey ok: {name} key_version {old_key_version} -> {new_key_version}");
+        println!("  pubkey:              {new_pubkey}");
+        println!("  previous (in grace): {old_pubkey}");
+        println!("  grace expires:       {}", grace_expires.to_rfc3339());
+    }
     Ok(())
 }
 

--- a/mur-core/src/cmd/agent_rekey.rs
+++ b/mur-core/src/cmd/agent_rekey.rs
@@ -299,3 +299,95 @@ fn send_sigterm(_pid: u32) {
     // Windows: SIGTERM not available — runtime doesn't auto-restart on
     // Windows in P0a anyway. The user must restart manually.
 }
+
+/// `mur agent rekey-status <name>` — show current/previous keys, grace
+/// remaining, and the chain history length.
+pub fn cmd_rekey_status(name: &str, json_out: bool) -> Result<()> {
+    let mur_home = resolve_mur_home()?;
+    let agent_dir = mur_home.join("agents").join(name);
+    if !agent_dir.exists() {
+        bail!("agent '{name}' not found at {}", agent_dir.display());
+    }
+
+    let profile_path = agent_dir.join("profile.yaml");
+    let profile_yaml = fs::read_to_string(&profile_path)
+        .with_context(|| format!("read {}", profile_path.display()))?;
+    let profile: AgentProfile =
+        serde_yaml_ng::from_str(&profile_yaml).context("parse profile.yaml")?;
+
+    let rotations_path = agent_dir.join("rotations.jsonl");
+    let rotation_count = if rotations_path.exists() {
+        fs::read_to_string(&rotations_path)?
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .count()
+    } else {
+        0
+    };
+
+    let now = chrono::Utc::now();
+    let grace_remaining_days = profile
+        .identity
+        .grace_expires_at
+        .as_deref()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|exp| (exp.with_timezone(&chrono::Utc) - now).num_days());
+
+    if json_out {
+        let out = serde_json::json!({
+            "name": name,
+            "uuid": profile.id,
+            "algorithm": profile.identity.algorithm,
+            "key_version": profile.identity.key_version,
+            "pubkey": profile.identity.pubkey,
+            "previous_pubkey": profile.identity.previous_pubkey,
+            "previous_key_version": profile.identity.previous_key_version,
+            "grace_expires_at": profile.identity.grace_expires_at,
+            "grace_remaining_days": grace_remaining_days,
+            "created_at_key": profile.identity.created_at_key,
+            "rotated_at": profile.identity.rotated_at,
+            "emergency_rekey_at": profile.identity.emergency_rekey_at,
+            "rotation_log_lines": rotation_count,
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else {
+        println!("agent: {name}");
+        println!("  uuid:               {}", profile.id);
+        println!("  algorithm:          {}", profile.identity.algorithm);
+        println!("  key_version:        {}", profile.identity.key_version);
+        println!("  pubkey:             {}", profile.identity.pubkey);
+        if let Some(t) = &profile.identity.created_at_key {
+            println!("  created_at_key:     {t}");
+        }
+        if let Some(prev) = &profile.identity.previous_pubkey {
+            println!("  previous_pubkey:    {prev}");
+            if let Some(v) = profile.identity.previous_key_version {
+                println!("  previous_key_ver:   {v}");
+            }
+        } else {
+            println!("  previous_pubkey:    <none in grace>");
+        }
+        if let Some(g) = &profile.identity.grace_expires_at {
+            print!("  grace_expires_at:   {g}");
+            if let Some(d) = grace_remaining_days {
+                if d >= 0 {
+                    println!(" ({d} days remaining)");
+                } else {
+                    println!(" (expired {} days ago)", -d);
+                }
+            } else {
+                println!();
+            }
+        }
+        if let Some(t) = &profile.identity.rotated_at {
+            println!("  last_rotation_at:   {t}");
+        }
+        if let Some(t) = &profile.identity.emergency_rekey_at {
+            println!("  EMERGENCY rekey at: {t}");
+            println!("  → peers will refuse trust until commander admin runs:");
+            println!("      murc agent approve-rekey {}", profile.id);
+        }
+        println!("  rotation log lines: {rotation_count}");
+    }
+    Ok(())
+}

--- a/mur-core/src/cmd/agent_rekey.rs
+++ b/mur-core/src/cmd/agent_rekey.rs
@@ -1,0 +1,240 @@
+//! `mur agent rekey` — rotate an agent's Ed25519 identity keypair.
+//!
+//! See spec: docs/superpowers/specs/2026-04-24-murmur-agent-rekey-design.md
+
+use anyhow::{Context, Result, anyhow, bail};
+use mur_common::agent::AgentProfile;
+use mur_common::identity::{AgentIdentity, RotationAttestation, RotationReason};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const GRACE_DAYS_DEFAULT: i64 = 30;
+
+#[derive(Debug, Clone, Copy)]
+pub enum RekeyReason {
+    Scheduled,
+    SuspectCompromise,
+    OwnerChange,
+    Emergency,
+}
+
+impl RekeyReason {
+    fn parse(s: &str) -> Result<Self> {
+        match s {
+            "scheduled" => Ok(Self::Scheduled),
+            "suspect-compromise" => Ok(Self::SuspectCompromise),
+            "owner-change" => Ok(Self::OwnerChange),
+            "emergency" => Ok(Self::Emergency),
+            other => bail!(
+                "unknown reason '{other}' (allowed: scheduled, suspect-compromise, owner-change, emergency)"
+            ),
+        }
+    }
+    fn into_attestation(self) -> RotationReason {
+        match self {
+            Self::Scheduled => RotationReason::Scheduled,
+            Self::SuspectCompromise => RotationReason::SuspectCompromise,
+            Self::OwnerChange => RotationReason::OwnerChange,
+            Self::Emergency => RotationReason::Emergency,
+        }
+    }
+}
+
+pub fn cmd_rekey(name: &str, reason: &str, yes: bool, emergency: bool) -> Result<()> {
+    if emergency {
+        bail!("--emergency lands in M4 — not yet supported");
+    }
+    let parsed_reason = RekeyReason::parse(reason)?;
+    if matches!(parsed_reason, RekeyReason::Emergency) {
+        bail!("--reason emergency requires --emergency flag (M4)");
+    }
+
+    let mur_home = resolve_mur_home()?;
+    let agent_dir = mur_home.join("agents").join(name);
+    if !agent_dir.exists() {
+        bail!("agent '{name}' not found at {}", agent_dir.display());
+    }
+
+    // Load current profile + identity
+    let profile_path = agent_dir.join("profile.yaml");
+    let profile_yaml = fs::read_to_string(&profile_path)
+        .with_context(|| format!("read {}", profile_path.display()))?;
+    let mut profile: AgentProfile =
+        serde_yaml_ng::from_str(&profile_yaml).context("parse profile.yaml")?;
+    let old_identity = AgentIdentity::load(&agent_dir)
+        .with_context(|| format!("load identity from {}", agent_dir.display()))?;
+
+    let old_pubkey = old_identity.pubkey_text();
+    let old_key_version = profile.identity.key_version;
+    let new_key_version = old_key_version + 1;
+
+    // Interactive confirm
+    if !yes {
+        eprintln!("About to rotate identity for agent '{name}':");
+        eprintln!("  current key_version: {old_key_version}");
+        eprintln!("  current pubkey:      {old_pubkey}");
+        eprintln!("  reason:              {reason}");
+        eprintln!("  grace period:        {GRACE_DAYS_DEFAULT} days");
+        eprintln!("  next key_version:    {new_key_version}");
+        eprint!("\nProceed? [y/N] ");
+        std::io::stderr().flush().ok();
+        let mut buf = String::new();
+        std::io::stdin().read_line(&mut buf).ok();
+        if !buf.trim().eq_ignore_ascii_case("y") {
+            eprintln!("aborted");
+            return Ok(());
+        }
+    }
+
+    // Generate new identity (in memory)
+    let new_identity = AgentIdentity::generate();
+    let new_pubkey = new_identity.pubkey_text();
+
+    // Build + sign attestation
+    let now = chrono::Utc::now();
+    let now_rfc = now.to_rfc3339();
+    let mut attestation = RotationAttestation::new(
+        &profile.id,
+        &old_pubkey,
+        &new_pubkey,
+        old_key_version,
+        new_key_version,
+        &now_rfc,
+        parsed_reason.into_attestation(),
+    );
+    attestation.sign(old_identity.signing_key());
+
+    // Atomic on-disk rotation
+    rotate_files_atomic(&agent_dir, &new_identity, &attestation)?;
+
+    // Update profile
+    let grace_expires = now + chrono::Duration::days(GRACE_DAYS_DEFAULT);
+    profile.identity.previous_pubkey = Some(old_pubkey.clone());
+    profile.identity.previous_key_version = Some(old_key_version);
+    profile.identity.pubkey = new_pubkey.clone();
+    profile.identity.key_version = new_key_version;
+    profile.identity.created_at_key = Some(now_rfc.clone());
+    profile.identity.rotated_at = Some(now_rfc);
+    profile.identity.grace_expires_at = Some(grace_expires.to_rfc3339());
+    profile.updated_at = chrono::Utc::now().to_rfc3339();
+
+    let new_yaml = serde_yaml_ng::to_string(&profile).context("serialize updated profile.yaml")?;
+    write_atomic(&profile_path, new_yaml.as_bytes())?;
+
+    // SIGTERM the running runtime if any
+    if let Some(pid) = read_running_pid(&agent_dir) {
+        send_sigterm(pid);
+        // brief wait — supervisor symlink will restart
+        std::thread::sleep(Duration::from_millis(500));
+    }
+
+    println!("rekey ok: {name} key_version {old_key_version} -> {new_key_version}");
+    println!("  pubkey:              {new_pubkey}");
+    println!("  previous (in grace): {old_pubkey}");
+    println!("  grace expires:       {}", grace_expires.to_rfc3339());
+    Ok(())
+}
+
+/// Atomic rotation: write everything new with `.new` suffix first, then
+/// rename in a crash-safe order so a partial state is always recoverable.
+fn rotate_files_atomic(
+    agent_dir: &Path,
+    new_identity: &AgentIdentity,
+    attestation: &RotationAttestation,
+) -> Result<()> {
+    let key_path = agent_dir.join("identity.key");
+    let pub_path = agent_dir.join("identity.pub");
+    let key_prev = agent_dir.join("identity.key.prev");
+    let pub_prev = agent_dir.join("identity.pub.prev");
+    let att_path = agent_dir.join("identity.attestation.json");
+    let att_new = agent_dir.join("identity.attestation.new.json");
+    let rotations = agent_dir.join("rotations.jsonl");
+
+    // 1. Write new keypair into a SCRATCH dir so the canonical paths stay
+    //    untouched until rename time. We use a sibling subdir so renames
+    //    cross no filesystem boundaries.
+    let scratch = agent_dir.join(".rekey-scratch");
+    if scratch.exists() {
+        fs::remove_dir_all(&scratch).ok();
+    }
+    new_identity
+        .save(&scratch)
+        .context("save new identity to scratch")?;
+
+    // 2. Write attestation alongside as `.new` for crash safety.
+    let att_json = serde_json::to_string(attestation).context("serialize attestation")?;
+    write_atomic(&att_new, att_json.as_bytes())?;
+
+    // 3. Move OLD key files to .prev (overwriting any stale .prev from a
+    //    previous interrupted rotation).
+    if key_prev.exists() {
+        fs::remove_file(&key_prev).ok();
+    }
+    if pub_prev.exists() {
+        fs::remove_file(&pub_prev).ok();
+    }
+    if key_path.exists() {
+        fs::rename(&key_path, &key_prev)?;
+    }
+    if pub_path.exists() {
+        fs::rename(&pub_path, &pub_prev)?;
+    }
+
+    // 4. Move new key files from scratch into canonical paths.
+    fs::rename(scratch.join("identity.key"), &key_path)?;
+    fs::rename(scratch.join("identity.pub"), &pub_path)?;
+    fs::remove_dir_all(&scratch).ok();
+
+    // 5. Promote .new attestation to canonical path.
+    fs::rename(&att_new, &att_path)?;
+
+    // 6. Append attestation to rotations.jsonl (append-only; no rename
+    //    needed since we never rewrite the file).
+    let mut f = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&rotations)
+        .with_context(|| format!("open {}", rotations.display()))?;
+    writeln!(f, "{att_json}")?;
+
+    Ok(())
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes).with_context(|| format!("write {}", tmp.display()))?;
+    fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+fn resolve_mur_home() -> Result<PathBuf> {
+    if let Some(v) = std::env::var_os("MUR_HOME") {
+        return Ok(PathBuf::from(v));
+    }
+    Ok(dirs::home_dir()
+        .ok_or_else(|| anyhow!("no home dir"))?
+        .join(".mur"))
+}
+
+fn read_running_pid(agent_dir: &Path) -> Option<u32> {
+    let lock = agent_dir.join("running.lock");
+    let bytes = fs::read(&lock).ok()?;
+    let v: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    v.get("pid").and_then(|p| p.as_u64()).map(|p| p as u32)
+}
+
+#[cfg(unix)]
+fn send_sigterm(pid: u32) {
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGTERM);
+    }
+}
+
+#[cfg(not(unix))]
+fn send_sigterm(_pid: u32) {
+    // Windows: SIGTERM not available — runtime doesn't auto-restart on
+    // Windows in P0a anyway. The user must restart manually.
+}

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod agent;
+pub(crate) mod agent_rekey;
 pub(crate) mod community_cmd;
 pub(crate) mod context;
 pub(crate) mod conversations_cmd;

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -901,9 +901,18 @@ enum AgentAction {
         /// Skip the interactive confirmation prompt
         #[arg(long)]
         yes: bool,
-        /// EMERGENCY rotation (no old key required). M4 — currently errors.
+        /// EMERGENCY rotation (old key not required). Writes an UNSIGNED
+        /// attestation; peers refuse trust until commander admin approves.
         #[arg(long)]
         emergency: bool,
+    },
+    /// Show identity rotation status for an agent (P0a.6).
+    RekeyStatus {
+        /// Agent name
+        name: String,
+        /// Emit JSON instead of a human-readable table
+        #[arg(long)]
+        json: bool,
     },
     /// Generate and (optionally) install a launchd/systemd user service
     InstallService {
@@ -1383,6 +1392,9 @@ async fn async_main() -> Result<()> {
                 yes,
                 emergency,
             } => cmd::agent_rekey::cmd_rekey(&name, &reason, yes, emergency)?,
+            AgentAction::RekeyStatus { name, json } => {
+                cmd::agent_rekey::cmd_rekey_status(&name, json)?
+            }
             AgentAction::InstallService { name, dry_run } => {
                 cmd::agent::cmd_install_service(&name, dry_run)?
             }

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -891,6 +891,20 @@ enum AgentAction {
         /// Agent name
         name: String,
     },
+    /// Rotate an agent's Ed25519 identity keypair (P0a.6).
+    Rekey {
+        /// Agent name
+        name: String,
+        /// Why this rotation is happening (audit hint)
+        #[arg(long, default_value = "scheduled")]
+        reason: String,
+        /// Skip the interactive confirmation prompt
+        #[arg(long)]
+        yes: bool,
+        /// EMERGENCY rotation (no old key required). M4 — currently errors.
+        #[arg(long)]
+        emergency: bool,
+    },
     /// Generate and (optionally) install a launchd/systemd user service
     InstallService {
         /// Agent name
@@ -1363,6 +1377,12 @@ async fn async_main() -> Result<()> {
             AgentAction::Rename { old, new } => cmd::agent::cmd_rename(&old, &new)?,
             AgentAction::Send { name, message } => cmd::agent::cmd_send(&name, &message)?,
             AgentAction::Card { name } => cmd::agent::cmd_card(&name)?,
+            AgentAction::Rekey {
+                name,
+                reason,
+                yes,
+                emergency,
+            } => cmd::agent_rekey::cmd_rekey(&name, &reason, yes, emergency)?,
             AgentAction::InstallService { name, dry_run } => {
                 cmd::agent::cmd_install_service(&name, dry_run)?
             }

--- a/mur-core/tests/agent_card_ephemeral.rs
+++ b/mur-core/tests/agent_card_ephemeral.rs
@@ -115,7 +115,8 @@ fn card_displays_identity_pubkey() {
     let v: serde_json::Value = serde_json::from_str(body.trim()).expect("card stdout must be JSON");
 
     // Verify pubkey field exists and is non-empty
-    let pubkey = v.get("pubkey")
+    let pubkey = v
+        .get("pubkey")
         .expect("card must include 'pubkey' field")
         .as_str()
         .expect("pubkey must be a string");

--- a/mur-core/tests/agent_create_identity.rs
+++ b/mur-core/tests/agent_create_identity.rs
@@ -47,4 +47,48 @@ fn agent_create_generates_identity_and_writes_into_profile() {
         yaml.contains("pubkey: z"),
         "profile missing z-prefixed pubkey: {yaml}"
     );
+
+    // M1.3: bootstrap rotation attestation
+    let rotations_path = agent_dir.join("rotations.jsonl");
+    assert!(
+        rotations_path.exists(),
+        "rotations.jsonl missing after agent create"
+    );
+    let content = std::fs::read_to_string(&rotations_path).unwrap();
+    let lines: Vec<&str> = content.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "expected exactly one bootstrap line, got {}",
+        lines.len()
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(lines[0]).expect("bootstrap line must be valid JSON");
+    assert_eq!(v["bootstrap"], true);
+    assert_eq!(v["old_key_version"], 0);
+    assert_eq!(v["new_key_version"], 0);
+    assert_eq!(v["algorithm"], "ed25519");
+    assert_eq!(v["old_pubkey"], "");
+    assert!(v["new_pubkey"].as_str().unwrap().starts_with('z'));
+    assert!(
+        v.get("signature")
+            .map(|s| s.as_str().unwrap_or("").is_empty())
+            .unwrap_or(true),
+        "bootstrap line must have empty/missing signature"
+    );
+
+    // M1.3: profile.yaml carries created_at_key + algorithm + key_version=0
+    assert!(
+        yaml.contains("algorithm: ed25519"),
+        "profile must declare algorithm"
+    );
+    assert!(
+        yaml.contains("created_at_key:"),
+        "profile must record created_at_key"
+    );
+    // key_version is 0 — serde may emit `key_version: 0` literally
+    assert!(
+        yaml.contains("key_version: 0"),
+        "profile must declare key_version 0"
+    );
 }

--- a/mur-core/tests/agent_rekey_cli.rs
+++ b/mur-core/tests/agent_rekey_cli.rs
@@ -143,9 +143,10 @@ fn rekey_with_suspect_compromise_reason_records_in_jsonl() {
 }
 
 #[test]
-fn rekey_emergency_flag_errors_in_m1() {
+fn rekey_emergency_writes_unsigned_attestation() {
     let home = TempDir::new().unwrap();
     create_agent(home.path(), "rekey_emerg");
+    let agent_dir = home.path().join("agents/rekey_emerg");
 
     let out = Command::new(mur_bin())
         .env("MUR_HOME", home.path())
@@ -154,7 +155,67 @@ fn rekey_emergency_flag_errors_in_m1() {
         .args(["agent", "rekey", "rekey_emerg", "--emergency", "--yes"])
         .output()
         .unwrap();
-    assert!(!out.status.success(), "emergency must fail in M1");
+    assert!(
+        out.status.success(),
+        "emergency rekey must succeed with --yes: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("PENDING APPROVAL"),
+        "stdout missing pending warn: {stdout}"
+    );
+
+    // Attestation present + signature empty + reason emergency
+    let att_str = std::fs::read_to_string(agent_dir.join("identity.attestation.json")).unwrap();
+    let att: serde_json::Value = serde_json::from_str(&att_str).unwrap();
+    assert_eq!(att["reason"], "emergency");
+    let sig = att.get("signature").and_then(|s| s.as_str()).unwrap_or("");
+    assert!(
+        sig.is_empty(),
+        "emergency attestation must have empty signature"
+    );
+
+    // Profile carries emergency_rekey_at
+    let yaml = std::fs::read_to_string(agent_dir.join("profile.yaml")).unwrap();
+    assert!(
+        yaml.contains("emergency_rekey_at:"),
+        "profile missing emergency_rekey_at: {yaml}"
+    );
+    assert!(yaml.contains("key_version: 1"));
+}
+
+#[test]
+fn rekey_emergency_aborts_without_confirmation_phrase() {
+    use std::io::Write as _;
+    use std::process::Stdio;
+
+    let home = TempDir::new().unwrap();
+    create_agent(home.path(), "rekey_emerg_abort");
+
+    // Without --yes, the CLI demands the literal "I UNDERSTAND" phrase.
+    // Pipe the wrong text and assert the rotation does NOT happen.
+    let mut child = Command::new(mur_bin())
+        .env("MUR_HOME", home.path())
+        .env("MUR_AGENT_BIN_DIR", home.path().join("bin"))
+        .env("MUR_AGENT_RUNTIME_BIN", runtime_bin())
+        .args(["agent", "rekey", "rekey_emerg_abort", "--emergency"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.as_mut().unwrap().write_all(b"yes\n").unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert!(out.status.success(), "abort path must exit 0");
     let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("M4"), "error must mention M4: {stderr}");
+    assert!(stderr.contains("aborted"), "must report abort: {stderr}");
+
+    // Profile must STILL be at key_version 0
+    let yaml =
+        std::fs::read_to_string(home.path().join("agents/rekey_emerg_abort/profile.yaml")).unwrap();
+    assert!(
+        yaml.contains("key_version: 0"),
+        "rotation must NOT have happened"
+    );
 }

--- a/mur-core/tests/agent_rekey_cli.rs
+++ b/mur-core/tests/agent_rekey_cli.rs
@@ -219,3 +219,51 @@ fn rekey_emergency_aborts_without_confirmation_phrase() {
         "rotation must NOT have happened"
     );
 }
+
+#[test]
+fn rekey_status_shows_initial_v0_state() {
+    let home = TempDir::new().unwrap();
+    create_agent(home.path(), "rekey_status_a");
+
+    let out = Command::new(mur_bin())
+        .env("MUR_HOME", home.path())
+        .env("MUR_AGENT_BIN_DIR", home.path().join("bin"))
+        .env("MUR_AGENT_RUNTIME_BIN", runtime_bin())
+        .args(["agent", "rekey-status", "rekey_status_a"])
+        .output()
+        .expect("rekey-status spawn");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("key_version:        0"), "stdout: {stdout}");
+    assert!(stdout.contains("algorithm:          ed25519"));
+    assert!(stdout.contains("rotation log lines: 1"));
+    assert!(stdout.contains("previous_pubkey:    <none in grace>"));
+}
+
+#[test]
+fn rekey_status_shows_after_rotation_with_grace() {
+    let home = TempDir::new().unwrap();
+    create_agent(home.path(), "rekey_status_b");
+    rekey(home.path(), "rekey_status_b", "scheduled");
+
+    let out = Command::new(mur_bin())
+        .env("MUR_HOME", home.path())
+        .env("MUR_AGENT_BIN_DIR", home.path().join("bin"))
+        .env("MUR_AGENT_RUNTIME_BIN", runtime_bin())
+        .args(["agent", "rekey-status", "rekey_status_b", "--json"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json output");
+    assert_eq!(v["key_version"], 1);
+    assert_eq!(v["algorithm"], "ed25519");
+    assert!(v["previous_pubkey"].as_str().unwrap_or("").starts_with('z'));
+    assert!(v["grace_expires_at"].is_string());
+    let remaining = v["grace_remaining_days"].as_i64().expect("grace days");
+    assert!(
+        (28..=30).contains(&remaining),
+        "expected ~30 days, got {remaining}"
+    );
+    assert_eq!(v["rotation_log_lines"], 2);
+}

--- a/mur-core/tests/agent_rekey_cli.rs
+++ b/mur-core/tests/agent_rekey_cli.rs
@@ -1,0 +1,160 @@
+//! Integration tests for `mur agent rekey` (M1.4).
+
+use std::path::PathBuf;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn mur_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_mur"))
+}
+
+fn runtime_bin() -> PathBuf {
+    let mur = mur_bin();
+    mur.parent()
+        .expect("mur has parent")
+        .join("mur-agent-runtime")
+}
+
+fn create_agent(home: &std::path::Path, name: &str) {
+    let status = Command::new(mur_bin())
+        .env("MUR_HOME", home)
+        .env("MUR_AGENT_BIN_DIR", home.join("bin"))
+        .env("MUR_AGENT_RUNTIME_BIN", runtime_bin())
+        .args(["agent", "create", name, "--no-interactive"])
+        .status()
+        .expect("spawn mur create");
+    assert!(status.success(), "agent create failed");
+}
+
+fn rekey(home: &std::path::Path, name: &str, reason: &str) {
+    let out = Command::new(mur_bin())
+        .env("MUR_HOME", home)
+        .env("MUR_AGENT_BIN_DIR", home.join("bin"))
+        .env("MUR_AGENT_RUNTIME_BIN", runtime_bin())
+        .args(["agent", "rekey", name, "--reason", reason, "--yes"])
+        .output()
+        .expect("spawn mur rekey");
+    assert!(
+        out.status.success(),
+        "rekey failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn rekey_advances_key_version_and_writes_prev() {
+    let home = TempDir::new().unwrap();
+    create_agent(home.path(), "rekey_basic");
+    let agent_dir = home.path().join("agents/rekey_basic");
+
+    let yaml_before = std::fs::read_to_string(agent_dir.join("profile.yaml")).unwrap();
+    assert!(yaml_before.contains("key_version: 0"));
+    let pubkey_before = std::fs::read_to_string(agent_dir.join("identity.pub")).unwrap();
+
+    rekey(home.path(), "rekey_basic", "scheduled");
+
+    // Profile updated
+    let yaml = std::fs::read_to_string(agent_dir.join("profile.yaml")).unwrap();
+    assert!(
+        yaml.contains("key_version: 1"),
+        "profile must advance to key_version 1: {yaml}"
+    );
+    assert!(yaml.contains("previous_pubkey:"));
+    assert!(yaml.contains("grace_expires_at:"));
+    assert!(yaml.contains("rotated_at:"));
+
+    // identity.pub differs
+    let pubkey_after = std::fs::read_to_string(agent_dir.join("identity.pub")).unwrap();
+    assert_ne!(
+        pubkey_before.trim(),
+        pubkey_after.trim(),
+        "pubkey must change"
+    );
+
+    // .prev files exist
+    assert!(
+        agent_dir.join("identity.key.prev").exists(),
+        "identity.key.prev missing"
+    );
+    assert!(
+        agent_dir.join("identity.pub.prev").exists(),
+        "identity.pub.prev missing"
+    );
+
+    // attestation file exists + has signature
+    let att_str = std::fs::read_to_string(agent_dir.join("identity.attestation.json")).unwrap();
+    let att: serde_json::Value = serde_json::from_str(&att_str).unwrap();
+    assert_eq!(att["old_key_version"], 0);
+    assert_eq!(att["new_key_version"], 1);
+    assert!(att["signature"].as_str().unwrap().starts_with('z'));
+
+    // jsonl has 2 lines
+    let jsonl = std::fs::read_to_string(agent_dir.join("rotations.jsonl")).unwrap();
+    let lines: Vec<&str> = jsonl.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 2, "jsonl should have bootstrap + 1 rotation");
+}
+
+#[test]
+fn double_rekey_advances_to_v2_with_chained_previous_pubkey() {
+    let home = TempDir::new().unwrap();
+    create_agent(home.path(), "rekey_double");
+    let agent_dir = home.path().join("agents/rekey_double");
+
+    let pubkey_v0 = std::fs::read_to_string(agent_dir.join("identity.pub")).unwrap();
+    let pubkey_v0 = pubkey_v0.trim().to_string();
+
+    rekey(home.path(), "rekey_double", "scheduled");
+    let pubkey_v1 = std::fs::read_to_string(agent_dir.join("identity.pub")).unwrap();
+    let pubkey_v1 = pubkey_v1.trim().to_string();
+    assert_ne!(pubkey_v0, pubkey_v1);
+
+    rekey(home.path(), "rekey_double", "scheduled");
+    let pubkey_v2 = std::fs::read_to_string(agent_dir.join("identity.pub")).unwrap();
+    let pubkey_v2 = pubkey_v2.trim().to_string();
+    assert_ne!(pubkey_v1, pubkey_v2);
+
+    let yaml = std::fs::read_to_string(agent_dir.join("profile.yaml")).unwrap();
+    assert!(yaml.contains("key_version: 2"));
+    // previous_pubkey should reflect v1, not v0
+    assert!(
+        yaml.contains(&format!("previous_pubkey: {pubkey_v1}")),
+        "profile previous_pubkey should == v1, yaml: {yaml}"
+    );
+
+    // jsonl has 3 lines (bootstrap + 2 rotations)
+    let jsonl = std::fs::read_to_string(agent_dir.join("rotations.jsonl")).unwrap();
+    let lines: Vec<&str> = jsonl.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 3);
+}
+
+#[test]
+fn rekey_with_suspect_compromise_reason_records_in_jsonl() {
+    let home = TempDir::new().unwrap();
+    create_agent(home.path(), "rekey_reason");
+    let agent_dir = home.path().join("agents/rekey_reason");
+
+    rekey(home.path(), "rekey_reason", "suspect-compromise");
+
+    let jsonl = std::fs::read_to_string(agent_dir.join("rotations.jsonl")).unwrap();
+    let last_line = jsonl.lines().filter(|l| !l.is_empty()).last().unwrap();
+    let v: serde_json::Value = serde_json::from_str(last_line).unwrap();
+    assert_eq!(v["reason"], "suspect_compromise");
+}
+
+#[test]
+fn rekey_emergency_flag_errors_in_m1() {
+    let home = TempDir::new().unwrap();
+    create_agent(home.path(), "rekey_emerg");
+
+    let out = Command::new(mur_bin())
+        .env("MUR_HOME", home.path())
+        .env("MUR_AGENT_BIN_DIR", home.path().join("bin"))
+        .env("MUR_AGENT_RUNTIME_BIN", runtime_bin())
+        .args(["agent", "rekey", "rekey_emerg", "--emergency", "--yes"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "emergency must fail in M1");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("M4"), "error must mention M4: {stderr}");
+}

--- a/mur-core/tests/profile_legacy_load.rs
+++ b/mur-core/tests/profile_legacy_load.rs
@@ -5,17 +5,22 @@ fn legacy_p0a_profile_loads_with_empty_identity() {
     // Reach across crates to the mur-common test fixture. If the relative
     // path doesn't work under cargo's test invocation, inline a minimal YAML
     // directly.
-    let yaml = std::fs::read_to_string(
-        "../mur-common/tests/fixtures/profile_p0a_minimal.yaml",
-    ).unwrap_or_else(|_| {
-        // Fallback: read via CARGO_MANIFEST_DIR if relative failed
-        let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .unwrap()
-            .join("mur-common/tests/fixtures/profile_p0a_minimal.yaml");
-        std::fs::read_to_string(p).expect("fixture must exist")
-    });
+    let yaml = std::fs::read_to_string("../mur-common/tests/fixtures/profile_p0a_minimal.yaml")
+        .unwrap_or_else(|_| {
+            // Fallback: read via CARGO_MANIFEST_DIR if relative failed
+            let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .join("mur-common/tests/fixtures/profile_p0a_minimal.yaml");
+            std::fs::read_to_string(p).expect("fixture must exist")
+        });
     let p: AgentProfile = serde_yaml::from_str(&yaml).unwrap();
-    assert!(p.identity.pubkey.is_empty(), "legacy P0a profile must default to empty pubkey");
-    assert!(p.identity.owner.is_none(), "legacy P0a profile must default to no owner");
+    assert!(
+        p.identity.pubkey.is_empty(),
+        "legacy P0a profile must default to empty pubkey"
+    );
+    assert!(
+        p.identity.owner.is_none(),
+        "legacy P0a profile must default to no owner"
+    );
 }


### PR DESCRIPTION
## Summary

**Draft.** First milestone (M1) of the `mur agent rekey` work. Lays the schema + cryptographic primitives + initial CLI for Ed25519 identity rotation. M2-M6 land as additional commits / PRs over the coming weeks.

**Spec:** `docs/superpowers/specs/2026-04-24-murmur-agent-rekey-design.md`
**Plan:** `docs/superpowers/plans/2026-04-24-murmur-agent-rekey-plan.md`

## What's in M1

- `mur-common::agent::IdentityConfig` — extended with `algorithm`, `key_version`, `created_at_key`, `previous_pubkey`, `previous_key_version`, `grace_expires_at`, `rotated_at`, `emergency_rekey_at` (all `#[serde(default)]` for back-compat). Manual `Default` impl ensures `algorithm = "ed25519"`.
- `mur-common::identity::RotationAttestation` — schema-1 attestation with sorted-key canonical JSON for signing; `RotationReason` enum (Scheduled / SuspectCompromise / OwnerChange / Emergency); `sign()` / `verify()` / `verify_or_emergency()` helpers; bootstrap entries skip verification.
- `mur agent create` — writes a bootstrap rotation line into `<agent_dir>/rotations.jsonl` and populates the new IdentityConfig fields.
- `mur agent rekey <name> [--reason ...] [--yes]` — normal rotation: signs an attestation with the OLD private key, atomically rotates `identity.{key,pub}` to `.prev`, writes new keypair, appends to `rotations.jsonl`, updates `profile.yaml` (key_version++, grace_expires_at = now + 30d), SIGTERMs the running runtime so the symlink supervisor restarts it.
- `--emergency` flag exists but errors with "lands in M4" — placeholder.

## Tests

- `mur-common/tests/profile_schema.rs` — 11 (3 new for rekey schema)
- `mur-common/tests/rotation_attestation.rs` — 10 (sign/verify roundtrip, tamper detection, bootstrap, emergency lenient verify, canonical-bytes determinism, serde)
- `mur-core/tests/agent_create_identity.rs` — extended for bootstrap line + new fields
- `mur-core/tests/agent_rekey_cli.rs` — 4 integration tests (advance v0→v1, double-rekey v0→v1→v2 with chained previous_pubkey, reason recording, emergency rejected in M1)

`cargo test --workspace` green. clippy + fmt clean.

## What's NOT in M1 (per plan)

- M2: commander-side `apply_rotation` + grace registry (separate PR)
- M3: TcpConnector fallback during grace
- M4: `--emergency` path + `murc agent approve-rekey`
- M5: split-attestation detection
- M6: grace cleanup + `rekey-status` + docs

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manual smoke: `mur agent create x` → `mur agent rekey x --yes` → verify `rotations.jsonl` has 2 lines + profile updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)