### PR TITLE
feat(runtime,core): Track C1 — M-c1.4 BridgeBeacon + degraded surface

### DIFF
--- a/mur-agent-runtime/src/bridge/beacon.rs
+++ b/mur-agent-runtime/src/bridge/beacon.rs
@@ -12,12 +12,19 @@
 //! See plan task M-c1.4 in
 //! `docs/superpowers/plans/2026-05-03-mur-agent-track-c1-a2a-bridge.md`.
 
-use std::time::Duration;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
 use tokio::sync::mpsc::Sender;
 
 use crate::telemetry_writer::Event;
 
 pub use mur_common::telemetry::METHOD_BRIDGE_ALIVE;
+
+/// Maximum age of a bridge's `running.lock` mtime before peers should
+/// treat the bridge as `Degraded`. The bridge supervisor emits a
+/// `telemetry/bridge_alive` notification every 30 s, so a 90 s window
+/// tolerates two missed beats.
+pub const DEGRADED_AFTER_SECS: u64 = 90;
 
 /// Build the JSON-RPC notification body emitted by [`BridgeBeacon`].
 ///
@@ -77,6 +84,44 @@ impl BridgeBeacon {
                 }
             }
         })
+    }
+}
+
+/// Coarse liveness classification for a bridge peer.
+///
+/// Returned by [`bridge_status_for_peer`]; consumed by `mur agent
+/// doctor`'s `bridges:` section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgePeerStatus {
+    /// `running.lock` exists and was modified within the last
+    /// [`DEGRADED_AFTER_SECS`] seconds.
+    Running,
+    /// `running.lock` exists but its mtime is older than
+    /// [`DEGRADED_AFTER_SECS`] seconds (heartbeat stalled).
+    Degraded,
+    /// `running.lock` is missing or unreadable.
+    Offline,
+}
+
+/// Classify a bridge peer by inspecting `running.lock` mtime in
+/// `agent_dir` (typically `~/.mur/agents/<name>/`).
+pub fn bridge_status_for_peer(agent_dir: &Path) -> BridgePeerStatus {
+    let meta = match std::fs::metadata(agent_dir.join("running.lock")) {
+        Ok(m) => m,
+        Err(_) => return BridgePeerStatus::Offline,
+    };
+    let mtime = match meta.modified() {
+        Ok(t) => t,
+        Err(_) => return BridgePeerStatus::Offline,
+    };
+    let age = SystemTime::now()
+        .duration_since(mtime)
+        .unwrap_or_default()
+        .as_secs();
+    if age > DEGRADED_AFTER_SECS {
+        BridgePeerStatus::Degraded
+    } else {
+        BridgePeerStatus::Running
     }
 }
 

