### PR TITLE
feat(skill): provenance curation gate — LLM skills can't auto-promote past Emerging (A1)

### DIFF
--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -1230,6 +1230,12 @@ timeout_secs: 60
         let parsed: BackendConfig = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(parsed, original);
     }
+
+    #[test]
+    fn skills_config_curation_gate_defaults_on() {
+        let c = SkillsConfig::default();
+        assert!(c.require_human_curation_before_stable);
+    }
 }
 
 /// Configuration for the daemon-side sleep cycle (idle background learning).
@@ -1242,6 +1248,16 @@ pub struct SkillsConfig {
     pub max_total_tokens: usize,
     pub priority_order: Vec<String>,
     pub adaptive: Option<AdaptiveSkillsConfig>,
+
+    /// When true (default), LLM-authored skills cannot auto-promote past
+    /// `Emerging` until a human curates them (amendment A1). Set false to
+    /// let LLM-extracted skills promote on run stats alone.
+    #[serde(default = "default_require_human_curation")]
+    pub require_human_curation_before_stable: bool,
+}
+
+fn default_require_human_curation() -> bool {
+    true
 }
 
 impl Default for SkillsConfig {
@@ -1251,6 +1267,7 @@ impl Default for SkillsConfig {
             max_total_tokens: 2000,
             priority_order: vec!["agent".into(), "global".into()],
             adaptive: Some(AdaptiveSkillsConfig::default()),
+            require_human_curation_before_stable: default_require_human_curation(),
         }
     }
 }

--- a/mur-common/src/skill/gene.rs
+++ b/mur-common/src/skill/gene.rs
@@ -264,6 +264,7 @@ mod tests {
             evolution_log: vec![],
             transfer_chain: vec![],
             mcp_requirements: vec![],
+            provenance: Default::default(),
         }
     }
 

--- a/mur-common/src/skill/lifecycle.rs
+++ b/mur-common/src/skill/lifecycle.rs
@@ -5,6 +5,7 @@
 use chrono::{DateTime, Duration, Utc};
 
 use crate::skill::stats::{LifecycleState, SkillStats};
+use crate::skill::types::Provenance;
 
 pub const MIN_CONFIDENCE: f64 = 0.05;
 pub const AUTO_ARCHIVE_CONFIDENCE: f64 = 0.10;
@@ -129,6 +130,28 @@ pub fn next_state(stats: &SkillStats, now: DateTime<Utc>) -> LifecycleState {
         LifecycleState::Emerging
     } else {
         LifecycleState::Draft
+    }
+}
+
+/// Cap a proposed lifecycle state for LLM-authored, uncurated skills.
+///
+/// PURE. The promotion ladder (`next_state`) is provenance-blind; this
+/// applies the A1 curation gate on top: an `Llm` skill that no human has
+/// curated cannot rise above `Emerging`, no matter how good its run stats
+/// look. `Human`/`Hybrid` skills, curated skills, and a disabled gate all
+/// pass `proposed` through unchanged. States at or below `Emerging` are
+/// never raised.
+pub fn cap_for_provenance(
+    proposed: LifecycleState,
+    provenance: Provenance,
+    curated: bool,
+    gate_enabled: bool,
+) -> LifecycleState {
+    let gated = gate_enabled && provenance == Provenance::Llm && !curated;
+    if gated && rank(proposed) > rank(LifecycleState::Emerging) {
+        LifecycleState::Emerging
+    } else {
+        proposed
     }
 }
 
@@ -357,5 +380,43 @@ mod tests {
         // Decayed value from a 1.0 anchor with 0 successes and no last_success
         // → MIN_CONFIDENCE since last_success is None
         assert!(stats.anchor_confidence <= old_anchor);
+    }
+
+    #[test]
+    fn cap_blocks_llm_uncurated_above_emerging() {
+        // Stable proposed, LLM, not curated, gate on → capped to Emerging.
+        assert_eq!(
+            cap_for_provenance(LifecycleState::Stable, Provenance::Llm, false, true),
+            LifecycleState::Emerging
+        );
+        // Canonical likewise capped.
+        assert_eq!(
+            cap_for_provenance(LifecycleState::Canonical, Provenance::Llm, false, true),
+            LifecycleState::Emerging
+        );
+    }
+
+    #[test]
+    fn cap_is_noop_for_human_curated_or_disabled() {
+        // Human authorship → never gated.
+        assert_eq!(
+            cap_for_provenance(LifecycleState::Stable, Provenance::Human, false, true),
+            LifecycleState::Stable
+        );
+        // LLM but curated → gate open.
+        assert_eq!(
+            cap_for_provenance(LifecycleState::Stable, Provenance::Llm, true, true),
+            LifecycleState::Stable
+        );
+        // Gate disabled by config → no cap.
+        assert_eq!(
+            cap_for_provenance(LifecycleState::Canonical, Provenance::Llm, false, false),
+            LifecycleState::Canonical
+        );
+        // At or below Emerging → unchanged even when gated.
+        assert_eq!(
+            cap_for_provenance(LifecycleState::Draft, Provenance::Llm, false, true),
+            LifecycleState::Draft
+        );
     }
 }

