### PR TITLE
feat(skill): M6a Skill↔MCP foundations (schema v2.1, doctor checks, validation)

### DIFF
--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -162,3 +162,51 @@ Submodules:
 
 - **Spec:** `docs/superpowers/specs/2026-04-29-mur-companion-phase-1-1-design.md`
 - **Plan:** `docs/superpowers/plans/2026-04-29-companion-phase-1-1-plan.md`
+
+---
+
+## Skills System
+
+Skills are installable agent capabilities packaged as YAML or Markdown manifests. Each skill lives under `~/.mur/skills/<name>/skill.yaml` (or `skill.md`). The CLI surface is `mur skill {validate,fmt,list,show,remove,search,info,audit,trust,from-pattern,doctor,consolidate,reindex-vec,reindex-stats}`.
+
+Key modules:
+
+- **`mur-common/src/skill/`** — Shared types and validation: `SkillManifest` (schema v2.1), `Skill` wrapper, `Content`, `Procedure`, `Trigger`, `Category`, `TrustLevel`, plus `scan_skill()` security scanning.
+- **`mur-core/src/cmd/skill_cmd.rs`** — `mur skill` CLI handlers (validate, fmt, list, show, remove, search, info, audit, trust).
+- **`mur-core/src/cmd/skill_doctor.rs`** — `mur skill doctor` checks: deprecated fields, missing abstract, untrusted skills, trigger coverage, MCP requirements coverage, MCP capability availability.
+- **`mur-core/src/cmd/skill_from_pattern.rs`** — `mur skill from-pattern`: promote a Stable/Canonical pattern to a skill, with optional LLM polish.
+- **`mur-core/src/skill_index/`** — Vector embedding (LanceDB) and BM25 index for `mur skill search`.
+- **`mur-core/src/cmd/skill_registry.rs`** — Remote registry fetch + search.
+
+### Skill↔MCP Integration (v2.1)
+
+Skills can declare MCP tool requirements via the `mcp_requirements` field, introduced in schema v2.1. This allows a skill manifest to specify which MCP tools it needs and what capability each tool provides, enabling the runtime to verify tool availability before execution (M6b).
+
+**Data model** (`mur-common/src/skill/mcp.rs`):
+
+- `SkillCapability` enum — `ReadFile | ListTools | Search | WriteFile | ExecuteSafe | NetworkHttp` (string-form serde, e.g. `"read_file"`).
+- `McpRequirement` struct — `tool_pattern` (glob), `capability` (SkillCapability), `fallback` (optional description for graceful degradation).
+
+Example manifest fragment:
+
+```yaml
+mcp_requirements:
+  - tool_pattern: "filesystem.read_*"
+    capability: read_file
+  - tool_pattern: "web.search"
+    capability: search
+    fallback: "Use built-in web search if MCP web tool unavailable"
+```
+
+**Validation** — `validate_requirements()` in `mur-common/src/skill/mcp.rs` checks glob syntax and rejects duplicate tool patterns. The main `validate()` function calls this for every manifest parse, returning `ValidationError::McpRequirements(idx, message)` on failure.
+
+**Doctor checks** (`mur-core/src/cmd/skill_doctor.rs`):
+
+| Check | Severity | What it does |
+|-------|----------|--------------|
+| `mcp-requirements-coverage` | Warn | Flags procedural skills whose steps reference dotted tool names (e.g. `filesystem.read_file`) but lack a matching `mcp_requirements` entry. |
+| `mcp-capability-available` | Warn/Unknown | Glob-matches each requirement's `tool_pattern` against the agent's configured MCP tools. Emits `Unknown` when run outside an agent context (no tool list available). Skills with a `fallback` are skipped. |
+
+**`mur skill show`** — When a skill has `mcp_requirements`, the command prints a formatted "MCP Requirements:" block after the YAML, listing each tool pattern with its capability and optional fallback.
+
+Execution-time enforcement of these requirements (resolving globs, checking tool availability, applying fallbacks) is deferred to M6b.

--- a/mur-common/Cargo.toml
+++ b/mur-common/Cargo.toml
@@ -48,6 +48,7 @@ flate2 = "1.1.9"
 semver = "1"
 fd-lock = "4"
 tempfile = "3"
+globset = "0.4"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation"] }

--- a/mur-common/src/skill/manifest.rs
+++ b/mur-common/src/skill/manifest.rs
@@ -1,6 +1,7 @@
 //! Skill manifest — full serde representation of canonical `skill.yaml`.
 
 use super::evolution::EvolutionEvent;
+use super::mcp::McpRequirement;
 use super::types::{Category, ContentMode, HostId, Priority, TriggerKind, TrustLevel};
 use serde::{Deserialize, Serialize};
 
