### PR TITLE
M11.1: B0 eval-harness scaffolding (re-merged)

### DIFF
--- a/mur-common/src/eval.rs
+++ b/mur-common/src/eval.rs
@@ -1,0 +1,214 @@
+//! B0 M11 — eval-harness output schema.
+//!
+//! Per-test JSONL records emitted by the Python harness in
+//! `scripts/eval/` and consumed by the Rust report aggregator
+//! (`mur agent eval report`, M11.4). Stable on-disk shape — bumping
+//! field semantics requires a new `EvalRecord.schema_version`.
+//!
+//! Spec: `docs/superpowers/specs/2026-05-06-b0-m11-eval-harness-design.md` §6.
+
+use serde::{Deserialize, Serialize};
+
+/// Schema version of the JSONL records this build emits / consumes.
+/// Increment when the JSONL contract changes; the report aggregator
+/// rejects records with a version it doesn't recognise.
+pub const EVAL_SCHEMA_VERSION: u32 = 1;
+
+/// Outcome the agent took in response to the attack — independent of
+/// whether that outcome was the "right" one (which is up to the test
+/// case's `expected` field).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalDecision {
+    /// Agent refused the attacker's instruction outright (a B0 hook
+    /// returned `Decision::Deny` or the model declined to proceed).
+    Refuse,
+    /// Agent did the user's intended thing without falling for the
+    /// embedded directive — the safe-and-correct outcome on most
+    /// indirect-injection cases.
+    ComplySafe,
+    /// Agent followed the attacker's directive — TEST FAIL on every
+    /// indirect-injection / jailbreak / agentic-misuse case.
+    ComplyUnsafe,
+}
+
+/// Which upstream benchmark the case came from. Determines how the
+/// aggregator buckets results in its markdown report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalSuite {
+    /// Princeton/ETH/Anthropic AgentDojo (Apache-2.0, NeurIPS 2024).
+    /// Indirect-prompt-injection focus.
+    Agentdojo,
+    /// CAIS HarmBench (CC-BY-4.0, ICML 2024). Jailbreak + agentic-
+    /// misuse focus.
+    Harmbench,
+}
+
+/// Which model backend produced the agent response. The mock backend
+/// is the CI-track stub; everything else is a real-LLM release-track
+/// run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvalLlmBackend {
+    /// Deterministic mock (`scripts/eval/mock_llm.py` — lands in M11.1).
+    /// Returns canonical `refuse` / `comply_safe` / `comply_unsafe`
+    /// per attack class. Fast, free, runs every PR.
+    Stub,
+    /// Anthropic API. Use for the canonical pass/fail vs. spec
+    /// thresholds. Default model: claude-sonnet-4-6.
+    Anthropic,
+    /// OpenAI API.
+    Openai,
+    /// Local Ollama. Useful for gating without an API key but
+    /// not the canonical baseline.
+    Ollama,
+}
+
+/// One observation from the B0 hook chain during the test run.
+/// Captured in chronological order so a later regression diagnosis
+/// can replay the protection logic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvalHookDecision {
+    /// Hook name + phase, e.g. `"B0SafetyHook.on_prompt_submit"`.
+    pub hook: String,
+    /// Decision returned, e.g. `"wrap_untrusted"`, `"AskUser"`,
+    /// `"Deny"`, `"Allow"`.
+    pub decision: String,
+    /// B0 rule number this firing maps to. None for hook decisions
+    /// outside the rule numbering (e.g. provenance ledger writes).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rule: Option<u32>,
+}
+
+/// One test case's result — written as a single JSONL line by the
+/// Python harness per case, parsed by `mur agent eval report` to
+/// build the markdown summary.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvalRecord {
+    /// Wire-version of this struct; mismatches abort report
+    /// generation rather than producing silently-wrong aggregates.
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    pub test_suite: EvalSuite,
+    /// Stable identifier — `<suite>:<env>:<id>` for AgentDojo,
+    /// `<suite>:<behavior_id>` for HarmBench.
+    pub test_id: String,
+    /// Free-form upstream tag, e.g. `"data_exfil"`,
+    /// `"prompt_injection"`, `"agentic_misuse"`. Used to bucket
+    /// the markdown report by category.
+    pub attack_category: String,
+    pub agent_decision: EvalDecision,
+    pub expected: EvalDecision,
+    pub passed: bool,
+    /// B0 hook chain trace for this test, in order. Empty if the
+    /// Python harness ran in fast-only mode (no hook capture).
+    #[serde(default)]
+    pub hook_decisions: Vec<EvalHookDecision>,
+    /// LLM token usage. None for the stub backend (no real tokens).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens_input: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tokens_output: Option<u64>,
+    pub wall_clock_ms: u64,
+    pub llm_backend: EvalLlmBackend,
+    /// Free-form model identifier — `"claude-sonnet-4-6"`,
+    /// `"stub"`, `"llama3.2:3b"`, etc.
+    pub llm_model: String,
+    /// Run-id this record belongs to; aggregator groups by this.
+    /// Format: ULID so records sort by time.
+    pub run_id: String,
+    /// RFC3339 timestamp of when this case finished.
+    pub timestamp: String,
+}
+
+fn default_schema_version() -> u32 {
+    EVAL_SCHEMA_VERSION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// JSONL contract: every record round-trips through serde_json
+    /// without losing any field. Catches accidental schema drift.
+    #[test]
+    fn record_roundtrips_full_fields() {
+        let r = EvalRecord {
+            schema_version: EVAL_SCHEMA_VERSION,
+            test_suite: EvalSuite::Agentdojo,
+            test_id: "agentdojo:slack:42".into(),
+            attack_category: "data_exfil".into(),
+            agent_decision: EvalDecision::Refuse,
+            expected: EvalDecision::Refuse,
+            passed: true,
+            hook_decisions: vec![
+                EvalHookDecision {
+                    hook: "B0SafetyHook.on_prompt_submit".into(),
+                    decision: "wrap_untrusted".into(),
+                    rule: Some(3),
+                },
+                EvalHookDecision {
+                    hook: "B0SafetyHook.pre_tool_use".into(),
+                    decision: "AskUser".into(),
+                    rule: Some(4),
+                },
+            ],
+            tokens_input: Some(9821),
+            tokens_output: Some(184),
+            wall_clock_ms: 1240,
+            llm_backend: EvalLlmBackend::Anthropic,
+            llm_model: "claude-sonnet-4-6".into(),
+            run_id: "01HF8K0M5ZQEJ8C7XV6NQAYWZP".into(),
+            timestamp: "2026-05-06T08:15:32.123Z".into(),
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let back: EvalRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, r);
+    }
+
+    /// Stub-backend records may omit `tokens_input` / `tokens_output`
+    /// (no real LLM call → no tokens). The schema must accept the
+    /// absent form on the way in.
+    #[test]
+    fn stub_record_without_tokens_roundtrips() {
+        let yaml = r#"{
+            "test_suite": "harmbench",
+            "test_id": "harmbench:b042",
+            "attack_category": "direct_jailbreak",
+            "agent_decision": "refuse",
+            "expected": "refuse",
+            "passed": true,
+            "wall_clock_ms": 38,
+            "llm_backend": "stub",
+            "llm_model": "stub",
+            "run_id": "01HF8K0M5ZQEJ8C7XV6NQAYWZP",
+            "timestamp": "2026-05-06T08:15:32.123Z"
+        }"#;
+        let r: EvalRecord = serde_json::from_str(yaml).unwrap();
+        assert_eq!(r.schema_version, EVAL_SCHEMA_VERSION); // applied default
+        assert_eq!(r.tokens_input, None);
+        assert_eq!(r.tokens_output, None);
+        assert!(r.hook_decisions.is_empty());
+    }
+
+    /// Decision serialization is snake_case so the Python harness
+    /// can emit canonical strings without a Rust import.
+    #[test]
+    fn decision_strings_are_snake_case() {
+        let r = serde_json::to_string(&EvalDecision::ComplyUnsafe).unwrap();
+        assert_eq!(r, "\"comply_unsafe\"");
+        let r = serde_json::to_string(&EvalSuite::Agentdojo).unwrap();
+        assert_eq!(r, "\"agentdojo\"");
+        let r = serde_json::to_string(&EvalLlmBackend::Anthropic).unwrap();
+        assert_eq!(r, "\"anthropic\"");
+    }
+
+    /// Schema-version mismatch must be detectable without panic so
+    /// the report aggregator can refuse to produce a misleading
+    /// summary on a future-format JSONL.
+    #[test]
+    fn schema_version_constant_is_one() {
+        assert_eq!(EVAL_SCHEMA_VERSION, 1);
+    }
+}

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -9,6 +9,8 @@ pub mod companion;
 pub mod config;
 pub mod conversation;
 pub mod error;
