### PR TITLE
feat(gui): D3 drag-drop — M3.5 OCR trait + pipeline wiring (Vision/tesseract deferred)

### DIFF
--- a/mur-agent-gui/src-tauri/src/multimodal/mod.rs
+++ b/mur-agent-gui/src-tauri/src/multimodal/mod.rs
@@ -8,6 +8,7 @@ pub mod decoder_protocol;
 pub mod dedupe;
 pub mod heic;
 pub mod icloud_fallback;
+pub mod ocr;
 pub mod pipeline;
 pub mod unicode_scrubber;
 

--- a/mur-agent-gui/src-tauri/src/multimodal/ocr/mod.rs
+++ b/mur-agent-gui/src-tauri/src/multimodal/ocr/mod.rs
@@ -1,0 +1,45 @@
+//! OCR engine abstraction.
+//!
+//! `OcrEngine` is the trait every platform-specific impl satisfies.
+//! `default_engine()` returns the appropriate platform default:
+//!
+//! * macOS (when M3.5.2 lands): `VisionOcr` via `objc2-vision`
+//! * Linux/Windows (when M3.5.3 lands): `TesseractOcr` shelling to the
+//!   `tesseract` CLI binary
+//! * Today (M3.5.1): `NoopOcr` everywhere — returns empty string. The
+//!   pipeline still runs; image artifacts ship with `ocr_text:
+//!   Some("")` until M3.5.2 / M3.5.3 wire real engines.
+//!
+//! This means the rest of M3 (UI, Tauri commands, B0SafetyHook) can
+//! land without waiting on the native-OCR work.
+
+pub mod platform;
+
+pub struct OcrResult {
+    pub text: String,
+    pub engine_version: String,
+}
+
+pub trait OcrEngine: Send + Sync {
+    fn recognize_png(&self, png_bytes: &[u8]) -> OcrResult;
+}
+
+/// Universal fallback. Returns empty string. Used in tests + on hosts
+/// that don't yet have a real engine wired up.
+pub struct NoopOcr;
+
+impl OcrEngine for NoopOcr {
+    fn recognize_png(&self, _bytes: &[u8]) -> OcrResult {
+        OcrResult {
+            text: String::new(),
+            engine_version: "noop/1.0".into(),
+        }
+    }
+}
+
+/// Build the platform-default OCR engine. M3.5.1 always returns
+/// `NoopOcr`; M3.5.2 + M3.5.3 will replace this with real platform
+/// dispatches.
+pub fn default_engine() -> Box<dyn OcrEngine> {
+    platform::default_engine()
+}

