### PR TITLE
feat(docs,e2e): Track C3 — M-c3.6 acceptance + cookbook + §5.5 footer

### DIFF
--- a/docs/cookbook/c3-send-from-any-app.md
+++ b/docs/cookbook/c3-send-from-any-app.md
@@ -1,0 +1,93 @@
+# Send-from-any-app (Track C3)
+
+A mur agent installed on your machine ought to feel like a teammate the OS already knows — you should be able to throw text, links, screenshots, and PDFs at it from any app you happen to be in, without copy-paste-switch-paste. Track C3 wires four lightweight channels for that. Every channel produces the same `SharePayload` shape and feeds it through the existing B0 multimodal pipeline, so once a payload is in the agent it's tagged `<untrusted_share>` and the next turn's tool use is on a one-turn cooldown.
+
+This cookbook walks the four channels, the per-agent slug constraint that shapes how each channel is registered, the multi-agent escape hatch for hotkey collisions, and what's deliberately deferred to v2.
+
+## URL scheme
+
+Every exported agent registers `muragent-<slug>://share?text=…` as a deep-link scheme. Drop a link in any browser, mail client, or scripting tool that opens URLs, and macOS / Windows / Linux dispatches it to the running agent (or launches it).
+
+```
+muragent-coach://share?text=aGVsbG8gd29ybGQ&type=text
+```
+
+- `text=` is base64url (`URL_SAFE_NO_PAD`) UTF-8.
+- `type=` is `text` (default) or `url`.
+- `host` must be `share`. Anything else parses as an error and is dropped silently in production (logged as a warning).
+
+The slug comes from `mur-core::cmd::agent_export_gui::sanitize_for_bundle_id` — it's the kebab-case agent name. So an agent named `Coach Bot 1.0` registers `muragent-coach-bot-1-0://`. The expected slug is baked into the binary at export time; URLs targeting a different slug error out so a malicious page can't blast every running agent at once.
+
+The scheme is registered in `tauri.conf.json`'s `plugins.deep-link.desktop.schemes` (NOT `bundle.macOS.urlSchemes` — Tauri 2 rejects that location). The export pipeline's `phase_4_rewrite_tauri_conf` substitutes `{{AGENT_SLUG}}` with the per-agent slug before the bundle step.
+
+## Global hotkey
+
+Each agent binds `Cmd+Shift+M+<X>` (where `<X>` is the first letter of the slug, uppercased) at startup. Hit the combo and the agent reads your current clipboard, classifies the contents, and ingests:
+
+- text starting with `http(s)://` → `ShareKind::Url`
+- other text → `ShareKind::Text`
+- image bytes → persisted to a temp PNG → `ShareKind::Image`
+- empty clipboard → flashes a "nothing to share" toast (the harness errors; production turns it into a UI nudge)
+
+### Multi-agent collisions
+
+Two agents whose slugs share a first letter (`coach` and `creator`) want the same combo. The escape hatch is per-agent:
+
+```bash
+mur agent companion settings <agent> --share-hotkey "CommandOrControl+Alt+K"
+```
+
+`resolve_combo(slug, user_override)` reads `share.hotkey` from `~/.mur/agents/<name>/companion/state.yaml` and uses it verbatim when present. Validation of the combo string itself is the GUI's job before persisting; the runtime trusts whatever's in the YAML.
+
+## Services menu
+
+On macOS, the agent registers three entries in the system Services menu via Info.plist's `NSServices` array:
+
+- **Send Selection to {Agent}** — sends highlighted text from any app
+- **Send Link to {Agent}** — sends the current selection as a URL
+- **Send Image to {Agent}** — sends an image selection (e.g. from Photos, Preview)
+
+Right-click in any app, pick the Services submenu, choose the entry. The selector (`serviceShare:`) reads `NSPasteboard`, decodes the bytes (text via `NSPasteboardTypeString`, image via `NSPasteboardTypePNG`), and ingests as `source = "services"`.
+
+The three entries all dispatch to the same selector — the dispatcher decides what to do based on what's actually in the pasteboard, not which menu item the user picked. This is intentional: Apple's menu items are advisory; the pasteboard is authoritative.
+
+The Info.plist template lives at `mur-agent-gui/src-tauri/Info.plist.template` and `mur-core::cmd::agent_export_gui::rewrite_nsservices` substitutes `{{AGENT_DISPLAY}}` (the human display name, e.g. `Coach`) into the menu titles + `NSPortName` at export time.
+
+## Drag-to-dock
+
+Drag any file onto the agent's dock icon. macOS delivers `application:openFiles:`, Tauri 2 surfaces it as `RunEvent::Opened { urls }`, and we classify each path by extension:
+
+- `png / jpg / jpeg / gif / webp / heic / heif` → `ShareKind::Image` (routed through OCR)
+- everything else → `ShareKind::File` (mime-sniffed by `process_artifact`)
+
+A multi-selection lands as multiple separate `SharePayload`s in the ingestor — each one independently wrapped by B0 with the one-turn cooldown.
+
+For the dock icon to highlight on the right kinds, `bundle.fileAssociations` (top level — Tauri 2 puts this *outside* `bundle.macOS`) declares six associations: `text`, `url`, `image`, `png`, `jpeg`, `pdf`. Linux and Windows ignore the macOS specifics here, but the field is harmless.
+
+## React composer treatment
+
+The Rust side emits `share:received` after the ingestor finishes wrapping. The React composer subscribes via `startShareListener(composer)` (from `ui/src/lib/share.ts`) and renders a `ShareBadge` next to the inserted body — amber border-l + soft amber background, mirroring the `<untrusted_share>` trust nudge. Channel labels:
+
+- url_scheme → "Shared via URL scheme"
+- hotkey → "Shared via hotkey"
+- services → "Shared via Services menu"
+- dock → "Shared by dropping on dock"
+
+Click the **Where this came from** accordion to see the raw provenance (e.g. the original `muragent-coach://share?text=...` URL or the bound hotkey combo). Useful when you want to audit a payload that doesn't look quite right.
+
+## Not in v1
+
+Two things are deliberately out of scope and tracked for v2:
+
+- **Unified `mur://` scheme.** Today every agent registers its own `muragent-<slug>://` so the OS can route deep links without a picker. A single `mur://share?...` scheme + an agent picker UI is cleaner but requires a full router (or a system service) and tangles with the install / uninstall lifecycle. Per-agent schemes work today; we'll consolidate later.
+- **Share Extension (`.appex`).** macOS's modern Share menu (the iOS-style upward arrow in apps that support it) requires a true `.appex` Share Extension bundled inside the host app. That's a separate Xcode-style bundle target and signing dance; Track C3 sticks with the older Services menu (which works in every Cocoa app today) and defers the `.appex` to v2.
+
+## Acceptance
+
+Run the full harness:
+
+```bash
+bash scripts/e2e/c3-send-from-any-app.sh
+```
+
+This gates every channel's parser / decoder / classifier and the `SharePayload → SendIngestor → B0` seam. Production wiring (`lib.rs::setup` hooks for hotkey, Services provider, `RunEvent::Opened`; `App.tsx` mount of `startShareListener`) lands in a follow-up PR with its own manual native-channel QA matrix.

