### PR TITLE
feat(skill): mur skill evolve — self-evolution loop (M3c)

### DIFF
--- a/mur-agent-runtime/src/telemetry_writer.rs
+++ b/mur-agent-runtime/src/telemetry_writer.rs
@@ -209,7 +209,7 @@ fn event_to_notification(ev: &Event, name: &str, uuid: &str) -> Value {
             latency_ms,
             cost_usd,
             provider,
-            fired_skills: _,
+            fired_skills,
         } => {
             params[GEN_AI_PROVIDER_NAME] = json!(provider);
             params[GEN_AI_REQUEST_MODEL] = json!(model);
@@ -219,6 +219,9 @@ fn event_to_notification(ev: &Event, name: &str, uuid: &str) -> Value {
             params["cost_usd"] = json!(cost_usd);
             params["trace_id"] = json!(trace_id);
             params[MUR_TASK_ID] = json!(task_id);
+            if !fired_skills.is_empty() {
+                params[MUR_FIRED_SKILLS] = json!(fired_skills);
+            }
             METHOD_LLM_CALL
         }
         Event::ToolCall {
@@ -298,6 +301,7 @@ fn event_to_notification(ev: &Event, name: &str, uuid: &str) -> Value {
             METHOD_BRIDGE_ALIVE
         }
     };
+    params[MUR_EVENT_TYPE] = json!(method);
     json!({"jsonrpc": "2.0", "method": method, "params": params})
 }
 

