### PR TITLE
feat(common,runtime): Track C1 — M-c1.3 SignedEnvelope + TrustedPeer + verify

### DIFF
--- a/mur-agent-runtime/src/bridge/mod.rs
+++ b/mur-agent-runtime/src/bridge/mod.rs
@@ -4,6 +4,18 @@
 //! a chat platform and a user agent. Envelope verification runs **regardless
 //! of transport** (Unix socket has no peer auth; Noise XK only proves *some*
 //! peer's identity, not authorization to claim the bridge role).
+//!
+//! ## Trust model
+//!
+//! Verification ([`verify::verify_inbound_envelope`]) runs **regardless of
+//! transport**. Every inbound A2A envelope from a bridge MUST carry a
+//! `SignedEnvelope` and the user agent MUST verify against
+//! `profile.yaml.trusted_peers[]` before processing.
+//!
+//! ## Sub-modules
+//!
+//! - [`dedupe`] — sled-backed `(bridge_id, platform_msg_id)`, 7-day TTL
+//! - [`verify`] — envelope verification against a trust list
 
 pub mod dedupe;
 pub mod verify;

--- a/mur-agent-runtime/src/bridge/mod.rs
+++ b/mur-agent-runtime/src/bridge/mod.rs
@@ -6,3 +6,4 @@
 //! peer's identity, not authorization to claim the bridge role).
 
 pub mod dedupe;
+pub mod verify;

--- a/mur-agent-runtime/src/bridge/verify.rs
+++ b/mur-agent-runtime/src/bridge/verify.rs
@@ -1,0 +1,28 @@
+//! Inbound envelope verification against an explicit trust list.
+//!
+//! See [`crate::bridge`] module docs for the trust model: verification is
+//! transport-independent and MUST run on every inbound A2A envelope from a
+//! bridge before processing.
+
+use mur_common::bridge::envelope::{EnvelopeError, SignedEnvelope, verify_envelope_with_pubkey};
+use mur_common::bridge::peer::TrustedPeer;
+
+/// Verify a `SignedEnvelope` against an explicit trust list. Returns Ok(()) only if:
+///   1. envelope's `bridge_pubkey_multibase` matches some `TrustedPeer`
+///   2. that peer's pinned `key_version`, if any, matches the envelope
+///   3. the Ed25519 signature verifies against `payload`
+pub fn verify_inbound_envelope(
+    env: &SignedEnvelope,
+    peers: &[TrustedPeer],
+) -> Result<(), EnvelopeError> {
+    let peer = peers
+        .iter()
+        .find(|p| p.pubkey_multibase == env.bridge_pubkey_multibase)
+        .ok_or(EnvelopeError::UntrustedPeer)?;
+    if let Some(pinned) = peer.key_version
+        && pinned != env.key_version
+    {
+        return Err(EnvelopeError::UntrustedPeer);
+    }
+    verify_envelope_with_pubkey(env, &peer.pubkey_multibase)
+}

--- a/mur-agent-runtime/tests/bridge_envelope_signing.rs
+++ b/mur-agent-runtime/tests/bridge_envelope_signing.rs
@@ -1,0 +1,46 @@
+use mur_agent_runtime::bridge::verify::verify_inbound_envelope;
+use mur_common::bridge::envelope::{EnvelopeError, sign_payload};
+use mur_common::bridge::peer::TrustedPeer;
+use mur_common::identity::{AgentIdentity, encode_pubkey};
+
+fn peer_for(id: &AgentIdentity, ver: Option<u32>) -> TrustedPeer {
+    TrustedPeer {
+        pubkey_multibase: encode_pubkey(&id.verifying_key()),
+        name: "stub".into(),
+        key_version: ver,
+    }
+}
+
+#[test]
+fn signed_by_trusted_passes() {
+    let id = AgentIdentity::generate();
+    let env = sign_payload(b"hi".to_vec(), &id, 0);
+    verify_inbound_envelope(&env, &[peer_for(&id, None)]).unwrap();
+}
+
+#[test]
+fn unknown_peer_rejected() {
+    let id = AgentIdentity::generate();
+    let env = sign_payload(b"hi".to_vec(), &id, 0);
+    assert!(matches!(
+        verify_inbound_envelope(&env, &[]).unwrap_err(),
+        EnvelopeError::UntrustedPeer
+    ));
+}
+
+#[test]
+fn key_version_pin_mismatch_rejected() {
+    let id = AgentIdentity::generate();
+    let env = sign_payload(b"hi".to_vec(), &id, 1);
+    assert!(matches!(
+        verify_inbound_envelope(&env, &[peer_for(&id, Some(2))]).unwrap_err(),
+        EnvelopeError::UntrustedPeer
+    ));
+}
+
+#[test]
+fn key_version_pin_match_accepted() {
+    let id = AgentIdentity::generate();
+    let env = sign_payload(b"hi".to_vec(), &id, 4);
+    verify_inbound_envelope(&env, &[peer_for(&id, Some(4))]).unwrap();
+}

