### PR TITLE
feat(ui): Track C3 — M-c3.5 React composer + ShareBadge

### DIFF
--- a/mur-agent-gui/ui/src/components/ShareBadge.test.tsx
+++ b/mur-agent-gui/ui/src/components/ShareBadge.test.tsx
@@ -1,0 +1,91 @@
+// Vitest doesn't ship a DOM by default and we don't want to pull in
+// @testing-library/react + jsdom just to assert that a label renders
+// — `renderToStaticMarkup` produces deterministic HTML that we can
+// substring-check against, which is exactly what these tests need.
+
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ShareBadge } from "./ShareBadge";
+
+describe("ShareBadge", () => {
+    it("renders the URL-scheme label", () => {
+        const html = renderToStaticMarkup(
+            <ShareBadge
+                source="url_scheme"
+                kindLabel="text"
+                detail="muragent-coach://share?text=..."
+            />,
+        );
+        expect(html).toContain("Shared via URL scheme");
+        expect(html).toContain("text");
+    });
+
+    it("renders the hotkey label", () => {
+        const html = renderToStaticMarkup(
+            <ShareBadge
+                source="hotkey"
+                kindLabel="text"
+                detail="Cmd+Shift+M+C"
+            />,
+        );
+        expect(html).toContain("Shared via hotkey");
+    });
+
+    it("renders the Services label", () => {
+        const html = renderToStaticMarkup(
+            <ShareBadge source="services" kindLabel="image" />,
+        );
+        expect(html).toContain("Shared via Services menu");
+    });
+
+    it("renders the dock-drop label", () => {
+        const html = renderToStaticMarkup(
+            <ShareBadge source="dock" kindLabel="file" />,
+        );
+        expect(html).toContain("Shared by dropping on dock");
+    });
+
+    it("falls back to a generic label for unknown sources", () => {
+        // Defensive: if the Rust side ever emits a new channel we
+        // haven't mapped yet, the badge still renders something
+        // sensible instead of "undefined".
+        const html = renderToStaticMarkup(
+            <ShareBadge source="future_channel" kindLabel="text" />,
+        );
+        expect(html).toContain("Shared via future_channel");
+    });
+
+    it("expandable accordion shows raw source detail", () => {
+        const html = renderToStaticMarkup(
+            <ShareBadge
+                source="hotkey"
+                kindLabel="text"
+                detail="Cmd+Shift+M+C"
+            />,
+        );
+        expect(html).toContain("<details");
+        expect(html).toContain("Where this came from");
+        expect(html).toContain("Cmd+Shift+M+C");
+    });
+
+    it("omits the accordion when no detail is supplied", () => {
+        // No detail → no accordion. Avoids rendering an empty
+        // collapsible that's confusing to click on.
+        const html = renderToStaticMarkup(
+            <ShareBadge source="hotkey" kindLabel="text" />,
+        );
+        expect(html).not.toContain("<details");
+        expect(html).not.toContain("Where this came from");
+    });
+
+    it("uses an amber border + background for trust nudging", () => {
+        // The visual treatment matches the B0 `<untrusted_share>`
+        // wrapping; tests pin the Tailwind classes so a future
+        // theme refactor can't silently downgrade the warning.
+        const html = renderToStaticMarkup(
+            <ShareBadge source="url_scheme" kindLabel="text" />,
+        );
+        expect(html).toContain("border-amber-400");
+        expect(html).toContain("bg-amber-50/40");
+    });
+});

