### PR TITLE
feat(gui,core): Track C3 — M-c3.1 muragent-<slug>:// URL scheme channel

### DIFF
--- a/mur-agent-gui/src-tauri/Cargo.toml
+++ b/mur-agent-gui/src-tauri/Cargo.toml
@@ -89,6 +89,12 @@ mime_guess = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-notification = "2"
+# Track C3 / M-c3.1 — `muragent-<slug>://share?...` URL scheme channel.
+# `tauri-plugin-deep-link` provides the runtime handler; `base64` and
+# `url` decode the inbound payload (URL_SAFE_NO_PAD, RFC 3986).
+tauri-plugin-deep-link = "2"
+base64 = "0.22"
+url = "2"
 
 # ───── multimodal decoder (D3 / M3) ─────
 # `image` is consumed by `mur-agent-decoder` for PNG/JPEG/WebP decode.

--- a/mur-agent-gui/src-tauri/src/lib.rs
+++ b/mur-agent-gui/src-tauri/src/lib.rs
@@ -8,5 +8,6 @@ pub mod companion_bridge;
 pub mod multimodal;
 pub mod send;
 pub mod sidecar;
+pub mod test_harness;
 pub mod theme;
 pub mod voice;

--- a/mur-agent-gui/src-tauri/src/send/url_scheme.rs
+++ b/mur-agent-gui/src-tauri/src/send/url_scheme.rs
@@ -1,2 +1,71 @@
 //! Track C3 channel A — `muragent-<slug>://share?...` deep-link
-//! handler. Implemented in M-c3.1.
+//! handler.
+//!
+//! On macOS the OS dispatches `muragent-coach://share?text=…&type=…`
+//! URLs to the running `MyAgent.app` via Launch Services + the
+//! [`tauri-plugin-deep-link`] plugin. This module owns the *parsing*
+//! half: turn a raw URL string into a [`SharePayload`] with strict
+//! validation (correct scheme prefix, correct host, base64-decoded
+//! body). The deep-link plugin is wired into `lib.rs::setup` in
+//! M-c3.1.3 — until then [`parse_share_url`] is exercised directly by
+//! the test harness.
+
+use anyhow::{Context, anyhow, ensure};
+use base64::Engine;
+
+use crate::send::{SharePayload, ShareKind};
+
+/// Parse a `muragent-<expected_slug>://share?text=<base64>&type=<kind>`
+/// URL into a [`SharePayload`].
+///
+/// Validation rules (fail-closed, in order):
+/// 1. URL syntactically parseable.
+/// 2. Scheme is exactly `muragent-<expected_slug>` — rejects URLs
+///    targeting a different agent installed on the same machine.
+/// 3. Host (the segment between `://` and the path/query) is `share`
+///    — rejects future control verbs at non-`share` hosts.
+/// 4. `text=<base64>` query parameter present and decodes as
+///    `URL_SAFE_NO_PAD` UTF-8.
+///
+/// `type=` selects the [`ShareKind`] arm:
+/// - `type=url` → [`ShareKind::Url`]
+/// - anything else (including missing) → [`ShareKind::Text`]
+pub fn parse_share_url(raw: &str, expected_slug: &str) -> anyhow::Result<SharePayload> {
+    let parsed = url::Url::parse(raw).with_context(|| format!("invalid URL: {raw}"))?;
+    let want_scheme = format!("muragent-{expected_slug}");
+    ensure!(
+        parsed.scheme() == want_scheme,
+        "scheme mismatch: got `{}`, expected `{want_scheme}`",
+        parsed.scheme()
+    );
+    ensure!(
+        parsed.host_str() == Some("share"),
+        "expected host `share`, got `{:?}`",
+        parsed.host_str()
+    );
+
+    let mut text_b64: Option<String> = None;
+    let mut kind_str = String::from("text");
+    for (k, v) in parsed.query_pairs() {
+        match k.as_ref() {
+            "text" => text_b64 = Some(v.into_owned()),
+            "type" => kind_str = v.into_owned(),
+            _ => {}
+        }
+    }
+    let b64 = text_b64.ok_or_else(|| anyhow!("missing `text=` query parameter"))?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(b64.as_bytes())
+        .with_context(|| "decode `text=` as URL_SAFE_NO_PAD base64")?;
+    let body = String::from_utf8(bytes).with_context(|| "decoded `text=` is not valid UTF-8")?;
+
+    let kind = match kind_str.as_str() {
+        "url" => ShareKind::Url(body),
+        _ => ShareKind::Text(body),
+    };
+    Ok(SharePayload {
+        source: "url_scheme".into(),
+        kind,
+        metadata: serde_json::json!({}),
+    })
+}