+/// B0 M11 — JSONL output schema for the eval harness.
+pub mod eval;
 pub mod event;
 pub mod identity;
 pub mod knowledge;

--- a/scripts/eval/LICENSES.md
+++ b/scripts/eval/LICENSES.md
@@ -1,0 +1,70 @@
+# Upstream benchmark licenses
+
+The B0 eval harness pip-installs two upstream benchmarks. Their
+licenses + attribution are reproduced here so users running the
+harness see the obligations without leaving the repo.
+
+## AgentDojo
+
+> Apache License 2.0
+>
+> Copyright 2024 ETH Zürich + Princeton + Tübingen + Anthropic + Meta
+>
+> Licensed under the Apache License, Version 2.0 (the "License");
+> you may not use this file except in compliance with the License.
+> You may obtain a copy of the License at
+>
+>     http://www.apache.org/licenses/LICENSE-2.0
+>
+> Unless required by applicable law or agreed to in writing, software
+> distributed under the License is distributed on an "AS IS" BASIS,
+> WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+> implied. See the License for the specific language governing
+> permissions and limitations under the License.
+
+Cite as:
+
+> Debenedetti, Edoardo et al. "AgentDojo: A Dynamic Environment to
+> Evaluate Prompt Injection Attacks and Defenses for LLM Agents."
+> NeurIPS 2024 (Datasets and Benchmarks Track).
+
+Project: https://github.com/ethz-spylab/agentdojo
+
+## HarmBench
+
+> Creative Commons Attribution 4.0 International (CC-BY-4.0)
+>
+> You are free to:
+>   - Share — copy and redistribute the material in any medium or format
+>   - Adapt — remix, transform, and build upon the material
+>     for any purpose, even commercially.
+>
+> Under the following terms:
+>   - Attribution — You must give appropriate credit, provide a link
+>     to the license, and indicate if changes were made. You may do so
+>     in any reasonable manner, but not in any way that suggests the
+>     licensor endorses you or your use.
+
+Cite as:
+
+> Mazeika, Mantas et al. "HarmBench: A Standardized Evaluation
+> Framework for Automated Red Teaming and Robust Refusal."
+> ICML 2024.
+
+Project: https://github.com/centerforaisafety/HarmBench
+
+## How we use these benchmarks
+
+- **No relabelling.** The dataset entries are used verbatim. We do
+  not re-categorize attacks or alter the expected outcomes.
+- **Subset selection only.** We pick 50 cases per benchmark for the
+  v1 acceptance gate; the choice is reproducible via a published
+  SHA-256-derived seed (see `README.md` §"Selection seed").
+- **Results published per release tag.** Each `eval-results/v<X.Y.Z>.jsonl`
+  cites the upstream version that was used + the model that
+  generated the responses, so reproducibility chains back to the
+  benchmark's own commit hash.
+
+If you redistribute mur with the eval harness disabled
+(`--features no-eval`), you don't need to include these licenses; if
+the harness is enabled in your build, you do.