--- a/mur-agent-runtime/src/bridge/beacon.rs
+++ b/mur-agent-runtime/src/bridge/beacon.rs
@@ -1,0 +1,93 @@
+//! `BridgeBeacon` — a 30 s heartbeat for LLM-less bridge agents.
+//!
+//! Each bridge agent (one whose `entitlements.llm.mode = off`) emits a
+//! `telemetry/bridge_alive` JSON-RPC notification every 30 s. Peers that
+//! cooperate with the bridge (typically a user agent reading the
+//! commander or another agent's notification stream) classify the
+//! bridge's liveness via [`bridge_status_for_peer`] which inspects the
+//! `running.lock` mtime — a still-running supervisor refreshes the lock
+//! on every beacon emit (file mtime advances when telemetry is written
+//! through `TelemetryWriter`'s JSONL append path).
+//!
+//! See plan task M-c1.4 in
+//! `docs/superpowers/plans/2026-05-03-mur-agent-track-c1-a2a-bridge.md`.
+
+use std::time::Duration;
+use tokio::sync::mpsc::Sender;
+
+use crate::telemetry_writer::Event;
+
+pub use mur_common::telemetry::METHOD_BRIDGE_ALIVE;
+
+/// Build the JSON-RPC notification body emitted by [`BridgeBeacon`].
+///
+/// Pure function exposed for tests and downstream tooling that needs to
+/// inspect / replay the on-wire shape without a live channel.
+pub fn make_alive_payload(bridge_id: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": METHOD_BRIDGE_ALIVE,
+        "params": {
+            "bridge_id": bridge_id,
+            "ts": chrono::Utc::now().to_rfc3339(),
+        },
+    }))
+    .expect("static JSON serializes")
+}
+
+/// Periodic heartbeat emitter for a bridge agent.
+///
+/// Construct one per supervisor and call [`BridgeBeacon::spawn`] to
+/// drive a background task. The task exits cleanly when the telemetry
+/// channel is closed (i.e. on supervisor shutdown).
+pub struct BridgeBeacon {
+    bridge_id: String,
+    tx: Sender<Event>,
+    interval: Duration,
+}
+
+impl BridgeBeacon {
+    /// Default 30 s heartbeat interval per spec §M-c1.4.1.
+    pub fn new(bridge_id: impl Into<String>, tx: Sender<Event>) -> Self {
+        Self {
+            bridge_id: bridge_id.into(),
+            tx,
+            interval: Duration::from_secs(30),
+        }
+    }
+
+    /// Spawn the heartbeat loop. Emits an `Event::BridgeAlive` event on
+    /// every tick; the runtime's `TelemetryWriter` translates that into
+    /// a `telemetry/bridge_alive` JSON-RPC notification matching
+    /// [`make_alive_payload`].
+    pub fn spawn(self) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut t = tokio::time::interval(self.interval);
+            // First tick fires immediately; we want to wait one full
+            // interval before the first beat so the supervisor has time
+            // to fully attach transports.
+            t.tick().await;
+            loop {
+                t.tick().await;
+                let ev = Event::BridgeAlive {
+                    bridge_id: self.bridge_id.clone(),
+                };
+                if self.tx.send(ev).await.is_err() {
+                    break;
+                }
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn payload_has_method_and_bridge_id() {
+        let p = make_alive_payload("bridge_telegram");
+        let v: serde_json::Value = serde_json::from_slice(&p).unwrap();
+        assert_eq!(v["method"], "telemetry/bridge_alive");
+        assert_eq!(v["params"]["bridge_id"], "bridge_telegram");
+    }
+}

--- a/mur-agent-runtime/src/bridge/mod.rs
+++ b/mur-agent-runtime/src/bridge/mod.rs
@@ -14,8 +14,10 @@
 //!
 //! ## Sub-modules
 //!
+//! - [`beacon`] — 30 s `telemetry/bridge_alive` heartbeat + degraded classifier
 //! - [`dedupe`] — sled-backed `(bridge_id, platform_msg_id)`, 7-day TTL
 //! - [`verify`] — envelope verification against a trust list
 
+pub mod beacon;
 pub mod dedupe;
 pub mod verify;

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -457,6 +457,19 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     write_lock(&lock_path, &lock)?;
     info!("agent {} ({}) ready", profile.inner.name, profile.inner.id);
 
+    // 8.5 — bridge agents (LLM disabled by entitlement) emit a 30 s
+    //       heartbeat so peers can classify them via
+    //       `bridge::beacon::bridge_status_for_peer` (running.lock mtime
+    //       refreshes whenever the writer task appends a JSONL line).
+    if profile.inner.entitlements.llm.mode == mur_common::LlmMode::Off {
+        let beacon = crate::bridge::beacon::BridgeBeacon::new(
+            profile.inner.name.clone(),
+            writer.sender(),
+        );
+        transport_tasks.push(beacon.spawn());
+        info!(name = %profile.inner.name, "spawned BridgeBeacon (30 s heartbeat)");
+    }
+
     // 8b. Companion subsystem (Phase 1.1 M5.7).
     //     Returns None when profile.companion.enabled is false — zero-cost path.
     let companion_clock =

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -462,10 +462,8 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     //       `bridge::beacon::bridge_status_for_peer` (running.lock mtime
     //       refreshes whenever the writer task appends a JSONL line).
     if profile.inner.entitlements.llm.mode == mur_common::LlmMode::Off {
-        let beacon = crate::bridge::beacon::BridgeBeacon::new(
-            profile.inner.name.clone(),
-            writer.sender(),
-        );
+        let beacon =
+            crate::bridge::beacon::BridgeBeacon::new(profile.inner.name.clone(), writer.sender());
         transport_tasks.push(beacon.spawn());
         info!(name = %profile.inner.name, "spawned BridgeBeacon (30 s heartbeat)");
     }

--- a/mur-agent-runtime/src/telemetry_writer.rs
+++ b/mur-agent-runtime/src/telemetry_writer.rs
@@ -60,6 +60,16 @@ pub enum Event {
         method: String,
         attrs: Value,
     },
+    /// 30 s liveness beat emitted by `BridgeBeacon` on bridge agents
+    /// (`entitlements.llm.mode = off`). Routed to peers via the same
+    /// notification side-channel as `Heartbeat`; consumed by
+    /// `mur agent doctor`'s `bridges:` section through
+    /// `bridge::beacon::bridge_status_for_peer` (which inspects
+    /// `running.lock` mtime — refreshed each time the writer task
+    /// appends a JSONL line).
+    BridgeAlive {
+        bridge_id: String,
+    },
 }
 
 pub struct TelemetryWriter {
@@ -214,6 +224,10 @@ fn event_to_notification(ev: &Event, name: &str, uuid: &str) -> Value {
                 }
             }
             return json!({"jsonrpc": "2.0", "method": method, "params": params});
