### PR TITLE
chore: fix three pre-existing clippy warnings on main

### DIFF
--- a/mur-agent-runtime/src/voice/tts.rs
+++ b/mur-agent-runtime/src/voice/tts.rs
@@ -295,10 +295,10 @@ mod tests {
             let col = i % 256;
             style_matrix[row][col] = f32::from_le_bytes(chunk.try_into().unwrap());
         }
-        for row in 0..5 {
-            for col in 0..256 {
+        for (row, row_vals) in style_matrix.iter().enumerate() {
+            for (col, val) in row_vals.iter().enumerate() {
                 assert_eq!(
-                    style_matrix[row][col], row as f32,
+                    *val, row as f32,
                     "style_matrix[{row}][{col}] expected {row}.0"
                 );
             }

--- a/mur-agent-runtime/tests/scheduler_integration.rs
+++ b/mur-agent-runtime/tests/scheduler_integration.rs
@@ -9,7 +9,7 @@ fn next_n_fires_returns_n_times() {
     for w in fires.windows(2) {
         let diff_min = (w[1] - w[0]).num_minutes();
         assert!(
-            diff_min >= 55 && diff_min <= 65,
+            (55..=65).contains(&diff_min),
             "expected ~60 min gap, got {diff_min} min"
         );
     }

--- a/mur-common/tests/companion_enums.rs
+++ b/mur-common/tests/companion_enums.rs
@@ -64,8 +64,10 @@ fn onboarding_state_pre_d2_yaml_still_deserializes() {
 #[test]
 fn proactive_tiers_helper() {
     use mur_common::agent::{CompanionConfig, ProactiveTier};
-    let mut c = CompanionConfig::default();
-    c.enabled = true;
+    let mut c = CompanionConfig {
+        enabled: true,
+        ..CompanionConfig::default()
+    };
     let t = ProactiveTier::from_config(&c);
     assert_eq!(t, ProactiveTier::WarmOnly);
 


### PR DESCRIPTION
## Summary

Three clippy-1.95 violations that show up under \`cargo clippy --workspace --all-targets -- -D warnings\` but are missed by lib-only checks. They had accumulated on main; the Phase 2 token-diet PRs (#233 / #234 / #235) noted them as out-of-scope.

| File | Lint | Fix |
|------|------|-----|
| \`mur-common/tests/companion_enums.rs:67\` | \`field_reassign_with_default\` | switch to struct-literal \`..Default::default()\` |
| \`mur-agent-runtime/src/voice/tts.rs:298\` | \`needless_range_loop\` | nested \`for ... in 0..N\` → \`for (i, val) in iter().enumerate()\` |
| \`mur-agent-runtime/tests/scheduler_integration.rs:11\` | \`manual_range_contains\` | \`x >= 55 && x <= 65\` → \`(55..=65).contains(&x)\` |

## Test plan

- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p mur-common --test companion_enums\` — 11/11 pass
- [x] \`cargo test -p mur-agent-runtime --test scheduler_integration\` — 3/3 pass
- [x] \`cargo test -p mur-agent-runtime --lib voice::tts\` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)