### PR TITLE
feat(media): VLC watch-together + scene-explain companion skills

### DIFF
--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -79,6 +79,7 @@ console = { version = "0.15", optional = true }
 open = "5"
 hostname = "0.4.2"
 dotenvy = "0.15"
+getrandom = "0.2"
 shellexpand = "3"
 urlencoding = "2"
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/mur-core/src/cmd/media/mod.rs
+++ b/mur-core/src/cmd/media/mod.rs
@@ -1,5 +1,10 @@
 //! Media companion: control VLC and explain the current frame with the local
 //! multimodal model. All control uses VLC's HTTP interface (no libVLC).
+//!
+//! Most items here are `pub` but used only by the `mur-mcp-server` crate, not
+//! by the `mur` binary — so clippy flags them as dead code in the binary
+//! target. The `expect` below is deliberate: these are library-facing exports.
+#![allow(dead_code)]
 
 pub mod scene;
 pub mod vlc;

--- a/mur-core/src/cmd/media/mod.rs
+++ b/mur-core/src/cmd/media/mod.rs
@@ -1,0 +1,79 @@
+//! Media companion: control VLC and explain the current frame with the local
+//! multimodal model. All control uses VLC's HTTP interface (no libVLC).
+
+pub mod scene;
+pub mod vlc;
+
+use serde::{Deserialize, Serialize};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+
+/// Per-session VLC HTTP connection details. Generated once and persisted so
+/// repeated tool calls reach the same running VLC instance.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VlcRuntime {
+    pub port: u16,
+    pub password: String,
+    /// Directory VLC writes snapshots to (`--snapshot-path`).
+    pub snapshot_dir: PathBuf,
+}
+
+/// Reserve a free localhost TCP port.
+pub fn pick_free_port() -> std::io::Result<u16> {
+    Ok(TcpListener::bind("127.0.0.1:0")?.local_addr()?.port())
+}
+
+/// 32-hex-char random password from the OS RNG (not a long-term secret, but
+/// must not be guessable by other local users).
+pub fn gen_password() -> String {
+    let mut buf = [0u8; 16];
+    getrandom::getrandom(&mut buf).expect("OS RNG");
+    buf.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+pub fn runtime_path(mur_home: &Path) -> PathBuf {
+    mur_home.join("runtime").join("vlc.json")
+}
+
+/// Load the persisted runtime config, if present and parseable.
+pub fn load_runtime(mur_home: &Path) -> Option<VlcRuntime> {
+    let body = std::fs::read_to_string(runtime_path(mur_home)).ok()?;
+    serde_json::from_str(&body).ok()
+}
+
+/// Persist the runtime config atomically.
+pub fn save_runtime(mur_home: &Path, rt: &VlcRuntime) -> std::io::Result<()> {
+    let path = runtime_path(mur_home);
+    if let Some(p) = path.parent() {
+        std::fs::create_dir_all(p)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, serde_json::to_vec_pretty(rt).unwrap())?;
+    std::fs::rename(&tmp, &path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn password_is_32_hex_chars() {
+        let p = gen_password();
+        assert_eq!(p.len(), 32);
+        assert!(p.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn runtime_roundtrips() {
+        let home = TempDir::new().unwrap();
+        assert!(load_runtime(home.path()).is_none());
+        let rt = VlcRuntime {
+            port: 50990,
+            password: "abc123".into(),
+            snapshot_dir: home.path().join("snaps"),
+        };
+        save_runtime(home.path(), &rt).unwrap();
+        assert_eq!(load_runtime(home.path()), Some(rt));
+    }
+}

--- a/mur-core/src/cmd/media/scene.rs
+++ b/mur-core/src/cmd/media/scene.rs
@@ -1,1 +1,46 @@
-//! scene-explain: capture + VLM narration. (Task 4 will populate.)
+//! scene-explain: capture the current VLC frame and explain it with the local
+//! multimodal model.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Return the most recently modified regular file in `dir`, if any.
+pub fn newest_file(dir: &Path) -> Option<PathBuf> {
+    let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
+    for entry in std::fs::read_dir(dir).ok()? {
+        let entry = entry.ok()?;
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let mtime = entry.metadata().ok()?.modified().ok()?;
+        if best.as_ref().map(|(t, _)| mtime > *t).unwrap_or(true) {
+            best = Some((mtime, path));
+        }
+    }
+    best.map(|(_, p)| p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn newest_file_picks_latest() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.png"), b"a").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(dir.path().join("b.png"), b"b").unwrap();
+        assert_eq!(
+            newest_file(dir.path()).unwrap().file_name().unwrap(),
+            "b.png"
+        );
+    }
+
+    #[test]
+    fn newest_file_empty_dir_is_none() {
+        let dir = TempDir::new().unwrap();
+        assert!(newest_file(dir.path()).is_none());
+    }
+}

--- a/mur-core/src/cmd/media/scene.rs
+++ b/mur-core/src/cmd/media/scene.rs
@@ -111,3 +111,54 @@ mod request_tests {
         assert_eq!(parse_completion(&resp).as_deref(), Some("這是一隻貓"));
     }
 }
+
+// ── Orchestrator ──
+
+use mur_common::config::DEFAULT_BUNDLED_MODEL_ID;
+
+/// Resolve the local model endpoint base URL (e.g. http://127.0.0.1:PORT/v1).
+fn local_base_url() -> Result<String> {
+    let home = crate::cmd::resolve_mur_home()?;
+    mur_common::local_llm::read_base_url(&home)
+        .context("local model endpoint not available (is MuR Hub running?)")
+}
+
+/// Capture the current VLC frame and explain it with the local multimodal model.
+pub async fn explain(prompt: Option<&str>) -> Result<String> {
+    let client = reqwest::Client::new();
+
+    // 1. Ensure VLC is up and take a snapshot.
+    let rt = super::vlc::ensure_for_snapshot(&client).await?;
+    super::vlc::snapshot_command(&rt, &client).await?;
+
+    // 2. Read the newest snapshot file (retry briefly for the file to land).
+    let mut img_path = None;
+    for _ in 0..10 {
+        if let Some(p) = newest_file(&rt.snapshot_dir) {
+            img_path = Some(p);
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    }
+    let img_path = img_path.context("no snapshot produced by VLC")?;
+    let bytes = std::fs::read(&img_path).context("read snapshot")?;
+
+    // 3. Call the local OpenAI-compatible vision endpoint.
+    let base = local_base_url()?;
+    let body = build_request(
+        DEFAULT_BUNDLED_MODEL_ID,
+        prompt.unwrap_or(DEFAULT_EXPLAIN_PROMPT),
+        &png_data_url(&bytes),
+    );
+    let resp: serde_json::Value = client
+        .post(format!("{}/chat/completions", base.trim_end_matches('/')))
+        .json(&body)
+        .send()
+        .await
+        .context("call local VLM")?
+        .json()
+        .await
+        .context("parse VLM response")?;
+
+    parse_completion(&resp).context("VLM returned no content")
+}

--- a/mur-core/src/cmd/media/scene.rs
+++ b/mur-core/src/cmd/media/scene.rs
@@ -1,0 +1,1 @@
+//! scene-explain: capture + VLM narration. (Task 4 will populate.)

--- a/mur-core/src/cmd/media/scene.rs
+++ b/mur-core/src/cmd/media/scene.rs
@@ -1,5 +1,10 @@
 //! scene-explain: capture the current VLC frame and explain it with the local
 //! multimodal model.
+//!
+//! Most items here are `pub` but used only by the `mur-mcp-server` crate, not
+//! by the `mur` binary — so clippy flags them as dead code in the binary
+//! target. This is deliberate: these are library-facing exports.
+#![allow(dead_code)]
 
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};

--- a/mur-core/src/cmd/media/scene.rs
+++ b/mur-core/src/cmd/media/scene.rs
@@ -44,3 +44,70 @@ mod tests {
         assert!(newest_file(dir.path()).is_none());
     }
 }
+
+// ── VLM vision request / response ──
+
+use serde_json::{Value, json};
+
+/// Default instruction when the caller gives no prompt.
+pub const DEFAULT_EXPLAIN_PROMPT: &str =
+    "用繁體中文、溫暖簡潔地說明這個畫面正在發生什麼；若有人物或字幕，也一併解讀。";
+
+/// Build an OpenAI-compatible vision chat request body.
+pub fn build_request(model: &str, prompt: &str, image_data_url: &str) -> Value {
+    json!({
+        "model": model,
+        "messages": [{
+            "role": "user",
+            "content": [
+                { "type": "text", "text": prompt },
+                { "type": "image_url", "image_url": { "url": image_data_url } }
+            ]
+        }],
+        "max_tokens": 512
+    })
+}
+
+/// Encode PNG bytes as a data URL for the image_url field.
+pub fn png_data_url(bytes: &[u8]) -> String {
+    use base64::Engine;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+    format!("data:image/png;base64,{b64}")
+}
+
+/// Extract assistant text from an OpenAI-compatible chat completion response.
+pub fn parse_completion(resp: &Value) -> Option<String> {
+    resp.get("choices")?
+        .get(0)?
+        .get("message")?
+        .get("content")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod request_tests {
+    use super::*;
+
+    #[test]
+    fn request_has_text_and_image_parts() {
+        let body = build_request("Qwen3.5-2B-MLX-4bit", "hi", "data:image/png;base64,AAA");
+        let content = &body["messages"][0]["content"];
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[1]["type"], "image_url");
+        assert_eq!(content[1]["image_url"]["url"], "data:image/png;base64,AAA");
+    }
+
+    #[test]
+    fn data_url_prefixed() {
+        assert!(png_data_url(b"\x89PNG").starts_with("data:image/png;base64,"));
+    }
+
+    #[test]
+    fn parse_extracts_content() {
+        let resp = serde_json::json!({
+            "choices": [{ "message": { "content": "這是一隻貓" } }]
+        });
+        assert_eq!(parse_completion(&resp).as_deref(), Some("這是一隻貓"));
+    }
+}

--- a/mur-core/src/cmd/media/vlc.rs
+++ b/mur-core/src/cmd/media/vlc.rs
@@ -88,3 +88,150 @@ mod tests {
         assert_eq!(s.volume, 256);
     }
 }
+
+// ── Runtime management ──
+
+use super::{gen_password, load_runtime, pick_free_port, save_runtime};
+
+/// Get the persisted runtime or create + persist a fresh one (does not spawn).
+fn ensure_runtime(mur_home: &Path) -> Result<VlcRuntime> {
+    if let Some(rt) = load_runtime(mur_home) {
+        return Ok(rt);
+    }
+    let rt = VlcRuntime {
+        port: pick_free_port().context("pick free port")?,
+        password: gen_password(),
+        snapshot_dir: mur_home.join("runtime").join("vlc-snapshots"),
+    };
+    std::fs::create_dir_all(&rt.snapshot_dir).ok();
+    save_runtime(mur_home, &rt)?;
+    Ok(rt)
+}
+
+/// Spawn VLC with the HTTP interface + snapshot path if it is not already
+/// answering on the configured port.
+async fn ensure_vlc_running(mur_home: &Path, client: &reqwest::Client) -> Result<VlcRuntime> {
+    let rt = ensure_runtime(mur_home)?;
+    // Probe: if status responds, VLC is up.
+    if client
+        .get(status_url(rt.port))
+        .basic_auth("", Some(&rt.password))
+        .send()
+        .await
+        .map(|r| r.status().is_success())
+        .unwrap_or(false)
+    {
+        return Ok(rt);
+    }
+    let vlc = detect_vlc().context("VLC not found (install VLC.app)")?;
+    std::process::Command::new(vlc)
+        .args([
+            "--extraintf=http",
+            "--http-host=127.0.0.1",
+            &format!("--http-port={}", rt.port),
+            &format!("--http-password={}", rt.password),
+            "--snapshot-format=png",
+            &format!("--snapshot-path={}", rt.snapshot_dir.display()),
+        ])
+        .spawn()
+        .context("spawn VLC")?;
+    // Give the HTTP iface a moment to come up.
+    for _ in 0..20 {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        if client
+            .get(status_url(rt.port))
+            .basic_auth("", Some(&rt.password))
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+        {
+            return Ok(rt);
+        }
+    }
+    anyhow::bail!("VLC HTTP interface did not come up on port {}", rt.port)
+}
+
+async fn get_status(rt: &VlcRuntime, client: &reqwest::Client) -> Result<VlcStatus> {
+    let xml = client
+        .get(status_url(rt.port))
+        .basic_auth("", Some(&rt.password))
+        .send()
+        .await?
+        .text()
+        .await?;
+    Ok(parse_status_xml(&xml))
+}
+
+async fn send_command(
+    rt: &VlcRuntime,
+    client: &reqwest::Client,
+    cmd: &str,
+    extra: &[(&str, &str)],
+) -> Result<VlcStatus> {
+    let xml = client
+        .get(command_url(rt.port, cmd, extra))
+        .basic_auth("", Some(&rt.password))
+        .send()
+        .await?
+        .text()
+        .await?;
+    Ok(parse_status_xml(&xml))
+}
+
+// ── Public API ──
+
+fn mur_home() -> Result<PathBuf> {
+    crate::cmd::resolve_mur_home()
+}
+
+/// Open a local file path or a URL (e.g. YouTube) in VLC.
+pub async fn open(source: &str) -> Result<VlcStatus> {
+    let client = reqwest::Client::new();
+    let home = mur_home()?;
+    let rt = ensure_vlc_running(&home, &client).await?;
+    send_command(&rt, &client, "in_play", &[("input", source)]).await
+}
+
+/// Playback control. `action` ∈ {play, pause, toggle, stop, seek, volume}.
+/// `value` is seconds (seek) or raw VLC volume (volume).
+pub async fn playback(action: &str, value: Option<f64>) -> Result<VlcStatus> {
+    let client = reqwest::Client::new();
+    let home = mur_home()?;
+    let rt = ensure_vlc_running(&home, &client).await?;
+    let v = value.unwrap_or(0.0);
+    let vs = format!("{}", v as i64);
+    match action {
+        "play" => send_command(&rt, &client, "pl_forceresume", &[]).await,
+        "pause" => send_command(&rt, &client, "pl_forcepause", &[]).await,
+        "toggle" => send_command(&rt, &client, "pl_pause", &[]).await,
+        "stop" => send_command(&rt, &client, "pl_stop", &[]).await,
+        "seek" => send_command(&rt, &client, "seek", &[("val", &vs)]).await,
+        "volume" => send_command(&rt, &client, "volume", &[("val", &vs)]).await,
+        other => anyhow::bail!("unknown playback action: {other}"),
+    }
+}
+
+/// Current playback status.
+pub async fn status() -> Result<VlcStatus> {
+    let client = reqwest::Client::new();
+    let home = mur_home()?;
+    let rt = ensure_vlc_running(&home, &client).await?;
+    get_status(&rt, &client).await
+}
+
+/// Internal accessor for scene.rs: ensure running and return the runtime.
+pub(super) async fn ensure_for_snapshot(
+    client: &reqwest::Client,
+) -> Result<VlcRuntime> {
+    let home = mur_home()?;
+    ensure_vlc_running(&home, client).await
+}
+
+pub(super) async fn snapshot_command(
+    rt: &VlcRuntime,
+    client: &reqwest::Client,
+) -> Result<()> {
+    let _ = send_command(rt, client, "snapshot", &[]).await?;
+    Ok(())
+}

--- a/mur-core/src/cmd/media/vlc.rs
+++ b/mur-core/src/cmd/media/vlc.rs
@@ -1,4 +1,9 @@
 //! VLC control via the HTTP interface.
+//!
+//! Most items here are `pub` but used only by the `mur-mcp-server` crate, not
+//! by the `mur` binary — so clippy flags them as dead code in the binary
+//! target. This is deliberate: these are library-facing exports.
+#![allow(dead_code)]
 
 use super::VlcRuntime;
 use anyhow::{Context, Result};

--- a/mur-core/src/cmd/media/vlc.rs
+++ b/mur-core/src/cmd/media/vlc.rs
@@ -17,10 +17,10 @@ pub fn detect_vlc() -> Option<PathBuf> {
 /// Parsed subset of VLC's `requests/status.xml`.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct VlcStatus {
-    pub state: String,   // "playing" | "paused" | "stopped"
-    pub time: i64,       // seconds elapsed
-    pub length: i64,     // seconds total
-    pub volume: i64,     // raw VLC volume (256 == 100%)
+    pub state: String, // "playing" | "paused" | "stopped"
+    pub time: i64,     // seconds elapsed
+    pub length: i64,   // seconds total
+    pub volume: i64,   // raw VLC volume (256 == 100%)
 }
 
 /// Base URL for the VLC HTTP interface.
@@ -221,17 +221,12 @@ pub async fn status() -> Result<VlcStatus> {
 }
 
 /// Internal accessor for scene.rs: ensure running and return the runtime.
-pub(super) async fn ensure_for_snapshot(
-    client: &reqwest::Client,
-) -> Result<VlcRuntime> {
+pub(super) async fn ensure_for_snapshot(client: &reqwest::Client) -> Result<VlcRuntime> {
     let home = mur_home()?;
     ensure_vlc_running(&home, client).await
 }
 
-pub(super) async fn snapshot_command(
-    rt: &VlcRuntime,
-    client: &reqwest::Client,
-) -> Result<()> {
+pub(super) async fn snapshot_command(rt: &VlcRuntime, client: &reqwest::Client) -> Result<()> {
     let _ = send_command(rt, client, "snapshot", &[]).await?;
     Ok(())
 }

--- a/mur-core/src/cmd/media/vlc.rs
+++ b/mur-core/src/cmd/media/vlc.rs
@@ -1,0 +1,1 @@
+//! VLC control via the HTTP interface. (Task 2 will populate.)

--- a/mur-core/src/cmd/media/vlc.rs
+++ b/mur-core/src/cmd/media/vlc.rs
@@ -1,1 +1,90 @@
-//! VLC control via the HTTP interface. (Task 2 will populate.)
+//! VLC control via the HTTP interface.
+
+use super::VlcRuntime;
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Default macOS VLC binary path; overridable via `MUR_VLC_PATH`.
+pub fn detect_vlc() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("MUR_VLC_PATH") {
+        let p = PathBuf::from(p);
+        return p.exists().then_some(p);
+    }
+    let candidate = Path::new("/Applications/VLC.app/Contents/MacOS/VLC");
+    candidate.exists().then(|| candidate.to_path_buf())
+}
+
+/// Parsed subset of VLC's `requests/status.xml`.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct VlcStatus {
+    pub state: String,   // "playing" | "paused" | "stopped"
+    pub time: i64,       // seconds elapsed
+    pub length: i64,     // seconds total
+    pub volume: i64,     // raw VLC volume (256 == 100%)
+}
+
+/// Base URL for the VLC HTTP interface.
+pub fn status_url(port: u16) -> String {
+    format!("http://127.0.0.1:{port}/requests/status.xml")
+}
+
+/// Build a command URL: `…/status.xml?command=<cmd>[&<extra>]`.
+pub fn command_url(port: u16, cmd: &str, extra: &[(&str, &str)]) -> String {
+    let mut url = format!("{}?command={}", status_url(port), cmd);
+    for (k, v) in extra {
+        url.push('&');
+        url.push_str(k);
+        url.push('=');
+        url.push_str(&urlencoding::encode(v));
+    }
+    url
+}
+
+/// Extract the text between `<tag>` and `</tag>` (first occurrence).
+fn tag(xml: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = xml.find(&open)? + open.len();
+    let end = xml[start..].find(&close)? + start;
+    Some(xml[start..end].to_string())
+}
+
+/// Parse the subset of status.xml we use. Missing fields default sensibly.
+pub fn parse_status_xml(xml: &str) -> VlcStatus {
+    VlcStatus {
+        state: tag(xml, "state").unwrap_or_else(|| "stopped".into()),
+        time: tag(xml, "time").and_then(|s| s.parse().ok()).unwrap_or(0),
+        length: tag(xml, "length").and_then(|s| s.parse().ok()).unwrap_or(0),
+        volume: tag(xml, "volume").and_then(|s| s.parse().ok()).unwrap_or(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_respects_env_override() {
+        // Point at a path that does not exist → None.
+        unsafe { std::env::set_var("MUR_VLC_PATH", "/no/such/vlc") };
+        assert_eq!(detect_vlc(), None);
+        unsafe { std::env::remove_var("MUR_VLC_PATH") };
+    }
+
+    #[test]
+    fn command_url_encodes_extra() {
+        let u = command_url(8080, "in_play", &[("input", "https://x/y?a=b")]);
+        assert!(u.starts_with("http://127.0.0.1:8080/requests/status.xml?command=in_play&input="));
+        assert!(u.contains("https%3A%2F%2Fx%2Fy%3Fa%3Db"));
+    }
+
+    #[test]
+    fn parse_status_extracts_fields() {
+        let xml = "<root><volume>256</volume><state>playing</state><time>42</time><length>3600</length></root>";
+        let s = parse_status_xml(xml);
+        assert_eq!(s.state, "playing");
+        assert_eq!(s.time, 42);
+        assert_eq!(s.length, 3600);
+        assert_eq!(s.volume, 256);
+    }
+}

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod init_local;
 pub(crate) mod inject_cmd;
 pub(crate) mod internals;
 pub(crate) mod learn;
+pub(crate) mod media;
 pub(crate) mod misc;
 pub(crate) mod model;
 pub(crate) mod murmurd;

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -34,7 +34,7 @@ pub(crate) mod init_local;
 pub(crate) mod inject_cmd;
 pub(crate) mod internals;
 pub(crate) mod learn;
-pub(crate) mod media;
+pub mod media;
 pub(crate) mod misc;
 pub(crate) mod model;
 pub(crate) mod murmurd;

--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -1150,6 +1150,14 @@ pub(crate) fn ensure_mur_skill(home: &std::path::Path) -> Result<bool> {
             "mur-session-remove",
             include_str!("../skills/mur_session_remove.yaml"),
         ),
+        (
+            "vlc-control",
+            include_str!("../skills/vlc_control.yaml"),
+        ),
+        (
+            "scene-explain",
+            include_str!("../skills/scene_explain.yaml"),
+        ),
     ];
 
     let mur_skills_dir = home.join(".mur").join("skills");

--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -1150,10 +1150,7 @@ pub(crate) fn ensure_mur_skill(home: &std::path::Path) -> Result<bool> {
             "mur-session-remove",
             include_str!("../skills/mur_session_remove.yaml"),
         ),
-        (
-            "vlc-control",
-            include_str!("../skills/vlc_control.yaml"),
-        ),
+        ("vlc-control", include_str!("../skills/vlc_control.yaml")),
         (
             "scene-explain",
             include_str!("../skills/scene_explain.yaml"),

--- a/mur-core/src/skills/scene_explain.yaml
+++ b/mur-core/src/skills/scene_explain.yaml
@@ -1,0 +1,24 @@
+name: scene-explain
+version: 0.1.0
+publisher: human:mur
+description: "Explain what is on screen in the currently playing video, using the local multimodal model (offline, private)."
+category: media
+hosts: [all]
+content:
+  abstract: |
+    When the user asks what's happening on screen, call scene_explain (optionally
+    with a specific question). It captures the current VLC frame and explains it
+    with the local model — no cloud, nothing uploaded.
+  context: |
+    # scene-explain — narrate the current frame
+
+    Call scene_explain(prompt?) to describe or interpret the current video frame.
+    Pause playback first (vlc_playback action=pause) so the frame is stable.
+    Answer in the user's language; default to warm Traditional Chinese.
+    Everything runs locally — emphasize privacy if the user asks.
+tags: [mur, media, vision, video, builtin]
+triggers:
+  - type: keyword
+    pattern: "(what('| i)s (happening|on screen|this scene)|explain (this|the) (scene|frame)|這(一)?幕|畫面.{0,6}(說明|解說)|他(剛)?說(的|了)什麼)"
+  - type: manual
+priority: normal

--- a/mur-core/src/skills/vlc_control.yaml
+++ b/mur-core/src/skills/vlc_control.yaml
@@ -1,0 +1,28 @@
+name: vlc-control
+version: 0.1.0
+publisher: human:mur
+description: "Watch and control video in VLC — open a local file or a YouTube link, play/pause/seek/volume, and check status."
+category: media
+hosts: [all]
+content:
+  abstract: |
+    To watch a movie with the user, drive VLC via the MCP tools: vlc_open
+    (local path or YouTube URL), vlc_playback (play/pause/toggle/stop/seek/volume),
+    and vlc_status. Check vlc_status before narrating so commentary matches the
+    current frame.
+  context: |
+    # vlc-control — watch together
+
+    Use these tools when the user wants to watch or control a video:
+    - vlc_open(source): start a local file or a URL (YouTube supported).
+    - vlc_playback(action, value?): play | pause | toggle | stop | seek | volume.
+    - vlc_status(): current state/time/length/volume.
+
+    Be warm and concise. Pause before explaining a frame. DRM-protected streaming
+    services (Netflix etc.) cannot be captured — decline gracefully if asked.
+tags: [mur, media, vlc, video, builtin]
+triggers:
+  - type: keyword
+    pattern: "(watch (a )?(movie|video)|play .{0,30}(in vlc|on vlc)|看(電影|影片)|一起看|youtube)"
+  - type: manual
+priority: normal

--- a/mur-mcp-server/src/tools.rs
+++ b/mur-mcp-server/src/tools.rs
@@ -149,6 +149,66 @@ pub fn all_tools() -> Vec<Tool> {
                 required: None,
             },
         },
+        // ── media tools ──
+        Tool {
+            name: "vlc_open".into(),
+            description: "Open a local video file path or a URL (e.g. a YouTube link) in VLC and start playing. Returns playback status.".into(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".into(),
+                properties: Some(vec![
+                    ("source".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "Local file path or video URL (YouTube supported)".into(),
+                        default: None,
+                    }),
+                ]),
+                required: Some(vec!["source".into()]),
+            },
+        },
+        Tool {
+            name: "vlc_playback".into(),
+            description: "Control VLC playback. action ∈ play|pause|toggle|stop|seek|volume. For seek, value=seconds; for volume, value=0-512 (256=100%).".into(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".into(),
+                properties: Some(vec![
+                    ("action".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "play|pause|toggle|stop|seek|volume".into(),
+                        default: None,
+                    }),
+                    ("value".into(), ToolParam {
+                        param_type: "number".into(),
+                        description: "Seconds (seek) or volume level (volume)".into(),
+                        default: None,
+                    }),
+                ]),
+                required: Some(vec!["action".into()]),
+            },
+        },
+        Tool {
+            name: "vlc_status".into(),
+            description: "Get current VLC playback status (state, time, length, volume). Use before narrating so the explanation matches the current frame.".into(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".into(),
+                properties: None,
+                required: None,
+            },
+        },
+        Tool {
+            name: "scene_explain".into(),
+            description: "Capture the current VLC frame and explain what is on screen using the local multimodal model (offline, private). Optionally pass a specific question.".into(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".into(),
+                properties: Some(vec![
+                    ("prompt".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "Optional question about the frame; defaults to a general description".into(),
+                        default: None,
+                    }),
+                ]),
+                required: None,
+            },
+        },
     ]
 }
 
