### PR TITLE
feat(core): Track C1 — M-c1.6 mur agent companion connector add --platform stub

### DIFF
--- a/mur-agent-runtime/src/bridge/ack.rs
+++ b/mur-agent-runtime/src/bridge/ack.rs
@@ -1,0 +1,57 @@
+//! Cursor-advancement helper. **`committed_offset` advances if and only if
+//! the user agent returns 2xx.** Generic over `T` so platforms with
+//! non-numeric cursors (e.g. Slack `next_cursor: String`) can use it.
+//!
+//! Concrete bridges MUST persist `committed_offset` to disk before resuming
+//! polling so a crash mid-pending does not skip messages.
+
+#[derive(Debug)]
+pub struct AckTracker<T: Clone + PartialEq> {
+    committed: T,
+    pending: Option<T>,
+}
+
+impl<T: Clone + PartialEq> AckTracker<T> {
+    pub fn new(initial: T) -> Self {
+        Self {
+            committed: initial,
+            pending: None,
+        }
+    }
+    pub fn committed_offset(&self) -> T {
+        self.committed.clone()
+    }
+    /// Idempotent: a second `start_pending` without intervening confirm/reject
+    /// replaces the first.
+    pub fn start_pending(&mut self, next: T) {
+        self.pending = Some(next);
+    }
+    pub fn confirm(&mut self) {
+        if let Some(p) = self.pending.take() {
+            self.committed = p;
+        }
+    }
+    pub fn reject(&mut self) {
+        self.pending = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn confirm_advances() {
+        let mut t = AckTracker::new(100);
+        t.start_pending(105);
+        assert_eq!(t.committed_offset(), 100);
+        t.confirm();
+        assert_eq!(t.committed_offset(), 105);
+    }
+    #[test]
+    fn reject_keeps_old() {
+        let mut t = AckTracker::new(100);
+        t.start_pending(105);
+        t.reject();
+        assert_eq!(t.committed_offset(), 100);
+    }
+}

--- a/mur-agent-runtime/src/bridge/mod.rs
+++ b/mur-agent-runtime/src/bridge/mod.rs
@@ -14,10 +14,12 @@
 //!
 //! ## Sub-modules
 //!
+//! - [`ack`] — cursor-advancement helper (advance iff user agent 2xx)
 //! - [`beacon`] — 30 s `telemetry/bridge_alive` heartbeat + degraded classifier
 //! - [`dedupe`] — sled-backed `(bridge_id, platform_msg_id)`, 7-day TTL
 //! - [`verify`] — envelope verification against a trust list
 
+pub mod ack;
 pub mod beacon;
 pub mod dedupe;
 pub mod verify;

--- a/mur-agent-runtime/tests/bridge_ack_tracker.rs
+++ b/mur-agent-runtime/tests/bridge_ack_tracker.rs
@@ -1,0 +1,30 @@
+use mur_agent_runtime::bridge::ack::AckTracker;
+
+fn simulate(t: &mut AckTracker<u64>, ok: bool, high: u64) {
+    t.start_pending(high);
+    if ok {
+        t.confirm();
+    } else {
+        t.reject();
+    }
+}
+
+#[test]
+fn five_xx_then_two_xx_recovers() {
+    let mut t = AckTracker::new(0u64);
+    simulate(&mut t, false, 10);
+    assert_eq!(t.committed_offset(), 0);
+    simulate(&mut t, true, 10);
+    assert_eq!(t.committed_offset(), 10);
+    simulate(&mut t, true, 20);
+    assert_eq!(t.committed_offset(), 20);
+}
+
+#[test]
+fn many_failures_pin_offset() {
+    let mut t = AckTracker::new(50u64);
+    for _ in 0..10 {
+        simulate(&mut t, false, 60);
+    }
+    assert_eq!(t.committed_offset(), 50);
+}

--- a/mur-core/src/cmd/agent_companion.rs
+++ b/mur-core/src/cmd/agent_companion.rs
@@ -48,6 +48,26 @@ pub enum CompanionCmd {
     Rhythm(RhythmArgs),
     /// Manage character cards (export / import / list / accept).
     Card(card::cli::CardArgs),
+    /// Manage cross-platform connectors (bridge agents). Track C1+.
+    Connector {
+        #[command(subcommand)]
+        action: ConnectorAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ConnectorAction {
+    /// Scaffold a new bridge agent for a given platform.
+    Add {
+        /// Bridge agent name (distinct from any user agent).
+        name: String,
+        /// Platform — only "stub" is supported in C1.
+        #[arg(long, default_value = "stub")]
+        platform: String,
+        /// Recipient agent for the default route. Required.
+        #[arg(long)]
+        default_route: String,
+    },
 }
 
 pub async fn run(args: CompanionArgs) -> anyhow::Result<()> {
@@ -68,10 +88,18 @@ pub async fn run(args: CompanionArgs) -> anyhow::Result<()> {
         CompanionCmd::WhyDidYouMessage(args) => why::run(args).await,
         CompanionCmd::Rhythm(args) => rhythm::run(args).await,
         CompanionCmd::Card(args) => card::cli::run(args).await,
+        CompanionCmd::Connector { action } => match action {
+            ConnectorAction::Add {
+                name,
+                platform,
+                default_route,
+            } => connector::add(name, &platform, &default_route).await,
+        },
     }
 }
 
 pub mod card;
+pub mod connector;
 mod content;
 mod inbox;
 pub mod init;

--- a/mur-core/src/cmd/agent_companion/connector.rs
+++ b/mur-core/src/cmd/agent_companion/connector.rs
@@ -1,0 +1,26 @@
+//! `mur agent companion connector ...` — bridge agent scaffolding (Track C1).
+//!
+//! In Track C1 only `--platform stub` is supported. The stub is a fully
+//! functional A2A bridge agent (LLM disabled, identity keypair, default
+//! route) that downstream tracks (C2 Telegram, C3 send-from-any-app)
+//! specialise.
+
+use anyhow::{Result, bail};
+
+/// Scaffold a new bridge agent. Currently only `--platform stub` is supported.
+pub async fn add(name: String, platform: &str, default_route: &str) -> Result<()> {
+    if platform != "stub" {
+        bail!(
+            "platform '{platform}' not supported in Track C1 — only 'stub' is available. \
+             Telegram lands in C2; send-from-any-app in C3."
+        );
+    }
+    if default_route.trim().is_empty() {
+        bail!("--default-route must be non-empty");
+    }
+    scaffold_stub_bridge(&name, default_route).await
+}
+
+pub(crate) async fn scaffold_stub_bridge(_name: &str, _default_route: &str) -> Result<()> {
+    bail!("scaffold not yet implemented") // M-c1.6.2
+}

--- a/mur-core/src/cmd/agent_companion/connector.rs
+++ b/mur-core/src/cmd/agent_companion/connector.rs
@@ -46,11 +46,7 @@ pub(crate) async fn scaffold_stub_bridge(name: &str, default_route: &str) -> Res
 
     let mur_home = std::env::var_os("MUR_HOME")
         .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            dirs::home_dir()
-                .expect("home dir resolvable")
-                .join(".mur")
-        });
+        .unwrap_or_else(|| dirs::home_dir().expect("home dir resolvable").join(".mur"));
     let dir = mur_home.join("agents").join(name);
     if dir.exists() {
         bail!("agent dir already exists: {}", dir.display());

--- a/mur-core/src/cmd/agent_companion/connector.rs
+++ b/mur-core/src/cmd/agent_companion/connector.rs
@@ -5,7 +5,7 @@
 //! route) that downstream tracks (C2 Telegram, C3 send-from-any-app)
 //! specialise.
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 
 /// Scaffold a new bridge agent. Currently only `--platform stub` is supported.
 pub async fn add(name: String, platform: &str, default_route: &str) -> Result<()> {
@@ -21,6 +21,196 @@ pub async fn add(name: String, platform: &str, default_route: &str) -> Result<()
     scaffold_stub_bridge(&name, default_route).await
 }
 
-pub(crate) async fn scaffold_stub_bridge(_name: &str, _default_route: &str) -> Result<()> {
-    bail!("scaffold not yet implemented") // M-c1.6.2
+/// Build a fresh stub-bridge agent directory under `$MUR_HOME/agents/<name>/`
+/// containing `profile.yaml`, `routes.yaml`, `identity.{key,pub}`, and a
+/// placeholder `sys_prompt.md`. The profile is constructed via direct struct
+/// instantiation (instead of a fixture-yaml round-trip) so future schema
+/// fields with `#[serde(default)]` don't drift the scaffolded output.
+pub(crate) async fn scaffold_stub_bridge(name: &str, default_route: &str) -> Result<()> {
+    use mur_common::agent::{
+        BackoffStrategy, CommunicationConfig, CompanionConfig, DeploymentConfig, Entitlements,
+        ExecutionMode, FileTransferConfig, FilesystemEntitlement, IdentityConfig, InboundNetwork,
+        LifecycleConfig, LimitsEntitlement, ModelConfig, NetworkEntitlement, NetworkOutboundMode,
+        NotificationsConfig, OutboundNetwork, Persona, PersonaCategory, PersonaTraits,
+        ProcessesEntitlement, ResolveDnsConfig, RestartPolicy, RetryConfig, RetryPolicy,
+        SocketTransportConfig, SpawnEntitlement, SpawnMode, SyscallsEntitlement,
+        TcpTransportConfig, TransportConfig,
+    };
+    use mur_common::bridge::routes::BridgeRouteConfig;
+    use mur_common::identity::AgentIdentity;
+    use mur_common::{AgentProfile, LlmEntitlement, LlmMode};
+    use std::path::PathBuf;
+
+    mur_common::validate_agent_name(name)
+        .with_context(|| format!("invalid bridge agent name {name:?}"))?;
+
+    let mur_home = std::env::var_os("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .expect("home dir resolvable")
+                .join(".mur")
+        });
+    let dir = mur_home.join("agents").join(name);
+    if dir.exists() {
+        bail!("agent dir already exists: {}", dir.display());
+    }
+    std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+
+    // 1. identity keypair (Ed25519)
+    let id = AgentIdentity::generate();
+    id.save(&dir)
+        .with_context(|| format!("save identity to {}", dir.display()))?;
+    let pubkey = id.pubkey_text();
+
+    // 2. routes.yaml (bridge-specific schema)
+    let routes = BridgeRouteConfig {
+        default_route: default_route.to_string(),
+        routes: vec![],
+    };
+    std::fs::write(
+        dir.join("routes.yaml"),
+        serde_yaml_ng::to_string(&routes).context("serialize routes.yaml")?,
+    )
+    .with_context(|| format!("write {}/routes.yaml", dir.display()))?;
+
+    // 3. profile.yaml — typed AgentProfile, not string-formatted, so future
+    //    schema additions don't drift. LLM is `off` so the supervisor refuses
+    //    to construct an LLM client; outbound network is `off` because a
+    //    stub bridge has no upstream to call.
+    let now = chrono::Utc::now().to_rfc3339();
+    let profile_id = uuid::Uuid::now_v7().to_string();
+    let profile = AgentProfile {
+        schema: 1,
+        id: profile_id,
+        name: name.to_string(),
+        display_name: name.to_string(),
+        version: "0.1.0".to_string(),
+        persona: Persona {
+            category: PersonaCategory::Custom,
+            description: format!("Bridge agent {name} (LLM disabled)"),
+            traits: PersonaTraits {
+                tone: "concise".into(),
+                risk: "cautious".into(),
+                verbosity: "low".into(),
+            },
+        },
+        sys_prompt_file: "sys_prompt.md".into(),
+        // model is required by the schema even though llm.mode = off blocks
+        // its use; supervisor never instantiates a client.
+        model: ModelConfig {
+            provider: "none".into(),
+            name: "none".into(),
+            params: std::collections::BTreeMap::new(),
+        },
+        model_ref: None,
+        mcp_servers: vec![],
+        skills: vec![],
+        transport: TransportConfig {
+            stdio: true,
+            socket: SocketTransportConfig {
+                enabled: true,
+                bind: format!("unix://{}/agent.sock", dir.display()),
+                auth: None,
+            },
+            tcp: TcpTransportConfig::default(),
+        },
+        communication: CommunicationConfig {
+            accepts_from: vec!["*".into()],
+            sends_to: vec![],
+        },
+        capabilities: vec!["a2a.message.send".into(), "a2a.tasks".into()],
+        entitlements: Entitlements {
+            network: NetworkEntitlement {
+                inbound: InboundNetwork { ports: vec![] },
+                outbound: OutboundNetwork {
+                    mode: NetworkOutboundMode::Off,
+                    allow_hosts: vec![],
+                    protocols: vec!["tcp".into()],
+                    resolve_dns: ResolveDnsConfig::default(),
+                },
+            },
+            filesystem: FilesystemEntitlement {
+                read: vec![],
+                write: vec![],
+                deny: vec!["~/.ssh".into(), "~/.aws".into()],
+            },
+            processes: ProcessesEntitlement {
+                spawn: SpawnEntitlement {
+                    mode: SpawnMode::Allowlist,
+                    allowed: vec![],
+                },
+            },
+            syscalls: SyscallsEntitlement {
+                mode: "default".into(),
+                extra_deny: vec![],
+            },
+            limits: LimitsEntitlement {
+                cpu_seconds: None,
+                memory_mb: 256,
+                file_descriptors: 512,
+                processes: 16,
+            },
+            llm: LlmEntitlement { mode: LlmMode::Off },
+        },
+        notifications: NotificationsConfig::default(),
+        retry: RetryConfig {
+            llm: RetryPolicy {
+                max_retries: 0,
+                backoff: BackoffStrategy::Fixed,
+                initial_delay_ms: 0,
+                max_delay_ms: None,
+                retry_on: vec![],
+            },
+            tool: RetryPolicy {
+                max_retries: 1,
+                backoff: BackoffStrategy::Fixed,
+                initial_delay_ms: 500,
+                max_delay_ms: None,
+                retry_on: vec![],
+            },
+        },
+        lifecycle: LifecycleConfig {
+            restart: RestartPolicy::OnFailure,
+            max_restarts: 3,
+            restart_window_secs: 600,
+            stop_timeout_secs: 15,
+            mcp_required: false,
+            execution: ExecutionMode::default(),
+            schedule: Vec::new(),
+        },
+        identity: IdentityConfig {
+            pubkey: pubkey.clone(),
+            owner: std::env::var("USER").ok(),
+            algorithm: "ed25519".into(),
+            key_version: 0,
+            created_at_key: Some(now.clone()),
+            ..Default::default()
+        },
+        file_transfer: FileTransferConfig::default(),
+        deployment: DeploymentConfig::default(),
+        companion: CompanionConfig::default(),
+        trusted_peers: vec![],
+        created_at: now.clone(),
+        updated_at: now,
+    };
+    std::fs::write(
+        dir.join("profile.yaml"),
+        serde_yaml_ng::to_string(&profile).context("serialize profile.yaml")?,
+    )
+    .with_context(|| format!("write {}/profile.yaml", dir.display()))?;
+
+    // 4. sys_prompt placeholder — schema requires the file to exist, but the
+    //    supervisor never reads it because llm.mode = off.
+    std::fs::write(
+        dir.join("sys_prompt.md"),
+        "# Bridge sys_prompt\nThis agent is a bridge (llm.mode = off).\n",
+    )
+    .with_context(|| format!("write {}/sys_prompt.md", dir.display()))?;
+
+    println!("stub bridge '{name}' scaffolded at {}", dir.display());
+    println!("   pubkey: {pubkey}");
+    println!("   default_route: {default_route}");
+    println!("   trusted_peers: []  (user agent must add this bridge to its trusted_peers[])");
+    Ok(())
 }

--- a/mur-core/tests/connector_add_stub.rs
+++ b/mur-core/tests/connector_add_stub.rs
@@ -55,3 +55,72 @@ fn stub_bridge_creates_expected_layout() {
         "routes.yaml missing default_route: coach"
     );
 }
+
+#[test]
+fn unknown_platform_errors() {
+    let tmp = TempDir::new().unwrap();
+    let mur_home = tmp.path().join(".mur");
+    std::fs::create_dir_all(&mur_home).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_mur"))
+        .args([
+            "agent",
+            "companion",
+            "connector",
+            "add",
+            "tg_bridge",
+            "--platform",
+            "telegram",
+            "--default-route",
+            "coach",
+        ])
+        .env("MUR_HOME", &mur_home)
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "expected failure for unknown platform"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not supported in Track C1"),
+        "stderr was: {stderr}"
+    );
+}
+
+#[test]
+fn duplicate_add_errors() {
+    let tmp = TempDir::new().unwrap();
+    let mur_home = tmp.path().join(".mur");
+    std::fs::create_dir_all(&mur_home).unwrap();
+    let exe = env!("CARGO_BIN_EXE_mur");
+    let go = || {
+        Command::new(exe)
+            .args([
+                "agent",
+                "companion",
+                "connector",
+                "add",
+                "stub_bridge",
+                "--platform",
+                "stub",
+                "--default-route",
+                "coach",
+            ])
+            .env("MUR_HOME", &mur_home)
+            .output()
+            .unwrap()
+    };
+    let first = go();
+    assert!(
+        first.status.success(),
+        "first add failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let dup = go();
+    assert!(
+        !dup.status.success(),
+        "expected duplicate-add failure but got success"
+    );
+    let stderr = String::from_utf8_lossy(&dup.stderr);
+    assert!(stderr.contains("already exists"), "stderr was: {stderr}");
+}

--- a/mur-core/tests/connector_add_stub.rs
+++ b/mur-core/tests/connector_add_stub.rs
@@ -1,0 +1,57 @@
+//! Track C1 / M-c1.6: `mur agent companion connector add --platform stub`
+//! integration tests.
+//!
+//! Windows: gated — the scaffold writes Unix-style symlinks indirectly via
+//! identity files; gating matches `agent_create.rs`.
+#![cfg(unix)]
+
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn stub_bridge_creates_expected_layout() {
+    let tmp = TempDir::new().unwrap();
+    let mur_home = tmp.path().join(".mur");
+    std::fs::create_dir_all(&mur_home).unwrap();
+
+    let exe = env!("CARGO_BIN_EXE_mur");
+    let out = Command::new(exe)
+        .args([
+            "agent",
+            "companion",
+            "connector",
+            "add",
+            "stub_bridge",
+            "--platform",
+            "stub",
+            "--default-route",
+            "coach",
+        ])
+        .env("MUR_HOME", &mur_home)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let dir = mur_home.join("agents/stub_bridge");
+    assert!(dir.join("profile.yaml").exists(), "profile.yaml missing");
+    assert!(dir.join("routes.yaml").exists(), "routes.yaml missing");
+    assert!(dir.join("identity.key").exists(), "identity.key missing");
+    assert!(dir.join("identity.pub").exists(), "identity.pub missing");
+
+    let p = std::fs::read_to_string(dir.join("profile.yaml")).unwrap();
+    assert!(p.contains("llm:"), "profile.yaml missing llm: block");
+    assert!(
+        p.contains("mode: off"),
+        "profile.yaml missing llm.mode = off"
+    );
+
+    let r = std::fs::read_to_string(dir.join("routes.yaml")).unwrap();
+    assert!(
+        r.contains("default_route: coach"),
+        "routes.yaml missing default_route: coach"
+    );
+}


### PR DESCRIPTION
## Summary

Track C1 / M-c1.6 — user-facing CLI to scaffold a stub bridge agent.

- **M-c1.6.1**: wires `Connector { Add }` under `mur agent companion`. Adds a `ConnectorAction::Add { name, platform, default_route }` enum + dispatch arm. Stub `scaffold_stub_bridge` bails until the body lands.
- **M-c1.6.2**: replaces the stub. Generates an Ed25519 keypair, writes `routes.yaml` (default-route only), `profile.yaml` with `entitlements.llm.mode: off` and `network.outbound.mode: off`, and a `sys_prompt.md` placeholder. **Deviation from plan pseudocode**: the plan called for \`..serde_yaml_ng::from_str(include_str!(\"../../../../mur-common/tests/fixtures/minimal_profile.yaml\"))\` but that fixture doesn't exist on this branch. Switched to direct \`AgentProfile { ... }\` struct construction (mirrors \`cmd_create\` in \`agent.rs\`) — robust to schema drift, no fragile relative include path.
- **M-c1.6.3**: error-path tests for non-stub platform + duplicate add.

## Test plan

- [x] \`cargo build -p mur-core\` clean
- [x] \`mur agent companion connector add --help\` shows the new verb
- [x] \`cargo test -p mur-core --test connector_add_stub\` — 3 tests pass
- [x] \`cargo clippy -p mur-core --all-targets -- -D warnings\` clean (pre-existing \`field_reassign_with_default\` warning in \`mur-common/tests/companion_enums.rs\` is out of scope — landed in #59)
- [x] \`cargo fmt --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)