### PR TITLE
feat(runtime): B0 text rules — M7.7 MCP binary signature check (rule 11)

### DIFF
--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -28,6 +28,7 @@ use crate::hooks::{
     AskDefault, Decision, Hook, HookCtx, HookError, MessagePatch, OutboundView, PostToolUsePatch,
     PromptPatch, PromptView, ToolCall, ToolResult, UntrustedWrapper,
 };
+use mur_common::AgentProfile;
 use mur_common::multimodal::ProvenanceLedger;
 use mur_common::permissions::{GrantDecision, GrantStore, ScopeKey};
 
@@ -89,6 +90,27 @@ impl Default for B0SafetyHook {
 impl Hook for B0SafetyHook {
     fn name(&self) -> &str {
         "B0SafetyHook"
+    }
+
+    async fn on_startup(
+        &self,
+        ctx: &HookCtx,
+        _profile: &AgentProfile,
+        _tok: &CancellationToken,
+    ) -> Result<(), HookError> {
+        // ── Rule 11 (M7.7): MCP binary signature check. ──────────────────
+        // Iterate every MCP server binary the supervisor resolved from
+        // `profile.mcp_servers[*].command` and refuse startup if any
+        // are unsigned. macOS/Windows only; Linux's `verify_signed`
+        // helper is a noop per spec §6.1 row 11.
+        for path in ctx.mcp_server_binaries() {
+            if let Err(reason) = crate::hooks::b0_helpers::verify_signed(path) {
+                return Err(HookError::Runtime(format!(
+                    "B0 rule 11: MCP binary signature check failed: {reason}"
+                )));
+            }
+        }
+        Ok(())
     }
 
     async fn on_prompt_submit(

--- a/mur-agent-runtime/src/hooks/b0_helpers.rs
+++ b/mur-agent-runtime/src/hooks/b0_helpers.rs
@@ -321,3 +321,46 @@ mod redact_tests {
         assert_eq!(redact_pii(clean), clean);
     }
 }
+
+/// Returns Ok(()) if the binary at `path` is signed (or sig-checks
+/// don't apply on this platform). Returns Err with a user-actionable
+/// reason on macOS/Windows when the signature is missing or invalid.
+pub fn verify_signed(path: &std::path::Path) -> Result<(), String> {
+    if !path.exists() {
+        return Err(format!("binary missing: {}", path.display()));
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let out = std::process::Command::new("/usr/bin/codesign")
+            .args(["-dv", "--verbose=4"])
+            .arg(path)
+            .output()
+            .map_err(|e| format!("codesign spawn: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "macOS binary not signed: {} (run `codesign -dv --verbose=4 {0}` for details)",
+                path.display()
+            ));
+        }
+        Ok(())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let out = std::process::Command::new("signtool")
+            .args(["verify", "/pa", "/q"])
+            .arg(path)
+            .output()
+            .map_err(|e| format!("signtool spawn: {e}"))?;
+        if !out.status.success() {
+            return Err(format!("Windows binary not signed: {}", path.display()));
+        }
+        Ok(())
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        // Linux: signing is not standard for native binaries.
+        // Spec calls this out as macOS/Windows only.
+        let _ = path;
+        Ok(())
+    }
+}

--- a/mur-agent-runtime/src/hooks/types.rs
+++ b/mur-agent-runtime/src/hooks/types.rs
@@ -42,6 +42,11 @@ pub struct HookCtx {
     /// (e.g. `B0SafetyHook` rule 5) to decide whether the agent is
     /// permitted to spawn a process, open a network connection, etc.
     pub entitlements: Entitlements,
+    /// Resolved binary paths for every entry in `profile.mcp_servers`.
+    /// Populated by the supervisor from each `McpServerEntry.command`'s
+    /// first whitespace-separated token. Read by `B0SafetyHook::on_startup`
+    /// (rule 11) to verify code signatures on macOS/Windows.
+    pub mcp_server_binaries: Vec<PathBuf>,
 }
 
 impl HookCtx {
@@ -61,6 +66,13 @@ impl HookCtx {
         &self.entitlements
     }
 
+    /// Resolved MCP server binary paths (one per `profile.mcp_servers` entry).
+    /// Read by `B0SafetyHook::on_startup` (rule 11) for the codesign /
+    /// signtool checks on macOS / Windows.
+    pub fn mcp_server_binaries(&self) -> &[PathBuf] {
+        &self.mcp_server_binaries
+    }
+
     /// Test helper: build a HookCtx pinned to an `agent_home` + `turn_id`.
     /// Used by integration tests that need a real on-disk ledger to read.
     pub fn for_test_with_home(home: PathBuf, turn_id: u64) -> Self {
@@ -74,6 +86,7 @@ impl HookCtx {
             turn_id,
             turn_flags: Vec::new(),
             entitlements: test_default_entitlements(),
+            mcp_server_binaries: Vec::new(),
         }
     }
 
@@ -90,6 +103,7 @@ impl HookCtx {
             turn_id: 0,
             turn_flags,
             entitlements: test_default_entitlements(),
+            mcp_server_binaries: Vec::new(),
         }
     }
 
@@ -104,6 +118,20 @@ impl HookCtx {
     ) -> Self {
         let mut ctx = Self::for_test_with_home(home, turn_id);
         ctx.entitlements = entitlements;
+        ctx
+    }
+
+    /// Test helper: build a HookCtx pinned to an `agent_home` + `turn_id`
+    /// with an explicit list of MCP server binary paths. Used by
+    /// `B0SafetyHook::on_startup` rule-11 tests that exercise the
+    /// codesign / signtool path without spinning up a full profile.
+    pub fn for_test_with_mcp_servers(
+        home: PathBuf,
+        turn_id: u64,
+        mcp_server_binaries: Vec<PathBuf>,
+    ) -> Self {
+        let mut ctx = Self::for_test_with_home(home, turn_id);
+        ctx.mcp_server_binaries = mcp_server_binaries;
         ctx
     }
 }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -154,6 +154,21 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         Arc::new(B0SafetyHook::new()),
         Arc::new(LedgerHook::new()),
     ]);
