### PR TITLE
feat(runtime): Track C1 — M-c1.2 sled-backed DedupeStore (7d TTL)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,4 @@ ulid = { version = "1", features = ["serde"] }
 fs2 = "0.4"
 chrono-tz = "0.8"
 insta = { version = "1", features = ["yaml"] }
+sled = "0.34"

--- a/mur-agent-runtime/Cargo.toml
+++ b/mur-agent-runtime/Cargo.toml
@@ -69,6 +69,10 @@ url = "2"
 # patterns once via OnceLock and matches each outbound message body before
 # delivery. Pattern set deliberately favors false-positives.
 regex = "1"
+# Track C1 — bridge dedupe store. Sled gives us an embedded transactional
+# K/V tree. We store `(bridge_id, platform_msg_id) -> u64 LE timestamp` and
+# sweep entries older than 7 days.
+sled = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/mur-agent-runtime/src/bridge/dedupe.rs
+++ b/mur-agent-runtime/src/bridge/dedupe.rs
@@ -52,14 +52,38 @@ impl DedupeStore {
     pub fn is_seen(&self, msg_id: &str) -> Result<bool, DedupeError> {
         let key = self.make_key(msg_id);
         let hit = self.tree.get(&key)?.is_some();
-        let n = self.counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        if n.wrapping_add(1) % SWEEP_EVERY == 0 {
+        let n = self
+            .counter
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if n.wrapping_add(1).is_multiple_of(SWEEP_EVERY) {
             let _ = self.sweep_expired();
         }
         Ok(hit)
     }
 
-    pub(crate) fn sweep_expired(&self) -> Result<usize, DedupeError> {
-        Ok(0) // implemented in M-c1.2.3
+    pub fn sweep_expired(&self) -> Result<usize, DedupeError> {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        let cutoff = now.saturating_sub(TTL.as_secs());
+        let mut evicted = 0;
+        for kv in self.tree.iter() {
+            let (key, value) = kv?;
+            if value.len() != 8 {
+                continue;
+            }
+            let mut ts = [0u8; 8];
+            ts.copy_from_slice(&value);
+            if u64::from_le_bytes(ts) < cutoff {
+                self.tree.remove(&key)?;
+                evicted += 1;
+            }
+        }
+        Ok(evicted)
+    }
+
+    #[doc(hidden)]
+    pub fn insert_at_for_test(&mut self, msg_id: &str, ts_secs: u64) -> Result<(), DedupeError> {
+        let key = self.make_key(msg_id);
+        self.tree.insert(&key, &ts_secs.to_le_bytes())?;
+        Ok(())
     }
 }

--- a/mur-agent-runtime/src/bridge/dedupe.rs
+++ b/mur-agent-runtime/src/bridge/dedupe.rs
@@ -1,0 +1,36 @@
+use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const TTL: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+const TREE_NAME: &str = "seen";
+/// Sweep TTL-expired keys every Nth lookup. 256 = busy bridges sweep ~once
+/// per few hundred messages; idle bridges almost never.
+const SWEEP_EVERY: u32 = 256;
+
+#[derive(thiserror::Error, Debug)]
+pub enum DedupeError {
+    #[error("sled error: {0}")]
+    Sled(#[from] sled::Error),
+    #[error("system time: {0}")]
+    Time(#[from] std::time::SystemTimeError),
+}
+
+pub struct DedupeStore {
+    _db: sled::Db,
+    tree: sled::Tree,
+    bridge_id: String,
+    counter: std::sync::atomic::AtomicU32,
+}
+
+impl DedupeStore {
+    pub fn open(dir: &Path, bridge_id: impl Into<String>) -> Result<Self, DedupeError> {
+        let db = sled::open(dir.join("seen.sled"))?;
+        let tree = db.open_tree(TREE_NAME)?;
+        Ok(Self {
+            _db: db,
+            tree,
+            bridge_id: bridge_id.into(),
+            counter: 0.into(),
+        })
+    }
+}

--- a/mur-agent-runtime/src/bridge/dedupe.rs
+++ b/mur-agent-runtime/src/bridge/dedupe.rs
@@ -33,4 +33,33 @@ impl DedupeStore {
             counter: 0.into(),
         })
     }
+
+    fn make_key(&self, msg_id: &str) -> Vec<u8> {
+        let mut k = Vec::with_capacity(self.bridge_id.len() + 1 + msg_id.len());
+        k.extend_from_slice(self.bridge_id.as_bytes());
+        k.push(0);
+        k.extend_from_slice(msg_id.as_bytes());
+        k
+    }
+
+    pub fn mark_seen(&mut self, msg_id: &str) -> Result<(), DedupeError> {
+        let key = self.make_key(msg_id);
+        let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        self.tree.insert(&key, &now.to_le_bytes())?;
+        Ok(())
+    }
+
+    pub fn is_seen(&self, msg_id: &str) -> Result<bool, DedupeError> {
+        let key = self.make_key(msg_id);
+        let hit = self.tree.get(&key)?.is_some();
+        let n = self.counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if n.wrapping_add(1) % SWEEP_EVERY == 0 {
+            let _ = self.sweep_expired();
+        }
+        Ok(hit)
+    }
+
+    pub(crate) fn sweep_expired(&self) -> Result<usize, DedupeError> {
+        Ok(0) // implemented in M-c1.2.3
+    }
 }

--- a/mur-agent-runtime/src/bridge/mod.rs
+++ b/mur-agent-runtime/src/bridge/mod.rs
@@ -1,0 +1,8 @@
+//! # Bridge support for the A2A runtime
+//!
+//! A "bridge" is a small, LLM-less mur agent that ferries messages between
+//! a chat platform and a user agent. Envelope verification runs **regardless
+//! of transport** (Unix socket has no peer auth; Noise XK only proves *some*
+//! peer's identity, not authorization to claim the bridge role).
+
+pub mod dedupe;

--- a/mur-agent-runtime/src/lib.rs
+++ b/mur-agent-runtime/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![allow(dead_code)]
 
+pub mod bridge;
 pub mod communication_policy;
 pub mod companion;
 pub mod durable;

--- a/mur-agent-runtime/tests/bridge_dedupe_sled.rs
+++ b/mur-agent-runtime/tests/bridge_dedupe_sled.rs
@@ -1,0 +1,31 @@
+use mur_agent_runtime::bridge::dedupe::DedupeStore;
+use tempfile::TempDir;
+
+#[test]
+fn mark_then_is_seen_returns_true() {
+    let tmp = TempDir::new().unwrap();
+    let mut s = DedupeStore::open(tmp.path(), "bridge_telegram").unwrap();
+    assert!(!s.is_seen("msg-42").unwrap());
+    s.mark_seen("msg-42").unwrap();
+    assert!(s.is_seen("msg-42").unwrap());
+}
+
+#[test]
+fn unseen_returns_false() {
+    let tmp = TempDir::new().unwrap();
+    let s = DedupeStore::open(tmp.path(), "x").unwrap();
+    assert!(!s.is_seen("never-marked").unwrap());
+}
+
+#[test]
+fn different_bridges_independent() {
+    let tmp = TempDir::new().unwrap();
+    let mut a = DedupeStore::open(tmp.path(), "a").unwrap();
+    a.mark_seen("msg-1").unwrap();
+    drop(a);
+    // separate bridge_id namespace inside the same DB
+    let b_dir = tmp.path().join("b");
+    std::fs::create_dir(&b_dir).unwrap();
+    let b = DedupeStore::open(&b_dir, "b").unwrap();
+    assert!(!b.is_seen("msg-1").unwrap());
+}

--- a/mur-agent-runtime/tests/bridge_dedupe_sled.rs
+++ b/mur-agent-runtime/tests/bridge_dedupe_sled.rs
@@ -29,3 +29,20 @@ fn different_bridges_independent() {
     let b = DedupeStore::open(&b_dir, "b").unwrap();
     assert!(!b.is_seen("msg-1").unwrap());
 }
+
+#[test]
+fn ttl_eviction_removes_old_entries() {
+    let tmp = TempDir::new().unwrap();
+    let mut s = DedupeStore::open(tmp.path(), "bridge").unwrap();
+    let stale_ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        - (8 * 24 * 60 * 60);
+    s.insert_at_for_test("stale", stale_ts).unwrap();
+    s.mark_seen("fresh").unwrap();
+    let evicted = s.sweep_expired().unwrap();
+    assert_eq!(evicted, 1);
+    assert!(!s.is_seen("stale").unwrap());
+    assert!(s.is_seen("fresh").unwrap());
+}

--- a/mur-common/src/bridge/mod.rs
+++ b/mur-common/src/bridge/mod.rs
@@ -8,4 +8,4 @@
 pub mod llm_entitlement;
 pub mod routes;
 pub use llm_entitlement::{LlmEntitlement, LlmMode};
-pub use routes::{BridgeRouteConfig, RouteEntry, RouteMatch};
+pub use routes::{BridgeRouteConfig, InboundMessage, Resolution, RouteEntry, RouteMatch};

--- a/mur-common/src/bridge/mod.rs
+++ b/mur-common/src/bridge/mod.rs
@@ -6,4 +6,6 @@
 //! first-class profile shape rather than an ad-hoc convention.
 
 pub mod llm_entitlement;
+pub mod routes;
 pub use llm_entitlement::{LlmEntitlement, LlmMode};
+pub use routes::{BridgeRouteConfig, RouteEntry, RouteMatch};

--- a/mur-common/src/bridge/routes.rs
+++ b/mur-common/src/bridge/routes.rs
@@ -34,6 +34,70 @@ pub struct RouteMatch {
     pub chat_id: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct InboundMessage {
+    pub platform: String,
+    pub chat_id: String,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Resolution {
+    primary: String,
+    fanout: Vec<String>,
+}
+
+impl Resolution {
+    pub fn recipients(&self) -> Vec<String> {
+        if self.fanout.is_empty() {
+            vec![self.primary.clone()]
+        } else {
+            self.fanout.clone()
+        }
+    }
+}
+
+impl BridgeRouteConfig {
+    pub fn resolve(&self, inbound: &InboundMessage) -> Resolution {
+        // Pass 1: mention (highest priority)
+        for entry in &self.routes {
+            if entry.match_.platform != inbound.platform {
+                continue;
+            }
+            if let Some(m) = &entry.match_.mention
+                && inbound.body.contains(m.as_str())
+            {
+                return Resolution {
+                    primary: entry.agent.clone(),
+                    fanout: entry.fanout.clone(),
+                };
+            }
+        }
+        // Pass 2: platform + chat_id (skip mention-routes; they only match in pass 1)
+        for entry in &self.routes {
+            if entry.match_.platform != inbound.platform {
+                continue;
+            }
+            if entry.match_.mention.is_some() {
+                continue;
+            }
+            if let Some(c) = &entry.match_.chat_id
+                && c == &inbound.chat_id
+            {
+                return Resolution {
+                    primary: entry.agent.clone(),
+                    fanout: entry.fanout.clone(),
+                };
+            }
+        }
+        // Pass 3: default
+        Resolution {
+            primary: self.default_route.clone(),
+            fanout: vec![],
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -59,5 +123,16 @@ routes:
         let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
         let s = serde_yaml_ng::to_string(&cfg).unwrap();
         assert_eq!(serde_yaml_ng::from_str::<BridgeRouteConfig>(&s).unwrap(), cfg);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_default() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        let r = cfg.resolve(&InboundMessage {
+            platform: "telegram".into(),
+            chat_id: "99999".into(),
+            body: "hello".into(),
+        });
+        assert_eq!(r.recipients(), vec!["coach"]);
     }
 }

--- a/mur-common/src/bridge/routes.rs
+++ b/mur-common/src/bridge/routes.rs
@@ -122,7 +122,10 @@ routes:
     fn round_trip_preserves_fields() {
         let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
         let s = serde_yaml_ng::to_string(&cfg).unwrap();
-        assert_eq!(serde_yaml_ng::from_str::<BridgeRouteConfig>(&s).unwrap(), cfg);
+        assert_eq!(
+            serde_yaml_ng::from_str::<BridgeRouteConfig>(&s).unwrap(),
+            cfg
+        );
     }
 
     #[test]
@@ -141,7 +144,7 @@ routes:
         let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
         let r = cfg.resolve(&InboundMessage {
             platform: "telegram".into(),
-            chat_id: "12345".into(), // would route to therapist
+            chat_id: "12345".into(),        // would route to therapist
             body: "hey @coach help".into(), // mention wins
         });
         assert_eq!(r.recipients(), vec!["coach"]);

--- a/mur-common/src/bridge/routes.rs
+++ b/mur-common/src/bridge/routes.rs
@@ -135,4 +135,48 @@ routes:
         });
         assert_eq!(r.recipients(), vec!["coach"]);
     }
+
+    #[test]
+    fn mention_wins_over_chat_id() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        let r = cfg.resolve(&InboundMessage {
+            platform: "telegram".into(),
+            chat_id: "12345".into(), // would route to therapist
+            body: "hey @coach help".into(), // mention wins
+        });
+        assert_eq!(r.recipients(), vec!["coach"]);
+    }
+
+    #[test]
+    fn chat_id_when_no_mention() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        let r = cfg.resolve(&InboundMessage {
+            platform: "telegram".into(),
+            chat_id: "12345".into(),
+            body: "no mentions".into(),
+        });
+        assert_eq!(r.recipients(), vec!["therapist"]);
+    }
+
+    #[test]
+    fn fanout_returns_full_list() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        let r = cfg.resolve(&InboundMessage {
+            platform: "telegram".into(),
+            chat_id: "67890".into(),
+            body: "ping".into(),
+        });
+        assert_eq!(r.recipients(), vec!["coach", "journal_agent"]);
+    }
+
+    #[test]
+    fn platform_mismatch_falls_through() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        let r = cfg.resolve(&InboundMessage {
+            platform: "slack".into(),
+            chat_id: "12345".into(),
+            body: "ping".into(),
+        });
+        assert_eq!(r.recipients(), vec!["coach"]);
+    }
 }

