### PR TITLE
feat(e4+e2): eval harness + Reflector/Curator

### DIFF
--- a/mur-common/src/model.rs
+++ b/mur-common/src/model.rs
@@ -31,11 +31,28 @@ pub struct ModelEntry {
     pub params: serde_json::Value,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct RoleEntry {
+    /// Registry model ID (key in `models:`) to use as primary.
+    pub primary: String,
+    /// Fallback model ID if primary is unavailable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fallback: Option<String>,
+    /// Optional daily cost cap in USD.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_budget_per_day_usd: Option<f64>,
+    /// If true, only use local models when handling sensitive data.
+    #[serde(default)]
+    pub privacy_local_only: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ModelRegistry {
     pub schema_version: u32,
     #[serde(default)]
     pub models: BTreeMap<String, ModelEntry>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub roles: BTreeMap<String, RoleEntry>,
 }
 
 impl Default for ModelRegistry {
@@ -43,6 +60,7 @@ impl Default for ModelRegistry {
         Self {
             schema_version: 1,
             models: BTreeMap::new(),
+            roles: BTreeMap::new(),
         }
     }
 }
@@ -80,6 +98,23 @@ impl ModelRegistry {
         }
         let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("no home dir"))?;
         Ok(home.join(".mur/models.yaml"))
+    }
+
+    /// Return the primary model ID for `role`, or the fallback if the primary
+    /// is not in the `models` map, or `None` if the role is not configured.
+    pub fn resolve_role(&self, role: &str) -> Option<&str> {
+        let entry = self.roles.get(role)?;
+        if self.models.contains_key(&entry.primary) {
+            return Some(&entry.primary);
+        }
+        // primary not in registry — try fallback
+        if let Some(fb) = &entry.fallback
+            && self.models.contains_key(fb)
+        {
+            return Some(fb);
+        }
+        // role configured but no available model
+        None
     }
 }
 
@@ -148,6 +183,83 @@ models:
 "#;
         let r: Result<ModelRegistry, _> = serde_yaml_ng::from_str(yaml);
         assert!(r.is_err(), "should reject unknown scheme");
