### PR TITLE
feat(common): D3 drag-drop — M3.1 shared types + ProvenanceLedger

### DIFF
--- a/mur-common/Cargo.toml
+++ b/mur-common/Cargo.toml
@@ -28,6 +28,8 @@ age = { version = "0.11", features = ["armor"] }
 tokio = { workspace = true }
 shellexpand = "3"
 shell-words = "1"
+fs2 = "0.4"
+tracing = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation"] }

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -13,6 +13,7 @@ pub mod knowledge;
 pub mod llm;
 pub mod lock_file;
 pub mod model;
+pub mod multimodal;
 pub mod parameterize;
 pub mod pattern;
 pub mod permissions;

--- a/mur-common/src/multimodal/artifact.rs
+++ b/mur-common/src/multimodal/artifact.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactKind {
+    Image,
+    Pdf,
+    Text,
+}
+
+/// In-memory record of one dropped/pasted artifact.
+///
+/// Consumed by:
+/// * the GUI composer (thumbnails + remove control)
+/// * `mur-agent-runtime`'s `B0SafetyHook` (untrusted wrapper injection,
+///   side-effect-tool deny via the `after_untrusted_input` turn-flag).
+///
+/// `decoder_version` and `ocr_engine_version` are persisted in
+/// `telemetry/inputs.jsonl` so a future audit can reproduce the exact
+/// decode chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultimodalArtifact {
+    /// Content hash of the *re-encoded* (sanitized) bytes.
+    pub sha256: String,
+    pub kind: ArtifactKind,
+    pub mime: String,
+    pub size_bytes: u64,
+    /// OCR'd text for images, extracted text for PDFs. None for `text/*`
+    /// (the body itself is the text).
+    pub ocr_text: Option<String>,
+    /// Page count for PDFs. None for images.
+    pub page_count: Option<u32>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub decoder_version: String,
+    pub ocr_engine_version: Option<String>,
+}

--- a/mur-common/src/multimodal/ledger.rs
+++ b/mur-common/src/multimodal/ledger.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use fs2::FileExt;
 use std::fs::OpenOptions;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
 use super::ProvenanceEntry;
