### PR TITLE
fix(hub): validate IPC inputs used as filesystem paths

### DIFF
--- a/mur-hub-gui/src-tauri/src/companion.rs
+++ b/mur-hub-gui/src-tauri/src/companion.rs
@@ -42,11 +42,28 @@ fn agent_inbox(agent: &str) -> PathBuf {
         .join("companion/inbox")
 }
 
+/// Reject agent names that aren't safe as a path component before they're
+/// joined under `~/.mur/agents/`. Uses the canonical agent-name rules so the
+/// GUI and CLI/HTTP surfaces agree.
+fn check_agent(agent: &str) -> Result<(), String> {
+    mur_common::agent_name::validate_agent_name(agent).map_err(|e| format!("invalid agent name: {e}"))
+}
+
+/// Lightweight traversal check for an opaque id used as a filename component
+/// (lenient on charset so real message ids still pass, strict on separators).
+fn check_path_component(s: &str, what: &str) -> Result<(), String> {
+    if s.is_empty() || s.contains('/') || s.contains('\\') || s.contains("..") || s.contains('\0') {
+        return Err(format!("invalid {what}"));
+    }
+    Ok(())
+}
+
 // ─── Tauri commands ──────────────────────────────────────────────────────────
 
 /// Return all pending (unresponded) inbox messages for `agent`.
 #[tauri::command]
 pub fn companion_bridge_pending(agent: String) -> Result<Vec<BridgeEvent>, String> {
+    check_agent(&agent)?;
     scan_pending(&agent_inbox(&agent)).map_err(|e| format!("{e:#}"))
 }
 
