### PR TITLE
feat(gui): D1 voice — M1.6.2 PTT button + capture worker thread

### DIFF
--- a/mur-agent-gui/src-tauri/src/commands.rs
+++ b/mur-agent-gui/src-tauri/src/commands.rs
@@ -590,9 +590,35 @@ pub async fn stt_transcribe_pcm16k(
     stt.transcribe(&samples_i16, None).await.map_err(err)
 }
 
-// PTT capture lifecycle (`voice_start_capture` / `voice_stop_capture`)
-// ships in M1.6.2 alongside the PttButton frontend. `cpal::Stream` is
-// `!Send` on macOS (Core Audio callbacks must run on the spawning
-// thread), so the capture handle can't live in `tauri::State`
-// directly — it needs a dedicated worker thread + tokio channel
-// pattern. Defer to keep this PR focused on the opt-in surface.
+// ─── PTT capture lifecycle (M1.6.2) ─────────────────────────────────
+//
+// cpal::Stream is !Send on macOS so the stream must live on a
+// dedicated OS thread. CaptureWorker (audio/capture_worker.rs) owns
+// that thread and exposes Send+Sync stop channels + JoinHandle, which
+// is safe to keep in tauri::State.
+
+use crate::voice::audio::capture_worker::CaptureWorker;
+
+pub struct ActiveCapture(pub tokio::sync::Mutex<CaptureWorker>);
+
+impl Default for ActiveCapture {
+    fn default() -> Self {
+        Self(tokio::sync::Mutex::new(CaptureWorker::new()))
+    }
+}
+
+#[tauri::command]
+pub async fn voice_start_capture(
+    state: tauri::State<'_, std::sync::Arc<ActiveCapture>>,
+) -> Result<(), String> {
+    let mut w = state.0.lock().await;
+    w.start().map_err(err)
+}
+
+#[tauri::command]
+pub async fn voice_stop_capture(
+    state: tauri::State<'_, std::sync::Arc<ActiveCapture>>,
+) -> Result<Vec<i16>, String> {
+    let mut w = state.0.lock().await;
+    w.stop().map_err(err)
+}

