### PR TITLE
feat(gui): D3 drag-drop — M3.6 Tauri commands (drop / paste / drag-drop event handler)

### DIFF
--- a/mur-agent-gui/src-tauri/src/commands.rs
+++ b/mur-agent-gui/src-tauri/src/commands.rs
@@ -901,3 +901,60 @@ pub async fn multimodal_drop(
         .await
         .map_err(err)
 }
+
+// ─── M3.6.2 — `multimodal_paste` (clipboard → pipeline) ────────────
+//
+// Two-tier clipboard reader:
+//   1. `MUR_TEST_CLIPBOARD_IMAGE` env var (test bypass — points at a
+//      file whose bytes we treat as the clipboard image)
+//   2. real Tauri clipboard plugin (TODO — `tauri-plugin-clipboard-manager`
+//      gates the image accessor behind platform-specific code paths
+//      which we wire in M3.7+/M3.9 alongside the React surface)
+//
+// If neither yields bytes we surface a `clipboard has no image` error
+// so the React side can show a polite message.
+
+pub async fn multimodal_paste_impl(
+    agent: &str,
+    turn_id: u64,
+) -> anyhow::Result<Vec<MultimodalArtifact>> {
+    let bytes = read_clipboard_image_for_test()
+        .or_else(read_clipboard_image_via_plugin)
+        .ok_or_else(|| anyhow::anyhow!("clipboard has no image"))?;
+    if bytes.len() as u64 > MAX_TOTAL_BYTES_PER_DROP {
+        anyhow::bail!("clipboard image > 30 MB");
+    }
+    let agent_home = onboarding_agent_dir(agent)?;
+    let pipeline = MultimodalPipeline::new(agent_home, turn_id);
+    let a = pipeline
+        .process(PipelineInput::Bytes {
+            bytes,
+            mime_hint: "image/png".into(),
+            source: "user_paste".into(),
+        })
+        .await?;
+    Ok(vec![a])
+}
+
+#[tauri::command]
+pub async fn multimodal_paste(
+    agent: String,
+    turn_id: u64,
+) -> Result<Vec<MultimodalArtifact>, String> {
+    multimodal_paste_impl(&agent, turn_id).await.map_err(err)
+}
+
+fn read_clipboard_image_for_test() -> Option<Vec<u8>> {
+    std::env::var("MUR_TEST_CLIPBOARD_IMAGE")
+        .ok()
+        .and_then(|p| std::fs::read(p).ok())
+}
+
+fn read_clipboard_image_via_plugin() -> Option<Vec<u8>> {
+    // Real Tauri clipboard wiring is platform-specific (the manager
+    // plugin's image accessor differs across macOS/Linux/Windows).
+    // For M3.6.2 we ship the test bypass; the production path is a
+    // TODO tracked alongside the M3.6 milestone (lands with M3.7
+    // when the React side wires up the paste handler).
+    None
+}

--- a/mur-agent-gui/src-tauri/src/commands.rs
+++ b/mur-agent-gui/src-tauri/src/commands.rs
@@ -11,9 +11,13 @@
 //! `~/.mur/agents/<name>/`). Stub here; real wiring lands in P1.3 +
 //! P1.6.
 
+use anyhow::Context;
 use mur_common::agent::{Entitlements, McpServerEntry};
+use mur_common::multimodal::MultimodalArtifact;
 use mur_core::agent_admin;
 use serde::Serialize;
