### PR TITLE
feat(common): Track C1 — M-c1.1 BridgeRouteConfig schema + resolve

### DIFF
--- a/mur-common/src/bridge/mod.rs
+++ b/mur-common/src/bridge/mod.rs
@@ -8,4 +8,4 @@
 pub mod llm_entitlement;
 pub mod routes;
 pub use llm_entitlement::{LlmEntitlement, LlmMode};
-pub use routes::{BridgeRouteConfig, RouteEntry, RouteMatch};
+pub use routes::{BridgeRouteConfig, InboundMessage, Resolution, RouteEntry, RouteMatch};

--- a/mur-common/src/bridge/mod.rs
+++ b/mur-common/src/bridge/mod.rs
@@ -6,4 +6,6 @@
 //! first-class profile shape rather than an ad-hoc convention.
 
 pub mod llm_entitlement;
+pub mod routes;
 pub use llm_entitlement::{LlmEntitlement, LlmMode};
+pub use routes::{BridgeRouteConfig, RouteEntry, RouteMatch};

--- a/mur-common/src/bridge/routes.rs
+++ b/mur-common/src/bridge/routes.rs
@@ -34,6 +34,70 @@ pub struct RouteMatch {
     pub chat_id: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct InboundMessage {
+    pub platform: String,
+    pub chat_id: String,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Resolution {
+    primary: String,
+    fanout: Vec<String>,
+}
+
+impl Resolution {
+    pub fn recipients(&self) -> Vec<String> {
+        if self.fanout.is_empty() {
+            vec![self.primary.clone()]
+        } else {
+            self.fanout.clone()
+        }
+    }
+}
+
+impl BridgeRouteConfig {
+    pub fn resolve(&self, inbound: &InboundMessage) -> Resolution {
+        // Pass 1: mention (highest priority)
+        for entry in &self.routes {
+            if entry.match_.platform != inbound.platform {
+                continue;
+            }
+            if let Some(m) = &entry.match_.mention
+                && inbound.body.contains(m.as_str())
+            {
+                return Resolution {
+                    primary: entry.agent.clone(),
+                    fanout: entry.fanout.clone(),
+                };
+            }
+        }
+        // Pass 2: platform + chat_id (skip mention-routes; they only match in pass 1)
+        for entry in &self.routes {
+            if entry.match_.platform != inbound.platform {
+                continue;
+            }
+            if entry.match_.mention.is_some() {
+                continue;
+            }
+            if let Some(c) = &entry.match_.chat_id
+                && c == &inbound.chat_id
+            {
+                return Resolution {
+                    primary: entry.agent.clone(),
+                    fanout: entry.fanout.clone(),
+                };
+            }
+        }
+        // Pass 3: default
+        Resolution {
+            primary: self.default_route.clone(),
+            fanout: vec![],
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -59,5 +123,16 @@ routes:
         let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
         let s = serde_yaml_ng::to_string(&cfg).unwrap();
         assert_eq!(serde_yaml_ng::from_str::<BridgeRouteConfig>(&s).unwrap(), cfg);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_default() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        let r = cfg.resolve(&InboundMessage {
+            platform: "telegram".into(),
+            chat_id: "99999".into(),
+            body: "hello".into(),
+        });
+        assert_eq!(r.recipients(), vec!["coach"]);
     }
 }

--- a/mur-common/src/bridge/routes.rs
+++ b/mur-common/src/bridge/routes.rs
@@ -122,7 +122,10 @@ routes:
     fn round_trip_preserves_fields() {
         let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
         let s = serde_yaml_ng::to_string(&cfg).unwrap();
-        assert_eq!(serde_yaml_ng::from_str::<BridgeRouteConfig>(&s).unwrap(), cfg);
+        assert_eq!(
+            serde_yaml_ng::from_str::<BridgeRouteConfig>(&s).unwrap(),
+            cfg
+        );
     }
 
     #[test]
@@ -141,7 +144,7 @@ routes:
         let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
         let r = cfg.resolve(&InboundMessage {
             platform: "telegram".into(),
-            chat_id: "12345".into(), // would route to therapist
+            chat_id: "12345".into(),        // would route to therapist
             body: "hey @coach help".into(), // mention wins
         });
         assert_eq!(r.recipients(), vec!["coach"]);

--- a/mur-common/src/bridge/routes.rs
+++ b/mur-common/src/bridge/routes.rs
@@ -135,4 +135,48 @@ routes:
         });
         assert_eq!(r.recipients(), vec!["coach"]);
     }
+
+    #[test]
+    fn mention_wins_over_chat_id() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        let r = cfg.resolve(&InboundMessage {
+            platform: "telegram".into(),
+            chat_id: "12345".into(), // would route to therapist
+            body: "hey @coach help".into(), // mention wins
+        });
+        assert_eq!(r.recipients(), vec!["coach"]);
+    }
+
+    #[test]
+    fn chat_id_when_no_mention() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        let r = cfg.resolve(&InboundMessage {
+            platform: "telegram".into(),
+            chat_id: "12345".into(),
+            body: "no mentions".into(),
+        });
+        assert_eq!(r.recipients(), vec!["therapist"]);
+    }
+
+    #[test]
+    fn fanout_returns_full_list() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        let r = cfg.resolve(&InboundMessage {
+            platform: "telegram".into(),
+            chat_id: "67890".into(),
+            body: "ping".into(),
+        });
+        assert_eq!(r.recipients(), vec!["coach", "journal_agent"]);
+    }
+
+    #[test]
+    fn platform_mismatch_falls_through() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        let r = cfg.resolve(&InboundMessage {
+            platform: "slack".into(),
+            chat_id: "12345".into(),
+            body: "ping".into(),
+        });
+        assert_eq!(r.recipients(), vec!["coach"]);
+    }
 }

