### PR TITLE
docs(contributing): explain axum 0.7/0.8 workaround for middleware (refs #39)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to mur
+
+## axum middleware in this workspace
+
+**TL;DR:** Do not use axum extractors as parameters in `from_fn` middleware functions in this workspace. Read extensions directly instead. See below for why and how.
+
+### The dual-version situation (issue #39)
+
+The workspace currently carries **two versions of axum** in its dependency graph:
+
+- **axum 0.8** — direct dependency of `mur-core` (server feature) and `mur-agent-runtime`
+- **axum 0.7** — transitive dependency pulled in by `qdrant-client` → `tonic 0.12`
+
+```
+$ cargo tree --workspace -i axum
+axum v0.7.9
+└── tonic v0.12.3
+    └── qdrant-client v1.17.0
+        └── mur-core v2.4.1
+
+axum v0.8.9
+├── mur-agent-runtime v0.1.0
+└── mur-core v2.4.1
+```
+
+The root cause is that `qdrant-client` (as of v1.17.0, the latest release) requires `tonic ^0.12`, which in turn requires axum 0.7. Tonic 0.13+ switched to axum 0.8, but qdrant-client has not yet published a release that adopts tonic 0.13. Until it does, the dual-version situation persists.
+
+Track progress on the fix at **[issue #39](https://github.com/mur-run/mur/issues/39)**.
+
+### Why this bites axum middleware
+
+The natural signature for `from_fn` middleware that inspects the peer address is:
+
+```rust
+// DO NOT USE — fails to compile in this workspace
+async fn loopback_only(
+    addr: Option<axum::extract::ConnectInfo<SocketAddr>>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    // ...
+}
+```
+
+This fails because Rust resolves the `FromRequestParts` trait implementation for `ConnectInfo` against **axum 0.7** (the version in scope via tonic's transitive dep), while the `from_fn` wrapper is compiled against **axum 0.8**. The trait bounds don't match and the compiler emits a confusing error that looks like a user error, not a dependency conflict.
+
+### The workaround pattern
+
+Read `ConnectInfo` (or any other extension that would normally be an extractor) directly from `req.extensions()`, bypassing `FromRequestParts` entirely:
+
+```rust
+// CORRECT — works regardless of which axum version tonic pulls in
+pub(crate) async fn loopback_only(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let is_loopback = req
+        .extensions()
+        .get::<axum::extract::ConnectInfo<SocketAddr>>()
+        .map(|axum::extract::ConnectInfo(addr)| addr.ip().is_loopback())
+        .unwrap_or(true);
+    // ...
+}
+```
+
+The canonical live example lives in
+`mur-core/src/server_agents/mod.rs` — the `loopback_only` function.
+
+### When the fix lands
+
+Once qdrant-client publishes a release that uses tonic 0.13+ (axum 0.8), bump `qdrant-client` in `mur-core/Cargo.toml`, verify `cargo tree --workspace -i axum` shows only one version, then rewrite `loopback_only` (and any other middleware that used this workaround) back to the natural extractor parameter form.

--- a/mur-core/src/server_agents/mod.rs
+++ b/mur-core/src/server_agents/mod.rs
@@ -67,8 +67,12 @@ pub(crate) async fn loopback_only(
     req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
-    // Extract ConnectInfo from the request extensions directly so we don't
-    // depend on FromRequestParts trait resolution across multiple axum versions.
+    // Extract ConnectInfo from request extensions directly rather than using the
+    // FromRequestParts extractor parameter form. The workspace carries both axum
+    // 0.7 (via qdrant-client → tonic 0.12) and axum 0.8 (direct dep); the
+    // extractor signature fails to compile because trait bounds resolve against
+    // the wrong version. See CONTRIBUTING.md § "axum middleware in this
+    // workspace" and issue #39 for the full explanation and the intended fix.
     let is_loopback = req
         .extensions()
         .get::<ConnectInfo<SocketAddr>>()


### PR DESCRIPTION
## Summary

- `qdrant-client` 1.17.0 (the current latest) still requires `tonic ^0.12`, which transitively pulls `axum 0.7` into the workspace alongside our direct `axum 0.8` dep. Tonic 0.13+ switched to axum 0.8, but qdrant-client has not yet published a release that adopts it — so a version bump of qdrant-client/tonic alone cannot fix this today.
- This is **Outcome B** from issue #39: document the workaround until the upstream catch-up lands.
- Adds `CONTRIBUTING.md` with a dedicated section **"axum middleware in this workspace"** explaining the dependency chain, why the natural `FromRequestParts` extractor parameter fails in `from_fn` middleware, and the correct `req.extensions().get::<ConnectInfo<_>>()` pattern.
- Enhances the inline comment on `loopback_only` in `mur-core/src/server_agents/mod.rs` to point at the new CONTRIBUTING.md section and issue #39, so the next developer who reads the workaround knows exactly where to look.

## Investigation

```
$ cargo tree --workspace -i axum
axum v0.7.9
└── tonic v0.12.3
    └── qdrant-client v1.17.0  ← latest; still requires tonic ^0.12
        └── mur-core v2.4.1

axum v0.8.9
├── mur-agent-runtime v0.1.0
└── mur-core v2.4.1
```

When the fix becomes possible (qdrant-client publishes with tonic 0.13+), CONTRIBUTING.md includes the exact steps: bump `qdrant-client` in `mur-core/Cargo.toml`, verify single axum version, and rewrite `loopback_only` back to the natural extractor form.

## Test plan

- [x] `cargo build --workspace --features server` — clean
- [x] `cargo test --workspace --features server` — all pass
- [x] `cargo clippy --workspace --features server -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

refs #39