### PR TITLE
M9.3: B0SafetyHook::on_startup verifies MCP install pin (B0 rule 6)

### DIFF
--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -109,7 +109,7 @@ impl Hook for B0SafetyHook {
     async fn on_startup(
         &self,
         ctx: &HookCtx,
-        _profile: &AgentProfile,
+        profile: &AgentProfile,
         _tok: &CancellationToken,
     ) -> Result<(), HookError> {
         // ── Rule 11 (M7.7): MCP binary signature check. ──────────────────
@@ -122,6 +122,61 @@ impl Hook for B0SafetyHook {
                 return Err(HookError::Runtime(format!(
                     "B0 rule 11: MCP binary signature check failed: {reason}"
                 )));
+            }
+        }
+
+        // ── Rule 6 (M9.3): MCP install-time pin verification. ────────────
+        // For every entry pinned at install time (via M9.2), re-hash
+        // the binary on disk and compare. On hard drift, refuse to
+        // start so the user is forced to run `mur agent mcp inspect
+        // <name>` and re-approve. On soft fails (binary missing or
+        // unreadable) we log a warning and continue — rule 11 above
+        // already caught real tampering, and a missing binary is more
+        // likely "user uninstalled the MCP without removing the
+        // profile entry" than an attack.
+        //
+        // Description-hash verification happens lazily at first MCP
+        // call (M9.3.5) rather than here; spawning every pinned MCP
+        // at startup just to read `tools/list` would N×-bloat boot
+        // time without user-visible benefit.
+        for entry in &profile.mcp_servers {
+            let Some(expected) = &entry.binary_sha256 else {
+                // Pre-M9 entry — skip silently; the cookbook documents
+                // `mur agent mcp pin <name>` as the migration verb.
+                continue;
+            };
+            // Same resolution as M9.2 install: the runtime's already-
+            // resolved `mcp_server_binaries` are paths derived from
+            // `command.split_whitespace().next()`. We mirror that here
+            // so install-side and verify-side hash the same bytes.
+            let path = std::path::PathBuf::from(
+                entry
+                    .command
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or(&entry.command),
+            );
+            match crate::hooks::b0_helpers::verify_mcp_binary_hash(expected, &path) {
+                Ok(()) => {
+                    tracing::debug!(mcp = %entry.name, "B0 rule 6: pin verified");
+                }
+                Err(crate::hooks::b0_helpers::PinDriftReason::BinaryDrift { .. }) => {
+                    return Err(HookError::Runtime(format!(
+                        "B0 rule 6: MCP `{}` changed since install — \
+                         run `mur agent mcp inspect {}` to review the \
+                         drift and `mur agent mcp pin {}` to re-approve, \
+                         or `mur agent mcp remove {}` to uninstall.",
+                        entry.name, entry.name, entry.name, entry.name,
+                    )));
+                }
+                Err(soft @ crate::hooks::b0_helpers::PinDriftReason::BinaryMissing { .. })
+                | Err(soft @ crate::hooks::b0_helpers::PinDriftReason::BinaryReadError { .. }) => {
+                    tracing::warn!(
+                        mcp = %entry.name,
+                        reason = %soft,
+                        "B0 rule 6: pin verify soft-failed; continuing",
+                    );
+                }
             }
         }
         Ok(())

--- a/mur-agent-runtime/src/hooks/b0_helpers.rs
+++ b/mur-agent-runtime/src/hooks/b0_helpers.rs
@@ -478,3 +478,172 @@ pub fn verify_signed(path: &std::path::Path) -> Result<(), String> {
         Ok(())
     }
 }
