### PR TITLE
feat(nudge): Phase 1 — core engine + CLI (workflow nudge)

### DIFF
--- a/docs/superpowers/plans/2026-05-29-companion-workflow-nudge-phase1.md
+++ b/docs/superpowers/plans/2026-05-29-companion-workflow-nudge-phase1.md
@@ -1,0 +1,924 @@
+# Companion Workflow Nudge — Phase 1 (Core Engine + CLI) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the surface-agnostic core of the workflow nudge — emergence-mined candidates filtered through an anti-nag ledger, surfaced at session-end, accepted/dismissed via the CLI, with accept creating a draft workflow — so the full nudge loop works headlessly before any companion GUI work.
+
+**Architecture:** A new `mur-core/src/nudge/` module turns `EmergentCandidate`s (from the existing `capture/emergence.rs`) into stable-id `WorkflowCandidate`s, persists their lifecycle in a JSON ledger (`~/.mur/nudges.json`) that enforces dedup / snooze / a daily cap, and on accept reuses the existing draft-workflow creation path. `mur session stop` computes and records actionable nudges; `mur suggest` lists them and `--accept`/`--dismiss` act on them.
+
+**Tech Stack:** Rust 2024 (`mur-core`, `mur-common`), `serde`/`serde_json`, `sha2`, `chrono`, `clap`.
+
+**Scope boundary:** Phase 1 = spec units 1 (CandidateSource), 2 (NudgeLedger), 3 (NudgeEmitter), 5 (CLI fallback). **Phase 2** (spec unit 4 — the companion speech-bubble surface: `Situation::WorkflowNudge`, i18n templates, outbox wiring, routing the `good`/`dismiss` `BridgeResponse` back to `apply_decision`) is a **separate plan**, because the `mur-agent-runtime` companion outbox is a mature orchestrator (generate/deliver/picker/passive-dismiss/rhythm) that warrants focused integration. Phase 1 delivers the entire loop via CLI; Phase 2 adds the proactive bubble on top of the same ledger.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-companion-workflow-nudge-design.md`
+
+---
+
+## File Structure
+
+- Modify `mur-common/src/config.rs` — add `NudgeConfig` + `Config.nudge` field (follow the `SleepCycleConfig` pattern).
+- Create `mur-core/src/nudge/mod.rs` — module root, re-exports.
+- Create `mur-core/src/nudge/candidate.rs` — `WorkflowCandidate`, `CandidateSource` trait, `EmergenceSource`.
+- Create `mur-core/src/nudge/ledger.rs` — `NudgeState`, `NudgeRecord`, `NudgeLedger` (load/save/filter/transition).
+- Create `mur-core/src/nudge/emitter.rs` — `NudgeEmitter` (emit_pending, apply_decision, `NudgeDecision`).
+- Modify `mur-core/src/lib.rs` (or `mur-core/src/cmd/mod.rs`) — register `pub mod nudge;`.
+- Modify `mur-core/src/cmd/workflow.rs` — extract `create_draft_workflow(...)` from `cmd_suggest`; reuse it.
+- Modify `mur-core/src/cli/mod.rs` — extend `Suggest` with `accept: Option<String>`, `dismiss: Option<String>`.
+- Modify `mur-core/src/cmd/session.rs` — hook the emitter after `detect_emergent` in `cmd_session_stop`.
+
+---
+
+## Task 1: `NudgeConfig` (mur-common)
+
+**Files:**
+- Modify: `mur-common/src/config.rs`
+- Test: `mur-common/src/config.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the test module in `mur-common/src/config.rs`:
+
+```rust
+#[test]
+fn nudge_config_defaults() {
+    let c = NudgeConfig::default();
+    assert!(!c.enabled);          // opt-in until Phase 2 surface exists
+    assert_eq!(c.daily_cap, 3);
+    assert_eq!(c.snooze_days, 7);
+    assert_eq!(c.threshold, 3);
+}
+
+#[test]
+fn config_has_nudge_section_with_defaults() {
+    // An empty config YAML still yields a usable nudge section via serde defaults.
+    let c: Config = serde_yaml_ng::from_str("{}").unwrap();
+    assert_eq!(c.nudge.daily_cap, 3);
+}
+```
+
+(Confirm the crate's YAML import name — the loader uses `serde_yaml_ng`; match it.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-common nudge_config`
+Expected: FAIL — `cannot find type NudgeConfig`.
+
+- [ ] **Step 3: Implement**
+
+In `mur-common/src/config.rs`, add the field to `Config`:
+
+```rust
+    #[serde(default)]
+    pub nudge: NudgeConfig,
+```
+
+and define (near `SleepCycleConfig`):
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NudgeConfig {
+    /// Master switch. Default off; Phase 2 (companion surface) flips the default.
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_nudge_daily_cap")]
+    pub daily_cap: u32,
+    #[serde(default = "default_nudge_snooze_days")]
+    pub snooze_days: u32,
+    #[serde(default = "default_nudge_threshold")]
+    pub threshold: usize,
+}
+
+fn default_nudge_daily_cap() -> u32 { 3 }
+fn default_nudge_snooze_days() -> u32 { 7 }
+fn default_nudge_threshold() -> usize { 3 }
+
+impl Default for NudgeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            daily_cap: default_nudge_daily_cap(),
+            snooze_days: default_nudge_snooze_days(),
+            threshold: default_nudge_threshold(),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-common nudge_config config_has_nudge_section`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/config.rs
+git commit -m "feat(nudge): NudgeConfig (daily_cap/snooze_days/threshold)"
+```
+
+---
+
+## Task 2: `WorkflowCandidate` + `CandidateSource` + `EmergenceSource` (mur-core)
+
+**Files:**
+- Create: `mur-core/src/nudge/mod.rs`
+- Create: `mur-core/src/nudge/candidate.rs`
+- Modify: `mur-core/src/lib.rs` (add `pub mod nudge;`)
+- Test: `mur-core/src/nudge/candidate.rs` (inline tests)
+
+> Grounding: `EmergentCandidate { behavior, keywords, session_count, session_ids, evidence, suggested_name, suggested_content }` and `detect_emergent(&[BehaviorFingerprint], threshold) -> Vec<EmergentCandidate>` / `load_fingerprints() -> Result<Vec<BehaviorFingerprint>>` are in `mur-core/src/capture/emergence.rs`.
+
+- [ ] **Step 1: Create the module root**
+
+`mur-core/src/nudge/mod.rs`:
+
+```rust
+//! Workflow nudge engine: turn emergence-mined recurring behavior into
+//! actionable "save this as a workflow?" prompts (surface-agnostic).
+pub mod candidate;
+pub mod ledger;
+pub mod emitter;
+
+pub use candidate::{CandidateSource, EmergenceSource, WorkflowCandidate};
+pub use emitter::{NudgeDecision, NudgeEmitter};
+pub use ledger::{NudgeLedger, NudgeRecord, NudgeState};
+```
+
+Add `pub mod nudge;` to `mur-core/src/lib.rs` (alongside the other `pub mod` declarations).
+
+- [ ] **Step 2: Write the failing test**
+
+`mur-core/src/nudge/candidate.rs` (start with the test):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capture::emergence::EmergentCandidate;
+
+    fn ec(behavior: &str, kw: &[&str]) -> EmergentCandidate {
+        EmergentCandidate {
+            behavior: behavior.into(),
+            keywords: kw.iter().map(|s| s.to_string()).collect(),
+            session_count: 3,
+            session_ids: vec!["s1".into(), "s2".into(), "s3".into()],
+            evidence: vec!["ran tests".into(), "committed".into()],
+            suggested_name: "test-then-commit".into(),
+            suggested_content: "…".into(),
+        }
+    }
+
+    #[test]
+    fn id_is_stable_and_order_independent() {
+        let a = WorkflowCandidate::from_emergent(&ec("b", &["test", "commit"]));
+        let b = WorkflowCandidate::from_emergent(&ec("b", &["commit", "test"]));
+        assert_eq!(a.id, b.id); // keyword order must not change the id
+        assert_eq!(a.session_count, 3);
+        assert_eq!(a.suggested_name, "test-then-commit");
+    }
+
+    #[test]
+    fn emergence_source_maps_candidates() {
+        let src = EmergenceSource::from_fingerprints(vec![]); // empty → no candidates
+        assert!(src.candidates(3).unwrap().is_empty());
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cargo test -p mur-core nudge::candidate`
+Expected: FAIL — `WorkflowCandidate` undefined.
+
+- [ ] **Step 4: Implement**
+
+Prepend to `mur-core/src/nudge/candidate.rs`:
+
+```rust
+use crate::capture::emergence::{detect_emergent, EmergentCandidate};
+use mur_common::event::BehaviorFingerprint;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowCandidate {
+    pub id: String,
+    pub title: String,
+    pub suggested_name: String,
+    pub steps_preview: Vec<String>,
+    pub session_count: usize,
+    pub evidence_session_ids: Vec<String>,
+}
+
+impl WorkflowCandidate {
+    pub fn from_emergent(e: &EmergentCandidate) -> Self {
+        let mut kw = e.keywords.clone();
+        kw.sort();
+        let mut h = Sha256::new();
+        h.update(e.behavior.as_bytes());
+        h.update([0]);
+        h.update(kw.join(",").as_bytes());
+        let id = format!("{:x}", h.finalize());
+        Self {
+            id,
+            title: e.behavior.clone(),
+            suggested_name: e.suggested_name.clone(),
+            steps_preview: e.evidence.clone(),
+            session_count: e.session_count,
+            evidence_session_ids: e.session_ids.clone(),
+        }
+    }
+}
+
+/// A source of workflow candidates. v1 has one impl (emergence); co-occurrence
+/// is added post-migration without changing consumers.
+pub trait CandidateSource {
+    fn candidates(&self, threshold: usize) -> anyhow::Result<Vec<WorkflowCandidate>>;
+}
+
+pub struct EmergenceSource {
+    fingerprints: Vec<BehaviorFingerprint>,
+}
+
+impl EmergenceSource {
+    pub fn from_fingerprints(fingerprints: Vec<BehaviorFingerprint>) -> Self {
+        Self { fingerprints }
+    }
+    /// Load all persisted fingerprints (~/.mur/fingerprints.jsonl).
+    pub fn from_disk() -> anyhow::Result<Self> {
+        Ok(Self { fingerprints: crate::capture::emergence::load_fingerprints()? })
+    }
+}
+
+impl CandidateSource for EmergenceSource {
+    fn candidates(&self, threshold: usize) -> anyhow::Result<Vec<WorkflowCandidate>> {
+        Ok(detect_emergent(&self.fingerprints, threshold)
+            .iter()
+            .map(WorkflowCandidate::from_emergent)
+            .collect())
+    }
+}
+```
+
+Confirm `sha2` is a `mur-core` dependency (it is used elsewhere; if not, add to `mur-core/Cargo.toml`).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p mur-core nudge::candidate`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/nudge/mod.rs mur-core/src/nudge/candidate.rs mur-core/src/lib.rs mur-core/Cargo.toml
+git commit -m "feat(nudge): WorkflowCandidate + emergence CandidateSource"
+```
+
+---
+
+## Task 3: `NudgeLedger` (mur-core)
+
+**Files:**
+- Create: `mur-core/src/nudge/ledger.rs`
+- Test: `mur-core/src/nudge/ledger.rs` (inline tests)
+
+> The ledger is the single source of truth for nudge state AND the candidate snapshot (so accept can rebuild the draft later). File: `~/.mur/nudges.json`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nudge::candidate::WorkflowCandidate;
+    use chrono::{Duration, Utc};
+
+    fn cand(id: &str) -> WorkflowCandidate {
+        WorkflowCandidate {
+            id: id.into(), title: "t".into(), suggested_name: "n".into(),
+            steps_preview: vec![], session_count: 3, evidence_session_ids: vec![],
+        }
+    }
+
+    #[test]
+    fn dismissed_never_resurfaces() {
+        let mut l = NudgeLedger::default();
+        l.set_state("a", NudgeState::Dismissed, Utc::now());
+        let actionable = l.filter_actionable(&[cand("a"), cand("b")], Utc::now(), 10);
+        let ids: Vec<_> = actionable.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(ids, vec!["b"]); // "a" dismissed → excluded
+    }
+
+    #[test]
+    fn snooze_hides_until_expiry() {
+        let mut l = NudgeLedger::default();
+        let now = Utc::now();
+        l.set_state("a", NudgeState::Snoozed { until: (now + Duration::days(3)).to_rfc3339() }, now);
+        assert!(l.filter_actionable(&[cand("a")], now, 10).is_empty());
+        let later = now + Duration::days(4);
+        assert_eq!(l.filter_actionable(&[cand("a")], later, 10).len(), 1);
+    }
+
+    #[test]
+    fn daily_cap_limits_new_surfaces() {
+        let l = NudgeLedger::default();
+        let now = Utc::now();
+        let out = l.filter_actionable(&[cand("a"), cand("b"), cand("c")], now, 2);
+        assert_eq!(out.len(), 2); // cap = 2
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core nudge::ledger`
+Expected: FAIL — `NudgeLedger` undefined.
+
+- [ ] **Step 3: Implement**
+
+```rust
+use crate::nudge::candidate::WorkflowCandidate;
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum NudgeState {
+    Surfaced,
+    Accepted,
+    Dismissed,
+    Snoozed { until: String }, // RFC3339
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NudgeRecord {
+    pub state: NudgeState,
+    pub last_ts: String,
+    pub surface_count: u32,
+    /// Snapshot kept so accept can rebuild the draft without re-mining.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate: Option<WorkflowCandidate>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NudgeLedger {
+    #[serde(default)]
+    records: BTreeMap<String, NudgeRecord>,
+}
+
+impl NudgeLedger {
+    pub fn default_path() -> PathBuf {
+        crate::default_mur_dir().join("nudges.json")
+    }
+    pub fn load(path: &Path) -> Result<Self> {
+        match std::fs::read_to_string(path) {
+            Ok(s) => Ok(serde_json::from_str(&s).unwrap_or_default()),
+            Err(_) => Ok(Self::default()),
+        }
+    }
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, serde_json::to_string_pretty(self)?)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+    pub fn get(&self, id: &str) -> Option<&NudgeRecord> {
+        self.records.get(id)
+    }
+    pub fn set_state(&mut self, id: &str, state: NudgeState, now: DateTime<Utc>) {
+        let rec = self.records.entry(id.to_string()).or_insert(NudgeRecord {
+            state: NudgeState::Surfaced, last_ts: now.to_rfc3339(), surface_count: 0, candidate: None,
+        });
+        rec.state = state;
+        rec.last_ts = now.to_rfc3339();
+    }
+    /// Mark a candidate Surfaced (storing its snapshot) and bump surface_count.
+    pub fn mark_surfaced(&mut self, c: &WorkflowCandidate, now: DateTime<Utc>) {
+        let rec = self.records.entry(c.id.clone()).or_insert(NudgeRecord {
+            state: NudgeState::Surfaced, last_ts: now.to_rfc3339(), surface_count: 0, candidate: None,
+        });
+        rec.state = NudgeState::Surfaced;
+        rec.last_ts = now.to_rfc3339();
+        rec.surface_count += 1;
+        rec.candidate = Some(c.clone());
+    }
+
+    /// Candidates eligible to surface: not accepted/dismissed, not currently
+    /// snoozed, capped at `daily_cap` newly-actionable items.
+    pub fn filter_actionable(
+        &self,
+        candidates: &[WorkflowCandidate],
+        now: DateTime<Utc>,
+        daily_cap: u32,
+    ) -> Vec<WorkflowCandidate> {
+        let mut out = Vec::new();
+        for c in candidates {
+            match self.records.get(&c.id).map(|r| &r.state) {
+                Some(NudgeState::Accepted) | Some(NudgeState::Dismissed) => continue,
+                Some(NudgeState::Snoozed { until }) => {
+                    let expired = DateTime::parse_from_rfc3339(until)
+                        .map(|u| now >= u.with_timezone(&Utc))
+                        .unwrap_or(true);
+                    if !expired { continue; }
+                }
+                _ => {}
+            }
+            out.push(c.clone());
+            if out.len() as u32 >= daily_cap { break; }
+        }
+        out
+    }
+}
+```
+
+(Confirm `crate::default_mur_dir()` is the canonical `~/.mur` accessor — `agent_history.rs` uses `default_mur_dir()`. Match the real path of that helper.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-core nudge::ledger`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/nudge/ledger.rs
+git commit -m "feat(nudge): ledger with dedup/snooze/daily-cap"
+```
+
+---
+
+## Task 4: Extract `create_draft_workflow` helper (mur-core)
+
+**Files:**
+- Modify: `mur-core/src/cmd/workflow.rs` (refactor `cmd_suggest`, ~lines 625-762)
+- Test: `mur-core/src/cmd/workflow.rs` (inline test) or `mur-core/tests/cli_nudge.rs`
+
+> Goal: one reusable function both `mur suggest --create` and nudge-accept call, so draft creation is DRY. Pure refactor of existing field construction — no behavior change.
+
+- [ ] **Step 1: Write the failing test**
+
+Add an inline test in `workflow.rs` (or a new `mur-core/tests/cli_nudge.rs` using a temp `MUR_HOME`):
+
+```rust
+#[test]
+fn create_draft_workflow_persists_draft() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = crate::store::workflow_yaml::WorkflowYamlStore::new(tmp.path().join("workflows")).unwrap();
+    create_draft_workflow_in(&store, "test-then-commit", "Run tests then commit",
+        "after editing code", &["s1".into(), "s2".into()]).unwrap();
+    assert!(store.exists("test-then-commit"));
+    let wf = store.get("test-then-commit").unwrap();
+    assert!(wf.base.is_draft);
+    assert_eq!(wf.trigger, "after editing code");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core create_draft_workflow_persists`
+Expected: FAIL — `create_draft_workflow_in` undefined.
+
+- [ ] **Step 3: Implement the helper + reuse it in `cmd_suggest`**
+
+In `workflow.rs`, extract the `Workflow` construction currently inside `cmd_suggest` into:
+
+```rust
+/// Build and save a draft Workflow. Shared by `mur suggest --create` and nudge-accept.
+pub(crate) fn create_draft_workflow_in(
+    store: &crate::store::workflow_yaml::WorkflowYamlStore,
+    name: &str,
+    description: &str,
+    trigger: &str,
+    source_sessions: &[String],
+) -> anyhow::Result<()> {
+    if store.exists(name) {
+        return Ok(()); // idempotent: don't clobber an existing workflow
+    }
+    let mut base = mur_common::KnowledgeBase::new(name, description); // use the real constructor
+    base.is_draft = true;
+    let wf = mur_common::workflow::Workflow {
+        base,
+        steps: vec![],
+        variables: vec![],
+        source_sessions: source_sessions.to_vec(),
+        trigger: trigger.to_string(),
+        tools: vec![],
+        published_version: 0,
+        permission: Default::default(),
+        schedule: None,
+        id: None,
+        notify: None,
+        requires: vec![],
+    };
+    store.save(&wf)
+}
+
+/// Convenience over the default store.
+pub(crate) fn create_draft_workflow(
+    name: &str, description: &str, trigger: &str, source_sessions: &[String],
+) -> anyhow::Result<()> {
+    let store = crate::store::workflow_yaml::WorkflowYamlStore::default_store()?;
+    create_draft_workflow_in(&store, name, description, trigger, source_sessions)
+}
+```
+
+Then replace the inline construction in `cmd_suggest` with a call to `create_draft_workflow_in(&workflow_store, &s.suggested_name, &description, &s.suggested_trigger, &[])`. Match the exact `KnowledgeBase` constructor the file already uses (grep `KnowledgeBase::new` / how `cmd_suggest` builds `base` today and mirror it — do not invent field names).
+
+- [ ] **Step 4: Run test + existing suggest tests**
+
+Run: `cargo test -p mur-core create_draft_workflow_persists` and `cargo test -p mur-core suggest`
+Expected: PASS; existing suggest behavior unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/workflow.rs
+git commit -m "refactor(workflow): extract create_draft_workflow helper (DRY)"
+```
+
+---
+
+## Task 5: `NudgeEmitter` (mur-core)
+
+**Files:**
+- Create: `mur-core/src/nudge/emitter.rs`
+- Test: `mur-core/src/nudge/emitter.rs` (inline tests)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nudge::candidate::WorkflowCandidate;
+    use crate::nudge::ledger::{NudgeLedger, NudgeState};
+    use chrono::Utc;
+
+    fn cand(id: &str) -> WorkflowCandidate {
+        WorkflowCandidate {
+            id: id.into(), title: "Run tests then commit".into(),
+            suggested_name: "test-then-commit".into(), steps_preview: vec![],
+            session_count: 3, evidence_session_ids: vec!["s1".into()],
+        }
+    }
+
+    #[test]
+    fn emit_marks_surfaced() {
+        let mut l = NudgeLedger::default();
+        NudgeEmitter::emit_pending(&mut l, &[cand("a")], Utc::now());
+        assert!(matches!(l.get("a").unwrap().state, NudgeState::Surfaced));
+        assert_eq!(l.get("a").unwrap().surface_count, 1);
+    }
+
+    #[test]
+    fn dismiss_decision_updates_ledger() {
+        let mut l = NudgeLedger::default();
+        NudgeEmitter::emit_pending(&mut l, &[cand("a")], Utc::now());
+        NudgeEmitter::apply_decision(&mut l, "a", NudgeDecision::Dismiss, 7, Utc::now(), &|_c| Ok(())).unwrap();
+        assert!(matches!(l.get("a").unwrap().state, NudgeState::Dismissed));
+    }
+
+    #[test]
+    fn accept_decision_calls_creator_and_marks_accepted() {
+        let mut l = NudgeLedger::default();
+        NudgeEmitter::emit_pending(&mut l, &[cand("a")], Utc::now());
+        let created = std::cell::Cell::new(false);
+        NudgeEmitter::apply_decision(&mut l, "a", NudgeDecision::Accept, 7, Utc::now(),
+            &|c| { assert_eq!(c.suggested_name, "test-then-commit"); created.set(true); Ok(()) }).unwrap();
+        assert!(created.get());
+        assert!(matches!(l.get("a").unwrap().state, NudgeState::Accepted));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core nudge::emitter`
+Expected: FAIL — `NudgeEmitter` undefined.
+
+- [ ] **Step 3: Implement**
+
+```rust
+use crate::nudge::candidate::WorkflowCandidate;
+use crate::nudge::ledger::{NudgeLedger, NudgeState};
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Duration, Utc};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NudgeDecision { Accept, Dismiss, Snooze }
+
+pub struct NudgeEmitter;
+
+impl NudgeEmitter {
+    /// Mark each actionable candidate Surfaced (records its snapshot).
+    pub fn emit_pending(ledger: &mut NudgeLedger, actionable: &[WorkflowCandidate], now: DateTime<Utc>) {
+        for c in actionable {
+            ledger.mark_surfaced(c, now);
+        }
+    }
+
+    /// Apply a user decision. `create` is called with the candidate on Accept
+    /// (injected so the emitter stays free of workflow-store deps for testing).
+    pub fn apply_decision(
+        ledger: &mut NudgeLedger,
+        id: &str,
+        decision: NudgeDecision,
+        snooze_days: u32,
+        now: DateTime<Utc>,
+        create: &dyn Fn(&WorkflowCandidate) -> Result<()>,
+    ) -> Result<()> {
+        match decision {
+            NudgeDecision::Accept => {
+                let cand = ledger.get(id).and_then(|r| r.candidate.clone())
+                    .ok_or_else(|| anyhow!("no pending nudge with id {id}"))?;
+                create(&cand)?;
+                ledger.set_state(id, NudgeState::Accepted, now);
+            }
+            NudgeDecision::Dismiss => ledger.set_state(id, NudgeState::Dismissed, now),
+            NudgeDecision::Snooze => {
+                let until = (now + Duration::days(snooze_days as i64)).to_rfc3339();
+                ledger.set_state(id, NudgeState::Snoozed { until }, now);
+            }
+        }
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-core nudge::emitter`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/nudge/emitter.rs
+git commit -m "feat(nudge): emitter (emit_pending + apply_decision)"
+```
+
+---
+
+## Task 6: CLI `--accept` / `--dismiss` + list pending (mur-core)
+
+**Files:**
+- Modify: `mur-core/src/cli/mod.rs` (the `Suggest` variant, ~line 207)
+- Modify: `mur-core/src/cmd/workflow.rs` (the `cmd_suggest` entry/dispatch)
+- Test: `mur-core/tests/cli_nudge.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+`mur-core/tests/cli_nudge.rs` (drive the dispatch fn with a temp `MUR_HOME`; mirror how other `tests/cli_*.rs` set the home env):
+
+```rust
+#[test]
+fn accept_creates_draft_and_marks_ledger() {
+    let home = tempfile::tempdir().unwrap();
+    // seed a ledger with one surfaced candidate id "abc"
+    // (write ~/.mur/nudges.json via NudgeLedger directly)
+    // ... set MUR_HOME=home.path() ...
+    mur_core::cmd::workflow::cmd_suggest_accept("abc").unwrap();
+    let l = mur_core::nudge::NudgeLedger::load(&mur_core::nudge::NudgeLedger::default_path()).unwrap();
+    assert!(matches!(l.get("abc").unwrap().state, mur_core::nudge::NudgeState::Accepted));
+    // and the workflow draft exists
+    assert!(mur_core::store::workflow_yaml::WorkflowYamlStore::default_store().unwrap().exists("…"));
+}
+```
+
+(Use the actual `MUR_HOME`/home override the test harness in `tests/cli_drafts.rs` uses.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core --test cli_nudge accept_creates_draft`
+Expected: FAIL — `cmd_suggest_accept` undefined.
+
+- [ ] **Step 3: Extend the CLI variant**
+
+In `mur-core/src/cli/mod.rs`:
+
+```rust
+    /// Show workflow composition suggestions and pending nudges.
+    Suggest {
+        /// Auto-create suggested workflows/patterns as drafts
+        #[arg(long)]
+        create: bool,
+        /// Accept a pending nudge by id → create its draft workflow
+        #[arg(long, value_name = "ID")]
+        accept: Option<String>,
+        /// Dismiss a pending nudge by id (never re-surfaces)
+        #[arg(long, value_name = "ID")]
+        dismiss: Option<String>,
+    },
+```
+
+- [ ] **Step 4: Implement the handlers + listing**
+
+In `workflow.rs`:
+
+```rust
+pub fn cmd_suggest_accept(id: &str) -> anyhow::Result<()> {
+    let cfg = mur_common::config::Config::load_or_default(&mur_common::config::Config::default_path());
+    let path = crate::nudge::NudgeLedger::default_path();
+    let mut ledger = crate::nudge::NudgeLedger::load(&path)?;
+    crate::nudge::NudgeEmitter::apply_decision(
+        &mut ledger, id, crate::nudge::NudgeDecision::Accept,
+        cfg.nudge.snooze_days, chrono::Utc::now(),
+        &|c| create_draft_workflow(&c.suggested_name, &c.title, "", &c.evidence_session_ids),
+    )?;
+    ledger.save(&path)?;
+    println!("✓ Saved workflow draft from nudge {id}. Run it with `mur run <name>`.");
+    Ok(())
+}
+
+pub fn cmd_suggest_dismiss(id: &str) -> anyhow::Result<()> {
+    let cfg = mur_common::config::Config::load_or_default(&mur_common::config::Config::default_path());
+    let path = crate::nudge::NudgeLedger::default_path();
+    let mut ledger = crate::nudge::NudgeLedger::load(&path)?;
+    crate::nudge::NudgeEmitter::apply_decision(
+        &mut ledger, id, crate::nudge::NudgeDecision::Dismiss,
+        cfg.nudge.snooze_days, chrono::Utc::now(), &|_| Ok(()))?;
+    ledger.save(&path)?;
+    println!("✓ Dismissed nudge {id}.");
+    Ok(())
+}
+```
+
+Add a pending-nudges section to the existing `cmd_suggest` output: load the ledger, print each `Surfaced` (or expired-`Snoozed`) record as `  [<id-short>] <title> (seen in <n> sessions) — mur suggest --accept <id>`. Wire the `accept`/`dismiss` args in the dispatch (where `Suggest { .. }` is matched — grep for the match arm and route to the two new fns; `create` keeps its current behavior).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p mur-core --test cli_nudge accept_creates_draft`
+Then: `cargo run -p mur-core -- suggest --help` (confirm `--accept/--dismiss` show).
+Expected: PASS; help renders.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/cli/mod.rs mur-core/src/cmd/workflow.rs mur-core/tests/cli_nudge.rs
+git commit -m "feat(nudge): mur suggest --accept/--dismiss + pending listing"
+```
+
+---
+
+## Task 7: Session-end hook (mur-core)
+
+**Files:**
+- Modify: `mur-core/src/cmd/session.rs` (`cmd_session_stop`, after `detect_emergent` ~line 138-144)
+- Test: `mur-core/tests/cli_nudge.rs`
+
+> Replace the current "run `mur skill suggest`" eprintln with: map candidates → filter through the ledger → `emit_pending` → persist → print a concise hint pointing at `mur suggest`. Respect `config.nudge.enabled` (when false, keep old behavior / skip emission — gate so Phase 1 is opt-in until Phase 2 surface ships, per Task 1 default).
+
+- [ ] **Step 1: Write the failing test**
+
+In `cli_nudge.rs`:
+
+```rust
+#[test]
+fn session_stop_records_pending_nudges() {
+    let home = tempfile::tempdir().unwrap();
+    // set MUR_HOME, enable nudges in config, seed ~/.mur/fingerprints.jsonl with
+    // >=3 sessions of the same behavior so detect_emergent yields a candidate.
+    // ... then:
+    mur_core::cmd::session::record_nudges_for_candidates(&candidates).unwrap();
+    let l = mur_core::nudge::NudgeLedger::load(&mur_core::nudge::NudgeLedger::default_path()).unwrap();
+    assert_eq!(l.get(&candidates[0].id).unwrap().surface_count, 1);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core --test cli_nudge session_stop_records`
+Expected: FAIL — `record_nudges_for_candidates` undefined.
+
+- [ ] **Step 3: Implement the hook**
+
+Add to `session.rs`:
+
+```rust
+/// Filter candidates through the nudge ledger and mark the actionable ones
+/// Surfaced. Returns the ids that were surfaced (for the CLI hint).
+pub(crate) fn record_nudges_for_candidates(
+    candidates: &[crate::nudge::WorkflowCandidate],
+) -> anyhow::Result<Vec<String>> {
+    let cfg = mur_common::config::Config::load_or_default(&mur_common::config::Config::default_path());
+    if !cfg.nudge.enabled || candidates.is_empty() {
+        return Ok(vec![]);
+    }
+    let path = crate::nudge::NudgeLedger::default_path();
+    let mut ledger = crate::nudge::NudgeLedger::load(&path)?;
+    let now = chrono::Utc::now();
+    let actionable = ledger.filter_actionable(candidates, now, cfg.nudge.daily_cap);
+    crate::nudge::NudgeEmitter::emit_pending(&mut ledger, &actionable, now);
+    ledger.save(&path)?;
+    Ok(actionable.into_iter().map(|c| c.id).collect())
+}
+```
+
+Then in `cmd_session_stop`, where `detect_emergent(&fps, 3)` runs (~line 138), map to candidates and call the hook:
+
+```rust
+let candidates: Vec<_> = crate::capture::emergence::detect_emergent(&fps, cfg.nudge.threshold)
+    .iter()
+    .map(crate::nudge::WorkflowCandidate::from_emergent)
+    .collect();
+let surfaced = record_nudges_for_candidates(&candidates)?;
+if !surfaced.is_empty() {
+    eprintln!("💡 Noticed {} repeated workflow(s). Review with `mur suggest`.", surfaced.len());
+}
+```
+
+(Load `cfg` once near the top of `cmd_session_stop` if not already present.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-core --test cli_nudge session_stop_records`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/session.rs mur-core/tests/cli_nudge.rs
+git commit -m "feat(nudge): surface pending nudges at session end (gated by config)"
+```
+
+---
+
+## Task 8: End-to-end integration test (mur-core)
+
+**Files:**
+- Test: `mur-core/tests/cli_nudge.rs`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+#[test]
+fn end_to_end_detect_accept_no_resurface() {
+    let home = tempfile::tempdir().unwrap();
+    // 1. enable nudges; seed fingerprints for one recurring behavior across 3 sessions.
+    // 2. compute candidates + record pending (record_nudges_for_candidates).
+    // 3. accept the candidate by id → draft created, ledger Accepted.
+    // 4. recompute + filter_actionable → the accepted candidate is NOT actionable again.
+    let cands = /* detect via EmergenceSource::from_disk()?.candidates(3) */;
+    let id = cands[0].id.clone();
+    mur_core::cmd::session::record_nudges_for_candidates(&cands).unwrap();
+    mur_core::cmd::workflow::cmd_suggest_accept(&id).unwrap();
+
+    let l = mur_core::nudge::NudgeLedger::load(&mur_core::nudge::NudgeLedger::default_path()).unwrap();
+    assert!(matches!(l.get(&id).unwrap().state, mur_core::nudge::NudgeState::Accepted));
+    assert!(l.filter_actionable(&cands, chrono::Utc::now(), 10).is_empty());
+    assert!(mur_core::store::workflow_yaml::WorkflowYamlStore::default_store().unwrap()
+        .exists(&cands[0].suggested_name));
+}
+```
+
+- [ ] **Step 2: Run + full suite + clippy/fmt**
+
+Run:
+```bash
+cargo test -p mur-core --test cli_nudge
+cargo test -p mur-core nudge::
+cargo test -p mur-common nudge_config
+cargo clippy -p mur-core -p mur-common -- -D warnings
+cargo fmt --check
+```
+Expected: all PASS / clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-core/tests/cli_nudge.rs
+git commit -m "test(nudge): end-to-end detect→accept→no-resurface"
+```
+
+---
+
+## Phase 2 (companion surface — separate plan)
+
+**Do not implement here.** Spec unit 4 (the proactive speech bubble) integrates the nudge into the `mur-agent-runtime` companion outbox subsystem. Write `docs/superpowers/plans/<date>-companion-workflow-nudge-phase2.md` covering:
+- A `Situation::WorkflowNudge` variant (`mur_common::companion`) + i18n templates (`companion/outbox/i18n.rs`, `companion/i18n.rs`).
+- Emitting the nudge as a `CompanionMessage` to the agent companion inbox (`companion/inbox.rs::write_inbox_md`) at session-end / idle, gated by `voice/dnd.rs::is_focus_active()`.
+- Routing the user's `BridgeResponse` (`good` → Accept, `dismiss` → Dismiss; add a `snooze` signal value in `companion_bridge/event.rs`) back to `NudgeEmitter::apply_decision`, reusing the existing outbox passive-dismiss/picker plumbing (`companion/outbox/mod.rs`).
+- Flipping `NudgeConfig::enabled` default to `true` once the surface exists.
+- Tests: DND suppression leaves the nudge pending; `good`/`dismiss`/`snooze` responses map to the right ledger transitions.
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 scope):**
+- §3 emergence-only signal, pluggable source → Task 2 (`CandidateSource`/`EmergenceSource`). Co-occurrence correctly deferred.
+- §4 unit 1 (CandidateSource) → Task 2; unit 2 (NudgeLedger) → Task 3; unit 3 (NudgeEmitter) → Task 5; unit 5 (CLI fallback) → Task 6. Unit 4 (companion) → Phase 2 (deferred).
+- §5 accept reuses existing draft path → Task 4 (extracted helper) + Task 6 (accept wires it).
+- §6 data flow (session-end → candidates → ledger filter → emit; accept → draft) → Tasks 7, 6, 8.
+- §7 anti-nag (dismissed terminal, snooze window, daily cap, stable ids) → Task 3 (filter) + Task 2 (stable id).
+- §8 testing (ledger dedup, snooze, daily cap, candidate mapping, accept creates draft) → Tasks 2,3,5,6,8. DND suppression → Phase 2 (companion-only).
+
+**Placeholder scan:** Code steps carry real code. The few "match the existing constructor/harness in <file>" notes point at concrete files (`tests/cli_drafts.rs` for the home-env harness; the existing `cmd_suggest` `KnowledgeBase` construction) rather than leaving logic undefined — necessary because the exact `KnowledgeBase::new` shape must be read from source, not invented.
+
+**Type consistency:** `WorkflowCandidate` (Task 2) fields are used unchanged in Tasks 3,5,6,7,8. `NudgeState`/`NudgeLedger` (Task 3) used in Tasks 5,6,7,8. `NudgeDecision`/`NudgeEmitter` (Task 5) used in Tasks 6,7. `create_draft_workflow`/`create_draft_workflow_in` (Task 4) used in Task 6. `record_nudges_for_candidates` (Task 7) used in Task 8.

--- a/docs/superpowers/plans/2026-05-29-companion-workflow-nudge-phase2.md
+++ b/docs/superpowers/plans/2026-05-29-companion-workflow-nudge-phase2.md
@@ -1,0 +1,633 @@
+# Companion Workflow Nudge — Phase 2 (Companion Surface) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface Phase 1's pending workflow nudges as proactive companion speech bubbles with Save / Not now / No thanks, routing the user's response back into the Phase-1 ledger (accept → draft workflow) — turning the CLI-only loop into the companion experience.
+
+**Architecture:** Reuse the companion **inbox** message format + **ack/response** plumbing, but **bypass the proactive outbox** (the `run_tick` picker/LLM/rhythm path is for time-of-day chatter, not event-triggered deterministic nudges). At session-end `mur-core` writes a deterministic nudge `.md` to each companion-enabled agent's inbox; the GUI displays it (gating on OS DND, which the GUI layer already has) with action buttons that write a response via the existing `companion_ack`; a `mur-core` drain reads the resulting `UserSignal` events and applies the decision through the Phase-1 `NudgeEmitter`.
+
+**Tech Stack:** Rust 2024 (`mur-core`, `mur-common`, `mur-gui-core`), `serde`; plus a thin TypeScript/React button layer in `mur-hub-gui` (Tauri).
+
+**Depends on:** **Phase 1** (`docs/superpowers/plans/2026-05-29-companion-workflow-nudge-phase1.md`) must be merged — this plan uses `WorkflowCandidate`, `NudgeLedger`, `NudgeState`, `NudgeEmitter`, `NudgeDecision`, `create_draft_workflow`, and the `~/.mur/nudges.json` ledger it introduces.
+
+**Architecture decisions (resolved — see the chat preamble for rationale):**
+1. Bypass the outbox; write the nudge inbox `.md` directly from `mur-core`.
+2. Nudge engine stays in `mur-core`; DND gating happens in the GUI display layer; no `mur-agent-runtime` changes; no type-move to `mur-common` (types-only crate).
+3. Accept→draft happens in a `mur-core` drain of `nudge:*` `UserSignal` events.
+4. Deliver to every companion-enabled agent's inbox; none → CLI-only fallback.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-companion-workflow-nudge-design.md` (§4 unit 4).
+
+---
+
+## File Structure
+
+- Modify `mur-common/src/companion/mod.rs` — add `Situation::WorkflowNudge`.
+- Create `mur-core/src/nudge/companion.rs` — deterministic nudge body + inbox writer + agent discovery + the response drain. (Keeps `nudge/` cohesive and files focused.)
+- Modify `mur-core/src/nudge/mod.rs` — `pub mod companion;` + re-exports.
+- Modify `mur-core/src/cmd/session.rs` — after Phase-1 `record_nudges_for_candidates`, deliver inbox messages.
+- Modify `mur-core/src/cmd/workflow.rs` — `cmd_suggest` calls the response drain before listing.
+- Modify `mur-common/src/config.rs` — flip `NudgeConfig::enabled` default to `true`.
+- Modify `mur-gui-core/src/companion_bridge/event.rs` — accept a `snooze` response value.
+- Modify `mur-hub-gui/src-tauri/src/companion.rs` — accept `snooze` in `companion_ack` validation; React buttons (TS) for nudge messages.
+
+---
+
+## Task 1: `Situation::WorkflowNudge` (mur-common)
+
+**Files:**
+- Modify: `mur-common/src/companion/mod.rs:29-34`
+- Test: same file (inline)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn workflow_nudge_situation_serializes_snake_case() {
+    assert_eq!(
+        serde_json::to_string(&Situation::WorkflowNudge).unwrap(),
+        "\"workflow_nudge\""
+    );
+    let back: Situation = serde_json::from_str("\"workflow_nudge\"").unwrap();
+    assert_eq!(back, Situation::WorkflowNudge);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-common workflow_nudge_situation`
+Expected: FAIL — no variant `WorkflowNudge`.
+
+- [ ] **Step 3: Add the variant**
+
+In `mur-common/src/companion/mod.rs`, extend the enum:
+
+```rust
+pub enum Situation {
+    MorningGreeting,
+    GentleCheckIn,
+    ShareQuote,
+    ShareLink,
+    WorkflowNudge,
+}
+```
+
+If any code `match`es `Situation` exhaustively (e.g. `situations::weights_by_hour`), add a `WorkflowNudge => 0.0` weight arm (the nudge is never picked by the proactive rhythm — it is delivered out-of-band). Grep `match` on `Situation` and fix non-exhaustive errors with a zero/neutral arm.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-common workflow_nudge_situation` and `cargo build -p mur-common -p mur-agent-runtime`
+Expected: PASS; both crates compile (exhaustive matches handled).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/companion/mod.rs
+git commit -m "feat(nudge): Situation::WorkflowNudge variant"
+```
+
+---
+
+## Task 2: Deterministic nudge body (mur-core)
+
+**Files:**
+- Create: `mur-core/src/nudge/companion.rs`
+- Modify: `mur-core/src/nudge/mod.rs` (add `pub mod companion;`)
+- Test: `mur-core/src/nudge/companion.rs` (inline)
+
+> The body is deterministic (not LLM-composed). Keep i18n minimal: an English default now; the locale arg lets Phase-3 add translations without signature change.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nudge::candidate::WorkflowCandidate;
+
+    fn cand() -> WorkflowCandidate {
+        WorkflowCandidate {
+            id: "abc123".into(),
+            title: "Run tests, then commit, then push".into(),
+            suggested_name: "test-commit-push".into(),
+            steps_preview: vec!["cargo test".into(), "git commit".into()],
+            session_count: 4,
+            evidence_session_ids: vec![],
+        }
+    }
+
+    #[test]
+    fn body_mentions_title_and_count() {
+        let b = nudge_body(&cand(), "en");
+        assert!(b.contains("Run tests, then commit, then push"));
+        assert!(b.contains("4")); // session count
+    }
+
+    #[test]
+    fn message_id_encodes_candidate_id() {
+        assert_eq!(nudge_msg_id("abc123"), "nudge:abc123");
+        assert_eq!(candidate_id_from_msg("nudge:abc123"), Some("abc123".to_string()));
+        assert_eq!(candidate_id_from_msg("other"), None);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core nudge::companion`
+Expected: FAIL — `nudge_body` undefined.
+
+- [ ] **Step 3: Implement**
+
+`mur-core/src/nudge/companion.rs` (top):
+
+```rust
+use crate::nudge::candidate::WorkflowCandidate;
+
+/// Message id namespace so the response drain can recognize nudge replies.
+pub const NUDGE_ID_PREFIX: &str = "nudge:";
+
+pub fn nudge_msg_id(candidate_id: &str) -> String {
+    format!("{NUDGE_ID_PREFIX}{candidate_id}")
+}
+
+pub fn candidate_id_from_msg(msg_id: &str) -> Option<String> {
+    msg_id.strip_prefix(NUDGE_ID_PREFIX).map(|s| s.to_string())
+}
+
+/// Deterministic, locale-aware nudge body. English default for v1.
+pub fn nudge_body(c: &WorkflowCandidate, _locale: &str) -> String {
+    format!(
+        "I noticed you did this across {} sessions:\n\n  {}\n\nWant me to save it as a replayable workflow you can run with `mur run {}`?",
+        c.session_count, c.title, c.suggested_name
+    )
+}
+```
+
+Add `pub mod companion;` to `mur-core/src/nudge/mod.rs`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-core nudge::companion`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/nudge/companion.rs mur-core/src/nudge/mod.rs
+git commit -m "feat(nudge): deterministic companion body + id namespace"
+```
+
+---
+
+## Task 3: Inbox writer (mur-core)
+
+**Files:**
+- Modify: `mur-core/src/nudge/companion.rs`
+- Test: `mur-core/src/nudge/companion.rs` (inline)
+
+> Mirror the inbox `.md` format that `mur-agent-runtime/src/companion/inbox.rs::write_inbox_md` produces and that `mur-core/src/cmd/agent_companion/inbox.rs::ack_at` reads: YAML frontmatter (`id`, `situation`, `template_id`, `locale`, `generated_at`) + body + a trailing `>>> response: <unset>` line. **Open both files and match the exact frontmatter keys/format byte-for-byte** so the GUI parser and `ack_at` accept it. Use `create_new` semantics (skip if the file already exists) for idempotency.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn writes_nudge_inbox_md_with_response_marker() {
+    let dir = tempfile::tempdir().unwrap();
+    let inbox = dir.path().join("inbox");
+    std::fs::create_dir_all(&inbox).unwrap();
+    let c = /* cand() from Task 2 */;
+    let path = write_nudge_inbox(&inbox, &c, "en").unwrap();
+    let s = std::fs::read_to_string(&path).unwrap();
+    assert!(s.contains("situation: workflow_nudge"));
+    assert!(s.contains("id: nudge:abc123"));
+    assert!(s.trim_end().ends_with(">>> response: <unset>"));
+    // idempotent: second write for same id is a no-op (already exists)
+    assert!(write_nudge_inbox(&inbox, &c, "en").is_ok());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core nudge::companion::tests::writes_nudge_inbox`
+Expected: FAIL — `write_nudge_inbox` undefined.
+
+- [ ] **Step 3: Implement**
+
+```rust
+use std::path::{Path, PathBuf};
+
+/// Write a nudge as a companion inbox `.md` (same format as the runtime's
+/// write_inbox_md). Returns the path. No-op (Ok) if a file for this id exists.
+pub fn write_nudge_inbox(inbox_dir: &Path, c: &WorkflowCandidate, locale: &str) -> anyhow::Result<PathBuf> {
+    let id = nudge_msg_id(&c.id);
+    // file name must avoid the ':' in the id on disk — sanitize like the runtime does
+    let file = inbox_dir.join(format!("{}.md", id.replace(':', "_")));
+    if file.exists() {
+        return Ok(file);
+    }
+    let generated_at = chrono::Utc::now().to_rfc3339();
+    let body = nudge_body(c, locale);
+    let content = format!(
+        "---\nid: {id}\nsituation: workflow_nudge\ntemplate_id: nudge\nlocale: {locale}\ngenerated_at: {generated_at}\n---\n\n{body}\n\n>>> response: <unset>"
+    );
+    let tmp = file.with_extension("md.tmp");
+    std::fs::write(&tmp, content)?;
+    std::fs::rename(&tmp, &file)?;
+    Ok(file)
+}
+```
+
+Adjust the exact frontmatter to match `write_inbox_md` precisely (key order, any extra fields, whether it uses `create_new`). If the runtime writer emits additional keys, include them.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-core nudge::companion::tests::writes_nudge_inbox`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/nudge/companion.rs
+git commit -m "feat(nudge): write nudge to companion inbox (.md)"
+```
+
+---
+
+## Task 4: Deliver at session-end to companion-enabled agents (mur-core)
+
+**Files:**
+- Modify: `mur-core/src/nudge/companion.rs` (agent discovery + deliver loop)
+- Modify: `mur-core/src/cmd/session.rs` (`cmd_session_stop`, after Phase-1 `record_nudges_for_candidates`)
+- Test: `mur-core/src/nudge/companion.rs` (inline)
+
+> Discover agents at `~/.mur/agents/<slug>/`; read each `profile.yaml` and check `companion.enabled` (the `CompanionConfig` block on `AgentProfile`). Deliver each surfaced candidate to each enabled agent's `companion/inbox/`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn deliver_writes_to_enabled_agent_inboxes_only() {
+    let mur = tempfile::tempdir().unwrap();
+    // agent "on": profile with companion.enabled = true
+    // agent "off": profile with companion.enabled = false
+    // (write minimal profile.yaml for each under agents/<slug>/)
+    let c = /* cand() */;
+    let n = deliver_nudges_to_companions(mur.path(), &[c], "en").unwrap();
+    assert_eq!(n, 1); // only the "on" agent got it
+    assert!(mur.path().join("agents/on/companion/inbox/nudge_abc123.md").exists());
+    assert!(!mur.path().join("agents/off/companion/inbox/nudge_abc123.md").exists());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core nudge::companion::tests::deliver_writes`
+Expected: FAIL — `deliver_nudges_to_companions` undefined.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Write each candidate to every companion-enabled agent's inbox.
+/// Returns the number of (agent × candidate) messages written.
+pub fn deliver_nudges_to_companions(
+    mur_dir: &Path,
+    candidates: &[WorkflowCandidate],
+    locale: &str,
+) -> anyhow::Result<usize> {
+    let agents_dir = mur_dir.join("agents");
+    if !agents_dir.exists() || candidates.is_empty() {
+        return Ok(0);
+    }
+    let mut written = 0;
+    for entry in std::fs::read_dir(&agents_dir)? {
+        let dir = entry?.path();
+        let profile = dir.join("profile.yaml");
+        if !profile.is_file() {
+            continue;
+        }
+        let body = std::fs::read_to_string(&profile)?;
+        let prof: mur_common::agent::AgentProfile = match serde_yaml_ng::from_str(&body) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if !prof.companion.enabled {
+            continue;
+        }
+        let inbox = dir.join("companion").join("inbox");
+        std::fs::create_dir_all(&inbox)?;
+        for c in candidates {
+            write_nudge_inbox(&inbox, c, locale)?;
+            written += 1;
+        }
+    }
+    Ok(written)
+}
+```
+
+(Confirm the `AgentProfile.companion.enabled` field path — grep `CompanionConfig` in `mur-common/src/agent.rs`. Match the real field name.)
+
+In `mur-core/src/cmd/session.rs`, after the Phase-1 surfaced ids are computed:
+
+```rust
+let surfaced = record_nudges_for_candidates(&candidates)?;
+if !surfaced.is_empty() && cfg.nudge.enabled {
+    // re-load the surfaced candidates (Phase-1 stored snapshots in the ledger)
+    let ledger = crate::nudge::NudgeLedger::load(&crate::nudge::NudgeLedger::default_path())?;
+    let surfaced_cands: Vec<_> = surfaced.iter()
+        .filter_map(|id| ledger.get(id).and_then(|r| r.candidate.clone()))
+        .collect();
+    let n = crate::nudge::companion::deliver_nudges_to_companions(
+        &crate::default_mur_dir(), &surfaced_cands, &cfg.locale())?;
+    eprintln!("💡 {} nudge(s) sent to your companion (or run `mur suggest`).", n.max(surfaced.len()));
+}
+```
+
+(Use the real config locale accessor; if none, pass `"en"`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-core nudge::companion::tests::deliver_writes`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/nudge/companion.rs mur-core/src/cmd/session.rs
+git commit -m "feat(nudge): deliver nudges to companion-enabled agent inboxes"
+```
+
+---
+
+## Task 5: `snooze` response value (mur-gui-core + mur-core)
+
+**Files:**
+- Modify: `mur-gui-core/src/companion_bridge/event.rs:43-75` (parser + `BridgeResponse`)
+- Modify: `mur-core/src/cmd/agent_companion/inbox.rs` (`ack_at` signal validation, ~line 101)
+- Test: `mur-gui-core/src/companion_bridge/event.rs` (inline)
+
+> Today the validated response set is `good | bad | dismiss`. Add `snooze`. Keep it a plain signal value (the snooze *duration* comes from `config.nudge.snooze_days`, applied by the drain — Task 6).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn parses_snooze_response() {
+    // build the inbox md text with ">>> response: snooze" and parse it
+    let ev = parse_inbox_md_str(/* … md with response: snooze … */).unwrap();
+    assert_eq!(ev.response, BridgeResponse::Signal("snooze".into()));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-gui-core parses_snooze_response`
+Expected: FAIL — `snooze` rejected by the parser (`bail!("unrecognized response value")`).
+
+- [ ] **Step 3: Implement**
+
+In `event.rs`, extend the validated set:
+
+```rust
+} else if matches!(response_value, "good" | "bad" | "dismiss" | "snooze") {
+    BridgeResponse::Signal(response_value.to_string())
+}
+```
+
+In `mur-core/src/cmd/agent_companion/inbox.rs::ack_at`, extend the signal validation/mapping to accept `"snooze"` (it maps to a nudge decision in Task 6; for non-nudge messages, treat `snooze` as a no-op/dismiss-equivalent or reject — match the existing validation style and add `snooze` to the allowed set).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-gui-core parses_snooze_response`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-gui-core/src/companion_bridge/event.rs mur-core/src/cmd/agent_companion/inbox.rs
+git commit -m "feat(nudge): add snooze response value"
+```
+
+---
+
+## Task 6: Response drain → apply decision (mur-core)
+
+**Files:**
+- Modify: `mur-core/src/nudge/companion.rs` (the drain)
+- Modify: `mur-core/src/cmd/workflow.rs` (`cmd_suggest` calls the drain first)
+- Test: `mur-core/src/nudge/companion.rs` (inline) + `mur-core/tests/cli_nudge.rs`
+
+> The drain scans companion inbox `.md` files (across agents) whose `id` is `nudge:*` and whose `>>> response:` is no longer `<unset>`, maps the response to a `NudgeDecision`, applies it via the Phase-1 emitter, and marks the inbox file consumed (rename/delete) so it is not re-applied.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn drain_applies_accept_and_creates_draft() {
+    let mur = tempfile::tempdir().unwrap();
+    // 1. seed nudge ledger (Phase 1) with a Surfaced candidate "abc123" (snapshot present)
+    // 2. write a nudge inbox md for an agent with ">>> response: good"
+    // 3. run the drain
+    let applied = drain_nudge_responses_in(mur.path()).unwrap();
+    assert_eq!(applied, 1);
+    let l = crate::nudge::NudgeLedger::load(&mur.path().join("nudges.json")).unwrap();
+    assert!(matches!(l.get("abc123").unwrap().state, crate::nudge::NudgeState::Accepted));
+    // draft workflow created (workflow_store under this mur dir)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-core nudge::companion::tests::drain_applies_accept`
+Expected: FAIL — `drain_nudge_responses_in` undefined.
+
+- [ ] **Step 3: Implement**
+
+```rust
+use crate::nudge::{NudgeDecision, NudgeEmitter, NudgeLedger};
+
+fn signal_to_decision(sig: &str) -> Option<NudgeDecision> {
+    match sig {
+        "good" => Some(NudgeDecision::Accept),
+        "dismiss" | "bad" => Some(NudgeDecision::Dismiss),
+        "snooze" => Some(NudgeDecision::Snooze),
+        _ => None,
+    }
+}
+
+/// Scan all companion inboxes for answered nudge messages, apply each decision
+/// to the nudge ledger, and consume the file. Returns count applied.
+pub fn drain_nudge_responses_in(mur_dir: &Path) -> anyhow::Result<usize> {
+    let cfg = mur_common::config::Config::load_or_default(&mur_common::config::Config::default_path());
+    let ledger_path = NudgeLedger::default_path_in(mur_dir); // add a *_in(dir) variant for tests
+    let mut ledger = NudgeLedger::load(&ledger_path)?;
+    let now = chrono::Utc::now();
+    let mut applied = 0;
+    let agents = mur_dir.join("agents");
+    if !agents.exists() { return Ok(0); }
+    for agent in std::fs::read_dir(&agents)? {
+        let inbox = agent?.path().join("companion").join("inbox");
+        if !inbox.is_dir() { continue; }
+        for f in std::fs::read_dir(&inbox)? {
+            let path = f?.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("md") { continue; }
+            let text = std::fs::read_to_string(&path)?;
+            let (id, resp) = parse_id_and_response(&text); // small local parser of frontmatter id + response line
+            let (Some(id), Some(resp)) = (id, resp) else { continue };
+            if resp == "<unset>" { continue; }
+            let Some(cand_id) = candidate_id_from_msg(&id) else { continue };
+            let Some(decision) = signal_to_decision(&resp) else { continue };
+            NudgeEmitter::apply_decision(&mut ledger, &cand_id, decision, cfg.nudge.snooze_days, now,
+                &|c| crate::cmd::workflow::create_draft_workflow(&c.suggested_name, &c.title, "", &c.evidence_session_ids))?;
+            std::fs::remove_file(&path).ok(); // consume
+            applied += 1;
+        }
+    }
+    if applied > 0 { ledger.save(&ledger_path)?; }
+    Ok(applied)
+}
+```
+
+Implement `parse_id_and_response` (read the frontmatter `id:` and the `>>> response:` line). Add `NudgeLedger::default_path_in(dir)` (and have `default_path()` call it with `default_mur_dir()`) so tests can target a temp dir. Call `drain_nudge_responses_in(&default_mur_dir())` at the top of `cmd_suggest` (before listing pending), so accepted nudges turn into drafts whenever the user runs `mur suggest`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-core nudge::companion::tests::drain_applies_accept`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/nudge/companion.rs mur-core/src/cmd/workflow.rs
+git commit -m "feat(nudge): drain companion responses → apply decision"
+```
+
+---
+
+## Task 7: Enable by default (mur-common)
+
+**Files:**
+- Modify: `mur-common/src/config.rs` (`NudgeConfig::default` / `default` of `enabled`)
+- Test: `mur-common/src/config.rs` (update Task-1 Phase-1 test)
+
+- [ ] **Step 1: Update the test**
+
+Change the Phase-1 `nudge_config_defaults` assertion:
+
+```rust
+assert!(c.enabled); // Phase 2: surface exists → on by default
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-common nudge_config_defaults`
+Expected: FAIL — still `false`.
+
+- [ ] **Step 3: Flip the default**
+
+In `NudgeConfig`, change the `enabled` default to `true` (update both the `#[serde(default = …)]`/field default and the `impl Default`). Replace the bare `#[serde(default)] pub enabled: bool` with an explicit `#[serde(default = "default_nudge_enabled")] pub enabled: bool` + `fn default_nudge_enabled() -> bool { true }`, and set `enabled: true` in `impl Default`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test -p mur-common nudge_config_defaults`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/config.rs
+git commit -m "feat(nudge): enable nudges by default (Phase 2 surface live)"
+```
+
+---
+
+## Task 8: GUI buttons (mur-hub-gui — TypeScript/React) [front-end]
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/companion.rs` (`companion_ack` — accept `snooze`)
+- Modify: the React companion component (TS) that renders inbox messages.
+
+> `mur-hub-gui` is a Tauri app (workspace-excluded), so this task is verified by build + manual smoke, not workspace `cargo test`.
+
+- [ ] **Step 1: Accept `snooze` in the Tauri command**
+
+In `mur-hub-gui/src-tauri/src/companion.rs::companion_ack`, extend the validation set to `{good, bad, dismiss, snooze}` (mirror Task 5).
+
+- [ ] **Step 2: Render nudge actions in React**
+
+In the companion message component, when `situation === "workflow_nudge"`, render three buttons:
+- **Save it** → `invoke("companion_ack", { agent, msgId, signal: "good" })`
+- **Not now** → `signal: "snooze"`
+- **No thanks** → `signal: "dismiss"`
+
+Gate the bubble's appearance on the existing DND state the GUI already tracks (do not pop a nudge while OS Focus/DND is active; it remains in the inbox and pops when DND clears).
+
+- [ ] **Step 3: Build + smoke test**
+
+Run the Tauri app build for `mur-hub-gui` (its own manifest, e.g. `npm run tauri build` / the project's documented GUI build). Manually: trigger a nudge (or hand-place a `workflow_nudge` inbox `.md`), confirm the bubble shows the three buttons, click **Save it**, then run `mur suggest` and confirm the draft workflow exists.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-hub-gui/src-tauri/src/companion.rs mur-hub-gui/src/<component>
+git commit -m "feat(nudge): companion bubble Save/Not now/No thanks buttons"
+```
+
+---
+
+## Task 9: End-to-end integration test (mur-core)
+
+**Files:**
+- Test: `mur-core/tests/cli_nudge.rs`
+
+- [ ] **Step 1: Write the test**
+
+```rust
+#[test]
+fn phase2_end_to_end_deliver_ack_drain() {
+    let mur = tempfile::tempdir().unwrap();
+    // 1. enable nudges; create a companion-enabled agent dir with profile.yaml.
+    // 2. seed fingerprints → candidates; record + deliver to the agent inbox.
+    // 3. simulate the GUI ack: rewrite the inbox file's ">>> response: <unset>" → "good".
+    // 4. drain → draft created, ledger Accepted, inbox file consumed.
+    // 5. re-deliver same candidate → no new message (ledger Accepted excludes it).
+    // assert each step.
+}
+```
+
+- [ ] **Step 2: Run + full suite + clippy/fmt**
+
+Run:
+```bash
+cargo test -p mur-core nudge::
+cargo test -p mur-core --test cli_nudge
+cargo test -p mur-common
+cargo test -p mur-gui-core companion_bridge
+cargo clippy -p mur-core -p mur-common -p mur-gui-core -- -D warnings
+cargo fmt --check
+```
+Expected: all PASS / clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-core/tests/cli_nudge.rs
+git commit -m "test(nudge): phase 2 end-to-end deliver→ack→drain"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (§4 unit 4 + §6/§7 surface parts):**
+- Proactive companion bubble → Tasks 3,4 (deliver) + 8 (render). Accept/dismiss/snooze → Tasks 5,6,8.
+- DND respected → Task 8 (GUI display gate — the layer that owns `is_focus_active`).
+- Accept → draft via existing path → Task 6 (drain calls Phase-1 `create_draft_workflow`).
+- Anti-nag carried over from Phase 1 ledger (dismissed terminal, snooze window, daily cap) — Task 6 applies decisions through the same `NudgeEmitter`/ledger.
+- Enable the surface → Task 7.
+
+**Placeholder scan:** Code steps carry real code. "Match the exact frontmatter/`companion.enabled` field in `<file>`" notes point at concrete sources (`inbox.rs::write_inbox_md`, `ack_at`, `AgentProfile.companion`) that must be read, not invented. Task 8 is explicitly front-end (build+smoke, no Rust unit test) by nature.
+
+**Type consistency:** `Situation::WorkflowNudge` (T1) used in T3 (frontmatter) + T8 (React switch). `nudge_msg_id`/`candidate_id_from_msg`/`nudge_body` (T2) used in T3,T6. `write_nudge_inbox` (T3) used in T4. `deliver_nudges_to_companions` (T4) used in session hook. `signal_to_decision`/`drain_nudge_responses_in` (T6) reuse Phase-1 `NudgeDecision`/`NudgeEmitter`/`create_draft_workflow`. `BridgeResponse::Signal("snooze")` (T5) consumed by T6's `signal_to_decision`.
+
+**Cross-crate note:** Everything testable lands in `mur-core`/`mur-common`/`mur-gui-core` (workspace crates); only Task 8's UI is in the excluded `mur-hub-gui`. No `mur-agent-runtime` changes (delivery bypasses the outbox per Architecture decision 1).

--- a/docs/superpowers/specs/2026-05-29-companion-workflow-nudge-design.md
+++ b/docs/superpowers/specs/2026-05-29-companion-workflow-nudge-design.md
@@ -1,0 +1,182 @@
+# Companion Workflow Nudge — Design
+
+**Date:** 2026-05-29
+**Status:** Design / spec (implementation-ready after plan)
+**Umbrella:** `docs/superpowers/specs/2026-05-29-mur-strategy-positioning-vs-archon.md` (§4.1 consumer wedge; §5 "authoring by recording"; §8.E automatic workflow mining)
+
+The consumer wedge's remaining unbuilt piece. MUR already mines recurring behavior into suggested workflows, but only when the user runs a CLI command (`mur suggest`, `mur emerge`). This feature turns that **CLI-pull into a companion-push**: after a session, if MUR detects a procedure repeated across multiple sessions, the companion proactively asks — *"I noticed you repeated this. Save it as a replayable workflow?"* — with accept / dismiss / snooze. It is the zero-authoring counter to Archon's hand-written YAML workflows.
+
+---
+
+## 1. Goal & non-goals
+
+**Goal.** Make MUR's existing emergence mining *visible at the right moment* through the companion, so a user discovers and saves replayable workflows without ever running a mining command — the "it watches how you work and offers to automate it" moment.
+
+**Non-goals (v1).**
+- No visual DAG editor and no workflow marketplace (umbrella §5/§7 — explicitly not built).
+- No new mining algorithm — reuse `capture/emergence.rs` as-is.
+- No co-occurrence signal in v1 (see §3 — its data feed is being removed by the Pattern→Skill migration; deferred and repointed later).
+- No in-bubble step editor — accept creates a *draft* workflow; editing uses the existing workflow-edit surface.
+- No new workflow storage — accept reuses the existing draft-creation path.
+
+---
+
+## 2. Background: existing mining (grounding)
+
+- **`capture/emergence.rs`** — `extract_fingerprints(transcript, session_id)` derives behavior fingerprints from a session transcript; `detect_emergent(fingerprints, threshold)` clusters them by `jaccard_similarity` and returns `EmergentCandidate { description, session_count, session_ids, … }` for clusters seen in ≥ `threshold` (default 3) distinct sessions. `generate_suggested_name(keywords)` and `build_candidate(...)` already exist. Fingerprints persist via `save_fingerprints` / `load_fingerprints` / `prune_fingerprints`. **Transcript-based — independent of the pattern model.**
+- **`evolve/cooccurrence.rs` + `compose.rs`** — `record_cooccurrence(&injected_patterns)` builds a `CooccurrenceMatrix`; `suggest_workflows(matrix, threshold)` yields `WorkflowSuggestion`. **Fed by the pattern-injection path**, which the Pattern→Skill migration removes (notes-design Resolved Decision #3: "the `inject/` push modules are removed"). Out of scope for v1 (see §3).
+- **`mur suggest [--create]`** (`cli/mod.rs:206`, `cmd/evolve_cmd.rs`) — prints suggestions; `--create` writes draft workflows via `workflow_store`. This is the existing CLI-pull surface and the accept path we reuse.
+- **Companion surface (`mur-gui-core`)** — `companion_bridge/{scanner,watcher}.rs` (filesystem bridge), `expression.rs` (speech bubbles/expressions), idle triggers (C6), `voice/dnd.rs` (DND/Focus detection). The nudge surfaces here.
+- **Recording lifecycle** — `mur-in` starts recording; `mur-out` stops and extracts. Session-end (`mur-out`) is where mining naturally runs.
+
+---
+
+## 3. Signal choice: Emergence now, Co-occurrence later
+
+Emergence and co-occurrence capture **different** things:
+
+| | Emergence | Co-occurrence |
+|---|---|---|
+| Semantics | **Ordered, procedural** recurrence (a repeated tool/command sequence across ≥3 sessions) | **Unordered, associative** ("these items tend to appear together") |
+| Natural product | A **replayable workflow** (has step order) | A **cluster / link** of related items (a relatedness graph) |
+| Data feed | Session transcript — **durable** | `record_cooccurrence(&injected_patterns)` — **feed removed by the migration** |
+
+**Decision: v1 is emergence-only.** Reasons:
+1. **Co-occurrence's data feed is being deleted.** Building the nudge on it would repeat the "built on a soon-removed model" mistake; reviving it post-migration requires repointing it to a new signal (skill co-retrieval / workflow co-run) and is partially blocked on the migration.
+2. **Higher fidelity for workflows.** "Save what you *repeated*" = an ordered procedure = emergence. An unordered cluster must invent step order/trigger, weakening the accept→run experience.
+3. **Co-occurrence's honest long-term role is *note/skill linking*** (a "these notes are related — link them?" nudge), not workflow synthesis. It returns post-migration in that role.
+4. **Zero architectural cost to defer.** The nudge layer consumes a generic `WorkflowCandidate` via a pluggable `CandidateSource`; adding a second source later is purely additive.
+
+---
+
+## 4. Architecture (unit boundaries)
+
+Five units, each with one responsibility and a clear interface. The mining→ledger→emit logic lives in **`mur-core`** (surface-agnostic and testable without a GUI); only rendering lives in **`mur-gui-core`**.
+
+```
+mur-out (session end)
+   │
+   ▼
+[1] CandidateSource (core)         emergence → Vec<WorkflowCandidate>
+   │
+   ▼
+[2] NudgeLedger (core)             dedup / frequency-cap / snooze  → keep only actionable
+   │
+   ▼
+[3] NudgeEmitter (core)            write pending nudge(s) for surfaces to consume
+   │
+   ├───────────────► [5] CLI fallback (core)  `mur suggest` lists pending; accept = existing --create
+   ▼
+[4] Companion surface (gui-core)   idle pickup → DND gate → speech bubble (accept/dismiss/snooze)
+   │
+   ▼  decision written back
+[3] NudgeEmitter applies decision  accept → create draft workflow (existing path); else update ledger
+```
+
+### Unit 1 — `CandidateSource` (core)
+
+```rust
+// mur-core/src/nudge/candidate.rs
+pub struct WorkflowCandidate {
+    pub id: String,            // stable hash of the behavior fingerprint cluster
+    pub title: String,         // human one-liner ("Run tests then commit then push")
+    pub suggested_name: String,// kebab name for the draft workflow
+    pub steps_preview: Vec<String>,
+    pub session_count: usize,
+    pub evidence_session_ids: Vec<String>,
+}
+
+pub trait CandidateSource {
+    fn candidates(&self, threshold: usize) -> anyhow::Result<Vec<WorkflowCandidate>>;
+}
+```
+
+v1 ships one impl, `EmergenceSource`, mapping `EmergentCandidate` → `WorkflowCandidate`. `id` = a stable hash over the cluster's normalized fingerprint so the same recurring behavior maps to the same id across runs (essential for dedup).
+
+### Unit 2 — `NudgeLedger` (core)
+
+Persistent anti-nag brain at `~/.mur/nudges.json`:
+
+```rust
+// mur-core/src/nudge/ledger.rs
+#[derive(Serialize, Deserialize)]
+pub enum NudgeState { Surfaced, Accepted, Dismissed, Snoozed { until: String /* RFC3339 */ } }
+
+#[derive(Serialize, Deserialize)]
+pub struct NudgeRecord { pub state: NudgeState, pub last_ts: String, pub surface_count: u32 }
+
+pub struct NudgeLedger { /* candidate_id -> NudgeRecord */ }
+```
+
+`filter_actionable(candidates, now, daily_cap)` returns only candidates that are: not `Accepted`, not `Dismissed`, not currently `Snoozed`, and within the per-day surface cap (default config `nudge.daily_cap = 2`). Thresholds/caps live in config (Mandatory Rule #1 — no hardcoding).
+
+### Unit 3 — `NudgeEmitter` (core)
+
+- `emit_pending(actionable: &[WorkflowCandidate])` — writes a pending-nudge record (one file per candidate or a single `pending.json`) under a bridge-watched path (e.g. `~/.mur/companion/nudges/`), and marks each `Surfaced` in the ledger with `surface_count += 1`.
+- `apply_decision(candidate_id, decision)` — `Accept` → create a draft workflow via the existing path (see §5) and mark `Accepted`; `Dismiss` → `Dismissed`; `Snooze` → `Snoozed { until = now + config.nudge.snooze_days }`. Removes the pending record.
+
+### Unit 4 — Companion surface (`mur-gui-core`)
+
+- The `companion_bridge` watcher gains awareness of the nudges path. On an **idle** tick (reuse C6 idle), it reads pending nudges, **checks DND/Focus** via `voice/dnd.rs`, and if clear, renders a speech bubble through `expression.rs` with three actions: **Save it** / **Not now** (snooze) / **No thanks** (dismiss).
+- The chosen action is written back to the bridge; the agent/daemon side calls `NudgeEmitter::apply_decision`. If DND is active, the nudge stays pending (re-checked next idle).
+
+### Unit 5 — CLI fallback (core)
+
+- `mur suggest` (existing) gains a section listing pending nudges (id, title, session_count) so headless / no-GUI users still see them; accepting reuses `mur suggest --create`. No new top-level command in v1 (keep surface small); a thin `--accept <id>` / `--dismiss <id>` on `suggest` is the minimal wiring.
+
+---
+
+## 5. Accept action (migration-independent)
+
+Accept reuses the **existing** draft-workflow creation path used by `mur suggest --create` / `cmd/evolve_cmd.rs` (`workflow_store`), producing a draft the user runs with `mur run <name>`. This is independent of the Pattern→Skill migration (workflows are not removed by it; only patterns are). **Forward-compat note:** once the migration lands and workflows become `category: workflow` skills, the accept path repoints to skill creation — a one-line change behind the same `apply_decision` interface; not a v1 concern.
+
+---
+
+## 6. Data flow
+
+1. `mur-out` finishes extraction; mining (`detect_emergent`) runs as it does today.
+2. `EmergenceSource::candidates(threshold)` → `Vec<WorkflowCandidate>`.
+3. `NudgeLedger::filter_actionable` drops accepted/dismissed/snoozed/over-cap.
+4. `NudgeEmitter::emit_pending` writes pending nudges + marks `Surfaced`.
+5. Companion idle tick reads pending → DND gate → speech bubble.
+6. User picks Save / Not now / No thanks → decision written back.
+7. `NudgeEmitter::apply_decision` creates the draft (accept) or updates the ledger, and clears the pending record.
+
+---
+
+## 7. Anti-nag guarantees
+
+- **Dismissed never re-surfaces** (ledger `Dismissed` is terminal for that candidate id).
+- **Snooze** hides for `config.nudge.snooze_days` (default 7), then becomes actionable again.
+- **Daily cap** (`config.nudge.daily_cap`, default 2) bounds interruptions.
+- **DND/Focus respected** — never bubbles during DND; stays pending.
+- **Stable ids** — the same recurring behavior is one ledger entry, so re-detection does not multiply nudges.
+
+---
+
+## 8. Testing
+
+- **Candidate mapping:** an `EmergentCandidate` with N sessions maps to a `WorkflowCandidate` with a stable `id` (same input → same id; reordered fingerprints that normalize equal → same id).
+- **Ledger dedup:** a `Dismissed` candidate is excluded by `filter_actionable` forever; an `Accepted` one too.
+- **Snooze:** snoozed candidate is excluded until `until`, then included.
+- **Daily cap:** with `daily_cap = 2`, the 3rd actionable candidate the same day is withheld.
+- **Accept creates a draft:** `apply_decision(id, Accept)` results in a draft workflow via the existing path (assert `workflow_store` contains it), idempotent on repeat.
+- **DND suppression:** with DND active, the companion leaves the nudge pending (unit-test the gate function in `mur-gui-core`).
+- **CLI fallback:** `mur suggest` lists pending nudges; `--accept <id>` creates the draft and marks `Accepted`.
+
+---
+
+## 9. Sequencing & honesty caveats
+
+- **Migration-independent.** Emergence (transcript-based) and the workflow-draft path are decoupled from the Pattern→Skill migration; v1 is **not blocked**.
+- **Co-occurrence deferred** to post-migration, repointed to a durable signal (skill co-retrieval / workflow co-run) and likely surfaced as a separate "link related notes?" nudge rather than workflow synthesis (§3).
+- **No marketplace / no DAG editor** (umbrella §5/§7).
+- A **read-only** visual viewer of a mined workflow is explicitly out of scope (optional future, per umbrella §5).
+
+---
+
+## 10. Open questions (for the plan)
+
+- Pending-nudge wire format and exact bridge path under `~/.mur/companion/` — align with how `companion_bridge/scanner.rs` already discovers files.
+- Whether the daemon or the `mur-out` process is the one that writes pending nudges (depends on which runs at session end in the current recording lifecycle) — confirm during planning.
+- Bubble copy / action labels (microcopy) — pick during planning; default to "Save it / Not now / No thanks".

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -52,6 +52,10 @@ pub struct Config {
     // --- M7a additions ---
     #[serde(default)]
     pub cross_agent: CrossAgentConfig,
+
+    // --- nudge additions ---
+    #[serde(default)]
+    pub nudge: NudgeConfig,
 }
 
 impl Config {
@@ -1074,6 +1078,21 @@ mod tests {
     use super::*;
 
     #[test]
+    fn nudge_config_defaults() {
+        let c = NudgeConfig::default();
+        assert!(!c.enabled);
+        assert_eq!(c.daily_cap, 3);
+        assert_eq!(c.snooze_days, 7);
+        assert_eq!(c.threshold, 3);
+    }
+
+    #[test]
+    fn config_has_nudge_section_with_defaults() {
+        let c: Config = serde_yaml_ng::from_str("{}").unwrap();
+        assert_eq!(c.nudge.daily_cap, 3);
+    }
+
+    #[test]
     fn storage_config_default_is_lancedb() {
         let c = StorageConfig::default();
         assert_eq!(c.vector_backend, "lancedb");
@@ -1326,6 +1345,42 @@ impl Default for SleepCycleConfig {
             enabled: false,
             idle_threshold_minutes: default_idle_threshold_minutes(),
             agent_idle_minutes: default_agent_idle_minutes(),
+        }
+    }
+}
+
+// ── Nudge config ───────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NudgeConfig {
+    /// Master switch. Default off; Phase 2 (companion surface) flips the default.
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_nudge_daily_cap")]
+    pub daily_cap: u32,
+    #[serde(default = "default_nudge_snooze_days")]
+    pub snooze_days: u32,
+    #[serde(default = "default_nudge_threshold")]
+    pub threshold: usize,
+}
+
+fn default_nudge_daily_cap() -> u32 {
+    3
+}
+fn default_nudge_snooze_days() -> u32 {
+    7
+}
+fn default_nudge_threshold() -> usize {
+    3
+}
+
+impl Default for NudgeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            daily_cap: default_nudge_daily_cap(),
+            snooze_days: default_nudge_snooze_days(),
+            threshold: default_nudge_threshold(),
         }
     }
 }

--- a/mur-core/src/cli/mod.rs
+++ b/mur-core/src/cli/mod.rs
@@ -203,11 +203,17 @@ pub enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
-    /// Show workflow composition & decomposition suggestions
+    /// Show workflow composition & decomposition suggestions and pending nudges.
     Suggest {
         /// Auto-create suggested workflows/patterns as drafts
         #[arg(long)]
         create: bool,
+        /// Accept a pending nudge by id -> create its draft workflow
+        #[arg(long, value_name = "ID")]
+        accept: Option<String>,
+        /// Dismiss a pending nudge by id (never re-surfaces)
+        #[arg(long, value_name = "ID")]
+        dismiss: Option<String>,
     },
     /// Terminal dashboard
     Dashboard,

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -71,7 +71,7 @@ pub(crate) mod update;
 #[allow(dead_code)]
 pub(crate) mod var;
 pub(crate) mod verify;
-pub(crate) mod workflow;
+pub mod workflow;
 
 #[cfg(feature = "sources")]
 pub(crate) mod source_cmd;

--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -142,6 +142,20 @@ pub(crate) async fn cmd_session_stop(analyze: bool, reflect: bool) -> Result<()>
                             candidates.len(),
                         );
                     }
+
+                    // Nudge hook: filter through ledger and surface actionable nudges.
+                    let nudge_candidates: Vec<_> = candidates
+                        .iter()
+                        .map(crate::nudge::WorkflowCandidate::from_emergent)
+                        .collect();
+                    if let Ok(surfaced) = record_nudges_for_candidates(&nudge_candidates)
+                        && !surfaced.is_empty()
+                    {
+                        eprintln!(
+                            "💡 Noticed {} repeated workflow(s). Review with `mur suggest`.",
+                            surfaced.len()
+                        );
+                    }
                 }
             }
 
@@ -1367,4 +1381,23 @@ pub(crate) async fn cmd_session_reflect(dry_run: bool) -> anyhow::Result<()> {
     };
     run_reflect_curate(&entry.path(), dry_run)?;
     Ok(())
+}
+
+/// Filter candidates through the nudge ledger and mark the actionable ones
+/// Surfaced. Returns the ids that were surfaced (for the CLI hint).
+pub(crate) fn record_nudges_for_candidates(
+    candidates: &[crate::nudge::WorkflowCandidate],
+) -> anyhow::Result<Vec<String>> {
+    let config_path = crate::store::yaml::default_mur_dir().join("config.yaml");
+    let cfg = mur_common::config::Config::load_or_default(&config_path);
+    if !cfg.nudge.enabled || candidates.is_empty() {
+        return Ok(vec![]);
+    }
+    let path = crate::nudge::NudgeLedger::default_path();
+    let mut ledger = crate::nudge::NudgeLedger::load(&path)?;
+    let now = chrono::Utc::now();
+    let actionable = ledger.filter_actionable(candidates, now, cfg.nudge.daily_cap);
+    crate::nudge::NudgeEmitter::emit_pending(&mut ledger, &actionable, now);
+    ledger.save(&path)?;
+    Ok(actionable.into_iter().map(|c| c.id).collect())
 }

--- a/mur-core/src/cmd/workflow.rs
+++ b/mur-core/src/cmd/workflow.rs
@@ -665,34 +665,17 @@ pub(crate) fn cmd_suggest(create: bool) -> Result<()> {
                         s.suggested_name
                     );
                 } else {
-                    // Create a draft workflow from the suggestion
-                    let wf = mur_common::workflow::Workflow {
-                        base: KnowledgeBase {
-                            name: s.suggested_name.clone(),
-                            description: format!(
-                                "Auto-suggested workflow from {} co-occurring patterns",
-                                s.patterns.len()
-                            ),
-                            content: Content::Plain(format!(
-                                "Combines patterns: {}",
-                                s.patterns.join(", ")
-                            )),
-                            tags: collect_tags_from_patterns(&s.patterns, &patterns),
-                            ..Default::default()
-                        },
-                        steps: vec![],
-                        variables: vec![],
-                        source_sessions: vec![],
-                        trigger: s.suggested_trigger.clone(),
-                        tools: vec![],
-                        published_version: 0,
-                        permission: Default::default(),
-                        schedule: None,
-                        id: None,
-                        notify: None,
-                        requires: vec![],
-                    };
-                    workflow_store.save(&wf)?;
+                    let description = format!(
+                        "Auto-suggested workflow from {} co-occurring patterns",
+                        s.patterns.len()
+                    );
+                    create_draft_workflow_in(
+                        &workflow_store,
+                        &s.suggested_name,
+                        &description,
+                        &s.suggested_trigger,
+                        &[],
+                    )?;
                     println!("     -> Created draft workflow: {}", s.suggested_name);
 
                     // Add cross-reference: link each source pattern to this workflow
@@ -1000,4 +983,75 @@ pub(crate) fn cmd_schedule_enable(name: &str, enable: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Build and save a draft Workflow. Shared by `mur suggest --create` and nudge-accept.
+pub(crate) fn create_draft_workflow_in(
+    store: &crate::store::workflow_yaml::WorkflowYamlStore,
+    name: &str,
+    description: &str,
+    trigger: &str,
+    source_sessions: &[String],
+) -> anyhow::Result<()> {
+    if store.exists(name) {
+        return Ok(()); // idempotent: don't clobber an existing workflow
+    }
+    let base = KnowledgeBase {
+        name: name.to_string(),
+        description: description.to_string(),
+        content: Content::Plain(trigger.to_string()),
+        maturity: mur_common::knowledge::Maturity::Draft,
+        ..Default::default()
+    };
+    let wf = mur_common::workflow::Workflow {
+        base,
+        steps: vec![],
+        variables: vec![],
+        source_sessions: source_sessions.to_vec(),
+        trigger: trigger.to_string(),
+        tools: vec![],
+        published_version: 0,
+        permission: Default::default(),
+        schedule: None,
+        id: None,
+        notify: None,
+        requires: vec![],
+    };
+    store.save(&wf)
+}
+
+/// Convenience over the default store.
+pub(crate) fn create_draft_workflow(
+    name: &str,
+    description: &str,
+    trigger: &str,
+    source_sessions: &[String],
+) -> anyhow::Result<()> {
+    let store = crate::store::workflow_yaml::WorkflowYamlStore::default_store()?;
+    create_draft_workflow_in(&store, name, description, trigger, source_sessions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_draft_workflow_persists_draft() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store =
+            crate::store::workflow_yaml::WorkflowYamlStore::new(tmp.path().join("workflows"))
+                .unwrap();
+        create_draft_workflow_in(
+            &store,
+            "test-then-commit",
+            "Run tests then commit",
+            "after editing code",
+            &["s1".into(), "s2".into()],
+        )
+        .unwrap();
+        assert!(store.exists("test-then-commit"));
+        let wf = store.get("test-then-commit").unwrap();
+        assert_eq!(wf.base.maturity, mur_common::knowledge::Maturity::Draft);
+        assert_eq!(wf.trigger, "after editing code");
+    }
 }

--- a/mur-core/src/cmd/workflow.rs
+++ b/mur-core/src/cmd/workflow.rs
@@ -622,7 +622,15 @@ pub(crate) fn cmd_workflow_install(name: &str, team: &str) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn cmd_suggest(create: bool) -> Result<()> {
+pub(crate) fn cmd_suggest(create: bool, accept: Option<&str>, dismiss: Option<&str>) -> Result<()> {
+    // ─── Nudge accept/dismiss (early exit) ────────────────────────────
+    if let Some(id) = accept {
+        return cmd_suggest_accept(id);
+    }
+    if let Some(id) = dismiss {
+        return cmd_suggest_dismiss(id);
+    }
+
     use evolve::compose::suggest_workflows_with_patterns;
     use evolve::cooccurrence::CooccurrenceMatrix;
     use evolve::decompose::{analyze_workflow_for_extraction, extract_pattern_from_step};
@@ -735,12 +743,97 @@ pub(crate) fn cmd_suggest(create: bool) -> Result<()> {
         }
     }
 
+    // ─── Part 3: Pending nudges ───────────────────────────────────────
+
+    let nudge_path = crate::nudge::NudgeLedger::default_path();
+    if let Ok(ledger) = crate::nudge::NudgeLedger::load(&nudge_path) {
+        let now = chrono::Utc::now();
+        let mut pending: Vec<(&String, &crate::nudge::NudgeRecord, &str)> = Vec::new();
+        for (id, rec) in &ledger.records {
+            let status = match &rec.state {
+                crate::nudge::NudgeState::Surfaced => "surfaced",
+                crate::nudge::NudgeState::Snoozed { until } => {
+                    let expired = chrono::DateTime::parse_from_rfc3339(until)
+                        .map(|u| now >= u.with_timezone(&chrono::Utc))
+                        .unwrap_or(true);
+                    if expired {
+                        "snoozed-expired"
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            };
+            pending.push((id, rec, status));
+        }
+
+        if !pending.is_empty() {
+            println!("── Pending Workflow Nudges ──\n");
+            for (id, rec, status) in &pending {
+                let short_id = if id.len() > 8 { &id[..8] } else { id };
+                let title = rec
+                    .candidate
+                    .as_ref()
+                    .map(|c| c.title.as_str())
+                    .unwrap_or("(unknown)");
+                let sessions = rec.candidate.as_ref().map(|c| c.session_count).unwrap_or(0);
+                println!(
+                    "  [{}] {} (seen in {} sessions) [{}]",
+                    short_id, title, sessions, status
+                );
+            }
+            println!();
+            println!("  Accept:  mur suggest --accept <id>");
+            println!("  Dismiss: mur suggest --dismiss <id>");
+            println!();
+        }
+    }
+
     // ─── Summary ─────────────────────────────────────────────────────
 
     if !create && (!suggestions.is_empty() || !workflows.is_empty()) {
         println!("Run `mur suggest --create` to auto-create suggested items as drafts.");
     }
 
+    Ok(())
+}
+
+pub(crate) fn cmd_suggest_accept(id: &str) -> Result<()> {
+    let config_path = crate::store::yaml::default_mur_dir().join("config.yaml");
+    let cfg = mur_common::config::Config::load_or_default(&config_path);
+    let path = crate::nudge::NudgeLedger::default_path();
+    let mut ledger = crate::nudge::NudgeLedger::load(&path)?;
+    crate::nudge::NudgeEmitter::apply_decision(
+        &mut ledger,
+        id,
+        crate::nudge::NudgeDecision::Accept,
+        cfg.nudge.snooze_days,
+        chrono::Utc::now(),
+        &|c| create_draft_workflow(&c.suggested_name, &c.title, "", &c.evidence_session_ids),
+    )?;
+    ledger.save(&path)?;
+    println!(
+        "✓ Saved workflow draft from nudge {}. Run it with `mur run <name>`.",
+        id
+    );
+    Ok(())
+}
+
+pub(crate) fn cmd_suggest_dismiss(id: &str) -> Result<()> {
+    let config_path = crate::store::yaml::default_mur_dir().join("config.yaml");
+    let cfg = mur_common::config::Config::load_or_default(&config_path);
+    let path = crate::nudge::NudgeLedger::default_path();
+    let mut ledger = crate::nudge::NudgeLedger::load(&path)?;
+    crate::nudge::NudgeEmitter::apply_decision(
+        &mut ledger,
+        id,
+        crate::nudge::NudgeDecision::Dismiss,
+        cfg.nudge.snooze_days,
+        chrono::Utc::now(),
+        &|_| Ok(()),
+    )?;
+    ledger.save(&path)?;
+    println!("✓ Dismissed nudge {}.", id);
     Ok(())
 }
 
@@ -986,7 +1079,7 @@ pub(crate) fn cmd_schedule_enable(name: &str, enable: bool) -> Result<()> {
 }
 
 /// Build and save a draft Workflow. Shared by `mur suggest --create` and nudge-accept.
-pub(crate) fn create_draft_workflow_in(
+pub fn create_draft_workflow_in(
     store: &crate::store::workflow_yaml::WorkflowYamlStore,
     name: &str,
     description: &str,
@@ -1021,7 +1114,7 @@ pub(crate) fn create_draft_workflow_in(
 }
 
 /// Convenience over the default store.
-pub(crate) fn create_draft_workflow(
+pub fn create_draft_workflow(
     name: &str,
     description: &str,
     trigger: &str,

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -187,7 +187,11 @@ pub async fn run(cli: Cli) -> Result<()> {
             GepAction::Status => cmd::community_cmd::cmd_gep_status()?,
         },
         Commands::Emerge { threshold, dry_run } => cmd::learn::cmd_emerge(threshold, dry_run)?,
-        Commands::Suggest { create } => cmd::workflow::cmd_suggest(create)?,
+        Commands::Suggest {
+            create,
+            accept,
+            dismiss,
+        } => cmd::workflow::cmd_suggest(create, accept.as_deref(), dismiss.as_deref())?,
         Commands::Context {
             quiet,
             compact,

--- a/mur-core/src/lib.rs
+++ b/mur-core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod federation;
 pub mod gep;
 pub mod inject;
 pub mod interactive;
+pub mod nudge;
 pub mod paths;
 pub mod retrieve;
 pub mod session;

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -33,6 +33,8 @@ mod federation;
 mod gep;
 mod inject;
 mod interactive;
+#[allow(dead_code, unused_imports)]
+mod nudge;
 mod paths;
 mod retrieve;
 mod server;

--- a/mur-core/src/nudge/candidate.rs
+++ b/mur-core/src/nudge/candidate.rs
@@ -1,0 +1,98 @@
+use crate::capture::emergence::{detect_emergent, EmergentCandidate};
+use mur_common::event::BehaviorFingerprint;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowCandidate {
+    pub id: String,
+    pub title: String,
+    pub suggested_name: String,
+    pub steps_preview: Vec<String>,
+    pub session_count: usize,
+    pub evidence_session_ids: Vec<String>,
+}
+
+impl WorkflowCandidate {
+    pub fn from_emergent(e: &EmergentCandidate) -> Self {
+        let mut kw = e.keywords.clone();
+        kw.sort();
+        let mut h = Sha256::new();
+        h.update(e.behavior.as_bytes());
+        h.update([0]);
+        h.update(kw.join(",").as_bytes());
+        let id = format!("{:x}", h.finalize());
+        Self {
+            id,
+            title: e.behavior.clone(),
+            suggested_name: e.suggested_name.clone(),
+            steps_preview: e.evidence.clone(),
+            session_count: e.session_count,
+            evidence_session_ids: e.session_ids.clone(),
+        }
+    }
+}
+
+/// A source of workflow candidates. v1 has one impl (emergence); co-occurrence
+/// is added post-migration without changing consumers.
+pub trait CandidateSource {
+    fn candidates(&self, threshold: usize) -> anyhow::Result<Vec<WorkflowCandidate>>;
+}
+
+pub struct EmergenceSource {
+    fingerprints: Vec<BehaviorFingerprint>,
+}
+
+impl EmergenceSource {
+    pub fn from_fingerprints(fingerprints: Vec<BehaviorFingerprint>) -> Self {
+        Self { fingerprints }
+    }
+    /// Load all persisted fingerprints (~/.mur/fingerprints.jsonl).
+    pub fn from_disk() -> anyhow::Result<Self> {
+        Ok(Self {
+            fingerprints: crate::capture::emergence::load_fingerprints()?,
+        })
+    }
+}
+
+impl CandidateSource for EmergenceSource {
+    fn candidates(&self, threshold: usize) -> anyhow::Result<Vec<WorkflowCandidate>> {
+        Ok(detect_emergent(&self.fingerprints, threshold)
+            .iter()
+            .map(WorkflowCandidate::from_emergent)
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capture::emergence::EmergentCandidate;
+
+    fn ec(behavior: &str, kw: &[&str]) -> EmergentCandidate {
+        EmergentCandidate {
+            behavior: behavior.into(),
+            keywords: kw.iter().map(|s| s.to_string()).collect(),
+            session_count: 3,
+            session_ids: vec!["s1".into(), "s2".into(), "s3".into()],
+            evidence: vec!["ran tests".into(), "committed".into()],
+            suggested_name: "test-then-commit".into(),
+            suggested_content: "\u{2026}".into(),
+        }
+    }
+
+    #[test]
+    fn id_is_stable_and_order_independent() {
+        let a = WorkflowCandidate::from_emergent(&ec("b", &["test", "commit"]));
+        let b = WorkflowCandidate::from_emergent(&ec("b", &["commit", "test"]));
+        assert_eq!(a.id, b.id); // keyword order must not change the id
+        assert_eq!(a.session_count, 3);
+        assert_eq!(a.suggested_name, "test-then-commit");
+    }
+
+    #[test]
+    fn emergence_source_maps_candidates() {
+        let src = EmergenceSource::from_fingerprints(vec![]); // empty -> no candidates
+        assert!(src.candidates(3).unwrap().is_empty());
+    }
+}

--- a/mur-core/src/nudge/candidate.rs
+++ b/mur-core/src/nudge/candidate.rs
@@ -1,4 +1,4 @@
-use crate::capture::emergence::{detect_emergent, EmergentCandidate};
+use crate::capture::emergence::{EmergentCandidate, detect_emergent};
 use mur_common::event::BehaviorFingerprint;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/mur-core/src/nudge/emitter.rs
+++ b/mur-core/src/nudge/emitter.rs
@@ -1,0 +1,1 @@
+// Stub — implemented in Task 5.

--- a/mur-core/src/nudge/emitter.rs
+++ b/mur-core/src/nudge/emitter.rs
@@ -1,6 +1,6 @@
 use crate::nudge::candidate::WorkflowCandidate;
 use crate::nudge::ledger::{NudgeLedger, NudgeState};
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use chrono::{DateTime, Duration, Utc};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -83,14 +83,9 @@ mod tests {
     fn dismiss_decision_updates_ledger() {
         let mut l = NudgeLedger::default();
         NudgeEmitter::emit_pending(&mut l, &[cand("a")], Utc::now());
-        NudgeEmitter::apply_decision(
-            &mut l,
-            "a",
-            NudgeDecision::Dismiss,
-            7,
-            Utc::now(),
-            &|_c| Ok(()),
-        )
+        NudgeEmitter::apply_decision(&mut l, "a", NudgeDecision::Dismiss, 7, Utc::now(), &|_c| {
+            Ok(())
+        })
         .unwrap();
         assert!(matches!(l.get("a").unwrap().state, NudgeState::Dismissed));
     }
@@ -100,18 +95,11 @@ mod tests {
         let mut l = NudgeLedger::default();
         NudgeEmitter::emit_pending(&mut l, &[cand("a")], Utc::now());
         let created = std::cell::Cell::new(false);
-        NudgeEmitter::apply_decision(
-            &mut l,
-            "a",
-            NudgeDecision::Accept,
-            7,
-            Utc::now(),
-            &|c| {
-                assert_eq!(c.suggested_name, "test-then-commit");
-                created.set(true);
-                Ok(())
-            },
-        )
+        NudgeEmitter::apply_decision(&mut l, "a", NudgeDecision::Accept, 7, Utc::now(), &|c| {
+            assert_eq!(c.suggested_name, "test-then-commit");
+            created.set(true);
+            Ok(())
+        })
         .unwrap();
         assert!(created.get());
         assert!(matches!(l.get("a").unwrap().state, NudgeState::Accepted));

--- a/mur-core/src/nudge/emitter.rs
+++ b/mur-core/src/nudge/emitter.rs
@@ -1,1 +1,119 @@
-// Stub — implemented in Task 5.
+use crate::nudge::candidate::WorkflowCandidate;
+use crate::nudge::ledger::{NudgeLedger, NudgeState};
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Duration, Utc};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NudgeDecision {
+    Accept,
+    Dismiss,
+    Snooze,
+}
+
+pub struct NudgeEmitter;
+
+impl NudgeEmitter {
+    /// Mark each actionable candidate Surfaced (records its snapshot).
+    pub fn emit_pending(
+        ledger: &mut NudgeLedger,
+        actionable: &[WorkflowCandidate],
+        now: DateTime<Utc>,
+    ) {
+        for c in actionable {
+            ledger.mark_surfaced(c, now);
+        }
+    }
+
+    /// Apply a user decision. `create` is called with the candidate on Accept
+    /// (injected so the emitter stays free of workflow-store deps for testing).
+    pub fn apply_decision(
+        ledger: &mut NudgeLedger,
+        id: &str,
+        decision: NudgeDecision,
+        snooze_days: u32,
+        now: DateTime<Utc>,
+        create: &dyn Fn(&WorkflowCandidate) -> Result<()>,
+    ) -> Result<()> {
+        match decision {
+            NudgeDecision::Accept => {
+                let cand = ledger
+                    .get(id)
+                    .and_then(|r| r.candidate.clone())
+                    .ok_or_else(|| anyhow!("no pending nudge with id {id}"))?;
+                create(&cand)?;
+                ledger.set_state(id, NudgeState::Accepted, now);
+            }
+            NudgeDecision::Dismiss => ledger.set_state(id, NudgeState::Dismissed, now),
+            NudgeDecision::Snooze => {
+                let until = (now + Duration::days(snooze_days as i64)).to_rfc3339();
+                ledger.set_state(id, NudgeState::Snoozed { until }, now);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nudge::candidate::WorkflowCandidate;
+    use crate::nudge::ledger::{NudgeLedger, NudgeState};
+    use chrono::Utc;
+
+    fn cand(id: &str) -> WorkflowCandidate {
+        WorkflowCandidate {
+            id: id.into(),
+            title: "Run tests then commit".into(),
+            suggested_name: "test-then-commit".into(),
+            steps_preview: vec![],
+            session_count: 3,
+            evidence_session_ids: vec!["s1".into()],
+        }
+    }
+
+    #[test]
+    fn emit_marks_surfaced() {
+        let mut l = NudgeLedger::default();
+        NudgeEmitter::emit_pending(&mut l, &[cand("a")], Utc::now());
+        assert!(matches!(l.get("a").unwrap().state, NudgeState::Surfaced));
+        assert_eq!(l.get("a").unwrap().surface_count, 1);
+    }
+
+    #[test]
+    fn dismiss_decision_updates_ledger() {
+        let mut l = NudgeLedger::default();
+        NudgeEmitter::emit_pending(&mut l, &[cand("a")], Utc::now());
+        NudgeEmitter::apply_decision(
+            &mut l,
+            "a",
+            NudgeDecision::Dismiss,
+            7,
+            Utc::now(),
+            &|_c| Ok(()),
+        )
+        .unwrap();
+        assert!(matches!(l.get("a").unwrap().state, NudgeState::Dismissed));
+    }
+
+    #[test]
+    fn accept_decision_calls_creator_and_marks_accepted() {
+        let mut l = NudgeLedger::default();
+        NudgeEmitter::emit_pending(&mut l, &[cand("a")], Utc::now());
+        let created = std::cell::Cell::new(false);
+        NudgeEmitter::apply_decision(
+            &mut l,
+            "a",
+            NudgeDecision::Accept,
+            7,
+            Utc::now(),
+            &|c| {
+                assert_eq!(c.suggested_name, "test-then-commit");
+                created.set(true);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(created.get());
+        assert!(matches!(l.get("a").unwrap().state, NudgeState::Accepted));
+    }
+}

--- a/mur-core/src/nudge/ledger.rs
+++ b/mur-core/src/nudge/ledger.rs
@@ -1,0 +1,1 @@
+// Stub — implemented in Task 3.

--- a/mur-core/src/nudge/ledger.rs
+++ b/mur-core/src/nudge/ledger.rs
@@ -1,1 +1,170 @@
-// Stub — implemented in Task 3.
+use crate::nudge::candidate::WorkflowCandidate;
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum NudgeState {
+    Surfaced,
+    Accepted,
+    Dismissed,
+    Snoozed { until: String }, // RFC3339
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NudgeRecord {
+    pub state: NudgeState,
+    pub last_ts: String,
+    pub surface_count: u32,
+    /// Snapshot kept so accept can rebuild the draft without re-mining.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidate: Option<WorkflowCandidate>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NudgeLedger {
+    #[serde(default)]
+    records: BTreeMap<String, NudgeRecord>,
+}
+
+impl NudgeLedger {
+    pub fn default_path() -> PathBuf {
+        crate::store::yaml::default_mur_dir().join("nudges.json")
+    }
+    pub fn load(path: &Path) -> Result<Self> {
+        match std::fs::read_to_string(path) {
+            Ok(s) => Ok(serde_json::from_str(&s).unwrap_or_default()),
+            Err(_) => Ok(Self::default()),
+        }
+    }
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, serde_json::to_string_pretty(self)?)?;
+        std::fs::rename(&tmp, path)?;
+        Ok(())
+    }
+    pub fn get(&self, id: &str) -> Option<&NudgeRecord> {
+        self.records.get(id)
+    }
+    pub fn set_state(&mut self, id: &str, state: NudgeState, now: DateTime<Utc>) {
+        let rec = self
+            .records
+            .entry(id.to_string())
+            .or_insert(NudgeRecord {
+                state: NudgeState::Surfaced,
+                last_ts: now.to_rfc3339(),
+                surface_count: 0,
+                candidate: None,
+            });
+        rec.state = state;
+        rec.last_ts = now.to_rfc3339();
+    }
+    /// Mark a candidate Surfaced (storing its snapshot) and bump surface_count.
+    pub fn mark_surfaced(&mut self, c: &WorkflowCandidate, now: DateTime<Utc>) {
+        let rec = self
+            .records
+            .entry(c.id.clone())
+            .or_insert(NudgeRecord {
+                state: NudgeState::Surfaced,
+                last_ts: now.to_rfc3339(),
+                surface_count: 0,
+                candidate: None,
+            });
+        rec.state = NudgeState::Surfaced;
+        rec.last_ts = now.to_rfc3339();
+        rec.surface_count += 1;
+        rec.candidate = Some(c.clone());
+    }
+
+    /// Candidates eligible to surface: not accepted/dismissed, not currently
+    /// snoozed, capped at `daily_cap` newly-actionable items.
+    pub fn filter_actionable(
+        &self,
+        candidates: &[WorkflowCandidate],
+        now: DateTime<Utc>,
+        daily_cap: u32,
+    ) -> Vec<WorkflowCandidate> {
+        let mut out = Vec::new();
+        for c in candidates {
+            match self.records.get(&c.id).map(|r| &r.state) {
+                Some(NudgeState::Accepted) | Some(NudgeState::Dismissed) => continue,
+                Some(NudgeState::Snoozed { until }) => {
+                    let expired = DateTime::parse_from_rfc3339(until)
+                        .map(|u| now >= u.with_timezone(&Utc))
+                        .unwrap_or(true);
+                    if !expired {
+                        continue;
+                    }
+                }
+                _ => {}
+            }
+            out.push(c.clone());
+            if out.len() as u32 >= daily_cap {
+                break;
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nudge::candidate::WorkflowCandidate;
+    use chrono::{Duration, Utc};
+
+    fn cand(id: &str) -> WorkflowCandidate {
+        WorkflowCandidate {
+            id: id.into(),
+            title: "t".into(),
+            suggested_name: "n".into(),
+            steps_preview: vec![],
+            session_count: 3,
+            evidence_session_ids: vec![],
+        }
+    }
+
+    #[test]
+    fn dismissed_never_resurfaces() {
+        let mut l = NudgeLedger::default();
+        l.set_state("a", NudgeState::Dismissed, Utc::now());
+        let actionable = l.filter_actionable(&[cand("a"), cand("b")], Utc::now(), 10);
+        let ids: Vec<_> = actionable.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(ids, vec!["b"]); // "a" dismissed -> excluded
+    }
+
+    #[test]
+    fn snooze_hides_until_expiry() {
+        let mut l = NudgeLedger::default();
+        let now = Utc::now();
+        l.set_state(
+            "a",
+            NudgeState::Snoozed {
+                until: (now + Duration::days(3)).to_rfc3339(),
+            },
+            now,
+        );
+        assert!(l
+            .filter_actionable(&[cand("a")], now, 10)
+            .is_empty());
+        let later = now + Duration::days(4);
+        assert_eq!(
+            l.filter_actionable(&[cand("a")], later, 10).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn daily_cap_limits_new_surfaces() {
+        let l = NudgeLedger::default();
+        let now = Utc::now();
+        let out = l.filter_actionable(&[cand("a"), cand("b"), cand("c")], now, 2);
+        assert_eq!(out.len(), 2); // cap = 2
+    }
+}

--- a/mur-core/src/nudge/ledger.rs
+++ b/mur-core/src/nudge/ledger.rs
@@ -27,7 +27,7 @@ pub struct NudgeRecord {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct NudgeLedger {
     #[serde(default)]
-    records: BTreeMap<String, NudgeRecord>,
+    pub records: BTreeMap<String, NudgeRecord>,
 }
 
 impl NudgeLedger {
@@ -53,29 +53,23 @@ impl NudgeLedger {
         self.records.get(id)
     }
     pub fn set_state(&mut self, id: &str, state: NudgeState, now: DateTime<Utc>) {
-        let rec = self
-            .records
-            .entry(id.to_string())
-            .or_insert(NudgeRecord {
-                state: NudgeState::Surfaced,
-                last_ts: now.to_rfc3339(),
-                surface_count: 0,
-                candidate: None,
-            });
+        let rec = self.records.entry(id.to_string()).or_insert(NudgeRecord {
+            state: NudgeState::Surfaced,
+            last_ts: now.to_rfc3339(),
+            surface_count: 0,
+            candidate: None,
+        });
         rec.state = state;
         rec.last_ts = now.to_rfc3339();
     }
     /// Mark a candidate Surfaced (storing its snapshot) and bump surface_count.
     pub fn mark_surfaced(&mut self, c: &WorkflowCandidate, now: DateTime<Utc>) {
-        let rec = self
-            .records
-            .entry(c.id.clone())
-            .or_insert(NudgeRecord {
-                state: NudgeState::Surfaced,
-                last_ts: now.to_rfc3339(),
-                surface_count: 0,
-                candidate: None,
-            });
+        let rec = self.records.entry(c.id.clone()).or_insert(NudgeRecord {
+            state: NudgeState::Surfaced,
+            last_ts: now.to_rfc3339(),
+            surface_count: 0,
+            candidate: None,
+        });
         rec.state = NudgeState::Surfaced;
         rec.last_ts = now.to_rfc3339();
         rec.surface_count += 1;
@@ -150,14 +144,9 @@ mod tests {
             },
             now,
         );
-        assert!(l
-            .filter_actionable(&[cand("a")], now, 10)
-            .is_empty());
+        assert!(l.filter_actionable(&[cand("a")], now, 10).is_empty());
         let later = now + Duration::days(4);
-        assert_eq!(
-            l.filter_actionable(&[cand("a")], later, 10).len(),
-            1
-        );
+        assert_eq!(l.filter_actionable(&[cand("a")], later, 10).len(), 1);
     }
 
     #[test]

--- a/mur-core/src/nudge/mod.rs
+++ b/mur-core/src/nudge/mod.rs
@@ -1,0 +1,7 @@
+//! Workflow nudge engine: turn emergence-mined recurring behavior into
+//! actionable "save this as a workflow?" prompts (surface-agnostic).
+pub mod candidate;
+pub mod ledger;
+pub mod emitter;
+
+pub use candidate::{CandidateSource, EmergenceSource, WorkflowCandidate};

--- a/mur-core/src/nudge/mod.rs
+++ b/mur-core/src/nudge/mod.rs
@@ -1,9 +1,12 @@
 //! Workflow nudge engine: turn emergence-mined recurring behavior into
 //! actionable "save this as a workflow?" prompts (surface-agnostic).
 pub mod candidate;
-pub mod ledger;
 pub mod emitter;
+pub mod ledger;
 
+#[allow(unused_imports)]
 pub use candidate::{CandidateSource, EmergenceSource, WorkflowCandidate};
+#[allow(unused_imports)]
 pub use emitter::{NudgeDecision, NudgeEmitter};
+#[allow(unused_imports)]
 pub use ledger::{NudgeLedger, NudgeRecord, NudgeState};

--- a/mur-core/src/nudge/mod.rs
+++ b/mur-core/src/nudge/mod.rs
@@ -5,3 +5,5 @@ pub mod ledger;
 pub mod emitter;
 
 pub use candidate::{CandidateSource, EmergenceSource, WorkflowCandidate};
+pub use emitter::{NudgeDecision, NudgeEmitter};
+pub use ledger::{NudgeLedger, NudgeRecord, NudgeState};

--- a/mur-core/tests/cli_nudge.rs
+++ b/mur-core/tests/cli_nudge.rs
@@ -1,0 +1,144 @@
+//! Integration tests for the nudge workflow: accept/dismiss + end-to-end.
+
+use mur_core::nudge::{NudgeDecision, NudgeEmitter, NudgeLedger, NudgeState, WorkflowCandidate};
+
+fn cand(id: &str, suggested_name: &str) -> WorkflowCandidate {
+    WorkflowCandidate {
+        id: id.into(),
+        title: format!("Test behavior {}", id),
+        suggested_name: suggested_name.into(),
+        steps_preview: vec![],
+        session_count: 3,
+        evidence_session_ids: vec!["s1".into()],
+    }
+}
+
+#[test]
+fn accept_creates_draft_and_marks_ledger() {
+    let home = tempfile::tempdir().unwrap();
+    let nudge_path = home.path().join("nudges.json");
+
+    // Seed a ledger with one surfaced candidate
+    let mut ledger = NudgeLedger::default();
+    NudgeEmitter::emit_pending(
+        &mut ledger,
+        &[cand("abc", "test-then-commit")],
+        chrono::Utc::now(),
+    );
+    ledger.save(&nudge_path).unwrap();
+
+    // Accept via the emitter with a creator that writes to temp store
+    let wf_dir = home.path().join("workflows");
+    let wf_store = mur_core::store::workflow_yaml::WorkflowYamlStore::new(wf_dir.clone()).unwrap();
+    let mut ledger = NudgeLedger::load(&nudge_path).unwrap();
+    NudgeEmitter::apply_decision(
+        &mut ledger,
+        "abc",
+        NudgeDecision::Accept,
+        7,
+        chrono::Utc::now(),
+        &|c| {
+            mur_core::cmd::workflow::create_draft_workflow_in(
+                &wf_store,
+                &c.suggested_name,
+                &c.title,
+                "",
+                &c.evidence_session_ids,
+            )
+        },
+    )
+    .unwrap();
+    ledger.save(&nudge_path).unwrap();
+
+    // Verify ledger state
+    assert!(matches!(
+        ledger.get("abc").unwrap().state,
+        NudgeState::Accepted
+    ));
+
+    // Verify draft workflow created
+    assert!(wf_store.exists("test-then-commit"));
+}
+
+#[test]
+fn dismiss_marks_ledger_and_never_resurfaces() {
+    let home = tempfile::tempdir().unwrap();
+    let nudge_path = home.path().join("nudges.json");
+
+    let mut ledger = NudgeLedger::default();
+    NudgeEmitter::emit_pending(&mut ledger, &[cand("abc", "wf-name")], chrono::Utc::now());
+    ledger.save(&nudge_path).unwrap();
+
+    let mut ledger = NudgeLedger::load(&nudge_path).unwrap();
+    NudgeEmitter::apply_decision(
+        &mut ledger,
+        "abc",
+        NudgeDecision::Dismiss,
+        7,
+        chrono::Utc::now(),
+        &|_| Ok(()),
+    )
+    .unwrap();
+    ledger.save(&nudge_path).unwrap();
+
+    assert!(matches!(
+        ledger.get("abc").unwrap().state,
+        NudgeState::Dismissed
+    ));
+
+    // Dismissed candidate is not actionable
+    let actionable = ledger.filter_actionable(&[cand("abc", "wf-name")], chrono::Utc::now(), 10);
+    assert!(actionable.is_empty());
+}
+
+#[test]
+fn end_to_end_detect_accept_no_resurface() {
+    let home = tempfile::tempdir().unwrap();
+    let nudge_path = home.path().join("nudges.json");
+
+    // 1. Emit a pending nudge for candidate "abc"
+    let mut ledger = NudgeLedger::default();
+    NudgeEmitter::emit_pending(
+        &mut ledger,
+        &[cand("abc", "my-workflow")],
+        chrono::Utc::now(),
+    );
+    ledger.save(&nudge_path).unwrap();
+
+    // 2. Accept it
+    let wf_dir = home.path().join("workflows");
+    let wf_store = mur_core::store::workflow_yaml::WorkflowYamlStore::new(wf_dir.clone()).unwrap();
+    let mut ledger = NudgeLedger::load(&nudge_path).unwrap();
+    NudgeEmitter::apply_decision(
+        &mut ledger,
+        "abc",
+        NudgeDecision::Accept,
+        7,
+        chrono::Utc::now(),
+        &|c| {
+            mur_core::cmd::workflow::create_draft_workflow_in(
+                &wf_store,
+                &c.suggested_name,
+                &c.title,
+                "",
+                &c.evidence_session_ids,
+            )
+        },
+    )
+    .unwrap();
+    ledger.save(&nudge_path).unwrap();
+
+    // 3. Verify Accepted state
+    assert!(matches!(
+        ledger.get("abc").unwrap().state,
+        NudgeState::Accepted
+    ));
+
+    // 4. Accepted candidate is not actionable again
+    let actionable =
+        ledger.filter_actionable(&[cand("abc", "my-workflow")], chrono::Utc::now(), 10);
+    assert!(actionable.is_empty());
+
+    // 5. Draft workflow exists
+    assert!(wf_store.exists("my-workflow"));
+}


### PR DESCRIPTION
## Summary

- **`NudgeConfig`** (`mur-common`): `enabled`/`daily_cap`/`snooze_days`/`threshold` — gated off by default until Phase 2 companion surface ships.
- **`WorkflowCandidate` + `CandidateSource`** (`mur-core::nudge`): stable-id candidates from emergence mining, pluggable source trait (v1: `EmergenceSource` only).
- **`NudgeLedger`** (`~/.mur/nudges.json`): persistent anti-nag brain — dedup, snooze windows, daily cap, dismissed-never-resurfaces.
- **`NudgeEmitter`**: `emit_pending` (mark surfaced) + `apply_decision` (accept→create draft, dismiss, snooze).
- **Extracted `create_draft_workflow_in`** from `cmd_suggest` — DRY: reused by both `mur suggest --create` and nudge-accept.
- **`mur suggest --accept <id>` / `--dismiss <id>`** + pending-nudge listing in `mur suggest` output.
- **Session-end hook**: after `detect_emergent`, maps candidates → filters through ledger → emits pending (gated by `config.nudge.enabled`).

## Test plan

- [x] `cargo test -p mur-core --lib -- "nudge::"` — 8 unit tests (candidate id stability, ledger dedup/snooze/cap, emitter accept/dismiss/emit)
- [x] `cargo test -p mur-core --test cli_nudge` — 3 integration tests (accept creates draft, dismiss blocks resurface, e2e detect→accept→no-resurface)
- [x] `cargo test -p mur-common --lib -- "nudge"` — 2 config tests (defaults, empty-YAML parse)
- [x] `cargo clippy -p mur-core -p mur-common -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Phase 2 (companion speech-bubble surface: `Situation::WorkflowNudge`, outbox wiring, DND gate) is specced in `docs/superpowers/plans/2026-05-29-companion-workflow-nudge-phase2.md` — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)