### PR TITLE
feat(gui): Track C3 — M-c3.4 drag-to-dock share channel

### DIFF
--- a/mur-agent-gui/src-tauri/src/send/dock.rs
+++ b/mur-agent-gui/src-tauri/src/send/dock.rs
@@ -1,2 +1,79 @@
 //! Track C3 channel D — macOS dock-icon drop target.
-//! Implemented in M-c3.4.
+//!
+//! When the user drags a file onto the dock icon, macOS delivers an
+//! `application:openFiles:` AppleEvent. Tauri 2 surfaces it as
+//! [`tauri::RunEvent::Opened`] with a `Vec<url::Url>` of `file://`
+//! URLs. We translate each URL to a path, run [`classify_path`] to
+//! pick a [`ShareKind`] (image vs. generic file), wrap it in a
+//! [`SharePayload`] tagged `source = "dock"`, and hand it to the
+//! [`SendIngestor`].
+//!
+//! Production wiring (`tauri::Builder::run` callback that pumps
+//! `RunEvent::Opened` through the ingestor) lands in a follow-up; the
+//! harness drives the same seam through `MockApp::simulate_opened`
+//! (M-c3.4.3).
+//!
+//! [`SendIngestor`]: super::SendIngestor
+
+#![cfg(target_os = "macos")]
+
+use std::path::Path;
+
+use super::ShareKind;
+
+/// Map a dropped path to the right [`ShareKind`] based on its
+/// extension. Image-y extensions (PNG/JPEG/GIF/WebP/HEIC/HEIF) route
+/// to [`ShareKind::Image`] so the multimodal pipeline runs OCR; every
+/// other extension (PDF, txt, md, .docx, …) goes to
+/// [`ShareKind::File`] which `process_artifact` dispatches by mime
+/// type. Extension matching is case-insensitive.
+pub fn classify_path(p: &Path) -> ShareKind {
+    let ext = p
+        .extension()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_ascii_lowercase());
+    match ext.as_deref() {
+        Some("png" | "jpg" | "jpeg" | "gif" | "webp" | "heic" | "heif") => {
+            ShareKind::Image(p.to_path_buf())
+        }
+        _ => ShareKind::File(p.to_path_buf()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn classify_png_as_image() {
+        assert!(matches!(
+            classify_path(&PathBuf::from("/tmp/foo.png")),
+            ShareKind::Image(_)
+        ));
+    }
+
+    #[test]
+    fn classify_pdf_as_file() {
+        assert!(matches!(
+            classify_path(&PathBuf::from("/tmp/foo.pdf")),
+            ShareKind::File(_)
+        ));
+    }
+
+    #[test]
+    fn classify_uppercase_extension_is_case_insensitive() {
+        assert!(matches!(
+            classify_path(&PathBuf::from("/tmp/SCREENSHOT.JPEG")),
+            ShareKind::Image(_)
+        ));
+    }
+
+    #[test]
+    fn classify_no_extension_falls_back_to_file() {
+        assert!(matches!(
+            classify_path(&PathBuf::from("/tmp/README")),
+            ShareKind::File(_)
+        ));
+    }
+}

--- a/mur-agent-gui/src-tauri/src/test_harness.rs
+++ b/mur-agent-gui/src-tauri/src/test_harness.rs
@@ -134,6 +134,29 @@ impl MockApp {
         self.ingestor.ingest(payload).await
     }
 
+    /// Drive the dock-drop path. Synthesizes the same per-URL
+    /// classification + ingest loop the production
+    /// `tauri::RunEvent::Opened { urls }` callback will use once
+    /// `lib.rs::setup` wires it up. Available only on macOS because
+    /// the dock-icon drop event is Cocoa-only.
+    ///
+    /// Each path goes through `dock::classify_path` independently so
+    /// dragging a multi-selection (e.g. `["screenshot.png",
+    /// "notes.pdf"]`) lands two separate payloads in the ingestor.
+    #[cfg(target_os = "macos")]
+    pub async fn simulate_opened(&self, paths: &[std::path::PathBuf]) -> anyhow::Result<()> {
+        for path in paths {
+            let kind = crate::send::dock::classify_path(path);
+            let payload = SharePayload {
+                source: "dock".into(),
+                kind,
+                metadata: serde_json::json!({}),
+            };
+            self.ingestor.ingest(payload).await?;
+        }
+        Ok(())
+    }
+
     /// Snapshot the recorded payloads. Returns an owned clone so
     /// callers can iterate without holding the mutex.
     pub fn captured_payloads(&self) -> Vec<SharePayload> {

--- a/mur-agent-gui/src-tauri/tauri.conf.json
+++ b/mur-agent-gui/src-tauri/tauri.conf.json
@@ -56,6 +56,14 @@
       "themes/**/*",
       "Resources/PrivacyInfo.xcprivacy"
     ],
+    "fileAssociations": [
+      { "name": "text", "ext": ["txt", "md"], "role": "Viewer" },
+      { "name": "url", "ext": ["webloc"], "role": "Viewer" },
+      { "name": "image", "ext": ["png", "jpg", "jpeg", "gif", "webp"], "role": "Viewer" },
+      { "name": "png", "ext": ["png"], "role": "Viewer" },
+      { "name": "jpeg", "ext": ["jpg", "jpeg"], "role": "Viewer" },
+      { "name": "pdf", "ext": ["pdf"], "role": "Viewer" }
+    ],
     "macOS": {
       "minimumSystemVersion": "12.0",
       "entitlements": "entitlements.plist",

--- a/mur-agent-gui/src-tauri/tests/send_dock.rs
+++ b/mur-agent-gui/src-tauri/tests/send_dock.rs
@@ -1,0 +1,37 @@
+//! Track C3 — M-c3.4 drag-to-dock channel tests.
+//!
+//! Layered like the previous channel suites:
+//! - M-c3.4.1: `tauri.conf.json` declares `fileAssociations` for
+//!   text/url/image/pdf so the dock icon highlights for the right
+//!   kinds.
+//! - M-c3.4.2: pure `classify_path(&Path)` routes file extensions to
+//!   `ShareKind::Image` vs `ShareKind::File`.
+//! - M-c3.4.3: end-to-end via `MockApp::simulate_opened` — a synthetic
+//!   `RunEvent::Opened { urls }` reaches the ingestor as a sequence of
+//!   `SharePayload`s with `source = "dock"`.
+
+#[test]
+fn file_associations_cover_text_url_image_pdf() {
+    let raw = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json"),
+    )
+    .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    // Tauri 2 mounts `fileAssociations` at the top level of `bundle`,
+    // not under `bundle.macOS`. The bundle pipeline still emits the
+    // matching macOS Info.plist `CFBundleDocumentTypes` from this list.
+    let assocs = v
+        .pointer("/bundle/fileAssociations")
+        .and_then(|x| x.as_array())
+        .expect("bundle.fileAssociations must be present");
+    let names: Vec<String> = assocs
+        .iter()
+        .filter_map(|a| a.get("name").and_then(|n| n.as_str().map(String::from)))
+        .collect();
+    for want in ["text", "url", "image", "png", "jpeg", "pdf"] {
+        assert!(
+            names.iter().any(|n| n == want),
+            "missing fileAssociation for {want} (saw {names:?})"
+        );
+    }
+}

--- a/mur-agent-gui/src-tauri/tests/send_dock.rs
+++ b/mur-agent-gui/src-tauri/tests/send_dock.rs
@@ -10,6 +10,31 @@
 //!   `RunEvent::Opened { urls }` reaches the ingestor as a sequence of
 //!   `SharePayload`s with `source = "dock"`.
 
+#[cfg(target_os = "macos")]
+#[test]
+fn classify_path_routes_extensions_correctly() {
+    use mur_agent_gui_lib::send::ShareKind;
+    use mur_agent_gui_lib::send::dock::classify_path;
+    use std::path::PathBuf;
+
+    assert!(matches!(
+        classify_path(&PathBuf::from("/tmp/a.png")),
+        ShareKind::Image(_)
+    ));
+    assert!(matches!(
+        classify_path(&PathBuf::from("/tmp/a.txt")),
+        ShareKind::File(_)
+    ));
+    assert!(matches!(
+        classify_path(&PathBuf::from("/tmp/a.pdf")),
+        ShareKind::File(_)
+    ));
+    assert!(matches!(
+        classify_path(&PathBuf::from("/tmp/Photo.HEIC")),
+        ShareKind::Image(_)
+    ));
+}
+
 #[test]
 fn file_associations_cover_text_url_image_pdf() {
     let raw = std::fs::read_to_string(

--- a/mur-agent-gui/src-tauri/tests/send_dock.rs
+++ b/mur-agent-gui/src-tauri/tests/send_dock.rs
@@ -11,10 +11,15 @@
 //!   `SharePayload`s with `source = "dock"`.
 
 #[cfg(target_os = "macos")]
+use mur_agent_gui_lib::send::ShareKind;
+#[cfg(target_os = "macos")]
+use mur_agent_gui_lib::send::dock::classify_path;
+#[cfg(target_os = "macos")]
+use mur_agent_gui_lib::test_harness::MockApp;
+
+#[cfg(target_os = "macos")]
 #[test]
 fn classify_path_routes_extensions_correctly() {
-    use mur_agent_gui_lib::send::ShareKind;
-    use mur_agent_gui_lib::send::dock::classify_path;
     use std::path::PathBuf;
 
     assert!(matches!(
@@ -33,6 +38,47 @@ fn classify_path_routes_extensions_correctly() {
         classify_path(&PathBuf::from("/tmp/Photo.HEIC")),
         ShareKind::Image(_)
     ));
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn opened_event_routes_each_url_through_ingestor() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = MockApp::new(tmp.path(), "coach");
+
+    let p1 = tmp.path().join("a.png");
+    let p2 = tmp.path().join("b.txt");
+    let p3 = tmp.path().join("c.pdf");
+    std::fs::write(&p1, b"\x89PNG\r\n\x1a\n").unwrap();
+    std::fs::write(&p2, b"hi").unwrap();
+    std::fs::write(&p3, b"%PDF-1.4").unwrap();
+
+    app.simulate_opened(&[p1.clone(), p2.clone(), p3.clone()])
+        .await
+        .unwrap();
+
+    let captured = app.captured_payloads();
+    assert_eq!(captured.len(), 3, "three drops → three ingest calls");
+    for p in &captured {
+        assert_eq!(p.source, "dock");
+    }
+    assert!(matches!(captured[0].kind, ShareKind::Image(_)));
+    assert!(matches!(captured[1].kind, ShareKind::File(_)));
+    assert!(matches!(captured[2].kind, ShareKind::File(_)));
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn opened_event_with_empty_url_list_is_a_noop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = MockApp::new(tmp.path(), "coach");
+
+    app.simulate_opened(&[]).await.unwrap();
+
+    assert!(
+        app.captured_payloads().is_empty(),
+        "empty drag must not synthesize phantom payloads"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds Track C3 channel D (drag-to-dock) — the **fourth and final** send-from-any-app channel. Stacked on **#148** (M-c3.3 Services menu).

When the user drags one or more files onto the dock icon, macOS delivers `application:openFiles:` and Tauri 2 surfaces it as `RunEvent::Opened { urls: Vec<url::Url> }`. We classify each path by extension and pump it through the same ingestor as the other three channels — and therefore through the same B0 `<untrusted_share>` wrapping + Rule-4 cooldown that landed in M-c3.0.

This PR is **harness-only**. Production wiring (the `tauri::Builder::run` callback that pumps `RunEvent::Opened` through the ingestor) lands in a follow-up so we can iterate on `classify_path` + the dock-drop seam against unit tests, without spinning up a real Tauri app per iteration.

The whole channel is gated `#[cfg(target_os = "macos")]`. Linux/Windows builds don't see `dock.rs` or the `simulate_opened` harness method.

## Milestones

- **M-c3.4.1** — `bundle.fileAssociations` declares six associations (text / url / image / png / jpeg / pdf) so the dock icon highlights for the right kinds. Tauri 2 mounts this at the top level of `bundle`, NOT under `bundle.macOS` (same trap as `bundle.macOS.urlSchemes` in M-c3.1.1).
- **M-c3.4.2** — `classify_path(&Path) -> ShareKind`:
  - `png / jpg / jpeg / gif / webp / heic / heif` → `ShareKind::Image`
  - everything else → `ShareKind::File`
  - case-insensitive (handles `SCREENSHOT.PNG` / `Photo.HEIC`)
- **M-c3.4.3** — `MockApp::simulate_opened(&[PathBuf])` drives the production seam: per-URL classify → ingest. Each path classified independently so multi-selection lands as multiple payloads.

## Track C3 status — all 4 channels harness-covered

| Channel | PR | Tests |
|---|---|---|
| A — `muragent-<slug>://` URL scheme | #146 | 10 (parser + E2E) |
| B — `Cmd+Shift+M+<X>` hotkey | #147 | 10 (combo + clipboard + E2E) |
| C — macOS Services menu | #148 | 8 (decoder + Info.plist + E2E) |
| D — drag-to-dock | **this PR** | 4 + 4 inline (associations + classify + E2E) |

Production wiring (lib.rs::setup hooks for hotkey, Services provider, RunEvent::Opened callback; tauri.conf.json `bundle.macOS.infoPlist`) lands as a separate follow-up PR.

## Test plan

- [x] `cargo test --test send_dock` (4 tests pass: 1 fileAssociations, 1 classify, 2 E2E)
- [x] `cargo test --lib send::dock` (4 inline classify_path tests)
- [x] Sibling channel suites still green (`send_hotkey` / `send_url_scheme` / `send_services`)
- [ ] Wire `RunEvent::Opened` in `lib.rs::setup` in a follow-up PR
- [ ] Manual: drag a `.png` / `.pdf` / `.txt` onto a built agent's dock icon, verify all three reach the inbox with correct ShareKind

🤖 Generated with [Claude Code](https://claude.com/claude-code)