### PR TITLE
fix: prefer mur project search over grep — hook parity + search skill + MCP wiring

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "mur": {
+      "command": "mur-mcp-server",
+      "args": [],
+      "env": {}
+    }
+  }
+}

--- a/build.sh
+++ b/build.sh
@@ -56,5 +56,11 @@ if $INSTALL; then
 #  cp "$BINARY" /usr/local/bin/mur
   echo "📥 Installing to /opt/homebrew/bin/mur..."
   sudo cp "$BINARY" /opt/homebrew/bin/mur
+
+  MCP_BINARY="$SCRIPT_DIR/target/release/mur-mcp-server"
+  if [ -f "$MCP_BINARY" ]; then
+    sudo cp "$MCP_BINARY" /opt/homebrew/bin/mur-mcp-server
+    echo "Installed mur-mcp-server -> /opt/homebrew/bin/mur-mcp-server"
+  fi
   echo "✅ Installed: $(mur --version 2>/dev/null || echo 'done')"
 fi

--- a/docs/superpowers/plans/2026-06-02-prefer-mur-project-search-over-grep.md
+++ b/docs/superpowers/plans/2026-06-02-prefer-mur-project-search-over-grep.md
@@ -1,0 +1,438 @@
+# Prefer `mur project search` over grep — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Steer Claude Code toward `mur project search` for concept/intent queries while keeping grep authoritative for exact/exhaustive/just-edited searches.
+
+**Architecture:** Three independent pieces — (1) fix the background-index worker so it installs the git post-commit auto-reindex hook (parity with the foreground path); (2) ship a new builtin `mur-project-search` guiding skill that encodes the tool-choice rule; (3) connect the `mur-mcp-server` binary to Claude Code via a project `.mcp.json` so `mur_project_search` becomes a first-class tool.
+
+**Tech Stack:** Rust (edition 2024, workspace crates `mur-core` / `mur-mcp-server`), embedded builtin skills (YAML via `include_str!`), MCP stdio JSON-RPC, git hooks.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-prefer-mur-project-search-over-grep-design.md`
+
+**Commit author note:** this repo's local git config is `github-actions[bot]`. For hand commits, set the author explicitly: `--author="karajanchang <david@twdd.com.tw>"` (also pass `-c user.name=karajanchang -c user.email=david@twdd.com.tw`). Every commit body ends with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+
+---
+
+## File Structure
+
+- `mur-core/src/codebase/mod.rs` — `ensure_git_hook` already implemented (line 707). **Add** a `#[cfg(test)]` module (none exists today) covering create/append/idempotency.
+- `mur-core/src/cmd/project.rs` — `cmd_project_index_worker` (line ~489) is the background path that **omits** the `ensure_git_hook` call the foreground path has (line 333). **Modify** to call it on success.
+- `mur-core/src/skills/mur_project_search.yaml` — **Create**. New builtin guiding skill (mirrors `mur_project_index.yaml`).
+- `mur-core/src/cmd/sync_cmd.rs` — `ensure_mur_skill` (line 1127) embeds builtin skills via `include_str!`. **Modify** the `skills` array to register the new skill.
+- `.mcp.json` (repo root) — **Create**. Project-scoped MCP server registration launching `mur-mcp-server`.
+- `build.sh` — **Modify** to build + install the `mur-mcp-server` binary alongside `mur`.
+- `mur-mcp-server/tests/integration.rs` — **Modify** to assert `mur_project_search` appears in `tools/list`.
+
+---
+
+## Task 1: Background-index worker installs the git hook
+
+The foreground index path calls `ensure_git_hook` (`project.rs:333`); the background worker (`cmd_project_index_worker`) does not. A large project whose first index runs via `--background` silently skips hook install. `ensure_git_hook` itself has zero tests. Add tests for it, then add the missing call.
+
+**Files:**
+- Modify: `mur-core/src/codebase/mod.rs` (add `#[cfg(test)]` module at end of file; `ensure_git_hook` at line 707)
+- Modify: `mur-core/src/cmd/project.rs` (`cmd_project_index_worker`, ~line 489)
+
+- [ ] **Step 1: Write failing tests for `ensure_git_hook`**
+
+Append to `mur-core/src/codebase/mod.rs` (end of file). The function signature is `pub fn ensure_git_hook(project_path: &Path, quiet: bool) -> Result<bool>` and the marker string is `# mur auto-index`.
+
+```rust
+#[cfg(test)]
+mod git_hook_tests {
+    use super::ensure_git_hook;
+    use std::fs;
+
+    /// Build a temp dir that looks like a git repo (just needs `.git/hooks`).
+    fn temp_repo() -> std::path::PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "mur-hook-test-{}-{}",
+            std::process::id(),
+            // monotonic-ish unique suffix without Instant/rand
+            fs::read_dir(std::env::temp_dir()).map(|d| d.count()).unwrap_or(0)
+        ));
+        fs::create_dir_all(base.join(".git").join("hooks")).unwrap();
+        base
+    }
+
+    #[test]
+    fn creates_hook_with_shebang_when_absent() {
+        let repo = temp_repo();
+        let installed = ensure_git_hook(&repo, true).unwrap();
+        assert!(installed, "should report it installed the hook");
+
+        let hook = repo.join(".git/hooks/post-commit");
+        let body = fs::read_to_string(&hook).unwrap();
+        assert!(body.starts_with("#!/bin/sh"), "must start with shebang");
+        assert!(body.contains("# mur auto-index"), "must contain marker");
+        assert!(body.contains("project index"), "must run project index");
+
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn is_idempotent_on_second_call() {
+        let repo = temp_repo();
+        assert!(ensure_git_hook(&repo, true).unwrap());
+        // Second call must be a no-op (marker already present).
+        let installed_again = ensure_git_hook(&repo, true).unwrap();
+        assert!(!installed_again, "second call should return false");
+
+        let body = fs::read_to_string(repo.join(".git/hooks/post-commit")).unwrap();
+        assert_eq!(
+            body.matches("# mur auto-index").count(),
+            1,
+            "marker must appear exactly once"
+        );
+
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn appends_to_existing_hook_without_clobbering() {
+        let repo = temp_repo();
+        let hook = repo.join(".git/hooks/post-commit");
+        fs::write(&hook, "#!/bin/sh\necho existing-user-hook\n").unwrap();
+
+        let installed = ensure_git_hook(&repo, true).unwrap();
+        assert!(installed);
+
+        let body = fs::read_to_string(&hook).unwrap();
+        assert!(
+            body.contains("echo existing-user-hook"),
+            "must preserve the pre-existing hook content"
+        );
+        assert!(body.contains("# mur auto-index"), "must append marker block");
+
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn returns_false_when_not_a_git_repo() {
+        let base = std::env::temp_dir().join(format!("mur-hook-nogit-{}", std::process::id()));
+        fs::create_dir_all(&base).unwrap();
+        // No .git/hooks dir → ensure_git_hook returns Ok(false).
+        assert!(!ensure_git_hook(&base, true).unwrap());
+        fs::remove_dir_all(&base).ok();
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they pass against existing `ensure_git_hook`**
+
+Run: `cargo test -p mur-core git_hook_tests`
+Expected: all four PASS (they characterize the existing, correct `ensure_git_hook`). If `appends_to_existing_hook_without_clobbering` or `is_idempotent_on_second_call` fail, that is a real defect in `ensure_git_hook` — fix the function before continuing; otherwise proceed.
+
+- [ ] **Step 3: Add the missing `ensure_git_hook` call to the background worker**
+
+In `mur-core/src/cmd/project.rs`, inside `cmd_project_index_worker`, in the `Ok(stats) => { ... }` arm, after `index.release_lock();` and before the `send_notification(...)` call, add:
+
+```rust
+            // Parity with the foreground path: install the post-commit
+            // auto-reindex hook on first successful index (idempotent).
+            let _ = crate::codebase::ensure_git_hook(&project_path, true);
+```
+
+(Use `let _ =` — a hook-install failure must not fail or mask a successful index. `quiet = true` because the worker has no foreground console.)
+
+- [ ] **Step 4: Verify it compiles and the suite still passes**
+
+Run: `cargo build -p mur-core && cargo test -p mur-core git_hook_tests`
+Expected: build succeeds; four tests PASS.
+
+- [ ] **Step 5: Verify lint clean**
+
+Run: `cargo clippy -p mur-core -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/codebase/mod.rs mur-core/src/cmd/project.rs
+git -c user.name=karajanchang -c user.email=david@twdd.com.tw commit \
+  --author="karajanchang <david@twdd.com.tw>" -m "fix(project): install git hook from background index worker
+
+Background index path skipped ensure_git_hook, so a large project's
+first --background index never installed the post-commit auto-reindex
+hook. Add the call (idempotent) for parity with the foreground path,
+plus characterization tests for ensure_git_hook.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add the `mur-project-search` guiding skill
+
+The mur skills loaded at session start cover indexing/removal only. There is no skill teaching the tool-choice rule. Ship one as a builtin so it auto-installs for all users (same mechanism as `mur-project-index`).
+
+**Files:**
+- Create: `mur-core/src/skills/mur_project_search.yaml`
+- Modify: `mur-core/src/cmd/sync_cmd.rs` (`ensure_mur_skill` array, ~line 1129)
+
+- [ ] **Step 1: Create the skill YAML**
+
+Create `mur-core/src/skills/mur_project_search.yaml` (mirrors the structure of `mur_project_index.yaml`):
+
+```yaml
+name: mur-project-search
+version: 0.1.0
+publisher: human:mur
+description: "Search project code by meaning. Use for concept/intent queries; use grep for exact strings and exhaustive matches."
+category: context
+hosts: [all]
+content:
+  abstract: |
+    For "where is the code that does X" style questions, use semantic search:
+    `mur project search "<intent>"` (or the mur_project_search MCP tool).
+    Keep grep for exact symbols, strings, and exhaustive matches.
+  context: |
+    # mur-project-search — Pick the right code search tool
+
+    Semantic search (hybrid vector + BM25) answers *intent* questions and is
+    usually cheaper than grepping then opening many files. But grep is exact,
+    exhaustive, and always reflects the working tree right now. Choose per query:
+
+    ## Use `mur project search "<query>"` (or mur_project_search MCP tool) when
+    - You are looking for a concept or behavior, not a known token:
+      "where is the logic that handles retries", "how does auth work",
+      "which file is responsible for decay scoring".
+
+    ## Use grep when
+    - You know the exact symbol, string, import, or config key.
+    - You need every occurrence (rename, find all callers, dead-code removal).
+      Semantic search returns ranked top-k, not all matches — it will miss some.
+
+    ## Hard rules (correctness)
+    - Code you created or edited this session and have NOT committed/indexed is
+      not in the index yet — use grep for it. Semantic results always lag
+      un-committed edits.
+    - Before trusting semantic results, check freshness with
+      `mur project status`. If it reports no index or indexing in progress,
+      fall back to grep.
+
+    The index is kept fresh automatically by a post-commit hook (installed on
+    first `mur project index`). See the mur-project-index skill.
+tags: [mur, project, search, grep, builtin]
+triggers:
+  - type: keyword
+    pattern: "(where is the code|how does .{0,30} work|which file (handles|is responsible)|find the (logic|code) (that|responsible)|semantic.{0,8}search|search the (codebase|project) for)"
+  - type: manual
+priority: normal
+```
+
+- [ ] **Step 2: Register the skill in `ensure_mur_skill`**
+
+In `mur-core/src/cmd/sync_cmd.rs`, in the `skills` array inside `ensure_mur_skill` (after the `mur-project-index` entry, ~line 1141), add:
+
+```rust
+        (
+            "mur-project-search",
+            include_str!("../skills/mur_project_search.yaml"),
+        ),
+```
+
+- [ ] **Step 3: Write a test that the new skill is installed**
+
+There is no existing dedicated test for `ensure_mur_skill`. Add one. Append to the existing `#[cfg(test)] mod tests` in `mur-core/src/cmd/sync_cmd.rs` (if none exists, create `#[cfg(test)] mod sync_skill_tests` at end of file):
+
+```rust
+    #[test]
+    fn installs_project_search_skill() {
+        let home = std::env::temp_dir().join(format!(
+            "mur-skilltest-{}-{}",
+            std::process::id(),
+            std::fs::read_dir(std::env::temp_dir()).map(|d| d.count()).unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+
+        super::ensure_mur_skill(&home).unwrap();
+
+        let skill_yaml = home
+            .join(".mur").join("skills").join("mur-project-search").join("skill.yaml");
+        assert!(skill_yaml.exists(), "mur-project-search skill.yaml must be written");
+        let body = std::fs::read_to_string(&skill_yaml).unwrap();
+        assert!(body.contains("name: mur-project-search"));
+
+        std::fs::remove_dir_all(&home).ok();
+    }
+```
+
+(If the existing test module is named differently, use `ensure_mur_skill` directly via the module path that compiles — it is `pub(crate)`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p mur-core installs_project_search_skill`
+Expected: PASS (the `include_str!` resolves at compile time, so a missing/renamed YAML would fail the build first).
+
+- [ ] **Step 5: Verify it renders for AI tools and lint is clean**
+
+Run: `cargo clippy -p mur-core -- -D warnings`
+Expected: no warnings. (`ensure_mur_skill` also renders `SKILL.md` next to `skill.yaml`; the test above confirms the YAML, which is the source of truth.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/skills/mur_project_search.yaml mur-core/src/cmd/sync_cmd.rs
+git -c user.name=karajanchang -c user.email=david@twdd.com.tw commit \
+  --author="karajanchang <david@twdd.com.tw>" -m "feat(skills): add mur-project-search guiding skill
+
+Teaches the tool-choice rule: semantic search for concept/intent
+queries, grep for exact/exhaustive/just-edited code, with a freshness
+fallback. Shipped as a builtin so it auto-installs via ensure_mur_skill.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Connect the `mur-mcp-server` to Claude Code
+
+`mur_project_search` exists as an MCP tool (`mur-mcp-server/src/tools.rs:77`) but the binary is not installed (`~/.mur/bin/` has no `mur-mcp-server`; `build.sh` installs only `mur`) and no `.mcp.json` registers it. Build + install the binary, register it, and lock the `tools/list` contract with a test.
+
+**Files:**
+- Modify: `build.sh` (install `mur-mcp-server` alongside `mur`)
+- Create: `.mcp.json` (repo root)
+- Modify: `mur-mcp-server/tests/integration.rs` (assert `mur_project_search` in `tools/list`)
+
+- [ ] **Step 1: Add a `tools/list` assertion for `mur_project_search`**
+
+In `mur-mcp-server/tests/integration.rs`, the existing `test_initialize_and_list_tools` already initializes and (per the file) checks the server name. Add a new test that sends `tools/list` and asserts the project-search tool is present. Append:
+
+```rust
+#[test]
+fn lists_project_search_tool() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mur-mcp-server"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = std::io::BufReader::new(child.stdout.take().unwrap());
+
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+    );
+    let _ = read_response(&mut stdout);
+
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
+    );
+    let resp = read_response(&mut stdout);
+
+    let names: Vec<String> = resp["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        names.iter().any(|n| n == "mur_project_search"),
+        "tools/list must include mur_project_search; got {names:?}"
+    );
+
+    let _ = child.kill();
+}
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `cargo test -p mur-mcp-server lists_project_search_tool`
+Expected: PASS (the tool is already registered in `tools.rs`). This locks the contract so the `.mcp.json` we add in Step 4 stays valid.
+
+- [ ] **Step 3: Make `build.sh` install the `mur-mcp-server` binary**
+
+`build.sh` currently builds the workspace and copies only `mur` to `/opt/homebrew/bin/mur` (line ~58). After that copy, add an install of the MCP server binary. Locate the block in `build.sh`:
+
+```sh
+  sudo cp "$BINARY" /opt/homebrew/bin/mur
+```
+
+Immediately after it, add:
+
+```sh
+  MCP_BINARY="$SCRIPT_DIR/target/release/mur-mcp-server"
+  if [ -f "$MCP_BINARY" ]; then
+    sudo cp "$MCP_BINARY" /opt/homebrew/bin/mur-mcp-server
+    echo "Installed mur-mcp-server -> /opt/homebrew/bin/mur-mcp-server"
+  fi
+```
+
+(`cargo build --release` already builds the whole workspace, so `target/release/mur-mcp-server` exists after the build step; no extra build flag needed.)
+
+- [ ] **Step 4: Create the project `.mcp.json`**
+
+Create `.mcp.json` at the repo root. Use the installed binary by name (resolved from `PATH`), matching the stdio contract in the MCP design spec (§4.4):
+
+```json
+{
+  "mcpServers": {
+    "mur": {
+      "command": "mur-mcp-server",
+      "args": [],
+      "env": {}
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Build, install, and verify the binary runs**
+
+Run:
+```bash
+./build.sh --release --install
+mur-mcp-server --help 2>/dev/null || echo "(no --help; server is stdio-only, that is expected)"
+```
+Expected: build + install succeed; `/opt/homebrew/bin/mur-mcp-server` exists (`ls -l /opt/homebrew/bin/mur-mcp-server`).
+
+- [ ] **Step 6: Manually verify Claude Code picks up the server**
+
+This is a manual verification step (no automated test — it depends on the Claude Code client).
+1. In a NEW Claude Code session in this repo, run `/mcp` (or check the MCP server list).
+2. Expected: a `mur` server listed as connected, exposing `mur_project_search` (and the other tools from `tools.rs`).
+3. If `ENABLE_CLAUDEAI_MCP_SERVERS` in `~/.claude/settings.json` blocks project MCP servers, note that project-scoped `.mcp.json` servers are governed separately; confirm the server appears and is approved when prompted.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add build.sh .mcp.json mur-mcp-server/tests/integration.rs
+git -c user.name=karajanchang -c user.email=david@twdd.com.tw commit \
+  --author="karajanchang <david@twdd.com.tw>" -m "feat(mcp): connect mur-mcp-server to Claude Code via .mcp.json
+
+Install the mur-mcp-server binary in build.sh and register it as a
+project-scoped MCP server so mur_project_search becomes a first-class
+tool alongside Grep. Lock the tools/list contract with a test.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full mur-core + mcp suites**
+
+Run: `cargo test -p mur-core && cargo test -p mur-mcp-server`
+Expected: all tests pass.
+
+- [ ] **Workspace lint + format**
+
+Run: `cargo clippy --workspace -- -D warnings && cargo fmt --check`
+Expected: clean.
+
+- [ ] **Docs checklist (per CLAUDE.md)**
+
+Consider whether `README.md` and the docs site (`app.mur.run/docs/core`) should mention that the `mur` MCP server exposes `mur_project_search` and the new search-vs-grep guidance. If yes, update in a follow-up commit; if no, note why (internal behavior, no user-facing surface change beyond the skill).
+
+---
+
+## Notes for the implementer
+
+- **Independence:** the three tasks are independent and can land in any order / separate PRs. Task 1 is the smallest and safest; Task 3 has a manual verification step. Do them in order for the cleanest history.
+- **Existing hook on dev machines:** an older-format hook (`... --quiet &` instead of `--quiet --background`) may already be installed; the marker check makes `ensure_git_hook` skip it. Rewriting stale-format hooks is explicitly out of scope for this plan (spec "Out of scope").
+- **Temp-dir uniqueness in tests:** `Instant`/`rand` are unavailable in the no-`Date::now` constraint; tests use `process::id()` + a dir count for a unique-enough suffix. If a collision ever occurs in CI, switch to a per-test fixed subdir name.

--- a/docs/superpowers/specs/2026-06-02-prefer-mur-project-search-over-grep-design.md
+++ b/docs/superpowers/specs/2026-06-02-prefer-mur-project-search-over-grep-design.md
@@ -1,0 +1,160 @@
+# Design: Make Claude Code prefer `mur project search` over grep
+
+**Date:** 2026-06-02
+**Status:** Draft (awaiting review)
+**Topic:** Steer Claude Code toward semantic codebase search where it helps, while keeping grep authoritative where it must be.
+
+## Problem
+
+When using Claude Code in this repo, Claude reaches for the built-in `Grep`
+tool for every code search, never `mur project search` — even though semantic
+(hybrid vector + BM25) search would answer concept/intent queries better and
+more cheaply.
+
+Root cause (verified):
+
+1. **The MCP server is not connected.** `~/.claude/settings.json` has
+   `ENABLE_CLAUDEAI_MCP_SERVERS: false`, there is no `.mcp.json`, and `mur` is
+   absent from the MCP tool list. The `mur_project_search` tool
+   (`mur-mcp-server/src/tools.rs:77`) therefore is not reachable.
+2. **No skill teaches Claude to choose it.** The mur skills loaded at session
+   start are `mur-project-index` and `mur-project-remove` only — both about
+   *building/removing* the index, neither about *searching*. There is no
+   `mur-project-search` skill.
+3. **No hook redirects search intent.** `on-tool.sh` captures/filters; it does
+   not rewrite `grep` → semantic search (and should not — see below).
+
+`Grep` is a first-class Claude Code tool, always available and the natural
+default. `mur project search` is only reachable via a Bash CLI call or the
+(disconnected) MCP tool. So Claude always falls back to grep.
+
+## Decision: complementary, not replacement
+
+We explicitly **reject** "fully replace grep" and **reject** hook-rewriting of
+grep calls. Two correctness hazards make replacement wrong, not merely
+sub-optimal:
+
+- **Freshness.** `grep` reads the working tree as it is *right now*, including
+  code Claude wrote seconds ago. `mur project search` reads an *index* that is
+  only as fresh as the last `mur project index`. In an active coding session,
+  relying on semantic search to find just-edited, un-indexed code yields false
+  negatives — Claude may conclude code "does not exist."
+- **Completeness.** Refactors (rename, find-all-callers, dead-path removal)
+  need *exhaustive, exact* matches. Semantic search returns ranked top-k
+  "most relevant" snippets by design — it does not guarantee every occurrence.
+  Missing a call site breaks the build.
+
+Hook-rewriting is rejected for the same reasons: a grep pattern alone cannot be
+classified as "exact symbol" vs "concept" (e.g. `handle.*payment` is both), so
+blunt rewriting would hit both hazards.
+
+**Adopted posture:** the decision *rule* is "right tool per intent" (complementary),
+with a *conservative default* — grep stays the default and the authoritative
+source; semantic search is the deliberate choice for fuzzy/conceptual queries.
+
+| Query shape | Tool |
+|---|---|
+| Concept / intent ("where is the logic that handles X") | `mur project search` |
+| Exact symbol / string / import / config key | **grep** |
+| Needs exhaustive results (rename, all callers) | **grep** |
+| Code edited this session, not yet indexed | **grep** (hard rule) |
+| Index reported stale by `mur project status` | **grep** (fall back) |
+
+Token note: for concept queries, one semantic call returning ~5 ranked
+`file:line` snippets is typically cheaper than grep returning dozens of matches
+that Claude must then open files to understand. The split above aligns with
+token economy, not just correctness.
+
+## Components
+
+Three pieces. One is already implemented; the work is the other two.
+
+### 1. Connect the mur MCP server  *(new)*
+
+Register the `mur-mcp-server` binary (stdio JSON-RPC; see
+`docs/superpowers/specs/2026-06-01-mur-mcp-server-and-skills-design.md`) so
+`mur_project_search` becomes a first-class tool alongside `Grep`.
+
+- Add a project-scoped `.mcp.json` at the repo root that launches the binary.
+  Command resolves to the installed binary (e.g. `~/.mur/bin/mur-mcp-server`
+  or the workspace `target` build); exact path/launcher to be pinned during
+  implementation, following the launch contract in the MCP design spec.
+- This is *necessary infrastructure*: without it, semantic search is only
+  reachable by shelling out via Bash, which Claude will not naturally choose.
+- Exposure alone does **not** change behavior — Claude still defaults to grep
+  until Component 2 guides the choice.
+
+### 2. Guiding skill `mur-project-search`  *(new — the missing piece)*
+
+A skill that encodes the decision rule so the model actually chooses correctly.
+
+- **Triggers:** keyword/intent patterns for conceptual search, e.g.
+  "where is the code that…", "how does X work", "find the logic responsible
+  for…", "which file handles…". Plus manual.
+- **Body teaches:**
+  - Concept/intent query → call `mur_project_search` (MCP) or
+    `mur project search "<query>"` (CLI fallback).
+  - Exact symbol/string, imports, config keys, or any exhaustive search
+    (rename, all callers) → use `Grep`.
+  - **Hard rule:** code created/modified in the current session and not yet
+    indexed → use `Grep` (semantic index always lags un-committed edits).
+  - Before trusting semantic results, if `mur project status` reports the
+    index stale/missing → fall back to `Grep`.
+- Mirrors the existing `mur-project-index` skill format (frontmatter with
+  `triggers`, `hosts`, `priority`, builtin tag).
+
+### 3. Freshness via git post-commit hook  *(largely already implemented)*
+
+`codebase::ensure_git_hook` (`mur-core/src/codebase/mod.rs:707`) already
+implements the agreed design:
+
+- Marker `# mur auto-index` makes it **idempotent** (skips if present).
+- Creates `.git/hooks/post-commit` with shebang + `0o755` if absent;
+  **appends a guarded block** if a hook already exists (never clobbers).
+- Hook runs `mur project index "<path>" --quiet --background` — incremental
+  (mtime cache), background, and a no-op guarded by `command -v`.
+- Invoked automatically after a foreground `mur project index`
+  (`mur-core/src/cmd/project.rs:333`).
+
+**Gap to fix:** the **background-index worker**
+(`cmd_project_index_worker`, `mur-core/src/cmd/project.rs`) does **not** call
+`ensure_git_hook`. A large project whose *first* index runs via `--background`
+(auto-detected when chunks exceed the background threshold) will silently skip
+hook installation. Fix: call `ensure_git_hook` from the background worker path
+too, so first-index hook installation has parity regardless of fg/bg mode.
+
+This satisfies the agreed decisions:
+- **(a) Install timing:** hook is installed automatically on first successful
+  index (after the gap fix, in both fg and bg paths) — no separate command to
+  remember.
+- **(b) Pre-existing hook:** append a marker-delimited block, idempotent, never
+  overwrite.
+
+## Out of scope
+
+- Hook-rewriting `Grep` calls into semantic search (rejected above).
+- A always-on file-watching daemon for instant reindex (option C; deferred —
+  cost outweighs benefit, and it still cannot cover un-saved edits).
+- Changes to retrieval quality / ranking of `mur project search` itself.
+- Tuning the MCP server's other tools.
+
+## Testing
+
+- **Component 1:** spawn `mur-mcp-server`, `tools/list` includes
+  `mur_project_search`; calling it on an indexed repo returns ranked
+  `file:line` snippets. Verify Claude Code lists the `mur` MCP server after
+  adding `.mcp.json`.
+- **Component 2:** skill loads at session start (appears in mur learning
+  index); a concept-style prompt triggers it; an exact-symbol prompt does not
+  divert from grep.
+- **Component 3:** unit/integration test that `ensure_git_hook` is invoked from
+  the background worker path; existing idempotency/append behavior covered by a
+  test that running it twice yields one marker block and that a pre-existing
+  hook is preserved.
+
+## Open implementation details (pin during plan)
+
+- Exact `.mcp.json` launch command and binary path resolution for
+  `mur-mcp-server` (installed vs workspace build).
+- Whether the `mur-project-search` skill ships as a builtin (alongside
+  `mur-project-index`) so it auto-installs for all users, vs project-local.

