### PR TITLE
feat(init): async:true + asyncRewake:true for Claude Code hooks

### DIFF
--- a/mur-core/src/cmd/init.rs
+++ b/mur-core/src/cmd/init.rs
@@ -353,14 +353,23 @@ pub(crate) fn cmd_init(hooks_flag: bool, refresh_discovery: bool) -> Result<()> 
                 true
             });
 
-            // Add our hook (Claude Code format: { hooks: [...], matcher: "" })
-            arr.push(serde_json::json!({
+            // Add our hook with Claude Code async flags
+            let async_flag = matches!(*event_name, "UserPromptSubmit");
+            let rewake_flag = matches!(*event_name, "Stop");
+            let mut hook_entry = serde_json::json!({
                 "hooks": [{
                     "type": "command",
                     "command": format!("bash {}", script_path),
                 }],
                 "matcher": ""
-            }));
+            });
+            if async_flag {
+                hook_entry["hooks"][0]["async"] = serde_json::json!(true);
+            }
+            if rewake_flag {
+                hook_entry["hooks"][0]["asyncRewake"] = serde_json::json!(true);
+            }
+            arr.push(hook_entry);
         }
 
         // Write settings back with pretty formatting
@@ -1449,5 +1458,35 @@ mod runtime_regression_tests {
             "discover_blocking should not error inside a tokio runtime: {:?}",
             result.err()
         );
+    }
+}
+
+#[cfg(test)]
+mod claude_hook_flags_tests {
+    use std::collections::HashMap;
+
+    #[test]
+    fn claude_hooks_have_async_flags() {
+        let events = ["UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "SessionStart"];
+        let mut results: HashMap<&str, serde_json::Value> = HashMap::new();
+        for event_name in events {
+            let async_flag = matches!(event_name, "UserPromptSubmit");
+            let rewake_flag = matches!(event_name, "Stop");
+            let mut hook_entry = serde_json::json!({
+                "hooks": [{"type": "command", "command": "bash /tmp/hook.sh"}],
+                "matcher": ""
+            });
+            if async_flag {
+                hook_entry["hooks"][0]["async"] = serde_json::json!(true);
+            }
+            if rewake_flag {
+                hook_entry["hooks"][0]["asyncRewake"] = serde_json::json!(true);
+            }
+            results.insert(event_name, hook_entry);
+        }
+        assert_eq!(results["UserPromptSubmit"]["hooks"][0]["async"], serde_json::json!(true));
+        assert_eq!(results["Stop"]["hooks"][0]["asyncRewake"], serde_json::json!(true));
+        assert!(results["PreToolUse"]["hooks"][0].get("async").is_none());
+        assert!(results["PostToolUse"]["hooks"][0].get("asyncRewake").is_none());
     }
 }

--- a/mur-core/src/cmd/init.rs
+++ b/mur-core/src/cmd/init.rs
@@ -213,6 +213,19 @@ pub(crate) const HOOK_SCRIPT_SESSION_START: &str = "#!/bin/bash
 exec mur hook session-start --tool \"${MUR_TOOL:-claude}\"
 ";
 
+/// Derive Claude Code async flags for a given hook event name.
+///
+/// Returns `(async_flag, rewake_flag)`:
+/// - `async_flag=true` for `UserPromptSubmit` (async execution)
+/// - `rewake_flag=true` for `Stop` (async re-wake after completion)
+/// - Both false for other events
+fn hook_async_flags(event_name: &str) -> (bool, bool) {
+    (
+        matches!(event_name, "UserPromptSubmit"),
+        matches!(event_name, "Stop"),
+    )
+}
+
 pub(crate) fn cmd_init(hooks_flag: bool, refresh_discovery: bool) -> Result<()> {
     let home =
         dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
@@ -354,8 +367,7 @@ pub(crate) fn cmd_init(hooks_flag: bool, refresh_discovery: bool) -> Result<()> 
             });
 
             // Add our hook with Claude Code async flags
-            let async_flag = matches!(*event_name, "UserPromptSubmit");
-            let rewake_flag = matches!(*event_name, "Stop");
+            let (async_flag, rewake_flag) = hook_async_flags(event_name);
             let mut hook_entry = serde_json::json!({
                 "hooks": [{
                     "type": "command",
@@ -1463,15 +1475,21 @@ mod runtime_regression_tests {
 
 #[cfg(test)]
 mod claude_hook_flags_tests {
+    use super::hook_async_flags;
     use std::collections::HashMap;
 
     #[test]
     fn claude_hooks_have_async_flags() {
-        let events = ["UserPromptSubmit", "PreToolUse", "PostToolUse", "Stop", "SessionStart"];
+        let events = [
+            "UserPromptSubmit",
+            "PreToolUse",
+            "PostToolUse",
+            "Stop",
+            "SessionStart",
+        ];
         let mut results: HashMap<&str, serde_json::Value> = HashMap::new();
         for event_name in events {
-            let async_flag = matches!(event_name, "UserPromptSubmit");
-            let rewake_flag = matches!(event_name, "Stop");
+            let (async_flag, rewake_flag) = hook_async_flags(event_name);
             let mut hook_entry = serde_json::json!({
                 "hooks": [{"type": "command", "command": "bash /tmp/hook.sh"}],
                 "matcher": ""
@@ -1484,9 +1502,29 @@ mod claude_hook_flags_tests {
             }
             results.insert(event_name, hook_entry);
         }
-        assert_eq!(results["UserPromptSubmit"]["hooks"][0]["async"], serde_json::json!(true));
-        assert_eq!(results["Stop"]["hooks"][0]["asyncRewake"], serde_json::json!(true));
+        assert_eq!(
+            results["UserPromptSubmit"]["hooks"][0]["async"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            results["Stop"]["hooks"][0]["asyncRewake"],
+            serde_json::json!(true)
+        );
         assert!(results["PreToolUse"]["hooks"][0].get("async").is_none());
-        assert!(results["PostToolUse"]["hooks"][0].get("asyncRewake").is_none());
+        assert!(
+            results["PostToolUse"]["hooks"][0]
+                .get("asyncRewake")
+                .is_none()
+        );
+        assert!(
+            results["SessionStart"]["hooks"][0].get("async").is_none(),
+            "SessionStart should not have async flag"
+        );
+        assert!(
+            results["SessionStart"]["hooks"][0]
+                .get("asyncRewake")
+                .is_none(),
+            "SessionStart should not have asyncRewake flag"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `async: true` to the `UserPromptSubmit` Claude Code hook entry written by `mur init --hooks`, preventing heavy hook processing from blocking the UI
- Adds `asyncRewake: true` to the `Stop` hook entry so Claude re-wakes after on-stop processing completes
- Extracts `fn hook_async_flags(event_name: &str) -> (bool, bool)` helper shared by production code and unit test

## Test plan

- [ ] `cargo test -p mur-core claude_hooks_have_async_flags` — verifies all 5 events get correct flags (or none)
- [ ] Re-run `mur init --hooks` and inspect `~/.claude/settings.json` — UserPromptSubmit entry should have `"async": true`, Stop entry should have `"asyncRewake": true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)