--- a/mur-common/Cargo.toml
+++ b/mur-common/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+serde_bytes = "0.11"
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 serde_yaml_ng = "0.10"

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -44,6 +44,10 @@ pub struct AgentProfile {
     /// continue to load without this block).
     #[serde(default)]
     pub companion: CompanionConfig,
+    /// Pubkeys of bridges (and other LLM-less peers) this agent will accept
+    /// signed envelopes from. Empty = accept no bridge traffic. Default = empty.
+    #[serde(default)]
+    pub trusted_peers: Vec<crate::bridge::peer::TrustedPeer>,
     pub created_at: String,
     pub updated_at: String,
 }

--- a/mur-common/src/bridge/envelope.rs
+++ b/mur-common/src/bridge/envelope.rs
@@ -67,8 +67,7 @@ pub fn verify_envelope_with_pubkey(
         return Err(EnvelopeError::BadSigLen(env.sig.len()));
     }
     let pub_bytes = crate::identity::decode_pubkey(expected_pubkey)?;
-    let vk =
-        VerifyingKey::from_bytes(&pub_bytes).map_err(|_| EnvelopeError::SignatureMismatch)?;
+    let vk = VerifyingKey::from_bytes(&pub_bytes).map_err(|_| EnvelopeError::SignatureMismatch)?;
     let sig_arr: [u8; 64] = env.sig.as_slice().try_into().unwrap();
     let sig = Signature::from_bytes(&sig_arr);
     vk.verify_strict(&env.payload, &sig)

--- a/mur-common/src/bridge/envelope.rs
+++ b/mur-common/src/bridge/envelope.rs
@@ -1,3 +1,4 @@
+use ed25519_dalek::Signer;
 use serde::{Deserialize, Serialize};
 
 /// Bridge-signed wrapper around an A2A payload. `payload` is the *already-
