### PR TITLE
M9.4: `mur agent mcp inspect` + `pin` CLI verbs (B0 rule 6)

### DIFF
--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -126,11 +126,9 @@ pub struct McpToolDescription {
 /// Caller is responsible for actually probing the MCP via stdio +
 /// rendering the user-facing confirmation prompt. This helper is the
 /// pure assembly step so it can be unit-tested without an MCP fixture.
-///
-/// Used by M9.4's `mur agent mcp pin` re-approval flow once the live
-/// probe lands; `cmd_mcp_add` inlines the same logic so the install-
-/// time prompt can interleave hash display with confirmation.
-#[allow(dead_code)] // wired by M9.4 (mur agent mcp pin)
+/// Currently used only by tests; M9.3.5 will switch `cmd_mcp_pin` to
+/// use it once the live description-probe lands.
+#[allow(dead_code)] // wired by M9.3.5 (description-hash live probe)
 pub fn build_pinned_entry(
     name: &str,
     command: &str,
@@ -148,6 +146,218 @@ pub fn build_pinned_entry(
         publisher,
         installed_at: Some(chrono::Utc::now()),
     }
+}
+
+// ───────────────────────────────────────────────────────────────────
+// `mur agent mcp inspect` + `mur agent mcp pin` (B0 rule 6 / M9.4)
+// ───────────────────────────────────────────────────────────────────
+
+/// Result of an `inspect` run, expressed as an exit code so the verb
+/// is machine-friendly for scripted re-approval flows. Stable contract:
+///
+/// - `0` Clean — pin matches current state.
+/// - `1` BinaryDrift — the binary hash changed since install.
+/// - `2` DescriptionDrift — *reserved* for M9.3.5; not produced today.
+/// - `3` BothDrifted — *reserved* for M9.3.5.
+/// - `4` MissingPin — entry has no `binary_sha256` (pre-M9 entry).
+/// - `5` BinaryMissing — pinned binary not on disk anymore.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InspectStatus {
+    Clean = 0,
+    BinaryDrift = 1,
+    #[allow(dead_code)] // landed in M9.3.5 once description re-probe is wired
+    DescriptionDrift = 2,
+    #[allow(dead_code)] // landed in M9.3.5
+    BothDrifted = 3,
+    MissingPin = 4,
+    BinaryMissing = 5,
+}
+
+/// Print pinned vs current state for one MCP entry. Returns the
+/// exit-code-shaped status; `cmd_mcp_inspect` lifts that to
+/// `std::process::exit` after running through the dispatch.
+pub fn inspect_one(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
+    println!("MCP server: {}", entry.name);
+    println!("  command:        {}", entry.command);
+    if !entry.args.is_empty() {
+        println!("  args:           {}", entry.args.join(" "));
+    }
+    if let Some(p) = &entry.publisher {
+        println!("  publisher:      {}", p.name);
+        if let Some(h) = &p.homepage {
+            println!("                  {h}");
+        }
+        if let Some(r) = &p.registry_id {
+            println!("                  {r}");
+        }
+    }
+    if let Some(t) = &entry.installed_at {
+        println!("  installed_at:   {}", t.to_rfc3339());
+    }
+
+    let Some(expected) = &entry.binary_sha256 else {
+        println!("  pin status:     <unpinned> (pre-M9 entry)");
+        println!(
+            "  hint:           run `mur agent mcp pin {}` to start enforcing rule 6",
+            entry.name,
+        );
+        return InspectStatus::MissingPin;
+    };
+
+    println!("  pinned sha256:  {expected}");
+    let path = match resolve_command(&entry.command) {
+        Ok(p) => p,
+        Err(_) => {
+            println!("  current sha256: <binary not found on PATH>");
+            println!(
+                "  status:         BINARY MISSING — `mur agent mcp remove {}` to clean up, \
+                 or restore the binary and re-run inspect",
+                entry.name,
+            );
+            return InspectStatus::BinaryMissing;
+        }
+    };
+    let actual = match compute_binary_sha256(&path) {
+        Ok(h) => h,
+        Err(e) => {
+            println!("  current sha256: <read error: {e}>");
+            return InspectStatus::BinaryMissing;
+        }
+    };
+    println!("  current sha256: {actual}");
+    println!(
+        "  description:    <pinned hash deferred to M9.3.5 live probe; \
+         binary verification is authoritative for now>",
+    );
+
+    if actual.eq_ignore_ascii_case(expected) {
+        println!("  status:         CLEAN");
+        InspectStatus::Clean
+    } else {
+        println!("  status:         BINARY DRIFT");
+        println!(
+            "  hint:           `mur agent mcp pin {}` to re-approve, \
+             or `mur agent mcp remove {}` to uninstall",
+            entry.name, entry.name,
+        );
+        InspectStatus::BinaryDrift
+    }
+}
+
+/// `mur agent mcp inspect <name> [--server <id>]`. Without `--server`,
+/// prints all MCPs on the agent and returns the WORST status (highest
+/// numeric value) so a scripted caller knows whether ANY MCP drifted.
+pub fn cmd_mcp_inspect(name: &str, server_id: Option<&str>) -> Result<i32> {
+    let (_path, profile) = crate::cmd::agent::load_profile_for_edit(name)?;
+    if profile.mcp_servers.is_empty() {
+        println!("Agent `{name}` has no MCP servers configured.");
+        return Ok(0);
+    }
+    let mut worst: u8 = 0;
+    let mut printed = false;
+    for entry in &profile.mcp_servers {
+        if let Some(id) = server_id
+            && entry.name != id
+        {
+            continue;
+        }
+        if printed {
+            println!();
+        }
+        let status = inspect_one(entry) as u8;
+        worst = worst.max(status);
+        printed = true;
+    }
+    if !printed && let Some(id) = server_id {
+        bail!("MCP server `{id}` not found on agent `{name}`");
+    }
+    Ok(worst as i32)
+}
+
+/// `mur agent mcp pin <name> --server <id> [--force]`. Re-computes the
+/// install-time binary hash + (optional) publisher metadata, shows
+/// the same prompt as `mur agent mcp add`, and persists the refreshed
+/// pin into `profile.yaml`. Updates `installed_at` to "now" so the
+/// audit trail records the re-approval.
+pub fn cmd_mcp_pin(
+    name: &str,
+    server_id: &str,
+    force: bool,
+    publisher_name: Option<String>,
+    publisher_homepage: Option<String>,
+    publisher_registry_id: Option<String>,
+) -> Result<()> {
+    let (path, mut profile) = crate::cmd::agent::load_profile_for_edit(name)?;
+    let entry = profile
+        .mcp_servers
+        .iter_mut()
+        .find(|s| s.name == server_id)
+        .ok_or_else(|| anyhow::anyhow!("MCP server `{server_id}` not found on agent `{name}`"))?;
+
+    let resolved = resolve_command(&entry.command)
+        .with_context(|| format!("resolve command `{}`", entry.command))?;
+    let new_hash = compute_binary_sha256(&resolved)
+        .with_context(|| format!("hash binary at {}", resolved.display()))?;
+
+    // Preserve existing publisher unless any new field is provided
+    // (in which case the user's intent is to overwrite the metadata
+    // alongside the rehash).
+    let publisher = match (publisher_name, publisher_homepage, publisher_registry_id) {
+        (None, None, None) => entry.publisher.clone(),
+        (n, h, r) => Some(mur_common::agent::McpPublisherInfo {
+            name: n.unwrap_or_else(|| {
+                entry
+                    .publisher
+                    .as_ref()
+                    .map(|p| p.name.clone())
+                    .unwrap_or_default()
+            }),
+            homepage: h.or_else(|| entry.publisher.as_ref().and_then(|p| p.homepage.clone())),
+            registry_id: r.or_else(|| entry.publisher.as_ref().and_then(|p| p.registry_id.clone())),
+        }),
+    };
+
+    if !force {
+        println!("Re-approving MCP `{server_id}` on agent `{name}`:");
+        println!("  command:        {}", resolved.display());
+        if let Some(old) = &entry.binary_sha256 {
+            if old.eq_ignore_ascii_case(&new_hash) {
+                println!("  binary sha256:  {new_hash}  (unchanged)");
+            } else {
+                println!("  pinned sha256:  {old}  (old)");
+                println!("  current sha256: {new_hash}  (NEW — drifted)");
+            }
+        } else {
+            println!("  binary sha256:  {new_hash}  (was unpinned)");
+        }
+        if let Some(p) = &publisher {
+            println!("  publisher:      {}", p.name);
+            if let Some(h) = &p.homepage {
+                println!("                  {h}");
+            }
+            if let Some(r) = &p.registry_id {
+                println!("                  {r}");
+            }
+        }
+        print!("\nApprove? [y/N] ");
+        use std::io::{self, Write};
+        io::stdout().flush().ok();
+        let mut answer = String::new();
+        io::stdin()
+            .read_line(&mut answer)
+            .with_context(|| "read confirmation from stdin")?;
+        if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+            bail!("re-approval cancelled");
+        }
+    }
+
+    entry.binary_sha256 = Some(new_hash);
+    entry.publisher = publisher;
+    entry.installed_at = Some(chrono::Utc::now());
+    crate::cmd::agent::save_profile(&path, &mut profile)?;
+    println!("Re-approved MCP `{server_id}` on agent `{name}`.");
+    Ok(())
 }
 
 #[cfg(test)]
