### PR TITLE
feat(runtime): B0 text rules — M7.2 spawn deny (rule 5)

### DIFF
--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -149,6 +149,60 @@ impl Hook for B0SafetyHook {
                 default: AskDefault::Deny,
             });
         }
+        // ── Rule 5: process.spawn / eval / shell deny by default. ────────
+        // Per-agent toggle via entitlements.processes.spawn.mode:
+        //   - Allowlist (default) + empty allowed[]  → deny everything
+        //   - Allowlist + allowed[]                  → only those programs allow
+        //   - Any                                    → unrestricted (user opted in)
+        //
+        // We match the family of tool names — anything that ultimately
+        // exec()s a child process. Every match enters the gate; only
+        // `Any` mode falls through to subsequent rules.
+        const SPAWN_TOOLS: &[&str] = &[
+            "process.spawn",
+            "process.exec",
+            "shell.exec",
+            "shell.run",
+            "eval.run",
+            "command.run",
+        ];
+        if SPAWN_TOOLS.contains(&call.name()) {
+            let spawn = &ctx.entitlements().processes.spawn;
+            match spawn.mode {
+                mur_common::agent::SpawnMode::Any => {
+                    // user opted in; fall through to Rule 1 / default Allow
+                }
+                mur_common::agent::SpawnMode::None => {
+                    return Ok(Decision::Deny {
+                        reason: format!(
+                            "process spawn is disabled by entitlements (mode=none); \
+                             enable with `mur agent perm allow-spawn <name>` (or set \
+                             spawn.mode to `allowlist` / `any`). Tool: `{}`",
+                            call.name()
+                        ),
+                    });
+                }
+                mur_common::agent::SpawnMode::Allowlist => {
+                    let argv0 = call
+                        .input
+                        .get("argv")
+                        .and_then(|v| v.as_array())
+                        .and_then(|a| a.first())
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    if !spawn.allowed.iter().any(|p| p == argv0) {
+                        return Ok(Decision::Deny {
+                            reason: format!(
+                                "process spawn `{}` is not in the agent's allowlist; \
+                                 enable with `mur agent perm allow-spawn <name> \"{}\"` \
+                                 (or set spawn.mode to `any` for unrestricted)",
+                                argv0, argv0,
+                            ),
+                        });
+                    }
+                }
+            }
+        }
         // ── Rule 1: FS confinement (advisory). ───────────────────────────
         // For fs.write / fs.delete / fs.append / fs.create on a path
         // outside <agent_home>, ask the user. Read-only access is the

--- a/mur-agent-runtime/src/hooks/types.rs
+++ b/mur-agent-runtime/src/hooks/types.rs
@@ -1,6 +1,11 @@
 //! Hook-trait shared value types. All `Send + Sync + 'static` so they can
 //! cross `Arc<dyn Hook>` boundaries.
 
+use mur_common::agent::{
+    Entitlements, FilesystemEntitlement, InboundNetwork, LimitsEntitlement, NetworkEntitlement,
+    NetworkOutboundMode, OutboundNetwork, ProcessesEntitlement, ResolveDnsConfig, SpawnEntitlement,
+    SpawnMode, SyscallsEntitlement,
+};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -33,6 +38,10 @@ pub struct HookCtx {
     /// Turn-scoped flags raised by mutate hooks (e.g.
     /// `"after_untrusted_input"`) and consumed by gate hooks.
     pub turn_flags: Vec<String>,
+    /// Snapshot of the agent profile's entitlements. Read by gate hooks
+    /// (e.g. `B0SafetyHook` rule 5) to decide whether the agent is
+    /// permitted to spawn a process, open a network connection, etc.
+    pub entitlements: Entitlements,
 }
 
 impl HookCtx {
@@ -48,6 +57,10 @@ impl HookCtx {
         &self.turn_flags
     }
 
+    pub fn entitlements(&self) -> &Entitlements {
+        &self.entitlements
+    }
+
     /// Test helper: build a HookCtx pinned to an `agent_home` + `turn_id`.
     /// Used by integration tests that need a real on-disk ledger to read.
     pub fn for_test_with_home(home: PathBuf, turn_id: u64) -> Self {
@@ -60,6 +73,7 @@ impl HookCtx {
             agent_home: home,
             turn_id,
             turn_flags: Vec::new(),
+            entitlements: test_default_entitlements(),
         }
     }
 
@@ -75,7 +89,49 @@ impl HookCtx {
             agent_home: PathBuf::new(),
             turn_id: 0,
             turn_flags,
+            entitlements: test_default_entitlements(),
         }
+    }
+
+    /// Test helper: build a HookCtx pinned to an `agent_home` + `turn_id`
+    /// with an explicit `Entitlements` snapshot. Used by gate-hook tests
+    /// that exercise rules keyed off the entitlement (e.g. rule 5
+    /// process-spawn allowlist).
+    pub fn for_test_with_entitlements(
+        home: PathBuf,
+        turn_id: u64,
+        entitlements: Entitlements,
+    ) -> Self {
+        let mut ctx = Self::for_test_with_home(home, turn_id);
+        ctx.entitlements = entitlements;
+        ctx
+    }
+}
+
+/// Test-only Entitlements default. Mirrors `default_entitlements_custom`
+/// in `mur-core::cmd::agent` so test contexts behave like a freshly
+/// created agent: `Restricted` outbound network, empty allow lists,
+/// `SpawnMode::Allowlist` with no allowed programs (deny-by-default).
+fn test_default_entitlements() -> Entitlements {
+    Entitlements {
+        network: NetworkEntitlement {
+            inbound: InboundNetwork { ports: vec![] },
+            outbound: OutboundNetwork {
+                mode: NetworkOutboundMode::Restricted,
+                allow_hosts: vec![],
+                protocols: vec!["tcp".into()],
+                resolve_dns: ResolveDnsConfig::default(),
+            },
+        },
+        filesystem: FilesystemEntitlement::default(),
+        processes: ProcessesEntitlement {
+            spawn: SpawnEntitlement {
+                mode: SpawnMode::Allowlist,
+                allowed: vec![],
+            },
+        },
+        syscalls: SyscallsEntitlement::default(),
+        limits: LimitsEntitlement::default(),
     }
 }
 

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -166,6 +166,11 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         // lands with the gate-hook integration in a follow-up milestone.
         turn_id: 0,
         turn_flags: Vec::new(),