--- a/docs/superpowers/specs/2026-06-02-self-contained-hub-install-design.md
+++ b/docs/superpowers/specs/2026-06-02-self-contained-hub-install-design.md
@@ -1,0 +1,249 @@
+# Self-Contained MuR Hub — Double-Click-to-Life End-User Install (macOS)
+
+**Status:** Design
+**Date:** 2026-06-02
+**Author:** brainstorming session
+**Scope:** macOS (Apple Silicon) first. Windows/Linux deferred.
+
+## 1. Problem
+
+Today an end user (a non-developer friend) cannot realistically install and run a
+MuR agent:
+
+- `mur-agent-runtime` has no first-class distribution. `resolve_runtime_target()`
+  (`mur-core/src/cmd/agent/mod.rs:120`) looks for the runtime binary next to the
+  `mur` binary or on `PATH`; the crates.io publish of the runtime is "allowed to
+  fail" in `release.yml`. A user who installed only `mur` ends up with an agent
+  symlink pointing at a missing target.
+- `mur-hub-gui` has **no** end-user install path at all. Its `README.md` documents
+  only a developer dev-loop (`npm run dev` + `cargo tauri dev` in two terminals).
+  `release.yml` does not build, sign, or ship the Hub app.
+
+The result: trying MuR requires Rust, npm, and a manual binary dance. There is no
+"must try" moment.
+
+## 2. Goal
+
+On macOS (Apple Silicon), a non-developer can:
+
+1. Download one signed, notarized `.dmg`.
+2. Drag **MuR Hub** to Applications.
+3. Open it — a built-in concierge agent named **Mur** is already alive and speaks
+   immediately, offline, with **no API key and no signup**, in fluent Chinese
+   (Traditional preferred) and other languages.
+4. Receive a `.muragent` file from a friend, double-click it, and watch that agent
+   install and come alive in Hub.
+
+No CLI, no npm, no Rust at any point. The CLI is available to power users as an
+opt-in, not a prerequisite.
+
+This realizes the existing strategy pillar "give-to-a-friend = Host signed once +
+data-only `.muragent`" (see `2026-05-11-mur-hub-companion-design.md` and the export
+UX pillar): the **Host** is the self-contained Hub app.
+
+## 3. Chosen Approach
+
+**Approach C** — a single self-contained, signed `MuR Hub.app` that embeds `mur` +
+`mur-agent-runtime` + a bundled local model + the seed "Mur" agent, **plus** an
+"Install command-line tools…" menu item for power users.
+
+Rejected alternatives:
+
+- **B (CLI installer + thin Hub shell):** keeps two installs, two notarizations, and
+  PATH coupling — exactly the pain we are removing.
+- **A (self-contained, no CLI menu):** good, but leaves power users with no clean way
+  to get the CLI. C is A plus a small, well-understood menu item (the VS Code
+  "shell command" pattern).
+
+## 4. Distribution Architecture
+
+`MuR Hub.app` is the single shipped artifact, delivered inside a `.dmg`.
+
+The Tauri bundle (`mur-hub-gui/src-tauri/tauri.conf.json`) already targets
+`["app", "dmg"]`, already registers the `.muragent` file association, and already
+uses identifier `run.mur.hub`. We extend it to embed binaries, the inference
+backend, and the model, mirroring the existing pattern in
+`mur-agent-gui/src-tauri/tauri.conf.json` (`externalBin` + `resources`).
+
+Bundle contents:
+
+- `externalBin`: `mur`, `mur-agent-runtime` (placed under `binaries/`).
+- `resources`:
+  - the MLX inference sidecar (see §6),
+  - the bundled model weights (see §5),
+  - the seed "Mur" agent template (profile + system prompt + concierge skill, §7).
+
+Estimated `.dmg` size: ~1.5–1.8 GB (dominated by the model). Acceptable for a 2026
+desktop download.
+
+## 5. Bundled Model (Local Brain)
+
+Requirement: a **small, multilingual, strong-Chinese (Traditional preferred)
+instruct model** that runs snappily on Apple Silicon with **zero key and no
+network**.
+
+Research (2026-06) findings that drive the choice:
+
+- Qwen3.5 small series (released 2026-03-01): 0.8B / 2B / 4B / 9B, natively
+  multilingual (~201 languages), MLX-optimized. The Qwen family is the strongest
+  open family for Chinese.
+- Qwen3.5 uses a Gated DeltaNet hybrid attention architecture that is **poorly
+  supported on llama.cpp (~14× slower)** but well-optimized on **MLX**. This rules
+  out a GGUF/llama.cpp backend and confirms MLX — consistent with the repo's
+  existing MLX-first preference in `mur-core/src/cmd/init_local.rs`.
+
+Selection:
+
+| Role | Model | Rationale |
+|------|-------|-----------|
+| **Default bundled brain** | `Qwen3.5-2B-MLX-4bit` | Best balance of wow / size / Chinese. 30–50 tok/s on Apple Silicon, runs offline, ~1.3 GB at 4-bit. |
+| Optional upgrade (wizard download) | `Qwen3.5-4B-MLX-4bit` | More capable when the user wants it; ~2.5 GB. |
+| Rejected | 0.8B | Too weak to carry a convincing concierge conversation. |
+
+The default model id is **configuration, not a hardcoded constant** (per project
+rule "no hardcoded values"). It lives in config so it can be swapped without code
+changes; `Qwen3.5-2B-MLX-4bit` is only the default value.
+
+Model weights are **not committed to git**. They are fetched during the release
+build (CI step / cache / LFS-external) and embedded into the bundle at package time.
+
+## 6. Inference Backend (MLX Sidecar)
+
+The Hub spawns a local inference server that exposes an OpenAI-compatible HTTP
+endpoint on `127.0.0.1:<port>`, pointed at the bundled model.
+
+- **Backend:** MLX (Apple Silicon). GGUF/llama.cpp is explicitly rejected for the
+  Qwen3.5 architecture (§5).
+- **Packaging decision (implementation):** prefer a **native MLX-Swift sidecar
+  binary** so the `.app` does not have to embed a full Python runtime. Fallback if
+  the native server is not ready in time: a frozen `mlx-lm` server (e.g.
+  PyInstaller). This is an implementation choice to be finalized in the plan; the
+  spec requires only "an MLX-backed, OpenAI-compatible local server bundled as a
+  sidecar, no Python install required by the user."
+- **Port:** chosen at runtime (ephemeral / configurable), written into the agent's
+  runtime config. **No hardcoded port.**
+- **Lifecycle:** started lazily on first need and tied to the Hub process; stopped
+  when Hub exits.
+- **Provider wiring:** reuse the existing provider plumbing. The repo already speaks
+  an Ollama-style, key-less local endpoint (`mur-core/src/extract_llm.rs`,
+  `init_local.rs`). The seed Mur agent's model points at the local server using the
+  same mechanism. A `local`/`bundled` provider variant is added if needed; it must
+  require no API key.
+
+## 7. Seed "Mur" Concierge Agent
+
+On first launch, if no agents exist in `~/.mur/agents/`, Hub seeds a built-in agent
+named **Mur** from the bundled template:
+
+- Copies the template into `~/.mur/agents/mur/` (profile.yaml, sys_prompt.md, a
+  concierge skill).
+- Creates the per-agent symlink and starts the agent via the existing lifecycle path
+  (`mur-core/src/cmd/agent/lifecycle.rs`).
+- Mur's model defaults to the local MLX server (§6).
+- Mur's system prompt frames it as the product's guide: greet the user, explain what
+  MuR does, and walk them through creating their own first agent or connecting a
+  larger model.
+
+Seeding is **idempotent**: it runs only when no agents exist (or when the seed agent
+is absent), so it never clobbers a user who already has agents or who deleted Mur on
+purpose.
+
+"Mur" as the concierge name is intentional — it doubles as the product mascot and
+keeps branding consistent. (Minor downside: same name as the product; acceptable for
+a default guide persona.)
+
+## 8. Runtime Path Resolution
+
+`resolve_runtime_target()` (`mur-core/src/cmd/agent/mod.rs:120`) gains a new
+**first-priority** branch: when the running executable is inside a macOS `.app`
+bundle (`…/Contents/…`), resolve `mur-agent-runtime` from the bundle's
+`Resources`/`MacOS` directory.
+
+Order becomes:
+
+1. `MUR_AGENT_RUNTIME_BIN` env override (unchanged).
+2. **App-bundle-relative location (new).**
+3. Next-to-current-exe (unchanged).
+4. Bare filename on `PATH` (unchanged).
+
+This makes the embedded runtime authoritative inside Hub, so the runtime no longer
+needs independent distribution. CLI-only installs keep working via the existing
+branches.
+
+## 9. First-Run and `.muragent` Open Flow
+
+**First run:**
+
+1. Welcome screen.
+2. Optional microphone / voice permission prompt (companion voice already exists).
+3. Local MLX server starts; seed Mur agent appears and greets the user.
+
+**`.muragent` double-click:**
+
+1. The OS routes the file to Hub via the registered association (already configured).
+2. The Tauri shell handles the file-open event (both cold-start and
+   already-running cases).
+3. Hub invokes the existing agent import path (`mur agent` import / `--load`) to
+   install the package into `~/.mur/agents/`.
+4. The new agent is started and brought to the foreground — it comes alive in Hub.
+
+Import must reuse existing, tested import logic rather than re-implementing it.
+
+## 10. Command-Line Tools Menu (Approach C)
+
+A menu item, "Install `mur` command-line tools…", symlinks the bundled `mur` into a
+PATH directory (`/opt/homebrew/bin`, falling back to `~/.local/bin`), prompting for
+elevation only when required. End users can ignore it; power users get the CLI in one
+click. The CLI is thereby an opt-in, not a prerequisite.
+
+## 11. Release Pipeline
+
+Add a macOS job to `release.yml`:
+
+1. Build the Hub UI (`mur-hub-gui/ui`: `npm ci && npm run build`).
+2. Fetch the bundled model weights (cache/external; not from git).
+3. `cargo tauri build` for `mur-hub-gui`, embedding `mur`, `mur-agent-runtime`, the
+   MLX sidecar, and the model.
+4. `codesign` → `notarytool submit` → `stapler staple` (reuse the existing signing
+   identity and notarization flow already used for `mur-*.dmg`).
+5. Upload `MuR-Hub-aarch64-apple-darwin.dmg` to the GitHub Release.
+
+The main README Quick Start gains a "Download MuR Hub for macOS" entry pointing at
+this artifact.
+
+## 12. Out of Scope (YAGNI)
+
+- Windows and Linux Hub installers.
+- Single-file signed `.muragent` (signing complexity; deferred per export pillar).
+- Hosted free-trial inference credits (contradicts local-first; adds backend/cost).
+- Committing model weights to git.
+- Bundling the larger 4B model by default (offered as an opt-in download instead).
+
+## 13. Testing
+
+- **Unit:** the new app-bundle branch in `resolve_runtime_target()`; local provider
+  configuration produces a key-less endpoint config.
+- **Integration:** Mur seeding is idempotent (no-op when agents exist); `.muragent`
+  open → import → start path installs and launches an agent.
+- **Manual (clean Mac):** download → drag → open → Mur greets in Traditional
+  Chinese; Gatekeeper/notarization passes (`spctl`); `.muragent` double-click brings
+  an agent to life; "Install command-line tools" makes `mur` available on PATH.
+
+## 14. Affected Components
+
+- `mur-hub-gui/src-tauri/tauri.conf.json` — externalBin, resources, dmg.
+- `mur-hub-gui/src-tauri/` — first-run flow, file-open handler, MLX sidecar
+  supervision, CLI-tools menu, Mur seeding trigger.
+- `mur-core/src/cmd/agent/mod.rs` — `resolve_runtime_target()` app-bundle branch.
+- `mur-core/src/cmd/init_local.rs` / provider plumbing — key-less local MLX provider.
+- Seed "Mur" agent template assets (new bundled resource).
+- `.github/workflows/release.yml` — Hub build/sign/notarize/upload job.
+- `README.md` — macOS Hub download in Quick Start.
+
+## 15. Open Implementation Questions (resolve during planning)
+
+- Native MLX-Swift sidecar vs frozen `mlx-lm` — pick based on readiness; spec
+  requires only a Python-free user experience.
+- Exact model-hosting mechanism in CI (HF download + cache vs release asset mirror).
+- Whether the local provider is a new provider variant or a reuse of the existing
+  Ollama-style provider pointed at the sidecar port.

