### PR TITLE
feat(core): D4 card — M4.2 canonical-JSON + Ed25519 sign/verify

### DIFF
--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -71,6 +71,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 sysinfo = "0.30"
 pulldown-cmark = "0.12"
 rand = "0.8"
+serde_jcs = "0.2"
 
 [features]
 default = ["cli", "server", "sources"]

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -72,6 +72,8 @@ sysinfo = "0.30"
 pulldown-cmark = "0.12"
 rand = "0.8"
 serde_jcs = "0.2"
+ed25519-dalek = { version = "2", features = ["rand_core", "pkcs8"] }
+bs58 = "0.5"
 
 [features]
 default = ["cli", "server", "sources"]

--- a/mur-core/src/character_card/canonical.rs
+++ b/mur-core/src/character_card/canonical.rs
@@ -1,0 +1,32 @@
+//! Canonical-JSON encoding of `MurCard.data` (excluding the signature
+//! block) for Ed25519 signing.
+//!
+//! Algorithm (RFC 8785-ish):
+//! 1. Serialize the card as JSON via serde_json.
+//! 2. Walk the tree and remove `extensions.mur.provenance.signature`
+//!    (the signature can't sign itself).
+//! 3. Canonicalize via `serde_jcs`: sort object keys lexically (UTF-8
+//!    bytewise), strip whitespace, normalize numbers per RFC 8785 §3.2.2.
+//! 4. Output as bytes.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use super::schema::MurCard;
+
+pub fn canonical_data_bytes(card: &MurCard) -> Result<Vec<u8>> {
+    let mut v = serde_json::to_value(card).context("card → Value")?;
+    strip_signature(&mut v);
+    let canon = serde_jcs::to_vec(&v).context("canonical JSON encode")?;
+    Ok(canon)
+}
+
+fn strip_signature(v: &mut Value) {
+    if let Some(obj) = v.as_object_mut()
+        && let Some(ext) = obj.get_mut("extensions").and_then(|e| e.as_object_mut())
+        && let Some(mur) = ext.get_mut("mur").and_then(|m| m.as_object_mut())
+        && let Some(prov) = mur.get_mut("provenance").and_then(|p| p.as_object_mut())
+    {
+        prov.remove("signature");
+    }
+}

--- a/mur-core/src/character_card/mod.rs
+++ b/mur-core/src/character_card/mod.rs
@@ -4,6 +4,7 @@
 //! Spec: `docs/superpowers/specs/2026-04-30-mur-agent-d2-onboarding-design.md`
 //! §4.4.
 
+pub mod canonical;
 pub mod extensions;
 pub mod first_memory;
 pub mod schema;

--- a/mur-core/src/character_card/mod.rs
+++ b/mur-core/src/character_card/mod.rs
@@ -9,3 +9,4 @@ pub mod extensions;
 pub mod first_memory;
 pub mod schema;
 pub mod serde_round_trip;
+pub mod signing;

