### PR TITLE
feat(retrieve): Skill Retrievable impl — LoadedSkill, candidate loader, generic entry

### DIFF
--- a/mur-core/src/retrieve/mod.rs
+++ b/mur-core/src/retrieve/mod.rs
@@ -1,5 +1,6 @@
 pub mod gate;
 pub mod scoring;
+pub mod skill_candidates;
 
 // ---------- P1.3: sources retrieve (gated behind "sources" feature) ----------
 

--- a/mur-core/src/retrieve/scoring.rs
+++ b/mur-core/src/retrieve/scoring.rs
@@ -236,6 +236,27 @@ pub fn score_and_rank(query: &str, candidates: Vec<Pattern>) -> Vec<ScoredPatter
     score_and_rank_with_scope(query, candidates, None, None)
 }
 
+/// Public generic entry point: score and rank any `Vec<T>` where
+/// `T: Retrievable`. Keyword-only relevance, no scope, no project_language,
+/// default scoring config. Mirrors `score_and_rank` for the generic case.
+///
+/// Hybrid / scope-aware generic entries are added in later plans as needed.
+pub fn score_and_rank_generic<T: Retrievable>(
+    query: &str,
+    candidates: Vec<T>,
+) -> Vec<Scored<T>> {
+    let query_lower = query.to_lowercase();
+    let query_words: Vec<&str> = query_lower.split_whitespace().collect();
+    score_and_rank_inner(
+        &query_words,
+        candidates,
+        None,
+        None,
+        None,
+        |words, item: &T| keyword_relevance(words, item),
+    )
+}
+
 /// Score with keyword-only relevance, using config-driven retrieval parameters.
 pub fn score_and_rank_with_config(
     query: &str,
@@ -1130,5 +1151,18 @@ mod tests {
             p.decay_half_life_days(),
             p.tier.decay_half_life_days() as f64
         );
+    }
+
+    #[test]
+    fn score_and_rank_generic_ranks_pattern_corpus_like_score_and_rank() {
+        let p1 = make_pattern("alpha", "alpha body about deploy");
+        let p2 = make_pattern("beta", "beta body about something else");
+        let generic = score_and_rank_generic("alpha deploy", vec![p1.clone(), p2.clone()]);
+        let legacy = score_and_rank("alpha deploy", vec![p1, p2]);
+        assert_eq!(generic.len(), legacy.len());
+        for (g, l) in generic.iter().zip(legacy.iter()) {
+            assert_eq!(g.item.name, l.item.name);
+            assert!((g.score - l.score).abs() < 1e-9);
+        }
     }
 }

--- a/mur-core/src/retrieve/scoring.rs
+++ b/mur-core/src/retrieve/scoring.rs
@@ -241,10 +241,8 @@ pub fn score_and_rank(query: &str, candidates: Vec<Pattern>) -> Vec<ScoredPatter
 /// default scoring config. Mirrors `score_and_rank` for the generic case.
 ///
 /// Hybrid / scope-aware generic entries are added in later plans as needed.
