### PR TITLE
chore(release): bump version 2.5.0 → 2.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.5.0"
+version = "2.6.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-agent-gui/src-tauri/Cargo.toml
+++ b/mur-agent-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mur-agent-gui"
-version = "2.5.0"
+version = "2.6.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"


### PR DESCRIPTION
## Summary

Fixes the v2.6.0 release reporting itself as 2.5.0.

User report:

\`\`\`
$ brew reinstall mur
🍺  /opt/homebrew/Cellar/mur/2.6.0: 4 files, 185.2MB
$ mur --version
mur 2.5.0
\`\`\`

## Root cause

The v2.6.0 GitHub Release shipped a prebuilt binary built from a tree where workspace \`Cargo.toml\`'s \`[workspace.package].version\` still said \`"2.5.0"\` — the version bump was forgotten before the tag was cut. The Homebrew formula correctly downloads from \`releases/download/v2.6.0/mur-aarch64-apple-darwin.tar.gz\`, but \`mur --version\` reads \`CARGO_PKG_VERSION\` which the compiler resolves at build time from \`Cargo.toml\`, not the git tag.

## Fix

Bump to 2.6.1 (don't re-cut v2.6.0; keeps the published tag immutable).

- \`[workspace.package].version\` in root \`Cargo.toml\` — picked up by every workspace crate
- \`mur-agent-gui\` package version separately (workspace-EXCLUDED)

## Verification

\`\`\`
$ cargo run -p mur-core -- --version
mur 2.6.1
\`\`\`

## Release steps after merge

1. \`git tag -a v2.6.1 -m "..."\`
2. \`git push --tags\`
3. CI release pipeline builds new tarballs
4. Update \`mur-run/homebrew-tap\` formula \`url\` (v2.6.1) + \`sha256\`
5. \`brew update && brew upgrade mur\` reports \`mur 2.6.1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)