--- a/mur-core/src/character_card/signing.rs
+++ b/mur-core/src/character_card/signing.rs
@@ -1,0 +1,125 @@
+//! Ed25519 sign / verify for `MurCard`.
+//!
+//! Signs `canonical_data_bytes(&card)` — the canonical JSON of the
+//! card with the signature block stripped. Public key + signature are
+//! multibase-encoded (z-prefix, base58btc) so they round-trip cleanly
+//! through YAML.
+//!
+//! `verify_card` is non-fatal for unsigned cards: it returns
+//! `VerifyOutcome::Unsigned` so the importer can tag `import_trust:
+//! "unsigned"` and surface a yellow banner instead of refusing to load.
+
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+
+use super::canonical::canonical_data_bytes;
+use super::extensions::{CardSignature, MurExt, ProvenanceExt};
+use super::schema::{Extensions, MurCard};
+
+const MULTIBASE_Z: char = 'z';
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerifyOutcome {
+    Signed,
+    Unsigned,
+}
+
+pub fn sign_card(card: &mut MurCard, sk: &SigningKey) -> Result<()> {
+    // Set up the extensions / mur / provenance scaffolding up-front and
+    // clear any pre-existing signature. Doing it BEFORE
+    // `canonical_data_bytes` ensures that sign-time and verify-time see
+    // the same enclosing structure (verify only ever strips
+    // `provenance.signature`, never the surrounding objects).
+    let ext = card.extensions.get_or_insert_with(Extensions::default);
+    let mur = ext.mur.get_or_insert(MurExt {
+        schema_version: 1,
+        voice: None,
+        avatar: None,
+        relationship: None,
+        first_memory: None,
+        companion: None,
+        provenance: None,
+    });
+    let prov = mur.provenance.get_or_insert(ProvenanceExt {
+        signature: None,
+        content_rating: None,
+        import_trust: None,
+    });
+    prov.signature = None;
+
+    let pubkey = encode_multibase_z(&sk.verifying_key().to_bytes());
+    let signed_at = Utc::now();
+
+    // Compute canonical bytes with the scaffolding present and signature
+    // absent — exactly what `verify_card` will see post-strip.
+    let bytes = canonical_data_bytes(card)?;
+    let sig: Signature = sk.sign(&bytes);
+    let value = encode_multibase_z(&sig.to_bytes());
+
+    let cs = CardSignature {
+        algorithm: "ed25519".into(),
+        public_key: pubkey,
+        value,
+        signed_at,
+    };
+    // Re-borrow to attach the freshly-computed signature.
+    card.extensions
+        .as_mut()
+        .and_then(|e| e.mur.as_mut())
+        .and_then(|m| m.provenance.as_mut())
+        .expect("scaffolding installed above")
+        .signature = Some(cs);
+    Ok(())
+}
+
+pub fn verify_card(card: &MurCard) -> Result<VerifyOutcome> {
+    let Some(sig) = card
+        .extensions
+        .as_ref()
+        .and_then(|e| e.mur.as_ref())
+        .and_then(|m| m.provenance.as_ref())
+        .and_then(|p| p.signature.as_ref())
+    else {
+        return Ok(VerifyOutcome::Unsigned);
+    };
+    if sig.algorithm != "ed25519" {
+        bail!("unsupported signature algorithm: {}", sig.algorithm);
+    }
+    let pub_bytes = decode_multibase_z(&sig.public_key).context("decode public_key")?;
+    let sig_bytes = decode_multibase_z(&sig.value).context("decode signature value")?;
+
+    let pub_arr: [u8; 32] = pub_bytes
+        .as_slice()
+        .try_into()
+        .context("public_key length must be 32 bytes")?;
+    let sig_arr: [u8; 64] = sig_bytes
+        .as_slice()
+        .try_into()
+        .context("signature length must be 64 bytes")?;
+
+    let vk = VerifyingKey::from_bytes(&pub_arr).context("VerifyingKey::from_bytes")?;
+    let sig_obj = Signature::from_bytes(&sig_arr);
+    let bytes = canonical_data_bytes(card)?;
+    vk.verify(&bytes, &sig_obj)
+        .map_err(|e| anyhow::anyhow!("signature verification failed: {e}"))?;
+    Ok(VerifyOutcome::Signed)
+}
+
+fn encode_multibase_z(bytes: &[u8]) -> String {
+    let body = bs58::encode(bytes).into_string();
+    let mut out = String::with_capacity(body.len() + 1);
+    out.push(MULTIBASE_Z);
+    out.push_str(&body);
+    out
+}
+
+fn decode_multibase_z(s: &str) -> Result<Vec<u8>> {
+    let mut chars = s.chars();
+    let prefix = chars.next().context("empty multibase string")?;
+    if prefix != MULTIBASE_Z {
+        bail!("only multibase z-prefix supported, got '{prefix}'");
+    }
+    let body: String = chars.collect();
+    bs58::decode(body).into_vec().context("base58 decode")
+}

