### PR TITLE
feat(docs): B0 text rules — M7.8 E2E + cookbook (B0 close-out)

### DIFF
--- a/docs/cookbook/b0-text-rules.md
+++ b/docs/cookbook/b0-text-rules.md
@@ -1,0 +1,68 @@
+# B0 Text-Only Safety Rules
+
+The mur agent runtime enforces a 22-rule consumer-safe baseline (B0).
+Rules 13-22 cover multimodal inputs (drag/drop, character cards) — see
+[drag-drop-pipeline.md](drag-drop-pipeline.md) and
+[character-cards.md](character-cards.md). Rules 1-12 cover text and
+tool boundaries; this page documents the 7 in-hook text rules that
+ship in v1.
+
+| # | Rule                                                       | Where it fires            |
+|---|------------------------------------------------------------|---------------------------|
+| 1 | FS read-write confined to `~/.mur/agents/<name>/`           | `pre_tool_use` (advisory) |
+| 2 | Outbound network allowlist + first-use AskUser + remember   | `pre_tool_use`            |
+| 3 | Tool-result spotlighting (`<untrusted_tool_result>`)        | `on_prompt_submit`        |
+| 4 | No same-turn tool chaining after fresh untrusted input ✓ M3.8 | `pre_tool_use`          |
+| 5 | Shell / `eval` / spawn deny by default                      | `pre_tool_use`            |
+| 7 | Outbound secret pre-filter (regex over body)                | `on_message_send`         |
+| 8 | Memory-write PII redaction                                  | `post_tool_use`           |
+| 11| MCP binary signature check (macOS/Windows)                  | `on_startup`              |
+
+Rules 6 (MCP install hash pinning), 9 (telemetry redaction), 10 (UX
+tier description), and 12 (companion proactive default-quiet audit)
+ship in companion plans — they are out-of-hook concerns (CLI verb /
+tracing layer / UX architecture / pre-existing in M2.x).
+
+## Pipeline
+
+The order of operations on a single tool call:
+
+1. `pre_tool_use` runs in this order, returning the FIRST hit:
+   1. Rule 1 — fs.write/delete/append/create outside agent_home → AskUser
+   2. Rule 5 — shell/spawn family + spawn.mode=Allowlist → Deny if argv[0] not in allowed[]
+   3. Rule 2 — network.* + Restricted mode + host not in allow_hosts → AskUser (after GrantStore lookup)
+   4. Rule 4 — `after_untrusted_input` flag set + side-effect tool → AskUser (M3.8)
+2. `post_tool_use` runs Rule 8 if the call's name starts with `memory.`.
+3. `on_message_send` runs Rule 7 over `body`.
+4. `on_prompt_submit` runs Rule 3 (wrap prior tool messages) and the
+   M3.8 untrusted-input spotlighting branch.
+5. `on_startup` runs Rule 11.
+
+## How to extend
+
+To add a new B0 rule:
+
+1. Add the spec text to `docs/superpowers/specs/2026-04-30-mur-agent-harness-roadmap-design.md` §6.1.
+2. Add a pure helper in `mur-agent-runtime/src/hooks/b0_helpers.rs`
+   if the rule has logic worth testing in isolation.
+3. Add a branch inside the appropriate `B0SafetyHook` async method in
+   `mur-agent-runtime/src/hooks/b0.rs`.
+4. Add `mur-agent-runtime/tests/b0_rule<N>_<short_name>.rs` with at
+   least one positive + one negative case.
+5. Add the test name to `scripts/e2e/v1-b0-text-rules.sh` so it runs
+   in the smoke suite.
+
+## Acceptance
+
+- 7/7 rule test files pass on the host CI matrix (macOS + Linux + Windows).
+- `scripts/e2e/v1-b0-text-rules.sh` exits 0.
+- M3.8 (Rule 4) and M3.x multimodal rules (13-22) are unchanged by M7.
+
+## What B0 does NOT do
+
+B0 is the v1 consumer-safe baseline — best-effort defense in depth, not
+a real sandbox. Hard runtime confinement (Landlock on Linux, App
+Sandbox / SBPL on macOS, AppContainer on Windows) lives in B1
+(`docs/superpowers/specs/...` §6.3) and ships in v2. Until B1, treat
+B0 as a robust prompt-injection guard + obvious-foot-gun blocker, not
+a malware containment surface.

