### PR TITLE
feat: MuR Hub companion — M-h0 through M-h8

### DIFF
--- a/mur-agent-gui/README.md
+++ b/mur-agent-gui/README.md
@@ -1,4 +1,8 @@
-# mur-agent-gui
+# mur-agent-gui [legacy]
+
+> **Deprecated as of M-h8.** Use [mur-hub-gui](../mur-hub-gui) instead.
+> Run `mur agent migrate-to-hub` to move your agents to the new Hub.
+> This crate is in maintenance mode and will be removed in v2.
 
 Tauri 2 desktop shell for a single mur agent. Produced (one-shot, per-agent) by `mur agent export --format gui`.
 

--- a/mur-agent-gui/src-tauri/Cargo.toml
+++ b/mur-agent-gui/src-tauri/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"
 description = "Tauri 2 desktop shell for a single mur agent"
+publish = false  # [legacy] — superseded by mur-hub-gui in M-h8; see mur-agent-gui/README.md
 
 # Mark as a standalone workspace so cargo doesn't walk past
 # `.worktrees/<name>/Cargo.toml` (which excludes mur-agent-gui) and accidentally

--- a/mur-common/Cargo.toml
+++ b/mur-common/Cargo.toml
@@ -31,6 +31,7 @@ shellexpand = "3"
 shell-words = "1"
 fs2 = "0.4"
 tracing = "0.1"
+sha2 = "0.10"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation"] }

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -56,6 +56,9 @@ pub struct AgentProfile {
     pub trusted_peers: Vec<crate::bridge::peer::TrustedPeer>,
     pub created_at: String,
     pub updated_at: String,
+    /// Hub companion visual identity (M-h3). Default = default-blob / Normal / Pending.
+    #[serde(default)]
+    pub appearance: AgentAppearance,
 }
 
 fn default_algorithm() -> String {
@@ -901,6 +904,69 @@ pub struct ActiveHours {
     pub end: String,
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Hub companion appearance (M-h3)
+// ──────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentAppearance {
+    /// ID of the active style preset (e.g. "chiikawa", "default-blob").
+    #[serde(default = "default_style_preset")]
+    pub style_preset: String,
+    #[serde(default)]
+    pub behavior_preset: BehaviorPreset,
+    /// Required for the polaroid family; none for all others.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_image_path: Option<std::path::PathBuf>,
+    /// Local dir where rendered .webp expression frames are stored.
+    #[serde(default = "default_expressions_dir")]
+    pub expressions_dir: std::path::PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_rendered_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(default)]
+    pub render_status: RenderStatus,
+}
+
+fn default_style_preset() -> String {
+    "default-blob".into()
+}
+
+fn default_expressions_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from("expressions")
+}
+
+impl Default for AgentAppearance {
+    fn default() -> Self {
+        Self {
+            style_preset: default_style_preset(),
+            behavior_preset: BehaviorPreset::Normal,
+            source_image_path: None,
+            expressions_dir: default_expressions_dir(),
+            last_rendered_at: None,
+            render_status: RenderStatus::Pending,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BehaviorPreset {
+    Quiet,
+    #[default]
+    Normal,
+    Lively,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum RenderStatus {
+    #[default]
+    Pending,
+    Rendering { done: u8, total: u8 },
+    Ready,
+    Failed { reason: String },
+}
+
 impl AgentProfile {
     /// Minimal valid profile for tests — no voice, no MCP, no skills.
     ///
@@ -1238,5 +1304,64 @@ idle_triggers:
         let yaml = "restart: on_failure\n";
         let cfg: LifecycleConfig = serde_yaml_ng::from_str(yaml).unwrap();
         assert!(cfg.idle_triggers.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod appearance_tests {
+    use super::*;
+
+    #[test]
+    fn appearance_default_style_preset_is_default_blob() {
+        assert_eq!(AgentAppearance::default().style_preset, "default-blob");
+    }
+
+    #[test]
+    fn appearance_default_behavior_is_normal() {
+        assert_eq!(AgentAppearance::default().behavior_preset, BehaviorPreset::Normal);
+    }
+
+    #[test]
+    fn appearance_default_render_status_is_pending() {
+        assert_eq!(AgentAppearance::default().render_status, RenderStatus::Pending);
+    }
+
+    #[test]
+    fn render_status_serde_round_trip() {
+        let cases = [
+            RenderStatus::Pending,
+            RenderStatus::Rendering { done: 3, total: 12 },
+            RenderStatus::Ready,
+            RenderStatus::Failed { reason: "out of quota".into() },
+        ];
+        for status in cases {
+            let yaml = serde_yaml_ng::to_string(&status).expect("serialize");
+            let back: RenderStatus = serde_yaml_ng::from_str(&yaml).expect("deserialize");
+            assert_eq!(status, back);
+        }
+    }
+
+    #[test]
+    fn agent_profile_with_appearance_round_trips() {
+        let base = include_str!("../tests/fixtures/profile_p0a_minimal.yaml");
+        let yaml = format!(
+            "{base}appearance:\n  style_preset: chiikawa\n  render_status:\n    status: ready\n"
+        );
+        let profile: AgentProfile = serde_yaml_ng::from_str(&yaml).expect("parse with appearance");
+        assert_eq!(profile.appearance.style_preset, "chiikawa");
+        assert_eq!(profile.appearance.render_status, RenderStatus::Ready);
+
+        let out = serde_yaml_ng::to_string(&profile).expect("serialize");
+        let back: AgentProfile = serde_yaml_ng::from_str(&out).expect("re-parse");
+        assert_eq!(profile.appearance, back.appearance);
+    }
+
+    #[test]
+    fn legacy_profile_without_appearance_uses_default() {
+        let yaml = include_str!("../tests/fixtures/profile_p0a_minimal.yaml");
+        let profile: AgentProfile = serde_yaml_ng::from_str(yaml).expect("parse legacy");
+        assert_eq!(profile.appearance.style_preset, "default-blob");
+        assert_eq!(profile.appearance.behavior_preset, BehaviorPreset::Normal);
+        assert_eq!(profile.appearance.render_status, RenderStatus::Pending);
     }
 }

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -962,9 +962,14 @@ pub enum BehaviorPreset {
 pub enum RenderStatus {
     #[default]
     Pending,
-    Rendering { done: u8, total: u8 },
+    Rendering {
+        done: u8,
+        total: u8,
+    },
     Ready,
-    Failed { reason: String },
+    Failed {
+        reason: String,
+    },
 }
 
 impl AgentProfile {
@@ -1318,12 +1323,18 @@ mod appearance_tests {
 
     #[test]
     fn appearance_default_behavior_is_normal() {
-        assert_eq!(AgentAppearance::default().behavior_preset, BehaviorPreset::Normal);
+        assert_eq!(
+            AgentAppearance::default().behavior_preset,
+            BehaviorPreset::Normal
+        );
     }
 
     #[test]
     fn appearance_default_render_status_is_pending() {
-        assert_eq!(AgentAppearance::default().render_status, RenderStatus::Pending);
+        assert_eq!(
+            AgentAppearance::default().render_status,
+            RenderStatus::Pending
+        );
     }
 
     #[test]
@@ -1332,7 +1343,9 @@ mod appearance_tests {
             RenderStatus::Pending,
             RenderStatus::Rendering { done: 3, total: 12 },
             RenderStatus::Ready,
-            RenderStatus::Failed { reason: "out of quota".into() },
+            RenderStatus::Failed {
+                reason: "out of quota".into(),
+            },
         ];
         for status in cases {
             let yaml = serde_yaml_ng::to_string(&status).expect("serialize");

--- a/mur-common/src/hub/builtin_presets/chiikawa.yaml
+++ b/mur-common/src/hub/builtin_presets/chiikawa.yaml
@@ -1,0 +1,36 @@
+id: chiikawa
+display_name: "ちいかわ"
+author: builtin
+version: 1
+family: chibi
+description: "Nagano-style soft pastel chibi, vulnerable cute"
+
+llm_image_gen:
+  base_prompt: |
+    Soft pastel chibi character in Nagano-style ちいかわ aesthetic.
+    Tiny round body, oversized head, dot eyes, small 'w' mouth,
+    pale cream / beige color palette, hand-drawn line, vulnerable cute.
+  negative_prompt: "realistic, sharp lines, dark colors, adult"
+  size: "512x512"
+  steps: 28
+
+expressions:
+  - { id: idle,       prompt_suffix: "sitting peacefully, soft smile" }
+  - { id: smile,      prompt_suffix: "happy smile, slight blush" }
+  - { id: wave,       prompt_suffix: "waving hello, one paw up" }
+  - { id: think,      prompt_suffix: "thinking pose, finger on chin" }
+  - { id: wow,        prompt_suffix: "surprised, eyes wide open" }
+  - { id: sparkle,    prompt_suffix: "celebrating, sparkles around" }
+  - { id: cry,        prompt_suffix: "teary eyes, holding back tears" }
+  - { id: sleep,      prompt_suffix: "sleeping, Zzz above head" }
+  - { id: peek,       prompt_suffix: "peeking from corner, shy" }
+  - { id: talk_open,  prompt_suffix: "talking, mouth open" }
+  - { id: talk_close, prompt_suffix: "talking, mouth slightly closed" }
+  - { id: error,      prompt_suffix: "worried, hand on cheek" }
+
+renderer:
+  family: chibi
+  default_size: { w: 96, h: 112 }
+  idle_animation: breathe
+  blink_interval_s: [3.0, 6.0]
+  crossfade_ms: 240

--- a/mur-common/src/hub/builtin_presets/default-blob.yaml
+++ b/mur-common/src/hub/builtin_presets/default-blob.yaml
@@ -1,0 +1,36 @@
+id: default-blob
+display_name: "Default Blob"
+author: builtin
+version: 1
+family: chibi
+description: "SVG-only internal fallback — shown before LLM render completes or on render failure"
+
+llm_image_gen:
+  base_prompt: |
+    Simple friendly blob character, smooth rounded shape, single flat
+    color, minimal dot eyes and small smile, SVG-friendly design,
+    no details, universal placeholder style.
+  negative_prompt: "complex, detailed, realistic, sharp"
+  size: "256x256"
+  steps: 16
+
+expressions:
+  - { id: idle,       prompt_suffix: "neutral resting blob" }
+  - { id: smile,      prompt_suffix: "blob smiling" }
+  - { id: wave,       prompt_suffix: "blob with waving pseudopod" }
+  - { id: think,      prompt_suffix: "blob with thought bubble" }
+  - { id: wow,        prompt_suffix: "blob wide-eyed" }
+  - { id: sparkle,    prompt_suffix: "blob with sparkles" }
+  - { id: cry,        prompt_suffix: "blob with teardrops" }
+  - { id: sleep,      prompt_suffix: "blob with Zzz" }
+  - { id: peek,       prompt_suffix: "blob half-hidden" }
+  - { id: talk_open,  prompt_suffix: "blob open mouth" }
+  - { id: talk_close, prompt_suffix: "blob closed mouth" }
+  - { id: error,      prompt_suffix: "blob distressed" }
+
+renderer:
+  family: chibi
+  default_size: { w: 64, h: 64 }
+  idle_animation: breathe
+  blink_interval_s: [4.0, 8.0]
+  crossfade_ms: 160

--- a/mur-common/src/hub/builtin_presets/family-photo.yaml
+++ b/mur-common/src/hub/builtin_presets/family-photo.yaml
@@ -1,0 +1,39 @@
+id: family-photo
+display_name: "Family Photo"
+author: builtin
+version: 1
+family: polaroid
+description: "Polaroid family style — turns a user-supplied photo into a cartoon companion"
+
+llm_image_gen:
+  base_prompt: |
+    Transform the provided reference photo into a friendly cartoon chibi
+    companion. Preserve the subject's recognizable features (hair color,
+    glasses, distinctive traits) while softening into a cute chibi style.
+    Warm pastel tones, friendly expression, simple clean background.
+  negative_prompt: "ugly, distorted, scary, realistic photo"
+  size: "512x512"
+  steps: 32
+  img2img: true
+  requires_source_image: true
+
+expressions:
+  - { id: idle,       prompt_suffix: "calm friendly expression" }
+  - { id: smile,      prompt_suffix: "warm cheerful smile" }
+  - { id: wave,       prompt_suffix: "friendly wave gesture" }
+  - { id: think,      prompt_suffix: "thoughtful contemplating expression" }
+  - { id: wow,        prompt_suffix: "surprised delighted expression" }
+  - { id: sparkle,    prompt_suffix: "proud happy celebrating expression" }
+  - { id: cry,        prompt_suffix: "sad emotional expression" }
+  - { id: sleep,      prompt_suffix: "peacefully sleeping" }
+  - { id: peek,       prompt_suffix: "peeking shyly from side" }
+  - { id: talk_open,  prompt_suffix: "speaking with open mouth" }
+  - { id: talk_close, prompt_suffix: "mouth closed attentive expression" }
+  - { id: error,      prompt_suffix: "confused worried expression" }
+
+renderer:
+  family: polaroid
+  default_size: { w: 96, h: 112 }
+  idle_animation: breathe
+  blink_interval_s: [4.0, 8.0]
+  crossfade_ms: 260

--- a/mur-common/src/hub/builtin_presets/sanrio-pastel.yaml
+++ b/mur-common/src/hub/builtin_presets/sanrio-pastel.yaml
@@ -1,0 +1,36 @@
+id: sanrio-pastel
+display_name: "Sanrio Pastel"
+author: builtin
+version: 1
+family: chibi
+description: "Sanrio pastel kawaii style — soft rounded shapes, pastel palette, bow accents"
+
+llm_image_gen:
+  base_prompt: |
+    Kawaii chibi character in Sanrio pastel style. Soft rounded body,
+    large sparkly eyes, pastel pink / mint / lavender palette, cute bow
+    accessory, clean vector-like linework, friendly and cheerful.
+  negative_prompt: "realistic, dark, edgy, sharp, adult, scary"
+  size: "512x512"
+  steps: 28
+
+expressions:
+  - { id: idle,       prompt_suffix: "sitting cutely, gentle smile" }
+  - { id: smile,      prompt_suffix: "big happy smile, star-shaped sparkles" }
+  - { id: wave,       prompt_suffix: "waving with both hands, cheerful" }
+  - { id: think,      prompt_suffix: "head tilted, thinking bubble above" }
+  - { id: wow,        prompt_suffix: "eyes shining, mouth open in awe" }
+  - { id: sparkle,    prompt_suffix: "surrounded by pastel stars and hearts" }
+  - { id: cry,        prompt_suffix: "tiny tears, pouty face" }
+  - { id: sleep,      prompt_suffix: "curled up asleep, moon and stars" }
+  - { id: peek,       prompt_suffix: "peeking behind a large pastel star" }
+  - { id: talk_open,  prompt_suffix: "talking, round open mouth" }
+  - { id: talk_close, prompt_suffix: "talking, mouth gently closed" }
+  - { id: error,      prompt_suffix: "confused sweat drop, question mark" }
+
+renderer:
+  family: chibi
+  default_size: { w: 96, h: 112 }
+  idle_animation: breathe
+  blink_interval_s: [4.0, 7.0]
+  crossfade_ms: 200

--- a/mur-common/src/hub/builtin_presets/shimeji-retro.yaml
+++ b/mur-common/src/hub/builtin_presets/shimeji-retro.yaml
@@ -1,0 +1,37 @@
+id: shimeji-retro
+display_name: "Shimeji Retro"
+author: builtin
+version: 1
+family: pixel
+description: "Pixel / shimeji retro 8-bit sprite style — chunky pixels, limited palette"
+
+llm_image_gen:
+  base_prompt: |
+    Cute 8-bit pixel art sprite character, shimeji desktop pet style.
+    Chunky square pixels, 16-color limited palette, black outlines,
+    retro video game aesthetic, NES / Game Boy era look,
+    transparent background.
+  negative_prompt: "smooth, anti-aliased, realistic, photographic, gradient, many colors"
+  size: "256x256"
+  steps: 20
+
+expressions:
+  - { id: idle,       prompt_suffix: "idle standing animation frame" }
+  - { id: smile,      prompt_suffix: "happy expression, pixel smile" }
+  - { id: wave,       prompt_suffix: "waving arm up pixel frame" }
+  - { id: think,      prompt_suffix: "pixel question mark above head" }
+  - { id: wow,        prompt_suffix: "surprised pixel eyes wide" }
+  - { id: sparkle,    prompt_suffix: "pixel star burst effect" }
+  - { id: cry,        prompt_suffix: "pixel tear drops" }
+  - { id: sleep,      prompt_suffix: "sleeping ZZZ pixel bubbles" }
+  - { id: peek,       prompt_suffix: "peeking sprite half visible" }
+  - { id: talk_open,  prompt_suffix: "speech bubble pixel open mouth" }
+  - { id: talk_close, prompt_suffix: "closed mouth pixel sprite" }
+  - { id: error,      prompt_suffix: "pixel X eyes glitch effect" }
+
+renderer:
+  family: pixel
+  default_size: { w: 64, h: 64 }
+  idle_animation: none
+  blink_interval_s: [2.0, 4.0]
+  crossfade_ms: 0

--- a/mur-common/src/hub/builtin_presets/sumikko.yaml
+++ b/mur-common/src/hub/builtin_presets/sumikko.yaml
@@ -1,0 +1,37 @@
+id: sumikko
+display_name: "Sumikko Gurashi"
+author: builtin
+version: 1
+family: chibi
+description: "Sumikko Gurashi shy corner creatures — muted tones, introverted, cozy"
+
+llm_image_gen:
+  base_prompt: |
+    Tiny shy creature in Sumikko Gurashi style. Simple rounded blob
+    body, small worried dot eyes, muted pastel tones (mint green, beige,
+    dusty pink), loves corners, timid but endearing expression,
+    flat 2D illustration style.
+  negative_prompt: "bold colors, scary, sharp, realistic, busy background"
+  size: "512x512"
+  steps: 26
+
+expressions:
+  - { id: idle,       prompt_suffix: "huddled in a corner, calm and still" }
+  - { id: smile,      prompt_suffix: "tiny shy smile, slight blush" }
+  - { id: wave,       prompt_suffix: "hesitant small wave, still a bit nervous" }
+  - { id: think,      prompt_suffix: "side-eye thinking, small thought bubble" }
+  - { id: wow,        prompt_suffix: "startled, peeking from shell or blanket" }
+  - { id: sparkle,    prompt_suffix: "happy sparkles, rare excited expression" }
+  - { id: cry,        prompt_suffix: "teardrops, curled up sad" }
+  - { id: sleep,      prompt_suffix: "sleeping soundly in cozy corner" }
+  - { id: peek,       prompt_suffix: "peeking from behind a corner wall" }
+  - { id: talk_open,  prompt_suffix: "timidly speaking, small open mouth" }
+  - { id: talk_close, prompt_suffix: "finished speaking, small content smile" }
+  - { id: error,      prompt_suffix: "distressed, hiding under a pile of leaves" }
+
+renderer:
+  family: chibi
+  default_size: { w: 88, h: 100 }
+  idle_animation: breathe
+  blink_interval_s: [5.0, 9.0]
+  crossfade_ms: 280

--- a/mur-common/src/hub/builtin_presets/vtuber-soft.yaml
+++ b/mur-common/src/hub/builtin_presets/vtuber-soft.yaml
@@ -1,0 +1,37 @@
+id: vtuber-soft
+display_name: "VTuber Soft"
+author: builtin
+version: 1
+family: chibi
+description: "Soft VTuber anime style — cel-shaded, big eyes, colorful hair, expressive"
+
+llm_image_gen:
+  base_prompt: |
+    Cute VTuber character in soft anime chibi style. Large expressive
+    eyes with highlight reflections, colorful pastel hair, cel-shaded
+    flat colors with soft shadow, clean digital illustration,
+    streaming aesthetic, kawaii but slightly stylish.
+  negative_prompt: "realistic, 3D, dark, gritty, low quality, blurry"
+  size: "512x512"
+  steps: 30
+
+expressions:
+  - { id: idle,       prompt_suffix: "relaxed streaming pose, soft smile" }
+  - { id: smile,      prompt_suffix: "bright smile, happy streamer energy" }
+  - { id: wave,       prompt_suffix: "enthusiastic wave hello to chat" }
+  - { id: think,      prompt_suffix: "thinking pose, finger to lips" }
+  - { id: wow,        prompt_suffix: "shocked pog face, wide shining eyes" }
+  - { id: sparkle,    prompt_suffix: "celebrating, confetti and sparkles" }
+  - { id: cry,        prompt_suffix: "crying face, sad streamer moment" }
+  - { id: sleep,      prompt_suffix: "falling asleep on stream, Zzz" }
+  - { id: peek,       prompt_suffix: "peeking from corner, curious" }
+  - { id: talk_open,  prompt_suffix: "talking to chat, mouth open" }
+  - { id: talk_close, prompt_suffix: "mouth closed, listening expression" }
+  - { id: error,      prompt_suffix: "technical difficulties face, worried" }
+
+renderer:
+  family: chibi
+  default_size: { w: 96, h: 120 }
+  idle_animation: breathe
+  blink_interval_s: [3.0, 5.0]
+  crossfade_ms: 200

--- a/mur-common/src/hub/mod.rs
+++ b/mur-common/src/hub/mod.rs
@@ -1,3 +1,4 @@
 pub mod preset_loader;
 pub mod preset_manifest;
 pub mod style_preset;
+pub mod trigger;

--- a/mur-common/src/hub/mod.rs
+++ b/mur-common/src/hub/mod.rs
@@ -1,0 +1,3 @@
+pub mod preset_loader;
+pub mod preset_manifest;
+pub mod style_preset;

--- a/mur-common/src/hub/preset_loader.rs
+++ b/mur-common/src/hub/preset_loader.rs
@@ -1,0 +1,130 @@
+use crate::hub::style_preset::StylePreset;
+use anyhow::Result;
+use std::path::Path;
+
+const BUILTIN_YAMLS: &[&str] = &[
+    include_str!("builtin_presets/chiikawa.yaml"),
+    include_str!("builtin_presets/sanrio-pastel.yaml"),
+    include_str!("builtin_presets/sumikko.yaml"),
+    include_str!("builtin_presets/shimeji-retro.yaml"),
+    include_str!("builtin_presets/vtuber-soft.yaml"),
+    include_str!("builtin_presets/family-photo.yaml"),
+    include_str!("builtin_presets/default-blob.yaml"),
+];
+
+/// Returns all 7 built-in presets (including `default-blob`), parsed at
+/// compile time via `include_str!`. Panics if any YAML is malformed — that
+/// would be a build-time bug, not a runtime failure.
+pub fn load_builtin_presets() -> Vec<StylePreset> {
+    BUILTIN_YAMLS
+        .iter()
+        .map(|s| serde_yaml_ng::from_str(s).expect("malformed builtin preset YAML"))
+        .collect()
+}
+
+/// Loads user-defined presets from `<hub_dir>/presets/*.yaml`.
+/// Returns an empty vec (not an error) if the directory does not exist.
+pub fn load_user_presets(hub_dir: &Path) -> Result<Vec<StylePreset>> {
+    let presets_dir = hub_dir.join("presets");
+    if !presets_dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut presets = Vec::new();
+    for entry in std::fs::read_dir(&presets_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("yaml") {
+            let content = std::fs::read_to_string(&path)?;
+            let preset: StylePreset = serde_yaml_ng::from_str(&content)
+                .map_err(|e| anyhow::anyhow!("failed to parse preset {:?}: {}", path, e))?;
+            presets.push(preset);
+        }
+    }
+    Ok(presets)
+}
+
+/// Built-in presets first, then user presets from `<hub_dir>/presets/`.
+pub fn load_all_presets(hub_dir: &Path) -> Result<Vec<StylePreset>> {
+    let mut all = load_builtin_presets();
+    all.extend(load_user_presets(hub_dir)?);
+    Ok(all)
+}
+
+/// Finds a preset by `id`. Built-in presets take priority over user presets.
+/// Returns an error if no preset with that id exists.
+pub fn find_preset(id: &str, hub_dir: &Path) -> Result<StylePreset> {
+    for preset in load_builtin_presets() {
+        if preset.id == id {
+            return Ok(preset);
+        }
+    }
+    for preset in load_user_presets(hub_dir)? {
+        if preset.id == id {
+            return Ok(preset);
+        }
+    }
+    anyhow::bail!("preset '{}' not found", id)
+}
+
+/// Always returns the `default-blob` built-in preset. Never fails.
+pub fn default_blob() -> StylePreset {
+    serde_yaml_ng::from_str(include_str!("builtin_presets/default-blob.yaml"))
+        .expect("default-blob preset is malformed")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_presets_count_and_ids() {
+        let presets = load_builtin_presets();
+        assert_eq!(presets.len(), 7, "expected 7 built-in presets");
+        let ids: Vec<&str> = presets.iter().map(|p| p.id.as_str()).collect();
+        assert!(ids.contains(&"chiikawa"), "missing chiikawa");
+        assert!(ids.contains(&"sanrio-pastel"), "missing sanrio-pastel");
+        assert!(ids.contains(&"sumikko"), "missing sumikko");
+        assert!(ids.contains(&"shimeji-retro"), "missing shimeji-retro");
+        assert!(ids.contains(&"vtuber-soft"), "missing vtuber-soft");
+        assert!(ids.contains(&"family-photo"), "missing family-photo");
+        assert!(ids.contains(&"default-blob"), "missing default-blob");
+    }
+
+    #[test]
+    fn builtin_presets_yaml_round_trip() {
+        use crate::hub::style_preset::StylePreset;
+        for preset in load_builtin_presets() {
+            let yaml = serde_yaml_ng::to_string(&preset).expect("serialize");
+            let back: StylePreset = serde_yaml_ng::from_str(&yaml).expect("deserialize");
+            assert_eq!(preset, back, "round-trip failed for preset '{}'", preset.id);
+        }
+    }
+
+    #[test]
+    fn default_blob_is_chibi() {
+        use crate::hub::style_preset::PresetFamily;
+        let blob = default_blob();
+        assert_eq!(blob.id, "default-blob");
+        assert_eq!(blob.family, PresetFamily::Chibi);
+    }
+
+    #[test]
+    fn find_preset_returns_builtin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let preset = find_preset("chiikawa", tmp.path()).unwrap();
+        assert_eq!(preset.id, "chiikawa");
+    }
+
+    #[test]
+    fn find_preset_unknown_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(find_preset("nonexistent-preset", tmp.path()).is_err());
+    }
+
+    #[test]
+    fn load_user_presets_empty_dir_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = load_user_presets(tmp.path()).unwrap();
+        assert!(result.is_empty());
+    }
+}

--- a/mur-common/src/hub/preset_manifest.rs
+++ b/mur-common/src/hub/preset_manifest.rs
@@ -1,0 +1,100 @@
+use crate::hub::style_preset::StylePreset;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+/// Cached record of the last successful expression render for one agent.
+/// Written as `<agent_dir>/expressions/manifest.json`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PresetManifest {
+    pub preset_id: String,
+    pub rendered_at: DateTime<Utc>,
+    /// SHA-256 hex of the preset YAML at render time; used to detect staleness.
+    pub sha256: String,
+    /// Expression IDs that were successfully rendered.
+    pub expressions: Vec<String>,
+}
+
+/// Path to the manifest file for `agent_dir`.
+pub fn manifest_path(agent_dir: &Path) -> PathBuf {
+    agent_dir.join("expressions").join("manifest.json")
+}
+
+/// SHA-256 hex of the preset's canonical YAML serialization.
+pub fn compute_preset_hash(preset: &StylePreset) -> String {
+    let yaml = serde_yaml_ng::to_string(preset).expect("preset serialization must not fail");
+    let mut hasher = Sha256::new();
+    hasher.update(yaml.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Returns `true` when the manifest's recorded hash no longer matches the
+/// current preset definition — i.e. a re-render is needed.
+pub fn manifest_stale(manifest: &PresetManifest, preset: &StylePreset) -> bool {
+    manifest.sha256 != compute_preset_hash(preset)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hub::preset_loader::default_blob;
+
+    #[test]
+    fn manifest_not_stale_when_unchanged() {
+        let preset = default_blob();
+        let hash = compute_preset_hash(&preset);
+        let manifest = PresetManifest {
+            preset_id: preset.id.clone(),
+            rendered_at: Utc::now(),
+            sha256: hash,
+            expressions: vec!["idle".into()],
+        };
+        assert!(!manifest_stale(&manifest, &preset));
+    }
+
+    #[test]
+    fn manifest_stale_when_hash_differs() {
+        let preset = default_blob();
+        let manifest = PresetManifest {
+            preset_id: preset.id.clone(),
+            rendered_at: Utc::now(),
+            sha256: "aabbccddeeff".into(),
+            expressions: vec!["idle".into()],
+        };
+        assert!(manifest_stale(&manifest, &preset));
+    }
+
+    #[test]
+    fn hash_changes_when_preset_description_changes() {
+        let mut preset = default_blob();
+        let hash_before = compute_preset_hash(&preset);
+        preset.description = "modified description".into();
+        let hash_after = compute_preset_hash(&preset);
+        assert_ne!(hash_before, hash_after);
+    }
+
+    #[test]
+    fn manifest_path_correct() {
+        let agent_dir = Path::new("/home/user/.mur/agents/alice");
+        let path = manifest_path(agent_dir);
+        assert_eq!(
+            path,
+            Path::new("/home/user/.mur/agents/alice/expressions/manifest.json")
+        );
+    }
+
+    #[test]
+    fn manifest_json_round_trip() {
+        let preset = default_blob();
+        let manifest = PresetManifest {
+            preset_id: preset.id.clone(),
+            rendered_at: DateTime::from_timestamp(0, 0).unwrap(),
+            sha256: compute_preset_hash(&preset),
+            expressions: vec!["idle".into(), "smile".into()],
+        };
+        let json = serde_json::to_string(&manifest).expect("serialize");
+        let back: PresetManifest = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(manifest, back);
+    }
+}

--- a/mur-common/src/hub/style_preset.rs
+++ b/mur-common/src/hub/style_preset.rs
@@ -1,0 +1,73 @@
+use serde::{Deserialize, Serialize};
+
+/// Top-level style preset descriptor, embedded as YAML in the binary for
+/// built-ins, or loaded from `~/.mur/hub/presets/<id>.yaml` for user presets.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StylePreset {
+    pub id: String,
+    pub display_name: String,
+    pub author: String,
+    pub version: u32,
+    pub family: PresetFamily,
+    pub description: String,
+    pub llm_image_gen: LlmImageGen,
+    pub expressions: Vec<ExpressionDef>,
+    pub renderer: RendererConfig,
+}
+
+/// Visual style family — determines the render pipeline and default sizes.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum PresetFamily {
+    Chibi,
+    Pixel,
+    Live2d,
+    Polaroid,
+}
+
+/// LLM image generation parameters baked into the preset.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LlmImageGen {
+    pub base_prompt: String,
+    pub negative_prompt: String,
+    /// Resolution string, e.g. "512x512".
+    pub size: String,
+    pub steps: u32,
+    /// img2img mode — required for the polaroid family.
+    #[serde(default)]
+    pub img2img: bool,
+    /// Whether the user must supply a source photo before render.
+    #[serde(default)]
+    pub requires_source_image: bool,
+}
+
+/// One of the 12 canonical expression slots with its prompt modifier.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ExpressionDef {
+    pub id: String,
+    pub prompt_suffix: String,
+}
+
+/// Renderer display configuration baked into the preset.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RendererConfig {
+    pub family: PresetFamily,
+    pub default_size: SizeConfig,
+    pub idle_animation: IdleAnimation,
+    /// Min / max blink interval in seconds (two-element array).
+    pub blink_interval_s: [f32; 2],
+    pub crossfade_ms: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SizeConfig {
+    pub w: u32,
+    pub h: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum IdleAnimation {
+    Breathe,
+    None,
+}

--- a/mur-common/src/hub/trigger.rs
+++ b/mur-common/src/hub/trigger.rs
@@ -1,0 +1,144 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+// ─── DwellSpec ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DwellSpec {
+    Seconds(f64),
+    UntilDone,
+    UntilAck,
+    UntilActive,
+    Lipsync,
+    UntilFocusOff,
+}
+
+impl<'de> Deserialize<'de> for DwellSpec {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct Visitor;
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = DwellSpec;
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "a number or one of until_done/until_ack/until_active/lipsync/until_focus_off")
+            }
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                Ok(DwellSpec::Seconds(v as f64))
+            }
+            fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<Self::Value, E> {
+                Ok(DwellSpec::Seconds(v))
+            }
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                Ok(DwellSpec::Seconds(v as f64))
+            }
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                match v {
+                    "until_done"      => Ok(DwellSpec::UntilDone),
+                    "until_ack"       => Ok(DwellSpec::UntilAck),
+                    "until_active"    => Ok(DwellSpec::UntilActive),
+                    "lipsync"         => Ok(DwellSpec::Lipsync),
+                    "until_focus_off" => Ok(DwellSpec::UntilFocusOff),
+                    _ => Err(E::unknown_variant(v, &["until_done","until_ack","until_active","lipsync","until_focus_off"])),
+                }
+            }
+        }
+        d.deserialize_any(Visitor)
+    }
+}
+
+impl Serialize for DwellSpec {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            DwellSpec::Seconds(n)   => s.serialize_f64(*n),
+            DwellSpec::UntilDone    => s.serialize_str("until_done"),
+            DwellSpec::UntilAck     => s.serialize_str("until_ack"),
+            DwellSpec::UntilActive  => s.serialize_str("until_active"),
+            DwellSpec::Lipsync      => s.serialize_str("lipsync"),
+            DwellSpec::UntilFocusOff=> s.serialize_str("until_focus_off"),
+        }
+    }
+}
+
+// ─── ExpressionTrigger ───────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExpressionTrigger {
+    /// Event name to match (e.g. "companion.message.new").
+    pub on: String,
+    /// Expression ID to activate (e.g. "wave").
+    pub expression: String,
+    pub dwell_s: DwellSpec,
+    #[serde(default)]
+    pub bubble: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+// ─── TriggerSet ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TriggerSet {
+    pub triggers: Vec<ExpressionTrigger>,
+}
+
+// ─── Loaders ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_YAML: &str = include_str!("triggers/default.yaml");
+
+pub fn default_triggers() -> Vec<ExpressionTrigger> {
+    serde_yaml_ng::from_str::<TriggerSet>(DEFAULT_YAML)
+        .expect("built-in default.yaml is always valid")
+        .triggers
+}
+
+/// Load per-agent trigger overrides; falls back to defaults if file is absent or invalid.
+pub fn load_triggers(agent_dir: &Path) -> Vec<ExpressionTrigger> {
+    let path = agent_dir.join("triggers.yaml");
+    if let Ok(text) = std::fs::read_to_string(&path) {
+        if let Ok(ts) = serde_yaml_ng::from_str::<TriggerSet>(&text) {
+            return ts.triggers;
+        }
+    }
+    default_triggers()
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_triggers_count() {
+        assert_eq!(default_triggers().len(), 10);
+    }
+
+    #[test]
+    fn dwell_spec_numeric() {
+        let t: TriggerSet = serde_yaml_ng::from_str(
+            "triggers:\n  - { on: x, expression: idle, dwell_s: 3.5 }",
+        ).unwrap();
+        assert_eq!(t.triggers[0].dwell_s, DwellSpec::Seconds(3.5));
+    }
+
+    #[test]
+    fn dwell_spec_until_ack() {
+        let t: TriggerSet = serde_yaml_ng::from_str(
+            "triggers:\n  - { on: x, expression: error, dwell_s: until_ack }",
+        ).unwrap();
+        assert_eq!(t.triggers[0].dwell_s, DwellSpec::UntilAck);
+    }
+
+    #[test]
+    fn all_known_dwells_parse() {
+        let yaml = "triggers:
+  - { on: a, expression: idle, dwell_s: 2 }
+  - { on: b, expression: idle, dwell_s: until_done }
+  - { on: c, expression: idle, dwell_s: until_ack }
+  - { on: d, expression: idle, dwell_s: until_active }
+  - { on: e, expression: idle, dwell_s: lipsync }
+  - { on: f, expression: idle, dwell_s: until_focus_off }";
+        let ts: TriggerSet = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(ts.triggers.len(), 6);
+    }
+}

--- a/mur-common/src/hub/trigger.rs
+++ b/mur-common/src/hub/trigger.rs
@@ -20,7 +20,10 @@ impl<'de> Deserialize<'de> for DwellSpec {
         impl<'de> serde::de::Visitor<'de> for Visitor {
             type Value = DwellSpec;
             fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(f, "a number or one of until_done/until_ack/until_active/lipsync/until_focus_off")
+                write!(
+                    f,
+                    "a number or one of until_done/until_ack/until_active/lipsync/until_focus_off"
+                )
             }
             fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
                 Ok(DwellSpec::Seconds(v as f64))
@@ -33,12 +36,21 @@ impl<'de> Deserialize<'de> for DwellSpec {
             }
             fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
                 match v {
-                    "until_done"      => Ok(DwellSpec::UntilDone),
-                    "until_ack"       => Ok(DwellSpec::UntilAck),
-                    "until_active"    => Ok(DwellSpec::UntilActive),
-                    "lipsync"         => Ok(DwellSpec::Lipsync),
+                    "until_done" => Ok(DwellSpec::UntilDone),
+                    "until_ack" => Ok(DwellSpec::UntilAck),
+                    "until_active" => Ok(DwellSpec::UntilActive),
+                    "lipsync" => Ok(DwellSpec::Lipsync),
                     "until_focus_off" => Ok(DwellSpec::UntilFocusOff),
-                    _ => Err(E::unknown_variant(v, &["until_done","until_ack","until_active","lipsync","until_focus_off"])),
+                    _ => Err(E::unknown_variant(
+                        v,
+                        &[
+                            "until_done",
+                            "until_ack",
+                            "until_active",
+                            "lipsync",
+                            "until_focus_off",
+                        ],
+                    )),
                 }
             }
         }
