### PR TITLE
feat(core): D2 onboarding — M2.7 character card schema + first_memory export helper

### DIFF
--- a/mur-core/src/character_card/first_memory.rs
+++ b/mur-core/src/character_card/first_memory.rs
@@ -1,0 +1,15 @@
+//! `FirstMemoryExt` — the payload of the `extensions.mur.first_memory`
+//! field in a `.murcard.yaml`. Carries the user-supplied first memory text
+//! plus the timestamp at which onboarding established it.
+//!
+//! This is the on-disk projection of `mur_common::agent::FirstMemory`. The
+//! two are intentionally separate types so the card schema can evolve
+//! independently of the live agent profile.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FirstMemoryExt {
+    pub text: String,
+    pub established_at: chrono::DateTime<chrono::Utc>,
+}

--- a/mur-core/src/character_card/mod.rs
+++ b/mur-core/src/character_card/mod.rs
@@ -1,0 +1,9 @@
+//! Character card schema (`.murcard.yaml`) — CCv3-compatible with a
+//! `extensions.mur` namespace for mur-specific additions.
+//!
+//! Spec: `docs/superpowers/specs/2026-04-30-mur-agent-d2-onboarding-design.md`
+//! §4.4.
+
+pub mod first_memory;
+pub mod schema;
+pub mod serde_round_trip;

