### PR TITLE
feat(gui): Track C3 wiring M-w2 — Cmd+Shift+M+<X> hotkey + clipboard

### DIFF
--- a/mur-agent-gui/src-tauri/src/main.rs
+++ b/mur-agent-gui/src-tauri/src/main.rs
@@ -152,28 +152,31 @@ fn main() -> Result<()> {
                 }
             });
 
-            // ── Track C3 / channel A — deep-link → ingestor ──────────
+            // ── Track C3 — channel callbacks ─────────────────────────
             //
             // `bootstrap::bootstrap_if_needed` ran above and exported
             // `MUR_GUI_AGENT_NAME`; `current_agent_slug` reads it (or
             // falls back to "template" so dev builds still work).
             //
-            // The `on_open_url` callback fires once per
-            // `muragent-<slug>://share?...` invocation. `parse_share_url`
-            // is pure — anything malformed (wrong host, wrong slug,
-            // bad base64) returns Err. Production silently logs and
-            // drops; the harness surfaces.
+            // One ingestor instance is shared across channels so
+            // provenance + B0 cooldown state stay consistent.
             {
                 use tauri_plugin_deep_link::DeepLinkExt;
                 let slug = send::wiring::current_agent_slug();
                 let ingestor = send::wiring::build_ingestor(app.handle().clone(), &slug);
+
+                // Channel A — `muragent-<slug>://share?...` deep-link.
+                // The `on_open_url` callback fires once per invocation.
+                // `parse_share_url` is pure; malformed URLs (wrong
+                // host, wrong slug, bad base64) get logged and dropped.
                 let cb_slug = slug.clone();
+                let cb_ing = ingestor.clone();
                 app.deep_link().on_open_url(move |event| {
                     for url in event.urls() {
                         let url_str = url.to_string();
                         match send::url_scheme::parse_share_url(&url_str, &cb_slug) {
                             Ok(payload) => {
-                                let ing = ingestor.clone();
+                                let ing = cb_ing.clone();
                                 tauri::async_runtime::spawn(async move {
                                     if let Err(e) = ing.ingest(payload).await {
                                         tracing::warn!(
@@ -191,6 +194,21 @@ fn main() -> Result<()> {
                         }
                     }
                 });
+
+                // Channel B — global hotkey + clipboard. The combo
+                // is per-agent (Cmd+Shift+M+<X>) with a user override
+                // honoured from `companion/state.yaml`. Failure to
+                // register (e.g. another app owns the combo) logs
+                // and continues — the agent stays usable via the
+                // other three channels.
+                match send::wiring::register_share_hotkey(
+                    app.handle(),
+                    &slug,
+                    ingestor.clone(),
+                ) {
+                    Ok(combo) => tracing::info!(combo = %combo, "share hotkey registered"),
+                    Err(e) => tracing::warn!(error = %e, "share hotkey not registered"),
+                }
             }
 
             // Tray menu — primary UX for the menubar launcher.

--- a/mur-agent-gui/src-tauri/src/send/wiring.rs
+++ b/mur-agent-gui/src-tauri/src/send/wiring.rs
@@ -18,7 +18,10 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use tauri::{AppHandle, Emitter};
+use tauri_plugin_clipboard_manager::ClipboardExt;
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutState};
 
+use super::hotkey::{Clipboard, default_combo_for, resolve_combo, synthesize_from_clipboard};
 use super::{DefaultIngestor, SendIngestor, ShareEmitter, SharePayload};
 
 /// Live emitter that pushes `share:received` events into the webview
@@ -48,6 +51,58 @@ impl ShareEmitter for EventShareEmitter {
         self.app
             .emit("share:received", payload)
             .with_context(|| "emit share:received event")
+    }
+}
+
+/// Live [`Clipboard`] impl backed by `tauri-plugin-clipboard-manager`.
+///
+/// `read_text` returns `None` when the pasteboard has no text slot
+/// (the plugin returns `Err`; we map that to `None` so the synthesizer
+/// can short-circuit cleanly). `read_image` reads RGBA pixels from
+/// the system clipboard and re-encodes them as PNG so the existing
+/// `synthesize_from_clipboard` machinery can persist a temp file
+/// and route it through the multimodal pipeline.
+pub struct TauriClipboard {
+    app: AppHandle,
+}
+
+impl TauriClipboard {
+    pub fn new(app: AppHandle) -> Self {
+        Self { app }
+    }
+}
+
+#[async_trait::async_trait]
+impl Clipboard for TauriClipboard {
+    async fn read_text(&self) -> Result<Option<String>> {
+        // The plugin returns Err when the pasteboard has no text
+        // slot (vs. a slot containing an empty string). Both are
+        // "nothing to share"; collapsing them keeps the synthesizer
+        // contract uniform with `FakeClipboard`.
+        Ok(self.app.clipboard().read_text().ok().filter(|s| !s.is_empty()))
+    }
+
+    async fn read_image(&self) -> Result<Option<Vec<u8>>> {
+        let img = match self.app.clipboard().read_image() {
+            Ok(img) => img,
+            Err(_) => return Ok(None),
+        };
+        let rgba = img.rgba();
+        let width = img.width();
+        let height = img.height();
+        if rgba.is_empty() || width == 0 || height == 0 {
+            return Ok(None);
+        }
+        // Re-encode RGBA → PNG so downstream code that writes
+        // `mur-share-*.png` files gets bytes the OS / image viewers
+        // / mime-sniffer all recognise.
+        let buf = image::RgbaImage::from_raw(width, height, rgba.to_vec())
+            .context("clipboard rgba dimensions don't match buffer length")?;
+        let mut png = Vec::with_capacity(rgba.len());
+        image::DynamicImage::ImageRgba8(buf)
+            .write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
+            .context("encode clipboard image as PNG")?;
+        Ok(Some(png))
     }
 }
 
@@ -87,12 +142,109 @@ pub fn current_agent_slug() -> String {
     std::env::var("MUR_GUI_AGENT_NAME").unwrap_or_else(|_| "template".to_string())
 }
 
+/// Read the user's `share.hotkey` override from
+/// `~/.mur/agents/<slug>/companion/state.yaml` if present.
+/// Returns `None` when the file doesn't exist, the file can't be
+/// parsed, or the field isn't set — the caller falls back to the
+/// per-agent default combo.
+///
+/// Failures here are deliberately silent: a malformed state.yaml
+/// shouldn't crash the agent on boot, and the user can still trigger
+/// the default combo while they fix the file. We log at `debug` so
+/// operators can correlate against `RUST_LOG=mur_agent_gui_lib=debug`
+/// if something looks off.
+pub fn read_user_hotkey_override(slug: &str) -> Option<String> {
+    let path = agent_home_for(slug)
+        .join("companion")
+        .join("state.yaml");
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let parsed: serde_yaml_ng::Value = serde_yaml_ng::from_str(&raw)
+        .map_err(|e| {
+            tracing::debug!(error = %e, path = %path.display(), "ignore malformed state.yaml");
+            e
+        })
+        .ok()?;
+    parsed
+        .get("share")?
+        .get("hotkey")?
+        .as_str()
+        .map(str::to_string)
+}
+
+/// Wire the channel B (hotkey + clipboard) registration. Reads the
+/// user override (if any), registers the resolved combo with the
+/// global-shortcut plugin, and runs the synthesize → ingest pipeline
+/// on each press.
+///
+/// Errors during initial registration bubble out so the caller can
+/// log + continue startup — the agent stays useful via the other
+/// three channels even if the OS refused to bind the combo (e.g.
+/// another app already owns it).
+pub fn register_share_hotkey(
+    app: &AppHandle,
+    slug: &str,
+    ingestor: Arc<dyn SendIngestor>,
+) -> Result<String> {
+    let combo = resolve_combo(slug, read_user_hotkey_override(slug).as_deref());
+    let parsed: Shortcut = combo
+        .parse()
+        .with_context(|| format!("parse hotkey combo `{combo}`"))?;
+
+    let app_for_handler = app.clone();
+    app.global_shortcut()
+        .on_shortcut(parsed, move |_, _, event| {
+            // Trigger on Pressed (key-down) only — global-shortcut
+            // fires both Pressed + Released; the share path doesn't
+            // care about hold-to-talk semantics.
+            if event.state() != ShortcutState::Pressed {
+                return;
+            }
+            let cb = TauriClipboard::new(app_for_handler.clone());
+            let ing = ingestor.clone();
+            tauri::async_runtime::spawn(async move {
+                match synthesize_from_clipboard(&cb).await {
+                    Ok(payload) => {
+                        if let Err(e) = ing.ingest(payload).await {
+                            tracing::warn!(error = %e, "hotkey ingest failed");
+                        }
+                    }
+                    Err(e) => {
+                        // Empty clipboard is the common case — debug
+                        // not warn so users hammering the combo by
+                        // accident don't fill the log.
+                        tracing::debug!(error = %e, "hotkey synth (clipboard empty?)");
+                    }
+                }
+            });
+        })
+        .map_err(|e| anyhow::anyhow!("register share hotkey {combo}: {e}"))
+        .with_context(|| format!("register share hotkey {combo}"))?;
+
+    Ok(combo)
+}
+
+/// Default combo string for tests / introspection. Just exposes
+/// `default_combo_for` from `super::hotkey` so callers don't need a
+/// second `use`.
+#[cfg(test)]
+fn default_combo(slug: &str) -> String {
+    default_combo_for(slug)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Tests in this module mutate process-wide env vars (MUR_HOME,
+    // MUR_GUI_AGENT_NAME). Vitest-style parallel test execution
+    // causes spurious failures when one test clears MUR_HOME mid-
+    // assertion in another. A single mutex serialises them.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn agent_home_honors_mur_home_override() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         // SAFETY: tests share a process; serializing via a literal
         // env-var write is fine because integration tests in this
         // crate don't otherwise touch MUR_HOME.
@@ -108,6 +260,7 @@ mod tests {
 
     #[test]
     fn current_agent_slug_falls_back_to_template() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         // Save and clear so the test is independent of bootstrap state.
         let prior = std::env::var("MUR_GUI_AGENT_NAME").ok();
         unsafe {
@@ -119,5 +272,78 @@ mod tests {
                 std::env::set_var("MUR_GUI_AGENT_NAME", v);
             }
         }
+    }
+
+    #[test]
+    fn user_hotkey_override_reads_share_hotkey_field() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let mur_root = tmp.path();
+        unsafe {
+            std::env::set_var("MUR_HOME", mur_root);
+        }
+
+        let companion_dir = mur_root
+            .join(".mur")
+            .join("agents")
+            .join("override-bot")
+            .join("companion");
+        std::fs::create_dir_all(&companion_dir).unwrap();
+        std::fs::write(
+            companion_dir.join("state.yaml"),
+            "share:\n  hotkey: CommandOrControl+Alt+K\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_user_hotkey_override("override-bot").as_deref(),
+            Some("CommandOrControl+Alt+K"),
+        );
+
+        unsafe {
+            std::env::remove_var("MUR_HOME");
+        }
+    }
+
+    #[test]
+    fn user_hotkey_override_returns_none_when_state_missing() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("MUR_HOME", tmp.path());
+        }
+        assert_eq!(read_user_hotkey_override("ghost"), None);
+        unsafe {
+            std::env::remove_var("MUR_HOME");
+        }
+    }
+
+    #[test]
+    fn user_hotkey_override_tolerates_malformed_yaml() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp
+            .path()
+            .join(".mur")
+            .join("agents")
+            .join("malformed")
+            .join("companion");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("state.yaml"), "this: is: not: valid").unwrap();
+
+        unsafe {
+            std::env::set_var("MUR_HOME", tmp.path());
+        }
+        // Must not panic and must not throw — silent fallback is the
+        // contract documented above.
+        assert_eq!(read_user_hotkey_override("malformed"), None);
+        unsafe {
+            std::env::remove_var("MUR_HOME");
+        }
+    }
+
+    #[test]
+    fn default_combo_helper_matches_underlying() {
+        assert_eq!(default_combo("coach"), "CommandOrControl+Shift+M+C");
     }
 }


