### PR TITLE
feat(core): C5 M5.1 — webhook config schema + `mur agent webhook` CLI

### DIFF
--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -161,6 +161,11 @@ pub struct TransportConfig {
     pub socket: SocketTransportConfig,
     #[serde(default)]
     pub tcp: TcpTransportConfig,
+    /// Track C5 — HTTP webhook receiver. Default off; enabling
+    /// requires an HMAC secret in the OS keychain (`SecretRef`).
+    /// See `docs/superpowers/specs/2026-05-05-mur-agent-c5-webhook-design.md`.
+    #[serde(default)]
+    pub webhook: WebhookTransportConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -171,6 +176,53 @@ pub struct TcpTransportConfig {
     pub bind: String,
     #[serde(default)]
     pub noise: NoiseConfig,
+}
+
+/// HTTP webhook receiver — Track C5.
+///
+/// External systems POST `SharePayload`-shaped JSON to
+/// `http://<bind>:<port>/agents/<slug>/webhook` with an
+/// `X-Mur-Signature: sha256=<hex>` header carrying an HMAC-SHA256
+/// over the raw body. The HMAC secret is stored in the OS keychain
+/// via `SecretRef` (same pattern as Telegram bot tokens in C2);
+/// `hmac_secret_ref` is the `service:account` lookup key.
+///
+/// `bind` defaults to `127.0.0.1` so a fresh enable doesn't
+/// inadvertently expose the agent to the local network. Users who
+/// want VPN / Tailscale reachability override to `0.0.0.0` or the
+/// VPN interface address explicitly.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WebhookTransportConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_webhook_bind")]
+    pub bind: String,
+    #[serde(default = "default_webhook_port")]
+    pub port: u16,
+    /// `service:account` key into the OS keychain. Empty string
+    /// when `enabled = false`; required (and validated) at startup
+    /// when enabled.
+    #[serde(default)]
+    pub hmac_secret_ref: String,
+}
+
+fn default_webhook_bind() -> String {
+    "127.0.0.1".to_string()
+}
+
+fn default_webhook_port() -> u16 {
+    6789
+}
+
+impl Default for WebhookTransportConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind: default_webhook_bind(),
+            port: default_webhook_port(),
+            hmac_secret_ref: String::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/mur-core/src/cmd/agent.rs
+++ b/mur-core/src/cmd/agent.rs
@@ -108,6 +108,7 @@ pub fn cmd_create(
                 auth: None,
             },
             tcp: TcpTransportConfig::default(),
+            webhook: mur_common::agent::WebhookTransportConfig::default(),
         },
         communication: CommunicationConfig {
             accepts_from: vec!["*".into()],

--- a/mur-core/src/cmd/agent_companion/connector.rs
+++ b/mur-core/src/cmd/agent_companion/connector.rs
@@ -433,6 +433,7 @@ pub(crate) async fn scaffold_stub_bridge(name: &str, default_route: &str) -> Res
                 auth: None,
             },
             tcp: TcpTransportConfig::default(),
