### PR TITLE
fix(agent): scrub removed export formats from CLI + stop --load clobbering identity

### DIFF
--- a/mur-common/src/muragent/installer.rs
+++ b/mur-common/src/muragent/installer.rs
@@ -244,11 +244,27 @@ fn try_apply_rotation(
     Ok(())
 }
 
-/// Remove every entry in `dir` except `data/`. Used by the update path.
+/// Files and directories that must survive an in-place update: the agent's
+/// runtime `data/` and its local identity keypair (private material the
+/// incoming, sanitized package never carries — clobbering it would orphan the
+/// agent's signing key and break re-export).
+const PRESERVE_ON_UPDATE: &[&str] = &[
+    "data",
+    "identity.key",
+    "identity.pub",
+    "identity.key.prev",
+    "identity.pub.prev",
+];
+
+/// Remove every entry in `dir` except the [`PRESERVE_ON_UPDATE`] set. Used by
+/// the update path.
 fn clear_except_data(dir: &Path) -> Result<(), MuragentError> {
     for entry in fs::read_dir(dir).map_err(MuragentError::Io)? {
         let entry = entry.map_err(MuragentError::Io)?;
-        if entry.file_name() == "data" {
+        if PRESERVE_ON_UPDATE
+            .iter()
+            .any(|keep| entry.file_name() == *keep)
+        {
             continue;
         }
         let path = entry.path();
@@ -422,6 +438,55 @@ mod tests {
         assert!(outcome2.was_update);
         let preserved = fs::read(data_dir.join("history.jsonl")).unwrap();
         assert_eq!(preserved, b"important");
+
+        // Cleanup
+        unsafe {
+            if let Some(p) = prev {
+                std::env::set_var("MUR_HOME", p);
+            } else {
+                std::env::remove_var("MUR_HOME");
+            }
+        }
+    }
+
+    #[test]
+    fn update_preserves_local_identity_keypair() {
+        // Regression: loading a template-mode (.muragent carries no private
+        // key) package over an existing agent must NOT delete the agent's
+        // locally-minted identity keypair, or `mur agent export` afterward
+        // fails with "identity files not found".
+        let _guard = crate::trust::test_env_lock::MUR_HOME_LOCK.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let mur_home = tmp.path().join("mur");
+        let prev = std::env::var_os("MUR_HOME");
+        unsafe { std::env::set_var("MUR_HOME", &mur_home) };
+
+        let pkg = make_test_package(&tmp);
+        let archive = MuragentArchive::read(&pkg).unwrap();
+        let outcome = install(&archive, &mur_home, "test").unwrap();
+        let slug = outcome.manifest.agent.slug.clone();
+        let agent_dir = mur_home.join("agents").join(&slug);
+
+        // Simulate a locally-minted keypair (as `mur agent create` writes).
+        fs::write(agent_dir.join("identity.key"), b"PRIVATE-KEY").unwrap();
+        fs::write(agent_dir.join("identity.pub"), b"PUBLIC-KEY").unwrap();
+
+        // Re-install (same archive, same UUID) → update path runs clear_except_data.
+        let outcome2 = install(&archive, &mur_home, "test").unwrap();
+        assert!(outcome2.was_update);
+
+        assert!(
+            agent_dir.join("identity.key").exists(),
+            "identity.key must survive an in-place update"
+        );
+        assert_eq!(
+            fs::read(agent_dir.join("identity.key")).unwrap(),
+            b"PRIVATE-KEY"
+        );
+        assert!(
+            agent_dir.join("identity.pub").exists(),
+            "identity.pub must survive an in-place update"
+        );
 
         // Cleanup
         unsafe {

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -122,30 +122,18 @@ pub enum AgentAction {
         #[command(subcommand)]
         action: AgentPermAction,
     },
-    /// Export an agent to a .muragent (default, signed v2 portable), .murpkg (legacy),
-    /// self-contained binary, or click-to-launch GUI app
+    /// Export an agent to a portable `.muragent` (default, signed v2) or a
+    /// legacy `.murpkg`. Recipients open it with the MuR Hub app or run it
+    /// headless via `mur-agent-runtime --load <file>.muragent`.
     Export {
         /// Agent name
         name: String,
-        /// Output path (e.g. agent.muragent, agent.murpkg, my_agent, or MyAgent.app)
+        /// Output path (e.g. agent.muragent or agent.murpkg)
         #[arg(long, short = 'o')]
         out: String,
-        /// Format: "muragent" (default — signed v2 portable), "pkg" (legacy v1), "bin", or "gui"
+        /// Format: "muragent" (default — signed v2 portable) or "pkg" (legacy v1)
         #[arg(long, default_value = "muragent")]
         format: String,
-        /// (gui only) Default theme baked into the bundle
-        #[arg(long, default_value = "light")]
-        theme: String,
-        /// (gui only) Override theme's app icon with this PNG
-        #[arg(long)]
-        icon: Option<String>,
-        /// (gui only) Embed identity.{key,pub} so recipient inherits identity
-        /// (rekeys on first launch). Default: template mode mints fresh keys.
-        #[arg(long)]
-        clone_identity: bool,
-        /// (gui only) Skip macOS codesign + notarization (testing only)
-        #[arg(long)]
-        skip_notarize: bool,
     },
     /// Install an agent from a signed `.muragent` package
     Install {

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1158,9 +1158,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 cmd::agent::cmd_perm_set_limit(&name, &key, value)?
             }
         },
-        AgentAction::Export {
-            name, out, format, ..
-        } => {
+        AgentAction::Export { name, out, format } => {
             cmd::agent::cmd_export(&name, &out, &format)?;
         }
         AgentAction::Install { path, model } => {


### PR DESCRIPTION
## Harness-found bug batch — `mur agent export` round-trip test

Found while harness-testing the export → run round trip (build agent → export `.muragent` → `mur-agent-runtime --load` → run).

### 1. Stale `--help` advertises removed formats
`mur agent export --help` advertised `bin`, `gui` (`.app`) formats and gui-only flags (`--theme/--icon/--clone-identity/--skip-notarize`). The code `bail!`s on `bin`/`gui` as *"no longer supported"*. Trimmed the `Export` clap variant to the two real formats (`muragent`, `pkg`).

### 2. Dead gui-only flags silently accepted
The gui-only flags were still parsed and silently ignored under `--format=muragent` — even `--icon /nonexistent.png` returned exit 0. Removed them (dispatch already dropped them via `..`).

### 3. `--load` clobbers an existing agent's identity keypair (data loss)
Loading a `.muragent` into a home that already has a same-named agent took the *update* path, whose `clear_except_data()` deleted everything but `data/` — including the locally-minted `identity.key`/`identity.pub`. The incoming **template-mode** package carries no private key, so the keypair was destroyed and subsequent `mur agent export <name>` failed with *"identity files not found"*.

Fix: `clear_except_data()` now preserves the identity keypair as well (`PRESERVE_ON_UPDATE`: `data`, `identity.{key,pub}`, `identity.{key,pub}.prev`). Adds regression test `update_preserves_local_identity_keypair`.

### Verification
- `cargo test -p mur-common muragent::installer` → 4 ok (incl. new regression)
- `cargo fmt --check` clean, `cargo clippy -p mur-core -p mur-common` clean
- End-to-end: create → export → `--load` into same home → identity survives → re-export exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)