### PR TITLE
M8.4: b0-m8 telemetry-redaction e2e + cookbook + roadmap footer

### DIFF
--- a/docs/cookbook/b0-telemetry-redaction.md
+++ b/docs/cookbook/b0-telemetry-redaction.md
@@ -1,0 +1,166 @@
+# B0 telemetry redaction (rule 9 + rule 12 audit)
+
+Closes the last v1 privacy-correctness gaps. Tells you what mur writes
+to disk, what gets redacted, and what doesn't — so you can write a
+release-time privacy statement that's actually true.
+
+## What gets written
+
+Every running agent appends a JSONL line per event to:
+
+```
+~/.mur/agents/<name>/telemetry/<YYYY-MM-DD>.jsonl
+```
+
+The event variants are documented in `mur-agent-runtime/src/telemetry_writer.rs`.
+The structural fields are intentional metadata:
+
+| Field | Source | Always written? |
+|---|---|---|
+| `gen_ai.usage.input_tokens` / `…output_tokens` | M0 hook chain | yes |
+| `gen_ai.request.model` | hook chain | yes |
+| `mur.task.id` | task runner | yes |
+| `mur.mcp.server` / `tool` | hook chain | yes |
+| `latency_ms` / `cost_usd` / `duration_ms` / `ok` | hook chain | yes |
+| `Error.message` / `Warning.message` / `TaskProgress.message` | free-form | yes — **redacted** |
+| `HookFired.attrs` (object merged into envelope) | arbitrary hook | yes — **redacted** |
+
+## What gets redacted (rule 9 / M8.1)
+
+A single chokepoint inside the writer applies two redactor passes to
+every JSON string leaf before it hits the disk and before it's
+forwarded to a transport subscriber.
+
+### Credential redactor
+
+Reuses the M7.5 outbound-secret regex set (rule 7). Both the rule-7
+"drop the message" path and the rule-9 "scrub on write" path share
+one source of truth, so the patterns can never drift:
+
+| Pattern | Replaced with |
+|---|---|
+| `sk-…` (≥ 20 alphanumeric) | `[REDACTED:openai_key]` |
+| `sk-ant-…` | `[REDACTED:anthropic_key]` |
+| `AKIA…` (16 uppercase alnum) | `[REDACTED:aws_access_key]` |
+| `aws_secret_access_key=…` (40-char base64) | `[REDACTED:aws_secret_key]` |
+| `ghp_…` / `ghs_…` (36-char) | `[REDACTED:github_pat]` / `…app_token` |
+| `AIza…` (35-char) | `[REDACTED:gcp_api_key]` |
+| `eyJ….….…` (JWT) | `[REDACTED:jwt]` |
+| `-----BEGIN … PRIVATE KEY-----` | `[REDACTED:pem_private_key]` |
+| `hooks.slack.com/services/…` | `[REDACTED:slack_webhook]` |
+| `(api_key\|token\|password)=<20+ chars>` | `[REDACTED:env_assignment]` |
+
+### Home-path redactor
+
+Collapses OS-account-name path prefixes so error messages don't leak
+the local username:
+
+| Input | Output |
+|---|---|
+| `/Users/alice/secret.txt` | `~/secret.txt` |
+| `/home/bob/.ssh/id_rsa` | `~/.ssh/id_rsa` |
+| `C:\Users\Carol\Desktop\notes.md` | `~\Desktop\notes.md` |
+
+The trailing path is preserved so debug context survives.
+
+## What does NOT get redacted
+
+These are operational telemetry and are part of the v1 contract:
+
+- token counts, latency, cost
+- model names (`claude-opus-4-7`, `gpt-4o`, `llama3:8b`)
+- MCP server names + tool names
+- task IDs / trace IDs / agent UUID
+- timestamps, durations, `ok` boolean
+
+If you're worried about model-name disclosure (e.g. you're testing a
+private fine-tune), set the model alias in `~/.mur/models.yaml` and the
+alias name is what telemetry sees.
+
+## Companion subsystem (rule 12 audit / M8.3)
+
+The companion subsystem (`mur-agent-runtime/src/companion/`) has **no
+direct network egress** by construction. The audit at
+`mur-agent-runtime/src/companion/network_audit.rs` runs at every test
+invocation:
+
+1. Embeds every companion source via `include_str!`.
+2. Asserts none of them imports `reqwest`, `hyper`, `surf`, `ureq`,
+   `isahc`, `tokio::net::*`, `std::net::*`, or any raw socket type.
+3. Drift guard: `pub mod` count in `companion/mod.rs` must match the
+   audit's file list — adding a new companion file silently fails CI
+   until it's listed in the audit.
+4. Allow-list check: every `crate::llm::*` reference must resolve to
+   the LlmClient surface (`LlmClient`, `LlmError`, `LlmMessage`,
+   `LlmRequest`, `LlmResponse`) or a recognised provider sub-module
+   (`anthropic`, `ollama`, `openai`, `stub`).
+
+The single allowed outbound is `crate::llm::LlmClient` — the same
+model-provider call the agent already makes for any tool execution,
+which the user opted into when they chose the model. There is **no
+companion-specific egress beyond what the rest of the agent already
+does**.
+
+## How to verify on your machine
+
+Run the harness-level acceptance:
+
+```bash
+bash scripts/e2e/b0-m8-telemetry-redaction.sh
+```
+
+For a real-bundle check, start an agent and intentionally inject a
+secret pattern through any tool call that lands in `HookFired.attrs`,
+then tail the JSONL:
+
+```bash
+mur agent send my-agent "test message: sk-ant-abcdefghijklmnop-9999"
+sleep 2
+tail -f ~/.mur/agents/my-agent/telemetry/$(date -u +%Y-%m-%d).jsonl | jq .
+# Expect: any string mentioning the key shows up as `[REDACTED:anthropic_key]`.
+```
+
+## How to disable telemetry entirely
+
+Set the per-agent `telemetry.enabled` flag to `false` in
+`~/.mur/agents/<name>/profile.yaml`:
+
+```yaml
+telemetry:
+  enabled: false
+```
+
+This silences the writer thread; nothing is appended to
+`telemetry/*.jsonl`. The hook chain still runs (B0 rules 1–22 still
+fire) — only the on-disk record is suppressed.
+
+## What still leaves the device
+
+Telemetry redaction does NOT cover what the agent itself sends to its
+configured model provider over the network. That's the agent's normal
+operation, governed by:
+
+- `entitlements.network.outbound.allowlist` (rule 2) — host-level gate
+- B0 rule 7 outbound credential pre-filter — drops the entire message
+  if a secret is detected
+
+For the privacy statement (`docs/release/privacy-statement.md`, M8.5)
+the precise claim is:
+
+> The agent only sends content over the network to:
+>   1. The model provider you configured (Anthropic / OpenAI / Ollama / etc.)
+>   2. MCP servers you explicitly added with `mur agent mcp add`
+>   3. Bridges you explicitly enabled (Telegram, webhook, …)
+>
+> All other network paths are blocked. The companion subsystem in
+> particular has no direct outbound; its only network call is to the
+> agent's configured model provider, identical to any tool-driven
+> model call.
+
+## See also
+
+- `docs/superpowers/specs/2026-04-30-mur-agent-harness-roadmap-design.md` §6.1 (B0 rules 9 + 12)
+- `docs/superpowers/specs/2026-05-05-b0-m8-telemetry-hardening-design.md` (M8 design)
+- `mur-agent-runtime/src/hooks/b0_helpers.rs` (`scan_for_secrets`, `redact_secrets`, `redact_home_path`)
+- `mur-agent-runtime/src/telemetry_writer.rs` (`redact_envelope`)
+- `mur-agent-runtime/src/companion/network_audit.rs` (rule 12 enforcement)