--- a/mur-agent-gui/src-tauri/src/test_harness.rs
+++ b/mur-agent-gui/src-tauri/src/test_harness.rs
@@ -1,0 +1,116 @@
+//! Pure-Rust test harness for Track C3 share channels.
+//!
+//! Building a real `tauri::test::mock_builder()` requires the full
+//! Tauri runtime + a frontend bundle, which is overkill for verifying
+//! that a deep-link URL parses into a [`SharePayload`] and reaches the
+//! ingestor. Instead, [`MockApp`] threads a [`RecordingIngestor`] (a
+//! `Mutex<Vec<SharePayload>>` recorder) through the same
+//! `parse_share_url` → `SendIngestor::ingest` path the production
+//! `app.deep_link().on_open_url(...)` callback will use.
+//!
+//! `lib.rs::setup` integration with `tauri-plugin-deep-link` lands in a
+//! follow-up so we can iterate on the parser + harness independently.
+//!
+//! Always compiled into the lib (so integration tests can reach it)
+//! but `#[doc(hidden)]` to discourage production callers — the bin
+//! crate (`main.rs`) doesn't reference these types.
+
+#![doc(hidden)]
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use crate::send::{SendIngestor, SharePayload, ShareEmitter, url_scheme};
+
+/// Counts emit-received calls and stores the payloads. Callers swap
+/// this in for the production `tauri::AppHandle`-backed emitter.
+#[derive(Default)]
+pub struct CountingEmitter {
+    pub emitted: Mutex<Vec<SharePayload>>,
+}
+
+impl ShareEmitter for CountingEmitter {
+    fn emit_received(&self, payload: &SharePayload) -> anyhow::Result<()> {
+        self.emitted
+            .lock()
+            .expect("CountingEmitter mutex poisoned")
+            .push(payload.clone());
+        Ok(())
+    }
+}
+
+/// Vec-backed `SendIngestor` used by tests to assert which payloads
+/// the URL scheme parser produced. Wraps the real `DefaultIngestor`'s
+/// behavior would couple tests to filesystem / multimodal pipeline,
+/// so the recorder skips the `process_*_text` / `process_artifact`
+/// hop and just stores the payload. Channel-level tests own the
+/// payload-shape assertion; the multimodal-pipeline → B0 chain is
+/// covered separately in M-c3.0 tests.
+#[derive(Default)]
+pub struct RecordingIngestor {
+    pub payloads: Mutex<Vec<SharePayload>>,
+}
+
+#[async_trait::async_trait]
+impl SendIngestor for RecordingIngestor {
+    async fn ingest(&self, payload: SharePayload) -> anyhow::Result<()> {
+        self.payloads
+            .lock()
+            .expect("RecordingIngestor mutex poisoned")
+            .push(payload);
+        Ok(())
+    }
+}
+
+/// Test-only stand-in for the Tauri shell.
+///
+/// `simulate_open_url` is the seam that production code will reach
+/// from `tauri-plugin-deep-link`'s `on_open_url` callback once it's
+/// wired into `lib.rs::setup`. The harness drives that seam directly
+/// to keep the test free of Tauri runtime dependencies.
+pub struct MockApp {
+    /// Per-agent slug; the parser rejects URLs targeting a different
+    /// agent so we plumb the slug through here.
+    pub slug: String,
+    /// Mirrors the production `agent_home` directory contract even
+    /// though `RecordingIngestor` doesn't write to disk — callers may
+    /// want to assert downstream artifacts in stacked harnesses.
+    pub agent_home: PathBuf,
+    pub ingestor: Arc<RecordingIngestor>,
+}
+
+impl MockApp {
+    pub fn new(agent_home: impl AsRef<Path>, slug: impl Into<String>) -> Self {
+        Self {
+            slug: slug.into(),
+            agent_home: agent_home.as_ref().to_path_buf(),
+            ingestor: Arc::new(RecordingIngestor::default()),
+        }
+    }
+
+    /// Drive the deep-link URL through the same parse → ingest path
+    /// the production `on_open_url` callback uses. Errors fail the
+    /// test rather than being swallowed (production silently logs
+    /// invalid URLs; the harness surfaces them).
+    pub async fn simulate_open_url(&self, url: &str) -> anyhow::Result<()> {
+        let payload = url_scheme::parse_share_url(url, &self.slug)?;
+        self.ingestor.ingest(payload).await
+    }
+
+    /// Snapshot the recorded payloads. Returns an owned clone so
+    /// callers can iterate without holding the mutex.
+    pub fn captured_payloads(&self) -> Vec<SharePayload> {
+        self.ingestor
+            .payloads
+            .lock()
+            .expect("RecordingIngestor mutex poisoned")
+            .clone()
+    }
+}
+
+/// Convenience constructor matching the plan's `mock_app(home, slug)`
+/// signature. Async because the production analogue (a
+/// `tauri::Builder::default().setup(...)`) is async.
+pub async fn mock_app(agent_home: impl AsRef<Path>, slug: impl Into<String>) -> MockApp {
+    MockApp::new(agent_home, slug)
+}

