### PR TITLE
feat: D2 onboarding — M2.8 E2E acceptance script + cookbook

### DIFF
--- a/docs/cookbook/first-memory-onboarding.md
+++ b/docs/cookbook/first-memory-onboarding.md
@@ -1,0 +1,39 @@
+# First-Memory Onboarding (D2)
+
+The 5-step wizard runs on first launch of a `mur agent export --format gui` bundle (and via `mur agent companion init <name>` from the CLI).
+
+## Steps
+
+1. **Name your agent** — display name only; the slug from `mur agent create` stays the same.
+2. **Voice** — opt-in, default *Skip — enable later*. Voice setup in Settings → Voice triggers a one-time ~190 MB whisper download.
+3. **Relationship** — Friend / Coach / Accountability buddy / Mentor.
+4. **First memory** — one fact the agent should remember. Surfaced on day-3+ `morning_greeting` templates.
+5. **Behavior** — three-layer toggle:
+   - *Warm voice only* (default, recommended)
+   - *Warm + behavior collection*
+   - *All including proactive check-ins*
+
+## Where it's stored
+
+- `~/.mur/agents/<name>/profile.yaml` — `companion.onboarding.{completed_at,agent_display_name,first_memory}`, plus `companion.{enabled,rhythm.enabled,proactive.enabled}` for the three-layer toggle.
+- `~/.mur/agents/<name>/companion/relationship.json` — duplicates `first_memory.text` (for runtime + character-card export).
+
+## Re-running
+
+```bash
+mur agent companion init <name> --re-init
+```
+
+## Character card
+
+`mur agent export --format card` (D4) emits `extensions.mur.first_memory.{text, established_at}` round-trippable per CCv3 passthrough.
+
+## Acceptance gates
+
+```
+scripts/e2e/v1-d2-onboarding.sh
+```
+
+- Wizard ≤ 120 s
+- `mur agent companion preview <name> --situation morning_greeting --no-llm` output references the first_memory string verbatim
+- 72-hour MockClock test produces a proactive message containing the first_memory

--- a/scripts/e2e/run-all.sh
+++ b/scripts/e2e/run-all.sh
@@ -56,6 +56,9 @@ echo "==> Running companion Phase 1.1 E2E smoke..."
 echo "==> Running v1 D1 voice E2E smoke..."
 "$REPO_ROOT/scripts/e2e/v1-d1-voice.sh"
 
+echo "==> Running D2 onboarding E2E smoke..."
+"$REPO_ROOT/scripts/e2e/v1-d2-onboarding.sh"
+
 if [[ "$RUN_COVERAGE" == "1" ]]; then
   if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
     echo "cargo-llvm-cov not installed (cargo install cargo-llvm-cov)" >&2

