### PR TITLE
feat(sync): MuR ↔ Commander Channel 1 Closure

### DIFF
--- a/mur-core/src/cmd/inject_cmd.rs
+++ b/mur-core/src/cmd/inject_cmd.rs
@@ -24,6 +24,10 @@ pub(crate) async fn cmd_inject(query: &str) -> Result<()> {
     }
 
     let yaml_store = YamlStore::default_store()?;
+    // Drain pending commander signals so evidence scores are current before ranking
+    if let Ok(inbox) = crate::sync::inbox::Inbox::default_location() {
+        let _ = inbox.apply_all(&yaml_store);
+    }
     let patterns = yaml_store.list_all()?;
 
     // Also load workflows
@@ -106,6 +110,71 @@ pub(crate) async fn cmd_inject(query: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::store::yaml::YamlStore;
+    use crate::sync::inbox::Inbox;
+    use mur_common::knowledge::KnowledgeBase;
+    use mur_common::pattern::{Content, Pattern, Tier};
+    use mur_common::{
+        Actor, ActorSource, SIGNAL_SCHEMA_VERSION, Scope, Signal, SignalKind, SignalTarget,
+    };
+    use uuid::Uuid;
+
+    fn make_pattern(name: &str) -> Pattern {
+        Pattern {
+            base: KnowledgeBase {
+                name: name.into(),
+                description: "test".into(),
+                content: Content::Plain("body".into()),
+                tier: Tier::Session,
+                ..Default::default()
+            },
+            kind: None,
+            origin: None,
+            attachments: vec![],
+        }
+    }
+
+    #[test]
+    fn inbox_drain_applies_signals_to_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let patterns_dir = tmp.path().join("patterns");
+        let inbox_dir = tmp.path().join("inbox");
+        std::fs::create_dir_all(&inbox_dir).unwrap();
+
+        let store = YamlStore::new(patterns_dir).unwrap();
+        store.save(&make_pattern("drain-test")).unwrap();
+
+        let signal = Signal {
+            id: Uuid::new_v4(),
+            emitted_at: chrono::Utc::now(),
+            actor: Actor {
+                source: ActorSource::Slack,
+                native_id: "bot".into(),
+                display_name: None,
+                resolved_user_id: None,
+            },
+            target: SignalTarget::Pattern {
+                name: "drain-test".into(),
+                scope: Scope::Personal,
+            },
+            kind: SignalKind::ExecutionSuccess,
+            scope: Scope::Personal,
+            confidence: 0.9,
+            schema_version: SIGNAL_SCHEMA_VERSION,
+        };
+        let inbox = Inbox::new(&inbox_dir).unwrap();
+        inbox.receive(&signal).unwrap();
+
+        let report = inbox.apply_all(&store).unwrap();
+        assert_eq!(report.applied, 1);
+
+        let p = store.get("drain-test").unwrap();
+        assert_eq!(p.evidence.success_signals, 1);
+    }
 }
 
 pub(crate) fn cmd_why(name: &str) -> Result<()> {

--- a/mur-core/src/cmd/misc.rs
+++ b/mur-core/src/cmd/misc.rs
@@ -181,6 +181,44 @@ pub(crate) fn cmd_gc(auto: bool) -> Result<()> {
         println!("Applied {} lifecycle changes.\n", lifecycle_changes);
     }
 
+    // C3: Auto-generate commander workflow files for Stable/Canonical patterns
+    // that don't already have a workflow. Closes the pattern→workflow feedback loop.
+    {
+        use evolve::commander_bridge::CommanderBridge;
+        let bridge = CommanderBridge::with_defaults();
+        let by_name: std::collections::HashMap<String, Pattern> = store
+            .list_all()?
+            .into_iter()
+            .map(|p| (p.name.clone(), p))
+            .collect();
+        let candidates = bridge.detect_workflow_candidates(
+            &by_name.values().cloned().collect::<Vec<_>>(),
+        );
+        let mut wf_count = 0;
+        for candidate in &candidates {
+            if let Some(pattern) = by_name.get(&candidate.pattern_name) {
+                match bridge.suggest_workflow(pattern) {
+                    Ok(Some(preview)) => {
+                        let wf_path = bridge
+                            .config
+                            .workflows_dir
+                            .join(format!("{}.yaml", preview.workflow.name));
+                        if !wf_path.exists() {
+                            if bridge.save_workflow(&preview.workflow).is_ok() {
+                                wf_count += 1;
+                                println!("  🔗 Generated workflow: {}", preview.workflow.name);
+                            }
+                        }
+                    }
+                    Ok(None) | Err(_) => {}
+                }
+            }
+        }
+        if wf_count > 0 {
+            println!("Generated {} commander workflow(s).\n", wf_count);
+        }
+    }
+
     // Link discovery pass (pattern↔pattern and pattern↔workflow)
     {
         use evolve::linker::{

--- a/mur-core/src/cmd/misc.rs
+++ b/mur-core/src/cmd/misc.rs
@@ -195,21 +195,16 @@ pub(crate) fn cmd_gc(auto: bool) -> Result<()> {
             bridge.detect_workflow_candidates(&by_name.values().cloned().collect::<Vec<_>>());
         let mut wf_count = 0;
         for candidate in &candidates {
-            if let Some(pattern) = by_name.get(&candidate.pattern_name) {
-                match bridge.suggest_workflow(pattern) {
-                    Ok(Some(preview)) => {
-                        let wf_path = bridge
-                            .config
-                            .workflows_dir
-                            .join(format!("{}.yaml", preview.workflow.name));
-                        if !wf_path.exists() {
-                            if bridge.save_workflow(&preview.workflow).is_ok() {
-                                wf_count += 1;
-                                println!("  🔗 Generated workflow: {}", preview.workflow.name);
-                            }
-                        }
-                    }
-                    Ok(None) | Err(_) => {}
+            if let Some(pattern) = by_name.get(&candidate.pattern_name)
+                && let Ok(Some(preview)) = bridge.suggest_workflow(pattern)
+            {
+                let wf_path = bridge
+                    .config
+                    .workflows_dir
+                    .join(format!("{}.yaml", preview.workflow.name));
+                if !wf_path.exists() && bridge.save_workflow(&preview.workflow).is_ok() {
+                    wf_count += 1;
+                    println!("  🔗 Generated workflow: {}", preview.workflow.name);
                 }
             }
         }

--- a/mur-core/src/cmd/misc.rs
+++ b/mur-core/src/cmd/misc.rs
@@ -191,9 +191,8 @@ pub(crate) fn cmd_gc(auto: bool) -> Result<()> {
             .into_iter()
             .map(|p| (p.name.clone(), p))
             .collect();
-        let candidates = bridge.detect_workflow_candidates(
-            &by_name.values().cloned().collect::<Vec<_>>(),
-        );
+        let candidates =
+            bridge.detect_workflow_candidates(&by_name.values().cloned().collect::<Vec<_>>());
         let mut wf_count = 0;
         for candidate in &candidates {
             if let Some(pattern) = by_name.get(&candidate.pattern_name) {

--- a/mur-core/src/server/mod.rs
+++ b/mur-core/src/server/mod.rs
@@ -34,6 +34,7 @@ mod patterns;
 mod pipelines;
 mod search;
 mod sessions;
+mod signals;
 mod stats;
 mod workflows;
 
@@ -47,6 +48,7 @@ use pipelines::{
     run_pipeline_expr, update_pipeline, validate_pipeline,
 };
 use search::search_patterns;
+use signals::batch_signals;
 use sessions::{
     bulk_delete_sessions, delete_session, get_session, get_session_events, list_sessions,
     patch_session,
@@ -201,6 +203,8 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/v1/context", post(context_retrieve))
         .route("/api/v1/ingest", post(context_ingest))
         .route("/api/v1/feedback", post(context_feedback))
+        // Cloud-mode signal ingestion
+        .route("/api/v1/core/signals/batch", post(batch_signals))
         // Sessions
         .route("/api/v1/sessions", get(list_sessions))
         .route(

--- a/mur-core/src/server/mod.rs
+++ b/mur-core/src/server/mod.rs
@@ -48,11 +48,11 @@ use pipelines::{
     run_pipeline_expr, update_pipeline, validate_pipeline,
 };
 use search::search_patterns;
-use signals::batch_signals;
 use sessions::{
     bulk_delete_sessions, delete_session, get_session, get_session_events, list_sessions,
     patch_session,
 };
+use signals::batch_signals;
 use stats::{get_links, get_stats, get_tags};
 use workflows::{
     create_workflow, delete_workflow, extract_workflow_from_session, get_workflow, list_workflows,

--- a/mur-core/src/server/signals.rs
+++ b/mur-core/src/server/signals.rs
@@ -1,9 +1,9 @@
 //! POST /api/v1/core/signals/batch — receive sync signals from commander
 use std::sync::Arc;
 
+use axum::Json;
 use axum::extract::State;
 use axum::response::IntoResponse;
-use axum::Json;
 use mur_common::Signal;
 use serde::{Deserialize, Serialize};
 

--- a/mur-core/src/server/signals.rs
+++ b/mur-core/src/server/signals.rs
@@ -27,6 +27,14 @@ pub struct RejectedSignal {
     pub reason: String,
 }
 
+/// Receive a batch of sync signals from commander and apply them to pattern evidence.
+///
+/// # Concurrency note
+/// This endpoint uses a two-phase write: `receive` appends YAML files to the inbox,
+/// then `apply_all` reads and applies them. Under concurrent requests the last writer
+/// wins per pattern (the YAML store uses atomic rename). This is acceptable because
+/// the commander daemon runs as a single process with one `FlushService`, so concurrent
+/// batches from the same process are not expected in practice.
 pub async fn batch_signals(
     State(state): State<Arc<AppState>>,
     Json(body): Json<BatchRequest>,
@@ -57,7 +65,20 @@ pub async fn batch_signals(
     }
 
     if !accepted.is_empty() {
-        let _ = inbox.apply_all(&store);
+        match inbox.apply_all(&store) {
+            Ok(report) if !report.errors.is_empty() => {
+                tracing::warn!(
+                    "signals/batch: {} signal(s) accepted but {} failed to apply: {:?}",
+                    accepted.len(),
+                    report.errors.len(),
+                    report.errors
+                );
+            }
+            Err(e) => {
+                tracing::error!("signals/batch: apply_all failed: {:#}", e);
+            }
+            Ok(_) => {}
+        }
     }
 
     Ok(Json(BatchResponse { accepted, rejected }))

--- a/mur-core/src/server/signals.rs
+++ b/mur-core/src/server/signals.rs
@@ -1,0 +1,177 @@
+//! POST /api/v1/core/signals/batch — receive sync signals from commander
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::response::IntoResponse;
+use axum::Json;
+use mur_common::Signal;
+use serde::{Deserialize, Serialize};
+
+use super::{AppError, AppState};
+use crate::sync::inbox::Inbox;
+
+#[derive(Deserialize)]
+pub struct BatchRequest {
+    pub signals: Vec<Signal>,
+}
+
+#[derive(Serialize)]
+pub struct BatchResponse {
+    pub accepted: Vec<String>,
+    pub rejected: Vec<RejectedSignal>,
+}
+
+#[derive(Serialize)]
+pub struct RejectedSignal {
+    pub id: String,
+    pub reason: String,
+}
+
+pub async fn batch_signals(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<BatchRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    if state.config.readonly {
+        return Err(AppError::Readonly);
+    }
+
+    let store = state.pattern_store()?;
+    let inbox_dir = state
+        .patterns_dir
+        .parent()
+        .unwrap_or(&state.patterns_dir)
+        .join("inbox");
+    let inbox = Inbox::new(&inbox_dir).map_err(AppError::Internal)?;
+
+    let mut accepted = Vec::new();
+    let mut rejected = Vec::new();
+
+    for signal in &body.signals {
+        match inbox.receive(signal) {
+            Ok(_) => accepted.push(signal.id.to_string()),
+            Err(e) => rejected.push(RejectedSignal {
+                id: signal.id.to_string(),
+                reason: e.to_string(),
+            }),
+        }
+    }
+
+    if !accepted.is_empty() {
+        let _ = inbox.apply_all(&store);
+    }
+
+    Ok(Json(BatchResponse { accepted, rejected }))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use mur_common::knowledge::KnowledgeBase;
+    use mur_common::pattern::{Content, Pattern, Tier};
+    use mur_common::{
+        Actor, ActorSource, SIGNAL_SCHEMA_VERSION, Scope, Signal, SignalKind, SignalTarget,
+    };
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use crate::server::build_router;
+    use crate::server::tests::test_state_for_signals;
+    use crate::store::yaml::YamlStore;
+
+    fn make_pattern(name: &str) -> Pattern {
+        Pattern {
+            base: KnowledgeBase {
+                name: name.into(),
+                description: "test".into(),
+                content: Content::Plain("body".into()),
+                tier: Tier::Session,
+                ..Default::default()
+            },
+            kind: None,
+            origin: None,
+            attachments: vec![],
+        }
+    }
+
+    fn exec_success_signal(pattern_name: &str) -> Signal {
+        Signal {
+            id: Uuid::new_v4(),
+            emitted_at: chrono::Utc::now(),
+            actor: Actor {
+                source: ActorSource::Slack,
+                native_id: "bot".into(),
+                display_name: None,
+                resolved_user_id: None,
+            },
+            target: SignalTarget::Pattern {
+                name: pattern_name.into(),
+                scope: Scope::Personal,
+            },
+            kind: SignalKind::ExecutionSuccess,
+            scope: Scope::Personal,
+            confidence: 0.9,
+            schema_version: SIGNAL_SCHEMA_VERSION,
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_signals_accepted_and_updates_evidence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_for_signals(&tmp);
+        let store = YamlStore::new(state.patterns_dir.clone()).unwrap();
+        store.save(&make_pattern("p1")).unwrap();
+
+        let app = build_router(state);
+        let body = serde_json::json!({
+            "signals": [exec_success_signal("p1")]
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/core/signals/batch")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["accepted"].as_array().unwrap().len(), 1);
+        assert_eq!(json["rejected"].as_array().unwrap().len(), 0);
+
+        let updated = YamlStore::new(tmp.path().join("patterns"))
+            .unwrap()
+            .get("p1")
+            .unwrap();
+        assert_eq!(updated.evidence.success_signals, 1);
+    }
+
+    #[tokio::test]
+    async fn batch_signals_readonly_returns_403() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut state = test_state_for_signals(&tmp);
+        state.config.readonly = true;
+
+        let app = build_router(state);
+        let body = serde_json::json!({ "signals": [] });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/core/signals/batch")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/mur-core/src/server/signals.rs
+++ b/mur-core/src/server/signals.rs
@@ -64,9 +64,9 @@ pub async fn batch_signals(
         }
     }
 
-    if !accepted.is_empty() {
-        match inbox.apply_all(&store) {
-            Ok(report) if !report.errors.is_empty() => {
+    if !accepted.is_empty()
+        && let Err(e) = inbox.apply_all(&store).map(|report| {
+            if !report.errors.is_empty() {
                 tracing::warn!(
                     "signals/batch: {} signal(s) accepted but {} failed to apply: {:?}",
                     accepted.len(),
@@ -74,11 +74,9 @@ pub async fn batch_signals(
                     report.errors
                 );
             }
-            Err(e) => {
-                tracing::error!("signals/batch: apply_all failed: {:#}", e);
-            }
-            Ok(_) => {}
-        }
+        })
+    {
+        tracing::error!("signals/batch: apply_all failed: {:#}", e);
     }
 
     Ok(Json(BatchResponse { accepted, rejected }))

--- a/mur-core/src/server/tests.rs
+++ b/mur-core/src/server/tests.rs
@@ -40,6 +40,11 @@ fn test_state_readonly(tmp: &tempfile::TempDir) -> AppState {
     state
 }
 
+/// Re-exported for use by sibling module tests (e.g. signals::tests).
+pub(super) fn test_state_for_signals(tmp: &tempfile::TempDir) -> AppState {
+    test_state(tmp)
+}
+
 fn make_test_pattern(name: &str) -> Pattern {
     Pattern {
         base: KnowledgeBase {

--- a/mur-core/src/sync/inbox.rs
+++ b/mur-core/src/sync/inbox.rs
@@ -5,7 +5,9 @@ use anyhow::{Context, Result};
 use chrono::Utc;
 use mur_common::pattern::Contribution;
 use mur_common::{Signal, SignalKind, SignalTarget};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use uuid::Uuid;
 
 use crate::store::yaml::YamlStore;
 
@@ -58,8 +60,13 @@ impl Inbox {
     ///
     /// Successfully-applied or intentionally-skipped files are removed from
     /// the inbox; failures stay in place to be retried next run.
+    ///
+    /// Signal IDs are tracked in `.seen.yaml` to prevent double-counting when
+    /// the same signal UUID is re-emitted (e.g. after a retry in FlushService).
     pub fn apply_all(&self, store: &YamlStore) -> Result<ApplyReport> {
         let mut report = ApplyReport::default();
+        let mut seen = self.load_seen_ids();
+        let mut newly_seen: Vec<Uuid> = Vec::new();
 
         for entry in std::fs::read_dir(&self.dir)? {
             let p = entry?.path();
@@ -86,22 +93,61 @@ impl Inbox {
                 }
             };
 
+            // Skip duplicate signal IDs (idempotency guard against FlushService retries)
+            if seen.contains(&signal.id) {
+                report.skipped += 1;
+                let _ = std::fs::remove_file(&p);
+                continue;
+            }
+
             match self.apply_one(store, &signal) {
                 Ok(true) => {
                     report.applied += 1;
+                    newly_seen.push(signal.id);
                     let _ = std::fs::remove_file(&p);
                 }
                 Ok(false) => {
                     report.skipped += 1;
+                    newly_seen.push(signal.id);
                     let _ = std::fs::remove_file(&p);
                 }
                 Err(e) => {
                     report.errors.push(format!("{}: {e}", p.display()));
-                    // Keep file for retry
+                    // Keep file for retry — do NOT record as seen
                 }
             }
         }
+
+        if !newly_seen.is_empty() {
+            seen.extend(newly_seen);
+            let _ = self.save_seen_ids(&seen);
+        }
+
         Ok(report)
+    }
+
+    fn load_seen_ids(&self) -> HashSet<Uuid> {
+        let path = self.dir.join(".seen.yaml");
+        std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| serde_yaml::from_str::<Vec<Uuid>>(&s).ok())
+            .map(|v| v.into_iter().collect())
+            .unwrap_or_default()
+    }
+
+    fn save_seen_ids(&self, seen: &HashSet<Uuid>) -> Result<()> {
+        let mut ids: Vec<Uuid> = seen.iter().copied().collect();
+        ids.sort();
+        // Cap at 2048 to prevent unbounded growth
+        if ids.len() > 2048 {
+            let start = ids.len() - 2048;
+            ids = ids[start..].to_vec();
+        }
+        let yaml = serde_yaml::to_string(&ids)?;
+        let tmp = self.dir.join(".seen.tmp");
+        std::fs::write(&tmp, &yaml)?;
+        std::fs::rename(&tmp, self.dir.join(".seen.yaml"))?;
+        Ok(())
     }
 
     fn apply_one(&self, store: &YamlStore, signal: &Signal) -> Result<bool> {
@@ -150,9 +196,13 @@ impl Inbox {
                 store.save(&pattern)?;
                 Ok(true)
             }
-            SignalTarget::NewDraftPattern { .. } => {
-                // Phase 2 handles drafts; silently skip here.
-                Ok(false)
+            SignalTarget::NewDraftPattern { payload } => {
+                // Never overwrite a pattern the user may have edited
+                if store.exists(&payload.name) {
+                    return Ok(false);
+                }
+                store.save(payload)?;
+                Ok(true)
             }
         }
     }
@@ -336,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_skips_new_draft_pattern_target() {
+    fn apply_creates_new_draft_pattern() {
         let tmp = tempdir().unwrap();
         let (store, inbox) = setup(tmp.path());
         let pat = make_pattern("draft-x");
@@ -361,10 +411,42 @@ mod tests {
         };
         inbox.receive(&sig).unwrap();
         let report = inbox.apply_all(&store).unwrap();
+        assert_eq!(report.applied, 1);
+        assert_eq!(report.skipped, 0);
+        // Pattern was created as draft
+        assert!(store.exists("draft-x"));
+    }
+
+    #[test]
+    fn apply_skips_new_draft_pattern_when_pattern_already_exists() {
+        let tmp = tempdir().unwrap();
+        let (store, inbox) = setup(tmp.path());
+        // Pre-existing pattern with the same name
+        store.save(&make_pattern("draft-x")).unwrap();
+        let pat = make_pattern("draft-x");
+        let sig = Signal {
+            id: Uuid::new_v4(),
+            emitted_at: Utc::now(),
+            actor: Actor {
+                source: ActorSource::Slack,
+                native_id: "alice".into(),
+                display_name: None,
+                resolved_user_id: None,
+            },
+            target: SignalTarget::NewDraftPattern {
+                payload: Box::new(pat),
+            },
+            kind: SignalKind::NewPatternProposal {
+                origin_context: "chat".into(),
+            },
+            scope: Scope::Personal,
+            confidence: 1.0,
+            schema_version: SIGNAL_SCHEMA_VERSION,
+        };
+        inbox.receive(&sig).unwrap();
+        let report = inbox.apply_all(&store).unwrap();
         assert_eq!(report.skipped, 1);
         assert_eq!(report.applied, 0);
-        // Pattern was NOT auto-created:
-        assert!(!store.exists("draft-x"));
     }
 
     #[test]
@@ -416,5 +498,32 @@ mod tests {
         let bob = p.evidence.contributions.get("Slack:bob").unwrap();
         assert_eq!(alice.success_signals, 2);
         assert_eq!(bob.override_signals, 3);
+    }
+
+    #[test]
+    fn duplicate_signal_id_is_not_double_counted() {
+        let tmp = tempdir().unwrap();
+        let (store, inbox) = setup(tmp.path());
+        store.save(&make_pattern("p1")).unwrap();
+
+        // First receive + apply
+        let sig = signal("p1", SignalKind::ExecutionSuccess, "alice");
+        inbox.receive(&sig).unwrap();
+        inbox.apply_all(&store).unwrap();
+
+        // Receive the SAME signal UUID again (retry scenario) with different filename
+        // by writing directly with a different timestamp prefix
+        let yaml = serde_yaml::to_string(&sig).unwrap();
+        let dup_path = inbox.dir.join("2099-01-01T00-00-00-dup.yaml");
+        std::fs::write(&dup_path, yaml).unwrap();
+        let report = inbox.apply_all(&store).unwrap();
+
+        // The duplicate should be skipped (not applied again)
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.skipped, 1);
+
+        let p = store.get("p1").unwrap();
+        // Still only 1 success signal — not incremented twice
+        assert_eq!(p.evidence.success_signals, 1);
     }
 }


### PR DESCRIPTION
## Summary

Closes the mur ↔ commander execution-feedback loop so workflow signals reliably update pattern Evidence scores.

**Three changes in mur (this PR):**
- `POST /api/v1/core/signals/batch` server endpoint — matches the URL `CommanderSyncClient` already calls in cloud mode
- Inbox drain in `cmd_inject` — `apply_all()` runs before hybrid scoring so Evidence scores are current at injection time
- Signal UUID dedup via `.seen.yaml` sidecar — prevents double-counting on FlushService retries
- Phase 2 `NewDraftPattern` — `NewDraftPattern` signals now create draft patterns in YamlStore (previously silently skipped)
- C3 auto-trigger in `mur gc` — `CommanderBridge` auto-generates workflow YAML for Stable/Canonical patterns that have no file yet

**Companion change in mur-commander (already merged to that repo's main):**
- `LocalBridge` in daemon — ticks every 30 s and `fs::rename`s outbox YAML → `~/.mur/inbox/` without HTTP, active by default when `MUR_SERVER_URL` is not set (the common local-only case)

## Architecture

```
Commander executes workflow
    ↓ C1: Signal outbox → LocalBridge → ~/.mur/inbox/ → Evidence updated  ← this PR
Mur pattern scores reflect execution history
    ↓ C3: mur gc auto-generates workflow YAML for high-quality patterns    ← this PR
Commander picks up updated workflows
    ↓ C2: LongTermStore facts → Draft patterns (Phase 2 inbox handler)    ← this PR (groundwork)
New mur patterns emerge from commander experience
```

## Test Plan
- [ ] `cargo test -p mur-core --lib inbox` — 18 tests pass (3 new: dedup, Phase 2 create, Phase 2 skip-if-exists)
- [ ] `cargo test -p mur-core server::signals` — 2 tests pass
- [ ] `cargo test --workspace` — 1128 pass, 1 pre-existing failure (`context_api::tests::test_retrieve_returns_patterns`)
- [ ] Manual: run `mur gc` with a Stable pattern → confirm `~/.mur/workflows/<name>.yaml` generated
- [ ] Manual: run commander workflow → confirm `~/.mur/commander/outbox/` files appear, then get moved to `~/.mur/inbox/` within 30 s

🤖 Generated with [Claude Code](https://claude.ai/claude-code)