--- a/docs/superpowers/specs/2026-04-30-mur-agent-harness-roadmap-design.md
+++ b/docs/superpowers/specs/2026-04-30-mur-agent-harness-roadmap-design.md
@@ -603,6 +603,8 @@ All four channels feed received content into the same B0 multimodal pipeline (D3
 
 **Acceptance**: select text in Safari → right-click Services → Send to Coach → Coach.app opens, content appears in composer wrapped in `<untrusted_share>`; same flow via drag-to-dock on a screenshot file applies the full multimodal pipeline.
 
+**Status: shipped 2026-05-04** — harness coverage for all four channels + the React composer integration cascade-merged across PRs M-c3.0 → M-c3.6. `lib.rs::setup` production wiring (the actual `tauri-plugin-deep-link` / `global-shortcut` mounts, `NSApplication.servicesProvider` registration, `RunEvent::Opened` callback, and `App.tsx` mount of `startShareListener`) lands in a stacked follow-up PR with its own manual native-channel QA matrix; the cookbook at `docs/cookbook/c3-send-from-any-app.md` is authoritative for both layers. Acceptance gate: `bash scripts/e2e/c3-send-from-any-app.sh`.
+
 ### 5.6 C4-C9 (v2 Boundary)
 
 Deferred to v2 / v3 with their own specs:

--- a/mur-core/tests/verify_c3_cookbook.rs
+++ b/mur-core/tests/verify_c3_cookbook.rs
@@ -1,0 +1,54 @@
+//! Track C3 / M-c3.6.2 — gate on the cookbook covering every channel
+//! and surfacing the v1 deferral notes. Tests live in mur-core
+//! because that's where verify_*.rs siblings already are (b0,
+//! companion-gui-bridge, c1-bridge, c2-telegram); the doc itself
+//! sits in repo-root `docs/cookbook/` so the working dir resolves to
+//! the workspace root.
+
+const COOKBOOK: &str = include_str!("../../docs/cookbook/c3-send-from-any-app.md");
+
+#[test]
+fn cookbook_documents_all_four_channels() {
+    for section in ["URL scheme", "Global hotkey", "Services menu", "Drag-to-dock"] {
+        assert!(
+            COOKBOOK.contains(section),
+            "cookbook missing section: {section}"
+        );
+    }
+}
+
+#[test]
+fn cookbook_explains_per_agent_slug_constraint() {
+    // Each agent registers `muragent-<slug>://` — flag if the
+    // cookbook drifts away from documenting why the slug is
+    // per-agent (so a malicious page can't blast every running
+    // agent at once).
+    assert!(COOKBOOK.contains("muragent-<slug>"));
+}
+
+#[test]
+fn cookbook_explains_v1_deferrals() {
+    // Two specific things are out of scope for v1: a unified
+    // `mur://` scheme + an `.appex` Share Extension. Both are
+    // called out so a future contributor doesn't try to ship
+    // either of them inside this PR series.
+    assert!(COOKBOOK.contains("not in v1") || COOKBOOK.contains("Not in v1"));
+    assert!(COOKBOOK.contains(".appex"));
+}
+
+#[test]
+fn cookbook_documents_hotkey_collision_escape_hatch() {
+    // `share.hotkey` in companion state.yaml is the override.
+    // Two agents with the same first letter collide on the
+    // default combo; the escape hatch must stay documented.
+    assert!(COOKBOOK.contains("share.hotkey") || COOKBOOK.contains("share-hotkey"));
+}
+
+#[test]
+fn cookbook_references_b0_untrusted_share_wrapping() {
+    // The whole point of routing through SendIngestor is that
+    // B0 wraps the body as <untrusted_share> with a one-turn
+    // cooldown. If the cookbook stops mentioning that, a reader
+    // could (incorrectly) assume shared content is trusted.
+    assert!(COOKBOOK.contains("<untrusted_share>"));
+}

--- a/mur-core/tests/verify_c3_spec_tick.rs
+++ b/mur-core/tests/verify_c3_spec_tick.rs
@@ -1,0 +1,55 @@
+//! Track C3 / M-c3.6.3 — gate on the §5.5 acceptance footer being
+//! marked shipped in the roadmap spec. Mirrors the §5.4 spec-tick
+//! gate (verify_c2_spec_tick.rs) — same shape so a spec drift check
+//! catches both Track C2 and Track C3 the same way.
+
+const SPEC: &str = include_str!(
+    "../../docs/superpowers/specs/2026-04-30-mur-agent-harness-roadmap-design.md"
+);
+
+/// Extract the body of §5.5 — from `### 5.5` up to the next `### `
+/// header. Anchoring on the section header (not the changelog
+/// reference at line 82) keeps the test stable against future
+/// reshuffles of the changelog.
+fn section_5_5_body() -> &'static str {
+    let header = "### 5.5 C3";
+    let start = SPEC.find(header).expect("§5.5 section header missing");
+    let rest = &SPEC[start..];
+    let next_header = rest[header.len()..]
+        .find("\n### ")
+        .map(|i| i + header.len())
+        .unwrap_or(rest.len());
+    &rest[..next_header]
+}
+
+#[test]
+fn spec_section_5_5_marked_shipped() {
+    let body = section_5_5_body();
+    assert!(
+        body.contains("Status: shipped") || body.contains("[shipped 2026-05-04]"),
+        "§5.5 missing shipped marker. Body:\n{body}"
+    );
+}
+
+#[test]
+fn spec_section_5_5_dates_the_ship() {
+    let body = section_5_5_body();
+    assert!(
+        body.contains("2026-05-04"),
+        "§5.5 ship marker must carry an absolute date so future readers \
+         can tell when this landed without git archaeology"
+    );
+}
+
+#[test]
+fn spec_section_5_5_acknowledges_deferred_production_wiring() {
+    // Harness landing without lib.rs::setup wiring is the whole story
+    // of this PR series. The spec footer must not pretend it's a full
+    // ship — readers walking the spec → cookbook chain need to know
+    // there's a stacked follow-up.
+    let body = section_5_5_body();
+    assert!(
+        body.contains("follow-up") || body.contains("stacked"),
+        "§5.5 footer must call out the deferred production wiring"
+    );
+}