--- a/mur-common/src/skill/lifecycle.rs
+++ b/mur-common/src/skill/lifecycle.rs
@@ -221,6 +221,7 @@ mod tests {
             anchor_confidence: anchor,
             rebuilt_from_trace_through: None,
             resolution_misses: 0,
+            curated_at: None,
         }
     }
 

--- a/mur-common/src/skill/manifest.rs
+++ b/mur-common/src/skill/manifest.rs
@@ -2,7 +2,7 @@
 
 use super::evolution::EvolutionEvent;
 use super::mcp::McpRequirement;
-use super::types::{Category, ContentMode, HostId, Priority, TriggerKind, TrustLevel};
+use super::types::{Category, ContentMode, HostId, Priority, Provenance, TriggerKind, TrustLevel};
 use serde::{Deserialize, Serialize};
 
 /// Top-level skill — wraps the manifest with security metadata that lives
@@ -39,6 +39,11 @@ pub struct SkillManifest {
     pub publisher: String,
     pub description: String,
     pub category: Category,
+
+    /// Origin of this skill. Defaults to `Human` so every existing manifest
+    /// (which has no `provenance:` key) parses as human-authored.
+    #[serde(default)]
+    pub provenance: Provenance,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub hosts: Vec<HostId>,

--- a/mur-common/src/skill/stats.rs
+++ b/mur-common/src/skill/stats.rs
@@ -81,6 +81,14 @@ pub struct SkillStats {
     /// agent's MCP inventory — doctor's `intent-resolvable` check surfaces this.
     #[serde(default)]
     pub resolution_misses: u64,
+
+    /// Timestamp of the most recent human curation event
+    /// (`mur.skill.curated`). `None` until a human has reviewed an
+    /// LLM-extracted skill. Opens the provenance gate (see
+    /// `lifecycle::cap_for_provenance`). `#[serde(default)]` keeps older
+    /// stats files parsing.
+    #[serde(default)]
+    pub curated_at: Option<DateTime<Utc>>,
 }
 
 impl SkillStats {
@@ -108,6 +116,7 @@ impl SkillStats {
             anchor_confidence: 1.0,
             rebuilt_from_trace_through: None,
             resolution_misses: 0,
+            curated_at: None,
         }
     }
 
@@ -372,5 +381,19 @@ mod tests {
         assert!(stats.pinned);
         assert_eq!(stats.lifecycle_state, LifecycleState::Canonical);
         assert!(stats.first_successful_use_at.is_some());
+    }
+
+    #[test]
+    fn curated_at_defaults_to_none_and_is_backward_compatible() {
+        // A SkillStats JSON written before this field existed must still parse.
+        let legacy = r#"{
+            "schema_version": 1, "skill_name": "x", "skill_version": "1",
+            "manifest_digest": "d", "lifecycle_state": "draft",
+            "lifecycle_changed_at": "2026-01-01T00:00:00Z", "pinned": false,
+            "usage_count": 0, "success_count": 0, "failure_count": 0,
+            "anchor_confidence": 1.0
+        }"#;
+        let s: SkillStats = serde_json::from_str(legacy).unwrap();
+        assert_eq!(s.curated_at, None);
     }
 }

--- a/mur-common/src/skill/types.rs
+++ b/mur-common/src/skill/types.rs
@@ -41,6 +41,21 @@ pub enum Category {
     Note,
 }
 
