### PR TITLE
feat(core): D2 onboarding — M2.3 CLI 5-step wizard + companion preview hydration

### DIFF
--- a/mur-core/src/cmd/agent_companion.rs
+++ b/mur-core/src/cmd/agent_companion.rs
@@ -70,7 +70,7 @@ pub async fn run(args: CompanionArgs) -> anyhow::Result<()> {
 
 mod content;
 mod inbox;
-mod init;
+pub mod init;
 mod preview;
 mod proactive;
 mod quiet;

--- a/mur-core/src/cmd/agent_companion/init.rs
+++ b/mur-core/src/cmd/agent_companion/init.rs
@@ -151,10 +151,49 @@ fn load_answers(path: &Path) -> Result<Answers> {
         .with_context(|| format!("parse answers {}", path.display()))
 }
 
-/// Three-step interactive wizard. Mirrors the `--answers` shape so the
-/// downstream atomic-write code path is identical.
+/// Five-step interactive wizard (D2 onboarding §M2.3.2). Mirrors the
+/// `--answers` shape so the downstream atomic-write code path is identical.
+///
+/// Steps:
+/// 1. Name the agent (`agent_display_name`).
+/// 2. Voice — consent only; the actual picker lives in the GUI.
+/// 3. Locale + `name_for_user` + relationship (with example greeting).
+/// 4. First memory — one optional fact.
+/// 5. Three-tier proactive permission (`ProactiveTier`).
+///
+/// Wraps the whole flow in an `Instant` and prints `"Elapsed {n}s."` as a
+/// soft acceptance gate; the M2.8.1 E2E script enforces ≤ 120s on the
+/// `--answers` path.
 fn run_wizard() -> Result<Answers> {
-    // Step 1: locale + name.
+    use std::time::Instant;
+    let started = Instant::now();
+
+    // Step 1 — display name. The user names *the agent*, not themselves.
+    let agent_display_name: String = Input::new()
+        .with_prompt("What should this agent be called? (display name)")
+        .interact_text()
+        .context("read agent display name")?;
+
+    // Step 2 — voice consent. The CLI doesn't open a picker; the actual
+    // voice file is selected in Settings → Voice in the GUI. This step
+    // records intent only.
+    let voice_choices = [
+        "Skip — enable voice later in Settings",
+        "Enable voice (opens picker)",
+    ];
+    let v_idx = Select::new()
+        .with_prompt("Voice (we never send audio off your machine)")
+        .items(&voice_choices)
+        .default(0)
+        .interact()
+        .context("voice choice")?;
+    if v_idx == 1 {
+        println!(
+            "(open Settings → Voice in the GUI to pick a voice; the CLI just records consent)"
+        );
+    }
+
+    // Step 3 — locale + name_for_user + relationship.
     let locale: String = Input::new()
         .with_prompt("Language (BCP-47, e.g. zh-TW)")
         .default(default_locale())
@@ -164,8 +203,6 @@ fn run_wizard() -> Result<Answers> {
         .with_prompt("What should I call you?")
         .interact_text()
         .context("read name")?;
-
-    // Step 2: relationship slot + example greeting.
     let choices = ["Friend", "Coach", "Accountability buddy", "Mentor"];
     let idx = Select::new()
         .with_prompt("How should this agent relate to you?")
@@ -183,8 +220,40 @@ fn run_wizard() -> Result<Answers> {
         println!("{example}");
     }
 
-    // Step 3: earned-permission narrative (print only).
+    // Step 4 — first memory. Empty input is allowed and stored as `None`.
+    let raw_memory: String = Input::new()
+        .with_prompt("Share one fact about you, in a sentence")
+        .with_initial_text("")
+        .allow_empty(true)
+        .interact_text()
+        .context("read first_memory")?;
+    let first_memory = if raw_memory.trim().is_empty() {
+        None
+    } else {
+        Some(raw_memory)
+    };
+
+    // Step 5 — three-tier proactive.
+    let tier_choices = [
+        "Warm voice only (recommended)",
+        "Warm voice + collect rhythm (no proactive sends)",
+        "All — including occasional proactive check-ins",
+    ];
+    let t_idx = Select::new()
+        .with_prompt("How should I behave?")
+        .items(&tier_choices)
+        .default(0)
+        .interact()
+        .context("select proactive tier")?;
+    let proactive_tier = Some(match t_idx {
+        0 => ProactiveTier::WarmOnly,
+        1 => ProactiveTier::WarmAndBehavior,
+        _ => ProactiveTier::All,
+    });
+
+    // Earned-permission narrative (print only).
     print_narrative(&locale);
+    println!("Elapsed {}s.", started.elapsed().as_secs());
 
     Ok(Answers {
         locale,
@@ -192,11 +261,9 @@ fn run_wizard() -> Result<Answers> {
         relationship,
         formality: Some(Formality::Casual),
         extra_instructions: Some(String::new()),
-        // M2.3.2 will collect these in the interactive wizard. Until then
-        // the 3-step path leaves them unset, matching pre-D2 behaviour.
-        agent_display_name: None,
-        first_memory: None,
-        proactive_tier: None,
+        agent_display_name: Some(agent_display_name),
+        first_memory,
+        proactive_tier,
     })
 }
 

--- a/mur-core/src/cmd/agent_companion/init.rs
+++ b/mur-core/src/cmd/agent_companion/init.rs
@@ -7,7 +7,9 @@ use anyhow::{Context, Result, anyhow, bail};
 use chrono::Utc;
 use dialoguer::{Input, Select};
 use fs2::FileExt;
-use mur_common::agent::{AgentProfile, OnboardingState, VoiceOverrides, default_locale};
+use mur_common::agent::{
+    AgentProfile, FirstMemory, OnboardingState, ProactiveTier, VoiceOverrides, default_locale,
+};
 use mur_common::companion::{Formality, Relationship};
 use serde::{Deserialize, Serialize};
 use std::fs::{self, OpenOptions};
@@ -16,6 +18,17 @@ use std::path::{Path, PathBuf};
 use super::util::{atomic_write_json, atomic_write_yaml};
 
 /// On-disk shape of the `--answers <file>` YAML payload.
+///
+/// D2 onboarding (Phase 1.1 §M2.3.1) extends the original 3-step shape
+/// with three optional fields:
+/// * `agent_display_name` — what the user names *the agent*
+/// * `first_memory` — the seed fact recorded as a `FirstMemory`
+/// * `proactive_tier` — three-layer permission selector mapped onto
+///   `companion.{enabled, rhythm.enabled, proactive.enabled}` via
+///   [`ProactiveTier::apply`]
+///
+/// All three are `#[serde(default)]` so legacy 3-step YAML files keep
+/// deserialising unchanged.
 #[derive(Debug, Deserialize)]
 struct Answers {
     locale: String,
@@ -25,6 +38,12 @@ struct Answers {
     formality: Option<Formality>,
     #[serde(default)]
     extra_instructions: Option<String>,
+    #[serde(default)]
+    agent_display_name: Option<String>,
+    #[serde(default)]
+    first_memory: Option<String>,
+    #[serde(default)]
+    proactive_tier: Option<ProactiveTier>,
 }
 
 /// Schema written to `companion/relationship.json`.
@@ -37,6 +56,8 @@ struct RelationshipFile<'a> {
     formality: &'a Option<Formality>,
     extra_instructions: &'a Option<String>,
     onboarded_at: chrono::DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    first_memory: Option<&'a FirstMemory>,
 }
 
 pub async fn run(name: &str, answers: Option<PathBuf>, re_init: bool) -> Result<()> {
@@ -74,7 +95,6 @@ pub async fn run(name: &str, answers: Option<PathBuf>, re_init: bool) -> Result<
     }
 
     let now = Utc::now();
-    profile.companion.enabled = true;
     profile.companion.locale = answers.locale.clone();
     profile.companion.relationship = answers.relationship.clone();
     profile.companion.voice_overrides = VoiceOverrides {
@@ -82,12 +102,23 @@ pub async fn run(name: &str, answers: Option<PathBuf>, re_init: bool) -> Result<
         formality: answers.formality.clone(),
         extra_instructions: answers.extra_instructions.clone(),
     };
+    let first_memory = answers.first_memory.as_ref().map(|s| FirstMemory {
+        text: s.clone(),
+        established_at: now,
+    });
     profile.companion.onboarding = OnboardingState {
         completed_at: Some(now),
         version: 1,
-        ..OnboardingState::default()
+        agent_display_name: answers.agent_display_name.clone(),
+        first_memory: first_memory.clone(),
     };
-    // proactive + rhythm are deliberately untouched.
+    // Three-tier proactive: default to WarmOnly when missing — that's the
+    // 5-step UX default and matches the prior behaviour of unconditionally
+    // setting `companion.enabled = true` while leaving rhythm + proactive
+    // dormant. `apply` is the single source of truth for the three-bool
+    // mapping (Spec §4.2 step 5 / `ProactiveTier`).
+    let tier = answers.proactive_tier.unwrap_or(ProactiveTier::WarmOnly);
+    tier.apply(&mut profile.companion);
 
     atomic_write_yaml(&profile_path, &profile)
         .with_context(|| format!("write {}", profile_path.display()))?;
@@ -101,6 +132,7 @@ pub async fn run(name: &str, answers: Option<PathBuf>, re_init: bool) -> Result<
         formality: &answers.formality,
         extra_instructions: &answers.extra_instructions,
         onboarded_at: now,
+        first_memory: first_memory.as_ref(),
     };
     atomic_write_json(&rel_path, &rel).with_context(|| format!("write {}", rel_path.display()))?;
 
@@ -160,6 +192,11 @@ fn run_wizard() -> Result<Answers> {
         relationship,
         formality: Some(Formality::Casual),
         extra_instructions: Some(String::new()),
+        // M2.3.2 will collect these in the interactive wizard. Until then
+        // the 3-step path leaves them unset, matching pre-D2 behaviour.
+        agent_display_name: None,
+        first_memory: None,
+        proactive_tier: None,
     })
 }
 