--- a/mur-common/src/skill/evolution.rs
+++ b/mur-common/src/skill/evolution.rs
@@ -1,0 +1,80 @@
+//! Skill evolution log — records every generation of a skill.
+
+use serde::{Deserialize, Serialize};
+
+pub const CURRENT_GENERATION: u32 = 0;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvolutionEvent {
+    pub version: String,
+    #[serde(default)]
+    pub generation: u32,
+    pub source: String,
+    pub changes: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quality_score: Option<f64>,
+    #[serde(default)]
+    pub timestamp: String,
+}
+
+impl EvolutionEvent {
+    pub fn initial_human(publisher: &str, version: &str) -> Self {
+        Self {
+            version: version.to_string(),
+            generation: 0,
+            source: format!("human:{publisher}"),
+            changes: "Initial creation".into(),
+            quality_score: None,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+
+    pub fn evolved(version: &str, generation: u32, changes: &str, score: f64) -> Self {
+        Self {
+            version: version.to_string(),
+            generation,
+            source: "agent:evolver".into(),
+            changes: changes.into(),
+            quality_score: Some(score),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initial_human_produces_correct_shape() {
+        let event = EvolutionEvent::initial_human("david", "0.1.0");
+        assert_eq!(event.version, "0.1.0");
+        assert_eq!(event.generation, 0);
+        assert_eq!(event.source, "human:david");
+        assert_eq!(event.changes, "Initial creation");
+        assert!(event.quality_score.is_none());
+        assert!(!event.timestamp.is_empty());
+    }
+
+    #[test]
+    fn evolved_bumps_generation_and_sets_quality_score() {
+        let event = EvolutionEvent::evolved("0.1.1", 1, "fixed tool name", 0.85);
+        assert_eq!(event.version, "0.1.1");
+        assert_eq!(event.generation, 1);
+        assert_eq!(event.source, "agent:evolver");
+        assert_eq!(event.changes, "fixed tool name");
+        assert_eq!(event.quality_score, Some(0.85));
+    }
+
+    #[test]
+    fn evolution_event_roundtrips() {
+        let event = EvolutionEvent::evolved("1.2.3", 3, "patched X", 0.92);
+        let json = serde_json::to_string(&event).unwrap();
+        let back: EvolutionEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.version, event.version);
+        assert_eq!(back.generation, event.generation);
+        assert_eq!(back.source, event.source);
+        assert_eq!(back.changes, event.changes);
+        assert_eq!(back.quality_score, event.quality_score);
+    }
+}

--- a/mur-common/src/skill/manifest.rs
+++ b/mur-common/src/skill/manifest.rs
@@ -1,5 +1,6 @@
 //! Skill manifest — full serde representation of canonical `skill.yaml`.
 
+use super::evolution::EvolutionEvent;
 use super::types::{Category, ContentMode, HostId, Priority, TriggerKind, TrustLevel};
 use serde::{Deserialize, Serialize};
 
@@ -54,6 +55,10 @@ pub struct SkillManifest {
 
     #[serde(default)]
     pub priority: Priority,
+
+    /// Evolution history — each entry records one generation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evolution_log: Vec<EvolutionEvent>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -190,5 +195,48 @@ priority: normal
             command: None,
         };
         assert_eq!(c.mode(), None);
+    }
+
+    #[test]
+    fn skill_without_evolution_log_defaults_to_empty() {
+        // YAML without evolution_log field must parse and default to vec![].
+        let yaml = r#"
+name: no-evol
+version: 0.1.0
+publisher: human:test
+description: test
+category: workflow
+content:
+  abstract: test
+"#;
+        let m: SkillManifest = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(m.evolution_log.is_empty());
+    }
+
+    #[test]
+    fn skill_with_evolution_log_roundtrips() {
+        let yaml = r#"
+name: with-evol
+version: 0.1.0
+publisher: human:test
+description: test
+category: workflow
+content:
+  abstract: test
+evolution_log:
+  - version: "0.1.0"
+    generation: 0
+    source: "human:test"
+    changes: "Initial"
+    timestamp: "2026-01-01T00:00:00Z"
+"#;
+        let m: SkillManifest = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(m.evolution_log.len(), 1);
+        assert_eq!(m.evolution_log[0].version, "0.1.0");
+        // Round-trip.
+        let back = serde_yaml_ng::to_string(&m).unwrap();
+        let m2: SkillManifest = serde_yaml_ng::from_str(&back).unwrap();
+        assert_eq!(m2.evolution_log.len(), 1);
+        assert_eq!(m2.evolution_log[0].generation, 0);
     }
 }

--- a/mur-common/src/skill/mod.rs
+++ b/mur-common/src/skill/mod.rs
@@ -1,8 +1,8 @@
 //! MuR skill ecosystem — see `docs/superpowers/specs/2026-05-24-mur-skill-ecosystem-design.md`.
 
 pub mod capability;
-pub mod evolution;
 pub mod constraint;
+pub mod evolution;
 pub mod hash;
 pub mod loader;
 pub mod local;
@@ -18,9 +18,9 @@ pub mod validate;
 
 pub use capability::{Capability, CapabilityViolation, allowed_for, check_capabilities};
 pub use constraint::{Constraint, ConstraintError};
+pub use evolution::EvolutionEvent;
 pub use hash::{DriftStatus, content_sha256, ct_eq_hex, drift_status, sha256_hex};
 pub use loader::{LoadedSkill, SkillScope, load_all};
-pub use evolution::EvolutionEvent;
 pub use lockfile::{LockfileError, SkillLock};
 pub use manifest::*;
 pub use parser::{

--- a/mur-common/src/skill/mod.rs
+++ b/mur-common/src/skill/mod.rs
@@ -1,6 +1,7 @@
 //! MuR skill ecosystem — see `docs/superpowers/specs/2026-05-24-mur-skill-ecosystem-design.md`.
 
 pub mod capability;
+pub mod evolution;
 pub mod constraint;
 pub mod hash;
 pub mod loader;
@@ -19,6 +20,7 @@ pub use capability::{Capability, CapabilityViolation, allowed_for, check_capabil
 pub use constraint::{Constraint, ConstraintError};
 pub use hash::{DriftStatus, content_sha256, ct_eq_hex, drift_status, sha256_hex};
 pub use loader::{LoadedSkill, SkillScope, load_all};
+pub use evolution::EvolutionEvent;
 pub use lockfile::{LockfileError, SkillLock};
 pub use manifest::*;
 pub use parser::{

--- a/mur-common/src/telemetry.rs
+++ b/mur-common/src/telemetry.rs
@@ -44,6 +44,8 @@ pub const MUR_TRIGGER_KIND: &str = "mur.trigger.kind";
 pub const MUR_A2A_PEER_PUBKEY: &str = "mur.a2a.peer.pubkey";
 pub const MUR_HOOK_NAME: &str = "mur.hook.name";
 pub const MUR_HOOK_PHASE: &str = "mur.hook.phase";
+pub const MUR_FIRED_SKILLS: &str = "mur.fired_skills";
+pub const MUR_EVENT_TYPE: &str = "mur.event.type";
 
 // ───── method names emitted on the JSON-RPC notification side-channel ─────
 pub const METHOD_LLM_CALL: &str = "telemetry/llm_call";

--- a/mur-core/src/cli/skill.rs
+++ b/mur-core/src/cli/skill.rs
@@ -95,4 +95,15 @@ pub enum SkillAction {
         #[clap(long, default_value = "3")]
         threshold: usize,
     },
+    /// Self-evolve a skill by analyzing telemetry and applying minimal fixes.
+    Evolve {
+        /// Skill name to evolve.
+        name: String,
+        /// Preview changes without writing.
+        #[clap(long)]
+        dry_run: bool,
+        /// Max evolution iterations (default 3).
+        #[clap(long, default_value = "3")]
+        max_iterations: usize,
+    },
 }

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -43,6 +43,7 @@ pub(crate) mod server_cmd;
 pub(crate) mod session;
 pub mod skill_cmd;
 pub mod skill_deps;
+pub mod skill_evolve;
 pub mod skill_from_pattern;
 pub mod skill_generate;
 pub mod skill_install;

--- a/mur-core/src/cmd/skill_evolve.rs
+++ b/mur-core/src/cmd/skill_evolve.rs
@@ -1,0 +1,49 @@
+//! `mur skill evolve <name>` — self-evolution loop.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+pub struct EvolveOptions {
+    pub skill_name: String,
+    pub dry_run: bool,
+    pub max_iterations: usize,
+}
+
+pub async fn cmd_evolve(home: &Path, opts: EvolveOptions) -> Result<()> {
+    let config_path = home.join("config.yaml");
+    let cfg = mur_common::config::Config::load_or_default(&config_path);
+    let backend = cfg.conversations.ask.synthesize_backend();
+    let llm = crate::conversations::backend::factory::build_for_stage(&backend, "skill.evolve")
+        .context("build LLM client")?;
+
+    // Resolve agent name from env or config.
+    let agent_name = std::env::var("MUR_AGENT_NAME").unwrap_or_else(|_| "default".into());
+
+    let result = crate::evolve::skill_evolve::evolve_skill(
+        home,
+        &agent_name,
+        &opts.skill_name,
+        &*llm,
+        opts.max_iterations,
+        opts.dry_run,
+    )
+    .await?;
+
+    if opts.dry_run {
+        println!("Dry run complete — no changes written.");
+    }
+
+    // Print summary
+    if !result.diagnoses.is_empty() || result.new_version != result.original_version {
+        println!(
+            "Evolved {}: {} → {} (gen {}, score {:.2})",
+            opts.skill_name,
+            result.original_version,
+            result.new_version,
+            result.new_generation,
+            result.quality_score,
+        );
+    }
+
+    Ok(())
+}

--- a/mur-core/src/cmd/skill_from_pattern.rs
+++ b/mur-core/src/cmd/skill_from_pattern.rs
@@ -97,6 +97,7 @@ pub fn pattern_to_skill(pattern: &Pattern, polish: bool) -> Result<SkillManifest
         tags,
         triggers: vec![],
         priority: Default::default(),
+        evolution_log: vec![],
     };
 
     validate(&manifest).context("derived skill manifest failed schema validation")?;

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -320,6 +320,22 @@ pub async fn run(cli: Cli) -> Result<()> {
                     },
                 )?
             }
