### PR TITLE
feat(skill): M4a peer transfer pull via `agent://`

### DIFF
--- a/mur-agent-runtime/src/protocol/methods/card.rs
+++ b/mur-agent-runtime/src/protocol/methods/card.rs
@@ -75,6 +75,20 @@ impl MethodHandler for CardHandler {
                 "traits": p.persona.traits,
             },
             "skills": p.skills.iter().map(|s| json!({"id": s})).collect::<Vec<_>>(),
+            "installed_skills": p.installed_skills.iter().map(|s| json!({
+                "name": s.name,
+                "version": s.version,
+                "publisher": s.publisher,
+                "description": s.description,
+                "category": s.category,
+                "tags": s.tags,
+                "triggers": s.triggers.iter().map(|t| json!({
+                    "type": t.kind,
+                    "pattern": t.pattern,
+                })).collect::<Vec<_>>(),
+                "abstract": s.abstract_text,
+                "transfer_chain": s.transfer_chain,
+            })).collect::<Vec<_>>(),
             "entitlements": p.entitlements,
         });
 

--- a/mur-agent-runtime/src/protocol/methods/mod.rs
+++ b/mur-agent-runtime/src/protocol/methods/mod.rs
@@ -1,4 +1,5 @@
 //! A2A method handlers.
 pub mod card;
 pub mod message_send;
+pub mod skills;
 pub mod tasks;

