### PR TITLE
feat(runtime): B0 text rules — M7.6 memory redaction (rule 8)

### DIFF
--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -25,8 +25,8 @@ use std::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use crate::hooks::{
-    AskDefault, Decision, Hook, HookCtx, HookError, MessagePatch, OutboundView, PromptPatch,
-    PromptView, ToolCall, UntrustedWrapper,
+    AskDefault, Decision, Hook, HookCtx, HookError, MessagePatch, OutboundView, PostToolUsePatch,
+    PromptPatch, PromptView, ToolCall, ToolResult, UntrustedWrapper,
 };
 use mur_common::multimodal::ProvenanceLedger;
 use mur_common::permissions::{GrantDecision, GrantStore, ScopeKey};
@@ -423,6 +423,39 @@ impl Hook for B0SafetyHook {
             )));
         }
         Ok(MessagePatch::noop())
+    }
+
+    async fn post_tool_use(
+        &self,
+        _ctx: &HookCtx,
+        call: &ToolCall,
+        result: &ToolResult,
+        _tok: &CancellationToken,
+    ) -> Result<PostToolUsePatch, HookError> {
+        // ── Rule 8 (M7.6): redact PII in memory.* tool outputs. ──────────
+        // Only memory.* tools get the redaction pass; everything else
+        // is unchanged. The redactor is permissive (catches obvious
+        // email/SSN/cc/phone patterns) and the patch is consumed by
+        // the supervisor to rewrite `ToolResult.output` before the
+        // value lands in the persisted memory store.
+        //
+        // NOTE: this hook returns the patch; wiring `chain.post_tool_use`'s
+        // returned `PostToolUsePatch` into the persistence path is
+        // tracked separately. M7.6 only covers the hook + chain folding;
+        // the supervisor caller does not yet act on `replace_output`.
+        if !call.name().starts_with("memory.") {
+            return Ok(PostToolUsePatch::default());
+        }
+        let Some(text) = result.output.as_str() else {
+            return Ok(PostToolUsePatch::default());
+        };
+        let redacted = crate::hooks::b0_helpers::redact_pii(text);
+        if redacted == text {
+            return Ok(PostToolUsePatch::default());
+        }
+        Ok(PostToolUsePatch {
+            replace_output: Some(serde_json::Value::String(redacted)),
+        })
     }
 }
 

