### PR TITLE
feat(runtime): B0 text rules — M7.1 fs confinement (rule 1)

### DIFF
--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -119,6 +119,35 @@ impl Hook for B0SafetyHook {
         call: &ToolCall,
         _tok: &CancellationToken,
     ) -> Result<Decision, HookError> {
+        // ── Rule 1: FS confinement (advisory). ───────────────────────────
+        // For fs.write / fs.delete / fs.append / fs.create on a path
+        // outside <agent_home>, ask the user. Read-only access is the
+        // OS picker's job (granted via tauri-plugin-fs's runtime open
+        // dialog), so we don't gate fs.read here.
+        if matches!(
+            call.name(),
+            "fs.write" | "fs.delete" | "fs.append" | "fs.create"
+        ) && let Some(path) = call.input.get("path").and_then(|v| v.as_str())
+        {
+            let candidate = std::path::Path::new(path);
+            if !crate::hooks::b0_helpers::path_confined_to(candidate, ctx.agent_home()) {
+                let scope_key = ScopeKey {
+                    agent_id: ctx.agent_uuid.clone(),
+                    tool_name: format!("fs_outside_home::{}", call.name()),
+                    input_schema_hash: String::new(),
+                };
+                return Ok(Decision::AskUser {
+                    scope_key,
+                    prompt: format!(
+                        "`{}` is about to write at `{}`, which is outside the agent's \
+                         home directory. Allow this once?",
+                        call.name(),
+                        path,
+                    ),
+                    default: AskDefault::Deny,
+                });
+            }
+        }
         if !ctx
             .turn_flags()
             .iter()

--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -119,6 +119,36 @@ impl Hook for B0SafetyHook {
         call: &ToolCall,
         _tok: &CancellationToken,
     ) -> Result<Decision, HookError> {
+        // ── Rule 4 (M3.8): no same-turn side-effect after fresh untrusted input. ─
+        // Fires FIRST so the most-specific gate wins: if the runtime
+        // already saw a multimodal/card-import wrapper this turn AND the
+        // tool is a known side-effect, we ask before doing anything else.
+        if ctx
+            .turn_flags()
+            .iter()
+            .any(|f| f == TURN_FLAG_AFTER_UNTRUSTED)
+            && is_side_effect_tool(call.name())
+        {
+            // M3.8.2 only needs the scope key as a stable identifier for
+            // the user-facing prompt; the per-input schema-hash dimension
+            // belongs to the M8 GrantStore lookup. Tag the key with the
+            // rule name so future grants are scoped to
+            // "after-untrusted-input + this tool" rather than the tool
+            // alone.
+            let scope_key = ScopeKey {
+                agent_id: ctx.agent_uuid.clone(),
+                tool_name: format!("{}::{}", TURN_FLAG_AFTER_UNTRUSTED, call.name()),
+                input_schema_hash: String::new(),
+            };
+            return Ok(Decision::AskUser {
+                scope_key,
+                prompt: format!(
+                    "An attached image or PDF may contain instructions. Allow `{}` to run anyway?",
+                    call.name()
+                ),
+                default: AskDefault::Deny,
+            });
+        }
         // ── Rule 1: FS confinement (advisory). ───────────────────────────
         // For fs.write / fs.delete / fs.append / fs.create on a path
         // outside <agent_home>, ask the user. Read-only access is the
@@ -148,34 +178,7 @@ impl Hook for B0SafetyHook {
                 });
             }
         }
-        if !ctx
-            .turn_flags()
-            .iter()
-            .any(|f| f == TURN_FLAG_AFTER_UNTRUSTED)
-        {
-            return Ok(Decision::Allow);
-        }
-        if !is_side_effect_tool(call.name()) {
-            return Ok(Decision::Allow);
-        }
-        // M3.8.2 only needs the scope key as a stable identifier for the
-        // user-facing prompt; the per-input schema-hash dimension belongs
-        // to the M8 GrantStore lookup. Tag the key with the rule name so
-        // future grants are scoped to "after-untrusted-input + this tool"
-        // rather than the tool alone.
-        let scope_key = ScopeKey {
-            agent_id: ctx.agent_uuid.clone(),
-            tool_name: format!("{}::{}", TURN_FLAG_AFTER_UNTRUSTED, call.name()),
-            input_schema_hash: String::new(),
-        };
-        Ok(Decision::AskUser {
-            scope_key,
-            prompt: format!(
-                "An attached image or PDF may contain instructions. Allow `{}` to run anyway?",
-                call.name()
-            ),
-            default: AskDefault::Deny,
-        })
+        Ok(Decision::Allow)
     }
 }
 

