### PR TITLE
release: v2.5.0 — Desktop Companion + Cloud Backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,100 @@
 # Changelog
 
+## v2.5.0 (2026-05-04) — Desktop Companion + Cloud Backends
+
+### TL;DR by use case
+
+**You use mur as a CLI / session-capture tool:**
+→ `mur learn`, `mur extract`, `mur conversations` now support
+Anthropic / OpenAI / OpenRouter / Together / Fireworks / Gemini via
+`~/.mur/config.yaml` `llm.provider`. New `mur conversations cost-report
+--since 7d` shows per-stage USD spend. Apple Silicon users: `mur init`
+auto-detects oMLX.app / mlx-lm CLI, prefers them over Ollama. Fixes a
+silent regression where local Ollama returned empty strings for
+`mur learn extract --llm`.
+
+**You want to try the Agent / Companion subsystem:**
+→ GUI shipped: drag-drop multimodal (HEIC/PDF/OCR), character card
+import (SillyTavern + Character.AI), desktop notifications, 5-step
+onboarding wizard. `mur agent export --format gui` produces a notarized
+.app. Runtime now sandboxed with 11 safety rules.
+
+### 🆕 New — CLI / Session Capture
+
+- **6 cloud LLM providers** — Anthropic / OpenAI / OpenRouter / Together
+  / Fireworks / Gemini, all routed through unified `ChatBackend`;
+  existing Ollama users unaffected
+- **`mur conversations cost-report`** — new command; aggregates per-stage
+  (extractive / abstractive / rollup / extract_llm / learn / starter)
+  USD estimates; `--json` for scripting
+- **MLX local detection** — `mur init` auto-detects oMLX.app (port 8000)
+  and mlx-lm CLI (port 8080) on Apple Silicon; priority oMLX > mlx-lm >
+  Ollama
+- **Anthropic prompt caching wire** — `cache_system` / `cache_user_prefix`
+  hints land on the wire; activates when prompts grow past Haiku's
+  2048-token cacheable minimum
+
+### 🆕 New — Desktop Companion
+
+- **Onboarding Wizard (D2)** — 5-step first-launch (CLI and GUI dual
+  channel) builds first_memory + persona + proactive tier
+- **Drag-Drop Multimodal (D3)** — sandboxed decoder
+  (HEIC / PDF / Vision-OCR), ProvenanceLedger records asset origin, B0
+  multimodal safety rules 13-22
+- **Character Card I/O (D4)** — full CCv3 schema, Ed25519 sign/verify,
+  SillyTavern PNG (chara + ccv3 chunks) bidirectional, Character.AI
+  scraped JSON normalizer, `mur agent card export/accept` CLI, inbox
+  quarantine
+- **GUI Inbox Bridge (D5)** — notify-based watcher → Tauri
+  `Channel<BridgeEvent>` → React sidebar + desktop notification + dock
+  badge + why-accordion + quiet/proactive toggles + ack buttons
+  (good / bad / dismiss)
+
+### 🛡️ Hardening
+
+- **macOS** — PrivacyInfo.xcprivacy (4 NSPrivacyAccessedAPICategory
+  entries), `xcrun notarytool submit --wait`, `xcrun stapler staple`,
+  `spctl --assess --type execute`, CI grep gate against non-compliant
+  API usage
+- **Runtime sandbox (B0 text-mode, 11 rules)** — fs confinement, network
+  allowlist + GrantStore, tool-result history spotlight, spawn deny,
+  outbound secret prefilter, memory redaction, MCP binary signature
+  check
+
+### 🐛 Bug Fixes
+
+- **Ollama silent regression** — `num_predict: 0` was sent literally and
+  Ollama interpreted it as "produce 0 tokens", causing
+  `mur learn extract --llm` to return empty strings and silently fall
+  through to logic-only extraction. Fixed: sentinel 0 → `num_predict:
+  None` (matches pre-P4 behavior)
+- **Anthropic OAuth transport leak** — OAuth handling decoupled from
+  public transport surface (#79)
+
+### ⬆️ Upgrade Notes
+
+- **Config schema:** compatible — existing `~/.mur/config.yaml` needs no
+  changes; all new fields are `#[serde(default)]`
+- **Vector index:** no reindex needed — store schema unchanged
+- **Brew users:** `brew update && brew upgrade mur`
+- **Source build:** Rust 1.82+ (unchanged from v2.4.1)
+
+### 📦 Internal / Foundations
+
+- **Cloud-LLM rollout (P0–P4)** — deleted `mur-core/src/llm.rs`
+  (524 LOC); all LLM calls now flow through
+  `conversations::backend::ChatBackend` trait; ~−700 LOC net delete
+- **Track C1 (A2A bridge foundations)** — `LlmEntitlement`,
+  `BridgeRouteConfig`, `SignedEnvelope` + `TrustedPeer` verify,
+  sled-backed `DedupeStore` (7d TTL), `AckTracker`, `BridgeBeacon`
+  degraded surface have landed; full agent-to-agent message bridge
+  (Telegram, send-from-any-app) planned for v2.6
+- **Stats:** 98 commits / 24 PRs since v2.4.1
+
+### 🙏 Thanks
+
+(no external contributors this cycle — internal-only release)
+
 ## v2.2.0 (2026-03-25)
 
 ### 🚀 New Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.4.1"
+version = "2.5.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/docs/plans/2026-05-04-v2.5.0-release-design.md
+++ b/docs/plans/2026-05-04-v2.5.0-release-design.md
@@ -1,0 +1,175 @@
+# v2.5.0 Release Design — "Desktop Companion + Cloud Backends"
+
+**Date:** 2026-05-04
+**Tag target:** `v2.5.0`
+**Previous:** `v2.4.1`
+**Commits since v2.4.1:** 98
+
+## Decision rationale
+
+### Why v2.5.0 (not v2.4.2)
+
+SemVer minor bump triggered by:
+
+- New user-facing CLI commands: `mur conversations cost-report`,
+  `mur agent card export/accept`, `mur agent companion connector add`
+- New supported `~/.mur/config.yaml` `llm.provider` values:
+  `openai`, `gemini`, `openrouter` (v2.4.1 errors on these)
+- GUI shipped from nothing to production-ready
+  (`mur agent export --format gui` now produces a notarized macOS .app)
+- 11 new runtime sandbox rules (B0 text-mode) that change agent
+  behavior (fs/network enforcement)
+
+Patch (v2.4.2) would imply "mostly bug fixes". This release is
+primarily new functionality, so minor bump is name-and-shame correct.
+
+### Why split TL;DR by use case
+
+mur in v2.4.x had two distinct user populations:
+
+- **CLI / session-capture users** — historical brew tap audience;
+  use `mur learn`, `mur extract`, `mur conversations`, hooks/workflows
+- **Agent / companion users** — newer; opted in via `mur agent create`
+  + GUI export
+
+A single tagline ("Desktop Companion") would alienate group 1.
+Two-paragraph TL;DR lets each group find their lede.
+
+## Scope
+
+### In (release notes)
+
+- D2 onboarding wizard (CLI + GUI dual-channel)
+- D3 drag-drop multimodal (HEIC/PDF/OCR + B0 multimodal rules 13-22)
+- D4 character card I/O (CCv3 + Ed25519 + SillyTavern + Character.AI)
+- D5 companion → GUI bridge (notify watcher + Tauri channel + React sidebar)
+- macOS hardening (PrivacyInfo + notarize + staple + spctl + CI gate)
+- B0 text-mode safety rules (11 runtime sandbox rules)
+- Cloud-LLM rollout P0-P4 (6 providers + cost-report + caching wire)
+- MLX local detection on Apple Silicon
+- Bug fixes (Ollama `num_predict: 0`, Anthropic OAuth transport leak)
+
+### Out (deferred to v2.6)
+
+- Track C1 (A2A bridge foundations) — complete but deferred to v2.6
+  with C2/C3 for one cohesive "agent network" release. Mentioned in
+  Internal section so users grep'ing for `SignedEnvelope` find context.
+- Track C2 (Telegram bridge) — 2/8 milestones done as of cut date,
+  in active progress
+- Track C3 (send-from-any-app) — plan-only, not started
+
+## Release process
+
+1. `docs/plans/2026-05-04-v2.5.0-release-design.md` — this file (commit
+   on `release/v2.5.0` branch)
+2. `CHANGELOG.md` — prepend v2.5.0 section per template below
+3. `Cargo.toml` (workspace) — version `2.4.1` → `2.5.0`
+4. `cargo build --release --workspace` — verify clean
+5. PR → main, wait for 8/8 CI green, squash-merge
+6. Tag: `git tag -a v2.5.0 -m "Desktop Companion + Cloud Backends"`
+7. Push tag: `git push origin v2.5.0`
+8. **Manual step:** Update Homebrew tap (`mur-run/homebrew-tap`):
+   - sha256: `curl -sL https://github.com/mur-run/mur/archive/refs/tags/v2.5.0.tar.gz | shasum -a 256`
+   - Edit `Formula/mur.rb` url + sha256, commit, push
+9. Verify: `brew update && brew upgrade mur`
+
+## Release notes template
+
+(copied to `CHANGELOG.md` at step 2)
+
+```markdown
+## v2.5.0 (2026-05-04) — Desktop Companion + Cloud Backends
+
+### TL;DR by use case
+
+**You use mur as a CLI / session-capture tool:**
+→ `mur learn`, `mur extract`, `mur conversations` now support
+  Anthropic / OpenAI / OpenRouter / Together / Fireworks / Gemini
+  via `~/.mur/config.yaml` `llm.provider`. New `mur conversations
+  cost-report --since 7d` shows per-stage USD spend. Apple Silicon
+  users: `mur init` auto-detects oMLX.app / mlx-lm CLI, prefers them
+  over Ollama. Fixes a silent regression where local Ollama returned
+  empty strings for `mur learn extract --llm`.
+
+**You want to try the Agent / Companion subsystem:**
+→ GUI shipped: drag-drop multimodal (HEIC/PDF/OCR), character card
+  import (SillyTavern + Character.AI), desktop notifications, 5-step
+  onboarding wizard. `mur agent export --format gui` produces a
+  notarized .app. Runtime now sandboxed with 11 safety rules.
+
+### 🆕 New — CLI / Session Capture
+
+- **6 cloud LLM providers** — Anthropic / OpenAI / OpenRouter /
+  Together / Fireworks / Gemini, all routed through unified
+  `ChatBackend`; existing Ollama users unaffected
+- **`mur conversations cost-report`** — new command; aggregates
+  per-stage (extractive / abstractive / rollup / extract_llm /
+  learn / starter) USD estimates; `--json` for scripting
+- **MLX local detection** — `mur init` auto-detects oMLX.app
+  (port 8000) and mlx-lm CLI (port 8080) on Apple Silicon;
+  priority oMLX > mlx-lm > Ollama
+- **Anthropic prompt caching wire** — `cache_system` /
+  `cache_user_prefix` hints land on the wire; activates when
+  prompts grow past Haiku's 2048-token cacheable minimum
+
+### 🆕 New — Desktop Companion
+
+- **Onboarding Wizard (D2)** — 5-step first-launch (CLI and GUI
+  dual-channel) builds first_memory + persona + proactive tier
+- **Drag-Drop Multimodal (D3)** — sandboxed decoder
+  (HEIC / PDF / Vision-OCR), ProvenanceLedger records asset origin,
+  B0 multimodal safety rules 13-22
+- **Character Card I/O (D4)** — full CCv3 schema, Ed25519
+  sign/verify, SillyTavern PNG (chara + ccv3 chunks) bidirectional,
+  Character.AI scraped JSON normalizer, `mur agent card export/accept`
+  CLI, inbox quarantine
+- **GUI Inbox Bridge (D5)** — notify-based watcher → Tauri
+  `Channel<BridgeEvent>` → React sidebar + desktop notification +
+  dock badge + why-accordion + quiet/proactive toggles +
+  ack buttons (good/bad/dismiss)
+
+### 🛡️ Hardening
+
+- **macOS** — PrivacyInfo.xcprivacy (4 NSPrivacyAccessedAPICategory
+  entries), `xcrun notarytool submit --wait`, `xcrun stapler staple`,
+  `spctl --assess --type execute`, CI grep gate against
+  non-compliant API usage
+- **Runtime sandbox (B0 text-mode 11 rules)** — fs confinement,
+  network allowlist + GrantStore, tool-result history spotlight,
+  spawn deny, outbound secret prefilter, memory redaction,
+  MCP binary signature check
+
+### 🐛 Bug Fixes
+
+- **Ollama silent regression** — `num_predict: 0` was being sent
+  literally and Ollama interpreted it as "produce 0 tokens",
+  causing `mur learn extract --llm` to return empty strings and
+  silently fall through to logic-only extraction. Fixed: sentinel
+  0 → `num_predict: None` (matches pre-P4 behavior)
+- **Anthropic OAuth transport leak** — OAuth handling decoupled
+  from public transport surface (#79)
+
+### ⬆️ Upgrade Notes
+
+- **Config schema:** compatible — existing `~/.mur/config.yaml`
+  needs no changes; all new fields are `#[serde(default)]`
+- **Vector index:** no reindex needed — store schema unchanged
+- **Brew users:** `brew update && brew upgrade mur`
+- **Source build:** Rust 1.82+ (unchanged from v2.4.1)
+
+### 📦 Internal / Foundations
+
+- **Cloud-LLM rollout (P0-P4)** — deleted `mur-core/src/llm.rs`
+  (524 LOC); all LLM calls now flow through
+  `conversations::backend::ChatBackend` trait; ~−700 LOC net delete
+- **Track C1 (A2A bridge foundations)** — `LlmEntitlement`,
+  `BridgeRouteConfig`, `SignedEnvelope` + `TrustedPeer` verify,
+  sled-backed `DedupeStore` (7d TTL), `AckTracker`, `BridgeBeacon`
+  degraded surface have landed; full agent-to-agent message bridge
+  (Telegram, send-from-any-app) planned for v2.6
+- **Stats:** 98 commits / 24 PRs since v2.4.1
+
+### 🙏 Thanks
+
+(no external contributors this cycle — internal-only release)
+```

--- a/mur-agent-gui/src-tauri/Cargo.toml
+++ b/mur-agent-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mur-agent-gui"
-version = "2.4.1"
+version = "2.5.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"


### PR DESCRIPTION
## Summary

v2.5.0 release prep. 98 commits / 24 PRs since v2.4.1.

### Why v2.5.0 (not v2.4.2)

SemVer minor bump triggered by:
- New user-facing CLI commands (`mur conversations cost-report`, `mur agent card export/accept`, `mur agent companion connector add`)
- New `~/.mur/config.yaml` `llm.provider` values: `openai`, `gemini`, `openrouter` (v2.4.1 errored on these)
- GUI shipped from nothing to production-ready (`mur agent export --format gui` produces a notarized macOS .app)
- 11 new runtime sandbox rules (B0 text-mode) that change agent behavior

Rationale + scope decisions documented in \`docs/plans/2026-05-04-v2.5.0-release-design.md\`.

### Diff in this PR

- \`docs/plans/2026-05-04-v2.5.0-release-design.md\` (new) — release design + decision rationale
- \`CHANGELOG.md\` — prepended v2.5.0 section with two-paragraph TL;DR (split by use case)
- \`Cargo.toml\` — workspace version 2.4.1 → 2.5.0
- \`mur-agent-gui/src-tauri/Cargo.toml\` — same

### Test plan

- [x] \`cargo build -p mur-core --release\` clean (6m 33s, target/release/mur reports \"mur 2.5.0\")
- [ ] CI green on all 8 checks
- [ ] After merge: tag v2.5.0, push tag
- [ ] After tag: manually update homebrew tap (sha256 + url in \`mur-run/homebrew-tap/Formula/mur.rb\`)
- [ ] Verify: \`brew update && brew upgrade mur && mur --version\`

### Out of scope (deferred to v2.6)

- Track C1 (A2A bridge) — complete but bundled with C2/C3 for one cohesive \"agent network\" release
- Track C2 (Telegram bridge) — 2/8 milestones done, in active progress
- Track C3 (send-from-any-app) — plan only

🤖 Generated with [Claude Code](https://claude.com/claude-code)