--- a/mur-core/tests/card_canonical_signature.rs
+++ b/mur-core/tests/card_canonical_signature.rs
@@ -1,0 +1,85 @@
+use mur_core::character_card::canonical::canonical_data_bytes;
+use mur_core::character_card::schema::{CardData, MurCard};
+
+fn minimal_card() -> MurCard {
+    MurCard {
+        spec: "murcard_v1".into(),
+        spec_version: "1.0".into(),
+        data: CardData {
+            name: "Aiko".into(),
+            ..Default::default()
+        },
+        extensions: None,
+        ccv3_passthrough: Default::default(),
+    }
+}
+
+#[test]
+fn canonical_is_deterministic() {
+    let c = minimal_card();
+    let a = canonical_data_bytes(&c).unwrap();
+    let b = canonical_data_bytes(&c).unwrap();
+    assert_eq!(a, b);
+}
+
+#[test]
+fn canonical_excludes_signature_block() {
+    use mur_core::character_card::extensions::*;
+    use mur_core::character_card::schema::Extensions;
+
+    // Build a card with provenance.content_rating set but no signature.
+    let mut unsigned_card = minimal_card();
+    unsigned_card.extensions = Some(Extensions {
+        mur: Some(MurExt {
+            schema_version: 1,
+            voice: None,
+            avatar: None,
+            relationship: None,
+            first_memory: None,
+            companion: None,
+            provenance: Some(ProvenanceExt {
+                signature: None,
+                content_rating: Some("sfw".into()),
+                import_trust: None,
+            }),
+        }),
+    });
+    let unsigned = canonical_data_bytes(&unsigned_card).unwrap();
+
+    // Same card but with a signature attached.
+    let mut signed_card = unsigned_card.clone();
+    signed_card
+        .extensions
+        .as_mut()
+        .unwrap()
+        .mur
+        .as_mut()
+        .unwrap()
+        .provenance
+        .as_mut()
+        .unwrap()
+        .signature = Some(CardSignature {
+        algorithm: "ed25519".into(),
+        public_key: "z6MkABC".into(),
+        value: "z3sigDEF".into(),
+        signed_at: chrono::Utc::now(),
+    });
+    let signed = canonical_data_bytes(&signed_card).unwrap();
+    assert_eq!(
+        signed, unsigned,
+        "signature block must NOT influence canonical bytes",
+    );
+}
+
+#[test]
+fn canonical_array_order_preserved() {
+    // Arrays preserve author order — different tag order produces
+    // different canonical bytes.
+    let mut c1 = minimal_card();
+    c1.data.tags = vec!["a".into(), "b".into()];
+    let mut c2 = minimal_card();
+    c2.data.tags = vec!["b".into(), "a".into()];
+    let b1 = canonical_data_bytes(&c1).unwrap();
+    let b2 = canonical_data_bytes(&c2).unwrap();
+    assert_ne!(b1, b2);
+}

--- a/mur-core/tests/card_canonical_signature.rs
+++ b/mur-core/tests/card_canonical_signature.rs
@@ -83,3 +83,55 @@ fn canonical_array_order_preserved() {
     let b2 = canonical_data_bytes(&c2).unwrap();
     assert_ne!(b1, b2);
 }
