### PR TITLE
feat(gui): D2 onboarding — M2.6 first-launch detection + App.tsx integration

### DIFF
--- a/mur-agent-gui/src-tauri/tests/onboarding_first_launch.rs
+++ b/mur-agent-gui/src-tauri/tests/onboarding_first_launch.rs
@@ -1,0 +1,99 @@
+//! M2.6.3 — first-launch detection ↔ skip integration test.
+//!
+//! Pins the contract App.tsx relies on: a freshly-seeded agent reports
+//! `completed_at = None` (wizard renders), and after
+//! `companion_onboarding_skip` it reports `completed_at = Some(_)`
+//! (wizard hides on next launch).
+//!
+//! Cargo runs each integration test file as its own crate, so the
+//! `MurHomeGuard` helper in `onboarding_commands.rs` isn't importable
+//! from here — the env-var dance is inlined verbatim to keep the same
+//! invariants (process-wide mutex around `MUR_HOME` mutation, cleanup
+//! on Drop).
+
+use std::path::Path;
+use std::sync::{LazyLock, Mutex, MutexGuard};
+use tempfile::TempDir;
+
+/// Process-global mutex around `MUR_HOME` mutation. The sister test
+/// file uses an identically-shaped guard; if both files happen to run
+/// in the same process they each get their own lock instance, which is
+/// fine because Cargo schedules integration tests in separate binaries.
+static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+struct MurHomeGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl MurHomeGuard {
+    fn set(path: &Path) -> Self {
+        let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: process-wide mutex held across the env mutation; cleared
+        // again in `Drop`.
+        unsafe { std::env::set_var("MUR_HOME", path) };
+        MurHomeGuard { _lock: lock }
+    }
+}
+
+impl Drop for MurHomeGuard {
+    fn drop(&mut self) {
+        // SAFETY: still holding `_lock` until our fields drop.
+        unsafe { std::env::remove_var("MUR_HOME") };
+    }
+}
+
+/// Resolve the shared P0a fixture across the same candidate paths
+/// `onboarding_commands.rs` uses, then rename the agent to `default`
+/// so it matches the App.tsx fallback identifier.
+fn fixture_default() -> String {
+    let candidates = [
+        "../../mur-common/tests/fixtures/profile_p0a_minimal.yaml",
+        "../mur-common/tests/fixtures/profile_p0a_minimal.yaml",
+        "mur-common/tests/fixtures/profile_p0a_minimal.yaml",
+    ];
+    let yaml = candidates
+        .iter()
+        .find_map(|p| std::fs::read_to_string(p).ok())
+        .unwrap_or_else(|| {
+            let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .ancestors()
+                .nth(2)
+                .unwrap()
+                .join("mur-common/tests/fixtures/profile_p0a_minimal.yaml");
+            std::fs::read_to_string(p).expect("fixture must exist")
+        });
+    yaml.replace("name: agent_test", "name: default")
+}
+
+#[tokio::test]
+async fn first_launch_status_pending_then_completed_after_skip() {
+    let tmp = TempDir::new().unwrap();
+    let _guard = MurHomeGuard::set(tmp.path());
+    let agent_dir = tmp.path().join("agents").join("default");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(agent_dir.join("profile.yaml"), fixture_default()).unwrap();
+
+    // Pre-skip: App.tsx must see this and render the wizard.
+    let s = mur_agent_gui_lib::commands::companion_onboarding_status_impl("default")
+        .await
+        .expect("status must succeed for a fresh agent");
+    assert!(
+        s.completed_at.is_none(),
+        "fresh agent: pending — completed_at should be None, got {:?}",
+        s.completed_at
+    );
+
+    // The user dismisses the wizard via the Skip path.
+    mur_agent_gui_lib::commands::companion_onboarding_skip_impl("default")
+        .await
+        .expect("skip must succeed");
+
+    // Post-skip: App.tsx must see this and hide the wizard on next launch.
+    let s = mur_agent_gui_lib::commands::companion_onboarding_status_impl("default")
+        .await
+        .expect("status after skip must succeed");
+    assert!(
+        s.completed_at.is_some(),
+        "after skip: complete — completed_at should be Some(_)"
+    );
+}

--- a/mur-agent-gui/ui/src/App.tsx
+++ b/mur-agent-gui/ui/src/App.tsx
@@ -8,7 +8,14 @@ import PermissionsTab from "./tabs/Permissions";
 import IdentityTab from "./tabs/Identity";
 import { VoiceTab } from "./voice/VoiceTab";
 import { PttButton } from "./voice/PttButton";
-import { setTheme as setThemeApi, getDefaultTheme, applyThemeColors } from "./lib/api";
+import { OnboardingWizard } from "./onboarding/OnboardingWizard";
+import {
+  setTheme as setThemeApi,
+  getDefaultTheme,
+  applyThemeColors,
+  getOnboardingStatus,
+  status as getStatus,
+} from "./lib/api";
 
 type TabId =
   | "status"
