### PR TITLE
feat(hook): M5 hook stats — mur hook stats telemetry dashboard

### DIFF
--- a/mur-core/src/cmd/hook.rs
+++ b/mur-core/src/cmd/hook.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::io::Read;
 
 use crate::inject::event::{EventKind, parse_event};
@@ -234,7 +234,12 @@ pub(crate) async fn cmd_hook_session_start(tool: &str) -> Result<()> {
 }
 
 pub(crate) fn cmd_hook_stats() -> Result<()> {
-    println!("hook stats: not yet implemented (M5)");
+    let home = dirs::home_dir().context("could not determine home directory")?;
+    let queue_path = home.join(".mur").join("queue").join("events.jsonl");
+    let events = crate::inject::queue::read_all_events(&queue_path);
+    let stats = crate::inject::stats::compute(&events);
+    let output = crate::inject::stats::format_stats(&stats, &queue_path.display().to_string());
+    print!("{output}");
     Ok(())
 }
 

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod evolve_cmd;
 pub(crate) mod hook;
 pub(crate) mod init;
 pub(crate) mod init_local;
+pub(crate) mod hook;
 pub(crate) mod inject_cmd;
 pub(crate) mod learn;
 pub(crate) mod misc;

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -14,7 +14,6 @@ pub(crate) mod evolve_cmd;
 pub(crate) mod hook;
 pub(crate) mod init;
 pub(crate) mod init_local;
-pub(crate) mod hook;
 pub(crate) mod inject_cmd;
 pub(crate) mod learn;
 pub(crate) mod misc;

--- a/mur-core/src/inject/mod.rs
+++ b/mur-core/src/inject/mod.rs
@@ -2,4 +2,5 @@ pub mod event;
 pub mod hook;
 pub mod index;
 pub mod queue;
+pub mod stats;
 pub mod sync;

--- a/mur-core/src/inject/queue.rs
+++ b/mur-core/src/inject/queue.rs
@@ -12,7 +12,7 @@ pub fn enqueue(event: &NormalizedEvent) -> Result<()> {
     enqueue_to(event, &queue_dir.join("events.jsonl"))
 }
 
-fn enqueue_to(event: &NormalizedEvent, path: &Path) -> Result<()> {
+pub fn enqueue_to(event: &NormalizedEvent, path: &Path) -> Result<()> {
     let line = serde_json::to_string(event)? + "\n";
     let mut f = std::fs::OpenOptions::new()
         .create(true)

--- a/mur-core/src/inject/queue.rs
+++ b/mur-core/src/inject/queue.rs
@@ -22,6 +22,21 @@ fn enqueue_to(event: &NormalizedEvent, path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Read all events from the queue file. Returns an empty Vec if the file
+/// does not exist or cannot be read. Malformed JSON lines are silently skipped
+/// so a corrupt line never crashes the stats command.
+#[allow(dead_code)] // called from cmd::hook_stats in Task 3
+pub fn read_all_events(path: &Path) -> Vec<NormalizedEvent> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,5 +96,37 @@ mod tests {
         assert_eq!(lines.len(), 2, "both events must be present (append mode)");
         let ev0: NormalizedEvent = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(ev0.query.as_deref(), Some("first"));
+    }
+
+    #[test]
+    fn read_all_events_returns_empty_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent.jsonl");
+        let events = read_all_events(&path);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn read_all_events_parses_written_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        enqueue_to(&make_event("first"), &path).unwrap();
+        enqueue_to(&make_event("second"), &path).unwrap();
+        let events = read_all_events(&path);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].query.as_deref(), Some("first"));
+        assert_eq!(events[1].query.as_deref(), Some("second"));
+    }
+
+    #[test]
+    fn read_all_events_skips_malformed_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        std::fs::write(&path, "not-json\n{\"bad\":true}\n").unwrap();
+        let events = read_all_events(&path);
+        assert!(
+            events.is_empty(),
+            "malformed lines must be silently skipped"
+        );
     }
 }

