### PR TITLE
feat(core): Track C2 — M-c2.1 BotFather 5-step setup UX + keychain

### DIFF
--- a/mur-core/src/bridge_keychain.rs
+++ b/mur-core/src/bridge_keychain.rs
@@ -18,6 +18,9 @@ use std::sync::Mutex;
 /// `SystemKeychain` (real backend) and `MockKeychain` (test double).
 pub trait Keychain: Send + Sync {
     fn put(&self, account: &str, secret: &str) -> anyhow::Result<()>;
+    /// Read a secret. Used by tests and by the runtime poller (M-c2.2+);
+    /// the bin target's CLI flow only uses `put`, hence the allow.
+    #[allow(dead_code)]
     fn get(&self, account: &str) -> anyhow::Result<String>;
 }
 
@@ -68,7 +71,8 @@ mod tests {
     #[test]
     fn mock_keychain_round_trip() {
         let kc = MockKeychain::default();
-        kc.put("agent-1/telegram_bot_token", "secret-token").unwrap();
+        kc.put("agent-1/telegram_bot_token", "secret-token")
+            .unwrap();
         assert_eq!(
             kc.get("agent-1/telegram_bot_token").unwrap(),
             "secret-token"

--- a/mur-core/src/bridge_keychain.rs
+++ b/mur-core/src/bridge_keychain.rs
@@ -1,0 +1,83 @@
+//! Track C2 — bridge keychain abstraction.
+//!
+//! `Keychain` is the put/get trait the Telegram (and future) bridge setup
+//! flow uses to stash provider secrets such as bot tokens. `SystemKeychain`
+//! delegates to the OS-native secret store via the `keyring` crate (macOS
+//! Keychain, Windows Credential Manager, Linux Secret Service / dbus).
+//! `MockKeychain` is an in-memory `HashMap` used by the integration tests so
+//! CI never has to touch a real keychain backend.
+//!
+//! The account-name convention is `{bridge_id}/{KEY}` (e.g.
+//! `tg-bridge-1/telegram_bot_token`); the service is fixed to `mur-agent` to
+//! line up with `mur agent secret` and the runtime's lookup behaviour.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Abstract put/get for an OS-keychain-backed secret store. Implemented by
+/// `SystemKeychain` (real backend) and `MockKeychain` (test double).
+pub trait Keychain: Send + Sync {
+    fn put(&self, account: &str, secret: &str) -> anyhow::Result<()>;
+    fn get(&self, account: &str) -> anyhow::Result<String>;
+}
+
+/// Real OS-keychain-backed implementation. Service is fixed to `mur-agent`.
+pub struct SystemKeychain;
+
+impl Keychain for SystemKeychain {
+    fn put(&self, account: &str, secret: &str) -> anyhow::Result<()> {
+        let entry = keyring::Entry::new("mur-agent", account)?;
+        entry.set_password(secret)?;
+        Ok(())
+    }
+    fn get(&self, account: &str) -> anyhow::Result<String> {
+        let entry = keyring::Entry::new("mur-agent", account)?;
+        Ok(entry.get_password()?)
+    }
+}
+
+/// In-memory `Keychain` test double. Deterministic and CI-safe; use this in
+/// integration tests via `MUR_TELEGRAM_KEYCHAIN_BACKEND=mock`.
+#[derive(Default)]
+pub struct MockKeychain {
+    inner: Mutex<HashMap<String, String>>,
+}
+
+impl Keychain for MockKeychain {
+    fn put(&self, account: &str, secret: &str) -> anyhow::Result<()> {
+        self.inner
+            .lock()
+            .unwrap()
+            .insert(account.into(), secret.into());
+        Ok(())
+    }
+    fn get(&self, account: &str) -> anyhow::Result<String> {
+        self.inner
+            .lock()
+            .unwrap()
+            .get(account)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("keychain: no entry for {}", account))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_keychain_round_trip() {
+        let kc = MockKeychain::default();
+        kc.put("agent-1/telegram_bot_token", "secret-token").unwrap();
+        assert_eq!(
+            kc.get("agent-1/telegram_bot_token").unwrap(),
+            "secret-token"
+        );
+    }
+
+    #[test]
+    fn mock_keychain_missing_errors() {
+        let kc = MockKeychain::default();
+        assert!(kc.get("nope").is_err());
+    }
+}

--- a/mur-core/src/cmd/agent_companion.rs
+++ b/mur-core/src/cmd/agent_companion.rs
@@ -61,12 +61,32 @@ pub enum ConnectorAction {
     Add {
         /// Bridge agent name (distinct from any user agent).
         name: String,
-        /// Platform — only "stub" is supported in C1.
+        /// Platform — "stub" (C1) or "telegram" (C2).
         #[arg(long, default_value = "stub")]
         platform: String,
         /// Recipient agent for the default route. Required.
         #[arg(long)]
         default_route: String,
+        /// (Telegram) Bot token from BotFather. Triggers the non-interactive
+        /// path when provided alongside `--bot-username`, `--chat-id`, and
+        /// `--ack`. Otherwise the interactive 5-step BotFather flow runs.
+        #[arg(long)]
+        bot_token: Option<String>,
+        /// (Telegram) Public bot username (without leading `@`).
+        #[arg(long)]
+        bot_username: Option<String>,
+        /// (Telegram) Primary chat ID for DMs.
+        #[arg(long)]
+        chat_id: Option<i64>,
+        /// (Telegram) Acknowledge the E2E disclosure non-interactively. Must
+        /// be set alongside the other `--bot-*` flags for the non-interactive
+        /// path; without it the scaffold refuses to write any state.
+        #[arg(long)]
+        ack: bool,
+        /// (Telegram) Group chat IDs to allow alongside the primary DM. When
+        /// non-empty the resulting profile has `privacy_mode: allow_groups`.
+        #[arg(long, value_delimiter = ',')]
+        allow_group: Vec<i64>,
     },
 }
 
@@ -93,7 +113,24 @@ pub async fn run(args: CompanionArgs) -> anyhow::Result<()> {
                 name,
                 platform,
                 default_route,
-            } => connector::add(name, &platform, &default_route).await,
+                bot_token,
+                bot_username,
+                chat_id,
+                ack,
+                allow_group,
+            } => {
+                connector::add(
+                    name,
+                    &platform,
+                    &default_route,
+                    bot_token,
+                    bot_username,
+                    chat_id,
+                    ack,
+                    allow_group,
+                )
+                .await
+            }
         },
     }
 }

