### PR TITLE
feat(runtime): B0 text rules — M7.3 network allowlist + GrantStore (rule 2)

### DIFF
--- a/mur-agent-runtime/Cargo.toml
+++ b/mur-agent-runtime/Cargo.toml
@@ -60,6 +60,11 @@ dirs = "5"
 tempfile = "3"
 whatlang = { workspace = true }
 rand = { workspace = true }
+# B0 rule 2 (M7.3) parses `url` field from network tool inputs to derive the
+# host before consulting the entitlement allowlist + GrantStore. Already
+# pulled in transitively by reqwest; declare it explicitly here so the
+# import surface is documented.
+url = "2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -149,6 +149,60 @@ impl Hook for B0SafetyHook {
                 default: AskDefault::Deny,
             });
         }
+        // ── Rule 5: process.spawn / eval / shell deny by default. ────────
+        // Per-agent toggle via entitlements.processes.spawn.mode:
+        //   - Allowlist (default) + empty allowed[]  → deny everything
+        //   - Allowlist + allowed[]                  → only those programs allow
+        //   - Any                                    → unrestricted (user opted in)
+        //
+        // We match the family of tool names — anything that ultimately
+        // exec()s a child process. Every match enters the gate; only
+        // `Any` mode falls through to subsequent rules.
+        const SPAWN_TOOLS: &[&str] = &[
+            "process.spawn",
+            "process.exec",
+            "shell.exec",
+            "shell.run",
+            "eval.run",
+            "command.run",
+        ];
+        if SPAWN_TOOLS.contains(&call.name()) {
+            let spawn = &ctx.entitlements().processes.spawn;
+            match spawn.mode {
+                mur_common::agent::SpawnMode::Any => {
+                    // user opted in; fall through to Rule 1 / default Allow
+                }
+                mur_common::agent::SpawnMode::None => {
+                    return Ok(Decision::Deny {
+                        reason: format!(
+                            "process spawn is disabled by entitlements (mode=none); \
+                             enable with `mur agent perm allow-spawn <name>` (or set \
+                             spawn.mode to `allowlist` / `any`). Tool: `{}`",
+                            call.name()
+                        ),
+                    });
+                }
+                mur_common::agent::SpawnMode::Allowlist => {
+                    let argv0 = call
+                        .input
+                        .get("argv")
+                        .and_then(|v| v.as_array())
+                        .and_then(|a| a.first())
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    if !spawn.allowed.iter().any(|p| p == argv0) {
+                        return Ok(Decision::Deny {
+                            reason: format!(
+                                "process spawn `{}` is not in the agent's allowlist; \
+                                 enable with `mur agent perm allow-spawn <name> \"{}\"` \
+                                 (or set spawn.mode to `any` for unrestricted)",
+                                argv0, argv0,
+                            ),
+                        });
+                    }
+                }
+            }
+        }
         // ── Rule 1: FS confinement (advisory). ───────────────────────────
         // For fs.write / fs.delete / fs.append / fs.create on a path
         // outside <agent_home>, ask the user. Read-only access is the

--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -19,6 +19,9 @@
 //! lookup, post_tool_use redaction, on_message_received untrusted
 //! flag) land with the M8 text-only baseline.
 