--- a/scripts/eval/README.md
+++ b/scripts/eval/README.md
@@ -1,0 +1,64 @@
+# mur B0 eval harness
+
+Closes the v1 B0 quantitative acceptance gate via two upstream
+benchmarks: AgentDojo (indirect-injection) + HarmBench (jailbreak +
+agentic misuse).
+
+This directory is the **measurement infrastructure**, not new B0
+protection logic. The B0 hooks are already implemented in
+`mur-agent-runtime/src/hooks/` (M7.x + M8.x + M9.x + M10).
+
+## Status
+
+| Milestone | State |
+|---|---|
+| M11.0 design | shipped (`docs/superpowers/specs/2026-05-06-b0-m11-eval-harness-design.md`) |
+| M11.1 scaffolding | this PR |
+| M11.2 AgentDojo runner | TODO |
+| M11.3 HarmBench runner | TODO |
+| M11.4 report aggregator | TODO |
+| M11.5 CI integration | TODO |
+| M11.6 first real-run baseline | TODO |
+
+The Python harness (M11.2 / M11.3), the report aggregator (M11.4),
+and the CI workflow (M11.5) are not yet implemented. This directory
+currently holds:
+
+- license attribution for the upstream benchmarks
+- pinned dependency requirements
+- this README (status + pointers)
+
+## Two-track output
+
+- **CI gate (mock-LLM):** runs on every PR. Free, deterministic.
+  Detects regressions in the B0 hook chain.
+- **Release gate (real-LLM):** runs once per release tag against
+  Anthropic Sonnet 4.5+ at `temperature=0`. Manually triggered to
+  cap cost. Result committed to `eval-results/v<X.Y.Z>.jsonl`.
+
+## Selection seed
+
+The 50-case subsets (one each from AgentDojo + HarmBench) are
+selected with a fixed seed so the choice is reproducible:
+
+```
+seed = int(SHA256("mur-b0-acceptance-2026").hexdigest()[:8], 16)
+```
+
+Selection scripts will land in M11.2 / M11.3 and emit
+`scripts/eval/{agentdojo,harmbench}/case_selection.json` (committed).
+
+## Costs
+
+Per release-gate run (50 + 50 tests, Anthropic Sonnet 4.5,
+~10 K input + 200 output tokens / test): ~$5.
+
+Hard cap enforced by M11.5: fail loudly if `tokens_input > 50K` total
+OR `wall_clock > 30 min`.
+
+## See also
+
+- `docs/superpowers/specs/2026-05-06-b0-m11-eval-harness-design.md` (full design)
+- `docs/superpowers/specs/2026-04-30-mur-agent-harness-roadmap-design.md` §6.1 (B0 acceptance gate target)
+- `LICENSES.md` (upstream attribution)
+- `requirements.txt` (pinned upstream packages)

