### PR TITLE
feat(nudge): companion surface — proactive workflow-nudge speech bubbles

### DIFF
--- a/mur-agent-runtime/src/companion/situations.rs
+++ b/mur-agent-runtime/src/companion/situations.rs
@@ -7,14 +7,15 @@ use mur_common::companion::Situation;
 use rand::RngCore;
 use rand::distributions::{Distribution, WeightedIndex};
 
-/// Returns weights for `(morning_greeting, gentle_check_in, share_quote, share_link)`
-/// at the given hour. `None` means quiet hours (no situation eligible).
-fn weights_by_hour(hour: u32) -> Option<[f32; 4]> {
+/// Returns weights for `(morning_greeting, gentle_check_in, share_quote, share_link, workflow_nudge)`
+/// at the given hour. WorkflowNudge is never picked by the proactive rhythm (0.0 weight).
+/// `None` means quiet hours (no situation eligible).
+fn weights_by_hour(hour: u32) -> Option<[f32; 5]> {
     match hour {
-        6..=9 => Some([0.6, 0.0, 0.4, 0.0]),
-        10..=13 => Some([0.0, 0.4, 0.2, 0.4]),
-        14..=17 => Some([0.0, 0.5, 0.0, 0.5]),
-        18..=21 => Some([0.0, 0.0, 0.6, 0.4]),
+        6..=9 => Some([0.6, 0.0, 0.4, 0.0, 0.0]),
+        10..=13 => Some([0.0, 0.4, 0.2, 0.4, 0.0]),
+        14..=17 => Some([0.0, 0.5, 0.0, 0.5, 0.0]),
+        18..=21 => Some([0.0, 0.0, 0.6, 0.4, 0.0]),
         _ => None, // 22:00–06:00 → quiet
     }
 }
@@ -40,6 +41,7 @@ pub fn pick_for_hour<R: RngCore>(
         1 => Situation::GentleCheckIn,
         2 => Situation::ShareQuote,
         3 => Situation::ShareLink,
+        4 => Situation::WorkflowNudge,
         _ => unreachable!(),
     })
 }

