### PR TITLE
refactor(retrieve): extract Retrievable trait from Pattern-coupled scorer

### DIFF
--- a/docs/superpowers/specs/2026-05-28-mur-notes-design.md
+++ b/docs/superpowers/specs/2026-05-28-mur-notes-design.md
@@ -1,6 +1,9 @@
 # MuR Notes — Personal Knowledge Management with Lifecycle
 
-> **Status:** Draft | **Date:** 2026-05-28 | **Depends on:** Workflow Engine v2 (pattern removal)
+> **Status:** Draft | **Date:** 2026-05-28 | **Depends on:** Workflow Engine v2
+> (`2026-05-28-mur-workflow-engine-design-v2.md`) — Pattern removal **and** the
+> shared Skill foundation (Category/ContentMode extension, unified event log,
+> stats reducer, `mur skill evolve`).
 
 ## Thesis
 
@@ -10,14 +13,77 @@ evidence tracking, hybrid retrieval, linking — is valuable and unique. Nobody 
 the 2026 PKM landscape (Karpathy's LLM Wiki, BrainDB, Vannevar, Obsidian
 plugins) offers true lifecycle management for personal notes.
 
-**v2 thesis (Workflow Engine):** A workflow is a Skill with `category: Workflow`.
+**v2 thesis (Workflow Engine):** A workflow is a `Skill` with `category: Workflow`
+whose `content.procedure` is executable.
 
-**This thesis (Notes):** A note is a Skill with `category: Note` — a
-human-curated, file-first knowledge artifact with a managed lifecycle. Same
-subsystem, same retrieve pipeline, same decay and evolution. The only thing
-Pattern did that Note doesn't is auto-inject into AI coding sessions (which
-never worked). What Note adds that Pattern lacked: human authorship, external
-tool interoperability, and an MCP query surface.
+**This thesis (Notes):** A note is a `Skill` with `category: Note` — a
+human-curated, file-first knowledge artifact with a managed lifecycle. **Same
+on-disk model, same `SkillStats`, same `next_state` lifecycle, same retrieve
+pipeline, same `mur skill evolve` sweep.** Workflow and Note are two *projections*
+of one knowledge object: Workflow is the *executable* projection (its usage signal
+is a run), Note is the *reference* projection (its usage signal is a retrieval).
+
+The only thing Pattern did that Note doesn't is auto-inject into AI coding
+sessions (which never worked). What Note adds that Pattern lacked: human
+authorship, external-tool interoperability (Obsidian export), and an MCP query
+surface.
+
+## Shared foundation (owned by Workflow Engine v2)
+
+Both specs build on **one** model. These elements are defined once in v2 and
+**reused, not re-invented, here**:
+
+| Element | Where it lives | Note's use of it |
+|---|---|---|
+| On-disk unit: `~/.mur/skills/<name>/` directory | v2 storage decision | A note is a skill directory with `category: note` |
+| `SkillStats` + its store (`new`/`path`/`load`/`merge_in_place`, **already implemented**) | `skill/stats.rs`, `cmd/skill_stats.rs` | Note reuses the existing persistence; only the event→stats reducer is new |
+| `next_state(stats, now)` lifecycle function + `LifecycleState` ladder | `skill/lifecycle.rs` | No new state machine; retrieval stats drive it |
+| Per-skill append-only `events.jsonl` → stats reducer | v2 Layer 4 (generalized from `runs.jsonl`) | Note appends a `retrieval` event; workflow appends a `run` event |
+| `mur skill evolve [--category …]` sweep | v2 Layer 4 | One sweep evolves notes and workflows alike |
+| Corpus vector index (LanceDB) | `store::vector::VectorStore` | Indexes all skills; category is a filter |
+| MCP `skill_search(query, category?)` | agent-runtime skill path | Note search is `category: note` filtered |
+
+**Storage decision (route 1, agreed).** The canonical source of truth is the
+per-skill directory `~/.mur/skills/<name>/`, **not** a separate `~/.mur/notes/`
+markdown tree. This keeps one source of truth, lets the workflow run-ledger live
+beside its skill, and reuses the existing skill store. **Obsidian compatibility
+becomes a derived export view** (`mur notes export --obsidian <vault>`), not a
+second canonical format. We trade "edit `~/.mur/notes/*.md` directly in Obsidian"
+(which had no coherent write-back story anyway) for a single, unambiguous source
+of truth.
+
+**Note body format (1a — body in `content`).** A note's prose lives **inside**
+the canonical `skill.yaml`, in a `content` field (a new `note`/`body` mode →
+`ContentMode::Note`), exactly as a context skill stores `content.context` and a
+workflow stores `content.procedure`. This is decisive for integrity:
+`content_sha256` (the basis of DSSE signing, drift detection, trust hash, and
+registry lookup) is computed over the whole manifest's canonical YAML. Body-in-
+`content` is covered **for free**; a sibling file would fall outside the signed
+hash, breaking the "inherits signing exactly as a Workflow does" promise and
+letting a pinned note's prose change without drift detection.
+
+The ergonomic cost of editing YAML-embedded markdown is already solved by the
+existing authoring surface: `parser.rs::parse_markdown` round-trips a
+markdown-frontmatter view (`---` YAML frontmatter + free markdown body) to/from
+canonical `skill.yaml` — its own doc comment states *"markdown is the
+human-authoring surface; canonical YAML remains source of truth on disk."* So:
+
+```
+~/.mur/skills/rust-error-handling/
+├── skill.yaml        ← manifest incl. content.note (the markdown body) — signed/hashed
+├── stats.yaml        ← SkillStats (lifecycle_state, usage_count, …)     [shared]
+└── events.jsonl      ← append-only usage log (retrieval events)         [shared]
+```
+
+- **Edit:** `mur notes edit` renders a SKILL.md view (frontmatter + clean
+  markdown), opens `$EDITOR`, re-serializes via `serialize_canonical`.
+- **Obsidian export:** `mur notes export --obsidian` emits the same SKILL.md view.
+- **Ingest:** `mur notes ingest` parses SKILL.md back via `parse_markdown`.
+
+One round-trip format (SKILL.md) serves editing, export, and ingest; the on-disk
+canonical stays single-file `skill.yaml`. (Minor follow-up: force block-scalar
+`|` output for multiline strings so `skill.yaml` git diffs stay clean — a shared
+serializer nicety, not a blocker, and not new to notes.)
 
 ## Market context (2026 Q1–Q2)
 
@@ -42,315 +108,371 @@ Three converging signals validate this direction:
    state machine (decay is search-ranking only, no promote/demote/archive).
 
 **Gap:** No competitor has maturity lifecycle (Draft → Emerging → Stable →
-Canonical → Deprecated → Archived). This is mur's differentiator.
+Canonical → Deprecated → Archived). This is mur's differentiator — and because a
+Note *is* a Skill, it inherits that lifecycle, hybrid retrieval, linking, signing,
+and peer sharing for free, exactly as a Workflow does.
 
 ## Architecture
 
 ```
-~/.mur/notes/                    ← Source of truth (markdown + YAML frontmatter)
-├── rust/
-│   ├── error-handling.md
-│   └── async-patterns.md
-├── deploy/
-│   └── fly-io-setup.md
+~/.mur/skills/                       ← Source of truth (one directory per skill)
+├── rust-error-handling/             ← category: note
+│   ├── skill.yaml                   ← incl. content.note (markdown body)
+│   ├── stats.yaml
+│   └── events.jsonl
+├── fly-io-deploy/                   ← category: workflow (v2)
+│   ├── skill.yaml
+│   ├── stats.yaml
+│   ├── events.jsonl                 ← run events
+│   └── runs.jsonl                   ← (v2 projection of events; see v2 spec)
 └── ...
 
         ↓ parse + embed (rebuildable)
 
 ┌─────────────────────────────┐
-│ SQLite (~/.mur/notes.db)    │  ← metadata index: tags, path, maturity, decay, mtime
-│                             │     fast filtering: "rust + stable, not deprecated"
+│ LanceDB (~/.mur/vectors/)   │  ← corpus vector index: hybrid BM25 + semantic
+│                             │     rebuildable from skill directories
 └─────────────────────────────┘
 
-┌─────────────────────────────┐
-│ LanceDB (~/.mur/vectors/)   │  ← vector index: hybrid BM25 + semantic search
-│                             │     rebuildable from markdown files
-└─────────────────────────────┘
+   (optional, deferred) SQLite corpus metadata index — see Storage layers
 
         ↓ expose via
 
-┌──────────┬──────────┬──────────┐
-│ MCP      │ CLI      │ Obsidian │
-│ server   │ search   │ vault    │
-└──────────┴──────────┴──────────┘
+┌──────────┬──────────┬───────────────────────┐
+│ MCP      │ CLI      │ Obsidian export view  │
+│ skill_*  │ mur notes│ (derived, not source) │
+└──────────┴──────────┴───────────────────────┘
 ```
 
 **Design rules:**
-- Files are the canonical source. SQLite and LanceDB are derivative indexes —
-  delete either, rebuild from files.
-- No schema migrations on SQLite. Schema changes → delete `.db`, rescan.
-- Obsidian-compatible: drop `~/.mur/notes/` into any Obsidian vault. Extra
-  YAML frontmatter fields are ignored by Obsidian but preserved.
+- The per-skill directory is canonical. LanceDB (and any SQLite index) are
+  derivative — delete either, rebuild from skill directories via `mur skill reindex`.
+- One source of truth. Obsidian interop is a *generated export*, never a second
+  canonical store.
+- No schema migrations on derivative indexes. Schema change → delete index, rescan.
 
 ## Data model
 
-### On-disk format: Markdown + YAML frontmatter
+A note reuses the existing `SkillManifest` with two foundation extensions
+(defined in v2, listed here for completeness):
 
-```markdown
----
-schema: 4
-name: rust-error-handling
-description: Rust 錯誤處理最佳實踐
-kind: reference
+1. `Category` gains a `Note` variant (currently `Context | Workflow | Command | Meta`).
+2. `ContentMode` gains a `Note` variant (currently `Context | Workflow | Command`);
+   `Content::mode()` returns `Note` when the note body is present.
+
+### On-disk `skill.yaml` (note-mode)
+
+```yaml
+schema: <skill manifest schema version>
+name: rust-error-handling           # kebab-case, unique id
+description: Rust 錯誤處理最佳實踐     # one-line summary (also the L2 abstract)
+category: note
+kind: reference                      # note-specific sub-kind (see NoteKind)
 tags: [rust, error-handling, patterns]
 tier: project
 importance: 0.8
-maturity: stable
-created_at: 2026-05-28T10:00:00Z
-updated_at: 2026-05-28T14:00:00Z
-decay:
-  last_active: 2026-05-28T14:00:00Z
 links:
   related: [rust-async-patterns]
   supersedes: []
-source_sessions: [session-abc123]
+created_at: 2026-05-28T10:00:00Z
+updated_at: 2026-05-28T14:00:00Z
+content:
+  abstract: Rust 錯誤處理最佳實踐
+  note: |                            # markdown body lives here → ContentMode::Note
+    # Rust Error Handling
+
+    ## Technical
+    使用 `anyhow` 處理應用層錯誤,`thiserror` 定義 library 錯誤類型。
+
+    ## Principle
+    不要在 library 層 leak `anyhow::Error`——呼叫方無法 match。
+# lifecycle_state / decay / usage live in stats.yaml, NOT here (manifest is signable & immutable)
+```
+
+### SKILL.md authoring/export view (derived, via `parse_markdown`)
+
+```markdown
+---
+name: rust-error-handling
+category: note
+kind: reference
+tags: [rust, error-handling, patterns]
 ---
 
 # Rust Error Handling
 
 ## Technical
-使用 `anyhow` 處理應用層錯誤，`thiserror` 定義 library 錯誤類型。
+使用 `anyhow` 處理應用層錯誤,`thiserror` 定義 library 錯誤類型。
 
 ## Principle
 不要在 library 層 leak `anyhow::Error`——呼叫方無法 match。
 ```
 
-### Rust struct (in-memory + parse)
+`mur notes edit` / `export` / `ingest` all use this round-trip view; the on-disk
+canonical remains the single-file `skill.yaml` above.
+
+### Rust types
+
+`kind` is the only note-specific manifest field. Everything else is shared
+`SkillManifest`.
 
 ```rust