+
+use crate::multimodal::pipeline::{MultimodalPipeline, PipelineInput};
 
 fn agent_name() -> String {
     std::env::var("MUR_GUI_AGENT_NAME").unwrap_or_else(|_| "template".to_string())
@@ -834,4 +838,66 @@ pub async fn companion_onboarding_skip_impl(agent: &str) -> anyhow::Result<()> {
 #[tauri::command]
 pub async fn companion_onboarding_skip(agent: String) -> Result<(), String> {
     companion_onboarding_skip_impl(&agent).await.map_err(err)
+}
+
+// ─── D3 multimodal drag-drop / paste (M3.6) ────────────────────────
+//
+// Two helpers (`_impl`) back the `#[tauri::command]` wrappers so they
+// can be unit-tested without a webview. Caps are enforced *before*
+// any pipeline work runs:
+//
+//   * `MAX_FILES_PER_DROP` — fail-fast on glob-drop accidents
+//   * `MAX_TOTAL_BYTES_PER_DROP` — keep one drop bounded
+//
+// After caps the pipeline does HEIC normalize, sandboxed decode, OCR,
+// Unicode scrub, provenance ledger entry. Step 1 (dedupe) lives in
+// `main.rs`'s `on_window_event`; step 7 (`untrusted_image_text`) and
+// step 9 (turn-flag) land in M3.8 with the `B0SafetyHook`.
+
+const MAX_FILES_PER_DROP: usize = 10;
+const MAX_TOTAL_BYTES_PER_DROP: u64 = 30 * 1024 * 1024;
+
+pub async fn multimodal_drop_impl(
+    agent: &str,
+    paths: Vec<std::path::PathBuf>,
+    turn_id: u64,
+) -> anyhow::Result<Vec<MultimodalArtifact>> {
+    if paths.len() > MAX_FILES_PER_DROP {
+        anyhow::bail!(
+            "multimodal_drop: max 10 files per drop, got {}",
+            paths.len()
+        );
+    }
+    let mut total_bytes = 0u64;
+    for p in &paths {
+        let m = std::fs::metadata(p).with_context(|| format!("metadata {}", p.display()))?;
+        total_bytes += m.len();
+    }
+    if total_bytes > MAX_TOTAL_BYTES_PER_DROP {
+        anyhow::bail!("multimodal_drop: total > 30 MB ({total_bytes} bytes)");
+    }
+    let agent_home = onboarding_agent_dir(agent)?;
+    let pipeline = MultimodalPipeline::new(agent_home, turn_id);
+    let mut out = Vec::with_capacity(paths.len());
+    for p in paths {
+        let a = pipeline
+            .process(PipelineInput::Path {
+                path: p,
+                source: "user_drop".into(),
+            })
+            .await?;
+        out.push(a);
+    }
+    Ok(out)
+}
+
+#[tauri::command]
+pub async fn multimodal_drop(
+    agent: String,
+    paths: Vec<std::path::PathBuf>,
+    turn_id: u64,
+) -> Result<Vec<MultimodalArtifact>, String> {
+    multimodal_drop_impl(&agent, paths, turn_id)
+        .await
+        .map_err(err)
 }

--- a/mur-agent-gui/src-tauri/src/main.rs
+++ b/mur-agent-gui/src-tauri/src/main.rs
@@ -253,6 +253,35 @@ fn main() -> Result<()> {
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_notification::init())
+        // ── D3 / M3.6.3 — drag-drop event → React ──────────────────
+        //
+        // Tauri 2 delivers drag-drop through `WindowEvent::DragDrop`.
+        // The webview ALSO fires HTML5 `drop` events on its own, so
+        // we use `DropDeduper` (sorted-paths within a 120ms window —
+        // workaround for Tauri issue #14134, which also covers the
+        // double-fire seen on macOS) to make sure the React side gets
+        // exactly one `multimodal://drop` per physical drop. React
+        // then invokes `multimodal_drop` with these paths via the
+        // Tauri RPC.
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::DragDrop(tauri::DragDropEvent::Drop { paths, .. }) = event {
+                use std::sync::Mutex;
+                use tauri::Emitter;
+                static DEDUPE: Mutex<Option<crate::multimodal::DropDeduper>> = Mutex::new(None);
+                let now = std::time::Instant::now();
+                let mut g = DEDUPE.lock().unwrap_or_else(|p| p.into_inner());
+                if g.is_none() {
+                    *g = Some(crate::multimodal::DropDeduper::new());
+                }
+                if !g.as_mut().unwrap().observe(paths, now) {
+                    return;
+                }
+                drop(g);
+                if let Err(e) = window.emit("multimodal://drop", paths.clone()) {
+                    tracing::warn!("emit multimodal://drop: {e:#}");
+                }
+            }
+        })
         .invoke_handler(tauri::generate_handler![
             // Status / lifecycle
             commands::status,

--- a/mur-agent-gui/src-tauri/src/main.rs
+++ b/mur-agent-gui/src-tauri/src/main.rs
@@ -314,6 +314,8 @@ fn main() -> Result<()> {
             commands::companion_onboarding_status,
             commands::companion_onboarding_submit,
             commands::companion_onboarding_skip,
+            // D3 multimodal drag-drop / paste (M3.6)
+            commands::multimodal_drop,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/mur-agent-gui/src-tauri/src/main.rs
+++ b/mur-agent-gui/src-tauri/src/main.rs
@@ -316,6 +316,7 @@ fn main() -> Result<()> {
             commands::companion_onboarding_skip,
             // D3 multimodal drag-drop / paste (M3.6)
             commands::multimodal_drop,
+            commands::multimodal_paste,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/mur-agent-gui/src-tauri/tests/common/mod.rs
+++ b/mur-agent-gui/src-tauri/tests/common/mod.rs
@@ -1,0 +1,39 @@
+//! Shared `MurHomeGuard` for integration tests that flip `MUR_HOME`.
+//!
+//! Cargo treats each integration test file as its own crate, so this
+//! module is `mod common;`'d into every test file that needs it. The
+//! `LazyLock<Mutex<()>>` serialises parallel test threads inside a
+//! single integration-test binary; cross-binary serialisation isn't
+//! needed because each `cargo test` per-test-file binary owns its own
+//! process.
+
+#![allow(dead_code)] // each test file uses a subset of helpers
+
+use std::sync::{LazyLock, Mutex, MutexGuard};
+
+static GUARD_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+pub struct MurHomeGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl MurHomeGuard {
+    pub fn set(path: &std::path::Path) -> Self {
+        let lock = GUARD_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: process-wide mutex held across the env mutation; cleared
+        // again in `Drop`.
+        unsafe {
+            std::env::set_var("MUR_HOME", path);
+        }
+        Self { _lock: lock }
+    }
+}
+
+impl Drop for MurHomeGuard {
+    fn drop(&mut self) {
+        // SAFETY: still holding `_lock` until our fields drop.
+        unsafe {
+            std::env::remove_var("MUR_HOME");
+        }
+    }
+}

--- a/mur-agent-gui/src-tauri/tests/multimodal_commands.rs
+++ b/mur-agent-gui/src-tauri/tests/multimodal_commands.rs
@@ -1,0 +1,107 @@
+//! Integration tests for the M3.6 Tauri commands that wire the
+//! drag-drop / paste pipeline into the React frontend.
+//!
+//! Each test exercises the `_impl` helper that backs the
+//! `#[tauri::command]` wrapper, so we don't need a real webview.
+//! `MUR_HOME` is flipped via the shared `MurHomeGuard`.
+
+use mur_agent_gui_lib::commands::multimodal_drop_impl;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+mod common;
+use common::MurHomeGuard;
+
+fn fixture_with_name(name: &str) -> String {
+    let candidates = [
+        "../../mur-common/tests/fixtures/profile_p0a_minimal.yaml",
+        "../mur-common/tests/fixtures/profile_p0a_minimal.yaml",
+        "mur-common/tests/fixtures/profile_p0a_minimal.yaml",
+    ];
+    let yaml = candidates
+        .iter()
+        .find_map(|p| std::fs::read_to_string(p).ok())
+        .unwrap_or_else(|| {
+            let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .ancestors()
+                .nth(2)
+                .unwrap()
+                .join("mur-common/tests/fixtures/profile_p0a_minimal.yaml");
+            std::fs::read_to_string(p).expect("fixture must exist")
+        });
+    yaml.replace("name: agent_test", &format!("name: {name}"))
+}
+
+fn seed(home: &std::path::Path, name: &str) {
+    let dir = home.join(format!("agents/{name}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::create_dir_all(dir.join("telemetry")).unwrap();
+    std::fs::write(dir.join("profile.yaml"), fixture_with_name(name)).unwrap();
+}
+
+// ─── M3.6.1 — `multimodal_drop` ────────────────────────────────────
+
+#[tokio::test]
+async fn multimodal_drop_one_png_succeeds() {
+    unsafe {
+        std::env::set_var(
+            "MUR_AGENT_DECODER_BIN",
+            env!("CARGO_BIN_EXE_mur-agent-decoder"),
+        );
+    }
+    let tmp = TempDir::new().unwrap();
+    let _g = MurHomeGuard::set(tmp.path());
+    seed(tmp.path(), "drop");
+    let png = tmp.path().join("hello.png");
+    std::fs::write(&png, include_bytes!("fixtures/tiny.png")).unwrap();
+
+    let artifacts = multimodal_drop_impl("drop", vec![png], 1).await.unwrap();
+
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].mime, "image/png");
+    assert_eq!(artifacts[0].sha256.len(), 64);
+}
+
+#[tokio::test]
+async fn multimodal_drop_more_than_10_files_rejects() {
+    let tmp = TempDir::new().unwrap();
+    let _g = MurHomeGuard::set(tmp.path());
+    seed(tmp.path(), "many");
+    let paths: Vec<PathBuf> = (0..11)
+        .map(|i| {
+            let p = tmp.path().join(format!("f{i}.png"));
+            std::fs::write(&p, include_bytes!("fixtures/tiny.png")).unwrap();
+            p
+        })
+        .collect();
+
+    let err = multimodal_drop_impl("many", paths, 1)
+        .await
+        .expect_err("too many files");
+    assert!(
+        err.to_string().contains("max 10"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn multimodal_drop_size_cap_rejects() {
+    let tmp = TempDir::new().unwrap();
+    let _g = MurHomeGuard::set(tmp.path());
+    seed(tmp.path(), "huge");
+    // Two 16 MB files → 32 MB total > 30 MB cap.
+    let buf = vec![0u8; 16 * 1024 * 1024];
+    let p1 = tmp.path().join("a.bin");
+    let p2 = tmp.path().join("b.bin");
+    std::fs::write(&p1, &buf).unwrap();
+    std::fs::write(&p2, &buf).unwrap();
+
+    let err = multimodal_drop_impl("huge", vec![p1, p2], 1)
+        .await
+        .expect_err("> 30 MB");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("30 MB") || msg.contains("> 30"),
+        "unexpected error: {msg}"
+    );
+}

--- a/mur-agent-gui/src-tauri/tests/multimodal_commands.rs
+++ b/mur-agent-gui/src-tauri/tests/multimodal_commands.rs
@@ -105,3 +105,50 @@ async fn multimodal_drop_size_cap_rejects() {
         "unexpected error: {msg}"
     );
 }
+
+// ─── M3.6.2 — `multimodal_paste` ───────────────────────────────────
+
+#[tokio::test]
+async fn multimodal_paste_with_image_in_clipboard_succeeds() {
+    unsafe {
+        std::env::set_var(
+            "MUR_AGENT_DECODER_BIN",
+            env!("CARGO_BIN_EXE_mur-agent-decoder"),
+        );
+    }
+    let tmp = TempDir::new().unwrap();
+    let _g = MurHomeGuard::set(tmp.path());
+    seed(tmp.path(), "paste");
+    let png = include_bytes!("fixtures/tiny.png").to_vec();
+    let png_path = tmp.path().join("clip.png");
+    std::fs::write(&png_path, &png).unwrap();
+    unsafe {
+        std::env::set_var("MUR_TEST_CLIPBOARD_IMAGE", png_path.to_str().unwrap());
+    }
+
+    let artifacts = mur_agent_gui_lib::commands::multimodal_paste_impl("paste", 1)
+        .await
+        .unwrap();
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].mime, "image/png");
+    unsafe {
+        std::env::remove_var("MUR_TEST_CLIPBOARD_IMAGE");
+    }
+}
+
+#[tokio::test]
+async fn multimodal_paste_no_clipboard_image_errors() {
+    let tmp = TempDir::new().unwrap();
+    let _g = MurHomeGuard::set(tmp.path());
+    seed(tmp.path(), "noclip");
+    unsafe {
+        std::env::remove_var("MUR_TEST_CLIPBOARD_IMAGE");
+    }
+    let err = mur_agent_gui_lib::commands::multimodal_paste_impl("noclip", 1)
+        .await
+        .expect_err("no clipboard image");
+    assert!(
+        err.to_string().to_lowercase().contains("clipboard"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

Sixth milestone (M3.6) of the M3 D3 plan (#69). Three Tauri commands + a `WebviewWindow::on_drag_drop_event` handler bridge the GUI process to the React side. The pipeline + B0 wrapping are now reachable via real drag-drop events.

## What's in

**M3.6.1** `0ac43fe` — `multimodal_drop(agent, paths, turn_id) -> Vec<MultimodalArtifact>`. Caps: 10 files / 30 MB total enforced BEFORE pipeline invocation. Each path runs through `MultimodalPipeline::process(PipelineInput::Path { source: "user_drop" })`.

**M3.6.2** `f6ce450` — `multimodal_paste(agent, turn_id) -> Vec<MultimodalArtifact>`. Reads clipboard image (test bypass via `MUR_TEST_CLIPBOARD_IMAGE` env; production `read_clipboard_image_via_plugin()` returns `None` — Tauri-clipboard wiring is platform-specific and follows in a future task per plan).

**M3.6.3** `05c08fd` — `Builder::on_window_event` handler. Static `DEDUPE: Mutex<Option<DropDeduper>>` filters Tauri #14134's double-fire. Lock dropped BEFORE `window.emit` to avoid holding across the emit call. Emits `multimodal://drop` carrying paths so React invokes `multimodal_drop` with them.

## Tests added

5 tests in `multimodal_commands.rs`, all passing:
- `multimodal_drop_one_png_succeeds`
- `multimodal_drop_more_than_10_files_rejects`
- `multimodal_drop_size_cap_rejects`
- `multimodal_paste_with_image_in_clipboard_succeeds`
- `multimodal_paste_no_clipboard_image_errors`

Plus shared `tests/common/mod.rs` with `MurHomeGuard` (lifted from M2.4's onboarding tests; serializes parallel test threads via `LazyLock<Mutex<()>>` + clears MUR_HOME on drop).

`cargo build --bin mur-agent-gui` clean. `cargo fmt --check` clean.

## Stack

- #69 → #70 → #71 → #72 → #73 → #74 → **THIS** M3.6 → M3.7 (next, React UI)

## Test plan

- [ ] `cd mur-agent-gui/src-tauri && cargo test --test multimodal_commands`
- [ ] `cd mur-agent-gui/src-tauri && cargo build --bin mur-agent-gui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)