### PR TITLE
feat(runtime): B0 text rules — M7.5 outbound secret prefilter (rule 7)

### DIFF
--- a/mur-agent-runtime/Cargo.toml
+++ b/mur-agent-runtime/Cargo.toml
@@ -65,6 +65,10 @@ rand = { workspace = true }
 # pulled in transitively by reqwest; declare it explicitly here so the
 # import surface is documented.
 url = "2"
+# B0 rule 7 (M7.5) outbound secret pre-filter compiles ~11 credential
+# patterns once via OnceLock and matches each outbound message body before
+# delivery. Pattern set deliberately favors false-positives.
+regex = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -25,8 +25,8 @@ use std::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use crate::hooks::{
-    AskDefault, Decision, Hook, HookCtx, HookError, PromptPatch, PromptView, ToolCall,
-    UntrustedWrapper,
+    AskDefault, Decision, Hook, HookCtx, HookError, MessagePatch, OutboundView, PromptPatch,
+    PromptView, ToolCall, UntrustedWrapper,
 };
 use mur_common::multimodal::ProvenanceLedger;
 use mur_common::permissions::{GrantDecision, GrantStore, ScopeKey};
@@ -401,6 +401,28 @@ impl Hook for B0SafetyHook {
             }
         }
         Ok(Decision::Allow)
+    }
+
+    async fn on_message_send(
+        &self,
+        _ctx: &HookCtx,
+        view: &OutboundView,
+        _tok: &CancellationToken,
+    ) -> Result<MessagePatch, HookError> {
+        // ── Rule 7 (M7.5): outbound credential pre-filter. ───────────────
+        // Match the body against ~11 well-known credential patterns
+        // (OpenAI / Anthropic / AWS / GitHub / GCP / JWT / PEM /
+        // Slack-webhook / .env-style assignment). On hit, drop the
+        // message entirely with a reason that names the matched class
+        // so the agent can self-correct.
+        if let Some(label) = crate::hooks::b0_helpers::scan_for_secrets(&view.body) {
+            tracing::warn!("B0SafetyHook: dropping outbound — secret detected ({label})");
+            return Ok(MessagePatch::drop_with(&format!(
+                "outbound message blocked: contains credential pattern ({label}). \
+                 Strip the secret and retry. (B0 rule 7)"
+            )));
+        }
+        Ok(MessagePatch::noop())
     }
 }
 

--- a/mur-agent-runtime/src/hooks/b0_helpers.rs
+++ b/mur-agent-runtime/src/hooks/b0_helpers.rs
@@ -143,3 +143,107 @@ mod allowlist_tests {
         assert!(!host_is_allowlisted("api.openai.com", &[]));
     }
 }