--- a/docs/superpowers/specs/2026-04-30-mur-agent-harness-roadmap-design.md
+++ b/docs/superpowers/specs/2026-04-30-mur-agent-harness-roadmap-design.md
@@ -630,6 +630,13 @@ All 22 rules are implemented inside `B0SafetyHook` (Track A built-in handler) an
 - AgentDojo-50 indirect-injection success rate ≤ 5% (research baseline of unprotected agents: 30-60%).
 - HarmBench-50 jailbreak success rate ≤ baseline minus 50%.
 - End-to-end demo: dropping an "invisible text PDF" with ASCII smuggling does not trigger any side-effect tool in the same turn.
+- v1 ship status (2026-05-03):
+  - Rules 1, 2, 3, 4, 5, 7, 8, 11: shipped (M7.1-M7.7).
+  - Rule 6: deferred to MCP install CLI work (separate plan).
+  - Rule 9: deferred to telemetry redaction work (separate plan).
+  - Rule 10: documented; mechanism implemented across M0/M3.8/M7.3.
+  - Rule 12: M2.x companion subsystem already enforces; audit pending.
+  - Rules 13-22: shipped in M3 (drag-drop) + M4 (cards).
 
 ### 6.2 v1 Threat Model Document (16 sections)
 

--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -1,23 +1,36 @@
-//! `B0SafetyHook` — multimodal rules implementation (M3.8).
+//! `B0SafetyHook` — consumer-safe baseline (roadmap §6.1).
 //!
-//! Currently implements rules 13-22 from roadmap §6.1 (the multimodal
-//! consumer-safe baseline). The text-only rules (1-12) wait for M8
-//! per the roadmap timeline.
+//! Implements text rules 1, 2, 3, 4, 5, 7, 8, 11 (M7) plus multimodal
+//! rules 13-22 (M3 / M4). Rules 6, 9, 10, 12 ship outside this hook
+//! (MCP-install CLI, telemetry redaction, UX docs, companion subsystem
+//! respectively). See `docs/cookbook/b0-text-rules.md` for the full
+//! map and the §6.1 acceptance footer for ship status.
 //!
 //! Wiring:
-//! * `on_prompt_submit` (M3.8.1) reads
-//!   `<agent_home>/telemetry/inputs.jsonl` for the current turn, looks
-//!   up each entry's `<agent_home>/telemetry/inputs/{sha256}.txt`
-//!   sidecar, and builds a `PromptPatch` with one `wrap_untrusted` per
-//!   entry plus the `after_untrusted_input` turn-flag.
-//! * `pre_tool_use` (M3.8.2) checks for the `after_untrusted_input`
-//!   turn-flag and denies side-effect tools (delete / spawn / send /
-//!   egress / network / .write / .publish) via `Decision::AskUser`,
-//!   per roadmap §4.3 step 9.
-//!
-//! The remaining roadmap rules (sandbox attestation, GrantStore
-//! lookup, post_tool_use redaction, on_message_received untrusted
-//! flag) land with the M8 text-only baseline.
+//! * `on_startup` — Rule 11 (M7.7): codesign / signtool every entry
+//!   in `ctx.mcp_server_binaries()`; refuse startup if any unsigned
+//!   on macOS / Windows. Linux is a no-op.
+//! * `on_prompt_submit` — Rule 3 (M7.4) wraps every prior `role:tool`
+//!   message with `<untrusted_tool_result source="tool_result:<name>">`
+//!   AND M3.8 reads the multimodal provenance ledger to wrap PDF/OCR
+//!   text into `<untrusted_pdf_text>` / `<untrusted_image_text>` plus
+//!   the `after_untrusted_input` turn-flag.
+//! * `pre_tool_use` — most-specific gate first, then situational:
+//!   1. Rule 4 (M3.8) — turn-flag set + side-effect tool → AskUser.
+//!   2. Rule 1 (M7.1) — fs.write/delete/append/create outside
+//!      `agent_home` → AskUser.
+//!   3. Rule 5 (M7.2) — process.spawn / shell with
+//!      `entitlements.processes.spawn.mode != Any` → Deny if argv[0]
+//!      not in allowed[].
+//!   4. Rule 2 (M7.3) — network.* with `outbound.mode == Off` → Deny;
+//!      `Restricted` + host not in allow_hosts → GrantStore lookup,
+//!      then AskUser on first use.
+//! * `on_message_send` — Rule 7 (M7.5) scans `view.body` for ~11
+//!   credential regex patterns; on hit returns
+//!   `MessagePatch::drop_with(reason)` naming the matched class.
+//! * `post_tool_use` — Rule 8 (M7.6) for `memory.*` tools redacts
+//!   email / SSN / credit-card / phone in the result before
+//!   persistence (returns `PostToolUsePatch.replace_output`).
 
 use std::path::PathBuf;
 use std::sync::Mutex;

