### PR TITLE
fix(media): companion-media-skills followup — 9 fixes from PR #339 review

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 anyhow = "1"
 thiserror = "2"
+quick-xml = "0.36"
 
 # Template processing dependencies
 handlebars = "4.5"

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -90,6 +90,7 @@ serde_jcs = "0.2"
 ed25519-dalek = { version = "2", features = ["rand_core", "pkcs8"] }
 bs58 = "0.5"
 base64 = "0.22"          # cmd::agent_companion::card::png chara/ccv3 chunk decode
+quick-xml = { workspace = true }
 ulid = { workspace = true }  # cmd::agent_companion::card::import inbox id
 
 [features]

--- a/mur-core/src/cmd/media/mod.rs
+++ b/mur-core/src/cmd/media/mod.rs
@@ -1,17 +1,14 @@
 //! Media companion: control VLC and explain the current frame with the local
 //! multimodal model. All control uses VLC's HTTP interface (no libVLC).
-//!
-//! Most items here are `pub` but used only by the `mur-mcp-server` crate, not
-//! by the `mur` binary — so clippy flags them as dead code in the binary
-//! target. The `expect` below is deliberate: these are library-facing exports.
-#![allow(dead_code)]
 
 pub mod scene;
 pub mod vlc;
 
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 /// Per-session VLC HTTP connection details. Generated once and persisted so
 /// repeated tool calls reach the same running VLC instance.