+
+/// Scan body for known credential/secret patterns. Returns the FIRST
+/// match's classification (or `None` if clean). Patterns deliberately
+/// favor false-positives over false-negatives — accidentally dropping
+/// a benign message is fine; leaking a key is not.
+pub fn scan_for_secrets(body: &str) -> Option<&'static str> {
+    use regex::Regex;
+    use std::sync::OnceLock;
+
+    // Compile once; share across calls.
+    static PATTERNS: OnceLock<Vec<(Regex, &'static str)>> = OnceLock::new();
+    let patterns = PATTERNS.get_or_init(|| {
+        vec![
+            // OpenAI / Anthropic API keys
+            (Regex::new(r"\bsk-[a-zA-Z0-9]{20,}\b").unwrap(), "openai_key"),
+            (Regex::new(r"\bsk-ant-[a-zA-Z0-9-]{20,}\b").unwrap(), "anthropic_key"),
+            // AWS access keys
+            (Regex::new(r"\bAKIA[0-9A-Z]{16}\b").unwrap(), "aws_access_key"),
+            (Regex::new(r"\baws_secret_access_key\s*[:=]\s*[A-Za-z0-9/+=]{40}\b").unwrap(), "aws_secret_key"),
+            // GitHub PAT
+            (Regex::new(r"\bghp_[A-Za-z0-9]{36}\b").unwrap(), "github_pat"),
+            (Regex::new(r"\bghs_[A-Za-z0-9]{36}\b").unwrap(), "github_app_token"),
+            // GCP service account / API key
+            (Regex::new(r"\bAIza[0-9A-Za-z_-]{35}\b").unwrap(), "gcp_api_key"),
+            // JWT (3 base64url segments separated by dots)
+            (Regex::new(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b").unwrap(), "jwt"),
+            // PEM private key
+            (Regex::new(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----").unwrap(), "pem_private_key"),
+            // Slack webhook
+            (Regex::new(r"\bhooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]+\b").unwrap(), "slack_webhook"),
+            // Generic .env-style assignment with high-entropy value
+            (Regex::new(r"(?i)\b(api_key|api_secret|secret_key|access_token|password|token)\s*[:=]\s*[A-Za-z0-9_\-./+=]{20,}\b").unwrap(), "env_assignment"),
+        ]
+    });
+
+    for (rx, label) in patterns {
+        if rx.is_match(body) {
+            return Some(label);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod secret_tests {
+    use super::*;
+
+    #[test]
+    fn detects_openai_key() {
+        assert_eq!(
+            scan_for_secrets("here is my key: sk-abcd1234567890efghij1234"),
+            Some("openai_key"),
+        );
+    }
+
+    #[test]
+    fn detects_anthropic_key() {
+        assert!(scan_for_secrets("sk-ant-abcdefghijklmnopqrst-1234").is_some());
+    }
+
+    #[test]
+    fn detects_aws_access_key() {
+        assert_eq!(
+            scan_for_secrets("AKIAIOSFODNN7EXAMPLE"),
+            Some("aws_access_key"),
+        );
+    }
+
+    #[test]
+    fn detects_github_pat() {
+        assert_eq!(
+            scan_for_secrets("ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            Some("github_pat"),
+        );
+    }
+
+    #[test]
+    fn detects_jwt() {
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        assert_eq!(scan_for_secrets(jwt), Some("jwt"));
+    }
+
+    #[test]
+    fn detects_pem() {
+        assert_eq!(
+            scan_for_secrets("-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END..."),
+            Some("pem_private_key"),
+        );
+    }
+
+    #[test]
+    fn detects_env_assignment() {
+        assert_eq!(
+            scan_for_secrets("api_key=abcdefghij1234567890"),
+            Some("env_assignment"),
+        );
+    }
+
+    #[test]
+    fn clean_text_returns_none() {
+        assert_eq!(scan_for_secrets("the model is gpt-4o today"), None);
+        assert_eq!(scan_for_secrets("this is a normal message"), None);
+    }
+}

--- a/mur-agent-runtime/tests/b0_rule7_secret_prefilter.rs
+++ b/mur-agent-runtime/tests/b0_rule7_secret_prefilter.rs
@@ -1,0 +1,56 @@
+//! Rule 7: outbound message containing a credential is dropped.
+//!
+//! Field-name note: `MessagePatch` exposes a `drop: bool` flag plus a
+//! `drop_reason: Option<String>` for telemetry. We assert against
+//! `drop_reason.is_some()` (the plan's `patch.drop.is_some()` line was
+//! pseudocode — the real field is `drop_reason`).
+
+use mur_agent_runtime::hooks::{B0SafetyHook, Hook, HookCtx, OutboundView};
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn outbound_with_openai_key_is_dropped() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_home(dir.path().to_path_buf(), 1);
+    let view = OutboundView {
+        recipient: Some("peer".into()),
+        body: "here is my OpenAI key: sk-abcd1234567890efghij1234".into(),
+        locale: None,
+    };
+    let cancel = CancellationToken::new();
+    let patch = hook.on_message_send(&ctx, &view, &cancel).await.unwrap();
+    assert!(
+        patch.drop,
+        "expected drop=true on credential-containing body; got {patch:?}",
+    );
+    assert!(
+        patch.drop_reason.is_some(),
+        "expected drop_reason on credential-containing body; got {patch:?}",
+    );
+    let reason = patch.drop_reason.as_ref().unwrap();
+    assert!(
+        reason.contains("openai_key") || reason.contains("secret"),
+        "got {reason}"
+    );
+}
+
+#[tokio::test]
+async fn clean_outbound_message_passes_through() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_home(dir.path().to_path_buf(), 1);
+    let view = OutboundView {
+        recipient: Some("peer".into()),
+        body: "hi friend, did you see today's weather?".into(),
+        locale: None,
+    };
+    let cancel = CancellationToken::new();
+    let patch = hook.on_message_send(&ctx, &view, &cancel).await.unwrap();
+    assert!(!patch.drop, "clean message should pass; got {patch:?}");
+    assert!(
+        patch.drop_reason.is_none(),
+        "clean message should pass; got {patch:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- `scan_for_secrets` pure helper covers 11 credential patterns (OpenAI / Anthropic / AWS / GitHub / GCP / JWT / PEM / Slack-webhook / .env-style assignment).
- `B0SafetyHook::on_message_send` drops outbound with a clear reason identifying which pattern matched (B0 rule 7).
- Field-name note: tests assert `patch.drop` (bool) + `patch.drop_reason` (Option<String>) — these are the actual MessagePatch fields.

## Test plan

- [x] `cargo test --lib hooks::b0_helpers` — 18/18 (5 fs + 5 net + 8 secret)
- [x] `cargo test --test b0_rule7_secret_prefilter` — 2/2
- [x] full `cargo test -p mur-agent-runtime --tests` green
- [x] clippy + fmt clean