### PR TITLE
feat(gui): Track C3 — M-c3.2 global hotkey + clipboard share channel

### DIFF
--- a/mur-agent-gui/src-tauri/src/send/hotkey.rs
+++ b/mur-agent-gui/src-tauri/src/send/hotkey.rs
@@ -7,9 +7,15 @@
 //!
 //! `lib.rs::setup` wiring is deferred to a follow-up so we can iterate
 //! on the combo + clipboard logic in isolation; the [`crate::test_harness::MockApp`]
-//! drives the same parse → ingest path used by production.
+//! drives the same trigger → ingest path used by production.
 //!
 //! [`SendIngestor`]: super::SendIngestor
+
+use std::sync::Mutex;
+
+use anyhow::bail;
+
+use crate::send::{ShareKind, SharePayload};
 
 /// Default hotkey combo for an agent.
 ///
@@ -29,6 +35,138 @@ pub fn default_combo_for(slug: &str) -> String {
         .map(|c| c.to_ascii_uppercase())
         .unwrap_or('A');
     format!("CommandOrControl+Shift+M+{first}")
+}
+
+/// Read-only clipboard surface the hotkey handler depends on.
+///
+/// Production wiring delegates to `tauri-plugin-clipboard-manager`;
+/// tests inject a [`FakeClipboard`] so they don't need a real
+/// pasteboard or a Tauri runtime.
+#[async_trait::async_trait]
+pub trait Clipboard: Send + Sync {
+    async fn read_text(&self) -> anyhow::Result<Option<String>>;
+    async fn read_image(&self) -> anyhow::Result<Option<Vec<u8>>>;
+}
+
+/// Synthesize a [`SharePayload`] from the current clipboard contents.
+///
+/// Routing rules:
+/// 1. Text starting with `http://` or `https://` → [`ShareKind::Url`].
+/// 2. Other text → [`ShareKind::Text`].
+/// 3. Image bytes → write to a temp PNG file, return [`ShareKind::Image`]
+///    pointing at it. The temp file persists past this call so the
+///    [`super::SendIngestor`] can read it; cleanup is deferred to the
+///    OS temp-dir GC, which is fine for hotkey usage where individual
+///    payloads are small (<10 MB) and rare.
+/// 4. Empty clipboard → fail with a clear error so the hotkey handler
+///    can flash a "nothing to share" toast instead of silently
+///    sending a blank payload.
+pub async fn synthesize_from_clipboard(cb: &dyn Clipboard) -> anyhow::Result<SharePayload> {
+    if let Some(text) = cb.read_text().await?
+        && !text.is_empty()
+    {
+        let kind = if text.starts_with("http://") || text.starts_with("https://") {
+            ShareKind::Url(text)
+        } else {
+            ShareKind::Text(text)
+        };
+        return Ok(SharePayload {
+            source: "hotkey".into(),
+            kind,
+            metadata: serde_json::json!({}),
+        });
+    }
+    if let Some(bytes) = cb.read_image().await?
+        && !bytes.is_empty()
+    {
+        let mut named = tempfile::Builder::new()
+            .prefix("mur-share-")
+            .suffix(".png")
+            .tempfile()?;
+        std::io::Write::write_all(named.as_file_mut(), &bytes)?;
+        let (_, path) = named.keep()?;
+        return Ok(SharePayload {
+            source: "hotkey".into(),
+            kind: ShareKind::Image(path),
+            metadata: serde_json::json!({}),
+        });
+    }
+    bail!("clipboard empty — nothing to share")
+}
+
+/// Resolve the hotkey combo for an agent, honouring an optional user
+/// override (read from `~/.mur/agents/<name>/companion/state.yaml`
+/// field `share.hotkey`).
+///
+/// `None` falls back to [`default_combo_for`]. The override is taken
+/// verbatim — the GUI is expected to validate it before persisting.
+pub fn resolve_combo(slug: &str, user_override: Option<&str>) -> String {
+    user_override
+        .map(str::to_string)
+        .unwrap_or_else(|| default_combo_for(slug))
+}
+
+/// Test fake — wraps `Mutex<Option<…>>` slots so tests can pre-load
+/// either a text or an image and pass it to `synthesize_from_clipboard`
+/// without bringing the real pasteboard plugin.
+pub struct FakeClipboard {
+    text: Mutex<Option<String>>,
+    image: Mutex<Option<Vec<u8>>>,
+}
+
+impl FakeClipboard {
+    pub fn empty() -> Self {
+        Self {
+            text: Mutex::new(None),
+            image: Mutex::new(None),
+        }
+    }
+
+    pub fn with_text(text: impl Into<String>) -> Self {
+        Self {
+            text: Mutex::new(Some(text.into())),
+            image: Mutex::new(None),
+        }
+    }
+
+    pub fn with_image(bytes: impl Into<Vec<u8>>) -> Self {
+        Self {
+            text: Mutex::new(None),
+            image: Mutex::new(Some(bytes.into())),
+        }
+    }
+
+    /// Drop any cached payload. Mirrors a user clearing the clipboard
+    /// between two hotkey presses; used by harness tests.
+    pub fn clear(&self) {
+        *self.text.lock().expect("FakeClipboard mutex poisoned") = None;
+        *self.image.lock().expect("FakeClipboard mutex poisoned") = None;
+    }
+
+    /// Replace the held text. Used by `MockApp::set_clipboard_text`
+    /// in M-c3.2.4.
+    pub fn set_text(&self, text: impl Into<String>) {
+        *self.text.lock().expect("FakeClipboard mutex poisoned") = Some(text.into());
+        *self.image.lock().expect("FakeClipboard mutex poisoned") = None;
+    }
+}
+
+#[async_trait::async_trait]
+impl Clipboard for FakeClipboard {
+    async fn read_text(&self) -> anyhow::Result<Option<String>> {
+        Ok(self
+            .text
+            .lock()
+            .expect("FakeClipboard mutex poisoned")
+            .clone())
+    }
+    async fn read_image(&self) -> anyhow::Result<Option<Vec<u8>>> {
+        Ok(self
+            .image
+            .lock()
+            .expect("FakeClipboard mutex poisoned")
+            .clone())
+    }
 }
 
 #[cfg(test)]