+use std::path::PathBuf;
+use std::sync::Mutex;
+
 use tokio_util::sync::CancellationToken;
 
 use crate::hooks::{
@@ -26,18 +29,53 @@ use crate::hooks::{
     UntrustedWrapper,
 };
 use mur_common::multimodal::ProvenanceLedger;
-use mur_common::permissions::ScopeKey;
+use mur_common::permissions::{GrantDecision, GrantStore, ScopeKey};
 
 /// Turn-flag raised by `on_prompt_submit` when at least one untrusted
 /// multimodal artifact was attached to the current turn. Read by
 /// `pre_tool_use` to decide whether to gate side-effect tools.
 const TURN_FLAG_AFTER_UNTRUSTED: &str = "after_untrusted_input";
 
-pub struct B0SafetyHook;
+pub struct B0SafetyHook {
+    /// Loaded lazily on first use per `HookCtx::agent_home()` so tests
+    /// can construct the hook with `B0SafetyHook::new()` and the real
+    /// runtime gets it initialized on first tool call. The cached
+    /// `(PathBuf, GrantStore)` pair lets us detect agent_home swaps
+    /// (e.g. test fixtures sharing a hook) and reload accordingly.
+    grant_store: Mutex<Option<(PathBuf, GrantStore)>>,
+}
 
 impl B0SafetyHook {
     pub fn new() -> Self {
-        Self
+        Self {
+            grant_store: Mutex::new(None),
+        }
+    }
+
+    /// Load (or return cached) GrantStore for this `agent_home`.
+    fn ensure_store(&self, agent_home: &std::path::Path) -> std::io::Result<()> {
+        let mut guard = self.grant_store.lock().unwrap();
+        let needs_reload = match &*guard {
+            Some((cached_home, _)) => cached_home != agent_home,
+            None => true,
+        };
+        if needs_reload {
+            let mut store = GrantStore::new(agent_home);
+            store.load()?;
+            *guard = Some((agent_home.to_path_buf(), store));
+        }
+        Ok(())
+    }
+
+    /// Lookup a grant. Returns `None` if no grant or the grant is
+    /// expired. The `now` clock comes from `chrono::Utc::now()` rather
+    /// than `HookCtx::clock` because `GrantStore` consumes
+    /// `chrono::DateTime<Utc>` directly.
+    fn lookup_grant(&self, scope: &ScopeKey) -> Option<GrantDecision> {
+        let guard = self.grant_store.lock().unwrap();
+        guard
+            .as_ref()
+            .and_then(|(_, store)| store.lookup(scope, chrono::Utc::now()))
     }
 }
 
@@ -230,6 +268,94 @@ impl Hook for B0SafetyHook {
                     ),
                     default: AskDefault::Deny,
                 });
+            }
+        }
+        // ── Rule 2 (M7.3): outbound network allowlist + GrantStore. ──────
+        // Per-agent toggle via entitlements.network.outbound.mode:
+        //   - Unrestricted   → fall through (Allow)
+        //   - Off            → deny everything
+        //   - Restricted (default) + host on allow_hosts → fall through
+        //   - Restricted + host NOT on allow_hosts:
+        //       * GrantStore Allow → fall through silently
+        //       * GrantStore Deny  → bail with revoke instructions
+        //       * no grant         → AskUser (default Deny)
+        //
+        // We extract the host from the tool input's `url` field — the
+        // common shape across the network tool family. Adapt per-tool
+        // if a future tool surfaces a different field name.
+        const NET_TOOLS: &[&str] = &[
+            "network.http_get",
+            "network.http_post",
+            "network.tcp_connect",
+            "network.udp_send",
+            "network.dns_resolve",
+            "fetch", // common alias
+        ];
+        if NET_TOOLS.contains(&call.name()) {
+            let outbound = &ctx.entitlements().network.outbound;
+            let host = call
+                .input
+                .get("url")
+                .and_then(|v| v.as_str())
+                .and_then(|u| {
+                    url::Url::parse(u)
+                        .ok()
+                        .and_then(|p| p.host_str().map(|s| s.to_string()))
+                });
+
+            match outbound.mode {
+                mur_common::agent::NetworkOutboundMode::Unrestricted => {
+                    // user opted in; fall through to default Allow
+                }
+                mur_common::agent::NetworkOutboundMode::Off => {
+                    return Ok(Decision::Deny {
+                        reason: "outbound network is disabled by entitlements (mode=off)".into(),
+                    });
+                }
+                mur_common::agent::NetworkOutboundMode::Restricted => {
+                    let host = host.unwrap_or_default();
+                    if !crate::hooks::b0_helpers::host_is_allowlisted(&host, &outbound.allow_hosts)
+                    {
+                        // Lazy-load the GrantStore for this agent. A load
+                        // failure (e.g. corrupt YAML) shouldn't crash
+                        // execution — fall through to AskUser so the user
+                        // can re-grant.
+                        if self.ensure_store(ctx.agent_home()).is_err() {
+                            tracing::warn!(
+                                "B0SafetyHook: GrantStore load failed; falling back to AskUser"
+                            );
+                        }
+                        let scope_key = ScopeKey {
+                            agent_id: ctx.agent_uuid.clone(),
+                            tool_name: format!("network_outbound::{host}"),
+                            input_schema_hash: String::new(),
+                        };
+                        match self.lookup_grant(&scope_key) {
+                            Some(GrantDecision::Allow) => {
+                                // fall through silently
+                            }
+                            Some(GrantDecision::Deny) => {
+                                return Ok(Decision::Deny {
+                                    reason: format!(
+                                        "outbound to `{host}` was previously denied; \
+                                         revoke via `mur agent perm revoke …` to re-prompt"
+                                    ),
+                                });
+                            }
+                            None => {
+                                return Ok(Decision::AskUser {
+                                    scope_key,
+                                    prompt: format!(
+                                        "Agent wants to make an outbound request to \
+                                         `{host}`. This host isn't on the agent's \
+                                         allowlist. Allow once?"
+                                    ),
+                                    default: AskDefault::Deny,
+                                });
+                            }
+                        }
+                    }
+                }
             }
         }
         Ok(Decision::Allow)