--- a/mur-core/src/cmd/project.rs
+++ b/mur-core/src/cmd/project.rs
@@ -526,6 +526,10 @@ pub(crate) async fn cmd_project_index_worker(
             let _ = index.write_progress(&progress);
             index.release_lock();
 
+            // Parity with the foreground path: install the post-commit
+            // auto-reindex hook on first successful index (idempotent).
+            let _ = crate::codebase::ensure_git_hook(&project_path, true);
+
             // Desktop notification
             send_notification(
                 &format!("mur: {} indexed", project_name),

--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -1143,6 +1143,10 @@ pub(crate) fn ensure_mur_skill(home: &std::path::Path) -> Result<bool> {
             include_str!("../skills/mur_project_remove.yaml"),
         ),
         (
+            "mur-project-search",
+            include_str!("../skills/mur_project_search.yaml"),
+        ),
+        (
             "mur-session-remove",
             include_str!("../skills/mur_session_remove.yaml"),
         ),
@@ -1526,5 +1530,36 @@ mod sync_status_tests {
         // run_status uses default_location() which creates dirs under $HOME/.mur/.
         // We just verify it doesn't panic and returns Ok.
         run_status().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod sync_skill_tests {
+    #[test]
+    fn installs_project_search_skill() {
+        let home = std::env::temp_dir().join(format!(
+            "mur-skilltest-{}-{}",
+            std::process::id(),
+            std::fs::read_dir(std::env::temp_dir())
+                .map(|d| d.count())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&home).unwrap();
+
+        super::ensure_mur_skill(&home).unwrap();
+
+        let skill_yaml = home
+            .join(".mur")
+            .join("skills")
+            .join("mur-project-search")
+            .join("skill.yaml");
+        assert!(
+            skill_yaml.exists(),
+            "mur-project-search skill.yaml must be written"
+        );
+        let body = std::fs::read_to_string(&skill_yaml).unwrap();
+        assert!(body.contains("name: mur-project-search"));
+
+        std::fs::remove_dir_all(&home).ok();
     }
 }

--- a/mur-core/src/codebase/mod.rs
+++ b/mur-core/src/codebase/mod.rs
@@ -760,3 +760,84 @@ fn codebase_schema(dim: i32) -> Arc<Schema> {
         ),
     ]))
 }