--- a/mur-agent-gui/src-tauri/src/send/hotkey.rs
+++ b/mur-agent-gui/src-tauri/src/send/hotkey.rs
@@ -1,2 +1,49 @@
-//! Track C3 channel B — global hotkey capture (text from active app
-//! via clipboard). Implemented in M-c3.2.
+//! Track C3 channel B — global hotkey capture.
+//!
+//! Bound at app startup via [`tauri-plugin-global-shortcut`]. When the
+//! user hits the bound combo, we read the system clipboard
+//! (`tauri-plugin-clipboard-manager`), synthesize a [`SharePayload`],
+//! and hand it to the [`SendIngestor`].
+//!
+//! `lib.rs::setup` wiring is deferred to a follow-up so we can iterate
+//! on the combo + clipboard logic in isolation; the [`crate::test_harness::MockApp`]
+//! drives the same parse → ingest path used by production.
+//!
+//! [`SendIngestor`]: super::SendIngestor
+
+/// Default hotkey combo for an agent.
+///
+/// Single-agent installs land on `Cmd+Shift+M`; the per-agent suffix
+/// (the first letter of the slug, uppercased) only matters when more
+/// than one mur agent is installed. Two agents whose slugs share a
+/// first letter still collide — see
+/// [`resolve_combo`] for the user-override escape hatch.
+///
+/// `slug` is expected to be the kebab-case agent name produced by
+/// `mur-core::cmd::agent_export_gui::sanitize_for_bundle_id`. An
+/// empty slug falls back to `A` so the combo stays valid.
+pub fn default_combo_for(slug: &str) -> String {
+    let first = slug
+        .chars()
+        .next()
+        .map(|c| c.to_ascii_uppercase())
+        .unwrap_or('A');
+    format!("CommandOrControl+Shift+M+{first}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_default_combo_for_slug() {
+        assert_eq!(default_combo_for("coach"), "CommandOrControl+Shift+M+C");
+        assert_eq!(default_combo_for("draft"), "CommandOrControl+Shift+M+D");
+        assert_eq!(default_combo_for("mur-bot"), "CommandOrControl+Shift+M+M");
+    }
+
+    #[test]
+    fn unit_default_combo_empty_slug_falls_back_to_a() {
+        assert_eq!(default_combo_for(""), "CommandOrControl+Shift+M+A");
+    }
+}