@@ -30,10 +27,10 @@ pub fn pick_free_port() -> std::io::Result<u16> {
 
 /// 32-hex-char random password from the OS RNG (not a long-term secret, but
 /// must not be guessable by other local users).
-pub fn gen_password() -> String {
+pub fn gen_password() -> anyhow::Result<String> {
     let mut buf = [0u8; 16];
-    getrandom::getrandom(&mut buf).expect("OS RNG");
-    buf.iter().map(|b| format!("{b:02x}")).collect()
+    getrandom::getrandom(&mut buf)?;
+    Ok(buf.iter().map(|b| format!("{b:02x}")).collect())
 }
 
 pub fn runtime_path(mur_home: &Path) -> PathBuf {
@@ -47,14 +44,26 @@ pub fn load_runtime(mur_home: &Path) -> Option<VlcRuntime> {
 }
 
 /// Persist the runtime config atomically.
-pub fn save_runtime(mur_home: &Path, rt: &VlcRuntime) -> std::io::Result<()> {
+pub fn save_runtime(mur_home: &Path, rt: &VlcRuntime) -> anyhow::Result<()> {
     let path = runtime_path(mur_home);
     if let Some(p) = path.parent() {
         std::fs::create_dir_all(p)?;
     }
     let tmp = path.with_extension("json.tmp");
-    std::fs::write(&tmp, serde_json::to_vec_pretty(rt).unwrap())?;
-    std::fs::rename(&tmp, &path)
+    let data = serde_json::to_vec_pretty(rt).context("serialize VlcRuntime")?;
+    std::fs::write(&tmp, data).context("write runtime tmp")?;
+    std::fs::rename(&tmp, &path).context("rename runtime tmp")?;
+    Ok(())
+}
+
+/// Reusable HTTP client with connection pooling for VLC and VLM endpoints.
+pub fn shared_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .build()
+            .expect("build reqwest Client")
+    })
 }
 
 #[cfg(test)]
@@ -64,7 +73,7 @@ mod tests {
 
     #[test]
     fn password_is_32_hex_chars() {
-        let p = gen_password();
+        let p = gen_password().unwrap();
         assert_eq!(p.len(), 32);
         assert!(p.chars().all(|c| c.is_ascii_hexdigit()));
     }

--- a/mur-core/src/cmd/media/scene.rs
+++ b/mur-core/src/cmd/media/scene.rs
@@ -1,13 +1,9 @@
 //! scene-explain: capture the current VLC frame and explain it with the local
 //! multimodal model.
-//!
-//! Most items here are `pub` but used only by the `mur-mcp-server` crate, not
-//! by the `mur` binary — so clippy flags them as dead code in the binary
-//! target. This is deliberate: these are library-facing exports.
-#![allow(dead_code)]
 
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// Return the most recently modified regular file in `dir`, if any.
 pub fn newest_file(dir: &Path) -> Option<PathBuf> {
@@ -129,24 +125,49 @@ fn local_base_url() -> Result<String> {
 }
 
 /// Capture the current VLC frame and explain it with the local multimodal model.
+#[allow(dead_code)]
 pub async fn explain(prompt: Option<&str>) -> Result<String> {
-    let client = reqwest::Client::new();
+    let client = super::shared_client();
 
     // 1. Ensure VLC is up and take a snapshot.
-    let rt = super::vlc::ensure_for_snapshot(&client).await?;
-    super::vlc::snapshot_command(&rt, &client).await?;
+    let rt = super::vlc::ensure_for_snapshot(client).await?;
+    super::vlc::snapshot_command(&rt, client).await?;
 
     // 2. Read the newest snapshot file (retry briefly for the file to land).
     let mut img_path = None;
-    for _ in 0..10 {
+    for i in 0..10 {
         if let Some(p) = newest_file(&rt.snapshot_dir) {
             img_path = Some(p);
             break;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        // Periodically verify VLC is still alive before retrying.
+        if i > 0 && i % 3 == 0 {
+            let alive = client
+                .get(super::vlc::status_url(rt.port))
+                .basic_auth("", Some(&rt.password))
+                .timeout(Duration::from_secs(2))
+                .send()
+                .await
+                .map(|r| r.status().is_success())
+                .unwrap_or(false);
+            if !alive {
+                anyhow::bail!("VLC disconnected while waiting for snapshot");
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
     }
     let img_path = img_path.context("no snapshot produced by VLC")?;
-    let bytes = std::fs::read(&img_path).context("read snapshot")?;
+
+    // Handle race: VLC may replace the snapshot file between discovery and read.
+    let bytes = match std::fs::read(&img_path) {
+        Ok(b) => b,
+        Err(_) => {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            let retry = newest_file(&rt.snapshot_dir)
+                .context("no snapshot (file vanished and no replacement found)")?;
+            std::fs::read(&retry).context("read snapshot")?
+        }
+    };
 
     // 3. Call the local OpenAI-compatible vision endpoint.
     let base = local_base_url()?;
@@ -158,6 +179,7 @@ pub async fn explain(prompt: Option<&str>) -> Result<String> {
     let resp: serde_json::Value = client
         .post(format!("{}/chat/completions", base.trim_end_matches('/')))
         .json(&body)
+        .timeout(Duration::from_secs(30))
         .send()
         .await
         .context("call local VLM")?

--- a/mur-core/src/cmd/media/vlc.rs
+++ b/mur-core/src/cmd/media/vlc.rs
@@ -1,21 +1,20 @@
 //! VLC control via the HTTP interface.
-//!
-//! Most items here are `pub` but used only by the `mur-mcp-server` crate, not
-//! by the `mur` binary — so clippy flags them as dead code in the binary
-//! target. This is deliberate: these are library-facing exports.
-#![allow(dead_code)]
 
 use super::VlcRuntime;
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-/// Default macOS VLC binary path; overridable via `MUR_VLC_PATH`.
+/// Default macOS VLC binary path.
+const DEFAULT_VLC_PATH: &str = "/Applications/VLC.app/Contents/MacOS/VLC";
+
+/// Locate VLC binary: env override `MUR_VLC_PATH`, else default path.
 pub fn detect_vlc() -> Option<PathBuf> {
     if let Some(p) = std::env::var_os("MUR_VLC_PATH") {
         let p = PathBuf::from(p);
         return p.exists().then_some(p);
     }
-    let candidate = Path::new("/Applications/VLC.app/Contents/MacOS/VLC");
+    let candidate = Path::new(DEFAULT_VLC_PATH);
     candidate.exists().then(|| candidate.to_path_buf())
 }
 
@@ -45,22 +44,45 @@ pub fn command_url(port: u16, cmd: &str, extra: &[(&str, &str)]) -> String {
     url
 }
 
-/// Extract the text between `<tag>` and `</tag>` (first occurrence).
-fn tag(xml: &str, tag: &str) -> Option<String> {
-    let open = format!("<{tag}>");
-    let close = format!("</{tag}>");
-    let start = xml.find(&open)? + open.len();
-    let end = xml[start..].find(&close)? + start;
-    Some(xml[start..end].to_string())
-}
-
-/// Parse the subset of status.xml we use. Missing fields default sensibly.
+/// Parse the subset of VLC's `status.xml` using a proper XML reader.
+/// Missing fields default sensibly.
 pub fn parse_status_xml(xml: &str) -> VlcStatus {
+    use quick_xml::Reader;
+    use quick_xml::events::Event;
+
+    let mut reader = Reader::from_str(xml);
+    let mut state = "stopped".to_string();
+    let mut time = 0i64;
+    let mut length = 0i64;
+    let mut volume = 0i64;
+    let mut buf = Vec::new();
+    let mut in_tag = String::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                in_tag = String::from_utf8_lossy(e.name().as_ref()).into_owned();
+            }
+            Ok(Event::Text(ref e)) => {
+                let text = e.unescape().unwrap_or_default().to_string();
+                match in_tag.as_str() {
+                    "state" => state = text,
+                    "time" => time = text.parse().unwrap_or(0),
+                    "length" => length = text.parse().unwrap_or(0),
+                    "volume" => volume = text.parse().unwrap_or(0),
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) => break,
+            _ => {}
+        }
+        buf.clear();
+    }
     VlcStatus {
-        state: tag(xml, "state").unwrap_or_else(|| "stopped".into()),
-        time: tag(xml, "time").and_then(|s| s.parse().ok()).unwrap_or(0),
-        length: tag(xml, "length").and_then(|s| s.parse().ok()).unwrap_or(0),
-        volume: tag(xml, "volume").and_then(|s| s.parse().ok()).unwrap_or(0),
+        state,
+        time,
+        length,
+        volume,
     }
 }
 
@@ -105,7 +127,7 @@ fn ensure_runtime(mur_home: &Path) -> Result<VlcRuntime> {
     }
     let rt = VlcRuntime {
         port: pick_free_port().context("pick free port")?,
-        password: gen_password(),
+        password: gen_password().context("generate VLC password")?,
         snapshot_dir: mur_home.join("runtime").join("vlc-snapshots"),
     };
     std::fs::create_dir_all(&rt.snapshot_dir).ok();
@@ -121,6 +143,7 @@ async fn ensure_vlc_running(mur_home: &Path, client: &reqwest::Client) -> Result
     if client
         .get(status_url(rt.port))
         .basic_auth("", Some(&rt.password))
+        .timeout(Duration::from_secs(3))
         .send()
         .await
         .map(|r| r.status().is_success())
@@ -146,6 +169,7 @@ async fn ensure_vlc_running(mur_home: &Path, client: &reqwest::Client) -> Result
         if client
             .get(status_url(rt.port))
             .basic_auth("", Some(&rt.password))
+            .timeout(Duration::from_secs(3))
             .send()
             .await
             .map(|r| r.status().is_success())
@@ -161,6 +185,7 @@ async fn get_status(rt: &VlcRuntime, client: &reqwest::Client) -> Result<VlcStat
     let xml = client
         .get(status_url(rt.port))
         .basic_auth("", Some(&rt.password))
+        .timeout(Duration::from_secs(5))
         .send()
         .await?
         .text()
@@ -177,6 +202,7 @@ async fn send_command(
     let xml = client
         .get(command_url(rt.port, cmd, extra))
         .basic_auth("", Some(&rt.password))
+        .timeout(Duration::from_secs(5))
         .send()
         .await?
         .text()
@@ -191,46 +217,51 @@ fn mur_home() -> Result<PathBuf> {
 }
 
 /// Open a local file path or a URL (e.g. YouTube) in VLC.
+#[allow(dead_code)]
 pub async fn open(source: &str) -> Result<VlcStatus> {
-    let client = reqwest::Client::new();
+    let client = super::shared_client();
     let home = mur_home()?;
-    let rt = ensure_vlc_running(&home, &client).await?;
-    send_command(&rt, &client, "in_play", &[("input", source)]).await
+    let rt = ensure_vlc_running(&home, client).await?;
+    send_command(&rt, client, "in_play", &[("input", source)]).await
 }
 
 /// Playback control. `action` ∈ {play, pause, toggle, stop, seek, volume}.
 /// `value` is seconds (seek) or raw VLC volume (volume).
+#[allow(dead_code)]
 pub async fn playback(action: &str, value: Option<f64>) -> Result<VlcStatus> {
-    let client = reqwest::Client::new();
+    let client = super::shared_client();
     let home = mur_home()?;
-    let rt = ensure_vlc_running(&home, &client).await?;
+    let rt = ensure_vlc_running(&home, client).await?;
     let v = value.unwrap_or(0.0);
     let vs = format!("{}", v as i64);
     match action {
-        "play" => send_command(&rt, &client, "pl_forceresume", &[]).await,
-        "pause" => send_command(&rt, &client, "pl_forcepause", &[]).await,
-        "toggle" => send_command(&rt, &client, "pl_pause", &[]).await,
-        "stop" => send_command(&rt, &client, "pl_stop", &[]).await,
-        "seek" => send_command(&rt, &client, "seek", &[("val", &vs)]).await,
-        "volume" => send_command(&rt, &client, "volume", &[("val", &vs)]).await,
+        "play" => send_command(&rt, client, "pl_forceresume", &[]).await,
+        "pause" => send_command(&rt, client, "pl_forcepause", &[]).await,
+        "toggle" => send_command(&rt, client, "pl_pause", &[]).await,
+        "stop" => send_command(&rt, client, "pl_stop", &[]).await,
+        "seek" => send_command(&rt, client, "seek", &[("val", &vs)]).await,
+        "volume" => send_command(&rt, client, "volume", &[("val", &vs)]).await,
         other => anyhow::bail!("unknown playback action: {other}"),
     }
 }
 
 /// Current playback status.
+#[allow(dead_code)]
 pub async fn status() -> Result<VlcStatus> {
-    let client = reqwest::Client::new();
+    let client = super::shared_client();
     let home = mur_home()?;
-    let rt = ensure_vlc_running(&home, &client).await?;
-    get_status(&rt, &client).await
+    let rt = ensure_vlc_running(&home, client).await?;
+    get_status(&rt, client).await
 }
 
 /// Internal accessor for scene.rs: ensure running and return the runtime.
+#[allow(dead_code)]
 pub(super) async fn ensure_for_snapshot(client: &reqwest::Client) -> Result<VlcRuntime> {
     let home = mur_home()?;
     ensure_vlc_running(&home, client).await
 }
 
+#[allow(dead_code)]
 pub(super) async fn snapshot_command(rt: &VlcRuntime, client: &reqwest::Client) -> Result<()> {
     let _ = send_command(rt, client, "snapshot", &[]).await?;
     Ok(())


### PR DESCRIPTION
## What

Applies the 9 deferred best-practice fixes from the companion-media-skills feature (PR #339).

### High (crash risk)

| Fix | Before | After |
|-----|--------|-------|
| **gen_password() panic** |  panics in production | Returns `anyhow::Result<String>`, propagates `getrandom` error |
| **save_runtime() unwrap** | `serde_json::to_vec_pretty(rt).unwrap()` panics | `.context()` propagates serde error |
| **VLC HTTP timeout** | No timeout — hangs forever | 3s on probes, 5s on commands, 30s on VLM calls |

### Medium (correctness)

| Fix | Before | After |
|-----|--------|-------|
| **Fragile XML parser** | String `find("<state>")` breaks on attributes, self-closing tags | `quick_xml::Reader` proper event-driven parser |
| **File race in explain()** | `newest_file()` then `fs::read()` — file can be deleted in between | Retries with re-detect on read failure |
| **Blind 1.5s retry** | 10×150ms sleep regardless of VLC state | Checks VLC HTTP health every 3rd iteration, bails early on disconnect |

### Low (convention)

| Fix | Before | After |
|-----|--------|-------|
| **dead_code scope** | `#![allow(dead_code)]` module-wide | `#[allow(dead_code)]` on individual exports only |
| **Hardcoded VLC path** | Inline string literal | `const DEFAULT_VLC_PATH` |
| **Client reuse** | New `reqwest::Client` per call | Shared `OnceLock<Client>` with connection pooling |

## Files changed

```
 Cargo.toml                      |   1 +
 mur-core/Cargo.toml             |   1 +
 mur-core/src/cmd/media/mod.rs   |  33 ++++++++-----
 mur-core/src/cmd/media/scene.rs |  44 +++++++++++++-----
 mur-core/src/cmd/media/vlc.rs   | 100 +++++++++++++++++++++++++---------------
 5 files changed, 119 insertions(+), 60 deletions(-)
```

## Verification

- ✅ `cargo build --workspace` — clean
- ✅ `cargo clippy -p mur-core -- -D warnings` — clean
- ✅ `cargo test -p mur-core cmd::media::` — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)