+            webhook: mur_common::agent::WebhookTransportConfig::default(),
         },
         communication: CommunicationConfig {
             accepts_from: vec!["*".into()],

--- a/mur-core/src/cmd/agent_webhook.rs
+++ b/mur-core/src/cmd/agent_webhook.rs
@@ -1,0 +1,123 @@
+//! Track C5 / M5.1 — `mur agent webhook ...` CLI verbs.
+//!
+//! Mutates the agent's `profile.yaml` (`transport.webhook` block) and
+//! the OS keychain entry holding the HMAC secret. The runtime uses
+//! the same shape (M5.3): when `transport.webhook.enabled = true`,
+//! the supervisor starts an Axum listener and validates the
+//! `X-Mur-Signature` HMAC against `keychain_get(SECRET_SERVICE,
+//! <agent>/WEBHOOK_HMAC)`.
+//!
+//! All four verbs are sync except `secret-set` which goes async to
+//! await `keychain_set`. `enable` / `disable` / `show` write a
+//! single YAML value through the existing `load_profile_for_edit`
+//! helper so the file stays atomic.
+
+use anyhow::{Context, Result, ensure};
+use mur_common::agent::WebhookTransportConfig;
+
+use super::agent::load_profile_for_edit;
+
+/// Same service name the rest of the agent secrets use; key is
+/// always the literal `WEBHOOK_HMAC` so callers don't have to
+/// remember another knob.
+const SECRET_SERVICE: &str = "mur-agent";
+const SECRET_KEY: &str = "WEBHOOK_HMAC";
+
+/// Default port we suggest when `--port` isn't passed. Mirrors
+/// `WebhookTransportConfig::default()`'s port; kept in sync via the
+/// same constant in `mur-common`.
+const DEFAULT_PORT: u16 = 6789;
+
+pub fn cmd_webhook_enable(agent: &str, bind: Option<String>, port: Option<u16>) -> Result<()> {
+    let (path, mut profile) = load_profile_for_edit(agent)?;
+    let acct = format!("{agent}/{SECRET_KEY}");
+    let secret_ref = format!("{SECRET_SERVICE}:{acct}");
+
+    let cfg = WebhookTransportConfig {
+        enabled: true,
+        bind: bind.unwrap_or_else(|| "127.0.0.1".to_string()),
+        port: port.unwrap_or(DEFAULT_PORT),
+        hmac_secret_ref: secret_ref.clone(),
+    };
+    profile.transport.webhook = cfg.clone();
+    write_profile_atomic(&path, &profile)?;
+    println!(
+        "Enabled webhook for {agent}: http://{}:{}/agents/{agent}/webhook",
+        cfg.bind, cfg.port,
+    );
+    println!("HMAC secret ref: {secret_ref}");
+    println!(
+        "Run `mur agent webhook secret-set {agent}` to write the HMAC key, then restart the agent."
+    );
+    Ok(())
+}
+
+pub fn cmd_webhook_disable(agent: &str) -> Result<()> {
+    let (path, mut profile) = load_profile_for_edit(agent)?;
+    profile.transport.webhook.enabled = false;
+    // Leave bind/port/hmac_secret_ref alone so re-enabling doesn't
+    // need a fresh secret-set.
+    write_profile_atomic(&path, &profile)?;
+    println!("Disabled webhook for {agent}");
+    Ok(())
+}
+
+pub fn cmd_webhook_show(agent: &str) -> Result<()> {
+    let (_path, profile) = load_profile_for_edit(agent)?;
+    let yaml =
+        serde_yaml_ng::to_string(&profile.transport.webhook).context("serialize webhook config")?;
+    print!("{yaml}");
+    Ok(())
+}
+
+pub async fn cmd_webhook_secret_set(agent: &str, value: Option<&str>) -> Result<()> {
+    use mur_common::secret::keychain_set;
+    let val: String = match value {
+        Some(v) => v.to_string(),
+        None => {
+            eprint!("Enter HMAC secret for {agent} (input hidden): ");
+            rpassword::read_password().context("read hidden value")?
+        }
+    };
+    ensure!(!val.is_empty(), "HMAC secret must not be empty");
+    let acct = format!("{agent}/{SECRET_KEY}");
+    keychain_set(SECRET_SERVICE, &acct, &val)
+        .await
+        .with_context(|| format!("set {SECRET_SERVICE}/{acct}"))?;
+    println!("Wrote {SECRET_SERVICE}/{acct}");
+    Ok(())
+}
+
+fn write_profile_atomic(
+    path: &std::path::Path,
+    profile: &mur_common::agent::AgentProfile,
+) -> Result<()> {
+    let yaml = serde_yaml_ng::to_string(profile).context("serialize profile.yaml")?;
+    let tmp = path.with_extension("yaml.tmp");
+    std::fs::write(&tmp, yaml).with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_port_matches_common_default() {
+        // Drift guard: `WebhookTransportConfig::default().port` and
+        // this module's `DEFAULT_PORT` must agree so the CLI's
+        // implicit default lines up with the runtime's view.
+        assert_eq!(WebhookTransportConfig::default().port, DEFAULT_PORT);
+    }
+
+    #[test]
+    fn default_bind_matches_common_default() {
+        assert_eq!(
+            WebhookTransportConfig::default().bind,
+            "127.0.0.1",
+            "default bind must stay localhost — public exposure is opt-in"
+        );
+    }
+}

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -3,6 +3,8 @@ pub mod agent_companion;
 pub mod agent_export;
 pub mod agent_export_gui;
 pub(crate) mod agent_rekey;
+/// Track C5 / M5.1 — webhook receiver config + CLI verbs.
+pub(crate) mod agent_webhook;
 pub(crate) mod community_cmd;
 pub(crate) mod context;
 pub(crate) mod conversations_cmd;

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -1093,6 +1093,40 @@ enum AgentAction {
         #[command(subcommand)]
         action: AgentSecretAction,
     },
+    /// Manage the C5 webhook receiver for an agent (enable/disable/show/secret).
+    Webhook {
+        /// Agent name
+        agent: String,
+        #[command(subcommand)]
+        action: AgentWebhookAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum AgentWebhookAction {
+    /// Turn on the receiver. Writes `transport.webhook` into
+    /// `profile.yaml`. The HMAC secret must be set first via
+    /// `secret-set` — startup will refuse to bind otherwise.
+    Enable {
+        /// Override default bind address (`127.0.0.1`).
+        #[arg(long)]
+        bind: Option<String>,
+        /// Override default port (`6789`).
+        #[arg(long)]
+        port: Option<u16>,
+    },
+    /// Turn off the receiver. Leaves `hmac_secret_ref` in place so
+    /// re-enabling doesn't need to re-set the secret.
+    Disable,
+    /// Print the current `transport.webhook` block in YAML.
+    Show,
+    /// Write the HMAC secret to the OS keychain
+    /// (`service=mur-agent`, `account=<agent>/WEBHOOK_HMAC`). Reads
+    /// from a hidden prompt when no inline VALUE is given.
+    SecretSet {
+        /// Optional value; omit to read from a hidden prompt.
+        value: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -1708,6 +1742,16 @@ async fn async_main() -> Result<()> {
                 AgentSecretAction::List => cmd::agent::cmd_secret_list(&agent).await?,
                 AgentSecretAction::Delete { key } => {
                     cmd::agent::cmd_secret_delete(&agent, &key).await?
+                }
+            },
+            AgentAction::Webhook { agent, action } => match action {
+                AgentWebhookAction::Enable { bind, port } => {
+                    cmd::agent_webhook::cmd_webhook_enable(&agent, bind, port)?
+                }
+                AgentWebhookAction::Disable => cmd::agent_webhook::cmd_webhook_disable(&agent)?,
+                AgentWebhookAction::Show => cmd::agent_webhook::cmd_webhook_show(&agent)?,
+                AgentWebhookAction::SecretSet { value } => {
+                    cmd::agent_webhook::cmd_webhook_secret_set(&agent, value.as_deref()).await?
                 }
             },
         },


### PR DESCRIPTION
## Summary

First implementation milestone for Track C5 (spec #166). Wires the config schema + four CLI verbs that mutate \`profile.yaml\` and the OS keychain. Pure configuration plumbing — no runtime listener yet (lands in M5.2/M5.3).

## What's new

\`mur_common::agent::WebhookTransportConfig\`:
- \`enabled\` (default false), \`bind\` (default \`127.0.0.1\`), \`port\` (default \`6789\`), \`hmac_secret_ref\`
- Wired into \`TransportConfig\` as \`#[serde(default)]\` — existing profiles deserialize unchanged

\`mur agent webhook ...\`:
- \`enable [--bind ADDR] [--port N]\` — flips on, fills defaults, prints URL + \`secret-set\` reminder
- \`disable\` — flag-only flip; preserves bind/port/secret-ref for re-enable
- \`show\` — dumps the YAML block
- \`secret-set [VALUE]\` — writes HMAC key to OS keychain (\`service=mur-agent\`, \`account=<agent>/WEBHOOK_HMAC\`); hidden prompt if no value

Two existing \`TransportConfig {...}\` construction sites updated with the new field.

## Test plan

- [x] \`cargo build -p mur-common\` clean
- [x] \`cargo build -p mur-core\` clean
- [x] \`cargo test -p mur-core --lib agent_webhook\` (2 drift guards pass: default port + default bind = localhost)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean

## Next milestones

| # | Scope |
|---|---|
| M5.2 | \`transport/webhook.rs\` Axum handler + HMAC verifier (pure unit tests against synthetic Axum requests) |
| M5.3 | Supervisor wiring (start Axum when enabled; bind localhost default) |
| M5.4 | \`SendIngestor\` bridge → multimodal pipeline |
| M5.5 | Per-source rate limit (token bucket) |
| M5.6 | E2E (\`scripts/e2e/c5-webhook.sh\`) + cookbook |

🤖 Generated with [Claude Code](https://claude.com/claude-code)