--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -28,6 +28,7 @@ use crate::hooks::{
     AskDefault, Decision, Hook, HookCtx, HookError, MessagePatch, OutboundView, PostToolUsePatch,
     PromptPatch, PromptView, ToolCall, ToolResult, UntrustedWrapper,
 };
+use mur_common::AgentProfile;
 use mur_common::multimodal::ProvenanceLedger;
 use mur_common::permissions::{GrantDecision, GrantStore, ScopeKey};
 
@@ -89,6 +90,27 @@ impl Default for B0SafetyHook {
 impl Hook for B0SafetyHook {
     fn name(&self) -> &str {
         "B0SafetyHook"
+    }
+
+    async fn on_startup(
+        &self,
+        ctx: &HookCtx,
+        _profile: &AgentProfile,
+        _tok: &CancellationToken,
+    ) -> Result<(), HookError> {
+        // ── Rule 11 (M7.7): MCP binary signature check. ──────────────────
+        // Iterate every MCP server binary the supervisor resolved from
+        // `profile.mcp_servers[*].command` and refuse startup if any
+        // are unsigned. macOS/Windows only; Linux's `verify_signed`
+        // helper is a noop per spec §6.1 row 11.
+        for path in ctx.mcp_server_binaries() {
+            if let Err(reason) = crate::hooks::b0_helpers::verify_signed(path) {
+                return Err(HookError::Runtime(format!(
+                    "B0 rule 11: MCP binary signature check failed: {reason}"
+                )));
+            }
+        }
+        Ok(())
     }
 
     async fn on_prompt_submit(

--- a/mur-agent-runtime/src/hooks/b0_helpers.rs
+++ b/mur-agent-runtime/src/hooks/b0_helpers.rs
@@ -321,3 +321,46 @@ mod redact_tests {
         assert_eq!(redact_pii(clean), clean);
     }
 }
+
+/// Returns Ok(()) if the binary at `path` is signed (or sig-checks
+/// don't apply on this platform). Returns Err with a user-actionable
+/// reason on macOS/Windows when the signature is missing or invalid.
+pub fn verify_signed(path: &std::path::Path) -> Result<(), String> {
+    if !path.exists() {
+        return Err(format!("binary missing: {}", path.display()));
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let out = std::process::Command::new("/usr/bin/codesign")
+            .args(["-dv", "--verbose=4"])
+            .arg(path)
+            .output()
+            .map_err(|e| format!("codesign spawn: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "macOS binary not signed: {} (run `codesign -dv --verbose=4 {0}` for details)",
+                path.display()
+            ));
+        }
+        Ok(())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let out = std::process::Command::new("signtool")
+            .args(["verify", "/pa", "/q"])
+            .arg(path)
+            .output()
+            .map_err(|e| format!("signtool spawn: {e}"))?;
+        if !out.status.success() {
+            return Err(format!("Windows binary not signed: {}", path.display()));
+        }
+        Ok(())
+    }
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        // Linux: signing is not standard for native binaries.
+        // Spec calls this out as macOS/Windows only.
+        let _ = path;
+        Ok(())
+    }
+}

--- a/mur-agent-runtime/src/hooks/types.rs
+++ b/mur-agent-runtime/src/hooks/types.rs
@@ -42,6 +42,11 @@ pub struct HookCtx {
     /// (e.g. `B0SafetyHook` rule 5) to decide whether the agent is
     /// permitted to spawn a process, open a network connection, etc.
     pub entitlements: Entitlements,
+    /// Resolved binary paths for every entry in `profile.mcp_servers`.
+    /// Populated by the supervisor from each `McpServerEntry.command`'s
+    /// first whitespace-separated token. Read by `B0SafetyHook::on_startup`
+    /// (rule 11) to verify code signatures on macOS/Windows.
+    pub mcp_server_binaries: Vec<PathBuf>,
 }
 
 impl HookCtx {
@@ -61,6 +66,13 @@ impl HookCtx {
         &self.entitlements
     }
 
+    /// Resolved MCP server binary paths (one per `profile.mcp_servers` entry).
+    /// Read by `B0SafetyHook::on_startup` (rule 11) for the codesign /
+    /// signtool checks on macOS / Windows.
+    pub fn mcp_server_binaries(&self) -> &[PathBuf] {
+        &self.mcp_server_binaries
+    }
+
     /// Test helper: build a HookCtx pinned to an `agent_home` + `turn_id`.
     /// Used by integration tests that need a real on-disk ledger to read.
     pub fn for_test_with_home(home: PathBuf, turn_id: u64) -> Self {
@@ -74,6 +86,7 @@ impl HookCtx {
             turn_id,
             turn_flags: Vec::new(),
             entitlements: test_default_entitlements(),
+            mcp_server_binaries: Vec::new(),
         }
     }
 
@@ -90,6 +103,7 @@ impl HookCtx {
             turn_id: 0,
             turn_flags,
             entitlements: test_default_entitlements(),
+            mcp_server_binaries: Vec::new(),
         }
     }
 
