### PR TITLE
feat(server): /api/v1/agents/* read-only routes (Phase 4)

### DIFF
--- a/mur-agent-runtime/src/lock_file.rs
+++ b/mur-agent-runtime/src/lock_file.rs
@@ -67,19 +67,22 @@ pub fn read_lock(path: &Path) -> Result<LockFile, LockError> {
 /// A lock is stale if either
 /// (a) its pid is not alive, or
 /// (b) flock can be acquired (nobody's holding it).
+///
+/// Steps (a) uses `mur_common::lock_file::read` and `pid_alive` — the
+/// canonical single source of truth (closes #36). Step (b) (flock probe) is
+/// a stronger, runtime-specific check and stays local.
 pub fn is_stale(path: &Path) -> Result<bool, LockError> {
-    if !path.exists() {
-        return Ok(true);
-    }
-    let lock: LockFile = match read_lock(path) {
-        Ok(l) => l,
-        Err(_) => return Ok(true), // corrupt = stale
+    // Step (a): read + pid liveness via the canonical common helpers.
+    let lock = match mur_common::lock_file::read(path).map_err(LockError::Io)? {
+        None => return Ok(true), // no lock file → stale
+        Some(l) => l,
     };
-    if !pid_alive(lock.pid) {
+    if !mur_common::lock_file::pid_alive(lock.pid) {
         return Ok(true);
     }
-    // If this process owns the lock, flock on a fresh fd returns a misleading
-    // result on macOS/BSD (independent locks per open). Trust the pid.
+    // Step (b): flock probe — if this process owns the lock, flock on a
+    // fresh fd returns a misleading result on macOS/BSD (independent locks
+    // per open). Trust the pid in that case.
     if lock.pid == std::process::id() {
         return Ok(false);
     }
@@ -90,24 +93,4 @@ pub fn is_stale(path: &Path) -> Result<bool, LockError> {
         return Ok(true);
     }
     Ok(false)
-}
-
-#[cfg(unix)]
-fn pid_alive(pid: u32) -> bool {
-    // kill(pid, 0) checks existence without sending a signal.
-    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
-}
-
-#[cfg(windows)]
-fn pid_alive(pid: u32) -> bool {
-    use windows_sys::Win32::Foundation::CloseHandle;
-    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
-    unsafe {
-        let h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
-        if h.is_null() {
-            return false;
-        }
-        CloseHandle(h);
-        true
-    }
 }

--- a/mur-agent-runtime/tests/grace_cleanup.rs
+++ b/mur-agent-runtime/tests/grace_cleanup.rs
@@ -1,4 +1,9 @@
 //! M6.1 — agent-side grace expiry cleanup.
+//
+// Uses `std::os::unix::fs::PermissionsExt::set_mode` which is Unix-only.
+// Gate the whole file matching the pattern used by other Unix-only tests
+// in this crate (sigterm_shutdown, long_path, etc.).
+#![cfg(unix)]
 
 use mur_agent_runtime::supervisor::grace_cleanup_if_expired;
 use mur_common::agent::AgentProfile;

--- a/mur-common/Cargo.toml
+++ b/mur-common/Cargo.toml
@@ -23,5 +23,8 @@ x25519-dalek = { version = "2", features = ["static_secrets"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 multibase = "0.9"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation"] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/mur-common/src/agent_name.rs
+++ b/mur-common/src/agent_name.rs
@@ -1,0 +1,141 @@
+//! Canonical agent-name validation. Used by both `mur agent create` (CLI) and
+//! the `/api/v1/agents/{name}` HTTP routes so the two surfaces never disagree
+//! on what names are valid.
+
+use std::fmt;
+
+pub const MAX_AGENT_NAME_LEN: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentNameError {
+    Empty,
+    TooLong { max: usize, actual: usize },
+    InvalidChar(char),
+    LeadingDash,
+    ContainsTraversal,
+}
+
+impl fmt::Display for AgentNameError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "agent name must not be empty"),
+            Self::TooLong { max, actual } => {
+                write!(f, "agent name is {actual} chars; max is {max}")
+            }
+            Self::InvalidChar(c) => write!(
+                f,
+                "agent name contains invalid character {c:?} \
+                 (allowed: ASCII letters, digits, '-', '_')"
+            ),
+            Self::LeadingDash => write!(
+                f,
+                "agent name must not start with '-' (parses as a CLI flag)"
+            ),
+            Self::ContainsTraversal => {
+                write!(f, "agent name must not contain '..' (path traversal)")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AgentNameError {}
+
+/// Validate an agent name from any caller (HTTP path param, CLI argument,
+/// import file). Returns `Ok(())` if the name is safe to use as a directory
+/// component under `~/.mur/agents/`.
+pub fn validate_agent_name(name: &str) -> Result<(), AgentNameError> {
+    if name.is_empty() {
+        return Err(AgentNameError::Empty);
+    }
+    if name.len() > MAX_AGENT_NAME_LEN {
+        return Err(AgentNameError::TooLong {
+            max: MAX_AGENT_NAME_LEN,
+            actual: name.len(),
+        });
+    }
+    if name.starts_with('-') {
+        return Err(AgentNameError::LeadingDash);
+    }
+    if name.contains("..") {
+        return Err(AgentNameError::ContainsTraversal);
+    }
+    for c in name.chars() {
+        if !c.is_ascii_alphanumeric() && !matches!(c, '-' | '_') {
+            return Err(AgentNameError::InvalidChar(c));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_typical_names() {
+        for name in ["alpha", "support_bot", "agent-1", "research_v2", "a", "X"] {
+            assert!(
+                validate_agent_name(name).is_ok(),
+                "expected {name} to be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert_eq!(validate_agent_name(""), Err(AgentNameError::Empty));
+    }
+
+    #[test]
+    fn rejects_traversal() {
+        assert_eq!(
+            validate_agent_name(".."),
+            Err(AgentNameError::ContainsTraversal)
+        );
+        assert_eq!(
+            validate_agent_name("a..b"),
+            Err(AgentNameError::ContainsTraversal)
+        );
+    }
+
+    #[test]
+    fn rejects_path_separators_and_other_specials() {
+        for bad in ["a/b", "a\\b", "a b", "a.b", "a:b", "a$b", "a@b", "a\0b"] {
+            let err = validate_agent_name(bad).unwrap_err();
+            // Specifically expect InvalidChar (not Empty / TooLong / etc.)
+            assert!(
+                matches!(err, AgentNameError::InvalidChar(_)),
+                "expected InvalidChar for {bad:?}, got {err:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unicode_lookalikes() {
+        // Cyrillic 'а' (U+0430) vs ASCII 'a' (U+0061)
+        assert!(matches!(
+            validate_agent_name("аlpha").unwrap_err(),
+            AgentNameError::InvalidChar(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_leading_dash() {
+        assert_eq!(validate_agent_name("-rf"), Err(AgentNameError::LeadingDash));
+    }
+
+    #[test]
+    fn rejects_too_long() {
+        let long = "a".repeat(MAX_AGENT_NAME_LEN + 1);
+        assert!(matches!(
+            validate_agent_name(&long).unwrap_err(),
+            AgentNameError::TooLong { .. }
+        ));
+    }
+
+    #[test]
+    fn accepts_max_length() {
+        let max = "a".repeat(MAX_AGENT_NAME_LEN);
+        assert!(validate_agent_name(&max).is_ok());
+    }
+}

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod a2a;
 pub mod actor;
 pub mod agent;
+pub mod agent_name;
 pub mod config;
 pub mod conversation;
 pub mod error;
@@ -32,6 +33,7 @@ pub use agent::{
     FileTransferConfig, IdentityConfig, LockFile, Persona, PersonaCategory, RetryPolicy,
     ScheduleEntry,
 };
+pub use agent_name::{AgentNameError, MAX_AGENT_NAME_LEN, validate_agent_name};
 pub use identity::{
     AgentIdentity, ChainError, ChainOptions, ChainOutcome, IdentityError, RotationAttestation,
     RotationReason, decode_pubkey, encode_pubkey, verify_chain,

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod event;
 pub mod identity;
 pub mod knowledge;
 pub mod llm;
+pub mod lock_file;
 pub mod parameterize;
 pub mod pattern;
 pub mod pipeline;

--- a/mur-common/src/lock_file.rs
+++ b/mur-common/src/lock_file.rs
@@ -1,0 +1,223 @@
+//! Canonical `running.lock` reader + 3-state agent status classifier.
+//!
+//! Used by:
+//! - `mur agent list/status` (CLI) — see `mur-core/src/cmd/agent.rs`
+//! - `/api/v1/agents/*` (HTTP) — see `mur-core/src/server_agents/`
+//! - `mur-agent-runtime` supervisor — see `mur-agent-runtime/src/lock_file.rs`
+//!   (the runtime additionally uses `flock`; that check stays local)
+
+use crate::LockFile;
+use serde::Serialize;
+use std::path::Path;
+
+/// Three-state classification of an agent's runtime state.
+#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentStatusKind {
+    /// Lock present and the recorded pid is alive.
+    Running,
+    /// Lock present but the pid is not alive (crash/kill — orphan lock).
+    Stale,
+    /// No lock file.
+    Stopped,
+}
+
+/// Result of classifying an agent's lock state.
+#[derive(Debug, Clone, Copy)]
+pub struct AgentStatus {
+    pub kind: AgentStatusKind,
+    /// PID from the lock file. `None` when no lock or unparseable lock.
+    pub pid: Option<u32>,
+}
+
+/// Read and JSON-parse `<home>/running.lock`. Returns:
+/// - `Ok(None)` if the file does not exist (agent stopped).
+/// - `Ok(Some(_))` if the file exists and parses successfully.
+/// - `Err(_)` if the file exists but I/O fails or JSON is malformed.
+pub fn read(lock_path: &Path) -> std::io::Result<Option<LockFile>> {
+    let bytes = match std::fs::read(lock_path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    serde_json::from_slice(&bytes)
+        .map(Some)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+/// Is the given pid currently a live process the calling user can signal?
+///
+/// On Unix uses `kill(pid, 0)` — signal 0 is a no-op probe that checks
+/// process existence and permission without delivering any signal.
+///
+/// On Windows uses `OpenProcess` with `PROCESS_QUERY_LIMITED_INFORMATION`.
+///
+/// On other platforms returns `true` (optimistically treat any present lock
+/// as live, since P0a agents are not supported there).
+#[cfg(unix)]
+pub fn pid_alive(pid: u32) -> bool {
+    // SAFETY: kill(2) with signal 0 delivers no signal; it only checks
+    // process existence and our permission to signal it. Always safe to call.
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+#[cfg(windows)]
+pub fn pid_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+    unsafe {
+        let h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if h.is_null() {
+            return false;
+        }
+        CloseHandle(h);
+        true
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+pub fn pid_alive(_pid: u32) -> bool {
+    true
+}
+
+/// Classify the agent's running state by inspecting `<home>/running.lock`.
+///
+/// - No lock → `Stopped`
+/// - Lock present, parses, pid alive → `Running`
+/// - Lock present but pid not alive (crash / SIGKILL / OOM) → `Stale`
+/// - Lock present but unparseable / unreadable → `Stale` with `pid: None`
+///   (treat as stale rather than running so dashboards don't paint dead
+///   agents green)
+pub fn classify(lock_path: &Path) -> AgentStatus {
+    match read(lock_path) {
+        Ok(None) => AgentStatus {
+            kind: AgentStatusKind::Stopped,
+            pid: None,
+        },
+        Err(_) => AgentStatus {
+            kind: AgentStatusKind::Stale,
+            pid: None,
+        },
+        Ok(Some(lock)) => {
+            let kind = if pid_alive(lock.pid) {
+                AgentStatusKind::Running
+            } else {
+                AgentStatusKind::Stale
+            };
+            AgentStatus {
+                kind,
+                pid: Some(lock.pid),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::LockTransports;
+
+    fn make_lock(pid: u32) -> LockFile {
+        LockFile {
+            schema: 1,
+            uuid: "01JQX4TM8Y9K7VQH6B2N3R5DPE".into(),
+            name: "agent_a".into(),
+            pid,
+            ppid: 1,
+            started_at: "2026-04-22T08:00:00Z".into(),
+            binary_version: "mur-agent-runtime 0.1.0".into(),
+            transports: LockTransports {
+                stdio: false,
+                unix_socket: Some("/tmp/x.sock".into()),
+                tcp: None,
+            },
+            card_digest: "sha256:abc".into(),
+            capabilities: vec!["a2a.message.send".into()],
+        }
+    }
+
+    fn write_lock_file(dir: &std::path::Path, pid: u32) -> std::path::PathBuf {
+        let path = dir.join("running.lock");
+        let lock = make_lock(pid);
+        std::fs::write(&path, serde_json::to_vec_pretty(&lock).unwrap()).unwrap();
+        path
+    }
+
+    #[test]
+    fn classify_returns_stopped_when_no_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_path = tmp.path().join("running.lock");
+        let status = classify(&lock_path);
+        assert_eq!(status.kind, AgentStatusKind::Stopped);
+        assert_eq!(status.pid, None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_returns_running_when_pid_alive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_path = write_lock_file(tmp.path(), std::process::id());
+        let status = classify(&lock_path);
+        assert_eq!(status.kind, AgentStatusKind::Running);
+        assert_eq!(status.pid, Some(std::process::id()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_returns_stale_when_pid_dead() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dead_pid: u32 = 999_999;
+        let lock_path = write_lock_file(tmp.path(), dead_pid);
+        let status = classify(&lock_path);
+        assert_eq!(status.kind, AgentStatusKind::Stale);
+        assert_eq!(status.pid, Some(dead_pid));
+    }
+
+    #[test]
+    fn classify_returns_stale_when_lock_malformed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_path = tmp.path().join("running.lock");
+        std::fs::write(&lock_path, b"not json").unwrap();
+        let status = classify(&lock_path);
+        assert_eq!(status.kind, AgentStatusKind::Stale);
+        assert_eq!(status.pid, None);
+    }
+
+    #[test]
+    fn read_returns_none_for_missing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_path = tmp.path().join("running.lock");
+        let result = read(&lock_path).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn read_returns_ok_for_valid_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_path = write_lock_file(tmp.path(), 42);
+        let result = read(&lock_path).unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().pid, 42);
+    }
+
+    #[test]
+    fn read_returns_err_for_malformed_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lock_path = tmp.path().join("running.lock");
+        std::fs::write(&lock_path, b"not json").unwrap();
+        let result = read(&lock_path);
+        assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pid_alive_returns_true_for_self() {
+        assert!(pid_alive(std::process::id()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pid_alive_returns_false_for_dead_pid() {
+        assert!(!pid_alive(999_999));
+    }
+}

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -81,3 +81,5 @@ tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 wiremock = "0.6"
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "handshake"] }
+futures-util = "0.3"

--- a/mur-core/src/cmd/agent.rs
+++ b/mur-core/src/cmd/agent.rs
@@ -167,13 +167,7 @@ pub fn cmd_create(
 }
 
 fn validate_name(name: &str) -> Result<()> {
-    if name.is_empty() {
-        bail!("agent name must not be empty");
-    }
-    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
-        bail!("agent name must match [A-Za-z0-9_]+");
-    }
-    Ok(())
+    mur_common::validate_agent_name(name).with_context(|| format!("invalid agent name {name:?}"))
 }
 
 fn resolve_mur_home() -> Result<PathBuf> {

--- a/mur-core/src/cmd/agent.rs
+++ b/mur-core/src/cmd/agent.rs
@@ -344,40 +344,42 @@ fn collect_agents() -> Result<Vec<AgentRow>> {
     Ok(rows)
 }
 
+/// Classify an agent lock for the CLI table display.
+///
+/// Returns `(status_str, pid, uptime)`. Delegates to
+/// `mur_common::lock_file::classify` for the 3-state liveness logic and
+/// adds uptime computation (CLI-specific) on top.
 fn classify(lock_path: &Path) -> (&'static str, Option<u32>, Option<String>) {
-    if !lock_path.exists() {
-        return ("stopped", None, None);
-    }
-    let bytes = match fs::read(lock_path) {
-        Ok(b) => b,
-        Err(_) => return ("stale", None, None),
+    use mur_common::lock_file::AgentStatusKind;
+    let status = mur_common::lock_file::classify(lock_path);
+    let status_str = match status.kind {
+        AgentStatusKind::Running => "running",
+        AgentStatusKind::Stale => "stale",
+        AgentStatusKind::Stopped => "stopped",
     };
-    let lock: LockFile = match serde_json::from_slice(&bytes) {
-        Ok(l) => l,
-        Err(_) => return ("stale", None, None),
+    // Compute uptime from the lock file's started_at only when running.
+    let uptime = if status.kind == AgentStatusKind::Running {
+        mur_common::lock_file::read(lock_path)
+            .ok()
+            .flatten()
+            .and_then(|lock| chrono::DateTime::parse_from_rfc3339(&lock.started_at).ok())
+            .map(|start| {
+                let secs = (chrono::Utc::now() - start.with_timezone(&chrono::Utc))
+                    .num_seconds()
+                    .max(0);
+                format!("{}s", secs)
+            })
+    } else {
+        None
     };
-    if !pid_alive(lock.pid) {
-        return ("stale", Some(lock.pid), None);
-    }
-    let uptime = chrono::DateTime::parse_from_rfc3339(&lock.started_at)
-        .ok()
-        .map(|start| {
-            let secs = (chrono::Utc::now() - start.with_timezone(&chrono::Utc))
-                .num_seconds()
-                .max(0);
-            format!("{}s", secs)
-        });
-    ("running", Some(lock.pid), uptime)
+    (status_str, status.pid, uptime)
 }
 
-#[cfg(unix)]
+/// Liveness probe for a pid. Delegates to the canonical implementation in
+/// `mur_common::lock_file` so stop/remove/rename guards share the same logic
+/// as classify().
 fn pid_alive(pid: u32) -> bool {
-    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
-}
-
-#[cfg(not(unix))]
-fn pid_alive(_pid: u32) -> bool {
-    false
+    mur_common::lock_file::pid_alive(pid)
 }
 
 // ─── stop / remove / rename ──────────────────────────────────────────────

--- a/mur-core/src/cmd/server_cmd.rs
+++ b/mur-core/src/cmd/server_cmd.rs
@@ -10,6 +10,7 @@ pub(crate) async fn cmd_serve(port: u16, open: bool, readonly: bool) -> Result<(
         patterns_dir: mur_dir.join("patterns"),
         workflows_dir: mur_dir.join("workflows"),
         pipelines_dir: mur_dir.join("pipelines"),
+        agents_dir: mur_dir.join("agents"),
         index_dir: mur_dir.join("index"),
         config: crate::server::ServerConfig { readonly },
         events_tx,

--- a/mur-core/src/lib.rs
+++ b/mur-core/src/lib.rs
@@ -30,6 +30,8 @@ pub mod yaml_edit;
 
 #[cfg(feature = "server")]
 pub mod server;
+#[cfg(feature = "server")]
+pub mod server_agents;
 
 pub use mur_common::config::Config;
 pub use mur_common::event::MurEvent;

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -20,6 +20,7 @@ mod llm;
 mod paths;
 mod retrieve;
 mod server;
+#[cfg(feature = "server")]
 mod server_agents;
 mod session;
 #[cfg(feature = "sources")]

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -20,6 +20,7 @@ mod llm;
 mod paths;
 mod retrieve;
 mod server;
+mod server_agents;
 mod session;
 #[cfg(feature = "sources")]
 mod sources;

--- a/mur-core/src/server.rs
+++ b/mur-core/src/server.rs
@@ -3,6 +3,7 @@
 //! Exposes the pattern and workflow stores over HTTP so the web dashboard
 //! (mur.run SPA or localhost dev) can read and write data.
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -247,7 +248,11 @@ pub async fn run_server(
         }
     }
 
-    axum::serve(listener, app).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await?;
     Ok(())
 }
 

--- a/mur-core/src/server.rs
+++ b/mur-core/src/server.rs
@@ -64,6 +64,7 @@ pub struct AppState {
     pub workflows_dir: PathBuf,
     pub pipelines_dir: PathBuf,
     /// `~/.mur/agents/` — root for per-agent profiles, telemetry, evals.
+    #[allow(dead_code)]
     pub agents_dir: PathBuf,
     /// Path to the LanceDB vector index (`~/.mur/index`).
     /// When present the context endpoint uses hybrid scoring.

--- a/mur-core/src/server.rs
+++ b/mur-core/src/server.rs
@@ -64,7 +64,6 @@ pub struct AppState {
     pub workflows_dir: PathBuf,
     pub pipelines_dir: PathBuf,
     /// `~/.mur/agents/` — root for per-agent profiles, telemetry, evals.
-    #[allow(dead_code)]
     pub agents_dir: PathBuf,
     /// Path to the LanceDB vector index (`~/.mur/index`).
     /// When present the context endpoint uses hybrid scoring.

--- a/mur-core/src/server.rs
+++ b/mur-core/src/server.rs
@@ -63,6 +63,8 @@ pub struct AppState {
     pub patterns_dir: PathBuf,
     pub workflows_dir: PathBuf,
     pub pipelines_dir: PathBuf,
+    /// `~/.mur/agents/` — root for per-agent profiles, telemetry, evals.
+    pub agents_dir: PathBuf,
     /// Path to the LanceDB vector index (`~/.mur/index`).
     /// When present the context endpoint uses hybrid scoring.
     pub index_dir: PathBuf,
@@ -205,6 +207,8 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/rates/{currency}", get(get_rate))
         // WebSocket for real-time events
         .route("/api/v1/ws", get(ws_handler))
+        // Agents (Phase 4 read-only routes)
+        .nest("/api/v1/agents", crate::server_agents::router())
         .layer(cors)
         .with_state(Arc::new(state))
         // Fallback: serve embedded web UI
@@ -1498,15 +1502,18 @@ mod tests {
         let patterns_dir = tmp.path().join("patterns");
         let workflows_dir = tmp.path().join("workflows");
         let pipelines_dir = tmp.path().join("pipelines");
+        let agents_dir = tmp.path().join("agents");
         let index_dir = tmp.path().join("index"); // non-existent → keyword-only fallback
         std::fs::create_dir_all(&patterns_dir).unwrap();
         std::fs::create_dir_all(&workflows_dir).unwrap();
         std::fs::create_dir_all(&pipelines_dir).unwrap();
+        std::fs::create_dir_all(&agents_dir).unwrap();
         let (events_tx, _) = broadcast::channel(64);
         AppState {
             patterns_dir,
             workflows_dir,
             pipelines_dir,
+            agents_dir,
             index_dir,
             config: ServerConfig { readonly: false },
             events_tx,
@@ -2204,5 +2211,25 @@ mod tests {
             .unwrap();
 
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn test_agents_router_mounted_returns_404_for_unknown_subpath() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = build_router(test_state(&tmp));
+
+        // /api/v1/agents/__nope__ should resolve into the agents subrouter
+        // (and fall through to a 404), proving the nested router is mounted.
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/__nope__/__nope__")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/mur-core/src/server_agents/detail.rs
+++ b/mur-core/src/server_agents/detail.rs
@@ -8,15 +8,17 @@ use serde::Serialize;
 
 use crate::server::{AppError, AppState};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, Clone)]
 pub struct AgentDetail {
     pub profile: mur_common::AgentProfile,
     pub status: AgentStatus,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, Clone)]
 pub struct AgentStatus {
-    pub running: bool,
+    /// One of: `"running"`, `"stale"`, `"stopped"`.
+    pub status: super::AgentStatusKind,
+    /// PID from the lock file. None when no lock or unparseable lock.
     pub pid: Option<u32>,
 }
 
@@ -46,14 +48,14 @@ pub async fn handler(
         )
     })?;
 
-    let pid = std::fs::read_to_string(home.join("running.lock"))
-        .ok()
-        .and_then(|s| s.trim().parse::<u32>().ok());
-    let running = super::is_running(&home);
+    let status = super::agent_status(&home);
 
     Ok(Json(AgentDetail {
         profile,
-        status: AgentStatus { running, pid },
+        status: AgentStatus {
+            status: status.kind,
+            pid: status.pid,
+        },
     }))
 }
 
@@ -79,13 +81,24 @@ mod tests {
         }
     }
 
+    /// Build a minimal but valid `LockFile` with the given pid.
+    fn make_lock(pid: u32) -> mur_common::LockFile {
+        super::super::list::tests::make_lock(pid, "alpha")
+    }
+
     #[tokio::test]
     async fn detail_returns_full_profile_and_status() {
         let tmp = tempfile::tempdir().unwrap();
         let state = build_state(&tmp);
         let home = state.agents_dir.join("alpha");
         super::super::list::tests::write_min_profile(&home, "alpha", "Alpha Bot");
-        std::fs::write(home.join("running.lock"), "9999").unwrap();
+        // Use the current process's PID so the liveness check succeeds.
+        let lock = make_lock(std::process::id());
+        std::fs::write(
+            home.join("running.lock"),
+            serde_json::to_vec_pretty(&lock).unwrap(),
+        )
+        .unwrap();
 
         let app = build_router(state);
         let resp = app
@@ -104,8 +117,88 @@ mod tests {
         assert_eq!(json["profile"]["name"], "alpha");
         assert_eq!(json["profile"]["display_name"], "Alpha Bot");
         assert_eq!(json["profile"]["model"]["provider"], "ollama");
-        assert_eq!(json["status"]["running"], true);
-        assert_eq!(json["status"]["pid"], 9999);
+        assert_eq!(json["status"]["status"], "running");
+        assert_eq!(json["status"]["pid"], std::process::id());
+    }
+
+    #[tokio::test]
+    async fn detail_reports_stale_when_pid_not_alive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+        // PID 999_999 is almost certainly dead on any real host.
+        let dead_pid: u32 = 999_999;
+        let lock = make_lock(dead_pid);
+        std::fs::write(
+            home.join("running.lock"),
+            serde_json::to_vec_pretty(&lock).unwrap(),
+        )
+        .unwrap();
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/alpha")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["status"]["status"], "stale");
+        assert_eq!(json["status"]["pid"], dead_pid);
+    }
+
+    #[tokio::test]
+    async fn detail_reports_stopped_when_no_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+        // No running.lock written.
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/alpha")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["status"]["status"], "stopped");
+        assert_eq!(json["status"]["pid"], serde_json::Value::Null);
+    }
+
+    #[tokio::test]
+    async fn detail_reports_stale_when_lock_is_malformed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+        // Plain integer (the OLD broken format) is now malformed → stale.
+        std::fs::write(home.join("running.lock"), "9999").unwrap();
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/alpha")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["status"]["status"], "stale");
+        assert_eq!(json["status"]["pid"], serde_json::Value::Null);
     }
 
     #[tokio::test]

--- a/mur-core/src/server_agents/detail.rs
+++ b/mur-core/src/server_agents/detail.rs
@@ -1,0 +1,1 @@
+//! `GET /api/v1/agents/{name}` — full profile + status.

--- a/mur-core/src/server_agents/detail.rs
+++ b/mur-core/src/server_agents/detail.rs
@@ -46,11 +46,10 @@ pub async fn handler(
                 .context(format!("parse {}", profile_path.display())),
         ))?;
 
-    let lock_path = home.join("running.lock");
-    let pid = std::fs::read_to_string(&lock_path)
+    let pid = std::fs::read_to_string(home.join("running.lock"))
         .ok()
         .and_then(|s| s.trim().parse::<u32>().ok());
-    let running = lock_path.exists();
+    let running = super::is_running(&home);
 
     Ok(Json(AgentDetail {
         profile,

--- a/mur-core/src/server_agents/detail.rs
+++ b/mur-core/src/server_agents/detail.rs
@@ -1,1 +1,117 @@
 //! `GET /api/v1/agents/{name}` — full profile + status.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use serde::Serialize;
+
+use crate::server::{AppError, AppState};
+
+#[derive(Serialize)]
+pub struct AgentDetail {
+    pub profile: mur_common::AgentProfile,
+    pub status: AgentStatus,
+}
+
+#[derive(Serialize)]
+pub struct AgentStatus {
+    pub running: bool,
+    pub pid: Option<u32>,
+}
+
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> Result<Json<AgentDetail>, AppError> {
+    let home = super::agent_home(&state.agents_dir, &name);
+    let profile_path = home.join("profile.yaml");
+
+    let yaml = match std::fs::read_to_string(&profile_path) {
+        Ok(y) => y,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(AppError::NotFound(format!("agent '{name}' not found")));
+        }
+        Err(e) => {
+            return Err(AppError::Internal(
+                anyhow::Error::from(e)
+                    .context(format!("read {}", profile_path.display())),
+            ));
+        }
+    };
+
+    let profile: mur_common::AgentProfile = serde_yaml_ng::from_str(&yaml)
+        .map_err(|e| AppError::Internal(
+            anyhow::Error::from(e)
+                .context(format!("parse {}", profile_path.display())),
+        ))?;
+
+    let lock_path = home.join("running.lock");
+    let pid = std::fs::read_to_string(&lock_path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok());
+    let running = lock_path.exists();
+
+    Ok(Json(AgentDetail {
+        profile,
+        status: AgentStatus { running, pid },
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::server::{AppState, ServerConfig, build_router};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    fn build_state(tmp: &tempfile::TempDir) -> AppState {
+        let agents_dir = tmp.path().join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        AppState {
+            patterns_dir: tmp.path().join("patterns"),
+            workflows_dir: tmp.path().join("workflows"),
+            pipelines_dir: tmp.path().join("pipelines"),
+            agents_dir,
+            index_dir: tmp.path().join("index"),
+            config: ServerConfig { readonly: false },
+            events_tx: tokio::sync::broadcast::channel(64).0,
+        }
+    }
+
+    #[tokio::test]
+    async fn detail_returns_full_profile_and_status() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha Bot");
+        std::fs::write(home.join("running.lock"), "9999").unwrap();
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(Request::builder().uri("/api/v1/agents/alpha").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["profile"]["name"], "alpha");
+        assert_eq!(json["profile"]["display_name"], "Alpha Bot");
+        assert_eq!(json["profile"]["model"]["provider"], "ollama");
+        assert_eq!(json["status"]["running"], true);
+        assert_eq!(json["status"]["pid"], 9999);
+    }
+
+    #[tokio::test]
+    async fn detail_returns_404_for_unknown_agent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = build_router(build_state(&tmp));
+        let resp = app
+            .oneshot(Request::builder().uri("/api/v1/agents/ghost").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/mur-core/src/server_agents/detail.rs
+++ b/mur-core/src/server_agents/detail.rs
@@ -34,17 +34,16 @@ pub async fn handler(
         }
         Err(e) => {
             return Err(AppError::Internal(
-                anyhow::Error::from(e)
-                    .context(format!("read {}", profile_path.display())),
+                anyhow::Error::from(e).context(format!("read {}", profile_path.display())),
             ));
         }
     };
 
-    let profile: mur_common::AgentProfile = serde_yaml_ng::from_str(&yaml)
-        .map_err(|e| AppError::Internal(
-            anyhow::Error::from(e)
-                .context(format!("parse {}", profile_path.display())),
-        ))?;
+    let profile: mur_common::AgentProfile = serde_yaml_ng::from_str(&yaml).map_err(|e| {
+        AppError::Internal(
+            anyhow::Error::from(e).context(format!("parse {}", profile_path.display())),
+        )
+    })?;
 
     let pid = std::fs::read_to_string(home.join("running.lock"))
         .ok()
@@ -89,7 +88,12 @@ mod tests {
 
         let app = build_router(state);
         let resp = app
-            .oneshot(Request::builder().uri("/api/v1/agents/alpha").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/alpha")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
 
@@ -108,7 +112,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let app = build_router(build_state(&tmp));
         let resp = app
-            .oneshot(Request::builder().uri("/api/v1/agents/ghost").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/ghost")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);

--- a/mur-core/src/server_agents/detail.rs
+++ b/mur-core/src/server_agents/detail.rs
@@ -24,6 +24,7 @@ pub async fn handler(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<AgentDetail>, AppError> {
+    super::validate_agent_name(&name)?;
     let home = super::agent_home(&state.agents_dir, &name);
     let profile_path = home.join("profile.yaml");
 
@@ -121,5 +122,21 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn detail_rejects_path_traversal_in_agent_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = build_router(build_state(&tmp));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/..")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/mur-core/src/server_agents/evals.rs
+++ b/mur-core/src/server_agents/evals.rs
@@ -1,0 +1,1 @@
+//! `GET /api/v1/agents/{name}/evals[/{run_id}]`.

--- a/mur-core/src/server_agents/evals.rs
+++ b/mur-core/src/server_agents/evals.rs
@@ -52,13 +52,27 @@ pub async fn list_handler(
             Ok(v) => v,
             Err(_) => continue,
         };
-        let run_id = v.get("run_id").and_then(|s| s.as_str()).unwrap_or("").to_string();
+        let run_id = v
+            .get("run_id")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_string();
         if run_id.is_empty() {
             continue;
         }
-        let suite = v.get("suite").and_then(|s| s.as_str()).unwrap_or("").to_string();
-        let started_at = v.get("started_at").and_then(|s| s.as_str()).map(String::from);
-        let finished_at = v.get("finished_at").and_then(|s| s.as_str()).map(String::from);
+        let suite = v
+            .get("suite")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_string();
+        let started_at = v
+            .get("started_at")
+            .and_then(|s| s.as_str())
+            .map(String::from);
+        let finished_at = v
+            .get("finished_at")
+            .and_then(|s| s.as_str())
+            .map(String::from);
         let summary = v.get("summary").cloned().unwrap_or(serde_json::json!({}));
         out.push(EvalRunSummary {
             run_id,
@@ -136,12 +150,7 @@ pub(crate) mod tests {
         }
     }
 
-    pub(crate) fn write_eval(
-        home: &std::path::Path,
-        run_id: &str,
-        suite: &str,
-        started_at: &str,
-    ) {
+    pub(crate) fn write_eval(home: &std::path::Path, run_id: &str, suite: &str, started_at: &str) {
         let dir = home.join("evals");
         std::fs::create_dir_all(&dir).unwrap();
         let body = serde_json::json!({
@@ -167,13 +176,26 @@ pub(crate) mod tests {
         let state = build_state(&tmp);
         let home = state.agents_dir.join("alpha");
         super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
-        write_eval(&home, "eval-20260427T100000-aaaa", "v1", "2026-04-27T10:00:00Z");
-        write_eval(&home, "eval-20260428T072501-bbbb", "v1", "2026-04-28T07:25:01Z");
+        write_eval(
+            &home,
+            "eval-20260427T100000-aaaa",
+            "v1",
+            "2026-04-27T10:00:00Z",
+        );
+        write_eval(
+            &home,
+            "eval-20260428T072501-bbbb",
+            "v1",
+            "2026-04-28T07:25:01Z",
+        );
 
         let app = build_router(state);
         let resp = app
             .oneshot(
-                Request::builder().uri("/api/v1/agents/alpha/evals").body(Body::empty()).unwrap(),
+                Request::builder()
+                    .uri("/api/v1/agents/alpha/evals")
+                    .body(Body::empty())
+                    .unwrap(),
             )
             .await
             .unwrap();
@@ -198,7 +220,10 @@ pub(crate) mod tests {
         let app = build_router(state);
         let resp = app
             .oneshot(
-                Request::builder().uri("/api/v1/agents/alpha/evals").body(Body::empty()).unwrap(),
+                Request::builder()
+                    .uri("/api/v1/agents/alpha/evals")
+                    .body(Body::empty())
+                    .unwrap(),
             )
             .await
             .unwrap();
@@ -215,7 +240,12 @@ pub(crate) mod tests {
         let state = build_state(&tmp);
         let home = state.agents_dir.join("alpha");
         super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
-        write_eval(&home, "eval-20260428T072501-bbbb", "v1", "2026-04-28T07:25:01Z");
+        write_eval(
+            &home,
+            "eval-20260428T072501-bbbb",
+            "v1",
+            "2026-04-28T07:25:01Z",
+        );
 
         let app = build_router(state);
         let resp = app

--- a/mur-core/src/server_agents/evals.rs
+++ b/mur-core/src/server_agents/evals.rs
@@ -68,7 +68,11 @@ pub async fn list_handler(
             summary,
         });
     }
-    // run_id starts with `eval-<TIMESTAMP>-<HASH>`; lex sort = chronological.
+    // run_id format is `eval-<ISO8601-no-separators>-<HASH>` (e.g.
+    // `eval-20260428T072501-bbbb`). Because the timestamp prefix uses a
+    // fixed-width sortable encoding, lexicographic order matches chronological
+    // order. Reverse cmp = newest first. Files with malformed run_id are
+    // already skipped above.
     out.sort_by(|a, b| b.run_id.cmp(&a.run_id));
 
     Ok(Json(out))

--- a/mur-core/src/server_agents/evals.rs
+++ b/mur-core/src/server_agents/evals.rs
@@ -78,6 +78,42 @@ pub async fn list_handler(
     Ok(Json(out))
 }
 
+pub async fn detail_handler(
+    State(state): State<Arc<AppState>>,
+    Path((name, run_id)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    // run_id is used as a filename — reject anything that could escape the
+    // evals/ directory (path separators, '..', null bytes, etc.).
+    let safe = !run_id.is_empty()
+        && run_id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'));
+    if !safe || run_id.contains("..") {
+        return Err(AppError::BadRequest("invalid run_id".to_string()));
+    }
+
+    let home = super::agent_home(&state.agents_dir, &name);
+    let path = home.join("evals").join(format!("{run_id}.json"));
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(AppError::NotFound(format!("eval '{run_id}' not found")));
+        }
+        Err(e) => {
+            return Err(AppError::Internal(
+                anyhow::Error::from(e).context(format!("read {}", path.display())),
+            ));
+        }
+    };
+    let v: serde_json::Value = serde_json::from_slice(&bytes).map_err(|e| {
+        AppError::Internal(
+            anyhow::Error::from(e).context(format!("parse eval json {}", path.display())),
+        )
+    })?;
+
+    Ok(Json(v))
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::server::{AppState, ServerConfig, build_router};
@@ -171,5 +207,75 @@ pub(crate) mod tests {
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(json, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn detail_eval_returns_full_run_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+        write_eval(&home, "eval-20260428T072501-bbbb", "v1", "2026-04-28T07:25:01Z");
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/alpha/evals/eval-20260428T072501-bbbb")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["run_id"], "eval-20260428T072501-bbbb");
+        assert_eq!(json["suite"], "v1");
+        assert!(json.get("results").is_some());
+        assert!(json.get("summary").is_some());
+    }
+
+    #[tokio::test]
+    async fn detail_eval_returns_404_for_unknown_run() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/alpha/evals/ghost-run")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn detail_eval_rejects_path_traversal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/alpha/evals/..%2F..%2Fetc%2Fpasswd")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/mur-core/src/server_agents/evals.rs
+++ b/mur-core/src/server_agents/evals.rs
@@ -21,6 +21,7 @@ pub async fn list_handler(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<Vec<EvalRunSummary>>, AppError> {
+    super::validate_agent_name(&name)?;
     let home = super::agent_home(&state.agents_dir, &name);
     if !home.exists() {
         return Err(AppError::NotFound(format!("agent '{name}' not found")));
@@ -96,6 +97,7 @@ pub async fn detail_handler(
     State(state): State<Arc<AppState>>,
     Path((name, run_id)): Path<(String, String)>,
 ) -> Result<Json<serde_json::Value>, AppError> {
+    super::validate_agent_name(&name)?;
     // run_id is used as a filename — reject anything that could escape the
     // evals/ directory (path separators, '..', null bytes, etc.).
     let safe = !run_id.is_empty()

--- a/mur-core/src/server_agents/evals.rs
+++ b/mur-core/src/server_agents/evals.rs
@@ -1,1 +1,171 @@
 //! `GET /api/v1/agents/{name}/evals[/{run_id}]`.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use serde::Serialize;
+
+use crate::server::{AppError, AppState};
+
+#[derive(Serialize)]
+pub struct EvalRunSummary {
+    pub run_id: String,
+    pub suite: String,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    pub summary: serde_json::Value,
+}
+
+pub async fn list_handler(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+) -> Result<Json<Vec<EvalRunSummary>>, AppError> {
+    let home = super::agent_home(&state.agents_dir, &name);
+    if !home.exists() {
+        return Err(AppError::NotFound(format!("agent '{name}' not found")));
+    }
+    let dir = home.join("evals");
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(it) => it,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Json(Vec::new()));
+        }
+        Err(e) => {
+            return Err(AppError::Internal(
+                anyhow::Error::from(e).context(format!("read_dir {}", dir.display())),
+            ));
+        }
+    };
+
+    let mut out: Vec<EvalRunSummary> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let v: serde_json::Value = match serde_json::from_slice(&bytes) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let run_id = v.get("run_id").and_then(|s| s.as_str()).unwrap_or("").to_string();
+        if run_id.is_empty() {
+            continue;
+        }
+        let suite = v.get("suite").and_then(|s| s.as_str()).unwrap_or("").to_string();
+        let started_at = v.get("started_at").and_then(|s| s.as_str()).map(String::from);
+        let finished_at = v.get("finished_at").and_then(|s| s.as_str()).map(String::from);
+        let summary = v.get("summary").cloned().unwrap_or(serde_json::json!({}));
+        out.push(EvalRunSummary {
+            run_id,
+            suite,
+            started_at,
+            finished_at,
+            summary,
+        });
+    }
+    // run_id starts with `eval-<TIMESTAMP>-<HASH>`; lex sort = chronological.
+    out.sort_by(|a, b| b.run_id.cmp(&a.run_id));
+
+    Ok(Json(out))
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use crate::server::{AppState, ServerConfig, build_router};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    pub(crate) fn build_state(tmp: &tempfile::TempDir) -> AppState {
+        let agents_dir = tmp.path().join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        AppState {
+            patterns_dir: tmp.path().join("patterns"),
+            workflows_dir: tmp.path().join("workflows"),
+            pipelines_dir: tmp.path().join("pipelines"),
+            agents_dir,
+            index_dir: tmp.path().join("index"),
+            config: ServerConfig { readonly: false },
+            events_tx: tokio::sync::broadcast::channel(64).0,
+        }
+    }
+
+    pub(crate) fn write_eval(
+        home: &std::path::Path,
+        run_id: &str,
+        suite: &str,
+        started_at: &str,
+    ) {
+        let dir = home.join("evals");
+        std::fs::create_dir_all(&dir).unwrap();
+        let body = serde_json::json!({
+            "run_id": run_id,
+            "suite": suite,
+            "agent": "alpha",
+            "started_at": started_at,
+            "finished_at": started_at,
+            "matrix": {"providers": [], "system_prompts": []},
+            "results": [],
+            "summary": {"total": 0, "passed": 0, "failed": 0}
+        });
+        std::fs::write(
+            dir.join(format!("{run_id}.json")),
+            serde_json::to_vec_pretty(&body).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_evals_returns_run_summaries_newest_first() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+        write_eval(&home, "eval-20260427T100000-aaaa", "v1", "2026-04-27T10:00:00Z");
+        write_eval(&home, "eval-20260428T072501-bbbb", "v1", "2026-04-28T07:25:01Z");
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder().uri("/api/v1/agents/alpha/evals").body(Body::empty()).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let arr = json.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["run_id"], "eval-20260428T072501-bbbb"); // newest first
+        assert_eq!(arr[1]["run_id"], "eval-20260427T100000-aaaa");
+        assert_eq!(arr[0]["suite"], "v1");
+    }
+
+    #[tokio::test]
+    async fn list_evals_returns_empty_when_no_evals_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder().uri("/api/v1/agents/alpha/evals").body(Body::empty()).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json, serde_json::json!([]));
+    }
+}

--- a/mur-core/src/server_agents/list.rs
+++ b/mur-core/src/server_agents/list.rs
@@ -25,8 +25,7 @@ pub async fn handler(
         }
         Err(e) => {
             return Err(AppError::Internal(
-                anyhow::Error::from(e)
-                    .context(format!("read_dir {}", state.agents_dir.display())),
+                anyhow::Error::from(e).context(format!("read_dir {}", state.agents_dir.display())),
             ));
         }
     };
@@ -103,13 +102,22 @@ pub(crate) mod tests {
             config: crate::server::ServerConfig { readonly: false },
             events_tx: tokio::sync::broadcast::channel(64).0,
         };
-        for d in [&state.patterns_dir, &state.workflows_dir, &state.pipelines_dir] {
+        for d in [
+            &state.patterns_dir,
+            &state.workflows_dir,
+            &state.pipelines_dir,
+        ] {
             std::fs::create_dir_all(d).unwrap();
         }
 
         let app = build_router(state);
         let resp = app
-            .oneshot(Request::builder().uri("/api/v1/agents").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
 

--- a/mur-core/src/server_agents/list.rs
+++ b/mur-core/src/server_agents/list.rs
@@ -8,11 +8,11 @@ use serde::Serialize;
 
 use crate::server::{AppError, AppState};
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug, Clone)]
 pub struct AgentListEntry {
     pub name: String,
     pub display_name: String,
-    pub running: bool,
+    pub status: super::AgentStatusKind,
 }
 
 pub async fn handler(
@@ -48,7 +48,7 @@ pub async fn handler(
         out.push(AgentListEntry {
             name: profile.name,
             display_name: profile.display_name,
-            running: super::is_running(&path),
+            status: super::agent_status(&path).kind,
         });
     }
     out.sort_by(|a, b| a.name.cmp(&b.name));
@@ -83,14 +83,39 @@ pub(crate) mod tests {
         std::fs::write(dir.join("profile.yaml"), yaml).unwrap();
     }
 
+    /// Build a minimal but valid `LockFile` with the given pid.
+    pub(crate) fn make_lock(pid: u32, name: &str) -> mur_common::LockFile {
+        mur_common::LockFile {
+            schema: 1,
+            uuid: "0192f5a1-28ab-7111-8000-000000000001".to_string(),
+            name: name.to_string(),
+            pid,
+            ppid: 1,
+            started_at: "2026-04-28T10:00:00Z".to_string(),
+            binary_version: "0.1.0".to_string(),
+            transports: mur_common::agent::LockTransports {
+                stdio: true,
+                unix_socket: None,
+                tcp: None,
+            },
+            card_digest: "sha256:abc123".to_string(),
+            capabilities: vec!["a2a.message.send".to_string()],
+        }
+    }
+
     #[tokio::test]
-    async fn list_returns_known_agents_with_running_flag() {
+    async fn list_returns_known_agents_with_status() {
         let tmp = tempfile::tempdir().unwrap();
         let agents_dir = tmp.path().join("agents");
         write_min_profile(&agents_dir.join("alpha"), "alpha", "Alpha Bot");
         write_min_profile(&agents_dir.join("beta"), "beta", "Beta Bot");
-        // alpha is "running" — touch the lock file
-        std::fs::write(agents_dir.join("alpha").join("running.lock"), "1234").unwrap();
+        // alpha is "running" — write a real LockFile JSON using the current process's pid.
+        let lock = make_lock(std::process::id(), "alpha");
+        std::fs::write(
+            agents_dir.join("alpha").join("running.lock"),
+            serde_json::to_vec_pretty(&lock).unwrap(),
+        )
+        .unwrap();
 
         // Build state pointing at this temp agents dir
         let state = crate::server::AppState {
@@ -129,9 +154,9 @@ pub(crate) mod tests {
 
         let alpha = arr.iter().find(|a| a["name"] == "alpha").unwrap();
         assert_eq!(alpha["display_name"], "Alpha Bot");
-        assert_eq!(alpha["running"], true);
+        assert_eq!(alpha["status"], "running");
 
         let beta = arr.iter().find(|a| a["name"] == "beta").unwrap();
-        assert_eq!(beta["running"], false);
+        assert_eq!(beta["status"], "stopped");
     }
 }

--- a/mur-core/src/server_agents/list.rs
+++ b/mur-core/src/server_agents/list.rs
@@ -58,14 +58,14 @@ pub async fn handler(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use crate::server::build_router;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
-    fn write_min_profile(dir: &std::path::Path, name: &str, display: &str) {
+    pub(crate) fn write_min_profile(dir: &std::path::Path, name: &str, display: &str) {
         std::fs::create_dir_all(dir).unwrap();
         let id_suffix = name.bytes().fold(0u64, |a, b| a.wrapping_add(b as u64));
         // Use a minimal but valid profile YAML structure

--- a/mur-core/src/server_agents/list.rs
+++ b/mur-core/src/server_agents/list.rs
@@ -4,11 +4,9 @@ use std::sync::Arc;
 
 use axum::Json;
 use axum::extract::State;
-use axum::http::StatusCode;
-use axum::response::IntoResponse;
 use serde::Serialize;
 
-use crate::server::AppState;
+use crate::server::{AppError, AppState};
 
 #[derive(Serialize)]
 pub struct AgentListEntry {
@@ -17,14 +15,19 @@ pub struct AgentListEntry {
     pub running: bool,
 }
 
-pub async fn handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+pub async fn handler(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<AgentListEntry>>, AppError> {
     let entries = match std::fs::read_dir(&state.agents_dir) {
         Ok(it) => it,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return (StatusCode::OK, Json(Vec::<AgentListEntry>::new())).into_response();
+            return Ok(Json(Vec::new()));
         }
         Err(e) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+            return Err(AppError::Internal(
+                anyhow::Error::from(e)
+                    .context(format!("read_dir {}", state.agents_dir.display())),
+            ));
         }
     };
 
@@ -51,7 +54,7 @@ pub async fn handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     }
     out.sort_by(|a, b| a.name.cmp(&b.name));
 
-    (StatusCode::OK, Json(out)).into_response()
+    Ok(Json(out))
 }
 
 #[cfg(test)]

--- a/mur-core/src/server_agents/list.rs
+++ b/mur-core/src/server_agents/list.rs
@@ -1,1 +1,126 @@
 //! `GET /api/v1/agents` — list agents under `~/.mur/agents/`.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::Serialize;
+
+use crate::server::AppState;
+
+#[derive(Serialize)]
+pub struct AgentListEntry {
+    pub name: String,
+    pub display_name: String,
+    pub running: bool,
+}
+
+pub async fn handler(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let entries = match std::fs::read_dir(&state.agents_dir) {
+        Ok(it) => it,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return (StatusCode::OK, Json(Vec::<AgentListEntry>::new())).into_response();
+        }
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
+        }
+    };
+
+    let mut out: Vec<AgentListEntry> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let profile_path = path.join("profile.yaml");
+        let yaml = match std::fs::read_to_string(&profile_path) {
+            Ok(y) => y,
+            Err(_) => continue, // not an agent dir
+        };
+        let profile: mur_common::AgentProfile = match serde_yaml_ng::from_str(&yaml) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        out.push(AgentListEntry {
+            name: profile.name,
+            display_name: profile.display_name,
+            running: super::is_running(&path),
+        });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+
+    (StatusCode::OK, Json(out)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::server::build_router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    fn write_min_profile(dir: &std::path::Path, name: &str, display: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        let id_suffix = name.bytes().fold(0u64, |a, b| a.wrapping_add(b as u64));
+        // Use a minimal but valid profile YAML structure
+        let yaml = format!(
+            "schema: 1\nid: 0192f5a1-28ab-7111-8000-{id_suffix:012x}\nname: {name}\n\
+             display_name: \"{display}\"\nversion: \"0.1.0\"\npersona:\n  category: research\n  \
+             description: \"Test agent\"\n  traits:\n    tone: concise\n    risk: cautious\n    verbosity: low\n\
+             sys_prompt_file: \"sys_prompt.md\"\nmodel:\n  provider: ollama\n  name: \"m\"\n  params: {{}}\n\
+             mcp_servers: []\nskills: []\ntransport:\n  stdio: true\n  socket:\n    enabled: true\n    bind: \"unix:///tmp/{name}.sock\"\n\
+             communication:\n  accepts_from: [\"*\"]\n  sends_to: []\ncapabilities: [\"a2a.message.send\"]\n\
+             entitlements:\n  network:\n    inbound:\n      ports: []\n    outbound:\n      mode: restricted\n      allow_hosts: []\n      protocols: [\"tcp\"]\n      resolve_dns:\n        mode: system\n  filesystem:\n    read: []\n    write: []\n    deny: []\n  processes:\n    spawn:\n      mode: allowlist\n      allowed: []\n  syscalls:\n    mode: default\n  limits:\n    memory_mb: 512\n    file_descriptors: 1024\n    processes: 32\n\
+             notifications:\n  on_task_complete: []\n  on_error: []\n  on_shutdown: []\nretry:\n  llm:\n    max_retries: 3\n    backoff: exponential\n    initial_delay_ms: 1000\n    max_delay_ms: 30000\n    retry_on: [\"rate_limit\"]\n  tool:\n    max_retries: 1\n    backoff: fixed\n    initial_delay_ms: 500\n\
+             lifecycle:\n  restart: on_failure\n  max_restarts: 3\n  restart_window_secs: 600\n  stop_timeout_secs: 15\n  mcp_required: true\n\
+             created_at: \"2026-04-28T10:00:00+08:00\"\nupdated_at: \"2026-04-28T10:00:00+08:00\"\n"
+        );
+        std::fs::write(dir.join("profile.yaml"), yaml).unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_returns_known_agents_with_running_flag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents_dir = tmp.path().join("agents");
+        write_min_profile(&agents_dir.join("alpha"), "alpha", "Alpha Bot");
+        write_min_profile(&agents_dir.join("beta"), "beta", "Beta Bot");
+        // alpha is "running" — touch the lock file
+        std::fs::write(agents_dir.join("alpha").join("running.lock"), "1234").unwrap();
+
+        // Build state pointing at this temp agents dir
+        let state = crate::server::AppState {
+            patterns_dir: tmp.path().join("patterns"),
+            workflows_dir: tmp.path().join("workflows"),
+            pipelines_dir: tmp.path().join("pipelines"),
+            agents_dir,
+            index_dir: tmp.path().join("index"),
+            config: crate::server::ServerConfig { readonly: false },
+            events_tx: tokio::sync::broadcast::channel(64).0,
+        };
+        for d in [&state.patterns_dir, &state.workflows_dir, &state.pipelines_dir] {
+            std::fs::create_dir_all(d).unwrap();
+        }
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(Request::builder().uri("/api/v1/agents").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let arr = json.as_array().expect("response is an array");
+        assert_eq!(arr.len(), 2);
+
+        let alpha = arr.iter().find(|a| a["name"] == "alpha").unwrap();
+        assert_eq!(alpha["display_name"], "Alpha Bot");
+        assert_eq!(alpha["running"], true);
+
+        let beta = arr.iter().find(|a| a["name"] == "beta").unwrap();
+        assert_eq!(beta["running"], false);
+    }
+}

--- a/mur-core/src/server_agents/list.rs
+++ b/mur-core/src/server_agents/list.rs
@@ -1,0 +1,1 @@
+//! `GET /api/v1/agents` — list agents under `~/.mur/agents/`.

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -2,11 +2,14 @@
 //!
 //! Mounted under `/api/v1/agents` by [`crate::server::build_router`].
 
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use axum::Router;
+use axum::extract::ConnectInfo;
 use axum::http::StatusCode;
+use axum::response::IntoResponse;
 use serde::Serialize;
 
 use crate::server::{AppError, AppState};
@@ -37,6 +40,37 @@ pub fn router() -> Router<Arc<AppState>> {
         // Explicit 404 fallback: without this, unknown /api/v1/agents/* paths
         // bubble up to the outer router's SPA fallback and return 200 HTML.
         .fallback(|| async { StatusCode::NOT_FOUND })
+        .layer(axum::middleware::from_fn(loopback_only))
+}
+
+/// Reject any request whose peer is not loopback. This is a temporary stand-in
+/// for Phase 6 auth — until real auth lands, the agents API is treated as a
+/// localhost-only debugging surface.
+///
+/// In tests using `tower::ServiceExt::oneshot` no `ConnectInfo` is attached,
+/// so the extractor returns `None` and we allow the request. Production boot
+/// must use `into_make_service_with_connect_info::<SocketAddr>()` so the
+/// extension IS present and non-loopback callers actually get 403.
+pub(crate) async fn loopback_only(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    // Extract ConnectInfo from the request extensions directly so we don't
+    // depend on FromRequestParts trait resolution across multiple axum versions.
+    let is_loopback = req
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(addr)| addr.ip().is_loopback())
+        .unwrap_or(true); // no ConnectInfo (e.g. oneshot tests) → allow
+
+    if !is_loopback {
+        return (
+            StatusCode::FORBIDDEN,
+            "agents API is loopback-only until auth lands (issue #38)",
+        )
+            .into_response();
+    }
+    next.run(req).await
 }
 
 // ─── Shared helpers ────────────────────────────────────────────────
@@ -131,4 +165,81 @@ fn pid_alive(pid: u32) -> bool {
 fn pid_alive(_pid: u32) -> bool {
     // Windows agents are not supported in P0a; treat any present lock as live.
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    fn build_state(tmp: &tempfile::TempDir) -> crate::server::AppState {
+        let agents_dir = tmp.path().join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        // Also create the other dirs build_router might need
+        std::fs::create_dir_all(tmp.path().join("patterns")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("workflows")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("pipelines")).unwrap();
+        crate::server::AppState {
+            patterns_dir: tmp.path().join("patterns"),
+            workflows_dir: tmp.path().join("workflows"),
+            pipelines_dir: tmp.path().join("pipelines"),
+            agents_dir,
+            index_dir: tmp.path().join("index"),
+            config: crate::server::ServerConfig { readonly: false },
+            events_tx: tokio::sync::broadcast::channel(64).0,
+        }
+    }
+
+    #[tokio::test]
+    async fn loopback_only_allows_127_0_0_1() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = crate::server::build_router(build_state(&tmp));
+        let mut req = Request::builder()
+            .uri("/api/v1/agents")
+            .body(Body::empty())
+            .unwrap();
+        // Inject ConnectInfo as if a real client connected from loopback.
+        req.extensions_mut()
+            .insert(ConnectInfo::<SocketAddr>("127.0.0.1:5555".parse().unwrap()));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn loopback_only_rejects_lan_ip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = crate::server::build_router(build_state(&tmp));
+        let mut req = Request::builder()
+            .uri("/api/v1/agents")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(ConnectInfo::<SocketAddr>(
+            "192.168.1.42:5555".parse().unwrap(),
+        ));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let body = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(
+            body.contains("loopback-only"),
+            "body should explain why: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn loopback_only_allows_ipv6_loopback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = crate::server::build_router(build_state(&tmp));
+        let mut req = Request::builder()
+            .uri("/api/v1/agents")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut()
+            .insert(ConnectInfo::<SocketAddr>("[::1]:5555".parse().unwrap()));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
 }

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use axum::Router;
 use axum::http::StatusCode;
+use serde::Serialize;
 
 use crate::server::{AppError, AppState};
 
@@ -59,8 +60,75 @@ pub(crate) fn agent_home(agents_dir: &Path, name: &str) -> PathBuf {
     agents_dir.join(name)
 }
 
-/// True when `<agent_home>/running.lock` exists. Per the runtime spec
-/// the lock is created on supervisor start and removed on clean exit.
-pub(crate) fn is_running(home: &Path) -> bool {
-    home.join("running.lock").exists()
+/// Three-state classification of an agent's runtime state.
+///
+/// Mirrors `mur-core/src/cmd/agent.rs::classify` so the HTTP API and CLI
+/// agree on what "running" means.
+#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentStatusKind {
+    /// Lock present and the recorded pid is alive.
+    Running,
+    /// Lock present but the pid is not alive (crash/kill — orphan lock).
+    Stale,
+    /// No lock file.
+    Stopped,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AgentStatusInfo {
+    pub kind: AgentStatusKind,
+    pub pid: Option<u32>,
+}
+
+/// Inspect `<home>/running.lock` and classify the agent's state.
+///
+/// Mirrors `mur-core/src/cmd/agent.rs::classify` so the HTTP and CLI surfaces
+/// agree on what "running" means.
+pub(crate) fn agent_status(home: &Path) -> AgentStatusInfo {
+    let lock_path = home.join("running.lock");
+    let bytes = match std::fs::read(&lock_path) {
+        Ok(b) => b,
+        Err(_) => {
+            return AgentStatusInfo {
+                kind: AgentStatusKind::Stopped,
+                pid: None,
+            };
+        }
+    };
+    // Lock is JSON: see mur-agent-runtime/src/lock_file.rs.
+    let lock: mur_common::LockFile = match serde_json::from_slice(&bytes) {
+        Ok(l) => l,
+        Err(_) => {
+            // Malformed lock — treat as stale rather than running so dashboards
+            // don't paint dead agents green.
+            return AgentStatusInfo {
+                kind: AgentStatusKind::Stale,
+                pid: None,
+            };
+        }
+    };
+    let kind = if pid_alive(lock.pid) {
+        AgentStatusKind::Running
+    } else {
+        AgentStatusKind::Stale
+    };
+    AgentStatusInfo {
+        kind,
+        pid: Some(lock.pid),
+    }
+}
+
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    // Signal 0 is the standard liveness probe — returns 0 if the process exists
+    // and we have permission to signal it, ESRCH if not.
+    // SAFETY: kill(2) is safe to call with signal 0; no signal is delivered.
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn pid_alive(_pid: u32) -> bool {
+    // Windows agents are not supported in P0a; treat any present lock as live.
+    true
 }

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -1,6 +1,20 @@
 //! HTTP routes for `~/.mur/agents/*` — read-only Phase 4.
 //!
 //! Mounted under `/api/v1/agents` by [`crate::server::build_router`].
+//!
+//! # Response envelope
+//!
+//! These handlers intentionally return `Json<T>` directly, not the
+//! `{data, meta: {source, version, pattern_count}}` envelope that
+//! [`crate::server::wrap`] adds to patterns / workflows responses.
+//! The `pattern_count` field is patterns-specific and would be meaningless
+//! for agent data; rather than emit a misleading `pattern_count: 0`, agent
+//! routes skip the envelope entirely.
+//!
+//! Future contributors: do **not** wrap these responses to "match" the
+//! patterns / workflows shape — the difference is intentional. If a fully
+//! consistent envelope is wanted across the API, generalize `wrap()` first
+//! (see issue #37 for the design discussion).
 
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -8,15 +8,14 @@ use std::sync::Arc;
 use axum::Router;
 use axum::http::StatusCode;
 
-use crate::server::AppState;
+use crate::server::{AppError, AppState};
 
 pub mod detail;
 pub mod evals;
 pub mod list;
 pub mod telemetry;
 
-/// Build the nested `/api/v1/agents` router. Returns an empty router for
-/// now — handlers are wired in by later tasks.
+/// Build the nested `/api/v1/agents` router (Phase 4 read-only routes).
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
         .route("/", axum::routing::get(list::handler))
@@ -40,6 +39,20 @@ pub fn router() -> Router<Arc<AppState>> {
 }
 
 // ─── Shared helpers ────────────────────────────────────────────────
+
+/// Validate an agent name from a URL path parameter. Agent names follow a
+/// strict allowlist to prevent directory traversal via `agents_dir.join(name)`.
+pub(crate) fn validate_agent_name(name: &str) -> Result<(), AppError> {
+    let safe = !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_'))
+        && !name.contains("..");
+    if !safe {
+        return Err(AppError::BadRequest(format!("invalid agent name '{name}'")));
+    }
+    Ok(())
+}
 
 /// Absolute path to `~/.mur/agents/<name>/`. Does not check existence.
 pub(crate) fn agent_home(agents_dir: &Path, name: &str) -> PathBuf {

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -24,12 +24,14 @@ pub fn router() -> Router<Arc<AppState>> {
 // ─── Shared helpers ────────────────────────────────────────────────
 
 /// Absolute path to `~/.mur/agents/<name>/`. Does not check existence.
+#[allow(dead_code)]
 pub(crate) fn agent_home(agents_dir: &Path, name: &str) -> PathBuf {
     agents_dir.join(name)
 }
 
 /// True when `<agent_home>/running.lock` exists. Per the runtime spec
 /// the lock is created on supervisor start and removed on clean exit.
+#[allow(dead_code)]
 pub(crate) fn is_running(home: &Path) -> bool {
     home.join("running.lock").exists()
 }

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -1,0 +1,35 @@
+//! HTTP routes for `~/.mur/agents/*` — read-only Phase 4.
+//!
+//! Mounted under `/api/v1/agents` by [`crate::server::build_router`].
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use axum::http::StatusCode;
+use axum::Router;
+
+use crate::server::AppState;
+
+pub mod list;
+pub mod detail;
+pub mod telemetry;
+pub mod evals;
+
+/// Build the nested `/api/v1/agents` router. Returns an empty router for
+/// now — handlers are wired in by later tasks.
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new().fallback(|| async { StatusCode::NOT_FOUND })
+}
+
+// ─── Shared helpers ────────────────────────────────────────────────
+
+/// Absolute path to `~/.mur/agents/<name>/`. Does not check existence.
+pub(crate) fn agent_home(agents_dir: &Path, name: &str) -> PathBuf {
+    agents_dir.join(name)
+}
+
+/// True when `<agent_home>/running.lock` exists. Per the runtime spec
+/// the lock is created on supervisor start and removed on clean exit.
+pub(crate) fn is_running(home: &Path) -> bool {
+    home.join("running.lock").exists()
+}

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -30,6 +30,7 @@ pub fn router() -> Router<Arc<AppState>> {
             axum::routing::get(telemetry::stream_handler),
         )
         .route("/{name}/evals", axum::routing::get(evals::list_handler))
+        .route("/{name}/evals/{run_id}", axum::routing::get(evals::detail_handler))
         // Explicit 404 fallback: without this, unknown /api/v1/agents/* paths
         // bubble up to the outer router's SPA fallback and return 200 HTML.
         .fallback(|| async { StatusCode::NOT_FOUND })

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -5,15 +5,15 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use axum::http::StatusCode;
 use axum::Router;
+use axum::http::StatusCode;
 
 use crate::server::AppState;
 
-pub mod list;
 pub mod detail;
-pub mod telemetry;
 pub mod evals;
+pub mod list;
+pub mod telemetry;
 
 /// Build the nested `/api/v1/agents` router. Returns an empty router for
 /// now — handlers are wired in by later tasks.
@@ -21,8 +21,15 @@ pub fn router() -> Router<Arc<AppState>> {
     Router::new()
         .route("/", axum::routing::get(list::handler))
         .route("/{name}", axum::routing::get(detail::handler))
-        .route("/{name}/telemetry", axum::routing::get(telemetry::tail_handler))
-        .route("/{name}/stream", axum::routing::get(telemetry::stream_handler))
+        .route(
+            "/{name}/telemetry",
+            axum::routing::get(telemetry::tail_handler),
+        )
+        .route(
+            "/{name}/stream",
+            axum::routing::get(telemetry::stream_handler),
+        )
+        .route("/{name}/evals", axum::routing::get(evals::list_handler))
         // Explicit 404 fallback: without this, unknown /api/v1/agents/* paths
         // bubble up to the outer router's SPA fallback and return 200 HTML.
         .fallback(|| async { StatusCode::NOT_FOUND })

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -18,6 +18,8 @@ pub mod evals;
 /// Build the nested `/api/v1/agents` router. Returns an empty router for
 /// now — handlers are wired in by later tasks.
 pub fn router() -> Router<Arc<AppState>> {
+    // Explicit 404 fallback: without this, unknown /api/v1/agents/* paths
+    // bubble up to the outer router's SPA fallback and return 200 HTML.
     Router::new().fallback(|| async { StatusCode::NOT_FOUND })
 }
 

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -6,13 +6,11 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use crate::server::{AppError, AppState};
 use axum::Router;
 use axum::extract::ConnectInfo;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use serde::Serialize;
-
-use crate::server::{AppError, AppState};
 
 pub mod detail;
 pub mod evals;
@@ -87,77 +85,21 @@ pub(crate) fn agent_home(agents_dir: &Path, name: &str) -> PathBuf {
     agents_dir.join(name)
 }
 
-/// Three-state classification of an agent's runtime state.
-///
-/// Mirrors `mur-core/src/cmd/agent.rs::classify` so the HTTP API and CLI
-/// agree on what "running" means.
-#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum AgentStatusKind {
-    /// Lock present and the recorded pid is alive.
-    Running,
-    /// Lock present but the pid is not alive (crash/kill — orphan lock).
-    Stale,
-    /// No lock file.
-    Stopped,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct AgentStatusInfo {
-    pub kind: AgentStatusKind,
-    pub pid: Option<u32>,
-}
+// Re-export the canonical status types from mur_common so callers in
+// detail.rs and list.rs can reference them as `super::AgentStatusKind`.
+// This is the single source of truth for lock parsing + 3-state classification
+// (closes #36). Previously this logic was duplicated here, in cmd/agent.rs,
+// and in mur-agent-runtime/src/lock_file.rs.
+pub(crate) use mur_common::lock_file::AgentStatusKind;
+// AgentStatusInfo is the name local callers use; maps to the common AgentStatus.
+pub(crate) use mur_common::lock_file::AgentStatus as AgentStatusInfo;
 
 /// Inspect `<home>/running.lock` and classify the agent's state.
 ///
-/// Mirrors `mur-core/src/cmd/agent.rs::classify` so the HTTP and CLI surfaces
-/// agree on what "running" means.
+/// Delegates to `mur_common::lock_file::classify` — single source of truth
+/// for read + pid_alive + 3-state classification (closes #36).
 pub(crate) fn agent_status(home: &Path) -> AgentStatusInfo {
-    let lock_path = home.join("running.lock");
-    let bytes = match std::fs::read(&lock_path) {
-        Ok(b) => b,
-        Err(_) => {
-            return AgentStatusInfo {
-                kind: AgentStatusKind::Stopped,
-                pid: None,
-            };
-        }
-    };
-    // Lock is JSON: see mur-agent-runtime/src/lock_file.rs.
-    let lock: mur_common::LockFile = match serde_json::from_slice(&bytes) {
-        Ok(l) => l,
-        Err(_) => {
-            // Malformed lock — treat as stale rather than running so dashboards
-            // don't paint dead agents green.
-            return AgentStatusInfo {
-                kind: AgentStatusKind::Stale,
-                pid: None,
-            };
-        }
-    };
-    let kind = if pid_alive(lock.pid) {
-        AgentStatusKind::Running
-    } else {
-        AgentStatusKind::Stale
-    };
-    AgentStatusInfo {
-        kind,
-        pid: Some(lock.pid),
-    }
-}
-
-#[cfg(unix)]
-fn pid_alive(pid: u32) -> bool {
-    // Signal 0 is the standard liveness probe — returns 0 if the process exists
-    // and we have permission to signal it, ESRCH if not.
-    // SAFETY: kill(2) is safe to call with signal 0; no signal is delivered.
-    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
-}
-
-#[cfg(not(unix))]
-fn pid_alive(_pid: u32) -> bool {
-    // Windows agents are not supported in P0a; treat any present lock as live.
-    true
+    mur_common::lock_file::classify(&home.join("running.lock"))
 }
 
 #[cfg(test)]

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -75,18 +75,11 @@ pub(crate) async fn loopback_only(
 
 // ─── Shared helpers ────────────────────────────────────────────────
 
-/// Validate an agent name from a URL path parameter. Agent names follow a
-/// strict allowlist to prevent directory traversal via `agents_dir.join(name)`.
+/// Validate an agent name from a URL path parameter. Delegates to the
+/// canonical validator in `mur_common` so the HTTP API and CLI share a single
+/// source of truth.
 pub(crate) fn validate_agent_name(name: &str) -> Result<(), AppError> {
-    let safe = !name.is_empty()
-        && name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_'))
-        && !name.contains("..");
-    if !safe {
-        return Err(AppError::BadRequest(format!("invalid agent name '{name}'")));
-    }
-    Ok(())
+    mur_common::validate_agent_name(name).map_err(|e| AppError::BadRequest(e.to_string()))
 }
 
 /// Absolute path to `~/.mur/agents/<name>/`. Does not check existence.

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -20,6 +20,7 @@ pub mod evals;
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
         .route("/", axum::routing::get(list::handler))
+        .route("/{name}", axum::routing::get(detail::handler))
         // Explicit 404 fallback: without this, unknown /api/v1/agents/* paths
         // bubble up to the outer router's SPA fallback and return 200 HTML.
         .fallback(|| async { StatusCode::NOT_FOUND })
@@ -28,7 +29,6 @@ pub fn router() -> Router<Arc<AppState>> {
 // ─── Shared helpers ────────────────────────────────────────────────
 
 /// Absolute path to `~/.mur/agents/<name>/`. Does not check existence.
-#[allow(dead_code)]
 pub(crate) fn agent_home(agents_dir: &Path, name: &str) -> PathBuf {
     agents_dir.join(name)
 }

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -22,6 +22,7 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/", axum::routing::get(list::handler))
         .route("/{name}", axum::routing::get(detail::handler))
         .route("/{name}/telemetry", axum::routing::get(telemetry::tail_handler))
+        .route("/{name}/stream", axum::routing::get(telemetry::stream_handler))
         // Explicit 404 fallback: without this, unknown /api/v1/agents/* paths
         // bubble up to the outer router's SPA fallback and return 200 HTML.
         .fallback(|| async { StatusCode::NOT_FOUND })

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -30,7 +30,10 @@ pub fn router() -> Router<Arc<AppState>> {
             axum::routing::get(telemetry::stream_handler),
         )
         .route("/{name}/evals", axum::routing::get(evals::list_handler))
-        .route("/{name}/evals/{run_id}", axum::routing::get(evals::detail_handler))
+        .route(
+            "/{name}/evals/{run_id}",
+            axum::routing::get(evals::detail_handler),
+        )
         // Explicit 404 fallback: without this, unknown /api/v1/agents/* paths
         // bubble up to the outer router's SPA fallback and return 200 HTML.
         .fallback(|| async { StatusCode::NOT_FOUND })

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -18,9 +18,11 @@ pub mod evals;
 /// Build the nested `/api/v1/agents` router. Returns an empty router for
 /// now — handlers are wired in by later tasks.
 pub fn router() -> Router<Arc<AppState>> {
-    // Explicit 404 fallback: without this, unknown /api/v1/agents/* paths
-    // bubble up to the outer router's SPA fallback and return 200 HTML.
-    Router::new().fallback(|| async { StatusCode::NOT_FOUND })
+    Router::new()
+        .route("/", axum::routing::get(list::handler))
+        // Explicit 404 fallback: without this, unknown /api/v1/agents/* paths
+        // bubble up to the outer router's SPA fallback and return 200 HTML.
+        .fallback(|| async { StatusCode::NOT_FOUND })
 }
 
 // ─── Shared helpers ────────────────────────────────────────────────
@@ -33,7 +35,6 @@ pub(crate) fn agent_home(agents_dir: &Path, name: &str) -> PathBuf {
 
 /// True when `<agent_home>/running.lock` exists. Per the runtime spec
 /// the lock is created on supervisor start and removed on clean exit.
-#[allow(dead_code)]
 pub(crate) fn is_running(home: &Path) -> bool {
     home.join("running.lock").exists()
 }

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -21,6 +21,7 @@ pub fn router() -> Router<Arc<AppState>> {
     Router::new()
         .route("/", axum::routing::get(list::handler))
         .route("/{name}", axum::routing::get(detail::handler))
+        .route("/{name}/telemetry", axum::routing::get(telemetry::tail_handler))
         // Explicit 404 fallback: without this, unknown /api/v1/agents/* paths
         // bubble up to the outer router's SPA fallback and return 200 HTML.
         .fallback(|| async { StatusCode::NOT_FOUND })

--- a/mur-core/src/server_agents/telemetry.rs
+++ b/mur-core/src/server_agents/telemetry.rs
@@ -14,6 +14,16 @@ use tokio::time::{Duration, sleep};
 
 use crate::server::{AppError, AppState};
 
+fn is_valid_date(date: &str) -> bool {
+    let bytes = date.as_bytes();
+    bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes[..4].iter().all(|b| b.is_ascii_digit())
+        && bytes[5..7].iter().all(|b| b.is_ascii_digit())
+        && bytes[8..10].iter().all(|b| b.is_ascii_digit())
+}
+
 #[derive(Deserialize)]
 pub struct TelemetryQuery {
     /// `YYYY-MM-DD`. Defaults to today (UTC).
@@ -30,6 +40,7 @@ pub async fn tail_handler(
     Path(name): Path<String>,
     Query(q): Query<TelemetryQuery>,
 ) -> Result<Json<Vec<serde_json::Value>>, AppError> {
+    super::validate_agent_name(&name)?;
     let home = super::agent_home(&state.agents_dir, &name);
     if !home.exists() {
         return Err(AppError::NotFound(format!("agent '{name}' not found")));
@@ -37,6 +48,9 @@ pub async fn tail_handler(
     let date = q
         .date
         .unwrap_or_else(|| chrono::Utc::now().format("%Y-%m-%d").to_string());
+    if !is_valid_date(&date) {
+        return Err(AppError::BadRequest(format!("invalid date '{date}'")));
+    }
     let path = home.join("telemetry").join(format!("{date}.jsonl"));
 
     let body = match std::fs::read_to_string(&path) {
@@ -85,6 +99,13 @@ pub async fn stream_handler(
     Path(name): Path<String>,
     ws: WebSocketUpgrade,
 ) -> Response {
+    if super::validate_agent_name(&name).is_err() {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            format!("invalid agent name '{name}'"),
+        )
+            .into_response();
+    }
     let home = super::agent_home(&state.agents_dir, &name);
     if !home.exists() {
         return (StatusCode::NOT_FOUND, format!("agent '{name}' not found")).into_response();
@@ -295,6 +316,26 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn telemetry_rejects_invalid_date_format() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/alpha/telemetry?date=../../etc/shadow")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/mur-core/src/server_agents/telemetry.rs
+++ b/mur-core/src/server_agents/telemetry.rs
@@ -191,4 +191,20 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(json, serde_json::json!([]));
     }
+
+    #[tokio::test]
+    async fn telemetry_returns_404_for_missing_agent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let app = build_router(build_state(&tmp));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/ghost/telemetry")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
 }

--- a/mur-core/src/server_agents/telemetry.rs
+++ b/mur-core/src/server_agents/telemetry.rs
@@ -1,10 +1,16 @@
 //! `GET /api/v1/agents/{name}/telemetry` and `WS /api/v1/agents/{name}/stream`.
 
+use std::io::SeekFrom;
 use std::sync::Arc;
 
 use axum::Json;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, BufReader};
+use tokio::time::{Duration, sleep};
 
 use crate::server::{AppError, AppState};
 
@@ -66,6 +72,73 @@ pub async fn tail_handler(
     }
 
     Ok(Json(out))
+}
+
+// ─── WebSocket stream handler ───────────────────────────────────────
+
+const POLL_INTERVAL_MS: u64 = 250;
+
+pub async fn stream_handler(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let home = super::agent_home(&state.agents_dir, &name);
+    if !home.exists() {
+        return (StatusCode::NOT_FOUND, format!("agent '{name}' not found")).into_response();
+    }
+    ws.on_upgrade(move |socket| stream_loop(socket, home))
+}
+
+async fn stream_loop(mut socket: WebSocket, home: std::path::PathBuf) {
+    // Always tail today's file (UTC). On midnight rollover the loop
+    // re-resolves the path on the next tick.
+    let mut current_date = String::new();
+    let mut pos: u64 = 0;
+    let mut leftover = String::new();
+
+    loop {
+        let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+        if date != current_date {
+            current_date = date.clone();
+            pos = 0;
+            leftover.clear();
+            // Start at end-of-file so we only emit *new* lines after connect.
+            let path = home.join("telemetry").join(format!("{date}.jsonl"));
+            if let Ok(meta) = tokio::fs::metadata(&path).await {
+                pos = meta.len();
+            }
+        }
+
+        let path = home.join("telemetry").join(format!("{current_date}.jsonl"));
+        if let Ok(mut f) = tokio::fs::File::open(&path).await {
+            let len = f.metadata().await.map(|m| m.len()).unwrap_or(0);
+            if len < pos {
+                // truncated/rotated under us — restart from byte 0
+                pos = 0;
+                leftover.clear();
+            }
+            if len > pos && f.seek(SeekFrom::Start(pos)).await.is_ok() {
+                let mut buf = String::new();
+                if BufReader::new(&mut f).read_to_string(&mut buf).await.is_ok() {
+                    pos = len;
+                    leftover.push_str(&buf);
+                    while let Some(idx) = leftover.find('\n') {
+                        let line: String = leftover.drain(..=idx).collect();
+                        let line = line.trim_end_matches(['\r', '\n']);
+                        if line.is_empty() {
+                            continue;
+                        }
+                        if socket.send(Message::Text(line.to_string().into())).await.is_err() {
+                            return; // client disconnected
+                        }
+                    }
+                }
+            }
+        }
+
+        sleep(Duration::from_millis(POLL_INTERVAL_MS)).await;
+    }
 }
 
 #[cfg(test)]
@@ -206,5 +279,58 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn ws_stream_emits_lines_appended_after_connect() {
+        use tokio_tungstenite::tungstenite;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+        let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+        std::fs::create_dir_all(home.join("telemetry")).unwrap();
+        let log_path = home.join("telemetry").join(format!("{date}.jsonl"));
+        std::fs::write(&log_path, "").unwrap();
+
+        let app = build_router(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let url = format!("ws://127.0.0.1:{port}/api/v1/agents/alpha/stream");
+        let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+
+        // Append after the WS is connected
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        std::fs::write(
+            &log_path,
+            format!(
+                r#"{{"ts":"{date}T00:00:00Z","kind":"hello"}}
+"#
+            ),
+        )
+        .unwrap();
+
+        // Read one frame within a generous timeout (poll interval is 250ms)
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(3), {
+            use futures_util::StreamExt;
+            async { ws.next().await }
+        })
+        .await
+        .expect("ws frame within 3s")
+        .expect("stream not closed")
+        .expect("frame ok");
+
+        match msg {
+            tungstenite::Message::Text(t) => {
+                let v: serde_json::Value = serde_json::from_str(&t).unwrap();
+                assert_eq!(v["kind"], "hello");
+            }
+            other => panic!("expected text frame, got {other:?}"),
+        }
     }
 }

--- a/mur-core/src/server_agents/telemetry.rs
+++ b/mur-core/src/server_agents/telemetry.rs
@@ -1,1 +1,194 @@
 //! `GET /api/v1/agents/{name}/telemetry` and `WS /api/v1/agents/{name}/stream`.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use serde::Deserialize;
+
+use crate::server::{AppError, AppState};
+
+#[derive(Deserialize)]
+pub struct TelemetryQuery {
+    /// `YYYY-MM-DD`. Defaults to today (UTC).
+    pub date: Option<String>,
+    /// Drop lines whose `ts` field is `<= since` (RFC 3339 string compare —
+    /// telemetry timestamps are always UTC ISO-8601 so lex order = time order).
+    pub since: Option<String>,
+    /// Cap returned lines (keeps the most recent `n`). Default: no cap.
+    pub limit: Option<usize>,
+}
+
+pub async fn tail_handler(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    Query(q): Query<TelemetryQuery>,
+) -> Result<Json<Vec<serde_json::Value>>, AppError> {
+    let home = super::agent_home(&state.agents_dir, &name);
+    if !home.exists() {
+        return Err(AppError::NotFound(format!("agent '{name}' not found")));
+    }
+    let date = q.date.unwrap_or_else(|| chrono::Utc::now().format("%Y-%m-%d").to_string());
+    let path = home.join("telemetry").join(format!("{date}.jsonl"));
+
+    let body = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => {
+            return Err(AppError::Internal(
+                anyhow::Error::from(e).context(format!("read {}", path.display())),
+            ));
+        }
+    };
+
+    let mut out: Vec<serde_json::Value> = Vec::new();
+    for line in body.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue, // skip malformed lines
+        };
+        if let Some(ref since) = q.since
+            && let Some(ts) = v.get("ts").and_then(|t| t.as_str())
+            && ts.as_bytes() <= since.as_bytes()
+        {
+            continue;
+        }
+        out.push(v);
+    }
+    if let Some(n) = q.limit
+        && out.len() > n
+    {
+        let drop = out.len() - n;
+        out.drain(0..drop);
+    }
+
+    Ok(Json(out))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::server::{AppState, ServerConfig, build_router};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    fn build_state(tmp: &tempfile::TempDir) -> AppState {
+        let agents_dir = tmp.path().join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        AppState {
+            patterns_dir: tmp.path().join("patterns"),
+            workflows_dir: tmp.path().join("workflows"),
+            pipelines_dir: tmp.path().join("pipelines"),
+            agents_dir,
+            index_dir: tmp.path().join("index"),
+            config: ServerConfig { readonly: false },
+            events_tx: tokio::sync::broadcast::channel(64).0,
+        }
+    }
+
+    fn write_telemetry(home: &std::path::Path, date: &str, lines: &[&str]) {
+        let dir = home.join("telemetry");
+        std::fs::create_dir_all(&dir).unwrap();
+        let body = lines.join("\n") + "\n";
+        std::fs::write(dir.join(format!("{date}.jsonl")), body).unwrap();
+    }
+
+    #[tokio::test]
+    async fn telemetry_returns_recent_lines_in_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+        write_telemetry(
+            &home,
+            "2026-04-28",
+            &[
+                r#"{"ts":"2026-04-28T07:00:00Z","kind":"start"}"#,
+                r#"{"ts":"2026-04-28T07:00:01Z","kind":"message_send"}"#,
+                r#"{"ts":"2026-04-28T07:00:02Z","kind":"message_done"}"#,
+            ],
+        );
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/alpha/telemetry?date=2026-04-28&limit=10")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let arr = json.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0]["kind"], "start");
+        assert_eq!(arr[2]["kind"], "message_done");
+    }
+
+    #[tokio::test]
+    async fn telemetry_filters_by_since_timestamp() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+        write_telemetry(
+            &home,
+            "2026-04-28",
+            &[
+                r#"{"ts":"2026-04-28T07:00:00Z","kind":"start"}"#,
+                r#"{"ts":"2026-04-28T07:00:05Z","kind":"message_send"}"#,
+                r#"{"ts":"2026-04-28T07:00:10Z","kind":"message_done"}"#,
+            ],
+        );
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/alpha/telemetry?date=2026-04-28&since=2026-04-28T07:00:04Z")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let arr = json.as_array().unwrap();
+        assert_eq!(arr.len(), 2); // dropped the 07:00:00 line
+        assert_eq!(arr[0]["kind"], "message_send");
+    }
+
+    #[tokio::test]
+    async fn telemetry_returns_empty_when_no_file_for_date() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/agents/alpha/telemetry?date=1999-01-01")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json, serde_json::json!([]));
+    }
+}

--- a/mur-core/src/server_agents/telemetry.rs
+++ b/mur-core/src/server_agents/telemetry.rs
@@ -1,5 +1,7 @@
 //! `GET /api/v1/agents/{name}/telemetry` and `WS /api/v1/agents/{name}/stream`.
 
+use std::collections::VecDeque;
+use std::io::BufRead;
 use std::io::SeekFrom;
 use std::sync::Arc;
 
@@ -9,7 +11,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
-use tokio::io::{AsyncReadExt, AsyncSeekExt, BufReader};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::time::{Duration, sleep};
 
 use crate::server::{AppError, AppState};
@@ -53,24 +55,33 @@ pub async fn tail_handler(
     }
     let path = home.join("telemetry").join(format!("{date}.jsonl"));
 
-    let body = match std::fs::read_to_string(&path) {
-        Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+    let file = match std::fs::File::open(&path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Json(Vec::new()));
+        }
         Err(e) => {
             return Err(AppError::Internal(
-                anyhow::Error::from(e).context(format!("read {}", path.display())),
+                anyhow::Error::from(e).context(format!("open {}", path.display())),
             ));
         }
     };
 
-    let mut out: Vec<serde_json::Value> = Vec::new();
-    for line in body.lines() {
+    let reader = std::io::BufReader::new(file);
+    let mut buffer: VecDeque<serde_json::Value> = VecDeque::new();
+    let cap = q.limit;
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue, // I/O hiccup mid-file: skip the bad line, keep going
+        };
         if line.trim().is_empty() {
             continue;
         }
-        let v: serde_json::Value = match serde_json::from_str(line) {
+        let v: serde_json::Value = match serde_json::from_str(&line) {
             Ok(v) => v,
-            Err(_) => continue, // skip malformed lines
+            Err(_) => continue,
         };
         if let Some(ref since) = q.since
             && let Some(ts) = v.get("ts").and_then(|t| t.as_str())
@@ -78,21 +89,22 @@ pub async fn tail_handler(
         {
             continue;
         }
-        out.push(v);
-    }
-    if let Some(n) = q.limit
-        && out.len() > n
-    {
-        let drop = out.len() - n;
-        out.drain(0..drop);
+        buffer.push_back(v);
+        if let Some(n) = cap
+            && buffer.len() > n
+        {
+            buffer.pop_front();
+        }
     }
 
-    Ok(Json(out))
+    Ok(Json(buffer.into_iter().collect()))
 }
 
 // ─── WebSocket stream handler ───────────────────────────────────────
 
 const POLL_INTERVAL_MS: u64 = 250;
+const MAX_TICK_BYTES: usize = 1024 * 1024; // 1 MiB per tick
+const MAX_LEFTOVER_BYTES: usize = 2 * 1024 * 1024; // 2 MiB single-line cap
 
 pub async fn stream_handler(
     State(state): State<Arc<AppState>>,
@@ -122,7 +134,7 @@ async fn stream_loop(mut socket: WebSocket, home: std::path::PathBuf) {
     // the file may miss lines from the new file.
     let mut current_date = String::new();
     let mut pos: u64 = 0;
-    let mut leftover = String::new();
+    let mut leftover: Vec<u8> = Vec::new();
 
     loop {
         let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
@@ -145,27 +157,37 @@ async fn stream_loop(mut socket: WebSocket, home: std::path::PathBuf) {
                 pos = 0;
                 leftover.clear();
             }
-            if len > pos && f.seek(SeekFrom::Start(pos)).await.is_ok() {
-                let mut buf = String::new();
-                if BufReader::new(&mut f)
-                    .read_to_string(&mut buf)
-                    .await
-                    .is_ok()
-                {
-                    pos = len;
-                    leftover.push_str(&buf);
-                    while let Some(idx) = leftover.find('\n') {
-                        let line: String = leftover.drain(..=idx).collect();
-                        let line = line.trim_end_matches(['\r', '\n']);
-                        if line.is_empty() {
-                            continue;
+            if len > pos {
+                let want = ((len - pos) as usize).min(MAX_TICK_BYTES);
+                if f.seek(SeekFrom::Start(pos)).await.is_ok() {
+                    let mut buf = vec![0u8; want];
+                    if f.read_exact(&mut buf).await.is_ok() {
+                        pos += want as u64;
+                        leftover.extend_from_slice(&buf);
+                        while let Some(idx) = leftover.iter().position(|&b| b == b'\n') {
+                            let line_bytes: Vec<u8> = leftover.drain(..=idx).collect();
+                            // Trim CR/LF from the trailing edge
+                            let trimmed = line_bytes.strip_suffix(b"\n").unwrap_or(&line_bytes);
+                            let trimmed = trimmed.strip_suffix(b"\r").unwrap_or(trimmed);
+                            if trimmed.is_empty() {
+                                continue;
+                            }
+                            // Skip non-UTF-8 lines silently — telemetry should be ASCII/UTF-8.
+                            let s = match std::str::from_utf8(trimmed) {
+                                Ok(s) => s,
+                                Err(_) => continue,
+                            };
+                            if socket
+                                .send(Message::Text(s.to_string().into()))
+                                .await
+                                .is_err()
+                            {
+                                return; // client disconnected
+                            }
                         }
-                        if socket
-                            .send(Message::Text(line.to_string().into()))
-                            .await
-                            .is_err()
-                        {
-                            return; // client disconnected
+                        // Cap unconsumed leftover — single line larger than 2 MiB is corrupt.
+                        if leftover.len() > MAX_LEFTOVER_BYTES {
+                            leftover.clear();
                         }
                     }
                 }
@@ -355,7 +377,12 @@ mod tests {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let port = listener.local_addr().unwrap().port();
         tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .await
+            .unwrap();
         });
 
         let url = format!("ws://127.0.0.1:{port}/api/v1/agents/alpha/stream");
@@ -389,5 +416,62 @@ mod tests {
             }
             other => panic!("expected text frame, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn ws_stream_handles_multi_line_chunk() {
+        use tokio_tungstenite::tungstenite;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let state = build_state(&tmp);
+        let home = state.agents_dir.join("alpha");
+        super::super::list::tests::write_min_profile(&home, "alpha", "Alpha");
+        let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+        std::fs::create_dir_all(home.join("telemetry")).unwrap();
+        let log_path = home.join("telemetry").join(format!("{date}.jsonl"));
+        std::fs::write(&log_path, "").unwrap();
+
+        let app = build_router(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+            )
+            .await
+            .unwrap();
+        });
+
+        let url = format!("ws://127.0.0.1:{port}/api/v1/agents/alpha/stream");
+        let (mut ws, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Append 3 lines in a single write
+        std::fs::write(
+            &log_path,
+            format!(
+                "{{\"ts\":\"{date}T00:00:00Z\",\"kind\":\"a\"}}\n\
+                 {{\"ts\":\"{date}T00:00:01Z\",\"kind\":\"b\"}}\n\
+                 {{\"ts\":\"{date}T00:00:02Z\",\"kind\":\"c\"}}\n"
+            ),
+        )
+        .unwrap();
+
+        // Collect 3 frames within a generous timeout
+        use futures_util::StreamExt;
+        let mut kinds: Vec<String> = Vec::new();
+        for _ in 0..3 {
+            let msg = tokio::time::timeout(std::time::Duration::from_secs(3), ws.next())
+                .await
+                .expect("frame within 3s")
+                .expect("stream not closed")
+                .expect("frame ok");
+            if let tungstenite::Message::Text(t) = msg {
+                let v: serde_json::Value = serde_json::from_str(&t).unwrap();
+                kinds.push(v["kind"].as_str().unwrap().to_string());
+            }
+        }
+        assert_eq!(kinds, vec!["a", "b", "c"]);
     }
 }

--- a/mur-core/src/server_agents/telemetry.rs
+++ b/mur-core/src/server_agents/telemetry.rs
@@ -34,7 +34,9 @@ pub async fn tail_handler(
     if !home.exists() {
         return Err(AppError::NotFound(format!("agent '{name}' not found")));
     }
-    let date = q.date.unwrap_or_else(|| chrono::Utc::now().format("%Y-%m-%d").to_string());
+    let date = q
+        .date
+        .unwrap_or_else(|| chrono::Utc::now().format("%Y-%m-%d").to_string());
     let path = home.join("telemetry").join(format!("{date}.jsonl"));
 
     let body = match std::fs::read_to_string(&path) {
@@ -93,6 +95,10 @@ pub async fn stream_handler(
 async fn stream_loop(mut socket: WebSocket, home: std::path::PathBuf) {
     // Always tail today's file (UTC). On midnight rollover the loop
     // re-resolves the path on the next tick.
+    //
+    // Assumes append-only writers: detects truncation (`len < pos`) but not
+    // file replacement (inode change). External rotation tools that rm+recreate
+    // the file may miss lines from the new file.
     let mut current_date = String::new();
     let mut pos: u64 = 0;
     let mut leftover = String::new();
@@ -120,7 +126,11 @@ async fn stream_loop(mut socket: WebSocket, home: std::path::PathBuf) {
             }
             if len > pos && f.seek(SeekFrom::Start(pos)).await.is_ok() {
                 let mut buf = String::new();
-                if BufReader::new(&mut f).read_to_string(&mut buf).await.is_ok() {
+                if BufReader::new(&mut f)
+                    .read_to_string(&mut buf)
+                    .await
+                    .is_ok()
+                {
                     pos = len;
                     leftover.push_str(&buf);
                     while let Some(idx) = leftover.find('\n') {
@@ -129,7 +139,11 @@ async fn stream_loop(mut socket: WebSocket, home: std::path::PathBuf) {
                         if line.is_empty() {
                             continue;
                         }
-                        if socket.send(Message::Text(line.to_string().into())).await.is_err() {
+                        if socket
+                            .send(Message::Text(line.to_string().into()))
+                            .await
+                            .is_err()
+                        {
                             return; // client disconnected
                         }
                     }
@@ -226,7 +240,9 @@ mod tests {
         let resp = app
             .oneshot(
                 Request::builder()
-                    .uri("/api/v1/agents/alpha/telemetry?date=2026-04-28&since=2026-04-28T07:00:04Z")
+                    .uri(
+                        "/api/v1/agents/alpha/telemetry?date=2026-04-28&since=2026-04-28T07:00:04Z",
+                    )
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/mur-core/src/server_agents/telemetry.rs
+++ b/mur-core/src/server_agents/telemetry.rs
@@ -1,0 +1,1 @@
+//! `GET /api/v1/agents/{name}/telemetry` and `WS /api/v1/agents/{name}/stream`.

--- a/mur-core/tests/agent_create_identity.rs
+++ b/mur-core/tests/agent_create_identity.rs
@@ -1,3 +1,8 @@
+// Hardcodes a `/tmp/...` path for the runtime stub binary which doesn't exist
+// on Windows. Gate to Unix matching the pattern used by other Unix-only tests
+// in this crate.
+#![cfg(unix)]
+
 use mur_common::identity::AgentIdentity;
 use std::process::Command;
 use tempfile::TempDir;

--- a/mur-core/tests/agent_rekey_cli.rs
+++ b/mur-core/tests/agent_rekey_cli.rs
@@ -1,4 +1,9 @@
 //! Integration tests for `mur agent rekey` (M1.4).
+//
+// Spawns `mur agent create` which copies a runtime binary into a temp dir;
+// on Windows the source path lacks `.exe` and the copy fails. Gate to Unix
+// matching the pattern used by the rest of `mur-core/tests/agent_*.rs`.
+#![cfg(unix)]
 
 use std::path::PathBuf;
 use std::process::Command;

--- a/mur-core/tests/server_agents_routes.rs
+++ b/mur-core/tests/server_agents_routes.rs
@@ -1,0 +1,96 @@
+//! End-to-end smoke for the read-only Phase 4 agent routes.
+//! Spins up the real `build_router` against a tempdir, exercises every route.
+
+#![cfg(feature = "server")]
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use mur_core::server::{AppState, ServerConfig, build_router};
+
+fn build_state(tmp: &tempfile::TempDir) -> AppState {
+    let agents_dir = tmp.path().join("agents");
+    std::fs::create_dir_all(&agents_dir).unwrap();
+    AppState {
+        patterns_dir: tmp.path().join("patterns"),
+        workflows_dir: tmp.path().join("workflows"),
+        pipelines_dir: tmp.path().join("pipelines"),
+        agents_dir,
+        index_dir: tmp.path().join("index"),
+        config: ServerConfig { readonly: false },
+        events_tx: tokio::sync::broadcast::channel(64).0,
+    }
+}
+
+fn write_min_profile(dir: &std::path::Path, name: &str, display: &str) {
+    std::fs::create_dir_all(dir).unwrap();
+    let id_suffix = name.bytes().fold(0u64, |a, b| a.wrapping_add(b as u64));
+    let yaml = format!(
+        "schema: 1\nid: 0192f5a1-28ab-7111-8000-{id_suffix:012x}\nname: {name}\n\
+         display_name: \"{display}\"\nversion: \"0.1.0\"\npersona:\n  category: research\n  \
+         description: \"Test agent\"\n  traits:\n    tone: concise\n    risk: cautious\n    verbosity: low\n\
+         sys_prompt_file: \"sys_prompt.md\"\nmodel:\n  provider: ollama\n  name: \"m\"\n  params: {{}}\n\
+         mcp_servers: []\nskills: []\ntransport:\n  stdio: true\n  socket:\n    enabled: true\n    bind: \"unix:///tmp/{name}.sock\"\n\
+         communication:\n  accepts_from: [\"*\"]\n  sends_to: []\ncapabilities: [\"a2a.message.send\"]\n\
+         entitlements:\n  network:\n    inbound:\n      ports: []\n    outbound:\n      mode: restricted\n      allow_hosts: []\n      protocols: [\"tcp\"]\n      resolve_dns:\n        mode: system\n  filesystem:\n    read: []\n    write: []\n    deny: []\n  processes:\n    spawn:\n      mode: allowlist\n      allowed: []\n  syscalls:\n    mode: default\n  limits:\n    memory_mb: 512\n    file_descriptors: 1024\n    processes: 32\n\
+         notifications:\n  on_task_complete: []\n  on_error: []\n  on_shutdown: []\nretry:\n  llm:\n    max_retries: 3\n    backoff: exponential\n    initial_delay_ms: 1000\n    max_delay_ms: 30000\n    retry_on: [\"rate_limit\"]\n  tool:\n    max_retries: 1\n    backoff: fixed\n    initial_delay_ms: 500\n\
+         lifecycle:\n  restart: on_failure\n  max_restarts: 3\n  restart_window_secs: 600\n  stop_timeout_secs: 15\n  mcp_required: true\n\
+         created_at: \"2026-04-28T10:00:00+08:00\"\nupdated_at: \"2026-04-28T10:00:00+08:00\"\n"
+    );
+    std::fs::write(dir.join("profile.yaml"), yaml).unwrap();
+}
+
+#[tokio::test]
+async fn end_to_end_all_readonly_routes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state = build_state(&tmp);
+    let home = state.agents_dir.join("support_bot");
+    write_min_profile(&home, "support_bot", "Support");
+    std::fs::create_dir_all(home.join("telemetry")).unwrap();
+    std::fs::write(
+        home.join("telemetry").join("2026-04-28.jsonl"),
+        r#"{"ts":"2026-04-28T07:00:00Z","kind":"start"}
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(home.join("evals")).unwrap();
+    std::fs::write(
+        home.join("evals").join("eval-20260428T072501-aaaa.json"),
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "run_id": "eval-20260428T072501-aaaa",
+            "suite": "v1",
+            "agent": "support_bot",
+            "started_at": "2026-04-28T07:25:01Z",
+            "finished_at": "2026-04-28T07:25:05Z",
+            "matrix": {"providers": ["ollama/llama3.2:3b"], "system_prompts": ["a"]},
+            "results": [],
+            "summary": {"total": 0, "passed": 0, "failed": 0}
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let app = build_router(state);
+    for path in [
+        "/api/v1/agents",
+        "/api/v1/agents/support_bot",
+        "/api/v1/agents/support_bot/telemetry?date=2026-04-28",
+        "/api/v1/agents/support_bot/evals",
+        "/api/v1/agents/support_bot/evals/eval-20260428T072501-aaaa",
+    ] {
+        let resp = app
+            .clone()
+            .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "route {path} returned non-200"
+        );
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        assert!(!bytes.is_empty(), "route {path} returned empty body");
+    }
+}

--- a/mur-core/tests/server_agents_routes.rs
+++ b/mur-core/tests/server_agents_routes.rs
@@ -93,4 +93,27 @@ async fn end_to_end_all_readonly_routes() {
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         assert!(!bytes.is_empty(), "route {path} returned empty body");
     }
+
+    // Confirm the API shape: no lock was written, so support_bot must report "stopped".
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/agents/support_bot")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(
+        json["status"]["status"], "stopped",
+        "agent without a lock file must report status=stopped"
+    );
+    assert_eq!(
+        json["status"]["pid"],
+        serde_json::Value::Null,
+        "agent without a lock file must have null pid"
+    );
 }


### PR DESCRIPTION
## Summary
- Adds nested `/api/v1/agents/*` router with 6 read-only endpoints.
- Backed by `~/.mur/agents/<name>/{profile.yaml, running.lock, telemetry/<date>.jsonl, evals/<id>.json}` — no daemon, no socket calls.
- Live telemetry tail via WebSocket (poll-based, 250ms tick).
- Implements Phase 4 of the design at `mur-agent-harness/phase9/design.md` ("mur serve agent routes" table — read-only rows only).

## Routes
| Method | Path | Purpose |
|--------|------|---------|
| GET | `/api/v1/agents` | List agents under `~/.mur/agents/` with running flag |
| GET | `/api/v1/agents/{name}` | Full profile + lock-file status (running/pid) |
| GET | `/api/v1/agents/{name}/telemetry?date&since&limit` | JSONL tail |
| WS  | `/api/v1/agents/{name}/stream` | Live tail of today's JSONL |
| GET | `/api/v1/agents/{name}/evals` | Run summaries, newest first |
| GET | `/api/v1/agents/{name}/evals/{run_id}` | Full run JSON (path-traversal-guarded) |

## Out of scope (Phase 6)
- Write actions (POST messages, PUT profile, POST spawn/stop/run).
- Auth / CSRF.
- SPA dashboard tab (Phase 5).

## Test plan
- [x] Per-handler unit tests in each `server_agents/<name>.rs`
- [x] WebSocket round-trip test in `telemetry.rs`
- [x] End-to-end smoke in `tests/server_agents_routes.rs`
- [x] `cargo clippy --workspace --features server -- -D warnings`
- [x] `cargo fmt --check`