--- a/mur-agent-gui/src-tauri/src/multimodal/ocr/platform.rs
+++ b/mur-agent-gui/src-tauri/src/multimodal/ocr/platform.rs
@@ -1,0 +1,24 @@
+//! Platform dispatch for `default_engine()`.
+//!
+//! M3.5.1 returns `NoopOcr` on every platform. When M3.5.2 ships the
+//! macOS Vision.framework backend, replace the macOS arm; when M3.5.3
+//! ships tesseract, replace the non-macOS arm.
+
+#[cfg(target_os = "macos")]
+mod imp {
+    pub fn default_engine() -> Box<dyn super::super::OcrEngine> {
+        // TODO(M3.5.2): replace with `Box::new(super::super::vision::VisionOcr::new())`.
+        Box::new(super::super::NoopOcr)
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod imp {
+    pub fn default_engine() -> Box<dyn super::super::OcrEngine> {
+        // TODO(M3.5.3): try TesseractOcr::new() and fall back to NoopOcr
+        // if the tesseract binary isn't on PATH.
+        Box::new(super::super::NoopOcr)
+    }
+}
+
+pub use imp::default_engine;

--- a/mur-agent-gui/src-tauri/src/multimodal/pipeline.rs
+++ b/mur-agent-gui/src-tauri/src/multimodal/pipeline.rs
@@ -1,13 +1,13 @@
 //! 9-step drag-drop pipeline orchestrator (D3, roadmap §4.3).
 //!
 //! Steps that run here: 3 (HEIC normalize), 4 (sandboxed decode +
-//! re-encode), 8 (provenance ledger entry).
+//! re-encode), 5 (OCR via `OcrEngine` — Noop today, Vision/tesseract
+//! in M3.5.2/M3.5.3), 6 (Unicode scrub on OCR output), 8 (provenance
+//! ledger entry).
 //!
 //! Steps owned by callers / other layers:
 //! * 1 dedupe — caller-side via `DropDeduper` (in `main.rs`)
 //! * 2 iCloud fallback — caller-side via `icloud_fallback_bytes`
-//! * 5 OCR — added to this module in M3.5.4
-//! * 6 Unicode scrubber — applied to OCR output in M3.5.4
 //! * 7 untrusted_image_text wrapper — `B0SafetyHook` (M3.8)
 //! * 9 turn-flag — `B0SafetyHook` (M3.8)
 
@@ -39,6 +39,7 @@ pub struct MultimodalPipeline {
     agent_home: PathBuf,
     turn_id: u64,
     decoder: DecoderClient,
+    ocr: Box<dyn super::ocr::OcrEngine>,
 }
 
 impl MultimodalPipeline {
@@ -47,6 +48,7 @@ impl MultimodalPipeline {
             agent_home,
             turn_id,
             decoder: DecoderClient::new(),
+            ocr: super::ocr::default_engine(),
         }
     }
 
@@ -95,6 +97,16 @@ impl MultimodalPipeline {
             DecodeResponse::PdfText { .. } => bail!("got PDF response on image path"),
         };
 
+        // Step 5 + Step 6: OCR + Unicode scrub.
+        let ocr_result = self.ocr.recognize_png(&png);
+        let (scrubbed_ocr, _scrubbed_count) = unicode_scrubber::scrub(&ocr_result.text);
+        let ocr_text = if scrubbed_ocr.trim().is_empty() {
+            None
+        } else {
+            Some(scrubbed_ocr)
+        };
+        let ocr_engine_version = Some(ocr_result.engine_version.clone());
+
         // Step 8: provenance ledger entry.
         let mut hasher = Sha256::new();
         hasher.update(&png);
@@ -104,7 +116,7 @@ impl MultimodalPipeline {
             sha256: sha256.clone(),
             source: source.clone(),
             decoder_version: decoder_version.clone(),
-            ocr_engine_version: None, // M3.5.4 fills this
+            ocr_engine_version: ocr_engine_version.clone(),
             turn_id: self.turn_id,
             recorded_at: Utc::now(),
         };
@@ -116,11 +128,11 @@ impl MultimodalPipeline {
             kind: ArtifactKind::Image,
             mime: "image/png".into(),
             size_bytes: png.len() as u64,
-            ocr_text: None, // M3.5.4 wires this
+            ocr_text,
             page_count: None,
             created_at: Utc::now(),
             decoder_version,
-            ocr_engine_version: None,
+            ocr_engine_version,
         })
     }
 

--- a/mur-agent-gui/src-tauri/tests/multimodal_ocr_dispatch.rs
+++ b/mur-agent-gui/src-tauri/tests/multimodal_ocr_dispatch.rs
@@ -1,0 +1,21 @@
+use mur_agent_gui_lib::multimodal::ocr::{NoopOcr, OcrEngine};
+
+#[test]
+fn noop_returns_empty_string() {
+    let e = NoopOcr;
+    let r = e.recognize_png(&[0x89, 0x50, 0x4e, 0x47]);
+    assert!(r.text.is_empty());
+    assert!(r.engine_version.starts_with("noop"));
+}
+
+#[test]
+fn default_engine_constructs() {
+    // On every platform, default_engine() returns SOME engine — Vision
+    // on macOS (when M3.5.2 ships), tesseract on Linux/Windows (when
+    // M3.5.3 ships), or NoopOcr as the universal fallback today.
+    let e = mur_agent_gui_lib::multimodal::ocr::default_engine();
+    let r = e.recognize_png(&[0x89, 0x50, 0x4e, 0x47]);
+    // For now Noop; later platform impls will return real text. Either
+    // way, engine_version is non-empty.
+    assert!(!r.engine_version.is_empty());
+}

--- a/mur-agent-gui/src-tauri/tests/multimodal_pipeline_image.rs
+++ b/mur-agent-gui/src-tauri/tests/multimodal_pipeline_image.rs
@@ -69,6 +69,41 @@ async fn pipeline_from_path_reads_file_then_processes() {
     assert_eq!(a.mime, "image/png");
 }
 