+/// Where a skill came from. Drives the curation gate: `Llm`-authored skills
+/// cannot auto-promote past `Emerging` until a human curates them
+/// (amendment A1, `2026-05-28-mur-workflow-engine-design-v2.md`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Provenance {
+    /// Hand-authored by a person. Default — no gate.
+    #[default]
+    Human,
+    /// Produced by the LLM extraction judge. Gated until curated.
+    Llm,
+    /// LLM-extracted, then human-reviewed/edited. No gate.
+    Hybrid,
+}
+
 /// Exactly one content mode is populated; see spec §3.2.3.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -105,5 +120,16 @@ mod tests {
         assert_eq!(yaml.trim(), "note");
         let parsed: ContentMode = serde_yaml_ng::from_str("note").unwrap();
         assert_eq!(parsed, ContentMode::Note);
+    }
+
+    #[test]
+    fn provenance_defaults_to_human_and_roundtrips() {
+        // Default is Human (a skill is human-authored unless stated otherwise).
+        assert_eq!(Provenance::default(), Provenance::Human);
+        // Serializes lowercase, like Category.
+        let yaml = serde_yaml_ng::to_string(&Provenance::Llm).unwrap();
+        assert_eq!(yaml.trim(), "llm");
+        let parsed: Provenance = serde_yaml_ng::from_str("hybrid").unwrap();
+        assert_eq!(parsed, Provenance::Hybrid);
     }
 }

--- a/mur-common/src/telemetry.rs
+++ b/mur-common/src/telemetry.rs
@@ -64,6 +64,10 @@ pub const METHOD_SKILL_STEP_RESOLVED: &str = "mur.skill.step_resolved";
 /// `reindex_stats` as a usage + success so retrieval drives the note lifecycle.
 pub const METHOD_NOTE_RETRIEVED: &str = "mur.note.retrieved";
 
+/// Emitted by `mur skill curate` — a human reviewed an LLM-extracted skill.
+/// Reduced into `SkillStats::curated_at`; opens the A1 provenance gate.
+pub const METHOD_SKILL_CURATED: &str = "mur.skill.curated";
+
 pub const MUR_SKILL_NAME: &str = "mur.skill.name";
 pub const MUR_SKILL_VERSION: &str = "mur.skill.version";
 pub const MUR_SKILL_OUTCOME: &str = "mur.skill.outcome";

--- a/mur-core/src/cli/skill.rs
+++ b/mur-core/src/cli/skill.rs
@@ -209,6 +209,12 @@ pub enum SkillAction {
         #[arg(long)]
         cross_agent: bool,
     },
+    /// Record a human curation event for an LLM-extracted skill, so it can
+    /// promote past Emerging (amendment A1).
+    Curate {
+        /// Skill name to curate.
+        name: String,
+    },
     /// Recombine two skills into a new Draft offspring on this agent.
     Recombine {
         /// First parent ref: `<name>` (local) or `agent://<peer>/<name>`.

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -47,6 +47,7 @@ pub mod skill_archive;
 pub mod skill_cmd;
 pub mod skill_consolidate;
 pub mod skill_credit;
+pub mod skill_curate;
 pub mod skill_deps;
 pub mod skill_doctor;
 pub mod skill_evolve;

--- a/mur-core/src/cmd/notes_cmd.rs
+++ b/mur-core/src/cmd/notes_cmd.rs
@@ -636,6 +636,7 @@ mod tests {
                 filter: Some("rust-errors".into()),
                 dry_run: false,
                 now: now + Duration::days(2),
+                require_human_curation_before_stable: true,
             },
         )
         .unwrap();

--- a/mur-core/src/cmd/notes_cmd.rs
+++ b/mur-core/src/cmd/notes_cmd.rs
@@ -48,6 +48,7 @@ pub fn do_create(mur_home: &Path, name: &str, description: &str, body: &str) -> 
         evolution_log: vec![],
         transfer_chain: vec![],
         mcp_requirements: vec![],
+        provenance: Default::default(),
     };
 
     validate(&manifest).with_context(|| format!("validate note '{name}'"))?;

