### PR TITLE
feat(runtime): C7 Slack bridge — M-c7.2 inbound loop skeleton + mock

### DIFF
--- a/mur-agent-runtime/src/bridge/slack/inbound.rs
+++ b/mur-agent-runtime/src/bridge/slack/inbound.rs
@@ -1,8 +1,116 @@
-// Stub — fully implemented in M-c7.2+
+//! Slack inbound loop — processes Socket Mode `events_api` envelopes.
 
-pub trait SlackBotLike: Send + Sync + 'static {}
+use std::path::PathBuf;
 
-pub struct InboundDeps;
+use mur_common::bridge::SlackConfig;
+use mur_common::identity::AgentIdentity;
+
+use crate::bridge::ack::AckTracker;
+use crate::bridge::dedupe::DedupeStore;
+use crate::bridge::slack::SlackError;
+use crate::bridge::slack::mock::MockUserAgentHandle;
+
+// ── Slack event wire types ────────────────────────────────────────────────
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct SlackEnvelope {
+    pub envelope_id: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub payload: Option<SlackEventPayload>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct SlackEventPayload {
+    pub event: SlackEvent,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct SlackEvent {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub user: Option<String>,
+    pub text: Option<String>,
+    pub ts: String,
+    pub channel: String,
+    pub channel_type: Option<String>,
+    pub thread_ts: Option<String>,
+}
+
+// ── Bot trait + production type ───────────────────────────────────────────
+
+#[async_trait::async_trait]
+pub trait SlackBotLike: Send + Sync + 'static {
+    async fn post_message(
+        &self,
+        channel: &str,
+        text: &str,
+        thread_ts: Option<&str>,
+    ) -> Result<(), SlackError>;
+
+    async fn auth_test(&self) -> Result<String, SlackError>;
+}
+
+pub struct RealSlackBot {
+    pub(crate) client: reqwest::Client,
+    pub(crate) bot_token: String,
+}
+
+#[async_trait::async_trait]
+impl SlackBotLike for RealSlackBot {
+    async fn post_message(
+        &self,
+        channel: &str,
+        text: &str,
+        thread_ts: Option<&str>,
+    ) -> Result<(), SlackError> {
+        crate::bridge::slack::reply::post_message(
+            &self.client,
+            &self.bot_token,
+            channel,
+            text,
+            thread_ts,
+        )
+        .await
+    }
+
+    async fn auth_test(&self) -> Result<String, SlackError> {
+        let resp = self
+            .client
+            .post("https://slack.com/api/auth.test")
+            .bearer_auth(&self.bot_token)
+            .send()
+            .await
+            .map_err(|e| SlackError::Network(e.to_string()))?;
+
+        if resp.status().as_u16() == 401 {
+            return Err(SlackError::Auth(401));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| SlackError::Parse(e.to_string()))?;
+        body["user_id"]
+            .as_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| SlackError::Parse("missing user_id in auth.test".into()))
+    }
+}
+
+// ── InboundDeps ───────────────────────────────────────────────────────────
+
+pub struct InboundDeps {
+    pub config: SlackConfig,
+    pub dedupe: DedupeStore,
+    pub ack: AckTracker<String>,
+    pub identity: AgentIdentity,
+    pub key_version: u32,
+    pub always_5xx: bool,
+    pub user_agent: Option<MockUserAgentHandle>,
+    pub agent_home: PathBuf,
+}
+
+// ── SlackInboundLoop ──────────────────────────────────────────────────────
 
 pub struct SlackInboundLoop<B: SlackBotLike> {
     pub bot: B,
@@ -12,5 +120,12 @@ pub struct SlackInboundLoop<B: SlackBotLike> {
 impl<B: SlackBotLike> SlackInboundLoop<B> {
     pub fn stub_new(bot: B) -> Self {
         Self { bot, deps: None }
+    }
+
+    pub fn new(bot: B, deps: InboundDeps) -> Self {
+        Self {
+            bot,
+            deps: Some(deps),
+        }
     }
 }

--- a/mur-agent-runtime/src/bridge/slack/mock.rs
+++ b/mur-agent-runtime/src/bridge/slack/mock.rs
@@ -1,12 +1,98 @@
-// Stub — fully implemented in M-c7.2+
-use crate::bridge::slack::inbound::SlackBotLike;
+//! Test doubles for the C7 Slack bridge.
 
-pub struct MockSlackBot;
-impl SlackBotLike for MockSlackBot {}
+use std::sync::Mutex;
+
+use crate::bridge::slack::SlackError;
+use crate::bridge::slack::inbound::SlackBotLike;
 
 #[derive(Debug, Clone)]
 pub struct MockSlackMessage {
     pub channel: String,
     pub text: String,
     pub thread_ts: Option<String>,
+}
+
+pub struct MockSlackBot {
+    pub sent: Mutex<Vec<MockSlackMessage>>,
+    pub post_message_err: Option<SlackError>,
+    pub bot_user_id: String,
+}
+
+impl MockSlackBot {
+    pub fn new() -> Self {
+        Self {
+            sent: Mutex::new(Vec::new()),
+            post_message_err: None,
+            bot_user_id: "U_BOT_TEST".into(),
+        }
+    }
+
+    pub fn sent_messages(&self) -> Vec<MockSlackMessage> {
+        self.sent.lock().unwrap().clone()
+    }
+}
+
+impl Default for MockSlackBot {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl SlackBotLike for MockSlackBot {
+    async fn post_message(
+        &self,
+        channel: &str,
+        text: &str,
+        thread_ts: Option<&str>,
+    ) -> Result<(), SlackError> {
+        if let Some(ref err) = self.post_message_err {
+            return Err(match err {
+                SlackError::Auth(c) => SlackError::Auth(*c),
+                SlackError::RateLimit(d) => SlackError::RateLimit(*d),
+                SlackError::Network(s) => SlackError::Network(s.clone()),
+                SlackError::Parse(s) => SlackError::Parse(s.clone()),
+                SlackError::WebSocket(s) => SlackError::WebSocket(s.clone()),
+            });
+        }
+        self.sent.lock().unwrap().push(MockSlackMessage {
+            channel: channel.to_string(),
+            text: text.to_string(),
+            thread_ts: thread_ts.map(|s| s.to_string()),
+        });
+        Ok(())
+    }
+
+    async fn auth_test(&self) -> Result<String, SlackError> {
+        Ok(self.bot_user_id.clone())
+    }
+}
+
+pub struct MockUserAgentHandle {
+    pub received: Mutex<Vec<serde_json::Value>>,
+    pub status: u16,
+    pub reply_text: String,
+}
+
+impl MockUserAgentHandle {
+    pub fn new(status: u16, reply_text: impl Into<String>) -> Self {
+        Self {
+            received: Mutex::new(Vec::new()),
+            status,
+            reply_text: reply_text.into(),
+        }
+    }
+
+    pub fn ok(reply_text: impl Into<String>) -> Self {
+        Self::new(200, reply_text)
+    }
+
+    pub fn server_error() -> Self {
+        Self::new(500, "")
+    }
+
+    pub fn forward(&self, payload: serde_json::Value) -> (u16, String) {
+        self.received.lock().unwrap().push(payload);
+        (self.status, self.reply_text.clone())
+    }
 }

--- a/mur-agent-runtime/src/bridge/slack/mock.rs
+++ b/mur-agent-runtime/src/bridge/slack/mock.rs
@@ -47,13 +47,7 @@ impl SlackBotLike for MockSlackBot {
         thread_ts: Option<&str>,
     ) -> Result<(), SlackError> {
         if let Some(ref err) = self.post_message_err {
-            return Err(match err {
-                SlackError::Auth(c) => SlackError::Auth(*c),
-                SlackError::RateLimit(d) => SlackError::RateLimit(*d),
-                SlackError::Network(s) => SlackError::Network(s.clone()),
-                SlackError::Parse(s) => SlackError::Parse(s.clone()),
-                SlackError::WebSocket(s) => SlackError::WebSocket(s.clone()),
-            });
+            return Err(err.clone());
         }
         self.sent.lock().unwrap().push(MockSlackMessage {
             channel: channel.to_string(),

--- a/mur-agent-runtime/src/bridge/slack/mod.rs
+++ b/mur-agent-runtime/src/bridge/slack/mod.rs
@@ -14,7 +14,7 @@ pub use mock::{MockSlackBot, MockSlackMessage, MockUserAgentHandle};
 pub use socket::SlackSocketConn;
 
 /// Local error type for all Slack bridge operations.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum SlackError {
     #[error("Slack auth error (HTTP {0}): check your tokens")]
     Auth(u16),

--- a/mur-agent-runtime/src/bridge/slack/mod.rs
+++ b/mur-agent-runtime/src/bridge/slack/mod.rs
@@ -10,7 +10,7 @@ pub mod reply;
 pub mod socket;
 
 pub use inbound::{InboundDeps, SlackBotLike, SlackInboundLoop};
-pub use mock::{MockSlackBot, MockSlackMessage};
+pub use mock::{MockSlackBot, MockSlackMessage, MockUserAgentHandle};
 pub use socket::SlackSocketConn;
 
 /// Local error type for all Slack bridge operations.

--- a/mur-agent-runtime/src/bridge/slack/reply.rs
+++ b/mur-agent-runtime/src/bridge/slack/reply.rs
@@ -3,7 +3,6 @@ use reqwest::Client;
 use crate::bridge::slack::SlackError;
 
 /// Send a message to a Slack channel via `chat.postMessage`.
-/// Stub: will be fully implemented in M-c7.5.
 pub async fn post_message(
     _client: &Client,
     _bot_token: &str,

--- a/mur-agent-runtime/src/bridge/slack/reply.rs
+++ b/mur-agent-runtime/src/bridge/slack/reply.rs
@@ -1,1 +1,17 @@
 // Stub — fully implemented in M-c7.5
+
+use reqwest::Client;
+
+use crate::bridge::slack::SlackError;
+
+/// Send a message to a Slack channel via `chat.postMessage`.
+/// Stub: will be fully implemented in M-c7.5.
+pub async fn post_message(
+    _client: &Client,
+    _bot_token: &str,
+    _channel: &str,
+    _text: &str,
+    _thread_ts: Option<&str>,
+) -> Result<(), SlackError> {
+    unimplemented!("post_message implemented in M-c7.5")
+}

--- a/mur-agent-runtime/src/bridge/slack/reply.rs
+++ b/mur-agent-runtime/src/bridge/slack/reply.rs
@@ -1,5 +1,3 @@
-// Stub — fully implemented in M-c7.5
-
 use reqwest::Client;
 
 use crate::bridge::slack::SlackError;

--- a/mur-agent-runtime/tests/c7_slack_inbound.rs
+++ b/mur-agent-runtime/tests/c7_slack_inbound.rs
@@ -1,0 +1,50 @@
+//! Pipeline tests for the C7 Slack bridge inbound loop.
+
+use mur_agent_runtime::bridge::slack::inbound::{SlackBotLike, SlackInboundLoop};
+use mur_agent_runtime::bridge::slack::mock::{MockSlackBot, MockUserAgentHandle};
+
+#[test]
+fn stub_loop_constructs() {
+    let bot = MockSlackBot::new();
+    let _loop_ = SlackInboundLoop::stub_new(bot);
+}
+
+#[tokio::test]
+async fn mock_bot_records_post_message() {
+    let bot = MockSlackBot::new();
+    bot.post_message("C123", "hello", Some("1234567890.000001"))
+        .await
+        .unwrap();
+    let msgs = bot.sent_messages();
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].channel, "C123");
+    assert_eq!(msgs[0].text, "hello");
+    assert_eq!(msgs[0].thread_ts.as_deref(), Some("1234567890.000001"));
+}
+
+#[tokio::test]
+async fn mock_bot_auth_test() {
+    let bot = MockSlackBot::new();
+    let uid = bot.auth_test().await.unwrap();
+    assert_eq!(uid, "U_BOT_TEST");
+}
+
+#[test]
+fn mock_user_agent_handle_forward() {
+    let handle = MockUserAgentHandle::ok("pong");
+    let payload = serde_json::json!({"text": "ping"});
+    let (status, reply) = handle.forward(payload.clone());
+    assert_eq!(status, 200);
+    assert_eq!(reply, "pong");
+    let received = handle.received.lock().unwrap();
+    assert_eq!(received.len(), 1);
+    assert_eq!(received[0], payload);
+}
+
+#[test]
+fn mock_user_agent_server_error() {
+    let handle = MockUserAgentHandle::server_error();
+    let (status, reply) = handle.forward(serde_json::json!({}));
+    assert_eq!(status, 500);
+    assert_eq!(reply, "");
+}


### PR DESCRIPTION
## Summary

- `SlackEnvelope` / `SlackEvent` wire types (Socket Mode payload shape)
- `SlackBotLike` trait + `RealSlackBot` (delegates to `reply::post_message` stub) + `MockSlackBot`
- `InboundDeps` + `SlackInboundLoop<B>` skeleton (stub_new + new constructors)
- `MockUserAgentHandle` for routing tests
- `reply::post_message` stub signature added (implemented in M-c7.5)
- `mod.rs` re-exports updated to include `MockUserAgentHandle`

## Test plan

- [x] stub_loop_constructs — type wiring OK
- [x] mock_bot_records_post_message — MockSlackBot records calls
- [x] mock_bot_auth_test — returns configured user ID
- [x] mock_user_agent_handle_forward — forward() stores payload, returns (status, text)
- [x] mock_user_agent_server_error — server_error() convenience constructor

5 tests pass. Clippy clean. fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)