### PR TITLE
feat(runtime): A1.2 build_chain() — config-driven HookChain assembly

### DIFF
--- a/mur-agent-runtime/src/hooks/builder.rs
+++ b/mur-agent-runtime/src/hooks/builder.rs
@@ -1,0 +1,90 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use mur_common::agent::AgentProfile;
+use mur_common::companion::Formality;
+
+use super::{
+    Hook, HookChain, b0::B0SafetyHook, companion_voice::CompanionVoiceHook, ledger::LedgerHook,
+    telemetry::TelemetryHook, voice_input::VoiceInputHook,
+};
+use crate::companion::voice::{VoiceInput, compose_with_overrides};
+use crate::voice::stt::{VadGate, WhisperStt};
+
+/// Build the `HookChain` for `profile`.
+///
+/// Mandatory tier (always present, fixed order):
+///   TelemetryHook (pos 0) → B0SafetyHook (pos 1)
+///
+/// Optional tier (auto-wire from feature flags, overridable via `profile.hooks`):
+///   LedgerHook → CompanionVoiceHook → VoiceInputHook
+///
+/// * `agent_home` — `~/.mur/agents/<name>/`
+/// * `mur_home`   — `~/.mur/`
+pub fn build_chain(profile: &AgentProfile, agent_home: &Path, mur_home: &Path) -> HookChain {
+    let cfg = &profile.hooks;
+
+    let mut chain: Vec<Arc<dyn Hook>> = vec![
+        Arc::new(TelemetryHook::new()) as Arc<dyn Hook>,
+        Arc::new(B0SafetyHook::new()),
+    ];
+
+    if cfg.ledger {
+        chain.push(Arc::new(LedgerHook::new()));
+    }
+
+    let want_companion_voice = cfg.companion_voice.unwrap_or(profile.companion.enabled);
+    if want_companion_voice {
+        let formality_str = match profile.companion.voice_overrides.formality {
+            Some(Formality::Formal) => "formal",
+            _ => "casual",
+        };
+        let extra = profile
+            .companion
+            .voice_overrides
+            .extra_instructions
+            .as_deref()
+            .unwrap_or("");
+        let first_memory = profile
+            .companion
+            .onboarding
+            .first_memory
+            .as_ref()
+            .map(|m| m.text.as_str());
+        let rendered = compose_with_overrides(
+            Some(agent_home),
+            Some(mur_home),
+            VoiceInput {
+                relationship: profile.companion.relationship.clone(),
+                locale: &profile.companion.locale,
+                name_for_user: &profile.display_name,
+                first_memory,
+                formality: formality_str,
+                extra_instructions: extra,
+            },
+        );
+        chain.push(Arc::new(CompanionVoiceHook::new(Arc::new(rendered))));
+    }
+
+    let want_voice_input = cfg.voice_input.unwrap_or(profile.voice.enabled);
+    if want_voice_input {
+        let model_path = mur_home.join("voices/whisper-large-v3-turbo-q5_1.bin");
+        match WhisperStt::new(&model_path) {
+            Ok(stt) => chain.push(Arc::new(VoiceInputHook::new(
+                stt,
+                VadGate::default(),
+                profile.voice.input_device.clone(),
+                Duration::from_secs(30),
+            ))),
+            Err(e) => tracing::warn!(
+                model = %model_path.display(),
+                error = %e,
+                "VoiceInputHook skipped: whisper model not found; \
+                 run `mur voice install` to download"
+            ),
+        }
+    }
+
+    HookChain::new(chain)
+}

--- a/mur-agent-runtime/src/hooks/mod.rs
+++ b/mur-agent-runtime/src/hooks/mod.rs
@@ -16,6 +16,7 @@ pub mod types;
 
 pub mod b0;
 pub mod b0_helpers;
+pub mod builder;
 pub mod companion_voice;
 pub mod ledger;
 pub mod telemetry;

