### PR TITLE
feat(gui): Track C3 wiring M-w1 — muragent-<slug>:// deep-link → DefaultIngestor

### DIFF
--- a/mur-agent-gui/src-tauri/src/main.rs
+++ b/mur-agent-gui/src-tauri/src/main.rs
@@ -5,6 +5,7 @@ mod bootstrap;
 mod commands;
 mod companion_bridge;
 mod multimodal;
+mod send;
 mod sidecar;
 mod theme;
 mod voice;
@@ -151,6 +152,47 @@ fn main() -> Result<()> {
                 }
             });
 
+            // ── Track C3 / channel A — deep-link → ingestor ──────────
+            //
+            // `bootstrap::bootstrap_if_needed` ran above and exported
+            // `MUR_GUI_AGENT_NAME`; `current_agent_slug` reads it (or
+            // falls back to "template" so dev builds still work).
+            //
+            // The `on_open_url` callback fires once per
+            // `muragent-<slug>://share?...` invocation. `parse_share_url`
+            // is pure — anything malformed (wrong host, wrong slug,
+            // bad base64) returns Err. Production silently logs and
+            // drops; the harness surfaces.
+            {
+                use tauri_plugin_deep_link::DeepLinkExt;
+                let slug = send::wiring::current_agent_slug();
+                let ingestor = send::wiring::build_ingestor(app.handle().clone(), &slug);
+                let cb_slug = slug.clone();
+                app.deep_link().on_open_url(move |event| {
+                    for url in event.urls() {
+                        let url_str = url.to_string();
+                        match send::url_scheme::parse_share_url(&url_str, &cb_slug) {
+                            Ok(payload) => {
+                                let ing = ingestor.clone();
+                                tauri::async_runtime::spawn(async move {
+                                    if let Err(e) = ing.ingest(payload).await {
+                                        tracing::warn!(
+                                            error = %e,
+                                            "deep-link ingest failed",
+                                        );
+                                    }
+                                });
+                            }
+                            Err(e) => tracing::warn!(
+                                url = %url_str,
+                                error = %e,
+                                "rejected deep-link URL",
+                            ),
+                        }
+                    }
+                });
+            }
+
             // Tray menu — primary UX for the menubar launcher.
             let show_settings =
                 MenuItem::with_id(app, "show-settings", "Show Settings…", true, None::<&str>)?;
@@ -255,6 +297,16 @@ fn main() -> Result<()> {
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_notification::init())
+        // ── Track C3 / channel A — `muragent-<slug>://share?...` ─────
+        //
+        // Deep-link delivery: macOS routes through Launch Services
+        // (which speaks LSOpenURL); Linux through xdg-open + a per-
+        // user .desktop file the plugin manages; Windows through
+        // the registry. The on_open_url callback runs on the main
+        // thread; we hand the URL to `parse_share_url` (pure) and
+        // dispatch the resulting payload through the production
+        // `DefaultIngestor` constructed in `setup`.
+        .plugin(tauri_plugin_deep_link::init())
         // ── D3 / M3.6.3 — drag-drop event → React ──────────────────
         //
         // Tauri 2 delivers drag-drop through `WindowEvent::DragDrop`.

--- a/mur-agent-gui/src-tauri/src/send/mod.rs
+++ b/mur-agent-gui/src-tauri/src/send/mod.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod hotkey;
 pub mod url_scheme;
+pub mod wiring;
 
 #[cfg(target_os = "macos")]
 pub mod dock;

