### PR TITLE
feat(gui): M3.5.3 — Linux/Windows tesseract OCR backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           node-version-file: 'mur-agent-gui/ui/.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'mur-agent-gui/ui/package-lock.json'
-      - name: Install Linux system libraries (Tauri 2 + voice)
+      - name: Install Linux system libraries (Tauri 2 + voice + OCR)
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -96,7 +96,9 @@ jobs:
             libasound2-dev \
             pkg-config \
             protobuf-compiler \
-            libprotobuf-dev
+            libprotobuf-dev \
+            tesseract-ocr \
+            tesseract-ocr-eng
       - name: Install npm deps
         run: cd mur-agent-gui/ui && npm ci
       - name: Frontend build (populates dist/ for cargo check)

--- a/mur-agent-gui/src-tauri/src/multimodal/ocr/mod.rs
+++ b/mur-agent-gui/src-tauri/src/multimodal/ocr/mod.rs
@@ -18,6 +18,9 @@ pub mod platform;
 #[cfg(target_os = "macos")]
 pub mod vision;
 
+#[cfg(not(target_os = "macos"))]
+pub mod tesseract;
+
 pub struct OcrResult {
     pub text: String,
     pub engine_version: String,

--- a/mur-agent-gui/src-tauri/src/multimodal/ocr/platform.rs
+++ b/mur-agent-gui/src-tauri/src/multimodal/ocr/platform.rs
@@ -15,9 +15,20 @@ mod imp {
 #[cfg(not(target_os = "macos"))]
 mod imp {
     pub fn default_engine() -> Box<dyn super::super::OcrEngine> {
-        // TODO(M3.5.3): try TesseractOcr::new() and fall back to NoopOcr
-        // if the tesseract binary isn't on PATH.
-        Box::new(super::super::NoopOcr)
+        // M3.5.3 — try the system `tesseract` binary; fall back to
+        // `NoopOcr` when it isn't on PATH so a fresh install boots
+        // cleanly. The cookbook documents the install step
+        // (`apt install tesseract-ocr` / `winget install
+        // UB-Mannheim.TesseractOCR`).
+        match super::super::tesseract::TesseractOcr::try_new() {
+            Some(t) => Box::new(t),
+            None => {
+                tracing::info!(
+                    "tesseract not on PATH; OCR disabled until installed (using NoopOcr)"
+                );
+                Box::new(super::super::NoopOcr)
+            }
+        }
     }
 }
 

--- a/mur-agent-gui/src-tauri/src/multimodal/ocr/tesseract.rs
+++ b/mur-agent-gui/src-tauri/src/multimodal/ocr/tesseract.rs
@@ -58,9 +58,8 @@ impl TesseractOcr {
 
 fn parse_version(text: &str) -> Option<String> {
     text.lines()
-        .next()
         .map(str::trim)
-        .filter(|line| !line.is_empty())
+        .find(|line| !line.is_empty())
         .map(str::to_string)
 }
 

--- a/mur-agent-gui/src-tauri/src/multimodal/ocr/tesseract.rs
+++ b/mur-agent-gui/src-tauri/src/multimodal/ocr/tesseract.rs
@@ -1,0 +1,199 @@
+//! M3.5.3 — Linux / Windows OCR backend via the `tesseract` CLI.
+//!
+//! Shells out to the system `tesseract` binary (`apt install
+//! tesseract-ocr` / `winget install UB-Mannheim.TesseractOCR` /
+//! `brew install tesseract`) rather than linking against
+//! `libtesseract` directly. Trade-offs:
+//!
+//! - **Pro:** zero native build deps. CI just needs the binary on
+//!   PATH; the Rust code stays portable. Bundle install instructions
+//!   live in the cookbook.
+//! - **Pro:** version skew is the user's problem — they install
+//!   whatever their distro ships and we report it via `--version`.
+//! - **Con:** ~50 ms process spawn overhead per image. OCR pre-pass
+//!   runs once per dropped image so this is fine; if it ever moves
+//!   into a hot loop, switch to the `tesseract` crate's C bindings.
+//! - **Con:** binary not on PATH → graceful degradation to `NoopOcr`.
+//!   Users see "" for OCR text instead of an error; the cookbook
+//!   documents the install step.
+//!
+//! macOS is gated out — `vision::VisionOcr` is the macOS default
+//! (M3.5.2). Skipping macOS keeps the module tree focused: no
+//! Cocoa/objc2 in this file.
+
+#![cfg(not(target_os = "macos"))]
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use super::{OcrEngine, OcrResult};
+
+pub struct TesseractOcr {
+    /// Cached `tesseract --version` output (first line). Captured
+    /// once at construction so each `recognize_png` call doesn't
+    /// re-shell. Falls back to `"unknown"` if the version line
+    /// can't be parsed.
+    version: String,
+}
+
+impl TesseractOcr {
+    /// Probe `PATH` for a working `tesseract` binary. Returns `None`
+    /// if the probe fails (binary missing, wrong arch, sandbox
+    /// blocking spawn) so the caller can fall back to
+    /// [`super::NoopOcr`] without surfacing an error to the user.
+    pub fn try_new() -> Option<Self> {
+        let output = Command::new("tesseract").arg("--version").output().ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        // tesseract prints version on stderr OR stdout depending on
+        // the build; sample both and take the first non-empty line
+        // mentioning "tesseract".
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let version = parse_version(&stderr).or_else(|| parse_version(&stdout))?;
+        Some(Self { version })
+    }
+}
+
+fn parse_version(text: &str) -> Option<String> {
+    text.lines()
+        .next()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+}
+
+impl OcrEngine for TesseractOcr {
+    fn recognize_png(&self, png_bytes: &[u8]) -> OcrResult {
+        let text = match recognize(png_bytes) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "tesseract OCR failed; returning empty");
+                String::new()
+            }
+        };
+        OcrResult {
+            text,
+            engine_version: format!("tesseract-cli/{}", self.version),
+        }
+    }
+}
+
+fn recognize(png_bytes: &[u8]) -> anyhow::Result<String> {
+    if png_bytes.is_empty() {
+        return Ok(String::new());
+    }
+    // `tesseract <stdin> <stdout>` — pipes PNG bytes in, UTF-8 text
+    // out. `-l eng` matches the system's default; multi-language
+    // support is a follow-up (the user can override via the
+    // `TESSERACT_LANG` env var if they care today).
+    let lang = std::env::var("TESSERACT_LANG").unwrap_or_else(|_| "eng".to_string());
+    let mut child = Command::new("tesseract")
+        .args(["stdin", "stdout", "-l", &lang])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    {
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("tesseract stdin unavailable"))?;
+        stdin.write_all(png_bytes)?;
+    }
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("tesseract exit {:?}: {}", output.status.code(), stderr);
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .trim_end()
+        .to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `try_new` succeeds in CI / dev environments where tesseract
+    /// is installed; on hosts without it the test is skipped via
+    /// the early return so the rest of the suite still runs.
+    fn require_tesseract() -> Option<TesseractOcr> {
+        TesseractOcr::try_new()
+    }
+
+    #[test]
+    fn empty_input_returns_empty_string() {
+        let Some(ocr) = require_tesseract() else {
+            eprintln!("tesseract not on PATH — skipping");
+            return;
+        };
+        let result = ocr.recognize_png(&[]);
+        assert_eq!(result.text, "");
+        assert!(result.engine_version.starts_with("tesseract-cli/"));
+    }
+
+    #[test]
+    fn invalid_png_returns_empty_string_not_panic() {
+        let Some(ocr) = require_tesseract() else {
+            eprintln!("tesseract not on PATH — skipping");
+            return;
+        };
+        // tesseract refuses to decode random bytes and exits non-zero;
+        // the error path returns "" to keep the engine surface
+        // consistent with NoopOcr / VisionOcr.
+        let result = ocr.recognize_png(b"not a valid png");
+        assert_eq!(result.text, "");
+    }
+
+    #[test]
+    fn tiny_blank_png_returns_empty_string() {
+        let Some(ocr) = require_tesseract() else {
+            eprintln!("tesseract not on PATH — skipping");
+            return;
+        };
+        // 1x1 transparent PNG carries no text so OCR must yield "".
+        let png = std::fs::read("tests/fixtures/tiny.png").unwrap();
+        let result = ocr.recognize_png(&png);
+        assert_eq!(result.text, "");
+    }
+
+    #[test]
+    fn try_new_returns_none_when_binary_missing() {
+        // Force PATH to an empty value so `tesseract` resolution
+        // fails. Restore it afterwards. Locked via the crate-wide
+        // `TEST_ENV_LOCK` to avoid racing with bootstrap / wiring
+        // tests that also mutate `std::env`.
+        let _g = crate::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let prior = std::env::var_os("PATH");
+        unsafe {
+            std::env::set_var("PATH", "");
+        }
+        let result = TesseractOcr::try_new();
+        if let Some(p) = prior {
+            unsafe {
+                std::env::set_var("PATH", p);
+            }
+        } else {
+            unsafe {
+                std::env::remove_var("PATH");
+            }
+        }
+        assert!(result.is_none(), "expected None when PATH is empty");
+    }
+
+    #[test]
+    fn parse_version_extracts_first_nonblank_line() {
+        let text = "\n\ntesseract 5.3.0\n leptonica-1.83.1\n";
+        assert_eq!(parse_version(text).as_deref(), Some("tesseract 5.3.0"));
+    }
+
+    #[test]
+    fn parse_version_returns_none_for_empty_input() {
+        assert_eq!(parse_version(""), None);
+        assert_eq!(parse_version("\n\n\n"), None);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the other half of B0 rule 14 ("local OCR pre-pass") on Linux/Windows. macOS got Vision.framework in M3.5.2 (#161); this PR shells out to the system \`tesseract\` CLI for everywhere else.

## Trade-off

**Shell out to the binary** rather than link against \`libtesseract\`:
- ✅ zero native build deps in CI
- ✅ portable Rust code, no \`tesseract-sys\` cross-compile dance
- ✅ version skew is the user's problem (\`apt install tesseract-ocr\` etc.)
- ⚠️ ~50 ms process spawn per image — fine since OCR runs once per dropped image, not in a hot loop. If perf ever matters, swap to the \`tesseract\` crate.

## What's new

\`src/multimodal/ocr/tesseract.rs\` (Linux/Windows-only):
- \`TesseractOcr\` + \`OcrEngine\` impl
- \`try_new()\` — probes for the binary via \`tesseract --version\`; returns \`None\` if missing so callers fall back to \`NoopOcr\` cleanly
- \`recognize()\` — pipes PNG bytes to \`tesseract stdin stdout -l <lang>\`, reads UTF-8 from stdout
- \`TESSERACT_LANG\` env var overrides the default \`eng\`

\`src/multimodal/ocr/platform.rs\` (non-macOS arm):
- Tries \`TesseractOcr::try_new()\`; logs and falls back to \`NoopOcr\` when missing

\`.github/workflows/ci.yml\` (GUI crate job):
- Adds \`tesseract-ocr\` + \`tesseract-ocr-eng\` to the Linux apt-get list so the tests that require the binary actually run

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo clippy --lib -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] On macOS, the module is cfg-gated out so \`cargo test --lib\` is unaffected (88+3 from M3.5.2 = 91 still pass)
- [ ] Linux CI runner: with \`tesseract-ocr\` installed, the 5 new tests run and pass
- [ ] Windows CI runner: \`try_new()\` returns \`None\` (no tesseract on default Windows runner); tests log + skip gracefully
- [ ] Manual: drop a screenshot with text onto a built bundle on Linux, verify \`telemetry/inputs.jsonl\` has the OCR text

## Notes

- Failures (invalid PNG, non-zero exit) log at warn and return empty string, matching \`NoopOcr\` / \`VisionOcr\` shape so the multimodal pipeline doesn't have to special-case OCR errors.
- The "binary missing → graceful degradation" path means a fresh GUI install boots cleanly even without tesseract; the cookbook documents the install step.
- \`try_new_returns_none_when_binary_missing\` mutates \`$PATH\` and acquires the crate-wide \`TEST_ENV_LOCK\` (introduced in #160's deflake fix) to avoid racing with \`bootstrap::tests\` / \`send::wiring::tests\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)