--- a/mur-agent-runtime/src/hooks/b0_helpers.rs
+++ b/mur-agent-runtime/src/hooks/b0_helpers.rs
@@ -261,19 +261,27 @@ pub fn redact_pii(body: &str) -> String {
     let patterns = PATTERNS.get_or_init(|| {
         vec![
             // Email
-            (Regex::new(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b").unwrap(), "email"),
+            (
+                Regex::new(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b").unwrap(),
+                "email",
+            ),
             // US SSN
             (Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").unwrap(), "ssn"),
             // Credit card (very loose: 13-19 digits in groups)
             (Regex::new(r"\b(?:\d{4}[- ]?){3,4}\d{1,4}\b").unwrap(), "cc"),
             // Phone (international or US-style)
-            (Regex::new(r"\b\+?\d{1,3}[- ]?\(?\d{3}\)?[- ]?\d{3}[- ]?\d{4}\b").unwrap(), "phone"),
+            (
+                Regex::new(r"\b\+?\d{1,3}[- ]?\(?\d{3}\)?[- ]?\d{3}[- ]?\d{4}\b").unwrap(),
+                "phone",
+            ),
         ]
     });
 
     let mut out = body.to_string();
     for (rx, label) in patterns {
-        out = rx.replace_all(&out, format!("<REDACTED:{label}>")).to_string();
+        out = rx
+            .replace_all(&out, format!("<REDACTED:{label}>"))
+            .to_string();
     }
     out
 }
@@ -284,7 +292,10 @@ mod redact_tests {
 
     #[test]
     fn redacts_email() {
-        assert_eq!(redact_pii("contact alex@example.com"), "contact <REDACTED:email>");
+        assert_eq!(
+            redact_pii("contact alex@example.com"),
+            "contact <REDACTED:email>"
+        );
     }
 
     #[test]

--- a/mur-agent-runtime/src/hooks/b0_helpers.rs
+++ b/mur-agent-runtime/src/hooks/b0_helpers.rs
@@ -247,3 +247,66 @@ mod secret_tests {
         assert_eq!(scan_for_secrets("this is a normal message"), None);
     }
 }
+
+/// Redact common PII patterns in `body`. Returns the redacted text;
+/// the redaction is permissive (catches obvious patterns; defers to
+/// the user for ambiguous cases).
+///
+/// Replaces matched spans with `<REDACTED:label>`.
+pub fn redact_pii(body: &str) -> String {
+    use regex::Regex;
+    use std::sync::OnceLock;
+
+    static PATTERNS: OnceLock<Vec<(Regex, &'static str)>> = OnceLock::new();
+    let patterns = PATTERNS.get_or_init(|| {
+        vec![
+            // Email
+            (Regex::new(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b").unwrap(), "email"),
+            // US SSN
+            (Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").unwrap(), "ssn"),
+            // Credit card (very loose: 13-19 digits in groups)
+            (Regex::new(r"\b(?:\d{4}[- ]?){3,4}\d{1,4}\b").unwrap(), "cc"),
+            // Phone (international or US-style)
+            (Regex::new(r"\b\+?\d{1,3}[- ]?\(?\d{3}\)?[- ]?\d{3}[- ]?\d{4}\b").unwrap(), "phone"),
+        ]
+    });
+
+    let mut out = body.to_string();
+    for (rx, label) in patterns {
+        out = rx.replace_all(&out, format!("<REDACTED:{label}>")).to_string();
+    }
+    out
+}
+
+#[cfg(test)]
+mod redact_tests {
+    use super::*;
+
+    #[test]
+    fn redacts_email() {
+        assert_eq!(redact_pii("contact alex@example.com"), "contact <REDACTED:email>");
+    }
+
+    #[test]
+    fn redacts_ssn() {
+        assert_eq!(redact_pii("ssn 123-45-6789"), "ssn <REDACTED:ssn>");
+    }
+
+    #[test]
+    fn redacts_credit_card() {
+        let red = redact_pii("card 4111-1111-1111-1111");
+        assert!(red.contains("<REDACTED:cc>"), "got {red}");
+    }
+
+    #[test]
+    fn redacts_phone() {
+        let red = redact_pii("call +1-555-123-4567");
+        assert!(red.contains("<REDACTED:phone>"), "got {red}");
+    }
+
+    #[test]
+    fn clean_text_unchanged() {
+        let clean = "the project will ship next week.";
+        assert_eq!(redact_pii(clean), clean);
+    }
+}

--- a/mur-agent-runtime/src/hooks/chain.rs
+++ b/mur-agent-runtime/src/hooks/chain.rs
@@ -14,8 +14,8 @@ use tracing::warn;
 
 use crate::hooks::{
     A2AEnvelopeView, Decision, Hook, HookCtx, HookError, MessagePatch, OutboundView, Phase,
-    PromptPatch, PromptView, ShutdownReason, Step, ToolCall, ToolResult, TriggerKind,
-    TriggerPayload,
+    PostToolUsePatch, PromptPatch, PromptView, ShutdownReason, Step, ToolCall, ToolResult,
+    TriggerKind, TriggerPayload,
 };
 use mur_common::AgentProfile;
 
@@ -166,27 +166,39 @@ impl HookChain {
         }
     }
 
+    /// `post_tool_use` is observe-with-mutate-hatch (HOOK_SCHEMA_VERSION
+    /// 2). Hooks run in parallel via `join_all`; errors are logged and
+    /// not propagated. Successful patches are folded in chain order
+    /// using `PostToolUsePatch::merge` (last-write-wins for
+    /// `replace_output`) and the merged patch is returned to the
+    /// supervisor, which decides whether to rewrite
+    /// `ToolResult.output` before persisting.
     pub async fn post_tool_use(
         &self,
         ctx: &HookCtx,
         call: &ToolCall,
         result: &ToolResult,
         tok: &CancellationToken,
-    ) {
+    ) -> PostToolUsePatch {
         let futs = self
             .hooks
             .iter()
             .map(|h| h.post_tool_use(ctx, call, result, tok))
             .collect::<Vec<_>>();
+        let mut acc = PostToolUsePatch::noop();
         for (i, res) in futures::future::join_all(futs)
             .await
             .into_iter()
             .enumerate()
         {
-            if let Err(e) = res {
-                warn!(handler = self.hooks[i].name(), error = %e, "post_tool_use failed");
+            match res {
+                Ok(p) => acc = acc.merge(p),
+                Err(e) => {
+                    warn!(handler = self.hooks[i].name(), error = %e, "post_tool_use failed");
+                }
             }
         }
+        acc
     }
 
     pub async fn on_step_finish(&self, ctx: &HookCtx, step: &Step, tok: &CancellationToken) {

--- a/mur-agent-runtime/src/hooks/mod.rs
+++ b/mur-agent-runtime/src/hooks/mod.rs
@@ -23,7 +23,7 @@ pub mod telemetry;
 pub use b0::B0SafetyHook;
 pub use chain::HookChain;
 pub use decision::Decision;
-pub use patch::{MessagePatch, PromptPatch, UntrustedWrapper};
+pub use patch::{MessagePatch, PostToolUsePatch, PromptPatch, UntrustedWrapper};
 pub use types::{
     A2AEnvelopeView, AskDefault, ErrorAction, HookCtx, HookError, OutboundView, Phase, PromptView,
     ShutdownReason, Step, TelemetryEmitter, ToolCall, ToolResult, TriggerKind, TriggerPayload,
@@ -35,7 +35,13 @@ use tokio_util::sync::CancellationToken;
 /// Schema version for the frozen hook trait surface. Any breaking change
 /// (method rename, signature change, dispatch semantics shift, new phase
 /// inserted) must bump this value.
-pub const HOOK_SCHEMA_VERSION: u32 = 1;
+///
+/// Version history:
+/// * v1 — initial freeze (10 methods, observe phase returns `()`).
+/// * v2 — `post_tool_use` returns `Result<PostToolUsePatch, HookError>`
+///   (was `Result<(), HookError>`) so B0 rule 8 (M7.6) can redact
+///   PII in `memory.*` tool outputs before they're persisted.
+pub const HOOK_SCHEMA_VERSION: u32 = 2;
 
 #[async_trait::async_trait]
 pub trait Hook: Send + Sync {
@@ -102,14 +108,19 @@ pub trait Hook: Send + Sync {
         Ok(())
     }
 
+    /// Observe phase with an opt-in mutate hatch: hooks that don't need
+    /// to mutate the result return `PostToolUsePatch::default()`. The
+    /// chain runner folds patches (last-write-wins for
+    /// `replace_output`) and returns the merged patch to the supervisor
+    /// so it can rewrite `ToolResult.output` before persistence.
     async fn post_tool_use(
         &self,
         _ctx: &HookCtx,
         _call: &ToolCall,
         _result: &ToolResult,
         _tok: &CancellationToken,
-    ) -> Result<(), HookError> {
-        Ok(())
+    ) -> Result<PostToolUsePatch, HookError> {
+        Ok(PostToolUsePatch::default())
     }
 
     async fn on_step_finish(

--- a/mur-agent-runtime/src/hooks/patch.rs
+++ b/mur-agent-runtime/src/hooks/patch.rs
@@ -55,6 +55,40 @@ impl PromptPatch {
     }
 }
 
+/// Returned from `post_tool_use`. Default = pass-through (no mutation
+/// of the `ToolResult` before persistence).
+///
+/// Currently the only field is `replace_output`, written by B0 rule 8
+/// (PII redaction in `memory.*` tool results). Hooks that don't need
+/// to mutate the output return `PostToolUsePatch::default()`.
+///
+/// Fold semantics in the chain runner: last-write-wins. If multiple
+/// hooks return non-`None` `replace_output`, the last hook in chain
+/// order takes effect. This keeps the dispatcher simple while M7.6
+/// only has one redactor (B0SafetyHook); more elaborate merging can
+/// land later if a second post-tool mutator ships.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PostToolUsePatch {
+    /// Replace `ToolResult.output` with this value before persisting
+    /// or returning to the model. `None` = no change.
+    pub replace_output: Option<serde_json::Value>,
+}
+
+impl PostToolUsePatch {
+    pub fn noop() -> Self {
+        Self::default()
+    }
+
+    /// Deterministic fold. `other` runs after `self` (last-write-wins
+    /// for `replace_output`).
+    pub fn merge(mut self, other: PostToolUsePatch) -> Self {
+        if let Some(o) = other.replace_output {
+            self.replace_output = Some(o);
+        }
+        self
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MessagePatch {
     /// Replace body (e.g., translation by i18n).

--- a/mur-agent-runtime/src/hooks/telemetry.rs
+++ b/mur-agent-runtime/src/hooks/telemetry.rs
@@ -13,8 +13,9 @@ use serde_json::json;
 use tokio_util::sync::CancellationToken;
 
 use crate::hooks::{
-    A2AEnvelopeView, Hook, HookCtx, HookError, MessagePatch, OutboundView, Phase, PromptPatch,
-    PromptView, ShutdownReason, Step, ToolCall, ToolResult, TriggerKind, TriggerPayload,
+    A2AEnvelopeView, Hook, HookCtx, HookError, MessagePatch, OutboundView, Phase, PostToolUsePatch,
+    PromptPatch, PromptView, ShutdownReason, Step, ToolCall, ToolResult, TriggerKind,
+    TriggerPayload,
 };
 
 pub struct TelemetryHook;
@@ -146,7 +147,7 @@ impl Hook for TelemetryHook {
         call: &ToolCall,
         result: &ToolResult,
         _: &CancellationToken,
-    ) -> Result<(), HookError> {
+    ) -> Result<PostToolUsePatch, HookError> {
         self.emit(
             ctx,
             Phase::PostToolUse,
@@ -160,7 +161,7 @@ impl Hook for TelemetryHook {
             }),
         )
         .await;
-        Ok(())
+        Ok(PostToolUsePatch::default())
     }
 
     async fn on_step_finish(

--- a/mur-agent-runtime/tests/b0_rule8_memory_redaction.rs
+++ b/mur-agent-runtime/tests/b0_rule8_memory_redaction.rs
@@ -1,0 +1,111 @@
+//! Rule 8 (M7.6): `B0SafetyHook::post_tool_use` redacts PII in
+//! `memory.*` tool outputs before the value is persisted.
+//!
+//! These tests target the hook directly (not the chain) so they isolate
+//! the redaction logic from chain-folding semantics. Wiring the chain's
+//! `PostToolUsePatch` into the supervisor's persistence path is tracked
+//! separately.
+
+use mur_agent_runtime::hooks::{B0SafetyHook, Hook, HookCtx, ToolCall, ToolResult};
+use serde_json::json;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn memory_write_email_gets_redacted() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_home(dir.path().to_path_buf(), 1);
+    let call = ToolCall::test("memory.write", json!({"key": "user.email"}));
+    let result = ToolResult {
+        call_id: "test-call".into(),
+        ok: true,
+        output: serde_json::Value::String("alex@example.com".into()),
+        duration_ms: 1,
+    };
+    let cancel = CancellationToken::new();
+    let patch = hook
+        .post_tool_use(&ctx, &call, &result, &cancel)
+        .await
+        .unwrap();
+    let redacted = patch
+        .replace_output
+        .as_ref()
+        .expect("redaction patch expected");
+    assert!(redacted.as_str().unwrap().contains("<REDACTED:email>"));
+}
+
+#[tokio::test]
+async fn non_memory_tool_passes_through() {
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_home(dir.path().to_path_buf(), 1);
+    let call = ToolCall::test("fs.read", json!({"path": "/tmp/x"}));
+    let result = ToolResult {
+        call_id: "test-call".into(),
+        ok: true,
+        output: serde_json::Value::String("alex@example.com".into()),
+        duration_ms: 1,
+    };
+    let cancel = CancellationToken::new();
+    let patch = hook
+        .post_tool_use(&ctx, &call, &result, &cancel)
+        .await
+        .unwrap();
+    assert!(
+        patch.replace_output.is_none(),
+        "non-memory tool should not be redacted; got {patch:?}",
+    );
+}
+
+#[tokio::test]
+async fn memory_read_clean_text_no_patch() {
+    // memory.* tool output that's clean text should not produce a
+    // patch — the supervisor should see `replace_output == None` and
+    // leave the original output untouched.
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_home(dir.path().to_path_buf(), 1);
+    let call = ToolCall::test("memory.read", json!({"key": "project.name"}));
+    let result = ToolResult {
+        call_id: "test-call".into(),
+        ok: true,
+        output: serde_json::Value::String("the project will ship next week".into()),
+        duration_ms: 1,
+    };
+    let cancel = CancellationToken::new();
+    let patch = hook
+        .post_tool_use(&ctx, &call, &result, &cancel)
+        .await
+        .unwrap();
+    assert!(
+        patch.replace_output.is_none(),
+        "clean memory.* output should pass through; got {patch:?}",
+    );
+}
+
+#[tokio::test]
+async fn memory_write_non_string_output_passes_through() {
+    // Numeric / object outputs aren't redacted (no string body to scan).
+    // We currently only redact `Value::String`; richer types are a
+    // follow-up.
+    let dir = TempDir::new().unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_home(dir.path().to_path_buf(), 1);
+    let call = ToolCall::test("memory.write", json!({"key": "count"}));
+    let result = ToolResult {
+        call_id: "test-call".into(),
+        ok: true,
+        output: json!({"count": 42}),
+        duration_ms: 1,
+    };
+    let cancel = CancellationToken::new();
+    let patch = hook
+        .post_tool_use(&ctx, &call, &result, &cancel)
+        .await
+        .unwrap();
+    assert!(
+        patch.replace_output.is_none(),
+        "non-string memory.* output should pass through; got {patch:?}",
+    );
+}

--- a/mur-agent-runtime/tests/hooks_smoke.rs
+++ b/mur-agent-runtime/tests/hooks_smoke.rs
@@ -9,8 +9,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio_util::sync::CancellationToken;
 
 use mur_agent_runtime::hooks::{
-    Decision, Hook, HookChain, HookCtx, HookError, MessagePatch, OutboundView, PromptPatch,
-    PromptView, ToolCall, ToolResult, UntrustedWrapper,
+    Decision, Hook, HookChain, HookCtx, HookError, MessagePatch, OutboundView, PostToolUsePatch,
+    PromptPatch, PromptView, ToolCall, ToolResult, UntrustedWrapper,
 };
 
 fn ctx() -> HookCtx {
@@ -144,9 +144,9 @@ impl Hook for CountObserve {
         _: &ToolCall,
         _: &ToolResult,
         _: &CancellationToken,
-    ) -> Result<(), HookError> {
+    ) -> Result<PostToolUsePatch, HookError> {
         self.0.fetch_add(1, Ordering::SeqCst);
-        Ok(())
+        Ok(PostToolUsePatch::default())
     }
 }
 
@@ -171,7 +171,7 @@ async fn observe_runs_all_hooks_in_parallel() {
         output: serde_json::json!({}),
         duration_ms: 5,
     };
-    chain.post_tool_use(&ctx(), &call, &result, &tok).await;
+    let _patch = chain.post_tool_use(&ctx(), &call, &result, &tok).await;
     assert_eq!(counter.load(Ordering::SeqCst), 3);
 }
 

--- a/mur-agent-runtime/tests/hooks_snapshot.rs
+++ b/mur-agent-runtime/tests/hooks_snapshot.rs
@@ -11,8 +11,8 @@ use tokio_util::sync::CancellationToken;
 
 use mur_agent_runtime::hooks::{
     A2AEnvelopeView, Decision, Hook, HookChain, HookCtx, HookError, MessagePatch, OutboundView,
-    Phase, PromptPatch, PromptView, ShutdownReason, Step, ToolCall, ToolResult, TriggerKind,
-    TriggerPayload,
+    Phase, PostToolUsePatch, PromptPatch, PromptView, ShutdownReason, Step, ToolCall, ToolResult,
+    TriggerKind, TriggerPayload,
 };
 use mur_common::AgentProfile;
 
@@ -94,10 +94,10 @@ impl Hook for RecordHook {
         c: &ToolCall,
         _: &ToolResult,
         _: &CancellationToken,
-    ) -> Result<(), HookError> {
+    ) -> Result<PostToolUsePatch, HookError> {
         self.rec
             .push(format!("{}:post_tool:{}", self.name, c.tool_name));
-        Ok(())
+        Ok(PostToolUsePatch::default())
     }
     async fn on_step_finish(
         &self,
@@ -205,7 +205,7 @@ async fn hook_fire_sequence_telegram_inbound_to_outbound() {
         input: serde_json::json!({}),
     };
     let _ = chain.pre_tool_use(&c, &call, &tok).await.unwrap();
-    chain
+    let _ = chain
         .post_tool_use(
             &c,
             &call,


### PR DESCRIPTION
## Summary

- `redact_pii` helper covers email / SSN / loose credit-card / US+international phone, replacing matched spans with `<REDACTED:label>`. Compiled once via `OnceLock` and shared across calls.
- `B0SafetyHook::post_tool_use` now scans `memory.*` tool result strings through the redactor and returns a `PostToolUsePatch` with `replace_output: Some(<redacted>)` on a hit. Non-memory tools, non-string outputs, and clean strings pass through with the default (noop) patch.
- **`HOOK_SCHEMA_VERSION` bumps from 1 to 2.** `Hook::post_tool_use` now returns `Result<PostToolUsePatch, HookError>` (was `Result<(), HookError>`). The chain runner folds patches in chain order using last-write-wins for `replace_output` and returns the merged patch to the supervisor.

### Trait change callsites (5 src + 2 test)
- `mur-agent-runtime/src/hooks/mod.rs` — trait default impl, version bump (with `Version history` doc), `PostToolUsePatch` re-export.
- `mur-agent-runtime/src/hooks/chain.rs` — dispatcher folds + returns the patch.
- `mur-agent-runtime/src/hooks/telemetry.rs` — `TelemetryHook` returns `PostToolUsePatch::default()`.
- `mur-agent-runtime/src/hooks/b0.rs` — new override implements rule 8.
- `mur-agent-runtime/src/hooks/patch.rs` — adds `PostToolUsePatch { replace_output }` + `merge` (last-write-wins).
- `mur-agent-runtime/tests/hooks_smoke.rs` + `tests/hooks_snapshot.rs` — fixture impls updated.

### Note on supervisor wiring

The supervisor caller of `chain.post_tool_use` does **not** yet act on the returned `replace_output`. M7.6 ships the hook + chain folding so future post-tool mutators have a typed return value to plug into; wiring the patch into the persistence path is tracked as a follow-up. The integration tests target `B0SafetyHook::post_tool_use` directly to verify the patch is constructed correctly, independent of supervisor behavior.

## Test plan

- [x] `cargo test -p mur-agent-runtime --lib hooks::b0_helpers::redact_tests` — 5/5 passed (email, ssn, cc, phone, clean unchanged).
- [x] `cargo test -p mur-agent-runtime --test b0_rule8_memory_redaction` — 4/4 passed (memory_write_email_gets_redacted, non_memory_tool_passes_through, memory_read_clean_text_no_patch, memory_write_non_string_output_passes_through).
- [x] `cargo test -p mur-agent-runtime --tests` — 50 binaries green, 0 failures.
- [x] `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.