--- a/mur-core/src/cmd/agent_companion/connector.rs
+++ b/mur-core/src/cmd/agent_companion/connector.rs
@@ -1,30 +1,46 @@
-//! `mur agent companion connector ...` — bridge agent scaffolding (Track C1).
+//! `mur agent companion connector ...` — bridge agent scaffolding.
 //!
-//! In Track C1 only `--platform stub` is supported. The stub is a fully
-//! functional A2A bridge agent (LLM disabled, identity keypair, default
-//! route) that downstream tracks (C2 Telegram, C3 send-from-any-app)
-//! specialise.
+//! Track C1 introduced `--platform stub` (a fully functional A2A bridge with
+//! LLM disabled). Track C2 wires `--platform telegram`: the BotFather 5-step
+//! setup UX (M-c2.1) plus a non-interactive flag path used by the integration
+//! tests and CI.
 
 use anyhow::{Context, Result, bail};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use mur_common::bridge::{PrivacyMode, TelegramConfig};
+
+use crate::bridge_keychain::{Keychain, MockKeychain, SystemKeychain};
 
 /// Scaffold a new bridge agent.
 ///
 /// Track C1 supports `--platform stub`. Track C2 wires `--platform telegram`
-/// as a recognised platform; the BotFather setup UX itself lands in M-c2.1,
-/// so for now the telegram arm returns a typed "not yet wired" error. Other
-/// platform names continue to error out as unsupported.
-pub async fn add(name: String, platform: &str, default_route: &str) -> Result<()> {
+/// with both the interactive 5-step BotFather flow (DEFAULT, when no
+/// `--bot-token` is given) and a non-interactive flag path used by tests and
+/// CI: `--bot-token`, `--bot-username`, `--chat-id`, `--ack`.
+#[allow(clippy::too_many_arguments)]
+pub async fn add(
+    name: String,
+    platform: &str,
+    default_route: &str,
+    bot_token: Option<String>,
+    bot_username: Option<String>,
+    chat_id: Option<i64>,
+    ack: bool,
+    allow_groups: Vec<i64>,
+) -> Result<()> {
     if default_route.trim().is_empty() {
         bail!("--default-route must be non-empty");
     }
     match platform {
         "stub" => scaffold_stub_bridge(&name, default_route).await,
         "telegram" => {
-            bail!(
-                "BotFather setup not yet wired (M-c2.1). The Telegram bridge arm is \
-                 reserved on main to lock in the schema; the 5-step BotFather \
-                 nonce-pairing UX lands in milestone M-c2.1."
-            )
+            // First scaffold the underlying stub bridge directory (identity,
+            // profile.yaml, routes.yaml, sys_prompt.md). The Telegram-specific
+            // `telegram.yaml` is then written alongside.
+            scaffold_stub_bridge(&name, default_route).await?;
+            run_telegram_setup(&name, bot_token, bot_username, chat_id, ack, allow_groups).await
         }
         other => bail!(
             "platform '{other}' not supported in Track C1/C2 — recognised: 'stub', 'telegram'. \
@@ -32,6 +48,244 @@ pub async fn add(name: String, platform: &str, default_route: &str) -> Result<()
         ),
     }
 }
+
+/// Telegram setup driver. Picks between the non-interactive flag path
+/// (full `--bot-token` + `--bot-username` + `--chat-id` + `--ack`) and the
+/// interactive 5-step BotFather flow.
+async fn run_telegram_setup(
+    bridge_id: &str,
+    bot_token: Option<String>,
+    bot_username: Option<String>,
+    chat_id: Option<i64>,
+    ack: bool,
+    allow_groups: Vec<i64>,
+) -> Result<()> {
+    let kc: Box<dyn Keychain> = if std::env::var("MUR_TELEGRAM_KEYCHAIN_BACKEND")
+        .ok()
+        .as_deref()
+        == Some("mock")
+    {
+        Box::new(MockKeychain::default())
+    } else {
+        Box::new(SystemKeychain)
+    };
+
+    // Non-interactive path — all flags supplied.
+    if let (Some(token), Some(username), Some(cid)) =
+        (bot_token.as_deref(), bot_username.as_deref(), chat_id)
+    {
+        let args = ScaffoldArgs {
+            bridge_id: bridge_id.into(),
+            bot_token: token.into(),
+            bot_username: username.into(),
+            chat_id: cid,
+            ack,
+            allow_groups,
+        };
+        let outcome = scaffold_telegram_bridge(args, kc.as_ref())?;
+        let ScaffoldOutcome::Ok { profile_path, .. } = outcome;
+        println!(
+            "telegram bridge scaffolded; config: {}",
+            profile_path.display()
+        );
+        return Ok(());
+    }
+
+    // Interactive path — drive BotFather 5-step UX. We only run this when at
+    // least one of the non-interactive flags is missing. On a non-tty test
+    // harness `dialoguer::Input` will fail with an io error which propagates
+    // up — that's why the integration test for the no-flags branch only
+    // asserts non-zero exit, not specific output.
+    interactive_botfather_flow(bridge_id, kc.as_ref(), allow_groups).await
+}
+
+/// Five-step BotFather UX (Spec §M-c2.1):
+///   1. Print BotFather URL + prompt for bot token.
+///   2. Read token from stdin → write to keychain.
+///   3. Generate nonce, print `t.me/<bot_username>?start=<nonce>`.
+///   4. Wait for `/start <nonce>` from user's Telegram (30s timeout).
+///   5. Write `telegram.yaml` + show E2E disclosure (typed-confirm).
+///
+/// Step 4 in M-c2.1 uses a stub: we do not poll Telegram getUpdates yet
+/// (that lands in M-c2.2). Instead we prompt the user for the chat_id they
+/// see logged on their side after sending `/start <nonce>`. The real polling
+/// loop replaces this prompt in M-c2.2.
+async fn interactive_botfather_flow(
+    bridge_id: &str,
+    kc: &dyn Keychain,
+    allow_groups: Vec<i64>,
+) -> Result<()> {
+    use dialoguer::Input;
+
+    // Step 1: BotFather URL + token prompt.
+    println!(
+        "Step 1/5 — open BotFather and create a new bot:\n  https://t.me/BotFather\n\
+         Send /newbot and follow the prompts. When you receive your bot token, paste it below."
+    );
+    let bot_token: String = Input::new()
+        .with_prompt("Bot token")
+        .interact_text()
+        .context("read bot token")?;
+
+    // Step 2: persist token to keychain.
+    let account = format!("{bridge_id}/telegram_bot_token");
+    kc.put(&account, bot_token.trim())
+        .context("write bot token to keychain")?;
+    println!("Step 2/5 — token stored in keychain ({account}).");
+
+    // Step 3: generate nonce + print pairing URL.
+    let bot_username: String = Input::new()
+        .with_prompt("Bot username (without leading @)")
+        .interact_text()
+        .context("read bot username")?;
+    let nonce = generate_nonce();
+    println!(
+        "Step 3/5 — open this URL on the device with the user account that should pair with the bot:\n  \
+         https://t.me/{bot_username}?start={nonce}"
+    );
+
+    // Step 4: wait for /start <nonce>. M-c2.1 stub: prompt for chat_id rather
+    // than polling getUpdates. The real polling lands in M-c2.2.
+    println!(
+        "Step 4/5 — waiting up to 30s for the chat_id to be supplied (M-c2.1 stub: paste the chat_id manually for now)."
+    );
+    let chat_id_str: String = tokio::time::timeout(
+        Duration::from_secs(30),
+        tokio::task::spawn_blocking(|| {
+            Input::<String>::new()
+                .with_prompt("chat_id (numeric, from your /start <nonce> message)")
+                .interact_text()
+        }),
+    )
+    .await
+    .context("timed out waiting for /start <nonce> reply (30s)")?
+    .context("blocking-thread join failed")?
+    .context("read chat_id")?;
+    let chat_id: i64 = chat_id_str
+        .trim()
+        .parse()
+        .context("chat_id must be an integer")?;
+
+    // Step 5: E2E disclosure + final scaffold.
+    println!("Step 5/5 — Telegram E2E disclosure:\n{E2E_DISCLOSURE_TEXT}");
+    let typed: String = Input::new()
+        .with_prompt("Type 'I understand' to proceed")
+        .interact_text()
+        .context("read E2E disclosure ack")?;
+    if !confirm_e2e_disclosure(typed.trim_end_matches('\n')) {
+        bail!("telegram bridge requires E2E disclosure ack");
+    }
+
+    let outcome = scaffold_telegram_bridge(
+        ScaffoldArgs {
+            bridge_id: bridge_id.into(),
+            bot_token: bot_token.trim().into(),
+            bot_username,
+            chat_id,
+            ack: true,
+            allow_groups,
+        },
+        kc,
+    )?;
+    let ScaffoldOutcome::Ok { profile_path, .. } = outcome;
+    println!(
+        "telegram bridge scaffolded; config: {}",
+        profile_path.display()
+    );
+    Ok(())
+}
+
+fn generate_nonce() -> String {
+    use rand::Rng;
+    use rand::distributions::Alphanumeric;
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(16)
+        .map(char::from)
+        .collect()
+}
+
+/// Inputs to `scaffold_telegram_bridge`. Constructed by both the interactive
+/// CLI flow and the non-interactive flag path; the integration tests build
+/// these directly.
+pub struct ScaffoldArgs {
+    pub bridge_id: String,
+    pub bot_token: String,
+    pub bot_username: String,
+    pub chat_id: i64,
+    pub ack: bool,
+    pub allow_groups: Vec<i64>,
+}
+
+/// Outcome from `scaffold_telegram_bridge`. Currently a single `Ok` variant —
+/// the enum shape exists so future scaffold modes (rekey, repair) can extend
+/// it without breaking call sites.
+///
+/// `config` is exposed for tests / callers that want to inspect the resulting
+/// `TelegramConfig` without re-reading the YAML; the bin target's CLI flow
+/// only uses `profile_path`, hence the allow.
+pub enum ScaffoldOutcome {
+    Ok {
+        #[allow(dead_code)]
+        config: TelegramConfig,
+        profile_path: PathBuf,
+    },
+}
+
+/// Library-level entry point for Telegram bridge scaffolding. Persists the bot
+/// token to `kc` (the keychain), writes `telegram.yaml` under
+/// `$MUR_HOME/agents/<bridge_id>/`, and returns the resolved `TelegramConfig`.
+///
+/// Hard-gated on `args.ack == true` (M-c2.1.3) — refuses to write anything
+/// without an explicit E2E disclosure ack.
+pub fn scaffold_telegram_bridge(args: ScaffoldArgs, kc: &dyn Keychain) -> Result<ScaffoldOutcome> {
+    if !args.ack {
+        bail!("telegram bridge requires E2E disclosure ack");
+    }
+    let account = format!("{}/telegram_bot_token", args.bridge_id);
+    kc.put(&account, &args.bot_token)
+        .context("write bot token to keychain")?;
+    let cfg = TelegramConfig {
+        bot_username: args.bot_username,
+        bot_token_keychain_account: account,
+        chat_id: args.chat_id,
+        privacy_mode: if args.allow_groups.is_empty() {
+            PrivacyMode::DmOnly
+        } else {
+            PrivacyMode::AllowGroups
+        },
+        allow_groups: args.allow_groups,
+        e2e_disclosure_acked_at: Some(chrono::Utc::now()),
+    };
+    let profile_path = write_bridge_profile(&args.bridge_id, &cfg)?;
+    Ok(ScaffoldOutcome::Ok {
+        config: cfg,
+        profile_path,
+    })
+}
+
+fn write_bridge_profile(bridge_id: &str, cfg: &TelegramConfig) -> Result<PathBuf> {
+    let dir = crate::paths::mur_root(None).join("agents").join(bridge_id);
+    std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+    let path = dir.join("telegram.yaml");
+    std::fs::write(&path, serde_yaml_ng::to_string(cfg)?)
+        .with_context(|| format!("write {}", path.display()))?;
+    Ok(path)
+}
+
+/// Literal-match gate for the Telegram E2E disclosure (M-c2.1.3). The user
+/// must type the string `I understand` — case- and whitespace-sensitive.
+pub fn confirm_e2e_disclosure(input: &str) -> bool {
+    input == "I understand"
+}
+
+/// Disclosure text shown to the user before the literal-match prompt. Kept as
+/// a module constant so doc and CLI surfaces share the same wording.
+pub const E2E_DISCLOSURE_TEXT: &str = "\
+Telegram chats are NOT end-to-end encrypted unless using Secret Chats. \
+Bot messages traverse Telegram's servers in plaintext. \
+The bot token has full read/send access to messages addressed to the bot. \
+Type exactly 'I understand' to proceed.";
 
 /// Build a fresh stub-bridge agent directory under `$MUR_HOME/agents/<name>/`
 /// containing `profile.yaml`, `routes.yaml`, `identity.{key,pub}`, and a
@@ -51,7 +305,6 @@ pub(crate) async fn scaffold_stub_bridge(name: &str, default_route: &str) -> Res
     use mur_common::bridge::routes::BridgeRouteConfig;
     use mur_common::identity::AgentIdentity;
     use mur_common::{AgentProfile, LlmEntitlement, LlmMode};
-    use std::path::PathBuf;
 
     mur_common::validate_agent_name(name)
         .with_context(|| format!("invalid bridge agent name {name:?}"))?;

--- a/mur-core/src/lib.rs
+++ b/mur-core/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod agent_admin;
 pub mod auth;
+pub mod bridge_keychain;
 pub mod capture;
 pub mod character_card;
 // `cmd` is shared with the binary (`main.rs`). When compiled as part of the

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -3,6 +3,7 @@ use clap::{CommandFactory, Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 
 mod auth;
+mod bridge_keychain;
 mod capture;
 // `--format card` is a D4 milestone; M2.7 only ships the schema + helper
 // (callable from the library), so the bin target sees the types as unused.

--- a/mur-core/tests/c2_setup_flow.rs
+++ b/mur-core/tests/c2_setup_flow.rs
@@ -1,9 +1,19 @@
-//! Track C2 / M-c2.0.2: `mur agent companion connector add --platform telegram`
-//! integration test.
+//! Track C2 — `mur agent companion connector add --platform telegram`
+//! integration tests.
 //!
-//! M-c2.0 only locks in the schema and CLI plumbing; the BotFather setup UX
-//! itself lands in M-c2.1. The arm must therefore exit non-zero with a typed
-//! error message that downstream tracking can grep for.
+//! Coverage:
+//!  * M-c2.0.2 (legacy): the telegram arm without flags returns a typed error
+//!    pointing to M-c2.1 (still relevant — the interactive 5-step UX is
+//!    unchanged from M-c2.1.2 and we don't want to introduce a stdin-script
+//!    test for it here).
+//!  * M-c2.1.2: `scaffold_telegram_bridge` writes the bot token to the keychain
+//!    and produces a `TelegramConfig` with the expected fields.
+//!  * M-c2.1.3: `confirm_e2e_disclosure` requires the literal "I understand"
+//!    string — case- and whitespace-sensitive.
+//!  * M-c2.1.4: the CLI exposes the non-interactive flags
+//!    (`--bot-token`, `--bot-username`, `--chat-id`, `--ack`) and writes
+//!    `agents/<name>/telegram.yaml` under `MUR_HOME` when invoked with
+//!    `MUR_TELEGRAM_KEYCHAIN_BACKEND=mock`.
 //!
 //! Windows: gated for parity with `connector_add_stub.rs`.
 #![cfg(unix)]
@@ -11,8 +21,17 @@
 use std::process::Command;
 use tempfile::TempDir;
 
+use mur_core::bridge_keychain::{Keychain, MockKeychain};
+use mur_core::cmd::agent_companion::connector::{
+    ScaffoldArgs, ScaffoldOutcome, confirm_e2e_disclosure, scaffold_telegram_bridge,
+};
+
 #[test]
-fn telegram_arm_returns_typed_error_pre_m_c2_1() {
+fn telegram_arm_without_flags_returns_typed_error() {
+    // Without --bot-token / --bot-username / --chat-id / --ack the CLI falls
+    // back to the interactive flow, which on a non-tty test harness errors out
+    // with a deterministic message we can grep for. The exact wording is not
+    // load-bearing — the assertion is just that we exit non-zero.
     let tmp = TempDir::new().unwrap();
     let mur_home = tmp.path().join(".mur");
     std::fs::create_dir_all(&mur_home).unwrap();
@@ -30,18 +49,115 @@ fn telegram_arm_returns_typed_error_pre_m_c2_1() {
             "coach",
         ])
         .env("MUR_HOME", &mur_home)
+        .env("MUR_TELEGRAM_KEYCHAIN_BACKEND", "mock")
         .output()
         .unwrap();
 
     assert!(
         !out.status.success(),
-        "expected non-zero exit (M-c2.0.2 stub): stdout={} stderr={}",
+        "expected non-zero exit when interactive flags are missing: stdout={} stderr={}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr),
     );
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        stderr.contains("BotFather setup not yet wired"),
-        "stderr={stderr}"
+}
+
+#[test]
+fn scaffold_writes_keychain_and_yaml_with_token_and_nonce() {
+    let tmp = TempDir::new().unwrap();
+    // SAFETY: tests in this binary are serial w.r.t. each other on the same
+    // process, but other test binaries may run in parallel. MUR_HOME is read
+    // inside `scaffold_telegram_bridge` via `paths::mur_root(None)` so we set
+    // it for this test scope only.
+    unsafe { std::env::set_var("MUR_HOME", tmp.path()) };
+
+    let kc = MockKeychain::default();
+    let args = ScaffoldArgs {
+        bridge_id: "tg-bridge".into(),
+        bot_token: "1234:token".into(),
+        bot_username: "MyAgentBot".into(),
+        chat_id: 100,
+        ack: true,
+        allow_groups: vec![],
+    };
+    let outcome = scaffold_telegram_bridge(args, &kc).unwrap();
+    let ScaffoldOutcome::Ok {
+        config,
+        profile_path,
+    } = outcome;
+    assert_eq!(config.bot_username, "MyAgentBot");
+    assert_eq!(config.chat_id, 100);
+    assert!(config.e2e_disclosure_acked_at.is_some());
+    assert_eq!(
+        kc.get("tg-bridge/telegram_bot_token").unwrap(),
+        "1234:token"
     );
+    assert!(profile_path.exists(), "telegram.yaml not written");
+    assert!(profile_path.ends_with("agents/tg-bridge/telegram.yaml"));
+
+    unsafe { std::env::remove_var("MUR_HOME") };
+}
+
+#[test]
+fn scaffold_rejects_unacked() {
+    let kc = MockKeychain::default();
+    let args = ScaffoldArgs {
+        bridge_id: "tg2".into(),
+        bot_token: "x".into(),
+        bot_username: "B".into(),
+        chat_id: 1,
+        ack: false,
+        allow_groups: vec![],
+    };
+    let r = scaffold_telegram_bridge(args, &kc);
+    let err = match r {
+        Ok(_) => panic!("expected error when ack=false"),
+        Err(e) => e,
+    };
+    let msg = format!("{err}");
+    assert!(msg.contains("E2E disclosure"), "msg={msg}");
+}
+
+#[test]
+fn ack_text_must_match_literal() {
+    assert!(confirm_e2e_disclosure("I understand"));
+    assert!(!confirm_e2e_disclosure("yes"));
+    assert!(!confirm_e2e_disclosure("i understand"));
+    assert!(!confirm_e2e_disclosure(""));
+    // Whitespace must not be trimmed silently — the user has to type the
+    // exact literal.
+    assert!(!confirm_e2e_disclosure(" I understand "));
+}
+
+#[test]
+fn cli_scaffold_via_stdin_script() {
+    let tmp = TempDir::new().unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_mur"))
+        .env("MUR_HOME", tmp.path())
+        .env("MUR_TELEGRAM_KEYCHAIN_BACKEND", "mock")
+        .args([
+            "agent",
+            "companion",
+            "connector",
+            "add",
+            "tg",
+            "--platform",
+            "telegram",
+            "--default-route",
+            "coach",
+            "--bot-token",
+            "1234:abc",
+            "--bot-username",
+            "MyAgentBot",
+            "--chat-id",
+            "100",
+            "--ack",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(tmp.path().join("agents/tg/telegram.yaml").exists());
 }


### PR DESCRIPTION
## Summary

Track C2 / M-c2.1 — wires the `mur agent companion connector add --platform telegram` flow end-to-end. The arm previously errored out with a typed M-c2.1 placeholder; this PR replaces it with the real 5-step BotFather UX plus a non-interactive flag path used by tests and CI.

### Tasks

- **M-c2.1.1** — `bridge_keychain` module: `Keychain` trait, `SystemKeychain` (real `keyring` v3 backend), `MockKeychain` (in-memory test double). Account format `{bridge_id}/telegram_bot_token`, service `mur-agent`. Two unit tests.
- **M-c2.1.2** — `scaffold_telegram_bridge(args, kc)` + `run_telegram_setup` driver. Persists the bot token to the keychain abstraction and writes `agents/<bridge_id>/telegram.yaml`. Backed by 5 integration tests.
- **M-c2.1.3** — `confirm_e2e_disclosure(s)` literal-match gate (`s == "I understand"`, case- and whitespace-sensitive) + `E2E_DISCLOSURE_TEXT` constant for shared CLI/doc surfaces. Hard-gates `scaffold_telegram_bridge` (refuses to write any state when `args.ack == false`).
- **M-c2.1.4** — CLI flags: `--bot-token`, `--bot-username`, `--chat-id`, `--ack`, `--allow-group`. `MUR_TELEGRAM_KEYCHAIN_BACKEND=mock` switches the backend to `MockKeychain` for deterministic CI runs. Integration test `cli_scaffold_via_stdin_script` invokes the cargo bin end-to-end and asserts `telegram.yaml` lands under `MUR_HOME`.

### Step-4 stub note

Step 4 of the BotFather flow (`/start <nonce>` echo) is implemented as a 30s `tokio::time::timeout(spawn_blocking(Input::interact_text))` that prompts the operator for the chat_id rather than polling Telegram getUpdates. The polling loop replaces this prompt in **M-c2.2** (next milestone). The 30s timeout + spawn_blocking shape match the eventual real-loop shape so M-c2.2 only swaps the inner closure.

## Test plan

- [x] `cargo test -p mur-core --lib bridge_keychain` (2/2 pass)
- [x] `cargo test -p mur-core --test c2_setup_flow` (5/5 pass)
- [x] `cargo test -p mur-core --test connector_add_stub` (3/3 still pass — stub flow unchanged)
- [x] `cargo clippy -p mur-core --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

The pre-existing `clippy::field_reassign_with_default` warning in `mur-common/tests/companion_enums.rs` is on the base branch and is unrelated to this milestone.

## Watch-outs

- The interactive flow uses `dialoguer::Input` which fails on non-tty; the `telegram_arm_without_flags_returns_typed_error` test covers this path and asserts non-zero exit only (the exact error wording is not load-bearing).
- `Keychain::get` and `ScaffoldOutcome::Ok::config` carry `#[allow(dead_code)]` because the bin target's CLI flow only uses `put` / `profile_path`; M-c2.2 wires both into the runtime poller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)