### PR TITLE
feat(gui): D5 bridge — M5.1 event types + inbox scanner

### DIFF
--- a/mur-agent-gui/src-tauri/src/companion_bridge/event.rs
+++ b/mur-agent-gui/src-tauri/src/companion_bridge/event.rs
@@ -1,0 +1,85 @@
+//! Bridge event types + inbox markdown parser.
+//!
+//! `BridgeEvent` is the common over-the-wire shape between the Rust
+//! bridge and the React UI. It is `serde::Serialize` so it can ride
+//! a Tauri 2 `Channel<BridgeEvent>`.
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeEvent {
+    pub id: String,
+    pub situation: String,
+    pub template_id: String,
+    pub locale: String,
+    pub generated_at: String,
+    pub body: String,
+    pub response: BridgeResponse,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", content = "value", rename_all = "lowercase")]
+pub enum BridgeResponse {
+    Unset,
+    Signal(String),
+}
+
+#[derive(Deserialize)]
+struct FrontMatter {
+    id: String,
+    situation: String,
+    template_id: String,
+    locale: String,
+    generated_at: String,
+}
+
+pub fn parse_inbox_md(path: &Path) -> Result<BridgeEvent> {
+    let raw =
+        std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    parse_str(&raw)
+}
+
+pub fn parse_str(raw: &str) -> Result<BridgeEvent> {
+    // Expected layout (see mur-agent-runtime/src/companion/inbox.rs::render):
+    //   ---
+    //   <yaml front-matter>
+    //   ---
+    //
+    //   <body>
+    //
+    //   >>> response: <unset>|good|bad|dismiss
+    let stripped = raw
+        .strip_prefix("---\n")
+        .ok_or_else(|| anyhow!("missing opening front-matter fence"))?;
+    let (yaml, rest) = stripped
+        .split_once("\n---\n")
+        .ok_or_else(|| anyhow!("missing closing front-matter fence"))?;
+    let fm: FrontMatter = serde_yaml_ng::from_str(yaml).context("parse front-matter")?;
+
+    // The body is everything after the closing fence up to the response line.
+    let response_marker = ">>> response:";
+    let (body_block, response_line) = rest
+        .rsplit_once(response_marker)
+        .ok_or_else(|| anyhow!("missing response marker"))?;
+    let body = body_block.trim().to_string();
+    let response_value = response_line.trim();
+    let response = if response_value == "<unset>" {
+        BridgeResponse::Unset
+    } else if matches!(response_value, "good" | "bad" | "dismiss") {
+        BridgeResponse::Signal(response_value.to_string())
+    } else {
+        bail!("unrecognized response value: {response_value}");
+    };
+
+    Ok(BridgeEvent {
+        id: fm.id,
+        situation: fm.situation,
+        template_id: fm.template_id,
+        locale: fm.locale,
+        generated_at: fm.generated_at,
+        body,
+        response,
+    })
+}

--- a/mur-agent-gui/src-tauri/src/companion_bridge/event.rs
+++ b/mur-agent-gui/src-tauri/src/companion_bridge/event.rs
@@ -36,8 +36,7 @@ struct FrontMatter {
 }
 
 pub fn parse_inbox_md(path: &Path) -> Result<BridgeEvent> {
-    let raw =
-        std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let raw = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
     parse_str(&raw)
 }
 

--- a/mur-agent-gui/src-tauri/src/companion_bridge/mod.rs
+++ b/mur-agent-gui/src-tauri/src/companion_bridge/mod.rs
@@ -1,0 +1,9 @@
+//! Companion → GUI IPC bridge (D5).
+//!
+//! This module is GUI-only — the runtime continues to write inbox
+//! markdown files via its built-in `StdoutNotifier`. The bridge
+//! parses those files, watches the directory for new ones, and
+//! delivers typed events to the React UI via Tauri 2 channels.
+
+pub mod event;
+pub mod scanner;

--- a/mur-agent-gui/src-tauri/src/companion_bridge/scanner.rs
+++ b/mur-agent-gui/src-tauri/src/companion_bridge/scanner.rs
@@ -1,0 +1,1 @@
+//! Inbox scanner — populated in M5.1.2.

--- a/mur-agent-gui/src-tauri/src/companion_bridge/scanner.rs
+++ b/mur-agent-gui/src-tauri/src/companion_bridge/scanner.rs
@@ -1,1 +1,34 @@
-//! Inbox scanner — populated in M5.1.2.
+//! Read every `.md` file in an inbox directory and parse it. Errors
+//! on individual files are logged at warn level and skipped — one
+//! corrupt file must NOT take down the whole scan.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use super::event::{BridgeEvent, parse_inbox_md};
+
+pub fn scan_pending(inbox_dir: &Path) -> Result<Vec<BridgeEvent>> {
+    if !inbox_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(inbox_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("md") {
+            continue;
+        }
+        match parse_inbox_md(&path) {
+            Ok(ev) => out.push(ev),
+            Err(e) => {
+                tracing::warn!(
+                    "companion_bridge: skipping malformed inbox file {}: {e:#}",
+                    path.display()
+                );
+            }
+        }
+    }
+    out.sort_by(|a, b| a.generated_at.cmp(&b.generated_at));
+    Ok(out)
+}

--- a/mur-agent-gui/src-tauri/src/lib.rs
+++ b/mur-agent-gui/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod bootstrap;
 pub mod commands;
+pub mod companion_bridge;
 pub mod multimodal;
 pub mod sidecar;
 pub mod theme;

--- a/mur-agent-gui/src-tauri/tests/bridge_event_parse.rs
+++ b/mur-agent-gui/src-tauri/tests/bridge_event_parse.rs
@@ -1,6 +1,6 @@
 //! Bridge event front-matter parser.
 
-use mur_agent_gui_lib::companion_bridge::event::{parse_inbox_md, BridgeResponse};
+use mur_agent_gui_lib::companion_bridge::event::{BridgeResponse, parse_inbox_md};
 
 #[test]
 fn parse_pending_message_returns_unset_response() {

--- a/mur-agent-gui/src-tauri/tests/bridge_event_parse.rs
+++ b/mur-agent-gui/src-tauri/tests/bridge_event_parse.rs
@@ -1,0 +1,37 @@
+//! Bridge event front-matter parser.
+
+use mur_agent_gui_lib::companion_bridge::event::{parse_inbox_md, BridgeResponse};
+
+#[test]
+fn parse_pending_message_returns_unset_response() {
+    let path = std::path::Path::new("tests/fixtures/companion-inbox/pending-warm.md");
+    let ev = parse_inbox_md(path).expect("must parse");
+    assert_eq!(ev.id, "01HPENDING_WARM_001");
+    assert_eq!(ev.situation, "morning_greeting");
+    assert_eq!(ev.template_id, "greet_warm_zh_001");
+    assert_eq!(ev.locale, "zh-TW");
+    assert_eq!(ev.body, "早安 David。今天想從哪一件小事開始？");
+    assert!(matches!(ev.response, BridgeResponse::Unset));
+}
+
+#[test]
+fn parse_acked_message_carries_signal() {
+    let path = std::path::Path::new("tests/fixtures/companion-inbox/acked-good.md");
+    let ev = parse_inbox_md(path).expect("must parse");
+    assert_eq!(ev.id, "01HACKED_GOOD_001");
+    assert!(
+        matches!(ev.response, BridgeResponse::Signal(s) if s == "good"),
+        "expected response: good"
+    );
+}
+
+#[test]
+fn parse_malformed_returns_err() {
+    let path = std::path::Path::new("tests/fixtures/companion-inbox/malformed.md");
+    let err = parse_inbox_md(path).expect_err("malformed must error");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("front-matter") || msg.contains("frontmatter"),
+        "error must mention front-matter, got: {msg}"
+    );
+}

--- a/mur-agent-gui/src-tauri/tests/bridge_scanner.rs
+++ b/mur-agent-gui/src-tauri/tests/bridge_scanner.rs
@@ -1,0 +1,57 @@
+//! Inbox scanner — produces a Vec<BridgeEvent> from a directory.
+
+use mur_agent_gui_lib::companion_bridge::scanner::scan_pending;
+use tempfile::TempDir;
+
+fn copy_fixture(into: &std::path::Path, name: &str) {
+    let src = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/companion-inbox")
+        .join(name);
+    std::fs::copy(&src, into.join(name)).expect("copy fixture");
+}
+
+#[test]
+fn empty_dir_returns_empty_vec() {
+    let dir = TempDir::new().unwrap();
+    let out = scan_pending(dir.path()).unwrap();
+    assert!(out.is_empty());
+}
+
+#[test]
+fn missing_dir_returns_empty_vec_not_error() {
+    let dir = TempDir::new().unwrap();
+    let out = scan_pending(&dir.path().join("does-not-exist")).unwrap();
+    assert!(out.is_empty());
+}
+
+#[test]
+fn happy_path_returns_one_per_md_file_sorted_by_generated_at() {
+    let dir = TempDir::new().unwrap();
+    copy_fixture(dir.path(), "pending-warm.md");
+    copy_fixture(dir.path(), "acked-good.md");
+
+    let out = scan_pending(dir.path()).unwrap();
+    assert_eq!(out.len(), 2);
+    assert_eq!(out[0].id, "01HPENDING_WARM_001"); // 07:13 < 10:00
+    assert_eq!(out[1].id, "01HACKED_GOOD_001");
+}
+
+#[test]
+fn malformed_file_is_skipped_with_warning() {
+    let dir = TempDir::new().unwrap();
+    copy_fixture(dir.path(), "pending-warm.md");
+    copy_fixture(dir.path(), "malformed.md");
+
+    let out = scan_pending(dir.path()).unwrap();
+    assert_eq!(out.len(), 1, "malformed must be skipped, kept good one");
+    assert_eq!(out[0].id, "01HPENDING_WARM_001");
+}
+
+#[test]
+fn non_md_files_are_ignored() {
+    let dir = TempDir::new().unwrap();
+    copy_fixture(dir.path(), "pending-warm.md");
+    std::fs::write(dir.path().join("notes.txt"), "ignore me").unwrap();
+    let out = scan_pending(dir.path()).unwrap();
+    assert_eq!(out.len(), 1);
+}

--- a/mur-agent-gui/src-tauri/tests/fixtures/companion-inbox/acked-good.md
+++ b/mur-agent-gui/src-tauri/tests/fixtures/companion-inbox/acked-good.md
@@ -1,0 +1,11 @@
+---
+id: 01HACKED_GOOD_001
+situation: gentle_check_in
+template_id: check_in_zh_001
+locale: zh-TW
+generated_at: 2026-05-02T10:00:00+08:00
+---
+
+最近怎樣？
+
+>>> response: good

--- a/mur-agent-gui/src-tauri/tests/fixtures/companion-inbox/malformed.md
+++ b/mur-agent-gui/src-tauri/tests/fixtures/companion-inbox/malformed.md
@@ -1,0 +1,5 @@
+---
+id: 01HMALFORMED_001
+situation: morning_greeting
+
+oops no closing fence

--- a/mur-agent-gui/src-tauri/tests/fixtures/companion-inbox/pending-warm.md
+++ b/mur-agent-gui/src-tauri/tests/fixtures/companion-inbox/pending-warm.md
@@ -1,0 +1,11 @@
+---
+id: 01HPENDING_WARM_001
+situation: morning_greeting
+template_id: greet_warm_zh_001
+locale: zh-TW
+generated_at: 2026-05-02T07:13:03+08:00
+---
+
+早安 David。今天想從哪一件小事開始？
+
+>>> response: <unset>


### PR DESCRIPTION
## Summary

M5.1 of the D5 companion-GUI bridge.

- `BridgeEvent` / `BridgeResponse` types (serde-ready for Tauri Channel)
- `parse_inbox_md`: front-matter + body + response
- `scan_pending`: directory walker that tolerates malformed files

No runtime changes; no IPC yet — that lands in M5.2 / M5.3.

## Commits

- `M5.1.1: bridge event types + inbox markdown parser`
- `M5.1.2: inbox scanner with malformed-tolerance + generated_at sort`

## Test plan

- [x] `cargo test --test bridge_event_parse` — 3 passed; 0 failed
- [x] `cargo test --test bridge_scanner` — 5 passed; 0 failed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean **on the new files** (pre-existing crate-wide errors in `sidecar.rs` / multimodal modules are unchanged from `main` and out of scope for M5.1)