### PR TITLE
feat(export-ux): Phase A/B/C complete — .muragent file assoc, model wizard, Hub Share, onboarding

### DIFF
--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -151,6 +151,11 @@ pub enum AgentAction {
     Install {
         /// Path to the `.muragent` file
         path: String,
+        /// Bind to an existing model registry entry immediately (non-interactive).
+        /// The ref must already exist in ~/.mur/models.yaml.
+        /// Example: --model ollama_llama3_2_3b
+        #[arg(long)]
+        model: Option<String>,
     },
     /// Uninstall an agent (data preserved at <home>/data unless --purge)
     Uninstall {

--- a/mur-core/src/cmd/agent/install.rs
+++ b/mur-core/src/cmd/agent/install.rs
@@ -253,8 +253,8 @@ mod tests {
 
     #[test]
     fn maybe_resolve_with_model_ref_applies_without_prompt() {
-        use tempfile::TempDir;
         use mur_common::model::{ModelEntry, ModelRegistry};
+        use tempfile::TempDir;
 
         let tmp = TempDir::new().unwrap();
         let mur_home = tmp.path();
@@ -270,7 +270,9 @@ mod tests {
         .unwrap();
 
         // Pre-populate the registry so the ref resolves
-        unsafe { std::env::set_var("MUR_HOME", mur_home); }
+        unsafe {
+            std::env::set_var("MUR_HOME", mur_home);
+        }
         let reg_path = ModelRegistry::default_path().unwrap();
         let mut reg = ModelRegistry::load_from(&reg_path).unwrap_or_default();
         reg.models.insert(

--- a/mur-core/src/cmd/agent/install.rs
+++ b/mur-core/src/cmd/agent/install.rs
@@ -16,7 +16,7 @@ use mur_common::trust;
 
 use super::resolve_mur_home;
 
-pub fn cmd_install(path: &Path) -> Result<()> {
+pub fn cmd_install(path: &Path, model_ref_override: Option<&str>) -> Result<()> {
     let archive = MuragentArchive::read(path)
         .with_context(|| format!("read .muragent file at {}", path.display()))?;
     let mur_home = resolve_mur_home()?;
@@ -36,7 +36,11 @@ pub fn cmd_install(path: &Path) -> Result<()> {
     println!("  fingerprint: {}", outcome.fingerprint_hex);
     println!("  words:       {}", outcome.fingerprint_words);
 
-    maybe_resolve_model(&mur_home, &outcome.manifest.agent.slug, &archive)?;
+    if let Some(model_ref) = model_ref_override {
+        apply_model_ref_override(&mur_home, &outcome.manifest.agent.slug, model_ref)?;
+    } else {
+        maybe_resolve_model(&mur_home, &outcome.manifest.agent.slug, &archive)?;
+    }
     Ok(())
 }
 
@@ -123,7 +127,7 @@ pub fn cmd_inspect(path: &Path) -> Result<()> {
 
 fn maybe_resolve_model(mur_home: &Path, slug: &str, archive: &MuragentArchive) -> Result<()> {
     use crate::cmd::agent::model_resolve::{apply_model_choice, detect_hardware};
-    use mur_common::model_resolve::{Recommendation, recommend};
+    use mur_common::model_resolve::recommend;
 
     let manifest_yaml = archive
         .get_str("manifest.yaml")
@@ -135,13 +139,8 @@ fn maybe_resolve_model(mur_home: &Path, slug: &str, archive: &MuragentArchive) -
 
     if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
         println!(
-            "  model: {} — set one with `mur model add` then run the agent with --model <ref>",
-            match rec {
-                Recommendation::Local => "local recommended (Ollama/MLX)",
-                Recommendation::Cloud => "cloud model recommended",
-                Recommendation::CloudOrSmallerLocal => "cloud or a smaller local model",
-                Recommendation::NeutralMenu => "choose a backend",
-            }
+            "  model: not configured — use `mur agent install --model <ref>` \
+             or run `mur model add` then `mur agent start {slug}`"
         );
         return Ok(());
     }
@@ -160,6 +159,31 @@ fn maybe_resolve_model(mur_home: &Path, slug: &str, archive: &MuragentArchive) -
     } else {
         println!("  skipped — set one later with `mur model add`");
     }
+    Ok(())
+}
+
+/// Apply a `--model <ref>` override: verify the ref exists in the registry
+/// and point the agent at it. Used by `--model` flag (non-interactive path).
+fn apply_model_ref_override(mur_home: &Path, slug: &str, model_ref: &str) -> Result<()> {
+    use crate::cmd::agent::model_resolve::ModelChoice;
+    use mur_common::model::ModelRegistry;
+
+    let reg_path = ModelRegistry::default_path()?;
+    let reg = ModelRegistry::load_from(&reg_path)?;
+    anyhow::ensure!(
+        reg.models.contains_key(model_ref),
+        "model ref '{model_ref}' not found in ~/.mur/models.yaml — \
+         run `mur model add` to register it first"
+    );
+    let entry = &reg.models[model_ref];
+    let choice = ModelChoice {
+        provider: entry.provider.clone(),
+        model: entry.model.clone(),
+        base_url: entry.base_url.clone(),
+        secret: entry.secret.as_ref().map(|s| s.to_string()),
+    };
+    let key = crate::cmd::agent::model_resolve::apply_model_choice(mur_home, slug, &choice)?;
+    println!("  model_ref = {key}");
     Ok(())
 }
 
@@ -221,4 +245,54 @@ fn read_field(prompt: &str) -> Result<String> {
     let mut s = String::new();
     std::io::stdin().read_line(&mut s)?;
     Ok(s.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maybe_resolve_with_model_ref_applies_without_prompt() {
+        use tempfile::TempDir;
+        use mur_common::model::{ModelEntry, ModelRegistry};
+
+        let tmp = TempDir::new().unwrap();
+        let mur_home = tmp.path();
+
+        // Create agent dir with a default profile
+        let agent_home = mur_home.join("agents").join("demo");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        let p = mur_common::agent::AgentProfile::default_for_tests();
+        std::fs::write(
+            agent_home.join("profile.yaml"),
+            serde_yaml_ng::to_string(&p).unwrap(),
+        )
+        .unwrap();
+
+        // Pre-populate the registry so the ref resolves
+        unsafe { std::env::set_var("MUR_HOME", mur_home); }
+        let reg_path = ModelRegistry::default_path().unwrap();
+        let mut reg = ModelRegistry::load_from(&reg_path).unwrap_or_default();
+        reg.models.insert(
+            "ollama_llama3_2_3b".to_string(),
+            ModelEntry {
+                provider: "ollama".into(),
+                model: "llama3.2:3b".into(),
+                base_url: None,
+                secret: None,
+                capabilities: vec![],
+                params: serde_json::Value::Null,
+            },
+        );
+        reg.save_to(&reg_path).unwrap();
+
+        // Call the new apply_model_ref_override helper
+        apply_model_ref_override(mur_home, "demo", "ollama_llama3_2_3b").unwrap();
+
+        let profile: mur_common::agent::AgentProfile = serde_yaml_ng::from_str(
+            &std::fs::read_to_string(agent_home.join("profile.yaml")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(profile.model_ref.as_deref(), Some("ollama_llama3_2_3b"));
+    }
 }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -931,7 +931,9 @@ async fn run_agent(action: AgentAction) -> Result<()> {
         } => {
             cmd::agent::cmd_export(&name, &out, &format)?;
         }
-        AgentAction::Install { path } => cmd::agent::cmd_install(std::path::Path::new(&path))?,
+        AgentAction::Install { path, model } => {
+            cmd::agent::cmd_install(std::path::Path::new(&path), model.as_deref())?
+        }
         AgentAction::Uninstall { name, purge } => cmd::agent::cmd_uninstall(&name, purge)?,
         AgentAction::Inspect { path } => cmd::agent::cmd_inspect(std::path::Path::new(&path))?,
         AgentAction::Stats { name } => cmd::agent::cmd_stats(&name)?,

--- a/mur-daemon/src/main.rs
+++ b/mur-daemon/src/main.rs
@@ -9,8 +9,7 @@ use anyhow::Result;
 use chrono::Utc;
 use lock::{LockState, is_healthy, lock_path, read_lock, write_lock};
 use mur_core::inject::event::{EventKind, NormalizedEvent};
-use mur_core::inject::index::{build as build_index, format_l0};
-use mur_core::store::yaml::YamlStore;
+use mur_core::inject::index::{format_l0, load as load_capability_index};
 use std::time::Instant;
 
 const L0_BUDGET_CHARS: usize = 2400;
@@ -21,9 +20,12 @@ fn process_event(event: &NormalizedEvent) -> Result<()> {
             let Some(ref session_id) = event.session_id else {
                 return Ok(());
             };
-            let yaml_store = YamlStore::default_store()?;
-            let patterns = yaml_store.list_all()?;
-            let index = build_index(&patterns, None);
+            let index = load_capability_index().unwrap_or_else(|_| {
+                mur_core::inject::index::CapabilityIndex {
+                    entries: vec![],
+                    project: None,
+                }
+            });
             let content = format_l0(&index, L0_BUDGET_CHARS);
             if !content.is_empty() {
                 let path = inbox::inbox_path(session_id);

--- a/mur-hub-gui/src-tauri/Cargo.toml
+++ b/mur-hub-gui/src-tauri/Cargo.toml
@@ -28,6 +28,8 @@ tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-window-state = "2"
+tauri-plugin-deep-link = "2"
+tauri-plugin-single-instance = "2"
 
 # Workspace siblings — reused from the root repo via relative path.
 mur-common = { path = "../../mur-common" }

--- a/mur-hub-gui/src-tauri/Cargo.toml
+++ b/mur-hub-gui/src-tauri/Cargo.toml
@@ -51,3 +51,6 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "signa
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
+
+[dev-dependencies]
+tempfile = "3"

--- a/mur-hub-gui/src-tauri/capabilities/default.json
+++ b/mur-hub-gui/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "shell:allow-open",
-    "dialog:allow-open"
+    "dialog:allow-open",
+    "deep-link:default"
   ]
 }

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -335,13 +335,14 @@ pub fn run() {
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|app, event| {
-            if let tauri::RunEvent::Opened { urls } = event {
+        .run(|_app, _event| {
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Opened { urls } = _event {
                 for url in urls {
-                    if let Ok(path) = url.to_file_path() {
-                        if let Some(s) = path.to_str() {
-                            let _ = app.emit("open-muragent-file", s.to_string());
-                        }
+                    if let Ok(path) = url.to_file_path()
+                        && let Some(s) = path.to_str()
+                    {
+                        let _ = _app.emit("open-muragent-file", s.to_string());
                     }
                 }
             }

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -197,6 +197,19 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+        .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
+            for arg in argv.iter() {
+                if arg.ends_with(".muragent") {
+                    let _ = app.emit("open-muragent-file", arg.clone());
+                    break;
+                }
+            }
+            if let Some(win) = app.get_webview_window("dashboard") {
+                let _ = win.show();
+                let _ = win.set_focus();
+            }
+        }))
         .manage(AgentState(Mutex::new(Vec::new())))
         .manage(SupervisorState(supervisor))
         .manage(WizardState(Mutex::new(None)))
@@ -266,6 +279,17 @@ pub fn run() {
                 });
             }
 
+            #[cfg(target_os = "windows")]
+            {
+                let args: Vec<String> = std::env::args().collect();
+                for arg in args.iter().skip(1) {
+                    if arg.ends_with(".muragent") {
+                        let _ = app.handle().emit("open-muragent-file", arg.clone());
+                        break;
+                    }
+                }
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -307,8 +331,19 @@ pub fn run() {
             companion::companion_proactive,
             companion::companion_quiet,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app, event| {
+            if let tauri::RunEvent::Opened { urls } = event {
+                for url in urls {
+                    if let Ok(path) = url.to_file_path() {
+                        if let Some(s) = path.to_str() {
+                            let _ = app.emit("open-muragent-file", s.to_string());
+                        }
+                    }
+                }
+            }
+        });
 }
 
 fn mur_home_path() -> PathBuf {

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -307,6 +307,8 @@ pub fn run() {
             onboarding::wizard_start_render,
             onboarding::wizard_finish,
             onboarding::wizard_cancel,
+            onboarding::first_launch::check_first_launch,
+            onboarding::first_launch::mark_first_launch_done,
             pet::pet_spawn_at,
             pet::pet_close,
             pet::pet_reposition,

--- a/mur-hub-gui/src-tauri/src/onboarding/first_launch.rs
+++ b/mur-hub-gui/src-tauri/src/onboarding/first_launch.rs
@@ -1,0 +1,123 @@
+//! First-launch onboarding checks for the Hub.
+//!
+//! On macOS: verifies the app is running from /Applications, registers the
+//! .muragent handler via lsregister, and tracks completion via a marker file.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+const MARKER: &str = ".hub_onboarded";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FirstLaunchStatus {
+    /// True if this is the first launch (marker not yet written).
+    pub is_first_launch: bool,
+    /// True if running from /Applications (or non-macOS where this is N/A).
+    pub in_applications: bool,
+}
+
+/// Returns first-launch status and, on macOS first launch, registers the
+/// .muragent handler with LaunchServices.
+#[tauri::command]
+pub fn check_first_launch() -> FirstLaunchStatus {
+    let mur_home = mur_home_path();
+    let is_first_launch = !mur_home.join(MARKER).exists();
+    let in_applications = check_in_applications();
+
+    if is_first_launch {
+        #[cfg(target_os = "macos")]
+        run_lsregister();
+    }
+
+    FirstLaunchStatus {
+        is_first_launch,
+        in_applications,
+    }
+}
+
+/// Write the marker file so future launches are not treated as first-launch.
+#[tauri::command]
+pub fn mark_first_launch_done() {
+    let mur_home = mur_home_path();
+    let _ = std::fs::create_dir_all(&mur_home);
+    let _ = std::fs::write(mur_home.join(MARKER), "");
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+fn check_in_applications() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.canonicalize().ok())
+            .map(|p| {
+                p.starts_with("/Applications/")
+                    || p.to_str()
+                        .map(|s| s.contains("/Applications/"))
+                        .unwrap_or(false)
+            })
+            .unwrap_or(true) // assume fine if we can't tell
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        true
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn bundle_path() -> Option<PathBuf> {
+    // binary: /Applications/MuR Hub.app/Contents/MacOS/mur-hub-gui
+    // bundle: /Applications/MuR Hub.app
+    let exe = std::env::current_exe().ok()?;
+    let bundle = exe.parent()?.parent()?.parent()?;
+    if bundle.extension().and_then(|e| e.to_str()) == Some("app") {
+        Some(bundle.to_path_buf())
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn run_lsregister() {
+    const LSREG: &str = "/System/Library/Frameworks/CoreServices.framework/\
+        Frameworks/LaunchServices.framework/Support/lsregister";
+    let Some(bundle) = bundle_path() else { return };
+    let _ = std::process::Command::new(LSREG)
+        .args(["-f", bundle.to_str().unwrap_or("")])
+        .status();
+}
+
+fn mur_home_path() -> PathBuf {
+    std::env::var("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".mur")
+        })
+}
+
+pub fn marker_path(mur_home: &Path) -> PathBuf {
+    mur_home.join(MARKER)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn first_launch_writes_and_reads_marker() {
+        let tmp = TempDir::new().unwrap();
+        assert!(!tmp.path().join(MARKER).exists());
+        std::fs::write(marker_path(tmp.path()), "").unwrap();
+        assert!(tmp.path().join(MARKER).exists());
+    }
+
+    #[test]
+    fn in_applications_returns_bool() {
+        // Just verify it doesn't panic.
+        let _ = check_in_applications();
+    }
+}

--- a/mur-hub-gui/src-tauri/src/onboarding/mod.rs
+++ b/mur-hub-gui/src-tauri/src/onboarding/mod.rs
@@ -1,3 +1,6 @@
+pub mod first_launch;
+pub use first_launch::{check_first_launch, mark_first_launch_done};
+
 use mur_common::agent::{AgentAppearance, BehaviorPreset, RenderStatus};
 use mur_common::hub::preset_loader::{default_blob, find_preset};
 use mur_common::hub::style_preset::PresetFamily;

--- a/mur-hub-gui/src-tauri/tauri.conf.json
+++ b/mur-hub-gui/src-tauri/tauri.conf.json
@@ -41,7 +41,16 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["app"],
+    "targets": ["app", "dmg"],
+    "fileAssociations": [
+      {
+        "ext": ["muragent"],
+        "name": "MuR Agent Package",
+        "description": "A portable MuR agent bundle",
+        "mimeType": "application/vnd.mur.agent",
+        "role": "Viewer"
+      }
+    ],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -297,6 +297,7 @@ export function DashboardApp() {
   const [presetImportOpen, setPresetImportOpen] = useState(false);
   const [muragentImportOpen, setMuragentImportOpen] = useState(false);
   const [muragentImportPath, setMuragentImportPath] = useState<string | undefined>(undefined);
+  const [showAppsBanner, setShowAppsBanner] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
 
   // Build a lookup map for runtime statuses.
@@ -328,6 +329,20 @@ export function DashboardApp() {
     };
   }, []);
 
+  // First-launch check: show banner if not running from /Applications
+  useEffect(() => {
+    invoke<{ is_first_launch: boolean; in_applications: boolean }>(
+      "check_first_launch"
+    ).then((status) => {
+      if (!status.in_applications) {
+        setShowAppsBanner(true);
+      }
+      if (status.is_first_launch) {
+        invoke("mark_first_launch_done").catch(() => {});
+      }
+    }).catch(() => {});
+  }, []);
+
   // ⌘K focus search.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -350,7 +365,21 @@ export function DashboardApp() {
   return (
     <div className="dashboard-root">
       <Sidebar activeCategory={activeCategory} agents={agents} onSelect={setActiveCategory} />
-      <div className="dashboard-main">        <div className="toolbar">
+      <div className="dashboard-main">        {showAppsBanner && (
+          <div className="onboarding-banner">
+            <span>
+              Move MuR Hub to your <strong>Applications</strong> folder so .muragent files open here automatically.
+            </span>
+            <button
+              className="toolbar-btn"
+              onClick={() => setShowAppsBanner(false)}
+              title="Dismiss"
+            >
+              ✕
+            </button>
+          </div>
+        )}
+        <div className="toolbar">
           <button
             className="toolbar-btn"
             onClick={() => setWizardOpen(true)}

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { save } from "@tauri-apps/plugin-dialog";
 import { useAgents } from "../context/AgentContext";
 import type { AgentEntry, AgentRuntimeStatus, RuntimeState } from "../types";
 import { WizardModal } from "./wizard/WizardModal";
@@ -97,6 +98,16 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
       showToast(`Failed: ${e}`),
     );
   }
+  async function handleShare() {
+    const outPath = await save({
+      defaultPath: `${agent.name}.muragent`,
+      filters: [{ name: "MuR Agent", extensions: ["muragent"] }],
+    });
+    if (!outPath) return;
+    invoke<string>("export_muragent_file", { name: agent.name, outPath })
+      .then(() => showToast(`Exported ${agent.name}.muragent`))
+      .catch((e) => showToast(`Export failed: ${e}`));
+  }
 
   function startHold(e: React.MouseEvent) {
     if (e.button !== 0) return;
@@ -182,6 +193,12 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
             title="Stop agent runtime"
           >
             ■ Stop
+          </button>
+          <button
+            onClick={handleShare}
+            title="Export as .muragent to share"
+          >
+            ↑ Share
           </button>
         </div>
       </div>

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -279,6 +279,7 @@ export function DashboardApp() {
   const [wizardOpen, setWizardOpen] = useState(false);
   const [presetImportOpen, setPresetImportOpen] = useState(false);
   const [muragentImportOpen, setMuragentImportOpen] = useState(false);
+  const [muragentImportPath, setMuragentImportPath] = useState<string | undefined>(undefined);
   const searchRef = useRef<HTMLInputElement>(null);
 
   // Build a lookup map for runtime statuses.
@@ -296,6 +297,17 @@ export function DashboardApp() {
     });
     return () => {
       unSelect.then((fn) => fn());
+    };
+  }, []);
+
+  // Listen for .muragent file open events from OS file association / deep-link
+  useEffect(() => {
+    const unlisten = listen<string>("open-muragent-file", (e) => {
+      setMuragentImportPath(e.payload);
+      setMuragentImportOpen(true);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
     };
   }, []);
 
@@ -447,8 +459,10 @@ export function DashboardApp() {
       />
       <MuragentImportModal
         isOpen={muragentImportOpen}
+        initialPath={muragentImportPath}
         onClose={() => {
           setMuragentImportOpen(false);
+          setMuragentImportPath(undefined);
           invoke("list_agents").catch(() => {});
         }}
       />

--- a/mur-hub-gui/ui/src/components/MuragentImportModal.tsx
+++ b/mur-hub-gui/ui/src/components/MuragentImportModal.tsx
@@ -62,6 +62,29 @@ interface InstallReceipt {
   fingerprint_hex: string;
 }
 
+interface ModelHintView {
+  provider: string;
+  name: string;
+  tier: string;
+  min_ram_gb: number;
+  local_capable: boolean;
+}
+
+interface ResolutionView {
+  hint: ModelHintView | null;
+  total_ram_gb: number;
+  apple_silicon: boolean;
+  ollama_present: boolean;
+  recommendation: "local" | "cloud" | "cloud_or_smaller_local" | "neutral_menu";
+}
+
+interface ModelChoice {
+  provider: string;
+  model: string;
+  base_url?: string;
+  secret?: string;
+}
+
 const FIRST_TIME_AUTHOR_DELAY_MS = 5_000;
 
 export function MuragentImportModal({ isOpen, onClose }: Props) {
@@ -70,6 +93,9 @@ export function MuragentImportModal({ isOpen, onClose }: Props) {
   const [installing, setInstalling] = useState(false);
   const [receipt, setReceipt] = useState<InstallReceipt | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [resolutionView, setResolutionView] = useState<ResolutionView | null>(null);
+  const [modelApplied, setModelApplied] = useState(false);
+  const [modelError, setModelError] = useState<string | null>(null);
   // Counts down from FIRST_TIME_AUTHOR_DELAY_MS to 0 for first-time authors.
   // Known authors get 0 immediately. -1 means no inspection loaded yet.
   const [delayRemaining, setDelayRemaining] = useState<number>(-1);
@@ -82,6 +108,9 @@ export function MuragentImportModal({ isOpen, onClose }: Props) {
       setInstalling(false);
       setReceipt(null);
       setError(null);
+      setResolutionView(null);
+      setModelApplied(false);
+      setModelError(null);
       setDelayRemaining(-1);
     }
   }, [isOpen]);
@@ -131,10 +160,33 @@ export function MuragentImportModal({ isOpen, onClose }: Props) {
     try {
       const r = await invoke<InstallReceipt>("install_muragent_file", { path });
       setReceipt(r);
+      // Fetch model resolution info for the wizard step
+      try {
+        if (path) {
+          const rv = await invoke<ResolutionView>("model_resolution_view", { path });
+          // Only show the wizard if there's useful info (hint present or non-neutral recommendation)
+          if (rv.hint !== null || rv.recommendation !== "neutral_menu") {
+            setResolutionView(rv);
+          }
+        }
+      } catch {
+        // model_resolution_view is best-effort; failure just skips the wizard step
+      }
     } catch (e) {
       setError(String(e));
     } finally {
       setInstalling(false);
+    }
+  }
+
+  async function applyModelChoice(choice: ModelChoice) {
+    if (!receipt) return;
+    setModelError(null);
+    try {
+      await invoke<string>("apply_agent_model", { slug: receipt.slug, choice });
+      setModelApplied(true);
+    } catch (e) {
+      setModelError(String(e));
     }
   }
 
@@ -181,7 +233,31 @@ export function MuragentImportModal({ isOpen, onClose }: Props) {
             />
           )}
 
-          {receipt && <ReceiptStep receipt={receipt} />}
+          {receipt && !resolutionView && <ReceiptStep receipt={receipt} />}
+          {receipt && resolutionView && !modelApplied && (
+            <>
+              <ReceiptStep receipt={receipt} />
+              <hr style={{ margin: "12px 0", borderColor: "var(--border, #2a2a2a)" }} />
+              <ModelResolutionStep
+                receipt={receipt}
+                view={resolutionView}
+                applied={modelApplied}
+                error={modelError}
+                onApply={applyModelChoice}
+                onSkip={() => setResolutionView(null)}
+              />
+            </>
+          )}
+          {receipt && resolutionView && modelApplied && (
+            <ModelResolutionStep
+              receipt={receipt}
+              view={resolutionView}
+              applied={true}
+              error={null}
+              onApply={() => {}}
+              onSkip={() => {}}
+            />
+          )}
         </div>
 
         {inspection && !receipt && (
@@ -461,6 +537,130 @@ function ReceiptStep({ receipt }: { receipt: InstallReceipt }) {
       <div style={{ fontSize: 12, color: "var(--text-secondary, #888)" }}>
         Trust: <code>{receipt.trust_level}</code> · Fingerprint{" "}
         <code>{receipt.fingerprint_hex}</code>
+      </div>
+    </div>
+  );
+}
+
+// ─── Model resolution step (spec §7.3) ──────────────────────────────────────
+
+function ModelResolutionStep({
+  receipt,
+  view,
+  applied,
+  error,
+  onApply,
+  onSkip,
+}: {
+  receipt: InstallReceipt;
+  view: ResolutionView;
+  applied: boolean;
+  error: string | null;
+  onApply: (choice: ModelChoice) => void;
+  onSkip: () => void;
+}) {
+  const [provider, setProvider] = useState(
+    view.recommendation === "local" ? "ollama" : "anthropic"
+  );
+  const [model, setModel] = useState(
+    view.recommendation === "local"
+      ? (view.hint?.local_capable ? view.hint.name : "llama3.2:3b")
+      : (view.hint?.name ?? "claude-sonnet-4-6")
+  );
+  const [secret, setSecret] = useState("");
+
+  if (applied) {
+    return (
+      <div style={{ padding: "16px 0" }}>
+        <p style={{ color: "var(--success, #4caf50)", marginBottom: 8 }}>
+          ✅ Model configured. <strong>{receipt.display_name}</strong> is ready to use.
+        </p>
+        <p style={{ fontSize: 12, color: "var(--muted, #888)" }}>
+          Change it anytime with <code>mur model add</code> or via Hub settings.
+        </p>
+      </div>
+    );
+  }
+
+  const recLabel: Record<string, string> = {
+    local: "Local model recommended (your hardware can run it)",
+    cloud: "Cloud model recommended (agent was authored against a frontier model)",
+    cloud_or_smaller_local: "Cloud recommended — your RAM may be too low for the original local model",
+    neutral_menu: "Choose a model backend for this agent",
+  };
+
+  return (
+    <div style={{ padding: "8px 0" }}>
+      <p style={{ fontWeight: 600, marginBottom: 4 }}>Set up a model</p>
+      <p style={{ fontSize: 13, color: "var(--muted, #888)", marginBottom: 12 }}>
+        {recLabel[view.recommendation]}
+        {view.hint && (
+          <span>
+            {" "}(original: <code>{view.hint.provider}/{view.hint.name}</code>)
+          </span>
+        )}
+      </p>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <div style={{ display: "flex", gap: 8 }}>
+          <div style={{ flex: 1 }}>
+            <label style={{ fontSize: 12 }}>Provider</label>
+            <input
+              className="input"
+              value={provider}
+              onChange={(e) => setProvider(e.target.value)}
+              placeholder="ollama / anthropic / openai"
+              style={{ width: "100%", marginTop: 2 }}
+            />
+          </div>
+          <div style={{ flex: 2 }}>
+            <label style={{ fontSize: 12 }}>Model</label>
+            <input
+              className="input"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder="llama3.2:3b / claude-sonnet-4-6"
+              style={{ width: "100%", marginTop: 2 }}
+            />
+          </div>
+        </div>
+
+        {provider !== "ollama" && (
+          <div>
+            <label style={{ fontSize: 12 }}>API key (stored in your secret store)</label>
+            <input
+              className="input"
+              type="password"
+              value={secret}
+              onChange={(e) => setSecret(e.target.value)}
+              placeholder="sk-… or env:ANTHROPIC_API_KEY"
+              style={{ width: "100%", marginTop: 2 }}
+            />
+          </div>
+        )}
+
+        {error && (
+          <p style={{ color: "var(--error, #f44336)", fontSize: 12 }}>{error}</p>
+        )}
+      </div>
+
+      <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 12 }}>
+        <button className="toolbar-btn" onClick={onSkip} style={{ color: "var(--muted, #888)" }}>
+          Skip for now
+        </button>
+        <button
+          className="toolbar-btn primary"
+          onClick={() =>
+            onApply({
+              provider,
+              model,
+              secret: secret.trim() || undefined,
+            })
+          }
+          disabled={!provider.trim() || !model.trim()}
+        >
+          Save model
+        </button>
       </div>
     </div>
   );

--- a/mur-hub-gui/ui/src/components/MuragentImportModal.tsx
+++ b/mur-hub-gui/ui/src/components/MuragentImportModal.tsx
@@ -16,6 +16,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 interface Props {
   isOpen: boolean;
   onClose: () => void;
+  initialPath?: string;
 }
 
 interface McpServerView {
@@ -87,7 +88,7 @@ interface ModelChoice {
 
 const FIRST_TIME_AUTHOR_DELAY_MS = 5_000;
 
-export function MuragentImportModal({ isOpen, onClose }: Props) {
+export function MuragentImportModal({ isOpen, onClose, initialPath }: Props) {
   const [path, setPath] = useState<string | null>(null);
   const [inspection, setInspection] = useState<MuragentInspection | null>(null);
   const [installing, setInstalling] = useState(false);
@@ -114,6 +115,24 @@ export function MuragentImportModal({ isOpen, onClose }: Props) {
       setDelayRemaining(-1);
     }
   }, [isOpen]);
+
+  // Auto-inspect when a file path is provided via initialPath (e.g. from OS file open)
+  useEffect(() => {
+    if (!isOpen || !initialPath) return;
+    setPath(initialPath);
+    setError(null);
+    setReceipt(null);
+    invoke<MuragentInspection>("inspect_muragent_file", { path: initialPath })
+      .then((result) => {
+        setInspection(result);
+        if (result.signature_valid && result.trust_status.kind === "first_time_author") {
+          setDelayRemaining(FIRST_TIME_AUTHOR_DELAY_MS);
+        } else {
+          setDelayRemaining(0);
+        }
+      })
+      .catch((e) => setError(String(e)));
+  }, [isOpen, initialPath]);
 
   // 5-second delay tick for first-time-author imports (§7.2 rule 4)
   useEffect(() => {

--- a/mur-hub-gui/ui/src/styles.css
+++ b/mur-hub-gui/ui/src/styles.css
@@ -745,3 +745,18 @@ input {
   line-height: 1;
 }
 .pet-bubble-close:hover { color: #F9FAFB; background: #374151; }
+
+/* ─── First-launch banner ─────────────────────────────────────────────────── */
+.onboarding-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 16px;
+  background: #1e3a5f;
+  border-bottom: 1px solid #2d5a9e;
+  font-size: 13px;
+  color: #dbeafe;
+}
+.onboarding-banner strong { color: #93c5fd; }
+.onboarding-banner .toolbar-btn { padding: 2px 8px; font-size: 12px; }


### PR DESCRIPTION
## Summary

- **Phase A** — `.muragent` file association in `tauri.conf.json` (ext, mimeType, role), `dmg` bundle target, deep-link plugin, single-instance handler, open-file routing (`RunEvent::Opened` on macOS / argv on Windows), auto-load in import modal
- **Phase B** — `--model <ref>` CLI flag for non-interactive `mur agent install`; Hub model resolution wizard step (provider/model/secret fields + recommendation copy) shown after `.muragent` install
- **Phase C** — Hub "Share" button on each agent card: native save dialog → `export_muragent_file` → success toast
- **A-onboarding** — `check_first_launch` + `mark_first_launch_done` Tauri commands; `lsregister -f <bundle>` on macOS first launch; blue banner in Dashboard when not running from `/Applications`

## What's already shipped (not in this PR)

- D-cleanup (`--format=gui/bin` hard-error) — prior commits on main
- `mur-agent-runtime --load` — prior commits on main
- B-data (`model_hint` manifest field + writer + model-class table) — prior commits on main

## Test plan

- [ ] Double-click a `.muragent` file → Hub opens import modal with file pre-loaded
- [ ] `mur agent install test.muragent --model ollama_llama3_2_3b` applies model without prompt
- [ ] Import modal: after install, model resolution wizard step appears with recommendation text; "Save model" writes `model_ref` to profile
- [ ] Grid card "↑ Share" → save dialog → `.muragent` written; `cat ~/.mur/agents/<slug>/profile.yaml` model_hint present
- [ ] First launch (remove `~/.mur/.hub_onboarded`, run from non-Applications path) → blue banner visible; dismiss closes it
- [ ] First launch from `/Applications` → no banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)