+        }
+        Event::BridgeAlive { bridge_id } => {
+            params["bridge_id"] = json!(bridge_id);
+            METHOD_BRIDGE_ALIVE
         }
     };
     json!({"jsonrpc": "2.0", "method": method, "params": params})

--- a/mur-agent-runtime/tests/bridge_beacon_degraded.rs
+++ b/mur-agent-runtime/tests/bridge_beacon_degraded.rs
@@ -1,0 +1,44 @@
+//! Integration tests for `bridge::beacon::bridge_status_for_peer`.
+//!
+//! Plan task M-c1.4.2 — verifies the Running / Degraded / Offline
+//! classification by manipulating `running.lock` mtime in a tempdir.
+
+use mur_agent_runtime::bridge::beacon::{BridgePeerStatus, bridge_status_for_peer};
+use std::time::{Duration, SystemTime};
+use tempfile::TempDir;
+
+fn write_lock_with_age(dir: &std::path::Path, age: Duration) {
+    let lock = dir.join("running.lock");
+    std::fs::write(&lock, b"{}").unwrap();
+    let f = std::fs::File::open(&lock).unwrap();
+    f.set_modified(SystemTime::now() - age).unwrap();
+}
+
+#[test]
+fn fresh_lock_is_running() {
+    let tmp = TempDir::new().unwrap();
+    write_lock_with_age(tmp.path(), Duration::from_secs(5));
+    assert_eq!(
+        bridge_status_for_peer(tmp.path()),
+        BridgePeerStatus::Running
+    );
+}
+
+#[test]
+fn old_lock_is_degraded() {
+    let tmp = TempDir::new().unwrap();
+    write_lock_with_age(tmp.path(), Duration::from_secs(120));
+    assert_eq!(
+        bridge_status_for_peer(tmp.path()),
+        BridgePeerStatus::Degraded
+    );
+}
+
+#[test]
+fn missing_lock_is_offline() {
+    let tmp = TempDir::new().unwrap();
+    assert_eq!(
+        bridge_status_for_peer(tmp.path()),
+        BridgePeerStatus::Offline
+    );
+}

--- a/mur-agent-runtime/tests/bridge_beacon_degraded.rs
+++ b/mur-agent-runtime/tests/bridge_beacon_degraded.rs
@@ -10,7 +10,8 @@ use tempfile::TempDir;
 fn write_lock_with_age(dir: &std::path::Path, age: Duration) {
     let lock = dir.join("running.lock");
     std::fs::write(&lock, b"{}").unwrap();
-    let f = std::fs::File::open(&lock).unwrap();
+    // Windows requires write access to set mtime; std::fs::File::open is read-only.
+    let f = std::fs::OpenOptions::new().write(true).open(&lock).unwrap();
     f.set_modified(SystemTime::now() - age).unwrap();
 }
 

--- a/mur-common/src/telemetry.rs
+++ b/mur-common/src/telemetry.rs
@@ -53,3 +53,4 @@ pub const METHOD_HEARTBEAT: &str = "telemetry/heartbeat";
 pub const METHOD_WARNING: &str = "telemetry/warning";
 pub const METHOD_TASK_PROGRESS: &str = "task/progress";
 pub const METHOD_HOOK_FIRED: &str = "telemetry/hook_fired";
