### PR TITLE
fix(agent): robustness batch — list skips bad profiles, runtime --help, MUR_HOME for workflows

### DIFF
--- a/docs/superpowers/specs/2026-06-02-agent-skill-anthropic-layout-design.md
+++ b/docs/superpowers/specs/2026-06-02-agent-skill-anthropic-layout-design.md
@@ -1,0 +1,117 @@
+# Agent Skill Anthropic Layout — Design
+
+**Date:** 2026-06-02
+**Status:** Approved (design), pending implementation plan
+**Scope:** Per-agent skill storage only (`~/.mur/agents/<agent>/skills/`). The global
+skill layer (`~/.mur/skills/<name>/`, written by `sync_cmd`) is already
+Anthropic-compliant and is out of scope.
+
+## Problem
+
+Per-agent skills are installed as a **flat file** instead of the Anthropic
+skill-package directory format. Observed on disk for agent `Author`:
+
+```
+~/.mur/agents/Author/skills/technical-writing.md          # actual (wrong)
+```
+registered in `profile.yaml` as `skills/technical-writing.md`.
+
+The file *content* is already valid Anthropic format (frontmatter with only
+`name` + `description`, followed by a markdown body). Only the **placement** is
+wrong. The correct Anthropic layout is a directory whose entry point is the
+upper-case `SKILL.md`, so the package can also ship supporting resources:
+
+```
+~/.mur/agents/Author/skills/technical-writing/
+├── SKILL.md          # entry point (name + description frontmatter + body)
+├── scripts/          # optional executable helpers
+└── references/       # optional reference material
+```
+
+### Root cause
+
+`mur-core/src/cmd/agent/skill.rs::cmd_skill_add` copies the source file directly
+to `skills/<basename>` (`skill.rs:73`, `skills_dir.join(basename)`). It never
+creates a directory and silently drops any `scripts/` / `references/` that a
+package ships.
+
+### Why it currently "works" anyway
+
+The runtime loader reaches the flat file only through a **legacy fallback** in
+`mur-common/src/skill/store.rs::read_from_dir` (`dir.with_extension("md")`,
+parsed by the pre-M0 `parse_legacy_markdown`). It loads by luck of the deprecated
+path, not by design, and that path cannot carry supporting resources.
+
+## Decisions (best practice)
+
+| Concern | Decision | Rationale |
+|---|---|---|
+| Source of truth | **`SKILL.md` as-authored is canonical; do NOT convert to `skill.yaml`** | That is exactly what skill packages ship and what is already on disk; avoids mutating author content. |
+| Install source forms | **Accept both a single `.md` file and a directory** | Single file → wrap into `<name>/SKILL.md`. Directory → recursively copy the whole package (SKILL.md + scripts/ + references/ + assets/). |
+| On-disk entry filename | **Upper-case `SKILL.md`** | Anthropic official convention; matches the global layer `~/.mur/skills/<name>/SKILL.md`. |
+| `profile.yaml` registration | **Store the skill *name*** (`technical-writing`), not a file path | Aligns with the runtime loader, which identifies skills by directory name (`local::list_installed_agent` scans directories). |
+
+## Affected components
+
+### 1. Install — `mur-core/src/cmd/agent/skill.rs::cmd_skill_add`
+- Resolve a skill `<name>` from the source (file stem, or directory name).
+- Source is a `.md` file → create `skills/<name>/` and copy the file in as
+  `SKILL.md`.
+- Source is a directory → require a top-level `SKILL.md`; recursively copy the
+  whole directory tree to `skills/<name>/`.
+- Register `<name>` in `profile.skills` (was `skills/<basename>`).
+- Update `resolve_skill_id`, `cmd_skill_show`, `cmd_skill_remove` to the new
+  name/directory semantics. `remove` uses `remove_dir_all` on `skills/<name>/`.
+
+### 2. Loader read precedence — `mur-common/src/skill/store.rs::read_from_dir`
+Extend the lookup order to recognize the Anthropic entry file first:
+
+```
+SKILL.md  →  skill.yaml  →  skill.md  →  legacy flat <name>.md
+```
+
+`SKILL.md` is required explicitly because case-sensitive filesystems (Linux) do
+not match `skill.md` against `SKILL.md`; macOS case-insensitivity must not be
+relied upon.
+
+### 3. Lenient `SKILL.md` parsing
+Anthropic frontmatter carries only `name` + `description` + body. Parse it with
+the lenient defaulting already used by `parse_legacy_markdown`:
+- `content.abstract` ← `description`
+- `content.context` ← markdown body
+- supply sane defaults for absent `category` / `version` / `publisher`
+
+so an Anthropic-minimal `SKILL.md` loads without requiring MUR-specific fields.
+
+### 4. Export / Import recursion
+- `mur-agent-runtime/src/export/pkg.rs` (≈L97) and
+  `mur-agent-runtime/src/import.rs` (≈L98) currently iterate `skills/` and
+  `fs::copy` individual **files**, which skips subdirectories.
+- Change both to **recursively copy each skill directory**, so exported and
+  imported `.muragent` packages carry `scripts/` and `references/`.
+
+### 5. Migration of existing flat skills
+- Migrate `skills/<name>.md` → `skills/<name>/SKILL.md`, idempotent.
+- Run lazily on `mur agent skill add` and `mur agent skill list`, and expose an
+  explicit fix in `mur agent doctor`.
+- Rewrite any stale `profile.skills` entries of the form `skills/<name>.md` to
+  the bare `<name>`.
+- Result: `Author`'s `technical-writing.md` is upgraded in place to
+  `technical-writing/SKILL.md`.
+
+## Out of scope
+- Global `sync_cmd` skill layer — already correct.
+- Runtime injection semantics (e.g. the `SessionStart` trigger filter in
+  `inject_layer2`). This change only fixes on-disk layout, read precedence, and
+  package transport; it does not alter when/how skills are injected.
+
+## Acceptance criteria
+1. `mur agent skill add <file.md>` produces `skills/<name>/SKILL.md`.
+2. `mur agent skill add <dir/>` recursively installs a package containing
+   `SKILL.md`, `scripts/`, `references/`.
+3. The runtime loader loads a skill from `skills/<name>/SKILL.md`.
+4. `mur agent skill remove <name>` deletes the whole `skills/<name>/` directory.
+5. Exporting then importing an agent preserves `scripts/` and `references/`.
+6. An existing flat `skills/<name>.md` is migrated to `skills/<name>/SKILL.md`
+   and its `profile.skills` entry normalized to `<name>`.
+7. `profile.skills` stores skill names, not file paths.