--- a/scripts/eval/requirements.txt
+++ b/scripts/eval/requirements.txt
@@ -1,0 +1,25 @@
+# mur B0 eval harness — pinned upstream deps (M11.1).
+#
+# Both packages are pinned to specific versions so re-runs against a
+# given mur tag are reproducible. Bump these only as part of a deliberate
+# eval-harness update PR; the resulting drift in pass-rates should be
+# noted in `eval-results/v<X.Y.Z>.jsonl`.
+#
+# License compatibility: AgentDojo Apache-2.0 + HarmBench CC-BY-4.0 —
+# both compatible with mur's MIT. Attribution: scripts/eval/LICENSES.md.
+
+# AgentDojo — indirect-injection benchmark (Princeton/ETH/Anthropic 2024).
+# Pinned to the published v0.1.32 wheel; later versions may add new
+# environments that the M11.2 case-selection seed wouldn't cover.
+agentdojo==0.1.32
+
+# HarmBench — jailbreak + agentic-misuse benchmark (CAIS 2024).
+# Released as a GitHub repo, not a wheel; pip+git URL with commit
+# hash for full reproducibility. Bump the hash to update.
+harmbench @ git+https://github.com/centerforaisafety/HarmBench.git@v1.0.0
+
+# Driver glue — keep deps minimal. The harness orchestrates upstream
+# packages + spawns the mur runtime; it doesn't need a heavy framework.
+pydantic>=2.0,<3.0
+typer>=0.12,<1.0
+rich>=13.0,<14.0


### PR DESCRIPTION
## Summary
Re-applies M11.1 contents (`scripts/eval/{README,LICENSES,requirements.txt}` + `mur-common::eval` JSONL schema). The original PR #203 was marked merged in GitHub but its contents were orphaned because its base branch (the M11.0 spec branch) was squashed into main without picking up the M11.1 changes.

## Test plan
- [x] cherry-picked from `pr-203-recovery` (head SHA 592f82d preserved)
- [x] Same 4 tests as #203 — `cargo test -p mur-common --lib eval`
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)