--- a/mur-common/src/bridge/routes.rs
+++ b/mur-common/src/bridge/routes.rs
@@ -1,0 +1,63 @@
+//! `routes.yaml` schema for the A2A bridge.
+//!
+//! A bridge is an LLM-less mur agent that ferries chat-platform messages to
+//! the right *user* agent on the local A2A bus. `BridgeRouteConfig` describes
+//! a deterministic mapping from inbound message → recipient agent(s) with the
+//! precedence: explicit mention > platform-specific match (chat_id) >
+//! default_route. There is **no LLM triage** in routing — the resolver is a
+//! pure function over the inbound envelope and the static config.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BridgeRouteConfig {
+    pub default_route: String,
+    #[serde(default)]
+    pub routes: Vec<RouteEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteEntry {
+    #[serde(rename = "match")]
+    pub match_: RouteMatch,
+    pub agent: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fanout: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteMatch {
+    pub platform: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mention: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const SAMPLE: &str = r#"
+default_route: coach
+routes:
+  - match: { platform: telegram, mention: "@coach" }
+    agent: coach
+  - match: { platform: telegram, chat_id: "12345" }
+    agent: therapist
+  - match: { platform: telegram, chat_id: "67890" }
+    agent: coach
+    fanout: [coach, journal_agent]
+"#;
+    #[test]
+    fn parses_full_example() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        assert_eq!(cfg.default_route, "coach");
+        assert_eq!(cfg.routes.len(), 3);
+    }
+    #[test]
+    fn round_trip_preserves_fields() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        let s = serde_yaml_ng::to_string(&cfg).unwrap();
+        assert_eq!(serde_yaml_ng::from_str::<BridgeRouteConfig>(&s).unwrap(), cfg);
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `routes.yaml` schema for the A2A bridge — the foundation pattern for chat-platform connectors (Telegram / Slack / Discord / …). A bridge is an LLM-less mur agent that ferries inbound messages to the right user agent based on a deterministic, static config.

This PR implements **M-c1.1** of [Track C1 — A2A bridge architecture](../docs/superpowers/plans/2026-05-03-mur-agent-track-c1-a2a-bridge.md):

- **M-c1.1.1** — `BridgeRouteConfig` / `RouteEntry` / `RouteMatch` types + serde YAML round-trip in `mur-common/src/bridge/routes.rs`. Module wired into `mur-common/src/bridge/mod.rs` (extends the M-c1.0 `bridge` namespace alongside `LlmEntitlement`).
- **M-c1.1.2** — `InboundMessage`, `Resolution`, and `BridgeRouteConfig::resolve` (default-route fallback). `Resolution.fanout` is private; access via `recipients()` only. The resolver is a pure function over the inbound envelope and the static config — **no LLM triage**.
- **M-c1.1.3** — Precedence assertions: explicit mention > platform-specific match (chat_id) > `default_route`, plus fanout broadcast and platform-mismatch fallback.

## Tests

7 unit tests (all green via `cargo test -p mur-common bridge::routes`):

| Test | What it asserts |
|------|-----------------|
| `parses_full_example` | YAML deserializes into 3 routes + `default_route: coach` |
| `round_trip_preserves_fields` | YAML → struct → YAML → struct is identity |
| `resolve_falls_back_to_default` | unknown chat_id, no mention → `default_route` |
| `mention_wins_over_chat_id` | mention overrides a competing chat_id match |
| `chat_id_when_no_mention` | platform + chat_id matches when body has no mention |
| `fanout_returns_full_list` | fanout list overrides single primary recipient |
| `platform_mismatch_falls_through` | non-matching platform → `default_route` |

## Test plan

- [x] `cargo test -p mur-common bridge::routes` — 7 passed
- [x] `cargo clippy -p mur-common --lib -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

> Note on full-suite clippy: `cargo clippy -p mur-common --all-targets -- -D warnings` surfaces a pre-existing `field_reassign_with_default` lint in `mur-common/tests/companion_enums.rs` (unchanged from the M-c1.0 base). Not introduced by this PR.

## Notes

- Routing precedence (explicit mention > chat_id > `default_route`) is intentionally deterministic — there is **no LLM triage** in routing. M-c1.0's `LlmEntitlement` keeps bridges LLM-less; routing decisions must be reproducible offline.
- `Resolution.fanout` is a private field; callers go through `Resolution::recipients()`. This is required by the plan and gives us room to evolve broadcast semantics without breaking ABI.
- Module uses Rust 2024 let-chains (`if let Some(m) = … && condition`), already enabled workspace-wide.
- M-c1.1.4 (structural `validate()`) is intentionally **not** included — out of scope for this 3-task slice; will land in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)