### PR TITLE
feat(runtime): A1.3 supervisor uses build_chain() — replaces inline HookChain::new

### DIFF
--- a/docs/superpowers/plans/2026-05-08-mur-agent-a1-handler-picker.md
+++ b/docs/superpowers/plans/2026-05-08-mur-agent-a1-handler-picker.md
@@ -1,0 +1,972 @@
+# mur Agent A1 — Config-Driven Handler Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `hooks:` block to `profile.yaml` that controls which built-in handlers join the `HookChain`, and formally wire the two currently-disconnected handlers (`CompanionVoiceHook`, `VoiceInputHook`) based on feature flags.
+
+**Architecture:** Four stacked PRs off `main`. A1.1 adds `HooksConfig` to `mur-common`. A1.2 adds `build_chain()` to `mur-agent-runtime` and wires the optional handlers. A1.3 replaces the hardcoded chain assembly in `supervisor.rs`. A1.4 adds `mur agent hooks show [--json]` to `mur-core`. Cascade-merge bottom-up (squash + retarget to main) as in D3.
+
+**Tech Stack:** Rust 2024, `serde`, `clap`, existing `CompanionVoiceHook` / `VoiceInputHook` / `LedgerHook` / `B0SafetyHook` / `TelemetryHook` in `mur-agent-runtime`.
+
+**Commit prefix:** `A1.<milestone>.<task>: <subject>`
+
+**Branch policy:**
+- `feat/mur-agent-a1-handler-picker-a1.1-schema`
+- `feat/mur-agent-a1-handler-picker-a1.2-builder`
+- `feat/mur-agent-a1-handler-picker-a1.3-supervisor`
+- `feat/mur-agent-a1-handler-picker-a1.4-cli`
+
+Each stacks on the previous. Merge order: A1.1 → A1.2 → A1.3 → A1.4.
+
+**Key invariant:** `B0SafetyHook` and `TelemetryHook` are **always** in the chain (positions 0 and 1). They cannot be suppressed by any `hooks:` config. `LedgerHook` is default-on but can be disabled. `CompanionVoiceHook` / `VoiceInputHook` auto-wire from `companion.enabled` / `voice.enabled` and can be overridden.
+
+**Test command for mur-agent-gui (workspace-excluded):**
+```bash
+PROTOC=/opt/homebrew/bin/protoc cargo test --manifest-path mur-agent-gui/src-tauri/Cargo.toml
+```
+
+**cargo path:** `/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo` (not on PATH; use full path or `PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"`).
+
+---
+
+## File Map
+
+```
+mur-common/src/
+  hooks_config.rs                      CREATE — HooksConfig struct
+  lib.rs                               MODIFY — pub mod hooks_config; pub use hooks_config::HooksConfig;
+  agent.rs                             MODIFY — add `pub hooks: HooksConfig` to AgentProfile
+
+mur-common/tests/
+  hooks_config.rs                      CREATE — 4 unit tests
+
+mur-agent-runtime/src/hooks/
+  builder.rs                           CREATE — build_chain(profile, agent_home, mur_home)
+  mod.rs                               MODIFY — pub mod builder;
+
+mur-agent-runtime/src/
+  supervisor.rs                        MODIFY — replace inline HookChain::new([...]) with build_chain()
+
+mur-agent-runtime/tests/
+  hook_builder.rs                      CREATE — 6 unit tests
+
+mur-core/src/cmd/
+  agent_hooks.rs                       CREATE — cmd_hooks_show(name, json) impl
+  agent.rs                             MODIFY — (no change needed; hooks show wires through main.rs)
+
+mur-core/src/
+  main.rs                              MODIFY — add Hooks { action } arm + AgentHooksAction enum + dispatch
+```
+
+---
+
+## Milestone A1.1 — `HooksConfig` schema in mur-common
+
+**Branch:** `feat/mur-agent-a1-handler-picker-a1.1-schema` off `main`
+
+### Task A1.1.1: Add `HooksConfig` + `AgentProfile.hooks` field
+
+**Files:**
+- Create: `mur-common/src/hooks_config.rs`
+- Modify: `mur-common/src/lib.rs`
+- Modify: `mur-common/src/agent.rs`
+- Create: `mur-common/tests/hooks_config.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+// mur-common/tests/hooks_config.rs
+use mur_common::HooksConfig;
+
+#[test]
+fn hooks_config_defaults() {
+    let cfg = HooksConfig::default();
+    assert!(cfg.ledger, "ledger default is true");
+    assert_eq!(cfg.companion_voice, None, "companion_voice default is None (auto)");
+    assert_eq!(cfg.voice_input, None, "voice_input default is None (auto)");
+}
+
+#[test]
+fn hooks_config_roundtrip_empty_yaml() {
+    // A profile.yaml with no hooks: block at all should deserialize to defaults.
+    let yaml = "ledger: true\n";
+    let cfg: HooksConfig = serde_yaml::from_str(yaml).unwrap();
+    assert!(cfg.ledger);
+    assert_eq!(cfg.companion_voice, None);
+}
+
+#[test]
+fn hooks_config_partial_override_ledger_false() {
+    let yaml = "ledger: false\n";
+    let cfg: HooksConfig = serde_yaml::from_str(yaml).unwrap();
+    assert!(!cfg.ledger);
+    assert_eq!(cfg.companion_voice, None);
+    assert_eq!(cfg.voice_input, None);
+}
+
+#[test]
+fn hooks_config_explicit_companion_voice_true() {
+    let yaml = "companion_voice: true\n";
+    let cfg: HooksConfig = serde_yaml::from_str(yaml).unwrap();
+    assert!(cfg.ledger, "ledger still defaults to true");
+    assert_eq!(cfg.companion_voice, Some(true));
+    assert_eq!(cfg.voice_input, None);
+}
+```
+
+- [ ] **Step 2: Run, confirm fail**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo test -p mur-common --test hooks_config 2>&1 | tail -5
+```
+Expected: `error[E0432]: unresolved import 'mur_common::HooksConfig'`
+
+- [ ] **Step 3: Create `mur-common/src/hooks_config.rs`**
+
+```rust
+use serde::{Deserialize, Serialize};
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HooksConfig {
+    /// Whether the outbox `LedgerHook` runs. Default: true.
+    #[serde(default = "default_true")]
+    pub ledger: bool,
+
+    /// Whether `CompanionVoiceHook` runs.
+    /// `None` = auto-wire from `profile.companion.enabled`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub companion_voice: Option<bool>,
+
+    /// Whether `VoiceInputHook` runs.
+    /// `None` = auto-wire from `profile.voice.enabled`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub voice_input: Option<bool>,
+}
+
+impl Default for HooksConfig {
+    fn default() -> Self {
+        Self {
+            ledger: true,
+            companion_voice: None,
+            voice_input: None,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Wire into `mur-common/src/lib.rs`**
+
+Find the block of `pub mod` declarations and append:
+
+```rust
+pub mod hooks_config;
+pub use hooks_config::HooksConfig;
+```
+
+- [ ] **Step 5: Add `hooks` field to `AgentProfile` in `mur-common/src/agent.rs`**
+
+Find `pub voice: VoiceConfig,` (around line 49) and add directly after it:
+
+```rust
+    /// A1: config-driven handler picker. Absent block = all defaults.
+    #[serde(default)]
+    pub hooks: HooksConfig,
+```
+
+- [ ] **Step 6: Run tests, confirm pass**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo test -p mur-common --test hooks_config 2>&1 | tail -10
+```
+Expected: `4 passed`.
+
+- [ ] **Step 7: Run full mur-common suite + lint**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo test -p mur-common && \
+  cargo clippy -p mur-common -- -D warnings && \
+  cargo fmt --check
+```
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mur-common/src/hooks_config.rs mur-common/src/lib.rs \
+        mur-common/src/agent.rs mur-common/tests/hooks_config.rs
+git commit -m "A1.1.1: HooksConfig schema + AgentProfile.hooks field"
+```
+
+---
+
+## Milestone A1.2 — `build_chain()` builder in mur-agent-runtime
+
+**Branch:** `feat/mur-agent-a1-handler-picker-a1.2-builder` off `a1.1-schema`
+
+### Task A1.2.1: `hooks::builder` module with unit tests
+
+**Files:**
+- Create: `mur-agent-runtime/src/hooks/builder.rs`
+- Modify: `mur-agent-runtime/src/hooks/mod.rs`
+- Create: `mur-agent-runtime/tests/hook_builder.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+// mur-agent-runtime/tests/hook_builder.rs
+use mur_agent_runtime::hooks::builder::build_chain;
+use mur_common::agent::{AgentProfile, CompanionConfig, VoiceConfig};
+use mur_common::HooksConfig;
+use std::path::Path;
+
+/// Helper: a minimal AgentProfile with sane defaults, no companion, no voice.
+fn base_profile() -> AgentProfile {
+    let yaml = std::fs::read_to_string(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/bare_profile.yaml")
+    ).unwrap();
+    serde_yaml::from_str(&yaml).unwrap()
+}
+
+fn tmp_dirs() -> (tempfile::TempDir, tempfile::TempDir) {
+    (tempfile::TempDir::new().unwrap(), tempfile::TempDir::new().unwrap())
+}
+
+#[test]
+fn mandatory_handlers_always_present() {
+    let profile = base_profile();
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    let names = chain.names();
+    assert_eq!(names[0], "TelemetryHook", "TelemetryHook must be first");
+    assert_eq!(names[1], "B0SafetyHook", "B0SafetyHook must be second");
+}
+
+#[test]
+fn ledger_on_by_default() {
+    let profile = base_profile();
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(chain.names().contains(&"LedgerHook"), "LedgerHook on by default");
+}
+
+#[test]
+fn ledger_disabled_via_hooks_config() {
+    let mut profile = base_profile();
+    profile.hooks.ledger = false;
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(!chain.names().contains(&"LedgerHook"), "LedgerHook must be absent");
+}
+
+#[test]
+fn companion_voice_auto_wires_when_companion_enabled() {
+    let mut profile = base_profile();
+    profile.companion.enabled = true;
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(chain.names().contains(&"CompanionVoiceHook"),
+            "CompanionVoiceHook must auto-wire when companion.enabled = true");
+}
+
+#[test]
+fn companion_voice_explicit_override_when_companion_disabled() {
+    let mut profile = base_profile();
+    profile.companion.enabled = false;
+    profile.hooks.companion_voice = Some(true);
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(chain.names().contains(&"CompanionVoiceHook"),
+            "hooks.companion_voice=true must override companion.enabled=false");
+}
+
+#[test]
+fn voice_input_suppressed_when_model_absent() {
+    let mut profile = base_profile();
+    profile.voice.enabled = true;
+    // mur_tmp has no voices/ dir → model not found → handler skipped
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    // No panic; VoiceInputHook simply absent with a tracing::warn
+    assert!(!chain.names().contains(&"VoiceInputHook"),
+            "VoiceInputHook skipped gracefully when model absent");
+}
+```
+
+- [ ] **Step 2: Create `mur-agent-runtime/tests/fixtures/bare_profile.yaml`**
+
+```yaml
+schema: 1
+id: "01900000-0000-7000-8000-000000000001"
+name: "test-agent"
+display_name: "Test Agent"
+version: "0.1.0"
+persona:
+  category: general
+  traits:
+    tone: neutral
+    style: concise
+    personality: helpful
+sys_prompt_file: "sys_prompt.md"
+model:
+  provider: ollama
+  model: qwen3:14b
+transport:
+  stdio: { enabled: true }
+communication:
+  max_response_length: 4096
+  response_format: text
+capabilities: []
+entitlements:
+  llm:
+    mode: allowed
+  network:
+    outbound: { allow_hosts: [] }
+    inbound: {}
+  filesystem:
+    read: []
+    write: []
+  process:
+    spawn: []
+  resource_limits: {}
+notifications:
+  on_task_complete: false
+  on_error: false
+retry:
+  max_attempts: 3
+  backoff_ms: 500
+lifecycle:
+  execution: on_demand
+  schedule: []
+  idle_triggers: []
+identity: {}
+file_transfer: {}
+deployment: {}
+companion:
+  enabled: false
+  locale: "en-US"
+voice:
+  enabled: false
+created_at: "2026-05-08T00:00:00Z"
+updated_at: "2026-05-08T00:00:00Z"
+```
+
+- [ ] **Step 3: Run tests, confirm fail**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo test -p mur-agent-runtime --test hook_builder 2>&1 | tail -5
+```
+Expected: `error[E0432]: unresolved import 'mur_agent_runtime::hooks::builder'`
+
+- [ ] **Step 4: Create `mur-agent-runtime/src/hooks/builder.rs`**
+
+```rust
+//! A1 — config-driven chain builder.
+//!
+//! Mandatory tier (always present, fixed order):
+//!   TelemetryHook (pos 0) → B0SafetyHook (pos 1)
+//!
+//! Optional tier (auto-wire from feature flags, overridable via `profile.hooks`):
+//!   LedgerHook → CompanionVoiceHook → VoiceInputHook
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use mur_common::AgentProfile;
+use mur_common::companion::Formality;
+
+use super::{Hook, HookChain, b0::B0SafetyHook, companion_voice::CompanionVoiceHook,
+            ledger::LedgerHook, telemetry::TelemetryHook, voice_input::VoiceInputHook};
+use crate::companion::voice::{VoiceInput, compose_with_overrides};
+use crate::voice::stt::{VadGate, WhisperStt};
+
+/// Build the `HookChain` for `profile`.
+///
+/// * `agent_home` — `~/.mur/agents/<name>/`
+/// * `mur_home`   — `~/.mur/`
+pub fn build_chain(
+    profile: &AgentProfile,
+    agent_home: &Path,
+    mur_home: &Path,
+) -> HookChain {
+    let cfg = &profile.hooks;
+
+    let mut chain: Vec<Arc<dyn Hook>> = vec![
+        Arc::new(TelemetryHook::new()) as Arc<dyn Hook>,
+        Arc::new(B0SafetyHook::new()),
+    ];
+
+    if cfg.ledger {
+        chain.push(Arc::new(LedgerHook::new()));
+    }
+
+    let want_companion_voice = cfg.companion_voice
+        .unwrap_or(profile.companion.enabled);
+    if want_companion_voice {
+        let formality_str = match profile.companion.voice_overrides.formality {
+            Some(Formality::Formal) => "formal",
+            _ => "casual",
+        };
+        let extra = profile.companion.voice_overrides.extra_instructions
+            .as_deref()
+            .unwrap_or("");
+        let first_memory = profile.companion.onboarding.first_memory
+            .as_ref()
+            .map(|m| m.text.as_str());
+        let rendered = compose_with_overrides(
+            Some(agent_home),
+            Some(mur_home),
+            VoiceInput {
+                relationship: profile.companion.relationship,
+                locale: &profile.companion.locale,
+                name_for_user: &profile.display_name,
+                first_memory,
+                formality: formality_str,
+                extra_instructions: extra,
+            },
+        );
+        chain.push(Arc::new(CompanionVoiceHook::new(Arc::new(rendered))));
+    }
+
+    let want_voice_input = cfg.voice_input
+        .unwrap_or(profile.voice.enabled);
+    if want_voice_input {
+        let model_path = mur_home.join("voices/whisper-large-v3-turbo-q5_1.bin");
+        match WhisperStt::new(&model_path) {
+            Ok(stt) => chain.push(Arc::new(VoiceInputHook::new(
+                stt,
+                VadGate::default(),
+                profile.voice.input_device.clone(),
+                Duration::from_secs(30),
+            ))),
+            Err(e) => tracing::warn!(
+                model = %model_path.display(),
+                error = %e,
+                "VoiceInputHook skipped: whisper model not found; \
+                 run `mur voice install` to download"
+            ),
+        }
+    }
+
+    HookChain::new(chain)
+}
+```
+
+- [ ] **Step 5: Add `pub mod builder;` to `mur-agent-runtime/src/hooks/mod.rs`**
+
+At the end of the existing `pub mod` block (after `pub mod voice_input;`), add:
+
+```rust
+pub mod builder;
+```
+
+- [ ] **Step 6: Run tests, confirm pass**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo test -p mur-agent-runtime --test hook_builder 2>&1 | tail -15
+```
+Expected: `6 passed`.
+
+- [ ] **Step 7: Run full runtime suite + lint**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo test -p mur-agent-runtime && \
+  cargo clippy -p mur-agent-runtime -- -D warnings && \
+  cargo fmt --check
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mur-agent-runtime/src/hooks/builder.rs \
+        mur-agent-runtime/src/hooks/mod.rs \
+        mur-agent-runtime/tests/hook_builder.rs \
+        mur-agent-runtime/tests/fixtures/bare_profile.yaml
+git commit -m "A1.2.1: build_chain() — config-driven HookChain assembly"
+```
+
+---
+
+## Milestone A1.3 — Wire supervisor.rs to use `build_chain()`
+
+**Branch:** `feat/mur-agent-a1-handler-picker-a1.3-supervisor` off `a1.2-builder`
+
+### Task A1.3.1: Replace inline chain assembly in supervisor.rs
+
+**Files:**
+- Modify: `mur-agent-runtime/src/supervisor.rs`
+
+- [ ] **Step 1: Read the existing chain assembly block**
+
+In `supervisor.rs` around line 177–189, you will find:
+
+```rust
+    // 4a. Build the A0 hook chain. M0 ships TelemetryHook + B0SafetyHook
+    //     (no-op stub) + LedgerHook (no-op stub). CompanionVoiceHook is
+    //     registered when the companion subsystem renders its voice (out
+    //     of M0 scope; companion phase 1.1's reactive path remains
+    //     unchanged). The on_startup observe-hooks fire before transports
+    //     bind so telemetry includes the create_agent span event.
+    let telemetry_emitter: Arc<dyn TelemetryEmitter> =
+        Arc::new(WriterTelemetryEmitter::new(writer.sender()));
+    let hook_chain = HookChain::new(vec![
+        Arc::new(TelemetryHook::new()) as Arc<dyn Hook>,
+        Arc::new(B0SafetyHook::new()),
+        Arc::new(LedgerHook::new()),
+    ]);
+```
+
+- [ ] **Step 2: Locate `mur_home` in supervisor.rs**
+
+The supervisor computes `mur_home` around line 90:
+```rust
+let mur_home = std::env::var_os("MUR_HOME")
+    .map(PathBuf::from)
+    .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"));
+```
+This variable is in scope when chain assembly happens (line ~185).
+
+- [ ] **Step 3: Replace the chain assembly block**
+
+Replace the `hook_chain` assignment (lines ~184–189) with:
+
+```rust
+    // 4a. Build the A1 config-driven hook chain.
+    //     Mandatory: TelemetryHook → B0SafetyHook (always).
+    //     Optional: LedgerHook / CompanionVoiceHook / VoiceInputHook
+    //     controlled by profile.hooks + auto-wire from feature flags.
+    let telemetry_emitter: Arc<dyn TelemetryEmitter> =
+        Arc::new(WriterTelemetryEmitter::new(writer.sender()));
+    let hook_chain = crate::hooks::builder::build_chain(
+        &profile.inner,
+        &agent_home,
+        &mur_home,
+    );
+```
+
+- [ ] **Step 4: Remove now-unused imports from supervisor.rs**
+
+Remove `LedgerHook` from the existing hooks import at the top of supervisor.rs:
+
+```rust
+// Before:
+use crate::hooks::{
+    Hook, HookChain, HookCtx, ShutdownReason, TelemetryEmitter, b0::B0SafetyHook,
+    ledger::LedgerHook, telemetry::TelemetryHook,
+};
+// After:
+use crate::hooks::{
+    Hook, HookChain, HookCtx, ShutdownReason, TelemetryEmitter,
+};
+```
+
+(builder.rs owns all handler imports now.)
+
+- [ ] **Step 5: Build the workspace to confirm no type errors**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo build -p mur-agent-runtime 2>&1 | grep -E "^error" | head -10
+```
+Expected: zero errors.
+
+- [ ] **Step 6: Run full runtime suite + lint**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo test -p mur-agent-runtime && \
+  cargo clippy -p mur-agent-runtime -- -D warnings && \
+  cargo fmt --check
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-agent-runtime/src/supervisor.rs
+git commit -m "A1.3.1: supervisor uses build_chain() — replaces inline HookChain::new"
+```
+
+---
+
+## Milestone A1.4 — `mur agent hooks show [--json]` CLI
+
+**Branch:** `feat/mur-agent-a1-handler-picker-a1.4-cli` off `a1.3-supervisor`
+
+### Task A1.4.1: `agent_hooks.rs` command impl + main.rs wiring
+
+**Files:**
+- Create: `mur-core/src/cmd/agent_hooks.rs`
+- Modify: `mur-core/src/main.rs`
+
+**Reference pattern:** `mur-core/src/cmd/agent_schedule.rs` (reads profile, prints table).
+
+- [ ] **Step 1: Write the failing CLI test**
+
+```rust
+// mur-core/tests/cmd_hooks_show.rs
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+use std::fs;
+
+fn make_agent_dir(tmp: &TempDir, profile_yaml: &str) -> String {
+    let agent_name = "hooks-test-agent";
+    let mur_home = tmp.path().join(".mur");
+    let agent_home = mur_home.join("agents").join(agent_name);
+    fs::create_dir_all(&agent_home).unwrap();
+    fs::write(agent_home.join("profile.yaml"), profile_yaml).unwrap();
+    agent_name.to_string()
+}
+
+const BARE_PROFILE: &str = r#"
+schema: 1
+id: "01900000-0000-7000-8000-000000000002"
+name: "hooks-test-agent"
+display_name: "Hooks Test"
+version: "0.1.0"
+persona: { category: general, traits: { tone: neutral, style: concise, personality: helpful } }
+sys_prompt_file: "sys_prompt.md"
+model: { provider: ollama, model: qwen3:14b }
+transport: { stdio: { enabled: true } }
+communication: { max_response_length: 4096, response_format: text }
+capabilities: []
+entitlements:
+  llm: { mode: allowed }
+  network: { outbound: { allow_hosts: [] }, inbound: {} }
+  filesystem: { read: [], write: [] }
+  process: { spawn: [] }
+  resource_limits: {}
+notifications: { on_task_complete: false, on_error: false }
+retry: { max_attempts: 3, backoff_ms: 500 }
+lifecycle: { execution: on_demand, schedule: [], idle_triggers: [] }
+identity: {}
+file_transfer: {}
+deployment: {}
+companion: { enabled: false, locale: "en-US" }
+voice: { enabled: false }
+created_at: "2026-05-08T00:00:00Z"
+updated_at: "2026-05-08T00:00:00Z"
+"#;
+
+#[test]
+fn hooks_show_table_mandatory_always_listed() {
+    let tmp = TempDir::new().unwrap();
+    let agent_name = make_agent_dir(&tmp, BARE_PROFILE);
+    let mur_home = tmp.path().join(".mur");
+
+    Command::cargo_bin("mur").unwrap()
+        .env("MUR_HOME", &mur_home)
+        .args(["agent", "hooks", "show", &agent_name])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("TelemetryHook"))
+        .stdout(predicate::str::contains("B0SafetyHook"))
+        .stdout(predicate::str::contains("mandatory"));
+}
+
+#[test]
+fn hooks_show_json_parses() {
+    let tmp = TempDir::new().unwrap();
+    let agent_name = make_agent_dir(&tmp, BARE_PROFILE);
+    let mur_home = tmp.path().join(".mur");
+
+    let output = Command::cargo_bin("mur").unwrap()
+        .env("MUR_HOME", &mur_home)
+        .args(["agent", "hooks", "show", &agent_name, "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let v: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    let arr = v.as_array().expect("output must be JSON array");
+    assert!(arr.len() >= 2, "at least 2 entries (TelemetryHook + B0SafetyHook)");
+    assert_eq!(arr[0]["name"], "TelemetryHook");
+    assert_eq!(arr[0]["tier"], "mandatory");
+    assert_eq!(arr[0]["enabled"], true);
+}
+```
+
+- [ ] **Step 2: Run, confirm fail**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo test -p mur-core --test cmd_hooks_show 2>&1 | tail -5
+```
+Expected: compile error (no `hooks show` subcommand yet).
+
+- [ ] **Step 3: Create `mur-core/src/cmd/agent_hooks.rs`**
+
+```rust
+//! A1 — `mur agent hooks show [--json]`
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use mur_common::HooksConfig;
+use mur_common::agent::AgentProfile;
+
+#[derive(Serialize)]
+struct HookEntry {
+    name: &'static str,
+    tier: &'static str,
+    enabled: bool,
+    source: String,
+}
+
+fn chain_entries(profile: &AgentProfile) -> Vec<HookEntry> {
+    let cfg = &profile.hooks;
+    let mut out = vec![
+        HookEntry {
+            name: "TelemetryHook",
+            tier: "mandatory",
+            enabled: true,
+            source: "hardcoded".into(),
+        },
+        HookEntry {
+            name: "B0SafetyHook",
+            tier: "mandatory",
+            enabled: true,
+            source: "hardcoded".into(),
+        },
+        HookEntry {
+            name: "LedgerHook",
+            tier: "optional",
+            enabled: cfg.ledger,
+            source: "hooks.ledger".into(),
+        },
+    ];
+
+    let companion_voice_on = cfg.companion_voice.unwrap_or(profile.companion.enabled);
+    out.push(HookEntry {
+        name: "CompanionVoiceHook",
+        tier: "optional",
+        enabled: companion_voice_on,
+        source: match cfg.companion_voice {
+            Some(v) => format!("hooks.companion_voice = {v}"),
+            None => format!("auto ← companion.enabled = {}", profile.companion.enabled),
+        },
+    });
+
+    let voice_input_on = cfg.voice_input.unwrap_or(profile.voice.enabled);
+    out.push(HookEntry {
+        name: "VoiceInputHook",
+        tier: "optional",
+        enabled: voice_input_on,
+        source: match cfg.voice_input {
+            Some(v) => format!("hooks.voice_input = {v}"),
+            None => format!("auto ← voice.enabled = {}", profile.voice.enabled),
+        },
+    });
+
+    out
+}
+
+pub fn cmd_hooks_show(name: &str, json: bool) -> Result<()> {
+    let mur_home = crate::paths::mur_root();
+    let agent_home = mur_home.join("agents").join(name);
+    let profile_path = agent_home.join("profile.yaml");
+    let yaml = std::fs::read_to_string(&profile_path)
+        .with_context(|| format!("read {}", profile_path.display()))?;
+    let profile: AgentProfile = serde_yaml::from_str(&yaml)
+        .with_context(|| format!("parse {}", profile_path.display()))?;
+
+    let entries = chain_entries(&profile);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&entries)?);
+        return Ok(());
+    }
+
+    println!("── Hook chain for agent \"{name}\" ────────────────────────────────");
+    for e in &entries {
+        let state = if e.enabled { "on " } else { "off" };
+        println!("  [{:9}]  {:20}  {}  ({})", e.tier, e.name, state, e.source);
+    }
+    println!("──────────────────────────────────────────────────────────────────");
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Check `crate::paths::mur_root` exists in mur-core**
+
+```bash
+grep -rn "pub fn mur_root\|fn mur_root" /Volumes/Firecuda4tb/Projects/mur/mur-core/src/ | head -5
+```
+
+If `mur_root()` doesn't exist, find how the agent command reads `mur_home` and use the same pattern. Typical pattern is:
+
+```rust
+fn mur_root() -> std::path::PathBuf {
+    std::env::var_os("MUR_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"))
+}
+```
+
+Add this as a private helper at the top of `agent_hooks.rs` if `paths::mur_root` doesn't exist:
+
+```rust
+fn mur_root() -> std::path::PathBuf {
+    std::env::var_os("MUR_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"))
+}
+```
+
+And replace `crate::paths::mur_root()` with `mur_root()` in `cmd_hooks_show`.
+
+- [ ] **Step 5: Wire into `mur-core/src/main.rs`**
+
+Find the `Agent` subcommand dispatch (search for `AgentCmd` or the `agent` match arm). Add alongside the existing `Schedule` and `Companion` arms:
+
+**5a.** Add to the `pub mod cmd {` or the imports section at the top of main.rs:
+```rust
+// (in the cmd module or near other agent_* imports)
+mod agent_hooks;
+```
+
+**5b.** Find the `AgentCmd` enum (search for `/// Manage lifecycle cron schedule entries`) and add a new variant after `Schedule`:
+
+```rust
+    /// Show the active hook chain for an agent (A1)
+    Hooks {
+        #[command(subcommand)]
+        action: AgentHooksAction,
+    },
+```
+
+**5c.** Add the `AgentHooksAction` enum near `AgentScheduleAction`:
+
+```rust
+#[derive(clap::Subcommand, Debug)]
+enum AgentHooksAction {
+    /// Print the active hook chain (table or JSON)
+    Show {
+        /// Agent name
+        name: String,
+        /// Emit machine-readable JSON array
+        #[arg(long)]
+        json: bool,
+    },
+}
+```
+
+**5d.** Add the dispatch arm in the agent match block (near the `AgentCmd::Schedule` arm):
+
+```rust
+            AgentCmd::Hooks { action } => match action {
+                AgentHooksAction::Show { name, json } => {
+                    cmd::agent_hooks::cmd_hooks_show(&name, json)?
+                }
+            },
+```
+
+- [ ] **Step 6: Run tests, confirm pass**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo test -p mur-core --test cmd_hooks_show 2>&1 | tail -15
+```
+Expected: `2 passed`.
+
+- [ ] **Step 7: Smoke-test manually**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo run -p mur-core -- agent hooks show <your-agent-name> 2>&1 | head -10
+```
+Expected: table printed with TelemetryHook + B0SafetyHook shown as mandatory.
+
+- [ ] **Step 8: Run full mur-core suite + lint**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo test -p mur-core && \
+  cargo clippy -p mur-core -- -D warnings && \
+  cargo fmt --check
+```
+
+- [ ] **Step 9: Run workspace-level test**
+
+```bash
+PATH="/Users/david/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" \
+  cargo test --workspace 2>&1 | tail -20
+```
+Expected: all pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add mur-core/src/cmd/agent_hooks.rs mur-core/src/main.rs \
+        mur-core/tests/cmd_hooks_show.rs
+git commit -m "A1.4.1: mur agent hooks show [--json] — A1 CLI"
+```
+
+---
+
+## Cascade Merge (bottom-up)
+
+Merge order: A1.1 → A1.2 → A1.3 → A1.4.
+
+For each PR (starting from A1.1):
+
+```bash
+# 1. Open PR targeting main (or previous-milestone branch)
+gh pr create --title "feat(common): A1.1 HooksConfig schema" \
+  --base main --head feat/mur-agent-a1-handler-picker-a1.1-schema
+
+# 2. After review, squash-merge
+gh pr merge <PR#> --squash --delete-branch
+
+# 3. Retarget the next PR to main
+gh pr edit <next-PR#> --base main
+```
+
+Repeat for A1.2, A1.3, A1.4.
+
+After all four PRs are merged, bump the workspace version:
+
+```bash
+# In Cargo.toml workspace [workspace.package] section:
+# version = "2.13.0" → "2.14.0"
+git add Cargo.toml Cargo.lock
+git commit -m "chore: bump workspace version 2.13.0 → 2.14.0 (A1 handler picker)"
+git tag -a v2.14.0 -m "A1 config-driven handler picker"
+git push origin main --tags
+```
+
+---
+
+## Self-Review Checklist
+
+### Spec coverage
+- [x] §3.1 `HooksConfig` struct — Task A1.1.1
+- [x] §3.2 `AgentProfile.hooks` field — Task A1.1.1
+- [x] §3.3 YAML examples — covered by tests in A1.1.1
+- [x] §4 `build_chain()` with correct constructor calls — Task A1.2.1
+- [x] §4 `mur_root` derivation note — A1.3.1 uses supervisor's existing `mur_home`
+- [x] §4 VoiceInputHook graceful skip on missing model — Task A1.2.1
+- [x] §5 `mur agent hooks show` table + `--json` — Task A1.4.1
+- [x] §7 All 10 unit tests (4 common + 6 builder + 2 CLI) — Tasks A1.1.1, A1.2.1, A1.4.1
+- [x] §8 All file changes listed — File Map section
+- [x] §9 Backward-compat (`#[serde(default)]`) — Task A1.1.1 step 5
+
+### Type consistency
+- `build_chain(profile: &AgentProfile, agent_home: &Path, mur_home: &Path) -> HookChain` — used consistently in A1.2 and A1.3
+- `cmd_hooks_show(name: &str, json: bool) -> Result<()>` — matches A1.4 wiring
+- `HooksConfig.ledger: bool`, `.companion_voice: Option<bool>`, `.voice_input: Option<bool>` — consistent across all tasks
+- `CompanionVoiceHook::new(Arc<String>)` — matches actual constructor in `companion_voice.rs:26`
+- `VoiceInputHook::new(WhisperStt, VadGate, Option<String>, Duration)` — matches `voice_input.rs:48`
+- `compose_with_overrides(Option<&Path>, Option<&Path>, VoiceInput)` — matches `voice.rs:38`

--- a/docs/superpowers/specs/2026-05-08-mur-agent-a1-handler-picker-design.md
+++ b/docs/superpowers/specs/2026-05-08-mur-agent-a1-handler-picker-design.md
@@ -1,0 +1,317 @@
+# mur Agent A1 — Config-Driven Handler Picker Design
+
+**Date:** 2026-05-08
+**Status:** Draft
+**Predecessor:** A0 frozen hook surface (`docs/superpowers/specs/2026-04-30-mur-agent-hooks-a0.md`)
+**Roadmap ref:** `2026-04-30-mur-agent-harness-roadmap-design.md` §3.3
+
+---
+
+## 1. Goal
+
+Add a `hooks:` block to `profile.yaml` / `AgentProfile` that controls which built-in handlers are included in the `HookChain` at agent startup. No user-defined Rust code; no change to the A0 `Hook` trait surface.
+
+Two concrete wins this unlocks:
+
+1. **CompanionVoiceHook and VoiceInputHook are formally wired** — they exist as modules since D1/D5 but have never been added to the chain in `supervisor.rs`. A1 makes them first-class chain members, activated automatically from existing feature flags.
+2. **Power users can suppress optional handlers** — e.g. a bare-metal bridge agent can set `hooks.ledger: false` to skip outbox ledger writes.
+
+---
+
+## 2. Design Decisions
+
+### 2.1 Two-tier handler model
+
+| Tier | Handlers | Configurable? |
+|---|---|---|
+| **Mandatory** | `TelemetryHook` (pos 0), `B0SafetyHook` (pos 1) | Never — security and observability invariants |
+| **Optional** | `LedgerHook`, `CompanionVoiceHook`, `VoiceInputHook` | Yes — via `hooks:` config + auto-wire |
+
+Mandatory handlers always appear first, in fixed order. The A0 trait surface is unchanged.
+
+### 2.2 Convention over configuration
+
+Optional handlers auto-wire from existing feature flags — no YAML required for the common case:
+
+| Handler | Default | Auto-wire source |
+|---|---|---|
+| `LedgerHook` | **on** | always (default `true`) |
+| `CompanionVoiceHook` | **off** | `profile.companion.enabled` |
+| `VoiceInputHook` | **off** | `profile.voice.enabled` |
+
+The `hooks:` block only needs to be written when overriding a default.
+
+### 2.3 Chain order
+
+Fixed order within each tier:
+
+```
+TelemetryHook → B0SafetyHook → LedgerHook → CompanionVoiceHook → VoiceInputHook
+```
+
+Rationale: telemetry first (spans the whole chain); B0 second (security gate fires before any mutation); optional handlers after mandatory. Per-method ordering is A3 scope.
+
+---
+
+## 3. Schema
+
+### 3.1 `HooksConfig` (mur-common)
+
+```rust
+// mur-common/src/hooks_config.rs
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HooksConfig {
+    /// Whether the outbox LedgerHook runs. Default: true.
+    #[serde(default = "default_true")]
+    pub ledger: bool,
+
+    /// Whether CompanionVoiceHook runs.
+    /// `None` = auto (follows `profile.companion.enabled`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub companion_voice: Option<bool>,
+
+    /// Whether VoiceInputHook runs.
+    /// `None` = auto (follows `profile.voice.enabled`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub voice_input: Option<bool>,
+}
+
+fn default_true() -> bool { true }
+
+impl Default for HooksConfig {
+    fn default() -> Self {
+        Self { ledger: true, companion_voice: None, voice_input: None }
+    }
+}
+```
+
+`HooksConfig` is re-exported from `mur_common` alongside `AgentProfile`.
+
+### 3.2 `AgentProfile` addition (mur-common)
+
+```rust
+// mur-common/src/agent.rs — add field to AgentProfile
+#[serde(default)]
+pub hooks: HooksConfig,
+```
+
+`#[serde(default)]` preserves backward-compat: existing `profile.yaml` files without a `hooks:` block load cleanly with all defaults applied.
+
+### 3.3 Example `profile.yaml` fragments
+
+```yaml
+# Most agents — no hooks block needed; defaults are correct.
+
+# Bridge agent (no companion, no ledger):
+hooks:
+  ledger: false
+
+# Force companion_voice on even if companion.enabled = false (edge case):
+hooks:
+  companion_voice: true
+
+# Explicitly disable voice_input even when voice.enabled = true:
+hooks:
+  voice_input: false
+```
+
+---
+
+## 4. Chain Builder
+
+Move chain assembly out of `supervisor.rs` into a dedicated builder function. This isolates the "which handlers run" policy from the supervisor's transport/lifecycle code.
+
+`TelemetryHook` reads its emitter from `HookCtx` at call time (not from its constructor), so `build_chain` needs no emitter parameter. `CompanionVoiceHook` requires a pre-rendered voice string; `VoiceInputHook` requires a loaded `WhisperStt` model. Both are initialised inside the builder using `agent_home` and `mur_root`.
+
+```rust
+// mur-agent-runtime/src/hooks/builder.rs
+
+use std::sync::Arc;
+use std::path::Path;
+use anyhow::Result;
+use mur_common::AgentProfile;
+use super::{
+    Hook, HookChain,
+    b0::B0SafetyHook,
+    companion_voice::CompanionVoiceHook,
+    ledger::LedgerHook,
+    telemetry::TelemetryHook,
+    voice_input::VoiceInputHook,
+};
+use crate::companion::voice::{VoiceInput, compose_with_overrides};
+use crate::voice::stt::{VadGate, WhisperStt};
+
+/// Build the `HookChain` for `profile`.
+///
+/// Chain order (fixed):
+///   mandatory: TelemetryHook → B0SafetyHook
+///   optional:  LedgerHook → CompanionVoiceHook → VoiceInputHook
+///
+/// `agent_home` — `~/.mur/agents/<name>/`
+/// `mur_root`   — `~/.mur/`  (for whisper model + user-level voice templates)
+pub fn build_chain(
+    profile: &AgentProfile,
+    agent_home: &Path,
+    mur_root: &Path,
+) -> HookChain {
+    let cfg = &profile.hooks;
+
+    let mut chain: Vec<Arc<dyn Hook>> = vec![
+        Arc::new(TelemetryHook::new()) as Arc<dyn Hook>,
+        Arc::new(B0SafetyHook::new()),
+    ];
+
+    if cfg.ledger {
+        chain.push(Arc::new(LedgerHook::new()));
+    }
+
+    let want_companion_voice = cfg.companion_voice
+        .unwrap_or(profile.companion.enabled);
+    if want_companion_voice {
+        let rendered = compose_with_overrides(
+            Some(agent_home),
+            Some(mur_root),
+            VoiceInput {
+                relationship: profile.companion.relationship,
+                locale: &profile.companion.locale,
+                name_for_user: &profile.persona.display_name,
+                first_memory: None,  // injected by D2 onboarding at runtime
+                formality: "",
+                extra_instructions: "",
+            },
+        );
+        chain.push(Arc::new(CompanionVoiceHook::new(Arc::new(rendered))));
+    }
+
+    let want_voice_input = cfg.voice_input
+        .unwrap_or(profile.voice.enabled);
+    if want_voice_input {
+        // Whisper model lives at mur_root/voices/whisper-large-v3-turbo-q5_1.bin.
+        // If absent (fresh install before first download), log a warning and skip
+        // VoiceInputHook so the agent still starts cleanly.
+        let model_path = mur_root.join("voices/whisper-large-v3-turbo-q5_1.bin");
+        match WhisperStt::new(&model_path) {
+            Ok(stt) => chain.push(Arc::new(VoiceInputHook::new(
+                stt,
+                VadGate::default(),
+                profile.voice.input_device.clone(),
+                std::time::Duration::from_secs(30),
+            ))),
+            Err(e) => tracing::warn!(
+                model = %model_path.display(),
+                error = %e,
+                "VoiceInputHook skipped: whisper model not found; run `mur voice install` to download"
+            ),
+        }
+    }
+
+    HookChain::new(chain)
+}
+```
+
+`supervisor.rs` replaces its inline `HookChain::new(vec![...])` block with:
+
+```rust
+let hook_chain = hooks::builder::build_chain(&profile.inner, &agent_home, &mur_root);
+```
+
+`mur_root` is already available as `agent_home.parent().parent().unwrap_or(&agent_home)` (path: `~/.mur/agents/<name>` → `~/.mur`).
+
+---
+
+## 5. CLI — `mur agent hooks show`
+
+New subcommand under `mur agent` that prints the active chain for a named agent without starting the runtime.
+
+```
+$ mur agent hooks show alice
+── Hook chain for agent "alice" ─────────────────────────────────
+ [mandatory]  TelemetryHook       all 10 methods
+ [mandatory]  B0SafetyHook        pre_tool_use · on_prompt_submit · post_tool_use · ...
+ [optional]   LedgerHook          on (hooks.ledger = true)
+ [optional]   CompanionVoiceHook  on  (auto ← companion.enabled = true)
+ [optional]   VoiceInputHook      off (auto ← voice.enabled = false)
+─────────────────────────────────────────────────────────────────
+```
+
+Implementation: reads `profile.yaml`, calls `build_chain` with a no-op telemetry emitter, then calls `chain.names()` and annotates each entry from the config.
+
+`--json` flag emits a machine-readable array:
+
+```json
+[
+  {"name":"TelemetryHook","tier":"mandatory","enabled":true},
+  {"name":"B0SafetyHook","tier":"mandatory","enabled":true},
+  {"name":"LedgerHook","tier":"optional","enabled":true,"source":"hooks.ledger"},
+  {"name":"CompanionVoiceHook","tier":"optional","enabled":true,"source":"auto:companion.enabled"},
+  {"name":"VoiceInputHook","tier":"optional","enabled":false,"source":"auto:voice.enabled"}
+]
+```
+
+---
+
+## 6. Validation
+
+On `AgentProfile::validate()` (called at profile load):
+
+1. `hooks.companion_voice: true` is allowed even when `companion.enabled = false` (pre-enable for testing).
+2. `hooks.voice_input: true` is allowed even when `voice.enabled = false`.
+3. No validation errors for any `HooksConfig` value — the schema is permissive. Bad combinations produce no-op handlers (e.g. VoiceInputHook with no voice model configured logs a warning on `on_startup`).
+
+---
+
+## 7. Testing
+
+### Unit tests (mur-common)
+
+- `hooks_config_defaults_roundtrip` — `HooksConfig::default()` serializes without a `hooks:` key; a bare `profile.yaml` deserializes to defaults.
+- `hooks_config_partial_override` — `hooks: { ledger: false }` deserializes with `ledger=false`, all other fields at defaults.
+
+### Unit tests (mur-agent-runtime/tests/)
+
+- `builder_mandatory_always_present` — chain always starts with `TelemetryHook`, `B0SafetyHook` regardless of `hooks:` config.
+- `builder_ledger_disabled` — `hooks.ledger: false` → chain has no `LedgerHook`.
+- `builder_companion_voice_auto` — `companion.enabled=true`, no `hooks:` block → `CompanionVoiceHook` present.
+- `builder_voice_input_auto` — `voice.enabled=true`, no `hooks:` block → `VoiceInputHook` present.
+- `builder_explicit_override` — `companion.enabled=false` + `hooks.companion_voice: true` → `CompanionVoiceHook` present.
+- `builder_explicit_suppress` — `voice.enabled=true` + `hooks.voice_input: false` → `VoiceInputHook` absent.
+
+### CLI test
+
+- `cmd_hooks_show_table` — parses output of `mur agent hooks show <name>` for a fixture profile; asserts mandatory handlers listed and correct optional enable/disable state.
+- `cmd_hooks_show_json` — `--json` flag output passes serde round-trip and matches expected `enabled`/`source` fields.
+
+---
+
+## 8. File Changes
+
+| File | Action |
+|---|---|
+| `mur-common/src/hooks_config.rs` | CREATE — `HooksConfig` struct |
+| `mur-common/src/lib.rs` | MODIFY — `pub mod hooks_config; pub use hooks_config::HooksConfig;` |
+| `mur-common/src/agent.rs` | MODIFY — add `pub hooks: HooksConfig` to `AgentProfile` |
+| `mur-common/tests/hooks_config.rs` | CREATE — roundtrip + partial-override tests |
+| `mur-agent-runtime/src/hooks/builder.rs` | CREATE — `build_chain()` |
+| `mur-agent-runtime/src/hooks/mod.rs` | MODIFY — `pub mod builder;` |
+| `mur-agent-runtime/src/supervisor.rs` | MODIFY — replace inline chain assembly with `hooks::builder::build_chain(...)` |
+| `mur-agent-runtime/tests/hook_builder.rs` | CREATE — 6 builder unit tests |
+| `mur-core/src/cmd/agent/` | MODIFY — add `hooks show [--json]` subcommand |
+| `mur-core/tests/cmd_hooks_show.rs` | CREATE — CLI output tests |
+
+---
+
+## 9. Scope Boundaries
+
+| In A1 | Deferred |
+|---|---|
+| `HooksConfig` schema + `AgentProfile` field | Per-method handler lists (A3) |
+| `build_chain()` builder | WASM / Lua plugin loading (A2) |
+| CompanionVoiceHook + VoiceInputHook formally wired | Conditions / retry policy (A3) |
+| `mur agent hooks show` CLI | Visual editor (A4) |
+| Profile load backward-compat | Runtime handler swap (out of scope) |
+
+---
+
+## 10. Forward Compatibility
+
+`HooksConfig` uses `#[serde(default)]` on all fields. Future optional handlers (e.g. an A2 WASM plugin loader) can be added as new optional fields without breaking existing profiles. The mandatory-tier concept (hardcoded in `build_chain`) is replaced in A3 by a full composition spec that assigns tiers and ordering rules declaratively.

--- a/mur-agent-runtime/src/hooks/builder.rs
+++ b/mur-agent-runtime/src/hooks/builder.rs
@@ -1,0 +1,90 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use mur_common::agent::AgentProfile;
+use mur_common::companion::Formality;
+
+use super::{
+    Hook, HookChain, b0::B0SafetyHook, companion_voice::CompanionVoiceHook, ledger::LedgerHook,
+    telemetry::TelemetryHook, voice_input::VoiceInputHook,
+};
+use crate::companion::voice::{VoiceInput, compose_with_overrides};
+use crate::voice::stt::{VadGate, WhisperStt};
+
+/// Build the `HookChain` for `profile`.
+///
+/// Mandatory tier (always present, fixed order):
+///   TelemetryHook (pos 0) → B0SafetyHook (pos 1)
+///
+/// Optional tier (auto-wire from feature flags, overridable via `profile.hooks`):
+///   LedgerHook → CompanionVoiceHook → VoiceInputHook
+///
+/// * `agent_home` — `~/.mur/agents/<name>/`
+/// * `mur_home`   — `~/.mur/`
+pub fn build_chain(profile: &AgentProfile, agent_home: &Path, mur_home: &Path) -> HookChain {
+    let cfg = &profile.hooks;
+
+    let mut chain: Vec<Arc<dyn Hook>> = vec![
+        Arc::new(TelemetryHook::new()) as Arc<dyn Hook>,
+        Arc::new(B0SafetyHook::new()),
+    ];
+
+    if cfg.ledger {
+        chain.push(Arc::new(LedgerHook::new()));
+    }
+
+    let want_companion_voice = cfg.companion_voice.unwrap_or(profile.companion.enabled);
+    if want_companion_voice {
+        let formality_str = match profile.companion.voice_overrides.formality {
+            Some(Formality::Formal) => "formal",
+            _ => "casual",
+        };
+        let extra = profile
+            .companion
+            .voice_overrides
+            .extra_instructions
+            .as_deref()
+            .unwrap_or("");
+        let first_memory = profile
+            .companion
+            .onboarding
+            .first_memory
+            .as_ref()
+            .map(|m| m.text.as_str());
+        let rendered = compose_with_overrides(
+            Some(agent_home),
+            Some(mur_home),
+            VoiceInput {
+                relationship: profile.companion.relationship.clone(),
+                locale: &profile.companion.locale,
+                name_for_user: &profile.display_name,
+                first_memory,
+                formality: formality_str,
+                extra_instructions: extra,
+            },
+        );
+        chain.push(Arc::new(CompanionVoiceHook::new(Arc::new(rendered))));
+    }
+
+    let want_voice_input = cfg.voice_input.unwrap_or(profile.voice.enabled);
+    if want_voice_input {
+        let model_path = mur_home.join("voices/whisper-large-v3-turbo-q5_1.bin");
+        match WhisperStt::new(&model_path) {
+            Ok(stt) => chain.push(Arc::new(VoiceInputHook::new(
+                stt,
+                VadGate::default(),
+                profile.voice.input_device.clone(),
+                Duration::from_secs(30),
+            ))),
+            Err(e) => tracing::warn!(
+                model = %model_path.display(),
+                error = %e,
+                "VoiceInputHook skipped: whisper model not found; \
+                 run `mur voice install` to download"
+            ),
+        }
+    }
+
+    HookChain::new(chain)
+}

--- a/mur-agent-runtime/src/hooks/mod.rs
+++ b/mur-agent-runtime/src/hooks/mod.rs
@@ -16,6 +16,7 @@ pub mod types;
 
 pub mod b0;
 pub mod b0_helpers;
+pub mod builder;
 pub mod companion_voice;
 pub mod ledger;
 pub mod telemetry;

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -5,10 +5,7 @@ use anyhow::Context;
 
 use crate::companion::clock::SystemClock;
 use crate::entitlements::detect_warnings;
-use crate::hooks::{
-    Hook, HookChain, HookCtx, ShutdownReason, TelemetryEmitter, b0::B0SafetyHook,
-    ledger::LedgerHook, telemetry::TelemetryHook,
-};
+use crate::hooks::{HookCtx, ShutdownReason, TelemetryEmitter};
 use crate::idle_scheduler::IdleScheduler;
 use crate::llm::{
     LlmClient, anthropic::AnthropicClient, ollama::OllamaClient, openai::OpenAiClient,
@@ -174,19 +171,16 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     )
     .await?;
 
-    // 4a. Build the A0 hook chain. M0 ships TelemetryHook + B0SafetyHook
-    //     (no-op stub) + LedgerHook (no-op stub). CompanionVoiceHook is
-    //     registered when the companion subsystem renders its voice (out
-    //     of M0 scope; companion phase 1.1's reactive path remains
-    //     unchanged). The on_startup observe-hooks fire before transports
-    //     bind so telemetry includes the create_agent span event.
+    // 4a. Build the A1 config-driven hook chain.
+    //     Mandatory: TelemetryHook → B0SafetyHook (always).
+    //     Optional: LedgerHook / CompanionVoiceHook / VoiceInputHook
+    //     controlled by profile.hooks + auto-wire from feature flags.
     let telemetry_emitter: Arc<dyn TelemetryEmitter> =
         Arc::new(WriterTelemetryEmitter::new(writer.sender()));
-    let hook_chain = HookChain::new(vec![
-        Arc::new(TelemetryHook::new()) as Arc<dyn Hook>,
-        Arc::new(B0SafetyHook::new()),
-        Arc::new(LedgerHook::new()),
-    ]);
+    let mur_home = std::env::var_os("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"));
+    let hook_chain = crate::hooks::builder::build_chain(&profile.inner, &agent_home, &mur_home);
     // Resolve MCP server binary paths from `profile.mcp_servers[*].command`.
     // Each `command` is a shell command line; the first whitespace-separated
     // token is treated as the binary path. M7.7 (rule 11) reads these in