@@ -285,5 +495,79 @@ mod tests {
     fn resolve_command_errors_on_missing() {
         let r = resolve_command("/no/such/binary-xyz9876543210");
         assert!(r.is_err());
+    }
+
+    // ─── inspect / pin ────────────────────────────────────────────
+
+    #[test]
+    fn inspect_one_clean_returns_clean_status() {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"hello\n").unwrap();
+        let entry = mur_common::agent::McpServerEntry {
+            name: "weather".into(),
+            command: f.path().display().to_string(),
+            args: vec![],
+            // SHA-256("hello\n") (matches binary_sha256_matches_known_vector)
+            binary_sha256: Some(
+                "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03".into(),
+            ),
+            ..Default::default()
+        };
+        assert_eq!(inspect_one(&entry), InspectStatus::Clean);
+    }
+
+    #[test]
+    fn inspect_one_drift_returns_binary_drift() {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"different bytes\n").unwrap();
+        let entry = mur_common::agent::McpServerEntry {
+            name: "weather".into(),
+            command: f.path().display().to_string(),
+            args: vec![],
+            binary_sha256: Some(
+                "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03".into(),
+            ),
+            ..Default::default()
+        };
+        assert_eq!(inspect_one(&entry), InspectStatus::BinaryDrift);
+    }
+
+    #[test]
+    fn inspect_one_unpinned_entry_returns_missing_pin() {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"any\n").unwrap();
+        let entry = mur_common::agent::McpServerEntry {
+            name: "legacy".into(),
+            command: f.path().display().to_string(),
+            args: vec![],
+            // No pin → pre-M9 entry.
+            ..Default::default()
+        };
+        assert_eq!(inspect_one(&entry), InspectStatus::MissingPin);
+    }
+
+    #[test]
+    fn inspect_one_missing_binary_returns_binary_missing() {
+        let entry = mur_common::agent::McpServerEntry {
+            name: "ghost".into(),
+            command: "/no/such/binary-xyz9876543210".into(),
+            args: vec![],
+            binary_sha256: Some("deadbeef".repeat(8)),
+            ..Default::default()
+        };
+        assert_eq!(inspect_one(&entry), InspectStatus::BinaryMissing);
+    }
+
+    #[test]
+    fn inspect_status_exit_code_contract_is_stable() {
+        // Lock the wire contract — any change here is a breaking change
+        // for scripts that branch on `mur agent mcp inspect`'s exit
+        // code.
+        assert_eq!(InspectStatus::Clean as u8, 0);
+        assert_eq!(InspectStatus::BinaryDrift as u8, 1);
+        assert_eq!(InspectStatus::DescriptionDrift as u8, 2);
+        assert_eq!(InspectStatus::BothDrifted as u8, 3);
+        assert_eq!(InspectStatus::MissingPin as u8, 4);
+        assert_eq!(InspectStatus::BinaryMissing as u8, 5);
     }
 }

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -1250,6 +1250,32 @@ enum AgentMcpAction {
         old: String,
         new: String,
     },
