### PR TITLE
feat(gui): D1 voice — M1.4 whisper STT + cpal capture + PTT state machine

### DIFF
--- a/mur-agent-gui/src-tauri/src/voice/audio/mod.rs
+++ b/mur-agent-gui/src-tauri/src/voice/audio/mod.rs
@@ -1,7 +1,13 @@
-//! Audio I/O — cpal-based capture + playback. Full impl lands in
-//! M1.4.1 (capture) and M1.5.1 (playback).
+//! Audio I/O — cpal-based mic capture (mono i16 @ 16 kHz for whisper)
+//! and speaker playback (lands in M1.5.1).
 
 pub mod ptt;
+pub mod ring_buffer;
+
+use anyhow::{Result, anyhow};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use parking_lot::Mutex;
+use std::sync::Arc;
 
 /// Sample rate whisper.cpp expects (mono i16).
 pub const STT_SAMPLE_RATE_HZ: u32 = 16_000;
@@ -10,3 +16,170 @@ pub const STT_SAMPLE_RATE_HZ: u32 = 16_000;
 /// to 22.05 kHz for slightly faster synthesis at imperceptible quality
 /// loss (per first-byte tuning notes in roadmap §4.1).
 pub const TTS_PLAYBACK_SAMPLE_RATE_HZ: u32 = 22_050;