+    }
+
+    #[test]
+    fn test_registry_roundtrip_with_roles() {
+        let yaml = r#"
+schema_version: 1
+models:
+  haiku:
+    provider: anthropic
+    model: claude-haiku-4-5
+roles:
+  reflector:
+    primary: haiku
+    fallback: null
+    cost_budget_per_day_usd: 0.5
+"#;
+        let reg: ModelRegistry = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(reg.roles["reflector"].primary, "haiku");
+        let back = serde_yaml_ng::to_string(&reg).unwrap();
+        let reg2: ModelRegistry = serde_yaml_ng::from_str(&back).unwrap();
+        assert_eq!(reg, reg2);
+    }
+
+    #[test]
+    fn test_resolve_role_primary() {
+        let mut reg = ModelRegistry::default();
+        reg.models.insert(
+            "haiku".into(),
+            ModelEntry {
+                provider: "anthropic".into(),
+                model: "claude-haiku-4-5".into(),
+                base_url: None,
+                secret: None,
+                capabilities: vec![],
+                params: serde_json::Value::Null,
+            },
+        );
+        reg.roles.insert(
+            "reflector".into(),
+            RoleEntry {
+                primary: "haiku".into(),
+                fallback: None,
+                ..Default::default()
+            },
+        );
+        assert_eq!(reg.resolve_role("reflector"), Some("haiku"));
+    }
+
+    #[test]
+    fn test_resolve_role_fallback() {
+        let mut reg = ModelRegistry::default();
+        reg.models.insert(
+            "haiku".into(),
+            ModelEntry {
+                provider: "anthropic".into(),
+                model: "claude-haiku-4-5".into(),
+                base_url: None,
+                secret: None,
+                capabilities: vec![],
+                params: serde_json::Value::Null,
+            },
+        );
+        reg.roles.insert(
+            "reflector".into(),
+            RoleEntry {
+                primary: "nonexistent".into(),
+                fallback: Some("haiku".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(reg.resolve_role("reflector"), Some("haiku"));
+    }
+
+    #[test]
+    fn test_resolve_role_none() {
+        let reg = ModelRegistry::default();
+        assert_eq!(reg.resolve_role("reflector"), None);
     }
 }
 

--- a/mur-core/src/capture/curator.rs
+++ b/mur-core/src/capture/curator.rs
@@ -1,0 +1,262 @@
+//! Curator — applies Reflector deltas to the YAML pattern store.
+//!
+//! `curate` groups `ReflectResult`s by pattern name, detects conflicts
+//! (both Reinforced and Contradicted in the same session), and writes
+//! updated confidence + evidence signals back to the store.
+
+use crate::capture::feedback::SignalType;
+use crate::capture::reflector::ReflectResult;
+use crate::store::yaml::YamlStore;
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+/// A pattern that received conflicting signals in the same session.
+#[derive(Debug, Clone)]
+pub struct Conflict {
+    pub pattern_name: String,
+    pub reason: String,
+}
+
+/// Summary returned by `curate`.
+#[derive(Debug, Default)]
+pub struct CuratorResult {
+    /// Pattern names whose confidence was updated (or would be, in dry-run).
+    pub updated: Vec<String>,
+    /// Patterns that had conflicting signals; they are still updated.
+    pub conflicts: Vec<Conflict>,
+    /// Pattern names that were skipped (not in store, or all-Ignored).
+    pub skipped: Vec<String>,
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+/// Apply Reflector deltas to the YAML store.
+///
+/// * Groups deltas by `pattern_name`.
+/// * Skips patterns not present in the store.
+/// * Detects conflicts (Reinforced + Contradicted in the same session).
+/// * Applies net `confidence_delta`, clamped to `[0.0, 1.0]`.
+/// * Updates `evidence.success_signals` / `evidence.override_signals`.
+/// * When `dry_run` is `true`, computes everything but skips `store.save`.
+pub fn curate(
+    deltas: &[ReflectResult],
+    store: &mut YamlStore,
+    dry_run: bool,
+) -> anyhow::Result<CuratorResult> {
+    use std::collections::HashMap;
+
+    // Group deltas by pattern name, preserving order of first occurrence.
+    let mut groups: HashMap<String, Vec<&ReflectResult>> = HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+    for delta in deltas {
+        let entry = groups.entry(delta.pattern_name.clone()).or_insert_with(|| {
+            order.push(delta.pattern_name.clone());
+            Vec::new()
+        });
+        entry.push(delta);
+    }
+
+    let mut result = CuratorResult::default();
+
+    for name in &order {
+        let group = &groups[name];
+
+        // Partition by signal type.
+        let non_ignored: Vec<&&ReflectResult> = group
+            .iter()
+            .filter(|d| d.signal != SignalType::Ignored)
+            .collect();
+
+        if non_ignored.is_empty() {
+            // All signals are Ignored — skip.
+            if !result.skipped.contains(name) {
+                result.skipped.push(name.clone());
+            }
+            continue;
+        }
+
+        // Check if pattern exists in the store.
+        if !store.exists(name) {
+            result.skipped.push(name.clone());
+            continue;
+        }
+
+        // Conflict detection.
+        let has_reinforced = non_ignored
+            .iter()
+            .any(|d| d.signal == SignalType::Reinforced);
+        let has_contradicted = non_ignored
+            .iter()
+            .any(|d| d.signal == SignalType::Contradicted);
+        if has_reinforced && has_contradicted {
+            result.conflicts.push(Conflict {
+                pattern_name: name.clone(),
+                reason: "conflicting signals: reinforced and contradicted in same session"
+                    .to_string(),
+            });
+        }
+
+        // Net confidence delta (sum all non-ignored deltas).
+        let net_delta: f32 = non_ignored.iter().map(|d| d.confidence_delta).sum();
+
+        // Load, mutate, optionally save.
+        let mut pattern = store.get(name)?;
+        pattern.base.confidence = (pattern.base.confidence + net_delta as f64).clamp(0.0, 1.0);
+
+        for delta in &non_ignored {
+            match delta.signal {
+                SignalType::Reinforced => pattern.base.evidence.success_signals += 1,
+                SignalType::Contradicted => pattern.base.evidence.override_signals += 1,
+                SignalType::Ignored => {}
+            }
+        }
+
+        if !dry_run {
+            store.save(&pattern)?;
+        }
+
+        result.updated.push(name.clone());
+    }
+
+    Ok(result)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capture::feedback::SignalType;
+    use mur_common::knowledge::KnowledgeBase;
+    use mur_common::pattern::Pattern;
+    use tempfile::TempDir;
+
+    fn make_store(dir: &TempDir) -> YamlStore {
+        YamlStore::new(dir.path().to_path_buf()).unwrap()
+    }
+
+    fn make_pattern(name: &str) -> Pattern {
+        let mut kb = KnowledgeBase::default();
+        kb.name = name.to_string();
+        kb.description = "test".to_string();
+        kb.confidence = 0.5;
+        Pattern {
+            base: kb,
+            kind: None,
+            origin: None,
+            attachments: Vec::new(),
+        }
+    }
+
+    fn make_delta(name: &str, signal: SignalType, delta: f32) -> ReflectResult {
+        ReflectResult {
+            pattern_name: name.to_string(),
+            signal,
+            evidence: None,
+            confidence_delta: delta,
+            llm_used: false,
+        }
+    }
+
+    #[test]
+    fn test_curate_reinforced_updates_confidence() {
+        let dir = TempDir::new().unwrap();
+        let mut store = make_store(&dir);
+        let p = make_pattern("test-pattern");
+        store.save(&p).unwrap();
+        let deltas = vec![make_delta("test-pattern", SignalType::Reinforced, 0.05)];
+        let result = curate(&deltas, &mut store, false).unwrap();
+        assert!(result.updated.contains(&"test-pattern".to_string()));
+        let updated = store.get("test-pattern").unwrap();
+        assert!(updated.confidence > 0.5);
+    }
+
+    #[test]
+    fn test_curate_ignored_goes_to_skipped() {
+        let dir = TempDir::new().unwrap();
+        let mut store = make_store(&dir);
+        let p = make_pattern("test-pattern");
+        store.save(&p).unwrap();
+        let deltas = vec![make_delta("test-pattern", SignalType::Ignored, -0.01)];
+        let result = curate(&deltas, &mut store, false).unwrap();
+        assert!(result.skipped.contains(&"test-pattern".to_string()));
+        assert!(result.updated.is_empty());
+    }
+
+    #[test]
+    fn test_curate_conflict_detected() {
+        let dir = TempDir::new().unwrap();
+        let mut store = make_store(&dir);
+        let p = make_pattern("test-pattern");
+        store.save(&p).unwrap();
+        let deltas = vec![
+            make_delta("test-pattern", SignalType::Reinforced, 0.05),
+            make_delta("test-pattern", SignalType::Contradicted, -0.10),
+        ];
+        let result = curate(&deltas, &mut store, false).unwrap();
+        assert!(!result.conflicts.is_empty());
+        assert!(result.updated.contains(&"test-pattern".to_string()));
+    }
+
+    #[test]
+    fn test_curate_dry_run_no_save() {
+        let dir = TempDir::new().unwrap();
+        let mut store = make_store(&dir);
+        let p = make_pattern("test-pattern");
+        store.save(&p).unwrap();
+        let deltas = vec![make_delta("test-pattern", SignalType::Reinforced, 0.05)];
+        let result = curate(&deltas, &mut store, true).unwrap();
+        assert!(!result.updated.is_empty());
+        // Confidence should NOT change on disk in dry-run.
+        let unchanged = store.get("test-pattern").unwrap();
+        assert!((unchanged.confidence - 0.5).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_curate_missing_pattern_skipped() {
+        let dir = TempDir::new().unwrap();
+        let mut store = make_store(&dir);
+        let deltas = vec![make_delta("nonexistent", SignalType::Reinforced, 0.05)];
+        let result = curate(&deltas, &mut store, false).unwrap();
+        assert!(result.skipped.contains(&"nonexistent".to_string()));
+        assert!(result.updated.is_empty());
+    }
+
+    #[test]
+    fn test_curate_clamps_confidence_to_one() {
+        let dir = TempDir::new().unwrap();
+        let mut store = make_store(&dir);
+        let mut p = make_pattern("test-pattern");
+        p.base.confidence = 0.99;
+        store.save(&p).unwrap();
+        let deltas = vec![make_delta("test-pattern", SignalType::Reinforced, 0.2)];
+        let result = curate(&deltas, &mut store, false).unwrap();
+        assert!(!result.updated.is_empty());
+        let updated = store.get("test-pattern").unwrap();
+        assert!(updated.confidence <= 1.0);
+    }
+
+    #[test]
+    fn test_curate_updates_success_signals() {
+        let dir = TempDir::new().unwrap();
+        let mut store = make_store(&dir);
+        let p = make_pattern("test-pattern");
+        store.save(&p).unwrap();
+        let deltas = vec![make_delta("test-pattern", SignalType::Reinforced, 0.05)];
+        curate(&deltas, &mut store, false).unwrap();
+        let updated = store.get("test-pattern").unwrap();
+        assert_eq!(updated.base.evidence.success_signals, 1);
+    }
+
+    #[test]
+    fn test_curate_updates_override_signals() {
+        let dir = TempDir::new().unwrap();
+        let mut store = make_store(&dir);
+        let p = make_pattern("test-pattern");
+        store.save(&p).unwrap();
+        let deltas = vec![make_delta("test-pattern", SignalType::Contradicted, -0.10)];
+        curate(&deltas, &mut store, false).unwrap();
+        let updated = store.get("test-pattern").unwrap();
+        assert_eq!(updated.base.evidence.override_signals, 1);
+    }
+}

--- a/mur-core/src/capture/mod.rs
+++ b/mur-core/src/capture/mod.rs
@@ -2,6 +2,7 @@
 //
 // The learning pipeline: noise filter → significance → extractor → dedup → verify → link
 
+pub mod curator;
 pub mod emergence;
 pub mod feedback;
 pub mod import;
@@ -9,6 +10,5 @@ pub mod noise_filter;
 pub mod reflector;
 pub mod starter;
 
-#[allow(unused_imports)]
-pub use reflector::{ReflectResult, reflect_session};
-// pub mod style; // removed: entire module was dead code (never called from main)
+pub use curator::curate;
+pub use reflector::reflect_session;

--- a/mur-core/src/capture/mod.rs
+++ b/mur-core/src/capture/mod.rs
@@ -6,5 +6,9 @@ pub mod emergence;
 pub mod feedback;
 pub mod import;
 pub mod noise_filter;
+pub mod reflector;
 pub mod starter;
+
+#[allow(unused_imports)]
+pub use reflector::{ReflectResult, reflect_session};
 // pub mod style; // removed: entire module was dead code (never called from main)

--- a/mur-core/src/capture/reflector.rs
+++ b/mur-core/src/capture/reflector.rs
@@ -1,0 +1,370 @@
+//! LLM-backed session reflector with heuristic fallback.
+//!
+//! `reflect_session` checks the `ModelRegistry` for a "reflector" role. If
+//! one is configured, it calls the designated model (Anthropic or Ollama) to
+//! score injected patterns against the transcript. On any error — missing API
+//! key, network failure, JSON parse error — it falls back to the pure-keyword
+//! heuristic in `capture::feedback`.
+//!
+//! The module is part of the E2 library surface; `reflect_session` is not yet
+//! called from the CLI binary, so dead_code is expected until E2.3 wires it in.
+
+#![allow(dead_code)]
+
+use mur_common::model::{ModelEntry, ModelRegistry};
+use mur_common::secret::SecretRef;
+use serde::Deserialize;
+
+use crate::capture::feedback::{InjectedPatternRecord, SessionFeedback, SignalType};
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+/// Result of reflecting a single injected pattern against a session transcript.
+#[derive(Debug, Clone)]
+pub struct ReflectResult {
+    pub pattern_name: String,
+    pub signal: SignalType,
+    pub evidence: Option<String>,
+    pub confidence_delta: f32,
+    /// `true` when the result came from an LLM call, `false` for heuristic.
+    pub llm_used: bool,
+}
+
+// ─── Main entry point ─────────────────────────────────────────────────────────
+
+/// Reflect a session transcript against a set of injected patterns.
+///
+/// Uses the model registered under the "reflector" role when available;
+/// otherwise falls back to the keyword-matching heuristic in `feedback`.
+pub fn reflect_session(
+    transcript: &str,
+    injected: &[InjectedPatternRecord],
+    registry: &ModelRegistry,
+) -> Vec<ReflectResult> {
+    if injected.is_empty() {
+        return Vec::new();
+    }
+
+    // Try LLM path if a "reflector" role is configured and resolvable.
+    if let Some(model_id) = registry.resolve_role("reflector")
+        && let Some(entry) = registry.models.get(model_id)
+    {
+        let pattern_names: Vec<String> = injected.iter().map(|r| r.name.clone()).collect();
+        match call_llm(transcript, &pattern_names, entry) {
+            Ok(results) if !results.is_empty() => return results,
+            Ok(_) => {
+                tracing::debug!("reflector: LLM returned empty result, using heuristic");
+            }
+            Err(e) => {
+                tracing::debug!("reflector: LLM call failed ({e}), using heuristic");
+            }
+        }
+    }
+
+    heuristic_fallback(transcript, injected)
+}
+
+// ─── Heuristic fallback ───────────────────────────────────────────────────────
+
+fn heuristic_fallback(transcript: &str, injected: &[InjectedPatternRecord]) -> Vec<ReflectResult> {
+    crate::capture::feedback::analyze_session_feedback(transcript, injected)
+        .into_iter()
+        .map(|sf: SessionFeedback| ReflectResult {
+            pattern_name: sf.pattern_name,
+            signal: sf.signal,
+            evidence: sf.evidence,
+            confidence_delta: sf.confidence_delta as f32,
+            llm_used: false,
+        })
+        .collect()
+}
+
+// ─── LLM call ─────────────────────────────────────────────────────────────────
+
+/// Shape returned by the LLM in the JSON array.
+#[derive(Debug, Deserialize)]
+struct LlmItem {
+    name: String,
+    signal: String,
+    #[serde(default)]
+    evidence: Option<String>,
+    #[serde(default)]
+    confidence_delta: f32,
+}
+
+fn call_llm(
+    transcript: &str,
+    pattern_names: &[String],
+    entry: &ModelEntry,
+) -> anyhow::Result<Vec<ReflectResult>> {
+    let system = "You are a pattern quality evaluator. \
+        Analyze AI session transcripts and return JSON.";
+
+    let snippet = if transcript.len() > 200 {
+        &transcript[..200]
+    } else {
+        transcript
+    };
+
+    let names_list = pattern_names.join(", ");
+    let user = format!(
+        "Patterns injected: {names_list}.\n\
+        Transcript excerpt: {snippet}\n\n\
+        Return a JSON array (no prose, no markdown) with one object per pattern:\n\
+        [{{\"name\":\"<pattern_name>\",\
+        \"signal\":\"reinforced\"|\"contradicted\"|\"ignored\",\
+        \"evidence\":\"<quote or null>\",\
+        \"confidence_delta\":<float -0.2 to 0.2>}}]"
+    );
+
+    let raw = match entry.provider.as_str() {
+        "ollama" => call_ollama(&entry.model, entry.base_url.as_deref(), system, &user)?,
+        _ => call_anthropic(&entry.model, entry.secret.as_ref(), system, &user)?,
+    };
+
+    Ok(parse_llm_json(&raw, pattern_names))
+}
+
+fn call_anthropic(
+    model: &str,
+    secret: Option<&SecretRef>,
+    system: &str,
+    user: &str,
+) -> anyhow::Result<String> {
+    // Only SecretRef::Env is supported here; full resolution requires async.
+    let api_key = if let Some(SecretRef::Env(var)) = secret {
+        std::env::var(var).ok()
+    } else {
+        None
+    }
+    .or_else(|| std::env::var("ANTHROPIC_API_KEY").ok())
+    .ok_or_else(|| anyhow::anyhow!("no Anthropic API key available"))?;
+
+    let base = std::env::var("ANTHROPIC_BASE_URL")
+        .unwrap_or_else(|_| "https://api.anthropic.com".to_string());
+
+    let body = serde_json::json!({
+        "model": model,
+        "max_tokens": 1024,
+        "system": system,
+        "messages": [{"role": "user", "content": user}]
+    });
+
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .post(format!("{base}/v1/messages"))
+        .header("x-api-key", &api_key)
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().unwrap_or_default();
+        anyhow::bail!("Anthropic API error {status}: {text}");
+    }
+
+    let json: serde_json::Value = resp.json()?;
+    json["content"]
+        .as_array()
+        .and_then(|arr| arr.first())
+        .and_then(|item| item["text"].as_str())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("unexpected Anthropic response shape"))
+}
+
+fn call_ollama(
+    model: &str,
+    base_url: Option<&str>,
+    system: &str,
+    user: &str,
+) -> anyhow::Result<String> {
+    let base = base_url.unwrap_or("http://localhost:11434");
+
+    let body = serde_json::json!({
+        "model": model,
+        "stream": false,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user",   "content": user}
+        ]
+    });
+
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .post(format!("{base}/api/chat"))
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().unwrap_or_default();
+        anyhow::bail!("Ollama API error {status}: {text}");
+    }
+
+    let json: serde_json::Value = resp.json()?;
+    json["message"]["content"]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("unexpected Ollama response shape"))
+}
+
+// ─── JSON parser (pub(crate) for tests) ───────────────────────────────────────
+
+/// Parse the LLM JSON array into `ReflectResult`s.
+///
+/// Returns an empty vec on any parse error; the caller then falls back to
+/// the heuristic.
+pub(crate) fn parse_llm_json(raw: &str, pattern_names: &[String]) -> Vec<ReflectResult> {
+    // Strip markdown code fences if the model wrapped the JSON.
+    let trimmed = raw
+        .trim()
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+
+    // Try to find the JSON array even if there's surrounding prose.
+    let json_start = trimmed.find('[').unwrap_or(0);
+    let json_end = trimmed.rfind(']').map(|i| i + 1).unwrap_or(trimmed.len());
+    let json_slice = &trimmed[json_start..json_end];
+
+    let items: Vec<LlmItem> = match serde_json::from_str(json_slice) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    items
+        .into_iter()
+        .filter(|item| pattern_names.iter().any(|n| n == &item.name))
+        .map(|item| ReflectResult {
+            pattern_name: item.name,
+            signal: parse_signal(&item.signal),
+            evidence: item.evidence,
+            confidence_delta: item.confidence_delta.clamp(-0.2, 0.2),
+            llm_used: true,
+        })
+        .collect()
+}
+
+fn parse_signal(s: &str) -> SignalType {
+    match s.to_lowercase().as_str() {
+        "reinforced" => SignalType::Reinforced,
+        "contradicted" => SignalType::Contradicted,
+        _ => SignalType::Ignored,
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::model::ModelRegistry;
+
+    fn make_injected(name: &str) -> InjectedPatternRecord {
+        InjectedPatternRecord {
+            name: name.to_string(),
+            snippet: "use async/await".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_heuristic_fallback_no_role() {
+        // Empty registry → no reflector role → heuristic path.
+        let registry = ModelRegistry::default();
+        let results = reflect_session(
+            "some transcript with async/await usage",
+            &[make_injected("rust-async")],
+            &registry,
+        );
+        assert!(!results.is_empty());
+        assert!(
+            !results[0].llm_used,
+            "should use heuristic when no role configured"
+        );
+    }
+
+    #[test]
+    fn test_parse_llm_json_response() {
+        let json = r#"[{"name":"rust-async","signal":"reinforced","evidence":"used async/await","confidence_delta":0.05}]"#;
+        let parsed = parse_llm_json(json, &["rust-async".to_string()]);
+        assert_eq!(parsed.len(), 1);
+        assert!(matches!(parsed[0].signal, SignalType::Reinforced));
+        assert!(parsed[0].llm_used);
+        assert!((parsed[0].confidence_delta - 0.05).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_parse_llm_json_invalid_falls_back_to_empty() {
+        let parsed = parse_llm_json("not valid json", &["rust-async".to_string()]);
+        assert!(
+            parsed.is_empty(),
+            "invalid JSON should produce empty vec for heuristic fallback"
+        );
+    }
+
+    #[test]
+    fn test_parse_llm_json_contradicted() {
+        let json = r#"[{"name":"old-api","signal":"contradicted","evidence":"don't use this","confidence_delta":-0.15}]"#;
+        let parsed = parse_llm_json(json, &["old-api".to_string()]);
+        assert_eq!(parsed.len(), 1);
+        assert!(matches!(parsed[0].signal, SignalType::Contradicted));
+        assert_eq!(parsed[0].evidence.as_deref(), Some("don't use this"));
+    }
+
+    #[test]
+    fn test_parse_llm_json_ignored() {
+        let json = r#"[{"name":"pat","signal":"ignored","confidence_delta":-0.01}]"#;
+        let parsed = parse_llm_json(json, &["pat".to_string()]);
+        assert_eq!(parsed.len(), 1);
+        assert!(matches!(parsed[0].signal, SignalType::Ignored));
+    }
+
+    #[test]
+    fn test_parse_llm_json_strips_markdown_fences() {
+        let json =
+            "```json\n[{\"name\":\"p\",\"signal\":\"reinforced\",\"confidence_delta\":0.1}]\n```";
+        let parsed = parse_llm_json(json, &["p".to_string()]);
+        assert_eq!(parsed.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_llm_json_unknown_pattern_filtered() {
+        // Names not in the allow-list should be silently dropped.
+        let json = r#"[{"name":"unknown","signal":"reinforced","confidence_delta":0.1}]"#;
+        let parsed = parse_llm_json(json, &["known-pattern".to_string()]);
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn test_confidence_delta_clamped() {
+        let json = r#"[{"name":"p","signal":"reinforced","confidence_delta":9.9}]"#;
+        let parsed = parse_llm_json(json, &["p".to_string()]);
+        assert_eq!(parsed.len(), 1);
+        assert!(
+            parsed[0].confidence_delta <= 0.2,
+            "delta should be clamped to 0.2"
+        );
+    }
+
+    #[test]
+    fn test_empty_injected_returns_empty() {
+        let registry = ModelRegistry::default();
+        let results = reflect_session("some transcript", &[], &registry);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_heuristic_reinforced_signal() {
+        let registry = ModelRegistry::default();
+        let transcript = "The async/await pattern worked perfectly here.";
+        let injected = vec![make_injected("rust-async")];
+        let results = reflect_session(transcript, &injected, &registry);
+        assert_eq!(results.len(), 1);
+        assert!(matches!(results[0].signal, SignalType::Reinforced));
+        assert!(!results[0].llm_used);
+    }
+}

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -264,6 +264,9 @@ pub enum SessionAction {
         /// Run fingerprint extraction on the recording
         #[arg(long)]
         analyze: bool,
+        /// Run Reflector+Curator: update pattern confidence from session transcript.
+        #[arg(long)]
+        reflect: bool,
     },
     /// Record an event to the active session
     Record {
@@ -318,6 +321,15 @@ pub enum SessionAction {
         /// Push all unsynced sessions
         #[arg(long)]
         all: bool,
+    },
+    /// Reflect + curate the last session transcript (E2).
+    ///
+    /// Runs the Reflector+Curator pipeline on the most recent recording:
+    /// updates pattern confidence and evidence signals based on usage signals.
+    Reflect {
+        /// Preview changes without saving to the pattern store.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -611,3 +611,15 @@ pub enum DeployAction {
         file: Option<String>,
     },
 }
+
+#[derive(Subcommand)]
+pub enum EvalAction {
+    /// Run a named eval suite
+    Run {
+        /// Suite name: retrieval | maturity | reflector | federation
+        suite: String,
+        /// Output format: text (default) | json
+        #[arg(long, default_value = "text")]
+        format: String,
+    },
+}

--- a/mur-core/src/cli/mod.rs
+++ b/mur-core/src/cli/mod.rs
@@ -419,4 +419,9 @@ pub enum Commands {
         #[command(subcommand)]
         action: InternalsAction,
     },
+    /// Run an eval suite against the local pattern store
+    Eval {
+        #[command(subcommand)]
+        action: EvalAction,
+    },
 }

--- a/mur-core/src/cmd/eval.rs
+++ b/mur-core/src/cmd/eval.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use mur_common::config::RetrievalConfig;
 use mur_common::knowledge::KnowledgeBase;
 use mur_common::pattern::{Content, Pattern, Tier};
@@ -24,11 +24,19 @@ pub fn cmd_eval_run(suite: &str, format: &str) -> Result<i32> {
             println!("federation suite not yet implemented (E6 dependency)");
             Ok(0)
         }
-        other => bail!("unknown suite '{other}' — valid: retrieval, maturity, reflector, federation"),
+        other => {
+            bail!("unknown suite '{other}' — valid: retrieval, maturity, reflector, federation")
+        }
     }
 }
 
-fn make_pattern(name: &str, description: &str, content: &str, tier: Tier, importance: f64) -> Pattern {
+fn make_pattern(
+    name: &str,
+    description: &str,
+    content: &str,
+    tier: Tier,
+    importance: f64,
+) -> Pattern {
     Pattern {
         base: KnowledgeBase {
             name: name.to_string(),
@@ -46,12 +54,48 @@ fn make_pattern(name: &str, description: &str, content: &str, tier: Tier, import
 
 fn seed_patterns() -> Vec<(&'static str, &'static str, &'static str, Tier, f64)> {
     vec![
-        ("swift-testing", "Use @Test macro for Swift unit tests", "Use @Test macro instead of XCTest for Swift Testing framework", Tier::Project, 0.8),
-        ("rust-error-handling", "Use anyhow for error propagation in Rust binaries", "Use anyhow::Result for application-level error handling", Tier::Core, 0.9),
-        ("prefer-chinese", "Reply in Traditional Chinese", "Always respond to the user in Traditional Chinese (zh-TW)", Tier::Core, 0.9),
-        ("git-commit-format", "Conventional commit messages", "Use conventional commits: feat/fix/docs/refactor scope message", Tier::Project, 0.7),
-        ("no-comments", "Avoid unnecessary code comments", "Do not add comments unless the WHY is non-obvious", Tier::Core, 0.8),
-        ("test-before-commit", "Run tests before committing", "Always run cargo test --workspace before creating a git commit", Tier::Project, 0.8),
+        (
+            "swift-testing",
+            "Use @Test macro for Swift unit tests",
+            "Use @Test macro instead of XCTest for Swift Testing framework",
+            Tier::Project,
+            0.8,
+        ),
+        (
+            "rust-error-handling",
+            "Use anyhow for error propagation in Rust binaries",
+            "Use anyhow::Result for application-level error handling",
+            Tier::Core,
+            0.9,
+        ),
+        (
+            "prefer-chinese",
+            "Reply in Traditional Chinese",
+            "Always respond to the user in Traditional Chinese (zh-TW)",
+            Tier::Core,
+            0.9,
+        ),
+        (
+            "git-commit-format",
+            "Conventional commit messages",
+            "Use conventional commits: feat/fix/docs/refactor scope message",
+            Tier::Project,
+            0.7,
+        ),
+        (
+            "no-comments",
+            "Avoid unnecessary code comments",
+            "Do not add comments unless the WHY is non-obvious",
+            Tier::Core,
+            0.8,
+        ),
+        (
+            "test-before-commit",
+            "Run tests before committing",
+            "Always run cargo test --workspace before creating a git commit",
+            Tier::Project,
+            0.8,
+        ),
     ]
 }
 
@@ -60,7 +104,10 @@ fn test_queries() -> Vec<(&'static str, &'static str)> {
         ("swift @Test macro unit test", "swift-testing"),
         ("rust error handling anyhow result", "rust-error-handling"),
         ("reply language traditional chinese zh-TW", "prefer-chinese"),
-        ("git commit conventional format feat fix", "git-commit-format"),
+        (
+            "git commit conventional format feat fix",
+            "git-commit-format",
+        ),
         ("code comments documentation why", "no-comments"),
     ]
 }
@@ -120,7 +167,10 @@ fn run_retrieval_eval(format: &str) -> Result<i32> {
 
     for (query, expected) in &queries {
         let scored = score_and_rank_with_config(query, patterns.clone(), &config);
-        let rank = scored.iter().position(|sp| sp.pattern.name == *expected).map(|i| i + 1);
+        let rank = scored
+            .iter()
+            .position(|sp| sp.pattern.name == *expected)
+            .map(|i| i + 1);
         let hit = rank.is_some();
         if hit {
             hits += 1;
@@ -168,13 +218,8 @@ fn run_retrieval_eval(format: &str) -> Result<i32> {
                 None => "absent".to_string(),
             };
             let mark = if r.hit { "✓" } else { "✗" };
-            if r.hit {
-                println!("query: {:?}", r.query);
-                println!("  expected: {}  rank: {}  {}", r.expected, rank_str, mark);
-            } else {
-                println!("query: {:?}", r.query);
-                println!("  expected: {}  ✗ (rank {} or absent)", r.expected, rank_str);
-            }
+            println!("query: {:?}", r.query);
+            println!("  expected: {}  {} (rank {})", r.expected, mark, rank_str);
         }
         println!("{}", "─".repeat(30));
         let pass_str = if pass { "✓ PASS" } else { "✗ FAIL" };
@@ -201,6 +246,9 @@ mod tests {
         let err = cmd_eval_run("bogus", "text");
         assert!(err.is_err(), "unknown suite should return an error");
         let msg = err.unwrap_err().to_string();
-        assert!(msg.contains("unknown suite"), "error message should mention 'unknown suite'");
+        assert!(
+            msg.contains("unknown suite"),
+            "error message should mention 'unknown suite'"
+        );
     }
 }

--- a/mur-core/src/cmd/eval.rs
+++ b/mur-core/src/cmd/eval.rs
@@ -1,21 +1,20 @@
 use anyhow::{Result, bail};
+use chrono::{Duration, Utc};
 use mur_common::config::RetrievalConfig;
-use mur_common::knowledge::KnowledgeBase;
+use mur_common::knowledge::{KnowledgeBase, Maturity};
 use mur_common::pattern::{Content, Pattern, Tier};
 use serde::Serialize;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::evolve::maturity::evaluate_maturity;
 use crate::retrieve::scoring::score_and_rank_with_config;
 use crate::store::yaml::YamlStore;
 
 pub fn cmd_eval_run(suite: &str, format: &str) -> Result<i32> {
     match suite {
         "retrieval" => run_retrieval_eval(format),
-        "maturity" => {
-            println!("maturity suite not yet implemented");
-            Ok(0)
-        }
+        "maturity" => run_maturity_eval(format),
         "reflector" => {
             println!("reflector suite not yet implemented (E2 dependency)");
             Ok(0)
@@ -231,9 +230,135 @@ fn run_retrieval_eval(format: &str) -> Result<i32> {
     Ok(if pass { 0 } else { 1 })
 }
 
+fn new_pattern(name: &str) -> Pattern {
+    Pattern {
+        base: KnowledgeBase {
+            name: name.to_string(),
+            description: "eval test pattern".to_string(),
+            content: Content::Plain("test".to_string()),
+            tier: Tier::Session,
+            ..Default::default()
+        },
+        kind: None,
+        origin: None,
+        attachments: vec![],
+    }
+}
+
+fn run_maturity_eval(_format: &str) -> Result<i32> {
+    let now = Utc::now();
+    let mut results: Vec<(&'static str, bool, String)> = Vec::new();
+
+    // ── Test 1: Draft baseline ──────────────────────────────────────────
+    // New pattern with default evidence → maturity stays Draft (evaluate returns None)
+    {
+        let p = new_pattern("draft-baseline");
+        let outcome = evaluate_maturity(&p, now);
+        let pass = p.maturity == Maturity::Draft && outcome.is_none();
+        let detail = if pass {
+            String::new()
+        } else {
+            format!("expected Draft/None, got {:?}/{:?}", p.maturity, outcome)
+        };
+        results.push(("draft baseline", pass, detail));
+    }
+
+    // ── Test 2: Emerging promotion ──────────────────────────────────────
+    // Draft pattern with injection_count >= 3 and override_signals == 0 → Emerging
+    {
+        let mut p = new_pattern("emerging-promotion");
+        p.maturity = Maturity::Draft;
+        p.evidence.injection_count = 3;
+        p.evidence.success_signals = 3;
+        p.evidence.override_signals = 0;
+
+        let outcome = evaluate_maturity(&p, now);
+        let pass = outcome == Some(Maturity::Emerging);
+        let detail = if pass {
+            String::new()
+        } else {
+            format!("expected Some(Emerging), got {:?}", outcome)
+        };
+        results.push(("emerging promotion", pass, detail));
+    }
+
+    // ── Test 3: Stable promotion ────────────────────────────────────────
+    // Emerging pattern: injection_count >= 10, effectiveness >= 0.6, age >= 7 days → Stable
+    {
+        let mut p = new_pattern("stable-promotion");
+        p.maturity = Maturity::Emerging;
+        p.evidence.injection_count = 10;
+        // effectiveness = 8/(8+2) = 0.8 >= 0.6
+        p.evidence.success_signals = 8;
+        p.evidence.override_signals = 2;
+        // age = 10 days >= 7
+        p.created_at = now - Duration::days(10);
+
+        let outcome = evaluate_maturity(&p, now);
+        let pass = outcome == Some(Maturity::Stable);
+        let detail = if pass {
+            String::new()
+        } else {
+            format!("expected Some(Stable), got {:?}", outcome)
+        };
+        results.push(("stable promotion", pass, detail));
+    }
+
+    // ── Test 4: No-op at Stable ─────────────────────────────────────────
+    // Stable pattern with insufficient signals for Canonical and good enough
+    // effectiveness to avoid demotion → stays Stable (evaluate returns None)
+    {
+        let mut p = new_pattern("stable-noop");
+        p.maturity = Maturity::Stable;
+        // effectiveness = 7/(7+3) = 0.7 >= 0.4 (no demotion)
+        p.evidence.success_signals = 7;
+        p.evidence.override_signals = 3;
+        p.evidence.injection_count = 5; // < 30 (no promotion to Canonical)
+        p.lifecycle.pinned = false;
+        // recent activity so not considered inactive
+        p.lifecycle.last_injected = Some(now);
+        p.created_at = now - Duration::days(10);
+
+        let outcome = evaluate_maturity(&p, now);
+        let pass = outcome.is_none();
+        let detail = if pass {
+            String::new()
+        } else {
+            format!("expected None (no-op), got {:?}", outcome)
+        };
+        results.push(("no-op at stable", pass, detail));
+    }
+
+    // ── Report ───────────────────────────────────────────────────────────
+    let total = results.len();
+    let passed = results.iter().filter(|(_, ok, _)| *ok).count();
+    let all_pass = passed == total;
+
+    println!("mur eval — maturity suite");
+    println!("{}", "═".repeat(30));
+    for (name, ok, detail) in &results {
+        if *ok {
+            println!("  ✓ {name}");
+        } else {
+            println!("  ✗ {name}: {detail}");
+        }
+    }
+    println!("{}", "─".repeat(30));
+    let status = if all_pass { "PASS" } else { "FAIL" };
+    println!("maturity: {passed}/{total}  {status}");
+
+    Ok(if all_pass { 0 } else { 1 })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_maturity_eval_pass() {
+        let code = cmd_eval_run("maturity", "text").expect("maturity eval should not error");
+        assert_eq!(code, 0, "maturity eval should pass (all smoke tests)");
+    }
 
     #[test]
     fn test_retrieval_eval_pass() {

--- a/mur-core/src/cmd/eval.rs
+++ b/mur-core/src/cmd/eval.rs
@@ -16,11 +16,21 @@ pub fn cmd_eval_run(suite: &str, format: &str) -> Result<i32> {
         "retrieval" => run_retrieval_eval(format),
         "maturity" => run_maturity_eval(format),
         "reflector" => {
-            println!("reflector suite not yet implemented (E2 dependency)");
+            println!("mur eval — reflector suite");
+            println!("{}", "═".repeat(30));
+            println!("reflector suite not yet implemented (requires E2 Reflector/Curator)");
+            println!(
+                "Run `mur eval run retrieval` and `mur eval run maturity` for available suites."
+            );
             Ok(0)
         }
         "federation" => {
-            println!("federation suite not yet implemented (E6 dependency)");
+            println!("mur eval — federation suite");
+            println!("{}", "═".repeat(30));
+            println!("federation suite not yet implemented (requires E6 Agent Federation)");
+            println!(
+                "Run `mur eval run retrieval` and `mur eval run maturity` for available suites."
+            );
             Ok(0)
         }
         other => {
@@ -375,5 +385,17 @@ mod tests {
             msg.contains("unknown suite"),
             "error message should mention 'unknown suite'"
         );
+    }
+
+    #[test]
+    fn test_reflector_stub_returns_ok() {
+        let code = cmd_eval_run("reflector", "text").expect("reflector stub should not error");
+        assert_eq!(code, 0, "reflector stub should return exit code 0");
+    }
+
+    #[test]
+    fn test_federation_stub_returns_ok() {
+        let code = cmd_eval_run("federation", "text").expect("federation stub should not error");
+        assert_eq!(code, 0, "federation stub should return exit code 0");
     }
 }

--- a/mur-core/src/cmd/eval.rs
+++ b/mur-core/src/cmd/eval.rs
@@ -1,0 +1,206 @@
+use anyhow::{bail, Result};
+use mur_common::config::RetrievalConfig;
+use mur_common::knowledge::KnowledgeBase;
+use mur_common::pattern::{Content, Pattern, Tier};
+use serde::Serialize;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::retrieve::scoring::score_and_rank_with_config;
+use crate::store::yaml::YamlStore;
+
+pub fn cmd_eval_run(suite: &str, format: &str) -> Result<i32> {
+    match suite {
+        "retrieval" => run_retrieval_eval(format),
+        "maturity" => {
+            println!("maturity suite not yet implemented");
+            Ok(0)
+        }
+        "reflector" => {
+            println!("reflector suite not yet implemented (E2 dependency)");
+            Ok(0)
+        }
+        "federation" => {
+            println!("federation suite not yet implemented (E6 dependency)");
+            Ok(0)
+        }
+        other => bail!("unknown suite '{other}' — valid: retrieval, maturity, reflector, federation"),
+    }
+}
+
+fn make_pattern(name: &str, description: &str, content: &str, tier: Tier, importance: f64) -> Pattern {
+    Pattern {
+        base: KnowledgeBase {
+            name: name.to_string(),
+            description: description.to_string(),
+            content: Content::Plain(content.to_string()),
+            tier,
+            importance,
+            ..Default::default()
+        },
+        kind: None,
+        origin: None,
+        attachments: vec![],
+    }
+}
+
+fn seed_patterns() -> Vec<(&'static str, &'static str, &'static str, Tier, f64)> {
+    vec![
+        ("swift-testing", "Use @Test macro for Swift unit tests", "Use @Test macro instead of XCTest for Swift Testing framework", Tier::Project, 0.8),
+        ("rust-error-handling", "Use anyhow for error propagation in Rust binaries", "Use anyhow::Result for application-level error handling", Tier::Core, 0.9),
+        ("prefer-chinese", "Reply in Traditional Chinese", "Always respond to the user in Traditional Chinese (zh-TW)", Tier::Core, 0.9),
+        ("git-commit-format", "Conventional commit messages", "Use conventional commits: feat/fix/docs/refactor scope message", Tier::Project, 0.7),
+        ("no-comments", "Avoid unnecessary code comments", "Do not add comments unless the WHY is non-obvious", Tier::Core, 0.8),
+        ("test-before-commit", "Run tests before committing", "Always run cargo test --workspace before creating a git commit", Tier::Project, 0.8),
+    ]
+}
+
+fn test_queries() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("swift @Test macro unit test", "swift-testing"),
+        ("rust error handling anyhow result", "rust-error-handling"),
+        ("reply language traditional chinese zh-TW", "prefer-chinese"),
+        ("git commit conventional format feat fix", "git-commit-format"),
+        ("code comments documentation why", "no-comments"),
+    ]
+}
+
+#[derive(Serialize)]
+struct QueryResult {
+    query: String,
+    expected: String,
+    hit: bool,
+    rank: Option<usize>,
+}
+
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn create() -> Result<Self> {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = std::env::temp_dir().join(format!("mur_eval_{nonce}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self(path))
+    }
+
+    fn path(&self) -> &PathBuf {
+        &self.0
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn run_retrieval_eval(format: &str) -> Result<i32> {
+    let tmp = TempDir::create()?;
+    let store = YamlStore::new(tmp.path().clone())?;
+
+    for (name, desc, content, tier, importance) in seed_patterns() {
+        let p = make_pattern(name, desc, content, tier, importance);
+        store.save(&p)?;
+    }
+
+    let patterns = store.list_all()?;
+    let config = RetrievalConfig {
+        max_patterns: 3,
+        min_score: 0.0,
+        max_tokens: 10000,
+        mmr_threshold: 0.85,
+    };
+
+    let queries = test_queries();
+    let mut hits = 0usize;
+    let mut results: Vec<QueryResult> = Vec::new();
+
+    for (query, expected) in &queries {
+        let scored = score_and_rank_with_config(query, patterns.clone(), &config);
+        let rank = scored.iter().position(|sp| sp.pattern.name == *expected).map(|i| i + 1);
+        let hit = rank.is_some();
+        if hit {
+            hits += 1;
+        }
+        results.push(QueryResult {
+            query: query.to_string(),
+            expected: expected.to_string(),
+            hit,
+            rank,
+        });
+    }
+
+    let total = queries.len();
+    let precision = hits as f64 / total as f64;
+    let threshold = 0.70_f64;
+    let pass = precision >= threshold;
+
+    if format == "json" {
+        #[derive(Serialize)]
+        struct JsonOut {
+            suite: &'static str,
+            precision_at_3: f64,
+            queries: usize,
+            hits: usize,
+            threshold: f64,
+            pass: bool,
+            results: Vec<QueryResult>,
+        }
+        let out = JsonOut {
+            suite: "retrieval",
+            precision_at_3: precision,
+            queries: total,
+            hits,
+            threshold,
+            pass,
+            results,
+        };
+        println!("{}", serde_json::to_string(&out)?);
+    } else {
+        println!("mur eval — retrieval suite");
+        println!("{}", "═".repeat(30));
+        for r in &results {
+            let rank_str = match r.rank {
+                Some(n) => format!("#{n}"),
+                None => "absent".to_string(),
+            };
+            let mark = if r.hit { "✓" } else { "✗" };
+            if r.hit {
+                println!("query: {:?}", r.query);
+                println!("  expected: {}  rank: {}  {}", r.expected, rank_str, mark);
+            } else {
+                println!("query: {:?}", r.query);
+                println!("  expected: {}  ✗ (rank {} or absent)", r.expected, rank_str);
+            }
+        }
+        println!("{}", "─".repeat(30));
+        let pass_str = if pass { "✓ PASS" } else { "✗ FAIL" };
+        println!(
+            "precision@3: {hits}/{total}  ({precision:.2})  {pass_str}  [threshold {threshold:.2}]"
+        );
+    }
+
+    Ok(if pass { 0 } else { 1 })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_retrieval_eval_pass() {
+        let code = cmd_eval_run("retrieval", "text").expect("eval should not error");
+        assert_eq!(code, 0, "retrieval eval should pass (precision@3 >= 0.70)");
+    }
+
+    #[test]
+    fn test_retrieval_eval_unknown_suite() {
+        let err = cmd_eval_run("bogus", "text");
+        assert!(err.is_err(), "unknown suite should return an error");
+        let msg = err.unwrap_err().to_string();
+        assert!(msg.contains("unknown suite"), "error message should mention 'unknown suite'");
+    }
+}

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -22,6 +22,7 @@ pub mod conversations_cost_report;
 pub(crate) mod deploy;
 pub mod doctor;
 pub(crate) mod drafts;
+pub(crate) mod eval;
 pub(crate) mod evolve_cmd;
 pub(crate) mod hook;
 pub(crate) mod init;

--- a/mur-core/src/cmd/model.rs
+++ b/mur-core/src/cmd/model.rs
@@ -3,7 +3,7 @@
 use anyhow::Context;
 use clap::{Args, Subcommand};
 use mur_common::agent::AgentProfile;
-use mur_common::model::{ModelEntry, ModelRegistry};
+use mur_common::model::{ModelEntry, ModelRegistry, RoleEntry};
 use mur_common::secret::SecretRef;
 
 #[derive(Args, Debug)]
@@ -45,6 +45,33 @@ pub enum ModelCmd {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Manage model roles (reflector, curator, embedding).
+    Role {
+        #[command(subcommand)]
+        sub: RoleSubCmd,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum RoleSubCmd {
+    /// Assign a model to a role.
+    Set {
+        /// Role name (e.g. reflector, curator, embedding).
+        role: String,
+        /// Primary model ID from the registry.
+        model: String,
+        /// Fallback model ID.
+        #[arg(long)]
+        fallback: Option<String>,
+        /// Daily cost budget in USD.
+        #[arg(long)]
+        budget: Option<f64>,
+        /// Only use local models for sensitive data.
+        #[arg(long)]
+        privacy_local_only: bool,
+    },
+    /// List configured roles.
+    List,
 }
 
 pub fn run(args: ModelArgs) -> anyhow::Result<()> {
@@ -99,6 +126,7 @@ pub fn run(args: ModelArgs) -> anyhow::Result<()> {
             }
         }
         ModelCmd::Migrate { dry_run } => cmd_migrate(dry_run)?,
+        ModelCmd::Role { sub } => cmd_role(sub, &mut reg, &path)?,
     }
     Ok(())
 }
@@ -162,4 +190,48 @@ fn cmd_migrate(dry_run: bool) -> anyhow::Result<()> {
 fn synthesize_model_id(provider: &str, model: &str) -> String {
     let sanitized = model.replace(['-', ':', '.', '/'], "_");
     format!("{provider}_{sanitized}")
+}
+
+fn cmd_role(
+    sub: RoleSubCmd,
+    reg: &mut ModelRegistry,
+    path: &std::path::Path,
+) -> anyhow::Result<()> {
+    match sub {
+        RoleSubCmd::Set {
+            role,
+            model,
+            fallback,
+            budget,
+            privacy_local_only,
+        } => {
+            reg.roles.insert(
+                role.clone(),
+                RoleEntry {
+                    primary: model.clone(),
+                    fallback,
+                    cost_budget_per_day_usd: budget,
+                    privacy_local_only,
+                },
+            );
+            reg.save_to(path)?;
+            println!("Role {role} → {model}");
+        }
+        RoleSubCmd::List => {
+            if reg.roles.is_empty() {
+                println!("(no roles configured)");
+                return Ok(());
+            }
+            println!("{:<15} {:<25} {:<25}", "ROLE", "PRIMARY", "FALLBACK");
+            for (name, entry) in &reg.roles {
+                println!(
+                    "{:<15} {:<25} {:<25}",
+                    name,
+                    entry.primary,
+                    entry.fallback.as_deref().unwrap_or("-"),
+                );
+            }
+        }
+    }
+    Ok(())
 }

--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -72,7 +72,7 @@ pub(crate) fn cmd_session_start(source: &str) -> Result<()> {
     Ok(())
 }
 
-pub(crate) async fn cmd_session_stop(analyze: bool) -> Result<()> {
+pub(crate) async fn cmd_session_stop(analyze: bool, reflect: bool) -> Result<()> {
     match session::stop()? {
         Some(id) => {
             eprintln!("Session stopped: {}", &id[..8]);
@@ -94,6 +94,10 @@ pub(crate) async fn cmd_session_stop(analyze: bool) -> Result<()> {
                         eprintln!("Extracted {} fingerprints from session.", fps.len());
                     }
                 }
+            }
+
+            if reflect && recording_path.exists() {
+                run_reflect_curate(&recording_path, false)?;
             }
 
             // Auto-push to device sync if configured
@@ -1264,4 +1268,54 @@ fn format_epoch_ms(epoch_ms: u64) -> String {
     let mins = (secs % 3600) / 60;
     let s = secs % 60;
     format!("{:02}:{:02}:{:02}", hours, mins, s)
+}
+
+/// Shared reflect+curate logic for both `session stop --reflect` and `session reflect`.
+fn run_reflect_curate(recording_path: &std::path::Path, dry_run: bool) -> anyhow::Result<()> {
+    let content = std::fs::read_to_string(recording_path)?;
+    if content.trim().is_empty() {
+        return Ok(());
+    }
+    let registry = mur_common::model::ModelRegistry::load_from(
+        &mur_common::model::ModelRegistry::default_path()?,
+    )
+    .unwrap_or_default();
+    let injected = crate::capture::feedback::read_injection_record()
+        .map(|r| r.patterns)
+        .unwrap_or_default();
+    let results = crate::capture::reflect_session(&content, &injected, &registry);
+    let mut store = crate::store::yaml::YamlStore::default_store()?;
+    let cr = crate::capture::curate(&results, &mut store, dry_run)?;
+    eprintln!(
+        "Reflect+Curate: {} updated, {} conflicts, {} skipped{}",
+        cr.updated.len(),
+        cr.conflicts.len(),
+        cr.skipped.len(),
+        if dry_run { " (dry run)" } else { "" }
+    );
+    for c in &cr.conflicts {
+        eprintln!("  conflict: {} — {}", c.pattern_name, c.reason);
+    }
+    Ok(())
+}
+
+/// `mur session reflect` — run Reflector+Curator on the most recent recording.
+pub(crate) async fn cmd_session_reflect(dry_run: bool) -> anyhow::Result<()> {
+    let recordings_dir = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("no home dir"))?
+        .join(".mur/session/recordings");
+    if !recordings_dir.exists() {
+        eprintln!("No session recordings found.");
+        return Ok(());
+    }
+    let latest = std::fs::read_dir(&recordings_dir)?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("jsonl"))
+        .max_by_key(|e| e.metadata().and_then(|m| m.modified()).ok());
+    let Some(entry) = latest else {
+        eprintln!("No session recordings found.");
+        return Ok(());
+    };
+    run_reflect_curate(&entry.path(), dry_run)?;
+    Ok(())
 }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -10,7 +10,7 @@ use crate::cli::{
     AgentAction, AgentEvalAction, AgentHooksAction, AgentMcpAction, AgentPermAction,
     AgentPromptAction, AgentScheduleAction, AgentSecretAction, AgentSkillAction,
     AgentWebhookAction, ChatAction, Cli, Commands, CommunityAction, ConversationsAction,
-    DeployAction, DraftsAction, EvolveAction, ExchangeAction, FeedbackAction, GepAction, HookEvent,
+    DeployAction, DraftsAction, EvalAction, EvolveAction, ExchangeAction, FeedbackAction, GepAction, HookEvent,
     InternalsAction, LearnAction, MurmurdAction, PackAction, PatternAction, ScheduleAction,
     SessionAction, SyncAction, TeamAction, VoiceAction, WorkflowAction,
 };
@@ -446,6 +446,12 @@ pub async fn run(cli: Cli) -> Result<()> {
             InternalsAction::RebuildIndex { layer } => cmd::internals::cmd_rebuild_index(&layer)?,
             InternalsAction::Git { layer, args } => {
                 cmd::internals::cmd_internals_git(&layer, &args)?
+            }
+        },
+        Commands::Eval { action } => match action {
+            EvalAction::Run { suite, format } => {
+                let code = cmd::eval::cmd_eval_run(&suite, &format)?;
+                std::process::exit(code);
             }
         },
     }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -10,9 +10,9 @@ use crate::cli::{
     AgentAction, AgentEvalAction, AgentHooksAction, AgentMcpAction, AgentPermAction,
     AgentPromptAction, AgentScheduleAction, AgentSecretAction, AgentSkillAction,
     AgentWebhookAction, ChatAction, Cli, Commands, CommunityAction, ConversationsAction,
-    DeployAction, DraftsAction, EvalAction, EvolveAction, ExchangeAction, FeedbackAction, GepAction, HookEvent,
-    InternalsAction, LearnAction, MurmurdAction, PackAction, PatternAction, ScheduleAction,
-    SessionAction, SyncAction, TeamAction, VoiceAction, WorkflowAction,
+    DeployAction, DraftsAction, EvalAction, EvolveAction, ExchangeAction, FeedbackAction,
+    GepAction, HookEvent, InternalsAction, LearnAction, MurmurdAction, PackAction, PatternAction,
+    ScheduleAction, SessionAction, SyncAction, TeamAction, VoiceAction, WorkflowAction,
 };
 use crate::{cmd, dashboard, verify};
 

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -186,7 +186,9 @@ pub async fn run(cli: Cli) -> Result<()> {
         }
         Commands::Session { action } => match action {
             SessionAction::Start { source } => cmd::session::cmd_session_start(&source)?,
-            SessionAction::Stop { analyze } => cmd::session::cmd_session_stop(analyze).await?,
+            SessionAction::Stop { analyze, reflect } => {
+                cmd::session::cmd_session_stop(analyze, reflect).await?
+            }
             SessionAction::Record {
                 event_type,
                 tool,
@@ -206,6 +208,9 @@ pub async fn run(cli: Cli) -> Result<()> {
             } => cmd::session::cmd_session_export(&id, &format, analyze, output).await?,
             SessionAction::Push { id, all } => {
                 cmd::session::cmd_session_push(id.as_deref(), all).await?
+            }
+            SessionAction::Reflect { dry_run } => {
+                cmd::session::cmd_session_reflect(dry_run).await?
             }
         },
         Commands::Dashboard => {


### PR DESCRIPTION
## Summary

Cascade merge of E4 and E2 epics into main.

**E4 — Eval Harness:**
- `mur eval run retrieval` — precision@3 benchmark against fixed in-memory dataset
- `mur eval run maturity` — lifecycle smoke tests (Draft→Emerging→Stable→Canonical)
- `mur eval run reflector` / `federation` — informative stubs

**E2 — Reflector + Curator:**
- `ModelRegistry.roles` + `RoleEntry` (primary, fallback, cost_budget_per_day_usd) + `resolve_role()`
- `mur model role set|list` CLI
- `capture/reflector.rs` — LLM-backed session analyzer (Anthropic/Ollama) with heuristic fallback
- `capture/curator.rs` — applies deltas to pattern store (confidence, success/override signals, conflict detection, dry-run)
- `mur session stop --reflect` + `mur session reflect [--dry-run]`

## Test Plan

- [ ] `cargo test --workspace` passes
- [ ] `mur eval run retrieval` exits 0, prints precision@3
- [ ] `mur eval run maturity` exits 0, prints lifecycle results
- [ ] `mur model role set reflector <model>` writes to `~/.mur/models.yaml`
- [ ] `mur session reflect --dry-run` runs without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)