-// mur-common/src/note.rs
-pub struct NoteManifest {
-    pub schema: u32,
-    pub name: String,                    // kebab-case, unique id
-    pub description: String,             // one-line summary
-    #[serde(default)]
-    pub kind: NoteKind,                  // reference | decision | fact | procedure | insight
-    #[serde(default)]
-    pub tags: Vec<String>,
-    #[serde(default)]
-    pub tier: Tier,                      // session | project | core (reused)
-    #[serde(default = "default_importance")]
-    pub importance: f64,
-    #[serde(default)]
-    pub maturity: Maturity,              // Draft | Emerging | Stable | Canonical | Deprecated | Archived
-    pub created_at: DateTime<Utc>,
-    #[serde(default = "Utc::now")]
-    pub updated_at: DateTime<Utc>,
-    #[serde(default)]
-    pub decay: DecayMeta,
-    #[serde(default)]
-    pub links: NoteLinks,
-    #[serde(default)]
-    pub source_sessions: Vec<String>,    // only populated when ingested by local LLM
-    // ── Body: everything after the `---` frontmatter fence, stored separately ──
-}
+// mur-common/src/skill/manifest.rs — add to the manifest
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub kind: Option<NoteKind>,          // only meaningful for category: note
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum NoteKind {
     #[default]
     Reference,    // how-to, best practice, documentation
     Decision,     // architectural decision record
     Fact,         // server address, config value, known limitation
-    Procedure,    // step-by-step (may graduate to a Workflow skill)
+    Procedure,    // step-by-step (may graduate to a category: workflow skill)
     Insight,      // observation, analysis, learned lesson
-}
-
-pub struct Note {
-    pub manifest: NoteManifest,
-    pub body: String,                    // everything after the frontmatter
 }
 ```
 
-### Relationship to Skill
+The markdown body is stored in `content.note` inside `skill.yaml` (note mode of
+`Content`). The SKILL.md view is a derived authoring/export form, not a second
+canonical file.
 
-A `Note` and a `Workflow` are both `Skill` variants with different `category`
-values. They share:
-- Lifecycle state machine (`skill/lifecycle.rs`)
-- Decay (`Tier` half-lives)
-- Linking (`links.related`, `links.supersedes`)
-- Evidence tracking (usage count, success rate)
-- Vector indexing (LanceDB)
-- MCP exposure (agent-runtime skill path)
+### What `category: note` shares vs. specializes
 
-They differ in:
-- Note has no `procedure` (it's reference, not executable)
-- Note has `NoteKind`; Workflow has `FailureAction`/`RetryConfig`
-- Note body is free markdown; Workflow procedure is structured DAG steps
+Shares with every skill (incl. `category: workflow`):
+- `SkillStats` lifecycle state machine (`skill/stats.rs`, `skill/lifecycle.rs`)
+- Decay (`Tier` half-lives), linking (`links.related`, `links.supersedes`)
+- Evidence via the shared `events.jsonl` reducer
+- Vector indexing (LanceDB), MCP exposure, signing, registry, peer transfer
 
-### What we keep from Pattern
+Specializes:
+- Content is free markdown (`content.note`), not a structured `procedure` DAG
+- Carries `kind: NoteKind`; workflows carry `on_failure` / `retry` per step
+- Usage signal is a **retrieval** event, not a **run** event
+
+### What we keep from Pattern (route 1)
 
 | Component | Keep? | Notes |
 |---|---|---|
-| `KnowledgeBase` (name, desc, tier, importance, tags, applies, evidence, links, lifecycle, decay, maturity, scope, created_at) | Repurpose | Slim down to `NoteManifest` — drop `PatternKind` (replace with `NoteKind`), drop `confidence` (human-authored, not extracted), drop `Content::DualLayer` (free markdown instead) |
-| `Tier` + half-lives | Keep | session=14d, project=90d, core=365d |
-| `Maturity` + `LifecycleState` | Keep | Draft→Emerging→Stable→Canonical→Deprecated→Archived |
-| `Evidence` | Keep (simplified) | `retrieval_count`, `last_retrieved_at` instead of injection signals |
+| `KnowledgeBase` fields (name, desc, tier, importance, tags, links, created_at) | Fold into `SkillManifest` | Drop `PatternKind` (→ `NoteKind`), drop `confidence` (human-authored, not extracted — make it `Option`, left empty for notes), drop `Content::DualLayer` (free markdown in `content.note`) |
+| `Tier` + half-lives | Keep | session=14d, project=90d, core=365d (shared, exposed in config) |
+| `Maturity` / `LifecycleState` | Keep | Reuse `skill/lifecycle.rs` ladder verbatim |
+| `Evidence` | Replace | Superseded by `SkillStats` + `events.jsonl` (retrieval signal) |
 | `Links` | Keep | related, supersedes |
-| `DecayMeta` | Keep | last_active, half_life_override |
-| `capture/noise_filter.rs` | Keep | Repurposed for local LLM ingestion preprocessing |
-| `retrieve/` (scoring, gate, unified) | Keep | Hybrid BM25 + vector, recency boost, importance weighting |
-| `store/yaml.rs` | Replace | YAML → Markdown + frontmatter parser |
-| `store/lancedb.rs` | Keep | Vector index, rebuildable |
-| `inject/hook.rs` | Replace | Auto-inject → MCP server + CLI search |
-| `evolve/decay.rs`, `evolve/maturity.rs`, `evolve/lifecycle.rs` | Keep | Adapted to note retrieval signals |
-| `capture/emergence.rs` | **Remove** | LLM auto-extraction from sessions |
-| `capture/feedback.rs` | **Remove** | No injection = no feedback loop |
+| `capture/noise_filter.rs` | Keep | Repurposed for local-LLM ingestion preprocessing (shared with v2 extraction) |
+| `retrieve/` (scoring, gate, unified) | **Adapt** (not just keep) | The hybrid BM25+vector logic is reusable, but it is hard-typed to `Pattern` today (`ScoredPattern { pattern: Pattern }`, `score_and_rank_hybrid(Vec<Pattern>)`). Introduce a `Retrievable` trait (name, description, embed text, tier, importance, decay inputs) so Skill/Note and the transitional Pattern share one scorer. This is the most under-estimated migration in both specs — a type migration, not a repoint. |
+| `store/yaml.rs` | Reuse | The existing skill store writes `skill.yaml` with the body in `content.note` — no new file I/O, no `body.md` |
+| `store/lancedb.rs` | Keep | Corpus vector index, rebuildable |
+| `inject/hook.rs` | Replace | Auto-inject → MCP `skill_search` + CLI (shared with v2) |
+| `evolve/decay.rs`, `evolve/maturity.rs`, `evolve/lifecycle.rs` | Drop | Superseded by `skill/lifecycle.rs` + `mur skill evolve` |
+| `capture/emergence.rs`, `capture/feedback.rs` | **Remove** | LLM auto-extraction + injection feedback (no injection = no feedback loop) |
 | `inject/` (event, index, queue, stats) | **Remove** | Passive query, not active push |
-| `Pattern` type | **Remove** | Replaced by `Note` |
+| `Pattern` type | **Remove** | Replaced by `category: note` skills |
 
 ## Storage layers
 
 ### Layer 1: Filesystem (source of truth)
 
-- Path: `~/.mur/notes/<path-segments>/<name>.md`
-- Directory structure IS the category taxonomy. `rust/error-handling.md` has
-  implicit path `rust`.
-- Atomic writes: temp file + rename (same as current YAML store).
-- Git-friendly: plain text, diffable, mergeable.
+- Path: `~/.mur/skills/<name>/` (one directory per skill, all categories).
+- Note-mode keeps its markdown body in `content.note` inside `skill.yaml`; the
+  SKILL.md authoring/export view is derived via `parse_markdown`.
+- `tags` and an optional `path:`/topic field in the manifest carry the taxonomy
+  (route 1 has no directory-as-category tree — the corpus is flat under
+  `~/.mur/skills/`; grouping is by tag/topic, surfaced in CLI and the export view).
+- Atomic writes: temp file + rename (existing skill store behaviour).
+- Git-friendly: `skill.yaml` is plain text, diffable, mergeable (force block-scalar
+  output for the body keeps prose diffs clean).
 
-### Layer 2: SQLite (metadata index)
+### Layer 2: SQLite corpus metadata index (optional, deferred)
 
-- Path: `~/.mur/notes.db`
-- Schema: one table `notes` with columns for every filterable field
-  (name, path, kind, tier, maturity, importance, tags as JSON array,
-  created_at, updated_at, decay_last_active).
-- Purpose: fast `WHERE` queries without parsing 200 markdown files.
-- Rebuild: `mur notes reindex` — scans `~/.mur/notes/`, parses frontmatter,
-  upserts rows.
-- No migration: schema version stored as `PRAGMA user_version`. On mismatch,
+- **Not in the MVP.** At current corpus size (a handful of skills, ~160 patterns
+  to migrate) a directory scan is fast enough. Per Mandatory Rule #1, do not add
+  a second index until it earns its place.
+- When added, it indexes the **whole skill corpus** keyed by category
+  (`~/.mur/skills.db`), not a notes-only table. Purpose: fast `WHERE` filtering
+  (`category = note AND maturity = stable`) without parsing every directory.
+- Rebuild: `mur skill reindex`. No migration: `PRAGMA user_version` mismatch →
   delete and rebuild.
 
 ### Layer 3: LanceDB (vector index)
 
-- Existing `store::vector::VectorStore` trait; `LanceDbStore` impl.
-- Embedding model: `nomic-embed-text-v1.5` via Ollama (local, free).
-- Embedding input: `name + "\n" + description + "\n" + body` (truncated to
-  512 tokens).
+- Existing `store::vector::VectorStore` trait; `LanceDbStore` impl; corpus-wide.
+- Embedding: reuse the existing configurable embedder (`store/embedding.rs`):
+  provider + model come from `config.embedding` (Ollama default; current default
+  model `qwen3-embedding:0.6b`). **Do not hardcode a model** (Mandatory Rule #1).
+- **Dimension consistency:** notes MUST embed with the same model/dimensions as
+  the rest of the skill corpus, or hybrid search across categories breaks.
+  Changing the model is a corpus-wide reindex, never a notes-only change.
+- Embedding input (note): `name + "\n" + description + "\n" + body` (truncated per
+  `config.embedding` limit).
 - Hybrid scoring: vector similarity (0.7) + BM25 keyword (0.3), fused via RRF.
-- Max results: 10. Recency boost: ×1.2 for notes active in last 7 days.
+- Max results: 10. Recency boost: ×1.2 for skills active in last 7 days.
 
 ## Retrieval
 
-### CLI
+### CLI (`mur notes` = `category: note` convenience facade over `mur skill`)
 
 ```
-mur notes search "rust error handling"
+mur notes search "rust error handling"   # = mur skill search --category note
 mur notes show <name>
 mur notes list --kind decision --maturity stable
-mur notes edit <name>            # opens $EDITOR
+mur notes edit <name>            # SKILL.md view in $EDITOR, round-trips to skill.yaml
 mur notes create --kind reference
 mur notes archive <name>
-mur notes reindex                # rebuild SQLite + LanceDB from files
+mur notes export --obsidian <vault>      # derived flat-markdown view
+mur skill reindex                        # rebuild LanceDB (+ SQLite if enabled) — shared
+mur skill evolve --category note         # lifecycle sweep — shared
 ```
 
-### MCP server
+`mur notes` is a thin facade; reindex and evolve are **shared** `mur skill`
+commands, not note-private, so notes and workflows evolve through one path.
 
-Expose as MCP tools so AI assistants (Claude Code, Cursor, etc.) can search,
-read, and create notes during sessions:
+### MCP server (unified surface)
+
+Expose one search surface with a category filter, plus note-create:
 
 ```