--- a/mur-agent-runtime/src/hooks/b0_helpers.rs
+++ b/mur-agent-runtime/src/hooks/b0_helpers.rs
@@ -85,3 +85,61 @@ mod tests {
         assert!(!path_confined_to(&link, confine.path()));
     }
 }
+
+/// Match a host string against an allowlist that supports leading-dot
+/// wildcards (`.example.com` matches `api.example.com` and
+/// `example.com`). Exact match also passes.
+pub fn host_is_allowlisted(host: &str, allow: &[String]) -> bool {
+    let host = host.to_ascii_lowercase();
+    for pattern in allow {
+        let pattern = pattern.to_ascii_lowercase();
+        if let Some(suffix) = pattern.strip_prefix('.') {
+            if host == suffix || host.ends_with(&format!(".{suffix}")) {
+                return true;
+            }
+        } else if host == pattern {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod allowlist_tests {
+    use super::*;
+
+    #[test]
+    fn exact_match_allowed() {
+        assert!(host_is_allowlisted(
+            "api.openai.com",
+            &["api.openai.com".into()]
+        ));
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert!(host_is_allowlisted(
+            "API.OpenAI.com",
+            &["api.openai.com".into()]
+        ));
+    }
+
+    #[test]
+    fn dot_prefix_matches_subdomain() {
+        let allow = vec![".openai.com".into()];
+        assert!(host_is_allowlisted("api.openai.com", &allow));
+        assert!(host_is_allowlisted("openai.com", &allow));
+    }
+
+    #[test]
+    fn unrelated_host_rejected() {
+        let allow = vec![".openai.com".into()];
+        assert!(!host_is_allowlisted("evil.com", &allow));
+        assert!(!host_is_allowlisted("notopenai.com", &allow));
+    }
+
+    #[test]
+    fn empty_allowlist_rejects_everything() {
+        assert!(!host_is_allowlisted("api.openai.com", &[]));
+    }
+}

--- a/mur-agent-runtime/src/hooks/types.rs
+++ b/mur-agent-runtime/src/hooks/types.rs
@@ -1,6 +1,11 @@
 //! Hook-trait shared value types. All `Send + Sync + 'static` so they can
 //! cross `Arc<dyn Hook>` boundaries.
 
+use mur_common::agent::{
+    Entitlements, FilesystemEntitlement, InboundNetwork, LimitsEntitlement, NetworkEntitlement,
+    NetworkOutboundMode, OutboundNetwork, ProcessesEntitlement, ResolveDnsConfig, SpawnEntitlement,
+    SpawnMode, SyscallsEntitlement,
+};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -33,6 +38,10 @@ pub struct HookCtx {
     /// Turn-scoped flags raised by mutate hooks (e.g.
     /// `"after_untrusted_input"`) and consumed by gate hooks.
     pub turn_flags: Vec<String>,
+    /// Snapshot of the agent profile's entitlements. Read by gate hooks
+    /// (e.g. `B0SafetyHook` rule 5) to decide whether the agent is
+    /// permitted to spawn a process, open a network connection, etc.
+    pub entitlements: Entitlements,
 }
 
 impl HookCtx {
@@ -48,6 +57,10 @@ impl HookCtx {
         &self.turn_flags
     }
 
+    pub fn entitlements(&self) -> &Entitlements {
+        &self.entitlements
+    }
+
     /// Test helper: build a HookCtx pinned to an `agent_home` + `turn_id`.
     /// Used by integration tests that need a real on-disk ledger to read.
     pub fn for_test_with_home(home: PathBuf, turn_id: u64) -> Self {
@@ -60,6 +73,7 @@ impl HookCtx {
             agent_home: home,
             turn_id,
             turn_flags: Vec::new(),
+            entitlements: test_default_entitlements(),
         }
     }
 
@@ -75,7 +89,49 @@ impl HookCtx {
             agent_home: PathBuf::new(),
             turn_id: 0,
             turn_flags,
+            entitlements: test_default_entitlements(),
         }
+    }
+
+    /// Test helper: build a HookCtx pinned to an `agent_home` + `turn_id`
+    /// with an explicit `Entitlements` snapshot. Used by gate-hook tests
+    /// that exercise rules keyed off the entitlement (e.g. rule 5
+    /// process-spawn allowlist).
+    pub fn for_test_with_entitlements(
+        home: PathBuf,
+        turn_id: u64,
+        entitlements: Entitlements,
+    ) -> Self {
+        let mut ctx = Self::for_test_with_home(home, turn_id);
+        ctx.entitlements = entitlements;
+        ctx
+    }
+}
+
+/// Test-only Entitlements default. Mirrors `default_entitlements_custom`
+/// in `mur-core::cmd::agent` so test contexts behave like a freshly
+/// created agent: `Restricted` outbound network, empty allow lists,
+/// `SpawnMode::Allowlist` with no allowed programs (deny-by-default).
+fn test_default_entitlements() -> Entitlements {
+    Entitlements {
+        network: NetworkEntitlement {
+            inbound: InboundNetwork { ports: vec![] },
+            outbound: OutboundNetwork {
+                mode: NetworkOutboundMode::Restricted,
+                allow_hosts: vec![],
+                protocols: vec!["tcp".into()],
+                resolve_dns: ResolveDnsConfig::default(),
+            },
+        },
+        filesystem: FilesystemEntitlement::default(),
+        processes: ProcessesEntitlement {
+            spawn: SpawnEntitlement {
+                mode: SpawnMode::Allowlist,
+                allowed: vec![],
+            },
+        },
+        syscalls: SyscallsEntitlement::default(),
+        limits: LimitsEntitlement::default(),
     }
 }
 

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -166,6 +166,11 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         // lands with the gate-hook integration in a follow-up milestone.
         turn_id: 0,
         turn_flags: Vec::new(),
+        // Snapshot of the agent's entitlements at supervisor start.
+        // M7.2 (B0 rule 5) reads this from `pre_tool_use` to gate
+        // process-spawn calls. Mutating entitlements at runtime is out
+        // of scope: the supervisor restarts on profile.yaml change.
+        entitlements: profile.inner.entitlements.clone(),
     };
     let hook_cancel = tokio_util::sync::CancellationToken::new();
     hook_chain

--- a/mur-agent-runtime/tests/b0_rule2_network_allowlist.rs
+++ b/mur-agent-runtime/tests/b0_rule2_network_allowlist.rs
@@ -1,0 +1,215 @@
+//! Rule 2: outbound network allowlist + GrantStore consumption.
+//! New host → AskUser; existing grant → silent allow; existing deny → bail.
+
+use mur_agent_runtime::hooks::{AskDefault, B0SafetyHook, Decision, Hook, HookCtx, ToolCall};
+use mur_common::agent::{
+    Entitlements, FilesystemEntitlement, InboundNetwork, LimitsEntitlement, NetworkEntitlement,
+    NetworkOutboundMode, OutboundNetwork, ProcessesEntitlement, ResolveDnsConfig, SpawnEntitlement,
+    SpawnMode, SyscallsEntitlement,
+};
+use mur_common::permissions::{Grant, GrantDecision, GrantSource, GrantStore, ScopeKey};
+use serde_json::json;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+/// `for_test_with_entitlements` fills `agent_uuid` with this constant; the
+/// scope_key written into a pre-populated GrantStore must match it for the
+/// lookup to land.
+const TEST_AGENT_UUID: &str = "00000000-0000-0000-0000-000000000000";
+
+fn ent_with_outbound(mode: NetworkOutboundMode, allow: Vec<String>) -> Entitlements {
+    Entitlements {
+        network: NetworkEntitlement {
+            inbound: InboundNetwork { ports: vec![] },
+            outbound: OutboundNetwork {
+                mode,
+                allow_hosts: allow,
+                protocols: vec!["tcp".to_string()],
+                resolve_dns: ResolveDnsConfig::default(),
+            },
+        },
+        filesystem: FilesystemEntitlement::default(),
+        processes: ProcessesEntitlement {
+            spawn: SpawnEntitlement {
+                mode: SpawnMode::Allowlist,
+                allowed: vec![],
+            },
+        },
+        syscalls: SyscallsEntitlement::default(),
+        limits: LimitsEntitlement::default(),
+    }
+}
+
+const NET_TOOL: &str = "network.http_get";
+
+fn net_call(host: &str) -> ToolCall {
+    ToolCall::test(
+        NET_TOOL,
+        json!({"url": format!("https://{host}/v1/models")}),
+    )
+}
+
+#[tokio::test]
+async fn host_in_allowlist_is_allowed_silently() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_entitlements(
+        dir.path().to_path_buf(),
+        1,
+        ent_with_outbound(
+            NetworkOutboundMode::Restricted,
+            vec!["api.openai.com".into()],
+        ),
+    );
+    let cancel = CancellationToken::new();
+    let decision = hook
+        .pre_tool_use(&ctx, &net_call("api.openai.com"), &cancel)
+        .await
+        .unwrap();
+    assert!(matches!(decision, Decision::Allow), "got {decision:?}");
+}
+
+#[tokio::test]
+async fn new_host_triggers_ask_user() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_entitlements(
+        dir.path().to_path_buf(),
+        1,
+        ent_with_outbound(
+            NetworkOutboundMode::Restricted,
+            vec!["api.openai.com".into()],
+        ),
+    );
+    let cancel = CancellationToken::new();
+    let decision = hook
+        .pre_tool_use(&ctx, &net_call("evil.example.com"), &cancel)
+        .await
+        .unwrap();
+    match decision {
+        Decision::AskUser {
+            default, prompt, ..
+        } => {
+            assert!(matches!(default, AskDefault::Deny));
+            assert!(prompt.contains("evil.example.com"));
+        }
+        other => panic!("expected AskUser for new host, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn existing_grant_skips_prompt() {
+    let dir = TempDir::new().unwrap();
+    // Pre-populate a grant for the new host.
+    let mut store = GrantStore::new(dir.path());
+    let scope = ScopeKey {
+        agent_id: TEST_AGENT_UUID.into(),
+        tool_name: "network_outbound::evil.example.com".into(),
+        input_schema_hash: String::new(),
+    };
+    store
+        .insert(Grant {
+            scope_key: scope,
+            decision: GrantDecision::Allow,
+            granted_at: chrono::Utc::now(),
+            expires_at: None,
+            last_used_at: None,
+            source: GrantSource::Ui,
+            source_audit_id: None,
+        })
+        .unwrap();
+
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_entitlements(
+        dir.path().to_path_buf(),
+        1,
+        ent_with_outbound(
+            NetworkOutboundMode::Restricted,
+            vec!["api.openai.com".into()],
+        ),
+    );
+    let cancel = CancellationToken::new();
+    let decision = hook
+        .pre_tool_use(&ctx, &net_call("evil.example.com"), &cancel)
+        .await
+        .unwrap();
+    assert!(
+        matches!(decision, Decision::Allow),
+        "stored Allow grant should silently allow; got {decision:?}",
+    );
+}
+
+#[tokio::test]
+async fn existing_deny_grant_bails() {
+    let dir = TempDir::new().unwrap();
+    let mut store = GrantStore::new(dir.path());
+    let scope = ScopeKey {
+        agent_id: TEST_AGENT_UUID.into(),
+        tool_name: "network_outbound::evil.example.com".into(),
+        input_schema_hash: String::new(),
+    };
+    store
+        .insert(Grant {
+            scope_key: scope,
+            decision: GrantDecision::Deny,
+            granted_at: chrono::Utc::now(),
+            expires_at: None,
+            last_used_at: None,
+            source: GrantSource::Ui,
+            source_audit_id: None,
+        })
+        .unwrap();
+
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_entitlements(
+        dir.path().to_path_buf(),
+        1,
+        ent_with_outbound(NetworkOutboundMode::Restricted, vec![]),
+    );
+    let cancel = CancellationToken::new();
+    let decision = hook
+        .pre_tool_use(&ctx, &net_call("evil.example.com"), &cancel)
+        .await
+        .unwrap();
+    assert!(
+        matches!(decision, Decision::Deny { .. }),
+        "got {decision:?}"
+    );
+}
+
+#[tokio::test]
+async fn unrestricted_mode_allows_everything() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_entitlements(
+        dir.path().to_path_buf(),
+        1,
+        ent_with_outbound(NetworkOutboundMode::Unrestricted, vec![]),
+    );
+    let cancel = CancellationToken::new();
+    let decision = hook
+        .pre_tool_use(&ctx, &net_call("anywhere.com"), &cancel)
+        .await
+        .unwrap();
+    assert!(matches!(decision, Decision::Allow), "got {decision:?}");
+}
+
+#[tokio::test]
+async fn off_mode_denies_everything() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_entitlements(
+        dir.path().to_path_buf(),
+        1,
+        ent_with_outbound(NetworkOutboundMode::Off, vec!["api.openai.com".into()]),
+    );
+    let cancel = CancellationToken::new();
+    let decision = hook
+        .pre_tool_use(&ctx, &net_call("api.openai.com"), &cancel)
+        .await
+        .unwrap();
+    assert!(
+        matches!(decision, Decision::Deny { .. }),
+        "got {decision:?}"
+    );
+}