@@ -65,6 +66,14 @@ pub struct SkillManifest {
     /// Empty for registry-installed and locally-authored skills.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub transfer_chain: Vec<String>,
+
+    /// MCP tool capabilities this skill needs at runtime. Optional; absent
+    /// in M3-era v2.0 manifests. Added in schema v2.1.
+    ///
+    /// **Signature scope:** signed as part of the manifest. Changing
+    /// `mcp_requirements` invalidates an existing publisher signature.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_requirements: Vec<McpRequirement>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/mur-common/src/skill/mcp.rs
+++ b/mur-common/src/skill/mcp.rs
@@ -119,10 +119,7 @@ pub fn validate_requirements(reqs: &[McpRequirement]) -> Result<(), (usize, Stri
         }
         // Validate glob syntax.
         if globset::Glob::new(&req.tool_pattern).is_err() {
-            return Err((
-                i,
-                format!("invalid glob pattern: '{}'", req.tool_pattern),
-            ));
+            return Err((i, format!("invalid glob pattern: '{}'", req.tool_pattern)));
         }
         let cap_str = req.capability.as_str();
         if !seen.insert((&req.tool_pattern, cap_str)) {
@@ -144,12 +141,30 @@ mod tests {
 
     #[test]
     fn parse_valid_capabilities() {
-        assert_eq!("read_file".parse::<SkillCapability>().unwrap(), SkillCapability::ReadFile);
-        assert_eq!("list_tools".parse::<SkillCapability>().unwrap(), SkillCapability::ListTools);
-        assert_eq!("search".parse::<SkillCapability>().unwrap(), SkillCapability::Search);
-        assert_eq!("write_file".parse::<SkillCapability>().unwrap(), SkillCapability::WriteFile);
-        assert_eq!("execute_safe".parse::<SkillCapability>().unwrap(), SkillCapability::ExecuteSafe);
-        assert_eq!("network_http".parse::<SkillCapability>().unwrap(), SkillCapability::NetworkHttp);
+        assert_eq!(
+            "read_file".parse::<SkillCapability>().unwrap(),
+            SkillCapability::ReadFile
+        );
+        assert_eq!(
+            "list_tools".parse::<SkillCapability>().unwrap(),
+            SkillCapability::ListTools
+        );
+        assert_eq!(
+            "search".parse::<SkillCapability>().unwrap(),
+            SkillCapability::Search
+        );
+        assert_eq!(
+            "write_file".parse::<SkillCapability>().unwrap(),
+            SkillCapability::WriteFile
+        );
+        assert_eq!(
+            "execute_safe".parse::<SkillCapability>().unwrap(),
+            SkillCapability::ExecuteSafe
+        );
+        assert_eq!(
+            "network_http".parse::<SkillCapability>().unwrap(),
+            SkillCapability::NetworkHttp
+        );
     }
 
     #[test]

--- a/mur-common/src/skill/mcp.rs
+++ b/mur-common/src/skill/mcp.rs
@@ -1,0 +1,251 @@
+//! MCP capability declaration vocabulary (M6a).
+//!
+//! Shared string-form contract between skill manifests and commander's
+//! MCP trust store. `mur-common` owns the enum so the YAML schema is
+//! stable even if commander refactors internally.
+//!
+//! If commander adds a 7th capability, add the variant + `as_str`/`FromStr`
+//! arms here with no other code changes needed.
+
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+/// MCP capabilities a skill may declare it requires. Mirrors the six
+/// capabilities defined in mur-commander's `engine/src/mcp/trust.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SkillCapability {
+    ReadFile,
+    ListTools,
+    Search,
+    WriteFile,
+    ExecuteSafe,
+    NetworkHttp,
+}
+
+impl SkillCapability {
+    pub const ALL: &[SkillCapability] = &[
+        SkillCapability::ReadFile,
+        SkillCapability::ListTools,
+        SkillCapability::Search,
+        SkillCapability::WriteFile,
+        SkillCapability::ExecuteSafe,
+        SkillCapability::NetworkHttp,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SkillCapability::ReadFile => "read_file",
+            SkillCapability::ListTools => "list_tools",
+            SkillCapability::Search => "search",
+            SkillCapability::WriteFile => "write_file",
+            SkillCapability::ExecuteSafe => "execute_safe",
+            SkillCapability::NetworkHttp => "network_http",
+        }
+    }
+}
+
+impl std::fmt::Display for SkillCapability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for SkillCapability {
+    type Err = ParseCapabilityError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "read_file" => SkillCapability::ReadFile,
+            "list_tools" => SkillCapability::ListTools,
+            "search" => SkillCapability::Search,
+            "write_file" => SkillCapability::WriteFile,
+            "execute_safe" => SkillCapability::ExecuteSafe,
+            "network_http" => SkillCapability::NetworkHttp,
+            other => return Err(ParseCapabilityError(other.to_string())),
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "unknown MCP capability '{0}' (expected one of: read_file, list_tools, search, \
+     write_file, execute_safe, network_http)"
+)]
+pub struct ParseCapabilityError(pub String);
+
+// Serde uses the string form so YAML reads as `capability: read_file`,
+// not `capability: ReadFile`.
+impl Serialize for SkillCapability {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for SkillCapability {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+/// A requirement that one or more MCP tools matching `tool_pattern` be
+/// reachable at runtime, and that they are safe to invoke under `capability`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct McpRequirement {
+    /// Glob pattern matching tool names, e.g. `"browser.*"` or
+    /// `"filesystem.write.*"`.
+    pub tool_pattern: String,
+
+    /// Capability for the matched tool. Used by commander's trust store
+    /// at runtime (M6b) to decide whether to permit the call.
+    pub capability: SkillCapability,
+
+    /// Optional fallback. Empty string means "no fallback — fail if no
+    /// matching tool is available". Free-form; not validated here.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub fallback: String,
+}
+
+/// Validate a list of requirements at parse time.
+///
+/// Checks: non-empty pattern, valid glob syntax, no duplicate
+/// (pattern, capability) pairs.
+pub fn validate_requirements(reqs: &[McpRequirement]) -> Result<(), (usize, String)> {
+    use std::collections::HashSet;
+    let mut seen: HashSet<(&str, &str)> = HashSet::new();
+    for (i, req) in reqs.iter().enumerate() {
+        if req.tool_pattern.is_empty() {
+            return Err((i, "tool_pattern must not be empty".into()));
+        }
+        // Validate glob syntax.
+        if globset::Glob::new(&req.tool_pattern).is_err() {
+            return Err((
+                i,
+                format!("invalid glob pattern: '{}'", req.tool_pattern),
+            ));
+        }
+        let cap_str = req.capability.as_str();
+        if !seen.insert((&req.tool_pattern, cap_str)) {
+            return Err((
+                i,
+                format!(
+                    "duplicate (tool_pattern, capability) pair: '{}'/{}",
+                    req.tool_pattern, req.capability
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_capabilities() {
+        assert_eq!("read_file".parse::<SkillCapability>().unwrap(), SkillCapability::ReadFile);
+        assert_eq!("list_tools".parse::<SkillCapability>().unwrap(), SkillCapability::ListTools);
+        assert_eq!("search".parse::<SkillCapability>().unwrap(), SkillCapability::Search);
+        assert_eq!("write_file".parse::<SkillCapability>().unwrap(), SkillCapability::WriteFile);
+        assert_eq!("execute_safe".parse::<SkillCapability>().unwrap(), SkillCapability::ExecuteSafe);
+        assert_eq!("network_http".parse::<SkillCapability>().unwrap(), SkillCapability::NetworkHttp);
+    }
+
+    #[test]
+    fn parse_invalid_capability() {
+        let err = "telepathy".parse::<SkillCapability>().unwrap_err();
+        assert!(err.to_string().contains("unknown MCP capability"));
+        assert!(err.to_string().contains("telepathy"));
+    }
+
+    #[test]
+    fn capability_display_roundtrips() {
+        for cap in SkillCapability::ALL {
+            let s = cap.to_string();
+            let parsed: SkillCapability = s.parse().unwrap();
+            assert_eq!(parsed, *cap);
+        }
+    }
+
+    #[test]
+    fn capability_serializes_as_string() {
+        let json = serde_json::to_string(&SkillCapability::ReadFile).unwrap();
+        assert_eq!(json, "\"read_file\"");
+    }
+
+    #[test]
+    fn capability_deserializes_from_string() {
+        let cap: SkillCapability = serde_json::from_str("\"network_http\"").unwrap();
+        assert_eq!(cap, SkillCapability::NetworkHttp);
+    }
+
+    #[test]
+    fn capability_rejects_unknown_string() {
+        let err = serde_json::from_str::<SkillCapability>("\"telepathy\"").unwrap_err();
+        assert!(err.to_string().contains("unknown MCP capability"));
+    }
+
+    #[test]
+    fn validate_empty_requirements() {
+        assert!(validate_requirements(&[]).is_ok());
+    }
+
+    #[test]
+    fn validate_single_requirement() {
+        let reqs = vec![McpRequirement {
+            tool_pattern: "browser.*".into(),
+            capability: SkillCapability::NetworkHttp,
+            fallback: String::new(),
+        }];
+        assert!(validate_requirements(&reqs).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_empty_pattern() {
+        let reqs = vec![McpRequirement {
+            tool_pattern: String::new(),
+            capability: SkillCapability::ReadFile,
+            fallback: String::new(),
+        }];
+        let err = validate_requirements(&reqs).unwrap_err();
+        assert_eq!(err.0, 0);
+        assert!(err.1.contains("tool_pattern must not be empty"));
+    }
+
+    #[test]
+    fn validate_rejects_duplicate() {
+        let reqs = vec![
+            McpRequirement {
+                tool_pattern: "browser.*".into(),
+                capability: SkillCapability::NetworkHttp,
+                fallback: String::new(),
+            },
+            McpRequirement {
+                tool_pattern: "browser.*".into(),
+                capability: SkillCapability::NetworkHttp,
+                fallback: String::new(),
+            },
+        ];
+        let err = validate_requirements(&reqs).unwrap_err();
+        assert_eq!(err.0, 1);
+        assert!(err.1.contains("duplicate"));
+    }
+
+    #[test]
+    fn validate_allows_same_pattern_different_capability() {
+        let reqs = vec![
+            McpRequirement {
+                tool_pattern: "fs.*".into(),
+                capability: SkillCapability::ReadFile,
+                fallback: String::new(),
+            },
+            McpRequirement {
+                tool_pattern: "fs.*".into(),
+                capability: SkillCapability::WriteFile,
+                fallback: String::new(),
+            },
+        ];
+        assert!(validate_requirements(&reqs).is_ok());
+    }
+}

--- a/mur-common/src/skill/mod.rs
+++ b/mur-common/src/skill/mod.rs
@@ -10,6 +10,7 @@ pub mod loader;
 pub mod local;
 pub mod lockfile;
 pub mod manifest;
+pub mod mcp;
 pub mod parser;
 pub mod registry;
 pub mod scan;
@@ -18,6 +19,7 @@ pub mod stats;
 pub mod store;
 pub mod types;
 pub mod validate;
+pub mod version;
 
 pub use capability::{Capability, CapabilityViolation, allowed_for, check_capabilities};
 pub use constraint::{Constraint, ConstraintError};
@@ -40,3 +42,7 @@ pub use stats::{LifecycleState, SkillStats};
 pub use store::{StoreError, agent_skill_dir, global_skill_dir, read_from_dir, write_to_dir};
 pub use types::*;
 pub use validate::{ValidationError, validate};
+pub use version::{SKILL_MANIFEST_SCHEMA_VERSION, is_supported};
+pub use mcp::{
+    McpRequirement, ParseCapabilityError, SkillCapability, validate_requirements,
+};

--- a/mur-common/src/skill/mod.rs
+++ b/mur-common/src/skill/mod.rs
@@ -33,6 +33,7 @@ pub use lifecycle::{
 pub use loader::{LoadedSkill, SkillScope, load_all};
 pub use lockfile::{LockfileError, SkillLock};
 pub use manifest::*;
+pub use mcp::{McpRequirement, ParseCapabilityError, SkillCapability, validate_requirements};
 pub use parser::{
     ParseError, parse_canonical, parse_legacy_markdown, parse_markdown, serialize_canonical,
     serialize_markdown, yaml_to_markdown,
@@ -43,6 +44,3 @@ pub use store::{StoreError, agent_skill_dir, global_skill_dir, read_from_dir, wr
 pub use types::*;
 pub use validate::{ValidationError, validate};
 pub use version::{SKILL_MANIFEST_SCHEMA_VERSION, is_supported};
-pub use mcp::{
-    McpRequirement, ParseCapabilityError, SkillCapability, validate_requirements,
-};

--- a/mur-common/src/skill/validate.rs
+++ b/mur-common/src/skill/validate.rs
@@ -1,6 +1,7 @@
 //! Schema validation enforced after parsing.
 
 use super::manifest::SkillManifest;
+use super::mcp;
 use super::types::{Category, ContentMode, TriggerKind};
 use std::fmt;
 
@@ -17,6 +18,8 @@ pub enum ValidationError {
     },
     TriggerMissingPattern(TriggerKind),
     EmptyAbstract,
+    /// Invalid mcp_requirements entry. Fields: index, message.
+    McpRequirements(usize, String),
 }
 
 impl fmt::Display for ValidationError {
@@ -45,6 +48,9 @@ impl fmt::Display for ValidationError {
             }
             TriggerMissingPattern(k) => write!(f, "trigger '{k:?}' requires a `pattern` field"),
             EmptyAbstract => write!(f, "content.abstract must not be empty"),
+            McpRequirements(idx, msg) => {
+                write!(f, "mcp_requirements[{idx}]: {msg}")
+            }
         }
     }
 }
@@ -87,6 +93,10 @@ pub fn validate(m: &SkillManifest) -> Result<(), ValidationError> {
         if matches!(t.kind, TriggerKind::Command | TriggerKind::Keyword) && t.pattern.is_none() {
             return Err(ValidationError::TriggerMissingPattern(t.kind));
         }
+    }
+
+    if let Err((idx, msg)) = mcp::validate_requirements(&m.mcp_requirements) {
+        return Err(ValidationError::McpRequirements(idx, msg));
     }
 
     Ok(())
@@ -208,6 +218,95 @@ content:
         assert!(matches!(
             validate(&m),
             Err(ValidationError::ContentModeMismatch { .. })
+        ));
+    }
+
+    // ── M6a: mcp_requirements ──
+
+    #[test]
+    fn valid_mcp_requirements_passes() {
+        let yaml = r#"
+name: demo
+version: 1.0.0
+publisher: human:test
+description: d
+category: workflow
+content:
+  abstract: hi
+  procedure:
+    steps:
+      - description: test
+mcp_requirements:
+  - tool_pattern: "browser.*"
+    capability: network_http
+"#;
+        let m = parse_canonical(yaml).unwrap();
+        validate(&m).unwrap();
+    }
+
+    #[test]
+    fn empty_mcp_requirements_passes() {
+        let yaml = r#"
+name: demo
+version: 1.0.0
+publisher: human:test
+description: d
+category: context
+content:
+  abstract: hi
+  context: body
+"#;
+        let m = parse_canonical(yaml).unwrap();
+        validate(&m).unwrap();
+    }
+
+    #[test]
+    fn rejects_duplicate_mcp_requirements() {
+        let yaml = r#"
+name: demo
+version: 1.0.0
+publisher: human:test
+description: d
+category: workflow
+content:
+  abstract: hi
+  procedure:
+    steps:
+      - description: test
+mcp_requirements:
+  - tool_pattern: "fs.*"
+    capability: read_file
+  - tool_pattern: "fs.*"
+    capability: read_file
+"#;
+        let m = parse_canonical(yaml).unwrap();
+        assert!(matches!(
+            validate(&m),
+            Err(ValidationError::McpRequirements(1, _))
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_mcp_pattern() {
+        let yaml = r#"
+name: demo
+version: 1.0.0
+publisher: human:test
+description: d
+category: workflow
+content:
+  abstract: hi
+  procedure:
+    steps:
+      - description: test
+mcp_requirements:
+  - tool_pattern: ""
+    capability: read_file
+"#;
+        let m = parse_canonical(yaml).unwrap();
+        assert!(matches!(
+            validate(&m),
+            Err(ValidationError::McpRequirements(0, _))
         ));
     }
 

--- a/mur-common/src/skill/version.rs
+++ b/mur-common/src/skill/version.rs
@@ -1,0 +1,13 @@
+//! Schema version anchor for skill manifests.
+//!
+//! Versions are additive-only. Existing fields never change semantics;
+//! new optional fields bump the minor version.
+
+/// Current schema version written by `mur skill create` / `mur skill publish`.
+pub const SKILL_MANIFEST_SCHEMA_VERSION: &str = "2.1";
+
+/// Accepted schema versions. v2.0 manifests without `mcp_requirements` default
+/// to empty — behaviour unchanged.
+pub fn is_supported(version: &str) -> bool {
+    matches!(version, "2.0" | "2.1")
+}

--- a/mur-common/tests/skill_manifest_compat.rs
+++ b/mur-common/tests/skill_manifest_compat.rs
@@ -1,0 +1,170 @@
+//! Backward-compat tests for M6a schema evolution (v2.0 → v2.1).
+//!
+//! Verifies that M3-era v2.0 manifests load correctly with the new
+//! `mcp_requirements` field defaulting to empty, and that serialization
+//! is byte-identical so publisher signatures remain valid.
+
+use mur_common::skill::manifest::{Skill, SkillManifest};
+
+#[test]
+fn v20_manifest_loads_with_default_empty_requirements() {
+    let yaml = r#"
+name: legacy
+version: 1.0.0
+publisher: human:test
+description: A v2.0 manifest without mcp_requirements
+category: context
+content:
+  abstract: test
+  context: test context
+"#;
+    let skill: Skill = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(skill.manifest.mcp_requirements.len(), 0);
+
+    // Round-trip: the deserialized skill should still have empty requirements.
+    let out = serde_yaml_ng::to_string(&skill).unwrap();
+    let skill2: Skill = serde_yaml_ng::from_str(&out).unwrap();
+    assert_eq!(skill2.manifest.mcp_requirements.len(), 0);
+}
+
+#[test]
+fn v20_manifest_byte_identical_after_round_trip() {
+    let yaml = r#"
+name: legacy
+version: 1.0.0
+publisher: human:test
+description: A v2.0 manifest without mcp_requirements
+category: context
+content:
+  abstract: test
+  context: test context
+"#;
+    let skill: Skill = serde_yaml_ng::from_str(yaml).unwrap();
+    let out = serde_yaml_ng::to_string(&skill).unwrap();
+
+    // Re-parse and re-serialize — the second serialization should be
+    // identical to the first (no new fields leaked).
+    let skill2: Skill = serde_yaml_ng::from_str(&out).unwrap();
+    let out2 = serde_yaml_ng::to_string(&skill2).unwrap();
+    assert_eq!(out, out2, "v2.0 manifest round-trip must be byte-identical");
+}
+
+#[test]
+fn v21_manifest_with_requirements_round_trips() {
+    let yaml = r#"
+name: mcp-skill
+version: 1.0.0
+publisher: human:test
+description: Uses MCP tools
+category: workflow
+content:
+  abstract: test
+  procedure:
+    steps:
+      - description: search the web
+        tool: browser.navigate
+mcp_requirements:
+  - tool_pattern: "browser.*"
+    capability: network_http
+  - tool_pattern: "filesystem.write.*"
+    capability: write_file
+    fallback: builtin-touch
+"#;
+    let skill: Skill = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(skill.manifest.mcp_requirements.len(), 2);
+    assert_eq!(skill.manifest.mcp_requirements[0].tool_pattern, "browser.*");
+    assert_eq!(
+        skill.manifest.mcp_requirements[0].capability.to_string(),
+        "network_http"
+    );
+    assert_eq!(
+        skill.manifest.mcp_requirements[1].fallback,
+        "builtin-touch"
+    );
+
+    // Round-trip
+    let out = serde_yaml_ng::to_string(&skill).unwrap();
+    let skill2: Skill = serde_yaml_ng::from_str(&out).unwrap();
+    assert_eq!(skill2.manifest.mcp_requirements.len(), 2);
+    assert_eq!(
+        skill2.manifest.mcp_requirements[0].tool_pattern,
+        "browser.*"
+    );
+    assert_eq!(
+        skill2.manifest.mcp_requirements[1].fallback,
+        "builtin-touch"
+    );
+}
+
+#[test]
+fn unknown_capability_string_rejected() {
+    let yaml = r#"
+name: bad
+version: 1.0.0
+publisher: human:test
+description: bad capability
+category: context
+content:
+  abstract: test
+  context: test context
+mcp_requirements:
+  - tool_pattern: "x.*"
+    capability: telepathy
+"#;
+    let err = serde_yaml_ng::from_str::<Skill>(yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("unknown MCP capability"),
+        "expected 'unknown MCP capability' error, got: {err}"
+    );
+    assert!(
+        err.to_string().contains("telepathy"),
+        "error should name the bad capability, got: {err}"
+    );
+}
+
+#[test]
+fn empty_mcp_requirements_serializes_without_field() {
+    let yaml = r#"
+name: no-mcp
+version: 1.0.0
+publisher: human:test
+description: Explicitly empty requirements
+category: context
+content:
+  abstract: test
+  context: test context
+mcp_requirements: []
+"#;
+    let skill: Skill = serde_yaml_ng::from_str(yaml).unwrap();
+    assert!(skill.manifest.mcp_requirements.is_empty());
+
+    // Explicitly empty list should be serialized out (skip_serializing_if).
+    let out = serde_yaml_ng::to_string(&skill).unwrap();
+    assert!(
+        !out.contains("mcp_requirements"),
+        "empty mcp_requirements should be skipped on serialization"
+    );
+}
+
+#[test]
+fn manifest_deserializes_skillcapability_from_yaml() {
+    let yaml = r#"
+name: direct-cap
+version: 1.0.0
+publisher: human:test
+description: Direct SkillCapability deserialization
+category: context
+content:
+  abstract: test
+  context: test context
+mcp_requirements:
+  - tool_pattern: "*.search"
+    capability: search
+"#;
+    let m: SkillManifest = serde_yaml_ng::from_str(yaml).unwrap();
+    assert_eq!(m.mcp_requirements.len(), 1);
+    assert_eq!(
+        m.mcp_requirements[0].capability.to_string(),
+        "search"
+    );
+}

--- a/mur-common/tests/skill_manifest_compat.rs
+++ b/mur-common/tests/skill_manifest_compat.rs
@@ -77,10 +77,7 @@ mcp_requirements:
         skill.manifest.mcp_requirements[0].capability.to_string(),
         "network_http"
     );
-    assert_eq!(
-        skill.manifest.mcp_requirements[1].fallback,
-        "builtin-touch"
-    );
+    assert_eq!(skill.manifest.mcp_requirements[1].fallback, "builtin-touch");
 
     // Round-trip
     let out = serde_yaml_ng::to_string(&skill).unwrap();
@@ -163,8 +160,5 @@ mcp_requirements:
 "#;
     let m: SkillManifest = serde_yaml_ng::from_str(yaml).unwrap();
     assert_eq!(m.mcp_requirements.len(), 1);
-    assert_eq!(
-        m.mcp_requirements[0].capability.to_string(),
-        "search"
-    );
+    assert_eq!(m.mcp_requirements[0].capability.to_string(), "search");
 }

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -51,6 +51,7 @@ aho-corasick = "1"
 thiserror = { workspace = true }
 dirs = "6"
 tempfile = "3"
+globset = "0.4"
 sha2 = "0.10"
 hex = "0.4"
 regex = "1"

--- a/mur-core/src/cmd/skill_cmd.rs
+++ b/mur-core/src/cmd/skill_cmd.rs
@@ -83,8 +83,27 @@ pub fn cmd_show(name: &str) -> Result<()> {
     let home = resolve_mur_home()?;
     let m =
         local::load_installed(&home, name).map_err(|_| anyhow!("skill '{name}' not installed"))?;
+
+    // Check mcp_requirements before moving the manifest
+    let has_mcp = !m.mcp_requirements.is_empty();
+
     let yaml = serialize_canonical(&m)?;
     print!("{yaml}");
+
+    if has_mcp {
+        println!("\nMCP Requirements:");
+        for req in &m.mcp_requirements {
+            let cap = &req.capability;
+            if req.fallback.is_empty() {
+                println!("  - {:<30} (capability: {cap})", req.tool_pattern);
+            } else {
+                println!(
+                    "  - {:<30} (capability: {cap}, fallback: {})",
+                    req.tool_pattern, req.fallback
+                );
+            }
+        }
+    }
     Ok(())
 }
 

--- a/mur-core/src/cmd/skill_doctor.rs
+++ b/mur-core/src/cmd/skill_doctor.rs
@@ -753,7 +753,10 @@ mcp_requirements:
         write_skill(&dir, "covered-skill", yaml);
         let ctx = doctor_ctx(&dir);
         let findings = run_mcp_requirements_coverage(&ctx, "covered-skill");
-        assert!(findings.is_empty(), "expected no findings, got {findings:?}");
+        assert!(
+            findings.is_empty(),
+            "expected no findings, got {findings:?}"
+        );
     }
 
     #[test]
@@ -843,7 +846,8 @@ mcp_requirements:
     capability: network_http
 "#;
         write_skill(&dir, "browser-skill", yaml);
-        let ctx = doctor_ctx_with_tools(&dir, vec!["filesystem.read".into(), "search.google".into()]);
+        let ctx =
+            doctor_ctx_with_tools(&dir, vec!["filesystem.read".into(), "search.google".into()]);
         let findings = run_mcp_capability_available(&ctx, "browser-skill");
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].severity, Severity::Warn);
@@ -874,7 +878,10 @@ mcp_requirements:
             vec!["browser.navigate".into(), "browser.screenshot".into()],
         );
         let findings = run_mcp_capability_available(&ctx, "browser-skill");
-        assert!(findings.is_empty(), "expected no findings, got {findings:?}");
+        assert!(
+            findings.is_empty(),
+            "expected no findings, got {findings:?}"
+        );
     }
 
     #[test]
@@ -900,7 +907,10 @@ mcp_requirements:
         // No browser tools available — but fallback is set, so skip.
         let ctx = doctor_ctx_with_tools(&dir, vec!["filesystem.read".into()]);
         let findings = run_mcp_capability_available(&ctx, "fallback-skill");
-        assert!(findings.is_empty(), "fallback requirements should be skipped, got {findings:?}");
+        assert!(
+            findings.is_empty(),
+            "fallback requirements should be skipped, got {findings:?}"
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/skill_doctor.rs
+++ b/mur-core/src/cmd/skill_doctor.rs
@@ -90,6 +90,7 @@ pub fn cmd_doctor(
         "execution-recency",
         "failure-rate",
         "api-drift",
+        "mcp-requirements-coverage",
     ];
     let active_checks: Vec<&str> = if checks.is_empty() {
         all_checks.to_vec()
@@ -122,6 +123,9 @@ pub fn cmd_doctor(
                 }
                 "api-drift" => {
                     findings.extend(run_api_drift(&ctx, skill_name));
+                }
+                "mcp-requirements-coverage" => {
+                    findings.extend(run_mcp_requirements_coverage(&ctx, skill_name));
                 }
                 _ => {}
             }
@@ -460,6 +464,65 @@ fn run_api_drift(_ctx: &DoctorCtx, skill_name: &str) -> Vec<Finding> {
     }]
 }
 
+fn run_mcp_requirements_coverage(ctx: &DoctorCtx, skill_name: &str) -> Vec<Finding> {
+    let Some(manifest) = load_manifest(&ctx.home, skill_name) else {
+        return vec![Finding {
+            check_id: "mcp-requirements-coverage".into(),
+            category: "mcp".into(),
+            severity: Severity::Unknown,
+            skill_name: skill_name.to_string(),
+            message: "Cannot read manifest — unable to check MCP requirements coverage.".into(),
+            remediation: None,
+            fixable: false,
+        }];
+    };
+
+    // Only procedural skills can reference MCP tools in steps.
+    if manifest.content.mode() != Some(mur_common::skill::types::ContentMode::Workflow) {
+        return vec![];
+    }
+    // Already has explicit requirements — covered.
+    if !manifest.mcp_requirements.is_empty() {
+        return vec![];
+    }
+    let Some(proc) = &manifest.content.procedure else {
+        return vec![];
+    };
+
+    let referenced: Vec<&str> = proc
+        .steps
+        .iter()
+        .filter_map(|s| s.tool.as_deref())
+        .filter(|t| t.contains('.') && !t.starts_with("./") && !t.starts_with("../"))
+        .collect();
+
+    if referenced.is_empty() {
+        return vec![];
+    }
+
+    vec![Finding {
+        check_id: "mcp-requirements-coverage".into(),
+        category: "mcp".into(),
+        severity: Severity::Warn,
+        skill_name: skill_name.to_string(),
+        message: format!(
+            "procedural skill references {} dotted tool name(s) ({}) but declares no \
+             mcp_requirements — add an mcp_requirements block to declare the needed MCP capability",
+            referenced.len(),
+            referenced
+                .iter()
+                .take(3)
+                .copied()
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        remediation: Some(
+            "Add an mcp_requirements block mapping tool patterns to capabilities.".into(),
+        ),
+        fixable: false,
+    }]
+}
+
 // ── Output ──
 
 fn format_findings(findings: &[Finding], fmt: DoctorFormat, color: bool) -> Result<()> {
@@ -535,4 +598,117 @@ pub fn exit_code(findings: &[Finding], strict: bool) -> i32 {
     let any_fail = findings.iter().any(|f| f.severity == Severity::Fail);
     let any_warn = findings.iter().any(|f| f.severity == Severity::Warn);
     i32::from(any_fail || (strict && any_warn))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_skill(dir: &TempDir, name: &str, yaml: &str) {
+        let skill_dir = dir.path().join("skills").join(name);
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(skill_dir.join("skill.yaml"), yaml).unwrap();
+    }
+
+    fn doctor_ctx(dir: &TempDir) -> DoctorCtx {
+        DoctorCtx {
+            home: dir.path().to_path_buf(),
+            now: chrono::Utc::now(),
+            installed_skills: std::collections::HashSet::new(),
+        }
+    }
+
+    #[test]
+    fn coverage_workflow_with_dotted_tools_no_requirements() {
+        let dir = TempDir::new().unwrap();
+        let yaml = r#"
+name: browser-skill
+version: 1.0.0
+publisher: human:test
+description: Skill with tool refs but no mcp_requirements
+category: workflow
+content:
+  abstract: test
+  procedure:
+    steps:
+      - description: navigate
+        tool: browser.navigate
+      - description: search
+        tool: browser.search
+"#;
+        write_skill(&dir, "browser-skill", yaml);
+        let ctx = doctor_ctx(&dir);
+        let findings = run_mcp_requirements_coverage(&ctx, "browser-skill");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].check_id, "mcp-requirements-coverage");
+        assert_eq!(findings[0].severity, Severity::Warn);
+        assert!(findings[0].message.contains("browser.navigate"));
+    }
+
+    #[test]
+    fn coverage_workflow_with_requirements_no_finding() {
+        let dir = TempDir::new().unwrap();
+        let yaml = r#"
+name: covered-skill
+version: 1.0.0
+publisher: human:test
+description: Skill with tool refs and mcp_requirements
+category: workflow
+content:
+  abstract: test
+  procedure:
+    steps:
+      - description: navigate
+        tool: browser.navigate
+mcp_requirements:
+  - tool_pattern: "browser.*"
+    capability: network_http
+"#;
+        write_skill(&dir, "covered-skill", yaml);
+        let ctx = doctor_ctx(&dir);
+        let findings = run_mcp_requirements_coverage(&ctx, "covered-skill");
+        assert!(findings.is_empty(), "expected no findings, got {findings:?}");
+    }
+
+    #[test]
+    fn coverage_context_mode_skipped() {
+        let dir = TempDir::new().unwrap();
+        let yaml = r#"
+name: context-skill
+version: 1.0.0
+publisher: human:test
+description: Context skill with no procedure
+category: context
+content:
+  abstract: test
+  context: some context
+"#;
+        write_skill(&dir, "context-skill", yaml);
+        let ctx = doctor_ctx(&dir);
+        let findings = run_mcp_requirements_coverage(&ctx, "context-skill");
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn coverage_no_dotted_tools_no_finding() {
+        let dir = TempDir::new().unwrap();
+        let yaml = r#"
+name: no-tools
+version: 1.0.0
+publisher: human:test
+description: Workflow with no dotted tool refs
+category: workflow
+content:
+  abstract: test
+  procedure:
+    steps:
+      - description: do something
+"#;
+        write_skill(&dir, "no-tools", yaml);
+        let ctx = doctor_ctx(&dir);
+        let findings = run_mcp_requirements_coverage(&ctx, "no-tools");
+        assert!(findings.is_empty());
+    }
 }

--- a/mur-core/src/cmd/skill_doctor.rs
+++ b/mur-core/src/cmd/skill_doctor.rs
@@ -42,6 +42,9 @@ struct DoctorCtx {
     home: PathBuf,
     now: DateTime<Utc>,
     installed_skills: HashSet<String>,
+    /// Available MCP tool names across all configured servers.
+    /// `None` means "no agent context" — the check reports Unknown.
+    mcp_tools: Option<Vec<String>>,
 }
 
 pub fn cmd_doctor(
@@ -91,6 +94,7 @@ pub fn cmd_doctor(
         "failure-rate",
         "api-drift",
         "mcp-requirements-coverage",
+        "mcp-capability-available",
     ];
     let active_checks: Vec<&str> = if checks.is_empty() {
         all_checks.to_vec()
@@ -102,6 +106,7 @@ pub fn cmd_doctor(
         home,
         now,
         installed_skills: installed_names,
+        mcp_tools: None, // wired to agent MCP registry in M6b
     };
 
     let mut findings: Vec<Finding> = Vec::new();
@@ -126,6 +131,9 @@ pub fn cmd_doctor(
                 }
                 "mcp-requirements-coverage" => {
                     findings.extend(run_mcp_requirements_coverage(&ctx, skill_name));
+                }
+                "mcp-capability-available" => {
+                    findings.extend(run_mcp_capability_available(&ctx, skill_name));
                 }
                 _ => {}
             }
@@ -594,7 +602,73 @@ fn severity_color(s: Severity, icon: &str) -> String {
     out
 }
 
-pub fn exit_code(findings: &[Finding], strict: bool) -> i32 {
+fn run_mcp_capability_available(ctx: &DoctorCtx, skill_name: &str) -> Vec<Finding> {
+    let Some(manifest) = load_manifest(&ctx.home, skill_name) else {
+        return vec![Finding {
+            check_id: "mcp-capability-available".into(),
+            category: "mcp".into(),
+            severity: Severity::Unknown,
+            skill_name: skill_name.to_string(),
+            message: "Cannot read manifest — unable to check MCP capability availability.".into(),
+            remediation: None,
+            fixable: false,
+        }];
+    };
+
+    if manifest.mcp_requirements.is_empty() {
+        return vec![];
+    }
+
+    // Without agent context we can't enumerate available MCP tools.
+    // Wire to the agent's MCP server registry in M6b.
+    let Some(ref available) = ctx.mcp_tools else {
+        return vec![Finding {
+            check_id: "mcp-capability-available".into(),
+            category: "mcp".into(),
+            severity: Severity::Unknown,
+            skill_name: skill_name.to_string(),
+            message: "MCP capability-availability check requires agent context — \
+                     run from within an agent to check server availability."
+                .into(),
+            remediation: None,
+            fixable: false,
+        }];
+    };
+
+    let mut findings = Vec::new();
+    for (i, req) in manifest.mcp_requirements.iter().enumerate() {
+        // Skip requirements with a fallback.
+        if !req.fallback.is_empty() {
+            continue;
+        }
+        // Match glob pattern against available tools.
+        let Ok(glob) = globset::Glob::new(&req.tool_pattern) else {
+            continue;
+        };
+        let matcher = glob.compile_matcher();
+        let has_match = available.iter().any(|t| matcher.is_match(t));
+        if !has_match {
+            findings.push(Finding {
+                check_id: "mcp-capability-available".into(),
+                category: "mcp".into(),
+                severity: Severity::Warn,
+                skill_name: skill_name.to_string(),
+                message: format!(
+                    "mcp_requirements[{i}]: no MCP server provides tool matching \
+                     '{}' (capability {}, no fallback)",
+                    req.tool_pattern, req.capability
+                ),
+                remediation: Some(
+                    "Install an MCP server that provides this tool, or add a fallback.".into(),
+                ),
+                fixable: false,
+            });
+        }
+    }
+    findings
+}
+
+fn exit_code(findings: &[Finding], strict: bool) -> i32 {
     let any_fail = findings.iter().any(|f| f.severity == Severity::Fail);
     let any_warn = findings.iter().any(|f| f.severity == Severity::Warn);
     i32::from(any_fail || (strict && any_warn))
@@ -617,6 +691,16 @@ mod tests {
             home: dir.path().to_path_buf(),
             now: chrono::Utc::now(),
             installed_skills: std::collections::HashSet::new(),
+            mcp_tools: None,
+        }
+    }
+
+    fn doctor_ctx_with_tools(dir: &TempDir, tools: Vec<String>) -> DoctorCtx {
+        DoctorCtx {
+            home: dir.path().to_path_buf(),
+            now: chrono::Utc::now(),
+            installed_skills: std::collections::HashSet::new(),
+            mcp_tools: Some(tools),
         }
     }
 
@@ -709,6 +793,132 @@ content:
         write_skill(&dir, "no-tools", yaml);
         let ctx = doctor_ctx(&dir);
         let findings = run_mcp_requirements_coverage(&ctx, "no-tools");
+        assert!(findings.is_empty());
+    }
+
+    // ── mcp-capability-available ──
+
+    #[test]
+    fn capability_check_unknown_without_agent_context() {
+        let dir = TempDir::new().unwrap();
+        let yaml = r#"
+name: mcp-skill
+version: 1.0.0
+publisher: human:test
+description: Skill with MCP requirements
+category: workflow
+content:
+  abstract: test
+  procedure:
+    steps:
+      - description: test
+mcp_requirements:
+  - tool_pattern: "browser.*"
+    capability: network_http
+"#;
+        write_skill(&dir, "mcp-skill", yaml);
+        let ctx = doctor_ctx(&dir); // mcp_tools = None
+        let findings = run_mcp_capability_available(&ctx, "mcp-skill");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].check_id, "mcp-capability-available");
+        assert_eq!(findings[0].severity, Severity::Unknown);
+    }
+
+    #[test]
+    fn capability_check_warns_when_no_match() {
+        let dir = TempDir::new().unwrap();
+        let yaml = r#"
+name: browser-skill
+version: 1.0.0
+publisher: human:test
+description: Skill needing browser
+category: workflow
+content:
+  abstract: test
+  procedure:
+    steps:
+      - description: test
+mcp_requirements:
+  - tool_pattern: "browser.*"
+    capability: network_http
+"#;
+        write_skill(&dir, "browser-skill", yaml);
+        let ctx = doctor_ctx_with_tools(&dir, vec!["filesystem.read".into(), "search.google".into()]);
+        let findings = run_mcp_capability_available(&ctx, "browser-skill");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Warn);
+        assert!(findings[0].message.contains("browser.*"));
+    }
+
+    #[test]
+    fn capability_ok_when_glob_matches() {
+        let dir = TempDir::new().unwrap();
+        let yaml = r#"
+name: browser-skill
+version: 1.0.0
+publisher: human:test
+description: Skill needing browser
+category: workflow
+content:
+  abstract: test
+  procedure:
+    steps:
+      - description: test
+mcp_requirements:
+  - tool_pattern: "browser.*"
+    capability: network_http
+"#;
+        write_skill(&dir, "browser-skill", yaml);
+        let ctx = doctor_ctx_with_tools(
+            &dir,
+            vec!["browser.navigate".into(), "browser.screenshot".into()],
+        );
+        let findings = run_mcp_capability_available(&ctx, "browser-skill");
+        assert!(findings.is_empty(), "expected no findings, got {findings:?}");
+    }
+
+    #[test]
+    fn capability_skips_fallback_requirement() {
+        let dir = TempDir::new().unwrap();
+        let yaml = r#"
+name: fallback-skill
+version: 1.0.0
+publisher: human:test
+description: Skill with fallback
+category: workflow
+content:
+  abstract: test
+  procedure:
+    steps:
+      - description: test
+mcp_requirements:
+  - tool_pattern: "browser.*"
+    capability: network_http
+    fallback: builtin-http
+"#;
+        write_skill(&dir, "fallback-skill", yaml);
+        // No browser tools available — but fallback is set, so skip.
+        let ctx = doctor_ctx_with_tools(&dir, vec!["filesystem.read".into()]);
+        let findings = run_mcp_capability_available(&ctx, "fallback-skill");
+        assert!(findings.is_empty(), "fallback requirements should be skipped, got {findings:?}");
+    }
+
+    #[test]
+    fn capability_empty_requirements_no_finding() {
+        let dir = TempDir::new().unwrap();
+        let yaml = r#"
+name: simple-skill
+version: 1.0.0
+publisher: human:test
+description: No MCP requirements
+category: context
+content:
+  abstract: test
+  context: body
+"#;
+        write_skill(&dir, "simple-skill", yaml);
+        let ctx = doctor_ctx_with_tools(&dir, vec!["browser.navigate".into()]);
+        let findings = run_mcp_capability_available(&ctx, "simple-skill");
         assert!(findings.is_empty());
     }
 }

