### PR TITLE
feat(agent): status emoji in mur agent list

### DIFF
--- a/mur-common/src/lock_file.rs
+++ b/mur-common/src/lock_file.rs
@@ -22,6 +22,19 @@ pub enum AgentStatusKind {
     Stopped,
 }
 
+impl AgentStatusKind {
+    /// Stable visual marker for this status — the single source of truth for
+    /// the status→emoji mapping used by `mur agent list` and the agent card.
+    /// Exhaustive match: adding a variant is a compile error here by design.
+    pub fn emoji(&self) -> &'static str {
+        match self {
+            AgentStatusKind::Running => "🟢",
+            AgentStatusKind::Stale => "🟡",
+            AgentStatusKind::Stopped => "⚪",
+        }
+    }
+}
+
 /// Result of classifying an agent's lock state.
 #[derive(Debug, Clone, Copy)]
 pub struct AgentStatus {
@@ -116,6 +129,13 @@ pub fn classify(lock_path: &Path) -> AgentStatus {
 mod tests {
     use super::*;
     use crate::agent::LockTransports;
+
+    #[test]
+    fn status_emoji_mapping_is_stable() {
+        assert_eq!(AgentStatusKind::Running.emoji(), "🟢");
+        assert_eq!(AgentStatusKind::Stale.emoji(), "🟡");
+        assert_eq!(AgentStatusKind::Stopped.emoji(), "⚪");
+    }
 
     fn make_lock(pid: u32) -> LockFile {
         LockFile {

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -260,6 +260,10 @@ fn default_entitlements_custom() -> Entitlements {
 struct AgentRow {
     name: String,
     status: &'static str,
+    // Derived visual marker for `status`; CLI table only — kept out of the
+    // `--json` payload (PM scope: only the human table gains the column).
+    #[serde(skip)]
+    emoji: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pid: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -427,8 +431,8 @@ pub fn cmd_list(json: bool) -> Result<()> {
         println!("{}", serde_json::to_string(&rows)?);
     } else {
         println!(
-            "{:<20} {:<10} {:<20} {:<10} {:<12}",
-            "NAME", "STATUS", "UPTIME", "PID", "CATEGORY"
+            "{:<20} {:<6} {:<10} {:<20} {:<10} {:<12}",
+            "NAME", "EMOJI", "STATUS", "UPTIME", "PID", "CATEGORY"
         );
         for r in &rows {
             let pid = r
@@ -437,8 +441,8 @@ pub fn cmd_list(json: bool) -> Result<()> {
                 .unwrap_or_else(|| "-".to_string());
             let uptime = r.uptime.clone().unwrap_or_else(|| "-".to_string());
             println!(
-                "{:<20} {:<10} {:<20} {:<10} {:<12}",
-                r.name, r.status, uptime, pid, r.category
+                "{:<20} {:<6} {:<10} {:<20} {:<10} {:<12}",
+                r.name, r.emoji, r.status, uptime, pid, r.category
             );
         }
     }
@@ -501,10 +505,11 @@ fn collect_agents() -> Result<Vec<AgentRow>> {
         };
 
         let lock_path = dir.join("running.lock");
-        let (status, pid, uptime) = classify(&lock_path);
+        let (status, emoji, pid, uptime) = classify(&lock_path);
         rows.push(AgentRow {
             name: profile.name,
             status,
+            emoji,
             pid,
             uptime,
             category: format!("{:?}", profile.persona.category).to_lowercase(),
@@ -519,7 +524,7 @@ fn collect_agents() -> Result<Vec<AgentRow>> {
 /// Returns `(status_str, pid, uptime)`. Delegates to
 /// `mur_common::lock_file::classify` for the 3-state liveness logic and
 /// adds uptime computation (CLI-specific) on top.
-fn classify(lock_path: &Path) -> (&'static str, Option<u32>, Option<String>) {
+fn classify(lock_path: &Path) -> (&'static str, &'static str, Option<u32>, Option<String>) {
     use mur_common::lock_file::AgentStatusKind;
     let status = mur_common::lock_file::classify(lock_path);
     let status_str = match status.kind {
@@ -527,6 +532,7 @@ fn classify(lock_path: &Path) -> (&'static str, Option<u32>, Option<String>) {
         AgentStatusKind::Stale => "stale",
         AgentStatusKind::Stopped => "stopped",
     };
+    let emoji = status.kind.emoji();
     // Compute uptime from the lock file's started_at only when running.
     let uptime = if status.kind == AgentStatusKind::Running {
         mur_common::lock_file::read(lock_path)
@@ -542,7 +548,7 @@ fn classify(lock_path: &Path) -> (&'static str, Option<u32>, Option<String>) {
     } else {
         None
     };
-    (status_str, status.pid, uptime)
+    (status_str, emoji, status.pid, uptime)
 }
 
 // ─── stop / remove / rename ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a status→emoji column to `mur agent list`. This was built as the deliverable of a **7-role agent-team collaboration relay** (PM → Architect → Rust → DevOps → Reviewer → Security → QA) running as real mur runtime agents over A2A; the design decisions below trace directly to that relay (transcript on the `test/harness-agent-emoji` branch).

## What changed
- **`mur-common` (`AgentStatusKind::emoji()`)** — single source of truth, exhaustive `match` (adding a status variant is a compile error here by design). Mapping: `Running 🟢` · `Stale 🟡` · `Stopped ⚪`.
- **`mur-core` (`mur agent list`)** — new `EMOJI` column, immediately left of `STATUS`, populated from `AgentStatusKind::emoji()`.

## Design notes (from the team relay)
- **Architect**: method-on-enum over free fn → exhaustive, discoverable, zero-alloc `&'static str`.
- **PM scope**: human table only — `mur agent list --json` is **unchanged** (`emoji` is `#[serde(skip)]`).
- **Security**: emoji is *derived locally* from runtime status, never accepted from input → no untrusted-glyph / ZWJ / RTL-override / combining-mark injection surface.
- **Reviewer**: a non-optional emoji field on the A2A agent card would be a wire-format break → that part is **deferred** out of this PR.
- Adapted the PM's imagined 4 states to the real 3-state `AgentStatusKind` (no `error`/`starting` enum exists; `Stale` maps to 🟡).

## Testing
- `cargo build --release` / `cargo clippy -p mur-core -p mur-common` — clean.
- Unit test `status_emoji_mapping_is_stable` (all 3 variants) passes.
- Live: `mur agent list` shows the EMOJI column (🟢 for running agents); `--json` keys unchanged (`category,name,pid,status,uptime`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)