### PR TITLE
fix(runtime): D2 onboarding — M2.2.4 outbox uses template prompt_seed

### DIFF
--- a/mur-agent-runtime/src/companion/mod.rs
+++ b/mur-agent-runtime/src/companion/mod.rs
@@ -14,6 +14,7 @@ pub mod situations;
 pub mod telemetry;
 pub mod voice;
 
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -25,11 +26,13 @@ use crate::companion::{
     clock::Clock,
     notifier::StdoutNotifier,
     outbox::{Outbox, OutboxConfig},
-    picker::{BanditState, Picker},
+    picker::{BanditState, Picker, TemplateId},
     voice::{VoiceInput, compose_with_overrides},
 };
 use crate::durable::ledger::Ledger;
 use crate::llm::LlmClient;
+use mur_common::companion::Situation;
+use mur_common::companion::content_seed::{SituationFile, all_seeds, parse};
 
 // ──────────────────────────────────────────────────────────────────────────────
 // relationship.json — runtime-side parser
@@ -59,6 +62,71 @@ struct FirstMemoryRef {
     #[allow(dead_code)]
     #[serde(default)]
     established_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Content-pool seed loader (M2.2.4)
+// ──────────────────────────────────────────────────────────────────────────────
+//
+// Reads `<agent_dir>/companion/content/<situation>.<locale>.yaml` for every
+// supported situation, falling back to the embedded seeds when a disk file is
+// missing or unreadable. Returns a flat `template_id → prompt_seed` map that
+// the outbox uses (via `OutboxConfig.prompt_seeds`) to look up the picked
+// template's seed before LLM generation.
+//
+// Best-effort by design: a missing/malformed YAML is logged at warn level and
+// the situation is skipped; the outbox then falls back to the legacy hardcoded
+// "Compose one short message…" line for templates whose seed is unknown.
+
+fn load_prompt_seeds(agent_home: &Path, locale: &str) -> BTreeMap<TemplateId, String> {
+    let mut out: BTreeMap<TemplateId, String> = BTreeMap::new();
+    let situations: [(Situation, &str); 4] = [
+        (Situation::MorningGreeting, "morning_greeting"),
+        (Situation::GentleCheckIn, "gentle_check_in"),
+        (Situation::ShareQuote, "share_quote"),
+        (Situation::ShareLink, "share_link"),
+    ];
+
+    for (situation, slug) in situations {
+        // Try disk first.
+        let disk_path = agent_home
+            .join("companion/content")
+            .join(format!("{slug}.{locale}.yaml"));
+        let parsed: Option<SituationFile> = match std::fs::read_to_string(&disk_path) {
+            Ok(body) => match serde_yaml_ng::from_str::<SituationFile>(&body) {
+                Ok(p) => Some(p),
+                Err(e) => {
+                    tracing::warn!(
+                        "companion: failed to parse content seed {}: {e} — falling back to embedded",
+                        disk_path.display()
+                    );
+                    None
+                }
+            },
+            Err(_) => None,
+        };
+
+        // Fall through to embedded if disk missing or malformed.
+        let parsed = parsed.or_else(|| {
+            for (sit, loc, yaml) in all_seeds() {
+                if sit == situation
+                    && loc == locale
+                    && let Ok(p) = parse(yaml)
+                {
+                    return Some(p);
+                }
+            }
+            None
+        });
+
+        if let Some(file) = parsed {
+            for tpl in file.templates {
+                out.insert(tpl.id, tpl.prompt_seed);
+            }
+        }
+    }
+
+    out
 }
 
 /// Best-effort load of `<agent_dir>/companion/relationship.json`.
@@ -183,11 +251,23 @@ impl Companion {
         let picker = Picker::from_state(BanditState::default());
 
         // 5. OutboxConfig.
+        // M2.2.4 — load the content-pool seeds so the outbox can substitute
+        // `prompt_seed` placeholders into the LLM user prompt. The first_memory
+        // / placeholder context here is OWNED (cloned) because Outbox outlives
+        // the function-scoped `rel` we used for voice composition above.
+        let prompt_seeds = load_prompt_seeds(agent_home, &profile.companion.locale);
+        let first_memory_owned: Option<String> = first_memory.map(|s| s.to_string());
         let config = OutboxConfig {
             llm,
             notifier,
             voice_md,
             locale: profile.companion.locale.clone(),
+            prompt_seeds,
+            name_for_user: name_for_user.to_string(),
+            first_memory: first_memory_owned,
+            formality: formality_str,
+            extra_instructions: extra_instructions.to_string(),
+            relationship: profile.companion.relationship.clone(),
         };
 
         // 6. Outbox wrapped in Mutex for interior mutability across the tick task.

--- a/mur-agent-runtime/src/companion/outbox.rs
+++ b/mur-agent-runtime/src/companion/outbox.rs
@@ -169,6 +169,31 @@ pub struct OutboxConfig {
     /// Taken from `CompanionConfig.locale`; `ProactiveConfig` does not carry
     /// a locale field in the current schema.
     pub locale: String,
+    /// Map of `template_id → prompt_seed` loaded from the agent's content
+    /// pool (`<agent_dir>/companion/content/<situation>.<locale>.yaml`,
+    /// with embedded fallback). Populated at startup by `Companion::new`.
+    ///
+    /// M2.2.4: when the picker selects a `template_id` whose entry exists
+    /// here with a non-empty seed, the outbox uses that seed (after
+    /// placeholder substitution) as the LLM user prompt; otherwise it
+    /// falls back to the legacy `"Compose one short message…"` line.
+    pub prompt_seeds: BTreeMap<TemplateId, String>,
+    /// `name_for_user` — used to substitute `{{NAME_FOR_USER}}` in `prompt_seed`.
+    /// Comes from `profile.companion.voice_overrides.name_for_user`.
+    pub name_for_user: String,
+    /// First-memory text loaded from `relationship.json` — used to substitute
+    /// `{{FIRST_MEMORY}}` / `{{FIRST_MEMORY_PARAGRAPH}}` in `prompt_seed`.
+    /// `None` (or empty) collapses both placeholders to the empty string.
+    pub first_memory: Option<String>,
+    /// `formality` (lowercased Debug rendering, e.g. `"casual"`) — used to
+    /// substitute `{{FORMALITY}}`.
+    pub formality: String,
+    /// `extra_instructions` — used to substitute `{{EXTRA_INSTRUCTIONS}}`.
+    pub extra_instructions: String,
+    /// Companion `relationship` — used to construct the `VoiceInput` for
+    /// substitution. Not directly templated, but `voice::apply_placeholders`
+    /// requires it.
+    pub relationship: mur_common::companion::Relationship,
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -197,6 +222,16 @@ pub struct Outbox<R: RngCore + Send = StdRng> {
     /// Comes from `CompanionConfig.locale` (or caller's choice); ProactiveConfig
     /// does not carry a locale field in the current schema.
     pub locale: String,
+
+    // ── prompt_seed substitution context (M2.2.4) ──
+    /// Map of `template_id → prompt_seed`. See [`OutboxConfig::prompt_seeds`].
+    pub prompt_seeds: BTreeMap<TemplateId, String>,
+    /// Owned placeholder context — see the corresponding `OutboxConfig` fields.
+    pub name_for_user: String,
+    pub first_memory: Option<String>,
+    pub formality: String,
+    pub extra_instructions: String,
+    pub relationship: mur_common::companion::Relationship,
 
     // ── rhythm state ──
     /// Local time of the last successfully sent message (updated at step 12).
@@ -236,6 +271,12 @@ impl Outbox<StdRng> {
             notifier: config.notifier,
             voice_md: config.voice_md,
             locale: config.locale,
+            prompt_seeds: config.prompt_seeds,
+            name_for_user: config.name_for_user,
+            first_memory: config.first_memory,
+            formality: config.formality,
+            extra_instructions: config.extra_instructions,
+            relationship: config.relationship,
             last_send_at: None,
             sent_today: 0,
             morning_sent_today: None,
@@ -264,6 +305,12 @@ impl<R: RngCore + Send> Outbox<R> {
             notifier: config.notifier,
             voice_md: config.voice_md,
             locale: config.locale,
+            prompt_seeds: config.prompt_seeds,
+            name_for_user: config.name_for_user,
+            first_memory: config.first_memory,
+            formality: config.formality,
+            extra_instructions: config.extra_instructions,
+            relationship: config.relationship,
             last_send_at: None,
             sent_today: 0,
             morning_sent_today: None,
@@ -327,8 +374,9 @@ impl<R: RngCore + Send> Outbox<R> {
                     // Re-attempt generation.
                     let situation_str = format!("{:?}", paused.situation);
                     let locale = paused.locale_at_schedule.clone();
+                    let template_id = paused.template_id.clone();
                     match self
-                        .generate_with_lint(&id, &situation_str, &locale, now_utc)
+                        .generate_with_lint(&id, &template_id, &situation_str, &locale, now_utc)
                         .await
                     {
                         GenerateResult::Ok(body) => {
@@ -578,7 +626,7 @@ impl<R: RngCore + Send> Outbox<R> {
         let locale = self.locale.clone();
 
         let body = match self
-            .generate_with_lint(&id, &situation_str, &locale, now_utc)
+            .generate_with_lint(&id, &template_id, &situation_str, &locale, now_utc)
             .await
         {
             GenerateResult::Ok(text) => text,
@@ -797,6 +845,32 @@ impl<R: RngCore + Send> Outbox<R> {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
+    // Internal helper: prompt_seed placeholder substitution (M2.2.4)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Substitute companion placeholders into a `prompt_seed` string.
+    ///
+    /// Reuses [`crate::companion::voice::apply_placeholders`] so the
+    /// system-prompt path (voice template) and the user-prompt path
+    /// (this method, M2.2.4) never diverge in their substitution rules:
+    /// template-defined tokens (`{{LOCALE}}`, `{{FIRST_MEMORY}}`,
+    /// `{{FIRST_MEMORY_PARAGRAPH}}`) expand first, user-supplied tokens
+    /// (`{{NAME_FOR_USER}}`, `{{FORMALITY}}`, `{{EXTRA_INSTRUCTIONS}}`)
+    /// expand last (so they can't inject re-substituted `{{...}}` tokens).
+    fn substitute_prompt_seed(&self, seed: &str) -> String {
+        use crate::companion::voice::{VoiceInput, apply_placeholders};
+        let input = VoiceInput {
+            relationship: self.relationship.clone(),
+            locale: &self.locale,
+            name_for_user: &self.name_for_user,
+            first_memory: self.first_memory.as_deref(),
+            formality: &self.formality,
+            extra_instructions: &self.extra_instructions,
+        };
+        apply_placeholders(seed, &self.locale, &input)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // Internal helper: generate + lint with one regenerate
     // ─────────────────────────────────────────────────────────────────────────
 
@@ -806,24 +880,37 @@ impl<R: RngCore + Send> Outbox<R> {
     /// retries **once** with a `"\n[regenerate]"` suffix on the user prompt so
     /// the `StubLlm` can match a distinct scenario.  On second failure, appends
     /// both a second `MessageGenerated` and `MessageDropped { linter_persistent }`.
+    ///
+    /// **M2.2.4** — when the picked `template_id` has a non-empty
+    /// `prompt_seed` registered in `self.prompt_seeds`, that seed (with
+    /// placeholder substitution) is used as the user prompt instead of the
+    /// legacy `"Compose one short message…"` line. Empty / missing seeds
+    /// fall back to the legacy prompt so existing behaviour doesn't regress.
     async fn generate_with_lint(
         &mut self,
         id: &str,
+        template_id: &TemplateId,
         situation_str: &str,
         locale: &str,
         _now_utc: DateTime<Utc>,
     ) -> GenerateResult {
+        // Resolve the picked template's prompt_seed (if any) and substitute
+        // placeholders ONCE. Both regen attempts share the same base prompt;
+        // only the trailing `[regenerate]` marker differs.
+        let base_prompt: String = match self.prompt_seeds.get(template_id) {
+            Some(seed) if !seed.trim().is_empty() => self.substitute_prompt_seed(seed),
+            _ => format!(
+                "Compose one short message for situation: {situation_str}, locale: {locale}"
+            ),
+        };
+
         for regen_count in 0u32..=1 {
-            // Build the user prompt; append "[regenerate]" on the retry so
-            // StubLlm can match a distinct scenario (documented contract).
+            // Append "[regenerate]" on the retry so StubLlm can match a
+            // distinct scenario (documented contract).
             let user_prompt = if regen_count == 0 {
-                format!(
-                    "Compose one short message for situation: {situation_str}, locale: {locale}"
-                )
+                base_prompt.clone()
             } else {
-                format!(
-                    "Compose one short message for situation: {situation_str}, locale: {locale}\n[regenerate]"
-                )
+                format!("{base_prompt}\n[regenerate]")
             };
 
             let req = LlmRequest {
@@ -1127,6 +1214,12 @@ mod tests {
                 notifier,
                 voice_md: "You are a warm companion.".to_string(),
                 locale: "zh-TW".to_string(),
+                prompt_seeds: BTreeMap::new(),
+                name_for_user: String::new(),
+                first_memory: None,
+                formality: String::new(),
+                extra_instructions: String::new(),
+                relationship: mur_common::companion::Relationship::Friend,
             },
         )
     }
@@ -1578,6 +1671,12 @@ mod tests {
                 notifier: notifier.clone(),
                 voice_md: "You are a warm companion.".to_string(),
                 locale: "zh-TW".to_string(),
+                prompt_seeds: BTreeMap::new(),
+                name_for_user: String::new(),
+                first_memory: None,
+                formality: String::new(),
+                extra_instructions: String::new(),
+                relationship: mur_common::companion::Relationship::Friend,
             },
         );
 
@@ -1687,6 +1786,12 @@ mod tests {
                 notifier: notifier.clone(),
                 voice_md: "You are a warm companion.".to_string(),
                 locale: "zh-TW".to_string(),
+                prompt_seeds: BTreeMap::new(),
+                name_for_user: String::new(),
+                first_memory: None,
+                formality: String::new(),
+                extra_instructions: String::new(),
+                relationship: mur_common::companion::Relationship::Friend,
             },
         );
 
@@ -1795,6 +1900,12 @@ mod tests {
                 notifier: notifier.clone(),
                 voice_md: "You are a warm companion.".to_string(),
                 locale: "zh-TW".to_string(),
+                prompt_seeds: BTreeMap::new(),
+                name_for_user: String::new(),
+                first_memory: None,
+                formality: String::new(),
+                extra_instructions: String::new(),
+                relationship: mur_common::companion::Relationship::Friend,
             },
         );
 

--- a/mur-agent-runtime/src/companion/voice.rs
+++ b/mur-agent-runtime/src/companion/voice.rs
@@ -75,7 +75,26 @@ fn read_template_file(p: &Path) -> Option<String> {
     Some(body)
 }
 
-fn apply_placeholders(tpl: &str, locale_used: &str, input: &VoiceInput<'_>) -> String {
+/// Apply the companion's placeholder substitution rules to an arbitrary
+/// template string.
+///
+/// `locale_used` fills `{{LOCALE}}`. The other placeholders are taken from
+/// `input`. Substitution order is fixed:
+///
+/// 1. **Template-defined first** (`{{LOCALE}}`, `{{FIRST_MEMORY}}`,
+///    `{{FIRST_MEMORY_PARAGRAPH}}`) — this is content the runtime owns.
+/// 2. **User-supplied last** (`{{NAME_FOR_USER}}`, `{{FORMALITY}}`,
+///    `{{EXTRA_INSTRUCTIONS}}`) — free-form onboarding input. Going last
+///    means any `{{...}}` they happen to contain stays literal and can't
+///    inject new tokens for a re-substitution pass.
+///
+/// `Some("")` collapses identically to `None` for `first_memory` (an empty
+/// memory is semantically not-set).
+///
+/// Reused by both the system-prompt path (voice template composition) and
+/// the user-prompt path (M2.2.4: outbox `prompt_seed` substitution) so the
+/// two surfaces never diverge.
+pub(crate) fn apply_placeholders(tpl: &str, locale_used: &str, input: &VoiceInput<'_>) -> String {
     // Substitute template-defined placeholders (first_memory, locale) FIRST so
     // that user-supplied values (name_for_user, formality, extra_instructions)
     // — which are free-form input from the onboarding wizard — cannot inject

--- a/mur-agent-runtime/tests/companion_integration_common.rs
+++ b/mur-agent-runtime/tests/companion_integration_common.rs
@@ -348,6 +348,14 @@ impl HarnessBuilder {
             notifier: notifier.clone() as Arc<dyn Notifier>,
             voice_md: self.voice_md,
             locale: self.locale,
+            // M2.2.4 — these tests pre-date prompt_seed substitution; an
+            // empty seed map keeps them on the legacy hardcoded prompt path.
+            prompt_seeds: BTreeMap::new(),
+            name_for_user: String::new(),
+            first_memory: None,
+            formality: String::new(),
+            extra_instructions: String::new(),
+            relationship: mur_common::companion::Relationship::Friend,
         };
 
         let clock_for_outbox: Arc<dyn Clock> = clock.clone();

--- a/mur-agent-runtime/tests/onboarding_morning_greeting_72h.rs
+++ b/mur-agent-runtime/tests/onboarding_morning_greeting_72h.rs
@@ -34,15 +34,23 @@
 //! "Companion startup loads first_memory and threads it into voice
 //! composition."
 
-use std::sync::Arc;
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
 
-use chrono::{Duration, Utc};
+use async_trait::async_trait;
+use chrono::{Duration, NaiveDate, NaiveTime, TimeZone, Utc};
 use mur_agent_runtime::companion::{
     Companion,
     clock::{Clock, MockClock},
+    notifier::{CompanionMessage, Notifier, NotifyOutcome},
+    outbox::{Outbox, OutboxConfig, TickOutcome},
+    picker::{BanditState, Picker, TemplateState},
 };
-use mur_agent_runtime::llm::LlmClient;
+use mur_agent_runtime::durable::ledger::Ledger;
 use mur_agent_runtime::llm::stub::StubLlm;
+use mur_agent_runtime::llm::{LlmClient, LlmError, LlmRequest, LlmResponse};
+use mur_common::agent::ProactiveConfig;
+use mur_common::companion::Situation;
 use serde_json::json;
 use tempfile::TempDir;
 
@@ -172,6 +180,240 @@ async fn companion_threads_first_memory_from_relationship_json_into_voice_md() {
     assert!(
         voice_md.contains("David"),
         "voice_md must contain name_for_user; got: {voice_md}"
+    );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// M2.2.4 — outbox uses picked template's prompt_seed (with first_memory)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Capturing LLM stub: records the user-prompt text it receives, returns a
+/// fixed clean response. Exists only in this test module so the production
+/// `StubLlm` doesn't grow a capture-API surface for one assertion.
+struct CapturingLlm {
+    captured: Mutex<Vec<String>>,
+    response: String,
+}
+
+impl CapturingLlm {
+    fn new(response: impl Into<String>) -> Self {
+        Self {
+            captured: Mutex::new(Vec::new()),
+            response: response.into(),
+        }
+    }
+    fn captured_user_prompts(&self) -> Vec<String> {
+        self.captured.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl LlmClient for CapturingLlm {
+    async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        // Capture the user message content (the prompt the outbox built from
+        // prompt_seed). We deliberately DO NOT capture the system message
+        // (voice_md) — the assertion is about user-prompt construction.
+        if let Some(user) = req.messages.iter().find(|m| m.role == "user") {
+            self.captured.lock().unwrap().push(user.content.clone());
+        }
+        Ok(LlmResponse {
+            text: self.response.clone(),
+            input_tokens: 0,
+            output_tokens: 0,
+            model: "capturing-stub".to_string(),
+        })
+    }
+    fn model_name(&self) -> &str {
+        "capturing-stub"
+    }
+}
+
+/// Notifier that always reports `Delivered` without writing to disk. Avoids
+/// having the inbox file path leak into the test fixture; the test only
+/// cares about the LLM-side prompt construction.
+struct NoopNotifier;
+
+#[async_trait]
+impl Notifier for NoopNotifier {
+    fn name(&self) -> &'static str {
+        "noop-test"
+    }
+    async fn send(&self, _msg: &CompanionMessage) -> anyhow::Result<NotifyOutcome> {
+        Ok(NotifyOutcome::Delivered)
+    }
+}
+
+/// Build a UTC `DateTime` that converts to the given local-time tuple.
+fn local_as_utc(y: i32, mo: u32, d: u32, h: u32, mi: u32, s: u32) -> chrono::DateTime<Utc> {
+    let naive = NaiveDate::from_ymd_opt(y, mo, d)
+        .unwrap()
+        .and_time(NaiveTime::from_hms_opt(h, mi, s).unwrap());
+    chrono::Local
+        .from_local_datetime(&naive)
+        .single()
+        .expect("ambiguous local time in test")
+        .with_timezone(&Utc)
+}
+
+/// M2.2.4 — previously the outbox built a hardcoded user prompt
+/// (`"Compose one short message for situation: …"`) and ignored the picked
+/// template's `prompt_seed` entirely. This test pins that the picked
+/// `morning_first_memory_*` template's `prompt_seed` is substituted with the
+/// `first_memory` text and reaches the LLM.
+///
+/// The `CapturingLlm` records its inputs, so we can assert that
+/// `{{FIRST_MEMORY}}` was expanded BEFORE the LLM call (i.e. it isn't a
+/// model hallucination). The picker is seeded with ONLY the day-3+
+/// first-memory templates so the picker's WeightedIndex is forced to one of
+/// them, regardless of RNG seed.
+#[tokio::test]
+async fn morning_greeting_prompt_seed_substitutes_first_memory() {
+    // ── Arrange ──────────────────────────────────────────────────────────
+    let tmp = TempDir::new().unwrap();
+    let agent_home = tmp.path();
+    let companion_dir = agent_home.join("companion");
+    std::fs::create_dir_all(&companion_dir).unwrap();
+
+    // 1. Write relationship.json so the runtime's first_memory loader picks
+    //    up "Sunday in Taipei". Companion::new is NOT used here, but we
+    //    keep the on-disk shape consistent for fidelity.
+    let onboarded_at = Utc::now() - Duration::hours(72);
+    let rel_json = json!({
+        "version": 1,
+        "name_for_user": "David",
+        "relationship": "friend",
+        "locale": "en-US",
+        "formality": "casual",
+        "extra_instructions": "",
+        "onboarded_at": onboarded_at.to_rfc3339(),
+        "first_memory": {
+            "text": "Sunday in Taipei",
+            "established_at": onboarded_at.to_rfc3339(),
+        },
+    });
+    std::fs::write(
+        companion_dir.join("relationship.json"),
+        serde_json::to_vec_pretty(&rel_json).unwrap(),
+    )
+    .unwrap();
+
+    // 2. Build the prompt_seeds map directly from the bundled template
+    //    text — this is what `Companion::new` would also produce after
+    //    M2.2.4's `load_prompt_seeds` runs.
+    let mut prompt_seeds: BTreeMap<String, String> = BTreeMap::new();
+    prompt_seeds.insert(
+        "morning_first_memory_warm_en_001".to_string(),
+        // Verbatim from morning_greeting.en-US.yaml.
+        "Good morning {{NAME_FOR_USER}} — still thinking about {{FIRST_MEMORY}}.\nHow's that shaping your day? One sentence, warm tone.\n".to_string(),
+    );
+
+    // 3. Bandit-state seeded with ONE morning_greeting template so the
+    //    WeightedIndex collapses to that single entry. cooldown_days=0 so
+    //    we don't fight day-3 hold-back logic in this test.
+    let mut bandit = BanditState::default();
+    bandit.templates.insert(
+        "morning_first_memory_warm_en_001".to_string(),
+        TemplateState {
+            id: "morning_first_memory_warm_en_001".to_string(),
+            situation: Situation::MorningGreeting,
+            weight: 1.0,
+            last_used_at: None,
+            pos_count: 0,
+            neg_count: 0,
+            dismiss_count: 0,
+            cooldown_days: 0,
+        },
+    );
+
+    // 4. Construct the outbox directly. We pick 7:00 local on a weekday so
+    //    `situations::pick_for_hour` weights MorningGreeting non-zero, and
+    //    the proactive gate is wide open (no quiet hours, daily_cap=3).
+    let base_utc = local_as_utc(2026, 4, 29, 7, 0, 0);
+    let clock = Arc::new(MockClock::at(base_utc));
+    let ledger = Ledger::open(&companion_dir.join("outbox-ledger")).unwrap();
+    // Force MorningGreeting (idx 0). With seed=0 and a single eligible
+    // morning template, the WeightedIndex always returns the only entry —
+    // so the pick is deterministic regardless of the situation-RNG roll.
+    let picker = Picker::with_seed(bandit, 0);
+    let proactive = ProactiveConfig {
+        enabled: true,
+        daily_cap: 3,
+        quiet_hours: None,
+        ..ProactiveConfig::default()
+    };
+
+    let llm = Arc::new(CapturingLlm::new(
+        "Good morning, David — what's the day looking like?",
+    ));
+    let notifier = Arc::new(NoopNotifier);
+
+    let mut outbox = Outbox::with_picker(
+        clock.clone() as Arc<dyn Clock>,
+        ledger,
+        picker,
+        proactive,
+        OutboxConfig {
+            llm: llm.clone(),
+            notifier,
+            voice_md: "You are a warm companion.".to_string(),
+            locale: "en-US".to_string(),
+            prompt_seeds,
+            name_for_user: "David".to_string(),
+            first_memory: Some("Sunday in Taipei".to_string()),
+            formality: "casual".to_string(),
+            extra_instructions: String::new(),
+            relationship: mur_common::companion::Relationship::Friend,
+        },
+    );
+
+    // ── Act ──────────────────────────────────────────────────────────────
+    // Drive ticks until the morning send fires (situations::pick_for_hour
+    // also returns ShareQuote ~40% of the time at 06–09 — we may need a
+    // second tick, but the seed=0 picker is deterministic so this is
+    // bounded). We bail after 3 ticks to keep the test loud on regression.
+    let mut sent = false;
+    for _ in 0..3 {
+        let now_utc = clock.now_utc();
+        let now_local = clock.now_local();
+        let outcome = outbox.run_tick(now_utc, now_local).await;
+        if let TickOutcome::Sent { situation, .. } = outcome
+            && situation == Situation::MorningGreeting
+        {
+            sent = true;
+            break;
+        }
+        clock.advance(Duration::minutes(1));
+    }
+    assert!(
+        sent,
+        "expected at least one MorningGreeting Sent within 3 ticks"
+    );
+
+    // ── Assert ───────────────────────────────────────────────────────────
+    let prompts = llm.captured_user_prompts();
+    assert!(
+        !prompts.is_empty(),
+        "CapturingLlm must have received at least one user prompt"
+    );
+
+    // The substituted prompt_seed reached the LLM (NOT the legacy
+    // hardcoded "Compose one short message…" line).
+    let merged: String = prompts.join("\n---\n");
+    assert!(
+        merged.contains("Sunday in Taipei"),
+        "user prompt sent to LLM must contain substituted {{{{FIRST_MEMORY}}}}: {merged}"
+    );
+    assert!(
+        merged.contains("David"),
+        "user prompt must contain substituted {{{{NAME_FOR_USER}}}}: {merged}"
+    );
+    assert!(
+        !merged.contains("{{FIRST_MEMORY}}"),
+        "verbatim placeholder must not leak through to the LLM: {merged}"
+    );
+    assert!(
+        !merged.contains("Compose one short message for situation"),
+        "legacy hardcoded prompt must not be used when prompt_seed is set: {merged}"
     );
 }
 

--- a/mur-agent-runtime/tests/telemetry_no_pii.rs
+++ b/mur-agent-runtime/tests/telemetry_no_pii.rs
@@ -114,6 +114,15 @@ async fn no_pii_in_ledger_after_24h_simulation() {
         notifier: Arc::new(FakeNotifier) as Arc<dyn Notifier>,
         voice_md,
         locale: "en-US".into(),
+        // M2.2.4 — empty seed map keeps this test on the legacy hardcoded
+        // prompt path; we're not asserting prompt construction here, only
+        // that the sentinel never lands in the ledger.
+        prompt_seeds: BTreeMap::new(),
+        name_for_user: String::new(),
+        first_memory: None,
+        formality: String::new(),
+        extra_instructions: String::new(),
+        relationship: mur_common::companion::Relationship::Friend,
     };
 
     let mut outbox = Outbox::with_picker(clock.clone(), ledger, picker, proactive, config);


### PR DESCRIPTION
## Summary

Closes the M2.2.3 follow-up gap: previously the runtime outbox built a hardcoded user prompt (`"Compose one short message for situation: ..."`) and never read the picked template's `prompt_seed`, so the day-3+ first-memory templates from M2.2.2 were dead text in actual message bodies (despite being correctly seeded into the picker pool).

## What changed

- **Shared substitution helper.** Promoted `voice::apply_placeholders` to `pub(crate)` and gave it a thorough docstring. It now powers both the system-prompt path (voice template composition) and the user-prompt path (outbox `prompt_seed` substitution) so the two surfaces can never diverge on substitution rules — order, `Some("")` collapse, leading-space for `{{FIRST_MEMORY_PARAGRAPH}}`, all identical.
- **Content-pool loader.** New `companion::load_prompt_seeds(agent_home, locale)` reads `<agent_dir>/companion/content/<situation>.<locale>.yaml` for the four supported situations (morning_greeting / gentle_check_in / share_quote / share_link), falling back to the embedded seeds via `mur_common::companion::content_seed::all_seeds()`. Best-effort: missing or malformed YAML logs warn-level and the situation is skipped.
- **OutboxConfig extended.** New fields `prompt_seeds: BTreeMap<TemplateId, String>`, `name_for_user`, `first_memory: Option<String>`, `formality`, `extra_instructions`, `relationship`. `Companion::new` populates them from profile + relationship.json + the loaded seed pool.
- **`generate_with_lint` rewritten.** Now takes a `&TemplateId` parameter; when the picked id has a non-empty `prompt_seed` registered, the substituted seed becomes the LLM user prompt. Empty / missing falls back to the legacy hardcoded line so existing tests don't regress. Substitution runs ONCE per call (before the regen loop) so both attempts share the same base prompt; only the trailing `[regenerate]` marker differs.
- **Lifecycle.** `prompt_seeds` map is loaded at `Companion::new` time, mirroring the existing M2.2.3 voice composition lifecycle. `--re-init` / `companion content add` requires a runtime restart for the new seed to take effect (consistent with the documented voice_md lifecycle).

## Tests

- New `morning_greeting_prompt_seed_substitutes_first_memory` in `tests/onboarding_morning_greeting_72h.rs`. Local `CapturingLlm` records every user-role message it receives. Test seeds a `morning_first_memory` template into the picker pool with a matching `prompt_seed`, sets `first_memory: "Sunday in Taipei"` + `name_for_user: "David"`, drives up to 3 ticks. Assertions: captured user prompt contains `"Sunday in Taipei"` and `"David"`, does NOT contain the verbatim `{{FIRST_MEMORY}}` placeholder, does NOT contain the legacy `"Compose one short message for situation"` line — that last one is the regression guard pinning M2.2.4's wiring.
- All 16 outbox unit tests + every other integration test still pass (legacy hardcoded prompt path is preserved when `prompt_seeds` is empty).

`cargo test -p mur-agent-runtime` green; `cargo test --workspace` green; `cargo clippy -p mur-agent-runtime --tests -- -D warnings` clean; `cargo fmt --all --check` clean.

## Stack

- #58 plan → main
- #59 M2.1 → main
- #60 M2.2 → #59
- #61 M2.3 → #60
- #62 M2.4 → #61
- #63 M2.5 → #62
- #64 M2.6 → #63
- #65 M2.7 → #64
- #66 M2.8 → #65
- **THIS** M2.2.4 followup → #66 — completes the M2 D2 onboarding milestone

## Test plan

- [ ] `cargo test -p mur-agent-runtime`
- [ ] `cargo test --workspace`
- [ ] `scripts/e2e/v1-d2-onboarding.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)