### PR TITLE
fix(ci): extract release tarball into dist/ to avoid mur-mcp-server dir collision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,13 @@ jobs:
           name: mur-aarch64-apple-darwin
 
       - name: Extract binary from tar.gz
-        run: tar xzf mur-aarch64-apple-darwin.tar.gz
+        # Extract into a dedicated dir: the tarball contains a `mur-mcp-server`
+        # binary, but the checked-out source tree has a `mur-mcp-server/` crate
+        # directory at the repo root. Extracting in place fails with
+        # "Can't replace existing directory with non-directory".
+        run: |
+          mkdir -p dist
+          tar xzf mur-aarch64-apple-darwin.tar.gz -C dist
 
       - name: Import Apple signing certs
         uses: apple-actions/import-codesign-certs@v2
@@ -169,8 +175,8 @@ jobs:
         run: |
           mkdir -p pkg-root/usr/local/bin
           mkdir -p pkg-root/usr/local/share/doc/mur
-          cp mur pkg-root/usr/local/bin/mur
-          cp mur-mcp-server pkg-root/usr/local/bin/mur-mcp-server
+          cp dist/mur pkg-root/usr/local/bin/mur
+          cp dist/mur-mcp-server pkg-root/usr/local/bin/mur-mcp-server
           chmod +x pkg-root/usr/local/bin/mur
           chmod +x pkg-root/usr/local/bin/mur-mcp-server
           cp LICENSE pkg-root/usr/local/share/doc/mur/LICENSE


### PR DESCRIPTION
## Problem

The release workflow failed during the `package-macos` job ([run 26882796646](https://github.com/mur-run/mur/actions/runs/26882796646/job/79293750154)):

```
mur-mcp-server: Can't replace existing directory with non-directory: Directory not empty
```

## Root cause

The `package-macos` job runs `actions/checkout@v6` first, which lays down the repo's `mur-mcp-server/` **crate directory** at the working-dir root. Since #343 added the `mur-mcp-server` **binary** to the release tarball, `tar xzf` then tried to extract the binary file over the existing crate directory and failed.

## Fix

- Extract the tarball into a dedicated `dist/` directory (`tar xzf … -C dist`) so the extracted binaries never collide with the checked-out source tree.
- Reference `dist/mur` and `dist/mur-mcp-server` in the Stage pkg-root step.

macOS-only: the Homebrew install and Windows zip paths extract into clean build dirs and were never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)