--- a/mur-core/src/inject/queue.rs
+++ b/mur-core/src/inject/queue.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use std::io::Write;
+use std::io::{BufRead, Write};
 use std::path::Path;
 
 use super::event::NormalizedEvent;
@@ -27,13 +27,20 @@ fn enqueue_to(event: &NormalizedEvent, path: &Path) -> Result<()> {
 /// so a corrupt line never crashes the stats command.
 #[allow(dead_code)] // called from cmd::hook_stats in Task 3
 pub fn read_all_events(path: &Path) -> Vec<NormalizedEvent> {
-    let Ok(content) = std::fs::read_to_string(path) else {
-        return Vec::new();
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Vec::new(),
     };
-    content
+    std::io::BufReader::new(file)
         .lines()
-        .filter(|l| !l.trim().is_empty())
-        .filter_map(|line| serde_json::from_str(line).ok())
+        .filter_map(|line| {
+            let l = line.ok()?;
+            let trimmed = l.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            serde_json::from_str(trimmed).ok()
+        })
         .collect()
 }
 
@@ -128,5 +135,21 @@ mod tests {
             events.is_empty(),
             "malformed lines must be silently skipped"
         );
+    }
+
+    #[test]
+    fn read_all_events_returns_empty_for_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        std::fs::write(&path, "").unwrap();
+        assert!(read_all_events(&path).is_empty());
+    }
+
+    #[test]
+    fn read_all_events_skips_blank_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        std::fs::write(&path, "\n\n  \n").unwrap();
+        assert!(read_all_events(&path).is_empty());
     }
 }