+
+// ─────────────────────────────────────────────────────────────────
+// B0 rule 6 / M9.3 — MCP install-time pin verification.
+// ─────────────────────────────────────────────────────────────────
+
+/// Why a pinned MCP entry failed re-verification at startup. Used to
+/// drive the user-facing recovery prompt (`mur agent mcp inspect
+/// <name>`) so the message can specifically say "the binary changed"
+/// vs. "the description changed" rather than a generic mismatch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PinDriftReason {
+    /// The pinned binary path could not be resolved on disk. The user
+    /// either uninstalled the MCP without removing it from
+    /// profile.yaml or the binary moved. Treated as a soft fail (warn,
+    /// don't block) so the supervisor can still start.
+    BinaryMissing { path: String, io_error: String },
+    /// The pinned binary's SHA-256 did not match the recorded hash.
+    /// Hard fail — the binary on disk is not what was approved at
+    /// install time.
+    BinaryDrift { expected: String, actual: String },
+    /// I/O error while reading the binary (permissions / disk).
+    /// Treated as soft fail; rule 11 codesign check would have caught
+    /// the equivalent permission issue first.
+    BinaryReadError { path: String, io_error: String },
+}
+
+impl std::fmt::Display for PinDriftReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BinaryMissing { path, io_error } => {
+                write!(f, "binary at `{path}` cannot be located ({io_error})")
+            }
+            Self::BinaryDrift { expected, actual } => {
+                let exp_short = expected.chars().take(16).collect::<String>();
+                let act_short = actual.chars().take(16).collect::<String>();
+                write!(
+                    f,
+                    "binary SHA-256 changed (pinned: {exp_short}…, current: {act_short}…)"
+                )
+            }
+            Self::BinaryReadError { path, io_error } => {
+                write!(f, "binary at `{path}` could not be read ({io_error})")
+            }
+        }
+    }
+}
+
+/// Re-compute the SHA-256 of `path` and compare with `expected`. Used
+/// by `B0SafetyHook::on_startup` to enforce the rule-6 install-time
+/// pin on every supervisor start.
+///
+/// Mirrors the chunked stream-hash in `mur-core::cmd::agent_mcp_pin`
+/// so the install-side and verify-side outputs are byte-identical.
+/// Duplicated rather than imported to avoid the `mur-agent-runtime ←
+/// mur-core` dependency cycle this hook already takes pains to avoid.
+pub fn verify_mcp_binary_hash(
+    expected: &str,
+    path: &std::path::Path,
+) -> Result<(), PinDriftReason> {
+    use sha2::{Digest, Sha256};
+    use std::fs::File;
+    use std::io::Read;
+
+    let mut f = match File::open(path) {
+        Ok(f) => f,
+        Err(e) => {
+            // ENOENT vs other I/O — distinguish so the user sees a
+            // clear "uninstalled?" hint rather than a generic error.
+            if e.kind() == std::io::ErrorKind::NotFound {
+                return Err(PinDriftReason::BinaryMissing {
+                    path: path.display().to_string(),
+                    io_error: e.to_string(),
+                });
+            }
+            return Err(PinDriftReason::BinaryReadError {
+                path: path.display().to_string(),
+                io_error: e.to_string(),
+            });
+        }
+    };
+
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 65536];
+    loop {
+        let n = match f.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(e) => {
+                return Err(PinDriftReason::BinaryReadError {
+                    path: path.display().to_string(),
+                    io_error: e.to_string(),
+                });
+            }
+        };
+        hasher.update(&buf[..n]);
+    }
+    let actual = hex::encode(hasher.finalize());
+    if actual.eq_ignore_ascii_case(expected) {
+        Ok(())
+    } else {
+        Err(PinDriftReason::BinaryDrift {
+            expected: expected.to_string(),
+            actual,
+        })
+    }
+}
+
+#[cfg(test)]
+mod pin_verify_tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    /// Same SHA-256 fixture as `mur-core::cmd::agent_mcp_pin` so the
+    /// two halves of M9 stay in lockstep.
+    const HELLO_SHA: &str = "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03";
+
+    #[test]
+    fn matches_pinned_hash_returns_ok() {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"hello\n").unwrap();
+        assert!(verify_mcp_binary_hash(HELLO_SHA, f.path()).is_ok());
+    }
+
+    #[test]
+    fn case_insensitive_hash_match() {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"hello\n").unwrap();
+        let upper: String = HELLO_SHA.chars().map(|c| c.to_ascii_uppercase()).collect();
+        assert!(verify_mcp_binary_hash(&upper, f.path()).is_ok());
+    }
+
+    #[test]
+    fn drift_returns_specific_reason() {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"world\n").unwrap();
+        let err = verify_mcp_binary_hash(HELLO_SHA, f.path()).unwrap_err();
+        match err {
+            PinDriftReason::BinaryDrift { expected, actual } => {
+                assert_eq!(expected, HELLO_SHA);
+                assert_ne!(actual, HELLO_SHA);
+                assert_eq!(actual.len(), 64);
+            }
+            other => panic!("expected BinaryDrift, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_binary_distinguished_from_read_error() {
+        let err = verify_mcp_binary_hash(HELLO_SHA, std::path::Path::new("/no/such/binary-xyz"))
+            .unwrap_err();
+        assert!(
+            matches!(err, PinDriftReason::BinaryMissing { .. }),
+            "got {err:?}",
+        );
+    }
+
+    #[test]
+    fn drift_display_includes_short_hash_prefixes() {
+        let drift = PinDriftReason::BinaryDrift {
+            expected: "deadbeef00112233445566778899aabbccddeeff00112233445566778899aabb".into(),
+            actual: "cafebabe00112233445566778899aabbccddeeff00112233445566778899aabb".into(),
+        };
+        let s = drift.to_string();
+        assert!(s.contains("deadbeef00112233"), "got {s}");
+        assert!(s.contains("cafebabe00112233"), "got {s}");
+        assert!(!s.contains("deadbeef00112233445566"), "no full hash leak");
+    }
+}

