### PR TITLE
feat(mur-core): feature-gate qdrant-client (~3-5 min Windows CI savings, PR-F-medium)

### DIFF
--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -48,7 +48,7 @@ regex = "1"
 lancedb = "0.26"
 tantivy = "0.24"   # match lance's transitive dep so we don't compile two
                    # tantivy versions (~50K LOC each) on every CI run
-qdrant-client = "1.12"
+qdrant-client = { version = "1.12", optional = true }   # gated behind `qdrant` feature
 arrow-array = "57"
 arrow-schema = "57"
 futures = "0.3"
@@ -84,6 +84,13 @@ cli = ["dialoguer", "console", "clap"]
 server = ["axum", "tower-http", "rust-embed"]
 sources = []
 ollama-live-smoke = []
+# `qdrant` enables QdrantStore as a vector_backend. Off by default because
+# the qdrant-client@1.x dep tree drags in older axum/hyper/prost/tower/
+# reqwest/tonic versions (~5 duplicate compiles in our workspace), costing
+# ~3-5 min Windows CI compile per run. lancedb is the default backend
+# anyway; flip this only when you need to point at a remote Qdrant.
+#   cargo build --features qdrant
+qdrant = ["dep:qdrant-client"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/mur-core/src/store/vector/factory.rs
+++ b/mur-core/src/store/vector/factory.rs
@@ -1,7 +1,7 @@
 //! Vector store factory.
 //!
 //! Returns an `Arc<dyn VectorStore>` selected by `Config::storage::vector_backend`.
-//! Phase 1.1 supports `"lancedb"`; `"qdrant"` arrives in P1.3.
+//! Default is `"lancedb"`. `"qdrant"` requires building with `--features qdrant`.
 
 use anyhow::{Context, Result, bail};
 use mur_common::config::Config;
@@ -20,6 +20,7 @@ pub async fn get_vector_store(cfg: &Config, index_dir: &Path) -> Result<Arc<dyn 
                 .context("opening LanceDB vector store")?;
             Ok(Arc::new(store))
         }
+        #[cfg(feature = "qdrant")]
         "qdrant" => {
             let url = cfg
                 .storage
@@ -31,6 +32,11 @@ pub async fn get_vector_store(cfg: &Config, index_dir: &Path) -> Result<Arc<dyn 
                 .context("opening Qdrant vector store")?;
             Ok(Arc::new(store))
         }
+        #[cfg(not(feature = "qdrant"))]
+        "qdrant" => bail!(
+            "vector_backend = \"qdrant\" requires building mur with `--features qdrant`. \
+             Default builds use lancedb to keep CI fast (qdrant-client adds ~3-5 min compile)."
+        ),
         other => bail!("unknown storage.vector_backend: {other}"),
     }
 }
@@ -55,6 +61,7 @@ mod tests {
         let _ = store.count(None).await;
     }
 