### PR DESCRIPTION
## Summary

Second milestone of the Track C3 production-wiring follow-up. Stacked on **#152** (M-w1 deep-link).

Lights up channel B (hotkey + clipboard) end-to-end: global hotkey press → real clipboard read → \`synthesize_from_clipboard\` → \`DefaultIngestor\` → \`<untrusted_share>\` → \`share:received\`.

## What's new

\`send::wiring\` gains:
- \`TauriClipboard\` — production \`Clipboard\` impl backed by \`tauri-plugin-clipboard-manager\`. RGBA → PNG re-encode so downstream temp-file writers and mime-sniffer get a recognised binary format.
- \`read_user_hotkey_override(slug)\` — reads \`share.hotkey\` from \`~/.mur/agents/<slug>/companion/state.yaml\`. Silently returns \`None\` for missing/malformed/missing-field cases (a bad state.yaml shouldn't crash boot).
- \`register_share_hotkey(app, slug, ingestor)\` — resolves the combo (default + user override), parses via \`Shortcut::from_str\`, registers via \`app.global_shortcut().on_shortcut(...)\`. Handler fires on Pressed only, synthesizes from \`TauriClipboard\`, dispatches through the shared ingestor.

\`main.rs::setup\` wires the registration inside the same block as M-w1's deep-link callback, with one shared ingestor so provenance + B0 cooldown stay consistent. Hotkey-registration failures log + continue — the agent stays usable via channel A while the user resolves combo conflicts via the cookbook escape hatch.

## Notes

- Tests are serialised via a module-local mutex because parallel threads racing on \`$MUR_HOME\` caused intermittent failures. The runtime sidecar uses the same pattern.
- Empty-clipboard presses log at \`debug\`, not \`warn\` — accidental presses are common and shouldn't fill the log.

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo test --lib send::wiring\` (6 tests pass: M-w1's 2 + 4 new)
- [x] \`cargo test --test send_hotkey --test send_url_scheme\` (sibling regression all green)
- [ ] Manual: build a real GUI bundle, hit \`Cmd+Shift+M+<X>\` with text in clipboard, verify \`share:received\` reaches webview (pending stacked M-w5)
- [ ] Manual: edit \`companion/state.yaml\` with \`share.hotkey: \"CommandOrControl+Alt+K\"\`, restart, verify the override binds

🤖 Generated with [Claude Code](https://claude.com/claude-code)