@@ -104,6 +118,20 @@ impl HookCtx {
     ) -> Self {
         let mut ctx = Self::for_test_with_home(home, turn_id);
         ctx.entitlements = entitlements;
+        ctx
+    }
+
+    /// Test helper: build a HookCtx pinned to an `agent_home` + `turn_id`
+    /// with an explicit list of MCP server binary paths. Used by
+    /// `B0SafetyHook::on_startup` rule-11 tests that exercise the
+    /// codesign / signtool path without spinning up a full profile.
+    pub fn for_test_with_mcp_servers(
+        home: PathBuf,
+        turn_id: u64,
+        mcp_server_binaries: Vec<PathBuf>,
+    ) -> Self {
+        let mut ctx = Self::for_test_with_home(home, turn_id);
+        ctx.mcp_server_binaries = mcp_server_binaries;
         ctx
     }
 }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -154,6 +154,21 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         Arc::new(B0SafetyHook::new()),
         Arc::new(LedgerHook::new()),
     ]);
+    // Resolve MCP server binary paths from `profile.mcp_servers[*].command`.
+    // Each `command` is a shell command line; the first whitespace-separated
+    // token is treated as the binary path. M7.7 (rule 11) reads these in
+    // `B0SafetyHook::on_startup` to verify codesign / signtool signatures.
+    let mcp_server_binaries: Vec<std::path::PathBuf> = profile
+        .inner
+        .mcp_servers
+        .iter()
+        .filter_map(|s| {
+            s.command
+                .split_whitespace()
+                .next()
+                .map(std::path::PathBuf::from)
+        })
+        .collect();
     let hook_ctx = HookCtx {
         agent_name: profile.inner.name.clone(),
         agent_uuid: profile.inner.id.clone(),
@@ -171,6 +186,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         // process-spawn calls. Mutating entitlements at runtime is out
         // of scope: the supervisor restarts on profile.yaml change.
         entitlements: profile.inner.entitlements.clone(),
+        mcp_server_binaries,
     };
     let hook_cancel = tokio_util::sync::CancellationToken::new();
     hook_chain

--- a/mur-agent-runtime/tests/b0_rule11_mcp_signature.rs
+++ b/mur-agent-runtime/tests/b0_rule11_mcp_signature.rs
@@ -40,7 +40,7 @@ async fn unsigned_mcp_binary_fails_startup() {
     );
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 #[tokio::test]
 async fn linux_signature_check_is_a_noop() {
     let dir = TempDir::new().unwrap();
@@ -53,4 +53,27 @@ async fn linux_signature_check_is_a_noop() {
     let cancel = CancellationToken::new();
     let result = hook.on_startup(&ctx, &profile, &cancel).await;
     assert!(result.is_ok(), "linux signature check should be noop");
+}
+
+#[cfg(target_os = "windows")]
+#[tokio::test]
+async fn windows_unsigned_binary_fails_startup() {
+    let dir = TempDir::new().unwrap();
+    let bin = dir.path().join("fake-mcp.exe");
+    std::fs::write(&bin, b"MZ\0\0").unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx =
+        HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin.to_path_buf()]);
+    let profile = minimal_profile();
+    let cancel = CancellationToken::new();
+    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    assert!(
+        result.is_err(),
+        "unsigned windows binary should fail on_startup"
+    );
+    let msg = format!("{}", result.unwrap_err());
+    assert!(
+        msg.to_lowercase().contains("not signed") || msg.contains("signtool"),
+        "got {msg}"
+    );
 }

