### PR TITLE
feat(e1): versioned pattern/agent store — W1+W2+W3+bootstrap

### DIFF
--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -32,6 +32,7 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 anyhow = { workspace = true }
 git2 = { version = "0.20", default-features = false }
+diff = "0.1"
 async-trait = "0.1"
 notify = "6"
 oauth2 = { version = "4", features = ["reqwest"] }

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -31,6 +31,7 @@ tracing-subscriber = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 anyhow = { workspace = true }
+git2 = { version = "0.20", default-features = false }
 async-trait = "0.1"
 notify = "6"
 oauth2 = { version = "4", features = ["reqwest"] }

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -112,6 +112,47 @@ pub enum FeedbackAction {
 pub enum PatternAction {
     /// Show a pattern by name (with attachments)
     Show { name: String },
+    /// Show version history for a pattern
+    History {
+        /// Pattern name
+        name: String,
+    },
+    /// Show diff between two pattern versions (defaults: current vs previous)
+    Diff {
+        /// Pattern name
+        name: String,
+        /// First version number (default: previous)
+        v1: Option<u32>,
+        /// Second version number (default: current)
+        v2: Option<u32>,
+    },
+    /// Roll back a pattern to a prior version (creates a new commit)
+    Rollback {
+        /// Pattern name
+        name: String,
+        /// Version number to restore
+        #[arg(long)]
+        to: u32,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum InternalsAction {
+    /// Rebuild the versioned-store history index from git log (recovery only)
+    RebuildIndex {
+        /// Which layer: `knowledge` (patterns/workflows) or `agents`
+        #[arg(long, default_value = "knowledge")]
+        layer: String,
+    },
+    /// Run a raw git subcommand against the knowledge or agents repo
+    Git {
+        /// Which layer: `knowledge` or `agents`
+        #[arg(long, default_value = "knowledge")]
+        layer: String,
+        /// Git arguments (e.g. `log --oneline -10`)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -211,6 +211,19 @@ pub enum AgentAction {
     },
     /// Migrate all agents from mur-agent-gui (v0) to mur-hub (v1). Idempotent.
     MigrateToHub,
+    /// Show version history for an agent's profile (requires versioned store)
+    History {
+        /// Agent name
+        name: String,
+    },
+    /// Roll back an agent profile to a prior version (creates a new commit)
+    Rollback {
+        /// Agent name
+        name: String,
+        /// Version number to restore
+        #[arg(long)]
+        to: u32,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/mur-core/src/cli/mod.rs
+++ b/mur-core/src/cli/mod.rs
@@ -151,7 +151,12 @@ pub enum Commands {
         action: WorkflowAction,
     },
     /// Rebuild index from YAML files
-    Reindex,
+    Reindex {
+        /// Initialise the versioned git store and commit all existing patterns
+        /// in one bootstrap commit. Run once to enable `mur pattern history`.
+        #[arg(long)]
+        bootstrap: bool,
+    },
     /// Show pattern connections
     Links {
         /// Pattern name

--- a/mur-core/src/cli/mod.rs
+++ b/mur-core/src/cli/mod.rs
@@ -409,4 +409,9 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: cmd::source_cmd::SourceCommand,
     },
+    /// Low-level access to versioned-store internals (git repos, index rebuild)
+    Internals {
+        #[command(subcommand)]
+        action: InternalsAction,
+    },
 }

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -143,7 +143,32 @@ pub(crate) fn load_profile_for_edit(name: &str) -> Result<(PathBuf, _AgentProfil
 pub(crate) fn save_profile(path: &Path, profile: &mut _AgentProfile) -> Result<()> {
     profile.updated_at = chrono::Utc::now().to_rfc3339();
     let yaml = serde_yaml_ng::to_string(profile).context("serialize profile.yaml")?;
-    write_atomic(path, yaml.as_bytes())
+    write_atomic(path, yaml.as_bytes())?;
+
+    // Version gate: when the agents git repo is active, commit this change.
+    // Best-effort — a commit failure never fails the primary save.
+    if let Some(agent_dir) = path.parent()
+        && let Some(agents_root) = agent_dir.parent()
+        && let Some(agent_name) = agent_dir.file_name().and_then(|n| n.to_str())
+        && agents_root.join(".git").exists()
+    {
+        match crate::store::versioned::agent::VersionedAgentStore::open(agents_root) {
+            Ok(mut vs) => {
+                if let Err(e) = vs.commit_existing_profile(agent_name, "updated") {
+                    tracing::warn!(
+                        agent = %agent_name,
+                        error = %e,
+                        "versioned agent commit failed"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to open versioned agent store for commit");
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Used by stop/remove/rename to refuse mutation when the supervisor is alive.

--- a/mur-core/src/cmd/agent_history.rs
+++ b/mur-core/src/cmd/agent_history.rs
@@ -1,7 +1,7 @@
 //! `mur agent history/rollback` — versioned agent commands (E1 W3).
 
-use anyhow::{Context, Result};
 use crate::store::versioned::agent::VersionedAgentStore;
+use anyhow::{Context, Result};
 use std::path::Path;
 
 use crate::store::yaml::default_mur_dir;

--- a/mur-core/src/cmd/agent_history.rs
+++ b/mur-core/src/cmd/agent_history.rs
@@ -1,0 +1,71 @@
+//! `mur agent history/rollback` — versioned agent commands (E1 W3).
+
+use anyhow::{Context, Result};
+use crate::store::versioned::agent::VersionedAgentStore;
+use std::path::Path;
+
+use crate::store::yaml::default_mur_dir;
+
+fn agents_dir() -> std::path::PathBuf {
+    default_mur_dir().join("agents")
+}
+
+fn open_or_init(root: &Path) -> Result<VersionedAgentStore> {
+    if root.join(".git").exists() {
+        VersionedAgentStore::open(root)
+            .with_context(|| format!("open versioned agent store at {}", root.display()))
+    } else {
+        VersionedAgentStore::init(root)
+            .with_context(|| format!("init versioned agent store at {}", root.display()))
+    }
+}
+
+// ── history ───────────────────────────────────────────────────────────────────
+
+pub(crate) fn cmd_agent_history(name: &str) -> Result<()> {
+    let root = agents_dir();
+    let store = open_or_init(&root)?;
+
+    let hist = store.history(name)?;
+    if hist.is_empty() {
+        println!("No version history for agent '{name}'.");
+        println!("(History is recorded starting from the first save after versioned store init.)");
+        return Ok(());
+    }
+
+    println!("History for agent '{name}':");
+    println!("{:<5} {:<14} {:<26} reason", "v", "sha", "timestamp");
+    println!("{}", "-".repeat(70));
+    for e in &hist {
+        let ts = chrono::DateTime::from_timestamp(e.timestamp, 0)
+            .map(|dt: chrono::DateTime<chrono::Utc>| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        println!("{:<5} {:<14} {:<26} {}", e.version, e.sha, ts, e.reason);
+    }
+    Ok(())
+}
+
+// ── rollback ──────────────────────────────────────────────────────────────────
+
+pub(crate) fn cmd_agent_rollback(name: &str, to: u32) -> Result<()> {
+    let root = agents_dir();
+    let mut store = open_or_init(&root)?;
+
+    let current_v = store.current_version(name);
+    if current_v == 0 {
+        anyhow::bail!("Agent '{name}' has no version history — cannot rollback.");
+    }
+    if to >= current_v {
+        anyhow::bail!(
+            "Cannot rollback agent '{name}' to v{to}: current version is v{current_v}. \
+             Choose a version less than v{current_v}."
+        );
+    }
+
+    let rev = store.rollback_profile(name, to)?;
+    println!(
+        "Rolled back agent '{name}' profile to v{to} → new commit v{} ({})",
+        rev.version, rev.sha
+    );
+    Ok(())
+}

--- a/mur-core/src/cmd/internals.rs
+++ b/mur-core/src/cmd/internals.rs
@@ -1,0 +1,67 @@
+//! `mur internals rebuild-index / git` — versioned store maintenance (E1 W3).
+
+use anyhow::{Context, Result};
+use crate::store::versioned::{VersionedYamlStore, agent::VersionedAgentStore};
+
+use crate::store::yaml::default_mur_dir;
+
+pub(crate) fn cmd_rebuild_index(layer: &str) -> Result<()> {
+    let mur_dir = default_mur_dir();
+    match layer {
+        "knowledge" => {
+            let root = &mur_dir;
+            let mut store = if root.join(".git").exists() {
+                VersionedYamlStore::open(root)
+                    .with_context(|| "open knowledge versioned store")?
+            } else {
+                VersionedYamlStore::init(root)
+                    .with_context(|| "init knowledge versioned store")?
+            };
+            store.rebuild_index()?;
+            println!("Rebuilt knowledge index at {}", root.display());
+        }
+        "agents" => {
+            let root = mur_dir.join("agents");
+            let mut store = if root.join(".git").exists() {
+                VersionedAgentStore::open(&root)
+                    .with_context(|| "open agents versioned store")?
+            } else {
+                VersionedAgentStore::init(&root)
+                    .with_context(|| "init agents versioned store")?
+            };
+            store.rebuild_index()?;
+            println!("Rebuilt agents index at {}", root.display());
+        }
+        other => anyhow::bail!("Unknown layer '{other}'. Use 'knowledge' or 'agents'."),
+    }
+    Ok(())
+}
+
+pub(crate) fn cmd_internals_git(layer: &str, args: &[String]) -> Result<()> {
+    let mur_dir = default_mur_dir();
+    let repo_dir = match layer {
+        "knowledge" => mur_dir.clone(),
+        "agents" => mur_dir.join("agents"),
+        other => anyhow::bail!("Unknown layer '{other}'. Use 'knowledge' or 'agents'."),
+    };
+
+    if !repo_dir.join(".git").exists() {
+        anyhow::bail!(
+            "Versioned store not initialised at {}. \
+             Run `mur internals rebuild-index --layer {layer}` first.",
+            repo_dir.display()
+        );
+    }
+
+    let status = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo_dir)
+        .args(args)
+        .status()
+        .with_context(|| "failed to run git")?;
+
+    if !status.success() {
+        anyhow::bail!("git exited with status {status}");
+    }
+    Ok(())
+}

--- a/mur-core/src/cmd/internals.rs
+++ b/mur-core/src/cmd/internals.rs
@@ -1,7 +1,7 @@
 //! `mur internals rebuild-index / git` — versioned store maintenance (E1 W3).
 
-use anyhow::{Context, Result};
 use crate::store::versioned::{VersionedYamlStore, agent::VersionedAgentStore};
+use anyhow::{Context, Result};
 
 use crate::store::yaml::default_mur_dir;
 
@@ -11,11 +11,9 @@ pub(crate) fn cmd_rebuild_index(layer: &str) -> Result<()> {
         "knowledge" => {
             let root = &mur_dir;
             let mut store = if root.join(".git").exists() {
-                VersionedYamlStore::open(root)
-                    .with_context(|| "open knowledge versioned store")?
+                VersionedYamlStore::open(root).with_context(|| "open knowledge versioned store")?
             } else {
-                VersionedYamlStore::init(root)
-                    .with_context(|| "init knowledge versioned store")?
+                VersionedYamlStore::init(root).with_context(|| "init knowledge versioned store")?
             };
             store.rebuild_index()?;
             println!("Rebuilt knowledge index at {}", root.display());
@@ -23,11 +21,9 @@ pub(crate) fn cmd_rebuild_index(layer: &str) -> Result<()> {
         "agents" => {
             let root = mur_dir.join("agents");
             let mut store = if root.join(".git").exists() {
-                VersionedAgentStore::open(&root)
-                    .with_context(|| "open agents versioned store")?
+                VersionedAgentStore::open(&root).with_context(|| "open agents versioned store")?
             } else {
-                VersionedAgentStore::init(&root)
-                    .with_context(|| "init agents versioned store")?
+                VersionedAgentStore::init(&root).with_context(|| "init agents versioned store")?
             };
             store.rebuild_index()?;
             println!("Rebuilt agents index at {}", root.display());

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod agent;
+pub(crate) mod agent_history;
 pub mod agent_companion;
 /// B0 M11.4 — eval-harness JSONL → markdown report aggregator.
 pub(crate) mod agent_eval;
@@ -27,11 +28,13 @@ pub(crate) mod init;
 pub(crate) mod init_daemon;
 pub(crate) mod init_local;
 pub(crate) mod inject_cmd;
+pub(crate) mod internals;
 pub(crate) mod learn;
 pub(crate) mod misc;
 pub(crate) mod model;
 pub(crate) mod murmurd;
 pub(crate) mod pattern;
+pub(crate) mod pattern_history;
 pub(crate) mod reindex;
 pub(crate) mod search;
 pub(crate) mod server_cmd;

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -1,10 +1,10 @@
 pub(crate) mod agent;
-pub(crate) mod agent_history;
 pub mod agent_companion;
 /// B0 M11.4 — eval-harness JSONL → markdown report aggregator.
 pub(crate) mod agent_eval;
 pub mod agent_export;
 pub mod agent_export_gui;
+pub(crate) mod agent_history;
 /// A1 — hooks show [--json] CLI verb.
 pub mod agent_hooks;
 /// B0 M9.2 — install-time MCP hash + publisher prompt for `mur agent mcp add`.

--- a/mur-core/src/cmd/pattern_history.rs
+++ b/mur-core/src/cmd/pattern_history.rs
@@ -1,0 +1,123 @@
+//! `mur pattern history/diff/rollback` — versioned pattern commands (E1 W3).
+
+use anyhow::{Context, Result};
+use crate::store::versioned::VersionedYamlStore;
+use std::path::Path;
+
+use crate::store::yaml::default_mur_dir;
+
+// ── history ───────────────────────────────────────────────────────────────────
+
+pub(crate) fn cmd_pattern_history(name: &str) -> Result<()> {
+    let root = default_mur_dir();
+    let store = open_or_init(&root)?;
+
+    let hist = store.history(name)?;
+    if hist.is_empty() {
+        println!("No version history for '{name}'.");
+        println!("(History is recorded starting from the first save after versioned store init.)");
+        return Ok(());
+    }
+
+    println!("History for pattern '{name}':");
+    println!("{:<5} {:<14} {:<26} reason", "v", "sha", "timestamp");
+    println!("{}", "-".repeat(70));
+    for e in &hist {
+        let ts = chrono::DateTime::from_timestamp(e.timestamp, 0)
+            .map(|dt: chrono::DateTime<chrono::Utc>| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+        println!("{:<5} {:<14} {:<26} {}", e.version, e.sha, ts, e.reason);
+    }
+    Ok(())
+}
+
+// ── diff ──────────────────────────────────────────────────────────────────────
+
+pub(crate) fn cmd_pattern_diff(name: &str, v1: Option<u32>, v2: Option<u32>) -> Result<()> {
+    let root = default_mur_dir();
+    let store = open_or_init(&root)?;
+
+    let hist = store.history(name)?;
+    if hist.len() < 2 {
+        println!("Pattern '{name}' has fewer than 2 versions — nothing to diff.");
+        return Ok(());
+    }
+
+    // Resolve default versions: v1 = previous, v2 = current
+    let current_v = store.current_version(name);
+    let v2 = v2.unwrap_or(current_v);
+    let v1 = v1.unwrap_or_else(|| v2.saturating_sub(1).max(1));
+
+    let content_a = read_version(&root, name, v1, current_v)?;
+    let content_b = read_version(&root, name, v2, current_v)?;
+
+    if content_a == content_b {
+        println!("v{v1} and v{v2} are identical.");
+        return Ok(());
+    }
+
+    println!("Diff for pattern '{name}' (v{v1} → v{v2}):");
+    println!("{}", "-".repeat(60));
+    print_diff(&content_a, &content_b);
+    Ok(())
+}
+
+// ── rollback ──────────────────────────────────────────────────────────────────
+
+pub(crate) fn cmd_pattern_rollback(name: &str, to: u32) -> Result<()> {
+    let root = default_mur_dir();
+    let mut store = open_or_init(&root)?;
+
+    let current_v = store.current_version(name);
+    if current_v == 0 {
+        anyhow::bail!("Pattern '{name}' has no version history — cannot rollback.");
+    }
+    if to >= current_v {
+        anyhow::bail!(
+            "Cannot rollback to v{to}: current version is v{current_v}. \
+             Choose a version less than v{current_v}."
+        );
+    }
+
+    let rev = store.rollback_pattern(name, to)?;
+    println!("Rolled back '{name}' to v{to} → new commit v{} ({})", rev.version, rev.sha);
+    Ok(())
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn open_or_init(root: &Path) -> Result<VersionedYamlStore> {
+    if root.join(".git").exists() {
+        VersionedYamlStore::open(root)
+            .with_context(|| format!("open versioned store at {}", root.display()))
+    } else {
+        VersionedYamlStore::init(root)
+            .with_context(|| format!("init versioned store at {}", root.display()))
+    }
+}
+
+/// Return the YAML content for a given version of a pattern.
+/// `current_v` is the live version so we know whether to read from disk or archive.
+fn read_version(root: &Path, name: &str, version: u32, current_v: u32) -> Result<String> {
+    if version == current_v {
+        let path = root.join("patterns").join(format!("{name}.yaml"));
+        return std::fs::read_to_string(&path)
+            .with_context(|| format!("read current pattern file for '{name}'"));
+    }
+    let archive = root
+        .join("archive/patterns")
+        .join(name)
+        .join(format!("v{version}.yaml"));
+    std::fs::read_to_string(&archive)
+        .with_context(|| format!("read archive v{version} for '{name}'"))
+}
+
+fn print_diff(a: &str, b: &str) {
+    for diff in diff::lines(a, b) {
+        match diff {
+            diff::Result::Left(l)  => println!("- {l}"),
+            diff::Result::Right(r) => println!("+ {r}"),
+            diff::Result::Both(l, _) => println!("  {l}"),
+        }
+    }
+}

--- a/mur-core/src/cmd/pattern_history.rs
+++ b/mur-core/src/cmd/pattern_history.rs
@@ -1,7 +1,7 @@
 //! `mur pattern history/diff/rollback` — versioned pattern commands (E1 W3).
 
-use anyhow::{Context, Result};
 use crate::store::versioned::VersionedYamlStore;
+use anyhow::{Context, Result};
 use std::path::Path;
 
 use crate::store::yaml::default_mur_dir;
@@ -80,7 +80,10 @@ pub(crate) fn cmd_pattern_rollback(name: &str, to: u32) -> Result<()> {
     }
 
     let rev = store.rollback_pattern(name, to)?;
-    println!("Rolled back '{name}' to v{to} → new commit v{} ({})", rev.version, rev.sha);
+    println!(
+        "Rolled back '{name}' to v{to} → new commit v{} ({})",
+        rev.version, rev.sha
+    );
     Ok(())
 }
 
@@ -115,7 +118,7 @@ fn read_version(root: &Path, name: &str, version: u32, current_v: u32) -> Result
 fn print_diff(a: &str, b: &str) {
     for diff in diff::lines(a, b) {
         match diff {
-            diff::Result::Left(l)  => println!("- {l}"),
+            diff::Result::Left(l) => println!("- {l}"),
             diff::Result::Right(r) => println!("+ {r}"),
             diff::Result::Both(l, _) => println!("  {l}"),
         }

--- a/mur-core/src/cmd/reindex.rs
+++ b/mur-core/src/cmd/reindex.rs
@@ -109,26 +109,53 @@ pub(crate) async fn cmd_reindex() -> Result<()> {
 /// Initialise the knowledge git repo and commit all existing patterns in one
 /// bootstrap commit. After this, every `YamlStore::save` auto-commits via
 /// the write path gate, and `mur pattern history` returns real history.
+///
+/// Also bootstraps the agents git repo at `~/.mur/agents/.git` if it exists
+/// or if there are agent profiles to track.
 pub(crate) fn cmd_reindex_bootstrap() -> Result<()> {
     use crate::store::versioned::VersionedYamlStore;
+    use crate::store::versioned::agent::VersionedAgentStore;
 
     let mur_dir = default_mur_dir();
-    let already = mur_dir.join(".git").exists();
 
+    // ── Knowledge layer ───────────────────────────────────────────────────────
+    let already = mur_dir.join(".git").exists();
     let mut vs = if already {
-        println!("Versioned store already initialised — committing any un-tracked patterns.");
+        println!("Knowledge store already initialised — committing any un-tracked patterns.");
         VersionedYamlStore::open(&mur_dir)?
     } else {
-        println!("Initialising versioned store at {} ...", mur_dir.display());
+        println!("Initialising knowledge store at {} ...", mur_dir.display());
         VersionedYamlStore::init(&mur_dir)?
     };
 
     let count = vs.bootstrap_all()?;
     if count == 0 {
-        println!("All patterns already up to date in versioned store.");
+        println!("Knowledge: all patterns already up to date.");
     } else {
-        println!("Bootstrap complete: {count} pattern(s) committed.");
-        println!("Future saves are now auto-versioned. Try `mur pattern history <name>`.");
+        println!("Knowledge: {count} pattern(s) committed.");
     }
+
+    // ── Agents layer ──────────────────────────────────────────────────────────
+    let agents_dir = mur_dir.join("agents");
+    if agents_dir.exists() {
+        let agents_already = agents_dir.join(".git").exists();
+        let mut avs = if agents_already {
+            println!("Agents store already initialised — committing any un-tracked profiles.");
+            VersionedAgentStore::open(&agents_dir)?
+        } else {
+            println!("Initialising agents store at {} ...", agents_dir.display());
+            VersionedAgentStore::init(&agents_dir)?
+        };
+
+        let agent_count = avs.bootstrap_all()?;
+        if agent_count == 0 {
+            println!("Agents: all profiles already up to date.");
+        } else {
+            println!("Agents: {agent_count} agent profile(s) committed.");
+        }
+    }
+
+    println!("Future saves are now auto-versioned.");
+    println!("Try `mur pattern history <name>` or `mur agent history <name>`.");
     Ok(())
 }

--- a/mur-core/src/cmd/reindex.rs
+++ b/mur-core/src/cmd/reindex.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use crate::store::workflow_yaml::WorkflowYamlStore;
-use crate::store::yaml::YamlStore;
+use crate::store::yaml::{YamlStore, default_mur_dir};
 
 pub(crate) async fn cmd_reindex() -> Result<()> {
     use crate::store::embedding::{EmbeddingConfig, embed};
@@ -103,5 +103,32 @@ pub(crate) async fn cmd_reindex() -> Result<()> {
         index_path.display()
     );
 
+    Ok(())
+}
+
+/// Initialise the knowledge git repo and commit all existing patterns in one
+/// bootstrap commit. After this, every `YamlStore::save` auto-commits via
+/// the write path gate, and `mur pattern history` returns real history.
+pub(crate) fn cmd_reindex_bootstrap() -> Result<()> {
+    use crate::store::versioned::VersionedYamlStore;
+
+    let mur_dir = default_mur_dir();
+    let already = mur_dir.join(".git").exists();
+
+    let mut vs = if already {
+        println!("Versioned store already initialised — committing any un-tracked patterns.");
+        VersionedYamlStore::open(&mur_dir)?
+    } else {
+        println!("Initialising versioned store at {} ...", mur_dir.display());
+        VersionedYamlStore::init(&mur_dir)?
+    };
+
+    let count = vs.bootstrap_all()?;
+    if count == 0 {
+        println!("All patterns already up to date in versioned store.");
+    } else {
+        println!("Bootstrap complete: {count} pattern(s) committed.");
+        println!("Future saves are now auto-versioned. Try `mur pattern history <name>`.");
+    }
     Ok(())
 }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -443,9 +443,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         #[cfg(feature = "sources")]
         Commands::Source { cmd } => crate::cmd::source_cmd::handle(cmd).await?,
         Commands::Internals { action } => match action {
-            InternalsAction::RebuildIndex { layer } => {
-                cmd::internals::cmd_rebuild_index(&layer)?
-            }
+            InternalsAction::RebuildIndex { layer } => cmd::internals::cmd_rebuild_index(&layer)?,
             InternalsAction::Git { layer, args } => {
                 cmd::internals::cmd_internals_git(&layer, &args)?
             }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -11,8 +11,8 @@ use crate::cli::{
     AgentPromptAction, AgentScheduleAction, AgentSecretAction, AgentSkillAction,
     AgentWebhookAction, ChatAction, Cli, Commands, CommunityAction, ConversationsAction,
     DeployAction, DraftsAction, EvolveAction, ExchangeAction, FeedbackAction, GepAction, HookEvent,
-    LearnAction, MurmurdAction, PackAction, PatternAction, ScheduleAction, SessionAction,
-    SyncAction, TeamAction, VoiceAction, WorkflowAction,
+    InternalsAction, LearnAction, MurmurdAction, PackAction, PatternAction, ScheduleAction,
+    SessionAction, SyncAction, TeamAction, VoiceAction, WorkflowAction,
 };
 use crate::{cmd, dashboard, verify};
 
@@ -101,6 +101,13 @@ pub async fn run(cli: Cli) -> Result<()> {
         } => cmd::workflow::cmd_workflow_run(&query, fail_fast, prompt).await?,
         Commands::Pattern { action } => match action {
             PatternAction::Show { name } => cmd::pattern::cmd_pattern_show(&name)?,
+            PatternAction::History { name } => cmd::pattern_history::cmd_pattern_history(&name)?,
+            PatternAction::Diff { name, v1, v2 } => {
+                cmd::pattern_history::cmd_pattern_diff(&name, v1, v2)?
+            }
+            PatternAction::Rollback { name, to } => {
+                cmd::pattern_history::cmd_pattern_rollback(&name, to)?
+            }
         },
         Commands::Workflow { action } => match action {
             WorkflowAction::List => cmd::workflow::cmd_workflow_list()?,
@@ -429,6 +436,14 @@ pub async fn run(cli: Cli) -> Result<()> {
         }
         #[cfg(feature = "sources")]
         Commands::Source { cmd } => crate::cmd::source_cmd::handle(cmd).await?,
+        Commands::Internals { action } => match action {
+            InternalsAction::RebuildIndex { layer } => {
+                cmd::internals::cmd_rebuild_index(&layer)?
+            }
+            InternalsAction::Git { layer, args } => {
+                cmd::internals::cmd_internals_git(&layer, &args)?
+            }
+        },
     }
 
     Ok(())
@@ -677,6 +692,8 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             AgentHooksAction::Show { name, json } => cmd::agent_hooks::cmd_hooks_show(&name, json)?,
         },
         AgentAction::MigrateToHub => cmd::agent::cmd_migrate_to_hub()?,
+        AgentAction::History { name } => cmd::agent_history::cmd_agent_history(&name)?,
+        AgentAction::Rollback { name, to } => cmd::agent_history::cmd_agent_rollback(&name, to)?,
     }
     Ok(())
 }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -134,7 +134,13 @@ pub async fn run(cli: Cli) -> Result<()> {
                 cmd::workflow::cmd_workflow_install(&name, &from)?
             }
         },
-        Commands::Reindex => cmd::reindex::cmd_reindex().await?,
+        Commands::Reindex { bootstrap } => {
+            if bootstrap {
+                cmd::reindex::cmd_reindex_bootstrap()?;
+            } else {
+                cmd::reindex::cmd_reindex().await?;
+            }
+        }
         Commands::Promote { name, tier } => cmd::pattern::cmd_promote(&name, &tier)?,
         Commands::Deprecate { name } => cmd::pattern::cmd_deprecate(&name)?,
         Commands::Links { name } => cmd::pattern::cmd_links(&name)?,

--- a/mur-core/src/store/mod.rs
+++ b/mur-core/src/store/mod.rs
@@ -8,5 +8,6 @@ pub mod exchange;
 pub mod pipeline_yaml;
 pub mod spot_rate;
 pub mod vector;
+pub mod versioned;
 pub mod workflow_yaml;
 pub mod yaml;

--- a/mur-core/src/store/versioned/agent.rs
+++ b/mur-core/src/store/versioned/agent.rs
@@ -1,0 +1,327 @@
+//! `VersionedAgentStore` — git-backed execution-layer store (E1 W2).
+// Not yet wired into the CLI — remove when integrated (E1-W3).
+#![allow(dead_code)]
+//!
+//! Manages `~/.mur/agents/.git` (execution layer). Profile + skills
+//! for every agent are versioned here, independently from the knowledge
+//! layer in `~/.mur/.git`.
+//!
+//! ADR-0001 compliance: same FIN-1/2/3/4 rules as VersionedYamlStore.
+
+use anyhow::{Context, Result, anyhow};
+use git2::Repository;
+use std::path::{Path, PathBuf};
+
+use super::agent_index::AgentVersionIndex;
+use super::git_ops;
+
+const AGENTS_GITIGNORE: &str = include_str!("agents.gitignore");
+
+pub struct VersionedAgentStore {
+    /// `~/.mur/agents/`
+    root: PathBuf,
+    agents_repo: Repository,
+    index: AgentVersionIndex,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentRevision {
+    pub name: String,
+    pub version: u32,
+    /// 12-char short SHA of the agents-repo commit for this version.
+    pub sha: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentHistoryEntry {
+    pub version: u32,
+    pub sha: String,
+    pub timestamp: i64,
+    pub reason: String,
+}
+
+/// Outcome of [`VersionedAgentStore::repair`].
+#[derive(Debug, Clone, Default)]
+pub struct RepairReport {
+    pub recovered: bool,
+    pub agents_recommitted: usize,
+}
+
+impl VersionedAgentStore {
+    /// Initialise (or re-open) the agents store. Creates `.git` on first call.
+    pub fn init(root: &Path) -> Result<Self> {
+        std::fs::create_dir_all(root)
+            .with_context(|| format!("mkdir agents dir {}", root.display()))?;
+        let agents_repo =
+            git_ops::open_or_init_repo(root, AGENTS_GITIGNORE, "init: agents layer")?;
+        let index = AgentVersionIndex::load(root)?;
+        Ok(Self { root: root.to_path_buf(), agents_repo, index })
+    }
+
+    /// Open an existing store. Returns an error if `.git` is absent.
+    pub fn open(root: &Path) -> Result<Self> {
+        let agents_repo = Repository::open(root)
+            .with_context(|| format!("open agents repo at {}", root.display()))?;
+        let index = AgentVersionIndex::load(root)?;
+        Ok(Self { root: root.to_path_buf(), agents_repo, index })
+    }
+
+    /// Re-init agents repo when `.git` is missing or broken (split-brain
+    /// recovery). Existing agent dirs are preserved and committed in one
+    /// "repair" commit. Static fn because `open` would fail at this point.
+    pub fn repair(root: &Path) -> Result<RepairReport> {
+        std::fs::create_dir_all(root)?;
+        let git_dir = root.join(".git");
+        let openable = git_dir.exists() && Repository::open(root).is_ok();
+        if openable {
+            return Ok(RepairReport::default());
+        }
+
+        if git_dir.exists() {
+            std::fs::remove_dir_all(&git_dir)
+                .with_context(|| format!("remove broken {}", git_dir.display()))?;
+        }
+
+        let repo = Repository::init(root)?;
+        let gi_path = root.join(".gitignore");
+        if !gi_path.exists() {
+            std::fs::write(&gi_path, AGENTS_GITIGNORE)?;
+        }
+
+        let agents_recommitted = count_agent_dirs(root);
+        let sig = git_ops::signature()?;
+        let mut index = repo.index()?;
+        index.add_path(Path::new(".gitignore"))?;
+        // Recovery path only — add_all is allowed here (FIN-1 exception)
+        index.add_all(["."], git2::IndexAddOption::DEFAULT, None)?;
+        index.write()?;
+        {
+            let tree_id = index.write_tree()?;
+            let tree = repo.find_tree(tree_id)?;
+            repo.commit(
+                Some("HEAD"),
+                &sig,
+                &sig,
+                "repair: recover from missing/broken agents/.git",
+                &tree,
+                &[],
+            )?;
+        }
+
+        Ok(RepairReport { recovered: true, agents_recommitted })
+    }
+
+    /// Write `profile_yaml` to `<agent>/profile.yaml` and commit.
+    ///
+    /// No-op fast path: returns current revision if content is unchanged.
+    pub fn save_profile(
+        &mut self,
+        agent: &str,
+        profile_yaml: &str,
+        reason: &str,
+    ) -> Result<AgentRevision> {
+        let profile_rel = PathBuf::from(agent).join("profile.yaml");
+        let profile_abs = self.root.join(&profile_rel);
+
+        // No-op fast path
+        if profile_abs.exists() {
+            let existing = std::fs::read_to_string(&profile_abs)?;
+            if existing == profile_yaml {
+                return Ok(AgentRevision {
+                    name: agent.to_string(),
+                    version: self.index.current_version_of(agent),
+                    sha: git_ops::head_sha(&self.agents_repo)?,
+                });
+            }
+        }
+
+        let mut paths_to_stage = vec![profile_rel.clone()];
+
+        // Archive previous version (O(1) via index — FIN-2)
+        let prev_v = self.index.current_version_of(agent);
+        if prev_v > 0 && profile_abs.exists() {
+            let archive_dir = self.root.join(agent).join("archive");
+            std::fs::create_dir_all(&archive_dir)?;
+            let archive_rel =
+                PathBuf::from(agent).join("archive").join(format!("v{prev_v}.yaml"));
+            std::fs::copy(&profile_abs, self.root.join(&archive_rel))?;
+            paths_to_stage.push(archive_rel);
+        }
+
+        std::fs::create_dir_all(profile_abs.parent().unwrap())?;
+        // Atomic write
+        let tmp = profile_abs.with_extension("yaml.tmp");
+        std::fs::write(&tmp, profile_yaml)?;
+        std::fs::rename(&tmp, &profile_abs)?;
+
+        let new_v = prev_v + 1;
+        let ts = chrono::Utc::now().to_rfc3339();
+        let msg = format!("profile({agent}): v{new_v} {reason}");
+        let sha = git_ops::commit_paths(&self.agents_repo, &paths_to_stage, &msg)?;
+
+        let head = git_ops::head_sha(&self.agents_repo)?;
+        self.index.append_version(agent, &sha, reason, &head, &ts);
+        self.index.save(&self.root)?;
+
+        Ok(AgentRevision { name: agent.to_string(), version: new_v, sha })
+    }
+
+    pub fn read_profile(&self, agent: &str) -> Result<Option<String>> {
+        let path = self.root.join(agent).join("profile.yaml");
+        if !path.exists() {
+            return Ok(None);
+        }
+        Ok(Some(std::fs::read_to_string(path)?))
+    }
+
+    /// Write a skill file to `<agent>/skills/<skill>.md` and commit.
+    pub fn save_skill(
+        &mut self,
+        agent: &str,
+        skill: &str,
+        content: &str,
+        reason: &str,
+    ) -> Result<AgentRevision> {
+        let skills_dir = self.root.join(agent).join("skills");
+        std::fs::create_dir_all(&skills_dir)?;
+        let skill_rel = PathBuf::from(agent).join("skills").join(format!("{skill}.md"));
+        let skill_abs = self.root.join(&skill_rel);
+
+        // No-op fast path
+        if skill_abs.exists() && std::fs::read_to_string(&skill_abs)? == content {
+            return Ok(AgentRevision {
+                name: agent.to_string(),
+                version: self.index.current_version_of(agent),
+                sha: git_ops::head_sha(&self.agents_repo)?,
+            });
+        }
+
+        let tmp = skill_abs.with_extension("md.tmp");
+        std::fs::write(&tmp, content)?;
+        std::fs::rename(&tmp, &skill_abs)?;
+
+        let new_v = self.index.current_version_of(agent) + 1;
+        let ts = chrono::Utc::now().to_rfc3339();
+        let msg = format!("profile({agent}): v{new_v} {reason}");
+        let sha = git_ops::commit_paths(&self.agents_repo, &[skill_rel], &msg)?;
+
+        let head = git_ops::head_sha(&self.agents_repo)?;
+        self.index.append_version(agent, &sha, reason, &head, &ts);
+        self.index.save(&self.root)?;
+
+        Ok(AgentRevision { name: agent.to_string(), version: new_v, sha })
+    }
+
+    pub fn read_skill(&self, agent: &str, skill: &str) -> Result<Option<String>> {
+        let path = self.root.join(agent).join("skills").join(format!("{skill}.md"));
+        if !path.exists() {
+            return Ok(None);
+        }
+        Ok(Some(std::fs::read_to_string(path)?))
+    }
+
+    /// History from the index (FIN-3 — O(K) where K = revisions of this agent).
+    pub fn history(&self, agent: &str) -> Result<Vec<AgentHistoryEntry>> {
+        let ai = match self.index.agents.get(agent) {
+            Some(a) => a,
+            None => return Ok(vec![]),
+        };
+        Ok(ai
+            .versions
+            .iter()
+            .map(|e| AgentHistoryEntry {
+                version: e.v,
+                sha: e.sha.clone(),
+                timestamp: chrono::DateTime::parse_from_rfc3339(&e.ts)
+                    .map(|dt| dt.timestamp())
+                    .unwrap_or(0),
+                reason: e.reason.clone(),
+            })
+            .collect())
+    }
+
+    pub fn current_version(&self, agent: &str) -> u32 {
+        self.index.current_version_of(agent)
+    }
+
+    /// Roll back agent profile to `to_version` as a new commit.
+    pub fn rollback_profile(&mut self, agent: &str, to_version: u32) -> Result<AgentRevision> {
+        let archive = self
+            .root
+            .join(agent)
+            .join("archive")
+            .join(format!("v{to_version}.yaml"));
+        if !archive.exists() {
+            return Err(anyhow!("no archived v{to_version} for agent '{agent}'"));
+        }
+        let content = std::fs::read_to_string(&archive)?;
+        self.save_profile(agent, &content, &format!("rollback to v{to_version}"))
+    }
+
+    /// Export a single agent's git history as a portable bundle file.
+    ///
+    /// Uses `git subtree split --prefix=<agent>` to produce a branch
+    /// containing only commits that touched that agent's directory, then
+    /// bundles it with `git bundle create`.
+    ///
+    /// Requires git ≥ 2.37 with `subtree` contrib command available.
+    pub fn export_history(&self, agent: &str, bundle_path: &Path) -> Result<()> {
+        let root = &self.root;
+        let branch = format!("export-{agent}");
+
+        // 1. subtree split — isolate agent's history into a temp branch
+        let status = std::process::Command::new("git")
+            .args(["-C", root.to_str().unwrap(), "subtree", "split",
+                   "--prefix", agent, "-b", &branch])
+            .status()
+            .with_context(|| "git subtree split failed — is git-subtree installed?")?;
+        if !status.success() {
+            return Err(anyhow!("git subtree split returned non-zero for agent '{agent}'"));
+        }
+
+        // 2. bundle the split branch
+        let bundle_str = bundle_path.to_str().unwrap();
+        let status = std::process::Command::new("git")
+            .args(["-C", root.to_str().unwrap(), "bundle", "create",
+                   bundle_str, &branch])
+            .status()
+            .with_context(|| "git bundle create failed")?;
+        if !status.success() {
+            return Err(anyhow!("git bundle create returned non-zero"));
+        }
+
+        // 3. clean up temp branch
+        let _ = std::process::Command::new("git")
+            .args(["-C", root.to_str().unwrap(), "branch", "-D", &branch])
+            .status();
+
+        Ok(())
+    }
+
+    /// Returns `true` if on-disk HEAD differs from the index — external git surgery.
+    pub fn detect_external_change(&self) -> Result<bool> {
+        let head = git_ops::head_sha(&self.agents_repo)?;
+        Ok(!head.is_empty() && self.index.agents_head != head)
+    }
+
+    /// Rebuild index from git commit messages. O(total commits) — recovery only.
+    pub fn rebuild_index(&mut self) -> Result<()> {
+        self.index = AgentVersionIndex::rebuild_from_git(&self.agents_repo)?;
+        self.index.save(&self.root)?;
+        Ok(())
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+}
+
+fn count_agent_dirs(agents_dir: &Path) -> usize {
+    std::fs::read_dir(agents_dir)
+        .map(|rd| {
+            rd.flatten()
+                .filter(|e| e.path().is_dir() && !e.file_name().to_string_lossy().starts_with('.'))
+                .count()
+        })
+        .unwrap_or(0)
+}

--- a/mur-core/src/store/versioned/agent.rs
+++ b/mur-core/src/store/versioned/agent.rs
@@ -406,6 +406,73 @@ impl VersionedAgentStore {
         })
     }
 
+    /// Commit all existing `profile.yaml` files that are not yet in HEAD.
+    /// Returns the number of agents bootstrapped.
+    pub fn bootstrap_all(&mut self) -> Result<usize> {
+        let head_tree = self
+            .agents_repo
+            .head()
+            .ok()
+            .and_then(|r| r.peel_to_tree().ok());
+
+        let mut paths: Vec<PathBuf> = vec![];
+
+        for entry in std::fs::read_dir(&self.root)? {
+            let entry = entry?;
+            if !entry.path().is_dir() {
+                continue;
+            }
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.starts_with('.') {
+                continue;
+            }
+            let profile_rel = PathBuf::from(name_str.as_ref()).join("profile.yaml");
+            let profile_abs = self.root.join(&profile_rel);
+            if !profile_abs.exists() {
+                continue;
+            }
+            // Skip if already committed with identical content.
+            if let Some(tree) = &head_tree
+                && let Ok(te) = tree.get_path(&profile_rel)
+                && let Ok(blob) = self.agents_repo.find_blob(te.id())
+            {
+                let on_disk = std::fs::read(&profile_abs).unwrap_or_default();
+                if blob.content() == on_disk.as_slice() {
+                    continue;
+                }
+            }
+            paths.push(profile_rel);
+        }
+
+        if paths.is_empty() {
+            return Ok(0);
+        }
+
+        let count = paths.len();
+        let ts = chrono::Utc::now().to_rfc3339();
+        let msg = "bootstrap: import existing agent profiles";
+        let sha = git_ops::commit_paths(&self.agents_repo, &paths, msg)?;
+        let head = git_ops::head_sha(&self.agents_repo)?;
+
+        for path_rel in &paths {
+            // path_rel = "<agent>/profile.yaml" — take the first component
+            if let Some(agent) = path_rel.components().next().and_then(|c| {
+                if let std::path::Component::Normal(n) = c {
+                    n.to_str()
+                } else {
+                    None
+                }
+            }) {
+                self.index
+                    .append_version(agent, &sha, "bootstrap: import existing", &head, &ts);
+            }
+        }
+        self.index.save(&self.root)?;
+
+        Ok(count)
+    }
+
     fn read_head_blob_str(&self, rel: &Path) -> Result<String> {
         let tree = self.agents_repo.head()?.peel_to_tree()?;
         let entry = tree

--- a/mur-core/src/store/versioned/agent.rs
+++ b/mur-core/src/store/versioned/agent.rs
@@ -52,10 +52,13 @@ impl VersionedAgentStore {
     pub fn init(root: &Path) -> Result<Self> {
         std::fs::create_dir_all(root)
             .with_context(|| format!("mkdir agents dir {}", root.display()))?;
-        let agents_repo =
-            git_ops::open_or_init_repo(root, AGENTS_GITIGNORE, "init: agents layer")?;
+        let agents_repo = git_ops::open_or_init_repo(root, AGENTS_GITIGNORE, "init: agents layer")?;
         let index = AgentVersionIndex::load(root)?;
-        Ok(Self { root: root.to_path_buf(), agents_repo, index })
+        Ok(Self {
+            root: root.to_path_buf(),
+            agents_repo,
+            index,
+        })
     }
 
     /// Open an existing store. Returns an error if `.git` is absent.
@@ -63,7 +66,11 @@ impl VersionedAgentStore {
         let agents_repo = Repository::open(root)
             .with_context(|| format!("open agents repo at {}", root.display()))?;
         let index = AgentVersionIndex::load(root)?;
-        Ok(Self { root: root.to_path_buf(), agents_repo, index })
+        Ok(Self {
+            root: root.to_path_buf(),
+            agents_repo,
+            index,
+        })
     }
 
     /// Re-init agents repo when `.git` is missing or broken (split-brain
@@ -108,7 +115,10 @@ impl VersionedAgentStore {
             )?;
         }
 
-        Ok(RepairReport { recovered: true, agents_recommitted })
+        Ok(RepairReport {
+            recovered: true,
+            agents_recommitted,
+        })
     }
 
     /// Write `profile_yaml` to `<agent>/profile.yaml` and commit.
@@ -142,8 +152,9 @@ impl VersionedAgentStore {
         if prev_v > 0 && profile_abs.exists() {
             let archive_dir = self.root.join(agent).join("archive");
             std::fs::create_dir_all(&archive_dir)?;
-            let archive_rel =
-                PathBuf::from(agent).join("archive").join(format!("v{prev_v}.yaml"));
+            let archive_rel = PathBuf::from(agent)
+                .join("archive")
+                .join(format!("v{prev_v}.yaml"));
             std::fs::copy(&profile_abs, self.root.join(&archive_rel))?;
             paths_to_stage.push(archive_rel);
         }
@@ -163,7 +174,11 @@ impl VersionedAgentStore {
         self.index.append_version(agent, &sha, reason, &head, &ts);
         self.index.save(&self.root)?;
 
-        Ok(AgentRevision { name: agent.to_string(), version: new_v, sha })
+        Ok(AgentRevision {
+            name: agent.to_string(),
+            version: new_v,
+            sha,
+        })
     }
 
     pub fn read_profile(&self, agent: &str) -> Result<Option<String>> {
@@ -184,7 +199,9 @@ impl VersionedAgentStore {
     ) -> Result<AgentRevision> {
         let skills_dir = self.root.join(agent).join("skills");
         std::fs::create_dir_all(&skills_dir)?;
-        let skill_rel = PathBuf::from(agent).join("skills").join(format!("{skill}.md"));
+        let skill_rel = PathBuf::from(agent)
+            .join("skills")
+            .join(format!("{skill}.md"));
         let skill_abs = self.root.join(&skill_rel);
 
         // No-op fast path
@@ -209,11 +226,19 @@ impl VersionedAgentStore {
         self.index.append_version(agent, &sha, reason, &head, &ts);
         self.index.save(&self.root)?;
 
-        Ok(AgentRevision { name: agent.to_string(), version: new_v, sha })
+        Ok(AgentRevision {
+            name: agent.to_string(),
+            version: new_v,
+            sha,
+        })
     }
 
     pub fn read_skill(&self, agent: &str, skill: &str) -> Result<Option<String>> {
-        let path = self.root.join(agent).join("skills").join(format!("{skill}.md"));
+        let path = self
+            .root
+            .join(agent)
+            .join("skills")
+            .join(format!("{skill}.md"));
         if !path.exists() {
             return Ok(None);
         }
@@ -271,19 +296,35 @@ impl VersionedAgentStore {
 
         // 1. subtree split — isolate agent's history into a temp branch
         let status = std::process::Command::new("git")
-            .args(["-C", root.to_str().unwrap(), "subtree", "split",
-                   "--prefix", agent, "-b", &branch])
+            .args([
+                "-C",
+                root.to_str().unwrap(),
+                "subtree",
+                "split",
+                "--prefix",
+                agent,
+                "-b",
+                &branch,
+            ])
             .status()
             .with_context(|| "git subtree split failed — is git-subtree installed?")?;
         if !status.success() {
-            return Err(anyhow!("git subtree split returned non-zero for agent '{agent}'"));
+            return Err(anyhow!(
+                "git subtree split returned non-zero for agent '{agent}'"
+            ));
         }
 
         // 2. bundle the split branch
         let bundle_str = bundle_path.to_str().unwrap();
         let status = std::process::Command::new("git")
-            .args(["-C", root.to_str().unwrap(), "bundle", "create",
-                   bundle_str, &branch])
+            .args([
+                "-C",
+                root.to_str().unwrap(),
+                "bundle",
+                "create",
+                bundle_str,
+                &branch,
+            ])
             .status()
             .with_context(|| "git bundle create failed")?;
         if !status.success() {

--- a/mur-core/src/store/versioned/agent.rs
+++ b/mur-core/src/store/versioned/agent.rs
@@ -1,5 +1,5 @@
 //! `VersionedAgentStore` — git-backed execution-layer store (E1 W2).
-// Not yet wired into the CLI — remove when integrated (E1-W3).
+// Methods not yet fully wired to CLI commands — remove when integrated.
 #![allow(dead_code)]
 //!
 //! Manages `~/.mur/agents/.git` (execution layer). Profile + skills
@@ -354,6 +354,65 @@ impl VersionedAgentStore {
 
     pub fn root(&self) -> &Path {
         &self.root
+    }
+
+    /// Commit an already-written `profile.yaml` for `agent` into the agents
+    /// repo. Mirrors `VersionedYamlStore::commit_existing_pattern` — the
+    /// primary write has already happened; this gate records the version.
+    pub fn commit_existing_profile(&mut self, agent: &str, reason: &str) -> Result<AgentRevision> {
+        let profile_rel = PathBuf::from(agent).join("profile.yaml");
+        let profile_abs = self.root.join(&profile_rel);
+
+        let new_yaml = std::fs::read_to_string(&profile_abs)
+            .with_context(|| format!("read {}", profile_abs.display()))?;
+
+        // No-op: file on disk matches HEAD blob → nothing to commit.
+        let head_yaml = self.read_head_blob_str(&profile_rel).unwrap_or_default();
+        if head_yaml == new_yaml {
+            return Ok(AgentRevision {
+                name: agent.to_string(),
+                version: self.index.current_version_of(agent),
+                sha: git_ops::head_sha(&self.agents_repo)?,
+            });
+        }
+
+        let mut paths_to_stage = vec![profile_rel.clone()];
+
+        // Archive the HEAD blob (previous version) before committing new content.
+        let prev_v = self.index.current_version_of(agent);
+        if prev_v > 0 && !head_yaml.is_empty() {
+            let archive_dir = self.root.join(agent).join("archive");
+            std::fs::create_dir_all(&archive_dir)?;
+            let archive_rel = PathBuf::from(agent)
+                .join("archive")
+                .join(format!("v{prev_v}.yaml"));
+            std::fs::write(self.root.join(&archive_rel), &head_yaml)?;
+            paths_to_stage.push(archive_rel);
+        }
+
+        let new_v = prev_v + 1;
+        let ts = chrono::Utc::now().to_rfc3339();
+        let msg = format!("profile({agent}): v{new_v} {reason}");
+        let sha = git_ops::commit_paths(&self.agents_repo, &paths_to_stage, &msg)?;
+
+        let head = git_ops::head_sha(&self.agents_repo)?;
+        self.index.append_version(agent, &sha, reason, &head, &ts);
+        self.index.save(&self.root)?;
+
+        Ok(AgentRevision {
+            name: agent.to_string(),
+            version: new_v,
+            sha,
+        })
+    }
+
+    fn read_head_blob_str(&self, rel: &Path) -> Result<String> {
+        let tree = self.agents_repo.head()?.peel_to_tree()?;
+        let entry = tree
+            .get_path(rel)
+            .with_context(|| format!("path {} not in HEAD", rel.display()))?;
+        let blob = self.agents_repo.find_blob(entry.id())?;
+        Ok(String::from_utf8_lossy(blob.content()).into_owned())
     }
 }
 

--- a/mur-core/src/store/versioned/agent_index.rs
+++ b/mur-core/src/store/versioned/agent_index.rs
@@ -110,20 +110,17 @@ impl AgentVersionIndex {
         for oid_result in walker {
             let oid = oid_result?;
             let commit = repo.find_commit(oid)?;
-            let msg = commit
-                .message()
-                .unwrap_or("")
-                .lines()
-                .next()
-                .unwrap_or("");
+            let msg = commit.message().unwrap_or("").lines().next().unwrap_or("");
             if let Some((name, v, reason)) = parse_profile_commit(msg) {
                 let ts = chrono::DateTime::from_timestamp(commit.time().seconds(), 0)
                     .map(|dt: chrono::DateTime<chrono::Utc>| dt.to_rfc3339())
                     .unwrap_or_default();
-                per_agent
-                    .entry(name)
-                    .or_default()
-                    .push(VersionEntry { v, sha: git_ops::short_sha(&oid), ts, reason });
+                per_agent.entry(name).or_default().push(VersionEntry {
+                    v,
+                    sha: git_ops::short_sha(&oid),
+                    ts,
+                    reason,
+                });
             }
         }
 
@@ -136,7 +133,13 @@ impl AgentVersionIndex {
         for (name, mut entries) in per_agent {
             entries.sort_by_key(|e| e.v);
             let current_version = entries.last().map_or(0, |e| e.v);
-            idx.agents.insert(name, AgentIndex { versions: entries, current_version });
+            idx.agents.insert(
+                name,
+                AgentIndex {
+                    versions: entries,
+                    current_version,
+                },
+            );
         }
 
         Ok(idx)

--- a/mur-core/src/store/versioned/agent_index.rs
+++ b/mur-core/src/store/versioned/agent_index.rs
@@ -1,0 +1,173 @@
+//! `.mur-agents-versions.yaml` — load-bearing per-agent history index.
+// Not yet wired into the CLI — remove when integrated (E1-W3).
+#![allow(dead_code)]
+//!
+//! Mirrors `index.rs` for the execution layer (`~/.mur/agents/.git`).
+//! Same FIN-3 invariant: `history()` reads here, never from live git walk.
+
+use anyhow::Result;
+use git2::Repository;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use super::git_ops;
+
+pub const SCHEMA_VERSION: u32 = 3;
+pub const INDEX_FILE: &str = ".mur-agents-versions.yaml";
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct AgentVersionIndex {
+    pub schema_version: u32,
+    /// Full SHA of the agents repo HEAD at last index write.
+    pub agents_head: String,
+    #[serde(default)]
+    pub agents: BTreeMap<String, AgentIndex>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct AgentIndex {
+    pub versions: Vec<VersionEntry>,
+    pub current_version: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct VersionEntry {
+    pub v: u32,
+    pub sha: String,
+    pub ts: String,
+    pub reason: String,
+}
+
+impl AgentVersionIndex {
+    pub fn load(agents_dir: &Path) -> Result<Self> {
+        let path = agents_dir.join(INDEX_FILE);
+        if !path.exists() {
+            return Ok(Self {
+                schema_version: SCHEMA_VERSION,
+                ..Default::default()
+            });
+        }
+        let content = std::fs::read_to_string(&path)?;
+        let mut idx: Self = serde_yaml::from_str(&content)?;
+        idx.schema_version = SCHEMA_VERSION;
+        Ok(idx)
+    }
+
+    /// Atomic save (temp → rename).
+    pub fn save(&self, agents_dir: &Path) -> Result<()> {
+        let tmp = agents_dir.join(".mur-agents-versions.yaml.tmp");
+        let dest = agents_dir.join(INDEX_FILE);
+        let yaml = serde_yaml::to_string(self)?;
+        std::fs::write(&tmp, yaml)?;
+        std::fs::rename(&tmp, dest)?;
+        Ok(())
+    }
+
+    /// O(1) append. Returns new version number.
+    pub fn append_version(
+        &mut self,
+        agent: &str,
+        sha: &str,
+        reason: &str,
+        head: &str,
+        ts: &str,
+    ) -> u32 {
+        self.agents_head = head.to_string();
+        let entry = self.agents.entry(agent.to_string()).or_default();
+        let v = entry.current_version + 1;
+        entry.versions.push(VersionEntry {
+            v,
+            sha: sha.to_string(),
+            ts: ts.to_string(),
+            reason: reason.to_string(),
+        });
+        entry.current_version = v;
+        v
+    }
+
+    pub fn current_version_of(&self, agent: &str) -> u32 {
+        self.agents.get(agent).map_or(0, |a| a.current_version)
+    }
+
+    /// Rebuild from git commit messages. O(total commits) — recovery only.
+    ///
+    /// Commit message format: `"profile(<name>): v<N> <reason>"`
+    pub fn rebuild_from_git(repo: &Repository) -> Result<Self> {
+        let head = git_ops::head_sha(repo)?;
+        if head.is_empty() {
+            return Ok(Self {
+                schema_version: SCHEMA_VERSION,
+                agents_head: head,
+                ..Default::default()
+            });
+        }
+
+        let mut per_agent: BTreeMap<String, Vec<VersionEntry>> = BTreeMap::new();
+        let mut walker = repo.revwalk()?;
+        walker.push_head()?;
+
+        for oid_result in walker {
+            let oid = oid_result?;
+            let commit = repo.find_commit(oid)?;
+            let msg = commit
+                .message()
+                .unwrap_or("")
+                .lines()
+                .next()
+                .unwrap_or("");
+            if let Some((name, v, reason)) = parse_profile_commit(msg) {
+                let ts = chrono::DateTime::from_timestamp(commit.time().seconds(), 0)
+                    .map(|dt: chrono::DateTime<chrono::Utc>| dt.to_rfc3339())
+                    .unwrap_or_default();
+                per_agent
+                    .entry(name)
+                    .or_default()
+                    .push(VersionEntry { v, sha: git_ops::short_sha(&oid), ts, reason });
+            }
+        }
+
+        let mut idx = Self {
+            schema_version: SCHEMA_VERSION,
+            agents_head: head,
+            agents: BTreeMap::new(),
+        };
+
+        for (name, mut entries) in per_agent {
+            entries.sort_by_key(|e| e.v);
+            let current_version = entries.last().map_or(0, |e| e.v);
+            idx.agents.insert(name, AgentIndex { versions: entries, current_version });
+        }
+
+        Ok(idx)
+    }
+}
+
+/// Parse `"profile(<name>): v<N> <reason>"` → `(name, v, reason)`.
+pub fn parse_profile_commit(msg: &str) -> Option<(String, u32, String)> {
+    let msg = msg.strip_prefix("profile(")?;
+    let (name, rest) = msg.split_once("): v")?;
+    let (v_str, reason) = rest.split_once(' ')?;
+    let v: u32 = v_str.parse().ok()?;
+    Some((name.to_string(), v, reason.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_profile_commit_valid() {
+        let (name, v, reason) =
+            parse_profile_commit("profile(my-agent): v2 update skills").unwrap();
+        assert_eq!(name, "my-agent");
+        assert_eq!(v, 2);
+        assert_eq!(reason, "update skills");
+    }
+
+    #[test]
+    fn parse_profile_commit_non_profile() {
+        assert!(parse_profile_commit("init: agents layer").is_none());
+        assert!(parse_profile_commit("pattern(foo): v1 init").is_none());
+    }
+}

--- a/mur-core/src/store/versioned/agents.gitignore
+++ b/mur-core/src/store/versioned/agents.gitignore
@@ -1,0 +1,13 @@
+# Per-agent high-frequency state — never versioned (FIN-4: bare patterns)
+telemetry/
+outbox-ledger
+inbox/
+crashlogs/
+running.lock
+.extract_digest
+.apply-staging/
+.apply-in-progress
+
+# Derived — maintained by mur, NOT tracked in agents git
+.mur-agents-versions.yaml
+*.tmp

--- a/mur-core/src/store/versioned/git_ops.rs
+++ b/mur-core/src/store/versioned/git_ops.rs
@@ -1,0 +1,73 @@
+//! git2 helpers for the versioned store.
+// Not yet wired into the CLI — remove when integrated (E1-W3).
+#![allow(dead_code)]
+//!
+//! Key constraint from FIN-1 (spike R2): `commit_paths` MUST stage only
+//! the explicit paths the caller provides. Never call `index.add_all` on
+//! the save hot path — at 3000 patterns that caused O(N²) filesystem ops
+//! and CI timeout.
+
+use anyhow::{Context, Result};
+use git2::{Repository, Signature};
+use std::path::{Path, PathBuf};
+
+/// Open an existing repo at `dir`, or initialise one with a `.gitignore`
+/// and an initial commit if `.git` is absent.
+pub fn open_or_init_repo(dir: &Path, gitignore: &str, init_msg: &str) -> Result<Repository> {
+    if dir.join(".git").exists() {
+        return Repository::open(dir)
+            .with_context(|| format!("open repo at {}", dir.display()));
+    }
+
+    let repo = Repository::init(dir)
+        .with_context(|| format!("init repo at {}", dir.display()))?;
+    std::fs::write(dir.join(".gitignore"), gitignore)?;
+
+    let sig = signature()?;
+    {
+        let mut index = repo.index()?;
+        index.add_path(Path::new(".gitignore"))?;
+        index.write()?;
+        let tree_id = index.write_tree()?;
+        let tree = repo.find_tree(tree_id)?;
+        repo.commit(Some("HEAD"), &sig, &sig, init_msg, &tree, &[])?;
+    }
+    Ok(repo)
+}
+
+/// Stage exactly `paths` and create a commit. Returns 12-char short SHA.
+///
+/// FIN-1 compliance: explicit paths only — no `index.add_all`. Callers
+/// must pass every path they changed, including archive copies.
+pub fn commit_paths(repo: &Repository, paths: &[PathBuf], message: &str) -> Result<String> {
+    let sig = signature()?;
+    let mut index = repo.index()?;
+    for p in paths {
+        index
+            .add_path(p)
+            .with_context(|| format!("stage {}", p.display()))?;
+    }
+    index.write()?;
+    let tree_id = index.write_tree()?;
+    let tree = repo.find_tree(tree_id)?;
+    let parent = repo.head()?.peel_to_commit()?;
+    let oid = repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &[&parent])?;
+    Ok(short_sha(&oid))
+}
+
+/// Current HEAD commit SHA (full 40 chars). Empty string for unborn branch.
+pub fn head_sha(repo: &Repository) -> Result<String> {
+    match repo.head() {
+        Ok(r) => Ok(r.peel_to_commit()?.id().to_string()),
+        Err(e) if e.code() == git2::ErrorCode::UnbornBranch => Ok(String::new()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub fn signature() -> Result<Signature<'static>> {
+    Ok(Signature::now("mur", "store@mur.run")?)
+}
+
+pub fn short_sha(oid: &git2::Oid) -> String {
+    oid.to_string().chars().take(12).collect()
+}

--- a/mur-core/src/store/versioned/git_ops.rs
+++ b/mur-core/src/store/versioned/git_ops.rs
@@ -15,12 +15,10 @@ use std::path::{Path, PathBuf};
 /// and an initial commit if `.git` is absent.
 pub fn open_or_init_repo(dir: &Path, gitignore: &str, init_msg: &str) -> Result<Repository> {
     if dir.join(".git").exists() {
-        return Repository::open(dir)
-            .with_context(|| format!("open repo at {}", dir.display()));
+        return Repository::open(dir).with_context(|| format!("open repo at {}", dir.display()));
     }
 
-    let repo = Repository::init(dir)
-        .with_context(|| format!("init repo at {}", dir.display()))?;
+    let repo = Repository::init(dir).with_context(|| format!("init repo at {}", dir.display()))?;
     std::fs::write(dir.join(".gitignore"), gitignore)?;
 
     let sig = signature()?;

--- a/mur-core/src/store/versioned/index.rs
+++ b/mur-core/src/store/versioned/index.rs
@@ -117,20 +117,17 @@ impl VersionIndex {
         for oid_result in walker {
             let oid = oid_result?;
             let commit = repo.find_commit(oid)?;
-            let msg = commit
-                .message()
-                .unwrap_or("")
-                .lines()
-                .next()
-                .unwrap_or("");
+            let msg = commit.message().unwrap_or("").lines().next().unwrap_or("");
             if let Some((name, v, reason)) = parse_pattern_commit(msg) {
                 let ts = chrono::DateTime::from_timestamp(commit.time().seconds(), 0)
                     .map(|dt: chrono::DateTime<chrono::Utc>| dt.to_rfc3339())
                     .unwrap_or_default();
-                per_pattern
-                    .entry(name)
-                    .or_default()
-                    .push(VersionEntry { v, sha: git_ops::short_sha(&oid), ts, reason });
+                per_pattern.entry(name).or_default().push(VersionEntry {
+                    v,
+                    sha: git_ops::short_sha(&oid),
+                    ts,
+                    reason,
+                });
             }
         }
 
@@ -144,8 +141,13 @@ impl VersionIndex {
             // revwalk is newest-first; sort ascending by v for canonical order
             entries.sort_by_key(|e| e.v);
             let current_version = entries.last().map_or(0, |e| e.v);
-            idx.patterns
-                .insert(name, PatternIndex { versions: entries, current_version });
+            idx.patterns.insert(
+                name,
+                PatternIndex {
+                    versions: entries,
+                    current_version,
+                },
+            );
         }
 
         Ok(idx)
@@ -176,8 +178,7 @@ mod tests {
 
     #[test]
     fn parse_pattern_commit_rollback() {
-        let (name, v, reason) =
-            parse_pattern_commit("pattern(foo): v4 rollback to v2").unwrap();
+        let (name, v, reason) = parse_pattern_commit("pattern(foo): v4 rollback to v2").unwrap();
         assert_eq!(v, 4);
         assert_eq!(reason, "rollback to v2");
         assert_eq!(name, "foo");

--- a/mur-core/src/store/versioned/index.rs
+++ b/mur-core/src/store/versioned/index.rs
@@ -1,0 +1,191 @@
+//! `.mur-versions.yaml` — load-bearing per-pattern history index (FIN-3).
+// Not yet wired into the CLI — remove when integrated (E1-W3).
+#![allow(dead_code)]
+//!
+//! Maintained on every `save_pattern` call (O(1) append). `history()`
+//! reads directly from this index instead of walking git log — the live
+//! walk took 1.94s at 3000 commits in spike R2 (target: < 100ms).
+//!
+//! `rebuild_from_git` is the O(total-commits) recovery path; it runs only
+//! on `mur internals rebuild-index` or after external git surgery.
+
+use anyhow::Result;
+use git2::Repository;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use super::git_ops;
+
+pub const SCHEMA_VERSION: u32 = 3;
+pub const INDEX_FILE: &str = ".mur-versions.yaml";
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct VersionIndex {
+    pub schema_version: u32,
+    /// Full SHA of the knowledge repo HEAD at last index write.
+    pub knowledge_head: String,
+    #[serde(default)]
+    pub patterns: BTreeMap<String, PatternIndex>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct PatternIndex {
+    pub versions: Vec<VersionEntry>,
+    pub current_version: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct VersionEntry {
+    pub v: u32,
+    pub sha: String,
+    pub ts: String,
+    pub reason: String,
+}
+
+impl VersionIndex {
+    pub fn load(root: &Path) -> Result<Self> {
+        let path = root.join(INDEX_FILE);
+        if !path.exists() {
+            return Ok(Self {
+                schema_version: SCHEMA_VERSION,
+                ..Default::default()
+            });
+        }
+        let content = std::fs::read_to_string(&path)?;
+        let mut idx: Self = serde_yaml::from_str(&content)?;
+        idx.schema_version = SCHEMA_VERSION;
+        Ok(idx)
+    }
+
+    /// Atomic save (temp → rename) so a crash mid-write leaves the previous
+    /// index intact.
+    pub fn save(&self, root: &Path) -> Result<()> {
+        let tmp = root.join(".mur-versions.yaml.tmp");
+        let dest = root.join(INDEX_FILE);
+        let yaml = serde_yaml::to_string(self)?;
+        std::fs::write(&tmp, yaml)?;
+        std::fs::rename(&tmp, dest)?;
+        Ok(())
+    }
+
+    /// Append one version entry and advance `current_version`. O(1).
+    /// Returns the new version number.
+    pub fn append_version(
+        &mut self,
+        name: &str,
+        sha: &str,
+        reason: &str,
+        head: &str,
+        ts: &str,
+    ) -> u32 {
+        self.knowledge_head = head.to_string();
+        let entry = self.patterns.entry(name.to_string()).or_default();
+        let v = entry.current_version + 1;
+        entry.versions.push(VersionEntry {
+            v,
+            sha: sha.to_string(),
+            ts: ts.to_string(),
+            reason: reason.to_string(),
+        });
+        entry.current_version = v;
+        v
+    }
+
+    pub fn current_version_of(&self, name: &str) -> u32 {
+        self.patterns.get(name).map_or(0, |p| p.current_version)
+    }
+
+    /// Rebuild from git commit messages — O(total commits). Used only by
+    /// `mur internals rebuild-index` and recovery paths.
+    ///
+    /// Commit message format: `"pattern(<name>): v<N> <reason>"`
+    pub fn rebuild_from_git(repo: &Repository) -> Result<Self> {
+        let head = git_ops::head_sha(repo)?;
+        if head.is_empty() {
+            return Ok(Self {
+                schema_version: SCHEMA_VERSION,
+                knowledge_head: head,
+                ..Default::default()
+            });
+        }
+
+        let mut per_pattern: BTreeMap<String, Vec<VersionEntry>> = BTreeMap::new();
+        let mut walker = repo.revwalk()?;
+        walker.push_head()?;
+
+        for oid_result in walker {
+            let oid = oid_result?;
+            let commit = repo.find_commit(oid)?;
+            let msg = commit
+                .message()
+                .unwrap_or("")
+                .lines()
+                .next()
+                .unwrap_or("");
+            if let Some((name, v, reason)) = parse_pattern_commit(msg) {
+                let ts = chrono::DateTime::from_timestamp(commit.time().seconds(), 0)
+                    .map(|dt: chrono::DateTime<chrono::Utc>| dt.to_rfc3339())
+                    .unwrap_or_default();
+                per_pattern
+                    .entry(name)
+                    .or_default()
+                    .push(VersionEntry { v, sha: git_ops::short_sha(&oid), ts, reason });
+            }
+        }
+
+        let mut idx = Self {
+            schema_version: SCHEMA_VERSION,
+            knowledge_head: head,
+            patterns: BTreeMap::new(),
+        };
+
+        for (name, mut entries) in per_pattern {
+            // revwalk is newest-first; sort ascending by v for canonical order
+            entries.sort_by_key(|e| e.v);
+            let current_version = entries.last().map_or(0, |e| e.v);
+            idx.patterns
+                .insert(name, PatternIndex { versions: entries, current_version });
+        }
+
+        Ok(idx)
+    }
+}
+
+/// Parse `"pattern(<name>): v<N> <reason>"` → `(name, v, reason)`.
+fn parse_pattern_commit(msg: &str) -> Option<(String, u32, String)> {
+    let msg = msg.strip_prefix("pattern(")?;
+    let (name, rest) = msg.split_once("): v")?;
+    let (v_str, reason) = rest.split_once(' ')?;
+    let v: u32 = v_str.parse().ok()?;
+    Some((name.to_string(), v, reason.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_pattern_commit_valid() {
+        let (name, v, reason) =
+            parse_pattern_commit("pattern(rust-error-handling): v3 refine").unwrap();
+        assert_eq!(name, "rust-error-handling");
+        assert_eq!(v, 3);
+        assert_eq!(reason, "refine");
+    }
+
+    #[test]
+    fn parse_pattern_commit_rollback() {
+        let (name, v, reason) =
+            parse_pattern_commit("pattern(foo): v4 rollback to v2").unwrap();
+        assert_eq!(v, 4);
+        assert_eq!(reason, "rollback to v2");
+        assert_eq!(name, "foo");
+    }
+
+    #[test]
+    fn parse_pattern_commit_non_pattern() {
+        assert!(parse_pattern_commit("init: knowledge layer").is_none());
+        assert!(parse_pattern_commit("workflow(foo): v1 init").is_none());
+    }
+}

--- a/mur-core/src/store/versioned/knowledge.gitignore
+++ b/mur-core/src/store/versioned/knowledge.gitignore
@@ -1,0 +1,13 @@
+# Execution layer — has its own .git repo
+/agents/
+
+# Runtime state — never versioned
+/inbox/
+/outbox/
+/session/
+/cache/
+/secrets/
+
+# Derived index — maintained by mur, NOT tracked in git
+.mur-versions.yaml
+*.tmp

--- a/mur-core/src/store/versioned/mod.rs
+++ b/mur-core/src/store/versioned/mod.rs
@@ -10,10 +10,10 @@
 //!   FIN-3 — `.mur-versions.yaml` is load-bearing; `history()` reads it
 //!   FIN-4 — knowledge.gitignore uses bare patterns, no `*/` anchors
 
-mod git_ops;
-mod index;
 pub mod agent;
 mod agent_index;
+mod git_ops;
+mod index;
 
 use anyhow::{Context, Result, anyhow};
 use git2::Repository;
@@ -51,16 +51,16 @@ impl VersionedYamlStore {
     /// knowledge git repo and required subdirectories on first call.
     pub fn init(root: &Path) -> Result<Self> {
         for sub in ["patterns", "archive/patterns", "workflows"] {
-            std::fs::create_dir_all(root.join(sub))
-                .with_context(|| format!("mkdir {sub}"))?;
+            std::fs::create_dir_all(root.join(sub)).with_context(|| format!("mkdir {sub}"))?;
         }
-        let knowledge_repo = git_ops::open_or_init_repo(
-            root,
-            KNOWLEDGE_GITIGNORE,
-            "init: knowledge layer",
-        )?;
+        let knowledge_repo =
+            git_ops::open_or_init_repo(root, KNOWLEDGE_GITIGNORE, "init: knowledge layer")?;
         let index = VersionIndex::load(root)?;
-        Ok(Self { root: root.to_path_buf(), knowledge_repo, index })
+        Ok(Self {
+            root: root.to_path_buf(),
+            knowledge_repo,
+            index,
+        })
     }
 
     /// Open an existing store. Returns an error if `root/.git` is absent.
@@ -68,7 +68,11 @@ impl VersionedYamlStore {
         let knowledge_repo = Repository::open(root)
             .with_context(|| format!("open knowledge repo at {}", root.display()))?;
         let index = VersionIndex::load(root)?;
-        Ok(Self { root: root.to_path_buf(), knowledge_repo, index })
+        Ok(Self {
+            root: root.to_path_buf(),
+            knowledge_repo,
+            index,
+        })
     }
 
     /// Write `pattern` to disk and commit. Returns a `PatternRevision`
@@ -81,8 +85,7 @@ impl VersionedYamlStore {
         let pattern_rel = PathBuf::from("patterns").join(format!("{name}.yaml"));
         let pattern_abs = self.root.join(&pattern_rel);
 
-        let yaml = serde_yaml::to_string(pattern)
-            .with_context(|| format!("serialize {name}"))?;
+        let yaml = serde_yaml::to_string(pattern).with_context(|| format!("serialize {name}"))?;
 
         // No-op fast path
         if pattern_abs.exists() {
@@ -125,7 +128,11 @@ impl VersionedYamlStore {
         self.index.append_version(name, &sha, reason, &head, &ts);
         self.index.save(&self.root)?;
 
-        Ok(PatternRevision { name: name.clone(), version: new_v, sha })
+        Ok(PatternRevision {
+            name: name.clone(),
+            version: new_v,
+            sha,
+        })
     }
 
     #[allow(dead_code)]
@@ -136,8 +143,7 @@ impl VersionedYamlStore {
         }
         let content = std::fs::read_to_string(&path)?;
         Ok(Some(
-            serde_yaml::from_str(&content)
-                .with_context(|| format!("parse {name}"))?,
+            serde_yaml::from_str(&content).with_context(|| format!("parse {name}"))?,
         ))
     }
 
@@ -255,7 +261,11 @@ impl VersionedYamlStore {
         self.index.append_version(name, &sha, reason, &head, &ts);
         self.index.save(&self.root)?;
 
-        Ok(PatternRevision { name: name.clone(), version: new_v, sha })
+        Ok(PatternRevision {
+            name: name.clone(),
+            version: new_v,
+            sha,
+        })
     }
 
     /// Stage and commit all existing pattern YAML files in a single bootstrap

--- a/mur-core/src/store/versioned/mod.rs
+++ b/mur-core/src/store/versioned/mod.rs
@@ -14,6 +14,8 @@
 
 mod git_ops;
 mod index;
+pub mod agent;
+mod agent_index;
 
 use anyhow::{Context, Result, anyhow};
 use git2::Repository;

--- a/mur-core/src/store/versioned/mod.rs
+++ b/mur-core/src/store/versioned/mod.rs
@@ -1,0 +1,203 @@
+//! `VersionedYamlStore` — git-backed versioned pattern store (E1 W1).
+// Not yet wired into the CLI — remove when integrated (E1-W3).
+#![allow(dead_code)]
+//!
+//! Wraps `~/.mur/` as a knowledge-layer git repository. Every
+//! `save_pattern` call produces exactly one commit and an O(1) index
+//! append. `history()` reads the index directly (< 50ms target).
+//!
+//! ADR-0001 compliance:
+//!   FIN-1 — `commit_paths` stages only explicit paths (no `add_all`)
+//!   FIN-2 — version derivation O(1) via archive dir count
+//!   FIN-3 — `.mur-versions.yaml` is load-bearing; `history()` reads it
+//!   FIN-4 — knowledge.gitignore uses bare patterns, no `*/` anchors
+
+mod git_ops;
+mod index;
+
+use anyhow::{Context, Result, anyhow};
+use git2::Repository;
+use index::VersionIndex;
+use mur_common::pattern::Pattern;
+use std::path::{Path, PathBuf};
+
+const KNOWLEDGE_GITIGNORE: &str = include_str!("knowledge.gitignore");
+
+pub struct VersionedYamlStore {
+    root: PathBuf,
+    knowledge_repo: Repository,
+    index: VersionIndex,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PatternRevision {
+    pub name: String,
+    pub version: u32,
+    /// 12-char short SHA of the git commit for this version.
+    pub sha: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct HistoryEntry {
+    pub version: u32,
+    pub sha: String,
+    /// Unix timestamp (seconds since epoch).
+    pub timestamp: i64,
+    pub reason: String,
+}
+
+impl VersionedYamlStore {
+    /// Initialise (or re-open) a versioned store at `root`. Creates the
+    /// knowledge git repo and required subdirectories on first call.
+    pub fn init(root: &Path) -> Result<Self> {
+        for sub in ["patterns", "archive/patterns", "workflows"] {
+            std::fs::create_dir_all(root.join(sub))
+                .with_context(|| format!("mkdir {sub}"))?;
+        }
+        let knowledge_repo = git_ops::open_or_init_repo(
+            root,
+            KNOWLEDGE_GITIGNORE,
+            "init: knowledge layer",
+        )?;
+        let index = VersionIndex::load(root)?;
+        Ok(Self { root: root.to_path_buf(), knowledge_repo, index })
+    }
+
+    /// Open an existing store. Returns an error if `root/.git` is absent.
+    pub fn open(root: &Path) -> Result<Self> {
+        let knowledge_repo = Repository::open(root)
+            .with_context(|| format!("open knowledge repo at {}", root.display()))?;
+        let index = VersionIndex::load(root)?;
+        Ok(Self { root: root.to_path_buf(), knowledge_repo, index })
+    }
+
+    /// Write `pattern` to disk and commit. Returns a `PatternRevision`
+    /// describing the new version.
+    ///
+    /// No-op fast path: if the serialised YAML is byte-identical to what
+    /// is on disk, returns the current revision without a new commit.
+    pub fn save_pattern(&mut self, pattern: &Pattern, reason: &str) -> Result<PatternRevision> {
+        let name = &pattern.name;
+        let pattern_rel = PathBuf::from("patterns").join(format!("{name}.yaml"));
+        let pattern_abs = self.root.join(&pattern_rel);
+
+        let yaml = serde_yaml::to_string(pattern)
+            .with_context(|| format!("serialize {name}"))?;
+
+        // No-op fast path
+        if pattern_abs.exists() {
+            let existing = std::fs::read_to_string(&pattern_abs)?;
+            if existing == yaml {
+                return Ok(PatternRevision {
+                    name: name.clone(),
+                    version: self.index.current_version_of(name),
+                    sha: git_ops::head_sha(&self.knowledge_repo)?,
+                });
+            }
+        }
+
+        let mut paths_to_stage = vec![pattern_rel.clone()];
+
+        // Archive the current version before overwriting (FIN-2: uses
+        // current_version from index — O(1), not a git walk).
+        let prev_v = self.index.current_version_of(name);
+        if prev_v > 0 && pattern_abs.exists() {
+            let archive_dir = self.root.join("archive/patterns").join(name);
+            std::fs::create_dir_all(&archive_dir)?;
+            let archive_rel = PathBuf::from("archive/patterns")
+                .join(name)
+                .join(format!("v{prev_v}.yaml"));
+            std::fs::copy(&pattern_abs, self.root.join(&archive_rel))?;
+            paths_to_stage.push(archive_rel);
+        }
+
+        // Atomic write: temp → rename
+        let tmp = pattern_abs.with_extension("yaml.tmp");
+        std::fs::write(&tmp, &yaml)?;
+        std::fs::rename(&tmp, &pattern_abs)?;
+
+        let new_v = prev_v + 1;
+        let ts = chrono::Utc::now().to_rfc3339();
+        let msg = format!("pattern({name}): v{new_v} {reason}");
+        let sha = git_ops::commit_paths(&self.knowledge_repo, &paths_to_stage, &msg)?;
+
+        let head = git_ops::head_sha(&self.knowledge_repo)?;
+        self.index.append_version(name, &sha, reason, &head, &ts);
+        self.index.save(&self.root)?;
+
+        Ok(PatternRevision { name: name.clone(), version: new_v, sha })
+    }
+
+    pub fn read_pattern(&self, name: &str) -> Result<Option<Pattern>> {
+        let path = self.root.join("patterns").join(format!("{name}.yaml"));
+        if !path.exists() {
+            return Ok(None);
+        }
+        let content = std::fs::read_to_string(&path)?;
+        Ok(Some(
+            serde_yaml::from_str(&content)
+                .with_context(|| format!("parse {name}"))?,
+        ))
+    }
+
+    /// Current version from the index. O(1).
+    pub fn current_version(&self, name: &str) -> u32 {
+        self.index.current_version_of(name)
+    }
+
+    /// Full version history for `name` read from the index (FIN-3).
+    pub fn history(&self, name: &str) -> Result<Vec<HistoryEntry>> {
+        let pi = match self.index.patterns.get(name) {
+            Some(p) => p,
+            None => return Ok(vec![]),
+        };
+        Ok(pi
+            .versions
+            .iter()
+            .map(|e| HistoryEntry {
+                version: e.v,
+                sha: e.sha.clone(),
+                timestamp: chrono::DateTime::parse_from_rfc3339(&e.ts)
+                    .map(|dt| dt.timestamp())
+                    .unwrap_or(0),
+                reason: e.reason.clone(),
+            })
+            .collect())
+    }
+
+    /// Roll back `name` to `to_version` by re-applying the archived YAML
+    /// as a new commit. No history rewriting.
+    pub fn rollback_pattern(&mut self, name: &str, to_version: u32) -> Result<PatternRevision> {
+        let archive = self
+            .root
+            .join("archive/patterns")
+            .join(name)
+            .join(format!("v{to_version}.yaml"));
+        if !archive.exists() {
+            return Err(anyhow!("no archived v{to_version} for pattern '{name}'"));
+        }
+        let content = std::fs::read_to_string(&archive)?;
+        let pattern: Pattern = serde_yaml::from_str(&content)
+            .with_context(|| format!("parse archive v{to_version} of '{name}'"))?;
+        self.save_pattern(&pattern, &format!("rollback to v{to_version}"))
+    }
+
+    /// Returns `true` if the on-disk HEAD differs from the HEAD recorded in
+    /// the index — indicating external git surgery since the last save.
+    pub fn detect_external_change(&self) -> Result<bool> {
+        let head = git_ops::head_sha(&self.knowledge_repo)?;
+        Ok(!head.is_empty() && self.index.knowledge_head != head)
+    }
+
+    /// Rebuild `.mur-versions.yaml` by walking the full git log.
+    /// O(total commits) — use only for recovery or first migration.
+    pub fn rebuild_index(&mut self) -> Result<()> {
+        self.index = VersionIndex::rebuild_from_git(&self.knowledge_repo)?;
+        self.index.save(&self.root)?;
+        Ok(())
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+}

--- a/mur-core/src/store/versioned/mod.rs
+++ b/mur-core/src/store/versioned/mod.rs
@@ -1,6 +1,4 @@
 //! `VersionedYamlStore` — git-backed versioned pattern store (E1 W1).
-// Not yet wired into the CLI — remove when integrated (E1-W3).
-#![allow(dead_code)]
 //!
 //! Wraps `~/.mur/` as a knowledge-layer git repository. Every
 //! `save_pattern` call produces exactly one commit and an O(1) index
@@ -130,6 +128,7 @@ impl VersionedYamlStore {
         Ok(PatternRevision { name: name.clone(), version: new_v, sha })
     }
 
+    #[allow(dead_code)]
     pub fn read_pattern(&self, name: &str) -> Result<Option<Pattern>> {
         let path = self.root.join("patterns").join(format!("{name}.yaml"));
         if !path.exists() {
@@ -186,6 +185,7 @@ impl VersionedYamlStore {
 
     /// Returns `true` if the on-disk HEAD differs from the HEAD recorded in
     /// the index — indicating external git surgery since the last save.
+    #[allow(dead_code)]
     pub fn detect_external_change(&self) -> Result<bool> {
         let head = git_ops::head_sha(&self.knowledge_repo)?;
         Ok(!head.is_empty() && self.index.knowledge_head != head)
@@ -199,7 +199,133 @@ impl VersionedYamlStore {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn root(&self) -> &Path {
         &self.root
+    }
+
+    /// Stage and commit a pattern file that has **already been written to disk**
+    /// by `YamlStore::save()`. Used by the write path gate so that plain saves
+    /// are automatically versioned when the knowledge git repo is active.
+    ///
+    /// No-op fast path: compares the new YAML against the HEAD blob (not the
+    /// file) to detect whether anything actually changed.
+    pub fn commit_existing_pattern(
+        &mut self,
+        pattern: &Pattern,
+        reason: &str,
+    ) -> Result<PatternRevision> {
+        let name = &pattern.name;
+        let pattern_rel = PathBuf::from("patterns").join(format!("{name}.yaml"));
+
+        let new_yaml =
+            serde_yaml::to_string(pattern).with_context(|| format!("serialize {name}"))?;
+
+        // No-op: compare against HEAD blob (file on disk is already updated)
+        let head_yaml = self.read_head_blob_str(&pattern_rel).unwrap_or_default();
+        if head_yaml == new_yaml {
+            return Ok(PatternRevision {
+                name: name.clone(),
+                version: self.index.current_version_of(name),
+                sha: git_ops::head_sha(&self.knowledge_repo)?,
+            });
+        }
+
+        let mut paths_to_stage = vec![pattern_rel.clone()];
+
+        // Archive the HEAD version before committing the new one.
+        // The file on disk is already new content, so we copy from HEAD blob.
+        let prev_v = self.index.current_version_of(name);
+        if prev_v > 0 && !head_yaml.is_empty() {
+            let archive_dir = self.root.join("archive/patterns").join(name);
+            std::fs::create_dir_all(&archive_dir)?;
+            let archive_rel = PathBuf::from("archive/patterns")
+                .join(name)
+                .join(format!("v{prev_v}.yaml"));
+            std::fs::write(self.root.join(&archive_rel), &head_yaml)?;
+            paths_to_stage.push(archive_rel);
+        }
+
+        let new_v = prev_v + 1;
+        let ts = chrono::Utc::now().to_rfc3339();
+        let msg = format!("pattern({name}): v{new_v} {reason}");
+        let sha = git_ops::commit_paths(&self.knowledge_repo, &paths_to_stage, &msg)?;
+
+        let head = git_ops::head_sha(&self.knowledge_repo)?;
+        self.index.append_version(name, &sha, reason, &head, &ts);
+        self.index.save(&self.root)?;
+
+        Ok(PatternRevision { name: name.clone(), version: new_v, sha })
+    }
+
+    /// Stage and commit all existing pattern YAML files in a single bootstrap
+    /// commit. Skips patterns already identical to their HEAD blob.
+    ///
+    /// Used by `mur reindex --bootstrap` to import existing patterns into
+    /// git history in one operation.
+    pub fn bootstrap_all(&mut self) -> Result<usize> {
+        let patterns_dir = self.root.join("patterns");
+        if !patterns_dir.exists() {
+            return Ok(0);
+        }
+
+        let head_tree = self
+            .knowledge_repo
+            .head()
+            .ok()
+            .and_then(|r| r.peel_to_tree().ok());
+
+        let mut paths: Vec<PathBuf> = vec![];
+        for entry in std::fs::read_dir(&patterns_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+                continue;
+            }
+            let rel = match path.strip_prefix(&self.root) {
+                Ok(r) => r.to_path_buf(),
+                Err(_) => continue,
+            };
+            // Skip patterns already committed with identical content
+            if let Some(tree) = &head_tree
+                && let Ok(te) = tree.get_path(&rel)
+                && let Ok(blob) = self.knowledge_repo.find_blob(te.id())
+            {
+                let on_disk = std::fs::read(&path).unwrap_or_default();
+                if blob.content() == on_disk.as_slice() {
+                    continue;
+                }
+            }
+            paths.push(rel);
+        }
+
+        if paths.is_empty() {
+            return Ok(0);
+        }
+
+        let count = paths.len();
+        let ts = chrono::Utc::now().to_rfc3339();
+        let msg = "bootstrap: import existing patterns";
+        let sha = git_ops::commit_paths(&self.knowledge_repo, &paths, msg)?;
+        let head = git_ops::head_sha(&self.knowledge_repo)?;
+
+        for path_rel in &paths {
+            if let Some(name) = path_rel.file_stem().and_then(|s| s.to_str()) {
+                self.index
+                    .append_version(name, &sha, "bootstrap: import existing", &head, &ts);
+            }
+        }
+        self.index.save(&self.root)?;
+
+        Ok(count)
+    }
+
+    fn read_head_blob_str(&self, rel: &Path) -> Result<String> {
+        let tree = self.knowledge_repo.head()?.peel_to_tree()?;
+        let entry = tree
+            .get_path(rel)
+            .with_context(|| format!("path {} not in HEAD", rel.display()))?;
+        let blob = self.knowledge_repo.find_blob(entry.id())?;
+        Ok(String::from_utf8_lossy(blob.content()).into_owned())
     }
 }

--- a/mur-core/src/store/yaml.rs
+++ b/mur-core/src/store/yaml.rs
@@ -89,6 +89,27 @@ impl YamlStore {
         fs::rename(&tmp_path, &path)
             .with_context(|| format!("Failed to rename temp to final: {}", path.display()))?;
 
+        // Version gate: when the knowledge git repo is active, commit this
+        // change. Best-effort — a commit failure never fails the primary save.
+        if let Some(mur_dir) = self.patterns_dir.parent()
+            && mur_dir.join(".git").exists()
+        {
+            match crate::store::versioned::VersionedYamlStore::open(mur_dir) {
+                Ok(mut vs) => {
+                    if let Err(e) = vs.commit_existing_pattern(pattern, "updated") {
+                        tracing::warn!(
+                            pattern = %pattern.name,
+                            error = %e,
+                            "versioned commit failed"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to open versioned store for commit");
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/mur-core/tests/versioned_agent.rs
+++ b/mur-core/tests/versioned_agent.rs
@@ -1,0 +1,240 @@
+//! Integration tests for `VersionedAgentStore` (E1 W2).
+//!
+//! Validates ADR-0001 FIN-1/2/3/4 for the execution layer.
+
+use mur_core::store::versioned::agent::VersionedAgentStore;
+use std::time::Instant;
+use tempfile::TempDir;
+
+fn temp_store() -> (TempDir, VersionedAgentStore) {
+    let dir = TempDir::new().unwrap();
+    let store = VersionedAgentStore::init(dir.path()).unwrap();
+    (dir, store)
+}
+
+fn profile(content: &str) -> String {
+    format!("name: test\ndescription: {content}\n")
+}
+
+// ── Basic CRUD ────────────────────────────────────────────────────────────────
+
+#[test]
+fn save_and_read_profile_roundtrip() {
+    let (_dir, mut store) = temp_store();
+
+    let rev = store.save_profile("agent-a", &profile("v1"), "init").unwrap();
+    assert_eq!(rev.version, 1);
+    assert_eq!(rev.name, "agent-a");
+    assert!(!rev.sha.is_empty());
+
+    let loaded = store.read_profile("agent-a").unwrap().unwrap();
+    assert!(loaded.contains("v1"));
+}
+
+#[test]
+fn read_missing_agent_returns_none() {
+    let (_dir, store) = temp_store();
+    assert!(store.read_profile("nonexistent").unwrap().is_none());
+}
+
+// ── FIN-2: O(1) version derivation ────────────────────────────────────────────
+
+#[test]
+fn version_increments_on_each_save() {
+    let (_dir, mut store) = temp_store();
+
+    let r1 = store.save_profile("agent-b", &profile("v1"), "init").unwrap();
+    assert_eq!(r1.version, 1);
+
+    let r2 = store.save_profile("agent-b", &profile("v2"), "update").unwrap();
+    assert_eq!(r2.version, 2);
+
+    let r3 = store.save_profile("agent-b", &profile("v3"), "refine").unwrap();
+    assert_eq!(r3.version, 3);
+
+    assert_eq!(store.current_version("agent-b"), 3);
+}
+
+#[test]
+fn no_op_save_does_not_increment_version() {
+    let (_dir, mut store) = temp_store();
+    let content = profile("unchanged");
+
+    let r1 = store.save_profile("agent-c", &content, "init").unwrap();
+    let r2 = store.save_profile("agent-c", &content, "same").unwrap();
+
+    assert_eq!(r1.version, 1);
+    assert_eq!(r2.version, 1, "no-op must not bump version");
+}
+
+// ── FIN-3: history from index ─────────────────────────────────────────────────
+
+#[test]
+fn history_populated_after_saves() {
+    let (_dir, mut store) = temp_store();
+
+    store.save_profile("agent-d", &profile("v1"), "init").unwrap();
+    store.save_profile("agent-d", &profile("v2"), "update skills").unwrap();
+
+    let hist = store.history("agent-d").unwrap();
+    assert_eq!(hist.len(), 2);
+    assert_eq!(hist[0].version, 1);
+    assert_eq!(hist[0].reason, "init");
+    assert_eq!(hist[1].version, 2);
+    assert_eq!(hist[1].reason, "update skills");
+}
+
+#[test]
+fn history_empty_for_unknown_agent() {
+    let (_dir, store) = temp_store();
+    assert!(store.history("phantom").unwrap().is_empty());
+}
+
+#[test]
+fn history_fast_on_many_revisions() {
+    let (_dir, mut store) = temp_store();
+
+    for i in 1..=50u32 {
+        store.save_profile("perf-agent", &profile(&format!("v{i}")), &format!("rev {i}")).unwrap();
+    }
+
+    let t = Instant::now();
+    let hist = store.history("perf-agent").unwrap();
+    let elapsed = t.elapsed();
+
+    assert_eq!(hist.len(), 50);
+    assert!(
+        elapsed.as_millis() < 100,
+        "history() took {}ms (FIN-3 target < 100ms)",
+        elapsed.as_millis()
+    );
+}
+
+// ── Skill operations ──────────────────────────────────────────────────────────
+
+#[test]
+fn save_and_read_skill() {
+    let (_dir, mut store) = temp_store();
+
+    store.save_profile("agent-e", &profile("v1"), "init").unwrap();
+    store.save_skill("agent-e", "rust-basics", "# Rust basics\nUse Result.", "add skill").unwrap();
+
+    let content = store.read_skill("agent-e", "rust-basics").unwrap().unwrap();
+    assert!(content.contains("Rust basics"));
+}
+
+// ── Rollback ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn rollback_restores_profile_as_new_version() {
+    let (_dir, mut store) = temp_store();
+
+    store.save_profile("agent-f", &profile("original"), "init").unwrap(); // v1
+    store.save_profile("agent-f", &profile("modified"), "update").unwrap(); // v2
+
+    let rev = store.rollback_profile("agent-f", 1).unwrap(); // v3 = rollback to v1
+    assert_eq!(rev.version, 3);
+
+    let loaded = store.read_profile("agent-f").unwrap().unwrap();
+    assert!(!loaded.contains("modified"), "rollback should revert to v1 content");
+}
+
+#[test]
+fn rollback_missing_version_errors() {
+    let (_dir, mut store) = temp_store();
+    store.save_profile("agent-g", &profile("v1"), "init").unwrap();
+
+    let err = store.rollback_profile("agent-g", 99).unwrap_err();
+    assert!(err.to_string().contains("no archived"));
+}
+
+// ── detect_external_change & rebuild_index ────────────────────────────────────
+
+#[test]
+fn detect_external_change_false_after_save() {
+    let (_dir, mut store) = temp_store();
+    store.save_profile("agent-h", &profile("v1"), "init").unwrap();
+    assert!(!store.detect_external_change().unwrap());
+}
+
+#[test]
+fn rebuild_index_restores_history() {
+    let (_dir, mut store) = temp_store();
+    store.save_profile("agent-i", &profile("v1"), "init").unwrap();
+    store.save_profile("agent-i", &profile("v2"), "update").unwrap();
+
+    store.rebuild_index().unwrap();
+
+    let hist = store.history("agent-i").unwrap();
+    assert_eq!(hist.len(), 2);
+    assert_eq!(hist[0].reason, "init");
+    assert_eq!(hist[1].reason, "update");
+}
+
+// ── Split-brain repair ────────────────────────────────────────────────────────
+
+#[test]
+fn repair_recovers_missing_git_dir() {
+    let dir = TempDir::new().unwrap();
+    let agents_dir = dir.path();
+
+    // Create agent dir with profile, but no .git
+    let agent_dir = agents_dir.join("orphan-agent");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(agent_dir.join("profile.yaml"), profile("orphaned")).unwrap();
+
+    let report = VersionedAgentStore::repair(agents_dir).unwrap();
+    assert!(report.recovered);
+    assert_eq!(report.agents_recommitted, 1); // one agent dir recovered
+
+    // After repair, should be openable
+    let store = VersionedAgentStore::open(agents_dir).unwrap();
+    // Profile should be readable (it was committed in the repair commit)
+    assert!(store.read_profile("orphan-agent").unwrap().is_some());
+}
+
+#[test]
+fn repair_noop_when_git_healthy() {
+    let (_dir, store) = temp_store();
+    let report = VersionedAgentStore::repair(store.root()).unwrap();
+    assert!(!report.recovered);
+}
+
+// ── FIN-4: gitignore correctness ──────────────────────────────────────────────
+
+#[test]
+fn gitignore_ignores_runtime_files() {
+    let (_dir, store) = temp_store();
+    let repo = git2::Repository::open(store.root()).unwrap();
+
+    for path in [
+        "my-agent/telemetry/events.jsonl",
+        "my-agent/crashlogs/last.txt",
+        "my-agent/running.lock",
+        "my-agent/.extract_digest",
+        "my-agent/.apply-staging/tmp",
+    ] {
+        assert!(
+            repo.is_path_ignored(path).unwrap_or(false),
+            "'{path}' should be gitignored (FIN-4)"
+        );
+    }
+}
+
+#[test]
+fn gitignore_tracks_profile_and_skills() {
+    let (_dir, store) = temp_store();
+    let repo = git2::Repository::open(store.root()).unwrap();
+
+    for path in [
+        "my-agent/profile.yaml",
+        "my-agent/skills/rust.md",
+        "my-agent/sys_prompt.md",
+        "my-agent/identity.pub",
+    ] {
+        assert!(
+            !repo.is_path_ignored(path).unwrap_or(true),
+            "'{path}' should NOT be gitignored"
+        );
+    }
+}

--- a/mur-core/tests/versioned_agent.rs
+++ b/mur-core/tests/versioned_agent.rs
@@ -308,3 +308,31 @@ fn commit_existing_profile_versions_externally_written_file() {
     let rev2 = store.commit_existing_profile("agent1", "updated").unwrap();
     assert_eq!(rev2.version, 2);
 }
+
+// ── bootstrap_all ─────────────────────────────────────────────────────────────
+
+#[test]
+fn bootstrap_all_imports_existing_profiles() {
+    let dir = TempDir::new().unwrap();
+    let agents_dir = dir.path();
+
+    // Pre-create two agent dirs with profiles (no .git yet).
+    for name in ["alpha", "beta"] {
+        let agent_dir = agents_dir.join(name);
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(agent_dir.join("profile.yaml"), profile(name)).unwrap();
+    }
+
+    let mut store = VersionedAgentStore::init(agents_dir).unwrap();
+    let count = store.bootstrap_all().unwrap();
+    assert_eq!(count, 2);
+
+    // Both agents should be at version 1 and readable.
+    assert_eq!(store.current_version("alpha"), 1);
+    assert_eq!(store.current_version("beta"), 1);
+    assert!(store.read_profile("alpha").unwrap().is_some());
+
+    // Idempotent: second bootstrap is a no-op.
+    let count2 = store.bootstrap_all().unwrap();
+    assert_eq!(count2, 0);
+}

--- a/mur-core/tests/versioned_agent.rs
+++ b/mur-core/tests/versioned_agent.rs
@@ -22,7 +22,9 @@ fn profile(content: &str) -> String {
 fn save_and_read_profile_roundtrip() {
     let (_dir, mut store) = temp_store();
 
-    let rev = store.save_profile("agent-a", &profile("v1"), "init").unwrap();
+    let rev = store
+        .save_profile("agent-a", &profile("v1"), "init")
+        .unwrap();
     assert_eq!(rev.version, 1);
     assert_eq!(rev.name, "agent-a");
     assert!(!rev.sha.is_empty());
@@ -43,13 +45,19 @@ fn read_missing_agent_returns_none() {
 fn version_increments_on_each_save() {
     let (_dir, mut store) = temp_store();
 
-    let r1 = store.save_profile("agent-b", &profile("v1"), "init").unwrap();
+    let r1 = store
+        .save_profile("agent-b", &profile("v1"), "init")
+        .unwrap();
     assert_eq!(r1.version, 1);
 
-    let r2 = store.save_profile("agent-b", &profile("v2"), "update").unwrap();
+    let r2 = store
+        .save_profile("agent-b", &profile("v2"), "update")
+        .unwrap();
     assert_eq!(r2.version, 2);
 
-    let r3 = store.save_profile("agent-b", &profile("v3"), "refine").unwrap();
+    let r3 = store
+        .save_profile("agent-b", &profile("v3"), "refine")
+        .unwrap();
     assert_eq!(r3.version, 3);
 
     assert_eq!(store.current_version("agent-b"), 3);
@@ -73,8 +81,12 @@ fn no_op_save_does_not_increment_version() {
 fn history_populated_after_saves() {
     let (_dir, mut store) = temp_store();
 
-    store.save_profile("agent-d", &profile("v1"), "init").unwrap();
-    store.save_profile("agent-d", &profile("v2"), "update skills").unwrap();
+    store
+        .save_profile("agent-d", &profile("v1"), "init")
+        .unwrap();
+    store
+        .save_profile("agent-d", &profile("v2"), "update skills")
+        .unwrap();
 
     let hist = store.history("agent-d").unwrap();
     assert_eq!(hist.len(), 2);
@@ -95,7 +107,13 @@ fn history_fast_on_many_revisions() {
     let (_dir, mut store) = temp_store();
 
     for i in 1..=50u32 {
-        store.save_profile("perf-agent", &profile(&format!("v{i}")), &format!("rev {i}")).unwrap();
+        store
+            .save_profile(
+                "perf-agent",
+                &profile(&format!("v{i}")),
+                &format!("rev {i}"),
+            )
+            .unwrap();
     }
 
     let t = Instant::now();
@@ -116,8 +134,17 @@ fn history_fast_on_many_revisions() {
 fn save_and_read_skill() {
     let (_dir, mut store) = temp_store();
 
-    store.save_profile("agent-e", &profile("v1"), "init").unwrap();
-    store.save_skill("agent-e", "rust-basics", "# Rust basics\nUse Result.", "add skill").unwrap();
+    store
+        .save_profile("agent-e", &profile("v1"), "init")
+        .unwrap();
+    store
+        .save_skill(
+            "agent-e",
+            "rust-basics",
+            "# Rust basics\nUse Result.",
+            "add skill",
+        )
+        .unwrap();
 
     let content = store.read_skill("agent-e", "rust-basics").unwrap().unwrap();
     assert!(content.contains("Rust basics"));
@@ -129,20 +156,29 @@ fn save_and_read_skill() {
 fn rollback_restores_profile_as_new_version() {
     let (_dir, mut store) = temp_store();
 
-    store.save_profile("agent-f", &profile("original"), "init").unwrap(); // v1
-    store.save_profile("agent-f", &profile("modified"), "update").unwrap(); // v2
+    store
+        .save_profile("agent-f", &profile("original"), "init")
+        .unwrap(); // v1
+    store
+        .save_profile("agent-f", &profile("modified"), "update")
+        .unwrap(); // v2
 
     let rev = store.rollback_profile("agent-f", 1).unwrap(); // v3 = rollback to v1
     assert_eq!(rev.version, 3);
 
     let loaded = store.read_profile("agent-f").unwrap().unwrap();
-    assert!(!loaded.contains("modified"), "rollback should revert to v1 content");
+    assert!(
+        !loaded.contains("modified"),
+        "rollback should revert to v1 content"
+    );
 }
 
 #[test]
 fn rollback_missing_version_errors() {
     let (_dir, mut store) = temp_store();
-    store.save_profile("agent-g", &profile("v1"), "init").unwrap();
+    store
+        .save_profile("agent-g", &profile("v1"), "init")
+        .unwrap();
 
     let err = store.rollback_profile("agent-g", 99).unwrap_err();
     assert!(err.to_string().contains("no archived"));
@@ -153,15 +189,21 @@ fn rollback_missing_version_errors() {
 #[test]
 fn detect_external_change_false_after_save() {
     let (_dir, mut store) = temp_store();
-    store.save_profile("agent-h", &profile("v1"), "init").unwrap();
+    store
+        .save_profile("agent-h", &profile("v1"), "init")
+        .unwrap();
     assert!(!store.detect_external_change().unwrap());
 }
 
 #[test]
 fn rebuild_index_restores_history() {
     let (_dir, mut store) = temp_store();
-    store.save_profile("agent-i", &profile("v1"), "init").unwrap();
-    store.save_profile("agent-i", &profile("v2"), "update").unwrap();
+    store
+        .save_profile("agent-i", &profile("v1"), "init")
+        .unwrap();
+    store
+        .save_profile("agent-i", &profile("v2"), "update")
+        .unwrap();
 
     store.rebuild_index().unwrap();
 

--- a/mur-core/tests/versioned_agent.rs
+++ b/mur-core/tests/versioned_agent.rs
@@ -280,3 +280,31 @@ fn gitignore_tracks_profile_and_skills() {
         );
     }
 }
+
+// ── commit_existing_profile ───────────────────────────────────────────────────
+
+#[test]
+fn commit_existing_profile_versions_externally_written_file() {
+    let (dir, mut store) = temp_store();
+
+    // Seed a first version through the normal path so HEAD has a blob.
+    store
+        .save_profile("agent1", &profile("v1"), "created")
+        .unwrap();
+    assert_eq!(store.current_version("agent1"), 1);
+
+    // Simulate external write (what cmd::agent::save_profile does).
+    let profile_path = dir.path().join("agent1").join("profile.yaml");
+    std::fs::write(&profile_path, profile("v2")).unwrap();
+
+    let rev = store.commit_existing_profile("agent1", "updated").unwrap();
+    assert_eq!(rev.version, 2);
+    assert_eq!(store.current_version("agent1"), 2);
+
+    // Archive for v1 must exist.
+    assert!(dir.path().join("agent1/archive/v1.yaml").exists());
+
+    // No-op: same content on disk as HEAD → version stays at 2.
+    let rev2 = store.commit_existing_profile("agent1", "updated").unwrap();
+    assert_eq!(rev2.version, 2);
+}

--- a/mur-core/tests/versioned_yaml.rs
+++ b/mur-core/tests/versioned_yaml.rs
@@ -2,7 +2,10 @@
 //!
 //! Validates ADR-0001 FIN-1 through FIN-4 + basic CRUD.
 
-use mur_common::{knowledge::KnowledgeBase, pattern::{Content, Pattern}};
+use mur_common::{
+    knowledge::KnowledgeBase,
+    pattern::{Content, Pattern},
+};
 use mur_core::store::versioned::VersionedYamlStore;
 use std::time::Instant;
 use tempfile::TempDir;

--- a/mur-core/tests/versioned_yaml.rs
+++ b/mur-core/tests/versioned_yaml.rs
@@ -1,0 +1,227 @@
+//! Integration tests for `VersionedYamlStore` (E1 W1).
+//!
+//! Validates ADR-0001 FIN-1 through FIN-4 + basic CRUD.
+
+use mur_common::{knowledge::KnowledgeBase, pattern::{Content, Pattern}};
+use mur_core::store::versioned::VersionedYamlStore;
+use std::time::Instant;
+use tempfile::TempDir;
+
+fn temp_store() -> (TempDir, VersionedYamlStore) {
+    let dir = TempDir::new().unwrap();
+    let store = VersionedYamlStore::init(dir.path()).unwrap();
+    (dir, store)
+}
+
+fn minimal_pattern(name: &str, content: &str) -> Pattern {
+    Pattern {
+        base: KnowledgeBase {
+            name: name.to_string(),
+            content: Content::Plain(content.to_string()),
+            ..Default::default()
+        },
+        kind: None,
+        origin: None,
+        attachments: vec![],
+    }
+}
+
+// ── Basic CRUD ────────────────────────────────────────────────────────────────
+
+#[test]
+fn save_and_read_roundtrip() {
+    let (_dir, mut store) = temp_store();
+    let p = minimal_pattern("alpha", "alpha content v1");
+
+    let rev = store.save_pattern(&p, "init").unwrap();
+    assert_eq!(rev.version, 1);
+    assert_eq!(rev.name, "alpha");
+    assert!(!rev.sha.is_empty());
+
+    let loaded = store.read_pattern("alpha").unwrap().unwrap();
+    assert_eq!(loaded.name, "alpha");
+}
+
+#[test]
+fn read_missing_returns_none() {
+    let (_dir, store) = temp_store();
+    assert!(store.read_pattern("nonexistent").unwrap().is_none());
+}
+
+// ── FIN-2: O(1) version derivation ────────────────────────────────────────────
+
+#[test]
+fn version_increments_on_each_save() {
+    let (_dir, mut store) = temp_store();
+    let mut p = minimal_pattern("beta", "v1");
+
+    let r1 = store.save_pattern(&p, "init").unwrap();
+    assert_eq!(r1.version, 1);
+
+    p.base.description = "changed".to_string();
+    let r2 = store.save_pattern(&p, "update").unwrap();
+    assert_eq!(r2.version, 2);
+
+    p.base.description = "changed again".to_string();
+    let r3 = store.save_pattern(&p, "refine").unwrap();
+    assert_eq!(r3.version, 3);
+
+    assert_eq!(store.current_version("beta"), 3);
+}
+
+#[test]
+fn no_op_save_does_not_increment_version() {
+    let (_dir, mut store) = temp_store();
+    let p = minimal_pattern("gamma", "unchanged");
+
+    let r1 = store.save_pattern(&p, "init").unwrap();
+    let r2 = store.save_pattern(&p, "same content").unwrap();
+
+    assert_eq!(r1.version, 1);
+    assert_eq!(r2.version, 1, "no-op must not bump version");
+}
+
+// ── FIN-3: history reads from index (not git log) ─────────────────────────────
+
+#[test]
+fn history_populated_after_saves() {
+    let (_dir, mut store) = temp_store();
+    let mut p = minimal_pattern("delta", "v1");
+    store.save_pattern(&p, "init").unwrap();
+
+    p.base.description = "d2".to_string();
+    store.save_pattern(&p, "refine").unwrap();
+
+    let hist = store.history("delta").unwrap();
+    assert_eq!(hist.len(), 2);
+    assert_eq!(hist[0].version, 1);
+    assert_eq!(hist[0].reason, "init");
+    assert_eq!(hist[1].version, 2);
+    assert_eq!(hist[1].reason, "refine");
+}
+
+#[test]
+fn history_empty_for_unknown_pattern() {
+    let (_dir, store) = temp_store();
+    assert!(store.history("unknown").unwrap().is_empty());
+}
+
+#[test]
+fn history_fast_on_many_revisions() {
+    let (_dir, mut store) = temp_store();
+    let mut p = minimal_pattern("perf-target", "v0");
+
+    for i in 1..=50u32 {
+        p.base.description = format!("v{i}");
+        store.save_pattern(&p, &format!("rev {i}")).unwrap();
+    }
+
+    let t = Instant::now();
+    let hist = store.history("perf-target").unwrap();
+    let elapsed = t.elapsed();
+
+    assert_eq!(hist.len(), 50);
+    assert!(
+        elapsed.as_millis() < 100,
+        "history() took {}ms, expected < 100ms (FIN-3)",
+        elapsed.as_millis()
+    );
+}
+
+// ── Rollback ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn rollback_restores_content_as_new_version() {
+    let (_dir, mut store) = temp_store();
+    let mut p = minimal_pattern("epsilon", "original");
+
+    store.save_pattern(&p, "init").unwrap(); // v1 = "original"
+    p.base.description = "modified".to_string();
+    store.save_pattern(&p, "update").unwrap(); // v2 = "modified"
+
+    let rev = store.rollback_pattern("epsilon", 1).unwrap(); // v3 = rollback to v1
+    assert_eq!(rev.version, 3);
+
+    let loaded = store.read_pattern("epsilon").unwrap().unwrap();
+    // The rolled-back pattern should match v1's description
+    assert_ne!(loaded.description, "modified");
+}
+
+#[test]
+fn rollback_missing_version_errors() {
+    let (_dir, mut store) = temp_store();
+    let p = minimal_pattern("zeta", "content");
+    store.save_pattern(&p, "init").unwrap();
+
+    let err = store.rollback_pattern("zeta", 99).unwrap_err();
+    assert!(err.to_string().contains("no archived"));
+}
+
+// ── detect_external_change & rebuild_index ────────────────────────────────────
+
+#[test]
+fn detect_external_change_false_after_save() {
+    let (_dir, mut store) = temp_store();
+    let p = minimal_pattern("eta", "c");
+    store.save_pattern(&p, "init").unwrap();
+    // Index was written by save_pattern — head should match
+    assert!(!store.detect_external_change().unwrap());
+}
+
+#[test]
+fn rebuild_index_restores_history() {
+    let (_dir, mut store) = temp_store();
+    let mut p = minimal_pattern("theta", "v1");
+    store.save_pattern(&p, "init").unwrap();
+    p.base.description = "v2".to_string();
+    store.save_pattern(&p, "update").unwrap();
+
+    // Wipe the in-memory index and rebuild from git
+    store.rebuild_index().unwrap();
+
+    let hist = store.history("theta").unwrap();
+    assert_eq!(hist.len(), 2, "rebuild must recover 2 versions");
+    assert_eq!(hist[0].reason, "init");
+    assert_eq!(hist[1].reason, "update");
+}
+
+// ── FIN-4: gitignore correctness ──────────────────────────────────────────────
+
+#[test]
+fn gitignore_ignores_runtime_dirs() {
+    let (_dir, store) = temp_store();
+    let root = store.root();
+
+    let repo = git2::Repository::open(root).unwrap();
+
+    // These dirs must be ignored per knowledge.gitignore (bare patterns, FIN-4)
+    for path in [
+        "agents/some-agent/profile.yaml",
+        "session/active.json",
+        "cache/vectors.db",
+        "secrets/api.key",
+    ] {
+        assert!(
+            repo.is_path_ignored(path).unwrap_or(false),
+            "path '{path}' should be gitignored (FIN-4)"
+        );
+    }
+}
+
+#[test]
+fn gitignore_tracks_patterns_and_archive() {
+    let (_dir, store) = temp_store();
+    let root = store.root();
+    let repo = git2::Repository::open(root).unwrap();
+
+    for path in [
+        "patterns/my-pattern.yaml",
+        "archive/patterns/my-pattern/v1.yaml",
+        "workflows/my-workflow.yaml",
+    ] {
+        assert!(
+            !repo.is_path_ignored(path).unwrap_or(true),
+            "path '{path}' should NOT be gitignored"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **W1** `VersionedYamlStore` — git-backed knowledge layer at `~/.mur/.git`. Every `save_pattern` call produces one commit + O(1) index append. ADR-0001 compliant (FIN-1–4).
- **W2** `VersionedAgentStore` — git-backed execution layer at `~/.mur/agents/.git`. Same FIN rules + split-brain repair + `git subtree split` export for agent portability.
- **W3** CLI — `mur pattern history/diff/rollback`, `mur agent history/rollback`, `mur internals rebuild-index/git`.
- **Bootstrap** `mur reindex --bootstrap` — one-time command to initialise the knowledge git repo and commit all existing patterns. After this, every `YamlStore::save` auto-commits via the write path gate.

## User flow

```bash
mur reindex --bootstrap        # one-time: initialise + import existing patterns
mur pattern history my-pattern # shows versioned history
mur pattern diff my-pattern    # v(n-1) → v(n) diff
mur pattern rollback my-pattern --to 2  # restore to v2 as new commit
```

## Test plan

- [ ] `cargo test -p mur-core --test versioned_yaml` — 13 tests
- [ ] `cargo test -p mur-core --test versioned_agent` — 16 tests
- [ ] `cargo clippy -p mur-core -- -D warnings` — clean
- [ ] `mur reindex --bootstrap` on a real `~/.mur` dir
- [ ] `mur pattern history <existing-pattern>` shows v1 after bootstrap
- [ ] `mur pattern save` creates a new version automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)