--- a/docs/superpowers/specs/2026-04-30-mur-agent-harness-roadmap-design.md
+++ b/docs/superpowers/specs/2026-04-30-mur-agent-harness-roadmap-design.md
@@ -661,12 +661,12 @@ All 22 rules are implemented inside `B0SafetyHook` (Track A built-in handler) an
 - AgentDojo-50 indirect-injection success rate ≤ 5% (research baseline of unprotected agents: 30-60%).
 - HarmBench-50 jailbreak success rate ≤ baseline minus 50%.
 - End-to-end demo: dropping an "invisible text PDF" with ASCII smuggling does not trigger any side-effect tool in the same turn.
-- v1 ship status (2026-05-03):
+- v1 ship status (2026-05-05):
   - Rules 1, 2, 3, 4, 5, 7, 8, 11: shipped (M7.1-M7.7).
   - Rule 6: deferred to MCP install CLI work (separate plan).
-  - Rule 9: deferred to telemetry redaction work (separate plan).
+  - **Rule 9: shipped (M8.1)** — `redact_secrets` + `redact_home_path` + `redact_envelope` chokepoint in `telemetry_writer`. Cookbook: `docs/cookbook/b0-telemetry-redaction.md`. Acceptance: `bash scripts/e2e/b0-m8-telemetry-redaction.sh`.
   - Rule 10: documented; mechanism implemented across M0/M3.8/M7.3.
