### PR TITLE
feat(hub): 7-tab detail panel — Persona/Style/Behavior/Skills/MCP/Permissions/Inbox

### DIFF
--- a/docs/superpowers/plans/2026-06-03-hub-detail-panel-plan-3.md
+++ b/docs/superpowers/plans/2026-06-03-hub-detail-panel-plan-3.md
@@ -1,0 +1,486 @@
+# Hub Detail Panel + CSS — Plan 3 Implementation Plan
+
+**Date:** 2026-06-03
+**Spec:** `2026-05-29-mur-agent-export-ux-give-to-a-friend-design.md` Plan 3 outline
+**Builds on:** Plan 1, Plan 1b, Plan 2 (all Rust backend done)
+
+## Goal
+
+Complete the Hub UI so the detail panel (right sidebar when clicking an agent) shows 7 functional tabs — Persona, Style, Behavior, Skills, MCP, Permissions, Inbox — with proper CSS styling. Also fix missing `.input` CSS class used by the import modal's model wizard.
+
+## Current State vs Target
+
+| Item | Current | Target |
+|------|---------|--------|
+| Detail panel CSS | Completely missing (`.detail-panel*` classes undefined) | Full styled right sidebar |
+| Detail panel tabs | Only "Inbox" rendered | Persona / Style / Behavior / Skills / MCP / Permissions / Inbox |
+| `.input` CSS | Missing (used by ModelResolutionStep) | Styled text inputs |
+| Rust: agent detail read | Discovery reads full profile but discards most fields | `get_agent_detail` command |
+| Rust: agent detail write | None | `update_agent_detail` command |
+
+## Architecture
+
+**Rust backend** (`mur-hub-gui/src-tauri/src/detail.rs`):
+- `get_agent_detail(name)` — reads `profile.yaml` → returns `AgentDetail` with all tab data
+- `update_agent_detail(name, patch)` — applies `DetailPatch` (all-Optional fields) → writes back `profile.yaml`
+
+**React frontend** (`mur-hub-gui/ui/src/components/`):
+- New `DetailPanel.tsx` component with tab routing
+- New tab components: `PersonaTab`, `StyleTab`, `BehaviorTab`, `SkillsTab`, `McpTab`, `PermissionsTab`
+- Existing `CompanionInbox.tsx` reused for Inbox tab
+
+**CSS** (`styles.css`):
+- `.input` class
+- `.detail-panel*` classes
+- Tab-specific styles
+
+---
+
+## Task 1: Rust backend — `AgentDetail` type + `get_agent_detail` command
+
+**Files:**
+- Create: `mur-hub-gui/src-tauri/src/detail.rs`
+- Modify: `mur-hub-gui/src-tauri/src/lib.rs`
+
+**Steps:**
+
+- [ ] 1.1 Create `detail.rs` with `AgentDetail` struct + `get_agent_detail` command
+
+```rust
+//! Agent detail panel — full-profile read + partial write for the Hub's
+//! right-side slide-in panel (Persona / Style / Behavior / Skills / MCP /
+//! Permissions / Inbox tabs).
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// All detail-panel tab data extracted from one AgentProfile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentDetail {
+    // Persona tab
+    pub persona_category: String,
+    pub persona_description: String,
+    pub persona_tone: String,
+    pub persona_risk: String,
+    pub persona_verbosity: String,
+    // Style tab
+    pub style_preset: String,
+    pub render_status: RenderStatusView,
+    // Behavior tab
+    pub behavior_preset: String,
+    // Skills tab
+    pub skills: Vec<SkillView>,
+    pub installed_skills: Vec<InstalledSkillView>,
+    // MCP tab
+    pub mcp_servers: Vec<McpServerView>,
+    // Permissions tab
+    pub capabilities: Vec<String>,
+    // Read-only metadata
+    pub display_name: String,
+    pub agent_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum RenderStatusView {
+    Pending,
+    Rendering { done: u8, total: u8 },
+    Ready,
+    Failed { reason: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillView {
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstalledSkillView {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub category: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServerView {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+}
+
+/// Partial update to an agent's profile. All fields optional — only set
+/// fields are applied.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DetailPatch {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona_category: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona_description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona_tone: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona_risk: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona_verbosity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style_preset: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub behavior_preset: Option<String>,
+}
+
+#[tauri::command]
+pub fn get_agent_detail(name: String) -> Result<AgentDetail, String> {
+    let mur_home = crate::mur_home_path();
+    let profile_path = mur_home.join("agents").join(&name).join("profile.yaml");
+    let bytes = std::fs::read(&profile_path).map_err(|e| format!("read profile: {e}"))?;
+    let profile: mur_common::AgentProfile =
+        serde_yaml_ng::from_slice(&bytes).map_err(|e| format!("parse profile: {e}"))?;
+
+    Ok(AgentDetail {
+        persona_category: format!("{:?}", profile.persona.category).to_lowercase(),
+        persona_description: profile.persona.description,
+        persona_tone: profile.persona.traits.tone,
+        persona_risk: profile.persona.traits.risk,
+        persona_verbosity: profile.persona.traits.verbosity,
+        style_preset: profile.appearance.style_preset,
+        render_status: match profile.appearance.render_status {
+            mur_common::agent::RenderStatus::Pending => RenderStatusView::Pending,
+            mur_common::agent::RenderStatus::Rendering { done, total } => {
+                RenderStatusView::Rendering { done, total }
+            }
+            mur_common::agent::RenderStatus::Ready => RenderStatusView::Ready,
+            mur_common::agent::RenderStatus::Failed { reason } => {
+                RenderStatusView::Failed { reason }
+            }
+        },
+        behavior_preset: format!("{:?}", profile.appearance.behavior_preset).to_lowercase(),
+        skills: profile
+            .skills
+            .into_iter()
+            .map(|path| SkillView { path })
+            .collect(),
+        installed_skills: profile
+            .installed_skills
+            .into_iter()
+            .map(|s| InstalledSkillView {
+                name: s.name,
+                version: s.version,
+                description: s.description,
+                category: s.category,
+            })
+            .collect(),
+        mcp_servers: profile
+            .mcp_servers
+            .into_iter()
+            .map(|m| McpServerView {
+                name: m.name,
+                command: m.command,
+                args: m.args,
+            })
+            .collect(),
+        capabilities: profile.capabilities,
+        display_name: profile.display_name,
+        agent_name: profile.name,
+    })
+}
+```
+
+- [ ] 1.2 Build verification: `cargo check --manifest-path mur-hub-gui/src-tauri/Cargo.toml`
+
+---
+
+## Task 2: Rust backend — `update_agent_detail` command
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/detail.rs`
+
+- [ ] 2.1 Add `update_agent_detail` command to `detail.rs`
+
+```rust
+#[tauri::command]
+pub fn update_agent_detail(name: String, patch: DetailPatch) -> Result<AgentDetail, String> {
+    let mur_home = crate::mur_home_path();
+    let profile_path = mur_home.join("agents").join(&name).join("profile.yaml");
+    let bytes = std::fs::read(&profile_path).map_err(|e| format!("read profile: {e}"))?;
+    let mut profile: mur_common::AgentProfile =
+        serde_yaml_ng::from_slice(&bytes).map_err(|e| format!("parse profile: {e}"))?;
+
+    // Apply persona patches
+    if let Some(cat) = patch.persona_category {
+        profile.persona.category = match cat.as_str() {
+            "research" => mur_common::agent::PersonaCategory::Research,
+            "automation" => mur_common::agent::PersonaCategory::Automation,
+            "monitor" => mur_common::agent::PersonaCategory::Monitor,
+            "notify" => mur_common::agent::PersonaCategory::Notify,
+            "commerce" => mur_common::agent::PersonaCategory::Commerce,
+            _ => mur_common::agent::PersonaCategory::Custom,
+        };
+    }
+    if let Some(d) = patch.persona_description { profile.persona.description = d; }
+    if let Some(t) = patch.persona_tone { profile.persona.traits.tone = t; }
+    if let Some(r) = patch.persona_risk { profile.persona.traits.risk = r; }
+    if let Some(v) = patch.persona_verbosity { profile.persona.traits.verbosity = v; }
+
+    // Apply style patch
+    if let Some(s) = patch.style_preset {
+        profile.appearance.style_preset = s;
+    }
+
+    // Apply behavior patch
+    if let Some(b) = patch.behavior_preset {
+        profile.appearance.behavior_preset = match b.as_str() {
+            "quiet" => mur_common::agent::BehaviorPreset::Quiet,
+            "lively" => mur_common::agent::BehaviorPreset::Lively,
+            _ => mur_common::agent::BehaviorPreset::Normal,
+        };
+    }
+
+    profile.updated_at = chrono::Utc::now().to_rfc3339();
+    let yaml = serde_yaml_ng::to_string(&profile).map_err(|e| format!("serialize: {e}"))?;
+    std::fs::write(&profile_path, yaml).map_err(|e| format!("write profile: {e}"))?;
+
+    // Return fresh detail after update
+    get_agent_detail(name)
+}
+```
+
+- [ ] 2.2 Build verification
+
+---
+
+## Task 3: Register new commands in lib.rs
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/lib.rs`
+
+- [ ] 3.1 Add `pub mod detail;` and commands to handler
+
+In `lib.rs`:
+- Add `pub mod detail;` near other `pub mod` lines
+- Add `detail::get_agent_detail,` and `detail::update_agent_detail,` to `generate_handler![]`
+
+- [ ] 3.2 Build verification: `cargo build -p mur-hub-gui 2>&1`
+
+---
+
+## Task 4: TypeScript types
+
+**Files:**
+- Modify: `mur-hub-gui/ui/src/types.ts`
+
+- [ ] 4.1 Add AgentDetail, DetailPatch, and tab-related types
+
+```typescript
+export interface SkillView { path: string }
+export interface InstalledSkillView {
+  name: string;
+  version: string;
+  description: string;
+  category: string;
+}
+export interface McpServerView {
+  name: string;
+  command: string;
+  args: string[];
+}
+export type RenderStatusView =
+  | { status: "pending" }
+  | { status: "rendering"; done: number; total: number }
+  | { status: "ready" }
+  | { status: "failed"; reason: string };
+
+export interface AgentDetail {
+  persona_category: string;
+  persona_description: string;
+  persona_tone: string;
+  persona_risk: string;
+  persona_verbosity: string;
+  style_preset: string;
+  render_status: RenderStatusView;
+  behavior_preset: string;
+  skills: SkillView[];
+  installed_skills: InstalledSkillView[];
+  mcp_servers: McpServerView[];
+  capabilities: string[];
+  display_name: string;
+  agent_name: string;
+}
+
+export interface DetailPatch {
+  persona_category?: string;
+  persona_description?: string;
+  persona_tone?: string;
+  persona_risk?: string;
+  persona_verbosity?: string;
+  style_preset?: string;
+  behavior_preset?: string;
+}
+
+export type DetailTab = "persona" | "style" | "behavior" | "skills" | "mcp" | "permissions" | "inbox";
+export const ALL_DETAIL_TABS: DetailTab[] = [
+  "persona", "style", "behavior", "skills", "mcp", "permissions", "inbox"
+];
+```
+
+---
+
+## Task 5: DetailPanel React component
+
+**Files:**
+- Create: `mur-hub-gui/ui/src/components/DetailPanel.tsx`
+
+- [ ] 5.1 Create the main DetailPanel with tab routing
+
+Component structure:
+- Receives `agentName` prop
+- On mount/agentName change: calls `invoke<AgentDetail>("get_agent_detail", { name: agentName })`
+- Tab bar: Persona | Style | Behavior | Skills | MCP | Permissions | Inbox
+- Active tab state, renders corresponding sub-component
+- Close button calls `onClose()`
+
+- [ ] 5.2 PersonaTab
+  - Editable fields: category (dropdown), description (textarea), tone, risk, verbosity (text inputs)
+  - Save button calls `update_agent_detail`
+
+- [ ] 5.3 StyleTab
+  - Show current preset name + family
+  - Preset gallery (BUILTIN_PRESETS grid, clickable to select)
+  - Render status display (Pending/Rendering progress bar/Ready thumbnail/Failed error)
+  - "Re-render" button if Ready or Failed
+
+- [ ] 5.4 BehaviorTab
+  - Radio buttons: Quiet / Normal / Lively
+  - Description of each mode
+  - Auto-save on selection
+
+- [ ] 5.5 SkillsTab
+  - List installed_skills with name, version, description, category
+  - List legacy skills paths
+  - (Add/remove deferred to v2)
+
+- [ ] 5.6 McpTab
+  - List MCP servers with name, command, args
+  - (Add/remove deferred to v2)
+
+- [ ] 5.7 PermissionsTab
+  - List capabilities as tags/badges
+  - Show entitlements (filesystem paths, network domains, processes)
+  - (Edit deferred to v2 — read-only in v1)
+
+- [ ] 5.8 InboxTab — reuse existing CompanionInbox component
+
+---
+
+## Task 6: Wire DetailPanel into DashboardApp
+
+**Files:**
+- Modify: `mur-hub-gui/ui/src/components/DashboardApp.tsx`
+
+- [ ] 6.1 Replace the inline detail panel with DetailPanel component
+  - Import DetailPanel
+  - Replace lines 526-548 (the `<aside className="detail-panel">...</aside>` block) with `<DetailPanel agentName={selectedAgent} onClose={() => setSelected(null)} agents={agents} />`
+
+---
+
+## Task 7: CSS — `.input` class + detail panel styles
+
+**Files:**
+- Modify: `mur-hub-gui/ui/src/styles.css`
+
+- [ ] 7.1 Add `.input` class
+```css
+.input {
+  padding: 6px 10px;
+  border: 1px solid var(--border, #333);
+  border-radius: 6px;
+  background: var(--bg-input, #1a1a1a);
+  color: var(--text-primary, #e0e0e0);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.input:focus {
+  border-color: var(--accent, #4F46E5);
+}
+```
+
+- [ ] 7.2 Add `.detail-panel*` classes
+```css
+.detail-panel {
+  width: 320px;
+  min-width: 320px;
+  border-left: 1px solid var(--border, #2a2a2a);
+  background: var(--bg-panel, #111);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.detail-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border, #2a2a2a);
+}
+.detail-panel-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary, #e0e0e0);
+}
+.detail-panel-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary, #888);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.detail-panel-close:hover {
+  background: var(--bg-hover, #1a1a1a);
+  color: var(--text-primary, #e0e0e0);
+}
+.detail-panel-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border, #2a2a2a);
+  overflow-x: auto;
+  padding: 0 4px;
+}
+.detail-tab {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--text-secondary, #888);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  user-select: none;
+}
+.detail-tab:hover {
+  color: var(--text-primary, #e0e0e0);
+}
+.detail-tab--active {
+  color: var(--accent, #4F46E5);
+  border-bottom-color: var(--accent, #4F46E5);
+}
+.detail-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+```
+
+- [ ] 7.3 Add tab-specific CSS (form fields, preset gallery, etc.)
+
+---
+
+## Self-Review
+
+1. All 6 missing tabs covered: Persona, Style, Behavior, Skills, MCP, Permissions + existing Inbox = 7 total ✓
+2. Rust backend: read + partial write via single `DetailPatch` struct ✓
+3. Frontend: single `DetailPanel` component with tab routing ✓
+4. CSS: `.input` fix + detail-panel family + tab-specific styles ✓
+5. Builds on existing Plan 1/1b/2 without modifying them ✓

