### PR TITLE
deps(mur-core): bump tantivy 0.22 → 0.24 to dedupe with lance (PR-F-small)

### DIFF
--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -46,7 +46,8 @@ sha2 = "0.10"
 hex = "0.4"
 regex = "1"
 lancedb = "0.26"
-tantivy = "0.22"
+tantivy = "0.24"   # match lance's transitive dep so we don't compile two
+                   # tantivy versions (~50K LOC each) on every CI run
 qdrant-client = "1.12"
 arrow-array = "57"
 arrow-schema = "57"


### PR DESCRIPTION
## Summary
Tiny dep bump that eliminates a duplicate compile. \`lance\` (transitive via \`lancedb\`) pulls \`tantivy = 0.24\`; mur-core directly used \`tantivy = 0.22\`, so CI compiled both versions of tantivy (~50K LOC each) on every run.

After this PR, \`cargo tree --invert tantivy\` confirms a single \`tantivy v0.24.2\` used by both lance and mur-core.

## Why
PR-F-small from the [CI speedup audit](https://github.com/mur-run/mur/actions/runs/25401203432) on 2026-05-05. Out of 168 duplicate package versions in the workspace, tantivy was the lowest-effort dedup with no API breakage — only 2 minor versions apart, surface area = \`Index\`, \`IndexReader\`, \`IndexWriter\`, \`ReloadPolicy\`, \`TantivyDocument\`, \`doc!\`, \`query::QueryParser\`, \`schema::*\`, \`Term::from_field_text\`.

## Estimated impact
- ~1.5-2 min off Windows compile per CI run
- Smaller target/ for rust-cache restore (proportional to one less ~50K LOC compile)
- No runtime behavior change (BM25 ranking semantics preserved across 0.22 → 0.24)

## Verification (local)
- \`cargo check -p mur-core\` — clean, no source changes needed
- \`cargo test -p mur-core --lib sources::\` — 41/41 pass
- \`cargo tree --workspace -e=normal --invert tantivy\` confirms single version

## Note on Cargo.lock
mur intentionally doesn't track \`Cargo.lock\` (per \`.gitignore\`). Cargo will resolve \`tantivy = 0.24\` to the latest 0.24.x at CI time, matching lance's transitive constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)