--- a/scripts/e2e/c3-send-from-any-app.sh
+++ b/scripts/e2e/c3-send-from-any-app.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# scripts/e2e/c3-send-from-any-app.sh — Track C3 send-from-any-app
+# acceptance.
+#
+# This PR series ships the harness for all four channels (URL scheme,
+# global hotkey, macOS Services menu, drag-to-dock) plus the React
+# composer integration. Production wiring (lib.rs::setup hooks for
+# tauri-plugin-deep-link / global-shortcut, NSApplication.servicesProvider,
+# RunEvent::Opened, App.tsx mount of startShareListener) lands in a
+# follow-up. So this script gates the harness — every channel's
+# parser / decoder / classifier and the SharePayload → SendIngestor
+# seam — rather than building a real Tauri app and driving the
+# native side. The plan's `--self-test=<mode>` binary modes ship
+# alongside production wiring.
+#
+# Acceptance gates (roadmap §5.5):
+#  1. SharePayload + ShareKind round-trip (M-c3.0.1)
+#  2. SendIngestor routes Text/Url through process_share_text and
+#     Image/File through process_artifact (M-c3.0.2)
+#  3. B0SafetyHook wraps `--- share` sidecar bodies as
+#     `<untrusted_share>` (M-c3.0.3)
+#  4. Channel A — muragent-<slug>://share?... parser (M-c3.1)
+#  5. Channel B — Cmd+Shift+M+<X> hotkey + clipboard synth (M-c3.2)
+#  6. Channel C — NSPasteboard decoder + NSServices Info.plist rewrite
+#     (M-c3.3, macOS-only)
+#  7. Channel D — RunEvent::Opened classify_path + multi-URL ingest
+#     (M-c3.4, macOS-only)
+#  8. TS share handler + ShareBadge composer integration (M-c3.5)
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+UNAME="$(uname)"
+
+echo "==> 1/8 mur-core unit + integration tests (M-c3.0 SendIngestor + B0 wrapping)"
+cargo test -p mur-agent-runtime --quiet send -- --skip companion --test-threads=1
+
+echo "==> 2/8 mur-core URL scheme injection (M-c3.1.4)"
+cargo test -p mur-core --test agent_export_gui_url_scheme --quiet
+
+if [[ "$UNAME" == "Darwin" ]]; then
+    echo "==> 3/8 mur-core NSServices Info.plist injection (M-c3.3.3, macOS)"
+    cargo test -p mur-core --test agent_export_gui_nsservices --quiet
+else
+    echo "==> 3/8 SKIP NSServices (macOS-only)"
+fi
+
+# `mur-agent-gui` is a workspace-EXCLUDED standalone crate; cd into
+# it so cargo doesn't walk past the worktree's Cargo.toml.
+cd "$REPO_ROOT/mur-agent-gui/src-tauri"
+
+echo "==> 4/8 GUI URL scheme parser + MockApp (M-c3.1)"
+cargo test --test send_url_scheme --quiet
+
+echo "==> 5/8 GUI hotkey + clipboard synth + MockApp (M-c3.2)"
+cargo test --test send_hotkey --quiet
+
+if [[ "$UNAME" == "Darwin" ]]; then
+    echo "==> 6/8 GUI NSPasteboard decoder + MockApp (M-c3.3, macOS)"
+    cargo test --test send_services --quiet
+
+    echo "==> 7/8 GUI dock classify_path + simulate_opened (M-c3.4, macOS)"
+    cargo test --test send_dock --quiet
+else
+    echo "==> 6/8 SKIP services (macOS-only)"
+    echo "==> 7/8 SKIP dock (macOS-only, also skipped on cross-platform)"
+fi
+
+cd "$REPO_ROOT/mur-agent-gui/ui"
+
+echo "==> 8/8 TS share handler + ShareBadge composer integration (M-c3.5)"
+if [[ ! -d node_modules ]]; then
+    echo "    npm ci (first run)"
+    npm ci --silent
+fi
+npm test --silent -- --run
+
+cd "$REPO_ROOT"
+echo
+echo "OK — Track C3 acceptance gates passed (harness-level)."
+echo "Production wiring (lib.rs::setup hooks + App.tsx mount + --self-test"
+echo "binary modes) lands in a follow-up alongside the manual native-channel"
+echo "QA matrix described in docs/cookbook/c3-send-from-any-app.md."


