### PR TITLE
feat(gui,core): Track C3 — M-c3.3 macOS Services menu channel

### DIFF
--- a/mur-agent-gui/src-tauri/Cargo.toml
+++ b/mur-agent-gui/src-tauri/Cargo.toml
@@ -113,6 +113,23 @@ libc = "0.2"
 # whisper.cpp Metal backend — Apple-only; enabling on Linux/Windows breaks
 # CMake (it looks for the Foundation framework which only exists on macOS).
 whisper-rs = { version = "0.14", default-features = false, features = ["metal"] }
+# Track C3 / M-c3.3 — Services menu channel. `objc2` exposes the
+# Objective-C runtime; `objc2-app-kit` and `objc2-foundation` give us
+# NSPasteboard / NSApplication / NSString bindings used by the
+# `NSServiceProviderProtocol` bridge in `src/send/services.rs`.
+# Pinned to 0.3.x / 0.6.x to match the versions already pulled in
+# transitively by `tauri` 2 (via `arboard`, `muda`, `global-hotkey`)
+# — mixing major versions yields confusing trait-bound errors.
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", features = [
+    "NSApplication",
+    "NSPasteboard",
+] }
+objc2-foundation = { version = "0.3", features = [
+    "NSArray",
+    "NSData",
+    "NSString",
+] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 alsa = "0.9"

--- a/mur-agent-gui/src-tauri/Info.plist.template
+++ b/mur-agent-gui/src-tauri/Info.plist.template
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Track C3 / M-c3.3.3 — NSServices template merged into the bundled
+  Info.plist by `mur-core::cmd::agent_export_gui::rewrite_nsservices`
+  during the GUI export pipeline.
+
+  The `{{AGENT_DISPLAY}}` token is substituted with the per-agent
+  display name (e.g. "Coach"). Three menu items are exposed in the
+  Services menu — text selection, link, image — all dispatching to the
+  same `serviceShare:` selector registered on `NSApplication`. The
+  Rust handler decides what to do based on the pasteboard contents.
+
+  Apple guidance: keep these menu items short ("verb + noun + agent")
+  so they fit the Services submenu without truncation.
+-->
+<plist version="1.0">
+<dict>
+    <key>NSServices</key>
+    <array>
+        <dict>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>Send Selection to {{AGENT_DISPLAY}}</string>
+            </dict>
+            <key>NSMessage</key>
+            <string>serviceShare</string>
+            <key>NSPortName</key>
+            <string>{{AGENT_DISPLAY}}</string>
+            <key>NSSendTypes</key>
+            <array>
+                <string>public.utf8-plain-text</string>
+                <string>NSStringPboardType</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>Send Link to {{AGENT_DISPLAY}}</string>
+            </dict>
+            <key>NSMessage</key>
+            <string>serviceShare</string>
+            <key>NSPortName</key>
+            <string>{{AGENT_DISPLAY}}</string>
+            <key>NSSendTypes</key>
+            <array>
+                <string>public.url</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>Send Image to {{AGENT_DISPLAY}}</string>
+            </dict>
+            <key>NSMessage</key>
+            <string>serviceShare</string>
+            <key>NSPortName</key>
+            <string>{{AGENT_DISPLAY}}</string>
+            <key>NSSendTypes</key>
+            <array>
+                <string>public.image</string>
+                <string>public.png</string>
+                <string>public.jpeg</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/mur-agent-gui/src-tauri/src/send/services.rs
+++ b/mur-agent-gui/src-tauri/src/send/services.rs
@@ -1,2 +1,32 @@
 //! Track C3 channel C — macOS Services menu integration.
-//! Implemented in M-c3.3.
+//!
+//! The Services menu is the lowest-friction native share entry point on
+//! macOS — Bear, Drafts, Things, Mail, Safari all expose selections and
+//! links there. We register a [`ServicesProvider`] with
+//! `NSApplication.servicesProvider` so when the user picks
+//! `Send Selection to <Agent>` (the default menu item rendered via
+//! `Info.plist`'s `NSServices` array, see M-c3.3.3), AppKit invokes our
+//! `serviceShare:userData:error:` selector, which decodes
+//! `NSPasteboard` and hands the resulting [`SharePayload`] to the
+//! [`SendIngestor`].
+//!
+//! Production wiring (`NSApplication.setServicesProvider:` from
+//! `lib.rs::setup`) lands in a follow-up; the harness drives the same
+//! seam through `MockApp::invoke_services_selector` (M-c3.3.4) so we
+//! can iterate on the pasteboard decoder without spinning up a real
+//! Cocoa runtime per test.
+//!
+//! [`SendIngestor`]: super::SendIngestor
+//! [`SharePayload`]: super::SharePayload
+
+#![cfg(target_os = "macos")]
+
+use objc2::rc::Retained;
+use objc2::runtime::NSObject;
+
+/// Owns the boxed Objective-C subclass instance registered with
+/// `NSApplication.servicesProvider`. The actual selector body and
+/// pasteboard decoder land in M-c3.3.2.
+pub struct ServicesProvider {
+    _obj: Retained<NSObject>,
+}

--- a/mur-agent-gui/src-tauri/src/send/services.rs
+++ b/mur-agent-gui/src-tauri/src/send/services.rs
@@ -2,31 +2,134 @@
 //!
 //! The Services menu is the lowest-friction native share entry point on
 //! macOS — Bear, Drafts, Things, Mail, Safari all expose selections and
-//! links there. We register a [`ServicesProvider`] with
-//! `NSApplication.servicesProvider` so when the user picks
-//! `Send Selection to <Agent>` (the default menu item rendered via
-//! `Info.plist`'s `NSServices` array, see M-c3.3.3), AppKit invokes our
-//! `serviceShare:userData:error:` selector, which decodes
-//! `NSPasteboard` and hands the resulting [`SharePayload`] to the
-//! [`SendIngestor`].
+//! links there. Production (deferred to a `lib.rs::setup` follow-up)
+//! will register a [`ServicesProvider`] with
+//! `NSApplication.servicesProvider`. When the user picks
+//! `Send Selection to <Agent>` (the menu item rendered via `Info.plist`'s
+//! `NSServices` array — see M-c3.3.3), AppKit invokes the
+//! `serviceShare:userData:error:` selector on our subclass, which calls
+//! [`extract_payload_from_pasteboard`] and hands the resulting
+//! [`SharePayload`] to the [`SendIngestor`].
 //!
-//! Production wiring (`NSApplication.setServicesProvider:` from
-//! `lib.rs::setup`) lands in a follow-up; the harness drives the same
-//! seam through `MockApp::invoke_services_selector` (M-c3.3.4) so we
-//! can iterate on the pasteboard decoder without spinning up a real
-//! Cocoa runtime per test.
+//! This module exposes the pasteboard decoder as a free function so it
+//! can be exercised without spinning up a real Cocoa runtime per test.
+//! The harness drives the same seam through
+//! `MockApp::invoke_services_selector` (M-c3.3.4).
 //!
 //! [`SendIngestor`]: super::SendIngestor
-//! [`SharePayload`]: super::SharePayload
 
 #![cfg(target_os = "macos")]
 
+use anyhow::bail;
 use objc2::rc::Retained;
 use objc2::runtime::NSObject;
+use objc2_app_kit::{NSPasteboard, NSPasteboardTypePNG, NSPasteboardTypeString};
+use objc2_foundation::NSString;
+
+use super::{SharePayload, ShareKind};
 
 /// Owns the boxed Objective-C subclass instance registered with
-/// `NSApplication.servicesProvider`. The actual selector body and
-/// pasteboard decoder land in M-c3.3.2.
+/// `NSApplication.servicesProvider`. The selector body lives in the
+/// production wiring step (lib.rs::setup); the unit-testable
+/// pasteboard decoder is [`extract_payload_from_pasteboard`].
 pub struct ServicesProvider {
     _obj: Retained<NSObject>,
+}
+
+/// Decode an `NSPasteboard` into a [`SharePayload`].
+///
+/// Routing rules mirror the hotkey channel ([`super::hotkey::synthesize_from_clipboard`]):
+/// 1. `NSPasteboardTypeString` text starting with `http(s)://`
+///    → [`ShareKind::Url`].
+/// 2. Other text → [`ShareKind::Text`].
+/// 3. `NSPasteboardTypePNG` data → write to a persisted temp PNG,
+///    return [`ShareKind::Image`] pointing at it.
+/// 4. Pasteboard offers neither → fail with a clear error so the
+///    selector body can return an `NSError` and AppKit shows the
+///    standard "couldn't share" alert.
+pub fn extract_payload_from_pasteboard(pb: &NSPasteboard) -> anyhow::Result<SharePayload> {
+    if let Some(text) = read_string(pb)
+        && !text.is_empty()
+    {
+        let kind = if text.starts_with("http://") || text.starts_with("https://") {
+            ShareKind::Url(text)
+        } else {
+            ShareKind::Text(text)
+        };
+        return Ok(SharePayload {
+            source: "services".into(),
+            kind,
+            metadata: serde_json::json!({}),
+        });
+    }
+    if let Some(bytes) = read_png(pb)
+        && !bytes.is_empty()
+    {
+        let mut named = tempfile::Builder::new()
+            .prefix("mur-share-")
+            .suffix(".png")
+            .tempfile()?;
+        std::io::Write::write_all(named.as_file_mut(), &bytes)?;
+        let (_, path) = named.keep()?;
+        return Ok(SharePayload {
+            source: "services".into(),
+            kind: ShareKind::Image(path),
+            metadata: serde_json::json!({}),
+        });
+    }
+    bail!("pasteboard offers neither text nor PNG image — nothing to share")
+}
+
+fn read_string(pb: &NSPasteboard) -> Option<String> {
+    unsafe { pb.stringForType(NSPasteboardTypeString) }.map(|ns| ns.to_string())
+}
+
+fn read_png(pb: &NSPasteboard) -> Option<Vec<u8>> {
+    unsafe { pb.dataForType(NSPasteboardTypePNG) }.map(|data| data.to_vec())
+}
+
+/// Test helpers — exposed under `#[doc(hidden)]` so integration tests
+/// can build private `NSPasteboard` instances without polluting the
+/// user's actual general pasteboard. Production callers must not
+/// reach for these.
+#[doc(hidden)]
+pub mod test_helpers {
+    use super::*;
+    use objc2::Message;
+    use objc2_app_kit::NSPasteboard;
+    use objc2_foundation::{NSArray, NSData};
+
+    /// Build a `pasteboardWithUniqueName` carrying the given UTF-8 text
+    /// under `NSPasteboardTypeString`.
+    pub fn pasteboard_with_text(text: &str) -> Retained<NSPasteboard> {
+        let pb = NSPasteboard::pasteboardWithUniqueName();
+        let types = NSArray::from_retained_slice(&[unsafe { NSPasteboardTypeString.retain() }]);
+        unsafe { pb.declareTypes_owner(&types, None) };
+        let ns = NSString::from_str(text);
+        unsafe {
+            pb.setString_forType(&ns, NSPasteboardTypeString);
+        }
+        pb
+    }
+
+    /// Build an empty `pasteboardWithUniqueName` (no declared types).
+    /// Used by tests to assert the decoder errors when both text and
+    /// PNG slots are empty.
+    pub fn empty_pasteboard() -> Retained<NSPasteboard> {
+        NSPasteboard::pasteboardWithUniqueName()
+    }
+
+    /// Build a `pasteboardWithUniqueName` carrying PNG bytes under
+    /// `NSPasteboardTypePNG`.
+    pub fn pasteboard_with_image(bytes: &[u8]) -> Retained<NSPasteboard> {
+        let pb = NSPasteboard::pasteboardWithUniqueName();
+        let types = NSArray::from_retained_slice(&[unsafe { NSPasteboardTypePNG.retain() }]);
+        unsafe { pb.declareTypes_owner(&types, None) };
+        let data = NSData::with_bytes(bytes);
+        unsafe {
+            pb.setData_forType(Some(&data), NSPasteboardTypePNG);
+        }
+        pb
+    }
+
 }

--- a/mur-agent-gui/src-tauri/src/test_harness.rs
+++ b/mur-agent-gui/src-tauri/src/test_harness.rs
@@ -119,6 +119,21 @@ impl MockApp {
         self.ingestor.ingest(payload).await
     }
 
+    /// Drive the macOS Services menu path. Bypasses the
+    /// `NSApplication.servicesProvider` round-trip by calling the
+    /// pasteboard decoder directly — same seam the production
+    /// `serviceShare:userData:error:` selector body will use once
+    /// `lib.rs::setup` wires it up. Available only on macOS because
+    /// `NSPasteboard` is Cocoa-only.
+    #[cfg(target_os = "macos")]
+    pub async fn invoke_services_selector(
+        &self,
+        pb: &objc2_app_kit::NSPasteboard,
+    ) -> anyhow::Result<()> {
+        let payload = crate::send::services::extract_payload_from_pasteboard(pb)?;
+        self.ingestor.ingest(payload).await
+    }
+
     /// Snapshot the recorded payloads. Returns an owned clone so
     /// callers can iterate without holding the mutex.
     pub fn captured_payloads(&self) -> Vec<SharePayload> {

--- a/mur-agent-gui/src-tauri/tests/send_services.rs
+++ b/mur-agent-gui/src-tauri/tests/send_services.rs
@@ -17,10 +17,11 @@
 #![cfg(target_os = "macos")]
 
 use mur_agent_gui_lib::send::ShareKind;
-use mur_agent_gui_lib::send::services::{ServicesProvider, extract_payload_from_pasteboard};
 use mur_agent_gui_lib::send::services::test_helpers::{
     empty_pasteboard, pasteboard_with_image, pasteboard_with_text,
 };
+use mur_agent_gui_lib::send::services::{ServicesProvider, extract_payload_from_pasteboard};
+use mur_agent_gui_lib::test_harness::MockApp;
 
 #[test]
 fn services_module_compiles_on_macos() {
@@ -71,5 +72,57 @@ fn empty_pasteboard_returns_err() {
     assert!(
         err.to_string().contains("nothing to share"),
         "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn services_selector_invokes_ingestor_with_text() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = MockApp::new(tmp.path(), "coach");
+    let pb = pasteboard_with_text("services-text");
+
+    app.invoke_services_selector(&pb).await.unwrap();
+
+    let captured = app.captured_payloads();
+    assert_eq!(captured.len(), 1, "expected one payload, got {captured:?}");
+    assert_eq!(captured[0].source, "services");
+    match &captured[0].kind {
+        ShareKind::Text(t) => assert_eq!(t, "services-text"),
+        other => panic!("expected ShareKind::Text, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn services_selector_routes_image_through_ingestor() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = MockApp::new(tmp.path(), "coach");
+    let bytes = std::fs::read("tests/fixtures/tiny.png").unwrap();
+    let pb = pasteboard_with_image(&bytes);
+
+    app.invoke_services_selector(&pb).await.unwrap();
+
+    let captured = app.captured_payloads();
+    assert_eq!(captured.len(), 1);
+    match &captured[0].kind {
+        ShareKind::Image(path) => {
+            let written = std::fs::read(path).unwrap();
+            assert_eq!(written, bytes);
+            let _ = std::fs::remove_file(path);
+        }
+        other => panic!("expected ShareKind::Image, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn services_selector_with_empty_pasteboard_does_not_record() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = MockApp::new(tmp.path(), "coach");
+    let pb = empty_pasteboard();
+
+    let res = app.invoke_services_selector(&pb).await;
+    assert!(res.is_err(), "empty pasteboard must propagate error");
+    assert!(
+        app.captured_payloads().is_empty(),
+        "ingestor must not record anything when extraction fails"
     );
 }

--- a/mur-agent-gui/src-tauri/tests/send_services.rs
+++ b/mur-agent-gui/src-tauri/tests/send_services.rs
@@ -1,0 +1,25 @@
+//! Track C3 — M-c3.3 macOS Services menu channel tests.
+//!
+//! The whole channel is gated `#[cfg(target_os = "macos")]` because it
+//! depends on `objc2-app-kit` (NSPasteboard) and the Cocoa runtime.
+//! Linux / Windows builds compile a no-op stub so the integration test
+//! still links.
+//!
+//! - M-c3.3.1: type exists + module compiles when objc2 deps are in
+//!   place.
+//! - M-c3.3.2: `extract_payload_from_pasteboard` decodes text/url/image
+//!   into a `SharePayload`.
+//! - M-c3.3.3: `Info.plist` injection (covered in
+//!   `mur-core/tests/agent_export_gui_nsservices.rs`).
+//! - M-c3.3.4: `MockApp::invoke_services_selector` end-to-end via
+//!   harness, bypasses NSApplication round-trip.
+
+#![cfg(target_os = "macos")]
+
+#[test]
+fn services_module_compiles_on_macos() {
+    // The type only exists on macOS; this test asserts the module is
+    // wired up and the objc2 deps resolve. No runtime behavior yet —
+    // pasteboard decoding lands in M-c3.3.2.
+    let _ = std::any::TypeId::of::<mur_agent_gui_lib::send::services::ServicesProvider>();
+}

--- a/mur-agent-gui/src-tauri/tests/send_services.rs
+++ b/mur-agent-gui/src-tauri/tests/send_services.rs
@@ -16,10 +16,60 @@
 
 #![cfg(target_os = "macos")]
 
+use mur_agent_gui_lib::send::ShareKind;
+use mur_agent_gui_lib::send::services::{ServicesProvider, extract_payload_from_pasteboard};
+use mur_agent_gui_lib::send::services::test_helpers::{
+    empty_pasteboard, pasteboard_with_image, pasteboard_with_text,
+};
+
 #[test]
 fn services_module_compiles_on_macos() {
     // The type only exists on macOS; this test asserts the module is
-    // wired up and the objc2 deps resolve. No runtime behavior yet —
-    // pasteboard decoding lands in M-c3.3.2.
-    let _ = std::any::TypeId::of::<mur_agent_gui_lib::send::services::ServicesProvider>();
+    // wired up and the objc2 deps resolve.
+    let _ = std::any::TypeId::of::<ServicesProvider>();
+}
+
+#[test]
+fn pasteboard_text_extraction_yields_text_payload() {
+    let pb = pasteboard_with_text("from-services");
+    let p = extract_payload_from_pasteboard(&pb).unwrap();
+    assert_eq!(p.source, "services");
+    match p.kind {
+        ShareKind::Text(t) => assert_eq!(t, "from-services"),
+        other => panic!("expected ShareKind::Text, got {other:?}"),
+    }
+}
+
+#[test]
+fn pasteboard_url_text_classifies_as_url() {
+    let pb = pasteboard_with_text("https://example.com/post/9");
+    let p = extract_payload_from_pasteboard(&pb).unwrap();
+    match p.kind {
+        ShareKind::Url(u) => assert_eq!(u, "https://example.com/post/9"),
+        other => panic!("expected ShareKind::Url, got {other:?}"),
+    }
+}
+
+#[test]
+fn pasteboard_image_extraction_writes_temp_file() {
+    let bytes = std::fs::read("tests/fixtures/tiny.png").unwrap();
+    let pb = pasteboard_with_image(&bytes);
+    let p = extract_payload_from_pasteboard(&pb).unwrap();
+    let path = match p.kind {
+        ShareKind::Image(ref pp) => pp.clone(),
+        other => panic!("expected ShareKind::Image, got {other:?}"),
+    };
+    let written = std::fs::read(&path).unwrap();
+    assert_eq!(written, bytes);
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn empty_pasteboard_returns_err() {
+    let pb = empty_pasteboard();
+    let err = extract_payload_from_pasteboard(&pb).unwrap_err();
+    assert!(
+        err.to_string().contains("nothing to share"),
+        "unexpected error: {err}"
+    );
 }

--- a/mur-core/src/cmd/agent_export_gui.rs
+++ b/mur-core/src/cmd/agent_export_gui.rs
@@ -519,6 +519,30 @@ pub fn rewrite_url_scheme(tauri_conf_dir: &Path, slug: &str) -> Result<()> {
     Ok(())
 }
 
+/// Track C3 / M-c3.3.3 — substitute `{{AGENT_DISPLAY}}` in
+/// `Info.plist.template` and write the result back to `Info.plist`
+/// in the same directory.
+///
+/// `slug` is currently unused (Apple's `NSServices` array doesn't carry
+/// the kebab-case slug; menu titles + `NSPortName` use the human display
+/// name). It's wired through anyway so callers can match the
+/// `rewrite_url_scheme(slug)` signature and so future template fields
+/// (e.g. dock-drop UTI suffixes) can opt in without a signature break.
+///
+/// The output filename intentionally drops the `.template` suffix —
+/// `bundle.macOS.infoPlist` in `tauri.conf.json` is expected to point
+/// at `Info.plist` (the rendered file), not `Info.plist.template`.
+#[allow(dead_code)] // Reached only by `tests/agent_export_gui_nsservices.rs`.
+pub fn rewrite_nsservices(tauri_conf_dir: &Path, _slug: &str, display: &str) -> Result<()> {
+    let template = tauri_conf_dir.join("Info.plist.template");
+    let raw = std::fs::read_to_string(&template)
+        .with_context(|| format!("read {}", template.display()))?;
+    let rendered = raw.replace("{{AGENT_DISPLAY}}", display);
+    let out = tauri_conf_dir.join("Info.plist");
+    std::fs::write(&out, rendered).with_context(|| format!("write {}", out.display()))?;
+    Ok(())
+}
+
 /// Restore the pristine tauri.conf.json after the build (called from
 /// phase_13 success path AND from any failure; idempotent).
 fn restore_tauri_conf() -> Result<()> {

--- a/mur-core/tests/agent_export_gui_nsservices.rs
+++ b/mur-core/tests/agent_export_gui_nsservices.rs
@@ -1,0 +1,59 @@
+//! Track C3 / M-c3.3.3 — verify `rewrite_nsservices` substitutes the
+//! per-agent display name into `Info.plist.template` and writes the
+//! rendered `Info.plist` next to it. The bundle pipeline (Tauri 2's
+//! `bundle.macOS.infoPlist`) merges that file into the final
+//! `MyAgent.app/Contents/Info.plist`.
+
+use mur_core::cmd::agent_export_gui::rewrite_nsservices;
+
+const TEMPLATE: &str =
+    include_str!("../../mur-agent-gui/src-tauri/Info.plist.template");
+
+#[test]
+fn rewrite_injects_three_nsservices_entries() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("Info.plist.template"), TEMPLATE).unwrap();
+    rewrite_nsservices(tmp.path(), "coach", "Coach").unwrap();
+
+    let raw = std::fs::read_to_string(tmp.path().join("Info.plist")).unwrap();
+    assert!(raw.contains("Send Selection to Coach"));
+    assert!(raw.contains("Send Link to Coach"));
+    assert!(raw.contains("Send Image to Coach"));
+    assert!(raw.contains("<key>NSServices</key>"));
+
+    // Each entry must declare NSMessage = serviceShare so AppKit
+    // dispatches all three menu items to the same selector body.
+    let count = raw.matches("<string>serviceShare</string>").count();
+    assert_eq!(count, 3, "expected exactly 3 serviceShare bindings");
+}
+
+#[test]
+fn rewrite_substitutes_display_name_in_port_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("Info.plist.template"), TEMPLATE).unwrap();
+    rewrite_nsservices(tmp.path(), "draft-bot", "Draft Bot").unwrap();
+
+    let raw = std::fs::read_to_string(tmp.path().join("Info.plist")).unwrap();
+    // NSPortName must carry the display name verbatim — AppKit looks
+    // it up to address the running provider.
+    assert!(
+        raw.contains("<key>NSPortName</key>\n            <string>Draft Bot</string>"),
+        "expected NSPortName=Draft Bot, got:\n{raw}",
+    );
+    // Template token must be fully substituted.
+    assert!(
+        !raw.contains("{{AGENT_DISPLAY}}"),
+        "rendered Info.plist still contains a template token"
+    );
+}
+
+#[test]
+fn rewrite_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("Info.plist.template"), TEMPLATE).unwrap();
+    rewrite_nsservices(tmp.path(), "coach", "Coach").unwrap();
+    rewrite_nsservices(tmp.path(), "coach", "Coach").unwrap();
+    let raw = std::fs::read_to_string(tmp.path().join("Info.plist")).unwrap();
+    let count = raw.matches("Send Selection to Coach").count();
+    assert_eq!(count, 1, "running rewrite twice must not duplicate entries");
+}


### PR DESCRIPTION
## Summary

Adds Track C3 channel C (macOS Services menu) — third of the four send-from-any-app channels. Stacked on **#147** (M-c3.2 hotkey).

When the user picks `Send Selection to <Agent>` / `Send Link to <Agent>` / `Send Image to <Agent>` from any app's Services submenu (Bear, Drafts, Mail, Safari, Things…), AppKit calls our `serviceShare:` selector. The selector decodes `NSPasteboard` and produces a `SharePayload` that flows through the same ingestor as the URL-scheme + hotkey channels — and therefore through the same B0 `<untrusted_share>` wrapping + Rule-4 cooldown that landed in M-c3.0.

This PR is **harness-only**. Production wiring (`NSApplication.setServicesProvider:` from `lib.rs::setup` + the `bundle.macOS.infoPlist` field in `tauri.conf.json` pointing at the rendered `Info.plist`) lands in a follow-up so we can iterate on the pasteboard decoder + Info.plist template against unit tests, without spinning up a real Cocoa runtime per iteration.

The whole channel is gated `#[cfg(target_os = "macos")]`. Linux/Windows builds compile a no-op stub.

## Milestones

- **M-c3.3.1** — `objc2` 0.6 + `objc2-app-kit` 0.3 + `objc2-foundation` 0.3 deps under `[target.'cfg(target_os = \"macos\")'.dependencies]` (versions pinned to match the ones already pulled in transitively via tauri 2 / arboard / muda / global-hotkey — mixing major versions yields confusing trait-bound errors). \`ServicesProvider\` placeholder type compiles.
- **M-c3.3.2** — \`extract_payload_from_pasteboard(&NSPasteboard) -> SharePayload\`:
  - \`NSPasteboardTypeString\` starting with \`http(s)://\` → \`ShareKind::Url\`
  - other text → \`ShareKind::Text\`
  - \`NSPasteboardTypePNG\` bytes → persisted temp PNG → \`ShareKind::Image\`
  - empty → \`bail!(\"nothing to share\")\`

  \`#[doc(hidden)]\` \`test_helpers\` module exposes \`pasteboard_with_text\` / \`pasteboard_with_image\` / \`empty_pasteboard\`, each building a private \`pasteboardWithUniqueName\` so tests don't pollute the user's general pasteboard.
- **M-c3.3.3** — \`Info.plist.template\` ships three NSServices entries (text selection / link / image), each routing to the same \`serviceShare\` selector, with menu titles + \`NSPortName\` parameterized on \`{{AGENT_DISPLAY}}\`. \`mur_core::cmd::agent_export_gui::rewrite_nsservices(dir, slug, display)\` substitutes the token and writes the rendered \`Info.plist\` next to the template.
- **M-c3.3.4** — \`MockApp::invoke_services_selector(&NSPasteboard)\` drives the production seam end-to-end: pasteboard decode → ingest. macOS-only.

## Test plan

- [x] \`cargo test --test send_services\` (8 tests pass on macOS: 1 type, 4 decoder, 3 E2E)
- [x] \`cargo test -p mur-core --test agent_export_gui_nsservices\` (3 tests pass: substitution, port name, idempotence)
- [x] \`cargo test --test send_hotkey --test send_url_scheme\` (no regression on stacked predecessors)
- [ ] Wire \`NSApplication.servicesProvider\` + \`bundle.macOS.infoPlist\` in a follow-up PR
- [ ] Manual: install a built agent, check that \"Send Selection to <Agent>\" appears in the Services submenu, verify it reaches the inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)