--- a/mur-core/src/cmd/skill_from_pattern.rs
+++ b/mur-core/src/cmd/skill_from_pattern.rs
@@ -99,6 +99,7 @@ pub fn pattern_to_skill(pattern: &Pattern, polish: bool) -> Result<SkillManifest
         priority: Default::default(),
         evolution_log: vec![],
         transfer_chain: vec![],
+        mcp_requirements: vec![],
     };
 
     validate(&manifest).context("derived skill manifest failed schema validation")?;

--- a/mur-core/src/skill_index/text.rs
+++ b/mur-core/src/skill_index/text.rs
@@ -69,6 +69,7 @@ mod tests {
             priority: Default::default(),
             evolution_log: vec![],
             transfer_chain: vec![],
+            mcp_requirements: vec![],
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `SkillCapability` enum and `McpRequirement` struct to the skill data model (schema v2.1)
- Integrates `mcp_requirements` validation into manifest parsing (glob syntax + duplicate detection)
- Adds two doctor checks: `mcp-requirements-coverage` (warn on procedural skills missing MCP entries) and `mcp-capability-available` (glob-match requirements against configured tools)
- `mur skill show` now renders MCP requirements block when present
- Adds Skills System section with MCP integration docs to runtime-overview.md

## Test Plan

- [ ] `cargo test -p mur-common` — 11 mcp unit tests + 6 compat integration tests + 4 validation tests
- [ ] `cargo test -p mur-core` — 9 doctor tests (coverage + capability)
- [ ] `mur skill validate` accepts valid mcp_requirements and rejects duplicates/bad globs
- [ ] `mur skill show <skill-with-mcp>` prints MCP Requirements block

🤖 Generated with [Claude Code](https://claude.com/claude-code)