@@ -22,6 +22,15 @@ impl ProvenanceLedger {
 
     /// Append one entry as a single JSON line. Atomic via flock.
     /// Creates the parent directory if missing.
+    ///
+    /// Note on the open mode: we deliberately use `write(true)` +
+    /// explicit `seek(SeekFrom::End(0))` rather than `append(true)`.
+    /// On Windows, `append(true)` requests `FILE_APPEND_DATA` only,
+    /// which is *not* sufficient for `LockFileEx` (used internally by
+    /// `fs2::FileExt::lock_exclusive`) — Windows demands `GENERIC_WRITE`
+    /// access, otherwise the lock call fails with `ERROR_ACCESS_DENIED`.
+    /// Manual seek-to-end gives us append semantics on every platform
+    /// while keeping the flock contract intact.
     pub fn append(&self, entry: &ProvenanceEntry) -> Result<()> {
         if let Some(parent) = self.path.parent() {
             std::fs::create_dir_all(parent)
@@ -29,10 +38,14 @@ impl ProvenanceLedger {
         }
         let mut f = OpenOptions::new()
             .create(true)
-            .append(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
             .open(&self.path)
             .with_context(|| format!("open {}", self.path.display()))?;
         f.lock_exclusive().context("flock inputs.jsonl")?;
+        f.seek(SeekFrom::End(0))
+            .context("seek to end of inputs.jsonl")?;
         let line = serde_json::to_string(entry).context("serialize provenance")?;
         writeln!(f, "{line}").context("append provenance")?;
         f.unlock().context("unlock inputs.jsonl")?;

--- a/mur-common/src/multimodal/ledger.rs
+++ b/mur-common/src/multimodal/ledger.rs
@@ -1,0 +1,71 @@
+//! Append-only provenance ledger for `telemetry/inputs.jsonl`.
+//!
+//! Atomic via flock; readers skip malformed lines so a half-written
+//! entry from a crashed writer can't poison subsequent reads.
+
+use anyhow::{Context, Result};
+use fs2::FileExt;
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+
+use super::ProvenanceEntry;
+
+pub struct ProvenanceLedger {
+    path: PathBuf,
+}
+
+impl ProvenanceLedger {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    /// Append one entry as a single JSON line. Atomic via flock.
+    /// Creates the parent directory if missing.
+    pub fn append(&self, entry: &ProvenanceEntry) -> Result<()> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        let mut f = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .with_context(|| format!("open {}", self.path.display()))?;
+        f.lock_exclusive().context("flock inputs.jsonl")?;
+        let line = serde_json::to_string(entry).context("serialize provenance")?;
+        writeln!(f, "{line}").context("append provenance")?;
+        f.unlock().context("unlock inputs.jsonl")?;
+        Ok(())
+    }
+
+    /// Read every entry whose `turn_id == turn`. Malformed lines are
+    /// silently skipped (logged at warn level). Returns Ok(empty)
+    /// when the file does not exist.
+    pub fn read_turn(&self, turn: u64) -> Result<Vec<ProvenanceEntry>> {
+        let f = match OpenOptions::new().read(true).open(&self.path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(vec![]),
+            Err(e) => {
+                return Err(anyhow::Error::from(e).context(format!("open {}", self.path.display())));
+            }
+        };
+        let r = BufReader::new(f);
+        let mut out = Vec::new();
+        for (i, line) in r.lines().enumerate() {
+            let Ok(line) = line else { continue };
+            match serde_json::from_str::<ProvenanceEntry>(&line) {
+                Ok(e) if e.turn_id == turn => out.push(e),
+                Ok(_) => continue,
+                Err(e) => {
+                    tracing::warn!(
+                        "ledger {}: skipping malformed line {}: {e}",
+                        self.path.display(),
+                        i + 1
+                    );
+                }
+            }
+        }
+        Ok(out)
+    }
+}

--- a/mur-common/src/multimodal/mod.rs
+++ b/mur-common/src/multimodal/mod.rs
@@ -1,5 +1,7 @@
 pub mod artifact;
+pub mod ledger;
 pub mod provenance;
 
 pub use artifact::{ArtifactKind, MultimodalArtifact};
+pub use ledger::ProvenanceLedger;
 pub use provenance::ProvenanceEntry;

--- a/mur-common/src/multimodal/mod.rs
+++ b/mur-common/src/multimodal/mod.rs
@@ -1,0 +1,5 @@
+pub mod artifact;
+pub mod provenance;
+
+pub use artifact::{ArtifactKind, MultimodalArtifact};
+pub use provenance::ProvenanceEntry;

--- a/mur-common/src/multimodal/provenance.rs
+++ b/mur-common/src/multimodal/provenance.rs
@@ -1,0 +1,17 @@
+use serde::{Deserialize, Serialize};
+
+/// One line in `<agent_dir>/telemetry/inputs.jsonl`.
+///
+/// Append-only; per-turn read by `B0SafetyHook::on_prompt_submit` to
+/// know which untrusted artifacts to wrap.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProvenanceEntry {
+    pub sha256: String,
+    /// e.g. `"user_drop"`, `"user_paste"`, `"a2a_attachment"`.
+    pub source: String,
+    pub decoder_version: String,
+    pub ocr_engine_version: Option<String>,
+    /// Monotonic per-agent turn counter.
+    pub turn_id: u64,
+    pub recorded_at: chrono::DateTime<chrono::Utc>,
+}

--- a/mur-common/tests/multimodal_ledger.rs
+++ b/mur-common/tests/multimodal_ledger.rs
@@ -1,0 +1,72 @@
+use chrono::Utc;
+use mur_common::multimodal::{ProvenanceEntry, ProvenanceLedger};
+use tempfile::TempDir;
+
+#[test]
+fn ledger_append_then_read_back() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("inputs.jsonl");
+
+    let l = ProvenanceLedger::new(&path);
+    l.append(&ProvenanceEntry {
+        sha256: "a".repeat(64),
+        source: "user_drop".into(),
+        decoder_version: "test".into(),
+        ocr_engine_version: None,
+        turn_id: 1,
+        recorded_at: Utc::now(),
+    })
+    .unwrap();
+    l.append(&ProvenanceEntry {
+        sha256: "b".repeat(64),
+        source: "user_paste".into(),
+        decoder_version: "test".into(),
+        ocr_engine_version: None,
+        turn_id: 1,
+        recorded_at: Utc::now(),
+    })
+    .unwrap();
+
+    let entries = ProvenanceLedger::new(&path).read_turn(1).unwrap();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].sha256, "a".repeat(64));
+    assert_eq!(entries[1].sha256, "b".repeat(64));
+
+    // Wrong turn returns empty.
+    assert!(
+        ProvenanceLedger::new(&path)
+            .read_turn(2)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn ledger_atomic_append_handles_corrupt_lines() {
+    // A truncated line (e.g., from a crash mid-write) must not poison
+    // subsequent reads — read_turn skips malformed lines.
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("inputs.jsonl");
+    std::fs::write(&path, "{ partial json\n").unwrap();
+    let l = ProvenanceLedger::new(&path);
+    l.append(&ProvenanceEntry {
+        sha256: "c".repeat(64),
+        source: "user_drop".into(),
+        decoder_version: "test".into(),
+        ocr_engine_version: None,
+        turn_id: 5,
+        recorded_at: Utc::now(),
+    })
+    .unwrap();
+    let entries = l.read_turn(5).unwrap();
+    assert_eq!(entries.len(), 1, "corrupt line skipped, valid line read");
+}
+
+#[test]
+fn ledger_missing_file_returns_empty() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("nonexistent.jsonl");
+    let l = ProvenanceLedger::new(&path);
+    let entries = l.read_turn(1).unwrap();
+    assert!(entries.is_empty());
+}

