### PR TITLE
fix(hub): AgentDiscovery reads profile.yaml + macOS sandbox hardening

### DIFF
--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -130,7 +130,9 @@ pub fn build_sbpl_profile(policy: &SandboxPolicy) -> String {
         Some(ports) => {
             lines.push("(deny network-outbound)".to_string());
             for port in ports {
-                lines.push(format!("(allow network-outbound (remote tcp \"*:{port}\"))"));
+                lines.push(format!(
+                    "(allow network-outbound (remote tcp \"*:{port}\"))"
+                ));
             }
         }
     }
@@ -189,7 +191,10 @@ mod tests {
         let allow = sbpl
             .find("(allow file-write* (subpath \"/data/agent\"))")
             .expect("declared write path must be allowed");
-        assert!(allow > baseline, "allow must follow the deny baseline (last-match-wins)");
+        assert!(
+            allow > baseline,
+            "allow must follow the deny baseline (last-match-wins)"
+        );
     }
 
     #[test]
@@ -202,7 +207,10 @@ mod tests {
             !sbpl.contains("x\") (allow file-write* (subpath \"/\"))"),
             "unescaped injection payload leaked into profile:\n{sbpl}"
         );
-        assert!(sbpl.contains("\\\""), "quote should be backslash-escaped:\n{sbpl}");
+        assert!(
+            sbpl.contains("\\\""),
+            "quote should be backslash-escaped:\n{sbpl}"
+        );
     }
 
     #[test]

--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -45,44 +45,95 @@ pub fn apply_macos(policy: &SandboxPolicy) -> anyhow::Result<SandboxStatus> {
     })
 }
 
