### PR TITLE
perf(index): batch OpenAI embeddings + background project indexing

### DIFF
--- a/docs/superpowers/plans/2026-05-31-project-index-background.md
+++ b/docs/superpowers/plans/2026-05-31-project-index-background.md
@@ -1,0 +1,1060 @@
+# Project Index Background Execution + Batch Fix
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `mur project index` taking hours by (1) making `embed_batch` actually batch for OpenAI-compatible providers, and (2) auto-detecting large indexing jobs and running them in background with progress file + desktop notification.
+
+**Architecture:** Three layers: (a) fix `embed_batch` OpenAI path to send all texts in one HTTP request like Ollama already does, (b) add a hidden `project-index-worker` internal subcommand that does the actual work and writes progress/lock files, (c) `project index` CLI auto-detects chunk count > 200 and spawns the worker in background, returning immediately. `mur project status` reads the progress file for live status. Git hook updated to use `--background` for lock-file protection.
+
+**Tech Stack:** Rust (edition 2024), reqwest, serde_json, `osascript` (macOS notification), existing LanceDB + arrow stack.
+
+---
+
+## File Map
+
+| File | Role |
+|------|------|
+| `mur-core/src/store/embedding.rs` | Fix `embed_batch` OpenAI path — true batch API call |
+| `mur-core/src/cmd/reindex.rs` | Switch `cmd_reindex` from per-item `embed()` to `embed_batch()` |
+| `mur-core/src/codebase/mod.rs` | Add `IndexProgress`, `IndexLock`, lock/progress file I/O, background spawn logic, threshold constant |
+| `mur-core/src/cmd/project.rs` | Add `--background`/`--foreground` flags, auto-detect logic, `project-index-worker` hidden subcommand |
+| `mur-core/src/cli/mod.rs` | Add `BackgroundMode` enum + CLI args; add hidden `ProjectIndexWorker` subcommand |
+| `mur-core/src/dispatch.rs` | Wire new subcommand, pass background mode to `cmd_project_index` |
+| `mur-core/src/codebase/mod.rs` (git hook) | Update `ensure_git_hook` to use `--background` |
+
+---
+
+### Task 1: Fix `embed_batch` OpenAI path — true batch API call
+
+**Files:**
+- Modify: `mur-core/src/store/embedding.rs:159-201`
+
+The OpenAI embeddings API accepts `input: string | string[]`. We're sending one string per request. Fix: accept `Vec<String>` and send all at once.
+
+- [ ] **Step 1: Change `OpenAIEmbedRequest.input` to accept `Vec<String>`**
+
+Replace lines 159-163:
+```rust
+#[derive(Serialize)]
+struct OpenAIEmbedRequest {
+    model: String,
+    input: Vec<String>,
+}
+```
+
+- [ ] **Step 2: Add `embed_openai_batch()` function**
+
+Insert after `embed_openai()` (after line 201):
+
+```rust
+async fn embed_openai_batch(
+    texts: &[String],
+    base_url: &str,
+    api_key: &str,
+    model: &str,
+) -> Result<Vec<Vec<f32>>> {
+    if texts.is_empty() {
+        return Ok(Vec::new());
+    }
+    let client = reqwest::Client::new();
+    let url = format!("{}/embeddings", base_url.trim_end_matches('/'));
+    let resp = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .json(&OpenAIEmbedRequest {
+            model: model.into(),
+            input: texts.to_vec(),
+        })
+        .send()
+        .await
+        .with_context(|| format!("calling embed API at {}", url))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Embed API error {} at {}: {}", status, url, body);
+    }
+
+    let data: OpenAIEmbedResponse = resp.json().await.context("parsing embed response")?;
+    let embeddings: Vec<Vec<f32>> = data.data.into_iter().map(|d| d.embedding).collect();
+    if embeddings.len() != texts.len() {
+        anyhow::bail!(
+            "Embed API returned {} embeddings but {} were requested",
+            embeddings.len(),
+            texts.len()
+        );
+    }
+    Ok(embeddings)
+}
+```
+
+- [ ] **Step 3: Wire `embed_openai_batch` into `embed_batch`**
+
+Replace lines 83-89 in `embed_batch`:
+```rust
+// Before:
+EmbeddingProvider::OpenAI { .. } => {
+    let mut results = Vec::with_capacity(texts.len());
+    for text in texts {
+        results.push(embed(text, config).await?);
+    }
+    Ok(results)
+}
+
+// After:
+EmbeddingProvider::OpenAI { api_key, base_url } => {
+    embed_openai_batch(texts, base_url, api_key, &config.model).await
+}
+```
+
+- [ ] **Step 4: Build check**
+
+```bash
+cargo build -p mur-core 2>&1 | head -20
+```
+Expected: compiles cleanly (no signature changes to public API).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/store/embedding.rs
+git commit -m "fix(embed): make embed_batch actually batch for OpenAI-compatible providers
+
+OpenAI embeddings API accepts input: string[] but we were sending one
+string per HTTP request in a loop. Now sends all texts in a single
+batch request, matching the Ollama path behavior.
+
+This is a 10-100x speedup for providers like omlx that use the OpenAI
+API path with large embedding models."
+```
+
+---
+
+### Task 2: Fix `cmd_reindex` to use `embed_batch` instead of per-item `embed`
+
+**Files:**
+- Modify: `mur-core/src/cmd/reindex.rs:43-91`
+
+`cmd_reindex` loops through patterns and workflows one at a time calling `embed()`. Change to collect all texts, call `embed_batch()` once (or in chunks), then pair results back.
+
+- [ ] **Step 1: Replace sequential embed loop with batch**
+
+Replace lines 38-91 (the two for-loops and surrounding variables):
+
+```rust
+    // Collect all texts first
+    struct Item {
+        is_workflow: bool,
+        index: usize,
+        name: String,
+    }
+    let mut texts: Vec<String> = Vec::new();
+    let mut items: Vec<Item> = Vec::new();
+
+    for (i, pattern) in patterns.iter().enumerate() {
+        let mut text = format!(
+            "{}: {}\n{}",
+            pattern.name,
+            pattern.description,
+            pattern.content.as_text()
+        );
+        for att in &pattern.attachments {
+            if !att.description.is_empty() {
+                text.push_str("\n\n");
+                text.push_str(&att.description);
+            }
+        }
+        texts.push(text);
+        items.push(Item { is_workflow: false, index: i, name: pattern.name.clone() });
+    }
+
+    let pattern_count = patterns.len();
+    for (i, workflow) in workflows.iter().enumerate() {
+        let text = format!(
+            "{}: {}\n{}",
+            workflow.name,
+            workflow.description,
+            workflow.content.as_text()
+        );
+        texts.push(text);
+        items.push(Item { is_workflow: true, index: i, name: workflow.name.clone() });
+    }
+
+    let total = texts.len();
+    let mut errors = 0;
+
+    // Batch embed — use same batch size as project index
+    const EMBED_BATCH: usize = 200;
+    let mut all_embeddings: Vec<Vec<f32>> = Vec::with_capacity(total);
+
+    for batch_start in (0..total).step_by(EMBED_BATCH) {
+        let batch_end = (batch_start + EMBED_BATCH).min(total);
+        let batch_texts = &texts[batch_start..batch_end];
+        match embed_batch(&batch_texts.iter().cloned().collect::<Vec<_>>(), &config).await {
+            Ok(batch_embs) => {
+                all_embeddings.extend(batch_embs);
+                println!("  {}/{} embedded...", batch_end, total);
+            }
+            Err(e) => {
+                eprintln!("  ⚠️  batch {}-{} embedding failed: {}", batch_start, batch_end, e);
+                errors += batch_end - batch_start;
+                // Fill with zeros so indices stay aligned
+                for _ in batch_start..batch_end {
+                    all_embeddings.push(vec![0.0; config.dimensions]);
+                }
+            }
+        }
+    }
+
+    // Pair embeddings back to patterns/workflows
+    let mut indexed_patterns: Vec<(Pattern, Vec<f32>)> = Vec::new();
+    let mut indexed_workflows: Vec<(Workflow, Vec<f32>)> = Vec::new();
+
+    for (i, item) in items.iter().enumerate() {
+        if i < all_embeddings.len() && !all_embeddings[i].is_empty() && all_embeddings[i][0] != 0.0 || all_embeddings[i].len() > 1 {
+            if item.is_workflow {
+                indexed_workflows.push((workflows[item.index].clone(), all_embeddings[i].clone()));
+            } else {
+                indexed_patterns.push((patterns[item.index].clone(), all_embeddings[i].clone()));
+            }
+        }
+    }
+```
+
+Wait — the zero-check logic is fragile. Let me use a simpler approach: track which indices succeeded.
+
+Actually, let me simplify. Just collect into a Vec<Option<Vec<f32>>>:
+
+```rust
+    // Collect all texts
+    let mut texts: Vec<String> = Vec::with_capacity(patterns.len() + workflows.len());
+
+    for pattern in &patterns {
+        let mut text = format!(
+            "{}: {}\n{}",
+            pattern.name,
+            pattern.description,
+            pattern.content.as_text()
+        );
+        for att in &pattern.attachments {
+            if !att.description.is_empty() {
+                text.push_str("\n\n");
+                text.push_str(&att.description);
+            }
+        }
+        texts.push(text);
+    }
+    for workflow in &workflows {
+        let text = format!(
+            "{}: {}\n{}",
+            workflow.name,
+            workflow.description,
+            workflow.content.as_text()
+        );
+        texts.push(text);
+    }
+
+    let total = texts.len();
+    let mut embeddings: Vec<Option<Vec<f32>>> = vec![None; total];
+    let mut errors = 0;
+
+    const EMBED_BATCH: usize = 200;
+    for batch_start in (0..total).step_by(EMBED_BATCH) {
+        let batch_end = (batch_start + EMBED_BATCH).min(total);
+        let batch: Vec<String> = texts[batch_start..batch_end].to_vec();
+        match embed_batch(&batch, &config).await {
+            Ok(batch_embs) => {
+                for (j, emb) in batch_embs.into_iter().enumerate() {
+                    embeddings[batch_start + j] = Some(emb);
+                }
+                println!("  {}/{} embedded...", batch_end, total);
+            }
+            Err(e) => {
+                eprintln!("  ⚠️  batch {}-{} embedding failed: {}", batch_start, batch_end, e);
+                errors += batch_end - batch_start;
+            }
+        }
+    }
+
+    // Pair results back
+    let mut indexed_patterns = Vec::new();
+    let mut indexed_workflows = Vec::new();
+
+    for (i, pattern) in patterns.iter().enumerate() {
+        if let Some(emb) = embeddings[i].take() {
+            indexed_patterns.push((pattern.clone(), emb));
+        }
+    }
+    for (i, workflow) in workflows.iter().enumerate() {
+        if let Some(emb) = embeddings[patterns.len() + i].take() {
+            indexed_workflows.push((workflow.clone(), emb));
+        }
+    }
+```
+
+Also remove the now-unused `use crate::store::embedding::{EmbeddingConfig, embed};` import — change to `embed_batch`:
+
+Line 7: change `embed` to `embed_batch` in the import.
+
+- [ ] **Step 2: Build check**
+
+```bash
+cargo build -p mur-core 2>&1 | head -20
+```
+Expected: compiles cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-core/src/cmd/reindex.rs
+git commit -m "perf(reindex): use embed_batch instead of sequential per-item embed
+
+cmd_reindex was calling embed() once per pattern/workflow in a loop.
+With OpenAI-compatible providers this meant N sequential HTTP requests.
+Now collects all texts and calls embed_batch() in chunks of 200."
+```
+
+---
+
+### Task 3: Add `IndexProgress` and `IndexLock` types + lock file I/O
+
+**Files:**
+- Modify: `mur-core/src/codebase/mod.rs`
+
+Add types for progress tracking and lock file. Reuse the existing `pid_alive()` from `mur_common::lock_file` for lock validation.
+
+- [ ] **Step 1: Add new types after `DiscoveredIndex` (after line 67)**
+
+```rust
+/// Written during background indexing so `mur project status` can show live progress.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexProgress {
+    pub status: IndexStatus,
+    pub total_chunks: usize,
+    pub done_chunks: usize,
+    pub errors: usize,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexStatus {
+    Running,
+    Done,
+    Error,
+}
+
+/// Lightweight lock file to prevent concurrent indexing of the same project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexLock {
+    pub pid: u32,
+    pub project_name: String,
+    pub started_at: String,
+}
+```
+
+- [ ] **Step 2: Add const and path helpers to `CodebaseIndex` impl block (after line 95)**
+
+```rust
+/// Chunks above this threshold auto-trigger background mode.
+pub const BACKGROUND_CHUNK_THRESHOLD: usize = 200;
+
+fn lock_path(&self) -> PathBuf {
+    self.lance_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("{}.lock", self.project_name))
+}
+
+fn progress_path(&self) -> PathBuf {
+    self.lance_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(format!("{}.progress.json", self.project_name))
+}
+```
+
+- [ ] **Step 3: Add lock file methods to `CodebaseIndex`**
+
+```rust
+/// Try to acquire the index lock. Returns Ok(true) if we got it, Ok(false) if another
+/// live process holds it, Err if I/O fails.
+pub fn try_acquire_lock(&self) -> Result<bool> {
+    let path = self.lock_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Check existing lock
+    if path.exists() {
+        if let Ok(data) = std::fs::read_to_string(&path) {
+            if let Ok(lock) = serde_json::from_str::<IndexLock>(&data) {
+                if mur_common::lock_file::pid_alive(lock.pid) {
+                    return Ok(false); // Another live process holds the lock
+                }
+                // Stale lock — pid is dead, we'll overwrite
+            }
+        }
+    }
+    let lock = IndexLock {
+        pid: std::process::id(),
+        project_name: self.project_name.clone(),
+        started_at: chrono::Utc::now().to_rfc3339(),
+    };
+    std::fs::write(&path, serde_json::to_string(&lock)?)?;
+    Ok(true)
+}
+
+pub fn release_lock(&self) {
+    let path = self.lock_path();
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Write progress for `mur project status` to read.
+pub fn write_progress(&self, progress: &IndexProgress) -> Result<()> {
+    let path = self.progress_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, serde_json::to_string(progress)?)?;
+    Ok(())
+}
+
+/// Read progress file if it exists.
+pub fn read_progress(&self) -> Option<IndexProgress> {
+    let path = self.progress_path();
+    let data = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+```
+
+- [ ] **Step 4: Build check**
+
+```bash
+cargo build -p mur-core 2>&1 | head -20
+```
+Expected: compiles. `IndexProgress`/`IndexLock` not yet used, so allow dead_code warnings temporarily.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/codebase/mod.rs
+git commit -m "feat(index): add IndexProgress, IndexLock types and lock file I/O
+
+Adds:
+- IndexProgress: written during background indexing, read by `mur project status`
+- IndexLock: lightweight PID lock to prevent concurrent indexing
+- try_acquire_lock / release_lock / write_progress / read_progress methods
+- BACKGROUND_CHUNK_THRESHOLD constant (200 chunks)"
+```
+
+---
+
+### Task 4: Add background worker subcommand + CLI flags
+
+**Files:**
+- Modify: `mur-core/src/cli/mod.rs`
+- Modify: `mur-core/src/dispatch.rs`
+- Modify: `mur-core/src/cmd/project.rs`
+
+Add `--background`/`--foreground` flags and a hidden `ProjectIndexWorker` subcommand that does the actual work when spawned.
+
+- [ ] **Step 1: Add `BackgroundMode` to CLI args in `cli/mod.rs`**
+
+Find the `ProjectAction::Index` variant. Add fields:
+
+```rust
+// In ProjectAction::Index:
+ProjectAction::Index {
+    path: Option<String>,
+    rebuild: bool,
+    quiet: bool,
+    /// None = auto-detect, Some(true) = force background, Some(false) = force foreground
+    background: Option<bool>,
+}
+```
+
+Also add the hidden worker subcommand:
+```rust
+// In ProjectAction enum, add:
+ProjectAction::IndexWorker {
+    project_name: String,
+    project_path: String,
+    rebuild: bool,
+}
+```
+
+Update the clap derive for `ProjectAction::Index`:
+```rust
+Index {
+    /// Project path (defaults to current directory)
+    path: Option<String>,
+    /// Force full rebuild ignoring mtime cache
+    #[arg(long)]
+    rebuild: bool,
+    /// Less output
+    #[arg(long)]
+    quiet: bool,
+    /// Run indexing in background (default: auto-detect based on chunk count)
+    #[arg(long, conflicts_with = "foreground")]
+    background: bool,
+    /// Force foreground execution even for large projects
+    #[arg(long, conflicts_with = "background")]
+    foreground: bool,
+},
+```
+
+And the hidden worker:
+```rust
+/// Internal: spawned by `project index --background`. Not shown in help.
+#[command(hide = true)]
+IndexWorker {
+    project_name: String,
+    project_path: String,
+    #[arg(long)]
+    rebuild: bool,
+},
+```
+
+- [ ] **Step 2: Update `dispatch.rs` to pass new flags**
+
+Update the match arm for `ProjectAction::Index`:
+```rust
+ProjectAction::Index {
+    path,
+    rebuild,
+    quiet,
+    background,
+} => {
+    let mode = match (background, foreground) {
+        (true, _) => BackgroundMode::ForceBackground,
+        (_, true) => BackgroundMode::ForceForeground,
+        (false, false) => BackgroundMode::Auto,
+    };
+    cmd::project::cmd_project_index(path, rebuild, quiet, mode).await?
+}
+```
+
+Add dispatch for the worker:
+```rust
+ProjectAction::IndexWorker {
+    project_name,
+    project_path,
+    rebuild,
+} => cmd::project::cmd_project_index_worker(&project_name, &project_path, rebuild).await?,
+```
+
+- [ ] **Step 3: Add `BackgroundMode` enum and updated `cmd_project_index` in `cmd/project.rs`**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BackgroundMode {
+    /// Auto-detect: background if chunks > BACKGROUND_CHUNK_THRESHOLD
+    Auto,
+    /// Force background execution
+    ForceBackground,
+    /// Force foreground execution
+    ForceForeground,
+}
+```
+
+Rewrite `cmd_project_index`:
+```rust
+pub(crate) async fn cmd_project_index(
+    path: Option<String>,
+    rebuild: bool,
+    quiet: bool,
+    bg_mode: BackgroundMode,
+) -> Result<()> {
+    let project_path = match &path {
+        Some(p) => expand_tilde(p),
+        None => std::env::current_dir()?,
+    };
+    let project_path = project_path.canonicalize().unwrap_or(project_path);
+
+    if !project_path.join(".git").exists() {
+        anyhow::bail!(
+            "Not a git repository: {}\n  mur project index requires a git repo",
+            project_path.display()
+        );
+    }
+
+    let project_name = project_name_from_path(&project_path);
+    let cfg = load_config()?;
+    let embed_config = EmbeddingConfig::from_config(&cfg);
+    let index = CodebaseIndex::new(&project_name, &project_path);
+
+    // Determine whether to run in background
+    let run_in_background = match bg_mode {
+        BackgroundMode::ForceBackground => true,
+        BackgroundMode::ForceForeground => false,
+        BackgroundMode::Auto => {
+            // Quick scan to estimate chunk count
+            let files = scan_project(&project_path);
+            let estimated_chunks: usize = files.iter().map(|f| {
+                let lines = f.content.lines().count();
+                if lines < 50 { 1 } else { (lines / 60).max(1) + 1 }
+            }).sum();
+            estimated_chunks > BACKGROUND_CHUNK_THRESHOLD
+        }
+    };
+
+    if run_in_background {
+        // Check lock
+        if !index.try_acquire_lock()? {
+            eprintln!(
+                "Indexing already in progress for '{}' (lock held by another process).",
+                project_name
+            );
+            eprintln!("  Check status: mur project status");
+            return Ok(());
+        }
+
+        // Spawn worker subprocess
+        let mur_bin = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("mur"));
+        let mut cmd = std::process::Command::new(&mur_bin);
+        cmd.args(["project", "index-worker", &project_name, &project_path.display().to_string()]);
+        if rebuild {
+            cmd.arg("--rebuild");
+        }
+        cmd.stdout(std::process::Stdio::null());
+        cmd.stderr(std::process::Stdio::null());
+        cmd.stdin(std::process::Stdio::null());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            cmd.process_group(0); // Detach from parent process group
+        }
+
+        let child = cmd.spawn().with_context(|| "spawning background index worker")?;
+        let pid = child.id();
+
+        if !quiet {
+            eprintln!(
+                "Indexing '{}' in background (PID: {}). {} chunks estimated.",
+                project_name, pid, estimated_chunks
+            );
+            eprintln!("  Check progress: mur project status");
+        }
+
+        // Note: lock file already written by try_acquire_lock() with OUR pid.
+        // But the worker has a different pid! Overwrite with the child's pid.
+        let lock = IndexLock {
+            pid,
+            project_name: project_name.clone(),
+            started_at: chrono::Utc::now().to_rfc3339(),
+        };
+        let lock_path = index.lock_path();
+        std::fs::write(&lock_path, serde_json::to_string(&lock)?)?;
+
+        // Write initial progress
+        index.write_progress(&IndexProgress {
+            status: IndexStatus::Running,
+            total_chunks: estimated_chunks,
+            done_chunks: 0,
+            errors: 0,
+            started_at: chrono::Utc::now().to_rfc3339(),
+            finished_at: None,
+            error_message: None,
+        })?;
+
+        return Ok(());
+    }
+
+    // ── Foreground path (existing behavior) ──
+    if !quiet {
+        eprintln!("Indexing {} ({})...", project_name, project_path.display());
+    }
+
+    let stats = index
+        .build(&embed_config, rebuild, |done, total| {
+            if !quiet && total > 0 {
+                eprint!("\r  Embedding {}/{} chunks...", done, total);
+            }
+        })
+        .await?;
+
+    if !quiet {
+        eprintln!();
+        eprintln!(
+            "  {} files, {} chunks, {} changed, {} skipped ({:.1}s)",
+            stats.files_indexed,
+            stats.chunks_created,
+            stats.files_changed,
+            stats.files_skipped,
+            stats.duration_ms as f64 / 1000.0
+        );
+    }
+
+    ensure_git_hook(&project_path, quiet)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Add `cmd_project_index_worker` function**
+
+```rust
+/// Internal: runs the actual indexing work when spawned in background mode.
+pub(crate) async fn cmd_project_index_worker(
+    project_name: &str,
+    project_path_str: &str,
+    rebuild: bool,
+) -> Result<()> {
+    let project_path = PathBuf::from(project_path_str);
+    let cfg = load_config()?;
+    let embed_config = EmbeddingConfig::from_config(&cfg);
+    let index = CodebaseIndex::new(project_name, &project_path);
+
+    // Build with progress callbacks that write to the progress file
+    let build_result = index
+        .build(&embed_config, rebuild, |done, total| {
+            let progress = IndexProgress {
+                status: IndexStatus::Running,
+                total_chunks: total,
+                done_chunks: done,
+                errors: 0,
+                started_at: String::new(), // not used for running updates
+                finished_at: None,
+                error_message: None,
+            };
+            let _ = index.write_progress(&progress);
+        })
+        .await;
+
+    match build_result {
+        Ok(stats) => {
+            let progress = IndexProgress {
+                status: IndexStatus::Done,
+                total_chunks: stats.chunks_created,
+                done_chunks: stats.chunks_created,
+                errors: 0,
+                started_at: String::new(),
+                finished_at: Some(chrono::Utc::now().to_rfc3339()),
+                error_message: None,
+            };
+            let _ = index.write_progress(&progress);
+            index.release_lock();
+
+            // Desktop notification
+            send_notification(
+                &format!("mur: {} indexed", project_name),
+                &format!(
+                    "{} files, {} chunks in {:.1}s",
+                    stats.files_indexed,
+                    stats.chunks_created,
+                    stats.duration_ms as f64 / 1000.0
+                ),
+            );
+        }
+        Err(e) => {
+            let progress = IndexProgress {
+                status: IndexStatus::Error,
+                total_chunks: 0,
+                done_chunks: 0,
+                errors: 1,
+                started_at: String::new(),
+                finished_at: Some(chrono::Utc::now().to_rfc3339()),
+                error_message: Some(e.to_string()),
+            };
+            let _ = index.write_progress(&progress);
+            index.release_lock();
+
+            send_notification(
+                &format!("mur: {} index failed", project_name),
+                &format!("Error: {:.100}", e),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Send a desktop notification. macOS uses osascript; Linux uses notify-send if available.
+fn send_notification(title: &str, message: &str) {
+    #[cfg(target_os = "macos")]
+    {
+        let script = format!(
+            "display notification \"{}\" with title \"{}\"",
+            message.replace('"', "\\\""),
+            title.replace('"', "\\\"")
+        );
+        let _ = std::process::Command::new("osascript")
+            .args(["-e", &script])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // Fallback: terminal bell + stderr
+        eprintln!("\n\x07{}: {}", title, message);
+        // Try notify-send on Linux
+        #[cfg(target_os = "linux")]
+        {
+            let _ = std::process::Command::new("notify-send")
+                .args([title, message])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn();
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Add imports to `cmd/project.rs`**
+
+Add to existing imports:
+```rust
+use crate::codebase::{CodebaseIndex, IndexProgress, IndexStatus, IndexLock, BACKGROUND_CHUNK_THRESHOLD};
+use std::path::PathBuf;
+```
+
+- [ ] **Step 6: Build check**
+
+```bash
+cargo build -p mur-core 2>&1
+```
+Expected: compiles. Fix any missing imports or type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-core/src/cli/mod.rs mur-core/src/dispatch.rs mur-core/src/cmd/project.rs
+git commit -m "feat(index): add --background/--foreground flags with auto-detect
+
+- BackgroundMode enum: Auto / ForceBackground / ForceForeground
+- Auto-detect: estimate chunk count from file scan; if > 200, spawn worker
+- Hidden `project index-worker` subcommand for the background process
+- Worker writes progress to .progress.json and sends macOS notification on completion
+- Lock file prevents concurrent indexing of the same project"
+```
+
+---
+
+### Task 5: Update `mur project status` to show live background progress
+
+**Files:**
+- Modify: `mur-core/src/cmd/project.rs` (`cmd_project_status` function)
+
+- [ ] **Step 1: Update `cmd_project_status` to read progress file**
+
+Replace the existing `cmd_project_status` function:
+
+```rust
+pub(crate) async fn cmd_project_status(path: Option<String>) -> Result<()> {
+    let project_path = match &path {
+        Some(p) => expand_tilde(p),
+        None => std::env::current_dir()?,
+    };
+    let project_path = project_path.canonicalize().unwrap_or(project_path);
+    let project_name = project_name_from_path(&project_path);
+    let index = CodebaseIndex::new(&project_name, &project_path);
+
+    let has_db = index.lance_path().exists();
+    let stats = index.stats_async().await?;
+
+    println!("Project: {}", project_name);
+    println!("  Path: {}", project_path.display());
+
+    // Check if a background index is running
+    let lock_path = index.lock_path();
+    if lock_path.exists() {
+        if let Ok(data) = std::fs::read_to_string(&lock_path) {
+            if let Ok(lock) = serde_json::from_str::<IndexLock>(&data) {
+                if mur_common::lock_file::pid_alive(lock.pid) {
+                    // Live background process — show progress
+                    if let Some(progress) = index.read_progress() {
+                        let pct = if progress.total_chunks > 0 {
+                            (progress.done_chunks as f64 / progress.total_chunks as f64) * 100.0
+                        } else {
+                            0.0
+                        };
+                        println!("  Status: indexing in background (PID: {})", lock.pid);
+                        println!("  Progress: {}/{} chunks ({:.0}%)",
+                            progress.done_chunks, progress.total_chunks, pct);
+                        if progress.errors > 0 {
+                            println!("  Errors: {}", progress.errors);
+                        }
+                    } else {
+                        println!("  Status: indexing in background (PID: {})", lock.pid);
+                    }
+                    return Ok(());
+                } else {
+                    // Stale lock — process died
+                    if let Some(progress) = index.read_progress() {
+                        match progress.status {
+                            IndexStatus::Done => {
+                                println!("  Last index: completed");
+                            }
+                            IndexStatus::Error => {
+                                println!("  Last index: failed");
+                                if let Some(ref msg) = progress.error_message {
+                                    println!("  Error: {}", msg);
+                                }
+                            }
+                            IndexStatus::Running => {
+                                println!("  Last index: interrupted (stale lock, PID {} no longer alive)", lock.pid);
+                            }
+                        }
+                    } else {
+                        println!("  Last index: unknown (stale lock)");
+                    }
+                }
+            }
+        }
+    }
+
+    println!("  Indexed: {}", if has_db { "yes" } else { "no" });
+    if has_db {
+        println!("  Chunks: {}", stats.chunks_created);
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Build check**
+
+```bash
+cargo build -p mur-core 2>&1
+```
+Expected: compiles.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-core/src/cmd/project.rs
+git commit -m "feat(status): show live background indexing progress in `mur project status`
+
+Reads .lock and .progress.json files to display:
+- Live progress (% done, chunk count) when indexing is running
+- Completion/error status for finished background runs
+- Stale lock detection for crashed/interrupted runs"
+```
+
+---
+
+### Task 6: Update `ensure_git_hook` to use `--background`
+
+**Files:**
+- Modify: `mur-core/src/codebase/mod.rs:594-631`
+
+- [ ] **Step 1: Change hook to use `--background` flag**
+
+Replace line 609:
+```rust
+// Before:
+"{} project index \"{}\" --quiet &\n"
+
+// After:
+"{} project index \"{}\" --quiet --background\n"
+```
+
+The `--background` flag already handles: spawning a subprocess (so no `&` needed), lock file protection (prevents concurrent runs), and notification on completion. The `--quiet` suppresses the "Indexing in background..." message during git commit.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add mur-core/src/codebase/mod.rs
+git commit -m "fix(hook): use --background flag in git post-commit hook
+
+--background provides lock file protection against concurrent indexing
+and desktop notification on completion. No more bare `&` backgrounding."
+```
+
+---
+
+### Task 7: End-to-end smoke test
+
+- [ ] **Step 1: Build release binary**
+
+```bash
+cargo build --release -p mur-core 2>&1 | tail -5
+```
+Expected: builds successfully.
+
+- [ ] **Step 2: Test foreground small project**
+
+```bash
+# Create a tiny test repo
+cd /tmp
+mkdir test-mur-index && cd test-mur-index
+git init
+echo 'fn main() { println!("hello"); }' > main.rs
+git add main.rs && git commit -m "init"
+
+# Run index (should be foreground — tiny project)
+./target/release/mur project index --foreground
+```
+Expected: completes in foreground, shows progress, installs git hook.
+
+- [ ] **Step 3: Test background mode (force)**
+
+```bash
+./target/release/mur project index --background
+```
+Expected: prints "Indexing 'test-mur-index' in background (PID: X)", returns immediately.
+
+- [ ] **Step 4: Test `mur project status` with live progress**
+
+```bash
+./target/release/mur project status
+```
+Expected: shows "Status: indexing in background (PID: X)" with progress.
+
+- [ ] **Step 5: Test lock file prevents concurrent runs**
+
+```bash
+./target/release/mur project index --background
+# Should print "Indexing already in progress"
+```
+Expected: second run detects lock and refuses.
+
+- [ ] **Step 6: Test background completion notification**
+
+Wait for the background process to finish. macOS should show notification "mur: test-mur-index indexed".
+
+- [ ] **Step 7: Test `mur project status` after completion**
+
+```bash
+./target/release/mur project status
+```
+Expected: shows "Indexed: yes" with chunk count.
+
+- [ ] **Step 8: Run existing tests**
+
+```bash
+cargo test -p mur-core -- codebase 2>&1
+cargo test -p mur-core -- store::embedding 2>&1
+cargo test -p mur-core -- store::vector 2>&1
+```
+Expected: all pass.
+
+- [ ] **Step 9: Full test suite**
+
+```bash
+cargo test --workspace 2>&1 | tail -20
+```
+Expected: all tests pass.
+
+- [ ] **Step 10: Commit any test fixes**
+
+```bash
+git add -A
+git commit -m "test: add smoke test for project index background mode"
+```
+
+---
+
+## Post-Implementation
+
+After all tasks are done:
+
+```bash
+# Full verification
+cargo build --release -p mur-core
+cargo test --workspace
+cargo clippy --workspace -- -D warnings
+```

--- a/docs/superpowers/specs/2026-05-31-agent-action-pipeline-design.md
+++ b/docs/superpowers/specs/2026-05-31-agent-action-pipeline-design.md
@@ -1,0 +1,600 @@
+# Agent Action Pipeline — Design Spec
+
+> **Date**: 2026-05-31
+> **Status**: Draft
+> **Scope**: Agent platform enhancement — file notification + deletion safety + task queue (Block A)
+
+## Overview
+
+Unify three agent UX features into a single **Action Pipeline**: file/email notification with voice commands (A1), deletion confirmation with configurable delay (A2), and a user-facing task queue with pause/cancel (A3).
+
+These are not independent features — they are phases of the same value chain: **ingest → queue → execute → notify**. The pipeline design ensures they compose naturally rather than duplicating infrastructure.
+
+### Research Foundation
+
+Design validated against 2025–2026 industry best practices:
+
+- **File handling UX**: Multi-surface notification (badge + toast + OS notify), review-before-execute, structured notification metadata. Sources: [Smashing Magazine 2026](https://shop.smashingmagazine.com/2026/05/practical-interface-patterns-ai-transparency/), [Jacar](https://jacar.es/en/diseno-ui-agentes/), [Courier 2026](https://www.courier.com/blog/your-notifications-now-have-two-audiences-humans-and-ai-agents/)
+- **Deletion safety**: Archive-don't-delete (Trash), two-phase protocol (never propose+execute same-turn), schema-level enforcement (batch limits, no wildcards), deterministic policy enforcement. Sources: [Conseca (Google, HOTOS '25)](https://sigops.org/s/conferences/hotos/2025/papers/hotos25-100.pdf), [agent-safe-delete](https://github.com/ckckck/agent-safe-delete), [Replit Snapshot Engine](https://blog.replit.com/inside-replits-snapshot-engine), [Safe File Deletion MCP](https://www.npmjs.com/package/@mizunashi_mana/safe-file-deletion-mcp)
+- **Task queue UX**: Three-state execution row (pause/cancel/resume), dynamic checklist over progress bar, checkpoint-based pausing, AG-UI event model. Sources: [Morae (UIST '25)](https://ar5iv.labs.arxiv.org/html/2508.21456), [AgentField #243](https://github.com/Agent-Field/agentfield/issues/243), [AG-UI Protocol](https://futureagi.com/blog/agentic-ux-webinar-2025/#hero), [Autopoiesis #614](https://github.com/DavSimFel/autopoiesis/issues/614)
+- **Capability declaration**: Declarative manifest with scoped permissions, mime-type filtering, structured action definitions. Sources: [Agents.md](https://www.remio.ai/post/what-is-agents-md-a-complete-guide-to-the-new-ai-coding-agent-standard-in-2025), [OpenPort Protocol](https://ar5iv.labs.arxiv.org/html/2602.20196), [Claude Code Permission Model](https://skywork.ai/blog/permission-model-claude-code-vs-code-jetbrains-cli/)
+
+## Architecture
+
+### Pipeline Overview
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                    Agent Action Pipeline                          │
+│                                                                  │
+│  Phase 1: INGEST       Phase 2: QUEUE     Phase 3: EXEC   Phase 4: NOTIFY
+│  ┌──────────────┐    ┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+│  │ PendingStore │ ─→ │  TaskQueue   │→ │  Supervisor  │→ │  Aggregator  │
+│  │              │    │              │  │  ┌──────────┐ │  │              │
+│  │ file dropped │    │ prioritise   │  │  │TrashGuard│ │  │ badge update │
+│  │ paste/clip   │    │ throttle     │  │  └──────────┘ │  │ OS notify    │
+│  │ share URL    │    │ state mach.  │  │  dispatch     │  │ chat output  │
+│  └──────────────┘    └──────────────┘  └──────────────┘  └──────────────┘
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────┐    │
+│  │               Shared Ledger (JSONL)                       │    │
+│  │  <agent_home>/actions/ledger/YYYY-MM-DD.jsonl            │    │
+│  └──────────────────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Design Decision: Unified Pipeline over Per-Feature Modules
+
+Three architectural approaches were evaluated:
+
+| Approach | Integration | Code volume | Extensibility | Chosen |
+|----------|-------------|-------------|---------------|--------|
+| Extend existing systems independently | Poor | Minimal | Low | |
+| New subsystem per feature | Manual coordination | Highest | High | |
+| **Unified Action Pipeline** | **Native** | **Medium** | **Highest** | ✅ |
+
+The pipeline was chosen because A1, A2, A3 are phases of the same chain (ingest → queue → execute → notify), share a common ledger, and a shared state model eliminates duplication. Future features (agent roles, trigger modes, flow editor) extend by adding phases or hooks.
+
+## Data Model
+
+### Core Types
+
+```rust
+// ── Phase 1: Ingestion ──
+
+struct PendingItem {
+    id: Uuid,
+    source: ItemSource,
+    files: Vec<PendingFile>,
+    created_at: DateTime<Utc>,
+    status: PendingStatus,
+}
+
+enum ItemSource {
+    DragDrop { paths: Vec<PathBuf> },
+    Clipboard { mime_type: String },
+    ShareUrl { url: String, kind: ShareKind },
+}
+
+struct PendingFile {
+    path: PathBuf,
+    mime_type: String,
+    size_bytes: u64,
+    thumbnail_path: Option<PathBuf>,
+}
+
+enum PendingStatus {
+    AwaitingSelection,
+    Selected { action_id: String },
+    Expired,
+}
+
+// ── Phase 2: Task Queue ──
+
+struct Task {
+    id: Uuid,
+    pending_item_id: Uuid,
+    action: Action,
+    state: TaskState,
+    steps: Vec<TaskStep>,
+    created_at: DateTime<Utc>,
+    started_at: Option<DateTime<Utc>>,
+    completed_at: Option<DateTime<Utc>>,
+    timeout_seconds: u32,
+}
+
+struct Action {
+    id: String,                   // matches capabilities.file_actions[].id
+    label: String,
+    user_prompt: Option<String>,  // filled for ask_me
+}
+
+enum TaskState {
+    Queued,
+    Running,
+    Paused,
+    Completed { outcome: TaskOutcome },
+    Cancelled,
+}
+
+enum TaskOutcome {
+    Success { outputs: Vec<ActionOutput> },
+    PartialSuccess { succeeded: u32, failed: u32 },
+    Failed { error: String },
+}
+
+struct ActionOutput {
+    kind: OutputKind,             // file | chat_message | both
+    file_path: Option<PathBuf>,
+    chat_content: Option<String>,
+}
+
+struct TaskStep {
+    index: u32,
+    label: String,                // agent-defined: "Reading file..."
+    state: StepState,             // pending | running | done | failed
+    started_at: Option<DateTime<Utc>>,
+    completed_at: Option<DateTime<Utc>>,
+}
+
+// ── Phase 3: Deletion Safety ──
+
+struct TrashEntry {
+    id: Uuid,
+    original_path: PathBuf,
+    trash_path: PathBuf,          // <agent_home>/trash/{timestamp}_{filename}
+    file_size_bytes: u64,
+    created_by_task_id: Uuid,
+    created_at: DateTime<Utc>,
+    expires_at: DateTime<Utc>,    // created_at + deletion.ttl_minutes
+    status: TrashStatus,
+    restore_metadata: RestoreMeta,
+}
+
+enum TrashStatus {
+    Pending,
+    Restored,
+    PermDeleted,
+    AutoDeleted,
+}
+
+struct RestoreMeta {
+    owner_uid: u32,
+    owner_gid: u32,
+    permissions: u32,
+    // extended attributes as needed
+}
+
+// ── Shared Ledger Events ──
+
+enum ActionEvent {
+    ItemIngested       { item: PendingItem },
+    ItemSelected       { item_id: Uuid, action: Action },
+    ItemExpired        { item_id: Uuid },
+    TaskEnqueued       { task: Task },
+    TaskStarted        { task_id: Uuid },
+    TaskStepUpdated    { task_id: Uuid, step: TaskStep },
+    TaskPaused         { task_id: Uuid, reason: String },
+    TaskResumed        { task_id: Uuid },
+    TaskCompleted      { task_id: Uuid, outcome: TaskOutcome },
+    TaskCancelled      { task_id: Uuid },
+    TrashCreated       { entry: TrashEntry },
+    TrashRestored      { entry_id: Uuid },
+    TrashPermDeleted   { entry_id: Uuid },
+    TrashAutoDeleted   { entry_id: Uuid },
+}
+```
+
+### Disk Layout
+
+```
+<agent_home>/
+├── actions/
+│   ├── ledger/
+│   │   └── YYYY-MM-DD.jsonl     ← append-only event log
+│   └── pending.json              ← current pending snapshot (rebuildable from ledger)
+├── trash/
+│   └── {timestamp}_{filename}/   ← trashed files
+├── companion/                    ← existing
+├── profile.yaml                  ← existing + new fields
+└── ...
+```
+
+### Profile Schema Additions
+
+```yaml
+capabilities:
+  file_actions:                   # A1: declarative action list
+    - id: summarize
+      label:
+        en: "Summarize"
+        zh-TW: "摘要"
+      description: "Extract key points from the file"
+      mime_types: [text/*, application/pdf, application/msword]
+    - id: translate
+      label:
+        en: "Translate"
+        zh-TW: "翻譯"
+      mime_types: [text/*, application/pdf]
+    - id: ask_me                  # reserved: always last, skips mime check
+      label:
+        en: "Ask me anything..."
+        zh-TW: "自由指令..."
+
+deletion:                          # A2: deletion safety
+  trash_enabled: true
+  trash_ttl_minutes: 10
+  trash_max_mb: 1024
+  trusted_paths: []                # paths that bypass trash
+
+queue:                             # A3: queue settings
+  max_concurrent: 3
+  default_timeout_minutes: 30
+  pending_item_ttl_minutes: 60     # expiry for unhandled pending items
+```
+
+### Action Buttons from Capabilities
+
+Action buttons rendered in the selection UI are sourced from `profile.yaml → capabilities.file_actions`, filtered by the intersecting MIME types of the selected files. The `ask_me` action always appears last and accepts any file type.
+
+**Future extension points** (not in v1): `icon`, `shortcut_key`, `requires_confirmation`, `output_kind`, MCP tool binding.
+
+## Phase 1: INGEST — File Intake & Selection
+
+### Flow
+
+```
+User action (drop / share / paste)
+  → PendingStore::ingest()
+    → MIME detect via magic bytes
+    → Dedup: same path within 5 seconds = same batch
+    → Merge: new files within 5 seconds of existing PendingItem = extend batch
+    → Append ActionEvent::ItemIngested to ledger
+    → Write pending.json snapshot
+    → GUI check:
+        Foreground → emit pending:updated (show selection UI directly)
+        Background → OS notification + increment floating badge
+                     User clicks notification/badge → GUI foreground → selection UI
+```
+
+### Selection UI
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  📄 Pending (3)                                         │
+│                                                         │
+│  ☑️ paper1.pdf  (245 KB)                               │
+│  ☑️ paper2.pdf  (1.2 MB)                               │
+│  ☑️ paper3.pdf  (890 KB)                               │
+│                                                         │
+│  What should I do?                                      │
+│  ┌──────┐ ┌──────┐ ┌──────┐ ┌────────┐               │
+│  │ 📝   │ │ 🌐   │ │ 📂   │ │ 🎤     │               │
+│  │Summarize│Translate│Categorize│Ask... │               │
+│  └──────┘ └──────┘ └──────┘ └────────┘               │
+│                                                         │
+│  [Cancel]                              [Run Selected]    │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Voice Flow
+
+1. User taps 🎤 → STT via whisper.cpp
+2. Transcribed text fills the free-input field (editable for correction)
+3. User confirms → executes as `ask_me` action
+
+### Merge & Expiry Rules
+
+- **Merge window**: 5 seconds. New files arriving within 5s of the last file in a PendingItem are merged into the same batch (badge count increases).
+- **Expiry**: `pending_item_ttl_minutes` (default 60). Unhandled items auto-expire; badge decremented.
+- **No-action agent**: If the agent has no `file_actions` defined (or only `ask_me`), only the free-input field is shown. A hint appears: "This agent has no predefined actions for this file type."
+
+### Notification Metadata
+
+Following [Courier 2026 dual-audience guidance](https://www.courier.com/blog/your-notifications-now-have-two-audiences-humans-and-ai-agents/), notifications include structured metadata:
+
+```json
+{
+  "event_type": "pending_item_ingested",
+  "item_id": "<uuid>",
+  "file_count": 3,
+  "mime_types": ["application/pdf"],
+  "urgency": "low",
+  "human_readable": {
+    "title": "3 files received",
+    "body": "paper1.pdf, paper2.pdf, paper3.pdf"
+  }
+}
+```
+
+## Phase 2: QUEUE — Task Management
+
+### Flow
+
+```
+ItemSelected from Phase 1
+  → TaskQueue::enqueue(action, files)
+    → Create Task { state: Queued, ... }
+    → Append TaskEnqueued
+    → Check max_concurrent:
+        Under limit → TaskStarted → Phase 3
+        At limit → stays Queued, dequeued when slot opens
+    → Update GUI via bridge
+```
+
+### Queue Panel UI
+
+```
+┌─────────────────────────────────────────┐
+│  📋 Tasks                               │
+│                                         │
+│  ⏳ Waiting (2)                          │
+│  ├─ 📝 Summarize paper1-3.pdf           │
+│  │   [Cancel]                           │
+│  └─ 🌐 Translate contract.docx          │
+│      [Cancel]                           │
+│                                         │
+│  🔄 Running (1)                          │
+│  └─ 📂 Categorize photos (42)            │
+│      ▸ Scanning files... ✓              │
+│      ▸ Analyzing content... ⏳          │
+│      ▸ Moving files...                  │
+│      [Pause] [Cancel]                   │
+│                                         │
+│  ✅ Completed (12)  [Clear]              │
+│  ❌ Failed (1)     [Retry All]          │
+└─────────────────────────────────────────┘
+```
+
+### Pause Semantics
+
+- **Checkpoint mode**: Agent completes the current atomic step before pausing.
+- **Force timeout**: If no checkpoint reached within 30 seconds, force-interrupt.
+- Tasks paused are written to ledger; survive agent restart.
+
+### Cancel Semantics
+
+- Cancel cascades: aborting a task aborts all sub-operations.
+- **Cleanup**: Agent-created temp files are deleted (do NOT go through trash).
+- **Preservation**: Original user files are never touched by cancellation.
+
+### Step Reporting
+
+Agent reports steps via `TaskStepUpdated` events. Steps are agent-defined — it decides what level of detail to expose. The UI renders them as a Dynamic Checklist (validated by [Smashing Magazine 2026](https://shop.smashingmagazine.com/2026/05/practical-interface-patterns-ai-transparency/)).
+
+## Phase 3: EXEC — Execution & Deletion Safety
+
+### TrashGuard Interception
+
+```
+Every tool call passes through TrashGuard::intercept():
+
+1. DETECT destructive patterns:
+   - Shell: rm, unlink, delete
+   - Shell: mv to /dev/null
+   - Python: os.remove, os.unlink, shutil.rmtree
+   - MCP: delete_file tool invocations
+   - A2A: delete requests to other agents
+   - If path matches trusted_paths → allow (no trash)
+
+2. SCHEMA-LEVEL enforcement:
+   - Batch size ≤ 10 files per operation
+   - No wildcards (*, ?) in paths
+   - Path within allowed scope
+   - Reject with clear error if violation
+
+3. REWRITE destructive operations:
+   rm <path> → mv <path> <agent_home>/trash/{timestamp}_{filename}/
+
+4. CREATE TrashEntry with metadata:
+   - Original path, trash path, file size
+   - RestoreMetadata (owner, perms, xattrs)
+   - expires_at = created_at + deletion.ttl_minutes
+
+5. APPEND TrashCreated to ledger
+
+6. NOTIFY Phase 4 (deletion notifications are independent and urgent)
+```
+
+### Two-Phase Protocol
+
+Following the [Cursor/Gemini incident lesson](https://forum.cursor.com/t/gemini-deletes-destroys-code-despite-memories-forbidding-these-actions/135867): destructive actions are **never** proposed and executed in the same turn.
+
+- Turn 1: Preview what would be deleted
+- Await user confirmation
+- Turn 2: Execute only after explicit consent
+
+This is enforced at the TrashGuard level: the first time a task triggers a destructive operation, execution pauses and waits for user acknowledgment.
+
+### Trash Timer
+
+- Background tick every 30 seconds scans for `TrashEntry` where `expires_at < now()` and `status == Pending`
+- Expired entries → `TrashAutoDeleted` → files permanently removed
+- Individual timers per entry (not a single global timer)
+
+### Trash Capacity
+
+- Total trash size tracked. If new entry would exceed `trash_max_mb` → reject with notification "Trash full. Please empty trash before new deletions."
+- No automatic eviction (FIFO or otherwise) — user must explicitly manage.
+
+### Trusted Paths
+
+- Exact string match only; symlinks are NOT resolved
+- `~/Downloads/tmp/` as symlink → does NOT match → trash still applies
+- Design rationale: prevents agent from exploiting symlinks to bypass protection
+
+### Coverage Scope
+
+| Path | Intercepted? | Method |
+|------|-------------|--------|
+| Shell `rm` | ✅ | Tool-call pattern matching |
+| Python `os.remove` etc. | ✅ | Same shell tool-call path |
+| MCP `delete_file` | ✅ | MCP handler layer |
+| A2A delete request | ✅ | Supervisor dispatch |
+| Direct syscall from C extension | ❌ | Out of scope; requires OS sandbox (Phase 2) |
+
+## Phase 4: NOTIFY — Result Delivery
+
+### Aggregation
+
+- Same PendingItem results → 1 OS notification
+- Format: "Agent X completed: 47 succeeded, 3 failed"
+- Deletion notifications are independent (more urgent than completion)
+- Badge number = pending items + running tasks (completed/failed excluded)
+
+### Trash Notification UI
+
+```
+┌─────────────────────────────────────────┐
+│  ⚠️ Agent X wants to delete 3 files      │
+│                                         │
+│  📄 /tmp/paper1_ocr.pdf                 │
+│  📄 /tmp/paper2_ocr.pdf                 │
+│  📄 /tmp/paper3_ocr.pdf                 │
+│                                         │
+│  Will be permanently deleted in 10 min  │
+│  [Delete Now] [Restore All] [View Trash]│
+└─────────────────────────────────────────┘
+```
+
+### Output Routing
+
+Each `ActionOutput` carries a `kind` field:
+- `file` → write result to disk (alongside or near original)
+- `chat_message` → append to agent chat window
+- `both` → do both
+
+The agent decides which based on the action context.
+
+### Audit Trail
+
+Every completed task retains a "Show Work" link that replays:
+- Decision logic (which action was chosen, why)
+- Steps taken (from TaskStep ledger)
+- Files affected (created, modified, trashed)
+- Before/after diff previews where applicable
+
+Following the [Smashing Magazine audit trail pattern](https://shop.smashingmagazine.com/2026/05/practical-interface-patterns-ai-transparency/): the presence of the link signals the system stands behind its work, even if rarely clicked.
+
+## CLI Surface
+
+```
+# Phase 1
+mur agent pending <name>              # List pending items
+mur agent pending <name> --act <id>   # Execute action on pending item
+
+# Phase 2
+mur agent queue <name>                # List task queue
+mur agent queue <name> --pause <id>   # Pause task
+mur agent queue <name> --cancel <id>  # Cancel task
+mur agent queue <name> --retry <id>   # Retry failed task
+
+# Phase 3 (A2)
+mur agent trash <name>                # List trash contents
+mur agent trash <name> --restore <id> # Restore file from trash
+mur agent trash <name> --empty        # Permanently empty trash
+mur agent trash <name> --now <id>     # Immediately delete specific item
+```
+
+## Implementation Plan
+
+### Phase Order & Dependencies
+
+```
+Phase 0: Shared Infrastructure
+  → Phase 1: INGEST (A1 front half)
+    → Phase 2: QUEUE (A3)
+      → Phase 3: EXEC (A2 + A1 back half)
+        → Phase 4: NOTIFY (A1 back half)
+```
+
+Each phase builds on the previous. Phase 1 can be delivered standalone (files in → notify → select action). Phase 2 adds queue. Phase 3 adds safety. Phase 4 closes the loop.
+
+### File Structure
+
+**mur-core/src/action_pipeline/** (8 files, ~2050 lines total, all under 800-line limit):
+
+```
+mod.rs       ← ~120 lines: public API, Pipeline struct
+state.rs     ← ~350 lines: all types + serde
+ledger.rs    ← ~200 lines: JSONL read/write (reuses companion pattern)
+ingest.rs    ← ~300 lines: PendingStore, MIME detect, dedup, merge
+queue.rs     ← ~350 lines: TaskQueue, state machine, concurrency
+guard.rs     ← ~400 lines: TrashGuard, pattern matching, schema checks
+notify.rs    ← ~250 lines: Aggregator, notification formatting
+error.rs     ← ~80 lines:  error types
+```
+
+**mur-agent-gui/ui/src/** (new React components):
+
+```
+pending/     ← PendingPanel, FloatingBadge, FileChecklist, ActionButtons,
+               VoiceInput, usePendingBridge, api, types
+queue/       ← QueuePanel, TaskRow, StepList, useQueueBridge, api, types
+trash/       ← TrashPanel, TrashRow, useTrashBridge, api, types
+```
+
+### Crate Impact
+
+| Crate | New | Modified |
+|-------|-----|----------|
+| **mur-common** | `src/action.rs` (ActionEvent enum) | — |
+| **mur-core** | `src/action_pipeline/` (8 files) | `profile.yaml` schema, CLI dispatch |
+| **mur-agent-runtime** | `src/action_pipeline/` (step reporting), `trash_watcher.rs` | `supervisor.rs` (TrashGuard hook) |
+| **mur-agent-gui** | `pending/` `queue/` `trash/` (~18 files) | `CompanionBridge` (add action event), `App.tsx` (new tabs) |
+| **mur-daemon** | — | Optional: relocate trash timer here for long-running |
+
+## Testing Strategy
+
+### Unit Tests
+
+- **state.rs**: Serialization round-trips for all types
+- **ledger.rs**: Append + scan_days + state rebuild from ledger
+- **ingest.rs**: MIME detect, dedup window (5s), merge window (5s), expiry (TTL exceeded)
+- **queue.rs**: Enqueue below/at capacity, state machine transitions, pause at checkpoint (<30s), force-pause after timeout (≥30s), cancel cleanup, ledger rebuild (crash recovery)
+- **guard.rs**: Detect all destructive patterns (shell, Python, MCP, A2A), batch size reject, wildcard reject, trusted_paths bypass, rewrite rm→mv, TrashEntry expiry, auto-delete, capacity limit, restore, symlink-in-trusted-paths edge case
+- **notify.rs**: Same-batch aggregation, independent deletion notification, badge count correctness
+
+### E2E Tests
+
+- CLI: `mur agent pending` → list, act
+- CLI: `mur agent queue` → pause, cancel, retry
+- CLI: `mur agent trash` → restore, empty, now
+- GUI: OS notification when backgrounded
+- GUI: Badge updates on all state transitions
+- GUI: File drop → notification → selection → execution flow
+
+## Edge Cases Covered
+
+| Edge Case | Resolution |
+|-----------|-----------|
+| Files dropped during active selection | Merge into existing batch (5s window) |
+| Agent has no matching action for file type | Show only ask_me + hint |
+| Voice STT error | Show transcription in editable field; user corrects |
+| Agent crashes during task | Rebuild queue state from ledger on restart |
+| Trash capacity exceeded | Reject new deletions; notify user to empty |
+| Symlink in trusted_paths | Not resolved; trash still applies |
+| 50 files in one batch | 1 aggregated notification |
+| Task timeout | Mark failed; retain for retry |
+| Pending item unhandled past TTL | Auto-expire; decrement badge |
+
+## References
+
+- [Smashing Magazine — Practical Interface Patterns for AI Transparency (Part 2), 2026](https://shop.smashingmagazine.com/2026/05/practical-interface-patterns-ai-transparency/)
+- [Jacar — UI Design for Agents, 2025](https://jacar.es/en/diseno-ui-agentes/)
+- [Courier — Notifications Have Two Audiences: Humans and AI Agents, 2026](https://www.courier.com/blog/your-notifications-now-have-two-audiences-humans-and-ai-agents/)
+- [ioDroplet — Identifying Necessary Transparency Moments in Agentic AI (Part 1)](https://iodroplet.com/identifying-necessary-transparency-moments-in-agentic-ai-part-1/)
+- [Conseca — Contextual Security Policies for AI Agents (Google, HOTOS '25)](https://sigops.org/s/conferences/hotos/2025/papers/hotos25-100.pdf)
+- [agent-safe-delete — Open-source CLI](https://github.com/ckckck/agent-safe-delete)
+- [Safe File Deletion MCP — NPM package](https://www.npmjs.com/package/@mizunashi_mana/safe-file-deletion-mcp)
+- [Undisk MCP — Per-file undo](https://chat.mcp.so/server/undisk-mcp/Kiarash%20Adl)
+- [Replit — Inside the Snapshot Engine, Dec 2025](https://blog.replit.com/inside-replits-snapshot-engine)
+- [Morae — Proactively Pausing UI Agents (UIST '25)](https://ar5iv.labs.arxiv.org/html/2508.21456)
+- [AgentField — Cancel/Pause/Resume issue #243](https://github.com/Agent-Field/agentfield/issues/243)
+- [Autopoiesis — Delayed Action Buffer #614](https://github.com/DavSimFel/autopoiesis/issues/614)
+- [Autopoiesis — Unified Interaction Queue #547](https://github.com/DavSimFel/autopoiesis/issues/547)
+- [FutureAGI — Agentic UX in 2026: AG-UI Protocol](https://futureagi.com/blog/agentic-ux-webinar-2025/#hero)
+- [Agents.md — AI Coding Agent Open Standard, 2025](https://www.remio.ai/post/what-is-agents-md-a-complete-guide-to-the-new-ai-coding-agent-standard-in-2025)
+- [OpenPort Protocol — Security Governance for AI Agent Tool Access](https://ar5iv.labs.arxiv.org/html/2602.20196)
+- [Claude Code Permission Model — Skywork, 2025](https://skywork.ai/blog/permission-model-claude-code-vs-code-jetbrains-cli/)
+- [Cursor Forum — Gemini deletes code despite memories #135867](https://forum.cursor.com/t/gemini-deletes-destroys-code-despite-memories-forbidding-these-actions/135867)

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -744,10 +744,26 @@ pub enum ProjectAction {
     Index {
         #[arg(long)]
         path: Option<String>,
+        /// Force full rebuild ignoring mtime cache
         #[arg(long)]
         rebuild: bool,
+        /// Less output
         #[arg(long)]
         quiet: bool,
+        /// Run indexing in background (default: auto-detect based on chunk count)
+        #[arg(long, conflicts_with = "foreground")]
+        background: bool,
+        /// Force foreground execution even for large projects
+        #[arg(long, conflicts_with = "background")]
+        foreground: bool,
+    },
+    /// Internal: spawned by `project index --background`. Not shown in help.
+    #[command(hide = true)]
+    IndexWorker {
+        project_name: String,
+        project_path: String,
+        #[arg(long)]
+        rebuild: bool,
     },
     /// Search indexed code for a query
     Search {

--- a/mur-core/src/cmd/project.rs
+++ b/mur-core/src/cmd/project.rs
@@ -1,15 +1,29 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::PathBuf;
 
-use crate::codebase::scanner::{expand_tilde, project_name_from_path};
-use crate::codebase::{CodebaseIndex, discover_all_indexes};
+use crate::codebase::scanner::{expand_tilde, project_name_from_path, scan_project};
+use crate::codebase::{
+    CodebaseIndex, IndexProgress, IndexStatus, IndexLock, BACKGROUND_CHUNK_THRESHOLD,
+    discover_all_indexes,
+};
 use crate::store::config::load_config;
-use crate::store::embedding::{EmbeddingConfig, embed};
+use crate::store::embedding::{embed, EmbeddingConfig};
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BackgroundMode {
+    /// Auto-detect: background if chunks > BACKGROUND_CHUNK_THRESHOLD
+    Auto,
+    /// Force background execution
+    ForceBackground,
+    /// Force foreground execution
+    ForceForeground,
+}
 
 pub(crate) async fn cmd_project_index(
     path: Option<String>,
     rebuild: bool,
     quiet: bool,
+    bg_mode: BackgroundMode,
 ) -> Result<()> {
     let project_path = match &path {
         Some(p) => expand_tilde(p),
@@ -29,6 +43,89 @@ pub(crate) async fn cmd_project_index(
     let embed_config = EmbeddingConfig::from_config(&cfg);
     let index = CodebaseIndex::new(&project_name, &project_path);
 
+    // Determine whether to run in background
+    let run_in_background = match bg_mode {
+        BackgroundMode::ForceBackground => true,
+        BackgroundMode::ForceForeground => false,
+        BackgroundMode::Auto => {
+            // Quick scan to estimate chunk count
+            let files = scan_project(&project_path);
+            let estimated_chunks: usize = files.iter().map(|f| {
+                let lines = f.content.lines().count();
+                if lines < 50 { 1 } else { (lines / 60).max(1) + 1 }
+            }).sum();
+            estimated_chunks > BACKGROUND_CHUNK_THRESHOLD
+        }
+    };
+
+    if run_in_background {
+        // Check lock
+        if !index.try_acquire_lock()? {
+            eprintln!(
+                "Indexing already in progress for '{}' (lock held by another process).",
+                project_name
+            );
+            eprintln!("  Check status: mur project status");
+            return Ok(());
+        }
+
+        // Spawn worker subprocess
+        let mur_bin = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("mur"));
+        let mut cmd = std::process::Command::new(&mur_bin);
+        cmd.args([
+            "project",
+            "index-worker",
+            &project_name,
+            &project_path.display().to_string(),
+        ]);
+        if rebuild {
+            cmd.arg("--rebuild");
+        }
+        cmd.stdout(std::process::Stdio::null());
+        cmd.stderr(std::process::Stdio::null());
+        cmd.stdin(std::process::Stdio::null());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            cmd.process_group(0); // Detach from parent process group
+        }
+
+        let child = cmd.spawn().with_context(|| "spawning background index worker")?;
+        let pid = child.id();
+
+        if !quiet {
+            eprintln!(
+                "Indexing '{}' in background (PID: {}).",
+                project_name, pid,
+            );
+            eprintln!("  Check progress: mur project status");
+        }
+
+        // Overwrite lock with the child's pid
+        let lock = IndexLock {
+            pid,
+            project_name: project_name.clone(),
+            started_at: chrono::Utc::now().to_rfc3339(),
+        };
+        let lock_path = index.lock_path();
+        std::fs::write(&lock_path, serde_json::to_string(&lock)?)?;
+
+        // Write initial progress
+        index.write_progress(&IndexProgress {
+            status: IndexStatus::Running,
+            total_chunks: 0,
+            done_chunks: 0,
+            errors: 0,
+            started_at: chrono::Utc::now().to_rfc3339(),
+            finished_at: None,
+            error_message: None,
+        })?;
+
+        return Ok(());
+    }
+
+    // ── Foreground path (existing behavior) ──
     if !quiet {
         eprintln!("Indexing {} ({})...", project_name, project_path.display());
     }
@@ -54,7 +151,6 @@ pub(crate) async fn cmd_project_index(
     }
 
     crate::codebase::ensure_git_hook(&project_path, quiet)?;
-
     Ok(())
 }
 
@@ -190,4 +286,110 @@ pub(crate) fn cmd_project_list() -> Result<()> {
         println!("    path: {}", path_display);
     }
     Ok(())
+}
+
+/// Internal: runs the actual indexing work when spawned in background mode.
+pub(crate) async fn cmd_project_index_worker(
+    project_name: &str,
+    project_path_str: &str,
+    rebuild: bool,
+) -> Result<()> {
+    let project_path = PathBuf::from(project_path_str);
+    let cfg = load_config()?;
+    let embed_config = EmbeddingConfig::from_config(&cfg);
+    let index = CodebaseIndex::new(project_name, &project_path);
+
+    // Build with progress callbacks that write to the progress file
+    let build_result = index
+        .build(&embed_config, rebuild, |done, total| {
+            let progress = IndexProgress {
+                status: IndexStatus::Running,
+                total_chunks: total,
+                done_chunks: done,
+                errors: 0,
+                started_at: String::new(),
+                finished_at: None,
+                error_message: None,
+            };
+            let _ = index.write_progress(&progress);
+        })
+        .await;
+
+    match build_result {
+        Ok(stats) => {
+            let progress = IndexProgress {
+                status: IndexStatus::Done,
+                total_chunks: stats.chunks_created,
+                done_chunks: stats.chunks_created,
+                errors: 0,
+                started_at: String::new(),
+                finished_at: Some(chrono::Utc::now().to_rfc3339()),
+                error_message: None,
+            };
+            let _ = index.write_progress(&progress);
+            index.release_lock();
+
+            // Desktop notification
+            send_notification(
+                &format!("mur: {} indexed", project_name),
+                &format!(
+                    "{} files, {} chunks in {:.1}s",
+                    stats.files_indexed,
+                    stats.chunks_created,
+                    stats.duration_ms as f64 / 1000.0
+                ),
+            );
+        }
+        Err(e) => {
+            let progress = IndexProgress {
+                status: IndexStatus::Error,
+                total_chunks: 0,
+                done_chunks: 0,
+                errors: 1,
+                started_at: String::new(),
+                finished_at: Some(chrono::Utc::now().to_rfc3339()),
+                error_message: Some(e.to_string()),
+            };
+            let _ = index.write_progress(&progress);
+            index.release_lock();
+
+            send_notification(
+                &format!("mur: {} index failed", project_name),
+                &format!("Error: {:.100}", e),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Send a desktop notification. macOS uses osascript; Linux uses notify-send if available.
+fn send_notification(title: &str, message: &str) {
+    #[cfg(target_os = "macos")]
+    {
+        let script = format!(
+            "display notification \"{}\" with title \"{}\"",
+            message.replace('"', "\\\""),
+            title.replace('"', "\\\"")
+        );
+        let _ = std::process::Command::new("osascript")
+            .args(["-e", &script])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        // Fallback: terminal bell + stderr
+        eprintln!("\n\x07{}: {}", title, message);
+        // Try notify-send on Linux
+        #[cfg(target_os = "linux")]
+        {
+            let _ = std::process::Command::new("notify-send")
+                .args([title, message])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn();
+        }
+    }
 }

--- a/mur-core/src/cmd/project.rs
+++ b/mur-core/src/cmd/project.rs
@@ -3,11 +3,11 @@ use std::path::PathBuf;
 
 use crate::codebase::scanner::{expand_tilde, project_name_from_path, scan_project};
 use crate::codebase::{
-    CodebaseIndex, IndexProgress, IndexStatus, IndexLock, BACKGROUND_CHUNK_THRESHOLD,
+    BACKGROUND_CHUNK_THRESHOLD, CodebaseIndex, IndexLock, IndexProgress, IndexStatus,
     discover_all_indexes,
 };
 use crate::store::config::load_config;
-use crate::store::embedding::{embed, EmbeddingConfig};
+use crate::store::embedding::{EmbeddingConfig, embed};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BackgroundMode {
@@ -50,10 +50,17 @@ pub(crate) async fn cmd_project_index(
         BackgroundMode::Auto => {
             // Quick scan to estimate chunk count
             let files = scan_project(&project_path);
-            let estimated_chunks: usize = files.iter().map(|f| {
-                let lines = f.content.lines().count();
-                if lines < 50 { 1 } else { (lines / 60).max(1) + 1 }
-            }).sum();
+            let estimated_chunks: usize = files
+                .iter()
+                .map(|f| {
+                    let lines = f.content.lines().count();
+                    if lines < 50 {
+                        1
+                    } else {
+                        (lines / 60).max(1) + 1
+                    }
+                })
+                .sum();
             estimated_chunks > BACKGROUND_CHUNK_THRESHOLD
         }
     };
@@ -91,14 +98,13 @@ pub(crate) async fn cmd_project_index(
             cmd.process_group(0); // Detach from parent process group
         }
 
-        let child = cmd.spawn().with_context(|| "spawning background index worker")?;
+        let child = cmd
+            .spawn()
+            .with_context(|| "spawning background index worker")?;
         let pid = child.id();
 
         if !quiet {
-            eprintln!(
-                "Indexing '{}' in background (PID: {}).",
-                project_name, pid,
-            );
+            eprintln!("Indexing '{}' in background (PID: {}).", project_name, pid,);
             eprintln!("  Check progress: mur project status");
         }
 
@@ -277,8 +283,10 @@ pub(crate) async fn cmd_project_status(path: Option<String>) -> Result<()> {
                     0.0
                 };
                 println!("  Status: indexing in background (PID: {})", lock.pid);
-                println!("  Progress: {}/{} chunks ({:.0}%)",
-                    progress.done_chunks, progress.total_chunks, pct);
+                println!(
+                    "  Progress: {}/{} chunks ({:.0}%)",
+                    progress.done_chunks, progress.total_chunks, pct
+                );
                 if progress.errors > 0 {
                     println!("  Errors: {}", progress.errors);
                 }
@@ -300,7 +308,10 @@ pub(crate) async fn cmd_project_status(path: Option<String>) -> Result<()> {
                         }
                     }
                     IndexStatus::Running => {
-                        println!("  Last index: interrupted (stale lock, PID {} no longer alive)", lock.pid);
+                        println!(
+                            "  Last index: interrupted (stale lock, PID {} no longer alive)",
+                            lock.pid
+                        );
                     }
                 }
             } else {

--- a/mur-core/src/cmd/project.rs
+++ b/mur-core/src/cmd/project.rs
@@ -256,13 +256,62 @@ pub(crate) async fn cmd_project_status(path: Option<String>) -> Result<()> {
     let project_name = project_name_from_path(&project_path);
     let index = CodebaseIndex::new(&project_name, &project_path);
 
-    let meta = index.lance_path().exists();
+    let has_db = index.lance_path().exists();
     let stats = index.stats_async().await?;
 
     println!("Project: {}", project_name);
     println!("  Path: {}", project_path.display());
-    println!("  Indexed: {}", if meta { "yes" } else { "no" });
-    if meta {
+
+    // Check if a background index is running
+    let lock_path = index.lock_path();
+    if lock_path.exists() {
+        if let Ok(data) = std::fs::read_to_string(&lock_path) {
+            if let Ok(lock) = serde_json::from_str::<IndexLock>(&data) {
+                if mur_common::lock_file::pid_alive(lock.pid) {
+                    // Live background process — show progress
+                    if let Some(progress) = index.read_progress() {
+                        let pct = if progress.total_chunks > 0 {
+                            (progress.done_chunks as f64 / progress.total_chunks as f64) * 100.0
+                        } else {
+                            0.0
+                        };
+                        println!("  Status: indexing in background (PID: {})", lock.pid);
+                        println!("  Progress: {}/{} chunks ({:.0}%)",
+                            progress.done_chunks, progress.total_chunks, pct);
+                        if progress.errors > 0 {
+                            println!("  Errors: {}", progress.errors);
+                        }
+                    } else {
+                        println!("  Status: indexing in background (PID: {})", lock.pid);
+                    }
+                    return Ok(());
+                } else {
+                    // Stale lock — process died
+                    if let Some(progress) = index.read_progress() {
+                        match progress.status {
+                            IndexStatus::Done => {
+                                println!("  Last index: completed");
+                            }
+                            IndexStatus::Error => {
+                                println!("  Last index: failed");
+                                if let Some(ref msg) = progress.error_message {
+                                    println!("  Error: {}", msg);
+                                }
+                            }
+                            IndexStatus::Running => {
+                                println!("  Last index: interrupted (stale lock, PID {} no longer alive)", lock.pid);
+                            }
+                        }
+                    } else {
+                        println!("  Last index: unknown (stale lock)");
+                    }
+                }
+            }
+        }
+    }
+
+    println!("  Indexed: {}", if has_db { "yes" } else { "no" });
+    if has_db {
         println!("  Chunks: {}", stats.chunks_created);
     }
 

--- a/mur-core/src/cmd/project.rs
+++ b/mur-core/src/cmd/project.rs
@@ -264,48 +264,47 @@ pub(crate) async fn cmd_project_status(path: Option<String>) -> Result<()> {
 
     // Check if a background index is running
     let lock_path = index.lock_path();
-    if lock_path.exists() {
-        if let Ok(data) = std::fs::read_to_string(&lock_path) {
-            if let Ok(lock) = serde_json::from_str::<IndexLock>(&data) {
-                if mur_common::lock_file::pid_alive(lock.pid) {
-                    // Live background process — show progress
-                    if let Some(progress) = index.read_progress() {
-                        let pct = if progress.total_chunks > 0 {
-                            (progress.done_chunks as f64 / progress.total_chunks as f64) * 100.0
-                        } else {
-                            0.0
-                        };
-                        println!("  Status: indexing in background (PID: {})", lock.pid);
-                        println!("  Progress: {}/{} chunks ({:.0}%)",
-                            progress.done_chunks, progress.total_chunks, pct);
-                        if progress.errors > 0 {
-                            println!("  Errors: {}", progress.errors);
-                        }
-                    } else {
-                        println!("  Status: indexing in background (PID: {})", lock.pid);
-                    }
-                    return Ok(());
+    if lock_path.exists()
+        && let Ok(data) = std::fs::read_to_string(&lock_path)
+        && let Ok(lock) = serde_json::from_str::<IndexLock>(&data)
+    {
+        if mur_common::lock_file::pid_alive(lock.pid) {
+            // Live background process — show progress
+            if let Some(progress) = index.read_progress() {
+                let pct = if progress.total_chunks > 0 {
+                    (progress.done_chunks as f64 / progress.total_chunks as f64) * 100.0
                 } else {
-                    // Stale lock — process died
-                    if let Some(progress) = index.read_progress() {
-                        match progress.status {
-                            IndexStatus::Done => {
-                                println!("  Last index: completed");
-                            }
-                            IndexStatus::Error => {
-                                println!("  Last index: failed");
-                                if let Some(ref msg) = progress.error_message {
-                                    println!("  Error: {}", msg);
-                                }
-                            }
-                            IndexStatus::Running => {
-                                println!("  Last index: interrupted (stale lock, PID {} no longer alive)", lock.pid);
-                            }
+                    0.0
+                };
+                println!("  Status: indexing in background (PID: {})", lock.pid);
+                println!("  Progress: {}/{} chunks ({:.0}%)",
+                    progress.done_chunks, progress.total_chunks, pct);
+                if progress.errors > 0 {
+                    println!("  Errors: {}", progress.errors);
+                }
+            } else {
+                println!("  Status: indexing in background (PID: {})", lock.pid);
+            }
+            return Ok(());
+        } else {
+            // Stale lock — process died
+            if let Some(progress) = index.read_progress() {
+                match progress.status {
+                    IndexStatus::Done => {
+                        println!("  Last index: completed");
+                    }
+                    IndexStatus::Error => {
+                        println!("  Last index: failed");
+                        if let Some(ref msg) = progress.error_message {
+                            println!("  Error: {}", msg);
                         }
-                    } else {
-                        println!("  Last index: unknown (stale lock)");
+                    }
+                    IndexStatus::Running => {
+                        println!("  Last index: interrupted (stale lock, PID {} no longer alive)", lock.pid);
                     }
                 }
+            } else {
+                println!("  Last index: unknown (stale lock)");
             }
         }
     }

--- a/mur-core/src/cmd/reindex.rs
+++ b/mur-core/src/cmd/reindex.rs
@@ -4,7 +4,7 @@ use crate::store::workflow_yaml::WorkflowYamlStore;
 use crate::store::yaml::{YamlStore, default_mur_dir};
 
 pub(crate) async fn cmd_reindex() -> Result<()> {
-    use crate::store::embedding::{EmbeddingConfig, embed};
+    use crate::store::embedding::{EmbeddingConfig, embed_batch};
     use crate::store::vector::LanceDbStore as VectorStore;
 
     let pattern_store = YamlStore::default_store()?;
@@ -35,58 +35,68 @@ pub(crate) async fn cmd_reindex() -> Result<()> {
         }
     );
 
-    let mut indexed_patterns = Vec::new();
-    let mut indexed_workflows = Vec::new();
-    let mut errors = 0;
-    let total = patterns.len() + workflows.len();
+    // Collect all texts first
+    let mut texts: Vec<String> = Vec::with_capacity(patterns.len() + workflows.len());
 
-    for (i, pattern) in patterns.iter().enumerate() {
+    for pattern in &patterns {
         let mut text = format!(
             "{}: {}\n{}",
             pattern.name,
             pattern.description,
             pattern.content.as_text()
         );
-        // Include attachment descriptions in embedding text for better search
         for att in &pattern.attachments {
             if !att.description.is_empty() {
                 text.push_str("\n\n");
                 text.push_str(&att.description);
             }
         }
-        match embed(&text, &config).await {
-            Ok(embedding) => {
-                indexed_patterns.push((pattern.clone(), embedding));
-                if (i + 1) % 10 == 0 {
-                    println!("  {}/{} embedded...", i + 1, total);
-                }
-            }
-            Err(e) => {
-                eprintln!("  ⚠️  {} — {}", pattern.name, e);
-                errors += 1;
-            }
-        }
+        texts.push(text);
     }
-
-    for (i, workflow) in workflows.iter().enumerate() {
+    for workflow in &workflows {
         let text = format!(
             "{}: {}\n{}",
             workflow.name,
             workflow.description,
             workflow.content.as_text()
         );
-        match embed(&text, &config).await {
-            Ok(embedding) => {
-                indexed_workflows.push((workflow.clone(), embedding));
-                let idx = patterns.len() + i + 1;
-                if idx % 10 == 0 {
-                    println!("  {}/{} embedded...", idx, total);
+        texts.push(text);
+    }
+
+    let total = texts.len();
+    let mut embeddings: Vec<Option<Vec<f32>>> = vec![None; total];
+    let mut errors = 0;
+
+    const EMBED_BATCH: usize = 200;
+    for batch_start in (0..total).step_by(EMBED_BATCH) {
+        let batch_end = (batch_start + EMBED_BATCH).min(total);
+        let batch: Vec<String> = texts[batch_start..batch_end].to_vec();
+        match embed_batch(&batch, &config).await {
+            Ok(batch_embs) => {
+                for (j, emb) in batch_embs.into_iter().enumerate() {
+                    embeddings[batch_start + j] = Some(emb);
                 }
+                println!("  {}/{} embedded...", batch_end, total);
             }
             Err(e) => {
-                eprintln!("  ⚠️  {} — {}", workflow.name, e);
-                errors += 1;
+                eprintln!("  ⚠️  batch {}-{} embedding failed: {}", batch_start, batch_end, e);
+                errors += batch_end - batch_start;
             }
+        }
+    }
+
+    // Pair results back
+    let mut indexed_patterns = Vec::new();
+    let mut indexed_workflows = Vec::new();
+
+    for (i, pattern) in patterns.iter().enumerate() {
+        if let Some(emb) = embeddings[i].take() {
+            indexed_patterns.push((pattern.clone(), emb));
+        }
+    }
+    for (i, workflow) in workflows.iter().enumerate() {
+        if let Some(emb) = embeddings[patterns.len() + i].take() {
+            indexed_workflows.push((workflow.clone(), emb));
         }
     }
 

--- a/mur-core/src/cmd/reindex.rs
+++ b/mur-core/src/cmd/reindex.rs
@@ -79,7 +79,10 @@ pub(crate) async fn cmd_reindex() -> Result<()> {
                 println!("  {}/{} embedded...", batch_end, total);
             }
             Err(e) => {
-                eprintln!("  ⚠️  batch {}-{} embedding failed: {}", batch_start, batch_end, e);
+                eprintln!(
+                    "  ⚠️  batch {}-{} embedding failed: {}",
+                    batch_start, batch_end, e
+                );
                 errors += batch_end - batch_start;
             }
         }

--- a/mur-core/src/codebase/mod.rs
+++ b/mur-core/src/codebase/mod.rs
@@ -163,15 +163,13 @@ impl CodebaseIndex {
             std::fs::create_dir_all(parent)?;
         }
         // Check existing lock
-        if path.exists() {
-            if let Ok(data) = std::fs::read_to_string(&path) {
-                if let Ok(lock) = serde_json::from_str::<IndexLock>(&data) {
-                    if mur_common::lock_file::pid_alive(lock.pid) {
-                        return Ok(false); // Another live process holds the lock
-                    }
-                    // Stale lock — pid is dead, we'll overwrite
-                }
-            }
+        if path.exists()
+            && let Ok(data) = std::fs::read_to_string(&path)
+            && let Ok(lock) = serde_json::from_str::<IndexLock>(&data)
+            && mur_common::lock_file::pid_alive(lock.pid)
+        {
+            return Ok(false); // Another live process holds the lock
+            // Stale lock — pid is dead, we'll overwrite
         }
         let lock = IndexLock {
             pid: std::process::id(),

--- a/mur-core/src/codebase/mod.rs
+++ b/mur-core/src/codebase/mod.rs
@@ -24,6 +24,9 @@ use crate::store::embedding::{EmbeddingConfig, embed_batch};
 const TABLE_NAME: &str = "chunks";
 const EMBED_BATCH_SIZE: usize = 200;
 
+/// Chunks above this threshold auto-trigger background mode.
+pub const BACKGROUND_CHUNK_THRESHOLD: usize = 200;
+
 #[derive(Debug, Clone)]
 pub struct CodeChunk {
     pub file: String,
@@ -64,6 +67,34 @@ pub struct DiscoveredIndex {
     pub project_path: Option<String>,
     pub last_indexed: Option<String>,
     pub file_count: usize,
+}
+
+/// Written during background indexing so `mur project status` can show live progress.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexProgress {
+    pub status: IndexStatus,
+    pub total_chunks: usize,
+    pub done_chunks: usize,
+    pub errors: usize,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexStatus {
+    Running,
+    Done,
+    Error,
+}
+
+/// Lightweight lock file to prevent concurrent indexing of the same project.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexLock {
+    pub pid: u32,
+    pub project_name: String,
+    pub started_at: String,
 }
 
 pub struct CodebaseIndex {
@@ -108,6 +139,69 @@ impl CodebaseIndex {
         let data = serde_json::to_string_pretty(meta)?;
         std::fs::write(path, data)?;
         Ok(())
+    }
+
+    fn lock_path(&self) -> PathBuf {
+        self.lance_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(format!("{}.lock", self.project_name))
+    }
+
+    fn progress_path(&self) -> PathBuf {
+        self.lance_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(format!("{}.progress.json", self.project_name))
+    }
+
+    /// Try to acquire the index lock. Returns Ok(true) if we got it, Ok(false) if another
+    /// live process holds it, Err if I/O fails.
+    pub fn try_acquire_lock(&self) -> Result<bool> {
+        let path = self.lock_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        // Check existing lock
+        if path.exists() {
+            if let Ok(data) = std::fs::read_to_string(&path) {
+                if let Ok(lock) = serde_json::from_str::<IndexLock>(&data) {
+                    if mur_common::lock_file::pid_alive(lock.pid) {
+                        return Ok(false); // Another live process holds the lock
+                    }
+                    // Stale lock — pid is dead, we'll overwrite
+                }
+            }
+        }
+        let lock = IndexLock {
+            pid: std::process::id(),
+            project_name: self.project_name.clone(),
+            started_at: chrono::Utc::now().to_rfc3339(),
+        };
+        std::fs::write(&path, serde_json::to_string(&lock)?)?;
+        Ok(true)
+    }
+
+    pub fn release_lock(&self) {
+        let path = self.lock_path();
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Write progress for `mur project status` to read.
+    pub fn write_progress(&self, progress: &IndexProgress) -> Result<()> {
+        let path = self.progress_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&path, serde_json::to_string(progress)?)?;
+        Ok(())
+    }
+
+    /// Read progress file if it exists.
+    pub fn read_progress(&self) -> Option<IndexProgress> {
+        let path = self.progress_path();
+        let data = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&data).ok()
     }
 
     async fn get_db(&self) -> Result<&lancedb::Connection> {

--- a/mur-core/src/codebase/mod.rs
+++ b/mur-core/src/codebase/mod.rs
@@ -141,7 +141,7 @@ impl CodebaseIndex {
         Ok(())
     }
 
-    fn lock_path(&self) -> PathBuf {
+    pub(crate) fn lock_path(&self) -> PathBuf {
         self.lance_path
             .parent()
             .unwrap_or_else(|| Path::new("."))
@@ -700,7 +700,7 @@ pub fn ensure_git_hook(project_path: &Path, quiet: bool) -> Result<bool> {
         .map(|d| d.join(".mur").join("bin").join("mur"))
         .unwrap_or_else(|| PathBuf::from("mur"));
     let hook_content = format!(
-        "\n{}\nif command -v {} &>/dev/null; then\n  {} project index \"{}\" --quiet &\nfi\n",
+        "\n{}\nif command -v {} &>/dev/null; then\n  {} project index \"{}\" --quiet --background\nfi\n",
         marker,
         mur_bin.display(),
         mur_bin.display(),

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -979,7 +979,10 @@ pub async fn run(cli: Cli) -> Result<()> {
                 project_name,
                 project_path,
                 rebuild,
-            } => cmd::project::cmd_project_index_worker(&project_name, &project_path, rebuild).await?,
+            } => {
+                cmd::project::cmd_project_index_worker(&project_name, &project_path, rebuild)
+                    .await?
+            }
             ProjectAction::Search {
                 query,
                 project,

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -965,7 +965,21 @@ pub async fn run(cli: Cli) -> Result<()> {
                 path,
                 rebuild,
                 quiet,
-            } => cmd::project::cmd_project_index(path, rebuild, quiet).await?,
+                background,
+                foreground,
+            } => {
+                let mode = match (background, foreground) {
+                    (true, _) => cmd::project::BackgroundMode::ForceBackground,
+                    (_, true) => cmd::project::BackgroundMode::ForceForeground,
+                    (false, false) => cmd::project::BackgroundMode::Auto,
+                };
+                cmd::project::cmd_project_index(path, rebuild, quiet, mode).await?
+            }
+            ProjectAction::IndexWorker {
+                project_name,
+                project_path,
+                rebuild,
+            } => cmd::project::cmd_project_index_worker(&project_name, &project_path, rebuild).await?,
             ProjectAction::Search {
                 query,
                 project,

--- a/mur-core/src/store/embedding.rs
+++ b/mur-core/src/store/embedding.rs
@@ -80,12 +80,8 @@ pub async fn embed_batch(texts: &[String], config: &EmbeddingConfig) -> Result<V
         EmbeddingProvider::Ollama { base_url } => {
             embed_ollama_batch(texts, base_url, &config.model).await
         }
-        EmbeddingProvider::OpenAI { .. } => {
-            let mut results = Vec::with_capacity(texts.len());
-            for text in texts {
-                results.push(embed(text, config).await?);
-            }
-            Ok(results)
+        EmbeddingProvider::OpenAI { api_key, base_url } => {
+            embed_openai_batch(texts, base_url, api_key, &config.model).await
         }
     }
 }
@@ -159,7 +155,7 @@ async fn embed_ollama_batch(
 #[derive(Serialize)]
 struct OpenAIEmbedRequest {
     model: String,
-    input: String,
+    input: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -180,7 +176,7 @@ async fn embed_openai(text: &str, base_url: &str, api_key: &str, model: &str) ->
         .header("Authorization", format!("Bearer {}", api_key))
         .json(&OpenAIEmbedRequest {
             model: model.into(),
-            input: text.into(),
+            input: vec![text.to_string()],
         })
         .send()
         .await
@@ -198,6 +194,46 @@ async fn embed_openai(text: &str, base_url: &str, api_key: &str, model: &str) ->
         .next()
         .map(|d| d.embedding)
         .context("no embedding returned")
+}
+
+async fn embed_openai_batch(
+    texts: &[String],
+    base_url: &str,
+    api_key: &str,
+    model: &str,
+) -> Result<Vec<Vec<f32>>> {
+    if texts.is_empty() {
+        return Ok(Vec::new());
+    }
+    let client = reqwest::Client::new();
+    let url = format!("{}/embeddings", base_url.trim_end_matches('/'));
+    let resp = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", api_key))
+        .json(&OpenAIEmbedRequest {
+            model: model.into(),
+            input: texts.to_vec(),
+        })
+        .send()
+        .await
+        .with_context(|| format!("calling embed API at {}", url))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Embed API error {} at {}: {}", status, url, body);
+    }
+
+    let data: OpenAIEmbedResponse = resp.json().await.context("parsing embed response")?;
+    let embeddings: Vec<Vec<f32>> = data.data.into_iter().map(|d| d.embedding).collect();
+    if embeddings.len() != texts.len() {
+        anyhow::bail!(
+            "Embed API returned {} embeddings but {} were requested",
+            embeddings.len(),
+            texts.len()
+        );
+    }
+    Ok(embeddings)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- **Batch OpenAI embeddings:** `embed_batch` now sends all texts in a single HTTP request for OpenAI-compatible providers (was N sequential requests). 10-100x speedup for providers like omlx with large embedding models.
- **Batch reindex:** `mur internals reindex` now collects all texts and calls `embed_batch()` in chunks of 200 instead of per-item sequential `embed()`.
- **Background indexing:** `mur project index --background` spawns a worker subprocess, writes progress/lock files, and sends a macOS notification on completion. Auto-detects large projects (>200 chunks) and runs in background by default.
- **Live status:** `mur project status` reads lock/progress files to show live indexing progress (% done, PID, error state).
- **Lock protection:** Concurrent indexing of the same project is prevented via PID-based lock files. Stale locks from crashed processes are detected and overwritten.
- **Git hook:** Post-commit hook now uses `--background` flag instead of bare `&` backgrounding.

## Test Plan
- [x] `cargo build --release -p mur-core` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — 1249 pass, 6 pre-existing failures unchanged
- [x] E2E: foreground index on tiny git repo
- [x] E2E: background index spawns worker, lock/progress files visible via `mur project status`
- [x] E2E: lock file cleaned up after worker completion
- [x] CLI: `--background`/`--foreground` flags parse correctly, hidden `index-worker` subcommand works