--- a/mur-agent-runtime/tests/b0_rule5_spawn_deny.rs
+++ b/mur-agent-runtime/tests/b0_rule5_spawn_deny.rs
@@ -1,0 +1,83 @@
+//! Rule 5: shell / eval / arbitrary spawn disabled by default; per-agent
+//! toggle (entitlements.processes.spawn.mode = "any" or allowlist).
+
+use mur_agent_runtime::hooks::{B0SafetyHook, Decision, Hook, HookCtx, ToolCall};
+use mur_common::agent::{
+    Entitlements, FilesystemEntitlement, InboundNetwork, LimitsEntitlement, NetworkEntitlement,
+    NetworkOutboundMode, OutboundNetwork, ProcessesEntitlement, ResolveDnsConfig, SpawnEntitlement,
+    SpawnMode, SyscallsEntitlement,
+};
+use serde_json::json;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+fn ent_with_spawn(mode: SpawnMode, allowed: Vec<String>) -> Entitlements {
+    Entitlements {
+        network: NetworkEntitlement {
+            inbound: InboundNetwork { ports: vec![] },
+            outbound: OutboundNetwork {
+                mode: NetworkOutboundMode::Restricted,
+                allow_hosts: vec![],
+                protocols: vec!["tcp".into()],
+                resolve_dns: ResolveDnsConfig::default(),
+            },
+        },
+        filesystem: FilesystemEntitlement::default(),
+        processes: ProcessesEntitlement {
+            spawn: SpawnEntitlement { mode, allowed },
+        },
+        syscalls: SyscallsEntitlement::default(),
+        limits: LimitsEntitlement::default(),
+    }
+}
+
+#[tokio::test]
+async fn process_spawn_denied_when_allowlist_is_empty() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_entitlements(
+        dir.path().to_path_buf(),
+        1,
+        ent_with_spawn(SpawnMode::Allowlist, vec![]),
+    );
+    let call = ToolCall::test(
+        "process.spawn",
+        json!({"argv": ["/bin/sh", "-c", "echo hi"]}),
+    );
+    let cancel = CancellationToken::new();
+    let decision = hook.pre_tool_use(&ctx, &call, &cancel).await.unwrap();
+    assert!(
+        matches!(decision, Decision::Deny { .. }),
+        "got {decision:?}"
+    );
+}
+
+#[tokio::test]
+async fn process_spawn_allowed_when_program_in_allowlist() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_entitlements(
+        dir.path().to_path_buf(),
+        1,
+        ent_with_spawn(SpawnMode::Allowlist, vec!["/usr/bin/git".to_string()]),
+    );
+    let call = ToolCall::test("process.spawn", json!({"argv": ["/usr/bin/git", "status"]}));
+    let cancel = CancellationToken::new();
+    let decision = hook.pre_tool_use(&ctx, &call, &cancel).await.unwrap();
+    assert!(matches!(decision, Decision::Allow), "got {decision:?}");
+}
+
+#[tokio::test]
+async fn process_spawn_unrestricted_when_mode_any() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_entitlements(
+        dir.path().to_path_buf(),
+        1,
+        ent_with_spawn(SpawnMode::Any, vec![]),
+    );
+    let call = ToolCall::test("process.spawn", json!({"argv": ["/bin/sh"]}));
+    let cancel = CancellationToken::new();
+    let decision = hook.pre_tool_use(&ctx, &call, &cancel).await.unwrap();
+    assert!(matches!(decision, Decision::Allow), "got {decision:?}");
+}