+    /// Show pinned vs current state for one (or all) MCP entries.
+    /// Exit codes (B0 rule 6 / M9.4): 0 clean, 1 binary drift, 4
+    /// unpinned (pre-M9), 5 binary missing. Reports the worst status
+    /// across all servers when `--server` is omitted.
+    Inspect {
+        name: String,
+        /// Limit to a single MCP server entry; otherwise iterate all.
+        #[arg(long = "server")]
+        server: Option<String>,
+    },
+    /// Re-compute and persist the install-time binary pin (and
+    /// optionally refresh publisher metadata). Used after reviewing
+    /// drift surfaced by `mur agent mcp inspect`.
+    Pin {
+        name: String,
+        server_id: String,
+        /// Skip the y/N re-approval prompt.
+        #[arg(long)]
+        force: bool,
+        #[arg(long = "publisher-name")]
+        publisher_name: Option<String>,
+        #[arg(long = "publisher-homepage")]
+        publisher_homepage: Option<String>,
+        #[arg(long = "publisher-registry-id")]
+        publisher_registry_id: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1695,6 +1721,27 @@ async fn async_main() -> Result<()> {
                 AgentMcpAction::Rename { name, old, new } => {
                     cmd::agent::cmd_mcp_rename(&name, &old, &new)?
                 }
+                AgentMcpAction::Inspect { name, server } => {
+                    let code = cmd::agent_mcp_pin::cmd_mcp_inspect(&name, server.as_deref())?;
+                    if code != 0 {
+                        std::process::exit(code);
+                    }
+                }
+                AgentMcpAction::Pin {
+                    name,
+                    server_id,
+                    force,
+                    publisher_name,
+                    publisher_homepage,
+                    publisher_registry_id,
+                } => cmd::agent_mcp_pin::cmd_mcp_pin(
+                    &name,
+                    &server_id,
+                    force,
+                    publisher_name,
+                    publisher_homepage,
+                    publisher_registry_id,
+                )?,
             },
             AgentAction::Skill { action } => match action {
                 AgentSkillAction::List { name } => cmd::agent::cmd_skill_list(&name)?,


### PR DESCRIPTION
## Summary
- Two new CLI verbs: `mur agent mcp inspect` (drift report + stable exit codes) and `mur agent mcp pin` (re-approval after review).
- `InspectStatus` repr-u8 enum locks the exit-code wire contract via a regression test (0 clean / 1 binary drift / 2,3 reserved for M9.3.5 / 4 unpinned / 5 binary missing).
- `pin` preserves existing publisher metadata unless any `--publisher-*` flag overrides; updates `installed_at` to record re-approval.

## Test plan
- [x] `cargo test -p mur-core --lib agent_mcp_pin` — 13 passed (8 from M9.2 + 5 new)
- [x] `cargo build -p mur-core` clean
- [x] `cargo clippy -p mur-core --no-deps -- -D warnings` clean
- [x] `cargo fmt` clean
- [ ] CI matrix

## Stacked behind
PR #184 (M9.3 startup verify). Will retarget to main as the cascade lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)