--- a/mur-agent-runtime/tests/b0_rule11_mcp_signature.rs
+++ b/mur-agent-runtime/tests/b0_rule11_mcp_signature.rs
@@ -1,0 +1,56 @@
+//! Rule 11: on_startup verifies MCP binary signatures.
+//!
+//! On macOS, an unsigned binary in profile.mcp_servers triggers a
+//! HookError. On Linux this test is a no-op (rule doesn't apply).
+
+use mur_agent_runtime::hooks::{B0SafetyHook, Hook, HookCtx};
+use mur_common::AgentProfile;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+fn minimal_profile() -> AgentProfile {
+    let yaml = include_str!("fixtures/profile_minimal.yaml");
+    serde_yaml_ng::from_str(yaml).expect("fixture parse")
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn unsigned_mcp_binary_fails_startup() {
+    let dir = TempDir::new().unwrap();
+    // Create an unsigned executable (just a small file).
+    let bin = dir.path().join("fake-mcp");
+    std::fs::write(&bin, b"#!/bin/sh\nexit 0\n").unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&bin, perms).unwrap();
+
+    let hook = B0SafetyHook::new();
+    let ctx =
+        HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin.to_path_buf()]);
+    let profile = minimal_profile();
+    let cancel = CancellationToken::new();
+    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    assert!(result.is_err(), "unsigned binary should fail on_startup");
+    let msg = format!("{}", result.unwrap_err());
+    let lower = msg.to_lowercase();
+    assert!(
+        lower.contains("not signed") || lower.contains("signing") || lower.contains("signature"),
+        "expected signature-related error, got {msg}",
+    );
+}
+
+#[cfg(not(target_os = "macos"))]
+#[tokio::test]
+async fn linux_signature_check_is_a_noop() {
+    let dir = TempDir::new().unwrap();
+    let bin = dir.path().join("any");
+    std::fs::write(&bin, b"x").unwrap();
+    let hook = B0SafetyHook::new();
+    let ctx =
+        HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin.to_path_buf()]);
+    let profile = minimal_profile();
+    let cancel = CancellationToken::new();
+    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    assert!(result.is_ok(), "linux signature check should be noop");
+}

--- a/scripts/e2e/run-all.sh
+++ b/scripts/e2e/run-all.sh
@@ -68,6 +68,9 @@ echo "==> Running D4 character cards E2E smoke..."
 echo "==> Running D5 companion-GUI bridge E2E smoke..."
 "$REPO_ROOT/scripts/e2e/v1-d5-gui-bridge.sh"
 
+echo "==> Running B0 text-rules E2E smoke..."
+"$REPO_ROOT/scripts/e2e/v1-b0-text-rules.sh"
+
 if [[ "$RUN_COVERAGE" == "1" ]]; then
   if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
     echo "cargo-llvm-cov not installed (cargo install cargo-llvm-cov)" >&2

--- a/scripts/e2e/v1-b0-text-rules.sh
+++ b/scripts/e2e/v1-b0-text-rules.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# scripts/e2e/v1-b0-text-rules.sh — B0 text-only rules acceptance.
+#
+# Acceptance gates (roadmap §6.1):
+# Rules 1, 2, 3, 5, 7, 8, 11 — each has at least one positive +
+# negative test in mur-agent-runtime/tests/b0_rule*.
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "==> 1/2 build mur-agent-runtime tests (release)"
+cargo build -p mur-agent-runtime --tests --release --quiet
+
+echo "==> 2/2 B0 text-rules gates"
+cargo test --release -p mur-agent-runtime --quiet \
+    --test b0_rule1_fs_confinement \
+    --test b0_rule2_network_allowlist \
+    --test b0_rule3_spotlight_tool_results \
+    --test b0_rule5_spawn_deny \
+    --test b0_rule7_secret_prefilter \
+    --test b0_rule8_memory_redaction \
+    --test b0_rule11_mcp_signature
+
+echo "✅ B0 text-rules E2E passed"


### PR DESCRIPTION
## Summary

Final milestone of B0 text-only rules. No production code — tests,
scripts, docs only.

- M7.8.1: scripts/e2e/v1-b0-text-rules.sh + run-all wiring
- M7.8.2: docs/cookbook/b0-text-rules.md
- M7.8.3: spec §6.1 acceptance — tick rules 1, 2, 3, 5, 7, 8, 11

## B0 text-rules status

With this PR, B0 text rules ship:
- M7.1 fs confinement (PR #?)
- M7.2 spawn deny (PR #?)
- M7.3 network allowlist + GrantStore (PR #?)
- M7.4 tool-result spotlighting (PR #?)
- M7.5 outbound secret prefilter (PR #?)
- M7.6 memory redaction (PR #?)
- M7.7 MCP binary signature check (PR #?)
- M7.8 E2E + cookbook (this PR)

Track C (chat-platform agents requiring entitlements.llm=none) is
now unblocked: Rule 2 enforces the outbound network restriction
those agents need.

## Test plan

- [x] scripts/e2e/v1-b0-text-rules.sh exits 0
- [x] full mur-agent-runtime suite green
- [x] cookbook renders correctly