-pub fn score_and_rank_generic<T: Retrievable>(
-    query: &str,
-    candidates: Vec<T>,
-) -> Vec<Scored<T>> {
+#[allow(dead_code)]
+pub fn score_and_rank_generic<T: Retrievable>(query: &str, candidates: Vec<T>) -> Vec<Scored<T>> {
     let query_lower = query.to_lowercase();
     let query_words: Vec<&str> = query_lower.split_whitespace().collect();
     score_and_rank_inner(

--- a/mur-core/src/retrieve/skill_candidates.rs
+++ b/mur-core/src/retrieve/skill_candidates.rs
@@ -1,0 +1,198 @@
+//! Loaded skills (manifest + stats) and their `Retrievable` impl, so the
+//! generic scorer in `super::scoring` can rank skills.
+
+use std::path::Path;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use mur_common::pattern::Tier;
+use mur_common::skill::manifest::SkillManifest;
+use mur_common::skill::stats::{LifecycleState, SkillStats};
+use mur_common::skill::types::Priority;
+
+use super::scoring::{Retrievable, ScopeContext};
+
+/// A skill loaded together with its runtime stats. The retrieval pipeline
+/// scores `Vec<LoadedSkill>` through the generic `score_and_rank_inner`.
+#[derive(Debug, Clone)]
+pub struct LoadedSkill {
+    pub manifest: SkillManifest,
+    pub stats: SkillStats,
+}
+
+fn priority_to_tier(p: Priority) -> Tier {
+    match p {
+        Priority::Critical => Tier::Core,
+        Priority::High | Priority::Normal => Tier::Project,
+        Priority::Low => Tier::Session,
+    }
+}
+
+fn priority_to_importance(p: Priority) -> f64 {
+    match p {
+        Priority::Critical => 1.0,
+        Priority::High => 0.8,
+        Priority::Normal => 0.5,
+        Priority::Low => 0.3,
+    }
+}
+
+impl Retrievable for LoadedSkill {
+    fn name(&self) -> &str {
+        &self.manifest.name
+    }
+
+    fn description(&self) -> &str {
+        &self.manifest.description
+    }
+
+    fn text(&self) -> std::borrow::Cow<'_, str> {
+        // Pre-Note skills: abstract + description is the keyword/embed surface.
+        // Extended once ContentMode::Note (separate plan) lands.
+        std::borrow::Cow::Owned(format!(
+            "{}\n{}",
+            self.manifest.content.r#abstract, self.manifest.description
+        ))
+    }
+
+    fn tag_terms(&self) -> Vec<&str> {
+        self.manifest.tags.iter().map(String::as_str).collect()
+    }
+
+    fn importance(&self) -> f64 {
+        priority_to_importance(self.manifest.priority)
+    }
+
+    fn effectiveness(&self) -> f64 {
+        if self.stats.usage_count == 0 {
+            0.0
+        } else {
+            self.stats.success_count as f64 / self.stats.usage_count as f64
+        }
+    }
+
+    fn tier(&self) -> Tier {
+        priority_to_tier(self.manifest.priority)
+    }
+
+    fn created_at(&self) -> DateTime<Utc> {
+        // Manifest has no created_at; use the earliest stats anchor we have.
+        self.stats
+            .first_successful_use_at
+            .unwrap_or(self.stats.lifecycle_changed_at)
+    }
+
+    fn last_activity(&self) -> Option<DateTime<Utc>> {
+        self.stats.last_success_at
+    }
+
+    fn decay_half_life_days(&self) -> f64 {
+        self.tier().decay_half_life_days() as f64
+    }
+
+    fn is_active(&self) -> bool {
+        !matches!(
+            self.stats.lifecycle_state,
+            LifecycleState::Deprecated | LifecycleState::Archived
+        )
+    }
+
+    // adjust_score uses the trait default (identity) — skills have no
+    // Pattern-specific scope/lang/kind boosts.
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use mur_common::skill::manifest::Content;
+    use mur_common::skill::types::Category;
+
+    fn fake_loaded(name: &str, priority: Priority) -> LoadedSkill {
+        let manifest = SkillManifest {
+            name: name.into(),
+            version: "1.0.0".into(),
+            publisher: "human:test".into(),
+            description: format!("desc for {name}"),
+            category: Category::Context,
+            hosts: vec![],
+            content: Content {
+                r#abstract: format!("abstract about {name}"),
+                context: Some(format!("body of {name}")),
+                procedure: None,
+                command: None,
+            },
+            requires: vec![],
+            tags: vec!["alpha".into(), "beta".into()],
+            triggers: vec![],
+            priority,
+            evolution_log: vec![],
+            transfer_chain: vec![],
+            mcp_requirements: vec![],
+        };
+        let mut stats = SkillStats::new(name, "1.0.0", "", Utc::now() - Duration::days(2));
+        stats.usage_count = 4;
+        stats.success_count = 3;
+        stats.last_success_at = Some(Utc::now() - Duration::days(1));
+        stats.first_successful_use_at = Some(Utc::now() - Duration::days(2));
+        LoadedSkill { manifest, stats }
+    }
+
+    #[test]
+    fn retrievable_accessors_reflect_manifest_and_stats() {
+        let s = fake_loaded("alpha-skill", Priority::High);
+        assert_eq!(s.name(), "alpha-skill");
+        assert_eq!(s.description(), "desc for alpha-skill");
+        assert_eq!(&*s.text(), "abstract about alpha-skill\ndesc for alpha-skill");
+        assert_eq!(s.tag_terms(), vec!["alpha", "beta"]);
+        assert_eq!(s.importance(), 0.8);
+        assert_eq!(s.tier(), Tier::Project);
+        assert!((s.effectiveness() - 0.75).abs() < 1e-9);
+        assert!(s.is_active());
+        assert_eq!(s.decay_half_life_days(), Tier::Project.decay_half_life_days() as f64);
+        assert_eq!(s.last_activity(), s.stats.last_success_at);
+    }
+
+    #[test]
+    fn priority_critical_maps_to_core_tier_and_importance_one() {
+        let s = fake_loaded("k", Priority::Critical);
+        assert_eq!(s.tier(), Tier::Core);
+        assert_eq!(s.importance(), 1.0);
+    }
+
+    #[test]
+    fn priority_low_maps_to_session_tier_and_importance_zero_three() {
+        let s = fake_loaded("k", Priority::Low);
+        assert_eq!(s.tier(), Tier::Session);
+        assert!((s.importance() - 0.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn effectiveness_is_zero_when_usage_count_is_zero() {
+        let mut s = fake_loaded("k", Priority::Normal);
+        s.stats.usage_count = 0;
+        s.stats.success_count = 0;
+        assert_eq!(s.effectiveness(), 0.0);
+    }
+
+    #[test]
+    fn deprecated_skill_is_not_active() {
+        let mut s = fake_loaded("k", Priority::Normal);
+        s.stats.lifecycle_state = LifecycleState::Deprecated;
+        assert!(!s.is_active());
+    }
+
+    #[test]
+    fn archived_skill_is_not_active() {
+        let mut s = fake_loaded("k", Priority::Normal);
+        s.stats.lifecycle_state = LifecycleState::Archived;
+        assert!(!s.is_active());
+    }
+
+    #[test]
+    fn adjust_score_is_identity_for_skills() {
+        let s = fake_loaded("k", Priority::Normal);
+        let scope = ScopeContext::default();
+        assert_eq!(s.adjust_score(0.42, &["q"], Some(&scope), Some("rust")), 0.42);
+    }
+}

--- a/mur-core/src/retrieve/skill_candidates.rs
+++ b/mur-core/src/retrieve/skill_candidates.rs
@@ -10,7 +10,7 @@ use mur_common::skill::manifest::SkillManifest;
 use mur_common::skill::stats::{LifecycleState, SkillStats};
 use mur_common::skill::types::Priority;
 
-use super::scoring::{Retrievable, ScopeContext};
+use super::scoring::Retrievable;
 
 /// A skill loaded together with its runtime stats. The retrieval pipeline
 /// scores `Vec<LoadedSkill>` through the generic `score_and_rank_inner`.
@@ -18,6 +18,61 @@ use super::scoring::{Retrievable, ScopeContext};
 pub struct LoadedSkill {
     pub manifest: SkillManifest,
     pub stats: SkillStats,
+}
+
+/// Scan `skills_dir` (typically `<mur_home>/skills/`) for skill directories
+/// and return a `LoadedSkill` for each parseable `skill.yaml`.
+///
+/// Malformed or missing manifests are skipped with a `tracing::warn` so a
+/// single bad skill never poisons the corpus. Stats are loaded via
+/// `SkillStats::path(mur_home, name)`; if absent, a fresh `SkillStats` is
+/// constructed so the skill still scores (with `usage_count = 0`).
+pub fn load_skill_candidates(skills_dir: &Path, mur_home: &Path) -> Result<Vec<LoadedSkill>> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(skills_dir) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(e) => return Err(e.into()),
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let yaml_path = path.join("skill.yaml");
+        if !yaml_path.is_file() {
+            continue;
+        }
+        let yaml = match std::fs::read_to_string(&yaml_path) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(path = %yaml_path.display(), error = %e, "read skill.yaml failed");
+                continue;
+            }
+        };
+        let manifest = match mur_common::skill::parser::parse_canonical(&yaml) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(path = %yaml_path.display(), error = %e, "parse skill.yaml failed");
+                continue;
+            }
+        };
+
+        let stats_path = SkillStats::path(mur_home, &manifest.name);
+        let stats = match SkillStats::load(&stats_path) {
+            Ok(Some(s)) => s,
+            Ok(None) => SkillStats::new(&manifest.name, &manifest.version, "", Utc::now()),
+            Err(e) => {
+                tracing::warn!(path = %stats_path.display(), error = %e, "load skill stats failed; using fresh");
+                SkillStats::new(&manifest.name, &manifest.version, "", Utc::now())
+            }
+        };
+
+        out.push(LoadedSkill { manifest, stats });
+    }
+
+    Ok(out)
 }
 
 fn priority_to_tier(p: Priority) -> Tier {
@@ -104,6 +159,7 @@ impl Retrievable for LoadedSkill {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::retrieve::scoring::ScopeContext;
     use chrono::Duration;
     use mur_common::skill::manifest::Content;
     use mur_common::skill::types::Category;
@@ -194,5 +250,70 @@ mod tests {
         let s = fake_loaded("k", Priority::Normal);
         let scope = ScopeContext::default();
         assert_eq!(s.adjust_score(0.42, &["q"], Some(&scope), Some("rust")), 0.42);
+    }
+
+    #[test]
+    fn load_skill_candidates_reads_two_well_formed_skills() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let skills_dir = tmp.path().join("skills");
+        let mur_home = tmp.path();
+
+        // Write two well-formed skill directories.
+        for name in ["alpha", "beta"] {
+            let dir = skills_dir.join(name);
+            fs::create_dir_all(&dir).unwrap();
+            let yaml = format!(
+                "name: {name}\nversion: 1.0.0\npublisher: human:test\n\
+                 description: desc for {name}\ncategory: context\n\
+                 content:\n  abstract: a\n  context: c\n"
+            );
+            fs::write(dir.join("skill.yaml"), yaml).unwrap();
+        }
+
+        let loaded = load_skill_candidates(&skills_dir, mur_home).unwrap();
+        let names: Vec<_> = loaded.iter().map(|s| s.name().to_string()).collect();
+        assert_eq!(names.len(), 2);
+        assert!(names.contains(&"alpha".to_string()));
+        assert!(names.contains(&"beta".to_string()));
+    }
+
+    #[test]
+    fn load_skill_candidates_skips_directories_without_skill_yaml() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let skills_dir = tmp.path().join("skills");
+        fs::create_dir_all(skills_dir.join("not-a-skill")).unwrap();
+
+        let loaded = load_skill_candidates(&skills_dir, tmp.path()).unwrap();
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn load_skill_candidates_skips_malformed_yaml_with_warning() {
+        use std::fs;
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let skills_dir = tmp.path().join("skills");
+        fs::create_dir_all(skills_dir.join("broken")).unwrap();
+        fs::write(skills_dir.join("broken").join("skill.yaml"), "{ not valid yaml").unwrap();
+
+        // Loader must not propagate the parse error; return Ok(empty).
+        let loaded = load_skill_candidates(&skills_dir, tmp.path()).unwrap();
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn load_skill_candidates_returns_empty_if_skills_dir_missing() {
+        use tempfile::tempdir;
+        let tmp = tempdir().unwrap();
+        let skills_dir = tmp.path().join("does-not-exist");
+        let loaded = load_skill_candidates(&skills_dir, tmp.path()).unwrap();
+        assert!(loaded.is_empty());
     }
 }

--- a/mur-core/src/retrieve/skill_candidates.rs
+++ b/mur-core/src/retrieve/skill_candidates.rs
@@ -316,4 +316,51 @@ mod tests {
         let loaded = load_skill_candidates(&skills_dir, tmp.path()).unwrap();
         assert!(loaded.is_empty());
     }
+
+    #[test]
+    fn end_to_end_ranks_loaded_skills_via_generic_scorer() {
+        use crate::retrieve::scoring::score_and_rank_generic;
+        use std::fs;
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let skills_dir = tmp.path().join("skills");
+        let mur_home = tmp.path();
+
+        // alpha: matches query "deploy" in abstract and description.
+        fs::create_dir_all(skills_dir.join("deploy-fly")).unwrap();
+        fs::write(
+            skills_dir.join("deploy-fly").join("skill.yaml"),
+            "name: deploy-fly\nversion: 1.0.0\npublisher: human:test\n\
+             description: deploy to Fly.io\ncategory: context\n\
+             priority: high\ntags: [deploy, fly]\n\
+             content:\n  abstract: how to deploy a Rust app to Fly.io\n  context: details\n",
+        )
+        .unwrap();
+
+        // beta: unrelated keyword content.
+        fs::create_dir_all(skills_dir.join("brew-update")).unwrap();
+        fs::write(
+            skills_dir.join("brew-update").join("skill.yaml"),
+            "name: brew-update\nversion: 1.0.0\npublisher: human:test\n\
+             description: keep homebrew current\ncategory: context\n\
+             priority: normal\ntags: [brew, mac]\n\
+             content:\n  abstract: run brew update weekly\n  context: details\n",
+        )
+        .unwrap();
+
+        let candidates = load_skill_candidates(&skills_dir, mur_home).unwrap();
+        assert_eq!(candidates.len(), 2);
+
+        let ranked = score_and_rank_generic("deploy fly rust", candidates);
+        assert!(
+            !ranked.is_empty(),
+            "deploy query should rank at least the deploy-fly skill"
+        );
+        assert_eq!(ranked[0].item.name(), "deploy-fly");
+        // If brew-update made it past the score floor, it must rank below deploy-fly.
+        if ranked.len() > 1 {
+            assert!(ranked[0].score > ranked[1].score);
+        }
+    }
 }