+pub const METHOD_BRIDGE_ALIVE: &str = "telemetry/bridge_alive";

--- a/mur-core/src/cmd/doctor.rs
+++ b/mur-core/src/cmd/doctor.rs
@@ -7,6 +7,7 @@
 //! green `mur agent doctor --format gui` predicts a successful export.
 
 use anyhow::Result;
+use mur_agent_runtime::bridge::beacon::{BridgePeerStatus, bridge_status_for_peer};
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 
@@ -64,11 +65,107 @@ pub fn run(format: &str, json: bool) -> Result<()> {
     } else {
         print_human(&results);
     }
+
+    // M-c1.4.4 — `bridges:` section. Only emitted in `all` / unset
+    // mode (export-format-specific runs aren't interested in
+    // bridge liveness diagnostics).
+    if matches!(format, "all" | "") {
+        let mur_home = std::env::var("MUR_HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| {
+                dirs::home_dir()
+                    .expect("home directory required to locate ~/.mur")
+                    .join(".mur")
+            });
+        let bridges = collect_bridge_statuses(&mur_home);
+        if !bridges.is_empty() {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "bridges": bridges
+                            .iter()
+                            .map(|b| serde_json::json!({
+                                "name": b.name,
+                                "status": bridge_status_label(b.status),
+                            }))
+                            .collect::<Vec<_>>(),
+                    }))?
+                );
+            } else {
+                println!("\nbridges:");
+                for b in &bridges {
+                    println!("  {}: {}", b.name, bridge_status_label(b.status));
+                }
+            }
+        }
+    }
+
     let any_missing = results.iter().any(|r| r.status == CheckStatus::Missing);
     if any_missing {
         anyhow::bail!("doctor found missing prerequisites");
     }
     Ok(())
+}
+
+fn bridge_status_label(s: BridgePeerStatus) -> &'static str {
+    match s {
+        BridgePeerStatus::Running => "running",
+        BridgePeerStatus::Degraded => "degraded",
+        BridgePeerStatus::Offline => "offline",
+    }
+}
+
+/// Per-agent liveness summary surfaced in the `bridges:` section of
+/// `mur agent doctor`. Returned by [`collect_bridge_statuses`] and
+/// rendered by [`run`].
+#[derive(Debug)]
+pub struct BridgeSummary {
+    /// Agent directory name under `~/.mur/agents/`. Used as the key
+    /// because the on-disk directory is the stable identifier; the
+    /// profile's own `name:` field can drift.
+    pub name: String,
+    /// Coarse liveness derived from `running.lock` mtime.
+    pub status: BridgePeerStatus,
+}
+
+/// Walk `<mur_home>/agents/*/profile.yaml` and emit a [`BridgeSummary`]
+/// for every agent with `entitlements.llm.mode = off`. Sorted by name
+/// for stable rendering. Silent on parse / IO failures so a single
+/// malformed agent dir doesn't blank out the doctor report.
+pub fn collect_bridge_statuses(mur_home: &std::path::Path) -> Vec<BridgeSummary> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(mur_home.join("agents")) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() {
+            continue;
+        }
+        let yaml = match std::fs::read_to_string(dir.join("profile.yaml")) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let profile: mur_common::AgentProfile = match serde_yaml_ng::from_str(&yaml) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if profile.entitlements.llm.mode != mur_common::LlmMode::Off {
+            continue;
+        }
+        let name = match dir.file_name().and_then(|s| s.to_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        out.push(BridgeSummary {
+            name,
+            status: bridge_status_for_peer(&dir),
+        });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
 }
 
 /// Return the check list applicable to the given export format.

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod context;
 pub(crate) mod conversations_cmd;
 pub mod conversations_cost_report;
 pub(crate) mod deploy;
-pub(crate) mod doctor;
+pub mod doctor;
 pub(crate) mod drafts;
 pub(crate) mod evolve_cmd;
 pub(crate) mod init;

