### PR TITLE
chore(backend): cost-report cloud prices + drop transitional dead_code attrs

### DIFF
--- a/mur-core/src/cmd/conversations_cost_report.rs
+++ b/mur-core/src/cmd/conversations_cost_report.rs
@@ -84,6 +84,17 @@ fn price_table(model: &str) -> Option<(f64, f64, f64, f64)> {
         m if m.starts_with("claude-sonnet-4-6") => Some((3.00, 15.00, 3.75, 0.30)),
         m if m.starts_with("claude-opus-4-7") => Some((15.00, 75.00, 18.75, 1.50)),
         m if m.starts_with("claude-opus-4-6") => Some((15.00, 75.00, 18.75, 1.50)),
+        m if m.starts_with("gpt-4o-mini") => Some((0.15, 0.60, 0.0, 0.0)),
+        m if m.starts_with("gpt-4o") => Some((2.50, 10.00, 0.0, 0.0)),
+        m if m.starts_with("gpt-4.1-mini") => Some((0.40, 1.60, 0.0, 0.0)),
+        m if m.starts_with("gpt-4.1") => Some((2.00, 8.00, 0.0, 0.0)),
+        m if m.starts_with("gpt-5-mini") => Some((0.25, 2.00, 0.0, 0.0)),
+        m if m.starts_with("gpt-5") => Some((1.25, 10.00, 0.0, 0.0)),
+        m if m.starts_with("o3-mini") => Some((1.10, 4.40, 0.0, 0.0)),
+        m if m.starts_with("o3") => Some((2.00, 8.00, 0.0, 0.0)),
+        m if m.starts_with("gemini-2.5-flash") => Some((0.30, 2.50, 0.0, 0.0)),
+        m if m.starts_with("gemini-2.5-pro") => Some((1.25, 10.00, 0.0, 0.0)),
+        m if m.starts_with("gemini-pro-3") => Some((1.25, 10.00, 0.0, 0.0)),
         _ => None,
     }
 }
