### PR TITLE
fix(team): resolve team slug to UUID before API calls

### DIFF
--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -377,19 +377,24 @@ pub enum TeamAction {
         #[arg(long, env = "MUR_TEAM_ID")]
         team: Option<String>,
     },
+    /// Set the default team (saves to config so --team can be omitted)
+    Use {
+        /// Team slug or UUID
+        team: String,
+    },
     /// Share a pattern to your team
     Share {
         /// Pattern name
         name: String,
-        /// Team ID or slug
+        /// Team ID or slug (falls back to default set by `mur team use`)
         #[arg(long, env = "MUR_TEAM_ID")]
-        team: String,
+        team: Option<String>,
     },
     /// Pull latest team patterns
     Sync {
-        /// Team ID or slug
+        /// Team ID or slug (falls back to default set by `mur team use`)
         #[arg(long, env = "MUR_TEAM_ID")]
-        team: String,
+        team: Option<String>,
     },
 }
 

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -371,23 +371,23 @@ pub enum CommunityAction {
 
 #[derive(Subcommand)]
 pub enum TeamAction {
-    /// List team patterns
+    /// List your teams (or patterns in a specific team)
     List {
-        /// Team ID
+        /// Team ID or slug (optional — lists your teams if omitted)
         #[arg(long, env = "MUR_TEAM_ID")]
-        team: String,
+        team: Option<String>,
     },
     /// Share a pattern to your team
     Share {
         /// Pattern name
         name: String,
-        /// Team ID
+        /// Team ID or slug
         #[arg(long, env = "MUR_TEAM_ID")]
         team: String,
     },
     /// Pull latest team patterns
     Sync {
-        /// Team ID
+        /// Team ID or slug
         #[arg(long, env = "MUR_TEAM_ID")]
         team: String,
     },

--- a/mur-core/src/cmd/community_cmd.rs
+++ b/mur-core/src/cmd/community_cmd.rs
@@ -6,6 +6,7 @@ use crate::community;
 use crate::gep;
 use crate::store::yaml::YamlStore;
 use crate::team;
+use crate::store::config as store_config;
 
 pub(crate) async fn cmd_community_publish(name: &str) -> Result<()> {
     let store = YamlStore::default_store()?;
@@ -258,6 +259,25 @@ pub(crate) async fn cmd_community_pack_install(id: &str) -> Result<()> {
         resp.patterns.len(),
         resp.pack.name
     );
+    Ok(())
+}
+
+pub(crate) async fn cmd_team_use(slug: &str) -> Result<()> {
+    let client = reqwest::Client::new();
+    let team_id = team::resolve_team_id(&client, slug).await?;
+
+    let mut config = store_config::load_config()?;
+    config.sync.team_id = Some(team_id.clone());
+    store_config::save_config(&config)?;
+
+    // Show which team was selected
+    let teams = team::list_user_teams(&client).await?;
+    if let Some(t) = teams.iter().find(|t| t.id == team_id) {
+        println!("  Default team set to: {} ({})", t.name, t.slug);
+    } else {
+        println!("  Default team set to: {}", team_id);
+    }
+    println!("  Run `mur team sync` to pull patterns.");
     Ok(())
 }
 

--- a/mur-core/src/cmd/community_cmd.rs
+++ b/mur-core/src/cmd/community_cmd.rs
@@ -4,9 +4,9 @@ use mur_common::pattern::*;
 
 use crate::community;
 use crate::gep;
+use crate::store::config as store_config;
 use crate::store::yaml::YamlStore;
 use crate::team;
-use crate::store::config as store_config;
 
 pub(crate) async fn cmd_community_publish(name: &str) -> Result<()> {
     let store = YamlStore::default_store()?;

--- a/mur-core/src/cmd/community_cmd.rs
+++ b/mur-core/src/cmd/community_cmd.rs
@@ -261,6 +261,31 @@ pub(crate) async fn cmd_community_pack_install(id: &str) -> Result<()> {
     Ok(())
 }
 
+pub(crate) async fn cmd_team_list_mine() -> Result<()> {
+    let client = reqwest::Client::new();
+    let teams = team::list_user_teams(&client).await?;
+
+    if teams.is_empty() {
+        println!("  You are not a member of any teams.");
+        println!("  Visit https://app.mur.run to create or join a team.");
+        return Ok(());
+    }
+
+    println!("  {:<36}  {:<25}  {:<15}  ROLE", "ID", "NAME", "SLUG");
+    println!("  {}", "-".repeat(88));
+    for t in &teams {
+        println!(
+            "  {:<36}  {:<25}  {:<15}  {}",
+            t.id,
+            truncate(&t.name, 25),
+            truncate(&t.slug, 15),
+            t.role,
+        );
+    }
+    println!();
+    Ok(())
+}
+
 pub(crate) async fn cmd_team_list(team_id: &str) -> Result<()> {
     let client = reqwest::Client::new();
     let resp = team::list_team_patterns(&client, team_id).await?;

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -16,6 +16,20 @@ use crate::cli::{
     WorkflowAction,
 };
 use crate::{cmd, dashboard, team, verify};
+use crate::store::config as store_config;
+
+/// Resolve an optional --team arg, falling back to config's default team.
+fn resolve_team_arg(arg: Option<String>) -> Result<String> {
+    if let Some(t) = arg {
+        return Ok(t);
+    }
+    let cfg = store_config::load_config()?;
+    cfg.sync.team_id.ok_or_else(|| {
+        anyhow::anyhow!(
+            "No team specified. Pass --team <slug> or run `mur team use <slug>` to set a default."
+        )
+    })
+}
 
 pub async fn run(cli: Cli) -> Result<()> {
     match cli.command {
@@ -251,14 +265,17 @@ pub async fn run(cli: Cli) -> Result<()> {
                 }
                 None => cmd::community_cmd::cmd_team_list_mine().await?,
             },
+            TeamAction::Use { team } => cmd::community_cmd::cmd_team_use(&team).await?,
             TeamAction::Share { name, team } => {
+                let slug = resolve_team_arg(team)?;
                 let client = reqwest::Client::new();
-                let team_id = team::resolve_team_id(&client, &team).await?;
+                let team_id = team::resolve_team_id(&client, &slug).await?;
                 cmd::community_cmd::cmd_team_share(&name, &team_id).await?
             }
             TeamAction::Sync { team } => {
+                let slug = resolve_team_arg(team)?;
                 let client = reqwest::Client::new();
-                let team_id = team::resolve_team_id(&client, &team).await?;
+                let team_id = team::resolve_team_id(&client, &slug).await?;
                 cmd::community_cmd::cmd_team_sync(&team_id).await?
             }
         },

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -15,7 +15,7 @@ use crate::cli::{
     ProjectAction, ScheduleAction, SessionAction, SleepAction, SyncAction, TeamAction, VoiceAction,
     WorkflowAction,
 };
-use crate::{cmd, dashboard, verify};
+use crate::{cmd, dashboard, team, verify};
 
 pub async fn run(cli: Cli) -> Result<()> {
     match cli.command {
@@ -243,11 +243,24 @@ pub async fn run(cli: Cli) -> Result<()> {
             },
         },
         Commands::Team { action } => match action {
-            TeamAction::List { team } => cmd::community_cmd::cmd_team_list(&team).await?,
+            TeamAction::List { team } => match team {
+                Some(t) => {
+                    let client = reqwest::Client::new();
+                    let team_id = team::resolve_team_id(&client, &t).await?;
+                    cmd::community_cmd::cmd_team_list(&team_id).await?
+                }
+                None => cmd::community_cmd::cmd_team_list_mine().await?,
+            },
             TeamAction::Share { name, team } => {
-                cmd::community_cmd::cmd_team_share(&name, &team).await?
+                let client = reqwest::Client::new();
+                let team_id = team::resolve_team_id(&client, &team).await?;
+                cmd::community_cmd::cmd_team_share(&name, &team_id).await?
             }
-            TeamAction::Sync { team } => cmd::community_cmd::cmd_team_sync(&team).await?,
+            TeamAction::Sync { team } => {
+                let client = reqwest::Client::new();
+                let team_id = team::resolve_team_id(&client, &team).await?;
+                cmd::community_cmd::cmd_team_sync(&team_id).await?
+            }
         },
         Commands::Login => cmd::misc::cmd_login().await?,
         Commands::Logout => cmd::misc::cmd_logout()?,

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -15,8 +15,8 @@ use crate::cli::{
     ProjectAction, ScheduleAction, SessionAction, SleepAction, SyncAction, TeamAction, VoiceAction,
     WorkflowAction,
 };
-use crate::{cmd, dashboard, team, verify};
 use crate::store::config as store_config;
+use crate::{cmd, dashboard, team, verify};
 
 /// Resolve an optional --team arg, falling back to config's default team.
 fn resolve_team_arg(arg: Option<String>) -> Result<String> {

--- a/mur-core/src/team.rs
+++ b/mur-core/src/team.rs
@@ -89,10 +89,7 @@ pub async fn list_user_teams(client: &reqwest::Client) -> Result<Vec<UserTeam>> 
         anyhow::bail!("List teams failed ({}): {}", status, body);
     }
 
-    let data: ListUserTeamsResponse = resp
-        .json()
-        .await
-        .context("Invalid list teams response")?;
+    let data: ListUserTeamsResponse = resp.json().await.context("Invalid list teams response")?;
     Ok(data.teams)
 }
 

--- a/mur-core/src/team.rs
+++ b/mur-core/src/team.rs
@@ -55,6 +55,86 @@ pub struct TeamSyncResponse {
     pub count: u64,
 }
 
+/// A team the current user belongs to.
+#[derive(Debug, Clone, Deserialize)]
+pub struct UserTeam {
+    pub id: String,
+    pub name: String,
+    pub slug: String,
+    #[serde(default)]
+    pub role: String,
+    #[serde(default)]
+    pub pattern_count: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListUserTeamsResponse {
+    teams: Vec<UserTeam>,
+}
+
+/// List teams the current user belongs to.
+pub async fn list_user_teams(client: &reqwest::Client) -> Result<Vec<UserTeam>> {
+    let base = auth::server_url();
+    let url = format!("{}/api/v1/core/teams/", base);
+
+    let req = auth::auth_request(client, reqwest::Method::GET, &url).await?;
+    let resp = req
+        .send()
+        .await
+        .context("Failed to connect to mur server")?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("List teams failed ({}): {}", status, body);
+    }
+
+    let data: ListUserTeamsResponse = resp
+        .json()
+        .await
+        .context("Invalid list teams response")?;
+    Ok(data.teams)
+}
+
+fn is_uuid(s: &str) -> bool {
+    // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx (8-4-4-4-12, 36 chars)
+    let b = s.as_bytes();
+    b.len() == 36
+        && b[8] == b'-'
+        && b[13] == b'-'
+        && b[18] == b'-'
+        && b[23] == b'-'
+        && b.iter().enumerate().all(|(i, &c)| {
+            if i == 8 || i == 13 || i == 18 || i == 23 {
+                true
+            } else {
+                c.is_ascii_hexdigit()
+            }
+        })
+}
+
+/// Resolve a team identifier (slug or UUID) to a UUID.
+pub async fn resolve_team_id(client: &reqwest::Client, team_id_or_slug: &str) -> Result<String> {
+    if is_uuid(team_id_or_slug) {
+        return Ok(team_id_or_slug.to_string());
+    }
+
+    // Otherwise, look up by slug or name
+    let teams = list_user_teams(client).await?;
+    for team in &teams {
+        if team.slug.eq_ignore_ascii_case(team_id_or_slug)
+            || team.name.eq_ignore_ascii_case(team_id_or_slug)
+        {
+            return Ok(team.id.clone());
+        }
+    }
+
+    anyhow::bail!(
+        "Team '{}' not found. Use 'mur team ls' to see your teams.",
+        team_id_or_slug
+    )
+}
+
 /// List patterns shared in a team.
 pub async fn list_team_patterns(
     client: &reqwest::Client,


### PR DESCRIPTION
## Problem

`mur team sync --team twdd` failed with `400 Bad Request: invalid team ID` because the server API uses UUIDs in URL paths (`/teams/{uuid}/sync/pull`), but users only know their team slug (e.g. `twdd`). There was no way to discover the UUID from the CLI.

## Solution

### `mur-core/src/team.rs`
- `list_user_teams()` — calls `GET /api/v1/core/teams/` to fetch the current user's teams with their `id`, `name`, `slug`, and `role`
- `resolve_team_id()` — accepts a slug or UUID; if it matches exact UUID format (`8-4-4-4-12`), uses it directly; otherwise looks up by slug/name from the teams list
- `is_uuid()` — precise UUID format check (36 chars, dashes in positions 8/13/18/23)

### `mur-core/src/cli/actions.rs`
- `--team` now accepts a UUID or a slug in `share` and `sync`
- `list` subcommand's `--team` arg is now `Option<String>` — lists your own teams when omitted

### `mur-core/src/dispatch.rs`
- Wired `resolve_team_id()` before `share`, `sync`, and `list` (when a team is specified)
- Calls `cmd_team_list_mine()` when `list` is invoked without `--team`

### `mur-core/src/cmd/community_cmd.rs`
- Added `cmd_team_list_mine()` — displays the user's teams in a table with ID, name, slug, and role

## Usage after this fix

```
# List your teams (discover the UUID/slug)
mur team ls

# Sync using slug (was broken before)
mur team sync --team twdd

# Sync using UUID (still works)
mur team sync --team xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
```

## Test plan
- [ ] `mur team ls` shows teams table with ID/name/slug/role
- [ ] `mur team sync --team twdd` resolves slug and succeeds
- [ ] `mur team sync --team <uuid>` still works directly
- [ ] `mur team share <pattern> --team twdd` resolves slug correctly
- [ ] Unknown slug gives a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)