--- a/mur-agent-gui/src-tauri/src/main.rs
+++ b/mur-agent-gui/src-tauri/src/main.rs
@@ -113,6 +113,8 @@ fn main() -> Result<()> {
                         let state: commands::VoiceManagerState =
                             std::sync::Arc::new(tokio::sync::RwLock::new(mgr));
                         voice_app_handle.manage(state);
+                        voice_app_handle
+                            .manage(std::sync::Arc::new(commands::ActiveCapture::default()));
                         if was_enabled {
                             if let Err(e) = voice::hotkey::register_ptt(&voice_app_handle) {
                                 tracing::warn!("re-register PTT on boot: {e:#}");
@@ -282,6 +284,8 @@ fn main() -> Result<()> {
             commands::voice_stt_download,
             commands::tts_speak,
             commands::stt_transcribe_pcm16k,
+            commands::voice_start_capture,
+            commands::voice_stop_capture,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/mur-agent-gui/src-tauri/src/voice/audio/capture_worker.rs
+++ b/mur-agent-gui/src-tauri/src/voice/audio/capture_worker.rs
@@ -1,0 +1,122 @@
+//! Dedicated-thread capture worker.
+//!
+//! `cpal::Stream` is `!Send` on macOS — Core Audio callbacks must run
+//! on the same thread that built the stream. So we can't park a
+//! `CaptureHandle` in `tauri::State` (Tauri commands hop tokio
+//! workers). Instead, this worker owns an OS thread; `start()` spawns
+//! it, the thread builds the cpal stream, and parks on a stop
+//! channel. `stop()` signals the thread, joins it, and returns the
+//! drained samples.
+//!
+//! All public state (`stop_tx`, `join`) lives in `Send + Sync` types
+//! (channels + JoinHandle), so the worker itself is safe in
+//! `tokio::sync::Mutex<CaptureWorker>` inside Tauri state.
+
+use anyhow::{Result, bail};
+use std::sync::mpsc;
+use std::thread::JoinHandle;
+
+pub struct CaptureWorker {
+    join: Option<JoinHandle<Vec<i16>>>,
+    stop_tx: Option<mpsc::Sender<()>>,
+}
+
+impl CaptureWorker {
+    pub const fn new() -> Self {
+        Self {
+            join: None,
+            stop_tx: None,
+        }
+    }
+
+    /// True if a capture thread is currently running.
+    pub fn is_running(&self) -> bool {
+        self.join.is_some()
+    }
+
+    /// Spawn the capture thread. The thread builds the cpal stream,
+    /// blocks on `stop_rx.recv()`, and on stop drains the
+    /// `CaptureBuffer` into a `Vec<i16>` returned via `JoinHandle`.
+    pub fn start(&mut self) -> Result<()> {
+        if self.join.is_some() {
+            bail!("capture already running");
+        }
+        let (stop_tx, stop_rx) = mpsc::channel::<()>();
+        let join = std::thread::Builder::new()
+            .name("voice-capture".into())
+            .spawn(move || -> Vec<i16> {
+                let handle = match super::start_capture() {
+                    Ok(h) => h,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "capture thread: start_capture failed");
+                        return Vec::new();
+                    }
+                };
+                // Park until stop signal arrives. `recv()` returns Err
+                // only if the sender is dropped, which we treat as
+                // "stop now" (e.g., the worker was dropped without
+                // explicit stop()).
+                let _ = stop_rx.recv();
+                let samples = handle.buffer.drain();
+                // Dropping `handle` ends the cpal stream cleanly.
+                drop(handle);
+                samples
+            })?;
+        self.stop_tx = Some(stop_tx);
+        self.join = Some(join);
+        Ok(())
+    }
+
+    /// Signal the capture thread to stop and return the captured samples.
+    /// Idempotent: returns an error if no thread is running.
+    pub fn stop(&mut self) -> Result<Vec<i16>> {
+        let Some(stop) = self.stop_tx.take() else {
+            bail!("no active capture to stop");
+        };
+        let Some(join) = self.join.take() else {
+            bail!("no capture thread");
+        };
+        // Send is best-effort: if the thread already exited, drop the
+        // channel and just join.
+        let _ = stop.send(());
+        join.join()
+            .map_err(|_| anyhow::anyhow!("capture thread panicked"))
+    }
+}
+
+impl Default for CaptureWorker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for CaptureWorker {
+    fn drop(&mut self) {
+        // Signal stop on drop so a background capture doesn't outlive
+        // the worker. Best-effort: ignore stop / join errors.
+        if let Some(tx) = self.stop_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_worker_is_not_running() {
+        let w = CaptureWorker::new();
+        assert!(!w.is_running());
+    }
+
+    #[test]
+    fn stop_without_start_errors() {
+        let mut w = CaptureWorker::new();
+        let r = w.stop();
+        assert!(r.is_err());
+    }
+}

--- a/mur-agent-gui/src-tauri/src/voice/audio/mod.rs
+++ b/mur-agent-gui/src-tauri/src/voice/audio/mod.rs
@@ -1,6 +1,7 @@
 //! Audio I/O — cpal-based mic capture (mono i16 @ 16 kHz for whisper)
 //! and speaker playback (lands in M1.5.1).
 
+pub mod capture_worker;
 pub mod playback;
 pub mod ptt;
 pub mod ring_buffer;

--- a/mur-agent-gui/ui/src/App.tsx
+++ b/mur-agent-gui/ui/src/App.tsx
@@ -7,6 +7,7 @@ import McpTab from "./tabs/Mcp";
 import PermissionsTab from "./tabs/Permissions";
 import IdentityTab from "./tabs/Identity";
 import { VoiceTab } from "./voice/VoiceTab";
+import { PttButton } from "./voice/PttButton";
 import { setTheme as setThemeApi, getDefaultTheme, applyThemeColors } from "./lib/api";
 
 type TabId =
@@ -100,6 +101,15 @@ export default function App() {
         {tab === "permissions" && <PermissionsTab />}
         {tab === "identity" && <IdentityTab />}
       </main>
+      <PttButton
+        onTranscript={(text) => {
+          // For now, log + console. Future slices will wire this into
+          // an active chat composer. The transcript itself is already
+          // visible to the user via the recording → transcribing flow.
+          // eslint-disable-next-line no-console
+          console.log("ptt transcript:", text);
+        }}
+      />
     </div>
   );
 }

--- a/mur-agent-gui/ui/src/voice/PttButton.tsx
+++ b/mur-agent-gui/ui/src/voice/PttButton.tsx
@@ -1,0 +1,135 @@
+// Push-to-talk floating button. Default-off: renders null when
+// voice_status.enabled === false (no nag), so users who skipped
+// voice opt-in never see a "set up voice" floater on their screen.
+//
+// Hotkey wiring: the runtime emits `ptt://hotkey-down` /
+// `ptt://hotkey-up` when the user presses Cmd+Shift+' (or rebound
+// shortcut). Down → start capture. Up → stop, transcribe, hand
+// transcript to onTranscript callback. Holds shorter than 250ms
+// are treated as accidental and not transcribed; the FSM in the
+// runtime side mirrors this with the same threshold.
+
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import {
+  sttTranscribePcm16k,
+  voiceStartCapture,
+  voiceStatus,
+  voiceStopCapture,
+} from "./api";
+
+const MIN_HOLD_MS = 250;
+
+interface Props {
+  onTranscript: (transcript: string) => void;
+}
+
+export function PttButton({ onTranscript }: Props) {
+  const [enabled, setEnabled] = useState(false);
+  const [recording, setRecording] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  async function refresh() {
+    try {
+      const s = await voiceStatus();
+      setEnabled(s.enabled && s.stt_loaded);
+    } catch {
+      setEnabled(false);
+    }
+  }
+
+  useEffect(() => {
+    refresh();
+    let unlisten: (() => void) | null = null;
+    listen("voice://state-changed", () => {
+      refresh();
+    }).then((u) => {
+      unlisten = u;
+    });
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let downAt = 0;
+    let unlistenDown: (() => void) | null = null;
+    let unlistenUp: (() => void) | null = null;
+
+    listen("ptt://hotkey-down", () => {
+      downAt = Date.now();
+      setRecording(true);
+      voiceStartCapture().catch(() => {
+        // Suppress errors here — already-running, no-device, etc.
+        // The Up handler still tries to stop + drain.
+      });
+    }).then((u) => {
+      unlistenDown = u;
+    });
+
+    listen("ptt://hotkey-up", async () => {
+      const heldMs = Date.now() - downAt;
+      setRecording(false);
+      if (heldMs < MIN_HOLD_MS) {
+        // Debounce — drop the capture without transcribing.
+        try {
+          await voiceStopCapture();
+        } catch {
+          /* ignore */
+        }
+        return;
+      }
+      setBusy(true);
+      try {
+        const samples = await voiceStopCapture();
+        if (samples.length > 0) {
+          const text = await sttTranscribePcm16k(samples);
+          if (text) onTranscript(text);
+        }
+      } catch (e) {
+        // Don't surface mid-flow errors as toasts; just log.
+        // eslint-disable-next-line no-console
+        console.warn("ptt transcribe failed", e);
+      } finally {
+        setBusy(false);
+      }
+    }).then((u) => {
+      unlistenUp = u;
+    });
+
+    return () => {
+      if (unlistenDown) unlistenDown();
+      if (unlistenUp) unlistenUp();
+    };
+  }, [enabled, onTranscript]);
+
+  // Default-off: render NOTHING when voice is disabled. Users who
+  // skipped opt-in never see a floating "set up voice" prompt.
+  if (!enabled) return null;
+
+  return (
+    <div
+      className="fixed bottom-6 right-6 rounded-full px-4 py-3 shadow-lg text-sm font-medium select-none"
+      style={{
+        background: recording
+          ? "var(--color-error, #b91c1c)"
+          : busy
+            ? "var(--color-bg-secondary)"
+            : "var(--color-accent)",
+        color: "var(--color-accent-fg)",
+        opacity: busy ? 0.8 : 1,
+        transition: "background 80ms ease",
+      }}
+      title={
+        recording
+          ? "Recording — release to transcribe"
+          : busy
+            ? "Transcribing…"
+            : "Hold Cmd+Shift+' to talk"
+      }
+    >
+      {recording ? "● recording" : busy ? "… transcribing" : "Cmd+Shift+'"}
+    </div>
+  );
+}

--- a/mur-agent-gui/ui/src/voice/api.ts
+++ b/mur-agent-gui/ui/src/voice/api.ts
@@ -19,3 +19,5 @@ export const ttsSpeak = (text: string) =>
   invoke<void>("tts_speak", { text });
 export const sttTranscribePcm16k = (samplesI16: number[]) =>
   invoke<string>("stt_transcribe_pcm16k", { samplesI16 });
+export const voiceStartCapture = () => invoke<void>("voice_start_capture");
+export const voiceStopCapture = () => invoke<number[]>("voice_stop_capture");


### PR DESCRIPTION
## Summary

Stacked on PR #53 (M1.5 + M1.6.1). Implements **M1.6.2** — the deferred capture commands + PttButton frontend, closing the loop on the PTT pipeline.

**Stack:** main → #50 → #51 → #52 → #53 → **this**.
**Plan:** [`docs/superpowers/plans/2026-04-30-mur-agent-d1-voice.md`](docs/superpowers/plans/2026-04-30-mur-agent-d1-voice.md) §M1.6.2.

## What lands

### Capture worker thread (`voice/audio/capture_worker.rs`)
`cpal::Stream` is `!Send` on macOS — Core Audio callbacks must run on the spawning thread, so the stream can't live in `tauri::State` directly. `CaptureWorker` owns an OS thread that holds the stream and uses Send+Sync `mpsc::channel<()>` + `JoinHandle<Vec<i16>>` to drive start/stop from async Tauri commands.

- `start()` — spawns thread → builds cpal stream → blocks on stop signal → drains buffer on stop.
- `stop()` — signals + joins → returns drained samples.
- `Drop` impl signals stop + joins so a background capture doesn't outlive its worker.
- 2 unit tests (cumulative 52).

### Tauri commands (`commands.rs`)
- `ActiveCapture(tokio::sync::Mutex<CaptureWorker>)` — Send+Sync wrapper for state.
- `voice_start_capture` / `voice_stop_capture` — async, no `spawn_blocking` needed (start/stop are channel-fast).

### `main.rs`
- Manages `Arc<ActiveCapture>` alongside `VoiceManager`.
- Registers two new commands in `invoke_handler`.

### `PttButton.tsx`
- **Default-off**: renders `null` when `voice_status.{enabled, stt_loaded}` is false. Fresh installs and disable-after-enable users never see a "set up voice" floater.
- Listens on `ptt://hotkey-down` / `ptt://hotkey-up`.
- 250 ms debounce for accidental presses (matches the runtime-side `PttFsm`).
- Three visual states: `● recording` / `… transcribing` / `Cmd+Shift+'` ready, plus `title` hint per state.
- `voice://state-changed` subscription keeps it live with `voice_enable` / `voice_disable`.
- Globally mounted in `App.tsx` (bottom-right, regardless of active tab).

## Verification

- 2 new Rust unit tests; cumulative 52 voice tests pass.
- `cargo build -p mur-agent-gui` clean (~64 s).
- `cargo clippy --lib -- -D warnings` clean.
- `npm run build` clean (52 modules, TS strict, vite OK).

## Manual test plan (after CI green)

1. Fresh install (no `voice_state.json`): no PttButton visible. ✓
2. Settings → Voice → Enable → STT downloads → ready.
3. PttButton appears. Hold `Cmd+Shift+'` → "● recording".
4. Release after >250 ms → "… transcribing" → transcript logs to console.
5. Release before 250 ms → debounced, no transcribe.
6. Settings → Voice → Disable → PttButton disappears. ✓

## Next slice

**M1.6.3** hotkey rebinder UI (rebind `Cmd+Shift+'` from Settings).
**M1.6.4** bench harness (TTS first-byte ≤ 250 ms; STT RTF ≤ 0.5×).
**M1.6.5** `scripts/e2e/v1-d1-voice.sh`.
**M1.6.6** final acceptance sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)