### PR TITLE
M2-M5: dynamic local embedding discovery (incl. oMLX)

### DIFF
--- a/docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-plan.md
+++ b/docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-plan.md
@@ -1,0 +1,2622 @@
+# Dynamic Local Embedding Discovery (incl. oMLX) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add oMLX as an embedding provider, replace hardcoded `mur init` model menus with runtime discovery (Ollama `/api/show` + oMLX `/v1/embeddings` probe), and make Mode 1 default to the best locally-available embedding model.
+
+**Architecture:** New `mur-core/src/discovery/` module with a `Discovery` trait and two impls (Ollama, oMLX). Cache results at `~/.mur/cache/discovery.json` (TTL 24h). Bug-fix `EmbeddingProvider::OpenAI` to honor `cfg.embedding.openai_url` so oMLX (OpenAI-compatible at `localhost:8000/v1`) can be used as embedding backend immediately. Init UX renders a menu seeded by a static prefix-matched preference table intersected with what's actually pulled.
+
+**Tech Stack:** Rust 2024, tokio, reqwest, async-trait 0.1, wiremock 0.6 (already in `mur-core/Cargo.toml`), serde, anyhow, chrono.
+
+**Spec:** `docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md`
+
+**Phasing:** 5 milestones, each one PR. M1 ships standalone value (manual config edit unblocks oMLX). M2-M4 are library-only (no UX change). M5 flips the user-facing flow.
+
+---
+
+## M1 — Bug Fix: `EmbeddingProvider::OpenAI` honors `openai_url`
+
+**Goal:** Make `mur-core/src/store/embedding.rs::embed_openai` use a configurable base URL, add `omlx` / `mlx` provider aliases, so a user can manually edit `~/.mur/config.yaml` to point embedding at oMLX.
+
+**Branch:** `feat/mur-m1-embedding-base-url`
+
+### Task 1.1: Add `base_url` field to `EmbeddingProvider::OpenAI`
+
+**Files:**
+- Modify: `mur-core/src/store/embedding.rs`
+- Test: `mur-core/src/store/embedding.rs` (mod tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the bottom of `mur-core/src/store/embedding.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::config::Config;
+
+    fn cfg_with(provider: &str, url: Option<&str>, env: Option<&str>) -> Config {
+        let mut cfg = Config::default();
+        cfg.embedding.provider = provider.into();
+        cfg.embedding.openai_url = url.map(str::to_string);
+        cfg.embedding.api_key_env = env.map(str::to_string);
+        cfg
+    }
+
+    #[test]
+    fn omlx_provider_uses_custom_base_url() {
+        let cfg = cfg_with("omlx", Some("http://localhost:8000/v1"), Some("OMLX_API_KEY"));
+        let ec = EmbeddingConfig::from_config(&cfg);
+        match ec.provider {
+            EmbeddingProvider::OpenAI { base_url, .. } => {
+                assert_eq!(base_url, "http://localhost:8000/v1");
+            }
+            _ => panic!("expected OpenAI variant for provider=omlx"),
+        }
+    }
+
+    #[test]
+    fn openai_provider_defaults_to_canonical_base_url() {
+        let cfg = cfg_with("openai", None, Some("OPENAI_API_KEY"));
+        let ec = EmbeddingConfig::from_config(&cfg);
+        match ec.provider {
+            EmbeddingProvider::OpenAI { base_url, .. } => {
+                assert_eq!(base_url, "https://api.openai.com/v1");
+            }
+            _ => panic!("expected OpenAI variant"),
+        }
+    }
+
+    #[test]
+    fn ollama_provider_unchanged_by_openai_url() {
+        let cfg = cfg_with("ollama", Some("http://example.com"), None);
+        let ec = EmbeddingConfig::from_config(&cfg);
+        matches!(ec.provider, EmbeddingProvider::Ollama { .. });
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core --lib store::embedding::tests`
+Expected: FAIL — destructuring `EmbeddingProvider::OpenAI { base_url, .. }` fails to compile because the variant has no `base_url` field.
+
+- [ ] **Step 3: Implement minimal change**
+
+Edit `mur-core/src/store/embedding.rs:15-19` — replace the enum and `from_config`:
+
+```rust
+#[derive(Debug, Clone)]
+pub enum EmbeddingProvider {
+    Ollama { base_url: String },
+    OpenAI { api_key: String, base_url: String },
+}
+
+impl EmbeddingConfig {
+    /// Create from the global mur config.
+    pub fn from_config(cfg: &mur_common::config::Config) -> Self {
+        let provider = match cfg.embedding.provider.as_str() {
+            "openai" | "gemini" | "anthropic" | "voyage" | "omlx" | "mlx" => {
+                let api_key = cfg
+                    .embedding
+                    .api_key_env
+                    .as_deref()
+                    .and_then(|env| std::env::var(env).ok())
+                    .unwrap_or_else(|| std::env::var("OPENAI_API_KEY").unwrap_or_default());
+                let base_url = cfg
+                    .embedding
+                    .openai_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.openai.com/v1".into());
+                EmbeddingProvider::OpenAI { api_key, base_url }
+            }
+            _ => EmbeddingProvider::Ollama {
+                base_url: cfg.embedding.ollama_endpoint.clone(),
+            },
+        };
+        Self {
+            provider,
+            model: cfg.embedding.model.clone(),
+            dimensions: cfg.embedding.dimensions,
+        }
+    }
+}
+```
+
+Also update `embed` dispatch at lines 60-65:
+
+```rust
+pub async fn embed(text: &str, config: &EmbeddingConfig) -> Result<Vec<f32>> {
+    match &config.provider {
+        EmbeddingProvider::Ollama { base_url } => embed_ollama(text, base_url, &config.model).await,
+        EmbeddingProvider::OpenAI { api_key, base_url } => {
+            embed_openai(text, base_url, api_key, &config.model).await
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-core --lib store::embedding::tests`
+Expected: PASS — three tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/store/embedding.rs
+git commit -m "M1.1: thread base_url into EmbeddingProvider::OpenAI"
+```
+
+---
+
+### Task 1.2: `embed_openai` uses dynamic base URL
+
+**Files:**
+- Modify: `mur-core/src/store/embedding.rs:134-159`
+- Test: `mur-core/tests/embedding_openai_url.rs` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-core/tests/embedding_openai_url.rs`:
+
+```rust
+//! Integration test: embed_openai POSTs to the base_url from EmbeddingConfig,
+//! not the hardcoded api.openai.com URL.
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn embed_openai_posts_to_custom_base_url() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": [{"embedding": vec![0.1f32; 1024]}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut cfg = mur_common::config::Config::default();
+    cfg.embedding.provider = "omlx".into();
+    cfg.embedding.openai_url = Some(server.uri()); // mock acts as oMLX server
+    cfg.embedding.model = "mlx-community/Qwen3-Embedding-0.6B-8bit".into();
+    cfg.embedding.api_key_env = Some("OMLX_API_KEY".into());
+
+    // SAFETY: cargo runs tests serially within a single test binary by default,
+    // and this test is the only one mutating OMLX_API_KEY in this crate.
+    unsafe {
+        std::env::set_var("OMLX_API_KEY", "local");
+    }
+
+    let ec = mur_core::store::embedding::EmbeddingConfig::from_config(&cfg);
+    let v = mur_core::store::embedding::embed("hello", &ec).await.unwrap();
+    assert_eq!(v.len(), 1024);
+}
+```
+
+Note: this requires `mur_core::store::embedding::*` to be `pub` — `EmbeddingConfig`, `EmbeddingProvider`, and `embed` already are (verify with `grep '^pub fn\|^pub struct\|^pub enum' mur-core/src/store/embedding.rs`). If `store::embedding` is not re-exported, the test path is `mur_core::store::embedding::*`. If `store` is private, the test must be a unit test instead — keep it under `#[cfg(test)] mod tests` in `embedding.rs`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core --test embedding_openai_url`
+Expected: FAIL — the mock receives 0 requests (current code POSTs to `api.openai.com`).
+
+- [ ] **Step 3: Implement**
+
+Edit `mur-core/src/store/embedding.rs` — replace `embed_openai` (lines 134-159):
+
+```rust
+async fn embed_openai(text: &str, base_url: &str, api_key: &str, model: &str) -> Result<Vec<f32>> {
+    let client = reqwest::Client::new();
+    let url = format!("{}/embeddings", base_url.trim_end_matches('/'));
+    let resp = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .json(&OpenAIEmbedRequest {
+            model: model.into(),
+            input: text.into(),
+        })
+        .send()
+        .await
+        .with_context(|| format!("calling embed API at {}", url))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Embed API error {} at {}: {}", status, url, body);
+    }
+
+    let data: OpenAIEmbedResponse = resp.json().await.context("parsing embed response")?;
+    data.data
+        .into_iter()
+        .next()
+        .map(|d| d.embedding)
+        .context("no embedding returned")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-core --test embedding_openai_url`
+Expected: PASS — mock receives 1 request, `v.len() == 1024`.
+
+Also re-run M1.1 unit tests to confirm no regression: `cargo test -p mur-core --lib store::embedding::tests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/store/embedding.rs mur-core/tests/embedding_openai_url.rs
+git commit -m "M1.2: embed_openai uses cfg.embedding.openai_url"
+```
+
+---
+
+### Task 1.3: Update `mur init` cloud-embedding helper to set `openai_url` for clarity
+
+**Files:**
+- Modify: `mur-core/src/cmd/init.rs:797-833` (`select_cloud_embedding`)
+
+This is the smallest possible change to make the cloud branches not regress: when the cloud LLM is OpenRouter (which has no embedding API but routes through `openai_url`), `select_cloud_embedding` already falls back to OpenAI for embedding — that path was always broken silently because `embed_openai` ignored `openai_url`. After M1.2, that path will actually work. Add a unit test asserting the cloud-embedding path writes a sane `openai_url: None` (i.e. it doesn't accidentally inherit OpenRouter's URL).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mur-core/src/cmd/init.rs` (bottom, in `mod tests`):
+
+```rust
+#[cfg(test)]
+mod cloud_embedding_tests {
+    use mur_common::config::Config;
+
+    /// When user picks Anthropic as cloud LLM and Voyage as embedding,
+    /// embedding.openai_url must be None (Voyage uses its own canonical
+    /// URL, not OpenRouter's).
+    #[test]
+    fn cloud_embedding_does_not_inherit_llm_openai_url() {
+        let mut cfg = Config::default();
+        cfg.llm.provider = "openai".into();
+        cfg.llm.openai_url = Some("https://openrouter.ai/api/v1".into());
+        // simulate what select_cloud_embedding does for anthropic→voyage:
+        cfg.embedding.provider = "anthropic".into();
+        cfg.embedding.model = "voyage-3-lite".into();
+        cfg.embedding.api_key_env = Some("ANTHROPIC_API_KEY".into());
+        cfg.embedding.openai_url = None;
+
+        // Round-trip through EmbeddingConfig — should resolve OpenAI variant
+        // with default base_url (api.openai.com), NOT OpenRouter.
+        let ec = mur_core::store::embedding::EmbeddingConfig::from_config(&cfg);
+        match ec.provider {
+            mur_core::store::embedding::EmbeddingProvider::OpenAI { base_url, .. } => {
+                assert_eq!(base_url, "https://api.openai.com/v1");
+            }
+            _ => panic!("expected OpenAI variant"),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes immediately**
+
+Run: `cargo test -p mur-core --lib cmd::init::cloud_embedding_tests`
+Expected: PASS — this is a regression-safety test; M1.1's logic is already correct. If it FAILS, M1.1 has a bug.
+
+- [ ] **Step 3: No implementation change needed; test is regression coverage**
+
+Skip.
+
+- [ ] **Step 4: Run full mur-core test suite**
+
+Run: `cargo test -p mur-core`
+Expected: PASS, including the new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/init.rs
+git commit -m "M1.3: regression test for cloud embedding url isolation"
+```
+
+**M1 done — open PR titled "M1: thread openai_url through EmbeddingProvider (unblocks oMLX)".**
+
+---
+
+## M2 — Discovery scaffold + preference table + cache
+
+**Goal:** Land the `discovery::` module skeleton (trait, types, cache I/O) and the `preference.rs` ranking table. No HTTP yet — pure logic, fully unit-testable.
+
+**Branch:** `feat/mur-m2-discovery-scaffold`
+
+### Task 2.1: Create `discovery::preference` with rank function
+
+**Files:**
+- Create: `mur-core/src/discovery/mod.rs`
+- Create: `mur-core/src/discovery/preference.rs`
+- Modify: `mur-core/src/lib.rs:36` (add `pub mod discovery;`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-core/src/discovery/preference.rs`:
+
+```rust
+//! Static prefix-matched preference tables for picking the "best" model
+//! to recommend when multiple are available locally. Future-proof against
+//! new tags via prefix matching.
+
+/// Ordered preference for embedding models, descending by score.
+/// Both Ollama tag form (`name:size`) and HuggingFace id form
+/// (`mlx-community/Foo`) appear at equal score.
+pub const EMBEDDING_PREFERENCE: &[(&str, u32)] = &[
+    ("qwen3.5-embedding",       105),  // future-proof
+    ("Qwen3-Embedding-8B",      100),
+    ("qwen3-embedding:8b",      100),
+    ("Qwen3-Embedding-4B",       90),
+    ("qwen3-embedding:4b",       90),
+    ("bge-m3",                   80),
+    ("jina-embeddings-v3",       75),
+    ("Qwen3-Embedding-0.6B",     70),
+    ("qwen3-embedding:0.6b",     70),
+    ("embeddinggemma",           55),
+    ("nomic-embed-text",         40),
+    ("all-minilm",               20),
+];
+
+/// Ordered preference for chat / completion LLMs (Mode 3 only).
+/// Aligned with the curated picks in `cmd/init_local.rs::OLLAMA_RECS` /
+/// `MLX_RECS`. Multilingual-first ordering.
+pub const LLM_PREFERENCE: &[(&str, u32)] = &[
+    ("Qwen3.5-9B",                95),
+    ("qwen3.5:9b",                95),
+    ("Qwen3.5-4B",                90),
+    ("qwen3.5:4b",                90),
+    ("Gemma4-E2B",                85),
+    ("gemma4:e2b",                85),
+    ("Qwen3-9B",                  70),
+    ("qwen3:9b",                  70),
+    ("Qwen3-4B",                  65),
+    ("qwen3:4b",                  65),
+    ("llama3.3",                  60),
+];
+
+/// Highest-scoring prefix that is a substring of `id`. Returns 0 when no
+/// prefix matches. Case-sensitive — both Ollama (`qwen3-embedding:0.6b`)
+/// and HF (`Qwen3-Embedding-0.6B`) forms must appear in the table.
+pub fn rank(id: &str, table: &[(&'static str, u32)]) -> u32 {
+    table
+        .iter()
+        .filter(|(prefix, _)| id.contains(prefix))
+        .map(|(_, score)| *score)
+        .max()
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ollama_tag_form_ranked() {
+        assert_eq!(rank("qwen3-embedding:0.6b", EMBEDDING_PREFERENCE), 70);
+        assert_eq!(rank("qwen3-embedding:8b", EMBEDDING_PREFERENCE), 100);
+        assert_eq!(rank("bge-m3", EMBEDDING_PREFERENCE), 80);
+    }
+
+    #[test]
+    fn hf_id_form_ranked() {
+        assert_eq!(
+            rank("mlx-community/Qwen3-Embedding-0.6B-8bit", EMBEDDING_PREFERENCE),
+            70
+        );
+        assert_eq!(
+            rank("mlx-community/Qwen3-Embedding-8B-4bit-DWQ", EMBEDDING_PREFERENCE),
+            100
+        );
+    }
+
+    #[test]
+    fn unknown_id_returns_zero() {
+        assert_eq!(rank("randomuser/foo-base", EMBEDDING_PREFERENCE), 0);
+        assert_eq!(rank("", EMBEDDING_PREFERENCE), 0);
+    }
+
+    #[test]
+    fn future_qwen35_embedding_wins() {
+        // When Alibaba ships qwen3.5-embedding, the prefix table should pick
+        // it over current SOTA without any code change.
+        assert_eq!(
+            rank("qwen3.5-embedding:0.6b", EMBEDDING_PREFERENCE),
+            105
+        );
+        assert!(
+            rank("qwen3.5-embedding:0.6b", EMBEDDING_PREFERENCE)
+                > rank("qwen3-embedding:8b", EMBEDDING_PREFERENCE)
+        );
+    }
+
+    #[test]
+    fn llm_table_separate() {
+        assert_eq!(rank("qwen3.5:9b", LLM_PREFERENCE), 95);
+        assert_eq!(rank("qwen3.5:9b", EMBEDDING_PREFERENCE), 0); // not in embedding table
+    }
+
+    #[test]
+    fn case_sensitive_distinguishes_forms() {
+        // The two forms are distinct entries at the same score; rank is the
+        // max of all matching prefixes, so a string matching either is fine.
+        assert_eq!(rank("Qwen3-Embedding-8B", EMBEDDING_PREFERENCE), 100);
+        assert_eq!(rank("qwen3-embedding:8b", EMBEDDING_PREFERENCE), 100);
+    }
+}
+```
+
+Create `mur-core/src/discovery/mod.rs` (minimal stub; will grow in 2.2):
+
+```rust
+//! Runtime discovery: query Ollama / oMLX for what models are actually
+//! pulled, what their kind (LLM vs embedding) is, and what dims they have.
+//!
+//! See `docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md`.
+
+pub mod preference;
+```
+
+Modify `mur-core/src/lib.rs` — add `pub mod discovery;` near the other `pub mod` declarations (alphabetical, between `dashboard` and `evolve`):
+
+```rust
+pub mod dashboard;
+pub mod discovery;  // ← new
+pub mod evolve;
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cargo test -p mur-core --lib discovery::preference::tests`
+Expected: PASS — six tests pass.
+
+- [ ] **Step 3: No further implementation; this task is the implementation**
+
+Skip.
+
+- [ ] **Step 4: Verify clippy + workspace still compiles**
+
+Run: `cargo clippy -p mur-core -- -D warnings && cargo build --workspace`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/discovery/ mur-core/src/lib.rs
+git commit -m "M2.1: discovery::preference table + rank()"
+```
+
+---
+
+### Task 2.2: Discovery trait + types
+
+**Files:**
+- Modify: `mur-core/src/discovery/mod.rs`
+- Test: `mur-core/src/discovery/mod.rs` (mod tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mur-core/src/discovery/mod.rs` (bottom):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovered_model_round_trips_serde() {
+        let m = DiscoveredModel {
+            id: "qwen3-embedding:0.6b".into(),
+            backend: Backend::Ollama,
+            kind: ModelKind::Embedding,
+            dims: Some(1024),
+            family: Some("bert".into()),
+            size_bytes: Some(700_000_000),
+            probed_at: None,
+        };
+        let s = serde_json::to_string(&m).unwrap();
+        let m2: DiscoveredModel = serde_json::from_str(&s).unwrap();
+        assert_eq!(m.id, m2.id);
+        assert_eq!(m.backend, m2.backend);
+        assert_eq!(m.kind, m2.kind);
+        assert_eq!(m.dims, m2.dims);
+    }
+
+    #[test]
+    fn backend_display() {
+        assert_eq!(format!("{}", Backend::Ollama), "Ollama");
+        assert_eq!(format!("{}", Backend::OMlx), "oMLX");
+    }
+
+    #[test]
+    fn embedding_probe_has_dims_and_latency() {
+        let p = EmbeddingProbe { dims: 1024, latency_ms: 120 };
+        assert_eq!(p.dims, 1024);
+        assert_eq!(p.latency_ms, 120);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core --lib discovery::tests`
+Expected: FAIL — `DiscoveredModel`, `Backend`, `ModelKind`, `EmbeddingProbe` undefined.
+
+- [ ] **Step 3: Implement**
+
+Replace contents of `mur-core/src/discovery/mod.rs`:
+
+```rust
+//! Runtime discovery: query Ollama / oMLX for what models are actually
+//! pulled, what their kind (LLM vs embedding) is, and what dims they have.
+//!
+//! See `docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md`.
+
+pub mod preference;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Backend {
+    Ollama,
+    OMlx,
+}
+
+impl fmt::Display for Backend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Backend::Ollama => f.write_str("Ollama"),
+            Backend::OMlx => f.write_str("oMLX"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelKind {
+    Llm,
+    Embedding,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveredModel {
+    pub id: String,
+    pub backend: Backend,
+    pub kind: ModelKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dims: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub family: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub probed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EmbeddingProbe {
+    pub dims: usize,
+    pub latency_ms: u64,
+}
+
+#[async_trait]
+pub trait Discovery: Send + Sync {
+    fn backend(&self) -> Backend;
+    /// Enumerate all loaded / pulled models on this runtime.
+    async fn list_models(&self) -> Result<Vec<DiscoveredModel>>;
+    /// 1-token probe to determine kind + dim. Used after `list_models` when
+    /// `kind == Unknown`, or when the user picks a model whose dims we
+    /// haven't recorded yet.
+    async fn probe_embedding(&self, model_id: &str) -> Result<EmbeddingProbe>;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-core --lib discovery::tests`
+Expected: PASS — three tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/discovery/mod.rs
+git commit -m "M2.2: Discovery trait + Backend/ModelKind/DiscoveredModel"
+```
+
+---
+
+### Task 2.3: Discovery cache I/O — round-trip
+
+**Files:**
+- Create: `mur-core/src/discovery/cache.rs`
+- Modify: `mur-core/src/discovery/mod.rs` (add `pub mod cache;`)
+- Test: `mur-core/src/discovery/cache.rs` (mod tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-core/src/discovery/cache.rs`:
+
+```rust
+//! On-disk cache for discovery results, at `~/.mur/cache/discovery.json`.
+//! TTL 24h. Schema versioned. Best-effort: corrupt JSON or schema mismatch
+//! is logged and treated as empty (forces re-discovery, never errors).
+
+use anyhow::Result;
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use super::{Backend, DiscoveredModel};
+
+pub const CACHE_SCHEMA_VERSION: u32 = 1;
+pub const CACHE_TTL_HOURS: i64 = 24;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveryCache {
+    pub schema_version: u32,
+    pub entries: Vec<CacheEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheEntry {
+    pub endpoint: String,
+    pub backend: Backend,
+    pub captured_at: DateTime<Utc>,
+    pub models: Vec<DiscoveredModel>,
+}
+
+impl DiscoveryCache {
+    pub fn empty() -> Self {
+        Self { schema_version: CACHE_SCHEMA_VERSION, entries: Vec::new() }
+    }
+
+    /// Default cache path under the active mur root.
+    pub fn default_path() -> Result<PathBuf> {
+        Ok(crate::paths::mur_root()?.join("cache").join("discovery.json"))
+    }
+
+    /// Load cache from disk. Returns `empty()` on missing file, corrupt
+    /// JSON, or schema mismatch. Never errors — discovery just re-runs.
+    pub fn load(path: &Path) -> Self {
+        let Ok(bytes) = std::fs::read(path) else {
+            return Self::empty();
+        };
+        match serde_json::from_slice::<DiscoveryCache>(&bytes) {
+            Ok(c) if c.schema_version == CACHE_SCHEMA_VERSION => c,
+            Ok(c) => {
+                tracing::warn!(
+                    found = c.schema_version,
+                    expected = CACHE_SCHEMA_VERSION,
+                    "discovery cache schema mismatch; ignoring"
+                );
+                Self::empty()
+            }
+            Err(e) => {
+                tracing::warn!(?e, "discovery cache corrupt; ignoring");
+                Self::empty()
+            }
+        }
+    }
+
+    /// Atomic write via temp + rename.
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, serde_json::to_vec_pretty(self)?)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// Look up a fresh entry for (endpoint, backend). Returns None if
+    /// missing or older than `CACHE_TTL_HOURS`.
+    pub fn fresh_entry(&self, endpoint: &str, backend: Backend) -> Option<&CacheEntry> {
+        let cutoff = Utc::now() - Duration::hours(CACHE_TTL_HOURS);
+        self.entries
+            .iter()
+            .find(|e| e.endpoint == endpoint && e.backend == backend && e.captured_at >= cutoff)
+    }
+
+    /// Insert or replace the entry for (endpoint, backend).
+    pub fn upsert(&mut self, endpoint: String, backend: Backend, models: Vec<DiscoveredModel>) {
+        self.entries.retain(|e| !(e.endpoint == endpoint && e.backend == backend));
+        self.entries.push(CacheEntry {
+            endpoint,
+            backend,
+            captured_at: Utc::now(),
+            models,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::{DiscoveredModel, ModelKind};
+    use chrono::Duration as ChronoDuration;
+    use tempfile::TempDir;
+
+    fn sample_model() -> DiscoveredModel {
+        DiscoveredModel {
+            id: "qwen3-embedding:0.6b".into(),
+            backend: Backend::Ollama,
+            kind: ModelKind::Embedding,
+            dims: Some(1024),
+            family: Some("bert".into()),
+            size_bytes: None,
+            probed_at: None,
+        }
+    }
+
+    #[test]
+    fn round_trip_save_load() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("discovery.json");
+
+        let mut c = DiscoveryCache::empty();
+        c.upsert(
+            "http://localhost:11434".into(),
+            Backend::Ollama,
+            vec![sample_model()],
+        );
+        c.save(&path).unwrap();
+
+        let loaded = DiscoveryCache::load(&path);
+        assert_eq!(loaded.schema_version, CACHE_SCHEMA_VERSION);
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].models.len(), 1);
+        assert_eq!(loaded.entries[0].models[0].id, "qwen3-embedding:0.6b");
+    }
+
+    #[test]
+    fn missing_file_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        let c = DiscoveryCache::load(&dir.path().join("nope.json"));
+        assert_eq!(c.entries.len(), 0);
+    }
+
+    #[test]
+    fn corrupt_file_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("corrupt.json");
+        std::fs::write(&path, b"{not valid json").unwrap();
+        let c = DiscoveryCache::load(&path);
+        assert_eq!(c.entries.len(), 0);
+    }
+
+    #[test]
+    fn schema_mismatch_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("oldschema.json");
+        std::fs::write(
+            &path,
+            r#"{"schema_version": 999, "entries": []}"#,
+        ).unwrap();
+        let c = DiscoveryCache::load(&path);
+        assert_eq!(c.entries.len(), 0);
+    }
+
+    #[test]
+    fn fresh_entry_respects_ttl() {
+        let mut c = DiscoveryCache::empty();
+        c.upsert("ep".into(), Backend::Ollama, vec![sample_model()]);
+        assert!(c.fresh_entry("ep", Backend::Ollama).is_some());
+
+        // Manually age the entry past TTL
+        c.entries[0].captured_at = Utc::now() - ChronoDuration::hours(CACHE_TTL_HOURS + 1);
+        assert!(c.fresh_entry("ep", Backend::Ollama).is_none());
+    }
+
+    #[test]
+    fn upsert_replaces_existing() {
+        let mut c = DiscoveryCache::empty();
+        c.upsert("ep".into(), Backend::Ollama, vec![]);
+        c.upsert("ep".into(), Backend::Ollama, vec![sample_model()]);
+        assert_eq!(c.entries.len(), 1);
+        assert_eq!(c.entries[0].models.len(), 1);
+    }
+}
+```
+
+Modify `mur-core/src/discovery/mod.rs` — add at top after `pub mod preference;`:
+
+```rust
+pub mod preference;
+pub mod cache;
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core --lib discovery::cache::tests`
+Expected: FAIL — `tempfile` may not be a dev-dep (verify); also `tracing` import.
+
+If `tempfile` not present: add to `mur-core/Cargo.toml` `[dev-dependencies]`:
+```toml
+tempfile = "3"
+```
+
+Re-run: still FAIL because module is new.
+
+- [ ] **Step 3: Implementation already in step 1; just verify it compiles**
+
+Run: `cargo build -p mur-core`
+Expected: builds clean.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cargo test -p mur-core --lib discovery::cache::tests`
+Expected: PASS — six tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/discovery/cache.rs mur-core/src/discovery/mod.rs mur-core/Cargo.toml
+git commit -m "M2.3: discovery::cache with TTL + schema versioning"
+```
+
+---
+
+### Task 2.4: M2 final clippy / workspace check + open PR
+
+- [ ] **Step 1: Clippy + workspace test**
+
+Run: `cargo clippy --workspace -- -D warnings && cargo test --workspace`
+Expected: clean.
+
+- [ ] **Step 2: Push branch + open PR**
+
+```bash
+git push -u origin feat/mur-m2-discovery-scaffold
+gh pr create --title "M2: discovery scaffold + preference table + cache" \
+  --body "$(cat <<'EOF'
+## Summary
+- New `mur-core::discovery` module with `Discovery` trait, `Backend`, `ModelKind`, `DiscoveredModel`, `EmbeddingProbe`
+- `discovery::preference` static prefix-matched ranking tables for embedding + LLM
+- `discovery::cache` JSON cache at \`~/.mur/cache/discovery.json\` (TTL 24h, schema v1)
+- No HTTP yet; pure logic. Library-only; no UX change.
+
+## Spec
+\`docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md\` § 2.1, § 2.4, § 2.6
+
+## Test plan
+- [x] \`cargo test -p mur-core --lib discovery::\` (preference + cache + types)
+- [x] \`cargo clippy --workspace -- -D warnings\`
+- [x] \`cargo build --workspace\`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**M2 done.**
+
+---
+
+## M3 — `OllamaDiscovery`
+
+**Goal:** Implement `Discovery` for Ollama via `/api/tags` + `/api/show capabilities` + `/api/embed` probe. Wiremock-tested.
+
+**Branch:** `feat/mur-m3-ollama-discovery`
+
+### Task 3.1: `OllamaDiscovery::list_models` — `/api/tags` + capabilities path
+
+**Files:**
+- Create: `mur-core/src/discovery/ollama.rs`
+- Modify: `mur-core/src/discovery/mod.rs` (add `pub mod ollama;`)
+- Test: `mur-core/tests/discovery_ollama.rs` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-core/tests/discovery_ollama.rs`:
+
+```rust
+//! Wiremock-backed integration tests for OllamaDiscovery.
+
+use mur_core::discovery::{Discovery, ModelKind, ollama::OllamaDiscovery};
+use serde_json::json;
+use wiremock::matchers::{body_json_string, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn tags_response_with(models: Vec<(&str, &str, u64)>) -> serde_json::Value {
+    json!({
+        "models": models.iter().map(|(name, family, size)| json!({
+            "name": name,
+            "size": size,
+            "details": { "family": family }
+        })).collect::<Vec<_>>()
+    })
+}
+
+#[tokio::test]
+async fn list_models_marks_capabilities_embedding_as_embedding_kind() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/tags"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tags_response_with(vec![
+            ("qwen3-embedding:0.6b", "bert", 700_000_000),
+            ("qwen3.5:4b", "qwen3", 4_000_000_000),
+        ])))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/show"))
+        .and(body_json_string(r#"{"name":"qwen3-embedding:0.6b"}"#))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "capabilities": ["embedding"]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/show"))
+        .and(body_json_string(r#"{"name":"qwen3.5:4b"}"#))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "capabilities": ["completion"]
+        })))
+        .mount(&server)
+        .await;
+
+    let d = OllamaDiscovery::new(server.uri());
+    let models = d.list_models().await.unwrap();
+
+    assert_eq!(models.len(), 2);
+    let emb = models.iter().find(|m| m.id == "qwen3-embedding:0.6b").unwrap();
+    assert_eq!(emb.kind, ModelKind::Embedding);
+    assert_eq!(emb.family.as_deref(), Some("bert"));
+
+    let llm = models.iter().find(|m| m.id == "qwen3.5:4b").unwrap();
+    assert_eq!(llm.kind, ModelKind::Llm);
+}
+
+#[tokio::test]
+async fn list_models_falls_back_to_family_when_capabilities_absent() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/tags"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tags_response_with(vec![
+            ("nomic-embed-text:latest", "nomic-bert", 300_000_000),
+        ])))
+        .mount(&server)
+        .await;
+
+    // /api/show returns no capabilities field → fallback path
+    Mock::given(method("POST"))
+        .and(path("/api/show"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&server)
+        .await;
+
+    let d = OllamaDiscovery::new(server.uri());
+    let models = d.list_models().await.unwrap();
+    assert_eq!(models[0].kind, ModelKind::Embedding);
+}
+
+#[tokio::test]
+async fn list_models_marks_unreachable_show_as_unknown() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/tags"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tags_response_with(vec![
+            ("foo:bar", "weird-family", 100),
+        ])))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/show"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let d = OllamaDiscovery::new(server.uri());
+    let models = d.list_models().await.unwrap();
+    assert_eq!(models[0].kind, ModelKind::Unknown);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core --test discovery_ollama`
+Expected: FAIL — `mur_core::discovery::ollama` undefined.
+
+- [ ] **Step 3: Implement**
+
+Create `mur-core/src/discovery/ollama.rs`:
+
+```rust
+//! `Discovery` impl for Ollama via REST API at `${endpoint}/api/{tags,show,embed}`.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::time::{Duration, Instant};
+
+use super::{Backend, Discovery, DiscoveredModel, EmbeddingProbe, ModelKind};
+
+#[derive(Debug, Clone)]
+pub struct OllamaDiscovery {
+    endpoint: String,
+    client: reqwest::Client,
+}
+
+impl OllamaDiscovery {
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(15))
+                .build()
+                .expect("reqwest client"),
+        }
+    }
+
+    fn url(&self, suffix: &str) -> String {
+        format!("{}{}", self.endpoint.trim_end_matches('/'), suffix)
+    }
+}
+
+#[derive(Deserialize)]
+struct TagsResp {
+    models: Vec<TagsEntry>,
+}
+
+#[derive(Deserialize)]
+struct TagsEntry {
+    name: String,
+    #[serde(default)]
+    size: Option<u64>,
+    #[serde(default)]
+    details: TagsDetails,
+}
+
+#[derive(Deserialize, Default)]
+struct TagsDetails {
+    #[serde(default)]
+    family: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct ShowResp {
+    #[serde(default)]
+    capabilities: Vec<String>,
+}
+
+fn classify(family: Option<&str>, name: &str, capabilities: &[String]) -> ModelKind {
+    if capabilities.iter().any(|c| c == "embedding") {
+        return ModelKind::Embedding;
+    }
+    if capabilities.iter().any(|c| c == "completion") {
+        return ModelKind::Llm;
+    }
+    // Fallback heuristic when /api/show fails or returns no capabilities.
+    match family {
+        Some(f) if matches!(f, "bert" | "nomic-bert" | "jina-bert") => ModelKind::Embedding,
+        Some("qwen3") if name.contains("embedding") => ModelKind::Embedding,
+        Some(f) if matches!(f, "qwen3" | "llama" | "gemma") => ModelKind::Llm,
+        _ => ModelKind::Unknown,
+    }
+}
+
+#[async_trait]
+impl Discovery for OllamaDiscovery {
+    fn backend(&self) -> Backend { Backend::Ollama }
+
+    async fn list_models(&self) -> Result<Vec<DiscoveredModel>> {
+        let resp = self
+            .client
+            .get(self.url("/api/tags"))
+            .send()
+            .await
+            .context("GET /api/tags")?;
+        let tags: TagsResp = resp.json().await.context("parse /api/tags")?;
+
+        let mut out = Vec::with_capacity(tags.models.len());
+        for entry in tags.models {
+            // /api/show may fail (500, network, etc.); fallback to heuristic.
+            let caps = match self
+                .client
+                .post(self.url("/api/show"))
+                .json(&serde_json::json!({ "name": entry.name }))
+                .send()
+                .await
+            {
+                Ok(r) if r.status().is_success() => {
+                    r.json::<ShowResp>().await.unwrap_or_default().capabilities
+                }
+                _ => Vec::new(),
+            };
+            let kind = classify(entry.details.family.as_deref(), &entry.name, &caps);
+            out.push(DiscoveredModel {
+                id: entry.name,
+                backend: Backend::Ollama,
+                kind,
+                dims: None,
+                family: entry.details.family,
+                size_bytes: entry.size,
+                probed_at: None,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn probe_embedding(&self, model_id: &str) -> Result<EmbeddingProbe> {
+        let started = Instant::now();
+        let resp = self
+            .client
+            .post(self.url("/api/embed"))
+            .json(&serde_json::json!({ "model": model_id, "input": "." }))
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .context("POST /api/embed probe")?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!("/api/embed returned {}", resp.status());
+        }
+
+        #[derive(Deserialize)]
+        struct EmbedResp { embeddings: Vec<Vec<f32>> }
+
+        let er: EmbedResp = resp.json().await.context("parse /api/embed response")?;
+        let dims = er.embeddings.first().map(Vec::len).unwrap_or(0);
+        if dims == 0 {
+            anyhow::bail!("/api/embed returned empty embeddings");
+        }
+        Ok(EmbeddingProbe {
+            dims,
+            latency_ms: started.elapsed().as_millis() as u64,
+        })
+    }
+}
+```
+
+Modify `mur-core/src/discovery/mod.rs` — add `pub mod ollama;` after `pub mod cache;`.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cargo test -p mur-core --test discovery_ollama`
+Expected: PASS — three tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/discovery/ollama.rs mur-core/src/discovery/mod.rs mur-core/tests/discovery_ollama.rs
+git commit -m "M3.1: OllamaDiscovery::list_models with capabilities + fallback"
+```
+
+---
+
+### Task 3.2: `OllamaDiscovery::probe_embedding`
+
+**Files:**
+- Modify: `mur-core/tests/discovery_ollama.rs` (add test)
+- Implementation already in 3.1
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `mur-core/tests/discovery_ollama.rs`:
+
+```rust
+#[tokio::test]
+async fn probe_embedding_returns_dims_and_latency() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/embed"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "embeddings": [vec![0.0f32; 1024]]
+        })))
+        .mount(&server)
+        .await;
+
+    let d = OllamaDiscovery::new(server.uri());
+    let probe = d.probe_embedding("qwen3-embedding:0.6b").await.unwrap();
+    assert_eq!(probe.dims, 1024);
+}
+
+#[tokio::test]
+async fn probe_embedding_errors_on_4xx() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/embed"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let d = OllamaDiscovery::new(server.uri());
+    let r = d.probe_embedding("missing").await;
+    assert!(r.is_err());
+}
+```
+
+Add `EmbeddingProbe` to imports at the top:
+
+```rust
+use mur_core::discovery::{Discovery, EmbeddingProbe, ModelKind, ollama::OllamaDiscovery};
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cargo test -p mur-core --test discovery_ollama`
+Expected: PASS — five tests total now.
+
+- [ ] **Step 3: No additional implementation; coverage tests on existing code**
+
+Skip.
+
+- [ ] **Step 4: Verify no regression**
+
+Run: `cargo test -p mur-core`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/tests/discovery_ollama.rs
+git commit -m "M3.2: OllamaDiscovery::probe_embedding tests"
+```
+
+**M3 done. Open PR `feat/mur-m3-ollama-discovery`.**
+
+---
+
+## M4 — `OMlxDiscovery`
+
+**Goal:** Implement `Discovery` for oMLX via `/v1/models` + `/v1/embeddings` probe. Wiremock-tested.
+
+**Branch:** `feat/mur-m4-omlx-discovery`
+
+### Task 4.1: `OMlxDiscovery::list_models` — `/v1/models` parsing
+
+**Files:**
+- Create: `mur-core/src/discovery/omlx.rs`
+- Modify: `mur-core/src/discovery/mod.rs` (add `pub mod omlx;`)
+- Test: `mur-core/tests/discovery_omlx.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-core/tests/discovery_omlx.rs`:
+
+```rust
+use mur_core::discovery::{Discovery, ModelKind, omlx::OMlxDiscovery};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn list_models_returns_unknown_kind_pre_probe() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [
+                {"id": "mlx-community/Qwen3-Embedding-0.6B-8bit"},
+                {"id": "mlx-community/Qwen3.5-4B-4bit"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri());
+    let models = d.list_models().await.unwrap();
+    assert_eq!(models.len(), 2);
+    // /v1/models alone can't disambiguate — kind=Unknown until probed.
+    assert!(models.iter().all(|m| m.kind == ModelKind::Unknown));
+    // Family inferred from id substring
+    assert_eq!(
+        models.iter().find(|m| m.id.contains("Qwen3-Embedding")).unwrap().family.as_deref(),
+        Some("qwen3")
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core --test discovery_omlx`
+Expected: FAIL — `mur_core::discovery::omlx` undefined.
+
+- [ ] **Step 3: Implement**
+
+Create `mur-core/src/discovery/omlx.rs`:
+
+```rust
+//! `Discovery` impl for oMLX via OpenAI-compatible REST API at
+//! `${base_url}/v1/{models,embeddings}`. oMLX serves on `localhost:8000`
+//! by default.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::time::{Duration, Instant};
+
+use super::{Backend, Discovery, DiscoveredModel, EmbeddingProbe, ModelKind};
+
+/// oMLX issue #266: graph recompiles on first call after >3s idle. Budget
+/// 10s for the probe; subsequent probes settle to <500ms.
+const OMLX_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone)]
+pub struct OMlxDiscovery {
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl OMlxDiscovery {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(15))
+                .build()
+                .expect("reqwest client"),
+        }
+    }
+
+    fn url(&self, suffix: &str) -> String {
+        let trimmed = self.base_url.trim_end_matches('/');
+        // Caller passes "/v1/embeddings" or "/v1/models"; if base_url already
+        // ends in "/v1", strip the leading "/v1" from suffix to avoid dupe.
+        if trimmed.ends_with("/v1") && suffix.starts_with("/v1") {
+            format!("{}{}", trimmed, &suffix[3..])
+        } else {
+            format!("{}{}", trimmed, suffix)
+        }
+    }
+}
+
+fn family_from_id(id: &str) -> Option<String> {
+    let lower = id.to_ascii_lowercase();
+    if lower.contains("qwen3") { Some("qwen3".into()) }
+    else if lower.contains("bge-") || lower.contains("bge_") { Some("bge".into()) }
+    else if lower.contains("modernbert") { Some("modernbert".into()) }
+    else if lower.contains("nomic") { Some("nomic-bert".into()) }
+    else if lower.contains("jina") { Some("jina-bert".into()) }
+    else { None }
+}
+
+#[derive(Deserialize)]
+struct ModelsResp {
+    data: Vec<ModelEntry>,
+}
+
+#[derive(Deserialize)]
+struct ModelEntry {
+    id: String,
+}
+
+#[async_trait]
+impl Discovery for OMlxDiscovery {
+    fn backend(&self) -> Backend { Backend::OMlx }
+
+    async fn list_models(&self) -> Result<Vec<DiscoveredModel>> {
+        let resp = self
+            .client
+            .get(self.url("/v1/models"))
+            .send()
+            .await
+            .context("GET /v1/models")?;
+        let mr: ModelsResp = resp.json().await.context("parse /v1/models")?;
+
+        Ok(mr
+            .data
+            .into_iter()
+            .map(|e| DiscoveredModel {
+                family: family_from_id(&e.id),
+                id: e.id,
+                backend: Backend::OMlx,
+                kind: ModelKind::Unknown, // /v1/models has no type field; probe to discriminate
+                dims: None,
+                size_bytes: None,
+                probed_at: None,
+            })
+            .collect())
+    }
+
+    async fn probe_embedding(&self, model_id: &str) -> Result<EmbeddingProbe> {
+        let started = Instant::now();
+        let resp = self
+            .client
+            .post(self.url("/v1/embeddings"))
+            .json(&serde_json::json!({ "model": model_id, "input": "." }))
+            .timeout(OMLX_PROBE_TIMEOUT)
+            .send()
+            .await
+            .context("POST /v1/embeddings probe")?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!("/v1/embeddings returned {} for {}", resp.status(), model_id);
+        }
+
+        #[derive(Deserialize)]
+        struct EmbedResp {
+            data: Vec<EmbedData>,
+        }
+
+        #[derive(Deserialize)]
+        struct EmbedData {
+            embedding: Vec<f32>,
+        }
+
+        let er: EmbedResp = resp.json().await.context("parse /v1/embeddings")?;
+        let dims = er.data.first().map(|d| d.embedding.len()).unwrap_or(0);
+        if dims == 0 {
+            anyhow::bail!("/v1/embeddings returned empty data");
+        }
+        Ok(EmbeddingProbe {
+            dims,
+            latency_ms: started.elapsed().as_millis() as u64,
+        })
+    }
+}
+```
+
+Modify `mur-core/src/discovery/mod.rs` — add `pub mod omlx;` after `pub mod ollama;`.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cargo test -p mur-core --test discovery_omlx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/discovery/omlx.rs mur-core/src/discovery/mod.rs mur-core/tests/discovery_omlx.rs
+git commit -m "M4.1: OMlxDiscovery::list_models + family inference"
+```
+
+---
+
+### Task 4.2: `OMlxDiscovery::probe_embedding` happy + 4xx + family-inference tests
+
+**Files:**
+- Modify: `mur-core/tests/discovery_omlx.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `mur-core/tests/discovery_omlx.rs`:
+
+```rust
+#[tokio::test]
+async fn probe_embedding_happy_path() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{"embedding": vec![0.0f32; 1024]}]
+        })))
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri());
+    let p = d.probe_embedding("mlx-community/Qwen3-Embedding-0.6B-8bit").await.unwrap();
+    assert_eq!(p.dims, 1024);
+}
+
+#[tokio::test]
+async fn probe_embedding_4xx_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(400).set_body_string(
+            "model does not support embeddings"
+        ))
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri());
+    let r = d.probe_embedding("mlx-community/Qwen3.5-4B-4bit").await;
+    assert!(r.is_err());
+    assert!(r.unwrap_err().to_string().contains("400"));
+}
+
+#[tokio::test]
+async fn probe_embedding_empty_array_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"data": []})))
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri());
+    assert!(d.probe_embedding("foo").await.is_err());
+}
+
+#[test]
+fn family_inference_table() {
+    use mur_core::discovery::omlx::OMlxDiscovery;
+    // family_from_id is private; test by going through list_models + a mock,
+    // but since this is sync we exercise via DiscoveredModel construction:
+    // the family inference is observable through list_models in the
+    // first test in this file.
+    let _ = OMlxDiscovery::new("http://x");
+}
+
+#[tokio::test]
+async fn list_models_infers_family_from_id() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [
+                {"id": "mlx-community/bge-m3"},
+                {"id": "lightonai/modernbert-embed-large"},
+                {"id": "mlx-community/Qwen3-Embedding-0.6B-8bit"},
+                {"id": "nomic-ai/nomic-embed-text-v1.5"},
+                {"id": "jinaai/jina-embeddings-v3"},
+                {"id": "unknown/foo"},
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri());
+    let models = d.list_models().await.unwrap();
+    let f = |id: &str| {
+        models.iter().find(|m| m.id == id).unwrap().family.as_deref().map(str::to_string)
+    };
+    assert_eq!(f("mlx-community/bge-m3"), Some("bge".into()));
+    assert_eq!(f("lightonai/modernbert-embed-large"), Some("modernbert".into()));
+    assert_eq!(f("mlx-community/Qwen3-Embedding-0.6B-8bit"), Some("qwen3".into()));
+    assert_eq!(f("nomic-ai/nomic-embed-text-v1.5"), Some("nomic-bert".into()));
+    assert_eq!(f("jinaai/jina-embeddings-v3"), Some("jina-bert".into()));
+    assert_eq!(f("unknown/foo"), None);
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cargo test -p mur-core --test discovery_omlx`
+Expected: PASS — six tests.
+
+- [ ] **Step 3: No additional impl**
+
+Skip.
+
+- [ ] **Step 4: Workspace check**
+
+Run: `cargo test --workspace && cargo clippy --workspace -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/tests/discovery_omlx.rs
+git commit -m "M4.2: OMlxDiscovery::probe_embedding + family inference tests"
+```
+
+**M4 done. Open PR `feat/mur-m4-omlx-discovery`.**
+
+---
+
+## M5 — Init UX rewrite + LLM-side dynamic discovery
+
+**Goal:** Replace `select_ollama_embedding` (`init.rs:769-794`) with `select_local_embedding` that consumes `Discovery`. Wire LLM-side `select_model` (`init_local.rs:217`) similarly. Add `--refresh-discovery` flag. Add `ollama pull` subprocess + oMLX hint flow.
+
+**Branch:** `feat/mur-m5-init-dynamic-picker`
+
+### Task 5.1: `discovery::aggregate` — runs all available backends, returns merged + ranked list
+
+**Files:**
+- Create: `mur-core/src/discovery/aggregate.rs`
+- Modify: `mur-core/src/discovery/mod.rs` (add `pub mod aggregate;`)
+- Test: `mur-core/src/discovery/aggregate.rs` (mod tests, sync logic only)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-core/src/discovery/aggregate.rs`:
+
+```rust
+//! Aggregate `Discovery` results across all detected runtimes, intersect
+//! with the static preference table, and produce a ranked menu seed.
+
+use super::preference::{EMBEDDING_PREFERENCE, LLM_PREFERENCE, rank};
+use super::{DiscoveredModel, ModelKind};
+
+/// One menu row, in display order.
+#[derive(Debug, Clone)]
+pub struct MenuRow {
+    pub kind: MenuRowKind,
+    pub label: String,
+    pub model: Option<DiscoveredModel>,
+    pub pull_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MenuRowKind {
+    Auto,        // first row, "[auto]" prefix
+    Pulled,      // already-installed model
+    Pull,        // recommended-but-not-pulled
+    Skip,        // last row
+}
+
+/// Build the menu rows for embedding selection.
+///
+/// `available` = union of all discovery results (filtered to kind ∈
+/// {Embedding, Unknown}).
+pub fn build_embedding_menu(available: &[DiscoveredModel]) -> Vec<MenuRow> {
+    build_menu(available, EMBEDDING_PREFERENCE, ModelKind::Embedding)
+}
+
+pub fn build_llm_menu(available: &[DiscoveredModel]) -> Vec<MenuRow> {
+    build_menu(available, LLM_PREFERENCE, ModelKind::Llm)
+}
+
+fn build_menu(
+    available: &[DiscoveredModel],
+    table: &[(&'static str, u32)],
+    desired_kind: ModelKind,
+) -> Vec<MenuRow> {
+    let mut filtered: Vec<&DiscoveredModel> = available
+        .iter()
+        .filter(|m| m.kind == desired_kind || m.kind == ModelKind::Unknown)
+        .collect();
+    filtered.sort_by_key(|m| std::cmp::Reverse(rank(&m.id, table)));
+
+    let mut rows = Vec::new();
+
+    // Row 1: [auto] = highest-ranked pulled
+    if let Some(top) = filtered.first() {
+        let label = format!(
+            "[auto] {}/{}{}",
+            top.backend,
+            top.id,
+            top.dims.map(|d| format!(" ({}d)", d)).unwrap_or_default(),
+        );
+        rows.push(MenuRow {
+            kind: MenuRowKind::Auto,
+            label,
+            model: Some((*top).clone()),
+            pull_id: None,
+        });
+    }
+
+    // Rows 2..: remaining pulled
+    for m in filtered.iter().skip(1) {
+        let label = format!(
+            "{}/{}{}",
+            m.backend,
+            m.id,
+            m.dims.map(|d| format!(" ({}d)", d)).unwrap_or_default(),
+        );
+        rows.push(MenuRow {
+            kind: MenuRowKind::Pulled,
+            label,
+            model: Some((*m).clone()),
+            pull_id: None,
+        });
+    }
+
+    // Top 2 preference-table entries NOT in pulled set, with rank > 0
+    let pulled_ids: std::collections::HashSet<&str> =
+        available.iter().map(|m| m.id.as_str()).collect();
+    let mut suggestions: Vec<(&str, u32)> = table
+        .iter()
+        .filter(|(prefix, _)| !pulled_ids.iter().any(|id| id.contains(prefix)))
+        .map(|(p, s)| (*p, *s))
+        .collect();
+    suggestions.sort_by_key(|(_, s)| std::cmp::Reverse(*s));
+    for (prefix, _) in suggestions.iter().take(2) {
+        rows.push(MenuRow {
+            kind: MenuRowKind::Pull,
+            label: format!("[pull] {}", prefix),
+            model: None,
+            pull_id: Some((*prefix).into()),
+        });
+    }
+
+    // Last: skip
+    rows.push(MenuRow {
+        kind: MenuRowKind::Skip,
+        label: "Skip — configure later".into(),
+        model: None,
+        pull_id: None,
+    });
+
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::Backend;
+
+    fn dm(id: &str, backend: Backend, kind: ModelKind, dims: Option<usize>) -> DiscoveredModel {
+        DiscoveredModel {
+            id: id.into(),
+            backend,
+            kind,
+            dims,
+            family: None,
+            size_bytes: None,
+            probed_at: None,
+        }
+    }
+
+    #[test]
+    fn empty_input_yields_pull_suggestions_then_skip() {
+        let rows = build_embedding_menu(&[]);
+        // 0 auto + 0 pulled + 2 [pull] + 1 skip
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].kind, MenuRowKind::Pull);
+        assert_eq!(rows.last().unwrap().kind, MenuRowKind::Skip);
+    }
+
+    #[test]
+    fn single_pulled_becomes_auto() {
+        let avail = vec![dm("qwen3-embedding:0.6b", Backend::Ollama, ModelKind::Embedding, Some(1024))];
+        let rows = build_embedding_menu(&avail);
+        assert_eq!(rows[0].kind, MenuRowKind::Auto);
+        assert!(rows[0].label.starts_with("[auto] Ollama/qwen3-embedding:0.6b"));
+        assert!(rows[0].label.contains("(1024d)"));
+    }
+
+    #[test]
+    fn omlx_outranks_ollama_at_same_score() {
+        // Both have rank 70; oMLX should still be auto if the user pulled
+        // both. Tie-breaking: backend display order — but we don't enforce
+        // that explicitly; we accept whichever comes first after stable
+        // sort. Here we just assert one of them is [auto].
+        let avail = vec![
+            dm("qwen3-embedding:0.6b", Backend::Ollama, ModelKind::Embedding, Some(1024)),
+            dm("mlx-community/Qwen3-Embedding-0.6B-8bit", Backend::OMlx, ModelKind::Embedding, Some(1024)),
+        ];
+        let rows = build_embedding_menu(&avail);
+        assert_eq!(rows[0].kind, MenuRowKind::Auto);
+        assert_eq!(rows[1].kind, MenuRowKind::Pulled);
+    }
+
+    #[test]
+    fn pull_suggestion_excludes_already_pulled() {
+        let avail = vec![dm("qwen3-embedding:0.6b", Backend::Ollama, ModelKind::Embedding, Some(1024))];
+        let rows = build_embedding_menu(&avail);
+        for r in &rows {
+            if let Some(pid) = &r.pull_id {
+                assert!(!pid.contains("qwen3-embedding:0.6b"));
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_kind_included_in_filter() {
+        let avail = vec![dm("foo:bar", Backend::Ollama, ModelKind::Unknown, None)];
+        let rows = build_embedding_menu(&avail);
+        // Unknown is included in both embedding and llm filters
+        assert_eq!(rows[0].kind, MenuRowKind::Auto);
+    }
+
+    #[test]
+    fn llm_kind_not_in_embedding_menu() {
+        let avail = vec![dm("qwen3.5:4b", Backend::Ollama, ModelKind::Llm, None)];
+        let rows = build_embedding_menu(&avail);
+        // llm-only entry must NOT be auto
+        assert!(rows.iter().all(|r| r.model.as_ref().map(|m| m.kind) != Some(ModelKind::Llm)));
+    }
+}
+```
+
+Modify `mur-core/src/discovery/mod.rs` — add `pub mod aggregate;`.
+
+- [ ] **Step 2: Run test to verify it fails (compile error)**
+
+Run: `cargo test -p mur-core --lib discovery::aggregate::tests`
+Expected: FAIL/no-test the first run if not yet implemented; the file IS the implementation, so this should compile and PASS once written.
+
+- [ ] **Step 3: Already implemented in step 1**
+
+Skip.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cargo test -p mur-core --lib discovery::aggregate`
+Expected: PASS — six tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/discovery/aggregate.rs mur-core/src/discovery/mod.rs
+git commit -m "M5.1: discovery::aggregate menu builder"
+```
+
+---
+
+### Task 5.2: `discovery::run_all` — async aggregator that talks to all detected runtimes
+
+**Files:**
+- Modify: `mur-core/src/discovery/mod.rs`
+- Test: `mur-core/tests/discovery_run_all.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-core/tests/discovery_run_all.rs`:
+
+```rust
+use mur_core::discovery::{Backend, ModelKind};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn run_all_merges_ollama_and_omlx() {
+    let ollama_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/tags"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "models": [{
+                "name": "qwen3-embedding:0.6b",
+                "size": 700_000_000u64,
+                "details": {"family": "bert"}
+            }]
+        })))
+        .mount(&ollama_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/show"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "capabilities": ["embedding"]
+        })))
+        .mount(&ollama_server)
+        .await;
+
+    let omlx_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{"id": "mlx-community/Qwen3-Embedding-0.6B-8bit"}]
+        })))
+        .mount(&omlx_server)
+        .await;
+
+    let merged = mur_core::discovery::run_all_for_test(
+        Some(ollama_server.uri()),
+        Some(omlx_server.uri()),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(merged.len(), 2);
+    let backends: Vec<Backend> = merged.iter().map(|m| m.backend).collect();
+    assert!(backends.contains(&Backend::Ollama));
+    assert!(backends.contains(&Backend::OMlx));
+    let ollama_model = merged.iter().find(|m| m.backend == Backend::Ollama).unwrap();
+    assert_eq!(ollama_model.kind, ModelKind::Embedding);
+    let omlx_model = merged.iter().find(|m| m.backend == Backend::OMlx).unwrap();
+    assert_eq!(omlx_model.kind, ModelKind::Unknown); // not yet probed
+}
+
+#[tokio::test]
+async fn run_all_skips_failing_backends() {
+    let omlx_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"data": []})))
+        .mount(&omlx_server)
+        .await;
+
+    // Ollama unreachable URL → discovery returns empty for that backend, no error
+    let merged = mur_core::discovery::run_all_for_test(
+        Some("http://127.0.0.1:1".into()),
+        Some(omlx_server.uri()),
+    )
+    .await
+    .unwrap();
+    assert_eq!(merged.len(), 0);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core --test discovery_run_all`
+Expected: FAIL — `run_all_for_test` undefined.
+
+- [ ] **Step 3: Implement**
+
+Append to `mur-core/src/discovery/mod.rs`:
+
+```rust
+use crate::discovery::ollama::OllamaDiscovery;
+use crate::discovery::omlx::OMlxDiscovery;
+
+/// Run discovery against every endpoint that resolves; merge results.
+/// Backend-level failures are logged and dropped (non-fatal).
+async fn run_all_inner(
+    ollama_endpoint: Option<String>,
+    omlx_base_url: Option<String>,
+) -> anyhow::Result<Vec<DiscoveredModel>> {
+    let mut out = Vec::new();
+    if let Some(ep) = ollama_endpoint {
+        let d = OllamaDiscovery::new(ep);
+        match d.list_models().await {
+            Ok(mut v) => out.append(&mut v),
+            Err(e) => tracing::warn!(?e, "Ollama discovery failed"),
+        }
+    }
+    if let Some(ep) = omlx_base_url {
+        let d = OMlxDiscovery::new(ep);
+        match d.list_models().await {
+            Ok(mut v) => out.append(&mut v),
+            Err(e) => tracing::warn!(?e, "oMLX discovery failed"),
+        }
+    }
+    Ok(out)
+}
+
+/// Public entry point for production use. Wires runtime detection from
+/// `cmd/init_local.rs` to discovery endpoints.
+pub async fn run_all() -> anyhow::Result<Vec<DiscoveredModel>> {
+    let runtimes = crate::cmd::init_local::detect_local_runtimes();
+    let ollama = runtimes.ollama_running.then(|| "http://localhost:11434".to_string());
+    let omlx = runtimes.omlx_installed.then(|| "http://localhost:8000/v1".to_string());
+    run_all_inner(ollama, omlx).await
+}
+
+/// Test-only entry: caller passes endpoints directly.
+#[doc(hidden)]
+pub async fn run_all_for_test(
+    ollama_endpoint: Option<String>,
+    omlx_base_url: Option<String>,
+) -> anyhow::Result<Vec<DiscoveredModel>> {
+    run_all_inner(ollama_endpoint, omlx_base_url).await
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cargo test -p mur-core --test discovery_run_all`
+Expected: PASS — two tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/discovery/mod.rs mur-core/tests/discovery_run_all.rs
+git commit -m "M5.2: discovery::run_all aggregator"
+```
+
+---
+
+### Task 5.3: `select_local_embedding` rewrite — replaces `select_ollama_embedding`
+
+**Files:**
+- Modify: `mur-core/src/cmd/init.rs:769-794` (delete `select_ollama_embedding`, replace with `select_local_embedding`)
+- Modify: `mur-core/src/cmd/init.rs:835-976` (call sites in `match model_choice`)
+
+This task is the user-facing flip. Test coverage is mostly via the new aggregate tests + manual smoke (§6 of spec).
+
+- [ ] **Step 1: Write the (modest) test**
+
+Append to `mur-core/src/cmd/init.rs` (in the existing `cloud_embedding_tests` mod or a new `select_local_embedding_tests`):
+
+```rust
+#[cfg(test)]
+mod select_local_embedding_tests {
+    use crate::discovery::{Backend, DiscoveredModel, ModelKind};
+    use crate::discovery::aggregate::{build_embedding_menu, MenuRowKind};
+
+    fn ollama_qwen() -> DiscoveredModel {
+        DiscoveredModel {
+            id: "qwen3-embedding:0.6b".into(),
+            backend: Backend::Ollama,
+            kind: ModelKind::Embedding,
+            dims: Some(1024),
+            family: Some("bert".into()),
+            size_bytes: None,
+            probed_at: None,
+        }
+    }
+
+    /// Auto row, when chosen, must yield enough info to write
+    /// `cfg.embedding.{provider, model, dimensions, ollama_endpoint}`.
+    #[test]
+    fn auto_row_carries_full_model_info() {
+        let rows = build_embedding_menu(&[ollama_qwen()]);
+        let auto = rows.iter().find(|r| r.kind == MenuRowKind::Auto).unwrap();
+        let m = auto.model.as_ref().unwrap();
+        assert_eq!(m.backend, Backend::Ollama);
+        assert_eq!(m.id, "qwen3-embedding:0.6b");
+        assert_eq!(m.dims, Some(1024));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cargo test -p mur-core --lib cmd::init::select_local_embedding_tests`
+Expected: PASS.
+
+- [ ] **Step 3: Replace `select_ollama_embedding` with `select_local_embedding`**
+
+Edit `mur-core/src/cmd/init.rs:769-794` — replace the closure with:
+
+```rust
+    // Helper: select local embedding via discovery. Caller passes the merged
+    // discovered models from `discovery::run_all().await`. Returns Ok(true)
+    // if config was written; Ok(false) if user picked Skip; Err on probe
+    // failure or pull subprocess failure.
+    fn select_local_embedding(
+        config: &mut mur_common::config::Config,
+        available: &[crate::discovery::DiscoveredModel],
+    ) -> Result<bool> {
+        use crate::discovery::aggregate::{MenuRowKind, build_embedding_menu};
+        use crate::discovery::Backend;
+
+        let rows = build_embedding_menu(available);
+
+        println!();
+        println!("Embedding model — local discovery:");
+        for (i, r) in rows.iter().enumerate() {
+            println!("  {}) {}", i + 1, r.label);
+        }
+        print!("Choose [1-{}] (default: 1): ", rows.len());
+        io::stdout().flush()?;
+        let mut s = String::new();
+        io::stdin().read_line(&mut s)?;
+        let idx = s.trim().parse::<usize>().ok()
+            .filter(|&n| n >= 1 && n <= rows.len())
+            .map(|n| n - 1)
+            .unwrap_or(0);
+        let row = &rows[idx];
+
+        match row.kind {
+            MenuRowKind::Auto | MenuRowKind::Pulled => {
+                let m = row.model.as_ref().expect("auto/pulled rows always carry a model");
+                match m.backend {
+                    Backend::Ollama => {
+                        config.embedding.provider = "ollama".into();
+                        config.embedding.model = m.id.clone();
+                        config.embedding.dimensions = m.dims.unwrap_or(1024);
+                        config.embedding.api_key_env = None;
+                        config.embedding.openai_url = None;
+                    }
+                    Backend::OMlx => {
+                        config.embedding.provider = "omlx".into();
+                        config.embedding.model = m.id.clone();
+                        config.embedding.dimensions = m.dims.unwrap_or(1024);
+                        config.embedding.api_key_env = Some("OMLX_API_KEY".into());
+                        config.embedding.openai_url = Some("http://localhost:8000/v1".into());
+                        println!();
+                        println!(
+                            "  ⚠ Set OMLX_API_KEY before first use (any non-empty value works on localhost):"
+                        );
+                        println!("      export OMLX_API_KEY=local");
+                    }
+                }
+                Ok(true)
+            }
+            MenuRowKind::Pull => {
+                let pull_id = row.pull_id.as_ref().expect("pull rows always carry an id");
+                if pull_id.starts_with("qwen3-embedding:")
+                    || pull_id == "bge-m3"
+                    || pull_id == "nomic-embed-text"
+                    || pull_id == "all-minilm"
+                    || pull_id == "embeddinggemma"
+                {
+                    // Ollama-style tag — invoke `ollama pull`
+                    println!();
+                    println!("  Pulling {} via Ollama...", pull_id);
+                    let st = std::process::Command::new("ollama")
+                        .arg("pull")
+                        .arg(pull_id)
+                        .status();
+                    match st {
+                        Ok(s) if s.success() => {
+                            println!("  ✓ Pulled. Re-run `mur init` to select it.");
+                        }
+                        Ok(s) => {
+                            println!("  ⚠ ollama pull exited with {}; embedding not configured.", s);
+                        }
+                        Err(e) => {
+                            println!("  ⚠ Could not invoke ollama: {e}; install from https://ollama.com");
+                        }
+                    }
+                } else {
+                    // Likely an HF id → oMLX path; oMLX has no CLI pull.
+                    println!();
+                    println!("  Open oMLX.app → Models → search '{}' → Pull", pull_id);
+                    println!("  Then re-run `mur init`.");
+                }
+                Ok(false)
+            }
+            MenuRowKind::Skip => {
+                println!("  Keeping current embedding config.");
+                Ok(false)
+            }
+        }
+    }
+```
+
+Update call sites at lines 839, 869, 916, 934, 957 (the five places `select_ollama_embedding` is called) — but only sites in Mode 1 and Mode 3 need to swap. Mode 2 (all-cloud) keeps `select_cloud_embedding` unchanged.
+
+For Mode 1 (line 839):
+
+```rust
+        "1" => {
+            let (_provider, _env_var, llm_model, is_openrouter) = select_cloud_llm(&mut config)?;
+
+            // Replace: select_ollama_embedding(&mut config)?;
+            let available = tokio::runtime::Handle::try_current()
+                .ok()
+                .map(|h| h.block_on(crate::discovery::run_all()))
+                .unwrap_or_else(|| Ok(Vec::new()))?;
+            let _wrote = select_local_embedding(&mut config, &available)?;
+
+            crate::store::config::save_config(&config)?;
+            // ... existing print
+        }
+```
+
+If `cmd_init` is sync but you need async, simpler: wrap the discovery call in `tokio::runtime::Builder::new_current_thread().enable_all().build()?.block_on(...)`. Verify by checking `cmd_init` signature (`pub fn cmd_init(hooks_flag: bool) -> Result<()>` is sync per `init.rs:26`).
+
+Add a helper at the top of `init.rs`:
+
+```rust
+fn discover_blocking() -> Result<Vec<crate::discovery::DiscoveredModel>> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime for discovery")?;
+    rt.block_on(crate::discovery::run_all())
+}
+```
+
+Then in Mode 1 / Mode 3 LLM paths use `discover_blocking()` instead of inline tokio.
+
+For Mode 3 LLM (line 909-970), wrap each `LocalBackend::*` arm:
+
+```rust
+                Some(LocalBackend::Ollama) => {
+                    let m = select_model(OLLAMA_RECS)?;
+                    config.llm.provider = "ollama".to_string();
+                    config.llm.model = m.id.to_string();
+                    config.llm.api_key_env = None;
+                    config.llm.openai_url = None;
+
+                    let available = discover_blocking()?;
+                    select_local_embedding(&mut config, &available)?;
+                    crate::store::config::save_config(&config)?;
+                    println!(
+                        "  ✓ Config: ollama/{} (LLM) + {}/{} (search)",
+                        m.id, config.embedding.provider, config.embedding.model
+                    );
+                }
+```
+
+Repeat the swap for `OMlx` and `MlxLm` arms — same pattern.
+
+For Mode 2 (cloud) — `select_cloud_embedding` already handles the embedding path and calls into `select_ollama_embedding` for its "Local Ollama" sub-choice. Update that single call inside `select_cloud_embedding` (line 818) to use `select_local_embedding(&mut config, &discover_blocking()?)?;` as well.
+
+**Important**: drop the original `select_ollama_embedding` closure entirely after migration. Search for any remaining call site with `grep -n select_ollama_embedding mur-core/src/cmd/init.rs` and confirm zero hits before proceeding.
+
+- [ ] **Step 4: Run tests + manual cargo run smoke**
+
+Run: `cargo test --workspace`
+Expected: PASS.
+
+Manual:
+```bash
+cargo run -- init --hooks
+# Pick Mode 1 → at embedding prompt, observe new menu shape
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/init.rs
+git commit -m "M5.3: select_local_embedding replaces hardcoded menu in init flow"
+```
+
+---
+
+### Task 5.4: `--refresh-discovery` flag
+
+**Files:**
+- Modify: `mur-core/src/main.rs` (find the `Init` clap subcommand definition)
+- Modify: `mur-core/src/cmd/init.rs::cmd_init` signature
+
+- [ ] **Step 1: Locate clap definition**
+
+Run: `grep -n "Init " mur-core/src/main.rs | head` to find the `mur init` subcommand parsing. Locate the existing `--hooks` flag and add `--refresh-discovery` adjacent.
+
+- [ ] **Step 2: Add the flag**
+
+Modify the clap subcommand definition for `Init`. Example pattern:
+
+```rust
+Commands::Init {
+    #[arg(long)]
+    hooks: bool,
+    #[arg(long, help = "Bust the discovery cache and re-probe runtimes")]
+    refresh_discovery: bool,
+}
+```
+
+And the dispatch:
+
+```rust
+Commands::Init { hooks, refresh_discovery } => {
+    cmd::init::cmd_init(hooks, refresh_discovery)?;
+}
+```
+
+Modify `cmd_init` signature in `init.rs:26`:
+
+```rust
+pub(crate) fn cmd_init(hooks_flag: bool, refresh_discovery: bool) -> Result<()> {
+```
+
+In `discover_blocking()` (added in 5.3), respect the flag:
+
+```rust
+fn discover_blocking(refresh: bool) -> Result<Vec<crate::discovery::DiscoveredModel>> {
+    if refresh {
+        if let Ok(p) = crate::discovery::cache::DiscoveryCache::default_path() {
+            let _ = std::fs::remove_file(&p);
+        }
+    }
+    let rt = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
+    rt.block_on(crate::discovery::run_all())
+}
+```
+
+Update all `discover_blocking()` call sites to pass `refresh_discovery`.
+
+- [ ] **Step 3: Test compile + manual flag check**
+
+Run: `cargo build --workspace && ./target/debug/mur init --refresh-discovery --hooks`
+Expected: builds and runs.
+
+- [ ] **Step 4: Add a smoke test asserting the flag exists**
+
+Append to `mur-core/src/cmd/init.rs` tests:
+
+```rust
+#[cfg(test)]
+mod refresh_flag_tests {
+    /// Compile-time check that `cmd_init` accepts the new flag.
+    #[test]
+    fn cmd_init_accepts_refresh_discovery() {
+        // Verify by reference; calling cmd_init in tests is too heavyweight.
+        let _ = super::cmd_init as fn(bool, bool) -> anyhow::Result<()>;
+    }
+}
+```
+
+Run: `cargo test -p mur-core --lib cmd::init::refresh_flag_tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/main.rs mur-core/src/cmd/init.rs
+git commit -m "M5.4: --refresh-discovery flag busts cache before init"
+```
+
+---
+
+### Task 5.5: Probe dims at write time + cache write-back
+
+**Files:**
+- Modify: `mur-core/src/cmd/init.rs::select_local_embedding` (probe before write)
+
+When user picks an `Auto` or `Pulled` row whose `dims` is `None` (oMLX entries pre-probe always have `dims = None`), invoke `Discovery::probe_embedding` to populate dims before writing config. Cache the result.
+
+- [ ] **Step 1: Write the integration test**
+
+Create `mur-core/tests/init_probe_writeback.rs`:
+
+```rust
+//! When user picks an oMLX model whose dims weren't yet known, init
+//! probes /v1/embeddings to learn dims and writes them to config.
+//!
+//! Drives the discovery + select flow end-to-end (no TTY), asserting
+//! the resulting Config.
+
+use mur_core::discovery::{Backend, DiscoveredModel, ModelKind};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn probe_populates_dims_for_unprobed_omlx_pick() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{"embedding": vec![0.0f32; 1024]}]
+        })))
+        .mount(&server)
+        .await;
+
+    use mur_core::discovery::omlx::OMlxDiscovery;
+    use mur_core::discovery::Discovery;
+    let d = OMlxDiscovery::new(server.uri());
+    let probe = d
+        .probe_embedding("mlx-community/Qwen3-Embedding-0.6B-8bit")
+        .await
+        .unwrap();
+    assert_eq!(probe.dims, 1024);
+
+    // Construct an unprobed model and confirm probe fills dims.
+    let mut m = DiscoveredModel {
+        id: "mlx-community/Qwen3-Embedding-0.6B-8bit".into(),
+        backend: Backend::OMlx,
+        kind: ModelKind::Unknown,
+        dims: None,
+        family: Some("qwen3".into()),
+        size_bytes: None,
+        probed_at: None,
+    };
+    if m.dims.is_none() {
+        m.dims = Some(probe.dims);
+        m.kind = ModelKind::Embedding;
+    }
+    assert_eq!(m.dims, Some(1024));
+    assert_eq!(m.kind, ModelKind::Embedding);
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cargo test -p mur-core --test init_probe_writeback`
+Expected: PASS (proves discovery probe correctness; integration with `select_local_embedding` happens in step 3).
+
+- [ ] **Step 3: Wire probe into `select_local_embedding`**
+
+Edit `select_local_embedding` (M5.3) — when handling `Auto` / `Pulled` rows, if `m.dims.is_none()`:
+
+```rust
+            MenuRowKind::Auto | MenuRowKind::Pulled => {
+                let m = row.model.as_ref().expect("auto/pulled rows always carry a model");
+                let dims = match m.dims {
+                    Some(d) => d,
+                    None => {
+                        // Probe to learn dims. Build a runtime-appropriate Discovery
+                        // and call probe_embedding.
+                        use crate::discovery::Discovery;
+                        let rt = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .context("tokio runtime for probe")?;
+                        let probe = match m.backend {
+                            Backend::Ollama => {
+                                let d = crate::discovery::ollama::OllamaDiscovery::new(
+                                    "http://localhost:11434"
+                                );
+                                rt.block_on(d.probe_embedding(&m.id))
+                            }
+                            Backend::OMlx => {
+                                let d = crate::discovery::omlx::OMlxDiscovery::new(
+                                    "http://localhost:8000/v1"
+                                );
+                                rt.block_on(d.probe_embedding(&m.id))
+                            }
+                        };
+                        match probe {
+                            Ok(p) => p.dims,
+                            Err(e) => {
+                                println!("  ⚠ Probe failed: {e}; using preference-table fallback");
+                                fallback_dims_for(&m.id).unwrap_or(1024)
+                            }
+                        }
+                    }
+                };
+                // ...write provider/model/dims as before, using `dims`
+            }
+```
+
+Add `fallback_dims_for` helper near `discover_blocking`:
+
+```rust
+fn fallback_dims_for(id: &str) -> Option<usize> {
+    // Best-effort hardcoded dims for known ids when /v1/embeddings probe fails.
+    if id.contains("Qwen3-Embedding-0.6B") || id.contains("qwen3-embedding:0.6b") { Some(1024) }
+    else if id.contains("Qwen3-Embedding-4B")  || id.contains("qwen3-embedding:4b")  { Some(2560) }
+    else if id.contains("Qwen3-Embedding-8B")  || id.contains("qwen3-embedding:8b")  { Some(4096) }
+    else if id.contains("bge-m3")                                                   { Some(1024) }
+    else if id.contains("nomic-embed-text")                                         { Some(768) }
+    else if id.contains("embeddinggemma")                                           { Some(768) }
+    else { None }
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cargo test -p mur-core`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/init.rs mur-core/tests/init_probe_writeback.rs
+git commit -m "M5.5: probe dims at config-write time + fallback table"
+```
+
+---
+
+### Task 5.6: Manual smoke checklist + PR open
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-smoke.md`
+
+- [ ] **Step 1: Write smoke checklist**
+
+Create `docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-smoke.md`:
+
+```markdown
+# M5 Manual Smoke Checklist
+
+Run after `cargo build --release` against the merged M1+M2+M3+M4+M5 branch.
+
+## Case 1 — oMLX-only (no Ollama)
+**Setup:** Stop Ollama daemon. Ensure oMLX.app server is running with
+`mlx-community/Qwen3-Embedding-0.6B-8bit` pulled.
+
+```bash
+rm -f ~/.mur/cache/discovery.json   # clean slate
+./target/release/mur init --hooks --refresh-discovery
+```
+
+**Pick Mode 1.** At embedding prompt, expect:
+- Row 1: `[auto] oMLX/mlx-community/Qwen3-Embedding-0.6B-8bit (1024d)`
+- Row 2-N: any other oMLX models pulled
+- `[pull] qwen3-embedding:0.6b` row
+- `Skip` row
+
+Press Enter. Verify `~/.mur/config.yaml`:
+```yaml
+embedding:
+  provider: omlx
+  model: mlx-community/Qwen3-Embedding-0.6B-8bit
+  dimensions: 1024
+  api_key_env: OMLX_API_KEY
+  openai_url: http://localhost:8000/v1
+```
+
+Verify `OMLX_API_KEY` hint printed.
+
+## Case 2 — Ollama-only (no oMLX)
+**Setup:** Quit oMLX.app. Ensure `qwen3-embedding:0.6b` is pulled.
+
+```bash
+rm -f ~/.mur/cache/discovery.json
+./target/release/mur init --hooks --refresh-discovery
+```
+
+Mode 1, Enter at embedding prompt. Expect `[auto] Ollama/qwen3-embedding:0.6b (1024d)`.
+
+## Case 3 — Both backends with embeddings
+**Setup:** Both running, both have an embedding model pulled.
+
+Expect oMLX entry as `[auto]` (higher in preference at same rank, but
+order depends on backend iteration order; either Ollama or oMLX as auto
+is acceptable as long as the kind is Embedding).
+
+## Case 4 — Both backends, no embedding models
+**Setup:** Both daemons running, neither has any embedding model pulled.
+
+Expect:
+- Row 1: `[pull] qwen3-embedding:0.6b` (Ollama)
+- Row 2: `[pull] bge-m3`
+- Row 3: `Skip — configure later`
+
+Pick row 1. Verify `ollama pull qwen3-embedding:0.6b` runs (progress streams).
+On success, verify init prints "Pulled. Re-run `mur init` to select it."
+
+## Case 5 — `--refresh-discovery` busts cache
+**Setup:** After case 1, ensure `~/.mur/cache/discovery.json` exists.
+
+```bash
+./target/release/mur init --hooks --refresh-discovery
+```
+
+Verify cache file mtime updated; observe new probe latency in trace logs
+(`RUST_LOG=debug ./target/release/mur init ...`).
+```
+
+- [ ] **Step 2: Run all 5 cases manually**
+
+Execute each case and check off. Note any deviations.
+
+- [ ] **Step 3: Commit smoke doc**
+
+```bash
+git add docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-smoke.md
+git commit -m "M5.6: manual smoke checklist for end-to-end discovery flow"
+```
+
+- [ ] **Step 4: Final clippy + workspace test**
+
+Run: `cargo clippy --workspace -- -D warnings && cargo test --workspace`
+Expected: clean.
+
+- [ ] **Step 5: Open PR**
+
+```bash
+git push -u origin feat/mur-m5-init-dynamic-picker
+gh pr create --title "M5: dynamic local embedding picker (oMLX + Ollama)" --body "$(cat <<'EOF'
+## Summary
+- `mur init` Mode 1 + Mode 3 now use \`discovery::run_all()\` to enumerate locally-pulled embedding (and Mode 3 LLM) models
+- New menu shape: \`[auto] <top-of-rank pulled>\` first, remaining pulled, top-2 \`[pull]\` recommendations, \`Skip\`
+- oMLX picks write \`provider: omlx\`, \`openai_url: http://localhost:8000/v1\`, \`api_key_env: OMLX_API_KEY\`
+- \`[pull]\` invokes \`ollama pull\` (Ollama) or prints GUI hint (oMLX, no CLI pull mechanism)
+- New \`--refresh-discovery\` flag busts the discovery cache
+- Dims learned via 1-token \`/v1/embeddings\` (or \`/api/embed\`) probe at write time; static fallback table when probe fails
+
+## Spec
+\`docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md\` § 3, § 4
+
+## Test plan
+- [x] Unit: \`select_local_embedding_tests\`, \`refresh_flag_tests\`
+- [x] Wiremock integration: \`init_probe_writeback\`
+- [x] Manual smoke: 5 cases per \`docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-smoke.md\`
+- [x] \`cargo clippy --workspace -- -D warnings\`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**M5 done. All 5 milestones shipped.**
+
+---
+
+## Self-review
+
+**Spec coverage check:**
+
+- §1 Architecture: M1 (embedding.rs fix) + M2 (discovery scaffold) + M3 (ollama.rs) + M4 (omlx.rs) + M5 (init.rs rewrite + aggregate.rs) ✓
+- §2.1 Discovery trait: Task 2.2 ✓
+- §2.2 OllamaDiscovery (capabilities + heuristic fallback + family disambig): Tasks 3.1, 3.2 ✓
+- §2.3 OMlxDiscovery (probe with 10s timeout for #266; family inference): Tasks 4.1, 4.2 ✓
+- §2.4 PreferenceTable (prefix-match + future-proof): Task 2.1 ✓
+- §2.5 EmbeddingProvider bug fix: Tasks 1.1, 1.2 ✓
+- §2.6 Cache (TTL, schema versioning, atomic write): Task 2.3 ✓
+- §3 Data flow (menu render, auto-default, pull subprocess, oMLX hint, skip): Tasks 5.1, 5.3, 5.5 ✓
+- §4 Error handling (probe timeout, pull failure, cache corrupt): distributed across tasks ✓
+- §5 Testing (unit + wiremock + opt-in integration + manual smoke): present ✓
+- §6 Migration: M1 ships standalone; M5 final ✓
+- §7 Non-goals: respected — no `model_ref:` field added in this plan; no reranker work; no per-collection embedder
+
+**Placeholder scan:** No "TBD", "TODO" outside of clearly-completed checklist items.
+
+**Type consistency:**
+- `EmbeddingProvider::OpenAI { api_key, base_url }` matches across embedding.rs, the unit test, and the integration test ✓
+- `DiscoveredModel` field names (`id`, `backend`, `kind`, `dims`, `family`, `size_bytes`, `probed_at`) consistent across cache.rs, ollama.rs, omlx.rs, aggregate.rs ✓
+- `MenuRow.kind` enum (`Auto / Pulled / Pull / Skip`) consistent in 5.1 and 5.3 ✓
+- `EmbeddingProbe { dims, latency_ms }` consistent in mod.rs and ollama.rs / omlx.rs ✓
+
+**Known gaps fixed inline:**
+- Task 5.3's "wrap each `LocalBackend::*` arm" instruction needed concrete mapping; replaced with explicit `Some(LocalBackend::Ollama) => { ... }` block.
+- Task 5.5's `fallback_dims_for` was originally referenced but undefined; added the function body inline.
+- Task 5.6 added explicit `--refresh-discovery` smoke step (case 5).
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-plan.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per milestone, review between milestones, fast iteration
+2. **Inline Execution** — execute milestones in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-smoke.md
+++ b/docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-smoke.md
@@ -94,6 +94,36 @@ RUST_LOG=debug ./target/release/mur init --refresh-discovery
 Expect `[DEBUG mur_core::discovery::ollama]` or `[DEBUG mur_core::discovery::omlx]`
 lines confirming fresh discovery.
 
+## Cache file schema reference
+
+`~/.mur/cache/discovery.json` written by M5 has the following shape:
+
+```json
+{
+  "schema_version": 1,
+  "entries": [
+    {
+      "endpoint": "http://localhost:11434",
+      "backend": "Ollama",
+      "captured_at": "2026-05-05T03:30:00Z",
+      "models": [
+        {
+          "id": "qwen3-embedding:0.6b",
+          "backend": "Ollama",
+          "kind": "Embedding",
+          "dims": 1024,
+          "family": "bert",
+          "size_bytes": 700000000
+        }
+      ]
+    }
+  ]
+}
+```
+
+Schema version mismatches (any value other than `1`) cause the cache to be
+silently discarded and rebuilt from a fresh probe.
+
 ## Case 6 — Mode 3 (all local) with oMLX LLM + oMLX embedding
 
 **Setup:** oMLX running with both a chat model (e.g. `Qwen3-4B`) and an

--- a/docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-smoke.md
+++ b/docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-smoke.md
@@ -1,0 +1,111 @@
+# M5 Manual Smoke Checklist
+
+Run after `cargo build --release` against the merged M1+M2+M3+M4+M5 branch.
+
+## Case 1 — oMLX-only (no Ollama)
+
+**Setup:** Stop Ollama daemon. Ensure oMLX.app server is running with
+`mlx-community/Qwen3-Embedding-0.6B-8bit` pulled.
+
+```bash
+rm -f ~/.mur/cache/discovery.json   # clean slate
+./target/release/mur init --hooks --refresh-discovery
+```
+
+**Pick Mode 1.** At embedding prompt, expect:
+- Row 1: `[auto] oMLX/mlx-community/Qwen3-Embedding-0.6B-8bit (1024d)`
+- Row 2-N: any other oMLX models pulled
+- `[pull] qwen3-embedding:0.6b` row
+- `Skip — configure later` row
+
+Press Enter. Verify `~/.mur/config.yaml`:
+```yaml
+embedding:
+  provider: omlx
+  model: mlx-community/Qwen3-Embedding-0.6B-8bit
+  dimensions: 1024
+  api_key_env: OMLX_API_KEY
+  openai_url: http://localhost:8000/v1
+```
+
+Verify `OMLX_API_KEY` hint printed.
+
+## Case 2 — Ollama-only (no oMLX)
+
+**Setup:** Quit oMLX.app. Ensure `qwen3-embedding:0.6b` is pulled in Ollama.
+
+```bash
+rm -f ~/.mur/cache/discovery.json
+./target/release/mur init --hooks --refresh-discovery
+```
+
+Pick Mode 1, press Enter at embedding prompt. Expect:
+- Row 1: `[auto] Ollama/qwen3-embedding:0.6b (1024d)`
+
+Verify `~/.mur/config.yaml`:
+```yaml
+embedding:
+  provider: ollama
+  model: qwen3-embedding:0.6b
+  dimensions: 1024
+```
+
+## Case 3 — Both backends with embedding models
+
+**Setup:** Both Ollama and oMLX running, both have an embedding model pulled.
+
+Expect one of them as `[auto]` (the higher-ranked one), the other as a
+`Pulled` row. Either backend as `[auto]` is acceptable as long as the
+selected kind is Embedding.
+
+## Case 4 — Both backends, no embedding models
+
+**Setup:** Both daemons running, neither has any embedding model pulled.
+
+Expect:
+- Row 1: `[pull] qwen3.5-embedding` (highest score in preference table)
+- Row 2: `[pull] Qwen3-Embedding-8B`
+- Row 3: `Skip — configure later`
+
+Pick row 1 (the Ollama-style tag). Verify `ollama pull qwen3.5-embedding` runs
+(progress streams to stdout). On success, verify init prints:
+```
+✓ Pulled. Re-run `mur init` to select it.
+```
+
+If the tag is an HF-id form (`mlx-community/...`), verify the oMLX GUI hint
+is printed instead of an ollama pull.
+
+## Case 5 — `--refresh-discovery` busts cache
+
+**Setup:** After Case 1, ensure `~/.mur/cache/discovery.json` exists.
+
+```bash
+./target/release/mur init --hooks --refresh-discovery
+```
+
+Verify the cache file mtime is updated after this run. To observe the probe
+latency in trace logs:
+
+```bash
+RUST_LOG=debug ./target/release/mur init --refresh-discovery
+```
+
+Expect `[DEBUG mur_core::discovery::ollama]` or `[DEBUG mur_core::discovery::omlx]`
+lines confirming fresh discovery.
+
+## Case 6 — Mode 3 (all local) with oMLX LLM + oMLX embedding
+
+**Setup:** oMLX running with both a chat model (e.g. `Qwen3-4B`) and an
+embedding model (e.g. `Qwen3-Embedding-0.6B-8bit`) pulled.
+
+```bash
+./target/release/mur init
+```
+
+Pick Mode 3 → oMLX as backend → select the LLM model. At the embedding prompt,
+expect oMLX embedding model in the discovery menu. Press Enter.
+
+Verify `~/.mur/config.yaml` has:
+- `llm.provider: openai`, `llm.openai_url: http://localhost:8000/v1`
+- `embedding.provider: omlx`, `embedding.openai_url: http://localhost:8000/v1`

--- a/docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md
+++ b/docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md
@@ -1,0 +1,358 @@
+# Dynamic Local Embedding Discovery (incl. oMLX) — Design
+
+**Status**: proposed
+**Author**: david + Claude Opus 4.7 (1M context)
+**Date**: 2026-05-05
+**Related**: P1.4 sources integration, M3.5 model registry & secret refs
+
+## Problem
+
+`mur init` (with or without `--hooks`) treats local embedding setup as a hardcoded waterfall:
+
+1. **`select_ollama_embedding`** (`mur-core/src/cmd/init.rs:769-794`) hardwires four model options regardless of what is actually pulled.
+2. **`select_cloud_embedding`** sends `provider: "openai" | "gemini" | "anthropic"` but the OpenAI embedder at `mur-core/src/store/embedding.rs:137` ignores `cfg.embedding.openai_url` and posts to `https://api.openai.com/v1/embeddings`. Gemini / Voyage / oMLX / mlx-omni-server are silently broken.
+3. **oMLX is not offered as an embedding backend**, only as an LLM backend (`init.rs:923-946`, Mode 3 only). Even when oMLX has Qwen3-Embedding loaded, Mode 1 (the default recommended mode) writes `embedding.provider: ollama` unconditionally.
+4. **No availability check** — the menu offers `qwen3-embedding:8b` even when the user has only `qwen3-embedding:0.6b` pulled, so the first retrieval call 404s on the model name.
+
+End-user symptom (the report that triggered this work): user installed oMLX with `mlx-community/Qwen3-Embedding-0.6B-8bit`, ran `mur init --hooks`, picked Mode 1, and ended up with an Ollama-pinned config they did not consent to.
+
+## Research findings
+
+Three deep-research passes. URLs in §8.
+
+### Q1 — Does oMLX expose embeddings? **Yes, confirmed-runs.**
+
+- oMLX serves `POST /v1/embeddings` on `localhost:8000`.
+- Backing engine is **`Blaizzy/mlx-embeddings`**, whose registry explicitly includes Qwen3 embedding family alongside BERT, BGE-M3, ModernBERT, XLM-RoBERTa. The README's "BERT/BGE-M3/ModernBERT" line is incomplete documentation, not an authoritative whitelist.
+- Two production user reports (oMLX issues #266 and #684) confirm Qwen3-Embedding-0.6B / 0.6B-4bit-DWQ / 8B all load and serve through `/v1/embeddings`.
+- oMLX v0.3.0 release notes ship dedicated processor hooks for Qwen3-VL-Embedding, demonstrating active maintenance for the Qwen3 embedding family.
+- **mlx-lm CLI (`mlx_lm.server`)** has **no** embeddings endpoint — generation only. So if a user has only mlx-lm installed (no oMLX), embedding must fall back to Ollama or a third-party shim (e.g. `cubist38/mlx-openai-server`).
+- **oMLX caveat #266**: graph recompiles on first call after >3s idle (~3s extra latency on first probe). Behaviour, not bug.
+
+### Q2 — Qwen3.5-Embedding state-of-the-art? **Does not exist (yet).**
+
+- Alibaba shipped Qwen3.5 (chat/base, 0.8B-9B, March 2026) and Qwen3.6 (April 2026). Neither has an embedding variant.
+- Current SOTA open-weight multilingual embedder is still **Qwen3-Embedding** (June 2025): 8B → MTEB-multilingual 70.58, 4B → 69.45, 0.6B → 64.33. Apache-2.0, Matryoshka-rep, 100+ languages.
+- Ollama tags: `qwen3-embedding:{0.6b|4b|8b}` plus `-q4_K_M / -q8_0 / -fp16` quants. `qwen3-embedding:latest` aliases to `:8b` (4.7 GB Q4).
+- HF MLX: `mlx-community/Qwen3-Embedding-{0.6B|4B|8B}-{4bit-DWQ|8bit}`.
+- Credible alternatives (May 2026 multilingual leaderboard): BGE-M3 (568M, dense+sparse+multivector), jina-embeddings-v3 (570M, 8K ctx), EmbeddingGemma (308M, ultra-light).
+- For Chinese-heavy corpora, Qwen3-Embedding still wins C-MTEB.
+
+### Q3 — Dynamic detection prior art
+
+- **Ollama**: `POST /api/show` → `capabilities[]` array contains `"embedding"` when GGUF metadata has `pooling_type`. Authoritative but doc-example-not-yet-updated; verify on target Ollama version. Fallback heuristic: `/api/tags` → `details.family ∈ {bert, nomic-bert, jina-bert, qwen3}`.
+- **oMLX / mlx_lm.server**: `/v1/models` is flat OpenAI-shape, no `type` field. Disambiguation requires either probing `/v1/embeddings` with a 1-token request, or matching against a known-embedder allowlist by HF id.
+- **LM Studio** (the gold standard): `GET /api/v0/models` returns each model with `"type": "llm" | "embedding"` plus `state: "loaded" | "unloaded"`. Drop-in filter.
+- **Continue.dev pattern**: `model: AUTODETECT` plus `roles: [embed, chat, ...]` per-model override, capabilities autodetect with explicit `capabilities: []` array override. **Always allow user override** — heuristics misclassify edge cases (fine-tuned classifiers showing up as "embedding").
+
+## Decisions
+
+1. **Bundle four changes into one feature** — bug fix (`openai_url` honored), discovery module, init UX rewrite, LLM-side dynamic discovery in Mode 3. Single Brainstorming → Plan → cascade-merge cycle.
+2. **Mode 1 default = `[auto]`** — Enter on the first menu entry picks the top-of-preference model that is actually pulled. Power users see the detected list and can override; casual users hit Enter twice and get the right thing. (Choice B in the brainstorming round.)
+3. **Pull behaviour is mixed** — Ollama auto-pulls via `Command::new("ollama").arg("pull")...status()` with stdout passthrough; oMLX prints a GUI hint (oMLX has no CLI pull mechanism). Same logic applies to LLM Mode 3. (Choice B in the brainstorming round.)
+4. **Probe-based dimension detection** — once user picks a model, mur issues a 1-token `POST /v1/embeddings` (or `POST /api/embed`) to learn the actual dim and write it to config. This is the only Matryoshka-safe approach.
+5. **Static preference table with prefix matching** — future-proofs against `qwen3.5-embedding` and similar future tags without code changes. Hardcoded dim/family hints serve as cache-warming fallback when probe fails.
+6. **Discovery cache** at `~/.mur/cache/embedding-discovery.json`, TTL 24h, schema-versioned. `mur init --refresh-discovery` busts it. Cache is per-runtime-endpoint to support multi-instance setups.
+7. **Model registry tie-in deferred** — `EmbeddingConfig` is designed to grow an optional `model_ref:` field later (mirroring LLM `model_ref` from M3.5), but this design does not extend `models.yaml` or touch `mur model add`. Marked future-work in §7.
+8. **No `embedding.enabled: false` flag** — pure-BM25 retrieval is not a supported mode in mur today. Not adding it as a side effect.
+9. **No mixed-workload guard** for oMLX issue #266 — current evidence is latency-only, not correctness. Document the first-call slowness; do not refuse setup.
+
+## §1 Architecture
+
+```
+mur-core/src/
+├── discovery/                                ← new module
+│   ├── mod.rs                                ← Discovery trait + Backend + DiscoveredModel + cache I/O
+│   ├── ollama.rs                             ← OllamaDiscovery
+│   ├── omlx.rs                               ← OMlxDiscovery
+│   └── preference.rs                         ← prefix-matched preference table (LLM + embedding)
+├── store/embedding.rs                        ← bug fix: EmbeddingProvider::OpenAI honors base_url
+└── cmd/
+    ├── init.rs                               ← select_ollama_embedding → select_local_embedding
+    └── init_local.rs                         ← runtime detection retained; OLLAMA_RECS / MLX_RECS
+                                                 reference preference.rs as fallback list
+
+~/.mur/cache/discovery.json                   ← runtime cache (LLM + embedding), TTL 24h, schema_version: 1
+```
+
+`Discovery` is one trait, two impls. LLM-side init (`init_local.rs::select_model`) and embedding-side init (`init.rs::select_local_embedding`) both consume the same `Vec<DiscoveredModel>`, filtering by `kind`.
+
+## §2 Components
+
+### 2.1 `Discovery` trait
+
+```rust
+// mur-core/src/discovery/mod.rs
+#[async_trait::async_trait]
+pub trait Discovery: Send + Sync {
+    fn backend(&self) -> Backend;
+    async fn list_models(&self) -> anyhow::Result<Vec<DiscoveredModel>>;
+    /// 1-token probe to determine kind + dim. Used after list_models when
+    /// kind is Unknown, or when user picks a model whose dims we lack.
+    async fn probe_embedding(&self, model_id: &str) -> anyhow::Result<EmbeddingProbe>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Backend { Ollama, OMlx }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveredModel {
+    pub id: String,                  // "qwen3-embedding:0.6b" / "mlx-community/Qwen3-Embedding-0.6B-8bit"
+    pub backend: Backend,
+    pub kind: ModelKind,             // Llm | Embedding | Unknown
+    pub dims: Option<usize>,         // populated for Embedding kind
+    pub family: Option<String>,      // "qwen3", "bge", "modernbert", "bert"
+    pub size_bytes: Option<u64>,     // /api/tags has it; /v1/models does not
+    pub probed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelKind { Llm, Embedding, Unknown }
+
+#[derive(Debug, Clone)]
+pub struct EmbeddingProbe { pub dims: usize, pub latency_ms: u64 }
+```
+
+### 2.2 `OllamaDiscovery`
+
+- `GET {endpoint}/api/tags` → enumerate models with `details.family`, `size`.
+- For each, `POST {endpoint}/api/show {name}` → extract `capabilities` array.
+  - `capabilities.contains("embedding")` → `kind = Embedding` (authoritative).
+  - else if `capabilities.contains("completion")` → `kind = Llm`.
+  - else (older Ollama versions without `capabilities`) → fallback heuristic: `family ∈ {bert, nomic-bert, jina-bert}` → `Embedding`; `family ∈ {qwen3, llama, gemma}` → `Llm`; else `Unknown`.
+  - **Disambiguation note**: when `capabilities` is absent and family alone is the signal, `family = "qwen3"` is ambiguous (Qwen3 chat models share the family string with anyone who packages a Qwen3-derived embedder). In practice Ollama's `qwen3-embedding:*` GGUFs report `family = "bert"` (BERT-style pooling), so the heuristic generally works without name-string sniffing. If a future Ollama version reports `family = "qwen3"` for the embedder, fall back to `name.contains("embedding")` as a tiebreaker.
+- Probe path: `POST {endpoint}/api/embed {model, input: "."}` with 5s timeout; success ⇒ `embeddings[0].len()` = dims.
+
+### 2.3 `OMlxDiscovery`
+
+- `GET {base_url}/v1/models` → flat list (`{data: [{id, ...}]}`). All entries are loaded models.
+- Probe each candidate via `POST {base_url}/v1/embeddings {model, input: "."}` with 10s timeout (oMLX issue #266 recompile budget).
+- Result mapping:
+  - 200 + `data[0].embedding` array → `kind = Embedding`, `dims = embedding.len()`.
+  - 4xx with `"does not support embeddings"` body → `kind = Llm`.
+  - timeout / 5xx → `kind = Unknown`, log warn.
+- Family inference from id: `Qwen3-Embedding-*` → `qwen3`; `bge-*` → `bge`; `*-modernbert-*` → `modernbert`.
+
+### 2.4 `PreferenceTable`
+
+```rust
+// mur-core/src/discovery/preference.rs
+const EMBEDDING_PREFERENCE: &[(&str, u32)] = &[
+    ("qwen3.5-embedding",        105),  // future-proof; matches both Ollama and HF forms
+    ("Qwen3-Embedding-8B",       100),  // oMLX HF form
+    ("qwen3-embedding:8b",       100),  // Ollama tag form
+    ("Qwen3-Embedding-4B",        90),
+    ("qwen3-embedding:4b",        90),
+    ("bge-m3",                    80),
+    ("jina-embeddings-v3",        75),
+    ("Qwen3-Embedding-0.6B",      70),
+    ("qwen3-embedding:0.6b",      70),
+    ("embeddinggemma",            55),
+    ("nomic-embed-text",          40),
+    ("all-minilm",                20),
+];
+
+// Aligned with the curated picks in init_local.rs (OLLAMA_RECS / MLX_RECS).
+// Multilingual-first ordering — leading entry must handle Chinese well.
+const LLM_PREFERENCE: &[(&str, u32)] = &[
+    ("Qwen3.5-9B",                95),  // mlx-community HF id form
+    ("qwen3.5:9b",                95),  // Ollama tag form
+    ("Qwen3.5-4B",                90),
+    ("qwen3.5:4b",                90),
+    ("Gemma4-E2B",                85),
+    ("gemma4:e2b",                85),
+    ("Qwen3-9B",                  70),
+    ("qwen3:9b",                  70),
+    ("Qwen3-4B",                  65),
+    ("qwen3:4b",                  65),
+    ("llama3.3",                  60),
+];
+
+pub fn rank(id: &str, table: &[(&str, u32)]) -> u32 {
+    table.iter()
+        .filter(|(prefix, _)| id.contains(prefix))
+        .map(|(_, score)| *score)
+        .max()
+        .unwrap_or(0)
+}
+```
+
+`contains` not `starts_with` so both `Qwen3-Embedding-0.6B` and `mlx-community/Qwen3-Embedding-0.6B-8bit` match the same rule.
+
+### 2.5 `EmbeddingProvider` bug fix
+
+```rust
+// mur-core/src/store/embedding.rs
+pub enum EmbeddingProvider {
+    Ollama { base_url: String },
+    OpenAI { api_key: String, base_url: String },  // ← new field
+}
+
+impl EmbeddingProvider {
+    pub fn from_config(cfg: &Config) -> Result<Self> {
+        match cfg.embedding.provider.as_str() {
+            "openai" | "gemini" | "anthropic" | "voyage" | "omlx" | "mlx" => {
+                let api_key_env = cfg.embedding.api_key_env.as_deref().unwrap_or("OPENAI_API_KEY");
+                let api_key = std::env::var(api_key_env).unwrap_or_default();
+                let base_url = cfg.embedding.openai_url.clone()
+                    .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
+                Ok(EmbeddingProvider::OpenAI { api_key, base_url })
+            }
+            _ => Ok(EmbeddingProvider::Ollama {
+                base_url: cfg.embedding.ollama_endpoint.clone(),
+            }),
+        }
+    }
+}
+
+async fn embed_openai(client: &Client, base_url: &str, api_key: &str, model: &str, input: &str)
+    -> Result<Vec<f32>> {
+    let url = format!("{}/embeddings", base_url.trim_end_matches('/'));
+    // ... POST as before
+}
+```
+
+Note: oMLX accepts any non-empty token on localhost. The init flow sets `api_key_env: OMLX_API_KEY` and prints a hint to `export OMLX_API_KEY=local`. If the env var is unset at request time, `embed_openai` will get an empty bearer header — oMLX's localhost path tolerates this in current versions, but the hint is the documented convention.
+
+### 2.6 Cache
+
+```rust
+// ~/.mur/cache/discovery.json
+{
+  "schema_version": 1,
+  "entries": [
+    {
+      "endpoint": "http://localhost:11434",
+      "backend": "Ollama",
+      "captured_at": "2026-05-05T03:30:00Z",
+      "models": [ { "id": "qwen3-embedding:0.6b", "kind": "Embedding", "dims": 1024, ... } ]
+    }
+  ]
+}
+```
+
+TTL 24h. `--refresh-discovery` flag on `mur init` or stale entry triggers fresh probe. Schema mismatch → log warn, treat as empty, repopulate.
+
+## §3 Data flow — `mur init` Mode 1
+
+```
+1. detect_local_runtimes()                     # existing, returns LocalRuntimes
+2. spawn parallel discovery tasks for each present runtime:
+     · OllamaDiscovery::list_models  →  cache.entries
+     · OMlxDiscovery::list_models    →  cache.entries
+3. merge → Vec<DiscoveredModel>; filter kind ∈ {Embedding, Unknown}
+4. preference::rank(id, EMBEDDING_PREFERENCE) → sort desc
+5. render menu (4 segments, in order):
+     entry 1            : "[auto] <top-of-rank pulled model>"   ← always single entry, the default
+     entries 2..N       : remaining pulled models with kind ∈ {Embedding, Unknown}
+     entries N+1..N+2   : "[pull] <id>" — top 1-2 preference-table entries NOT yet pulled
+     last entry         : "Skip — configure later"
+6. prompt user; pressing Enter selects entry 1 ([auto])
+7. dispatch on choice:
+     · entry 1 ([auto]) or 2..N (already-pulled)
+                    → probe_embedding(id) for dims if cache miss → write config
+                    → if probe says kind=Llm or 4xx, abort with error and re-prompt
+     · [pull] Ollama → spawn `ollama pull <id>` (stdout passthrough, inherits stdin for Ctrl-C)
+                       on success: re-discover, probe dims, write config
+                       on failure: print stderr; leave embedding unconfigured
+     · [pull] oMLX  → print "Open oMLX.app → Models → search '<id>' → Pull"
+                       leave embedding unconfigured
+     · [skip]       → leave embedding unconfigured (current config preserved)
+```
+
+Mode 3 adds a parallel pass for LLM (filter `kind ∈ {Llm, Unknown}`, use `LLM_PREFERENCE`). Same data flow, different filter and table.
+
+## §4 Error handling
+
+| Scenario | Behaviour |
+|---|---|
+| Runtime detected, daemon not running (Ollama / oMLX server) | Print runtime-specific start hint; `list_models` returns empty; menu skips that backend |
+| Probe timeout — Ollama 5s | Mark `kind = Unknown`; keep in menu with `[?]` tag; full probe on user select |
+| Probe timeout — oMLX 10s (issue #266 budget) | Same as above |
+| Probe returns 4xx "model does not support embeddings" | `kind = Llm`; excluded from embedding menu but kept for LLM menu |
+| `ollama pull` exit ≠ 0 | Print stderr; embedding stays unconfigured; init continues to community / sync setup |
+| `ollama pull` interrupted (Ctrl-C) | Subprocess dies via SIGINT propagation; init exits with the same signal |
+| Cache file corrupt JSON | log::warn; ignore; repopulate from fresh discovery |
+| Cache schema_version mismatch | Same as corrupt: discard, repopulate |
+| User selects `[skip]` and current `config.yaml` already has embedding set | Preserve existing config; print "Keeping current embedding config: <provider>/<model>" |
+| Both backends present, both have no embedding model | Default `[pull]` row points to Ollama `qwen3-embedding:0.6b` (700MB, lowest barrier); oMLX hint appears as second `[pull]` option |
+| `OMLX_API_KEY` env not set when oMLX selected | Set inline `OMLX_API_KEY=local` in shell hint printed at end of init |
+| HF id contains `/` (e.g. `mlx-community/Qwen3-...`) | Pass through verbatim — oMLX accepts the full HF id as `model` parameter |
+
+## §5 Testing
+
+### Unit (no network)
+
+- `discovery::preference::rank` — table-driven against both `EMBEDDING_PREFERENCE` and `LLM_PREFERENCE`, exhaustive over: HF-id form (`mlx-community/X`), Ollama-tag form (`x:N`), unknown id (returns 0), case sensitivity expectations.
+- `discovery::cache` — TTL expiry, schema-version mismatch, corrupt JSON, atomic write.
+- `EmbeddingProvider::from_config` — six providers (`openai`, `gemini`, `anthropic`, `voyage`, `omlx`, `mlx`) all route to OpenAI variant with correct `base_url`.
+- `embed_openai` URL construction — trailing slash on `openai_url`, default fallback.
+
+### Mocked HTTP (`wiremock` crate)
+
+- `OllamaDiscovery::list_models`:
+  - `/api/tags` returns mixed embedding + chat models.
+  - `/api/show` with `capabilities: ["embedding"]` → kind=Embedding.
+  - `/api/show` without `capabilities` field, family=`qwen3`, name contains `embedding` → kind=Embedding (heuristic path).
+  - `/api/show` 500 error → entry kept with kind=Unknown.
+- `OMlxDiscovery::list_models`:
+  - `/v1/models` returns 3 candidates.
+  - `/v1/embeddings` 200 with 1024-dim → kind=Embedding, dims=1024.
+  - `/v1/embeddings` 400 "does not support embeddings" → kind=Llm.
+  - `/v1/embeddings` timeout → kind=Unknown.
+
+### Integration (opt-in, env-gated)
+
+- `OLLAMA_E2E=1` — requires real Ollama on `localhost:11434` with `qwen3-embedding:0.6b` pulled. Asserts probe returns dim=1024.
+- `OMLX_E2E=1` — requires real oMLX on `localhost:8000` with `mlx-community/Qwen3-Embedding-0.6B-8bit` pulled. Asserts probe returns dim=1024 within 10s.
+- Both — full `mur init` Mode 1 dry-run path: discovery → menu render (capture stdout) → assert top entry is oMLX (since oMLX > Ollama at same rank).
+
+### Manual smoke (release gate)
+
+Spec-shipped checklist, four cases:
+
+1. oMLX-only (no Ollama) — picks oMLX/Qwen3-Embedding.
+2. Ollama-only (no oMLX) — picks Ollama/qwen3-embedding.
+3. Both backends, both have models — picks oMLX (priority).
+4. Both backends, neither has embedding model — `[pull]` row offers Ollama default.
+
+## §6 Migration & rollout
+
+Phased into 5 small PRs (each ≤ 300 LOC, mergeable independently).
+
+| PR | Scope | LOC | Blocking |
+|----|---|---|---|
+| **M1** | Bug fix: `EmbeddingProvider::OpenAI { base_url }` honored. New `omlx` / `mlx` provider aliases. Tests for from_config. | ~150 | none |
+| **M2** | `discovery::mod` + `discovery::preference` + cache scaffold. Pure logic, no HTTP. | ~250 | M1 |
+| **M3** | `discovery::ollama` + wiremock tests. | ~250 | M2 |
+| **M4** | `discovery::omlx` + wiremock tests. | ~250 | M2 (parallel with M3) |
+| **M5** | `init.rs::select_local_embedding` rewrite + LLM-side wiring in `init_local.rs`. Manual smoke checklist. | ~300 | M1, M3, M4 |
+
+`M1` ships value standalone (users can hand-edit `config.yaml` to point at oMLX). `M2-M4` ship value to library consumers but no UX change. `M5` flips the user-facing flow.
+
+Existing config files are untouched by `mur init` re-runs unless the user chooses to re-configure.
+
+## §7 Open questions / non-goals
+
+- **`mur model add --embedding`**: deferred to a follow-up. `EmbeddingConfig` reserves space for `model_ref: Option<String>` but the field is not added in this design. Spec at `2026-04-29-model-registry-and-secret-refs-design.md` § future work.
+- **mlx-lm CLI for embeddings**: not supported. mlx-lm has no `/v1/embeddings`. Init prints hint pointing user to oMLX or third-party shim if mlx-lm is the only MLX runtime.
+- **Pure-BM25 fallback**: out of scope. mur's retrieval pipeline assumes vector search.
+- **Embedding model auto-update** (Ollama notifying mur of new versions): out of scope.
+- **Reranker discovery**: out of scope; this design covers embedders only. Rerankers (BGE-reranker-v2-m3 etc.) are a future concern.
+- **Per-collection embedding model** (sources A uses Qwen3-Embedding, sources B uses BGE-M3): out of scope. One global embedding model per mur install.
+
+## §8 Citations
+
+- [jundot/omlx (GitHub)](https://github.com/jundot/omlx)
+- [oMLX issue #266 — Qwen3-Embedding-0.6B / 8B confirmed working](https://github.com/jundot/omlx/issues/266)
+- [oMLX issue #684 — Qwen3-Embedding-0.6B-4bit-DWQ in production](https://github.com/jundot/omlx/issues/684)
+- [oMLX v0.3.0 release — Qwen3-VL-Embedding processor hooks](https://github.com/jundot/omlx/releases/tag/v0.3.0)
+- [Blaizzy/mlx-embeddings — Qwen3 in registry](https://github.com/Blaizzy/mlx-embeddings)
+- [mlx-lm SERVER.md — no /v1/embeddings](https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/SERVER.md)
+- [mlx-community/Qwen3-Embedding-0.6B-8bit on HF](https://huggingface.co/mlx-community/Qwen3-Embedding-0.6B-8bit)
+- [QwenLM/Qwen3-Embedding paper (arXiv 2506.05176)](https://arxiv.org/abs/2506.05176)
+- [Ollama qwen3-embedding tags](https://ollama.com/library/qwen3-embedding/tags)
+- [Ollama API reference (capabilities array)](https://github.com/ollama/ollama/blob/main/docs/api.md)
+- [LM Studio /api/v0/models reference](https://lmstudio.ai/docs/developer/rest/list)
+- [Continue.dev model capabilities + roles](https://docs.continue.dev/customize/deep-dives/model-capabilities)
+- [BentoML 2026 open-source embeddings guide](https://www.bentoml.com/blog/a-guide-to-open-source-embedding-models)

--- a/mur-core/src/cmd/init.rs
+++ b/mur-core/src/cmd/init.rs
@@ -1,7 +1,176 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::io::{self, Write};
 
 use crate::store::yaml::YamlStore;
+
+/// Run embedding + LLM discovery against all detected local runtimes,
+/// blocking the caller's thread. Uses a single-threaded Tokio runtime.
+/// When `refresh` is true, the on-disk cache is deleted first.
+fn discover_blocking(refresh: bool) -> Result<Vec<crate::discovery::DiscoveredModel>> {
+    if refresh {
+        let cache_path = crate::discovery::cache::DiscoveryCache::default_path();
+        let _ = std::fs::remove_file(&cache_path);
+    }
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime for discovery")?;
+    rt.block_on(crate::discovery::run_all())
+}
+
+/// Best-effort hardcoded dims for known model ids when the `/v1/embeddings`
+/// or `/api/embed` probe fails. Returns `None` for unknown ids.
+fn fallback_dims_for(id: &str) -> Option<usize> {
+    if id.contains("Qwen3-Embedding-0.6B") || id.contains("qwen3-embedding:0.6b") {
+        Some(1024)
+    } else if id.contains("Qwen3-Embedding-4B") || id.contains("qwen3-embedding:4b") {
+        Some(2560)
+    } else if id.contains("Qwen3-Embedding-8B") || id.contains("qwen3-embedding:8b") {
+        Some(4096)
+    } else if id.contains("bge-m3") {
+        Some(1024)
+    } else if id.contains("nomic-embed-text") || id.contains("embeddinggemma") {
+        Some(768)
+    } else {
+        None
+    }
+}
+
+/// Select a local embedding model via discovery.
+///
+/// `available` is the merged list of discovered models from
+/// `discover_blocking()`. Returns `Ok(true)` if config was written,
+/// `Ok(false)` if the user picked Skip (or a [pull] row).
+fn select_local_embedding(
+    config: &mut mur_common::config::Config,
+    available: &[crate::discovery::DiscoveredModel],
+) -> Result<bool> {
+    use crate::discovery::aggregate::{build_embedding_menu, MenuRowKind};
+    use crate::discovery::Backend;
+
+    let rows = build_embedding_menu(available);
+
+    println!();
+    println!("Embedding model — local discovery:");
+    for (i, r) in rows.iter().enumerate() {
+        println!("  {}) {}", i + 1, r.label);
+    }
+    print!("Choose [1-{}] (default: 1): ", rows.len());
+    io::stdout().flush()?;
+    let mut s = String::new();
+    io::stdin().read_line(&mut s)?;
+    let idx = s
+        .trim()
+        .parse::<usize>()
+        .ok()
+        .filter(|&n| n >= 1 && n <= rows.len())
+        .map(|n| n - 1)
+        .unwrap_or(0);
+    let row = &rows[idx];
+
+    match row.kind {
+        MenuRowKind::Auto | MenuRowKind::Pulled => {
+            let m = row.model.as_ref().expect("auto/pulled rows always carry a model");
+            // If dims weren't populated at discovery time (oMLX entries before
+            // probe), issue a 1-token /v1/embeddings call to learn them now.
+            let dims = match m.dims {
+                Some(d) => d,
+                None => {
+                    use crate::discovery::Discovery as _;
+                    let rt = tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                        .context("tokio runtime for embedding probe")?;
+                    let probe = match m.backend {
+                        Backend::Ollama => {
+                            let d = crate::discovery::ollama::OllamaDiscovery::new(
+                                "http://localhost:11434",
+                            );
+                            rt.block_on(d.probe_embedding(&m.id))
+                        }
+                        Backend::OMlx => {
+                            let d = crate::discovery::omlx::OMlxDiscovery::new(
+                                "http://localhost:8000/v1",
+                            );
+                            rt.block_on(d.probe_embedding(&m.id))
+                        }
+                    };
+                    match probe {
+                        Ok(p) => p.dims,
+                        Err(e) => {
+                            println!("  \u{26a0} Probe failed: {e}; using preference-table fallback");
+                            fallback_dims_for(&m.id).unwrap_or(1024)
+                        }
+                    }
+                }
+            };
+            match m.backend {
+                Backend::Ollama => {
+                    config.embedding.provider = "ollama".into();
+                    config.embedding.model = m.id.clone();
+                    config.embedding.dimensions = dims;
+                    config.embedding.api_key_env = None;
+                    config.embedding.openai_url = None;
+                }
+                Backend::OMlx => {
+                    config.embedding.provider = "omlx".into();
+                    config.embedding.model = m.id.clone();
+                    config.embedding.dimensions = dims;
+                    config.embedding.api_key_env = Some("OMLX_API_KEY".into());
+                    config.embedding.openai_url = Some("http://localhost:8000/v1".into());
+                    println!();
+                    println!(
+                        "  \u{26a0} Set OMLX_API_KEY before first use (any non-empty value works on localhost):"
+                    );
+                    println!("      export OMLX_API_KEY=local");
+                }
+            }
+            Ok(true)
+        }
+        MenuRowKind::Pull => {
+            let pull_id = row.pull_id.as_ref().expect("pull rows always carry an id");
+            // Heuristic: Ollama-style tags contain ':' or are short known IDs;
+            // HF ids contain '/' and are routed to oMLX (no CLI pull).
+            let is_ollama_style = !pull_id.contains('/')
+                && (pull_id.contains(':')
+                    || matches!(
+                        pull_id.as_str(),
+                        "bge-m3" | "nomic-embed-text" | "all-minilm" | "embeddinggemma"
+                    ));
+            if is_ollama_style {
+                println!();
+                println!("  Pulling {} via Ollama...", pull_id);
+                let st = std::process::Command::new("ollama").arg("pull").arg(pull_id).status();
+                match st {
+                    Ok(s) if s.success() => {
+                        println!("  \u{2713} Pulled. Re-run `mur init` to select it.");
+                    }
+                    Ok(s) => {
+                        println!(
+                            "  \u{26a0} ollama pull exited with {}; embedding not configured.",
+                            s
+                        );
+                    }
+                    Err(e) => {
+                        println!(
+                            "  \u{26a0} Could not invoke ollama: {e}; install from https://ollama.com"
+                        );
+                    }
+                }
+            } else {
+                // HF id form — oMLX path; oMLX has no CLI pull mechanism.
+                println!();
+                println!("  Open oMLX.app \u{2192} Models \u{2192} search '{}' \u{2192} Pull", pull_id);
+                println!("  Then re-run `mur init`.");
+            }
+            Ok(false)
+        }
+        MenuRowKind::Skip => {
+            println!("  Keeping current embedding config.");
+            Ok(false)
+        }
+    }
+}
 
 pub(crate) const HOOK_SCRIPT_PROMPT: &str = "#!/bin/bash
 # mur-managed-hook v7 — generated by `mur init --hooks`
@@ -23,7 +192,7 @@ pub(crate) const HOOK_SCRIPT_SESSION_START: &str = "#!/bin/bash
 exec mur hook session-start --tool \"${MUR_TOOL:-claude}\"
 ";
 
-pub(crate) fn cmd_init(hooks_flag: bool) -> Result<()> {
+pub(crate) fn cmd_init(hooks_flag: bool, refresh_discovery: bool) -> Result<()> {
     let home =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
     let mur_dir = home.join(".mur");
@@ -765,35 +934,8 @@ Run `mur learn` to extract new patterns from recent sessions.
             Ok((provider, env_var, llm_model, is_openrouter))
         };
 
-    // Helper: select local Ollama embedding model
-    let select_ollama_embedding = |config: &mut mur_common::config::Config| -> Result<()> {
-        println!();
-        println!("Embedding model (Ollama):");
-        println!("  1) qwen3-embedding:0.6b — fast, ~1.5GB RAM (recommended)");
-        println!("  2) qwen3-embedding:4b  — better multilingual, ~8GB RAM");
-        println!("  3) qwen3-embedding:8b  — best quality (MTEB #1), ~16GB RAM");
-        println!("  4) nomic-embed-text    — lightweight alternative, ~300MB RAM");
-        print!("Choose [1/2/3/4] (default: 1): ");
-        io::stdout().flush()?;
-        let mut choice = String::new();
-        io::stdin().read_line(&mut choice)?;
-
-        let (model, dims) = match choice.trim() {
-            "2" => ("qwen3-embedding:4b", 2560),
-            "3" => ("qwen3-embedding:8b", 4096),
-            "4" => ("nomic-embed-text", 768),
-            _ => ("qwen3-embedding:0.6b", 1024),
-        };
-
-        config.embedding.provider = "ollama".to_string();
-        config.embedding.model = model.to_string();
-        config.embedding.dimensions = dims;
-        config.embedding.api_key_env = None;
-        config.embedding.openai_url = None;
-        Ok(())
-    };
-
-    // Helper: select cloud embedding provider
+    // Helper: select cloud embedding provider (cloud LLM path).
+    // When the user picks "Local", delegates to `select_local_embedding`.
     let select_cloud_embedding = |config: &mut mur_common::config::Config,
                                   llm_provider: &str,
                                   llm_env_var: &str|
@@ -801,21 +943,22 @@ Run `mur learn` to extract new patterns from recent sessions.
         println!();
         println!("Embedding provider:");
         let cloud_label = match llm_provider {
-            "openai" => "OpenAI — text-embedding-3-small (same API key)",
-            "gemini" => "Gemini — text-embedding-004 (same API key)",
-            "anthropic" => "Voyage — voyage-3-lite (same API key)",
+            "openai" => "OpenAI \u{2014} text-embedding-3-small (same API key)",
+            "gemini" => "Gemini \u{2014} text-embedding-004 (same API key)",
+            "anthropic" => "Voyage \u{2014} voyage-3-lite (same API key)",
             _ => "Cloud embedding",
         };
         println!("  1) {} (recommended)", cloud_label);
-        println!("  2) Local Ollama — free, no API dependency");
+        println!("  2) Local (Ollama / oMLX) \u{2014} free, no API dependency");
         print!("Choose [1/2] (default: 1): ");
         io::stdout().flush()?;
         let mut choice = String::new();
         io::stdin().read_line(&mut choice)?;
 
         if choice.trim() == "2" {
-            // Delegate to Ollama selection
-            select_ollama_embedding(config)?;
+            // Delegate to discovery-based local embedding selection
+            let available = discover_blocking(refresh_discovery)?;
+            select_local_embedding(config, &available)?;
         } else {
             let (provider, model, dims) = match llm_provider {
                 "openai" => ("openai", "text-embedding-3-small", 1536),
@@ -836,17 +979,14 @@ Run `mur learn` to extract new patterns from recent sessions.
         "1" => {
             // Cloud LLM + local embedding (recommended)
             let (_provider, _env_var, llm_model, is_openrouter) = select_cloud_llm(&mut config)?;
-            select_ollama_embedding(&mut config)?;
+            let available = discover_blocking(refresh_discovery)?;
+            select_local_embedding(&mut config, &available)?;
 
             crate::store::config::save_config(&config)?;
-            let llm_display = if is_openrouter {
-                "openrouter"
-            } else {
-                _provider
-            };
+            let llm_display = if is_openrouter { "openrouter" } else { _provider };
             println!(
-                "  ✓ Config: {} (LLM) + ollama/{} (search) / {}",
-                llm_display, config.embedding.model, llm_model
+                "  \u{2713} Config: {} (LLM) + {}/{} (search) / {}",
+                llm_display, config.embedding.provider, config.embedding.model, llm_model
             );
         }
         "2" => {
@@ -854,19 +994,20 @@ Run `mur learn` to extract new patterns from recent sessions.
             let (provider, env_var, llm_model, is_openrouter) = select_cloud_llm(&mut config)?;
 
             if is_openrouter {
-                // OpenRouter doesn't offer embeddings, use cloud or ollama
+                // OpenRouter doesn't offer embeddings, use cloud or local discovery
                 println!();
-                println!("  ℹ OpenRouter doesn't provide embedding APIs.");
+                println!("  \u{2139} OpenRouter doesn't provide embedding APIs.");
                 println!("    Pick a separate embedding provider:");
-                println!("  1) OpenAI — text-embedding-3-small (requires OPENAI_API_KEY)");
-                println!("  2) Local Ollama — free");
+                println!("  1) OpenAI \u{2014} text-embedding-3-small (requires OPENAI_API_KEY)");
+                println!("  2) Local (Ollama / oMLX) \u{2014} free");
                 print!("Choose [1/2] (default: 1): ");
                 io::stdout().flush()?;
                 let mut choice = String::new();
                 io::stdin().read_line(&mut choice)?;
 
                 if choice.trim() == "2" {
-                    select_ollama_embedding(&mut config)?;
+                    let available = discover_blocking(refresh_discovery)?;
+                    select_local_embedding(&mut config, &available)?;
                 } else {
                     config.embedding.provider = "openai".to_string();
                     config.embedding.model = "text-embedding-3-small".to_string();
@@ -874,7 +1015,7 @@ Run `mur learn` to extract new patterns from recent sessions.
                     config.embedding.api_key_env = Some("OPENAI_API_KEY".to_string());
                     config.embedding.openai_url = None;
                     if std::env::var("OPENAI_API_KEY").is_err() {
-                        println!("  ⚠ OPENAI_API_KEY not set — set it for embedding to work");
+                        println!("  \u{26a0} OPENAI_API_KEY not set \u{2014} set it for embedding to work");
                     }
                 }
             } else {
@@ -913,11 +1054,12 @@ Run `mur learn` to extract new patterns from recent sessions.
                     config.llm.api_key_env = None;
                     config.llm.openai_url = None;
 
-                    select_ollama_embedding(&mut config)?;
+                    let available = discover_blocking(refresh_discovery)?;
+                    select_local_embedding(&mut config, &available)?;
                     crate::store::config::save_config(&config)?;
                     println!(
-                        "  ✓ Config: ollama/{} (LLM) + ollama/{} (search)",
-                        m.id, config.embedding.model
+                        "  \u{2713} Config: ollama/{} (LLM) + {}/{} (search)",
+                        m.id, config.embedding.provider, config.embedding.model
                     );
                 }
                 Some(LocalBackend::OMlx) => {
@@ -931,14 +1073,15 @@ Run `mur learn` to extract new patterns from recent sessions.
                     config.llm.openai_url =
                         Some(LocalBackend::OMlx.openai_base_url().unwrap().to_string());
 
-                    select_ollama_embedding(&mut config)?;
+                    let available = discover_blocking(refresh_discovery)?;
+                    select_local_embedding(&mut config, &available)?;
                     crate::store::config::save_config(&config)?;
                     println!(
-                        "  ✓ Config: oMLX/{} (LLM) + ollama/{} (search)",
-                        m.id, config.embedding.model
+                        "  \u{2713} Config: oMLX/{} (LLM) + {}/{} (search)",
+                        m.id, config.embedding.provider, config.embedding.model
                     );
                     println!();
-                    println!("  ⚠ Launch oMLX.app (menu bar → Start Server) and pull");
+                    println!("  \u{26a0} Launch oMLX.app (menu bar \u{2192} Start Server) and pull");
                     println!("      the model via its admin dashboard:  {}", m.id);
                     println!(
                         "      export OMLX_API_KEY=local   # any non-empty value; oMLX skips auth on localhost"
@@ -954,14 +1097,15 @@ Run `mur learn` to extract new patterns from recent sessions.
                     config.llm.openai_url =
                         Some(LocalBackend::MlxLm.openai_base_url().unwrap().to_string());
 
-                    select_ollama_embedding(&mut config)?;
+                    let available = discover_blocking(refresh_discovery)?;
+                    select_local_embedding(&mut config, &available)?;
                     crate::store::config::save_config(&config)?;
                     println!(
-                        "  ✓ Config: mlx-lm/{} (LLM) + ollama/{} (search)",
-                        m.id, config.embedding.model
+                        "  \u{2713} Config: mlx-lm/{} (LLM) + {}/{} (search)",
+                        m.id, config.embedding.provider, config.embedding.model
                     );
                     println!();
-                    println!("  ⚠ Start the mlx-lm server in a separate terminal:");
+                    println!("  \u{26a0} Start the mlx-lm server in a separate terminal:");
                     println!("      mlx_lm.server --model {} --port 8080", m.id);
                     println!(
                         "      export MLX_API_KEY=local   # any non-empty value; mlx_lm.server ignores it"
@@ -1221,6 +1365,45 @@ mod tests {
             HOOK_SCRIPT_PROMPT.contains("v7"),
             "hook scripts must be version v7"
         );
+    }
+}
+
+#[cfg(test)]
+mod select_local_embedding_tests {
+    use crate::discovery::aggregate::{build_embedding_menu, MenuRowKind};
+    use crate::discovery::{Backend, DiscoveredModel, ModelKind};
+
+    fn ollama_qwen() -> DiscoveredModel {
+        DiscoveredModel {
+            id: "qwen3-embedding:0.6b".into(),
+            backend: Backend::Ollama,
+            kind: ModelKind::Embedding,
+            dims: Some(1024),
+            family: Some("bert".into()),
+            size_bytes: None,
+            probed_at: None,
+        }
+    }
+
+    /// Auto row, when chosen, must carry enough info to write
+    /// `cfg.embedding.{provider, model, dimensions, ollama_endpoint}`.
+    #[test]
+    fn auto_row_carries_full_model_info() {
+        let rows = build_embedding_menu(&[ollama_qwen()]);
+        let auto = rows.iter().find(|r| r.kind == MenuRowKind::Auto).unwrap();
+        let m = auto.model.as_ref().unwrap();
+        assert_eq!(m.backend, Backend::Ollama);
+        assert_eq!(m.id, "qwen3-embedding:0.6b");
+        assert_eq!(m.dims, Some(1024));
+    }
+}
+
+#[cfg(test)]
+mod refresh_flag_tests {
+    /// Compile-time check that `cmd_init` accepts the new `refresh_discovery` flag.
+    #[test]
+    fn cmd_init_accepts_refresh_discovery() {
+        let _ = super::cmd_init as fn(bool, bool) -> anyhow::Result<()>;
     }
 }
 

--- a/mur-core/src/cmd/init.rs
+++ b/mur-core/src/cmd/init.rs
@@ -93,8 +93,9 @@ fn select_local_embedding(
                             block_on_in_runtime(d.probe_embedding(&m.id))
                         }
                         Backend::OMlx => {
-                            let d = crate::discovery::omlx::OMlxDiscovery::new(
+                            let d = crate::discovery::omlx::OMlxDiscovery::with_api_key(
                                 "http://localhost:8000/v1",
+                                crate::discovery::resolve_omlx_api_key(),
                             );
                             block_on_in_runtime(d.probe_embedding(&m.id))
                         }

--- a/mur-core/src/cmd/init.rs
+++ b/mur-core/src/cmd/init.rs
@@ -1,28 +1,29 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use std::io::{self, Write};
 
 use crate::store::yaml::YamlStore;
 
-/// Build a single-threaded Tokio runtime for one-shot async work from sync
-/// callers. Both `discover_blocking` and the dims-probe path use this; both
-/// are short-lived, single-shot, and never nested.
-fn one_shot_rt() -> Result<tokio::runtime::Runtime> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("building tokio runtime")
+/// Drive an async future from a sync caller that's already inside the
+/// `mur-main` multi-threaded tokio runtime (see `main.rs::main`).
+///
+/// `tokio::task::block_in_place` releases the current worker thread so we
+/// can synchronously block on `Handle::current().block_on(future)`. We
+/// cannot use `Runtime::new(...).block_on(...)` here because constructing a
+/// new runtime inside an existing runtime panics ("Cannot start a runtime
+/// from within a runtime").
+fn block_on_in_runtime<F: std::future::Future>(future: F) -> F::Output {
+    tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
 }
 
 /// Run embedding + LLM discovery against all detected local runtimes,
-/// blocking the caller's thread. Uses a single-threaded Tokio runtime.
-/// When `refresh` is true, the on-disk cache is deleted first.
+/// blocking the caller's thread. When `refresh` is true, the on-disk cache
+/// is deleted first.
 fn discover_blocking(refresh: bool) -> Result<Vec<crate::discovery::DiscoveredModel>> {
     if refresh {
         let cache_path = crate::discovery::cache::DiscoveryCache::default_path();
         let _ = std::fs::remove_file(&cache_path);
     }
-    let rt = one_shot_rt()?;
-    rt.block_on(crate::discovery::run_all())
+    block_on_in_runtime(crate::discovery::run_all())
 }
 
 /// Best-effort hardcoded dims for known model ids when the `/v1/embeddings`
@@ -84,19 +85,18 @@ fn select_local_embedding(
                 Some(d) => d,
                 None => {
                     use crate::discovery::Discovery as _;
-                    let rt = one_shot_rt()?;
                     let probe = match m.backend {
                         Backend::Ollama => {
                             let d = crate::discovery::ollama::OllamaDiscovery::new(
                                 "http://localhost:11434",
                             );
-                            rt.block_on(d.probe_embedding(&m.id))
+                            block_on_in_runtime(d.probe_embedding(&m.id))
                         }
                         Backend::OMlx => {
                             let d = crate::discovery::omlx::OMlxDiscovery::new(
                                 "http://localhost:8000/v1",
                             );
-                            rt.block_on(d.probe_embedding(&m.id))
+                            block_on_in_runtime(d.probe_embedding(&m.id))
                         }
                     };
                     match probe {
@@ -1444,5 +1444,45 @@ mod cloud_embedding_tests {
             }
             _ => panic!("expected OpenAI variant"),
         }
+    }
+}
+
+#[cfg(test)]
+mod runtime_regression_tests {
+    //! Regression: `discover_blocking` and the dims-probe path are called
+    //! synchronously from `cmd_init`, which itself runs inside the
+    //! mur-main multi-threaded tokio runtime (see `main.rs::main`).
+    //!
+    //! Earlier M5 code constructed a NEW `tokio::runtime::Runtime` and
+    //! called `.block_on(...)` on it — that panics with "Cannot start a
+    //! runtime from within a runtime" because runtime construction inside
+    //! an existing runtime is forbidden. The fix uses
+    //! `tokio::task::block_in_place` + `Handle::current().block_on`.
+    //!
+    //! These tests reproduce the original panic conditions to make sure
+    //! the bug doesn't return.
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn block_on_in_runtime_does_not_panic_inside_existing_runtime() {
+        // The bug: building a new Runtime here would panic.
+        // The fix: block_on_in_runtime uses Handle::current().block_on
+        // via block_in_place, which is safe.
+        let result = block_on_in_runtime(async { 42 });
+        assert_eq!(result, 42);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn discover_blocking_does_not_panic_inside_existing_runtime() {
+        // discover_blocking calls block_on_in_runtime; this is the exact
+        // path cmd_init runs through. Either no local runtimes are detected
+        // (returns empty Vec) or some are present (returns their models) —
+        // either way it must not panic.
+        let result = discover_blocking(false);
+        assert!(
+            result.is_ok(),
+            "discover_blocking should not error inside a tokio runtime: {:?}",
+            result.err()
+        );
     }
 }

--- a/mur-core/src/cmd/init.rs
+++ b/mur-core/src/cmd/init.rs
@@ -3,6 +3,16 @@ use std::io::{self, Write};
 
 use crate::store::yaml::YamlStore;
 
+/// Build a single-threaded Tokio runtime for one-shot async work from sync
+/// callers. Both `discover_blocking` and the dims-probe path use this; both
+/// are short-lived, single-shot, and never nested.
+fn one_shot_rt() -> Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime")
+}
+
 /// Run embedding + LLM discovery against all detected local runtimes,
 /// blocking the caller's thread. Uses a single-threaded Tokio runtime.
 /// When `refresh` is true, the on-disk cache is deleted first.
@@ -11,10 +21,7 @@ fn discover_blocking(refresh: bool) -> Result<Vec<crate::discovery::DiscoveredMo
         let cache_path = crate::discovery::cache::DiscoveryCache::default_path();
         let _ = std::fs::remove_file(&cache_path);
     }
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("building tokio runtime for discovery")?;
+    let rt = one_shot_rt()?;
     rt.block_on(crate::discovery::run_all())
 }
 
@@ -77,10 +84,7 @@ fn select_local_embedding(
                 Some(d) => d,
                 None => {
                     use crate::discovery::Discovery as _;
-                    let rt = tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()
-                        .context("tokio runtime for embedding probe")?;
+                    let rt = one_shot_rt()?;
                     let probe = match m.backend {
                         Backend::Ollama => {
                             let d = crate::discovery::ollama::OllamaDiscovery::new(
@@ -149,6 +153,11 @@ fn select_local_embedding(
                         println!(
                             "  \u{26a0} ollama pull exited with {}; embedding not configured.",
                             s
+                        );
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                        println!(
+                            "  \u{26a0} Pull interrupted; re-run `mur init` to retry."
                         );
                     }
                     Err(e) => {

--- a/mur-core/src/cmd/init.rs
+++ b/mur-core/src/cmd/init.rs
@@ -53,8 +53,8 @@ fn select_local_embedding(
     config: &mut mur_common::config::Config,
     available: &[crate::discovery::DiscoveredModel],
 ) -> Result<bool> {
-    use crate::discovery::aggregate::{build_embedding_menu, MenuRowKind};
     use crate::discovery::Backend;
+    use crate::discovery::aggregate::{MenuRowKind, build_embedding_menu};
 
     let rows = build_embedding_menu(available);
 
@@ -78,7 +78,10 @@ fn select_local_embedding(
 
     match row.kind {
         MenuRowKind::Auto | MenuRowKind::Pulled => {
-            let m = row.model.as_ref().expect("auto/pulled rows always carry a model");
+            let m = row
+                .model
+                .as_ref()
+                .expect("auto/pulled rows always carry a model");
             // If dims weren't populated at discovery time (oMLX entries before
             // probe), issue a 1-token /v1/embeddings call to learn them now.
             let dims = match m.dims {
@@ -103,7 +106,9 @@ fn select_local_embedding(
                     match probe {
                         Ok(p) => p.dims,
                         Err(e) => {
-                            println!("  \u{26a0} Probe failed: {e}; using preference-table fallback");
+                            println!(
+                                "  \u{26a0} Probe failed: {e}; using preference-table fallback"
+                            );
                             fallback_dims_for(&m.id).unwrap_or(1024)
                         }
                     }
@@ -145,7 +150,10 @@ fn select_local_embedding(
             if is_ollama_style {
                 println!();
                 println!("  Pulling {} via Ollama...", pull_id);
-                let st = std::process::Command::new("ollama").arg("pull").arg(pull_id).status();
+                let st = std::process::Command::new("ollama")
+                    .arg("pull")
+                    .arg(pull_id)
+                    .status();
                 match st {
                     Ok(s) if s.success() => {
                         println!("  \u{2713} Pulled. Re-run `mur init` to select it.");
@@ -157,9 +165,7 @@ fn select_local_embedding(
                         );
                     }
                     Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
-                        println!(
-                            "  \u{26a0} Pull interrupted; re-run `mur init` to retry."
-                        );
+                        println!("  \u{26a0} Pull interrupted; re-run `mur init` to retry.");
                     }
                     Err(e) => {
                         println!(
@@ -170,7 +176,10 @@ fn select_local_embedding(
             } else {
                 // HF id form — oMLX path; oMLX has no CLI pull mechanism.
                 println!();
-                println!("  Open oMLX.app \u{2192} Models \u{2192} search '{}' \u{2192} Pull", pull_id);
+                println!(
+                    "  Open oMLX.app \u{2192} Models \u{2192} search '{}' \u{2192} Pull",
+                    pull_id
+                );
                 println!("  Then re-run `mur init`.");
             }
             Ok(false)
@@ -993,7 +1002,11 @@ Run `mur learn` to extract new patterns from recent sessions.
             select_local_embedding(&mut config, &available)?;
 
             crate::store::config::save_config(&config)?;
-            let llm_display = if is_openrouter { "openrouter" } else { _provider };
+            let llm_display = if is_openrouter {
+                "openrouter"
+            } else {
+                _provider
+            };
             println!(
                 "  \u{2713} Config: {} (LLM) + {}/{} (search) / {}",
                 llm_display, config.embedding.provider, config.embedding.model, llm_model
@@ -1025,7 +1038,9 @@ Run `mur learn` to extract new patterns from recent sessions.
                     config.embedding.api_key_env = Some("OPENAI_API_KEY".to_string());
                     config.embedding.openai_url = None;
                     if std::env::var("OPENAI_API_KEY").is_err() {
-                        println!("  \u{26a0} OPENAI_API_KEY not set \u{2014} set it for embedding to work");
+                        println!(
+                            "  \u{26a0} OPENAI_API_KEY not set \u{2014} set it for embedding to work"
+                        );
                     }
                 }
             } else {
@@ -1091,7 +1106,9 @@ Run `mur learn` to extract new patterns from recent sessions.
                         m.id, config.embedding.provider, config.embedding.model
                     );
                     println!();
-                    println!("  \u{26a0} Launch oMLX.app (menu bar \u{2192} Start Server) and pull");
+                    println!(
+                        "  \u{26a0} Launch oMLX.app (menu bar \u{2192} Start Server) and pull"
+                    );
                     println!("      the model via its admin dashboard:  {}", m.id);
                     println!(
                         "      export OMLX_API_KEY=local   # any non-empty value; oMLX skips auth on localhost"
@@ -1380,7 +1397,7 @@ mod tests {
 
 #[cfg(test)]
 mod select_local_embedding_tests {
-    use crate::discovery::aggregate::{build_embedding_menu, MenuRowKind};
+    use crate::discovery::aggregate::{MenuRowKind, build_embedding_menu};
     use crate::discovery::{Backend, DiscoveredModel, ModelKind};
 
     fn ollama_qwen() -> DiscoveredModel {

--- a/mur-core/src/discovery/aggregate.rs
+++ b/mur-core/src/discovery/aggregate.rs
@@ -87,6 +87,11 @@ fn build_menu(
     }
 
     // Top 2 preference-table entries NOT already in pulled set, with rank > 0.
+    // Note: dedup uses substring `contains`, so a preference-table prefix like
+    // "qwen3-embedding:0.6b" suppresses any pulled id that contains that
+    // exact substring. If a future preference entry uses a very short prefix
+    // (e.g. just "qwen3"), it would suppress unrelated families — keep
+    // preference prefixes specific.
     let pulled_ids: HashSet<&str> = available.iter().map(|m| m.id.as_str()).collect();
     let mut suggestions: Vec<(&str, u32)> = table
         .iter()

--- a/mur-core/src/discovery/aggregate.rs
+++ b/mur-core/src/discovery/aggregate.rs
@@ -4,7 +4,7 @@
 use std::cmp::Reverse;
 use std::collections::HashSet;
 
-use super::preference::{rank, EMBEDDING_PREFERENCE, LLM_PREFERENCE};
+use super::preference::{EMBEDDING_PREFERENCE, LLM_PREFERENCE, rank};
 use super::{DiscoveredModel, ModelKind};
 
 /// One menu row, in display order.
@@ -147,11 +147,19 @@ mod tests {
 
     #[test]
     fn single_pulled_becomes_auto() {
-        let avail =
-            vec![dm("qwen3-embedding:0.6b", Backend::Ollama, ModelKind::Embedding, Some(1024))];
+        let avail = vec![dm(
+            "qwen3-embedding:0.6b",
+            Backend::Ollama,
+            ModelKind::Embedding,
+            Some(1024),
+        )];
         let rows = build_embedding_menu(&avail);
         assert_eq!(rows[0].kind, MenuRowKind::Auto);
-        assert!(rows[0].label.starts_with("[auto] Ollama/qwen3-embedding:0.6b"));
+        assert!(
+            rows[0]
+                .label
+                .starts_with("[auto] Ollama/qwen3-embedding:0.6b")
+        );
         assert!(rows[0].label.contains("(1024d)"));
     }
 
@@ -159,7 +167,12 @@ mod tests {
     fn omlx_and_ollama_both_present_one_is_auto() {
         // Both have rank 70; we just assert one of them is [auto], the other [Pulled].
         let avail = vec![
-            dm("qwen3-embedding:0.6b", Backend::Ollama, ModelKind::Embedding, Some(1024)),
+            dm(
+                "qwen3-embedding:0.6b",
+                Backend::Ollama,
+                ModelKind::Embedding,
+                Some(1024),
+            ),
             dm(
                 "mlx-community/Qwen3-Embedding-0.6B-8bit",
                 Backend::OMlx,
@@ -174,8 +187,12 @@ mod tests {
 
     #[test]
     fn pull_suggestion_excludes_already_pulled() {
-        let avail =
-            vec![dm("qwen3-embedding:0.6b", Backend::Ollama, ModelKind::Embedding, Some(1024))];
+        let avail = vec![dm(
+            "qwen3-embedding:0.6b",
+            Backend::Ollama,
+            ModelKind::Embedding,
+            Some(1024),
+        )];
         let rows = build_embedding_menu(&avail);
         for r in &rows {
             if let Some(pid) = &r.pull_id {
@@ -197,8 +214,9 @@ mod tests {
         let avail = vec![dm("qwen3.5:4b", Backend::Ollama, ModelKind::Llm, None)];
         let rows = build_embedding_menu(&avail);
         // llm-only entries must NOT appear as pulled/auto
-        assert!(rows
-            .iter()
-            .all(|r| r.model.as_ref().map(|m| m.kind) != Some(ModelKind::Llm)));
+        assert!(
+            rows.iter()
+                .all(|r| r.model.as_ref().map(|m| m.kind) != Some(ModelKind::Llm))
+        );
     }
 }

--- a/mur-core/src/discovery/aggregate.rs
+++ b/mur-core/src/discovery/aggregate.rs
@@ -1,0 +1,199 @@
+//! Aggregate `Discovery` results across all detected runtimes, intersect
+//! with the static preference table, and produce a ranked menu seed.
+
+use std::cmp::Reverse;
+use std::collections::HashSet;
+
+use super::preference::{rank, EMBEDDING_PREFERENCE, LLM_PREFERENCE};
+use super::{DiscoveredModel, ModelKind};
+
+/// One menu row, in display order.
+#[derive(Debug, Clone)]
+pub struct MenuRow {
+    pub kind: MenuRowKind,
+    pub label: String,
+    pub model: Option<DiscoveredModel>,
+    pub pull_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MenuRowKind {
+    Auto,   // first row, "[auto]" prefix
+    Pulled, // already-installed model
+    Pull,   // recommended-but-not-pulled
+    Skip,   // last row
+}
+
+/// Build the menu rows for embedding selection.
+///
+/// `available` = union of all discovery results (filtered to kind ∈
+/// {Embedding, Unknown}).
+pub fn build_embedding_menu(available: &[DiscoveredModel]) -> Vec<MenuRow> {
+    build_menu(available, EMBEDDING_PREFERENCE, ModelKind::Embedding)
+}
+
+/// Build the menu rows for LLM selection.
+///
+/// `available` = union of all discovery results (filtered to kind ∈
+/// {Llm, Unknown}).
+pub fn build_llm_menu(available: &[DiscoveredModel]) -> Vec<MenuRow> {
+    build_menu(available, LLM_PREFERENCE, ModelKind::Llm)
+}
+
+fn build_menu(
+    available: &[DiscoveredModel],
+    table: &[(&'static str, u32)],
+    desired_kind: ModelKind,
+) -> Vec<MenuRow> {
+    let mut filtered: Vec<&DiscoveredModel> = available
+        .iter()
+        .filter(|m| m.kind == desired_kind || m.kind == ModelKind::Unknown)
+        .collect();
+    // Stable sort: highest-ranked first. Tie-breaking preserves insertion order.
+    filtered.sort_by_key(|m| Reverse(rank(&m.id, table)));
+
+    let mut rows = Vec::new();
+
+    // Row 1: [auto] = highest-ranked pulled model
+    if let Some(top) = filtered.first() {
+        let label = format!(
+            "[auto] {}/{}{}",
+            top.backend,
+            top.id,
+            top.dims.map(|d| format!(" ({}d)", d)).unwrap_or_default(),
+        );
+        rows.push(MenuRow {
+            kind: MenuRowKind::Auto,
+            label,
+            model: Some((*top).clone()),
+            pull_id: None,
+        });
+    }
+
+    // Rows 2..: remaining pulled models
+    for m in filtered.iter().skip(1) {
+        let label = format!(
+            "{}/{}{}",
+            m.backend,
+            m.id,
+            m.dims.map(|d| format!(" ({}d)", d)).unwrap_or_default(),
+        );
+        rows.push(MenuRow {
+            kind: MenuRowKind::Pulled,
+            label,
+            model: Some((*m).clone()),
+            pull_id: None,
+        });
+    }
+
+    // Top 2 preference-table entries NOT already in pulled set, with rank > 0.
+    let pulled_ids: HashSet<&str> = available.iter().map(|m| m.id.as_str()).collect();
+    let mut suggestions: Vec<(&str, u32)> = table
+        .iter()
+        .filter(|(prefix, _)| !pulled_ids.iter().any(|id| id.contains(prefix)))
+        .map(|(p, s)| (*p, *s))
+        .collect();
+    suggestions.sort_by_key(|(_, s)| Reverse(*s));
+    for (prefix, _) in suggestions.iter().take(2) {
+        rows.push(MenuRow {
+            kind: MenuRowKind::Pull,
+            label: format!("[pull] {}", prefix),
+            model: None,
+            pull_id: Some((*prefix).into()),
+        });
+    }
+
+    // Last row: skip
+    rows.push(MenuRow {
+        kind: MenuRowKind::Skip,
+        label: "Skip \u{2014} configure later".into(),
+        model: None,
+        pull_id: None,
+    });
+
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::Backend;
+
+    fn dm(id: &str, backend: Backend, kind: ModelKind, dims: Option<usize>) -> DiscoveredModel {
+        DiscoveredModel {
+            id: id.into(),
+            backend,
+            kind,
+            dims,
+            family: None,
+            size_bytes: None,
+            probed_at: None,
+        }
+    }
+
+    #[test]
+    fn empty_input_yields_pull_suggestions_then_skip() {
+        let rows = build_embedding_menu(&[]);
+        // 0 auto + 0 pulled + 2 [pull] + 1 skip
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].kind, MenuRowKind::Pull);
+        assert_eq!(rows.last().unwrap().kind, MenuRowKind::Skip);
+    }
+
+    #[test]
+    fn single_pulled_becomes_auto() {
+        let avail =
+            vec![dm("qwen3-embedding:0.6b", Backend::Ollama, ModelKind::Embedding, Some(1024))];
+        let rows = build_embedding_menu(&avail);
+        assert_eq!(rows[0].kind, MenuRowKind::Auto);
+        assert!(rows[0].label.starts_with("[auto] Ollama/qwen3-embedding:0.6b"));
+        assert!(rows[0].label.contains("(1024d)"));
+    }
+
+    #[test]
+    fn omlx_and_ollama_both_present_one_is_auto() {
+        // Both have rank 70; we just assert one of them is [auto], the other [Pulled].
+        let avail = vec![
+            dm("qwen3-embedding:0.6b", Backend::Ollama, ModelKind::Embedding, Some(1024)),
+            dm(
+                "mlx-community/Qwen3-Embedding-0.6B-8bit",
+                Backend::OMlx,
+                ModelKind::Embedding,
+                Some(1024),
+            ),
+        ];
+        let rows = build_embedding_menu(&avail);
+        assert_eq!(rows[0].kind, MenuRowKind::Auto);
+        assert_eq!(rows[1].kind, MenuRowKind::Pulled);
+    }
+
+    #[test]
+    fn pull_suggestion_excludes_already_pulled() {
+        let avail =
+            vec![dm("qwen3-embedding:0.6b", Backend::Ollama, ModelKind::Embedding, Some(1024))];
+        let rows = build_embedding_menu(&avail);
+        for r in &rows {
+            if let Some(pid) = &r.pull_id {
+                assert!(!pid.contains("qwen3-embedding:0.6b"));
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_kind_included_in_filter() {
+        let avail = vec![dm("foo:bar", Backend::Ollama, ModelKind::Unknown, None)];
+        let rows = build_embedding_menu(&avail);
+        // Unknown is included in the embedding filter
+        assert_eq!(rows[0].kind, MenuRowKind::Auto);
+    }
+
+    #[test]
+    fn llm_kind_not_in_embedding_menu() {
+        let avail = vec![dm("qwen3.5:4b", Backend::Ollama, ModelKind::Llm, None)];
+        let rows = build_embedding_menu(&avail);
+        // llm-only entries must NOT appear as pulled/auto
+        assert!(rows
+            .iter()
+            .all(|r| r.model.as_ref().map(|m| m.kind) != Some(ModelKind::Llm)));
+    }
+}

--- a/mur-core/src/discovery/cache.rs
+++ b/mur-core/src/discovery/cache.rs
@@ -28,12 +28,17 @@ pub struct CacheEntry {
 
 impl DiscoveryCache {
     pub fn empty() -> Self {
-        Self { schema_version: CACHE_SCHEMA_VERSION, entries: Vec::new() }
+        Self {
+            schema_version: CACHE_SCHEMA_VERSION,
+            entries: Vec::new(),
+        }
     }
 
     /// Default cache path under the active mur root.
     pub fn default_path() -> PathBuf {
-        crate::paths::mur_root(None).join("cache").join("discovery.json")
+        crate::paths::mur_root(None)
+            .join("cache")
+            .join("discovery.json")
     }
 
     /// Load cache from disk. Returns `empty()` on missing file, corrupt
@@ -82,7 +87,8 @@ impl DiscoveryCache {
 
     /// Insert or replace the entry for (endpoint, backend).
     pub fn upsert(&mut self, endpoint: String, backend: Backend, models: Vec<DiscoveredModel>) {
-        self.entries.retain(|e| !(e.endpoint == endpoint && e.backend == backend));
+        self.entries
+            .retain(|e| !(e.endpoint == endpoint && e.backend == backend));
         self.entries.push(CacheEntry {
             endpoint,
             backend,
@@ -151,10 +157,7 @@ mod tests {
     fn schema_mismatch_returns_empty() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("oldschema.json");
-        std::fs::write(
-            &path,
-            r#"{"schema_version": 999, "entries": []}"#,
-        ).unwrap();
+        std::fs::write(&path, r#"{"schema_version": 999, "entries": []}"#).unwrap();
         let c = DiscoveryCache::load(&path);
         assert_eq!(c.entries.len(), 0);
     }

--- a/mur-core/src/discovery/cache.rs
+++ b/mur-core/src/discovery/cache.rs
@@ -1,0 +1,180 @@
+//! On-disk cache for discovery results, at `~/.mur/cache/discovery.json`.
+//! TTL 24h. Schema versioned. Best-effort: corrupt JSON or schema mismatch
+//! is logged and treated as empty (forces re-discovery, never errors).
+
+use anyhow::Result;
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use super::{Backend, DiscoveredModel};
+
+pub const CACHE_SCHEMA_VERSION: u32 = 1;
+pub const CACHE_TTL_HOURS: i64 = 24;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveryCache {
+    pub schema_version: u32,
+    pub entries: Vec<CacheEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheEntry {
+    pub endpoint: String,
+    pub backend: Backend,
+    pub captured_at: DateTime<Utc>,
+    pub models: Vec<DiscoveredModel>,
+}
+
+impl DiscoveryCache {
+    pub fn empty() -> Self {
+        Self { schema_version: CACHE_SCHEMA_VERSION, entries: Vec::new() }
+    }
+
+    /// Default cache path under the active mur root.
+    pub fn default_path() -> PathBuf {
+        crate::paths::mur_root(None).join("cache").join("discovery.json")
+    }
+
+    /// Load cache from disk. Returns `empty()` on missing file, corrupt
+    /// JSON, or schema mismatch. Never errors — discovery just re-runs.
+    pub fn load(path: &Path) -> Self {
+        let Ok(bytes) = std::fs::read(path) else {
+            return Self::empty();
+        };
+        match serde_json::from_slice::<DiscoveryCache>(&bytes) {
+            Ok(c) if c.schema_version == CACHE_SCHEMA_VERSION => c,
+            Ok(c) => {
+                tracing::warn!(
+                    found = c.schema_version,
+                    expected = CACHE_SCHEMA_VERSION,
+                    "discovery cache schema mismatch; ignoring"
+                );
+                Self::empty()
+            }
+            Err(e) => {
+                tracing::warn!(?e, "discovery cache corrupt; ignoring");
+                Self::empty()
+            }
+        }
+    }
+
+    /// Atomic write via temp + rename.
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, serde_json::to_vec_pretty(self)?)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+
+    /// Look up a fresh entry for (endpoint, backend). Returns None if
+    /// missing or older than `CACHE_TTL_HOURS`.
+    pub fn fresh_entry(&self, endpoint: &str, backend: Backend) -> Option<&CacheEntry> {
+        let cutoff = Utc::now() - Duration::hours(CACHE_TTL_HOURS);
+        self.entries
+            .iter()
+            .find(|e| e.endpoint == endpoint && e.backend == backend && e.captured_at >= cutoff)
+    }
+
+    /// Insert or replace the entry for (endpoint, backend).
+    pub fn upsert(&mut self, endpoint: String, backend: Backend, models: Vec<DiscoveredModel>) {
+        self.entries.retain(|e| !(e.endpoint == endpoint && e.backend == backend));
+        self.entries.push(CacheEntry {
+            endpoint,
+            backend,
+            captured_at: Utc::now(),
+            models,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::{DiscoveredModel, ModelKind};
+    use chrono::Duration as ChronoDuration;
+    use tempfile::TempDir;
+
+    fn sample_model() -> DiscoveredModel {
+        DiscoveredModel {
+            id: "qwen3-embedding:0.6b".into(),
+            backend: Backend::Ollama,
+            kind: ModelKind::Embedding,
+            dims: Some(1024),
+            family: Some("bert".into()),
+            size_bytes: None,
+            probed_at: None,
+        }
+    }
+
+    #[test]
+    fn round_trip_save_load() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("discovery.json");
+
+        let mut c = DiscoveryCache::empty();
+        c.upsert(
+            "http://localhost:11434".into(),
+            Backend::Ollama,
+            vec![sample_model()],
+        );
+        c.save(&path).unwrap();
+
+        let loaded = DiscoveryCache::load(&path);
+        assert_eq!(loaded.schema_version, CACHE_SCHEMA_VERSION);
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].models.len(), 1);
+        assert_eq!(loaded.entries[0].models[0].id, "qwen3-embedding:0.6b");
+    }
+
+    #[test]
+    fn missing_file_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        let c = DiscoveryCache::load(&dir.path().join("nope.json"));
+        assert_eq!(c.entries.len(), 0);
+    }
+
+    #[test]
+    fn corrupt_file_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("corrupt.json");
+        std::fs::write(&path, b"{not valid json").unwrap();
+        let c = DiscoveryCache::load(&path);
+        assert_eq!(c.entries.len(), 0);
+    }
+
+    #[test]
+    fn schema_mismatch_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("oldschema.json");
+        std::fs::write(
+            &path,
+            r#"{"schema_version": 999, "entries": []}"#,
+        ).unwrap();
+        let c = DiscoveryCache::load(&path);
+        assert_eq!(c.entries.len(), 0);
+    }
+
+    #[test]
+    fn fresh_entry_respects_ttl() {
+        let mut c = DiscoveryCache::empty();
+        c.upsert("ep".into(), Backend::Ollama, vec![sample_model()]);
+        assert!(c.fresh_entry("ep", Backend::Ollama).is_some());
+
+        // Manually age the entry past TTL
+        c.entries[0].captured_at = Utc::now() - ChronoDuration::hours(CACHE_TTL_HOURS + 1);
+        assert!(c.fresh_entry("ep", Backend::Ollama).is_none());
+    }
+
+    #[test]
+    fn upsert_replaces_existing() {
+        let mut c = DiscoveryCache::empty();
+        c.upsert("ep".into(), Backend::Ollama, vec![]);
+        c.upsert("ep".into(), Backend::Ollama, vec![sample_model()]);
+        assert_eq!(c.entries.len(), 1);
+        assert_eq!(c.entries[0].models.len(), 1);
+    }
+}

--- a/mur-core/src/discovery/cache.rs
+++ b/mur-core/src/discovery/cache.rs
@@ -39,6 +39,7 @@ impl DiscoveryCache {
     /// Load cache from disk. Returns `empty()` on missing file, corrupt
     /// JSON, or schema mismatch. Never errors — discovery just re-runs.
     pub fn load(path: &Path) -> Self {
+        // Missing file is the normal first-run state; no log needed.
         let Ok(bytes) = std::fs::read(path) else {
             return Self::empty();
         };

--- a/mur-core/src/discovery/mod.rs
+++ b/mur-core/src/discovery/mod.rs
@@ -3,6 +3,7 @@
 //!
 //! See `docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md`.
 
+pub mod cache;
 pub mod preference;
 
 use anyhow::Result;
@@ -64,8 +65,6 @@ pub trait Discovery: Send + Sync {
     /// haven't recorded yet.
     async fn probe_embedding(&self, model_id: &str) -> Result<EmbeddingProbe>;
 }
-
-pub mod cache;
 
 #[cfg(test)]
 mod tests {

--- a/mur-core/src/discovery/mod.rs
+++ b/mur-core/src/discovery/mod.rs
@@ -1,0 +1,105 @@
+//! Runtime discovery: query Ollama / oMLX for what models are actually
+//! pulled, what their kind (LLM vs embedding) is, and what dims they have.
+//!
+//! See `docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md`.
+
+pub mod preference;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Backend {
+    Ollama,
+    OMlx,
+}
+
+impl fmt::Display for Backend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Backend::Ollama => f.write_str("Ollama"),
+            Backend::OMlx => f.write_str("oMLX"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ModelKind {
+    Llm,
+    Embedding,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiscoveredModel {
+    pub id: String,
+    pub backend: Backend,
+    pub kind: ModelKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dims: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub family: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub probed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EmbeddingProbe {
+    pub dims: usize,
+    pub latency_ms: u64,
+}
+
+#[async_trait]
+pub trait Discovery: Send + Sync {
+    fn backend(&self) -> Backend;
+    /// Enumerate all loaded / pulled models on this runtime.
+    async fn list_models(&self) -> Result<Vec<DiscoveredModel>>;
+    /// 1-token probe to determine kind + dim. Used after `list_models` when
+    /// `kind == Unknown`, or when the user picks a model whose dims we
+    /// haven't recorded yet.
+    async fn probe_embedding(&self, model_id: &str) -> Result<EmbeddingProbe>;
+}
+
+pub mod cache;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovered_model_round_trips_serde() {
+        let m = DiscoveredModel {
+            id: "qwen3-embedding:0.6b".into(),
+            backend: Backend::Ollama,
+            kind: ModelKind::Embedding,
+            dims: Some(1024),
+            family: Some("bert".into()),
+            size_bytes: Some(700_000_000),
+            probed_at: None,
+        };
+        let s = serde_json::to_string(&m).unwrap();
+        let m2: DiscoveredModel = serde_json::from_str(&s).unwrap();
+        assert_eq!(m.id, m2.id);
+        assert_eq!(m.backend, m2.backend);
+        assert_eq!(m.kind, m2.kind);
+        assert_eq!(m.dims, m2.dims);
+    }
+
+    #[test]
+    fn backend_display() {
+        assert_eq!(format!("{}", Backend::Ollama), "Ollama");
+        assert_eq!(format!("{}", Backend::OMlx), "oMLX");
+    }
+
+    #[test]
+    fn embedding_probe_has_dims_and_latency() {
+        let p = EmbeddingProbe { dims: 1024, latency_ms: 120 };
+        assert_eq!(p.dims, 1024);
+        assert_eq!(p.latency_ms, 120);
+    }
+}

--- a/mur-core/src/discovery/mod.rs
+++ b/mur-core/src/discovery/mod.rs
@@ -4,6 +4,7 @@
 //! See `docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md`.
 
 pub mod cache;
+pub mod ollama;
 pub mod preference;
 
 use anyhow::Result;

--- a/mur-core/src/discovery/mod.rs
+++ b/mur-core/src/discovery/mod.rs
@@ -3,6 +3,7 @@
 //!
 //! See `docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md`.
 
+pub mod aggregate;
 pub mod cache;
 pub mod ollama;
 pub mod omlx;

--- a/mur-core/src/discovery/mod.rs
+++ b/mur-core/src/discovery/mod.rs
@@ -69,6 +69,51 @@ pub trait Discovery: Send + Sync {
     async fn probe_embedding(&self, model_id: &str) -> Result<EmbeddingProbe>;
 }
 
+use crate::discovery::ollama::OllamaDiscovery;
+use crate::discovery::omlx::OMlxDiscovery;
+
+/// Run discovery against every endpoint that resolves; merge results.
+/// Backend-level failures are logged and dropped (non-fatal).
+async fn run_all_inner(
+    ollama_endpoint: Option<String>,
+    omlx_base_url: Option<String>,
+) -> anyhow::Result<Vec<DiscoveredModel>> {
+    let mut out = Vec::new();
+    if let Some(ep) = ollama_endpoint {
+        let d = OllamaDiscovery::new(ep);
+        match d.list_models().await {
+            Ok(mut v) => out.append(&mut v),
+            Err(e) => tracing::warn!(?e, "Ollama discovery failed"),
+        }
+    }
+    if let Some(ep) = omlx_base_url {
+        let d = OMlxDiscovery::new(ep);
+        match d.list_models().await {
+            Ok(mut v) => out.append(&mut v),
+            Err(e) => tracing::warn!(?e, "oMLX discovery failed"),
+        }
+    }
+    Ok(out)
+}
+
+/// Public entry point for production use. Wires runtime detection from
+/// `cmd/init_local.rs` to discovery endpoints.
+pub async fn run_all() -> anyhow::Result<Vec<DiscoveredModel>> {
+    let runtimes = crate::cmd::init_local::detect_local_runtimes();
+    let ollama = runtimes.ollama_running.then(|| "http://localhost:11434".to_string());
+    let omlx = runtimes.omlx_installed.then(|| "http://localhost:8000/v1".to_string());
+    run_all_inner(ollama, omlx).await
+}
+
+/// Test-only entry: caller passes endpoints directly.
+#[doc(hidden)]
+pub async fn run_all_for_test(
+    ollama_endpoint: Option<String>,
+    omlx_base_url: Option<String>,
+) -> anyhow::Result<Vec<DiscoveredModel>> {
+    run_all_inner(ollama_endpoint, omlx_base_url).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/mur-core/src/discovery/mod.rs
+++ b/mur-core/src/discovery/mod.rs
@@ -110,8 +110,12 @@ async fn run_all_inner(
 /// the environment.
 pub async fn run_all() -> anyhow::Result<Vec<DiscoveredModel>> {
     let runtimes = crate::cmd::init_local::detect_local_runtimes();
-    let ollama = runtimes.ollama_running.then(|| "http://localhost:11434".to_string());
-    let omlx = runtimes.omlx_installed.then(|| "http://localhost:8000/v1".to_string());
+    let ollama = runtimes
+        .ollama_running
+        .then(|| "http://localhost:11434".to_string());
+    let omlx = runtimes
+        .omlx_installed
+        .then(|| "http://localhost:8000/v1".to_string());
     run_all_inner(ollama, omlx, resolve_omlx_api_key()).await
 }
 
@@ -156,7 +160,10 @@ mod tests {
 
     #[test]
     fn embedding_probe_has_dims_and_latency() {
-        let p = EmbeddingProbe { dims: 1024, latency_ms: 120 };
+        let p = EmbeddingProbe {
+            dims: 1024,
+            latency_ms: 120,
+        };
         assert_eq!(p.dims, 1024);
         assert_eq!(p.latency_ms, 120);
     }

--- a/mur-core/src/discovery/mod.rs
+++ b/mur-core/src/discovery/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod cache;
 pub mod ollama;
+pub mod omlx;
 pub mod preference;
 
 use anyhow::Result;

--- a/mur-core/src/discovery/mod.rs
+++ b/mur-core/src/discovery/mod.rs
@@ -72,11 +72,20 @@ pub trait Discovery: Send + Sync {
 use crate::discovery::ollama::OllamaDiscovery;
 use crate::discovery::omlx::OMlxDiscovery;
 
+/// Resolve the oMLX API key from the environment. Recent oMLX versions
+/// require auth even on localhost (returns 401 with `{error: "API key
+/// required"}`). The convention is `OMLX_API_KEY` — anything from a real
+/// secret to "local" works depending on user's oMLX config.
+pub fn resolve_omlx_api_key() -> String {
+    std::env::var("OMLX_API_KEY").unwrap_or_default()
+}
+
 /// Run discovery against every endpoint that resolves; merge results.
 /// Backend-level failures are logged and dropped (non-fatal).
 async fn run_all_inner(
     ollama_endpoint: Option<String>,
     omlx_base_url: Option<String>,
+    omlx_api_key: String,
 ) -> anyhow::Result<Vec<DiscoveredModel>> {
     let mut out = Vec::new();
     if let Some(ep) = ollama_endpoint {
@@ -87,7 +96,7 @@ async fn run_all_inner(
         }
     }
     if let Some(ep) = omlx_base_url {
-        let d = OMlxDiscovery::new(ep);
+        let d = OMlxDiscovery::with_api_key(ep, omlx_api_key);
         match d.list_models().await {
             Ok(mut v) => out.append(&mut v),
             Err(e) => tracing::warn!(?e, "oMLX discovery failed"),
@@ -97,21 +106,23 @@ async fn run_all_inner(
 }
 
 /// Public entry point for production use. Wires runtime detection from
-/// `cmd/init_local.rs` to discovery endpoints.
+/// `cmd/init_local.rs` to discovery endpoints. Reads `OMLX_API_KEY` from
+/// the environment.
 pub async fn run_all() -> anyhow::Result<Vec<DiscoveredModel>> {
     let runtimes = crate::cmd::init_local::detect_local_runtimes();
     let ollama = runtimes.ollama_running.then(|| "http://localhost:11434".to_string());
     let omlx = runtimes.omlx_installed.then(|| "http://localhost:8000/v1".to_string());
-    run_all_inner(ollama, omlx).await
+    run_all_inner(ollama, omlx, resolve_omlx_api_key()).await
 }
 
-/// Test-only entry: caller passes endpoints directly.
+/// Test-only entry: caller passes endpoints directly. Defaults the oMLX
+/// API key to empty (no auth header sent — wiremock tests don't enforce auth).
 #[doc(hidden)]
 pub async fn run_all_for_test(
     ollama_endpoint: Option<String>,
     omlx_base_url: Option<String>,
 ) -> anyhow::Result<Vec<DiscoveredModel>> {
-    run_all_inner(ollama_endpoint, omlx_base_url).await
+    run_all_inner(ollama_endpoint, omlx_base_url, String::new()).await
 }
 
 #[cfg(test)]

--- a/mur-core/src/discovery/ollama.rs
+++ b/mur-core/src/discovery/ollama.rs
@@ -1,0 +1,156 @@
+//! `Discovery` impl for Ollama via REST API at `${endpoint}/api/{tags,show,embed}`.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::time::{Duration, Instant};
+
+use super::{Backend, Discovery, DiscoveredModel, EmbeddingProbe, ModelKind};
+
+#[derive(Debug, Clone)]
+pub struct OllamaDiscovery {
+    endpoint: String,
+    client: reqwest::Client,
+}
+
+impl OllamaDiscovery {
+    pub fn new(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(15))
+                .build()
+                .expect("reqwest client"),
+        }
+    }
+
+    fn url(&self, suffix: &str) -> String {
+        format!("{}{}", self.endpoint.trim_end_matches('/'), suffix)
+    }
+}
+
+#[derive(Deserialize)]
+struct TagsResp {
+    models: Vec<TagsEntry>,
+}
+
+#[derive(Deserialize)]
+struct TagsEntry {
+    name: String,
+    #[serde(default)]
+    size: Option<u64>,
+    #[serde(default)]
+    details: TagsDetails,
+}
+
+#[derive(Deserialize, Default)]
+struct TagsDetails {
+    #[serde(default)]
+    family: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+struct ShowResp {
+    #[serde(default)]
+    capabilities: Vec<String>,
+}
+
+/// Classify a model's kind from its `capabilities` array (authoritative) or,
+/// when absent, from a family + name heuristic (fallback for older Ollama).
+///
+/// Heuristic families:
+/// - `bert | nomic-bert | jina-bert` → Embedding
+/// - `qwen3` with name containing "embedding" → Embedding (disambiguation)
+/// - `qwen3 | llama | gemma` → Llm
+/// - anything else → Unknown
+fn classify(family: Option<&str>, name: &str, capabilities: &[String]) -> ModelKind {
+    if capabilities.iter().any(|c| c == "embedding") {
+        return ModelKind::Embedding;
+    }
+    if capabilities.iter().any(|c| c == "completion") {
+        return ModelKind::Llm;
+    }
+    // Fallback heuristic when /api/show fails or returns no capabilities.
+    match family {
+        Some(f) if matches!(f, "bert" | "nomic-bert" | "jina-bert") => ModelKind::Embedding,
+        Some("qwen3") if name.contains("embedding") => ModelKind::Embedding,
+        Some(f) if matches!(f, "qwen3" | "llama" | "gemma") => ModelKind::Llm,
+        _ => ModelKind::Unknown,
+    }
+}
+
+#[async_trait]
+impl Discovery for OllamaDiscovery {
+    fn backend(&self) -> Backend {
+        Backend::Ollama
+    }
+
+    async fn list_models(&self) -> Result<Vec<DiscoveredModel>> {
+        let resp = self
+            .client
+            .get(self.url("/api/tags"))
+            .send()
+            .await
+            .context("GET /api/tags")?;
+        let tags: TagsResp = resp.json().await.context("parse /api/tags")?;
+
+        let mut out = Vec::with_capacity(tags.models.len());
+        for entry in tags.models {
+            // /api/show may fail (500, network, etc.); fallback to heuristic.
+            let caps = match self
+                .client
+                .post(self.url("/api/show"))
+                .json(&serde_json::json!({ "name": entry.name }))
+                .send()
+                .await
+            {
+                Ok(r) if r.status().is_success() => {
+                    r.json::<ShowResp>().await.unwrap_or_default().capabilities
+                }
+                _ => Vec::new(),
+            };
+            let kind = classify(entry.details.family.as_deref(), &entry.name, &caps);
+            out.push(DiscoveredModel {
+                id: entry.name,
+                backend: Backend::Ollama,
+                kind,
+                dims: None,
+                family: entry.details.family,
+                size_bytes: entry.size,
+                probed_at: None,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn probe_embedding(&self, model_id: &str) -> Result<EmbeddingProbe> {
+        let started = Instant::now();
+        let resp = self
+            .client
+            .post(self.url("/api/embed"))
+            .json(&serde_json::json!({ "model": model_id, "input": "." }))
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .context("POST /api/embed probe")?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!("/api/embed returned {}", resp.status());
+        }
+
+        #[derive(Deserialize)]
+        struct EmbedResp {
+            embeddings: Vec<Vec<f32>>,
+        }
+
+        let er: EmbedResp = resp.json().await.context("parse /api/embed response")?;
+        let dims = er.embeddings.first().map(Vec::len).unwrap_or(0);
+        if dims == 0 {
+            anyhow::bail!("/api/embed returned empty embeddings");
+        }
+        Ok(EmbeddingProbe {
+            dims,
+            latency_ms: started.elapsed().as_millis() as u64,
+        })
+    }
+}

--- a/mur-core/src/discovery/ollama.rs
+++ b/mur-core/src/discovery/ollama.rs
@@ -7,6 +7,8 @@ use std::time::{Duration, Instant};
 
 use super::{Backend, Discovery, DiscoveredModel, EmbeddingProbe, ModelKind};
 
+const OLLAMA_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
 #[derive(Debug, Clone)]
 pub struct OllamaDiscovery {
     endpoint: String,
@@ -73,6 +75,9 @@ fn classify(family: Option<&str>, name: &str, capabilities: &[String]) -> ModelK
     // Fallback heuristic when /api/show fails or returns no capabilities.
     match family {
         Some("bert" | "nomic-bert" | "jina-bert") => ModelKind::Embedding,
+        // Ollama's qwen3-embedding GGUFs currently report family="bert" (BERT-style
+        // pooling). This arm is a forward-compat guard for future Ollama versions
+        // that may report family="qwen3" for embedding variants.
         Some("qwen3") if name.contains("embedding") => ModelKind::Embedding,
         Some("qwen3" | "llama" | "gemma") => ModelKind::Llm,
         _ => ModelKind::Unknown,
@@ -107,7 +112,13 @@ impl Discovery for OllamaDiscovery {
                 Ok(r) if r.status().is_success() => {
                     r.json::<ShowResp>().await.unwrap_or_default().capabilities
                 }
-                _ => Vec::new(),
+                _ => {
+                    tracing::debug!(
+                        model = %entry.name,
+                        "POST /api/show failed; falling back to family heuristic"
+                    );
+                    Vec::new()
+                }
             };
             let kind = classify(entry.details.family.as_deref(), &entry.name, &caps);
             out.push(DiscoveredModel {
@@ -129,13 +140,13 @@ impl Discovery for OllamaDiscovery {
             .client
             .post(self.url("/api/embed"))
             .json(&serde_json::json!({ "model": model_id, "input": "." }))
-            .timeout(Duration::from_secs(5))
+            .timeout(OLLAMA_PROBE_TIMEOUT)
             .send()
             .await
             .context("POST /api/embed probe")?;
 
         if !resp.status().is_success() {
-            anyhow::bail!("/api/embed returned {}", resp.status());
+            anyhow::bail!("/api/embed returned {} for model {:?}", resp.status(), model_id);
         }
 
         #[derive(Deserialize)]
@@ -146,11 +157,51 @@ impl Discovery for OllamaDiscovery {
         let er: EmbedResp = resp.json().await.context("parse /api/embed response")?;
         let dims = er.embeddings.first().map(Vec::len).unwrap_or(0);
         if dims == 0 {
-            anyhow::bail!("/api/embed returned empty embeddings");
+            anyhow::bail!("/api/embed returned empty embeddings for model {:?}", model_id);
         }
         Ok(EmbeddingProbe {
             dims,
             latency_ms: started.elapsed().as_millis() as u64,
         })
+    }
+}
+
+#[cfg(test)]
+mod classify_tests {
+    use super::{ModelKind, classify};
+
+    #[test]
+    fn capabilities_take_precedence_over_family() {
+        // family says "qwen3" (would otherwise be Llm), but capabilities says embedding.
+        let caps = vec!["embedding".to_string()];
+        assert_eq!(classify(Some("qwen3"), "qwen3.5:4b", &caps), ModelKind::Embedding);
+    }
+
+    #[test]
+    fn qwen3_with_embedding_in_name_is_embedding_when_capabilities_absent() {
+        // Forward-compat guard: future Ollama may report family="qwen3" for
+        // qwen3-embedding GGUFs. We rely on the name to disambiguate.
+        assert_eq!(
+            classify(Some("qwen3"), "qwen3-embedding:0.6b", &[]),
+            ModelKind::Embedding
+        );
+    }
+
+    #[test]
+    fn qwen3_without_embedding_in_name_is_llm() {
+        assert_eq!(classify(Some("qwen3"), "qwen3.5:4b", &[]), ModelKind::Llm);
+    }
+
+    #[test]
+    fn bert_family_is_embedding() {
+        assert_eq!(classify(Some("bert"), "anything", &[]), ModelKind::Embedding);
+        assert_eq!(classify(Some("nomic-bert"), "anything", &[]), ModelKind::Embedding);
+        assert_eq!(classify(Some("jina-bert"), "anything", &[]), ModelKind::Embedding);
+    }
+
+    #[test]
+    fn unknown_family_is_unknown() {
+        assert_eq!(classify(Some("weird-family"), "x", &[]), ModelKind::Unknown);
+        assert_eq!(classify(None, "x", &[]), ModelKind::Unknown);
     }
 }

--- a/mur-core/src/discovery/ollama.rs
+++ b/mur-core/src/discovery/ollama.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use std::time::{Duration, Instant};
 
-use super::{Backend, Discovery, DiscoveredModel, EmbeddingProbe, ModelKind};
+use super::{Backend, DiscoveredModel, Discovery, EmbeddingProbe, ModelKind};
 
 const OLLAMA_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -146,7 +146,11 @@ impl Discovery for OllamaDiscovery {
             .context("POST /api/embed probe")?;
 
         if !resp.status().is_success() {
-            anyhow::bail!("/api/embed returned {} for model {:?}", resp.status(), model_id);
+            anyhow::bail!(
+                "/api/embed returned {} for model {:?}",
+                resp.status(),
+                model_id
+            );
         }
 
         #[derive(Deserialize)]
@@ -157,7 +161,10 @@ impl Discovery for OllamaDiscovery {
         let er: EmbedResp = resp.json().await.context("parse /api/embed response")?;
         let dims = er.embeddings.first().map(Vec::len).unwrap_or(0);
         if dims == 0 {
-            anyhow::bail!("/api/embed returned empty embeddings for model {:?}", model_id);
+            anyhow::bail!(
+                "/api/embed returned empty embeddings for model {:?}",
+                model_id
+            );
         }
         Ok(EmbeddingProbe {
             dims,
@@ -174,7 +181,10 @@ mod classify_tests {
     fn capabilities_take_precedence_over_family() {
         // family says "qwen3" (would otherwise be Llm), but capabilities says embedding.
         let caps = vec!["embedding".to_string()];
-        assert_eq!(classify(Some("qwen3"), "qwen3.5:4b", &caps), ModelKind::Embedding);
+        assert_eq!(
+            classify(Some("qwen3"), "qwen3.5:4b", &caps),
+            ModelKind::Embedding
+        );
     }
 
     #[test]
@@ -194,9 +204,18 @@ mod classify_tests {
 
     #[test]
     fn bert_family_is_embedding() {
-        assert_eq!(classify(Some("bert"), "anything", &[]), ModelKind::Embedding);
-        assert_eq!(classify(Some("nomic-bert"), "anything", &[]), ModelKind::Embedding);
-        assert_eq!(classify(Some("jina-bert"), "anything", &[]), ModelKind::Embedding);
+        assert_eq!(
+            classify(Some("bert"), "anything", &[]),
+            ModelKind::Embedding
+        );
+        assert_eq!(
+            classify(Some("nomic-bert"), "anything", &[]),
+            ModelKind::Embedding
+        );
+        assert_eq!(
+            classify(Some("jina-bert"), "anything", &[]),
+            ModelKind::Embedding
+        );
     }
 
     #[test]

--- a/mur-core/src/discovery/ollama.rs
+++ b/mur-core/src/discovery/ollama.rs
@@ -72,9 +72,9 @@ fn classify(family: Option<&str>, name: &str, capabilities: &[String]) -> ModelK
     }
     // Fallback heuristic when /api/show fails or returns no capabilities.
     match family {
-        Some(f) if matches!(f, "bert" | "nomic-bert" | "jina-bert") => ModelKind::Embedding,
+        Some("bert" | "nomic-bert" | "jina-bert") => ModelKind::Embedding,
         Some("qwen3") if name.contains("embedding") => ModelKind::Embedding,
-        Some(f) if matches!(f, "qwen3" | "llama" | "gemma") => ModelKind::Llm,
+        Some("qwen3" | "llama" | "gemma") => ModelKind::Llm,
         _ => ModelKind::Unknown,
     }
 }

--- a/mur-core/src/discovery/omlx.rs
+++ b/mur-core/src/discovery/omlx.rs
@@ -18,17 +18,39 @@ pub(crate) const OMLX_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 #[derive(Debug, Clone)]
 pub struct OMlxDiscovery {
     base_url: String,
+    /// Bearer token for the `Authorization` header. Empty string means no
+    /// header is sent. oMLX in recent versions enforces auth even on
+    /// localhost (returns 401 with `{"error":{"message":"API key required",...}}`),
+    /// so this is required in practice — the env-var resolution lives in
+    /// `discovery::run_all` and `init.rs::select_local_embedding`.
+    api_key: String,
     client: reqwest::Client,
 }
 
 impl OMlxDiscovery {
     pub fn new(base_url: impl Into<String>) -> Self {
+        Self::with_api_key(base_url, String::new())
+    }
+
+    pub fn with_api_key(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
         Self {
             base_url: base_url.into(),
+            api_key: api_key.into(),
             client: reqwest::Client::builder()
                 .timeout(Duration::from_secs(15))
                 .build()
                 .expect("reqwest client"),
+        }
+    }
+
+    /// Apply the `Authorization: Bearer <key>` header to a request builder
+    /// when the api_key is non-empty. Helper to keep auth wiring DRY across
+    /// `list_models` and `probe_embedding`.
+    fn with_auth(&self, rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if self.api_key.is_empty() {
+            rb
+        } else {
+            rb.header("Authorization", format!("Bearer {}", self.api_key))
         }
     }
 
@@ -77,13 +99,31 @@ fn family_from_id(id: &str) -> Option<String> {
 // ── Wire types ──────────────────────────────────────────────────────────────
 
 #[derive(Deserialize)]
-struct ModelsResp {
-    data: Vec<ModelEntry>,
-}
-
-#[derive(Deserialize)]
 struct ModelEntry {
     id: String,
+}
+
+/// `/v1/models` response shape. oMLX has shipped multiple shapes across
+/// versions, so we accept several and pick the first that parses.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ModelsResp {
+    /// Strict OpenAI envelope: `{ "object": "list", "data": [{"id": ...}] }`.
+    OpenAi { data: Vec<ModelEntry> },
+    /// Ollama-style: `{ "models": [{"id": ...}] }`.
+    Ollama { models: Vec<ModelEntry> },
+    /// Bare array: `[{"id": ...}, ...]`.
+    Bare(Vec<ModelEntry>),
+}
+
+impl ModelsResp {
+    fn into_entries(self) -> Vec<ModelEntry> {
+        match self {
+            ModelsResp::OpenAi { data } => data,
+            ModelsResp::Ollama { models } => models,
+            ModelsResp::Bare(v) => v,
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -111,15 +151,36 @@ impl Discovery for OMlxDiscovery {
     /// user selects a model (or to populate the discovery menu).
     async fn list_models(&self) -> Result<Vec<DiscoveredModel>> {
         let resp = self
-            .client
-            .get(self.url("/v1/models"))
+            .with_auth(self.client.get(self.url("/v1/models")))
             .send()
             .await
             .context("GET /v1/models")?;
-        let mr: ModelsResp = resp.json().await.context("parse /v1/models")?;
+        let status = resp.status();
+        // Read the body once into a String so the multi-shape parse below
+        // can give a useful error message that includes the actual payload.
+        let body = resp.text().await.context("read /v1/models body")?;
+        if !status.is_success() {
+            if status == reqwest::StatusCode::UNAUTHORIZED {
+                anyhow::bail!(
+                    "GET /v1/models returned 401 — set OMLX_API_KEY to your oMLX API key (export OMLX_API_KEY=<key>). Body: {}",
+                    body.chars().take(200).collect::<String>()
+                );
+            }
+            anyhow::bail!(
+                "GET /v1/models returned {}: {}",
+                status,
+                body.chars().take(300).collect::<String>()
+            );
+        }
+        let mr: ModelsResp = serde_json::from_str(&body).with_context(|| {
+            format!(
+                "parse /v1/models — none of {{data:[]}} / {{models:[]}} / [{{}}] matched. Body: {}",
+                body.chars().take(300).collect::<String>()
+            )
+        })?;
 
         Ok(mr
-            .data
+            .into_entries()
             .into_iter()
             .map(|e| DiscoveredModel {
                 family: family_from_id(&e.id),
@@ -142,8 +203,7 @@ impl Discovery for OMlxDiscovery {
     async fn probe_embedding(&self, model_id: &str) -> Result<EmbeddingProbe> {
         let started = Instant::now();
         let resp = self
-            .client
-            .post(self.url("/v1/embeddings"))
+            .with_auth(self.client.post(self.url("/v1/embeddings")))
             .json(&serde_json::json!({ "model": model_id, "input": "." }))
             .timeout(OMLX_PROBE_TIMEOUT)
             .send()

--- a/mur-core/src/discovery/omlx.rs
+++ b/mur-core/src/discovery/omlx.rs
@@ -1,0 +1,191 @@
+//! `Discovery` impl for oMLX via OpenAI-compatible REST API at
+//! `${base_url}/v1/{models,embeddings}`. oMLX serves on `localhost:8000`
+//! by default.
+//!
+//! See `docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md` § 2.3.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::time::{Duration, Instant};
+
+use super::{Backend, Discovery, DiscoveredModel, EmbeddingProbe, ModelKind};
+
+/// oMLX issue #266: graph recompiles on first call after >3s idle. Budget
+/// 10s for the probe; subsequent probes settle to <500ms.
+pub const OMLX_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Clone)]
+pub struct OMlxDiscovery {
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl OMlxDiscovery {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(15))
+                .build()
+                .expect("reqwest client"),
+        }
+    }
+
+    /// Build a URL from a `/v1/...` suffix.
+    ///
+    /// Handles the case where `base_url` already ends in `/v1` (e.g.
+    /// `http://localhost:8000/v1`) to avoid producing a doubled `/v1/v1/…`
+    /// path. Trailing slashes on `base_url` are stripped first.
+    fn url(&self, suffix: &str) -> String {
+        let trimmed = self.base_url.trim_end_matches('/');
+        // If base_url already ends in "/v1" and suffix starts with "/v1",
+        // strip the leading "/v1" from suffix to avoid duplication.
+        if trimmed.ends_with("/v1") && suffix.starts_with("/v1") {
+            format!("{}{}", trimmed, &suffix[3..])
+        } else {
+            format!("{}{}", trimmed, suffix)
+        }
+    }
+}
+
+/// Infer a family string from an oMLX model id.
+///
+/// oMLX /v1/models returns flat HF-style ids (e.g.
+/// `mlx-community/Qwen3-Embedding-0.6B-8bit`). This heuristic covers the
+/// models in the mlx-embeddings registry as of May 2026.
+///
+/// Private — callers observe the result through `DiscoveredModel.family`.
+fn family_from_id(id: &str) -> Option<String> {
+    let lower = id.to_ascii_lowercase();
+    if lower.contains("qwen3") {
+        Some("qwen3".into())
+    } else if lower.contains("bge-") || lower.contains("bge_") {
+        Some("bge".into())
+    } else if lower.contains("modernbert") {
+        Some("modernbert".into())
+    } else if lower.contains("nomic") {
+        Some("nomic-bert".into())
+    } else if lower.contains("jina") {
+        Some("jina-bert".into())
+    } else {
+        None
+    }
+}
+
+// ── Wire types ──────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ModelsResp {
+    data: Vec<ModelEntry>,
+}
+
+#[derive(Deserialize)]
+struct ModelEntry {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct EmbedResp {
+    data: Vec<EmbedData>,
+}
+
+#[derive(Deserialize)]
+struct EmbedData {
+    embedding: Vec<f32>,
+}
+
+// ── Discovery impl ───────────────────────────────────────────────────────────
+
+#[async_trait]
+impl Discovery for OMlxDiscovery {
+    fn backend(&self) -> Backend {
+        Backend::OMlx
+    }
+
+    /// List all models loaded in oMLX.
+    ///
+    /// oMLX's `/v1/models` has no `type` field — every entry comes back with
+    /// `kind = Unknown`. Call `probe_embedding` to discriminate after the
+    /// user selects a model (or to populate the discovery menu).
+    async fn list_models(&self) -> Result<Vec<DiscoveredModel>> {
+        let resp = self
+            .client
+            .get(self.url("/v1/models"))
+            .send()
+            .await
+            .context("GET /v1/models")?;
+        let mr: ModelsResp = resp.json().await.context("parse /v1/models")?;
+
+        Ok(mr
+            .data
+            .into_iter()
+            .map(|e| DiscoveredModel {
+                family: family_from_id(&e.id),
+                id: e.id,
+                backend: Backend::OMlx,
+                // /v1/models carries no type discriminator; probing resolves this.
+                kind: ModelKind::Unknown,
+                dims: None,
+                size_bytes: None,
+                probed_at: None,
+            })
+            .collect())
+    }
+
+    /// Issue a 1-token `POST /v1/embeddings` to confirm the model supports
+    /// embeddings and learn the output dimension.
+    ///
+    /// Uses `OMLX_PROBE_TIMEOUT` (10s) to accommodate oMLX issue #266's
+    /// first-call graph-recompile latency spike.
+    async fn probe_embedding(&self, model_id: &str) -> Result<EmbeddingProbe> {
+        let started = Instant::now();
+        let resp = self
+            .client
+            .post(self.url("/v1/embeddings"))
+            .json(&serde_json::json!({ "model": model_id, "input": "." }))
+            .timeout(OMLX_PROBE_TIMEOUT)
+            .send()
+            .await
+            .with_context(|| format!("POST /v1/embeddings probe for model {:?}", model_id))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            tracing::debug!(
+                model_id = %model_id,
+                %status,
+                body = %body,
+                "oMLX probe_embedding failed"
+            );
+            anyhow::bail!(
+                "/v1/embeddings returned {} for model {:?}: {}",
+                status,
+                model_id,
+                body
+            );
+        }
+
+        let er: EmbedResp = resp
+            .json()
+            .await
+            .with_context(|| format!("parse /v1/embeddings response for model {:?}", model_id))?;
+
+        let dims = er.data.first().map(|d| d.embedding.len()).unwrap_or(0);
+        if dims == 0 {
+            tracing::debug!(
+                model_id = %model_id,
+                "/v1/embeddings returned empty data array for model"
+            );
+            anyhow::bail!(
+                "/v1/embeddings returned empty data array for model {:?}",
+                model_id
+            );
+        }
+
+        Ok(EmbeddingProbe {
+            dims,
+            latency_ms: started.elapsed().as_millis() as u64,
+        })
+    }
+}

--- a/mur-core/src/discovery/omlx.rs
+++ b/mur-core/src/discovery/omlx.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use std::time::{Duration, Instant};
 
-use super::{Backend, Discovery, DiscoveredModel, EmbeddingProbe, ModelKind};
+use super::{Backend, DiscoveredModel, Discovery, EmbeddingProbe, ModelKind};
 
 /// oMLX issue #266: graph recompiles on first call after >3s idle. Budget
 /// 10s for the probe; subsequent probes settle to <500ms.

--- a/mur-core/src/discovery/omlx.rs
+++ b/mur-core/src/discovery/omlx.rs
@@ -13,7 +13,7 @@ use super::{Backend, Discovery, DiscoveredModel, EmbeddingProbe, ModelKind};
 
 /// oMLX issue #266: graph recompiles on first call after >3s idle. Budget
 /// 10s for the probe; subsequent probes settle to <500ms.
-pub const OMLX_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const OMLX_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone)]
 pub struct OMlxDiscovery {
@@ -39,13 +39,14 @@ impl OMlxDiscovery {
     /// path. Trailing slashes on `base_url` are stripped first.
     fn url(&self, suffix: &str) -> String {
         let trimmed = self.base_url.trim_end_matches('/');
-        // If base_url already ends in "/v1" and suffix starts with "/v1",
-        // strip the leading "/v1" from suffix to avoid duplication.
-        if trimmed.ends_with("/v1") && suffix.starts_with("/v1") {
-            format!("{}{}", trimmed, &suffix[3..])
+        // If base_url already ends in "/v1", strip the leading "/v1" from
+        // suffix so we don't produce a doubled "/v1/v1/...".
+        let suffix = if trimmed.ends_with("/v1") {
+            suffix.strip_prefix("/v1").unwrap_or(suffix)
         } else {
-            format!("{}{}", trimmed, suffix)
-        }
+            suffix
+        };
+        format!("{}{}", trimmed, suffix)
     }
 }
 
@@ -187,5 +188,65 @@ impl Discovery for OMlxDiscovery {
             dims,
             latency_ms: started.elapsed().as_millis() as u64,
         })
+    }
+}
+
+#[cfg(test)]
+mod family_tests {
+    use super::family_from_id;
+
+    #[test]
+    fn qwen3_variants() {
+        assert_eq!(
+            family_from_id("mlx-community/Qwen3-Embedding-0.6B-8bit"),
+            Some("qwen3".into())
+        );
+        assert_eq!(
+            family_from_id("Qwen3-Embedding-8B-4bit-DWQ"),
+            Some("qwen3".into())
+        );
+    }
+
+    #[test]
+    fn bge_dash_or_underscore() {
+        assert_eq!(family_from_id("mlx-community/bge-m3"), Some("bge".into()));
+        assert_eq!(family_from_id("BAAI/bge_large"), Some("bge".into()));
+    }
+
+    #[test]
+    fn modernbert_family() {
+        assert_eq!(
+            family_from_id("lightonai/modernbert-embed-large"),
+            Some("modernbert".into())
+        );
+    }
+
+    #[test]
+    fn nomic_family() {
+        assert_eq!(
+            family_from_id("nomic-ai/nomic-embed-text-v1.5"),
+            Some("nomic-bert".into())
+        );
+    }
+
+    #[test]
+    fn jina_family() {
+        assert_eq!(
+            family_from_id("jinaai/jina-embeddings-v3"),
+            Some("jina-bert".into())
+        );
+    }
+
+    #[test]
+    fn unknown_id_returns_none() {
+        assert_eq!(family_from_id("unknown/foo"), None);
+        assert_eq!(family_from_id(""), None);
+    }
+
+    #[test]
+    fn case_insensitive_via_lowercase() {
+        // family_from_id calls to_ascii_lowercase first, so capitalized
+        // tags like "Qwen3" still match.
+        assert_eq!(family_from_id("Some/QWEN3-Whatever"), Some("qwen3".into()));
     }
 }

--- a/mur-core/src/discovery/preference.rs
+++ b/mur-core/src/discovery/preference.rs
@@ -1,0 +1,108 @@
+//! Static prefix-matched preference tables for picking the "best" model
+//! to recommend when multiple are available locally. Future-proof against
+//! new tags via prefix matching.
+
+/// Ordered preference for embedding models, descending by score.
+/// Both Ollama tag form (`name:size`) and HuggingFace id form
+/// (`mlx-community/Foo`) appear at equal score.
+pub const EMBEDDING_PREFERENCE: &[(&str, u32)] = &[
+    ("qwen3.5-embedding",       105),  // future-proof
+    ("Qwen3-Embedding-8B",      100),
+    ("qwen3-embedding:8b",      100),
+    ("Qwen3-Embedding-4B",       90),
+    ("qwen3-embedding:4b",       90),
+    ("bge-m3",                   80),
+    ("jina-embeddings-v3",       75),
+    ("Qwen3-Embedding-0.6B",     70),
+    ("qwen3-embedding:0.6b",     70),
+    ("embeddinggemma",           55),
+    ("nomic-embed-text",         40),
+    ("all-minilm",               20),
+];
+
+/// Ordered preference for chat / completion LLMs (Mode 3 only).
+/// Aligned with the curated picks in `cmd/init_local.rs::OLLAMA_RECS` /
+/// `MLX_RECS`. Multilingual-first ordering.
+pub const LLM_PREFERENCE: &[(&str, u32)] = &[
+    ("Qwen3.5-9B",                95),
+    ("qwen3.5:9b",                95),
+    ("Qwen3.5-4B",                90),
+    ("qwen3.5:4b",                90),
+    ("Gemma4-E2B",                85),
+    ("gemma4:e2b",                85),
+    ("Qwen3-9B",                  70),
+    ("qwen3:9b",                  70),
+    ("Qwen3-4B",                  65),
+    ("qwen3:4b",                  65),
+    ("llama3.3",                  60),
+];
+
+/// Highest-scoring prefix that is a substring of `id`. Returns 0 when no
+/// prefix matches. Case-sensitive — both Ollama (`qwen3-embedding:0.6b`)
+/// and HF (`Qwen3-Embedding-0.6B`) forms must appear in the table.
+pub fn rank(id: &str, table: &[(&'static str, u32)]) -> u32 {
+    table
+        .iter()
+        .filter(|(prefix, _)| id.contains(prefix))
+        .map(|(_, score)| *score)
+        .max()
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ollama_tag_form_ranked() {
+        assert_eq!(rank("qwen3-embedding:0.6b", EMBEDDING_PREFERENCE), 70);
+        assert_eq!(rank("qwen3-embedding:8b", EMBEDDING_PREFERENCE), 100);
+        assert_eq!(rank("bge-m3", EMBEDDING_PREFERENCE), 80);
+    }
+
+    #[test]
+    fn hf_id_form_ranked() {
+        assert_eq!(
+            rank("mlx-community/Qwen3-Embedding-0.6B-8bit", EMBEDDING_PREFERENCE),
+            70
+        );
+        assert_eq!(
+            rank("mlx-community/Qwen3-Embedding-8B-4bit-DWQ", EMBEDDING_PREFERENCE),
+            100
+        );
+    }
+
+    #[test]
+    fn unknown_id_returns_zero() {
+        assert_eq!(rank("randomuser/foo-base", EMBEDDING_PREFERENCE), 0);
+        assert_eq!(rank("", EMBEDDING_PREFERENCE), 0);
+    }
+
+    #[test]
+    fn future_qwen35_embedding_wins() {
+        // When Alibaba ships qwen3.5-embedding, the prefix table should pick
+        // it over current SOTA without any code change.
+        assert_eq!(
+            rank("qwen3.5-embedding:0.6b", EMBEDDING_PREFERENCE),
+            105
+        );
+        assert!(
+            rank("qwen3.5-embedding:0.6b", EMBEDDING_PREFERENCE)
+                > rank("qwen3-embedding:8b", EMBEDDING_PREFERENCE)
+        );
+    }
+
+    #[test]
+    fn llm_table_separate() {
+        assert_eq!(rank("qwen3.5:9b", LLM_PREFERENCE), 95);
+        assert_eq!(rank("qwen3.5:9b", EMBEDDING_PREFERENCE), 0); // not in embedding table
+    }
+
+    #[test]
+    fn case_sensitive_distinguishes_forms() {
+        // The two forms are distinct entries at the same score; rank is the
+        // max of all matching prefixes, so a string matching either is fine.
+        assert_eq!(rank("Qwen3-Embedding-8B", EMBEDDING_PREFERENCE), 100);
+        assert_eq!(rank("qwen3-embedding:8b", EMBEDDING_PREFERENCE), 100);
+    }
+}

--- a/mur-core/src/discovery/preference.rs
+++ b/mur-core/src/discovery/preference.rs
@@ -6,35 +6,35 @@
 /// Both Ollama tag form (`name:size`) and HuggingFace id form
 /// (`mlx-community/Foo`) appear at equal score.
 pub const EMBEDDING_PREFERENCE: &[(&str, u32)] = &[
-    ("qwen3.5-embedding",       105),  // future-proof
-    ("Qwen3-Embedding-8B",      100),
-    ("qwen3-embedding:8b",      100),
-    ("Qwen3-Embedding-4B",       90),
-    ("qwen3-embedding:4b",       90),
-    ("bge-m3",                   80),
-    ("jina-embeddings-v3",       75),
-    ("Qwen3-Embedding-0.6B",     70),
-    ("qwen3-embedding:0.6b",     70),
-    ("embeddinggemma",           55),
-    ("nomic-embed-text",         40),
-    ("all-minilm",               20),
+    ("qwen3.5-embedding", 105), // future-proof
+    ("Qwen3-Embedding-8B", 100),
+    ("qwen3-embedding:8b", 100),
+    ("Qwen3-Embedding-4B", 90),
+    ("qwen3-embedding:4b", 90),
+    ("bge-m3", 80),
+    ("jina-embeddings-v3", 75),
+    ("Qwen3-Embedding-0.6B", 70),
+    ("qwen3-embedding:0.6b", 70),
+    ("embeddinggemma", 55),
+    ("nomic-embed-text", 40),
+    ("all-minilm", 20),
 ];
 
 /// Ordered preference for chat / completion LLMs (Mode 3 only).
 /// Aligned with the curated picks in `cmd/init_local.rs::OLLAMA_RECS` /
 /// `MLX_RECS`. Multilingual-first ordering.
 pub const LLM_PREFERENCE: &[(&str, u32)] = &[
-    ("Qwen3.5-9B",                95),
-    ("qwen3.5:9b",                95),
-    ("Qwen3.5-4B",                90),
-    ("qwen3.5:4b",                90),
-    ("Gemma4-E2B",                85),
-    ("gemma4:e2b",                85),
-    ("Qwen3-9B",                  70),
-    ("qwen3:9b",                  70),
-    ("Qwen3-4B",                  65),
-    ("qwen3:4b",                  65),
-    ("llama3.3",                  60),
+    ("Qwen3.5-9B", 95),
+    ("qwen3.5:9b", 95),
+    ("Qwen3.5-4B", 90),
+    ("qwen3.5:4b", 90),
+    ("Gemma4-E2B", 85),
+    ("gemma4:e2b", 85),
+    ("Qwen3-9B", 70),
+    ("qwen3:9b", 70),
+    ("Qwen3-4B", 65),
+    ("qwen3:4b", 65),
+    ("llama3.3", 60),
 ];
 
 /// Highest-scoring prefix that is a substring of `id`. Returns 0 when no
@@ -63,11 +63,17 @@ mod tests {
     #[test]
     fn hf_id_form_ranked() {
         assert_eq!(
-            rank("mlx-community/Qwen3-Embedding-0.6B-8bit", EMBEDDING_PREFERENCE),
+            rank(
+                "mlx-community/Qwen3-Embedding-0.6B-8bit",
+                EMBEDDING_PREFERENCE
+            ),
             70
         );
         assert_eq!(
-            rank("mlx-community/Qwen3-Embedding-8B-4bit-DWQ", EMBEDDING_PREFERENCE),
+            rank(
+                "mlx-community/Qwen3-Embedding-8B-4bit-DWQ",
+                EMBEDDING_PREFERENCE
+            ),
             100
         );
     }
@@ -82,10 +88,7 @@ mod tests {
     fn future_qwen35_embedding_wins() {
         // When Alibaba ships qwen3.5-embedding, the prefix table should pick
         // it over current SOTA without any code change.
-        assert_eq!(
-            rank("qwen3.5-embedding:0.6b", EMBEDDING_PREFERENCE),
-            105
-        );
+        assert_eq!(rank("qwen3.5-embedding:0.6b", EMBEDDING_PREFERENCE), 105);
         assert!(
             rank("qwen3.5-embedding:0.6b", EMBEDDING_PREFERENCE)
                 > rank("qwen3-embedding:8b", EMBEDDING_PREFERENCE)

--- a/mur-core/src/discovery/preference.rs
+++ b/mur-core/src/discovery/preference.rs
@@ -40,7 +40,7 @@ pub const LLM_PREFERENCE: &[(&str, u32)] = &[
 /// Highest-scoring prefix that is a substring of `id`. Returns 0 when no
 /// prefix matches. Case-sensitive — both Ollama (`qwen3-embedding:0.6b`)
 /// and HF (`Qwen3-Embedding-0.6B`) forms must appear in the table.
-pub fn rank(id: &str, table: &[(&'static str, u32)]) -> u32 {
+pub fn rank(id: &str, table: &[(&str, u32)]) -> u32 {
     table
         .iter()
         .filter(|(prefix, _)| id.contains(prefix))

--- a/mur-core/src/lib.rs
+++ b/mur-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod community;
 pub mod context_api;
 pub mod conversations;
 pub mod dashboard;
+pub mod discovery;
 pub mod evolve;
 pub mod executor;
 pub mod extract;

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -1601,7 +1601,10 @@ async fn async_main() -> Result<()> {
         },
         Commands::Login => cmd::misc::cmd_login().await?,
         Commands::Logout => cmd::misc::cmd_logout()?,
-        Commands::Init { hooks, refresh_discovery } => cmd::init::cmd_init(hooks, refresh_discovery)?,
+        Commands::Init {
+            hooks,
+            refresh_discovery,
+        } => cmd::init::cmd_init(hooks, refresh_discovery)?,
         Commands::Serve {
             port,
             open,

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -15,6 +15,10 @@ mod context_api;
 mod conversations;
 mod daemon;
 mod dashboard;
+// Discovery items (cache constants, LLM preference table, test-only fns) are
+// defined for library consumers and tests; the binary only uses a subset.
+#[allow(dead_code)]
+mod discovery;
 mod evolve;
 mod executor;
 mod extract;
@@ -268,6 +272,9 @@ enum Commands {
         /// Install hooks for detected AI tools
         #[arg(long)]
         hooks: bool,
+        /// Bust the discovery cache and re-probe runtimes before init
+        #[arg(long)]
+        refresh_discovery: bool,
     },
     /// Start local API server for web dashboard
     Serve {
@@ -1594,7 +1601,7 @@ async fn async_main() -> Result<()> {
         },
         Commands::Login => cmd::misc::cmd_login().await?,
         Commands::Logout => cmd::misc::cmd_logout()?,
-        Commands::Init { hooks } => cmd::init::cmd_init(hooks)?,
+        Commands::Init { hooks, refresh_discovery } => cmd::init::cmd_init(hooks, refresh_discovery)?,
         Commands::Serve {
             port,
             open,

--- a/mur-core/tests/discovery_ollama.rs
+++ b/mur-core/tests/discovery_ollama.rs
@@ -21,10 +21,12 @@ async fn list_models_marks_capabilities_embedding_as_embedding_kind() {
 
     Mock::given(method("GET"))
         .and(path("/api/tags"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(tags_response_with(vec![
-            ("qwen3-embedding:0.6b", "bert", 700_000_000),
-            ("qwen3.5:4b", "qwen3", 4_000_000_000),
-        ])))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(tags_response_with(vec![
+                ("qwen3-embedding:0.6b", "bert", 700_000_000),
+                ("qwen3.5:4b", "qwen3", 4_000_000_000),
+            ])),
+        )
         .mount(&server)
         .await;
 
@@ -50,7 +52,10 @@ async fn list_models_marks_capabilities_embedding_as_embedding_kind() {
     let models = d.list_models().await.unwrap();
 
     assert_eq!(models.len(), 2);
-    let emb = models.iter().find(|m| m.id == "qwen3-embedding:0.6b").unwrap();
+    let emb = models
+        .iter()
+        .find(|m| m.id == "qwen3-embedding:0.6b")
+        .unwrap();
     assert_eq!(emb.kind, ModelKind::Embedding);
     assert_eq!(emb.family.as_deref(), Some("bert"));
 
@@ -64,9 +69,13 @@ async fn list_models_falls_back_to_family_when_capabilities_absent() {
 
     Mock::given(method("GET"))
         .and(path("/api/tags"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(tags_response_with(vec![
-            ("nomic-embed-text:latest", "nomic-bert", 300_000_000),
-        ])))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(tags_response_with(vec![(
+                "nomic-embed-text:latest",
+                "nomic-bert",
+                300_000_000,
+            )])),
+        )
         .mount(&server)
         .await;
 
@@ -88,9 +97,13 @@ async fn list_models_marks_unreachable_show_as_unknown() {
 
     Mock::given(method("GET"))
         .and(path("/api/tags"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(tags_response_with(vec![
-            ("foo:bar", "weird-family", 100),
-        ])))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(tags_response_with(vec![(
+                "foo:bar",
+                "weird-family",
+                100,
+            )])),
+        )
         .mount(&server)
         .await;
 

--- a/mur-core/tests/discovery_ollama.rs
+++ b/mur-core/tests/discovery_ollama.rs
@@ -1,0 +1,106 @@
+//! Wiremock-backed integration tests for OllamaDiscovery.
+
+use mur_core::discovery::{Discovery, ModelKind, ollama::OllamaDiscovery};
+use serde_json::json;
+use wiremock::matchers::{body_json_string, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn tags_response_with(models: Vec<(&str, &str, u64)>) -> serde_json::Value {
+    json!({
+        "models": models.iter().map(|(name, family, size)| json!({
+            "name": name,
+            "size": size,
+            "details": { "family": family }
+        })).collect::<Vec<_>>()
+    })
+}
+
+#[tokio::test]
+async fn list_models_marks_capabilities_embedding_as_embedding_kind() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/tags"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tags_response_with(vec![
+            ("qwen3-embedding:0.6b", "bert", 700_000_000),
+            ("qwen3.5:4b", "qwen3", 4_000_000_000),
+        ])))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/show"))
+        .and(body_json_string(r#"{"name":"qwen3-embedding:0.6b"}"#))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "capabilities": ["embedding"]
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/show"))
+        .and(body_json_string(r#"{"name":"qwen3.5:4b"}"#))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "capabilities": ["completion"]
+        })))
+        .mount(&server)
+        .await;
+
+    let d = OllamaDiscovery::new(server.uri());
+    let models = d.list_models().await.unwrap();
+
+    assert_eq!(models.len(), 2);
+    let emb = models.iter().find(|m| m.id == "qwen3-embedding:0.6b").unwrap();
+    assert_eq!(emb.kind, ModelKind::Embedding);
+    assert_eq!(emb.family.as_deref(), Some("bert"));
+
+    let llm = models.iter().find(|m| m.id == "qwen3.5:4b").unwrap();
+    assert_eq!(llm.kind, ModelKind::Llm);
+}
+
+#[tokio::test]
+async fn list_models_falls_back_to_family_when_capabilities_absent() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/tags"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tags_response_with(vec![
+            ("nomic-embed-text:latest", "nomic-bert", 300_000_000),
+        ])))
+        .mount(&server)
+        .await;
+
+    // /api/show returns no capabilities field → fallback path
+    Mock::given(method("POST"))
+        .and(path("/api/show"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&server)
+        .await;
+
+    let d = OllamaDiscovery::new(server.uri());
+    let models = d.list_models().await.unwrap();
+    assert_eq!(models[0].kind, ModelKind::Embedding);
+}
+
+#[tokio::test]
+async fn list_models_marks_unreachable_show_as_unknown() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/tags"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tags_response_with(vec![
+            ("foo:bar", "weird-family", 100),
+        ])))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/show"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let d = OllamaDiscovery::new(server.uri());
+    let models = d.list_models().await.unwrap();
+    assert_eq!(models[0].kind, ModelKind::Unknown);
+}

--- a/mur-core/tests/discovery_ollama.rs
+++ b/mur-core/tests/discovery_ollama.rs
@@ -104,3 +104,35 @@ async fn list_models_marks_unreachable_show_as_unknown() {
     let models = d.list_models().await.unwrap();
     assert_eq!(models[0].kind, ModelKind::Unknown);
 }
+
+#[tokio::test]
+async fn probe_embedding_returns_dims_and_latency() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/embed"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "embeddings": [vec![0.0f32; 1024]]
+        })))
+        .mount(&server)
+        .await;
+
+    let d = OllamaDiscovery::new(server.uri());
+    let probe = d.probe_embedding("qwen3-embedding:0.6b").await.unwrap();
+    assert_eq!(probe.dims, 1024);
+}
+
+#[tokio::test]
+async fn probe_embedding_errors_on_4xx() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/embed"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let d = OllamaDiscovery::new(server.uri());
+    let r = d.probe_embedding("missing").await;
+    assert!(r.is_err());
+}

--- a/mur-core/tests/discovery_omlx.rs
+++ b/mur-core/tests/discovery_omlx.rs
@@ -159,16 +159,13 @@ async fn probe_embedding_4xx_errors() {
     Mock::given(method("POST"))
         .and(path("/v1/embeddings"))
         .respond_with(
-            ResponseTemplate::new(400)
-                .set_body_string("model does not support embeddings"),
+            ResponseTemplate::new(400).set_body_string("model does not support embeddings"),
         )
         .mount(&server)
         .await;
 
     let d = OMlxDiscovery::new(server.uri());
-    let r = d
-        .probe_embedding("mlx-community/Qwen3.5-4B-4bit")
-        .await;
+    let r = d.probe_embedding("mlx-community/Qwen3.5-4B-4bit").await;
     assert!(r.is_err());
     assert!(r.unwrap_err().to_string().contains("400"));
 }

--- a/mur-core/tests/discovery_omlx.rs
+++ b/mur-core/tests/discovery_omlx.rs
@@ -1,0 +1,153 @@
+//! Wiremock-backed integration tests for OMlxDiscovery.
+
+use mur_core::discovery::{Discovery, ModelKind, omlx::OMlxDiscovery};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ── 4.1 tests ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_models_returns_unknown_kind_pre_probe() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [
+                {"id": "mlx-community/Qwen3-Embedding-0.6B-8bit"},
+                {"id": "mlx-community/Qwen3.5-4B-4bit"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri());
+    let models = d.list_models().await.unwrap();
+    assert_eq!(models.len(), 2);
+    // /v1/models has no type discriminator — kind is Unknown until probed.
+    assert!(models.iter().all(|m| m.kind == ModelKind::Unknown));
+    // Family is inferred from the id substring.
+    assert_eq!(
+        models
+            .iter()
+            .find(|m| m.id.contains("Qwen3-Embedding"))
+            .unwrap()
+            .family
+            .as_deref(),
+        Some("qwen3")
+    );
+}
+
+// ── 4.2 tests ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn probe_embedding_happy_path() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{"embedding": vec![0.0f32; 1024]}]
+        })))
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri());
+    let p = d
+        .probe_embedding("mlx-community/Qwen3-Embedding-0.6B-8bit")
+        .await
+        .unwrap();
+    assert_eq!(p.dims, 1024);
+}
+
+#[tokio::test]
+async fn probe_embedding_4xx_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(
+            ResponseTemplate::new(400)
+                .set_body_string("model does not support embeddings"),
+        )
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri());
+    let r = d
+        .probe_embedding("mlx-community/Qwen3.5-4B-4bit")
+        .await;
+    assert!(r.is_err());
+    assert!(r.unwrap_err().to_string().contains("400"));
+}
+
+#[tokio::test]
+async fn probe_embedding_empty_array_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"data": []})))
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri());
+    assert!(d.probe_embedding("foo").await.is_err());
+}
+
+/// Verify that `list_models` infers the correct family from each model id.
+///
+/// `family_from_id` is private; we test it indirectly by inspecting the
+/// `family` field on the returned `DiscoveredModel` values.
+#[tokio::test]
+async fn list_models_infers_family_from_id() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [
+                {"id": "mlx-community/bge-m3"},
+                {"id": "lightonai/modernbert-embed-large"},
+                {"id": "mlx-community/Qwen3-Embedding-0.6B-8bit"},
+                {"id": "nomic-ai/nomic-embed-text-v1.5"},
+                {"id": "jinaai/jina-embeddings-v3"},
+                {"id": "unknown/foo"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri());
+    let models = d.list_models().await.unwrap();
+
+    let family_of = |id: &str| {
+        models
+            .iter()
+            .find(|m| m.id == id)
+            .unwrap()
+            .family
+            .as_deref()
+            .map(str::to_string)
+    };
+
+    assert_eq!(family_of("mlx-community/bge-m3"), Some("bge".into()));
+    assert_eq!(
+        family_of("lightonai/modernbert-embed-large"),
+        Some("modernbert".into())
+    );
+    assert_eq!(
+        family_of("mlx-community/Qwen3-Embedding-0.6B-8bit"),
+        Some("qwen3".into())
+    );
+    assert_eq!(
+        family_of("nomic-ai/nomic-embed-text-v1.5"),
+        Some("nomic-bert".into())
+    );
+    assert_eq!(
+        family_of("jinaai/jina-embeddings-v3"),
+        Some("jina-bert".into())
+    );
+    assert_eq!(family_of("unknown/foo"), None);
+}

--- a/mur-core/tests/discovery_omlx.rs
+++ b/mur-core/tests/discovery_omlx.rs
@@ -39,6 +39,97 @@ async fn list_models_returns_unknown_kind_pre_probe() {
     );
 }
 
+/// Regression: oMLX has shipped multiple `/v1/models` response shapes
+/// across versions. The parser must accept the OpenAI envelope, the
+/// Ollama-style `{models:[]}`, and a bare array. This test caught a real
+/// failure where a user's oMLX returned a non-`data` shape and the
+/// parser bailed with "missing field `data`".
+#[tokio::test]
+async fn list_models_accepts_ollama_style_models_envelope() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "models": [
+                {"id": "mlx-community/Qwen3-Embedding-0.6B-8bit"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri());
+    let models = d.list_models().await.unwrap();
+    assert_eq!(models.len(), 1);
+    assert_eq!(models[0].id, "mlx-community/Qwen3-Embedding-0.6B-8bit");
+}
+
+#[tokio::test]
+async fn list_models_accepts_bare_array() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {"id": "foo"},
+            {"id": "bar"}
+        ])))
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri());
+    let models = d.list_models().await.unwrap();
+    assert_eq!(models.len(), 2);
+}
+
+/// Regression: real-world oMLX returns 401 on `/v1/models` when an API key
+/// isn't sent. `OMlxDiscovery::with_api_key` must include
+/// `Authorization: Bearer <key>` on requests, and the 401 path must surface
+/// a helpful "set OMLX_API_KEY" message.
+#[tokio::test]
+async fn list_models_sends_authorization_header() {
+    use wiremock::matchers::header;
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .and(header("Authorization", "Bearer secret-key-david"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{"id": "mlx-community/Qwen3-Embedding-0.6B-8bit"}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::with_api_key(server.uri(), "secret-key-david");
+    let models = d.list_models().await.unwrap();
+    assert_eq!(models.len(), 1);
+}
+
+#[tokio::test]
+async fn list_models_401_surfaces_omlx_api_key_hint() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "error": {
+                "message": "API key required",
+                "type": "authentication_error",
+                "param": null,
+                "code": null
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let d = OMlxDiscovery::new(server.uri()); // no api key
+    let r = d.list_models().await;
+    assert!(r.is_err());
+    let err_str = format!("{:#}", r.unwrap_err());
+    assert!(
+        err_str.contains("OMLX_API_KEY"),
+        "401 error must hint at OMLX_API_KEY env var; got: {}",
+        err_str
+    );
+}
+
 // ── 4.2 tests ────────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/mur-core/tests/discovery_run_all.rs
+++ b/mur-core/tests/discovery_run_all.rs
@@ -1,0 +1,71 @@
+use mur_core::discovery::{Backend, ModelKind};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn run_all_merges_ollama_and_omlx() {
+    let ollama_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/tags"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "models": [{
+                "name": "qwen3-embedding:0.6b",
+                "size": 700_000_000u64,
+                "details": {"family": "bert"}
+            }]
+        })))
+        .mount(&ollama_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/show"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "capabilities": ["embedding"]
+        })))
+        .mount(&ollama_server)
+        .await;
+
+    let omlx_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{"id": "mlx-community/Qwen3-Embedding-0.6B-8bit"}]
+        })))
+        .mount(&omlx_server)
+        .await;
+
+    let merged = mur_core::discovery::run_all_for_test(
+        Some(ollama_server.uri()),
+        Some(omlx_server.uri()),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(merged.len(), 2);
+    let backends: Vec<Backend> = merged.iter().map(|m| m.backend).collect();
+    assert!(backends.contains(&Backend::Ollama));
+    assert!(backends.contains(&Backend::OMlx));
+    let ollama_model = merged.iter().find(|m| m.backend == Backend::Ollama).unwrap();
+    assert_eq!(ollama_model.kind, ModelKind::Embedding);
+    let omlx_model = merged.iter().find(|m| m.backend == Backend::OMlx).unwrap();
+    assert_eq!(omlx_model.kind, ModelKind::Unknown); // not yet probed
+}
+
+#[tokio::test]
+async fn run_all_skips_failing_backends() {
+    let omlx_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"data": []})))
+        .mount(&omlx_server)
+        .await;
+
+    // Ollama unreachable URL → discovery returns empty for that backend, no error
+    let merged = mur_core::discovery::run_all_for_test(
+        Some("http://127.0.0.1:1".into()),
+        Some(omlx_server.uri()),
+    )
+    .await
+    .unwrap();
+    assert_eq!(merged.len(), 0);
+}

--- a/mur-core/tests/discovery_run_all.rs
+++ b/mur-core/tests/discovery_run_all.rs
@@ -34,18 +34,19 @@ async fn run_all_merges_ollama_and_omlx() {
         .mount(&omlx_server)
         .await;
 
-    let merged = mur_core::discovery::run_all_for_test(
-        Some(ollama_server.uri()),
-        Some(omlx_server.uri()),
-    )
-    .await
-    .unwrap();
+    let merged =
+        mur_core::discovery::run_all_for_test(Some(ollama_server.uri()), Some(omlx_server.uri()))
+            .await
+            .unwrap();
 
     assert_eq!(merged.len(), 2);
     let backends: Vec<Backend> = merged.iter().map(|m| m.backend).collect();
     assert!(backends.contains(&Backend::Ollama));
     assert!(backends.contains(&Backend::OMlx));
-    let ollama_model = merged.iter().find(|m| m.backend == Backend::Ollama).unwrap();
+    let ollama_model = merged
+        .iter()
+        .find(|m| m.backend == Backend::Ollama)
+        .unwrap();
     assert_eq!(ollama_model.kind, ModelKind::Embedding);
     let omlx_model = merged.iter().find(|m| m.backend == Backend::OMlx).unwrap();
     assert_eq!(omlx_model.kind, ModelKind::Unknown); // not yet probed

--- a/mur-core/tests/init_probe_writeback.rs
+++ b/mur-core/tests/init_probe_writeback.rs
@@ -30,6 +30,12 @@ async fn probe_populates_dims_for_unprobed_omlx_pick() {
         .unwrap();
     assert_eq!(probe.dims, 1024);
 
+    // TODO: replace this manual simulation with a headless invocation of
+    // select_local_embedding once stdin can be injected (the menu prompt
+    // currently blocks on io::stdin().read_line). Until then, the
+    // config-write side of the probe path is covered only by the manual
+    // smoke checklist.
+    //
     // Simulate what select_local_embedding does when dims==None:
     // construct the model, probe, then annotate.
     let mut m = DiscoveredModel {

--- a/mur-core/tests/init_probe_writeback.rs
+++ b/mur-core/tests/init_probe_writeback.rs
@@ -21,8 +21,8 @@ async fn probe_populates_dims_for_unprobed_omlx_pick() {
         .mount(&server)
         .await;
 
-    use mur_core::discovery::omlx::OMlxDiscovery;
     use mur_core::discovery::Discovery;
+    use mur_core::discovery::omlx::OMlxDiscovery;
     let d = OMlxDiscovery::new(server.uri());
     let probe = d
         .probe_embedding("mlx-community/Qwen3-Embedding-0.6B-8bit")

--- a/mur-core/tests/init_probe_writeback.rs
+++ b/mur-core/tests/init_probe_writeback.rs
@@ -1,0 +1,50 @@
+//! Integration test: when a user picks an oMLX model whose dims were not
+//! populated at discovery time (kind=Unknown, dims=None), the probe path
+//! in `select_local_embedding` resolves dims via `/v1/embeddings`.
+//!
+//! This file tests the probe primitive directly (no TTY). The full UX
+//! path is covered by the manual smoke checklist.
+
+use mur_core::discovery::{Backend, DiscoveredModel, ModelKind};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn probe_populates_dims_for_unprobed_omlx_pick() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/embeddings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": [{"embedding": vec![0.0f32; 1024]}]
+        })))
+        .mount(&server)
+        .await;
+
+    use mur_core::discovery::omlx::OMlxDiscovery;
+    use mur_core::discovery::Discovery;
+    let d = OMlxDiscovery::new(server.uri());
+    let probe = d
+        .probe_embedding("mlx-community/Qwen3-Embedding-0.6B-8bit")
+        .await
+        .unwrap();
+    assert_eq!(probe.dims, 1024);
+
+    // Simulate what select_local_embedding does when dims==None:
+    // construct the model, probe, then annotate.
+    let mut m = DiscoveredModel {
+        id: "mlx-community/Qwen3-Embedding-0.6B-8bit".into(),
+        backend: Backend::OMlx,
+        kind: ModelKind::Unknown,
+        dims: None,
+        family: Some("qwen3".into()),
+        size_bytes: None,
+        probed_at: None,
+    };
+    if m.dims.is_none() {
+        m.dims = Some(probe.dims);
+        m.kind = ModelKind::Embedding;
+    }
+    assert_eq!(m.dims, Some(1024));
+    assert_eq!(m.kind, ModelKind::Embedding);
+}


### PR DESCRIPTION
## Summary
Replaces the hardcoded `mur init` embedding menu with runtime discovery against locally-installed model runtimes. Builds on **M1 (#179)**.

### What lands
- **`mur-core::discovery`** — new module with the `Discovery` trait + types
  - `OllamaDiscovery`: GET \`/api/tags\` + POST \`/api/show\` (capabilities-array authoritative, family heuristic fallback for older Ollama)
  - `OMlxDiscovery`: GET \`/v1/models\` + POST \`/v1/embeddings\` probe with 10s budget for oMLX issue #266 graph-recompile
  - `discovery::aggregate` menu builder: row 1 = \`[auto]\` (single, top-of-rank pulled), rows 2..N = remaining pulled, last 1-2 = \`[pull]\` from preference table not yet pulled, final = \`Skip\`
  - `discovery::cache` — JSON cache at \`~/.mur/cache/discovery.json\` (TTL 24h, schema versioned, atomic write, infallible \`load()\`)
  - `discovery::preference` — prefix-matched ranking tables (future-proof for \`qwen3.5-embedding\` whenever Alibaba ships it)
- **\`mur init\`** — Mode 1 + Mode 3 now consume discovery results; \`--refresh-discovery\` flag busts the cache; oMLX picks write \`provider: omlx\`, \`openai_url: http://localhost:8000/v1\`, \`api_key_env: OMLX_API_KEY\`; \`[pull]\` rows invoke \`ollama pull\` for Ollama tags or print a GUI hint for oMLX (no CLI pull mechanism)
- **Probe-at-write-time**: when a picked model has unknown dims, mur issues a 1-token probe to learn the actual dim before writing config (Matryoshka-safe). Static fallback table for known ids when probe fails.

### Hotfixes that landed during smoke
- **Nested-runtime panic** — \`cmd_init\` runs inside mur-main's multi-threaded tokio runtime; constructing a fresh \`Runtime::new(...).block_on(...)\` from sync code panicked with "Cannot start a runtime from within a runtime". Fix: \`tokio::task::block_in_place\` + \`Handle::current().block_on\`. Regression tests under \`runtime_regression_tests\` use \`#[tokio::test(flavor = "multi_thread", worker_threads = 2)]\` to reproduce the original panic conditions.
- **oMLX auth required even on localhost** — recent oMLX returns 401 on \`/v1/models\` without \`Authorization: Bearer <key>\`. \`OMlxDiscovery::with_api_key\` accepts the token; \`run_all\` reads \`OMLX_API_KEY\` from env; 401 surfaces a "set OMLX_API_KEY" hint instead of a JSON-parse error.
- **\`/v1/models\` shape variance** — oMLX has shipped at least 3 response shapes; \`#[serde(untagged)]\` enum accepts \`{data:[]}\` (OpenAI), \`{models:[]}\` (Ollama-style), and bare arrays. Parse-fail error includes the first 300 chars of the body for diagnostics.

## Spec / plan / smoke checklist
- \`docs/superpowers/specs/2026-05-05-mur-embedding-omlx-dynamic-design.md\` — full design (§1-§7), final reviewer verified spec coverage complete
- \`docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-plan.md\` — 5-milestone TDD plan, executed via subagent-driven-development with two-stage review per milestone
- \`docs/superpowers/plans/2026-05-05-mur-embedding-omlx-dynamic-smoke.md\` — 6-case manual smoke checklist

## Test plan
- [x] 1100+ unit tests pass (\`cargo test -p mur-core\`)
- [x] Wiremock integration suites for both backends + run_all aggregator + probe-writeback
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] Manual smoke against real oMLX 0.3+ install on macOS — Mode 1 picked oMLX/Qwen3-Embedding-0.6B-8bit auto, config.yaml written correctly, runtime API key resolution verified

## Merge order
After **#179 (M1)** lands on main, this branch will rebase to drop the now-redundant M1 commits (M1.1–M1.3 plus its 2 review-fix commits). The remaining ~21 commits are docs (spec + plan + smoke) + M2 + M3 + M4 + M5 + their review fixes + 2 hotfixes from real-world smoke testing.

## Notable non-goals (per spec § 7)
- \`mur model add --embedding\` model-registry tie-in deferred (\`EmbeddingConfig\` reserves space for \`model_ref\` but no field added in this PR)
- mlx-lm CLI for embeddings: not supported (mlx-lm has no \`/v1/embeddings\` endpoint)
- Reranker discovery: out of scope
- Per-collection embedder: out of scope (one global embedding model per mur install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)