--- a/mur-agent-runtime/src/protocol/methods/skills.rs
+++ b/mur-agent-runtime/src/protocol/methods/skills.rs
@@ -1,0 +1,110 @@
+//! A2A method: `skills/get` — serve a skill manifest by name.
+//!
+//! In M4a this handler is registered with the dispatcher but install does
+//! not yet reach it over a socket — install reads the local store directly.
+//! M4b wires the real round-trip.
+
+use async_trait::async_trait;
+use mur_common::skill::{
+    content_hash_for_trust, global_skill_dir, read_from_dir, serialize_canonical,
+};
+use serde_json::{Value, json};
+use std::path::PathBuf;
+
+use crate::protocol::a2a_server::{HandlerError, MethodHandler};
+
+pub struct SkillsGetHandler {
+    /// Root of the skill store this handler serves from. In M4a this is
+    /// `MUR_HOME`; skills resolve to `<root>/skills/<name>/skill.yaml`.
+    store_root: PathBuf,
+}
+
+impl SkillsGetHandler {
+    pub fn new(store_root: PathBuf) -> Self {
+        Self { store_root }
+    }
+}
+
+#[async_trait]
+impl MethodHandler for SkillsGetHandler {
+    async fn handle(&self, params: Option<Value>) -> Result<Value, HandlerError> {
+        let params = params
+            .ok_or_else(|| HandlerError::InvalidParams("missing params".into()))?;
+
+        let skill_name = params
+            .get("skill")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| HandlerError::InvalidParams("missing 'skill' field".into()))?;
+
+        let dir = global_skill_dir(&self.store_root, skill_name);
+        let manifest = read_from_dir(&dir)
+            .map_err(|e| HandlerError::Internal(format!("skill '{skill_name}' not found: {e}")))?;
+
+        let hash = content_hash_for_trust(&manifest)
+            .map_err(|e| HandlerError::Internal(format!("hash failed: {e}")))?;
+
+        let yaml = serialize_canonical(&manifest)
+            .map_err(|e| HandlerError::Internal(format!("serialize failed: {e}")))?;
+
+        Ok(json!({
+            "manifest": yaml,
+            "content_sha256": hash,
+            "transfer_chain": manifest.transfer_chain,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::skill::{parse_canonical, write_to_dir};
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn serves_installed_skill() {
+        let dir = tempdir().unwrap();
+        let m = parse_canonical(
+            r#"
+name: test-skill
+version: 1.0.0
+publisher: human:t
+description: d
+category: context
+content:
+  abstract: a
+  context: b
+"#,
+        )
+        .unwrap();
+        write_to_dir(&global_skill_dir(dir.path(), "test-skill"), &m).unwrap();
+
+        let handler = SkillsGetHandler::new(dir.path().to_path_buf());
+        let result = handler
+            .handle(Some(json!({"skill": "test-skill"})))
+            .await
+            .unwrap();
+
+        assert!(result["manifest"].as_str().unwrap().contains("test-skill"));
+        assert_eq!(result["content_sha256"].as_str().unwrap().len(), 64);
+        assert!(result["transfer_chain"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn missing_skill_returns_internal_error() {
+        let dir = tempdir().unwrap();
+        let handler = SkillsGetHandler::new(dir.path().to_path_buf());
+        let err = handler
+            .handle(Some(json!({"skill": "nope"})))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, HandlerError::Internal(_)));
+    }
+
+    #[tokio::test]
+    async fn missing_skill_param_returns_invalid_params() {
+        let dir = tempdir().unwrap();
+        let handler = SkillsGetHandler::new(dir.path().to_path_buf());
+        let err = handler.handle(Some(json!({}))).await.unwrap_err();
+        assert!(matches!(err, HandlerError::InvalidParams(_)));
+    }
+}

--- a/mur-agent-runtime/src/protocol/methods/skills.rs
+++ b/mur-agent-runtime/src/protocol/methods/skills.rs
@@ -28,8 +28,7 @@ impl SkillsGetHandler {
 #[async_trait]
 impl MethodHandler for SkillsGetHandler {
     async fn handle(&self, params: Option<Value>) -> Result<Value, HandlerError> {
-        let params = params
-            .ok_or_else(|| HandlerError::InvalidParams("missing params".into()))?;
+        let params = params.ok_or_else(|| HandlerError::InvalidParams("missing params".into()))?;
 
         let skill_name = params
             .get("skill")

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -27,7 +27,7 @@ use crate::transport::unix_socket::serve_unix;
 use crate::transport::webhook;
 use mur_common::identity::AgentIdentity;
 use mur_common::{JsonRpcError, JsonRpcRequest, JsonRpcResponse, LockFile, agent::LockTransports};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{info, warn};
 
@@ -59,6 +59,9 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     //    agent_home at the per-binary cache extraction dir, unless the
     //    operator overrides via MUR_AGENT_EXTERNAL_PROFILE.
     let embedded_override = std::env::var_os("MUR_AGENT_EXTERNAL_PROFILE").is_some();
+    let mur_home = std::env::var_os("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"));
     let agent_home = if crate::export::bin_embed::has_embedded_agent() && !embedded_override {
         match resolve_embedded_agent_home() {
             Ok(p) => p,
@@ -78,9 +81,6 @@ pub async fn entrypoint() -> anyhow::Result<()> {
                 std::process::exit(1);
             }
         };
-        let mur_home = std::env::var_os("MUR_HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"));
         let candidate = mur_home.join("agents").join(&name);
         // Verify_name_match runs after profile load below for both branches.
         // Stash the argv0-derived name so the post-load check can use it.
@@ -199,7 +199,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         &hook_cancel,
     )
     .await?;
-    let dispatcher = Arc::new(build_dispatcher(&profile_arc, &runner));
+    let dispatcher = Arc::new(build_dispatcher(&profile_arc, &runner, &mur_home));
 
     // 7. Transports
     let mut transport_tasks = vec![];
@@ -491,7 +491,11 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn build_dispatcher(profile: &Arc<Profile>, runner: &Arc<TaskRunner>) -> Dispatcher {
+fn build_dispatcher(
+    profile: &Arc<Profile>,
+    runner: &Arc<TaskRunner>,
+    mur_home: &Path,
+) -> Dispatcher {
     let mut d = Dispatcher::new();
     d.register("agent/card", Box::new(CardHandler::new(profile.clone())));
     d.register(
@@ -506,6 +510,12 @@ fn build_dispatcher(profile: &Arc<Profile>, runner: &Arc<TaskRunner>) -> Dispatc
     d.register(
         "tasks/list",
         Box::new(TasksListHandler::new(runner.clone())),
+    );
+    d.register(
+        "skills/get",
+        Box::new(crate::protocol::methods::skills::SkillsGetHandler::new(
+            mur_home.to_path_buf(),
+        )),
     );
     d
 }

--- a/mur-agent-runtime/tests/card_method.rs
+++ b/mur-agent-runtime/tests/card_method.rs
@@ -42,3 +42,27 @@ fn load_test_profile() -> mur_agent_runtime::profile::Profile {
     std::mem::forget(tmp);
     p
 }
+
+#[tokio::test]
+async fn card_emits_installed_skills_block() {
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().join("agent_b");
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let base = include_str!("fixtures/profile_minimal.yaml");
+    let yaml = format!(
+        "{base}installed_skills:\n  - name: find-prices\n    version: 1.0.0\n    publisher: human:alice\n    description: find prices\n    category: workflow\n    abstract: looks up prices\n    transfer_chain:\n      - agent://alice\n"
+    );
+    std::fs::write(dir.join("profile.yaml"), yaml).unwrap();
+    let profile = mur_agent_runtime::profile::Profile::load(&dir).unwrap();
+    std::mem::forget(tmp);
+
+    let handler = CardHandler::new(Arc::new(profile));
+    let card = handler.handle(None).await.unwrap();
+    let entries = card["installed_skills"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["name"], "find-prices");
+    assert_eq!(entries[0]["transfer_chain"][0], "agent://alice");
+}

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -5,6 +5,44 @@ use crate::companion::{Formality, Relationship};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+/// Skill metadata broadcast in the Agent Card (Layer 1 + Layer 2).
+///
+/// Populated by `mur skill install` (registry or agent:// URL). Distinct from
+/// `AgentProfile.skills`, which is the legacy per-agent-path list managed by
+/// `mur agent skill add`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct SkillCardEntry {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub version: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub publisher: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub category: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub triggers: Vec<SkillCardTrigger>,
+    /// Layer 2 abstract — injected at session start (~200 tokens).
+    /// On-disk YAML key is `abstract` (a Rust reserved word).
+    #[serde(default, skip_serializing_if = "String::is_empty", rename = "abstract")]
+    pub abstract_text: String,
+    /// Provenance chain copied from the installed manifest. Empty for
+    /// registry-installed skills.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transfer_chain: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct SkillCardTrigger {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub pattern: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentProfile {
     pub schema: u32,
@@ -23,6 +61,11 @@ pub struct AgentProfile {
     pub mcp_servers: Vec<McpServerEntry>,
     #[serde(default)]
     pub skills: Vec<String>,
+    /// Skills installed via `mur skill install`. Distinct from `skills`
+    /// (which holds legacy per-agent paths from `mur agent skill add`).
+    /// Broadcast in the Agent Card alongside `skills`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub installed_skills: Vec<SkillCardEntry>,
     pub transport: TransportConfig,
     pub communication: CommunicationConfig,
     #[serde(default)]
@@ -1489,5 +1532,51 @@ mod federation_tests {
         let cfg = FederationConfig::default();
         assert_eq!(cfg.evidence_flush_interval_minutes, 0);
         assert!(cfg.snapshot_ref.is_none());
+    }
+}
+
+#[cfg(test)]
+mod skill_card_tests {
+    use super::*;
+
+    #[test]
+    fn installed_skills_default_to_empty_when_absent() {
+        let yaml = include_str!("../tests/fixtures/profile_p0a_minimal.yaml");
+        let p: AgentProfile = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(p.installed_skills.is_empty());
+    }
+
+    #[test]
+    fn installed_skills_roundtrip_preserves_entries() {
+        let base = include_str!("../tests/fixtures/profile_p0a_minimal.yaml");
+        let yaml = format!(
+            "{base}installed_skills:\n  - name: s1\n    version: 1.0.0\n    publisher: human:d\n    description: desc\n    category: workflow\n    tags: [web]\n    triggers:\n      - type: command\n        pattern: /find\n    abstract: does things\n    transfer_chain:\n      - agent://alice\n"
+        );
+        let p: AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(p.installed_skills.len(), 1);
+        assert_eq!(p.installed_skills[0].name, "s1");
+        assert_eq!(p.installed_skills[0].abstract_text, "does things");
+        assert_eq!(p.installed_skills[0].transfer_chain, vec!["agent://alice"]);
+
+        let out = serde_yaml_ng::to_string(&p).unwrap();
+        assert!(out.contains("abstract: does things"));
+        assert!(out.contains("pattern: /find"));
+
+        let back: AgentProfile = serde_yaml_ng::from_str(&out).unwrap();
+        assert_eq!(p.installed_skills, back.installed_skills);
+    }
+
+    #[test]
+    fn installed_skills_minimal_entry_serializes_compactly() {
+        // A name-only entry must NOT emit empty string fields.
+        let entry = SkillCardEntry {
+            name: "minimal".into(),
+            ..Default::default()
+        };
+        let yaml = serde_yaml_ng::to_string(&entry).unwrap();
+        assert!(yaml.contains("name: minimal"));
+        assert!(!yaml.contains("version:"), "empty version must be skipped: {yaml}");
+        assert!(!yaml.contains("publisher:"), "empty publisher must be skipped: {yaml}");
+        assert!(!yaml.contains("abstract:"), "empty abstract must be skipped: {yaml}");
     }
 }

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -1575,8 +1575,17 @@ mod skill_card_tests {
         };
         let yaml = serde_yaml_ng::to_string(&entry).unwrap();
         assert!(yaml.contains("name: minimal"));
-        assert!(!yaml.contains("version:"), "empty version must be skipped: {yaml}");
-        assert!(!yaml.contains("publisher:"), "empty publisher must be skipped: {yaml}");
-        assert!(!yaml.contains("abstract:"), "empty abstract must be skipped: {yaml}");
+        assert!(
+            !yaml.contains("version:"),
+            "empty version must be skipped: {yaml}"
+        );
+        assert!(
+            !yaml.contains("publisher:"),
+            "empty publisher must be skipped: {yaml}"
+        );
+        assert!(
+            !yaml.contains("abstract:"),
+            "empty abstract must be skipped: {yaml}"
+        );
     }
 }

--- a/mur-common/src/skill/hash.rs
+++ b/mur-common/src/skill/hash.rs
@@ -3,6 +3,16 @@ use crate::skill::serialize_canonical;
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 
+/// Compute content hash for trust verification — excludes `transfer_chain`
+/// and `evolution_log` so registry lookup and trust-store keys remain stable
+/// across transfers and across generation increments.
+pub fn content_hash_for_trust(m: &SkillManifest) -> Result<String, crate::skill::ParseError> {
+    let mut clone = m.clone();
+    clone.transfer_chain = vec![];
+    clone.evolution_log = vec![];
+    content_sha256(&clone)
+}
+
 /// Hex-encoded SHA-256 of the canonical YAML form. Lowercase.
 pub fn content_sha256(m: &SkillManifest) -> Result<String, crate::skill::ParseError> {
     let yaml = serialize_canonical(m)?;
@@ -93,5 +103,44 @@ content:
     #[test]
     fn ct_eq_hex_rejects_unequal_length() {
         assert!(!ct_eq_hex("aa", "aaa"));
+    }
+
+    #[test]
+    fn trust_hash_is_stable_across_transfers() {
+        let m = parse_canonical(SAMPLE).unwrap();
+        let h1 = content_hash_for_trust(&m).unwrap();
+        let mut m2 = m.clone();
+        m2.transfer_chain = vec!["agent://alice".into(), "agent://bob".into()];
+        let h2 = content_hash_for_trust(&m2).unwrap();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn trust_hash_is_stable_across_evolution() {
+        use crate::skill::EvolutionEvent;
+        let m = parse_canonical(SAMPLE).unwrap();
+        let h1 = content_hash_for_trust(&m).unwrap();
+        let mut m2 = m.clone();
+        m2.evolution_log = vec![EvolutionEvent {
+            version: "0.2.0".into(),
+            generation: 0,
+            source: "agent:self".into(),
+            changes: "tweak".into(),
+            quality_score: None,
+            timestamp: "2026-05-25T00:00:00Z".into(),
+        }];
+        let h2 = content_hash_for_trust(&m2).unwrap();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn trust_hash_differs_when_content_changes() {
+        let m = parse_canonical(SAMPLE).unwrap();
+        let mut m2 = m.clone();
+        m2.description = "changed".into();
+        assert_ne!(
+            content_hash_for_trust(&m).unwrap(),
+            content_hash_for_trust(&m2).unwrap()
+        );
     }
 }

--- a/mur-common/src/skill/manifest.rs
+++ b/mur-common/src/skill/manifest.rs
@@ -59,6 +59,12 @@ pub struct SkillManifest {
     /// Evolution history — each entry records one generation.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub evolution_log: Vec<EvolutionEvent>,
+
+    /// Peer transfer provenance — each entry is `agent://<name>`.
+    /// Last entry is the immediate source; first entry is the original publisher.
+    /// Empty for registry-installed and locally-authored skills.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transfer_chain: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/mur-common/src/skill/mod.rs
+++ b/mur-common/src/skill/mod.rs
@@ -19,7 +19,9 @@ pub mod validate;
 pub use capability::{Capability, CapabilityViolation, allowed_for, check_capabilities};
 pub use constraint::{Constraint, ConstraintError};
 pub use evolution::EvolutionEvent;
-pub use hash::{DriftStatus, content_sha256, ct_eq_hex, drift_status, sha256_hex};
+pub use hash::{
+    DriftStatus, content_hash_for_trust, content_sha256, ct_eq_hex, drift_status, sha256_hex,
+};
 pub use loader::{LoadedSkill, SkillScope, load_all};
 pub use lockfile::{LockfileError, SkillLock};
 pub use manifest::*;

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -158,6 +158,7 @@ pub fn cmd_create(
         trusted_peers: Vec::new(),
         appearance: mur_common::AgentAppearance::default(),
         federation: mur_common::FederationConfig::default(),
+        installed_skills: vec![],
         created_at: now.clone(),
         updated_at: now,
     };

--- a/mur-core/src/cmd/agent_companion/connector.rs
+++ b/mur-core/src/cmd/agent_companion/connector.rs
@@ -634,6 +634,7 @@ pub(crate) async fn scaffold_stub_bridge(name: &str, default_route: &str) -> Res
         trusted_peers: vec![],
         appearance: mur_common::AgentAppearance::default(),
         federation: mur_common::FederationConfig::default(),
+        installed_skills: vec![],
         created_at: now.clone(),
         updated_at: now,
     };

--- a/mur-core/src/cmd/skill_from_pattern.rs
+++ b/mur-core/src/cmd/skill_from_pattern.rs
@@ -98,6 +98,7 @@ pub fn pattern_to_skill(pattern: &Pattern, polish: bool) -> Result<SkillManifest
         triggers: vec![],
         priority: Default::default(),
         evolution_log: vec![],
+        transfer_chain: vec![],
     };
 
     validate(&manifest).context("derived skill manifest failed schema validation")?;

--- a/mur-core/src/cmd/skill_install.rs
+++ b/mur-core/src/cmd/skill_install.rs
@@ -4,8 +4,8 @@ use anyhow::{Context, Result, anyhow, bail};
 use std::path::Path;
 
 use mur_common::skill::{
-    SkillLock, SkillManifest, TrustLevel, content_hash_for_trust, content_sha256,
-    global_skill_dir, lockfile, read_from_dir, scan::scan_skill, write_to_dir,
+    SkillLock, SkillManifest, TrustLevel, content_hash_for_trust, content_sha256, global_skill_dir,
+    lockfile, read_from_dir, scan::scan_skill, write_to_dir,
 };
 use mur_common::trust::skills::{SkillTrustStore, TrustEntry};
 
@@ -18,14 +18,10 @@ pub fn cmd_install(home: &Path, registry_url: &str, source: &str) -> Result<()> 
     // M4a: agent://<agent-name>/<skill-name> — peer transfer pull.
     if let Some(rest) = source.strip_prefix("agent://") {
         let (agent_name, skill_name) = rest.split_once('/').ok_or_else(|| {
-            anyhow!(
-                "invalid agent:// URL '{source}' — expected agent://<agent-name>/<skill-name>"
-            )
+            anyhow!("invalid agent:// URL '{source}' — expected agent://<agent-name>/<skill-name>")
         })?;
         if agent_name.is_empty() || skill_name.is_empty() {
-            bail!(
-                "invalid agent:// URL '{source}' — agent name and skill name must be non-empty"
-            );
+            bail!("invalid agent:// URL '{source}' — agent name and skill name must be non-empty");
         }
         return install_from_agent(home, agent_name, skill_name);
     }
@@ -125,11 +121,10 @@ fn install_from_agent(home: &Path, agent_name: &str, skill_name: &str) -> Result
 
     // 2. Pull — read the skill directly from the shared local store.
     let source_dir = global_skill_dir(home, skill_name);
-    let mut manifest: SkillManifest = read_from_dir(&source_dir).map_err(|e| {
-        anyhow!("pull from agent://{agent_name}/{skill_name} failed: {e}")
-    })?;
-    let received_hash = content_hash_for_trust(&manifest)
-        .map_err(|e| anyhow!("hash source manifest: {e}"))?;
+    let mut manifest: SkillManifest = read_from_dir(&source_dir)
+        .map_err(|e| anyhow!("pull from agent://{agent_name}/{skill_name} failed: {e}"))?;
+    let received_hash =
+        content_hash_for_trust(&manifest).map_err(|e| anyhow!("hash source manifest: {e}"))?;
 
     // 3. Verify — content-based trust.
     let trust_level = resolve_agent_install_trust(home, &manifest, &received_hash)?;
@@ -152,8 +147,8 @@ fn install_from_agent(home: &Path, agent_name: &str, skill_name: &str) -> Result
     write_to_dir(&dir, &manifest).context("write installed skill")?;
 
     // 7. Record in trust store.
-    let trust_key = content_hash_for_trust(&manifest)
-        .map_err(|e| anyhow!("hash trust key: {e}"))?;
+    let trust_key =
+        content_hash_for_trust(&manifest).map_err(|e| anyhow!("hash trust key: {e}"))?;
     let mut trust = SkillTrustStore::load(home).map_err(|e| anyhow!("load trust: {e}"))?;
     trust.insert(
         trust_key,
@@ -245,8 +240,8 @@ fn register_in_profile(home: &Path, agent_name: &str, m: &SkillManifest) -> Resu
     let profile_path = home.join("agents").join(agent_name).join("profile.yaml");
     let text = std::fs::read_to_string(&profile_path)
         .with_context(|| format!("read {}", profile_path.display()))?;
-    let mut profile: mur_common::AgentProfile =
-        serde_yaml_ng::from_str(&text).with_context(|| format!("parse {}", profile_path.display()))?;
+    let mut profile: mur_common::AgentProfile = serde_yaml_ng::from_str(&text)
+        .with_context(|| format!("parse {}", profile_path.display()))?;
 
     let entry = SkillCardEntry {
         name: m.name.clone(),
@@ -346,8 +341,7 @@ content:
             ("agent://emptyskill/", "non-empty"),
         ];
         for (input, expected_substr) in cases {
-            let err = cmd_install(home.path(), "https://example.com/registry", input)
-                .unwrap_err();
+            let err = cmd_install(home.path(), "https://example.com/registry", input).unwrap_err();
             let msg = err.to_string();
             assert!(
                 msg.contains(expected_substr),

--- a/mur-core/src/cmd/skill_install.rs
+++ b/mur-core/src/cmd/skill_install.rs
@@ -1,11 +1,11 @@
 //! Skill install orchestrator — resolve source, fetch, verify, store, trust, lock.
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use std::path::Path;
 
-use mur_common::skill::{SkillLock, lockfile};
 use mur_common::skill::{
-    TrustLevel, content_sha256, global_skill_dir, scan::scan_skill, write_to_dir,
+    SkillLock, SkillManifest, TrustLevel, content_hash_for_trust, content_sha256,
+    global_skill_dir, lockfile, read_from_dir, scan::scan_skill, write_to_dir,
 };
 use mur_common::trust::skills::{SkillTrustStore, TrustEntry};
 
@@ -15,6 +15,21 @@ use crate::cmd::skill_resolver::{self, ResolveSource, ResolvedNode, ResolverInpu
 
 /// Pure entry point — takes explicit home + registry_url. Used by tests and future M4 code.
 pub fn cmd_install(home: &Path, registry_url: &str, source: &str) -> Result<()> {
+    // M4a: agent://<agent-name>/<skill-name> — peer transfer pull.
+    if let Some(rest) = source.strip_prefix("agent://") {
+        let (agent_name, skill_name) = rest.split_once('/').ok_or_else(|| {
+            anyhow!(
+                "invalid agent:// URL '{source}' — expected agent://<agent-name>/<skill-name>"
+            )
+        })?;
+        if agent_name.is_empty() || skill_name.is_empty() {
+            bail!(
+                "invalid agent:// URL '{source}' — agent name and skill name must be non-empty"
+            );
+        }
+        return install_from_agent(home, agent_name, skill_name);
+    }
+
     let src_path = Path::new(source);
 
     let (reg_dir, _idx) =
@@ -97,6 +112,186 @@ fn install_resolved_node(home: &Path, node: &ResolvedNode) -> Result<()> {
     Ok(())
 }
 
+fn install_from_agent(home: &Path, agent_name: &str, skill_name: &str) -> Result<()> {
+    // 1. Discover — verify the named agent exists locally.
+    let agent_dir = home.join("agents").join(agent_name);
+    if !agent_dir.exists() {
+        bail!(
+            "agent '{agent_name}' not found at {} — \
+             M4a requires the source agent to live on the same MUR_HOME",
+            agent_dir.display()
+        );
+    }
+
+    // 2. Pull — read the skill directly from the shared local store.
+    let source_dir = global_skill_dir(home, skill_name);
+    let mut manifest: SkillManifest = read_from_dir(&source_dir).map_err(|e| {
+        anyhow!("pull from agent://{agent_name}/{skill_name} failed: {e}")
+    })?;
+    let received_hash = content_hash_for_trust(&manifest)
+        .map_err(|e| anyhow!("hash source manifest: {e}"))?;
+
+    // 3. Verify — content-based trust.
+    let trust_level = resolve_agent_install_trust(home, &manifest, &received_hash)?;
+
+    // 4. Append transfer chain.
+    manifest
+        .transfer_chain
+        .push(format!("agent://{agent_name}"));
+
+    // 5. Re-scan the post-mutation manifest.
+    let report = scan_skill(&manifest).context("scan manifest")?;
+    let effective_level = if report.has_blocking_findings() {
+        TrustLevel::Sandboxed
+    } else {
+        trust_level
+    };
+
+    // 6. Install — write to the target store.
+    let dir = global_skill_dir(home, &manifest.name);
+    write_to_dir(&dir, &manifest).context("write installed skill")?;
+
+    // 7. Record in trust store.
+    let trust_key = content_hash_for_trust(&manifest)
+        .map_err(|e| anyhow!("hash trust key: {e}"))?;
+    let mut trust = SkillTrustStore::load(home).map_err(|e| anyhow!("load trust: {e}"))?;
+    trust.insert(
+        trust_key,
+        TrustEntry {
+            name: manifest.name.clone(),
+            version: manifest.version.clone(),
+            level: effective_level,
+            installed_at: chrono::Utc::now().to_rfc3339(),
+            publisher: Some(manifest.publisher.clone()),
+        },
+    );
+    trust.save(home).map_err(|e| anyhow!("save trust: {e}"))?;
+
+    // 8. Register in the calling agent's profile.
+    if let Some(caller) = caller_agent_name(home)? {
+        register_in_profile(home, &caller, &manifest)?;
+    }
+
+    if report.has_blocking_findings() {
+        eprintln!(
+            "⚠ {} v{}: security findings — installed Sandboxed",
+            manifest.name, manifest.version
+        );
+        for line in report.human_summary() {
+            eprintln!("    {line}");
+        }
+    }
+
+    println!(
+        "installed: {} v{} ({effective_level:?}, from agent://{agent_name})",
+        manifest.name, manifest.version,
+    );
+    if effective_level == TrustLevel::Sandboxed {
+        println!(
+            "hint: run `mur skill trust {} verified` after review",
+            manifest.name
+        );
+    }
+    Ok(())
+}
+
+/// Content-based trust for agent-installed skills.
+/// Order: revocation > registry hash match > default Sandboxed.
+fn resolve_agent_install_trust(
+    home: &Path,
+    manifest: &SkillManifest,
+    received_hash: &str,
+) -> Result<TrustLevel> {
+    let trust_store = SkillTrustStore::load(home).map_err(|e| anyhow!("load trust: {e}"))?;
+    if trust_store.is_revoked(received_hash) {
+        bail!(
+            "skill '{}' (hash {}) is revoked — install blocked",
+            manifest.name,
+            received_hash
+        );
+    }
+
+    let cache_dir = crate::cmd::skill_registry::registry_cache_dir(home);
+    if cache_dir.exists()
+        && let Ok(idx) = crate::cmd::skill_registry::load_index(&cache_dir)
+        && let Some(entry) = idx.skills.get(&manifest.name)
+        && entry.content_sha256 == received_hash
+    {
+        return Ok(TrustLevel::Verified);
+    }
+
+    Ok(TrustLevel::Sandboxed)
+}
+
+/// Resolve the agent that issued this install command.
+fn caller_agent_name(home: &Path) -> Result<Option<String>> {
+    let Some(name) = std::env::var("MUR_AGENT_NAME").ok() else {
+        return Ok(None);
+    };
+    let agent_dir = home.join("agents").join(&name);
+    if !agent_dir.exists() {
+        bail!(
+            "MUR_AGENT_NAME='{name}' but {} does not exist",
+            agent_dir.display()
+        );
+    }
+    Ok(Some(name))
+}
+
+/// Push (or update) a `SkillCardEntry` into the calling agent's profile.
+fn register_in_profile(home: &Path, agent_name: &str, m: &SkillManifest) -> Result<()> {
+    use mur_common::agent::{SkillCardEntry, SkillCardTrigger};
+
+    let profile_path = home.join("agents").join(agent_name).join("profile.yaml");
+    let text = std::fs::read_to_string(&profile_path)
+        .with_context(|| format!("read {}", profile_path.display()))?;
+    let mut profile: mur_common::AgentProfile =
+        serde_yaml_ng::from_str(&text).with_context(|| format!("parse {}", profile_path.display()))?;
+
+    let entry = SkillCardEntry {
+        name: m.name.clone(),
+        version: m.version.clone(),
+        publisher: m.publisher.clone(),
+        description: m.description.clone(),
+        category: serde_yaml_ng::to_string(&m.category)
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+        tags: m.tags.clone(),
+        triggers: m
+            .triggers
+            .iter()
+            .map(|t| SkillCardTrigger {
+                kind: serde_yaml_ng::to_string(&t.kind)
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string(),
+                pattern: t.pattern.clone().unwrap_or_default(),
+            })
+            .collect(),
+        abstract_text: m.content.r#abstract.clone(),
+        transfer_chain: m.transfer_chain.clone(),
+    };
+
+    if let Some(slot) = profile
+        .installed_skills
+        .iter_mut()
+        .find(|e| e.name == entry.name)
+    {
+        *slot = entry;
+    } else {
+        profile.installed_skills.push(entry);
+    }
+
+    // Atomic write — temp file + rename.
+    let tmp = profile_path.with_extension("yaml.tmp");
+    let yaml = serde_yaml_ng::to_string(&profile)?;
+    std::fs::write(&tmp, yaml).with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, &profile_path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), profile_path.display()))?;
+    Ok(())
+}
+
 /// CLI shim — resolves MUR_HOME and MUR_SKILL_REGISTRY_URL from env.
 pub fn cmd_install_cli(source: &str) -> Result<()> {
     let home = resolve_mur_home()?;
@@ -122,6 +317,9 @@ pub fn cmd_update_cli(name: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
     #[test]
     fn valid_yaml_parses_and_validates() {
         let yaml = r#"
@@ -136,5 +334,25 @@ content:
 "#;
         let m = mur_common::skill::parse_canonical(yaml).unwrap();
         mur_common::skill::validate(&m).unwrap();
+    }
+
+    #[test]
+    fn malformed_agent_urls_are_rejected() {
+        let home = tempdir().unwrap();
+        let cases = [
+            ("agent://noslash", "expected agent://"),
+            ("agent://", "expected agent://"),
+            ("agent:///emptyagent", "non-empty"),
+            ("agent://emptyskill/", "non-empty"),
+        ];
+        for (input, expected_substr) in cases {
+            let err = cmd_install(home.path(), "https://example.com/registry", input)
+                .unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains(expected_substr),
+                "case {input:?}: expected '{expected_substr}' in '{msg}'"
+            );
+        }
     }
 }

--- a/mur-core/tests/skill_install_agent_e2e.rs
+++ b/mur-core/tests/skill_install_agent_e2e.rs
@@ -1,0 +1,142 @@
+//! Integration test for `mur skill install agent://...` in the M4a
+//! single-home reality. The handler/dispatcher wire round-trip is
+//! exercised separately in M4b.
+
+use mur_common::agent::AgentProfile;
+use mur_common::skill::{
+    TrustLevel, content_hash_for_trust, global_skill_dir, parse_canonical, read_from_dir,
+    write_to_dir,
+};
+use mur_common::trust::skills::SkillTrustStore;
+use mur_core::cmd::skill_install::cmd_install;
+use tempfile::tempdir;
+
+fn write_profile(home: &std::path::Path, name: &str) -> std::path::PathBuf {
+    let dir = home.join("agents").join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    let profile = AgentProfile {
+        name: name.to_string(),
+        ..AgentProfile::default_for_tests()
+    };
+    let yaml = serde_yaml_ng::to_string(&profile).unwrap();
+    let path = dir.join("profile.yaml");
+    std::fs::write(&path, yaml).unwrap();
+    path
+}
+
+#[test]
+fn agent_pull_installs_and_appends_transfer_chain() {
+    let home = tempdir().unwrap();
+
+    // Source agent "alice" — owns the skill.
+    write_profile(home.path(), "alice");
+    let manifest = parse_canonical(
+        r#"
+name: find-prices
+version: 1.0.0
+publisher: human:alice
+description: Find product prices
+category: workflow
+content:
+  abstract: Searches product prices.
+  context: "Full procedure."
+"#,
+    )
+    .unwrap();
+    write_to_dir(&global_skill_dir(home.path(), "find-prices"), &manifest).unwrap();
+
+    // Target agent "bob" — caller of the install.
+    let bob_profile_path = write_profile(home.path(), "bob");
+
+    // SAFETY: env mutation isn't thread-safe across parallel tests. This
+    // test file must be run with `--test-threads=1`.
+    unsafe { std::env::set_var("MUR_AGENT_NAME", "bob") };
+
+    let result = cmd_install(
+        home.path(),
+        "https://example.com/registry", // unused for agent:// path
+        "agent://alice/find-prices",
+    );
+
+    // SAFETY: see comment above.
+    unsafe { std::env::remove_var("MUR_AGENT_NAME") };
+    result.unwrap();
+
+    // 1. Skill file exists in the shared store.
+    let installed_dir = global_skill_dir(home.path(), "find-prices");
+    assert!(installed_dir.join("skill.yaml").exists());
+
+    // 2. transfer_chain was appended.
+    let installed = read_from_dir(&installed_dir).unwrap();
+    assert_eq!(installed.transfer_chain, vec!["agent://alice"]);
+
+    // 3. Trust entry is Sandboxed (no registry cache in this test).
+    let trust = SkillTrustStore::load(home.path()).unwrap();
+    let key = content_hash_for_trust(&installed).unwrap();
+    let entry = trust.lookup(&key).expect("trust entry exists");
+    assert!(matches!(entry.level, TrustLevel::Sandboxed));
+
+    // 4. Bob's profile carries the SkillCardEntry.
+    let bob_yaml = std::fs::read_to_string(&bob_profile_path).unwrap();
+    let bob: AgentProfile = serde_yaml_ng::from_str(&bob_yaml).unwrap();
+    assert_eq!(bob.installed_skills.len(), 1);
+    let entry = &bob.installed_skills[0];
+    assert_eq!(entry.name, "find-prices");
+    assert_eq!(entry.publisher, "human:alice");
+    assert_eq!(entry.abstract_text, "Searches product prices.");
+    assert_eq!(entry.transfer_chain, vec!["agent://alice"]);
+}
+
+#[test]
+fn agent_url_rejects_missing_source_agent() {
+    let home = tempdir().unwrap();
+    let err = cmd_install(
+        home.path(),
+        "https://example.com/registry",
+        "agent://nonexistent/skill",
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("not found"));
+}
+
+#[test]
+fn agent_url_rejects_missing_source_skill() {
+    let home = tempdir().unwrap();
+    write_profile(home.path(), "charlie");
+    let err = cmd_install(
+        home.path(),
+        "https://example.com/registry",
+        "agent://charlie/missing-skill",
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not found") || msg.contains("pull"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+fn agent_url_skips_profile_register_without_caller() {
+    let home = tempdir().unwrap();
+    write_profile(home.path(), "dave");
+    let manifest = parse_canonical(
+        r#"
+name: solo
+version: 1.0.0
+publisher: human:dave
+description: d
+category: context
+content:
+  abstract: a
+  context: b
+"#,
+    )
+    .unwrap();
+    write_to_dir(&global_skill_dir(home.path(), "solo"), &manifest).unwrap();
+
+    // No MUR_AGENT_NAME set → install succeeds, no profile mutation.
+    cmd_install(home.path(), "https://x", "agent://dave/solo").unwrap();
+    let installed = read_from_dir(&global_skill_dir(home.path(), "solo")).unwrap();
+    assert_eq!(installed.transfer_chain, vec!["agent://dave"]);
+}


### PR DESCRIPTION
## Summary

- `mur skill install agent://<agent>/<skill>` pulls a skill from another local agent's skill store
- Content-based trust verification: registry hash match → Verified, no match → Sandboxed, revoked → reject
- Transfer chain (`transfer_chain`) appended on each install, excluded from trust hash so revocation stays stable
- `SkillsGetHandler` A2A method registered (M4a reads local store directly; M4b wires real socket round-trip)
- Agent Card broadcasts `installed_skills` block with full Layer 1+2 metadata
- `SkillCardEntry` added to `AgentProfile` — separate from legacy `skills` paths (no breaking changes)
- Integration test covers 4 scenarios: happy path, missing agent, missing skill, no-caller

## Test Plan

- [x] `cargo test -p mur-common skill::hash` (7 tests)
- [x] `cargo test -p mur-common agent` (76 tests)
- [x] `cargo test -p mur-agent-runtime protocol::methods::skills` (3 tests)
- [x] `cargo test -p mur-agent-runtime --test card_method` (2 tests)
- [x] `cargo test -p mur-core --test skill_install_agent_e2e -- --test-threads=1` (4 tests)
- [x] `cargo test --workspace` — 1260+ pass, 1 pre-existing flaky failure unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)