### PR TITLE
fix(discovery): exclude LLM models from oMLX embedding menu

### DIFF
--- a/mur-core/src/discovery/aggregate.rs
+++ b/mur-core/src/discovery/aggregate.rs
@@ -47,9 +47,27 @@ fn build_menu(
     table: &[(&'static str, u32)],
     desired_kind: ModelKind,
 ) -> Vec<MenuRow> {
+    let other_table = match desired_kind {
+        ModelKind::Embedding => LLM_PREFERENCE,
+        ModelKind::Llm => EMBEDDING_PREFERENCE,
+        ModelKind::Unknown => &[],
+    };
     let mut filtered: Vec<&DiscoveredModel> = available
         .iter()
-        .filter(|m| m.kind == desired_kind || m.kind == ModelKind::Unknown)
+        .filter(|m| {
+            if m.kind == desired_kind {
+                return true;
+            }
+            if m.kind != ModelKind::Unknown {
+                return false;
+            }
+            // oMLX models all arrive as Unknown. Exclude them from this menu
+            // when the other table ranks them higher — an LLM model shouldn't
+            // appear in the embedding menu, and vice versa.
+            let this_rank = rank(&m.id, table);
+            let other_rank = rank(&m.id, other_table);
+            this_rank >= other_rank
+        })
         .collect();
     // Stable sort: highest-ranked first. Tie-breaking preserves insertion order.
     filtered.sort_by_key(|m| Reverse(rank(&m.id, table)));


### PR DESCRIPTION
## Summary
- oMLX returns all models as `ModelKind::Unknown`, so chat models like `Qwen3.5-4B-MLX-4bit` leaked into the embedding selection menu
- Added disambiguation: for `Unknown` models, compare their rank in the embedding vs LLM preference tables
- A model only appears in the embedding menu when `embedding_rank >= llm_rank` (and vice versa for LLM menu)

## Test plan
- [x] 1336 tests pass
- [x] `Qwen3.5-4B-MLX-4bit` (LLM rank 90, embedding rank 0) → excluded from embedding menu
- [x] `Qwen3-Embedding-4B-4bit-DWQ` (embedding rank 90, LLM rank 0) → still appears
- [x] Unknown/unmatched models (rank 0 both) → still appear in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)