### PR TITLE
feat(runtime): --load and --model flags for headless .muragent execution

### DIFF
--- a/docs/superpowers/plans/2026-05-29-agent-export-ux-plan-1-foundation.md
+++ b/docs/superpowers/plans/2026-05-29-agent-export-ux-plan-1-foundation.md
@@ -1,0 +1,720 @@
+# Agent Export UX — Plan 1: Foundation & Logic Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the data + logic foundation for "give an agent to a friend" — the `.muragent` `model_hint` field, the model-class table, the local-first/cloud-honest resolution decision tree, the export-side secret-leak fix, and the retirement of the toolchain-bound `--format=gui`/`--format=bin` export paths.
+
+**Architecture:** Pure-logic, fully unit-testable layer in `mur-common` (no GUI, no OS integration), plus a small `mur-core` CLI change. This is the substrate the later plans build on: Plan 1b wires `mur-agent-runtime --load` + CLI model resolution onto it; Plan 2 wires the Hub GUI Share command, OS file association, and the GUI model wizard.
+
+**Tech Stack:** Rust (edition 2024), `serde` / `serde_yaml_ng`, `anyhow`, existing `mur-common::muragent` package library and `mur-common::model` registry.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-mur-agent-export-ux-give-to-a-friend-design.md` (Workstreams B-data §7.1–7.2, the §7.3 decision tree, and D §8).
+
+---
+
+## Scope & follow-on plans
+
+This plan covers the parts that are pure-logic and risk-free to specify exactly:
+
+- **In scope:** `model_hint` manifest type + field (§7.1); model-class `classify()` table; writer populates the hint; export sanitization strips `model_ref` and overrides the hint from the registry (§7.2, closes the model-side secret leak); the `recommend()` decision tree (§7.3); retire `--format=gui`/`--format=bin` with a redirecting error and delete the secret-leaking `export_bin` (§8/D).
+- **Deferred to Plan 1b** (`mur-agent-runtime`): `--load <path.muragent>` + non-interactive `--model` + CLI interactive resolution prompts (needs supervisor-discovery work).
+- **Deferred to Plan 2** (`mur-hub-gui` + `mur-gui-core`): Hub "Share" command/UI (C), tauri.conf file association / deep-link / dmg / notarization + open-routing + onboarding (A), GUI model wizard step (B-wizard GUI surface).
+
+Each later plan depends only on the public types this plan introduces (`ModelHint`, `ModelTier`, `classify`, `Hardware`, `Recommendation`, `recommend`).
+
+---
+
+## File structure
+
+- `mur-common/src/muragent/manifest.rs` — **Modify.** Add `ModelTier` enum, `ModelHint` struct, and the `model_hint: Option<ModelHint>` field on `MuragentManifest`.
+- `mur-common/src/muragent/model_class.rs` — **Create.** `classify(provider, name) -> ModelHint` (the static model-class table).
+- `mur-common/src/muragent/mod.rs` — **Modify.** `pub mod model_class;`
+- `mur-common/src/muragent/writer.rs` — **Modify.** `build_manifest_from_profile` populates `model_hint` from the inline binding.
+- `mur-common/src/model_resolve.rs` — **Create.** `Hardware`, `Recommendation`, `recommend(...)` — the §7.3 decision tree.
+- `mur-common/src/lib.rs` — **Modify.** `pub mod model_resolve;`
+- `mur-core/src/cmd/agent/export.rs` — **Modify.** Sanitize strips `model_ref`; `export_muragent` overrides `model_hint` from the registry when `model_ref` was set; `cmd_export` redirects `bin`/`gui`; delete `export_bin` + `locate_runtime_manifest_dir`.
+- `mur-core/src/dispatch.rs` — **Modify.** Route the `gui` format through `cmd_export` (drop the special-case branch).
+
+---
+
+## Task 1: `ModelHint` / `ModelTier` types + manifest field
+
+**Files:**
+- Modify: `mur-common/src/muragent/manifest.rs`
+- Test: same file (`#[cfg(test)]` at bottom)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing test module (or create one) at the bottom of `manifest.rs`:
+
+```rust
+#[cfg(test)]
+mod model_hint_tests {
+    use super::*;
+
+    #[test]
+    fn manifest_round_trips_without_model_hint() {
+        let yaml = "\
+schema: mur-agent/2
+exported_at: '2026-05-29T00:00:00Z'
+exporter: { mur_version: 1.0.0, tool: mur }
+agent: { slug: coach, display_name: Coach, bundle_id: run.mur.agent.coach, url_scheme: muragent-coach, original_uuid: u1 }
+required_surfaces: [hub]
+icon: {}
+";
+        let m: MuragentManifest = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(m.model_hint.is_none());
+    }
+
+    #[test]
+    fn model_hint_serializes_and_parses() {
+        let hint = ModelHint {
+            provider: "ollama".into(),
+            name: "llama3.2:3b".into(),
+            tier: ModelTier::Small,
+            min_ram_gb: 8,
+            local_capable: true,
+        };
+        let s = serde_yaml_ng::to_string(&hint).unwrap();
+        let back: ModelHint = serde_yaml_ng::from_str(&s).unwrap();
+        assert_eq!(hint, back);
+        assert!(s.contains("tier: small"));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-common model_hint -- --nocapture`
+Expected: FAIL — `cannot find type ModelHint` / `no field model_hint`.
+
+- [ ] **Step 3: Add the types and field**
+
+In `manifest.rs`, add after the `Surface` enum:
+
+```rust
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelTier {
+    Small,
+    Mid,
+    Frontier,
+}
+
+/// Declares what kind of model the agent was authored against, so the
+/// recipient's first-run wizard can resolve a backend (no weights travel).
+/// See spec §7.1.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelHint {
+    pub provider: String,
+    pub name: String,
+    pub tier: ModelTier,
+    #[serde(default)]
+    pub min_ram_gb: u32,
+    pub local_capable: bool,
+}
+```
+
+In the `MuragentManifest` struct, add this field (after `assignment`):
+
+```rust
+    /// Model backend hint for the recipient's first-run resolution (§7.1).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_hint: Option<ModelHint>,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-common model_hint`
+Expected: PASS (both tests).
+
+> Note: adding the field breaks the `MuragentManifest { … }` struct literal in `writer.rs::build_manifest_from_profile` (missing field). Task 3 fixes it. If you build the whole crate now it will fail to compile until Task 3 — that is expected; run only the targeted `-p mur-common` lib test for `manifest`, or proceed to Task 3 before a full build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/muragent/manifest.rs
+git commit -m "feat(muragent): add model_hint manifest type + field"
+```
+
+---
+
+## Task 2: `classify()` model-class table
+
+**Files:**
+- Create: `mur-common/src/muragent/model_class.rs`
+- Modify: `mur-common/src/muragent/mod.rs`
+- Test: `mur-common/src/muragent/model_class.rs` (inline)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-common/src/muragent/model_class.rs`:
+
+```rust
+//! Static model-class table: map a (provider, name) binding to a `ModelHint`
+//! (tier, RAM estimate, local-capability). Heuristic + conservative on
+//! unknown providers. See spec §7.1.
+
+use crate::muragent::manifest::{ModelHint, ModelTier};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_small_model() {
+        let h = classify("ollama", "llama3.2:3b");
+        assert_eq!(h.tier, ModelTier::Small);
+        assert!(h.local_capable);
+        assert_eq!(h.min_ram_gb, 8);
+    }
+
+    #[test]
+    fn cloud_frontier_model() {
+        let h = classify("anthropic", "claude-opus-4-7");
+        assert_eq!(h.tier, ModelTier::Frontier);
+        assert!(!h.local_capable);
+        assert_eq!(h.min_ram_gb, 0);
+    }
+
+    #[test]
+    fn cloud_small_variant_is_mid() {
+        let h = classify("openai", "gpt-4o-mini");
+        assert_eq!(h.tier, ModelTier::Mid);
+        assert!(!h.local_capable);
+    }
+
+    #[test]
+    fn unknown_provider_is_conservative_local_mid() {
+        let h = classify("acme-llm", "whatever-v2");
+        assert_eq!(h.tier, ModelTier::Mid);
+        assert!(h.local_capable);
+        assert_eq!(h.min_ram_gb, 16);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-common model_class`
+Expected: FAIL — `cannot find function classify` (and module not declared).
+
+- [ ] **Step 3: Implement `classify` + declare the module**
+
+Add to the top of `model_class.rs` (above the test module):
+
+```rust
+const LOCAL_PROVIDERS: &[&str] =
+    &["ollama", "mlx", "llamacpp", "llama_cpp", "localai", "lmstudio"];
+const CLOUD_PROVIDERS: &[&str] = &[
+    "anthropic", "openai", "google", "gemini", "mistral", "groq", "cohere",
+    "deepseek", "xai", "openrouter",
+];
+const SMALL_MARKERS: &[&str] =
+    &["1b", "1.5b", "2b", "3b", "mini", "nano", "haiku", "flash", "small", "tiny"];
+const LARGE_LOCAL_MARKERS: &[&str] = &["70b", "72b", "405b", "mixtral", "command-r-plus"];
+
+/// Map a model binding to a `ModelHint`. Local providers classify by size
+/// markers in the name; known cloud providers are frontier unless a "small"
+/// variant marker is present; unknown providers fall back to a conservative
+/// local-capable mid tier (the wizard still offers all options).
+pub fn classify(provider: &str, name: &str) -> ModelHint {
+    let p = provider.to_ascii_lowercase();
+    let n = name.to_ascii_lowercase();
+    let has = |markers: &[&str]| markers.iter().any(|m| n.contains(m));
+
+    if LOCAL_PROVIDERS.contains(&p.as_str()) {
+        let (tier, min_ram_gb) = if has(SMALL_MARKERS) {
+            (ModelTier::Small, 8)
+        } else if has(LARGE_LOCAL_MARKERS) {
+            (ModelTier::Frontier, 64)
+        } else {
+            (ModelTier::Mid, 16)
+        };
+        return ModelHint {
+            provider: provider.to_string(),
+            name: name.to_string(),
+            tier,
+            min_ram_gb,
+            local_capable: true,
+        };
+    }
+
+    if CLOUD_PROVIDERS.contains(&p.as_str()) {
+        let tier = if has(SMALL_MARKERS) {
+            ModelTier::Mid
+        } else {
+            ModelTier::Frontier
+        };
+        return ModelHint {
+            provider: provider.to_string(),
+            name: name.to_string(),
+            tier,
+            min_ram_gb: 0,
+            local_capable: false,
+        };
+    }
+
+    // Unknown provider: conservative — assume a local-capable mid model.
+    ModelHint {
+        provider: provider.to_string(),
+        name: name.to_string(),
+        tier: ModelTier::Mid,
+        min_ram_gb: 16,
+        local_capable: true,
+    }
+}
+```
+
+In `mur-common/src/muragent/mod.rs`, add alongside the other `pub mod` lines:
+
+```rust
+pub mod model_class;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-common model_class`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/muragent/model_class.rs mur-common/src/muragent/mod.rs
+git commit -m "feat(muragent): model-class table for model_hint classification"
+```
+
+---
+
+## Task 3: Writer populates `model_hint`
+
+**Files:**
+- Modify: `mur-common/src/muragent/writer.rs:171-224` (the `MuragentManifest { … }` literal in `build_manifest_from_profile`)
+- Test: `mur-common/src/muragent/writer.rs` (test module at bottom)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` in `writer.rs`:
+
+```rust
+    #[test]
+    fn manifest_carries_model_hint_from_inline_binding() {
+        let mut profile = AgentProfile::default_for_tests();
+        profile.model = crate::agent::ModelConfig {
+            provider: "ollama".into(),
+            name: "llama3.2:3b".into(),
+            params: Default::default(),
+        };
+        let m = build_manifest_from_profile(&profile, "1.0.0");
+        let hint = m.model_hint.expect("model_hint populated");
+        assert_eq!(hint.tier, crate::muragent::manifest::ModelTier::Small);
+        assert!(hint.local_capable);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-common -- writer::tests::manifest_carries_model_hint`
+Expected: FAIL — struct literal missing field `model_hint` (compile error) or `model_hint` is `None`.
+
+- [ ] **Step 3: Populate the field in the struct literal**
+
+In `build_manifest_from_profile`, change the tail of the returned literal from:
+
+```rust
+        commander: None,
+        deployment: None,
+        assignment: None,
+    }
+```
+
+to:
+
+```rust
+        commander: None,
+        deployment: None,
+        assignment: None,
+        model_hint: Some(crate::muragent::model_class::classify(
+            &profile.model.provider,
+            &profile.model.name,
+        )),
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-common -- writer::tests::manifest_carries_model_hint`
+Then a full lib check: `cargo test -p mur-common`
+Expected: PASS; the crate now compiles (Task 1's literal gap is closed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/muragent/writer.rs
+git commit -m "feat(muragent): populate model_hint from inline binding on export"
+```
+
+---
+
+## Task 4: Sanitize strips `model_ref`
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/export.rs:89-121` (`sanitize_profile_for_export`)
+- Test: `mur-core/src/cmd/agent/export.rs` (inline test module)
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test module at the bottom of `export.rs`:
+
+```rust
+#[cfg(test)]
+mod sanitize_tests {
+    use super::*;
+    use mur_common::AgentProfile;
+
+    #[test]
+    fn sanitize_strips_model_ref() {
+        let mut p = AgentProfile::default_for_tests();
+        p.model_ref = Some("anthropic_opus_4_7".into());
+        let removed = sanitize_profile_for_export(&mut p);
+        assert!(p.model_ref.is_none(), "model_ref must be stripped");
+        assert!(
+            removed.iter().any(|r| r == "model_ref"),
+            "removed list must record model_ref, got {removed:?}"
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core -- sanitize_tests::sanitize_strips_model_ref`
+Expected: FAIL — `model_ref` still `Some`, not in removed list.
+
+- [ ] **Step 3: Strip `model_ref` in `sanitize_profile_for_export`**
+
+In `sanitize_profile_for_export`, just before `removed` is returned (after the `transport.socket.auth` block), add:
+
+```rust
+    if profile.model_ref.is_some() {
+        removed.push("model_ref".to_string());
+        profile.model_ref = None;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-core -- sanitize_tests::sanitize_strips_model_ref`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/export.rs
+git commit -m "fix(export): strip model_ref from exported profile (no registry/secret leak)"
+```
+
+---
+
+## Task 5: Override `model_hint` from the registry when `model_ref` was set
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/export.rs:37-84` (`export_muragent`)
+- Test: `mur-core/src/cmd/agent/export.rs` (inline test module)
+
+The inline `model:` block may be a stale default when the agent actually binds via `model_ref`. After building the manifest, if the *original* profile had a `model_ref`, resolve it in the registry and overwrite `model_hint` so the recipient's wizard sees the real tier.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `sanitize_tests` module (it already imports what we need; add a registry-backed test):
+
+```rust
+    #[test]
+    fn model_hint_override_uses_registry_entry() {
+        use mur_common::model::{ModelEntry, ModelRegistry};
+        let reg = ModelRegistry {
+            schema_version: 1,
+            models: std::collections::BTreeMap::from([(
+                "anthropic_opus_4_7".to_string(),
+                ModelEntry {
+                    provider: "anthropic".into(),
+                    model: "claude-opus-4-7".into(),
+                    base_url: None,
+                    secret: None,
+                    capabilities: vec![],
+                    params: serde_json::Value::Null,
+                },
+            )]),
+            roles: Default::default(),
+        };
+        let hint = model_hint_from_ref("anthropic_opus_4_7", &reg).expect("resolved");
+        assert_eq!(hint.tier, mur_common::muragent::manifest::ModelTier::Frontier);
+        assert!(!hint.local_capable);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core -- sanitize_tests::model_hint_override`
+Expected: FAIL — `cannot find function model_hint_from_ref`.
+
+- [ ] **Step 3: Add the helper and call it in `export_muragent`**
+
+Add this pure helper near `sanitize_profile_for_export` in `export.rs`:
+
+```rust
+/// Resolve a `model_ref` against a registry into a `ModelHint`. Returns
+/// `None` when the registry has no such entry (the inline-derived hint
+/// then stands).
+fn model_hint_from_ref(
+    model_ref: &str,
+    registry: &mur_common::model::ModelRegistry,
+) -> Option<mur_common::muragent::manifest::ModelHint> {
+    registry
+        .models
+        .get(model_ref)
+        .map(|e| mur_common::muragent::model_class::classify(&e.provider, &e.model))
+}
+```
+
+In `export_muragent`, the manifest is built before sanitization. Capture the original `model_ref` and override the hint. Change:
+
+```rust
+    let mur_version = env!("CARGO_PKG_VERSION");
+    let mut manifest = build_manifest_from_profile(&profile, mur_version);
+```
+
+to:
+
+```rust
+    let mur_version = env!("CARGO_PKG_VERSION");
+    let mut manifest = build_manifest_from_profile(&profile, mur_version);
+
+    // If the agent binds via model_ref, the inline-derived hint may be a
+    // stale default — override it from the registry entry (§7.1).
+    if let Some(model_ref) = profile.model_ref.as_deref() {
+        let reg_path = mur_common::model::ModelRegistry::default_path()?;
+        let registry = mur_common::model::ModelRegistry::load_from(&reg_path)?;
+        if let Some(hint) = model_hint_from_ref(model_ref, &registry) {
+            manifest.model_hint = Some(hint);
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-core -- sanitize_tests::model_hint_override`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/export.rs
+git commit -m "feat(export): override model_hint from registry when model_ref is set"
+```
+
+---
+
+## Task 6: Resolution decision tree (`recommend`)
+
+**Files:**
+- Create: `mur-common/src/model_resolve.rs`
+- Modify: `mur-common/src/lib.rs`
+- Test: `mur-common/src/model_resolve.rs` (inline)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-common/src/model_resolve.rs`:
+
+```rust
+//! First-run model-resolution decision tree (spec §7.3). Pure logic shared
+//! by the CLI (Plan 1b) and the Hub GUI wizard (Plan 2). Hardware detection
+//! and the actual pull/key-entry actions live in the surface layers; this
+//! module only decides the recommended default given a hint + hardware.
+
+use crate::muragent::manifest::ModelHint;
+
+/// Recipient hardware snapshot. `apple_silicon` and `ollama_present` inform
+/// which options a surface offers; the recommendation itself keys off RAM
+/// and the hint's `local_capable` flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Hardware {
+    pub total_ram_gb: u32,
+    pub apple_silicon: bool,
+    pub ollama_present: bool,
+}
+
+/// The highlighted default the wizard should pre-select. All escape hatches
+/// (local pull / paste key / endpoint) remain available regardless (§7.3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Recommendation {
+    Local,
+    Cloud,
+    CloudOrSmallerLocal,
+    NeutralMenu,
+}
+
+pub fn recommend(hint: Option<&ModelHint>, hw: &Hardware) -> Recommendation {
+    match hint {
+        None => Recommendation::NeutralMenu,
+        Some(h) if !h.local_capable => Recommendation::Cloud,
+        Some(h) if hw.total_ram_gb >= h.min_ram_gb => Recommendation::Local,
+        Some(_) => Recommendation::CloudOrSmallerLocal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::muragent::manifest::ModelTier;
+
+    fn hint(local: bool, min_ram: u32) -> ModelHint {
+        ModelHint {
+            provider: "p".into(),
+            name: "n".into(),
+            tier: if local { ModelTier::Small } else { ModelTier::Frontier },
+            min_ram_gb: min_ram,
+            local_capable: local,
+        }
+    }
+    fn hw(ram: u32) -> Hardware {
+        Hardware { total_ram_gb: ram, apple_silicon: true, ollama_present: true }
+    }
+
+    #[test]
+    fn no_hint_is_neutral() {
+        assert_eq!(recommend(None, &hw(16)), Recommendation::NeutralMenu);
+    }
+    #[test]
+    fn frontier_is_cloud() {
+        assert_eq!(recommend(Some(&hint(false, 0)), &hw(16)), Recommendation::Cloud);
+    }
+    #[test]
+    fn local_with_enough_ram_is_local() {
+        assert_eq!(recommend(Some(&hint(true, 8)), &hw(16)), Recommendation::Local);
+    }
+    #[test]
+    fn local_without_ram_is_cloud_or_smaller() {
+        assert_eq!(
+            recommend(Some(&hint(true, 16)), &hw(8)),
+            Recommendation::CloudOrSmallerLocal
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-common model_resolve`
+Expected: FAIL — module not declared (`cannot find`).
+
+- [ ] **Step 3: Declare the module**
+
+In `mur-common/src/lib.rs`, add alongside the other top-level `pub mod` lines:
+
+```rust
+pub mod model_resolve;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-common model_resolve`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/model_resolve.rs mur-common/src/lib.rs
+git commit -m "feat(model): first-run resolution decision tree (local-first, cloud-honest)"
+```
+
+---
+
+## Task 7: Retire `--format=gui` / `--format=bin`
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/export.rs` (`cmd_export`; delete `export_bin` + `locate_runtime_manifest_dir`)
+- Modify: `mur-core/src/dispatch.rs:974-1003` (drop the `gui` special-case)
+- Test: `mur-core/src/cmd/agent/export.rs` (inline)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `sanitize_tests` module in `export.rs`:
+
+```rust
+    #[test]
+    fn removed_formats_redirect() {
+        for fmt in ["bin", "gui"] {
+            let err = cmd_export("coach", "/tmp/out", fmt).unwrap_err().to_string();
+            assert!(err.contains(".muragent"), "fmt {fmt}: {err}");
+            assert!(err.contains("--load"), "fmt {fmt}: {err}");
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core -- sanitize_tests::removed_formats_redirect`
+Expected: FAIL — `bin` currently calls `export_bin` (cargo build) and `gui` is unreachable here (handled in dispatch); no redirect error.
+
+- [ ] **Step 3: Add the early redirect; delete `export_bin`**
+
+At the very top of `cmd_export`, before `resolve_mur_home()`:
+
+```rust
+pub fn cmd_export(name: &str, out: &str, format: &str) -> Result<()> {
+    if matches!(format, "bin" | "gui") {
+        bail!(
+            "--format={format} is no longer supported.\n\
+             Export a portable .muragent (the default) and share that one file:\n  \
+             mur agent export {name} -o {name}.muragent\n\
+             Recipients open it with the MuR Hub app, or run it headless with:\n  \
+             mur-agent-runtime --load {name}.muragent"
+        );
+    }
+    let mur_home = resolve_mur_home()?;
+```
+
+Remove the now-dead `"bin" => export_bin(...)` arm from the `match format` block (leave `muragent`, `pkg`, and the `other => bail!(...)` arms). Delete the `export_bin` function and the `locate_runtime_manifest_dir` helper entirely (and any now-unused imports they pulled in, e.g. `PathBuf` if unused — let the compiler guide you).
+
+- [ ] **Step 4: Route `gui` through `cmd_export` in dispatch**
+
+In `mur-core/src/dispatch.rs`, replace the whole `AgentAction::Export { … }` arm (the `if format == "gui" { … } else { … }` block) with:
+
+```rust
+        AgentAction::Export { name, out, format, .. } => {
+            cmd::agent::cmd_export(&name, &out, &format)?;
+        }
+```
+
+The `..` drops the gui-only `theme`/`icon`/`clone_identity`/`skip_notarize` bindings (now unused). Remove the `use`/call of `cmd::agent_export_gui` if it is no longer referenced anywhere else (compiler will flag an unused import).
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `cargo test -p mur-core -- sanitize_tests::removed_formats_redirect`
+Then: `cargo build -p mur-core`
+Expected: test PASS; crate builds (fix any unused-import warnings the deletions surfaced).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/export.rs mur-core/src/dispatch.rs
+git commit -m "refactor(export): retire --format=gui/bin with redirect; drop secret-leaking export_bin"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (Plan 1 scope):**
+- §7.1 `model_hint` field → Task 1; classification table → Task 2; populated on export → Tasks 3 & 5. ✓
+- §7.2 sanitize converts `model_ref` away (no registry/secret travels) → Task 4 (strip) + Task 5 (hint from registry). ✓
+- §7.3 decision tree → Task 6. ✓
+- §8/D retire `gui`/`bin`, remove secret-leaking `export_bin` → Task 7. ✓
+- Out-of-scope by design: `--load` (Plan 1b), GUI/distribution (Plan 2) — listed in "Scope & follow-on plans". ✓
+
+**2. Placeholder scan:** No "TBD"/"add error handling"/"similar to". Every code step shows the full code. ✓
+
+**3. Type consistency:** `ModelHint { provider, name, tier, min_ram_gb, local_capable }` and `ModelTier { Small, Mid, Frontier }` are used identically in Tasks 1, 2, 3, 5, 6. `classify(&str, &str) -> ModelHint` called the same way in Tasks 3 and 5. `recommend(Option<&ModelHint>, &Hardware) -> Recommendation` self-consistent in Task 6. `ModelEntry`/`ModelRegistry` field names match `mur-common/src/model.rs` (`provider`, `model`, `base_url`, `secret`, `capabilities`, `params`; `schema_version`, `models`, `roles`). ✓
+
+**Verification note:** `AgentProfile::default_for_tests()` is used by existing `writer.rs` tests, so it is available in `mur-common`; for the `mur-core` `export.rs` tests confirm it is re-exported (it is referenced as `mur_common::AgentProfile`). If `default_for_tests` is not public from `mur-core`'s view, construct the profile via `AgentProfile::default()` and set the two fields the tests touch (`model`, `model_ref`).

--- a/docs/superpowers/plans/2026-05-29-agent-export-ux-plan-1b-runtime-load.md
+++ b/docs/superpowers/plans/2026-05-29-agent-export-ux-plan-1b-runtime-load.md
@@ -1,0 +1,305 @@
+# Agent Export UX — Plan 1b: Runtime `--load` + `--model` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `mur-agent-runtime` a toolchain-free, signing-intact "run a `.muragent`" path for developers and servers: `mur-agent-runtime --load <path.muragent>` installs and runs the agent headless, and `--model <ref>` rebinds the model backend non-interactively (for servers that have no GUI/prompt).
+
+**Architecture:** No new format and no embedding. The pre-built (already-signed) runtime reuses the existing `mur-common::muragent::installer` to extract a `.muragent` into `~/.mur/agents/<slug>/`, then runs the normal supervisor for that slug. `--model` sets `profile.model_ref` after profile load; the existing `build_provider_runner` → `resolve_model_entry` path already honors `model_ref` against `~/.mur/models.yaml`, so the backend switches with no further wiring.
+
+**Tech Stack:** Rust (edition 2024), `anyhow`, existing `mur-common::muragent` installer/reader, existing `mur-agent-runtime` supervisor.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-mur-agent-export-ux-give-to-a-friend-design.md` §8 (D — toolchain-free developer replacement) and §7.5 (non-interactive surface).
+
+**Depends on:** Plan 1 (no hard code dependency, but ships after it so `--format=bin` is already retired and `.muragent` is the only export).
+
+---
+
+## Scope & boundaries
+
+- **In scope:** runtime argument parsing (`--load`, `--model`); `--load` install-and-run; `--model` non-interactive rebind; an integration test for the load path.
+- **Out of scope (Plan 2):** guided/interactive model resolution (hardware detection, Ollama detect/pull, `recommend()`-driven prompts, auto `mur model add`). Developers using `--model` are expected to have created the registry entry with the existing `mur model add` command. The guided wizard is a Plan 2 deliverable shared by CLI and Hub GUI.
+
+---
+
+## File structure
+
+- `mur-agent-runtime/src/subcommand.rs` — **Modify** (currently a one-line doc stub). Add the pure `flag_value` argument helper.
+- `mur-agent-runtime/src/supervisor.rs` — **Modify.** Add a `--load` branch to agent-home resolution (`entrypoint`, around line 62-91) and a `--model` override after `Profile::load` (around line 100-106). Add the `load_muragent_and_home` helper.
+- `mur-agent-runtime/tests/load_muragent.rs` — **Create.** Integration test: build a `.muragent`, load it, assert the agent home is materialized.
+
+---
+
+## Task 1: `flag_value` argument helper
+
+**Files:**
+- Modify: `mur-agent-runtime/src/subcommand.rs`
+- Test: same file (inline)
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the contents of `mur-agent-runtime/src/subcommand.rs` with:
+
+```rust
+//! CLI subcommand / flag parsing for the agent runtime binary.
+
+/// Return the value following `flag` in `args`, supporting both
+/// `--flag value` and `--flag=value` forms. Returns the first match.
+pub fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    let eq_prefix = format!("{flag}=");
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == flag {
+            return iter.next().cloned();
+        }
+        if let Some(rest) = arg.strip_prefix(&eq_prefix) {
+            return Some(rest.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(xs: &[&str]) -> Vec<String> {
+        xs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn space_separated_form() {
+        let a = args(&["mur-agent-runtime", "--load", "coach.muragent"]);
+        assert_eq!(flag_value(&a, "--load"), Some("coach.muragent".to_string()));
+    }
+
+    #[test]
+    fn equals_form() {
+        let a = args(&["mur-agent-runtime", "--model=anthropic_opus_4_7"]);
+        assert_eq!(flag_value(&a, "--model"), Some("anthropic_opus_4_7".to_string()));
+    }
+
+    #[test]
+    fn absent_flag_is_none() {
+        let a = args(&["mur-agent-runtime"]);
+        assert_eq!(flag_value(&a, "--load"), None);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails, then passes**
+
+Run: `cargo test -p mur-agent-runtime subcommand`
+Expected: the module compiles and the three tests PASS (this task is the implementation + test together; if `flag_value` had a bug the tests would fail).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-agent-runtime/src/subcommand.rs
+git commit -m "feat(runtime): flag_value argument helper"
+```
+
+---
+
+## Task 2: `--load <path.muragent>` install-and-run
+
+**Files:**
+- Modify: `mur-agent-runtime/src/supervisor.rs` (`entrypoint`, agent-home resolution block at lines ~62-91; add helper near it)
+
+- [ ] **Step 1: Add the `load_muragent_and_home` helper**
+
+Add this function in `supervisor.rs` (near `resolve_embedded_agent_home`):
+
+```rust
+/// `--load` path: install a `.muragent` into `mur_home/agents/<slug>` (reusing
+/// the shared installer — validation, trust, extraction) and return that home.
+/// Stashes the slug as the expected name so the post-load name check passes.
+fn load_muragent_and_home(path: &str, mur_home: &Path) -> anyhow::Result<PathBuf> {
+    use mur_common::muragent::installer;
+    use mur_common::muragent::reader::MuragentArchive;
+
+    let archive = MuragentArchive::read(Path::new(path))
+        .map_err(|e| anyhow::anyhow!("read .muragent at {path}: {e}"))?;
+    let outcome = installer::install(&archive, mur_home, "cli")
+        .map_err(|e| anyhow::anyhow!("install .muragent: {e}"))?;
+    let slug = outcome.manifest.agent.slug.clone();
+    // SAFETY: single-threaded startup, before any tokio tasks spawn.
+    unsafe {
+        std::env::set_var("MUR_RUNTIME_EXPECTED_NAME", &slug);
+    }
+    Ok(mur_home.join("agents").join(&slug))
+}
+```
+
+- [ ] **Step 2: Add the `--load` branch to agent-home resolution**
+
+In `entrypoint`, the agent-home resolution currently reads:
+
+```rust
+    let embedded_override = std::env::var_os("MUR_AGENT_EXTERNAL_PROFILE").is_some();
+    let mur_home = std::env::var_os("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"));
+    let agent_home = if crate::export::bin_embed::has_embedded_agent() && !embedded_override {
+```
+
+Insert a `--load` branch as the first condition:
+
+```rust
+    let embedded_override = std::env::var_os("MUR_AGENT_EXTERNAL_PROFILE").is_some();
+    let mur_home = std::env::var_os("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"));
+    let argv: Vec<String> = std::env::args().collect();
+    let load_path = crate::subcommand::flag_value(&argv, "--load");
+    let agent_home = if let Some(path) = load_path {
+        match load_muragent_and_home(&path, &mur_home) {
+            Ok(home) => home,
+            Err(e) => {
+                eprintln!("error[load]: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else if crate::export::bin_embed::has_embedded_agent() && !embedded_override {
+```
+
+(The rest of the `if/else` chain is unchanged — the embedded branch and the argv0 branch now follow as `else if` / `else`.)
+
+- [ ] **Step 3: Build**
+
+Run: `cargo build -p mur-agent-runtime`
+Expected: compiles. (Behavior is covered by the integration test in Task 4.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-agent-runtime/src/supervisor.rs
+git commit -m "feat(runtime): --load <path.muragent> installs and runs the agent headless"
+```
+
+---
+
+## Task 3: `--model <ref>` non-interactive rebind
+
+**Files:**
+- Modify: `mur-agent-runtime/src/supervisor.rs` (`entrypoint`, after `Profile::load` at lines ~100-106)
+
+- [ ] **Step 1: Make the profile mutable and apply the override**
+
+The profile load currently reads:
+
+```rust
+    let profile = match Profile::load(&agent_home) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error[profile_invalid]: {e}");
+            std::process::exit(1);
+        }
+    };
+```
+
+Change to capture as `mut` and apply `--model`:
+
+```rust
+    let mut profile = match Profile::load(&agent_home) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error[profile_invalid]: {e}");
+            std::process::exit(1);
+        }
+    };
+    // Non-interactive model rebind for headless/server use (§7.5). Honored
+    // by build_provider_runner via resolve_model_entry, which prefers
+    // model_ref over the inline model: block.
+    if let Some(model_ref) = crate::subcommand::flag_value(&argv, "--model") {
+        info!(model_ref = %model_ref, "overriding model binding from --model");
+        profile.inner.model_ref = Some(model_ref);
+    }
+```
+
+(`argv` is already in scope from Task 2. `info!` is already imported in `supervisor.rs`.)
+
+- [ ] **Step 2: Build**
+
+Run: `cargo build -p mur-agent-runtime`
+Expected: compiles. If the borrow checker complains that `profile` no longer needs `mut` when `--model` is compiled out, it will not — the assignment inside the `if let` keeps `mut` live.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-agent-runtime/src/supervisor.rs
+git commit -m "feat(runtime): --model <ref> rebinds backend non-interactively"
+```
+
+---
+
+## Task 4: Integration test for `--load`
+
+**Files:**
+- Create: `mur-agent-runtime/tests/load_muragent.rs`
+
+The supervisor's `load_muragent_and_home` is private; test the observable effect through the public installer the same way `--load` does, asserting an agent home is materialized from a freshly-written `.muragent`.
+
+- [ ] **Step 1: Write the test**
+
+Create `mur-agent-runtime/tests/load_muragent.rs`:
+
+```rust
+//! `--load` materializes an agent home from a `.muragent`. Mirrors the
+//! supervisor's load path (read archive → installer::install → agents/<slug>).
+
+use mur_common::agent::AgentProfile;
+use mur_common::identity::AgentIdentity;
+use mur_common::muragent::installer;
+use mur_common::muragent::reader::MuragentArchive;
+use mur_common::muragent::writer::{MuragentWriter, build_manifest_from_profile};
+
+#[test]
+fn load_muragent_materializes_agent_home() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let pkg = tmp.path().join("coach.muragent");
+    let mur_home = tmp.path().join("murhome");
+
+    // Author a minimal signed .muragent.
+    let mut profile = AgentProfile::default_for_tests();
+    profile.name = "coach".into();
+    profile.display_name = "Coach".into();
+    let identity = AgentIdentity::generate();
+    let manifest = build_manifest_from_profile(&profile, "1.0.0");
+    let profile_yaml = serde_yaml_ng::to_string(&profile).unwrap();
+    MuragentWriter::new(manifest, profile_yaml, identity)
+        .write(&pkg)
+        .unwrap();
+
+    // The load path: read + install into mur_home/agents/<slug>.
+    let archive = MuragentArchive::read(&pkg).unwrap();
+    let outcome = installer::install(&archive, &mur_home, "cli").unwrap();
+    assert_eq!(outcome.manifest.agent.slug, "coach");
+
+    let home = mur_home.join("agents").join("coach");
+    assert!(home.join("profile.yaml").exists(), "profile.yaml extracted");
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cargo test -p mur-agent-runtime --test load_muragent`
+Expected: PASS. (If `MuragentWriter::new` / `write` signatures differ, align with the usage in `mur-common/src/muragent/writer.rs` tests — they construct the writer identically.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-agent-runtime/tests/load_muragent.rs
+git commit -m "test(runtime): --load materializes agent home from .muragent"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** §8 toolchain-free developer replacement (`--load`) → Tasks 2 & 4; §7.5 non-interactive `--model` → Task 3; arg parsing prerequisite → Task 1. Guided resolution explicitly deferred to Plan 2 (see Scope). ✓
+
+**2. Placeholder scan:** No "TBD"/"add handling"/"similar to". Every code step shows full code. ✓
+
+**3. Type consistency:** `flag_value(&[String], &str) -> Option<String>` defined in Task 1 and called identically in Tasks 2 & 3. `load_muragent_and_home(&str, &Path) -> anyhow::Result<PathBuf>` returns the home used by `entrypoint`. `installer::install(&archive, mur_home, "cli") -> InstallOutcome` and `outcome.manifest.agent.slug` match `mur-core/src/cmd/agent/install.rs` usage. `profile.inner.model_ref: Option<String>` matches `AgentProfile` (`mur-common/src/agent.rs:59`). ✓
+
+**Verification note:** `MuragentWriter::new(manifest, profile_yaml, identity)` + `.write(path)` is the constructor used by `mur-core/src/cmd/agent/export.rs::export_muragent`; if the writer test in `mur-common` uses a builder variant, copy that exact form. `AgentProfile::default_for_tests()` is available in `mur-common` test/dev builds (used by `writer.rs` tests); the integration test runs against `mur-common`'s public surface.

--- a/docs/superpowers/plans/2026-05-29-agent-export-ux-plan-2-share-and-model-resolution.md
+++ b/docs/superpowers/plans/2026-05-29-agent-export-ux-plan-2-share-and-model-resolution.md
@@ -1,0 +1,581 @@
+# Agent Export UX — Plan 2: Share Command + Model-Resolution Backend
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Rust backend for the consumer giveaway loop's producer + recipient model steps: a Hub "Share this agent" command that produces a `.muragent`, an extension of the import inspection to surface the `model_hint`, host-hardware detection, and a shared `apply_model_choice` mechanism that writes a `~/.mur/models.yaml` entry and rebinds the installed agent — consumed by both the CLI (`mur agent install`) and (in Plan 3) the Hub GUI wizard.
+
+**Architecture:** `mur-hub-gui` already depends on `mur-core`, so the Share command is a thin Tauri wrapper over a newly-public `mur-core` export entry point. Model resolution reuses Plan 1's pure `recommend()` (in `mur-common`) plus new I/O helpers in `mur-core` (`Hardware::detect`, `apply_model_choice`) that both the CLI and the GUI call. No new format; weights never travel.
+
+**Tech Stack:** Rust (edition 2024), Tauri 2, `sysinfo` (new dep in `mur-core` for RAM), existing `mur-common::model` registry + `mur-common::muragent`.
+
+**Spec:** §6 (C — Share), §7.1–7.5 (B — model resolution).
+
+**Depends on:** Plan 1 (`ModelHint`, `ModelTier`, `classify`, `Hardware`, `Recommendation`, `recommend`). Ships after Plan 1.
+
+---
+
+## Scope & boundaries
+
+- **In scope (this plan, Rust + Tauri commands):** public `mur-core` export entry point; Hub `export_muragent_file` command; `MuragentInspection.model_hint`; `Hardware::detect`; `ModelChoice` + `apply_model_choice`; Hub `model_resolution_view` / `apply_model_choice` commands; CLI interactive resolution in `mur agent install`.
+- **Out of scope → Plan 3 (frontend + distribution):** the React UI (Share button, import-dialog model-wizard step) in `mur-hub-gui/ui`; `tauri.conf.json` `fileAssociations` / deep-link plugin / `dmg` target / mur Developer-ID notarization; OS open-file/url routing in `lib.rs`; first-launch onboarding (`/Applications`, `lsregister`, doctor). Plan 3 needs its own exploration of the `ui/` React tree and the release/signing pipeline before it can be bite-sized; it is outlined at the end of this file.
+
+---
+
+## File structure
+
+- `mur-core/src/cmd/agent/export.rs` — **Modify.** Add `pub fn export_agent_to_muragent(name, out)` (resolve home + call the existing `export_muragent`).
+- `mur-core/src/cmd/agent/model_resolve.rs` — **Create.** `ModelChoice`, `Hardware::detect`, `apply_model_choice`. Re-export Plan 1's `recommend`.
+- `mur-core/src/cmd/agent/mod.rs` — **Modify.** `pub mod model_resolve;` + export the new fns.
+- `mur-core/Cargo.toml` — **Modify.** Add `sysinfo`.
+- `mur-core/src/cmd/agent/install.rs` — **Modify.** Interactive model resolution after install.
+- `mur-hub-gui/src-tauri/src/export_muragent.rs` — **Create.** `export_muragent_file` command.
+- `mur-hub-gui/src-tauri/src/import_muragent.rs` — **Modify.** Add `model_hint` to `MuragentInspection`; add `model_resolution_view` + `apply_model_choice` commands.
+- `mur-hub-gui/src-tauri/src/lib.rs` — **Modify.** Register the three new commands.
+
+---
+
+## Task 1: Public export entry point in `mur-core`
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/export.rs`
+- Test: same file (`sanitize_tests` module from Plan 1)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `sanitize_tests` module:
+
+```rust
+    #[test]
+    fn export_entry_point_writes_muragent() {
+        use mur_common::identity::AgentIdentity;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path().join("agents").join("coach");
+        std::fs::create_dir_all(&home).unwrap();
+        let mut p = mur_common::AgentProfile::default_for_tests();
+        p.name = "coach".into();
+        std::fs::write(home.join("profile.yaml"), serde_yaml_ng::to_string(&p).unwrap()).unwrap();
+        AgentIdentity::generate().save(&home).unwrap();
+
+        let out = tmp.path().join("coach.muragent");
+        export_muragent("coach", &home, &out).unwrap();
+        assert!(out.exists(), ".muragent written");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails, then add the public wrapper**
+
+Run: `cargo test -p mur-core -- sanitize_tests::export_entry_point`
+Expected: PASS if `export_muragent` already works against a temp home (it is the existing private fn). If it needs a public, agent-name-only entry point for Hub, add:
+
+```rust
+/// Resolve an installed agent's home and export it to `out` as a `.muragent`.
+/// Public so the Hub "Share" command (mur-hub-gui) can reuse the exact CLI path.
+pub fn export_agent_to_muragent(name: &str, out: &Path) -> Result<()> {
+    let mur_home = resolve_mur_home()?;
+    let agent_home = mur_home.join("agents").join(name);
+    if !agent_home.exists() {
+        bail!("agent '{name}' not found");
+    }
+    export_muragent(name, &agent_home, out)
+}
+```
+
+- [ ] **Step 3: Run + commit**
+
+Run: `cargo test -p mur-core -- sanitize_tests::export_entry_point`
+Expected: PASS.
+
+```bash
+git add mur-core/src/cmd/agent/export.rs
+git commit -m "feat(export): public export_agent_to_muragent entry point for Hub reuse"
+```
+
+---
+
+## Task 2: `MuragentInspection.model_hint`
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/import_muragent.rs`
+
+The import dialog must show what model the agent needs so the recipient can resolve it. Surface `manifest.model_hint` in the inspection struct.
+
+- [ ] **Step 1: Add the field + a view type**
+
+In `import_muragent.rs`, add a serializable view near `DeclaredPermissions`:
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelHintView {
+    pub provider: String,
+    pub name: String,
+    pub tier: String,        // "small" | "mid" | "frontier"
+    pub min_ram_gb: u32,
+    pub local_capable: bool,
+}
+```
+
+Add this field to `MuragentInspection` (after `permissions`):
+
+```rust
+    /// Model the agent was authored against, for first-run resolution (§7.1).
+    pub model_hint: Option<ModelHintView>,
+```
+
+- [ ] **Step 2: Populate it in `build_inspection`**
+
+Find where `build_inspection` constructs the `MuragentInspection { … }` literal and add (mapping the manifest field):
+
+```rust
+        model_hint: manifest.model_hint.as_ref().map(|h| ModelHintView {
+            provider: h.provider.clone(),
+            name: h.name.clone(),
+            tier: format!("{:?}", h.tier).to_lowercase(),
+            min_ram_gb: h.min_ram_gb,
+            local_capable: h.local_capable,
+        }),
+```
+
+- [ ] **Step 3: Build + commit**
+
+Run: `cargo build -p mur-hub-gui` (or `cargo check --manifest-path mur-hub-gui/src-tauri/Cargo.toml`)
+Expected: compiles.
+
+```bash
+git add mur-hub-gui/src-tauri/src/import_muragent.rs
+git commit -m "feat(hub): surface model_hint in muragent inspection"
+```
+
+---
+
+## Task 3: `ModelChoice` + `Hardware::detect` + `apply_model_choice`
+
+**Files:**
+- Create: `mur-core/src/cmd/agent/model_resolve.rs`
+- Modify: `mur-core/src/cmd/agent/mod.rs`, `mur-core/Cargo.toml`
+
+- [ ] **Step 1: Add `sysinfo` to `mur-core/Cargo.toml`**
+
+Under `[dependencies]`:
+
+```toml
+sysinfo = "0.32"
+```
+
+- [ ] **Step 2: Write the failing test + module**
+
+Create `mur-core/src/cmd/agent/model_resolve.rs`:
+
+```rust
+//! First-run model resolution (I/O side). Pairs with the pure `recommend()`
+//! decision tree in `mur_common::model_resolve`. Shared by the CLI
+//! (`mur agent install`) and the Hub GUI wizard (Plan 3). Spec §7.3–7.5.
+
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use mur_common::model::{ModelEntry, ModelRegistry};
+use mur_common::model_resolve::Hardware;
+use serde::{Deserialize, Serialize};
+
+/// A concrete resolution the user (or a flag) selected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelChoice {
+    pub provider: String,
+    pub model: String,
+    #[serde(default)]
+    pub base_url: Option<String>,
+    /// Secret ref string (e.g. "env:OPENAI_API_KEY"); recipient-supplied,
+    /// never from the package.
+    #[serde(default)]
+    pub secret: Option<String>,
+}
+
+/// Detect host capabilities used by `recommend()` and the wizard UI.
+pub fn detect_hardware() -> Hardware {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    let total_ram_gb = (sys.total_memory() / 1024 / 1024 / 1024) as u32;
+    let apple_silicon = cfg!(all(target_os = "macos", target_arch = "aarch64"));
+    let ollama_present = which_ollama();
+    Hardware { total_ram_gb, apple_silicon, ollama_present }
+}
+
+fn which_ollama() -> bool {
+    std::process::Command::new("ollama")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Stable registry key for a choice, e.g. "ollama_llama3_2_3b".
+pub fn choice_ref_name(choice: &ModelChoice) -> String {
+    let raw = format!("{}_{}", choice.provider, choice.model);
+    raw.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c.to_ascii_lowercase() } else { '_' })
+        .collect()
+}
+
+/// Write a `models.yaml` entry for `choice` and set the installed agent's
+/// `model_ref` to it. Returns the registry key used.
+pub fn apply_model_choice(mur_home: &Path, slug: &str, choice: &ModelChoice) -> Result<String> {
+    let agent_home = mur_home.join("agents").join(slug);
+    let profile_path = agent_home.join("profile.yaml");
+    if !profile_path.exists() {
+        bail!("agent '{slug}' not installed at {}", profile_path.display());
+    }
+
+    // 1. Upsert the registry entry.
+    let reg_path = ModelRegistry::default_path()?;
+    let mut reg = ModelRegistry::load_from(&reg_path)?;
+    let key = choice_ref_name(choice);
+    reg.models.insert(
+        key.clone(),
+        ModelEntry {
+            provider: choice.provider.clone(),
+            model: choice.model.clone(),
+            base_url: choice.base_url.clone(),
+            secret: choice.secret.as_deref().map(|s| s.parse()).transpose()?,
+            capabilities: vec![],
+            params: serde_json::Value::Null,
+        },
+    );
+    reg.save_to(&reg_path)?;
+
+    // 2. Point the agent at it.
+    let mut profile: mur_common::AgentProfile =
+        serde_yaml_ng::from_str(&std::fs::read_to_string(&profile_path)?)
+            .with_context(|| format!("parse {}", profile_path.display()))?;
+    profile.model_ref = Some(key.clone());
+    let yaml = serde_yaml_ng::to_string(&profile)?;
+    std::fs::write(&profile_path, yaml).with_context(|| format!("write {}", profile_path.display()))?;
+
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_returns_plausible_ram() {
+        let hw = detect_hardware();
+        assert!(hw.total_ram_gb > 0, "RAM detection should be non-zero");
+    }
+
+    #[test]
+    fn choice_ref_name_is_sanitized() {
+        let c = ModelChoice {
+            provider: "ollama".into(),
+            model: "llama3.2:3b".into(),
+            base_url: None,
+            secret: None,
+        };
+        assert_eq!(choice_ref_name(&c), "ollama_llama3_2_3b");
+    }
+
+    #[test]
+    fn apply_writes_registry_and_sets_model_ref() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mur_home = tmp.path().to_path_buf();
+        let home = mur_home.join("agents").join("coach");
+        std::fs::create_dir_all(&home).unwrap();
+        let p = mur_common::AgentProfile::default_for_tests();
+        std::fs::write(home.join("profile.yaml"), serde_yaml_ng::to_string(&p).unwrap()).unwrap();
+
+        // Isolate the registry path to the temp home.
+        unsafe { std::env::set_var("MUR_HOME", &mur_home); }
+        let choice = ModelChoice {
+            provider: "ollama".into(),
+            model: "llama3.2:3b".into(),
+            base_url: None,
+            secret: None,
+        };
+        let key = apply_model_choice(&mur_home, "coach", &choice).unwrap();
+        assert_eq!(key, "ollama_llama3_2_3b");
+
+        let reloaded: mur_common::AgentProfile =
+            serde_yaml_ng::from_str(&std::fs::read_to_string(home.join("profile.yaml")).unwrap())
+                .unwrap();
+        assert_eq!(reloaded.model_ref.as_deref(), Some("ollama_llama3_2_3b"));
+    }
+}
+```
+
+> Note: `ModelRegistry::default_path()` honors `MUR_HOME` (confirm in `mur-common/src/model.rs:91`); if it does not read `MUR_HOME`, the test must point the registry path explicitly — adjust the test to call a path-taking variant. Verify before relying on the env override.
+
+- [ ] **Step 3: Declare the module**
+
+In `mur-core/src/cmd/agent/mod.rs`, add:
+
+```rust
+pub mod model_resolve;
+```
+
+- [ ] **Step 4: Run + commit**
+
+Run: `cargo test -p mur-core -- model_resolve`
+Expected: 3 tests PASS.
+
+```bash
+git add mur-core/src/cmd/agent/model_resolve.rs mur-core/src/cmd/agent/mod.rs mur-core/Cargo.toml
+git commit -m "feat(model): hardware detect + apply_model_choice (registry + model_ref)"
+```
+
+---
+
+## Task 4: Hub Tauri commands (Share + resolution)
+
+**Files:**
+- Create: `mur-hub-gui/src-tauri/src/export_muragent.rs`
+- Modify: `mur-hub-gui/src-tauri/src/import_muragent.rs`, `mur-hub-gui/src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Create the Share command**
+
+Create `mur-hub-gui/src-tauri/src/export_muragent.rs`:
+
+```rust
+//! `mur agent export` — Hub side. Produces a `.muragent` from an installed
+//! agent using the exact CLI path (template/sanitized). Spec §6 (C).
+
+use std::path::Path;
+
+#[tauri::command]
+pub fn export_muragent_file(name: String, out_path: String) -> Result<String, String> {
+    mur_core::cmd::agent::export::export_agent_to_muragent(&name, Path::new(&out_path))
+        .map_err(|e| e.to_string())?;
+    Ok(out_path)
+}
+```
+
+(Adjust the `mur_core::…` path to match how `export_agent_to_muragent` is re-exported; if `cmd` is private, add a `pub use` in `mur-core/src/lib.rs` or call through an existing public façade.)
+
+- [ ] **Step 2: Add resolution commands to `import_muragent.rs`**
+
+```rust
+use mur_core::cmd::agent::model_resolve::{ModelChoice, apply_model_choice, detect_hardware};
+use mur_common::model_resolve::{Recommendation, recommend};
+use mur_common::muragent::manifest::ModelHint;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ResolutionView {
+    pub hint: Option<ModelHintView>,
+    pub total_ram_gb: u32,
+    pub apple_silicon: bool,
+    pub ollama_present: bool,
+    pub recommendation: String, // "local" | "cloud" | "cloud_or_smaller_local" | "neutral_menu"
+}
+
+#[tauri::command]
+pub fn model_resolution_view(path: String) -> Result<ResolutionView, String> {
+    let archive = MuragentArchive::read(Path::new(&path)).map_err(|e| e.to_string())?;
+    let manifest_yaml = archive.get_str("manifest.yaml").map_err(|e| e.to_string())?;
+    let manifest: MuragentManifest =
+        serde_yaml_ng::from_str(manifest_yaml).map_err(|e| e.to_string())?;
+    let hw = detect_hardware();
+    let hint: Option<ModelHint> = manifest.model_hint.clone();
+    let rec = match recommend(hint.as_ref(), &hw) {
+        Recommendation::Local => "local",
+        Recommendation::Cloud => "cloud",
+        Recommendation::CloudOrSmallerLocal => "cloud_or_smaller_local",
+        Recommendation::NeutralMenu => "neutral_menu",
+    };
+    Ok(ResolutionView {
+        hint: hint.map(|h| ModelHintView {
+            provider: h.provider,
+            name: h.name,
+            tier: format!("{:?}", h.tier).to_lowercase(),
+            min_ram_gb: h.min_ram_gb,
+            local_capable: h.local_capable,
+        }),
+        total_ram_gb: hw.total_ram_gb,
+        apple_silicon: hw.apple_silicon,
+        ollama_present: hw.ollama_present,
+        recommendation: rec.to_string(),
+    })
+}
+
+#[tauri::command]
+pub fn apply_agent_model(slug: String, choice: ModelChoice) -> Result<String, String> {
+    let mur_home = trust::mur_home();
+    apply_model_choice(&mur_home, &slug, &choice).map_err(|e| e.to_string())
+}
+```
+
+- [ ] **Step 3: Register the three commands**
+
+In `mur-hub-gui/src-tauri/src/lib.rs`, add `pub mod export_muragent;` near the other module declarations, and add to the `tauri::generate_handler![ … ]` list (after the existing `import_muragent::*` entries):
+
+```rust
+            export_muragent::export_muragent_file,
+            import_muragent::model_resolution_view,
+            import_muragent::apply_agent_model,
+```
+
+- [ ] **Step 4: Build + commit**
+
+Run: `cargo check --manifest-path mur-hub-gui/src-tauri/Cargo.toml`
+Expected: compiles (resolve any `pub use` needed for the `mur_core::cmd::agent::…` paths).
+
+```bash
+git add mur-hub-gui/src-tauri/src/export_muragent.rs mur-hub-gui/src-tauri/src/import_muragent.rs mur-hub-gui/src-tauri/src/lib.rs
+git commit -m "feat(hub): Share command + model resolution view/apply Tauri commands"
+```
+
+---
+
+## Task 5: CLI interactive resolution in `mur agent install`
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/install.rs`
+
+After a successful install, if the agent has no resolvable model on this machine, run the §7.3 recommendation and prompt. Non-interactive callers can pre-set the binding with `mur model add` + edit, so the prompt only fires on a TTY.
+
+- [ ] **Step 1: Add a post-install resolution step**
+
+In `cmd_install`, after the success `println!`s and before `Ok(())`, add:
+
+```rust
+    maybe_resolve_model(&mur_home, &outcome.manifest.agent.slug, &archive)?;
+    Ok(())
+}
+
+fn maybe_resolve_model(
+    mur_home: &Path,
+    slug: &str,
+    archive: &MuragentArchive,
+) -> Result<()> {
+    use mur_common::model_resolve::{Recommendation, recommend};
+    use crate::cmd::agent::model_resolve::{ModelChoice, apply_model_choice, choice_ref_name, detect_hardware};
+
+    // Read the model hint from the package manifest.
+    let manifest_yaml = archive.get_str("manifest.yaml").context("read manifest.yaml")?;
+    let manifest: MuragentManifest = serde_yaml_ng::from_str(manifest_yaml)?;
+    let hint = manifest.model_hint.clone();
+    let hw = detect_hardware();
+    let rec = recommend(hint.as_ref(), &hw);
+
+    // Non-interactive (no TTY): print guidance and leave the binding as-is.
+    if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+        println!(
+            "  model: {} — set one with `mur model add` then run the agent with --model <ref>",
+            match rec {
+                Recommendation::Local => "local recommended (Ollama/MLX)",
+                Recommendation::Cloud => "cloud model recommended",
+                Recommendation::CloudOrSmallerLocal => "cloud or a smaller local model",
+                Recommendation::NeutralMenu => "choose a backend",
+            }
+        );
+        return Ok(());
+    }
+
+    // Interactive: offer the recommended default; fall back to a paste-key path.
+    println!("\nThis agent needs a model backend (no weights are bundled).");
+    if let Some(h) = &hint {
+        println!("  Authored for: {}/{} (tier {:?})", h.provider, h.name, h.tier);
+    }
+    let choice = prompt_model_choice(&rec, hint.as_ref())?;
+    if let Some(choice) = choice {
+        let key = apply_model_choice(mur_home, slug, &choice)?;
+        println!("  bound model_ref = {key}");
+    } else {
+        println!("  skipped — set one later with `mur model add`");
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Add the prompt helper**
+
+```rust
+fn prompt_model_choice(
+    rec: &mur_common::model_resolve::Recommendation,
+    hint: Option<&mur_common::muragent::manifest::ModelHint>,
+) -> Result<Option<crate::cmd::agent::model_resolve::ModelChoice>> {
+    use std::io::Write;
+    use mur_common::model_resolve::Recommendation;
+    use crate::cmd::agent::model_resolve::ModelChoice;
+
+    let default_local = hint.map(|h| (h.provider.clone(), h.name.clone()));
+    let prompt = match rec {
+        Recommendation::Local => "Pull a local model now? [Y/n] ",
+        Recommendation::Cloud | Recommendation::CloudOrSmallerLocal => {
+            "Paste an API key for a cloud model? [y/N] "
+        }
+        Recommendation::NeutralMenu => "Configure a model now? [y/N] ",
+    };
+    print!("{prompt}");
+    std::io::stdout().flush().ok();
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line)?;
+    let yes = matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes" | "");
+
+    if matches!(rec, Recommendation::Local) && yes {
+        if let Some((provider, model)) = default_local {
+            return Ok(Some(ModelChoice { provider, model, base_url: None, secret: None }));
+        }
+    }
+    if !yes {
+        return Ok(None);
+    }
+    // Cloud / neutral: collect provider + model + secret ref.
+    let provider = read_field("  provider (e.g. anthropic): ")?;
+    let model = read_field("  model (e.g. claude-opus-4-7): ")?;
+    let secret = read_field("  secret ref (e.g. env:ANTHROPIC_API_KEY): ")?;
+    Ok(Some(ModelChoice {
+        provider,
+        model,
+        base_url: None,
+        secret: if secret.is_empty() { None } else { Some(secret) },
+    }))
+}
+
+fn read_field(prompt: &str) -> Result<String> {
+    use std::io::Write;
+    print!("{prompt}");
+    std::io::stdout().flush().ok();
+    let mut s = String::new();
+    std::io::stdin().read_line(&mut s)?;
+    Ok(s.trim().to_string())
+}
+```
+
+- [ ] **Step 3: Build + manually verify**
+
+Run: `cargo build -p mur-core`
+Then manual: `mur agent install some.muragent` on a TTY shows the resolution prompt; piped (`mur agent install x </dev/null`) prints the non-interactive guidance line. (Add the needed `use mur_common::muragent::manifest::MuragentManifest;` / `mur_common::muragent::reader::MuragentArchive` already imported in this file.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/install.rs
+git commit -m "feat(install): interactive first-run model resolution (local-first, cloud-honest)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** §6 Share → Tasks 1 & 4; §7.1 hint surfaced → Task 2; §7.3 hardware + recommend wired → Tasks 3 & 4 & 5; §7.4 apply (registry + model_ref) → Task 3; §7.5 GUI surface (commands) → Task 4, CLI surface → Task 5, non-interactive guidance → Task 5. Frontend UI + distribution explicitly deferred to Plan 3. ✓
+
+**2. Placeholder scan:** No "TBD"/"add handling". Two flagged *verification notes* (the `mur_core::cmd::agent` re-export path; whether `ModelRegistry::default_path` honors `MUR_HOME`) are real "confirm-this-signature" checks, not content gaps — the code is complete and the note says exactly what to confirm. ✓
+
+**3. Type consistency:** `ModelChoice { provider, model, base_url, secret }` defined in Task 3, used identically in Tasks 4 & 5. `apply_model_choice(&Path, &str, &ModelChoice) -> Result<String>`, `detect_hardware() -> Hardware`, `choice_ref_name(&ModelChoice) -> String` consistent across tasks. `recommend(Option<&ModelHint>, &Hardware) -> Recommendation` matches Plan 1. `ModelHintView` fields match `ModelHint` (Plan 1). `ModelEntry`/`ModelRegistry` field names match `mur-common/src/model.rs`. `SecretRef` parsed via `str::parse` (confirm `SecretRef: FromStr` in `mur-common/src/secret.rs`; if not, construct it with its actual constructor). ✓
+
+---
+
+# Plan 3 (outline) — Frontend & Distribution
+
+> Not yet bite-sized: needs exploration of `mur-hub-gui/ui` (React) and the release/signing pipeline before TDD-level tasks can be written without speculation. Captured here so the loop is fully tracked.
+
+**A — Host distribution & OS file association** (`mur-hub-gui/src-tauri/tauri.conf.json`, `lib.rs`, `onboarding/`):
+- `tauri.conf.json`: add `bundle.fileAssociations` (`muragent` / `application/vnd.mur.agent`), add `bundle.targets` `dmg`, add macOS signing identity + notarization (mur Developer ID via CI env), Windows Trusted Signing. Keep identifier `run.mur.hub`.
+- Add `tauri-plugin-deep-link` dep + plugin init; in `lib.rs` `.setup`/`RunEvent`, route OS open-file (`RunEvent::Opened` on macOS, argv on Windows, `%f` on Linux) + `muragent-*://` URLs to `inspect_muragent_file`. Single-instance (focus existing Host on second open).
+- First-launch onboarding: enforce `/Applications`; register handler (`lsregister -f` / registry / `xdg-mime`); run `mur agent doctor`; offer drag-to-import.
+- `mur.run/get` DMG produced by mur CI (not a user command).
+
+**Frontend (React, `mur-hub-gui/ui`):**
+- "Share" action per agent → save dialog → `invoke("export_muragent_file", {name, outPath})` → success toast.
+- Import-dialog model-wizard step: call `model_resolution_view(path)`, render the recommended default + the always-present options (Ollama pull / MLX / paste key / endpoint), call `apply_agent_model(slug, choice)`; show pull progress.
+
+**Exploration needed before writing Plan 3:** the `ui/` component structure + invoke patterns; Tauri 2 deep-link plugin API specifics; the release pipeline + signing-credential custody; an Ollama-pull progress channel.

--- a/docs/superpowers/specs/2026-05-29-mur-agent-export-ux-give-to-a-friend-design.md
+++ b/docs/superpowers/specs/2026-05-29-mur-agent-export-ux-give-to-a-friend-design.md
@@ -1,0 +1,247 @@
+# MuR Agent Export UX — "Give an Agent to a Friend" (v1)
+
+**Date:** 2026-05-29
+**Status:** Design (ready for implementation plan)
+**Builds on:** `2026-05-20-agent-export-host-data-model-design.md` (Two-Surface architecture, `.muragent` v2, trust model), `2026-05-11-mur-hub-companion-design.md` (Hub), `2026-04-29-model-registry-and-secret-refs-design.md` (`~/.mur/models.yaml`).
+**Pillar of:** `2026-05-29-mur-strategy-positioning-vs-archon.md` §4.1 (consumer companion-app wedge) — this is the first pillar brainstormed out of that umbrella strategy.
+
+---
+
+## 1. Problem & reframe
+
+The strategy doc names "export your agent as a self-contained app you can give to a friend" as the consumer wedge, and points at the **embedded binary** mechanism (`mur-agent-runtime/export/bin_embed.rs`, `include_bytes!`). A code census on 2026-05-29 shows that framing is the *inferior* path, and that a better architecture was already designed and largely built:
+
+- The **`2026-05-20` Two-Surface design** already decided the right model: the **Host (Hub) app is signed once** with mur's own Developer ID; **`.muragent` is pure data (no executable code)**; per-agent OS identity (file association, Dock/taskbar) is expressed through **locally-generated stubs** created by the already-signed Host, so they never receive a quarantine flag and Gatekeeper/SmartScreen never gates them (the "Chrome PWA trick", §3.2–3.4 of that spec). This dodges **both** the build-toolchain problem and the code-signing problem that the embedded-binary path runs into.
+- Much of that substrate is **already implemented** (see §3). The remaining work is not new architecture — it is **completing the end-to-end give-to-a-friend UX** on top of the existing substrate.
+
+**This spec scopes that completion.** It does not redesign the package format, trust model, or runtime topology — those are inherited from `2026-05-20`.
+
+### Why not the embedded single-file binary?
+
+A single file that runs with nothing installed must embed the runtime. Appending a payload to a signed Mach-O (macOS) or PE (Windows) binary **breaks its code signature**, so the recipient hits "unidentified developer / damaged file" and must perform manual override steps — the exact friction this product is trying to remove. A truly smooth zero-install single file would require **per-export notarization** (a cloud signing service: cost, latency, network — contrary to the local-first/free ethos). The smooth single-file giveaway is therefore the **`.muragent` file + a one-time Host install** (like a document + its app), not an embedded executable. The embedded single-file binary is explicitly **deferred** (§12).
+
+---
+
+## 2. Goals & Non-Goals (v1)
+
+### Goals
+
+1. A producer can turn one of their agents into a single shareable file (`coach.muragent`) **from the Hub GUI** (and CLI) with **no build toolchain** and **no per-export signing**.
+2. A recipient who has never used MuR can install the Host once, **double-click the `.muragent`**, and reach a working conversation in **under 5 minutes**.
+3. On first run the recipient is guided through **model resolution** that is **local-first but cloud-honest** (§7), because model weights never travel in the package.
+4. The package never leaks the producer's private key, API keys, or other secrets.
+5. Same-platform giveaway works end-to-end (producer and recipient on the same OS/arch). Cross-platform is an additive future extension, not a v1 requirement.
+
+### Non-Goals (v1, explicitly deferred)
+
+- Embedded single-file executable (`--format=bin` append / `include_bytes!`). See §12.
+- Cross-platform export (produce a Windows package from a Mac). Architecture must not preclude it; v1 does not ship it.
+- Share-by-URL (`muragent-<slug>://share?...`) as a giveaway channel — v1 ships file-based giveaway only.
+- Commander cross-repo consumption (`2026-05-20` M-export-6).
+- V2 trust badge, `revocations.json` issuer infrastructure.
+- Bundling model weights of any size.
+
+---
+
+## 3. Current state (census, 2026-05-29)
+
+| Capability | State | Evidence |
+|---|---|---|
+| `.muragent` v2 format + DSSE signing + reader/writer/validator/installer | ✅ built | `mur-common/src/muragent/{writer,reader,validator,installer,dsse,statement,jcs_canonical}.rs` |
+| Trust store `~/.mur/trust/` + key-rotation manifests | ✅ built | `mur-common/src/muragent/installer.rs` (uses `crate::trust::{TrustStore,…}`, `~/.mur/trust/rotations/`) |
+| CLI `mur agent export / install / inspect / uninstall` | ✅ built | `mur-core/src/cmd/agent/{export,install}.rs`; default format `muragent` |
+| Export profile sanitization (strips private key, secretful notification targets, socket auth) | ✅ built | `sanitize_profile_for_export()`, `export.rs:89` |
+| Hub recipient import (inspect + install backend for §7.2 dialog) | ✅ built | `mur-hub-gui/src-tauri/src/import_muragent.rs` |
+| Per-platform stub generation | 🟡 partial | `mur-gui-core/src/stub/{macos,linux,windows}.rs` |
+| First-run extraction (content-addressed cache) + MCP prereq check | ✅ built | `mur-agent-runtime/src/export/{extract,prereq_check}.rs` |
+| Runtime model resolution from registry | ✅ built (partial) | `resolve_model_entry()`, `supervisor.rs:773` |
+| **Host distribution + `.muragent` OS file association** | ❌ gap | `tauri.conf.json`: `productName "MuR Hub"`, `targets ["app"]`, no `fileAssociations`, no deep-link plugin, no `dmg` |
+| **First-run model resolution wizard (no-backend case)** | ❌ gap | import dialog surfaces MCP/voice/pet/trust only; no model-backend resolution; `model_hint` absent from manifest |
+| **Hub "Share this agent" (producer side)** | ❌ gap | Hub has import only; no export command |
+| Legacy `--format=gui` 13-phase pipeline (cargo+npm+tauri) / `--format=bin` (cargo + raw-home tar → secret leak) | ❌ to retire | `agent_export_gui.rs` (13 phases), `export.rs:export_bin`, `build.rs` `append_dir_all(".", src)`, `doctor.rs::checks_for` |
+
+The four gaps map to Workstreams **A, B, C, D** below.
+
+---
+
+## 4. The give-to-a-friend loop (acceptance narratives)
+
+**Producer (Hub):** open Hub → pick agent "Coach" → **Share** → save `coach.muragent`. Instant; no toolchain; profile sanitized; signed with the producer's own author key. Send the one file by any channel.
+
+**Recipient (no prior MuR):**
+1. Receives `coach.muragent`.
+2. (First time only) downloads the free **MuR Host** from `mur.run/get`, drags to `/Applications`.
+3. Double-clicks `coach.muragent` → OS routes it to Host → §7.2 import dialog (trust + declared permissions).
+4. On install, first run shows the **model resolution wizard** (§7): local-first recommendation, cloud when the agent needs it, manual override always available.
+5. Conversation works. Total time < 5 min; no security warnings (Host is properly notarized; the package is data).
+
+---
+
+## 5. Workstream A — Host distribution & OS file association
+
+Goal: a double-clicked `.muragent` reaches the already-built import backend, and the Host is distributable.
+
+- **`mur-hub-gui/src-tauri/tauri.conf.json`:**
+  - Add `bundle.fileAssociations`: extension `muragent`, mimeType `application/vnd.mur.agent`, role Viewer, icon.
+  - Add the Tauri **deep-link plugin** for the `muragent-*://` scheme family (preserves the existing `parse_share_url` contract).
+  - Add `dmg` to `bundle.targets` (keep `app`).
+  - Configure macOS signing identity + notarization via **mur's own Developer ID**, read from CI environment (not a user step). Windows: Microsoft Trusted Signing (per `2026-05-20` §9.4).
+  - Keep identifier **`run.mur.hub`** (do not churn the shipping identity; the `2026-05-20` spec's `run.mur.host` is treated as a draft name). Login-Items grouping uses `AssociatedBundleIdentifiers = ["run.mur.hub"]`.
+- **Open routing** (`mur-hub-gui/src-tauri/src/lib.rs`): handle OS "open file" (macOS `RunEvent::Opened`, Windows argv, Linux `%f`) and "open URL" events → call existing `inspect_muragent_file` → render the §7.2 dialog. Single-instance so a second double-click focuses the running Host.
+- **First-launch onboarding** (extend `mur-hub-gui/src-tauri/src/onboarding/`): enforce `/Applications` placement (prompt to move if launched elsewhere); register as default `.muragent` handler (`lsregister -f` on macOS, registry on Windows, `xdg-mime` + `update-desktop-database` on Linux); run `mur agent doctor`; offer drag-to-import.
+- **`mur.run/get` DMG** is produced by mur's release pipeline (`build.sh` / CI), not a user command.
+
+---
+
+## 6. Workstream C — Hub "Share this agent" (producer side)
+
+Goal: produce a `.muragent` from the GUI, reusing the CLI path.
+
+- New Tauri command `export_muragent_file(name, out_path, mode)` in a new `mur-hub-gui/src-tauri/src/export_muragent.rs`, wrapping the same `MuragentWriter` + `build_manifest_from_profile` + `sanitize_profile_for_export` the CLI uses.
+- Default **template mode** (mint fresh keys on the recipient, sanitized). Clone mode stays gated exactly as today (`MUR_ALLOW_UNSAFE_CLONE`, until the rekey ceremony lands).
+- UI: per-agent "Share" action → native save dialog → `<slug>.muragent` → success toast ("Send this file to anyone with MuR Host").
+- File-based only in v1 (share-URL deferred, §2).
+
+---
+
+## 7. Workstream B — First-run model resolution wizard (the new UX)
+
+Model weights never travel; the agent's binding (`AgentProfile.model: ModelConfig` inline, or `model_ref` → `~/.mur/models.yaml`) will not resolve on the recipient's machine. The wizard resolves it, **local-first but honest about tasks that need a cloud-class model**, driven by what the agent declares — not a global toggle.
+
+### 7.1 `model_hint` (new manifest field)
+
+Add an optional `model_hint` to the `.muragent` manifest (`mur-common/src/muragent/manifest.rs`), populated by the writer from the source agent's resolved binding:
+
+```yaml
+model_hint:
+  provider: anthropic          # original provider
+  name: claude-opus-4-7        # original model id
+  tier: frontier               # small | mid | frontier  (derived via a model-class table)
+  min_ram_gb: 0                # estimated RAM for a local equivalent (0 = cloud-class)
+  local_capable: false         # was the agent authored against a local model?
+```
+
+- `local_capable` is the author's signal: bound to a local provider (ollama/mlx) → `true`; bound to a frontier cloud model → `false`.
+- Derived at export time from a **model-class table** (a small static map in `mur-common`, versioned in-repo; unknown models fall back to `tier: mid, local_capable: true, min_ram_gb: conservative`).
+- Optional + forward-compatible: validator treats absence as "no hint" (wizard then offers the neutral all-options menu).
+
+### 7.2 Export sanitization change
+
+Extend `sanitize_profile_for_export()`: convert `model_ref` → `model_hint` and **drop `model_ref`** (the referenced registry entry, which may hold an API-key secret-ref, never travels). Inline `model:` config is kept only for non-secret fields (provider/name/params); any secret material is stripped. This closes the model-side secret leak.
+
+### 7.3 Resolution decision tree
+
+On first run, detect recipient hardware (total RAM; Apple Silicon → MLX availability; Ollama presence) and read `model_hint`:
+
+| Condition | Recommended (highlighted) default | Also offered |
+|---|---|---|
+| `local_capable` && hardware can run the tier | **Local** — pull via Ollama/MLX (the hinted model, or a mapped local equivalent), progress bar | paste API key; OpenAI-compatible endpoint |
+| `!local_capable` (frontier) | **Cloud** — pick provider / paste key | "Use a strong local model instead (quality may drop)"; endpoint |
+| `local_capable` && hardware too small | **Cloud, or a smaller local model**, with an explanation of the RAM gap | both local-small and cloud |
+| no `model_hint` | neutral menu, no default pre-selected | all of the above |
+
+Principles: never claim a small local model replaces a frontier one; the escape hatches (Ollama pull / MLX / paste key / endpoint) are **always** present regardless of the recommendation.
+
+### 7.4 Applying the choice
+
+- Write a recipient-side `~/.mur/models.yaml` entry (reuse `mur model add` / `ModelRegistry`) and set the agent's `model_ref` to it.
+- Recipient-supplied API keys are stored in the recipient's own secret store (per `2026-05-20` §3.3 — mur never ships user secrets).
+- Verify with a single test call before declaring success.
+- Changeable later via `mur model` / Hub settings — not a one-way door.
+
+### 7.5 Surfaces (GUI + CLI/non-interactive)
+
+The wizard is **first-class on three surfaces**, sharing one resolution-logic module:
+
+1. **Hub GUI** — a step folded into / following the §7.2 import dialog.
+2. **CLI interactive** — `mur agent install` prompts in the terminal when no usable binding resolves.
+3. **Non-interactive / scriptable** — for servers and the developer `--load` path (§8): `--model <ref>` flag and/or environment variables; fails fast with a clear message rather than blocking on a prompt when run headless.
+
+---
+
+## 8. Workstream D — Retire legacy export paths; toolchain-free developer path
+
+- **`--format=gui`** → **hard-error** pointing to the Host + `.muragent` model (per `2026-05-20` §15). The 13-phase per-agent `.app` pipeline (`agent_export_gui.rs`, requiring cargo+node+npm+tauri) is retired as a *user* command; the Host itself is built once per release by mur's CI.
+- **`doctor::checks_for`** drops the cargo/node/npm/tauri checks from the user-facing export path (they remain relevant only to the CI build of the Host).
+- **`--format=bin`** (cargo build + raw-home tar) is **removed**, not patched — it required a toolchain and leaked the private key/secrets (`build.rs` tars the entire agent home). Both `--format=gui` and `--format=bin` return an **explicit redirecting error** (not the generic "unsupported format"): they name the replacement (`.muragent` + `mur-agent-runtime --load`). The toolchain-free, signing-intact developer/server replacement is:
+  - **`mur-agent-runtime --load <path.muragent>`** — ship the pre-built (already-signed) runtime + run a sanitized `.muragent`. Reuses `installer`/`extract.rs` + the existing embedded-divert hook (`supervisor.rs:65`). The only new surface is a minimal arg parser in the runtime (`subcommand.rs` is currently empty; `main.rs` goes straight to `supervisor::entrypoint()`).
+  - Idiomatic for its audience (`java -jar`, `docker run` style); preserves the runtime's signature because the binary is untouched and the payload is a data sidecar.
+  - First-run model resolution uses the §7.5 CLI/non-interactive path.
+
+The embedded single-file binary (append) remains the documented future option (§12), gated on a signing strategy.
+
+---
+
+## 9. Data-model & code impact
+
+**`mur-common`**
+- `muragent/manifest.rs`: add optional `model_hint` (§7.1).
+- `muragent/writer.rs`: populate `model_hint` from profile binding.
+- `muragent/validator.rs`: treat `model_hint` as optional/forward-compatible.
+- new small **model-class table** module (tier / min_ram / local_capable lookup).
+
+**`mur-core`**
+- `cmd/agent/export.rs`: `sanitize_profile_for_export` converts `model_ref` → `model_hint` and strips model secrets (§7.2); remove `export_bin`; `--format=gui` and `--format=bin` → hard-error/redirect.
+- `cmd/doctor.rs`: drop toolchain checks from the user path.
+- `cmd/agent/install.rs`: CLI model-resolution prompts (§7.5 surface 2/3).
+
+**`mur-agent-runtime`**
+- `subcommand.rs` / `main.rs`: add `--load <path.muragent>` (and `--model <ref>` for non-interactive resolution).
+- `export/bin_embed.rs`, `build.rs`: the `include_bytes!`/`MUR_EXPORT_AGENT_DIR` embed path is no longer driven by `--format=bin`; keep the runtime-side hook for the future append option but stop wiring the cargo build.
+
+**`mur-hub-gui`**
+- `src-tauri/tauri.conf.json`: fileAssociations, deep-link, `dmg`, signing/notarize (§5).
+- `src-tauri/src/lib.rs`: open-file / open-url routing + single-instance (§5).
+- `src-tauri/src/onboarding/*`: first-launch flow (§5).
+- `src-tauri/src/export_muragent.rs` (new): Share command (§6).
+- `src-tauri/src/import_muragent.rs`: add model-wizard commands (§7).
+
+**`mur-gui-core`**
+- `stub/*`: run the Gatekeeper validation gate (`2026-05-20` §12.4) when generating a launcher.
+
+**Shared model-resolution module:** one logic core consumed by Hub GUI, CLI, and `--load` (§7.5). Location to be decided in the plan (candidate: `mur-gui-core` or a new `mur-core` module re-exported to the runtime).
+
+---
+
+## 10. Testing strategy
+
+- **Unit:** `model_hint` derivation from each binding shape (inline ollama, inline frontier, `model_ref`); model-class table lookups incl. unknown-model fallback; sanitize drops `model_ref` + model secrets (property test: exported package contains no private key, no API key, no `model_ref`).
+- **Resolution decision tree:** table-driven tests over (`tier` × `local_capable` × RAM × Ollama/MLX present) → expected recommended default + offered options. Pure function, no I/O.
+- **Recipient import e2e:** produce a sanitized `.muragent` → import via installer → assert agent home, trust `pending`, model unbound → run wizard (mocked backends) → assert `~/.mur/models.yaml` entry + `model_ref` set + test-call invoked.
+- **`--load` e2e:** pre-built runtime + sanitized `.muragent` → `--load` extracts + supervises; non-interactive `--model <ref>` resolves without prompting; headless with no binding fails fast with a clear message.
+- **Host OS integration:** tauri.conf fileAssociations/deep-link present; open-file event routes to `inspect_muragent_file`; macOS Gatekeeper validation gate stays green for CI-signed Host (gated behind `MUR_APPLE_DEVELOPER_ID` like existing `agent_export_macos.rs`).
+- **Regression:** removing `--format=bin`/`--format=gui` returns the hard-error, not a panic; legacy `.murpkg`/`.app` paths already covered by `2026-05-20` §11 (clean break, no migration).
+
+---
+
+## 11. Implementation order (preview; full plan via writing-plans)
+
+1. **D-cleanup** — hard-error `--format=gui`/`--format=bin`; drop toolchain checks from `doctor` user path; remove `export_bin`. (Unblocks confusion, no new deps.)
+2. **B-data** — `model_hint` manifest field + writer + validator + model-class table; sanitize `model_ref` → `model_hint`. Property tests.
+3. **C** — Hub `export_muragent_file` Share command + UI (reuses #2 sanitize).
+4. **runtime `--load`** — arg parser + extract/supervise + non-interactive `--model`.
+5. **A** — `tauri.conf` (fileAssociations/deep-link/dmg/signing) + open routing + single-instance.
+6. **B-wizard** — shared resolution module + Hub GUI step + CLI interactive prompts.
+7. **A-onboarding** — first-launch `/Applications`/handler-registration/doctor flow.
+8. **e2e** — recipient import + `--load` + Host OS integration suites.
+
+---
+
+## 12. Deferred / future
+
+- **Embedded single-file binary (append).** Mechanically simple on all three OSes, but appending to a signed Mach-O/PE breaks the signature → recipient sees security warnings. A smooth zero-install single file needs per-export notarization (cloud signing service: cost/latency/network, contrary to local-first/free). Revisit only with a signing-service decision. The runtime-side embed hook is kept so this is additive.
+- **Cross-platform export** (host on Mac, package for Windows). Additive: ship per-target pre-built runtimes / Host shells; the `.muragent` data and wizard are already platform-agnostic.
+- **Share-by-URL** giveaway channel.
+- **Commander cross-repo** consumption of `.muragent` (`2026-05-20` M-export-6).
+- **V2 trust badge + `revocations.json`** issuer infrastructure.
+
+---
+
+## 13. Open questions / risks
+
+1. **Host notarization in CI** — custody of mur's Developer ID + notarytool credentials in the release pipeline; Windows Trusted Signing onboarding.
+2. **Model-class table maintenance** — who updates tiers/min-RAM as new models ship; unknown-model fallback must stay safe (prefer "offer all options" over a wrong confident default).
+3. **Cross-platform RAM / accelerator detection** — reliable RAM read and Apple-Silicon/MLX detection across macOS/Windows/Linux.
+4. **Deep-link reliability requires `/Applications`** (Tauri/LaunchServices constraint, `2026-05-20` §10.1) — onboarding must make this the default, not a buried option.
+5. **Shared model-resolution module placement** — must be reachable from `mur-hub-gui`, `mur-core` CLI, and `mur-agent-runtime` without pulling GUI deps into the runtime.
+6. **First-run latency** — a local pull of several GB is minutes on a fast link; the wizard must show real progress and allow "do this later / pick cloud now".

--- a/docs/superpowers/specs/2026-05-29-mur-strategy-positioning-vs-archon.md
+++ b/docs/superpowers/specs/2026-05-29-mur-strategy-positioning-vs-archon.md
@@ -1,0 +1,191 @@
+# MUR Strategy & Positioning — in light of Archon's roadmap
+
+**Date:** 2026-05-29
+**Status:** Strategy / positioning (not an implementation spec)
+**Trigger:** Competitor Archon (Cole Medin, `coleam00/archon`, ~17K stars) published a public roadmap — workflow marketplace, advanced control flow, persistent project orchestrator, local-LLM support, execution reliability — and reframed itself as "the first open-source harness builder for AI coding."
+
+This document records the strategic read on what that means for MUR, the moat MUR actually owns (grounded in the current codebase, not aspiration), the two go-to-market motions we will pursue, the workflow-orchestration strategy, the monetization model, and an inventory of under-marketed assets discovered during a code census on 2026-05-29.
+
+---
+
+## 1. Executive summary
+
+- **Archon and MUR are different species.** Archon is a *stateless harness* that wraps existing coding agents (Claude Code SDK, Codex SDK, Pi) and makes a single coding workflow deterministic. MUR is a *stateful, local-first runtime for a fleet of specialized agents* that learn and evolve, plus a human-facing companion layer and a cross-agent command/governance plane (MUR Commander). Archon threatens only MUR's "workflow" surface, not its core.
+- **The moat is local-first + native Rust.** With on-device LLMs (the reason Mac mini / Mac Studio are in demand), the binding constraint on consumer hardware is RAM and always-on cost. Python/TypeScript stacks (Archon is TS) cannot run an always-on fleet of specialized agents on a 16 GB machine; a native-Rust runtime can. This also flips the AI-SaaS margin problem: because inference runs on the user's machine, **MUR's marginal inference cost ≈ 0**, so MUR can sustain a free tier its cloud competitors structurally cannot.
+- **Two go-to-market motions, on one substrate.** (1) **Consumer/prosumer wedge** — export a specialized agent as a self-contained desktop companion app you can talk to and give to friends/clients. (2) **Enterprise moat** — governed, sandboxed, auditable autonomous agents orchestrated cross-network by MUR Commander. Consumer first (awareness, viral distribution); enterprise as the high-value conversion.
+- **First paid point: cross-device agent-fleet sync (Pro).** Local everything is free; you pay to replicate your *evolved* fleet (profiles, model bindings, skills, workflows, notes, and their maturity/fitness/lifecycle state) across your machines.
+- **We do NOT build a visual DAG editor or a workflow marketplace.** Recorded behavior is mined into suggested workflows automatically; control flow lives in the agent and in Commander, not in a graph canvas.
+
+---
+
+## 2. Competitive read: Archon vs MUR
+
+| | **Archon** | **MUR** |
+|---|---|---|
+| Essence | Harness / outer shell around existing agents | Runtime + memory/learning layer + human interface for many agents |
+| Core promise | Make AI *coding* deterministic & repeatable | Run a private, local, evolving fleet of specialized agents; export them as products |
+| State | Stateless — re-assembles context per run | Stateful — capture→store→retrieve→inject accumulates and evolves |
+| Stack | TypeScript | Native Rust |
+| Depth | Vertical (coding only) | Horizontal (coding / assistant / companion / chat-bridge) |
+| Authoring | Hand-written YAML workflows | Recorded behavior auto-mined into workflows |
+
+**Implications.**
+- Archon's published direction (marketplace, control flow, persistent orchestrator, local LLM, reliability) overlaps MUR *only* on the workflow axis. It does not touch MUR's memory/lifecycle layer, per-agent model binding, kernel sandbox, cryptographic governance, export-to-app, or voice/companion.
+- Two of the founder's own positions are validated by external research and by Archon's own constraints:
+  - **The pure harness layer is a contested middle that model vendors are absorbing.** Archon's cited 6.7% → ~70% PR-acceptance jump is real for simple, well-scoped tasks but does not solve hard/novel problems; meanwhile Codex/Claude Code now ship their own workflows, pet mode, and CLAUDE.md import. Betting MUR on "our workflow engine beats Archon's" is a losing fight against the model vendors.
+  - **A workflow marketplace is hard to bootstrap** (cold-start + "not-fit-for-me"); Archon itself is stuck on centralized PR review for safety, which throttles growth. MUR's record-and-mine approach sidesteps the marketplace entirely: personalized workflows beat shared ones.
+
+---
+
+## 3. The moat: local-first + native Rust (with two reinforcing layers)
+
+The defensible core is the combination model vendors and TS/Python tools structurally will not or cannot match:
+
+1. **Native-Rust, local-first multi-agent runtime.** Memory-safe, small binaries, fast startup, low RAM overhead — the only practical way to run a fleet of always-on specialized agents alongside a local LLM on a 16 GB consumer Mac. Model vendors won't go local (it kills their token revenue); TS/Python tools can't fit efficient always-on multi-agent on consumer RAM.
+2. **Accumulating memory + full lifecycle.** Agents learn and evolve (decay, Draft→Emerging→Stable→Canonical maturity, feedback, co-occurrence, gene-evolution). Cloud agents are stateless per session; vendors avoid sinking durable personal data on-device.
+3. **MUR Commander as the command/governance/eval plane.** Cross-network, cross-agent orchestration with cryptographic governance, immutable audit, and an agent-quality evaluation harness — a category no competitor occupies.
+
+**One-line positioning:** *MUR is a native-Rust, local-first fleet of specialized AI agents that learn and evolve — fast enough to be always-on on the Mac you already own, commanded and governed by MUR Commander, and each exportable as a companion app you can hand to anyone.*
+
+---
+
+## 4. Two go-to-market motions
+
+### 4.1 Consumer / prosumer wedge — "export your agent as a companion app" (lead)
+
+The 5-minute "wow": create a specialized agent, talk to it (voice + GUI), let it do work, and **export it as a self-contained app** you can run and give away. Validated by the desktop-companion market (≈ $49.5B 2026 → $435.9B 2034, 31% CAGR) and by OpenAI shipping Codex "pet mode" explicitly to make Codex a sticky daily tool.
+
+- **Distribution = the embedded self-contained binary** (`mur-agent-runtime/export/bin_embed.rs`: `--features=embedded-agent`, `include_bytes!`), NOT the lightweight stub. The stub (`mur-gui-core/src/stub/*`, `<100 KB` launcher) is great for the *owner's* multi-device use but requires Hub + `~/.mur/agents/<slug>` on the target machine. For "give it to a friend/client who doesn't run MUR," ship the embedded binary.
+- **Voice is fully on-device** (`mur-gui-core/src/voice/`: Kokoro 82M ONNX TTS + cpal; whisper.cpp STT wiring lands M-h8), and respects native DND / Focus / mic-busy. No cloud TTS.
+- **Companion presence** (`mur-hub-gui`, Tauri 2 + React): transparent always-on-top pet windows, lipsync, speech bubbles, filesystem-based companion bridge, OS-managed agent lifecycle (`mur-gui-core/src/sidecar.rs`) so agents survive Hub restarts.
+- App export/distribution is **free** — it is the viral acquisition engine, not a paywall.
+
+### 4.2 Enterprise moat — "governed autonomous agents" (high-value conversion)
+
+The asset cluster discovered in §8 (signed constitution + hash-chained audit + kernel sandbox + eval harness + cross-network Commander) adds up to a category nobody owns: *the only AI-agent platform you can safely let run autonomously inside a regulated enterprise.* This is the opposite end from the consumer wedge but rides the same Rust/local-first substrate, and it is where Team/Enterprise pricing is anchored.
+
+---
+
+## 5. Workflow orchestration strategy (no visual DAG, no marketplace)
+
+"Orchestrating recorded workflows" is solved by three layers already present in the codebase — none requiring a visual DAG canvas:
+
+1. **Within-step composition.** Workflows are ordered steps plus a pipeline expression language: `mur run "w1 | w2 && w3"` (`|` = parallel, `&&` = sequential), with fail-fast and per-step retry (`mur-core/executor/pipeline.rs`, `cmd/workflow.rs`). Text, git-friendly, Archon-like — but not hand-authored.
+2. **Runtime control flow = the agent.** Branches, loops, and conditionals are handled by the intelligent agent at execution time. Archon needs elaborate DAGs because its nodes are "dumb" (bash / single AI prompt); MUR's nodes are agents.
+3. **Cross-agent orchestration = Commander.** Plan executor (plan → human review → execute) and sub-agent spawning (up to 5 concurrent) in `mur-commander`.
+
+**Authoring by recording is already half-built:** `capture/emergence.rs` detects recurring cross-session tool sequences (≥3 independent sessions); `evolve/cooccurrence.rs` + `compose.rs` mine co-used patterns and `mur suggest --create` drafts workflows. Product work = polishing this into a "we noticed you repeated this — save it as a replayable workflow?" nudge inside the companion experience.
+
+**Decision:** Do not build a visual DAG editor or a workflow marketplace. Optional later: a *read-only* visual viewer of a mined workflow (visualization, not a drag-and-drop editor) and a simple linear step-list editor for tweaks.
+
+---
+
+## 6. Monetization model
+
+**Principle: everything local is free; you pay for what genuinely costs us to host.** This respects MUR's local-first ethos and exploits the ≈ 0 marginal-inference-cost advantage. No per-token pricing (local inference makes it pointless and throws away the advantage); no charging for app distribution (it kills viral spread); per-seat is a declining model and not the anchor.
+
+| Tier | Includes | Rationale |
+|---|---|---|
+| **Free (all local)** | Run agents, local LLM, voice, companion, export-to-app (embedded binary + stub), local Commander dashboard (`localhost:3939`), local audit log | Inference on user hardware → zero marginal cost; a free tier cloud competitors can't match |
+| **Pro (~$10–20/mo) — FIRST PAID POINT** | **Cross-device agent-fleet sync**, cloud observability dashboard + history retention, cloud session/signal archive | Genuinely costs us to host; respects "local = free" |
+| **Team (~$50+/mo)** | Shared agent registry, RBAC, team workflow sync, hash-chained audit retention (compliance), cross-network fleet orchestration, team eval dashboards | "Managers pay for control" |
+| **Enterprise** | SSO, SLA, on-prem server, audit export | High-touch, sales-led |
+
+**First paid point — cross-device agent-fleet sync (decided).** Not backup-for-backup's-sake. The valuable unit is the *evolved* fleet: agent profiles + model bindings + skills + workflows + notes **and their maturity / lifecycle / fitness state**, replicated so the same learned agents run the same workflows on laptop and Mac Studio — learning on machine A benefits machine B. The server already syncs patterns/sessions/commander-workflows; extending to full fleet + lifecycle is the natural Pro feature.
+
+**Server-side observability without the desktop Commander — confirmed in code.** The mur-server (Go) ingests telemetry directly over HTTP: `POST /api/v1/core/signals/batch` and `POST /api/v1/sessions`, authenticated via OAuth / device-code / API-key, aggregated by a background worker. The runtime emits local-only JSONL telemetry (`mur-agent-runtime/telemetry_writer.rs`); the CLI/daemon pushes "signals" to the server. So cloud observability is a Pro/Team server feature fully decoupled from whether the user runs the desktop Commander. Billing is already wired via **LemonSqueezy** (Free/Trial/Pro/Team/Enterprise); Commander also has membership tiers coded (Free 3 schedules / Pro 50 / Team 500).
+
+**Licensing:** protect the hosted offering (sync server, cloud dashboards) with AGPL or BSL while keeping the local client open.
+
+---
+
+## 7. Focus decisions
+
+| Decision | Item | Reason |
+|---|---|---|
+| **Downgrade / don't build** | Visual DAG editor; workflow marketplace | §5 shows neither is needed; marketplace has cold-start + not-fit-for-me + review-throttle problems |
+| **Reframe as "depth," not headline** | 200+ CLI commands, GEP, MKEF exchange, Obsidian/Notion/Joplin source adapters | They are moat depth, not the demo. Don't market "200 commands." |
+| **Invest (consumer)** | Export-to-app (embedded binary) + talk-to-agent + voice + companion | The wedge |
+| **Invest (enterprise)** | Commander: observability / eval / constitution / audit / cross-network | The moat (§8) |
+
+The real focus risk is surface-area sprawl, not too few features. Antidote: **one consumer demo (companion app) + one enterprise story (governable autonomous agents)**; everything else is depth behind those two.
+
+---
+
+## 8. Under-marketed assets (code census, 2026-05-29)
+
+Each item is implemented in the codebase and absent in Archon / Claude Code / Cursor. These are the strongest, hardest-to-copy selling points and are currently under-communicated.
+
+**A. Cryptographic agent governance — the most undersold enterprise asset.**
+Ed25519-signed, tamper-proof constitution (forbidden / requires-approval / auto-allowed patterns + resource limits + per-model sandbox flags) plus a SHA-256 hash-chained audit log (any tampering is retroactively detectable). Source: `mur-commander` `constitution/signing.rs`, `audit.rs`, `policy/engine.rs`. Pitch: *the only platform offering cryptographically provable agent governance and an immutable audit trail* — a pricing pillar for Team/Enterprise and a fit for finance/healthcare/government.
+
+**B. Cross-platform kernel sandbox — the prerequisite for safe autonomy.**
+Landlock v4 + seccomp (Linux), SBPL (macOS), Job Object (Windows), and a HostGuard DNS-resolver guard that filters egress at the HTTP layer so agents can't bypass network limits. Source: `mur-agent-runtime/sandbox/*`. As agents trend toward autonomy (Archon's "dark factory" zero-review experiments), "safely let an agent run autonomously on your machine" becomes a requirement. Python/TS competitors have nothing comparable.
+
+**C. Agent-quality evaluation harness — "评量" is real.**
+Commander's UX Harness: 27-case matrix, LLM judge (Haiku + G-Eval) + rule judge, scoring replies on tone / clarity / accuracy / safety, surfaced at `/health/score`. Source: `mur-commander` `harness-core/judge/*`. Pitch: *continuously measure and improve your agents' quality* — nobody ships agent scoring as a built-in.
+
+**D. Privacy-first redaction pipeline.**
+Crashlogs and telemetry are scrubbed at a single chokepoint (every string leaf redacted) before disk write or subscriber forward; a compile-time test forbids the companion module from importing network clients. Source: `crashlog.rs`, `telemetry_writer.rs`, `companion/network_audit.rs`. Pitch: *your agent's logs never leak secrets or PII* — versus competitors logging to proprietary clouds.
+
+**E. Automatic workflow mining + gene evolution.**
+Emergence + co-occurrence auto-discover workflows (§5); GEP treats patterns like genes with fitness / mutation / crossover / lineage (`mur-core/gep.rs`). Pitch: *MUR watches how you work and proposes reusable flows* — zero authoring friction, aimed straight at Archon's weak point.
+
+**F. Two export modes (product decision).**
+Stub (`.app`/`.lnk`/`.desktop`, `<100 KB` launcher; needs Hub on target) vs embedded self-contained binary (`include_bytes!`; runs without MUR installed). **"Package for a friend/client" → embedded binary; multi-device-self → stub.** This distinction is currently undocumented and should be made explicit in product and docs.
+
+**G. Built-in enterprise integrations.**
+Slack (C7), Telegram, **Jira (12 commands, `@mur implement PROJ-123`, 6 agentic tools)**, webhooks, MCP trust store. Jira-agentic is a ready B2B selling point.
+
+**H. Long-running autonomous execution.**
+Plan executor with "Ralph Loop" + cron-resume survives rate limits and context overflow (`mur-commander` plan executor) — matches the long-running-autonomous-agent trend with human-review checkpoints.
+
+---
+
+## 9. Competitor capability matrix
+
+| Capability | MUR | Archon | Claude Code | Cursor |
+|---|---|---|---|---|
+| Native local-first multi-agent runtime | ✓ (Rust) | ✗ (TS, cloud-leaning) | ✗ | ✗ |
+| On-device LLM as first-class (Ollama/MLX/OpenAI-compat + privacy gate) | ✓ | Planned | ✗ | ✗ |
+| Accumulating memory + maturity lifecycle | ✓ | ✗ | ✗ | ✗ |
+| Kernel sandbox (Landlock/seccomp/SBPL/JobObject + DNS guard) | ✓ | ✗ | ✗ | ✗ |
+| Ed25519-signed constitution + hash-chained audit | ✓ | partial (rules) | ✗ | ✗ |
+| Agent-quality eval harness | ✓ | ✗ | ✗ | ✗ |
+| Auto workflow mining from behavior | ✓ | ✗ | ✗ | ✗ |
+| Export agent as self-contained app | ✓ | ✗ | ✗ | ✗ |
+| Local on-device voice (DND-aware) | ✓ | ✗ | ✗ | ✗ |
+| Cross-network cross-agent orchestration | ✓ | partial | ✗ | ✗ |
+| Hand-authored YAML coding workflows | ✓ (mined) | ✓ (core) | partial | ✗ |
+
+---
+
+## 10. Maturity caveats (honesty check)
+
+Strategy must not be built on vapor. Known partial / stubbed items as of 2026-05-29:
+- MUR Commander remote transport: SSH-tunnel mode is a **stub** (queued P3.1); HTTPS-outbound reverse tunnel is the working cross-network path.
+- whisper.cpp STT is referenced but **not yet wired** into the Hub GUI (planned M-h8); TTS (Kokoro) is functional.
+- Server-side draft *accept* endpoint is **TBD** (only reject + pending list implemented); accept is currently a client-side write.
+- The `Cargo.toml` workspace note says mur-commander `v0.2.0`; the actual repo is at `v0.12.x` — internal versioning notes are stale and should be reconciled.
+- mur-server relay WebSocket commands/results are in-memory (no persisted audit trail of relay commands).
+
+These do not change the strategy but must be sequenced honestly in any downstream plan.
+
+---
+
+## 11. Open questions / next steps
+
+- **Sequencing:** consumer wedge polish (embedded-binary export UX + companion "save this workflow" nudge) vs Pro fleet-sync build-out — which ships first within the consumer motion?
+- **Fleet-sync scope v1:** which entities sync first (profiles + model bindings + workflows) and what conflict-resolution model (current server sync uses a simple incremental version with a ForceLocal override).
+- **Enterprise narrative timing:** when to start telling the governance/audit story publicly without over-promising the stubbed pieces in §10.
+- Each pillar that becomes a build target gets its own brainstorm → spec → plan cycle; this document is the umbrella positioning they reference.
+
+---
+
+## Sources (external research, 2026-05-29)
+
+- Archon: <https://github.com/coleam00/archon> · <https://agentconn.com/blog/archon-open-source-harness-builder-ai-coding-deterministic-review/> · <https://www.mindstudio.ai/blog/what-is-archon-harness-builder-ai-coding>
+- Multi-agent vs single-agent economics: <https://www.augmentcode.com/guides/single-agent-vs-multi-agent-ai> · <https://www.augmentcode.com/guides/ai-agent-loop-token-cost-context-constraints>
+- Desktop companion trend: <https://www.fortunebusinessinsights.com/ai-companion-market-113258> · <https://finance.biggo.com/news/202605040025_OpenAI_Codex_desktop_pets>
+- AI pricing & monetization: <https://www.bvp.com/atlas/the-ai-pricing-and-monetization-playbook> · <https://www.getmonetizely.com/blogs/the-2026-guide-to-saas-ai-and-agentic-pricing-models> · <https://korixinc.com/learning-center/ai-pricing-models-2026>
+- Open-source / local-first monetization: <https://www.reo.dev/blog/monetize-open-source-software> · <https://en.wikipedia.org/wiki/Business_models_for_open-source_software>

--- a/mur-agent-runtime/src/subcommand.rs
+++ b/mur-agent-runtime/src/subcommand.rs
@@ -1,1 +1,44 @@
-//! CLI subcommand definitions for the agent runtime binary.
+//! CLI subcommand / flag parsing for the agent runtime binary.
+
+/// Return the value following `flag` in `args`, supporting both
+/// `--flag value` and `--flag=value` forms. Returns the first match.
+pub fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    let eq_prefix = format!("{flag}=");
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == flag {
+            return iter.next().cloned();
+        }
+        if let Some(rest) = arg.strip_prefix(&eq_prefix) {
+            return Some(rest.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(xs: &[&str]) -> Vec<String> {
+        xs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn space_separated_form() {
+        let a = args(&["mur-agent-runtime", "--load", "coach.muragent"]);
+        assert_eq!(flag_value(&a, "--load"), Some("coach.muragent".to_string()));
+    }
+
+    #[test]
+    fn equals_form() {
+        let a = args(&["mur-agent-runtime", "--model=anthropic_opus_4_7"]);
+        assert_eq!(flag_value(&a, "--model"), Some("anthropic_opus_4_7".to_string()));
+    }
+
+    #[test]
+    fn absent_flag_is_none() {
+        let a = args(&["mur-agent-runtime"]);
+        assert_eq!(flag_value(&a, "--load"), None);
+    }
+}

--- a/mur-agent-runtime/src/subcommand.rs
+++ b/mur-agent-runtime/src/subcommand.rs
@@ -33,7 +33,10 @@ mod tests {
     #[test]
     fn equals_form() {
         let a = args(&["mur-agent-runtime", "--model=anthropic_opus_4_7"]);
-        assert_eq!(flag_value(&a, "--model"), Some("anthropic_opus_4_7".to_string()));
+        assert_eq!(
+            flag_value(&a, "--model"),
+            Some("anthropic_opus_4_7".to_string())
+        );
     }
 
     #[test]

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -62,7 +62,17 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     let mur_home = std::env::var_os("MUR_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"));
-    let agent_home = if crate::export::bin_embed::has_embedded_agent() && !embedded_override {
+    let argv: Vec<String> = std::env::args().collect();
+    let load_path = crate::subcommand::flag_value(&argv, "--load");
+    let agent_home = if let Some(path) = load_path {
+        match load_muragent_and_home(&path, &mur_home) {
+            Ok(home) => home,
+            Err(e) => {
+                eprintln!("error[load]: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else if crate::export::bin_embed::has_embedded_agent() && !embedded_override {
         match resolve_embedded_agent_home() {
             Ok(p) => p,
             Err(e) => {
@@ -630,6 +640,25 @@ fn resolve_embedded_agent_home() -> anyhow::Result<PathBuf> {
     {
         anyhow::bail!("embedded-agent feature not compiled in")
     }
+}
+
+/// `--load` path: install a `.muragent` into `mur_home/agents/<slug>` (reusing
+/// the shared installer — validation, trust, extraction) and return that home.
+/// Stashes the slug as the expected name so the post-load name check passes.
+fn load_muragent_and_home(path: &str, mur_home: &Path) -> anyhow::Result<PathBuf> {
+    use mur_common::muragent::installer;
+    use mur_common::muragent::reader::MuragentArchive;
+
+    let archive = MuragentArchive::read(Path::new(path))
+        .map_err(|e| anyhow::anyhow!("read .muragent at {path}: {e}"))?;
+    let outcome = installer::install(&archive, mur_home, "cli")
+        .map_err(|e| anyhow::anyhow!("install .muragent: {e}"))?;
+    let slug = outcome.manifest.agent.slug.clone();
+    // SAFETY: single-threaded startup, before any tokio tasks spawn.
+    unsafe {
+        std::env::set_var("MUR_RUNTIME_EXPECTED_NAME", &slug);
+    }
+    Ok(mur_home.join("agents").join(&slug))
 }
 
 fn read_flag_profile_from_args() -> anyhow::Result<String> {

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -107,13 +107,20 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     // surfaces on stderr via the chained previous hook.
     crate::crashlog::install_panic_hook(agent_home.clone());
 
-    let profile = match Profile::load(&agent_home) {
+    let mut profile = match Profile::load(&agent_home) {
         Ok(p) => p,
         Err(e) => {
             eprintln!("error[profile_invalid]: {e}");
             std::process::exit(1);
         }
     };
+    // Non-interactive model rebind for headless/server use (§7.5). Honored
+    // by build_provider_runner via resolve_model_entry, which prefers
+    // model_ref over the inline model: block.
+    if let Some(model_ref) = crate::subcommand::flag_value(&argv, "--model") {
+        info!(model_ref = %model_ref, "overriding model binding from --model");
+        profile.inner.model_ref = Some(model_ref);
+    }
     if let Some(expected) = std::env::var_os("MUR_RUNTIME_EXPECTED_NAME") {
         let expected = expected.to_string_lossy().into_owned();
         if let Err(e) = verify_name_match(&expected, &profile.inner.name) {

--- a/mur-agent-runtime/tests/load_muragent.rs
+++ b/mur-agent-runtime/tests/load_muragent.rs
@@ -29,7 +29,9 @@ fn load_muragent_materializes_agent_home() {
     // (a new key without a rotation manifest is accepted on first install).
     // SAFETY: single-threaded test startup, no other code reads MUR_HOME
     // concurrently during this test.
-    unsafe { std::env::set_var("MUR_HOME", &mur_home); }
+    unsafe {
+        std::env::set_var("MUR_HOME", &mur_home);
+    }
     let archive = MuragentArchive::read(&pkg).unwrap();
     let outcome = installer::install(&archive, &mur_home, "cli").unwrap();
     assert_eq!(outcome.manifest.agent.slug, "coach");

--- a/mur-agent-runtime/tests/load_muragent.rs
+++ b/mur-agent-runtime/tests/load_muragent.rs
@@ -1,0 +1,39 @@
+//! `--load` materializes an agent home from a `.muragent`. Mirrors the
+//! supervisor's load path (read archive → installer::install → agents/<slug>).
+
+use mur_common::agent::AgentProfile;
+use mur_common::identity::AgentIdentity;
+use mur_common::muragent::installer;
+use mur_common::muragent::reader::MuragentArchive;
+use mur_common::muragent::writer::{MuragentWriter, build_manifest_from_profile};
+
+#[test]
+fn load_muragent_materializes_agent_home() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let pkg = tmp.path().join("coach.muragent");
+    let mur_home = tmp.path().join("murhome");
+
+    // Author a minimal signed .muragent.
+    let mut profile = AgentProfile::default_for_tests();
+    profile.name = "coach".into();
+    profile.display_name = "Coach".into();
+    let identity = AgentIdentity::generate();
+    let manifest = build_manifest_from_profile(&profile, "1.0.0");
+    let profile_yaml = serde_yaml_ng::to_string(&profile).unwrap();
+    MuragentWriter::new(manifest, profile_yaml, identity)
+        .write(&pkg)
+        .unwrap();
+
+    // The load path: read + install into mur_home/agents/<slug>.
+    // Direct TrustStore to the temp dir so it sees an empty trust store
+    // (a new key without a rotation manifest is accepted on first install).
+    // SAFETY: single-threaded test startup, no other code reads MUR_HOME
+    // concurrently during this test.
+    unsafe { std::env::set_var("MUR_HOME", &mur_home); }
+    let archive = MuragentArchive::read(&pkg).unwrap();
+    let outcome = installer::install(&archive, &mur_home, "cli").unwrap();
+    assert_eq!(outcome.manifest.agent.slug, "coach");
+
+    let home = mur_home.join("agents").join("coach");
+    assert!(home.join("profile.yaml").exists(), "profile.yaml extracted");
+}


### PR DESCRIPTION
## Summary
- `--load <path.muragent>` installs and runs an agent from a signed `.muragent` file — no toolchain, no build step
- `--model <ref>` rebinds the model backend non-interactively for headless/server use (expects a `mur model add` registry entry)
- `flag_value` arg parser supporting both `--flag value` and `--flag=value` forms
- Integration test verifies `.muragent` → agent home materialization

Part of the agent export UX series (Plan 1b). Guided model resolution (hardware detection, Ollama detect/pull) deferred to Plan 2.

## Test Plan
- [x] All 200+ mur-agent-runtime tests pass
- [x] New integration test: `load_muragent_materializes_agent_home`
- [x] `--model` compiles and profiles load with `model_ref` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)