+
+#[test]
+fn sign_then_verify_round_trip() {
+    use ed25519_dalek::SigningKey;
+    use mur_core::character_card::signing::{VerifyOutcome, sign_card, verify_card};
+    use rand::rngs::OsRng;
+
+    let mut card = minimal_card();
+    let sk = SigningKey::generate(&mut OsRng);
+    sign_card(&mut card, &sk).unwrap();
+
+    let sig = card
+        .extensions
+        .as_ref()
+        .unwrap()
+        .mur
+        .as_ref()
+        .unwrap()
+        .provenance
+        .as_ref()
+        .unwrap()
+        .signature
+        .as_ref()
+        .unwrap();
+    assert_eq!(sig.algorithm, "ed25519");
+    assert!(sig.public_key.starts_with('z'));
+    assert!(sig.value.starts_with('z'));
+
+    let outcome = verify_card(&card).expect("freshly-signed card verifies");
+    assert!(matches!(outcome, VerifyOutcome::Signed));
+}
+
+#[test]
+fn tampered_card_fails_verification() {
+    use ed25519_dalek::SigningKey;
+    use mur_core::character_card::signing::{sign_card, verify_card};
+    use rand::rngs::OsRng;
+
+    let mut card = minimal_card();
+    let sk = SigningKey::generate(&mut OsRng);
+    sign_card(&mut card, &sk).unwrap();
+    card.data.description = "evil instructions".into();
+    assert!(verify_card(&card).is_err(), "tampered card must fail");
+}
+
+#[test]
+fn unsigned_card_returns_unsigned() {
+    use mur_core::character_card::signing::{VerifyOutcome, verify_card};
+    let card = minimal_card();
+    let outcome = verify_card(&card).expect("missing-sig is not an error");
+    assert!(matches!(outcome, VerifyOutcome::Unsigned));
+}


### PR DESCRIPTION
## Summary

Second milestone (M4.2) of the M4 D4 plan (#81). Makes `extensions.mur.provenance.signature` a real cryptographic signature: deterministic canonical-JSON encoding (with the signature block stripped) gets Ed25519-signed, multibase z-prefix (base58btc) keeps the YAML clean.

## What's in

**M4.2.1** `4b32f81` — `character_card/canonical.rs`:
- `canonical_data_bytes(&MurCard) -> Result<Vec<u8>>` walks the card via `serde_json::Value`, strips ONLY `extensions.mur.provenance.signature` (leaves `content_rating`/`import_trust` in place), then runs `serde_jcs::to_vec` for RFC 8785-compliant canonicalisation (sorted keys, no whitespace, normalized numbers).
- New dep: `serde_jcs = "0.2"`.

**M4.2.2** `44ae926` — `character_card/signing.rs`:
- `sign_card(&mut MurCard, &SigningKey)` installs the empty `provenance` scaffold BEFORE computing canonical bytes (so sign-time and verify-time see identical enclosing structure — caught a real bug in the plan's snippet here).
- `verify_card(&MurCard) -> Result<VerifyOutcome::{Signed, Unsigned}>`. Unsigned cards return `Ok(Unsigned)` (non-fatal — the importer tags `import_trust: "unsigned"` and surfaces a yellow banner instead of refusing to load). Tampered cards return `Err`.
- Multibase z-prefix on both pubkey + signature.
- New deps: `ed25519-dalek = "2"` (was only on `mur-common` before), `bs58 = "0.5"`.

## Implementer plan-bug catches

The implementer caught two real errors in the M4.2 plan snippet:

1. **`canonical_excludes_signature_block` test was wrong.** The plan compared an unsigned-no-extensions card vs. a signed-card-that-also-set-`content_rating: "sfw"`. Since `content_rating` lives in `provenance` and is NOT stripped, the bytes legitimately differ. Rewritten so signature presence is the only variable.

2. **`sign_card` scaffold-ordering bug.** Naive flow (compute bytes → sign → attach scaffold) produces different bytes at sign-time vs. verify-time because the empty `extensions/mur/provenance` enclosing objects ARE present at verify-time. Fix: install scaffold (with `signature: None`) BEFORE computing bytes.

Plus minor API adjustments (`bs58::encode(...).into_string()` instead of the plan's `Encode::into(&mut String)`; `get_or_insert(const)` to satisfy clippy).

## Tests added

6 tests in `mur-core/tests/card_canonical_signature.rs`, all passing:
- canonical: `is_deterministic`, `excludes_signature_block`, `array_order_preserved`.
- sign/verify: `sign_then_verify_round_trip`, `tampered_card_fails_verification`, `unsigned_card_returns_unsigned`.

`cargo clippy -p mur-core --tests -- -D warnings` clean. `cargo fmt --check` clean.

## Stack

- #81 plan
- #82 M4.1 schema
- **THIS** M4.2 sign/verify → #82
- M4.3 PNG importer (next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)