--- a/mur-core/tests/doctor_bridges_section.rs
+++ b/mur-core/tests/doctor_bridges_section.rs
@@ -1,0 +1,50 @@
+//! Integration test for `mur agent doctor` — `bridges:` section.
+//!
+//! Plan task M-c1.4.4 — verifies that
+//! [`mur_core::cmd::doctor::collect_bridge_statuses`] enumerates
+//! agents whose `entitlements.llm.mode = off` and classifies each by
+//! `running.lock` mtime via `bridge_status_for_peer`.
+
+use mur_agent_runtime::bridge::beacon::BridgePeerStatus;
+use mur_core::cmd::doctor::{BridgeSummary, collect_bridge_statuses};
+use tempfile::TempDir;
+
+fn write_bridge_fixture(dir: &std::path::Path) {
+    // Minimal AgentProfile YAML w/ entitlements.llm.mode = off. Adapted
+    // from the round-trip fixture at mur-common/src/agent.rs:691 with
+    // `entitlements.llm: { mode: off }` injected. The profile's own
+    // `name:` is irrelevant — `collect_bridge_statuses` keys results
+    // off the on-disk directory name (matching `~/.mur/agents/<name>/`).
+    std::fs::write(
+        dir.join("profile.yaml"),
+        include_str!("fixtures/bridge_profile.yaml"),
+    )
+    .unwrap();
+}
+
+#[test]
+fn lists_running_and_degraded() {
+    let tmp = TempDir::new().unwrap();
+    let agents = tmp.path().join("agents");
+    let a = agents.join("bridge_a");
+    let b = agents.join("bridge_b");
+    std::fs::create_dir_all(&a).unwrap();
+    std::fs::create_dir_all(&b).unwrap();
+    write_bridge_fixture(&a);
+    write_bridge_fixture(&b);
+    std::fs::write(a.join("running.lock"), b"{}").unwrap();
+    let stale = b.join("running.lock");
+    std::fs::write(&stale, b"{}").unwrap();
+    std::fs::File::open(&stale)
+        .unwrap()
+        .set_modified(std::time::SystemTime::now() - std::time::Duration::from_secs(120))
+        .unwrap();
+
+    let summary = collect_bridge_statuses(tmp.path());
+    let map: std::collections::BTreeMap<_, _> = summary
+        .iter()
+        .map(|s: &BridgeSummary| (s.name.clone(), s.status))
+        .collect();
+    assert_eq!(map["bridge_a"], BridgePeerStatus::Running);
+    assert_eq!(map["bridge_b"], BridgePeerStatus::Degraded);
+}

--- a/mur-core/tests/doctor_bridges_section.rs
+++ b/mur-core/tests/doctor_bridges_section.rs
@@ -35,7 +35,10 @@ fn lists_running_and_degraded() {
     std::fs::write(a.join("running.lock"), b"{}").unwrap();
     let stale = b.join("running.lock");
     std::fs::write(&stale, b"{}").unwrap();
-    std::fs::File::open(&stale)
+    // Windows requires write access to set mtime; std::fs::File::open is read-only.
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&stale)
         .unwrap()
         .set_modified(std::time::SystemTime::now() - std::time::Duration::from_secs(120))
         .unwrap();

--- a/mur-core/tests/fixtures/bridge_profile.yaml
+++ b/mur-core/tests/fixtures/bridge_profile.yaml
@@ -1,0 +1,34 @@
+schema: 1
+id: 01JQX4TM8Y9K7VQH6B2N3R5DPF
+name: bridge_test
+display_name: "Bridge Test Fixture"
+version: "0.1.0"
+persona:
+  category: research
+  description: "Bridge fixture used by mur-core/tests/doctor_bridges_section.rs"
+  traits: { tone: concise, risk: cautious, verbosity: low }
+sys_prompt_file: "sys_prompt.md"
+model: { provider: ollama, name: "llama3.2:3b", params: { temperature: 0.2, max_tokens: 4096 } }
+mcp_servers: []
+skills: []
+transport:
+  stdio: true
+  socket: { enabled: true, bind: "unix:///tmp/a.sock" }
+communication: { accepts_from: ["*"], sends_to: [] }
+capabilities: ["a2a.message.send", "a2a.tasks"]
+entitlements:
+  network:
+    inbound: { ports: [] }
+    outbound: { mode: restricted, allow_hosts: [], protocols: ["tcp"], resolve_dns: { mode: system } }
+  filesystem: { read: [], write: [], deny: [] }
+  processes: { spawn: { mode: allowlist, allowed: [] } }
+  syscalls: { mode: default }
+  limits: { memory_mb: 512, file_descriptors: 1024, processes: 32 }
+  llm: { mode: off }
+notifications: { on_task_complete: [], on_error: [], on_shutdown: [] }
+retry:
+  llm: { max_retries: 3, backoff: exponential, initial_delay_ms: 1000, max_delay_ms: 30000, retry_on: [rate_limit, timeout, connection_error] }
+  tool: { max_retries: 1, backoff: fixed, initial_delay_ms: 500 }
+lifecycle: { restart: on_failure, max_restarts: 3, restart_window_secs: 600, stop_timeout_secs: 15, mcp_required: true }
+created_at: "2026-04-22T10:00:00+08:00"
+updated_at: "2026-04-22T10:00:00+08:00"