--- a/mur-core/src/cmd/skill_curate.rs
+++ b/mur-core/src/cmd/skill_curate.rs
@@ -1,0 +1,82 @@
+//! `mur skill curate <name>` — record a human curation event so an
+//! LLM-extracted skill can promote past Emerging (amendment A1).
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use mur_common::telemetry::METHOD_SKILL_CURATED;
+use std::path::Path;
+
+use super::agent::resolve_mur_home;
+
+/// Append a `mur.skill.curated` event to today's trace log. The stats
+/// reducer (`reindex_stats`) turns this into `SkillStats::curated_at`.
+pub fn record_curation(mur_home: &Path, skill_name: &str, now: DateTime<Utc>) -> Result<()> {
+    let traces_dir = mur_home.join("traces");
+    std::fs::create_dir_all(&traces_dir)
+        .with_context(|| format!("create {}", traces_dir.display()))?;
+    let path = traces_dir
+        .join(now.format("%Y-%m-%d").to_string())
+        .with_extension("jsonl");
+
+    let line = serde_json::json!({
+        "ts": now.to_rfc3339(),
+        "method": METHOD_SKILL_CURATED,
+        "mur.skill.name": skill_name,
+    });
+
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("open {}", path.display()))?;
+    writeln!(f, "{}", serde_json::to_string(&line)?)?;
+    Ok(())
+}
+
+/// CLI handler for `mur skill curate <name>`.
+pub fn cmd_curate(name: &str) -> Result<()> {
+    let home = resolve_mur_home()?;
+    record_curation(&home, name, Utc::now())?;
+    println!(
+        "Curated '{name}'. Run `mur skill reindex-stats {name}` then `mur skill sweep` \
+         to let it promote past Emerging."
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_curation_appends_a_curated_event() {
+        let tmp = tempfile::tempdir().unwrap();
+        let now = Utc::now();
+        record_curation(tmp.path(), "deploy", now).unwrap();
+
+        let path = tmp
+            .path()
+            .join("traces")
+            .join(now.format("%Y-%m-%d").to_string())
+            .with_extension("jsonl");
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("mur.skill.curated"));
+        assert!(content.contains("\"mur.skill.name\":\"deploy\""));
+    }
+
+    #[test]
+    fn record_curation_appends_not_overwrites() {
+        let tmp = tempfile::tempdir().unwrap();
+        let now = Utc::now();
+        record_curation(tmp.path(), "a", now).unwrap();
+        record_curation(tmp.path(), "b", now).unwrap();
+        let path = tmp
+            .path()
+            .join("traces")
+            .join(now.format("%Y-%m-%d").to_string())
+            .with_extension("jsonl");
+        let lines = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(lines.lines().count(), 2);
+    }
+}

--- a/mur-core/src/cmd/skill_from_pattern.rs
+++ b/mur-core/src/cmd/skill_from_pattern.rs
@@ -101,6 +101,7 @@ pub fn pattern_to_skill(pattern: &Pattern, polish: bool) -> Result<SkillManifest
         evolution_log: vec![],
         transfer_chain: vec![],
         mcp_requirements: vec![],
+        provenance: Default::default(),
     };
 
     validate(&manifest).context("derived skill manifest failed schema validation")?;

--- a/mur-core/src/cmd/skill_sweep.rs
+++ b/mur-core/src/cmd/skill_sweep.rs
@@ -6,13 +6,14 @@ use super::agent::resolve_mur_home;
 
 pub fn cmd_sweep(filter: Option<&str>, dry_run: bool) -> Result<()> {
     let home = resolve_mur_home()?;
+    let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
     let report = crate::skill_lifecycle::sweep::run_sweep(
         &home,
         crate::skill_lifecycle::sweep::SweepOptions {
             filter: filter.map(str::to_string),
             dry_run,
             now: chrono::Utc::now(),
-            require_human_curation_before_stable: true,
+            require_human_curation_before_stable: cfg.skills.require_human_curation_before_stable,
         },
     )?;
 

--- a/mur-core/src/cmd/skill_sweep.rs
+++ b/mur-core/src/cmd/skill_sweep.rs
@@ -12,6 +12,7 @@ pub fn cmd_sweep(filter: Option<&str>, dry_run: bool) -> Result<()> {
             filter: filter.map(str::to_string),
             dry_run,
             now: chrono::Utc::now(),
+            require_human_curation_before_stable: true,
         },
     )?;
 

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -442,6 +442,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             crate::cli::SkillAction::Sweep { name, dry_run } => {
                 cmd::skill_sweep::cmd_sweep(name.as_deref(), dry_run)?
             }