+    #[cfg(feature = "qdrant")]
     #[tokio::test]
     async fn factory_qdrant_requires_url() {
         let tmp = TempDir::new().unwrap();
@@ -65,6 +72,19 @@ mod tests {
         assert!(
             err.to_string().contains("qdrant_url"),
             "expected qdrant_url error, got: {err}"
+        );
+    }
+
+    #[cfg(not(feature = "qdrant"))]
+    #[tokio::test]
+    async fn factory_qdrant_without_feature_emits_helpful_error() {
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = dims_128_cfg();
+        cfg.storage.vector_backend = "qdrant".into();
+        let err = get_vector_store(&cfg, tmp.path()).await.err().unwrap();
+        assert!(
+            err.to_string().contains("--features qdrant"),
+            "expected feature-gate hint, got: {err}"
         );
     }
 

--- a/mur-core/src/store/vector/mod.rs
+++ b/mur-core/src/store/vector/mod.rs
@@ -20,8 +20,9 @@ pub mod qdrant;
 pub mod tests;
 
 pub use self::lancedb::LanceDbStore;
+// QdrantStore selected at runtime via factory; re-exported for `tests/qdrant_smoke.rs`.
 #[cfg(all(feature = "qdrant", feature = "sources"))]
-#[allow(unused_imports)] // QdrantStore selected at runtime via factory; re-exported for `tests/qdrant_smoke.rs`
+#[allow(unused_imports)]
 pub use self::qdrant::QdrantStore;
 
 /// An embedded chunk ready to be stored.

--- a/mur-core/src/store/vector/mod.rs
+++ b/mur-core/src/store/vector/mod.rs
@@ -1,8 +1,11 @@
 //! Abstract vector store trait.
 //!
-//! Phase 1 has one implementation (`lancedb::LanceDbStore`). Phase 1.3 adds
-//! `qdrant::QdrantStore`. Callers interact through `Arc<dyn VectorStore>`
-//! obtained from `factory::get_vector_store(&config, &index_dir)`.
+//! Default implementation is `lancedb::LanceDbStore`. `qdrant::QdrantStore`
+//! is feature-gated behind `--features qdrant` because qdrant-client@1.x
+//! drags in an older HTTP/proto stack (axum 0.7, hyper 0.14, prost 0.13,
+//! tower 0.4, reqwest 0.11, tonic 0.12) that costs ~3-5 min Windows CI
+//! compile time. Callers interact through `Arc<dyn VectorStore>` obtained
+//! from `factory::get_vector_store(&config, &index_dir)`.
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -10,14 +13,15 @@ use chrono::{DateTime, Utc};
 
 pub mod factory;
 pub mod lancedb;
+#[cfg(feature = "qdrant")]
 pub mod qdrant;
 
 #[cfg(test)]
 pub mod tests;
 
 pub use self::lancedb::LanceDbStore;
-#[cfg(feature = "sources")]
-#[allow(unused_imports)] // QdrantStore selected at runtime via factory; wired to CLI in P1.4
+#[cfg(all(feature = "qdrant", feature = "sources"))]
+#[allow(unused_imports)] // QdrantStore selected at runtime via factory; re-exported for `tests/qdrant_smoke.rs`
 pub use self::qdrant::QdrantStore;
 
 /// An embedded chunk ready to be stored.

--- a/mur-core/tests/qdrant_smoke.rs
+++ b/mur-core/tests/qdrant_smoke.rs
@@ -1,9 +1,10 @@
 //! Runs the VectorStore conformance suite against a live Qdrant instance.
-//! Skipped unless `QDRANT_URL` is set.
+//! Skipped unless `QDRANT_URL` is set. Compiled only with `--features qdrant`.
 //!
 //! CI recipe:
 //!   docker compose -f docker/qdrant-compose.yml up -d
-//!   QDRANT_URL=http://localhost:6333 cargo test --test qdrant_smoke
+//!   QDRANT_URL=http://localhost:6333 cargo test --test qdrant_smoke --features qdrant
+#![cfg(feature = "qdrant")]
 
 use mur_core::store::vector::{QdrantStore, VectorStore};
 


### PR DESCRIPTION
## Summary
\`qdrant-client@1.x\` is a heavyweight transitive in mur-core that drags in an older HTTP/proto stack:

| Crate | qdrant pulls | Rest of workspace uses |
|---|---|---|
| axum | 0.7 | 0.8 |
| hyper | 0.14 | 1.x |
| prost | 0.13 | 0.14 |
| reqwest | 0.11 | 0.12 |
| tower | 0.4 | 0.5 |
| tonic | 0.12 | (not used) |

All compiled twice on every CI run for code that only fires when a user opts into Qdrant via \`storage.vector_backend = \"qdrant\"\` (default = lancedb). Most users never touch this path.

## What this PR does
Makes \`qdrant-client\` optional behind a new \`qdrant\` cargo feature, **off by default**. Default \`cargo build\` produces a lancedb-only mur with no qdrant-client / axum 0.7 / hyper 0.14 / etc. in the build graph.

To opt in:
\`\`\`bash
cargo build --features qdrant
\`\`\`

Runtime path produces a clear error when the feature is missing:
> \`vector_backend = \"qdrant\" requires building mur with \`--features qdrant\`. Default builds use lancedb to keep CI fast (qdrant-client adds ~3-5 min compile).\`

## Files changed (~41 lines net)
- \`mur-core/Cargo.toml\` — \`qdrant-client = { ..., optional = true }\` + new \`[features] qdrant = [\"dep:qdrant-client\"]\`
- \`mur-core/src/store/vector/mod.rs\` — \`#[cfg(feature = \"qdrant\")]\` gates on \`pub mod qdrant;\` and the \`pub use\` re-export
- \`mur-core/src/store/vector/factory.rs\` — split match arm into feature-on / feature-off paths; helpful error in feature-off; tests for each
- \`mur-core/tests/qdrant_smoke.rs\` — \`#![cfg(feature = \"qdrant\")]\` so it doesn't try to compile without the feature

## Verification
- \`cargo check -p mur-core\` (default features) — clean; \`cargo tree\` confirms qdrant-client absent
- \`cargo test -p mur-core --lib store::vector\` — 16/16 pass
- \`cargo clippy -p mur-core --lib --tests -- -D warnings\` — clean
- \`cargo tree -p mur-core --features qdrant\` — qdrant-client v1.17.0 + duplicates reappear (expected)

## Estimated impact
- **~3-5 min off Windows CI per run** (default builds — vast majority of CI runs)
- Smaller \`target/\` for rust-cache restore
- Works alongside [#193 (tantivy dedup)](https://github.com/mur-run/mur/pull/193); they target different duplicates

## Follow-up (not in this PR)
The CI workflow should add a Linux-only step that does \`cargo check -p mur-core --features qdrant\` so the qdrant path doesn't bitrot. Kept scope tight here; tracked in the audit memo at \`~/.claude/projects/-Volumes-Firecuda4tb-Projects-mur/memory/project_ci_speedup_2026_05_05.md\`.

## References
- Pre-merge audit findings (Cargo tree dups, qdrant-client as the dominant cause): see \"PR-F-medium\" in the CI-speedup memo
- [#193 PR-F-small](https://github.com/mur-run/mur/pull/193) — sibling tantivy dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)