### PR TITLE
E1 spike graduation: ADR-0001 + §4 patches + Signal v1 freeze

### DIFF
--- a/docs/architecture/adr/0001-e1-versioned-store-spike-findings.md
+++ b/docs/architecture/adr/0001-e1-versioned-store-spike-findings.md
@@ -1,0 +1,141 @@
+# ADR 0001 — E1 Versioned-Store Spike Findings
+
+**Status**: Accepted (2026-05-18)
+**Spec affected**: `plans/2026-05-18-continual-learning-versioned-evolution.md` §4
+**Spike branch**: `spike/e1-versioned-store` (frozen, tagged `spike-e1-final`)
+**Spike crate**: `spike-e1-versioned-store/` (workspace-excluded after this ADR)
+
+## Context
+
+Before committing 3 weeks of W1-W3 implementation to E1 (dual git-repo versioned store under `~/.mur/`), ran a 2-day spike validating 8 risk assumptions. CI matrix (ubuntu / macos-arm / windows) ran 5 risks. 3 went green by inspection; 2 surfaced production-blocking findings.
+
+| Risk | Status | Notes |
+|---|---|---|
+| R1 git2 three-platform | ✅ green | smoke + R1 pass on ubuntu / macos / windows |
+| R4 external `git reset --hard` recovery | ✅ green | `detect_external_change()` + `rebuild_index()` recover cleanly |
+| R8 split-brain (one .git nuked) | ✅ green | `repair_agents()` static fn re-inits, knowledge layer untouched |
+| **R2 history() perf @ 1k patterns** | ❌ → **FIN-1/2/3** | live `history()` took 1.94s (target 100ms, 20×) |
+| **R5 telemetry growth @ 24h appends** | ✅ (after fix) | exposed libgit2 quirk on `*/foo/` ignore patterns |
+| R3 / R6 / R7 | not run | judged non-blocking for §4 design decision; deferred to W1-W3 |
+
+## Findings
+
+### FIN-1: save hot path must NEVER call `git index.add_all`
+
+**Evidence.** CI macos / ubuntu / windows all timed out at 25min during R2's 3000-commit seed phase. Root cause: `commit_paths()` called `index.add_all(["."], ...)` on every commit, walking the entire working tree per commit. With 3000 patterns accumulating in the tree, total work was O(N²) ≈ 4.5M filesystem operations. Removed in spike commit `<TBD-sha>`.
+
+**Rule.** Production `VersionedYamlStore` / `VersionedAgentStore` MUST stage only explicit paths passed by the caller. No `add_all` on the hot path. Recovery paths (e.g. `repair_agents` for split-brain) may use `add_all` since they run once per disaster.
+
+**Verification.** After fix, smoke + R1 + R4 + R8 all complete in < 1 second on all three OS.
+
+### FIN-2: version derivation must be O(1)
+
+**Evidence.** Even after FIN-1 fix, R2 still hung. Root cause: `save_pattern()` called `current_pattern_version()` which called `history()` (full git revwalk + per-commit tree diff). Each save walked the entire history-to-date; cumulative work was again O(N²) ≈ 4.5M tree diffs.
+
+**Rule.** Version derivation on the save hot path MUST be O(1) regardless of repo size. Spike now uses `archive/patterns/<name>/` directory count plus current-file existence — a single `read_dir` call. Production implementation may store version inline in pattern YAML or in a sidecar metadata file, but MUST NOT walk git history during save.
+
+**Verification.** After fix, R2 completed in ~19 seconds end-to-end (seed + history measurement). Seed phase was ~17s, leaving the actual measurement of interest visible.
+
+### FIN-3: `history()` must read from a cache, NOT walk git log live
+
+**Evidence.** With FIN-1 + FIN-2 fixes in place, R2 finally completed and measured `history("p0500")` on a 3000-commit repo: **1.94 seconds**. The 100ms target was set in §4.2.6 as the limit beyond which `mur pattern history` and GUI History panel become unusable. 1.94s is 20× over.
+
+The walk is O(N) commits × O(diff) per commit. At 3000 commits with libgit2 in release mode, ~640µs per commit-touch check. There is no obvious algorithmic speedup of the live walk; the only way to hit < 100ms is a per-pattern history index that mur maintains alongside writes.
+
+**Rule.** `~/.mur/.mur-versions.yaml` (and the corresponding file under `agents/`) is upgraded from a **diagnostic drift detector** to a **load-bearing per-pattern history index**. Schema:
+
+```yaml
+schema_version: 3
+knowledge_head: <12-char sha>
+agents_head: <12-char sha>
+patterns:
+  rust-error-handling:
+    versions:
+      - { v: 1, sha: abc123def456, ts: 2026-04-12T..., reason: "init" }
+      - { v: 2, sha: def456abc789, ts: 2026-04-15T..., reason: "...refine" }
+    current_version: 2
+  ...
+workflows:
+  ...
+```
+
+Index is maintained on every save: O(1) append per save. Index is rebuilt from git log on `mur internals rebuild-index` (slow, runs only on recovery or first migration).
+
+`mur pattern history <name>` reads from index directly. Live git log walk becomes a fallback only when index is missing or stale relative to HEAD.
+
+**Verification target.** With the index, `history()` on a 10k-pattern × 5-revision repo should return in < 50ms. To be tested in W2.
+
+### FIN-4: `.gitignore` patterns — use bare names, not `*/` anchors
+
+**Evidence.** Initial `agents/.gitignore` used `*/telemetry/` (intent: match `agents/<name>/telemetry/`). libgit2's `Repository::statuses()` reported `agent-a/telemetry/` as untracked despite the pattern matching by git CLI semantics. Switching to bare `telemetry/` (no anchor) fixed the issue.
+
+Separately discovered that `Repository::is_path_ignored()` consults the libgit2 ignore engine **directly** and is the authoritative answer — `statuses()` iteration has its own quirks around untracked-directory reporting.
+
+**Rule.** Production `.gitignore` files under `~/.mur/` and `~/.mur/agents/` MUST use bare patterns:
+
+```
+# ~/.mur/agents/.gitignore — production
+telemetry/
+outbox-ledger
+inbox/
+crashlogs/
+running.lock
+.extract_digest
+.apply-staging/
+.apply-in-progress
+```
+
+(No `*/` prefix, no leading slash unless explicitly meant to anchor to gitignore-file's directory.)
+
+**Test rule.** Tests that verify gitignore correctness MUST use `repo.is_path_ignored("<path>")` as the assertion, never `statuses()` iteration.
+
+## Decision
+
+Adopt FIN-1 through FIN-4 as mandatory rules in v2 spec §4. Patch the spec to:
+
+1. Add §4.2.8 "Mandatory implementation rules from 2026-05-18 spike" enumerating FIN-1/2/3/4.
+2. Upgrade `.mur-versions.yaml` semantics in §4.2.7 from "drift detector" to "load-bearing per-pattern index".
+3. Replace `*/foo/` patterns with bare patterns in the §4.2.1 .gitignore examples.
+4. Extend §4.3 acceptance criteria with one new check:
+   - [ ] `history()` on 1000-pattern × 3-revision repo returns in < 100ms (via index, not live git log walk).
+
+Spec patch lands in the same commit as this ADR.
+
+## Consequences
+
+### On scope of W1-W3
+
+- Index maintenance is now in-scope for W1, not deferred. Adds ~3-5 days of work to W1.
+- Acceptance criteria for W2 grows by one perf test.
+- No change to overall dual-git-repo design or to E2-E6 dependencies.
+
+### On performance characteristics
+
+- `save_pattern` worst-case is O(1) git commit + O(1) index update + O(1) version derivation. Predictable regardless of repo size.
+- `history()` worst-case is O(K) where K = revisions of THIS pattern, not total repo. Sub-100ms even for canonical 50-version patterns.
+- `mur internals rebuild-index` is the only O(total-commits) operation; runs offline / on recovery only.
+
+### On future maintenance
+
+- Index file is now critical state. Backup / restore docs must include it explicitly.
+- Index drift (file out of sync with git HEAD) is a new failure mode. Detection logic in §4.2.7 step 2 already covers it; recovery path is the rebuild command above.
+
+## Evidence
+
+| Artifact | Pointer |
+|---|---|
+| Spike crate | `spike-e1-versioned-store/` on branch `spike/e1-versioned-store` |
+| FIN-1 fix commit | drops `add_all` from `commit_paths` |
+| FIN-2 fix commit | switches `current_pattern_version` to archive-dir count |
+| FIN-4 fix commit | `agents.gitignore` bare patterns + R5 test uses `is_path_ignored` |
+| R2 measurement | CI log `2026-05-18T08:..` — `r2: history p0500 took 1.935411254s` |
+| R5 measurement | CI log — `r5: telemetry file = 4 MB raw; agents/.git delta ~0` |
+| Final green CI | `gh run list --workflow=spike-e1.yml` first all-green run after this ADR |
+
+## References
+
+- `plans/2026-05-18-continual-learning-versioned-evolution.md` §4 (E1 spec, this ADR patches)
+- `docs/superpowers/specs/2026-05-18-mur-agent-manifest-design.md` (AgentManifest — uses execution-layer repo from §4.2.1)
+- `docs/superpowers/specs/2026-05-18-commander-feedback-wire-protocol-design.md` (E5 — depends on knowledge-layer commit history from §4.2.5)
+- `spike-e1-versioned-store/README.md` (spike intent + Day 1-3 plan)
+- libgit2 docs on `git_status_options` and `git_ignore_path_is_ignored`

--- a/docs/superpowers/specs/2026-05-18-commander-feedback-wire-protocol-design.md
+++ b/docs/superpowers/specs/2026-05-18-commander-feedback-wire-protocol-design.md
@@ -1,0 +1,710 @@
+# Commander → MuR Feedback Wire Protocol — v1 Freeze
+
+**Status**: proposed (schema freeze)
+**Author**: david + Claude Opus 4.7
+**Date**: 2026-05-18
+**Related**:
+- `plans/2026-05-18-continual-learning-versioned-evolution.md` v2 (§8 E5, D4, D8)
+- `docs/superpowers/specs/2026-04-18-mur-commander-memory-sync-design.md` (original design)
+- `docs/superpowers/plans/2026-05-18-mur-commander-channel1-closure.md` (implementation plan)
+- `mur-common/src/signal.rs` (existing schema, 11 round-trip tests)
+- `mur-common/src/bridge/envelope.rs` (existing Ed25519 wrapper, C7 reuse)
+- `mur-core/src/sync/inbox.rs` (live receive-side)
+
+## Problem
+
+The continual-learning v2 spec identified **D8 as the highest-priority gap**: commander's `LongTermStore` does not write back to `~/.mur/patterns/`, so execution evidence (thousands of data points per active user) never reaches mur's Evidence/Maturity loop.
+
+A deep code survey found that **the gap is asymmetric and smaller than the 2026-04-18 spec implied**:
+
+| Side | Status |
+|---|---|
+| `mur-common::signal::Signal` (envelope) | ✅ live, schema v1, 11 round-trip tests |
+| `SignalKind` (5 variants covering C1/C2/C3) | ✅ live |
+| `Actor` / `ActorSource` (8 sources incl. `CommanderDaemon`) | ✅ live |
+| `mur-common::bridge::envelope::SignedEnvelope` (Ed25519) | ✅ live (C7 Slack bridge already uses it) |
+| `mur-core::sync::inbox::Inbox::apply_all()` | ✅ live, used by `mur fetch` |
+| `mur-core::sync::outbox::Outbox` | ✅ live |
+| **HTTP endpoint `POST /v1/signals/batch` on mur-daemon** | ❌ **not implemented** |
+| **Bearer-token auth on signal endpoints** | ❌ **not implemented** |
+| **Commander-side `LocalBridge` / outbox writer** | ❌ **not implemented** (closed-source repo) |
+| **Idempotency / dedup at HTTP layer** | ❌ **not specified** |
+
+→ The schema is essentially already frozen by code shipped 2026-04-18. **What blocks D8 closure is the HTTP contract + commander-side implementation, not a new envelope type.**
+
+This spec freezes the contract so the commander team can implement outbox writers in parallel without ambiguity, and so mur-daemon can wire up the receiving HTTP endpoint against a stable target.
+
+## Decisions
+
+1. **Schema freeze: `Signal` v1 is frozen.** `mur-common::signal::Signal` and its supporting types (`SignalKind`, `SignalTarget`, `Actor`, `ActorSource`, `Scope`) are stable. Any change requires a SCHEMA_VERSION bump to 2 and a coordinated migration.
+2. **HTTP endpoints are versioned in the URL path**, not in JSON. `POST /v1/signals/batch`, `GET /v1/signals/pending`. v2 endpoints would coexist at `/v2/...`.
+3. **Auth: bearer token in v1**, Ed25519 envelope **optional in v1 / mandatory in v2.** Matches D4 from the continual-learning v2 spec.
+4. **Idempotency by `Signal.id` (UUID).** Server keeps a dedup window (default 7 days) keyed by `signal.id`; replay returns 200 with `{ "deduplicated": true }`.
+5. **Batch semantics: all-or-nothing per request.** Either every signal in the batch is accepted (or deduplicated) or the entire batch is rejected. Partial success is a footgun for at-least-once writers.
+6. **HTTP server lives on mur-daemon, bound to `127.0.0.1`.** Cross-machine deferred to v2 (per D4).
+7. **`SignedEnvelope` wraps the canonical-JSON Signal in v1+ optionally**, mandatory in v2. v1 servers accept both `Content-Type: application/json` (raw Signal/Batch) and `Content-Type: application/mur.signed-envelope+json` (signed wrapper) — clients pick.
+8. **Commander writes outbox files in the same on-disk YAML format that mur-core's `Inbox::receive()` accepts** — so a degenerate file-drop integration (commander writes to a shared `~/.mur/inbox/` directly) works without HTTP if both binaries run on the same machine. HTTP is the recommended path; file-drop is a documented fallback.
+9. **Frozen wire format is verified by a snapshot test in `mur-common`.** Any accidental schema change breaks CI before it ships.
+10. **One canonical commander-side reference implementation lives in this spec (§5)**. Commander team implements against it; mur team owns the receive side.
+
+## §1 Architecture
+
+```
+                    ┌─────────────────────────────────────┐
+                    │ commander daemon (closed-source)    │
+                    │                                     │
+                    │  workflow exec ──▶ LocalBridge      │
+                    │                       │              │
+                    │                       ▼              │
+                    │   ~/.mur/commander/outbox/*.yaml    │  (new directory,
+                    │                       │              │   commander-owned)
+                    │                       ▼              │
+                    │   HTTP POST /v1/signals/batch       │
+                    └───────────────┬─────────────────────┘
+                                    │ Bearer token (v1)
+                                    │ + optional SignedEnvelope (v1)
+                                    │ + mandatory SignedEnvelope (v2)
+                                    ▼
+                    ┌─────────────────────────────────────┐
+                    │ mur-daemon (mur-core)               │
+                    │                                     │
+                    │  server_agents::routes::signals     │  (NEW handler)
+                    │            │                         │
+                    │            ▼                         │
+                    │  Inbox::receive() per signal        │  (existing)
+                    │            │                         │
+                    │            ▼                         │
+                    │   ~/.mur/inbox/*.yaml               │  (existing)
+                    │            │                         │
+                    │            ▼                         │
+                    │  E3 sleep cycle drain_inbox()       │
+                    │            │                         │
+                    │            ▼                         │
+                    │  Inbox::apply_all(&store)           │  (existing)
+                    │            │                         │
+                    │            ▼                         │
+                    │  YamlStore update + E1 commit       │
+                    └─────────────────────────────────────┘
+```
+
+**File-drop fallback (same-machine, no HTTP)**: commander writes directly to `~/.mur/inbox/<ts>-<uuid>.yaml`. mur sleep cycle picks it up on next drain. Identical semantics minus auth + idempotency at the transport.
+
+## §2 Schema Freeze
+
+The frozen schema is **the code at `mur-common/src/signal.rs`** as of this date. No prose redefinition here (would drift). Reproduced for ergonomics only:
+
+```rust
+pub const SIGNAL_SCHEMA_VERSION: u32 = 1;
+
+pub struct Signal {
+    pub id: Uuid,
+    pub emitted_at: DateTime<Utc>,
+    pub actor: Actor,                     // source + native_id + display_name + resolved_user_id
+    pub target: SignalTarget,             // Pattern { name, scope } | NewDraftPattern { payload }
+    pub kind: SignalKind,                 // 5 variants below
+    pub scope: Scope,
+    pub confidence: f64,                  // default 1.0
+    pub schema_version: u32,              // default 1
+}
+
+pub enum SignalKind {
+    ExecutionSuccess,                              // C1
+    ExecutionFailure { error: String },            // C1
+    UserOverrideAtBreakpoint { reason: Option<String> },  // C1 (3x weight at scoring)
+    AutoFixApplied { step: String },               // C1
+    NewPatternProposal { origin_context: String }, // C2 + C3
+}
+```
+
+**Channel mapping** (no new variants needed):
+
+| Channel | SignalKind | SignalTarget | Notes |
+|---|---|---|---|
+| C1 evidence (success) | `ExecutionSuccess` | `Pattern` | per pattern used in step |
+| C1 evidence (failure) | `ExecutionFailure` | `Pattern` | `error` field carries reason |
+| C1 evidence (override) | `UserOverrideAtBreakpoint` | `Pattern` | 3× weight applied server-side |
+| C1 autofix | `AutoFixApplied` | `Pattern` | signals pattern inadequacy |
+| C2 chat extraction | `NewPatternProposal` | `NewDraftPattern { payload }` | `origin_context` = chat source |
+| C3 procedural | `NewPatternProposal` | `NewDraftPattern { payload }` | `origin_context` = AuditStore reference |
+
+### Freeze enforcement
+
+Add to `mur-common/src/signal.rs`:
+
+```rust
+// ─── FROZEN SCHEMA — v1 ──────────────────────────────────────────────────
+// This module is the canonical wire format between commander and mur.
+// SCHEMA FREEZE DATE: 2026-05-18
+// See: docs/superpowers/specs/2026-05-18-commander-feedback-wire-protocol-design.md
+//
+// Changes to Signal, SignalKind, SignalTarget, or SIGNAL_SCHEMA_VERSION
+// require:
+//   1. Bumping SIGNAL_SCHEMA_VERSION to 2
+//   2. Coordinated update in the commander repo (closed-source)
+//   3. Adding a v2 HTTP endpoint at /v2/signals/...
+//   4. Migration plan in a new design spec
+// ─────────────────────────────────────────────────────────────────────────
+```
+
+And a snapshot test ensuring serialization stays byte-stable across refactors (see §8).
+
+## §3 HTTP Wire Protocol
+
+### §3.1 Endpoints
+
+```
+POST   /v1/signals/batch         ← commander → mur (push)
+GET    /v1/signals/pending       ← mur → server (pull, used by `mur fetch`)
+GET    /v1/signals/dedup-cache   ← debug only, returns recent IDs (admin token)
+```
+
+This spec focuses on the push path (`POST /v1/signals/batch`). The pull path predates this spec and is unchanged.
+
+### §3.2 Request
+
+```http
+POST /v1/signals/batch HTTP/1.1
+Host: 127.0.0.1:7878
+Authorization: Bearer <token>            ← required in v1
+Content-Type: application/json | application/mur.signed-envelope+json
+Content-Length: …
+
+{
+  "batch_id": "01988fd8-3b00-7c0b-9a4c-3e8e8c0f4a11",
+  "schema_version": 1,
+  "signals": [
+    { … Signal v1 JSON … },
+    { … Signal v1 JSON … },
+    …
+  ]
+}
+```
+
+`batch_id` is a UUID owned by the sender — useful for log correlation and at-most-once HTTP delivery (sender retries with same batch_id → server returns cached response).
+
+`Content-Type: application/mur.signed-envelope+json` body shape:
+
+```json
+{
+  "payload": "<base64-of-canonical-JSON-batch>",
+  "sig": "<base64-of-ed25519-signature>",
+  "key_version": 1,
+  "bridge_pubkey_multibase": "z…"
+}
+```
+
+The signature covers the **base64 payload bytes** (re-use `mur-common::bridge::envelope::sign_payload`). Verifier MUST NOT re-canonicalize on receive — verify the exact stored bytes. This matches the existing C7 Slack bridge envelope rules.
+
+### §3.3 Response
+
+**Success (all signals accepted or deduplicated):**
+
+```http
+HTTP/1.1 202 Accepted
+Content-Type: application/json
+
+{
+  "batch_id": "01988fd8-…",
+  "accepted": 12,
+  "deduplicated": 3,
+  "received_at": "2026-05-18T10:34:11.412Z"
+}
+```
+
+**Failure (whole batch rejected):**
+
+```http
+HTTP/1.1 400 Bad Request | 401 | 413 | 422
+Content-Type: application/json
+
+{
+  "batch_id": "01988fd8-…",
+  "error": {
+    "code": "schema_version_mismatch" | "auth_failed" | "batch_too_large" |
+            "signal_invalid" | "signature_mismatch" | "untrusted_peer",
+    "message": "human-readable detail",
+    "offending_signal_id": "…"          ← only for signal_invalid
+  }
+}
+```
+
+**Status codes:**
+
+| Code | When |
+|---|---|
+| 202 | Batch accepted (incl. dedup). Always 202, never 200, to signal async processing. |
+| 400 | Malformed JSON / missing required fields. |
+| 401 | Bearer token absent / invalid. |
+| 413 | Batch exceeds 1 MiB or > 1000 signals. |
+| 422 | Schema-valid but semantic reject (e.g. unknown schema_version, signature mismatch, untrusted peer). |
+| 500 | Server-side bug (inbox write failure). Client SHOULD retry with same batch_id. |
+| 503 | Server overloaded or inbox quota exhausted. Client SHOULD back off. |
+
+### §3.4 Idempotency
+
+- **Per-signal**: server tracks `signal.id` for 7 days. Replays return `deduplicated++` in response, not an error.
+- **Per-batch**: server caches `batch_id` → response for 1 hour. Retry of same `batch_id` returns the cached response (RFC 7231-style safe retry).
+
+Dedup cache lives in `~/.mur/cache/signal-dedup.sqlite` (single-file SQLite, ephemeral). Cache loss → at-worst duplicate evidence application; tolerable because pattern scoring is monotonic and dedup is best-effort.
+
+### §3.5 Limits
+
+| Limit | Default | Rationale |
+|---|---|---|
+| Max signals per batch | 1000 | Keeps per-request work bounded |
+| Max batch body size | 1 MiB | Protects daemon memory on bulk imports |
+| Max signal `target.NewDraftPattern.payload` size | 64 KiB | Pattern YAML is text; this is generous |
+| Max request rate | 60 batch/min per token | Prevents accidental tight-loop writers |
+| Retention of accepted signals in inbox | until sleep cycle drain | Default 15 min upper bound |
+
+All configurable via `~/.mur/config.yaml` `commander_feedback.limits.*`.
+
+## §4 Authentication
+
+### §4.1 Bearer token (v1 baseline)
+
+Token generated on first mur-daemon start:
+
+```
+~/.mur/secrets/commander-token.yaml      (0600, never enters either git repo)
+```
+
+```yaml
+schema_version: 1
+token: "<32 random bytes, base64url-encoded>"
+created_at: 2026-05-18T10:00:00Z
+expires_at: null          # v1: no expiry; v2: rotateable
+rotated_from: null        # v2: previous-token grace-period field
+```
+
+Commander reads same file (same-machine assumption in v1) and includes in `Authorization: Bearer <token>` on every request.
+
+Rotation: `mur internals rotate commander-token` writes a new token, keeps previous in `rotated_from` for 1 hour to allow commander hot-reload without dropped signals.
+
+### §4.2 Ed25519 envelope (v1 optional, v2 mandatory)
+
+Re-uses `mur-common::bridge::envelope::SignedEnvelope` already shipped for C7 Slack bridge. The signing key is the commander instance's own `AgentIdentity` (commander treats itself as an A2A peer with its own identity).
+
+Verification path on mur side:
+1. Decode `SignedEnvelope` from request body.
+2. Look up `bridge_pubkey_multibase` in `~/.mur/commander/trusted-peers.yaml`.
+3. If unknown → 422 `untrusted_peer`.
+4. Verify via `mur_common::bridge::envelope::verify_envelope_with_pubkey`.
+5. On success, deserialize inner payload as `SignalBatch`.
+
+Trust list seeded on first commander pairing:
+
+```bash
+mur commander trust <pubkey-multibase>      # adds entry to trusted-peers.yaml
+mur commander revoke <pubkey-multibase>
+mur commander list-trusted
+```
+
+## §5 Commander-side Reference Implementation
+
+This section is the contract for the commander team. Code is reference-quality pseudocode in Rust idiom; commander may implement in any language as long as wire bytes match.
+
+### §5.1 LocalBridge struct
+
+```rust
+// In commander repo: crates/daemon/src/local_bridge.rs
+
+use mur_common::{Signal, SignalKind, SignalTarget, Actor, ActorSource, Scope};
+use uuid::Uuid;
+use chrono::Utc;
+
+pub struct LocalBridge {
+    outbox_dir: PathBuf,                     // ~/.mur/commander/outbox
+    daemon_url: String,                      // http://127.0.0.1:7878
+    bearer_token: String,
+    identity: Option<AgentIdentity>,         // None in v1 (no signing), Some in v2
+    flush_interval: Duration,
+    max_batch_size: usize,
+}
+
+impl LocalBridge {
+    /// Called by workflow engine when a step completes.
+    pub fn record_execution(&self, step: &Step, outcome: &Outcome) {
+        for pattern_name in step.patterns_used() {
+            let signal = Signal {
+                id: Uuid::new_v4(),
+                emitted_at: Utc::now(),
+                actor: self.actor(),
+                target: SignalTarget::Pattern {
+                    name: pattern_name.to_string(),
+                    scope: step.scope(),
+                },
+                kind: match outcome {
+                    Outcome::Success => SignalKind::ExecutionSuccess,
+                    Outcome::Failure(e) => SignalKind::ExecutionFailure { error: e.clone() },
+                    Outcome::UserOverride(r) => SignalKind::UserOverrideAtBreakpoint { reason: r.clone() },
+                    Outcome::AutoFix(s) => SignalKind::AutoFixApplied { step: s.clone() },
+                },
+                scope: step.scope(),
+                confidence: 1.0,
+                schema_version: mur_common::signal::SIGNAL_SCHEMA_VERSION,
+            };
+            self.enqueue(signal);
+        }
+    }
+
+    /// Called by chat-extraction tool (C2) or AuditStore analyzer (C3).
+    pub fn propose_pattern(&self, draft: Pattern, origin: &str) {
+        let signal = Signal {
+            id: Uuid::new_v4(),
+            emitted_at: Utc::now(),
+            actor: self.actor(),
+            target: SignalTarget::NewDraftPattern { payload: Box::new(draft) },
+            kind: SignalKind::NewPatternProposal { origin_context: origin.to_string() },
+            scope: Scope::Personal,
+            confidence: 0.5,                     // drafts start at lower confidence
+            schema_version: mur_common::signal::SIGNAL_SCHEMA_VERSION,
+        };
+        self.enqueue(signal);
+    }
+
+    fn actor(&self) -> Actor {
+        Actor {
+            source: ActorSource::CommanderDaemon,
+            native_id: gethostname::gethostname().to_string_lossy().into_owned(),
+            display_name: None,
+            resolved_user_id: None,
+        }
+    }
+
+    fn enqueue(&self, signal: Signal) {
+        let path = self.outbox_dir.join(format!(
+            "{}-{}.yaml",
+            signal.emitted_at.format("%Y-%m-%dT%H-%M-%S"),
+            signal.id
+        ));
+        let tmp = self.outbox_dir.join(format!(".{}.tmp", signal.id));
+        std::fs::write(&tmp, serde_yaml::to_string(&signal).unwrap()).unwrap();
+        std::fs::rename(&tmp, &path).unwrap();
+        // Background flusher picks up on next tick
+    }
+}
+```
+
+### §5.2 Flusher loop
+
+```rust
+async fn flush_loop(bridge: Arc<LocalBridge>) {
+    loop {
+        tokio::time::sleep(bridge.flush_interval).await;
+        let batch = bridge.collect_pending().await;
+        if batch.is_empty() { continue; }
+
+        let body = SignalBatch {
+            batch_id: Uuid::new_v4(),
+            schema_version: SIGNAL_SCHEMA_VERSION,
+            signals: batch.clone(),
+        };
+
+        let req = reqwest::Client::new()
+            .post(format!("{}/v1/signals/batch", bridge.daemon_url))
+            .bearer_auth(&bridge.bearer_token)
+            .json(&body);
+
+        let req = if let Some(id) = &bridge.identity {
+            let json_bytes = serde_json::to_vec(&body).unwrap();
+            let env = mur_common::bridge::envelope::sign_payload(json_bytes, id, 1);
+            reqwest::Client::new()
+                .post(format!("{}/v1/signals/batch", bridge.daemon_url))
+                .bearer_auth(&bridge.bearer_token)
+                .header("Content-Type", "application/mur.signed-envelope+json")
+                .json(&env)
+        } else { req };
+
+        match req.send().await {
+            Ok(r) if r.status() == 202 => bridge.delete_pending(&batch).await,
+            Ok(r) if r.status() == 401 => bridge.refresh_token().await,
+            Ok(r) if r.status() == 422 => bridge.quarantine_invalid(&batch, r).await,
+            Ok(_) | Err(_) => {
+                // Keep batch in outbox, retry next tick with backoff
+            }
+        }
+    }
+}
+```
+
+### §5.3 Outbox layout (commander-owned)
+
+```
+~/.mur/commander/                          ← commander owns this subdirectory
+├── outbox/
+│   └── 2026-05-18T10-34-11-<uuid>.yaml
+├── outbox.ledger                          ← commander state, not synced
+└── token-cache.yaml                       ← cached bearer token (mtime → reload)
+```
+
+`~/.mur/commander/` is in mur's `.gitignore` (D7) — commander state is not part of mur's knowledge or execution layer.
+
+## §6 MuR-side Receive Path
+
+### §6.1 New HTTP handler
+
+Add to `mur-core/src/server_agents/routes/`:
+
+```rust
+// signals.rs (NEW)
+use mur_common::signal::Signal;
+use crate::sync::inbox::Inbox;
+
+#[derive(Deserialize)]
+pub struct SignalBatch {
+    pub batch_id: Uuid,
+    pub schema_version: u32,
+    pub signals: Vec<Signal>,
+}
+
+pub async fn post_batch(
+    Headers(auth): Headers,
+    Body(body): Body,
+) -> Result<impl Reply, Rejection> {
+    require_bearer(&auth)?;
+
+    let (batch, signed) = match content_type(&headers) {
+        ContentType::Json => (serde_json::from_slice::<SignalBatch>(&body)?, false),
+        ContentType::SignedEnvelope => {
+            let env: SignedEnvelope = serde_json::from_slice(&body)?;
+            verify_against_trust_list(&env)?;
+            let inner: SignalBatch = serde_json::from_slice(&env.payload)?;
+            (inner, true)
+        }
+    };
+
+    if batch.schema_version != SIGNAL_SCHEMA_VERSION {
+        return Err(reject_schema_mismatch(batch.batch_id, batch.schema_version));
+    }
+    if batch.signals.len() > MAX_BATCH_SIGNALS {
+        return Err(reject_too_large(batch.batch_id));
+    }
+
+    let inbox = Inbox::default_location()?;
+    let dedup = DedupCache::open()?;
+    let mut accepted = 0;
+    let mut deduped = 0;
+
+    for sig in &batch.signals {
+        if !validate_signal(sig).is_ok() {
+            return Err(reject_signal_invalid(batch.batch_id, sig.id));
+        }
+        if dedup.contains(sig.id)? {
+            deduped += 1;
+            continue;
+        }
+        inbox.receive(sig)?;
+        dedup.insert(sig.id, Duration::from_days(7))?;
+        accepted += 1;
+    }
+
+    Ok(json!({
+        "batch_id": batch.batch_id,
+        "accepted": accepted,
+        "deduplicated": deduped,
+        "received_at": Utc::now(),
+    }))
+}
+```
+
+### §6.2 Sleep cycle integration
+
+E3's `sleep_cycle::drain_inbox()` (continual-learning v2 spec §6.2.2 step 1) calls existing `Inbox::apply_all(&store)`. No change needed in inbox/apply logic.
+
+Curator (E2 §5.2.2) wraps the apply step with the new versioning store (E1 `VersionedYamlStore`), producing one git commit per applied signal with reason `feedback(c1): commander <actor> <kind>` etc.
+
+## §7 Compatibility & Versioning Rules
+
+| Change type | Allowed without bump | Requires bump | Notes |
+|---|---|---|---|
+| Add new `SignalKind` variant | ❌ | ✅ → v2 | Old clients can't deserialize new variants |
+| Add new field to `Signal` with `#[serde(default)]` | ✅ | — | Forward-compatible additive |
+| Add new field without default | ❌ | ✅ → v2 | Breaks deserialization on old clients |
+| Add new `ActorSource` variant | ❌ | ✅ → v2 | Same reason |
+| Rename field via `#[serde(alias = ...)]` (read both names) | ⚠️ allowed but discouraged | — | Hard to audit; prefer no-rename |
+| Change `Pattern` schema in `NewDraftPattern.payload` | governed by `Pattern.schema` field | — | Independent versioning, see knowledge.rs |
+| Add new HTTP endpoint at `/v1/...` | ✅ | — | URL is the version |
+| Change response shape of existing `/v1/...` endpoint | ❌ | ✅ → /v2/... | New endpoint with new URL |
+| Tighten validation (reject previously-accepted input) | ❌ | ✅ → v2 | Breaks existing senders |
+| Loosen validation (accept previously-rejected input) | ✅ | — | Backward-compat |
+
+**Process for v1 → v2 bump** (future):
+
+1. Open design spec referencing this doc.
+2. Bump `SIGNAL_SCHEMA_VERSION = 2` in `signal.rs`.
+3. Add `/v2/signals/batch` handler keeping `/v1/signals/batch` working in parallel for ≥ 90 days.
+4. Coordinated PR in commander repo to support v2 wire format.
+5. Deprecation warning emitted by `/v1/signals/batch` for last 30 days.
+
+## §8 Test Fixtures
+
+### §8.1 Canonical YAML sample (C1 execution success)
+
+```yaml
+id: 01988fd8-3b00-7c0b-9a4c-3e8e8c0f4a11
+emitted_at: 2026-05-18T10:34:11.412Z
+actor:
+  source: commander_daemon
+  native_id: host-prod-1.example.com
+target:
+  kind: pattern
+  name: rust-error-handling
+  scope:
+    kind: personal
+kind:
+  type: execution_success
+scope:
+  kind: personal
+confidence: 1.0
+schema_version: 1
+```
+
+### §8.2 Canonical YAML sample (C2 new draft proposal)
+
+```yaml
+id: 01988fd8-4400-7000-8aaa-aaaaaaaaaaaa
+emitted_at: 2026-05-18T11:00:00Z
+actor:
+  source: slack
+  native_id: U07A9C8DEFG
+  display_name: alice
+target:
+  kind: new_draft_pattern
+  payload:
+    name: prefer-pnpm-over-npm
+    description: Use pnpm for monorepos, npm for single-package projects
+    schema: 2
+    tier: session
+    content:
+      plain: |
+        Use pnpm in this org. npm causes peer-dep churn in our monorepo.
+    importance: 0.5
+    tags: [tooling, node]
+kind:
+  type: new_pattern_proposal
+  origin_context: "slack:#dev-platform thread ts=1747560000.000100"
+scope:
+  kind: personal
+confidence: 0.5
+schema_version: 1
+```
+
+### §8.3 Required snapshot test (to be added to `mur-common`)
+
+```rust
+// mur-common/tests/wire_format_snapshot.rs
+
+#[test]
+fn signal_v1_wire_format_is_frozen() {
+    let signal: Signal = serde_yaml::from_str(include_str!("fixtures/c1_execution_success.yaml")).unwrap();
+    let re = serde_yaml::to_string(&signal).unwrap();
+    insta::assert_snapshot!("c1_execution_success", re);
+}
+
+#[test]
+fn signal_v1_unknown_field_strict_reject() {
+    let yaml = r#"
+id: 01988fd8-3b00-7c0b-9a4c-3e8e8c0f4a11
+emitted_at: 2026-05-18T10:34:11Z
+actor: { source: commander_daemon, native_id: x }
+target: { kind: pattern, name: x, scope: { kind: personal } }
+kind: { type: execution_success }
+scope: { kind: personal }
+new_future_field: "this should reject under v1 strict mode"
+"#;
+    // Currently serde_yaml ignores unknown fields by default. Spec §7 says
+    // unknown variants → v2 bump, but unknown FIELDS are silently ignored
+    // (forward-compat additive). This test documents the current behavior.
+    let s: Result<Signal, _> = serde_yaml::from_str(yaml);
+    assert!(s.is_ok());
+}
+```
+
+### §8.4 HTTP integration test (to be added to `mur-core`)
+
+```rust
+// mur-core/tests/signals_endpoint.rs
+
+#[tokio::test]
+async fn post_batch_accepts_and_dedups() {
+    let server = test_daemon().await;
+    let token = server.commander_token();
+
+    let batch = SignalBatch {
+        batch_id: Uuid::new_v4(),
+        schema_version: 1,
+        signals: vec![sample_signal(), sample_signal()],   // 2 distinct
+    };
+
+    // first POST: 202, accepted=2
+    let r1 = server.post("/v1/signals/batch", &batch, &token).await;
+    assert_eq!(r1.status(), 202);
+    assert_eq!(r1.json::<Resp>().await.accepted, 2);
+
+    // second POST same batch_id: cached response
+    let r2 = server.post("/v1/signals/batch", &batch, &token).await;
+    assert_eq!(r2.status(), 202);
+
+    // third POST with new batch_id but same signal ids: deduplicated
+    let batch3 = SignalBatch { batch_id: Uuid::new_v4(), ..batch.clone() };
+    let r3 = server.post("/v1/signals/batch", &batch3, &token).await;
+    assert_eq!(r3.json::<Resp>().await.deduplicated, 2);
+}
+```
+
+## §9 Open Questions
+
+1. **Where does the dedup SQLite live during dev?** `~/.mur/cache/signal-dedup.sqlite` is the proposal. Alternative: in-memory only (acceptable since dedup is best-effort). **Proposed answer**: SQLite for prod (survives daemon restart, useful during commander reconnect storms); in-memory for `cargo test` (overrideable via env var).
+2. **Should mur-daemon expose a Prometheus metric for accepted/deduplicated/rejected counts?** **Proposed**: yes, behind `mur-core/src/server_agents/metrics.rs` (already exists for B0 telemetry). Names: `mur_signals_batch_accepted_total`, `_deduplicated_total`, `_rejected_total{reason="..."}`.
+3. **Multi-tenant token model.** v1 has one token shared with commander. What about future support for Slack bridge writing C2 signals directly (without going through commander)? **Proposed**: defer to v2. v1 path: Slack bridge writes to commander, commander forwards via this protocol.
+4. **What about a signal flowing in the other direction (mur → commander, e.g., "this pattern just got Stable, you may now reference it")?** **Proposed**: out of scope for this spec. Existing `mur-core::evolve::commander_bridge` writes workflow YAML to `~/.mur/workflows/` and commander polls. If push notification needed, separate spec.
+
+## §10 Non-goals
+
+- **End-to-end encryption** beyond Ed25519 signing — TLS on a different machine is v2.
+- **Multi-host fan-out** — v1 is single-machine. Commander running on a different host requires v2 work (TLS, IP allowlist, mutual auth).
+- **Replay attack mitigation** beyond dedup window — assumes localhost is not a hostile network in v1.
+- **Schema evolution tooling** — manual coordination is fine while we have one consumer.
+
+## §11 Implementation Checklist
+
+For mur side (this repo):
+
+- [ ] Add freeze annotation to `mur-common/src/signal.rs` (§2)
+- [ ] Add `SignalBatch` type to `mur-common/src/signal.rs`
+- [ ] Add `mur-common/tests/wire_format_snapshot.rs` with insta snapshots (§8.3)
+- [ ] Implement `mur-core/src/server_agents/routes/signals.rs` (§6.1)
+- [ ] Implement dedup cache (`mur-core/src/sync/dedup.rs` + SQLite migration)
+- [ ] Implement `~/.mur/secrets/commander-token.yaml` generation on daemon first start
+- [ ] Add `mur internals rotate commander-token` CLI
+- [ ] Add `mur commander trust|revoke|list-trusted` CLI for §4.2
+- [ ] Integration test `mur-core/tests/signals_endpoint.rs` (§8.4)
+- [ ] Wire E3 `sleep_cycle::drain_inbox()` to existing `Inbox::apply_all()` (continual-learning v2 spec §6.2.2)
+- [ ] Add metrics counters (§9 Q2)
+- [ ] Docs page: "Commander integration — connecting Commander to MuR"
+
+For commander side (separate repo, parallel work):
+
+- [ ] Add `mur-common` as dep (already may be; confirm version pin)
+- [ ] Implement `crates/daemon/src/local_bridge.rs` per §5.1
+- [ ] Implement flusher loop per §5.2
+- [ ] Outbox directory at `~/.mur/commander/outbox/` per §5.3
+- [ ] Read bearer token from `~/.mur/secrets/commander-token.yaml`
+- [ ] Optional: implement Ed25519 signing pass once commander has identity
+- [ ] Wire workflow engine: every step completion → `LocalBridge::record_execution`
+- [ ] Wire chat-extraction tool → `LocalBridge::propose_pattern` (C2)
+- [ ] Wire AuditStore analyzer → `LocalBridge::propose_pattern` (C3)
+- [ ] Outbox retention: 7 days uncategorized, then archive/discard
+
+## §12 References
+
+- `docs/superpowers/specs/2026-04-18-mur-commander-memory-sync-design.md` — original C1/C2/C3 design
+- `docs/superpowers/plans/2026-05-18-mur-commander-channel1-closure.md` — implementation plan that this spec replaces
+- `plans/2026-05-18-continual-learning-versioned-evolution.md` — v2 strategy spec (E5, D4, D8)
+- `docs/superpowers/specs/2026-05-18-mur-agent-manifest-design.md` — manifest spec (orthogonal but uses same auth model)
+- `mur-common/src/signal.rs` — the frozen schema, source of truth
+- `mur-common/src/bridge/envelope.rs` — SignedEnvelope (C7 Slack bridge already in production use)
+- `mur-core/src/sync/inbox.rs` — receive-side, live
+- RFC 7231 §4.2.2 (Idempotent Methods)
+- RFC 7807 (Problem Details for HTTP APIs) — error response shape inspiration

--- a/docs/superpowers/specs/2026-05-18-mur-agent-manifest-design.md
+++ b/docs/superpowers/specs/2026-05-18-mur-agent-manifest-design.md
@@ -1,0 +1,440 @@
+# Agent Manifest — Design
+
+**Status**: proposed
+**Author**: david + Claude Opus 4.7
+**Date**: 2026-05-18
+**Related**: `plans/2026-05-18-continual-learning-versioned-evolution.md` (v2 spec §8.3, D6 / D7 / E6), `2026-04-29-model-registry-and-secret-refs-design.md`, `2026-04-22-murmur-p0-agent-runtime-design.md`
+
+## Problem
+
+Building a mur agent today is **imperative and scattered**. Recreating "the same agent" on another machine — or letting commander provision it remotely — requires running N CLI commands in a specific order:
+
+```bash
+mur agent create code-reviewer --type=chat --model-ref=anthropic/sonnet-4-6
+mur agent perm allow-host code-reviewer github.com
+mur agent perm allow-host code-reviewer sentry.io
+mur agent perm allow-read code-reviewer /Users/david/Projects
+mur agent skill add code-reviewer skills/review-rust.md
+mur agent skill add code-reviewer skills/review-typescript.md
+mur agent mcp add code-reviewer github --command npx ...
+mur agent secret set code-reviewer GITHUB_TOKEN keychain:mur-github/work
+mur agent prompt set code-reviewer < sys_prompt.md
+mur agent companion add code-reviewer slack-bridge ...
+```
+
+This blocks five concrete workflows:
+
+1. **Cross-machine deployment** — commander wants to push the same agent to 5 remote hosts. No single artifact to ship.
+2. **GitOps for agents** — user wants `infra/agents/*.yaml` in a project repo with PR review on changes. No declarative artifact to put under review.
+3. **Drift detection** — after weeks of ad-hoc CLI edits, no way to ask "is this agent still in the shape I intended?".
+4. **E6 federation config** — the new pattern snapshot filter (`applies_in`, `tier`, `maturity`, `max_count`) needs a home. `profile.yaml` is the wrong layer (it's about runtime identity, not knowledge filtering).
+5. **Cost & resource limits** — no per-agent token budget, no per-agent concurrent-session cap. Bill shock waiting to happen once a user runs 20 agents.
+
+Existing `profile.yaml` is **runtime identity** (model, transport, entitlements, capabilities) — not the right shape to absorb skills, MCP servers, secrets bindings, federation policy, and resource limits. Expanding it would conflate concerns and break P0a's hot-path assumptions.
+
+## Research consensus
+
+Three reference points converge on the same shape:
+
+- **Kubernetes manifests** — `apiVersion / kind / metadata / spec`, declarative, server reconciles state to match. Battle-tested across millions of clusters. Drift detection via `kubectl diff`.
+- **GitHub Actions workflows** — single YAML per workflow, lives in git, applied by a controller, drives both local (`act`) and remote (Actions runners) execution from one source. Proves "same spec, multiple targets" works without coordination protocol.
+- **Letta `AgentFile`** (2025 Q4 OSS) — declarative agent definition with memory blocks + tools + persona inline; portable across Letta server instances. Closest direct analogue, but ours must accommodate mur's existing `profile.yaml` + git layering.
+
+The conclusion: **AgentManifest is additive over `profile.yaml`, not a replacement**. Existing agents work unchanged. Manifest is opt-in for users who want declarative ops. Future-proofs commander remote deployment (D6 in continual-learning v2 spec).
+
+## Decisions
+
+1. **`AgentManifest` is the declarative wrapper, `profile.yaml` remains the runtime artifact.** Apply flow: manifest → controller reconciles → writes/updates `profile.yaml`, `sys_prompt.md`, `skills/`, perms, MCP configs. Runtime never reads manifest directly; it reads the reconciled artifacts.
+
+2. **`apiVersion: mur.run/v1`, `kind: AgentManifest`.** Future kinds (`WorkflowManifest`, `TeamManifest`, `PolicyManifest`) follow the same shape; share metadata structure via `mur-common::manifest::Metadata`.
+
+3. **Manifest can mix inline + ref.** Small agents inline everything (one file, easy to read). Large agents reference external files (`skills_refs: [skills/x.md, skills/y.md]`). Reconciler resolves refs relative to manifest file's directory.
+
+4. **Apply is idempotent + diffable.** `mur agent apply -f m.yaml` always produces the same state given the same input. `mur agent diff -f m.yaml` shows would-be changes without applying. `mur agent diff <name>` shows manifest vs current actual state (drift report).
+
+5. **No templating / no admission controllers in v1.** Users who need templating use external tools (`envsubst`, helm-style). v1 is a flat schema. Future: jsonnet/CUE adapter as separate tool.
+
+6. **Each apply produces an E1 commit.** Reconciler commits to `~/.mur/agents/.git` with reason `agent(<name>): apply manifest <kind> <delta-summary>`. Rollback = re-apply previous manifest revision (E1 history is the audit trail).
+
+7. **`AgentManifest` is the source of truth for E6 federation config.** `spec.patterns.filter` and `spec.federation.*` live here, not in `profile.yaml`. profile.yaml stays small and runtime-focused.
+
+8. **Commander uses the same schema.** `mur commander apply -f m.yaml --target=host:agent-name` ships the manifest to remote host and invokes `mur agent apply` there over A2A tunnel. Schema parity is enforced by both binaries depending on the same `mur-common::manifest` crate module.
+
+9. **Secrets follow existing `SecretRef`** (2026-04-29 design). Manifest is commit-safe — never inline secret values.
+
+10. **`mur agent describe <name> > m.yaml` exports current state.** Migration path for existing imperatively-created agents. Output is the manifest that, when applied, reproduces the current state exactly.
+
+## §1 Architecture
+
+```
+~/.mur/
+├── agents/
+│   ├── .git/                          (E1 execution-layer repo)
+│   └── <name>/
+│       ├── manifest.yaml              ← NEW: source of truth (optional)
+│       ├── profile.yaml               ← reconciled artifact (existing)
+│       ├── sys_prompt.md              ← reconciled artifact
+│       ├── skills/                    ← reconciled artifacts
+│       ├── mcp/                       ← reconciled artifacts
+│       └── identity.pub/.prev         ← runtime, not managed by manifest
+```
+
+```
+mur-common::manifest                   (new module)
+  ├── Metadata { name, workspace, annotations }
+  ├── AgentManifest { api_version, kind, metadata, spec }
+  ├── AgentSpec { profile, sys_prompt, skills, mcp_servers,
+  │              patterns, resources, entitlements, federation,
+  │              companion, secrets }
+  └── validation / diff / merge helpers
+
+mur-core::manifest                     (new module — reconciler)
+  ├── reconcile(manifest) → ChangeSet
+  ├── apply(change_set) → Result<CommitId>
+  ├── diff(manifest, actual) → Diff
+  └── describe(agent_name) → AgentManifest
+
+mur-core::cmd::agent::apply.rs         ← `mur agent apply -f m.yaml`
+mur-core::cmd::agent::diff.rs          ← `mur agent diff [-f m.yaml] <name>`
+mur-core::cmd::agent::describe.rs      ← `mur agent describe <name>`
+mur-core::cmd::agent::validate.rs      ← `mur agent validate -f m.yaml`
+```
+
+**Apply dataflow** (local):
+
+```
+1. Read manifest file, resolve refs relative to file dir
+2. Validate schema (JSON Schema) + semantic (referenced files exist, model_ref resolves,
+   entitlements parse, secret refs parse)
+3. Load current agent state from ~/.mur/agents/<name>/ (or empty if new)
+4. Compute ChangeSet: profile.yaml diff, sys_prompt.md diff, skills/ add/remove,
+   mcp/ add/remove, perms diff, federation config diff
+5. If --dry-run: print Diff and exit
+6. Reconcile: write all artifacts atomically (tempdir + rename), run
+   `mur agent stop` if model/transport/entitlements changed (require restart)
+7. Commit to ~/.mur/agents/.git with reason `agent(<name>): apply <summary>`
+8. If agent was running and not stopped above, send SIGHUP to reload (skills + prompt
+   hot-reload supported; profile/entitlements changes need full restart)
+```
+
+**Apply dataflow** (commander remote):
+
+```
+1-2. Same (run on commander control plane)
+3. Open A2A tunnel to target host's mur-daemon
+4. POST /v1/agents/apply with manifest body + target name
+5. Remote daemon runs steps 3-8 from local flow above
+6. Stream reconciliation log back to commander; commander records to audit store
+```
+
+## §2 Schema
+
+`~/.mur/agents/<name>/manifest.yaml` (canonical example, all fields):
+
+```yaml
+apiVersion: mur.run/v1
+kind: AgentManifest
+
+metadata:
+  name: code-reviewer
+  workspace: default                   # defaults to "default"
+  annotations:
+    owner: david@example.com
+    purpose: "Review PRs in Mur project"
+  labels:                              # for `mur agent list -l owner=david`
+    owner: david
+    env: dev
+
+spec:
+  # ─── Identity & runtime ──────────────────────────────────────
+  display_name: "Code Reviewer"
+  model_ref: anthropic/sonnet-4-6      # resolves via models.yaml
+  transport: a2a                        # a2a | stdio | http
+  capabilities:
+    streaming: true
+    tools: true
+
+  # ─── Prompt & skills ─────────────────────────────────────────
+  sys_prompt: |                         # inline form
+    You are a senior code reviewer focused on Rust and TypeScript...
+  # — or —
+  # sys_prompt_ref: ./prompts/code-reviewer.md
+
+  skills:                               # inline list of skill objects
+    - name: review-rust
+      content_ref: ./skills/review-rust.md
+    - name: review-typescript
+      content: |
+        # Review TypeScript
+        Focus on...
+
+  # ─── MCP servers ─────────────────────────────────────────────
+  mcp_servers:
+    - name: github
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-github"]
+      env:
+        GITHUB_PERSONAL_ACCESS_TOKEN: ${secrets.GITHUB_TOKEN}
+
+  # ─── Knowledge federation (E6) ───────────────────────────────
+  patterns:
+    filter:
+      applies_in: [code, review]
+      applies_to_projects: [mur, dashboard]
+      tier: [project, core]
+      maturity: [stable, canonical]
+      importance_min: 0.5
+      max_count: 200
+    snapshot_policy: pull-on-start      # pull-on-start | pull-periodic | manual
+    snapshot_interval_minutes: 60       # only if policy=pull-periodic
+
+  # ─── Resource governance ─────────────────────────────────────
+  resources:
+    token_budget_per_day_usd: 5.00      # hard cap; over → agent refuses new turns
+    max_concurrent_sessions: 3
+    max_context_tokens: 200000
+
+  # ─── Entitlements (P0a sandbox) ──────────────────────────────
+  entitlements:
+    network:
+      hosts: [api.github.com, sentry.io, api.anthropic.com]
+    filesystem:
+      read: [/Users/david/Projects/mur]
+      write: []
+    spawn:
+      allowed: [git, cargo, rustfmt]
+    limits:
+      cpu_percent: 50
+      memory_mb: 2048
+
+  # ─── Federation (E6) ─────────────────────────────────────────
+  federation:
+    evidence_outbox_max_age_minutes: 15
+    snapshot_diff_threshold_pct: 20     # > N% pattern change → require human ack
+
+  # ─── Companion (Slack/TG/Discord bridges, C7) ────────────────
+  companion:
+    enabled: true
+    channels:
+      - kind: slack
+        team_ref: keychain:mur-slack/team1
+      - kind: telegram
+        bot_ref: keychain:mur-telegram/bot
+
+  # ─── Secrets binding ─────────────────────────────────────────
+  secrets:
+    GITHUB_TOKEN: keychain:mur-github/work
+    OPENAI_API_KEY: env:OPENAI_API_KEY
+    # See 2026-04-29 design for full SecretRef codec
+
+  # ─── Lifecycle hooks ─────────────────────────────────────────
+  hooks:
+    on_apply:                            # runs after reconcile, before restart
+      - run: ./scripts/post-apply.sh
+    on_first_start:
+      - mur: "agent send code-reviewer 'Initialized.'"
+```
+
+### Schema versioning
+
+- `apiVersion: mur.run/v1` is frozen once shipped. Field deprecations: keep + warn for 2 minor versions, then `mur.run/v2`.
+- Reconciler accepts `mur.run/v1` indefinitely; unknown future fields under v1 are **rejected** (strict parse) to avoid silent drift.
+- `mur agent validate` reports unknown fields with helpful suggestions ("did you mean `entitlements.network.hosts`?").
+
+### Minimal manifest
+
+For a simple agent:
+
+```yaml
+apiVersion: mur.run/v1
+kind: AgentManifest
+metadata:
+  name: scratch
+spec:
+  model_ref: anthropic/haiku-4-5
+  sys_prompt: "You are a quick helper."
+```
+
+All other fields default. `transport: stdio`, no skills, no MCP, no federation, no companion, no entitlements override (uses workspace default policy).
+
+## §3 CLI
+
+```
+mur agent apply -f <manifest.yaml> [--dry-run] [--no-restart] [--force]
+mur agent apply -f <dir>/                     # recursive apply on a directory
+mur agent diff [-f <manifest.yaml>] <name>    # vs manifest, or manifest vs current
+mur agent describe <name> [-o yaml|json]      # export current state → manifest
+mur agent validate -f <manifest.yaml>         # schema + semantic check, no side effect
+mur agent delete -f <manifest.yaml>           # remove agent declared in manifest
+                                              # (--cascade also removes ~/.mur/agents/<name>/)
+mur agent list -l owner=david                  # label selector (k8s style)
+
+mur commander apply -f <manifest.yaml> --target=<host[:agent-name]>
+mur commander diff <host>:<name>
+mur commander list-deployments
+```
+
+**Important defaults:**
+
+- `mur agent apply` without `--no-restart` will stop & restart agent if profile/entitlements/transport changed. With `--no-restart`, changes are written to disk but daemon defers restart until next manual stop/start.
+- `--dry-run` prints unified diff of all reconciled artifacts; exits 0 if no changes, 2 if changes pending.
+- `--force` bypasses the "manifest_revision in metadata differs from last-applied" optimistic-concurrency check (default behavior prevents stomping on parallel apply).
+
+## §4 Reconciler details
+
+### §4.1 ChangeSet computation
+
+```rust
+pub struct ChangeSet {
+    pub agent_name: String,
+    pub profile_changes: ProfileDiff,            // model_ref, transport, capabilities
+    pub sys_prompt_change: Option<TextDiff>,
+    pub skill_changes: SkillSetDiff,             // added, removed, modified
+    pub mcp_changes: McpSetDiff,
+    pub perm_changes: PermDiff,
+    pub federation_changes: FederationDiff,
+    pub companion_changes: CompanionDiff,
+    pub secret_changes: SecretBindingDiff,
+    pub requires_restart: bool,                  // profile/entitlements/transport touched
+    pub requires_snapshot_refresh: bool,         // E6: patterns.filter touched
+}
+```
+
+### §4.2 Apply order (deterministic, fail-safe)
+
+1. **Validate** entire manifest. Bail on any error before touching disk.
+2. **Stop** agent if `requires_restart` and agent is running. Persist intent (`~/.mur/agents/<name>/.apply-in-progress`) so an interrupted apply can resume.
+3. **Write artifacts** to tempdir (`~/.mur/agents/<name>/.apply-staging/`). Atomic rename per file.
+4. **Update perms / entitlements** in profile.yaml.
+5. **Reconcile companion** (notify companion controller of channel changes).
+6. **Refresh snapshot** if `requires_snapshot_refresh`: invoke E6 `federation::pull_snapshot`. On failure, keep old snapshot, log warning, continue.
+7. **Commit** to `~/.mur/agents/.git`.
+8. **Restart** agent if needed (read fresh profile).
+9. **Run hooks** (`on_apply` then, if first start, `on_first_start`).
+10. Remove `.apply-in-progress` marker.
+
+If step 2-9 fails after step 7 (commit): the commit stays (auditable record of intent), but a follow-up `agent(<name>): apply failed at <stage>` commit is written with the partial state. Operator sees both in `mur agent history`.
+
+### §4.3 Drift detection (`mur agent diff <name>`)
+
+1. `describe(<name>)` → current state as `AgentManifest`
+2. Read declared manifest from `~/.mur/agents/<name>/manifest.yaml`
+3. Compute `Diff` (same engine as apply)
+4. Report. Exit 0 if no drift, 3 if drift detected (CI-friendly).
+
+If `manifest.yaml` is absent (imperatively-created agent), report "no manifest declared — run `mur agent describe <name> > manifest.yaml` to adopt declarative mode".
+
+## §5 Commander integration
+
+### §5.1 Wire protocol
+
+Commander → mur daemon over A2A tunnel (existing transport). New endpoint:
+
+```
+POST /v1/manifest/apply
+  Headers:
+    Authorization: Bearer <commander-token>     (D4 from continual-learning spec)
+    Content-Type: application/yaml
+  Body: <AgentManifest YAML>
+  Response (streaming):
+    event: validate    data: { ok: true }
+    event: changeset   data: { ... }
+    event: stage       data: { name: "stop", status: "ok" }
+    event: stage       data: { name: "write", status: "ok" }
+    ...
+    event: commit      data: { sha: "abc123", reason: "..." }
+    event: done        data: { agent: "code-reviewer", restarted: true }
+```
+
+Commander records every event to its own audit store (per-host, per-deployment).
+
+### §5.2 Multi-target deployment
+
+`mur commander apply -f m.yaml --target=host1,host2,host3`:
+
+- Iterates targets serially by default (one host fails → halt, don't cascade).
+- `--parallel=N` for fan-out (use with care).
+- `--rollout=canary --canary-pct=10` for staged rollout (future, not v1).
+
+### §5.3 Commander-side state
+
+Commander stores per-host **applied manifest digest** (not the manifest itself — that lives on the target). On next apply, commander computes manifest digest, compares, skips if unchanged (`--force` to bypass). This avoids re-applying identical manifests to hundreds of hosts.
+
+## §6 Validation rules
+
+Semantic checks beyond schema:
+
+| Rule | Failure |
+|---|---|
+| `metadata.name` matches `^[a-z][a-z0-9-]{1,62}$` | reject |
+| `spec.model_ref` resolves in `~/.mur/models.yaml` | reject (or warn if `--allow-unresolved`) |
+| `spec.sys_prompt_ref` file exists, readable | reject |
+| Each `spec.skills[].content_ref` file exists | reject |
+| `spec.secrets.*` parses as valid `SecretRef` | reject |
+| `spec.entitlements.network.hosts` are valid hostnames or IPs | reject |
+| `spec.entitlements.spawn.allowed` are non-empty, single-word executable names | reject |
+| `spec.patterns.filter.tier` ⊆ `[session, project, core]` | reject |
+| `spec.patterns.filter.maturity` ⊆ `[draft, emerging, stable, canonical]` | reject |
+| `spec.resources.token_budget_per_day_usd` >= 0 | reject |
+| `spec.companion.channels[].kind` ⊆ supported kinds | reject |
+| Unknown top-level field under `spec.` | reject (strict) |
+
+## §7 Migration
+
+### §7.1 Adopting manifests for existing agents
+
+```bash
+mur agent describe my-existing-agent > ~/.mur/agents/my-existing-agent/manifest.yaml
+mur agent diff my-existing-agent                # should be empty
+git -C ~/.mur/agents add my-existing-agent/manifest.yaml
+git -C ~/.mur/agents commit -m "agent(my-existing-agent): adopt manifest"
+```
+
+After this, edits go through `mur agent apply` (or direct edit + apply). CLI commands like `mur agent perm allow-host` still work — they re-render the manifest and re-apply, so the manifest stays in sync.
+
+### §7.2 Detecting "imperative drift"
+
+After adopting a manifest, if user runs `mur agent perm allow-host my-agent example.com` (imperative), the CLI:
+
+1. Loads current manifest
+2. Adds entitlement to in-memory copy
+3. Writes back manifest.yaml
+4. Calls `mur agent apply -f manifest.yaml`
+
+→ No drift. Manifest stays canonical.
+
+If user **directly edits** `profile.yaml`:
+
+- Next `mur agent diff` detects drift, suggests `mur agent describe > manifest.yaml` to re-adopt or `mur agent apply -f manifest.yaml` to revert.
+
+### §7.3 Removing manifest mode
+
+```bash
+rm ~/.mur/agents/<name>/manifest.yaml
+```
+
+Agent reverts to imperative mode. No state lost (artifacts still on disk).
+
+## §8 Open questions
+
+1. **Apply ordering across multiple manifests** — when applying a directory, should agents that reference each other (e.g., `companion.peer_agent_ref`) be ordered? **v1 answer**: no inter-manifest refs in v1; defer to v2.
+2. **Workspace concept** — `metadata.workspace` is declared but currently `~/.mur/agents/` is flat. Should we move to `~/.mur/workspaces/<ws>/agents/<name>/`? **v1 answer**: keep flat; workspace is a label/filter only. Migrate to dir structure in v2 if multi-workspace becomes load-bearing.
+3. **Secret resolution in manifest at apply time** — should we resolve secrets at apply time to verify they exist? **v1 answer**: yes, with `--skip-secret-check` opt-out (useful when applying on a control plane without the runtime secrets). Resolution result is **not stored**; only "does it resolve" boolean.
+4. **Manifest in agent's own git** — when commander applies remotely, the target host's `~/.mur/agents/.git` gets the commit. Should commander also keep a copy in its own audit store? **v1 answer**: yes, commander stores the manifest body in audit store keyed by `(host, agent, manifest_digest, applied_at)`. Allows commander-side rollback even if target host is gone.
+
+## §9 Non-goals (explicit)
+
+- **Templating** — no `{{ .Values.x }}` in v1. Use `envsubst` externally.
+- **Inheritance / overlays** — no `base: parent-manifest.yaml`. v1 is flat.
+- **Schema migrations between v1 and future v2** — out of scope (handled by `mur agent migrate-manifest` when v2 ships).
+- **Cron / scheduled apply** — out of scope (use system cron + `mur agent apply`).
+- **Manifest as runtime config** — runtime always reads reconciled artifacts. Performance reason: no YAML parse + ref resolution + validation in hot path.
+
+## §10 References
+
+- Continual-learning v2 spec — `plans/2026-05-18-continual-learning-versioned-evolution.md` §8.3 (D6), §9 (E6)
+- P0a agent runtime — `docs/superpowers/specs/2026-04-22-murmur-p0-agent-runtime-design.md`
+- Model registry & SecretRef — `docs/superpowers/specs/2026-04-29-model-registry-and-secret-refs-design.md`
+- Commander memory sync — `docs/superpowers/specs/2026-04-18-mur-commander-memory-sync-design.md`
+- Kubernetes — [API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md), [kubectl apply semantics](https://kubernetes.io/docs/reference/using-api/server-side-apply/)
+- Letta AgentFile — [letta-ai/letta repo](https://github.com/letta-ai/letta)

--- a/mur-common/src/signal.rs
+++ b/mur-common/src/signal.rs
@@ -13,7 +13,23 @@ use uuid::Uuid;
 
 use crate::{Actor, Pattern, Scope};
 
-/// Current schema version of the Signal wire format.
+// ─── FROZEN SCHEMA — v1 ──────────────────────────────────────────────────
+// This module is the canonical wire format between commander and mur.
+// SCHEMA FREEZE DATE: 2026-05-18
+// Spec: docs/superpowers/specs/2026-05-18-commander-feedback-wire-protocol-design.md
+//
+// Changes to Signal, SignalKind, SignalTarget, Actor, ActorSource, or
+// SIGNAL_SCHEMA_VERSION require:
+//   1. Bumping SIGNAL_SCHEMA_VERSION to 2
+//   2. Coordinated update in the commander repo (closed-source)
+//   3. Adding a v2 HTTP endpoint at /v2/signals/...
+//   4. Migration plan in a new design spec
+//
+// Additive changes (new fields with #[serde(default)]) are allowed within v1.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Current schema version of the Signal wire format. FROZEN at v1 — see
+/// module-level comment for change rules.
 pub const SIGNAL_SCHEMA_VERSION: u32 = 1;
 
 /// A single event envelope: who produced what kind of event about which target,

--- a/plans/2026-05-18-continual-learning-versioned-evolution.md
+++ b/plans/2026-05-18-continual-learning-versioned-evolution.md
@@ -1,0 +1,710 @@
+# MuR / MuR Commander — 持續學習與版本化演進規格 v2
+
+**日期：** 2026-05-18（v2 修訂：併入 Q1-Q4 + A-D 深度問題）
+**狀態：** Draft（規格，待 review）
+**取代：** v1（同檔，commit 留存）
+**範疇：** mur-core / mur-common / mur-agent-runtime / mur-daemon / mur-hub-gui，整合 MuR Commander
+
+**v2 主要變更（vs v1）：**
+1. 新增 §0 Decisions Log（Q1-Q4 + A-D 共 8 項裁決）
+2. **E1 改為雙 git repo 設計**（知識層 `~/.mur/.git` + 執行層 `~/.mur/agents/.git`）
+3. **新增 E6：Agent Pattern Federation**（解決 A: agent 與記憶系統解耦）
+4. E5 contract 明確化（mur 側 inbox 已 live，缺 commander 側 writer）
+5. 路線圖延至 120 天
+
+---
+
+## 0. Decisions Log（v2 新增）
+
+| # | 議題 | 決策 | 出處 |
+|---|---|---|---|
+| D1 | Reflector model 預設 | **獨立 role 概念 + 3 階自動降階**：`local/qwen2.5-14b` → `anthropic/haiku-4-5` → 首次 prompt。Reflector / Curator / Embedding 各為一個 role，在 `~/.mur/models.yaml` 配置。 | Q1 |
+| D2 | Sleep cycle 預設值 | **opt-in，三段式 rollout**：v2.17 default off + 三時機提示；v2.18-19 收 telemetry；v2.20 若 rollback 率 <1% 才考慮 default-on。 | Q2 |
+| D3 | `mur internals git` | **YES 暴露，三色名單**：白（log/status/diff/show）直通；灰（checkout/stash）confirm；黑（reset --hard/rebase/push）需 `--i-know-what-im-doing`。daemon 啟動偵測外部 HEAD 變動自動 rebuild index。 | Q3 |
+| D4 | C1/C2/C3 v1 transport | **`127.0.0.1` bind + bearer token**，重用已 frozen 的 `mur-common::signal::Signal` v1 schema（`signal.id` 做 idempotency、`actor.source` 即 `ActorSource` enum、`schema_version` 為 wire 版本）；簽章走既有 `SignedEnvelope` wrapper，v1 可選 / v2 強制。詳見 wire-protocol spec。 | Q4 |
+| D5 | Agent ↔ 記憶系統的關係 | **Hybrid Federation 模型**：daemon 為 canonical store；每個 agent 啟動時拉取 `applies` 過濾後的 pattern snapshot 進 `~/.mur/agents/<name>/patterns_cache/`；agent 寫 evidence 到本地 outbox；export bundle 連 snapshot 一起打包，可離線運作，rejoin 時同步。詳見 **E6**。 | A |
+| D6 | mur ↔ commander 管控分工 | **三層職責分離**：mur CLI 管 lifecycle（create/edit/inspect）、commander 管 task orchestration（workflows/audit）、hub-gui 管 monitoring + chat UI。新增 **AgentManifest** 概念作為兩者共用的宣告式 spec（K8s 風格）。詳見 E5 §8.3。 | B |
+| D7 | `~/.mur/agents/` 是否進 git | **拆兩個 git repo**：`~/.mur/.git`（知識層：patterns/workflows/config）+ `~/.mur/agents/.git`（執行層：agent profiles/skills/perms）。**不**用 per-agent `.git`（100 agents = 100 repo 不可行）。telemetry/outbox-ledger/crashlogs/running.lock 全 gitignore。export 時用 `git subtree split` 產出 per-agent 乾淨歷史。詳見 **E1 §4.2**。 | C |
+| D8 | LongTermStore 回流 gap 現況 | **確認 gap 存在**。mur 側 `mur-core/src/sync/inbox.rs:14-100` `Inbox::apply_all()` 已實裝且 live；commander 側 outbox writer / local_bridge **0%**。E5 的工作量集中在 commander 側 + 兩端 contract 明確化（mur 側只需把 Curator 接到既有 `apply_all`）。 | D |
+
+---
+
+## 1. 為什麼此時做？業界 2025-2026 風向
+
+### 1.1 三個共識（v1 已寫，此處摘要）
+
+1. **學習在 token-space，不在 weight-space**（[a16z](https://a16z.com/why-we-need-continual-learning/)、[Letta CL](https://www.letta.com/blog/continual-learning)）
+2. **記憶 = 可變、可審計資產**，SSGM 點名 Memory Poisoning / Semantic Drift / Conflict 三大失敗模式（[SSGM](https://arxiv.org/html/2603.11768v1)）
+3. **角色分工**：ACE Generator/Reflector/Curator（[ACE](https://arxiv.org/abs/2510.04618)） + Letta Primary/Sleep-time（[Sleep-time](https://www.letta.com/blog/sleep-time-compute)）
+
+### 1.2 v2 新增的第四共識：Agent ≠ Memory Sink
+
+最新一波 production 系統都不再把 agent 當「無記憶執行器」：
+- **Letta Context Repositories**（2025 Q4）每個 agent 都有自己的 git-backed memfs
+- **OpenAI Agents SDK + Memory** 把 memory tool 當第一公民傳給 agent
+- **Anthropic Skills**（MuR 已部分採用）把 markdown 技能視為 agent 級資產
+
+**MuR 現在的反例：** 完整 grep `mur-agent-runtime/src/` 找 `patterns` → 零次知識層讀取。每個 agent 是「啞 supervisor + LLM + skills」，學習成果由中央 daemon 包辦，但 export 出去就斷線。
+
+→ **這驅動 E6 的存在**。
+
+### 1.3 業界 vs MuR 對應更新
+
+| 業界做法 | MuR 現況 | 缺什麼 | 對應 Epic |
+|---|---|---|---|
+| Letta git-backed memory | YAML 為真相但無 git history | 版本化 store | **E1** |
+| ACE Reflector/Curator | `capture/feedback.rs` 純 keyword | 角色分工 + delta | **E2** |
+| Sleep-time compute | 無閒置 reasoning | sleep cycle | **E3** |
+| MemoryBench/Evo-Memory | 只有 B0 M11 安全 eval | retrieval eval | **E4** |
+| Letta git memory per agent / OpenAI memory tool | **agent 與記憶完全隔離** | Agent federation | **E6 (新)** |
+| Commander 雙向同步（draft 2026-04-18） | mur 側 inbox 已 ready, commander 側 0% | commander writer + contract | **E5** |
+
+---
+
+## 2. MuR Codebase 現況盤點（v2 補充 agent 層）
+
+### 2.1 既有「學習迴圈」（v1 已寫，不重複）
+
+略——見 v1 §2.1，內容不變。
+
+### 2.2 致命缺口（v1 表格 + v2 新增三項）
+
+| 缺口 | 證據 | 影響 |
+|---|---|---|
+| 無 pattern 版本欄位 | `KnowledgeBase.schema = 2` 常數 | A/B 不可能、無法回滾 |
+| 無 audit log | 只有 `updated_at` 戳記 | 無法追溯變更 |
+| edit 是 destructive | `store/yaml.rs` 原子寫入但覆蓋 | bad edit 永久損失 |
+| 無 retrieval 品質 eval | `inject/stats.rs` 只計數 | 改演算法無法量化 |
+| Workflow 版本化半成品 | `workflow.rs:41` 有欄位但 store 不支援多版本 | 無法平行跑兩版 |
+| `team.rs` dead code | 整檔 `#![allow(dead_code)]` | 跨 agent 學習無法觸發 |
+| Commander feedback 未出貨 | `2026-04-18` spec draft + `2026-05-18` plan 0% | 千筆 audit 無法回流 |
+| **v2 新增：Agent ↔ memory 完全隔離** | `mur-agent-runtime/src/` grep `patterns` 零讀寫；export 不含 LanceDB | Exported agent 無學習能力；offline VPS agent 是 stateless |
+| **v2 新增：agent 目錄與 telemetry 混居** | telemetry/jsonl + outbox-ledger 與 profile.yaml 同層 | 整目錄無法乾淨 git 化 |
+| **v2 新增：無 multi-agent orchestrator** | 每個 agent 獨立 `running.lock`、無 supervisor 樹 | A2A 只能 1:1，無法做工作流編排 |
+
+### 2.3（v2 新增）Agent 層盤點
+
+從 explore 報告精煉：
+
+- **mur-agent-runtime** 每個實例獨立，無 inter-agent 通訊以外的協調
+- **`~/.mur/agents/<name>/` 結構**：
+  - **User-edited（要 version）**：`profile.yaml`, `sys_prompt.md`, `skills/`, perm config, secret metadata
+  - **Runtime cache（不要 version）**：`running.lock`, `telemetry/<date>.jsonl`, `companion/outbox-ledger`, `crashlogs/`, `.extract_digest`, `companion/inbox/`
+- **`mur agent` 40+ 子命令**：lifecycle / comm / service / stats / export / mcp / perm / skill / prompt / secret / companion / rekey / schedule
+- **export 機制**：`mur agent export --format=pkg|bin`，前者 tar.gz（profile + sys_prompt + skills + mcp prereq），後者把整 agent 目錄嵌入二進制（`MUR_EXPORT_AGENT_DIR`）
+- **A2A v0.3 supervisor** 在 `mur-agent-runtime/src/supervisor.rs:40-150` — 純 per-agent，無集中視角
+- **HostGuard/Landlock/SBPL** 由 `profile.entitlements` 驅動 per agent
+
+---
+
+## 3. 規格總覽：6 個 Epic（v2 加 E6）
+
+```
+        ┌─→ E2  Reflector + Curator  ─┐
+        │                              │
+E1 ─────┼─→ E3  Sleep-time            ─┼─→ E5  Commander Feedback Loop
+(基礎)   │                              │
+        ├─→ E4  Eval Harness          ─┤
+        │                              │
+        └─→ E6  Agent Federation      ─┘
+                  (v2 新增)
+```
+
+**依賴規則**：
+- E1 是所有其他 Epic 的前提（沒有版本化就沒有安全的自動寫入）
+- E2 / E3 / E4 / E6 可平行（建議順序 E1 → E4 → E2 → E6 → E3 → E5）
+- E5 整合所有上游，是最後 milestone
+
+---
+
+## 4. E1 — Versioned Store（v2 重大改寫：雙 git repo）
+
+### 4.1 目標
+
+讓 mur 的所有可變狀態都 git-backed、可 rollback、可審計。**v2 變更：拆兩個 git repo** 對應知識層與執行層職責不同。
+
+### 4.2 雙 git repo 設計
+
+#### 4.2.1 佈局
+
+```
+~/.mur/
+├── .git/                              # ① 知識層 repo
+├── .gitignore                         # 忽略 agents/, inbox/, session/, cache/, lance.db
+├── patterns/*.yaml                    # tracked
+├── workflows/*.yaml                   # tracked
+├── config.yaml                        # tracked
+├── models.yaml                        # tracked
+├── policy.yaml                        # tracked
+├── archive/                           # tracked
+│   └── patterns/<name>/v<n>-<sha>.yaml
+├── .mur-versions.yaml                 # tracked (索引)
+│
+├── inbox/                             # ignored (高頻；E5 用)
+├── outbox/                            # ignored (高頻；E5 用)
+├── session/                           # ignored (active.json + recordings/)
+├── cache/                             # ignored (lance.db 衍生品)
+├── secrets/                           # ignored (絕對不入 git)
+│
+└── agents/                            # ① 內 gitignore，但自己有 ②
+    ├── .git/                          # ② 執行層 repo
+    ├── .gitignore                     # 細粒度，每 agent 子目錄都有規則
+    ├── README.md                      # tracked: 機器列表 + agent 清單
+    ├── agent-a/
+    │   ├── profile.yaml               # tracked
+    │   ├── sys_prompt.md              # tracked
+    │   ├── skills/*.md                # tracked
+    │   ├── identity.pub               # tracked (Ed25519 public)
+    │   ├── identity.prev              # tracked
+    │   ├── patterns_cache/            # tracked (E6: snapshot pointer)
+    │   │   └── .snapshot-ref          # 指向知識層 commit SHA
+    │   ├── telemetry/                 # ignored (高頻 jsonl)
+    │   ├── companion/outbox-ledger    # ignored (高頻狀態)
+    │   ├── companion/inbox/           # ignored
+    │   ├── crashlogs/                 # ignored
+    │   ├── running.lock               # ignored
+    │   └── .extract_digest            # ignored
+    └── agent-b/
+        └── ...
+```
+
+#### 4.2.2 為什麼分兩個 repo
+
+| 維度 | 知識層 `~/.mur/.git` | 執行層 `~/.mur/agents/.git` |
+|---|---|---|
+| 寫入頻率 | 中（Curator commit、user 編輯） | 低（user 改 profile/skills） |
+| 寫者 | daemon（Curator / sleep cycle） + user | user + daemon（E6 snapshot ref 更新） |
+| 內容性質 | 「mur 學到什麼」 | 「user 配置了什麼」 |
+| 多人協作 | 未來可能跨機器同步 | 通常單機/單 user |
+| Export 對象 | pattern set / workflow set | 個別 agent（用 `git subtree split`） |
+| 適合的 retention | 永久 | 長期但可 prune |
+
+**反例（為何不用單一 git）**：telemetry 每秒 append → 整 repo 寫入熱點轉移到非知識內容，git pack 效率劣化、`git log patterns/` 變慢。
+
+**反例（為何不用 per-agent .git）**：
+- 100 agents = 100 個 `.git/` 目錄，磁碟膨脹（每個基本 4MB起跳）
+- 跨 agent 操作（`mur agent diff <a> <b>` / `mur agent batch rollback`）需手動跑 100 次
+- 無集中視角看 agent 配置歷史
+
+#### 4.2.3 Export 時的 history 抽取
+
+```bash
+mur agent export --format=git --include-history my-agent
+# 內部執行：
+#   git -C ~/.mur/agents subtree split --prefix=my-agent -b export-my-agent
+#   git -C ~/.mur/agents bundle create my-agent.gitbundle export-my-agent
+#   tar czf my-agent.murpkg profile.yaml ... my-agent.gitbundle
+# 接收端：
+#   tar xzf my-agent.murpkg
+#   git clone my-agent.gitbundle ~/.mur/agents/my-agent
+#   mur agent register my-agent
+```
+
+→ 跨機器遷移 agent **自動帶版本歷史**，不需要中央 server。
+
+#### 4.2.4 資料模型變更（mur-common）
+
+`KnowledgeBase` 新增（v1 已寫，重申）：
+```rust
+pub version: u32,                       // 1, 2, 3...
+pub revision: Option<String>,           // 12-char git short SHA
+pub previous_revision: Option<u32>,
+```
+schema 升 `3`。
+
+`AgentProfile` 新增（v2 新增）：
+```rust
+pub snapshot_ref: Option<SnapshotRef>,  // E6 用
+```
+```rust
+pub struct SnapshotRef {
+    pub knowledge_commit: String,       // 知識層 SHA
+    pub taken_at: DateTime<Utc>,
+    pub pattern_filter: PatternFilter,  // applies / tier / maturity 過濾條件
+}
+```
+
+#### 4.2.5 寫入路徑
+
+- `VersionedYamlStore`（知識層 wrapper）→ commit 到 `~/.mur/.git`
+- `VersionedAgentStore`（執行層 wrapper，v2 新增）→ commit 到 `~/.mur/agents/.git`
+- 兩者共用底層 `git2` crate + 一個 commit message convention：
+
+```
+<kind>(<scope>): <one-line>
+
+kind  = pattern | workflow | profile | skill | maturity | feedback | snapshot | rollback
+scope = pattern/workflow/agent name
+```
+
+#### 4.2.6 CLI 新增（合併 v1）
+
+```
+# 知識層
+mur pattern history <name>
+mur pattern diff <name> [v1] [v2]
+mur pattern rollback <name> --to v<n>
+mur pattern branch <name> <branch>
+mur pattern merge <branch>
+
+# 執行層（v2 新增）
+mur agent history <name>
+mur agent diff <name> [v1] [v2]
+mur agent rollback <name> --to v<n>
+
+# 通用 escape hatch（D3 決策）
+mur internals git --layer=knowledge|agents <git-subcommand>
+mur internals rebuild-index --layer=knowledge|agents
+```
+
+#### 4.2.7 daemon 啟動安全檢查
+
+對兩個 repo 各自：
+1. `git fsck` 偵測 broken refs
+2. HEAD SHA vs `.mur-versions.yaml` 比對；不一致 → rebuild index + hub notification
+3. `git gc --auto`（每 7 天）
+4. 若 `.git` 損毀 → daemon 進 read-only，禁止 Curator 寫入
+
+> **`.mur-versions.yaml` 是 load-bearing 索引，不是診斷檔（spike FIN-3）。** 內含每個 pattern / workflow 的版本對 commit SHA 映射，供 `mur pattern history` O(1) 查詢。詳見 §4.2.8 規則 #3 與 [ADR-0001](../docs/architecture/adr/0001-e1-versioned-store-spike-findings.md)。
+
+#### 4.2.8 強制實作規則（2026-05-18 spike 結論，**production code MUST 遵守**）
+
+詳細推導見 [ADR-0001](../docs/architecture/adr/0001-e1-versioned-store-spike-findings.md)。
+
+1. **FIN-1 — save hot path 禁用 `git index.add_all`**。`VersionedYamlStore::save_pattern` / `VersionedAgentStore::save_profile` 只能 `index.add_path(p)` 顯式路徑（caller 傳入的 pattern 檔 + archive 檔）。違反 → repo 規模上升後 O(N²) 拖垮 daemon。
+   - 例外：`repair_*` 一次性 disaster recovery 可用 add_all。
+
+2. **FIN-2 — save hot path 禁用 git history walk**。version 派發必須 O(1)。建議實作：
+   ```rust
+   fn current_version(name: &str) -> u32 {
+       archive_dir_count(name) + (if current_file_exists(name) { 1 } else { 0 })
+   }
+   ```
+   或把 `version: u32` 寫進 pattern YAML metadata（schema=3 已預留欄位）。**不可**呼叫 `git log` 或 revwalk 在 save 路徑。
+
+3. **FIN-3 — `.mur-versions.yaml` 升級為 load-bearing 每-pattern 索引**。原 v1 spec 是純 HEAD-SHA 比對的診斷檔；spike 量到 3000-commit repo 上 `git log` 走訪 1.94 秒（目標 100ms 的 20×）。**index 必填內容**：
+   ```yaml
+   schema_version: 3
+   knowledge_head: <12-char sha>
+   agents_head:    <12-char sha>
+   patterns:
+     <name>:
+       current_version: <u32>
+       versions:
+         - { v: 1, sha: <12-char>, ts: <iso8601>, reason: <commit-msg-1st-line> }
+         - { v: 2, sha: <12-char>, ts: <iso8601>, reason: ... }
+   workflows: ...
+   ```
+   每次 save → 同步 append 一筆（O(1)）。`mur pattern history <name>` 直接讀索引；live revwalk 只在索引缺失 / 損毀時的 fallback。重建命令：`mur internals rebuild-index --layer=knowledge|agents`（離線 O(total-commits)）。
+
+4. **FIN-4 — `.gitignore` 用 bare 模式，不要 `*/` anchor**。libgit2 對 `*/foo/` 在 `statuses()` 的 reporting 有不一致行為；用 bare `foo/` 才穩。正式 production `~/.mur/agents/.gitignore`：
+   ```gitignore
+   telemetry/
+   outbox-ledger
+   inbox/
+   crashlogs/
+   running.lock
+   .extract_digest
+   .apply-staging/
+   .apply-in-progress
+   ```
+   單元測試驗 gitignore 正確性 **必須** 用 `Repository::is_path_ignored(path)`，不能用 `statuses()` 迭代判斷。
+
+### 4.3 驗收條件
+
+- [ ] `mur reindex --bootstrap` 後兩個 `.git` 都存在，且有初始 commit
+- [ ] 編輯任一 pattern 3 次 → `mur pattern history` 顯示 3 revision，archive 對應
+- [ ] 編輯任一 agent profile 3 次 → `mur agent history` 顯示 3 revision
+- [ ] `mur agent export --format=git --include-history` 產出可在另一台機器 `git clone` 並 register 的 bundle
+- [ ] daemon 從外部跑 `cd ~/.mur && git reset --hard HEAD~1` 後重啟，自動 rebuild index 不崩
+- [ ] telemetry 每秒寫入 24 小時，`~/.mur/agents/.git/` 大小不超過 5MB 增長
+- [ ] **`history()` 在 1000-pattern × 3-revision 的 repo 上回傳時間 < 100ms（走 `.mur-versions.yaml` 索引，不走 live git log）**（FIN-3 驗收）
+- [ ] **`save_pattern` 在 10k-pattern repo 上的 wall-clock 與在 100-pattern repo 上的差距 < 2×**（FIN-1 + FIN-2 驗收，確認 O(1) per save）
+
+---
+
+## 5. E2 — Reflector + Curator（v2 微調：併入 D1）
+
+v1 設計大致不變。**v2 補強：Reflector model 走 role 概念。**
+
+### 5.1 Role-based model 配置（D1 決策落地）
+
+```yaml
+# ~/.mur/models.yaml (新增 roles)
+providers:
+  local:
+    base_url: http://localhost:11434
+  anthropic:
+    api_key_ref: secret://anthropic_key
+  openai:
+    api_key_ref: secret://openai_key
+
+models:
+  local/qwen2.5-14b:
+    provider: local
+    context: 32768
+  anthropic/haiku-4-5:
+    provider: anthropic
+    context: 200000
+    cost_per_mtok_in: 1.00
+    cost_per_mtok_out: 5.00
+
+roles:
+  reflector:
+    primary: local/qwen2.5-14b
+    fallback: anthropic/haiku-4-5
+    cost_budget_per_day_usd: 0.50
+    privacy_local_only_when_sensitive: true   # 看 policy.yaml sensitive_paths
+  curator:
+    primary: anthropic/haiku-4-5
+    fallback: local/qwen2.5-14b
+  embedding:
+    primary: local/bge-m3
+```
+
+首次啟動偵測：
+```rust
+// mur-core/src/cmd/role_setup.rs (新)
+fn auto_detect_reflector() -> RoleConfig {
+    if ollama_has("qwen2.5:14b") || ollama_has("gemma3:12b") { /* local primary */ }
+    else if has_secret("anthropic_key") { /* haiku */ }
+    else { push_hub_notification("setup_reflector_role") }
+}
+```
+
+CLI：
+```
+mur model role set reflector <model_name>
+mur model role list
+mur model role usage [--since 7d]
+```
+
+### 5.2 其餘設計（Reflector / Curator / 排程）
+
+維持 v1 §5.2-5.3，不重複。
+
+---
+
+## 6. E3 — Sleep-time Companion（v2 微調：併入 D2 + 增 agent-side）
+
+### 6.1 v2 變更：兩種 sleep cycle
+
+**v1 只考慮 daemon-side sleep。v2 新增 agent-side sleep cycle**，因為 E6 後每個 agent 有自己的 patterns_cache 和 evidence outbox：
+
+| 層 | 何時跑 | 做什麼 | 寫到哪 |
+|---|---|---|---|
+| **daemon-side** | 使用者閒置 15 分鐘 | drain commander/c1c2c3 inbox → reflect → curate → consolidate → decay | 知識層 git |
+| **agent-side** | agent 處於 idle session 5 分鐘 | flush local evidence outbox → 同步 snapshot（看是否有新版） | agent outbox + snapshot_ref |
+
+兩種 cycle 都受 D2 三段式 rollout 規範（opt-in）。
+
+### 6.2 安全閾值 + telemetry 指標（D2 決策落地）
+
+新增 telemetry：
+- `sleep_cycle.enable_rate`
+- `sleep_cycle.rollback_rate_per_1k_commits`
+- `sleep_cycle.cost_p95_per_user_per_week`
+- `sleep_cycle.disable_after_enable_rate`
+- `sleep_cycle.agent_side.snapshot_drift_pct`（agent 拒收新 snapshot 的比例 — 過高代表 daemon 學歪）
+
+升級 default-on 的 gate：上述前三項全部達標連續 6 週。
+
+### 6.3 三時機 opt-in 提示（D2）
+
+略——同上次回答內容。實作在 `mur-core/src/cmd/sleep_onboarding.rs`。
+
+---
+
+## 7. E4 — Eval Harness（v2 微調：新增 federation eval）
+
+v1 設計不變，v2 新增第 5 個 suite：
+
+```rust
+pub struct FederationEval;   // E6 用：
+// 給定一連串「daemon 學到新 pattern → agent snapshot 更新 → agent 用該 pattern」
+// 量測：snapshot lag (median seconds)、agent acceptance rate、cross-agent
+// pattern reuse rate
+```
+
+CLI 新增 `mur eval run federation`。
+
+---
+
+## 8. E5 — Commander Feedback Loop（v2 重寫 contract，2026-05-18 修訂）
+
+> **修訂註記**：在寫 §8.2 過程中掃了 codebase 才發現 schema 基礎建設遠比 v1 spec 假設的完整。**原本要新建的 `FeedbackEnvelope` 是重複輪子**——直接重用既有 `mur-common::signal::Signal`（v1 schema，11 個測試）。完整 HTTP wire contract 已抽出到獨立 spec：
+> 👉 **`docs/superpowers/specs/2026-05-18-commander-feedback-wire-protocol-design.md`**（本節為摘要 + 連結）
+
+### 8.1 v2 變更（D8 決策落地）
+
+**mur 側基礎設施掃描結果**（比 v1 想像更 ready）：
+
+| 元件 | 狀態 | 位置 |
+|---|---|---|
+| `Signal` envelope (v1 schema) | ✅ live + frozen 2026-05-18 | `mur-common/src/signal.rs` |
+| `SignalKind` 5 variant 涵蓋 C1/C2/C3 | ✅ live | 同上 |
+| `SignalTarget::Pattern / NewDraftPattern` | ✅ live | 同上 |
+| `Actor` + `ActorSource`（含 `CommanderDaemon`） | ✅ live | `mur-common/src/actor.rs` |
+| `SignedEnvelope` Ed25519 wrapper | ✅ live（C7 Slack bridge 在用） | `mur-common/src/bridge/envelope.rs` |
+| `Inbox::apply_all()` 受端 | ✅ live | `mur-core/src/sync/inbox.rs:14-100` |
+| `Outbox` 發端 | ✅ live | `mur-core/src/sync/outbox.rs` |
+| **`POST /v1/signals/batch` HTTP handler** | ❌ 未實裝 | `mur-core/src/server_agents/routes/` |
+| **Bearer token 認證** | ❌ 未實裝 | — |
+| **Dedup cache** | ❌ 未實裝 | — |
+| **Commander 側 LocalBridge / outbox writer** | ❌ 未實裝（閉源倉） | — |
+
+**剩下工作集中在三件事**：
+1. **HTTP endpoint 與 dedup**（mur 側）— wire-protocol spec §6
+2. **Commander 端 outbox writer + flusher**（commander 倉，閉源，平行開工）— wire-protocol spec §5 已備 reference impl
+3. **Curator 接到 inbox**（mur 側，順接 E2/E3 sleep cycle 的 `drain_inbox()`）
+
+### 8.2 HTTP contract 摘要（細節見 wire-protocol spec）
+
+**裁決：不新建 `FeedbackEnvelope` 型別**。重用既有 `Signal`，只新增一個 HTTP 批次包裝：
+
+```rust
+// mur-common/src/signal.rs (在既有檔內新增；不開新 module)
+pub struct SignalBatch {
+    pub batch_id: Uuid,                  // 給 commander 端做 at-most-once 重試
+    pub schema_version: u32,             // = SIGNAL_SCHEMA_VERSION = 1
+    pub signals: Vec<Signal>,            // 既有 frozen v1 型別
+}
+```
+
+**Endpoint**（單一批次端點，不分 channel — channel 由 `SignalKind` + `SignalTarget` 隱含）：
+
+```
+POST /v1/signals/batch    (127.0.0.1 only, Bearer token, 可選 SignedEnvelope)
+GET  /v1/signals/pending  (既有 pull 路徑，不變)
+```
+
+**Channel 對應**（無需新 variant）：
+
+| Channel | SignalKind | SignalTarget |
+|---|---|---|
+| C1 evidence | `ExecutionSuccess` / `ExecutionFailure` / `UserOverrideAtBreakpoint` / `AutoFixApplied` | `Pattern { name, scope }` |
+| C2 chat extraction | `NewPatternProposal { origin_context }` | `NewDraftPattern { payload: Box<Pattern> }` |
+| C3 procedural | `NewPatternProposal { origin_context }` | `NewDraftPattern { payload: Box<Pattern> }` |
+
+**Auth**：daemon 首啟產 `~/.mur/secrets/commander-token.yaml`（D4），bearer 在 v1 必填、`SignedEnvelope` 在 v1 可選 / v2 強制。
+
+**Idempotency**：server 對 `signal.id` (UUID) 維護 7 天 dedup cache（SQLite at `~/.mur/cache/signal-dedup.sqlite`）；重送回 202 + `{ "deduplicated": true }`。
+
+**File-drop fallback**：同機部署可繞過 HTTP，commander 直接寫 `~/.mur/inbox/<ts>-<uuid>.yaml`（與 `Inbox::receive()` 相同格式），sleep cycle 下次 drain 自動接收。
+
+**詳細部份請看 wire-protocol spec**：
+- §3 HTTP 完整 request/response + 6 個 status code 對應情境
+- §4 Auth model（bearer + Ed25519 verification path）
+- §5 Commander 端 reference implementation（`LocalBridge` 完整 Rust 偽碼 + flusher loop）
+- §6 MuR 端 handler 偽碼
+- §7 Versioning rules（哪些變更可加在 v1、哪些要 bump v2）
+- §8 Test fixtures（canonical YAML + snapshot test + integration test）
+- §11 雙倉 implementation checklist（mur 13 項 + commander 10 項）
+
+### 8.3 AgentManifest（D6 決策落地，新概念）
+
+宣告式 spec，mur CLI 與 commander 雙方共用：
+
+```yaml
+# example: ~/.mur/agents/agent-a/manifest.yaml
+apiVersion: mur.run/v1
+kind: AgentManifest
+metadata:
+  name: code-reviewer
+  workspace: default
+spec:
+  profile_ref: profile.yaml
+  sys_prompt_ref: sys_prompt.md
+  skills:
+    - skills/review-rust.md
+    - skills/review-typescript.md
+  patterns:
+    filter:
+      applies_in: [code, review]
+      tier: [project, core]
+      maturity: [stable, canonical]
+    snapshot_policy: pull-on-start
+  resources:
+    token_budget_per_day_usd: 5.00
+    max_concurrent_sessions: 3
+  entitlements:
+    network: [github.com, sentry.io]
+    filesystem_read: [/Users/david/Projects]
+    filesystem_write: []
+  federation:
+    evidence_outbox: outbox/
+    sync_interval_minutes: 15
+```
+
+部署：
+```bash
+mur agent apply -f manifest.yaml         # 本地建立/更新
+mur commander apply -f manifest.yaml     # 由 commander 推到遠端機器
+```
+
+→ 兩個工具相同 schema，類 K8s 風格，避免 mur/commander 之間 spec 漂移。
+
+### 8.4 Team scope 啟用（v1 §8.2.4 強化）
+
+`team.rs` 移除 `#![allow(dead_code)]`，配合 E1 commit 序解決 conflict：
+- 同一 pattern 從不同 `actor_id` 來的 evidence → 不互相覆蓋，各記 per-actor `helpful_count`
+- 若兩 actor signal 矛盾（A success / B override）→ Curator 產生 `InsightKind::Conflict` 並 log 到 hub
+
+### 8.5 驗收（v1 + v2 增量）
+
+- [ ] Commander mock 打一個 `SignalBatch` 含 C1/C2/C3 各 1 個 `Signal` → 回 202 / `accepted: 3` → 三筆落 `~/.mur/inbox/` → sleep cycle 跑完知識層各產一 commit
+- [ ] 重送同 `batch_id` → 回 cached 202；重送同 `signal.id`（不同 batch）→ `deduplicated++`、無 double apply
+- [ ] Bearer token 缺/錯 → 401；token 對但 `SignedEnvelope` 簽章不符（v2 模式）→ 422 `signature_mismatch`
+- [ ] `mur internals replay-inbox --from <date>`（debug/migration）可重跑歷史 signal YAML
+- [ ] `mur-common/tests/wire_format_snapshot.rs` 跑 insta snapshot 通過，意外改動 schema → CI 紅
+
+---
+
+## 9.（v2 新增）E6 — Agent Pattern Federation
+
+### 9.1 目標
+
+打通 A 問題：讓 agent 從「無記憶 thin client」變成「有 snapshot + 本地 outbox 的記憶節點」，同時不破壞 daemon 為 canonical store 的中心化模型。
+
+### 9.2 設計
+
+#### 9.2.1 三個關鍵概念
+
+1. **Snapshot** — daemon 在 agent 啟動時，依 `manifest.spec.patterns.filter` 過濾出該 agent 用得到的 pattern subset，寫入 `~/.mur/agents/<name>/patterns_cache/*.yaml`，並在 `.snapshot-ref` 記下知識層 commit SHA
+2. **Evidence Outbox** — agent runtime 執行中產生的 signal（pattern 是否被引用、被使用者讚/反駁）寫到 `~/.mur/agents/<name>/outbox/<ts>-<nonce>.yaml`
+3. **Federation Sync** — 兩種同步：
+   - **pull**（snapshot 更新）：agent idle 5 min 或 commander/hub 強制觸發 → daemon 重算 snapshot → diff → 寫入 patterns_cache
+   - **push**（outbox 上行）：agent 每 N 分鐘掃 outbox → 透過 daemon local API 注入 inbox → Curator 處理
+
+#### 9.2.2 Snapshot 過濾語言
+
+```yaml
+patterns:
+  filter:
+    applies_in: [code, review]          # KnowledgeBase.applies.contexts
+    applies_to_projects: [project-x]    # 預設「不限」
+    tier: [project, core]
+    maturity: [stable, canonical]
+    importance_min: 0.5
+    max_count: 200
+  snapshot_policy: pull-on-start | pull-periodic | manual
+```
+
+snapshot policy 三檔讓不同信任度的 agent 採不同節奏（例如 production agent 用 manual，dev agent 用 pull-on-start）。
+
+#### 9.2.3 Offline 場景
+
+`mur agent export --format=bin --include-snapshot` 把 patterns_cache 一起嵌入二進制 → 拿到無網路 VPS 跑：
+- agent 用 snapshot 中的 pattern（read-only）
+- evidence 仍寫 outbox（local file）
+- 下次連回有 daemon 的環境 → `mur agent reconnect <name>` 主動 push outbox
+
+#### 9.2.4 安全模型
+
+- agent 沒有寫 `~/.mur/patterns/` 的權限（檔案系統層用 D3 sandbox 阻擋）
+- agent 唯一寫入：自己的 outbox + telemetry
+- 所有對 canonical 的影響都經過 daemon Curator → 等於把 E2 的安全閘門複用到 federation
+
+#### 9.2.5 衝突解決
+
+當 daemon 推新 snapshot 而 agent 本地 outbox 有未 flush evidence 時：
+1. 先 push outbox（讓 daemon 知道最新 evidence）
+2. daemon 把 evidence 套用到 canonical（可能改變該 pattern）
+3. 重新計算 snapshot 並 pull
+4. agent 收到「自己貢獻過 evidence 的 pattern」更新版
+
+→ 形成完整 federation feedback loop，呼應 ACE「context as living playbook」。
+
+### 9.3 mur-agent-runtime 改動
+
+新增三個模組：
+- `mur-agent-runtime/src/federation/snapshot.rs` — pull/diff/apply
+- `mur-agent-runtime/src/federation/outbox.rs` — write/queue/flush
+- `mur-agent-runtime/src/federation/client.rs` — talks to daemon local API
+
+新增 supervisor 啟動步驟（在 sandbox apply 之後）：
+```rust
+// supervisor.rs
+federation::pull_snapshot(profile.snapshot_ref, manifest.spec.patterns.filter)?;
+federation::start_outbox_flusher(interval_minutes);
+```
+
+daemon 側新增 endpoint：
+```
+GET  /v1/agents/:name/snapshot       — 回傳 snapshot YAML tarball + ref SHA
+POST /v1/agents/:name/evidence       — agent push outbox 用
+POST /v1/agents/:name/reconnect      — offline agent 重連
+```
+
+### 9.4 驗收
+
+- [ ] 建一個 agent + manifest 過濾 `tier: [core]` → snapshot 只含 core patterns
+- [ ] daemon 升級某 pattern 到 core → 下次 snapshot pull 含該 pattern；agent log 顯示「snapshot updated to <sha>」
+- [ ] agent 在 offline VPS 跑 1 小時產生 10 條 outbox → `mur agent reconnect` 後 daemon inbox 收到 10 envelope
+- [ ] E4 `mur eval run federation` 顯示 snapshot lag p50 < 5 分鐘、agent acceptance rate > 95%
+
+---
+
+## 10. 120 天路線（v2 延長）
+
+| 週 | Epic | 工作 |
+|---|---|---|
+| W1-W3 | E1 | schema=3、雙 git repo、archive、CLI history/diff/rollback、`mur internals git` |
+| W4 | E1 | GUI History（hub）、integration test、文件 |
+| W5-W6 | E4 | retrieval / maturity / reflector eval suites、CI |
+| W7-W8 | E2 | role 配置（D1）、Reflector LLM + heuristic fallback、Curator、conflict resolution |
+| W9-W11 | **E6** | manifest schema、snapshot pull/diff、outbox、daemon endpoints、agent runtime hook |
+| W12 | E6 | `mur agent export --include-snapshot`、offline reconnect、federation eval |
+| W13-W14 | E3 | daemon-side sleep cycle、agent-side sleep cycle、IdleScheduler hook、安全閾值 |
+| W15 | E3 | opt-in onboarding（D2）、hub 顯示、telemetry 指標 |
+| W16 | E5 | mur 側 HTTP endpoint（D4）、bearer token、AgentManifest CLI（`mur agent apply`） |
+| W17 | E5 | 與 commander 對齊 contract、跑 mock e2e |
+| W18 | (release) | dogfood、bug bash、文件、v2.20 release |
+
+每 Epic 結束跑 E4 全套 suite。
+
+---
+
+## 11. 護城河說明（v2 補強）
+
+| 對手 | 強項 | 對 MuR 威脅 | v2 完成後差異化 |
+|---|---|---|---|
+| **Letta** | git-backed memory、Skills、sleep-time | 直接撞 MuR 核心 | 雙 git 設計 + agent federation 比 Letta 單層 memory 更貼近 multi-agent ops；**MuR 本地優先 + 跨 runtime 可攜（E6）** 是 Letta 沒有的 |
+| **Mem0** | 20+ backend、token-efficient algo | retrieval 品質 | E4 eval harness 量化追趕；dual-layer pattern + maturity lifecycle + federation 是結構優勢 |
+| **ACE** | Reflector/Curator + delta | 演算法領先 | E2 直接吸收；**MuR 多 per-actor evidence、commander 執行回饋、agent snapshot federation** 三條 ACE 沒觸及的工程閉環 |
+| **OpenAI / Anthropic 原生 memory** | 模型原生 | 大廠紅利 | **跨模型可攜（agent 換 model 不丟資產）、純本地、git 可審計**；E6 export 可離線跑這條他們完全沒有 |
+| **K8s/Operator 風格 agent 編排** | 成熟生態 | 未來企業需求 | E5 §8.3 `AgentManifest` 直接對齊 K8s 風格，但執行體是輕量 supervisor 而非 container — 對開發者友善 |
+
+---
+
+## 12. 風險與緩解（v2 補強）
+
+| 風險 | 緩解 |
+|---|---|
+| 雙 git repo → 磁碟雙倍 | 兩個都跑 `git gc --auto`；archive 用 git-LFS-like external storage（v2.5） |
+| Reflector LLM 費用爆 | role-level cost budget hard cap（D1）；local primary 預設 |
+| sleep cycle 把 pattern 改壞 | E1 rollback + E4 bisect 是治理；drift 指標自動 alert |
+| commander outbox 沒人寫 | E5 §8 把 contract 寫死，閉源 commander 倉照規格實作；mur 側 mock server 在 dev tools |
+| **v2 新增：snapshot 與 outbox 衝突** | §9.2.5 順序（push outbox → 重算 canonical → pull snapshot），不可顛倒 |
+| **v2 新增：agent 太多 → snapshot 過載** | filter 強制 `max_count: 200`，超過拒收；daemon limit 並發 snapshot 計算 |
+| **v2 新增：export bundle 含 snapshot 洩密** | 預設 `--include-snapshot` opt-in，文件警告 snapshot 可能含 sensitive pattern |
+
+---
+
+## 13. Sources
+
+- [a16z — Why We Need Continual Learning](https://a16z.com/why-we-need-continual-learning/)
+- [Jiayi Weng — Learning Beyond Gradients](https://trinkle23897.github.io/learning-beyond-gradients/)
+- [Letta — Continual Learning in Token Space](https://www.letta.com/blog/continual-learning)
+- [Letta — Context Repositories](https://www.letta.com/blog/context-repositories)
+- [Letta — Sleep-time Compute](https://www.letta.com/blog/sleep-time-compute)
+- [ACE — Agentic Context Engineering (arXiv 2510.04618)](https://arxiv.org/abs/2510.04618)
+- [Sleep-time Compute (arXiv 2504.13171)](https://arxiv.org/abs/2504.13171)
+- [Evo-Memory (arXiv 2511.20857)](https://arxiv.org/html/2511.20857v1)
+- [MemoryBench (arXiv 2510.17281)](https://arxiv.org/html/2510.17281v4)
+- [SSGM — Governing Evolving Memory](https://arxiv.org/html/2603.11768v1)
+- [Mem0 — State of AI Agent Memory 2026](https://mem0.ai/blog/state-of-ai-agent-memory-2026)
+- [NVIDIA — TTT for LLM Memory](https://developer.nvidia.com/blog/reimagining-llm-memory-using-context-as-training-data-unlocks-models-that-learn-at-test-time/)
+- 內部 spec：`docs/superpowers/specs/2026-04-18-mur-commander-memory-sync-design.md`
+- 內部 spec：`docs/superpowers/specs/2026-04-22-murmur-p0a-agent-runtime-design.md`
+- 內部 plan：`docs/superpowers/plans/2026-05-18-mur-commander-channel1-closure.md`


### PR DESCRIPTION
## Summary

Closes the 2-day E1 versioned-store spike (branch `spike/e1-versioned-store`, tag `spike-e1-final`) and graduates 5 durable artifacts to main.

- **ADR-0001** captures all 4 spike findings (FIN-1/2/3/4) with CI evidence, rules, and consequences for W1-W3 scope.
- **plans/2026-05-18-continual-learning-versioned-evolution.md** is the v2 strategy spec for E1-E6 (continual learning + versioned evolution), with §4 patched per ADR-0001.
- **wire-protocol spec** freezes the commander → mur HTTP contract using existing `mur-common::signal::Signal` v1 (no new envelope type — discovered the schema was already shipped).
- **AgentManifest spec** introduces the K8s-style declarative spec shared by `mur agent apply` and `mur commander apply`.
- **signal.rs freeze annotation** documents the v1 schema as frozen with change-control rules.

## Key spike findings (full text in ADR-0001)

| # | Finding | Spec impact |
|---|---|---|
| **FIN-1** | save hot path must NEVER call `git index.add_all` | §4.2.8 rule 1 |
| **FIN-2** | version derivation must be O(1), never walk git history | §4.2.8 rule 2 |
| **FIN-3** | `history()` 1.94s on 3000-commit repo → cache index mandatory | §4.2.7 + §4.2.8 rule 3 |
| **FIN-4** | `.gitignore` must use bare patterns; tests use `is_path_ignored()` | §4.2.8 rule 4 |

## What stays on the spike branch (NOT in this PR)

- `spike-e1-versioned-store/` throwaway crate — retained on branch `spike/e1-versioned-store` and tag `spike-e1-final` for archeology only.
- `.github/workflows/spike-e1.yml` — spike-only CI matrix.

## Test plan

- [x] No runtime code changes; existing 11 `signal.rs` tests remain green
- [x] `cargo build --workspace` unaffected (spike crate not in main workspace)
- [ ] After merge: W1-W3 implementation starts against v2 spec §4 (FIN-3 cache work now in-scope for W1)

## References

- Spike CI all-green run: spike-e1-final tag
- Spike crate code: \`git checkout spike-e1-final\`
- ADR-0001 supersedes earlier draft `docs/superpowers/specs/2026-04-18-mur-commander-memory-sync-design.md` in the wire-protocol contract area only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)