--- a/mur-agent-runtime/tests/fixtures/bare_profile.yaml
+++ b/mur-agent-runtime/tests/fixtures/bare_profile.yaml
@@ -1,0 +1,38 @@
+schema: 1
+id: "0192f5a1-28ab-7111-8000-000000000099"
+name: "test-agent"
+display_name: "Test Agent"
+version: "0.1.0"
+persona:
+  category: research
+  description: "Minimal test profile for builder tests"
+  traits: { tone: neutral, risk: cautious, verbosity: low }
+sys_prompt_file: "sys_prompt.md"
+model: { provider: ollama, name: "qwen3:14b", params: {} }
+mcp_servers: []
+skills: []
+transport:
+  stdio: true
+  socket: { enabled: false, bind: "unix:///tmp/test-agent.sock" }
+communication: { accepts_from: ["*"], sends_to: [] }
+capabilities: []
+entitlements:
+  network:
+    inbound: { ports: [] }
+    outbound: { mode: restricted, allow_hosts: [], protocols: ["tcp"], resolve_dns: { mode: system } }
+  filesystem: { read: [], write: [], deny: [] }
+  processes: { spawn: { mode: allowlist, allowed: [] } }
+  syscalls: { mode: default }
+  limits: { memory_mb: 512, file_descriptors: 1024, processes: 32 }
+notifications: { on_task_complete: [], on_error: [], on_shutdown: [] }
+retry:
+  llm: { max_retries: 3, backoff: exponential, initial_delay_ms: 1000, max_delay_ms: 30000, retry_on: ["rate_limit"] }
+  tool: { max_retries: 1, backoff: fixed, initial_delay_ms: 500 }
+lifecycle: { restart: on_failure, max_restarts: 3, restart_window_secs: 600, stop_timeout_secs: 15, mcp_required: true }
+companion:
+  enabled: false
+  locale: "en-US"
+voice:
+  enabled: false
+created_at: "2026-05-08T00:00:00Z"
+updated_at: "2026-05-08T00:00:00Z"

--- a/mur-agent-runtime/tests/hook_builder.rs
+++ b/mur-agent-runtime/tests/hook_builder.rs
@@ -1,0 +1,89 @@
+use mur_agent_runtime::hooks::builder::build_chain;
+use mur_common::agent::AgentProfile;
+
+fn base_profile() -> AgentProfile {
+    let yaml = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/bare_profile.yaml"
+    ))
+    .unwrap();
+    serde_yaml_ng::from_str(&yaml).unwrap()
+}
+
+fn tmp_dirs() -> (tempfile::TempDir, tempfile::TempDir) {
+    (
+        tempfile::TempDir::new().unwrap(),
+        tempfile::TempDir::new().unwrap(),
+    )
+}
+
+#[test]
+fn mandatory_handlers_always_present() {
+    let profile = base_profile();
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    let names = chain.names();
+    assert_eq!(names[0], "TelemetryHook", "TelemetryHook must be first");
+    assert_eq!(names[1], "B0SafetyHook", "B0SafetyHook must be second");
+}
+
+#[test]
+fn ledger_on_by_default() {
+    let profile = base_profile();
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(
+        chain.names().contains(&"LedgerHook"),
+        "LedgerHook on by default"
+    );
+}
+
+#[test]
+fn ledger_disabled_via_hooks_config() {
+    let mut profile = base_profile();
+    profile.hooks.ledger = false;
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(
+        !chain.names().contains(&"LedgerHook"),
+        "LedgerHook must be absent"
+    );
+}
+
+#[test]
+fn companion_voice_auto_wires_when_companion_enabled() {
+    let mut profile = base_profile();
+    profile.companion.enabled = true;
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(
+        chain.names().contains(&"CompanionVoiceHook"),
+        "CompanionVoiceHook must auto-wire when companion.enabled = true"
+    );
+}
+
+#[test]
+fn companion_voice_explicit_override_when_companion_disabled() {
+    let mut profile = base_profile();
+    profile.companion.enabled = false;
+    profile.hooks.companion_voice = Some(true);
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(
+        chain.names().contains(&"CompanionVoiceHook"),
+        "hooks.companion_voice=true must override companion.enabled=false"
+    );
+}
+
+#[test]
+fn voice_input_suppressed_when_model_absent() {
+    let mut profile = base_profile();
+    profile.voice.enabled = true;
+    // mur_tmp has no voices/ dir → model not found → handler skipped gracefully
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(
+        !chain.names().contains(&"VoiceInputHook"),
+        "VoiceInputHook skipped gracefully when model absent"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `mur-agent-runtime/src/hooks/builder.rs` with `build_chain(profile, agent_home, mur_home) -> HookChain`
- Mandatory tier: TelemetryHook → B0SafetyHook (always present)
- Optional tier: LedgerHook (default-on) → CompanionVoiceHook (auto-wire from companion.enabled) → VoiceInputHook (auto-wire from voice.enabled, graceful skip if model absent)
- 6 unit tests + `tests/fixtures/bare_profile.yaml` fixture

## Test plan
- [x] `cargo test -p mur-agent-runtime --test hook_builder` — 6 passed
- [x] `cargo clippy -p mur-agent-runtime -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)