### PR TITLE
feat(skill): recursive dependency resolution + lock file (M3a)

### DIFF
--- a/mur-common/Cargo.toml
+++ b/mur-common/Cargo.toml
@@ -45,6 +45,7 @@ hex = "0.4.3"
 base64 = "0.22.1"
 tar = "0.4.46"
 flate2 = "1.1.9"
+semver = "1"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation"] }

--- a/mur-common/src/skill/constraint.rs
+++ b/mur-common/src/skill/constraint.rs
@@ -1,0 +1,85 @@
+use semver::{Version, VersionReq};
+
+#[derive(Debug, Clone)]
+pub struct Constraint(pub VersionReq);
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConstraintError {
+    #[error("invalid version requirement '{0}': {1}")]
+    Parse(String, String),
+}
+
+impl Constraint {
+    /// Parse "requires:[].version".
+    /// Accepts: `>=1.0.0`, `^1.2.3`, `~1.2.3`, exact `1.2.3`, `*`.
+    /// Empty string and `*` both mean "any".
+    pub fn parse(s: &str) -> Result<Self, ConstraintError> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() || trimmed == "*" {
+            return Ok(Self(VersionReq::STAR));
+        }
+        VersionReq::parse(trimmed)
+            .map(Self)
+            .map_err(|e| ConstraintError::Parse(trimmed.into(), e.to_string()))
+    }
+
+    pub fn matches(&self, v: &Version) -> bool {
+        self.0.matches(v)
+    }
+
+    pub fn any() -> Self {
+        Self(VersionReq::STAR)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn star_matches_anything() {
+        let c = Constraint::parse("*").unwrap();
+        assert!(c.matches(&Version::parse("0.0.1").unwrap()));
+        assert!(c.matches(&Version::parse("99.99.99").unwrap()));
+    }
+
+    #[test]
+    fn ge_pins_minimum() {
+        let c = Constraint::parse(">=1.0.0").unwrap();
+        assert!(!c.matches(&Version::parse("0.9.9").unwrap()));
+        assert!(c.matches(&Version::parse("1.0.0").unwrap()));
+        assert!(c.matches(&Version::parse("2.0.0").unwrap()));
+    }
+
+    #[test]
+    fn caret_locks_major() {
+        let c = Constraint::parse("^1.2.3").unwrap();
+        assert!(c.matches(&Version::parse("1.9.0").unwrap()));
+        assert!(!c.matches(&Version::parse("2.0.0").unwrap()));
+    }
+
+    #[test]
+    fn tilde_locks_minor() {
+        let c = Constraint::parse("~1.2.3").unwrap();
+        assert!(c.matches(&Version::parse("1.2.9").unwrap()));
+        assert!(!c.matches(&Version::parse("1.3.0").unwrap()));
+    }
+
+    #[test]
+    fn exact_pins_exact() {
+        let c = Constraint::parse("=1.2.3").unwrap();
+        assert!(c.matches(&Version::parse("1.2.3").unwrap()));
+        assert!(!c.matches(&Version::parse("1.2.4").unwrap()));
+    }
+
+    #[test]
+    fn empty_means_any() {
+        let c = Constraint::parse("").unwrap();
+        assert!(c.matches(&Version::parse("0.0.1").unwrap()));
+    }
+
+    #[test]
+    fn garbage_fails() {
+        assert!(Constraint::parse("not-a-version").is_err());
+    }
+}