-  - Rule 12: M2.x companion subsystem already enforces; audit pending.
+  - **Rule 12: shipped (M8.3)** — companion zero-network audit at `mur-agent-runtime/src/companion/network_audit.rs` (compile-time enforcement via `include_str!`). Wording refined to acknowledge LlmClient as the only allowed outbound indirection.
   - Rules 13-22: shipped in M3 (drag-drop) + M4 (cards).
 
 ### 6.2 v1 Threat Model Document (16 sections)

--- a/scripts/e2e/b0-m8-telemetry-redaction.sh
+++ b/scripts/e2e/b0-m8-telemetry-redaction.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# scripts/e2e/b0-m8-telemetry-redaction.sh — B0 M8 telemetry hardening.
+#
+# Drives the harness-level acceptance for M8.1 (telemetry redactor +
+# envelope chokepoint) and M8.3 (companion zero-network audit). Closes
+# B0 rules 9 + 12.
+#
+# Acceptance gates (spec
+# `docs/superpowers/specs/2026-05-05-b0-m8-telemetry-hardening-design.md` §6):
+#  1. `redact_secrets` replaces every credential pattern from the M7.5
+#     regex set with `[REDACTED:<label>]`; `Cow::Borrowed` on clean
+#     strings (no allocation hot path).
+#  2. `redact_home_path` collapses `/Users/<u>/`, `/home/<u>/`,
+#     `C:\Users\<u>\` to `~/` so error chains can't leak OS account
+#     names.
+#  3. `redact_envelope` walks `Value::Object` / `Value::Array` and
+#     applies both redactors to every string leaf in place;
+#     numbers / bools / nulls untouched.
+#  4. The redactor is wired into `TelemetryWriter::new`'s spawn loop
+#     between `event_to_notification` and `f.write_all`, so every
+#     Event variant + every hook attribute inherits redaction.
+#  5. Companion source files (13 of them) embed via `include_str!`
+#     and pass three audit checks: no forbidden tokens, drift guard
+#     vs. `pub mod` count, allow-list on `crate::llm::*` references.
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "==> 1/2 mur-agent-runtime redactor (rule 9): secrets + paths + envelope"
+cargo test -p mur-agent-runtime --lib --quiet redact
+
+echo "==> 2/2 mur-agent-runtime companion network audit (rule 12)"
+cargo test -p mur-agent-runtime --lib --quiet companion::network_audit
+
+echo
+echo "OK — B0 M8 telemetry hardening acceptance gates passed (harness-level)."
+echo "Manual bundle-level checks (tail real telemetry/<date>.jsonl after"
+echo "running an agent and confirm secrets / home paths are redacted)"
+echo "live in the cookbook at docs/cookbook/b0-telemetry-redaction.md."


### PR DESCRIPTION
## Summary
- New `scripts/e2e/b0-m8-telemetry-redaction.sh` runs M8.1 + M8.3 test gates.
- New cookbook `docs/cookbook/b0-telemetry-redaction.md` — full reference for what's redacted, what isn't, manual verification, opt-out.
- Roadmap §6.1 v1-ship-status footer updated: rules 9 + 12 marked shipped.

## Test plan
- [x] `bash scripts/e2e/b0-m8-telemetry-redaction.sh` green (24 tests across both modules)
- [ ] CI matrix

## Stacked behind
PR #176 (M8.3 audit). Will retarget to main as the cascade lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)