### PR TITLE
feat(common): D2 onboarding — M2.1 schema (FirstMemory + ProactiveTier + OnboardingState extension)

### DIFF
--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -753,3 +753,55 @@ mod model_ref_tests {
         assert_eq!(p2.model_ref.as_deref(), Some("anthropic_opus_4_7"));
     }
 }
+
+/// GUI-facing reification of the companion's three-layer permission toggle.
+///
+/// On-disk schema doesn't change — this helper just maps between the
+/// three independent booleans (`enabled`, `rhythm.enabled`,
+/// `proactive.enabled`) and a single ordered tier. Use
+/// [`ProactiveTiers::from_config`] to read and [`ProactiveTiers::apply`]
+/// to write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProactiveTiers {
+    Off,
+    WarmOnly,
+    WarmAndBehavior,
+    All,
+}
+
+impl ProactiveTiers {
+    pub fn from_config(c: &CompanionConfig) -> Self {
+        match (c.enabled, c.rhythm.enabled, c.proactive.enabled) {
+            (false, _, _) => Self::Off,
+            (true, false, false) => Self::WarmOnly,
+            (true, true, false) => Self::WarmAndBehavior,
+            (true, _, true) => Self::All,
+        }
+    }
+
+    pub fn apply(&self, c: &mut CompanionConfig) {
+        match self {
+            Self::Off => {
+                c.enabled = false;
+                c.rhythm.enabled = false;
+                c.proactive.enabled = false;
+            }
+            Self::WarmOnly => {
+                c.enabled = true;
+                c.rhythm.enabled = false;
+                c.proactive.enabled = false;
+            }
+            Self::WarmAndBehavior => {
+                c.enabled = true;
+                c.rhythm.enabled = true;
+                c.proactive.enabled = false;
+            }
+            Self::All => {
+                c.enabled = true;
+                c.rhythm.enabled = true;
+                c.proactive.enabled = true;
+            }
+        }
+    }
+}

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -759,18 +759,18 @@ mod model_ref_tests {
 /// On-disk schema doesn't change — this helper just maps between the
 /// three independent booleans (`enabled`, `rhythm.enabled`,
 /// `proactive.enabled`) and a single ordered tier. Use
-/// [`ProactiveTiers::from_config`] to read and [`ProactiveTiers::apply`]
+/// [`ProactiveTier::from_config`] to read and [`ProactiveTier::apply`]
 /// to write.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ProactiveTiers {
+pub enum ProactiveTier {
     Off,
     WarmOnly,
     WarmAndBehavior,
     All,
 }
 
-impl ProactiveTiers {
+impl ProactiveTier {
     pub fn from_config(c: &CompanionConfig) -> Self {
         match (c.enabled, c.rhythm.enabled, c.proactive.enabled) {
             (false, _, _) => Self::Off,

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -596,12 +596,22 @@ pub struct VoiceOverrides {
     pub extra_instructions: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FirstMemory {
+    pub text: String,
+    pub established_at: chrono::DateTime<chrono::Utc>,
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OnboardingState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(default)]
     pub version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_display_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_memory: Option<FirstMemory>,
 }
 
 /// Phase 1.2 reservation. 1.1 keeps `enabled = false` (rhythm collection is

--- a/mur-common/tests/companion_enums.rs
+++ b/mur-common/tests/companion_enums.rs
@@ -60,3 +60,32 @@ fn onboarding_state_pre_d2_yaml_still_deserializes() {
     assert!(s.agent_display_name.is_none());
     assert!(s.first_memory.is_none());
 }
+
+#[test]
+fn proactive_tiers_helper() {
+    use mur_common::agent::{CompanionConfig, ProactiveTiers};
+    let mut c = CompanionConfig::default();
+    c.enabled = true;
+    let t = ProactiveTiers::from_config(&c);
+    assert_eq!(t, ProactiveTiers::WarmOnly);
+
+    c.rhythm.enabled = true;
+    let t = ProactiveTiers::from_config(&c);
+    assert_eq!(t, ProactiveTiers::WarmAndBehavior);
+
+    c.proactive.enabled = true;
+    let t = ProactiveTiers::from_config(&c);
+    assert_eq!(t, ProactiveTiers::All);
+}
+
+#[test]
+fn proactive_tiers_apply_round_trip() {
+    use mur_common::agent::{CompanionConfig, ProactiveTiers};
+    let mut c = CompanionConfig::default();
+    ProactiveTiers::All.apply(&mut c);
+    assert!(c.enabled && c.rhythm.enabled && c.proactive.enabled);
+    ProactiveTiers::WarmOnly.apply(&mut c);
+    assert!(c.enabled && !c.rhythm.enabled && !c.proactive.enabled);
+    ProactiveTiers::Off.apply(&mut c);
+    assert!(!c.enabled && !c.rhythm.enabled && !c.proactive.enabled);
+}

--- a/mur-common/tests/companion_enums.rs
+++ b/mur-common/tests/companion_enums.rs
@@ -63,29 +63,44 @@ fn onboarding_state_pre_d2_yaml_still_deserializes() {
 
 #[test]
 fn proactive_tiers_helper() {
-    use mur_common::agent::{CompanionConfig, ProactiveTiers};
+    use mur_common::agent::{CompanionConfig, ProactiveTier};
     let mut c = CompanionConfig::default();
     c.enabled = true;
-    let t = ProactiveTiers::from_config(&c);
-    assert_eq!(t, ProactiveTiers::WarmOnly);
+    let t = ProactiveTier::from_config(&c);
+    assert_eq!(t, ProactiveTier::WarmOnly);
 
     c.rhythm.enabled = true;
-    let t = ProactiveTiers::from_config(&c);
-    assert_eq!(t, ProactiveTiers::WarmAndBehavior);
+    let t = ProactiveTier::from_config(&c);
+    assert_eq!(t, ProactiveTier::WarmAndBehavior);
 
     c.proactive.enabled = true;
-    let t = ProactiveTiers::from_config(&c);
-    assert_eq!(t, ProactiveTiers::All);
+    let t = ProactiveTier::from_config(&c);
+    assert_eq!(t, ProactiveTier::All);
 }
 
 #[test]
 fn proactive_tiers_apply_round_trip() {
-    use mur_common::agent::{CompanionConfig, ProactiveTiers};
+    use mur_common::agent::{CompanionConfig, ProactiveTier};
     let mut c = CompanionConfig::default();
-    ProactiveTiers::All.apply(&mut c);
+    ProactiveTier::All.apply(&mut c);
     assert!(c.enabled && c.rhythm.enabled && c.proactive.enabled);
-    ProactiveTiers::WarmOnly.apply(&mut c);
+    ProactiveTier::WarmOnly.apply(&mut c);
     assert!(c.enabled && !c.rhythm.enabled && !c.proactive.enabled);
-    ProactiveTiers::Off.apply(&mut c);
+    ProactiveTier::Off.apply(&mut c);
     assert!(!c.enabled && !c.rhythm.enabled && !c.proactive.enabled);
+}
+
+#[test]
+fn proactive_tier_apply_then_from_config_is_identity() {
+    use mur_common::agent::{CompanionConfig, ProactiveTier};
+    for t in [
+        ProactiveTier::Off,
+        ProactiveTier::WarmOnly,
+        ProactiveTier::WarmAndBehavior,
+        ProactiveTier::All,
+    ] {
+        let mut c = CompanionConfig::default();
+        t.apply(&mut c);
+        assert_eq!(ProactiveTier::from_config(&c), t, "round-trip failed for {t:?}");
+    }
 }

--- a/mur-common/tests/companion_enums.rs
+++ b/mur-common/tests/companion_enums.rs
@@ -1,4 +1,6 @@
 use mur_common::companion::{Formality, Relationship, Signal, Situation};
+use mur_common::agent::FirstMemory;
+use chrono::{TimeZone, Utc};
 
 #[test]
 fn relationship_default_is_friend() {
@@ -31,4 +33,17 @@ fn signal_serde_roundtrip() {
     // smoke-check: ensure Signal is in scope and serializes snake_case
     let s = serde_json::to_string(&Signal::Positive).unwrap();
     assert_eq!(s, "\"positive\"");
+}
+
+#[test]
+fn first_memory_yaml_roundtrip() {
+    let fm = FirstMemory {
+        text: "We met on a Sunday in Taipei.".into(),
+        established_at: Utc.with_ymd_and_hms(2026, 4, 30, 14, 13, 0).unwrap(),
+    };
+    let s = serde_yaml_ng::to_string(&fm).unwrap();
+    assert!(s.contains("text:"));
+    assert!(s.contains("established_at:"));
+    let back: FirstMemory = serde_yaml_ng::from_str(&s).unwrap();
+    assert_eq!(back, fm);
 }

--- a/mur-common/tests/companion_enums.rs
+++ b/mur-common/tests/companion_enums.rs
@@ -47,3 +47,16 @@ fn first_memory_yaml_roundtrip() {
     let back: FirstMemory = serde_yaml_ng::from_str(&s).unwrap();
     assert_eq!(back, fm);
 }
+
+#[test]
+fn onboarding_state_pre_d2_yaml_still_deserializes() {
+    // A profile written before M2.1.1 has no agent_display_name / first_memory
+    // fields; #[serde(default)] must let it round-trip cleanly with the new
+    // optional fields = None.
+    let yaml = "completed_at: null\nversion: 0\n";
+    let s: mur_common::agent::OnboardingState = serde_yaml_ng::from_str(yaml).unwrap();
+    assert!(s.completed_at.is_none());
+    assert_eq!(s.version, 0);
+    assert!(s.agent_display_name.is_none());
+    assert!(s.first_memory.is_none());
+}

--- a/mur-common/tests/companion_enums.rs
+++ b/mur-common/tests/companion_enums.rs
@@ -104,3 +104,35 @@ fn proactive_tier_apply_then_from_config_is_identity() {
         assert_eq!(ProactiveTier::from_config(&c), t, "round-trip failed for {t:?}");
     }
 }
+
+#[test]
+fn agent_profile_with_first_memory_roundtrip() {
+    use mur_common::agent::{AgentProfile, FirstMemory, OnboardingState};
+
+    // Load minimal profile from fixture and add companion + onboarding data
+    let yaml = include_str!("fixtures/profile_p0a_minimal.yaml");
+    let mut p: AgentProfile = serde_yaml_ng::from_str(yaml).unwrap();
+
+    p.companion.enabled = true;
+    p.companion.onboarding = OnboardingState {
+        completed_at: Some(chrono::Utc::now()),
+        version: 1,
+        agent_display_name: Some("Mochi".into()),
+        first_memory: Some(FirstMemory {
+            text: "first day in Taipei".into(),
+            established_at: chrono::Utc::now(),
+        }),
+    };
+
+    let yaml_out = serde_yaml_ng::to_string(&p).unwrap();
+    assert!(yaml_out.contains("first_memory:"), "yaml missing first_memory: {}", yaml_out);
+    assert!(yaml_out.contains("agent_display_name: Mochi"), "yaml missing display name: {}", yaml_out);
+
+    let back: AgentProfile = serde_yaml_ng::from_str(&yaml_out).unwrap();
+    assert_eq!(back.companion.onboarding.agent_display_name.as_deref(), Some("Mochi"));
+    assert!(back.companion.onboarding.first_memory.is_some());
+    assert_eq!(
+        back.companion.onboarding.first_memory.as_ref().unwrap().text,
+        "first day in Taipei",
+    );
+}

--- a/mur-common/tests/companion_enums.rs
+++ b/mur-common/tests/companion_enums.rs
@@ -1,6 +1,6 @@
-use mur_common::companion::{Formality, Relationship, Signal, Situation};
-use mur_common::agent::FirstMemory;
 use chrono::{TimeZone, Utc};
+use mur_common::agent::FirstMemory;
+use mur_common::companion::{Formality, Relationship, Signal, Situation};
 
 #[test]
 fn relationship_default_is_friend() {
@@ -101,7 +101,11 @@ fn proactive_tier_apply_then_from_config_is_identity() {
     ] {
         let mut c = CompanionConfig::default();
         t.apply(&mut c);
-        assert_eq!(ProactiveTier::from_config(&c), t, "round-trip failed for {t:?}");
+        assert_eq!(
+            ProactiveTier::from_config(&c),
+            t,
+            "round-trip failed for {t:?}"
+        );
     }
 }
 
@@ -125,14 +129,30 @@ fn agent_profile_with_first_memory_roundtrip() {
     };
 
     let yaml_out = serde_yaml_ng::to_string(&p).unwrap();
-    assert!(yaml_out.contains("first_memory:"), "yaml missing first_memory: {}", yaml_out);
-    assert!(yaml_out.contains("agent_display_name: Mochi"), "yaml missing display name: {}", yaml_out);
+    assert!(
+        yaml_out.contains("first_memory:"),
+        "yaml missing first_memory: {}",
+        yaml_out
+    );
+    assert!(
+        yaml_out.contains("agent_display_name: Mochi"),
+        "yaml missing display name: {}",
+        yaml_out
+    );
 
     let back: AgentProfile = serde_yaml_ng::from_str(&yaml_out).unwrap();
-    assert_eq!(back.companion.onboarding.agent_display_name.as_deref(), Some("Mochi"));
+    assert_eq!(
+        back.companion.onboarding.agent_display_name.as_deref(),
+        Some("Mochi")
+    );
     assert!(back.companion.onboarding.first_memory.is_some());
     assert_eq!(
-        back.companion.onboarding.first_memory.as_ref().unwrap().text,
+        back.companion
+            .onboarding
+            .first_memory
+            .as_ref()
+            .unwrap()
+            .text,
         "first day in Taipei",
     );
 }

--- a/mur-core/src/cmd/agent_companion/init.rs
+++ b/mur-core/src/cmd/agent_companion/init.rs
@@ -85,6 +85,7 @@ pub async fn run(name: &str, answers: Option<PathBuf>, re_init: bool) -> Result<
     profile.companion.onboarding = OnboardingState {
         completed_at: Some(now),
         version: 1,
+        ..OnboardingState::default()
     };
     // proactive + rhythm are deliberately untouched.
 


### PR DESCRIPTION
## Summary

First milestone (M2.1) of the M2 D2 first-memory onboarding plan (PR #58). Schema-only change in `mur-common`, plus a one-line keep-mur-core-compiling fix.

## What's in

**M2.1.1** — `FirstMemory { text, established_at }` struct + `OnboardingState` extended with `agent_display_name: Option<String>` and `first_memory: Option<FirstMemory>`. Both new fields are `#[serde(default, skip_serializing_if = "Option::is_none")]` so existing serialized profiles deserialize cleanly.

**M2.1.2** — `ProactiveTier` enum (`Off / WarmOnly / WarmAndBehavior / All`) with `from_config(&CompanionConfig)` reader and `apply(&mut CompanionConfig)` writer. Reifies the three-layer toggle (warm voice / behavior collection / proactive sends) as a single value the GUI can show/edit, without changing on-disk schema. Renamed from `ProactiveTiers` → `ProactiveTier` per code-quality NIT (matches every other singular enum in `agent.rs`).

**M2.1.2.fix** — `mur-core/src/cmd/agent_companion/init.rs:88` adds `..OnboardingState::default()` to the existing 3-step wizard's struct literal so it still compiles after M2.1.1 added the two new fields. The 5-step wizard (M2.3.2) will populate them explicitly.

**M2.1.3** — Integration test verifying `AgentProfile` YAML round-trip with both new fields populated.

## Tests added

- `first_memory_yaml_roundtrip` — FirstMemory serde round-trip.
- `onboarding_state_pre_d2_yaml_still_deserializes` — backward-compat test pinning that pre-M2.1 profile YAML deserializes with new fields = None.
- `proactive_tiers_helper` + `proactive_tiers_apply_round_trip` + `proactive_tier_apply_then_from_config_is_identity` — three-layer toggle.
- `agent_profile_with_first_memory_roundtrip` — full profile round-trip.

11 tests in `companion_enums.rs` total; full mur-common suite (224 tests) green; clippy clean.

## Stack

This is the bottom of the M2 D2 stack:
- **#58** — D2 plan (draft)
- **THIS** — M2.1 schema
- M2.2 picker (next)
- M2.3 CLI wizard
- M2.4 Tauri commands
- M2.5 React wizard
- M2.6 first-launch
- M2.7 character card
- M2.8 E2E + cookbook

## Test plan

- [ ] `cargo test -p mur-common`
- [ ] `cargo test --workspace` (full repo green; verifies init.rs fix)
- [ ] `cargo clippy --workspace -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)