-/// Build an SBPL profile string from the policy.
-/// Strategy: allow everything (allow default), deny explicit paths,
-/// then restrict writes to only allowed write paths.
-pub fn build_sbpl_profile(policy: &SandboxPolicy) -> String {
-    let mut lines = vec!["(version 1)".to_string(), "(allow default)".to_string()];
+/// Standard macOS locations a process must be able to write to in order to
+/// function (per-user temp + cache used by dyld, confstr, NSURLSession, etc.).
+/// Under the default-deny-write baseline these are re-allowed so confinement
+/// blocks user data (Documents, etc.) without breaking the runtime.
+const MACOS_SYSTEM_WRITE_PATHS: &[&str] = &[
+    "/private/var/folders", // per-user temp + dyld closures + confstr dirs
+    "/private/tmp",         // /tmp symlinks here
+    "/dev/null",
+    "/dev/stdout",
+    "/dev/stderr",
+];
 
-    // Deny reads AND writes to explicitly denied paths.
+/// Escape a string for safe inclusion in an SBPL double-quoted literal.
+///
+/// SBPL (a TinyScheme dialect) honors `\\` and `\"` inside string literals.
+/// Without escaping, a path or host containing `"` / `)` could break out of
+/// the literal and rewrite the policy — and if the resulting profile fails to
+/// parse, `apply_macos` falls back to advisory-only (no sandbox). Since paths
+/// and hosts originate from `profile.yaml` (attacker-influenced for imported
+/// `.muragent` packages), escaping is a trust boundary, not cosmetics.
+fn sbpl_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            // Drop control characters that could corrupt the profile text.
+            c if c.is_control() => {}
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+/// Build an SBPL profile string from the policy.
+///
+/// Strategy: default-allow for reads/exec/network (so the process can load
+/// system libraries and run), but **default-deny for filesystem writes** —
+/// nothing is writable except the agent's own declared write paths plus the
+/// standard macOS system-write locations. This matches the Linux Landlock
+/// posture for writes without the fragility of a full `(deny default)` that
+/// would also block dyld and system access. All interpolated paths/hosts are
+/// escaped to prevent s-expression injection via a malicious profile.
+pub fn build_sbpl_profile(policy: &SandboxPolicy) -> String {
+    let mut lines = vec![
+        "(version 1)".to_string(),
+        "(allow default)".to_string(),
+        // Baseline: deny ALL writes. Specific paths are re-allowed below.
+        "(deny file-write* (subpath \"/\"))".to_string(),
+    ];
+
+    // Deny reads (and keep an explicit write-deny) on sensitive paths.
     for path in &policy.fs_deny {
-        let p = path.to_string_lossy();
-        lines.push(format!("(deny file-write* (subpath \"{p}\"))"));
+        let p = sbpl_escape(&path.to_string_lossy());
         lines.push(format!("(deny file-read* (subpath \"{p}\"))"));
+        lines.push(format!("(deny file-write* (subpath \"{p}\"))"));
     }
 
-    // Allow writes to explicitly allowed write paths.
-    for path in &policy.fs_write {
-        let p = path.to_string_lossy();
+    // Re-allow writes for the standard macOS system-write locations so the
+    // runtime (dyld, temp, stdio) keeps working under the deny baseline.
+    for p in MACOS_SYSTEM_WRITE_PATHS {
         lines.push(format!("(allow file-write* (subpath \"{p}\"))"));
     }
 
-    // Network restrictions.
-    if let Some(hosts) = &policy.net_allow_hosts {
-        if hosts.is_empty() {
+    // Re-allow writes to the policy's explicitly allowed write paths. These
+    // come last so they win the last-match-wins evaluation over the baseline.
+    for path in &policy.fs_write {
+        let p = sbpl_escape(&path.to_string_lossy());
+        lines.push(format!("(allow file-write* (subpath \"{p}\"))"));
+    }
+
+    // Network restrictions. NOTE: macOS SBPL `remote tcp` only accepts `*` or
+    // `localhost` as the host — a hostname like "api.anthropic.com:443" is a
+    // hard parse error that fails sandbox_init for the WHOLE profile (silent
+    // fail-open). So we restrict by PORT here (host `*`) and delegate hostname
+    // allowlisting to the HostGuard reqwest layer.
+    match &policy.net_allow_ports {
+        None => { /* Unrestricted: (allow default) covers outbound. */ }
+        Some(ports) if ports.is_empty() => {
             // Off: deny all outbound TCP.
             lines.push("(deny network-outbound)".to_string());
-        } else {
-            // Restricted: deny all, then allow listed hosts on ports 443 and 80.
+        }
+        Some(ports) => {
             lines.push("(deny network-outbound)".to_string());
-            for host in hosts {
-                lines.push(format!(
-                    "(allow network-outbound (remote tcp \"{host}:443\"))"
-                ));
-                lines.push(format!(
-                    "(allow network-outbound (remote tcp \"{host}:80\"))"
-                ));
+            for port in ports {
+                lines.push(format!("(allow network-outbound (remote tcp \"*:{port}\"))"));
             }
         }
     }
-    // None (Unrestricted): leave network unblocked — (allow default) covers it.
 
     lines.join("\n")
 }
@@ -96,4 +147,97 @@ unsafe extern "C" {
     ) -> libc::c_int;
 
     fn sandbox_free_error(errorbuf: *mut libc::c_char);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn policy_with(write: Vec<PathBuf>, deny: Vec<PathBuf>) -> SandboxPolicy {
+        SandboxPolicy {
+            fs_write: write,
+            fs_deny: deny,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn writes_are_default_deny_with_baseline() {
+        let sbpl = build_sbpl_profile(&policy_with(vec![], vec![]));
+        assert!(
+            sbpl.contains("(deny file-write* (subpath \"/\"))"),
+            "missing default-deny-write baseline:\n{sbpl}"
+        );
+    }
+
+    #[test]
+    fn system_write_paths_are_reallowed() {
+        let sbpl = build_sbpl_profile(&policy_with(vec![], vec![]));
+        for p in MACOS_SYSTEM_WRITE_PATHS {
+            assert!(
+                sbpl.contains(&format!("(allow file-write* (subpath \"{p}\"))")),
+                "missing system write allow for {p}:\n{sbpl}"
+            );
+        }
+    }
+
+    #[test]
+    fn declared_write_path_is_allowed_after_baseline() {
+        let sbpl = build_sbpl_profile(&policy_with(vec![PathBuf::from("/data/agent")], vec![]));
+        let baseline = sbpl.find("(deny file-write* (subpath \"/\"))").unwrap();
+        let allow = sbpl
+            .find("(allow file-write* (subpath \"/data/agent\"))")
+            .expect("declared write path must be allowed");
+        assert!(allow > baseline, "allow must follow the deny baseline (last-match-wins)");
+    }
+
+    #[test]
+    fn malicious_path_is_escaped_not_injected() {
+        // A path crafted to break out of the SBPL string literal must be
+        // neutralized — the raw injection payload must not appear verbatim.
+        let evil = PathBuf::from("x\") (allow file-write* (subpath \"/");
+        let sbpl = build_sbpl_profile(&policy_with(vec![evil], vec![]));
+        assert!(
+            !sbpl.contains("x\") (allow file-write* (subpath \"/\"))"),
+            "unescaped injection payload leaked into profile:\n{sbpl}"
+        );
+        assert!(sbpl.contains("\\\""), "quote should be backslash-escaped:\n{sbpl}");
+    }
+
+    #[test]
+    fn off_mode_denies_network() {
+        let mut policy = policy_with(vec![], vec![]);
+        policy.net_allow_ports = Some(vec![]);
+        let sbpl = build_sbpl_profile(&policy);
+        assert!(sbpl.contains("(deny network-outbound)"));
+        assert!(
+            !sbpl.contains("(allow network-outbound"),
+            "Off mode must not allow any outbound:\n{sbpl}"
+        );
+    }
+
+    #[test]
+    fn restricted_uses_port_wildcard_not_hostname() {
+        // Regression: hostname-based `remote tcp` is invalid SBPL and fails
+        // sandbox_init for the whole profile (silent fail-open). Restricted
+        // mode must emit `*:<port>` rules only.
+        let mut policy = policy_with(vec![], vec![]);
+        policy.net_allow_ports = Some(vec![443, 80]);
+        policy.net_allow_hosts = Some(vec!["api.anthropic.com".to_string()]);
+        let sbpl = build_sbpl_profile(&policy);
+        assert!(sbpl.contains("(allow network-outbound (remote tcp \"*:443\"))"));
+        assert!(sbpl.contains("(allow network-outbound (remote tcp \"*:80\"))"));
+        assert!(
+            !sbpl.contains("api.anthropic.com"),
+            "SBPL must not contain hostnames (invalid `remote tcp` host):\n{sbpl}"
+        );
+    }
+
+    #[test]
+    fn unrestricted_emits_no_network_rules() {
+        let policy = policy_with(vec![], vec![]); // net_allow_ports defaults to None
+        let sbpl = build_sbpl_profile(&policy);
+        assert!(!sbpl.contains("network-outbound"));
+    }
 }

--- a/mur-gui-core/src/discovery.rs
+++ b/mur-gui-core/src/discovery.rs
@@ -1,4 +1,4 @@
-//! Agent discovery — filesystem scan of `~/.mur/agents/*/agent.yaml`.
+//! Agent discovery — filesystem scan of `~/.mur/agents/*/profile.yaml`.
 //!
 //! Publishes a `Vec<AgentEntry>` snapshot every 5 seconds via a
 //! `tokio::sync::watch` channel so Tauri backends can push `agents-updated`
@@ -43,7 +43,7 @@ pub struct AgentEntry {
     pub model_id: String,
 }
 
-/// Background scanner that polls `$mur_home/agents/*/agent.yaml` at 5s intervals.
+/// Background scanner that polls `$mur_home/agents/*/profile.yaml` at 5s intervals.
 pub struct AgentDiscovery {
     mur_home: PathBuf,
     tx: watch::Sender<Vec<AgentEntry>>,
@@ -81,7 +81,7 @@ impl AgentDiscovery {
     }
 }
 
-/// Scan `$mur_home/agents/*/agent.yaml` and return current entries sorted by name.
+/// Scan `$mur_home/agents/*/profile.yaml` and return current entries sorted by name.
 pub fn scan_agents(mur_home: &Path) -> Vec<AgentEntry> {
     let agents_dir = mur_home.join("agents");
     let Ok(dir) = std::fs::read_dir(&agents_dir) else {
@@ -93,7 +93,7 @@ pub fn scan_agents(mur_home: &Path) -> Vec<AgentEntry> {
         .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
         .filter_map(|dir_entry| {
             let agent_dir = dir_entry.path();
-            let yaml_path = agent_dir.join("agent.yaml");
+            let yaml_path = agent_dir.join("profile.yaml");
             let bytes = std::fs::read(&yaml_path).ok()?;
             let profile: AgentProfile = serde_yaml_ng::from_slice(&bytes).ok()?;
             let lock_path = agent_dir.join("running.lock");
@@ -169,7 +169,7 @@ updated_at: "2026-01-01T00:00:00+00:00"
         let dir = tempdir().unwrap();
         let agents_dir = dir.path().join("agents").join("bad-agent");
         fs::create_dir_all(&agents_dir).unwrap();
-        fs::write(agents_dir.join("agent.yaml"), b"not: valid: yaml: [[[").unwrap();
+        fs::write(agents_dir.join("profile.yaml"), b"not: valid: yaml: [[[").unwrap();
         let result = scan_agents(dir.path());
         assert!(result.is_empty());
     }
@@ -180,7 +180,7 @@ updated_at: "2026-01-01T00:00:00+00:00"
         let agent_dir = dir.path().join("agents").join("test-agent");
         fs::create_dir_all(&agent_dir).unwrap();
         fs::write(
-            agent_dir.join("agent.yaml"),
+            agent_dir.join("profile.yaml"),
             make_agent_yaml(
                 "test-agent",
                 "Test Agent",
@@ -202,7 +202,7 @@ updated_at: "2026-01-01T00:00:00+00:00"
         let agent_dir = dir.path().join("agents").join("live-agent");
         fs::create_dir_all(&agent_dir).unwrap();
         fs::write(
-            agent_dir.join("agent.yaml"),
+            agent_dir.join("profile.yaml"),
             make_agent_yaml(
                 "live-agent",
                 "Live Agent",


### PR DESCRIPTION
## Summary

Two fixes for the Hub and agent sandbox:

### 1. Hub AgentDiscovery: scan profile.yaml, not agent.yaml (861552f)

**Root cause:** `AgentDiscovery::scan_agents()` was the **only** code path in the entire codebase that read `agent.yaml`. Every agent writer — `seed_mur`, onboarding wizard, CLI create/import/export, lifecycle — writes `profile.yaml`. The seeded Mur agent template (PR #338) ships `profile.yaml`, so Discovery never found it and the Hub showed zero agents on first launch.

**Fix:** Change the scan path from `agent.yaml` → `profile.yaml` in `discovery.rs`.

### 2. macOS SBPL sandbox hardening (157ab51)

Three security fixes:
- **Default-deny-write baseline:** Matches Linux Landlock posture. Previously writes were unrestricted under `(allow default)`.
- **SBPL injection escape:** `sbpl_escape()` prevents malicious paths in imported `.muragent` profiles from breaking out of TinyScheme string literals.
- **Network port rules:** Replace `(remote tcp "hostname:443")` with `(remote tcp "*:443")`. SBPL only accepts `*" or "localhost" as the remote-tcp host — hostnames cause `sandbox_init` to **silently fail** for the entire profile (fail-open, no sandbox).

## Files changed
- `mur-gui-core/src/discovery.rs` — agent.yaml → profile.yaml (7 lines: 3 docs + 1 path + 3 tests)
- `mur-agent-runtime/src/sandbox/macos.rs` — default-deny-write, sbpl_escape, net port rules + 7 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)