--- a/mur-agent-runtime/tests/b0_rule6_mcp_pin.rs
+++ b/mur-agent-runtime/tests/b0_rule6_mcp_pin.rs
@@ -119,7 +119,15 @@ async fn missing_binary_soft_fails_does_not_block_startup() {
     });
 
     let hook = B0SafetyHook::new();
-    let ctx = HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![phantom]);
+    // Rule 11 reads `ctx.mcp_server_binaries()` (resolved by the
+    // supervisor — production already filters out unresolvable paths
+    // before the hook runs). Rule 6 reads `profile.mcp_servers`. To
+    // exercise rule 6's soft-fail path in isolation, we pass an
+    // empty mcp_server_binaries list — rule 11 then has nothing to
+    // verify, and rule 6 alone sees the phantom entry from the
+    // profile.
+    let _ = phantom;
+    let ctx = HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![]);
     let cancel = CancellationToken::new();
     let result = hook.on_startup(&ctx, &profile, &cancel).await;
     assert!(

--- a/mur-agent-runtime/tests/b0_rule6_mcp_pin.rs
+++ b/mur-agent-runtime/tests/b0_rule6_mcp_pin.rs
@@ -1,0 +1,154 @@
+//! B0 rule 6 / M9.3 — `B0SafetyHook::on_startup` enforces install-time
+//! MCP binary pin.
+//!
+//! Construction follows the same pattern as `b0_rule11_mcp_signature.rs`:
+//! load a minimal `AgentProfile`, inject a synthetic `mcp_servers`
+//! entry whose `binary_sha256` either matches or differs from the
+//! actual file on disk, then assert `on_startup` outcome.
+//!
+//! Linux-only because on macOS rule 11 (codesign check) fires before
+//! rule 6 and would refuse the unsigned synthetic binary. The unit
+//! tests in `hooks::b0_helpers::pin_verify_tests` cover the verifier
+//! itself cross-platform.
+
+#![cfg(target_os = "linux")]
+
+use mur_agent_runtime::hooks::{B0SafetyHook, Hook, HookCtx};
+use mur_common::AgentProfile;
+use mur_common::agent::McpServerEntry;
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+fn minimal_profile() -> AgentProfile {
+    let yaml = include_str!("fixtures/profile_minimal.yaml");
+    serde_yaml_ng::from_str(yaml).expect("fixture parse")
+}
+
+fn write_fake_binary(dir: &std::path::Path, contents: &[u8]) -> PathBuf {
+    // Use a unique name in case multiple tests share the same TempDir.
+    let bin = dir.join(format!("fake-mcp-{}", uuid::Uuid::now_v7()));
+    std::fs::write(&bin, contents).unwrap();
+    bin
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    hex::encode(h.finalize())
+}
+
+/// On Linux the rule 11 signature check is a no-op so we can land
+/// pinned-but-unsigned binaries cleanly. On macOS the rule 11
+/// codesign check fires before rule 6, so this rule-6 test would
+/// require a signed binary fixture — gate it to Linux only for now.
+/// (The unit tests in `hooks::b0_helpers::pin_verify_tests` cover
+/// the verifier itself cross-platform.)
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn matching_binary_hash_passes_startup() {
+    let dir = TempDir::new().unwrap();
+    let payload = b"pretend MCP body v1\n";
+    let bin = write_fake_binary(dir.path(), payload);
+    let pinned_hash = sha256_hex(payload);
+
+    let mut profile = minimal_profile();
+    profile.mcp_servers.push(McpServerEntry {
+        name: "weather".into(),
+        command: bin.display().to_string(),
+        args: vec![],
+        binary_sha256: Some(pinned_hash),
+        ..Default::default()
+    });
+
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin.clone()]);
+    let cancel = CancellationToken::new();
+    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    assert!(result.is_ok(), "matching pin should pass: {result:?}");
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn binary_drift_fails_startup_with_inspect_hint() {
+    let dir = TempDir::new().unwrap();
+    let installed = b"pretend MCP body v1\n";
+    let bin = write_fake_binary(dir.path(), installed);
+    // Pin records v1's hash; rewrite the file to v2's bytes.
+    let pinned_hash = sha256_hex(installed);
+    std::fs::write(&bin, b"pretend MCP body v2 -- drifted\n").unwrap();
+
+    let mut profile = minimal_profile();
+    profile.mcp_servers.push(McpServerEntry {
+        name: "weather".into(),
+        command: bin.display().to_string(),
+        args: vec![],
+        binary_sha256: Some(pinned_hash),
+        ..Default::default()
+    });
+
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin]);
+    let cancel = CancellationToken::new();
+    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    let err = result.expect_err("drift should fail startup");
+    let msg = err.to_string();
+    assert!(msg.contains("B0 rule 6"), "got {msg}");
+    assert!(msg.contains("mur agent mcp inspect weather"), "got {msg}");
+    assert!(msg.contains("mur agent mcp pin weather"), "got {msg}");
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn missing_binary_soft_fails_does_not_block_startup() {
+    let dir = TempDir::new().unwrap();
+    // Path that doesn't exist — the supervisor would catch this in
+    // its own resolve step in production, but the verify path must
+    // not crash on a missing file (user uninstalled the MCP without
+    // removing it from profile.yaml).
+    let phantom = dir.path().join("phantom-mcp");
+
+    let mut profile = minimal_profile();
+    profile.mcp_servers.push(McpServerEntry {
+        name: "ghost".into(),
+        command: phantom.display().to_string(),
+        args: vec![],
+        binary_sha256: Some("deadbeef".repeat(8)),
+        ..Default::default()
+    });
+
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![phantom]);
+    let cancel = CancellationToken::new();
+    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    assert!(
+        result.is_ok(),
+        "missing binary should soft-fail (warn, allow start): {result:?}",
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn pre_m9_entry_without_pin_skipped_cleanly() {
+    let dir = TempDir::new().unwrap();
+    let bin = write_fake_binary(dir.path(), b"any bytes");
+
+    let mut profile = minimal_profile();
+    profile.mcp_servers.push(McpServerEntry {
+        name: "legacy".into(),
+        command: bin.display().to_string(),
+        args: vec![],
+        // binary_sha256 stays None — pre-M9 entry, exempt from rule 6.
+        ..Default::default()
+    });
+
+    let hook = B0SafetyHook::new();
+    let ctx = HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin]);
+    let cancel = CancellationToken::new();
+    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    assert!(
+        result.is_ok(),
+        "pre-M9 (no pin) entry should pass: {result:?}",
+    );
+}


### PR DESCRIPTION
## Summary
- New `verify_mcp_binary_hash` helper + typed `PinDriftReason` enum in `hooks::b0_helpers`.
- `B0SafetyHook::on_startup` extended: refuses startup on hard drift with `mur agent mcp inspect/pin/remove` hint in the message; soft-fails gracefully on missing/unreadable binaries.
- Description-hash verification deferred to M9.3.5 — spawning every pinned MCP at startup would N×-bloat boot time. Lands in the supervisor's lazy MCP-spawn path instead.

## Test plan
- [x] `cargo test -p mur-agent-runtime --lib pin_verify` — 5 passed cross-platform
- [x] `cargo build -p mur-agent-runtime --tests` clean
- [x] `cargo clippy -p mur-agent-runtime --tests -- -D warnings` clean
- [x] `cargo fmt` clean
- [ ] CI Linux runner exercises 4 integration tests in `tests/b0_rule6_mcp_pin.rs` (`#![cfg(target_os = "linux")]`)
- [ ] CI matrix

## Stacked behind
PR #183 (M9.2 install hash + prompt). Will retarget to main as the cascade lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)