### PR TITLE
feat(gui): macOS hardening — M6.1 PrivacyInfo.xcprivacy manifest

### DIFF
--- a/mur-agent-gui/src-tauri/Resources/PrivacyInfo.xcprivacy
+++ b/mur-agent-gui/src-tauri/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required Reason APIs the app + sidecars use.
+         Categories + reason codes per Apple's published list:
+         https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
+         -->
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <!-- UserDefaults: tauri-plugin-store + WKWebView session prefs -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+        <!-- File timestamps: companion-bridge inbox watcher reads
+             mtimes via std::fs::metadata; runtime ledger reads dir
+             entries' mtimes for log-rotation cutoff. -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+        <!-- System boot time: tracing subscriber initializes monotonic
+             clock; companion outbox uses Instant::now() which on
+             macOS reads system uptime. -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+        </dict>
+        <!-- Disk space: M1 voice model download free-space precheck;
+             M3 multimodal pipeline temp-dir provisioning. -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>E174.1</string>
+            </array>
+        </dict>
+    </array>
+
+    <!-- We do NOT collect or transmit any data we don't already
+         document; tracking is disabled. -->
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

M6.1 of the Track D §4.6 macOS hardening stack.

- Creates mur-agent-gui/src-tauri/Resources/PrivacyInfo.xcprivacy.
- Declares exactly the four NSPrivacyAccessedAPICategory entries the
  spec requires: UserDefaults (CA92.1), FileTimestamp (C617.1),
  SystemBootTime (35F9.1), DiskSpace (E174.1).
- NSPrivacyTracking=false, no domains, no collected data.

The manifest does NOT yet ship in the bundle — that's M6.2 (Tauri
bundle.resources wiring).

## Test plan

- [x] plutil -lint passes (run locally on macOS host)
- [x] plutil -extract NSPrivacyAccessedAPITypes raw lists all four categories