@@ -305,6 +316,25 @@ mod tests {
     fn estimate_cost_haiku_matches_table() {
         let cost = estimate_cost("claude-haiku-4-5", 1_000_000, 1_000_000, 0, 0).unwrap();
         assert!((cost - 6.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn estimate_cost_openai_gpt4o_mini_matches_table() {
+        // 1M in @ $0.15 + 1M out @ $0.60 = $0.75
+        let cost = estimate_cost("gpt-4o-mini", 1_000_000, 1_000_000, 0, 0).unwrap();
+        assert!((cost - 0.75).abs() < 0.001);
+    }
+
+    #[test]
+    fn estimate_cost_gemini_25_flash_matches_table() {
+        // 1M in @ $0.30 + 1M out @ $2.50 = $2.80
+        let cost = estimate_cost("gemini-2.5-flash", 1_000_000, 1_000_000, 0, 0).unwrap();
+        assert!((cost - 2.80).abs() < 0.001);
+    }
+
+    #[test]
+    fn estimate_cost_unknown_model_returns_none() {
+        assert!(estimate_cost("some-unknown-model-vNext", 1, 1, 0, 0).is_none());
     }
 
     #[test]

--- a/mur-core/src/conversations/backend/anthropic.rs
+++ b/mur-core/src/conversations/backend/anthropic.rs
@@ -3,8 +3,6 @@
 //!
 //! See spec §5.2.
 
-#![allow(dead_code)] // wired by factory + compact.extractive in Tasks 6 & 7.
-
 use std::time::Duration;
 
 use anyhow::Result;

--- a/mur-core/src/conversations/backend/factory.rs
+++ b/mur-core/src/conversations/backend/factory.rs
@@ -3,8 +3,6 @@
 //!
 //! See spec §5.4 + §8.1.
 
-#![allow(dead_code)] // wired into more call sites across P1.
-
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -24,6 +22,7 @@ use super::{ChatBackend, mock::MockBackend, ollama::OllamaBackend};
 /// **Backwards-compatible: builds without telemetry.** Used by tests and any
 /// caller that doesn't have a stage tag. Production call sites should use
 /// `build_for_stage` so per-call cost telemetry is recorded.
+#[allow(dead_code)] // used by tests/cli_conversations.rs (separate compilation unit)
 pub fn build(cfg: &BackendConfig) -> Result<Arc<dyn ChatBackend>> {
     build_raw(cfg)
 }

--- a/mur-core/src/conversations/backend/gemini.rs
+++ b/mur-core/src/conversations/backend/gemini.rs
@@ -3,8 +3,6 @@
 //! system_instruction + contents wire shape, usageMetadata for tokens.
 //! See P4 plan task 3.
 
-#![allow(dead_code)] // wired into factory in P4 task 4.
-
 use std::time::Duration;
 
 use anyhow::Result;
@@ -12,8 +10,6 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use super::{BackendError, ChatBackend, ChatRequest, ChatResponse, ChatStream, Usage};
-
-const DEFAULT_ENDPOINT: &str = "https://generativelanguage.googleapis.com";
 
 pub struct GeminiBackend {
     endpoint: String,

--- a/mur-core/src/conversations/backend/mock.rs
+++ b/mur-core/src/conversations/backend/mock.rs
@@ -4,8 +4,6 @@
 //!
 //! See spec §5.3.
 
-#![allow(dead_code)] // wired by factory in Task 5.
-
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::stream;

--- a/mur-core/src/conversations/backend/mod.rs
+++ b/mur-core/src/conversations/backend/mod.rs
@@ -1,8 +1,6 @@
 //! ChatBackend trait and supporting types. See spec
 //! `docs/superpowers/specs/2026-05-01-cloud-llm-backend-design.md` §4.
 
-#![allow(dead_code)] // wired progressively across P0 tasks.
-
 pub mod anthropic;
 pub mod factory;
 pub mod gemini;
@@ -86,6 +84,7 @@ pub trait ChatBackend: Send + Sync {
     /// True when the backend honors `cache_system` / `cache_user_prefix`
     /// hints. False = hints are silently ignored. Default: false.
     /// AnthropicBackend overrides to true (P3+).
+    #[allow(dead_code)] // future-API contract; no caller queries it today
     fn supports_caching(&self) -> bool {
         false
     }
@@ -117,6 +116,8 @@ pub enum BackendError {
     },
 
     #[error("provider {provider} timed out after {seconds}s")]
+    #[allow(dead_code)]
+    // typed contract — reqwest timeouts currently land in Network{is_timeout()}
     Timeout {
         provider: &'static str,
         seconds: u64,

--- a/mur-core/src/conversations/backend/ollama.rs
+++ b/mur-core/src/conversations/backend/ollama.rs
@@ -1,8 +1,6 @@
 //! Adapter wrapping the existing OllamaClient as a ChatBackend.
 //! See spec §5.1.
 
-#![allow(dead_code)] // wired by factory in Task 5.
-
 use std::time::Duration;
 
 use anyhow::Result;

--- a/mur-core/src/conversations/backend/openai.rs
+++ b/mur-core/src/conversations/backend/openai.rs
@@ -2,8 +2,6 @@
 //! providers (OpenRouter, Together, Fireworks, etc.) via `endpoint` override.
 //! Non-streaming only — see spec §5.x, plan task 2.
 
-#![allow(dead_code)] // wired into factory in P4 task 4.
-
 use std::time::Duration;
 
 use anyhow::Result;
@@ -13,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use super::{BackendError, ChatBackend, ChatRequest, ChatResponse, ChatStream, Usage};
 
 const DEFAULT_MAX_TOKENS: u32 = 4096;
-const DEFAULT_ENDPOINT: &str = "https://api.openai.com/v1";
 
 pub struct OpenAIBackend {
     endpoint: String,

--- a/mur-core/src/conversations/backend/retry.rs
+++ b/mur-core/src/conversations/backend/retry.rs
@@ -8,8 +8,6 @@
 //!
 //! See spec §8.1.
 
-#![allow(dead_code)] // wired into factory in Task 6.
-
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;

--- a/mur-core/src/conversations/backend/telemetry.rs
+++ b/mur-core/src/conversations/backend/telemetry.rs
@@ -1,8 +1,6 @@
 //! Per-call cost telemetry: writes one JSONL record per LLM call to
 //! `~/.mur/telemetry/llm-calls-<YYYY-MM-DD>.jsonl`. See spec §11 + plan task 8.
 
-#![allow(dead_code)] // wired into call sites in the same task.
-
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -46,16 +44,12 @@ impl TelemetryBackend {
         }
     }
 
+    /// Test-only path override; integration tests redirect telemetry writes
+    /// to a tempdir. Lib build sees no in-tree caller hence the allow.
+    #[allow(dead_code)]
     pub fn with_path_override(mut self, path: PathBuf) -> Self {
         self.log_path_override = Some(path);
         self
-    }
-
-    fn log_path(&self) -> PathBuf {
-        if let Some(p) = &self.log_path_override {
-            return p.clone();
-        }
-        default_log_path()
     }
 
     fn write_record(&self, rec: &LlmCallRecord) {


### PR DESCRIPTION
## Summary

Two small follow-ups after the cloud-LLM rollout (P0 #80 → P1 #91 → P2 #98 → P3 #103 → P4 #112) shipped.

### 1. OpenAI + Gemini prices in cost-report

Post-P4, the new \`extract_llm\`/\`learn\`/\`starter\` stage tags route to whichever cloud backend the user configured. \`mur conversations cost-report\` only knew Anthropic prices, so OpenAI/Gemini calls showed \`est_\$ = "—"\`. Added entries for:

- **OpenAI:** gpt-4o, gpt-4o-mini, gpt-4.1, gpt-4.1-mini, gpt-5, gpt-5-mini, o3, o3-mini
- **Gemini:** gemini-2.5-flash, gemini-2.5-pro, gemini-pro-3

Cache-write/read columns are \`0\` for both — these providers don't expose Anthropic-style prompt-cache token counts on the wire. 3 new tests + existing claude-haiku table roundtrip still passes.

### 2. Drop transitional dead_code attrs

P0–P3 scaffolding left \`#![allow(dead_code)]\` module attrs all over \`conversations/backend/*.rs\`. Code reviewer (P4 final review, item M1) flagged. Also removed unused \`DEFAULT_ENDPOINT\` constants in openai.rs + gemini.rs (factory carries its own defaults).

Three legitimately-unused-in-lib symbols got targeted \`#[allow(dead_code)]\` with a one-line WHY:
- \`factory::build\` — used only by integration test (separate compilation unit; lib doesn't see)
- \`TelemetryBackend::with_path_override\` — same
- \`ChatBackend::supports_caching\` — future-API contract; no caller queries it today
- \`BackendError::Timeout\` — typed contract; reqwest timeouts currently land in \`Network{is_timeout()}\` per the P4 retry fix

\`TelemetryBackend::log_path\` was a genuinely dead helper — deleted outright.

## Test plan

- [x] \`cargo test -p mur-core --lib -- --test-threads=1\` — 980/980 pass
- [x] \`cargo clippy -p mur-core --all-targets -- -D warnings\` clean (was clean before too, just via blanket module suppressions; now via targeted attrs that document intent)
- [x] \`cargo fmt --check\` clean
- [x] 3 new cost-report tests cover gpt-4o-mini, gemini-2.5-flash, unknown-model-returns-None

🤖 Generated with [Claude Code](https://claude.com/claude-code)