### PR TITLE
feat(gui): D1 voice — M1.2 manifest + signed-CDN download client

### DIFF
--- a/mur-agent-gui/src-tauri/build.rs
+++ b/mur-agent-gui/src-tauri/build.rs
@@ -1,3 +1,17 @@
 fn main() {
+    // M1.2.1: dev-time placeholder verifying key for the voice manifest
+    // signature pipeline. Real release builds MUST override via the
+    // MUR_VOICE_PUBKEY env var (e.g. set in CI before tauri build).
+    // This dev key is non-functional (all-zeros pubkey rejects every
+    // signature) — sufficient to make compile-time `env!()` succeed
+    // without bypassing verification at runtime.
+    if std::env::var("MUR_VOICE_PUBKEY").is_err() {
+        // 32-byte zero pubkey, base58btc multibase-encoded with leading 'z'.
+        println!(
+            "cargo:rustc-env=MUR_VOICE_PUBKEY=z11111111111111111111111111111111"
+        );
+    }
+    println!("cargo:rerun-if-env-changed=MUR_VOICE_PUBKEY");
+
     tauri_build::build()
 }

--- a/mur-agent-gui/src-tauri/build.rs
+++ b/mur-agent-gui/src-tauri/build.rs
@@ -7,9 +7,7 @@ fn main() {
     // without bypassing verification at runtime.
     if std::env::var("MUR_VOICE_PUBKEY").is_err() {
         // 32-byte zero pubkey, base58btc multibase-encoded with leading 'z'.
-        println!(
-            "cargo:rustc-env=MUR_VOICE_PUBKEY=z11111111111111111111111111111111"
-        );
+        println!("cargo:rustc-env=MUR_VOICE_PUBKEY=z11111111111111111111111111111111");
     }
     println!("cargo:rerun-if-env-changed=MUR_VOICE_PUBKEY");
 

--- a/mur-agent-gui/src-tauri/src/voice/download.rs
+++ b/mur-agent-gui/src-tauri/src/voice/download.rs
@@ -1,1 +1,269 @@
-//! Voice download client — full impl lands in M1.2.2.
+//! Voice download client. Streams bytes from a signed CDN, computes
+//! SHA-256 incrementally, verifies against the manifest, and stages
+//! each asset atomically (temp file + rename).
+//!
+//! Used by both `voice_download` (per-voice packs) and `voice_stt_download`
+//! (the whisper STT model). The two share schema + verification +
+//! atomicity guarantees; only the manifest deserialisation differs.
+
+use anyhow::{Context, Result, bail};
+use futures::StreamExt;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+
+use super::manifest::{
+    AssetBundle, AssetEntry, SttModelManifest, VoiceManifest, verify_and_parse, verify_signature,
+};
+
+const CONNECT_TIMEOUT_S: u64 = 10;
+const TOTAL_TIMEOUT_S: u64 = 600;
+
+/// Override for tests / staging via `MUR_VOICE_CDN_BASE`.
+fn cdn_base() -> String {
+    std::env::var("MUR_VOICE_CDN_BASE").unwrap_or_else(|_| "https://voices.mur.run".to_string())
+}
+
+/// Progress events streamed back to the GUI for the progress UI.
+/// Frontend listens on `voice://download-progress` (voices) or
+/// `voice://stt-download-progress` (STT model).
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind")]
+pub enum DownloadProgress {
+    ManifestFetched,
+    ManifestVerified,
+    AssetStarted {
+        name: String,
+        size_bytes: u64,
+    },
+    AssetProgress {
+        name: String,
+        downloaded_bytes: u64,
+        total_bytes: u64,
+    },
+    AssetComplete {
+        name: String,
+    },
+    Done,
+}
+
+#[derive(Debug, Clone)]
+pub struct DownloadHandle {
+    pub bundle_id: String,
+    pub install_dir: PathBuf,
+}
+
+/// Download a voice pack. The downloaded `manifest.json` + `manifest.json.sig`
+/// are persisted alongside the assets so later launches can re-verify
+/// integrity without re-fetching the network.
+pub async fn download_voice(
+    voice_id: &str,
+    install_dir: PathBuf,
+    progress: tokio::sync::mpsc::Sender<DownloadProgress>,
+    cancel: tokio_util::sync::CancellationToken,
+) -> Result<DownloadHandle> {
+    let client = build_client()?;
+
+    let manifest_url = format!("{}/{voice_id}/manifest.json", cdn_base());
+    let sig_url = format!("{}/{voice_id}/manifest.json.sig", cdn_base());
+
+    let manifest_bytes = client
+        .get(&manifest_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+    let _ = progress.send(DownloadProgress::ManifestFetched).await;
+
+    let sig_bytes = client
+        .get(&sig_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+
+    let bundle = verify_and_parse(&manifest_bytes, &sig_bytes)
+        .context("voice manifest verification failed; refusing to install")?;
+    let _ = progress.send(DownloadProgress::ManifestVerified).await;
+
+    let manifest: VoiceManifest = match bundle {
+        AssetBundle::Voice(v) => v,
+        AssetBundle::SttModel(_) => bail!("expected `kind: voice` manifest, got STT model"),
+    };
+    if manifest.voice_id != voice_id {
+        bail!(
+            "manifest voice_id `{}` does not match request `{voice_id}`",
+            manifest.voice_id
+        );
+    }
+
+    fs::create_dir_all(&install_dir).await?;
+    for asset in &manifest.assets {
+        if cancel.is_cancelled() {
+            bail!("download cancelled");
+        }
+        download_one_asset(&client, asset, &install_dir, &progress, &cancel)
+            .await
+            .with_context(|| format!("downloading asset {}", asset.name))?;
+    }
+
+    fs::write(install_dir.join("manifest.json"), &manifest_bytes).await?;
+    fs::write(install_dir.join("manifest.json.sig"), &sig_bytes).await?;
+
+    let _ = progress.send(DownloadProgress::Done).await;
+    Ok(DownloadHandle {
+        bundle_id: voice_id.into(),
+        install_dir,
+    })
+}
+
+/// Download an STT model bundle (whisper-large-v3-turbo-q5_1 in v1).
+/// Mirrors `download_voice` but expects `kind: stt-model`.
+pub async fn download_stt_model(
+    model_id: &str,
+    install_dir: PathBuf,
+    progress: tokio::sync::mpsc::Sender<DownloadProgress>,
+    cancel: tokio_util::sync::CancellationToken,
+) -> Result<DownloadHandle> {
+    let client = build_client()?;
+
+    let manifest_url = format!("{}/_stt/{model_id}/manifest.json", cdn_base());
+    let sig_url = format!("{}/_stt/{model_id}/manifest.json.sig", cdn_base());
+
+    let manifest_bytes = client
+        .get(&manifest_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+    let _ = progress.send(DownloadProgress::ManifestFetched).await;
+
+    let sig_bytes = client
+        .get(&sig_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+
+    verify_signature(&manifest_bytes, &sig_bytes)
+        .context("STT manifest signature verification failed; refusing to install")?;
+    let _ = progress.send(DownloadProgress::ManifestVerified).await;
+
+    let manifest: SttModelManifest = serde_json::from_slice(&manifest_bytes)
+        .context("STT manifest is not valid SttModelManifest JSON")?;
+    if manifest.model_id != model_id {
+        bail!(
+            "manifest model_id `{}` does not match request `{model_id}`",
+            manifest.model_id
+        );
+    }
+
+    fs::create_dir_all(&install_dir).await?;
+    for asset in &manifest.assets {
+        if cancel.is_cancelled() {
+            bail!("download cancelled");
+        }
+        download_one_asset(&client, asset, &install_dir, &progress, &cancel)
+            .await
+            .with_context(|| format!("downloading asset {}", asset.name))?;
+    }
+
+    fs::write(install_dir.join("manifest.json"), &manifest_bytes).await?;
+    fs::write(install_dir.join("manifest.json.sig"), &sig_bytes).await?;
+
+    let _ = progress.send(DownloadProgress::Done).await;
+    Ok(DownloadHandle {
+        bundle_id: model_id.into(),
+        install_dir,
+    })
+}
+
+fn build_client() -> Result<reqwest::Client> {
+    Ok(reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(CONNECT_TIMEOUT_S))
+        .timeout(std::time::Duration::from_secs(TOTAL_TIMEOUT_S))
+        .build()?)
+}
+
+async fn download_one_asset(
+    client: &reqwest::Client,
+    asset: &AssetEntry,
+    install_dir: &Path,
+    progress: &tokio::sync::mpsc::Sender<DownloadProgress>,
+    cancel: &tokio_util::sync::CancellationToken,
+) -> Result<()> {
+    let _ = progress
+        .send(DownloadProgress::AssetStarted {
+            name: asset.name.clone(),
+            size_bytes: asset.size_bytes,
+        })
+        .await;
+
+    let resp = client.get(&asset.url).send().await?.error_for_status()?;
+    let mut stream = resp.bytes_stream();
+
+    let tmp = install_dir.join(format!("{}.partial", asset.name));
+    let final_path = install_dir.join(&asset.name);
+    let mut file = fs::File::create(&tmp).await?;
+    let mut hasher = Sha256::new();
+    let mut downloaded: u64 = 0;
+    let mut last_progress = std::time::Instant::now();
+
+    while let Some(chunk) = stream.next().await {
+        if cancel.is_cancelled() {
+            drop(file);
+            let _ = fs::remove_file(&tmp).await;
+            bail!("download cancelled mid-asset");
+        }
+        let bytes = chunk?;
+        hasher.update(&bytes);
+        file.write_all(&bytes).await?;
+        downloaded += bytes.len() as u64;
+        if last_progress.elapsed() > std::time::Duration::from_millis(150) {
+            let _ = progress
+                .send(DownloadProgress::AssetProgress {
+                    name: asset.name.clone(),
+                    downloaded_bytes: downloaded,
+                    total_bytes: asset.size_bytes,
+                })
+                .await;
+            last_progress = std::time::Instant::now();
+        }
+    }
+    file.flush().await?;
+    file.sync_all().await?;
+    drop(file);
+
+    if downloaded != asset.size_bytes {
+        let _ = fs::remove_file(&tmp).await;
+        bail!(
+            "size mismatch on {}: got {}, expected {}",
+            asset.name,
+            downloaded,
+            asset.size_bytes
+        );
+    }
+    let actual = hex::encode(hasher.finalize());
+    if actual != asset.sha256_hex {
+        let _ = fs::remove_file(&tmp).await;
+        bail!(
+            "sha256 mismatch on {}: got {actual}, expected {}",
+            asset.name,
+            asset.sha256_hex
+        );
+    }
+
+    fs::rename(&tmp, &final_path).await?;
+    let _ = progress
+        .send(DownloadProgress::AssetComplete {
+            name: asset.name.clone(),
+        })
+        .await;
+    Ok(())
+}

--- a/mur-agent-gui/src-tauri/src/voice/manifest.rs
+++ b/mur-agent-gui/src-tauri/src/voice/manifest.rs
@@ -1,1 +1,208 @@
-//! Voice manifest — full impl lands in M1.2.1.
+//! Voice manifest — signed JSON describing a voice asset bundle.
+//!
+//! Hosted at `<MUR_VOICE_CDN_BASE>/<voice_id>/manifest.json` with a
+//! detached Ed25519 signature at `manifest.json.sig`.
+//!
+//! The verifying public key is **pinned at build time** via the
+//! `MUR_VOICE_PUBKEY` env var. Rotation requires a binary release.
+//! Dev builds get a placeholder via `build.rs`; production releases
+//! MUST override `MUR_VOICE_PUBKEY` in CI before the Tauri build.
+//!
+//! Schema is shared between voice packs and the STT model bundle —
+//! see roadmap §4.1 + the M1 plan §M1.2.1 for the design rationale.
+
+use anyhow::{Context, Result, bail};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Compile-time pinned voice-manifest verifying key (multibase z…).
+pub const PINNED_VOICE_PUBKEY: &str = env!("MUR_VOICE_PUBKEY");
+
+/// Tagged union of asset-bundle manifests. New `kind` values are
+/// additive and must default-deserialise on existing clients.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum AssetBundle {
+    Voice(VoiceManifest),
+    SttModel(SttModelManifest),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VoiceManifest {
+    pub schema_version: u32,
+    pub voice_id: String,
+    pub display_name: String,
+    /// BCP-47, e.g. `en-US` or `zh-TW`.
+    pub language: String,
+    /// Kokoro is 24 kHz; we resample to 22.05 kHz for playback.
+    pub sample_rate_hz: u32,
+    /// SPDX license id, e.g. "MIT".
+    pub license: String,
+    pub creator: String,
+    pub assets: Vec<AssetEntry>,
+    pub size_bytes_total: u64,
+}
+
+/// STT model manifest. Same signing + SHA-256 + atomic-rename
+/// download path as voices, but lives under a separate registry slot
+/// (`<app_data>/voices/_stt/<model_id>/`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SttModelManifest {
+    pub schema_version: u32,
+    pub model_id: String,
+    pub display_name: String,
+    /// "whisper.cpp" only in v1.
+    pub backend: String,
+    /// BCP-47 list of languages the model supports well.
+    pub languages: Vec<String>,
+    pub license: String,
+    pub assets: Vec<AssetEntry>,
+    pub size_bytes_total: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssetEntry {
+    pub name: String,
+    /// Lowercase hex of the asset's SHA-256.
+    pub sha256_hex: String,
+    pub size_bytes: u64,
+    /// Absolute https URL.
+    pub url: String,
+}
+
+/// Verify the detached signature against `manifest_bytes` using the
+/// pinned pubkey. Returns the parsed bundle on success.
+pub fn verify_and_parse(manifest_bytes: &[u8], sig_bytes: &[u8]) -> Result<AssetBundle> {
+    verify_signature(manifest_bytes, sig_bytes)?;
+    serde_json::from_slice(manifest_bytes).context("voice manifest is not valid JSON")
+}
+
+/// Just verify the signature without parsing — useful when the caller
+/// already deserialises into a specific variant.
+pub fn verify_signature(manifest_bytes: &[u8], sig_bytes: &[u8]) -> Result<()> {
+    if sig_bytes.len() != 64 {
+        bail!(
+            "voice manifest signature must be 64 bytes; got {}",
+            sig_bytes.len()
+        );
+    }
+    let pubkey = decode_pinned_pubkey()?;
+    let mut sig_arr = [0u8; 64];
+    sig_arr.copy_from_slice(sig_bytes);
+    let signature = Signature::from_bytes(&sig_arr);
+    pubkey
+        .verify(manifest_bytes, &signature)
+        .context("voice manifest signature verification failed")?;
+    Ok(())
+}
+
+/// SHA-256 hex of `bytes`. Used to verify each downloaded asset against
+/// the manifest entry.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+fn decode_pinned_pubkey() -> Result<VerifyingKey> {
+    let raw = multibase_decode_z(PINNED_VOICE_PUBKEY)?;
+    if raw.len() != 32 {
+        bail!(
+            "pinned voice pubkey must decode to 32 bytes; got {}",
+            raw.len()
+        );
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&raw);
+    VerifyingKey::from_bytes(&arr).context("invalid pinned voice pubkey")
+}
+
+fn multibase_decode_z(s: &str) -> Result<Vec<u8>> {
+    let s = s
+        .strip_prefix('z')
+        .context("expected multibase z prefix on voice pubkey")?;
+    bs58::decode(s)
+        .into_vec()
+        .context("invalid base58 in voice pubkey")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+    use rand::rngs::OsRng;
+
+    #[test]
+    fn sha256_hex_matches_known_vector() {
+        // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn signature_round_trip_with_freshly_generated_key() {
+        // Exercises the signing path; end-to-end pubkey pinning is
+        // exercised by integration tests with MUR_VOICE_PUBKEY override.
+        let mut csprng = OsRng;
+        let key = SigningKey::generate(&mut csprng);
+        let payload = br#"{"kind":"voice","schema_version":1,"voice_id":"x","display_name":"X","language":"en-US","sample_rate_hz":24000,"license":"MIT","creator":"test","assets":[],"size_bytes_total":0}"#;
+        let sig = key.sign(payload);
+        assert!(key.verifying_key().verify(payload, &sig).is_ok());
+    }
+
+    #[test]
+    fn signature_wrong_length_rejected() {
+        let r = verify_signature(b"hello", &[0u8; 32]);
+        assert!(r.is_err());
+        assert!(format!("{r:?}").contains("64 bytes"));
+    }
+
+    #[test]
+    fn parse_voice_manifest_round_trip() {
+        let m = AssetBundle::Voice(VoiceManifest {
+            schema_version: 1,
+            voice_id: "af_heart".into(),
+            display_name: "Af Heart".into(),
+            language: "en-US".into(),
+            sample_rate_hz: 24000,
+            license: "MIT".into(),
+            creator: "hexgrad".into(),
+            assets: vec![AssetEntry {
+                name: "voice.onnx".into(),
+                sha256_hex: "abc".into(),
+                size_bytes: 100,
+                url: "https://x".into(),
+            }],
+            size_bytes_total: 100,
+        });
+        let s = serde_json::to_vec(&m).unwrap();
+        let parsed: AssetBundle = serde_json::from_slice(&s).unwrap();
+        match parsed {
+            AssetBundle::Voice(v) => assert_eq!(v.voice_id, "af_heart"),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn parse_stt_model_manifest_round_trip() {
+        let m = AssetBundle::SttModel(SttModelManifest {
+            schema_version: 1,
+            model_id: "whisper-large-v3-turbo-q5_1".into(),
+            display_name: "Whisper Large v3 Turbo (q5_1)".into(),
+            backend: "whisper.cpp".into(),
+            languages: vec!["en".into(), "zh".into()],
+            license: "MIT".into(),
+            assets: vec![],
+            size_bytes_total: 0,
+        });
+        let s = serde_json::to_vec(&m).unwrap();
+        let parsed: AssetBundle = serde_json::from_slice(&s).unwrap();
+        match parsed {
+            AssetBundle::SttModel(v) => assert_eq!(v.backend, "whisper.cpp"),
+            _ => panic!("wrong variant"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Second slice of M1 D1 voice — the signed-CDN substrate. Lays down the manifest schema + Ed25519 verify + SHA-256 streaming download path that both voice packs and the whisper STT model use. No behavior change: nothing calls these yet (Tauri commands wire up in M1.5.1, GUI surfaces in M1.5.2).

**Plan:** [`docs/superpowers/plans/2026-04-30-mur-agent-d1-voice.md`](docs/superpowers/plans/2026-04-30-mur-agent-d1-voice.md) §M1.2.1 + §M1.2.2.
**Predecessors:** PR #44 (M0 hooks), #46 (threat model), #47 (M1 plan), #48 (M1.1 foundation) — all merged.

## What lands

**M1.2.1 — `voice/manifest.rs` (216 LOC + 5 unit tests):**
- `AssetBundle` tagged union (`kind: voice | stt-model`) — same signing path serves both, per the plan's default-off update.
- `VoiceManifest` { schema_version, voice_id, display_name, language (BCP-47), sample_rate_hz, license, creator, assets[], size_bytes_total }.
- `SttModelManifest` { schema_version, model_id, display_name, backend ("whisper.cpp" v1), languages[], license, assets[], size_bytes_total }.
- `AssetEntry` { name, sha256_hex, size_bytes, url } shared by both variants.
- `verify_and_parse()` happy path + `verify_signature()` sig-only (used when caller deserialises into a specific variant).
- `sha256_hex()` helper for incremental verify during download.
- Pubkey pinned at compile time via `env!("MUR_VOICE_PUBKEY")`. Release builds **must** set this; `build.rs` ships a non-functional all-zeros placeholder for dev so `env!()` succeeds without bypassing runtime verification.
- Multibase z-base58btc decoder for the pubkey (matches mur-common identity convention).

**M1.2.2 — `voice/download.rs` (269 LOC):**
- `DownloadProgress` enum streamed to the frontend (`#[serde(tag = "kind")]` for JS pattern matching).
- `download_voice(voice_id, install_dir, progress, cancel)` — full fetch-verify-stream-rename cycle. Persists `manifest.json` + `manifest.json.sig` alongside assets so later launches can re-verify integrity offline.
- `download_stt_model(model_id, ...)` — same shape, posts at `<CDN>/_stt/<model_id>/...`, expects `kind: stt-model`.
- `download_one_asset()` — shared streaming + cancellation + size + SHA-256 + atomic temp+rename pipeline.
- `cdn_base()` reads `MUR_VOICE_CDN_BASE` env for tests/staging; default `https://voices.mur.run`.
- 150 ms progress throttling avoids flooding the GUI event channel.
- Connect timeout 10 s, total timeout 600 s.

## Verification

- M1.2.1 unit tests: 5/5 pass (sha256 known vector, sig round-trip, sig-length rejection, voice manifest round-trip, STT manifest round-trip).
- M1.2.2 build: not verified locally (disk pressure on local dev). CI will verify on push.

## Next slices

- M1.2.3 `VoiceRegistry` full impl (persistence + bundled-voice seeding)
- M1.2.4 Integration test (httpmock + ed25519 round-trip)
- M1.3.x Kokoro TTS
- M1.4.x whisper STT + cpal
- M1.5.x Tauri commands + frontend voice picker + opt-in panel
- M1.6.x PTT hotkey + bench + e2e

## Test plan

- [ ] CI green on macOS / Linux / Windows
- [x] No behavior change (no commands registered, no UI)
- [x] Backward compatible: existing `mur-agent-gui` features unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)