### PR TITLE
feat(gui): D2 onboarding — M2.5 React 5-step wizard

### DIFF
--- a/mur-agent-gui/ui/src/onboarding/OnboardingWizard.tsx
+++ b/mur-agent-gui/ui/src/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,184 @@
+// 5-step modal wizard shell.
+//
+// Owns the local state for every wizard answer plus the current step
+// (1-5), renders one step component at a time, and is the single place
+// that calls `submitOnboarding` / `skipOnboarding`. App.tsx (M2.6
+// territory) hides the wizard via `onComplete` once the round-trip
+// succeeds — both the Skip path and the Finish path.
+//
+// `re_init` is hard-coded to `false`. A future "Edit" entrypoint
+// against an already-onboarded agent will need a different shell that
+// passes `true`; we explicitly do NOT support that here so a misroute
+// can never silently overwrite a user's first_memory.
+
+import { useState } from "react";
+import { skipOnboarding, submitOnboarding } from "./api";
+import type { ProactiveTier, Relationship } from "./types";
+import { Step1AgentName } from "./Step1AgentName";
+import { Step2VoicePick } from "./Step2VoicePick";
+import { Step3Relationship } from "./Step3Relationship";
+import { Step4FirstMemory } from "./Step4FirstMemory";
+import { Step5ProactiveTiers } from "./Step5ProactiveTiers";
+
+const LOCALE_DEFAULT =
+  typeof navigator !== "undefined" && navigator.language
+    ? navigator.language
+    : "en-US";
+
+interface Props {
+  agent: string;
+  /// Called once the wizard is finished (skip OR final submit) so the
+  /// caller can hide it. The caller is also responsible for any
+  /// follow-up state refresh.
+  onComplete: () => void;
+  /// Called from Step 2 when the user picks "Enable voice (opens
+  /// picker)". The wizard advances to Step 3 immediately so the user
+  /// isn't blocked while they configure voice in another tab.
+  onOpenVoiceSettings: () => void;
+}
+
+type StepIdx = 1 | 2 | 3 | 4 | 5;
+
+export function OnboardingWizard({
+  agent,
+  onComplete,
+  onOpenVoiceSettings,
+}: Props) {
+  const [step, setStep] = useState<StepIdx>(1);
+  const [agentDisplay, setAgentDisplay] = useState("");
+  const [nameForUser, setNameForUser] = useState("");
+  const [rel, setRel] = useState<Relationship>("friend");
+  const [memory, setMemory] = useState("");
+  const [tier, setTier] = useState<ProactiveTier>("warm_only");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const goto = (next: StepIdx) => {
+    setErr(null);
+    setStep(next);
+  };
+
+  const skipAll = async () => {
+    if (busy) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      await skipOnboarding(agent);
+      onComplete();
+    } catch (e: unknown) {
+      setErr(typeof e === "string" ? e : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const finish = async (chosenTier: ProactiveTier) => {
+    if (busy) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      await submitOnboarding(agent, {
+        agent_display_name: agentDisplay,
+        locale: LOCALE_DEFAULT,
+        name_for_user: nameForUser,
+        relationship: rel,
+        first_memory: memory.trim().length === 0 ? null : memory,
+        proactive_tier: chosenTier,
+        // Hard-coded false — see file header. The future "Edit"
+        // entrypoint will need its own shell.
+        re_init: false,
+      });
+      onComplete();
+    } catch (e: unknown) {
+      setErr(typeof e === "string" ? e : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: "rgba(0, 0, 0, 0.5)" }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Companion onboarding"
+    >
+      <div
+        className="rounded-lg border p-5 shadow-lg"
+        style={{
+          width: "480px",
+          maxWidth: "92vw",
+          maxHeight: "90vh",
+          overflowY: "auto",
+          borderColor: "var(--color-border)",
+          background: "var(--color-bg-secondary)",
+        }}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <span className="text-xs uppercase tracking-wider opacity-60">
+            Welcome · agent: {agent}
+          </span>
+          <span className="text-xs opacity-60">Step {step} of 5</span>
+        </div>
+
+        {step === 1 && (
+          <Step1AgentName
+            value={agentDisplay}
+            onChange={setAgentDisplay}
+            onNext={() => goto(2)}
+            onSkip={skipAll}
+          />
+        )}
+
+        {step === 2 && (
+          <Step2VoicePick
+            onBack={() => goto(1)}
+            onNext={() => goto(3)}
+            onEnable={onOpenVoiceSettings}
+          />
+        )}
+
+        {step === 3 && (
+          <Step3Relationship
+            locale={LOCALE_DEFAULT}
+            nameForUser={nameForUser}
+            relationship={rel}
+            onNameChange={setNameForUser}
+            onRelationshipChange={setRel}
+            onBack={() => goto(2)}
+            onNext={() => goto(4)}
+          />
+        )}
+
+        {step === 4 && (
+          <Step4FirstMemory
+            value={memory}
+            onChange={setMemory}
+            onBack={() => goto(3)}
+            onNext={() => goto(5)}
+          />
+        )}
+
+        {step === 5 && (
+          <Step5ProactiveTiers
+            value={tier}
+            onChange={setTier}
+            onBack={() => goto(4)}
+            onSubmit={finish}
+            busy={busy}
+          />
+        )}
+
+        {err && (
+          <div
+            className="mt-4 text-sm"
+            style={{ color: "var(--color-error, #b91c1c)" }}
+          >
+            {err}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/mur-agent-gui/ui/src/onboarding/OnboardingWizard.tsx
+++ b/mur-agent-gui/ui/src/onboarding/OnboardingWizard.tsx
@@ -11,7 +11,7 @@
 // passes `true`; we explicitly do NOT support that here so a misroute
 // can never silently overwrite a user's first_memory.
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { skipOnboarding, submitOnboarding } from "./api";
 import type { ProactiveTier, Relationship } from "./types";
 import { Step1AgentName } from "./Step1AgentName";
@@ -57,6 +57,24 @@ export function OnboardingWizard({
     setErr(null);
     setStep(next);
   };
+
+  // Esc-to-skip — modal hygiene. Escape exits the wizard via the same
+  // skipOnboarding path as the explicit "Skip onboarding" button so the
+  // user never gets trapped with no clear way out. Doesn't fire while a
+  // submit / skip is already in flight.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) {
+        e.preventDefault();
+        void skipAll();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+    // skipAll closes over busy but referencing it would re-attach the
+    // listener every keystroke; the busy guard inside skipAll is enough.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [busy]);
 
   const skipAll = async () => {
     if (busy) return;

--- a/mur-agent-gui/ui/src/onboarding/Step1AgentName.tsx
+++ b/mur-agent-gui/ui/src/onboarding/Step1AgentName.tsx
@@ -31,7 +31,11 @@ export function Step1AgentName({ value, onChange, onNext, onSkip }: Props) {
         </p>
       </div>
 
+      <label htmlFor="onboarding-agent-display-name" className="sr-only">
+        Agent display name
+      </label>
       <input
+        id="onboarding-agent-display-name"
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}

--- a/mur-agent-gui/ui/src/onboarding/Step1AgentName.tsx
+++ b/mur-agent-gui/ui/src/onboarding/Step1AgentName.tsx
@@ -1,0 +1,81 @@
+// Step 1 of the onboarding wizard — display name.
+//
+// The user names *the agent*, not themselves. We disable Next until the
+// trimmed input is non-empty so an accidental Enter through the wizard
+// can't produce an unnamed agent. A "Skip onboarding" secondary button
+// drops out of the wizard entirely (the shell wires this to
+// skipOnboarding(), which lands on the WarmOnly default tier).
+
+interface Props {
+  value: string;
+  onChange: (next: string) => void;
+  onNext: () => void;
+  onSkip: () => void;
+}
+
+export function Step1AgentName({ value, onChange, onNext, onSkip }: Props) {
+  const canAdvance = value.trim().length > 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2
+          className="text-lg font-medium mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          What should this agent be called?
+        </h2>
+        <p className="text-sm opacity-80">
+          A display name — something short and human. You can change it
+          later.
+        </p>
+      </div>
+
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && canAdvance) onNext();
+        }}
+        autoFocus
+        placeholder="e.g. Iris, Coach, Pebble"
+        className="rounded-md border px-3 py-2 text-sm outline-none"
+        style={{
+          borderColor: "var(--color-border)",
+          background: "var(--color-bg)",
+          color: "var(--color-fg)",
+        }}
+      />
+
+      <div className="flex items-center justify-between mt-2">
+        <button
+          type="button"
+          onClick={onSkip}
+          className="text-sm underline opacity-70 hover:opacity-100"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Skip onboarding
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          disabled={!canAdvance}
+          className="px-4 py-2 text-sm rounded font-medium"
+          style={{
+            background: canAdvance
+              ? "var(--color-accent)"
+              : "var(--color-bg-secondary)",
+            color: canAdvance
+              ? "var(--color-accent-fg)"
+              : "var(--color-fg)",
+            opacity: canAdvance ? 1 : 0.5,
+            cursor: canAdvance ? "pointer" : "not-allowed",
+          }}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/mur-agent-gui/ui/src/onboarding/Step2VoicePick.tsx
+++ b/mur-agent-gui/ui/src/onboarding/Step2VoicePick.tsx
@@ -1,0 +1,83 @@
+// Step 2 — voice consent. Mirrors the CLI's two-option Select in
+// `run_wizard()` (mur-core/src/cmd/agent_companion/init.rs §177-194):
+// either skip and enable later from Settings, or open the picker now.
+//
+// Like the CLI, this step records *intent* only — the actual voice
+// download lives in the existing Voice tab + VoiceEnablePanel. When the
+// user picks "Enable", the shell hands off to App.tsx via
+// `onOpenVoiceSettings` and then advances to step 3 immediately so the
+// wizard doesn't block the picker.
+
+import { useState } from "react";
+
+type Choice = "skip" | "enable";
+
+interface Props {
+  onBack: () => void;
+  onNext: () => void;
+  onEnable: () => void;
+}
+
+export function Step2VoicePick({ onBack, onNext, onEnable }: Props) {
+  const [choice, setChoice] = useState<Choice>("skip");
+
+  const advance = () => {
+    if (choice === "enable") {
+      onEnable();
+    }
+    onNext();
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2
+          className="text-lg font-medium mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Voice
+        </h2>
+        <p className="text-sm opacity-80">
+          Voice setup is opt-in and downloads ~190&nbsp;MB on first use.
+          We never send audio off your machine.
+        </p>
+      </div>
+
+      <select
+        value={choice}
+        onChange={(e) => setChoice(e.target.value as Choice)}
+        className="rounded-md border px-3 py-2 text-sm outline-none"
+        style={{
+          borderColor: "var(--color-border)",
+          background: "var(--color-bg)",
+          color: "var(--color-fg)",
+        }}
+      >
+        <option value="skip">Skip — enable voice later in Settings</option>
+        <option value="enable">Enable voice (opens picker)</option>
+      </select>
+
+      <div className="flex items-center justify-between mt-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-sm underline opacity-70 hover:opacity-100"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={advance}
+          className="px-4 py-2 text-sm rounded font-medium"
+          style={{
+            background: "var(--color-accent)",
+            color: "var(--color-accent-fg)",
+          }}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/mur-agent-gui/ui/src/onboarding/Step3Relationship.tsx
+++ b/mur-agent-gui/ui/src/onboarding/Step3Relationship.tsx
@@ -1,0 +1,170 @@
+// Step 3 — locale + name_for_user + relationship picker.
+//
+// The locale stays out of sight (the shell defaults from
+// navigator.language); this step's two interactive concerns are:
+//   * the name the agent should call the user
+//   * the relationship card (4 options, each with an example greeting
+//     matched 1:1 against the CLI's `example_greeting` helper in
+//     mur-core/src/cmd/agent_companion/init.rs §273-291)
+//
+// Selection state is rendered with the `--color-accent` border so the
+// active card is obvious in any theme.
+
+import type { Relationship } from "./types";
+
+interface Props {
+  locale: string;
+  nameForUser: string;
+  relationship: Relationship;
+  onNameChange: (next: string) => void;
+  onRelationshipChange: (next: Relationship) => void;
+  onBack: () => void;
+  onNext: () => void;
+}
+
+interface Card {
+  value: Relationship;
+  title: string;
+  exampleEn: string;
+  exampleZh: string;
+}
+
+const CARDS: Card[] = [
+  {
+    value: "friend",
+    title: "Friend",
+    exampleEn: "\"Hey — how's it going?\"",
+    exampleZh: "「嗨，今天好嗎？」",
+  },
+  {
+    value: "coach",
+    title: "Coach",
+    exampleEn: "\"Hey. What's the goal?\"",
+    exampleZh: "「嗨，目標是什麼？」",
+  },
+  {
+    value: "accountability_buddy",
+    title: "Accountability buddy",
+    exampleEn: "\"Hi, what's on your plate today?\"",
+    exampleZh: "「嗨，今天有什麼想做的嗎？」",
+  },
+  {
+    value: "mentor",
+    title: "Mentor",
+    exampleEn: "\"Hi. What's been on your mind?\"",
+    exampleZh: "「嗨，最近在思考什麼？」",
+  },
+];
+
+function exampleFor(card: Card, locale: string): string {
+  if (locale.startsWith("zh")) return card.exampleZh;
+  // Match the CLI: zh-* prints zh-TW phrasing; en-* / fallback prints
+  // English (init.rs §273-291 prefers no-greeting for other locales,
+  // but here we always show *something* so the cards aren't blank).
+  return card.exampleEn;
+}
+
+export function Step3Relationship({
+  locale,
+  nameForUser,
+  relationship,
+  onNameChange,
+  onRelationshipChange,
+  onBack,
+  onNext,
+}: Props) {
+  const canAdvance = nameForUser.trim().length > 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2
+          className="text-lg font-medium mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          How should this agent relate to you?
+        </h2>
+        <p className="text-sm opacity-80">
+          Pick what fits today — you can change it later.
+        </p>
+      </div>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-sm opacity-80">What should I call you?</span>
+        <input
+          type="text"
+          value={nameForUser}
+          onChange={(e) => onNameChange(e.target.value)}
+          placeholder="Your name or a nickname"
+          className="rounded-md border px-3 py-2 text-sm outline-none"
+          style={{
+            borderColor: "var(--color-border)",
+            background: "var(--color-bg)",
+            color: "var(--color-fg)",
+          }}
+        />
+      </label>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {CARDS.map((c) => {
+          const active = c.value === relationship;
+          return (
+            <button
+              key={c.value}
+              type="button"
+              onClick={() => onRelationshipChange(c.value)}
+              className="rounded-md border p-3 text-left transition-colors"
+              style={{
+                borderColor: active
+                  ? "var(--color-accent)"
+                  : "var(--color-border)",
+                background: active
+                  ? "var(--color-bg-secondary)"
+                  : "var(--color-bg)",
+              }}
+            >
+              <div
+                className="font-medium"
+                style={{ color: "var(--color-fg)" }}
+              >
+                {c.title}
+              </div>
+              <div className="text-xs opacity-70 mt-1">
+                {exampleFor(c, locale)}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center justify-between mt-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-sm underline opacity-70 hover:opacity-100"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          disabled={!canAdvance}
+          className="px-4 py-2 text-sm rounded font-medium"
+          style={{
+            background: canAdvance
+              ? "var(--color-accent)"
+              : "var(--color-bg-secondary)",
+            color: canAdvance
+              ? "var(--color-accent-fg)"
+              : "var(--color-fg)",
+            opacity: canAdvance ? 1 : 0.5,
+            cursor: canAdvance ? "pointer" : "not-allowed",
+          }}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/mur-agent-gui/ui/src/onboarding/Step3Relationship.tsx
+++ b/mur-agent-gui/ui/src/onboarding/Step3Relationship.tsx
@@ -112,6 +112,8 @@ export function Step3Relationship({
             <button
               key={c.value}
               type="button"
+              role="radio"
+              aria-checked={active}
               onClick={() => onRelationshipChange(c.value)}
               className="rounded-md border p-3 text-left transition-colors"
               style={{

--- a/mur-agent-gui/ui/src/onboarding/Step4FirstMemory.tsx
+++ b/mur-agent-gui/ui/src/onboarding/Step4FirstMemory.tsx
@@ -1,0 +1,88 @@
+// Step 4 — first memory. The highest-impact field in the wizard.
+//
+// This text is the seed for `{{FIRST_MEMORY}}` substitution in the
+// morning_greeting template (M2.2.3) and is one of the only durable
+// per-relationship facts the agent carries. We hard-cap at 200 chars
+// (matches the FirstMemory schema in mur-common::companion) and show a
+// live remaining-character counter. Empty is allowed — submit sends
+// `null` so `init::run` records "no first_memory" rather than an empty
+// string.
+
+const MAX = 200;
+
+interface Props {
+  value: string;
+  onChange: (next: string) => void;
+  onBack: () => void;
+  onNext: () => void;
+}
+
+export function Step4FirstMemory({ value, onChange, onBack, onNext }: Props) {
+  const remaining = MAX - value.length;
+  const overLimit = remaining < 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2
+          className="text-lg font-medium mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Share one fact about you, in a sentence
+        </h2>
+        <p className="text-sm opacity-80">
+          Anything memorable. I'll bring it up later. This is the
+          highest-impact thing in this wizard — but it's also OK to skip.
+        </p>
+      </div>
+
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        maxLength={MAX}
+        rows={4}
+        placeholder="e.g. I'm learning to bake sourdough on weekends."
+        className="rounded-md border px-3 py-2 text-sm outline-none resize-none"
+        style={{
+          borderColor: "var(--color-border)",
+          background: "var(--color-bg)",
+          color: "var(--color-fg)",
+        }}
+      />
+
+      <div
+        className="text-xs"
+        style={{
+          color: overLimit
+            ? "var(--color-error, #b91c1c)"
+            : "var(--color-fg)",
+          opacity: overLimit ? 1 : 0.6,
+        }}
+      >
+        {remaining} characters remaining
+      </div>
+
+      <div className="flex items-center justify-between mt-2">
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-sm underline opacity-70 hover:opacity-100"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          className="px-4 py-2 text-sm rounded font-medium"
+          style={{
+            background: "var(--color-accent)",
+            color: "var(--color-accent-fg)",
+          }}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/mur-agent-gui/ui/src/onboarding/Step5ProactiveTiers.tsx
+++ b/mur-agent-gui/ui/src/onboarding/Step5ProactiveTiers.tsx
@@ -1,0 +1,130 @@
+// Step 5 — three-layer proactive toggle.
+//
+// Mirrors the CLI's terminal step (init.rs §236-252): "Warm voice only"
+// is the recommended default and stays that way unless the user picks
+// otherwise. The three options map 1:1 to the `ProactiveTier` variants
+// the M2.4 submit handler accepts:
+//
+//   warm_only         → companion enabled, rhythm dormant, proactive off
+//   warm_and_behavior → companion + rhythm collection, proactive off
+//   all               → companion + rhythm + proactive sends enabled
+//
+// The "off" variant isn't offered here because the wizard exists to
+// turn the companion *on* — users who don't want any of this hit Skip
+// in step 1 (which lands on warm_only via skipOnboarding()) or keep
+// proactive off via `mur agent companion proactive disable` later.
+
+import type { ProactiveTier } from "./types";
+
+interface Props {
+  value: ProactiveTier;
+  onChange: (next: ProactiveTier) => void;
+  onBack: () => void;
+  onSubmit: (tier: ProactiveTier) => void;
+  busy: boolean;
+}
+
+interface Option {
+  value: ProactiveTier;
+  title: string;
+  desc: string;
+}
+
+const OPTIONS: Option[] = [
+  {
+    value: "warm_only",
+    title: "Warm voice only (recommended)",
+    desc: "I'll respond in a more human tone, but I'll never message you first.",
+  },
+  {
+    value: "warm_and_behavior",
+    title: "Warm + behavior collection",
+    desc: "I'll quietly learn your rhythm so a future opt-in is well-timed. Still no proactive sends.",
+  },
+  {
+    value: "all",
+    title: "All — including proactive check-ins",
+    desc: "I may send the occasional warm check-in once I've earned permission. You can pause or turn this off any time.",
+  },
+];
+
+export function Step5ProactiveTiers({
+  value,
+  onChange,
+  onBack,
+  onSubmit,
+  busy,
+}: Props) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2
+          className="text-lg font-medium mb-1"
+          style={{ color: "var(--color-fg)" }}
+        >
+          How should I behave?
+        </h2>
+        <p className="text-sm opacity-80">
+          You can change this any time from the Voice tab or with{" "}
+          <code>mur agent companion proactive</code>.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        {OPTIONS.map((opt) => {
+          const active = opt.value === value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => onChange(opt.value)}
+              className="rounded-md border p-3 text-left transition-colors"
+              style={{
+                borderColor: active
+                  ? "var(--color-accent)"
+                  : "var(--color-border)",
+                background: active
+                  ? "var(--color-bg-secondary)"
+                  : "var(--color-bg)",
+              }}
+            >
+              <div
+                className="font-medium"
+                style={{ color: "var(--color-fg)" }}
+              >
+                {opt.title}
+              </div>
+              <div className="text-xs opacity-70 mt-1">{opt.desc}</div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center justify-between mt-2">
+        <button
+          type="button"
+          onClick={onBack}
+          disabled={busy}
+          className="text-sm underline opacity-70 hover:opacity-100"
+          style={{ color: "var(--color-fg)" }}
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={() => onSubmit(value)}
+          disabled={busy}
+          className="px-4 py-2 text-sm rounded font-medium"
+          style={{
+            background: "var(--color-accent)",
+            color: "var(--color-accent-fg)",
+            opacity: busy ? 0.6 : 1,
+            cursor: busy ? "wait" : "pointer",
+          }}
+        >
+          {busy ? "Finishing…" : "Finish"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/mur-agent-gui/ui/src/onboarding/Step5ProactiveTiers.tsx
+++ b/mur-agent-gui/ui/src/onboarding/Step5ProactiveTiers.tsx
@@ -77,6 +77,8 @@ export function Step5ProactiveTiers({
             <button
               key={opt.value}
               type="button"
+              role="radio"
+              aria-checked={active}
               onClick={() => onChange(opt.value)}
               className="rounded-md border p-3 text-left transition-colors"
               style={{

--- a/mur-agent-gui/ui/src/onboarding/api.ts
+++ b/mur-agent-gui/ui/src/onboarding/api.ts
@@ -1,0 +1,20 @@
+// Thin wrappers around the M2.4 onboarding Tauri commands. Mirrors the
+// `companion_onboarding_*` surface in
+// mur-agent-gui/src-tauri/src/commands.rs.
+//
+// Helper modules wrap each command 1:1 so the wizard components stay
+// agnostic of `invoke()` and the underlying error shape — an
+// invoke-failure surfaces as a thrown string, which the wizard catches
+// and renders inline.
+
+import { invoke } from "@tauri-apps/api/core";
+import type { OnboardingStatus, OnboardingSubmit } from "./types";
+
+export const getOnboardingStatus = (agent: string) =>
+  invoke<OnboardingStatus>("companion_onboarding_status", { agent });
+
+export const submitOnboarding = (agent: string, payload: OnboardingSubmit) =>
+  invoke<void>("companion_onboarding_submit", { agent, payload });
+
+export const skipOnboarding = (agent: string) =>
+  invoke<void>("companion_onboarding_skip", { agent });

--- a/mur-agent-gui/ui/src/onboarding/types.ts
+++ b/mur-agent-gui/ui/src/onboarding/types.ts
@@ -1,0 +1,47 @@
+// Mirrors the M2.4 Tauri command surface in
+// mur-agent-gui/src-tauri/src/commands.rs (companion_onboarding_*).
+//
+// `Relationship` and `ProactiveTier` are the same string literals the
+// CLI's `--answers` YAML accepts (see mur-core/src/cmd/agent_companion/
+// init.rs), so the wizard payload round-trips through `init::run`
+// without re-mapping.
+
+export type Relationship =
+  | "friend"
+  | "coach"
+  | "accountability_buddy"
+  | "mentor";
+
+export type ProactiveTier =
+  | "off"
+  | "warm_only"
+  | "warm_and_behavior"
+  | "all";
+
+/// Returned by `companion_onboarding_status`. `completed_at` is the
+/// RFC 3339 timestamp the wizard wrote on submit/skip; the wizard reads
+/// it on launch to decide whether to show itself or step aside.
+export interface OnboardingStatus {
+  completed_at: string | null;
+  agent_display_name: string | null;
+  first_memory_text: string | null;
+  /// Lower-case `ProactiveTier` discriminant. Sourced from
+  /// `ProactiveTier::from_config`, so a profile that's never been
+  /// onboarded reports `"off"` rather than a missing/empty string.
+  proactive_tier: string;
+}
+
+/// Payload accepted by `companion_onboarding_submit`.
+///
+/// `re_init` defaults to `false` server-side (`#[serde(default)]`), but
+/// TypeScript requires it explicitly — pass `false` for the first-launch
+/// wizard and `true` only from a future "Edit" entrypoint.
+export interface OnboardingSubmit {
+  agent_display_name: string;
+  locale: string;
+  name_for_user: string;
+  relationship: Relationship;
+  first_memory: string | null;
+  proactive_tier: ProactiveTier;
+  re_init: boolean;
+}


### PR DESCRIPTION
## Summary

Fifth milestone (M2.5) of the M2 D2 plan (#58). Builds the React 5-step wizard that drives the M2.4 Tauri commands — entirely self-contained under `mur-agent-gui/ui/src/onboarding/`. App.tsx integration is M2.6 (next).

## What's in

8 commits across the wizard module:

- **M2.5.1** `7746b44` — types.ts (Relationship / ProactiveTier / OnboardingStatus / OnboardingSubmit incl. explicit `re_init: boolean`) + api.ts (thin `invoke<T>` wrappers).
- **M2.5.2** `0419515` — Step1AgentName: text input, Enter advances, Skip exits the wizard.
- **M2.5.3** `4c9b623` — Step2VoicePick: Skip / Open Settings; Enable branch fires the parent's `onOpenVoiceSettings` and advances. Privacy hint reaffirms "audio never leaves this Mac".
- **M2.5.4** `af98756` — Step3Relationship: 4 cards with example greetings character-identical to `mur-core/src/cmd/agent_companion/init.rs::example_greeting` (en + zh-TW).
- **M2.5.5** `4919c32` — Step4FirstMemory: 200-char textarea + live counter; empty trims to `null`.
- **M2.5.6** `eeb9b44` — Step5ProactiveTiers: three cards (`warm_only` default, `warm_and_behavior`, `all`).
- **M2.5.7** `70b9d28` — OnboardingWizard shell: 480px modal overlay (`fixed inset-0`), 5-step navigation, owns the local state for every answer, routes Skip / Finish through `skipOnboarding` / `submitOnboarding`. `re_init: false` hard-coded (a future Edit entrypoint will need a separate shell).
- **a11y polish** `6646d08` — `<label>` for Step1, `role="radio"` + `aria-checked` on Step3/Step5 cards, Esc routes through Skip.

## Strict-TS

- No `any`, no `console.*`, no Tailwind colour classes (theme tokens via `var(--color-*)` to match the existing voice/ convention).
- Strings warm + consistent with the CLI prompts.
- `cd mur-agent-gui/ui && npm run build` — tsc -b + vite build clean (181 kB JS, 56 kB gzipped).

## What's deferred

- App.tsx integration (M2.6).
- Focus trap inside the modal (a11y MINOR).
- `aria-live` region for the Step4 counter (a11y NIT).
- "Edit" entrypoint that passes `re_init: true` (post-M2.8).

## Stack

- #58 plan → main
- #59 M2.1 → main
- #60 M2.2 → #59
- #61 M2.3 → #60
- #62 M2.4 → #61
- **THIS** M2.5 → #62
- M2.6 first-launch wiring (next)

## Test plan

- [ ] `cd mur-agent-gui/ui && npm run build`
- [ ] Manual: launch the GUI after M2.6 lands; walk through 5 steps end-to-end
- [ ] Manual: Esc at any step exits via the Skip path

🤖 Generated with [Claude Code](https://claude.com/claude-code)