### PR TITLE
feat(common,runtime): Track C1 — M-c1.0 LlmEntitlement schema + supervisor guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,8 @@ The per-agent supervisor lives in `mur-agent-runtime/`. Each agent has a directo
 - **Crate README:** `mur-agent-runtime/README.md`
 - **E2E runner:** `scripts/e2e/run-all.sh`
 
+`entitlements.llm.mode` is `allowed` by default; bridges set it to `off` so the supervisor refuses to construct an LLM client. See `docs/cookbook/c1-a2a-bridge.md`.
+
 ### P0a.5 additions (identity + TCP Noise + commander integration)
 
 - **`mur-common` schema** — `AgentProfile.identity` (Ed25519 pubkey + owner), `transport.tcp` (Noise XK bind + pattern, default off), `lifecycle.{execution,schedule}` (daemon vs on-demand + cron), `file_transfer` caps, `deployment` (laptop / vm / docker / k8s / lambda).

--- a/mur-agent-runtime/src/hooks/types.rs
+++ b/mur-agent-runtime/src/hooks/types.rs
@@ -160,6 +160,7 @@ fn test_default_entitlements() -> Entitlements {
         },
         syscalls: SyscallsEntitlement::default(),
         limits: LimitsEntitlement::default(),
+        llm: Default::default(),
     }
 }
 

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -1,11 +1,32 @@
 //! LLM client abstraction.
 
 use async_trait::async_trait;
+use mur_common::{AgentProfile, LlmMode};
 
 pub mod anthropic;
 pub mod ollama;
 pub mod openai;
 pub mod stub;
+
+/// Gate function that the supervisor calls before constructing any concrete
+/// LLM client. Returns `Err` when `entitlements.llm.mode = off`, which
+/// declares the agent a "bridge" — an LLM-less mur agent that relays chat
+/// traffic to/from the A2A bus. Bridges have no model, no API key, and the
+/// supervisor must not dial a provider on their behalf.
+///
+/// Default `mode = Allowed` (back-compat), so this is a no-op for every
+/// existing agent profile.
+///
+/// See `mur-common::bridge::LlmEntitlement` and Track C1 task M-c1.0.
+pub fn build_client(profile: &AgentProfile) -> anyhow::Result<()> {
+    if profile.entitlements.llm.mode == LlmMode::Off {
+        anyhow::bail!(
+            "llm.mode = off — agent '{}' is a bridge and may not call an LLM",
+            profile.name
+        );
+    }
+    Ok(())
+}
 
 #[derive(Debug, Clone)]
 pub struct LlmMessage {

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -205,6 +205,13 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     // implemented) fall through to echo. Setting MUR_AGENT_FORCE_ECHO=1
     // forces echo regardless of profile (useful for tests).
     let force_echo = std::env::var_os("MUR_AGENT_FORCE_ECHO").is_some();
+    // Track C1 (M-c1.0.2): refuse to construct an LLM client when the profile
+    // declares `entitlements.llm.mode = off` — i.e. the agent is a bridge.
+    // Bridges relay chat-platform traffic to/from the A2A bus and must not
+    // dial a provider. The gate fails closed.
+    if let Err(e) = crate::llm::build_client(&profile.inner) {
+        return Err(anyhow::anyhow!("supervisor refusing LLM construction: {e}"));
+    }
     // `llm_for_companion` carries the real LLM client (None when echo/stub) so
     // the companion subsystem can share the same provider without a second dial.
     let (runner, llm_for_companion): (_, Option<Arc<dyn LlmClient>>) = if force_echo {

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -209,9 +209,8 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     // declares `entitlements.llm.mode = off` — i.e. the agent is a bridge.
     // Bridges relay chat-platform traffic to/from the A2A bus and must not
     // dial a provider. The gate fails closed.
-    if let Err(e) = crate::llm::build_client(&profile.inner) {
-        return Err(anyhow::anyhow!("supervisor refusing LLM construction: {e}"));
-    }
+    crate::llm::build_client(&profile.inner)
+        .map_err(|e| anyhow::anyhow!("supervisor refusing LLM construction: {e}"))?;
     // `llm_for_companion` carries the real LLM client (None when echo/stub) so
     // the companion subsystem can share the same provider without a second dial.
     let (runner, llm_for_companion): (_, Option<Arc<dyn LlmClient>>) = if force_echo {

--- a/mur-agent-runtime/tests/b0_rule2_network_allowlist.rs
+++ b/mur-agent-runtime/tests/b0_rule2_network_allowlist.rs
@@ -37,6 +37,7 @@ fn ent_with_outbound(mode: NetworkOutboundMode, allow: Vec<String>) -> Entitleme
         },
         syscalls: SyscallsEntitlement::default(),
         limits: LimitsEntitlement::default(),
+        llm: Default::default(),
     }
 }
 