### PR DESCRIPTION
## Summary

Track C1 milestone **M-c1.4** — heartbeat + degraded surface for bridge agents.

- **M-c1.4.1** — `BridgeBeacon` emits a `telemetry/bridge_alive` JSON-RPC notification every 30 s. New `Event::BridgeAlive { bridge_id }` enum variant + matching arm in `event_to_notification` so the beacon flows through the same fanout as `Event::Heartbeat`. `METHOD_BRIDGE_ALIVE` constant added to `mur-common::telemetry`.
- **M-c1.4.2** — `bridge_status_for_peer(agent_dir)` classifier returning `Running` / `Degraded` / `Offline` based on `running.lock` mtime. Threshold = 90 s (3 missed beats). Added to the same `bridge::beacon` module.
- **M-c1.4.3** — supervisor spawns the beacon when `entitlements.llm.mode == LlmMode::Off`. Pushed onto the existing `transport_tasks` `Vec<JoinHandle>` so it participates in the same shutdown abort loop as other transports — no new collection needed.
- **M-c1.4.4** — `mur agent doctor` surfaces a `bridges:` section listing each LLM-less agent's status. Added `pub fn collect_bridge_statuses(mur_home)` returning `Vec<BridgeSummary>` and rendered in both human + JSON modes. Only emitted when `format ∈ {"all", ""}` so export-format-specific runs (gui/bin/pkg) stay focused on prereqs.

### Plan deviations

- **Telemetry channel signature** — plan pseudocode assumed `Sender<Vec<u8>>`; actual runtime channel is `Sender<Event>` (the typed enum). Followed the existing `METHOD_HEARTBEAT` pattern by adding a new `Event::BridgeAlive { bridge_id }` variant and routing through `event_to_notification`. `make_alive_payload` is still kept as a public helper for tests to inspect on-wire shape.
- **`background_tasks` vec** — plan suggested declaring a new `background_tasks: Vec<JoinHandle<()>>`. The supervisor already has `transport_tasks` with the same lifecycle (aborted on graceful shutdown at line 530–532); the beacon is registered there to avoid duplicating the abort loop.
- **Bridge directory name as identifier** — plan's M-c1.4.4 pseudocode used `profile.name`. The integration test asserts `map["bridge_a"]` / `map["bridge_b"]` for two bridges that share the same fixture YAML. To make those keys distinct, `collect_bridge_statuses` keys results off the on-disk directory name. The on-disk directory matches the conventional `~/.mur/agents/<name>/` layout, so this is also the most stable identifier.
- **Two side-fixes for compile** — pre-existing breakage from M-c1.3 (PR #129) blocked `cargo build -p mur-core`:
  1. `cmd::doctor` was `pub(crate)` — promoted to `pub` per the plan's explicit instruction so the integration test can import the new types.
  2. `cmd::agent::cmd_create`'s `AgentProfile { … }` literal was missing `trusted_peers: Vec::new()` (added to the schema in M-c1.3.3 but not propagated). Fixed in-place.

## Test plan

- [x] `cargo test -p mur-agent-runtime bridge::beacon::tests` — 1 passed
- [x] `cargo test -p mur-agent-runtime --test bridge_beacon_degraded` — 3 passed (`fresh_lock_is_running`, `old_lock_is_degraded`, `missing_lock_is_offline`)
- [x] `cargo test -p mur-core --test doctor_bridges_section` — 1 passed (`lists_running_and_degraded`)
- [x] `cargo build -p mur-agent-runtime` clean
- [x] `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` clean
- [x] `cargo clippy -p mur-core --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)