--- a/mur-common/src/companion/mod.rs
+++ b/mur-common/src/companion/mod.rs
@@ -31,6 +31,22 @@ pub enum Situation {
     GentleCheckIn,
     ShareQuote,
     ShareLink,
+    WorkflowNudge,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workflow_nudge_situation_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&Situation::WorkflowNudge).unwrap(),
+            "\"workflow_nudge\""
+        );
+        let back: Situation = serde_json::from_str("\"workflow_nudge\"").unwrap();
+        assert_eq!(back, Situation::WorkflowNudge);
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -1080,7 +1080,7 @@ mod tests {
     #[test]
     fn nudge_config_defaults() {
         let c = NudgeConfig::default();
-        assert!(!c.enabled);
+        assert!(c.enabled);
         assert_eq!(c.daily_cap, 3);
         assert_eq!(c.snooze_days, 7);
         assert_eq!(c.threshold, 3);
@@ -1353,8 +1353,8 @@ impl Default for SleepCycleConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NudgeConfig {
-    /// Master switch. Default off; Phase 2 (companion surface) flips the default.
-    #[serde(default)]
+    /// Master switch. Default on — Phase 2 companion surface is live.
+    #[serde(default = "default_nudge_enabled")]
     pub enabled: bool,
     #[serde(default = "default_nudge_daily_cap")]
     pub daily_cap: u32,
@@ -1364,6 +1364,9 @@ pub struct NudgeConfig {
     pub threshold: usize,
 }
 
+fn default_nudge_enabled() -> bool {
+    true
+}
 fn default_nudge_daily_cap() -> u32 {
     3
 }
@@ -1377,7 +1380,7 @@ fn default_nudge_threshold() -> usize {
 impl Default for NudgeConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             daily_cap: default_nudge_daily_cap(),
             snooze_days: default_nudge_snooze_days(),
             threshold: default_nudge_threshold(),

--- a/mur-core/src/cmd/agent_companion/inbox.rs
+++ b/mur-core/src/cmd/agent_companion/inbox.rs
@@ -18,12 +18,14 @@ pub struct InboxArgs {
 pub struct AckArgs {
     pub name: String,
     pub msg_id: String,
-    #[arg(long, conflicts_with_all = ["bad", "dismiss"])]
+    #[arg(long, conflicts_with_all = ["bad", "dismiss", "snooze"])]
     pub good: bool,
-    #[arg(long, conflicts_with_all = ["good", "dismiss"])]
+    #[arg(long, conflicts_with_all = ["good", "dismiss", "snooze"])]
     pub bad: bool,
-    #[arg(long, conflicts_with_all = ["good", "bad"])]
+    #[arg(long, conflicts_with_all = ["good", "bad", "snooze"])]
     pub dismiss: bool,
+    #[arg(long, conflicts_with_all = ["good", "bad", "dismiss"])]
+    pub snooze: bool,
 }
 
 // ── Domain types ───────────────────────────────────────────────────────────
@@ -90,8 +92,10 @@ pub async fn run_ack(args: AckArgs) -> Result<()> {
         "bad"
     } else if args.dismiss {
         "dismiss"
+    } else if args.snooze {
+        "snooze"
     } else {
-        anyhow::bail!("one of --good, --bad, --dismiss is required");
+        anyhow::bail!("one of --good, --bad, --dismiss, --snooze is required");
     };
 
     let agent_home = super::util::agent_home_for(&args.name)?;
@@ -119,6 +123,7 @@ fn ack_at(agent_home: &Path, msg_id: &str, signal: &str) -> Result<()> {
         "good" => mur_common::companion::Signal::Positive,
         "bad" => mur_common::companion::Signal::Negative,
         "dismiss" => mur_common::companion::Signal::Dismiss,
+        "snooze" => mur_common::companion::Signal::Dismiss,
         _ => unreachable!(),
     };
     let event = mur_agent_runtime::companion::telemetry::OutboxEvent::UserSignal {

--- a/mur-core/src/cmd/agent_companion/preview.rs
+++ b/mur-core/src/cmd/agent_companion/preview.rs
@@ -354,8 +354,9 @@ fn parse_situation_slug(slug: &str) -> Result<Situation> {
         "gentle_check_in" => Ok(Situation::GentleCheckIn),
         "share_quote" => Ok(Situation::ShareQuote),
         "share_link" => Ok(Situation::ShareLink),
+        "workflow_nudge" => Ok(Situation::WorkflowNudge),
         other => anyhow::bail!(
-            "unknown situation `{other}`; valid values: morning_greeting, gentle_check_in, share_quote, share_link"
+            "unknown situation `{other}`; valid values: morning_greeting, gentle_check_in, share_quote, share_link, workflow_nudge"
         ),
     }
 }
@@ -366,6 +367,7 @@ fn situation_to_slug(s: &Situation) -> &'static str {
         Situation::GentleCheckIn => "gentle_check_in",
         Situation::ShareQuote => "share_quote",
         Situation::ShareLink => "share_link",
+        Situation::WorkflowNudge => "workflow_nudge",
     }
 }
 

--- a/mur-core/src/cmd/agent_companion/why.rs
+++ b/mur-core/src/cmd/agent_companion/why.rs
@@ -329,6 +329,7 @@ fn situation_to_slug(s: &mur_common::companion::Situation) -> &'static str {
         Situation::GentleCheckIn => "gentle_check_in",
         Situation::ShareQuote => "share_quote",
         Situation::ShareLink => "share_link",
+        Situation::WorkflowNudge => "workflow_nudge",
     }
 }
 

--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -155,6 +155,25 @@ pub(crate) async fn cmd_session_stop(analyze: bool, reflect: bool) -> Result<()>
                             "💡 Noticed {} repeated workflow(s). Review with `mur suggest`.",
                             surfaced.len()
                         );