--- a/mur-agent-runtime/tests/b0_rule5_spawn_deny.rs
+++ b/mur-agent-runtime/tests/b0_rule5_spawn_deny.rs
@@ -28,6 +28,7 @@ fn ent_with_spawn(mode: SpawnMode, allowed: Vec<String>) -> Entitlements {
         },
         syscalls: SyscallsEntitlement::default(),
         limits: LimitsEntitlement::default(),
+        llm: Default::default(),
     }
 }
 

--- a/mur-agent-runtime/tests/bridge_llm_off_blocks.rs
+++ b/mur-agent-runtime/tests/bridge_llm_off_blocks.rs
@@ -1,0 +1,36 @@
+//! Track C1 — M-c1.0.2: supervisor refuses to construct an LLM client when
+//! `entitlements.llm.mode = off`.
+//!
+//! Bridges (LLM-less mur agents that relay chat-platform traffic to/from the
+//! A2A bus) must not dial a provider. `mur_agent_runtime::llm::build_client`
+//! is the gate the supervisor calls before its provider-specific
+//! construction; this test exercises the gate in isolation.
+
+use mur_common::{AgentProfile, LlmMode};
+
+fn profile_with_llm_off() -> AgentProfile {
+    let yaml = include_str!("fixtures/minimal_profile.yaml");
+    let mut p: AgentProfile = serde_yaml_ng::from_str(yaml).unwrap();
+    p.entitlements.llm.mode = LlmMode::Off;
+    p
+}
+
+#[test]
+fn llm_off_blocks_construction() {
+    let profile = profile_with_llm_off();
+    let err = mur_agent_runtime::llm::build_client(&profile).expect_err("llm.mode=off must block");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("llm.mode = off"),
+        "expected error to mention 'llm.mode = off', got: {msg}"
+    );
+}
+
+#[test]
+fn llm_allowed_passes_gate() {
+    let yaml = include_str!("fixtures/minimal_profile.yaml");
+    let p: AgentProfile = serde_yaml_ng::from_str(yaml).unwrap();
+    // Default mode is Allowed; gate must succeed.
+    assert_eq!(p.entitlements.llm.mode, LlmMode::Allowed);
+    mur_agent_runtime::llm::build_client(&p).expect("llm.mode=allowed must pass gate");
+}

