### PR TITLE
refactor(conversations): introduce ChatBackend trait (P0 of cloud-LLM rollout)

### DIFF
--- a/docs/superpowers/plans/2026-05-01-cloud-llm-backend-p0-plan.md
+++ b/docs/superpowers/plans/2026-05-01-cloud-llm-backend-p0-plan.md
@@ -1,0 +1,1136 @@
+# Cloud LLM Backend P0 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Introduce a `ChatBackend` trait inside `mur-core/src/conversations/backend/` with `OllamaBackend`, `MockBackend`, and `factory::build`, then refactor `ask::rewriter` to use it as the canary call site. **No user-visible behavior change** — all existing tests must pass byte-identically.
+
+**Architecture:** New `backend` module with a trait + 2 impls. `OllamaBackend` wraps the existing `OllamaClient`. `MockBackend` reuses the pattern-matching logic from `ollama.rs::mock_generate`. `factory::build` selects backend from `BackendConfig` (or env var for mock). `ask::rewriter::rewrite` is migrated from `&OllamaClient` to `&dyn ChatBackend` as proof the trait is right; remaining 9+ call sites stay on `OllamaClient` until P1.
+
+**Tech Stack:** Rust 2024 · `async-trait` (already in workspace deps via tonic transitive — verify in Task 0) · `tokio` · `tracing` · `anyhow` for application errors · `thiserror` for `BackendError` at the trait boundary. No new crates if `async-trait` is already available; otherwise +1 dep.
+
+**Spec:** `docs/superpowers/specs/2026-05-01-cloud-llm-backend-design.md` §3 (architecture), §4 (trait), §5.1 (OllamaBackend), §5.3 (MockBackend), §5.4 (factory). P1 (Anthropic backend, streaming, `BackendConfig` schema, doctor enhancements) is out of scope here.
+
+**Out of scope for P0:**
+- `AnthropicBackend` — P1
+- Streaming method on the trait — P2 (`generate_stream` returns `unimplemented!()` for OllamaBackend in P0; only the non-streaming path is exercised by `ask::rewriter`)
+- Retry envelope — P1 (Ollama + Mock don't need it; lift from `extract_llm.rs` when cloud lands)
+- Per-stage `BackendConfig` schema in `mur-common/src/config.rs` — P1
+- Migrating `compact`, `ask::generate`, `ask::abstractive`, `summarize::*` — P1/P2
+- Prompt caching, cost telemetry — P3
+
+---
+
+## Task 0: Verify dependencies and read existing code
+
+**Files:**
+- Read: `Cargo.toml` (workspace root), `mur-core/Cargo.toml`
+- Read: `mur-core/src/conversations/ollama.rs` (full file — 600+ lines)
+- Read: `mur-core/src/conversations/ask/rewriter.rs` (full file — 217 lines)
+- Read: `mur-core/src/conversations/mod.rs` (to confirm `ENV_LOCK` and module structure)
+
+**Step 1: Check whether `async-trait` is already a workspace dep**
+
+Run:
+```bash
+grep -rn "async-trait\|async_trait" /Users/david/Projects/mur/Cargo.toml /Users/david/Projects/mur/mur-core/Cargo.toml /Users/david/Projects/mur/mur-common/Cargo.toml
+```
+
+If `async-trait` is missing, add it to `mur-core/Cargo.toml` `[dependencies]` as `async-trait = "0.1"`. If already present (likely via a transitive workspace member), reuse.
+
+**Step 2: Confirm `tokio` is in `mur-core/Cargo.toml`**
+
+It is — tracing, anyhow, thiserror are all there too. Just confirm by `grep` so a missing dep doesn't bite us mid-task.
+
+**Step 3: Read the three files listed above end-to-end**
+
+Specifically note:
+- `OllamaClient::new` signature, `generate` request/response types, `mock_from_env` and `mock_generate`
+- `mock_generate`'s prompt-pattern dispatch (which prompt prefixes map to which canned responses)
+- `rewriter::rewrite` signature and the two existing tests (`empty_prior_turns_returns_identity_without_calling_ollama`, `connection_failure_returns_fallback_to_raw`)
+
+**Step 4: No commit** (this is a read-only context-loading task)
+
+---
+
+## Task 1: Create `backend` module skeleton + data types
+
+**Files:**
+- Create: `mur-core/src/conversations/backend/mod.rs`
+- Modify: `mur-core/src/conversations/mod.rs` (add `pub mod backend;`)
+
+**Step 1: Write the failing tests in a new test module at the bottom of `mod.rs`**
+
+Add to `mur-core/src/conversations/backend/mod.rs`:
+
+```rust
+//! ChatBackend trait and supporting types. See spec
+//! `docs/superpowers/specs/2026-05-01-cloud-llm-backend-design.md` §4.
+
+#![allow(dead_code)] // wired progressively across P0 tasks.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use anyhow::Result;
+use futures::stream::Stream;
+use serde::Serialize;
+
+/// Per-call request to a chat-completion backend. Borrows where it can —
+/// callers typically hold owned strings and pass &str.
+#[derive(Debug, Clone)]
+pub struct ChatRequest<'a> {
+    pub model: &'a str,
+    pub system: Option<&'a str>,
+    pub user: &'a str,
+    pub max_tokens: u32,
+    pub temperature: Option<f32>,
+    pub stop: Vec<String>,
+    /// Anthropic prompt-caching hint for the system prompt. Ignored by
+    /// backends where `supports_caching()` is false.
+    pub cache_system: bool,
+    /// Anthropic prompt-caching hint: split `user` at this byte offset and
+    /// place a cache_control breakpoint after the prefix. Ignored when
+    /// `supports_caching()` is false. P0 stub only — wiring lands in P3.
+    pub cache_user_prefix: Option<usize>,
+}
+
+/// Non-streaming response. `text` is the model output; `usage` reports
+/// per-call token accounting (cache fields are 0 on non-caching backends).
+#[derive(Debug, Clone)]
+pub struct ChatResponse {
+    pub text: String,
+    pub usage: Usage,
+}
+
+/// Per-call token accounting. Both Anthropic-specific cache fields are
+/// always present and default to 0 on non-Anthropic backends — keeps
+/// downstream serialization shape uniform.
+#[derive(Debug, Clone, Serialize)]
+pub struct Usage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_input_tokens: u64,
+    pub cache_read_input_tokens: u64,
+    pub provider: &'static str,
+    pub model: String,
+}
+
+/// Streaming chunk. `delta` is the incremental token payload (may be empty
+/// on the final chunk). `usage` is `Some` ONLY on the final chunk.
+#[derive(Debug, Clone)]
+pub struct ChatChunk {
+    pub delta: String,
+    pub usage: Option<Usage>,
+}
+
+/// Type alias for the boxed stream of chunks returned by `generate_stream`.
+pub type ChatStream = Pin<Box<dyn Stream<Item = Result<ChatChunk>> + Send>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chat_request_builds_with_required_fields() {
+        let req = ChatRequest {
+            model: "test-model",
+            system: Some("you are a tester"),
+            user: "hello",
+            max_tokens: 16,
+            temperature: None,
+            stop: vec![],
+            cache_system: false,
+            cache_user_prefix: None,
+        };
+        assert_eq!(req.user, "hello");
+        assert_eq!(req.model, "test-model");
+    }
+
+    #[test]
+    fn usage_serializes_with_zero_cache_fields_on_non_anthropic() {
+        let u = Usage {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            provider: "ollama",
+            model: "qwen3:14b".into(),
+        };
+        let json = serde_json::to_string(&u).unwrap();
+        assert!(json.contains("\"cache_read_input_tokens\":0"));
+        assert!(json.contains("\"provider\":\"ollama\""));
+    }
+}
+```
+
+Modify `mur-core/src/conversations/mod.rs` — add line near other `pub mod` declarations:
+
+```rust
+pub mod backend;
+```
+
+**Step 2: Run tests to confirm they fail to compile**
+
+Run: `cargo test -p mur-core --lib conversations::backend -- --nocapture`
+
+Expected: FAIL — file/module doesn't exist yet (you wrote tests but nothing compiles past the missing imports). If `futures` isn't already a dep, this fails on the `Stream` import.
+
+**Step 3: Verify `futures` is available**
+
+Run: `grep '^futures' /Users/david/Projects/mur/mur-core/Cargo.toml`
+
+Expected: a line like `futures = "0.3"` (it's already used by `ollama.rs`). If absent, add it.
+
+**Step 4: Re-run tests to verify they pass**
+
+Run: `cargo test -p mur-core --lib conversations::backend -- --nocapture`
+
+Expected: PASS — both `chat_request_builds_with_required_fields` and `usage_serializes_with_zero_cache_fields_on_non_anthropic`.
+
+**Step 5: Lint and format**
+
+Run:
+```bash
+cargo fmt --check && cargo clippy -p mur-core --lib -- -D warnings
+```
+
+Expected: clean (no diff from fmt, no clippy warnings).
+
+**Step 6: Commit**
+
+```bash
+git add mur-core/src/conversations/backend/mod.rs mur-core/src/conversations/mod.rs
+git commit -m "feat(backend): scaffold ChatBackend module with request/response types
+
+Introduces the data-only surface (ChatRequest, ChatResponse, Usage,
+ChatChunk, ChatStream) for the new conversations::backend module.
+Trait and impls land in subsequent commits. No call sites changed.
+
+Refs spec docs/superpowers/specs/2026-05-01-cloud-llm-backend-design.md §4.2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Define `ChatBackend` trait + `BackendError` enum
+
+**Files:**
+- Modify: `mur-core/src/conversations/backend/mod.rs`
+
+**Step 1: Add the failing test for trait-object compatibility**
+
+Append to the `tests` module in `mod.rs`:
+
+```rust
+    #[test]
+    fn chat_backend_is_object_safe() {
+        // Compile-time check: ChatBackend must be usable as `dyn ChatBackend`.
+        // If this fails to compile, the trait broke object safety
+        // (e.g. someone added a generic method or `Self: Sized` bound).
+        fn _accepts(_: &dyn ChatBackend) {}
+    }
+
+    #[test]
+    fn backend_error_displays_with_provider_name() {
+        let e = BackendError::Unauthorized { provider: "anthropic" };
+        let msg = format!("{e}");
+        assert!(msg.contains("anthropic"));
+        assert!(msg.contains("401"));
+    }
+```
+
+**Step 2: Run tests to confirm compile failure**
+
+Run: `cargo test -p mur-core --lib conversations::backend`
+
+Expected: FAIL — `ChatBackend` and `BackendError` not defined.
+
+**Step 3: Add the trait and error enum to `mod.rs`**
+
+Insert before the `#[cfg(test)]` block:
+
+```rust
+/// Backend-agnostic chat-completion interface.
+///
+/// Backends MUST be object-safe (no generics on methods, no `Self: Sized`).
+/// Both methods are async via `async-trait`. `generate_stream` MAY return
+/// a single-chunk stream when the backend doesn't natively stream
+/// (e.g. P0 OllamaBackend stubs `generate_stream` to `unimplemented!()` —
+/// only the non-streaming path is exercised in P0).
+#[async_trait::async_trait]
+pub trait ChatBackend: Send + Sync {
+    async fn generate(&self, req: ChatRequest<'_>) -> Result<ChatResponse>;
+
+    async fn generate_stream(&self, req: ChatRequest<'_>) -> Result<ChatStream>;
+
+    fn provider_name(&self) -> &'static str;
+
+    /// True when the backend honors `cache_system` / `cache_user_prefix`
+    /// hints. False = hints are silently ignored. Default: false.
+    fn supports_caching(&self) -> bool {
+        false
+    }
+}
+
+/// Typed errors at the backend boundary. Backend impls construct these
+/// and convert via `anyhow::Error::from(...)` so callers see anyhow
+/// chains but can still downcast for retry-policy decisions.
+///
+/// See spec §4.3.
+#[derive(Debug, thiserror::Error)]
+pub enum BackendError {
+    #[error("provider {provider} returned 401: invalid or missing API key")]
+    Unauthorized { provider: &'static str },
+
+    #[error("provider {provider} returned 429: rate limited (retry-after: {retry_after_secs:?}s)")]
+    RateLimited {
+        provider: &'static str,
+        retry_after_secs: Option<u64>,
+    },
+
+    #[error("provider {provider} returned {status}: server error")]
+    ServerError {
+        provider: &'static str,
+        status: u16,
+    },
+
+    #[error("provider {provider} model {model} not found")]
+    ModelNotFound {
+        provider: &'static str,
+        model: String,
+    },
+
+    #[error("provider {provider} timed out after {seconds}s")]
+    Timeout {
+        provider: &'static str,
+        seconds: u64,
+    },
+
+    #[error("network error talking to {provider}: {source}")]
+    Network {
+        provider: &'static str,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    #[error("malformed response from {provider}: {message}")]
+    BadResponse {
+        provider: &'static str,
+        message: String,
+    },
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cargo test -p mur-core --lib conversations::backend`
+
+Expected: PASS — `chat_backend_is_object_safe` compiles, `backend_error_displays_with_provider_name` produces a message containing "anthropic" and "401".
+
+**Step 5: Lint and format**
+
+Run:
+```bash
+cargo fmt --check && cargo clippy -p mur-core --lib -- -D warnings
+```
+
+Expected: clean.
+
+**Step 6: Commit**
+
+```bash
+git add mur-core/src/conversations/backend/mod.rs
+git commit -m "feat(backend): add ChatBackend trait and BackendError enum
+
+Object-safe async trait with generate, generate_stream, provider_name,
+and supports_caching default-false. BackendError uses thiserror with
+named-field variants per project convention (no catch-all Other variant).
+
+Refs spec §4.1 / §4.3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Implement `MockBackend`
+
+**Files:**
+- Create: `mur-core/src/conversations/backend/mock.rs`
+- Modify: `mur-core/src/conversations/backend/mod.rs` (add `pub mod mock;`)
+
+**Step 1: Read the existing `mock_generate` function**
+
+Run: `sed -n '260,330p' /Users/david/Projects/mur/mur-core/src/conversations/ollama.rs`
+
+This is the pattern dispatcher we're going to adapt — note which prompt prefixes route to which canned responses. **Do not modify** `ollama.rs::mock_generate` — `OllamaBackend` will continue to use it via `OllamaClient` until everything else also moves to `ChatBackend`.
+
+**Step 2: Write the failing tests for MockBackend**
+
+Create `mur-core/src/conversations/backend/mock.rs` with:
+
+```rust
+//! Test-only ChatBackend that returns pattern-matched canned responses.
+//! Reuses the prompt-dispatch logic from `ollama.rs::mock_generate` —
+//! activated by `MUR_LLM_MOCK=1` (preferred) or `MUR_OLLAMA_MOCK=1` (legacy).
+//!
+//! See spec §5.3.
+
+#![allow(dead_code)] // wired by factory in Task 5.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::stream;
+
+use super::{ChatBackend, ChatChunk, ChatRequest, ChatResponse, ChatStream, Usage};
+
+pub struct MockBackend;
+
+impl MockBackend {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for MockBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ChatBackend for MockBackend {
+    async fn generate(&self, req: ChatRequest<'_>) -> Result<ChatResponse> {
+        // Reuse the existing pattern dispatcher. ollama::mock_generate takes
+        // a GenerateRequest, so build one from our ChatRequest.
+        use crate::conversations::ollama::{GenerateOptions, GenerateRequest};
+        let g_req = GenerateRequest {
+            model: req.model,
+            prompt: req.user,
+            system: req.system,
+            stream: false,
+            options: GenerateOptions {
+                temperature: req.temperature,
+                top_p: None,
+                num_predict: Some(req.max_tokens),
+                stop: req.stop.clone(),
+            },
+        };
+        let g_resp = crate::conversations::ollama::mock_generate(&g_req);
+        Ok(ChatResponse {
+            text: g_resp.response,
+            usage: Usage {
+                input_tokens: g_resp.prompt_eval_count,
+                output_tokens: g_resp.eval_count,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                provider: "mock",
+                model: req.model.to_string(),
+            },
+        })
+    }
+
+    async fn generate_stream(&self, req: ChatRequest<'_>) -> Result<ChatStream> {
+        // Mock streaming = single-chunk stream containing the full mock response.
+        let resp = self.generate(req).await?;
+        let final_chunk = ChatChunk {
+            delta: resp.text.clone(),
+            usage: Some(resp.usage),
+        };
+        Ok(Box::pin(stream::iter(vec![Ok(final_chunk)])))
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "mock"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    fn req<'a>(prompt: &'a str) -> ChatRequest<'a> {
+        ChatRequest {
+            model: "mock-model",
+            system: None,
+            user: prompt,
+            max_tokens: 100,
+            temperature: None,
+            stop: vec![],
+            cache_system: false,
+            cache_user_prefix: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn generate_returns_text_and_usage() {
+        let b = MockBackend::new();
+        let r = b.generate(req("hello")).await.unwrap();
+        // Mock returns *some* text — exact content depends on prompt patterns
+        // in ollama::mock_generate. The contract here is just non-empty.
+        assert!(!r.text.is_empty());
+        assert_eq!(r.usage.provider, "mock");
+        assert_eq!(r.usage.model, "mock-model");
+    }
+
+    #[tokio::test]
+    async fn generate_stream_emits_single_chunk_with_usage() {
+        let b = MockBackend::new();
+        let mut stream = b.generate_stream(req("hello")).await.unwrap();
+        let first = stream.next().await.unwrap().unwrap();
+        assert!(!first.delta.is_empty());
+        assert!(first.usage.is_some());
+        assert!(stream.next().await.is_none(), "should be a single-chunk stream");
+    }
+
+    #[test]
+    fn provider_name_is_mock() {
+        assert_eq!(MockBackend::new().provider_name(), "mock");
+    }
+}
+```
+
+Append to `mur-core/src/conversations/backend/mod.rs`:
+
+```rust
+pub mod mock;
+```
+
+**Step 3: Check whether `ollama::mock_generate` is `pub(crate)` or private**
+
+Run: `grep -n "fn mock_generate" /Users/david/Projects/mur/mur-core/src/conversations/ollama.rs`
+
+If it's `fn mock_generate` (private), change it to `pub(crate) fn mock_generate` so `backend::mock` can call it. Same for `GenerateRequest` / `GenerateOptions` if they aren't already crate-visible.
+
+**Step 4: Run tests**
+
+Run: `cargo test -p mur-core --lib conversations::backend::mock`
+
+Expected: PASS for all three tests.
+
+**Step 5: Lint and format**
+
+Run:
+```bash
+cargo fmt --check && cargo clippy -p mur-core --lib -- -D warnings
+```
+
+Expected: clean.
+
+**Step 6: Commit**
+
+```bash
+git add mur-core/src/conversations/backend/mock.rs mur-core/src/conversations/backend/mod.rs mur-core/src/conversations/ollama.rs
+git commit -m "feat(backend): add MockBackend reusing ollama::mock_generate
+
+Test-only ChatBackend impl. Adapts ChatRequest <-> GenerateRequest and
+delegates pattern matching to the existing ollama::mock_generate. Single-
+chunk generate_stream that emits the full mock response with usage.
+
+Visibility bump on ollama::{mock_generate, GenerateRequest, GenerateOptions}
+from private to pub(crate). Behavior unchanged for existing callers.
+
+Refs spec §5.3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Implement `OllamaBackend`
+
+**Files:**
+- Create: `mur-core/src/conversations/backend/ollama.rs`
+- Modify: `mur-core/src/conversations/backend/mod.rs` (add `pub mod ollama;`)
+
+**Step 1: Write the failing test**
+
+Create `mur-core/src/conversations/backend/ollama.rs`:
+
+```rust
+//! Adapter wrapping the existing OllamaClient as a ChatBackend.
+//! See spec §5.1.
+
+#![allow(dead_code)] // wired by factory in Task 5.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::conversations::ollama::{GenerateOptions, GenerateRequest, OllamaClient};
+
+use super::{ChatBackend, ChatChunk, ChatRequest, ChatResponse, ChatStream, Usage};
+
+pub struct OllamaBackend {
+    client: OllamaClient,
+}
+
+impl OllamaBackend {
+    pub fn new(endpoint: &str, timeout: Duration) -> Self {
+        Self {
+            client: OllamaClient::new(endpoint, timeout),
+        }
+    }
+}
+
+#[async_trait]
+impl ChatBackend for OllamaBackend {
+    async fn generate(&self, req: ChatRequest<'_>) -> Result<ChatResponse> {
+        let g_req = GenerateRequest {
+            model: req.model,
+            prompt: req.user,
+            system: req.system,
+            stream: false,
+            options: GenerateOptions {
+                temperature: req.temperature,
+                top_p: None,
+                num_predict: Some(req.max_tokens),
+                stop: req.stop.clone(),
+            },
+        };
+        let resp = self.client.generate(g_req).await?;
+        Ok(ChatResponse {
+            text: resp.response,
+            usage: Usage {
+                input_tokens: resp.prompt_eval_count,
+                output_tokens: resp.eval_count,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                provider: "ollama",
+                model: req.model.to_string(),
+            },
+        })
+    }
+
+    async fn generate_stream(&self, _req: ChatRequest<'_>) -> Result<ChatStream> {
+        // P0: streaming through the trait is not yet wired. The existing
+        // OllamaClient::generate_stream is still used directly by ask::generate.
+        // This becomes real in P2 when ask::generate migrates onto the trait.
+        anyhow::bail!("OllamaBackend::generate_stream not wired in P0")
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "ollama"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conversations::backend::ChatBackend;
+
+    #[test]
+    fn provider_name_is_ollama() {
+        let b = OllamaBackend::new("http://127.0.0.1:1", Duration::from_millis(100));
+        assert_eq!(b.provider_name(), "ollama");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn generate_propagates_connection_failure() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+        unsafe { std::env::remove_var("MUR_LLM_MOCK") };
+        let b = OllamaBackend::new("http://127.0.0.1:1", Duration::from_millis(200));
+        let req = ChatRequest {
+            model: "qwen3:14b",
+            system: None,
+            user: "hi",
+            max_tokens: 16,
+            temperature: None,
+            stop: vec![],
+            cache_system: false,
+            cache_user_prefix: None,
+        };
+        let r = b.generate(req).await;
+        assert!(r.is_err(), "unreachable endpoint should error");
+    }
+
+    #[tokio::test]
+    async fn generate_stream_returns_unimplemented_error_in_p0() {
+        let b = OllamaBackend::new("http://127.0.0.1:1", Duration::from_millis(100));
+        let req = ChatRequest {
+            model: "qwen3:14b",
+            system: None,
+            user: "hi",
+            max_tokens: 16,
+            temperature: None,
+            stop: vec![],
+            cache_system: false,
+            cache_user_prefix: None,
+        };
+        let r = b.generate_stream(req).await;
+        assert!(r.is_err());
+        assert!(format!("{:#}", r.unwrap_err()).contains("not wired in P0"));
+    }
+}
+```
+
+Append to `mur-core/src/conversations/backend/mod.rs`:
+
+```rust
+pub mod ollama;
+```
+
+**Step 2: Run tests to confirm they fail**
+
+Run: `cargo test -p mur-core --lib conversations::backend::ollama`
+
+Expected: FAIL — likely on `ENV_LOCK` not being `pub(crate)`.
+
+**Step 3: Make `ENV_LOCK` crate-visible if needed**
+
+Run: `grep -n "ENV_LOCK" /Users/david/Projects/mur/mur-core/src/conversations/mod.rs`
+
+Adjust visibility to `pub(crate) static ENV_LOCK: ...` if currently private.
+
+**Step 4: Re-run tests**
+
+Run: `cargo test -p mur-core --lib conversations::backend::ollama`
+
+Expected: PASS.
+
+**Step 5: Lint and format**
+
+Run:
+```bash
+cargo fmt --check && cargo clippy -p mur-core --lib -- -D warnings
+```
+
+Expected: clean.
+
+**Step 6: Commit**
+
+```bash
+git add mur-core/src/conversations/backend/ollama.rs mur-core/src/conversations/backend/mod.rs mur-core/src/conversations/mod.rs
+git commit -m "feat(backend): add OllamaBackend adapter over OllamaClient
+
+Wraps existing OllamaClient. generate() forwards through; generate_stream()
+intentionally bails in P0 (no callers on the trait path yet — ask::generate
+still uses OllamaClient::generate_stream directly until P2).
+
+Visibility bump on conversations::ENV_LOCK to pub(crate) so backend tests
+can serialize env-var mutation against existing test code.
+
+Refs spec §5.1.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Implement `factory::build`
+
+**Files:**
+- Create: `mur-core/src/conversations/backend/factory.rs`
+- Modify: `mur-core/src/conversations/backend/mod.rs` (add `pub mod factory;`)
+
+**Step 1: Write the failing tests**
+
+Create `mur-core/src/conversations/backend/factory.rs`:
+
+```rust
+//! ChatBackend factory. Selects backend from a thin BackendSpec
+//! (P0 minimal — full BackendConfig schema lands in P1).
+//!
+//! See spec §5.4.
+
+#![allow(dead_code)] // wired into ask::rewriter in Task 6.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+
+use super::{
+    mock::MockBackend, ollama::OllamaBackend, ChatBackend,
+};
+
+/// P0 minimal backend specification. Will be replaced by the full
+/// BackendConfig struct from `mur-common` in P1, when per-stage
+/// schema lands. Kept local here so P0 doesn't touch mur-common.
+#[derive(Debug, Clone)]
+pub struct BackendSpec {
+    pub provider: String,
+    pub endpoint: Option<String>,
+    pub timeout_secs: Option<u64>,
+}
+
+impl BackendSpec {
+    pub fn ollama(endpoint: impl Into<String>, timeout_secs: u64) -> Self {
+        Self {
+            provider: "ollama".into(),
+            endpoint: Some(endpoint.into()),
+            timeout_secs: Some(timeout_secs),
+        }
+    }
+}
+
+/// Build a backend from spec. Honors MUR_LLM_MOCK / MUR_OLLAMA_MOCK
+/// env vars: when either is set, returns MockBackend regardless of spec.
+pub fn build(spec: &BackendSpec) -> Result<Arc<dyn ChatBackend>> {
+    if std::env::var("MUR_LLM_MOCK").is_ok() || std::env::var("MUR_OLLAMA_MOCK").is_ok() {
+        tracing::debug!(provider = %spec.provider, "MUR_LLM_MOCK active — using MockBackend");
+        return Ok(Arc::new(MockBackend::new()));
+    }
+    match spec.provider.as_str() {
+        "ollama" => {
+            let endpoint = spec.endpoint.as_deref().unwrap_or("http://localhost:11434");
+            let timeout = Duration::from_secs(spec.timeout_secs.unwrap_or(120));
+            Ok(Arc::new(OllamaBackend::new(endpoint, timeout)))
+        }
+        other => bail!("unsupported provider in P0: {other} (anthropic lands in P1)"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn mock_env_var_forces_mock_backend() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_LLM_MOCK", "1") };
+        let spec = BackendSpec::ollama("http://localhost:11434", 5);
+        let b = build(&spec).unwrap();
+        assert_eq!(b.provider_name(), "mock");
+        unsafe { std::env::remove_var("MUR_LLM_MOCK") };
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn legacy_mur_ollama_mock_env_var_also_forces_mock() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("MUR_LLM_MOCK") };
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let spec = BackendSpec::ollama("http://localhost:11434", 5);
+        let b = build(&spec).unwrap();
+        assert_eq!(b.provider_name(), "mock");
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn ollama_provider_returns_ollama_backend() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("MUR_LLM_MOCK") };
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+        let spec = BackendSpec::ollama("http://127.0.0.1:1", 1);
+        let b = build(&spec).unwrap();
+        assert_eq!(b.provider_name(), "ollama");
+    }
+
+    #[test]
+    fn unsupported_provider_errors() {
+        let spec = BackendSpec {
+            provider: "openai".into(),
+            endpoint: None,
+            timeout_secs: None,
+        };
+        let r = build(&spec);
+        assert!(r.is_err());
+        assert!(format!("{:#}", r.unwrap_err()).contains("unsupported"));
+    }
+}
+```
+
+Append to `mur-core/src/conversations/backend/mod.rs`:
+
+```rust
+pub mod factory;
+```
+
+**Step 2: Run tests**
+
+Run: `cargo test -p mur-core --lib conversations::backend::factory -- --test-threads=1`
+
+(`--test-threads=1` because the env-var tests serialize on `ENV_LOCK` and we want deterministic interleaving.)
+
+Expected: PASS for all four tests.
+
+**Step 3: Run the full backend test suite to confirm no cross-test leakage**
+
+Run: `cargo test -p mur-core --lib conversations::backend -- --test-threads=1`
+
+Expected: all backend tests pass.
+
+**Step 4: Lint and format**
+
+Run:
+```bash
+cargo fmt --check && cargo clippy -p mur-core --lib -- -D warnings
+```
+
+Expected: clean.
+
+**Step 5: Commit**
+
+```bash
+git add mur-core/src/conversations/backend/factory.rs mur-core/src/conversations/backend/mod.rs
+git commit -m "feat(backend): add factory::build with mock env-var detection
+
+BackendSpec is the P0-minimal stand-in for the full BackendConfig schema
+(P1). MUR_LLM_MOCK and legacy MUR_OLLAMA_MOCK both activate MockBackend
+regardless of provider. Anthropic provider returns 'unsupported in P0' —
+slot reserved for P1.
+
+Refs spec §5.4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Refactor `ask::rewriter` to use `ChatBackend`
+
+**Files:**
+- Modify: `mur-core/src/conversations/ask/rewriter.rs`
+- Modify: `mur-core/src/cmd/conversations_cmd.rs` (only the rewriter call site at line 1160-1163)
+
+**Step 1: Re-read the existing rewriter contract**
+
+Run: `cat /Users/david/Projects/mur/mur-core/src/conversations/ask/rewriter.rs`
+
+Note:
+- `pub async fn rewrite(client: &OllamaClient, model: &str, input: RewriteInput<'_>) -> RewriteResult`
+- Two existing tests use real `OllamaClient::new(unreachable_url)` to test fallback
+- The contract preserves: `RewriteInput { prior_turns, raw_question }` → `RewriteResult { rewritten, status }`
+
+Goal: change the first param to `&dyn ChatBackend` while preserving every other behavior.
+
+**Step 2: Modify the test signatures FIRST (TDD — drive the API change from the tests)**
+
+In `mur-core/src/conversations/ask/rewriter.rs`, replace the two `#[tokio::test]` blocks at lines ~188–215:
+
+```rust
+    #[tokio::test]
+    async fn empty_prior_turns_returns_identity_without_calling_backend() {
+        // Use OllamaBackend pointing at unreachable endpoint — if we
+        // accidentally call it, we'd get a connection error. The empty-
+        // prior-turns short-circuit should fire before any backend call.
+        use crate::conversations::backend::ollama::OllamaBackend;
+        let backend = OllamaBackend::new("http://127.0.0.1:1", Duration::from_millis(100));
+        let input = RewriteInput {
+            prior_turns: &[],
+            raw_question: "what did I ship?",
+        };
+        let r = rewrite(&backend, "qwen3:14b", input).await;
+        assert_eq!(r.status, RewriterStatus::Skipped);
+        assert_eq!(r.rewritten, "what did I ship?");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn connection_failure_returns_fallback_to_raw() {
+        use crate::conversations::backend::ollama::OllamaBackend;
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+        unsafe { std::env::remove_var("MUR_LLM_MOCK") };
+        let backend = OllamaBackend::new("http://127.0.0.1:1", Duration::from_millis(200));
+        let turns = vec![trec(1, "first q", "first a")];
+        let input = RewriteInput {
+            prior_turns: &turns,
+            raw_question: "follow up",
+        };
+        let r = rewrite(&backend, "qwen3:14b", input).await;
+        assert_eq!(r.status, RewriterStatus::FailedFellBackToRaw);
+        assert_eq!(r.rewritten, "follow up");
+    }
+```
+
+**Step 3: Run the tests to confirm they fail to compile**
+
+Run: `cargo test -p mur-core --lib conversations::ask::rewriter`
+
+Expected: FAIL — `rewrite` still takes `&OllamaClient`, not `&OllamaBackend`.
+
+**Step 4: Update the `rewrite` signature and body**
+
+Replace lines 1-110ish of `rewriter.rs`. Specifically:
+
+- Remove the `use crate::conversations::ollama::{GenerateOptions, GenerateRequest, OllamaClient};` import
+- Add `use crate::conversations::backend::{ChatBackend, ChatRequest};`
+- Change the function signature from `pub async fn rewrite(client: &OllamaClient, model: &str, input: RewriteInput<'_>) -> RewriteResult` to `pub async fn rewrite(backend: &dyn ChatBackend, model: &str, input: RewriteInput<'_>) -> RewriteResult`
+- Change the call body from `client.generate(GenerateRequest { ... }).await` to:
+
+```rust
+    let resp = backend
+        .generate(ChatRequest {
+            model,
+            user: &prompt,
+            system: None,
+            max_tokens: 80,
+            temperature: Some(0.1),
+            stop: vec!["\n".into()],
+            cache_system: false,
+            cache_user_prefix: None,
+        })
+        .await;
+```
+
+- Change `Ok(r) => { let trimmed = r.response.trim().to_string(); ... }` to `Ok(r) => { let trimmed = r.text.trim().to_string(); ... }` (field rename `response` → `text`)
+
+**Step 5: Update the production call site**
+
+In `mur-core/src/cmd/conversations_cmd.rs`, find the rewriter setup at lines 1160-1163:
+
+```rust
+    let rewriter_client = OllamaClient::new(
+        &ask_cfg.ollama_endpoint,
+        std::time::Duration::from_secs(ask_cfg.rewriter_timeout_secs as u64),
+    );
+    let rewrite = ask::rewriter::rewrite(
+        &rewriter_client,
+        &model,
+        ...
+    ).await;
+```
+
+Replace with:
+
+```rust
+    let rewriter_backend = crate::conversations::backend::factory::build(
+        &crate::conversations::backend::factory::BackendSpec::ollama(
+            &ask_cfg.ollama_endpoint,
+            ask_cfg.rewriter_timeout_secs as u64,
+        ),
+    )?;
+    let rewrite = ask::rewriter::rewrite(
+        rewriter_backend.as_ref(),
+        &model,
+        ...
+    ).await;
+```
+
+(`as_ref()` deref-coerces `Arc<dyn ChatBackend>` to `&dyn ChatBackend`.)
+
+You may need to drop the `use crate::conversations::ollama::OllamaClient;` import in `conversations_cmd.rs` — only if no other call site in this file still uses it. Check: `grep -c OllamaClient /Users/david/Projects/mur/mur-core/src/cmd/conversations_cmd.rs`. If 0 after the edit, remove the import.
+
+**Step 6: Re-run rewriter tests**
+
+Run: `cargo test -p mur-core --lib conversations::ask::rewriter -- --test-threads=1`
+
+Expected: PASS for both `empty_prior_turns_returns_identity_without_calling_backend` and `connection_failure_returns_fallback_to_raw`.
+
+**Step 7: Run the full conversations test suite to catch regressions**
+
+Run: `cargo test -p mur-core --lib conversations -- --test-threads=1`
+
+Expected: PASS — no other test references `rewrite`'s old signature.
+
+**Step 8: Run integration tests**
+
+Run: `cargo test -p mur-core --test cli_conversations -- --test-threads=1`
+
+Expected: PASS — `test_ask_basic` and friends should still work because the rewriter behavior is byte-identical.
+
+**Step 9: Lint and format**
+
+Run:
+```bash
+cargo fmt --check && cargo clippy --workspace -- -D warnings
+```
+
+Expected: clean.
+
+**Step 10: Commit**
+
+```bash
+git add mur-core/src/conversations/ask/rewriter.rs mur-core/src/cmd/conversations_cmd.rs
+git commit -m "refactor(ask): migrate rewriter to ChatBackend trait
+
+ask::rewriter::rewrite now takes &dyn ChatBackend instead of &OllamaClient.
+Production call site in cmd_ask uses backend::factory::build to construct
+the backend (currently always Ollama in P0; P1 will plumb provider config).
+
+Behavior is byte-identical: same prompt template, same num_predict=80,
+same stop="\\n", same fallback-to-raw on error. Existing rewriter tests
+preserved with updated imports.
+
+This is the P0 canary for the new trait — remaining call sites
+(compact, ask::generate, ask::abstractive, summarize::*) migrate in P1/P2.
+
+Refs spec §3 (call-site refactor list) and plan task 6.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: End-to-end smoke verify and final report
+
+**Files:** none modified
+
+**Step 1: Full workspace build**
+
+Run: `cargo build --workspace`
+
+Expected: clean build, no warnings.
+
+**Step 2: Full test suite**
+
+Run: `cargo test --workspace -- --test-threads=1`
+
+Expected: all tests pass. (Use `--test-threads=1` to keep `ENV_LOCK`-serialized tests deterministic.)
+
+**Step 3: Workspace-wide clippy + fmt**
+
+Run:
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: both clean.
+
+**Step 4: Smoke test the actual `ask` command with mock**
+
+Run:
+```bash
+MUR_LLM_MOCK=1 cargo run --bin mur -- conversations ask "what did I ship today?" 2>&1 | head -20
+```
+
+Expected: command exits 0, produces some mock output. (Exact text depends on `mock_generate`'s pattern matching for `qa` prompts — verify it doesn't error.)
+
+**Step 5: Verify the legacy mock env var still works**
+
+Run:
+```bash
+MUR_OLLAMA_MOCK=1 cargo run --bin mur -- conversations ask "what did I ship today?" 2>&1 | head -20
+```
+
+Expected: same behavior as Step 4 — both env vars activate MockBackend.
+
+**Step 6: No new commit** — this is verification only. If anything fails, return to the relevant earlier task and fix.
+
+**Step 7: Report what was done**
+
+Summarize for the human reviewer:
+- 6 commits on this branch
+- New module: `mur-core/src/conversations/backend/{mod,mock,ollama,factory}.rs` (~400 LOC including tests)
+- One refactored call site: `ask::rewriter`
+- Test count delta: +12 unit tests, 0 removed
+- Behavior: byte-identical for `ask` command (rewriter uses same prompt, same options)
+- What's NOT done (deferred to P1+): AnthropicBackend, streaming on the trait, BackendConfig schema in mur-common, doctor enhancements, cost telemetry, migration of remaining 9+ call sites
+
+---
+
+## Out of scope — explicitly deferred
+
+Do **not** do any of these in P0. Each is a P1+ phase per spec §12:
+
+- **`AnthropicBackend`** — P1 (~250 LOC, raw HTTP via reqwest, SSE streaming)
+- **`BackendConfig` in `mur-common/src/config.rs`** — P1 (per-stage routing schema)
+- **Migrate `compact::extractive` / `compact::abstractive`** — P1 (canary cloud call site)
+- **`generate_stream` real impl on `OllamaBackend`** — P2 (when `ask::generate` migrates)
+- **Migrate `ask::generate`, `ask::abstractive`, `summarize::rollup`** — P1/P2
+- **Retry envelope** — P1 (lift from `extract_llm.rs`)
+- **Doctor cloud-provider checks** — P1
+- **Prompt caching wiring** — P3
+- **Cost telemetry, `cost-report` command** — P3
+- **Migrate `learn` / `extract_llm` onto `ChatBackend`, delete `llm.rs`** — P4
+
+If an instruction in this plan tempts you to touch these, **stop and ask** — it means the plan is wrong, not that you should do extra work.

--- a/docs/superpowers/specs/2026-05-01-cloud-llm-backend-design.md
+++ b/docs/superpowers/specs/2026-05-01-cloud-llm-backend-design.md
@@ -1,0 +1,529 @@
+# mur Conversations — Cloud LLM Backend Design
+
+**Status:** Draft 2026-05-01
+**Depends on:** Phase 3.5.1 shipped (current `compact` + `ask` pipeline using Ollama only).
+**Replaces:** Hardcoded Ollama-only paths in `mur-core/src/conversations/{summarize,ask}/`.
+
+---
+
+## 1. Purpose
+
+`mur conversations compact` and `mur conversations ask` currently call only `OllamaClient` (`mur-core/src/conversations/ollama.rs`). When `qwen3:14b` (the configured default) is not pulled locally, both commands fail with an Ollama 404 — there is no fallback. Users without 12+ GB of RAM available for a local 14B model are effectively locked out of these features.
+
+This design adds a `ChatBackend` trait and a Claude API (Anthropic) implementation alongside the existing Ollama backend, with **per-stage routing** so the user can mix providers (e.g. Haiku for extractive, Sonnet for ask, local Ollama for the cheap rewriter step). It does **not** remove the Ollama path — local-first remains the default, cloud is opt-in.
+
+mur already has `mur-core/src/llm.rs::llm_complete()` for `learn`/`extract_llm` (Anthropic / OpenAI / Gemini / OpenRouter / Ollama, non-streaming). That code is the seed; this design generalizes it into a trait that supports streaming and prompt caching, then migrates `compact`/`ask` to use it. A follow-up phase (P4 below) migrates `learn`/`extract_llm` onto the same trait and deletes `llm.rs`.
+
+## 2. Non-goals
+
+Explicitly deferred or declined:
+
+- **Adopting a third-party multi-provider crate** (`rig`, `multi-llm`, `edgequake-llm`, `flyllm`, `llmao`). mur's existing `llm.rs` covers ~80% of the surface; the missing pieces (streaming + prompt caching + per-stage routing) are ~400 LOC of focused work. Pulling a crate adds transitive deps, version-pin churn, and audit surface for marginal payoff. Revisit only if Bedrock / Vertex / Foundry support is requested.
+- **Bedrock / Vertex AI / Foundry support.** Not needed today; the trait surface is provider-agnostic so adding them later is local.
+- **Streaming for `compact`.** Compact's per-call output is bounded (`max_abstractive_words: 400` ≈ 600 tokens). Non-streaming is correct.
+- **Auto-fallback from cloud to Ollama on cloud outage.** Silent provider switching causes summary-format drift. Failure modes are explicit per §8.
+- **Cost guardrails this phase.** A `max_daily_cost_usd` config is desirable but lands in a follow-up; first ship telemetry (P3) so users see real numbers before a guardrail is calibrated.
+- **Embedding migration to cloud.** The existing `qwen3-embedding:0.6b` Ollama path stays. This design covers chat/completion only.
+- **Computer-use, tool calling, MCP, structured outputs.** None apply to compact/ask. The trait surface omits them entirely.
+
+## 3. Architecture
+
+```
+                          ┌──────────────────────────────────┐
+                          │  mur-core/src/conversations/     │
+                          │      backend/  (NEW)             │
+                          │                                  │
+                          │  trait ChatBackend  ─────────┐   │
+                          │     │                         │  │
+                          │     ├─ OllamaBackend         │  │
+                          │     │   (wraps existing      │  │
+                          │     │    OllamaClient)       │  │
+                          │     │                         │  │
+                          │     ├─ AnthropicBackend      │  │
+                          │     │   (raw HTTP via        │  │
+                          │     │    reqwest, no SDK)    │  │
+                          │     │                         │  │
+                          │     └─ MockBackend            │  │
+                          │         (test-only, replaces │  │
+                          │          MUR_OLLAMA_MOCK)    │  │
+                          │                              │  │
+                          │  fn build(BackendConfig) ────┘  │
+                          └────────────┬─────────────────────┘
+                                       │ used by
+            ┌──────────────────────────┴──────────────────────────┐
+            │                                                     │
+   conversations/summarize/                          conversations/ask/
+     extractive.rs                                    rewriter.rs
+     abstractive.rs                                   abstractive.rs
+     rollup.rs                                        generate.rs (streaming)
+```
+
+**File structure:**
+
+| File | Role | Status |
+|---|---|---|
+| `mur-core/src/conversations/backend/mod.rs` | `ChatBackend` trait, `ChatRequest`, `ChatResponse`, `Usage`, `ChatChunk`, `BackendError` | **New** (~150 LOC) |
+| `mur-core/src/conversations/backend/ollama.rs` | `OllamaBackend` — wraps `OllamaClient` | **New** (~80 LOC) |
+| `mur-core/src/conversations/backend/anthropic.rs` | `AnthropicBackend` — non-streaming + SSE streaming via `reqwest` | **New** (~250 LOC) |
+| `mur-core/src/conversations/backend/mock.rs` | `MockBackend` — replaces `mock_generate()` from `ollama.rs` | **New** (~80 LOC) |
+| `mur-core/src/conversations/backend/factory.rs` | `build(cfg: &BackendConfig) -> Result<Arc<dyn ChatBackend>>` + retry policy | **New** (~60 LOC) |
+| `mur-common/src/config.rs` | `BackendConfig` struct; `CompactConfig`/`AskConfig` gain optional per-stage overrides | Modify |
+| `mur-core/src/conversations/summarize/{extractive,abstractive,rollup}.rs` | Replace `OllamaClient` calls with `ChatBackend` | Modify |
+| `mur-core/src/conversations/ask/{rewriter,abstractive,generate}.rs` | Replace `OllamaClient` calls with `ChatBackend` | Modify |
+| `mur-core/src/cmd/conversations_cmd.rs` | Wire `factory::build()` into `cmd_conversations_compact` and `cmd_ask` | Modify |
+| `mur-core/src/cmd/conversations_cmd.rs::cmd_conversations_doctor` | Add cloud-provider reachability + API-key checks | Modify |
+| `mur-core/tests/cli_conversations.rs` | Mock-backend tests; add cloud-provider integration test gated `#[ignore]` | Modify |
+
+**No changes to:** `OllamaClient` itself (kept as backend impl detail), embedding pipeline, vector store, capture/retrieve/inject, agent runtime.
+
+**New Cargo dependencies:** `eventsource-stream` is **declined** — SSE parsing is ~30 lines and we already hand-roll NDJSON in `ollama.rs::generate_stream`. Reuse the same buffer-and-split pattern. No new crates.
+
+**Tech stack:** Rust 2024 · `reqwest` (already in deps) · `tokio` · `tracing` · `anyhow` for application errors · `thiserror` for `BackendError` at the trait boundary.
+
+## 4. `ChatBackend` trait (`backend/mod.rs`)
+
+### 4.1 Trait
+
+```rust
+use std::pin::Pin;
+use std::sync::Arc;
+use anyhow::Result;
+use futures::stream::Stream;
+
+#[async_trait::async_trait]
+pub trait ChatBackend: Send + Sync {
+    /// Single non-streaming completion. Used by extractive, abstractive,
+    /// rewriter, and ask::abstractive::compress_hit.
+    async fn generate(&self, req: ChatRequest<'_>) -> Result<ChatResponse>;
+
+    /// Token-streaming completion. Used by ask::generate::stream_answer.
+    /// Implementations that don't support streaming MAY emit the whole
+    /// response as a single chunk.
+    async fn generate_stream(
+        &self,
+        req: ChatRequest<'_>,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<ChatChunk>> + Send>>>;
+
+    fn provider_name(&self) -> &'static str;
+
+    /// True if the backend honors `cache_system` / `cache_user_prefix`
+    /// hints in `ChatRequest`. False = hints are silently ignored.
+    fn supports_caching(&self) -> bool { false }
+}
+```
+
+### 4.2 Request / response types
+
+```rust
+pub struct ChatRequest<'a> {
+    pub model: &'a str,
+    pub system: Option<&'a str>,
+    pub user: &'a str,
+    pub max_tokens: u32,
+    /// Per-call temperature override. Trait-level — backends decide whether
+    /// to send it. AnthropicBackend ignores on Opus 4.7 (where it 400s).
+    pub temperature: Option<f32>,
+    pub stop: Vec<String>,
+    /// Anthropic prompt-caching hints. Ignored when supports_caching() = false.
+    pub cache_system: bool,
+    pub cache_user_prefix: Option<usize>, // bytes from front of `user` to cache
+}
+
+pub struct ChatResponse {
+    pub text: String,
+    pub usage: Usage,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Usage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_input_tokens: u64, // Anthropic-only; 0 for others
+    pub cache_read_input_tokens: u64,     // Anthropic-only; 0 for others
+    pub provider: &'static str,
+    pub model: String,
+}
+
+pub struct ChatChunk {
+    pub delta: String,
+    pub usage: Option<Usage>, // Some on the final chunk only
+}
+```
+
+### 4.3 Errors
+
+`BackendError` is a `thiserror` enum at the trait boundary so callers can dispatch on failure mode (vs. anyhow's opaque chain):
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum BackendError {
+    #[error("provider {provider} returned 401: invalid or missing API key")]
+    Unauthorized { provider: &'static str },
+
+    #[error("provider {provider} returned 429: rate limited (retry-after: {retry_after_secs:?}s)")]
+    RateLimited { provider: &'static str, retry_after_secs: Option<u64> },
+
+    #[error("provider {provider} returned 5xx: server error (status {status})")]
+    ServerError { provider: &'static str, status: u16 },
+
+    #[error("provider {provider} model {model} not found")]
+    ModelNotFound { provider: &'static str, model: String },
+
+    #[error("provider {provider} timed out after {seconds}s")]
+    Timeout { provider: &'static str, seconds: u64 },
+
+    #[error("network error talking to {provider}: {source}")]
+    Network { provider: &'static str, #[source] source: reqwest::Error },
+
+    #[error("malformed response from {provider}: {0}")]
+    BadResponse(String),
+}
+```
+
+`ChatBackend::generate` returns `anyhow::Result<ChatResponse>` (not `Result<_, BackendError>`) so call sites stay simple — but every backend impl wraps its raw error in `BackendError` first, then `.into()` to anyhow. This preserves the typed dispatch via `err.downcast_ref::<BackendError>()` for the retry loop in §8.
+
+## 5. Backend implementations
+
+### 5.1 `OllamaBackend` — wraps existing client
+
+Pure adapter. Construct with the same `OllamaClient::new(endpoint, timeout)` and forward calls. `Usage` is populated from `GenerateResponse.prompt_eval_count` + `eval_count` (already returned by Ollama, currently unused per the audit). `cache_*_input_tokens` always 0. `supports_caching()` = false.
+
+### 5.2 `AnthropicBackend` — raw HTTP
+
+Rust has no official Anthropic SDK ([cached `claude-api` skill confirms](#sources)). Implement raw HTTP via `reqwest`.
+
+**Endpoint:** `https://api.anthropic.com/v1/messages`
+
+**Required headers:**
+```
+x-api-key: $ANTHROPIC_API_KEY
+anthropic-version: 2023-06-01
+content-type: application/json
+```
+
+No beta headers needed for the features we use (caching is GA).
+
+**Request body** (non-streaming):
+```json
+{
+  "model": "claude-haiku-4-5",
+  "max_tokens": 4096,
+  "system": [
+    {"type": "text", "text": "...", "cache_control": {"type": "ephemeral"}}
+  ],
+  "messages": [
+    {"role": "user", "content": [
+      {"type": "text", "text": "<cacheable prefix>", "cache_control": {"type": "ephemeral"}},
+      {"type": "text", "text": "<volatile suffix>"}
+    ]}
+  ]
+}
+```
+
+`cache_control` blocks are emitted **only when `req.cache_system` is true** (system) and **only when `req.cache_user_prefix` is `Some(n)`** (user, splitting the user string at byte n). When neither is set the `system` field is sent as a plain string and the `user` content is a single-block array. This minimizes JSON-shape churn for callers that don't need caching.
+
+**Streaming request:** add `"stream": true`. SSE response shape from the `claude-api` skill (`curl/examples.md`):
+
+```
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+```
+
+Parser dispatches on `data` JSON `type` field:
+- `content_block_delta` with `delta.type == "text_delta"` → emit `ChatChunk { delta: text, usage: None }`
+- `message_delta` → capture `usage` for the final chunk
+- `message_stop` → emit `ChatChunk { delta: "", usage: Some(final_usage) }` and end stream
+
+**Caching invariants** (per `shared/prompt-caching.md`, loaded via the `claude-api` skill):
+
+1. **Render order is `tools → system → messages`.** A breakpoint on the last system block caches both tools and system together. mur uses no tools in compact/ask, so a single system breakpoint caches the full prefix.
+2. **Any byte change anywhere in the prefix invalidates everything after.** The `compact` and `ask` system prompts MUST be free of timestamps, UUIDs, and per-call interpolation. Move any per-day or per-call data into the user message.
+3. **Max 4 `cache_control` breakpoints per request.** mur uses at most 2 (system + user prefix).
+4. **Minimum cacheable prefix:** 2048 tokens for Haiku 4.5, 4096 tokens for Opus 4.6/4.7. Below this, `cache_control` is silently ignored — verify via `usage.cache_creation_input_tokens`.
+
+**Sampling parameters on Opus 4.7:** the skill states `temperature`, `top_p`, `top_k` return 400 on Opus 4.7. `AnthropicBackend` checks `req.model.starts_with("claude-opus-4-7")` and **drops** `temperature` from the request body if set. `tracing::warn!` once on first occurrence (avoid log spam).
+
+**Thinking config:** mur uses no extended thinking. `AnthropicBackend` sends `"thinking": {"type": "disabled"}` for Opus 4.6+ to skip the implicit adaptive default — saves tokens, irrelevant to our use case.
+
+### 5.3 `MockBackend` — replaces `MUR_OLLAMA_MOCK`
+
+Reuses the existing `mock_generate()` pattern-matching logic from `ollama.rs:261-323` verbatim (extractive JSON, abstractive prose, narrative time windows, CONDENSE identity, QA citation). Returns synthetic `Usage` numbers.
+
+**Activation:** new env var `MUR_LLM_MOCK=1`. The old `MUR_OLLAMA_MOCK=1` continues to work for backward compat — `MockBackend` is selected by `factory::build()` when **either** is set. Deprecation warning is `tracing::warn!` only; both env vars are accepted indefinitely.
+
+### 5.4 Factory
+
+```rust
+pub fn build(cfg: &BackendConfig) -> Result<Arc<dyn ChatBackend>> {
+    if std::env::var("MUR_LLM_MOCK").is_ok()
+        || std::env::var("MUR_OLLAMA_MOCK").is_ok()
+    {
+        return Ok(Arc::new(MockBackend::new()));
+    }
+    match cfg.provider.as_str() {
+        "ollama" => Ok(Arc::new(OllamaBackend::new(
+            &cfg.endpoint.as_deref().unwrap_or("http://localhost:11434"),
+            Duration::from_secs(cfg.timeout_secs.unwrap_or(120)),
+        ))),
+        "anthropic" => {
+            let key = resolve_api_key(cfg)?;
+            Ok(Arc::new(AnthropicBackend::new(key, &cfg)?))
+        }
+        other => bail!("unsupported provider: {other}"),
+    }
+}
+
+fn resolve_api_key(cfg: &BackendConfig) -> Result<String> {
+    // 1. cfg.api_key_env (e.g. "ANTHROPIC_API_KEY")
+    // 2. fallback to std env "ANTHROPIC_API_KEY"
+    // 3. (P3+) keychain via secrecy::SecretString — see §10
+}
+```
+
+`Arc<dyn ChatBackend>` (not `Box`) so call sites can clone cheaply for `tokio::spawn`.
+
+## 6. Config schema (`mur-common/src/config.rs`)
+
+Add `BackendConfig` and per-stage overrides. `#[serde(default)]` everywhere — every existing config file keeps working unchanged.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct BackendConfig {
+    /// "ollama" | "anthropic". Defaults to "ollama" for backward compat.
+    pub provider: String,
+    /// Model name as the provider sees it ("claude-haiku-4-5", "qwen3:14b", …).
+    pub model: String,
+    /// Provider endpoint. None = provider default
+    /// (ollama: http://localhost:11434, anthropic: https://api.anthropic.com).
+    pub endpoint: Option<String>,
+    /// Env var holding the API key. None = no auth (ollama).
+    pub api_key_env: Option<String>,
+    /// Per-call timeout. None = 120s.
+    pub timeout_secs: Option<u64>,
+}
+
+impl Default for BackendConfig {
+    fn default() -> Self {
+        Self {
+            provider: "ollama".into(),
+            model: "qwen3:14b".into(),
+            endpoint: None,
+            api_key_env: None,
+            timeout_secs: None,
+        }
+    }
+}
+```
+
+`CompactConfig` and `AskConfig` gain optional per-stage `BackendConfig` overrides:
+
+```rust
+pub struct CompactConfig {
+    // ...existing fields preserved...
+    pub extractive_model: String,         // kept; legacy fallback
+    pub abstractive_model: String,        // kept; legacy fallback
+    pub ollama_endpoint: String,          // kept; legacy fallback
+
+    /// NEW — per-stage overrides. None = synthesize from legacy fields above.
+    #[serde(default)]
+    pub extractive_backend: Option<BackendConfig>,
+    #[serde(default)]
+    pub abstractive_backend: Option<BackendConfig>,
+}
+
+pub struct AskConfig {
+    // ...existing fields preserved...
+    pub model: String,
+    pub ollama_endpoint: String,
+
+    #[serde(default)]
+    pub backend: Option<BackendConfig>,        // for the answer model
+    #[serde(default)]
+    pub rewriter_backend: Option<BackendConfig>,
+}
+```
+
+**Resolution order** when constructing the backend for a stage:
+1. If the per-stage `backend` field is `Some`, use it.
+2. Else, synthesize a `BackendConfig { provider: "ollama", model: <legacy field>, endpoint: Some(<legacy ollama_endpoint>), .. }`.
+
+This keeps every existing config file working byte-identically — no migration required, no deprecation warnings.
+
+**Recommended user config** (documented in `~/.mur/config.yaml` comments and the docs site):
+
+```yaml
+conversations:
+  compact:
+    extractive_backend:
+      provider: anthropic
+      model: claude-haiku-4-5
+      api_key_env: ANTHROPIC_API_KEY
+    abstractive_backend:
+      provider: anthropic
+      model: claude-haiku-4-5
+      api_key_env: ANTHROPIC_API_KEY
+  ask:
+    backend:
+      provider: anthropic
+      model: claude-sonnet-4-6
+      api_key_env: ANTHROPIC_API_KEY
+    rewriter_backend:
+      provider: ollama
+      model: llama3.2:3b   # tiny local model — rewriter is latency-sensitive
+```
+
+## 7. Per-stage routing rationale
+
+| Stage | Volume | Quality bar | Default cloud model | Rationale |
+|---|---|---|---|---|
+| `compact.extractive` | High (every chunk every day) | Low — span selection | `claude-haiku-4-5` | $1/$5 per 1M; quality difference vs Sonnet on span-selection is negligible |
+| `compact.abstractive` | Medium (1× per day + rollups) | Medium — narrative summary | `claude-haiku-4-5` | Same; user can upgrade to Sonnet for prose quality |
+| `ask` answer gen | Low (user-initiated, streaming) | High — final user-facing answer | `claude-sonnet-4-6` | $3/$15; matters for the answer the user reads |
+| `ask` rewriter | Low (per ask, ≤80 tokens out) | Low — query reformulation | `llama3.2:3b` (Ollama) | Local + fast; rewriter latency directly hits TTFB |
+
+**Why not default to Opus 4.7 for `ask`:** the loaded `claude-api` skill says *"Always use claude-opus-4-7 unless the user explicitly names a different model. Never downgrade for cost — that's the user's decision."* That guidance applies to **engineering an Anthropic-API app from scratch** (where the developer is the decider). For mur, the *user* is the decider, and they configure the model in `config.yaml`. The shipped defaults (Haiku/Sonnet) are reasoned defaults for autonomous nightly compact + interactive ask, not "downgrades." Documentation explicitly flags Opus 4.7 as the upgrade path.
+
+## 8. Retry, timeout, and failure policy
+
+### 8.1 Retry envelope
+
+Lift the retry logic from `mur-core/src/extract_llm.rs:216-252` into `factory::build` (so all backends inherit it):
+
+- 3 attempts max
+- Exponential backoff: 1s, 2s, 4s + jitter
+- Retry on: `BackendError::ServerError { status: 500..=599 }`, `BackendError::Timeout`, `BackendError::RateLimited` (respect `retry_after_secs` if present, capped at 30s)
+- Do **not** retry on: `Unauthorized`, `ModelNotFound`, `BadResponse`, `Network` other than connect-timeout
+
+Retry happens inside the `Arc<dyn ChatBackend>` adapter so callers don't need to reimplement.
+
+### 8.2 Failure surface per command
+
+| Command | Backend down | Cloud auth fails | Local model missing |
+|---|---|---|---|
+| `mur conversations compact` | **Skip day**, mark `outcome: deferred`, retry on next sweep | **Hard fail** with API-key error | **Hard fail** with `ollama pull X` hint |
+| `mur conversations ask` | **Hard fail** — user is waiting | **Hard fail** with API-key error | **Hard fail** with `ollama pull X` hint |
+| `mur conversations doctor` | Show ✗ for unreachable provider; keep other checks running | Show ✗ with hint | Show ✗ with hint |
+
+**No automatic fallback from cloud to Ollama** (or vice versa). Silent provider switching causes summary-format drift that pollutes the LanceDB index. Users who want a fallback configure two `mur conversations compact` cron jobs with different configs and let the second one fill gaps.
+
+### 8.3 Doctor enhancements
+
+`cmd_conversations_doctor` (`mur-core/src/cmd/conversations_cmd.rs:434`) gains:
+
+- For each unique provider in active config: probe reachability (Ollama: GET `/api/tags`; Anthropic: GET `/v1/models` with the API key)
+- For each unique cloud provider: verify the named env var is set and non-empty
+- For each Anthropic model in config: GET `/v1/models/{id}` to verify it exists
+
+Probe pattern follows the existing Ollama check (2-second timeout, non-fatal if backend is intentionally disabled).
+
+## 9. Streaming SSE parser
+
+`AnthropicBackend::generate_stream` mirrors the structure of `ollama.rs::generate_stream` (lines 161-243) — same `futures::stream::unfold` shape with a line-buffered byte stream, but the inner parser dispatches on SSE `event:` / `data:` framing instead of raw NDJSON.
+
+Pseudocode:
+
+```rust
+loop {
+    // 1. Drain any complete `event: X\ndata: Y\n\n` block from buf
+    if let Some(end) = buf.find("\n\n") {
+        let block: String = buf.drain(..=end + 1).collect();
+        match parse_sse_block(&block) {
+            SseEvent::ContentBlockDelta { text } => return yield ChatChunk { delta: text, usage: None },
+            SseEvent::MessageDelta { usage } => { final_usage = Some(usage); continue; }
+            SseEvent::MessageStop => return yield ChatChunk { delta: String::new(), usage: final_usage },
+            SseEvent::Other => continue,
+        }
+    }
+    // 2. Read more bytes
+    match inner.next().await { ... }
+}
+```
+
+This is ~30 lines of bespoke parsing — no `eventsource-stream` dep needed. Test coverage mirrors the existing `ollama.rs:387-465` chunked-JSON-split tests.
+
+## 10. Secrets handling
+
+P1 ships **env-var only** (`api_key_env` field naming the env var that holds the key). Sufficient for local CLI use; matches `LlmConfig.api_key_env`'s existing shape.
+
+P3+ gains keychain integration via the existing `mur-agent-runtime` keychain code path (`agent secret set` already uses `keyring` crate). The `BackendConfig` struct gains a `secret_ref: Option<String>` field that resolves through the same model-registry → SecretRef lookup that `mur-agent-runtime` uses (per `docs/superpowers/specs/2026-04-29-model-registry-and-secret-refs-design.md`).
+
+Until P3, document `ANTHROPIC_API_KEY` in the install guide and add a `mur conversations doctor` check that prints a clear hint if the env var is unset.
+
+## 11. Telemetry (P3, ships before P4)
+
+Every `ChatBackend::generate` and `generate_stream` call emits a structured tracing span at `info` level:
+
+```rust
+#[tracing::instrument(skip_all, fields(
+    provider = backend.provider_name(),
+    model = req.model,
+    stage = stage,
+))]
+async fn call_with_telemetry(...) {
+    let start = Instant::now();
+    let resp = backend.generate(req).await?;
+    tracing::info!(
+        input_tokens = resp.usage.input_tokens,
+        output_tokens = resp.usage.output_tokens,
+        cache_read_tokens = resp.usage.cache_read_input_tokens,
+        cache_write_tokens = resp.usage.cache_creation_input_tokens,
+        latency_ms = start.elapsed().as_millis() as u64,
+        "llm call completed"
+    );
+    Ok(resp)
+}
+```
+
+A `tracing_subscriber` JSON layer writes these to `~/.mur/telemetry/llm-calls-<date>.jsonl` (rotated daily). New command `mur conversations cost-report [--since <duration>]` aggregates these spans and prints provider × model × stage × token totals + estimated USD cost (from a hardcoded price table sourced from `claude-api`'s `shared/models.md`).
+
+## 12. Phased delivery
+
+Each phase is independently shippable and reviewable.
+
+| Phase | Scope | LOC est | User-visible? |
+|---|---|---|---|
+| **P0** | `ChatBackend` trait + `OllamaBackend` + `MockBackend` + `factory::build`. Refactor `ask::rewriter` only. No behavior change. | ~350 | No |
+| **P1** | `AnthropicBackend` (non-streaming). `BackendConfig` schema. Wire `compact.extractive` as canary. Doctor enhancements. | ~400 | Yes — opt-in |
+| **P2** | `AnthropicBackend::generate_stream` (SSE). Wire `ask` answer gen. | ~150 | Yes |
+| **P3** | Prompt caching wiring (cache_control on system prompts). Telemetry + `cost-report` command. | ~200 | Yes |
+| **P4** | Migrate `learn` / `extract_llm` onto `ChatBackend`. Delete `mur-core/src/llm.rs`. | ~100 net (delete) | No |
+
+P0 lands as a refactor PR; P1 is the first user-visible PR and gates on a manual test pass. P3 is the unlock that makes cloud cheaper than local for users without the 14B model pulled.
+
+## 13. Cost guidance (documentation)
+
+For a heavy mur user (~50K tokens/day of transcript content, ~5 chunks/day, compact runs nightly):
+
+| Setup | Per-day | Per-month |
+|---|---|---|
+| All Ollama (current) | $0 + ~12GB RAM peak | $0 |
+| Compact: Haiku, Ask: Sonnet, no caching | ~$0.10 | ~$3.00 |
+| Compact: Haiku, Ask: Sonnet, **with caching** (P3) | ~$0.08 | ~$2.40 |
+| Compact: Sonnet, Ask: Sonnet (overkill) | ~$0.30 | ~$9.00 |
+| Compact: Opus, Ask: Opus (very overkill) | ~$1.50 | ~$45 |
+
+Docs and product-page copy should lead with "Haiku for compact, Sonnet for ask, ~$3/month" — that's the recommended config and the 90th-percentile cost.
+
+## 14. Migration / backward compatibility
+
+Any existing `~/.mur/config.yaml` continues to work unchanged. The audit confirms current configs hold legacy `extractive_model`, `abstractive_model`, `ollama_endpoint` strings; resolution order in §6 synthesizes a `BackendConfig` from those when no per-stage override is set.
+
+`MUR_OLLAMA_MOCK=1` continues to activate `MockBackend` (alongside the new `MUR_LLM_MOCK=1`). All existing test fixtures pass without changes.
+
+`mur conversations compact` and `mur conversations ask` CLI surfaces are unchanged. Existing `--model` flag continues to work and overrides the per-stage `backend.model` field at call time.
+
+## 15. Open questions
+
+1. Should `BackendConfig` support **per-call retry-policy override** (some users may want zero retries on `ask` for fast-fail UX)? Lean towards no — defer until requested.
+2. Should the `ask` streaming path show a **provider tag** in the streamed output (e.g. `[claude-sonnet-4-6]` prefix on first chunk)? Useful for debugging mixed-provider configs but noisy for normal use. Lean: gate behind `--show-provider` flag.
+3. Should `cost-report` also report against an **org-level budget** read from a new config field? Defer to follow-up — first ship telemetry, see usage, then design the guardrail.
+4. Eventually, should `mur agent` also use `ChatBackend`? P0a runtime currently has its own model-resolution path. Out of scope for this design but worth flagging — the model-registry design (`2026-04-29-model-registry-and-secret-refs-design.md`) and this design should converge in a future cleanup.
+
+## 16. References
+
+- `docs/superpowers/specs/2026-04-19-mur-conversations-design.md` — original conversations subsystem design
+- `docs/superpowers/specs/2026-04-29-model-registry-and-secret-refs-design.md` — agent runtime's `SecretRef` model that P3 keychain support will mirror
+- `mur-core/src/conversations/ollama.rs` — current Ollama client (becomes `OllamaBackend` impl detail)
+- `mur-core/src/llm.rs` — current Anthropic/OpenAI/Gemini path (P4 migrates onto `ChatBackend` and deletes this file)
+- Anthropic prompt caching, model catalog, SSE format, sampling-param removal on Opus 4.7 — sourced from the `claude-api` skill content (cached 2026-04-15)

--- a/mur-core/src/cmd/conversations_cmd.rs
+++ b/mur-core/src/cmd/conversations_cmd.rs
@@ -1116,7 +1116,6 @@ pub(crate) fn resolve_summarize(
 
 pub async fn cmd_ask(args: AskArgs) -> Result<()> {
     use crate::conversations::ask;
-    use crate::conversations::ollama::OllamaClient;
     use chrono::{NaiveDate, Utc};
     use futures::StreamExt;
     use std::io::Write;
@@ -1157,12 +1156,14 @@ pub async fn cmd_ask(args: AskArgs) -> Result<()> {
     // the full ask_cfg.timeout_secs budget (plumbed via ask_stream).
     let prior_slice = session.last_n(history_turns);
     let model = args.model.clone().unwrap_or_else(|| ask_cfg.model.clone());
-    let rewriter_client = OllamaClient::new(
-        &ask_cfg.ollama_endpoint,
-        std::time::Duration::from_secs(ask_cfg.rewriter_timeout_secs as u64),
-    );
+    let rewriter_backend = crate::conversations::backend::factory::build(
+        &crate::conversations::backend::factory::BackendSpec::ollama(
+            &ask_cfg.ollama_endpoint,
+            ask_cfg.rewriter_timeout_secs as u64,
+        ),
+    )?;
     let rewrite = ask::rewriter::rewrite(
-        &rewriter_client,
+        rewriter_backend.as_ref(),
         &model,
         ask::rewriter::RewriteInput {
             prior_turns: prior_slice,

--- a/mur-core/src/conversations/ask/rewriter.rs
+++ b/mur-core/src/conversations/ask/rewriter.rs
@@ -5,7 +5,7 @@
 //! Failure modes (timeout / empty / etc.) fall back to raw question.
 #![allow(dead_code)] // wired by Task 7.
 
-use crate::conversations::ollama::{GenerateOptions, GenerateRequest, OllamaClient};
+use crate::conversations::backend::{ChatBackend, ChatRequest};
 
 use super::session::{RewriterStatus, TurnRecord};
 
@@ -63,7 +63,11 @@ fn truncate_chars(s: &str, max: usize) -> String {
 /// Short-circuits to `Skipped` when `prior_turns` is empty — no LLM call.
 /// On Ollama error, returns `FailedFellBackToRaw`. On identity echo
 /// (trimmed, case-insensitive, ignoring trailing `?!.`), returns `NoRewriteNeeded`.
-pub async fn rewrite(client: &OllamaClient, model: &str, input: RewriteInput<'_>) -> RewriteResult {
+pub async fn rewrite(
+    backend: &dyn ChatBackend,
+    model: &str,
+    input: RewriteInput<'_>,
+) -> RewriteResult {
     if input.prior_turns.is_empty() {
         return RewriteResult {
             rewritten: input.raw_question.to_string(),
@@ -76,31 +80,29 @@ pub async fn rewrite(client: &OllamaClient, model: &str, input: RewriteInput<'_>
         .replace("{history}", &history)
         .replace("{question}", input.raw_question);
 
-    let resp = client
-        .generate(GenerateRequest {
+    let resp = backend
+        .generate(ChatRequest {
             model,
-            prompt: &prompt,
+            user: &prompt,
             system: None,
-            stream: false,
-            options: GenerateOptions {
-                temperature: Some(0.1),
-                top_p: Some(0.9),
-                num_predict: Some(80),
-                stop: vec!["\n".into()],
-            },
+            max_tokens: 80,
+            temperature: Some(0.1),
+            stop: vec!["\n".into()],
+            cache_system: false,
+            cache_user_prefix: None,
         })
         .await;
 
     match resp {
         Err(e) => {
-            tracing::warn!("rewriter Ollama error: {e:#}");
+            tracing::warn!("rewriter backend error: {e:#}");
             RewriteResult {
                 rewritten: input.raw_question.to_string(),
                 status: RewriterStatus::FailedFellBackToRaw,
             }
         }
         Ok(r) => {
-            let trimmed = r.response.trim().to_string();
+            let trimmed = r.text.trim().to_string();
             if trimmed.is_empty() {
                 tracing::warn!("rewriter returned empty response; falling back to raw");
                 return RewriteResult {
@@ -186,14 +188,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn empty_prior_turns_returns_identity_without_calling_ollama() {
-        // Unreachable endpoint — if we accidentally call Ollama, we'd panic/error.
-        let client = OllamaClient::new("http://127.0.0.1:1", Duration::from_millis(100));
+    async fn empty_prior_turns_returns_identity_without_calling_backend() {
+        // Use OllamaBackend pointing at unreachable endpoint — if we
+        // accidentally call it, we'd get a connection error. The empty-
+        // prior-turns short-circuit should fire before any backend call.
+        use crate::conversations::backend::ollama::OllamaBackend;
+        let backend = OllamaBackend::new("http://127.0.0.1:1", Duration::from_millis(100));
         let input = RewriteInput {
             prior_turns: &[],
             raw_question: "what did I ship?",
         };
-        let r = rewrite(&client, "qwen3:14b", input).await;
+        let r = rewrite(&backend, "qwen3:14b", input).await;
         assert_eq!(r.status, RewriterStatus::Skipped);
         assert_eq!(r.rewritten, "what did I ship?");
     }
@@ -201,15 +206,17 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn connection_failure_returns_fallback_to_raw() {
+        use crate::conversations::backend::ollama::OllamaBackend;
         let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
         unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
-        let client = OllamaClient::new("http://127.0.0.1:1", Duration::from_millis(200));
+        unsafe { std::env::remove_var("MUR_LLM_MOCK") };
+        let backend = OllamaBackend::new("http://127.0.0.1:1", Duration::from_millis(200));
         let turns = vec![trec(1, "first q", "first a")];
         let input = RewriteInput {
             prior_turns: &turns,
             raw_question: "follow up",
         };
-        let r = rewrite(&client, "qwen3:14b", input).await;
+        let r = rewrite(&backend, "qwen3:14b", input).await;
         assert_eq!(r.status, RewriterStatus::FailedFellBackToRaw);
         assert_eq!(r.rewritten, "follow up");
     }

--- a/mur-core/src/conversations/backend/factory.rs
+++ b/mur-core/src/conversations/backend/factory.rs
@@ -1,0 +1,102 @@
+//! ChatBackend factory. Selects backend from a thin BackendSpec
+//! (P0 minimal — full BackendConfig schema lands in P1).
+//!
+//! See spec §5.4.
+
+#![allow(dead_code)] // wired into ask::rewriter in Task 6.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Result, bail};
+
+use super::{ChatBackend, mock::MockBackend, ollama::OllamaBackend};
+
+/// P0 minimal backend specification. Will be replaced by the full
+/// BackendConfig struct from `mur-common` in P1, when per-stage
+/// schema lands. Kept local here so P0 doesn't touch mur-common.
+#[derive(Debug, Clone)]
+pub struct BackendSpec {
+    pub provider: String,
+    pub endpoint: Option<String>,
+    pub timeout_secs: Option<u64>,
+}
+
+impl BackendSpec {
+    pub fn ollama(endpoint: impl Into<String>, timeout_secs: u64) -> Self {
+        Self {
+            provider: "ollama".into(),
+            endpoint: Some(endpoint.into()),
+            timeout_secs: Some(timeout_secs),
+        }
+    }
+}
+
+/// Build a backend from spec. Honors MUR_LLM_MOCK / MUR_OLLAMA_MOCK
+/// env vars: when either is set, returns MockBackend regardless of spec.
+pub fn build(spec: &BackendSpec) -> Result<Arc<dyn ChatBackend>> {
+    if std::env::var("MUR_LLM_MOCK").is_ok() || std::env::var("MUR_OLLAMA_MOCK").is_ok() {
+        tracing::debug!(provider = %spec.provider, "MUR_LLM_MOCK active — using MockBackend");
+        return Ok(Arc::new(MockBackend::new()));
+    }
+    match spec.provider.as_str() {
+        "ollama" => {
+            let endpoint = spec.endpoint.as_deref().unwrap_or("http://localhost:11434");
+            let timeout = Duration::from_secs(spec.timeout_secs.unwrap_or(120));
+            Ok(Arc::new(OllamaBackend::new(endpoint, timeout)))
+        }
+        other => bail!("unsupported provider in P0: {other} (anthropic lands in P1)"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn mock_env_var_forces_mock_backend() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::set_var("MUR_LLM_MOCK", "1") };
+        let spec = BackendSpec::ollama("http://localhost:11434", 5);
+        let b = build(&spec).unwrap();
+        assert_eq!(b.provider_name(), "mock");
+        unsafe { std::env::remove_var("MUR_LLM_MOCK") };
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn legacy_mur_ollama_mock_env_var_also_forces_mock() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("MUR_LLM_MOCK") };
+        unsafe { std::env::set_var("MUR_OLLAMA_MOCK", "1") };
+        let spec = BackendSpec::ollama("http://localhost:11434", 5);
+        let b = build(&spec).unwrap();
+        assert_eq!(b.provider_name(), "mock");
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn ollama_provider_returns_ollama_backend() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("MUR_LLM_MOCK") };
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+        let spec = BackendSpec::ollama("http://127.0.0.1:1", 1);
+        let b = build(&spec).unwrap();
+        assert_eq!(b.provider_name(), "ollama");
+    }
+
+    #[test]
+    fn unsupported_provider_errors() {
+        let spec = BackendSpec {
+            provider: "openai".into(),
+            endpoint: None,
+            timeout_secs: None,
+        };
+        let r = build(&spec);
+        assert!(r.is_err());
+        let err = r.err().unwrap();
+        assert!(format!("{err:#}").contains("unsupported"));
+    }
+}

--- a/mur-core/src/conversations/backend/mock.rs
+++ b/mur-core/src/conversations/backend/mock.rs
@@ -1,0 +1,122 @@
+//! Test-only ChatBackend that returns pattern-matched canned responses.
+//! Reuses the prompt-dispatch logic from `ollama.rs::mock_generate` —
+//! activated by `MUR_LLM_MOCK=1` (preferred) or `MUR_OLLAMA_MOCK=1` (legacy).
+//!
+//! See spec §5.3.
+
+#![allow(dead_code)] // wired by factory in Task 5.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::stream;
+
+use super::{ChatBackend, ChatChunk, ChatRequest, ChatResponse, ChatStream, Usage};
+
+pub struct MockBackend;
+
+impl MockBackend {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for MockBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ChatBackend for MockBackend {
+    async fn generate(&self, req: ChatRequest<'_>) -> Result<ChatResponse> {
+        // Reuse the existing pattern dispatcher. ollama::mock_generate takes
+        // a GenerateRequest, so build one from our ChatRequest.
+        use crate::conversations::ollama::{GenerateOptions, GenerateRequest};
+        let g_req = GenerateRequest {
+            model: req.model,
+            prompt: req.user,
+            system: req.system,
+            stream: false,
+            options: GenerateOptions {
+                temperature: req.temperature,
+                top_p: None,
+                num_predict: Some(req.max_tokens),
+                stop: req.stop.clone(),
+            },
+        };
+        let g_resp = crate::conversations::ollama::mock_generate(&g_req);
+        Ok(ChatResponse {
+            text: g_resp.response,
+            usage: Usage {
+                input_tokens: g_resp.prompt_eval_count,
+                output_tokens: g_resp.eval_count,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                provider: "mock",
+                model: req.model.to_string(),
+            },
+        })
+    }
+
+    async fn generate_stream(&self, req: ChatRequest<'_>) -> Result<ChatStream> {
+        // Mock streaming = single-chunk stream containing the full mock response.
+        let resp = self.generate(req).await?;
+        let final_chunk = ChatChunk {
+            delta: resp.text.clone(),
+            usage: Some(resp.usage),
+        };
+        Ok(Box::pin(stream::iter(vec![Ok(final_chunk)])))
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "mock"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    fn req<'a>(prompt: &'a str) -> ChatRequest<'a> {
+        ChatRequest {
+            model: "mock-model",
+            system: None,
+            user: prompt,
+            max_tokens: 100,
+            temperature: None,
+            stop: vec![],
+            cache_system: false,
+            cache_user_prefix: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn generate_returns_text_and_usage() {
+        let b = MockBackend::new();
+        let r = b.generate(req("hello")).await.unwrap();
+        // Mock returns *some* text — exact content depends on prompt patterns
+        // in ollama::mock_generate. The contract here is just non-empty.
+        assert!(!r.text.is_empty());
+        assert_eq!(r.usage.provider, "mock");
+        assert_eq!(r.usage.model, "mock-model");
+    }
+
+    #[tokio::test]
+    async fn generate_stream_emits_single_chunk_with_usage() {
+        let b = MockBackend::new();
+        let mut stream = b.generate_stream(req("hello")).await.unwrap();
+        let first = stream.next().await.unwrap().unwrap();
+        assert!(!first.delta.is_empty());
+        assert!(first.usage.is_some());
+        assert!(
+            stream.next().await.is_none(),
+            "should be a single-chunk stream"
+        );
+    }
+
+    #[test]
+    fn provider_name_is_mock() {
+        assert_eq!(MockBackend::new().provider_name(), "mock");
+    }
+}

--- a/mur-core/src/conversations/backend/mod.rs
+++ b/mur-core/src/conversations/backend/mod.rs
@@ -1,0 +1,96 @@
+//! ChatBackend trait and supporting types. See spec
+//! `docs/superpowers/specs/2026-05-01-cloud-llm-backend-design.md` §4.
+
+#![allow(dead_code)] // wired progressively across P0 tasks.
+
+use anyhow::Result;
+use futures::stream::Stream;
+use serde::Serialize;
+use std::pin::Pin;
+
+/// Per-call request to a chat-completion backend. Borrows where it can —
+/// callers typically hold owned strings and pass &str.
+#[derive(Debug, Clone)]
+pub struct ChatRequest<'a> {
+    pub model: &'a str,
+    pub system: Option<&'a str>,
+    pub user: &'a str,
+    pub max_tokens: u32,
+    pub temperature: Option<f32>,
+    pub stop: Vec<String>,
+    /// Anthropic prompt-caching hint for the system prompt. Ignored by
+    /// backends where `supports_caching()` is false.
+    pub cache_system: bool,
+    /// Anthropic prompt-caching hint: split `user` at this byte offset and
+    /// place a cache_control breakpoint after the prefix. Ignored when
+    /// `supports_caching()` is false. P0 stub only — wiring lands in P3.
+    pub cache_user_prefix: Option<usize>,
+}
+
+/// Non-streaming response. `text` is the model output; `usage` reports
+/// per-call token accounting (cache fields are 0 on non-caching backends).
+#[derive(Debug, Clone)]
+pub struct ChatResponse {
+    pub text: String,
+    pub usage: Usage,
+}
+
+/// Per-call token accounting. Both Anthropic-specific cache fields are
+/// always present and default to 0 on non-Anthropic backends — keeps
+/// downstream serialization shape uniform.
+#[derive(Debug, Clone, Serialize)]
+pub struct Usage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_creation_input_tokens: u64,
+    pub cache_read_input_tokens: u64,
+    pub provider: &'static str,
+    pub model: String,
+}
+
+/// Streaming chunk. `delta` is the incremental token payload (may be empty
+/// on the final chunk). `usage` is `Some` ONLY on the final chunk.
+#[derive(Debug, Clone)]
+pub struct ChatChunk {
+    pub delta: String,
+    pub usage: Option<Usage>,
+}
+
+/// Type alias for the boxed stream of chunks returned by `generate_stream`.
+pub type ChatStream = Pin<Box<dyn Stream<Item = Result<ChatChunk>> + Send>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chat_request_builds_with_required_fields() {
+        let req = ChatRequest {
+            model: "test-model",
+            system: Some("you are a tester"),
+            user: "hello",
+            max_tokens: 16,
+            temperature: None,
+            stop: vec![],
+            cache_system: false,
+            cache_user_prefix: None,
+        };
+        assert_eq!(req.user, "hello");
+        assert_eq!(req.model, "test-model");
+    }
+
+    #[test]
+    fn usage_serializes_with_zero_cache_fields_on_non_anthropic() {
+        let u = Usage {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            provider: "ollama",
+            model: "qwen3:14b".into(),
+        };
+        let json = serde_json::to_string(&u).unwrap();
+        assert!(json.contains("\"cache_read_input_tokens\":0"));
+        assert!(json.contains("\"provider\":\"ollama\""));
+    }
+}

--- a/mur-core/src/conversations/backend/mod.rs
+++ b/mur-core/src/conversations/backend/mod.rs
@@ -3,6 +3,7 @@
 
 #![allow(dead_code)] // wired progressively across P0 tasks.
 
+pub mod factory;
 pub mod mock;
 pub mod ollama;
 

--- a/mur-core/src/conversations/backend/mod.rs
+++ b/mur-core/src/conversations/backend/mod.rs
@@ -59,6 +59,73 @@ pub struct ChatChunk {
 /// Type alias for the boxed stream of chunks returned by `generate_stream`.
 pub type ChatStream = Pin<Box<dyn Stream<Item = Result<ChatChunk>> + Send>>;
 
+/// Backend-agnostic chat-completion interface.
+///
+/// Backends MUST be object-safe (no generics on methods, no `Self: Sized`).
+/// Both methods are async via `async-trait`. `generate_stream` MAY return
+/// a single-chunk stream when the backend doesn't natively stream
+/// (e.g. P0 OllamaBackend stubs `generate_stream` to `unimplemented!()` —
+/// only the non-streaming path is exercised in P0).
+#[async_trait::async_trait]
+pub trait ChatBackend: Send + Sync {
+    async fn generate(&self, req: ChatRequest<'_>) -> Result<ChatResponse>;
+
+    async fn generate_stream(&self, req: ChatRequest<'_>) -> Result<ChatStream>;
+
+    fn provider_name(&self) -> &'static str;
+
+    /// True when the backend honors `cache_system` / `cache_user_prefix`
+    /// hints. False = hints are silently ignored. Default: false.
+    fn supports_caching(&self) -> bool {
+        false
+    }
+}
+
+/// Typed errors at the backend boundary. Backend impls construct these
+/// and convert via `anyhow::Error::from(...)` so callers see anyhow
+/// chains but can still downcast for retry-policy decisions.
+///
+/// See spec §4.3.
+#[derive(Debug, thiserror::Error)]
+pub enum BackendError {
+    #[error("provider {provider} returned 401: invalid or missing API key")]
+    Unauthorized { provider: &'static str },
+
+    #[error("provider {provider} returned 429: rate limited (retry-after: {retry_after_secs:?}s)")]
+    RateLimited {
+        provider: &'static str,
+        retry_after_secs: Option<u64>,
+    },
+
+    #[error("provider {provider} returned {status}: server error")]
+    ServerError { provider: &'static str, status: u16 },
+
+    #[error("provider {provider} model {model} not found")]
+    ModelNotFound {
+        provider: &'static str,
+        model: String,
+    },
+
+    #[error("provider {provider} timed out after {seconds}s")]
+    Timeout {
+        provider: &'static str,
+        seconds: u64,
+    },
+
+    #[error("network error talking to {provider}: {source}")]
+    Network {
+        provider: &'static str,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    #[error("malformed response from {provider}: {message}")]
+    BadResponse {
+        provider: &'static str,
+        message: String,
+    },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,5 +159,23 @@ mod tests {
         let json = serde_json::to_string(&u).unwrap();
         assert!(json.contains("\"cache_read_input_tokens\":0"));
         assert!(json.contains("\"provider\":\"ollama\""));
+    }
+
+    #[test]
+    fn chat_backend_is_object_safe() {
+        // Compile-time check: ChatBackend must be usable as `dyn ChatBackend`.
+        // If this fails to compile, the trait broke object safety
+        // (e.g. someone added a generic method or `Self: Sized` bound).
+        fn _accepts(_: &dyn ChatBackend) {}
+    }
+
+    #[test]
+    fn backend_error_displays_with_provider_name() {
+        let e = BackendError::Unauthorized {
+            provider: "anthropic",
+        };
+        let msg = format!("{e}");
+        assert!(msg.contains("anthropic"));
+        assert!(msg.contains("401"));
     }
 }

--- a/mur-core/src/conversations/backend/mod.rs
+++ b/mur-core/src/conversations/backend/mod.rs
@@ -3,6 +3,8 @@
 
 #![allow(dead_code)] // wired progressively across P0 tasks.
 
+pub mod mock;
+
 use anyhow::Result;
 use futures::stream::Stream;
 use serde::Serialize;

--- a/mur-core/src/conversations/backend/mod.rs
+++ b/mur-core/src/conversations/backend/mod.rs
@@ -4,6 +4,7 @@
 #![allow(dead_code)] // wired progressively across P0 tasks.
 
 pub mod mock;
+pub mod ollama;
 
 use anyhow::Result;
 use futures::stream::Stream;

--- a/mur-core/src/conversations/backend/ollama.rs
+++ b/mur-core/src/conversations/backend/ollama.rs
@@ -1,0 +1,118 @@
+//! Adapter wrapping the existing OllamaClient as a ChatBackend.
+//! See spec §5.1.
+
+#![allow(dead_code)] // wired by factory in Task 5.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::conversations::ollama::{GenerateOptions, GenerateRequest, OllamaClient};
+
+use super::{ChatBackend, ChatRequest, ChatResponse, ChatStream, Usage};
+
+pub struct OllamaBackend {
+    client: OllamaClient,
+}
+
+impl OllamaBackend {
+    pub fn new(endpoint: &str, timeout: Duration) -> Self {
+        Self {
+            client: OllamaClient::new(endpoint, timeout),
+        }
+    }
+}
+
+#[async_trait]
+impl ChatBackend for OllamaBackend {
+    async fn generate(&self, req: ChatRequest<'_>) -> Result<ChatResponse> {
+        let g_req = GenerateRequest {
+            model: req.model,
+            prompt: req.user,
+            system: req.system,
+            stream: false,
+            options: GenerateOptions {
+                temperature: req.temperature,
+                top_p: None,
+                num_predict: Some(req.max_tokens),
+                stop: req.stop.clone(),
+            },
+        };
+        let resp = self.client.generate(g_req).await?;
+        Ok(ChatResponse {
+            text: resp.response,
+            usage: Usage {
+                input_tokens: resp.prompt_eval_count,
+                output_tokens: resp.eval_count,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                provider: "ollama",
+                model: req.model.to_string(),
+            },
+        })
+    }
+
+    async fn generate_stream(&self, _req: ChatRequest<'_>) -> Result<ChatStream> {
+        // P0: streaming through the trait is not yet wired. The existing
+        // OllamaClient::generate_stream is still used directly by ask::generate.
+        // This becomes real in P2 when ask::generate migrates onto the trait.
+        anyhow::bail!("OllamaBackend::generate_stream not wired in P0")
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "ollama"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conversations::backend::ChatBackend;
+
+    #[test]
+    fn provider_name_is_ollama() {
+        let b = OllamaBackend::new("http://127.0.0.1:1", Duration::from_millis(100));
+        assert_eq!(b.provider_name(), "ollama");
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn generate_propagates_connection_failure() {
+        let _env_guard = crate::conversations::ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("MUR_OLLAMA_MOCK") };
+        unsafe { std::env::remove_var("MUR_LLM_MOCK") };
+        let b = OllamaBackend::new("http://127.0.0.1:1", Duration::from_millis(200));
+        let req = ChatRequest {
+            model: "qwen3:14b",
+            system: None,
+            user: "hi",
+            max_tokens: 16,
+            temperature: None,
+            stop: vec![],
+            cache_system: false,
+            cache_user_prefix: None,
+        };
+        let r = b.generate(req).await;
+        assert!(r.is_err(), "unreachable endpoint should error");
+    }
+
+    #[tokio::test]
+    async fn generate_stream_returns_unimplemented_error_in_p0() {
+        let b = OllamaBackend::new("http://127.0.0.1:1", Duration::from_millis(100));
+        let req = ChatRequest {
+            model: "qwen3:14b",
+            system: None,
+            user: "hi",
+            max_tokens: 16,
+            temperature: None,
+            stop: vec![],
+            cache_system: false,
+            cache_user_prefix: None,
+        };
+        let r = b.generate_stream(req).await;
+        assert!(r.is_err());
+        let err = r.err().unwrap();
+        assert!(format!("{err:#}").contains("not wired in P0"));
+    }
+}

--- a/mur-core/src/conversations/mod.rs
+++ b/mur-core/src/conversations/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod ask;
 pub mod audit;
+pub mod backend;
 pub mod blob;
 pub mod index;
 pub mod ingest;

--- a/mur-core/src/conversations/ollama.rs
+++ b/mur-core/src/conversations/ollama.rs
@@ -258,7 +258,7 @@ fn extract_latest_question_from_condense_prompt(prompt: &str) -> String {
 
 /// Deterministic fake response for tests. Echoes model+prompt hints so each
 /// test can assert which call site fired without a real Ollama.
-fn mock_generate(req: &GenerateRequest<'_>) -> GenerateResponse {
+pub(crate) fn mock_generate(req: &GenerateRequest<'_>) -> GenerateResponse {
     let is_abstractive = req
         .system
         .map(|s| s.contains("You compress text for retrieval context"))


### PR DESCRIPTION
## Summary
- Introduces `mur-core/src/conversations/backend/` with `ChatBackend` trait, `OllamaBackend` adapter, `MockBackend` (replaces `MUR_OLLAMA_MOCK` flow), and `factory::build` for env-var-aware backend selection.
- Migrates `ask::rewriter` to the new trait as the P0 canary call site. **Zero user-visible behavior change.**
- Foundation for P1 (`AnthropicBackend`), P2 (streaming), P3 (prompt caching), P4 (migrate `learn`/`extract_llm`, delete `mur-core/src/llm.rs`).

## Design
- Spec: `docs/superpowers/specs/2026-05-01-cloud-llm-backend-design.md`
- Plan: `docs/superpowers/plans/2026-05-01-cloud-llm-backend-p0-plan.md`

## Test Plan
- [x] `cargo test --workspace -- --test-threads=1` — exit 0
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] Smoke: `MUR_LLM_MOCK=1 mur ask "..."` returns canned no-hits response
- [x] Smoke: `MUR_OLLAMA_MOCK=1 mur ask "..."` (legacy env var) — same output
- [x] 14 new backend unit tests, 268 conversations tests pass, 24 integration tests pass

## Review notes
- Two minor plan deviations, both required by Rust:
  - Removed unused `use std::sync::Arc;` from Task 1 (lands in Task 5 factory where it's actually used).
  - Used `r.err().unwrap()` instead of `r.unwrap_err()` in two tests where `Result<T, _>` had `T = ChatStream` / `Arc<dyn ChatBackend>` — `unwrap_err` requires `T: Debug`, boxed-dyn types don't have it.
- Subagent code-quality reviews planned in the plan were skipped due to Agent quota exhaustion mid-execution; rigorous inline self-review applied instead.
- Coordinates with `refactor/anthropic-base-url` (also Anthropic-related, touches `mur-core/src/llm.rs`). My P4 deletes `llm.rs`, so suggested merge order: `refactor/anthropic-base-url` first, then this PR rebased, then P1+ on top.

## Out of scope (P1+)
`AnthropicBackend`, streaming on the trait, `BackendConfig` schema in `mur-common`, doctor cloud-provider checks, prompt caching, cost telemetry, and migrating the remaining 9+ call sites (compact, `ask::generate`, `ask::abstractive`, `summarize::*`, `learn`, `extract_llm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)