--- a/mur-core/src/inject/stats.rs
+++ b/mur-core/src/inject/stats.rs
@@ -1,0 +1,206 @@
+use std::collections::HashMap;
+
+use crate::inject::event::{EventKind, NormalizedEvent};
+
+#[allow(dead_code)] // called from cmd::hook_stats in Task 3
+#[derive(Debug, Default)]
+pub struct HookStats {
+    pub total: usize,
+    pub by_kind: HashMap<String, usize>,
+    pub by_provider: HashMap<String, usize>,
+    /// Top tools sorted descending by call count, truncated to 5.
+    pub top_tools: Vec<(String, usize)>,
+    pub unique_sessions: usize,
+}
+
+#[allow(dead_code)] // called from cmd::hook_stats in Task 3
+pub fn compute(events: &[NormalizedEvent]) -> HookStats {
+    let mut by_kind: HashMap<String, usize> = HashMap::new();
+    let mut by_provider: HashMap<String, usize> = HashMap::new();
+    let mut tool_counts: HashMap<String, usize> = HashMap::new();
+    let mut sessions: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for ev in events {
+        let kind_key = match ev.kind {
+            EventKind::Prompt => "Prompt",
+            EventKind::Tool => "Tool",
+            EventKind::Stop => "Stop",
+            EventKind::SessionStart => "SessionStart",
+        };
+        *by_kind.entry(kind_key.to_owned()).or_default() += 1;
+        *by_provider.entry(ev.tool_provider.clone()).or_default() += 1;
+        if let Some(tool) = &ev.tool_called {
+            *tool_counts.entry(tool.clone()).or_default() += 1;
+        }
+        if let Some(sid) = &ev.session_id {
+            sessions.insert(sid.clone());
+        }
+    }
+
+    let mut top_tools: Vec<(String, usize)> = tool_counts.into_iter().collect();
+    top_tools.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+    top_tools.truncate(5);
+
+    HookStats {
+        total: events.len(),
+        by_kind,
+        by_provider,
+        top_tools,
+        unique_sessions: sessions.len(),
+    }
+}
+
+#[allow(dead_code)] // called from cmd::hook_stats in Task 3
+pub fn format_stats(stats: &HookStats, queue_path: &str) -> String {
+    if stats.total == 0 {
+        return format!("No hook events recorded yet.\nQueue: {queue_path}\n");
+    }
+
+    let mut out = String::new();
+    out.push_str(&format!("Hook events  ({})\n", queue_path));
+    out.push_str(&format!("  Total:     {}\n", stats.total));
+    out.push_str(&format!("  Sessions:  {}\n", stats.unique_sessions));
+
+    out.push_str("\nBy kind:\n");
+    for kind in ["Prompt", "Tool", "Stop", "SessionStart"] {
+        if let Some(n) = stats.by_kind.get(kind) {
+            out.push_str(&format!("  {:<16}{}\n", format!("{kind}:"), n));
+        }
+    }
+
+    if !stats.top_tools.is_empty() {
+        out.push_str("\nTop tools:\n");
+        for (tool, n) in &stats.top_tools {
+            out.push_str(&format!("  {:<16}{}\n", format!("{tool}:"), n));
+        }
+    }
+
+    if stats.by_provider.len() > 1 {
+        out.push_str("\nProviders:\n");
+        let mut providers: Vec<_> = stats.by_provider.iter().collect();
+        providers.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+        for (prov, n) in providers {
+            out.push_str(&format!("  {:<16}{}\n", format!("{prov}:"), n));
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inject::event::{EventKind, NormalizedEvent};
+
+    fn ev(
+        kind: EventKind,
+        provider: &str,
+        tool: Option<&str>,
+        session: Option<&str>,
+    ) -> NormalizedEvent {
+        NormalizedEvent {
+            kind,
+            tool_provider: provider.into(),
+            query: None,
+            tool_called: tool.map(str::to_owned),
+            tool_input: None,
+            stop_reason: None,
+            session_id: session.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn compute_empty_returns_all_zeroes() {
+        let stats = compute(&[]);
+        assert_eq!(stats.total, 0);
+        assert_eq!(stats.unique_sessions, 0);
+        assert!(stats.by_kind.is_empty());
+        assert!(stats.top_tools.is_empty());
+    }
+
+    #[test]
+    fn compute_counts_events_by_kind() {
+        let events = vec![
+            ev(EventKind::Prompt, "claude", None, None),
+            ev(EventKind::Prompt, "claude", None, None),
+            ev(EventKind::Tool, "claude", Some("Edit"), None),
+            ev(EventKind::Stop, "claude", None, None),
+        ];
+        let stats = compute(&events);
+        assert_eq!(stats.total, 4);
+        assert_eq!(stats.by_kind["Prompt"], 2);
+        assert_eq!(stats.by_kind["Tool"], 1);
+        assert_eq!(stats.by_kind["Stop"], 1);
+    }
+
+    #[test]
+    fn compute_top_tools_sorted_descending() {
+        let events = vec![
+            ev(EventKind::Tool, "claude", Some("Bash"), None),
+            ev(EventKind::Tool, "claude", Some("Bash"), None),
+            ev(EventKind::Tool, "claude", Some("Bash"), None),
+            ev(EventKind::Tool, "claude", Some("Edit"), None),
+            ev(EventKind::Tool, "claude", Some("Edit"), None),
+            ev(EventKind::Tool, "claude", Some("Write"), None),
+        ];
+        let stats = compute(&events);
+        assert_eq!(stats.top_tools[0], ("Bash".to_owned(), 3));
+        assert_eq!(stats.top_tools[1], ("Edit".to_owned(), 2));
+        assert_eq!(stats.top_tools[2], ("Write".to_owned(), 1));
+    }
+
+    #[test]
+    fn compute_top_tools_truncated_to_5() {
+        let tools = ["A", "B", "C", "D", "E", "F", "G"];
+        let events: Vec<NormalizedEvent> = tools
+            .iter()
+            .map(|t| ev(EventKind::Tool, "claude", Some(t), None))
+            .collect();
+        let stats = compute(&events);
+        assert!(stats.top_tools.len() <= 5);
+    }
+
+    #[test]
+    fn compute_unique_sessions() {
+        let events = vec![
+            ev(EventKind::Prompt, "claude", None, Some("sess_a")),
+            ev(EventKind::Prompt, "claude", None, Some("sess_a")),
+            ev(EventKind::Prompt, "claude", None, Some("sess_b")),
+            ev(EventKind::Prompt, "claude", None, None),
+        ];
+        let stats = compute(&events);
+        assert_eq!(stats.unique_sessions, 2);
+    }
+
+    #[test]
+    fn compute_provider_breakdown() {
+        let events = vec![
+            ev(EventKind::Prompt, "claude", None, None),
+            ev(EventKind::Prompt, "claude", None, None),
+            ev(EventKind::Prompt, "gemini", None, None),
+        ];
+        let stats = compute(&events);
+        assert_eq!(stats.by_provider["claude"], 2);
+        assert_eq!(stats.by_provider["gemini"], 1);
+    }
+
+    #[test]
+    fn format_stats_empty_shows_no_events() {
+        let stats = HookStats::default();
+        let out = format_stats(&stats, "~/.mur/queue/events.jsonl");
+        assert!(out.contains("No hook events"), "got: {out}");
+    }
+
+    #[test]
+    fn format_stats_non_empty_contains_key_fields() {
+        let events = vec![
+            ev(EventKind::Prompt, "claude", None, Some("s1")),
+            ev(EventKind::Tool, "claude", Some("Edit"), Some("s1")),
+        ];
+        let stats = compute(&events);
+        let out = format_stats(&stats, "/tmp/events.jsonl");
+        assert!(out.contains("Total"), "got: {out}");
+        assert!(out.contains("Prompt"), "got: {out}");
+        assert!(out.contains("Edit"), "got: {out}");
+    }
+}

--- a/mur-core/src/inject/stats.rs
+++ b/mur-core/src/inject/stats.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::inject::event::{EventKind, NormalizedEvent};
 
@@ -18,7 +18,7 @@ pub fn compute(events: &[NormalizedEvent]) -> HookStats {
     let mut by_kind: HashMap<String, usize> = HashMap::new();
     let mut by_provider: HashMap<String, usize> = HashMap::new();
     let mut tool_counts: HashMap<String, usize> = HashMap::new();
-    let mut sessions: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut sessions: HashSet<String> = HashSet::new();
 
     for ev in events {
         let kind_key = match ev.kind {
@@ -29,7 +29,9 @@ pub fn compute(events: &[NormalizedEvent]) -> HookStats {
         };
         *by_kind.entry(kind_key.to_owned()).or_default() += 1;
         *by_provider.entry(ev.tool_provider.clone()).or_default() += 1;
-        if let Some(tool) = &ev.tool_called {
+        if ev.kind == EventKind::Tool
+            && let Some(tool) = &ev.tool_called
+        {
             *tool_counts.entry(tool.clone()).or_default() += 1;
         }
         if let Some(sid) = &ev.session_id {
@@ -56,22 +58,34 @@ pub fn format_stats(stats: &HookStats, queue_path: &str) -> String {
         return format!("No hook events recorded yet.\nQueue: {queue_path}\n");
     }
 
+    // Compute column width from the widest label we'll print
+    let kinds = ["Prompt", "Tool", "Stop", "SessionStart"];
+    let max_kind_len = kinds.iter().map(|k| k.len()).max().unwrap_or(0);
+    let max_tool_len = stats
+        .top_tools
+        .iter()
+        .map(|(t, _)| t.len())
+        .max()
+        .unwrap_or(0);
+    let max_prov_len = stats.by_provider.keys().map(|k| k.len()).max().unwrap_or(0);
+    let col_w = (max_kind_len.max(max_tool_len).max(max_prov_len) + 2).max(16);
+
     let mut out = String::new();
     out.push_str(&format!("Hook events  ({})\n", queue_path));
     out.push_str(&format!("  Total:     {}\n", stats.total));
     out.push_str(&format!("  Sessions:  {}\n", stats.unique_sessions));
 
     out.push_str("\nBy kind:\n");
-    for kind in ["Prompt", "Tool", "Stop", "SessionStart"] {
+    for kind in kinds {
         if let Some(n) = stats.by_kind.get(kind) {
-            out.push_str(&format!("  {:<16}{}\n", format!("{kind}:"), n));
+            out.push_str(&format!("  {:<col_w$}{}\n", format!("{kind}:"), n));
         }
     }
 
     if !stats.top_tools.is_empty() {
         out.push_str("\nTop tools:\n");
         for (tool, n) in &stats.top_tools {
-            out.push_str(&format!("  {:<16}{}\n", format!("{tool}:"), n));
+            out.push_str(&format!("  {:<col_w$}{}\n", format!("{tool}:"), n));
         }
     }
 
@@ -80,7 +94,7 @@ pub fn format_stats(stats: &HookStats, queue_path: &str) -> String {
         let mut providers: Vec<_> = stats.by_provider.iter().collect();
         providers.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
         for (prov, n) in providers {
-            out.push_str(&format!("  {:<16}{}\n", format!("{prov}:"), n));
+            out.push_str(&format!("  {:<col_w$}{}\n", format!("{prov}:"), n));
         }
     }
 
@@ -202,5 +216,64 @@ mod tests {
         assert!(out.contains("Total"), "got: {out}");
         assert!(out.contains("Prompt"), "got: {out}");
         assert!(out.contains("Edit"), "got: {out}");
+    }
+
+    #[test]
+    fn compute_tool_called_on_non_tool_event_not_counted() {
+        // tool_called on a Prompt event must NOT appear in top_tools
+        let events = vec![NormalizedEvent {
+            kind: EventKind::Prompt,
+            tool_provider: "claude".into(),
+            query: None,
+            tool_called: Some("Edit".to_owned()), // would be counted without the kind guard
+            tool_input: None,
+            stop_reason: None,
+            session_id: None,
+        }];
+        let stats = compute(&events);
+        assert!(
+            stats.top_tools.is_empty(),
+            "tool_called on Prompt must not be counted"
+        );
+    }
+
+    #[test]
+    fn compute_top_tools_exactly_5_when_more_available() {
+        let tools = ["A", "B", "C", "D", "E", "F", "G"];
+        let events: Vec<NormalizedEvent> = tools
+            .iter()
+            .map(|t| ev(EventKind::Tool, "claude", Some(t), None))
+            .collect();
+        let stats = compute(&events);
+        assert_eq!(stats.top_tools.len(), 5, "must be exactly 5, not just ≤ 5");
+    }
+
+    #[test]
+    fn format_stats_single_provider_omits_providers_section() {
+        let events = vec![ev(EventKind::Prompt, "claude", None, None)];
+        let stats = compute(&events);
+        let out = format_stats(&stats, "/tmp/e.jsonl");
+        assert!(
+            !out.contains("Providers"),
+            "single provider must not show Providers section; got: {out}"
+        );
+    }
+
+    #[test]
+    fn format_stats_includes_queue_path_and_sessions() {
+        let events = vec![
+            ev(EventKind::Prompt, "claude", None, Some("s1")),
+            ev(EventKind::Stop, "claude", None, Some("s1")),
+        ];
+        let stats = compute(&events);
+        let out = format_stats(&stats, "/custom/path/events.jsonl");
+        assert!(
+            out.contains("/custom/path/events.jsonl"),
+            "queue path must appear; got: {out}"
+        );
+        assert!(
+            out.contains("Sessions:  1"),
+            "session count must appear; got: {out}"
+        );
     }
 }

--- a/mur-core/tests/hook_stats_integration.rs
+++ b/mur-core/tests/hook_stats_integration.rs
@@ -1,9 +1,7 @@
 //! Integration: write real events, then compute + format through the full pipeline.
 
-use std::io::Write;
-
 use mur_core::inject::event::{EventKind, NormalizedEvent};
-use mur_core::inject::queue::read_all_events;
+use mur_core::inject::queue::{enqueue_to, read_all_events};
 use mur_core::inject::stats::{compute, format_stats};
 
 fn make_event(kind: EventKind, tool: Option<&str>, session: Option<&str>) -> NormalizedEvent {
@@ -34,14 +32,7 @@ fn stats_from_real_queue_file() {
         make_event(EventKind::Stop, None, Some("sess_2")),
     ];
     for ev in &events_to_write {
-        let line = serde_json::to_string(ev).unwrap() + "\n";
-        std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .unwrap()
-            .write_all(line.as_bytes())
-            .unwrap();
+        enqueue_to(ev, &path).unwrap();
     }
 
     let events = read_all_events(&path);

--- a/mur-core/tests/hook_stats_integration.rs
+++ b/mur-core/tests/hook_stats_integration.rs
@@ -1,0 +1,73 @@
+//! Integration: write real events, then compute + format through the full pipeline.
+
+use std::io::Write;
+
+use mur_core::inject::event::{EventKind, NormalizedEvent};
+use mur_core::inject::queue::read_all_events;
+use mur_core::inject::stats::{compute, format_stats};
+
+fn make_event(kind: EventKind, tool: Option<&str>, session: Option<&str>) -> NormalizedEvent {
+    NormalizedEvent {
+        kind,
+        tool_provider: "claude".into(),
+        query: None,
+        tool_called: tool.map(str::to_owned),
+        tool_input: None,
+        stop_reason: None,
+        session_id: session.map(str::to_owned),
+    }
+}
+
+#[test]
+fn stats_from_real_queue_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("events.jsonl");
+
+    let events_to_write = vec![
+        make_event(EventKind::SessionStart, None, Some("sess_1")),
+        make_event(EventKind::Prompt, None, Some("sess_1")),
+        make_event(EventKind::Tool, Some("Edit"), Some("sess_1")),
+        make_event(EventKind::Tool, Some("Bash"), Some("sess_1")),
+        make_event(EventKind::Stop, None, Some("sess_1")),
+        make_event(EventKind::Prompt, None, Some("sess_2")),
+        make_event(EventKind::Tool, Some("Edit"), Some("sess_2")),
+        make_event(EventKind::Stop, None, Some("sess_2")),
+    ];
+    for ev in &events_to_write {
+        let line = serde_json::to_string(ev).unwrap() + "\n";
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(line.as_bytes())
+            .unwrap();
+    }
+
+    let events = read_all_events(&path);
+    assert_eq!(events.len(), 8);
+
+    let stats = compute(&events);
+    assert_eq!(stats.total, 8);
+    assert_eq!(stats.unique_sessions, 2);
+    assert_eq!(stats.by_kind["Prompt"], 2);
+    assert_eq!(stats.by_kind["Tool"], 3);
+    assert_eq!(stats.top_tools[0].0, "Edit");
+    assert_eq!(stats.top_tools[0].1, 2);
+
+    let out = format_stats(&stats, "/tmp/events.jsonl");
+    assert!(out.contains("Total"), "output: {out}");
+    assert!(out.contains("Edit"), "output: {out}");
+    assert!(out.contains("Sessions:  2"), "output: {out}");
+}
+
+#[test]
+fn stats_empty_queue_graceful() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("no_events.jsonl");
+    let events = read_all_events(&path);
+    assert!(events.is_empty());
+    let stats = compute(&events);
+    let out = format_stats(&stats, &path.display().to_string());
+    assert!(out.contains("No hook events"), "output: {out}");
+}


### PR DESCRIPTION
## Summary

- Adds `read_all_events(path)` to `inject/queue.rs` — BufReader-based JSONL parser; silently skips malformed lines and missing files
- Adds `inject/stats.rs` — `compute(&[NormalizedEvent]) -> HookStats` (single-pass aggregation) + `format_stats` (dynamic column widths, hides single-provider section)
- Implements `cmd_hook_stats()` in `cmd/hook.rs` — reads `~/.mur/queue/events.jsonl`, computes, prints
- 6 queue tests + 12 stats unit tests + 2 integration tests (via `tests/hook_stats_integration.rs`)

Rebased onto main after PR #154 (M0–M4) merged.

## Test Plan

- [ ] `cargo test -p mur-core` — all tests pass
- [ ] `cargo fmt --check -p mur-core` — clean
- [ ] `mur hook stats` shows formatted dashboard (or graceful empty output if no queue file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)