@@ -20,6 +21,61 @@ impl SignedEnvelope {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum EnvelopeError {
+    #[error("multibase decode: {0}")]
+    Multibase(#[from] crate::identity::IdentityError),
+    #[error("bad sig length: expected 64, got {0}")]
+    BadSigLen(usize),
+    #[error("signature does not verify")]
+    SignatureMismatch,
+    #[error("untrusted peer")]
+    UntrustedPeer,
+}
+
+/// Sign a canonical-JSON payload with the bridge's identity key.
+///
+/// `payload` MUST already be canonicalized (sorted keys, no whitespace) —
+/// this function does NOT re-canonicalize. Verifiers re-use the exact bytes
+/// stored in the resulting `SignedEnvelope.payload`; never re-canonicalize on
+/// receive.
+pub fn sign_payload(
+    payload: Vec<u8>,
+    identity: &crate::identity::AgentIdentity,
+    key_version: u32,
+) -> SignedEnvelope {
+    let sig = identity.signing_key().sign(&payload);
+    SignedEnvelope {
+        payload,
+        sig: sig.to_bytes().to_vec(),
+        key_version,
+        bridge_pubkey_multibase: crate::identity::encode_pubkey(&identity.verifying_key()),
+    }
+}
+
+/// Verify the envelope's signature against an expected pubkey (multibase).
+///
+/// This is the low-level check: it does not consult any trust list. Callers
+/// that need authorization (peer-must-be-trusted) should layer
+/// `verify_inbound_envelope` on top of this.
+pub fn verify_envelope_with_pubkey(
+    env: &SignedEnvelope,
+    expected_pubkey: &str,
+) -> Result<(), EnvelopeError> {
+    use ed25519_dalek::{Signature, VerifyingKey};
+    if env.sig.len() != 64 {
+        return Err(EnvelopeError::BadSigLen(env.sig.len()));
+    }
+    let pub_bytes = crate::identity::decode_pubkey(expected_pubkey)?;
+    let vk =
+        VerifyingKey::from_bytes(&pub_bytes).map_err(|_| EnvelopeError::SignatureMismatch)?;
+    let sig_arr: [u8; 64] = env.sig.as_slice().try_into().unwrap();
+    let sig = Signature::from_bytes(&sig_arr);
+    vk.verify_strict(&env.payload, &sig)
+        .map_err(|_| EnvelopeError::SignatureMismatch)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -33,5 +89,40 @@ mod tests {
             bridge_pubkey_multibase: "z".into(),
         };
         assert_eq!(e.canonical_payload_for_signing(), payload.as_slice());
+    }
+
+    #[test]
+    fn sign_then_verify_round_trips() {
+        use crate::identity::AgentIdentity;
+        let id = AgentIdentity::generate();
+        let env = sign_payload(b"hello".to_vec(), &id, 7);
+        assert_eq!(env.key_version, 7);
+        verify_envelope_with_pubkey(&env, &env.bridge_pubkey_multibase).unwrap();
+    }
+
+    #[test]
+    fn verify_with_wrong_pubkey_fails() {
+        use crate::identity::{AgentIdentity, encode_pubkey};
+        let a = AgentIdentity::generate();
+        let b = AgentIdentity::generate();
+        let env = sign_payload(b"x".to_vec(), &a, 0);
+        let pub_b = encode_pubkey(&b.verifying_key());
+        assert!(matches!(
+            verify_envelope_with_pubkey(&env, &pub_b).unwrap_err(),
+            EnvelopeError::SignatureMismatch
+        ));
+    }
+
+    #[test]
+    fn tampered_payload_fails() {
+        use crate::identity::AgentIdentity;
+        let id = AgentIdentity::generate();
+        let mut env = sign_payload(b"orig".to_vec(), &id, 0);
+        env.payload = b"tamper".to_vec();
+        let pub_ = env.bridge_pubkey_multibase.clone();
+        assert!(matches!(
+            verify_envelope_with_pubkey(&env, &pub_).unwrap_err(),
+            EnvelopeError::SignatureMismatch
+        ));
     }
 }

--- a/mur-common/src/bridge/envelope.rs
+++ b/mur-common/src/bridge/envelope.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+/// Bridge-signed wrapper around an A2A payload. `payload` is the *already-
+/// canonical* JSON-serialized A2A `JsonRpcRequest`; the bridge canonicalizes
+/// (sorted keys, no whitespace) BEFORE construction. Verification re-uses
+/// these exact bytes — never re-canonicalize on receive.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedEnvelope {
+    #[serde(with = "serde_bytes")]
+    pub payload: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub sig: Vec<u8>,
+    pub key_version: u32,
+    pub bridge_pubkey_multibase: String,
+}
+
+impl SignedEnvelope {
+    pub fn canonical_payload_for_signing(&self) -> &[u8] {
+        &self.payload
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn canonical_payload_is_passthrough() {
+        let payload = serde_json::json!({"a": 1}).to_string().into_bytes();
+        let e = SignedEnvelope {
+            payload: payload.clone(),
+            sig: vec![0u8; 64],
+            key_version: 1,
+            bridge_pubkey_multibase: "z".into(),
+        };
+        assert_eq!(e.canonical_payload_for_signing(), payload.as_slice());
+    }
+}

--- a/mur-common/src/bridge/mod.rs
+++ b/mur-common/src/bridge/mod.rs
@@ -5,7 +5,9 @@
 //! types here describe schema bits shared across crates so bridges are a
 //! first-class profile shape rather than an ad-hoc convention.
 
+pub mod envelope;
 pub mod llm_entitlement;
 pub mod routes;
+pub use envelope::SignedEnvelope;
 pub use llm_entitlement::{LlmEntitlement, LlmMode};
 pub use routes::{BridgeRouteConfig, InboundMessage, Resolution, RouteEntry, RouteMatch};

--- a/mur-common/src/bridge/mod.rs
+++ b/mur-common/src/bridge/mod.rs
@@ -7,7 +7,9 @@
 
 pub mod envelope;
 pub mod llm_entitlement;
+pub mod peer;
 pub mod routes;
 pub use envelope::SignedEnvelope;
 pub use llm_entitlement::{LlmEntitlement, LlmMode};
+pub use peer::TrustedPeer;
 pub use routes::{BridgeRouteConfig, InboundMessage, Resolution, RouteEntry, RouteMatch};

--- a/mur-common/src/bridge/peer.rs
+++ b/mur-common/src/bridge/peer.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+/// One pubkey of a bridge (or other LLM-less peer) that this agent will accept
+/// signed envelopes from.
+///
+/// `key_version` is an optional pin: when `Some(N)`, only envelopes with
+/// `key_version == N` are accepted; when `None`, any `key_version` is accepted
+/// as long as the pubkey matches. Pins let an operator quarantine a specific
+/// rotation without removing the peer entirely.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrustedPeer {
+    pub pubkey_multibase: String,
+    pub name: String,
+    /// Optional version pin. None = any key_version with matching pubkey.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_version: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn round_trip() {
+        let p = TrustedPeer {
+            pubkey_multibase: "z6Mk".into(),
+            name: "tg_bridge".into(),
+            key_version: Some(3),
+        };
+        let s = serde_yaml_ng::to_string(&p).unwrap();
+        assert_eq!(serde_yaml_ng::from_str::<TrustedPeer>(&s).unwrap(), p);
+    }
+}