--- a/mur-core/src/character_card/schema.rs
+++ b/mur-core/src/character_card/schema.rs
@@ -1,0 +1,45 @@
+//! `MurCard` — the minimal `.murcard.yaml` schema.
+//!
+//! The card is CCv3-compatible: any unknown top-level key is captured by
+//! the `ccv3_passthrough` map and re-emitted verbatim on serialize. mur's
+//! own additions live under the `extensions.mur` namespace so consumers
+//! that only understand stock CCv3 can ignore them safely.
+//!
+//! Phase M2.7 lands the schema + a single helper. The full
+//! `mur agent export --format card` pipeline is a D4 milestone.
+
+use serde::{Deserialize, Serialize};
+use serde_yaml_ng::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MurCard {
+    /// `"murcard_v1"`.
+    pub spec: String,
+    /// `"1.0"`.
+    pub spec_version: String,
+    pub data: CardData,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<Extensions>,
+    /// CCv3 passthrough: any unknown top-level key gets preserved verbatim.
+    #[serde(flatten)]
+    pub ccv3_passthrough: std::collections::BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CardData {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Extensions {
+    #[serde(default, rename = "mur", skip_serializing_if = "Option::is_none")]
+    pub mur: Option<MurExt>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MurExt {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub first_memory: Option<super::first_memory::FirstMemoryExt>,
+}

--- a/mur-core/src/character_card/serde_round_trip.rs
+++ b/mur-core/src/character_card/serde_round_trip.rs
@@ -1,0 +1,6 @@
+//! Round-trip helpers for `MurCard`.
+//!
+//! The CCv3 passthrough is implemented directly on `schema::MurCard` via
+//! `#[serde(flatten)] BTreeMap<String, serde_yaml_ng::Value>`, so this
+//! module is currently a placeholder. Future helpers (e.g. canonical
+//! field-order writers, schema-version migrators) will land here.

--- a/mur-core/src/cmd/agent_export.rs
+++ b/mur-core/src/cmd/agent_export.rs
@@ -1,0 +1,8 @@
+//! `mur agent export ...` subcommand modules.
+//!
+//! Phase D2/M2.7 only ships the `card` helper used by D4's
+//! `--format card` pipeline. The existing `--format gui` flow continues to
+//! live in the sibling `agent_export_gui.rs` flat file; consolidating the
+//! two is deliberately out of scope for M2.7.
+
+pub mod card;

--- a/mur-core/src/cmd/agent_export/card.rs
+++ b/mur-core/src/cmd/agent_export/card.rs
@@ -1,0 +1,51 @@
+//! `build_card_from_profile` — pure helper that projects an `AgentProfile`
+//! into a `MurCard`. The full `mur agent export --format card` pipeline is
+//! a D4 milestone; M2.7 only lands this helper so D4 doesn't have to
+//! retrofit first_memory plumbing later.
+//!
+//! Spec: `docs/superpowers/specs/2026-04-30-mur-agent-d2-onboarding-design.md`
+//! §4.4.
+
+use crate::character_card::{first_memory::FirstMemoryExt, schema::*};
+use mur_common::agent::AgentProfile;
+
+/// Build a `MurCard` from an agent profile, threading the companion
+/// onboarding's `first_memory` into `extensions.mur.first_memory` when
+/// present. The card's `data.name` prefers the onboarding display name and
+/// falls back to the agent's profile `name`.
+///
+/// `--format card` is a D4 milestone; M2.7 only ships this helper, so the
+/// `mur` binary sees no callers yet — hence `#[allow(dead_code)]`. The
+/// integration tests in `mur-core/tests/companion_first_memory_to_card.rs`
+/// exercise it via the library.
+#[allow(dead_code)]
+pub fn build_card_from_profile(p: &AgentProfile) -> MurCard {
+    let first_memory = p
+        .companion
+        .onboarding
+        .first_memory
+        .as_ref()
+        .map(|fm| FirstMemoryExt {
+            text: fm.text.clone(),
+            established_at: fm.established_at,
+        });
+    MurCard {
+        spec: "murcard_v1".into(),
+        spec_version: "1.0".into(),
+        data: CardData {
+            name: p
+                .companion
+                .onboarding
+                .agent_display_name
+                .clone()
+                .unwrap_or_else(|| p.name.clone()),
+            description: String::new(),
+        },
+        extensions: first_memory.map(|fm| Extensions {
+            mur: Some(MurExt {
+                first_memory: Some(fm),
+            }),
+        }),
+        ccv3_passthrough: Default::default(),
+    }
+}

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod agent;
 pub mod agent_companion;
+pub mod agent_export;
 pub(crate) mod agent_export_gui;
 pub(crate) mod agent_rekey;
 pub(crate) mod community_cmd;

--- a/mur-core/src/lib.rs
+++ b/mur-core/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod agent_admin;
 pub mod auth;
 pub mod capture;
+pub mod character_card;
 // `cmd` is shared with the binary (`main.rs`). When compiled as part of the
 // library, most CLI dispatch fns are unreachable — they're only invoked by
 // the binary's clap parser — so `dead_code` warnings here are expected.

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -4,6 +4,10 @@ use tracing_subscriber::EnvFilter;
 
 mod auth;
 mod capture;
+// `--format card` is a D4 milestone; M2.7 only ships the schema + helper
+// (callable from the library), so the bin target sees the types as unused.
+#[allow(dead_code)]
+mod character_card;
 mod cmd;
 mod community;
 mod context_api;

--- a/mur-core/tests/character_card_round_trip.rs
+++ b/mur-core/tests/character_card_round_trip.rs
@@ -1,0 +1,44 @@
+//! M2.7.1 — `MurCard` round-trips an unknown top-level CCv3 field plus the
+//! `extensions.mur.first_memory` block. Plan §M2.7.1 step 3.
+
+use mur_core::character_card::schema::*;
+
+#[test]
+fn round_trip_unknown_v3_field_preserved() {
+    let yaml = r#"
+spec: murcard_v1
+spec_version: "1.0"
+data:
+  name: Mochi
+extensions:
+  mur:
+    first_memory:
+      text: "Sunday in Taipei"
+      established_at: "2026-04-30T14:13:00Z"
+unknown_v3_field:
+  hello: world
+"#;
+    let c: MurCard = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(
+        c.extensions
+            .as_ref()
+            .unwrap()
+            .mur
+            .as_ref()
+            .unwrap()
+            .first_memory
+            .as_ref()
+            .unwrap()
+            .text,
+        "Sunday in Taipei",
+    );
+    let back = serde_yaml_ng::to_string(&c).unwrap();
+    assert!(
+        back.contains("unknown_v3_field"),
+        "passthrough lost the unknown top-level key:\n{back}"
+    );
+    assert!(
+        back.contains("hello: world"),
+        "passthrough lost the nested value:\n{back}"
+    );
+}

--- a/mur-core/tests/companion_first_memory_to_card.rs
+++ b/mur-core/tests/companion_first_memory_to_card.rs
@@ -1,0 +1,68 @@
+//! M2.7.2 — `build_card_from_profile` threads the companion's first memory
+//! into `MurCard.extensions.mur.first_memory` and falls back to the agent
+//! profile's `name` when no display name was supplied.
+//!
+//! `AgentProfile` does not derive `Default`, so we build profiles by
+//! parsing the shared P0a fixture (same pattern as
+//! `mur-core/tests/companion_init_5step.rs`).
+
+use mur_common::agent::{AgentProfile, FirstMemory, OnboardingState};
+
+/// Load the shared P0a fixture and rename it so each test starts from a
+/// known-parseable baseline. Mirrors the helper in
+/// `mur-core/tests/companion_init_5step.rs`.
+fn fixture_with_name(name: &str) -> AgentProfile {
+    let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("mur-common/tests/fixtures/profile_p0a_minimal.yaml");
+    let yaml = std::fs::read_to_string(&p).expect("fixture profile_p0a_minimal.yaml must exist");
+    let yaml = yaml.replace("name: agent_test", &format!("name: {name}"));
+    serde_yaml_ng::from_str(&yaml).expect("fixture must parse as AgentProfile")
+}
+
+#[test]
+fn build_card_includes_first_memory_when_present() {
+    let mut p = fixture_with_name("test");
+    p.companion.onboarding = OnboardingState {
+        completed_at: Some(chrono::Utc::now()),
+        version: 1,
+        agent_display_name: Some("Mochi".into()),
+        first_memory: Some(FirstMemory {
+            text: "Sunday in Taipei".into(),
+            established_at: chrono::Utc::now(),
+        }),
+    };
+
+    let card = mur_core::cmd::agent_export::card::build_card_from_profile(&p);
+    assert_eq!(card.data.name, "Mochi");
+    assert_eq!(card.data.description, "");
+    assert_eq!(card.spec, "murcard_v1");
+    assert_eq!(card.spec_version, "1.0");
+
+    let yaml = serde_yaml_ng::to_string(&card).unwrap();
+    assert!(
+        yaml.contains("Sunday in Taipei"),
+        "first_memory text missing from serialized card:\n{yaml}"
+    );
+    assert!(
+        yaml.contains("first_memory:"),
+        "first_memory key missing from serialized card:\n{yaml}"
+    );
+}
+
+#[test]
+fn build_card_omits_first_memory_when_absent() {
+    let p = fixture_with_name("blank");
+    // Default companion onboarding has no display name and no first memory.
+    let card = mur_core::cmd::agent_export::card::build_card_from_profile(&p);
+    // Falls back to profile.name when agent_display_name is None.
+    assert_eq!(card.data.name, "blank");
+    assert!(card.extensions.is_none());
+
+    let yaml = serde_yaml_ng::to_string(&card).unwrap();
+    assert!(
+        !yaml.contains("first_memory:"),
+        "first_memory must not appear when absent:\n{yaml}"
+    );
+}


### PR DESCRIPTION
## Summary

Seventh milestone (M2.7) of the M2 D2 plan (#58). Lands the minimal CCv3-compatible `MurCard` schema + `build_card_from_profile` helper so D4's `mur agent export --format card` can wire in without retrofitting. No CLI surface yet — D4 owns that.

## What's in

**M2.7.1** `c830705` — `mur-core/src/character_card/`:
- `schema.rs` — `MurCard { spec, spec_version, data, extensions, ccv3_passthrough }` with `#[serde(flatten)] BTreeMap<String, serde_yaml_ng::Value>` for round-trippable unknown V3 fields. `Extensions { mur }` carries the `extensions.mur` namespace; `MurExt { first_memory }` is the immediate slot.
- `first_memory.rs` — `FirstMemoryExt { text, established_at }`.
- `serde_round_trip.rs` — placeholder for future canonical-write helpers.
- `mur-core/src/lib.rs` + `main.rs` declare the module (with `#[allow(dead_code)]` on the bin until D4 wires the CLI).
- Round-trip test pins that an `unknown_v3_field` survives deserialize → serialize verbatim. **`serde_yaml_ng` flattened BTreeMap round-tripped cleanly** — no pivot to `serde_json::Value` needed.

**M2.7.2** `2595dc4` — `mur-core/src/cmd/agent_export/card.rs`:
- `build_card_from_profile(&AgentProfile) -> MurCard` — pulls `agent_display_name` (fallback to `profile.name`) into `data.name`, threads `companion.onboarding.first_memory` into `extensions.mur.first_memory`. Empty/None first_memory means no `extensions` block emitted.
- New `agent_export.rs` module sibling to the existing flat `agent_export_gui.rs` (left untouched per scope). Mirrors the `agent_companion.rs` + `agent_companion/` nested pattern already used in `cmd/`.
- Two tests: `build_card_includes_first_memory_when_present` + `build_card_omits_first_memory_when_absent`. Used the same fixture-load pattern as M2.3.1 since `AgentProfile` doesn't derive `Default`.

## Tests

- `cargo test -p mur-core --test character_card_round_trip` — 1/1 pass
- `cargo test -p mur-core --test companion_first_memory_to_card` — 2/2 pass
- `cargo test --workspace` green
- `cargo clippy --workspace -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Stack

- #58 plan → main
- #59 M2.1 → main
- #60 M2.2 → #59
- #61 M2.3 → #60
- #62 M2.4 → #61
- #63 M2.5 → #62
- #64 M2.6 → #63
- **THIS** M2.7 → #64
- M2.8 E2E + cookbook (next, last in stack)

## Test plan

- [ ] `cargo test --workspace`
- [ ] Confirm `MurCard` round-trip preserves arbitrary V3 passthrough fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)