### PR TITLE
feat(runtime): C7 Slack bridge — M-c7.5 chat.postMessage reply

### DIFF
--- a/mur-agent-runtime/src/bridge/slack/inbound.rs
+++ b/mur-agent-runtime/src/bridge/slack/inbound.rs
@@ -70,6 +70,7 @@ impl SlackBotLike for RealSlackBot {
             channel,
             text,
             thread_ts,
+            None,
         )
         .await
     }

--- a/mur-agent-runtime/src/bridge/slack/reply.rs
+++ b/mur-agent-runtime/src/bridge/slack/reply.rs
@@ -1,14 +1,83 @@
+//! `chat.postMessage` helper with Retry-After rate-limit handling.
+
+use std::time::Duration;
+
 use reqwest::Client;
 
 use crate::bridge::slack::SlackError;
 
-/// Send a message to a Slack channel via `chat.postMessage`.
+/// Max retries on HTTP 429 (rate limited) before giving up.
+const MAX_RETRIES: u32 = 3;
+/// Default retry wait when Slack omits the `Retry-After` header.
+const DEFAULT_RETRY_AFTER: Duration = Duration::from_secs(5);
+
+/// POST `chat.postMessage` to Slack.
+///
+/// On HTTP 429 reads `Retry-After` header (seconds) and retries up to
+/// `MAX_RETRIES` times. After exhausting retries returns
+/// `SlackError::RateLimit`. On HTTP 401 returns `SlackError::Auth`.
+///
+/// `base_url` overrides `https://slack.com` — used in tests to redirect to a
+/// local mock server.
 pub async fn post_message(
-    _client: &Client,
-    _bot_token: &str,
-    _channel: &str,
-    _text: &str,
-    _thread_ts: Option<&str>,
+    client: &Client,
+    bot_token: &str,
+    channel: &str,
+    text: &str,
+    thread_ts: Option<&str>,
+    base_url: Option<&str>,
 ) -> Result<(), SlackError> {
-    unimplemented!("post_message implemented in M-c7.5")
+    let url = format!(
+        "{}/api/chat.postMessage",
+        base_url.unwrap_or("https://slack.com")
+    );
+
+    let mut body = serde_json::json!({
+        "channel": channel,
+        "text":    text,
+    });
+    if let Some(ts) = thread_ts {
+        body["thread_ts"] = serde_json::json!(ts);
+    }
+
+    let mut attempts = 0u32;
+    loop {
+        let resp = client
+            .post(&url)
+            .bearer_auth(bot_token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| SlackError::Network(e.to_string()))?;
+
+        let status = resp.status().as_u16();
+
+        if status == 401 {
+            return Err(SlackError::Auth(401));
+        }
+
+        if status == 429 {
+            attempts += 1;
+            if attempts > MAX_RETRIES {
+                return Err(SlackError::RateLimit(DEFAULT_RETRY_AFTER));
+            }
+            let wait = resp
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok())
+                .map(Duration::from_secs)
+                .unwrap_or(DEFAULT_RETRY_AFTER);
+            tokio::time::sleep(wait).await;
+            continue;
+        }
+
+        if !resp.status().is_success() {
+            return Err(SlackError::Network(format!(
+                "chat.postMessage HTTP {status}"
+            )));
+        }
+
+        return Ok(());
+    }
 }

--- a/mur-agent-runtime/tests/c7_slack_inbound.rs
+++ b/mur-agent-runtime/tests/c7_slack_inbound.rs
@@ -258,6 +258,49 @@ async fn a2a_5xx_does_not_advance_ack() {
     );
 }
 
+// ── M-c7.5 tests ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn rate_limit_exhausted_returns_error() {
+    use mur_agent_runtime::bridge::slack::reply::post_message;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    tokio::spawn(async move {
+        // MAX_RETRIES=3 means 4 total attempts; accept 5 to be safe
+        for _ in 0..5u32 {
+            if let Ok((mut s, _)) = listener.accept().await {
+                let mut buf = [0u8; 4096];
+                let _ = s.read(&mut buf).await;
+                let resp = b"HTTP/1.1 429 Too Many Requests\r\nRetry-After: 0\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                let _ = s.write_all(resp).await;
+            }
+        }
+    });
+
+    let client = reqwest::Client::new();
+    let base_url = format!("http://127.0.0.1:{port}");
+    let result = post_message(
+        &client,
+        "xoxb-fake",
+        "C_CHAN",
+        "hello",
+        None,
+        Some(&base_url),
+    )
+    .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(mur_agent_runtime::bridge::slack::SlackError::RateLimit(_))
+        ),
+        "expected RateLimit after exhausted retries, got: {result:?}"
+    );
+}
+
 #[tokio::test]
 async fn envelope_signed_correctly() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- `post_message()`: POST chat.postMessage; thread_ts for mentions, None for DMs
- Rate limit: reads Retry-After header, retries up to 3 times, returns SlackError::RateLimit after exhaustion
- Auth errors (401) propagate immediately without retry
- `base_url: Option<&str>` parameter enables redirect to local mock server in tests

## Test plan

- [x] rate_limit_exhausted_returns_error — mock server returns 429×4, confirms RateLimit error after MAX_RETRIES=3
- [x] full runtime inbound suite: 15/15 green