--- a/mur-agent-runtime/src/subcommand.rs
+++ b/mur-agent-runtime/src/subcommand.rs
@@ -16,6 +16,12 @@ pub fn flag_value(args: &[String], flag: &str) -> Option<String> {
     None
 }
 
+/// Return true if any of `flags` appears as a standalone argument in `args`.
+/// Used to detect `--help`/`-h`/`--version`/`-V` before entering the serve loop.
+pub fn has_flag(args: &[String], flags: &[&str]) -> bool {
+    args.iter().any(|a| flags.iter().any(|f| a == f))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -43,5 +49,15 @@ mod tests {
     fn absent_flag_is_none() {
         let a = args(&["mur-agent-runtime"]);
         assert_eq!(flag_value(&a, "--load"), None);
+    }
+
+    #[test]
+    fn has_flag_detects_help_and_version() {
+        assert!(has_flag(&args(&["x", "--help"]), &["--help", "-h"]));
+        assert!(has_flag(&args(&["x", "-h"]), &["--help", "-h"]));
+        assert!(has_flag(&args(&["x", "-V"]), &["--version", "-V"]));
+        assert!(!has_flag(&args(&["x", "--load", "a"]), &["--help", "-h"]));
+        // `--help=foo` must NOT count as the bare flag.
+        assert!(!has_flag(&args(&["x", "--help=foo"]), &["--help", "-h"]));
     }
 }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -32,6 +32,33 @@ use std::sync::Arc;
 use tracing::{info, warn};
 
 pub async fn entrypoint() -> anyhow::Result<()> {
+    // Handle --help/--version before any side effects (process-group changes,
+    // socket creation, serve loop). Running the symlink with these flags must
+    // print and exit, not silently start the supervisor daemon.
+    let argv: Vec<String> = std::env::args().collect();
+    if crate::subcommand::has_flag(&argv, &["--help", "-h"]) {
+        let exe = argv
+            .first()
+            .map(String::as_str)
+            .unwrap_or("mur-agent-runtime");
+        println!(
+            "{exe} — MUR per-agent A2A supervisor runtime\n\n\
+             Usage: mur_agent_<name> [OPTIONS]\n\n\
+             Running with no options starts the agent's A2A supervisor (Unix socket).\n\n\
+             Options:\n  \
+             --load <PATH>   Load and run a portable .muragent package\n  \
+             -h, --help      Print this help and exit\n  \
+             -V, --version   Print version and exit\n\n\
+             Environment:\n  \
+             MUR_HOME        Override the MUR home directory (default ~/.mur)"
+        );
+        return Ok(());
+    }
+    if crate::subcommand::has_flag(&argv, &["--version", "-V"]) {
+        println!("mur-agent-runtime {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .init();
@@ -62,7 +89,6 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     let mur_home = std::env::var_os("MUR_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"));
-    let argv: Vec<String> = std::env::args().collect();
     let load_path = crate::subcommand::flag_value(&argv, "--load");
     let agent_home = if let Some(path) = load_path {
         match load_muragent_and_home(&path, &mur_home) {

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -483,10 +483,22 @@ fn collect_agents() -> Result<Vec<AgentRow>> {
         if !profile_path.exists() {
             continue;
         }
-        let yaml = fs::read_to_string(&profile_path)
-            .with_context(|| format!("read {}", profile_path.display()))?;
-        let profile: _AgentProfile = serde_yaml_ng::from_str(&yaml)
-            .with_context(|| format!("parse {}", profile_path.display()))?;
+        let yaml = match fs::read_to_string(&profile_path) {
+            Ok(y) => y,
+            Err(e) => {
+                eprintln!("warning: skipping {}: {e}", profile_path.display());
+                continue;
+            }
+        };
+        // A single malformed profile must not abort listing every other agent.
+        // Mirror the pattern store's skip-and-warn behavior (store/yaml.rs).
+        let profile: _AgentProfile = match serde_yaml_ng::from_str(&yaml) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("warning: skipping {}: {e}", profile_path.display());
+                continue;
+            }
+        };
 
         let lock_path = dir.join("running.lock");
         let (status, pid, uptime) = classify(&lock_path);

--- a/mur-core/src/cmd/workflow.rs
+++ b/mur-core/src/cmd/workflow.rs
@@ -50,10 +50,7 @@ pub(crate) async fn cmd_workflow_run(query: &str, fail_fast: bool, prompt: bool)
     }
 
     // Semantic search
-    let index_path = dirs::home_dir()
-        .expect("no home dir")
-        .join(".mur")
-        .join("index");
+    let index_path = crate::paths::mur_root(None).join("index");
 
     let mut best_name: Option<String> = None;
 
@@ -285,10 +282,7 @@ pub(crate) async fn cmd_workflow_search(query: &str, limit: usize) -> Result<()>
         return Ok(());
     }
 
-    let index_path = dirs::home_dir()
-        .expect("no home dir")
-        .join(".mur")
-        .join("index");
+    let index_path = crate::paths::mur_root(None).join("index");
 
     if index_path.exists() {
         // Semantic search via LanceDB
@@ -492,9 +486,7 @@ pub(crate) fn cmd_workflow_publish(name: &str, team: &str) -> Result<()> {
     let device_os = crate::auth::get_device_os();
 
     let yaml_content = std::fs::read_to_string(
-        dirs::home_dir()
-            .unwrap_or_default()
-            .join(".mur")
+        crate::paths::mur_root(None)
             .join("workflows")
             .join(format!("{}.yaml", name)),
     )?;
@@ -789,10 +781,7 @@ pub(crate) fn collect_tags_from_patterns(
 use mur_common::schedule::{Schedule, ScheduleNotify, SchedulesFile};
 
 fn schedules_path() -> std::path::PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("~"))
-        .join(".mur")
-        .join("schedules.yaml")
+    crate::paths::mur_root(None).join("schedules.yaml")
 }
 
 fn load_schedules() -> Result<Vec<Schedule>> {

--- a/mur-core/src/store/workflow_yaml.rs
+++ b/mur-core/src/store/workflow_yaml.rs
@@ -30,10 +30,9 @@ impl WorkflowYamlStore {
 
     /// Create a WorkflowYamlStore using the default ~/.mur/workflows/ path.
     pub fn default_store() -> Result<Self> {
-        let dir = dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("~"))
-            .join(".mur")
-            .join("workflows");
+        // Honor MUR_HOME via the canonical resolver so workflows live in the
+        // same home as agents/patterns (see crate::paths).
+        let dir = crate::paths::mur_root(None).join("workflows");
         Self::new(dir)
     }
 


### PR DESCRIPTION
## Summary

Three independent robustness fixes discovered while harness-testing `mur agent` operations. All found by exercising the real CLI; each fixed at its root cause with a focused change.

### 1. `mur agent list` aborts on one malformed profile
A single `profile.yaml` failing to parse (e.g. a legacy profile missing the `schema` field) made `mur agent list` exit 1 with `missing field schema` — hiding **every** healthy agent. `collect_agents()` now skips-and-warns per profile (mirroring the pattern store in `store/yaml.rs`) instead of propagating with `?`.

### 2. Agent runtime ignores `--help` / `--version` (starts a daemon)
Running `mur_agent_<name> --help` silently started the A2A supervisor (created socket + `running.lock`) instead of printing help. `entrypoint()` now handles `--help`/`-h`/`--version`/`-V` **before any side effects** and exits. Adds `subcommand::has_flag()` + unit test.

### 3. Workflows ignore `MUR_HOME`
`WorkflowYamlStore::default_store()` and several `workflow.rs` paths (semantic index, team-workflow download, `schedules.yaml`) used `dirs::home_dir().join(".mur")` directly, bypassing the canonical `paths::mur_root()` resolver — so they read the real `~/.mur` even when `MUR_HOME` pointed elsewhere (agents/patterns already honored it). Routed through `paths::mur_root(None)`.

## Testing
- `cargo build` / `cargo clippy -p mur-core -p mur-agent-runtime` — clean.
- New unit test `subcommand::has_flag_detects_help_and_version` passes.
- End-to-end validated against a real `~/.mur` containing malformed profiles:
  - `mur agent list` now lists healthy agents with per-profile warnings.
  - `mur_agent_<name> --help`/`--version` print and exit 0.
  - `MUR_HOME=/tmp/x mur workflow list` reads the override, not `~/.mur`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)