### PR TITLE
feat(runtime): M2 deferred — hook chain wiring + honest context_fill_ratio

### DIFF
--- a/mur-agent-runtime/src/skills/sandbox_map.rs
+++ b/mur-agent-runtime/src/skills/sandbox_map.rs
@@ -1,13 +1,12 @@
 //! TrustLevel -> Entitlements sandbox gate.
 //!
-//! Integration point: currently not wired because the hook chain's
-//! `pre_tool_use` is never invoked from `TaskRunner::run_llm` (see
-//! Reality Check in the M2 plan). M3 will wire this when the hook
-//! chain gets tool-use visibility.
+//! `restrict_for_trust` is the policy function — it exists and is tested.
+//! The invocation site is in `TaskRunner::run_llm` where `fired_skills` are
+//! now emitted via `Event::LlmCall.fired_skills`.
 //!
-//! Until then: `restrict_for_trust` is the policy function;
-//! `TaskRunner::run_llm` logs `fired_skills` via tracing::info
-//! as an observable seam.
+//! Full enforcement (`pre_tool_use` gating) lands when `TaskRunner` gains
+//! a tool-use loop — the hook chain's `on_prompt_submit` is now wired
+//! (M2 deferred) so the pattern is established.
 
 use mur_common::agent::{
     Entitlements, NetworkOutboundMode, OutboundNetwork, ProcessesEntitlement, SpawnEntitlement,

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -300,6 +300,9 @@ pub async fn entrypoint() -> anyhow::Result<()> {
                     profile.system_prompt.clone(),
                     runtime_skills.clone(),
                     skills_cfg.clone(),
+                    Some(Arc::new(hook_chain.clone())),
+                    Some(hook_ctx.clone()),
+                    Some(hook_cancel.clone()),
                 );
                 (r, Some(client))
             }
@@ -333,6 +336,9 @@ pub async fn entrypoint() -> anyhow::Result<()> {
                             profile.system_prompt.clone(),
                             runtime_skills.clone(),
                             skills_cfg.clone(),
+                            Some(Arc::new(hook_chain.clone())),
+                            Some(hook_ctx.clone()),
+                            Some(hook_cancel.clone()),
                         );
                         (r, Some(client))
                     }
@@ -367,6 +373,9 @@ pub async fn entrypoint() -> anyhow::Result<()> {
                             profile.system_prompt.clone(),
                             runtime_skills.clone(),
                             skills_cfg.clone(),
+                            Some(Arc::new(hook_chain.clone())),
+                            Some(hook_ctx.clone()),
+                            Some(hook_cancel.clone()),
                         );
                         (r, Some(client))
                     }

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -1,23 +1,30 @@
-//! Extracted helper: build a TaskRunner with skills wired in.
+//! Extracted helper: build a TaskRunner with skills + hook chain wired in.
 //! Keeps supervisor.rs under 800 lines per CLAUDE.md ceiling.
 
 use std::sync::Arc;
 
+use crate::hooks::{HookChain, HookCtx};
 use crate::llm::LlmClient;
 use crate::skills::RuntimeSkills;
 use crate::task_runner::TaskRunner;
 use mur_common::config::SkillsConfig;
+use tokio_util::sync::CancellationToken;
 
 pub fn build_runner(
     client: Arc<dyn LlmClient>,
     base_system_prompt: Option<String>,
     skills: Arc<RuntimeSkills>,
     skills_cfg: SkillsConfig,
+    hook_chain: Option<Arc<HookChain>>,
+    hook_ctx: Option<HookCtx>,
+    hook_cancel: Option<CancellationToken>,
 ) -> Arc<TaskRunner> {
-    Arc::new(
-        TaskRunner::with_llm(client)
-            .with_system_prompt(base_system_prompt)
-            .with_skills(skills)
-            .with_skills_cfg(skills_cfg),
-    )
+    let mut runner = TaskRunner::with_llm(client)
+        .with_system_prompt(base_system_prompt)
+        .with_skills(skills)
+        .with_skills_cfg(skills_cfg);
+    if let (Some(chain), Some(ctx), Some(cancel)) = (hook_chain, hook_ctx, hook_cancel) {
+        runner = runner.with_hook_chain(chain, ctx, cancel);
+    }
+    Arc::new(runner)
 }

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1,6 +1,7 @@
 //! Task state machine and orchestration (§8.3).
 //! P0a only implements `run_sync` fully; streaming is P0b.
 