--- a/mur-agent-runtime/tests/hooks_smoke.rs
+++ b/mur-agent-runtime/tests/hooks_smoke.rs
@@ -8,32 +8,16 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio_util::sync::CancellationToken;
 
-use mur_agent_runtime::companion::clock::SystemClock;
 use mur_agent_runtime::hooks::{
     Decision, Hook, HookChain, HookCtx, HookError, MessagePatch, OutboundView, PromptPatch,
-    PromptView, TelemetryEmitter, ToolCall, ToolResult, UntrustedWrapper,
+    PromptView, ToolCall, ToolResult, UntrustedWrapper,
 };
 
-struct CountingTelemetry(AtomicUsize);
-
-#[async_trait::async_trait]
-impl TelemetryEmitter for CountingTelemetry {
-    async fn emit_span_event(&self, _name: &str, _attrs: serde_json::Value) {
-        self.0.fetch_add(1, Ordering::SeqCst);
-    }
-}
-
 fn ctx() -> HookCtx {
-    HookCtx {
-        agent_name: "test".into(),
-        agent_uuid: "00000000-0000-0000-0000-000000000000".into(),
-        run_id: "01HQ".into(),
-        clock: Arc::new(SystemClock),
-        telemetry: Arc::new(CountingTelemetry(AtomicUsize::new(0))),
-        agent_home: std::path::PathBuf::new(),
-        turn_id: 0,
-        turn_flags: Vec::new(),
-    }
+    // The custom CountingTelemetry that lived here was never asserted on
+    // (its counter was never read), so the standard test helper covers
+    // every case in this file.
+    HookCtx::for_test_with_home(std::path::PathBuf::new(), 0)
 }
 
 struct DenyOnceHook(AtomicUsize);