@@ -292,6 +352,44 @@ pub async fn call_tool(name: &str, arguments: &Value) -> Result<Value, String> {
             }))
         }
 
+        "vlc_open" => {
+            let source = arguments
+                .get("source")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "Missing required parameter: 'source' (string)".to_string())?;
+            let status = mur_core::cmd::media::vlc::open(source)
+                .await
+                .map_err(|e| format!("vlc_open failed: {}", e))?;
+            Ok(serde_json::to_value(status).unwrap_or(Value::Null))
+        }
+
+        "vlc_playback" => {
+            let action = arguments
+                .get("action")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "Missing required parameter: 'action' (string)".to_string())?;
+            let value = arguments.get("value").and_then(|v| v.as_f64());
+            let status = mur_core::cmd::media::vlc::playback(action, value)
+                .await
+                .map_err(|e| format!("vlc_playback failed: {}", e))?;
+            Ok(serde_json::to_value(status).unwrap_or(Value::Null))
+        }
+
+        "vlc_status" => {
+            let status = mur_core::cmd::media::vlc::status()
+                .await
+                .map_err(|e| format!("vlc_status failed: {}", e))?;
+            Ok(serde_json::to_value(status).unwrap_or(Value::Null))
+        }
+
+        "scene_explain" => {
+            let prompt = arguments.get("prompt").and_then(|v| v.as_str());
+            let text = mur_core::cmd::media::scene::explain(prompt)
+                .await
+                .map_err(|e| format!("scene_explain failed: {}", e))?;
+            Ok(json!({ "explanation": text }))
+        }
+
         _ => Err(format!("Unknown tool: {}", name)),
     }
 }
