### PR TITLE
feat(docs,e2e): C5 M5.6 — c5-webhook.sh + cookbook + §5.6 acceptance footer

### DIFF
--- a/docs/cookbook/c5-webhook.md
+++ b/docs/cookbook/c5-webhook.md
@@ -1,0 +1,136 @@
+# Webhook receiver (Track C5)
+
+The agent runtime can listen on an HTTP port for `POST /agents/<slug>/webhook` requests with HMAC-signed bodies. Use case: any external system that can `curl` — GitHub Actions, Zapier, n8n, iOS Shortcuts, a sibling mur-commander instance — can deliver text / URLs / files / images into the agent's inbox with the same B0 `<untrusted_share>` wrapping + Rule-4 cooldown the local Track C3 channels get.
+
+## When to use it
+
+- **CI build summaries**: a GitHub Action posts the failing test diff so the agent sees it on the next turn.
+- **Cross-host A2A fallback**: when Noise XK isn't reachable (e.g. the peer's behind a strict firewall), HMAC-signed HTTP works.
+- **Mobile capture**: an iOS Shortcut with the share-sheet output → cURL into the user's home Tailscale address.
+
+## When NOT to use it
+
+- **Public internet**: bind to localhost (default) or a VPN interface. Public-internet exposure means front-proxying the listener with a TLS terminator + WAF; we don't ship that. Route through Tailscale / WireGuard / SSH tunnel instead.
+- **High-throughput streaming**: one POST = one ack. WebSocket / SSE join the v3 cross-host A2A track.
+- **File uploads > 10 MiB**: hard 413 cap. Big files want multipart streaming, not base64-in-JSON; that's a v3 follow-up.
+
+## Setup
+
+```bash
+# 1. Set the HMAC secret (hidden prompt; OS keychain storage)
+mur agent webhook secret-set coach
+# Enter HMAC secret for coach (input hidden): <type a strong key>
+# Wrote mur-agent/coach/WEBHOOK_HMAC
+
+# 2. Enable the listener (default 127.0.0.1:6789)
+mur agent webhook enable coach
+# Enabled webhook for coach: http://127.0.0.1:6789/agents/coach/webhook
+# HMAC secret ref: mur-agent:coach/WEBHOOK_HMAC
+# Run `mur agent webhook secret-set coach` … then restart the agent.
+
+# 3. Restart the agent so the supervisor reads the new config
+mur agent restart coach   # or kill + relaunch via your usual flow
+```
+
+Confirm the listener is up:
+
+```bash
+$ mur agent webhook show coach
+enabled: true
+bind: 127.0.0.1
+port: 6789
+hmac_secret_ref: mur-agent:coach/WEBHOOK_HMAC
+```
+
+`running.lock` will carry `transports.webhook = "http://127.0.0.1:6789"` so peers and the commander can discover the live URL without re-reading `profile.yaml`.
+
+## Sending — curl
+
+The HMAC is sha256 over the raw body. With `openssl`:
+
+```bash
+SECRET='your-strong-key'
+BODY='{"kind":"text","value":"build #1234 failed: src/lib.rs:142"}'
+SIG="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -binary | xxd -p -c 256)"
+
+curl -sS -X POST http://127.0.0.1:6789/agents/coach/webhook \
+    -H "X-Mur-Signature: $SIG" \
+    -H 'X-Mur-Source: github-actions/myrepo' \
+    -H 'Content-Type: application/json' \
+    -d "$BODY"
+# {"id":"4d8e…","queued_at":"2026-05-05T14:30:00.123Z"}
+```
+
+The agent's next turn sees the body wrapped in `<untrusted_share>`, with Rule-4 (after-untrusted-input) gating side-effect tools for one turn.
+
+## Sending — GitHub Actions
+
+```yaml
+- name: Notify mur agent
+  if: failure()
+  env:
+    MUR_HMAC: ${{ secrets.MUR_WEBHOOK_HMAC }}
+  run: |
+    BODY="{\"kind\":\"text\",\"value\":\"build ${{ github.run_id }} failed at ${{ github.sha }}\"}"
+    SIG="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$MUR_HMAC" -binary | xxd -p -c 256)"
+    curl -sS -X POST $MUR_WEBHOOK_URL \
+        -H "X-Mur-Signature: $SIG" \
+        -H 'X-Mur-Source: github-actions' \
+        -H 'Content-Type: application/json' \
+        -d "$BODY"
+```
+
+The `X-Mur-Source` header scopes the rate-limit bucket: 60 requests per minute per source by default. Many CI runs sharing one source key still share one bucket; for stricter isolation give each pipeline its own source string.
+
+## Payload shape
+
+```jsonc
+{
+  "kind": "text" | "url" | "image" | "file",
+  "value": "<text/url, or base64-url-no-pad bytes for image/file>",
+  "metadata": {
+    "filename": "screenshot.png",   // optional; informs mime-sniff for image/file
+    "source_hint": "ci-build-1234"  // optional; free-form, surfaces in telemetry
+  }
+}
+```
+
+## Error matrix
+
+| Status | Meaning |
+|---|---|
+| 202 | Accepted; body sha256 in `id`, RFC3339 timestamp in `queued_at` |
+| 401 | Missing or wrong `X-Mur-Signature` |
+| 404 | Slug in path doesn't match this listener's agent |
+| 413 | Body > 10 MiB |
+| 422 | Body isn't valid JSON or `kind` isn't one of `text`/`url`/`image`/`file` |
+| 429 | Rate limit exceeded (60/min per source by default) |
+| 500 | Pipeline dispatch failed (disk error, mime decode failure) — logs carry the detail |
+
+## Acceptance gate
+
+```bash
+bash scripts/e2e/c5-webhook.sh
+```
+
+Runs the harness suites:
+
+- `mur-common` — `transport.webhook` round-trips through serde
+- `mur-core` — CLI drift guards (default port + bind = localhost)
+- `mur-agent-runtime` — 20 webhook tests covering the handler, HMAC verifier, pipeline dispatch, and token-bucket limiter
+
+Bundle-level QA (signed bundle, real port bind, curl from outside) is a manual matrix — see "Manual matrix" below.
+
+## Manual matrix
+
+After landing all 6 milestones (M5.1 → M5.6) on main:
+
+- [ ] `mur agent webhook secret-set` rejects an empty value (smoke test)
+- [ ] `mur agent webhook enable` writes `profile.yaml` atomically (no half-written file when the rename fails)
+- [ ] Restart agent, confirm `running.lock` has `transports.webhook` populated
+- [ ] `curl` with valid signature → 202; body lands in `telemetry/inputs.jsonl` with `source: webhook`
+- [ ] `curl` with wrong signature → 401
+- [ ] `curl` from outside the bind interface (when bind=127.0.0.1) → connection refused
+- [ ] Rapid-fire 100 `curl`s → ~60 succeed, rest 429
+- [ ] `mur agent webhook disable` stops the listener on next agent restart
+- [ ] After delete: `keychain` entry survives disable (re-enable doesn't need re-set)

--- a/docs/superpowers/specs/2026-04-30-mur-agent-harness-roadmap-design.md
+++ b/docs/superpowers/specs/2026-04-30-mur-agent-harness-roadmap-design.md
@@ -610,7 +610,7 @@ All four channels feed received content into the same B0 multimodal pipeline (D3
 Deferred to v2 / v3 with their own specs:
 
 - **C4** Cron + `lifecycle.schedule` (already designed in fleet-architecture; v2 implements).
-- **C5** Webhook receiver (reuse `mur-core/src/server.rs` Axum; per-agent endpoint + HMAC).
+- **C5** Webhook receiver (per-agent Axum endpoint + HMAC). **Status: shipped 2026-05-05** — design at `docs/superpowers/specs/2026-05-05-mur-agent-c5-webhook-design.md`, cookbook at `docs/cookbook/c5-webhook.md`. Listener lives in `mur-agent-runtime/src/transport/webhook.rs`; supervisor wiring conditional on `transport.webhook.enabled`. Acceptance gate: `bash scripts/e2e/c5-webhook.sh`.
 - **C6** Heartbeat / idle triggers (reuse companion `schedule.rs` `should_send_now`).
 - **C7** Slack / Discord / LINE / iMessage bridges (third-party may fork the Telegram bridge against the C1 protocol, or we ship official ones).
 - **C8** macOS `.appex` Share Extension via post-build Xcode merge — adds Phase 14 to `agent_export_gui.rs`; uses App Group for IPC.

--- a/scripts/e2e/c5-webhook.sh
+++ b/scripts/e2e/c5-webhook.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# scripts/e2e/c5-webhook.sh — Track C5 webhook acceptance.
+#
+# Drives the harness-level acceptance for M5.1–M5.5: the config
+# schema, Axum handler, supervisor wiring, pipeline bridge, and
+# rate limiter. The full bundle-level e2e (real signed bundle +
+# `mur agent webhook enable` + curl from outside the box) needs a
+# release build and a free port and is documented in the cookbook
+# manual matrix instead.
+#
+# Acceptance gates (spec §5.6):
+#  1. `transport.webhook` block deserializes from a synthetic
+#     profile.yaml without dropping fields (mur-common).
+#  2. `mur agent webhook` CLI verbs compile + serialize correctly
+#     (mur-core agent_webhook unit tests).
+#  3. Webhook handler accepts signed text, rejects unsigned/wrong-
+#     sig/wrong-slug/oversize/malformed/unknown-kind requests
+#     (mur-agent-runtime transport::webhook unit tests).
+#  4. `dispatch_to_pipeline` writes telemetry/inputs.jsonl with the
+#     correct provenance source on text+image kinds, errors clean
+#     on invalid base64.
+#  5. Token-bucket limiter exhausts → 429 then refills.
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "==> 1/3 mur-common schema (transport.webhook deserialization)"
+cargo test -p mur-common --quiet -- --quiet
+
+echo "==> 2/3 mur-core CLI (agent_webhook drift guards)"
+cargo test -p mur-core --lib --quiet agent_webhook -- --quiet
+
+echo "==> 3/3 mur-agent-runtime webhook (handler + dispatch + limiter)"
+cargo test -p mur-agent-runtime --lib --quiet transport::webhook -- --quiet
+
+echo
+echo "OK — Track C5 webhook acceptance gates passed (harness-level)."
+echo "Bundle-level QA (real listener bound to localhost, signed curl"
+echo "from outside) lives in the cookbook manual matrix at"
+echo "docs/cookbook/c5-webhook.md."


### PR DESCRIPTION
## Summary

Closes Track C5. Stacked on **#171** (M5.5 rate limit). Final milestone in the v2-first cascade.

## What's new

\`scripts/e2e/c5-webhook.sh\` — harness acceptance:
1. \`mur-common\` — \`transport.webhook\` serde round-trip
2. \`mur-core\` — \`agent_webhook\` CLI drift guards
3. \`mur-agent-runtime\` — 20 webhook tests (handler + HMAC + dispatch + limiter)

\`docs/cookbook/c5-webhook.md\` — per-channel walkthrough:
- When to use / when NOT to use
- Setup (secret-set → enable → restart)
- curl + GitHub Actions worked examples
- Payload shape + error matrix (202 / 401 / 404 / 413 / 422 / 429 / 500)
- 8-item manual QA matrix for bundle-level verification

\`docs/superpowers/specs/2026-04-30-...\` §5.6 C5 entry: \`Status: shipped 2026-05-05\` with pointers.

## Track C5 status

| # | PR | Title |
|---|---|---|
| spec | #166 | C5 webhook receiver design (v2 entry) |
| M5.1 | #167 | webhook config schema + CLI |
| M5.2 | #168 | Axum handler + HMAC verifier |
| M5.3 | #169 | supervisor wires listener |
| M5.4 | #170 | pipeline bridge |
| M5.5 | #171 | per-source token-bucket rate limit |
| **M5.6** | **this PR** | e2e + cookbook + §5.6 footer |

🤖 Generated with [Claude Code](https://claude.com/claude-code)