### PR TITLE
feat(runtime): Track C1 — M-c1.5 AckTracker (offset advance only on 2xx)

### DIFF
--- a/mur-agent-runtime/src/bridge/ack.rs
+++ b/mur-agent-runtime/src/bridge/ack.rs
@@ -1,0 +1,57 @@
+//! Cursor-advancement helper. **`committed_offset` advances if and only if
+//! the user agent returns 2xx.** Generic over `T` so platforms with
+//! non-numeric cursors (e.g. Slack `next_cursor: String`) can use it.
+//!
+//! Concrete bridges MUST persist `committed_offset` to disk before resuming
+//! polling so a crash mid-pending does not skip messages.
+
+#[derive(Debug)]
+pub struct AckTracker<T: Clone + PartialEq> {
+    committed: T,
+    pending: Option<T>,
+}
+
+impl<T: Clone + PartialEq> AckTracker<T> {
+    pub fn new(initial: T) -> Self {
+        Self {
+            committed: initial,
+            pending: None,
+        }
+    }
+    pub fn committed_offset(&self) -> T {
+        self.committed.clone()
+    }
+    /// Idempotent: a second `start_pending` without intervening confirm/reject
+    /// replaces the first.
+    pub fn start_pending(&mut self, next: T) {
+        self.pending = Some(next);
+    }
+    pub fn confirm(&mut self) {
+        if let Some(p) = self.pending.take() {
+            self.committed = p;
+        }
+    }
+    pub fn reject(&mut self) {
+        self.pending = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn confirm_advances() {
+        let mut t = AckTracker::new(100);
+        t.start_pending(105);
+        assert_eq!(t.committed_offset(), 100);
+        t.confirm();
+        assert_eq!(t.committed_offset(), 105);
+    }
+    #[test]
+    fn reject_keeps_old() {
+        let mut t = AckTracker::new(100);
+        t.start_pending(105);
+        t.reject();
+        assert_eq!(t.committed_offset(), 100);
+    }
+}

--- a/mur-agent-runtime/src/bridge/mod.rs
+++ b/mur-agent-runtime/src/bridge/mod.rs
@@ -14,10 +14,12 @@
 //!
 //! ## Sub-modules
 //!
+//! - [`ack`] — cursor-advancement helper (advance iff user agent 2xx)
 //! - [`beacon`] — 30 s `telemetry/bridge_alive` heartbeat + degraded classifier
 //! - [`dedupe`] — sled-backed `(bridge_id, platform_msg_id)`, 7-day TTL
 //! - [`verify`] — envelope verification against a trust list
 
+pub mod ack;
 pub mod beacon;
 pub mod dedupe;
 pub mod verify;

--- a/mur-agent-runtime/tests/bridge_ack_tracker.rs
+++ b/mur-agent-runtime/tests/bridge_ack_tracker.rs
@@ -1,0 +1,30 @@
+use mur_agent_runtime::bridge::ack::AckTracker;
+
+fn simulate(t: &mut AckTracker<u64>, ok: bool, high: u64) {
+    t.start_pending(high);
+    if ok {
+        t.confirm();
+    } else {
+        t.reject();
+    }
+}
+
+#[test]
+fn five_xx_then_two_xx_recovers() {
+    let mut t = AckTracker::new(0u64);
+    simulate(&mut t, false, 10);
+    assert_eq!(t.committed_offset(), 0);
+    simulate(&mut t, true, 10);
+    assert_eq!(t.committed_offset(), 10);
+    simulate(&mut t, true, 20);
+    assert_eq!(t.committed_offset(), 20);
+}
+
+#[test]
+fn many_failures_pin_offset() {
+    let mut t = AckTracker::new(50u64);
+    for _ in 0..10 {
+        simulate(&mut t, false, 60);
+    }
+    assert_eq!(t.committed_offset(), 50);
+}


### PR DESCRIPTION
## Summary

- Adds `AckTracker<T>` (generic over cursor type) in `mur-agent-runtime/src/bridge/ack.rs` — bridges advance their platform offset/cursor ONLY when the user agent returns 2xx on `message/send`.
- Module doc states the invariant (advance iff 2xx) plus persistence requirement (concrete bridges MUST persist `committed_offset` to disk before resuming polling).
- Generic over `T: Clone + PartialEq` so platforms with non-numeric cursors (e.g. Slack `next_cursor: String`) can use it.

API:

- `new(initial: T)` — construct with a starting committed offset
- `committed_offset(&self) -> T` — read durable offset (clone)
- `start_pending(&mut self, next: T)` — record a candidate offset; idempotent (later call replaces earlier)
- `confirm(&mut self)` — advance to the pending offset (no-op if no pending)
- `reject(&mut self)` — drop the pending offset

## Test plan

- [x] `cargo test -p mur-agent-runtime --lib bridge::ack` — 2 unit tests pass (confirm advances, reject keeps old)
- [x] `cargo test -p mur-agent-runtime --test bridge_ack_tracker` — 2 integration tests pass (5xx-then-2xx recovery, many failures pin offset)
- [x] `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo doc -p mur-agent-runtime --no-deps` — no new warnings on `bridge::ack`

Plan: `docs/superpowers/plans/2026-05-03-mur-agent-track-c1-a2a-bridge.md` lines 1281-1384 (M-c1.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)