--- a/mur-agent-runtime/tests/fixtures/minimal_profile.yaml
+++ b/mur-agent-runtime/tests/fixtures/minimal_profile.yaml
@@ -1,0 +1,31 @@
+schema: 1
+id: 0192f5a1-28ab-7111-8000-000000000099
+name: bridge_test
+display_name: "Bridge Test"
+version: "0.1.0"
+persona:
+  category: research
+  description: "Minimal bridge profile fixture for llm.mode=off guard test"
+  traits: { tone: concise, risk: cautious, verbosity: low }
+sys_prompt_file: "sys_prompt.md"
+model: { provider: ollama, name: "m", params: {} }
+mcp_servers: []
+skills: []
+transport: { stdio: true, socket: { enabled: true, bind: "unix:///tmp/a.sock" } }
+communication: { accepts_from: ["*"], sends_to: [] }
+capabilities: ["a2a.message.send","a2a.tasks"]
+entitlements:
+  network:
+    inbound: { ports: [] }
+    outbound: { mode: restricted, allow_hosts: [], protocols: ["tcp"], resolve_dns: { mode: system } }
+  filesystem: { read: [], write: [], deny: ["~/.ssh"] }
+  processes: { spawn: { mode: allowlist, allowed: [] } }
+  syscalls: { mode: default }
+  limits: { memory_mb: 512, file_descriptors: 1024, processes: 32 }
+notifications: { on_task_complete: [], on_error: [], on_shutdown: [] }
+retry:
+  llm: { max_retries: 3, backoff: exponential, initial_delay_ms: 1000, max_delay_ms: 30000, retry_on: ["rate_limit"] }
+  tool: { max_retries: 1, backoff: fixed, initial_delay_ms: 500 }
+lifecycle: { restart: on_failure, max_restarts: 3, restart_window_secs: 600, stop_timeout_secs: 15, mcp_required: true }
+created_at: "2026-04-22T10:00:00+08:00"
+updated_at: "2026-04-22T10:00:00+08:00"

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -216,6 +216,10 @@ pub struct Entitlements {
     pub syscalls: SyscallsEntitlement,
     #[serde(default)]
     pub limits: LimitsEntitlement,
+    /// LLM call permission. Default = Allowed (back-compat). Bridges set to Off
+    /// so the supervisor refuses to construct an LLM client.
+    #[serde(default)]
+    pub llm: crate::bridge::llm_entitlement::LlmEntitlement,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/mur-common/src/bridge/llm_entitlement.rs
+++ b/mur-common/src/bridge/llm_entitlement.rs
@@ -1,0 +1,45 @@
+//! `LlmEntitlement` — controls whether an agent's supervisor is permitted to
+//! construct an LLM client.
+//!
+//! Bridges (chat-platform connectors built on the agent runtime) are
+//! intentionally LLM-less: their job is to relay messages between an external
+//! transport (Slack, Discord, Telegram, etc.) and the A2A bus. They set
+//! `entitlements.llm.mode = off` so the supervisor refuses to construct an
+//! LLM client at startup. Default = `Allowed` for backward-compat with
+//! existing agent profiles that pre-date this schema.
+//!
+//! See `docs/superpowers/plans/2026-05-03-mur-agent-track-c1-a2a-bridge.md`
+//! task M-c1.0 for context.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum LlmMode {
+    #[default]
+    Allowed,
+    Off,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct LlmEntitlement {
+    #[serde(default)]
+    pub mode: LlmMode,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn default_mode_is_allowed() {
+        let e: LlmEntitlement = serde_yaml_ng::from_str("{}").unwrap();
+        assert_eq!(e.mode, LlmMode::Allowed);
+    }
+    #[test]
+    fn mode_off_round_trips() {
+        let e = LlmEntitlement { mode: LlmMode::Off };
+        let s = serde_yaml_ng::to_string(&e).unwrap();
+        assert!(s.contains("mode: off"));
+        assert_eq!(serde_yaml_ng::from_str::<LlmEntitlement>(&s).unwrap(), e);
+    }
+}

--- a/mur-common/src/bridge/mod.rs
+++ b/mur-common/src/bridge/mod.rs
@@ -1,0 +1,9 @@
+//! Bridge-related shared types.
+//!
+//! A "bridge" is an LLM-less mur agent that relays messages between an
+//! external chat platform (Slack, Discord, Telegram, …) and the A2A bus. The
+//! types here describe schema bits shared across crates so bridges are a
+//! first-class profile shape rather than an ad-hoc convention.
+
+pub mod llm_entitlement;
+pub use llm_entitlement::{LlmEntitlement, LlmMode};

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -36,13 +36,13 @@ pub use signal::{SIGNAL_SCHEMA_VERSION, Signal, SignalKind, SignalTarget};
 
 pub use a2a::Message as A2aMessage;
 pub use a2a::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, Task, TaskState};
-pub use bridge::{LlmEntitlement, LlmMode};
 pub use agent::{
     AgentProfile, DeploymentConfig, DeploymentType, Entitlements, ExecutionMode,
     FileTransferConfig, IdentityConfig, LockFile, Persona, PersonaCategory, RetryPolicy,
     ScheduleEntry,
 };
 pub use agent_name::{AgentNameError, MAX_AGENT_NAME_LEN, validate_agent_name};
+pub use bridge::{LlmEntitlement, LlmMode};
 pub use identity::{
     AgentIdentity, ChainError, ChainOptions, ChainOutcome, IdentityError, RotationAttestation,
     RotationReason, decode_pubkey, encode_pubkey, verify_chain,

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod a2a;
 pub mod actor;
 pub mod agent;
 pub mod agent_name;
+pub mod bridge;
 pub mod bundle;
 pub mod companion;
 pub mod config;
@@ -35,6 +36,7 @@ pub use signal::{SIGNAL_SCHEMA_VERSION, Signal, SignalKind, SignalTarget};
 
 pub use a2a::Message as A2aMessage;
 pub use a2a::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, Task, TaskState};