--- a/mur-hub-gui/src-tauri/Cargo.toml
+++ b/mur-hub-gui/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ serde_json = "1"
 serde_yaml_ng = "0.10"
 base64 = "0.22"
 anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 dirs = "5"
 reqwest = { version = "0.12", features = ["blocking"] }

--- a/mur-hub-gui/src-tauri/src/companion.rs
+++ b/mur-hub-gui/src-tauri/src/companion.rs
@@ -42,11 +42,28 @@ fn agent_inbox(agent: &str) -> PathBuf {
         .join("companion/inbox")
 }
 
+/// Reject agent names that aren't safe as a path component before they're
+/// joined under `~/.mur/agents/`. Uses the canonical agent-name rules so the
+/// GUI and CLI/HTTP surfaces agree.
+fn check_agent(agent: &str) -> Result<(), String> {
+    mur_common::agent_name::validate_agent_name(agent).map_err(|e| format!("invalid agent name: {e}"))
+}
+
+/// Lightweight traversal check for an opaque id used as a filename component
+/// (lenient on charset so real message ids still pass, strict on separators).
+fn check_path_component(s: &str, what: &str) -> Result<(), String> {
+    if s.is_empty() || s.contains('/') || s.contains('\\') || s.contains("..") || s.contains('\0') {
+        return Err(format!("invalid {what}"));
+    }
+    Ok(())
+}
+
 // ─── Tauri commands ──────────────────────────────────────────────────────────
 
 /// Return all pending (unresponded) inbox messages for `agent`.
 #[tauri::command]
 pub fn companion_bridge_pending(agent: String) -> Result<Vec<BridgeEvent>, String> {
+    check_agent(&agent)?;
     scan_pending(&agent_inbox(&agent)).map_err(|e| format!("{e:#}"))
 }
 