-mcp__mur__notes_search(query, kind?, maturity?, limit?)
-mcp__mur__notes_read(name)
-mcp__mur__notes_create(name, description, kind, body, tags?)
-mcp__mur__notes_link(from, to, relationship)
+mcp__mur__skill_search(query, category?, kind?, maturity?, limit?)
+mcp__mur__skill_read(name)
+mcp__mur__note_create(name, description, kind, body, tags?)
+mcp__mur__note_link(from, to, relationship)
 ```
 
-The MCP server is a thin wrapper around the existing agent-runtime skill
-injection path — notes are just `category: Note` skills.
+`notes_search` / `notes_read` may exist as thin aliases that pin
+`category: note`, but the canonical tools are category-filtered `skill_*`. The
+server is a thin wrapper around the existing agent-runtime skill path — notes are
+just `category: note` skills.
 
-### Obsidian / external tools
+### Obsidian / external tools (derived export)
 
-`~/.mur/notes/` is a valid Obsidian vault root. Users can:
-- Open it directly as an Obsidian vault
-- Symlink it into an existing vault
-- Use any markdown editor
-
-mur does not compete with Obsidian — it adds a lifecycle layer and an AI query
-surface *on top of* the same markdown files.
+`mur notes export --obsidian <vault>` writes flat `SKILL.md` files
+(frontmatter + body) into the target vault. The export is read-oriented: edits
+made in Obsidian are not written back to `~/.mur/skills/` automatically. To bring
+external edits in, `mur notes ingest <file>` (post-MVP, see below) re-imports a
+markdown file as a note. mur does not compete with Obsidian — it adds a lifecycle
+layer and an AI query surface on top of the same content, exposed as a vault view.
 
 ## Lifecycle (the differentiator)
 
-Reuse `skill/lifecycle.rs` with note-specific signals:
+Reuse `skill/lifecycle.rs` and `SkillStats` unchanged. The note-specific part is
+only *what counts as a use*: a **retrieval** (CLI/MCP read) appends a
+`{"ts": …, "kind": "retrieval"}` line to the skill's shared `events.jsonl`. The
+stats reducer turns that into `usage_count` / `last_success_at`, and
+`next_state(stats, now)` does the rest — the same ladder workflows use.
 
-| State | Condition |
+| State | Note condition (via shared ladder) |
 |---|---|
 | **Draft** | Default. Newly created, not yet validated. |
-| **Emerging** | Retrieved ≥ 3 times. Promising. |
-| **Stable** | Retrieved ≥ 10 times, last active < 30d. Trusted. |
-| **Canonical** | Pinned by user. Never auto-demoted. |
+| **Emerging** | Retrieved ≥ `PROMOTE_DRAFT_USES` (default 3). |
+| **Stable** | Retrieved ≥ `PROMOTE_EMERGING_USES` (default 10), rate/age gates met. |
+| **Canonical** | `pinned` by user. Never auto-demoted. |
 | **Deprecated** | No retrieval in 90d, OR user explicitly deprecates. |
-| **Archived** | Deprecated + 180d no activity. Candidate for deletion. |
+| **Archived** | Decay + age past threshold. Candidate for hard-delete sweep. |
 
-**Decay:** `last_active` is updated on every retrieval. Tier half-lives
-determine decay rate (session=14d, project=90d, core=365d). Importance decays
-by `0.5 ^ (days_since_last_active / half_life_days)`.
+**Retrieval has no failure.** A retrieval always "succeeds", so for a note every
+event increments both `usage_count` and `success_count` (`success_rate == 1.0`).
+The promotion ladder therefore degenerates to **count + age** (the rate gates
+auto-pass), and the `success_rate < 0.3` deprecation rule **never fires** for
+notes — note demotion is driven only by decay+age (`AUTO_ARCHIVE_*`) or manual
+deprecate. This is intentional; it must be explicit so an implementer does not
+invent a "note failure" signal. `SkillStats::anchor_confidence` (the decaying
+quantity, default 1.0) is seeded from the note's `importance` at create time.
 
-**Promotion/demotion sweep:** `mur notes evolve` (runnable manually or via
-cron). Sweeps all notes, updates maturity based on retrieval stats, decays
-importance, flags candidates for archival.
+**Why append-only events, not write-on-read.** The first draft mutated
+`last_active` on every retrieval. Appending to `events.jsonl` instead avoids
+read-path write contention, matches the workflow run-ledger exactly, and lets
+the shared reducer compute stats lazily during `mur skill evolve`.
+
+**Decay:** Tier half-lives (session=14d, project=90d, core=365d) determine the
+rate; `importance` decays by `0.5 ^ (days_since_last_active / half_life_days)`.
+Thresholds live in config (shared with v2 P4).
 
 **Contradiction detection** (post-MVP): optional nightly sweep via local LLM.
 Two notes with high similarity but conflicting conclusions → flag for user
-review. Inspired by BrainDB's five contradiction strategies.
+review. Inspired by BrainDB's contradiction strategies.
 
 ## Local LLM integration (post-MVP)
 
 A local LLM (Ollama, 7B+) can assist with:
 
-1. **Ingest:** `mur notes ingest <file>` — reads a raw document, extracts
-   structured notes with frontmatter, writes them into `~/.mur/notes/`.
+1. **Ingest:** `mur notes ingest <file>` — reads a raw document (or an
+   Obsidian-edited export), extracts structured notes with frontmatter, writes
+   them as `category: note` skills.
 2. **Consolidate:** detects near-duplicate notes, suggests merges.
 3. **Contradiction detection:** nightly sweep for conflicting claims.
-4. **Summarize:** `mur notes summarize <name>` — regenerates description from body.
+4. **Summarize:** `mur notes summarize <name>` — regenerates `description` from body.
 
 All LLM features are **optional**. Manual `mur notes create` requires no LLM.
-The gate is: if `ollama list` returns no models, LLM features are disabled
-with a clear message ("install Ollama and pull a model to enable AI features").
+Gate: if `ollama list` returns no models, LLM features are disabled with a clear
+message ("install Ollama and pull a model to enable AI features").
+
+`source_sessions` (which sessions a note was extracted from) is **only** populated
+by the LLM ingest path. Since ingest is post-MVP, the field is omitted from the
+MVP manifest and added with the ingest feature, rather than carried as a dead
+field.
 
 ## Migration from Patterns
 
-1. Export all 160 patterns to `~/.mur/exported-patterns/<name>.md` (markdown
-   with frontmatter).
-2. Delete `~/.mur/patterns/`, `~/.mur/fingerprints.jsonl`.
-3. Remove pattern pipeline code (emergence, fingerprinting, feedback, inject).
-4. Create `~/.mur/notes/` directory with a README.md explaining the new system.
-5. Users manually promote exported patterns they want to keep:
-   `cp ~/.mur/exported-patterns/rust-error-handling.md ~/.mur/notes/rust/`
-6. Run `mur notes reindex` to build SQLite + LanceDB indexes.
+Aligned with v2's Pattern-removal sequence (v2 owns the removal; this owns the
+note bootstrap):
+
+1. v2 exports all 160 patterns to `~/.mur/exported-patterns/<name>.md` (markdown
+   with frontmatter) before deleting `~/.mur/patterns/` and the pattern pipeline.
+2. Users manually promote exported patterns worth keeping by importing them as
+   notes: `mur notes ingest ~/.mur/exported-patterns/rust-error-handling.md`
+   (or, pre-ingest, hand-create the `~/.mur/skills/<name>/` directory).
+3. `mur skill reindex` rebuilds the LanceDB index.
 
 No automatic migration. The old patterns are code-convention-focused and most
-have low value as general reference notes. Let the user curate.
+have low value as general reference notes — let the user curate.
 
 ## Development phases
 
-| Phase | Content | Est. |
-|---|---|---|
-| **P1: Schema + storage** | `NoteManifest` struct; markdown frontmatter parser; SQLite metadata index; file watcher (mtime → reindex changed files) | 1 wk |
-| **P2: CLI** | `mur notes {search, show, list, create, edit, archive, reindex, evolve}` | 1 wk |
-| **P3: Retrieve** | Adapt existing hybrid retrieval (LanceDB + BM25) for notes; RRF fusion; recency/importance weighting | 3–4 d |
-| **P4: Lifecycle** | Adapt `skill/lifecycle.rs` for note retrieval signals; `mur notes evolve` sweep; decay + promotion/demotion | 3–4 d |
-| **P5: MCP server** | Expose `notes_search`, `notes_read`, `notes_create`, `notes_link` as MCP tools via agent-runtime skill path | 3–4 d |
-| **P6: Local LLM (P2)** | Ingest, consolidate, contradiction detection, summarize — all gated on Ollama availability | 1 wk |
-| **P7: Migration** | Pattern export → md; pattern pipeline removal (from Workflow Engine v2 P1); `~/.mur/notes/` bootstrap | 1–2 d |
+P1–P4 deliver a working CLI note system without LLM dependency. They depend on
+the **shared foundation** landing first (v2 P1–P4: Pattern removal, Category/
+ContentMode extension, `events.jsonl` + stats reducer, `mur skill evolve`).
 
-Total: ~5 weeks to full feature set. P1–P4 deliver a working CLI note system
-without LLM dependency. P5 adds AI assistant integration. P6 adds LLM smarts.
+| Phase | Content | Est. | Depends on |
+|---|---|---|---|
+| **N1: Note schema** | `category: note`, `ContentMode::Note`, `content.note` body field, `NoteKind`; extend `parse_markdown`/`serialize_canonical` for the note SKILL.md round-trip (no new file I/O) | 3–4 d | v2 Category/ContentMode + skill store |
+| **N2: CLI facade** | `mur notes {search, show, list, create, edit, archive}` over `mur skill`; `mur notes export --obsidian` | 1 wk | N1, v2 corpus index |
+| **N3: Retrieve** | Implement `Retrievable` for `Note`; reuse hybrid retrieval (LanceDB + BM25 + RRF); recency/importance weighting | 2–3 d | N1, v2 `Retrievable` trait (P1b) |
+| **N4: Lifecycle wire-up** | Retrieval → `events.jsonl`; rely on shared stats reducer + `next_state` + `mur skill evolve --category note` | 2–3 d | v2 events/stats/evolve |
+| **N5: MCP** | `skill_search(category?)`, `skill_read`, `note_create`, `note_link` via agent-runtime skill path | 3–4 d | v2 MCP skill path |
+| **N6: Local LLM (P2)** | ingest, consolidate, contradiction detection, summarize — gated on Ollama | 1 wk | N1–N5 |
+
+Total incremental over the shared foundation: ~3.5 weeks to full feature set.
 
 ## Resolved decisions
 
-1. **Markdown + YAML frontmatter is the canonical format.** Not SQLite, not
-   plain YAML. Markdown is human-readable, Obsidian-compatible, git-diffable.
-2. **SQLite is a derivative index, not source of truth.** Delete and rebuild
-   from files at any time.
+1. **Route 1 storage (agreed).** Canonical source of truth is the per-skill
+   directory `~/.mur/skills/<name>/`. No separate `~/.mur/notes/` tree. Obsidian
+   is a derived export view, not a second canonical format.
+2. **Note body lives in `content.note` inside `skill.yaml`** (route 1a), not a
+   sibling file. Decisive reason: `content_sha256` (DSSE signing, drift detection,
+   trust hash, registry lookup) hashes the whole manifest's canonical YAML — body-
+   in-`content` is signed/drift-covered for free, identical to a workflow
+   `procedure`; a sibling file falls outside the hash. Authoring ergonomics come
+   from the existing `parse_markdown` SKILL.md round-trip, not from a second
+   canonical file.
 3. **No automatic injection.** Notes are passive reference material queried on
-   demand via CLI or MCP. The `inject/` module is removed entirely.
-4. **Local LLM is optional.** All core features work without one. LLM features
-   are gated on Ollama availability.
-5. **No automatic migration from Patterns.** Export as archive; user curates
-   what to promote.
-6. **Notes and Workflows are both Skills** (`category: Note` / `category:
-   Workflow`). They share lifecycle, decay, linking, retrieval, and MCP
-   exposure. They differ in content shape (free markdown vs. structured DAG).
-7. **Tier half-lives and maturity ladder are exposed in config** (per Mandatory
-   Rule #1, shared with Workflow Engine v2 P4).
+   demand via CLI or MCP. The `inject/` push modules are removed.
+4. **Lifecycle is shared, not re-implemented.** Notes reuse `SkillStats` +
+   `skill/lifecycle.rs` + the shared `events.jsonl` reducer + `mur skill evolve`.
+   A note "use" is a retrieval event; a workflow "use" is a run event.
+5. **`mur notes` is a facade.** Category-private convenience commands wrap shared
+   `mur skill` machinery (reindex/evolve are shared, not note-private).
+6. **Unified MCP surface.** `skill_search(category?)` is canonical; `notes_*` are
+   optional aliases.
+7. **SQLite metadata index is deferred** and, when added, is corpus-wide
+   (all categories), not notes-only.
+8. **`confidence` becomes `Option`, left empty for notes** (extraction artifact,
+   meaningful only for v2's extracted workflows).
+9. **`source_sessions` ships with the LLM ingest feature**, not the MVP.
+10. **No automatic migration from Patterns.** v2 exports as archive; user curates
+    what to promote via `mur notes ingest`.
+11. **Notes and Workflows are both Skills** (`category: note` / `category:
+    workflow`) — two projections of one knowledge object, sharing lifecycle,
+    decay, linking, retrieval, signing, peer transfer, and MCP exposure, differing
+    only in content shape (free markdown vs. structured DAG) and usage signal
+    (retrieval vs. run).

--- a/docs/superpowers/specs/2026-05-28-mur-notes-design.md
+++ b/docs/superpowers/specs/2026-05-28-mur-notes-design.md
@@ -1,0 +1,356 @@
+# MuR Notes — Personal Knowledge Management with Lifecycle
+
+> **Status:** Draft | **Date:** 2026-05-28 | **Depends on:** Workflow Engine v2 (pattern removal)
+
+## Thesis
+
+Pattern as "auto-extracted AI coding rule" never delivered value (`injection_count == 0`
+across 160 patterns). But the *infrastructure* — lifecycle state machine, decay,
+evidence tracking, hybrid retrieval, linking — is valuable and unique. Nobody in
+the 2026 PKM landscape (Karpathy's LLM Wiki, BrainDB, Vannevar, Obsidian
+plugins) offers true lifecycle management for personal notes.
+
+**v2 thesis (Workflow Engine):** A workflow is a Skill with `category: Workflow`.
+
+**This thesis (Notes):** A note is a Skill with `category: Note` — a
+human-curated, file-first knowledge artifact with a managed lifecycle. Same
+subsystem, same retrieve pipeline, same decay and evolution. The only thing
+Pattern did that Note doesn't is auto-inject into AI coding sessions (which
+never worked). What Note adds that Pattern lacked: human authorship, external
+tool interoperability, and an MCP query surface.
+
+## Market context (2026 Q1–Q2)
+
+Three converging signals validate this direction:
+
+1. **Karpathy's LLM Wiki (April 2026).** File-first three-layer architecture
+   (Raw Sources → Wiki → Schema). Core insight: "compile knowledge once at
+   ingest time, query the compiled wiki forever." Limitation: `index.md` breaks
+   past ~100 pages; community fix is local hybrid search (llmwiki: Tantivy BM25
+   + fastembed vectors + RRF).
+
+2. **"Memory as Metabolism" (arXiv:2604.12034, April 2026).** Five core
+   operations for personal LLM memory: TRIAGE, DECAY, CONTEXTUALIZE,
+   CONSOLIDATE, AUDIT. Identifies "Kuhnian ossification" — wikis entrench
+   dominant interpretations — as the key failure mode. mur's lifecycle state
+   machine + decay + evidence tracking is the only open-source implementation
+   that maps to all five operations.
+
+3. **BrainDB (2026).** 5,420+ memories in production. SQLite + FTS5 + vectors.
+   30-day half-life freshness scoring. Contradiction detection. Multi-agent
+   coordination. Closest real-world analogue to mur Notes — but no lifecycle
+   state machine (decay is search-ranking only, no promote/demote/archive).
+
+**Gap:** No competitor has maturity lifecycle (Draft → Emerging → Stable →
+Canonical → Deprecated → Archived). This is mur's differentiator.
+
+## Architecture
+
+```
+~/.mur/notes/                    ← Source of truth (markdown + YAML frontmatter)
+├── rust/
+│   ├── error-handling.md
+│   └── async-patterns.md
+├── deploy/
+│   └── fly-io-setup.md
+└── ...
+
+        ↓ parse + embed (rebuildable)
+
+┌─────────────────────────────┐
+│ SQLite (~/.mur/notes.db)    │  ← metadata index: tags, path, maturity, decay, mtime
+│                             │     fast filtering: "rust + stable, not deprecated"
+└─────────────────────────────┘
+
+┌─────────────────────────────┐
+│ LanceDB (~/.mur/vectors/)   │  ← vector index: hybrid BM25 + semantic search
+│                             │     rebuildable from markdown files
+└─────────────────────────────┘
+
+        ↓ expose via
+
+┌──────────┬──────────┬──────────┐
+│ MCP      │ CLI      │ Obsidian │
+│ server   │ search   │ vault    │
+└──────────┴──────────┴──────────┘
+```
+
+**Design rules:**
+- Files are the canonical source. SQLite and LanceDB are derivative indexes —
+  delete either, rebuild from files.
+- No schema migrations on SQLite. Schema changes → delete `.db`, rescan.
+- Obsidian-compatible: drop `~/.mur/notes/` into any Obsidian vault. Extra
+  YAML frontmatter fields are ignored by Obsidian but preserved.
+
+## Data model
+
+### On-disk format: Markdown + YAML frontmatter
+
+```markdown
+---
+schema: 4
+name: rust-error-handling
+description: Rust 錯誤處理最佳實踐
+kind: reference
+tags: [rust, error-handling, patterns]
+tier: project
+importance: 0.8
+maturity: stable
+created_at: 2026-05-28T10:00:00Z
+updated_at: 2026-05-28T14:00:00Z
+decay:
+  last_active: 2026-05-28T14:00:00Z
+links:
+  related: [rust-async-patterns]
+  supersedes: []
+source_sessions: [session-abc123]
+---
+
+# Rust Error Handling
+
+## Technical
+使用 `anyhow` 處理應用層錯誤，`thiserror` 定義 library 錯誤類型。
+
+## Principle
+不要在 library 層 leak `anyhow::Error`——呼叫方無法 match。
+```
+
+### Rust struct (in-memory + parse)
+
+```rust
+// mur-common/src/note.rs
+pub struct NoteManifest {
+    pub schema: u32,
+    pub name: String,                    // kebab-case, unique id
+    pub description: String,             // one-line summary
+    #[serde(default)]
+    pub kind: NoteKind,                  // reference | decision | fact | procedure | insight
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub tier: Tier,                      // session | project | core (reused)
+    #[serde(default = "default_importance")]
+    pub importance: f64,
+    #[serde(default)]
+    pub maturity: Maturity,              // Draft | Emerging | Stable | Canonical | Deprecated | Archived
+    pub created_at: DateTime<Utc>,
+    #[serde(default = "Utc::now")]
+    pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub decay: DecayMeta,
+    #[serde(default)]
+    pub links: NoteLinks,
+    #[serde(default)]
+    pub source_sessions: Vec<String>,    // only populated when ingested by local LLM
+    // ── Body: everything after the `---` frontmatter fence, stored separately ──
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NoteKind {
+    #[default]
+    Reference,    // how-to, best practice, documentation
+    Decision,     // architectural decision record
+    Fact,         // server address, config value, known limitation
+    Procedure,    // step-by-step (may graduate to a Workflow skill)
+    Insight,      // observation, analysis, learned lesson
+}
+
+pub struct Note {
+    pub manifest: NoteManifest,
+    pub body: String,                    // everything after the frontmatter
+}
+```
+
+### Relationship to Skill
+
+A `Note` and a `Workflow` are both `Skill` variants with different `category`
+values. They share:
+- Lifecycle state machine (`skill/lifecycle.rs`)
+- Decay (`Tier` half-lives)
+- Linking (`links.related`, `links.supersedes`)
+- Evidence tracking (usage count, success rate)
+- Vector indexing (LanceDB)
+- MCP exposure (agent-runtime skill path)
+
+They differ in:
+- Note has no `procedure` (it's reference, not executable)
+- Note has `NoteKind`; Workflow has `FailureAction`/`RetryConfig`
+- Note body is free markdown; Workflow procedure is structured DAG steps
+
+### What we keep from Pattern
+
+| Component | Keep? | Notes |
+|---|---|---|
+| `KnowledgeBase` (name, desc, tier, importance, tags, applies, evidence, links, lifecycle, decay, maturity, scope, created_at) | Repurpose | Slim down to `NoteManifest` — drop `PatternKind` (replace with `NoteKind`), drop `confidence` (human-authored, not extracted), drop `Content::DualLayer` (free markdown instead) |
+| `Tier` + half-lives | Keep | session=14d, project=90d, core=365d |
+| `Maturity` + `LifecycleState` | Keep | Draft→Emerging→Stable→Canonical→Deprecated→Archived |
+| `Evidence` | Keep (simplified) | `retrieval_count`, `last_retrieved_at` instead of injection signals |
+| `Links` | Keep | related, supersedes |
+| `DecayMeta` | Keep | last_active, half_life_override |
+| `capture/noise_filter.rs` | Keep | Repurposed for local LLM ingestion preprocessing |
+| `retrieve/` (scoring, gate, unified) | Keep | Hybrid BM25 + vector, recency boost, importance weighting |
+| `store/yaml.rs` | Replace | YAML → Markdown + frontmatter parser |
+| `store/lancedb.rs` | Keep | Vector index, rebuildable |
+| `inject/hook.rs` | Replace | Auto-inject → MCP server + CLI search |
+| `evolve/decay.rs`, `evolve/maturity.rs`, `evolve/lifecycle.rs` | Keep | Adapted to note retrieval signals |
+| `capture/emergence.rs` | **Remove** | LLM auto-extraction from sessions |
+| `capture/feedback.rs` | **Remove** | No injection = no feedback loop |
+| `inject/` (event, index, queue, stats) | **Remove** | Passive query, not active push |
+| `Pattern` type | **Remove** | Replaced by `Note` |
+
+## Storage layers
+
+### Layer 1: Filesystem (source of truth)
+
+- Path: `~/.mur/notes/<path-segments>/<name>.md`
+- Directory structure IS the category taxonomy. `rust/error-handling.md` has
+  implicit path `rust`.
+- Atomic writes: temp file + rename (same as current YAML store).
+- Git-friendly: plain text, diffable, mergeable.
+
+### Layer 2: SQLite (metadata index)
+
+- Path: `~/.mur/notes.db`
+- Schema: one table `notes` with columns for every filterable field
+  (name, path, kind, tier, maturity, importance, tags as JSON array,
+  created_at, updated_at, decay_last_active).
+- Purpose: fast `WHERE` queries without parsing 200 markdown files.
+- Rebuild: `mur notes reindex` — scans `~/.mur/notes/`, parses frontmatter,
+  upserts rows.
+- No migration: schema version stored as `PRAGMA user_version`. On mismatch,
+  delete and rebuild.
+
+### Layer 3: LanceDB (vector index)
+
+- Existing `store::vector::VectorStore` trait; `LanceDbStore` impl.
+- Embedding model: `nomic-embed-text-v1.5` via Ollama (local, free).
+- Embedding input: `name + "\n" + description + "\n" + body` (truncated to
+  512 tokens).
+- Hybrid scoring: vector similarity (0.7) + BM25 keyword (0.3), fused via RRF.
+- Max results: 10. Recency boost: ×1.2 for notes active in last 7 days.
+
+## Retrieval
+
+### CLI
+
+```
+mur notes search "rust error handling"
+mur notes show <name>
+mur notes list --kind decision --maturity stable
+mur notes edit <name>            # opens $EDITOR
+mur notes create --kind reference
+mur notes archive <name>
+mur notes reindex                # rebuild SQLite + LanceDB from files
+```
+
+### MCP server
+
+Expose as MCP tools so AI assistants (Claude Code, Cursor, etc.) can search,
+read, and create notes during sessions:
+
+```
+mcp__mur__notes_search(query, kind?, maturity?, limit?)
+mcp__mur__notes_read(name)
+mcp__mur__notes_create(name, description, kind, body, tags?)
+mcp__mur__notes_link(from, to, relationship)
+```
+
+The MCP server is a thin wrapper around the existing agent-runtime skill
+injection path — notes are just `category: Note` skills.
+
+### Obsidian / external tools
+
+`~/.mur/notes/` is a valid Obsidian vault root. Users can:
+- Open it directly as an Obsidian vault
+- Symlink it into an existing vault
+- Use any markdown editor
+
+mur does not compete with Obsidian — it adds a lifecycle layer and an AI query
+surface *on top of* the same markdown files.
+
+## Lifecycle (the differentiator)
+
+Reuse `skill/lifecycle.rs` with note-specific signals:
+
+| State | Condition |
+|---|---|
+| **Draft** | Default. Newly created, not yet validated. |
+| **Emerging** | Retrieved ≥ 3 times. Promising. |
+| **Stable** | Retrieved ≥ 10 times, last active < 30d. Trusted. |
+| **Canonical** | Pinned by user. Never auto-demoted. |
+| **Deprecated** | No retrieval in 90d, OR user explicitly deprecates. |
+| **Archived** | Deprecated + 180d no activity. Candidate for deletion. |
+
+**Decay:** `last_active` is updated on every retrieval. Tier half-lives
+determine decay rate (session=14d, project=90d, core=365d). Importance decays
+by `0.5 ^ (days_since_last_active / half_life_days)`.
+
+**Promotion/demotion sweep:** `mur notes evolve` (runnable manually or via
+cron). Sweeps all notes, updates maturity based on retrieval stats, decays
+importance, flags candidates for archival.
+
+**Contradiction detection** (post-MVP): optional nightly sweep via local LLM.
+Two notes with high similarity but conflicting conclusions → flag for user
+review. Inspired by BrainDB's five contradiction strategies.
+
+## Local LLM integration (post-MVP)
+
+A local LLM (Ollama, 7B+) can assist with:
+
+1. **Ingest:** `mur notes ingest <file>` — reads a raw document, extracts
+   structured notes with frontmatter, writes them into `~/.mur/notes/`.
+2. **Consolidate:** detects near-duplicate notes, suggests merges.
+3. **Contradiction detection:** nightly sweep for conflicting claims.
+4. **Summarize:** `mur notes summarize <name>` — regenerates description from body.
+
+All LLM features are **optional**. Manual `mur notes create` requires no LLM.
+The gate is: if `ollama list` returns no models, LLM features are disabled
+with a clear message ("install Ollama and pull a model to enable AI features").
+
+## Migration from Patterns
+
+1. Export all 160 patterns to `~/.mur/exported-patterns/<name>.md` (markdown
+   with frontmatter).
+2. Delete `~/.mur/patterns/`, `~/.mur/fingerprints.jsonl`.
+3. Remove pattern pipeline code (emergence, fingerprinting, feedback, inject).
+4. Create `~/.mur/notes/` directory with a README.md explaining the new system.
+5. Users manually promote exported patterns they want to keep:
+   `cp ~/.mur/exported-patterns/rust-error-handling.md ~/.mur/notes/rust/`
+6. Run `mur notes reindex` to build SQLite + LanceDB indexes.
+
+No automatic migration. The old patterns are code-convention-focused and most
+have low value as general reference notes. Let the user curate.
+
+## Development phases
+
+| Phase | Content | Est. |
+|---|---|---|
+| **P1: Schema + storage** | `NoteManifest` struct; markdown frontmatter parser; SQLite metadata index; file watcher (mtime → reindex changed files) | 1 wk |
+| **P2: CLI** | `mur notes {search, show, list, create, edit, archive, reindex, evolve}` | 1 wk |
+| **P3: Retrieve** | Adapt existing hybrid retrieval (LanceDB + BM25) for notes; RRF fusion; recency/importance weighting | 3–4 d |
+| **P4: Lifecycle** | Adapt `skill/lifecycle.rs` for note retrieval signals; `mur notes evolve` sweep; decay + promotion/demotion | 3–4 d |
+| **P5: MCP server** | Expose `notes_search`, `notes_read`, `notes_create`, `notes_link` as MCP tools via agent-runtime skill path | 3–4 d |
+| **P6: Local LLM (P2)** | Ingest, consolidate, contradiction detection, summarize — all gated on Ollama availability | 1 wk |
+| **P7: Migration** | Pattern export → md; pattern pipeline removal (from Workflow Engine v2 P1); `~/.mur/notes/` bootstrap | 1–2 d |
+
+Total: ~5 weeks to full feature set. P1–P4 deliver a working CLI note system
+without LLM dependency. P5 adds AI assistant integration. P6 adds LLM smarts.
+
+## Resolved decisions
+
+1. **Markdown + YAML frontmatter is the canonical format.** Not SQLite, not
+   plain YAML. Markdown is human-readable, Obsidian-compatible, git-diffable.
+2. **SQLite is a derivative index, not source of truth.** Delete and rebuild
+   from files at any time.
+3. **No automatic injection.** Notes are passive reference material queried on
+   demand via CLI or MCP. The `inject/` module is removed entirely.
+4. **Local LLM is optional.** All core features work without one. LLM features
+   are gated on Ollama availability.
+5. **No automatic migration from Patterns.** Export as archive; user curates
+   what to promote.
+6. **Notes and Workflows are both Skills** (`category: Note` / `category:
+   Workflow`). They share lifecycle, decay, linking, retrieval, and MCP
+   exposure. They differ in content shape (free markdown vs. structured DAG).
+7. **Tier half-lives and maturity ladder are exposed in config** (per Mandatory
+   Rule #1, shared with Workflow Engine v2 P4).

--- a/docs/superpowers/specs/2026-05-28-mur-workflow-engine-design-v2.md
+++ b/docs/superpowers/specs/2026-05-28-mur-workflow-engine-design-v2.md
@@ -1,0 +1,391 @@
+# MuR Workflow Engine v2 — Workflow as an Executable Skill
+
+> **Status:** Approved | **Date:** 2026-05-28 | **Supersedes:** `2026-05-28-mur-workflow-engine-design.md` (v1)
+
+## Why v2
+
+v1 proposed building a standalone Workflow Engine: extraction, an evolution state
+machine, progressive injection, and team sharing. A codebase audit showed three
+problems with that plan:
+
+1. **No execution ledger exists.** `PipelineExecutor` returns an `exit_code` and
+   discards it. Nothing persists run history. v1's entire Layer 4 (10 successes →
+   Trusted, 3 consecutive failures → Broken, 90 days stale, …) was built on a
+   foundation that does not exist and v1 did not design it.
+2. **A parallel subsystem already implements ~80% of v1's plan.** The Skill
+   subsystem (`mur-common/src/skill/`, 25+ modules) already has classification
+   (`Category`, including a `Workflow` variant), 3-layer progressive disclosure,
+   agent-runtime dynamic invocation (`trigger_matcher` + `injector`), a
+   stats-driven lifecycle state machine, self-evolution (`evolution_log`, gene),
+   DSSE signing, a registry, and peer transfer. v1 mentioned none of it.
+3. **Steps are linear, with no schema.** `workflow::Step` carries `order: u32`
+   and no edges. A Hub DAG editor needs an explicit step graph and a JSON Schema;
+   neither exists.
+
+**v2 thesis:** *A workflow is not a new entity. It is a `Skill` with
+`category: Workflow` whose `content.procedure` is executable. The Skill subsystem
+owns identity, classification, disclosure, evolution, signing, and sharing. The
+Workflow engine adds exactly two things on top: (1) a deterministic DAG executor,
+and (2) a run-ledger that feeds the skill lifecycle that already exists.*
+
+The Pattern-removal decision from v1 stands (see [Decision: remove Pattern](#decision-remove-pattern)).
+
+## What already exists (audited, do NOT rebuild)
+
+| Capability v1 planned to build | Already in codebase | Location |
+|---|---|---|
+| Classification / category | `Category { Context, Workflow, Command, Meta }`, `Priority`, `tags` | `skill/types.rs`, `skill/manifest.rs` |
+| Progressive disclosure | 3-layer: L2 `abstract` at session start, L3 `procedure` on trigger | `mur-agent-runtime/src/skills/{injector,trigger_matcher}.rs` |
+| Agent dynamic invocation | trigger match → layered inject | `mur-agent-runtime/src/skills/` |
+| **Evolution state machine** | `next_state(stats, now)` over `LifecycleState { Draft, Emerging, Stable, Canonical, Deprecated, Archived }` with promotion ladder, hysteresis, decay, auto-archive | `skill/lifecycle.rs` |
+| Self-evolution | `evolution_log: Vec<EvolutionEvent>`, gene | `skill/{evolution,gene}.rs` |
+| Signing / trust | DSSE envelope, `TrustLevel` | `skill/sign.rs`, `skill/manifest.rs` |
+| Sharing | registry + `transfer_chain` (peer), team publish/install | `skill/{registry,peers}.rs`, `cmd/workflow.rs` |
+| Workflow-level composition | `|` pipe, `&&` seq, `,` parallel | `mur-common/src/pipeline.rs` |
+| Deterministic executor | shell exec, exit-code gating, retry, timeout | `mur-core/src/executor/pipeline.rs` |
+| Session recording | JSONL append, scrub | `mur-core/src/session/` |
+
+The v1 state-machine map collapses onto the existing one:
+
+| v1 proposed | Existing `LifecycleState` |
+|---|---|
+| Draft | Draft |
+| Active (first success) | Emerging (`PROMOTE_DRAFT_USES = 3` successes) |
+| Trusted (10 successes) | Stable (`PROMOTE_EMERGING_USES = 10`, rate ≥ 0.6, age ≥ 7d) |
+| Canonical (50 + review) | Canonical (`pinned` + `PROMOTE_STABLE_USES = 30`, rate ≥ 0.8, age ≥ 30d) |
+| Broken (3 consecutive failures) | Deprecated (rate < 0.3 w/ usage ≥ 5, or 90d no success) — **add** consecutive-failure fast path |
+| Trash | Archived (decay < 0.10 + age > 180d) |
+
+→ Layer 4 is ~90% done. The only missing input is run data.
+
+## What is actually missing (the real work)
+
+1. **Run-ledger** — the only true foundation gap. (§ Layer 4)
+2. **Executable + DAG fields on `ProcedureStep`** — `id`, `depends_on`, `command`,
+   `on_failure`, `retry`, `timeout_secs`, `needs_approval`. (§ Schema)
+3. **JSON Schema generation** for the Hub DAG editor. (§ Schema)
+4. **Extraction (LLM judge → produces a `category: Workflow` skill)** — gate +
+   extract, with cross-session aggregation and noise filtering. (§ Layer 2)
+5. **Unified executor** that runs a `procedure` DAG (command-mode steps
+   deterministically; intent-mode steps via the agent). (§ Layer 4)
+6. **Migration** of `~/.mur/workflows/*.yaml` → `~/.mur/skills/` and Pattern export.
+
+## Architecture: the converged model
+
+```
+Session Recording ──→ Extraction ──→ category:Workflow Skill ──→ Run + Lifecycle
+   (existing)          (LLM judge)      (skill = source of truth)   (executor + ledger)
+                                              │
+                                   ┌──────────┼───────────┐
+                                3-layer    DAG editor   evolution
+                                inject     (Hub+schema)  (existing)
+                                (existing)               (existing)
+```
+
+A `category: Workflow` skill whose steps are all command-mode is a classic
+runnable workflow. One with intent-mode steps is an agent procedure. Same type,
+same lifecycle, same disclosure, same registry. There is one knowledge unit.
+
+### Schema: executable DAG steps
+
+Extend `skill::manifest::ProcedureStep`. All new fields are `Option`/`default`,
+so existing manifests parse unchanged.
+
+```rust
+// mur-common/src/skill/manifest.rs — ProcedureStep (extended)
+pub struct ProcedureStep {
+    pub description: String,
+
+    // ── existing agent-mode fields (kept) ──
+    pub tool: Option<String>,
+    pub intent: Option<String>,
+    pub tool_hint: Option<String>,
+
+    // ── NEW: DAG identity ──
+    pub id: String,                  // stable kebab id for edges (required; migration auto-assigns s1..sn by file position)
+    #[serde(default)]
+    pub depends_on: Vec<String>,     // ids that must complete first; empty = root
+
+    // ── NEW: deterministic execution (command-mode) ──
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,     // shell command; presence ⇒ command-mode
+    #[serde(default)]
+    pub on_failure: FailureAction,   // skip | abort | retry  (reuse workflow::FailureAction)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry: Option<RetryConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+    #[serde(default)]
+    pub needs_approval: bool,
+}
+```
+
+**Step modes** (validated, mutually exclusive enough to dispatch):
+- *command-mode*: `command` is set → deterministic executor runs `sh -c`, gates on
+  exit code. Variables interpolate as `{{name}}` (shell-escaped, reuse
+  `pipeline::inject_input`).
+- *intent-mode*: `command` unset, `intent`/`tool` set → resolved against MCP
+  inventory at inject time, executed by the agent (existing behaviour).
+
+**DAG, not a line.** `order: u32` is **removed entirely**. Step ordering is
+derived from `depends_on` via topological sort; display order is the topo-sort
+result. The executor builds the graph, detects cycles, and runs independent
+branches concurrently. This matches GitHub Actions `needs:`, Argo, Airflow,
+Temporal. A linear chain is simply `s2.depends_on = [s1]`, `s3.depends_on = [s2]`. This matches GitHub Actions `needs:`, Argo, Airflow, Temporal.
+For display/back-compat, a linear chain is just `s2.depends_on = [s1]`, etc.
+
+**JSON Schema.** Derive `schemars::JsonSchema` on `SkillManifest` and emit
+`mur skill schema --json` → `schema/skill.schema.json`. The Hub DAG editor uses
+it to (a) render a node-per-step / edge-per-dependency graph, (b) generate a
+form per step, (c) validate before save. This is the prerequisite the user
+identified for DAG editing.
+
+**Signing note.** `ProcedureStep` lives inside `content`, inside the signed
+`SkillManifest`. Editing a step re-hashes content and invalidates any publisher
+signature — which is correct: extracted and locally-edited skills are unsigned
+(they enter at `Sandboxed`/`Local` trust). Re-signing only matters when
+re-publishing to a team. The DAG editor must drop the signature on save and mark
+the skill unsigned-local.
+
+### Schema: one `Variable` type
+
+Today `workflow::Variable` (typed `VarType` enum, `default_value: Option<String>`)
+and `skill::manifest::Variable` (free `var_type: String`,
+`default: Option<serde_yaml_ng::Value>`) diverge. Three consumers need the
+variable: the shell executor (runtime is a string), the Hub editor (needs a type
+to pick a widget + validate), and JSON Schema (type drives validation). A typed
+enum serves all three; a free string serves none well. For `default`, the
+industry norm (GitHub Actions inputs, Terraform variables, Argo parameters) is
+*string-encoded value + type metadata + runtime coercion* — this avoids YAML
+scalar surprises (`yes` → bool, `1.0` → float), keeps diffs stable, and matches a
+shell executor. Unify on one type in `skill::manifest` (the source of truth):
+
+```rust
+// mur-common/src/skill/manifest.rs — Variable (unified)
+pub struct Variable {
+    pub name: String,
+    #[serde(rename = "type", default)]
+    pub var_type: VarType,                 // String|Path|Url|Number|Bool|Array (from workflow)
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default, alias = "default_value", skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,           // string-encoded; coerced against var_type at run
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub choices: Vec<String>,              // enum/select widget + validation; empty = free input
+}
+```
+
+`VarType` moves from `workflow.rs` into `skill::manifest`. `alias = "default_value"`
+lets the migration step read old workflow YAMLs. `serde_yaml_ng::Value` defaults
+are dropped. Runtime coercion: `Number`/`Bool` parsed, `Array` decoded as JSON or
+comma-separated, others passed through.
+
+### Layer 1: Recording (enrich SessionEvent)
+
+Add execution metadata so extraction has signal. (Unchanged from v1 in intent.)
+
+```rust
+// mur-core/src/session/mod.rs — SessionEvent (extended; all Option/default)
+pub struct SessionEvent {
+    pub timestamp: u64,
+    pub event_type: String,
+    pub tool: Option<String>,
+    pub content: String,
+    // ── NEW ──
+    pub exit_code: Option<i32>,
+    pub working_dir: Option<String>,
+    pub git_branch: Option<String>,
+}
+```
+
+Per-session `detected_vars` is **dropped** from v1: single-session variable
+guessing is unreliable. Variables are detected across sessions (see Layer 2).
+
+### Layer 2: Extraction (LLM judge → a `category: Workflow` skill)
+
+**Two manual / automatic entry points, one output type (a draft skill).**
+
+**A. Trigger heuristics → config, not hardcoded.** v1's `≥8 turns`,
+`2+ exit 0`, `≥3 tool calls` violate Mandatory Rule #1. Move to
+`config.yaml: workflow.extraction.*` with these defaults, all overridable:
+
+```yaml
+workflow:
+  extraction:
+    min_substantive_turns: 8
+    completion_exit0_run: 2
+    min_tool_steps: 3
+```
+
+**B. Noise filter is RETAINED, not removed.** v1 deletes `noise_filter.rs`, but
+process-mining practice is unanimous that filtering test runs, exploratory
+commands, and failed/aborted operations is the *prerequisite* of extraction, not
+optional. Repurpose `capture/noise_filter.rs` to clean the event stream before
+the judge sees it. (`exit_code == 0` alone is NOT a completion signal — `ls`/`cat`
+spam exits 0; many valuable sessions have no shell at all.)
+
+**C. The judge does ONE thing at a time** (LLM-as-judge best practice:
+single-objective, explicit rubric). Split v1's all-in-one call into two:
+
+1. **Gate** (cheap, binary, rubric-scored). "Is this session a repeatable
+   procedure?" Rubric checklist, all must hold:
+   - steps have a determinate order / dependency
+   - commands are parameterizable (not one-off literals)
+   - it is not pure exploration (grep/read/ls browsing)
+   - the outcome is verifiable (a build, a deploy, a test pass)
+   Returns `{repeatable: bool, confidence: f64, reason}`. If false → NOOP.
+2. **Extract** (only if gated true). Produce a draft `category: Workflow` skill:
+   `name`, `description`, `content.abstract` (Layer 2 text), `content.procedure`
+   (steps with `command`/`tool`, inferred `depends_on` from data/order),
+   `triggers`, `variables`.
+
+**D. Cross-session aggregation is the real value.** Do not emit one draft per
+session. Cluster recordings by step-sequence similarity; when the same procedure
+recurs with differing literals (`deploy app_a` / `deploy app_b`), that *diff* is
+the strongest variable signal (`{{app_name}}`) and each recurrence raises the
+draft's `usage_count`/confidence. This is what turns 5 noisy sessions into 1
+high-confidence workflow — and it is where evolution earns its keep.
+
+**Notification** (unchanged from v1):
+```
+💡 Repeatable workflow detected: "Deploy to Fly.io"
+   1. cargo build --release
+   2. fly deploy --app {{app_name}}
+   3. curl {{health_check_url}}
+   [Accept & edit] [Ignore] [Later]
+```
+
+### Layer 3: Disclosure & invocation — REUSED, not built
+
+Extracted `category: Workflow` skills automatically get:
+- **Layer 2 injection** of `abstract` at session start (`injector.rs`).
+- **Layer 3 expansion** of `procedure` on trigger match (`trigger_matcher.rs`).
+- **Agent dynamic invocation** through the existing runtime path.
+
+No new injection code. `inject/hook.rs` switches from injecting Patterns to
+injecting (a) recommended skills via the existing skill path. This also closes
+the v1 gap where the Workflow engine and the agent runtime were two disconnected
+worlds.
+
+### Layer 4: Run + Lifecycle
+
+**Unified executor.** `mur run <name>` / `mur workflow run <name>`:
+1. Load the `category: Workflow` skill.
+2. Build the step DAG from `depends_on`; topologically sort; detect cycles.
+3. Execute: command-mode steps run via the existing executor (exit-code gating,
+   retry, timeout, `needs_approval` prompt); intent-mode steps require the agent
+   runtime — in pure CLI they are **printed as instructions** (the resolved
+   intent/tool text) and marked skipped in the ledger, never silently dropped.
+4. Independent branches may run concurrently (reuse `pipeline.rs` parallel).
+5. Append one record to the run-ledger.
+
+`pipeline.rs` (`|`/`&&`/`,`) stays for **composing multiple skills**; the new DAG
+is **within** one skill.
+
+**Run-ledger (THE missing foundation).** Append-only, one file per skill:
+
+```
+~/.mur/skills/<name>/runs.jsonl
+{"ts": 1730000000, "exit_code": 0, "duration_ms": 8421,
+ "failed_step": null, "env_class": "ok", "trigger": "manual"}
+```
+
+`env_class` distinguishes *workflow failure* from *environment failure*
+(network/credentials/missing-binary classified from stderr), so a flaky network
+does not falsely mark a workflow Broken.
+
+**Evolution = feed the ledger into the existing state machine.** A sweep reduces
+`runs.jsonl` → `SkillStats` (`usage_count`, `success_count`, `last_success_at`,
+`first_successful_use_at`, …) and calls the existing
+`skill::lifecycle::next_state(stats, now)`. No new state machine.
+
+Two small additions to `lifecycle.rs`:
+- **Broken fast-path**: N consecutive `env_class == "workflow"` failures →
+  `Deprecated` immediately + notify user (N in config, default 3). Current rule
+  (rate < 0.3 at usage ≥ 5) is too slow for a freshly-broken workflow.
+- Confirm `Archived` (decay + age) serves as v1's "Trash"; a separate hard-delete
+  sweep removes Archived skills after a configurable grace period.
+
+**Cold-start.** With ~0 real workflows today, absolute-count thresholds (50 runs →
+Canonical) are effectively unreachable for a single user. The existing ladder is
+already *rate × age × count*, not pure count — keep it, but expose the constants
+in config so a solo user can lower them. Bootstrap the first workflows via the
+**manual** `mur-in`/`mur-out` path (no LLM variance, immediate output) before
+relying on automatic extraction.
+
+## Decision: remove Pattern
+
+Carried from v1, with corrections from the audit:
+
+- **Count is 160 yaml files**, not 42 (`~/.mur/patterns/`), plus `archive/`.
+  `injection_count == 0` confirmed across all real patterns (non-zero values exist
+  only in test fixtures) — the removal rationale holds.
+- **Export before delete.** Dump each pattern to a markdown file under
+  `~/.mur/exported-patterns/` before removing, then delete. Never hard-delete user
+  data without a backup path.
+- Remove: `capture/emergence.rs`, fingerprint extraction, pattern `decay`/
+  `maturity` logic in `pattern.rs`, `~/.mur/fingerprints.jsonl`.
+- **Keep `capture/noise_filter.rs`** (repurposed for extraction — see Layer 2).
+- `inject/hook.rs`, `retrieve/`, `sync.rs`: repoint from Pattern to skill/workflow.
+
+## What we remove / keep / add
+
+**Remove**
+- Pattern pipeline: `capture/emergence.rs`, fingerprinting, `evolve/decay.rs`
+  half-life guessing, pattern `maturity` in `pattern.rs`.
+- Standalone `mur-common/src/workflow.rs` **as a persisted type** — folded into
+  `skill` (`category: Workflow` + extended `ProcedureStep`). `FailureAction`,
+  `RetryConfig`, `Variable` move/merge into `skill::manifest`.
+- `~/.mur/fingerprints.jsonl`, pattern archive (after export).
+
+**Keep / reuse**
+- Entire `skill/` subsystem (lifecycle, evolution, gene, signing, registry,
+  peers, triggers, mcp_requirements).
+- `mur-agent-runtime/src/skills/` 3-layer injector + trigger matcher.
+- `mur-common/src/pipeline.rs` composition + `executor/pipeline.rs`.
+- `session/` recording + scrub.
+
+**Add**
+- `ProcedureStep` DAG/executable fields + JSON Schema emit.
+- Run-ledger + stats reducer + Broken fast-path.
+- LLM judge (gate + extract) + cross-session aggregation.
+- Hub DAG editor.
+- Migration: `~/.mur/workflows/` → `~/.mur/skills/`; Pattern export.
+
+## Competitive positioning
+
+Unchanged from v1, with one sharpened claim: the differentiator is **Session →
+executable Skill**, and because the executable unit *is* the skill, it inherits
+disclosure, evolution, signing, and peer sharing for free. No competitor unifies
+extraction, a deterministic DAG executor, and an observable lifecycle on one
+shared knowledge object.
+
+## Development phases (re-scoped)
+
+P4 was under-scoped in v1 (no ledger); P5/P6 were over-scoped (skill infra exists).
+
+| Phase | Content | Est. |
+|---|---|---|
+| **P1: Clean slate** | Export 160 patterns → md; remove pattern pipeline; repoint inject/retrieve/sync; keep noise_filter | 2–3 d |
+| **P2: Schema + ledger** | Extend `ProcedureStep` (DAG + exec); JSON Schema emit; SessionEvent enrich; run-ledger + stats reducer | 1.5 wk |
+| **P3: Unified executor** | DAG topo-sort + concurrent branches; command/intent dispatch; `needs_approval`; wire run-ledger | 1 wk |
+| **P4: Lifecycle wire-up** | Feed stats → `next_state`; Broken fast-path; Archived hard-delete sweep; move ALL thresholds to config (run-driven + existing `lifecycle.rs` `PROMOTE_*`/`DEMOTE_*` constants) | 3–4 d |
+| **P5: Extraction** | noise filter prep; LLM judge gate+extract; cross-session aggregation; notification | 1.5 wk |
+| **P6: Hub DAG editor** | graph view from schema; per-step form; variable mgmt; test-run in sandbox | 2 wk |
+| **P7: Migration + sharing** | `workflows/` → `skills/`; reuse existing registry/transfer for team share | 1 wk |
+
+## Resolved decisions
+
+1. **`order: u32` is removed entirely.** Step ordering derives from `depends_on`
+   (topo-sort); display order is the topo-sort result.
+2. **Pure-CLI intent-mode steps are printed as instructions** (resolved
+   intent/tool text) and marked skipped in the ledger — never silently dropped.
+3. **One `Variable` type** in `skill::manifest`: typed `VarType` enum +
+   `default: Option<String>` (string-encoded, runtime-coerced) + `choices`.
+   `serde(alias = "default_value")` for migration. Skill's free-string /
+   `serde_yaml_ng::Value` form is dropped. (See § Schema: one `Variable` type.)
+4. **All thresholds go to config in P4** — both the new run-driven ones and the
+   existing hardcoded `lifecycle.rs` constants (`PROMOTE_*`, `DEMOTE_*`,
+   `AUTO_ARCHIVE_*`), per Mandatory Rule #1.

--- a/docs/superpowers/specs/2026-05-28-mur-workflow-engine-design-v2.md
+++ b/docs/superpowers/specs/2026-05-28-mur-workflow-engine-design-v2.md
@@ -102,7 +102,8 @@ pub struct ProcedureStep {
     pub tool_hint: Option<String>,
 
     // ── NEW: DAG identity ──
-    pub id: String,                  // stable kebab id for edges (required; migration auto-assigns s1..sn by file position)
+    #[serde(default = "default_step_id")]  // "s0" default; migration assigns s1..sn by file position
+    pub id: String,
     #[serde(default)]
     pub depends_on: Vec<String>,     // ids that must complete first; empty = root
 
@@ -127,12 +128,17 @@ pub struct ProcedureStep {
 - *intent-mode*: `command` unset, `intent`/`tool` set → resolved against MCP
   inventory at inject time, executed by the agent (existing behaviour).
 
+**Backward-compat note.** `id` defaults to `"s0"` via `default_step_id()`, so
+existing manifests with `procedure` but no `id` field parse without error. The
+migration step (P7) assigns stable `s1..sn` ids by original file position
+*before* any consumer reads the skill — the default is a safety net, not the
+primary path. The DAG editor must generate unique ids for new steps.
+
 **DAG, not a line.** `order: u32` is **removed entirely**. Step ordering is
 derived from `depends_on` via topological sort; display order is the topo-sort
 result. The executor builds the graph, detects cycles, and runs independent
 branches concurrently. This matches GitHub Actions `needs:`, Argo, Airflow,
-Temporal. A linear chain is simply `s2.depends_on = [s1]`, `s3.depends_on = [s2]`. This matches GitHub Actions `needs:`, Argo, Airflow, Temporal.
-For display/back-compat, a linear chain is just `s2.depends_on = [s1]`, etc.
+Temporal. A linear chain is simply `s2.depends_on = [s1]`, `s3.depends_on = [s2]`.
 
 **JSON Schema.** Derive `schemars::JsonSchema` on `SkillManifest` and emit
 `mur skill schema --json` → `schema/skill.schema.json`. The Hub DAG editor uses
@@ -248,6 +254,22 @@ the strongest variable signal (`{{app_name}}`) and each recurrence raises the
 draft's `usage_count`/confidence. This is what turns 5 noisy sessions into 1
 high-confidence workflow — and it is where evolution earns its keep.
 
+**Algorithm (high-level):**
+1. **Normalize** each session's command sequence: strip literals (quoted strings,
+   paths, hostnames) → command skeletons (`fly deploy --app <STR>`).
+2. **Pairwise similarity** via n-gram Jaccard on the skeleton sequence
+   (bigrams over command+tool tuples; picks up order without strict alignment).
+3. **Cluster** with DBSCAN (eps tuned so identical-procedure sessions group;
+   exploration sessions become noise). Each cluster ≥ min_sessions (default 3)
+   becomes a candidate workflow.
+4. **Diff literals within the cluster** → candidate variables. A literal
+   position that varies across cluster members with low cardinality (≤5 distinct
+   values) is a strong variable signal; high-cardinality literals (UUIDs,
+   timestamps) are discarded.
+5. **Feed the cluster** (not a single session) to the Extract judge so it sees
+   the full variation, producing one consolidated draft skill with variables
+   pre-populated.
+
 **Notification** (unchanged from v1):
 ```
 💡 Repeatable workflow detected: "Deploy to Fly.io"
@@ -275,11 +297,20 @@ worlds.
 1. Load the `category: Workflow` skill.
 2. Build the step DAG from `depends_on`; topologically sort; detect cycles.
 3. Execute: command-mode steps run via the existing executor (exit-code gating,
-   retry, timeout, `needs_approval` prompt); intent-mode steps require the agent
-   runtime — in pure CLI they are **printed as instructions** (the resolved
-   intent/tool text) and marked skipped in the ledger, never silently dropped.
-4. Independent branches may run concurrently (reuse `pipeline.rs` parallel).
-5. Append one record to the run-ledger.
+   retry, timeout). Intent-mode steps require the agent runtime — in pure CLI
+   they are **printed as instructions** (the resolved intent/tool text) and
+   marked skipped in the ledger, never silently dropped.
+4. **Concurrent branches.** After topo-sort, group steps by rank (length of
+   longest path from root). Steps within the same rank share no dependency edges
+   and can execute concurrently. The executor spawns them via
+   `tokio::task::spawn` and awaits the rank before advancing to the next. This
+   is a proper task-graph executor; `pipeline.rs` (`,` parallel operator) is
+   not reused here — it stays for composing *multiple* skills at the CLI level.
+5. **`needs_approval` steps:** when stdin is a TTY, prompt the user and wait.
+   When non-TTY (cron, CI, agent-driven), auto-skip and mark the step
+   `skipped_approval` in the ledger. Pass `--yes` to auto-approve all
+   `needs_approval` steps in non-interactive runs.
+6. Append one record to the run-ledger.
 
 `pipeline.rs` (`|`/`&&`/`,`) stays for **composing multiple skills**; the new DAG
 is **within** one skill.
@@ -293,8 +324,16 @@ is **within** one skill.
 ```
 
 `env_class` distinguishes *workflow failure* from *environment failure*
-(network/credentials/missing-binary classified from stderr), so a flaky network
-does not falsely mark a workflow Broken.
+(network/credentials/missing-binary classified from stderr patterns), so a flaky
+network does not falsely mark a workflow Broken. Classification is heuristic;
+add a `confidence` field (0.0–1.0) and let the user override via
+`mur run --env-class workflow|env`. The Broken fast-path only triggers on
+`env_class == "workflow"` with confidence ≥ 0.8.
+
+**Single-machine assumption.** `runs.jsonl` is per-skill on the local machine.
+Multi-machine aggregation (e.g. a team member runs the same workflow on their
+laptop) is out of scope for v2. The ledger is append-only JSONL so future
+merge/ sync is straightforward: union the files, sort by `ts`, done.
 
 **Evolution = feed the ledger into the existing state machine.** A sweep reduces
 `runs.jsonl` → `SkillStats` (`usage_count`, `success_count`, `last_success_at`,
@@ -368,13 +407,14 @@ P4 was under-scoped in v1 (no ledger); P5/P6 were over-scoped (skill infra exist
 
 | Phase | Content | Est. |
 |---|---|---|
-| **P1: Clean slate** | Export 160 patterns → md; remove pattern pipeline; repoint inject/retrieve/sync; keep noise_filter | 2–3 d |
+| **P1a: Export + delete** | Export 160 patterns → md; remove pattern pipeline (emergence, fingerprinting, decay, maturity); keep noise_filter | 1–2 d |
+| **P1b: Repoint** | Repoint `inject/hook.rs`, `retrieve/`, `sync.rs` from Pattern to skill/workflow; verify no regressions | 2–3 d |
 | **P2: Schema + ledger** | Extend `ProcedureStep` (DAG + exec); JSON Schema emit; SessionEvent enrich; run-ledger + stats reducer | 1.5 wk |
-| **P3: Unified executor** | DAG topo-sort + concurrent branches; command/intent dispatch; `needs_approval`; wire run-ledger | 1 wk |
+| **P3: Unified executor** | DAG topo-sort + concurrent branches; command/intent dispatch; `needs_approval` + `--yes` flag; wire run-ledger | 1 wk |
 | **P4: Lifecycle wire-up** | Feed stats → `next_state`; Broken fast-path; Archived hard-delete sweep; move ALL thresholds to config (run-driven + existing `lifecycle.rs` `PROMOTE_*`/`DEMOTE_*` constants) | 3–4 d |
-| **P5: Extraction** | noise filter prep; LLM judge gate+extract; cross-session aggregation; notification | 1.5 wk |
-| **P6: Hub DAG editor** | graph view from schema; per-step form; variable mgmt; test-run in sandbox | 2 wk |
-| **P7: Migration + sharing** | `workflows/` → `skills/`; reuse existing registry/transfer for team share | 1 wk |
+| **P5: Extraction** | noise filter prep; LLM judge gate+extract; cross-session aggregation (normalize → Jaccard → DBSCAN → diff); notification | 1.5 wk |
+| **P6: Hub DAG editor** | graph view from schema; per-step form; variable mgmt; test-run in sandbox | 2–3 wk |
+| **P7: Migration + sharing** | `workflows/` → `skills/` (convert `order` → `depends_on`, `default_value` → `default`, dedupe against existing skills); reuse existing registry/transfer for team share | 1 wk |
 
 ## Resolved decisions
 
@@ -389,3 +429,15 @@ P4 was under-scoped in v1 (no ledger); P5/P6 were over-scoped (skill infra exist
 4. **All thresholds go to config in P4** — both the new run-driven ones and the
    existing hardcoded `lifecycle.rs` constants (`PROMOTE_*`, `DEMOTE_*`,
    `AUTO_ARCHIVE_*`), per Mandatory Rule #1.
+5. **`needs_approval` in non-TTY contexts:** auto-skip and mark `skipped_approval`
+   in the ledger. `--yes` flag auto-approves all. No silent dropping, no hanging
+   on a prompt that will never be answered.
+6. **Concurrent branches use a proper task-graph executor** (topo-sort → rank
+   grouping → `tokio::spawn` per rank), not `pipeline.rs` `,` operator.
+   `pipeline.rs` stays for CLI-level composition of multiple skills.
+7. **Migration converts `order` → `depends_on`:** for each existing workflow YAML
+   with `steps` using `order: u32`, sort by `order`, then emit
+   `s1.depends_on = [s0]`, `s2.depends_on = [s1]`, etc. Steps without `order`
+   (already DAG) pass through unchanged. Variables rename `default_value` →
+   `default` via serde alias. The migration is a `mur migrate --workflows` one-shot
+   that runs before any consumer reads from `~/.mur/skills/`.

--- a/docs/superpowers/specs/2026-05-28-mur-workflow-engine-design-v2.md
+++ b/docs/superpowers/specs/2026-05-28-mur-workflow-engine-design-v2.md
@@ -60,7 +60,12 @@ The v1 state-machine map collapses onto the existing one:
 
 ## What is actually missing (the real work)
 
-1. **Run-ledger** — the only true foundation gap. (§ Layer 4)
+1. **Run-ledger + the event→stats reducer** — the foundation gap. Note that
+   `SkillStats` *persistence* already exists (`skill/stats.rs`
+   `new`/`path`/`load`/`merge_in_place`; `cmd/skill_stats.rs`); what is missing is
+   (a) reducing a per-skill append-only event log into `SkillStats` and (b) a
+   sweep that persists the `next_state` result. The gap is narrower than "build a
+   ledger from scratch". (§ Layer 4)
 2. **Executable + DAG fields on `ProcedureStep`** — `id`, `depends_on`, `command`,
    `on_failure`, `retry`, `timeout_secs`, `needs_approval`. (§ Schema)
 3. **JSON Schema generation** for the Hub DAG editor. (§ Schema)
@@ -85,6 +90,17 @@ Session Recording ──→ Extraction ──→ category:Workflow Skill ──�
 A `category: Workflow` skill whose steps are all command-mode is a classic
 runnable workflow. One with intent-mode steps is an agent procedure. Same type,
 same lifecycle, same disclosure, same registry. There is one knowledge unit.
+
+**Sibling projection: Notes.** `category: Note` (see
+`2026-05-28-mur-notes-design.md`) is the *reference* projection of the same
+knowledge object: free-markdown content instead of an executable `procedure`, and
+a **retrieval** usage signal instead of a **run**. It reuses everything this spec
+builds — `SkillStats`, `next_state`, the per-skill event log, the stats reducer,
+`mur skill evolve`, the corpus index, and the MCP `skill_search` surface. The
+shared additions this spec must therefore make category-agnostic, not
+workflow-private: (1) the `Category`/`ContentMode` enums gain a `Note` variant;
+(2) the run-ledger is one *projection* of a per-skill `events.jsonl`; (3)
+`mur skill evolve` and the corpus index/search work across categories.
 
 ### Schema: executable DAG steps
 
@@ -315,11 +331,14 @@ worlds.
 `pipeline.rs` (`|`/`&&`/`,`) stays for **composing multiple skills**; the new DAG
 is **within** one skill.
 
-**Run-ledger (THE missing foundation).** Append-only, one file per skill:
+**Run-ledger (THE missing foundation).** Append-only, one file per skill. It is
+the *workflow projection* of a per-skill `events.jsonl`: a workflow appends a
+`run` event, a note (sibling spec) appends a `retrieval` event, and both feed the
+same stats reducer. The run projection records:
 
 ```
-~/.mur/skills/<name>/runs.jsonl
-{"ts": 1730000000, "exit_code": 0, "duration_ms": 8421,
+~/.mur/skills/<name>/runs.jsonl   (run events; sibling: retrieval events for notes)
+{"ts": 1730000000, "kind": "run", "exit_code": 0, "duration_ms": 8421,
  "failed_step": null, "env_class": "ok", "trigger": "manual"}
 ```
 
@@ -338,7 +357,10 @@ merge/ sync is straightforward: union the files, sort by `ts`, done.
 **Evolution = feed the ledger into the existing state machine.** A sweep reduces
 `runs.jsonl` → `SkillStats` (`usage_count`, `success_count`, `last_success_at`,
 `first_successful_use_at`, …) and calls the existing
-`skill::lifecycle::next_state(stats, now)`. No new state machine.
+`skill::lifecycle::next_state(stats, now)`. No new state machine. The sweep is
+the category-agnostic `mur skill evolve [--category …]` — it reduces every
+skill's `events.jsonl` (run events for workflows, retrieval events for notes)
+through one reducer, so notes and workflows evolve through one path.
 
 Two small additions to `lifecycle.rs`:
 - **Broken fast-path**: N consecutive `env_class == "workflow"` failures →
@@ -389,6 +411,12 @@ Carried from v1, with corrections from the audit:
 **Add**
 - `ProcedureStep` DAG/executable fields + JSON Schema emit.
 - Run-ledger + stats reducer + Broken fast-path.
+- **Category-agnostic foundation (shared with Notes):** `Note` variant on
+  `Category`/`ContentMode` (extend `Content::mode()` from a 3-tuple to a 4-tuple
+  and update `validate`'s "exactly one content mode" rule + all exhaustive match
+  sites); the run-ledger as a projection of per-skill `events.jsonl`; `mur skill
+  evolve` and the corpus index/`skill_search` made category-aware. Notes
+  (`2026-05-28-mur-notes-design.md`) depends on this.
 - LLM judge (gate + extract) + cross-session aggregation.
 - Hub DAG editor.
 - Migration: `~/.mur/workflows/` → `~/.mur/skills/`; Pattern export.
@@ -408,11 +436,12 @@ P4 was under-scoped in v1 (no ledger); P5/P6 were over-scoped (skill infra exist
 | Phase | Content | Est. |
 |---|---|---|
 | **P1a: Export + delete** | Export 160 patterns → md; remove pattern pipeline (emergence, fingerprinting, decay, maturity); keep noise_filter | 1–2 d |
-| **P1b: Repoint** | Repoint `inject/hook.rs`, `retrieve/`, `sync.rs` from Pattern to skill/workflow; verify no regressions | 2–3 d |
+| **P1b: Repoint** | Repoint `inject/hook.rs`, `sync.rs`; **`retrieve/` is hard-typed to `Pattern`** (`ScoredPattern`, `score_and_rank_hybrid(Vec<Pattern>)`) — introduce a `Retrievable` trait so Skill/Note + transitional Pattern share one scorer (a type migration, not a repoint); verify no regressions | 4–6 d |
 | **P2: Schema + ledger** | Extend `ProcedureStep` (DAG + exec); JSON Schema emit; SessionEvent enrich; run-ledger + stats reducer | 1.5 wk |
 | **P3: Unified executor** | DAG topo-sort + concurrent branches; command/intent dispatch; `needs_approval` + `--yes` flag; wire run-ledger | 1 wk |
 | **P4: Lifecycle wire-up** | Feed stats → `next_state`; Broken fast-path; Archived hard-delete sweep; move ALL thresholds to config (run-driven + existing `lifecycle.rs` `PROMOTE_*`/`DEMOTE_*` constants) | 3–4 d |
-| **P5: Extraction** | noise filter prep; LLM judge gate+extract; cross-session aggregation (normalize → Jaccard → DBSCAN → diff); notification | 1.5 wk |
+| **P5a: Manual + single-session extract** | noise filter prep; manual `mur-in`/`mur-out` → draft `category: Workflow` skill; LLM judge gate+extract on one session; notification. Delivers value at cold-start with no clustering | 1 wk |
+| **P5b: Cross-session aggregation** | normalize → n-gram Jaccard → DBSCAN cluster → literal-diff variables → one consolidated draft. **Defer until real session volume exists** — DBSCAN needs density that cold-start lacks | 1 wk |
 | **P6: Hub DAG editor** | graph view from schema; per-step form; variable mgmt; test-run in sandbox | 2–3 wk |
 | **P7: Migration + sharing** | `workflows/` → `skills/` (convert `order` → `depends_on`, `default_value` → `default`, dedupe against existing skills); reuse existing registry/transfer for team share | 1 wk |
 
@@ -434,7 +463,13 @@ P4 was under-scoped in v1 (no ledger); P5/P6 were over-scoped (skill infra exist
    on a prompt that will never be answered.
 6. **Concurrent branches use a proper task-graph executor** (topo-sort → rank
    grouping → `tokio::spawn` per rank), not `pipeline.rs` `,` operator.
-   `pipeline.rs` stays for CLI-level composition of multiple skills.
+   `pipeline.rs` stays for CLI-level composition of multiple skills. The DAG
+   topology is new, but the per-step `FailureAction::{Abort,Skip,Retry}` handling,
+   retry/timeout, and `tokio::spawn` pattern are **lifted from
+   `executor/pipeline.rs`** (already implemented there, ~lines 204-219), not
+   rewritten — which requires `FailureAction`/`RetryConfig` to have moved into
+   `skill::manifest` first (P2), since `pipeline.rs` imports them from
+   `workflow.rs` today.
 7. **Migration converts `order` → `depends_on`:** for each existing workflow YAML
    with `steps` using `order: u32`, sort by `order`, then emit
    `s1.depends_on = [s0]`, `s2.depends_on = [s1]`, etc. Steps without `order`

--- a/docs/superpowers/specs/2026-05-28-mur-workflow-engine-design.md
+++ b/docs/superpowers/specs/2026-05-28-mur-workflow-engine-design.md
@@ -1,0 +1,142 @@
+# MuR Workflow Engine — Session → Workflow → Replay
+
+> **Status:** Approved design | **Date:** 2026-05-28
+
+## Decision
+
+**砍掉 Pattern（自動學習）整條 pipeline，聚焦 Session Recording → Workflow Extraction → Replay。**
+
+Pattern injection 在實際使用中從未運作過（injection_count = 0 across all 42 patterns）。Emergence pipeline 在 LLM summarization 被關閉後，降級為 fingerprint counting，產出 62% 結構性垃圾。舊版 LLM summarization pipeline（Problem/Solution/Why 格式）品質較好但因 token 成本過高而在 5 月初被關閉。
+
+Pattern 功能的核心矛盾無法解決：價值延遲（2-4 週）+ 成本立即感受（token）+ 品質不可驗證。Workflow 解決全部三個問題：價值立即（`mur run` 直接執行）、成本可控（只在「完成一件事」時才呼叫 LLM judge）、品質可觀測（exit code 判定成功/失敗）。
+
+## Architecture: Four-Layer Pipeline
+
+```
+Session Recording ──→ Extraction ──→ Web Editor ──→ Replay/Evolution
+     (Layer 1)        (Layer 2)       (Layer 3)        (Layer 4)
+```
+
+### Layer 1: Recording（強化現有 session JSONL）
+
+在 `SessionEvent` 加入 execution metadata，讓 extraction 有足夠訊號判斷「這是一個可重覆的工作流程」。
+
+```rust
+// mur-core/src/session/mod.rs — SessionEvent 擴展
+pub struct SessionEvent {
+    pub timestamp: u64,
+    pub event_type: String,       // "tool_call" | "tool_result" | "user_message" | "completion"
+    pub tool: Option<String>,
+    pub content: String,
+    // ── NEW ──
+    pub exit_code: Option<i32>,       // 指令成功(0)或失敗(!0)
+    pub working_dir: Option<String>,  // 在哪個目錄下執行
+    pub git_branch: Option<String>,   // 哪個 branch
+    pub detected_vars: Option<HashMap<String, String>>, // LLM 初步標記的可變參數
+}
+```
+
+### Layer 2: Extraction（LLM Judge + 手動截取）
+
+**A. 自動提取（LLM 主動通知）**
+
+觸發條件（三者同時滿足才呼叫 LLM，控制成本）：
+1. 累積 ≥ 8 輪實質對話（排除打招呼/閒聊）
+2. 偵測到「任務完成」訊號（連續 2+ tool_results 的 exit_code = 0）
+3. 偵測到 ≥ 3 個相關 tool calls 構成步驟序列
+
+LLM prompt 只做 JUDGE，不做 GENERATE：
+- 判斷：這個 session 的步驟序列是否可重覆？
+- 判斷：哪些值是變數？
+- 如果可重覆 → 產生 Workflow draft（title + steps + variables）
+- 如果不行 → 回 NOOP
+
+通知格式：
+```
+💡 偵測到可重覆的 workflow: "Deploy to Fly.io"
+   1. cargo build --release
+   2. fly deploy --app {{app_name}}
+   3. curl {{health_check_url}}
+   [接受並編輯] [忽略] [稍後]
+```
+
+**B. 手動截取**
+
+- `mur-in` 開始標記（或整個 session 已在 recording）
+- 工作完成後 `mur-out` → 自動 extraction → 可選打開 Hub web editor
+
+### Layer 3: Web Editor（Hub Workflow Editor）
+
+Hub 內的 workflow 編輯器：
+- Steps 列表（拖放排序、編輯 command/tool/timeout/on_failure）
+- Variables 管理（從 extraction 標記的變數，可編輯 default value）
+- Test Run 按鈕（在 sandbox 中試跑）
+- 狀態：Draft / Published
+
+### Layer 4: Replay + Evolution（執行 + 自動生命週期）
+
+**執行：** `mur run <workflow-name>` 或 `mur workflow run <name>`
+
+**自動狀態機（可觀測訊號驅動）：**
+
+```
+Draft ──(首次成功)──→ Active ──(10次成功)──→ Trusted ──(50次+人審)──→ Canonical
+  │                      │                    │
+  │                  連續失敗 3 次               │
+  │                      ↓                    │
+  │                   Broken ←─────────────────┘
+  │                      │
+  │                  30 天未修復
+  │                      ↓
+  └──────────────→ Trash ──(30天)──→ 永久刪除
+```
+
+| 訊號 | 來源 | 動作 |
+|---|---|---|
+| 首次執行成功 | `mur run` exit 0 | Draft → Active |
+| 累積 10 次成功 | run history counter | Active → Trusted |
+| 連續 3 次失敗 | run history（最近 3 次 exit != 0） | → Broken + 通知用戶 |
+| 30 天未修復 | Broken + last_modified | Broken → Trash |
+| 90 天未執行 | last_run timestamp | 降低推薦優先級（stale） |
+| 累積 50 次成功 + 人審 | run history + manual flag | Trusted → Canonical（團隊共享） |
+
+## What We Remove
+
+- `mur-core/src/capture/` — emergence.rs, noise_filter.rs（fingerprint-based extraction）
+- `mur-core/src/evolve/decay.rs` — 半衰期猜測邏輯（改為觀測驅動的 workflow 狀態機）
+- `~/.mur/patterns/` — 現有 42 個 MUR schema patterns（26 個結構性垃圾）
+- `~/.mur/archive/patterns/` — 24 MB 版本歷史
+- `~/.mur/fingerprints.jsonl` — 4.1 MB noise log
+- `mur-common/src/pattern.rs` 中的硬性 decay/maturity 邏輯
+
+## What We Keep
+
+- `mur-common/src/workflow.rs` — Workflow 型別（已有 Step, Variable, trigger, tools, lifecycle）
+- `mur-core/src/session/` — Recording 基礎（mod.rs, scrub.rs）
+- `mur-core/src/inject/hook.rs` — 改為注入推薦 workflows（而非 patterns）
+- `mur-core/src/retrieve/` — 檢索 pipeline（改為匹配 workflows）
+- `~/.mur/workflows/` — Workflow 儲存
+- `~/.mur/session/recordings/` — Session 記錄
+
+## Competitive Positioning
+
+| | Archon (21K⭐) | Tembo | Sekko | **mur** |
+|---|---|---|---|---|
+| Session Recording | ❌ | ❌ | ✅ (browser+term) | ✅ (AI coding) |
+| Workflow Extraction | ❌ (手寫YAML) | ❌ | ✅ (→markdown) | ✅ (→executable) |
+| Web Editor | ✅ (DAG builder) | ❌ | ❌ | ✅ (Hub) |
+| Replay/Execute | ✅ | ✅ (async sandbox) | ❌ | ✅ (mur run) |
+| Evolution Engine | ❌ (Git only) | ❌ | ❌ | ✅ (觀測驅動) |
+
+**核心差異化：Session → Workflow 自動提取。沒有人把這四步串起來。**
+
+## Development Phases
+
+| Phase | 內容 | 時間 |
+|---|---|---|
+| **P1: Clean Slate** | 砍掉 capture/ + evolve/ + 垃圾 patterns | 2-3 天 |
+| **P2: Recording 強化** | SessionEvent 擴展 + mur-in/mur-out 修復 | 1 週 |
+| **P3: Extraction (LLM Judge)** | 完成訊號偵測 + LLM judge prompt + 通知 | 1.5 週 |
+| **P4: Workflow Evolution Engine** | 狀態機 + broken detection + trash 清理 | 1 週 |
+| **P5: Hub Workflow Editor** | Web 編排器（step 編輯、variable 管理、test run） | 2 週 |
+| **P6: Team Sharing** | Canonical workflow publish → team 可用 | 2 週 |

--- a/mur-core/src/cmd/context.rs
+++ b/mur-core/src/cmd/context.rs
@@ -231,7 +231,7 @@ pub(crate) async fn cmd_context(
 
     let mut injected_patterns: Vec<Pattern> = Vec::new();
     for sp in results {
-        let mut p = sp.pattern;
+        let mut p = sp.item;
         if p.lifecycle.status == LifecycleStatus::Archived {
             continue;
         }

--- a/mur-core/src/cmd/eval.rs
+++ b/mur-core/src/cmd/eval.rs
@@ -337,7 +337,7 @@ fn run_retrieval_eval(format: &str) -> Result<i32> {
         let scored = score_and_rank_with_config(query, patterns.clone(), &config);
         let rank = scored
             .iter()
-            .position(|sp| sp.pattern.name == *expected)
+            .position(|sp| sp.item.name == *expected)
             .map(|i| i + 1);
         let hit = rank.is_some();
         if hit {

--- a/mur-core/src/cmd/hook.rs
+++ b/mur-core/src/cmd/hook.rs
@@ -121,8 +121,8 @@ pub(crate) async fn cmd_hook_prompt(tool: &str) -> Result<()> {
 
     let injected: Vec<_> = score_and_rank(&query, patterns)
         .into_iter()
-        .filter(|sp| sp.pattern.lifecycle.status != LifecycleStatus::Archived)
-        .map(|sp| sp.pattern)
+        .filter(|sp| sp.item.lifecycle.status != LifecycleStatus::Archived)
+        .map(|sp| sp.item)
         .collect();
 
     let budget = match effective_tier {
@@ -197,8 +197,8 @@ pub(crate) async fn cmd_hook_tool(tool: &str) -> Result<()> {
 
     let injected: Vec<_> = score_and_rank(query, patterns)
         .into_iter()
-        .filter(|sp| sp.pattern.lifecycle.status != LifecycleStatus::Archived)
-        .map(|sp| sp.pattern)
+        .filter(|sp| sp.item.lifecycle.status != LifecycleStatus::Archived)
+        .map(|sp| sp.item)
         .collect();
 
     const L2_BUDGET: usize = 2000;

--- a/mur-core/src/cmd/inject_cmd.rs
+++ b/mur-core/src/cmd/inject_cmd.rs
@@ -72,7 +72,7 @@ pub(crate) async fn cmd_inject(query: &str) -> Result<()> {
         .unwrap_or_default();
     let mut injected_patterns: Vec<Pattern> = Vec::new();
     for sp in results {
-        let mut p = sp.pattern;
+        let mut p = sp.item;
         if p.lifecycle.status == LifecycleStatus::Archived {
             continue;
         }

--- a/mur-core/src/cmd/pattern.rs
+++ b/mur-core/src/cmd/pattern.rs
@@ -215,7 +215,7 @@ pub(crate) fn cmd_search(query: &str) -> Result<()> {
 
     println!("🔍 Found {} patterns for \"{}\":\n", results.len(), query);
     for sp in &results {
-        let p = &sp.pattern;
+        let p = &sp.item;
         let tier_icon = match p.tier {
             Tier::Session => "📝",
             Tier::Project => "📁",

--- a/mur-core/src/cmd/search.rs
+++ b/mur-core/src/cmd/search.rs
@@ -130,7 +130,7 @@ async fn existing_pattern_search_names(query: &str) -> anyhow::Result<Vec<(Strin
     let scored = score_and_rank(query, patterns);
     let results = scored
         .into_iter()
-        .map(|sp| (sp.pattern.name.clone(), sp.score))
+        .map(|sp| (sp.item.name.clone(), sp.score))
         .collect();
     Ok(results)
 }

--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -978,7 +978,7 @@ pub(crate) async fn cmd_sync(quiet: bool, project_aware: bool, team: Option<&str
         if project_aware {
             let detected_lang = capture::starter::detect_language_name(&cwd);
             for sp in &mut scored {
-                let p = &sp.pattern;
+                let p = &sp.item;
                 // Boost patterns that explicitly list this project
                 if p.applies
                     .projects
@@ -1013,7 +1013,7 @@ pub(crate) async fn cmd_sync(quiet: bool, project_aware: bool, team: Option<&str
         let top: Vec<Pattern> = scored
             .into_iter()
             .take(target.max_patterns)
-            .map(|sp| sp.pattern)
+            .map(|sp| sp.item)
             .collect();
 
         if top.is_empty() {

--- a/mur-core/src/context_api/mod.rs
+++ b/mur-core/src/context_api/mod.rs
@@ -175,7 +175,7 @@ fn retrieve_with_config(
     let mut injection_ids = Vec::new();
 
     for sp in &scored {
-        let kind_str = match sp.pattern.effective_kind() {
+        let kind_str = match sp.item.effective_kind() {
             PatternKind::Technical => "technical",
             PatternKind::Preference => "preference",
             PatternKind::Fact => "fact",
@@ -183,13 +183,13 @@ fn retrieve_with_config(
             PatternKind::Behavioral => "behavioral",
         };
         response_patterns.push(ScoredPatternResponse {
-            name: sp.pattern.name.clone(),
-            description: sp.pattern.description.clone(),
+            name: sp.item.name.clone(),
+            description: sp.item.description.clone(),
             score: sp.score,
             kind: kind_str.to_string(),
         });
-        injection_ids.push(sp.pattern.name.clone());
-        format_patterns.push(sp.pattern.clone());
+        injection_ids.push(sp.item.name.clone());
+        format_patterns.push(sp.item.clone());
     }
 
     // Format within token budget

--- a/mur-core/src/interactive.rs
+++ b/mur-core/src/interactive.rs
@@ -512,7 +512,7 @@ pub fn explain_why(pattern: &Pattern, store: &YamlStore) -> Result<()> {
 
         if let Some(pos) = results
             .iter()
-            .position(|sp| sp.pattern.name == pattern.name)
+            .position(|sp| sp.item.name == pattern.name)
         {
             println!();
             println!(

--- a/mur-core/src/interactive.rs
+++ b/mur-core/src/interactive.rs
@@ -510,10 +510,7 @@ pub fn explain_why(pattern: &Pattern, store: &YamlStore) -> Result<()> {
         let total_candidates = all_patterns.len();
         let results: Vec<ScoredPattern> = score_and_rank(&query, all_patterns);
 
-        if let Some(pos) = results
-            .iter()
-            .position(|sp| sp.item.name == pattern.name)
-        {
+        if let Some(pos) = results.iter().position(|sp| sp.item.name == pattern.name) {
             println!();
             println!(
                 "  Combined rank: #{} of {} candidates (query: \"{}\")",

--- a/mur-core/src/retrieve/scoring.rs
+++ b/mur-core/src/retrieve/scoring.rs
@@ -998,6 +998,78 @@ mod tests {
     }
 
     #[test]
+    fn generic_scorer_works_for_non_pattern_retrievable() {
+        use super::Retrievable;
+        use chrono::{Duration, Utc};
+        use std::borrow::Cow;
+
+        struct FakeItem {
+            name: String,
+            description: String,
+            body: String,
+            importance: f64,
+        }
+        impl Retrievable for FakeItem {
+            fn name(&self) -> &str {
+                &self.name
+            }
+            fn description(&self) -> &str {
+                &self.description
+            }
+            fn text(&self) -> Cow<'_, str> {
+                Cow::Borrowed(&self.body)
+            }
+            fn tag_terms(&self) -> Vec<&str> {
+                vec![]
+            }
+            fn importance(&self) -> f64 {
+                self.importance
+            }
+            fn effectiveness(&self) -> f64 {
+                1.0
+            }
+            fn tier(&self) -> Tier {
+                Tier::Project
+            }
+            fn created_at(&self) -> chrono::DateTime<chrono::Utc> {
+                Utc::now() - Duration::days(1)
+            }
+            fn last_activity(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+                Some(Utc::now() - Duration::days(1))
+            }
+            fn decay_half_life_days(&self) -> f64 {
+                90.0
+            }
+            fn is_active(&self) -> bool {
+                true
+            }
+        }
+
+        let items = vec![FakeItem {
+            name: "fly-deploy".into(),
+            description: "Deploy to Fly.io".into(),
+            body: "Run fly deploy in the project root.".into(),
+            importance: 0.8,
+        }];
+
+        let scored = score_and_rank_inner(
+            &["fly", "deploy"],
+            items,
+            None,
+            None,
+            None,
+            |words, item: &FakeItem| keyword_relevance(words, item),
+        );
+
+        assert!(
+            !scored.is_empty(),
+            "fake item should be retrievable through the generic path"
+        );
+        assert_eq!(scored[0].item.name, "fly-deploy");
+        assert!(scored[0].score > 0.0);
+    }
+
+    #[test]
     fn pattern_adjust_score_preserves_scope_kind_lang_combination() {
         use super::Retrievable;
         let mut p = make_pattern("rust-error", "rust error body");

--- a/mur-core/src/retrieve/scoring.rs
+++ b/mur-core/src/retrieve/scoring.rs
@@ -1,5 +1,7 @@
 //! Multi-signal scoring pipeline for pattern retrieval.
 
+use std::borrow::Cow;
+
 use chrono::Utc;
 use mur_common::config::RetrievalConfig;
 use mur_common::pattern::{Origin, Pattern, PatternKind, Tier};
@@ -14,6 +16,85 @@ pub struct ScopeContext {
     pub platform: Option<String>,
     /// The task description — used to detect task-type queries for Procedure boost.
     pub task: Option<String>,
+}
+
+/// A retrievable knowledge item. The hybrid scorer is generic over this trait so
+/// `Pattern`, `Skill`, and (later) `Note` share one scoring pipeline.
+///
+/// Default `adjust_score` is the identity; `Pattern` overrides it to apply
+/// scope/language/kind boosts so existing Pattern behavior is preserved exactly.
+pub trait Retrievable {
+    fn name(&self) -> &str;
+    fn description(&self) -> &str;
+    fn text(&self) -> Cow<'_, str>;
+    fn tag_terms(&self) -> Vec<&str>;
+    fn importance(&self) -> f64;
+    fn effectiveness(&self) -> f64;
+    fn tier(&self) -> Tier;
+    fn created_at(&self) -> chrono::DateTime<chrono::Utc>;
+    fn last_activity(&self) -> Option<chrono::DateTime<chrono::Utc>>;
+    fn decay_half_life_days(&self) -> f64;
+    /// Filter predicate: items where this returns false are dropped before scoring.
+    fn is_active(&self) -> bool;
+
+    /// Hook for item-specific score adjustment. Default: identity.
+    /// Pattern overrides to apply `scope_mult`, `kind_score_boost`, `lang_mult`.
+    fn adjust_score(
+        &self,
+        weighted_sum: f64,
+        _query_words: &[&str],
+        _scope: Option<&ScopeContext>,
+        _project_language: Option<&str>,
+    ) -> f64 {
+        weighted_sum
+    }
+}
+
+impl Retrievable for Pattern {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn description(&self) -> &str {
+        &self.description
+    }
+    fn text(&self) -> Cow<'_, str> {
+        self.content.as_text()
+    }
+    fn tag_terms(&self) -> Vec<&str> {
+        self.tags
+            .topics
+            .iter()
+            .chain(self.tags.languages.iter())
+            .map(String::as_str)
+            .collect()
+    }
+    fn importance(&self) -> f64 {
+        self.importance
+    }
+    fn effectiveness(&self) -> f64 {
+        self.evidence.effectiveness()
+    }
+    fn tier(&self) -> Tier {
+        self.tier
+    }
+    fn created_at(&self) -> chrono::DateTime<chrono::Utc> {
+        self.created_at
+    }
+    fn last_activity(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.lifecycle
+            .last_injected
+            .or(self.evidence.last_validated)
+    }
+    fn decay_half_life_days(&self) -> f64 {
+        self.lifecycle
+            .decay_half_life
+            .unwrap_or_else(|| self.tier.decay_half_life_days()) as f64
+    }
+    fn is_active(&self) -> bool {
+        !self.lifecycle.muted
+            && self.lifecycle.status == mur_common::pattern::LifecycleStatus::Active
+    }
+    // adjust_score implemented in Task 5 (currently inherits identity default)
 }
 
 /// A pattern with its computed relevance score.
@@ -917,5 +998,20 @@ mod tests {
         let weights = std::collections::HashMap::new();
         let out = score_sources(hits, &weights);
         assert_eq!(out[0].external_id, "new");
+    }
+
+    #[test]
+    fn pattern_implements_retrievable_with_expected_accessors() {
+        use super::Retrievable;
+        let p = make_pattern("alpha", "alpha body");
+        assert_eq!(p.name(), "alpha");
+        assert_eq!(p.description(), p.description.as_str());
+        assert_eq!(&*p.text(), &*p.content.as_text());
+        assert_eq!(p.importance(), p.importance);
+        assert_eq!(p.effectiveness(), p.evidence.effectiveness());
+        assert_eq!(p.tier(), p.tier);
+        assert_eq!(p.created_at(), p.created_at);
+        assert!(p.is_active());
+        assert_eq!(p.decay_half_life_days(), p.tier.decay_half_life_days() as f64);
     }
 }

--- a/mur-core/src/retrieve/scoring.rs
+++ b/mur-core/src/retrieve/scoring.rs
@@ -117,11 +117,7 @@ impl Retrievable for Pattern {
                     .languages
                     .iter()
                     .any(|l| l.to_lowercase() == proj_lang_lower);
-                if matches {
-                    1.2
-                } else {
-                    0.05
-                }
+                if matches { 1.2 } else { 0.05 }
             } else {
                 1.0
             }
@@ -1130,6 +1126,9 @@ mod tests {
         assert_eq!(p.tier(), p.tier);
         assert_eq!(p.created_at(), p.created_at);
         assert!(p.is_active());
-        assert_eq!(p.decay_half_life_days(), p.tier.decay_half_life_days() as f64);
+        assert_eq!(
+            p.decay_half_life_days(),
+            p.tier.decay_half_life_days() as f64
+        );
     }
 }

--- a/mur-core/src/retrieve/scoring.rs
+++ b/mur-core/src/retrieve/scoring.rs
@@ -281,75 +281,46 @@ pub fn score_and_rank_with_scope_and_config(
 }
 
 /// Shared scoring logic: filter, score with a relevance function, sort, and budget-limit.
-fn score_and_rank_inner<F>(
+/// Generic over T: Retrievable so Pattern, Skill, and Note share one pipeline.
+fn score_and_rank_inner<T, F>(
     query_words: &[&str],
-    candidates: Vec<Pattern>,
+    candidates: Vec<T>,
     scope: Option<&ScopeContext>,
     project_language: Option<&str>,
     config: Option<&RetrievalConfig>,
     relevance_fn: F,
-) -> Vec<ScoredPattern>
+) -> Vec<Scored<T>>
 where
-    F: Fn(&[&str], &Pattern) -> f64,
+    T: Retrievable,
+    F: Fn(&[&str], &T) -> f64,
 {
     let score_floor = config.map_or(SCORE_FLOOR, |c| c.min_score);
     let max_patterns = config.map_or(MAX_PATTERNS, |c| c.max_patterns);
     let max_tokens = config.map_or(MAX_TOKENS, |c| c.max_tokens);
 
-    let mut scored: Vec<ScoredPattern> = candidates
+    let mut scored: Vec<Scored<T>> = candidates
         .into_iter()
-        .filter(|p| !p.lifecycle.muted)
-        .filter(|p| p.lifecycle.status == mur_common::pattern::LifecycleStatus::Active)
-        .map(|p| {
-            let relevance = relevance_fn(query_words, &p);
-            let recency = recency_score(&p);
-            let effectiveness = p.evidence.effectiveness();
-            let importance = p.importance;
-            let time_decay = time_decay_score(&p);
-            let content_len = p.content.as_text().len();
+        .filter(Retrievable::is_active)
+        .map(|item| {
+            let relevance = relevance_fn(query_words, &item);
+            let recency = recency_score_for(&item);
+            let effectiveness = item.effectiveness();
+            let importance = item.importance();
+            let time_decay = time_decay_score_for(&item);
+            let content_len = item.text().len();
             let length_norm = length_norm_score_from_len(content_len);
 
-            let scope_mult = if p.applies.projects.is_empty()
-                && p.applies.languages.is_empty()
-                && p.applies.tools.is_empty()
-            {
-                0.7
-            } else {
-                1.0
-            };
-
-            // Language mismatch penalty: if pattern specifies languages that
-            // don't match the current project, heavily penalize
-            let lang_mult = if let Some(proj_lang) = project_language {
-                if !p.applies.languages.is_empty() {
-                    let proj_lang_lower = proj_lang.to_lowercase();
-                    let matches = p
-                        .applies
-                        .languages
-                        .iter()
-                        .any(|l| l.to_lowercase() == proj_lang_lower);
-                    if matches { 1.2 } else { 0.05 }
-                } else {
-                    1.0 // pattern has no language restriction, neutral
-                }
-            } else {
-                1.0 // no project language detected, neutral
-            };
-
-            let base_score = (relevance * W_RELEVANCE
+            let weighted_sum = relevance * W_RELEVANCE
                 + recency * W_RECENCY
                 + effectiveness * W_EFFECTIVENESS
                 + importance * W_IMPORTANCE
                 + time_decay * W_TIME_DECAY
-                + length_norm * W_LENGTH_NORM)
-                * scope_mult;
+                + length_norm * W_LENGTH_NORM;
 
-            // Kind-aware boost: scope-aware preference/procedure boost
-            let kind_boost = kind_score_boost(&p, query_words, scope);
-            let score = (base_score + kind_boost) * lang_mult;
+            let score = item.adjust_score(weighted_sum, query_words, scope, project_language);
 
             Scored {
-                item: p,
+                item,
                 score,
                 relevance,
             }
@@ -357,11 +328,11 @@ where
         .filter(|sp| sp.score >= score_floor)
         .collect();
 
-    // Sort by score descending, with tier priority as tiebreaker
+    // Sort by score descending, with tier priority as tiebreaker.
     scored.sort_by(|a, b| {
         let score_diff = (a.score - b.score).abs();
         if score_diff < 0.05 {
-            tier_priority(&b.item.tier).cmp(&tier_priority(&a.item.tier))
+            tier_priority(&b.item.tier()).cmp(&tier_priority(&a.item.tier()))
         } else {
             b.score
                 .partial_cmp(&a.score)
@@ -369,21 +340,20 @@ where
         }
     });
 
-    // Budget: max patterns and max tokens
+    // Budget: max items and max tokens.
     let mut result = Vec::new();
     let mut token_count = 0;
     for sp in scored {
         if result.len() >= max_patterns {
             break;
         }
-        let est_tokens = sp.item.content.as_text().len() / 4;
+        let est_tokens = sp.item.text().len() / 4;
         if token_count + est_tokens > max_tokens && !result.is_empty() {
             break;
         }
         token_count += est_tokens;
         result.push(sp);
     }
-
     result
 }
 
@@ -414,12 +384,12 @@ impl LowerCache {
 }
 
 /// Keyword-based relevance (Phase 1, replaced by vector search in Phase 2).
-fn keyword_relevance(query_words: &[&str], pattern: &Pattern) -> f64 {
+fn keyword_relevance<T: Retrievable + ?Sized>(query_words: &[&str], item: &T) -> f64 {
     if query_words.is_empty() {
         return 0.0;
     }
 
-    let cache = LowerCache::from_item(pattern);
+    let cache = LowerCache::from_item(item);
     keyword_relevance_cached(query_words, &cache)
 }
 
@@ -469,15 +439,6 @@ fn time_decay_score_for<T: Retrievable + ?Sized>(item: &T) -> f64 {
     let last = item.last_activity().unwrap_or_else(|| item.created_at());
     let days = (Utc::now() - last).num_days().max(0) as f64;
     0.5 + 0.5 * (-days / half_life).exp()
-}
-
-// Pattern-typed shims preserved for the existing inner-scoring call sites;
-// removed in Task 6 when score_and_rank_inner becomes generic.
-fn recency_score(pattern: &Pattern) -> f64 {
-    recency_score_for(pattern)
-}
-fn time_decay_score(pattern: &Pattern) -> f64 {
-    time_decay_score_for(pattern)
 }
 
 /// Length normalization: 1 / (1 + 0.5 * log2(len / 500))
@@ -781,7 +742,7 @@ mod tests {
     fn test_recency_score_recent_is_high() {
         let p = make_pattern("recent", "content");
         // make_pattern sets last_injected to now, so recency should be ~1.0
-        let score = recency_score(&p);
+        let score = recency_score_for(&p);
         assert!(
             score > 0.9,
             "Recently injected pattern should have high recency, got {}",
@@ -794,7 +755,7 @@ mod tests {
         let mut p = make_pattern("old", "content");
         p.lifecycle.last_injected = Some(Utc::now() - chrono::Duration::days(60));
         p.evidence.last_validated = None;
-        let score = recency_score(&p);
+        let score = recency_score_for(&p);
         assert!(
             score < 0.1,
             "60-day-old pattern should have low recency, got {}",

--- a/mur-core/src/retrieve/scoring.rs
+++ b/mur-core/src/retrieve/scoring.rs
@@ -97,13 +97,17 @@ impl Retrievable for Pattern {
     // adjust_score implemented in Task 5 (currently inherits identity default)
 }
 
-/// A pattern with its computed relevance score.
+/// A retrieved item with its computed relevance score.
 #[derive(Debug, Clone)]
-pub struct ScoredPattern {
-    pub pattern: Pattern,
+pub struct Scored<T> {
+    pub item: T,
     pub score: f64,
     pub relevance: f64,
 }
+
+/// Backward-compatible alias for existing call sites.
+/// New code should prefer `Scored<T>`.
+pub type ScoredPattern = Scored<Pattern>;
 
 /// Scoring weights (from PLAN.md)
 const W_RELEVANCE: f64 = 0.45;
@@ -308,8 +312,8 @@ where
             let kind_boost = kind_score_boost(&p, query_words, scope);
             let score = (base_score + kind_boost) * lang_mult;
 
-            ScoredPattern {
-                pattern: p,
+            Scored {
+                item: p,
                 score,
                 relevance,
             }
@@ -321,7 +325,7 @@ where
     scored.sort_by(|a, b| {
         let score_diff = (a.score - b.score).abs();
         if score_diff < 0.05 {
-            tier_priority(&b.pattern.tier).cmp(&tier_priority(&a.pattern.tier))
+            tier_priority(&b.item.tier).cmp(&tier_priority(&a.item.tier))
         } else {
             b.score
                 .partial_cmp(&a.score)
@@ -336,7 +340,7 @@ where
         if result.len() >= max_patterns {
             break;
         }
-        let est_tokens = sp.pattern.content.as_text().len() / 4;
+        let est_tokens = sp.item.content.as_text().len() / 4;
         if token_count + est_tokens > max_tokens && !result.is_empty() {
             break;
         }
@@ -619,7 +623,7 @@ mod tests {
         let p2 = make_pattern("rust-error-handling", "Use anyhow for Rust error handling");
         let results = score_and_rank("swift testing", vec![p1, p2]);
         assert!(!results.is_empty());
-        assert_eq!(results[0].pattern.name, "swift-testing");
+        assert_eq!(results[0].item.name, "swift-testing");
     }
 
     #[test]
@@ -703,7 +707,7 @@ mod tests {
         let results = score_and_rank("rust error", vec![p_name, p_content]);
         if results.len() >= 2 {
             assert_eq!(
-                results[0].pattern.name, "rust-error",
+                results[0].item.name, "rust-error",
                 "Name match should rank higher"
             );
         }
@@ -773,7 +777,7 @@ mod tests {
 
         let results = score_and_rank_hybrid("swift testing", vec![p1, p2], &vector_scores);
         assert!(!results.is_empty());
-        assert_eq!(results[0].pattern.name, "swift-testing");
+        assert_eq!(results[0].item.name, "swift-testing");
     }
 
     #[test]
@@ -793,7 +797,7 @@ mod tests {
         // Total token estimate should stay under MAX_TOKENS
         let total_tokens: usize = results
             .iter()
-            .map(|sp| sp.pattern.content.as_text().len() / 4)
+            .map(|sp| sp.item.content.as_text().len() / 4)
             .sum();
         assert!(
             total_tokens <= MAX_TOKENS || results.len() == 1,
@@ -815,8 +819,8 @@ mod tests {
         let results = score_and_rank("rust error", vec![p_session, p_core]);
         if results.len() >= 2 {
             // Core should be preferred as tiebreaker
-            let first_tier = &results[0].pattern.tier;
-            let second_tier = &results[1].pattern.tier;
+            let first_tier = &results[0].item.tier;
+            let second_tier = &results[1].item.tier;
             let score_diff = (results[0].score - results[1].score).abs();
             if score_diff < 0.05 {
                 assert_eq!(
@@ -994,6 +998,19 @@ mod tests {
         let weights = std::collections::HashMap::new();
         let out = score_sources(hits, &weights);
         assert_eq!(out[0].external_id, "new");
+    }
+
+    #[test]
+    fn scored_pattern_is_alias_of_scored_pattern_generic() {
+        fn _accepts_alias(_: ScoredPattern) {}
+        fn _accepts_generic(_: Scored<Pattern>) {}
+        let p = make_pattern("alpha", "alpha body");
+        let s: Scored<Pattern> = Scored {
+            item: p,
+            score: 1.0,
+            relevance: 1.0,
+        };
+        _accepts_alias(s);
     }
 
     #[test]

--- a/mur-core/src/retrieve/scoring.rs
+++ b/mur-core/src/retrieve/scoring.rs
@@ -94,7 +94,43 @@ impl Retrievable for Pattern {
         !self.lifecycle.muted
             && self.lifecycle.status == mur_common::pattern::LifecycleStatus::Active
     }
-    // adjust_score implemented in Task 5 (currently inherits identity default)
+    fn adjust_score(
+        &self,
+        weighted_sum: f64,
+        query_words: &[&str],
+        scope: Option<&ScopeContext>,
+        project_language: Option<&str>,
+    ) -> f64 {
+        let scope_mult = if self.applies.projects.is_empty()
+            && self.applies.languages.is_empty()
+            && self.applies.tools.is_empty()
+        {
+            0.7
+        } else {
+            1.0
+        };
+        let lang_mult = if let Some(proj_lang) = project_language {
+            if !self.applies.languages.is_empty() {
+                let proj_lang_lower = proj_lang.to_lowercase();
+                let matches = self
+                    .applies
+                    .languages
+                    .iter()
+                    .any(|l| l.to_lowercase() == proj_lang_lower);
+                if matches {
+                    1.2
+                } else {
+                    0.05
+                }
+            } else {
+                1.0
+            }
+        } else {
+            1.0
+        };
+        let kind_boost = kind_score_boost(self, query_words, scope);
+        (weighted_sum * scope_mult + kind_boost) * lang_mult
+    }
 }
 
 /// A retrieved item with its computed relevance score.
@@ -998,6 +1034,22 @@ mod tests {
         let weights = std::collections::HashMap::new();
         let out = score_sources(hits, &weights);
         assert_eq!(out[0].external_id, "new");
+    }
+
+    #[test]
+    fn pattern_adjust_score_preserves_scope_kind_lang_combination() {
+        use super::Retrievable;
+        let mut p = make_pattern("rust-error", "rust error body");
+        p.applies.languages = vec!["rust".into()];
+        let query_words = ["rust", "error"];
+        let scope = ScopeContext {
+            user: None,
+            platform: None,
+            task: None,
+        };
+        let weighted_sum = 0.42;
+        let adjusted = p.adjust_score(weighted_sum, &query_words, Some(&scope), Some("rust"));
+        assert!((adjusted - (0.42 * 1.0 + 0.0) * 1.2).abs() < 1e-9);
     }
 
     #[test]

--- a/mur-core/src/retrieve/scoring.rs
+++ b/mur-core/src/retrieve/scoring.rs
@@ -416,30 +416,28 @@ fn keyword_relevance_cached(query_words: &[&str], cache: &LowerCache) -> f64 {
     }
 }
 
-/// Recency score: exp(-days / 14)
-fn recency_score(pattern: &Pattern) -> f64 {
-    let last = pattern
-        .lifecycle
-        .last_injected
-        .or(pattern.evidence.last_validated)
-        .unwrap_or(pattern.created_at);
+/// Recency score: exp(-days / 14). Generic over Retrievable.
+fn recency_score_for<T: Retrievable + ?Sized>(item: &T) -> f64 {
+    let last = item.last_activity().unwrap_or_else(|| item.created_at());
     let days = (Utc::now() - last).num_days().max(0) as f64;
     (-days / 14.0).exp()
 }
 
-/// Time decay: 0.5 + 0.5 * exp(-days / half_life)
-fn time_decay_score(pattern: &Pattern) -> f64 {
-    let half_life = pattern
-        .lifecycle
-        .decay_half_life
-        .unwrap_or_else(|| pattern.tier.decay_half_life_days()) as f64;
-    let last = pattern
-        .lifecycle
-        .last_injected
-        .or(pattern.evidence.last_validated)
-        .unwrap_or(pattern.created_at);
+/// Time decay: 0.5 + 0.5 * exp(-days / half_life). Generic over Retrievable.
+fn time_decay_score_for<T: Retrievable + ?Sized>(item: &T) -> f64 {
+    let half_life = item.decay_half_life_days();
+    let last = item.last_activity().unwrap_or_else(|| item.created_at());
     let days = (Utc::now() - last).num_days().max(0) as f64;
     0.5 + 0.5 * (-days / half_life).exp()
+}
+
+// Pattern-typed shims preserved for the existing inner-scoring call sites;
+// removed in Task 6 when score_and_rank_inner becomes generic.
+fn recency_score(pattern: &Pattern) -> f64 {
+    recency_score_for(pattern)
+}
+fn time_decay_score(pattern: &Pattern) -> f64 {
+    time_decay_score_for(pattern)
 }
 
 /// Length normalization: 1 / (1 + 0.5 * log2(len / 500))
@@ -996,6 +994,17 @@ mod tests {
         let weights = std::collections::HashMap::new();
         let out = score_sources(hits, &weights);
         assert_eq!(out[0].external_id, "new");
+    }
+
+    #[test]
+    fn recency_and_decay_use_retrievable_accessors() {
+        use chrono::{Duration, Utc};
+        let mut p = make_pattern("alpha", "alpha body");
+        p.lifecycle.last_injected = Some(Utc::now() - Duration::days(1));
+        let r_generic = recency_score_for(&p as &dyn Retrievable);
+        let d_generic = time_decay_score_for(&p as &dyn Retrievable);
+        assert!((r_generic - 0.93_f64).abs() < 0.02);
+        assert!(d_generic > 0.5 && d_generic <= 1.0);
     }
 
     #[test]

--- a/mur-core/src/retrieve/scoring.rs
+++ b/mur-core/src/retrieve/scoring.rs
@@ -357,19 +357,17 @@ struct LowerCache {
 }
 
 impl LowerCache {
-    fn from_pattern(pattern: &Pattern) -> Self {
-        let tags_text: String = pattern
-            .tags
-            .topics
+    fn from_item<T: Retrievable + ?Sized>(item: &T) -> Self {
+        let tags_text: String = item
+            .tag_terms()
             .iter()
-            .chain(pattern.tags.languages.iter())
             .map(|t| t.to_lowercase())
             .collect::<Vec<_>>()
             .join(" ");
         Self {
-            name: pattern.name.to_lowercase(),
-            description: pattern.description.to_lowercase(),
-            content: pattern.content.as_text().to_lowercase(),
+            name: item.name().to_lowercase(),
+            description: item.description().to_lowercase(),
+            content: item.text().to_lowercase(),
             tags_text,
         }
     }
@@ -381,7 +379,7 @@ fn keyword_relevance(query_words: &[&str], pattern: &Pattern) -> f64 {
         return 0.0;
     }
 
-    let cache = LowerCache::from_pattern(pattern);
+    let cache = LowerCache::from_item(pattern);
     keyword_relevance_cached(query_words, &cache)
 }
 
@@ -998,6 +996,15 @@ mod tests {
         let weights = std::collections::HashMap::new();
         let out = score_sources(hits, &weights);
         assert_eq!(out[0].external_id, "new");
+    }
+
+    #[test]
+    fn lower_cache_builds_from_retrievable_with_lowered_fields() {
+        let p = make_pattern("AlphaBeta", "AlphaBeta Body Content");
+        let cache = LowerCache::from_item(&p);
+        assert_eq!(cache.name, "alphabeta");
+        assert!(cache.description.chars().all(|c| !c.is_uppercase()));
+        assert!(cache.content.chars().all(|c| !c.is_uppercase()));
     }
 
     #[test]

--- a/mur-core/src/server/search.rs
+++ b/mur-core/src/server/search.rs
@@ -47,13 +47,13 @@ pub(super) async fn search_patterns(
         .into_iter()
         .take(req.limit)
         .map(|sp| SearchResult {
-            name: sp.pattern.name.clone(),
-            description: sp.pattern.description.clone(),
+            name: sp.item.name.clone(),
+            description: sp.item.description.clone(),
             score: sp.score,
             relevance: sp.relevance,
-            tier: format!("{:?}", sp.pattern.tier).to_lowercase(),
-            maturity: format!("{:?}", sp.pattern.maturity).to_lowercase(),
-            confidence: sp.pattern.confidence,
+            tier: format!("{:?}", sp.item.tier).to_lowercase(),
+            maturity: format!("{:?}", sp.item.maturity).to_lowercase(),
+            confidence: sp.item.confidence,
         })
         .collect();
 


### PR DESCRIPTION
## Summary
- Extract `Retrievable` trait in `scoring.rs` so `Pattern`, `Skill`, and (later) `Note` share one hybrid scoring pipeline
- Genericize `score_and_rank_inner<T: Retrievable>`, `LowerCache::from_item`, `recency_score_for`, `time_decay_score_for`
- Introduce `Scored<T>` with `pub type ScoredPattern = Scored<Pattern>` — all external call sites compile unchanged
- Pattern-specific boosts (`scope_mult`, `lang_mult`, `kind_score_boost`) moved into `Pattern::adjust_score`
- 6 new tests including a `FakeItem` impl proving the generic path works for non-Pattern types

## Files changed
- **`mur-core/src/retrieve/scoring.rs`** — trait + generic inner + `Scored<T>` (core changes)
- **10 external files** — `.pattern` → `.item` renames only, no logic changes

## Behavior
**Zero behavior change** for the Pattern path. All 24 existing retrieve tests + 6 new tests pass. Clean clippy, clean fmt.

Adding `impl Retrievable for Skill` is now a ~12-line block; `impl Retrievable for Note` likewise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)