### PR TITLE
feat(skill): Note content mode — Category::Note, Content.note, validation, ranking

### DIFF
--- a/mur-common/src/skill/gene.rs
+++ b/mur-common/src/skill/gene.rs
@@ -255,6 +255,7 @@ mod tests {
                     steps,
                 }),
                 command: None,
+                note: None,
             },
             requires: vec![],
             tags: vec![],

--- a/mur-common/src/skill/manifest.rs
+++ b/mur-common/src/skill/manifest.rs
@@ -90,6 +90,11 @@ pub struct Content {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
+
+    /// Note mode (category: note): free markdown body, stored inline in the
+    /// canonical skill.yaml per the 1a storage decision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
 }
 
 impl Content {
@@ -98,10 +103,12 @@ impl Content {
             self.context.is_some(),
             self.procedure.is_some(),
             self.command.is_some(),
+            self.note.is_some(),
         ) {
-            (true, false, false) => Some(ContentMode::Context),
-            (false, true, false) => Some(ContentMode::Workflow),
-            (false, false, true) => Some(ContentMode::Command),
+            (true, false, false, false) => Some(ContentMode::Context),
+            (false, true, false, false) => Some(ContentMode::Workflow),
+            (false, false, true, false) => Some(ContentMode::Command),
+            (false, false, false, true) => Some(ContentMode::Note),
             _ => None,
         }
     }
@@ -224,6 +231,7 @@ priority: normal
             context: Some("ctx".into()),
             procedure: None,
             command: None,
+            note: None,
         };
         assert_eq!(c.mode(), Some(ContentMode::Context));
     }
@@ -235,6 +243,31 @@ priority: normal
             context: None,
             procedure: None,
             command: None,
+            note: None,
+        };
+        assert_eq!(c.mode(), None);
+    }
+
+    #[test]
+    fn mode_returns_note_when_only_note_populated() {
+        let c = Content {
+            r#abstract: "a".into(),
+            context: None,
+            procedure: None,
+            command: None,
+            note: Some("# body".into()),
+        };
+        assert_eq!(c.mode(), Some(ContentMode::Note));
+    }
+
+    #[test]
+    fn mode_returns_none_when_note_and_context_both_populated() {
+        let c = Content {
+            r#abstract: "a".into(),
+            context: Some("ctx".into()),
+            procedure: None,
+            command: None,
+            note: Some("# body".into()),
         };
         assert_eq!(c.mode(), None);
     }

--- a/mur-common/src/skill/types.rs
+++ b/mur-common/src/skill/types.rs
@@ -38,6 +38,7 @@ pub enum Category {
     Workflow,
     Command,
     Meta,
+    Note,
 }
 
 /// Exactly one content mode is populated; see spec §3.2.3.
@@ -47,6 +48,7 @@ pub enum ContentMode {
     Context,
     Workflow,
     Command,
+    Note,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -87,5 +89,21 @@ mod tests {
     #[test]
     fn host_id_default_is_all() {
         assert_eq!(HostId::default(), HostId::All);
+    }
+
+    #[test]
+    fn note_category_serialises_lowercase_and_roundtrips() {
+        let yaml = serde_yaml_ng::to_string(&Category::Note).unwrap();
+        assert_eq!(yaml.trim(), "note");
+        let parsed: Category = serde_yaml_ng::from_str("note").unwrap();
+        assert_eq!(parsed, Category::Note);
+    }
+
+    #[test]
+    fn note_content_mode_serialises_lowercase_and_roundtrips() {
+        let yaml = serde_yaml_ng::to_string(&ContentMode::Note).unwrap();
+        assert_eq!(yaml.trim(), "note");
+        let parsed: ContentMode = serde_yaml_ng::from_str("note").unwrap();
+        assert_eq!(parsed, ContentMode::Note);
     }
 }

--- a/mur-common/src/skill/validate.rs
+++ b/mur-common/src/skill/validate.rs
@@ -34,11 +34,11 @@ impl fmt::Display for ValidationError {
             ),
             NoContentMode => write!(
                 f,
-                "content must populate exactly one of: context / procedure / command"
+                "content must populate exactly one of: context / procedure / command / note"
             ),
             MultipleContentModes => write!(
                 f,
-                "content must populate only one of: context / procedure / command"
+                "content must populate only one of: context / procedure / command / note"
             ),
             ContentModeMismatch { category, mode } => {
                 write!(
@@ -71,6 +71,7 @@ pub fn validate(m: &SkillManifest) -> Result<(), ValidationError> {
             m.content.context.is_some(),
             m.content.procedure.is_some(),
             m.content.command.is_some(),
+            m.content.note.is_some(),
         ]
         .iter()
         .filter(|b| **b)
@@ -172,6 +173,7 @@ fn mode_matches_category(cat: Category, mode: ContentMode) -> bool {
             | (Category::Command, ContentMode::Command)
             | (Category::Context, ContentMode::Context)
             | (Category::Meta, ContentMode::Context)
+            | (Category::Note, ContentMode::Note)
     )
 }
 
@@ -351,5 +353,35 @@ triggers:
             validate(&m),
             Err(ValidationError::TriggerMissingPattern(TriggerKind::Command))
         ));