+#[tokio::test]
+async fn pipeline_image_runs_ocr_with_noop_engine() {
+    unsafe {
+        std::env::set_var(
+            "MUR_AGENT_DECODER_BIN",
+            env!("CARGO_BIN_EXE_mur-agent-decoder"),
+        );
+    }
+    let tmp = TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join("telemetry")).unwrap();
+    let png = include_bytes!("fixtures/tiny.png").to_vec();
+    let pipeline = MultimodalPipeline::new(tmp.path().to_path_buf(), 1);
+    let a = pipeline
+        .process(PipelineInput::Bytes {
+            bytes: png,
+            mime_hint: "image/png".into(),
+            source: "user_drop".into(),
+        })
+        .await
+        .unwrap();
+    // M3.5.4 wires OCR. NoopOcr returns empty text → ocr_text is None
+    // (we collapse empty OCR strings to None so downstream readers
+    // don't see Some("")).
+    assert!(a.ocr_text.is_none());
+    // engine_version is always set (Noop returns "noop/1.0").
+    assert_eq!(a.ocr_engine_version.as_deref(), Some("noop/1.0"));
+
+    // Provenance entry's ocr_engine_version is also recorded.
+    let ledger =
+        mur_common::multimodal::ProvenanceLedger::new(tmp.path().join("telemetry/inputs.jsonl"));
+    let entries = ledger.read_turn(1).unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].ocr_engine_version.as_deref(), Some("noop/1.0"));
+}
+
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn pipeline_heic_normalizes_then_decodes() {


### PR DESCRIPTION
## Summary

Fifth milestone (M3.5) of the M3 D3 plan (#69) — partial. Lands the `OcrEngine` trait abstraction + Noop fallback + pipeline wiring so the rest of M3 (Tauri commands, React UI, B0SafetyHook, E2E) can proceed without waiting on the fiddly native-OCR work.

## What's in

**M3.5.1** `285fff3` — OCR architecture:
- `OcrEngine` trait (`Send + Sync` bound so the engine can live in a `Box<dyn>` across `.await` points).
- `OcrResult { text: String, engine_version: String }`.
- `NoopOcr` returns empty text + `"noop/1.0"` version. Universal fallback.
- `default_engine()` platform dispatch in `multimodal/ocr/platform.rs`. Today both arms return Noop with `TODO(M3.5.2)` / `TODO(M3.5.3)` markers.

**M3.5.4** `45e2c5e` — Pipeline integration:
- `MultimodalPipeline.ocr: Box<dyn OcrEngine>` field, populated via `default_engine()` in `new()`.
- Image path runs OCR on the decoder's PNG output, scrubs the OCR text via Unicode scrubber, collapses empty trimmed strings to `None` (so downstream never sees `Some("")`).
- `ocr_engine_version` recorded on both `MultimodalArtifact` AND `ProvenanceEntry`.
- PDF path unchanged (PDFs use native pdfium-render text extraction, not OCR).

## What's deliberately deferred

**M3.5.2 (macOS Vision.framework via `objc2-vision`)** and **M3.5.3 (tesseract fallback)** are tracked as Tasks #56/#57. Reasons:

- `objc2-vision` API churns frequently; the plan's snippet may not compile against the current crate version. Best to land the trait + Noop now and write the Vision impl with the actual API in front of us.
- `tesseract` requires the system binary on Linux/Windows; nontrivial CI setup. Deferring keeps M3.6/M3.7/M3.8/M3.9 unblocked.

When M3.5.2/M3.5.3 land, they slot in via the existing trait — no call-site changes.

## Tests added

3 new tests, all passing:
- `multimodal_ocr_dispatch.rs` — 2 (Noop returns empty + version; `default_engine()` constructs).
- `multimodal_pipeline_image.rs` (extended) — 1 (`pipeline_image_runs_ocr_with_noop_engine` — asserts `ocr_text.is_none()` due to collapse + `ocr_engine_version: Some("noop/1.0")` + ledger entry has the engine version).

`cargo fmt --check` clean. Existing 5 pipeline tests (3 image + 2 PDF) still pass.

## Stack

- #69 D3 plan (draft)
- #70 → #71 → #72 → #73 → **THIS** M3.5 → M3.6 (next, Tauri commands)

## Test plan

- [ ] `cd mur-agent-gui/src-tauri && cargo test --test multimodal_ocr_dispatch --test multimodal_pipeline_image --test multimodal_pipeline_pdf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)