### PR TITLE
docs(spec): B0 M9.3.5 MCP description-hash live probe design

### DIFF
--- a/docs/superpowers/specs/2026-05-06-b0-m9.3.5-description-hash-probe-design.md
+++ b/docs/superpowers/specs/2026-05-06-b0-m9.3.5-description-hash-probe-design.md
@@ -1,0 +1,169 @@
+# B0 M9.3.5 — MCP description-hash live probe design
+
+**Status:** Draft
+**Author:** david
+**Date:** 2026-05-06
+**Predecessors:** M9.0–M9.5 (binary-hash pin + on_startup verify + inspect/pin verbs).
+
+---
+
+## 1. Goal
+
+Close the second half of B0 rule 6: detect MCP rug-pulls where the
+binary is unchanged but the tool descriptions changed (the
+"benign-binary, malicious-description" prompt-injection vector).
+
+M9.3 deferred this from supervisor `on_startup` because spawning N
+MCPs at boot just to read `tools/list` would N×-bloat startup. M9.3.5
+lands the verification at two natural choke points:
+
+1. **`mur agent mcp pin`** — when the user re-approves an entry, also
+   spawn the MCP, fetch `tools/list`, compute description hash,
+   persist alongside the binary hash. This is when description_hash
+   actually starts being non-None for installed entries.
+2. **`mur agent mcp inspect --probe`** — opt-in flag that spawns the
+   MCP during the inspect run and verifies live `tools/list` against
+   the pinned `description_hash`. Default `inspect` stays fast
+   (no-spawn). Lights up exit codes 2 (description drift) + 3 (both)
+   that M9.4 reserved.
+
+Future M9.3.6 (out of scope here) will hook into the supervisor's
+lazy MCP-spawn path once one exists in the codebase.
+
+## 2. What's already built
+
+The hashing helpers all exist:
+
+- `mur_core::cmd::agent_mcp_pin::compute_description_hash(&[McpToolDescription]) -> String`
+  (currently `#[allow(dead_code)]` waiting for a caller).
+- `mur_core::cmd::agent_mcp_pin::McpToolDescription` — name +
+  description + input_schema (matches `mur_agent_runtime::protocol::mcp_client::ToolInfo` shape).
+- `mur_common::canonical::canonical_json` — single source of truth.
+- `mur_agent_runtime::protocol::mcp_client::McpClient::{spawn,
+  initialize, list_tools, shutdown}` — already implements the
+  stdio probe, currently used only by tests.
+
+So this milestone is glue + UX, not new crypto.
+
+## 3. Architecture
+
+### 3.1 Cross-crate dependency
+
+`mur-core::cmd::agent_mcp_pin` already depends on
+`mur-agent-runtime` via Cargo.toml (used by `cmd_export`). Adding the
+spawn-and-probe path stays inside that existing dependency edge.
+
+### 3.2 New helper: `probe_mcp_descriptions`
+
+```rust
+// mur-core::cmd::agent_mcp_pin
+pub async fn probe_mcp_descriptions(
+    entry: &McpServerEntry,
+    timeout: std::time::Duration,
+) -> Result<(String, Vec<ToolInfo>)>
+```
+
+- Spawns `McpClient` on the entry, runs `initialize()` (captures
+  publisher metadata if present), runs `list_tools()`, calls
+  `shutdown()`, returns canonical hash + raw tools.
+- Wraps the whole thing in `tokio::time::timeout` (default 10s,
+  overridable via `MUR_MCP_PROBE_TIMEOUT_S` env). Long-startup MCPs
+  exceeding the budget return a typed `ProbeError::Timeout`.
+- Internally walks the upstream `ToolInfo` into `McpToolDescription`
+  shape so `compute_description_hash` (already shipped in M9.2)
+  produces identical bytes to install-side / verify-side hashes.
+
+### 3.3 `mur agent mcp pin` enhancement
+
+Currently `cmd_mcp_pin` re-hashes the binary only. Extend to
+optionally also probe descriptions:
+
+- Default: probe the MCP (live spawn) and persist description_hash.
+- `--no-probe` flag: skip the spawn (useful if the MCP can't be
+  cleanly probed — slow boot, side-effects on init, etc.).
+- On probe failure (timeout / spawn error): print warning, persist
+  with description_hash = None (caller can re-pin later).
+
+### 3.4 `mur agent mcp inspect` enhancement
+
+Currently `inspect_one` only compares binary hashes. Extend:
+
+- `--probe` flag (opt-in): spawn the MCP, recompute description hash,
+  compare against pinned `entry.description_hash`. Lights up exit
+  codes 2 (DescriptionDrift) and 3 (BothDrifted).
+- Without `--probe`: behavior unchanged from M9.4. Description hash
+  shown if pinned but not actively verified — line reads
+  `description hash: <pinned>; not verified (use --probe)`.
+
+### 3.5 Drift output
+
+When description drifts, show a unified diff between the pinned
+tools (from `entry.description_hash` — but we only have the hash, not
+the full payload). Compromise: show only the current `tools/list`
+output flagged "different from install time" + the hint to re-pin.
+Storing the full pinned payload was rejected to keep `profile.yaml`
+small (description payloads can be 10s of KB).
+
+## 4. Milestones
+
+### M9.3.5.1 — `probe_mcp_descriptions` + `pin` enhancement (~150 LOC)
+
+- New `probe_mcp_descriptions` async helper in `agent_mcp_pin.rs`.
+- `cmd_mcp_pin` calls it by default; `--no-probe` skips.
+- `MUR_MCP_PROBE_TIMEOUT_S` env var honored.
+- Tests: probe timeout fires, probe failure persists None, successful
+  probe persists hash matching `compute_description_hash`.
+
+**Acceptance:** `cargo test -p mur-core --lib agent_mcp_pin::probe`
+green.
+
+### M9.3.5.2 — `inspect --probe` (~100 LOC)
+
+- `--probe` flag on `mur agent mcp inspect`.
+- `inspect_one` extended to take a `ProbeConfig` (skip / probe with
+  timeout); on probe path, lights up DescriptionDrift /
+  BothDrifted exit codes.
+- Tests: probe-clean returns 0, drift returns 2, both-drifted returns 3.
+
+**Acceptance:** `cargo test -p mur-core --lib agent_mcp_pin::inspect_probe` green.
+
+### M9.3.5.3 — E2E + cookbook update (~80 LOC + docs)
+
+- `scripts/e2e/b0-m9.3.5-description-probe.sh` (mocks an MCP via
+  the existing `tests/fixtures/mock_mcp` binary; verifies the probe
+  path round-trips).
+- `docs/cookbook/b0-mcp-install-verify.md` updated: new section on
+  "running `mur agent mcp inspect --probe` periodically" + describing
+  what each new exit code means + the `MUR_MCP_PROBE_TIMEOUT_S` knob.
+- Roadmap §6.1 footer updated to mark description-hash probe shipped
+  via `--probe` opt-in.
+
+## 5. Non-goals
+
+- **Not** spawning MCPs at supervisor startup (the original M9.3
+  design rejected this). The probe is opt-in via `--probe` or
+  triggered by user-initiated `pin`.
+- **Not** adding the lazy supervisor MCP-spawn path (when one is
+  added, the helper here gets reused by it — that's M9.3.6).
+- **Not** storing the full `tools/list` payload in `profile.yaml`
+  for diff display (only the hash; cookbook documents the
+  trade-off).
+
+## 6. Acceptance gates
+
+- `cargo test -p mur-core --lib agent_mcp_pin::probe` green.
+- `cargo test -p mur-core --lib agent_mcp_pin::inspect_probe` green.
+- `bash scripts/e2e/b0-m9.3.5-description-probe.sh` green.
+- Roadmap §6.1 rule 6 footer references M9.3.5 ship status.
+
+## 7. Cascade plan
+
+| PR | Branch | Base |
+|---|---|---|
+| M9.3.5.0 (this spec) | `feat/mur-agent-b0-m9.3.5-spec` | main |
+| M9.3.5.1 probe + pin | `feat/mur-agent-b0-m9.3.5.1-probe` | M9.3.5.0 |
+| M9.3.5.2 inspect --probe | `feat/mur-agent-b0-m9.3.5.2-inspect-probe` | M9.3.5.1 |
+| M9.3.5.3 E2E + cookbook | `feat/mur-agent-b0-m9.3.5.3-e2e` | M9.3.5.2 |
+
+3 mur-side PRs after the spec. Estimated ~1.5 dev-days. Same Tier 2
+stacked-PR recipe as M5 / M7 / M8 / M9.


### PR DESCRIPTION
## Summary
- Spec for the M9.3.5 cascade closing the description-hash half of B0 rule 6.
- 3-milestone plan with reuse-everything strategy (helpers from M9.2 + McpClient from runtime crate are already in place).
- Reframes the live-probe trigger from "supervisor startup" (N×-bloat boot) to "user-initiated `mur agent mcp pin` / `inspect --probe`".

## Plan
- M9.3.5.1 `probe_mcp_descriptions` helper + `cmd_mcp_pin` enhancement
- M9.3.5.2 `mur agent mcp inspect --probe` (lights up reserved codes 2 + 3)
- M9.3.5.3 e2e + cookbook update

## Test plan
- [ ] User review of spec
- [ ] ~1.5 dev-days, same Tier 2 stacked-PR cascade

🤖 Generated with [Claude Code](https://claude.com/claude-code)