--- a/mur-agent-gui/ui/src/components/ShareBadge.tsx
+++ b/mur-agent-gui/ui/src/components/ShareBadge.tsx
@@ -1,0 +1,59 @@
+// Track C3 / M-c3.5.2 — visual treatment for shared content.
+//
+// Rendered next to a composer entry whenever a Track C3 channel
+// (URL scheme / hotkey / Services menu / dock-drop) injected the
+// content. The amber border-l + soft amber background nudges the
+// user that this came from outside the agent's normal trust
+// boundary — same visual language the B0 hook applies in the
+// `<untrusted_share>` tag.
+//
+// The expandable `<details>` accordion shows raw provenance
+// ("where this came from") so a user can audit in the rare case
+// they're suspicious about a payload — e.g. a URL that doesn't
+// match what they thought they were sharing.
+
+import type { ReactElement } from "react";
+
+const CHANNEL_LABELS: Record<string, string> = {
+    url_scheme: "Shared via URL scheme",
+    hotkey: "Shared via hotkey",
+    services: "Shared via Services menu",
+    dock: "Shared by dropping on dock",
+};
+
+export interface ShareBadgeProps {
+    source: string;
+    kindLabel: string;
+    detail?: string;
+}
+
+export function ShareBadge({
+    source,
+    kindLabel,
+    detail,
+}: ShareBadgeProps): ReactElement {
+    const label = CHANNEL_LABELS[source] ?? `Shared via ${source}`;
+    return (
+        <div
+            data-testid="share-badge"
+            data-source={source}
+            data-kind={kindLabel}
+            className="border-l-4 border-amber-400 bg-amber-50/40 px-3 py-2 text-sm"
+        >
+            <div className="font-medium text-amber-900">{label}</div>
+            <div className="text-xs uppercase tracking-wide text-amber-700">
+                {kindLabel}
+            </div>
+            {detail !== undefined && (
+                <details className="mt-1 text-xs text-amber-800">
+                    <summary className="cursor-pointer select-none">
+                        Where this came from
+                    </summary>
+                    <pre className="mt-1 whitespace-pre-wrap break-all font-mono">
+                        {detail}
+                    </pre>
+                </details>
+            )}
+        </div>
+    );
+}

--- a/mur-agent-gui/ui/src/components/ShareComposerView.test.tsx
+++ b/mur-agent-gui/ui/src/components/ShareComposerView.test.tsx
@@ -1,0 +1,84 @@
+// Integration coverage for the M-c3.5.1 share handler + M-c3.5.2
+// ShareBadge together. Stubs a `ComposerHandle` whose mutators
+// drive a `ShareDraft` state, runs `handleShareReceived` against
+// it, and snapshots the rendered HTML.
+//
+// Avoids Playwright (the plan's original choice) so the harness
+// stays in vitest — same posture as every other "Tauri-shaped
+// surface, lib only" milestone in this PR series. Real
+// browser-driven snapshots land alongside the production wiring
+// follow-up.
+
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+    handleShareReceived,
+    type ComposerHandle,
+    type SharePayload,
+} from "../lib/share";
+import {
+    ShareComposerView,
+    type ShareDraft,
+} from "./ShareComposerView";
+
+function draftDrivenComposer(): { composer: ComposerHandle; draft: ShareDraft } {
+    const draft: ShareDraft = { badge: null, body: "" };
+    const composer: ComposerHandle = {
+        insert: (text) => {
+            draft.body = draft.body + text;
+        },
+        addBadge: (b) => {
+            draft.badge = { ...b };
+        },
+        attachFile: (path, kindLabel) => {
+            draft.attachment = { path, kindLabel };
+        },
+    };
+    return { composer, draft };
+}
+
+describe("ShareComposerView + handleShareReceived", () => {
+    it("renders share badge + body for a URL-scheme text share", () => {
+        const { composer, draft } = draftDrivenComposer();
+        const payload: SharePayload = {
+            source: "url_scheme",
+            kind: { kind: "text", value: "hello from URL scheme" },
+            metadata: {},
+        };
+        handleShareReceived(payload, composer);
+
+        const html = renderToStaticMarkup(<ShareComposerView draft={draft} />);
+        expect(html).toContain("Shared via URL scheme");
+        expect(html).toContain("hello from URL scheme");
+        // No attachment chip for plain text.
+        expect(html).not.toContain("share-attachment");
+    });
+
+    it("renders the dock-drop label for image attachments", () => {
+        const { composer, draft } = draftDrivenComposer();
+        const payload: SharePayload = {
+            source: "dock",
+            kind: { kind: "image", value: "/tmp/screenshot.png" },
+            metadata: {},
+        };
+        handleShareReceived(payload, composer);
+
+        const html = renderToStaticMarkup(<ShareComposerView draft={draft} />);
+        expect(html).toContain("Shared by dropping on dock");
+        // Attachment chip rendered with the path.
+        expect(html).toContain("share-attachment");
+        expect(html).toContain("/tmp/screenshot.png");
+        // No body insert for image shares.
+        const bodyMatch = html.match(/data-testid="share-body"[^>]*>([^<]*)</);
+        expect(bodyMatch?.[1]).toBe("");
+    });
+
+    it("renders no badge when the draft is empty", () => {
+        // Sanity check — ShareComposerView used outside the
+        // share-handler path renders just the body.
+        const empty: ShareDraft = { badge: null, body: "regular message" };
+        const html = renderToStaticMarkup(<ShareComposerView draft={empty} />);
+        expect(html).not.toContain("share-badge");
+        expect(html).toContain("regular message");
+    });
+});