+pub use bridge::{LlmEntitlement, LlmMode};
 pub use agent::{
     AgentProfile, DeploymentConfig, DeploymentType, Entitlements, ExecutionMode,
     FileTransferConfig, IdentityConfig, LockFile, Persona, PersonaCategory, RetryPolicy,

--- a/mur-core/src/cmd/agent.rs
+++ b/mur-core/src/cmd/agent.rs
@@ -304,6 +304,7 @@ fn default_entitlements_custom() -> Entitlements {
             file_descriptors: 1024,
             processes: 32,
         },
+        llm: Default::default(),
     }
 }
 


### PR DESCRIPTION
## Summary

Track C1 (A2A bridge architecture) **M-c1.0** — the foundation for chat-platform connectors built on the agent runtime. Bridges are LLM-less mur agents: `entitlements.llm.mode = off` means the supervisor refuses to construct an LLM client.

Three tasks per the plan at `docs/superpowers/plans/2026-05-03-mur-agent-track-c1-a2a-bridge.md` (lines 80-210):

### M-c1.0.1 — `LlmEntitlement` schema

- New `mur-common::bridge::{LlmEntitlement, LlmMode}` (`{Allowed, Off}`, default = `Allowed`).
- Wired as `llm: LlmEntitlement` (`#[serde(default)]`) on `Entitlements` so legacy profile.yaml files continue to parse unchanged.
- Three local `Entitlements { ... }` literal sites updated with `llm: Default::default()` (test helpers in mur-core, mur-agent-runtime hooks, two B0 rule integration tests).
- Tests: `bridge::llm_entitlement::tests::default_mode_is_allowed`, `bridge::llm_entitlement::tests::mode_off_round_trips`.

### M-c1.0.2 — Supervisor LLM guard

- New `mur_agent_runtime::llm::build_client(profile) -> Result<()>` — thin permission gate the supervisor invokes before any provider-specific construction.
- Wired into `supervisor::entrypoint()` immediately after lock acquisition (line 212): when the gate denies, the supervisor returns `Err` and exits.
- Test fixture `mur-agent-runtime/tests/fixtures/minimal_profile.yaml` (mirrors the existing `profile_minimal.yaml` shape).
- Tests: `bridge_llm_off_blocks::llm_off_blocks_construction` (asserts error contains `"llm.mode = off"`), `bridge_llm_off_blocks::llm_allowed_passes_gate`.

### M-c1.0.3 — CLAUDE.md note

One-sentence addition under "Agent Runtime (murmur P0a)" so future contributors know `entitlements.llm.mode` defaults to `allowed` and that bridges must set it to `off`.

## How this unblocks bridges

Subsequent M-c1.x milestones (route resolver, transport adapters, sandbox plumbing) can now declare a profile with `entitlements.llm.mode = off` and trust that the supervisor will refuse to dial a provider. The bridge runner that those milestones add will be selected based on the same flag, replacing the LLM-routing path entirely.

## Deviations from the plan's pseudocode

- The plan suggested `pub fn build_client(profile: &AgentProfile) -> Result<…>` returning `Arc<dyn LlmClient>`. The supervisor already has provider-specific construction logic inline (Ollama / Anthropic / OpenAI), and refactoring all of it into a single `build_client` returning `Arc<dyn LlmClient>` was out of scope for the foundation milestone. Instead `build_client` is a permission gate returning `anyhow::Result<()>` — the supervisor calls it first, then proceeds with its existing construction. This matches the plan's "watch out" guidance: *"create a small `mur-agent-runtime/src/llm/mod.rs` with a `build_client(profile)` thin wrapper that the rest of the runtime calls."*
- `LlmMode` uses `#[derive(Default)]` with `#[default]` on `Allowed` rather than a manual `impl Default` (clippy `derivable_impls` rule).

## Test plan

- [x] `cargo test -p mur-common --lib llm_entitlement` — 2 new tests pass
- [x] `cargo test -p mur-common --lib agent::tests` — existing AgentProfile round-trip still parses
- [x] `cargo test -p mur-common` — 187 unit + all integration tests pass
- [x] `cargo test -p mur-agent-runtime --test bridge_llm_off_blocks` — 2 new tests pass
- [x] `cargo test -p mur-agent-runtime --test b0_rule5_spawn_deny --test b0_rule2_network_allowlist` — 9 existing tests still pass with new `Entitlements` field
- [x] `cargo clippy -p mur-common --lib -- -D warnings` clean
- [x] `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)