### PR TITLE
feat(e1): schema-3 versioned store — version field + git-backed history

### DIFF
--- a/mur-core/src/context_api/mod.rs
+++ b/mur-core/src/context_api/mod.rs
@@ -136,6 +136,16 @@ pub fn retrieve(
     store: &YamlStore,
     vector_scores: Option<&std::collections::HashMap<String, f64>>,
 ) -> Result<ContextResponse> {
+    let config = load_config().unwrap_or_default();
+    retrieve_with_config(req, store, vector_scores, &config)
+}
+
+fn retrieve_with_config(
+    req: &ContextRequest,
+    store: &YamlStore,
+    vector_scores: Option<&std::collections::HashMap<String, f64>>,
+    config: &mur_common::config::Config,
+) -> Result<ContextResponse> {
     // Apply query gate
     if evaluate_query(&req.query).tier == GateTier::Skip {
         return Ok(ContextResponse {
@@ -153,7 +163,6 @@ pub fn retrieve(
     let filtered = apply_scope_filter(all_patterns, &req.scope, &req.source);
 
     // Score and rank using config-driven retrieval parameters
-    let config = load_config().unwrap_or_default();
     let scored = if let Some(vs) = vector_scores {
         score_and_rank_hybrid_with_config(&req.query, filtered, vs, &config.retrieval)
     } else {
@@ -488,7 +497,7 @@ mod tests {
             scope: ContextScope::default(),
             source: "test".into(),
         };
-        let resp = retrieve(&req, &store, None).unwrap();
+        let resp = retrieve_with_config(&req, &store, None, &mur_common::config::Config::default()).unwrap();
         assert!(!resp.patterns.is_empty());
         assert!(!resp.formatted.is_empty());
         assert!(!resp.injection_ids.is_empty());

--- a/mur-core/src/context_api/mod.rs
+++ b/mur-core/src/context_api/mod.rs
@@ -497,7 +497,8 @@ mod tests {
             scope: ContextScope::default(),
             source: "test".into(),
         };
-        let resp = retrieve_with_config(&req, &store, None, &mur_common::config::Config::default()).unwrap();
+        let resp = retrieve_with_config(&req, &store, None, &mur_common::config::Config::default())
+            .unwrap();
         assert!(!resp.patterns.is_empty());
         assert!(!resp.formatted.is_empty());
         assert!(!resp.injection_ids.is_empty());


### PR DESCRIPTION
## Summary

- **Schema-3**: add `version`, `revision`, `previous_revision` fields to `KnowledgeBase`; bump `SCHEMA_VERSION` to 3
- **VersionedYamlStore**: git-backed knowledge store with O(1) save, O(1) version derivation (FIN-1/2), and `.mur-versions.yaml` load-bearing index (FIN-3); hooks into `YamlStore::save` when `~/.mur/.git` exists
- **VersionedAgentStore**: same for `~/.mur/agents/.git`; gitignore uses bare patterns per FIN-4
- **CLI**: `mur pattern history/diff/rollback`, `mur agent history/rollback`, `mur internals git` (three-color allowlist: white/grey/black), `mur internals rebuild-index`
- **Daemon**: startup store health checks (fsck + HEAD vs index drift + gc scheduling); `mur internals git` allowlist enforcement
- **Tests**: 14 versioned_yaml + 18 versioned_agent integration tests; context_api test isolated from local `~/.mur/config.yaml`

## Test Plan

- [x] `cargo test --workspace` — 0 failures
- [x] `cargo clippy -p mur-core -p mur-common -p mur-agent-runtime -p mur-daemon -- -D warnings` — clean
- [x] `mur reindex --bootstrap` initialises `.git` and imports all patterns in one commit
- [x] `mur pattern history <name>` reads from `.mur-versions.yaml` index (< 100 ms on 1000-pattern × 3-revision repo)
- [x] `mur internals git --layer=knowledge log --oneline` works; `git reset --hard` blocked by allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)