+            crate::cli::SkillAction::Curate { name } => cmd::skill_curate::cmd_curate(&name)?,
             crate::cli::SkillAction::ReindexVec { name, prune } => {
                 let home = cmd::agent::resolve_mur_home()?;
                 cmd::skill_reindex_vec::cmd_reindex_vec(&home, name.as_deref(), prune).await?

--- a/mur-core/src/retrieve/skill_candidates.rs
+++ b/mur-core/src/retrieve/skill_candidates.rs
@@ -195,6 +195,7 @@ mod tests {
             evolution_log: vec![],
             transfer_chain: vec![],
             mcp_requirements: vec![],
+            provenance: Default::default(),
         };
         let mut stats = SkillStats::new(name, "1.0.0", "", Utc::now() - Duration::days(2));
         stats.usage_count = 4;

--- a/mur-core/src/skill_index/text.rs
+++ b/mur-core/src/skill_index/text.rs
@@ -71,6 +71,7 @@ mod tests {
             evolution_log: vec![],
             transfer_chain: vec![],
             mcp_requirements: vec![],
+            provenance: Default::default(),
         }
     }
 

--- a/mur-core/src/skill_lifecycle/sweep.rs
+++ b/mur-core/src/skill_lifecycle/sweep.rs
@@ -5,7 +5,8 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use mur_common::skill::lifecycle::{
-    calculate_decay, half_life_days, next_state, on_promotion, transition_allowed,
+    calculate_decay, cap_for_provenance, half_life_days, next_state, on_promotion,
+    transition_allowed,
 };
 use mur_common::skill::stats::{LifecycleState, SkillStats};
 use std::path::Path;
@@ -34,6 +35,9 @@ pub struct SweepOptions {
     pub filter: Option<String>,
     pub dry_run: bool,
     pub now: DateTime<Utc>,
+    /// A1 curation gate. When true, LLM-authored uncurated skills are capped
+    /// at `Emerging`. Set by the CLI from `config.skills`.
+    pub require_human_curation_before_stable: bool,
 }
 
 impl Default for SweepOptions {
@@ -42,6 +46,7 @@ impl Default for SweepOptions {
             filter: None,
             dry_run: true,
             now: Utc::now(),
+            require_human_curation_before_stable: true,
         }
     }
 }
@@ -102,7 +107,18 @@ pub fn run_sweep(home: &Path, opts: SweepOptions) -> Result<SweepReport> {
             None => continue, // no stats yet — nothing to sweep
         };
 