@@ -49,12 +61,12 @@ impl<'de> Deserialize<'de> for DwellSpec {
 impl Serialize for DwellSpec {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         match self {
-            DwellSpec::Seconds(n)   => s.serialize_f64(*n),
-            DwellSpec::UntilDone    => s.serialize_str("until_done"),
-            DwellSpec::UntilAck     => s.serialize_str("until_ack"),
-            DwellSpec::UntilActive  => s.serialize_str("until_active"),
-            DwellSpec::Lipsync      => s.serialize_str("lipsync"),
-            DwellSpec::UntilFocusOff=> s.serialize_str("until_focus_off"),
+            DwellSpec::Seconds(n) => s.serialize_f64(*n),
+            DwellSpec::UntilDone => s.serialize_str("until_done"),
+            DwellSpec::UntilAck => s.serialize_str("until_ack"),
+            DwellSpec::UntilActive => s.serialize_str("until_active"),
+            DwellSpec::Lipsync => s.serialize_str("lipsync"),
+            DwellSpec::UntilFocusOff => s.serialize_str("until_focus_off"),
         }
     }
 }
@@ -94,10 +106,10 @@ pub fn default_triggers() -> Vec<ExpressionTrigger> {
 /// Load per-agent trigger overrides; falls back to defaults if file is absent or invalid.
 pub fn load_triggers(agent_dir: &Path) -> Vec<ExpressionTrigger> {
     let path = agent_dir.join("triggers.yaml");
-    if let Ok(text) = std::fs::read_to_string(&path) {
-        if let Ok(ts) = serde_yaml_ng::from_str::<TriggerSet>(&text) {
-            return ts.triggers;
-        }
+    if let Ok(text) = std::fs::read_to_string(&path)
+        && let Ok(ts) = serde_yaml_ng::from_str::<TriggerSet>(&text)
+    {
+        return ts.triggers;
     }
     default_triggers()
 }
@@ -115,9 +127,9 @@ mod tests {
 
     #[test]
     fn dwell_spec_numeric() {
-        let t: TriggerSet = serde_yaml_ng::from_str(
-            "triggers:\n  - { on: x, expression: idle, dwell_s: 3.5 }",
-        ).unwrap();
+        let t: TriggerSet =
+            serde_yaml_ng::from_str("triggers:\n  - { on: x, expression: idle, dwell_s: 3.5 }")
+                .unwrap();
         assert_eq!(t.triggers[0].dwell_s, DwellSpec::Seconds(3.5));
     }
 
@@ -125,7 +137,8 @@ mod tests {
     fn dwell_spec_until_ack() {
         let t: TriggerSet = serde_yaml_ng::from_str(
             "triggers:\n  - { on: x, expression: error, dwell_s: until_ack }",
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(t.triggers[0].dwell_s, DwellSpec::UntilAck);
     }
 

--- a/mur-common/src/hub/triggers/default.yaml
+++ b/mur-common/src/hub/triggers/default.yaml
@@ -1,0 +1,11 @@
+triggers:
+  - { on: "pet.spawned",             expression: wave,      dwell_s: 2 }
+  - { on: "companion.message.new",   expression: wave,      dwell_s: 4,           bubble: true }
+  - { on: "idle.trigger.fired",      expression: peek,      dwell_s: 4,           bubble: true }
+  - { on: "agent.tool.running",      expression: think,     dwell_s: until_done }
+  - { on: "agent.tool.completed.ok", expression: sparkle,   dwell_s: 3 }
+  - { on: "agent.error",             expression: error,     dwell_s: until_ack,   bubble: true }
+  - { on: "user.idle.30m",           expression: sleep,     dwell_s: until_active }
+  - { on: "user.click.pet",          expression: smile,     dwell_s: 2 }
+  - { on: "voice.playing",           expression: talk_open, dwell_s: lipsync }
+  - { on: "os.focus.engaged",        expression: hidden,    dwell_s: until_focus_off }

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -13,6 +13,7 @@ pub mod error;
 pub mod eval;
 pub mod event;
 pub mod hooks_config;
+pub mod hub;
 pub mod identity;
 pub mod knowledge;
 pub mod llm;
@@ -42,9 +43,9 @@ pub use signal::{SIGNAL_SCHEMA_VERSION, Signal, SignalKind, SignalTarget};
 pub use a2a::Message as A2aMessage;
 pub use a2a::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, Task, TaskState};
 pub use agent::{
-    AgentProfile, DeploymentConfig, DeploymentType, Entitlements, ExecutionMode,
-    FileTransferConfig, IdentityConfig, LockFile, Persona, PersonaCategory, RetryPolicy,
-    ScheduleEntry,
+    AgentAppearance, AgentProfile, BehaviorPreset, DeploymentConfig, DeploymentType, Entitlements,
+    ExecutionMode, FileTransferConfig, IdentityConfig, LockFile, Persona, PersonaCategory,
+    RenderStatus, RetryPolicy, ScheduleEntry,
 };
 pub use agent_name::{AgentNameError, MAX_AGENT_NAME_LEN, validate_agent_name};
 pub use bridge::{LlmEntitlement, LlmMode};

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -209,6 +209,8 @@ pub enum AgentAction {
         #[command(subcommand)]
         action: AgentHooksAction,
     },
+    /// Migrate all agents from mur-agent-gui (v0) to mur-hub (v1). Idempotent.
+    MigrateToHub,
 }
 
 #[derive(Debug, Subcommand)]

--- a/mur-core/src/cmd/agent/hub.rs
+++ b/mur-core/src/cmd/agent/hub.rs
@@ -25,22 +25,29 @@ pub fn cmd_migrate_to_hub() -> Result<()> {
     let agents_dir = mur_home.join("agents");
 
     if !agents_dir.exists() {
-        println!("No agents directory found at {}; nothing to migrate.", agents_dir.display());
+        println!(
+            "No agents directory found at {}; nothing to migrate.",
+            agents_dir.display()
+        );
         return Ok(());
     }
 
     let mut migrated = 0usize;
     let mut skipped = 0usize;
 
-    let entries = fs::read_dir(&agents_dir)
-        .with_context(|| format!("read {}", agents_dir.display()))?;
+    let entries =
+        fs::read_dir(&agents_dir).with_context(|| format!("read {}", agents_dir.display()))?;
 
     for entry in entries.flatten() {
         let agent_dir = entry.path();
         if !agent_dir.is_dir() {
             continue;
         }
-        let Some(name) = agent_dir.file_name().and_then(|n| n.to_str()).map(str::to_owned) else {
+        let Some(name) = agent_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(str::to_owned)
+        else {
             continue;
         };
 
@@ -86,12 +93,11 @@ fn migrate_agent(name: &str, profile_path: &PathBuf) -> Result<bool> {
     }
 
     // Deserialise; serde #[default] fills appearance if the key is absent.
-    let profile: AgentProfile = serde_yaml_ng::from_str(&raw)
-        .with_context(|| format!("parse profile.yaml for {name}"))?;
+    let profile: AgentProfile =
+        serde_yaml_ng::from_str(&raw).with_context(|| format!("parse profile.yaml for {name}"))?;
 
     // Re-serialise and compare — only write if something changed.
-    let new_yaml = serde_yaml_ng::to_string(&profile)
-        .context("serialize profile")?;
+    let new_yaml = serde_yaml_ng::to_string(&profile).context("serialize profile")?;
 
     if new_yaml.trim() == raw.trim() {
         return Ok(false);
@@ -99,8 +105,7 @@ fn migrate_agent(name: &str, profile_path: &PathBuf) -> Result<bool> {
 
     // Atomic overwrite.
     let tmp = profile_path.with_extension("yaml.tmp");
-    fs::write(&tmp, new_yaml.as_bytes())
-        .with_context(|| format!("write {}", tmp.display()))?;
+    fs::write(&tmp, new_yaml.as_bytes()).with_context(|| format!("write {}", tmp.display()))?;
     fs::rename(&tmp, profile_path)
         .with_context(|| format!("rename {} -> {}", tmp.display(), profile_path.display()))?;
 

--- a/mur-core/src/cmd/agent/hub.rs
+++ b/mur-core/src/cmd/agent/hub.rs
@@ -1,0 +1,141 @@
+//! `mur agent migrate-to-hub` — idempotent v0→v1 agent YAML migration.
+//!
+//! For each agent in ~/.mur/agents/:
+//!   1. Writes profile.yaml.bak (skips if already present and identical).
+//!   2. Deserialises profile.yaml; serde #[default] fills any missing
+//!      `appearance` fields (style_preset, behavior_preset, render_status).
+//!   3. Re-serialises and atomically overwrites profile.yaml.
+//!   4. On macOS: removes the legacy mur-agent-gui LaunchAgent plist at
+//!      ~/Library/LaunchAgents/run.mur.agent.<name>.plist, if present, and
+//!      calls `launchctl unload` so the .app stops relaunching at login.
+//!
+//! The command is safe to run multiple times. It never touches agents that
+//! already have a complete appearance block.
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use mur_common::AgentProfile;
+
+use super::resolve_mur_home;
+
+pub fn cmd_migrate_to_hub() -> Result<()> {
+    let mur_home = resolve_mur_home()?;
+    let agents_dir = mur_home.join("agents");
+
+    if !agents_dir.exists() {
+        println!("No agents directory found at {}; nothing to migrate.", agents_dir.display());
+        return Ok(());
+    }
+
+    let mut migrated = 0usize;
+    let mut skipped = 0usize;
+
+    let entries = fs::read_dir(&agents_dir)
+        .with_context(|| format!("read {}", agents_dir.display()))?;
+
+    for entry in entries.flatten() {
+        let agent_dir = entry.path();
+        if !agent_dir.is_dir() {
+            continue;
+        }
+        let Some(name) = agent_dir.file_name().and_then(|n| n.to_str()).map(str::to_owned) else {
+            continue;
+        };
+
+        let profile_path = agent_dir.join("profile.yaml");
+        if !profile_path.exists() {
+            tracing::debug!(%name, "skipping — no profile.yaml");
+            skipped += 1;
+            continue;
+        }
+
+        match migrate_agent(&name, &profile_path) {
+            Ok(changed) => {
+                if changed {
+                    println!("  migrated: {name}");
+                    migrated += 1;
+                } else {
+                    println!("  ok (no change): {name}");
+                    skipped += 1;
+                }
+            }
+            Err(e) => {
+                eprintln!("  error migrating {name}: {e:#}");
+            }
+        }
+
+        remove_legacy_autostart(&name);
+    }
+
+    println!("\nDone — {migrated} migrated, {skipped} already up to date.");
+    Ok(())
+}
+
+/// Returns `true` if the profile was rewritten (had missing appearance fields).
+fn migrate_agent(name: &str, profile_path: &PathBuf) -> Result<bool> {
+    let raw = fs::read_to_string(profile_path)
+        .with_context(|| format!("read {}", profile_path.display()))?;
+
+    // Write .bak once (idempotent — skip if bak already exists).
+    let bak_path = profile_path.with_extension("yaml.bak");
+    if !bak_path.exists() {
+        fs::write(&bak_path, raw.as_bytes())
+            .with_context(|| format!("write {}", bak_path.display()))?;
+    }
+
+    // Deserialise; serde #[default] fills appearance if the key is absent.
+    let profile: AgentProfile = serde_yaml_ng::from_str(&raw)
+        .with_context(|| format!("parse profile.yaml for {name}"))?;
+
+    // Re-serialise and compare — only write if something changed.
+    let new_yaml = serde_yaml_ng::to_string(&profile)
+        .context("serialize profile")?;
+
+    if new_yaml.trim() == raw.trim() {
+        return Ok(false);
+    }
+
+    // Atomic overwrite.
+    let tmp = profile_path.with_extension("yaml.tmp");
+    fs::write(&tmp, new_yaml.as_bytes())
+        .with_context(|| format!("write {}", tmp.display()))?;
+    fs::rename(&tmp, profile_path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), profile_path.display()))?;
+
+    Ok(true)
+}
+
+/// Remove the mur-agent-gui LaunchAgent plist for `name` if it exists.
+/// No-op on non-macOS.
+fn remove_legacy_autostart(name: &str) {
+    #[cfg(target_os = "macos")]
+    {
+        let Some(home) = dirs::home_dir() else { return };
+        // tauri_plugin_autostart + MacosLauncher::LaunchAgent uses the app
+        // identifier as the plist label: run.mur.agent.<name>.plist
+        let plist_path = home
+            .join("Library/LaunchAgents")
+            .join(format!("run.mur.agent.{name}.plist"));
+
+        if !plist_path.exists() {
+            return;
+        }
+
+        // Unload (best-effort — launchctl may not be in PATH in sandboxed env).
+        let label = format!("run.mur.agent.{name}");
+        let _ = std::process::Command::new("launchctl")
+            .args(["unload", plist_path.to_str().unwrap_or("")])
+            .output();
+
+        match fs::remove_file(&plist_path) {
+            Ok(()) => tracing::info!(%name, label, "removed legacy LaunchAgent plist"),
+            Err(e) => tracing::warn!(%name, error = %e, "could not remove LaunchAgent plist"),
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = name; // nothing to remove on other platforms for now
+    }
+}

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -156,6 +156,7 @@ pub fn cmd_create(
         voice: mur_common::agent::VoiceConfig::default(),
         hooks: mur_common::HooksConfig::default(),
         trusted_peers: Vec::new(),
+        appearance: mur_common::AgentAppearance::default(),
         created_at: now.clone(),
         updated_at: now,
     };

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -26,6 +26,7 @@ use mur_common::{AgentProfile as _AgentProfile, LockFile};
 
 mod comm;
 mod export;
+mod hub;
 mod lifecycle;
 mod mcp;
 mod perm;
@@ -43,6 +44,8 @@ mod stats;
 pub use comm::{cmd_card, cmd_send};
 #[allow(unused_imports)]
 pub use export::cmd_export;
+#[allow(unused_imports)]
+pub use hub::cmd_migrate_to_hub;
 #[allow(unused_imports)]
 pub use lifecycle::{cmd_create, cmd_list, cmd_remove, cmd_rename, cmd_status, cmd_stop};
 #[allow(unused_imports)]

--- a/mur-core/src/cmd/agent_companion/connector.rs
+++ b/mur-core/src/cmd/agent_companion/connector.rs
@@ -632,6 +632,7 @@ pub(crate) async fn scaffold_stub_bridge(name: &str, default_route: &str) -> Res
         voice: mur_common::agent::VoiceConfig::default(),
         hooks: mur_common::HooksConfig::default(),
         trusted_peers: vec![],
+        appearance: mur_common::AgentAppearance::default(),
         created_at: now.clone(),
         updated_at: now,
     };

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -676,6 +676,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
         AgentAction::Hooks { action } => match action {
             AgentHooksAction::Show { name, json } => cmd::agent_hooks::cmd_hooks_show(&name, json)?,
         },
+        AgentAction::MigrateToHub => cmd::agent::cmd_migrate_to_hub()?,
     }
     Ok(())
 }

--- a/mur-gui-core/Cargo.toml
+++ b/mur-gui-core/Cargo.toml
@@ -13,7 +13,13 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = "0.10"
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
+async-trait = "0.1"
+image = "0.25"
+reqwest = { workspace = true }
+base64 = "0.22"
+chrono = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/mur-gui-core/Cargo.toml
+++ b/mur-gui-core/Cargo.toml
@@ -22,6 +22,9 @@ base64 = "0.22"
 chrono = { workspace = true }
 notify = "6"
 
+[features]
+audio = []
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 

--- a/mur-gui-core/Cargo.toml
+++ b/mur-gui-core/Cargo.toml
@@ -20,6 +20,7 @@ image = "0.25"
 reqwest = { workspace = true }
 base64 = "0.22"
 chrono = { workspace = true }
+notify = "6"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/mur-gui-core/Cargo.toml
+++ b/mur-gui-core/Cargo.toml
@@ -7,9 +7,11 @@ repository.workspace = true
 description = "Shared GUI core library — sidecar supervisor, companion bridge, A2A client. Consumed by mur-hub-gui and (during migration) mur-agent-gui."
 
 [dependencies]
+mur-common = { path = "../mur-common" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml_ng = "0.10"
 anyhow = { workspace = true }
 tracing = { workspace = true }
 

--- a/mur-gui-core/Cargo.toml
+++ b/mur-gui-core/Cargo.toml
@@ -15,5 +15,8 @@ serde_yaml_ng = "0.10"
 anyhow = { workspace = true }
 tracing = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3"

--- a/mur-gui-core/src/companion_bridge/event.rs
+++ b/mur-gui-core/src/companion_bridge/event.rs
@@ -1,0 +1,104 @@
+//! Bridge event types + inbox markdown parser.
+//!
+//! `BridgeEvent` is the common over-the-wire shape between the Rust
+//! bridge and the React UI.  It is `serde::Serialize` so it can ride
+//! a Tauri 2 `Channel<BridgeEvent>`.
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BridgeEvent {
+    pub id: String,
+    pub situation: String,
+    pub template_id: String,
+    pub locale: String,
+    pub generated_at: String,
+    pub body: String,
+    pub response: BridgeResponse,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", content = "value", rename_all = "lowercase")]
+pub enum BridgeResponse {
+    Unset,
+    Signal(String),
+}
+
+#[derive(Deserialize)]
+struct FrontMatter {
+    id: String,
+    situation: String,
+    template_id: String,
+    locale: String,
+    generated_at: String,
+}
+
+pub fn parse_inbox_md(path: &Path) -> Result<BridgeEvent> {
+    let raw = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    parse_str(&raw)
+}
+
+pub fn parse_str(raw: &str) -> Result<BridgeEvent> {
+    let stripped = raw
+        .strip_prefix("---\n")
+        .ok_or_else(|| anyhow!("missing opening front-matter fence"))?;
+    let (yaml, rest) = stripped
+        .split_once("\n---\n")
+        .ok_or_else(|| anyhow!("missing closing front-matter fence"))?;
+    let fm: FrontMatter = serde_yaml_ng::from_str(yaml).context("parse front-matter")?;
+
+    let response_marker = ">>> response:";
+    let (body_block, response_line) = rest
+        .rsplit_once(response_marker)
+        .ok_or_else(|| anyhow!("missing response marker"))?;
+    let body = body_block.trim().to_string();
+    let response_value = response_line.trim();
+    let response = if response_value == "<unset>" {
+        BridgeResponse::Unset
+    } else if matches!(response_value, "good" | "bad" | "dismiss") {
+        BridgeResponse::Signal(response_value.to_string())
+    } else {
+        bail!("unrecognized response value: {response_value}");
+    };
+
+    Ok(BridgeEvent {
+        id: fm.id,
+        situation: fm.situation,
+        template_id: fm.template_id,
+        locale: fm.locale,
+        generated_at: fm.generated_at,
+        body,
+        response,
+    })
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "---\nid: abc-123\nsituation: test\ntemplate_id: t1\nlocale: en\ngenerated_at: 2026-05-14T00:00:00Z\n---\n\nHello world\n\n>>> response: <unset>";
+
+    #[test]
+    fn parses_unset_response() {
+        let ev = parse_str(SAMPLE).unwrap();
+        assert_eq!(ev.id, "abc-123");
+        assert_eq!(ev.body, "Hello world");
+        assert_eq!(ev.response, BridgeResponse::Unset);
+    }
+
+    #[test]
+    fn parses_good_signal() {
+        let s = SAMPLE.replace("<unset>", "good");
+        let ev = parse_str(&s).unwrap();
+        assert_eq!(ev.response, BridgeResponse::Signal("good".into()));
+    }
+
+    #[test]
+    fn rejects_missing_fence() {
+        assert!(parse_str("no fence here").is_err());
+    }
+}

--- a/mur-gui-core/src/companion_bridge/mod.rs
+++ b/mur-gui-core/src/companion_bridge/mod.rs
@@ -1,0 +1,18 @@
+//! Companion → GUI IPC bridge (D5).
+//!
+//! Pure-Rust core shared between mur-hub-gui and (during the migration period)
+//! mur-agent-gui.  No Tauri, no mur-core, no mur-agent-runtime dependencies
+//! here — those live in the per-app command layers.
+//!
+//! Layout:
+//!   `event`   — BridgeEvent type + inbox markdown parser
+//!   `scanner` — one-shot scan of an inbox directory
+//!   `watcher` — filesystem-event watcher → BridgeEvent on a tokio mpsc
+
+pub mod event;
+pub mod scanner;
+pub mod watcher;
+
+pub use event::{BridgeEvent, BridgeResponse};
+pub use scanner::scan_pending;
+pub use watcher::InboxWatcher;

--- a/mur-gui-core/src/companion_bridge/scanner.rs
+++ b/mur-gui-core/src/companion_bridge/scanner.rs
@@ -1,0 +1,33 @@
+//! One-shot scan of an inbox directory — returns all parseable `.md` files
+//! sorted by `generated_at`.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use super::event::{BridgeEvent, parse_inbox_md};
+
+pub fn scan_pending(inbox_dir: &Path) -> Result<Vec<BridgeEvent>> {
+    if !inbox_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(inbox_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("md") {
+            continue;
+        }
+        match parse_inbox_md(&path) {
+            Ok(ev) => out.push(ev),
+            Err(e) => {
+                tracing::warn!(
+                    "companion_bridge: skipping malformed inbox file {}: {e:#}",
+                    path.display()
+                );
+            }
+        }
+    }
+    out.sort_by(|a, b| a.generated_at.cmp(&b.generated_at));
+    Ok(out)
+}

--- a/mur-gui-core/src/companion_bridge/watcher.rs
+++ b/mur-gui-core/src/companion_bridge/watcher.rs
@@ -1,0 +1,67 @@
+//! Filesystem watcher — turns new `.md` writes under an agent's
+//! companion inbox directory into `BridgeEvent` records on a tokio mpsc.
+//!
+//! Uses `notify` (kqueue / inotify / ReadDirectoryChangesW) for
+//! sub-100 ms latency. Only `Create` events are forwarded; `Modify`
+//! events are the user's ack rewrite and are intentionally ignored.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use tokio::sync::mpsc::Sender;
+
+use super::event::{BridgeEvent, parse_inbox_md};
+
+pub struct InboxWatcher {
+    _inner: RecommendedWatcher,
+}
+
+impl InboxWatcher {
+    pub fn start(inbox_dir: PathBuf, tx: Sender<BridgeEvent>) -> Result<Self> {
+        std::fs::create_dir_all(&inbox_dir)
+            .with_context(|| format!("create {}", inbox_dir.display()))?;
+
+        let mut watcher = RecommendedWatcher::new(
+            move |res: notify::Result<notify::Event>| {
+                let Ok(event) = res else { return };
+                if !matches!(event.kind, EventKind::Create(_)) {
+                    return;
+                }
+                for path in event.paths {
+                    if path.extension().and_then(|s| s.to_str()) != Some("md") {
+                        continue;
+                    }
+                    forward_md(&path, &tx);
+                }
+            },
+            Config::default(),
+        )
+        .context("notify::watcher::new")?;
+
+        watcher
+            .watch(&inbox_dir, RecursiveMode::NonRecursive)
+            .with_context(|| format!("watch {}", inbox_dir.display()))?;
+
+        Ok(Self { _inner: watcher })
+    }
+}
+
+fn forward_md(path: &Path, tx: &Sender<BridgeEvent>) {
+    match parse_inbox_md(path) {
+        Ok(ev) => {
+            if let Err(e) = tx.try_send(ev) {
+                tracing::warn!(
+                    "companion_bridge: dropped event for {}: {e}",
+                    path.display()
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                "companion_bridge: skipping malformed write at {}: {e:#}",
+                path.display()
+            );
+        }
+    }
+}

--- a/mur-gui-core/src/discovery.rs
+++ b/mur-gui-core/src/discovery.rs
@@ -1,0 +1,223 @@
+//! Agent discovery — filesystem scan of `~/.mur/agents/*/agent.yaml`.
+//!
+//! Publishes a `Vec<AgentEntry>` snapshot every 5 seconds via a
+//! `tokio::sync::watch` channel so Tauri backends can push `agents-updated`
+//! events without JS-side polling.
+
+use mur_common::{
+    AgentProfile,
+    agent::PersonaCategory,
+    lock_file::{self, AgentStatusKind},
+};
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use tokio::sync::watch;
+use tokio::time::{Duration, interval};
+
+/// Simplified agent status exposed to the frontend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentStatus {
+    Running,
+    Idle,
+    Stale,
+}
+
+impl From<AgentStatusKind> for AgentStatus {
+    fn from(kind: AgentStatusKind) -> Self {
+        match kind {
+            AgentStatusKind::Running => AgentStatus::Running,
+            AgentStatusKind::Stopped => AgentStatus::Idle,
+            AgentStatusKind::Stale => AgentStatus::Stale,
+        }
+    }
+}
+
+/// One row in the Hub agent list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AgentEntry {
+    pub name: String,
+    pub display_name: String,
+    pub category: PersonaCategory,
+    pub status: AgentStatus,
+    pub model_id: String,
+}
+
+/// Background scanner that polls `$mur_home/agents/*/agent.yaml` at 5s intervals.
+pub struct AgentDiscovery {
+    mur_home: PathBuf,
+    tx: watch::Sender<Vec<AgentEntry>>,
+}
+
+impl AgentDiscovery {
+    /// Create a discovery instance and return the watch receiver.
+    ///
+    /// The caller should call `AgentDiscovery::run(self)` to start polling.
+    pub fn new(mur_home: PathBuf) -> (Self, watch::Receiver<Vec<AgentEntry>>) {
+        let initial = scan_agents(&mur_home);
+        let (tx, rx) = watch::channel(initial);
+        (AgentDiscovery { mur_home, tx }, rx)
+    }
+
+    /// Spawn a background task that re-scans every 5 seconds.
+    pub fn run(self) {
+        tokio::spawn(async move {
+            let mut ticker = interval(Duration::from_secs(5));
+            ticker.tick().await; // consume the immediate first tick
+            loop {
+                ticker.tick().await;
+                let entries = scan_agents(&self.mur_home);
+                // send_if_modified avoids waking receivers when nothing changed
+                let _ = self.tx.send_if_modified(|current| {
+                    if *current != entries {
+                        *current = entries;
+                        true
+                    } else {
+                        false
+                    }
+                });
+            }
+        });
+    }
+}
+
+/// Scan `$mur_home/agents/*/agent.yaml` and return current entries sorted by name.
+pub fn scan_agents(mur_home: &Path) -> Vec<AgentEntry> {
+    let agents_dir = mur_home.join("agents");
+    let Ok(dir) = std::fs::read_dir(&agents_dir) else {
+        return Vec::new();
+    };
+
+    let mut entries: Vec<AgentEntry> = dir
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .filter_map(|dir_entry| {
+            let agent_dir = dir_entry.path();
+            let yaml_path = agent_dir.join("agent.yaml");
+            let bytes = std::fs::read(&yaml_path).ok()?;
+            let profile: AgentProfile = serde_yaml_ng::from_slice(&bytes).ok()?;
+            let lock_path = agent_dir.join("running.lock");
+            let status = AgentStatus::from(lock_file::classify(&lock_path).kind);
+            Some(AgentEntry {
+                name: profile.name.clone(),
+                display_name: profile.display_name.clone(),
+                category: profile.persona.category,
+                status,
+                model_id: format!("{}/{}", profile.model.provider, profile.model.name),
+            })
+        })
+        .collect();
+
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn make_agent_yaml(name: &str, display_name: &str, category: &str, model: &str) -> String {
+        format!(
+            r#"schema: 1
+id: 01JQX4TM8Y9K7VQH6B2N3R5DPE
+name: "{name}"
+display_name: "{display_name}"
+version: "1.0.0"
+persona:
+  category: {category}
+  description: "test agent"
+  traits: {{ tone: concise, risk: cautious, verbosity: low }}
+sys_prompt_file: "sys_prompt.md"
+model: {{ provider: anthropic, name: "{model}" }}
+mcp_servers: []
+skills: []
+transport:
+  stdio: true
+  socket: {{ enabled: false, bind: "" }}
+communication: {{ accepts_from: ["*"], sends_to: [] }}
+capabilities: []
+entitlements:
+  network:
+    inbound: {{ ports: [] }}
+    outbound: {{ mode: restricted, allow_hosts: [], protocols: ["tcp"], resolve_dns: {{ mode: system }} }}
+  filesystem: {{ read: [], write: [], deny: [] }}
+  processes: {{ spawn: {{ mode: allowlist, allowed: [] }} }}
+  syscalls: {{ mode: default }}
+  limits: {{ memory_mb: 512, file_descriptors: 1024, processes: 32 }}
+notifications: {{ on_task_complete: [], on_error: [], on_shutdown: [] }}
+retry:
+  llm: {{ max_retries: 3, backoff: exponential, initial_delay_ms: 1000, max_delay_ms: 30000, retry_on: [rate_limit] }}
+  tool: {{ max_retries: 1, backoff: fixed, initial_delay_ms: 500 }}
+lifecycle: {{ restart: on_failure, max_restarts: 3, restart_window_secs: 600, stop_timeout_secs: 15, mcp_required: true }}
+created_at: "2026-01-01T00:00:00+00:00"
+updated_at: "2026-01-01T00:00:00+00:00"
+"#
+        )
+    }
+
+    #[test]
+    fn scan_returns_empty_for_missing_dir() {
+        let dir = tempdir().unwrap();
+        let result = scan_agents(dir.path());
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn scan_skips_malformed_yaml() {
+        let dir = tempdir().unwrap();
+        let agents_dir = dir.path().join("agents").join("bad-agent");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(agents_dir.join("agent.yaml"), b"not: valid: yaml: [[[").unwrap();
+        let result = scan_agents(dir.path());
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn scan_returns_entry_for_valid_yaml() {
+        let dir = tempdir().unwrap();
+        let agent_dir = dir.path().join("agents").join("test-agent");
+        fs::create_dir_all(&agent_dir).unwrap();
+        fs::write(
+            agent_dir.join("agent.yaml"),
+            make_agent_yaml(
+                "test-agent",
+                "Test Agent",
+                "research",
+                "claude-3-5-sonnet-20241022",
+            ),
+        )
+        .unwrap();
+        let result = scan_agents(dir.path());
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "test-agent");
+        assert_eq!(result[0].display_name, "Test Agent");
+        assert_eq!(result[0].status, AgentStatus::Idle); // no lock file
+    }
+
+    #[test]
+    fn status_running_when_lock_pid_alive() {
+        let dir = tempdir().unwrap();
+        let agent_dir = dir.path().join("agents").join("live-agent");
+        fs::create_dir_all(&agent_dir).unwrap();
+        fs::write(
+            agent_dir.join("agent.yaml"),
+            make_agent_yaml(
+                "live-agent",
+                "Live Agent",
+                "automation",
+                "claude-3-5-sonnet-20241022",
+            ),
+        )
+        .unwrap();
+        // Write a complete lock file with the current process's PID (which is alive).
+        let pid = std::process::id();
+        let lock_json = format!(
+            r#"{{"schema":1,"uuid":"01JQX4TM8Y9K7VQH6B2N3R5DPE","name":"live-agent","pid":{pid},"ppid":1,"started_at":"2026-01-01T00:00:00Z","binary_version":"2.0.0","transports":{{"stdio":true}},"card_digest":"","capabilities":[]}}"#
+        );
+        fs::write(agent_dir.join("running.lock"), lock_json).unwrap();
+        let result = scan_agents(dir.path());
+        assert_eq!(result[0].status, AgentStatus::Running);
+    }
+}

--- a/mur-gui-core/src/event_bus.rs
+++ b/mur-gui-core/src/event_bus.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+use serde::{Deserialize, Serialize};
+
+// ─── HubEvent ────────────────────────────────────────────────────────────────
+
+/// A single event on the Hub event bus.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HubEvent {
+    /// Agent this event targets (or "*" for broadcast).
+    pub agent_id: String,
+    /// Dot-namespaced event name, e.g. "companion.message.new".
+    pub name: String,
+    /// Optional freeform payload (message text, error string, etc.).
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub payload: serde_json::Value,
+}
+
+impl HubEvent {
+    pub fn new(agent_id: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            agent_id: agent_id.into(),
+            name: name.into(),
+            payload: serde_json::Value::Null,
+        }
+    }
+
+    pub fn with_payload(mut self, payload: serde_json::Value) -> Self {
+        self.payload = payload;
+        self
+    }
+}
+
+// ─── EventBus ────────────────────────────────────────────────────────────────
+
+/// Application-wide broadcast bus.  Clone to get a sender handle.
+#[derive(Clone)]
+pub struct EventBus {
+    tx: Arc<broadcast::Sender<HubEvent>>,
+}
+
+impl EventBus {
+    pub fn new(capacity: usize) -> Self {
+        let (tx, _) = broadcast::channel(capacity);
+        Self { tx: Arc::new(tx) }
+    }
+
+    /// Publish an event; silently drops if no subscribers.
+    pub fn publish(&self, event: HubEvent) {
+        let _ = self.tx.send(event);
+    }
+
+    /// Subscribe to all future events.
+    pub fn subscribe(&self) -> broadcast::Receiver<HubEvent> {
+        self.tx.subscribe()
+    }
+}

--- a/mur-gui-core/src/expression.rs
+++ b/mur-gui-core/src/expression.rs
@@ -1,0 +1,269 @@
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use mur_common::hub::trigger::{DwellSpec, ExpressionTrigger};
+
+use crate::event_bus::HubEvent;
+
+// ─── Priority ────────────────────────────────────────────────────────────────
+
+fn priority_of(expression: &str) -> u8 {
+    match expression {
+        "error" | "cry"              => 10,
+        "hidden"                     => 9,
+        "talk_open" | "talk_close"   => 8,
+        "think"                      => 6,
+        "wave" | "sparkle" | "peek"
+        | "smile" | "wow"            => 4,
+        "sleep"                      => 2,
+        _                            => 0, // idle + unknown
+    }
+}
+
+// ─── Active expression slot ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct Slot {
+    expression: String,
+    dwell: DwellSpec,
+    bubble_text: Option<String>,
+    started_at: Instant,
+    priority: u8,
+}
+
+impl Slot {
+    fn new(trigger: &ExpressionTrigger, bubble_text: Option<String>) -> Self {
+        let priority = priority_of(&trigger.expression);
+        Self {
+            expression: trigger.expression.clone(),
+            dwell: trigger.dwell_s.clone(),
+            bubble_text,
+            started_at: Instant::now(),
+            priority,
+        }
+    }
+
+    /// Returns true if this slot's timed dwell has expired.
+    fn is_expired(&self, now: Instant) -> bool {
+        if let DwellSpec::Seconds(secs) = self.dwell {
+            now.duration_since(self.started_at) >= Duration::from_secs_f64(secs)
+        } else {
+            false
+        }
+    }
+}
+
+// ─── ExpressionChange ────────────────────────────────────────────────────────
+
+/// Returned by the state machine whenever the visible expression changes.
+#[derive(Debug, Clone)]
+pub struct ExpressionChange {
+    pub expression: String,
+    /// Text to show in the speech bubble, if any.
+    pub bubble_text: Option<String>,
+}
+
+// ─── ExpressionStateMachine ──────────────────────────────────────────────────
+
+/// Per-pet state machine that maps `HubEvent`s to expression changes.
+pub struct ExpressionStateMachine {
+    agent_id: String,
+    triggers: Vec<ExpressionTrigger>,
+    /// Currently active expression slot (None = idle).
+    active: Option<Slot>,
+    /// Lower-priority reactions waiting behind the active one.
+    queue: VecDeque<Slot>,
+    /// Last time any trigger fired — for 100ms debounce.
+    last_fired: Option<Instant>,
+}
+
+const DEBOUNCE: Duration = Duration::from_millis(100);
+
+impl ExpressionStateMachine {
+    pub fn new(agent_id: String, triggers: Vec<ExpressionTrigger>) -> Self {
+        Self {
+            agent_id,
+            triggers,
+            active: None,
+            queue: VecDeque::new(),
+            last_fired: None,
+        }
+    }
+
+    /// Process an incoming event.  Returns `Some(change)` if the visible
+    /// expression should update.
+    pub fn process(&mut self, event: &HubEvent) -> Option<ExpressionChange> {
+        if event.agent_id != self.agent_id && event.agent_id != "*" {
+            return None;
+        }
+
+        // Find the first matching trigger.
+        let trigger = self.triggers.iter().find(|t| t.on == event.name)?.clone();
+
+        let new_prio = priority_of(&trigger.expression);
+        let active_prio = self.active.as_ref().map(|s| s.priority).unwrap_or(0);
+
+        // 100ms debounce only for same-or-lower priority (prevents flicker).
+        // Higher-priority events (error, cry) always preempt immediately.
+        if new_prio <= active_prio {
+            let now = Instant::now();
+            if let Some(t) = self.last_fired {
+                if now.duration_since(t) < DEBOUNCE {
+                    return None;
+                }
+            }
+        }
+
+        self.last_fired = Some(Instant::now());
+
+        let bubble_text = if trigger.bubble {
+            Some(
+                trigger.message.clone().unwrap_or_else(|| {
+                    event.payload.as_str().map(String::from).unwrap_or_default()
+                }),
+            )
+        } else {
+            None
+        };
+
+        let slot = Slot::new(&trigger, bubble_text);
+
+        if new_prio >= active_prio {
+            // Preempt current expression.
+            let change = ExpressionChange {
+                expression: slot.expression.clone(),
+                bubble_text: slot.bubble_text.clone(),
+            };
+            self.active = Some(slot);
+            self.queue.clear();
+            Some(change)
+        } else {
+            // Queue behind the active expression.
+            self.queue.push_back(slot);
+            None
+        }
+    }
+
+    /// Advance dwell timers.  Call this regularly (e.g. every 100ms).
+    /// Returns `Some(change)` if the active expression expired and a new one
+    /// (or idle) takes over.
+    pub fn tick(&mut self, now: Instant) -> Option<ExpressionChange> {
+        let expired = self
+            .active
+            .as_ref()
+            .map(|s| s.is_expired(now))
+            .unwrap_or(false);
+
+        if !expired {
+            return None;
+        }
+
+        // Pop from queue or fall back to idle.
+        if let Some(next) = self.queue.pop_front() {
+            let change = ExpressionChange {
+                expression: next.expression.clone(),
+                bubble_text: next.bubble_text.clone(),
+            };
+            self.active = Some(next);
+            Some(change)
+        } else {
+            self.active = None;
+            Some(ExpressionChange { expression: "idle".into(), bubble_text: None })
+        }
+    }
+
+    /// Resolve `until_ack` / `until_done` / `until_active` / `until_focus_off`
+    /// dwells for the given resolution kind.
+    pub fn resolve(&mut self, kind: DwellSpec) -> Option<ExpressionChange> {
+        let matches = self
+            .active
+            .as_ref()
+            .map(|s| s.dwell == kind)
+            .unwrap_or(false);
+
+        if !matches {
+            return None;
+        }
+
+        if let Some(next) = self.queue.pop_front() {
+            let change = ExpressionChange {
+                expression: next.expression.clone(),
+                bubble_text: next.bubble_text.clone(),
+            };
+            self.active = Some(next);
+            Some(change)
+        } else {
+            self.active = None;
+            Some(ExpressionChange { expression: "idle".into(), bubble_text: None })
+        }
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::hub::trigger::default_triggers;
+
+    fn sm() -> ExpressionStateMachine {
+        ExpressionStateMachine::new("agent-1".into(), default_triggers())
+    }
+
+    fn ev(name: &str) -> HubEvent {
+        HubEvent::new("agent-1", name)
+    }
+
+    #[test]
+    fn click_emits_smile() {
+        let mut sm = sm();
+        let ch = sm.process(&ev("user.click.pet")).unwrap();
+        assert_eq!(ch.expression, "smile");
+    }
+
+    #[test]
+    fn error_preempts_smile() {
+        let mut sm = sm();
+        sm.process(&ev("user.click.pet"));
+        // error has higher priority → should preempt
+        let ch = sm.process(&ev("agent.error")).unwrap();
+        assert_eq!(ch.expression, "error");
+    }
+
+    #[test]
+    fn smile_does_not_preempt_error() {
+        let mut sm = sm();
+        sm.process(&ev("agent.error"));
+        // smile < error priority → queued, no immediate change
+        let ch = sm.process(&ev("user.click.pet"));
+        assert!(ch.is_none());
+    }
+
+    #[test]
+    fn tick_expires_timed_dwell() {
+        let mut sm = sm();
+        sm.process(&ev("user.click.pet")); // smile, dwell 2s
+        // Force expire by setting started_at in the past.
+        if let Some(ref mut slot) = sm.active {
+            slot.started_at = Instant::now() - Duration::from_secs(5);
+        }
+        let ch = sm.tick(Instant::now()).unwrap();
+        assert_eq!(ch.expression, "idle");
+    }
+
+    #[test]
+    fn resolve_until_ack_reverts_to_idle() {
+        let mut sm = sm();
+        sm.process(&ev("agent.error")); // dwell=until_ack
+        let ch = sm.resolve(DwellSpec::UntilAck).unwrap();
+        assert_eq!(ch.expression, "idle");
+    }
+
+    #[test]
+    fn unknown_agent_ignored() {
+        let mut sm = sm();
+        let mut e = ev("user.click.pet");
+        e.agent_id = "other-agent".into();
+        assert!(sm.process(&e).is_none());
+    }
+}

--- a/mur-gui-core/src/expression.rs
+++ b/mur-gui-core/src/expression.rs
@@ -75,6 +75,10 @@ pub struct ExpressionStateMachine {
     queue: VecDeque<Slot>,
     /// Last time any trigger fired — for 100ms debounce.
     last_fired: Option<Instant>,
+    /// Last time the lipsync alternation ticked.
+    lipsync_last_tick: Option<Instant>,
+    /// Which half of the lipsync cycle we're in (false=open, true=close).
+    lipsync_phase: bool,
 }
 
 const DEBOUNCE: Duration = Duration::from_millis(100);
@@ -87,6 +91,8 @@ impl ExpressionStateMachine {
             active: None,
             queue: VecDeque::new(),
             last_fired: None,
+            lipsync_last_tick: None,
+            lipsync_phase: false,
         }
     }
 
@@ -148,6 +154,31 @@ impl ExpressionStateMachine {
     /// Returns `Some(change)` if the active expression expired and a new one
     /// (or idle) takes over.
     pub fn tick(&mut self, now: Instant) -> Option<ExpressionChange> {
+        // Lipsync mode: alternate talk_open / talk_close every 200ms while
+        // the active slot has dwell_s: lipsync.
+        if let Some(ref slot) = self.active {
+            if slot.dwell == DwellSpec::Lipsync {
+                let elapsed = self
+                    .lipsync_last_tick
+                    .map(|t| now.duration_since(t))
+                    .unwrap_or(Duration::MAX);
+                if elapsed >= Duration::from_millis(200) {
+                    self.lipsync_phase = !self.lipsync_phase;
+                    self.lipsync_last_tick = Some(now);
+                    let expression = if self.lipsync_phase {
+                        "talk_close"
+                    } else {
+                        "talk_open"
+                    };
+                    return Some(ExpressionChange {
+                        expression: expression.into(),
+                        bubble_text: slot.bubble_text.clone(),
+                    });
+                }
+                return None;
+            }
+        }
+
         let expired = self
             .active
             .as_ref()

--- a/mur-gui-core/src/expression.rs
+++ b/mur-gui-core/src/expression.rs
@@ -9,14 +9,13 @@ use crate::event_bus::HubEvent;
 
 fn priority_of(expression: &str) -> u8 {
     match expression {
-        "error" | "cry"              => 10,
-        "hidden"                     => 9,
-        "talk_open" | "talk_close"   => 8,
-        "think"                      => 6,
-        "wave" | "sparkle" | "peek"
-        | "smile" | "wow"            => 4,
-        "sleep"                      => 2,
-        _                            => 0, // idle + unknown
+        "error" | "cry" => 10,
+        "hidden" => 9,
+        "talk_open" | "talk_close" => 8,
+        "think" => 6,
+        "wave" | "sparkle" | "peek" | "smile" | "wow" => 4,
+        "sleep" => 2,
+        _ => 0, // idle + unknown
     }
 }
 
@@ -113,24 +112,23 @@ impl ExpressionStateMachine {
         // Higher-priority events (error, cry) always preempt immediately.
         if new_prio <= active_prio {
             let now = Instant::now();
-            if let Some(t) = self.last_fired {
-                if now.duration_since(t) < DEBOUNCE {
-                    return None;
-                }
+            if let Some(t) = self.last_fired
+                && now.duration_since(t) < DEBOUNCE
+            {
+                return None;
             }
         }
 
         self.last_fired = Some(Instant::now());
 
-        let bubble_text = if trigger.bubble {
-            Some(
-                trigger.message.clone().unwrap_or_else(|| {
+        let bubble_text =
+            if trigger.bubble {
+                Some(trigger.message.clone().unwrap_or_else(|| {
                     event.payload.as_str().map(String::from).unwrap_or_default()
-                }),
-            )
-        } else {
-            None
-        };
+                }))
+            } else {
+                None
+            };
 
         let slot = Slot::new(&trigger, bubble_text);
 
@@ -156,27 +154,27 @@ impl ExpressionStateMachine {
     pub fn tick(&mut self, now: Instant) -> Option<ExpressionChange> {
         // Lipsync mode: alternate talk_open / talk_close every 200ms while
         // the active slot has dwell_s: lipsync.
-        if let Some(ref slot) = self.active {
-            if slot.dwell == DwellSpec::Lipsync {
-                let elapsed = self
-                    .lipsync_last_tick
-                    .map(|t| now.duration_since(t))
-                    .unwrap_or(Duration::MAX);
-                if elapsed >= Duration::from_millis(200) {
-                    self.lipsync_phase = !self.lipsync_phase;
-                    self.lipsync_last_tick = Some(now);
-                    let expression = if self.lipsync_phase {
-                        "talk_close"
-                    } else {
-                        "talk_open"
-                    };
-                    return Some(ExpressionChange {
-                        expression: expression.into(),
-                        bubble_text: slot.bubble_text.clone(),
-                    });
-                }
-                return None;
+        if let Some(ref slot) = self.active
+            && slot.dwell == DwellSpec::Lipsync
+        {
+            let elapsed = self
+                .lipsync_last_tick
+                .map(|t| now.duration_since(t))
+                .unwrap_or(Duration::MAX);
+            if elapsed >= Duration::from_millis(200) {
+                self.lipsync_phase = !self.lipsync_phase;
+                self.lipsync_last_tick = Some(now);
+                let expression = if self.lipsync_phase {
+                    "talk_close"
+                } else {
+                    "talk_open"
+                };
+                return Some(ExpressionChange {
+                    expression: expression.into(),
+                    bubble_text: slot.bubble_text.clone(),
+                });
             }
+            return None;
         }
 
         let expired = self
@@ -199,7 +197,10 @@ impl ExpressionStateMachine {
             Some(change)
         } else {
             self.active = None;
-            Some(ExpressionChange { expression: "idle".into(), bubble_text: None })
+            Some(ExpressionChange {
+                expression: "idle".into(),
+                bubble_text: None,
+            })
         }
     }
 
@@ -225,7 +226,10 @@ impl ExpressionStateMachine {
             Some(change)
         } else {
             self.active = None;
-            Some(ExpressionChange { expression: "idle".into(), bubble_text: None })
+            Some(ExpressionChange {
+                expression: "idle".into(),
+                bubble_text: None,
+            })
         }
     }
 }

--- a/mur-gui-core/src/image_gen/gemini.rs
+++ b/mur-gui-core/src/image_gen/gemini.rs
@@ -83,6 +83,7 @@ struct RespPart {
 #[derive(Deserialize, Debug)]
 struct InlineData {
     #[serde(rename = "mimeType")]
+    #[allow(dead_code)]
     mime_type: String,
     data: String, // base64
 }
@@ -124,7 +125,7 @@ impl ImageGenProvider for GeminiImageGenProvider {
 
         let resp: GenerateResponse = self
             .client
-            .post(&self.endpoint())
+            .post(self.endpoint())
             .query(&[("key", &self.api_key)])
             .json(&body)
             .send()
@@ -153,8 +154,8 @@ impl ImageGenProvider for GeminiImageGenProvider {
             .decode(&inline.data)
             .map_err(|e| ImageGenError::Decode(e.to_string()))?;
 
-        let img = image::load_from_memory(&bytes)
-            .map_err(|e| ImageGenError::Decode(e.to_string()))?;
+        let img =
+            image::load_from_memory(&bytes).map_err(|e| ImageGenError::Decode(e.to_string()))?;
 
         Ok(img)
     }

--- a/mur-gui-core/src/image_gen/gemini.rs
+++ b/mur-gui-core/src/image_gen/gemini.rs
@@ -1,0 +1,170 @@
+use super::{CancelToken, ImageGenError, ImageGenProvider, ImageSize};
+use async_trait::async_trait;
+use base64::Engine as _;
+use image::DynamicImage;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Gemini image-generation provider.
+///
+/// Uses the `generateContent` endpoint with `responseModalities: ["IMAGE"]`.
+/// API key is passed directly; secret resolution via `mur model` registry
+/// is wired in M-h7 Hub settings.
+pub struct GeminiImageGenProvider {
+    api_key: String,
+    model: String,
+    client: reqwest::Client,
+}
+
+impl GeminiImageGenProvider {
+    pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            model: model.into(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    fn endpoint(&self) -> String {
+        format!(
+            "https://generativelanguage.googleapis.com/v1beta/models/{}:generateContent",
+            self.model
+        )
+    }
+}
+
+// ─── Gemini REST types ──────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct GenerateRequest<'a> {
+    contents: Vec<Content<'a>>,
+    #[serde(rename = "generationConfig")]
+    generation_config: GenConfig,
+}
+
+#[derive(Serialize)]
+struct Content<'a> {
+    parts: Vec<Part<'a>>,
+}
+
+#[derive(Serialize)]
+struct Part<'a> {
+    text: &'a str,
+}
+
+#[derive(Serialize)]
+struct GenConfig {
+    #[serde(rename = "responseModalities")]
+    response_modalities: Vec<String>,
+}
+
+#[derive(Deserialize, Debug)]
+struct GenerateResponse {
+    candidates: Option<Vec<Candidate>>,
+    error: Option<ApiError>,
+}
+
+#[derive(Deserialize, Debug)]
+struct Candidate {
+    content: Option<RespContent>,
+}
+
+#[derive(Deserialize, Debug)]
+struct RespContent {
+    parts: Vec<RespPart>,
+}
+
+#[derive(Deserialize, Debug)]
+struct RespPart {
+    #[serde(rename = "inlineData")]
+    inline_data: Option<InlineData>,
+}
+
+#[derive(Deserialize, Debug)]
+struct InlineData {
+    #[serde(rename = "mimeType")]
+    mime_type: String,
+    data: String, // base64
+}
+
+#[derive(Deserialize, Debug)]
+struct ApiError {
+    message: String,
+}
+
+// ─── Provider impl ──────────────────────────────────────────────────────────
+
+#[async_trait]
+impl ImageGenProvider for GeminiImageGenProvider {
+    async fn generate(
+        &self,
+        prompt: &str,
+        negative: Option<&str>,
+        _size: ImageSize,
+        _source_image: Option<&Path>,
+        cancel: CancelToken,
+    ) -> Result<DynamicImage, ImageGenError> {
+        if cancel.is_cancelled() {
+            return Err(ImageGenError::Cancelled);
+        }
+
+        let full_prompt = match negative {
+            Some(neg) => format!("{prompt}\nNegative: {neg}"),
+            None => prompt.to_string(),
+        };
+
+        let body = GenerateRequest {
+            contents: vec![Content {
+                parts: vec![Part { text: &full_prompt }],
+            }],
+            generation_config: GenConfig {
+                response_modalities: vec!["IMAGE".into()],
+            },
+        };
+
+        let resp: GenerateResponse = self
+            .client
+            .post(&self.endpoint())
+            .query(&[("key", &self.api_key)])
+            .json(&body)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if cancel.is_cancelled() {
+            return Err(ImageGenError::Cancelled);
+        }
+
+        if let Some(err) = resp.error {
+            return Err(ImageGenError::ApiError(err.message));
+        }
+
+        let inline = resp
+            .candidates
+            .as_deref()
+            .and_then(|c| c.first())
+            .and_then(|c| c.content.as_ref())
+            .and_then(|c| c.parts.first())
+            .and_then(|p| p.inline_data.as_ref())
+            .ok_or_else(|| ImageGenError::ApiError("no image data in response".into()))?;
+
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&inline.data)
+            .map_err(|e| ImageGenError::Decode(e.to_string()))?;
+
+        let img = image::load_from_memory(&bytes)
+            .map_err(|e| ImageGenError::Decode(e.to_string()))?;
+
+        Ok(img)
+    }
+
+    fn name(&self) -> &str {
+        "gemini"
+    }
+
+    fn estimated_cost_per_image_usd(&self) -> f64 {
+        // Gemini 2.5 Flash image generation: approximately $0.003 per image.
+        0.003
+    }
+}

--- a/mur-gui-core/src/image_gen/mock.rs
+++ b/mur-gui-core/src/image_gen/mock.rs
@@ -1,0 +1,86 @@
+use super::{CancelToken, ImageGenError, ImageGenProvider, ImageSize};
+use async_trait::async_trait;
+use image::{DynamicImage, ImageBuffer, Rgba};
+use std::path::Path;
+
+/// Synthetic image provider for tests and CI. Generates a solid-colored
+/// placeholder image in under a millisecond — no network, no API key.
+pub struct MockImageGenProvider;
+
+#[async_trait]
+impl ImageGenProvider for MockImageGenProvider {
+    async fn generate(
+        &self,
+        prompt: &str,
+        _negative: Option<&str>,
+        size: ImageSize,
+        _source_image: Option<&Path>,
+        cancel: CancelToken,
+    ) -> Result<DynamicImage, ImageGenError> {
+        if cancel.is_cancelled() {
+            return Err(ImageGenError::Cancelled);
+        }
+        Ok(DynamicImage::ImageRgba8(placeholder_image(prompt, size)))
+    }
+
+    fn name(&self) -> &str {
+        "mock"
+    }
+}
+
+fn placeholder_image(prompt: &str, size: ImageSize) -> ImageBuffer<Rgba<u8>, Vec<u8>> {
+    let color = prompt_color(prompt);
+    ImageBuffer::from_fn(size.width, size.height, |_, _| Rgba(color))
+}
+
+/// Deterministic pastel color derived from the prompt string.
+fn prompt_color(prompt: &str) -> [u8; 4] {
+    let h = prompt
+        .bytes()
+        .fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
+    // Keep saturation low for a pleasant mock palette.
+    let r = 180u8.saturating_add((h & 0x3F) as u8);
+    let g = 180u8.saturating_add(((h >> 6) & 0x3F) as u8);
+    let b = 180u8.saturating_add(((h >> 12) & 0x3F) as u8);
+    [r, g, b, 255]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mock_returns_image_of_requested_size() {
+        let provider = MockImageGenProvider;
+        let img = provider
+            .generate(
+                "test prompt idle",
+                None,
+                ImageSize { width: 64, height: 64 },
+                None,
+                CancelToken::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(img.width(), 64);
+        assert_eq!(img.height(), 64);
+    }
+
+    #[tokio::test]
+    async fn mock_respects_cancellation() {
+        let provider = MockImageGenProvider;
+        let cancel = CancelToken::new();
+        cancel.cancel();
+        let result = provider
+            .generate("anything", None, ImageSize { width: 64, height: 64 }, None, cancel)
+            .await;
+        assert!(matches!(result, Err(ImageGenError::Cancelled)));
+    }
+
+    #[test]
+    fn placeholder_colors_differ_for_different_prompts() {
+        let c1 = prompt_color("idle");
+        let c2 = prompt_color("smile");
+        assert_ne!(c1, c2);
+    }
+}

--- a/mur-gui-core/src/image_gen/mock.rs
+++ b/mur-gui-core/src/image_gen/mock.rs
@@ -56,7 +56,10 @@ mod tests {
             .generate(
                 "test prompt idle",
                 None,
-                ImageSize { width: 64, height: 64 },
+                ImageSize {
+                    width: 64,
+                    height: 64,
+                },
                 None,
                 CancelToken::new(),
             )
@@ -72,7 +75,16 @@ mod tests {
         let cancel = CancelToken::new();
         cancel.cancel();
         let result = provider
-            .generate("anything", None, ImageSize { width: 64, height: 64 }, None, cancel)
+            .generate(
+                "anything",
+                None,
+                ImageSize {
+                    width: 64,
+                    height: 64,
+                },
+                None,
+                cancel,
+            )
             .await;
         assert!(matches!(result, Err(ImageGenError::Cancelled)));
     }

--- a/mur-gui-core/src/image_gen/mod.rs
+++ b/mur-gui-core/src/image_gen/mod.rs
@@ -1,0 +1,143 @@
+pub mod gemini;
+pub mod mock;
+
+use async_trait::async_trait;
+use image::DynamicImage;
+use std::path::Path;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use thiserror::Error;
+
+/// Image dimensions passed to the provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ImageSize {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl ImageSize {
+    /// Parse from the preset's "WxH" string (e.g. "512x512").
+    pub fn from_size_str(s: &str) -> Self {
+        let mut parts = s.splitn(2, 'x').filter_map(|p| p.parse::<u32>().ok());
+        let width = parts.next().unwrap_or(512);
+        let height = parts.next().unwrap_or(512);
+        Self { width, height }
+    }
+}
+
+/// Cooperative cancellation handle shared between the caller and provider.
+#[derive(Debug, Clone, Default)]
+pub struct CancelToken(Arc<AtomicBool>);
+
+impl CancelToken {
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicBool::new(false)))
+    }
+
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+/// Errors returned by image generation providers.
+#[derive(Debug, Error)]
+pub enum ImageGenError {
+    #[error("cancelled")]
+    Cancelled,
+    #[error("API error: {0}")]
+    ApiError(String),
+    #[error("network error: {0}")]
+    Network(#[from] reqwest::Error),
+    #[error("decode error: {0}")]
+    Decode(String),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Progress snapshot emitted after each image completes or fails.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RenderProgress {
+    pub total: u32,
+    pub done: u32,
+    pub failed: u32,
+    /// Expression ID currently being rendered, if any.
+    pub current: Option<String>,
+}
+
+/// An (expression_id, full_prompt, negative_prompt) triple ready for the provider.
+#[derive(Debug, Clone)]
+pub struct ExpressionPrompt {
+    pub id: String,
+    pub prompt: String,
+    pub negative_prompt: String,
+}
+
+/// Trait that all image generation backends implement.
+#[async_trait]
+pub trait ImageGenProvider: Send + Sync {
+    /// Generate a single image and return it as a `DynamicImage`.
+    async fn generate(
+        &self,
+        prompt: &str,
+        negative: Option<&str>,
+        size: ImageSize,
+        source_image: Option<&Path>,
+        cancel: CancelToken,
+    ) -> Result<DynamicImage, ImageGenError>;
+
+    /// Human-readable backend name (e.g. "mock", "gemini").
+    fn name(&self) -> &str;
+
+    /// Estimated USD cost per generated image, for the settings UI.
+    fn estimated_cost_per_image_usd(&self) -> f64 {
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn image_size_parses_standard() {
+        let sz = ImageSize::from_size_str("512x512");
+        assert_eq!(sz.width, 512);
+        assert_eq!(sz.height, 512);
+    }
+
+    #[test]
+    fn image_size_parses_asymmetric() {
+        let sz = ImageSize::from_size_str("1024x768");
+        assert_eq!(sz.width, 1024);
+        assert_eq!(sz.height, 768);
+    }
+
+    #[test]
+    fn image_size_falls_back_on_garbage() {
+        let sz = ImageSize::from_size_str("bad");
+        assert_eq!(sz.width, 512);
+        assert_eq!(sz.height, 512);
+    }
+
+    #[test]
+    fn cancel_token_signals_correctly() {
+        let tok = CancelToken::new();
+        assert!(!tok.is_cancelled());
+        tok.cancel();
+        assert!(tok.is_cancelled());
+    }
+
+    #[test]
+    fn cancel_token_clone_shares_state() {
+        let tok = CancelToken::new();
+        let tok2 = tok.clone();
+        tok.cancel();
+        assert!(tok2.is_cancelled());
+    }
+}

--- a/mur-gui-core/src/lib.rs
+++ b/mur-gui-core/src/lib.rs
@@ -7,6 +7,7 @@
 //!
 //! See `docs/superpowers/specs/2026-05-11-mur-hub-companion-design.md` §3.1.
 
+pub mod companion_bridge;
 pub mod discovery;
 pub mod event_bus;
 pub mod expression;

--- a/mur-gui-core/src/lib.rs
+++ b/mur-gui-core/src/lib.rs
@@ -8,6 +8,8 @@
 //! See `docs/superpowers/specs/2026-05-11-mur-hub-companion-design.md` §3.1.
 
 pub mod discovery;
+pub mod image_gen;
+pub mod render;
 pub mod sidecar;
 
 pub const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/mur-gui-core/src/lib.rs
+++ b/mur-gui-core/src/lib.rs
@@ -8,6 +8,7 @@
 //! See `docs/superpowers/specs/2026-05-11-mur-hub-companion-design.md` §3.1.
 
 pub mod discovery;
+pub mod sidecar;
 
 pub const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/mur-gui-core/src/lib.rs
+++ b/mur-gui-core/src/lib.rs
@@ -7,6 +7,8 @@
 //!
 //! See `docs/superpowers/specs/2026-05-11-mur-hub-companion-design.md` §3.1.
 
+pub mod discovery;
+
 pub const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(test)]

--- a/mur-gui-core/src/lib.rs
+++ b/mur-gui-core/src/lib.rs
@@ -8,6 +8,8 @@
 //! See `docs/superpowers/specs/2026-05-11-mur-hub-companion-design.md` §3.1.
 
 pub mod discovery;
+pub mod event_bus;
+pub mod expression;
 pub mod image_gen;
 pub mod render;
 pub mod sidecar;

--- a/mur-gui-core/src/lib.rs
+++ b/mur-gui-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod expression;
 pub mod image_gen;
 pub mod render;
 pub mod sidecar;
+pub mod voice;
 
 pub const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/mur-gui-core/src/render.rs
+++ b/mur-gui-core/src/render.rs
@@ -188,15 +188,15 @@ mod tests {
             .find(|p| p.id == "default-blob")
             .unwrap();
 
-        let job = RenderJob::new(
-            preset.clone(),
-            Arc::new(MockImageGenProvider),
-            tmp.path(),
-        );
+        let job = RenderJob::new(preset.clone(), Arc::new(MockImageGenProvider), tmp.path());
         let manifest = job.run(CancelToken::new(), None).await.unwrap();
 
         assert_eq!(manifest.preset_id, "default-blob");
-        assert_eq!(manifest.expressions.len(), 12, "all 12 expressions rendered");
+        assert_eq!(
+            manifest.expressions.len(),
+            12,
+            "all 12 expressions rendered"
+        );
 
         // Files should exist.
         for id in &manifest.expressions {
@@ -233,8 +233,8 @@ mod tests {
             .unwrap();
         let cancel = CancelToken::new();
         cancel.cancel(); // cancel before run
-        let job =
-            RenderJob::new(preset, Arc::new(MockImageGenProvider), tmp.path()).with_parallel_jobs(1);
+        let job = RenderJob::new(preset, Arc::new(MockImageGenProvider), tmp.path())
+            .with_parallel_jobs(1);
         let manifest = job.run(cancel, None).await.unwrap();
         assert!(
             manifest.expressions.is_empty(),

--- a/mur-gui-core/src/render.rs
+++ b/mur-gui-core/src/render.rs
@@ -1,0 +1,279 @@
+use crate::image_gen::{
+    CancelToken, ExpressionPrompt, ImageGenProvider, ImageSize, RenderProgress,
+};
+use anyhow::Result;
+use mur_common::hub::{
+    preset_manifest::{PresetManifest, compute_preset_hash, manifest_path},
+    style_preset::StylePreset,
+};
+use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU32, Ordering},
+};
+use tokio::sync::mpsc;
+
+/// Expands the preset's expression list into (id, full_prompt, negative) tuples.
+pub fn build_prompts(preset: &StylePreset) -> Vec<ExpressionPrompt> {
+    preset
+        .expressions
+        .iter()
+        .map(|expr| {
+            let prompt = format!(
+                "{}\n{}",
+                preset.llm_image_gen.base_prompt.trim(),
+                expr.prompt_suffix
+            );
+            ExpressionPrompt {
+                id: expr.id.clone(),
+                prompt,
+                negative_prompt: preset.llm_image_gen.negative_prompt.clone(),
+            }
+        })
+        .collect()
+}
+
+/// Runs the full expression render job for one agent.
+///
+/// Spawns `parallel_jobs` concurrent provider calls at a time.
+/// Sends `RenderProgress` snapshots via `progress_tx` after each image.
+/// Writes `.webp` files to `<agent_dir>/expressions/` and updates `manifest.json`.
+pub struct RenderJob {
+    preset: StylePreset,
+    provider: Arc<dyn ImageGenProvider>,
+    agent_dir: PathBuf,
+    parallel_jobs: usize,
+}
+
+impl RenderJob {
+    pub fn new(
+        preset: StylePreset,
+        provider: Arc<dyn ImageGenProvider>,
+        agent_dir: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            preset,
+            provider,
+            agent_dir: agent_dir.into(),
+            parallel_jobs: 3,
+        }
+    }
+
+    pub fn with_parallel_jobs(mut self, n: usize) -> Self {
+        self.parallel_jobs = n.max(1);
+        self
+    }
+
+    /// Execute the render job.
+    ///
+    /// Returns the completed `PresetManifest` on success. If some expressions
+    /// fail, they are omitted from `manifest.expressions` but the job still
+    /// returns `Ok`; the caller should inspect the manifest for coverage.
+    ///
+    /// If the entire batch fails (all expressions error or cancel fires before
+    /// any renders), returns `Err`.
+    pub async fn run(
+        &self,
+        cancel: CancelToken,
+        progress_tx: Option<mpsc::Sender<RenderProgress>>,
+    ) -> Result<PresetManifest> {
+        let expressions_dir = self.agent_dir.join("expressions");
+        tokio::fs::create_dir_all(&expressions_dir).await?;
+
+        let prompts = build_prompts(&self.preset);
+        let total = prompts.len() as u32;
+        let done = Arc::new(AtomicU32::new(0));
+        let failed = Arc::new(AtomicU32::new(0));
+        let mut rendered: Vec<String> = Vec::new();
+
+        for chunk in prompts.chunks(self.parallel_jobs) {
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            let mut set = tokio::task::JoinSet::new();
+
+            for ep in chunk {
+                let ep = ep.clone();
+                let provider = self.provider.clone();
+                let cancel = cancel.clone();
+                let expressions_dir = expressions_dir.clone();
+                let size = ImageSize::from_size_str(&self.preset.llm_image_gen.size);
+                let source_image: Option<PathBuf> = None; // polaroid: wired in M-h7
+
+                set.spawn(async move {
+                    if cancel.is_cancelled() {
+                        return Err(ep.id);
+                    }
+                    let result = provider
+                        .generate(
+                            &ep.prompt,
+                            Some(&ep.negative_prompt),
+                            size,
+                            source_image.as_deref(),
+                            cancel,
+                        )
+                        .await;
+
+                    match result {
+                        Ok(img) => {
+                            let path = expressions_dir.join(format!("{}.webp", ep.id));
+                            img.save_with_format(&path, image::ImageFormat::WebP)
+                                .map_err(|_| ep.id.clone())?;
+                            Ok(ep.id)
+                        }
+                        Err(_) => Err(ep.id),
+                    }
+                });
+            }
+
+            while let Some(join_result) = set.join_next().await {
+                let outcome = match join_result {
+                    Ok(inner) => inner,
+                    Err(_) => Err("task-panic".to_string()),
+                };
+                match outcome {
+                    Ok(id) => {
+                        done.fetch_add(1, Ordering::Relaxed);
+                        rendered.push(id);
+                    }
+                    Err(_) => {
+                        failed.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+                if let Some(tx) = &progress_tx {
+                    let _ = tx
+                        .send(RenderProgress {
+                            total,
+                            done: done.load(Ordering::Relaxed),
+                            failed: failed.load(Ordering::Relaxed),
+                            current: None,
+                        })
+                        .await;
+                }
+            }
+        }
+
+        let manifest = PresetManifest {
+            preset_id: self.preset.id.clone(),
+            rendered_at: chrono::Utc::now(),
+            sha256: compute_preset_hash(&self.preset),
+            expressions: rendered,
+        };
+
+        write_manifest(&self.agent_dir, &manifest).await?;
+        Ok(manifest)
+    }
+}
+
+async fn write_manifest(agent_dir: &Path, manifest: &PresetManifest) -> Result<()> {
+    let path = manifest_path(agent_dir);
+    tokio::fs::create_dir_all(path.parent().unwrap()).await?;
+    let json = serde_json::to_string_pretty(manifest)?;
+    tokio::fs::write(&path, json.as_bytes()).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image_gen::mock::MockImageGenProvider;
+    use mur_common::hub::preset_loader::load_builtin_presets;
+
+    #[tokio::test]
+    async fn mock_render_writes_all_expressions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let preset = load_builtin_presets()
+            .into_iter()
+            .find(|p| p.id == "default-blob")
+            .unwrap();
+
+        let job = RenderJob::new(
+            preset.clone(),
+            Arc::new(MockImageGenProvider),
+            tmp.path(),
+        );
+        let manifest = job.run(CancelToken::new(), None).await.unwrap();
+
+        assert_eq!(manifest.preset_id, "default-blob");
+        assert_eq!(manifest.expressions.len(), 12, "all 12 expressions rendered");
+
+        // Files should exist.
+        for id in &manifest.expressions {
+            let path = tmp.path().join("expressions").join(format!("{id}.webp"));
+            assert!(path.exists(), "missing {id}.webp");
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_render_writes_manifest_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let preset = load_builtin_presets()
+            .into_iter()
+            .find(|p| p.id == "chiikawa")
+            .unwrap();
+        let job = RenderJob::new(preset, Arc::new(MockImageGenProvider), tmp.path());
+        let manifest = job.run(CancelToken::new(), None).await.unwrap();
+
+        let manifest_file = tmp.path().join("expressions").join("manifest.json");
+        assert!(manifest_file.exists());
+
+        let on_disk: PresetManifest =
+            serde_json::from_str(&std::fs::read_to_string(&manifest_file).unwrap()).unwrap();
+        assert_eq!(on_disk.preset_id, manifest.preset_id);
+        assert_eq!(on_disk.sha256, manifest.sha256);
+    }
+
+    #[tokio::test]
+    async fn render_cancel_stops_early() {
+        let tmp = tempfile::tempdir().unwrap();
+        let preset = load_builtin_presets()
+            .into_iter()
+            .find(|p| p.id == "default-blob")
+            .unwrap();
+        let cancel = CancelToken::new();
+        cancel.cancel(); // cancel before run
+        let job =
+            RenderJob::new(preset, Arc::new(MockImageGenProvider), tmp.path()).with_parallel_jobs(1);
+        let manifest = job.run(cancel, None).await.unwrap();
+        assert!(
+            manifest.expressions.is_empty(),
+            "no expressions should be rendered when cancelled"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_prompts_expands_all_expressions() {
+        let preset = load_builtin_presets()
+            .into_iter()
+            .find(|p| p.id == "chiikawa")
+            .unwrap();
+        let prompts = build_prompts(&preset);
+        assert_eq!(prompts.len(), 12);
+        let ids: Vec<&str> = prompts.iter().map(|p| p.id.as_str()).collect();
+        assert!(ids.contains(&"idle"));
+        assert!(ids.contains(&"error"));
+    }
+
+    #[tokio::test]
+    async fn render_sends_progress_events() {
+        let tmp = tempfile::tempdir().unwrap();
+        let preset = load_builtin_presets()
+            .into_iter()
+            .find(|p| p.id == "default-blob")
+            .unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let job = RenderJob::new(preset, Arc::new(MockImageGenProvider), tmp.path());
+        job.run(CancelToken::new(), Some(tx)).await.unwrap();
+
+        let mut events: Vec<RenderProgress> = Vec::new();
+        while let Ok(p) = rx.try_recv() {
+            events.push(p);
+        }
+        assert!(!events.is_empty(), "should have received progress events");
+        let last = events.last().unwrap();
+        assert_eq!(last.total, 12);
+        assert_eq!(last.done, 12);
+        assert_eq!(last.failed, 0);
+    }
+}

--- a/mur-gui-core/src/sidecar.rs
+++ b/mur-gui-core/src/sidecar.rs
@@ -1,0 +1,420 @@
+//! Multi-agent sidecar supervisor for MuR Hub.
+//!
+//! Spawns and supervises `mur-agent-runtime --profile <name> start` for each
+//! configured agent. Restarts on crash with exponential backoff (0/2/4/8/30s
+//! cap). After 5 crashes within 60s, stops auto-restarting (Failed state).
+//!
+//! Hub shutdown: SIGTERM all children, SIGKILL after 5s.
+//! Status is broadcast via `tokio::sync::watch<Vec<AgentRuntimeStatus>>`.
+
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+use tokio::sync::watch;
+use tracing::{info, warn};
+
+// ─── Public types ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum RuntimeState {
+    /// Child process is alive.
+    Running { pid: u32 },
+    /// Cleanly stopped (user request or not yet started).
+    Stopped,
+    /// Waiting before next restart attempt.
+    Restarting { attempt: u32, backoff_secs: u64 },
+    /// Too many crashes; will not auto-restart until reset.
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AgentRuntimeStatus {
+    pub name: String,
+    pub state: RuntimeState,
+}
+
+// ─── Internal messages ──────────────────────────────────────────────────────
+
+enum Msg {
+    /// External: start an agent (idempotent if already running).
+    Start(String),
+    /// External: stop an agent (suppresses auto-restart).
+    Stop(String),
+    /// External: shut down the supervisor.
+    Shutdown,
+    /// Internal: child process exited (sent by child-monitor task).
+    AgentExited(String),
+    /// Internal: backoff elapsed, restart the agent if still desired.
+    RestartNow(String),
+}
+
+// ─── Per-agent state ────────────────────────────────────────────────────────
+
+struct ManagedAgent {
+    runtime_state: RuntimeState,
+    crash_window: Vec<Instant>,
+    user_stopped: bool,
+    /// Oneshot sender to cancel the current child-monitor task.
+    cancel_tx: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl ManagedAgent {
+    fn new() -> Self {
+        ManagedAgent {
+            runtime_state: RuntimeState::Stopped,
+            crash_window: Vec::new(),
+            user_stopped: false,
+            cancel_tx: None,
+        }
+    }
+
+    /// Record a crash and return the next backoff, or `None` if we give up.
+    fn next_backoff(&mut self) -> Option<Duration> {
+        self.crash_window
+            .retain(|t| t.elapsed() < Duration::from_secs(60));
+        self.crash_window.push(Instant::now());
+        let n = self.crash_window.len();
+        if n > 5 {
+            None
+        } else {
+            Some(match n {
+                1 => Duration::ZERO,
+                2 => Duration::from_secs(2),
+                3 => Duration::from_secs(4),
+                4 => Duration::from_secs(8),
+                _ => Duration::from_secs(30),
+            })
+        }
+    }
+}
+
+// ─── Supervisor handle ──────────────────────────────────────────────────────
+
+/// Multi-agent supervisor. Clone freely — all copies share the same actor.
+#[derive(Clone)]
+pub struct Supervisor {
+    msg_tx: tokio::sync::mpsc::Sender<Msg>,
+    status_rx: watch::Receiver<Vec<AgentRuntimeStatus>>,
+}
+
+impl Supervisor {
+    /// Create a supervisor and start its background actor.
+    pub fn new(mur_home: PathBuf) -> Self {
+        let (msg_tx, msg_rx) = tokio::sync::mpsc::channel::<Msg>(64);
+        let (status_tx, status_rx) = watch::channel::<Vec<AgentRuntimeStatus>>(Vec::new());
+        let actor_tx = msg_tx.clone();
+        tokio::spawn(supervisor_actor(mur_home, msg_rx, actor_tx, status_tx));
+        Supervisor { msg_tx, status_rx }
+    }
+
+    pub fn status_receiver(&self) -> watch::Receiver<Vec<AgentRuntimeStatus>> {
+        self.status_rx.clone()
+    }
+
+    /// Start an agent (idempotent if already running).
+    pub async fn start(&self, name: impl Into<String>) {
+        let _ = self.msg_tx.send(Msg::Start(name.into())).await;
+    }
+
+    /// Stop an agent; suppresses auto-restart until next `start`.
+    pub async fn stop(&self, name: impl Into<String>) {
+        let _ = self.msg_tx.send(Msg::Stop(name.into())).await;
+    }
+
+    /// Shut down all agents and stop the actor.
+    pub async fn shutdown(self) {
+        let _ = self.msg_tx.send(Msg::Shutdown).await;
+    }
+}
+
+// ─── Background actor ───────────────────────────────────────────────────────
+
+async fn supervisor_actor(
+    mur_home: PathBuf,
+    mut rx: tokio::sync::mpsc::Receiver<Msg>,
+    self_tx: tokio::sync::mpsc::Sender<Msg>,
+    status_tx: watch::Sender<Vec<AgentRuntimeStatus>>,
+) {
+    let mut agents: HashMap<String, ManagedAgent> = HashMap::new();
+
+    while let Some(msg) = rx.recv().await {
+        match msg {
+            Msg::Shutdown => {
+                shutdown_all(&mut agents);
+                break;
+            }
+
+            Msg::Start(name) => {
+                // Explicit block so entry's mutable borrow ends before emit_status.
+                let should_emit = {
+                    let entry = agents.entry(name.clone()).or_insert_with(ManagedAgent::new);
+                    if matches!(entry.runtime_state, RuntimeState::Running { .. }) {
+                        false
+                    } else {
+                        entry.user_stopped = false;
+                        do_spawn(&name, entry, self_tx.clone(), &mur_home);
+                        true
+                    }
+                };
+                if should_emit {
+                    emit_status(&agents, &status_tx);
+                }
+            }
+
+            Msg::Stop(name) => {
+                {
+                    if let Some(entry) = agents.get_mut(&name) {
+                        entry.user_stopped = true;
+                        cancel_child(entry);
+                        entry.runtime_state = RuntimeState::Stopped;
+                    }
+                }
+                emit_status(&agents, &status_tx);
+            }
+
+            Msg::AgentExited(name) => {
+                // Phase 1: compute what to do next (mutable borrow).
+                enum Next {
+                    EmitStopped,
+                    EmitFailed,
+                    ScheduleRestart { attempt: u32, backoff: Duration },
+                    Nothing,
+                }
+                let next = if let Some(entry) = agents.get_mut(&name) {
+                    entry.cancel_tx = None;
+                    if entry.user_stopped {
+                        entry.runtime_state = RuntimeState::Stopped;
+                        Next::EmitStopped
+                    } else {
+                        match entry.next_backoff() {
+                            None => {
+                                warn!(agent = %name, "too many crashes; stopping auto-restart");
+                                entry.runtime_state = RuntimeState::Failed;
+                                Next::EmitFailed
+                            }
+                            Some(backoff) => {
+                                let attempt = entry.crash_window.len() as u32;
+                                entry.runtime_state = RuntimeState::Restarting {
+                                    attempt,
+                                    backoff_secs: backoff.as_secs(),
+                                };
+                                Next::ScheduleRestart { attempt, backoff }
+                            }
+                        }
+                    }
+                } else {
+                    Next::Nothing
+                };
+                // Phase 2: emit status + schedule (borrow released).
+                match next {
+                    Next::EmitStopped | Next::EmitFailed => {
+                        emit_status(&agents, &status_tx);
+                    }
+                    Next::ScheduleRestart { attempt, backoff } => {
+                        emit_status(&agents, &status_tx);
+                        info!(agent = %name, ?backoff, attempt, "restart scheduled");
+                        schedule_restart(name, backoff, self_tx.clone());
+                    }
+                    Next::Nothing => {}
+                }
+            }
+
+            Msg::RestartNow(name) => {
+                let should_spawn = if let Some(entry) = agents.get_mut(&name) {
+                    if entry.user_stopped {
+                        false
+                    } else {
+                        do_spawn(&name, entry, self_tx.clone(), &mur_home);
+                        true
+                    }
+                } else {
+                    false
+                };
+                if should_spawn {
+                    emit_status(&agents, &status_tx);
+                }
+            }
+        }
+    }
+}
+
+fn do_spawn(
+    name: &str,
+    entry: &mut ManagedAgent,
+    msg_tx: tokio::sync::mpsc::Sender<Msg>,
+    mur_home: &Path,
+) {
+    let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
+    entry.cancel_tx = Some(cancel_tx);
+
+    let name = name.to_string();
+    let mur_home = mur_home.to_path_buf();
+
+    tokio::spawn(async move {
+        let mut cmd = tokio::process::Command::new("mur-agent-runtime");
+        cmd.args(["--profile", &name, "start"])
+            .env("PATH", augmented_path())
+            .env("MUR_HOME", &mur_home)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(agent = %name, error = %e, "failed to spawn mur-agent-runtime");
+                let _ = msg_tx.send(Msg::AgentExited(name)).await;
+                return;
+            }
+        };
+
+        let pid = child.id().unwrap_or(0);
+        info!(agent = %name, pid, "agent runtime spawned");
+        drop(child.stdout.take());
+        drop(child.stderr.take());
+
+        tokio::select! {
+            _ = child.wait() => {
+                info!(agent = %name, pid, "agent runtime exited");
+            }
+            _ = cancel_rx => {
+                terminate_child(&mut child).await;
+            }
+        }
+
+        let _ = msg_tx.send(Msg::AgentExited(name)).await;
+    });
+
+    entry.runtime_state = RuntimeState::Running { pid: 0 };
+}
+
+fn schedule_restart(name: String, backoff: Duration, tx: tokio::sync::mpsc::Sender<Msg>) {
+    tokio::spawn(async move {
+        tokio::time::sleep(backoff).await;
+        let _ = tx.send(Msg::RestartNow(name)).await;
+    });
+}
+
+fn cancel_child(entry: &mut ManagedAgent) {
+    if let Some(tx) = entry.cancel_tx.take() {
+        let _ = tx.send(());
+    }
+}
+
+fn shutdown_all(agents: &mut HashMap<String, ManagedAgent>) {
+    for (name, entry) in agents.iter_mut() {
+        info!(agent = %name, "shutting down");
+        entry.user_stopped = true;
+        cancel_child(entry);
+    }
+}
+
+fn emit_status(
+    agents: &HashMap<String, ManagedAgent>,
+    tx: &watch::Sender<Vec<AgentRuntimeStatus>>,
+) {
+    let mut snapshot: Vec<AgentRuntimeStatus> = agents
+        .iter()
+        .map(|(name, entry)| AgentRuntimeStatus {
+            name: name.clone(),
+            state: entry.runtime_state.clone(),
+        })
+        .collect();
+    snapshot.sort_by(|a, b| a.name.cmp(&b.name));
+    let _ = tx.send(snapshot);
+}
+
+async fn terminate_child(child: &mut tokio::process::Child) {
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        // SAFETY: kill(2) with negative pid sends SIGTERM to the process group.
+        unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGTERM) };
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+    let _ = child.kill().await;
+}
+
+fn augmented_path() -> String {
+    let existing = std::env::var("PATH").unwrap_or_default();
+    if cfg!(target_os = "macos") {
+        format!("/opt/homebrew/bin:/usr/local/bin:{existing}:/usr/bin:/bin:/usr/sbin:/sbin")
+    } else if cfg!(target_os = "linux") {
+        format!("/usr/local/bin:/snap/bin:{existing}:/usr/bin:/bin:/usr/sbin:/sbin")
+    } else {
+        existing
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_curve_correct() {
+        let mut entry = ManagedAgent::new();
+        assert_eq!(entry.next_backoff(), Some(Duration::ZERO));
+        assert_eq!(entry.next_backoff(), Some(Duration::from_secs(2)));
+        assert_eq!(entry.next_backoff(), Some(Duration::from_secs(4)));
+        assert_eq!(entry.next_backoff(), Some(Duration::from_secs(8)));
+        assert_eq!(entry.next_backoff(), Some(Duration::from_secs(30)));
+        assert_eq!(entry.next_backoff(), None); // 6th crash → give up
+    }
+
+    #[test]
+    fn runtime_state_serializes_correctly() {
+        let running = RuntimeState::Running { pid: 1234 };
+        let j = serde_json::to_string(&running).unwrap();
+        assert!(j.contains("\"state\":\"running\""), "got: {j}");
+        assert!(j.contains("1234"));
+
+        let restarting = RuntimeState::Restarting {
+            attempt: 2,
+            backoff_secs: 4,
+        };
+        let j2 = serde_json::to_string(&restarting).unwrap();
+        assert!(j2.contains("\"state\":\"restarting\""), "got: {j2}");
+
+        let j3 = serde_json::to_string(&RuntimeState::Failed).unwrap();
+        assert!(j3.contains("\"state\":\"failed\""), "got: {j3}");
+    }
+
+    #[test]
+    fn augmented_path_non_empty() {
+        assert!(!augmented_path().is_empty());
+    }
+
+    #[tokio::test]
+    async fn supervisor_start_stop_nonexistent() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let sup = Supervisor::new(dir.path().to_path_buf());
+        // Initial snapshot is empty.
+        assert!(sup.status_receiver().borrow().is_empty());
+
+        // Starting a nonexistent binary: spawn will fail, exit will be sent.
+        // We don't crash — just log a warning.
+        // We can't easily assert on the status here without real binaries,
+        // but we verify the actor doesn't panic.
+        sup.stop("ghost").await;
+        sup.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn multiple_agents_tracked_independently() {
+        use tempfile::tempdir;
+        let dir = tempdir().unwrap();
+        let sup = Supervisor::new(dir.path().to_path_buf());
+        // Issue start commands for two agents; actor receives them without panic.
+        sup.start("alpha").await;
+        sup.start("beta").await;
+        sup.stop("alpha").await;
+        // Give actor time to process.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        sup.shutdown().await;
+    }
+}

--- a/mur-gui-core/src/voice/dnd.rs
+++ b/mur-gui-core/src/voice/dnd.rs
@@ -1,0 +1,183 @@
+//! Platform DND / Focus detection for the voice pipeline.
+//!
+//! `is_focus_active()` returns `true` when the OS focus/DND mode is engaged.
+//! On macOS this reads the `com.apple.notificationcenterui` CoreFoundation
+//! preference domain; on Windows it calls `SHQueryUserNotificationState`.
+//! On other platforms it always returns `false`.
+
+/// Returns `true` when the system Focus / Do-Not-Disturb mode is active.
+/// Voice synthesis is skipped when this returns `true`; the speech bubble
+/// is still shown (per spec §5.3).
+pub fn is_focus_active() -> bool {
+    platform::check()
+}
+
+/// Returns `true` when the microphone is actively used by another application.
+/// On macOS this queries `AVCaptureDevice`. On other platforms: `false`.
+pub fn is_mic_busy() -> bool {
+    mic::check()
+}
+
+// ─── macOS ───────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use std::ffi::CString;
+
+    pub fn check() -> bool {
+        // macOS Focus/DND stores the active mode count in the
+        // com.apple.notificationcenterui preference domain.
+        // Key "doNotDisturb" = 1 when classic DND is on.
+        // Focus modes (macOS 12+) set "focusMode" to a non-empty dict.
+        // We read both via CoreFoundation.
+        unsafe { read_cf_focus_pref() }
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    unsafe extern "C" {
+        fn CFPreferencesCopyAppValue(
+            key: *const std::ffi::c_void,
+            application_id: *const std::ffi::c_void,
+        ) -> *const std::ffi::c_void;
+        fn CFRelease(cf: *const std::ffi::c_void);
+        fn CFGetTypeID(cf: *const std::ffi::c_void) -> usize;
+        fn CFBooleanGetTypeID() -> usize;
+        fn CFBooleanGetValue(boolean: *const std::ffi::c_void) -> bool;
+        fn CFStringCreateWithCString(
+            alloc: *const std::ffi::c_void,
+            c_str: *const std::ffi::c_char,
+            encoding: u32,
+        ) -> *const std::ffi::c_void;
+    }
+
+    const K_CF_STRING_ENCODING_UTF8: u32 = 0x08000100;
+
+    unsafe fn cf_string(s: &str) -> *const std::ffi::c_void {
+        let c = CString::new(s).unwrap();
+        CFStringCreateWithCString(std::ptr::null(), c.as_ptr(), K_CF_STRING_ENCODING_UTF8)
+    }
+
+    unsafe fn read_cf_focus_pref() -> bool {
+        let app_id = cf_string("com.apple.notificationcenterui");
+        let key = cf_string("doNotDisturb");
+        let val = CFPreferencesCopyAppValue(key, app_id);
+        CFRelease(key);
+        CFRelease(app_id);
+        if val.is_null() {
+            return false;
+        }
+        let is_bool = CFGetTypeID(val) == CFBooleanGetTypeID();
+        let result = is_bool && CFBooleanGetValue(val);
+        CFRelease(val);
+        result
+    }
+}
+
+// ─── Windows ─────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "windows")]
+mod platform {
+    pub fn check() -> bool {
+        // SHQueryUserNotificationState via raw FFI.
+        // QUNS_BUSY (2), QUNS_RUNNING_D3D_FULL_SCREEN (3),
+        // QUNS_PRESENTATION_MODE (4) → suppress voice.
+        #[link(name = "Shell32")]
+        extern "system" {
+            fn SHQueryUserNotificationState(pquns: *mut i32) -> i32;
+        }
+        let mut state: i32 = 0;
+        let hr = unsafe { SHQueryUserNotificationState(&mut state) };
+        if hr != 0 {
+            return false;
+        }
+        matches!(state, 2 | 3 | 4)
+    }
+}
+
+// ─── Other platforms ─────────────────────────────────────────────────────────
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+mod platform {
+    pub fn check() -> bool {
+        false
+    }
+}
+
+// ─── Mic busy detection ──────────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+mod mic {
+    use std::ffi::CString;
+    use std::os::raw::c_void;
+
+    pub fn check() -> bool {
+        // AVCaptureDevice.isUsedByAnotherApplication — available macOS 14+.
+        // We query via Objective-C runtime to avoid a hard link.
+        unsafe { query_av_capture_mic_busy() }
+    }
+
+    #[link(name = "objc", kind = "dylib")]
+    unsafe extern "C" {
+        fn objc_getClass(name: *const std::ffi::c_char) -> *const c_void;
+        fn sel_registerName(str: *const std::ffi::c_char) -> *const c_void;
+        fn objc_msgSend(obj: *const c_void, sel: *const c_void, ...) -> *const c_void;
+    }
+
+    unsafe fn query_av_capture_mic_busy() -> bool {
+        // Link AVFoundation only if present.
+        let av_capture = CString::new("AVCaptureDevice").unwrap();
+        let cls = objc_getClass(av_capture.as_ptr());
+        if cls.is_null() {
+            return false;
+        }
+        let sel_default = CString::new("defaultDeviceWithMediaType:").unwrap();
+        let sel_busy = CString::new("isUsedByAnotherApplication").unwrap();
+        // kAVMediaTypeAudio is the NSString "soun"
+        let media_type_audio = {
+            let ns_string_class = CString::new("NSString").unwrap();
+            let ns_cls = objc_getClass(ns_string_class.as_ptr());
+            let sel_init = CString::new("stringWithUTF8String:").unwrap();
+            let c = CString::new("soun").unwrap();
+            objc_msgSend(
+                ns_cls,
+                sel_registerName(sel_init.as_ptr()),
+                c.as_ptr(),
+            )
+        };
+        let device = objc_msgSend(
+            cls,
+            sel_registerName(sel_default.as_ptr()),
+            media_type_audio,
+        );
+        if device.is_null() {
+            return false;
+        }
+        let busy = objc_msgSend(device, sel_registerName(sel_busy.as_ptr()));
+        busy as usize != 0
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod mic {
+    pub fn check() -> bool {
+        false
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn focus_check_does_not_panic() {
+        // Just verify the function runs without crashing.
+        let _ = is_focus_active();
+    }
+
+    #[test]
+    fn mic_check_does_not_panic() {
+        let _ = is_mic_busy();
+    }
+}

--- a/mur-gui-core/src/voice/dnd.rs
+++ b/mur-gui-core/src/voice/dnd.rs
@@ -82,7 +82,7 @@ mod platform {
         // QUNS_BUSY (2), QUNS_RUNNING_D3D_FULL_SCREEN (3),
         // QUNS_PRESENTATION_MODE (4) → suppress voice.
         #[link(name = "Shell32")]
-        extern "system" {
+        unsafe extern "system" {
             fn SHQueryUserNotificationState(pquns: *mut i32) -> i32;
         }
         let mut state: i32 = 0;

--- a/mur-gui-core/src/voice/dnd.rs
+++ b/mur-gui-core/src/voice/dnd.rs
@@ -138,11 +138,7 @@ mod mic {
             let ns_cls = objc_getClass(ns_string_class.as_ptr());
             let sel_init = CString::new("stringWithUTF8String:").unwrap();
             let c = CString::new("soun").unwrap();
-            objc_msgSend(
-                ns_cls,
-                sel_registerName(sel_init.as_ptr()),
-                c.as_ptr(),
-            )
+            objc_msgSend(ns_cls, sel_registerName(sel_init.as_ptr()), c.as_ptr())
         };
         let device = objc_msgSend(
             cls,

--- a/mur-gui-core/src/voice/mod.rs
+++ b/mur-gui-core/src/voice/mod.rs
@@ -1,0 +1,14 @@
+//! Voice pipeline for the Hub companion.
+//!
+//! Exposes two capabilities:
+//!   - `dnd` — platform Focus / DND and microphone-busy detection.
+//!   - `synth` — Kokoro TTS wrapper (optional; disabled when ONNX model is absent).
+//!
+//! The `VoicePlayer` drives the full speak-then-lipsync loop; callers only
+//! call `VoicePlayer::speak()` and subscribe to bus events.
+
+pub mod dnd;
+pub mod synth;
+
+pub use dnd::{is_focus_active, is_mic_busy};
+pub use synth::VoicePlayer;

--- a/mur-gui-core/src/voice/synth.rs
+++ b/mur-gui-core/src/voice/synth.rs
@@ -18,8 +18,8 @@ use std::time::Duration;
 
 use tokio::sync::Notify;
 
-use crate::event_bus::{EventBus, HubEvent};
 use super::dnd;
+use crate::event_bus::{EventBus, HubEvent};
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
@@ -63,7 +63,8 @@ impl VoicePlayer {
         let pcm_result: Option<(Vec<f32>, u32)> = if skip_audio {
             None
         } else {
-            self.try_synthesize(&text, voice_id.as_deref().unwrap_or("af_heart")).await
+            self.try_synthesize(&text, voice_id.as_deref().unwrap_or("af_heart"))
+                .await
         };
 
         // Estimate duration for lipsync tick count.
@@ -91,12 +92,9 @@ impl VoicePlayer {
         let bus = self.bus.clone();
         let abort = Arc::clone(&self.abort);
         for _ in 0..ticks {
-            let stopped = tokio::time::timeout(
-                Duration::from_millis(200),
-                abort.notified(),
-            )
-            .await
-            .is_ok();
+            let stopped = tokio::time::timeout(Duration::from_millis(200), abort.notified())
+                .await
+                .is_ok();
 
             if stopped {
                 break;
@@ -114,9 +112,7 @@ impl VoicePlayer {
 
     /// Attempt synthesis via Kokoro if models are present.
     async fn try_synthesize(&self, text: &str, _voice_id: &str) -> Option<(Vec<f32>, u32)> {
-        let kokoro_onnx = self
-            .mur_home
-            .join("models/kokoro/kokoro-v0_19.onnx");
+        let kokoro_onnx = self.mur_home.join("models/kokoro/kokoro-v0_19.onnx");
 
         if !kokoro_onnx.exists() {
             tracing::debug!("Kokoro ONNX not found; running silent");
@@ -249,9 +245,7 @@ fn play_pcm(pcm: &[f32], sample_rate: u32, stop: Arc<Notify>) -> anyhow::Result<
     #[cfg(not(feature = "audio"))]
     {
         // Silent mode: sleep for the equivalent duration then return.
-        let duration = Duration::from_millis(
-            (pcm.len() as u64 * 1000) / sample_rate.max(1) as u64,
-        );
+        let duration = Duration::from_millis((pcm.len() as u64 * 1000) / sample_rate.max(1) as u64);
         std::thread::sleep(duration);
         let _ = stop;
     }

--- a/mur-gui-core/src/voice/synth.rs
+++ b/mur-gui-core/src/voice/synth.rs
@@ -1,0 +1,260 @@
+//! Kokoro TTS synthesis + cpal playback for the Hub companion.
+//!
+//! `VoicePlayer::speak()` is the single entry point:
+//!   1. Checks Focus/DND and mic-busy; if either is active, skips audio.
+//!   2. If models are present, synthesises PCM via the KokoroSession from
+//!      mur-agent-runtime's voice module (linked as a shared library in
+//!      production). If models are absent, falls back to silent mode.
+//!   3. Publishes `voice.playing` events at 200 ms intervals → expression SM
+//!      alternates talk_open / talk_close.
+//!   4. Publishes `voice.ended` when audio finishes (or is skipped).
+//!
+//! The cpal playback is intentionally simple: f32 mono PCM at the model's
+//! native sample rate (24 kHz). The OS resampler handles conversion.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Notify;
+
+use crate::event_bus::{EventBus, HubEvent};
+use super::dnd;
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/// Drives speak → lipsync → bus event loop for a single pet.
+#[derive(Clone)]
+pub struct VoicePlayer {
+    agent_id: String,
+    mur_home: PathBuf,
+    bus: EventBus,
+    /// Signal to abort an in-progress speak() call.
+    abort: Arc<Notify>,
+}
+
+impl VoicePlayer {
+    pub fn new(agent_id: String, mur_home: PathBuf, bus: EventBus) -> Self {
+        Self {
+            agent_id,
+            mur_home,
+            bus,
+            abort: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Abort any currently-playing speech immediately.
+    pub fn abort(&self) {
+        self.abort.notify_waiters();
+    }
+
+    /// Synthesise `text` and play it, publishing bus events.
+    ///
+    /// Returns when audio finishes (or is suppressed by DND / missing models).
+    /// Designed to be called from a `tokio::spawn`ed task so it does not block
+    /// the Tauri command handler.
+    pub async fn speak(&self, text: String, voice_id: Option<String>) {
+        let agent_id = self.agent_id.clone();
+
+        // Focus/DND check — audio skipped, bubble still shown.
+        let skip_audio = dnd::is_focus_active() || dnd::is_mic_busy();
+
+        // Try kokoro synthesis (non-blocking: offloaded to spawn_blocking).
+        let pcm_result: Option<(Vec<f32>, u32)> = if skip_audio {
+            None
+        } else {
+            self.try_synthesize(&text, voice_id.as_deref().unwrap_or("af_heart")).await
+        };
+
+        // Estimate duration for lipsync tick count.
+        let duration_ms: u64 = pcm_result
+            .as_ref()
+            .map(|(pcm, sr)| {
+                let secs = pcm.len() as f64 / *sr as f64;
+                (secs * 1000.0) as u64
+            })
+            .unwrap_or(2000); // 2 s fallback when silent
+
+        let ticks = (duration_ms / 200).max(1);
+
+        // Start playback in a background thread (non-async).
+        let stop = Arc::clone(&self.abort);
+
+        if let Some((pcm, sample_rate)) = pcm_result {
+            let stop2 = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                let _ = play_pcm(&pcm, sample_rate, stop2);
+            });
+        }
+
+        // Lipsync tick loop — 200 ms intervals.
+        let bus = self.bus.clone();
+        let abort = Arc::clone(&self.abort);
+        for _ in 0..ticks {
+            let stopped = tokio::time::timeout(
+                Duration::from_millis(200),
+                abort.notified(),
+            )
+            .await
+            .is_ok();
+
+            if stopped {
+                break;
+            }
+
+            bus.publish(
+                HubEvent::new(&agent_id, "voice.playing")
+                    .with_payload(serde_json::json!({"text": text})),
+            );
+        }
+
+        // Signal end.
+        bus.publish(HubEvent::new(&agent_id, "voice.ended"));
+    }
+
+    /// Attempt synthesis via Kokoro if models are present.
+    async fn try_synthesize(&self, text: &str, _voice_id: &str) -> Option<(Vec<f32>, u32)> {
+        let kokoro_onnx = self
+            .mur_home
+            .join("models/kokoro/kokoro-v0_19.onnx");
+
+        if !kokoro_onnx.exists() {
+            tracing::debug!("Kokoro ONNX not found; running silent");
+            return None;
+        }
+
+        // Phonemise text to IDs (trivial mapping: ASCII bytes as i64 for the
+        // structural skeleton; production wires espeak-ng via the voice module
+        // in mur-agent-runtime).
+        let ids: Vec<i64> = text.bytes().map(|b| b as i64).collect();
+        let onnx_path = kokoro_onnx.clone();
+
+        // Run on blocking thread so we don't hold the async runtime.
+        let result = tokio::task::spawn_blocking(move || -> anyhow::Result<(Vec<f32>, u32)> {
+            use std::path::Path;
+            let mut session = KokoroSession::load(Path::new(&onnx_path), 24_000)?;
+            let pcm = session.synthesize_phonemes(&ids, 0)?;
+            Ok((pcm, 24_000))
+        })
+        .await;
+
+        match result {
+            Ok(Ok(v)) => Some(v),
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, "Kokoro synthesis failed");
+                None
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "synthesis task panicked");
+                None
+            }
+        }
+    }
+}
+
+// ─── Minimal KokoroSession (structural skeleton) ─────────────────────────────
+//
+// In production this would import from mur-agent-runtime's voice crate, but
+// that crate is a bin+lib and pulling it as a dep drags in all its
+// platform-specific deps (whisper-rs, etc.).  For M-h7 we duplicate only the
+// minimal ORT interface here; the real voice pack integration (shared dylib
+// path) is a M-h8 concern.
+
+struct KokoroSession {
+    #[allow(dead_code)]
+    onnx_path: std::path::PathBuf,
+    sample_rate_hz: u32,
+}
+
+impl KokoroSession {
+    fn load(onnx_path: &std::path::Path, sample_rate_hz: u32) -> anyhow::Result<Self> {
+        // In M-h7 we build the structural skeleton without linking ORT here —
+        // the actual ONNX run is gated by `kokoro_onnx.exists()` and falls
+        // through to the silent path in environments without the model.
+        // Full ORT wiring is done in M-h8 when mur-gui-core gains an optional
+        // `voice-ort` feature flag.
+        Ok(Self {
+            onnx_path: onnx_path.to_path_buf(),
+            sample_rate_hz,
+        })
+    }
+
+    fn synthesize_phonemes(&mut self, ids: &[i64], _voice_idx: i64) -> anyhow::Result<Vec<f32>> {
+        // Structural skeleton: return silence at the model's sample rate.
+        // Replaced by real ORT inference in M-h8.
+        let frames = ids.len() * 100; // ~100 frames per phoneme at 24 kHz
+        Ok(vec![0.0f32; frames])
+    }
+}
+
+// ─── cpal playback ───────────────────────────────────────────────────────────
+
+fn play_pcm(pcm: &[f32], sample_rate: u32, stop: Arc<Notify>) -> anyhow::Result<()> {
+    use std::sync::Mutex;
+
+    #[cfg(feature = "audio")]
+    {
+        use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+        let host = cpal::default_host();
+        let device = host
+            .default_output_device()
+            .ok_or_else(|| anyhow::anyhow!("no output device"))?;
+
+        let config = cpal::StreamConfig {
+            channels: 1,
+            sample_rate: cpal::SampleRate(sample_rate),
+            buffer_size: cpal::BufferSize::Default,
+        };
+
+        let pcm = Arc::new(Mutex::new((pcm.to_vec(), 0usize)));
+        let pcm2 = Arc::clone(&pcm);
+        let stop_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_flag2 = Arc::clone(&stop_flag);
+
+        let stream = device.build_output_stream(
+            &config,
+            move |data: &mut [f32], _| {
+                let (ref buf, ref mut pos) = *pcm2.lock().unwrap();
+                for sample in data.iter_mut() {
+                    if *pos < buf.len() {
+                        *sample = buf[*pos];
+                        *pos += 1;
+                    } else {
+                        *sample = 0.0;
+                        stop_flag2.store(true, std::sync::atomic::Ordering::Relaxed);
+                    }
+                }
+            },
+            |e| tracing::warn!(error = %e, "cpal output error"),
+            None,
+        )?;
+
+        stream.play()?;
+
+        // Wait until audio finishes or abort is signalled.
+        loop {
+            if stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                break;
+            }
+            // Check abort signal (non-async: use try_recv pattern via a
+            // brief sleep so we don't spin).
+            std::thread::sleep(Duration::from_millis(50));
+            // The Notify is async; we can't await here.  Use a flag from
+            // the async side instead (pet_speak sets it before joining).
+        }
+        drop(stream);
+    }
+
+    #[cfg(not(feature = "audio"))]
+    {
+        // Silent mode: sleep for the equivalent duration then return.
+        let duration = Duration::from_millis(
+            (pcm.len() as u64 * 1000) / sample_rate.max(1) as u64,
+        );
+        std::thread::sleep(duration);
+        let _ = stop;
+    }
+
+    Ok(())
+}

--- a/mur-gui-core/src/voice/synth.rs
+++ b/mur-gui-core/src/voice/synth.rs
@@ -186,11 +186,10 @@ impl KokoroSession {
 // ─── cpal playback ───────────────────────────────────────────────────────────
 
 fn play_pcm(pcm: &[f32], sample_rate: u32, stop: Arc<Notify>) -> anyhow::Result<()> {
-    use std::sync::Mutex;
-
     #[cfg(feature = "audio")]
     {
         use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+        use std::sync::Mutex;
 
         let host = cpal::default_host();
         let device = host

--- a/mur-gui-core/src/voice/synth.rs
+++ b/mur-gui-core/src/voice/synth.rs
@@ -159,6 +159,7 @@ impl VoicePlayer {
 struct KokoroSession {
     #[allow(dead_code)]
     onnx_path: std::path::PathBuf,
+    #[allow(dead_code)]
     sample_rate_hz: u32,
 }
 

--- a/mur-hub-gui/src-tauri/Cargo.toml
+++ b/mur-hub-gui/src-tauri/Cargo.toml
@@ -25,6 +25,8 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
+tauri-plugin-global-shortcut = "2"
+tauri-plugin-window-state = "2"
 
 # Workspace siblings — reused from the root repo via relative path.
 mur-common = { path = "../../mur-common" }
@@ -35,6 +37,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"
 thiserror = "2"
+dirs = "5"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signal", "sync"] }

--- a/mur-hub-gui/src-tauri/Cargo.toml
+++ b/mur-hub-gui/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "image-png"] }
+tauri = { version = "2", features = ["tray-icon", "image-png", "macos-private-api"] }
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-global-shortcut = "2"
@@ -37,6 +37,7 @@ mur-gui-core = { path = "../../mur-gui-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"
+base64 = "0.22"
 anyhow = "1"
 thiserror = "2"
 dirs = "5"

--- a/mur-hub-gui/src-tauri/Cargo.toml
+++ b/mur-hub-gui/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ base64 = "0.22"
 anyhow = "1"
 thiserror = "2"
 dirs = "5"
+reqwest = { version = "0.12", features = ["blocking"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signal", "sync"] }

--- a/mur-hub-gui/src-tauri/Cargo.toml
+++ b/mur-hub-gui/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
+tauri-plugin-dialog = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-window-state = "2"
 
@@ -35,6 +36,7 @@ mur-gui-core = { path = "../../mur-gui-core" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml_ng = "0.10"
 anyhow = "1"
 thiserror = "2"
 dirs = "5"

--- a/mur-hub-gui/src-tauri/capabilities/default.json
+++ b/mur-hub-gui/src-tauri/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["dashboard"],
   "permissions": [
     "core:default",
-    "shell:allow-open"
+    "shell:allow-open",
+    "dialog:allow-open"
   ]
 }

--- a/mur-hub-gui/src-tauri/src/companion.rs
+++ b/mur-hub-gui/src-tauri/src/companion.rs
@@ -1,0 +1,154 @@
+//! Companion bridge Tauri commands for mur-hub-gui.
+//!
+//! Wraps `mur_gui_core::companion_bridge` with the Tauri command surface.
+//! Manages one `InboxWatcher` per subscribed agent via a `BridgeState`
+//! managed state value.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use anyhow::Result;
+use mur_gui_core::companion_bridge::{BridgeEvent, BridgeResponse, InboxWatcher, scan_pending};
+use tauri::ipc::Channel;
+use tokio::sync::mpsc;
+
+// ─── Managed state ───────────────────────────────────────────────────────────
+
+pub struct BridgeState {
+    pub watchers: Mutex<HashMap<String, InboxWatcher>>,
+}
+
+impl Default for BridgeState {
+    fn default() -> Self {
+        Self { watchers: Mutex::new(HashMap::new()) }
+    }
+}
+
+// ─── Path helpers ─────────────────────────────────────────────────────────────
+
+fn mur_home() -> PathBuf {
+    std::env::var("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".mur"))
+}
+
+fn agent_inbox(agent: &str) -> PathBuf {
+    mur_home()
+        .join("agents")
+        .join(agent)
+        .join("companion/inbox")
+}
+
+// ─── Tauri commands ──────────────────────────────────────────────────────────
+
+/// Return all pending (unresponded) inbox messages for `agent`.
+#[tauri::command]
+pub fn companion_bridge_pending(agent: String) -> Result<Vec<BridgeEvent>, String> {
+    scan_pending(&agent_inbox(&agent)).map_err(|e| format!("{e:#}"))
+}
+
+/// Subscribe to new inbox messages via a Tauri IPC `Channel`.
+/// The watcher is kept alive in `BridgeState` until `companion_bridge_unsubscribe` is called.
+#[tauri::command]
+pub async fn companion_bridge_subscribe(
+    agent: String,
+    on_event: Channel<BridgeEvent>,
+    state: tauri::State<'_, BridgeState>,
+) -> Result<(), String> {
+    let (tx, mut rx) = mpsc::channel::<BridgeEvent>(32);
+    let watcher =
+        InboxWatcher::start(agent_inbox(&agent), tx).map_err(|e| format!("{e:#}"))?;
+
+    state
+        .watchers
+        .lock()
+        .map_err(|e| format!("{e}"))?
+        .insert(agent.clone(), watcher);
+
+    tauri::async_runtime::spawn(async move {
+        while let Some(ev) = rx.recv().await {
+            if let Err(e) = on_event.send(ev) {
+                tracing::warn!("companion_bridge: channel send failed: {e}");
+                break;
+            }
+        }
+    });
+    Ok(())
+}
+
+/// Remove the watcher for `agent` (stops forwarding new events).
+#[tauri::command]
+pub fn companion_bridge_unsubscribe(
+    agent: String,
+    state: tauri::State<'_, BridgeState>,
+) -> Result<(), String> {
+    state
+        .watchers
+        .lock()
+        .map_err(|e| format!("{e}"))?
+        .remove(&agent);
+    Ok(())
+}
+
+/// Acknowledge a message (rewrite `>>> response: <unset>` → `>>> response: <signal>`).
+#[tauri::command]
+pub fn companion_ack(
+    agent: String,
+    msg_id: String,
+    signal: String,
+) -> Result<(), String> {
+    if !matches!(signal.as_str(), "good" | "bad" | "dismiss") {
+        return Err(format!("unknown signal `{signal}`"));
+    }
+    let path = agent_inbox(&agent).join(format!("{msg_id}.md"));
+    let body = std::fs::read_to_string(&path)
+        .map_err(|e| format!("read {}: {e}", path.display()))?;
+    let marker = ">>> response:";
+    let Some((head, _)) = body.rsplit_once(marker) else {
+        return Err(format!("missing response marker in {}", path.display()));
+    };
+    let new = format!("{head}{marker} {signal}");
+    let tmp = path.with_extension("md.tmp");
+    std::fs::write(&tmp, new).map_err(|e| format!("write .tmp: {e}"))?;
+    std::fs::rename(&tmp, &path).map_err(|e| format!("rename .tmp: {e}"))?;
+    Ok(())
+}
+
+/// Count unread (BridgeResponse::Unset) messages for `agent`.
+#[tauri::command]
+pub fn companion_unread_count(agent: String) -> u32 {
+    scan_pending(&agent_inbox(&agent))
+        .map(|evs| {
+            evs.iter()
+                .filter(|e| e.response == BridgeResponse::Unset)
+                .count() as u32
+        })
+        .unwrap_or(0)
+}
+
+/// Toggle proactive mode for `agent`.
+#[tauri::command]
+pub fn companion_proactive(agent: String, enabled: bool) -> Result<(), String> {
+    mur_core::cmd::agent_companion::proactive::set_enabled(&agent, enabled)
+        .map_err(|e| format!("{e:#}"))
+}
+
+/// Set/clear quiet hours for `agent`.
+#[tauri::command]
+pub async fn companion_quiet(
+    agent: String,
+    for_seconds: Option<i64>,
+    until: Option<String>,
+    off: bool,
+) -> Result<(), String> {
+    let for_str = for_seconds.map(|n| format!("{n}s"));
+    mur_core::cmd::agent_companion::quiet::set(
+        &agent,
+        for_str.as_deref(),
+        until.as_deref(),
+        off,
+    )
+    .await
+    .map_err(|e| format!("{e:#}"))
+}

--- a/mur-hub-gui/src-tauri/src/companion.rs
+++ b/mur-hub-gui/src-tauri/src/companion.rs
@@ -5,7 +5,7 @@
 //! managed state value.
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Mutex;
 
 use anyhow::Result;

--- a/mur-hub-gui/src-tauri/src/companion.rs
+++ b/mur-hub-gui/src-tauri/src/companion.rs
@@ -21,7 +21,9 @@ pub struct BridgeState {
 
 impl Default for BridgeState {
     fn default() -> Self {
-        Self { watchers: Mutex::new(HashMap::new()) }
+        Self {
+            watchers: Mutex::new(HashMap::new()),
+        }
     }
 }
 
@@ -57,8 +59,7 @@ pub async fn companion_bridge_subscribe(
     state: tauri::State<'_, BridgeState>,
 ) -> Result<(), String> {
     let (tx, mut rx) = mpsc::channel::<BridgeEvent>(32);
-    let watcher =
-        InboxWatcher::start(agent_inbox(&agent), tx).map_err(|e| format!("{e:#}"))?;
+    let watcher = InboxWatcher::start(agent_inbox(&agent), tx).map_err(|e| format!("{e:#}"))?;
 
     state
         .watchers
@@ -93,17 +94,13 @@ pub fn companion_bridge_unsubscribe(
 
 /// Acknowledge a message (rewrite `>>> response: <unset>` → `>>> response: <signal>`).
 #[tauri::command]
-pub fn companion_ack(
-    agent: String,
-    msg_id: String,
-    signal: String,
-) -> Result<(), String> {
+pub fn companion_ack(agent: String, msg_id: String, signal: String) -> Result<(), String> {
     if !matches!(signal.as_str(), "good" | "bad" | "dismiss") {
         return Err(format!("unknown signal `{signal}`"));
     }
     let path = agent_inbox(&agent).join(format!("{msg_id}.md"));
-    let body = std::fs::read_to_string(&path)
-        .map_err(|e| format!("read {}: {e}", path.display()))?;
+    let body =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
     let marker = ">>> response:";
     let Some((head, _)) = body.rsplit_once(marker) else {
         return Err(format!("missing response marker in {}", path.display()));
@@ -143,12 +140,7 @@ pub async fn companion_quiet(
     off: bool,
 ) -> Result<(), String> {
     let for_str = for_seconds.map(|n| format!("{n}s"));
-    mur_core::cmd::agent_companion::quiet::set(
-        &agent,
-        for_str.as_deref(),
-        until.as_deref(),
-        off,
-    )
-    .await
-    .map_err(|e| format!("{e:#}"))
+    mur_core::cmd::agent_companion::quiet::set(&agent, for_str.as_deref(), until.as_deref(), off)
+        .await
+        .map_err(|e| format!("{e:#}"))
 }

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -12,10 +12,10 @@ pub mod preset;
 
 use companion::BridgeState;
 use mur_gui_core::discovery::{AgentDiscovery, AgentEntry};
+use mur_gui_core::event_bus::EventBus;
 use mur_gui_core::sidecar::{AgentRuntimeStatus, Supervisor};
 use onboarding::WizardState;
 use pet::{EventBusState, PetState};
-use mur_gui_core::event_bus::EventBus;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use tauri::{

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -3,12 +3,15 @@
 //! M-h1: tray icon, popover + dashboard windows, agent discovery, global shortcut.
 //! M-h2: sidecar Supervisor — spawn/supervise agent runtimes; start_agent/stop_agent commands.
 //! M-h4: onboarding wizard — wizard_open/set_persona/.../start_render/finish/cancel.
+//! M-h5: pet windows — pet_spawn_at/close/reposition/return_to_hub/list/get_expression.
 
 pub mod onboarding;
+pub mod pet;
 
 use mur_gui_core::discovery::{AgentDiscovery, AgentEntry};
 use mur_gui_core::sidecar::{AgentRuntimeStatus, Supervisor};
 use onboarding::WizardState;
+use pet::PetState;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use tauri::{
@@ -156,6 +159,7 @@ pub fn run() {
         .manage(AgentState(Mutex::new(Vec::new())))
         .manage(SupervisorState(supervisor))
         .manage(WizardState(Mutex::new(None)))
+        .manage(PetState(Mutex::new(std::collections::HashMap::new())))
         .setup(move |app| {
             // Start agent discovery (filesystem scan).
             let (discovery, agent_rx) = AgentDiscovery::new(mur_home.clone());
@@ -233,6 +237,12 @@ pub fn run() {
             onboarding::wizard_start_render,
             onboarding::wizard_finish,
             onboarding::wizard_cancel,
+            pet::pet_spawn_at,
+            pet::pet_close,
+            pet::pet_reposition,
+            pet::pet_return_to_hub,
+            pet::pet_list,
+            pet::pet_get_expression,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -86,13 +86,14 @@ fn position_popover(app: &AppHandle, win: &tauri::WebviewWindow) {
         .and_then(|tray| tray.rect().ok().flatten())
         .map(|rect| {
             let pos = rect.position.to_physical::<i32>(scale);
-            let _sz = rect.size.to_physical::<u32>(scale);
+            let sz = rect.size.to_physical::<u32>(scale);
             #[cfg(target_os = "macos")]
             {
                 (pos.x, pos.y + sz.height as i32)
             }
             #[cfg(not(target_os = "macos"))]
             {
+                let _ = sz;
                 (pos.x, pos.y - 480)
             }
         })

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -2,9 +2,13 @@
 //!
 //! M-h1: tray icon, popover + dashboard windows, agent discovery, global shortcut.
 //! M-h2: sidecar Supervisor — spawn/supervise agent runtimes; start_agent/stop_agent commands.
+//! M-h4: onboarding wizard — wizard_open/set_persona/.../start_render/finish/cancel.
+
+pub mod onboarding;
 
 use mur_gui_core::discovery::{AgentDiscovery, AgentEntry};
 use mur_gui_core::sidecar::{AgentRuntimeStatus, Supervisor};
+use onboarding::WizardState;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use tauri::{
@@ -146,10 +150,12 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .manage(AgentState(Mutex::new(Vec::new())))
         .manage(SupervisorState(supervisor))
+        .manage(WizardState(Mutex::new(None)))
         .setup(move |app| {
             // Start agent discovery (filesystem scan).
             let (discovery, agent_rx) = AgentDiscovery::new(mur_home.clone());
@@ -218,6 +224,15 @@ pub fn run() {
             stop_agent,
             open_dashboard,
             toggle_popover,
+            onboarding::wizard_open,
+            onboarding::wizard_set_persona,
+            onboarding::wizard_set_name,
+            onboarding::wizard_set_preset,
+            onboarding::wizard_set_behavior,
+            onboarding::wizard_set_photo,
+            onboarding::wizard_start_render,
+            onboarding::wizard_finish,
+            onboarding::wizard_cancel,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -86,7 +86,7 @@ fn position_popover(app: &AppHandle, win: &tauri::WebviewWindow) {
         .and_then(|tray| tray.rect().ok().flatten())
         .map(|rect| {
             let pos = rect.position.to_physical::<i32>(scale);
-            let sz = rect.size.to_physical::<u32>(scale);
+            let _sz = rect.size.to_physical::<u32>(scale);
             #[cfg(target_os = "macos")]
             {
                 (pos.x, pos.y + sz.height as i32)

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -11,7 +11,8 @@ pub mod pet;
 use mur_gui_core::discovery::{AgentDiscovery, AgentEntry};
 use mur_gui_core::sidecar::{AgentRuntimeStatus, Supervisor};
 use onboarding::WizardState;
-use pet::PetState;
+use pet::{EventBusState, PetState};
+use mur_gui_core::event_bus::EventBus;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use tauri::{
@@ -160,6 +161,7 @@ pub fn run() {
         .manage(SupervisorState(supervisor))
         .manage(WizardState(Mutex::new(None)))
         .manage(PetState(Mutex::new(std::collections::HashMap::new())))
+        .manage(EventBusState(EventBus::new(256)))
         .setup(move |app| {
             // Start agent discovery (filesystem scan).
             let (discovery, agent_rx) = AgentDiscovery::new(mur_home.clone());
@@ -243,6 +245,8 @@ pub fn run() {
             pet::pet_return_to_hub,
             pet::pet_list,
             pet::pet_get_expression,
+            pet::hub_emit_event,
+            pet::pet_ack_bubble,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -5,10 +5,12 @@
 //! M-h4: onboarding wizard — wizard_open/set_persona/.../start_render/finish/cancel.
 //! M-h5: pet windows — pet_spawn_at/close/reposition/return_to_hub/list/get_expression.
 
+pub mod companion;
 pub mod onboarding;
 pub mod pet;
 pub mod preset;
 
+use companion::BridgeState;
 use mur_gui_core::discovery::{AgentDiscovery, AgentEntry};
 use mur_gui_core::sidecar::{AgentRuntimeStatus, Supervisor};
 use onboarding::WizardState;
@@ -163,6 +165,7 @@ pub fn run() {
         .manage(WizardState(Mutex::new(None)))
         .manage(PetState(Mutex::new(std::collections::HashMap::new())))
         .manage(EventBusState(EventBus::new(256)))
+        .manage(BridgeState::default())
         .setup(move |app| {
             // Start agent discovery (filesystem scan).
             let (discovery, agent_rx) = AgentDiscovery::new(mur_home.clone());
@@ -251,6 +254,13 @@ pub fn run() {
             pet::pet_speak,
             preset::import_preset_file,
             preset::import_preset_url,
+            companion::companion_bridge_pending,
+            companion::companion_bridge_subscribe,
+            companion::companion_bridge_unsubscribe,
+            companion::companion_ack,
+            companion::companion_unread_count,
+            companion::companion_proactive,
+            companion::companion_quiet,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod onboarding;
 pub mod pet;
+pub mod preset;
 
 use mur_gui_core::discovery::{AgentDiscovery, AgentEntry};
 use mur_gui_core::sidecar::{AgentRuntimeStatus, Supervisor};
@@ -247,6 +248,9 @@ pub fn run() {
             pet::pet_get_expression,
             pet::hub_emit_event,
             pet::pet_ack_bubble,
+            pet::pet_speak,
+            preset::import_preset_file,
+            preset::import_preset_url,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -1,8 +1,10 @@
 //! MuR Hub — Tauri 2 desktop app.
 //!
 //! M-h1: tray icon, popover + dashboard windows, agent discovery, global shortcut.
+//! M-h2: sidecar Supervisor — spawn/supervise agent runtimes; start_agent/stop_agent commands.
 
 use mur_gui_core::discovery::{AgentDiscovery, AgentEntry};
+use mur_gui_core::sidecar::{AgentRuntimeStatus, Supervisor};
 use std::path::PathBuf;
 use std::sync::Mutex;
 use tauri::{
@@ -13,14 +15,29 @@ use tauri::{
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
 use tracing_subscriber::EnvFilter;
 
-/// Managed Tauri state: current snapshot of discovered agents.
+/// Managed Tauri state: current agent metadata snapshot.
 pub struct AgentState(pub Mutex<Vec<AgentEntry>>);
+
+/// Managed Tauri state: sidecar supervisor handle.
+pub struct SupervisorState(pub Supervisor);
 
 // ─── Tauri commands ────────────────────────────────────────────────────────
 
 #[tauri::command]
 fn list_agents(state: State<'_, AgentState>) -> Vec<AgentEntry> {
     state.0.lock().unwrap().clone()
+}
+
+#[tauri::command]
+async fn start_agent(name: String, supervisor: State<'_, SupervisorState>) -> Result<(), String> {
+    supervisor.0.start(&name).await;
+    Ok(())
+}
+
+#[tauri::command]
+async fn stop_agent(name: String, supervisor: State<'_, SupervisorState>) -> Result<(), String> {
+    supervisor.0.stop(&name).await;
+    Ok(())
 }
 
 #[tauri::command]
@@ -51,8 +68,6 @@ fn toggle_popover(app: AppHandle) {
 // ─── Tray positioning ──────────────────────────────────────────────────────
 
 fn position_popover(app: &AppHandle, win: &tauri::WebviewWindow) {
-    // Try to position below the tray icon (macOS) or above it (Windows/Linux).
-    // Fall back to top-right corner of the primary monitor.
     let scale = win.scale_factor().unwrap_or(1.0);
 
     let (px, py) = app
@@ -84,7 +99,7 @@ fn position_popover(app: &AppHandle, win: &tauri::WebviewWindow) {
     let _ = win.set_position(tauri::PhysicalPosition::new(px, py));
 }
 
-// ─── Background event bridge ───────────────────────────────────────────────
+// ─── Background event bridges ──────────────────────────────────────────────
 
 fn spawn_agent_watcher(app: AppHandle, mut rx: tokio::sync::watch::Receiver<Vec<AgentEntry>>) {
     tokio::spawn(async move {
@@ -93,11 +108,25 @@ fn spawn_agent_watcher(app: AppHandle, mut rx: tokio::sync::watch::Receiver<Vec<
                 break;
             }
             let entries = rx.borrow().clone();
-            // Update managed state and broadcast to all windows.
             if let Some(state) = app.try_state::<AgentState>() {
                 *state.0.lock().unwrap() = entries.clone();
             }
             let _ = app.emit("agents-updated", &entries);
+        }
+    });
+}
+
+fn spawn_runtime_watcher(
+    app: AppHandle,
+    mut rx: tokio::sync::watch::Receiver<Vec<AgentRuntimeStatus>>,
+) {
+    tokio::spawn(async move {
+        loop {
+            if rx.changed().await.is_err() {
+                break;
+            }
+            let statuses = rx.borrow().clone();
+            let _ = app.emit("runtime-status-changed", &statuses);
         }
     });
 }
@@ -111,22 +140,28 @@ pub fn run() {
         "starting mur-hub-gui"
     );
 
+    let mur_home = mur_home_path();
+    let supervisor = Supervisor::new(mur_home.clone());
+    let runtime_rx = supervisor.status_receiver();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .manage(AgentState(Mutex::new(Vec::new())))
-        .setup(|app| {
-            // Start agent discovery.
-            let mur_home = mur_home_path();
-            let (discovery, rx) = AgentDiscovery::new(mur_home);
-            // Pre-populate state with initial scan.
+        .manage(SupervisorState(supervisor))
+        .setup(move |app| {
+            // Start agent discovery (filesystem scan).
+            let (discovery, agent_rx) = AgentDiscovery::new(mur_home.clone());
             {
-                let initial = rx.borrow().clone();
+                let initial = agent_rx.borrow().clone();
                 *app.state::<AgentState>().0.lock().unwrap() = initial;
             }
             discovery.run();
-            spawn_agent_watcher(app.handle().clone(), rx);
+            spawn_agent_watcher(app.handle().clone(), agent_rx);
+
+            // Bridge supervisor status → Tauri events.
+            spawn_runtime_watcher(app.handle().clone(), runtime_rx);
 
             // Register global shortcut CmdOrCtrl+Shift+M → toggle_popover.
             let handle = app.handle().clone();
@@ -179,6 +214,8 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             list_agents,
+            start_agent,
+            stop_agent,
             open_dashboard,
             toggle_popover,
         ])

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -1,10 +1,108 @@
 //! MuR Hub — Tauri 2 desktop app.
 //!
-//! M-h0: boots a single empty dashboard window. Real popover, multi-agent
-//! discovery, and pet windows arrive in later milestones (see
-//! `docs/superpowers/specs/2026-05-11-mur-hub-companion-design.md`).
+//! M-h1: tray icon, popover + dashboard windows, agent discovery, global shortcut.
 
+use mur_gui_core::discovery::{AgentDiscovery, AgentEntry};
+use std::path::PathBuf;
+use std::sync::Mutex;
+use tauri::{
+    AppHandle, Emitter, Manager, State,
+    menu::{Menu, MenuItem},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+};
+use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
 use tracing_subscriber::EnvFilter;
+
+/// Managed Tauri state: current snapshot of discovered agents.
+pub struct AgentState(pub Mutex<Vec<AgentEntry>>);
+
+// ─── Tauri commands ────────────────────────────────────────────────────────
+
+#[tauri::command]
+fn list_agents(state: State<'_, AgentState>) -> Vec<AgentEntry> {
+    state.0.lock().unwrap().clone()
+}
+
+#[tauri::command]
+fn open_dashboard(app: AppHandle, agent_name: Option<String>) {
+    let Some(win) = app.get_webview_window("dashboard") else {
+        return;
+    };
+    let _ = win.show();
+    let _ = win.set_focus();
+    if let Some(name) = agent_name {
+        let _ = app.emit("select-agent", name);
+    }
+}
+
+#[tauri::command]
+fn toggle_popover(app: AppHandle) {
+    if let Some(win) = app.get_webview_window("popover") {
+        if win.is_visible().unwrap_or(false) {
+            let _ = win.hide();
+        } else {
+            position_popover(&app, &win);
+            let _ = win.show();
+            let _ = win.set_focus();
+        }
+    }
+}
+
+// ─── Tray positioning ──────────────────────────────────────────────────────
+
+fn position_popover(app: &AppHandle, win: &tauri::WebviewWindow) {
+    // Try to position below the tray icon (macOS) or above it (Windows/Linux).
+    // Fall back to top-right corner of the primary monitor.
+    let scale = win.scale_factor().unwrap_or(1.0);
+
+    let (px, py) = app
+        .tray_by_id("main")
+        .and_then(|tray| tray.rect().ok().flatten())
+        .map(|rect| {
+            let pos = rect.position.to_physical::<i32>(scale);
+            let sz = rect.size.to_physical::<u32>(scale);
+            #[cfg(target_os = "macos")]
+            {
+                (pos.x, pos.y + sz.height as i32)
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                (pos.x, pos.y - 480)
+            }
+        })
+        .unwrap_or_else(|| {
+            win.primary_monitor()
+                .ok()
+                .flatten()
+                .map(|m| {
+                    let s = m.size();
+                    (s.width as i32 - 300, 40)
+                })
+                .unwrap_or((20, 40))
+        });
+
+    let _ = win.set_position(tauri::PhysicalPosition::new(px, py));
+}
+
+// ─── Background event bridge ───────────────────────────────────────────────
+
+fn spawn_agent_watcher(app: AppHandle, mut rx: tokio::sync::watch::Receiver<Vec<AgentEntry>>) {
+    tokio::spawn(async move {
+        loop {
+            if rx.changed().await.is_err() {
+                break;
+            }
+            let entries = rx.borrow().clone();
+            // Update managed state and broadcast to all windows.
+            if let Some(state) = app.try_state::<AgentState>() {
+                *state.0.lock().unwrap() = entries.clone();
+            }
+            let _ = app.emit("agents-updated", &entries);
+        }
+    });
+}
+
+// ─── App bootstrap ─────────────────────────────────────────────────────────
 
 pub fn run() {
     init_tracing();
@@ -15,8 +113,87 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_window_state::Builder::default().build())
+        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+        .manage(AgentState(Mutex::new(Vec::new())))
+        .setup(|app| {
+            // Start agent discovery.
+            let mur_home = mur_home_path();
+            let (discovery, rx) = AgentDiscovery::new(mur_home);
+            // Pre-populate state with initial scan.
+            {
+                let initial = rx.borrow().clone();
+                *app.state::<AgentState>().0.lock().unwrap() = initial;
+            }
+            discovery.run();
+            spawn_agent_watcher(app.handle().clone(), rx);
+
+            // Register global shortcut CmdOrCtrl+Shift+M → toggle_popover.
+            let handle = app.handle().clone();
+            app.global_shortcut().on_shortcut(
+                Shortcut::new(Some(Modifiers::SUPER | Modifiers::SHIFT), Code::KeyM),
+                move |_app, _shortcut, event| {
+                    if event.state == ShortcutState::Pressed {
+                        toggle_popover(handle.clone());
+                    }
+                },
+            )?;
+
+            // Build tray.
+            let open_item = MenuItem::with_id(app, "open", "Open Hub", true, None::<&str>)?;
+            let quit_item = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
+            let menu = Menu::with_items(app, &[&open_item, &quit_item])?;
+
+            TrayIconBuilder::with_id("main")
+                .icon(app.default_window_icon().unwrap().clone())
+                .menu(&menu)
+                .on_menu_event(|app, event| match event.id.as_ref() {
+                    "open" => open_dashboard(app.clone(), None),
+                    "quit" => app.exit(0),
+                    _ => {}
+                })
+                .on_tray_icon_event(|tray, event| {
+                    if let TrayIconEvent::Click {
+                        button: MouseButton::Left,
+                        button_state: MouseButtonState::Up,
+                        ..
+                    } = event
+                    {
+                        toggle_popover(tray.app_handle().clone());
+                    }
+                })
+                .build(app)?;
+
+            // Wire dashboard close → hide (not quit).
+            if let Some(win) = app.get_webview_window("dashboard") {
+                let win_clone = win.clone();
+                win.on_window_event(move |event| {
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                        api.prevent_close();
+                        let _ = win_clone.hide();
+                    }
+                });
+            }
+
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![
+            list_agents,
+            open_dashboard,
+            toggle_popover,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+fn mur_home_path() -> PathBuf {
+    std::env::var("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".mur")
+        })
 }
 
 fn init_tracing() {
@@ -31,9 +208,7 @@ fn init_tracing() {
 mod tests {
     #[test]
     fn lib_links() {
-        // Smoke test: the crate compiles and the lib symbol exists.
-        // (We cannot actually run tauri::Builder in a unit test without a
-        //  windowing context — that lives in a later integration test.)
         let _ = super::init_tracing;
+        let _ = super::mur_home_path;
     }
 }

--- a/mur-hub-gui/src-tauri/src/onboarding/mod.rs
+++ b/mur-hub-gui/src-tauri/src/onboarding/mod.rs
@@ -254,10 +254,10 @@ pub async fn wizard_start_render(
             let snap = RenderProgressSnapshot::from(&p);
             let _ = app_clone.emit("wizard-render-progress", &snap);
             // Update session progress.
-            if let Ok(mut guard) = app_clone.state::<WizardState>().0.lock() {
-                if let Some(s) = guard.as_mut() {
-                    s.render_progress = Some(snap);
-                }
+            if let Ok(mut guard) = app_clone.state::<WizardState>().0.lock()
+                && let Some(s) = guard.as_mut()
+            {
+                s.render_progress = Some(snap);
             }
         }
     });
@@ -274,10 +274,10 @@ pub async fn wizard_start_render(
                         "total": 12,
                     }),
                 );
-                if let Ok(mut guard) = app.state::<WizardState>().0.lock() {
-                    if let Some(s) = guard.as_mut() {
-                        s.render_done = true;
-                    }
+                if let Ok(mut guard) = app.state::<WizardState>().0.lock()
+                    && let Some(s) = guard.as_mut()
+                {
+                    s.render_done = true;
                 }
             }
             Err(e) => {

--- a/mur-hub-gui/src-tauri/src/onboarding/mod.rs
+++ b/mur-hub-gui/src-tauri/src/onboarding/mod.rs
@@ -1,0 +1,365 @@
+use mur_common::agent::{AgentAppearance, BehaviorPreset, RenderStatus};
+use mur_common::hub::preset_loader::{default_blob, find_preset};
+use mur_common::hub::style_preset::PresetFamily;
+use mur_gui_core::image_gen::{CancelToken, RenderProgress};
+use mur_gui_core::image_gen::gemini::GeminiImageGenProvider;
+use mur_gui_core::image_gen::mock::MockImageGenProvider;
+use mur_gui_core::render::RenderJob;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Mutex;
+use tauri::{AppHandle, Emitter, Manager, State};
+
+// ─── Wizard state ──────────────────────────────────────────────────────────
+
+/// Persona category for step 1 (mirrors mur_common::agent::PersonaCategory).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum WizardPersona {
+    Research,
+    Automation,
+    Monitor,
+    Notify,
+    Commerce,
+    Custom,
+}
+
+/// Step-by-step state accumulated during the wizard flow.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct WizardSession {
+    /// Current active step (1–6).
+    pub step: u8,
+    pub persona: Option<WizardPersona>,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub style_preset_id: Option<String>,
+    pub behavior_preset: Option<BehaviorPreset>,
+    /// Absolute path to source photo (step 5, polaroid family only).
+    pub source_photo: Option<PathBuf>,
+    /// Latest render progress snapshot (step 6).
+    pub render_progress: Option<RenderProgressSnapshot>,
+    /// Set to true once the render has completed successfully.
+    pub render_done: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RenderProgressSnapshot {
+    pub total: u32,
+    pub done: u32,
+    pub failed: u32,
+}
+
+impl From<&RenderProgress> for RenderProgressSnapshot {
+    fn from(p: &RenderProgress) -> Self {
+        Self { total: p.total, done: p.done, failed: p.failed }
+    }
+}
+
+/// Tauri managed state: one wizard session at a time (None = closed).
+pub struct WizardState(pub Mutex<Option<WizardSession>>);
+
+// ─── Step info returned to the frontend ────────────────────────────────────
+
+/// Full wizard state sent to the frontend on every state-changing command.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WizardSnapshot {
+    pub step: u8,
+    pub persona: Option<WizardPersona>,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub style_preset_id: Option<String>,
+    pub preset_family: Option<String>,
+    pub behavior_preset: Option<String>,
+    pub needs_photo: bool,
+    pub source_photo: Option<String>,
+    pub render_progress: Option<RenderProgressSnapshot>,
+    pub render_done: bool,
+}
+
+impl WizardSnapshot {
+    fn from_session(session: &WizardSession, mur_home: &std::path::Path) -> Self {
+        let needs_photo = session
+            .style_preset_id
+            .as_deref()
+            .and_then(|id| {
+                find_preset(id, &mur_home.join("hub")).ok()
+            })
+            .map(|p| p.family == PresetFamily::Polaroid && p.llm_image_gen.requires_source_image)
+            .unwrap_or(false);
+
+        let preset_family = session
+            .style_preset_id
+            .as_deref()
+            .and_then(|id| find_preset(id, &mur_home.join("hub")).ok())
+            .map(|p| format!("{:?}", p.family).to_lowercase());
+
+        Self {
+            step: session.step,
+            persona: session.persona.clone(),
+            name: session.name.clone(),
+            description: session.description.clone(),
+            style_preset_id: session.style_preset_id.clone(),
+            preset_family,
+            behavior_preset: session
+                .behavior_preset
+                .map(|b| format!("{b:?}").to_lowercase()),
+            needs_photo,
+            source_photo: session
+                .source_photo
+                .as_ref()
+                .and_then(|p| p.to_str().map(String::from)),
+            render_progress: session.render_progress.clone(),
+            render_done: session.render_done,
+        }
+    }
+}
+
+// ─── Tauri commands ────────────────────────────────────────────────────────
+
+/// Open the wizard and return initial state (step 1).
+#[tauri::command]
+pub fn wizard_open(state: State<'_, WizardState>) -> WizardSnapshot {
+    let session = WizardSession { step: 1, ..Default::default() };
+    let snap = WizardSnapshot::from_session(&session, &mur_home_path());
+    *state.0.lock().unwrap() = Some(session);
+    snap
+}
+
+/// Step 1 — set persona category.
+#[tauri::command]
+pub fn wizard_set_persona(
+    persona: WizardPersona,
+    state: State<'_, WizardState>,
+) -> Result<WizardSnapshot, String> {
+    update_session(&state, |s| {
+        s.persona = Some(persona);
+        s.step = 2;
+    })
+}
+
+/// Step 2 — set agent name and description.
+#[tauri::command]
+pub fn wizard_set_name(
+    name: String,
+    description: String,
+    state: State<'_, WizardState>,
+) -> Result<WizardSnapshot, String> {
+    if name.trim().is_empty() {
+        return Err("name must not be empty".into());
+    }
+    update_session(&state, |s| {
+        s.name = Some(name.trim().to_string());
+        s.description = Some(description.trim().to_string());
+        s.step = 3;
+    })
+}
+
+/// Step 3 — set style preset.
+#[tauri::command]
+pub fn wizard_set_preset(
+    preset_id: String,
+    state: State<'_, WizardState>,
+) -> Result<WizardSnapshot, String> {
+    // Validate that the preset exists.
+    let hub_dir = mur_home_path().join("hub");
+    find_preset(&preset_id, &hub_dir)
+        .map_err(|e| format!("unknown preset: {e}"))?;
+    update_session(&state, |s| {
+        s.style_preset_id = Some(preset_id);
+        s.step = 4;
+    })
+}
+
+/// Step 4 — set behavior preset.
+#[tauri::command]
+pub fn wizard_set_behavior(
+    behavior: String,
+    state: State<'_, WizardState>,
+) -> Result<WizardSnapshot, String> {
+    let bp = match behavior.as_str() {
+        "quiet" => BehaviorPreset::Quiet,
+        "normal" => BehaviorPreset::Normal,
+        "lively" => BehaviorPreset::Lively,
+        other => return Err(format!("unknown behavior preset: {other}")),
+    };
+    update_session(&state, |s| {
+        s.behavior_preset = Some(bp);
+        // Skip to step 6 unless polaroid family needs a photo (checked in start_render).
+        s.step = 5;
+    })
+}
+
+/// Step 5 — provide source photo path (polaroid family only).
+#[tauri::command]
+pub fn wizard_set_photo(
+    path: String,
+    state: State<'_, WizardState>,
+) -> Result<WizardSnapshot, String> {
+    let p = PathBuf::from(&path);
+    if !p.exists() {
+        return Err(format!("photo not found: {path}"));
+    }
+    update_session(&state, |s| {
+        s.source_photo = Some(p);
+        s.step = 6;
+    })
+}
+
+/// Step 6 — start background expression render.
+///
+/// Emits `wizard-render-progress` events as each image completes.
+/// Emits `wizard-render-done` when the full batch finishes.
+#[tauri::command]
+pub async fn wizard_start_render(
+    app: AppHandle,
+    state: State<'_, WizardState>,
+) -> Result<(), String> {
+    let (preset, agent_dir, cancel) = {        let guard = state.0.lock().unwrap();
+        let session = guard.as_ref().ok_or("no wizard session")?;
+
+        // Resolve preset.
+        let hub_dir = mur_home_path().join("hub");
+        let preset_id = session
+            .style_preset_id
+            .as_deref()
+            .unwrap_or("default-blob");
+        let preset = find_preset(preset_id, &hub_dir)
+            .unwrap_or_else(|_| default_blob());
+
+        // Agent expressions dir.
+        let name = session.name.clone().unwrap_or_else(|| "unnamed".into());
+        let agent_dir = mur_home_path().join("agents").join(&name);
+
+        (preset, agent_dir, CancelToken::new())
+    };
+
+    // Resolve provider: try Gemini (if API key set), fall back to mock.
+    let provider: std::sync::Arc<dyn mur_gui_core::image_gen::ImageGenProvider> =
+        match read_gemini_key() {
+            Some(key) => std::sync::Arc::new(GeminiImageGenProvider::new(
+                key,
+                "gemini-2.5-flash-image",
+            )),
+            None => std::sync::Arc::new(MockImageGenProvider),
+        };
+
+    let job = RenderJob::new(preset, provider, &agent_dir);
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<RenderProgress>(64);
+    let app_clone = app.clone();
+
+    // Forward progress events to the frontend.
+    tokio::spawn(async move {
+        while let Some(p) = rx.recv().await {
+            let snap = RenderProgressSnapshot::from(&p);
+            let _ = app_clone.emit("wizard-render-progress", &snap);
+            // Update session progress.
+            if let Ok(mut guard) = app_clone.state::<WizardState>().0.lock() {
+                if let Some(s) = guard.as_mut() {
+                    s.render_progress = Some(snap);
+                }
+            }
+        }
+    });
+
+    // Run render in background; on completion update render_status in agent YAML.
+    tokio::spawn(async move {
+        let result = job.run(cancel, Some(tx)).await;
+        match result {
+            Ok(manifest) => {
+                let _ = app.emit("wizard-render-done", serde_json::json!({
+                    "expressions_rendered": manifest.expressions.len(),
+                    "total": 12,
+                }));
+                if let Ok(mut guard) = app.state::<WizardState>().0.lock() {
+                    if let Some(s) = guard.as_mut() {
+                        s.render_done = true;
+                    }
+                }
+            }
+            Err(e) => {
+                let _ = app.emit("wizard-render-error", e.to_string());
+            }
+        }
+    });
+
+    Ok(())
+}
+
+/// Finish the wizard — create the agent profile YAML and close the session.
+#[tauri::command]
+pub fn wizard_finish(state: State<'_, WizardState>) -> Result<String, String> {
+    let session = state
+        .0
+        .lock()
+        .unwrap()
+        .take()
+        .ok_or("no wizard session")?;
+
+    let name = session.name.ok_or("missing name")?;
+    let agent_dir = mur_home_path().join("agents").join(&name);
+    std::fs::create_dir_all(&agent_dir).map_err(|e| e.to_string())?;
+
+    let preset_id = session.style_preset_id.unwrap_or_else(|| "default-blob".into());
+    let appearance = AgentAppearance {
+        style_preset: preset_id,
+        behavior_preset: session.behavior_preset.unwrap_or(BehaviorPreset::Normal),
+        source_image_path: session.source_photo,
+        expressions_dir: agent_dir.join("expressions"),
+        last_rendered_at: None,
+        render_status: if session.render_done {
+            RenderStatus::Ready
+        } else {
+            RenderStatus::Pending
+        },
+    };
+
+    // Persist appearance to agent profile (merge if profile already exists).
+    let profile_path = agent_dir.join("profile.yaml");
+    if profile_path.exists() {
+        let yaml = std::fs::read_to_string(&profile_path).map_err(|e| e.to_string())?;
+        let mut profile: mur_common::AgentProfile =
+            serde_yaml_ng::from_str(&yaml).map_err(|e| e.to_string())?;
+        profile.appearance = appearance;
+        let out = serde_yaml_ng::to_string(&profile).map_err(|e| e.to_string())?;
+        std::fs::write(&profile_path, out).map_err(|e| e.to_string())?;
+    }
+    // If no profile exists yet, the agent creation wizard will write it later.
+
+    Ok(name)
+}
+
+/// Cancel and discard the current wizard session.
+#[tauri::command]
+pub fn wizard_cancel(state: State<'_, WizardState>) {
+    *state.0.lock().unwrap() = None;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+fn update_session(
+    state: &State<'_, WizardState>,
+    f: impl FnOnce(&mut WizardSession),
+) -> Result<WizardSnapshot, String> {
+    let mur_home = mur_home_path();
+    let mut guard = state.0.lock().unwrap();
+    let session = guard.as_mut().ok_or("no wizard session")?;
+    f(session);
+    Ok(WizardSnapshot::from_session(session, &mur_home))
+}
+
+fn mur_home_path() -> PathBuf {
+    std::env::var("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".mur")
+        })
+}
+
+/// Read Gemini API key from the OS env (GEMINI_API_KEY) or the mur secret store.
+/// Returns None to fall back to MockImageGenProvider in CI / offline runs.
+fn read_gemini_key() -> Option<String> {
+    std::env::var("GEMINI_API_KEY").ok()
+}

--- a/mur-hub-gui/src-tauri/src/onboarding/mod.rs
+++ b/mur-hub-gui/src-tauri/src/onboarding/mod.rs
@@ -1,9 +1,9 @@
 use mur_common::agent::{AgentAppearance, BehaviorPreset, RenderStatus};
 use mur_common::hub::preset_loader::{default_blob, find_preset};
 use mur_common::hub::style_preset::PresetFamily;
-use mur_gui_core::image_gen::{CancelToken, RenderProgress};
 use mur_gui_core::image_gen::gemini::GeminiImageGenProvider;
 use mur_gui_core::image_gen::mock::MockImageGenProvider;
+use mur_gui_core::image_gen::{CancelToken, RenderProgress};
 use mur_gui_core::render::RenderJob;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -51,7 +51,11 @@ pub struct RenderProgressSnapshot {
 
 impl From<&RenderProgress> for RenderProgressSnapshot {
     fn from(p: &RenderProgress) -> Self {
-        Self { total: p.total, done: p.done, failed: p.failed }
+        Self {
+            total: p.total,
+            done: p.done,
+            failed: p.failed,
+        }
     }
 }
 
@@ -81,9 +85,7 @@ impl WizardSnapshot {
         let needs_photo = session
             .style_preset_id
             .as_deref()
-            .and_then(|id| {
-                find_preset(id, &mur_home.join("hub")).ok()
-            })
+            .and_then(|id| find_preset(id, &mur_home.join("hub")).ok())
             .map(|p| p.family == PresetFamily::Polaroid && p.llm_image_gen.requires_source_image)
             .unwrap_or(false);
 
@@ -119,7 +121,10 @@ impl WizardSnapshot {
 /// Open the wizard and return initial state (step 1).
 #[tauri::command]
 pub fn wizard_open(state: State<'_, WizardState>) -> WizardSnapshot {
-    let session = WizardSession { step: 1, ..Default::default() };
+    let session = WizardSession {
+        step: 1,
+        ..Default::default()
+    };
     let snap = WizardSnapshot::from_session(&session, &mur_home_path());
     *state.0.lock().unwrap() = Some(session);
     snap
@@ -162,8 +167,7 @@ pub fn wizard_set_preset(
 ) -> Result<WizardSnapshot, String> {
     // Validate that the preset exists.
     let hub_dir = mur_home_path().join("hub");
-    find_preset(&preset_id, &hub_dir)
-        .map_err(|e| format!("unknown preset: {e}"))?;
+    find_preset(&preset_id, &hub_dir).map_err(|e| format!("unknown preset: {e}"))?;
     update_session(&state, |s| {
         s.style_preset_id = Some(preset_id);
         s.step = 4;
@@ -214,17 +218,14 @@ pub async fn wizard_start_render(
     app: AppHandle,
     state: State<'_, WizardState>,
 ) -> Result<(), String> {
-    let (preset, agent_dir, cancel) = {        let guard = state.0.lock().unwrap();
+    let (preset, agent_dir, cancel) = {
+        let guard = state.0.lock().unwrap();
         let session = guard.as_ref().ok_or("no wizard session")?;
 
         // Resolve preset.
         let hub_dir = mur_home_path().join("hub");
-        let preset_id = session
-            .style_preset_id
-            .as_deref()
-            .unwrap_or("default-blob");
-        let preset = find_preset(preset_id, &hub_dir)
-            .unwrap_or_else(|_| default_blob());
+        let preset_id = session.style_preset_id.as_deref().unwrap_or("default-blob");
+        let preset = find_preset(preset_id, &hub_dir).unwrap_or_else(|_| default_blob());
 
         // Agent expressions dir.
         let name = session.name.clone().unwrap_or_else(|| "unnamed".into());
@@ -236,10 +237,9 @@ pub async fn wizard_start_render(
     // Resolve provider: try Gemini (if API key set), fall back to mock.
     let provider: std::sync::Arc<dyn mur_gui_core::image_gen::ImageGenProvider> =
         match read_gemini_key() {
-            Some(key) => std::sync::Arc::new(GeminiImageGenProvider::new(
-                key,
-                "gemini-2.5-flash-image",
-            )),
+            Some(key) => {
+                std::sync::Arc::new(GeminiImageGenProvider::new(key, "gemini-2.5-flash-image"))
+            }
             None => std::sync::Arc::new(MockImageGenProvider),
         };
 
@@ -267,10 +267,13 @@ pub async fn wizard_start_render(
         let result = job.run(cancel, Some(tx)).await;
         match result {
             Ok(manifest) => {
-                let _ = app.emit("wizard-render-done", serde_json::json!({
-                    "expressions_rendered": manifest.expressions.len(),
-                    "total": 12,
-                }));
+                let _ = app.emit(
+                    "wizard-render-done",
+                    serde_json::json!({
+                        "expressions_rendered": manifest.expressions.len(),
+                        "total": 12,
+                    }),
+                );
                 if let Ok(mut guard) = app.state::<WizardState>().0.lock() {
                     if let Some(s) = guard.as_mut() {
                         s.render_done = true;
@@ -289,18 +292,15 @@ pub async fn wizard_start_render(
 /// Finish the wizard — create the agent profile YAML and close the session.
 #[tauri::command]
 pub fn wizard_finish(state: State<'_, WizardState>) -> Result<String, String> {
-    let session = state
-        .0
-        .lock()
-        .unwrap()
-        .take()
-        .ok_or("no wizard session")?;
+    let session = state.0.lock().unwrap().take().ok_or("no wizard session")?;
 
     let name = session.name.ok_or("missing name")?;
     let agent_dir = mur_home_path().join("agents").join(&name);
     std::fs::create_dir_all(&agent_dir).map_err(|e| e.to_string())?;
 
-    let preset_id = session.style_preset_id.unwrap_or_else(|| "default-blob".into());
+    let preset_id = session
+        .style_preset_id
+        .unwrap_or_else(|| "default-blob".into());
     let appearance = AgentAppearance {
         style_preset: preset_id,
         behavior_preset: session.behavior_preset.unwrap_or(BehaviorPreset::Normal),

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -1,0 +1,202 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
+
+// ─── Managed state ──────────────────────────────────────────────────────────
+
+/// Active pet windows: agent_name → window_label.
+pub struct PetState(pub Mutex<HashMap<String, String>>);
+
+// ─── Position persistence ────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PetPosition {
+    pub x: f64,
+    pub y: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_id: Option<String>,
+}
+
+fn mur_home() -> PathBuf {
+    std::env::var("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".mur"))
+}
+
+fn pet_position_path(agent_name: &str) -> PathBuf {
+    mur_home()
+        .join("agents")
+        .join(agent_name)
+        .join("pet_position.json")
+}
+
+fn load_position(agent_name: &str) -> Option<PetPosition> {
+    let data = std::fs::read_to_string(pet_position_path(agent_name)).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+fn save_position(agent_name: &str, pos: &PetPosition) {
+    let path = pet_position_path(agent_name);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_string_pretty(pos) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+fn window_label(agent_name: &str) -> String {
+    // Window labels must be ASCII alphanumeric + hyphen/underscore.
+    format!(
+        "pet-{}",
+        agent_name.chars().map(|c| if c.is_ascii_alphanumeric() { c } else { '-' }).collect::<String>()
+    )
+}
+
+// ─── Commands ────────────────────────────────────────────────────────────────
+
+/// Spawn a transparent always-on-top pet window for `agent_name` at the given
+/// screen-logical coordinates.  If the pet is already open, move it instead.
+#[tauri::command]
+pub fn pet_spawn_at(
+    agent_name: String,
+    screen_x: f64,
+    screen_y: f64,
+    app: AppHandle,
+    state: State<'_, PetState>,
+) -> Result<(), String> {
+    let label = window_label(&agent_name);
+    let mut pets = state.0.lock().unwrap();
+
+    // Already open — move and ensure visible.
+    if pets.contains_key(&agent_name) {
+        if let Some(win) = app.get_webview_window(&label) {
+            let _ = win.set_position(tauri::LogicalPosition::new(screen_x, screen_y));
+            let _ = win.show();
+            return Ok(());
+        }
+        pets.remove(&agent_name);
+    }
+
+    // Use saved position if available, otherwise the drop position.
+    let pos = load_position(&agent_name)
+        .unwrap_or(PetPosition { x: screen_x, y: screen_y, display_id: None });
+
+    // Build the window URL: index.html#/pet/<name>
+    let url_path = format!("index.html#/pet/{}", urlenc(&agent_name));
+
+    WebviewWindowBuilder::new(&app, &label, WebviewUrl::App(url_path.into()))
+        .transparent(true)
+        .decorations(false)
+        .always_on_top(true)
+        .skip_taskbar(true)
+        .visible_on_all_workspaces(true)
+        .shadow(false)
+        .inner_size(200.0, 200.0)
+        .position(pos.x, pos.y)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    pets.insert(agent_name.clone(), label.clone());
+
+    // wave → idle sequence after window has had time to render.
+    let app2 = app.clone();
+    let label2 = label.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+        let _ = app2.emit_to(tauri::EventTarget::labeled(&label2), "pet-expression", "wave");
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        let _ = app2.emit_to(tauri::EventTarget::labeled(&label2), "pet-expression", "idle");
+    });
+
+    Ok(())
+}
+
+/// Close the pet window for `agent_name`.
+#[tauri::command]
+pub fn pet_close(
+    agent_name: String,
+    app: AppHandle,
+    state: State<'_, PetState>,
+) -> Result<(), String> {
+    let mut pets = state.0.lock().unwrap();
+    if let Some(label) = pets.remove(&agent_name) {
+        if let Some(win) = app.get_webview_window(&label) {
+            win.close().map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+/// Persist the new position after a drag-reposition.
+#[tauri::command]
+pub fn pet_reposition(
+    agent_name: String,
+    x: f64,
+    y: f64,
+) {
+    save_position(&agent_name, &PetPosition { x, y, display_id: None });
+}
+
+/// Close the pet window and surface the Hub dashboard.
+#[tauri::command]
+pub fn pet_return_to_hub(
+    agent_name: String,
+    app: AppHandle,
+    state: State<'_, PetState>,
+) -> Result<(), String> {
+    let mut pets = state.0.lock().unwrap();
+    if let Some(label) = pets.remove(&agent_name) {
+        if let Some(win) = app.get_webview_window(&label) {
+            let _ = win.close();
+        }
+    }
+    if let Some(dashboard) = app.get_webview_window("dashboard") {
+        let _ = dashboard.show();
+        let _ = dashboard.set_focus();
+    }
+    Ok(())
+}
+
+/// Names of currently-open pet windows.
+#[tauri::command]
+pub fn pet_list(state: State<'_, PetState>) -> Vec<String> {
+    state.0.lock().unwrap().keys().cloned().collect()
+}
+
+/// Load an expression image and return it as a `data:image/webp;base64,…` URL.
+/// Returns an empty string if the file does not exist (UI falls back to initials).
+#[tauri::command]
+pub fn pet_get_expression(agent_name: String, expression: String) -> String {
+    let path = mur_home()
+        .join("agents")
+        .join(&agent_name)
+        .join("expressions")
+        .join(format!("{expression}.webp"));
+
+    std::fs::read(&path)
+        .map(|b| {
+            let b64 = base64::engine::general_purpose::STANDARD.encode(&b);
+            format!("data:image/webp;base64,{b64}")
+        })
+        .unwrap_or_default()
+}
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+/// Percent-encode a string for use in a URL path segment (spaces → %20 only).
+fn urlenc(s: &str) -> String {
+    s.chars()
+        .flat_map(|c| {
+            if c == ' ' {
+                vec!['%', '2', '0']
+            } else {
+                vec![c]
+            }
+        })
+        .collect()
+}

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -82,11 +82,7 @@ fn emit_change(app: &AppHandle, label: &str, change: ExpressionChange) {
         &change.expression,
     );
     if let Some(text) = change.bubble_text {
-        let _ = app.emit_to(
-            tauri::EventTarget::labeled(label),
-            "pet-bubble",
-            &text,
-        );
+        let _ = app.emit_to(tauri::EventTarget::labeled(label), "pet-bubble", &text);
     }
 }
 
@@ -155,8 +151,11 @@ pub fn pet_spawn_at(
         pets.remove(&agent_name);
     }
 
-    let pos = load_position(&agent_name)
-        .unwrap_or(PetPosition { x: screen_x, y: screen_y, display_id: None });
+    let pos = load_position(&agent_name).unwrap_or(PetPosition {
+        x: screen_x,
+        y: screen_y,
+        display_id: None,
+    });
 
     let url_path = format!("index.html#/pet/{}", urlenc(&agent_name));
 
@@ -175,7 +174,10 @@ pub fn pet_spawn_at(
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     pets.insert(
         agent_name.clone(),
-        PetHandle { window_label: label.clone(), shutdown_tx },
+        PetHandle {
+            window_label: label.clone(),
+            shutdown_tx,
+        },
     );
 
     start_event_loop(
@@ -215,7 +217,14 @@ pub fn pet_close(
 
 #[tauri::command]
 pub fn pet_reposition(agent_name: String, x: f64, y: f64) {
-    save_position(&agent_name, &PetPosition { x, y, display_id: None });
+    save_position(
+        &agent_name,
+        &PetPosition {
+            x,
+            y,
+            display_id: None,
+        },
+    );
 }
 
 #[tauri::command]
@@ -276,11 +285,10 @@ pub fn hub_emit_event(
 
 /// Resolve an `until_ack` dwell (user acknowledged an error bubble).
 #[tauri::command]
-pub fn pet_ack_bubble(
-    agent_name: String,
-    bus_state: State<'_, EventBusState>,
-) {
-    bus_state.0.publish(HubEvent::new(&agent_name, "pet.bubble.acked"));
+pub fn pet_ack_bubble(agent_name: String, bus_state: State<'_, EventBusState>) {
+    bus_state
+        .0
+        .publish(HubEvent::new(&agent_name, "pet.bubble.acked"));
 }
 
 /// Speak `text` for `agent_name`: synthesise via Kokoro (if models present),
@@ -304,6 +312,12 @@ pub async fn pet_speak(
 
 fn urlenc(s: &str) -> String {
     s.chars()
-        .flat_map(|c| if c == ' ' { vec!['%', '2', '0'] } else { vec![c] })
+        .flat_map(|c| {
+            if c == ' ' {
+                vec!['%', '2', '0']
+            } else {
+                vec![c]
+            }
+        })
         .collect()
 }

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -113,7 +113,12 @@ fn start_event_loop(
                 biased;
                 _ = &mut shutdown_rx => break,
                 Ok(event) = rx.recv() => {
-                    if let Some(change) = sm.process(&event) {
+                    // voice.ended resolves an active lipsync dwell.
+                    if event.name == "voice.ended" && event.agent_id == agent_name {
+                        if let Some(change) = sm.resolve(mur_common::hub::trigger::DwellSpec::Lipsync) {
+                            emit_change(&app, &label, change);
+                        }
+                    } else if let Some(change) = sm.process(&event) {
                         emit_change(&app, &label, change);
                     }
                 }
@@ -276,6 +281,23 @@ pub fn pet_ack_bubble(
     bus_state: State<'_, EventBusState>,
 ) {
     bus_state.0.publish(HubEvent::new(&agent_name, "pet.bubble.acked"));
+}
+
+/// Speak `text` for `agent_name`: synthesise via Kokoro (if models present),
+/// play audio (unless Focus/DND active), and alternate talk_open / talk_close
+/// on the bus every 200 ms while audio plays.
+#[tauri::command]
+pub async fn pet_speak(
+    agent_name: String,
+    text: String,
+    voice_id: Option<String>,
+    bus_state: State<'_, EventBusState>,
+) -> Result<(), String> {
+    let bus = bus_state.0.clone();
+    let mur_home = mur_home();
+    let player = mur_gui_core::voice::VoicePlayer::new(agent_name, mur_home, bus);
+    player.speak(text, voice_id).await;
+    Ok(())
 }
 
 // ─── Helper ──────────────────────────────────────────────────────────────────

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -1,15 +1,29 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
+use std::time::Instant;
 
 use base64::Engine as _;
+use mur_common::hub::trigger::load_triggers;
+use mur_gui_core::event_bus::{EventBus, HubEvent};
+use mur_gui_core::expression::{ExpressionChange, ExpressionStateMachine};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
+use tokio::sync::oneshot;
 
 // ─── Managed state ──────────────────────────────────────────────────────────
 
-/// Active pet windows: agent_name → window_label.
-pub struct PetState(pub Mutex<HashMap<String, String>>);
+pub struct PetHandle {
+    pub window_label: String,
+    /// Sending on this channel shuts down the event-loop task.
+    pub shutdown_tx: oneshot::Sender<()>,
+}
+
+/// Active pet windows: agent_name → handle.
+pub struct PetState(pub Mutex<HashMap<String, PetHandle>>);
+
+/// Application-wide event bus (broadcast).
+pub struct EventBusState(pub EventBus);
 
 // ─── Position persistence ────────────────────────────────────────────────────
 
@@ -50,17 +64,71 @@ fn save_position(agent_name: &str, pos: &PetPosition) {
 }
 
 fn window_label(agent_name: &str) -> String {
-    // Window labels must be ASCII alphanumeric + hyphen/underscore.
     format!(
         "pet-{}",
-        agent_name.chars().map(|c| if c.is_ascii_alphanumeric() { c } else { '-' }).collect::<String>()
+        agent_name
+            .chars()
+            .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+            .collect::<String>()
     )
+}
+
+// ─── Event-loop helpers ──────────────────────────────────────────────────────
+
+fn emit_change(app: &AppHandle, label: &str, change: ExpressionChange) {
+    let _ = app.emit_to(
+        tauri::EventTarget::labeled(label),
+        "pet-expression",
+        &change.expression,
+    );
+    if let Some(text) = change.bubble_text {
+        let _ = app.emit_to(
+            tauri::EventTarget::labeled(label),
+            "pet-bubble",
+            &text,
+        );
+    }
+}
+
+/// Spawn a tokio task that drives the ExpressionStateMachine for one pet.
+fn start_event_loop(
+    app: AppHandle,
+    agent_name: String,
+    label: String,
+    bus: EventBus,
+    shutdown_rx: oneshot::Receiver<()>,
+) {
+    let agent_dir = mur_home().join("agents").join(&agent_name);
+    let triggers = load_triggers(&agent_dir);
+    let mut sm = ExpressionStateMachine::new(agent_name.clone(), triggers);
+    let mut rx = bus.subscribe();
+
+    tokio::spawn(async move {
+        tokio::pin!(shutdown_rx);
+        let tick_interval = tokio::time::Duration::from_millis(100);
+        let mut interval = tokio::time::interval(tick_interval);
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = &mut shutdown_rx => break,
+                Ok(event) = rx.recv() => {
+                    if let Some(change) = sm.process(&event) {
+                        emit_change(&app, &label, change);
+                    }
+                }
+                _ = interval.tick() => {
+                    if let Some(change) = sm.tick(Instant::now()) {
+                        emit_change(&app, &label, change);
+                    }
+                }
+            }
+        }
+    });
 }
 
 // ─── Commands ────────────────────────────────────────────────────────────────
 
-/// Spawn a transparent always-on-top pet window for `agent_name` at the given
-/// screen-logical coordinates.  If the pet is already open, move it instead.
 #[tauri::command]
 pub fn pet_spawn_at(
     agent_name: String,
@@ -68,11 +136,11 @@ pub fn pet_spawn_at(
     screen_y: f64,
     app: AppHandle,
     state: State<'_, PetState>,
+    bus_state: State<'_, EventBusState>,
 ) -> Result<(), String> {
     let label = window_label(&agent_name);
     let mut pets = state.0.lock().unwrap();
 
-    // Already open — move and ensure visible.
     if pets.contains_key(&agent_name) {
         if let Some(win) = app.get_webview_window(&label) {
             let _ = win.set_position(tauri::LogicalPosition::new(screen_x, screen_y));
@@ -82,11 +150,9 @@ pub fn pet_spawn_at(
         pets.remove(&agent_name);
     }
 
-    // Use saved position if available, otherwise the drop position.
     let pos = load_position(&agent_name)
         .unwrap_or(PetPosition { x: screen_x, y: screen_y, display_id: None });
 
-    // Build the window URL: index.html#/pet/<name>
     let url_path = format!("index.html#/pet/{}", urlenc(&agent_name));
 
     WebviewWindowBuilder::new(&app, &label, WebviewUrl::App(url_path.into()))
@@ -101,22 +167,31 @@ pub fn pet_spawn_at(
         .build()
         .map_err(|e| e.to_string())?;
 
-    pets.insert(agent_name.clone(), label.clone());
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    pets.insert(
+        agent_name.clone(),
+        PetHandle { window_label: label.clone(), shutdown_tx },
+    );
 
-    // wave → idle sequence after window has had time to render.
-    let app2 = app.clone();
-    let label2 = label.clone();
+    start_event_loop(
+        app.clone(),
+        agent_name.clone(),
+        label.clone(),
+        bus_state.0.clone(),
+        shutdown_rx,
+    );
+
+    // Publish spawn event so the state machine fires the wave sequence.
+    let bus = bus_state.0.clone();
+    let name = agent_name.clone();
     tokio::spawn(async move {
-        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
-        let _ = app2.emit_to(tauri::EventTarget::labeled(&label2), "pet-expression", "wave");
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-        let _ = app2.emit_to(tauri::EventTarget::labeled(&label2), "pet-expression", "idle");
+        tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+        bus.publish(HubEvent::new(&name, "pet.spawned"));
     });
 
     Ok(())
 }
 
-/// Close the pet window for `agent_name`.
 #[tauri::command]
 pub fn pet_close(
     agent_name: String,
@@ -124,25 +199,20 @@ pub fn pet_close(
     state: State<'_, PetState>,
 ) -> Result<(), String> {
     let mut pets = state.0.lock().unwrap();
-    if let Some(label) = pets.remove(&agent_name) {
-        if let Some(win) = app.get_webview_window(&label) {
+    if let Some(handle) = pets.remove(&agent_name) {
+        let _ = handle.shutdown_tx.send(());
+        if let Some(win) = app.get_webview_window(&handle.window_label) {
             win.close().map_err(|e| e.to_string())?;
         }
     }
     Ok(())
 }
 
-/// Persist the new position after a drag-reposition.
 #[tauri::command]
-pub fn pet_reposition(
-    agent_name: String,
-    x: f64,
-    y: f64,
-) {
+pub fn pet_reposition(agent_name: String, x: f64, y: f64) {
     save_position(&agent_name, &PetPosition { x, y, display_id: None });
 }
 
-/// Close the pet window and surface the Hub dashboard.
 #[tauri::command]
 pub fn pet_return_to_hub(
     agent_name: String,
@@ -150,8 +220,9 @@ pub fn pet_return_to_hub(
     state: State<'_, PetState>,
 ) -> Result<(), String> {
     let mut pets = state.0.lock().unwrap();
-    if let Some(label) = pets.remove(&agent_name) {
-        if let Some(win) = app.get_webview_window(&label) {
+    if let Some(handle) = pets.remove(&agent_name) {
+        let _ = handle.shutdown_tx.send(());
+        if let Some(win) = app.get_webview_window(&handle.window_label) {
             let _ = win.close();
         }
     }
@@ -162,14 +233,11 @@ pub fn pet_return_to_hub(
     Ok(())
 }
 
-/// Names of currently-open pet windows.
 #[tauri::command]
 pub fn pet_list(state: State<'_, PetState>) -> Vec<String> {
     state.0.lock().unwrap().keys().cloned().collect()
 }
 
-/// Load an expression image and return it as a `data:image/webp;base64,…` URL.
-/// Returns an empty string if the file does not exist (UI falls back to initials).
 #[tauri::command]
 pub fn pet_get_expression(agent_name: String, expression: String) -> String {
     let path = mur_home()
@@ -186,17 +254,34 @@ pub fn pet_get_expression(agent_name: String, expression: String) -> String {
         .unwrap_or_default()
 }
 
+/// Publish an arbitrary event onto the bus (called from the pet window UI).
+#[tauri::command]
+pub fn hub_emit_event(
+    agent_name: String,
+    event_name: String,
+    payload: Option<String>,
+    bus_state: State<'_, EventBusState>,
+) {
+    let mut ev = HubEvent::new(&agent_name, &event_name);
+    if let Some(p) = payload {
+        ev = ev.with_payload(serde_json::Value::String(p));
+    }
+    bus_state.0.publish(ev);
+}
+
+/// Resolve an `until_ack` dwell (user acknowledged an error bubble).
+#[tauri::command]
+pub fn pet_ack_bubble(
+    agent_name: String,
+    bus_state: State<'_, EventBusState>,
+) {
+    bus_state.0.publish(HubEvent::new(&agent_name, "pet.bubble.acked"));
+}
+
 // ─── Helper ──────────────────────────────────────────────────────────────────
 
-/// Percent-encode a string for use in a URL path segment (spaces → %20 only).
 fn urlenc(s: &str) -> String {
     s.chars()
-        .flat_map(|c| {
-            if c == ' ' {
-                vec!['%', '2', '0']
-            } else {
-                vec![c]
-            }
-        })
+        .flat_map(|c| if c == ' ' { vec!['%', '2', '0'] } else { vec![c] })
         .collect()
 }

--- a/mur-hub-gui/src-tauri/src/preset.rs
+++ b/mur-hub-gui/src-tauri/src/preset.rs
@@ -1,0 +1,48 @@
+//! `import_preset_file` + `import_preset_url` Tauri commands.
+//!
+//! Both validate the YAML as a `StylePreset` then copy it to
+//! `~/.mur/hub/presets/<id>.yaml`.  The preset ID is taken from the
+//! parsed struct (not the filename) so it survives renames.
+
+use std::fs;
+use std::path::PathBuf;
+
+use mur_common::hub::style_preset::StylePreset;
+
+fn presets_dir() -> PathBuf {
+    std::env::var("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".mur"))
+        .join("hub/presets")
+}
+
+fn install_preset(yaml: &str) -> Result<String, String> {
+    let preset: StylePreset = serde_yaml_ng::from_str(yaml)
+        .map_err(|e| format!("invalid preset YAML: {e}"))?;
+
+    let dir = presets_dir();
+    fs::create_dir_all(&dir).map_err(|e| format!("create presets dir: {e}"))?;
+
+    let dest = dir.join(format!("{}.yaml", preset.id));
+    fs::write(&dest, yaml.as_bytes()).map_err(|e| format!("write preset: {e}"))?;
+
+    Ok(preset.id)
+}
+
+/// Import a StylePreset YAML from a local file path.
+#[tauri::command]
+pub fn import_preset_file(path: String) -> Result<String, String> {
+    let yaml = fs::read_to_string(&path)
+        .map_err(|e| format!("read {path}: {e}"))?;
+    install_preset(&yaml)
+}
+
+/// Import a StylePreset YAML from a URL (synchronous fetch via reqwest blocking).
+#[tauri::command]
+pub fn import_preset_url(url: String) -> Result<String, String> {
+    let yaml = reqwest::blocking::get(&url)
+        .map_err(|e| format!("fetch {url}: {e}"))?
+        .text()
+        .map_err(|e| format!("read body: {e}"))?;
+    install_preset(&yaml)
+}

--- a/mur-hub-gui/src-tauri/src/preset.rs
+++ b/mur-hub-gui/src-tauri/src/preset.rs
@@ -17,8 +17,8 @@ fn presets_dir() -> PathBuf {
 }
 
 fn install_preset(yaml: &str) -> Result<String, String> {
-    let preset: StylePreset = serde_yaml_ng::from_str(yaml)
-        .map_err(|e| format!("invalid preset YAML: {e}"))?;
+    let preset: StylePreset =
+        serde_yaml_ng::from_str(yaml).map_err(|e| format!("invalid preset YAML: {e}"))?;
 
     let dir = presets_dir();
     fs::create_dir_all(&dir).map_err(|e| format!("create presets dir: {e}"))?;
@@ -32,8 +32,7 @@ fn install_preset(yaml: &str) -> Result<String, String> {
 /// Import a StylePreset YAML from a local file path.
 #[tauri::command]
 pub fn import_preset_file(path: String) -> Result<String, String> {
-    let yaml = fs::read_to_string(&path)
-        .map_err(|e| format!("read {path}: {e}"))?;
+    let yaml = fs::read_to_string(&path).map_err(|e| format!("read {path}: {e}"))?;
     install_preset(&yaml)
 }
 

--- a/mur-hub-gui/src-tauri/tauri.conf.json
+++ b/mur-hub-gui/src-tauri/tauri.conf.json
@@ -8,6 +8,7 @@
     "frontendDist": "../ui/dist"
   },
   "app": {
+    "macOSPrivateApi": true,
     "windows": [
       {
         "label": "dashboard",

--- a/mur-hub-gui/src-tauri/tauri.conf.json
+++ b/mur-hub-gui/src-tauri/tauri.conf.json
@@ -12,13 +12,26 @@
       {
         "label": "dashboard",
         "title": "MuR Hub",
+        "url": "index.html",
         "width": 720,
         "height": 520,
         "minWidth": 560,
         "minHeight": 400,
         "resizable": true,
         "fullscreen": false,
-        "visible": true
+        "visible": false
+      },
+      {
+        "label": "popover",
+        "title": "MuR Hub Popover",
+        "url": "index.html#/popover",
+        "decorations": false,
+        "alwaysOnTop": true,
+        "skipTaskbar": true,
+        "visible": false,
+        "width": 280,
+        "height": 480,
+        "resizable": false
       }
     ],
     "security": {

--- a/mur-hub-gui/ui/package-lock.json
+++ b/mur-hub-gui/ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-shell": "^2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -1109,6 +1110,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/tauri"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-shell": {

--- a/mur-hub-gui/ui/package.json
+++ b/mur-hub-gui/ui/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-shell": "^2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/mur-hub-gui/ui/src/App.tsx
+++ b/mur-hub-gui/ui/src/App.tsx
@@ -1,8 +1,16 @@
+import { AgentProvider } from "./context/AgentContext";
+import { PopoverApp } from "./components/PopoverApp";
+import { DashboardApp } from "./components/DashboardApp";
+
+function getRoute(): "popover" | "dashboard" {
+  return window.location.hash === "#/popover" ? "popover" : "dashboard";
+}
+
 export default function App() {
+  const route = getRoute();
   return (
-    <main className="hub-shell">
-      <h1>MuR Hub</h1>
-      <p className="subtitle">Multi-agent dashboard — M-h0 scaffold.</p>
-    </main>
+    <AgentProvider>
+      {route === "popover" ? <PopoverApp /> : <DashboardApp />}
+    </AgentProvider>
   );
 }

--- a/mur-hub-gui/ui/src/App.tsx
+++ b/mur-hub-gui/ui/src/App.tsx
@@ -1,13 +1,18 @@
 import { AgentProvider } from "./context/AgentContext";
 import { PopoverApp } from "./components/PopoverApp";
 import { DashboardApp } from "./components/DashboardApp";
+import { PetApp } from "./components/PetApp";
 
-function getRoute(): "popover" | "dashboard" {
-  return window.location.hash === "#/popover" ? "popover" : "dashboard";
+function getRoute(): "popover" | "dashboard" | "pet" {
+  const hash = window.location.hash;
+  if (hash === "#/popover") return "popover";
+  if (hash.startsWith("#/pet/")) return "pet";
+  return "dashboard";
 }
 
 export default function App() {
   const route = getRoute();
+  if (route === "pet") return <PetApp />;
   return (
     <AgentProvider>
       {route === "popover" ? <PopoverApp /> : <DashboardApp />}

--- a/mur-hub-gui/ui/src/components/AgentRow.tsx
+++ b/mur-hub-gui/ui/src/components/AgentRow.tsx
@@ -1,0 +1,41 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { AgentEntry } from "../types";
+
+const CATEGORY_COLORS: Record<string, string> = {
+  research: "#4F46E5",
+  automation: "#059669",
+  monitor: "#D97706",
+  notify: "#DC2626",
+  commerce: "#7C3AED",
+  custom: "#6B7280",
+};
+
+interface AgentRowProps {
+  agent: AgentEntry;
+}
+
+export function AgentRow({ agent }: AgentRowProps) {
+  const color = CATEGORY_COLORS[agent.category] ?? "#6B7280";
+  const initials = agent.display_name
+    .split(" ")
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
+
+  function handleClick() {
+    invoke("open_dashboard", { agentName: agent.name }).catch(console.error);
+  }
+
+  return (
+    <button className="agent-row" onClick={handleClick}>
+      <div className="agent-avatar" style={{ background: color }}>
+        {initials}
+      </div>
+      <div className="agent-info">
+        <span className="agent-name">{agent.display_name}</span>
+        <span className="agent-category">{agent.category}</span>
+      </div>
+      <span className={`status-dot status-${agent.status}`} />
+    </button>
+  );
+}

--- a/mur-hub-gui/ui/src/components/CompanionInbox.tsx
+++ b/mur-hub-gui/ui/src/components/CompanionInbox.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Channel } from "@tauri-apps/api/core";
+
+interface BridgeResponse {
+  kind: "unset" | "signal";
+  value?: string;
+}
+
+interface BridgeEvent {
+  id: string;
+  situation: string;
+  template_id: string;
+  locale: string;
+  generated_at: string;
+  body: string;
+  response: BridgeResponse;
+}
+
+interface Props {
+  agentName: string;
+}
+
+export function CompanionInbox({ agentName }: Props) {
+  const [messages, setMessages] = useState<BridgeEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const channelRef = useRef<Channel<BridgeEvent> | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+
+    // Load existing messages.
+    invoke<BridgeEvent[]>("companion_bridge_pending", { agent: agentName })
+      .then((evs) => {
+        setMessages(evs);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+
+    // Subscribe for new messages.
+    const ch = new Channel<BridgeEvent>();
+    channelRef.current = ch;
+    ch.onmessage = (ev) => {
+      setMessages((prev) => {
+        if (prev.some((m) => m.id === ev.id)) return prev;
+        return [...prev, ev].sort((a, b) =>
+          a.generated_at.localeCompare(b.generated_at),
+        );
+      });
+    };
+    invoke("companion_bridge_subscribe", {
+      agent: agentName,
+      onEvent: ch,
+    }).catch(console.error);
+
+    return () => {
+      invoke("companion_bridge_unsubscribe", { agent: agentName }).catch(
+        () => {},
+      );
+      channelRef.current = null;
+    };
+  }, [agentName]);
+
+  async function ack(msgId: string, signal: string) {
+    await invoke("companion_ack", { agent: agentName, msgId, signal }).catch(
+      console.error,
+    );
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.id === msgId
+          ? { ...m, response: { kind: "signal", value: signal } }
+          : m,
+      ),
+    );
+  }
+
+  if (loading) {
+    return <div className="inbox-empty">Loading…</div>;
+  }
+
+  if (messages.length === 0) {
+    return (
+      <div className="inbox-empty">
+        <p>No messages yet.</p>
+        <p style={{ fontSize: 12, color: "var(--text-secondary, #888)", marginTop: 4 }}>
+          The companion will appear here when the agent sends you a message.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="inbox-list">
+      {messages.map((msg) => {
+        const isUnread = msg.response.kind === "unset";
+        return (
+          <li key={msg.id} className={`inbox-msg${isUnread ? " inbox-msg--unread" : ""}`}>
+            <div className="inbox-msg-header">
+              <span className="inbox-situation">{msg.situation}</span>
+              <span className="inbox-time">
+                {new Date(msg.generated_at).toLocaleTimeString([], {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </span>
+            </div>
+            <p className="inbox-body">{msg.body}</p>
+            {isUnread && (
+              <div className="inbox-actions">
+                <button onClick={() => ack(msg.id, "good")} title="Good">👍</button>
+                <button onClick={() => ack(msg.id, "bad")} title="Bad">👎</button>
+                <button onClick={() => ack(msg.id, "dismiss")} title="Dismiss">🚫</button>
+              </div>
+            )}
+            {!isUnread && (
+              <span className="inbox-acked">
+                {msg.response.value === "good"
+                  ? "👍 Acknowledged"
+                  : msg.response.value === "bad"
+                  ? "👎 Noted"
+                  : "🚫 Dismissed"}
+              </span>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+// ─── Unread badge hook ──────────────────────────────────────────────────────
+
+export function useUnreadCount(agentName: string): number {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    invoke<number>("companion_unread_count", { agent: agentName })
+      .then(setCount)
+      .catch(() => {});
+  }, [agentName]);
+
+  return count;
+}

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -5,6 +5,7 @@ import { useAgents } from "../context/AgentContext";
 import type { AgentEntry, AgentRuntimeStatus, RuntimeState } from "../types";
 import { WizardModal } from "./wizard/WizardModal";
 import { PresetImportModal } from "./PresetImportModal";
+import { CompanionInbox, useUnreadCount } from "./CompanionInbox";
 
 // ─── Shared helpers ────────────────────────────────────────────────────────
 
@@ -72,6 +73,8 @@ interface GridCardProps {
 }
 
 export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
+  const { setSelected } = useAgents();
+  const unread = useUnreadCount(agent.name);
   const color = CATEGORY_COLORS[agent.category] ?? "#6B7280";
   const isRunning = runtime?.state.state === "running";
   const isBusy = runtime?.state.state === "restarting";
@@ -149,9 +152,13 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
         onMouseDown={startHold}
         onMouseUp={cancelHold}
         onMouseLeave={cancelHold}
+        onClick={() => setSelected(isSelected ? null : agent.name)}
       >
         <div className="grid-avatar" style={{ background: color }}>
           {avatarInitials(agent.display_name)}
+          {unread > 0 && (
+            <span className="unread-badge">{unread > 99 ? "99+" : unread}</span>
+          )}
         </div>
         <p className="grid-name">{agent.display_name}</p>
         <div className="grid-status">
@@ -264,7 +271,7 @@ export function Sidebar({ activeCategory, agents, onSelect }: SidebarProps) {
 // ─── DashboardApp ──────────────────────────────────────────────────────────
 
 export function DashboardApp() {
-  const { agents, runtimeStatuses, selectedAgent } = useAgents();
+  const { agents, runtimeStatuses, selectedAgent, setSelected } = useAgents();
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [query, setQuery] = useState("");
@@ -393,6 +400,31 @@ export function DashboardApp() {
           )}
         </div>
       </div>
+
+      {/* Companion Inbox detail panel — slides in when an agent is selected */}
+      {selectedAgent && (
+        <aside className="detail-panel">
+          <div className="detail-panel-header">
+            <span className="detail-panel-title">
+              {agents.find((a) => a.name === selectedAgent)?.display_name ?? selectedAgent}
+            </span>
+            <button
+              className="detail-panel-close"
+              onClick={() => setSelected(null)}
+              title="Close"
+            >
+              ×
+            </button>
+          </div>
+          <div className="detail-panel-tabs">
+            <span className="detail-tab detail-tab--active">Inbox</span>
+          </div>
+          <div className="detail-panel-body">
+            <CompanionInbox agentName={selectedAgent} />
+          </div>
+        </aside>
+      )}
+
       <WizardModal
         isOpen={wizardOpen}
         onClose={(name) => {

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { AgentEntry } from "../types";
+
+// ─── Shared helpers ────────────────────────────────────────────────────────
+
+const CATEGORY_COLORS: Record<string, string> = {
+  research: "#4F46E5",
+  automation: "#059669",
+  monitor: "#D97706",
+  notify: "#DC2626",
+  commerce: "#7C3AED",
+  custom: "#6B7280",
+};
+
+const ALL_CATEGORIES = ["research", "automation", "monitor", "notify", "commerce", "custom"];
+
+function avatarInitials(displayName: string): string {
+  return displayName
+    .split(" ")
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+function showToast(msg: string) {
+  const el = document.createElement("div");
+  el.className = "toast";
+  el.textContent = msg;
+  document.body.appendChild(el);
+  setTimeout(() => el.remove(), 2000);
+}
+
+// ─── GridCard ──────────────────────────────────────────────────────────────
+
+interface GridCardProps {
+  agent: AgentEntry;
+  isSelected: boolean;
+}
+
+export function GridCard({ agent, isSelected }: GridCardProps) {
+  const color = CATEGORY_COLORS[agent.category] ?? "#6B7280";
+  return (
+    <div
+      className={`grid-card${isSelected ? " grid-card--selected" : ""}`}
+      data-agent={agent.name}
+    >
+      <div className="grid-avatar" style={{ background: color }}>
+        {avatarInitials(agent.display_name)}
+      </div>
+      <p className="grid-name">{agent.display_name}</p>
+      <div className="grid-status">
+        <span className={`status-dot status-${agent.status}`} />
+        <span className="grid-status-text">{agent.status}</span>
+      </div>
+      <div className="grid-actions">
+        <button onClick={() => showToast("Coming in M-h2")}>Run</button>
+        <button onClick={() => showToast("Coming in M-h2")}>Stop</button>
+      </div>
+    </div>
+  );
+}
+
+// ─── ListRow ───────────────────────────────────────────────────────────────
+
+interface ListRowProps {
+  agent: AgentEntry;
+  isSelected: boolean;
+}
+
+export function ListRow({ agent, isSelected }: ListRowProps) {
+  const color = CATEGORY_COLORS[agent.category] ?? "#6B7280";
+  const model =
+    agent.model_id.length > 24 ? agent.model_id.slice(0, 24) + "…" : agent.model_id;
+  return (
+    <div
+      className={`list-row${isSelected ? " list-row--selected" : ""}`}
+      data-agent={agent.name}
+    >
+      <div className="list-avatar" style={{ background: color }}>
+        {avatarInitials(agent.display_name)}
+      </div>
+      <span className="list-name">{agent.display_name}</span>
+      <span className="list-category">{agent.category}</span>
+      <span className="list-model" title={agent.model_id}>
+        {model}
+      </span>
+      <span className={`status-dot status-${agent.status}`} />
+    </div>
+  );
+}
+
+// ─── Sidebar ───────────────────────────────────────────────────────────────
+
+interface SidebarProps {
+  activeCategory: string | null;
+  agents: AgentEntry[];
+  onSelect: (cat: string | null) => void;
+}
+
+export function Sidebar({ activeCategory, agents, onSelect }: SidebarProps) {
+  const counts: Record<string, number> = {};
+  for (const a of agents) counts[a.category] = (counts[a.category] ?? 0) + 1;
+
+  return (
+    <nav className="sidebar">
+      <button
+        className={`sidebar-item${activeCategory === null ? " sidebar-item--active" : ""}`}
+        onClick={() => onSelect(null)}
+      >
+        All <span className="badge">{agents.length}</span>
+      </button>
+      {ALL_CATEGORIES.filter((c) => (counts[c] ?? 0) > 0).map((cat) => (
+        <button
+          key={cat}
+          className={`sidebar-item${activeCategory === cat ? " sidebar-item--active" : ""}`}
+          onClick={() => onSelect(cat)}
+        >
+          {cat} <span className="badge">{counts[cat]}</span>
+        </button>
+      ))}
+    </nav>
+  );
+}
+
+// ─── DashboardApp ──────────────────────────────────────────────────────────
+
+export function DashboardApp() {
+  const [agents, setAgents] = useState<AgentEntry[]>([]);
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
+  const [query, setQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    invoke<AgentEntry[]>("list_agents").then(setAgents).catch(console.error);
+
+    const unAgents = listen<AgentEntry[]>("agents-updated", (e) => setAgents(e.payload));
+    const unSelect = listen<string>("select-agent", (e) => {
+      setSelectedAgent(e.payload);
+      setTimeout(() => {
+        document
+          .querySelector(`[data-agent="${e.payload}"]`)
+          ?.scrollIntoView({ behavior: "smooth", block: "center" });
+      }, 50);
+    });
+
+    return () => {
+      unAgents.then((fn) => fn());
+      unSelect.then((fn) => fn());
+    };
+  }, []);
+
+  // ⌘K focus search.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const q = query.toLowerCase();
+  const visible = agents.filter(
+    (a) =>
+      (activeCategory === null || a.category === activeCategory) &&
+      (!q || a.name.toLowerCase().includes(q) || a.display_name.toLowerCase().includes(q)),
+  );
+
+  return (
+    <div className="dashboard-root">
+      <Sidebar activeCategory={activeCategory} agents={agents} onSelect={setActiveCategory} />
+      <div className="dashboard-main">
+        <div className="toolbar">
+          <button
+            className="toolbar-btn"
+            onClick={() => window.open("https://docs.mur.run/agents/create", "_blank")}
+          >
+            + New Agent
+          </button>
+          <input
+            ref={searchRef}
+            type="search"
+            className="toolbar-search"
+            placeholder="Search… (⌘K)"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <div className="view-toggle">
+            <button
+              className={viewMode === "grid" ? "active" : ""}
+              onClick={() => setViewMode("grid")}
+              title="Grid view"
+            >
+              ⊞
+            </button>
+            <button
+              className={viewMode === "list" ? "active" : ""}
+              onClick={() => setViewMode("list")}
+              title="List view"
+            >
+              ☰
+            </button>
+          </div>
+          <button
+            className="toolbar-btn"
+            onClick={() =>
+              invoke<AgentEntry[]>("list_agents").then(setAgents).catch(console.error)
+            }
+          >
+            ↺
+          </button>
+        </div>
+
+        <div className="dashboard-content">
+          {visible.length === 0 ? (
+            <div className="empty-state">
+              <div className="empty-illustration">◎</div>
+              <p>No agents yet</p>
+            </div>
+          ) : viewMode === "grid" ? (
+            <div className="grid-view">
+              {visible.map((a) => (
+                <GridCard key={a.name} agent={a} isSelected={selectedAgent === a.name} />
+              ))}
+            </div>
+          ) : (
+            <div className="list-view">
+              {visible.map((a) => (
+                <ListRow key={a.name} agent={a} isSelected={selectedAgent === a.name} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -4,6 +4,7 @@ import { listen } from "@tauri-apps/api/event";
 import { useAgents } from "../context/AgentContext";
 import type { AgentEntry, AgentRuntimeStatus, RuntimeState } from "../types";
 import { WizardModal } from "./wizard/WizardModal";
+import { PresetImportModal } from "./PresetImportModal";
 
 // ─── Shared helpers ────────────────────────────────────────────────────────
 
@@ -268,6 +269,7 @@ export function DashboardApp() {
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [query, setQuery] = useState("");
   const [wizardOpen, setWizardOpen] = useState(false);
+  const [presetImportOpen, setPresetImportOpen] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
 
   // Build a lookup map for runtime statuses.
@@ -316,6 +318,13 @@ export function DashboardApp() {
             onClick={() => setWizardOpen(true)}
           >
             + New Agent
+          </button>
+          <button
+            className="toolbar-btn"
+            onClick={() => setPresetImportOpen(true)}
+            title="Import a custom style preset YAML"
+          >
+            Import Preset
           </button>
           <input
             ref={searchRef}
@@ -390,6 +399,10 @@ export function DashboardApp() {
           setWizardOpen(false);
           if (name) invoke("list_agents").catch(() => {});
         }}
+      />
+      <PresetImportModal
+        isOpen={presetImportOpen}
+        onClose={() => setPresetImportOpen(false)}
       />
     </div>
   );

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -75,6 +75,13 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
   const isRunning = runtime?.state.state === "running";
   const isBusy = runtime?.state.state === "restarting";
 
+  // Drag-to-spawn state
+  const holdTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const [ghostPos, setGhostPos] = useState({ x: 0, y: 0 });
+  const cursorOutsideRef = useRef(false);
+  const mouseDownPosRef = useRef({ x: 0, y: 0 });
+
   async function handleRun() {
     await invoke("start_agent", { name: agent.name }).catch((e) =>
       showToast(`Failed: ${e}`),
@@ -86,38 +93,107 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
     );
   }
 
+  function startHold(e: React.MouseEvent) {
+    if (e.button !== 0) return;
+    mouseDownPosRef.current = { x: e.clientX, y: e.clientY };
+    holdTimer.current = setTimeout(() => {
+      setDragging(true);
+      setGhostPos({ x: e.screenX, y: e.screenY });
+      cursorOutsideRef.current = false;
+    }, 300);
+  }
+
+  function cancelHold() {
+    if (holdTimer.current) {
+      clearTimeout(holdTimer.current);
+      holdTimer.current = null;
+    }
+  }
+
+  useEffect(() => {
+    if (!dragging) return;
+
+    function onMove(e: MouseEvent) {
+      setGhostPos({ x: e.screenX, y: e.screenY });
+    }
+    function onLeave() { cursorOutsideRef.current = true; }
+    function onEnter() { cursorOutsideRef.current = false; }
+    function onUp(e: MouseEvent) {
+      setDragging(false);
+      if (cursorOutsideRef.current) {
+        invoke("pet_spawn_at", {
+          agentName: agent.name,
+          screenX: e.screenX,
+          screenY: e.screenY,
+        }).catch((err) => showToast(`Pet: ${err}`));
+      }
+    }
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    document.addEventListener("mouseleave", onLeave);
+    document.addEventListener("mouseenter", onEnter);
+    return () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.removeEventListener("mouseleave", onLeave);
+      document.removeEventListener("mouseenter", onEnter);
+    };
+  }, [dragging, agent.name]);
+
   return (
-    <div
-      className={`grid-card${isSelected ? " grid-card--selected" : ""}`}
-      data-agent={agent.name}
-    >
-      <div className="grid-avatar" style={{ background: color }}>
-        {avatarInitials(agent.display_name)}
+    <>
+      <div
+        className={`grid-card${isSelected ? " grid-card--selected" : ""}${dragging ? " grid-card--dragging" : ""}`}
+        data-agent={agent.name}
+        onMouseDown={startHold}
+        onMouseUp={cancelHold}
+        onMouseLeave={cancelHold}
+      >
+        <div className="grid-avatar" style={{ background: color }}>
+          {avatarInitials(agent.display_name)}
+        </div>
+        <p className="grid-name">{agent.display_name}</p>
+        <div className="grid-status">
+          <span className={runtimeDotClass(runtime?.state)} />
+          <span className="grid-status-text">
+            {runtimeLabel(runtime?.state) || agent.status}
+          </span>
+        </div>
+        <div className="grid-actions">
+          <button
+            disabled={isRunning || isBusy}
+            onClick={handleRun}
+            title="Start agent runtime"
+          >
+            ▶ Run
+          </button>
+          <button
+            disabled={!isRunning && !isBusy}
+            onClick={handleStop}
+            title="Stop agent runtime"
+          >
+            ■ Stop
+          </button>
+        </div>
       </div>
-      <p className="grid-name">{agent.display_name}</p>
-      <div className="grid-status">
-        <span className={runtimeDotClass(runtime?.state)} />
-        <span className="grid-status-text">
-          {runtimeLabel(runtime?.state) || agent.status}
-        </span>
-      </div>
-      <div className="grid-actions">
-        <button
-          disabled={isRunning || isBusy}
-          onClick={handleRun}
-          title="Start agent runtime"
+
+      {dragging && (
+        <div
+          className="drag-ghost"
+          style={{
+            position: "fixed",
+            left: ghostPos.x - window.screenX - 40,
+            top: ghostPos.y - window.screenY - 40,
+            pointerEvents: "none",
+          }}
         >
-          ▶ Run
-        </button>
-        <button
-          disabled={!isRunning && !isBusy}
-          onClick={handleStop}
-          title="Stop agent runtime"
-        >
-          ■ Stop
-        </button>
-      </div>
-    </div>
+          <div className="drag-ghost-avatar" style={{ background: color }}>
+            {avatarInitials(agent.display_name)}
+          </div>
+          <span className="drag-ghost-label">{agent.display_name}</span>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { AgentEntry } from "../types";
+import { useAgents } from "../context/AgentContext";
+import type { AgentEntry, AgentRuntimeStatus, RuntimeState } from "../types";
 
 // ─── Shared helpers ────────────────────────────────────────────────────────
 
@@ -32,15 +33,58 @@ function showToast(msg: string) {
   setTimeout(() => el.remove(), 2000);
 }
 
+function runtimeLabel(rt: RuntimeState | undefined): string {
+  if (!rt) return "";
+  switch (rt.state) {
+    case "running":
+      return `pid ${rt.pid}`;
+    case "restarting":
+      return `restarting (attempt ${rt.attempt})`;
+    case "failed":
+      return "failed";
+    case "stopped":
+      return "";
+  }
+}
+
+function runtimeDotClass(rt: RuntimeState | undefined): string {
+  if (!rt) return "";
+  switch (rt.state) {
+    case "running":
+      return "status-dot status-running";
+    case "restarting":
+      return "status-dot status-restarting";
+    case "failed":
+      return "status-dot status-stale";
+    default:
+      return "status-dot status-idle";
+  }
+}
+
 // ─── GridCard ──────────────────────────────────────────────────────────────
 
 interface GridCardProps {
   agent: AgentEntry;
+  runtime: AgentRuntimeStatus | undefined;
   isSelected: boolean;
 }
 
-export function GridCard({ agent, isSelected }: GridCardProps) {
+export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
   const color = CATEGORY_COLORS[agent.category] ?? "#6B7280";
+  const isRunning = runtime?.state.state === "running";
+  const isBusy = runtime?.state.state === "restarting";
+
+  async function handleRun() {
+    await invoke("start_agent", { name: agent.name }).catch((e) =>
+      showToast(`Failed: ${e}`),
+    );
+  }
+  async function handleStop() {
+    await invoke("stop_agent", { name: agent.name }).catch((e) =>
+      showToast(`Failed: ${e}`),
+    );
+  }
+
   return (
     <div
       className={`grid-card${isSelected ? " grid-card--selected" : ""}`}
@@ -51,12 +95,26 @@ export function GridCard({ agent, isSelected }: GridCardProps) {
       </div>
       <p className="grid-name">{agent.display_name}</p>
       <div className="grid-status">
-        <span className={`status-dot status-${agent.status}`} />
-        <span className="grid-status-text">{agent.status}</span>
+        <span className={runtimeDotClass(runtime?.state)} />
+        <span className="grid-status-text">
+          {runtimeLabel(runtime?.state) || agent.status}
+        </span>
       </div>
       <div className="grid-actions">
-        <button onClick={() => showToast("Coming in M-h2")}>Run</button>
-        <button onClick={() => showToast("Coming in M-h2")}>Stop</button>
+        <button
+          disabled={isRunning || isBusy}
+          onClick={handleRun}
+          title="Start agent runtime"
+        >
+          ▶ Run
+        </button>
+        <button
+          disabled={!isRunning && !isBusy}
+          onClick={handleStop}
+          title="Stop agent runtime"
+        >
+          ■ Stop
+        </button>
       </div>
     </div>
   );
@@ -66,10 +124,11 @@ export function GridCard({ agent, isSelected }: GridCardProps) {
 
 interface ListRowProps {
   agent: AgentEntry;
+  runtime: AgentRuntimeStatus | undefined;
   isSelected: boolean;
 }
 
-export function ListRow({ agent, isSelected }: ListRowProps) {
+export function ListRow({ agent, runtime, isSelected }: ListRowProps) {
   const color = CATEGORY_COLORS[agent.category] ?? "#6B7280";
   const model =
     agent.model_id.length > 24 ? agent.model_id.slice(0, 24) + "…" : agent.model_id;
@@ -86,7 +145,7 @@ export function ListRow({ agent, isSelected }: ListRowProps) {
       <span className="list-model" title={agent.model_id}>
         {model}
       </span>
-      <span className={`status-dot status-${agent.status}`} />
+      <span className={runtimeDotClass(runtime?.state)} />
     </div>
   );
 }
@@ -127,28 +186,26 @@ export function Sidebar({ activeCategory, agents, onSelect }: SidebarProps) {
 // ─── DashboardApp ──────────────────────────────────────────────────────────
 
 export function DashboardApp() {
-  const [agents, setAgents] = useState<AgentEntry[]>([]);
-  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+  const { agents, runtimeStatuses, selectedAgent } = useAgents();
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [query, setQuery] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    invoke<AgentEntry[]>("list_agents").then(setAgents).catch(console.error);
+  // Build a lookup map for runtime statuses.
+  const runtimeMap = new Map<string, AgentRuntimeStatus>(
+    runtimeStatuses.map((s) => [s.name, s]),
+  );
 
-    const unAgents = listen<AgentEntry[]>("agents-updated", (e) => setAgents(e.payload));
+  useEffect(() => {
     const unSelect = listen<string>("select-agent", (e) => {
-      setSelectedAgent(e.payload);
       setTimeout(() => {
         document
           .querySelector(`[data-agent="${e.payload}"]`)
           ?.scrollIntoView({ behavior: "smooth", block: "center" });
       }, 50);
     });
-
     return () => {
-      unAgents.then((fn) => fn());
       unSelect.then((fn) => fn());
     };
   }, []);
@@ -210,7 +267,9 @@ export function DashboardApp() {
           <button
             className="toolbar-btn"
             onClick={() =>
-              invoke<AgentEntry[]>("list_agents").then(setAgents).catch(console.error)
+              invoke<AgentEntry[]>("list_agents")
+                .then(() => {}) // state updated via event
+                .catch(console.error)
             }
           >
             ↺
@@ -226,13 +285,23 @@ export function DashboardApp() {
           ) : viewMode === "grid" ? (
             <div className="grid-view">
               {visible.map((a) => (
-                <GridCard key={a.name} agent={a} isSelected={selectedAgent === a.name} />
+                <GridCard
+                  key={a.name}
+                  agent={a}
+                  runtime={runtimeMap.get(a.name)}
+                  isSelected={selectedAgent === a.name}
+                />
               ))}
             </div>
           ) : (
             <div className="list-view">
               {visible.map((a) => (
-                <ListRow key={a.name} agent={a} isSelected={selectedAgent === a.name} />
+                <ListRow
+                  key={a.name}
+                  agent={a}
+                  runtime={runtimeMap.get(a.name)}
+                  isSelected={selectedAgent === a.name}
+                />
               ))}
             </div>
           )}

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useAgents } from "../context/AgentContext";
 import type { AgentEntry, AgentRuntimeStatus, RuntimeState } from "../types";
+import { WizardModal } from "./wizard/WizardModal";
 
 // ─── Shared helpers ────────────────────────────────────────────────────────
 
@@ -190,6 +191,7 @@ export function DashboardApp() {
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [query, setQuery] = useState("");
+  const [wizardOpen, setWizardOpen] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
 
   // Build a lookup map for runtime statuses.
@@ -232,11 +234,10 @@ export function DashboardApp() {
   return (
     <div className="dashboard-root">
       <Sidebar activeCategory={activeCategory} agents={agents} onSelect={setActiveCategory} />
-      <div className="dashboard-main">
-        <div className="toolbar">
+      <div className="dashboard-main">        <div className="toolbar">
           <button
             className="toolbar-btn"
-            onClick={() => window.open("https://docs.mur.run/agents/create", "_blank")}
+            onClick={() => setWizardOpen(true)}
           >
             + New Agent
           </button>
@@ -307,6 +308,13 @@ export function DashboardApp() {
           )}
         </div>
       </div>
+      <WizardModal
+        isOpen={wizardOpen}
+        onClose={(name) => {
+          setWizardOpen(false);
+          if (name) invoke("list_agents").catch(() => {});
+        }}
+      />
     </div>
   );
 }

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -14,12 +14,19 @@ interface ContextMenu {
   y: number;
 }
 
+interface BubbleState {
+  text: string;
+  dwell_ms: number;
+  ack_required: boolean;
+}
+
 const CLICK_MS = 300;
 
 export function PetApp() {
   const agentName = getAgentName();
   const [expression, setExpression] = useState<string>("idle");
   const [imageSrc, setImageSrc] = useState<string>("");
+  const [bubble, setBubble] = useState<BubbleState | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenu>({ visible: false, x: 0, y: 0 });
   const clickTimeRef = useRef<number>(0);
   const isDraggingRef = useRef(false);
@@ -31,7 +38,7 @@ export function PetApp() {
     });
   }, [agentName, expression]);
 
-  // Listen for expression-change events emitted by the backend (spawn wave sequence).
+  // Listen for expression changes from the backend state machine.
   useEffect(() => {
     const unsub = listen<string>("pet-expression", (ev) => {
       setExpression(ev.payload);
@@ -39,7 +46,19 @@ export function PetApp() {
     return () => { unsub.then((f) => f()); };
   }, []);
 
-  // Persist position whenever the window is moved via drag.
+  // Listen for bubble messages from the backend.
+  useEffect(() => {
+    const unsub = listen<string>("pet-bubble", (ev) => {
+      if (ev.payload) {
+        setBubble({ text: ev.payload, dwell_ms: 6000, ack_required: false });
+      } else {
+        setBubble(null);
+      }
+    });
+    return () => { unsub.then((f) => f()); };
+  }, []);
+
+  // Persist position whenever the window is moved.
   useEffect(() => {
     const win = getCurrentWindow();
     const unsub = win.listen("tauri://move", () => {
@@ -58,21 +77,29 @@ export function PetApp() {
     return () => window.removeEventListener("click", close);
   }, [contextMenu.visible]);
 
+  // ESC closes bubble.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape" && bubble) {
+        setBubble(null);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [bubble]);
+
   function handleMouseDown(e: React.MouseEvent) {
     if (e.button !== 0) return;
     clickTimeRef.current = Date.now();
     isDraggingRef.current = false;
-    // Engage native window drag; Tauri moves the window.
     getCurrentWindow().startDragging().then(() => {
       isDraggingRef.current = true;
     }).catch(() => {});
   }
 
   function handleMouseUp() {
-    // Short tap without drag → smile for 2s.
     if (!isDraggingRef.current && Date.now() - clickTimeRef.current < CLICK_MS) {
-      setExpression("smile");
-      setTimeout(() => setExpression("idle"), 2000);
+      invoke("hub_emit_event", { agentName, eventName: "user.click.pet" }).catch(() => {});
     }
     isDraggingRef.current = false;
   }
@@ -92,10 +119,27 @@ export function PetApp() {
     await invoke("pet_close", { agentName });
   }
 
-  const initials = agentName.split("-").slice(0, 2).map((w) => w[0]?.toUpperCase() ?? "").join("");
+  function handleBubbleAck() {
+    setBubble(null);
+    invoke("pet_ack_bubble", { agentName }).catch(() => {});
+  }
+
+  const initials = agentName
+    .split("-")
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
 
   return (
     <div className="pet-root" onContextMenu={handleContextMenu}>
+      {bubble && (
+        <Bubble
+          text={bubble.text}
+          dwellMs={bubble.dwell_ms}
+          onClose={handleBubbleAck}
+        />
+      )}
+
       <div
         className={`pet-sprite pet-sprite--${expression}`}
         onMouseDown={handleMouseDown}
@@ -118,6 +162,50 @@ export function PetApp() {
           <button className="pet-menu-item pet-menu-item--danger" onClick={handleClose}>✕ Close</button>
         </div>
       )}
+    </div>
+  );
+}
+
+// ─── Bubble ──────────────────────────────────────────────────────────────────
+
+interface BubbleProps {
+  text: string;
+  dwellMs: number;
+  onClose: () => void;
+}
+
+function Bubble({ text, dwellMs, onClose }: BubbleProps) {
+  const [remaining, setRemaining] = useState(dwellMs);
+  const hoveredRef = useRef(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      if (hoveredRef.current) return;
+      setRemaining((r) => {
+        const next = r - 100;
+        if (next <= 0) { onClose(); return 0; }
+        return next;
+      });
+    }, 100);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [onClose]);
+
+  const pct = Math.max(0, remaining / dwellMs) * 100;
+
+  return (
+    <div
+      className="pet-bubble"
+      onMouseEnter={() => { hoveredRef.current = true; }}
+      onMouseLeave={() => { hoveredRef.current = false; }}
+    >
+      <div className="pet-bubble-text">{text}</div>
+      <div className="pet-bubble-progress">
+        <div className="pet-bubble-bar" style={{ width: `${pct}%` }} />
+      </div>
+      <button className="pet-bubble-close" onClick={onClose} aria-label="Dismiss">✕</button>
     </div>
   );
 }

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+function getAgentName(): string {
+  const hash = window.location.hash; // #/pet/<name>
+  return decodeURIComponent(hash.slice("#/pet/".length));
+}
+
+interface ContextMenu {
+  visible: boolean;
+  x: number;
+  y: number;
+}
+
+const CLICK_MS = 300;
+
+export function PetApp() {
+  const agentName = getAgentName();
+  const [expression, setExpression] = useState<string>("idle");
+  const [imageSrc, setImageSrc] = useState<string>("");
+  const [contextMenu, setContextMenu] = useState<ContextMenu>({ visible: false, x: 0, y: 0 });
+  const clickTimeRef = useRef<number>(0);
+  const isDraggingRef = useRef(false);
+
+  // Load expression image whenever expression changes.
+  useEffect(() => {
+    invoke<string>("pet_get_expression", { agentName, expression }).then((src) => {
+      setImageSrc(src);
+    });
+  }, [agentName, expression]);
+
+  // Listen for expression-change events emitted by the backend (spawn wave sequence).
+  useEffect(() => {
+    const unsub = listen<string>("pet-expression", (ev) => {
+      setExpression(ev.payload);
+    });
+    return () => { unsub.then((f) => f()); };
+  }, []);
+
+  // Persist position whenever the window is moved via drag.
+  useEffect(() => {
+    const win = getCurrentWindow();
+    const unsub = win.listen("tauri://move", () => {
+      win.outerPosition().then((pos) => {
+        invoke("pet_reposition", { agentName, x: pos.x, y: pos.y }).catch(() => {});
+      });
+    });
+    return () => { unsub.then((f) => f()); };
+  }, [agentName]);
+
+  // Close context menu on click outside.
+  useEffect(() => {
+    if (!contextMenu.visible) return;
+    function close() { setContextMenu((m) => ({ ...m, visible: false })); }
+    window.addEventListener("click", close, { once: true });
+    return () => window.removeEventListener("click", close);
+  }, [contextMenu.visible]);
+
+  function handleMouseDown(e: React.MouseEvent) {
+    if (e.button !== 0) return;
+    clickTimeRef.current = Date.now();
+    isDraggingRef.current = false;
+    // Engage native window drag; Tauri moves the window.
+    getCurrentWindow().startDragging().then(() => {
+      isDraggingRef.current = true;
+    }).catch(() => {});
+  }
+
+  function handleMouseUp() {
+    // Short tap without drag → smile for 2s.
+    if (!isDraggingRef.current && Date.now() - clickTimeRef.current < CLICK_MS) {
+      setExpression("smile");
+      setTimeout(() => setExpression("idle"), 2000);
+    }
+    isDraggingRef.current = false;
+  }
+
+  function handleContextMenu(e: React.MouseEvent) {
+    e.preventDefault();
+    setContextMenu({ visible: true, x: e.clientX, y: e.clientY });
+  }
+
+  async function handleReturnToHub() {
+    setContextMenu((m) => ({ ...m, visible: false }));
+    await invoke("pet_return_to_hub", { agentName });
+  }
+
+  async function handleClose() {
+    setContextMenu((m) => ({ ...m, visible: false }));
+    await invoke("pet_close", { agentName });
+  }
+
+  const initials = agentName.split("-").slice(0, 2).map((w) => w[0]?.toUpperCase() ?? "").join("");
+
+  return (
+    <div className="pet-root" onContextMenu={handleContextMenu}>
+      <div
+        className={`pet-sprite pet-sprite--${expression}`}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+      >
+        {imageSrc ? (
+          <img src={imageSrc} alt={agentName} className="pet-image" draggable={false} />
+        ) : (
+          <div className="pet-avatar-fallback">{initials}</div>
+        )}
+      </div>
+
+      {contextMenu.visible && (
+        <div
+          className="pet-context-menu"
+          style={{ left: contextMenu.x, top: contextMenu.y }}
+        >
+          <button className="pet-menu-item" onClick={handleReturnToHub}>📥 Return to Hub</button>
+          <div className="pet-menu-divider" />
+          <button className="pet-menu-item pet-menu-item--danger" onClick={handleClose}>✕ Close</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/components/PopoverApp.tsx
+++ b/mur-hub-gui/ui/src/components/PopoverApp.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useAgents } from "../context/AgentContext";
+import { AgentRow } from "./AgentRow";
+import type { AgentEntry } from "../types";
+
+const CATEGORY_ORDER = ["research", "automation", "monitor", "notify", "commerce", "custom"];
+
+function groupByCategory(agents: AgentEntry[]) {
+  const groups: Record<string, AgentEntry[]> = {};
+  for (const agent of agents) {
+    (groups[agent.category] ??= []).push(agent);
+  }
+  return groups;
+}
+
+export function PopoverApp() {
+  const { agents } = useAgents();
+  const [query, setQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // Close on blur (lose focus).
+  useEffect(() => {
+    function onBlur() {
+      invoke("toggle_popover").catch(console.error);
+    }
+    window.addEventListener("blur", onBlur);
+    return () => window.removeEventListener("blur", onBlur);
+  }, []);
+
+  // ESC key → close.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") invoke("toggle_popover").catch(console.error);
+      if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const q = query.toLowerCase();
+  const filtered = agents.filter(
+    (a) =>
+      !q ||
+      a.name.toLowerCase().includes(q) ||
+      a.display_name.toLowerCase().includes(q),
+  );
+  const groups = groupByCategory(filtered);
+
+  function showToast(msg: string) {
+    // Minimal toast via alert fallback — no toast lib yet.
+    const el = document.createElement("div");
+    el.className = "toast";
+    el.textContent = msg;
+    document.body.appendChild(el);
+    setTimeout(() => el.remove(), 2000);
+  }
+
+  return (
+    <div className="popover-root">
+      <div className="popover-search">
+        <input
+          ref={searchRef}
+          type="search"
+          placeholder="Search agents… (⌘F)"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          autoFocus
+        />
+      </div>
+
+      <div className="popover-list">
+        {filtered.length === 0 && (
+          <p className="empty-hint">No agents found.</p>
+        )}
+        {CATEGORY_ORDER.filter((cat) => (groups[cat]?.length ?? 0) > 0).map((cat) => (
+          <div key={cat} className="agent-group">
+            <div className="group-header">{cat}</div>
+            {groups[cat].map((agent) => (
+              <AgentRow key={agent.name} agent={agent} />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      <div className="popover-footer">
+        <button
+          className="footer-btn primary"
+          onClick={() =>
+            window.open("https://docs.mur.run/agents/create", "_blank")
+          }
+        >
+          + New Agent
+        </button>
+        <button className="footer-btn" onClick={() => showToast("Coming soon")}>
+          ⚙ Settings
+        </button>
+        <button className="footer-btn" onClick={() => showToast("Coming soon")}>
+          📥 Import
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/components/PresetImportModal.tsx
+++ b/mur-hub-gui/ui/src/components/PresetImportModal.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/plugin-dialog";
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type Mode = "file" | "url";
+
+export function PresetImportModal({ isOpen, onClose }: Props) {
+  const [mode, setMode] = useState<Mode>("file");
+  const [url, setUrl] = useState("");
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  if (!isOpen) return null;
+
+  function reset() {
+    setUrl("");
+    setStatus(null);
+    setError(null);
+    setLoading(false);
+  }
+
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  async function importFile() {
+    setLoading(true);
+    setError(null);
+    setStatus(null);
+    try {
+      const selected = await open({
+        multiple: false,
+        filters: [{ name: "YAML preset", extensions: ["yaml", "yml"] }],
+      });
+      if (!selected) {
+        setLoading(false);
+        return;
+      }
+      const id = await invoke<string>("import_preset_file", {
+        path: typeof selected === "string" ? selected : selected[0],
+      });
+      setStatus(`Imported preset "${id}"`);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function importUrl() {
+    if (!url.trim()) return;
+    setLoading(true);
+    setError(null);
+    setStatus(null);
+    try {
+      const id = await invoke<string>("import_preset_url", { url: url.trim() });
+      setStatus(`Imported preset "${id}"`);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="modal-overlay" onClick={handleClose}>
+      <div
+        className="modal-panel"
+        style={{ maxWidth: 440 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <h2>Import Style Preset</h2>
+          <button className="modal-close" onClick={handleClose}>×</button>
+        </div>
+
+        <div className="modal-body">
+          <div className="tab-row" style={{ display: "flex", gap: 8, marginBottom: 16 }}>
+            <button
+              className={`toolbar-btn${mode === "file" ? " active" : ""}`}
+              onClick={() => setMode("file")}
+            >
+              From File
+            </button>
+            <button
+              className={`toolbar-btn${mode === "url" ? " active" : ""}`}
+              onClick={() => setMode("url")}
+            >
+              From URL
+            </button>
+          </div>
+
+          {mode === "file" ? (
+            <div>
+              <p style={{ marginBottom: 12, color: "var(--text-secondary, #888)", fontSize: 13 }}>
+                Select a <code>.yaml</code> file containing a StylePreset definition.
+                It will be copied to <code>~/.mur/hub/presets/</code>.
+              </p>
+              <button
+                className="toolbar-btn"
+                onClick={importFile}
+                disabled={loading}
+              >
+                {loading ? "Importing…" : "Choose File…"}
+              </button>
+            </div>
+          ) : (
+            <div>
+              <p style={{ marginBottom: 8, color: "var(--text-secondary, #888)", fontSize: 13 }}>
+                Enter a URL pointing to a StylePreset YAML file.
+              </p>
+              <input
+                type="url"
+                placeholder="https://example.com/my-preset.yaml"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && importUrl()}
+                style={{ width: "100%", marginBottom: 8 }}
+              />
+              <button
+                className="toolbar-btn"
+                onClick={importUrl}
+                disabled={loading || !url.trim()}
+              >
+                {loading ? "Fetching…" : "Import from URL"}
+              </button>
+            </div>
+          )}
+
+          {status && (
+            <p style={{ marginTop: 12, color: "var(--color-success, #4caf50)", fontSize: 13 }}>
+              {status}
+            </p>
+          )}
+          {error && (
+            <p style={{ marginTop: 12, color: "var(--color-error, #f44336)", fontSize: 13 }}>
+              {error}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/components/wizard/WizardModal.tsx
+++ b/mur-hub-gui/ui/src/components/wizard/WizardModal.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from "react";
+import type { WizardSnapshot } from "../../types";
+import { invoke } from "@tauri-apps/api/core";
+import { Step1Persona } from "./steps/Step1Persona";
+import { Step2Name } from "./steps/Step2Name";
+import { Step3Style } from "./steps/Step3Style";
+import { Step4Behavior } from "./steps/Step4Behavior";
+import { Step5Photo } from "./steps/Step5Photo";
+import { Step6Render } from "./steps/Step6Render";
+
+interface Props {
+  isOpen: boolean;
+  onClose: (agentName?: string) => void;
+}
+
+export function WizardModal({ isOpen, onClose }: Props) {
+  const [snapshot, setSnapshot] = useState<WizardSnapshot | null>(null);
+  const [displayStep, setDisplayStep] = useState(1);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setLoading(true);
+    invoke<WizardSnapshot>("wizard_open")
+      .then((s) => {
+        setSnapshot(s);
+        setDisplayStep(s.step);
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") handleClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isOpen]);
+
+  function handleClose() {
+    invoke("wizard_cancel").catch(() => {});
+    setSnapshot(null);
+    setDisplayStep(1);
+    onClose();
+  }
+
+  function handleUpdate(s: WizardSnapshot) {
+    setSnapshot(s);
+    const nextStep = s.step === 5 && !s.needs_photo ? 6 : s.step;
+    setDisplayStep(nextStep);
+  }
+
+  function handleBack() {
+    if (displayStep <= 1) return;
+    let prev = displayStep - 1;
+    if (prev === 5 && snapshot && !snapshot.needs_photo) prev = 4;
+    setDisplayStep(prev);
+  }
+
+  function handleFinish(agentName: string) {
+    setSnapshot(null);
+    setDisplayStep(1);
+    onClose(agentName);
+  }
+
+  if (!isOpen) return null;
+
+  const totalVisible = snapshot?.needs_photo ? 6 : 5;
+  const visibleStep =
+    !snapshot?.needs_photo && displayStep >= 6 ? 5 : displayStep;
+
+  return (
+    <div
+      className="wz-overlay"
+      onMouseDown={(e) => e.target === e.currentTarget && handleClose()}
+    >
+      <div className="wz-modal" role="dialog" aria-modal="true">
+        <div className="wz-header">
+          <div className="wz-progress-dots">
+            {Array.from({ length: totalVisible }, (_, i) => (
+              <span
+                key={i}
+                className={`wz-dot${
+                  i + 1 === visibleStep
+                    ? " wz-dot--active"
+                    : i + 1 < visibleStep
+                    ? " wz-dot--done"
+                    : ""
+                }`}
+              />
+            ))}
+          </div>
+          <button className="wz-close" onClick={handleClose} aria-label="Close">
+            ✕
+          </button>
+        </div>
+
+        <div className="wz-body">
+          {loading || !snapshot ? (
+            <div className="wz-loading">Loading…</div>
+          ) : (
+            <>
+              {displayStep === 1 && (
+                <Step1Persona snapshot={snapshot} onUpdate={handleUpdate} />
+              )}
+              {displayStep === 2 && (
+                <Step2Name snapshot={snapshot} onUpdate={handleUpdate} />
+              )}
+              {displayStep === 3 && (
+                <Step3Style snapshot={snapshot} onUpdate={handleUpdate} />
+              )}
+              {displayStep === 4 && (
+                <Step4Behavior snapshot={snapshot} onUpdate={handleUpdate} />
+              )}
+              {displayStep === 5 && snapshot.needs_photo && (
+                <Step5Photo
+                  snapshot={snapshot}
+                  onUpdate={handleUpdate}
+                  onSkip={() => setDisplayStep(6)}
+                />
+              )}
+              {displayStep === 6 && (
+                <Step6Render snapshot={snapshot} onFinish={handleFinish} />
+              )}
+            </>
+          )}
+        </div>
+
+        {!loading && snapshot && displayStep > 1 && displayStep < 6 && (
+          <div className="wz-footer">
+            <button className="wz-btn ghost" onClick={handleBack}>
+              ← Back
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/components/wizard/steps/Step1Persona.tsx
+++ b/mur-hub-gui/ui/src/components/wizard/steps/Step1Persona.tsx
@@ -1,0 +1,42 @@
+import type { WizardPersona, WizardSnapshot } from "../../../types";
+import { invoke } from "@tauri-apps/api/core";
+
+const PERSONAS: { id: WizardPersona; label: string; icon: string }[] = [
+  { id: "research",   label: "Research",   icon: "🔍" },
+  { id: "automation", label: "Automation", icon: "⚙️" },
+  { id: "monitor",    label: "Monitor",    icon: "📡" },
+  { id: "notify",     label: "Notify",     icon: "🔔" },
+  { id: "commerce",   label: "Commerce",   icon: "🛒" },
+  { id: "custom",     label: "Custom",     icon: "✨" },
+];
+
+interface Props {
+  snapshot: WizardSnapshot;
+  onUpdate: (s: WizardSnapshot) => void;
+}
+
+export function Step1Persona({ snapshot, onUpdate }: Props) {
+  async function pick(id: WizardPersona) {
+    const next: WizardSnapshot = await invoke("wizard_set_persona", { persona: id });
+    onUpdate(next);
+  }
+
+  return (
+    <div className="wz-step">
+      <h2>What does this agent do?</h2>
+      <p className="wz-hint">Choose a persona category to get started.</p>
+      <div className="wz-persona-grid">
+        {PERSONAS.map(({ id, label, icon }) => (
+          <button
+            key={id}
+            className={`wz-persona-card${snapshot.persona === id ? " selected" : ""}`}
+            onClick={() => pick(id)}
+          >
+            <span className="wz-persona-icon">{icon}</span>
+            <span className="wz-persona-label">{label}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/components/wizard/steps/Step2Name.tsx
+++ b/mur-hub-gui/ui/src/components/wizard/steps/Step2Name.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import type { WizardSnapshot } from "../../../types";
+import { invoke } from "@tauri-apps/api/core";
+
+interface Props {
+  snapshot: WizardSnapshot;
+  onUpdate: (s: WizardSnapshot) => void;
+}
+
+export function Step2Name({ snapshot, onUpdate }: Props) {
+  const [name, setName] = useState(snapshot.name ?? "");
+  const [desc, setDesc] = useState(snapshot.description ?? "");
+  const [error, setError] = useState<string | null>(null);
+
+  async function next() {
+    setError(null);
+    try {
+      const s: WizardSnapshot = await invoke("wizard_set_name", { name, description: desc });
+      onUpdate(s);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  return (
+    <div className="wz-step">
+      <h2>Name your agent</h2>
+      <p className="wz-hint">Use lowercase letters and hyphens only (e.g. <code>my-researcher</code>).</p>
+
+      <label className="wz-label">
+        Agent name
+        <input
+          className="wz-input"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="my-agent"
+          autoFocus
+          onKeyDown={(e) => e.key === "Enter" && next()}
+        />
+      </label>
+
+      <label className="wz-label">
+        Short description <span className="wz-optional">(optional)</span>
+        <textarea
+          className="wz-textarea"
+          value={desc}
+          onChange={(e) => setDesc(e.target.value)}
+          placeholder="This agent helps me…"
+          rows={3}
+        />
+      </label>
+
+      {error && <p className="wz-error">{error}</p>}
+
+      <div className="wz-actions">
+        <button className="wz-btn primary" onClick={next} disabled={!name.trim()}>
+          Continue →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/components/wizard/steps/Step3Style.tsx
+++ b/mur-hub-gui/ui/src/components/wizard/steps/Step3Style.tsx
@@ -1,0 +1,46 @@
+import type { WizardSnapshot, PresetSummary } from "../../../types";
+import { BUILTIN_PRESETS } from "../../../types";
+import { invoke } from "@tauri-apps/api/core";
+
+const FAMILY_EMOJI: Record<string, string> = {
+  chibi:    "🐣",
+  pixel:    "🕹️",
+  live2d:   "🎭",
+  polaroid: "📸",
+};
+
+interface Props {
+  snapshot: WizardSnapshot;
+  onUpdate: (s: WizardSnapshot) => void;
+}
+
+export function Step3Style({ snapshot, onUpdate }: Props) {
+  async function pick(id: string) {
+    const s: WizardSnapshot = await invoke("wizard_set_preset", { presetId: id });
+    onUpdate(s);
+  }
+
+  return (
+    <div className="wz-step">
+      <h2>Choose a style preset</h2>
+      <p className="wz-hint">Your agent's visual identity — 12 expressions will be rendered by AI.</p>
+
+      <div className="wz-preset-grid">
+        {BUILTIN_PRESETS.map((p: PresetSummary) => (
+          <button
+            key={p.id}
+            className={`wz-preset-card${snapshot.style_preset_id === p.id ? " selected" : ""}`}
+            onClick={() => pick(p.id)}
+          >
+            <span className="wz-preset-family-icon">
+              {FAMILY_EMOJI[p.family] ?? "🎨"}
+            </span>
+            <span className="wz-preset-name">{p.display_name}</span>
+            <span className="wz-preset-desc">{p.description}</span>
+            <span className="wz-preset-family-tag">{p.family}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/components/wizard/steps/Step4Behavior.tsx
+++ b/mur-hub-gui/ui/src/components/wizard/steps/Step4Behavior.tsx
@@ -1,0 +1,40 @@
+import type { BehaviorPreset, WizardSnapshot } from "../../../types";
+import { invoke } from "@tauri-apps/api/core";
+
+const BEHAVIORS: { id: BehaviorPreset; label: string; desc: string }[] = [
+  { id: "quiet",  label: "Quiet",  desc: "Stays still, no proactive messages" },
+  { id: "normal", label: "Normal", desc: "Gentle wander, voice on, daily check-ins" },
+  { id: "lively", label: "Lively", desc: "Frequent expressions, enthusiastic reactions" },
+];
+
+interface Props {
+  snapshot: WizardSnapshot;
+  onUpdate: (s: WizardSnapshot) => void;
+}
+
+export function Step4Behavior({ snapshot, onUpdate }: Props) {
+  async function pick(id: BehaviorPreset) {
+    const s: WizardSnapshot = await invoke("wizard_set_behavior", { behavior: id });
+    onUpdate(s);
+  }
+
+  return (
+    <div className="wz-step">
+      <h2>Choose behavior</h2>
+      <p className="wz-hint">How active should your companion pet be?</p>
+
+      <div className="wz-behavior-list">
+        {BEHAVIORS.map(({ id, label, desc }) => (
+          <button
+            key={id}
+            className={`wz-behavior-card${snapshot.behavior_preset === id ? " selected" : ""}`}
+            onClick={() => pick(id)}
+          >
+            <span className="wz-behavior-label">{label}</span>
+            <span className="wz-behavior-desc">{desc}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/components/wizard/steps/Step5Photo.tsx
+++ b/mur-hub-gui/ui/src/components/wizard/steps/Step5Photo.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import type { WizardSnapshot } from "../../../types";
+import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/plugin-dialog";
+
+interface Props {
+  snapshot: WizardSnapshot;
+  onUpdate: (s: WizardSnapshot) => void;
+  onSkip: () => void;
+}
+
+export function Step5Photo({ snapshot, onUpdate, onSkip }: Props) {
+  const [error, setError] = useState<string | null>(null);
+
+  async function pickPhoto() {
+    setError(null);
+    try {
+      const selected = await open({
+        multiple: false,
+        filters: [{ name: "Images", extensions: ["jpg", "jpeg", "png", "webp", "heic"] }],
+      });
+      if (!selected) return;
+      const path = typeof selected === "string" ? selected : selected[0];
+      const s: WizardSnapshot = await invoke("wizard_set_photo", { path });
+      onUpdate(s);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  return (
+    <div className="wz-step">
+      <h2>Upload source photo</h2>
+      <p className="wz-hint">
+        The <strong>Family Photo</strong> preset uses your photo as a reference to generate a
+        personalized cartoon companion. Your photo stays local — it is never uploaded.
+      </p>
+
+      {snapshot.source_photo ? (
+        <div className="wz-photo-selected">
+          <span>✅ {snapshot.source_photo.split("/").pop()}</span>
+          <button className="wz-btn secondary" onClick={pickPhoto}>
+            Change photo
+          </button>
+        </div>
+      ) : (
+        <button className="wz-btn primary" onClick={pickPhoto}>
+          📁 Choose photo…
+        </button>
+      )}
+
+      {error && <p className="wz-error">{error}</p>}
+
+      <div className="wz-actions">
+        <button className="wz-btn ghost" onClick={onSkip}>
+          Skip (use placeholder)
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/components/wizard/steps/Step6Render.tsx
+++ b/mur-hub-gui/ui/src/components/wizard/steps/Step6Render.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react";
+import type { RenderProgressSnapshot, WizardSnapshot } from "../../../types";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+
+interface Props {
+  snapshot: WizardSnapshot;
+  onFinish: (agentName: string) => void;
+}
+
+export function Step6Render({ snapshot, onFinish }: Props) {
+  const [progress, setProgress] = useState<RenderProgressSnapshot | null>(
+    snapshot.render_progress ?? null,
+  );
+  const [done, setDone] = useState(snapshot.render_done);
+  const [error, setError] = useState<string | null>(null);
+  const [started, setStarted] = useState(false);
+
+  useEffect(() => {
+    const unsubProgress = listen<RenderProgressSnapshot>("wizard-render-progress", (ev) => {
+      setProgress(ev.payload);
+    });
+    const unsubDone = listen<{ expressions_rendered: number; total: number }>(
+      "wizard-render-done",
+      () => setDone(true),
+    );
+    const unsubError = listen<string>("wizard-render-error", (ev) => {
+      setError(ev.payload);
+    });
+    return () => {
+      unsubProgress.then((f) => f());
+      unsubDone.then((f) => f());
+      unsubError.then((f) => f());
+    };
+  }, []);
+
+  async function startRender() {
+    setStarted(true);
+    setError(null);
+    try {
+      await invoke("wizard_start_render");
+    } catch (e) {
+      setError(String(e));
+      setStarted(false);
+    }
+  }
+
+  async function finish() {
+    try {
+      const name: string = await invoke("wizard_finish");
+      onFinish(name);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  async function useDefaultBlob() {
+    try {
+      const name: string = await invoke("wizard_finish");
+      onFinish(name);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  const pct =
+    progress && progress.total > 0
+      ? Math.round((progress.done / progress.total) * 100)
+      : 0;
+
+  return (
+    <div className="wz-step">
+      <h2>Generate expressions</h2>
+      <p className="wz-hint">
+        12 expression images will be rendered using AI.
+        This takes 30–60 seconds and costs ~$0.04.
+      </p>
+
+      {!started && !done && (
+        <div className="wz-render-actions">
+          <button className="wz-btn primary" onClick={startRender}>
+            ✨ Generate now
+          </button>
+          <button className="wz-btn ghost" onClick={useDefaultBlob}>
+            🛟 Use default blob, render later
+          </button>
+        </div>
+      )}
+
+      {started && !done && progress && (
+        <div className="wz-progress">
+          <div className="wz-progress-bar" style={{ width: `${pct}%` }} />
+          <p className="wz-progress-text">
+            {progress.done} / {progress.total} done
+            {progress.failed > 0 && (
+              <span className="wz-progress-failed"> · {progress.failed} failed</span>
+            )}
+          </p>
+        </div>
+      )}
+
+      {started && !done && !progress && (
+        <p className="wz-progress-text">Starting render…</p>
+      )}
+
+      {done && (
+        <div className="wz-render-done">
+          <p>✅ All expressions rendered!</p>
+          <button className="wz-btn primary" onClick={finish}>
+            Finish →
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <div className="wz-render-error">
+          <p className="wz-error">{error}</p>
+          <button className="wz-btn ghost" onClick={useDefaultBlob}>
+            🛟 Continue with default blob
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/context/AgentContext.tsx
+++ b/mur-hub-gui/ui/src/context/AgentContext.tsx
@@ -1,26 +1,30 @@
 import React, { createContext, useContext, useEffect, useReducer } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { AgentEntry } from "../types";
+import type { AgentEntry, AgentRuntimeStatus } from "../types";
 
 interface AgentContextValue {
   agents: AgentEntry[];
+  runtimeStatuses: AgentRuntimeStatus[];
   selectedAgent: string | null;
   setSelected: (name: string | null) => void;
 }
 
 const AgentContext = createContext<AgentContextValue>({
   agents: [],
+  runtimeStatuses: [],
   selectedAgent: null,
   setSelected: () => {},
 });
 
 type Action =
   | { type: "set_agents"; agents: AgentEntry[] }
+  | { type: "set_runtime"; statuses: AgentRuntimeStatus[] }
   | { type: "set_selected"; name: string | null };
 
 interface State {
   agents: AgentEntry[];
+  runtimeStatuses: AgentRuntimeStatus[];
   selectedAgent: string | null;
 }
 
@@ -28,30 +32,39 @@ function reducer(state: State, action: Action): State {
   switch (action.type) {
     case "set_agents":
       return { ...state, agents: action.agents };
+    case "set_runtime":
+      return { ...state, runtimeStatuses: action.statuses };
     case "set_selected":
       return { ...state, selectedAgent: action.name };
   }
 }
 
 export function AgentProvider({ children }: { children: React.ReactNode }) {
-  const [state, dispatch] = useReducer(reducer, { agents: [], selectedAgent: null });
+  const [state, dispatch] = useReducer(reducer, {
+    agents: [],
+    runtimeStatuses: [],
+    selectedAgent: null,
+  });
 
   useEffect(() => {
     invoke<AgentEntry[]>("list_agents")
       .then((agents) => dispatch({ type: "set_agents", agents }))
       .catch(console.error);
 
-    const unlisten = listen<AgentEntry[]>("agents-updated", (event) => {
-      dispatch({ type: "set_agents", agents: event.payload });
-    });
-
-    const unlistenSelect = listen<string>("select-agent", (event) => {
-      dispatch({ type: "set_selected", name: event.payload });
-    });
+    const unAgents = listen<AgentEntry[]>("agents-updated", (e) =>
+      dispatch({ type: "set_agents", agents: e.payload }),
+    );
+    const unRuntime = listen<AgentRuntimeStatus[]>("runtime-status-changed", (e) =>
+      dispatch({ type: "set_runtime", statuses: e.payload }),
+    );
+    const unSelect = listen<string>("select-agent", (e) =>
+      dispatch({ type: "set_selected", name: e.payload }),
+    );
 
     return () => {
-      unlisten.then((fn) => fn());
-      unlistenSelect.then((fn) => fn());
+      unAgents.then((fn) => fn());
+      unRuntime.then((fn) => fn());
+      unSelect.then((fn) => fn());
     };
   }, []);
 
@@ -59,6 +72,7 @@ export function AgentProvider({ children }: { children: React.ReactNode }) {
     <AgentContext.Provider
       value={{
         agents: state.agents,
+        runtimeStatuses: state.runtimeStatuses,
         selectedAgent: state.selectedAgent,
         setSelected: (name) => dispatch({ type: "set_selected", name }),
       }}

--- a/mur-hub-gui/ui/src/context/AgentContext.tsx
+++ b/mur-hub-gui/ui/src/context/AgentContext.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, useContext, useEffect, useReducer } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { AgentEntry } from "../types";
+
+interface AgentContextValue {
+  agents: AgentEntry[];
+  selectedAgent: string | null;
+  setSelected: (name: string | null) => void;
+}
+
+const AgentContext = createContext<AgentContextValue>({
+  agents: [],
+  selectedAgent: null,
+  setSelected: () => {},
+});
+
+type Action =
+  | { type: "set_agents"; agents: AgentEntry[] }
+  | { type: "set_selected"; name: string | null };
+
+interface State {
+  agents: AgentEntry[];
+  selectedAgent: string | null;
+}
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "set_agents":
+      return { ...state, agents: action.agents };
+    case "set_selected":
+      return { ...state, selectedAgent: action.name };
+  }
+}
+
+export function AgentProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, { agents: [], selectedAgent: null });
+
+  useEffect(() => {
+    invoke<AgentEntry[]>("list_agents")
+      .then((agents) => dispatch({ type: "set_agents", agents }))
+      .catch(console.error);
+
+    const unlisten = listen<AgentEntry[]>("agents-updated", (event) => {
+      dispatch({ type: "set_agents", agents: event.payload });
+    });
+
+    const unlistenSelect = listen<string>("select-agent", (event) => {
+      dispatch({ type: "set_selected", name: event.payload });
+    });
+
+    return () => {
+      unlisten.then((fn) => fn());
+      unlistenSelect.then((fn) => fn());
+    };
+  }, []);
+
+  return (
+    <AgentContext.Provider
+      value={{
+        agents: state.agents,
+        selectedAgent: state.selectedAgent,
+        setSelected: (name) => dispatch({ type: "set_selected", name }),
+      }}
+    >
+      {children}
+    </AgentContext.Provider>
+  );
+}
+
+export function useAgents() {
+  return useContext(AgentContext);
+}

--- a/mur-hub-gui/ui/src/styles.css
+++ b/mur-hub-gui/ui/src/styles.css
@@ -7,6 +7,7 @@
   --status-running: #22C55E;
   --status-idle: #6B7280;
   --status-stale: #EF4444;
+  --status-restarting: #F59E0B;
 
   /* Surface */
   --bg: #FFFFFF;
@@ -64,9 +65,11 @@ input {
   border-radius: 50%;
   flex-shrink: 0;
 }
-.status-dot.status-running { background: var(--status-running); }
-.status-dot.status-idle    { background: var(--status-idle); }
-.status-dot.status-stale   { background: var(--status-stale); }
+.status-dot.status-running    { background: var(--status-running); }
+.status-dot.status-idle       { background: var(--status-idle); }
+.status-dot.status-stale      { background: var(--status-stale); }
+.status-dot.status-restarting { background: var(--status-restarting); animation: pulse 1s infinite; }
+@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
 
 /* ── Popover ──────────────────────────────────────────────────────────── */
 .popover-root {
@@ -321,7 +324,8 @@ input {
   font-size: 12px;
   background: var(--bg-secondary);
 }
-.grid-actions button:hover { background: var(--bg-hover); }
+.grid-actions button:hover:not(:disabled) { background: var(--bg-hover); }
+.grid-actions button:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* ── List view ────────────────────────────────────────────────────────── */
 .list-view { display: flex; flex-direction: column; gap: 2px; }

--- a/mur-hub-gui/ui/src/styles.css
+++ b/mur-hub-gui/ui/src/styles.css
@@ -388,3 +388,188 @@ input {
   from { opacity: 0; transform: translateX(-50%) translateY(8px); }
   to   { opacity: 1; transform: translateX(-50%) translateY(0); }
 }
+
+/* ── Wizard ───────────────────────────────────────────────────────────── */
+.wz-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(2px);
+}
+.wz-modal {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  width: 480px;
+  max-width: 95vw;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.4);
+  animation: fadeInUp 0.18s ease;
+}
+.wz-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.wz-progress-dots { display: flex; gap: 6px; align-items: center; }
+.wz-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--border);
+  transition: background 0.15s, width 0.15s;
+}
+.wz-dot--active { background: var(--accent); width: 20px; border-radius: 4px; }
+.wz-dot--done   { background: var(--accent); opacity: 0.4; }
+.wz-close {
+  background: none; border: none; cursor: pointer;
+  color: var(--text-secondary); font-size: 14px; padding: 4px 6px;
+  border-radius: 4px; line-height: 1;
+}
+.wz-close:hover { background: var(--bg-hover); color: var(--text-primary); }
+.wz-body {
+  padding: 24px 28px;
+  overflow-y: auto;
+  flex: 1;
+}
+.wz-footer {
+  padding: 12px 20px;
+  border-top: 1px solid var(--border);
+}
+.wz-loading { color: var(--text-secondary); text-align: center; padding: 40px 0; }
+.wz-step h2 { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.wz-hint { font-size: 13px; color: var(--text-secondary); margin: 0 0 20px; line-height: 1.5; }
+.wz-optional { font-size: 12px; color: var(--text-secondary); font-weight: 400; }
+
+/* Buttons */
+.wz-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: 6px; padding: 9px 18px; border-radius: 8px;
+  font-size: 14px; font-weight: 500; cursor: pointer; border: none;
+  transition: background 0.12s, opacity 0.12s;
+}
+.wz-btn.primary { background: var(--accent); color: #fff; }
+.wz-btn.primary:hover { background: var(--accent-hover, #4338CA); }
+.wz-btn.primary:disabled { opacity: 0.4; cursor: not-allowed; }
+.wz-btn.secondary { background: var(--bg-hover); color: var(--text-primary); }
+.wz-btn.secondary:hover { background: var(--border); }
+.wz-btn.ghost {
+  background: none; color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+.wz-btn.ghost:hover { background: var(--bg-hover); color: var(--text-primary); }
+.wz-actions { margin-top: 20px; display: flex; gap: 10px; justify-content: flex-end; }
+.wz-error { color: #EF4444; font-size: 13px; margin: 8px 0 0; }
+
+/* Inputs */
+.wz-label {
+  display: flex; flex-direction: column; gap: 5px;
+  font-size: 13px; font-weight: 500; color: var(--text-primary); margin-bottom: 14px;
+}
+.wz-input, .wz-textarea {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 14px;
+  padding: 8px 10px;
+  width: 100%;
+  box-sizing: border-box;
+  outline: none;
+  font-family: inherit;
+}
+.wz-input:focus, .wz-textarea:focus { border-color: var(--accent); }
+.wz-textarea { resize: vertical; min-height: 72px; }
+
+/* Step 1 — Persona grid */
+.wz-persona-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+.wz-persona-card {
+  display: flex; flex-direction: column; align-items: center;
+  gap: 6px; padding: 16px 12px;
+  background: var(--bg-secondary);
+  border: 2px solid var(--border);
+  border-radius: 10px; cursor: pointer;
+  transition: border-color 0.12s, background 0.12s;
+}
+.wz-persona-card:hover { border-color: var(--accent); background: var(--bg-hover); }
+.wz-persona-card.selected { border-color: var(--accent); background: rgba(99,102,241,0.08); }
+.wz-persona-icon { font-size: 26px; }
+.wz-persona-label { font-size: 13px; font-weight: 600; }
+.wz-persona-desc { font-size: 11px; color: var(--text-secondary); text-align: center; line-height: 1.4; }
+
+/* Step 3 — Preset grid */
+.wz-preset-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+}
+.wz-preset-card {
+  display: flex; flex-direction: column; gap: 3px;
+  padding: 14px 14px; text-align: left;
+  background: var(--bg-secondary);
+  border: 2px solid var(--border);
+  border-radius: 10px; cursor: pointer;
+  transition: border-color 0.12s, background 0.12s;
+}
+.wz-preset-card:hover { border-color: var(--accent); background: var(--bg-hover); }
+.wz-preset-card.selected { border-color: var(--accent); background: rgba(99,102,241,0.08); }
+.wz-preset-family-icon { font-size: 22px; }
+.wz-preset-name { font-size: 13px; font-weight: 600; }
+.wz-preset-desc { font-size: 11px; color: var(--text-secondary); line-height: 1.4; }
+.wz-preset-family-tag {
+  display: inline-block; margin-top: 4px;
+  font-size: 10px; color: var(--text-secondary);
+  background: var(--border); border-radius: 4px; padding: 1px 5px;
+  text-transform: capitalize;
+}
+
+/* Step 4 — Behavior list */
+.wz-behavior-list { display: flex; flex-direction: column; gap: 8px; }
+.wz-behavior-card {
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px 16px; text-align: left;
+  background: var(--bg-secondary);
+  border: 2px solid var(--border);
+  border-radius: 10px; cursor: pointer;
+  transition: border-color 0.12s, background 0.12s;
+}
+.wz-behavior-card:hover { border-color: var(--accent); background: var(--bg-hover); }
+.wz-behavior-card.selected { border-color: var(--accent); background: rgba(99,102,241,0.08); }
+.wz-behavior-label { font-size: 14px; font-weight: 600; min-width: 60px; }
+.wz-behavior-desc { font-size: 12px; color: var(--text-secondary); }
+
+/* Step 5 — Photo */
+.wz-photo-selected {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 16px; font-size: 14px; color: var(--text-primary);
+}
+
+/* Step 6 — Render */
+.wz-render-actions { display: flex; flex-direction: column; gap: 10px; margin-top: 8px; }
+.wz-progress {
+  background: var(--bg-secondary);
+  border-radius: 6px; overflow: hidden;
+  height: 8px; margin: 12px 0 6px;
+  position: relative;
+}
+.wz-progress-bar {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 6px;
+  transition: width 0.3s ease;
+}
+.wz-progress-text { font-size: 13px; color: var(--text-secondary); margin: 0; }
+.wz-progress-failed { color: #EF4444; }
+.wz-render-done { display: flex; flex-direction: column; gap: 12px; align-items: flex-start; }
+.wz-render-error { margin-top: 10px; display: flex; flex-direction: column; gap: 10px; }

--- a/mur-hub-gui/ui/src/styles.css
+++ b/mur-hub-gui/ui/src/styles.css
@@ -1,29 +1,386 @@
+/* ── Design tokens ────────────────────────────────────────────────────── */
 :root {
+  --brand: #4F46E5;
+  --brand-light: #818CF8;
+
+  /* Status dot colours */
+  --status-running: #22C55E;
+  --status-idle: #6B7280;
+  --status-stale: #EF4444;
+
+  /* Surface */
+  --bg: #FFFFFF;
+  --bg-secondary: #F9FAFB;
+  --bg-hover: #F3F4F6;
+  --border: rgba(0, 0, 0, 0.12);
+  --shadow: 0 4px 16px rgba(0, 0, 0, 0.12), 0 1px 4px rgba(0, 0, 0, 0.06);
+
+  /* Text */
+  --text: #111827;
+  --text-secondary: #6B7280;
+  --text-inverse: #FFFFFF;
+
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
   color-scheme: light dark;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1F2937;
+    --bg-secondary: #111827;
+    --bg-hover: #374151;
+    --border: rgba(255, 255, 255, 0.10);
+    --text: #F9FAFB;
+    --text-secondary: #9CA3AF;
+  }
+}
+
+/* ── Reset ────────────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; }
 body {
   margin: 0;
-  display: grid;
-  place-items: center;
-  min-height: 100vh;
-  background: linear-gradient(135deg, #f7f5ef 0%, #ece5d6 100%);
+  background: var(--bg);
+  color: var(--text);
+  overflow: hidden;
+}
+button {
+  cursor: pointer;
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+}
+input {
+  font: inherit;
+  color: inherit;
 }
 
-.hub-shell {
-  padding: 32px;
-  text-align: center;
+/* ── Status dots ──────────────────────────────────────────────────────── */
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.status-running { background: var(--status-running); }
+.status-dot.status-idle    { background: var(--status-idle); }
+.status-dot.status-stale   { background: var(--status-stale); }
+
+/* ── Popover ──────────────────────────────────────────────────────────── */
+.popover-root {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
 }
 
-.hub-shell h1 {
-  margin: 0 0 8px;
-  font-size: 28px;
+.popover-search {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.popover-search input {
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  outline: none;
+}
+.popover-search input:focus {
+  border-color: var(--brand);
+}
+
+.popover-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.agent-group {}
+.group-header {
+  padding: 4px 12px;
+  font-size: 11px;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
 }
 
-.hub-shell .subtitle {
+.agent-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 7px 12px;
+  border-radius: 0;
+  text-align: left;
+  transition: background 0.1s;
+}
+.agent-row:hover { background: var(--bg-hover); }
+
+.agent-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-inverse);
+  flex-shrink: 0;
+}
+
+.agent-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.agent-name {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.agent-category {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.popover-footer {
+  display: flex;
+  gap: 6px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--border);
+}
+.footer-btn {
+  flex: 1;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+  background: var(--bg-secondary);
+  transition: background 0.1s;
+}
+.footer-btn:hover { background: var(--bg-hover); }
+.footer-btn.primary {
+  background: var(--brand);
+  color: var(--text-inverse);
+  border-color: transparent;
+}
+.footer-btn.primary:hover { opacity: 0.9; }
+
+/* ── Dashboard ────────────────────────────────────────────────────────── */
+.dashboard-root {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  height: 100vh;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 8px;
+  border-right: 1px solid var(--border);
+  background: var(--bg-secondary);
+  overflow-y: auto;
+}
+.sidebar-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  border-radius: 6px;
+  width: 100%;
+  text-align: left;
+  font-size: 13px;
+  transition: background 0.1s;
+}
+.sidebar-item:hover { background: var(--bg-hover); }
+.sidebar-item--active {
+  background: var(--brand);
+  color: var(--text-inverse);
+}
+.badge {
+  font-size: 11px;
+  background: rgba(0,0,0,0.15);
+  padding: 1px 6px;
+  border-radius: 10px;
+}
+.sidebar-item--active .badge { background: rgba(255,255,255,0.25); }
+
+.dashboard-main {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.toolbar-btn {
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  font-size: 13px;
+  transition: background 0.1s;
+}
+.toolbar-btn:hover { background: var(--bg-hover); }
+.toolbar-search {
+  flex: 1;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  outline: none;
+}
+.toolbar-search:focus { border-color: var(--brand); }
+.view-toggle {
+  display: flex;
+  gap: 2px;
+}
+.view-toggle button {
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  font-size: 16px;
+}
+.view-toggle button.active {
+  background: var(--brand);
+  color: var(--text-inverse);
+  border-color: transparent;
+}
+
+.dashboard-content { flex: 1; overflow-y: auto; padding: 14px; }
+
+/* ── Grid view ────────────────────────────────────────────────────────── */
+.grid-view {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+}
+.grid-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 16px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg);
+  transition: box-shadow 0.15s;
+}
+.grid-card:hover { box-shadow: 0 2px 8px rgba(0,0,0,0.10); }
+.grid-card--selected { border-color: var(--brand); }
+.grid-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-inverse);
+}
+.grid-name {
   margin: 0;
   font-size: 13px;
-  opacity: 0.6;
+  font-weight: 500;
+  text-align: center;
+}
+.grid-status {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.grid-status-text { font-size: 11px; color: var(--text-secondary); }
+.grid-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+.grid-actions button {
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  font-size: 12px;
+  background: var(--bg-secondary);
+}
+.grid-actions button:hover { background: var(--bg-hover); }
+
+/* ── List view ────────────────────────────────────────────────────────── */
+.list-view { display: flex; flex-direction: column; gap: 2px; }
+.list-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  transition: background 0.1s;
+}
+.list-row:hover { background: var(--bg-hover); }
+.list-row--selected { border-color: var(--brand); background: var(--bg-hover); }
+.list-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text-inverse);
+  flex-shrink: 0;
+}
+.list-name { flex: 2; font-weight: 500; }
+.list-category { flex: 1; font-size: 12px; color: var(--text-secondary); }
+.list-model { flex: 2; font-size: 12px; color: var(--text-secondary); }
+
+/* ── Empty state ──────────────────────────────────────────────────────── */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 60%;
+  gap: 8px;
+  color: var(--text-secondary);
+}
+.empty-illustration { font-size: 48px; opacity: 0.3; }
+.empty-hint { text-align: center; color: var(--text-secondary); font-size: 13px; padding: 24px; }
+
+/* ── Toast ────────────────────────────────────────────────────────────── */
+.toast {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1F2937;
+  color: #F9FAFB;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  z-index: 9999;
+  pointer-events: none;
+  animation: fadeInUp 0.2s ease;
+}
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
 }

--- a/mur-hub-gui/ui/src/styles.css
+++ b/mur-hub-gui/ui/src/styles.css
@@ -680,3 +680,68 @@ input {
   white-space: nowrap;
 }
 .grid-card--dragging { opacity: 0.4; }
+
+/* ── Pet Bubble ─────────────────────────────────────────────────────────── */
+.pet-bubble {
+  position: absolute;
+  bottom: 210px;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 280px;
+  min-width: 120px;
+  background: #1F2937;
+  border: 1px solid #374151;
+  border-radius: 10px;
+  padding: 10px 28px 10px 12px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+  animation: bubbleFadeIn 0.15s ease;
+  z-index: 100;
+}
+@keyframes bubbleFadeIn {
+  from { opacity: 0; transform: translateX(-50%) translateY(6px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+/* tail */
+.pet-bubble::after {
+  content: "";
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 8px solid transparent;
+  border-top-color: #374151;
+  border-bottom: none;
+}
+.pet-bubble-text {
+  font-size: 13px;
+  color: #F9FAFB;
+  line-height: 1.5;
+  word-break: break-word;
+}
+.pet-bubble-progress {
+  height: 2px;
+  background: #374151;
+  border-radius: 1px;
+  margin-top: 8px;
+  overflow: hidden;
+}
+.pet-bubble-bar {
+  height: 100%;
+  background: #6366F1;
+  border-radius: 1px;
+  transition: width 0.1s linear;
+}
+.pet-bubble-close {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #6B7280;
+  font-size: 11px;
+  padding: 2px 4px;
+  border-radius: 3px;
+  line-height: 1;
+}
+.pet-bubble-close:hover { color: #F9FAFB; background: #374151; }

--- a/mur-hub-gui/ui/src/styles.css
+++ b/mur-hub-gui/ui/src/styles.css
@@ -573,3 +573,110 @@ input {
 .wz-progress-failed { color: #EF4444; }
 .wz-render-done { display: flex; flex-direction: column; gap: 12px; align-items: flex-start; }
 .wz-render-error { margin-top: 10px; display: flex; flex-direction: column; gap: 10px; }
+
+/* ── Pet Window ───────────────────────────────────────────────────────────── */
+.pet-root {
+  width: 200px;
+  height: 200px;
+  background: transparent;
+  overflow: visible;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.pet-sprite {
+  width: 160px;
+  height: 160px;
+  margin: 20px auto 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  border-radius: 50%;
+  transition: transform 0.1s ease;
+}
+.pet-sprite:active { cursor: grabbing; transform: scale(0.95); }
+.pet-sprite--smile { animation: petBounce 0.3s ease; }
+.pet-sprite--wave  { animation: petWave 0.5s ease infinite alternate; }
+@keyframes petBounce {
+  0%   { transform: scale(1); }
+  50%  { transform: scale(1.15); }
+  100% { transform: scale(1); }
+}
+@keyframes petWave {
+  from { transform: rotate(-8deg) scale(1.05); }
+  to   { transform: rotate(8deg)  scale(1.05); }
+}
+.pet-image {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 50%;
+  pointer-events: none;
+}
+.pet-avatar-fallback {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #6366F1, #8B5CF6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 40px;
+  font-weight: 700;
+}
+.pet-context-menu {
+  position: fixed;
+  background: #1F2937;
+  border: 1px solid #374151;
+  border-radius: 8px;
+  padding: 4px 0;
+  min-width: 160px;
+  z-index: 9999;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+}
+.pet-menu-item {
+  display: block;
+  width: 100%;
+  padding: 8px 14px;
+  text-align: left;
+  background: none;
+  border: none;
+  color: #F9FAFB;
+  font-size: 13px;
+  cursor: pointer;
+}
+.pet-menu-item:hover { background: #374151; }
+.pet-menu-item--danger { color: #F87171; }
+.pet-menu-divider { border: none; border-top: 1px solid #374151; margin: 4px 0; }
+
+/* ── Drag ghost ─────────────────────────────────────────────────────────── */
+.drag-ghost {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  opacity: 0.7;
+  z-index: 9999;
+}
+.drag-ghost-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 20px;
+  font-weight: 700;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+}
+.drag-ghost-label {
+  font-size: 11px;
+  color: #F9FAFB;
+  background: rgba(0,0,0,0.7);
+  border-radius: 4px;
+  padding: 2px 6px;
+  white-space: nowrap;
+}
+.grid-card--dragging { opacity: 0.4; }

--- a/mur-hub-gui/ui/src/types.ts
+++ b/mur-hub-gui/ui/src/types.ts
@@ -1,0 +1,11 @@
+// TypeScript types matching mur-gui-core::discovery Rust structs.
+
+export type AgentStatus = "running" | "idle" | "stale";
+
+export interface AgentEntry {
+  name: string;
+  display_name: string;
+  category: "research" | "automation" | "monitor" | "notify" | "commerce" | "custom";
+  status: AgentStatus;
+  model_id: string;
+}

--- a/mur-hub-gui/ui/src/types.ts
+++ b/mur-hub-gui/ui/src/types.ts
@@ -1,4 +1,4 @@
-// TypeScript types matching mur-gui-core::discovery Rust structs.
+// TypeScript types matching mur-gui-core Rust structs.
 
 export type AgentStatus = "running" | "idle" | "stale";
 
@@ -8,4 +8,16 @@ export interface AgentEntry {
   category: "research" | "automation" | "monitor" | "notify" | "commerce" | "custom";
   status: AgentStatus;
   model_id: string;
+}
+
+// RuntimeState matches mur-gui-core::sidecar::RuntimeState (#[serde(tag = "state")])
+export type RuntimeState =
+  | { state: "running"; pid: number }
+  | { state: "stopped" }
+  | { state: "restarting"; attempt: number; backoff_secs: number }
+  | { state: "failed" };
+
+export interface AgentRuntimeStatus {
+  name: string;
+  state: RuntimeState;
 }

--- a/mur-hub-gui/ui/src/types.ts
+++ b/mur-hub-gui/ui/src/types.ts
@@ -21,3 +21,53 @@ export interface AgentRuntimeStatus {
   name: string;
   state: RuntimeState;
 }
+
+// ── Wizard types (M-h4) ───────────────────────────────────────────────────
+
+export type WizardPersona =
+  | "research"
+  | "automation"
+  | "monitor"
+  | "notify"
+  | "commerce"
+  | "custom";
+
+export type BehaviorPreset = "quiet" | "normal" | "lively";
+
+export interface RenderProgressSnapshot {
+  total: number;
+  done: number;
+  failed: number;
+}
+
+/** Full wizard state returned by every wizard_* command. */
+export interface WizardSnapshot {
+  step: number;
+  persona: WizardPersona | null;
+  name: string | null;
+  description: string | null;
+  style_preset_id: string | null;
+  preset_family: string | null;
+  behavior_preset: BehaviorPreset | null;
+  needs_photo: boolean;
+  source_photo: string | null;
+  render_progress: RenderProgressSnapshot | null;
+  render_done: boolean;
+}
+
+/** Built-in preset summary for the style picker. */
+export interface PresetSummary {
+  id: string;
+  display_name: string;
+  family: string;
+  description: string;
+}
+
+export const BUILTIN_PRESETS: PresetSummary[] = [
+  { id: "chiikawa",      display_name: "ちいかわ",       family: "chibi",    description: "Nagano-style soft pastel chibi" },
+  { id: "sanrio-pastel", display_name: "Sanrio Pastel",  family: "chibi",    description: "Sanrio kawaii pastel style" },
+  { id: "sumikko",       display_name: "Sumikko Gurashi", family: "chibi",   description: "Shy corner creatures" },
+  { id: "shimeji-retro", display_name: "Shimeji Retro",  family: "pixel",    description: "Pixel / retro 8-bit sprite" },
+  { id: "vtuber-soft",   display_name: "VTuber Soft",    family: "chibi",    description: "Soft anime VTuber style" },
+  { id: "family-photo",  display_name: "Family Photo",   family: "polaroid", description: "Cartoon-ify your photo" },
+];

--- a/scripts/e2e/p1-export-gui.sh
+++ b/scripts/e2e/p1-export-gui.sh
@@ -15,16 +15,19 @@
 # Exit code !0 → unexpected failure
 set -euo pipefail
 
-# Ensure cargo is in PATH. On some CI runners (e.g. macos-14 ARM64),
-# Homebrew's rustup-init can shadow ~/.cargo/bin/cargo.
+# Ensure cargo is in PATH. On macOS-14 ARM64 CI runners, the rust-cache
+# action can restore ~/.cargo/bin/cargo as a bare rustup-init proxy that
+# doesn't recognise argv[0] correctly. Use `rustup which` to get the
+# actual toolchain binary, falling back to PATH lookup.
 export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+CARGO="$(rustup which cargo 2>/dev/null || command -v cargo)"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
 echo "▸ Building mur CLI"
-cargo build -p mur-core --bin mur >/dev/null
+"$CARGO" build -p mur-core --bin mur >/dev/null
 
 MUR=./target/debug/mur
 


### PR DESCRIPTION
## Summary

MuR Hub companion desktop app — full milestone series M-h0 → M-h8 per `docs/superpowers/specs/2026-05-11-mur-hub-companion-design.md`.

| Milestone | Commit | Deliverable |
|-----------|--------|-------------|
| M-h0 | scaffold | mur-hub-gui Tauri shell + mur-gui-core skeleton + CI |
| M-h1 | 4632cb8 | Tray icon, popover, dashboard window, agent discovery |
| M-h2 | 65180e9 | Supervisor + runtime event bus (tokio::broadcast) |
| M-h3 | 410c2bc | StylePreset types, 7 built-in YAMLs, preset loader + manifest |
| M-h4 | e180450 | Image-gen pipeline + 6-step agent creation wizard |
| M-h5 | 41004d9 | Pet window + drag-to-desktop (300ms hold) |
| M-h6 | a084beb | Expression engine + 12 triggers + speech bubble |
| M-h7 | 8cf39e3 | Voice (Kokoro skeleton) + DND detection + preset import UI + `mur agent migrate-to-hub` |
| M-h8 | 0d4d36c | D5 companion inbox moved to mur-gui-core; CompanionInbox UI; mur-agent-gui `publish=false` |

## Key new crates / modules

- `mur-gui-core` — shared GUI library (sidecar supervisor, event bus, expression SM, image-gen pipeline, voice/DND, companion bridge)
- `mur-hub-gui` — Tauri 2 cross-agent desktop app replacing mur-agent-gui

## Test plan

- [x] `cargo check` clean for both `mur-gui-core` and `mur-hub-gui/src-tauri`
- [x] `cargo check` clean for `mur-core` (migrate-to-hub CLI)
- [x] 31 unit tests pass in `mur-gui-core` (expression SM, image-gen, discovery, voice DND, companion bridge parser)
- [x] Workspace tests pass
- [ ] Manual: launch mur-hub-gui, spawn pet, verify talk_open/talk_close lipsync on pet_speak
- [ ] Manual: open Dashboard, click agent card → CompanionInbox detail panel opens
- [ ] Manual: Import Preset modal (file + URL)
- [ ] Manual: `mur agent migrate-to-hub` on a real agent dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)