+        // Snapshot of the agent's entitlements at supervisor start.
+        // M7.2 (B0 rule 5) reads this from `pre_tool_use` to gate
+        // process-spawn calls. Mutating entitlements at runtime is out
+        // of scope: the supervisor restarts on profile.yaml change.
+        entitlements: profile.inner.entitlements.clone(),
     };
     let hook_cancel = tokio_util::sync::CancellationToken::new();
     hook_chain

--- a/mur-agent-runtime/tests/b0_rule5_spawn_deny.rs
+++ b/mur-agent-runtime/tests/b0_rule5_spawn_deny.rs
@@ -1,0 +1,83 @@
+//! Rule 5: shell / eval / arbitrary spawn disabled by default; per-agent
+//! toggle (entitlements.processes.spawn.mode = "any" or allowlist).
+
+use mur_agent_runtime::hooks::{B0SafetyHook, Decision, Hook, HookCtx, ToolCall};
+use mur_common::agent::{
+    Entitlements, FilesystemEntitlement, InboundNetwork, LimitsEntitlement, NetworkEntitlement,
+    NetworkOutboundMode, OutboundNetwork, ProcessesEntitlement, ResolveDnsConfig, SpawnEntitlement,
+    SpawnMode, SyscallsEntitlement,
+};
+use serde_json::json;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+fn ent_with_spawn(mode: SpawnMode, allowed: Vec<String>) -> Entitlements {
+    Entitlements {
+        network: NetworkEntitlement {
+            inbound: InboundNetwork { ports: vec![] },
+            outbound: OutboundNetwork {
+                mode: NetworkOutboundMode::Restricted,
+                allow_hosts: vec![],
+                protocols: vec!["tcp".into()],
+                resolve_dns: ResolveDnsConfig::default(),
+            },
+        },
+        filesystem: FilesystemEntitlement::default(),
+        processes: ProcessesEntitlement {
+            spawn: SpawnEntitlement { mode, allowed },
+        },
+        syscalls: SyscallsEntitlement::default(),
+        limits: LimitsEntitlement::default(),
+    }
+}
+
+#[tokio::test]
+async fn process_spawn_denied_when_allowlist_is_empty() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_entitlements(
+        dir.path().to_path_buf(),
+        1,
+        ent_with_spawn(SpawnMode::Allowlist, vec![]),
+    );
+    let call = ToolCall::test(
+        "process.spawn",
+        json!({"argv": ["/bin/sh", "-c", "echo hi"]}),
+    );
+    let cancel = CancellationToken::new();
+    let decision = hook.pre_tool_use(&ctx, &call, &cancel).await.unwrap();
+    assert!(
+        matches!(decision, Decision::Deny { .. }),
+        "got {decision:?}"
+    );
+}
+
+#[tokio::test]
+async fn process_spawn_allowed_when_program_in_allowlist() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_entitlements(
+        dir.path().to_path_buf(),
+        1,
+        ent_with_spawn(SpawnMode::Allowlist, vec!["/usr/bin/git".to_string()]),
+    );
+    let call = ToolCall::test("process.spawn", json!({"argv": ["/usr/bin/git", "status"]}));
+    let cancel = CancellationToken::new();
+    let decision = hook.pre_tool_use(&ctx, &call, &cancel).await.unwrap();
+    assert!(matches!(decision, Decision::Allow), "got {decision:?}");
+}
+
+#[tokio::test]
+async fn process_spawn_unrestricted_when_mode_any() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_entitlements(
+        dir.path().to_path_buf(),
+        1,
+        ent_with_spawn(SpawnMode::Any, vec![]),
+    );
+    let call = ToolCall::test("process.spawn", json!({"argv": ["/bin/sh"]}));
+    let cancel = CancellationToken::new();
+    let decision = hook.pre_tool_use(&ctx, &call, &cancel).await.unwrap();
+    assert!(matches!(decision, Decision::Allow), "got {decision:?}");
+}