--- a/mur-core/src/cmd/agent.rs
+++ b/mur-core/src/cmd/agent.rs
@@ -150,6 +150,7 @@ pub fn cmd_create(
         file_transfer: FileTransferConfig::default(),
         deployment: DeploymentConfig::default(),
         companion: CompanionConfig::default(),
+        trusted_peers: Vec::new(),
         created_at: now.clone(),
         updated_at: now,
     };


### PR DESCRIPTION
## Summary

Track C1 — M-c1.3: bridge envelope signing.

Bridges sign every outbound A2A message with their Ed25519 identity key; user-agents verify against `profile.yaml.trusted_peers[]` regardless of transport (Unix sockets carry no peer auth; Noise XK only proves *some* peer's identity, not authorization to claim a bridge role).

## Per-task summary

| Commit | Tests | What it adds |
|--------|------|--------------|
| `M-c1.3.1` | 1 | `SignedEnvelope` schema (`payload`, `sig`, `key_version`, `bridge_pubkey_multibase`); `serde_bytes 0.11` dep |
| `M-c1.3.2` | 3 | `sign_payload`, `verify_envelope_with_pubkey`, `EnvelopeError` (Multibase/BadSigLen/SignatureMismatch/UntrustedPeer) |
| `M-c1.3.3` | 1 | `TrustedPeer { pubkey_multibase, name, key_version: Option<u32> }`; `AgentProfile.trusted_peers: Vec<TrustedPeer>` (`#[serde(default)]` for back-compat) |
| `M-c1.3.4` | 4 | `mur_agent_runtime::bridge::verify::verify_inbound_envelope` — checks pubkey membership, optional `key_version` pin, then signature |
| `M-c1.3.5` | — | Module-level "Trust model" doc on `mur-agent-runtime::bridge` |
| `M-c1.3` fmt | — | `cargo fmt` cleanup (single-line `let vk = …`) |

## Test counts

- `cargo test -p mur-common bridge::` — **14 passed** (5 new: 4 envelope + 1 peer; rest from M-c1.0/c1.1)
- `cargo test -p mur-agent-runtime --test bridge_envelope_signing` — **4 passed** (all new)

## Notes

- **Verify runs regardless of transport.** Unix sockets have no peer auth; Noise XK only proves *some* peer's identity, not authorization to claim a bridge role. Every inbound envelope MUST be verified against the trust list before processing.
- **`AgentProfile.trusted_peers`** is a new field with `#[serde(default)]` — legacy profiles parse unchanged (verified via existing `agent::tests::profile_round_trip_yaml` + `model_ref_tests::legacy_profile_without_model_ref_still_parses`).
- **`key_version` pin semantics**: `Some(N)` = only accept envelopes with that exact version; `None` = accept any version with matching pubkey. Lets an operator quarantine a specific rotation without removing the peer entirely.
- **Time-of-check vs time-of-use**: the envelope carries `key_version`; pin checks happen before signature verification so a wrong-version envelope never reaches `ed25519` verification (cheap reject).
- **HOOK_SCHEMA_VERSION**: not bumped (this PR doesn't touch hook payloads — still 2 from M7.6).
- **Pre-existing clippy lint** in `mur-common/tests/companion_enums.rs` (`clippy::field-reassign-with-default` triggered by Rust 1.95) was confirmed to fire on `main` as well — not introduced by this PR. Library + bins clippy clean for both crates; integration test in this PR clippy-clean.

## Test plan

- [x] `cargo test -p mur-common bridge::envelope` — green (4 tests)
- [x] `cargo test -p mur-common bridge::peer` — green (1 test)
- [x] `cargo test -p mur-common --lib agent::` — green (3 tests, back-compat)
- [x] `cargo test -p mur-agent-runtime --test bridge_envelope_signing` — green (4 tests)
- [x] `cargo clippy -p mur-common --lib -- -D warnings` clean
- [x] `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)