--- a/mur-agent-gui/src-tauri/tauri.conf.json
+++ b/mur-agent-gui/src-tauri/tauri.conf.json
@@ -32,6 +32,13 @@
       "csp": "default-src 'self'; img-src 'self' asset: data:; style-src 'self' 'unsafe-inline'; script-src 'self'"
     }
   },
+  "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["muragent-{{AGENT_SLUG}}"]
+      }
+    }
+  },
   "bundle": {
     "active": true,
     "targets": ["app"],

--- a/mur-agent-gui/src-tauri/tests/send_url_scheme.rs
+++ b/mur-agent-gui/src-tauri/tests/send_url_scheme.rs
@@ -85,6 +85,39 @@ fn rejects_invalid_base64() {
     );
 }
 
+#[tokio::test]
+async fn deep_link_event_reaches_ingestor() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = mur_agent_gui_lib::test_harness::mock_app(tmp.path(), "coach").await;
+    let body = "hello";
+    let url = format!("muragent-coach://share?text={}&type=text", b64(body));
+    app.simulate_open_url(&url).await.unwrap();
+    let payloads = app.captured_payloads();
+    assert_eq!(payloads.len(), 1, "exactly one payload should be recorded");
+    assert_eq!(payloads[0].source, "url_scheme");
+    match &payloads[0].kind {
+        ShareKind::Text(t) => assert_eq!(t, body),
+        other => panic!("expected ShareKind::Text, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn deep_link_invalid_url_propagates_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = mur_agent_gui_lib::test_harness::mock_app(tmp.path(), "coach").await;
+    // Wrong slug — must NOT reach the ingestor.
+    let url = format!(
+        "muragent-other://share?text={}&type=text",
+        b64("attacker payload")
+    );
+    let res = app.simulate_open_url(&url).await;
+    assert!(res.is_err(), "wrong-slug URLs must error, not silently route");
+    assert!(
+        app.captured_payloads().is_empty(),
+        "ingestor must not record anything on parse failure"
+    );
+}
+
 #[test]
 fn url_schemes_present_in_tauri_conf() {
     // Tauri 2 rejects a top-level `bundle.macOS.urlSchemes` key, and

--- a/mur-agent-gui/src-tauri/tests/send_url_scheme.rs
+++ b/mur-agent-gui/src-tauri/tests/send_url_scheme.rs
@@ -8,6 +8,83 @@
 //! - End-to-end: deep-link event reaches the ingestor via the
 //!   pure-Rust `MockApp` test harness (M-c3.1.3)
 
+use base64::Engine;
+use mur_agent_gui_lib::send::ShareKind;
+use mur_agent_gui_lib::send::url_scheme::parse_share_url;
+
+fn b64(body: &str) -> String {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(body)
+}
+
+#[test]
+fn parse_text_share() {
+    let body = "hello world";
+    let url = format!("muragent-coach://share?text={}&type=text", b64(body));
+    let p = parse_share_url(&url, "coach").unwrap();
+    assert_eq!(p.source, "url_scheme");
+    match p.kind {
+        ShareKind::Text(t) => assert_eq!(t, body),
+        other => panic!("expected ShareKind::Text, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_url_share() {
+    let body = "https://example.com/post/42";
+    let url = format!("muragent-coach://share?text={}&type=url", b64(body));
+    let p = parse_share_url(&url, "coach").unwrap();
+    match p.kind {
+        ShareKind::Url(u) => assert_eq!(u, body),
+        other => panic!("expected ShareKind::Url, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_defaults_type_to_text() {
+    let body = "no type query";
+    let url = format!("muragent-coach://share?text={}", b64(body));
+    let p = parse_share_url(&url, "coach").unwrap();
+    assert!(matches!(p.kind, ShareKind::Text(ref t) if t == body));
+}
+
+#[test]
+fn rejects_wrong_slug() {
+    let body = "hello";
+    let url = format!("muragent-other://share?text={}&type=text", b64(body));
+    assert!(
+        parse_share_url(&url, "coach").is_err(),
+        "must reject scheme that targets a different agent"
+    );
+}
+
+#[test]
+fn rejects_wrong_host() {
+    let body = "hello";
+    let url = format!("muragent-coach://exec?text={}", b64(body));
+    assert!(
+        parse_share_url(&url, "coach").is_err(),
+        "must reject hosts other than `share`"
+    );
+}
+
+#[test]
+fn rejects_missing_text_param() {
+    let url = "muragent-coach://share?type=text";
+    assert!(
+        parse_share_url(url, "coach").is_err(),
+        "must reject URLs missing the `text=` query parameter"
+    );
+}
+
+#[test]
+fn rejects_invalid_base64() {
+    let url = "muragent-coach://share?text=%21%21not-base64%21%21&type=text";
+    assert!(
+        parse_share_url(url, "coach").is_err(),
+        "must reject `text=` payloads that aren't URL_SAFE_NO_PAD base64"
+    );
+}
+
 #[test]
 fn url_schemes_present_in_tauri_conf() {
     // Tauri 2 rejects a top-level `bundle.macOS.urlSchemes` key, and

--- a/mur-agent-gui/src-tauri/tests/send_url_scheme.rs
+++ b/mur-agent-gui/src-tauri/tests/send_url_scheme.rs
@@ -1,0 +1,38 @@
+//! Track C3 — M-c3.1 URL scheme channel tests.
+//!
+//! Covers:
+//! - tauri.conf.json carries a per-agent `muragent-<slug>` URL scheme
+//!   placeholder (M-c3.1.1)
+//! - `parse_share_url` decodes deep-link URLs into `SharePayload`
+//!   (M-c3.1.2)
+//! - End-to-end: deep-link event reaches the ingestor via the
+//!   pure-Rust `MockApp` test harness (M-c3.1.3)
+
+#[test]
+fn url_schemes_present_in_tauri_conf() {
+    // Tauri 2 rejects a top-level `bundle.macOS.urlSchemes` key, and
+    // its `bundle.macOS.infoPlist` field expects a path (not inline
+    // JSON). The canonical home for desktop URL scheme registration in
+    // Tauri 2 is the `tauri-plugin-deep-link` plugin config under
+    // `plugins.deep-link.desktop.schemes` — the plugin handles the
+    // `CFBundleURLTypes` Info.plist injection at bundle time on macOS.
+    //
+    // This test asserts the templated `muragent-{{AGENT_SLUG}}` scheme
+    // is reachable so `phase_4_rewrite_tauri_conf` (M-c3.1.4) has
+    // somewhere to substitute the real per-agent slug.
+    let raw = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json"),
+    )
+    .unwrap();
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let schemes = v
+        .pointer("/plugins/deep-link/desktop/schemes")
+        .and_then(|x| x.as_array())
+        .expect("deep-link desktop schemes array missing under plugins.deep-link.desktop.schemes");
+    assert!(
+        schemes
+            .iter()
+            .any(|s| s.as_str().unwrap_or("").starts_with("muragent-")),
+        "muragent-<slug> URL scheme must be templated in"
+    );
+}

--- a/mur-core/src/cmd/agent_export_gui.rs
+++ b/mur-core/src/cmd/agent_export_gui.rs
@@ -448,6 +448,12 @@ fn phase_4_rewrite_tauri_conf(
         }
     }
 
+    // Track C3 / M-c3.1.4 — substitute the per-agent slug into the
+    // `muragent-{{AGENT_SLUG}}` placeholder under
+    // `plugins.deep-link.desktop.schemes`. The shared helper is
+    // re-used by `rewrite_url_scheme` for hermetic unit testing.
+    apply_url_scheme_substitution(&mut conf, &safe_name);
+
     std::fs::write(&conf_path, serde_json::to_string_pretty(&conf)?)?;
 
     // Copy staged payload + metadata next to tauri.conf.json so the
@@ -467,6 +473,49 @@ fn phase_4_rewrite_tauri_conf(
         opts.agent_name,
         span.elapsed()
     );
+    Ok(())
+}
+
+/// Walk a parsed `tauri.conf.json` value and replace every
+/// `{{AGENT_SLUG}}` token under `plugins.deep-link.desktop.schemes`
+/// with `slug`. Idempotent — running it twice is a no-op once the
+/// substitution has happened. Tolerates a missing `plugins` block so
+/// older configs (or future ones that drop deep-link) don't error.
+fn apply_url_scheme_substitution(conf: &mut serde_json::Value, slug: &str) {
+    let Some(schemes) = conf
+        .get_mut("plugins")
+        .and_then(|p| p.get_mut("deep-link"))
+        .and_then(|d| d.get_mut("desktop"))
+        .and_then(|d| d.get_mut("schemes"))
+        .and_then(|s| s.as_array_mut())
+    else {
+        return;
+    };
+    for entry in schemes.iter_mut() {
+        if let Some(s) = entry.as_str() {
+            let replaced = s.replace("{{AGENT_SLUG}}", slug);
+            *entry = serde_json::Value::String(replaced);
+        }
+    }
+}
+
+/// Stand-alone hermetic entry point that the integration test calls
+/// without spinning up the full export pipeline. Reads
+/// `tauri_conf_dir/tauri.conf.json`, applies the slug substitution,
+/// writes back. Production callers route through
+/// `phase_4_rewrite_tauri_conf`, which calls
+/// `apply_url_scheme_substitution` directly to avoid the disk
+/// round-trip; this wrapper exists so the unit test can verify the
+/// disk-side semantics in isolation.
+#[allow(dead_code)] // Reached only by `tests/agent_export_gui_url_scheme.rs`.
+pub fn rewrite_url_scheme(tauri_conf_dir: &Path, slug: &str) -> Result<()> {
+    let path = tauri_conf_dir.join("tauri.conf.json");
+    let raw = std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let mut conf: serde_json::Value =
+        serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
+    apply_url_scheme_substitution(&mut conf, slug);
+    std::fs::write(&path, serde_json::to_string_pretty(&conf)?)
+        .with_context(|| format!("write {}", path.display()))?;
     Ok(())
 }
 

--- a/mur-core/tests/agent_export_gui_url_scheme.rs
+++ b/mur-core/tests/agent_export_gui_url_scheme.rs
@@ -1,0 +1,103 @@
+//! Track C3 / M-c3.1.4 — verify `rewrite_url_scheme` substitutes the
+//! per-agent slug into the `muragent-{{AGENT_SLUG}}` placeholder under
+//! `plugins.deep-link.desktop.schemes`.
+
+use mur_core::cmd::agent_export_gui::rewrite_url_scheme;
+
+#[test]
+fn rewrite_substitutes_agent_slug() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("tauri.conf.json"),
+        r#"{
+            "plugins": {
+                "deep-link": {
+                    "desktop": {
+                        "schemes": ["muragent-{{AGENT_SLUG}}"]
+                    }
+                }
+            }
+        }"#,
+    )
+    .unwrap();
+    rewrite_url_scheme(tmp.path(), "coach").unwrap();
+    let raw = std::fs::read_to_string(tmp.path().join("tauri.conf.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(
+        v.pointer("/plugins/deep-link/desktop/schemes/0")
+            .and_then(|x| x.as_str()),
+        Some("muragent-coach"),
+    );
+}
+
+#[test]
+fn rewrite_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("tauri.conf.json"),
+        r#"{
+            "plugins": {
+                "deep-link": {
+                    "desktop": {
+                        "schemes": ["muragent-{{AGENT_SLUG}}"]
+                    }
+                }
+            }
+        }"#,
+    )
+    .unwrap();
+    rewrite_url_scheme(tmp.path(), "coach").unwrap();
+    rewrite_url_scheme(tmp.path(), "coach").unwrap();
+    let raw = std::fs::read_to_string(tmp.path().join("tauri.conf.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    assert_eq!(
+        v.pointer("/plugins/deep-link/desktop/schemes/0")
+            .and_then(|x| x.as_str()),
+        Some("muragent-coach"),
+    );
+}
+
+#[test]
+fn rewrite_tolerates_missing_plugins_block() {
+    let tmp = tempfile::tempdir().unwrap();
+    let raw = r#"{ "productName": "MurAgent" }"#;
+    std::fs::write(tmp.path().join("tauri.conf.json"), raw).unwrap();
+    // Should be a no-op, not an error.
+    rewrite_url_scheme(tmp.path(), "coach").unwrap();
+    let after = std::fs::read_to_string(tmp.path().join("tauri.conf.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&after).unwrap();
+    assert_eq!(
+        v.get("productName").and_then(|x| x.as_str()),
+        Some("MurAgent")
+    );
+}
+
+#[test]
+fn rewrite_handles_multiple_schemes() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("tauri.conf.json"),
+        r#"{
+            "plugins": {
+                "deep-link": {
+                    "desktop": {
+                        "schemes": [
+                            "muragent-{{AGENT_SLUG}}",
+                            "muragent-{{AGENT_SLUG}}-dev"
+                        ]
+                    }
+                }
+            }
+        }"#,
+    )
+    .unwrap();
+    rewrite_url_scheme(tmp.path(), "draft").unwrap();
+    let raw = std::fs::read_to_string(tmp.path().join("tauri.conf.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let schemes = v
+        .pointer("/plugins/deep-link/desktop/schemes")
+        .and_then(|s| s.as_array())
+        .unwrap();
+    assert_eq!(schemes[0].as_str(), Some("muragent-draft"));
+    assert_eq!(schemes[1].as_str(), Some("muragent-draft-dev"));
+}


### PR DESCRIPTION
## Summary

Re-opens the M-c3.1 work after #146 was auto-closed when its base branch (#145) merged. Branch rebased onto current main; commits are now standalone on top of the squashed M-c3.0 (\`f1771ff\`).

Adds **channel A** of the four Track C3 send-from-any-app channels — \`muragent-<slug>://share?text=<base64>&type={text|url}\` deep-link delivery. Per-agent slug is baked in at export time, so URLs targeting a different agent error out (a malicious page can't blast every running agent at once).

## Milestones (4 commits, unchanged from #146 except the rebase)

- **M-c3.1.1** — \`tauri-plugin-deep-link\` + \`muragent-{{AGENT_SLUG}}\` placeholder under \`plugins.deep-link.desktop.schemes\` in \`tauri.conf.json\` (Tauri 2 rejects \`bundle.macOS.urlSchemes\`).
- **M-c3.1.2** — \`parse_share_url(raw, expected_slug) -> SharePayload\` — strict validation: scheme matches \`muragent-<slug>\`, host = \`share\`, \`text=\` is base64url (\`URL_SAFE_NO_PAD\`), \`type=\` is \`text\`/\`url\`.
- **M-c3.1.3** — \`MockApp::simulate_open_url\` E2E via the pure-Rust test harness (no Tauri runtime needed).
- **M-c3.1.4** — \`agent_export_gui::phase_4_rewrite_tauri_conf\` injects the per-agent slug into the placeholder via \`apply_url_scheme_substitution\`.

## Test plan

- [x] \`cargo test --test send_url_scheme\` (10 pass on rebased branch)
- [x] \`cargo test -p mur-core --test agent_export_gui_url_scheme\` (4 pass)
- [ ] Manual: register the scheme via \`open\` after M-w1 wiring lands

## Stack note

PR #146 was auto-closed when \`gh pr merge 145 --delete-branch\` removed its base branch. Going forward, the cascade will retarget each PR to main + skip \`--delete-branch\` to avoid orphaning dependents (see deep-think discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)