### PR TITLE
feat(gui): D3 drag-drop — M3.7 React UI (DropOverlay + Thumbnails + App.tsx wiring)

### DIFF
--- a/mur-agent-gui/ui/src/App.tsx
+++ b/mur-agent-gui/ui/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
 import StatusTab from "./tabs/Status";
 import PromptTab from "./tabs/Prompt";
 import ModelTab from "./tabs/Model";
@@ -9,6 +10,10 @@ import IdentityTab from "./tabs/Identity";
 import { VoiceTab } from "./voice/VoiceTab";
 import { PttButton } from "./voice/PttButton";
 import { OnboardingWizard } from "./onboarding/OnboardingWizard";
+import { DropOverlay } from "./multimodal/DropOverlay";
+import { Thumbnails } from "./multimodal/Thumbnails";
+import { multimodalDrop, multimodalPaste } from "./multimodal/api";
+import type { MultimodalArtifact } from "./multimodal/types";
 import {
   setTheme as setThemeApi,
   getDefaultTheme,
@@ -51,6 +56,46 @@ export default function App() {
   // keeps a hand-built dev shell working too.
   const [onboarded, setOnboarded] = useState<boolean | null>(null);
   const [agent, setAgent] = useState<string>("default");
+
+  // Multimodal attachments staged for the next composer turn.
+  // The Tauri side emits `multimodal://drop` whenever the user drops
+  // files anywhere on the window; the listener below resolves those
+  // paths through the `multimodal_drop` command (which decodes,
+  // hashes, and persists each artifact) and appends to this list.
+  // The clipboard `paste` handler does the same via `multimodal_paste`.
+  // `turnId` is held flat for now — M3.8 will rotate it on send.
+  const [artifacts, setArtifacts] = useState<MultimodalArtifact[]>([]);
+  const [turnId] = useState<number>(1);
+
+  useEffect(() => {
+    const u = listen<string[]>("multimodal://drop", async (e) => {
+      const paths = e.payload;
+      try {
+        const fresh = await multimodalDrop(agent, paths, turnId);
+        setArtifacts((prev) => [...prev, ...fresh]);
+      } catch (err) {
+        console.warn("multimodal_drop failed:", err);
+      }
+    });
+    return () => {
+      u.then((un) => un()).catch(() => {});
+    };
+  }, [agent, turnId]);
+
+  useEffect(() => {
+    const onPaste = async (e: ClipboardEvent) => {
+      if (!e.clipboardData || e.clipboardData.files.length === 0) return;
+      e.preventDefault();
+      try {
+        const fresh = await multimodalPaste(agent, turnId);
+        setArtifacts((prev) => [...prev, ...fresh]);
+      } catch (err) {
+        console.warn("multimodal_paste failed:", err);
+      }
+    };
+    window.addEventListener("paste", onPaste);
+    return () => window.removeEventListener("paste", onPaste);
+  }, [agent, turnId]);
 
   // Apply the bundle's baked-in default theme on mount, so the
   // window picks up the colors chosen at `mur agent export --theme`.
@@ -139,6 +184,12 @@ export default function App() {
         </ul>
       </nav>
       <main className="flex-1 overflow-auto p-6">
+        <Thumbnails
+          artifacts={artifacts}
+          onRemove={(sha) =>
+            setArtifacts((prev) => prev.filter((a) => a.sha256 !== sha))
+          }
+        />
         {tab === "status" && <StatusTab />}
         {tab === "prompt" && <PromptTab />}
         {tab === "model" && <ModelTab />}
@@ -148,6 +199,7 @@ export default function App() {
         {tab === "permissions" && <PermissionsTab />}
         {tab === "identity" && <IdentityTab />}
       </main>
+      <DropOverlay />
       <PttButton
         onTranscript={(text) => {
           // For now, log + console. Future slices will wire this into

--- a/mur-agent-gui/ui/src/multimodal/DropOverlay.tsx
+++ b/mur-agent-gui/ui/src/multimodal/DropOverlay.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+
+/// Full-window dashed-border overlay that appears whenever the user
+/// is dragging files over the window. Pure visual — actual file
+/// processing fires from `App.tsx`'s `multimodal://drop` Tauri
+/// listener. Uses a counter so nested dragenter/dragleave events
+/// (which Webkit fires for every child element) don't flicker the
+/// overlay.
+export function DropOverlay() {
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    let counter = 0;
+    const enter = (e: DragEvent) => {
+      e.preventDefault();
+      counter += 1;
+      if (counter === 1) setActive(true);
+    };
+    const over = (e: DragEvent) => e.preventDefault();
+    const leave = (_e: DragEvent) => {
+      counter -= 1;
+      if (counter <= 0) {
+        counter = 0;
+        setActive(false);
+      }
+    };
+    const drop = (e: DragEvent) => {
+      e.preventDefault();
+      counter = 0;
+      setActive(false);
+    };
+    window.addEventListener("dragenter", enter);
+    window.addEventListener("dragover", over);
+    window.addEventListener("dragleave", leave);
+    window.addEventListener("drop", drop);
+    return () => {
+      window.removeEventListener("dragenter", enter);
+      window.removeEventListener("dragover", over);
+      window.removeEventListener("dragleave", leave);
+      window.removeEventListener("drop", drop);
+    };
+  }, []);
+
+  if (!active) return null;
+  return (
+    <div
+      role="presentation"
+      className="fixed inset-0 z-40 flex items-center justify-center pointer-events-none"
+      style={{ background: "rgba(0,0,0,0.35)" }}
+    >
+      <div
+        className="rounded-lg p-8 text-center"
+        style={{
+          border: "2px dashed var(--color-accent)",
+          background: "var(--color-bg)",
+          color: "var(--color-fg)",
+        }}
+      >
+        <div className="text-lg font-medium">Drop files to attach</div>
+        <div className="text-sm opacity-75 mt-1">
+          Up to 10 files, 30 MB total. Images and PDFs.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/mur-agent-gui/ui/src/multimodal/ThumbnailItem.tsx
+++ b/mur-agent-gui/ui/src/multimodal/ThumbnailItem.tsx
@@ -1,0 +1,41 @@
+import type { MultimodalArtifact } from "./types";
+
+interface Props {
+  artifact: MultimodalArtifact;
+  onRemove: (sha256: string) => void;
+}
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function ThumbnailItem({ artifact, onRemove }: Props) {
+  return (
+    <div
+      className="flex items-center gap-2 rounded border px-2 py-1 text-xs"
+      style={{
+        borderColor: "var(--color-border)",
+        background: "var(--color-bg-secondary)",
+      }}
+    >
+      <span aria-hidden="true">
+        {artifact.kind === "pdf" ? "PDF" : artifact.kind === "image" ? "IMG" : "TXT"}
+      </span>
+      <span className="opacity-75">{fmtBytes(artifact.size_bytes)}</span>
+      {artifact.page_count != null && (
+        <span className="opacity-75">{artifact.page_count} pp</span>
+      )}
+      <button
+        type="button"
+        aria-label="Remove attachment"
+        onClick={() => onRemove(artifact.sha256)}
+        className="ml-1"
+        style={{ color: "var(--color-fg)", opacity: 0.5 }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/mur-agent-gui/ui/src/multimodal/Thumbnails.tsx
+++ b/mur-agent-gui/ui/src/multimodal/Thumbnails.tsx
@@ -1,0 +1,18 @@
+import type { MultimodalArtifact } from "./types";
+import { ThumbnailItem } from "./ThumbnailItem";
+
+interface Props {
+  artifacts: MultimodalArtifact[];
+  onRemove: (sha256: string) => void;
+}
+
+export function Thumbnails({ artifacts, onRemove }: Props) {
+  if (artifacts.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1 p-2">
+      {artifacts.map((a) => (
+        <ThumbnailItem key={a.sha256} artifact={a} onRemove={onRemove} />
+      ))}
+    </div>
+  );
+}

--- a/mur-agent-gui/ui/src/multimodal/api.ts
+++ b/mur-agent-gui/ui/src/multimodal/api.ts
@@ -1,0 +1,8 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { MultimodalArtifact } from "./types";
+
+export const multimodalDrop = (agent: string, paths: string[], turnId: number) =>
+  invoke<MultimodalArtifact[]>("multimodal_drop", { agent, paths, turnId });
+
+export const multimodalPaste = (agent: string, turnId: number) =>
+  invoke<MultimodalArtifact[]>("multimodal_paste", { agent, turnId });

--- a/mur-agent-gui/ui/src/multimodal/types.ts
+++ b/mur-agent-gui/ui/src/multimodal/types.ts
@@ -1,0 +1,13 @@
+export type ArtifactKind = "image" | "pdf" | "text";
+
+export interface MultimodalArtifact {
+  sha256: string;
+  kind: ArtifactKind;
+  mime: string;
+  size_bytes: number;
+  ocr_text: string | null;
+  page_count: number | null;
+  created_at: string;
+  decoder_version: string;
+  ocr_engine_version: string | null;
+}


### PR DESCRIPTION
## Summary

Seventh milestone (M3.7) of the M3 D3 plan (#69). Lights up the user-visible side of the drag-drop pipeline: a full-window dashed overlay on drag-enter, an inline thumbnail strip above the composer, and App.tsx wiring that listens for the `multimodal://drop` Tauri event + window paste events.

## What's in

**M3.7.1** `a683eec` — `mur-agent-gui/ui/src/multimodal/{types,api}.ts`. `MultimodalArtifact` TS type mirrors the Rust struct field-for-field (snake_case wire format). `multimodalDrop` + `multimodalPaste` are thin `invoke<T>` wrappers.

**M3.7.2** `2b4c230` — `<DropOverlay />`. Full-window dashed border with the canonical Claude/ChatGPT/Cursor "Drop files to attach" copy. Counter-based show/hide so dragenter/dragleave on child elements doesn't flicker. `pointer-events-none` so the overlay doesn't intercept the drop event itself. Implementer fixed a TS6133 (unused param) error in the plan's reference snippet via `_e: DragEvent`.

**M3.7.3** `1b65634` — `<ThumbnailItem />` + `<Thumbnails />`. Per project convention: no emojis — plain text labels (`PDF` / `IMG` / `TXT`). Page count rendered inline for PDFs (`5 pp`). Remove button with `aria-label="Remove attachment"`. Theme tokens via `var(--color-*)`, not Tailwind colour classes.

**M3.7.4** `6086f4a` — App.tsx integration. Two `useEffect` hooks:
- Tauri `listen<string[]>("multimodal://drop", ...)` → `multimodalDrop(agent, paths, turnId)` → append to `artifacts`.
- Window `paste` event → `multimodalPaste(agent, turnId)` → append.

Both return cleanup. `<DropOverlay />` + `<Thumbnails />` rendered alongside the existing tabs.

`turnId` is held flat at `1` for now; rotating it on send is composer-integration work that follows.

## Tests

No unit tests for the React components — they're presentational and the integration is exercised through the M3.6 Tauri commands (5 tests passing on the parent branch). Build verifies type-check.

`cd mur-agent-gui/ui && npm run build` clean (60→64 modules; +2.75 KB raw JS / +0.75 KB gzipped).

## Stack

- #69 → #70 → #71 → #72 → #73 → #74 → #75 → **THIS** M3.7 → M3.8 (next, B0SafetyHook)

## Test plan

- [ ] `cd mur-agent-gui/ui && npm run build`
- [ ] Manual: launch the GUI, drag a PNG over the window, observe overlay + thumbnail
- [ ] Manual: paste an image, observe thumbnail

🤖 Generated with [Claude Code](https://claude.com/claude-code)