### PR TITLE
fix(agent): bundle sys_prompt + skills in .muragent export

### DIFF
--- a/mur-common/src/muragent/installer.rs
+++ b/mur-common/src/muragent/installer.rs
@@ -347,6 +347,44 @@ mod tests {
         out
     }
 
+    #[test]
+    fn install_extracts_sys_prompt_and_skills() {
+        // Regression: `.muragent` export must bundle the system prompt and
+        // skill files so the loaded agent keeps its persona + non-dangling
+        // skill registrations.
+        let _guard = crate::trust::test_env_lock::MUR_HOME_LOCK.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let mur_home = tmp.path().join("mur");
+        let prev = std::env::var_os("MUR_HOME");
+        unsafe { std::env::set_var("MUR_HOME", &mur_home) };
+
+        let profile = AgentProfile::default_for_tests();
+        let manifest = build_manifest_from_profile(&profile, "2.13.0");
+        let profile_yaml = serde_yaml_ng::to_string(&profile).unwrap();
+        let mut writer = MuragentWriter::new(manifest, profile_yaml, AgentIdentity::generate());
+        writer.set_sys_prompt("You are a helpful test agent.".into());
+        writer.add_skill("demo.md", b"# demo skill\nbody".to_vec());
+        let out = tmp.path().join("withextras.muragent");
+        writer.write(&out).unwrap();
+
+        let archive = MuragentArchive::read(&out).unwrap();
+        let outcome = install(&archive, &mur_home, "test").unwrap();
+        let agent_dir = mur_home.join("agents").join(&outcome.manifest.agent.slug);
+
+        let prompt = fs::read_to_string(agent_dir.join("sys_prompt.md")).unwrap();
+        assert_eq!(prompt, "You are a helpful test agent.");
+        let skill = fs::read_to_string(agent_dir.join("skills").join("demo.md")).unwrap();
+        assert_eq!(skill, "# demo skill\nbody");
+
+        unsafe {
+            if let Some(p) = prev {
+                std::env::set_var("MUR_HOME", p);
+            } else {
+                std::env::remove_var("MUR_HOME");
+            }
+        }
+    }
+
     fn make_test_package_with_identity(
         tmp: &TempDir,
         identity: &AgentIdentity,

--- a/mur-common/src/muragent/writer.rs
+++ b/mur-common/src/muragent/writer.rs
@@ -19,6 +19,8 @@ pub struct MuragentWriter {
     identity: AgentIdentity,
     icon_files: Vec<(String, Vec<u8>)>,
     voice_yaml: Option<String>,
+    sys_prompt_md: Option<String>,
+    skill_files: Vec<(String, Vec<u8>)>,
     commander_assets: Vec<(String, Vec<u8>)>,
     hub_assets: Vec<(String, Vec<u8>)>,
 }
@@ -31,6 +33,8 @@ impl MuragentWriter {
             identity,
             icon_files: Vec::new(),
             voice_yaml: None,
+            sys_prompt_md: None,
+            skill_files: Vec::new(),
             commander_assets: Vec::new(),
             hub_assets: Vec::new(),
         }
@@ -42,6 +46,18 @@ impl MuragentWriter {
 
     pub fn set_voice_yaml(&mut self, yaml: String) {
         self.voice_yaml = Some(yaml);
+    }
+
+    /// Bundle the agent's system prompt so the recipient runs with the same
+    /// persona/instructions (without this the loaded agent has no prompt).
+    pub fn set_sys_prompt(&mut self, md: String) {
+        self.sys_prompt_md = Some(md);
+    }
+
+    /// Bundle a skill markdown file under `skills/<name>` so skill
+    /// registrations in the profile keep their backing file after load.
+    pub fn add_skill(&mut self, name: &str, data: Vec<u8>) {
+        self.skill_files.push((format!("skills/{name}"), data));
     }
 
     pub fn add_commander_asset(&mut self, path: &str, data: Vec<u8>) {
@@ -94,6 +110,14 @@ impl MuragentWriter {
             add_blob(&mut tar, "voice/voice.yaml", voice_yaml.as_bytes())?;
         }
 
+        if let Some(ref sys_prompt) = self.sys_prompt_md {
+            add_blob(&mut tar, "sys_prompt.md", sys_prompt.as_bytes())?;
+        }
+
+        for (name, data) in &self.skill_files {
+            add_blob(&mut tar, name, data)?;
+        }
+
         for (name, data) in &self.commander_assets {
             add_blob(&mut tar, name, data)?;
         }
@@ -129,6 +153,14 @@ impl MuragentWriter {
 
         if let Some(ref voice) = self.voice_yaml {
             files.push(("voice/voice.yaml".into(), voice.as_bytes().to_vec()));
+        }
+
+        if let Some(ref sys_prompt) = self.sys_prompt_md {
+            files.push(("sys_prompt.md".into(), sys_prompt.as_bytes().to_vec()));
+        }
+
+        for (name, data) in &self.skill_files {
+            files.push((name.clone(), data.clone()));
         }
 
         for (name, data) in &self.commander_assets {

--- a/mur-core/src/cmd/agent/export.rs
+++ b/mur-core/src/cmd/agent/export.rs
@@ -105,6 +105,33 @@ fn export_muragent(name: &str, agent_home: &Path, out: &Path) -> Result<()> {
         writer.set_voice_yaml(voice);
     }
 
+    // System prompt (persona / core instructions) — without this the loaded
+    // agent runs with no prompt.
+    let sys_prompt_path = agent_home.join("sys_prompt.md");
+    if sys_prompt_path.exists() {
+        let md = fs::read_to_string(&sys_prompt_path)
+            .with_context(|| format!("read {}", sys_prompt_path.display()))?;
+        writer.set_sys_prompt(md);
+    }
+
+    // Skill backing files — the profile keeps the skill registrations; bundle
+    // the files so they aren't dangling references after load.
+    let skills_dir = agent_home.join("skills");
+    if skills_dir.exists() {
+        for entry in fs::read_dir(&skills_dir)
+            .with_context(|| format!("read {}", skills_dir.display()))?
+            .flatten()
+        {
+            if entry.file_type().map(|t| t.is_file()).unwrap_or(false)
+                && let Some(name) = entry.file_name().to_str()
+            {
+                let data = fs::read(entry.path())
+                    .with_context(|| format!("read skill {}", entry.path().display()))?;
+                writer.add_skill(name, data);
+            }
+        }
+    }
+
     writer
         .write(out)
         .with_context(|| format!("write .muragent to {}", out.display()))?;

--- a/mur-hub-gui/src-tauri/tests/muragent_open_roundtrip.rs
+++ b/mur-hub-gui/src-tauri/tests/muragent_open_roundtrip.rs
@@ -1,0 +1,51 @@
+//! Phase D harness: load a `.muragent` through the **Hub GUI** open path
+//! (`install_muragent_file`, the same Tauri command the app invokes on a
+//! `.muragent` file association) and assert the bundled system prompt + skill
+//! files land in the recipient home. Exercises the batch-2 export-fidelity fix
+//! through the GUI surface, not just the CLI.
+
+use std::fs;
+
+use mur_common::AgentProfile;
+use mur_common::identity::AgentIdentity;
+use mur_common::muragent::writer::{MuragentWriter, build_manifest_from_profile};
+
+#[test]
+fn hub_gui_open_muragent_lands_prompt_and_skills() {
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    // Build a signed .muragent carrying a system prompt + a skill file.
+    let mut profile = AgentProfile::default_for_tests();
+    profile.name = "hubbot".into();
+    let manifest = build_manifest_from_profile(&profile, env!("CARGO_PKG_VERSION"));
+    let profile_yaml = serde_yaml_ng::to_string(&profile).unwrap();
+    let mut writer = MuragentWriter::new(manifest, profile_yaml, AgentIdentity::generate());
+    writer.set_sys_prompt("You are HubBot, opened via the Hub GUI.".into());
+    writer.add_skill("greet.md", b"# greet\nsay hi".to_vec());
+    let pkg = tmp.path().join("hubbot.muragent");
+    writer.write(&pkg).unwrap();
+
+    // Point the install at an isolated home and invoke the GUI command.
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).unwrap();
+    // SAFETY: single-threaded test; trust::mur_home() reads MUR_HOME.
+    unsafe { std::env::set_var("MUR_HOME", &home) }
+
+    let receipt =
+        mur_hub_gui_lib::import_muragent::install_muragent_file(pkg.to_string_lossy().into_owned())
+            .expect("Hub GUI install_muragent_file should succeed");
+
+    let agent_dir = home.join("agents").join(&receipt.slug);
+    assert_eq!(
+        fs::read_to_string(agent_dir.join("sys_prompt.md")).unwrap(),
+        "You are HubBot, opened via the Hub GUI.",
+        "system prompt must survive the Hub GUI open path"
+    );
+    assert_eq!(
+        fs::read_to_string(agent_dir.join("skills").join("greet.md")).unwrap(),
+        "# greet\nsay hi",
+        "skill backing file must survive the Hub GUI open path"
+    );
+
+    unsafe { std::env::remove_var("MUR_HOME") }
+}


### PR DESCRIPTION
## Harness-found bug batch 2 — export fidelity

Found while running the export → run round trip with a real 3-agent team: an exported then `--load`ed agent had lost its system prompt and its skill files.

The `.muragent` writer bundled only `profile.yaml` + icons + voice. Confirmed via `tar tzf agent.muragent`. So export dropped:

### sys_prompt.md (data loss)
The agent's system prompt — its persona / core instructions. After `--load`, `agent prompt show` errored and the recipient agent ran with **no prompt**.

### skills/*.md (dangling references)
Skill *registrations* live in `profile.yaml`, so `skill list` still listed them — but the backing files were gone. `skill show` failed with *No such file or directory*.

The legacy `.murpkg` writer already bundled both (`pkg.rs`); the v2 `.muragent` path had regressed.

### Fix
- `MuragentWriter` gains `set_sys_prompt()` / `add_skill()`. Both are added to the tar **and** the in-toto subject list, so DSSE signatures still verify.
- `export.rs` reads `sys_prompt.md` + `skills/*` from the agent home.
- The installer's `extract_payload` already restores any archived file → no load-side change.

### Verification
- `cargo test -p mur-common muragent::installer` → 5 ok (incl. new `install_extracts_sys_prompt_and_skills`)
- `cargo fmt --check` clean, `cargo clippy` clean
- End-to-end: export → `--load` into a fresh home → prompt + skill file present, `skill show` works, `inspect` shows **Signature: VALID**

🤖 Generated with [Claude Code](https://claude.com/claude-code)