+
+pub struct CaptureBuffer {
+    /// Resampled to STT_SAMPLE_RATE_HZ, mono, i16.
+    samples: Mutex<Vec<i16>>,
+}
+
+impl CaptureBuffer {
+    pub fn new() -> Self {
+        Self {
+            samples: Mutex::new(vec![]),
+        }
+    }
+
+    /// Take all buffered samples, leaving the buffer empty.
+    pub fn drain(&self) -> Vec<i16> {
+        std::mem::take(&mut self.samples.lock())
+    }
+
+    pub fn len(&self) -> usize {
+        self.samples.lock().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.samples.lock().is_empty()
+    }
+
+    fn extend(&self, more: &[i16]) {
+        self.samples.lock().extend_from_slice(more);
+    }
+}
+
+impl Default for CaptureBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Active capture stream. Dropping this stops capture.
+pub struct CaptureHandle {
+    _stream: cpal::Stream,
+    pub buffer: Arc<CaptureBuffer>,
+}
+
+/// Open the default input device, resample to 16 kHz mono i16, and
+/// stream into the returned `CaptureBuffer`. Drop the handle to stop.
+///
+/// Errors if no input device is available or the device's default
+/// config uses a sample format we don't yet handle (v1: f32 only;
+/// extending to i16/u16 is straightforward and lands when a real
+/// device demands it).
+pub fn start_capture() -> Result<CaptureHandle> {
+    let host = cpal::default_host();
+    let device = host
+        .default_input_device()
+        .ok_or_else(|| anyhow!("no input device available"))?;
+    let config = device.default_input_config()?;
+    let sample_rate = config.sample_rate().0;
+    let channels = config.channels() as usize;
+    let buffer = Arc::new(CaptureBuffer::new());
+    let buffer2 = buffer.clone();
+
+    let stream = match config.sample_format() {
+        cpal::SampleFormat::F32 => device.build_input_stream(
+            &config.into(),
+            move |data: &[f32], _| {
+                let mono = downmix_to_mono_f32(data, channels);
+                let resampled = resample_simple_to_16k(&mono, sample_rate);
+                let i16_samples: Vec<i16> = resampled
+                    .iter()
+                    .map(|&s| (s * i16::MAX as f32).clamp(i16::MIN as f32, i16::MAX as f32) as i16)
+                    .collect();
+                buffer2.extend(&i16_samples);
+            },
+            |e| tracing::warn!(error = %e, "capture stream error"),
+            None,
+        )?,
+        other => return Err(anyhow!("unsupported input sample format: {other:?}")),
+    };
+    stream.play()?;
+    Ok(CaptureHandle {
+        _stream: stream,
+        buffer,
+    })
+}
+
+fn downmix_to_mono_f32(data: &[f32], channels: usize) -> Vec<f32> {
+    if channels <= 1 {
+        return data.to_vec();
+    }
+    data.chunks(channels)
+        .map(|c| c.iter().sum::<f32>() / channels as f32)
+        .collect()
+}
+
+/// Naive linear-interpolation resampler. Sufficient for whisper input
+/// (it does its own internal resampling); production should use
+/// `rubato` (M1.4.4 hardening — not v1 critical path).
+fn resample_simple_to_16k(samples: &[f32], from_rate: u32) -> Vec<f32> {
+    if from_rate == STT_SAMPLE_RATE_HZ {
+        return samples.to_vec();
+    }
+    if samples.is_empty() {
+        return vec![];
+    }
+    let ratio = STT_SAMPLE_RATE_HZ as f32 / from_rate as f32;
+    let out_len = (samples.len() as f32 * ratio) as usize;
+    let mut out = Vec::with_capacity(out_len);
+    for i in 0..out_len {
+        let src = i as f32 / ratio;
+        let i0 = (src as usize).min(samples.len() - 1);
+        let i1 = (i0 + 1).min(samples.len() - 1);
+        let frac = src - i0 as f32;
+        out.push(samples[i0] * (1.0 - frac) + samples[i1] * frac);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_buffer_drain_round_trips() {
+        let b = CaptureBuffer::new();
+        assert!(b.is_empty());
+        b.extend(&[1, 2, 3]);
+        assert_eq!(b.len(), 3);
+        let got = b.drain();
+        assert_eq!(got, vec![1i16, 2, 3]);
+        assert!(b.is_empty());
+    }
+
+    #[test]
+    fn downmix_passes_through_mono() {
+        let got = downmix_to_mono_f32(&[1.0, 2.0, 3.0], 1);
+        assert_eq!(got, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn downmix_averages_stereo_channels() {
+        // Two stereo frames: [L=1, R=3], [L=2, R=4] → [(1+3)/2, (2+4)/2] = [2.0, 3.0]
+        let got = downmix_to_mono_f32(&[1.0, 3.0, 2.0, 4.0], 2);
+        assert_eq!(got, vec![2.0, 3.0]);
+    }
+
+    #[test]
+    fn resample_passes_through_when_already_at_16k() {
+        let got = resample_simple_to_16k(&[1.0, 2.0, 3.0], 16_000);
+        assert_eq!(got, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn resample_downsample_48k_to_16k_yields_third_length() {
+        // 48k → 16k = 1/3 ratio; 90 samples → 30 samples.
+        let input: Vec<f32> = (0..90).map(|i| i as f32).collect();
+        let got = resample_simple_to_16k(&input, 48_000);
+        assert_eq!(got.len(), 30);
+        // First sample matches input[0]; last sample within [last-1, last]
+        assert!((got[0] - 0.0).abs() < 0.5);
+    }
+
+    #[test]
+    fn resample_handles_empty_input() {
+        let got = resample_simple_to_16k(&[], 48_000);
+        assert!(got.is_empty());
+    }
+}

--- a/mur-agent-gui/src-tauri/src/voice/audio/ptt.rs
+++ b/mur-agent-gui/src-tauri/src/voice/audio/ptt.rs
@@ -1,1 +1,152 @@
-//! Push-to-talk state machine — stub for M1.1.2; full impl + tests in M1.4.3.
+//! Push-to-talk state machine.
+//!
+//! Lifecycle:
+//!   Idle — HotkeyDown → Recording — HotkeyUp → Transcribing → Idle
+//!
+//! Holds shorter than `MIN_HOLD_MS` are debounced (modifier
+//! double-taps, accidental brushes against the rebound key).
+
+use std::time::{Duration, Instant};
+
+const MIN_HOLD_MS: u64 = 250;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PttState {
+    Idle,
+    Recording { started_at: Instant },
+    Transcribing,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PttEvent {
+    HotkeyDown,
+    HotkeyUp,
+    TranscribeDone,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PttAction {
+    /// Stray event (e.g., key-repeat); take no action.
+    None,
+    /// Start mic capture.
+    StartCapture,
+    /// Stop capture and dispatch to STT. `hold_ms` is informational
+    /// (telemetry / waveform UI).
+    StopCaptureAndTranscribe { hold_ms: u64 },
+    /// Hold was below the debounce threshold; abort capture without
+    /// transcribing. The GUI still ends the visual "recording" state.
+    Suppressed,
+}
+
+pub struct PttFsm {
+    state: PttState,
+}
+
+impl Default for PttFsm {
+    fn default() -> Self {
+        Self {
+            state: PttState::Idle,
+        }
+    }
+}
+
+impl PttFsm {
+    pub fn state(&self) -> PttState {
+        self.state
+    }
+
+    pub fn handle(&mut self, ev: PttEvent) -> PttAction {
+        match (self.state, ev) {
+            (PttState::Idle, PttEvent::HotkeyDown) => {
+                self.state = PttState::Recording {
+                    started_at: Instant::now(),
+                };
+                PttAction::StartCapture
+            }
+            (PttState::Recording { started_at }, PttEvent::HotkeyUp) => {
+                let hold = started_at.elapsed();
+                if hold < Duration::from_millis(MIN_HOLD_MS) {
+                    self.state = PttState::Idle;
+                    PttAction::Suppressed
+                } else {
+                    self.state = PttState::Transcribing;
+                    PttAction::StopCaptureAndTranscribe {
+                        hold_ms: hold.as_millis() as u64,
+                    }
+                }
+            }
+            (PttState::Transcribing, PttEvent::TranscribeDone) => {
+                self.state = PttState::Idle;
+                PttAction::None
+            }
+            // Stray events: key-repeat HotkeyDown while Recording, an
+            // unsolicited TranscribeDone while Idle, etc. Ignore.
+            _ => PttAction::None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+
+    #[test]
+    fn happy_path_capture_then_transcribe() {
+        let mut fsm = PttFsm::default();
+        assert_eq!(fsm.handle(PttEvent::HotkeyDown), PttAction::StartCapture);
+        sleep(Duration::from_millis(MIN_HOLD_MS + 10));
+        match fsm.handle(PttEvent::HotkeyUp) {
+            PttAction::StopCaptureAndTranscribe { hold_ms } => {
+                assert!(hold_ms >= MIN_HOLD_MS);
+            }
+            other => panic!("unexpected action: {other:?}"),
+        }
+        assert_eq!(fsm.handle(PttEvent::TranscribeDone), PttAction::None);
+        assert_eq!(fsm.state(), PttState::Idle);
+    }
+
+    #[test]
+    fn short_press_is_suppressed() {
+        let mut fsm = PttFsm::default();
+        fsm.handle(PttEvent::HotkeyDown);
+        // Release immediately — well under MIN_HOLD_MS.
+        assert_eq!(fsm.handle(PttEvent::HotkeyUp), PttAction::Suppressed);
+        assert_eq!(fsm.state(), PttState::Idle);
+    }
+
+    #[test]
+    fn key_repeat_during_recording_is_ignored() {
+        let mut fsm = PttFsm::default();
+        fsm.handle(PttEvent::HotkeyDown);
+        // OS key-repeat → another HotkeyDown while already Recording.
+        assert_eq!(fsm.handle(PttEvent::HotkeyDown), PttAction::None);
+        // Still in Recording.
+        assert!(matches!(fsm.state(), PttState::Recording { .. }));
+    }
+
+    #[test]
+    fn stray_transcribe_done_in_idle_is_ignored() {
+        let mut fsm = PttFsm::default();
+        assert_eq!(fsm.handle(PttEvent::TranscribeDone), PttAction::None);
+        assert_eq!(fsm.state(), PttState::Idle);
+    }
+
+    #[test]
+    fn hotkey_up_in_idle_is_ignored() {
+        let mut fsm = PttFsm::default();
+        assert_eq!(fsm.handle(PttEvent::HotkeyUp), PttAction::None);
+        assert_eq!(fsm.state(), PttState::Idle);
+    }
+
+    #[test]
+    fn hotkey_up_during_transcribing_is_ignored() {
+        let mut fsm = PttFsm::default();
+        fsm.handle(PttEvent::HotkeyDown);
+        sleep(Duration::from_millis(MIN_HOLD_MS + 5));
+        let _ = fsm.handle(PttEvent::HotkeyUp); // → Transcribing
+        // User starts pressing again while still transcribing — ignored.
+        assert_eq!(fsm.handle(PttEvent::HotkeyDown), PttAction::None);
+        assert_eq!(fsm.state(), PttState::Transcribing);
+    }
+}

--- a/mur-agent-gui/src-tauri/src/voice/audio/ring_buffer.rs
+++ b/mur-agent-gui/src-tauri/src/voice/audio/ring_buffer.rs
@@ -1,0 +1,89 @@
+//! Bounded interior-mutable ring buffer for streaming audio samples.
+//! Used for both capture (mic → STT) and playback (TTS → speaker)
+//! paths. Thread-safe via `parking_lot::Mutex`; oldest-sample-eviction
+//! on overflow (we prefer dropping latency over memory growth).
+
+use parking_lot::Mutex;
+use std::collections::VecDeque;
+
+pub struct PlaybackRing {
+    inner: Mutex<VecDeque<f32>>,
+    capacity: usize,
+}
+
+impl PlaybackRing {
+    pub fn new(capacity_samples: usize) -> Self {
+        Self {
+            inner: Mutex::new(VecDeque::with_capacity(capacity_samples)),
+            capacity: capacity_samples,
+        }
+    }
+
+    pub fn push(&self, samples: &[f32]) {
+        let mut q = self.inner.lock();
+        for &s in samples {
+            if q.len() >= self.capacity {
+                q.pop_front();
+            }
+            q.push_back(s);
+        }
+    }
+
+    pub fn pop(&self, n: usize) -> Vec<f32> {
+        let mut q = self.inner.lock();
+        let take = n.min(q.len());
+        q.drain(..take).collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.lock().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().is_empty()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_then_pop_round_trips() {
+        let r = PlaybackRing::new(8);
+        r.push(&[1.0, 2.0, 3.0]);
+        assert_eq!(r.len(), 3);
+        let got = r.pop(2);
+        assert_eq!(got, vec![1.0, 2.0]);
+        assert_eq!(r.len(), 1);
+    }
+
+    #[test]
+    fn overflow_drops_oldest_samples() {
+        let r = PlaybackRing::new(3);
+        r.push(&[1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(r.len(), 3);
+        let got = r.pop(3);
+        assert_eq!(got, vec![2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn pop_more_than_available_returns_all() {
+        let r = PlaybackRing::new(8);
+        r.push(&[1.0, 2.0]);
+        let got = r.pop(100);
+        assert_eq!(got, vec![1.0, 2.0]);
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn pop_empty_returns_empty() {
+        let r = PlaybackRing::new(8);
+        let got = r.pop(5);
+        assert!(got.is_empty());
+    }
+}

--- a/mur-agent-gui/src-tauri/src/voice/stt/mod.rs
+++ b/mur-agent-gui/src-tauri/src/voice/stt/mod.rs
@@ -1,13 +1,96 @@
-//! STT engine — whisper.cpp backend via whisper-rs (stub).
+//! STT engine — whisper.cpp backend (statically linked via whisper-rs).
 //!
-//! Full implementation lands in M1.4.2.
+//! Default-off lifecycle: constructed empty by `VoiceManager::new`; the
+//! GUI calls `load_model` after the user opts in via Settings → Voice
+//! → Enable. `unload` is called from `voice_disable` to free RAM.
+
+pub mod whisper;
 
 use anyhow::Result;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
-pub struct SttEngine;
+use whisper::WhisperBackend;
+
+pub struct SttEngine {
+    backend: Arc<RwLock<Option<WhisperBackend>>>,
+}
 
 impl SttEngine {
     pub fn new() -> Result<Self> {
-        Ok(Self)
+        Ok(Self {
+            backend: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    /// Load whisper context from disk. Async-friendly via spawn_blocking
+    /// since whisper.cpp's mmap can stall on disk I/O.
+    pub async fn load_model(&self, model_path: &Path) -> Result<()> {
+        let path_owned = model_path.to_path_buf();
+        let backend = tokio::task::spawn_blocking(move || WhisperBackend::load(&path_owned))
+            .await
+            .map_err(|e| anyhow::anyhow!("spawn_blocking join: {e}"))??;
+        *self.backend.write().await = Some(backend);
+        Ok(())
+    }
+
+    /// Drop the loaded whisper context, freeing RAM. Used by
+    /// `voice_disable` to honor the opt-in promise.
+    pub async fn unload(&self) {
+        *self.backend.write().await = None;
+    }
+
+    /// True if a model is loaded; false means the GUI must call
+    /// `voice_stt_download` (or `voice_enable` which subsumes it)
+    /// before any transcribe attempt can succeed.
+    pub async fn is_ready(&self) -> bool {
+        self.backend.read().await.is_some()
+    }
+
+    pub async fn transcribe(&self, samples_i16: &[i16], language: Option<&str>) -> Result<String> {
+        // Off-load the synchronous whisper run from the async runtime.
+        let backend = self.backend.clone();
+        let samples = samples_i16.to_vec();
+        let lang = language.map(|s| s.to_string());
+        tokio::task::spawn_blocking(move || {
+            // Acquire read lock inside the blocking task.
+            let g = futures::executor::block_on(backend.read());
+            let b = g.as_ref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "STT model not loaded — run `voice_stt_download` (or `voice_enable`) first"
+                )
+            })?;
+            b.transcribe(&samples, lang.as_deref())
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("spawn_blocking join: {e}"))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn unloaded_engine_is_not_ready() {
+        let e = SttEngine::new().unwrap();
+        assert!(!e.is_ready().await);
+    }
+
+    #[tokio::test]
+    async fn unload_is_idempotent_when_not_loaded() {
+        let e = SttEngine::new().unwrap();
+        e.unload().await;
+        e.unload().await;
+        assert!(!e.is_ready().await);
+    }
+
+    #[tokio::test]
+    async fn transcribe_without_model_errors() {
+        let e = SttEngine::new().unwrap();
+        let r = e.transcribe(&[0i16; 16000], Some("en")).await;
+        assert!(r.is_err());
+        assert!(format!("{r:?}").contains("STT model not loaded"));
     }
 }

--- a/mur-agent-gui/src-tauri/src/voice/stt/whisper.rs
+++ b/mur-agent-gui/src-tauri/src/voice/stt/whisper.rs
@@ -1,0 +1,57 @@
+//! whisper-rs adapter — `whisper-large-v3-turbo-q5_1` by default.
+//! Apple Silicon gets the Metal backend (Cargo.toml gates the `metal`
+//! feature on `cfg(target_os = "macos")`); Linux/Windows fall back to
+//! whisper.cpp's CPU backend.
+//!
+//! RTF target on M2: ≤ 0.5×; verified by the M1.6.4 bench harness.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+
+pub struct WhisperBackend {
+    ctx: WhisperContext,
+}
+
+impl WhisperBackend {
+    pub fn load(model_path: &Path) -> Result<Self> {
+        let params = WhisperContextParameters::default();
+        let path_str = model_path
+            .to_str()
+            .context("whisper model path must be valid UTF-8")?;
+        let ctx =
+            WhisperContext::new_with_params(path_str, params).context("whisper context init")?;
+        Ok(Self { ctx })
+    }
+
+    /// Transcribe a 16 kHz mono i16 PCM clip. Optional BCP-47 hint
+    /// (`en`, `zh`, etc.) skips whisper's internal language detection.
+    pub fn transcribe(&self, samples_i16: &[i16], language: Option<&str>) -> Result<String> {
+        let mut state = self.ctx.create_state().context("whisper create_state")?;
+        let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+        params.set_translate(false);
+        if let Some(lang) = language {
+            params.set_language(Some(lang));
+        }
+        params.set_print_special(false);
+        params.set_print_progress(false);
+        params.set_print_realtime(false);
+        params.set_print_timestamps(false);
+
+        // whisper-rs wants normalised f32 in [-1.0, 1.0]
+        let samples_f32: Vec<f32> = samples_i16
+            .iter()
+            .map(|&s| s as f32 / i16::MAX as f32)
+            .collect();
+        state.full(params, &samples_f32).context("whisper full")?;
+
+        let n = state.full_n_segments().context("whisper full_n_segments")?;
+        let mut out = String::new();
+        for i in 0..n {
+            if let Ok(seg) = state.full_get_segment_text(i) {
+                out.push_str(&seg);
+            }
+        }
+        Ok(out.trim().to_string())
+    }
+}


### PR DESCRIPTION
## Summary

- M1.4 STT: whisper-rs adapter (large-v3-turbo q5_1) + cpal mic capture + PTT FSM.
- Replaces #52 (auto-closed when its base branch was deleted on #56 merge).
- Rebased onto current `main` (which now includes #56, M1.3 Kokoro TTS).

## Stack

- Base: `main`
- Followups still open: #53 M1.5, #54 M1.6.2, #55 M1.6.3-6 (all retargeted to `main`).

## Test plan

- [ ] `cargo check -p mur-agent-gui --target-dir mur-agent-gui/src-tauri/target`
- [ ] `cargo test -p mur-agent-gui voice::stt voice::audio` (STT adapter + ring buffer + PTT FSM)
- [ ] CI: macOS + Linux builds green

🤖 Generated with [Claude Code](https://claude.com/claude-code)