@@ -299,4 +397,16 @@ pub async fn call_tool(name: &str, arguments: &Value) -> Result<Value, String> {
 /// Resolve ~/.mur from environment or default.
 fn resolve_mur_home() -> anyhow::Result<std::path::PathBuf> {
     mur_core::cmd::resolve_mur_home()
+}
+
+#[cfg(test)]
+mod media_tool_tests {
+    use super::*;
+    #[test]
+    fn media_tools_registered() {
+        let names: Vec<_> = all_tools().into_iter().map(|t| t.name).collect();
+        for n in ["vlc_open", "vlc_playback", "vlc_status", "scene_explain"] {
+            assert!(names.contains(&n.to_string()), "missing {n}");
+        }
+    }
 }

--- a/mur-mcp-server/tests/integration.rs
+++ b/mur-mcp-server/tests/integration.rs
@@ -53,7 +53,7 @@ fn test_initialize_and_list_tools() {
     );
     let resp = read_response(&mut stdout);
     let tools = resp["result"]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 6, "Expected 6 tools");
+    assert_eq!(tools.len(), 10, "Expected 10 tools");
 
     // Verify tool names
     let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
@@ -63,6 +63,10 @@ fn test_initialize_and_list_tools() {
     assert!(names.contains(&"mur_project_status"));
     assert!(names.contains(&"mur_agent_status"));
     assert!(names.contains(&"mur_hook_context"));
+    assert!(names.contains(&"vlc_open"));
+    assert!(names.contains(&"vlc_playback"));
+    assert!(names.contains(&"vlc_status"));
+    assert!(names.contains(&"scene_explain"));
 
     child.kill().ok();
 }


### PR DESCRIPTION
## Companion Media Skills — VLC Watch-Together + Scene Explain

VLC control + scene explanation companion skills for Mur.

### What changed
- `mur-core/src/cmd/media/` — VLC runtime, HTTP control, snapshot, scene explain
- `mur-mcp-server/src/tools.rs` — vlc_open/playback/status + scene_explain tools
- `skills/vlc_control.yaml`, `skills/scene_explain.yaml` — skill manifests

### Tests
- [x] 10 new unit tests pass
- [x] Full `cargo test --workspace` (same 6 pre-existing failures on main as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)