--- a/mur-agent-gui/ui/src/components/ShareComposerView.tsx
+++ b/mur-agent-gui/ui/src/components/ShareComposerView.tsx
@@ -1,0 +1,51 @@
+// Track C3 / M-c3.5.3 — composer wrapper that renders the
+// `ShareBadge` whenever a Track C3 share landed in the active draft.
+//
+// Production composer (in `tabs/Chat.tsx` or wherever the chat tab
+// finally lives) will mount this internally; for now the component
+// is a thin presentational wrapper so the integration test can
+// snapshot the badge + body together without spinning up Playwright.
+
+import type { ReactElement } from "react";
+import { ShareBadge } from "./ShareBadge";
+
+export interface ShareDraft {
+    /// `null` when no Track C3 share is attached to the current draft.
+    badge: { source: string; kindLabel: string; detail?: string } | null;
+    body: string;
+    /// Optional file ref for image / file shares. Rendered as a chip
+    /// next to the body so users can confirm what they're about to send.
+    attachment?: { path: string; kindLabel: string };
+}
+
+export interface ShareComposerViewProps {
+    draft: ShareDraft;
+}
+
+export function ShareComposerView({
+    draft,
+}: ShareComposerViewProps): ReactElement {
+    return (
+        <div data-testid="share-composer" className="flex flex-col gap-2">
+            {draft.badge && (
+                <ShareBadge
+                    source={draft.badge.source}
+                    kindLabel={draft.badge.kindLabel}
+                    detail={draft.badge.detail}
+                />
+            )}
+            {draft.attachment && (
+                <div
+                    data-testid="share-attachment"
+                    data-path={draft.attachment.path}
+                    className="rounded border border-stone-300 bg-stone-50 px-2 py-1 text-xs"
+                >
+                    📎 {draft.attachment.path} ({draft.attachment.kindLabel})
+                </div>
+            )}
+            <div data-testid="share-body" className="whitespace-pre-wrap">
+                {draft.body}
+            </div>
+        </div>
+    );
+}

