### PR TITLE
feat(runtime): C5 M5.3 — supervisor wires webhook listener

### DIFF
--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -1,6 +1,8 @@
 //! Agent runtime entrypoint — assembles profile, dispatcher, telemetry, and
 //! drives the stdio (and optionally Unix-socket) transports until SIGTERM.
 
+use anyhow::Context;
+
 use crate::companion::clock::SystemClock;
 use crate::entitlements::detect_warnings;
 use crate::hooks::{
@@ -27,6 +29,7 @@ use crate::transport::stdio::serve_stdio;
 use crate::transport::tcp::{TcpTransportConfig, spawn_tcp_listener};
 #[cfg(unix)]
 use crate::transport::unix_socket::serve_unix;
+use crate::transport::webhook;
 use mur_common::identity::AgentIdentity;
 use mur_common::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, LockFile, agent::LockTransports};
 use std::path::PathBuf;
@@ -327,6 +330,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         stdio: profile.inner.transport.stdio,
         unix_socket: None,
         tcp: None,
+        webhook: None,
     };
 
     // Decide how to route telemetry notifications. Socket (if present) gets
@@ -438,6 +442,45 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         transport_tasks.push(tokio::spawn(async move {
             let _keep_tx_alive = tcp_shutdown_tx;
             tcp_handle.await_shutdown().await;
+        }));
+    }
+
+    // 7c. Conditionally spawn C5 webhook listener.
+    //     Mirrors 7b's pattern: bind synchronously so failures
+    //     surface before the agent claims ready, then drive
+    //     `axum::serve` on a transport task. HMAC secret comes
+    //     from the OS keychain — the `hmac_secret_ref` in
+    //     `profile.yaml` is the `service:account` lookup key
+    //     written by `mur agent webhook secret-set`.
+    if profile.inner.transport.webhook.enabled && !profile.inner.transport.webhook.bind.is_empty() {
+        let cfg = &profile.inner.transport.webhook;
+        let (svc, acct) = cfg.hmac_secret_ref.split_once(':').ok_or_else(|| {
+            anyhow::anyhow!(
+                "transport.webhook.hmac_secret_ref must be `service:account`, got `{}`",
+                cfg.hmac_secret_ref,
+            )
+        })?;
+        let secret = mur_common::secret::keychain_get(svc, acct)
+            .await
+            .with_context(|| format!("read webhook HMAC secret {svc}:{acct}"))?
+            .ok_or_else(|| anyhow::anyhow!(
+                "webhook enabled but HMAC secret missing — run `mur agent webhook secret-set {}`",
+                profile.inner.name,
+            ))?;
+        use secrecy::ExposeSecret;
+        let state =
+            webhook::WebhookState::new(&profile.inner.name, secret.expose_secret().as_bytes());
+        let handle = webhook::spawn_webhook_listener(&cfg.bind, cfg.port, state).await?;
+        info!(
+            "webhook listener at http://{} (slug: {})",
+            handle.local_addr, profile.inner.name,
+        );
+        // Stash the local addr in the lock file so peers (and the
+        // commander) can discover the live URL without re-reading
+        // profile.yaml; mirrors the TCP listener's lock entry.
+        lock_transports.webhook = Some(format!("http://{}", handle.local_addr));
+        transport_tasks.push(tokio::spawn(async move {
+            handle.await_shutdown().await;
         }));
     }
 

--- a/mur-agent-runtime/src/transport/webhook.rs
+++ b/mur-agent-runtime/src/transport/webhook.rs
@@ -166,6 +166,57 @@ fn body_sha256(body: &[u8]) -> String {
     hex::encode(h)
 }
 
