### PR TITLE
feat(gui): macOS hardening — M6.2 ship PrivacyInfo via bundle.resources

### DIFF
--- a/mur-agent-gui/src-tauri/Resources/PrivacyInfo.xcprivacy
+++ b/mur-agent-gui/src-tauri/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required Reason APIs the app + sidecars use.
+         Categories + reason codes per Apple's published list:
+         https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
+         -->
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <!-- UserDefaults: tauri-plugin-store + WKWebView session prefs -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+        <!-- File timestamps: companion-bridge inbox watcher reads
+             mtimes via std::fs::metadata; runtime ledger reads dir
+             entries' mtimes for log-rotation cutoff. -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+        <!-- System boot time: tracing subscriber initializes monotonic
+             clock; companion outbox uses Instant::now() which on
+             macOS reads system uptime. -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+        </dict>
+        <!-- Disk space: M1 voice model download free-space precheck;
+             M3 multimodal pipeline temp-dir provisioning. -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>E174.1</string>
+            </array>
+        </dict>
+    </array>
+
+    <!-- We do NOT collect or transmit any data we don't already
+         document; tracking is disabled. -->
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+</dict>
+</plist>

--- a/mur-agent-gui/src-tauri/tauri.conf.json
+++ b/mur-agent-gui/src-tauri/tauri.conf.json
@@ -46,7 +46,8 @@
       "icons/icon.ico"
     ],
     "resources": [
-      "themes/**/*"
+      "themes/**/*",
+      "Resources/PrivacyInfo.xcprivacy"
     ],
     "macOS": {
       "minimumSystemVersion": "12.0",


### PR DESCRIPTION
## Summary

M6.2 wires the M6.1 manifest into Tauri's bundling step so `cargo
tauri build` copies it to `MyAgent.app/Contents/Resources/PrivacyInfo.xcprivacy`.

- `bundle.resources` gains the explicit `Resources/PrivacyInfo.xcprivacy` entry.
- Existing `themes/**/*` glob is unchanged.
- Stacked on top of #105 (M6.1 — adds `mur-agent-gui/src-tauri/Resources/PrivacyInfo.xcprivacy`).

## Test plan

- [x] `python3 -c "import json; json.load(open('mur-agent-gui/src-tauri/tauri.conf.json'))"` returns `json ok`
- [ ] `cargo tauri build` on macOS deposits the file at `<App>.app/Contents/Resources/PrivacyInfo.xcprivacy` — **skipped locally (5-15 min build); will be verified by macOS-latest CI / M6.5 `phase_11_assess`**
- [ ] Manual `ls <App>.app/Contents/Resources/PrivacyInfo.xcprivacy` post-build (deferred to CI)

Used the explicit form (`Resources/PrivacyInfo.xcprivacy`), not the glob fallback. If CI surfaces double-nesting under `Contents/Resources/Resources/`, M6.3 will switch to the `Resources/*.xcprivacy` glob form per the plan's documented fallback.