--- a/mur-common/src/bridge/routes.rs
+++ b/mur-common/src/bridge/routes.rs
@@ -1,0 +1,63 @@
+//! `routes.yaml` schema for the A2A bridge.
+//!
+//! A bridge is an LLM-less mur agent that ferries chat-platform messages to
+//! the right *user* agent on the local A2A bus. `BridgeRouteConfig` describes
+//! a deterministic mapping from inbound message → recipient agent(s) with the
+//! precedence: explicit mention > platform-specific match (chat_id) >
+//! default_route. There is **no LLM triage** in routing — the resolver is a
+//! pure function over the inbound envelope and the static config.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BridgeRouteConfig {
+    pub default_route: String,
+    #[serde(default)]
+    pub routes: Vec<RouteEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteEntry {
+    #[serde(rename = "match")]
+    pub match_: RouteMatch,
+    pub agent: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fanout: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteMatch {
+    pub platform: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mention: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const SAMPLE: &str = r#"
+default_route: coach
+routes:
+  - match: { platform: telegram, mention: "@coach" }
+    agent: coach
+  - match: { platform: telegram, chat_id: "12345" }
+    agent: therapist
+  - match: { platform: telegram, chat_id: "67890" }
+    agent: coach
+    fanout: [coach, journal_agent]
+"#;
+    #[test]
+    fn parses_full_example() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        assert_eq!(cfg.default_route, "coach");
+        assert_eq!(cfg.routes.len(), 3);
+    }
+    #[test]
+    fn round_trip_preserves_fields() {
+        let cfg: BridgeRouteConfig = serde_yaml_ng::from_str(SAMPLE).unwrap();
+        let s = serde_yaml_ng::to_string(&cfg).unwrap();
+        assert_eq!(serde_yaml_ng::from_str::<BridgeRouteConfig>(&s).unwrap(), cfg);
+    }
+}