### PR DESCRIPTION
## Summary

Closes out Track C3. Stacked on **#150** (M-c3.5 React composer). Final PR in the cascade.

Three pieces:
1. **`scripts/e2e/c3-send-from-any-app.sh`** — harness-acceptance E2E exercising every channel's parser/decoder/classifier and the SharePayload → SendIngestor seam.
2. **`docs/cookbook/c3-send-from-any-app.md`** — per-channel walkthroughs (URL scheme, hotkey, Services menu, dock-drop) + multi-agent collision escape hatch + v1 deferrals.
3. **§5.5 spec footer** — roadmap marked shipped 2026-05-04 with explicit pointer to the deferred production-wiring follow-up.

## Milestones

- **M-c3.6.1** — `c3-send-from-any-app.sh`: 8 acceptance gates (M-c3.0 ingestor + B0; M-c3.1.4 URL scheme rewrite; M-c3.3.3 NSServices Info.plist [macOS]; channel A/B [cross-platform]; channel C/D [macOS-only]; M-c3.5 TS share handler). Skips macOS-only sections cleanly on Linux/Windows.
- **M-c3.6.2** — cookbook + 5 verification gates (`mur-core/tests/verify_c3_cookbook.rs`):
  - all four channel sections present
  - per-agent slug constraint documented
  - v1 deferrals (`not in v1` + `.appex`) called out
  - hotkey-collision escape hatch documented
  - `<untrusted_share>` trust story preserved (so a future reader doesn't mistakenly assume shared content is trusted)
- **M-c3.6.3** — §5.5 acceptance footer + 3 verification gates (`mur-core/tests/verify_c3_spec_tick.rs`):
  - `Status: shipped` marker present
  - absolute date carried
  - footer acknowledges deferred production wiring (so spec-only readers know there's a stacked follow-up)

## Track C3 status — full cascade

| PR | Milestone | Tests |
|---|---|---|
| #145 | M-c3.0 SendIngestor + `<untrusted_share>` | runtime + B0 unit tests |
| #146 | M-c3.1 URL scheme channel | 10 (parser + E2E) |
| #147 | M-c3.2 hotkey + clipboard | 10 (combo + clipboard + E2E) |
| #148 | M-c3.3 macOS Services menu | 8 + 3 (decoder + Info.plist + E2E) |
| #149 | M-c3.4 drag-to-dock | 4 + 4 inline (associations + classify + E2E) |
| #150 | M-c3.5 React composer + ShareBadge | 18 (share handler + ShareBadge + integration) |
| **this PR** | M-c3.6 acceptance + cookbook + footer | 8 (cookbook + spec gates) |

Production wiring follow-up will land:
- `lib.rs::setup` mounts of `tauri-plugin-deep-link`, `tauri-plugin-global-shortcut`, NSApplication.servicesProvider, RunEvent::Opened
- `App.tsx` mount of `startShareListener`
- `bundle.macOS.infoPlist` field in tauri.conf.json wired to the rendered Info.plist
- `--self-test=<mode>` binary modes for the full c3-send-from-any-app.sh acceptance script

## Test plan

- [x] `cargo test -p mur-core --test verify_c3_cookbook` (5 pass)
- [x] `cargo test -p mur-core --test verify_c3_spec_tick` (3 pass)
- [x] `bash -n scripts/e2e/c3-send-from-any-app.sh` (syntax clean)
- [ ] Once #145–#150 merge, run `bash scripts/e2e/c3-send-from-any-app.sh` against main as the green baseline before kicking off the production-wiring PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)