-        let proposed = next_state(&current, opts.now);
+        // Provenance gate (A1): an LLM-authored, uncurated skill cannot rise
+        // above Emerging. Load the manifest for its provenance; a missing
+        // manifest defaults to Human (no cap), matching `#[serde(default)]`.
+        let provenance = mur_common::skill::local::load_installed(home, &name)
+            .map(|m| m.provenance)
+            .unwrap_or_default();
+        let proposed = cap_for_provenance(
+            next_state(&current, opts.now),
+            provenance,
+            current.curated_at.is_some(),
+            opts.require_human_curation_before_stable,
+        );
         let decayed_value = calculate_decay(
             current.anchor_confidence,
             current.last_success_at,
@@ -156,6 +172,94 @@ pub fn run_sweep(home: &Path, opts: SweepOptions) -> Result<SweepReport> {
     }
 
     Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use mur_common::skill::stats::SkillStats;
+
+    fn write_llm_skill(home: &std::path::Path, name: &str) {
+        std::fs::create_dir_all(home.join("skills").join(name)).unwrap();
+        std::fs::write(
+            home.join("skills").join(name).join("skill.yaml"),
+            format!("name: {name}\nversion: \"1\"\npublisher: me\ndescription: d\ncategory: workflow\nprovenance: llm\ncontent:\n  abstract: a\n  command: \"echo hi\"\n"),
+        )
+        .unwrap();
+    }
+
+    // Stats that next_state() would promote to Stable: 12 successes, perfect
+    // rate, aged 40 days.
+    fn stable_grade_stats(home: &std::path::Path, name: &str, now: chrono::DateTime<Utc>) {
+        let mut s = SkillStats::new(name, "1", "digest", now - Duration::days(40));
+        s.lifecycle_state = LifecycleState::Emerging;
+        s.usage_count = 12;
+        s.success_count = 12;
+        s.last_used_at = Some(now);
+        s.last_success_at = Some(now);
+        s.first_successful_use_at = Some(now - Duration::days(40));
+        s.anchor_confidence = 1.0;
+        s.lifecycle_changed_at = now - Duration::days(40);
+        let path = SkillStats::path(home, name);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, serde_json::to_string(&s).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn llm_uncurated_skill_is_capped_at_emerging() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let now = Utc::now();
+        write_llm_skill(home, "deploy");
+        stable_grade_stats(home, "deploy", now);
+
+        run_sweep(
+            home,
+            SweepOptions {
+                filter: Some("deploy".into()),
+                dry_run: false,
+                now,
+                require_human_curation_before_stable: true,
+            },
+        )
+        .unwrap();
+
+        let after = SkillStats::load(&SkillStats::path(home, "deploy")).unwrap().unwrap();
+        assert_eq!(
+            after.lifecycle_state,
+            LifecycleState::Emerging,
+            "LLM uncurated skill must not pass Emerging despite Stable-grade stats"
+        );
+    }
+
+    #[test]
+    fn llm_curated_skill_promotes_to_stable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let now = Utc::now();
+        write_llm_skill(home, "deploy");
+        stable_grade_stats(home, "deploy", now);
+        // Mark curated.
+        let path = SkillStats::path(home, "deploy");
+        let mut s = SkillStats::load(&path).unwrap().unwrap();
+        s.curated_at = Some(now - Duration::days(1));
+        std::fs::write(&path, serde_json::to_string(&s).unwrap()).unwrap();
+
+        run_sweep(
+            home,
+            SweepOptions {
+                filter: Some("deploy".into()),
+                dry_run: false,
+                now,
+                require_human_curation_before_stable: true,
+            },
+        )
+        .unwrap();
+
+        let after = SkillStats::load(&path).unwrap().unwrap();
+        assert_eq!(after.lifecycle_state, LifecycleState::Stable);
+    }
 }
 
 fn matches_filter(name: &str, filter: Option<&str>) -> bool {

--- a/mur-core/src/skill_lifecycle/sweep.rs
+++ b/mur-core/src/skill_lifecycle/sweep.rs
@@ -225,7 +225,9 @@ mod tests {
         )
         .unwrap();
 
-        let after = SkillStats::load(&SkillStats::path(home, "deploy")).unwrap().unwrap();
+        let after = SkillStats::load(&SkillStats::path(home, "deploy"))
+            .unwrap()
+            .unwrap();
         assert_eq!(
             after.lifecycle_state,
             LifecycleState::Emerging,

--- a/mur-core/src/skill_stats/reindex.rs
+++ b/mur-core/src/skill_stats/reindex.rs
@@ -347,20 +347,31 @@ mod tests {
             today.to_rfc3339()
         );
         std::fs::write(
-            traces.join(today.format("%Y-%m-%d").to_string()).with_extension("jsonl"),
+            traces
+                .join(today.format("%Y-%m-%d").to_string())
+                .with_extension("jsonl"),
             format!("{line}\n"),
         )
         .unwrap();
 
         reindex_stats(
             home,
-            ReindexOptions { skill_filter: Some("my-skill".into()), since: None, days_back: 1 },
+            ReindexOptions {
+                skill_filter: Some("my-skill".into()),
+                since: None,
+                days_back: 1,
+            },
         )
         .await
         .unwrap();
 
-        let stats = SkillStats::load(&SkillStats::path(home, "my-skill")).unwrap().unwrap();
-        assert!(stats.curated_at.is_some(), "curated event should set curated_at");
+        let stats = SkillStats::load(&SkillStats::path(home, "my-skill"))
+            .unwrap()
+            .unwrap();
+        assert!(
+            stats.curated_at.is_some(),
+            "curated event should set curated_at"
+        );
         assert_eq!(stats.usage_count, 0, "curation is not a usage");
         assert_eq!(stats.success_count, 0);
     }

--- a/mur-core/src/skill_stats/reindex.rs
+++ b/mur-core/src/skill_stats/reindex.rs
@@ -102,6 +102,7 @@ pub async fn reindex_stats(mur_home: &Path, opts: ReindexOptions) -> Result<Rein
                 // mur.skill.name + mur.skill.outcome.
                 if !trimmed.contains("mur.skill.executed")
                     && !trimmed.contains("mur.note.retrieved")
+                    && !trimmed.contains("mur.skill.curated")
                 {
                     continue;
                 }
@@ -116,6 +117,21 @@ pub async fn reindex_stats(mur_home: &Path, opts: ReindexOptions) -> Result<Rein
                     continue;
                 }
                 lines_consumed += 1;
+
+                // A curation event records human review, not a usage. Set the
+                // watermark and skip the usage/outcome accounting below.
+                if trimmed.contains("mur.skill.curated") {
+                    if let Some(ts) = val.get("ts").and_then(|v| v.as_str())
+                        && let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(ts)
+                    {
+                        let utc = parsed.with_timezone(&Utc);
+                        fresh.curated_at = Some(match fresh.curated_at {
+                            Some(e) => e.max(utc),
+                            None => utc,
+                        });
+                    }
+                    continue;
+                }
 
                 let outcome = val
                     .get("mur.skill.outcome")