--- a/mur-agent-runtime/tests/fixtures/bare_profile.yaml
+++ b/mur-agent-runtime/tests/fixtures/bare_profile.yaml
@@ -1,0 +1,38 @@
+schema: 1
+id: "0192f5a1-28ab-7111-8000-000000000099"
+name: "test-agent"
+display_name: "Test Agent"
+version: "0.1.0"
+persona:
+  category: research
+  description: "Minimal test profile for builder tests"
+  traits: { tone: neutral, risk: cautious, verbosity: low }
+sys_prompt_file: "sys_prompt.md"
+model: { provider: ollama, name: "qwen3:14b", params: {} }
+mcp_servers: []
+skills: []
+transport:
+  stdio: true
+  socket: { enabled: false, bind: "unix:///tmp/test-agent.sock" }
+communication: { accepts_from: ["*"], sends_to: [] }
+capabilities: []
+entitlements:
+  network:
+    inbound: { ports: [] }
+    outbound: { mode: restricted, allow_hosts: [], protocols: ["tcp"], resolve_dns: { mode: system } }
+  filesystem: { read: [], write: [], deny: [] }
+  processes: { spawn: { mode: allowlist, allowed: [] } }
+  syscalls: { mode: default }
+  limits: { memory_mb: 512, file_descriptors: 1024, processes: 32 }
+notifications: { on_task_complete: [], on_error: [], on_shutdown: [] }
+retry:
+  llm: { max_retries: 3, backoff: exponential, initial_delay_ms: 1000, max_delay_ms: 30000, retry_on: ["rate_limit"] }
+  tool: { max_retries: 1, backoff: fixed, initial_delay_ms: 500 }
+lifecycle: { restart: on_failure, max_restarts: 3, restart_window_secs: 600, stop_timeout_secs: 15, mcp_required: true }
+companion:
+  enabled: false
+  locale: "en-US"
+voice:
+  enabled: false
+created_at: "2026-05-08T00:00:00Z"
+updated_at: "2026-05-08T00:00:00Z"