--- a/mur-agent-gui/ui/src/lib/share.test.ts
+++ b/mur-agent-gui/ui/src/lib/share.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleShareReceived } from "./share";
+
+describe("handleShareReceived", () => {
+    it("inserts text into composer with badge", () => {
+        const composer = { insert: vi.fn(), addBadge: vi.fn() };
+        handleShareReceived(
+            {
+                source: "url_scheme",
+                kind: { kind: "text", value: "hello" },
+                metadata: {},
+            },
+            composer,
+        );
+        expect(composer.insert).toHaveBeenCalledWith("hello");
+        expect(composer.addBadge).toHaveBeenCalledWith({
+            source: "url_scheme",
+            kindLabel: "text",
+        });
+    });
+
+    it("inserts url with link treatment", () => {
+        const composer = { insert: vi.fn(), addBadge: vi.fn() };
+        handleShareReceived(
+            {
+                source: "hotkey",
+                kind: { kind: "url", value: "https://x.com" },
+                metadata: {},
+            },
+            composer,
+        );
+        expect(composer.insert).toHaveBeenCalledWith("https://x.com");
+        expect(composer.addBadge).toHaveBeenCalledWith({
+            source: "hotkey",
+            kindLabel: "url",
+        });
+    });
+
+    it("attaches image with file ref", () => {
+        const composer = {
+            insert: vi.fn(),
+            addBadge: vi.fn(),
+            attachFile: vi.fn(),
+        };
+        handleShareReceived(
+            {
+                source: "dock",
+                kind: { kind: "image", value: "/tmp/a.png" },
+                metadata: {},
+            },
+            composer,
+        );
+        expect(composer.attachFile).toHaveBeenCalledWith("/tmp/a.png", "image");
+        expect(composer.addBadge).toHaveBeenCalledWith({
+            source: "dock",
+            kindLabel: "image",
+        });
+        // File refs do NOT also call insert — that would double-render
+        // the path as both a chip and inline text.
+        expect(composer.insert).not.toHaveBeenCalled();
+    });
+
+    it("attaches file with file ref", () => {
+        const composer = {
+            insert: vi.fn(),
+            addBadge: vi.fn(),
+            attachFile: vi.fn(),
+        };
+        handleShareReceived(
+            {
+                source: "services",
+                kind: { kind: "file", value: "/tmp/notes.pdf" },
+                metadata: {},
+            },
+            composer,
+        );
+        expect(composer.attachFile).toHaveBeenCalledWith(
+            "/tmp/notes.pdf",
+            "file",
+        );
+    });
+
+    it("missing attachFile is a soft no-op for image/file payloads", () => {
+        // Composer that only knows about text — share handler must not
+        // throw when it sees an image; the badge alone is still useful.
+        const composer = { insert: vi.fn(), addBadge: vi.fn() };
+        expect(() =>
+            handleShareReceived(
+                {
+                    source: "dock",
+                    kind: { kind: "image", value: "/tmp/a.png" },
+                    metadata: {},
+                },
+                composer,
+            ),
+        ).not.toThrow();
+        expect(composer.addBadge).toHaveBeenCalled();
+    });
+});