+    }
+
+    #[test]
+    fn valid_note_manifest_passes() {
+        let yaml = "name: rust-notes\nversion: 1.0.0\npublisher: human:test\n\
+                    category: note\ndescription: d\n\
+                    content:\n  abstract: a\n  note: |\n    # body\n";
+        let m = parse_canonical(yaml).unwrap();
+        assert!(validate(&m).is_ok());
+    }
+
+    #[test]
+    fn note_category_with_context_mode_is_mismatch() {
+        let yaml = "name: rust-notes\nversion: 1.0.0\npublisher: human:test\n\
+                    category: note\ndescription: d\n\
+                    content:\n  abstract: a\n  context: c\n";
+        let m = parse_canonical(yaml).unwrap();
+        assert!(matches!(
+            validate(&m),
+            Err(ValidationError::ContentModeMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn note_plus_command_is_multiple_modes() {
+        let yaml = "name: rust-notes\nversion: 1.0.0\npublisher: human:test\n\
+                    category: note\ndescription: d\n\
+                    content:\n  abstract: a\n  note: x\n  command: y\n";
+        let m = parse_canonical(yaml).unwrap();
+        assert!(matches!(validate(&m), Err(ValidationError::MultipleContentModes)));
     }
 }

--- a/mur-common/src/skill/validate.rs
+++ b/mur-common/src/skill/validate.rs
@@ -382,6 +382,9 @@ triggers:
                     category: note\ndescription: d\n\
                     content:\n  abstract: a\n  note: x\n  command: y\n";
         let m = parse_canonical(yaml).unwrap();
-        assert!(matches!(validate(&m), Err(ValidationError::MultipleContentModes)));
+        assert!(matches!(
+            validate(&m),
+            Err(ValidationError::MultipleContentModes)
+        ));
     }
 }

--- a/mur-core/src/cmd/skill_from_pattern.rs
+++ b/mur-core/src/cmd/skill_from_pattern.rs
@@ -92,6 +92,7 @@ pub fn pattern_to_skill(pattern: &Pattern, polish: bool) -> Result<SkillManifest
             context: Some(technical),
             procedure: None,
             command: None,
+            note: None,
         },
         requires: vec![],
         tags,

--- a/mur-core/src/retrieve/skill_candidates.rs
+++ b/mur-core/src/retrieve/skill_candidates.rs
@@ -106,12 +106,17 @@ impl Retrievable for LoadedSkill {
     }
 
     fn text(&self) -> std::borrow::Cow<'_, str> {
-        // Pre-Note skills: abstract + description is the keyword/embed surface.
-        // Extended once ContentMode::Note (separate plan) lands.
-        std::borrow::Cow::Owned(format!(
+        // abstract + description is the base keyword/embed surface; note-mode
+        // skills append their markdown body so they rank on their content.
+        let mut s = format!(
             "{}\n{}",
             self.manifest.content.r#abstract, self.manifest.description
-        ))
+        );
+        if let Some(note) = &self.manifest.content.note {
+            s.push('\n');
+            s.push_str(note);
+        }
+        std::borrow::Cow::Owned(s)
     }
 
     fn tag_terms(&self) -> Vec<&str> {
@@ -380,5 +385,24 @@ mod tests {
         if ranked.len() > 1 {
             assert!(ranked[0].score > ranked[1].score);
         }
+    }
+
+    #[test]
+    fn text_includes_note_body_when_present() {
+        use mur_common::skill::manifest::Content;
+        use mur_common::skill::types::Category;
+
+        let mut s = fake_loaded("note-skill", Priority::Normal);
+        s.manifest.category = Category::Note;
+        s.manifest.content = Content {
+            r#abstract: "abstract line".into(),
+            context: None,
+            procedure: None,
+            command: None,
+            note: Some("the note body about rust errors".into()),
+        };
+        let text = s.text();
+        assert!(text.contains("abstract line"));
+        assert!(text.contains("the note body about rust errors"));
     }
 }

--- a/mur-core/src/retrieve/skill_candidates.rs
+++ b/mur-core/src/retrieve/skill_candidates.rs
@@ -181,6 +181,7 @@ mod tests {
                 context: Some(format!("body of {name}")),
                 procedure: None,
                 command: None,
+                note: None,
             },
             requires: vec![],
             tags: vec!["alpha".into(), "beta".into()],

--- a/mur-core/src/skill_index/text.rs
+++ b/mur-core/src/skill_index/text.rs
@@ -62,6 +62,7 @@ mod tests {
                 context: Some("context text".into()),
                 procedure: None,
                 command: None,
+                note: None,
             },
             requires: vec![],
             triggers: vec![],


### PR DESCRIPTION
## Summary
- `Category::Note` / `ContentMode::Note` variants with lowercase serde
- `Content.note: Option<String>` for inline markdown body storage (1a)
- `Content::mode()` extended to 4-tuple recognizing note mode
- Validation: `(Category::Note, ContentMode::Note)` pairing, disambiguation, error messages
- `LoadedSkill::text()` includes note body so notes rank on content through the generic scorer
- 8 new tests + smoke validated (`mur skill validate` on a note skill)

**Depends on:** #293 (feat/skill-retrievable-impl) — stacked PR.

## Test Plan
- [x] `cargo test -p mur-common --lib -- "skill::types::tests"` — 5 pass
- [x] `cargo test -p mur-common --lib -- "skill::manifest::tests"` — 10 pass
- [x] `cargo test -p mur-common --lib -- "skill::validate::tests"` — 13 pass
- [x] `cargo test -p mur-core --lib -- "retrieve::"` — 93 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `mur skill validate` smoke test on a `category: note` manifest — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)