+            crate::cli::SkillAction::Evolve {
+                name,
+                dry_run,
+                max_iterations,
+            } => {
+                let home = cmd::agent::resolve_mur_home()?;
+                cmd::skill_evolve::cmd_evolve(
+                    &home,
+                    cmd::skill_evolve::EvolveOptions {
+                        skill_name: name,
+                        dry_run,
+                        max_iterations,
+                    },
+                )
+                .await?
+            }
         },
         Commands::Exchange { action } => match action {
             ExchangeAction::Import { file } => cmd::misc::cmd_exchange_import(&file)?,

--- a/mur-core/src/evolve/mod.rs
+++ b/mur-core/src/evolve/mod.rs
@@ -9,6 +9,7 @@ pub mod feedback;
 pub mod lifecycle;
 pub mod linker;
 pub mod maturity;
+pub mod skill_evolve;
 pub mod telemetry_reader;
 
 use mur_common::pattern::Pattern;

--- a/mur-core/src/evolve/mod.rs
+++ b/mur-core/src/evolve/mod.rs
@@ -9,6 +9,7 @@ pub mod feedback;
 pub mod lifecycle;
 pub mod linker;
 pub mod maturity;
+pub mod telemetry_reader;
 
 use mur_common::pattern::Pattern;
 

--- a/mur-core/src/evolve/skill_evolve.rs
+++ b/mur-core/src/evolve/skill_evolve.rs
@@ -1,0 +1,397 @@
+//! Skill evolution engine — FailureAnalyzer + SkillOptimizer + orchestration.
+//!
+//! Implements the closed loop: Create → Execute → Evaluate → Diagnose → Optimize → Repeat.
+
+use anyhow::{Context, Result};
+use mur_common::skill::{
+    EvolutionEvent, SkillManifest, global_skill_dir, parse_canonical, read_from_dir, validate,
+    write_to_dir,
+};
+use mur_common::skill::scan::{ContentScanReport, scan_skill};
+
+use super::telemetry_reader::{SkillExecution, read_skill_executions};
+use crate::conversations::backend::{ChatBackend, ChatRequest};
+
+// ─── Failure Analyzer ────────────────────────────────────────────────
+
+pub const FAILURE_ANALYZER_SYSTEM: &str = r#"
+You are a Failure Analyzer for a skill system. Given a skill's content and its
+execution telemetry, diagnose failures across 4 dimensions:
+
+1. Knowledge — skill lacks domain information
+2. Tool — wrong tool or wrong tool parameters
+3. Clarification — ambiguous instructions / under-specified variables
+4. Style — output format mismatch
+
+INPUT: skill YAML + list of execution records (tool calls, errors, latencies).
+
+OUTPUT: JSON array of diagnoses:
+[{
+  "dimension": "Knowledge|Tool|Clarification|Style",
+  "severity": 0.0-1.0,
+  "finding": "what is wrong",
+  "suggested_fix": "specific change to make in the skill YAML",
+  "evidence": ["telemetry excerpt 1", ...]
+}]
+
+Rules:
+- Only report actionable findings with clear evidence.
+- Severity 0.0 = cosmetic, 1.0 = blocking.
+- If no failures occurred, return an empty array [].
+"#;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Diagnosis {
+    pub dimension: DiagnosisDimension,
+    pub severity: f64,
+    pub finding: String,
+    pub suggested_fix: String,
+    pub evidence: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum DiagnosisDimension {
+    Knowledge,
+    Tool,
+    Clarification,
+    Style,
+}
+
+pub async fn diagnose_failures(
+    skill: &SkillManifest,
+    executions: &[SkillExecution],
+    llm: &dyn ChatBackend,
+) -> Result<Vec<Diagnosis>> {
+    let failed: Vec<_> = executions.iter().filter(|e| !e.was_successful).collect();
+    if failed.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let skill_yaml = serde_yaml_ng::to_string(skill).context("serialize skill for LLM")?;
+
+    let prompt = format!(
+        "Skill:\n{skill_yaml}\n\nExecutions ({} total, {} failures):\n{}",
+        executions.len(),
+        failed.len(),
+        failed
+            .iter()
+            .map(|e| format!(
+                "task={} tool_calls={:?} errors={:?} latency={}ms",
+                e.task_id, e.tool_calls, e.errors, e.latency_ms
+            ))
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+
+    let system = Some(FAILURE_ANALYZER_SYSTEM);
+    let resp = llm
+        .generate(ChatRequest {
+            model: "",
+            system,
+            user: &prompt,
+            max_tokens: 2048,
+            temperature: Some(0.1f32),
+            stop: vec![],
+            cache_system: false,
+            cache_user_prefix: None,
+        })
+        .await
+        .context("failure analyzer LLM call")?;
+
+    let raw = resp
+        .text
+        .trim()
+        .trim_start_matches("```json")
+        .trim_end_matches("```")
+        .trim();
+    let diagnoses: Vec<Diagnosis> =
+        serde_json::from_str(raw).context("failure analyzer did not return valid JSON")?;
+    Ok(diagnoses)
+}
+
+// ─── Skill Optimizer ──────────────────────────────────────────────────
+
+pub const SKILL_OPTIMIZER_SYSTEM: &str = r#"
+You are a Skill Optimizer. Given a skill YAML and a list of diagnosed failures,
+rewrite the skill applying the minimal changes needed to fix each issue.
+
+PRINCIPLE: Only change what's broken. Preserve verified behavior.
+- If a procedure step has the wrong tool, fix the tool name — don't rewrite the step.
+- If a variable is missing, add it — don't rename existing ones.
+- If instructions are ambiguous, clarify — don't restructure.
+
+INPUT: current skill YAML + JSON array of diagnoses.
+OUTPUT: complete rewritten skill YAML (all fields present).
+"#;
+
+pub async fn optimize_skill(
+    skill: &SkillManifest,
+    diagnoses: &[Diagnosis],
+    llm: &dyn ChatBackend,
+) -> Result<SkillManifest> {
+    let skill_yaml = serde_yaml_ng::to_string(skill).context("serialize skill for LLM")?;
+    let diagnoses_json =
+        serde_json::to_string_pretty(diagnoses).context("serialize diagnoses for LLM")?;
+
+    let prompt = format!("Current skill YAML:\n{skill_yaml}\n\nDiagnoses:\n{diagnoses_json}");
+
+    let system = Some(SKILL_OPTIMIZER_SYSTEM);
+    let resp = llm
+        .generate(ChatRequest {
+            model: "",
+            system,
+            user: &prompt,
+            max_tokens: 4096,
+            temperature: Some(0.2f32),
+            stop: vec![],
+            cache_system: false,
+            cache_user_prefix: None,
+        })
+        .await
+        .context("skill optimizer LLM call")?;
+
+    let yaml = resp
+        .text
+        .trim()
+        .trim_start_matches("```yaml")
+        .trim_end_matches("```")
+        .trim();
+    let evolved = parse_canonical(yaml).map_err(|e| anyhow::anyhow!("{e}"))?;
+    validate(&evolved).map_err(|e| anyhow::anyhow!("{e}"))?;
+    Ok(evolved)
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+fn bump_patch(version: &str) -> String {
+    let parts: Vec<&str> = version.splitn(3, '.').collect();
+    if parts.len() == 3 {
+        if let Ok(patch) = parts[2].parse::<u32>() {
+            return format!("{}.{}.{}", parts[0], parts[1], patch + 1);
+        }
+    }
+    format!("{version}.1")
+}
+
+fn score_executions(executions: &[SkillExecution]) -> f64 {
+    if executions.is_empty() {
+        return 0.0;
+    }
+    let ok = executions.iter().filter(|e| e.was_successful).count();
+    ok as f64 / executions.len() as f64
+}
+
+// ─── Orchestrator ─────────────────────────────────────────────────────
+
+pub struct EvolutionResult {
+    pub original_version: String,
+    pub new_version: String,
+    pub new_generation: u32,
+    pub quality_score: f64,
+    pub diagnoses: Vec<Diagnosis>,
+    pub changes_summary: String,
+    pub evolved_manifest: SkillManifest,
+}
+
+pub async fn evolve_skill(
+    home: &std::path::Path,
+    agent_name: &str,
+    skill_name: &str,
+    llm: &dyn ChatBackend,
+    max_iterations: usize,
+    dry_run: bool,
+) -> Result<EvolutionResult> {
+    let skill_dir = global_skill_dir(home, skill_name);
+    let manifest =
+        read_from_dir(&skill_dir).with_context(|| format!("skill '{skill_name}' not found"))?;
+
+    let telemetry_dir = home.join("agents").join(agent_name).join("telemetry");
+    let executions = read_skill_executions(&telemetry_dir, skill_name, 50)?;
+
+    if executions.is_empty() {
+        println!("No execution data for '{skill_name}' — nothing to evolve.");
+        return Ok(EvolutionResult {
+            original_version: manifest.version.clone(),
+            new_version: manifest.version.clone(),
+            new_generation: manifest
+                .evolution_log
+                .last()
+                .map(|e| e.generation)
+                .unwrap_or(0),
+            quality_score: 0.0,
+            diagnoses: vec![],
+            changes_summary: String::new(),
+            evolved_manifest: manifest,
+        });
+    }
+
+    let original_version = manifest.version.clone();
+    let mut current = manifest;
+
+    for iteration in 1..=max_iterations {
+        let diagnoses = diagnose_failures(&current, &executions, llm).await?;
+        if diagnoses.is_empty() {
+            println!("Iteration {iteration}: no failures diagnosed — skill is stable.");
+            break;
+        }
+
+        eprintln!(
+            "Iteration {iteration}: {} diagnosis(s) — {}",
+            diagnoses.len(),
+            diagnoses
+                .iter()
+                .map(|d| format!("{:?}({:.1})", d.dimension, d.severity))
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+
+        if dry_run {
+            for d in &diagnoses {
+                println!("  [{:?}] {} → {}", d.dimension, d.finding, d.suggested_fix);
+            }
+            continue;
+        }
+
+        let mut evolved = optimize_skill(&current, &diagnoses, llm).await?;
+
+        // Bump version: 0.1.0 → 0.1.1
+        let new_version = bump_patch(&current.version);
+        let generation = current
+            .evolution_log
+            .last()
+            .map(|e| e.generation + 1)
+            .unwrap_or(1);
+
+        let quality_score = score_executions(&executions);
+        let changes = diagnoses
+            .iter()
+            .map(|d| d.suggested_fix.clone())
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        evolved.version = new_version.clone();
+        evolved.evolution_log = current.evolution_log.clone();
+        evolved.evolution_log.push(EvolutionEvent::evolved(
+            &new_version,
+            generation,
+            &changes,
+            quality_score,
+        ));
+
+        // Write back.
+        write_to_dir(&skill_dir, &evolved)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .context("write evolved skill")?;
+
+        // Re-scan security.
+        let report: ContentScanReport =
+            scan_skill(&evolved).map_err(|e| anyhow::anyhow!("{e}"))?;
+        if report.has_blocking_findings() {
+            eprintln!("warning: evolved skill has new security findings — staying Sandboxed");
+        }
+
+        eprintln!("Evolved to v{new_version} (gen {generation}, score {quality_score:.2})");
+        current = evolved;
+    }
+
+    let new_version = current.version.clone();
+    let new_generation = current
+        .evolution_log
+        .last()
+        .map(|e| e.generation)
+        .unwrap_or(0);
+    let quality_score = score_executions(&executions);
+
+    Ok(EvolutionResult {
+        original_version,
+        new_version: new_version.clone(),
+        new_generation,
+        quality_score,
+        diagnoses: vec![], // Last iteration's diagnoses already consumed
+        changes_summary: current
+            .evolution_log
+            .last()
+            .map(|e| e.changes.clone())
+            .unwrap_or_default(),
+        evolved_manifest: current,
+    })
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bump_patch_increments() {
+        assert_eq!(bump_patch("0.1.0"), "0.1.1");
+        assert_eq!(bump_patch("2.0.0"), "2.0.1");
+        assert_eq!(bump_patch("1.2.9"), "1.2.10");
+    }
+
+    #[test]
+    fn bump_patch_handles_bad_input() {
+        assert_eq!(bump_patch("0.1"), "0.1.1");
+        assert_eq!(bump_patch("v1.2.3"), "v1.2.4");
+    }
+
+    #[test]
+    fn score_executions_all_ok() {
+        let execs = vec![
+            SkillExecution {
+                skill_name: "s".into(),
+                task_id: "t1".into(),
+                model: "m".into(),
+                input_tokens: 100,
+                latency_ms: 1000,
+                tool_calls: vec![],
+                errors: vec![],
+                was_successful: true,
+            },
+            SkillExecution {
+                skill_name: "s".into(),
+                task_id: "t2".into(),
+                model: "m".into(),
+                input_tokens: 200,
+                latency_ms: 1500,
+                tool_calls: vec![],
+                errors: vec![],
+                was_successful: true,
+            },
+        ];
+        assert_eq!(score_executions(&execs), 1.0);
+    }
+
+    #[test]
+    fn score_executions_mixed() {
+        let execs = vec![
+            SkillExecution {
+                skill_name: "s".into(),
+                task_id: "t1".into(),
+                model: "m".into(),
+                input_tokens: 100,
+                latency_ms: 1000,
+                tool_calls: vec![],
+                errors: vec![],
+                was_successful: true,
+            },
+            SkillExecution {
+                skill_name: "s".into(),
+                task_id: "t2".into(),
+                model: "m".into(),
+                input_tokens: 200,
+                latency_ms: 1500,
+                tool_calls: vec![],
+                errors: vec!["fail".into()],
+                was_successful: false,
+            },
+        ];
+        assert_eq!(score_executions(&execs), 0.5);
+    }
+
+    #[test]
+    fn score_executions_empty() {
+        assert_eq!(score_executions(&[]), 0.0);
+    }
+}

--- a/mur-core/src/evolve/skill_evolve.rs
+++ b/mur-core/src/evolve/skill_evolve.rs
@@ -3,11 +3,11 @@
 //! Implements the closed loop: Create → Execute → Evaluate → Diagnose → Optimize → Repeat.
 
 use anyhow::{Context, Result};
+use mur_common::skill::scan::{ContentScanReport, scan_skill};
 use mur_common::skill::{
     EvolutionEvent, SkillManifest, global_skill_dir, parse_canonical, read_from_dir, validate,
     write_to_dir,
 };
-use mur_common::skill::scan::{ContentScanReport, scan_skill};
 
 use super::telemetry_reader::{SkillExecution, read_skill_executions};
 use crate::conversations::backend::{ChatBackend, ChatRequest};
@@ -165,10 +165,10 @@ pub async fn optimize_skill(
 
 fn bump_patch(version: &str) -> String {
     let parts: Vec<&str> = version.splitn(3, '.').collect();
-    if parts.len() == 3 {
-        if let Ok(patch) = parts[2].parse::<u32>() {
-            return format!("{}.{}.{}", parts[0], parts[1], patch + 1);
-        }
+    if parts.len() == 3
+        && let Ok(patch) = parts[2].parse::<u32>()
+    {
+        return format!("{}.{}.{}", parts[0], parts[1], patch + 1);
     }
     format!("{version}.1")
 }
@@ -183,6 +183,7 @@ fn score_executions(executions: &[SkillExecution]) -> f64 {
 
 // ─── Orchestrator ─────────────────────────────────────────────────────
 
+#[allow(dead_code)]
 pub struct EvolutionResult {
     pub original_version: String,
     pub new_version: String,
@@ -249,7 +250,7 @@ pub async fn evolve_skill(
             for d in &diagnoses {
                 println!("  [{:?}] {} → {}", d.dimension, d.finding, d.suggested_fix);
             }
-            continue;
+            break;
         }
 
         let mut evolved = optimize_skill(&current, &diagnoses, llm).await?;
@@ -284,8 +285,7 @@ pub async fn evolve_skill(
             .context("write evolved skill")?;
 
         // Re-scan security.
-        let report: ContentScanReport =
-            scan_skill(&evolved).map_err(|e| anyhow::anyhow!("{e}"))?;
+        let report: ContentScanReport = scan_skill(&evolved).map_err(|e| anyhow::anyhow!("{e}"))?;
         if report.has_blocking_findings() {
             eprintln!("warning: evolved skill has new security findings — staying Sandboxed");
         }

--- a/mur-core/src/evolve/telemetry_reader.rs
+++ b/mur-core/src/evolve/telemetry_reader.rs
@@ -27,10 +27,12 @@ struct TelemetryLine {
     #[serde(rename = "message", default)]
     message: Option<String>,
     #[serde(rename = "kind", default)]
+    #[allow(dead_code)]
     kind: Option<String>,
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct SkillExecution {
     pub skill_name: String,
     pub task_id: String,
@@ -43,6 +45,7 @@ pub struct SkillExecution {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct ToolCallRecord {
     pub tool: String,
     pub ok: bool,
@@ -81,34 +84,31 @@ pub fn read_skill_executions(
             if executions.len() >= max_entries {
                 break;
             }
-            if let Ok(tl) = serde_json::from_str::<TelemetryLine>(line) {
-                if tl.event_type.as_deref() == Some("telemetry/llm_call")
-                    && tl
-                        .fired_skills
-                        .as_ref()
-                        .map_or(false, |fs| fs.iter().any(|s| s == skill_name))
-                {
-                    executions.push(SkillExecution {
-                        skill_name: skill_name.to_string(),
-                        task_id: tl.task_id.unwrap_or_default(),
-                        model: tl.model.unwrap_or_default(),
-                        input_tokens: tl.input_tokens.unwrap_or(0),
-                        latency_ms: tl.latency_ms.unwrap_or(0),
-                        tool_calls: vec![],
-                        errors: vec![],
-                        was_successful: true,
-                    });
-                }
+            if let Ok(tl) = serde_json::from_str::<TelemetryLine>(line)
+                && tl.event_type.as_deref() == Some("telemetry/llm_call")
+                && tl
+                    .fired_skills
+                    .as_ref()
+                    .is_some_and(|fs| fs.iter().any(|s| s == skill_name))
+            {
+                executions.push(SkillExecution {
+                    skill_name: skill_name.to_string(),
+                    task_id: tl.task_id.unwrap_or_default(),
+                    model: tl.model.unwrap_or_default(),
+                    input_tokens: tl.input_tokens.unwrap_or(0),
+                    latency_ms: tl.latency_ms.unwrap_or(0),
+                    tool_calls: vec![],
+                    errors: vec![],
+                    was_successful: true,
+                });
             }
         }
     }
 
     // Second pass (forward): correlate tool calls + errors with task IDs.
     // Build a set of tracked task IDs from the found executions.
-    let tracked_tasks: std::collections::HashSet<String> = executions
-        .iter()
-        .map(|e| e.task_id.clone())
-        .collect();
+    let tracked_tasks: std::collections::HashSet<String> =
+        executions.iter().map(|e| e.task_id.clone()).collect();
 
     for entry in &files {
         let content = match std::fs::read_to_string(entry.path()) {
@@ -180,7 +180,9 @@ mod tests {
         write_telemetry(
             dir.path(),
             "2026-05-25.jsonl",
-            &[r#"{"mur.event.type":"telemetry/llm_call","mur.task.id":"t1","mur.fired_skills":["target-skill"],"gen_ai.usage.input_tokens":100,"gen_ai.request.model":"claude","latency_ms":1200}"#],
+            &[
+                r#"{"mur.event.type":"telemetry/llm_call","mur.task.id":"t1","mur.fired_skills":["target-skill"],"gen_ai.usage.input_tokens":100,"gen_ai.request.model":"claude","latency_ms":1200}"#,
+            ],
         );
         let result = read_skill_executions(dir.path(), "target-skill", 50).unwrap();
         assert_eq!(result.len(), 1);
@@ -195,7 +197,9 @@ mod tests {
         write_telemetry(
             dir.path(),
             "2026-05-25.jsonl",
-            &[r#"{"mur.event.type":"telemetry/llm_call","mur.task.id":"t1","mur.fired_skills":["other-skill"],"gen_ai.usage.input_tokens":50,"gen_ai.request.model":"claude","latency_ms":800}"#],
+            &[
+                r#"{"mur.event.type":"telemetry/llm_call","mur.task.id":"t1","mur.fired_skills":["other-skill"],"gen_ai.usage.input_tokens":50,"gen_ai.request.model":"claude","latency_ms":800}"#,
+            ],
         );
         let result = read_skill_executions(dir.path(), "target-skill", 50).unwrap();
         assert!(result.is_empty());
@@ -208,7 +212,11 @@ mod tests {
         for i in 1..=5 {
             lines.push(format!(r#"{{"mur.event.type":"telemetry/llm_call","mur.task.id":"t{i}","mur.fired_skills":["my-skill"],"gen_ai.usage.input_tokens":100,"gen_ai.request.model":"claude","latency_ms":1000}}"#));
         }
-        write_telemetry(dir.path(), "2026-05-25.jsonl", &lines.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+        write_telemetry(
+            dir.path(),
+            "2026-05-25.jsonl",
+            &lines.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+        );
         let result = read_skill_executions(dir.path(), "my-skill", 2).unwrap();
         assert_eq!(result.len(), 2);
     }

--- a/mur-core/src/evolve/telemetry_reader.rs
+++ b/mur-core/src/evolve/telemetry_reader.rs
@@ -1,0 +1,234 @@
+//! Read agent telemetry JSONL, correlate with skill executions.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, Clone, Deserialize)]
+struct TelemetryLine {
+    #[serde(rename = "mur.event.type", default)]
+    event_type: Option<String>,
+    #[serde(rename = "mur.task.id", default)]
+    task_id: Option<String>,
+    #[serde(rename = "gen_ai.request.model", default)]
+    model: Option<String>,
+    #[serde(rename = "gen_ai.usage.input_tokens", default)]
+    input_tokens: Option<u64>,
+    #[serde(rename = "latency_ms", default)]
+    latency_ms: Option<u64>,
+    #[serde(rename = "tool", default)]
+    tool: Option<String>,
+    #[serde(rename = "ok", default)]
+    ok: Option<bool>,
+    #[serde(rename = "duration_ms", default)]
+    duration_ms: Option<u64>,
+    #[serde(rename = "mur.fired_skills", default)]
+    fired_skills: Option<Vec<String>>,
+    #[serde(rename = "message", default)]
+    message: Option<String>,
+    #[serde(rename = "kind", default)]
+    kind: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SkillExecution {
+    pub skill_name: String,
+    pub task_id: String,
+    pub model: String,
+    pub input_tokens: u64,
+    pub latency_ms: u64,
+    pub tool_calls: Vec<ToolCallRecord>,
+    pub errors: Vec<String>,
+    pub was_successful: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolCallRecord {
+    pub tool: String,
+    pub ok: bool,
+    pub duration_ms: u64,
+}
+
+/// Parse all telemetry files in `telemetry_dir`, return executions where
+/// `fired_skills` includes `skill_name`. Scans at most `max_entries` LlmCall
+/// events (most recent first via reverse file-scan).
+pub fn read_skill_executions(
+    telemetry_dir: &Path,
+    skill_name: &str,
+    max_entries: usize,
+) -> Result<Vec<SkillExecution>> {
+    if !telemetry_dir.exists() {
+        return Ok(vec![]);
+    }
+
+    // Collect JSONL files sorted by name descending (dates).
+    let mut files: Vec<_> = std::fs::read_dir(telemetry_dir)
+        .context("read telemetry dir")?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("jsonl"))
+        .collect();
+    files.sort_by_key(|e| std::cmp::Reverse(e.file_name()));
+
+    let mut executions: Vec<SkillExecution> = Vec::new();
+
+    for entry in &files {
+        if executions.len() >= max_entries {
+            break;
+        }
+        let content = std::fs::read_to_string(entry.path())
+            .with_context(|| format!("read {}", entry.path().display()))?;
+        for line in content.lines().rev() {
+            if executions.len() >= max_entries {
+                break;
+            }
+            if let Ok(tl) = serde_json::from_str::<TelemetryLine>(line) {
+                if tl.event_type.as_deref() == Some("telemetry/llm_call")
+                    && tl
+                        .fired_skills
+                        .as_ref()
+                        .map_or(false, |fs| fs.iter().any(|s| s == skill_name))
+                {
+                    executions.push(SkillExecution {
+                        skill_name: skill_name.to_string(),
+                        task_id: tl.task_id.unwrap_or_default(),
+                        model: tl.model.unwrap_or_default(),
+                        input_tokens: tl.input_tokens.unwrap_or(0),
+                        latency_ms: tl.latency_ms.unwrap_or(0),
+                        tool_calls: vec![],
+                        errors: vec![],
+                        was_successful: true,
+                    });
+                }
+            }
+        }
+    }
+
+    // Second pass (forward): correlate tool calls + errors with task IDs.
+    // Build a set of tracked task IDs from the found executions.
+    let tracked_tasks: std::collections::HashSet<String> = executions
+        .iter()
+        .map(|e| e.task_id.clone())
+        .collect();
+
+    for entry in &files {
+        let content = match std::fs::read_to_string(entry.path()) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        for line in content.lines() {
+            if let Ok(tl) = serde_json::from_str::<TelemetryLine>(line) {
+                let tid = tl.task_id.as_deref().unwrap_or("");
+                if !tracked_tasks.contains(tid) {
+                    continue;
+                }
+                match tl.event_type.as_deref() {
+                    Some("telemetry/tool_call") => {
+                        if let Some(tool) = &tl.tool {
+                            for exec in &mut executions {
+                                if exec.task_id == tid {
+                                    exec.tool_calls.push(ToolCallRecord {
+                                        tool: tool.clone(),
+                                        ok: tl.ok.unwrap_or(false),
+                                        duration_ms: tl.duration_ms.unwrap_or(0),
+                                    });
+                                    if !tl.ok.unwrap_or(true) {
+                                        exec.was_successful = false;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Some("telemetry/error") => {
+                        if let Some(msg) = &tl.message {
+                            for exec in &mut executions {
+                                if exec.task_id == tid {
+                                    exec.errors.push(msg.clone());
+                                    exec.was_successful = false;
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    Ok(executions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_telemetry(dir: &Path, filename: &str, lines: &[&str]) {
+        let content = lines.join("\n");
+        std::fs::write(dir.join(filename), content).unwrap();
+    }
+
+    #[test]
+    fn empty_telemetry_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = read_skill_executions(dir.path(), "my-skill", 50).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn single_match() {
+        let dir = tempfile::tempdir().unwrap();
+        write_telemetry(
+            dir.path(),
+            "2026-05-25.jsonl",
+            &[r#"{"mur.event.type":"telemetry/llm_call","mur.task.id":"t1","mur.fired_skills":["target-skill"],"gen_ai.usage.input_tokens":100,"gen_ai.request.model":"claude","latency_ms":1200}"#],
+        );
+        let result = read_skill_executions(dir.path(), "target-skill", 50).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].skill_name, "target-skill");
+        assert_eq!(result[0].task_id, "t1");
+        assert!(result[0].was_successful);
+    }
+
+    #[test]
+    fn non_matching_skill_filtered_out() {
+        let dir = tempfile::tempdir().unwrap();
+        write_telemetry(
+            dir.path(),
+            "2026-05-25.jsonl",
+            &[r#"{"mur.event.type":"telemetry/llm_call","mur.task.id":"t1","mur.fired_skills":["other-skill"],"gen_ai.usage.input_tokens":50,"gen_ai.request.model":"claude","latency_ms":800}"#],
+        );
+        let result = read_skill_executions(dir.path(), "target-skill", 50).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn respects_max_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut lines = Vec::new();
+        for i in 1..=5 {
+            lines.push(format!(r#"{{"mur.event.type":"telemetry/llm_call","mur.task.id":"t{i}","mur.fired_skills":["my-skill"],"gen_ai.usage.input_tokens":100,"gen_ai.request.model":"claude","latency_ms":1000}}"#));
+        }
+        write_telemetry(dir.path(), "2026-05-25.jsonl", &lines.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+        let result = read_skill_executions(dir.path(), "my-skill", 2).unwrap();
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn tool_errors_set_was_successful_false() {
+        let dir = tempfile::tempdir().unwrap();
+        write_telemetry(
+            dir.path(),
+            "2026-05-25.jsonl",
+            &[
+                r#"{"mur.event.type":"telemetry/llm_call","mur.task.id":"t1","mur.fired_skills":["my-skill"],"gen_ai.usage.input_tokens":100,"gen_ai.request.model":"claude","latency_ms":1200}"#,
+                r#"{"mur.event.type":"telemetry/tool_call","mur.task.id":"t1","tool":"wrong.tool","ok":false,"duration_ms":500}"#,
+                r#"{"mur.event.type":"telemetry/error","mur.task.id":"t1","kind":"ToolError","message":"tool not found"}"#,
+            ],
+        );
+        let result = read_skill_executions(dir.path(), "my-skill", 50).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(!result[0].was_successful);
+        assert_eq!(result[0].errors.len(), 1);
+        assert_eq!(result[0].tool_calls.len(), 1);
+    }
+}

--- a/mur-core/tests/skill_evolve_e2e.rs
+++ b/mur-core/tests/skill_evolve_e2e.rs
@@ -1,0 +1,163 @@
+//! E2E: drives evolve_skill with a ScriptedChatBackend over synthetic telemetry.
+
+use async_trait::async_trait;
+use mur_common::skill::{global_skill_dir, read_from_dir, write_to_dir};
+use mur_core::conversations::backend::{ChatBackend, ChatRequest, ChatResponse, ChatStream, Usage};
+use mur_core::evolve::skill_evolve::evolve_skill;
+use std::sync::Mutex;
+
+struct ScriptedChatBackend {
+    responses: Mutex<Vec<String>>,
+}
+
+impl ScriptedChatBackend {
+    fn new(responses: Vec<String>) -> Self {
+        Self {
+            responses: Mutex::new(responses),
+        }
+    }
+}
+
+#[async_trait]
+impl ChatBackend for ScriptedChatBackend {
+    async fn generate(&self, _req: ChatRequest<'_>) -> anyhow::Result<ChatResponse> {
+        let text = self.responses.lock().unwrap().remove(0);
+        Ok(ChatResponse {
+            text,
+            usage: Usage {
+                input_tokens: 100,
+                output_tokens: 200,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                provider: "test",
+                model: "test-model".into(),
+            },
+        })
+    }
+
+    async fn generate_stream(&self, _req: ChatRequest<'_>) -> anyhow::Result<ChatStream> {
+        unimplemented!("streaming not used in tests")
+    }
+
+    fn provider_name(&self) -> &'static str {
+        "test"
+    }
+}
+
+/// Build a valid minimal skill that round-trips through parse_canonical.
+fn minimal_skill_yaml(name: &str, version: &str, extra_tool: &str) -> String {
+    format!(
+        r#"
+name: {name}
+version: {version}
+publisher: human:test
+description: test skill
+category: context
+hosts: [mur-agent]
+content:
+  abstract: test
+  context: "Use {extra_tool}."
+"#
+    )
+}
+
+fn write_telemetry_fixture(telemetry_dir: &std::path::Path, skill_name: &str) {
+    std::fs::create_dir_all(telemetry_dir).unwrap();
+    let lines = [
+        format!(
+            r#"{{"mur.event.type":"telemetry/llm_call","mur.task.id":"t1","mur.fired_skills":["{skill_name}"],"gen_ai.usage.input_tokens":100,"gen_ai.request.model":"claude","latency_ms":1200}}"#
+        ),
+        format!(
+            r#"{{"mur.event.type":"telemetry/tool_call","mur.task.id":"t1","tool":"wrong.tool","ok":false,"duration_ms":500}}"#
+        ),
+        format!(
+            r#"{{"mur.event.type":"telemetry/error","mur.task.id":"t1","kind":"ToolError","message":"tool 'wrong.tool' not found"}}"#
+        ),
+    ];
+    std::fs::write(telemetry_dir.join("2026-05-25.jsonl"), lines.join("\n")).unwrap();
+}
+
+#[tokio::test]
+async fn evolve_writes_new_version_and_log_entry() {
+    let home = tempfile::tempdir().unwrap();
+
+    // 1. Write a skill with a known tool flaw.
+    let skill_yaml = minimal_skill_yaml("broken-skill", "0.1.0", "wrong.tool");
+    let manifest = mur_common::skill::parse_canonical(&skill_yaml).unwrap();
+    let skill_dir = global_skill_dir(home.path(), "broken-skill");
+    write_to_dir(&skill_dir, &manifest).unwrap();
+
+    // 2. Write telemetry with 1 failure.
+    let telemetry_dir = home.path().join("agents").join("test").join("telemetry");
+    write_telemetry_fixture(&telemetry_dir, "broken-skill");
+
+    // 3. Scripted LLM: diagnosis then optimized YAML.
+    let responses = vec![
+        r#"[{"dimension":"Tool","severity":0.9,"finding":"wrong.tool not found","suggested_fix":"replace wrong.tool with correct.tool","evidence":["t1"]}]"#.to_string(),
+        format!(
+            "name: broken-skill\nversion: 0.1.1\npublisher: human:test\ndescription: test skill\ncategory: context\nhosts:\n  - mur-agent\ncontent:\n  abstract: test\n  context: \"Use correct.tool.\"\nevolution_log:\n  - version: 0.1.1\n    generation: 1\n    source: agent:evolver\n    changes: replace wrong.tool with correct.tool\n    quality_score: 0.0\n    timestamp: 2026-05-25T00:00:00Z\n"
+        ),
+    ];
+    let llm = ScriptedChatBackend::new(responses);
+
+    // 4. Run evolve.
+    let result = evolve_skill(home.path(), "test", "broken-skill", &llm, 1, false)
+        .await
+        .unwrap();
+    assert_eq!(result.new_version, "0.1.1");
+
+    // 5. Verify skill on disk has evolution_log entry.
+    let evolved = read_from_dir(&skill_dir).unwrap();
+    assert_eq!(evolved.evolution_log.len(), 1);
+    assert_eq!(evolved.evolution_log[0].source, "agent:evolver");
+    assert_eq!(evolved.evolution_log[0].generation, 1);
+}
+
+#[tokio::test]
+async fn no_telemetry_returns_clean() {
+    let home = tempfile::tempdir().unwrap();
+
+    let skill_yaml = minimal_skill_yaml("no-data", "0.1.0", "some.tool");
+    let manifest = mur_common::skill::parse_canonical(&skill_yaml).unwrap();
+    let skill_dir = global_skill_dir(home.path(), "no-data");
+    write_to_dir(&skill_dir, &manifest).unwrap();
+
+    // No telemetry directory at all.
+    let llm = ScriptedChatBackend::new(vec![]);
+
+    let result = evolve_skill(home.path(), "test", "no-data", &llm, 3, false)
+        .await
+        .unwrap();
+    assert_eq!(result.new_version, result.original_version);
+    assert!(result.diagnoses.is_empty());
+}
+
+#[tokio::test]
+async fn dry_run_does_not_write() {
+    let home = tempfile::tempdir().unwrap();
+
+    let skill_yaml = minimal_skill_yaml("dry-run-skill", "0.1.0", "bad.tool");
+    let manifest = mur_common::skill::parse_canonical(&skill_yaml).unwrap();
+    let skill_dir = global_skill_dir(home.path(), "dry-run-skill");
+    write_to_dir(&skill_dir, &manifest).unwrap();
+
+    let telemetry_dir = home.path().join("agents").join("test").join("telemetry");
+    write_telemetry_fixture(&telemetry_dir, "dry-run-skill");
+
+    let responses = vec![
+        r#"[{"dimension":"Tool","severity":0.9,"finding":"bad.tool not found","suggested_fix":"replace bad.tool with good.tool","evidence":["t1"]}]"#.to_string(),
+    ];
+    let llm = ScriptedChatBackend::new(responses);
+
+    let result = evolve_skill(home.path(), "test", "dry-run-skill", &llm, 3, true)
+        .await
+        .unwrap();
+
+    // Dry run should not change version.
+    assert_eq!(result.new_version, result.original_version);
+
+    // Skill on disk should be unchanged.
+    let disk = read_from_dir(&skill_dir).unwrap();
+    assert_eq!(disk.version, "0.1.0");
+    assert!(disk.evolution_log.is_empty());
+}


### PR DESCRIPTION
## Summary
- `mur skill evolve <name>` reads agent execution telemetry, diagnoses failures across 4 dimensions (Knowledge, Tool, Clarification, Style), and applies minimal-modification patches via LLM
- Closed-loop: Create → Execute → Evaluate → Diagnose → Optimize → Repeat
- Evolution tracking via `evolution_log` on `SkillManifest` — each generation recorded with version, quality score, and changes
- Telemetry reader correlates `fired_skills` from M2 deferred (PR #270) with per-skill execution records

## Commits
1. `EvolutionEvent` type + `evolution_log` field on `SkillManifest`
2. Telemetry reader — parse JSONL, filter by skill name
3. Failure Analyzer + Skill Optimizer + evolution orchestrator
4. `mur skill evolve` CLI wiring
5. E2E tests with scripted ChatBackend

## Test Plan
- [x] Unit: 5 evolution tests, 5 telemetry reader tests, 5 helper tests
- [x] E2E: 3 integration tests (evolve, no-telemetry, dry-run) with ScriptedChatBackend
- [x] Full suite: 1259 pass (1 pre-existing flaky `sleep::disable_writes_config`)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)