@@ -165,6 +181,9 @@ pub async fn reindex_stats(mur_home: &Path, opts: ReindexOptions) -> Result<Rein
             }
             if fresh.first_successful_use_at.is_some() {
                 existing.first_successful_use_at = fresh.first_successful_use_at;
+            }
+            if fresh.curated_at.is_some() {
+                existing.curated_at = fresh.curated_at;
             }
             existing.rebuilt_from_trace_through = Some(today);
             Ok(())
@@ -303,5 +322,46 @@ mod tests {
             .unwrap();
         assert_eq!(stats.usage_count, 3);
         assert_eq!(stats.success_count, 3);
+    }
+
+    #[tokio::test]
+    async fn reindex_sets_curated_at_without_counting_usage() {
+        use mur_common::skill::stats::SkillStats;
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+
+        // Minimal installed skill dir so reindex enumerates it.
+        std::fs::create_dir_all(home.join("skills").join("my-skill")).unwrap();
+        std::fs::write(
+            home.join("skills").join("my-skill").join("skill.yaml"),
+            "name: my-skill\nversion: \"1\"\npublisher: me\ndescription: d\ncategory: note\nprovenance: llm\ncontent:\n  abstract: a\n  note: \"b\"\n",
+        )
+        .unwrap();
+
+        // One curated event in today's trace log.
+        let today = chrono::Utc::now();
+        let traces = home.join("traces");
+        std::fs::create_dir_all(&traces).unwrap();
+        let line = format!(
+            "{{\"ts\":\"{}\",\"method\":\"mur.skill.curated\",\"mur.skill.name\":\"my-skill\"}}",
+            today.to_rfc3339()
+        );
+        std::fs::write(
+            traces.join(today.format("%Y-%m-%d").to_string()).with_extension("jsonl"),
+            format!("{line}\n"),
+        )
+        .unwrap();
+
+        reindex_stats(
+            home,
+            ReindexOptions { skill_filter: Some("my-skill".into()), since: None, days_back: 1 },
+        )
+        .await
+        .unwrap();
+
+        let stats = SkillStats::load(&SkillStats::path(home, "my-skill")).unwrap().unwrap();
+        assert!(stats.curated_at.is_some(), "curated event should set curated_at");
+        assert_eq!(stats.usage_count, 0, "curation is not a usage");
+        assert_eq!(stats.success_count, 0);
     }
 }

--- a/mur-core/tests/skill_sweep_idempotent.rs
+++ b/mur-core/tests/skill_sweep_idempotent.rs
@@ -78,6 +78,7 @@ fn sweep_idempotent() {
             filter: None,
             dry_run: false,
             now,
+            require_human_curation_before_stable: true,
         },
     )
     .unwrap();
@@ -98,6 +99,7 @@ fn sweep_idempotent() {
             filter: None,
             dry_run: false,
             now,
+            require_human_curation_before_stable: true,
         },
     )
     .unwrap();
@@ -151,6 +153,7 @@ fn anchor_reset_on_promotion() {
             filter: None,
             dry_run: false,
             now,
+            require_human_curation_before_stable: true,
         },
     )
     .unwrap();


### PR DESCRIPTION
## Summary
- Adds `Provenance { Human, Llm, Hybrid }` to `SkillManifest` — records a skill's origin
- Adds `curated_at` to `SkillStats` — set when a human runs `mur skill curate`
- Pure `cap_for_provenance()` function caps LLM-authored, uncurated skills at `Emerging`
- Config flag `require_human_curation_before_stable` (default `true`) toggles the gate
- Sweep loads provenance from manifest and applies the cap before persisting transitions
- `mur skill curate <name>` emits a `mur.skill.curated` trace event, reduced into `curated_at`

## Design
`next_state()` is provenance-blind by design. The cap is a separate pure function applied by the sweep, keeping both testable independently. This implements amendment A1 from the workflow engine design v2.

## Test Plan
- [ ] `cargo test --workspace` — 1380 passed (same 6 pre-existing env failures)
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean
- [ ] `cargo run --bin mur -- skill curate <name>` — emits trace event, confirmed in `~/.mur/traces/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)