+    // Resolve MCP server binary paths from `profile.mcp_servers[*].command`.
+    // Each `command` is a shell command line; the first whitespace-separated
+    // token is treated as the binary path. M7.7 (rule 11) reads these in
+    // `B0SafetyHook::on_startup` to verify codesign / signtool signatures.
+    let mcp_server_binaries: Vec<std::path::PathBuf> = profile
+        .inner
+        .mcp_servers
+        .iter()
+        .filter_map(|s| {
+            s.command
+                .split_whitespace()
+                .next()
+                .map(std::path::PathBuf::from)
+        })
+        .collect();
     let hook_ctx = HookCtx {
         agent_name: profile.inner.name.clone(),
         agent_uuid: profile.inner.id.clone(),
@@ -171,6 +186,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         // process-spawn calls. Mutating entitlements at runtime is out
         // of scope: the supervisor restarts on profile.yaml change.
         entitlements: profile.inner.entitlements.clone(),
+        mcp_server_binaries,
     };
     let hook_cancel = tokio_util::sync::CancellationToken::new();
     hook_chain

--- a/mur-agent-runtime/tests/b0_rule11_mcp_signature.rs
+++ b/mur-agent-runtime/tests/b0_rule11_mcp_signature.rs
@@ -40,7 +40,7 @@ async fn unsigned_mcp_binary_fails_startup() {
     );
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn linux_signature_check_is_a_noop() {
     let dir = TempDir::new().unwrap();
@@ -53,4 +53,27 @@ async fn linux_signature_check_is_a_noop() {
     let cancel = CancellationToken::new();
     let result = hook.on_startup(&ctx, &profile, &cancel).await;
     assert!(result.is_ok(), "linux signature check should be noop");
+}
+
+#[cfg(target_os = "windows")]
+#[tokio::test]
+async fn windows_unsigned_binary_fails_startup() {
+    let dir = TempDir::new().unwrap();
+    let bin = dir.path().join("fake-mcp.exe");
+    std::fs::write(&bin, b"MZ\0\0").unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx =
+        HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin.to_path_buf()]);
+    let profile = minimal_profile();
+    let cancel = CancellationToken::new();
+    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    assert!(
+        result.is_err(),
+        "unsigned windows binary should fail on_startup"
+    );
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.to_lowercase().contains("not signed") || msg.contains("signtool"),
+        "got {msg}"
+    );
 }

--- a/mur-agent-runtime/tests/b0_rule11_mcp_signature.rs
+++ b/mur-agent-runtime/tests/b0_rule11_mcp_signature.rs
@@ -1,0 +1,56 @@
+//! Rule 11: on_startup verifies MCP binary signatures.
+//!
+//! On macOS, an unsigned binary in profile.mcp_servers triggers a
+//! HookError. On Linux this test is a no-op (rule doesn't apply).
+
+use mur_agent_runtime::hooks::{B0SafetyHook, Hook, HookCtx};
+use mur_common::AgentProfile;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+fn minimal_profile() -> AgentProfile {
+    let yaml = include_str!("fixtures/profile_minimal.yaml");
+    serde_yaml_ng::from_str(yaml).expect("fixture parse")
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn unsigned_mcp_binary_fails_startup() {
+    let dir = TempDir::new().unwrap();
+    // Create an unsigned executable (just a small file).
+    let bin = dir.path().join("fake-mcp");
+    std::fs::write(&bin, b"#!/bin/sh\nexit 0\n").unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&bin, perms).unwrap();
+
+    let hook = B0SafetyHook::new();
+    let ctx =
+        HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin.to_path_buf()]);
+    let profile = minimal_profile();
+    let cancel = CancellationToken::new();
+    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    assert!(result.is_err(), "unsigned binary should fail on_startup");
+    let msg = format!("{}", result.unwrap_err());
+    let lower = msg.to_lowercase();
+    assert!(
+        lower.contains("not signed") || lower.contains("signing") || lower.contains("signature"),
+        "expected signature-related error, got {msg}",
+    );
+}
+
+#[cfg(not(target_os = "macos"))]
+#[tokio::test]
+async fn linux_signature_check_is_a_noop() {
+    let dir = TempDir::new().unwrap();
+    let bin = dir.path().join("any");
+    std::fs::write(&bin, b"x").unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx =
+        HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin.to_path_buf()]);
+    let profile = minimal_profile();
+    let cancel = CancellationToken::new();
+    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    assert!(result.is_ok(), "linux signature check should be noop");
+}


### PR DESCRIPTION
## Summary

- `verify_signed` helper: `codesign` on macOS, `signtool` on Windows, no-op on Linux (per spec §6.1 row 11).
- `HookCtx` gains a `mcp_server_binaries: Vec<PathBuf>` field; supervisor populates it from `profile.mcp_servers[*].command` (first whitespace-separated token = binary path).
- `B0SafetyHook::on_startup` iterates `ctx.mcp_server_binaries()` and refuses startup if any are unsigned (returns `HookError::Runtime`).
- New `HookCtx::for_test_with_mcp_servers(home, turn_id, paths)` helper; existing `for_test_with_*` helpers default to empty MCP list.

## Test plan

- [x] `cargo test --test b0_rule11_mcp_signature` — 1/1 passing on macOS (unsigned-binary fails startup; Linux/Windows test compiled out)
- [x] full `cargo test -p mur-agent-runtime --tests` green
- [x] clippy + fmt clean