--- a/scripts/e2e/v1-d2-onboarding.sh
+++ b/scripts/e2e/v1-d2-onboarding.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# scripts/e2e/v1-d2-onboarding.sh — D2 onboarding wizard E2E acceptance.
+#
+# Acceptance gates (roadmap §4.2):
+#   1. Wizard completes in <= 120 seconds (--answers path; non-interactive).
+#   2. `companion preview <name> --situation morning_greeting --no-llm`
+#      output contains the first_memory text.
+#   3. MockClock-driven runtime test advances 72 h and produces a
+#      proactive message body containing the first_memory string
+#      (the cargo test in onboarding_morning_greeting_72h.rs).
+#
+# The script uses a tmpfs MUR_HOME so it never pollutes ~/.mur, and
+# redirects MUR_AGENT_BIN_DIR so `mur agent create` doesn't drop a
+# symlink under ~/.local/bin.
+#
+# Usage:
+#   scripts/e2e/v1-d2-onboarding.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# ── Hermetic temp HOME ───────────────────────────────────────────────────────
+
+TMPHOME="$(mktemp -d -t mur-d2-onboarding-e2e.XXXXXX)"
+export MUR_HOME="$TMPHOME"
+export MUR_AGENT_BIN_DIR="$TMPHOME/bin"
+mkdir -p "$MUR_AGENT_BIN_DIR"
+trap 'rm -rf "$TMPHOME"' EXIT
+
+# ── 1/3 build ────────────────────────────────────────────────────────────────
+
+echo "==> 1/3 build mur (release)"
+cargo build --release --bin mur --quiet
+
+MUR="$REPO_ROOT/target/release/mur"
+[[ -x "$MUR" ]] || { echo "expected binary at $MUR" >&2; exit 1; }
+
+# ── 2/3 create agent + run wizard via --answers ──────────────────────────────
+
+echo "==> 2/3 create agent + run wizard via --answers"
+ANSWERS="$TMPHOME/onboarding-answers.yaml"
+cat >"$ANSWERS" <<'YAML'
+locale: en-US
+name_for_user: David
+agent_display_name: Mochi
+relationship: friend
+formality: casual
+extra_instructions: ""
+first_memory: "Sunday in Taipei"
+proactive_tier: warm_only
+YAML
+
+t0=$(date +%s)
+"$MUR" agent create d2-test --provider stub
+"$MUR" agent companion init d2-test --answers "$ANSWERS"
+t1=$(date +%s)
+elapsed=$((t1 - t0))
+echo "    wizard --answers elapsed ${elapsed}s"
+[[ $elapsed -le 120 ]] || { echo "FAIL: wizard took ${elapsed}s (> 120s)" >&2; exit 1; }
+
+# ── 3/3 preview morning_greeting ─────────────────────────────────────────────
+
+echo "==> 3/3 preview morning_greeting (--no-llm)"
+out=$("$MUR" agent companion preview d2-test --situation morning_greeting --no-llm)
+echo "$out" | grep -q "Sunday in Taipei" || {
+  echo "FAIL: preview did not include first_memory; got:" >&2
+  echo "$out" >&2
+  exit 1
+}
+
+# ── 72h MockClock acceptance (cargo test) ────────────────────────────────────
+
+echo "==> 72h MockClock acceptance (cargo test)"
+cargo test -p mur-agent-runtime --test onboarding_morning_greeting_72h --release --quiet
+
+echo "✅ D2 onboarding E2E passed"


### PR DESCRIPTION
## Summary

Final milestone (M2.8) of the M2 D2 plan (#58). End-to-end acceptance gate + cookbook.

## What's in

**M2.8.1** `744bb24` — `scripts/e2e/v1-d2-onboarding.sh`. Hermetic (`MUR_HOME` + `MUR_AGENT_BIN_DIR` to tmpfs) acceptance script enforcing the three roadmap §4.2 gates:

1. `mur agent companion init <name> --answers ...` completes ≤ 120s (measured: 6s on a warm cache).
2. `mur agent companion preview <name> --situation morning_greeting --no-llm` references the first_memory string verbatim.
3. The 72-hour MockClock test (`mur-agent-runtime/tests/onboarding_morning_greeting_72h.rs`, landed in M2.2.3) passes in release mode.

Final line: `✅ D2 onboarding E2E passed`.

**M2.8.2** `e4b9523` — `scripts/e2e/run-all.sh` invokes `v1-d2-onboarding.sh` after the existing companion-phase11.sh step.

**M2.8.3** `aebeb8d` — `docs/cookbook/first-memory-onboarding.md`: 5-step walkthrough, storage paths, `--re-init` note, forward-reference to D4's `--format card` export, acceptance gate listing.

## Stack

- #58 plan → main
- #59 M2.1 → main
- #60 M2.2 → #59
- #61 M2.3 → #60
- #62 M2.4 → #61
- #63 M2.5 → #62
- #64 M2.6 → #63
- #65 M2.7 → #64
- **THIS** M2.8 → #65 — final M2 milestone

## Test plan

- [ ] `scripts/e2e/v1-d2-onboarding.sh`
- [ ] `scripts/e2e/run-all.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)