### PR DESCRIPTION
## Summary

Track C1 — A2A bridge architecture, M-c1.2 (3 tasks). Adds a sled-backed `DedupeStore` that bridges use to track `(bridge_id, platform_msg_id)` pairs with a 7-day TTL. Critical for "exactly-once" inbound delivery: if a bridge restarts mid-loop, it can re-poll the platform without re-firing already-acked messages.

- **M-c1.2.1** — Add `sled = "0.34"` to workspace deps + `mur-agent-runtime/Cargo.toml`. Create `mur-agent-runtime/src/bridge/{mod.rs, dedupe.rs}` skeleton (`DedupeStore::open` only). Wire `pub mod bridge;` into `lib.rs`.
- **M-c1.2.2** — `mark_seen(&mut self, msg_id) -> Result<()>` writes `now_secs.to_le_bytes()` under key `{bridge_id}\0{msg_id}`. `is_seen(&self, msg_id) -> Result<bool>` reads the tree and increments an `AtomicU32` counter that triggers `sweep_expired()` every 256 lookups (interior-mutability path so callers don't need `&mut`).
- **M-c1.2.3** — `sweep_expired(&self)` iterates the tree, removes entries whose stored timestamp is older than `now - 7d`, returns the eviction count. `#[doc(hidden)] insert_at_for_test()` lets the test inject a stale entry without waiting 8 days.

## Tests

`cargo test -p mur-agent-runtime --test bridge_dedupe_sled` — 4 green:
- `mark_then_is_seen_returns_true`
- `unseen_returns_false`
- `different_bridges_independent`
- `ttl_eviction_removes_old_entries`

`cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` — clean.
`cargo fmt --check` — clean.

## Notes

- **`bridge_id` is the namespace prefix in the sled key** (`{bridge_id}\0{msg_id}`), so multiple bridges can share a tree without colliding. The `different_bridges_independent` test currently exercises the simpler "separate DB dir" path; the namespacing also defends against shared-tree collisions if a future caller decides to reuse one DB across bridges.
- **`sweep_expired()` runs on every Nth `is_seen()` call** (`SWEEP_EVERY = 256`), keeping idle bridges from doing unnecessary work. Busy bridges sweep once per few hundred messages; idle bridges almost never. Counter wraps via `wrapping_add` so a long-lived bridge never panics.
- `is_seen` takes `&self` (not `&mut self`) and uses an `AtomicU32` for the counter — bridges can call it from their poll loop without restructuring borrows.

## Cascade

Branched off `feat/mur-agent-track-c1-m-c1.1-routes-yaml` (PR #127, in flight). Once #127 lands, the cascade controller will retarget this PR's base to `main`.

## Test plan

- [ ] `cargo test -p mur-agent-runtime --test bridge_dedupe_sled` reports 4 passed
- [ ] `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] After cascade rebase to main, full `cargo test --workspace` still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)