### PR TITLE
feat(gui): D5 bridge — M5.2 notify-based inbox watcher

### DIFF
--- a/mur-agent-gui/src-tauri/Cargo.toml
+++ b/mur-agent-gui/src-tauri/Cargo.toml
@@ -38,6 +38,9 @@ tauri-plugin-store = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-fs = "2"
+# Companion → GUI bridge (D5) — debounced filesystem watcher on
+# ~/.mur/agents/<name>/companion/inbox/.
+notify = "6"
 tauri-plugin-process = "2"
 
 # Reuse the upstream library so admin commands and types match the CLI.

--- a/mur-agent-gui/src-tauri/src/companion_bridge/mod.rs
+++ b/mur-agent-gui/src-tauri/src/companion_bridge/mod.rs
@@ -7,3 +7,4 @@
 
 pub mod event;
 pub mod scanner;
+pub mod watcher;

--- a/mur-agent-gui/src-tauri/src/companion_bridge/watcher.rs
+++ b/mur-agent-gui/src-tauri/src/companion_bridge/watcher.rs
@@ -1,0 +1,77 @@
+//! Filesystem watcher that turns new `.md` writes under the agent's
+//! companion inbox directory into BridgeEvent records on a tokio mpsc.
+//!
+//! Why notify (not polling): we need ≤ 1 s end-to-end latency from
+//! outbox tick to GUI. notify uses kqueue (macOS), inotify (Linux),
+//! ReadDirectoryChangesW (Windows) — all sub-100 ms. Polling at 1 s
+//! would push us over budget once the React render lands on top.
+//!
+//! Why we ignore non-Create events: outbox always uses
+//! O_CREAT | O_EXCL (see runtime's inbox.rs); a Modify on an inbox
+//! file is the user pressing 👍/👎/🚫 (the response line is rewritten
+//! in place) and is NOT a new message. Filtering on Create avoids a
+//! double-emit.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use tokio::sync::mpsc::Sender;
+
+use super::event::{BridgeEvent, parse_inbox_md};
+
+pub struct InboxWatcher {
+    /// Hold the watcher alive until the bridge is dropped.
+    _inner: RecommendedWatcher,
+}
+
+impl InboxWatcher {
+    pub fn start(inbox_dir: PathBuf, tx: Sender<BridgeEvent>) -> Result<Self> {
+        std::fs::create_dir_all(&inbox_dir)
+            .with_context(|| format!("create {}", inbox_dir.display()))?;
+        let dir_for_handler = Arc::new(inbox_dir.clone());
+        let mut watcher = RecommendedWatcher::new(
+            move |res: notify::Result<notify::Event>| {
+                let Ok(event) = res else { return };
+                if !matches!(event.kind, EventKind::Create(_)) {
+                    return;
+                }
+                for path in event.paths {
+                    if path.extension().and_then(|s| s.to_str()) != Some("md") {
+                        continue;
+                    }
+                    forward_md(&path, &tx);
+                }
+                let _ = &dir_for_handler;
+            },
+            Config::default(),
+        )
+        .context("notify::watcher::new")?;
+        watcher
+            .watch(&inbox_dir, RecursiveMode::NonRecursive)
+            .with_context(|| format!("watch {}", inbox_dir.display()))?;
+        Ok(Self { _inner: watcher })
+    }
+}
+
+fn forward_md(path: &Path, tx: &Sender<BridgeEvent>) {
+    match parse_inbox_md(path) {
+        Ok(ev) => {
+            // try_send drops if the receiver buffer is full (>=8). The UI
+            // can always re-scan via scan_pending if it falls behind.
+            if let Err(e) = tx.try_send(ev) {
+                tracing::warn!(
+                    "companion_bridge: dropped event for {}: {e}",
+                    path.display()
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                "companion_bridge: skipping malformed write at {}: {e:#}",
+                path.display()
+            );
+        }
+    }
+}

--- a/mur-agent-gui/src-tauri/tests/bridge_watcher.rs
+++ b/mur-agent-gui/src-tauri/tests/bridge_watcher.rs
@@ -1,0 +1,45 @@
+//! InboxWatcher — emits BridgeEvent on every new .md write.
+
+use mur_agent_gui_lib::companion_bridge::watcher::InboxWatcher;
+use std::time::Duration;
+use tempfile::TempDir;
+use tokio::sync::mpsc;
+
+const FIXTURE_BODY: &str = "\
+---
+id: 01HWATCHER_TEST_001
+situation: morning_greeting
+template_id: greet_warm_zh_001
+locale: zh-TW
+generated_at: 2026-05-02T07:13:03+08:00
+---
+
+早安。
+
+>>> response: <unset>";
+
+#[tokio::test]
+async fn writing_a_new_md_file_emits_one_event() {
+    let dir = TempDir::new().unwrap();
+    let (tx, mut rx) = mpsc::channel(8);
+    let watcher = InboxWatcher::start(dir.path().to_path_buf(), tx).expect("watcher start");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    std::fs::write(dir.path().join("01HWATCHER_TEST_001.md"), FIXTURE_BODY).unwrap();
+    let ev = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("watcher must emit within 2s")
+        .expect("channel still open");
+    assert_eq!(ev.id, "01HWATCHER_TEST_001");
+    drop(watcher);
+}
+
+#[tokio::test]
+async fn malformed_file_does_not_emit_and_does_not_crash() {
+    let dir = TempDir::new().unwrap();
+    let (tx, mut rx) = mpsc::channel(8);
+    let _watcher = InboxWatcher::start(dir.path().to_path_buf(), tx).unwrap();
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    std::fs::write(dir.path().join("garbage.md"), "no front matter here").unwrap();
+    let result = tokio::time::timeout(Duration::from_millis(500), rx.recv()).await;
+    assert!(result.is_err(), "malformed file must not produce an event");
+}


### PR DESCRIPTION
## Summary

D5 (Companion → GUI IPC Bridge) M5.2: live filesystem watcher that turns
new `.md` writes under `~/.mur/agents/<name>/companion/inbox/` into
`BridgeEvent` records on a tokio mpsc channel. Eliminates polling — gets
us to the ≤ 1 s "outbox tick → GUI" latency budget required by the spec.

Stacked on top of `feat/mur-agent-d5-gui-bridge-m5.1-scaffold` (PR #94).

## Commits

- **M5.2.1** `M5.2.1: add notify=6 dep for inbox filesystem watcher` — adds
  `notify = "6"` (kqueue / inotify / ReadDirectoryChangesW backend) to
  `mur-agent-gui/src-tauri/Cargo.toml`. Dep-only commit; nothing uses it
  yet so the build still passes cleanly.
- **M5.2.2** `M5.2.2: notify-based InboxWatcher emits BridgeEvent on .md create` —
  introduces `companion_bridge::watcher::InboxWatcher` plus two
  integration tests. Filters on `EventKind::Create(_)` only so user
  ack rewrites (Modify in place) don't double-emit. Reuses
  `parse_inbox_md` from M5.1 — no markdown re-parsing.

## Why filter Create-only

The runtime's outbox writes inbox files with `O_CREAT | O_EXCL` (see
`mur-agent-runtime/src/companion/inbox.rs`). Modify events on inbox
files are the user pressing 👍 / 👎 / 🚫 — the `>>> response:` line is
rewritten in place — and are NOT a new message. Watching only Create
keeps the bridge idempotent.

## Test plan

- [x] `cargo test --test bridge_watcher` → `2 passed`
  - `writing_a_new_md_file_emits_one_event` — happy path, verifies the
    150 ms attach window + ≤ 2 s emit budget
  - `malformed_file_does_not_emit_and_does_not_crash` — unparseable .md
    files are skipped with a `tracing::warn!`, never propagate panics
- [x] `cargo build` clean (notify 6.1.1 locked)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` — new files lint-clean (pre-existing
  `items after a test module` warning in `src/sidecar.rs` is unrelated
  baseline noise)

## Plan reference

`docs/superpowers/plans/2026-05-02-mur-agent-d5-gui-bridge.md` §M5.2.