--- a/mur-agent-gui/ui/src/lib/share.ts
+++ b/mur-agent-gui/ui/src/lib/share.ts
@@ -1,0 +1,68 @@
+// Track C3 / M-c3.5.1 — Tauri share-event listener.
+//
+// The Rust side emits a `share:received` event from `DefaultIngestor`
+// (mur-agent-gui/src-tauri/src/send/mod.rs) once a shared payload has
+// been routed through the multimodal pipeline. The composer UI calls
+// `startShareListener` at mount; each event resolves to a
+// `SharePayload` that we hand to `handleShareReceived`, which pushes
+// the body into the active composer and tags it with a `ShareBadge`
+// so the user knows where the content came from.
+//
+// `ComposerHandle` is intentionally minimal — the real composer is
+// owned by the chat tab (M-c3.5.2 wires it up). Tests pass `vi.fn()`
+// stubs so we can assert on the calls without rendering anything.
+
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+// Wire-shape mirrors `mur_agent_gui_lib::send::ShareKind` (see
+// `src-tauri/src/send/mod.rs`). Tagged-union `kind`/`value` matches
+// `#[serde(rename_all = "snake_case", tag = "kind", content = "value")]`.
+export type ShareKind =
+    | { kind: "text"; value: string }
+    | { kind: "url"; value: string }
+    | { kind: "image"; value: string }
+    | { kind: "file"; value: string };
+
+export interface SharePayload {
+    source: string;
+    kind: ShareKind;
+    metadata: Record<string, unknown>;
+}
+
+// The composer surface the share handler talks to. Defined as an
+// interface (not a class) so the chat tab and unit tests can each
+// supply their own implementation without a shared base type.
+export interface ComposerHandle {
+    insert(text: string): void;
+    addBadge(b: { source: string; kindLabel: string }): void;
+    attachFile?(path: string, kindLabel: string): void;
+}
+
+// Pure routing logic — extracted so it can be unit-tested without
+// touching `@tauri-apps/api/event`. `startShareListener` is the thin
+// wrapper that wires this to the actual event bus.
+export function handleShareReceived(p: SharePayload, composer: ComposerHandle) {
+    const kindLabel = p.kind.kind;
+    composer.addBadge({ source: p.source, kindLabel });
+    switch (p.kind.kind) {
+        case "text":
+        case "url":
+            composer.insert(p.kind.value);
+            break;
+        case "image":
+        case "file":
+            composer.attachFile?.(p.kind.value, kindLabel);
+            break;
+    }
+}
+
+// Subscribe to `share:received`. Caller must invoke the returned
+// `UnlistenFn` on unmount to avoid duplicate handlers when the
+// composer remounts (e.g. tab switch).
+export async function startShareListener(
+    composer: ComposerHandle,
+): Promise<UnlistenFn> {
+    return listen<SharePayload>("share:received", (e) =>
+        handleShareReceived(e.payload, composer),
+    );
+}


### PR DESCRIPTION
## Summary

Adds the React-side counterpart to the four Track C3 share channels. Stacked on **#149** (M-c3.4 dock).

The Rust ingestor emits a `share:received` Tauri event after wrapping payloads through B0; this PR wires React to that event:

1. `lib/share.ts` — `handleShareReceived` routes payloads into a `ComposerHandle` (text/url → insert, image/file → attachFile chip), and `startShareListener` subscribes to the event bus.
2. `components/ShareBadge.tsx` — visual treatment with amber border-l + soft amber background (mirrors B0's `<untrusted_share>` trust nudge), per-channel labels ("Shared via URL scheme" / hotkey / Services menu / dock-drop), and an optional `<details>` accordion for raw provenance.
3. `components/ShareComposerView.tsx` — thin wrapper that mounts the badge + body + attachment chip together; the integration test drives `handleShareReceived` against a draft-backed composer and snapshots the resulting HTML.

## Milestones

- **M-c3.5.1** — `share.ts` event listener. 5 vitest cases covering text/url insert, image/file attach, and the soft no-op path when a composer doesn't implement attachFile.
- **M-c3.5.2** — `ShareBadge` component. 8 vitest cases via `renderToStaticMarkup` covering the four channel labels, generic fallback for unknown sources, accordion presence/absence, and the amber Tailwind classes.
- **M-c3.5.3** — `ShareComposerView` integration. 3 vitest cases: URL-scheme text share, dock image share with attachment chip, empty draft sanity.

## Notes on test posture

The plan's original M-c3.5.3 used Playwright snapshots. This PR scopes that down to vitest + `renderToStaticMarkup` to keep the same harness-only posture as the four channel suites (M-c3.1–M-c3.4) — adding Playwright now would require browser binaries, snapshot baselines, and a separate test runner. The real browser-driven snapshots land alongside the production wiring follow-up (where the chat tab actually mounts the listener and the badge's interactive `<details>` accordion needs verifying in a live DOM).

## Test plan

- [x] `npm test -- --run` (18 tests across 4 suites: 5 share + 8 ShareBadge + 3 ShareComposerView + 2 pre-existing parseBridgeEvent)
- [x] `npx tsc -b --noEmit` (clean)
- [ ] Wire `startShareListener` in `App.tsx` mount in the production-wiring follow-up
- [ ] Manual: send a share payload via each channel, verify the badge + body render correctly in the live composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)