--- a/mur-agent-gui/src-tauri/src/send/wiring.rs
+++ b/mur-agent-gui/src-tauri/src/send/wiring.rs
@@ -1,0 +1,123 @@
+//! Track C3 production-wiring plumbing.
+//!
+//! The four channel modules (`url_scheme`, `hotkey`, `services`,
+//! `dock`) ship pure parser/decoder/classifier surfaces plus harness
+//! [`MockApp`] coverage. This module bridges them to the live Tauri
+//! runtime: it owns the `AppHandle`-backed [`ShareEmitter`] that emits
+//! `share:received` to the React composer, and it constructs the
+//! production [`DefaultIngestor`] each channel callback feeds.
+//!
+//! Lives behind its own module so harness tests don't accidentally
+//! pull in `tauri::AppHandle` (which would require the full Tauri
+//! runtime + a frontend bundle to instantiate).
+//!
+//! [`MockApp`]: crate::test_harness::MockApp
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use tauri::{AppHandle, Emitter};
+
+use super::{DefaultIngestor, SendIngestor, ShareEmitter, SharePayload};
+
+/// Live emitter that pushes `share:received` events into the webview
+/// so React's [`startShareListener`](../../../ui/src/lib/share.ts) can
+/// flash the badge and insert the body.
+///
+/// Cloning is cheap — `AppHandle` is itself `Clone`-able and refcounted
+/// internally — so callers can hand each channel callback its own
+/// emitter without sharing a `Mutex`.
+pub struct EventShareEmitter {
+    app: AppHandle,
+}
+
+impl EventShareEmitter {
+    pub fn new(app: AppHandle) -> Self {
+        Self { app }
+    }
+}
+
+impl ShareEmitter for EventShareEmitter {
+    fn emit_received(&self, payload: &SharePayload) -> Result<()> {
+        // Tauri's `emit` broadcasts to every webview; the composer
+        // mounts a single listener so we don't worry about scoping
+        // to a specific window. If multi-window scoping ever
+        // matters, switch to `emit_to(...)` against the settings
+        // window label.
+        self.app
+            .emit("share:received", payload)
+            .with_context(|| "emit share:received event")
+    }
+}
+
+/// Resolve `~/.mur/agents/<slug>/` for the live agent. Mirrors the
+/// resolution used by the runtime sidecar so artifacts written by the
+/// ingestor land in the same tree.
+///
+/// `MUR_HOME` overrides the user's home directory — used by the e2e
+/// runner so tests don't pollute `$HOME/.mur`. Bootstrap exports
+/// `MUR_GUI_AGENT_NAME`; falling back to `template` matches the
+/// development-build convention.
+pub fn agent_home_for(slug: &str) -> PathBuf {
+    let home = std::env::var_os("MUR_HOME")
+        .map(PathBuf::from)
+        .or_else(dirs::home_dir)
+        .unwrap_or_else(std::env::temp_dir);
+    home.join(".mur").join("agents").join(slug)
+}
+
+/// Construct the production [`DefaultIngestor`] for the given agent.
+/// Each channel callback (deep-link, hotkey, Services, dock) shares
+/// one ingestor instance so provenance + B0 cooldown state stay
+/// consistent across channels.
+pub fn build_ingestor(app: AppHandle, slug: &str) -> Arc<dyn SendIngestor> {
+    Arc::new(DefaultIngestor {
+        agent_home: agent_home_for(slug),
+        emitter: Arc::new(EventShareEmitter::new(app)),
+    })
+}
+
+/// Read `MUR_GUI_AGENT_NAME` (set by `bootstrap::bootstrap_if_needed`)
+/// or fall back to `template`. The slug is what every channel uses to
+/// scope its registration: deep-link checks the URL scheme matches
+/// `muragent-<slug>://`, hotkey appends the slug's first letter to the
+/// default combo, etc.
+pub fn current_agent_slug() -> String {
+    std::env::var("MUR_GUI_AGENT_NAME").unwrap_or_else(|_| "template".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_home_honors_mur_home_override() {
+        // SAFETY: tests share a process; serializing via a literal
+        // env-var write is fine because integration tests in this
+        // crate don't otherwise touch MUR_HOME.
+        unsafe {
+            std::env::set_var("MUR_HOME", "/tmp/mur-test-home");
+        }
+        let p = agent_home_for("coach");
+        assert_eq!(p, PathBuf::from("/tmp/mur-test-home/.mur/agents/coach"));
+        unsafe {
+            std::env::remove_var("MUR_HOME");
+        }
+    }
+
+    #[test]
+    fn current_agent_slug_falls_back_to_template() {
+        // Save and clear so the test is independent of bootstrap state.
+        let prior = std::env::var("MUR_GUI_AGENT_NAME").ok();
+        unsafe {
+            std::env::remove_var("MUR_GUI_AGENT_NAME");
+        }
+        assert_eq!(current_agent_slug(), "template");
+        if let Some(v) = prior {
+            unsafe {
+                std::env::set_var("MUR_GUI_AGENT_NAME", v);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First milestone of the Track C3 production-wiring follow-up. Stacked on **#151** (the harness cascade tip).

Lights up channel A (URL scheme) end-to-end: deep-link delivery → URL parser → `DefaultIngestor` → B0 `<untrusted_share>` wrapping → `share:received` event → React composer (which mounts via #150's \`startShareListener\`, pending its own wiring PR M-w5).

## What's new

\`src/send/wiring.rs\`:
- \`EventShareEmitter\` — \`AppHandle\`-backed \`ShareEmitter\` that emits \`share:received\` to the webview
- \`agent_home_for(slug)\` — resolves \`~/.mur/agents/<slug>/\`, honours \`$MUR_HOME\` for the e2e runner
- \`build_ingestor(app, slug)\` — production \`DefaultIngestor\` factory, shared across channel callbacks
- \`current_agent_slug()\` — reads \`$MUR_GUI_AGENT_NAME\` from bootstrap, falls back to "template"

\`main.rs\`:
- \`tauri-plugin-deep-link\` mounted in the plugin chain
- \`app.deep_link().on_open_url(...)\` callback inside \`setup\`: each URL goes through \`parse_share_url\` (pure, from M-c3.1.2), and the resulting \`SharePayload\` is dispatched through the shared ingestor on \`tauri::async_runtime\`. Malformed URLs (wrong host / wrong slug / bad base64) get logged at \`warn\` and dropped — production posture matches the harness contract documented in M-c3.1's PR description

## Track C3 wiring follow-up plan

| Milestone | Channel | Touches |
|---|---|---|
| **M-w1 (this PR)** | A — deep-link | \`tauri-plugin-deep-link\` + \`on_open_url\` |
| M-w2 | B — hotkey | \`tauri-plugin-global-shortcut\` register + \`Clipboard\` impl |
| M-w3 | C — Services menu (macOS) | \`NSApplication.servicesProvider\` + \`bundle.macOS.infoPlist\` |
| M-w4 | D — drag-to-dock (macOS) | \`RunEvent::Opened\` callback in \`tauri::Builder::run\` |
| M-w5 | composer | \`App.tsx\` mount of \`startShareListener\` |
| M-w6 | acceptance | \`--self-test=*\` binary modes for the full e2e script |

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo test --lib send::wiring\` (2 tests pass: MUR_HOME override, slug fallback)
- [x] \`cargo test --test send_url_scheme --test send_hotkey\` (sibling regression, all green)
- [ ] Manual: build a real GUI bundle, register the scheme, fire \`open 'muragent-coach://share?text=aGVsbG8&type=text'\`, verify the \`share:received\` event reaches the webview (pending stacked M-w5 mounting the listener)

🤖 Generated with [Claude Code](https://claude.com/claude-code)