--- a/mur-agent-gui/src-tauri/src/test_harness.rs
+++ b/mur-agent-gui/src-tauri/src/test_harness.rs
@@ -20,7 +20,8 @@
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use crate::send::{SendIngestor, SharePayload, ShareEmitter, url_scheme};
+use crate::send::hotkey::{FakeClipboard, synthesize_from_clipboard};
+use crate::send::{SendIngestor, ShareEmitter, SharePayload, url_scheme};
 
 /// Counts emit-received calls and stores the payloads. Callers swap
 /// this in for the production `tauri::AppHandle`-backed emitter.
@@ -77,6 +78,10 @@ pub struct MockApp {
     /// want to assert downstream artifacts in stacked harnesses.
     pub agent_home: PathBuf,
     pub ingestor: Arc<RecordingIngestor>,
+    /// Stand-in for the system clipboard. Hotkey channel tests load
+    /// content via [`set_clipboard_text`] / [`set_clipboard_image`]
+    /// before calling [`trigger_shortcut`].
+    pub clipboard: Arc<FakeClipboard>,
 }
 
 impl MockApp {
@@ -85,6 +90,7 @@ impl MockApp {
             slug: slug.into(),
             agent_home: agent_home.as_ref().to_path_buf(),
             ingestor: Arc::new(RecordingIngestor::default()),
+            clipboard: Arc::new(FakeClipboard::empty()),
         }
     }
 