--- a/mur-core/src/cmd/agent_companion/preview.rs
+++ b/mur-core/src/cmd/agent_companion/preview.rs
@@ -5,15 +5,15 @@
 
 use anyhow::{Context, Result};
 use clap::Args;
+use mur_agent_runtime::companion::voice::{VoiceInput, compose_in_memory};
 use mur_agent_runtime::llm::{LlmClient, LlmMessage, LlmRequest};
 use mur_common::agent::AgentProfile;
 use mur_common::companion::Situation;
 use mur_common::companion::content_seed::{SituationFile, TemplateSeed, all_seeds, parse};
+use serde::Deserialize;
 use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
-
-use super::voice::compose_from_profile;
 
 // ─── CLI types ────────────────────────────────────────────────────────────────
 
@@ -54,14 +54,25 @@ pub(crate) async fn run_at(
     let profile = load_profile(agent_home)?;
     let situation = parse_situation_slug(situation_slug)?;
 
-    // Compose voice.md in-memory — never written.
-    let voice = compose_from_profile(&profile);
+    // M2.3.3 — load first_memory from relationship.json so the rendered body
+    // can expand `{{FIRST_MEMORY}}` placeholders. Mirrors the runtime-side
+    // `mur_agent_runtime::companion::Companion::new` wiring (M2.2.3) on the
+    // CLI preview path. Best-effort: a missing/malformed file collapses
+    // first_memory placeholders to empty strings.
+    let first_memory = load_relationship_first_memory(agent_home);
 
-    // Pick deterministic first template for preview.
-    let template = pick_first_template_for_preview(agent_home, &profile, situation)?;
+    // Compose voice.md in-memory — never written.
+    let voice = compose_voice_for_preview(&profile, first_memory.as_deref());
+
+    // Pick deterministic template for preview. When first_memory is set,
+    // prefer a template whose `prompt_seed` references `{{FIRST_MEMORY}}` so
+    // the seed text actually surfaces in the rendered body — otherwise the
+    // first template is picked unchanged.
+    let template =
+        pick_first_template_for_preview(agent_home, &profile, situation, first_memory.as_deref())?;
 
     if no_llm {
-        return preview_no_llm_inner(out, &voice, &template);
+        return preview_no_llm_inner(out, &voice, &template, &profile, first_memory.as_deref());
     }
 
     // LLM path.
@@ -85,18 +96,119 @@ pub(crate) fn preview_no_llm_at(
 ) -> Result<()> {
     let profile = load_profile(agent_home)?;
     let situation = parse_situation_slug(situation_slug)?;
-    let voice = compose_from_profile(&profile);
-    let template = pick_first_template_for_preview(agent_home, &profile, situation)?;
-    preview_no_llm_inner(out, &voice, &template)
+    let first_memory = load_relationship_first_memory(agent_home);
+    let voice = compose_voice_for_preview(&profile, first_memory.as_deref());
+    let template =
+        pick_first_template_for_preview(agent_home, &profile, situation, first_memory.as_deref())?;
+    preview_no_llm_inner(out, &voice, &template, &profile, first_memory.as_deref())
 }
 
-fn preview_no_llm_inner(out: &mut impl Write, voice: &str, template: &TemplateSeed) -> Result<()> {
+fn preview_no_llm_inner(
+    out: &mut impl Write,
+    voice: &str,
+    template: &TemplateSeed,
+    profile: &AgentProfile,
+    first_memory: Option<&str>,
+) -> Result<()> {
+    let rendered_seed = substitute_prompt_seed(&template.prompt_seed, profile, first_memory);
     writeln!(out, "# voice.md")?;
     writeln!(out, "{voice}")?;
     writeln!(out)?;
     writeln!(out, "# prompt_seed (template `{}`)", template.id)?;
-    writeln!(out, "{}", template.prompt_seed)?;
+    writeln!(out, "{rendered_seed}")?;
     Ok(())
+}
+
+/// Compose voice in-memory with the same placeholder substitutions the
+/// runtime applies, so `{{FIRST_MEMORY}}`-bearing voice templates render
+/// correctly when previewed.
+fn compose_voice_for_preview(profile: &AgentProfile, first_memory: Option<&str>) -> String {
+    let formality = profile
+        .companion
+        .voice_overrides
+        .formality
+        .as_ref()
+        .map(|f| format!("{f:?}").to_lowercase())
+        .unwrap_or_default();
+    let name_for_user = profile
+        .companion
+        .voice_overrides
+        .name_for_user
+        .as_deref()
+        .unwrap_or("");
+    let extra = profile
+        .companion
+        .voice_overrides
+        .extra_instructions
+        .as_deref()
+        .unwrap_or("");
+    compose_in_memory(VoiceInput {
+        relationship: profile.companion.relationship.clone(),
+        locale: &profile.companion.locale,
+        name_for_user,
+        first_memory,
+        formality: &formality,
+        extra_instructions: extra,
+    })
+}
+
+/// Apply the same placeholder rules to a `prompt_seed` that the runtime's
+/// `voice::apply_placeholders` applies to voice templates. Keeps the
+/// substitution surface consistent: the user-facing template-defined tokens
+/// (`{{FIRST_MEMORY}}`, `{{FIRST_MEMORY_PARAGRAPH}}`, `{{NAME_FOR_USER}}`)
+/// expand here, and unknown tokens are left untouched.
+fn substitute_prompt_seed(
+    prompt_seed: &str,
+    profile: &AgentProfile,
+    first_memory: Option<&str>,
+) -> String {
+    // first_memory FIRST so user-supplied name_for_user can't inject more
+    // `{{...}}` tokens that get re-substituted.
+    let mut s = match first_memory {
+        Some(fm) if !fm.is_empty() => prompt_seed
+            .replace("{{FIRST_MEMORY}}", fm)
+            .replace("{{FIRST_MEMORY_PARAGRAPH}}", &format!(" {fm}")),
+        _ => prompt_seed
+            .replace("{{FIRST_MEMORY}}", "")
+            .replace("{{FIRST_MEMORY_PARAGRAPH}}", ""),
+    };
+    let name_for_user = profile
+        .companion
+        .voice_overrides
+        .name_for_user
+        .as_deref()
+        .unwrap_or("");
+    s = s.replace("{{NAME_FOR_USER}}", name_for_user);
+    s
+}
+
+// ─── relationship.json loader (best-effort) ──────────────────────────────────
+
+/// Minimal projection of `companion/relationship.json` — only the fields the
+/// preview path needs. Mirrors the runtime parser in
+/// `mur_agent_runtime::companion::RelationshipFile`.
+#[derive(Debug, Default, Deserialize)]
+struct RelationshipFile {
+    #[serde(default)]
+    first_memory: Option<FirstMemoryRef>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FirstMemoryRef {
+    text: String,
+}
+
+/// Best-effort load of `<agent_home>/companion/relationship.json` for the
+/// preview path. Returns `None` when the file is missing, unreadable, or
+/// malformed — the preview then renders with `{{FIRST_MEMORY}}` collapsed
+/// to empty (same fallback as the runtime).
+fn load_relationship_first_memory(agent_home: &Path) -> Option<String> {
+    let p = agent_home.join("companion/relationship.json");
+    let s = std::fs::read_to_string(&p).ok()?;
+    match serde_json::from_str::<RelationshipFile>(&s) {
+        Ok(rel) => rel.first_memory.map(|fm| fm.text),
+        Err(_) => None,
+    }
 }
 
 // ─── Template picker ──────────────────────────────────────────────────────────
@@ -105,6 +217,7 @@ fn pick_first_template_for_preview(
     agent_home: &Path,
     profile: &AgentProfile,
     situation: Situation,
+    first_memory: Option<&str>,
 ) -> Result<TemplateSeed> {
     let locale = &profile.companion.locale;
     let situation_slug = situation_to_slug(&situation);
@@ -118,7 +231,7 @@ fn pick_first_template_for_preview(
             .with_context(|| format!("read {}", disk_path.display()))?;
         let parsed: SituationFile = serde_yaml_ng::from_str(&body)
             .with_context(|| format!("parse {}", disk_path.display()))?;
-        if let Some(t) = parsed.templates.into_iter().next() {
+        if let Some(t) = pick_template_from_list(parsed.templates, first_memory) {
             return Ok(t);
         }
     }
@@ -127,13 +240,42 @@ fn pick_first_template_for_preview(
     for (sit, loc, yaml) in all_seeds() {
         if sit == situation && loc == locale {
             let parsed = parse(yaml).context("parse embedded seed")?;
-            if let Some(t) = parsed.templates.into_iter().next() {
+            if let Some(t) = pick_template_from_list(parsed.templates, first_memory) {
                 return Ok(t);
             }
         }
     }
 
     anyhow::bail!("no template available for {situation_slug}.{locale} (preview cannot proceed)");
+}
+
+/// Deterministic picker: when `first_memory` is set, prefer the first
+/// template whose `prompt_seed` references `{{FIRST_MEMORY}}` so the seed
+/// text actually surfaces in the preview output. Falls back to the first
+/// template in declaration order — the same shape the picker had before
+/// M2.3.3.
+fn pick_template_from_list(
+    templates: Vec<TemplateSeed>,
+    first_memory: Option<&str>,
+) -> Option<TemplateSeed> {
+    if let Some(fm) = first_memory
+        && !fm.is_empty()
+    {
+        // Two-pass walk so the original Vec order still wins ties when no
+        // `{{FIRST_MEMORY}}` template exists for this situation.
+        let mut iter = templates.into_iter();
+        let mut head: Option<TemplateSeed> = None;
+        for t in iter.by_ref() {
+            if t.prompt_seed.contains("{{FIRST_MEMORY}}") {
+                return Some(t);
+            }
+            if head.is_none() {
+                head = Some(t);
+            }
+        }
+        return head;
+    }
+    templates.into_iter().next()
 }
 
 // ─── LLM client construction ─────────────────────────────────────────────────

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod agent;
-pub(crate) mod agent_companion;
+pub mod agent_companion;
 pub(crate) mod agent_export_gui;
 pub(crate) mod agent_rekey;
 pub(crate) mod community_cmd;

--- a/mur-core/tests/companion_init_5step.rs
+++ b/mur-core/tests/companion_init_5step.rs
@@ -1,0 +1,160 @@
+//! M2.3.1 — `mur agent companion init --answers` accepts the two new
+//! D2-onboarding fields (`agent_display_name`, `first_memory`) plus the
+//! three-tier `proactive_tier` selector. Spec §4.2 / plan §M2.3.1.
+//!
+//! Calls the library entrypoint directly (`agent_companion::init::run`)
+//! to avoid building the `mur` binary across the full workspace just to
+//! exercise YAML deserialisation.
+
+use std::path::Path;
+use std::sync::{LazyLock, Mutex, MutexGuard};
+use tempfile::TempDir;
+
+/// Cargo runs integration tests in parallel threads; `MUR_HOME` is a
+/// process-global env var, so we serialise tests that mutate it.
+static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+struct MurHomeGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl MurHomeGuard {
+    fn set(path: &Path) -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: process-wide mutex held across the env mutation; cleared
+        // again in `Drop`.
+        unsafe { std::env::set_var("MUR_HOME", path) };
+        MurHomeGuard { _lock: lock }
+    }
+}
+
+impl Drop for MurHomeGuard {
+    fn drop(&mut self) {
+        // SAFETY: still holding `_lock` until our fields drop.
+        unsafe { std::env::remove_var("MUR_HOME") };
+    }
+}
+
+/// Load the shared P0a fixture and substitute `name: agent_test` →
+/// `name: <name>` so the same baseline profile can host any agent.
+fn fixture_with_name(name: &str) -> String {
+    let yaml = std::fs::read_to_string("../mur-common/tests/fixtures/profile_p0a_minimal.yaml")
+        .unwrap_or_else(|_| {
+            let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .join("mur-common/tests/fixtures/profile_p0a_minimal.yaml");
+            std::fs::read_to_string(p).expect("fixture must exist")
+        });
+    yaml.replace("name: agent_test", &format!("name: {name}"))
+}
+
+#[tokio::test]
+async fn answers_yaml_supports_first_memory_and_display_name() {
+    let tmp = TempDir::new().unwrap();
+    let mur_home = tmp.path();
+    let _guard = MurHomeGuard::set(mur_home);
+
+    // Pre-create a minimal agent home with a parseable AgentProfile.
+    let agent_dir = mur_home.join("agents/test");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(agent_dir.join("profile.yaml"), fixture_with_name("test")).unwrap();
+
+    // Five-step answers payload: extends the 3-step YAML with
+    // `agent_display_name`, `first_memory`, `proactive_tier`.
+    let answers_path = tmp.path().join("answers.yaml");
+    std::fs::write(
+        &answers_path,
+        r#"locale: en-US
+name_for_user: David
+agent_display_name: Mochi
+relationship: friend
+formality: casual
+extra_instructions: ""
+first_memory: "Sunday in Taipei"
+proactive_tier: warm_only
+"#,
+    )
+    .unwrap();
+
+    mur_core::cmd::agent_companion::init::run("test", Some(answers_path), false)
+        .await
+        .expect("companion init must succeed");
+
+    // profile.yaml: companion.onboarding now carries display name + first memory.
+    let pf: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(&std::fs::read_to_string(agent_dir.join("profile.yaml")).unwrap())
+            .unwrap();
+    assert_eq!(
+        pf["companion"]["onboarding"]["agent_display_name"].as_str(),
+        Some("Mochi")
+    );
+    assert!(pf["companion"]["onboarding"]["first_memory"]["text"].is_string());
+    assert_eq!(
+        pf["companion"]["onboarding"]["first_memory"]["text"].as_str(),
+        Some("Sunday in Taipei")
+    );
+
+    // relationship.json round-trips first_memory too.
+    let rel: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(agent_dir.join("companion/relationship.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        rel["first_memory"]["text"].as_str(),
+        Some("Sunday in Taipei")
+    );
+
+    // Three-tier toggle: warm_only → companion.enabled = true,
+    // rhythm.enabled = false, proactive.enabled = false.
+    assert_eq!(pf["companion"]["enabled"], serde_yaml_ng::Value::Bool(true));
+    assert_eq!(
+        pf["companion"]["rhythm"]["enabled"],
+        serde_yaml_ng::Value::Bool(false)
+    );
+    assert_eq!(
+        pf["companion"]["proactive"]["enabled"],
+        serde_yaml_ng::Value::Bool(false)
+    );
+}
+
+/// Pre-D2 (3-step) `--answers` files lack the three new fields. They
+/// must continue to deserialise cleanly thanks to `#[serde(default)]`.
+#[tokio::test]
+async fn legacy_3step_answers_still_parse() {
+    let tmp = TempDir::new().unwrap();
+    let mur_home = tmp.path();
+    let _guard = MurHomeGuard::set(mur_home);
+
+    let agent_dir = mur_home.join("agents/legacy");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(agent_dir.join("profile.yaml"), fixture_with_name("legacy")).unwrap();
+
+    let answers_path = tmp.path().join("answers.yaml");
+    std::fs::write(
+        &answers_path,
+        "locale: en-US\nname_for_user: Alex\nrelationship: coach\nformality: neutral\nextra_instructions: \"\"\n",
+    )
+    .unwrap();
+
+    mur_core::cmd::agent_companion::init::run("legacy", Some(answers_path), false)
+        .await
+        .expect("legacy 3-step answers must still parse");
+
+    let pf: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(&std::fs::read_to_string(agent_dir.join("profile.yaml")).unwrap())
+            .unwrap();
+    // Display name + first_memory absent in answers → onboarding stays without them.
+    assert!(pf["companion"]["onboarding"]["agent_display_name"].is_null());
+    assert!(pf["companion"]["onboarding"]["first_memory"].is_null());
+    // Default tier when absent is WarmOnly per M2.3.1 plan.
+    assert_eq!(pf["companion"]["enabled"], serde_yaml_ng::Value::Bool(true));
+    assert_eq!(
+        pf["companion"]["rhythm"]["enabled"],
+        serde_yaml_ng::Value::Bool(false)
+    );
+    assert_eq!(
+        pf["companion"]["proactive"]["enabled"],
+        serde_yaml_ng::Value::Bool(false)
+    );
+}

--- a/mur-core/tests/companion_preview_first_memory.rs
+++ b/mur-core/tests/companion_preview_first_memory.rs
@@ -1,0 +1,101 @@
+//! M2.3.3 — `mur agent companion preview --no-llm` hydrates `first_memory`
+//! from `companion/relationship.json` so that templates referencing
+//! `{{FIRST_MEMORY}}` render the actual seed text. Mirrors the runtime-side
+//! M2.2.3 wiring on the CLI preview path. Plan §M2.3.3.
+
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn mur_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mur")
+}
+
+/// Load the shared P0a fixture and substitute `name: agent_test` →
+/// `name: <name>` so the same baseline profile can host any agent.
+fn fixture_with_name(name: &str) -> String {
+    let yaml = std::fs::read_to_string("../mur-common/tests/fixtures/profile_p0a_minimal.yaml")
+        .unwrap_or_else(|_| {
+            let p = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .join("mur-common/tests/fixtures/profile_p0a_minimal.yaml");
+            std::fs::read_to_string(p).expect("fixture must exist")
+        });
+    yaml.replace("name: agent_test", &format!("name: {name}"))
+}
+
+#[test]
+fn preview_morning_greeting_includes_first_memory() {
+    let tmp = TempDir::new().unwrap();
+    let mur_home = tmp.path().join(".mur");
+    std::fs::create_dir_all(&mur_home).unwrap();
+
+    // Pre-create the agent.
+    let agent_dir = mur_home.join("agents/preview_test");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(
+        agent_dir.join("profile.yaml"),
+        fixture_with_name("preview_test"),
+    )
+    .unwrap();
+
+    // Write answers.yaml with a known first_memory.
+    let answers_path = tmp.path().join("answers.yaml");
+    std::fs::write(
+        &answers_path,
+        r#"locale: en-US
+name_for_user: David
+agent_display_name: Mochi
+relationship: friend
+formality: casual
+extra_instructions: ""
+first_memory: "Sunday in Taipei"
+proactive_tier: warm_only
+"#,
+    )
+    .unwrap();
+
+    // Run `mur agent companion init --answers <path>` end-to-end via the
+    // built `mur` binary so the relationship.json on disk is what the
+    // preview path will actually read.
+    let init = Command::new(mur_bin())
+        .env("HOME", tmp.path())
+        .env("MUR_HOME", &mur_home)
+        .args(["agent", "companion", "init", "preview_test", "--answers"])
+        .arg(&answers_path)
+        .output()
+        .expect("spawn mur agent companion init");
+    assert!(
+        init.status.success(),
+        "init failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&init.stdout),
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // Now exercise `mur agent companion preview <name> --situation morning_greeting --no-llm`.
+    let preview = Command::new(mur_bin())
+        .env("HOME", tmp.path())
+        .env("MUR_HOME", &mur_home)
+        .args([
+            "agent",
+            "companion",
+            "preview",
+            "preview_test",
+            "--situation",
+            "morning_greeting",
+            "--no-llm",
+        ])
+        .output()
+        .expect("spawn mur agent companion preview");
+    let body = format!(
+        "{}{}",
+        String::from_utf8_lossy(&preview.stdout),
+        String::from_utf8_lossy(&preview.stderr)
+    );
+    assert!(preview.status.success(), "preview exited non-zero: {body}");
+    assert!(
+        body.contains("Sunday in Taipei"),
+        "preview output should include first_memory; got:\n{body}"
+    );
+}


### PR DESCRIPTION
## Summary

Third milestone (M2.3) of the M2 D2 plan (#58). Surfaces M2.1's schema and M2.2's runtime threading on the CLI side: `mur agent companion init` becomes a 5-step interactive wizard with `--answers` YAML support for the new fields, and `mur agent companion preview` now references the user's first memory in its rendered output.

## What's in

**M2.3.1** — `Answers` struct in `mur-core/src/cmd/agent_companion/init.rs` extended with three optional fields (`agent_display_name`, `first_memory`, `proactive_tier`); all `#[serde(default)]` so legacy 3-step YAML files keep deserialising. `RelationshipFile` extended with `first_memory: Option<&'a FirstMemory>` and `skip_serializing_if`. `run()` now applies `ProactiveTier` (default `WarmOnly`) instead of writing booleans inline. Visibility bumps (`pub mod agent_companion`, `pub mod init`) for integration testing. New test: `companion_init_5step.rs` covers both 5-step + legacy 3-step deserialization paths.

**M2.3.2** — `run_wizard()` rewritten as 5-step interactive flow:
1. Name your agent (display name)
2. Voice — opt-in (Skip / Enable hint; the actual picker lives in the GUI)
3. Locale + name_for_user + relationship + example greeting
4. First memory (one optional fact, empty trims to None)
5. Three-tier proactive (`WarmOnly` / `WarmAndBehavior` / `All`)

Wraps in `Instant` and prints `"Elapsed Ns."` as a soft timing gate (the M2.8.1 E2E script enforces ≤ 120s on the `--answers` path).

**M2.3.3** — `mur agent companion preview --no-llm` output now includes `first_memory` text. New helpers in `preview.rs`:
- `load_relationship_first_memory()` — best-effort parse of `companion/relationship.json` mirroring M2.2.3's runtime loader
- `compose_voice_for_preview()` — builds `VoiceInput` with first_memory threaded
- `substitute_prompt_seed()` — applies `{{FIRST_MEMORY}}` / `{{FIRST_MEMORY_PARAGRAPH}}` substitution to template prompt_seed (consistent with runtime's `apply_placeholders`)
- `pick_first_template_for_preview()` is `{{FIRST_MEMORY}}`-preferring when `first_memory` is `Some(non-empty)` so the new M2.2.2 seed templates surface; falls back to the previous head-pick when memory is unset.

New test: `companion_preview_first_memory.rs` drives the full CLI end-to-end (`init --answers` → `preview --no-llm`), asserts the first_memory string appears in stdout.

## Tests added

- `mur-core/tests/companion_init_5step.rs`: 2 tests (5-step + legacy backward-compat).
- `mur-core/tests/companion_preview_first_memory.rs`: 1 end-to-end CLI test.

Full workspace: green. `cargo fmt --all --check` clean. `cargo clippy --workspace -- -D warnings` clean.

## Stack

- #58 — D2 plan (draft)
- #59 — M2.1 schema (base = main)
- #60 — M2.2 picker (base = #59)
- **THIS** — M2.3 CLI (base = #60)
- M2.4 Tauri commands (next)

## Test plan

- [ ] `cargo test --workspace`
- [ ] Manual: `mur agent companion init <name>` → walk through 5 steps
- [ ] Manual: `mur agent companion preview <name> --situation morning_greeting --no-llm` → first_memory visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)