--- a/mur-agent-runtime/tests/hook_builder.rs
+++ b/mur-agent-runtime/tests/hook_builder.rs
@@ -1,0 +1,89 @@
+use mur_agent_runtime::hooks::builder::build_chain;
+use mur_common::agent::AgentProfile;
+
+fn base_profile() -> AgentProfile {
+    let yaml = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/bare_profile.yaml"
+    ))
+    .unwrap();
+    serde_yaml_ng::from_str(&yaml).unwrap()
+}
+
+fn tmp_dirs() -> (tempfile::TempDir, tempfile::TempDir) {
+    (
+        tempfile::TempDir::new().unwrap(),
+        tempfile::TempDir::new().unwrap(),
+    )
+}
+
+#[test]
+fn mandatory_handlers_always_present() {
+    let profile = base_profile();
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    let names = chain.names();
+    assert_eq!(names[0], "TelemetryHook", "TelemetryHook must be first");
+    assert_eq!(names[1], "B0SafetyHook", "B0SafetyHook must be second");
+}
+
+#[test]
+fn ledger_on_by_default() {
+    let profile = base_profile();
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(
+        chain.names().contains(&"LedgerHook"),
+        "LedgerHook on by default"
+    );
+}
+
+#[test]
+fn ledger_disabled_via_hooks_config() {
+    let mut profile = base_profile();
+    profile.hooks.ledger = false;
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(
+        !chain.names().contains(&"LedgerHook"),
+        "LedgerHook must be absent"
+    );
+}
+
+#[test]
+fn companion_voice_auto_wires_when_companion_enabled() {
+    let mut profile = base_profile();
+    profile.companion.enabled = true;
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(
+        chain.names().contains(&"CompanionVoiceHook"),
+        "CompanionVoiceHook must auto-wire when companion.enabled = true"
+    );
+}
+
+#[test]
+fn companion_voice_explicit_override_when_companion_disabled() {
+    let mut profile = base_profile();
+    profile.companion.enabled = false;
+    profile.hooks.companion_voice = Some(true);
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(
+        chain.names().contains(&"CompanionVoiceHook"),
+        "hooks.companion_voice=true must override companion.enabled=false"
+    );
+}
+
+#[test]
+fn voice_input_suppressed_when_model_absent() {
+    let mut profile = base_profile();
+    profile.voice.enabled = true;
+    // mur_tmp has no voices/ dir → model not found → handler skipped gracefully
+    let (agent_tmp, mur_tmp) = tmp_dirs();
+    let chain = build_chain(&profile, agent_tmp.path(), mur_tmp.path());
+    assert!(
+        !chain.names().contains(&"VoiceInputHook"),
+        "VoiceInputHook skipped gracefully when model absent"
+    );
+}

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -47,6 +47,9 @@ pub struct AgentProfile {
     /// Voice I/O configuration (D1). Default = disabled.
     #[serde(default)]
     pub voice: VoiceConfig,
+    /// A1: config-driven handler picker. Absent block = all defaults.
+    #[serde(default)]
+    pub hooks: crate::HooksConfig,
     /// Pubkeys of bridges (and other LLM-less peers) this agent will accept
     /// signed envelopes from. Empty = accept no bridge traffic. Default = empty.
     #[serde(default)]

--- a/mur-common/src/hooks_config.rs
+++ b/mur-common/src/hooks_config.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HooksConfig {
+    /// Whether the outbox `LedgerHook` runs. Default: true.
+    #[serde(default = "default_true")]
+    pub ledger: bool,
+
+    /// Whether `CompanionVoiceHook` runs.
+    /// `None` = auto-wire from `profile.companion.enabled`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub companion_voice: Option<bool>,
+
+    /// Whether `VoiceInputHook` runs.
+    /// `None` = auto-wire from `profile.voice.enabled`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub voice_input: Option<bool>,
+}
+
+impl Default for HooksConfig {
+    fn default() -> Self {
+        Self {
+            ledger: true,
+            companion_voice: None,
+            voice_input: None,
+        }
+    }
+}

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod error;
 /// B0 M11 — JSONL output schema for the eval harness.
 pub mod eval;
 pub mod event;
+pub mod hooks_config;
 pub mod identity;
 pub mod knowledge;
 pub mod llm;
@@ -33,6 +34,7 @@ pub mod workflow;
 
 pub use actor::{Actor, ActorSource};
 pub use conversation::{CONVERSATION_SCHEMA_VERSION, Content, Message, Role, Source};
+pub use hooks_config::HooksConfig;
 pub use pattern::Pattern;
 pub use scope::Scope;
 pub use signal::{SIGNAL_SCHEMA_VERSION, Signal, SignalKind, SignalTarget};

--- a/mur-common/tests/hooks_config.rs
+++ b/mur-common/tests/hooks_config.rs
@@ -1,0 +1,39 @@
+use mur_common::HooksConfig;
+
+#[test]
+fn hooks_config_defaults() {
+    let cfg = HooksConfig::default();
+    assert!(cfg.ledger, "ledger default is true");
+    assert_eq!(
+        cfg.companion_voice, None,
+        "companion_voice default is None (auto)"
+    );
+    assert_eq!(cfg.voice_input, None, "voice_input default is None (auto)");
+}
+
+#[test]
+fn hooks_config_roundtrip_empty_yaml() {
+    // A profile.yaml with no hooks: block at all should deserialize to defaults.
+    let yaml = "ledger: true\n";
+    let cfg: HooksConfig = serde_yaml::from_str(yaml).unwrap();
+    assert!(cfg.ledger);
+    assert_eq!(cfg.companion_voice, None);
+}
+
+#[test]
+fn hooks_config_partial_override_ledger_false() {
+    let yaml = "ledger: false\n";
+    let cfg: HooksConfig = serde_yaml::from_str(yaml).unwrap();
+    assert!(!cfg.ledger);
+    assert_eq!(cfg.companion_voice, None);
+    assert_eq!(cfg.voice_input, None);
+}
+
+#[test]
+fn hooks_config_explicit_companion_voice_true() {
+    let yaml = "companion_voice: true\n";
+    let cfg: HooksConfig = serde_yaml::from_str(yaml).unwrap();
+    assert!(cfg.ledger, "ledger still defaults to true");
+    assert_eq!(cfg.companion_voice, Some(true));
+    assert_eq!(cfg.voice_input, None);
+}


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `HookChain::new(vec![TelemetryHook, B0SafetyHook, LedgerHook])` in `supervisor.rs` with `crate::hooks::builder::build_chain(&profile.inner, &agent_home, &mur_home)`
- Removes now-unused imports from supervisor
- `mur_home` re-derived from `MUR_HOME` env var (same pattern as agent-home resolution)

## Test plan
- [x] `cargo build -p mur-agent-runtime` — zero errors
- [x] `cargo clippy -p mur-agent-runtime -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)