### PR TITLE
feat(gui): Track C3 wiring M-w6 — --self-test=<mode> binary modes

### DIFF
--- a/mur-agent-gui/src-tauri/src/lib.rs
+++ b/mur-agent-gui/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bootstrap;
 pub mod commands;
 pub mod companion_bridge;
 pub mod multimodal;
+pub mod self_test;
 pub mod send;
 pub mod sidecar;
 pub mod test_harness;

--- a/mur-agent-gui/src-tauri/src/main.rs
+++ b/mur-agent-gui/src-tauri/src/main.rs
@@ -5,6 +5,7 @@ mod bootstrap;
 mod commands;
 mod companion_bridge;
 mod multimodal;
+mod self_test;
 mod send;
 mod sidecar;
 mod theme;
@@ -15,6 +16,26 @@ use tracing::info;
 use tracing_subscriber::EnvFilter;
 
 fn main() -> Result<()> {
+    // ── Track C3 / M-w6 — `--self-test=<mode>` short-circuit ──────
+    //
+    // The e2e script (`scripts/e2e/c3-send-from-any-app.sh`) builds
+    // a real bundle and invokes it directly to verify each channel's
+    // parser/decoder/classifier survives bundling + signing. Bail
+    // out before the Tauri runtime starts so the binary just
+    // exercises the pure seam and exits.
+    if let Some(mode) = self_test::parse_self_test_arg() {
+        match self_test::run(&mode) {
+            Ok(()) => {
+                println!("OK {mode}");
+                return Ok(());
+            }
+            Err(e) => {
+                eprintln!("FAIL {mode}: {e:#}");
+                std::process::exit(1);
+            }
+        }
+    }
+
     init_tracing();
 
     info!("starting mur-agent-gui");

--- a/mur-agent-gui/src-tauri/src/self_test.rs
+++ b/mur-agent-gui/src-tauri/src/self_test.rs
@@ -1,0 +1,159 @@
+//! Track C3 / M-w6 — `--self-test=<mode>` binary modes.
+//!
+//! The e2e script `scripts/e2e/c3-send-from-any-app.sh` builds a real
+//! GUI bundle and then invokes the binary directly to verify each
+//! channel's parser/decoder/classifier survives the bundling +
+//! signing path. Without these modes, the script can only run the
+//! harness (`cargo test`) — which doesn't exercise the production
+//! build.
+//!
+//! Each mode runs a minimal end-to-end through the channel's pure
+//! seam (no Tauri runtime, no plugins) and exits with `OK <mode>`
+//! on success or `FAIL <mode>: <error>` on failure. The e2e script
+//! greps for the `OK` line.
+//!
+//! Modes:
+//! - `ping` — sanity check; verifies the binary launches and the
+//!   self-test dispatcher itself works
+//! - `url-scheme` — `parse_share_url` round-trip
+//! - `hotkey` — `synthesize_from_clipboard` against a `FakeClipboard`
+//! - `services` (macOS only) — `extract_payload_from_pasteboard`
+//! - `dock-image` (macOS only) — `classify_path` on a `.png` path
+//!
+//! The full production wiring (deep-link delivery, hotkey
+//! registration, NSApplication.servicesProvider, RunEvent::Opened)
+//! is exercised by manual QA — automating it across CI hosts would
+//! require XCTest / Spectator-style harness that's outside this
+//! PR series's scope.
+
+use std::path::PathBuf;
+
+use crate::send::ShareKind;
+
+/// Parse `--self-test=<mode>` from `std::env::args()`. Returns the
+/// mode string if present, `None` otherwise. Accepts both
+/// `--self-test=mode` and `--self-test mode` forms.
+pub fn parse_self_test_arg() -> Option<String> {
+    let mut args = std::env::args();
+    while let Some(arg) = args.next() {
+        if let Some(value) = arg.strip_prefix("--self-test=") {
+            return Some(value.to_string());
+        }
+        if arg == "--self-test" {
+            return args.next();
+        }
+    }
+    None
+}
+
+/// Run the named self-test mode. Returns `Ok(())` on success;
+/// callers print `OK <mode>` and exit 0. On `Err`, callers print
+/// `FAIL <mode>: <error>` and exit 1.
+pub fn run(mode: &str) -> anyhow::Result<()> {
+    match mode {
+        "ping" => Ok(()),
+        "url-scheme" => self_test_url_scheme(),
+        "hotkey" => self_test_hotkey(),
+        #[cfg(target_os = "macos")]
+        "services" => self_test_services(),
+        #[cfg(target_os = "macos")]
+        "dock-image" => self_test_dock_image(),
+        other => anyhow::bail!("unknown self-test mode `{other}`"),
+    }
+}
+
+fn self_test_url_scheme() -> anyhow::Result<()> {
+    use base64::Engine;
+    let body = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode("hello self-test");
+    let url = format!("muragent-coach://share?text={body}&type=text");
+    let payload = crate::send::url_scheme::parse_share_url(&url, "coach")?;
+    match payload.kind {
+        ShareKind::Text(t) if t == "hello self-test" => Ok(()),
+        other => anyhow::bail!("unexpected payload kind: {other:?}"),
+    }
+}
+
+fn self_test_hotkey() -> anyhow::Result<()> {
+    use crate::send::hotkey::{FakeClipboard, synthesize_from_clipboard};
+    // Block in-place since this runs before the Tauri runtime
+    // starts; spinning up a full tokio runtime just for one
+    // synthesizer call is overkill, so block on a single-thread rt.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let cb = FakeClipboard::with_text("hello self-test");
+    let payload = rt.block_on(synthesize_from_clipboard(&cb))?;
+    match payload.kind {
+        ShareKind::Text(t) if t == "hello self-test" => Ok(()),
+        other => anyhow::bail!("unexpected payload kind: {other:?}"),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn self_test_services() -> anyhow::Result<()> {
+    use crate::send::services::extract_payload_from_pasteboard;
+    use crate::send::services::test_helpers::pasteboard_with_text;
+    let pb = pasteboard_with_text("hello self-test");
+    let payload = extract_payload_from_pasteboard(&pb)?;
+    match payload.kind {
+        ShareKind::Text(t) if t == "hello self-test" => Ok(()),
+        other => anyhow::bail!("unexpected payload kind: {other:?}"),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn self_test_dock_image() -> anyhow::Result<()> {
+    use crate::send::dock::classify_path;
+    let p = PathBuf::from("/tmp/mur-self-test.png");
+    match classify_path(&p) {
+        ShareKind::Image(_) => Ok(()),
+        other => anyhow::bail!("expected ShareKind::Image, got {other:?}"),
+    }
+}
+
+// `PathBuf` is only used by macOS-gated paths; keep the import
+// referenced on Linux/Windows so the self-test module still
+// compiles cross-platform.
+#[cfg(not(target_os = "macos"))]
+fn _silence_pathbuf(_: &PathBuf) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_self_test_arg_handles_equals_form() {
+        // `parse_self_test_arg` reads from `std::env::args()`, which
+        // we can't override at test time; instead, just verify the
+        // happy path through the dispatch surface.
+        assert!(run("ping").is_ok());
+    }
+
+    #[test]
+    fn run_url_scheme_round_trips() {
+        run("url-scheme").expect("url-scheme self-test must pass");
+    }
+
+    #[test]
+    fn run_hotkey_round_trips() {
+        run("hotkey").expect("hotkey self-test must pass");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn run_services_round_trips() {
+        run("services").expect("services self-test must pass");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn run_dock_image_classifies_png() {
+        run("dock-image").expect("dock-image self-test must pass");
+    }
+
+    #[test]
+    fn run_unknown_mode_errors() {
+        let err = run("nonexistent").unwrap_err();
+        assert!(err.to_string().contains("unknown self-test mode"));
+    }
+}


### PR DESCRIPTION
## Summary

Closes the Track C3 production-wiring follow-up. The other 5 wiring milestones (M-w1/w2/w3/w3b/w4/w5) cover deep-link / hotkey / Services Info.plist / dock / Services runtime registration / React mount; this PR adds the binary self-tests so `scripts/e2e/c3-send-from-any-app.sh` can exercise the **production build** (signed bundle, real Tauri ICU loading) — not just the harness.

## What's new

\`src/self_test.rs\`:
- \`parse_self_test_arg()\` — reads \`--self-test=<mode>\` from \`std::env::args()\`
- \`run(mode)\` — dispatches each channel through its pure seam:
  - \`ping\` — sanity check (binary launched + dispatcher works)
  - \`url-scheme\` — \`parse_share_url\` round-trip
  - \`hotkey\` — \`synthesize_from_clipboard\` against a \`FakeClipboard\` (current-thread tokio runtime built in-place since Tauri's runtime hasn't started yet)
  - \`services\` (macOS) — \`extract_payload_from_pasteboard\` against \`pasteboardWithUniqueName\`
  - \`dock-image\` (macOS) — \`classify_path\` on a \`.png\` path
- Each mode exercises the channel's pure seam (no Tauri runtime, no plugins) and returns \`Ok(())\` on success.

\`main.rs\` short-circuits before tracing init / Tauri builder:
- \`OK <mode>\` to stdout + exit 0 on success
- \`FAIL <mode>: <error>\` to stderr + exit 1 on failure

The e2e script greps for the \`OK\` line. Manual production QA (real deep-link delivery, hotkey registration, Services menu invocation, dock-drop) stays in the cookbook matrix.

## Bundles cherry-picked fixes (so this PR can target main directly)

- \`fix(M-w4)\`: drop unused \`default_combo_for\` import (lib clippy)
- \`chore(fmt)\`: mur-core files
- \`fix(test)\`: CRLF normalisation in Info.plist substring
- \`chore(fmt)\`: gui crate

These will go away on rebase once the parent PRs (#157/#159/#158) merge to main.

## Test plan

- [x] \`cargo clippy --lib -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --lib self_test\` (6 inline tests pass)
- [ ] Manual: build a real bundle and run \`./MyAgent.app/Contents/MacOS/MyAgent --self-test=ping\` → "OK ping"

## Track C3 wiring follow-up status

| Milestone | Channel / Layer | Status |
|---|---|---|
| M-w1 (#152) | A — deep-link | merged |
| M-w2 (#153) | B — hotkey + clipboard | merged |
| M-w3 (#155) | C — Services Info.plist export | merged |
| M-w4 (#157) | D — dock RunEvent::Opened | open |
| M-w3b (#159) | C — Services runtime registration (objc2) | open |
| M-w5 (#158) | composer — App.tsx mount | open |
| **M-w6 (this)** | acceptance — \`--self-test=*\` modes | open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)