### PR TITLE
ci(paths-filter): remove `predicate-quantifier: every` (was bypassing tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,16 @@ jobs:
       - id: filter
         uses: dorny/paths-filter@v3
         with:
-          # On push:main, paths-filter sees no diff context — force
-          # everything to true via predicate-quantifier so we never
-          # accidentally skip a job after merge.
-          predicate-quantifier: 'every'
+          # Use the default `some` quantifier — at least ONE changed file
+          # matching a filter's patterns is enough to trigger that filter.
+          # The previous `predicate-quantifier: every` was a misreading of
+          # the docs and required ALL changed files to match, so any
+          # multi-file PR that touched even one file outside a filter's
+          # patterns came back false → all jobs skipped → tests bypassed.
+          #
+          # For push:main events, paths-filter falls back to "match all
+          # filters as true" automatically when there's no diff context,
+          # so the post-merge safety net is preserved without `every`.
           filters: |
             code:
               - '**/*.rs'


### PR DESCRIPTION
## Summary
**This is a bugfix for a CI gate that's been silently bypassing tests** since #190 (PR-D paths-filter) merged.

The \`predicate-quantifier: 'every'\` setting was a misreading of [dorny/paths-filter v3 docs](https://github.com/dorny/paths-filter#determining-changes):

- \`'some'\` (default): **at least one** changed file matches a filter's patterns → filter true
- \`'every'\`: **every** changed file must match → filter true

I had \`every\` configured. Result: any multi-file PR that touched even one file outside a filter's patterns came back \`false\` for all filters → \`test\` / \`clippy\` / \`gui\` / \`e2e_quick\` all **skipped** → \`CI pass\` aggregator showed green because \`skipped\` was acceptable.

## Affected PRs
Confirmed via \`gh run view\` that **#193 and #196** both passed CI without their test matrices ever executing:

\`\`\`
PR 196 (qdrant feature-gate):
  Detect changed paths → outputs.code: false, gui: false, e2e: false
  Test (...) → skipped
  Clippy → skipped
  GUI crate → skipped
  E2E quick → skipped
  CI pass → ✅ (because skipped is acceptable)
\`\`\`

I tested both PRs locally before pushing, so they're not actually broken — but the CI gate was broken.

## What this fixes
Removing \`predicate-quantifier: 'every'\` lets the action use the default \`'some'\`, which means a filter triggers if **any** changed file matches its patterns. This is what we actually want.

The original concern about \`push:main\` no-diff context is unfounded — paths-filter automatically returns true for all filters when there's no diff context, so the post-merge safety net is preserved.

## After this lands
Re-trigger CI on #193 and #196 (force-push or empty commit) to confirm their test matrices actually execute. If those pass, merge them. If anything fails, that's a real bug we missed.

## Risk
Low. The bug currently in main makes CI **less strict** than intended; this fix restores the intended behavior. Worst case: a PR's test matrix runs that didn't before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)