### PR TITLE
ci: drop `predicate-quantifier: every` (path-filter correctness fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,15 @@ jobs:
       - id: filter
         uses: dorny/paths-filter@v3
         with:
-          # On push:main, paths-filter sees no diff context — force
-          # everything to true via predicate-quantifier so we never
-          # accidentally skip a job after merge.
-          predicate-quantifier: 'every'
+          # Default `some` semantics: filter is true iff AT LEAST ONE
+          # changed file matches the pattern set. We previously set
+          # `every` here intending to "fail safe" on push:main, but
+          # `every` means the OPPOSITE — it only matches when EVERY
+          # changed file is in the filter, so a PR that touches a
+          # Rust file AND a docs file silently skipped Test / Clippy.
+          # Caught on M10 PR #199 + qdrant feature-gate PR #196.
+          # The push:main safety is already provided by the per-job
+          # `if: github.event_name == 'push' || …` short-circuit.
           filters: |
             code:
               - '**/*.rs'


### PR DESCRIPTION
## Summary
- `predicate-quantifier: every` was the wrong direction — it requires EVERY changed file to match the filter, not "at least one matches". So mixed Rust+docs PRs silently skipped Test/Clippy/GUI/E2E.
- Caught on #196 (qdrant feature-gate) + #199 (M10 crashlog redactor); both merged with local-only verification.
- Removing the quantifier defaults to `some` semantics (at least one match) which is what we wanted.
- The push:main safety net is the per-job `if: github.event_name == 'push' || ...` short-circuit, not the quantifier.

## Test plan
- [ ] This PR itself only touches `.github/workflows/ci.yml`. With the fix, the `code:` filter should evaluate FALSE (only a workflow file changed, not Rust). Test/Clippy stay SKIPPED — that's correct.
- [ ] Watch the next mixed Rust+docs PR after merge — Test/Clippy should now run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)