+                        // Deliver to companion-enabled agents' inboxes.
+                        let ledger_path = crate::nudge::NudgeLedger::default_path();
+                        if let Ok(ledger) = crate::nudge::NudgeLedger::load(&ledger_path) {
+                            let surfaced_cands: Vec<_> = surfaced
+                                .iter()
+                                .filter_map(|id| {
+                                    ledger.get(id).and_then(|r| r.candidate.clone())
+                                })
+                                .collect();
+                            if let Ok(n) = crate::nudge::companion::deliver_nudges_to_companions(
+                                &crate::store::yaml::default_mur_dir(),
+                                &surfaced_cands,
+                                "en",
+                            ) {
+                                if n > 0 {
+                                    eprintln!("  📬 {n} nudge(s) sent to your companion (or run `mur suggest`).");
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -160,18 +160,17 @@ pub(crate) async fn cmd_session_stop(analyze: bool, reflect: bool) -> Result<()>
                         if let Ok(ledger) = crate::nudge::NudgeLedger::load(&ledger_path) {
                             let surfaced_cands: Vec<_> = surfaced
                                 .iter()
-                                .filter_map(|id| {
-                                    ledger.get(id).and_then(|r| r.candidate.clone())
-                                })
+                                .filter_map(|id| ledger.get(id).and_then(|r| r.candidate.clone()))
                                 .collect();
                             if let Ok(n) = crate::nudge::companion::deliver_nudges_to_companions(
                                 &crate::store::yaml::default_mur_dir(),
                                 &surfaced_cands,
                                 "en",
-                            ) {
-                                if n > 0 {
-                                    eprintln!("  📬 {n} nudge(s) sent to your companion (or run `mur suggest`).");
-                                }
+                            ) && n > 0
+                            {
+                                eprintln!(
+                                    "  📬 {n} nudge(s) sent to your companion (or run `mur suggest`)."
+                                );
                             }
                         }
                     }

--- a/mur-core/src/cmd/workflow.rs
+++ b/mur-core/src/cmd/workflow.rs
@@ -631,6 +631,12 @@ pub(crate) fn cmd_suggest(create: bool, accept: Option<&str>, dismiss: Option<&s
         return cmd_suggest_dismiss(id);
     }
 
+    // Drain companion nudge responses before listing pending.
+    let _ = crate::nudge::companion::drain_nudge_responses_in(
+        &crate::store::yaml::default_mur_dir(),
+        &|c| create_draft_workflow(&c.suggested_name, &c.title, "", &c.evidence_session_ids),
+    );
+
     use evolve::compose::suggest_workflows_with_patterns;
     use evolve::cooccurrence::CooccurrenceMatrix;
     use evolve::decompose::{analyze_workflow_for_extraction, extract_pattern_from_step};

--- a/mur-core/src/nudge/companion.rs
+++ b/mur-core/src/nudge/companion.rs
@@ -1,0 +1,54 @@
+use crate::nudge::candidate::WorkflowCandidate;
+
+/// Message id namespace so the response drain can recognize nudge replies.
+pub const NUDGE_ID_PREFIX: &str = "nudge:";
+
+pub fn nudge_msg_id(candidate_id: &str) -> String {
+    format!("{NUDGE_ID_PREFIX}{candidate_id}")
+}
+
+pub fn candidate_id_from_msg(msg_id: &str) -> Option<String> {
+    msg_id.strip_prefix(NUDGE_ID_PREFIX).map(|s| s.to_string())
+}
+
+/// Deterministic, locale-aware nudge body. English default for v1.
+pub fn nudge_body(c: &WorkflowCandidate, _locale: &str) -> String {
+    format!(
+        "I noticed you did this across {} sessions:\n\n  {}\n\nWant me to save it as a replayable workflow you can run with `mur run {}`?",
+        c.session_count, c.title, c.suggested_name
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nudge::candidate::WorkflowCandidate;
+
+    fn cand() -> WorkflowCandidate {
+        WorkflowCandidate {
+            id: "abc123".into(),
+            title: "Run tests, then commit, then push".into(),
+            suggested_name: "test-commit-push".into(),
+            steps_preview: vec!["cargo test".into(), "git commit".into()],
+            session_count: 4,
+            evidence_session_ids: vec![],
+        }
+    }
+
+    #[test]
+    fn body_mentions_title_and_count() {
+        let b = nudge_body(&cand(), "en");
+        assert!(b.contains("Run tests, then commit, then push"));
+        assert!(b.contains("4")); // session count
+    }
+
+    #[test]
+    fn message_id_encodes_candidate_id() {
+        assert_eq!(nudge_msg_id("abc123"), "nudge:abc123");
+        assert_eq!(
+            candidate_id_from_msg("nudge:abc123"),
+            Some("abc123".to_string())
+        );
+        assert_eq!(candidate_id_from_msg("other"), None);
+    }
+}

--- a/mur-core/src/nudge/companion.rs
+++ b/mur-core/src/nudge/companion.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 
-use crate::nudge::candidate::WorkflowCandidate;
 use crate::nudge::NudgeDecision;
+use crate::nudge::candidate::WorkflowCandidate;
 
 /// Message id namespace so the response drain can recognize nudge replies.
 pub const NUDGE_ID_PREFIX: &str = "nudge:";
@@ -26,11 +26,7 @@ pub fn nudge_body(c: &WorkflowCandidate, _locale: &str) -> String {
 /// Write a nudge as a companion inbox `.md` (same frontmatter format as the
 /// runtime's write_inbox_md). Returns the path. No-op (Ok) if a file for this
 /// id already exists (create_new semantics).
-pub fn write_nudge_inbox(
-    inbox_dir: &Path,
-    c: &WorkflowCandidate,
-    locale: &str,
-) -> Result<PathBuf> {
+pub fn write_nudge_inbox(inbox_dir: &Path, c: &WorkflowCandidate, locale: &str) -> Result<PathBuf> {
     let id = nudge_msg_id(&c.id);
     // Sanitize the ':' in the id for the filesystem.
     let filename = format!("{}.md", id.replace(':', "_"));
@@ -249,12 +245,8 @@ mod tests {
         let c = cand();
         let n = deliver_nudges_to_companions(mur.path(), &[c], "en").unwrap();
         assert_eq!(n, 1); // only the "on" agent got it
-        assert!(on_dir
-            .join("companion/inbox/nudge_abc123.md")
-            .exists());
-        assert!(!off_dir
-            .join("companion/inbox/nudge_abc123.md")
-            .exists());
+        assert!(on_dir.join("companion/inbox/nudge_abc123.md").exists());
+        assert!(!off_dir.join("companion/inbox/nudge_abc123.md").exists());
     }
 
     #[test]
@@ -266,7 +258,9 @@ mod tests {
         let c = cand();
         let mut ledger = NudgeLedger::default();
         NudgeEmitter::emit_pending(&mut ledger, &[c.clone()], chrono::Utc::now());
-        ledger.save(&NudgeLedger::default_path_in(mur.path())).unwrap();
+        ledger
+            .save(&NudgeLedger::default_path_in(mur.path()))
+            .unwrap();
 
         let mut prof = mur_common::agent::AgentProfile::default_for_tests();
         prof.companion.enabled = true;
@@ -282,11 +276,7 @@ mod tests {
             "---\nid: nudge:abc123\nsituation: workflow_nudge\ntemplate_id: nudge\nlocale: en\ngenerated_at: {}\n---\n\nbody\n\n>>> response: good",
             chrono::Utc::now().to_rfc3339()
         );
-        std::fs::write(
-            agent_dir.join("companion/inbox/nudge_abc123.md"),
-            &inbox_md,
-        )
-        .unwrap();
+        std::fs::write(agent_dir.join("companion/inbox/nudge_abc123.md"), &inbox_md).unwrap();
         // 3. Run the drain
         let created = std::cell::Cell::new(false);
         let applied = drain_nudge_responses_in(mur.path(), &|c| {
@@ -299,9 +289,10 @@ mod tests {
         assert!(created.get());
         // 4. Verify ledger state and file consumed
         let l = NudgeLedger::load(&NudgeLedger::default_path_in(mur.path())).unwrap();
-        assert!(matches!(l.get("abc123").unwrap().state, NudgeState::Accepted));
-        assert!(!agent_dir
-            .join("companion/inbox/nudge_abc123.md")
-            .exists());
+        assert!(matches!(
+            l.get("abc123").unwrap().state,
+            NudgeState::Accepted
+        ));
+        assert!(!agent_dir.join("companion/inbox/nudge_abc123.md").exists());
     }
 }

--- a/mur-core/src/nudge/companion.rs
+++ b/mur-core/src/nudge/companion.rs
@@ -58,6 +58,46 @@ pub fn write_nudge_inbox(
     Ok(file)
 }
 
+/// Write each candidate to every companion-enabled agent's inbox.
+/// Returns the number of (agent × candidate) messages written.
+pub fn deliver_nudges_to_companions(
+    mur_dir: &Path,
+    candidates: &[WorkflowCandidate],
+    locale: &str,
+) -> Result<usize> {
+    let agents_dir = mur_dir.join("agents");
+    if !agents_dir.exists() || candidates.is_empty() {
+        return Ok(0);
+    }
+    let mut written = 0;
+    for entry in std::fs::read_dir(&agents_dir)? {
+        let dir = entry?.path();
+        let profile = dir.join("profile.yaml");
+        if !profile.is_file() {
+            continue;
+        }
+        let body = std::fs::read_to_string(&profile)?;
+        let prof: mur_common::agent::AgentProfile = match serde_yaml_ng::from_str(&body) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if !prof.companion.enabled {
+            continue;
+        }
+        let inbox = dir.join("companion").join("inbox");
+        let loc = if prof.companion.locale.is_empty() {
+            locale
+        } else {
+            &prof.companion.locale
+        };
+        for c in candidates {
+            write_nudge_inbox(&inbox, c, loc)?;
+            written += 1;
+        }
+    }
+    Ok(written)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -103,5 +143,34 @@ mod tests {
         assert!(s.trim_end().ends_with(">>> response: <unset>"));
         // idempotent: second write for same id is a no-op (already exists)
         assert!(write_nudge_inbox(&inbox, &c, "en").is_ok());
+    }
+
+    #[test]
+    fn deliver_writes_to_enabled_agent_inboxes_only() {
+        let mur = tempfile::tempdir().unwrap();
+        // Build minimal profiles using default_for_tests + companion block.
+        let mut prof = mur_common::agent::AgentProfile::default_for_tests();
+        let base_yaml = serde_yaml_ng::to_string(&prof).unwrap();
+        // agent "on": profile with companion.enabled = true
+        prof.companion.enabled = true;
+        let on_yaml = serde_yaml_ng::to_string(&prof).unwrap();
+        // agent "off": profile with companion.enabled = false
+        prof.companion.enabled = false;
+        let off_yaml = serde_yaml_ng::to_string(&prof).unwrap();
+        let on_dir = mur.path().join("agents/on");
+        std::fs::create_dir_all(&on_dir).unwrap();
+        std::fs::write(on_dir.join("profile.yaml"), on_yaml).unwrap();
+        let off_dir = mur.path().join("agents/off");
+        std::fs::create_dir_all(&off_dir).unwrap();
+        std::fs::write(off_dir.join("profile.yaml"), off_yaml).unwrap();
+        let c = cand();
+        let n = deliver_nudges_to_companions(mur.path(), &[c], "en").unwrap();
+        assert_eq!(n, 1); // only the "on" agent got it
+        assert!(on_dir
+            .join("companion/inbox/nudge_abc123.md")
+            .exists());
+        assert!(!off_dir
+            .join("companion/inbox/nudge_abc123.md")
+            .exists());
     }
 }

--- a/mur-core/src/nudge/companion.rs
+++ b/mur-core/src/nudge/companion.rs
@@ -1,3 +1,6 @@
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
 use crate::nudge::candidate::WorkflowCandidate;
 
 /// Message id namespace so the response drain can recognize nudge replies.
@@ -17,6 +20,42 @@ pub fn nudge_body(c: &WorkflowCandidate, _locale: &str) -> String {
         "I noticed you did this across {} sessions:\n\n  {}\n\nWant me to save it as a replayable workflow you can run with `mur run {}`?",
         c.session_count, c.title, c.suggested_name
     )
+}
+
+/// Write a nudge as a companion inbox `.md` (same frontmatter format as the
+/// runtime's write_inbox_md). Returns the path. No-op (Ok) if a file for this
+/// id already exists (create_new semantics).
+pub fn write_nudge_inbox(
+    inbox_dir: &Path,
+    c: &WorkflowCandidate,
+    locale: &str,
+) -> Result<PathBuf> {
+    let id = nudge_msg_id(&c.id);
+    // Sanitize the ':' in the id for the filesystem.
+    let filename = format!("{}.md", id.replace(':', "_"));
+    let file = inbox_dir.join(&filename);
+
+    std::fs::create_dir_all(inbox_dir)?;
+
+    // create_new: skip if already exists (idempotent)
+    let mut f = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&file)
+    {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => return Ok(file),
+        Err(e) => return Err(e.into()),
+    };
+
+    let generated_at = chrono::Utc::now().to_rfc3339();
+    let body = nudge_body(c, locale);
+    let content = format!(
+        "---\nid: {id}\nsituation: workflow_nudge\ntemplate_id: nudge\nlocale: {locale}\ngenerated_at: {generated_at}\n---\n\n{body}\n\n>>> response: <unset>"
+    );
+    std::io::Write::write_all(&mut f, content.as_bytes())?;
+
+    Ok(file)
 }
 
 #[cfg(test)]
@@ -50,5 +89,19 @@ mod tests {
             Some("abc123".to_string())
         );
         assert_eq!(candidate_id_from_msg("other"), None);
+    }
+
+    #[test]
+    fn writes_nudge_inbox_md_with_response_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = dir.path().join("inbox");
+        let c = cand();
+        let path = write_nudge_inbox(&inbox, &c, "en").unwrap();
+        let s = std::fs::read_to_string(&path).unwrap();
+        assert!(s.contains("situation: workflow_nudge"));
+        assert!(s.contains("id: nudge:abc123"));
+        assert!(s.trim_end().ends_with(">>> response: <unset>"));
+        // idempotent: second write for same id is a no-op (already exists)
+        assert!(write_nudge_inbox(&inbox, &c, "en").is_ok());
     }
 }

--- a/mur-core/src/nudge/companion.rs
+++ b/mur-core/src/nudge/companion.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::path::{Path, PathBuf};
 
 use crate::nudge::candidate::WorkflowCandidate;
+use crate::nudge::NudgeDecision;
 
 /// Message id namespace so the response drain can recognize nudge replies.
 pub const NUDGE_ID_PREFIX: &str = "nudge:";
@@ -98,6 +99,88 @@ pub fn deliver_nudges_to_companions(
     Ok(written)
 }
 
+fn signal_to_decision(sig: &str) -> Option<NudgeDecision> {
+    match sig {
+        "good" => Some(NudgeDecision::Accept),
+        "dismiss" | "bad" => Some(NudgeDecision::Dismiss),
+        "snooze" => Some(NudgeDecision::Snooze),
+        _ => None,
+    }
+}
+
+/// Parse the frontmatter `id:` and the `>>> response:` value from an inbox `.md`.
+fn parse_id_and_response(text: &str) -> (Option<String>, Option<String>) {
+    let id = text
+        .lines()
+        .find(|l| l.starts_with("id: "))
+        .map(|l| l.trim_start_matches("id: ").trim().to_string());
+    let resp = text
+        .lines()
+        .find(|l| l.starts_with(">>> response: "))
+        .map(|l| l.trim_start_matches(">>> response: ").trim().to_string());
+    (id, resp)
+}
+
+/// Scan all companion inboxes for answered nudge messages, apply each decision
+/// to the nudge ledger, and consume the file. Returns count applied.
+pub fn drain_nudge_responses_in(
+    mur_dir: &Path,
+    create: &dyn Fn(&WorkflowCandidate) -> anyhow::Result<()>,
+) -> anyhow::Result<usize> {
+    use crate::nudge::{NudgeEmitter, NudgeLedger};
+
+    let config_path = crate::store::yaml::default_mur_dir().join("config.yaml");
+    let cfg = mur_common::config::Config::load_or_default(&config_path);
+    let ledger_path = NudgeLedger::default_path_in(mur_dir);
+    let mut ledger = NudgeLedger::load(&ledger_path)?;
+    let now = chrono::Utc::now();
+    let mut applied = 0;
+    let agents = mur_dir.join("agents");
+    if !agents.exists() {
+        return Ok(0);
+    }
+    for agent in std::fs::read_dir(&agents)? {
+        let inbox = agent?.path().join("companion").join("inbox");
+        if !inbox.is_dir() {
+            continue;
+        }
+        for f in std::fs::read_dir(&inbox)? {
+            let path = f?.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path)?;
+            let (id, resp) = parse_id_and_response(&text);
+            let (Some(id), Some(resp)) = (id, resp) else {
+                continue;
+            };
+            if resp == "<unset>" {
+                continue;
+            }
+            let Some(cand_id) = candidate_id_from_msg(&id) else {
+                continue;
+            };
+            let Some(decision) = signal_to_decision(&resp) else {
+                continue;
+            };
+            NudgeEmitter::apply_decision(
+                &mut ledger,
+                &cand_id,
+                decision,
+                cfg.nudge.snooze_days,
+                now,
+                create,
+            )?;
+            std::fs::remove_file(&path).ok(); // consume
+            applied += 1;
+        }
+    }
+    if applied > 0 {
+        ledger.save(&ledger_path)?;
+    }
+    Ok(applied)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,6 +253,54 @@ mod tests {
             .join("companion/inbox/nudge_abc123.md")
             .exists());
         assert!(!off_dir
+            .join("companion/inbox/nudge_abc123.md")
+            .exists());
+    }
+
+    #[test]
+    fn drain_applies_accept_and_creates_draft() {
+        use crate::nudge::{NudgeEmitter, NudgeLedger, NudgeState};
+
+        let mur = tempfile::tempdir().unwrap();
+        // 1. Seed nudge ledger with a surfaced candidate "abc123" (snapshot present)
+        let c = cand();
+        let mut ledger = NudgeLedger::default();
+        NudgeEmitter::emit_pending(&mut ledger, &[c.clone()], chrono::Utc::now());
+        ledger.save(&NudgeLedger::default_path_in(mur.path())).unwrap();
+
+        let mut prof = mur_common::agent::AgentProfile::default_for_tests();
+        prof.companion.enabled = true;
+        let agent_dir = mur.path().join("agents/test-agent");
+        std::fs::create_dir_all(agent_dir.join("companion/inbox")).unwrap();
+        std::fs::write(
+            agent_dir.join("profile.yaml"),
+            serde_yaml_ng::to_string(&prof).unwrap(),
+        )
+        .unwrap();
+        // 2. Write a nudge inbox md with ">>> response: good"
+        let inbox_md = format!(
+            "---\nid: nudge:abc123\nsituation: workflow_nudge\ntemplate_id: nudge\nlocale: en\ngenerated_at: {}\n---\n\nbody\n\n>>> response: good",
+            chrono::Utc::now().to_rfc3339()
+        );
+        std::fs::write(
+            agent_dir.join("companion/inbox/nudge_abc123.md"),
+            &inbox_md,
+        )
+        .unwrap();
+        // 3. Run the drain
+        let created = std::cell::Cell::new(false);
+        let applied = drain_nudge_responses_in(mur.path(), &|c| {
+            assert_eq!(c.suggested_name, "test-commit-push");
+            created.set(true);
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(applied, 1);
+        assert!(created.get());
+        // 4. Verify ledger state and file consumed
+        let l = NudgeLedger::load(&NudgeLedger::default_path_in(mur.path())).unwrap();
+        assert!(matches!(l.get("abc123").unwrap().state, NudgeState::Accepted));
+        assert!(!agent_dir
             .join("companion/inbox/nudge_abc123.md")
             .exists());
     }

--- a/mur-core/src/nudge/ledger.rs
+++ b/mur-core/src/nudge/ledger.rs
@@ -32,7 +32,10 @@ pub struct NudgeLedger {
 
 impl NudgeLedger {
     pub fn default_path() -> PathBuf {
-        crate::store::yaml::default_mur_dir().join("nudges.json")
+        Self::default_path_in(&crate::store::yaml::default_mur_dir())
+    }
+    pub fn default_path_in(mur_dir: &Path) -> PathBuf {
+        mur_dir.join("nudges.json")
     }
     pub fn load(path: &Path) -> Result<Self> {
         match std::fs::read_to_string(path) {

--- a/mur-core/src/nudge/mod.rs
+++ b/mur-core/src/nudge/mod.rs
@@ -1,6 +1,7 @@
 //! Workflow nudge engine: turn emergence-mined recurring behavior into
 //! actionable "save this as a workflow?" prompts (surface-agnostic).
 pub mod candidate;
+pub mod companion;
 pub mod emitter;
 pub mod ledger;
 

--- a/mur-core/tests/cli_nudge.rs
+++ b/mur-core/tests/cli_nudge.rs
@@ -142,3 +142,80 @@ fn end_to_end_detect_accept_no_resurface() {
     // 5. Draft workflow exists
     assert!(wf_store.exists("my-workflow"));
 }
+
+#[test]
+fn phase2_end_to_end_deliver_ack_drain() {
+    let mur = tempfile::tempdir().unwrap();
+
+    // 1. Create a companion-enabled agent profile.
+    let mut prof = mur_common::agent::AgentProfile::default_for_tests();
+    prof.companion.enabled = true;
+    let agent_dir = mur.path().join("agents/test-agent");
+    std::fs::create_dir_all(&agent_dir).unwrap();
+    std::fs::write(
+        agent_dir.join("profile.yaml"),
+        serde_yaml_ng::to_string(&prof).unwrap(),
+    )
+    .unwrap();
+
+    // 2. Seed a ledger with a surfaced candidate (snapshot present).
+    let c = cand("phase2", "phase2-workflow");
+    let mut ledger = NudgeLedger::default();
+    NudgeEmitter::emit_pending(&mut ledger, &[c.clone()], chrono::Utc::now());
+    ledger
+        .save(&NudgeLedger::default_path_in(mur.path()))
+        .unwrap();
+
+    // 3. Deliver the candidate to the agent inbox.
+    let n =
+        mur_core::nudge::companion::deliver_nudges_to_companions(mur.path(), &[c.clone()], "en")
+            .unwrap();
+    assert_eq!(n, 1);
+    let inbox_file = agent_dir.join("companion/inbox/nudge_phase2.md");
+    assert!(inbox_file.exists());
+
+    // 4. Simulate GUI ack: rewrite response to "good".
+    let content = std::fs::read_to_string(&inbox_file).unwrap();
+    let new_content = content.replace("<unset>", "good");
+    std::fs::write(&inbox_file, &new_content).unwrap();
+
+    // 5. Drain → draft created, ledger Accepted, inbox file consumed.
+    let wf_dir = mur.path().join("workflows");
+    let wf_store = mur_core::store::workflow_yaml::WorkflowYamlStore::new(wf_dir.clone()).unwrap();
+    let applied = mur_core::nudge::companion::drain_nudge_responses_in(mur.path(), &|cand| {
+        mur_core::cmd::workflow::create_draft_workflow_in(
+            &wf_store,
+            &cand.suggested_name,
+            &cand.title,
+            "",
+            &cand.evidence_session_ids,
+        )
+    })
+    .unwrap();
+    assert_eq!(applied, 1);
+
+    // Verify ledger → Accepted.
+    let ledger = NudgeLedger::load(&NudgeLedger::default_path_in(mur.path())).unwrap();
+    assert!(matches!(
+        ledger.get("phase2").unwrap().state,
+        NudgeState::Accepted
+    ));
+
+    // Verify draft workflow created.
+    assert!(wf_store.exists("phase2-workflow"));
+
+    // Verify inbox file consumed.
+    assert!(!inbox_file.exists());
+
+    // 6. Re-deliver same candidate → write_nudge_inbox is idempotent
+    //    but the consumed file was removed. Re-deliver recreates it;
+    //    the ledger filter in record_nudges_for_candidates prevents
+    //    accepted candidates from being surfaced again upstream.
+    let n2 =
+        mur_core::nudge::companion::deliver_nudges_to_companions(mur.path(), &[c.clone()], "en")
+            .unwrap();
+    assert_eq!(n2, 1); // deliver doesn't check ledger; file was consumed
+    // But filter_actionable excludes it:
+    let actionable = ledger.filter_actionable(&[c], chrono::Utc::now(), 10);
+    assert!(actionable.is_empty());
+}

--- a/mur-gui-core/src/companion_bridge/event.rs
+++ b/mur-gui-core/src/companion_bridge/event.rs
@@ -57,7 +57,7 @@ pub fn parse_str(raw: &str) -> Result<BridgeEvent> {
     let response_value = response_line.trim();
     let response = if response_value == "<unset>" {
         BridgeResponse::Unset
-    } else if matches!(response_value, "good" | "bad" | "dismiss") {
+    } else if matches!(response_value, "good" | "bad" | "dismiss" | "snooze") {
         BridgeResponse::Signal(response_value.to_string())
     } else {
         bail!("unrecognized response value: {response_value}");
@@ -95,6 +95,13 @@ mod tests {
         let s = SAMPLE.replace("<unset>", "good");
         let ev = parse_str(&s).unwrap();
         assert_eq!(ev.response, BridgeResponse::Signal("good".into()));
+    }
+
+    #[test]
+    fn parses_snooze_response() {
+        let s = SAMPLE.replace("<unset>", "snooze");
+        let ev = parse_str(&s).unwrap();
+        assert_eq!(ev.response, BridgeResponse::Signal("snooze".into()));
     }
 
     #[test]

--- a/mur-hub-gui/src-tauri/src/companion.rs
+++ b/mur-hub-gui/src-tauri/src/companion.rs
@@ -95,7 +95,7 @@ pub fn companion_bridge_unsubscribe(
 /// Acknowledge a message (rewrite `>>> response: <unset>` → `>>> response: <signal>`).
 #[tauri::command]
 pub fn companion_ack(agent: String, msg_id: String, signal: String) -> Result<(), String> {
-    if !matches!(signal.as_str(), "good" | "bad" | "dismiss") {
+    if !matches!(signal.as_str(), "good" | "bad" | "dismiss" | "snooze") {
         return Err(format!("unknown signal `{signal}`"));
     }
     let path = agent_inbox(&agent).join(format!("{msg_id}.md"));

--- a/mur-hub-gui/ui/src/components/CompanionInbox.tsx
+++ b/mur-hub-gui/ui/src/components/CompanionInbox.tsx
@@ -105,7 +105,14 @@ export function CompanionInbox({ agentName }: Props) {
               </span>
             </div>
             <p className="inbox-body">{msg.body}</p>
-            {isUnread && (
+            {isUnread && msg.situation === "workflow_nudge" && (
+              <div className="inbox-actions">
+                <button onClick={() => ack(msg.id, "good")}>Save it</button>
+                <button onClick={() => ack(msg.id, "snooze")}>Not now</button>
+                <button onClick={() => ack(msg.id, "dismiss")}>No thanks</button>
+              </div>
+            )}
+            {isUnread && msg.situation !== "workflow_nudge" && (
               <div className="inbox-actions">
                 <button onClick={() => ack(msg.id, "good")} title="Good">👍</button>
                 <button onClick={() => ack(msg.id, "bad")} title="Bad">👎</button>
@@ -115,9 +122,13 @@ export function CompanionInbox({ agentName }: Props) {
             {!isUnread && (
               <span className="inbox-acked">
                 {msg.response.value === "good"
-                  ? "👍 Acknowledged"
+                  ? msg.situation === "workflow_nudge"
+                    ? "💾 Saved"
+                    : "👍 Acknowledged"
                   : msg.response.value === "bad"
                   ? "👎 Noted"
+                  : msg.response.value === "snooze"
+                  ? "⏳ Snoozed"
                   : "🚫 Dismissed"}
               </span>
             )}


### PR DESCRIPTION
## Summary
- Surfaces Phase 1's pending workflow nudges as **proactive companion speech bubbles** at session-end, with Save / Not now / No thanks buttons
- Adds `Situation::WorkflowNudge` variant to `mur-common`, handled with zero weight in the proactive rhythm (nudges are delivered out-of-band, not picked by the time-of-day scheduler)
- Writes deterministic nudge inbox `.md` files (matching the runtime's frontmatter format byte-for-byte) into each companion-enabled agent's `companion/inbox/`
- Adds `snooze` to the validated response set in both the bridge event parser (`mur-gui-core`) and the `companion_ack` Tauri command / CLI command (`mur-core`)
- Response drain in `mur suggest` reads answered nudge inbox files and applies decisions via Phase 1's `NudgeEmitter` / `NudgeLedger` — Accept creates a draft workflow; Dismiss/Snooze update the ledger
- Companion UI (`mur-hub-gui`): renders **Save it / Not now / No thanks** text buttons when `situation === "workflow_nudge"`, distinct from the emoji buttons for regular companion messages
- Flips `NudgeConfig::enabled` default to `true` — the companion surface is now live

## Test Plan
- [x] `cargo test -p mur-core nudge::` — 12 nudge unit tests pass
- [x] `cargo test -p mur-core --test cli_nudge` — 4 integration tests pass (including phase2 end-to-end deliver→ack→drain)
- [x] `cargo test -p mur-common` — passes
- [x] `cargo test -p mur-gui-core companion_bridge` — 4 bridge tests pass (including snooze parsing)
- [x] `cargo clippy -p mur-core -p mur-common -p mur-gui-core -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual smoke: trigger a nudge via session recording, confirm bubble appears in Hub with 3 buttons, click Save it, verify `mur suggest` shows draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)