--- a/mur-common/tests/multimodal_roundtrip.rs
+++ b/mur-common/tests/multimodal_roundtrip.rs
@@ -1,0 +1,38 @@
+use chrono::Utc;
+use mur_common::multimodal::{ArtifactKind, MultimodalArtifact, ProvenanceEntry};
+
+#[test]
+fn artifact_yaml_roundtrip() {
+    let a = MultimodalArtifact {
+        sha256: "0".repeat(64),
+        kind: ArtifactKind::Image,
+        mime: "image/png".into(),
+        size_bytes: 4096,
+        ocr_text: Some("hello world".into()),
+        page_count: None,
+        created_at: Utc::now(),
+        decoder_version: "image-rs/0.25 + libheif-rs/1.0".into(),
+        ocr_engine_version: Some("Vision.framework/14.5".into()),
+    };
+    let s = serde_json::to_string(&a).unwrap();
+    assert!(s.contains("\"kind\":\"image\""));
+    let back: MultimodalArtifact = serde_json::from_str(&s).unwrap();
+    assert_eq!(back.sha256, a.sha256);
+    assert_eq!(back.ocr_text, a.ocr_text);
+}
+
+#[test]
+fn provenance_entry_jsonl_roundtrip() {
+    let p = ProvenanceEntry {
+        sha256: "0".repeat(64),
+        source: "user_drop".into(),
+        decoder_version: "image-rs/0.25".into(),
+        ocr_engine_version: Some("vision/14.5".into()),
+        turn_id: 42,
+        recorded_at: Utc::now(),
+    };
+    let line = serde_json::to_string(&p).unwrap();
+    assert!(!line.contains('\n'), "jsonl entries must be single-line");
+    let back: ProvenanceEntry = serde_json::from_str(&line).unwrap();
+    assert_eq!(back.turn_id, 42);
+}


### PR DESCRIPTION
## Summary

First milestone (M3.1) of the M3 D3 plan (#69). Pure schema work in `mur-common::multimodal` — both the GUI (decoder pipeline writer) and the runtime (B0SafetyHook reader) consume these types.

## What's in

**M3.1.1** `801a733` — `mur-common::multimodal` module:
- `ArtifactKind { Image, Pdf, Text }` with `#[serde(rename_all = "snake_case")]`.
- `MultimodalArtifact { sha256, kind, mime, size_bytes, ocr_text, page_count, created_at, decoder_version, ocr_engine_version }`.
- `ProvenanceEntry { sha256, source, decoder_version, ocr_engine_version, turn_id, recorded_at }`.

**M3.1.2** `d29108b` — `ProvenanceLedger`:
- `append(&entry)` flock-protected (`fs2::FileExt::lock_exclusive`); creates parent dir if missing; trailing newline for JSONL compliance.
- `read_turn(turn)` filters by `turn_id`; missing file → `Ok(empty)`; corrupt lines logged at warn level + skipped.

New direct deps on mur-common: `fs2 = "0.4"` (file locking) + `tracing = "0.1"` (warn-level logging on corrupt lines).

## Tests added

5 tests:
- `artifact_yaml_roundtrip` — JSON round-trip including `kind="image"` lowercase.
- `provenance_entry_jsonl_roundtrip` — single-line JSONL guarantee + round-trip.
- `ledger_append_then_read_back` — round-trip 2 entries on turn 1, confirm turn 2 empty.
- `ledger_atomic_append_handles_corrupt_lines` — pre-write malformed line, then valid append, confirm only valid entry read.
- `ledger_missing_file_returns_empty` — graceful no-file path.

`cargo test -p mur-common` green (165 tests). `cargo clippy -p mur-common -- -D warnings` clean. `cargo fmt --check` clean.

## Stack

- #69 — D3 plan (draft)
- **THIS** — M3.1 schema (base for everything else)
- M3.2 sandboxed decoder (next)

## Test plan

- [ ] `cargo test -p mur-common`
- [ ] `cargo clippy -p mur-common -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)