--- a/mur-agent-runtime/tests/hooks_snapshot.rs
+++ b/mur-agent-runtime/tests/hooks_snapshot.rs
@@ -9,11 +9,10 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
-use mur_agent_runtime::companion::clock::SystemClock;
 use mur_agent_runtime::hooks::{
     A2AEnvelopeView, Decision, Hook, HookChain, HookCtx, HookError, MessagePatch, OutboundView,
-    Phase, PromptPatch, PromptView, ShutdownReason, Step, TelemetryEmitter, ToolCall, ToolResult,
-    TriggerKind, TriggerPayload,
+    Phase, PromptPatch, PromptView, ShutdownReason, Step, ToolCall, ToolResult, TriggerKind,
+    TriggerPayload,
 };
 use mur_common::AgentProfile;
 
@@ -139,24 +138,10 @@ impl Hook for RecordHook {
     }
 }
 
-struct NoopTel;
-
-#[async_trait::async_trait]
-impl TelemetryEmitter for NoopTel {
-    async fn emit_span_event(&self, _: &str, _: serde_json::Value) {}
-}
-
 fn ctx() -> HookCtx {
-    HookCtx {
-        agent_name: "test".into(),
-        agent_uuid: "00000000-0000-0000-0000-000000000000".into(),
-        run_id: "01HQ".into(),
-        clock: Arc::new(SystemClock),
-        telemetry: Arc::new(NoopTel),
-        agent_home: std::path::PathBuf::new(),
-        turn_id: 0,
-        turn_flags: Vec::new(),
-    }
+    // The struct fields (agent_name, run_id, etc.) aren't asserted on in
+    // this test — it only checks fire sequence — so the helper is fine.
+    HookCtx::for_test_with_home(std::path::PathBuf::new(), 0)
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `B0SafetyHook` gains a lazy-loaded `GrantStore` (loaded on first
  `pre_tool_use` call per `agent_home`; cached for subsequent calls,
  reloaded if `agent_home` changes).
- New `host_is_allowlisted` helper in `b0_helpers.rs` supports
  leading-dot wildcards (`.openai.com` matches `api.openai.com` and
  `openai.com`) and exact match. Case-insensitive.
- Rule 2 branch in `pre_tool_use`:
  - `mode=Unrestricted` → fall through (Allow)
  - `mode=Off` → Deny everything
  - `mode=Restricted` + host in `allow_hosts` → fall through
  - `mode=Restricted` + host NOT in `allow_hosts`:
    - GrantStore Allow grant → fall through silently
    - GrantStore Deny grant → Deny with revoke instructions
    - no grant → AskUser (default Deny)
- 6 net-tool aliases gated (`network.http_get/post`, `tcp_connect`,
  `udp_send`, `dns_resolve`, `fetch`).
- Adds `url = "2"` to `mur-agent-runtime/Cargo.toml` (already
  transitive via reqwest; explicit declaration documents the import
  surface).

## Rule ordering

Pre-existing chain stays intact; Rule 2 lands at the tail before the
default `Decision::Allow`:

1. Rule 4 (M3.8): same-turn side-effect after fresh untrusted input
2. Rule 5 (M7.2): process spawn allowlist
3. Rule 1 (M7.1): FS confinement to agent_home
4. **Rule 2 (M7.3)**: outbound network allowlist + GrantStore
5. Default `Decision::Allow`

Rule 4's `is_side_effect_tool` already classifies `network.*` as side-
effects, so a multimodal-drop turn intentionally short-circuits to the
M3.8 prompt before Rule 2 runs. Rule 2 fires on the next, clean turn
once the multimodal flag has cleared.

## Test plan

- [x] `cargo test --test b0_rule2_network_allowlist` — 6/6 pass
- [x] `cargo test --lib hooks::b0_helpers` — 10/10 pass (5 new
      allowlist + 5 existing path-confinement)
- [x] full `mur-agent-runtime --tests` suite green; M3.8 / M4.8 / M7.1
      / M7.2 tests unaffected (b0_after_card_import_deny 1/1,
      b0_rule1_fs_confinement 2/2, b0_rule5_spawn_deny 3/3,
      b0_side_effect_deny 4/4, b0_untrusted_wrapper 3/3, card_extended
      3/3, card_method 1/1, hooks_smoke 4/4, hooks_snapshot 1/1)
- [x] `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings`
- [x] `cargo fmt --check`

## Invariant matrix

| Mode         | Allowlist hit | Grant         | Decision   |
|--------------|---------------|---------------|------------|
| Unrestricted | n/a           | n/a           | Allow      |
| Off          | n/a           | n/a           | Deny       |
| Restricted   | yes           | n/a           | Allow      |
| Restricted   | no            | none          | AskUser    |
| Restricted   | no            | Allow         | Allow      |
| Restricted   | no            | Deny          | Deny       |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>