--- a/mur-agent-runtime/src/hooks/b0_helpers.rs
+++ b/mur-agent-runtime/src/hooks/b0_helpers.rs
@@ -1,0 +1,87 @@
+//! Pure helpers for B0SafetyHook rule branches.
+//!
+//! Each helper is a free function with no IO and no Tauri/runtime
+//! state, so unit tests can construct fixtures directly. The helpers
+//! are imported by `mur-agent-runtime/src/hooks/b0.rs` from the rule
+//! branches that need them.
+
+use std::path::Path;
+
+/// Returns `true` when `candidate` is inside `confine_to` (after
+/// canonicalization). A `candidate` that does NOT exist is checked
+/// against the parent's canonical path — useful for fs.write where
+/// the file may be about to be created.
+///
+/// Symlinks ARE followed (`canonicalize` resolves them) so this is a
+/// real-world confinement check, not a string-prefix match.
+pub fn path_confined_to(candidate: &Path, confine_to: &Path) -> bool {
+    let confine_canonical = match std::fs::canonicalize(confine_to) {
+        Ok(p) => p,
+        Err(_) => return false, // confine_to missing — fail closed
+    };
+    let candidate_canonical = match std::fs::canonicalize(candidate) {
+        Ok(p) => p,
+        Err(_) => {
+            // Not yet created. Check the parent.
+            match candidate.parent() {
+                Some(parent) => match std::fs::canonicalize(parent) {
+                    Ok(p) => p,
+                    Err(_) => return false,
+                },
+                None => return false,
+            }
+        }
+    };
+    candidate_canonical.starts_with(&confine_canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn confined_path_is_inside() {
+        let dir = TempDir::new().unwrap();
+        let inner = dir.path().join("inside.txt");
+        std::fs::write(&inner, "x").unwrap();
+        assert!(path_confined_to(&inner, dir.path()));
+    }
+
+    #[test]
+    fn outside_path_rejected() {
+        let dir = TempDir::new().unwrap();
+        let other = TempDir::new().unwrap();
+        let foreign = other.path().join("file.txt");
+        std::fs::write(&foreign, "x").unwrap();
+        assert!(!path_confined_to(&foreign, dir.path()));
+    }
+
+    #[test]
+    fn nonexistent_file_uses_parent_for_check() {
+        let dir = TempDir::new().unwrap();
+        let new_file = dir.path().join("doesnt-exist-yet.txt");
+        // Parent (dir) exists and IS the confine root.
+        assert!(path_confined_to(&new_file, dir.path()));
+    }
+
+    #[test]
+    fn nonexistent_parent_fails_closed() {
+        let dir = TempDir::new().unwrap();
+        let two_deep = dir.path().join("ghost-dir/file.txt");
+        assert!(!path_confined_to(&two_deep, dir.path()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_outside_rejected() {
+        let confine = TempDir::new().unwrap();
+        let other = TempDir::new().unwrap();
+        let target = other.path().join("real.txt");
+        std::fs::write(&target, "x").unwrap();
+        let link = confine.path().join("escape.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        // Symlink resolves outside confine_to → reject.
+        assert!(!path_confined_to(&link, confine.path()));
+    }
+}

--- a/mur-agent-runtime/src/hooks/mod.rs
+++ b/mur-agent-runtime/src/hooks/mod.rs
@@ -15,6 +15,7 @@ pub mod patch;
 pub mod types;
 
 pub mod b0;
+pub mod b0_helpers;
 pub mod companion_voice;
 pub mod ledger;
 pub mod telemetry;

--- a/mur-agent-runtime/tests/b0_rule1_fs_confinement.rs
+++ b/mur-agent-runtime/tests/b0_rule1_fs_confinement.rs
@@ -1,0 +1,39 @@
+//! Rule 1: pre_tool_use issues AskUser for fs.write outside agent_home.
+
+use mur_agent_runtime::hooks::{AskDefault, B0SafetyHook, Decision, Hook, HookCtx, ToolCall};
+use serde_json::json;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn fs_write_inside_agent_home_is_allowed() {
+    let agent_home = TempDir::new().unwrap();
+    let target = agent_home.path().join("notes.txt");
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_home(agent_home.path().to_path_buf(), 1);
+    let call = ToolCall::test("fs.write", json!({"path": target.display().to_string()}));
+    let cancel = CancellationToken::new();
+    let decision = hook.pre_tool_use(&ctx, &call, &cancel).await.unwrap();
+    assert!(matches!(decision, Decision::Allow), "got {:?}", decision);
+}
+
+#[tokio::test]
+async fn fs_write_outside_agent_home_asks_user() {
+    let agent_home = TempDir::new().unwrap();
+    let other = TempDir::new().unwrap();
+    let target = other.path().join("foreign.txt");
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_home(agent_home.path().to_path_buf(), 1);
+    let call = ToolCall::test("fs.write", json!({"path": target.display().to_string()}));
+    let cancel = CancellationToken::new();
+    let decision = hook.pre_tool_use(&ctx, &call, &cancel).await.unwrap();
+    match decision {
+        Decision::AskUser {
+            default, prompt, ..
+        } => {
+            assert!(matches!(default, AskDefault::Deny));
+            assert!(prompt.to_lowercase().contains("outside") || prompt.contains("foreign"));
+        }
+        other => panic!("expected AskUser for outside-home write, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

M7.1 of the B0 text-only rules (roadmap §6.1).

- Adds path_confined_to pure helper (canonicalize-based, follows symlinks).
- Wires Rule 1 (fs read-write confined to <agent_home>) into pre_tool_use.
- fs.write/fs.delete/fs.append/fs.create outside the agent home → AskUser.
- Inside-home + non-fs tools → unchanged Allow path.

## Test plan

- [x] cargo test -p mur-agent-runtime --lib hooks::b0_helpers — 5/5
- [x] cargo test -p mur-agent-runtime --test b0_rule1_fs_confinement — 2/2
- [x] cargo test -p mur-agent-runtime --tests — full suite green
- [x] cargo clippy + fmt clean