--- a/mur-common/src/skill/lockfile.rs
+++ b/mur-common/src/skill/lockfile.rs
@@ -1,0 +1,109 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+pub const SCHEMA_VERSION: u32 = 1;
+pub const FILE_NAME: &str = "skill.lock";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SkillLock {
+    #[serde(default = "default_schema")]
+    pub schema_version: u32,
+    #[serde(default)]
+    pub locked: BTreeMap<String, String>,
+    #[serde(default)]
+    pub installed_at: String,
+}
+
+fn default_schema() -> u32 {
+    SCHEMA_VERSION
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LockfileError {
+    #[error("io: {0}")]
+    Io(#[from] io::Error),
+    #[error("parse: {0}")]
+    Parse(#[from] serde_yaml_ng::Error),
+}
+
+impl SkillLock {
+    pub fn path(skill_dir: &Path) -> std::path::PathBuf {
+        skill_dir.join(FILE_NAME)
+    }
+
+    pub fn read(skill_dir: &Path) -> Result<Self, LockfileError> {
+        let p = Self::path(skill_dir);
+        if !p.exists() {
+            return Ok(Self {
+                schema_version: SCHEMA_VERSION,
+                ..Default::default()
+            });
+        }
+        let s = fs::read_to_string(&p)?;
+        if s.trim().is_empty() {
+            return Ok(Self {
+                schema_version: SCHEMA_VERSION,
+                ..Default::default()
+            });
+        }
+        Ok(serde_yaml_ng::from_str(&s)?)
+    }
+
+    pub fn write(&self, skill_dir: &Path) -> Result<(), LockfileError> {
+        fs::create_dir_all(skill_dir)?;
+        let yaml = serde_yaml_ng::to_string(self)?;
+        let final_path = Self::path(skill_dir);
+        let tmp = skill_dir.join(format!(".{FILE_NAME}.tmp"));
+        fs::write(&tmp, yaml)?;
+        fs::rename(tmp, final_path)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn empty_when_missing() {
+        let d = tempdir().unwrap();
+        let l = SkillLock::read(d.path()).unwrap();
+        assert_eq!(l.schema_version, SCHEMA_VERSION);
+        assert!(l.locked.is_empty());
+    }
+
+    #[test]
+    fn round_trip() {
+        let d = tempdir().unwrap();
+        let mut l = SkillLock {
+            schema_version: SCHEMA_VERSION,
+            locked: BTreeMap::new(),
+            installed_at: "2026-05-25T00:00:00Z".into(),
+        };
+        l.locked.insert("web-browsing".into(), "1.2.0".into());
+        l.locked
+            .insert("data-table-export".into(), "0.6.1".into());
+        l.write(d.path()).unwrap();
+        let back = SkillLock::read(d.path()).unwrap();
+        assert_eq!(back.locked["web-browsing"], "1.2.0");
+        assert_eq!(back.installed_at, l.installed_at);
+    }
+
+    #[test]
+    fn corrupt_yaml_returns_parse_err() {
+        let d = tempdir().unwrap();
+        fs::write(
+            SkillLock::path(d.path()),
+            "this is :: not yaml :: at all",
+        )
+        .unwrap();
+        assert!(matches!(
+            SkillLock::read(d.path()),
+            Err(LockfileError::Parse(_))
+        ));
+    }
+}

--- a/mur-common/src/skill/lockfile.rs
+++ b/mur-common/src/skill/lockfile.rs
@@ -85,8 +85,7 @@ mod tests {
             installed_at: "2026-05-25T00:00:00Z".into(),
         };
         l.locked.insert("web-browsing".into(), "1.2.0".into());
-        l.locked
-            .insert("data-table-export".into(), "0.6.1".into());
+        l.locked.insert("data-table-export".into(), "0.6.1".into());
         l.write(d.path()).unwrap();
         let back = SkillLock::read(d.path()).unwrap();
         assert_eq!(back.locked["web-browsing"], "1.2.0");
@@ -96,11 +95,7 @@ mod tests {
     #[test]
     fn corrupt_yaml_returns_parse_err() {
         let d = tempdir().unwrap();
-        fs::write(
-            SkillLock::path(d.path()),
-            "this is :: not yaml :: at all",
-        )
-        .unwrap();
+        fs::write(SkillLock::path(d.path()), "this is :: not yaml :: at all").unwrap();
         assert!(matches!(
             SkillLock::read(d.path()),
             Err(LockfileError::Parse(_))

--- a/mur-common/src/skill/mod.rs
+++ b/mur-common/src/skill/mod.rs
@@ -1,6 +1,7 @@
 //! MuR skill ecosystem — see `docs/superpowers/specs/2026-05-24-mur-skill-ecosystem-design.md`.
 
 pub mod capability;
+pub mod constraint;
 pub mod hash;
 pub mod loader;
 pub mod local;
@@ -14,6 +15,7 @@ pub mod types;
 pub mod validate;
 
 pub use capability::{Capability, CapabilityViolation, allowed_for, check_capabilities};
+pub use constraint::{Constraint, ConstraintError};
 pub use hash::{DriftStatus, content_sha256, ct_eq_hex, drift_status, sha256_hex};
 pub use loader::{LoadedSkill, SkillScope, load_all};
 pub use manifest::*;

--- a/mur-common/src/skill/mod.rs
+++ b/mur-common/src/skill/mod.rs
@@ -5,6 +5,7 @@ pub mod constraint;
 pub mod hash;
 pub mod loader;
 pub mod local;
+pub mod lockfile;
 pub mod manifest;
 pub mod parser;
 pub mod registry;
@@ -18,6 +19,7 @@ pub use capability::{Capability, CapabilityViolation, allowed_for, check_capabil
 pub use constraint::{Constraint, ConstraintError};
 pub use hash::{DriftStatus, content_sha256, ct_eq_hex, drift_status, sha256_hex};
 pub use loader::{LoadedSkill, SkillScope, load_all};
+pub use lockfile::{LockfileError, SkillLock};
 pub use manifest::*;
 pub use parser::{
     ParseError, parse_canonical, parse_legacy_markdown, parse_markdown, serialize_canonical,

--- a/mur-core/src/cli/skill.rs
+++ b/mur-core/src/cli/skill.rs
@@ -60,4 +60,9 @@ pub enum SkillAction {
         /// Name of installed skill to update.
         name: String,
     },
+    /// Print the resolved dependency tree for an installed skill.
+    Deps {
+        /// Name of installed skill.
+        name: String,
+    },
 }

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -42,6 +42,7 @@ pub(crate) mod search;
 pub(crate) mod server_cmd;
 pub(crate) mod session;
 pub(crate) mod skill_cmd;
+pub(crate) mod skill_deps;
 pub(crate) mod skill_install;
 pub(crate) mod skill_publish;
 pub(crate) mod skill_registry;

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -45,6 +45,7 @@ pub(crate) mod skill_cmd;
 pub(crate) mod skill_install;
 pub(crate) mod skill_publish;
 pub(crate) mod skill_registry;
+#[allow(dead_code)]
 pub(crate) mod skill_resolver;
 pub(crate) mod sleep;
 pub(crate) mod sync_cmd;

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -45,6 +45,7 @@ pub(crate) mod skill_cmd;
 pub(crate) mod skill_install;
 pub(crate) mod skill_publish;
 pub(crate) mod skill_registry;
+pub(crate) mod skill_resolver;
 pub(crate) mod sleep;
 pub(crate) mod sync_cmd;
 pub(crate) mod system_schedule;

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -41,13 +41,13 @@ pub(crate) mod reindex;
 pub(crate) mod search;
 pub(crate) mod server_cmd;
 pub(crate) mod session;
-pub(crate) mod skill_cmd;
-pub(crate) mod skill_deps;
-pub(crate) mod skill_install;
+pub mod skill_cmd;
+pub mod skill_deps;
+pub mod skill_install;
 pub(crate) mod skill_publish;
-pub(crate) mod skill_registry;
+pub mod skill_registry;
 #[allow(dead_code)]
-pub(crate) mod skill_resolver;
+pub mod skill_resolver;
 pub(crate) mod sleep;
 pub(crate) mod sync_cmd;
 pub(crate) mod system_schedule;

--- a/mur-core/src/cmd/skill_deps.rs
+++ b/mur-core/src/cmd/skill_deps.rs
@@ -1,7 +1,7 @@
 //! `mur skill deps <name>` — print the resolved dependency tree from `skill.lock`.
 
 use anyhow::{Context, Result, bail};
-use mur_common::skill::{SkillLock, Requirement, global_skill_dir, local::load_installed};
+use mur_common::skill::{Requirement, SkillLock, global_skill_dir, local::load_installed};
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::Path;

--- a/mur-core/src/cmd/skill_deps.rs
+++ b/mur-core/src/cmd/skill_deps.rs
@@ -1,0 +1,105 @@
+//! `mur skill deps <name>` — print the resolved dependency tree from `skill.lock`.
+
+use anyhow::{Context, Result, bail};
+use mur_common::skill::{SkillLock, Requirement, global_skill_dir, local::load_installed};
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::Path;
+
+use crate::cmd::agent::resolve_mur_home;
+
+pub fn cmd_deps(home: &Path, name: &str) -> Result<()> {
+    cmd_deps_to(home, name, &mut std::io::stdout().lock())
+}
+
+pub fn cmd_deps_to(home: &Path, name: &str, w: &mut dyn Write) -> Result<()> {
+    let root_dir = global_skill_dir(home, name);
+    if !root_dir.exists() {
+        bail!("'{name}' is not installed");
+    }
+    let lock = SkillLock::read(&root_dir).context("read skill.lock")?;
+    let root_manifest = load_installed(home, name).context("read root manifest")?;
+
+    writeln!(w, "{} v{}", name, root_manifest.version)?;
+    print_subtree(w, &lock.locked, &root_manifest.requires, "  ")?;
+    Ok(())
+}
+
+/// CLI shim — resolves MUR_HOME from env.
+pub fn cmd_deps_cli(name: &str) -> Result<()> {
+    let home = resolve_mur_home()?;
+    cmd_deps(&home, name)
+}
+
+fn print_subtree(
+    w: &mut dyn Write,
+    locked: &BTreeMap<String, String>,
+    reqs: &[Requirement],
+    indent: &str,
+) -> Result<()> {
+    for r in reqs {
+        let pinned = locked.get(&r.name).map(String::as_str).unwrap_or("?");
+        writeln!(w, "{indent}{} ({}) -> {pinned}", r.name, r.version)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::skill::{SkillLock, lockfile};
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn not_installed() {
+        let home = tempdir().unwrap();
+        let err = cmd_deps(home.path(), "nonexistent").unwrap_err();
+        assert!(
+            err.to_string().contains("not installed"),
+            "expected not-installed, got: {err}"
+        );
+    }
+
+    #[test]
+    fn prints_lock_contents() {
+        let home = tempdir().unwrap();
+        let skill_dir = global_skill_dir(home.path(), "test-skill");
+        fs::create_dir_all(&skill_dir).unwrap();
+
+        let skill_yaml = r#"
+name: test-skill
+version: 1.0.0
+publisher: human:test
+description: test
+category: context
+requires:
+  - name: dep-a
+    version: ">=1.0.0"
+  - name: dep-b
+    version: "^2.0.0"
+content:
+  abstract: a
+  context: b
+"#;
+        fs::write(skill_dir.join("skill.yaml"), skill_yaml).unwrap();
+
+        let mut lock = SkillLock {
+            schema_version: lockfile::SCHEMA_VERSION,
+            installed_at: "2026-05-25T00:00:00Z".into(),
+            locked: BTreeMap::new(),
+        };
+        lock.locked.insert("test-skill".into(), "1.0.0".into());
+        lock.locked.insert("dep-a".into(), "1.2.0".into());
+        lock.locked.insert("dep-b".into(), "2.5.0".into());
+        lock.write(&skill_dir).unwrap();
+
+        let mut buf = Vec::new();
+        cmd_deps_to(home.path(), "test-skill", &mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+
+        assert!(out.contains("test-skill v1.0.0"), "output: {out}");
+        assert!(out.contains("dep-a (>=1.0.0) -> 1.2.0"), "output: {out}");
+        assert!(out.contains("dep-b (^2.0.0) -> 2.5.0"), "output: {out}");
+    }
+}

--- a/mur-core/src/cmd/skill_install.rs
+++ b/mur-core/src/cmd/skill_install.rs
@@ -1,95 +1,127 @@
-//! Skill install orchestrator — resolve source, fetch, verify, store, trust.
+//! Skill install orchestrator — resolve source, fetch, verify, store, trust, lock.
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use std::path::Path;
 
 use mur_common::skill::{
-    content_sha256, global_skill_dir, parse_canonical, scan::scan_skill, validate, write_to_dir,
+    content_sha256, global_skill_dir, scan::scan_skill, write_to_dir, TrustLevel,
 };
+use mur_common::skill::{SkillLock, lockfile};
 use mur_common::trust::skills::{SkillTrustStore, TrustEntry};
 
 use crate::cmd::agent::resolve_mur_home;
 use crate::cmd::skill_registry;
+use crate::cmd::skill_resolver::{self, ResolveSource, ResolvedNode, ResolverInput};
 
-pub fn cmd_install(source: &str) -> Result<()> {
-    let home = resolve_mur_home()?;
+/// Pure entry point — takes explicit home + registry_url. Used by tests and future M4 code.
+pub fn cmd_install(home: &Path, registry_url: &str, source: &str) -> Result<()> {
     let src_path = Path::new(source);
 
-    if src_path.exists() && src_path.is_file() {
-        return install_from_file(&home, src_path);
+    let (reg_dir, _idx) = skill_registry::fetch_and_load(home, registry_url)
+        .context("fetch registry")?;
+
+    let input = ResolverInput {
+        mur_home: home.to_path_buf(),
+        registry_dir: reg_dir,
+    };
+
+    let source_enum = if src_path.exists() && src_path.is_file() {
+        ResolveSource::LocalFile(src_path)
+    } else {
+        ResolveSource::RegistryLatest(source)
+    };
+
+    let order = skill_resolver::resolve(&input, source_enum)?;
+    if order.is_empty() {
+        bail!("resolver returned empty install order");
     }
 
-    // Treat as registry name
-    install_from_registry(&home, source)
+    // Install leaves first. The root is the last entry.
+    for node in &order {
+        install_resolved_node(home, node)?;
+    }
+
+    // Write lock at the root skill dir.
+    let root = order.last().unwrap();
+    let lock = SkillLock {
+        schema_version: lockfile::SCHEMA_VERSION,
+        installed_at: chrono::Utc::now().to_rfc3339(),
+        locked: order
+            .iter()
+            .map(|n| (n.name.clone(), n.version.to_string()))
+            .collect(),
+    };
+    let root_dir = global_skill_dir(home, &root.name);
+    lock.write(&root_dir).context("write skill.lock")?;
+
+    println!("installed: {} v{}", root.name, root.version);
+    if order.len() > 1 {
+        println!("  + {} transitive dependencies", order.len() - 1);
+    }
+    Ok(())
 }
 
-fn install_from_file(home: &Path, path: &Path) -> Result<()> {
-    let text = std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-    let m = parse_canonical(&text)?;
-    validate(&m)?;
-
-    let report = scan_skill(&m)?;
-    if report.has_blocking_findings() {
-        eprintln!("⚠ Security findings — install proceeds in Sandboxed mode:");
-        for line in report.human_summary() {
-            eprintln!("  {line}");
-        }
-    }
-
-    let dir = global_skill_dir(home, &m.name);
-    write_to_dir(&dir, &m)?;
-
-    let hash = content_sha256(&m)?;
-    let mut trust = SkillTrustStore::load(home).map_err(|e| anyhow!("load trust: {e}"))?;
+fn install_resolved_node(home: &Path, node: &ResolvedNode) -> Result<()> {
+    let report = scan_skill(&node.manifest)?;
+    let dir = global_skill_dir(home, &node.name);
+    write_to_dir(&dir, &node.manifest)?;
+    let hash = content_sha256(&node.manifest)?;
+    let mut trust = SkillTrustStore::load(home).map_err(|e| anyhow::anyhow!("load trust: {e}"))?;
     let level = if report.has_blocking_findings() {
-        mur_common::skill::TrustLevel::Sandboxed
+        TrustLevel::Sandboxed
     } else {
-        mur_common::skill::TrustLevel::Verified
+        TrustLevel::Verified
     };
     trust.insert(
         hash,
         TrustEntry {
-            name: m.name.clone(),
-            version: m.version.clone(),
+            name: node.name.clone(),
+            version: node.version.to_string(),
             level,
             installed_at: chrono::Utc::now().to_rfc3339(),
-            publisher: Some(m.publisher.clone()),
+            publisher: Some(node.manifest.publisher.clone()),
         },
     );
-    trust.save(home).map_err(|e| anyhow!("save trust: {e}"))?;
-
-    println!("installed: {} v{}", m.name, m.version);
+    trust
+        .save(home)
+        .map_err(|e| anyhow::anyhow!("save trust: {e}"))?;
+    if report.has_blocking_findings() {
+        eprintln!(
+            "⚠ {} v{}: security findings — installed Sandboxed",
+            node.name, node.version
+        );
+        for line in report.human_summary() {
+            eprintln!("    {line}");
+        }
+    }
     Ok(())
 }
 
-fn install_from_registry(home: &Path, name: &str) -> Result<()> {
-    let (_reg_dir, idx) = skill_registry::fetch_and_load(home, skill_registry::DEFAULT_REGISTRY)
-        .context("fetch registry")?;
-
-    let entry = idx
-        .skills
-        .get(name)
-        .ok_or_else(|| anyhow!("skill '{name}' not found in registry"))?;
-
-    let reg_dir = skill_registry::registry_cache_dir(home);
-    let skill_path = skill_registry::skill_yaml_path(&reg_dir, name, &entry.latest);
-    if !skill_path.exists() {
-        bail!("skill file not found at {}", skill_path.display());
-    }
-
-    install_from_file(home, &skill_path)
+/// CLI shim — resolves MUR_HOME and MUR_SKILL_REGISTRY_URL from env.
+pub fn cmd_install_cli(source: &str) -> Result<()> {
+    let home = resolve_mur_home()?;
+    let registry_url = std::env::var("MUR_SKILL_REGISTRY_URL")
+        .unwrap_or_else(|_| skill_registry::DEFAULT_REGISTRY.to_string());
+    cmd_install(&home, &registry_url, source)
 }
 
-pub fn cmd_update(name: &str) -> Result<()> {
-    install_from_registry(&resolve_mur_home()?, name)?;
+/// Pure update — re-resolves to latest versions.
+pub fn cmd_update(home: &Path, registry_url: &str, name: &str) -> Result<()> {
+    cmd_install(home, registry_url, name)?;
     println!("updated: {name}");
     Ok(())
 }
 
+/// CLI shim for update.
+pub fn cmd_update_cli(name: &str) -> Result<()> {
+    let home = resolve_mur_home()?;
+    let registry_url = std::env::var("MUR_SKILL_REGISTRY_URL")
+        .unwrap_or_else(|_| skill_registry::DEFAULT_REGISTRY.to_string());
+    cmd_update(&home, &registry_url, name)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
     fn valid_yaml_parses_and_validates() {
         let yaml = r#"
@@ -102,7 +134,7 @@ content:
   abstract: a
   context: b
 "#;
-        let m = parse_canonical(yaml).unwrap();
-        validate(&m).unwrap();
+        let m = mur_common::skill::parse_canonical(yaml).unwrap();
+        mur_common::skill::validate(&m).unwrap();
     }
 }

--- a/mur-core/src/cmd/skill_install.rs
+++ b/mur-core/src/cmd/skill_install.rs
@@ -3,10 +3,10 @@
 use anyhow::{Context, Result, bail};
 use std::path::Path;
 
-use mur_common::skill::{
-    content_sha256, global_skill_dir, scan::scan_skill, write_to_dir, TrustLevel,
-};
 use mur_common::skill::{SkillLock, lockfile};
+use mur_common::skill::{
+    TrustLevel, content_sha256, global_skill_dir, scan::scan_skill, write_to_dir,
+};
 use mur_common::trust::skills::{SkillTrustStore, TrustEntry};
 
 use crate::cmd::agent::resolve_mur_home;
@@ -17,8 +17,8 @@ use crate::cmd::skill_resolver::{self, ResolveSource, ResolvedNode, ResolverInpu
 pub fn cmd_install(home: &Path, registry_url: &str, source: &str) -> Result<()> {
     let src_path = Path::new(source);
 
-    let (reg_dir, _idx) = skill_registry::fetch_and_load(home, registry_url)
-        .context("fetch registry")?;
+    let (reg_dir, _idx) =
+        skill_registry::fetch_and_load(home, registry_url).context("fetch registry")?;
 
     let input = ResolverInput {
         mur_home: home.to_path_buf(),

--- a/mur-core/src/cmd/skill_registry.rs
+++ b/mur-core/src/cmd/skill_registry.rs
@@ -80,9 +80,7 @@ pub fn available_versions(registry_dir: &Path, name: &str) -> Result<Vec<Version
         return Ok(vec![]);
     }
     let mut out = Vec::new();
-    for entry in
-        std::fs::read_dir(&dir).with_context(|| format!("read {}", dir.display()))?
-    {
+    for entry in std::fs::read_dir(&dir).with_context(|| format!("read {}", dir.display()))? {
         let entry = entry?;
         if !entry.file_type()?.is_file() {
             continue;

--- a/mur-core/src/cmd/skill_registry.rs
+++ b/mur-core/src/cmd/skill_registry.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{Context, Result};
 use mur_common::skill::registry::{RegistryIndex, RegistrySkillEntry};
+use semver::Version;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -71,6 +72,39 @@ pub fn skill_yaml_path(registry_dir: &Path, name: &str, version: &str) -> PathBu
         .join(format!("{version}.yaml"))
 }
 
+/// List the versions of `name` available in the registry cache.
+/// Returns sorted ascending. Returns `Ok(vec![])` if the skill dir doesn't exist.
+pub fn available_versions(registry_dir: &Path, name: &str) -> Result<Vec<Version>> {
+    let dir = registry_dir.join("skills").join(name).join("versions");
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut out = Vec::new();
+    for entry in
+        std::fs::read_dir(&dir).with_context(|| format!("read {}", dir.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let file_name = entry.file_name();
+        let name_str = file_name.to_string_lossy();
+        let Some(stripped) = name_str.strip_suffix(".yaml") else {
+            continue;
+        };
+        match Version::parse(stripped) {
+            Ok(v) => out.push(v),
+            Err(e) => tracing::warn!(
+                file = %name_str,
+                error = %e,
+                "skipping non-semver version filename"
+            ),
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
 pub fn search_registry<'a>(
     idx: &'a RegistryIndex,
     query: &str,
@@ -116,5 +150,41 @@ skills:
         let d = tempdir().unwrap();
         let p = skill_yaml_path(d.path(), "my-skill", "1.2.3");
         assert!(p.ends_with("skills/my-skill/versions/1.2.3.yaml"));
+    }
+
+    #[test]
+    fn available_versions_missing_dir() {
+        let d = tempdir().unwrap();
+        let vs = available_versions(d.path(), "nonexistent").unwrap();
+        assert!(vs.is_empty());
+    }
+
+    #[test]
+    fn available_versions_sorted() {
+        let d = tempdir().unwrap();
+        let versions_dir = d.path().join("skills/my-skill/versions");
+        fs::create_dir_all(&versions_dir).unwrap();
+        fs::write(versions_dir.join("1.0.0.yaml"), "").unwrap();
+        fs::write(versions_dir.join("0.9.0.yaml"), "").unwrap();
+        fs::write(versions_dir.join("2.0.0.yaml"), "").unwrap();
+        let vs = available_versions(d.path(), "my-skill").unwrap();
+        assert_eq!(
+            vs.iter().map(|v| v.to_string()).collect::<Vec<_>>(),
+            vec!["0.9.0", "1.0.0", "2.0.0"]
+        );
+    }
+
+    #[test]
+    fn available_versions_skips_non_semver() {
+        let d = tempdir().unwrap();
+        let versions_dir = d.path().join("skills/my-skill/versions");
+        fs::create_dir_all(&versions_dir).unwrap();
+        fs::write(versions_dir.join("1.0.0.yaml"), "").unwrap();
+        fs::write(versions_dir.join("not-a-version.yaml"), "").unwrap();
+        fs::write(versions_dir.join("2.0.0.yaml"), "").unwrap();
+        let vs = available_versions(d.path(), "my-skill").unwrap();
+        assert_eq!(vs.len(), 2);
+        assert_eq!(vs[0].to_string(), "1.0.0");
+        assert_eq!(vs[1].to_string(), "2.0.0");
     }
 }

--- a/mur-core/src/cmd/skill_resolver.rs
+++ b/mur-core/src/cmd/skill_resolver.rs
@@ -1,0 +1,308 @@
+//! Recursive resolver for `mur skill install` — DFS with cycle detection,
+//! semver constraint matching, leaves-first install ordering.
+
+use anyhow::Result;
+use mur_common::skill::{Constraint, ConstraintError, SkillManifest, parse_canonical, validate};
+use semver::Version;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ResolveError {
+    #[error("cyclic dependency: {0}")]
+    Cycle(String),
+    #[error(
+        "no version of '{name}' satisfies '{req}' (existing pin: {existing}); available: {available:?}"
+    )]
+    Conflict {
+        name: String,
+        req: String,
+        existing: String,
+        available: Vec<String>,
+    },
+    #[error("no version of '{name}' satisfies '{req}'; available: {available:?}")]
+    NoMatch {
+        name: String,
+        req: String,
+        available: Vec<String>,
+    },
+    #[error("skill '{0}' not found in registry cache")]
+    NotFound(String),
+    #[error("constraint parse: {0}")]
+    BadConstraint(#[from] ConstraintError),
+    #[error("manifest parse: {0}")]
+    BadManifest(String),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedNode {
+    pub name: String,
+    pub version: Version,
+    pub yaml_path: PathBuf,
+    pub manifest: SkillManifest,
+}
+
+pub enum ResolveSource<'a> {
+    LocalFile(&'a Path),
+    RegistryLatest(&'a str),
+}
+
+pub struct ResolverInput {
+    pub mur_home: PathBuf,
+    pub registry_dir: PathBuf,
+}
+
+pub fn resolve(
+    input: &ResolverInput,
+    source: ResolveSource<'_>,
+) -> Result<Vec<ResolvedNode>, ResolveError> {
+    let mut state = State::default();
+    let root = load_root(input, source)?;
+    visit(input, &mut state, root, Constraint::any())?;
+    Ok(state
+        .install_order
+        .into_iter()
+        .map(|n| state.selected.remove(&n).unwrap())
+        .collect())
+}
+
+#[derive(Default)]
+struct State {
+    selected: BTreeMap<String, ResolvedNode>,
+    on_stack: Vec<String>,
+    install_order: Vec<String>,
+}
+
+fn load_root(input: &ResolverInput, src: ResolveSource<'_>) -> Result<ResolvedNode, ResolveError> {
+    match src {
+        ResolveSource::LocalFile(p) => load_from_path(p),
+        ResolveSource::RegistryLatest(name) => {
+            let versions =
+                crate::cmd::skill_registry::available_versions(&input.registry_dir, name)
+                    .map_err(ResolveError::Other)?;
+            let v = versions
+                .last()
+                .cloned()
+                .ok_or_else(|| ResolveError::NotFound(name.into()))?;
+            let path = crate::cmd::skill_registry::skill_yaml_path(
+                &input.registry_dir,
+                name,
+                &v.to_string(),
+            );
+            load_from_path(&path)
+        }
+    }
+}
+
+fn load_from_path(path: &Path) -> Result<ResolvedNode, ResolveError> {
+    let text = std::fs::read_to_string(path).map_err(|e| ResolveError::Other(e.into()))?;
+    let m = parse_canonical(&text).map_err(|e| ResolveError::BadManifest(e.to_string()))?;
+    validate(&m).map_err(|e| ResolveError::BadManifest(e.to_string()))?;
+    let v =
+        Version::parse(&m.version).map_err(|e| ResolveError::BadManifest(format!("version: {e}")))?;
+    Ok(ResolvedNode {
+        name: m.name.clone(),
+        version: v,
+        yaml_path: path.to_path_buf(),
+        manifest: m,
+    })
+}
+
+fn pick_best(
+    input: &ResolverInput,
+    name: &str,
+    c: &Constraint,
+) -> Result<ResolvedNode, ResolveError> {
+    let versions = crate::cmd::skill_registry::available_versions(&input.registry_dir, name)
+        .map_err(ResolveError::Other)?;
+    let mut candidates: Vec<&Version> = versions.iter().filter(|v| c.matches(v)).collect();
+    candidates.sort();
+    let pick = candidates.last().ok_or_else(|| ResolveError::NoMatch {
+        name: name.into(),
+        req: c.0.to_string(),
+        available: versions.iter().map(|v| v.to_string()).collect(),
+    })?;
+    let path = crate::cmd::skill_registry::skill_yaml_path(
+        &input.registry_dir,
+        name,
+        &pick.to_string(),
+    );
+    load_from_path(&path)
+}
+
+fn visit(
+    input: &ResolverInput,
+    state: &mut State,
+    node: ResolvedNode,
+    requested: Constraint,
+) -> Result<(), ResolveError> {
+    if state.on_stack.iter().any(|n| n == &node.name) {
+        let mut path = state.on_stack.clone();
+        path.push(node.name.clone());
+        return Err(ResolveError::Cycle(path.join(" -> ")));
+    }
+    if let Some(existing) = state.selected.get(&node.name) {
+        if !requested.matches(&existing.version) {
+            return Err(ResolveError::Conflict {
+                name: node.name,
+                req: requested.0.to_string(),
+                existing: existing.version.to_string(),
+                available: vec![existing.version.to_string()],
+            });
+        }
+        return Ok(());
+    }
+    state.on_stack.push(node.name.clone());
+    let name = node.name.clone();
+    let requires = node.manifest.requires.clone();
+    state.selected.insert(name.clone(), node);
+
+    for req in requires {
+        let c = Constraint::parse(&req.version)?;
+        let chosen = pick_best(input, &req.name, &c)?;
+        visit(input, state, chosen, c)?;
+    }
+
+    state.install_order.push(name);
+    state.on_stack.pop();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_skill(reg_dir: &Path, name: &str, version: &str, requires: &[(&str, &str)]) {
+        let vdir = reg_dir.join("skills").join(name).join("versions");
+        fs::create_dir_all(&vdir).unwrap();
+        let mut yaml = format!(
+            "name: {name}\nversion: {version}\npublisher: human:test\ndescription: test\ncategory: context\ncontent:\n  abstract: a\n  context: b\n"
+        );
+        if !requires.is_empty() {
+            yaml.push_str("requires:\n");
+            for (n, v) in requires {
+                yaml.push_str(&format!("  - name: {n}\n    version: \"{v}\"\n"));
+            }
+        }
+        fs::write(vdir.join(format!("{version}.yaml")), yaml).unwrap();
+    }
+
+    fn make_input(reg_dir: &Path) -> ResolverInput {
+        ResolverInput {
+            mur_home: reg_dir.to_path_buf(),
+            registry_dir: reg_dir.to_path_buf(),
+        }
+    }
+
+    #[test]
+    fn single_skill_no_requires() {
+        let d = tempdir().unwrap();
+        write_skill(d.path(), "solo", "1.0.0", &[]);
+        let input = make_input(d.path());
+        let nodes = resolve(&input, ResolveSource::RegistryLatest("solo")).unwrap();
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].name, "solo");
+        assert_eq!(nodes[0].version.to_string(), "1.0.0");
+    }
+
+    #[test]
+    fn transitive_picks_highest_and_leaves_first_order() {
+        let d = tempdir().unwrap();
+        write_skill(d.path(), "dep-b", "1.0.0", &[]);
+        write_skill(d.path(), "dep-b", "1.1.0", &[]);
+        write_skill(d.path(), "root", "0.1.0", &[("dep-b", ">=1.0.0")]);
+        let input = make_input(d.path());
+        let nodes = resolve(&input, ResolveSource::RegistryLatest("root")).unwrap();
+        assert_eq!(nodes.len(), 2, "root + dep-b");
+        // Leaves first: dep-b before root
+        assert_eq!(nodes[0].name, "dep-b");
+        assert_eq!(nodes[0].version.to_string(), "1.1.0");
+        assert_eq!(nodes[1].name, "root");
+    }
+
+    #[test]
+    fn conflict_when_constraints_clash() {
+        let d = tempdir().unwrap();
+        // A requires B 1.x, C requires B 2.x; A also requires C
+        write_skill(d.path(), "dep-b", "1.0.0", &[]);
+        write_skill(d.path(), "dep-b", "2.0.0", &[]);
+        write_skill(d.path(), "dep-c", "1.0.0", &[("dep-b", "^2.0.0")]);
+        write_skill(
+            d.path(),
+            "root",
+            "0.1.0",
+            &[("dep-b", "^1.0.0"), ("dep-c", "*")],
+        );
+        let input = make_input(d.path());
+        let err = resolve(&input, ResolveSource::RegistryLatest("root")).unwrap_err();
+        assert!(
+            matches!(err, ResolveError::Conflict { .. }),
+            "expected Conflict, got: {err}"
+        );
+    }
+
+    #[test]
+    fn cycle_detection_direct() {
+        let d = tempdir().unwrap();
+        write_skill(d.path(), "alpha", "1.0.0", &[("beta", "*")]);
+        write_skill(d.path(), "beta", "1.0.0", &[("alpha", "*")]);
+        let input = make_input(d.path());
+        let err = resolve(&input, ResolveSource::RegistryLatest("alpha")).unwrap_err();
+        assert!(
+            matches!(err, ResolveError::Cycle(_)),
+            "expected Cycle, got: {err}"
+        );
+    }
+
+    #[test]
+    fn no_match_when_versions_too_low() {
+        let d = tempdir().unwrap();
+        write_skill(d.path(), "dep-b", "1.0.0", &[]);
+        write_skill(d.path(), "dep-b", "1.1.0", &[]);
+        write_skill(d.path(), "root", "0.1.0", &[("dep-b", "^2.0.0")]);
+        let input = make_input(d.path());
+        let err = resolve(&input, ResolveSource::RegistryLatest("root")).unwrap_err();
+        assert!(
+            matches!(err, ResolveError::NoMatch { .. }),
+            "expected NoMatch, got: {err}"
+        );
+    }
+
+    #[test]
+    fn diamond_dep_appears_once() {
+        let d = tempdir().unwrap();
+        write_skill(d.path(), "dep-d", "1.0.0", &[]);
+        write_skill(d.path(), "dep-b", "1.0.0", &[("dep-d", "1.x")]);
+        write_skill(d.path(), "dep-c", "1.0.0", &[("dep-d", "1.x")]);
+        write_skill(
+            d.path(),
+            "root",
+            "0.1.0",
+            &[("dep-b", "*"), ("dep-c", "*")],
+        );
+        let input = make_input(d.path());
+        let nodes = resolve(&input, ResolveSource::RegistryLatest("root")).unwrap();
+        // dep-d should appear exactly once
+        let d_count = nodes.iter().filter(|n| n.name == "dep-d").count();
+        assert_eq!(d_count, 1, "diamond dep appeared {d_count} times, expected 1");
+        // Total: root + b + c + d = 4
+        assert_eq!(nodes.len(), 4);
+    }
+
+    #[test]
+    fn garbage_version_in_requires_is_bad_constraint() {
+        let d = tempdir().unwrap();
+        write_skill(d.path(), "dep-b", "1.0.0", &[]);
+        write_skill(d.path(), "root", "0.1.0", &[("dep-b", "not-semver")]);
+        let input = make_input(d.path());
+        let err = resolve(&input, ResolveSource::RegistryLatest("root")).unwrap_err();
+        assert!(
+            matches!(err, ResolveError::BadConstraint(_)),
+            "expected BadConstraint, got: {err}"
+        );
+    }
+}

--- a/mur-core/src/cmd/skill_resolver.rs
+++ b/mur-core/src/cmd/skill_resolver.rs
@@ -100,8 +100,8 @@ fn load_from_path(path: &Path) -> Result<ResolvedNode, ResolveError> {
     let text = std::fs::read_to_string(path).map_err(|e| ResolveError::Other(e.into()))?;
     let m = parse_canonical(&text).map_err(|e| ResolveError::BadManifest(e.to_string()))?;
     validate(&m).map_err(|e| ResolveError::BadManifest(e.to_string()))?;
-    let v =
-        Version::parse(&m.version).map_err(|e| ResolveError::BadManifest(format!("version: {e}")))?;
+    let v = Version::parse(&m.version)
+        .map_err(|e| ResolveError::BadManifest(format!("version: {e}")))?;
     Ok(ResolvedNode {
         name: m.name.clone(),
         version: v,
@@ -124,11 +124,8 @@ fn pick_best(
         req: c.0.to_string(),
         available: versions.iter().map(|v| v.to_string()).collect(),
     })?;
-    let path = crate::cmd::skill_registry::skill_yaml_path(
-        &input.registry_dir,
-        name,
-        &pick.to_string(),
-    );
+    let path =
+        crate::cmd::skill_registry::skill_yaml_path(&input.registry_dir, name, &pick.to_string());
     load_from_path(&path)
 }
 
@@ -278,17 +275,15 @@ mod tests {
         write_skill(d.path(), "dep-d", "1.0.0", &[]);
         write_skill(d.path(), "dep-b", "1.0.0", &[("dep-d", "1.x")]);
         write_skill(d.path(), "dep-c", "1.0.0", &[("dep-d", "1.x")]);
-        write_skill(
-            d.path(),
-            "root",
-            "0.1.0",
-            &[("dep-b", "*"), ("dep-c", "*")],
-        );
+        write_skill(d.path(), "root", "0.1.0", &[("dep-b", "*"), ("dep-c", "*")]);
         let input = make_input(d.path());
         let nodes = resolve(&input, ResolveSource::RegistryLatest("root")).unwrap();
         // dep-d should appear exactly once
         let d_count = nodes.iter().filter(|n| n.name == "dep-d").count();
-        assert_eq!(d_count, 1, "diamond dep appeared {d_count} times, expected 1");
+        assert_eq!(
+            d_count, 1,
+            "diamond dep appeared {d_count} times, expected 1"
+        );
         // Total: root + b + c + d = 4
         assert_eq!(nodes.len(), 4);
     }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -287,6 +287,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             }
             crate::cli::SkillAction::Publish { path } => cmd::skill_publish::cmd_publish(&path)?,
             crate::cli::SkillAction::Update { name } => cmd::skill_install::cmd_update_cli(&name)?,
+            crate::cli::SkillAction::Deps { name } => cmd::skill_deps::cmd_deps_cli(&name)?,
         },
         Commands::Exchange { action } => match action {
             ExchangeAction::Import { file } => cmd::misc::cmd_exchange_import(&file)?,

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -283,10 +283,10 @@ pub async fn run(cli: Cli) -> Result<()> {
                 cmd::skill_cmd::cmd_trust(&name, &level)?
             }
             crate::cli::SkillAction::Install { source } => {
-                cmd::skill_install::cmd_install(&source)?
+                cmd::skill_install::cmd_install_cli(&source)?
             }
             crate::cli::SkillAction::Publish { path } => cmd::skill_publish::cmd_publish(&path)?,
-            crate::cli::SkillAction::Update { name } => cmd::skill_install::cmd_update(&name)?,
+            crate::cli::SkillAction::Update { name } => cmd::skill_install::cmd_update_cli(&name)?,
         },
         Commands::Exchange { action } => match action {
             ExchangeAction::Import { file } => cmd::misc::cmd_exchange_import(&file)?,

--- a/mur-core/tests/common/mod.rs
+++ b/mur-core/tests/common/mod.rs
@@ -1,0 +1,86 @@
+//! Test-only: filesystem git repo that behaves like the real mur skill registry.
+//! Tests clone it via `git clone file://...` exactly as production does.
+
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+pub struct TestRegistry {
+    dir: TempDir,
+}
+
+impl TestRegistry {
+    pub fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        run(dir.path(), &["init", "-q", "-b", "main"]);
+        run(dir.path(), &["config", "user.email", "test@mur.local"]);
+        run(dir.path(), &["config", "user.name", "test"]);
+        let index_yaml = "schema_version: 1\nupdated_at: 2026-01-01T00:00:00Z\nskills: {}\n";
+        std::fs::write(dir.path().join("index.yaml"), index_yaml).unwrap();
+        Self { dir }
+    }
+
+    /// Publish a skill version. Each call adds a new `versions/<v>.yaml` and
+    /// updates `index.yaml`'s `latest` to this version.
+    pub fn publish(&self, name: &str, version: &str, requires: &[(&str, &str)]) {
+        let vdir = self.dir.path().join("skills").join(name).join("versions");
+        std::fs::create_dir_all(&vdir).unwrap();
+        std::fs::write(
+            vdir.join(format!("{version}.yaml")),
+            build_skill_yaml(name, version, requires),
+        )
+        .unwrap();
+        bump_index_latest(self.dir.path(), name, version);
+    }
+
+    /// `git add . && git commit` so the repo has a real HEAD that `git clone` can fetch.
+    pub fn commit(&self) {
+        run(self.dir.path(), &["add", "."]);
+        run(self.dir.path(), &["commit", "-q", "-m", "test fixture"]);
+    }
+
+    /// `file://` URL accepted by `git clone` on macOS/Linux/Windows alike.
+    pub fn url(&self) -> String {
+        format!("file://{}", self.dir.path().display())
+    }
+}
+
+fn run(cwd: &Path, args: &[&str]) {
+    let st = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .status()
+        .expect("git available");
+    assert!(st.success(), "git {:?} failed in {}", args, cwd.display());
+}
+
+fn build_skill_yaml(name: &str, version: &str, requires: &[(&str, &str)]) -> String {
+    let mut s = format!(
+        "name: {name}\nversion: {version}\npublisher: human:test\ndescription: test\ncategory: context\ncontent:\n  abstract: a\n  context: b\n"
+    );
+    if !requires.is_empty() {
+        s.push_str("requires:\n");
+        for (n, v) in requires {
+            s.push_str(&format!("  - name: {n}\n    version: \"{v}\"\n"));
+        }
+    }
+    s
+}
+
+fn bump_index_latest(reg_root: &Path, name: &str, version: &str) {
+    use mur_common::skill::registry::{RegistryIndex, RegistrySkillEntry};
+    let p = reg_root.join("index.yaml");
+    let mut idx: RegistryIndex =
+        serde_yaml_ng::from_str(&std::fs::read_to_string(&p).unwrap()).unwrap();
+    let entry = idx.skills.entry(name.into()).or_insert(RegistrySkillEntry {
+        latest: version.into(),
+        description: "test".into(),
+        publisher: "human:test".into(),
+        category: "context".into(),
+        tags: vec![],
+        content_sha256: String::new(),
+        install_count: 0,
+    });
+    entry.latest = version.into();
+    std::fs::write(&p, idx.to_yaml().unwrap()).unwrap();
+}

--- a/mur-core/tests/skill_install_recursive_e2e.rs
+++ b/mur-core/tests/skill_install_recursive_e2e.rs
@@ -1,0 +1,84 @@
+mod common;
+use common::TestRegistry;
+use mur_common::skill::SkillLock;
+use mur_common::trust::skills::SkillTrustStore;
+use mur_core::cmd::skill_install::cmd_install;
+use std::collections::HashSet;
+
+#[test]
+fn install_with_transitive_deps_writes_full_lock_and_trust() {
+    let home = tempfile::tempdir().unwrap();
+    let reg = TestRegistry::new();
+    reg.publish("dep-c", "1.0.0", &[]);
+    reg.publish("dep-b", "1.2.0", &[("dep-c", ">=1.0.0")]);
+    reg.publish("root", "0.1.0", &[("dep-b", "^1.0.0")]);
+    reg.commit();
+
+    cmd_install(home.path(), &reg.url(), "root").expect("install ok");
+
+    // All three skill.yaml files written
+    for name in ["root", "dep-b", "dep-c"] {
+        assert!(
+            home.path()
+                .join("skills")
+                .join(name)
+                .join("skill.yaml")
+                .exists(),
+            "{name} skill.yaml"
+        );
+    }
+
+    // skill.lock at root with all three pinned versions
+    let lock = SkillLock::read(&home.path().join("skills/root")).unwrap();
+    assert_eq!(lock.locked.get("root").map(String::as_str), Some("0.1.0"));
+    assert_eq!(lock.locked.get("dep-b").map(String::as_str), Some("1.2.0"));
+    assert_eq!(lock.locked.get("dep-c").map(String::as_str), Some("1.0.0"));
+    // installed_at — shape, not value
+    chrono::DateTime::parse_from_rfc3339(&lock.installed_at).expect("rfc3339");
+
+    // Trust store has all three (look up by name, not hash)
+    let trust = SkillTrustStore::load(home.path()).unwrap();
+    let names: HashSet<String> = trust.entries.values().map(|e| e.name.clone()).collect();
+    let expected: HashSet<String> = ["root", "dep-b", "dep-c"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    assert_eq!(names, expected);
+}
+
+#[test]
+fn cycle_propagates_error_and_leaves_clean_filesystem() {
+    let home = tempfile::tempdir().unwrap();
+    let reg = TestRegistry::new();
+    reg.publish("alpha", "1.0.0", &[("beta", "*")]);
+    reg.publish("beta", "1.0.0", &[("alpha", "*")]);
+    reg.commit();
+
+    let err = cmd_install(home.path(), &reg.url(), "alpha").unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("cyclic"),
+        "expected cyclic-dependency error, got: {err}"
+    );
+
+    // Resolver fails before any disk install — neither alpha nor beta should be installed.
+    assert!(!home.path().join("skills/alpha/skill.yaml").exists());
+    assert!(!home.path().join("skills/beta/skill.yaml").exists());
+    assert!(!home.path().join("skills/alpha/skill.lock").exists());
+}
+
+#[test]
+fn re_install_is_idempotent_and_rewrites_lock() {
+    let home = tempfile::tempdir().unwrap();
+    let reg = TestRegistry::new();
+    reg.publish("solo", "1.0.0", &[]);
+    reg.commit();
+
+    cmd_install(home.path(), &reg.url(), "solo").unwrap();
+    let lock1 = SkillLock::read(&home.path().join("skills/solo")).unwrap();
+
+    // Second call: must not panic, must produce equivalent end state.
+    cmd_install(home.path(), &reg.url(), "solo").unwrap();
+    let lock2 = SkillLock::read(&home.path().join("skills/solo")).unwrap();
+
+    assert_eq!(lock1.locked, lock2.locked);
+}


### PR DESCRIPTION
## Summary

- Adds semver `Constraint` parser for `requires:` version matching (`>=1.0.0`, `^1.2.3`, `~1.2.3`, exact, `*`)
- Adds `SkillLock` with atomic temp+rename write at `~/.mur/skills/<name>/skill.lock`
- Registry: `available_versions()` enumerates `skills/<name>/versions/*.yaml` on disk
- DFS resolver with cycle detection, semver constraint matching, leaves-first install ordering, and conflict reporting
- `mur skill install` now recursively resolves `requires:`, installs transitive deps, scans each, and writes `skill.lock`
- `mur skill update` re-resolves to latest registry versions
- `mur skill deps <name>` prints the locked dependency tree
- Refactored `cmd_install`/`cmd_update` into pure functions (home + registry_url) + CLI shims for testability and future M4 peer-transfer
- `MUR_SKILL_REGISTRY_URL` env var for private mirrors / enterprise air-gapped registries
- E2E integration tests over real `git clone` against `file://` registry

## Test Plan

- [x] `cargo test -p mur-common` — 7 constraint tests + 3 lockfile tests pass
- [x] `cargo test -p mur-core` — 1221 tests pass (7 resolver + 3 registry + 2 deps + 1 install); 1 pre-existing failure (sleep config)
- [x] `cargo test -p mur-core --test skill_install_recursive_e2e` — 3 e2e tests (transitive install, cycle detection, idempotency) pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)