@@ -94,6 +100,22 @@ impl MockApp {
     /// invalid URLs; the harness surfaces them).
     pub async fn simulate_open_url(&self, url: &str) -> anyhow::Result<()> {
         let payload = url_scheme::parse_share_url(url, &self.slug)?;
+        self.ingestor.ingest(payload).await
+    }
+
+    /// Pre-load text into the harness clipboard so the next
+    /// [`trigger_shortcut`] call yields a [`crate::send::ShareKind::Text`]
+    /// (or `Url` if the value starts with `http(s)://`).
+    pub fn set_clipboard_text(&self, text: impl Into<String>) {
+        self.clipboard.set_text(text);
+    }
+
+    /// Drive the hotkey path: read from [`Self::clipboard`] via
+    /// `synthesize_from_clipboard`, then ingest. Same seam the
+    /// production `tauri-plugin-global-shortcut` callback will use
+    /// once `lib.rs::setup` wires it up.
+    pub async fn trigger_shortcut(&self) -> anyhow::Result<()> {
+        let payload = synthesize_from_clipboard(self.clipboard.as_ref()).await?;
         self.ingestor.ingest(payload).await
     }
 

--- a/mur-agent-gui/src-tauri/tests/send_hotkey.rs
+++ b/mur-agent-gui/src-tauri/tests/send_hotkey.rs
@@ -1,0 +1,27 @@
+//! Track C3 — M-c3.2 global hotkey channel tests.
+//!
+//! Layered like the URL scheme suite:
+//! - M-c3.2.1: pure `default_combo_for(slug)` derives a per-agent
+//!   `CommandOrControl+Shift+M+<FIRST_LETTER>` combo.
+//! - M-c3.2.2: `Clipboard` trait + `synthesize_from_clipboard`
+//!   reads text/url/image and produces a `SharePayload`.
+//! - M-c3.2.3: `resolve_combo(slug, user_override)` lets the user
+//!   override the per-agent default in companion settings.
+//! - M-c3.2.4: end-to-end via `MockApp::trigger_shortcut` — a hotkey
+//!   firing reaches the ingestor with the clipboard contents.
+
+use mur_agent_gui_lib::send::hotkey::default_combo_for;
+
+#[test]
+fn default_hotkey_combo_for_slug() {
+    assert_eq!(default_combo_for("coach"), "CommandOrControl+Shift+M+C");
+    assert_eq!(default_combo_for("draft"), "CommandOrControl+Shift+M+D");
+}
+
+#[test]
+fn collision_when_two_agents_share_first_letter() {
+    // Documented limitation: two agents starting with "c" will collide
+    // on the default combo. The user has to override one of them via
+    // the companion settings escape hatch — see M-c3.2.3.
+    assert_eq!(default_combo_for("coach"), default_combo_for("creator"));
+}

--- a/mur-agent-gui/src-tauri/tests/send_hotkey.rs
+++ b/mur-agent-gui/src-tauri/tests/send_hotkey.rs
@@ -14,6 +14,7 @@ use mur_agent_gui_lib::send::ShareKind;
 use mur_agent_gui_lib::send::hotkey::{
     FakeClipboard, default_combo_for, resolve_combo, synthesize_from_clipboard,
 };
+use mur_agent_gui_lib::test_harness::MockApp;
 
 #[test]
 fn default_hotkey_combo_for_slug() {
@@ -89,5 +90,52 @@ async fn empty_clipboard_returns_err() {
     assert!(
         err.to_string().contains("nothing to share"),
         "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn hotkey_event_reaches_ingestor() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = MockApp::new(tmp.path(), "coach");
+
+    app.set_clipboard_text("snippet from any app");
+    app.trigger_shortcut().await.unwrap();
+
+    let captured = app.captured_payloads();
+    assert_eq!(captured.len(), 1, "exactly one payload should be ingested");
+    let p = &captured[0];
+    assert_eq!(p.source, "hotkey");
+    match &p.kind {
+        ShareKind::Text(t) => assert_eq!(t, "snippet from any app"),
+        other => panic!("expected ShareKind::Text, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn hotkey_event_classifies_url_clipboard() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = MockApp::new(tmp.path(), "coach");
+
+    app.set_clipboard_text("https://example.com/post/42");
+    app.trigger_shortcut().await.unwrap();
+
+    let captured = app.captured_payloads();
+    assert_eq!(captured.len(), 1);
+    match &captured[0].kind {
+        ShareKind::Url(u) => assert_eq!(u, "https://example.com/post/42"),
+        other => panic!("expected ShareKind::Url, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn hotkey_with_empty_clipboard_does_not_record() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = MockApp::new(tmp.path(), "coach");
+
+    let res = app.trigger_shortcut().await;
+    assert!(res.is_err(), "trigger on empty clipboard must error");
+    assert!(
+        app.captured_payloads().is_empty(),
+        "ingestor must not record anything when synthesis fails"
     );
 }

--- a/mur-agent-gui/src-tauri/tests/send_hotkey.rs
+++ b/mur-agent-gui/src-tauri/tests/send_hotkey.rs
@@ -12,7 +12,7 @@
 
 use mur_agent_gui_lib::send::ShareKind;
 use mur_agent_gui_lib::send::hotkey::{
-    FakeClipboard, default_combo_for, synthesize_from_clipboard,
+    FakeClipboard, default_combo_for, resolve_combo, synthesize_from_clipboard,
 };
 
 #[test]
@@ -65,6 +65,21 @@ async fn hotkey_handler_reads_image() {
         }
         other => panic!("expected ShareKind::Image, got {other:?}"),
     }
+}
+
+#[test]
+fn user_override_takes_precedence_over_default() {
+    // Companion settings (`share.hotkey`) win when set; the per-agent
+    // default only applies when no override is configured.
+    assert_eq!(
+        resolve_combo("coach", Some("CommandOrControl+Alt+K")),
+        "CommandOrControl+Alt+K"
+    );
+    assert_eq!(
+        resolve_combo("coach", None),
+        default_combo_for("coach"),
+        "None must defer to default_combo_for"
+    );
 }
 
 #[tokio::test]

--- a/mur-agent-gui/src-tauri/tests/send_hotkey.rs
+++ b/mur-agent-gui/src-tauri/tests/send_hotkey.rs
@@ -10,7 +10,10 @@
 //! - M-c3.2.4: end-to-end via `MockApp::trigger_shortcut` — a hotkey
 //!   firing reaches the ingestor with the clipboard contents.
 
-use mur_agent_gui_lib::send::hotkey::default_combo_for;
+use mur_agent_gui_lib::send::ShareKind;
+use mur_agent_gui_lib::send::hotkey::{
+    FakeClipboard, default_combo_for, synthesize_from_clipboard,
+};
 
 #[test]
 fn default_hotkey_combo_for_slug() {
@@ -24,4 +27,52 @@ fn collision_when_two_agents_share_first_letter() {
     // on the default combo. The user has to override one of them via
     // the companion settings escape hatch — see M-c3.2.3.
     assert_eq!(default_combo_for("coach"), default_combo_for("creator"));
+}
+
+#[tokio::test]
+async fn hotkey_handler_reads_text() {
+    let cb = FakeClipboard::with_text("hello hotkey");
+    let payload = synthesize_from_clipboard(&cb).await.unwrap();
+    assert_eq!(payload.source, "hotkey");
+    match payload.kind {
+        ShareKind::Text(t) => assert_eq!(t, "hello hotkey"),
+        other => panic!("expected ShareKind::Text, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn hotkey_handler_classifies_url_text_as_url() {
+    let cb = FakeClipboard::with_text("https://example.com/article");
+    let payload = synthesize_from_clipboard(&cb).await.unwrap();
+    match payload.kind {
+        ShareKind::Url(u) => assert_eq!(u, "https://example.com/article"),
+        other => panic!("expected ShareKind::Url, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn hotkey_handler_reads_image() {
+    let bytes = std::fs::read("tests/fixtures/tiny.png").unwrap();
+    let cb = FakeClipboard::with_image(bytes.clone());
+    let payload = synthesize_from_clipboard(&cb).await.unwrap();
+    assert_eq!(payload.source, "hotkey");
+    match payload.kind {
+        ShareKind::Image(path) => {
+            let written = std::fs::read(&path).unwrap();
+            assert_eq!(written, bytes);
+            // Cleanup the persisted temp file the synthesizer kept.
+            let _ = std::fs::remove_file(&path);
+        }
+        other => panic!("expected ShareKind::Image, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn empty_clipboard_returns_err() {
+    let cb = FakeClipboard::empty();
+    let err = synthesize_from_clipboard(&cb).await.unwrap_err();
+    assert!(
+        err.to_string().contains("nothing to share"),
+        "unexpected error: {err}"
+    );
 }


### PR DESCRIPTION
## Summary

Adds Track C3 channel B (global hotkey + clipboard) — second of the four send-from-any-app channels. Stacked on **#146** (M-c3.1 URL scheme).

When the user hits a per-agent shortcut (default `Cmd+Shift+M+<X>`, where `<X>` is the slug's first letter), the runtime reads the system clipboard and produces a `SharePayload` that flows through the same ingestor as the URL-scheme channel — and therefore through the same B0 `<untrusted_share>` wrapping + Rule-4 cooldown that landed in M-c3.0.

This PR is **harness-only**. The Tauri runtime wiring (`lib.rs::setup` + `tauri-plugin-global-shortcut` + `tauri-plugin-clipboard-manager`) lands in a follow-up so we can iterate on the combo + clipboard logic against unit tests, without spinning up a real Tauri app for each iteration.

## Milestones

- **M-c3.2.1** — `default_combo_for(slug) → "CommandOrControl+Shift+M+<X>"`. Empty-slug fallback is `A`. Documented collision case for two agents sharing a first letter.
- **M-c3.2.2** — `Clipboard` trait + `synthesize_from_clipboard`:
  - text starting with `http(s)://` → `ShareKind::Url`
  - other text → `ShareKind::Text`
  - image bytes → persisted temp PNG → `ShareKind::Image(path)`
  - empty clipboard → `bail!("nothing to share")`
- **M-c3.2.3** — `resolve_combo(slug, override)` honours companion-settings `share.hotkey` verbatim, falls back to the per-agent default when `None`.
- **M-c3.2.4** — `MockApp` gains `clipboard: Arc<FakeClipboard>` + `set_clipboard_text` + `trigger_shortcut`. Drives the production seam end-to-end: clipboard read → synthesize → ingest.

## Test plan

- [x] `cargo test --test send_hotkey` (all 10 tests pass: 3 combo, 1 override, 4 synth, 3 E2E)
- [x] `cargo test --test send_url_scheme` (still green — M-c3.2.4 touched test_harness.rs)
- [ ] Wire `tauri-plugin-global-shortcut` into `lib.rs::setup` in a follow-up PR
- [ ] Manual: install a built agent and verify `Cmd+Shift+M+<X>` triggers the inbox
- [ ] Manual: override hotkey in companion `state.yaml`, restart agent, verify new combo binds

🤖 Generated with [Claude Code](https://claude.com/claude-code)