### PR TITLE
feat(gui): D2 onboarding — M2.4 Tauri commands (status / submit / skip)

### DIFF
--- a/mur-agent-gui/src-tauri/Cargo.toml
+++ b/mur-agent-gui/src-tauri/Cargo.toml
@@ -50,6 +50,7 @@ tokio = { version = "1", features = ["time", "signal", "macros", "sync", "rt-mul
 tokio-util = { version = "0.7", features = ["io", "rt"] }
 flate2 = "1"
 tar = "0.4"
+tempfile = "3"
 
 # ───── voice (D1 / M1) ─────
 ort = { version = "=2.0.0-rc.10", default-features = false, features = ["copy-dylibs", "load-dynamic"] }

--- a/mur-agent-gui/src-tauri/src/commands.rs
+++ b/mur-agent-gui/src-tauri/src/commands.rs
@@ -800,3 +800,27 @@ pub async fn companion_onboarding_submit(
         .await
         .map_err(err)
 }
+
+pub async fn companion_onboarding_skip_impl(agent: &str) -> anyhow::Result<()> {
+    let dir = onboarding_agent_dir(agent)?;
+    let pf_path = dir.join("profile.yaml");
+    let body = tokio::fs::read_to_string(&pf_path).await?;
+    let mut p: mur_common::agent::AgentProfile = serde_yaml_ng::from_str(&body)?;
+    // WarmOnly tier — flips `companion.enabled` true so voice composition
+    // works, leaves rhythm + proactive dormant. Same default the 5-step
+    // wizard lands on for users who hit Enter through every step.
+    mur_common::agent::ProactiveTier::WarmOnly.apply(&mut p.companion);
+    p.companion.onboarding.completed_at = Some(chrono::Utc::now());
+    p.companion.onboarding.version = 1;
+    let yaml = serde_yaml_ng::to_string(&p)?;
+    // Atomic write: temp file + rename, mirroring `cmd::agent_companion::util`.
+    let tmp_path = pf_path.with_extension("yaml.tmp");
+    tokio::fs::write(&tmp_path, yaml).await?;
+    tokio::fs::rename(&tmp_path, &pf_path).await?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn companion_onboarding_skip(agent: String) -> Result<(), String> {
+    companion_onboarding_skip_impl(&agent).await.map_err(err)
+}

--- a/mur-agent-gui/src-tauri/src/commands.rs
+++ b/mur-agent-gui/src-tauri/src/commands.rs
@@ -654,3 +654,69 @@ pub async fn voice_stop_capture(
     let mut w = state.0.lock().await;
     w.stop().map_err(err)
 }
+
+// ─── D2 onboarding (M2.4) ──────────────────────────────────────────
+//
+// Three commands back the GUI's onboarding wizard:
+//   * `companion_onboarding_status` — reads the persisted state so the
+//     wizard can route to "show wizard" vs "show summary" on launch
+//   * `companion_onboarding_submit` — invokes the same `init::run` path
+//     the CLI uses (`mur agent companion init --answers`)
+//   * `companion_onboarding_skip`   — closes the door for users who
+//     don't want a relationship-keyed agent: marks `completed_at = now`
+//     and applies the WarmOnly tier (Spec §4.2 default)
+//
+// All three resolve `~/.mur` via `mur_core::paths::mur_root` so the
+// `MUR_HOME` override (used in tests + first-launch bootstrap) works.
+// Helpers split out of the `#[tauri::command]` wrappers so integration
+// tests can call them without a webview.
+
+fn onboarding_agent_dir(agent: &str) -> anyhow::Result<std::path::PathBuf> {
+    let dir = mur_core::paths::mur_root(None).join("agents").join(agent);
+    if !dir.exists() {
+        anyhow::bail!(
+            "agent {agent} does not exist at {} — run `mur agent create {agent}` first",
+            dir.display()
+        );
+    }
+    Ok(dir)
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct OnboardingStatus {
+    pub completed_at: Option<String>,
+    pub agent_display_name: Option<String>,
+    pub first_memory_text: Option<String>,
+    /// One of `off` | `warm_only` | `warm_and_behavior` | `all`,
+    /// derived from `companion.{enabled, rhythm.enabled, proactive.enabled}`
+    /// via `ProactiveTier::from_config`. Lower-case so the React wizard
+    /// can match on the same string the submit payload uses.
+    pub proactive_tier: String,
+}
+
+pub async fn companion_onboarding_status_impl(agent: &str) -> anyhow::Result<OnboardingStatus> {
+    let dir = onboarding_agent_dir(agent)?;
+    let body = tokio::fs::read_to_string(dir.join("profile.yaml")).await?;
+    let p: mur_common::agent::AgentProfile = serde_yaml_ng::from_str(&body)?;
+    let tier = mur_common::agent::ProactiveTier::from_config(&p.companion);
+    let tier_str = serde_json::to_value(tier)?
+        .as_str()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "off".to_string());
+    Ok(OnboardingStatus {
+        completed_at: p.companion.onboarding.completed_at.map(|t| t.to_rfc3339()),
+        agent_display_name: p.companion.onboarding.agent_display_name.clone(),
+        first_memory_text: p
+            .companion
+            .onboarding
+            .first_memory
+            .as_ref()
+            .map(|f| f.text.clone()),
+        proactive_tier: tier_str,
+    })
+}
+
+#[tauri::command]
+pub async fn companion_onboarding_status(agent: String) -> Result<OnboardingStatus, String> {
+    companion_onboarding_status_impl(&agent).await.map_err(err)
+}

--- a/mur-agent-gui/src-tauri/src/commands.rs
+++ b/mur-agent-gui/src-tauri/src/commands.rs
@@ -720,3 +720,83 @@ pub async fn companion_onboarding_status_impl(agent: &str) -> anyhow::Result<Onb
 pub async fn companion_onboarding_status(agent: String) -> Result<OnboardingStatus, String> {
     companion_onboarding_status_impl(&agent).await.map_err(err)
 }
+
+/// Wizard payload — mirrors the CLI's `--answers` YAML shape one-for-one.
+/// Fields are validated downstream when `init::run` deserialises the
+/// generated YAML, so this struct stays a flat string-typed bag.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct OnboardingSubmit {
+    pub agent_display_name: String,
+    pub locale: String,
+    pub name_for_user: String,
+    /// One of `friend` | `coach` | `accountability_buddy` | `mentor`.
+    pub relationship: String,
+    pub first_memory: Option<String>,
+    /// One of `off` | `warm_only` | `warm_and_behavior` | `all`.
+    pub proactive_tier: String,
+}
+
+pub async fn companion_onboarding_submit_impl(
+    agent: &str,
+    p: OnboardingSubmit,
+) -> anyhow::Result<()> {
+    use std::io::Write;
+    // Build the `--answers` payload as JSON-via-serde_json::Value first so
+    // we can omit `first_memory` cleanly when absent (a literal `null` in
+    // the YAML deserialises as `Some("null"-ish)` — but `serde_yaml_ng`
+    // round-trips `Value::Null` to a real null, which `init::run` then
+    // sees as `None` per `#[serde(default)]`).
+    let mut obj = serde_json::Map::new();
+    obj.insert("locale".into(), serde_json::Value::String(p.locale));
+    obj.insert(
+        "name_for_user".into(),
+        serde_json::Value::String(p.name_for_user),
+    );
+    obj.insert(
+        "agent_display_name".into(),
+        serde_json::Value::String(p.agent_display_name),
+    );
+    obj.insert(
+        "relationship".into(),
+        serde_json::Value::String(p.relationship),
+    );
+    obj.insert(
+        "formality".into(),
+        serde_json::Value::String("casual".into()),
+    );
+    obj.insert(
+        "extra_instructions".into(),
+        serde_json::Value::String(String::new()),
+    );
+    if let Some(text) = p.first_memory {
+        obj.insert("first_memory".into(), serde_json::Value::String(text));
+    }
+    obj.insert(
+        "proactive_tier".into(),
+        serde_json::Value::String(p.proactive_tier),
+    );
+    let yaml = serde_yaml_ng::to_string(&serde_json::Value::Object(obj))?;
+
+    // Use a NamedTempFile so the file is unlinked on drop even if
+    // `init::run` panics. The CLI parses by path, so we hand it the
+    // path (not a handle) and keep the temp file alive for the call.
+    let tmp = tempfile::NamedTempFile::new()?;
+    tmp.as_file().write_all(yaml.as_bytes())?;
+    tmp.as_file().sync_all().ok();
+    let answers_path = tmp.path().to_path_buf();
+    // re-init: the GUI wizard re-runs onboarding when the user clicks
+    // "Edit", so allow overwriting an existing onboarding state.
+    mur_core::cmd::agent_companion::init::run(agent, Some(answers_path), true).await?;
+    drop(tmp);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn companion_onboarding_submit(
+    agent: String,
+    payload: OnboardingSubmit,
+) -> Result<(), String> {
+    companion_onboarding_submit_impl(&agent, payload)
+        .await
+        .map_err(err)
+}

--- a/mur-agent-gui/src-tauri/src/commands.rs
+++ b/mur-agent-gui/src-tauri/src/commands.rs
@@ -724,6 +724,11 @@ pub async fn companion_onboarding_status(agent: String) -> Result<OnboardingStat
 /// Wizard payload — mirrors the CLI's `--answers` YAML shape one-for-one.
 /// Fields are validated downstream when `init::run` deserialises the
 /// generated YAML, so this struct stays a flat string-typed bag.
+///
+/// `re_init` defaults to `false` (matching the CLI safety default).
+/// The frontend must explicitly set it to `true` when re-running the
+/// wizard from the "Edit" entrypoint so a user's first_memory cannot be
+/// silently overwritten by an accidental wizard re-entry.
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct OnboardingSubmit {
     pub agent_display_name: String,
@@ -734,6 +739,10 @@ pub struct OnboardingSubmit {
     pub first_memory: Option<String>,
     /// One of `off` | `warm_only` | `warm_and_behavior` | `all`.
     pub proactive_tier: String,
+    /// `true` only when the wizard is launched from the "Edit" button
+    /// against an already-onboarded agent. Default `false`.
+    #[serde(default)]
+    pub re_init: bool,
 }
 
 pub async fn companion_onboarding_submit_impl(
@@ -784,9 +793,11 @@ pub async fn companion_onboarding_submit_impl(
     tmp.as_file().write_all(yaml.as_bytes())?;
     tmp.as_file().sync_all().ok();
     let answers_path = tmp.path().to_path_buf();
-    // re-init: the GUI wizard re-runs onboarding when the user clicks
-    // "Edit", so allow overwriting an existing onboarding state.
-    mur_core::cmd::agent_companion::init::run(agent, Some(answers_path), true).await?;
+    // re-init defaults off — the frontend must set re_init=true via the
+    // "Edit" entrypoint to overwrite an existing onboarding state, so
+    // the wizard's normal first-launch path can never silently clobber
+    // a user's first_memory.
+    mur_core::cmd::agent_companion::init::run(agent, Some(answers_path), p.re_init).await?;
     drop(tmp);
     Ok(())
 }

--- a/mur-agent-gui/src-tauri/src/main.rs
+++ b/mur-agent-gui/src-tauri/src/main.rs
@@ -309,6 +309,8 @@ fn main() -> Result<()> {
             commands::voice_stop_capture,
             commands::voice_get_hotkey,
             commands::voice_rebind_hotkey,
+            // D2 onboarding (M2.4)
+            commands::companion_onboarding_status,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/mur-agent-gui/src-tauri/src/main.rs
+++ b/mur-agent-gui/src-tauri/src/main.rs
@@ -312,6 +312,7 @@ fn main() -> Result<()> {
             // D2 onboarding (M2.4)
             commands::companion_onboarding_status,
             commands::companion_onboarding_submit,
+            commands::companion_onboarding_skip,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/mur-agent-gui/src-tauri/src/main.rs
+++ b/mur-agent-gui/src-tauri/src/main.rs
@@ -311,6 +311,7 @@ fn main() -> Result<()> {
             commands::voice_rebind_hotkey,
             // D2 onboarding (M2.4)
             commands::companion_onboarding_status,
+            commands::companion_onboarding_submit,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/mur-agent-gui/src-tauri/tests/onboarding_commands.rs
+++ b/mur-agent-gui/src-tauri/tests/onboarding_commands.rs
@@ -100,3 +100,63 @@ async fn onboarding_status_missing_agent_errors() {
     let res = mur_agent_gui_lib::commands::companion_onboarding_status_impl("nope").await;
     assert!(res.is_err(), "missing agent dir must error");
 }
+
+// ─── M2.4.2 — `companion_onboarding_submit` ────────────────────────────────
+
+#[tokio::test]
+async fn onboarding_submit_persists_fields_and_tier() {
+    let tmp = TempDir::new().unwrap();
+    let _guard = MurHomeGuard::set(tmp.path());
+    seed_agent(tmp.path(), "submit");
+
+    let payload = mur_agent_gui_lib::commands::OnboardingSubmit {
+        agent_display_name: "Mochi".into(),
+        locale: "en-US".into(),
+        name_for_user: "David".into(),
+        relationship: "friend".into(),
+        first_memory: Some("Sunday in Taipei".into()),
+        proactive_tier: "warm_only".into(),
+    };
+
+    mur_agent_gui_lib::commands::companion_onboarding_submit_impl("submit", payload)
+        .await
+        .expect("submit must succeed");
+
+    // Re-read via the status helper to confirm persistence.
+    let s = mur_agent_gui_lib::commands::companion_onboarding_status_impl("submit")
+        .await
+        .expect("status after submit must succeed");
+
+    assert!(s.completed_at.is_some(), "completed_at should be set");
+    assert_eq!(s.agent_display_name.as_deref(), Some("Mochi"));
+    assert_eq!(s.first_memory_text.as_deref(), Some("Sunday in Taipei"));
+    assert_eq!(s.proactive_tier, "warm_only");
+}
+
+#[tokio::test]
+async fn onboarding_submit_without_first_memory_writes_none() {
+    let tmp = TempDir::new().unwrap();
+    let _guard = MurHomeGuard::set(tmp.path());
+    seed_agent(tmp.path(), "nofm");
+
+    let payload = mur_agent_gui_lib::commands::OnboardingSubmit {
+        agent_display_name: "Sage".into(),
+        locale: "en-US".into(),
+        name_for_user: "Alex".into(),
+        relationship: "coach".into(),
+        first_memory: None,
+        proactive_tier: "all".into(),
+    };
+
+    mur_agent_gui_lib::commands::companion_onboarding_submit_impl("nofm", payload)
+        .await
+        .expect("submit without first_memory must succeed");
+
+    let s = mur_agent_gui_lib::commands::companion_onboarding_status_impl("nofm")
+        .await
+        .unwrap();
+    assert!(s.completed_at.is_some());
+    assert_eq!(s.agent_display_name.as_deref(), Some("Sage"));
+    assert!(s.first_memory_text.is_none());
+    assert_eq!(s.proactive_tier, "all");
+}

--- a/mur-agent-gui/src-tauri/tests/onboarding_commands.rs
+++ b/mur-agent-gui/src-tauri/tests/onboarding_commands.rs
@@ -160,3 +160,42 @@ async fn onboarding_submit_without_first_memory_writes_none() {
     assert!(s.first_memory_text.is_none());
     assert_eq!(s.proactive_tier, "all");
 }
+
+// ─── M2.4.3 — `companion_onboarding_skip` ──────────────────────────────────
+
+#[tokio::test]
+async fn onboarding_skip_marks_completed_and_warm_only() {
+    let tmp = TempDir::new().unwrap();
+    let _guard = MurHomeGuard::set(tmp.path());
+    seed_agent(tmp.path(), "skipper");
+
+    mur_agent_gui_lib::commands::companion_onboarding_skip_impl("skipper")
+        .await
+        .expect("skip must succeed");
+
+    let s = mur_agent_gui_lib::commands::companion_onboarding_status_impl("skipper")
+        .await
+        .expect("status after skip must succeed");
+
+    assert!(s.completed_at.is_some(), "skip sets completed_at");
+    assert!(
+        s.agent_display_name.is_none(),
+        "skip must not invent a display name"
+    );
+    assert!(
+        s.first_memory_text.is_none(),
+        "skip must not invent a first memory"
+    );
+    assert_eq!(
+        s.proactive_tier, "warm_only",
+        "skip applies WarmOnly tier (Spec §4.2 default)"
+    );
+}
+
+#[tokio::test]
+async fn onboarding_skip_missing_agent_errors() {
+    let tmp = TempDir::new().unwrap();
+    let _guard = MurHomeGuard::set(tmp.path());
+    let res = mur_agent_gui_lib::commands::companion_onboarding_skip_impl("ghost").await;
+    assert!(res.is_err(), "skip on missing agent must error");
+}

--- a/mur-agent-gui/src-tauri/tests/onboarding_commands.rs
+++ b/mur-agent-gui/src-tauri/tests/onboarding_commands.rs
@@ -116,6 +116,7 @@ async fn onboarding_submit_persists_fields_and_tier() {
         relationship: "friend".into(),
         first_memory: Some("Sunday in Taipei".into()),
         proactive_tier: "warm_only".into(),
+        re_init: false,
     };
 
     mur_agent_gui_lib::commands::companion_onboarding_submit_impl("submit", payload)
@@ -146,6 +147,7 @@ async fn onboarding_submit_without_first_memory_writes_none() {
         relationship: "coach".into(),
         first_memory: None,
         proactive_tier: "all".into(),
+        re_init: false,
     };
 
     mur_agent_gui_lib::commands::companion_onboarding_submit_impl("nofm", payload)
@@ -159,6 +161,91 @@ async fn onboarding_submit_without_first_memory_writes_none() {
     assert_eq!(s.agent_display_name.as_deref(), Some("Sage"));
     assert!(s.first_memory_text.is_none());
     assert_eq!(s.proactive_tier, "all");
+}
+
+#[tokio::test]
+async fn onboarding_submit_without_re_init_rejects_already_onboarded() {
+    // R12 first-memory-is-sacred guard — an accidental wizard re-entry
+    // must not silently overwrite an already-set first_memory.
+    let tmp = TempDir::new().unwrap();
+    let _guard = MurHomeGuard::set(tmp.path());
+    seed_agent(tmp.path(), "twice");
+
+    let first = mur_agent_gui_lib::commands::OnboardingSubmit {
+        agent_display_name: "Mochi".into(),
+        locale: "en-US".into(),
+        name_for_user: "David".into(),
+        relationship: "friend".into(),
+        first_memory: Some("Sunday in Taipei".into()),
+        proactive_tier: "warm_only".into(),
+        re_init: false,
+    };
+    mur_agent_gui_lib::commands::companion_onboarding_submit_impl("twice", first)
+        .await
+        .expect("first submit must succeed");
+
+    let second = mur_agent_gui_lib::commands::OnboardingSubmit {
+        agent_display_name: "Mochi-2".into(),
+        locale: "en-US".into(),
+        name_for_user: "Imposter".into(),
+        relationship: "coach".into(),
+        first_memory: Some("Tuesday in Tokyo".into()),
+        proactive_tier: "all".into(),
+        re_init: false, // explicitly not re-init — must be rejected
+    };
+    let err = mur_agent_gui_lib::commands::companion_onboarding_submit_impl("twice", second)
+        .await
+        .expect_err("second submit without re_init must reject");
+    assert!(
+        err.to_string().contains("already initialized"),
+        "expected re-init guard error, got: {err}"
+    );
+
+    // Original first_memory unchanged.
+    let s = mur_agent_gui_lib::commands::companion_onboarding_status_impl("twice")
+        .await
+        .unwrap();
+    assert_eq!(s.first_memory_text.as_deref(), Some("Sunday in Taipei"));
+    assert_eq!(s.agent_display_name.as_deref(), Some("Mochi"));
+}
+
+#[tokio::test]
+async fn onboarding_submit_with_re_init_overwrites() {
+    // Edit-mode wizard (re_init = true) must successfully overwrite.
+    let tmp = TempDir::new().unwrap();
+    let _guard = MurHomeGuard::set(tmp.path());
+    seed_agent(tmp.path(), "edit");
+
+    let first = mur_agent_gui_lib::commands::OnboardingSubmit {
+        agent_display_name: "Mochi".into(),
+        locale: "en-US".into(),
+        name_for_user: "David".into(),
+        relationship: "friend".into(),
+        first_memory: Some("v1".into()),
+        proactive_tier: "warm_only".into(),
+        re_init: false,
+    };
+    mur_agent_gui_lib::commands::companion_onboarding_submit_impl("edit", first)
+        .await
+        .unwrap();
+
+    let edit = mur_agent_gui_lib::commands::OnboardingSubmit {
+        agent_display_name: "Mochi".into(),
+        locale: "en-US".into(),
+        name_for_user: "David".into(),
+        relationship: "friend".into(),
+        first_memory: Some("v2".into()),
+        proactive_tier: "warm_only".into(),
+        re_init: true,
+    };
+    mur_agent_gui_lib::commands::companion_onboarding_submit_impl("edit", edit)
+        .await
+        .expect("re_init=true must succeed");
+
+    let s = mur_agent_gui_lib::commands::companion_onboarding_status_impl("edit")
+        .await
+        .unwrap();
+    assert_eq!(s.first_memory_text.as_deref(), Some("v2"));
 }
 
 // ─── M2.4.3 — `companion_onboarding_skip` ──────────────────────────────────

--- a/mur-agent-gui/src-tauri/tests/onboarding_commands.rs
+++ b/mur-agent-gui/src-tauri/tests/onboarding_commands.rs
@@ -1,0 +1,102 @@
+//! Integration tests for the D2 onboarding Tauri commands
+//! (M2.4.1 / M2.4.2 / M2.4.3).
+//!
+//! These tests exercise the `_impl` helpers that back each Tauri
+//! `#[tauri::command]` wrapper. The command wrappers themselves only
+//! map `anyhow::Error -> String`; the core logic lives in the helpers
+//! so they can be unit-tested without a webview.
+//!
+//! All three commands respect `MUR_HOME` via `mur_core::paths::mur_root`,
+//! which is what the CLI side does too.
+
+use std::path::Path;
+use std::sync::{LazyLock, Mutex, MutexGuard};
+use tempfile::TempDir;
+
+/// Cargo runs integration tests in parallel threads; `MUR_HOME` is a
+/// process-global env var, so we serialise the tests that mutate it.
+static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+struct MurHomeGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl MurHomeGuard {
+    fn set(path: &Path) -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: process-wide mutex held across the env mutation; cleared
+        // again in `Drop`.
+        unsafe { std::env::set_var("MUR_HOME", path) };
+        MurHomeGuard { _lock: lock }
+    }
+}
+
+impl Drop for MurHomeGuard {
+    fn drop(&mut self) {
+        // SAFETY: still holding `_lock` until our fields drop.
+        unsafe { std::env::remove_var("MUR_HOME") };
+    }
+}
+
+/// Load the shared P0a fixture and substitute `name: agent_test` →
+/// `name: <name>` so the same baseline profile can host any agent.
+fn fixture_with_name(name: &str) -> String {
+    let candidates = [
+        "../../mur-common/tests/fixtures/profile_p0a_minimal.yaml",
+        "../mur-common/tests/fixtures/profile_p0a_minimal.yaml",
+        "mur-common/tests/fixtures/profile_p0a_minimal.yaml",
+    ];
+    let yaml = candidates
+        .iter()
+        .find_map(|p| std::fs::read_to_string(p).ok())
+        .unwrap_or_else(|| {
+            // Last-ditch resolve via CARGO_MANIFEST_DIR for direct
+            // `cargo test` invocations.
+            let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .ancestors()
+                .nth(2)
+                .unwrap()
+                .join("mur-common/tests/fixtures/profile_p0a_minimal.yaml");
+            std::fs::read_to_string(p).expect("fixture must exist")
+        });
+    yaml.replace("name: agent_test", &format!("name: {name}"))
+}
+
+fn seed_agent(mur_home: &Path, name: &str) {
+    let agent_dir = mur_home.join("agents").join(name);
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(agent_dir.join("profile.yaml"), fixture_with_name(name)).unwrap();
+}
+
+// ─── M2.4.1 — `companion_onboarding_status` ────────────────────────────────
+
+#[tokio::test]
+async fn onboarding_status_returns_pending_for_new_agent() {
+    let tmp = TempDir::new().unwrap();
+    let _guard = MurHomeGuard::set(tmp.path());
+    seed_agent(tmp.path(), "fresh");
+
+    let s = mur_agent_gui_lib::commands::companion_onboarding_status_impl("fresh")
+        .await
+        .expect("status must succeed for a fresh agent");
+
+    assert!(
+        s.completed_at.is_none(),
+        "fresh agent: not onboarded — completed_at should be None"
+    );
+    assert!(s.agent_display_name.is_none());
+    assert!(s.first_memory_text.is_none());
+    assert_eq!(
+        s.proactive_tier, "off",
+        "default config has companion.enabled=false → tier off"
+    );
+}
+
+#[tokio::test]
+async fn onboarding_status_missing_agent_errors() {
+    let tmp = TempDir::new().unwrap();
+    let _guard = MurHomeGuard::set(tmp.path());
+    // No agent directory — should bubble up the file-not-found error.
+    let res = mur_agent_gui_lib::commands::companion_onboarding_status_impl("nope").await;
+    assert!(res.is_err(), "missing agent dir must error");
+}


### PR DESCRIPTION
## Summary

Fourth milestone (M2.4) of the M2 D2 plan (#58). Three Tauri commands wrap the M2.3 CLI surface so the React wizard (M2.5) can talk to the runtime.

## Commands

| Command | Purpose |
|---|---|
| `companion_onboarding_status(agent)` | Read profile.yaml, return `{ completed_at, agent_display_name, first_memory_text, proactive_tier }` for first-launch detection + Settings display. |
| `companion_onboarding_submit(agent, payload)` | Write a temp `--answers` YAML and invoke `mur_core::cmd::agent_companion::init::run`. Gated by explicit `payload.re_init: bool` so accidental wizard re-entry can't silently overwrite a user's first_memory (R12). |
| `companion_onboarding_skip(agent)` | Mark `completed_at = now`, apply `ProactiveTier::WarmOnly`, leave first_memory + display_name as None. |

## Implementation notes

- **Helper:** `mur_core::paths::mur_root(None).join("agents").join(agent)` (the publicly-exported path resolver). The plan suggested non-existent helpers; this is the same call chain the CLI's `util::agent_home_for` uses internally.
- **`OnboardingSubmit.re_init: bool`** (default `false` via `#[serde(default)]`). Frontend must explicitly set `true` from the "Edit" entrypoint. Per code-quality review IMPORTANT — guards against accidental first_memory overwrite.
- **`tempfile`** moved from dev-deps to runtime deps. The submit path bridges the typed payload to `init::run`'s path-based `--answers` API via a `NamedTempFile`. Refactoring `init::run` to accept either path or in-memory `Answers` would be a larger change; pragmatic for now.
- **Skip** writes profile.yaml directly (not through `atomic_write_yaml` because the CLI helper is `pub(super)`). Acceptable for the GUI hot path; flag for future API-elevation if cross-crate use grows.
- All commands registered in `tauri::generate_handler!` (main.rs:312-315).

## Tests

`mur-agent-gui/src-tauri/tests/onboarding_commands.rs` — 8 tests, all green:

- status: `returns_pending_for_new_agent`, `missing_agent_errors`
- submit: `persists_fields_and_tier`, `without_first_memory_writes_none`, `without_re_init_rejects_already_onboarded`, `with_re_init_overwrites`
- skip: `marks_completed_and_warm_only`, `missing_agent_errors`

`MurHomeGuard` (LazyLock<Mutex<()>> + env mutation) serializes parallel tests + drops env on guard release. `cargo fmt --all --check` clean.

## Stack

- #58 plan → main
- #59 M2.1 → main
- #60 M2.2 → #59
- #61 M2.3 → #60
- **THIS** M2.4 → #61
- M2.5 React wizard (next, base = THIS)

## Test plan

- [ ] `cd mur-agent-gui/src-tauri && cargo test --test onboarding_commands`
- [ ] `cargo fmt --all --check`
- [ ] Review the `re_init` gate semantics (does the GUI need a separate "Edit" verb, or is the boolean enough?)

🤖 Generated with [Claude Code](https://claude.com/claude-code)