### PR TITLE
feat(ui): Track C3 wiring M-w5 — App.tsx mounts startShareListener + share banner

### DIFF
--- a/mur-agent-gui/src-tauri/src/bootstrap.rs
+++ b/mur-agent-gui/src-tauri/src/bootstrap.rs
@@ -262,6 +262,13 @@ mod tests {
 
     #[test]
     fn bootstrap_extracts_template_payload() {
+        // Acquire the crate-wide env-var lock so we don't race with
+        // other tests that mutate `MUR_HOME` / `MUR_AGENT_BIN_DIR`
+        // (notably `send::wiring::tests`). `unwrap_or_else(into_inner)`
+        // tolerates a poisoned lock from a panic in another test.
+        let _g = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let tmp = tempdir_for_test();
         // Write a fake metadata + payload.
         let meta = EmbeddedMetadata {

--- a/mur-agent-gui/src-tauri/src/lib.rs
+++ b/mur-agent-gui/src-tauri/src/lib.rs
@@ -11,3 +11,14 @@ pub mod sidecar;
 pub mod test_harness;
 pub mod theme;
 pub mod voice;
+
+/// Process-wide env-var mutex shared by every `#[cfg(test)]` block
+/// that mutates `std::env`. Tests across modules (`bootstrap`,
+/// `send::wiring`) all touch `MUR_HOME` / `MUR_AGENT_BIN_DIR` /
+/// `MUR_GUI_AGENT_NAME`, and `cargo test --lib` runs them in
+/// parallel — without a shared lock they race and one test's
+/// `set_var` clobbers another's view mid-assertion. A single static
+/// here keeps them serial without forcing `--test-threads=1` for
+/// the whole CI job.
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/mur-agent-gui/src-tauri/src/send/wiring.rs
+++ b/mur-agent-gui/src-tauri/src/send/wiring.rs
@@ -230,13 +230,14 @@ pub fn register_share_hotkey(
 mod tests {
     use super::super::hotkey::default_combo_for;
     use super::*;
-    use std::sync::Mutex;
 
     // Tests in this module mutate process-wide env vars (MUR_HOME,
     // MUR_GUI_AGENT_NAME). Vitest-style parallel test execution
     // causes spurious failures when one test clears MUR_HOME mid-
-    // assertion in another. A single mutex serialises them.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    // assertion in another. The crate-wide `TEST_ENV_LOCK`
+    // (defined in `lib.rs`) is shared with `bootstrap::tests` so
+    // env-touching tests across both modules serialise globally.
+    use crate::TEST_ENV_LOCK as ENV_LOCK;
 
     #[test]
     fn agent_home_honors_mur_home_override() {

--- a/mur-agent-gui/ui/src/App.tsx
+++ b/mur-agent-gui/ui/src/App.tsx
@@ -15,6 +15,11 @@ import { Thumbnails } from "./multimodal/Thumbnails";
 import { multimodalDrop, multimodalPaste } from "./multimodal/api";
 import type { MultimodalArtifact } from "./multimodal/types";
 import { CompanionSidebar } from "./companion/CompanionSidebar";
+import { startShareListener, type ComposerHandle } from "./lib/share";
+import {
+  ShareComposerView,
+  type ShareDraft,
+} from "./components/ShareComposerView";
 import {
   setTheme as setThemeApi,
   getDefaultTheme,
@@ -68,6 +73,16 @@ export default function App() {
   const [artifacts, setArtifacts] = useState<MultimodalArtifact[]>([]);
   const [turnId] = useState<number>(1);
 
+  // Track C3 — latest share payload for the "Shared with you" banner
+  // at the top of the window. The Rust ingestor (`DefaultIngestor`)
+  // emits `share:received` after the multimodal pipeline has
+  // wrapped the bytes in `<untrusted_share>`; the listener stashes
+  // the payload here so the user gets a visible confirmation that
+  // the share actually landed. Dismissing the banner clears it;
+  // the chat tab integration that consumes this draft directly
+  // lands in a follow-up.
+  const [shareDraft, setShareDraft] = useState<ShareDraft | null>(null);
+
   useEffect(() => {
     const u = listen<string[]>("multimodal://drop", async (e) => {
       const paths = e.payload;
@@ -82,6 +97,44 @@ export default function App() {
       u.then((un) => un()).catch(() => {});
     };
   }, [agent, turnId]);
+
+  // Track C3 — mount `share:received` listener.
+  //
+  // The composer handle is a lightweight `useState`-backed view: the
+  // first share creates a draft (badge + body or attachment); each
+  // subsequent share replaces it (the banner only ever shows the
+  // most recent share so the user sees the confirmation that just
+  // arrived, not a backlog). This mirrors the `ShareDraft` shape
+  // the unit-test harness exercises (`ShareComposerView.test.tsx`).
+  useEffect(() => {
+    const composer: ComposerHandle = {
+      insert: (text) => {
+        setShareDraft((prev) => ({
+          badge: prev?.badge ?? null,
+          body: text,
+          attachment: prev?.attachment,
+        }));
+      },
+      addBadge: (b) => {
+        setShareDraft((prev) => ({
+          badge: { ...b },
+          body: prev?.body ?? "",
+          attachment: prev?.attachment,
+        }));
+      },
+      attachFile: (path, kindLabel) => {
+        setShareDraft((prev) => ({
+          badge: prev?.badge ?? null,
+          body: prev?.body ?? "",
+          attachment: { path, kindLabel },
+        }));
+      },
+    };
+    const u = startShareListener(composer);
+    return () => {
+      u.then((un) => un()).catch(() => {});
+    };
+  }, []);
 
   useEffect(() => {
     const onPaste = async (e: ClipboardEvent) => {
@@ -185,6 +238,30 @@ export default function App() {
         </ul>
       </nav>
       <main className="flex-1 overflow-auto p-6">
+        {/* Track C3 — "Shared with you" banner. Renders the most
+            recent share landed via any of the four channels (URL
+            scheme / hotkey / Services menu / dock-drop). The chat
+            tab integration that picks up `shareDraft` directly
+            lands in a follow-up; until then the banner is a visible
+            confirmation that the share actually reached the agent.
+            Dismiss button clears it locally — the underlying
+            `<untrusted_share>`-wrapped artifact is already on disk
+            and visible to the next agent turn. */}
+        {shareDraft && (
+          <div className="mb-4 flex items-start gap-2">
+            <div className="flex-1">
+              <ShareComposerView draft={shareDraft} />
+            </div>
+            <button
+              className="self-start rounded border px-2 py-1 text-xs"
+              style={{ borderColor: "var(--color-border)" }}
+              onClick={() => setShareDraft(null)}
+              aria-label="dismiss-share"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
         <Thumbnails
           artifacts={artifacts}
           onRemove={(sha) =>


### PR DESCRIPTION
## Summary

Closes the React-side wiring for Track C3. The `share:received` Tauri event (emitted by `DefaultIngestor::emit_received` after each channel's payload has been wrapped by B0) now reaches React and triggers a visible "Shared with you" banner at the top of the main pane.

## What's new

\`App.tsx\`:
- \`useEffect\` mounts \`startShareListener\` once on first render and cleans up on unmount.
- Composer handle backs a single \`ShareDraft | null\` state slot (\`shareDraft\`); each fresh \`share:received\` replaces the prior draft so the user sees the most-recent confirmation, not a backlog.
- Composer mutators map to draft fields:
  - \`insert(text)\` → body
  - \`addBadge({source, kindLabel})\` → badge
  - \`attachFile(path, kindLabel)\` → attachment
- Renders \`<ShareComposerView>\` at the top of the main pane when \`shareDraft\` is non-null, with a "Dismiss" button.

The underlying \`<untrusted_share>\`-wrapped artifact is already on disk by the time React sees the event (the ingestor's \`process_share_text\` / \`process_artifact\` calls land it before \`emit_received\`), so the banner is purely a confirmation UI — dismissing it doesn't drop the share.

## Test plan

- [x] \`npx tsc -b --noEmit\` clean
- [x] \`npm test -- --run\` (18 vitest pass — share handler + ShareBadge + ShareComposerView + parseBridgeEvent)
- [ ] Manual: build a real GUI bundle, fire \`open 'muragent-coach://share?text=...'\`, verify the banner appears in the settings window
- [ ] Manual: hit \`Cmd+Shift+M+<X>\` with text in clipboard, verify the banner appears

## Track C3 wiring follow-up status

| Milestone | Channel | Status |
|---|---|---|
| M-w1 (#152) | A — deep-link | merged |
| M-w2 (#153) | B — hotkey + clipboard | merged |
| M-w3 (#155) | C — Services Info.plist export | merged |
| M-w4 (#157) | D — drag-to-dock RunEvent::Opened | open |
| **M-w5 (this)** | composer — App.tsx mount | open |
| M-w3b | C — Services runtime registration (objc2 subclass) | pending |
| M-w6 | acceptance — \`--self-test=*\` modes | pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)