--- a/mur-agent-runtime/tests/hooks_smoke.rs
+++ b/mur-agent-runtime/tests/hooks_smoke.rs
@@ -8,32 +8,16 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio_util::sync::CancellationToken;
 
-use mur_agent_runtime::companion::clock::SystemClock;
 use mur_agent_runtime::hooks::{
     Decision, Hook, HookChain, HookCtx, HookError, MessagePatch, OutboundView, PromptPatch,
-    PromptView, TelemetryEmitter, ToolCall, ToolResult, UntrustedWrapper,
+    PromptView, ToolCall, ToolResult, UntrustedWrapper,
 };
 
-struct CountingTelemetry(AtomicUsize);
-
-#[async_trait::async_trait]
-impl TelemetryEmitter for CountingTelemetry {
-    async fn emit_span_event(&self, _name: &str, _attrs: serde_json::Value) {
-        self.0.fetch_add(1, Ordering::SeqCst);
-    }
-}
-
 fn ctx() -> HookCtx {
-    HookCtx {
-        agent_name: "test".into(),
-        agent_uuid: "00000000-0000-0000-0000-000000000000".into(),
-        run_id: "01HQ".into(),
-        clock: Arc::new(SystemClock),
-        telemetry: Arc::new(CountingTelemetry(AtomicUsize::new(0))),
-        agent_home: std::path::PathBuf::new(),
-        turn_id: 0,
-        turn_flags: Vec::new(),
-    }
+    // The custom CountingTelemetry that lived here was never asserted on
+    // (its counter was never read), so the standard test helper covers
+    // every case in this file.
+    HookCtx::for_test_with_home(std::path::PathBuf::new(), 0)
 }
 
 struct DenyOnceHook(AtomicUsize);

--- a/mur-agent-runtime/tests/hooks_snapshot.rs
+++ b/mur-agent-runtime/tests/hooks_snapshot.rs
@@ -9,11 +9,10 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
-use mur_agent_runtime::companion::clock::SystemClock;
 use mur_agent_runtime::hooks::{
     A2AEnvelopeView, Decision, Hook, HookChain, HookCtx, HookError, MessagePatch, OutboundView,
-    Phase, PromptPatch, PromptView, ShutdownReason, Step, TelemetryEmitter, ToolCall, ToolResult,
-    TriggerKind, TriggerPayload,
+    Phase, PromptPatch, PromptView, ShutdownReason, Step, ToolCall, ToolResult, TriggerKind,
+    TriggerPayload,
 };
 use mur_common::AgentProfile;
 
@@ -139,24 +138,10 @@ impl Hook for RecordHook {
     }
 }
 
-struct NoopTel;
-
-#[async_trait::async_trait]
-impl TelemetryEmitter for NoopTel {
-    async fn emit_span_event(&self, _: &str, _: serde_json::Value) {}
-}
-
 fn ctx() -> HookCtx {
-    HookCtx {
-        agent_name: "test".into(),
-        agent_uuid: "00000000-0000-0000-0000-000000000000".into(),
-        run_id: "01HQ".into(),
-        clock: Arc::new(SystemClock),
-        telemetry: Arc::new(NoopTel),
-        agent_home: std::path::PathBuf::new(),
-        turn_id: 0,
-        turn_flags: Vec::new(),
-    }
+    // The struct fields (agent_name, run_id, etc.) aren't asserted on in
+    // this test — it only checks fire sequence — so the helper is fine.
+    HookCtx::for_test_with_home(std::path::PathBuf::new(), 0)
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

M7.2 of the B0 text-only rules.

- M7.2.1: threads Entitlements through HookCtx (scenario C from plan — touched 4 files, but the surface is small: types.rs adds field + constructor + test_default helper, supervisor.rs passes profile.inner.entitlements.clone(), tests/hooks_smoke.rs and tests/hooks_snapshot.rs simplified to use HookCtx::for_test_with_home).
- Bonus fix commit: reorders pre_tool_use so M3.8 Rule 4 fires BEFORE M7.1 Rule 1, fixing a regression in mur-core's card_malicious_description_blocks test that asserts on the after_untrusted_input scope_key tag.
- M7.2.2: pre_tool_use gates 6 spawn-family tool names (process.spawn, process.exec, shell.exec, shell.run, eval.run, command.run) by entitlements.processes.spawn.{mode,allowed}.
  - Allowlist (default) + empty allowed[] = Deny.
  - Allowlist + program in allowed[] = fall through (Allow via subsequent rules).
  - Any = fall through.
  - None (3rd variant) = Deny.
- All M3.8 / M7.1 / M4.8 tests still green.

## Test plan

- [x] cargo test --test b0_rule5_spawn_deny — 3/3
- [x] full mur-agent-runtime suite green
- [x] mur-core card_malicious_description_blocks (M4.8) green again
- [x] cargo clippy clean
- [x] cargo fmt --check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)