@@ -34,12 +41,52 @@ const TABS: { id: TabId; label: string }[] = [
 export default function App() {
   const [tab, setTab] = useState<TabId>("status");
 
+  // First-launch onboarding gate. `null` while the status round-trip
+  // is in flight (UI renders normally), `false` once we've confirmed
+  // the agent has never completed onboarding (wizard overlays), `true`
+  // once it has (or once a fetch error swallows the question — we
+  // never block the UI on a status hiccup). The agent name comes from
+  // the existing `status` command, which reads `MUR_GUI_AGENT_NAME`
+  // baked in by the bundle export pipeline; falling back to `default`
+  // keeps a hand-built dev shell working too.
+  const [onboarded, setOnboarded] = useState<boolean | null>(null);
+  const [agent, setAgent] = useState<string>("default");
+
   // Apply the bundle's baked-in default theme on mount, so the
   // window picks up the colors chosen at `mur agent export --theme`.
   useEffect(() => {
     getDefaultTheme()
       .then((t) => applyThemeColors(t.colors))
       .catch(() => {});
+  }, []);
+
+  // Resolve the bundled agent name and probe its onboarding state.
+  // Both calls are tolerant of failure: a missing agent or a transient
+  // IPC error treats the user as already-onboarded so the wizard
+  // never traps them on a broken install.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      let name = "default";
+      try {
+        const s = await getStatus();
+        if (s?.name) name = s.name;
+      } catch {
+        // Keep the fallback agent name; the onboarding probe below
+        // will also tolerate failure and let the UI through.
+      }
+      if (cancelled) return;
+      setAgent(name);
+      try {
+        const o = await getOnboardingStatus(name);
+        if (!cancelled) setOnboarded(!!o.completed_at);
+      } catch {
+        if (!cancelled) setOnboarded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // OS appearance subscriber for the "Match System" mode (spec § 7.3).
@@ -110,6 +157,13 @@ export default function App() {
           console.log("ptt transcript:", text);
         }}
       />
+      {onboarded === false && (
+        <OnboardingWizard
+          agent={agent}
+          onComplete={() => setOnboarded(true)}
+          onOpenVoiceSettings={() => setTab("voice")}
+        />
+      )}
     </div>
   );
 }

--- a/mur-agent-gui/ui/src/lib/api.ts
+++ b/mur-agent-gui/ui/src/lib/api.ts
@@ -2,6 +2,7 @@
 // a `#[tauri::command]` in src-tauri/src/commands.rs.
 
 import { invoke } from "@tauri-apps/api/core";
+import type { OnboardingStatus } from "../onboarding/types";
 
 // ─── Status ────────────────────────────────────────────────────────
 export interface StatusView {
@@ -16,6 +17,14 @@ export const status = () => invoke<StatusView>("status");
 export const startAgent = () => invoke<void>("start_agent");
 export const stopAgent = () => invoke<void>("stop_agent");
 export const restartAgent = () => invoke<void>("restart_agent");
+
+// ─── Onboarding ───────────────────────────────────────────────────
+// App.tsx's first-launch detection contract. The wizard itself uses the
+// richer helper module in `../onboarding/api.ts` (same Tauri command
+// under the hood) — keeping a separate shell-level helper here lets
+// App.tsx stay decoupled from the wizard package.
+export const getOnboardingStatus = (agent: string) =>
+  invoke<OnboardingStatus>("companion_onboarding_status", { agent });
 
 // ─── System Prompt ────────────────────────────────────────────────
 export const promptGet = () => invoke<string>("prompt_get");


### PR DESCRIPTION
## Summary

Sixth milestone (M2.6) of the M2 D2 plan (#58). Wires the M2.5 React wizard into the live App.tsx so the user actually sees it on first launch.

## What's in

**M2.6.1** `3a24eb5` — `lib/api.ts` re-exports `getOnboardingStatus` (App.tsx's contract; the wizard's own `onboarding/api.ts` continues to be the wizard-internal contract — same Tauri call under both).

**M2.6.2** `0bb0c90` — `App.tsx` integration:
- Resolves the bundled agent name dynamically via the existing `status()` Tauri command (which reads `MUR_GUI_AGENT_NAME` from `bootstrap.rs`); falls back to `"default"` only on error so hand-built dev shells still work.
- `useEffect` fires once on mount, swallows fetch errors as "already onboarded" so the UI never blocks.
- `<OnboardingWizard agent={agent} onComplete={...} onOpenVoiceSettings={() => setTab("voice")} />` overlays only when `onboarded === false`. Loading (`null`) and complete (`true`) skip render.
- `setTab("voice")` typechecks against the existing `TabId` union — no cast needed.

**M2.6.3** `aacefab` — Tauri-side integration test `onboarding_first_launch.rs`. Asserts pending → complete after skip. `MurHomeGuard` inlined (cargo treats each integration test file as its own crate binary, so the guard from M2.4's test file isn't reusable cross-file).

## Tests

- `cd mur-agent-gui/src-tauri && cargo test --test onboarding_first_launch` — 1/1 pass
- `cd mur-agent-gui/src-tauri && cargo test --test onboarding_commands` — still 8/8 (M2.4 regression)
- `cd mur-agent-gui/ui && npm run build` — tsc + vite clean

## Stack

- #58 plan → main
- #59 M2.1 → main
- #60 M2.2 → #59
- #61 M2.3 → #60
- #62 M2.4 → #61
- #63 M2.5 → #62
- **THIS** M2.6 → #63
- M2.7 character card (next)

## Test plan

- [ ] `cd mur-agent-gui/ui && npm run build`
- [ ] `cd mur-agent-gui/src-tauri && cargo test`
- [ ] Manual: launch the GUI; confirm wizard overlay appears; finish + Skip both hide it; subsequent launches don't re-show

🤖 Generated with [Claude Code](https://claude.com/claude-code)