### PR TITLE
fix(embed): wire config embedding_batch_size to control model-server RAM

### DIFF
--- a/mur-core/src/cmd/reindex.rs
+++ b/mur-core/src/cmd/reindex.rs
@@ -67,9 +67,13 @@ pub(crate) async fn cmd_reindex() -> Result<()> {
     let mut embeddings: Vec<Option<Vec<f32>>> = vec![None; total];
     let mut errors = 0;
 
-    const EMBED_BATCH: usize = 200;
-    for batch_start in (0..total).step_by(EMBED_BATCH) {
-        let batch_end = (batch_start + EMBED_BATCH).min(total);
+    let embed_batch_size = if config.batch_size > 0 {
+        config.batch_size
+    } else {
+        32 // fallback
+    };
+    for batch_start in (0..total).step_by(embed_batch_size) {
+        let batch_end = (batch_start + embed_batch_size).min(total);
         let batch: Vec<String> = texts[batch_start..batch_end].to_vec();
         match embed_batch(&batch, &config).await {
             Ok(batch_embs) => {

--- a/mur-core/src/codebase/mod.rs
+++ b/mur-core/src/codebase/mod.rs
@@ -22,7 +22,8 @@ use scanner::scan_project;
 use crate::store::embedding::{EmbeddingConfig, embed_batch};
 
 const TABLE_NAME: &str = "chunks";
-const EMBED_BATCH_SIZE: usize = 200;
+/// Fallback when embed_config.batch_size is zero (shouldn't happen).
+const FALLBACK_EMBED_BATCH_SIZE: usize = 32;
 
 /// Chunks above this threshold auto-trigger background mode.
 pub const BACKGROUND_CHUNK_THRESHOLD: usize = 200;
@@ -377,8 +378,14 @@ impl CodebaseIndex {
         if total_to_embed > 0 {
             on_progress(0, total_to_embed);
         }
-        for batch_start in (0..total_to_embed).step_by(EMBED_BATCH_SIZE) {
-            let batch_end = (batch_start + EMBED_BATCH_SIZE).min(total_to_embed);
+        let embed_batch_size = if embed_config.batch_size > 0 {
+            embed_config.batch_size
+        } else {
+            FALLBACK_EMBED_BATCH_SIZE
+        };
+
+        for batch_start in (0..total_to_embed).step_by(embed_batch_size) {
+            let batch_end = (batch_start + embed_batch_size).min(total_to_embed);
             let batch_indices = &chunks_to_embed[batch_start..batch_end];
 
             let texts: Vec<String> = batch_indices

--- a/mur-core/src/store/embedding.rs
+++ b/mur-core/src/store/embedding.rs
@@ -10,6 +10,8 @@ pub struct EmbeddingConfig {
     pub model: String,
     #[allow(dead_code)] // Used by callers to pass dimensions to VectorStore
     pub dimensions: usize,
+    /// Max texts per embedding API request (controls model-server RAM).
+    pub batch_size: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -45,6 +47,7 @@ impl EmbeddingConfig {
             provider,
             model: cfg.embedding.model.clone(),
             dimensions: cfg.embedding.dimensions,
+            batch_size: cfg.sources_global.embedding_batch_size,
         }
     }
 }
@@ -57,6 +60,7 @@ impl Default for EmbeddingConfig {
             },
             model: "qwen3-embedding:0.6b".into(),
             dimensions: 1024,
+            batch_size: 32,
         }
     }
 }


### PR DESCRIPTION
## Problem

`mur project index` with large embedding models (e.g. Qwen3-Embedding-4B) consumes ~10 GB RAM in the model server process.

**Root cause:** Commit `32ccbdd` changed OpenAI-compatible embedding from sequential (1 text/request) to batched (all texts in a single HTTP request). The hardcoded `EMBED_BATCH_SIZE=200` sends 200 texts per request, forcing the 4B-parameter model to hold activations for all 200 sequences simultaneously.

The config's `sources_global.embedding_batch_size: 32` existed but was never wired to `EmbeddingConfig` — it was dead config.

## Fix

Three files changed (21 insertions, 6 deletions):

1. **`mur-core/src/store/embedding.rs`** — Add `batch_size: usize` field to `EmbeddingConfig`, populated from `cfg.sources_global.embedding_batch_size` (default 32)
2. **`mur-core/src/codebase/mod.rs`** — Replace hardcoded `EMBED_BATCH_SIZE=200` with `embed_config.batch_size` + `FALLBACK_EMBED_BATCH_SIZE=32`
3. **`mur-core/src/cmd/reindex.rs`** — Same: replace `EMBED_BATCH=200` with config-driven value

**Effect:** Each HTTP request now sends 32 texts (configurable) instead of 200. Model server activation memory drops from ~10 GB → ~1.6 GB for 4B models.

Users can tune `sources_global.embedding_batch_size` in `~/.mur/config.yaml` to balance speed vs RAM for their specific model.

## Verification

- Build succeeds (`cargo build -p mur-core`)
- All 7 codebase unit tests pass (`cargo test -p mur-core --lib -- 'codebase::'`)
- No new clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)