### PR TITLE
fix(agent): unblock real-LLM agents — provider parsing, skill aliases, runtime LLM wiring, sys_prompt forwarding

### DIFF
--- a/mur-agent-runtime/src/llm/anthropic.rs
+++ b/mur-agent-runtime/src/llm/anthropic.rs
@@ -1,1 +1,128 @@
 //! Anthropic Claude client — remote inference via Anthropic Messages API.
+//!
+//! POST https://api.anthropic.com/v1/messages
+//!   x-api-key: $ANTHROPIC_API_KEY
+//!   anthropic-version: 2023-06-01
+//!   {"model": ..., "max_tokens": ..., "system": "...", "messages": [...]}
+//!
+//! The Anthropic API has a top-level `system` field rather than a system role
+//! in `messages`. We translate `LlmMessage{role:"system"}` -> top-level system.
+
+use super::{LlmClient, LlmError, LlmRequest, LlmResponse};
+use async_trait::async_trait;
+use serde_json::json;
+
+const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
+const DEFAULT_VERSION: &str = "2023-06-01";
+const DEFAULT_MAX_TOKENS: u32 = 1024;
+
+pub struct AnthropicClient {
+    base_url: String,
+    api_key: String,
+    version: String,
+    model: String,
+    http: reqwest::Client,
+}
+
+impl AnthropicClient {
+    pub fn new(base_url: String, api_key: String, model: String) -> Self {
+        Self {
+            base_url,
+            api_key,
+            version: DEFAULT_VERSION.to_string(),
+            model,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// Convenience constructor reading API key from `ANTHROPIC_API_KEY`.
+    pub fn from_env(model: String) -> Result<Self, LlmError> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY")
+            .map_err(|_| LlmError::InvalidResponse("ANTHROPIC_API_KEY not set".into()))?;
+        let base_url = std::env::var("ANTHROPIC_BASE_URL")
+            .unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+        Ok(Self::new(base_url, api_key, model))
+    }
+}
+
+#[async_trait]
+impl LlmClient for AnthropicClient {
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+
+    async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        // Split out system messages — Anthropic puts them at the top level.
+        let mut system_chunks: Vec<String> = Vec::new();
+        let mut convo: Vec<serde_json::Value> = Vec::new();
+        for m in &req.messages {
+            if m.role == "system" {
+                system_chunks.push(m.content.clone());
+            } else {
+                // Anthropic accepts roles "user" and "assistant" only.
+                let role = if m.role == "agent" { "assistant" } else { m.role.as_str() };
+                convo.push(json!({"role": role, "content": m.content}));
+            }
+        }
+
+        let mut body = json!({
+            "model": self.model,
+            "max_tokens": req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+            "messages": convo,
+        });
+        if !system_chunks.is_empty() {
+            body["system"] = json!(system_chunks.join("\n\n"));
+        }
+        if let Some(t) = req.temperature {
+            body["temperature"] = json!(t);
+        }
+
+        let url = format!("{}/v1/messages", self.base_url);
+        let resp = self
+            .http
+            .post(url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", &self.version)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| LlmError::Http(e.to_string()))?;
+
+        let status = resp.status();
+        if status == 429 {
+            return Err(LlmError::RateLimit);
+        }
+        let v: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| LlmError::Http(e.to_string()))?;
+        if !status.is_success() {
+            let msg = v["error"]["message"].as_str().unwrap_or("unknown");
+            return Err(LlmError::Http(format!("status {status}: {msg}")));
+        }
+
+        // Extract text from `content[0..n]` array of blocks; concatenate text blocks.
+        let text = v["content"]
+            .as_array()
+            .ok_or_else(|| LlmError::InvalidResponse("missing content array".into()))?
+            .iter()
+            .filter_map(|b| {
+                if b["type"].as_str() == Some("text") {
+                    b["text"].as_str().map(str::to_string)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        let input_tokens = v["usage"]["input_tokens"].as_u64().unwrap_or(0);
+        let output_tokens = v["usage"]["output_tokens"].as_u64().unwrap_or(0);
+        Ok(LlmResponse {
+            text,
+            input_tokens,
+            output_tokens,
+            model: self.model.clone(),
+        })
+    }
+}

--- a/mur-agent-runtime/src/llm/anthropic.rs
+++ b/mur-agent-runtime/src/llm/anthropic.rs
@@ -39,8 +39,8 @@ impl AnthropicClient {
     pub fn from_env(model: String) -> Result<Self, LlmError> {
         let api_key = std::env::var("ANTHROPIC_API_KEY")
             .map_err(|_| LlmError::InvalidResponse("ANTHROPIC_API_KEY not set".into()))?;
-        let base_url = std::env::var("ANTHROPIC_BASE_URL")
-            .unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+        let base_url =
+            std::env::var("ANTHROPIC_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
         Ok(Self::new(base_url, api_key, model))
     }
 }
@@ -60,7 +60,11 @@ impl LlmClient for AnthropicClient {
                 system_chunks.push(m.content.clone());
             } else {
                 // Anthropic accepts roles "user" and "assistant" only.
-                let role = if m.role == "agent" { "assistant" } else { m.role.as_str() };
+                let role = if m.role == "agent" {
+                    "assistant"
+                } else {
+                    m.role.as_str()
+                };
                 convo.push(json!({"role": role, "content": m.content}));
             }
         }

--- a/mur-agent-runtime/src/llm/openai.rs
+++ b/mur-agent-runtime/src/llm/openai.rs
@@ -1,1 +1,107 @@
 //! OpenAI-compatible client — inference via OpenAI Chat Completions API.
+//!
+//! POST $base_url/chat/completions
+//!   Authorization: Bearer $OPENAI_API_KEY
+//!   {"model": ..., "messages": [{"role":"system|user|assistant","content":"..."}], ...}
+//!
+//! Compatible with anything that speaks the OpenAI Chat Completions schema
+//! (Together AI, Groq, Fireworks, vLLM, LM Studio, ...). The base URL is
+//! settable so non-openai.com endpoints work out of the box.
+
+use super::{LlmClient, LlmError, LlmRequest, LlmResponse};
+use async_trait::async_trait;
+use serde_json::json;
+
+const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+
+pub struct OpenAiClient {
+    base_url: String,
+    api_key: String,
+    model: String,
+    http: reqwest::Client,
+}
+
+impl OpenAiClient {
+    pub fn new(base_url: String, api_key: String, model: String) -> Self {
+        Self {
+            base_url,
+            api_key,
+            model,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// Convenience constructor reading API key from `OPENAI_API_KEY` and base
+    /// URL from `OPENAI_BASE_URL` (defaults to api.openai.com/v1).
+    pub fn from_env(model: String) -> Result<Self, LlmError> {
+        let api_key = std::env::var("OPENAI_API_KEY")
+            .map_err(|_| LlmError::InvalidResponse("OPENAI_API_KEY not set".into()))?;
+        let base_url = std::env::var("OPENAI_BASE_URL")
+            .unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+        Ok(Self::new(base_url, api_key, model))
+    }
+}
+
+#[async_trait]
+impl LlmClient for OpenAiClient {
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+
+    async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        let messages: Vec<_> = req
+            .messages
+            .iter()
+            .map(|m| {
+                // OpenAI uses {system,user,assistant}. Mur internally may use "agent".
+                let role = if m.role == "agent" { "assistant" } else { m.role.as_str() };
+                json!({"role": role, "content": m.content})
+            })
+            .collect();
+        let mut body = json!({"model": self.model, "messages": messages});
+        if let Some(t) = req.temperature {
+            body["temperature"] = json!(t);
+        }
+        if let Some(m) = req.max_tokens {
+            body["max_tokens"] = json!(m);
+        }
+
+        let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
+        let resp = self
+            .http
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| LlmError::Http(e.to_string()))?;
+
+        let status = resp.status();
+        if status == 429 {
+            return Err(LlmError::RateLimit);
+        }
+        let v: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| LlmError::Http(e.to_string()))?;
+        if !status.is_success() {
+            let msg = v["error"]["message"].as_str().unwrap_or("unknown");
+            return Err(LlmError::Http(format!("status {status}: {msg}")));
+        }
+
+        let text = v["choices"][0]["message"]["content"]
+            .as_str()
+            .ok_or_else(|| {
+                LlmError::InvalidResponse("missing choices[0].message.content".into())
+            })?
+            .to_string();
+        let input_tokens = v["usage"]["prompt_tokens"].as_u64().unwrap_or(0);
+        let output_tokens = v["usage"]["completion_tokens"].as_u64().unwrap_or(0);
+        Ok(LlmResponse {
+            text,
+            input_tokens,
+            output_tokens,
+            model: self.model.clone(),
+        })
+    }
+}

--- a/mur-agent-runtime/src/llm/openai.rs
+++ b/mur-agent-runtime/src/llm/openai.rs
@@ -36,8 +36,8 @@ impl OpenAiClient {
     pub fn from_env(model: String) -> Result<Self, LlmError> {
         let api_key = std::env::var("OPENAI_API_KEY")
             .map_err(|_| LlmError::InvalidResponse("OPENAI_API_KEY not set".into()))?;
-        let base_url = std::env::var("OPENAI_BASE_URL")
-            .unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+        let base_url =
+            std::env::var("OPENAI_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
         Ok(Self::new(base_url, api_key, model))
     }
 }
@@ -54,7 +54,11 @@ impl LlmClient for OpenAiClient {
             .iter()
             .map(|m| {
                 // OpenAI uses {system,user,assistant}. Mur internally may use "agent".
-                let role = if m.role == "agent" { "assistant" } else { m.role.as_str() };
+                let role = if m.role == "agent" {
+                    "assistant"
+                } else {
+                    m.role.as_str()
+                };
                 json!({"role": role, "content": m.content})
             })
             .collect();
@@ -91,9 +95,7 @@ impl LlmClient for OpenAiClient {
 
         let text = v["choices"][0]["message"]["content"]
             .as_str()
-            .ok_or_else(|| {
-                LlmError::InvalidResponse("missing choices[0].message.content".into())
-            })?
+            .ok_or_else(|| LlmError::InvalidResponse("missing choices[0].message.content".into()))?
             .to_string();
         let input_tokens = v["usage"]["prompt_tokens"].as_u64().unwrap_or(0);
         let output_tokens = v["usage"]["completion_tokens"].as_u64().unwrap_or(0);

--- a/mur-agent-runtime/src/profile.rs
+++ b/mur-agent-runtime/src/profile.rs
@@ -23,6 +23,10 @@ pub struct Profile {
     pub agent_home: PathBuf,
     pub digest: String,
     pub raw_yaml: String, // retained for re-emit / yaml_edit round-trip
+    /// E6 fix: contents of `sys_prompt_file`, loaded once at startup so the
+    /// task runner can inject it as the system message on every LLM call.
+    /// None when the file is missing or empty.
+    pub system_prompt: Option<String>,
 }
 
 impl Profile {
@@ -37,11 +41,19 @@ impl Profile {
         validate_uuid_v7(&inner.id)?;
         validate_filesystem_paths(&inner, agent_home)?;
         let digest = compute_digest(&expanded);
+        let system_prompt = {
+            let sp_path = agent_home.join(&inner.sys_prompt_file);
+            match fs::read_to_string(&sp_path) {
+                Ok(s) if !s.trim().is_empty() => Some(s),
+                _ => None,
+            }
+        };
         Ok(Self {
             inner,
             agent_home: agent_home.to_path_buf(),
             digest,
             raw_yaml,
+            system_prompt,
         })
     }
 }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -13,7 +13,9 @@ use crate::protocol::methods::{
 };
 #[cfg(unix)]
 use crate::socket_path::resolve_bind_target;
-use crate::llm::{LlmClient, ollama::OllamaClient};
+use crate::llm::{
+    LlmClient, anthropic::AnthropicClient, ollama::OllamaClient, openai::OpenAiClient,
+};
 use crate::task_runner::TaskRunner;
 use crate::telemetry_writer::{Event, TelemetryWriter};
 use crate::transport::stdio::serve_stdio;
@@ -141,6 +143,38 @@ pub async fn entrypoint() -> anyhow::Result<()> {
                 Arc::new(
                     TaskRunner::with_llm(client).with_system_prompt(profile.system_prompt.clone()),
                 )
+            }
+            "anthropic" => {
+                let model = profile.inner.model.name.clone();
+                match AnthropicClient::from_env(model) {
+                    Ok(c) => {
+                        let client: Arc<dyn LlmClient> = Arc::new(c);
+                        Arc::new(
+                            TaskRunner::with_llm(client)
+                                .with_system_prompt(profile.system_prompt.clone()),
+                        )
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "anthropic client unavailable; falling back to echo");
+                        Arc::new(TaskRunner::new_stub_echo())
+                    }
+                }
+            }
+            "openai" => {
+                let model = profile.inner.model.name.clone();
+                match OpenAiClient::from_env(model) {
+                    Ok(c) => {
+                        let client: Arc<dyn LlmClient> = Arc::new(c);
+                        Arc::new(
+                            TaskRunner::with_llm(client)
+                                .with_system_prompt(profile.system_prompt.clone()),
+                        )
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "openai client unavailable; falling back to echo");
+                        Arc::new(TaskRunner::new_stub_echo())
+                    }
+                }
             }
             other => {
                 tracing::warn!(provider = %other, "no LLM client implemented; falling back to echo");

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -2,6 +2,9 @@
 //! drives the stdio (and optionally Unix-socket) transports until SIGTERM.
 
 use crate::entitlements::detect_warnings;
+use crate::llm::{
+    LlmClient, anthropic::AnthropicClient, ollama::OllamaClient, openai::OpenAiClient,
+};
 use crate::lock_file::{LockHandle, write_lock};
 use crate::multi_call::{DispatchError, extract_profile_name, verify_name_match};
 use crate::profile::Profile;
@@ -13,9 +16,6 @@ use crate::protocol::methods::{
 };
 #[cfg(unix)]
 use crate::socket_path::resolve_bind_target;
-use crate::llm::{
-    LlmClient, anthropic::AnthropicClient, ollama::OllamaClient, openai::OpenAiClient,
-};
 use crate::task_runner::TaskRunner;
 use crate::telemetry_writer::{Event, TelemetryWriter};
 use crate::transport::stdio::serve_stdio;

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -13,6 +13,7 @@ use crate::protocol::methods::{
 };
 #[cfg(unix)]
 use crate::socket_path::resolve_bind_target;
+use crate::llm::{LlmClient, ollama::OllamaClient};
 use crate::task_runner::TaskRunner;
 use crate::telemetry_writer::{Event, TelemetryWriter};
 use crate::transport::stdio::serve_stdio;
@@ -122,7 +123,28 @@ pub async fn entrypoint() -> anyhow::Result<()> {
 
     // 6. Build dispatcher (shared Arc so multiple transports can read it)
     let profile_arc = Arc::new(profile.clone());
-    let runner = Arc::new(TaskRunner::new_stub_echo()); // Task 21 swaps to real backend
+    // E4: select runner backend based on profile.model.provider.
+    // Ollama: real client. Other providers (anthropic/openai stubs not yet
+    // implemented) fall through to echo. Setting MUR_AGENT_FORCE_ECHO=1
+    // forces echo regardless of profile (useful for tests).
+    let force_echo = std::env::var_os("MUR_AGENT_FORCE_ECHO").is_some();
+    let runner = if force_echo {
+        Arc::new(TaskRunner::new_stub_echo())
+    } else {
+        match profile.inner.model.provider.as_str() {
+            "ollama" => {
+                let base = std::env::var("OLLAMA_BASE_URL")
+                    .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string());
+                let model = profile.inner.model.name.clone();
+                let client: Arc<dyn LlmClient> = Arc::new(OllamaClient::new(base, model));
+                Arc::new(TaskRunner::with_llm(client))
+            }
+            other => {
+                tracing::warn!(provider = %other, "no LLM client implemented; falling back to echo");
+                Arc::new(TaskRunner::new_stub_echo())
+            }
+        }
+    };
     let dispatcher = Arc::new(build_dispatcher(&profile_arc, &runner));
 
     // 7. Transports

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -137,7 +137,10 @@ pub async fn entrypoint() -> anyhow::Result<()> {
                     .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string());
                 let model = profile.inner.model.name.clone();
                 let client: Arc<dyn LlmClient> = Arc::new(OllamaClient::new(base, model));
-                Arc::new(TaskRunner::with_llm(client))
+                // E6: forward the loaded system prompt so it actually reaches the LLM.
+                Arc::new(
+                    TaskRunner::with_llm(client).with_system_prompt(profile.system_prompt.clone()),
+                )
             }
             other => {
                 tracing::warn!(provider = %other, "no LLM client implemented; falling back to echo");

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -34,6 +34,8 @@ pub struct TaskRunner {
     registry: Arc<Mutex<HashMap<String, TaskState>>>,
     cancel_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>>,
     telemetry: Option<mpsc::Sender<Event>>,
+    /// E6: optional system prompt prepended to LLM requests.
+    system_prompt: Option<String>,
 }
 
 impl TaskRunner {
@@ -55,11 +57,18 @@ impl TaskRunner {
             registry: Arc::new(Mutex::new(HashMap::new())),
             cancel_signals: Arc::new(Mutex::new(HashMap::new())),
             telemetry: None,
+            system_prompt: None,
         }
     }
 
     pub fn with_telemetry(mut self, tx: mpsc::Sender<Event>) -> Self {
         self.telemetry = Some(tx);
+        self
+    }
+
+    /// E6: attach a system prompt to be sent on every LLM call.
+    pub fn with_system_prompt(mut self, prompt: Option<String>) -> Self {
+        self.system_prompt = prompt;
         self
     }
 
@@ -150,11 +159,19 @@ impl TaskRunner {
 
     async fn run_llm(&self, task_id: &str, client: &dyn LlmClient, input: &Message) -> Message {
         let prompt = text_of(input);
+        let mut messages: Vec<LlmMessage> = Vec::new();
+        if let Some(sp) = &self.system_prompt {
+            messages.push(LlmMessage {
+                role: "system".into(),
+                content: sp.clone(),
+            });
+        }
+        messages.push(LlmMessage {
+            role: input.role.clone(),
+            content: prompt,
+        });
         let req = LlmRequest {
-            messages: vec![LlmMessage {
-                role: input.role.clone(),
-                content: prompt,
-            }],
+            messages,
             temperature: None,
             max_tokens: None,
         };

--- a/mur-core/src/cmd/agent.rs
+++ b/mur-core/src/cmd/agent.rs
@@ -18,6 +18,7 @@ pub fn cmd_create(
     _no_interactive: bool,
     display_name: Option<String>,
     model: Option<String>,
+    provider: Option<String>,
 ) -> Result<()> {
     validate_name(name)?;
 
@@ -39,7 +40,18 @@ pub fn cmd_create(
     );
 
     let display_name = display_name.unwrap_or_else(|| name.to_string());
-    let model = model.unwrap_or_else(|| "llama3.2:3b".to_string());
+    let raw_model = model.unwrap_or_else(|| "llama3.2:3b".to_string());
+    // E2 fix: support `provider/model` shorthand in --model. Explicit --provider
+    // wins. Default provider is `ollama` for backward compatibility.
+    let (resolved_provider, resolved_model) = match provider {
+        Some(p) => (p, raw_model),
+        None => match raw_model.split_once('/') {
+            Some((p, rest)) if !p.is_empty() && !rest.is_empty() && is_known_provider(p) => {
+                (p.to_string(), rest.to_string())
+            }
+            _ => ("ollama".to_string(), raw_model),
+        },
+    };
     let now = chrono::Utc::now().to_rfc3339();
     let id = uuid::Uuid::now_v7().to_string();
 
@@ -81,8 +93,8 @@ pub fn cmd_create(
         },
         sys_prompt_file: "sys_prompt.md".into(),
         model: ModelConfig {
-            provider: "ollama".into(),
-            name: model,
+            provider: resolved_provider,
+            name: resolved_model,
             params: BTreeMap::new(),
         },
         mcp_servers: vec![],
@@ -168,6 +180,55 @@ pub fn cmd_create(
 
 fn validate_name(name: &str) -> Result<()> {
     mur_common::validate_agent_name(name).with_context(|| format!("invalid agent name {name:?}"))
+}
+
+/// Whether a string is one of the providers we recognize when splitting
+/// `provider/model` shorthand. Conservative allowlist to avoid mis-splitting
+/// HuggingFace-style model ids like `meta-llama/Llama-3.2-3B`.
+fn is_known_provider(s: &str) -> bool {
+    matches!(
+        s,
+        "ollama"
+            | "anthropic"
+            | "openai"
+            | "azure"
+            | "bedrock"
+            | "gemini"
+            | "google"
+            | "mistral"
+            | "together"
+            | "groq"
+            | "fireworks"
+            | "deepseek"
+            | "xai"
+            | "cohere"
+    )
+}
+
+/// Resolve a user-supplied skill query against a profile's skill list.
+/// Tries exact match, then trailing path component, then trailing path component
+/// without the `.md` suffix. Returns the canonical stored id on success.
+fn resolve_skill_id<'a>(profile: &'a _AgentProfile, query: &str) -> Option<&'a String> {
+    if let Some(s) = profile.skills.iter().find(|s| s.as_str() == query) {
+        return Some(s);
+    }
+    if let Some(s) = profile.skills.iter().find(|s| {
+        Path::new(s.as_str())
+            .file_name()
+            .and_then(|f| f.to_str())
+            .is_some_and(|f| f == query)
+    }) {
+        return Some(s);
+    }
+    if let Some(s) = profile.skills.iter().find(|s| {
+        Path::new(s.as_str())
+            .file_stem()
+            .and_then(|f| f.to_str())
+            .is_some_and(|f| f == query)
+    }) {
+        return Some(s);
+    }
+    None
 }
 
 fn resolve_mur_home() -> Result<PathBuf> {
@@ -1120,34 +1181,29 @@ pub fn cmd_skill_add(name: &str, source: &str) -> Result<()> {
     save_profile(&path, &mut profile)
 }
 
-pub fn cmd_skill_remove(name: &str, skill_id: &str) -> Result<()> {
+pub fn cmd_skill_remove(name: &str, query: &str) -> Result<()> {
     let (path, mut profile) = load_profile_for_edit(name)?;
-    let before = profile.skills.len();
-    profile.skills.retain(|s| s != skill_id);
-    if profile.skills.len() == before {
-        bail!("skill '{skill_id}' not found on '{name}'");
-    }
+    let resolved = resolve_skill_id(&profile, query)
+        .ok_or_else(|| anyhow!("skill '{query}' not found on '{name}'"))?
+        .clone();
+    profile.skills.retain(|s| s != &resolved);
     save_profile(&path, &mut profile)?;
 
     // Delete the backing file if no other skill entry references it.
     let agent_home = resolve_mur_home()?.join("agents").join(name);
-    let file_path = agent_home.join(skill_id);
-    if file_path.exists() {
-        let still_referenced = profile.skills.iter().any(|s| s == skill_id);
-        if !still_referenced {
-            let _ = fs::remove_file(&file_path);
-        }
+    let file_path = agent_home.join(&resolved);
+    if file_path.exists() && !profile.skills.iter().any(|s| s == &resolved) {
+        let _ = fs::remove_file(&file_path);
     }
     Ok(())
 }
 
-pub fn cmd_skill_show(name: &str, skill_id: &str) -> Result<()> {
+pub fn cmd_skill_show(name: &str, query: &str) -> Result<()> {
     let (_path, profile) = load_profile_for_edit(name)?;
-    if !profile.skills.iter().any(|s| s == skill_id) {
-        bail!("skill '{skill_id}' not registered on '{name}'");
-    }
+    let resolved = resolve_skill_id(&profile, query)
+        .ok_or_else(|| anyhow!("skill '{query}' not registered on '{name}'"))?;
     let agent_home = resolve_mur_home()?.join("agents").join(name);
-    let file_path = agent_home.join(skill_id);
+    let file_path = agent_home.join(resolved);
     let body =
         fs::read_to_string(&file_path).with_context(|| format!("read {}", file_path.display()))?;
     print!("{body}");

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -861,9 +861,14 @@ enum AgentAction {
         /// Display name (defaults to the agent name)
         #[arg(long)]
         display_name: Option<String>,
-        /// Model id (e.g. llama3.2:3b)
+        /// Model id (e.g. llama3.2:3b, claude-opus-4-7).
+        /// May also be `provider/model` (e.g. anthropic/claude-opus-4-7).
         #[arg(long)]
         model: Option<String>,
+        /// Model provider (e.g. ollama, anthropic, openai). Defaults to ollama.
+        /// Takes precedence over a `provider/model` prefix in --model.
+        #[arg(long)]
+        provider: Option<String>,
     },
     /// List agents under $MUR_HOME/agents
     List {
@@ -1026,15 +1031,20 @@ enum AgentPermAction {
 enum AgentSkillAction {
     /// List attached skill ids
     List { name: String },
-    /// Copy a skill markdown file into the agent and register it
+    /// Copy a skill markdown file into the agent and register it.
+    /// The skill is stored under `skills/<basename>` inside the agent dir.
     Add {
         name: String,
-        /// Path to a skill .md file (basename becomes its id)
+        /// Path to a skill .md file. Stored id is `skills/<basename>`.
         source: String,
     },
-    /// Remove a skill entry; deletes the backing file if orphaned
+    /// Remove a skill entry; deletes the backing file if orphaned.
+    /// `skill_id` may be the full id (`skills/foo.md`), the basename (`foo.md`),
+    /// or the basename without extension (`foo`).
     Remove { name: String, skill_id: String },
-    /// Print the contents of a skill file
+    /// Print the contents of a skill file.
+    /// `skill_id` may be the full id (`skills/foo.md`), the basename (`foo.md`),
+    /// or the basename without extension (`foo`).
     Show { name: String, skill_id: String },
 }
 
@@ -1427,7 +1437,8 @@ async fn async_main() -> Result<()> {
                 no_interactive,
                 display_name,
                 model,
-            } => cmd::agent::cmd_create(&name, no_interactive, display_name, model)?,
+                provider,
+            } => cmd::agent::cmd_create(&name, no_interactive, display_name, model, provider)?,
             AgentAction::List { json } => cmd::agent::cmd_list(json)?,
             AgentAction::Status { name } => cmd::agent::cmd_status(&name)?,
             AgentAction::Stop { name } => cmd::agent::cmd_stop(&name)?,

--- a/mur-core/tests/agent_create.rs
+++ b/mur-core/tests/agent_create.rs
@@ -85,11 +85,13 @@ fn agent_create_parses_provider_slash_model_shorthand() {
         ])
         .output()
         .unwrap();
-    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
-    let yaml = std::fs::read_to_string(
-        mur_home.path().join("agents/anthropic_a/profile.yaml"),
-    )
-    .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let yaml =
+        std::fs::read_to_string(mur_home.path().join("agents/anthropic_a/profile.yaml")).unwrap();
     let p: AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
     assert_eq!(p.model.provider, "anthropic");
     assert_eq!(p.model.name, "claude-opus-4-7");
@@ -109,7 +111,11 @@ fn agent_create_parses_provider_slash_model_shorthand() {
         ])
         .output()
         .unwrap();
-    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let yaml = std::fs::read_to_string(mur_home.path().join("agents/hf_a/profile.yaml")).unwrap();
     let p: AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
     assert_eq!(p.model.provider, "ollama");
@@ -140,11 +146,13 @@ fn agent_create_explicit_provider_wins_over_model_prefix() {
         ])
         .output()
         .unwrap();
-    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
-    let yaml = std::fs::read_to_string(
-        mur_home.path().join("agents/explicit_a/profile.yaml"),
-    )
-    .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let yaml =
+        std::fs::read_to_string(mur_home.path().join("agents/explicit_a/profile.yaml")).unwrap();
     let p: AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
     assert_eq!(p.model.provider, "openai");
     assert_eq!(p.model.name, "anthropic/foo");

--- a/mur-core/tests/agent_create.rs
+++ b/mur-core/tests/agent_create.rs
@@ -59,3 +59,93 @@ fn agent_create_non_interactive_writes_profile_prompt_and_symlink() {
     let link_target = std::fs::read_link(&symlink).expect("read_link");
     assert_eq!(link_target.to_string_lossy(), runtime_target);
 }
+
+/// E2 regression: `--model provider/model` shorthand routes to the right
+/// provider for known providers; falls back to ollama for unknown prefixes
+/// (e.g. HuggingFace `org/model`).
+#[test]
+fn agent_create_parses_provider_slash_model_shorthand() {
+    let mur_home = TempDir::new().unwrap();
+    let bin_dir = TempDir::new().unwrap();
+    let runtime_target = "/tmp/mur-agent-runtime-stub-for-test";
+    let mur = env!("CARGO_BIN_EXE_mur");
+
+    // anthropic/<model> → provider=anthropic
+    let out = Command::new(mur)
+        .env("MUR_HOME", mur_home.path())
+        .env("MUR_AGENT_BIN_DIR", bin_dir.path())
+        .env("MUR_AGENT_RUNTIME_BIN", runtime_target)
+        .args([
+            "agent",
+            "create",
+            "anthropic_a",
+            "--no-interactive",
+            "--model",
+            "anthropic/claude-opus-4-7",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    let yaml = std::fs::read_to_string(
+        mur_home.path().join("agents/anthropic_a/profile.yaml"),
+    )
+    .unwrap();
+    let p: AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
+    assert_eq!(p.model.provider, "anthropic");
+    assert_eq!(p.model.name, "claude-opus-4-7");
+
+    // unknown prefix (HuggingFace style) → provider stays ollama, name kept whole
+    let out = Command::new(mur)
+        .env("MUR_HOME", mur_home.path())
+        .env("MUR_AGENT_BIN_DIR", bin_dir.path())
+        .env("MUR_AGENT_RUNTIME_BIN", runtime_target)
+        .args([
+            "agent",
+            "create",
+            "hf_a",
+            "--no-interactive",
+            "--model",
+            "meta-llama/Llama-3.2-3B",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    let yaml = std::fs::read_to_string(mur_home.path().join("agents/hf_a/profile.yaml")).unwrap();
+    let p: AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
+    assert_eq!(p.model.provider, "ollama");
+    assert_eq!(p.model.name, "meta-llama/Llama-3.2-3B");
+}
+
+/// E2 regression: explicit `--provider` overrides any prefix in `--model`.
+#[test]
+fn agent_create_explicit_provider_wins_over_model_prefix() {
+    let mur_home = TempDir::new().unwrap();
+    let bin_dir = TempDir::new().unwrap();
+    let runtime_target = "/tmp/mur-agent-runtime-stub-for-test";
+    let mur = env!("CARGO_BIN_EXE_mur");
+
+    let out = Command::new(mur)
+        .env("MUR_HOME", mur_home.path())
+        .env("MUR_AGENT_BIN_DIR", bin_dir.path())
+        .env("MUR_AGENT_RUNTIME_BIN", runtime_target)
+        .args([
+            "agent",
+            "create",
+            "explicit_a",
+            "--no-interactive",
+            "--provider",
+            "openai",
+            "--model",
+            "anthropic/foo",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    let yaml = std::fs::read_to_string(
+        mur_home.path().join("agents/explicit_a/profile.yaml"),
+    )
+    .unwrap();
+    let p: AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
+    assert_eq!(p.model.provider, "openai");
+    assert_eq!(p.model.name, "anthropic/foo");
+}

--- a/mur-core/tests/agent_skill.rs
+++ b/mur-core/tests/agent_skill.rs
@@ -117,3 +117,63 @@ fn skill_list_show_remove_roundtrip() {
     let dest = mur_home.path().join("agents/agent_x/skills/research.md");
     assert!(!dest.exists(), "orphaned skill file should be deleted");
 }
+
+/// E3 regression: `skill show` and `skill remove` accept the basename
+/// (`research.md`) and the stem (`research`) in addition to the full
+/// stored id (`skills/research.md`).
+#[test]
+fn skill_show_and_remove_accept_basename_and_stem() {
+    let mur_home = TempDir::new().unwrap();
+    let bin_dir = TempDir::new().unwrap();
+    mur_create(mur_home.path(), bin_dir.path(), "agent_x");
+    let src = TempDir::new().unwrap();
+    let skill_src = src.path().join("research.md");
+    std::fs::write(&skill_src, "skill-body").unwrap();
+    let _ = run(
+        mur_home.path(),
+        &[
+            "agent",
+            "skill",
+            "add",
+            "agent_x",
+            skill_src.to_str().unwrap(),
+        ],
+    );
+
+    // show by basename
+    let out = run(
+        mur_home.path(),
+        &["agent", "skill", "show", "agent_x", "research.md"],
+    );
+    assert!(
+        out.status.success(),
+        "show by basename failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(String::from_utf8_lossy(&out.stdout).contains("skill-body"));
+
+    // show by stem (without .md)
+    let out = run(
+        mur_home.path(),
+        &["agent", "skill", "show", "agent_x", "research"],
+    );
+    assert!(
+        out.status.success(),
+        "show by stem failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(String::from_utf8_lossy(&out.stdout).contains("skill-body"));
+
+    // remove by stem
+    let out = run(
+        mur_home.path(),
+        &["agent", "skill", "remove", "agent_x", "research"],
+    );
+    assert!(
+        out.status.success(),
+        "remove by stem failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let p = read_profile(mur_home.path(), "agent_x");
+    assert!(p.skills.is_empty(), "skill should be removed");
+}


### PR DESCRIPTION
## Summary

Five fixes to the `mur agent` surface, discovered while running an autonomous multi-scenario harness against v2.4.1. Each fix is one self-contained commit with regression tests where unit-testable.

| # | Commit | Subject |
|---|--------|---------|
| E2 + E3 | 9d7ccb3 | \`mur agent create --provider\` flag + \`provider/model\` shorthand parsing; \`skill show/remove\` accepts basename and stem in addition to the full id |
| E4 | d8a43e9 | runtime selects LLM backend from \`profile.model.provider\` (was hardcoded \`new_stub_echo()\` with a Task 21 TODO); \`MUR_AGENT_FORCE_ECHO=1\` keeps tests deterministic |
| E6 | b11e3f9 | \`Profile::load\` reads \`sys_prompt.md\` and \`TaskRunner\` injects it as a system message — previously the system prompt was configured but never sent to the LLM |
| LLM clients | e217953 | Anthropic Messages API + OpenAI-compatible Chat Completions clients (the two stubs in \`llm/{anthropic,openai}.rs\` were 1-line files); supervisor falls back to echo with a warn when API keys are missing |

## Why these matter together

Before this branch, an agent declared in a profile as \`provider: anthropic, model: claude-…\` would:
1. Be silently created as \`provider: ollama\` (E2 — \`--model\` ignored \`--provider\` info).
2. Once corrected, the runtime would still echo because no LLM client was instantiated (E4).
3. After E4, the system prompt configured via \`mur agent prompt set\` would still be ignored because the runtime never read \`sys_prompt.md\` (E6).
4. With E4+E6, only Ollama actually had a working client; Anthropic + OpenAI were 1-line stubs.

After this branch, the full chain works: \`mur agent create foo --provider anthropic --model claude-… && mur agent prompt set foo "you are …" && ~/.local/bin/mur_agent_foo &\` produces a real Anthropic-backed agent that honors its system prompt.

## Verification

- \`cargo test --release -p mur-core\`: 1641+ tests, 0 failures (Phase 1 unit tests for E2/E3 included).
- \`cargo test --release -p mur-agent-runtime\`: full suite green.
- Multi-scenario harness (\`/tmp/mur-agent-harness/harness.py\`) — 7/7 office scenarios pass:
  - 6 echo-mode scenarios (single Q&A, FS-mediated pipeline, fan-out triage, accepts_from policy, heartbeat+restart, 50-msg backpressure)
  - 1 real-LLM scenario with llama3.2:3b: researcher (3 bullets) → summarizer (1 sentence) chain with files persisted to shared FS. Required E6 to produce the constrained output shape.
- Smoke: agent with \`--provider anthropic\` and no \`ANTHROPIC_API_KEY\` boots, warns, and falls back to echo as designed.
- Live calls against api.anthropic.com / api.openai.com were **not** exercised — no keys on this host. Wire-shape was hand-checked against the public API docs.

## Test plan

- [ ] CI green on this branch
- [ ] Live smoke against Anthropic (set ANTHROPIC_API_KEY, create agent, send) — leaves grace for reviewer with key
- [ ] Live smoke against an OpenAI-compatible endpoint (Together / Groq / etc.)
- [ ] Brew formula (\`mur-run/homebrew-tap\`) updated separately to ship \`mur-agent-runtime\` alongside \`mur\` (E1 deployment — out of scope for this repo)

## Related

This branch was generated as part of an autonomous \"harness engineering\" run that exercised the full \`mur agent\` CLI + runtime surface, accumulating errors before fixing them in batches. Full session log + scenario report: \`/tmp/mur-agent-harness/\` on the dev host (not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)