+/// Listener handle returned by [`spawn_webhook_listener`].
+///
+/// Holds the resolved `local_addr` (helpful when the user binds
+/// `0.0.0.0:0` for ephemeral testing) and a `JoinHandle` so the
+/// supervisor can `.abort()` the task during graceful shutdown.
+pub struct WebhookHandle {
+    pub local_addr: std::net::SocketAddr,
+    join: tokio::task::JoinHandle<()>,
+}
+
+impl WebhookHandle {
+    /// Block until the listener task exits. Mirrors the TCP
+    /// listener's `await_shutdown` so supervisor wiring can use the
+    /// same pattern across transports.
+    pub async fn await_shutdown(self) {
+        let _ = self.join.await;
+    }
+
+    /// Force-stop the listener immediately. Used by the supervisor
+    /// on SIGTERM where we don't want to wait for in-flight requests.
+    pub fn abort(&self) {
+        self.join.abort();
+    }
+}
+
+/// Bind the Axum router to `bind:port` and start serving.
+///
+/// Synchronous up to the bind step so the supervisor can surface
+/// "address already in use" before the agent claims to be ready;
+/// once the listener is bound the actual `axum::serve` future moves
+/// onto a tokio task.
+pub async fn spawn_webhook_listener(
+    bind: &str,
+    port: u16,
+    state: WebhookState,
+) -> anyhow::Result<WebhookHandle> {
+    use anyhow::Context;
+    let addr = format!("{bind}:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .with_context(|| format!("bind webhook listener at {addr}"))?;
+    let local_addr = listener.local_addr().context("read local_addr")?;
+    let app = router(state);
+    let join = tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, app).await {
+            tracing::warn!(error = %e, "webhook listener exited with error");
+        }
+    });
+    Ok(WebhookHandle { local_addr, join })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/mur-agent-runtime/tests/lock_file.rs
+++ b/mur-agent-runtime/tests/lock_file.rs
@@ -16,6 +16,7 @@ fn sample_lock() -> LockFile {
             stdio: false,
             unix_socket: Some("/tmp/x.sock".into()),
             tcp: None,
+            webhook: None,
         },
         card_digest: "sha256:abc".into(),
         capabilities: vec!["a2a.message.send".into()],

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -612,6 +612,12 @@ pub struct LockTransports {
     pub unix_socket: Option<String>,
     #[serde(default)]
     pub tcp: Option<String>,
+    /// C5 / M5.3 — webhook listener URL (e.g. `http://127.0.0.1:6789`).
+    /// Populated by the supervisor when `transport.webhook.enabled =
+    /// true` so peers and the commander can discover the live
+    /// endpoint without re-reading `profile.yaml`.
+    #[serde(default)]
+    pub webhook: Option<String>,
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/mur-common/src/lock_file.rs
+++ b/mur-common/src/lock_file.rs
@@ -130,6 +130,7 @@ mod tests {
                 stdio: false,
                 unix_socket: Some("/tmp/x.sock".into()),
                 tcp: None,
+                webhook: None,
             },
             card_digest: "sha256:abc".into(),
             capabilities: vec!["a2a.message.send".into()],

--- a/mur-core/src/server_agents/list.rs
+++ b/mur-core/src/server_agents/list.rs
@@ -97,6 +97,7 @@ pub(crate) mod tests {
                 stdio: true,
                 unix_socket: None,
                 tcp: None,
+                webhook: None,
             },
             card_digest: "sha256:abc123".to_string(),
             capabilities: vec!["a2a.message.send".to_string()],

--- a/mur-core/tests/agent_lifecycle.rs
+++ b/mur-core/tests/agent_lifecycle.rs
@@ -41,6 +41,7 @@ fn write_lock_with_pid(mur_home: &std::path::Path, name: &str, pid: u32) {
             stdio: true,
             unix_socket: None,
             tcp: None,
+            webhook: None,
         },
         card_digest: "sha256:x".into(),
         capabilities: vec![],

--- a/mur-core/tests/agent_list_status.rs
+++ b/mur-core/tests/agent_list_status.rs
@@ -36,6 +36,7 @@ fn write_running_lock(mur_home: &std::path::Path, name: &str, pid: u32) {
             stdio: true,
             unix_socket: None,
             tcp: None,
+            webhook: None,
         },
         card_digest: "sha256:test".into(),
         capabilities: vec!["a2a.message.send".into()],

--- a/mur-core/tests/agent_send.rs
+++ b/mur-core/tests/agent_send.rs
@@ -38,6 +38,7 @@ fn write_running_lock(mur_home: &Path, name: &str, sock: &str) {
             stdio: false,
             unix_socket: Some(sock.into()),
             tcp: None,
+            webhook: None,
         },
         card_digest: "sha256:mock".into(),
         capabilities: vec!["a2a.message.send".into()],


### PR DESCRIPTION
## Summary

Third C5 milestone, stacked on **#168**. Wires M5.2's Axum router into the agent supervisor so an enabled webhook actually serves requests at boot. Live URL flows into \`running.lock\` for peer/commander discovery.

## What's new

\`mur-agent-runtime/src/transport/webhook.rs\`:
- \`WebhookHandle { local_addr, join }\` — mirrors \`tcp::TcpHandle\`'s shape
- \`spawn_webhook_listener(bind, port, state)\` — binds TCP synchronously (so "address in use" surfaces before agent claims ready), then drives \`axum::serve\` on a tokio task

\`supervisor.rs\` step 7c (between TCP and lock write):
- Reads HMAC secret via \`keychain_get(service, account)\` from \`hmac_secret_ref\`
- Bails on missing secret with a hint to run \`mur agent webhook secret-set <name>\`
- Populates \`LockTransports::webhook = Some("http://<local_addr>")\`

\`mur_common::agent::LockTransports.webhook: Option<String>\` added behind \`#[serde(default)]\`. Five existing construction sites updated.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo test -p mur-agent-runtime --lib\` (94 pass — 83 pre-existing + 11 M5.2 webhook handler)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] M5.4 will plug the validated payload into the multimodal pipeline; M5.6 e2e exercises the full POST → ingest → telemetry flow

## Stack

| # | PR | Status |
|---|---|---|
| M5.1 | #167 | merged |
| M5.2 | #168 | open (this PR's base) |
| **M5.3** | **this PR** | open |
| M5.4 | pending | SendIngestor bridge → multimodal pipeline |
| M5.5 | pending | rate limit |
| M5.6 | pending | e2e + cookbook |

🤖 Generated with [Claude Code](https://claude.com/claude-code)