+
+#[cfg(test)]
+mod git_hook_tests {
+    use super::ensure_git_hook;
+    use std::fs;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static HOOK_TEST_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    /// Build a temp dir that looks like a git repo (just needs `.git/hooks`).
+    fn temp_repo() -> std::path::PathBuf {
+        let n = HOOK_TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let base = std::env::temp_dir().join(format!("mur-hook-test-{}-{}", std::process::id(), n));
+        fs::create_dir_all(base.join(".git").join("hooks")).unwrap();
+        base
+    }
+
+    #[test]
+    fn creates_hook_with_shebang_when_absent() {
+        let repo = temp_repo();
+        let installed = ensure_git_hook(&repo, true).unwrap();
+        assert!(installed, "should report it installed the hook");
+
+        let hook = repo.join(".git/hooks/post-commit");
+        let body = fs::read_to_string(&hook).unwrap();
+        assert!(body.starts_with("#!/bin/sh"), "must start with shebang");
+        assert!(body.contains("# mur auto-index"), "must contain marker");
+        assert!(body.contains("project index"), "must run project index");
+
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn is_idempotent_on_second_call() {
+        let repo = temp_repo();
+        assert!(ensure_git_hook(&repo, true).unwrap());
+        // Second call must be a no-op (marker already present).
+        let installed_again = ensure_git_hook(&repo, true).unwrap();
+        assert!(!installed_again, "second call should return false");
+
+        let body = fs::read_to_string(repo.join(".git/hooks/post-commit")).unwrap();
+        assert_eq!(
+            body.matches("# mur auto-index").count(),
+            1,
+            "marker must appear exactly once"
+        );
+
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn appends_to_existing_hook_without_clobbering() {
+        let repo = temp_repo();
+        let hook = repo.join(".git/hooks/post-commit");
+        fs::write(&hook, "#!/bin/sh\necho existing-user-hook\n").unwrap();
+
+        let installed = ensure_git_hook(&repo, true).unwrap();
+        assert!(installed);
+
+        let body = fs::read_to_string(&hook).unwrap();
+        assert!(
+            body.contains("echo existing-user-hook"),
+            "must preserve the pre-existing hook content"
+        );
+        assert!(
+            body.contains("# mur auto-index"),
+            "must append marker block"
+        );
+
+        fs::remove_dir_all(&repo).ok();
+    }
+
+    #[test]
+    fn returns_false_when_not_a_git_repo() {
+        let base = std::env::temp_dir().join(format!("mur-hook-nogit-{}", std::process::id()));
+        fs::create_dir_all(&base).unwrap();
+        // No .git/hooks dir → ensure_git_hook returns Ok(false).
+        assert!(!ensure_git_hook(&base, true).unwrap());
+        fs::remove_dir_all(&base).ok();
+    }
+}

--- a/mur-core/src/skills/mur_project_search.yaml
+++ b/mur-core/src/skills/mur_project_search.yaml
@@ -1,0 +1,44 @@
+name: mur-project-search
+version: 0.1.0
+publisher: human:mur
+description: "Search project code by meaning. Use for concept/intent queries; use grep for exact strings and exhaustive matches."
+category: context
+hosts: [all]
+content:
+  abstract: |
+    For "where is the code that does X" style questions, use semantic search:
+    `mur project search "<intent>"` (or the mur_project_search MCP tool).
+    Keep grep for exact symbols, strings, and exhaustive matches.
+  context: |
+    # mur-project-search — Pick the right code search tool
+
+    Semantic search (hybrid vector + BM25) answers *intent* questions and is
+    usually cheaper than grepping then opening many files. But grep is exact,
+    exhaustive, and always reflects the working tree right now. Choose per query:
+
+    ## Use `mur project search "<query>"` (or mur_project_search MCP tool) when
+    - You are looking for a concept or behavior, not a known token:
+      "where is the logic that handles retries", "how does auth work",
+      "which file is responsible for decay scoring".
+
+    ## Use grep when
+    - You know the exact symbol, string, import, or config key.
+    - You need every occurrence (rename, find all callers, dead-code removal).
+      Semantic search returns ranked top-k, not all matches — it will miss some.
+
+    ## Hard rules (correctness)
+    - Code you created or edited this session and have NOT committed/indexed is
+      not in the index yet — use grep for it. Semantic results always lag
+      un-committed edits.
+    - Before trusting semantic results, check freshness with
+      `mur project status`. If it reports no index or indexing in progress,
+      fall back to grep.
+
+    The index is kept fresh automatically by a post-commit hook (installed on
+    first `mur project index`). See the mur-project-index skill.
+tags: [mur, project, search, grep, builtin]
+triggers:
+  - type: keyword
+    pattern: "(where is the code|how does .{0,30} work|which file (handles|is responsible)|find the (logic|code) (that|responsible)|semantic.{0,8}search|search the (codebase|project) for)"
+  - type: manual
+priority: normal

--- a/mur-mcp-server/tests/integration.rs
+++ b/mur-mcp-server/tests/integration.rs
@@ -106,3 +106,48 @@ fn test_tools_list_response_under_token_budget() {
 
     child.kill().ok();
 }
+
+#[test]
+fn lists_project_search_tool() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mur-mcp-server"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = std::io::BufReader::new(child.stdout.take().unwrap());
+
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+    );
+    let _ = read_response(&mut stdout);
+
+    // Confirm initialization (required by MCP protocol)
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+    );
+    let _ = read_response(&mut stdout);
+
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
+    );
+    let resp = read_response(&mut stdout);
+
+    let names: Vec<String> = resp["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        names.iter().any(|n| n == "mur_project_search"),
+        "tools/list must include mur_project_search; got {names:?}"
+    );
+
+    let _ = child.kill();
+}


### PR DESCRIPTION
## Summary

Three independent changes to steer Claude Code toward `mur project search` for concept/intent queries:

- **Background hook parity**: `cmd_project_index_worker` now calls `ensure_git_hook` (idempotent), so large projects indexed via `--background` get the auto-reindex post-commit hook
- **Search guiding skill**: New `mur-project-search` builtin skill teaches the semantic-vs-grep tool-choice rule, auto-installed via `ensure_mur_skill`
- **MCP wiring**: `mur-mcp-server` binary now installed by `build.sh` + registered as a project-scoped MCP server via `.mcp.json`

## Test Plan

- [x] 4 characterization tests for `ensure_git_hook` (create / idempotent / append / no-git-repo)
- [x] `installs_project_search_skill` - verifies YAML is written on sync
- [x] `lists_project_search_tool` - contract test locking `mur_project_search` in MCP `tools/list`
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)