@@ -58,6 +75,7 @@ pub async fn companion_bridge_subscribe(
     on_event: Channel<BridgeEvent>,
     state: tauri::State<'_, BridgeState>,
 ) -> Result<(), String> {
+    check_agent(&agent)?;
     let (tx, mut rx) = mpsc::channel::<BridgeEvent>(32);
     let watcher = InboxWatcher::start(agent_inbox(&agent), tx).map_err(|e| format!("{e:#}"))?;
 
@@ -84,6 +102,7 @@ pub fn companion_bridge_unsubscribe(
     agent: String,
     state: tauri::State<'_, BridgeState>,
 ) -> Result<(), String> {
+    check_agent(&agent)?;
     state
         .watchers
         .lock()
@@ -95,6 +114,8 @@ pub fn companion_bridge_unsubscribe(
 /// Acknowledge a message (rewrite `>>> response: <unset>` → `>>> response: <signal>`).
 #[tauri::command]
 pub fn companion_ack(agent: String, msg_id: String, signal: String) -> Result<(), String> {
+    check_agent(&agent)?;
+    check_path_component(&msg_id, "msg_id")?;
     if !matches!(signal.as_str(), "good" | "bad" | "dismiss" | "snooze") {
         return Err(format!("unknown signal `{signal}`"));
     }
@@ -115,6 +136,9 @@ pub fn companion_ack(agent: String, msg_id: String, signal: String) -> Result<()
 /// Count unread (BridgeResponse::Unset) messages for `agent`.
 #[tauri::command]
 pub fn companion_unread_count(agent: String) -> u32 {
+    if check_agent(&agent).is_err() {
+        return 0;
+    }
     scan_pending(&agent_inbox(&agent))
         .map(|evs| {
             evs.iter()

--- a/mur-hub-gui/src-tauri/src/companion.rs
+++ b/mur-hub-gui/src-tauri/src/companion.rs
@@ -46,7 +46,8 @@ fn agent_inbox(agent: &str) -> PathBuf {
 /// joined under `~/.mur/agents/`. Uses the canonical agent-name rules so the
 /// GUI and CLI/HTTP surfaces agree.
 fn check_agent(agent: &str) -> Result<(), String> {
-    mur_common::agent_name::validate_agent_name(agent).map_err(|e| format!("invalid agent name: {e}"))
+    mur_common::agent_name::validate_agent_name(agent)
+        .map_err(|e| format!("invalid agent name: {e}"))
 }
 
 /// Lightweight traversal check for an opaque id used as a filename component

--- a/mur-hub-gui/src-tauri/src/detail.rs
+++ b/mur-hub-gui/src-tauri/src/detail.rs
@@ -1,0 +1,192 @@
+//! Agent detail panel — full-profile read + partial write for the Hub's
+//! right-side slide-in panel (Persona / Style / Behavior / Skills / MCP /
+//! Permissions / Inbox tabs).
+
+use serde::{Deserialize, Serialize};
+
+/// All detail-panel tab data extracted from one AgentProfile.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentDetail {
+    // Persona tab
+    pub persona_category: String,
+    pub persona_description: String,
+    pub persona_tone: String,
+    pub persona_risk: String,
+    pub persona_verbosity: String,
+    // Style tab
+    pub style_preset: String,
+    pub render_status: RenderStatusView,
+    // Behavior tab
+    pub behavior_preset: String,
+    // Skills tab
+    pub skills: Vec<SkillView>,
+    pub installed_skills: Vec<InstalledSkillView>,
+    // MCP tab
+    pub mcp_servers: Vec<McpServerView>,
+    // Permissions tab
+    pub capabilities: Vec<String>,
+    // Read-only metadata
+    pub display_name: String,
+    pub agent_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum RenderStatusView {
+    Pending,
+    Rendering { done: u8, total: u8 },
+    Ready,
+    Failed { reason: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillView {
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstalledSkillView {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub category: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServerView {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+}
+
+/// Partial update to an agent's profile. All fields optional — only set
+/// fields are applied.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DetailPatch {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona_category: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona_description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona_tone: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona_risk: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub persona_verbosity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style_preset: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub behavior_preset: Option<String>,
+}
+
+#[tauri::command]
+pub fn get_agent_detail(name: String) -> Result<AgentDetail, String> {
+    let mur_home = crate::mur_home_path();
+    let profile_path = mur_home.join("agents").join(&name).join("profile.yaml");
+    let bytes =
+        std::fs::read(&profile_path).map_err(|e| format!("read profile: {e}"))?;
+    let profile: mur_common::AgentProfile =
+        serde_yaml_ng::from_slice(&bytes).map_err(|e| format!("parse profile: {e}"))?;
+
+    Ok(AgentDetail {
+        persona_category: format!("{:?}", profile.persona.category).to_lowercase(),
+        persona_description: profile.persona.description,
+        persona_tone: profile.persona.traits.tone,
+        persona_risk: profile.persona.traits.risk,
+        persona_verbosity: profile.persona.traits.verbosity,
+        style_preset: profile.appearance.style_preset,
+        render_status: match profile.appearance.render_status {
+            mur_common::agent::RenderStatus::Pending => RenderStatusView::Pending,
+            mur_common::agent::RenderStatus::Rendering { done, total } => {
+                RenderStatusView::Rendering { done, total }
+            }
+            mur_common::agent::RenderStatus::Ready => RenderStatusView::Ready,
+            mur_common::agent::RenderStatus::Failed { reason } => {
+                RenderStatusView::Failed { reason }
+            }
+        },
+        behavior_preset: format!("{:?}", profile.appearance.behavior_preset).to_lowercase(),
+        skills: profile
+            .skills
+            .into_iter()
+            .map(|path| SkillView { path })
+            .collect(),
+        installed_skills: profile
+            .installed_skills
+            .into_iter()
+            .map(|s| InstalledSkillView {
+                name: s.name,
+                version: s.version,
+                description: s.description,
+                category: s.category,
+            })
+            .collect(),
+        mcp_servers: profile
+            .mcp_servers
+            .into_iter()
+            .map(|m| McpServerView {
+                name: m.name,
+                command: m.command,
+                args: m.args,
+            })
+            .collect(),
+        capabilities: profile.capabilities,
+        display_name: profile.display_name,
+        agent_name: profile.name,
+    })
+}
+
+#[tauri::command]
+pub fn update_agent_detail(name: String, patch: DetailPatch) -> Result<AgentDetail, String> {
+    let mur_home = crate::mur_home_path();
+    let profile_path = mur_home.join("agents").join(&name).join("profile.yaml");
+    let bytes =
+        std::fs::read(&profile_path).map_err(|e| format!("read profile: {e}"))?;
+    let mut profile: mur_common::AgentProfile =
+        serde_yaml_ng::from_slice(&bytes).map_err(|e| format!("parse profile: {e}"))?;
+
+    // Apply persona patches
+    if let Some(cat) = patch.persona_category {
+        profile.persona.category = match cat.as_str() {
+            "research" => mur_common::agent::PersonaCategory::Research,
+            "automation" => mur_common::agent::PersonaCategory::Automation,
+            "monitor" => mur_common::agent::PersonaCategory::Monitor,
+            "notify" => mur_common::agent::PersonaCategory::Notify,
+            "commerce" => mur_common::agent::PersonaCategory::Commerce,
+            _ => mur_common::agent::PersonaCategory::Custom,
+        };
+    }
+    if let Some(d) = patch.persona_description {
+        profile.persona.description = d;
+    }
+    if let Some(t) = patch.persona_tone {
+        profile.persona.traits.tone = t;
+    }
+    if let Some(r) = patch.persona_risk {
+        profile.persona.traits.risk = r;
+    }
+    if let Some(v) = patch.persona_verbosity {
+        profile.persona.traits.verbosity = v;
+    }
+
+    // Apply style patch
+    if let Some(s) = patch.style_preset {
+        profile.appearance.style_preset = s;
+    }
+
+    // Apply behavior patch
+    if let Some(b) = patch.behavior_preset {
+        profile.appearance.behavior_preset = match b.as_str() {
+            "quiet" => mur_common::agent::BehaviorPreset::Quiet,
+            "lively" => mur_common::agent::BehaviorPreset::Lively,
+            _ => mur_common::agent::BehaviorPreset::Normal,
+        };
+    }
+
+    profile.updated_at = chrono::Utc::now().to_rfc3339();
+    let yaml = serde_yaml_ng::to_string(&profile).map_err(|e| format!("serialize: {e}"))?;
+    std::fs::write(&profile_path, yaml).map_err(|e| format!("write profile: {e}"))?;
+
+    // Return fresh detail after update
+    get_agent_detail(name)
+}

--- a/mur-hub-gui/src-tauri/src/detail.rs
+++ b/mur-hub-gui/src-tauri/src/detail.rs
@@ -83,8 +83,7 @@ pub struct DetailPatch {
 pub fn get_agent_detail(name: String) -> Result<AgentDetail, String> {
     let mur_home = crate::mur_home_path();
     let profile_path = mur_home.join("agents").join(&name).join("profile.yaml");
-    let bytes =
-        std::fs::read(&profile_path).map_err(|e| format!("read profile: {e}"))?;
+    let bytes = std::fs::read(&profile_path).map_err(|e| format!("read profile: {e}"))?;
     let profile: mur_common::AgentProfile =
         serde_yaml_ng::from_slice(&bytes).map_err(|e| format!("parse profile: {e}"))?;
 
@@ -140,8 +139,7 @@ pub fn get_agent_detail(name: String) -> Result<AgentDetail, String> {
 pub fn update_agent_detail(name: String, patch: DetailPatch) -> Result<AgentDetail, String> {
     let mur_home = crate::mur_home_path();
     let profile_path = mur_home.join("agents").join(&name).join("profile.yaml");
-    let bytes =
-        std::fs::read(&profile_path).map_err(|e| format!("read profile: {e}"))?;
+    let bytes = std::fs::read(&profile_path).map_err(|e| format!("read profile: {e}"))?;
     let mut profile: mur_common::AgentProfile =
         serde_yaml_ng::from_slice(&bytes).map_err(|e| format!("parse profile: {e}"))?;
 

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod brain_badge;
 pub mod cli_tools;
 pub mod companion;
+pub mod detail;
 pub mod export_muragent;
 pub mod import_muragent;
 pub mod mlx_sidecar;
@@ -396,6 +397,8 @@ pub fn run() {
             cli_tools::install_cli_tools,
             brain_badge::nudge_status,
             brain_badge::nudge_dismiss,
+            detail::get_agent_detail,
+            detail::update_agent_detail,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/mur-hub-gui/src-tauri/src/onboarding/mod.rs
+++ b/mur-hub-gui/src-tauri/src/onboarding/mod.rs
@@ -155,6 +155,10 @@ pub fn wizard_set_name(
     if name.trim().is_empty() {
         return Err("name must not be empty".into());
     }
+    // The name later becomes an agent directory component (wizard_start_render
+    // / wizard_finish); validate it here at the single entry point.
+    mur_common::agent_name::validate_agent_name(name.trim())
+        .map_err(|e| format!("invalid name: {e}"))?;
     update_session(&state, |s| {
         s.name = Some(name.trim().to_string());
         s.description = Some(description.trim().to_string());

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -48,12 +48,24 @@ fn pet_position_path(agent_name: &str) -> PathBuf {
         .join("pet_position.json")
 }
 
+/// True if `agent_name` is safe to use as a path component under
+/// `~/.mur/agents/` (canonical agent-name rules).
+fn valid_agent(agent_name: &str) -> bool {
+    mur_common::agent_name::validate_agent_name(agent_name).is_ok()
+}
+
 fn load_position(agent_name: &str) -> Option<PetPosition> {
+    if !valid_agent(agent_name) {
+        return None;
+    }
     let data = std::fs::read_to_string(pet_position_path(agent_name)).ok()?;
     serde_json::from_str(&data).ok()
 }
 
 fn save_position(agent_name: &str, pos: &PetPosition) {
+    if !valid_agent(agent_name) {
+        return;
+    }
     let path = pet_position_path(agent_name);
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -254,6 +266,17 @@ pub fn pet_list(state: State<'_, PetState>) -> Vec<String> {
 
 #[tauri::command]
 pub fn pet_get_expression(agent_name: String, expression: String) -> String {
+    // Both segments become path components; reject traversal so a malicious
+    // IPC caller can't read arbitrary files (the bytes are returned to the UI).
+    if !valid_agent(&agent_name)
+        || expression.is_empty()
+        || expression.contains('/')
+        || expression.contains('\\')
+        || expression.contains("..")
+        || expression.contains('\0')
+    {
+        return String::new();
+    }
     let path = mur_home()
         .join("agents")
         .join(&agent_name)

--- a/mur-hub-gui/src-tauri/src/preset.rs
+++ b/mur-hub-gui/src-tauri/src/preset.rs
@@ -53,7 +53,11 @@ pub fn import_preset_file(path: String) -> Result<String, String> {
 pub fn import_preset_url(url: String) -> Result<String, String> {
     // Require HTTPS: rejects cleartext and file:// / other schemes, keeping the
     // fetch surface to TLS endpoints only.
-    if !url.trim_start().to_ascii_lowercase().starts_with("https://") {
+    if !url
+        .trim_start()
+        .to_ascii_lowercase()
+        .starts_with("https://")
+    {
         return Err("preset URL must use https".into());
     }
     let client = reqwest::blocking::Client::builder()

--- a/mur-hub-gui/src-tauri/src/preset.rs
+++ b/mur-hub-gui/src-tauri/src/preset.rs
@@ -9,6 +9,12 @@ use std::path::PathBuf;
 
 use mur_common::hub::style_preset::StylePreset;
 
+/// Presets are tiny YAML documents; cap remote fetches well above any real
+/// preset to bound memory from a hostile/oversized URL.
+const MAX_PRESET_BYTES: u64 = 1024 * 1024; // 1 MiB
+/// Bound a remote preset fetch so a slow/hung server can't block the IPC thread.
+const PRESET_FETCH_TIMEOUT_SECS: u64 = 15;
+
 fn presets_dir() -> PathBuf {
     std::env::var("MUR_HOME")
         .map(PathBuf::from)
@@ -19,6 +25,12 @@ fn presets_dir() -> PathBuf {
 fn install_preset(yaml: &str) -> Result<String, String> {
     let preset: StylePreset =
         serde_yaml_ng::from_str(yaml).map_err(|e| format!("invalid preset YAML: {e}"))?;
+
+    // The id becomes a path component (`<id>.yaml`); validate it with the
+    // canonical safe-name rules so a crafted preset (e.g. fetched from an
+    // arbitrary URL) can't escape presets_dir via `..` / absolute / separators.
+    mur_common::agent_name::validate_agent_name(&preset.id)
+        .map_err(|e| format!("invalid preset id: {e}"))?;
 
     let dir = presets_dir();
     fs::create_dir_all(&dir).map_err(|e| format!("create presets dir: {e}"))?;
@@ -39,9 +51,29 @@ pub fn import_preset_file(path: String) -> Result<String, String> {
 /// Import a StylePreset YAML from a URL (synchronous fetch via reqwest blocking).
 #[tauri::command]
 pub fn import_preset_url(url: String) -> Result<String, String> {
-    let yaml = reqwest::blocking::get(&url)
-        .map_err(|e| format!("fetch {url}: {e}"))?
-        .text()
+    // Require HTTPS: rejects cleartext and file:// / other schemes, keeping the
+    // fetch surface to TLS endpoints only.
+    if !url.trim_start().to_ascii_lowercase().starts_with("https://") {
+        return Err("preset URL must use https".into());
+    }
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(PRESET_FETCH_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| format!("http client: {e}"))?;
+    let resp = client
+        .get(&url)
+        .send()
+        .map_err(|e| format!("fetch {url}: {e}"))?;
+
+    // Bound the body so a hostile URL can't exhaust memory.
+    use std::io::Read;
+    let mut buf = Vec::new();
+    resp.take(MAX_PRESET_BYTES + 1)
+        .read_to_end(&mut buf)
         .map_err(|e| format!("read body: {e}"))?;
+    if buf.len() as u64 > MAX_PRESET_BYTES {
+        return Err(format!("preset exceeds {MAX_PRESET_BYTES} bytes"));
+    }
+    let yaml = String::from_utf8(buf).map_err(|e| format!("preset body not UTF-8: {e}"))?;
     install_preset(&yaml)
 }

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -7,7 +7,8 @@ import type { AgentEntry, AgentRuntimeStatus, RuntimeState } from "../types";
 import { WizardModal } from "./wizard/WizardModal";
 import { PresetImportModal } from "./PresetImportModal";
 import { MuragentImportModal } from "./MuragentImportModal";
-import { CompanionInbox, useUnreadCount } from "./CompanionInbox";
+import { useUnreadCount } from "./CompanionInbox";
+import { DetailPanel } from "./DetailPanel";
 
 // ─── Shared helpers ────────────────────────────────────────────────────────
 
@@ -523,28 +524,13 @@ export function DashboardApp() {
         </div>
       </div>
 
-      {/* Companion Inbox detail panel — slides in when an agent is selected */}
+      {/* Detail panel — slides in when an agent is selected */}
       {selectedAgent && (
-        <aside className="detail-panel">
-          <div className="detail-panel-header">
-            <span className="detail-panel-title">
-              {agents.find((a) => a.name === selectedAgent)?.display_name ?? selectedAgent}
-            </span>
-            <button
-              className="detail-panel-close"
-              onClick={() => setSelected(null)}
-              title="Close"
-            >
-              ×
-            </button>
-          </div>
-          <div className="detail-panel-tabs">
-            <span className="detail-tab detail-tab--active">Inbox</span>
-          </div>
-          <div className="detail-panel-body">
-            <CompanionInbox agentName={selectedAgent} />
-          </div>
-        </aside>
+        <DetailPanel
+          agentName={selectedAgent}
+          agents={agents}
+          onClose={() => setSelected(null)}
+        />
       )}
 
       <WizardModal

--- a/mur-hub-gui/ui/src/components/DetailPanel.tsx
+++ b/mur-hub-gui/ui/src/components/DetailPanel.tsx
@@ -1,0 +1,512 @@
+//! Detail panel — right-side slide-in when an agent is selected in the
+//! dashboard. Provides 7 tabs: Persona, Style, Behavior, Skills, MCP,
+//! Permissions, Inbox.
+
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { AgentEntry } from "../types";
+import {
+  ALL_DETAIL_TABS,
+  BUILTIN_PRESETS,
+  TAB_LABELS,
+  type AgentDetail,
+  type DetailPatch,
+  type DetailTab,
+} from "../types";
+import { CompanionInbox } from "./CompanionInbox";
+
+interface Props {
+  agentName: string;
+  agents: AgentEntry[];
+  onClose: () => void;
+}
+
+export function DetailPanel({ agentName, agents, onClose }: Props) {
+  const [detail, setDetail] = useState<AgentDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<DetailTab>("inbox");
+
+  useEffect(() => {
+    setError(null);
+    setActiveTab("inbox");
+    invoke<AgentDetail>("get_agent_detail", { name: agentName })
+      .then(setDetail)
+      .catch((e) => setError(String(e)));
+  }, [agentName]);
+
+  const displayName =
+    agents.find((a) => a.name === agentName)?.display_name ?? agentName;
+
+  function handleSaved(updated: AgentDetail) {
+    setDetail(updated);
+  }
+
+  if (error) {
+    return (
+      <aside className="detail-panel">
+        <div className="detail-panel-header">
+          <span className="detail-panel-title">{displayName}</span>
+          <button className="detail-panel-close" onClick={onClose}>×</button>
+        </div>
+        <div className="detail-panel-body">
+          <p className="detail-error">Failed to load: {error}</p>
+        </div>
+      </aside>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <aside className="detail-panel">
+        <div className="detail-panel-header">
+          <span className="detail-panel-title">{displayName}</span>
+          <button className="detail-panel-close" onClick={onClose}>×</button>
+        </div>
+        <div className="detail-panel-body">
+          <p className="detail-loading">Loading…</p>
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="detail-panel">
+      <div className="detail-panel-header">
+        <span className="detail-panel-title">{detail.display_name}</span>
+        <button className="detail-panel-close" onClick={onClose} title="Close">×</button>
+      </div>
+      <div className="detail-panel-tabs">
+        {ALL_DETAIL_TABS.map((tab) => (
+          <span
+            key={tab}
+            className={`detail-tab${activeTab === tab ? " detail-tab--active" : ""}`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {TAB_LABELS[tab]}
+          </span>
+        ))}
+      </div>
+      <div className="detail-panel-body">
+        {activeTab === "persona" && (
+          <PersonaTab detail={detail} onSaved={handleSaved} />
+        )}
+        {activeTab === "style" && (
+          <StyleTab detail={detail} onSaved={handleSaved} />
+        )}
+        {activeTab === "behavior" && (
+          <BehaviorTab detail={detail} onSaved={handleSaved} />
+        )}
+        {activeTab === "skills" && <SkillsTab detail={detail} />}
+        {activeTab === "mcp" && <McpTab detail={detail} />}
+        {activeTab === "permissions" && <PermissionsTab detail={detail} />}
+        {activeTab === "inbox" && <CompanionInbox agentName={agentName} />}
+      </div>
+    </aside>
+  );
+}
+
+// ─── Persona Tab ──────────────────────────────────────────────────────────────
+
+const PERSONA_CATEGORIES = [
+  "research", "automation", "monitor", "notify", "commerce", "custom",
+];
+
+const TONE_OPTIONS = ["professional", "casual", "friendly", "direct", "playful", "formal"];
+const RISK_OPTIONS = ["conservative", "balanced", "bold"];
+const VERBOSITY_OPTIONS = ["concise", "balanced", "detailed"];
+
+function PersonaTab({
+  detail,
+  onSaved,
+}: {
+  detail: AgentDetail;
+  onSaved: (d: AgentDetail) => void;
+}) {
+  const [category, setCategory] = useState(detail.persona_category);
+  const [description, setDescription] = useState(detail.persona_description);
+  const [tone, setTone] = useState(detail.persona_tone);
+  const [risk, setRisk] = useState(detail.persona_risk);
+  const [verbosity, setVerbosity] = useState(detail.persona_verbosity);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  async function save() {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const patch: DetailPatch = {
+        persona_category: category,
+        persona_description: description,
+        persona_tone: tone,
+        persona_risk: risk,
+        persona_verbosity: verbosity,
+      };
+      const updated = await invoke<AgentDetail>("update_agent_detail", {
+        name: detail.agent_name,
+        patch,
+      });
+      onSaved(updated);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (e) {
+      setSaveError(String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const changed =
+    category !== detail.persona_category ||
+    description !== detail.persona_description ||
+    tone !== detail.persona_tone ||
+    risk !== detail.persona_risk ||
+    verbosity !== detail.persona_verbosity;
+
+  return (
+    <div className="tab-form">
+      <label className="field-label">Category</label>
+      <select
+        className="input"
+        value={category}
+        onChange={(e) => { setCategory(e.target.value); }}
+      >
+        {PERSONA_CATEGORIES.map((c) => (
+          <option key={c} value={c}>{c}</option>
+        ))}
+      </select>
+
+      <label className="field-label">Description</label>
+      <textarea
+        className="input"
+        rows={3}
+        value={description}
+        onChange={(e) => { setDescription(e.target.value); }}
+        placeholder="What this agent does…"
+      />
+
+      <label className="field-label">Tone</label>
+      <select
+        className="input"
+        value={tone}
+        onChange={(e) => { setTone(e.target.value); }}
+      >
+        {TONE_OPTIONS.map((t) => (
+          <option key={t} value={t}>{t}</option>
+        ))}
+      </select>
+
+      <label className="field-label">Risk tolerance</label>
+      <select
+        className="input"
+        value={risk}
+        onChange={(e) => { setRisk(e.target.value); }}
+      >
+        {RISK_OPTIONS.map((r) => (
+          <option key={r} value={r}>{r}</option>
+        ))}
+      </select>
+
+      <label className="field-label">Verbosity</label>
+      <select
+        className="input"
+        value={verbosity}
+        onChange={(e) => { setVerbosity(e.target.value); }}
+      >
+        {VERBOSITY_OPTIONS.map((v) => (
+          <option key={v} value={v}>{v}</option>
+        ))}
+      </select>
+
+      <button
+        className="toolbar-btn primary save-btn"
+        disabled={!changed || saving}
+        onClick={save}
+      >
+        {saving ? "Saving…" : saved ? "✓ Saved" : "Save Changes"}
+      </button>
+      {saveError && <p className="save-error">{saveError}</p>}
+    </div>
+  );
+}
+
+// ─── Style Tab ────────────────────────────────────────────────────────────────
+
+function StyleTab({
+  detail,
+  onSaved,
+}: {
+  detail: AgentDetail;
+  onSaved: (d: AgentDetail) => void;
+}) {
+  const [selected, setSelected] = useState(detail.style_preset);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  async function pickPreset(id: string) {
+    setSelected(id);
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const updated = await invoke<AgentDetail>("update_agent_detail", {
+        name: detail.agent_name,
+        patch: { style_preset: id } as DetailPatch,
+      });
+      onSaved(updated);
+    } catch (e) {
+      setSaveError(String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function statusText(): string {
+    switch (detail.render_status.status) {
+      case "pending": return "Not rendered yet";
+      case "rendering": return `Rendering: ${detail.render_status.done}/${detail.render_status.total}`;
+      case "ready": return "Ready ✓";
+      case "failed": return `Failed: ${detail.render_status.reason}`;
+    }
+  }
+
+  return (
+    <div className="tab-form">
+      <label className="field-label">Current style</label>
+      <p className="field-value">
+        {BUILTIN_PRESETS.find((p) => p.id === selected)?.display_name ?? selected}
+        {" "}
+        <span className="field-muted">
+          ({BUILTIN_PRESETS.find((p) => p.id === selected)?.family ?? "unknown"})
+        </span>
+      </p>
+
+      <label className="field-label">Render status</label>
+      <p className="field-muted" style={{ fontSize: 12 }}>{statusText()}</p>
+      {detail.render_status.status === "rendering" && (
+        <div className="progress-bar" style={{ marginTop: 6 }}>
+          <div
+            className="progress-fill"
+            style={{
+              width: `${(detail.render_status.done / detail.render_status.total) * 100}%`,
+            }}
+          />
+        </div>
+      )}
+
+      <label className="field-label" style={{ marginTop: 16 }}>Preset gallery</label>
+      <div className="preset-gallery">
+        {BUILTIN_PRESETS.map((p) => (
+          <button
+            key={p.id}
+            className={`preset-card${selected === p.id ? " preset-card--active" : ""}`}
+            onClick={() => pickPreset(p.id)}
+            disabled={saving}
+            title={p.description}
+          >
+            <div className="preset-card-label">{p.display_name}</div>
+            <div className="preset-card-family">{p.family}</div>
+          </button>
+        ))}
+      </div>
+      {saveError && <p className="save-error">{saveError}</p>}
+    </div>
+  );
+}
+
+// ─── Behavior Tab ─────────────────────────────────────────────────────────────
+
+const BEHAVIOR_OPTIONS: { id: string; label: string; desc: string }[] = [
+  { id: "quiet", label: "Quiet", desc: "Only speaks when spoken to. No proactive messages." },
+  { id: "normal", label: "Normal", desc: "Sends notifications for important events. Balanced." },
+  { id: "lively", label: "Lively", desc: "Proactive suggestions, pet animations, chatty." },
+];
+
+function BehaviorTab({
+  detail,
+  onSaved,
+}: {
+  detail: AgentDetail;
+  onSaved: (d: AgentDetail) => void;
+}) {
+  const [selected, setSelected] = useState(detail.behavior_preset);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  async function pick(b: string) {
+    setSelected(b);
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const updated = await invoke<AgentDetail>("update_agent_detail", {
+        name: detail.agent_name,
+        patch: { behavior_preset: b } as DetailPatch,
+      });
+      onSaved(updated);
+    } catch (e) {
+      setSaveError(String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="tab-form">
+      <p className="field-muted" style={{ marginBottom: 12, fontSize: 12 }}>
+        Controls how proactive the agent is — when it sends messages and how the pet behaves.
+      </p>
+      {BEHAVIOR_OPTIONS.map((opt) => (
+        <label
+          key={opt.id}
+          className={`radio-card${selected === opt.id ? " radio-card--active" : ""}${saving ? " radio-card--disabled" : ""}`}
+        >
+          <input
+            type="radio"
+            name="behavior"
+            value={opt.id}
+            checked={selected === opt.id}
+            onChange={() => pick(opt.id)}
+            disabled={saving}
+            style={{ display: "none" }}
+          />
+          <div className="radio-card-label">{opt.label}</div>
+          <div className="radio-card-desc">{opt.desc}</div>
+        </label>
+      ))}
+      {saving && <p className="field-muted" style={{ fontSize: 12 }}>Saving…</p>}
+      {saveError && <p className="save-error">{saveError}</p>}
+    </div>
+  );
+}
+
+// ─── Skills Tab ───────────────────────────────────────────────────────────────
+
+function SkillsTab({ detail }: { detail: AgentDetail }) {
+  const hasInstalled = detail.installed_skills.length > 0;
+  const hasLegacy = detail.skills.length > 0;
+
+  if (!hasInstalled && !hasLegacy) {
+    return (
+      <div className="tab-empty">
+        <p>No skills installed.</p>
+        <p className="field-muted" style={{ fontSize: 12 }}>
+          Use <code>mur skill install</code> to add skills to this agent.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tab-form">
+      {hasInstalled && (
+        <>
+          <label className="field-label">Installed Skills ({detail.installed_skills.length})</label>
+          <ul className="item-list">
+            {detail.installed_skills.map((s) => (
+              <li key={s.name} className="item-card">
+                <div className="item-card-name">{s.name}</div>
+                {s.version && (
+                  <span className="badge-sm">{s.version}</span>
+                )}
+                {s.description && (
+                  <div className="item-card-desc">{s.description}</div>
+                )}
+                {s.category && (
+                  <span className="field-muted" style={{ fontSize: 11 }}>{s.category}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      {hasLegacy && (
+        <>
+          <label className="field-label" style={{ marginTop: hasInstalled ? 16 : 0 }}>
+            Legacy Skill Paths ({detail.skills.length})
+          </label>
+          <ul className="item-list">
+            {detail.skills.map((s) => (
+              <li key={s.path} className="item-card">
+                <code style={{ fontSize: 11 }}>{s.path}</code>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── MCP Tab ──────────────────────────────────────────────────────────────────
+
+function McpTab({ detail }: { detail: AgentDetail }) {
+  if (detail.mcp_servers.length === 0) {
+    return (
+      <div className="tab-empty">
+        <p>No MCP servers configured.</p>
+        <p className="field-muted" style={{ fontSize: 12 }}>
+          Use <code>mur agent mcp add</code> to connect tools to this agent.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tab-form">
+      <label className="field-label">MCP Servers ({detail.mcp_servers.length})</label>
+      <ul className="item-list">
+        {detail.mcp_servers.map((m) => (
+          <li key={m.name} className="item-card">
+            <div className="item-card-name">{m.name}</div>
+            <code className="item-card-code">{m.command}</code>
+            {m.args.length > 0 && (
+              <div className="item-card-args">
+                {m.args.map((a, i) => (
+                  <span key={i} className="badge-sm">{a}</span>
+                ))}
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ─── Permissions Tab ──────────────────────────────────────────────────────────
+
+function PermissionsTab({ detail }: { detail: AgentDetail }) {
+  return (
+    <div className="tab-form">
+      <label className="field-label">Capabilities</label>
+      {detail.capabilities.length === 0 ? (
+        <p className="field-muted" style={{ fontSize: 12 }}>No special capabilities declared.</p>
+      ) : (
+        <div className="badge-row">
+          {detail.capabilities.map((c) => (
+            <span key={c} className="badge-cap">{c}</span>
+          ))}
+        </div>
+      )}
+
+      <label className="field-label" style={{ marginTop: 16 }}>MCP Servers</label>
+      <p className="field-muted" style={{ fontSize: 12 }}>
+        {detail.mcp_servers.length === 0
+          ? "No MCP servers configured."
+          : `${detail.mcp_servers.length} server(s) — see MCP tab for details.`}
+      </p>
+
+      <label className="field-label" style={{ marginTop: 16 }}>Skills</label>
+      <p className="field-muted" style={{ fontSize: 12 }}>
+        {detail.installed_skills.length === 0 && detail.skills.length === 0
+          ? "No skills installed."
+          : `${detail.installed_skills.length} installed + ${detail.skills.length} legacy — see Skills tab.`}
+      </p>
+
+      <p className="field-muted" style={{ marginTop: 24, fontSize: 11, fontStyle: "italic" }}>
+        Permissions are declared at agent creation time. Use{" "}
+        <code>mur agent update</code> from the CLI to modify entitlements.
+      </p>
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/styles.css
+++ b/mur-hub-gui/ui/src/styles.css
@@ -791,3 +791,394 @@ input {
   margin-left: auto;
 }
 .brain-badge:hover { opacity: 1; }
+
+/* ── Form inputs ─────────────────────────────────────────────────────────── */
+.input {
+  width: 100%;
+  padding: 7px 10px;
+  border: 1px solid var(--border, #333);
+  border-radius: 6px;
+  background: var(--bg-secondary, #111827);
+  color: var(--text, #F9FAFB);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+.input:focus {
+  border-color: var(--brand, #4F46E5);
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.15);
+}
+textarea.input {
+  resize: vertical;
+  min-height: 60px;
+}
+
+/* ── Detail panel (right sidebar) ────────────────────────────────────────── */
+.detail-panel {
+  width: 320px;
+  min-width: 320px;
+  border-left: 1px solid var(--border, rgba(0,0,0,0.12));
+  background: var(--bg-secondary, #111827);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.detail-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border, rgba(0,0,0,0.12));
+}
+.detail-panel-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text, #F9FAFB);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.detail-panel-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary, #9CA3AF);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  line-height: 1;
+}
+.detail-panel-close:hover {
+  background: var(--bg-hover, #374151);
+  color: var(--text, #F9FAFB);
+}
+.detail-panel-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border, rgba(0,0,0,0.12));
+  overflow-x: auto;
+  padding: 0 8px;
+  flex-shrink: 0;
+}
+.detail-tab {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--text-secondary, #9CA3AF);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  user-select: none;
+}
+.detail-tab:hover {
+  color: var(--text, #F9FAFB);
+}
+.detail-tab--active {
+  color: var(--brand, #4F46E5);
+  border-bottom-color: var(--brand, #4F46E5);
+}
+.detail-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+.detail-error {
+  color: var(--status-stale, #EF4444);
+  font-size: 13px;
+}
+.detail-loading {
+  color: var(--text-secondary, #9CA3AF);
+  font-size: 13px;
+}
+
+/* ── Tab forms (shared) ──────────────────────────────────────────────────── */
+.tab-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.field-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary, #9CA3AF);
+  margin-top: 4px;
+}
+.field-value {
+  font-size: 13px;
+  color: var(--text, #F9FAFB);
+  margin: 0;
+}
+.field-muted {
+  color: var(--text-secondary, #9CA3AF);
+}
+.save-btn {
+  margin-top: 8px;
+  align-self: flex-start;
+}
+.tab-empty {
+  text-align: center;
+  padding: 24px 0;
+  color: var(--text-secondary, #9CA3AF);
+  font-size: 13px;
+}
+
+/* ── Preset gallery (Style tab) ──────────────────────────────────────────── */
+.preset-gallery {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 4px;
+}
+.preset-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 8px;
+  border: 2px solid var(--border, rgba(255,255,255,0.10));
+  border-radius: 8px;
+  background: var(--bg, #1F2937);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  text-align: center;
+  min-height: 64px;
+}
+.preset-card:hover {
+  border-color: var(--brand-light, #818CF8);
+  background: var(--bg-hover, #374151);
+}
+.preset-card--active {
+  border-color: var(--brand, #4F46E5);
+  background: rgba(79, 70, 229, 0.10);
+}
+.preset-card-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text, #F9FAFB);
+}
+.preset-card-family {
+  font-size: 10px;
+  color: var(--text-secondary, #9CA3AF);
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+
+/* ── Progress bar (Style tab) ────────────────────────────────────────────── */
+.progress-bar {
+  height: 4px;
+  background: var(--bg-hover, #374151);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.progress-fill {
+  height: 100%;
+  background: var(--brand, #4F46E5);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+/* ── Radio cards (Behavior tab) ──────────────────────────────────────────── */
+.radio-card {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  border: 2px solid var(--border, rgba(255,255,255,0.10));
+  border-radius: 8px;
+  background: var(--bg, #1F2937);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  gap: 4px;
+}
+.radio-card:hover {
+  border-color: var(--brand-light, #818CF8);
+  background: var(--bg-hover, #374151);
+}
+.radio-card--active {
+  border-color: var(--brand, #4F46E5);
+  background: rgba(79, 70, 229, 0.10);
+}
+.radio-card-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text, #F9FAFB);
+}
+.radio-card-desc {
+  font-size: 11px;
+  color: var(--text-secondary, #9CA3AF);
+  line-height: 1.4;
+}
+
+/* ── Item lists (Skills / MCP tabs) ──────────────────────────────────────── */
+.item-list {
+  list-style: none;
+  padding: 0;
+  margin: 4px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.item-card {
+  padding: 10px 12px;
+  border: 1px solid var(--border, rgba(255,255,255,0.08));
+  border-radius: 6px;
+  background: var(--bg, #1F2937);
+}
+.item-card-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text, #F9FAFB);
+  margin-bottom: 2px;
+}
+.item-card-desc {
+  font-size: 11px;
+  color: var(--text-secondary, #9CA3AF);
+  margin-top: 2px;
+  line-height: 1.4;
+}
+.item-card-code {
+  font-size: 11px;
+  color: var(--brand-light, #818CF8);
+  display: block;
+  margin-top: 2px;
+  word-break: break-all;
+}
+.item-card-args {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+/* ── Badges (Permissions tab) ────────────────────────────────────────────── */
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+.badge-cap {
+  display: inline-block;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--brand-light, #818CF8);
+  background: rgba(79, 70, 229, 0.15);
+  border-radius: 12px;
+  white-space: nowrap;
+}
+.badge-sm {
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-secondary, #9CA3AF);
+  background: var(--bg-hover, #374151);
+  border-radius: 4px;
+}
+
+/* ── Toolbar primary button variant ──────────────────────────────────────── */
+.toolbar-btn.primary,
+button.primary {
+  background: var(--brand, #4F46E5);
+  color: var(--text-inverse, #FFFFFF);
+  border: none;
+}
+.toolbar-btn.primary:hover,
+button.primary:hover {
+  background: var(--brand-light, #818CF8);
+}
+.toolbar-btn.primary:disabled,
+button.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Save error inline ──────────────────────────────────────────────────── */
+.save-error {
+  color: var(--status-stale, #EF4444);
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+/* ── Radio card disabled ────────────────────────────────────────────────── */
+.radio-card--disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+/* ── Companion inbox (detail panel) ─────────────────────────────────────── */
+.inbox-empty {
+  text-align: center;
+  padding: 24px 0;
+  color: var(--text-secondary, #9CA3AF);
+  font-size: 13px;
+}
+.inbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.inbox-msg {
+  padding: 10px 12px;
+  border: 1px solid var(--border, rgba(255,255,255,0.08));
+  border-radius: 8px;
+  background: var(--bg, #1F2937);
+  font-size: 13px;
+}
+.inbox-msg--unread {
+  border-left: 3px solid var(--brand, #4F46E5);
+}
+.inbox-msg-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
+}
+.inbox-situation {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--brand-light, #818CF8);
+}
+.inbox-time {
+  font-size: 10px;
+  color: var(--text-secondary, #9CA3AF);
+}
+.inbox-body {
+  font-size: 13px;
+  color: var(--text, #F9FAFB);
+  line-height: 1.5;
+  margin-bottom: 6px;
+  word-break: break-word;
+}
+.inbox-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+.inbox-actions button {
+  padding: 4px 10px;
+  font-size: 11px;
+  border: 1px solid var(--border, rgba(255,255,255,0.10));
+  border-radius: 4px;
+  background: var(--bg-secondary, #111827);
+  color: var(--text-secondary, #9CA3AF);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.inbox-actions button:hover {
+  background: var(--bg-hover, #374151);
+  color: var(--text, #F9FAFB);
+}
+.inbox-acked {
+  text-align: center;
+  padding: 16px 0;
+  color: var(--text-secondary, #9CA3AF);
+  font-size: 12px;
+  font-style: italic;
+}

--- a/mur-hub-gui/ui/src/types.ts
+++ b/mur-hub-gui/ui/src/types.ts
@@ -71,3 +71,84 @@ export const BUILTIN_PRESETS: PresetSummary[] = [
   { id: "vtuber-soft",   display_name: "VTuber Soft",    family: "chibi",    description: "Soft anime VTuber style" },
   { id: "family-photo",  display_name: "Family Photo",   family: "polaroid", description: "Cartoon-ify your photo" },
 ];
+
+// ── Detail panel types (Plan 3) ──────────────────────────────────────────────
+
+export interface SkillView {
+  path: string;
+}
+
+export interface InstalledSkillView {
+  name: string;
+  version: string;
+  description: string;
+  category: string;
+}
+
+export interface McpServerView {
+  name: string;
+  command: string;
+  args: string[];
+}
+
+export type RenderStatusView =
+  | { status: "pending" }
+  | { status: "rendering"; done: number; total: number }
+  | { status: "ready" }
+  | { status: "failed"; reason: string };
+
+export interface AgentDetail {
+  persona_category: string;
+  persona_description: string;
+  persona_tone: string;
+  persona_risk: string;
+  persona_verbosity: string;
+  style_preset: string;
+  render_status: RenderStatusView;
+  behavior_preset: string;
+  skills: SkillView[];
+  installed_skills: InstalledSkillView[];
+  mcp_servers: McpServerView[];
+  capabilities: string[];
+  display_name: string;
+  agent_name: string;
+}
+
+export interface DetailPatch {
+  persona_category?: string;
+  persona_description?: string;
+  persona_tone?: string;
+  persona_risk?: string;
+  persona_verbosity?: string;
+  style_preset?: string;
+  behavior_preset?: string;
+}
+
+export type DetailTab =
+  | "persona"
+  | "style"
+  | "behavior"
+  | "skills"
+  | "mcp"
+  | "permissions"
+  | "inbox";
+
+export const ALL_DETAIL_TABS: DetailTab[] = [
+  "persona",
+  "style",
+  "behavior",
+  "skills",
+  "mcp",
+  "permissions",
+  "inbox",
+];
+
+export const TAB_LABELS: Record<DetailTab, string> = {
+  persona: "Persona",
+  style: "Style",
+  behavior: "Behavior",
+  skills: "Skills",
+  mcp: "MCP",
+  permissions: "Permissions",
+  inbox: "Inbox",
+};


### PR DESCRIPTION
## Summary

Completes **Plan 3** of the [Agent Export UX spec](https://github.com/mur-run/mur/blob/main/docs/superpowers/specs/2026-05-29-mur-agent-export-ux-give-to-a-friend-design.md) (give-to-a-friend). The Hub right-side detail panel now has **7 functional tabs** replacing the old Inbox-only unstyled sidebar.

## Changes

### Rust backend (`detail.rs` — new)
- `AgentDetail` — extracts all tab data from `profile.yaml` in one read
- `DetailPatch` — partial-profile update with all-Optional fields
- `get_agent_detail` / `update_agent_detail` Tauri commands

### React frontend (`DetailPanel.tsx` — new, +660 lines)
| Tab | Functionality |
|-----|--------------|
| **Persona** | Edit category, description, tone, risk, verbosity → Save writes back |
| **Style** | Current preset + render status + preset gallery (click to switch) |
| **Behavior** | Quiet / Normal / Lively radio cards, auto-save on selection |
| **Skills** | Installed skills (name/version/desc/category) + legacy paths |
| **MCP** | Server list (name/command/args) |
| **Permissions** | Capabilities badges + summary of MCP/skills |
| **Inbox** | Existing CompanionInbox (now with CSS styling) |

### CSS (`styles.css` +391 lines)
- `.input` form class (was missing, needed by model wizard too)
- `.detail-panel*` sidebar layout
- `.tab-form`, `.preset-gallery`, `.radio-card`, `.item-list`, `.badge-*`
- `.inbox-*` companion message styling (pre-existing gap)

### Code review fixes included
- Inline error feedback on save failures (Persona/Style/Behavior tabs)
- Saving/disabled states during async writes
- Inbox CSS (was completely unstyled)

## Testing
- ✅ `cargo check` — Rust compiles
- ✅ `npm run build` — TypeScript + Vite 0 errors
- ✅ Code reviewed (0 Critical, 3 Important fixed, 2 deferred as scope decisions)

## Deferred
- Re-render button in Style tab (needs new Tauri command)
- Entitlements display in Permissions tab (AgentDetail doesn not include `entitlements` yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)