### PR TITLE
feat(runtime): C7 Slack bridge — M-c7.3 dedupe + privacy gate

### DIFF
--- a/mur-agent-runtime/src/bridge/slack/inbound.rs
+++ b/mur-agent-runtime/src/bridge/slack/inbound.rs
@@ -138,7 +138,6 @@ pub struct TickResult {
 
 impl<B: SlackBotLike> SlackInboundLoop<B> {
     /// Process one `events_api` envelope through phases 1-3 (classify, privacy, dedupe).
-    /// Phases 4-7 (sign, A2A forward, ack, reply) are added in M-c7.4/M-c7.5.
     pub async fn tick_once(&mut self, envelope: SlackEnvelope) -> Result<TickResult, SlackError> {
         let Some(payload) = envelope.payload else {
             return Ok(TickResult { forwarded: false });
@@ -170,7 +169,9 @@ impl<B: SlackBotLike> SlackInboundLoop<B> {
         if deps.dedupe.is_seen(&dedupe_key).unwrap_or(false) {
             return Ok(TickResult { forwarded: false });
         }
-        let _ = deps.dedupe.mark_seen(&dedupe_key);
+        deps.dedupe
+            .mark_seen(&dedupe_key)
+            .map_err(|e| SlackError::Network(e.to_string()))?;
 
         Ok(TickResult { forwarded: true })
     }

--- a/mur-agent-runtime/src/bridge/slack/inbound.rs
+++ b/mur-agent-runtime/src/bridge/slack/inbound.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use mur_common::bridge::SlackConfig;
+use mur_common::bridge::{SlackConfig, SlackPrivacyMode};
 use mur_common::identity::AgentIdentity;
 
 use crate::bridge::ack::AckTracker;
@@ -127,5 +127,51 @@ impl<B: SlackBotLike> SlackInboundLoop<B> {
             bot,
             deps: Some(deps),
         }
+    }
+}
+
+/// Result of processing one Socket Mode envelope.
+#[derive(Debug)]
+pub struct TickResult {
+    pub forwarded: bool,
+}
+
+impl<B: SlackBotLike> SlackInboundLoop<B> {
+    /// Process one `events_api` envelope through phases 1-3 (classify, privacy, dedupe).
+    /// Phases 4-7 (sign, A2A forward, ack, reply) are added in M-c7.4/M-c7.5.
+    pub async fn tick_once(&mut self, envelope: SlackEnvelope) -> Result<TickResult, SlackError> {
+        let Some(payload) = envelope.payload else {
+            return Ok(TickResult { forwarded: false });
+        };
+        let event = &payload.event;
+
+        let is_dm = event.channel_type.as_deref() == Some("im");
+        let is_mention = event.kind == "app_mention";
+        if !is_dm && !is_mention {
+            return Ok(TickResult { forwarded: false });
+        }
+
+        let deps = self
+            .deps
+            .as_mut()
+            .expect("tick_once called on stub_new loop");
+
+        if is_mention && deps.config.privacy_mode == SlackPrivacyMode::DmOnly {
+            return Ok(TickResult { forwarded: false });
+        }
+        if is_mention
+            && !deps.config.allowed_channels.is_empty()
+            && !deps.config.allowed_channels.contains(&event.channel)
+        {
+            return Ok(TickResult { forwarded: false });
+        }
+
+        let dedupe_key = format!("{}:{}", event.channel, event.ts);
+        if deps.dedupe.is_seen(&dedupe_key).unwrap_or(false) {
+            return Ok(TickResult { forwarded: false });
+        }
+        let _ = deps.dedupe.mark_seen(&dedupe_key);
+
+        Ok(TickResult { forwarded: true })
     }
 }

--- a/mur-agent-runtime/tests/c7_slack_inbound.rs
+++ b/mur-agent-runtime/tests/c7_slack_inbound.rs
@@ -1,7 +1,77 @@
 //! Pipeline tests for the C7 Slack bridge inbound loop.
 
-use mur_agent_runtime::bridge::slack::inbound::{SlackBotLike, SlackInboundLoop};
+use mur_agent_runtime::bridge::ack::AckTracker;
+use mur_agent_runtime::bridge::dedupe::DedupeStore;
+use mur_agent_runtime::bridge::slack::inbound::{
+    InboundDeps, SlackBotLike, SlackEnvelope, SlackEvent, SlackEventPayload, SlackInboundLoop,
+};
 use mur_agent_runtime::bridge::slack::mock::{MockSlackBot, MockUserAgentHandle};
+use mur_common::bridge::{SlackConfig, SlackPrivacyMode};
+use mur_common::identity::AgentIdentity;
+use tempfile::TempDir;
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+fn test_config(privacy: SlackPrivacyMode, allowed: Vec<String>) -> SlackConfig {
+    SlackConfig {
+        workspace_url: "https://test.slack.com".into(),
+        bot_token_keychain_account: "mur_slack_bot_test".into(),
+        app_token_keychain_account: "mur_slack_app_test".into(),
+        privacy_mode: privacy,
+        allowed_channels: allowed,
+    }
+}
+
+fn mention_envelope(channel: &str, ts: &str, text: &str) -> SlackEnvelope {
+    SlackEnvelope {
+        envelope_id: format!("Ev_{ts}"),
+        kind: "events_api".into(),
+        payload: Some(SlackEventPayload {
+            event: SlackEvent {
+                kind: "app_mention".into(),
+                user: Some("U_SENDER".into()),
+                text: Some(text.into()),
+                ts: ts.into(),
+                channel: channel.into(),
+                channel_type: None,
+                thread_ts: None,
+            },
+        }),
+    }
+}
+
+fn dm_envelope(channel: &str, ts: &str, text: &str) -> SlackEnvelope {
+    SlackEnvelope {
+        envelope_id: format!("Ev_{ts}"),
+        kind: "events_api".into(),
+        payload: Some(SlackEventPayload {
+            event: SlackEvent {
+                kind: "message".into(),
+                user: Some("U_SENDER".into()),
+                text: Some(text.into()),
+                ts: ts.into(),
+                channel: channel.into(),
+                channel_type: Some("im".into()),
+                thread_ts: None,
+            },
+        }),
+    }
+}
+
+fn make_deps(privacy: SlackPrivacyMode, allowed: Vec<String>, dir: &TempDir) -> InboundDeps {
+    InboundDeps {
+        config: test_config(privacy, allowed),
+        dedupe: DedupeStore::in_memory().expect("in-memory dedupe"),
+        ack: AckTracker::new(String::new()),
+        identity: AgentIdentity::generate(),
+        key_version: 1,
+        always_5xx: false,
+        user_agent: None,
+        agent_home: dir.path().to_path_buf(),
+    }
+}
+
+// ── M-c7.2 tests ──────────────────────────────────────────────────────────
 
 #[test]
 fn stub_loop_constructs() {
@@ -47,4 +117,62 @@ fn mock_user_agent_server_error() {
     let (status, reply) = handle.forward(serde_json::json!({}));
     assert_eq!(status, 500);
     assert_eq!(reply, "");
+}
+
+// ── M-c7.3 tests ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn dm_only_mode_drops_channel_mention() {
+    let dir = TempDir::new().unwrap();
+    let bot = MockSlackBot::new();
+    let deps = make_deps(SlackPrivacyMode::DmOnly, vec![], &dir);
+    let mut loop_ = SlackInboundLoop::new(bot, deps);
+    let env = mention_envelope("C_CHANNEL", "1000000001.000001", "<@U_BOT> help");
+    let result = loop_.tick_once(env).await.unwrap();
+    assert!(!result.forwarded, "DmOnly should drop channel mentions");
+    assert_eq!(loop_.bot.sent_messages().len(), 0);
+}
+
+#[tokio::test]
+async fn dm_allowed_in_dm_only_mode() {
+    let dir = TempDir::new().unwrap();
+    let bot = MockSlackBot::new();
+    let mut deps = make_deps(SlackPrivacyMode::DmOnly, vec![], &dir);
+    deps.user_agent = Some(MockUserAgentHandle::ok("reply text"));
+    let mut loop_ = SlackInboundLoop::new(bot, deps);
+    let env = dm_envelope("D_DM", "1000000002.000001", "hello");
+    let result = loop_.tick_once(env).await.unwrap();
+    assert!(result.forwarded, "DM should pass DmOnly gate");
+}
+
+#[tokio::test]
+async fn allowed_channels_gate_drops_unlisted_channel() {
+    let dir = TempDir::new().unwrap();
+    let bot = MockSlackBot::new();
+    let deps = make_deps(
+        SlackPrivacyMode::DmAndMentions,
+        vec!["C_ALLOWED".into()],
+        &dir,
+    );
+    let mut loop_ = SlackInboundLoop::new(bot, deps);
+    let env = mention_envelope("C_OTHER", "1000000003.000001", "<@U_BOT> help");
+    let result = loop_.tick_once(env).await.unwrap();
+    assert!(
+        !result.forwarded,
+        "channel not in allowlist should be dropped"
+    );
+}
+
+#[tokio::test]
+async fn duplicate_event_skipped() {
+    let dir = TempDir::new().unwrap();
+    let bot = MockSlackBot::new();
+    let mut deps = make_deps(SlackPrivacyMode::DmAndMentions, vec![], &dir);
+    deps.user_agent = Some(MockUserAgentHandle::ok("reply"));
+    let mut loop_ = SlackInboundLoop::new(bot, deps);
+    let env = mention_envelope("C_CHAN", "1000000004.000001", "<@U_BOT> hello");
+    let r1 = loop_.tick_once(env.clone()).await.unwrap();
+    let r2 = loop_.tick_once(env).await.unwrap();
+    assert!(r1.forwarded, "first delivery should forward");
+    assert!(!r2.forwarded, "duplicate should be skipped");
 }


### PR DESCRIPTION
## Summary

- \`tick_once\` phase 1: classify events (mention/DM/other)
- \`PrivacyGate\`: DmOnly drops channel mentions; \`allowed_channels\` whitelist
- \`DedupeStore\`: \`"{channel}:{ts}"\` key; 7-day TTL from C1

## Test plan

- [x] dm_only_mode_drops_channel_mention
- [x] dm_allowed_in_dm_only_mode
- [x] allowed_channels_gate_drops_unlisted_channel
- [x] duplicate_event_skipped
- [x] cargo clippy + fmt clean