--- a/mur-core/src/retrieve/skill_candidates.rs
+++ b/mur-core/src/retrieve/skill_candidates.rs
@@ -15,6 +15,7 @@ use super::scoring::Retrievable;
 /// A skill loaded together with its runtime stats. The retrieval pipeline
 /// scores `Vec<LoadedSkill>` through the generic `score_and_rank_inner`.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct LoadedSkill {
     pub manifest: SkillManifest,
     pub stats: SkillStats,
@@ -27,6 +28,7 @@ pub struct LoadedSkill {
 /// single bad skill never poisons the corpus. Stats are loaded via
 /// `SkillStats::path(mur_home, name)`; if absent, a fresh `SkillStats` is
 /// constructed so the skill still scores (with `usage_count = 0`).
+#[allow(dead_code)]
 pub fn load_skill_candidates(skills_dir: &Path, mur_home: &Path) -> Result<Vec<LoadedSkill>> {
     let mut out = Vec::new();
     let entries = match std::fs::read_dir(skills_dir) {
@@ -75,6 +77,7 @@ pub fn load_skill_candidates(skills_dir: &Path, mur_home: &Path) -> Result<Vec<L
     Ok(out)
 }
 
+#[allow(dead_code)]
 fn priority_to_tier(p: Priority) -> Tier {
     match p {
         Priority::Critical => Tier::Core,
@@ -83,6 +86,7 @@ fn priority_to_tier(p: Priority) -> Tier {
     }
 }
 
+#[allow(dead_code)]
 fn priority_to_importance(p: Priority) -> f64 {
     match p {
         Priority::Critical => 1.0,
@@ -199,13 +203,19 @@ mod tests {
         let s = fake_loaded("alpha-skill", Priority::High);
         assert_eq!(s.name(), "alpha-skill");
         assert_eq!(s.description(), "desc for alpha-skill");
-        assert_eq!(&*s.text(), "abstract about alpha-skill\ndesc for alpha-skill");
+        assert_eq!(
+            &*s.text(),
+            "abstract about alpha-skill\ndesc for alpha-skill"
+        );
         assert_eq!(s.tag_terms(), vec!["alpha", "beta"]);
         assert_eq!(s.importance(), 0.8);
         assert_eq!(s.tier(), Tier::Project);
         assert!((s.effectiveness() - 0.75).abs() < 1e-9);
         assert!(s.is_active());
-        assert_eq!(s.decay_half_life_days(), Tier::Project.decay_half_life_days() as f64);
+        assert_eq!(
+            s.decay_half_life_days(),
+            Tier::Project.decay_half_life_days() as f64
+        );
         assert_eq!(s.last_activity(), s.stats.last_success_at);
     }
 
@@ -249,7 +259,10 @@ mod tests {
     fn adjust_score_is_identity_for_skills() {
         let s = fake_loaded("k", Priority::Normal);
         let scope = ScopeContext::default();
-        assert_eq!(s.adjust_score(0.42, &["q"], Some(&scope), Some("rust")), 0.42);
+        assert_eq!(
+            s.adjust_score(0.42, &["q"], Some(&scope), Some("rust")),
+            0.42
+        );
     }
 
     #[test]
@@ -301,7 +314,11 @@ mod tests {
         let tmp = tempdir().unwrap();
         let skills_dir = tmp.path().join("skills");
         fs::create_dir_all(skills_dir.join("broken")).unwrap();
-        fs::write(skills_dir.join("broken").join("skill.yaml"), "{ not valid yaml").unwrap();
+        fs::write(
+            skills_dir.join("broken").join("skill.yaml"),
+            "{ not valid yaml",
+        )
+        .unwrap();
 
         // Loader must not propagate the parse error; return Ok(empty).
         let loaded = load_skill_candidates(&skills_dir, tmp.path()).unwrap();


### PR DESCRIPTION
## Summary
- `LoadedSkill { manifest, stats }` with `impl Retrievable` — Priority→Tier/importance mapping, stats-driven effectiveness/activity/decay
- `load_skill_candidates(skills_dir, mur_home)` — corpus scanner, skips malformed/missing with `tracing::warn`
- `pub fn score_and_rank_generic<T: Retrievable>` — public generic entry point, mirrors `score_and_rank`
- 13 new tests + all 92 existing retrieve tests pass
- Validates the `Retrievable` trait against a real second consumer beyond `Pattern`

**Depends on:** #292 (feat/retrievable-trait-extraction) — stacked PR.

## Test Plan
- [x] `cargo test -p mur-core --lib -- "retrieve::"` — 92 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] After #292 merges, rebase this onto main and verify no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)