@@ -58,6 +75,7 @@ pub async fn companion_bridge_subscribe(
     on_event: Channel<BridgeEvent>,
     state: tauri::State<'_, BridgeState>,
 ) -> Result<(), String> {
+    check_agent(&agent)?;
     let (tx, mut rx) = mpsc::channel::<BridgeEvent>(32);
     let watcher = InboxWatcher::start(agent_inbox(&agent), tx).map_err(|e| format!("{e:#}"))?;
 
@@ -84,6 +102,7 @@ pub fn companion_bridge_unsubscribe(
     agent: String,
     state: tauri::State<'_, BridgeState>,
 ) -> Result<(), String> {
+    check_agent(&agent)?;
     state
         .watchers
         .lock()
@@ -95,6 +114,8 @@ pub fn companion_bridge_unsubscribe(
 /// Acknowledge a message (rewrite `>>> response: <unset>` → `>>> response: <signal>`).
 #[tauri::command]
 pub fn companion_ack(agent: String, msg_id: String, signal: String) -> Result<(), String> {
+    check_agent(&agent)?;
+    check_path_component(&msg_id, "msg_id")?;
     if !matches!(signal.as_str(), "good" | "bad" | "dismiss" | "snooze") {
         return Err(format!("unknown signal `{signal}`"));
     }
@@ -115,6 +136,9 @@ pub fn companion_ack(agent: String, msg_id: String, signal: String) -> Result<()
 /// Count unread (BridgeResponse::Unset) messages for `agent`.
 #[tauri::command]
 pub fn companion_unread_count(agent: String) -> u32 {
+    if check_agent(&agent).is_err() {
+        return 0;
+    }
     scan_pending(&agent_inbox(&agent))
         .map(|evs| {
             evs.iter()

--- a/mur-hub-gui/src-tauri/src/companion.rs
+++ b/mur-hub-gui/src-tauri/src/companion.rs
@@ -46,7 +46,8 @@ fn agent_inbox(agent: &str) -> PathBuf {
 /// joined under `~/.mur/agents/`. Uses the canonical agent-name rules so the
 /// GUI and CLI/HTTP surfaces agree.
 fn check_agent(agent: &str) -> Result<(), String> {
-    mur_common::agent_name::validate_agent_name(agent).map_err(|e| format!("invalid agent name: {e}"))
+    mur_common::agent_name::validate_agent_name(agent)
+        .map_err(|e| format!("invalid agent name: {e}"))
 }
 
 /// Lightweight traversal check for an opaque id used as a filename component

--- a/mur-hub-gui/src-tauri/src/onboarding/mod.rs
+++ b/mur-hub-gui/src-tauri/src/onboarding/mod.rs
@@ -155,6 +155,10 @@ pub fn wizard_set_name(
     if name.trim().is_empty() {
         return Err("name must not be empty".into());
     }
+    // The name later becomes an agent directory component (wizard_start_render
+    // / wizard_finish); validate it here at the single entry point.
+    mur_common::agent_name::validate_agent_name(name.trim())
+        .map_err(|e| format!("invalid name: {e}"))?;
     update_session(&state, |s| {
         s.name = Some(name.trim().to_string());
         s.description = Some(description.trim().to_string());

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -48,12 +48,24 @@ fn pet_position_path(agent_name: &str) -> PathBuf {
         .join("pet_position.json")
 }
 
+/// True if `agent_name` is safe to use as a path component under
+/// `~/.mur/agents/` (canonical agent-name rules).
+fn valid_agent(agent_name: &str) -> bool {
+    mur_common::agent_name::validate_agent_name(agent_name).is_ok()
+}
+
 fn load_position(agent_name: &str) -> Option<PetPosition> {
+    if !valid_agent(agent_name) {
+        return None;
+    }
     let data = std::fs::read_to_string(pet_position_path(agent_name)).ok()?;
     serde_json::from_str(&data).ok()
 }
 
 fn save_position(agent_name: &str, pos: &PetPosition) {
+    if !valid_agent(agent_name) {
+        return;
+    }
     let path = pet_position_path(agent_name);
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -254,6 +266,17 @@ pub fn pet_list(state: State<'_, PetState>) -> Vec<String> {
 
 #[tauri::command]
 pub fn pet_get_expression(agent_name: String, expression: String) -> String {
+    // Both segments become path components; reject traversal so a malicious
+    // IPC caller can't read arbitrary files (the bytes are returned to the UI).
+    if !valid_agent(&agent_name)
+        || expression.is_empty()
+        || expression.contains('/')
+        || expression.contains('\\')
+        || expression.contains("..")
+        || expression.contains('\0')
+    {
+        return String::new();
+    }
     let path = mur_home()
         .join("agents")
         .join(&agent_name)

--- a/mur-hub-gui/src-tauri/src/preset.rs
+++ b/mur-hub-gui/src-tauri/src/preset.rs
@@ -53,7 +53,11 @@ pub fn import_preset_file(path: String) -> Result<String, String> {
 pub fn import_preset_url(url: String) -> Result<String, String> {
     // Require HTTPS: rejects cleartext and file:// / other schemes, keeping the
     // fetch surface to TLS endpoints only.
-    if !url.trim_start().to_ascii_lowercase().starts_with("https://") {
+    if !url
+        .trim_start()
+        .to_ascii_lowercase()
+        .starts_with("https://")
+    {
         return Err("preset URL must use https".into());
     }
     let client = reqwest::blocking::Client::builder()

--- a/mur-hub-gui/src-tauri/src/preset.rs
+++ b/mur-hub-gui/src-tauri/src/preset.rs
@@ -9,6 +9,12 @@ use std::path::PathBuf;
 
 use mur_common::hub::style_preset::StylePreset;
 
+/// Presets are tiny YAML documents; cap remote fetches well above any real
+/// preset to bound memory from a hostile/oversized URL.
+const MAX_PRESET_BYTES: u64 = 1024 * 1024; // 1 MiB
+/// Bound a remote preset fetch so a slow/hung server can't block the IPC thread.
+const PRESET_FETCH_TIMEOUT_SECS: u64 = 15;
+
 fn presets_dir() -> PathBuf {
     std::env::var("MUR_HOME")
         .map(PathBuf::from)
@@ -19,6 +25,12 @@ fn presets_dir() -> PathBuf {
 fn install_preset(yaml: &str) -> Result<String, String> {
     let preset: StylePreset =
         serde_yaml_ng::from_str(yaml).map_err(|e| format!("invalid preset YAML: {e}"))?;
+
+    // The id becomes a path component (`<id>.yaml`); validate it with the
+    // canonical safe-name rules so a crafted preset (e.g. fetched from an
+    // arbitrary URL) can't escape presets_dir via `..` / absolute / separators.
+    mur_common::agent_name::validate_agent_name(&preset.id)
+        .map_err(|e| format!("invalid preset id: {e}"))?;
 
     let dir = presets_dir();
     fs::create_dir_all(&dir).map_err(|e| format!("create presets dir: {e}"))?;
@@ -39,9 +51,29 @@ pub fn import_preset_file(path: String) -> Result<String, String> {
 /// Import a StylePreset YAML from a URL (synchronous fetch via reqwest blocking).
 #[tauri::command]
 pub fn import_preset_url(url: String) -> Result<String, String> {
-    let yaml = reqwest::blocking::get(&url)
-        .map_err(|e| format!("fetch {url}: {e}"))?
-        .text()
+    // Require HTTPS: rejects cleartext and file:// / other schemes, keeping the
+    // fetch surface to TLS endpoints only.
+    if !url.trim_start().to_ascii_lowercase().starts_with("https://") {
+        return Err("preset URL must use https".into());
+    }
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(PRESET_FETCH_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| format!("http client: {e}"))?;
+    let resp = client
+        .get(&url)
+        .send()
+        .map_err(|e| format!("fetch {url}: {e}"))?;
+
+    // Bound the body so a hostile URL can't exhaust memory.
+    use std::io::Read;
+    let mut buf = Vec::new();
+    resp.take(MAX_PRESET_BYTES + 1)
+        .read_to_end(&mut buf)
         .map_err(|e| format!("read body: {e}"))?;
+    if buf.len() as u64 > MAX_PRESET_BYTES {
+        return Err(format!("preset exceeds {MAX_PRESET_BYTES} bytes"));
+    }
+    let yaml = String::from_utf8(buf).map_err(|e| format!("preset body not UTF-8: {e}"))?;
     install_preset(&yaml)
 }


### PR DESCRIPTION
## Summary

Final piece of the agent/hub security-hardening batch from the deep code review. The earlier parts (core correctness + bridge sender authz + DoS hardening, Noise-XK TCP peer-auth, macOS SBPL default-deny + HostGuard SSRF) are already on `main` via the 2.22.x releases; this PR adds the remaining **Hub Tauri IPC input validation**.

Several `#[tauri::command]` handlers joined frontend-supplied strings straight into paths under `~/.mur` with no validation. Names normally come from trusted discovery, but a compromised/malicious IPC caller could traverse out, and the preset URL path allowed a remote-influenced write.

## Changes

- **preset**: validate `preset.id` with the canonical `validate_agent_name` rules before using it as `<id>.yaml` — a preset fetched from an arbitrary URL otherwise yielded a remote-influenced out-of-bounds write. `import_preset_url` now requires **https**, applies a **fetch timeout**, and **caps the body size** (SSRF / DoS surface).
- **companion**: validate `agent` on the inbox commands and the `msg_id` filename component in `companion_ack`.
- **pet**: reject unsafe `agent_name` in load/save position, and reject traversal in `pet_get_expression`'s `agent_name` / `expression` (it returns file bytes to the webview — an arbitrary-read sink otherwise).
- **onboarding**: validate the wizard `name` at `wizard_set_name`, the single entry point before it becomes an agent directory in `start_render` / `finish`.

## Verification

- `cargo check` + `cargo clippy` on `mur-hub-gui/src-tauri` — clean.
- Validation reuses `mur_common::agent_name::validate_agent_name`, which is unit-tested in `mur-common`.

## Follow-ups (tracked, not in scope)

- Connector-level guard for IP-literal URL SSRF (reqwest's resolver is bypassed for IP literals).
- B0 `pre_tool_use` / `TrashGuard` wiring (awaits the P0b tool-exec loop).
- A2A `SignedEnvelope` production transport + replay nonce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)