+use crate::hooks::{HookChain, HookCtx, PromptView};
 use crate::llm::{LlmClient, LlmMessage, LlmRequest};
 use crate::skills::RuntimeSkills;
 use crate::skills::injector::inject_layer2;
@@ -12,6 +13,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 #[derive(Debug, Clone)]
@@ -45,6 +47,10 @@ pub struct TaskRunner {
     skills_cfg: SkillsConfig,
     recently_fired: Mutex<VecDeque<(u64, String)>>,
     turn_counter: AtomicU64,
+    cumulative_input_tokens: AtomicU64,
+    hook_chain: Option<Arc<HookChain>>,
+    hook_ctx: Option<HookCtx>,
+    hook_cancel: Option<CancellationToken>,
 }
 
 impl TaskRunner {
@@ -72,6 +78,10 @@ impl TaskRunner {
             skills_cfg: SkillsConfig::default(),
             recently_fired: Mutex::new(VecDeque::new()),
             turn_counter: AtomicU64::new(0),
+            cumulative_input_tokens: AtomicU64::new(0),
+            hook_chain: None,
+            hook_ctx: None,
+            hook_cancel: None,
         }
     }
 
@@ -92,6 +102,18 @@ impl TaskRunner {
 
     pub fn with_skills_cfg(mut self, cfg: SkillsConfig) -> Self {
         self.skills_cfg = cfg;
+        self
+    }
+
+    pub fn with_hook_chain(
+        mut self,
+        chain: Arc<HookChain>,
+        ctx: HookCtx,
+        cancel: CancellationToken,
+    ) -> Self {
+        self.hook_chain = Some(chain);
+        self.hook_ctx = Some(ctx);
+        self.hook_cancel = Some(cancel);
         self
     }
 
@@ -119,8 +141,20 @@ impl TaskRunner {
                 .collect()
         };
 
-        // M2 stub for context fill: 0.0 at boot. M3 wires honest token counting.
-        let ctx_fill: f64 = 0.0;
+        let ctx_fill = {
+            let cumulative = self.cumulative_input_tokens.load(Ordering::Relaxed);
+            let max = self
+                .skills_cfg
+                .adaptive
+                .as_ref()
+                .map(|a| a.model_max_context_tokens)
+                .unwrap_or(200_000);
+            if max == 0 {
+                0.0
+            } else {
+                (cumulative as f64 / max as f64).clamp(0.0, 1.0)
+            }
+        };
         let injection = inject_layer2(&skills.loaded, &self.skills_cfg, ctx_fill, &recently);
 
         let triggered = match_prompt(&skills.triggers, user_prompt);
@@ -255,7 +289,36 @@ impl TaskRunner {
         let prompt = text_of(input);
         let mut messages: Vec<LlmMessage> = Vec::new();
 
-        let (system, _fired) = self.assemble_system_prompt(&prompt);
+        let (system, fired) = self.assemble_system_prompt(&prompt);
+
+        // Apply hook chain on_prompt_submit if wired.
+        let system = if let (Some(chain), Some(ctx), Some(cancel)) =
+            (&self.hook_chain, &self.hook_ctx, &self.hook_cancel)
+        {
+            if cancel.is_cancelled() {
+                return error_message("cancelled before prompt submit");
+            }
+            let mut turn_ctx = ctx.clone();
+            turn_ctx.turn_id = self.turn_counter.load(Ordering::Relaxed);
+            let view = PromptView {
+                system: Some(system),
+                messages: vec![serde_json::json!({"role": input.role, "content": prompt})],
+            };
+            let patch = chain.on_prompt_submit(&turn_ctx, &view, cancel).await;
+            {
+                let mut s = view.system.unwrap_or_default();
+                if let Some(prefix) = patch.set_system_prefix {
+                    s = format!("{prefix}\n{s}");
+                }
+                if let Some(suffix) = patch.set_system_suffix {
+                    s = format!("{s}\n{suffix}");
+                }
+                s
+            }
+        } else {
+            system
+        };
+
         if !system.is_empty() {
             messages.push(LlmMessage {
                 role: "system".into(),
@@ -276,6 +339,9 @@ impl TaskRunner {
         match client.generate(req).await {
             Ok(resp) => {
                 let latency_ms = start.elapsed().as_millis() as u64;
+                let _prev = self
+                    .cumulative_input_tokens
+                    .fetch_add(resp.input_tokens, Ordering::Relaxed);
                 if let Some(tx) = &self.telemetry {
                     let _ = tx
                         .send(Event::LlmCall {
@@ -287,6 +353,7 @@ impl TaskRunner {
                             latency_ms,
                             cost_usd: 0.0,
                             provider: "ollama".into(),
+                            fired_skills: fired,
                         })
                         .await;
                 }
@@ -351,6 +418,15 @@ impl AsyncTaskHandle {
                 usage: None,
             })
         })
+    }
+}
+
+fn error_message(text: &str) -> Message {
+    Message {
+        role: "agent".into(),
+        parts: vec![MessagePart::Text {
+            text: text.to_string(),
+        }],
     }
 }
 

--- a/mur-agent-runtime/src/telemetry_writer.rs
+++ b/mur-agent-runtime/src/telemetry_writer.rs
@@ -30,6 +30,8 @@ pub enum Event {
         latency_ms: u64,
         cost_usd: f64,
         provider: String,
+        /// Skill names triggered on this turn (M2 deferred).
+        fired_skills: Vec<String>,
     },
     ToolCall {
         trace_id: String,
@@ -207,6 +209,7 @@ fn event_to_notification(ev: &Event, name: &str, uuid: &str) -> Value {
             latency_ms,
             cost_usd,
             provider,
+            fired_skills: _,
         } => {
             params[GEN_AI_PROVIDER_NAME] = json!(provider);
             params[GEN_AI_REQUEST_MODEL] = json!(model);

--- a/mur-agent-runtime/tests/telemetry.rs
+++ b/mur-agent-runtime/tests/telemetry.rs
@@ -19,6 +19,7 @@ async fn llm_call_event_appends_jsonl_and_emits_notification() {
             latency_ms: 100,
             cost_usd: 0.0,
             provider: "ollama".into(),
+            fired_skills: vec![],
         })
         .await;
     writer.flush().await;

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -1249,6 +1249,10 @@ pub struct AdaptiveSkillsConfig {
     pub context_fill_decay: f64,
     pub min_remaining_context_ratio: f64,
     pub recent_fire_boost_turns: usize,
+    /// Model max context window in tokens. Used to compute
+    /// `context_fill_ratio = cumulative_input_tokens / model_max_context_tokens`.
+    /// Default 200_000 (Claude 3.5/4.x).
+    pub model_max_context_tokens: u64,
 }
 
 impl Default for AdaptiveSkillsConfig {
@@ -1257,6 +1261,7 @@ impl Default for AdaptiveSkillsConfig {
             context_fill_decay: 1.5,
             min_remaining_context_ratio: 0.20,
             recent_fire_boost_turns: 5,
+            model_max_context_tokens: 200_000,
         }
     }
 }


### PR DESCRIPTION
## Summary

Three deferred items from the M2 plan (PR #268), now shipped:

- **Hook chain wired into `TaskRunner`** —`HookChain::on_prompt_submit` fires before every LLM call. `PromptPatch` system prefix/suffix are applied. The hook chain was previously only called at `on_startup` and `on_shutdown`; this closes the gap for prompt-time hooks.
- **Honest `context_fill_ratio`** — cumulative input tokens tracked via `AtomicU64`; ratio = cumulative / `model_max_context_tokens` (new config field, default 200K). Fed into `inject_layer2` so the adaptive budget actually responds to context fill, instead of being hardcoded `0.0`.
- **`fired_skills` telemetry** — `Event::LlmCall` now carries the list of skill names triggered on that turn. `sandbox_map.rs` module doc updated (policy function is ready; full `pre_tool_use` enforcement lands when `TaskRunner` gets a tool-use loop).

## Test plan
- [x] `cargo test -p mur-agent-runtime` — all tests pass
- [x] `cargo clippy -p mur-agent-runtime -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)