### PR TITLE
feat(compress): native reversible token-compression (mur-compress crate + 3 MCP tools)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "mur-gui-core",
     "mur-agent-launcher",
     "mur-mcp-server",
+    "mur-compress",
     # "mur-commander",  # separate crate — v0.2.0 released
 ]
 exclude = [

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ For the full Agent platform — MCP server, skills, action pipeline, companion, 
 | **Workflow Engine** | Multi-step workflows with variables, tools, and session extraction |
 | **Embedded Dashboard** | Built-in web UI for pattern management, workflow editing, and session review |
 | **YAML + Git Friendly** | Human-readable patterns, version-controllable, no opaque database lock-in |
+| **Token Compression** | Offline, reversible token compression via `mur compress` / `mur retrieve` and three MCP tools (`mur_compress`, `mur_retrieve`, `mur_compress_stats`). Reduces large payloads 40–80% while keeping originals retrievable by blake3 hash. |
 | **100% Local First** | All data on your machine. Zero telemetry. Injection scanning + content hashing for security. |
 | **Multi-language** | Dashboard UI in English, 繁體中文, 简体中文 |
 

--- a/docs/superpowers/plans/2026-06-03-mur-compress-token.md
+++ b/docs/superpowers/plans/2026-06-03-mur-compress-token.md
@@ -1,0 +1,2435 @@
+# MUR Compress-Token Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a native, offline, local-first token-compression subsystem for MUR (`mur-compress` crate) exposing reversible compress/retrieve/stats over MCP.
+
+**Architecture:** A pure leaf crate `mur-compress` implements a two-stage pipeline — lossless **Reformat** then reversible **Offload** (originals stored in a CCR store under `~/.mur/compress/`, retrievable by `blake3` hash). Content is routed by a regex `ContentType` detector to one of five compressors (search/log/diff/json/fallback). Tokens are counted with `tiktoken-rs`. `mur-mcp-server` resolves `mur_home()` and wires three tools. Everything is synchronous, deterministic, and fail-safe (any error ⇒ return original unchanged).
+
+**Tech Stack:** Rust (edition 2024), `tiktoken-rs`, `blake3`, `flate2`, `serde`/`serde_json`/`serde_yaml`, `regex`, `thiserror`; custom BM25; existing custom JSON-RPC MCP server.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-mur-compress-token-design.md`
+
+---
+
+## File Structure
+
+```
+mur-compress/                         # NEW workspace member (8th crate), MIT
+  Cargo.toml
+  src/
+    lib.rs            # re-exports + CompressEngine (orchestrator: detect→dispatch→measure→retrieve)
+    types.rs         # ContentType, CompressCtx, CompressOutput, CompressResult, RetrieveResult, CompressError
+    config.rs        # CompressConfig (+ DetectCfg/StoreCfg/StatsCfg), Default, load()
+    tokenizer.rs     # TokenCounter trait, TiktokenCounter, HeuristicCounter, default_counter()
+    detect.rs        # detect_content_type()
+    bm25.rs          # bm25_rank()
+    stats.rs         # StatsTracker, StatsData, StatsSnapshot
+    ccr/
+      mod.rs         # re-exports
+      entry.rs       # CompressedEntry
+      store.rs       # CcrStore (put/get/put_original/eviction), hash_content(), gzip helpers
+    compressors/
+      mod.rs
+      fallback.rs    # whitespace/blank-line reformat (no offload)
+      search.rs      # group-by-file reformat + top-K/head offload
+      log.rs         # repeat-collapse reformat + noise-drop offload
+      diff.rs        # context-trim reformat + unchanged-block offload
+      json.rs        # minify reformat + array row-collapse offload
+  tests/
+    end_to_end.rs    # compress→retrieve reversibility, fail-safe, ratios
+
+mur-mcp-server/
+  Cargo.toml         # MODIFY: add mur-compress dep
+  src/tools.rs       # MODIFY: 3 Tool literals + 3 call_tool arms + engine() helper
+  tests/integration.rs # MODIFY: cover the 3 new tools
+
+mur-core/
+  src/cmd/compress.rs  # NEW (Task 15, optional CLI)
+  src/cmd/mod.rs       # MODIFY: register module
+  (clap wiring)        # MODIFY main arg parser
+
+Cargo.toml             # MODIFY: add "mur-compress" to [workspace] members
+```
+
+**Conventions for the engineer (zero-context):**
+- Build one crate: `cargo build -p mur-compress`. Test one: `cargo test -p mur-compress`. Test by name: `cargo test -p mur-compress <name>`.
+- This repo uses **edition 2024** (`LazyLock`, let-chains available). Keep every source file under **800 lines**.
+- Commit after every green task. Commit messages end with the trailer shown in Task 1.
+
+---
+
+## Task 1: Scaffold the `mur-compress` crate
+
+**Files:**
+- Create: `mur-compress/Cargo.toml`
+- Create: `mur-compress/src/lib.rs`
+- Modify: `Cargo.toml` (workspace members)
+
+- [ ] **Step 1: Create `mur-compress/Cargo.toml`**
+
+```toml
+[package]
+name = "mur-compress"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
+regex = "1"
+thiserror = "1"
+blake3 = "1"
+flate2 = "1"
+tiktoken-rs = "0.6"
+
+[dev-dependencies]
+tempfile = "3"
+```
+
+> If `tiktoken-rs = "0.6"` fails to resolve, run `cargo add -p mur-compress tiktoken-rs` to pick the current release; if its `encode_with_special_tokens` method name differs, adjust `tokenizer.rs` in Task 3.
+
+- [ ] **Step 2: Create a minimal `mur-compress/src/lib.rs`**
+
+```rust
+//! mur-compress: native, offline, reversible token compression for MUR.
+//!
+//! Design inspiration: headroom (https://github.com/chopratejas/headroom, Apache-2.0).
+//! This crate is a clean-room reimplementation; no headroom source is copied.
+
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+```
+
+- [ ] **Step 3: Add the crate to the workspace members**
+
+In `Cargo.toml` (repo root), modify the `members` list — add `"mur-compress",` after `"mur-mcp-server",`:
+
+```toml
+members = [
+    "mur-common",
+    "mur-core",
+    "mur-agent-runtime",
+    "mur-daemon",
+    "mur-gui-core",
+    "mur-agent-launcher",
+    "mur-mcp-server",
+    "mur-compress",
+]
+```
+
+- [ ] **Step 4: Verify it builds**
+
+Run: `cargo build -p mur-compress`
+Expected: compiles clean (downloads `tiktoken-rs`, `blake3`, `flate2` on first build).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml mur-compress/Cargo.toml mur-compress/src/lib.rs
+git commit -m "feat(compress): scaffold mur-compress crate" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Core types & errors (`types.rs`)
+
+**Files:**
+- Create: `mur-compress/src/types.rs`
+- Modify: `mur-compress/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test** — append to `mur-compress/src/types.rs`:
+
+```rust
+//! Shared types for the compression pipeline.
+
+use serde::{Deserialize, Serialize};
+
+/// Detected content category that selects a compressor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ContentType {
+    SearchResults,
+    BuildLog,
+    GitDiff,
+    Json,
+    Generic,
+}
+
+impl ContentType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ContentType::SearchResults => "search_results",
+            ContentType::BuildLog => "build_log",
+            ContentType::GitDiff => "git_diff",
+            ContentType::Json => "json",
+            ContentType::Generic => "generic",
+        }
+    }
+}
+
+/// Per-call context handed to a compressor.
+pub struct CompressCtx<'a> {
+    pub query: Option<&'a str>,
+    pub config: &'a crate::config::CompressConfig,
+}
+
+/// Internal output of a single compressor (before token measurement).
+#[derive(Debug, Clone)]
+pub struct CompressOutput {
+    pub compressed: String,
+    pub hash: Option<String>,
+    pub transforms: Vec<String>,
+}
+
+/// Public result of `CompressEngine::compress`.
+#[derive(Debug, Clone)]
+pub struct CompressResult {
+    pub compressed: String,
+    pub hash: Option<String>,
+    pub original_tokens: usize,
+    pub compressed_tokens: usize,
+    pub tokens_saved: usize,
+    pub savings_percent: f32,
+    pub transforms: Vec<String>,
+    pub content_type: ContentType,
+}
+
+/// Public result of `CompressEngine::retrieve`.
+#[derive(Debug, Clone)]
+pub enum RetrieveResult {
+    Full {
+        content_type: String,
+        original_content: String,
+        item_count: usize,
+    },
+    Filtered {
+        query: String,
+        results: Vec<String>,
+        count: usize,
+    },
+    NotFound,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CompressError {
+    #[error("tokenizer error: {0}")]
+    Tokenizer(String),
+    #[error("store error: {0}")]
+    Store(String),
+    #[error("parse error: {0}")]
+    Parse(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_type_as_str_roundtrips() {
+        assert_eq!(ContentType::Json.as_str(), "json");
+        assert_eq!(ContentType::SearchResults.as_str(), "search_results");
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module** — in `mur-compress/src/lib.rs` add at top (below the doc comment):
+
+```rust
+pub mod config;
+pub mod types;
+
+pub use types::{
+    CompressCtx, CompressError, CompressOutput, CompressResult, ContentType, RetrieveResult,
+};
+```
+
+(`config` is created in Task 4; add the `pub mod config;` line now — it will fail to compile until Task 4. To keep this task green, create an empty `mur-compress/src/config.rs` placeholder containing only `// filled in Task 4` AND the minimal `CompressConfig` stub below, then flesh it out in Task 4.)
+
+Minimal `mur-compress/src/config.rs` stub so `types.rs` compiles:
+
+```rust
+//! Filled out in Task 4.
+#[derive(Debug, Clone, Default)]
+pub struct CompressConfig;
+```
+
+- [ ] **Step 3: Run the test to verify it fails, then passes**
+
+Run: `cargo test -p mur-compress content_type_as_str_roundtrips`
+Expected: PASS (this task is pure type definitions; the assertion validates `as_str`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-compress/src/types.rs mur-compress/src/config.rs mur-compress/src/lib.rs
+git commit -m "feat(compress): core types and errors" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Tokenizer (`tokenizer.rs`)
+
+**Files:**
+- Create: `mur-compress/src/tokenizer.rs`
+- Modify: `mur-compress/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test** — create `mur-compress/src/tokenizer.rs`:
+
+```rust
+//! Token counting. Real counts via tiktoken-rs (cl100k_base, offline);
+//! a chars/4 heuristic is the degrade-don't-fail fallback.
+
+use crate::types::CompressError;
+
+pub trait TokenCounter: Send + Sync {
+    fn count(&self, text: &str) -> usize;
+}
+
+pub struct TiktokenCounter {
+    bpe: tiktoken_rs::CoreBPE,
+}
+
+impl TiktokenCounter {
+    pub fn new() -> Result<Self, CompressError> {
+        let bpe = tiktoken_rs::cl100k_base()
+            .map_err(|e| CompressError::Tokenizer(e.to_string()))?;
+        Ok(Self { bpe })
+    }
+}
+
+impl TokenCounter for TiktokenCounter {
+    fn count(&self, text: &str) -> usize {
+        self.bpe.encode_with_special_tokens(text).len()
+    }
+}
+
+pub struct HeuristicCounter;
+
+impl TokenCounter for HeuristicCounter {
+    fn count(&self, text: &str) -> usize {
+        text.len().div_ceil(4)
+    }
+}
+
+/// Returns the best available counter; never fails.
+pub fn default_counter() -> Box<dyn TokenCounter> {
+    match TiktokenCounter::new() {
+        Ok(c) => Box::new(c),
+        Err(_) => Box::new(HeuristicCounter),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tiktoken_counts_are_positive_and_subword() {
+        let c = TiktokenCounter::new().expect("cl100k_base loads");
+        // "hello world" is 2 tokens in cl100k_base.
+        assert_eq!(c.count("hello world"), 2);
+        assert!(c.count("") == 0);
+    }
+
+    #[test]
+    fn heuristic_is_chars_over_four() {
+        let h = HeuristicCounter;
+        assert_eq!(h.count("abcd"), 1);
+        assert_eq!(h.count("abcde"), 2); // div_ceil
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module** — add to `mur-compress/src/lib.rs`:
+
+```rust
+pub mod tokenizer;
+pub use tokenizer::{default_counter, TokenCounter};
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p mur-compress tokenizer`
+Expected: PASS. If `tiktoken_counts_are_positive_and_subword` fails on the exact count `2`, replace the assertion with `assert!(c.count("hello world") >= 2);` (vocab build differences) and keep going.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-compress/src/tokenizer.rs mur-compress/src/lib.rs
+git commit -m "feat(compress): tiktoken-rs token counter with heuristic fallback" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Config (`config.rs`)
+
+**Files:**
+- Modify: `mur-compress/src/config.rs` (replace the Task 2 stub)
+
+- [ ] **Step 1: Replace `mur-compress/src/config.rs` with the full config**
+
+```rust
+//! Compression configuration. Mirrors the `compress:` section of
+//! ~/.mur/config.yaml (see design spec §11). Every field has a default.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct CompressConfig {
+    pub enabled: bool,
+    pub tokenizer: String,
+    pub target_ratio: f32,
+    pub bloat_threshold: f32,
+    pub protect_head_lines: usize,
+    pub protect_tail_lines: usize,
+    pub retrieve_top_k: usize,
+    pub retrieve_score_threshold: f32,
+    pub detect: DetectCfg,
+    pub store: StoreCfg,
+    pub stats: StatsCfg,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct DetectCfg {
+    pub search_min_ratio: f32,
+    pub log_min_ratio: f32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct StoreCfg {
+    pub dir: Option<String>,
+    pub ttl_days: u64,
+    pub max_entries: usize,
+    pub max_bytes: u64,
+    pub compress_at_rest: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct StatsCfg {
+    pub cost_per_mtok_usd: f64,
+}
+
+impl Default for CompressConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            tokenizer: "cl100k_base".into(),
+            target_ratio: 0.30,
+            bloat_threshold: 0.20,
+            protect_head_lines: 20,
+            protect_tail_lines: 20,
+            retrieve_top_k: 20,
+            retrieve_score_threshold: 0.30,
+            detect: DetectCfg::default(),
+            store: StoreCfg::default(),
+            stats: StatsCfg::default(),
+        }
+    }
+}
+
+impl Default for DetectCfg {
+    fn default() -> Self {
+        Self { search_min_ratio: 0.6, log_min_ratio: 0.5 }
+    }
+}
+
+impl Default for StoreCfg {
+    fn default() -> Self {
+        Self {
+            dir: None,
+            ttl_days: 7,
+            max_entries: 2000,
+            max_bytes: 536_870_912, // 512 MiB
+            compress_at_rest: true,
+        }
+    }
+}
+
+impl Default for StatsCfg {
+    fn default() -> Self {
+        Self { cost_per_mtok_usd: 3.0 }
+    }
+}
+
+impl CompressConfig {
+    /// Load the `compress:` section from `<home>/config.yaml`, else defaults.
+    pub fn load(home: &Path) -> Self {
+        let path = home.join("config.yaml");
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            return Self::default();
+        };
+        let Ok(root) = serde_yaml::from_str::<serde_yaml::Value>(&text) else {
+            return Self::default();
+        };
+        root.get("compress")
+            .and_then(|v| serde_yaml::from_value::<CompressConfig>(v.clone()).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn ttl_secs(&self) -> u64 {
+        self.store.ttl_days.saturating_mul(86_400)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_sane() {
+        let c = CompressConfig::default();
+        assert_eq!(c.store.ttl_days, 7);
+        assert_eq!(c.ttl_secs(), 7 * 86_400);
+        assert_eq!(c.retrieve_top_k, 20);
+        assert!(c.store.compress_at_rest);
+    }
+
+    #[test]
+    fn missing_config_file_yields_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let c = CompressConfig::load(dir.path());
+        assert_eq!(c.protect_head_lines, 20);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p mur-compress config`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-compress/src/config.rs
+git commit -m "feat(compress): config matching spec compress: section" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Content detection (`detect.rs`)
+
+**Files:**
+- Create: `mur-compress/src/detect.rs`
+- Modify: `mur-compress/src/lib.rs`
+
+- [ ] **Step 1: Write `mur-compress/src/detect.rs` with tests**
+
+```rust
+//! Deterministic content-type detection (regex heuristics, no ML).
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::config::CompressConfig;
+use crate::types::ContentType;
+
+static SEARCH_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[^\s:]+:\d+:").unwrap());
+static LOG_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)\b(ERROR|WARN|WARNING|INFO|DEBUG|TRACE|FATAL)\b").unwrap());
+
+pub fn detect_content_type(content: &str, cfg: &CompressConfig) -> ContentType {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return ContentType::Generic;
+    }
+
+    // JSON: must actually parse.
+    if (trimmed.starts_with('{') || trimmed.starts_with('['))
+        && serde_json::from_str::<serde_json::Value>(trimmed).is_ok()
+    {
+        return ContentType::Json;
+    }
+
+    // Git diff: structural markers.
+    if content.contains("diff --git")
+        || content.lines().any(|l| l.starts_with("@@ ") || l.starts_with("@@-"))
+        || (content.contains("\n--- ") && content.contains("\n+++ "))
+    {
+        return ContentType::GitDiff;
+    }
+
+    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.is_empty() {
+        return ContentType::Generic;
+    }
+    let n = lines.len() as f32;
+
+    let search_hits = lines.iter().filter(|l| SEARCH_RE.is_match(l)).count() as f32;
+    if search_hits / n >= cfg.detect.search_min_ratio {
+        return ContentType::SearchResults;
+    }
+
+    let log_hits = lines.iter().filter(|l| LOG_RE.is_match(l)).count() as f32;
+    if log_hits / n >= cfg.detect.log_min_ratio {
+        return ContentType::BuildLog;
+    }
+
+    ContentType::Generic
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> CompressConfig {
+        CompressConfig::default()
+    }
+
+    #[test]
+    fn detects_json_array() {
+        assert_eq!(detect_content_type(r#"[{"a":1},{"a":2}]"#, &cfg()), ContentType::Json);
+    }
+
+    #[test]
+    fn detects_search_results() {
+        let s = "src/a.rs:10:fn foo\nsrc/b.rs:22:let x\nsrc/c.rs:3:use bar";
+        assert_eq!(detect_content_type(s, &cfg()), ContentType::SearchResults);
+    }
+
+    #[test]
+    fn detects_git_diff() {
+        let s = "diff --git a/x b/x\n@@ -1,2 +1,2 @@\n-old\n+new";
+        assert_eq!(detect_content_type(s, &cfg()), ContentType::GitDiff);
+    }
+
+    #[test]
+    fn detects_build_log() {
+        let s = "INFO starting\nERROR boom\nWARN careful\nDEBUG trace";
+        assert_eq!(detect_content_type(s, &cfg()), ContentType::BuildLog);
+    }
+
+    #[test]
+    fn falls_back_to_generic() {
+        assert_eq!(detect_content_type("just some prose here", &cfg()), ContentType::Generic);
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module** — add to `mur-compress/src/lib.rs`:
+
+```rust
+pub mod detect;
+pub use detect::detect_content_type;
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p mur-compress detect`
+Expected: 5 tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-compress/src/detect.rs mur-compress/src/lib.rs
+git commit -m "feat(compress): regex content-type detection" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: BM25 ranker (`bm25.rs`)
+
+**Files:**
+- Create: `mur-compress/src/bm25.rs`
+- Modify: `mur-compress/src/lib.rs`
+
+- [ ] **Step 1: Write `mur-compress/src/bm25.rs` with tests**
+
+```rust
+//! Tiny self-contained BM25 over a list of documents (used by query-filtered
+//! retrieve and search-result offload). Returns (index, raw_score) desc.
+
+use std::collections::HashSet;
+
+const K1: f32 = 1.5;
+const B: f32 = 0.75;
+
+fn tokenize(s: &str) -> Vec<String> {
+    s.split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_lowercase())
+        .collect()
+}
+
+pub fn bm25_rank(query: &str, docs: &[String]) -> Vec<(usize, f32)> {
+    let q_terms = tokenize(query);
+    if q_terms.is_empty() || docs.is_empty() {
+        return Vec::new();
+    }
+    let doc_terms: Vec<Vec<String>> = docs.iter().map(|d| tokenize(d)).collect();
+    let n = docs.len() as f32;
+    let total_len: usize = doc_terms.iter().map(|d| d.len()).sum();
+    let avgdl = (total_len as f32 / n).max(1.0);
+
+    let mut scores = vec![0.0f32; docs.len()];
+    let unique_terms: HashSet<&String> = q_terms.iter().collect();
+    for term in unique_terms {
+        let df = doc_terms.iter().filter(|d| d.contains(term)).count() as f32;
+        if df == 0.0 {
+            continue;
+        }
+        let idf = (((n - df + 0.5) / (df + 0.5)) + 1.0).ln();
+        for (i, d) in doc_terms.iter().enumerate() {
+            let tf = d.iter().filter(|t| *t == term).count() as f32;
+            if tf == 0.0 {
+                continue;
+            }
+            let dl = d.len() as f32;
+            scores[i] += idf * (tf * (K1 + 1.0)) / (tf + K1 * (1.0 - B + B * dl / avgdl));
+        }
+    }
+
+    let mut ranked: Vec<(usize, f32)> = scores
+        .into_iter()
+        .enumerate()
+        .filter(|(_, s)| *s > 0.0)
+        .collect();
+    ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    ranked
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ranks_relevant_doc_first() {
+        let docs = vec![
+            "the cat sat on the mat".to_string(),
+            "database connection error retry".to_string(),
+            "weather is nice today".to_string(),
+        ];
+        let ranked = bm25_rank("database error", &docs);
+        assert_eq!(ranked.first().unwrap().0, 1);
+    }
+
+    #[test]
+    fn empty_query_returns_empty() {
+        let docs = vec!["a".to_string()];
+        assert!(bm25_rank("", &docs).is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module** — add to `mur-compress/src/lib.rs`:
+
+```rust
+pub mod bm25;
+pub use bm25::bm25_rank;
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p mur-compress bm25`
+Expected: 2 tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-compress/src/bm25.rs mur-compress/src/lib.rs
+git commit -m "feat(compress): self-contained BM25 ranker" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: CCR store (`ccr/entry.rs`, `ccr/store.rs`, `ccr/mod.rs`)
+
+**Files:**
+- Create: `mur-compress/src/ccr/entry.rs`
+- Create: `mur-compress/src/ccr/store.rs`
+- Create: `mur-compress/src/ccr/mod.rs`
+- Modify: `mur-compress/src/lib.rs`
+
+- [ ] **Step 1: Create `mur-compress/src/ccr/entry.rs`**
+
+```rust
+//! A stored original, retrievable by hash, with parsed items for query filter.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompressedEntry {
+    pub hash: String,
+    pub content_type: String,
+    pub created_at: u64,
+    pub ttl_secs: u64,
+    pub original_text: String,
+    pub items: Vec<String>,
+    pub original_tokens: usize,
+    pub item_count: usize,
+}
+
+impl CompressedEntry {
+    pub fn is_expired(&self, now: u64) -> bool {
+        self.ttl_secs > 0 && now > self.created_at + self.ttl_secs
+    }
+}
+```
+
+- [ ] **Step 2: Create `mur-compress/src/ccr/store.rs`**
+
+```rust
+//! Persistent, bounded CCR store. One JSON(.gz) file per entry under
+//! <dir>/entries/. Atomic temp+rename writes. TTL on read, size/count eviction.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use crate::ccr::entry::CompressedEntry;
+use crate::tokenizer::TokenCounter;
+use crate::types::ContentType;
+
+pub fn hash_content(s: &str) -> String {
+    let hex = blake3::hash(s.as_bytes()).to_hex();
+    hex[..24].to_string()
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn gzip(data: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    enc.write_all(data)?;
+    enc.finish()
+}
+
+fn gunzip(data: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut dec = flate2::read::GzDecoder::new(data);
+    let mut out = Vec::new();
+    dec.read_to_end(&mut out)?;
+    Ok(out)
+}
+
+pub struct CcrStore {
+    entries_dir: PathBuf,
+    ttl_secs: u64,
+    max_entries: usize,
+    max_bytes: u64,
+    compress_at_rest: bool,
+}
+
+impl CcrStore {
+    pub fn new(
+        dir: impl Into<PathBuf>,
+        ttl_secs: u64,
+        max_entries: usize,
+        max_bytes: u64,
+        compress_at_rest: bool,
+    ) -> std::io::Result<Self> {
+        let entries_dir = dir.into().join("entries");
+        std::fs::create_dir_all(&entries_dir)?;
+        Ok(Self { entries_dir, ttl_secs, max_entries, max_bytes, compress_at_rest })
+    }
+
+    pub fn ttl_secs(&self) -> u64 {
+        self.ttl_secs
+    }
+
+    fn path_for(&self, hash: &str) -> PathBuf {
+        let ext = if self.compress_at_rest { "json.gz" } else { "json" };
+        self.entries_dir.join(format!("{hash}.{ext}"))
+    }
+
+    pub fn put(&self, entry: &CompressedEntry) -> std::io::Result<()> {
+        let path = self.path_for(&entry.hash);
+        let json = serde_json::to_vec(entry)?;
+        let bytes = if self.compress_at_rest { gzip(&json)? } else { json };
+        let tmp = path.with_extension("tmp");
+        std::fs::write(&tmp, &bytes)?;
+        std::fs::rename(&tmp, &path)?;
+        self.evict_if_needed()?;
+        Ok(())
+    }
+
+    /// Build + store an entry for `original`, returning its hash.
+    pub fn put_original(
+        &self,
+        original: &str,
+        items: Vec<String>,
+        content_type: ContentType,
+        tok: &dyn TokenCounter,
+    ) -> std::io::Result<String> {
+        let hash = hash_content(original);
+        let item_count = items.len();
+        let entry = CompressedEntry {
+            hash: hash.clone(),
+            content_type: content_type.as_str().to_string(),
+            created_at: now_secs(),
+            ttl_secs: self.ttl_secs,
+            original_text: original.to_string(),
+            items,
+            original_tokens: tok.count(original),
+            item_count,
+        };
+        self.put(&entry)?;
+        Ok(hash)
+    }
+
+    pub fn get(&self, hash: &str) -> std::io::Result<Option<CompressedEntry>> {
+        let path = self.path_for(hash);
+        let raw = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        let json = if self.compress_at_rest { gunzip(&raw)? } else { raw };
+        let entry: CompressedEntry = serde_json::from_slice(&json)?;
+        if entry.is_expired(now_secs()) {
+            let _ = std::fs::remove_file(&path);
+            return Ok(None);
+        }
+        Ok(Some(entry))
+    }
+
+    pub fn stats(&self) -> (usize, u64) {
+        let mut count = 0usize;
+        let mut bytes = 0u64;
+        if let Ok(rd) = std::fs::read_dir(&self.entries_dir) {
+            for e in rd.flatten() {
+                if let Ok(md) = e.metadata() {
+                    if md.is_file() && e.path().extension().is_some_and(|x| x != "tmp") {
+                        count += 1;
+                        bytes += md.len();
+                    }
+                }
+            }
+        }
+        (count, bytes)
+    }
+
+    fn evict_if_needed(&self) -> std::io::Result<()> {
+        let mut files: Vec<(PathBuf, std::time::SystemTime, u64)> = Vec::new();
+        let mut total = 0u64;
+        for e in std::fs::read_dir(&self.entries_dir)? {
+            let e = e?;
+            let md = e.metadata()?;
+            if !md.is_file() {
+                continue;
+            }
+            let mtime = md.modified().unwrap_or(std::time::UNIX_EPOCH);
+            total += md.len();
+            files.push((e.path(), mtime, md.len()));
+        }
+        files.sort_by_key(|(_, t, _)| *t); // oldest first
+        let mut idx = 0;
+        while idx < files.len()
+            && ((files.len() - idx) > self.max_entries || total > self.max_bytes)
+        {
+            let (p, _, sz) = &files[idx];
+            let _ = std::fs::remove_file(p);
+            total = total.saturating_sub(*sz);
+            idx += 1;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tokenizer::HeuristicCounter;
+
+    fn store(dir: &Path, compress: bool) -> CcrStore {
+        CcrStore::new(dir, 3600, 100, 1 << 30, compress).unwrap()
+    }
+
+    #[test]
+    fn put_get_roundtrip_plain_and_gz() {
+        for compress in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let s = store(dir.path(), compress);
+            let h = s
+                .put_original("a\nb\nc", vec!["a".into(), "b".into(), "c".into()], ContentType::SearchResults, &HeuristicCounter)
+                .unwrap();
+            let got = s.get(&h).unwrap().expect("entry exists");
+            assert_eq!(got.original_text, "a\nb\nc");
+            assert_eq!(got.item_count, 3);
+        }
+    }
+
+    #[test]
+    fn expired_entry_is_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        // ttl_secs = 0 means "no expiry"; use 1 and a backdated entry.
+        let s = CcrStore::new(dir.path(), 1, 100, 1 << 30, false).unwrap();
+        let mut entry = CompressedEntry {
+            hash: hash_content("x"),
+            content_type: "generic".into(),
+            created_at: 0, // far in the past
+            ttl_secs: 1,
+            original_text: "x".into(),
+            items: vec![],
+            original_tokens: 1,
+            item_count: 0,
+        };
+        entry.hash = hash_content("x");
+        s.put(&entry).unwrap();
+        assert!(s.get(&entry.hash).unwrap().is_none());
+    }
+
+    #[test]
+    fn missing_hash_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = store(dir.path(), false);
+        assert!(s.get("deadbeef").unwrap().is_none());
+    }
+}
+```
+
+- [ ] **Step 3: Create `mur-compress/src/ccr/mod.rs`**
+
+```rust
+pub mod entry;
+pub mod store;
+
+pub use entry::CompressedEntry;
+pub use store::{hash_content, CcrStore};
+```
+
+- [ ] **Step 4: Wire into `mur-compress/src/lib.rs`**
+
+```rust
+pub mod ccr;
+pub use ccr::{CcrStore, CompressedEntry};
+```
+
+Also make `HeuristicCounter` visible to the store test: in `tokenizer.rs` it is already `pub struct HeuristicCounter;` — confirm it is `pub`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p mur-compress ccr`
+Expected: 3 tests PASS (roundtrip x2 modes, expiry, missing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-compress/src/ccr mur-compress/src/lib.rs
+git commit -m "feat(compress): CCR store (blake3 key, gzip-at-rest, TTL+LRU eviction)" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Fallback compressor (`compressors/fallback.rs`)
+
+**Files:**
+- Create: `mur-compress/src/compressors/fallback.rs`
+- Create: `mur-compress/src/compressors/mod.rs`
+- Modify: `mur-compress/src/lib.rs`
+
+- [ ] **Step 1: Create `mur-compress/src/compressors/fallback.rs`**
+
+```rust
+//! Generic fallback: lossless-ish densify (trim trailing ws, collapse blank
+//! runs). No offload — prose/code are left intact in v1.
+
+use crate::ccr::CcrStore;
+use crate::tokenizer::TokenCounter;
+use crate::types::{CompressCtx, CompressError, CompressOutput};
+
+pub fn compress(
+    content: &str,
+    _ctx: &CompressCtx,
+    _store: &CcrStore,
+    _tok: &dyn TokenCounter,
+) -> Result<CompressOutput, CompressError> {
+    let mut out = String::with_capacity(content.len());
+    let mut blank_run = 0;
+    for line in content.lines() {
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            blank_run += 1;
+            if blank_run > 1 {
+                continue;
+            }
+        } else {
+            blank_run = 0;
+        }
+        out.push_str(trimmed);
+        out.push('\n');
+    }
+    if !content.ends_with('\n') {
+        out.pop();
+    }
+    Ok(CompressOutput {
+        compressed: out,
+        hash: None,
+        transforms: vec!["fallback.whitespace".into()],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CompressConfig;
+    use crate::tokenizer::HeuristicCounter;
+
+    #[test]
+    fn collapses_blank_runs_and_trailing_ws() {
+        let cfg = CompressConfig::default();
+        let dir = tempfile::tempdir().unwrap();
+        let store = CcrStore::new(dir.path(), 3600, 10, 1 << 30, false).unwrap();
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let input = "line one   \n\n\n\nline two\n";
+        let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert_eq!(out.compressed, "line one\n\nline two\n");
+        assert!(out.hash.is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Create `mur-compress/src/compressors/mod.rs`**
+
+```rust
+pub mod fallback;
+// search, log, diff, json added in Tasks 9–12.
+```
+
+- [ ] **Step 3: Wire into `mur-compress/src/lib.rs`**
+
+```rust
+pub mod compressors;
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p mur-compress fallback`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-compress/src/compressors mur-compress/src/lib.rs
+git commit -m "feat(compress): fallback whitespace compressor" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Search compressor (`compressors/search.rs`)
+
+**Files:**
+- Create: `mur-compress/src/compressors/search.rs`
+- Modify: `mur-compress/src/compressors/mod.rs`
+
+- [ ] **Step 1: Create `mur-compress/src/compressors/search.rs`**
+
+```rust
+//! Search-result compressor. Reformat: group hits by file. Offload: with a
+//! query keep top-K by BM25, else keep the head window; stash the rest.
+
+use crate::bm25::bm25_rank;
+use crate::ccr::CcrStore;
+use crate::tokenizer::TokenCounter;
+use crate::types::{CompressCtx, CompressError, CompressOutput, ContentType};
+
+fn file_of(line: &str) -> &str {
+    // "path:line:content" -> "path"
+    line.split(':').next().unwrap_or("")
+}
+
+fn group_by_file(items: &[String]) -> String {
+    let mut out = String::new();
+    let mut current = "";
+    for it in items {
+        let f = file_of(it);
+        if f != current {
+            out.push_str(&format!("{f}:\n"));
+            current = f;
+        }
+        // strip the leading "path:" so the file header carries it
+        let rest = it.strip_prefix(f).and_then(|r| r.strip_prefix(':')).unwrap_or(it);
+        out.push_str("  ");
+        out.push_str(rest);
+        out.push('\n');
+    }
+    out
+}
+
+pub fn compress(
+    content: &str,
+    ctx: &CompressCtx,
+    store: &CcrStore,
+    tok: &dyn TokenCounter,
+) -> Result<CompressOutput, CompressError> {
+    let items: Vec<String> = content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|s| s.to_string())
+        .collect();
+    let mut transforms = vec!["search.group_by_file".to_string()];
+    let cfg = ctx.config;
+
+    let keep_idx: Vec<usize> = if let Some(q) = ctx.query {
+        let ranked = bm25_rank(q, &items);
+        if ranked.is_empty() {
+            (0..items.len().min(cfg.protect_head_lines)).collect()
+        } else {
+            let mut idx: Vec<usize> =
+                ranked.into_iter().take(cfg.retrieve_top_k).map(|(i, _)| i).collect();
+            idx.sort_unstable();
+            idx
+        }
+    } else {
+        (0..items.len().min(cfg.protect_head_lines)).collect()
+    };
+
+    if keep_idx.len() >= items.len() {
+        return Ok(CompressOutput {
+            compressed: group_by_file(&items),
+            hash: None,
+            transforms,
+        });
+    }
+
+    let hash = store
+        .put_original(content, items.clone(), ContentType::SearchResults, tok)
+        .map_err(|e| CompressError::Store(e.to_string()))?;
+    transforms.push("search.offload".to_string());
+
+    let kept: Vec<String> = keep_idx.iter().map(|&i| items[i].clone()).collect();
+    let mut body = group_by_file(&kept);
+    body.push_str(&format!(
+        "[{} of {} hits shown; {} offloaded. Retrieve all with hash={}]\n",
+        kept.len(),
+        items.len(),
+        items.len() - kept.len(),
+        hash
+    ));
+    Ok(CompressOutput { compressed: body, hash: Some(hash), transforms })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CompressConfig;
+    use crate::tokenizer::HeuristicCounter;
+
+    fn mk(dir: &std::path::Path) -> CcrStore {
+        CcrStore::new(dir, 3600, 100, 1 << 30, false).unwrap()
+    }
+
+    #[test]
+    fn offloads_tail_and_keeps_query_relevant() {
+        let mut cfg = CompressConfig::default();
+        cfg.protect_head_lines = 1;
+        cfg.retrieve_top_k = 1;
+        let dir = tempfile::tempdir().unwrap();
+        let store = mk(dir.path());
+        let ctx = CompressCtx { query: Some("database"), config: &cfg };
+        let input = "a.rs:1:hello world\nb.rs:2:database connection\nc.rs:3:weather";
+        let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.hash.is_some());
+        assert!(out.compressed.contains("database connection"));
+        assert!(out.compressed.contains("hash="));
+        // original retrievable
+        let got = store.get(out.hash.as_ref().unwrap()).unwrap().unwrap();
+        assert_eq!(got.item_count, 3);
+    }
+}
+```
+
+- [ ] **Step 2: Register the module** — in `mur-compress/src/compressors/mod.rs` add `pub mod search;`
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p mur-compress search`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-compress/src/compressors/search.rs mur-compress/src/compressors/mod.rs
+git commit -m "feat(compress): search compressor (group-by-file + query offload)" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Log compressor (`compressors/log.rs`)
+
+**Files:**
+- Create: `mur-compress/src/compressors/log.rs`
+- Modify: `mur-compress/src/compressors/mod.rs`
+
+- [ ] **Step 1: Create `mur-compress/src/compressors/log.rs`**
+
+```rust
+//! Log compressor. Reformat: collapse consecutive duplicate lines into
+//! "<line>  (xN)". Offload: keep ERROR/WARN/FATAL + head/tail; stash full log.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::ccr::CcrStore;
+use crate::tokenizer::TokenCounter;
+use crate::types::{CompressCtx, CompressError, CompressOutput, ContentType};
+
+static IMPORTANT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)\b(ERROR|WARN|WARNING|FATAL|PANIC|FAIL)\b").unwrap());
+
+fn collapse_repeats(lines: &[String]) -> String {
+    let mut out = String::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let mut count = 1;
+        while i + count < lines.len() && lines[i + count] == lines[i] {
+            count += 1;
+        }
+        out.push_str(&lines[i]);
+        if count > 1 {
+            out.push_str(&format!("  (x{count})"));
+        }
+        out.push('\n');
+        i += count;
+    }
+    out
+}
+
+pub fn compress(
+    content: &str,
+    ctx: &CompressCtx,
+    store: &CcrStore,
+    tok: &dyn TokenCounter,
+) -> Result<CompressOutput, CompressError> {
+    let items: Vec<String> = content.lines().map(|s| s.to_string()).collect();
+    let cfg = ctx.config;
+    let mut transforms = vec!["log.collapse_repeats".to_string()];
+    let n = items.len();
+
+    let keep_idx: Vec<usize> = (0..n)
+        .filter(|&i| {
+            i < cfg.protect_head_lines
+                || i >= n.saturating_sub(cfg.protect_tail_lines)
+                || IMPORTANT.is_match(&items[i])
+        })
+        .collect();
+
+    if keep_idx.len() >= n {
+        return Ok(CompressOutput {
+            compressed: collapse_repeats(&items),
+            hash: None,
+            transforms,
+        });
+    }
+
+    let hash = store
+        .put_original(content, items.clone(), ContentType::BuildLog, tok)
+        .map_err(|e| CompressError::Store(e.to_string()))?;
+    transforms.push("log.offload".to_string());
+
+    let kept: Vec<String> = keep_idx.iter().map(|&i| items[i].clone()).collect();
+    let mut body = collapse_repeats(&kept);
+    body.push_str(&format!(
+        "[{} of {} log lines shown; {} offloaded. Full log: hash={}]\n",
+        kept.len(),
+        n,
+        n - kept.len(),
+        hash
+    ));
+    Ok(CompressOutput { compressed: body, hash: Some(hash), transforms })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CompressConfig;
+    use crate::tokenizer::HeuristicCounter;
+
+    #[test]
+    fn keeps_errors_offloads_noise() {
+        let mut cfg = CompressConfig::default();
+        cfg.protect_head_lines = 0;
+        cfg.protect_tail_lines = 0;
+        let dir = tempfile::tempdir().unwrap();
+        let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let mut lines = vec![];
+        for _ in 0..50 {
+            lines.push("DEBUG noise".to_string());
+        }
+        lines.push("ERROR boom".to_string());
+        let input = lines.join("\n");
+        let out = compress(&input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.compressed.contains("ERROR boom"));
+        assert!(out.hash.is_some());
+        assert!(out.compressed.contains("offloaded"));
+    }
+}
+```
+
+- [ ] **Step 2: Register the module** — in `mur-compress/src/compressors/mod.rs` add `pub mod log;`
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p mur-compress compressors::log`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-compress/src/compressors/log.rs mur-compress/src/compressors/mod.rs
+git commit -m "feat(compress): log compressor (repeat-collapse + noise offload)" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Diff compressor (`compressors/diff.rs`)
+
+**Files:**
+- Create: `mur-compress/src/compressors/diff.rs`
+- Modify: `mur-compress/src/compressors/mod.rs`
+
+- [ ] **Step 1: Create `mur-compress/src/compressors/diff.rs`**
+
+```rust
+//! Diff compressor. Reformat+Offload: keep headers and changed (+/-) lines;
+//! collapse long unchanged-context runs (>3 lines) to a marker; stash full diff.
+
+use crate::ccr::CcrStore;
+use crate::tokenizer::TokenCounter;
+use crate::types::{CompressCtx, CompressError, CompressOutput, ContentType};
+
+const CONTEXT_KEEP: usize = 3;
+
+fn is_header(l: &str) -> bool {
+    l.starts_with("diff ")
+        || l.starts_with("@@")
+        || l.starts_with("--- ")
+        || l.starts_with("+++ ")
+        || l.starts_with("index ")
+}
+
+pub fn compress(
+    content: &str,
+    _ctx: &CompressCtx,
+    store: &CcrStore,
+    tok: &dyn TokenCounter,
+) -> Result<CompressOutput, CompressError> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut transforms = vec!["diff.trim_context".to_string()];
+    let mut kept: Vec<String> = Vec::new();
+    let mut context_run = 0usize;
+    let mut dropped = 0usize;
+
+    for l in &lines {
+        let change = l.starts_with('+') || l.starts_with('-');
+        let header = is_header(l);
+        let context = !change && !header;
+        if context {
+            context_run += 1;
+            if context_run <= CONTEXT_KEEP {
+                kept.push((*l).to_string());
+            } else {
+                dropped += 1;
+            }
+        } else {
+            if context_run > CONTEXT_KEEP {
+                kept.push(format!("... ({} unchanged lines)", context_run - CONTEXT_KEEP));
+            }
+            context_run = 0;
+            kept.push((*l).to_string());
+        }
+    }
+    if context_run > CONTEXT_KEEP {
+        kept.push(format!("... ({} unchanged lines)", context_run - CONTEXT_KEEP));
+    }
+
+    if dropped == 0 {
+        return Ok(CompressOutput {
+            compressed: content.to_string(),
+            hash: None,
+            transforms,
+        });
+    }
+
+    let items: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
+    let hash = store
+        .put_original(content, items, ContentType::GitDiff, tok)
+        .map_err(|e| CompressError::Store(e.to_string()))?;
+    transforms.push("diff.offload".to_string());
+
+    let mut body = kept.join("\n");
+    body.push_str(&format!(
+        "\n[diff context trimmed; {dropped} lines offloaded. Full diff: hash={hash}]"
+    ));
+    Ok(CompressOutput { compressed: body, hash: Some(hash), transforms })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CompressConfig;
+    use crate::tokenizer::HeuristicCounter;
+
+    #[test]
+    fn trims_large_unchanged_context() {
+        let cfg = CompressConfig::default();
+        let dir = tempfile::tempdir().unwrap();
+        let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let mut s = String::from("diff --git a/x b/x\n@@ -1,20 +1,20 @@\n");
+        for _ in 0..20 {
+            s.push_str(" unchanged\n");
+        }
+        s.push_str("+added line\n");
+        let out = compress(&s, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.compressed.contains("+added line"));
+        assert!(out.compressed.contains("unchanged lines)"));
+        assert!(out.hash.is_some());
+    }
+}
+```
+
+- [ ] **Step 2: Register the module** — in `mur-compress/src/compressors/mod.rs` add `pub mod diff;`
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p mur-compress compressors::diff`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-compress/src/compressors/diff.rs mur-compress/src/compressors/mod.rs
+git commit -m "feat(compress): diff compressor (context trim + offload)" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: JSON compressor (`compressors/json.rs`)
+
+**Files:**
+- Create: `mur-compress/src/compressors/json.rs`
+- Modify: `mur-compress/src/compressors/mod.rs`
+
+- [ ] **Step 1: Create `mur-compress/src/compressors/json.rs`**
+
+```rust
+//! JSON compressor. Reformat: minify. Offload (SmartCrusher-lite): for a long
+//! top-level array, emit schema keys + first-N sample + count; stash full array.
+
+use crate::ccr::CcrStore;
+use crate::tokenizer::TokenCounter;
+use crate::types::{CompressCtx, CompressError, CompressOutput, ContentType};
+
+const MIN_ARRAY_FOR_COLLAPSE: usize = 4;
+
+pub fn compress(
+    content: &str,
+    ctx: &CompressCtx,
+    store: &CcrStore,
+    tok: &dyn TokenCounter,
+) -> Result<CompressOutput, CompressError> {
+    let val: serde_json::Value =
+        serde_json::from_str(content.trim()).map_err(|e| CompressError::Parse(e.to_string()))?;
+    let mut transforms = vec!["json.minify".to_string()];
+    let minified =
+        serde_json::to_string(&val).map_err(|e| CompressError::Parse(e.to_string()))?;
+    let cfg = ctx.config;
+
+    if let serde_json::Value::Array(arr) = &val {
+        let sample_n = cfg.protect_head_lines.min(arr.len());
+        if arr.len() >= MIN_ARRAY_FOR_COLLAPSE && arr.len() > sample_n {
+            let keys: Vec<String> = match arr.first() {
+                Some(serde_json::Value::Object(m)) => m.keys().cloned().collect(),
+                _ => Vec::new(),
+            };
+            let items: Vec<String> =
+                arr.iter().map(|v| serde_json::to_string(v).unwrap_or_default()).collect();
+            let hash = store
+                .put_original(content, items, ContentType::Json, tok)
+                .map_err(|e| CompressError::Store(e.to_string()))?;
+            transforms.push("json.row_collapse".to_string());
+
+            let sample = serde_json::Value::Array(arr[..sample_n].to_vec());
+            let body = serde_json::json!({
+                "_schema": keys,
+                "_total": arr.len(),
+                "_shown": sample_n,
+                "sample": sample,
+                "_note": format!("{} rows collapsed; full array hash={}", arr.len() - sample_n, hash),
+            });
+            return Ok(CompressOutput {
+                compressed: serde_json::to_string(&body).unwrap_or(minified),
+                hash: Some(hash),
+                transforms,
+            });
+        }
+    }
+
+    Ok(CompressOutput { compressed: minified, hash: None, transforms })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CompressConfig;
+    use crate::tokenizer::HeuristicCounter;
+
+    #[test]
+    fn collapses_long_array() {
+        let mut cfg = CompressConfig::default();
+        cfg.protect_head_lines = 2;
+        let dir = tempfile::tempdir().unwrap();
+        let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let input = r#"[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6}]"#;
+        let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.hash.is_some());
+        assert!(out.compressed.contains("_total"));
+        let got = store.get(out.hash.as_ref().unwrap()).unwrap().unwrap();
+        assert_eq!(got.item_count, 6);
+    }
+
+    #[test]
+    fn minifies_short_json() {
+        let cfg = CompressConfig::default();
+        let dir = tempfile::tempdir().unwrap();
+        let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let out = compress("{\n  \"a\": 1\n}", &ctx, &store, &HeuristicCounter).unwrap();
+        assert_eq!(out.compressed, r#"{"a":1}"#);
+        assert!(out.hash.is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Register the module** — in `mur-compress/src/compressors/mod.rs` add `pub mod json;`
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p mur-compress compressors::json`
+Expected: 2 tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-compress/src/compressors/json.rs mur-compress/src/compressors/mod.rs
+git commit -m "feat(compress): json compressor (minify + array row-collapse)" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Stats tracker (`stats.rs`)
+
+**Files:**
+- Create: `mur-compress/src/stats.rs`
+- Modify: `mur-compress/src/lib.rs`
+
+- [ ] **Step 1: Create `mur-compress/src/stats.rs`**
+
+```rust
+//! Persistent savings stats (atomic JSON at <store>/stats.json).
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct StatsData {
+    compressions: u64,
+    retrievals: u64,
+    total_input_tokens: u64,
+    total_output_tokens: u64,
+    total_tokens_saved: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct StatsSnapshot {
+    pub compressions: u64,
+    pub retrievals: u64,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub total_tokens_saved: u64,
+    pub savings_percent: f32,
+    pub estimated_cost_saved_usd: f64,
+    pub store_entries: usize,
+    pub store_bytes: u64,
+}
+
+pub struct StatsTracker {
+    path: PathBuf,
+    inner: Mutex<StatsData>,
+}
+
+impl StatsTracker {
+    pub fn new(path: PathBuf) -> Self {
+        let inner = std::fs::read(&path)
+            .ok()
+            .and_then(|b| serde_json::from_slice::<StatsData>(&b).ok())
+            .unwrap_or_default();
+        Self { path, inner: Mutex::new(inner) }
+    }
+
+    fn flush(&self, d: &StatsData) {
+        if let Ok(bytes) = serde_json::to_vec(d) {
+            let tmp = self.path.with_extension("tmp");
+            if std::fs::write(&tmp, &bytes).is_ok() {
+                let _ = std::fs::rename(&tmp, &self.path);
+            }
+        }
+    }
+
+    pub fn record_compression(&self, before: usize, after: usize) {
+        let mut d = self.inner.lock().unwrap();
+        d.compressions += 1;
+        d.total_input_tokens += before as u64;
+        d.total_output_tokens += after as u64;
+        d.total_tokens_saved += before.saturating_sub(after) as u64;
+        self.flush(&d);
+    }
+
+    pub fn record_retrieval(&self) {
+        let mut d = self.inner.lock().unwrap();
+        d.retrievals += 1;
+        self.flush(&d);
+    }
+
+    pub fn snapshot(&self, cost_per_mtok_usd: f64, store_entries: usize, store_bytes: u64) -> StatsSnapshot {
+        let d = self.inner.lock().unwrap().clone();
+        let pct = if d.total_input_tokens > 0 {
+            d.total_tokens_saved as f32 / d.total_input_tokens as f32 * 100.0
+        } else {
+            0.0
+        };
+        let cost = d.total_tokens_saved as f64 * cost_per_mtok_usd / 1_000_000.0;
+        StatsSnapshot {
+            compressions: d.compressions,
+            retrievals: d.retrievals,
+            total_input_tokens: d.total_input_tokens,
+            total_output_tokens: d.total_output_tokens,
+            total_tokens_saved: d.total_tokens_saved,
+            savings_percent: pct,
+            estimated_cost_saved_usd: cost,
+            store_entries,
+            store_bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accumulates_and_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stats.json");
+        let t = StatsTracker::new(path.clone());
+        t.record_compression(100, 30);
+        t.record_retrieval();
+        let snap = t.snapshot(3.0, 1, 123);
+        assert_eq!(snap.compressions, 1);
+        assert_eq!(snap.total_tokens_saved, 70);
+        assert!((snap.savings_percent - 70.0).abs() < 0.01);
+        // reload from disk
+        let t2 = StatsTracker::new(path);
+        let snap2 = t2.snapshot(3.0, 0, 0);
+        assert_eq!(snap2.total_tokens_saved, 70);
+    }
+}
+```
+
+- [ ] **Step 2: Wire into `mur-compress/src/lib.rs`**
+
+```rust
+pub mod stats;
+pub use stats::{StatsSnapshot, StatsTracker};
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p mur-compress stats`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-compress/src/stats.rs mur-compress/src/lib.rs
+git commit -m "feat(compress): persistent savings stats tracker" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: Orchestrator `CompressEngine` + end-to-end tests
+
+**Files:**
+- Modify: `mur-compress/src/lib.rs` (add the engine)
+- Create: `mur-compress/tests/end_to_end.rs`
+
+- [ ] **Step 1: Append the engine to `mur-compress/src/lib.rs`**
+
+```rust
+use std::path::PathBuf;
+
+use crate::compressors::{diff, fallback, json, log, search};
+// IMPORTANT: do NOT add `use crate::ccr::CcrStore;`, `use crate::config::CompressConfig;`,
+// `use crate::tokenizer::{default_counter, TokenCounter};`, etc. Those names are already
+// in crate-root scope via the `pub use` re-exports added in earlier tasks (and the
+// `pub use config::CompressConfig;` below). Re-`use`-ing them here causes
+// "the name `X` is defined multiple times" compile errors.
+
+/// Top-level engine: owns the store, tokenizer, config, and stats.
+pub struct CompressEngine {
+    store: CcrStore,
+    tok: Box<dyn TokenCounter>,
+    config: CompressConfig,
+    stats: StatsTracker,
+}
+
+impl CompressEngine {
+    pub fn new(dir: impl Into<PathBuf>, config: CompressConfig) -> std::io::Result<Self> {
+        let dir = dir.into();
+        let store = CcrStore::new(
+            &dir,
+            config.ttl_secs(),
+            config.store.max_entries,
+            config.store.max_bytes,
+            config.store.compress_at_rest,
+        )?;
+        let stats = StatsTracker::new(dir.join("stats.json"));
+        Ok(Self { store, tok: default_counter(), config, stats })
+    }
+
+    fn dispatch(
+        &self,
+        ct: ContentType,
+        content: &str,
+        ctx: &CompressCtx,
+    ) -> Result<CompressOutput, CompressError> {
+        match ct {
+            ContentType::SearchResults => search::compress(content, ctx, &self.store, self.tok.as_ref()),
+            ContentType::BuildLog => log::compress(content, ctx, &self.store, self.tok.as_ref()),
+            ContentType::GitDiff => diff::compress(content, ctx, &self.store, self.tok.as_ref()),
+            ContentType::Json => json::compress(content, ctx, &self.store, self.tok.as_ref()),
+            ContentType::Generic => fallback::compress(content, ctx, &self.store, self.tok.as_ref()),
+        }
+    }
+
+    /// Compress `content`. Never errors: any failure returns the original.
+    pub fn compress(&self, content: &str, query: Option<&str>) -> CompressResult {
+        let ct = detect_content_type(content, &self.config);
+        let ctx = CompressCtx { query, config: &self.config };
+        let out = self.dispatch(ct, content, &ctx).unwrap_or_else(|_| CompressOutput {
+            compressed: content.to_string(),
+            hash: None,
+            transforms: Vec::new(),
+        });
+
+        let before = self.tok.count(content);
+        let after = self.tok.count(&out.compressed);
+        let saved = before.saturating_sub(after);
+        let pct = if before > 0 { saved as f32 / before as f32 * 100.0 } else { 0.0 };
+        self.stats.record_compression(before, after);
+
+        CompressResult {
+            compressed: out.compressed,
+            hash: out.hash,
+            original_tokens: before,
+            compressed_tokens: after,
+            tokens_saved: saved,
+            savings_percent: pct,
+            transforms: out.transforms,
+            content_type: ct,
+        }
+    }
+
+    /// Retrieve a stored original by hash, optionally BM25-filtered by query.
+    pub fn retrieve(&self, hash: &str, query: Option<&str>) -> RetrieveResult {
+        let entry = match self.store.get(hash) {
+            Ok(Some(e)) => e,
+            _ => return RetrieveResult::NotFound,
+        };
+        self.stats.record_retrieval();
+        match query {
+            Some(q) => {
+                let ranked = bm25_rank(q, &entry.items);
+                let max = ranked.first().map(|(_, s)| *s).unwrap_or(1.0).max(1e-6);
+                let results: Vec<String> = ranked
+                    .into_iter()
+                    .map(|(i, s)| (i, s / max))
+                    .filter(|(_, s)| *s >= self.config.retrieve_score_threshold)
+                    .take(self.config.retrieve_top_k)
+                    .map(|(i, _)| entry.items[i].clone())
+                    .collect();
+                RetrieveResult::Filtered { query: q.to_string(), count: results.len(), results }
+            }
+            None => RetrieveResult::Full {
+                content_type: entry.content_type,
+                original_content: entry.original_text,
+                item_count: entry.item_count,
+            },
+        }
+    }
+
+    pub fn stats_snapshot(&self) -> StatsSnapshot {
+        let (entries, bytes) = self.store.stats();
+        self.stats.snapshot(self.config.stats.cost_per_mtok_usd, entries, bytes)
+    }
+}
+```
+
+Add the matching re-export near the top re-exports:
+
+```rust
+pub use config::CompressConfig;
+```
+
+- [ ] **Step 2: Create `mur-compress/tests/end_to_end.rs`**
+
+```rust
+use mur_compress::{CompressConfig, CompressEngine, RetrieveResult};
+
+fn engine(dir: &std::path::Path) -> CompressEngine {
+    let mut cfg = CompressConfig::default();
+    cfg.protect_head_lines = 2;
+    cfg.protect_tail_lines = 1;
+    cfg.store.compress_at_rest = false;
+    CompressEngine::new(dir, cfg).unwrap()
+}
+
+#[test]
+fn search_compress_then_retrieve_is_reversible() {
+    let dir = tempfile::tempdir().unwrap();
+    let eng = engine(dir.path());
+    let mut lines = Vec::new();
+    for i in 0..40 {
+        lines.push(format!("src/file{i}.rs:{i}:some content number {i}"));
+    }
+    let input = lines.join("\n");
+
+    let res = eng.compress(&input, Some("content number 7"));
+    assert!(res.hash.is_some(), "large search output should offload");
+    assert!(res.tokens_saved > 0);
+
+    // Full retrieve reproduces the original exactly.
+    match eng.retrieve(res.hash.as_ref().unwrap(), None) {
+        RetrieveResult::Full { original_content, item_count, .. } => {
+            assert_eq!(original_content, input);
+            assert_eq!(item_count, 40);
+        }
+        _ => panic!("expected Full"),
+    }
+
+    // Query-filtered retrieve returns relevant items.
+    match eng.retrieve(res.hash.as_ref().unwrap(), Some("number 7")) {
+        RetrieveResult::Filtered { count, results, .. } => {
+            assert!(count > 0);
+            assert!(results.iter().any(|r| r.contains("number 7")));
+        }
+        _ => panic!("expected Filtered"),
+    }
+}
+
+#[test]
+fn fail_safe_passthrough_on_generic_prose() {
+    let dir = tempfile::tempdir().unwrap();
+    let eng = engine(dir.path());
+    let input = "This is ordinary prose that should not be aggressively compressed.";
+    let res = eng.compress(input, None);
+    // generic -> fallback, no offload, no data loss of words
+    assert!(res.hash.is_none());
+    assert!(res.compressed.contains("ordinary prose"));
+}
+
+#[test]
+fn retrieve_unknown_hash_is_not_found() {
+    let dir = tempfile::tempdir().unwrap();
+    let eng = engine(dir.path());
+    assert!(matches!(eng.retrieve("nope", None), RetrieveResult::NotFound));
+}
+
+#[test]
+fn json_array_roundtrips_through_store() {
+    let dir = tempfile::tempdir().unwrap();
+    let eng = engine(dir.path());
+    let input = r#"[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8}]"#;
+    let res = eng.compress(input, None);
+    assert!(res.hash.is_some());
+    match eng.retrieve(res.hash.as_ref().unwrap(), None) {
+        RetrieveResult::Full { original_content, .. } => assert_eq!(original_content, input),
+        _ => panic!("expected Full"),
+    }
+}
+```
+
+- [ ] **Step 3: Run the whole crate's tests**
+
+Run: `cargo test -p mur-compress`
+Expected: all unit tests + 4 end-to-end tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-compress/src/lib.rs mur-compress/tests/end_to_end.rs
+git commit -m "feat(compress): CompressEngine orchestrator + reversibility tests" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: Wire the three MCP tools
+
+**Files:**
+- Modify: `mur-mcp-server/Cargo.toml`
+- Modify: `mur-mcp-server/src/tools.rs`
+- Modify: `mur-mcp-server/tests/integration.rs`
+
+- [ ] **Step 1: Add the dependency** — in `mur-mcp-server/Cargo.toml` under `[dependencies]` add:
+
+```toml
+mur-compress = { path = "../mur-compress" }
+```
+
+- [ ] **Step 2: Add an `engine()` helper + tool registrations in `mur-mcp-server/src/tools.rs`**
+
+At the top of the file (after the existing `use` lines), add:
+
+```rust
+use mur_compress::{CompressConfig, CompressEngine, RetrieveResult};
+
+/// Build a per-call compression engine rooted at <mur_home>/compress.
+fn compress_engine() -> Result<CompressEngine, String> {
+    let home = mur_common::trust::mur_home();
+    let cfg = CompressConfig::load(&home);
+    CompressEngine::new(home.join("compress"), cfg)
+        .map_err(|e| format!("compress engine unavailable: {e}"))
+}
+```
+
+In `all_tools()`, insert these three `Tool` literals just before the closing `]` of the `vec![` (i.e., after the last existing tool, before line ~214):
+
+```rust
+        // ── compress tools ──
+        Tool {
+            name: "mur_compress".into(),
+            description: "Compress bulky agent text (tool output, logs, search results, diffs, JSON) before it reaches the LLM. Reversible: the original is stored locally and retrievable by hash via mur_retrieve.".into(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".into(),
+                properties: Some(BTreeMap::from([
+                    ("content".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "The text to compress.".into(),
+                        default: None,
+                    }),
+                    ("query".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "Optional query to bias which lines/items are kept.".into(),
+                        default: None,
+                    }),
+                ])),
+                required: Some(vec!["content".into()]),
+            },
+        },
+        Tool {
+            name: "mur_retrieve".into(),
+            description: "Retrieve the original content stored by mur_compress, by its hash. With a query, returns only the BM25-relevant items.".into(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".into(),
+                properties: Some(BTreeMap::from([
+                    ("hash".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "Hash from a prior mur_compress result (e.g. hash=abc123...).".into(),
+                        default: None,
+                    }),
+                    ("query".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "Optional query to filter the stored items.".into(),
+                        default: None,
+                    }),
+                ])),
+                required: Some(vec!["hash".into()]),
+            },
+        },
+        Tool {
+            name: "mur_compress_stats".into(),
+            description: "Show cumulative token-compression savings (compressions, tokens saved, % saved, estimated cost saved, store size).".into(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".into(),
+                properties: None,
+                required: None,
+            },
+        },
+```
+
+- [ ] **Step 3: Add the three dispatch arms in `call_tool`**
+
+In `mur-mcp-server/src/tools.rs`, inside `call_tool`, add these arms before the final `_ => Err(format!("Unknown tool: {}", name)),`:
+
+```rust
+        "mur_compress" => {
+            let content = arguments
+                .get("content")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "Missing required parameter: 'content' (string)".to_string())?;
+            let query = arguments.get("query").and_then(|v| v.as_str());
+
+            let eng = compress_engine()?;
+            let r = eng.compress(content, query);
+            let note = match &r.hash {
+                Some(h) => format!(
+                    "Original stored with hash={h}. Use mur_retrieve to fetch full content."
+                ),
+                None => "No content offloaded; nothing to retrieve.".to_string(),
+            };
+            Ok(json!({
+                "compressed": r.compressed,
+                "hash": r.hash,
+                "content_type": r.content_type.as_str(),
+                "original_tokens": r.original_tokens,
+                "compressed_tokens": r.compressed_tokens,
+                "tokens_saved": r.tokens_saved,
+                "savings_percent": r.savings_percent,
+                "transforms": r.transforms,
+                "note": note,
+            }))
+        }
+
+        "mur_retrieve" => {
+            let hash = arguments
+                .get("hash")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "Missing required parameter: 'hash' (string)".to_string())?;
+            let query = arguments.get("query").and_then(|v| v.as_str());
+
+            let eng = compress_engine()?;
+            match eng.retrieve(hash, query) {
+                RetrieveResult::Full { content_type, original_content, item_count } => Ok(json!({
+                    "hash": hash,
+                    "content_type": content_type,
+                    "original_content": original_content,
+                    "item_count": item_count,
+                })),
+                RetrieveResult::Filtered { query, results, count } => Ok(json!({
+                    "hash": hash,
+                    "query": query,
+                    "results": results,
+                    "count": count,
+                })),
+                RetrieveResult::NotFound => Ok(json!({
+                    "error": "Content not found or expired.",
+                    "hash": hash,
+                    "hint": "The hash may be wrong or the entry's TTL has elapsed.",
+                })),
+            }
+        }
+
+        "mur_compress_stats" => {
+            let eng = compress_engine()?;
+            let s = eng.stats_snapshot();
+            Ok(json!({
+                "compressions": s.compressions,
+                "retrievals": s.retrievals,
+                "total_input_tokens": s.total_input_tokens,
+                "total_output_tokens": s.total_output_tokens,
+                "total_tokens_saved": s.total_tokens_saved,
+                "savings_percent": s.savings_percent,
+                "estimated_cost_saved_usd": s.estimated_cost_saved_usd,
+                "store": { "entries": s.store_entries, "bytes": s.store_bytes },
+            }))
+        }
+```
+
+> `mur-mcp-server` is a **binary-only crate** (no `lib.rs`); its tests spawn the built binary and drive it over stdio JSON-RPC. So the new tests follow that exact pattern — do NOT try to import `call_tool` directly.
+
+- [ ] **Step 4a: Update the existing tool-count assertion** in `mur-mcp-server/tests/integration.rs`
+
+The test `test_initialize_and_list_tools` hard-codes the tool count. Adding 3 tools changes 10 → 13. Change line ~56:
+
+```rust
+    assert_eq!(tools.len(), 13, "Expected 13 tools");
+```
+
+And add three name assertions next to the existing `names.contains(...)` block (after the `scene_explain` assertion):
+
+```rust
+    assert!(names.contains(&"mur_compress"));
+    assert!(names.contains(&"mur_retrieve"));
+    assert!(names.contains(&"mur_compress_stats"));
+```
+
+- [ ] **Step 4b: Add a `tempfile` dev-dependency** to `mur-mcp-server/Cargo.toml`
+
+```toml
+[dev-dependencies]
+tempfile = "3"
+```
+
+- [ ] **Step 4c: Add a stdio call test** — append to `mur-mcp-server/tests/integration.rs`:
+
+```rust
+#[test]
+fn calls_mur_compress_tool() {
+    // Isolate the CCR store in a throwaway MUR_HOME for the child process.
+    let home = tempfile::tempdir().unwrap();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mur-mcp-server"))
+        .env("MUR_HOME", home.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = std::io::BufReader::new(child.stdout.take().unwrap());
+
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+    );
+    let _ = read_response(&mut stdout);
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+    );
+    let _ = read_response(&mut stdout);
+
+    // A long search-style payload that should compress and offload.
+    let mut lines = Vec::new();
+    for i in 0..40 {
+        lines.push(format!("src/f{i}.rs:{i}:token number {i}"));
+    }
+    let content = lines.join("\n");
+    let req = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": { "name": "mur_compress", "arguments": { "content": content, "query": "number 7" } }
+    })
+    .to_string();
+    send_request(&mut stdin, &req);
+    let resp = read_response(&mut stdout);
+
+    // The tool's JSON result is embedded in the MCP content array; rather than
+    // depend on the exact nesting, assert the markers appear anywhere in the response.
+    let resp_str = serde_json::to_string(&resp).unwrap();
+    assert!(
+        resp_str.contains("tokens_saved"),
+        "mur_compress result missing tokens_saved: {resp_str}"
+    );
+    assert!(
+        resp_str.contains("hash="),
+        "mur_compress result should include a retrieval-hash note: {resp_str}"
+    );
+
+    child.kill().ok();
+}
+```
+
+- [ ] **Step 5: Build & test**
+
+Run: `cargo test -p mur-mcp-server`
+Expected: the updated `test_initialize_and_list_tools` (now 13 tools) + the new `calls_mur_compress_tool` PASS, alongside the existing tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-mcp-server/Cargo.toml mur-mcp-server/src/tools.rs mur-mcp-server/tests/integration.rs
+git commit -m "feat(mcp): wire mur_compress/mur_retrieve/mur_compress_stats tools" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 16: Optional CLI (`mur compress` / `mur retrieve`)
+
+> **Optional / cuttable.** Skip if you only need the MCP surface. This adds the same capability to the `mur` binary for manual testing.
+
+**Files:**
+- Create: `mur-core/src/cmd/compress.rs`
+- Modify: `mur-core/src/cmd/mod.rs` (register the module)
+- Modify: the `mur` clap command tree (wherever top-level subcommands are defined)
+
+- [ ] **Step 1: Find where subcommands are defined**
+
+Run: `grep -rn "Subcommand" mur-core/src/cmd/mod.rs | head` and `grep -rn "enum Command" mur-core/src | head`
+Expected: locate the top-level `clap` subcommand enum (e.g. `Commands`) and its dispatch `match`.
+
+- [ ] **Step 2: Create `mur-core/src/cmd/compress.rs`**
+
+```rust
+//! `mur compress` / `mur retrieve` — thin CLI over mur-compress.
+
+use std::io::Read;
+
+use mur_compress::{CompressConfig, CompressEngine, RetrieveResult};
+
+fn engine() -> anyhow::Result<CompressEngine> {
+    let home = mur_common::trust::mur_home();
+    let cfg = CompressConfig::load(&home);
+    Ok(CompressEngine::new(home.join("compress"), cfg)?)
+}
+
+fn read_input(file: Option<&str>) -> anyhow::Result<String> {
+    match file {
+        Some("-") | None => {
+            let mut s = String::new();
+            std::io::stdin().read_to_string(&mut s)?;
+            Ok(s)
+        }
+        Some(path) => Ok(std::fs::read_to_string(path)?),
+    }
+}
+
+pub fn do_compress(file: Option<&str>, query: Option<&str>) -> anyhow::Result<()> {
+    let eng = engine()?;
+    let content = read_input(file)?;
+    let r = eng.compress(&content, query);
+    println!("{}", r.compressed);
+    eprintln!(
+        "[{} -> {} tokens ({:.1}% saved){}]",
+        r.original_tokens,
+        r.compressed_tokens,
+        r.savings_percent,
+        r.hash.map(|h| format!(", hash={h}")).unwrap_or_default()
+    );
+    Ok(())
+}
+
+pub fn do_retrieve(hash: &str, query: Option<&str>) -> anyhow::Result<()> {
+    let eng = engine()?;
+    match eng.retrieve(hash, query) {
+        RetrieveResult::Full { original_content, .. } => println!("{original_content}"),
+        RetrieveResult::Filtered { results, .. } => {
+            for r in results {
+                println!("{r}");
+            }
+        }
+        RetrieveResult::NotFound => {
+            anyhow::bail!("content not found or expired for hash={hash}");
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Register module + dependency**
+
+In `mur-core/src/cmd/mod.rs` add `pub mod compress;`. In `mur-core/Cargo.toml` `[dependencies]` add `mur-compress = { path = "../mur-compress" }` (and confirm `anyhow` + `mur-common` are already deps — they are).
+
+- [ ] **Step 4: Add the subcommands to the clap tree**
+
+Add two variants to the top-level `Commands` enum (match the existing style found in Step 1), e.g.:
+
+```rust
+    /// Compress bulky text (stdin or FILE), storing the original for retrieval.
+    Compress {
+        /// Input file, or "-"/omitted for stdin.
+        file: Option<String>,
+        /// Optional query to bias what is kept.
+        #[arg(long)]
+        query: Option<String>,
+    },
+    /// Retrieve content previously stored by `mur compress`.
+    Retrieve {
+        /// Hash from a prior compress.
+        hash: String,
+        /// Optional query to filter stored items.
+        #[arg(long)]
+        query: Option<String>,
+    },
+```
+
+And in the dispatch `match`:
+
+```rust
+        Commands::Compress { file, query } => {
+            cmd::compress::do_compress(file.as_deref(), query.as_deref())?;
+        }
+        Commands::Retrieve { hash, query } => {
+            cmd::compress::do_retrieve(&hash, query.as_deref())?;
+        }
+```
+
+- [ ] **Step 5: Build & smoke test**
+
+Run:
+```bash
+cargo build -p mur-core
+printf 'src/a.rs:1:hello\nsrc/b.rs:2:database error\n' | cargo run -- compress --query database
+```
+Expected: prints grouped/compressed output; stderr shows the token delta.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/cmd/compress.rs mur-core/src/cmd/mod.rs mur-core/Cargo.toml
+# plus the file holding the Commands enum/dispatch
+git commit -m "feat(cli): mur compress / mur retrieve commands" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 17: Workspace verification, lint, docs
+
+**Files:**
+- Modify: `README.md` (CLI surface / tools note — optional)
+
+- [ ] **Step 1: Full workspace build & test**
+
+Run: `cargo test --workspace`
+Expected: all crates green, including `mur-compress` and `mur-mcp-server`.
+
+- [ ] **Step 2: Lint & format**
+
+Run: `cargo clippy --workspace -- -D warnings`
+Expected: no warnings. Fix any (common: needless clones, `format!` in push_str — acceptable, or use `write!`).
+
+Run: `cargo fmt`
+Then: `cargo fmt --check`
+Expected: clean.
+
+- [ ] **Step 3: Update docs (optional but recommended)**
+
+In `README.md`, under the MCP tools / CLI surface, add a one-line mention of `mur_compress` / `mur_retrieve` / `mur_compress_stats` and `mur compress`. Keep it short.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "chore(compress): workspace test + clippy clean, docs note" \
+  -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: (Do NOT bump version or tag.)** Release is a separate, user-initiated step per CLAUDE.md.
+
+---
+
+## Notes & deviations from the spec
+
+- **Reformat/Offload as functions, not traits.** Spec §6 sketches `Reformat`/`Offload` traits. For v1 (five compressors) the two stages are implemented as clearly-separated sections inside each compressor function — same behavior (lossless densify, then reversible offload), less indirection. Trait-ifying is a clean v1.1 refactor if more compressors arrive. This honors spec §4 (the two-stage pipeline) which is the load-bearing part.
+- **`estimate_bloat()` gate** is realized implicitly: each compressor cheaply checks "is there anything to offload?" (`keep_idx.len() >= items.len()`, `dropped == 0`, array length) and returns reformat-only output when not. A standalone trait method is unnecessary for v1.
+- **Clean-room + MIT.** No headroom source/fixtures are copied; headroom is credited in `lib.rs`. This is the documented adjustment to the spec's "borrow fixtures" idea (§15) to keep the crate cleanly MIT.
+- **Per-call engine** (MCP + CLI) keeps tests trivial and avoids global state; the `cl100k_base` load cost is acceptable for an interactive tool. Caching via `OnceLock` is a v1.1 option.
+- **Reformat roundtrip guard relaxed.** Spec §16 calls for a strict byte-`reconstruct == original` assertion on reformats. The v1 reformats are intentional *safe densification* (trim trailing whitespace, collapse blank/duplicate runs, JSON-minify, group-by-file) — not byte-lossless — so a strict byte-roundtrip would reject them all. The safety property the spec wants ("never lose information irrecoverably") is still guaranteed two ways: (1) any error in any stage ⇒ passthrough the original; (2) whenever an **offload** drops content, the verbatim original is stored in the CCR store and is retrievable. Reformat-only outputs change only non-semantic whitespace/duplication. A semantic guard (e.g. JSON parse-equality) can be added per-compressor in v1.1.
+- **Ratio-band tests deferred.** Spec §17 lists per-content-type savings-band regression tests. v1 asserts `tokens_saved > 0` on representative fixtures (Task 14 e2e); explicit bands (e.g. "search ≥ 80%") are a cheap follow-up once real corpora are wired in.
+```

--- a/docs/superpowers/specs/2026-06-03-mur-compress-token-design.md
+++ b/docs/superpowers/specs/2026-06-03-mur-compress-token-design.md
@@ -1,0 +1,290 @@
+# MUR Compress-Token — Design Spec
+
+- **Date:** 2026-06-03
+- **Status:** Approved (design) → ready for implementation planning
+- **Author:** David Chang (with Claude Code)
+- **Topic:** A native, local-first token-compression subsystem for MUR, exposed as MCP tools, modeled on the proven architecture of [`headroom`](https://github.com/chopratejas/headroom) (Apache-2.0) but reimplemented clean-room as a lean MIT crate.
+
+---
+
+## 1. Context & Motivation
+
+AI coding agents (Claude Code, Codex, etc.) burn most of their context budget on **machine-generated bulk text**: grep/ripgrep dumps, build/test logs, git diffs, and large JSON payloads. `headroom` demonstrates that **content-type-aware, reversible compression** cuts this by 60–95% with no measured accuracy loss on standard benchmarks — and crucially, the largest real-world wins (code search ~92%, SRE log triage ~92%) come from **deterministic, structure-aware transforms**, not ML.
+
+MUR already exposes interactive MCP tools (`mur-mcp-server`) and owns a retrieval pipeline (hybrid BM25 + vector). Adding a native compress/retrieve capability lets any MCP client shrink tool output before it reaches the LLM, while keeping originals locally retrievable — directly aligned with MUR's local-first positioning.
+
+This spec defines a new `mur-compress` crate plus three MCP tools, deliberately scoped to deterministic offline transforms.
+
+## 2. The Optimization Target — what "better compression" means
+
+Compression quality is defined as **savings × task-accuracy × reversibility**, measured in **tokens** (not bytes). Three inviolable rules follow:
+
+1. **Token-denominated.** All measurement, targets, and stop conditions use a real tokenizer, not byte length.
+2. **Never corrupt the input.** A compressor that occasionally mangles a tool output is worse than no compression. Any uncertainty or error ⇒ return the original unchanged (fail-safe passthrough).
+3. **Lossy-in-prompt, lossless-on-disk.** Anything dropped from the prompt is stored verbatim and retrievable on demand (CCR). The model fetches the full original only if it actually needs it.
+
+## 3. Goals / Non-Goals
+
+### Goals (v1)
+- A `mur-compress` crate implementing a **two-stage transform pipeline** (Reformat → Offload) with reversible CCR storage.
+- Four deterministic, content-aware compressors: **search, log, diff, json** + a safe **fallback**.
+- A real tokenizer (`tiktoken-rs`) replacing MUR's `len/4` heuristic for this subsystem.
+- Three MCP tools: `mur_compress`, `mur_retrieve`, `mur_compress_stats`.
+- A thin optional CLI (`mur compress` / `mur retrieve`) for testing and manual use.
+- Persistent, bounded CCR store under `~/.mur/compress/`.
+
+### Non-Goals (explicitly deferred — YAGNI)
+- HTTP **proxy** mode and **agent-wrap** mode (overlaps with MUR's existing positioning).
+- **ML prose compression** (the Kompress-base / ModernBERT path) — heaviest dependency (ONNX/fastembed/hf-hub), smallest marginal win. Deferred to v2.
+- **Code AST** compression (tree-sitter / ast-grep). v1 treats source code as fallback. Deferred to v2.
+- **CacheAligner** (provider KV-cache prefix stabilization) — relevant to a proxy, not an ad-hoc tool. Deferred.
+- Vector/embedding retrieval for CCR lookup. v1 uses BM25-only (offline, already available via `tantivy`).
+
+## 4. Architecture — two-stage reversible pipeline
+
+The core best-practice insight from headroom: **the first quality lever is content-type routing + format-specific transforms**, and high ratios come from a **two-stage** design where a safe lossless pass runs always, and a reversible lossy pass runs only when it pays off.
+
+```
+mur_compress(content, query?)
+  │
+  ├─ 1. detect_content_type(content)          # regex heuristics; ambiguous → Generic (passthrough)
+  │
+  ├─ 2. REFORMAT  (always run, lossless)       # re-encode same info more densely
+  │        └─ roundtrip check: reconstruct == original, else discard reformat & passthrough
+  │
+  ├─ 3. estimate_bloat() > threshold ?         # cheap O(n) token-denominated gate
+  │        └─ 4. OFFLOAD (reversible)          # drop low-value content → original/items into CcrStore
+  │                 └─ if query present: keep top-K by BM25 relevance, offload the tail
+  │
+  └─ 5. measure with tiktoken-rs
+        → { compressed, hash, tokens_before, tokens_after, tokens_saved,
+            savings_percent, transforms[], note:"…hash=…" }
+
+  Any error in any stage ⇒ return original content unchanged.
+```
+
+- **Reformat = lossless densification.** Always safe, always reversible by reconstruction, needs no store. Examples: JSON minify, log templating, search-result file grouping.
+- **Offload = reversible drop.** Removes content the LLM probably won't read, **stashing the verbatim original (at item granularity) in the CcrStore** and leaving a `hash=` marker. This is where the big percentage comes from, but nothing is truly lost.
+- **`estimate_bloat()` gate.** A cheap O(n) pre-pass (token-denominated) decides whether the offloader is worth engaging. Already-dense or tiny content is left alone — avoids latency and "helping backwards."
+- **Query bias.** When a query (or inferable last-user-turn context) is present, the offloader keeps the most relevant items and offloads the rest — this is what lets "100 search hits → top-8 + retrieve-on-demand" preserve task accuracy.
+
+## 5. Content detection (`detect.rs`)
+
+Deterministic regex/heuristic classifier (no ML, no `magika` in v1). Returns a `ContentType`; on any ambiguity returns `Generic`.
+
+| `ContentType` | Heuristic (illustrative) |
+|---|---|
+| `SearchResults` | high fraction of lines matching `^\S+:\d+:` (grep/rg `file:line:content`) |
+| `BuildLog` | high fraction of lines matching timestamp/log-level patterns (`\b(ERROR|WARN|INFO|DEBUG|TRACE)\b`, ISO-8601/epoch stamps) |
+| `GitDiff` | presence of `^diff --git`, `^@@ .* @@`, `^--- a/`, `^+++ b/` |
+| `Json` | content parses as JSON (array or object) after trimming |
+| `Generic` | anything else (prose, source code, mixed) → fallback compressor |
+
+Thresholds are **config-driven constants** (see §11), never hardcoded magic numbers inline.
+
+## 6. Transform traits (`transform.rs`)
+
+Two small traits mirror headroom's proven Reformat/Offload split, but use MUR-native types:
+
+```rust
+/// Lossless densification. Must be reconstructable: a Reformat is only
+/// accepted if reformat→reconstruct reproduces the original byte-for-byte.
+pub trait Reformat: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn applies_to(&self) -> &[ContentType];
+    fn apply(&self, content: &str) -> Result<ReformatOutput, CompressError>;
+}
+
+/// Reversible drop. Stashes the verbatim original (item-granular) in the
+/// store and returns compressed text plus the retrieval hash.
+pub trait Offload: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn applies_to(&self) -> &[ContentType];
+    /// Cheap O(n) token-denominated estimate of how much is droppable.
+    fn estimate_bloat(&self, content: &str, tok: &dyn TokenCounter) -> f32;
+    fn apply(
+        &self,
+        content: &str,
+        ctx: &CompressCtx,        // query, target_ratio, protect budget
+        store: &dyn CcrStore,
+    ) -> Result<OffloadOutput, CompressError>;
+}
+```
+
+The orchestrator (`lib.rs`) runs detection → reformat (with roundtrip guard) → bloat gate → offload, then measures. The pipeline is **synchronous and deterministic**.
+
+## 7. The four compressors + fallback (`compressors/`)
+
+Each compressor = a Reformat stage (always) + an optional Offload stage (gated).
+
+| Compressor | Reformat (lossless) | Offload (reversible → CCR) | Typical savings |
+|---|---|---|---|
+| **search** | group hits by file; fold repeated `path:` prefixes; relative line numbers | with query, keep top-K hits by BM25; offload the rest as items | 85–92% |
+| **log** | template extraction `<TS> <LVL> <MSG>` + varying-field table; merge repeated templates with counts | drop INFO/DEBUG noise & duplicates; keep ERROR/WARN + head/tail; full log → store | 80–92% |
+| **diff** | drop redundancy recomputable from hunk headers; keep ± lines + headers | offload large unchanged context blocks, leave anchors; full diff → store | 50–80% |
+| **json** | minify; hoist shared keys into a schema | SmartCrusher-style: collapse repeated array rows → schema + sample + count; offload long-array tail; original array → store | 70–95% |
+| **fallback** | strip trailing whitespace; collapse repeated blank lines | none by default (passthrough); prose/code left for v2 | 0–20% |
+
+Each compressor caps work by a **token target ratio** and a **protect budget** (head/tail or recent items always preserved), both config-driven.
+
+## 8. Tokenizer (`tokenizer.rs`)
+
+- `TokenCounter` trait with a `tiktoken-rs` implementation using `cl100k_base` (embedded in the crate; **fully offline, no network**).
+- Used as a **Claude approximation**: Anthropic does not publish its tokenizer; headroom uses the same approximation. The reported counts are documented as estimates.
+- A `len/4` fallback counter remains available for environments where the vocab fails to load, so the subsystem degrades rather than fails.
+
+## 9. CCR reversible store (`ccr/store.rs`)
+
+- **Location:** `~/.mur/compress/` (resolved via `mur_home()` in `mur-common`, honoring `$MUR_HOME`).
+- **Write:** atomic temp-file + rename (same pattern as `mur-core/src/store/yaml.rs`).
+- **Key:** `blake3(original)[:24]` hex (24 chars / 96 bits). `blake3` added as a dep; if we prefer zero new hash deps, `sha2` (already a `mur-core` dep) is an acceptable substitute — decided at implementation time, behavior identical.
+- **Granularity:** store **structured items** (parsed search hits / log line-groups / diff hunks / JSON rows), not one opaque blob, so retrieval can BM25-filter *within* a stored original and return only relevant items.
+- **Entry schema (serialized):**
+  ```
+  hash, content_type, created_at, ttl,
+  original_text, items[]            # parsed items for query-filtered retrieve
+  original_tokens, compressed_tokens, item_count, last_accessed, retrieval_count
+  ```
+- **Payload compression at rest:** optional `flate2`/`zstd` to keep `~/.mur/compress/` small (originals can be large). `flate2` exists in `mur-agent-runtime`; it (or `zstd`) is added to this crate.
+- **Eviction:** persistent (survives restarts) + **TTL (default 7 days)** + **size cap (default: max entries / max bytes)** + LRU. Expiry checked on access; opportunistic sweep on write. All limits config-driven.
+
+## 10. MCP tools (`mur-mcp-server`)
+
+Mirror headroom's tool surface (familiar to agents already using `headroom_*`). Added by **two edits in `mur-mcp-server/src/tools.rs`**: a `Tool {}` literal in `all_tools()` and a match arm in `call_tool()`. No changes to `server.rs`/`jsonrpc.rs`.
+
+### `mur_compress`
+- **Input:** `{ "content": string (required), "query": string (optional) }`
+- **Output (JSON):** `{ compressed, hash, original_tokens, compressed_tokens, tokens_saved, savings_percent, transforms: [..], note: "Original stored with hash=<hash>. Use mur_retrieve to fetch full content." }`
+
+### `mur_retrieve`
+- **Input:** `{ "hash": string (required), "query": string (optional) }`
+- **Behavior:** O(1) store lookup. With `query`, BM25-score the stored items and return top-K above threshold; without `query`, return the full original.
+- **Output (JSON):** full → `{ hash, content_type, original_content, item_count }`; filtered → `{ hash, query, results: [..], count }`; miss → `{ error, hash, hint }`.
+
+### `mur_compress_stats`
+- **Input:** none.
+- **Output (JSON):** `{ compressions, retrievals, total_input_tokens, total_output_tokens, total_tokens_saved, savings_percent, estimated_cost_saved_usd, store: { entries, bytes, max_entries } }`. Cost estimate uses a **config-driven $/M-token rate** (not a hardcoded constant).
+
+## 11. Configuration
+
+New section in `~/.mur/config.yaml` (all values have defaults; nothing hardcoded inline):
+
+```yaml
+compress:
+  enabled: true
+  tokenizer: cl100k_base          # tiktoken-rs vocab
+  target_ratio: 0.30              # aim to reach <=30% of original tokens
+  bloat_threshold: 0.20           # engage offloader only if >=20% estimated droppable
+  protect_head_lines: 20
+  protect_tail_lines: 20
+  retrieve_top_k: 20
+  retrieve_score_threshold: 0.30  # BM25 cutoff for query-filtered retrieve
+  detect:
+    search_min_ratio: 0.6
+    log_min_ratio: 0.5
+  store:
+    dir: ~/.mur/compress
+    ttl_days: 7
+    max_entries: 2000
+    max_bytes: 536870912          # 512 MiB
+    compress_at_rest: true
+  stats:
+    cost_per_mtok_usd: 3.0
+```
+
+## 12. CLI (optional, `mur-core` → `cmd/compress.rs`)
+
+- `mur compress [--query Q] [FILE|-]` → prints compressed text + the hash marker; stores original.
+- `mur retrieve <hash> [--query Q]` → prints original or filtered items.
+- Thin wrappers over the same `mur-compress` API. May be cut without affecting the MCP surface.
+
+## 13. Crate structure
+
+```
+mur-compress/                 # new workspace member (8th crate), MIT
+  Cargo.toml
+  src/
+    lib.rs                    # orchestrator: detect → reformat → gate → offload → measure
+    detect.rs                 # ContentType heuristics
+    transform.rs              # Reformat / Offload traits, CompressCtx, outputs, CompressError
+    tokenizer.rs              # TokenCounter trait + tiktoken-rs impl + len/4 fallback
+    compressors/
+      mod.rs
+      search.rs
+      log.rs
+      diff.rs
+      json.rs
+      fallback.rs
+    ccr/
+      mod.rs
+      store.rs                # CcrStore: item-granular, blake3 key, TTL+LRU, atomic write
+      entry.rs                # CompressedEntry schema
+    stats.rs                  # savings tracker (atomic JSON, models savings_tracker.py)
+    config.rs                 # serde view over the `compress:` config section
+  tests/
+    fixtures/                 # MUR-authored sample inputs per content type
+    roundtrip.rs              # reformat reconstruct == original
+    reversibility.rs          # offload → retrieve == original
+    ratios.rs                 # savings within expected bands per content type
+```
+
+Each source file stays under the **800-line** project limit; split into submodules if a compressor grows.
+
+## 14. Dependencies
+
+| Dep | Status | Use |
+|---|---|---|
+| `serde`, `serde_json`, `serde_yaml` | workspace | entry/config (de)serialization |
+| `regex` | present (mur-core) | detection, templating |
+| `tantivy` | present (mur-core) | BM25 for query-filtered retrieve |
+| `tempfile` | present | atomic writes / tests |
+| `tiktoken-rs` | **add** | offline token counting (`cl100k_base`) |
+| `flate2` or `zstd` | **add (to this crate)** | payload-at-rest compression |
+| `blake3` | **add (optional)** | content-address hashing (or reuse `sha2`) |
+
+No ONNX / fastembed / magika / hf-hub / tree-sitter in v1 — keeps the crate offline and light.
+
+## 15. Correctness strategy & licensing
+
+headroom is **Apache-2.0**; this workspace is **MIT**. To keep licensing clean:
+
+- **Clean-room reimplementation.** The compressors are written from the *documented behavior and algorithm ideas* described in this spec, **not** by copying headroom source. headroom is credited as design inspiration in code comments / a `CREDITS` note, which Apache-2.0 §4 attribution welcomes.
+- **MUR-authored fixtures.** Test fixtures are original inputs we write to model the same scenarios (code search, SRE log, git diff, JSON array), not copied from headroom's fixture corpus.
+- If, during implementation, any headroom code or data is copied verbatim, that file is marked Apache-2.0 with a `NOTICE` attribution — but the default is clean-room MIT.
+
+This is a deliberate, documented adjustment to the originally-discussed "borrow their parity fixtures" idea (avoids Apache→MIT entanglement).
+
+## 16. Error handling & fail-safe
+
+- Every stage returns `Result<_, CompressError>`; the orchestrator catches any error and returns the **original content unchanged** with `transforms: []` and zero savings. Compression is best-effort and must never break a caller.
+- Reformat stages are guarded by a **roundtrip assertion** (reconstruct == original); a failed assertion discards the reformat rather than risking lossy "lossless" output.
+- Retrieve on an expired/missing hash returns a structured `{ error, hint }`, never panics.
+
+## 17. Testing strategy
+
+- **Roundtrip:** every Reformat reconstructs its input exactly (property-style over fixtures).
+- **Reversibility:** for every Offload, `retrieve(hash)` returns the verbatim original; `retrieve(hash, query)` returns the relevant items.
+- **Ratio bands:** each content type compresses within an expected savings band on fixtures (regression guard against quality drift).
+- **Fail-safe:** malformed/edge inputs (truncated JSON, binary, empty, huge single line) return passthrough, never error.
+- **Tokenizer:** counts match `tiktoken-rs` reference values on known strings; fallback path activates when vocab is absent.
+- **MCP integration:** extend `mur-mcp-server/tests/integration.rs` to cover the three new tools end-to-end.
+
+## 18. Confirmed defaults (from design review)
+
+1. **Tokenizer:** `tiktoken-rs` `cl100k_base` as a documented Claude approximation.
+2. **Storage:** persistent on disk (cross-session) with TTL 7 days + size cap + LRU.
+3. **prose/code:** v1 passthrough (fallback compressor only); AST + ML prose are v2.
+4. **CLI:** included but cuttable.
+
+## 19. Future (v2+)
+
+- ML prose compression (Kompress-base or equivalent) behind a feature flag.
+- Code-AST compression (tree-sitter).
+- Internal MUR use: compress context-injection / retrieved patterns / session recordings before they reach an agent.
+- Optional vector-scored retrieve (reuse `score_and_rank_hybrid`).
+- `magika`-backed content detection if regex heuristics prove insufficient.
+
+## 20. References
+
+- headroom repo (Apache-2.0): https://github.com/chopratejas/headroom — `headroom/transforms/`, `headroom/ccr/`, `headroom/integrations/mcp/server.py`, `crates/headroom-core/src/transforms/pipeline/`.
+- MUR integration points: `mur-mcp-server/src/tools.rs` (`all_tools()`, `call_tool()`), `mur-core/src/store/yaml.rs` (atomic write), `mur-core/src/retrieve/scoring.rs` (BM25/hybrid), `mur-common` `mur_home()`.

--- a/mur-compress/Cargo.toml
+++ b/mur-compress/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mur-compress"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+thiserror = { workspace = true }
+blake3 = "1"
+flate2 = "1"
+tiktoken-rs = "0.6"
+regex = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/mur-compress/src/bm25.rs
+++ b/mur-compress/src/bm25.rs
@@ -1,0 +1,78 @@
+//! Tiny self-contained BM25 over a list of documents (used by query-filtered
+//! retrieve and search-result offload). Returns (index, raw_score) desc.
+
+use std::collections::HashSet;
+
+const K1: f32 = 1.5;
+const B: f32 = 0.75;
+
+fn tokenize(s: &str) -> Vec<String> {
+    s.split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_lowercase())
+        .collect()
+}
+
+pub fn bm25_rank(query: &str, docs: &[String]) -> Vec<(usize, f32)> {
+    let q_terms = tokenize(query);
+    if q_terms.is_empty() {
+        return vec![];
+    }
+
+    let doc_terms: Vec<Vec<String>> = docs.iter().map(|d| tokenize(d)).collect();
+    let n = doc_terms.len() as f32;
+    let avgdl = if doc_terms.is_empty() {
+        1.0
+    } else {
+        doc_terms.iter().map(|d| d.len() as f32).sum::<f32>() / n
+    };
+
+    let mut scores = vec![0.0f32; docs.len()];
+    let unique_terms: HashSet<&String> = q_terms.iter().collect();
+    for term in unique_terms {
+        let df = doc_terms.iter().filter(|d| d.contains(term)).count() as f32;
+        if df == 0.0 {
+            continue;
+        }
+
+        let idf = (((n - df + 0.5) / (df + 0.5)) + 1.0).ln();
+        for (i, d) in doc_terms.iter().enumerate() {
+            let tf = d.iter().filter(|t| *t == term).count() as f32;
+            if tf == 0.0 {
+                continue;
+            }
+            let dl = d.len() as f32;
+            scores[i] += idf * (tf * (K1 + 1.0)) / (tf + K1 * (1.0 - B + B * dl / avgdl));
+        }
+    }
+
+    let mut ranked: Vec<(usize, f32)> = scores
+        .into_iter()
+        .enumerate()
+        .filter(|(_, s)| *s > 0.0)
+        .collect();
+    ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    ranked
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ranks_relevant_doc_first() {
+        let docs = vec![
+            "the cat sat on the mat".to_string(),
+            "database connection error retry".to_string(),
+            "weather is nice today".to_string(),
+        ];
+        let ranked = bm25_rank("database error", &docs);
+        assert_eq!(ranked.first().unwrap().0, 1);
+    }
+
+    #[test]
+    fn empty_query_returns_empty() {
+        let docs = vec!["a".to_string()];
+        assert!(bm25_rank("", &docs).is_empty());
+    }
+}

--- a/mur-compress/src/ccr/entry.rs
+++ b/mur-compress/src/ccr/entry.rs
@@ -1,0 +1,21 @@
+//! A stored original, retrievable by hash, with parsed items for query filter.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompressedEntry {
+    pub hash: String,
+    pub content_type: String,
+    pub created_at: u64,
+    pub ttl_secs: u64,
+    pub original_text: String,
+    pub items: Vec<String>,
+    pub original_tokens: usize,
+    pub item_count: usize,
+}
+
+impl CompressedEntry {
+    pub fn is_expired(&self, now: u64) -> bool {
+        self.ttl_secs > 0 && now > self.created_at + self.ttl_secs
+    }
+}

--- a/mur-compress/src/ccr/mod.rs
+++ b/mur-compress/src/ccr/mod.rs
@@ -1,0 +1,5 @@
+pub mod entry;
+pub mod store;
+
+pub use entry::CompressedEntry;
+pub use store::{CcrStore, hash_content};

--- a/mur-compress/src/ccr/store.rs
+++ b/mur-compress/src/ccr/store.rs
@@ -1,0 +1,234 @@
+//! Persistent, bounded CCR store. One JSON(.gz) file per entry under
+//! <dir>/entries/. Atomic temp+rename writes. TTL on read, size/count eviction.
+
+use std::io::{Read, Write};
+use std::path::PathBuf;
+
+use crate::ccr::entry::CompressedEntry;
+use crate::tokenizer::TokenCounter;
+use crate::types::ContentType;
+
+pub fn hash_content(s: &str) -> String {
+    let hex = blake3::hash(s.as_bytes()).to_hex();
+    hex[..24].to_string()
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn gzip(data: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    enc.write_all(data)?;
+    enc.finish()
+}
+
+fn gunzip(data: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut dec = flate2::read::GzDecoder::new(data);
+    let mut out = Vec::new();
+    dec.read_to_end(&mut out)?;
+    Ok(out)
+}
+
+pub struct CcrStore {
+    entries_dir: PathBuf,
+    ttl_secs: u64,
+    max_entries: usize,
+    max_bytes: u64,
+    compress_at_rest: bool,
+}
+
+impl CcrStore {
+    pub fn new(
+        dir: impl Into<PathBuf>,
+        ttl_secs: u64,
+        max_entries: usize,
+        max_bytes: u64,
+        compress_at_rest: bool,
+    ) -> std::io::Result<Self> {
+        let entries_dir = dir.into().join("entries");
+        std::fs::create_dir_all(&entries_dir)?;
+        Ok(Self {
+            entries_dir,
+            ttl_secs,
+            max_entries,
+            max_bytes,
+            compress_at_rest,
+        })
+    }
+
+    pub fn ttl_secs(&self) -> u64 {
+        self.ttl_secs
+    }
+
+    fn path_for(&self, hash: &str) -> PathBuf {
+        let ext = if self.compress_at_rest {
+            "json.gz"
+        } else {
+            "json"
+        };
+        self.entries_dir.join(format!("{hash}.{ext}"))
+    }
+
+    pub fn put(&self, entry: &CompressedEntry) -> std::io::Result<()> {
+        let path = self.path_for(&entry.hash);
+        let json = serde_json::to_vec(entry)?;
+        let bytes = if self.compress_at_rest {
+            gzip(&json)?
+        } else {
+            json
+        };
+        let tmp = path.with_extension("tmp");
+        std::fs::write(&tmp, &bytes)?;
+        std::fs::rename(&tmp, &path)?;
+        self.evict_if_needed()?;
+        Ok(())
+    }
+
+    /// Build + store an entry for `original`, returning its hash.
+    pub fn put_original(
+        &self,
+        original: &str,
+        items: Vec<String>,
+        content_type: ContentType,
+        tok: &dyn TokenCounter,
+    ) -> std::io::Result<String> {
+        let hash = hash_content(original);
+        let item_count = items.len();
+        let entry = CompressedEntry {
+            hash: hash.clone(),
+            content_type: content_type.as_str().to_string(),
+            created_at: now_secs(),
+            ttl_secs: self.ttl_secs,
+            original_text: original.to_string(),
+            items,
+            original_tokens: tok.count(original),
+            item_count,
+        };
+        self.put(&entry)?;
+        Ok(hash)
+    }
+
+    pub fn get(&self, hash: &str) -> std::io::Result<Option<CompressedEntry>> {
+        let path = self.path_for(hash);
+        let raw = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        let json = if self.compress_at_rest {
+            gunzip(&raw)?
+        } else {
+            raw
+        };
+        let entry: CompressedEntry = serde_json::from_slice(&json)?;
+        if entry.is_expired(now_secs()) {
+            let _ = std::fs::remove_file(&path);
+            return Ok(None);
+        }
+        Ok(Some(entry))
+    }
+
+    pub fn stats(&self) -> (usize, u64) {
+        let mut count = 0usize;
+        let mut bytes = 0u64;
+        if let Ok(rd) = std::fs::read_dir(&self.entries_dir) {
+            for e in rd.flatten() {
+                if let Ok(md) = e.metadata()
+                    && md.is_file()
+                    && e.path().extension().is_some_and(|x| x != "tmp")
+                {
+                    count += 1;
+                    bytes += md.len();
+                }
+            }
+        }
+        (count, bytes)
+    }
+
+    fn evict_if_needed(&self) -> std::io::Result<()> {
+        let mut files: Vec<(PathBuf, std::time::SystemTime, u64)> = Vec::new();
+        let mut total = 0u64;
+        for e in std::fs::read_dir(&self.entries_dir)? {
+            let e = e?;
+            let md = e.metadata()?;
+            if !md.is_file() {
+                continue;
+            }
+            let mtime = md.modified().unwrap_or(std::time::UNIX_EPOCH);
+            total += md.len();
+            files.push((e.path(), mtime, md.len()));
+        }
+        files.sort_by_key(|(_, t, _)| *t); // oldest first
+        let mut idx = 0;
+        while idx < files.len()
+            && ((files.len() - idx) > self.max_entries || total > self.max_bytes)
+        {
+            let (p, _, sz) = &files[idx];
+            let _ = std::fs::remove_file(p);
+            total = total.saturating_sub(*sz);
+            idx += 1;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tokenizer::HeuristicCounter;
+    use std::path::Path;
+
+    fn store(dir: &Path, compress: bool) -> CcrStore {
+        CcrStore::new(dir, 3600, 100, 1 << 30, compress).unwrap()
+    }
+
+    #[test]
+    fn put_get_roundtrip_plain_and_gz() {
+        for compress in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let s = store(dir.path(), compress);
+            let h = s
+                .put_original(
+                    "a\nb\nc",
+                    vec!["a".into(), "b".into(), "c".into()],
+                    ContentType::SearchResults,
+                    &HeuristicCounter,
+                )
+                .unwrap();
+            let got = s.get(&h).unwrap().expect("entry exists");
+            assert_eq!(got.original_text, "a\nb\nc");
+            assert_eq!(got.item_count, 3);
+        }
+    }
+
+    #[test]
+    fn expired_entry_is_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        // ttl_secs = 0 means "no expiry"; use 1 and a backdated entry.
+        let s = CcrStore::new(dir.path(), 1, 100, 1 << 30, false).unwrap();
+        let mut entry = CompressedEntry {
+            hash: hash_content("x"),
+            content_type: "generic".into(),
+            created_at: 0, // far in the past
+            ttl_secs: 1,
+            original_text: "x".into(),
+            items: vec![],
+            original_tokens: 1,
+            item_count: 0,
+        };
+        entry.hash = hash_content("x");
+        s.put(&entry).unwrap();
+        assert!(s.get(&entry.hash).unwrap().is_none());
+    }
+
+    #[test]
+    fn missing_hash_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let s = store(dir.path(), false);
+        assert!(s.get("deadbeef").unwrap().is_none())
+    }
+}

--- a/mur-compress/src/compressors/diff.rs
+++ b/mur-compress/src/compressors/diff.rs
@@ -1,0 +1,96 @@
+//! Diff compressor. Reformat+Offload: keep headers and changed (+/-) lines;
+//! collapse long unchanged-context runs (>3 lines) to a marker; stash full diff.
+
+use crate::ccr::CcrStore;
+use crate::tokenizer::TokenCounter;
+use crate::types::{CompressCtx, CompressError, CompressOutput, ContentType};
+
+const CONTEXT_KEEP: usize = 3;
+
+fn is_header(l: &str) -> bool {
+    l.starts_with("diff ")
+        || l.starts_with("@@")
+        || l.starts_with("--- ")
+        || l.starts_with("+++ ")
+        || l.starts_with("index ")
+}
+
+pub fn compress(
+    content: &str,
+    _ctx: &CompressCtx,
+    store: &CcrStore,
+    tok: &dyn TokenCounter,
+) -> Result<CompressOutput, CompressError> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut transforms = vec!["diff.trim_context".to_string()];
+    let mut kept: Vec<String> = Vec::new();
+    let mut context_run = 0usize;
+    let mut dropped = 0usize;
+
+    for l in &lines {
+        let change = l.starts_with('+') || l.starts_with('-');
+        let header = is_header(l);
+        let context = !change && !header;
+        if context {
+            context_run += 1;
+            if context_run <= CONTEXT_KEEP {
+                kept.push((*l).to_string());
+            } else {
+                dropped += 1;
+            }
+        } else {
+            if context_run > CONTEXT_KEEP {
+                kept.push(format!("... ({} unchanged lines)", context_run - CONTEXT_KEEP));
+            }
+            context_run = 0;
+            kept.push((*l).to_string());
+        }
+    }
+    if context_run > CONTEXT_KEEP {
+        kept.push(format!("... ({} unchanged lines)", context_run - CONTEXT_KEEP));
+    }
+
+    if dropped == 0 {
+        return Ok(CompressOutput {
+            compressed: content.to_string(),
+            hash: None,
+            transforms,
+        });
+    }
+
+    let items: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
+    let hash = store
+        .put_original(content, items, ContentType::GitDiff, tok)
+        .map_err(|e| CompressError::Store(e.to_string()))?;
+    transforms.push("diff.offload".to_string());
+
+    let mut body = kept.join("\n");
+    body.push_str(&format!(
+        "\n[diff context trimmed; {dropped} lines offloaded. Full diff: hash={hash}]"
+    ));
+    Ok(CompressOutput { compressed: body, hash: Some(hash), transforms })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CompressConfig;
+    use crate::tokenizer::HeuristicCounter;
+
+    #[test]
+    fn trims_large_unchanged_context() {
+        let cfg = CompressConfig::default();
+        let dir = tempfile::tempdir().unwrap();
+        let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let mut s = String::from("diff --git a/x b/x\n@@ -1,20 +1,20 @@\n");
+        for _ in 0..20 {
+            s.push_str(" unchanged\n");
+        }
+        s.push_str("+added line\n");
+        let out = compress(&s, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.compressed.contains("+added line"));
+        assert!(out.compressed.contains("unchanged lines)"));
+        assert!(out.hash.is_some());
+    }
+}

--- a/mur-compress/src/compressors/diff.rs
+++ b/mur-compress/src/compressors/diff.rs
@@ -40,14 +40,20 @@ pub fn compress(
             }
         } else {
             if context_run > CONTEXT_KEEP {
-                kept.push(format!("... ({} unchanged lines)", context_run - CONTEXT_KEEP));
+                kept.push(format!(
+                    "... ({} unchanged lines)",
+                    context_run - CONTEXT_KEEP
+                ));
             }
             context_run = 0;
             kept.push((*l).to_string());
         }
     }
     if context_run > CONTEXT_KEEP {
-        kept.push(format!("... ({} unchanged lines)", context_run - CONTEXT_KEEP));
+        kept.push(format!(
+            "... ({} unchanged lines)",
+            context_run - CONTEXT_KEEP
+        ));
     }
 
     if dropped == 0 {
@@ -68,7 +74,11 @@ pub fn compress(
     body.push_str(&format!(
         "\n[diff context trimmed; {dropped} lines offloaded. Full diff: hash={hash}]"
     ));
-    Ok(CompressOutput { compressed: body, hash: Some(hash), transforms })
+    Ok(CompressOutput {
+        compressed: body,
+        hash: Some(hash),
+        transforms,
+    })
 }
 
 #[cfg(test)]
@@ -82,7 +92,10 @@ mod tests {
         let cfg = CompressConfig::default();
         let dir = tempfile::tempdir().unwrap();
         let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
-        let ctx = CompressCtx { query: None, config: &cfg };
+        let ctx = CompressCtx {
+            query: None,
+            config: &cfg,
+        };
         let mut s = String::from("diff --git a/x b/x\n@@ -1,20 +1,20 @@\n");
         for _ in 0..20 {
             s.push_str(" unchanged\n");

--- a/mur-compress/src/compressors/fallback.rs
+++ b/mur-compress/src/compressors/fallback.rs
@@ -1,0 +1,56 @@
+//! Generic fallback: lossless-ish densify (trim trailing ws, collapse blank
+//! runs). No offload — prose/code are left intact in v1.
+
+use crate::ccr::CcrStore;
+use crate::tokenizer::TokenCounter;
+use crate::types::{CompressCtx, CompressError, CompressOutput};
+
+pub fn compress(
+    content: &str,
+    _ctx: &CompressCtx,
+    _store: &CcrStore,
+    _tok: &dyn TokenCounter,
+) -> Result<CompressOutput, CompressError> {
+    let mut out = String::with_capacity(content.len());
+    let mut blank_run = 0;
+    for line in content.lines() {
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            blank_run += 1;
+            if blank_run > 1 {
+                continue;
+            }
+        } else {
+            blank_run = 0;
+        }
+        out.push_str(trimmed);
+        out.push('\n');
+    }
+    if !content.ends_with('\n') {
+        out.pop();
+    }
+    Ok(CompressOutput {
+        compressed: out,
+        hash: None,
+        transforms: vec!["fallback.whitespace".into()],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CompressConfig;
+    use crate::tokenizer::HeuristicCounter;
+
+    #[test]
+    fn collapses_blank_runs_and_trailing_ws() {
+        let cfg = CompressConfig::default();
+        let dir = tempfile::tempdir().unwrap();
+        let store = CcrStore::new(dir.path(), 3600, 10, 1 << 30, false).unwrap();
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let input = "line one   \n\n\n\nline two\n";
+        let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert_eq!(out.compressed, "line one\n\nline two\n");
+        assert!(out.hash.is_none());
+    }
+}

--- a/mur-compress/src/compressors/fallback.rs
+++ b/mur-compress/src/compressors/fallback.rs
@@ -47,7 +47,10 @@ mod tests {
         let cfg = CompressConfig::default();
         let dir = tempfile::tempdir().unwrap();
         let store = CcrStore::new(dir.path(), 3600, 10, 1 << 30, false).unwrap();
-        let ctx = CompressCtx { query: None, config: &cfg };
+        let ctx = CompressCtx {
+            query: None,
+            config: &cfg,
+        };
         let input = "line one   \n\n\n\nline two\n";
         let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
         assert_eq!(out.compressed, "line one\n\nline two\n");

--- a/mur-compress/src/compressors/json.rs
+++ b/mur-compress/src/compressors/json.rs
@@ -1,0 +1,87 @@
+//! JSON compressor. Reformat: minify. Offload (SmartCrusher-lite): for a long
+//! top-level array, emit schema keys + first-N sample + count; stash full array.
+
+use crate::ccr::CcrStore;
+use crate::tokenizer::TokenCounter;
+use crate::types::{CompressCtx, CompressError, CompressOutput, ContentType};
+
+const MIN_ARRAY_FOR_COLLAPSE: usize = 4;
+
+pub fn compress(
+    content: &str,
+    ctx: &CompressCtx,
+    store: &CcrStore,
+    tok: &dyn TokenCounter,
+) -> Result<CompressOutput, CompressError> {
+    let val: serde_json::Value =
+        serde_json::from_str(content.trim()).map_err(|e| CompressError::Parse(e.to_string()))?;
+    let mut transforms = vec!["json.minify".to_string()];
+    let minified =
+        serde_json::to_string(&val).map_err(|e| CompressError::Parse(e.to_string()))?;
+    let cfg = ctx.config;
+
+    if let serde_json::Value::Array(arr) = &val {
+        let sample_n = cfg.protect_head_lines.min(arr.len());
+        if arr.len() >= MIN_ARRAY_FOR_COLLAPSE && arr.len() > sample_n {
+            let keys: Vec<String> = match arr.first() {
+                Some(serde_json::Value::Object(m)) => m.keys().cloned().collect(),
+                _ => Vec::new(),
+            };
+            let items: Vec<String> =
+                arr.iter().map(|v| serde_json::to_string(v).unwrap_or_default()).collect();
+            let hash = store
+                .put_original(content, items, ContentType::Json, tok)
+                .map_err(|e| CompressError::Store(e.to_string()))?;
+            transforms.push("json.row_collapse".to_string());
+
+            let sample = serde_json::Value::Array(arr[..sample_n].to_vec());
+            let body = serde_json::json!({
+                "_schema": keys,
+                "_total": arr.len(),
+                "_shown": sample_n,
+                "sample": sample,
+                "_note": format!("{} rows collapsed; full array hash={}", arr.len() - sample_n, hash),
+            });
+            return Ok(CompressOutput {
+                compressed: serde_json::to_string(&body).unwrap_or(minified),
+                hash: Some(hash),
+                transforms,
+            });
+        }
+    }
+
+    Ok(CompressOutput { compressed: minified, hash: None, transforms })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CompressConfig;
+    use crate::tokenizer::HeuristicCounter;
+
+    #[test]
+    fn collapses_long_array() {
+        let mut cfg = CompressConfig::default();
+        cfg.protect_head_lines = 2;
+        let dir = tempfile::tempdir().unwrap();
+        let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let input = r#"[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6}]"#;
+        let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.hash.is_some());
+        assert!(out.compressed.contains("_total"));
+        let got = store.get(out.hash.as_ref().unwrap()).unwrap().unwrap();
+        assert_eq!(got.item_count, 6);
+    }
+
+    #[test]
+    fn minifies_short_json() {
+        let cfg = CompressConfig::default();
+        let dir = tempfile::tempdir().unwrap();
+        let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let out = compress("{\n  \"a\": 1\n}", &ctx, &store, &HeuristicCounter).unwrap();
+        assert_eq!(out.compressed, r#"{"a":1}"#);
+        assert!(out.hash.is_none());
+    }
+}

--- a/mur-compress/src/compressors/json.rs
+++ b/mur-compress/src/compressors/json.rs
@@ -16,8 +16,7 @@ pub fn compress(
     let val: serde_json::Value =
         serde_json::from_str(content.trim()).map_err(|e| CompressError::Parse(e.to_string()))?;
     let mut transforms = vec!["json.minify".to_string()];
-    let minified =
-        serde_json::to_string(&val).map_err(|e| CompressError::Parse(e.to_string()))?;
+    let minified = serde_json::to_string(&val).map_err(|e| CompressError::Parse(e.to_string()))?;
     let cfg = ctx.config;
 
     if let serde_json::Value::Array(arr) = &val {
@@ -27,8 +26,10 @@ pub fn compress(
                 Some(serde_json::Value::Object(m)) => m.keys().cloned().collect(),
                 _ => Vec::new(),
             };
-            let items: Vec<String> =
-                arr.iter().map(|v| serde_json::to_string(v).unwrap_or_default()).collect();
+            let items: Vec<String> = arr
+                .iter()
+                .map(|v| serde_json::to_string(v).unwrap_or_default())
+                .collect();
             let hash = store
                 .put_original(content, items, ContentType::Json, tok)
                 .map_err(|e| CompressError::Store(e.to_string()))?;
@@ -50,7 +51,11 @@ pub fn compress(
         }
     }
 
-    Ok(CompressOutput { compressed: minified, hash: None, transforms })
+    Ok(CompressOutput {
+        compressed: minified,
+        hash: None,
+        transforms,
+    })
 }
 
 #[cfg(test)]
@@ -65,7 +70,10 @@ mod tests {
         cfg.protect_head_lines = 2;
         let dir = tempfile::tempdir().unwrap();
         let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
-        let ctx = CompressCtx { query: None, config: &cfg };
+        let ctx = CompressCtx {
+            query: None,
+            config: &cfg,
+        };
         let input = r#"[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6}]"#;
         let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
         assert!(out.hash.is_some());
@@ -79,7 +87,10 @@ mod tests {
         let cfg = CompressConfig::default();
         let dir = tempfile::tempdir().unwrap();
         let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
-        let ctx = CompressCtx { query: None, config: &cfg };
+        let ctx = CompressCtx {
+            query: None,
+            config: &cfg,
+        };
         let out = compress("{\n  \"a\": 1\n}", &ctx, &store, &HeuristicCounter).unwrap();
         assert_eq!(out.compressed, r#"{"a":1}"#);
         assert!(out.hash.is_none());

--- a/mur-compress/src/compressors/log.rs
+++ b/mur-compress/src/compressors/log.rs
@@ -1,0 +1,102 @@
+//! Log compressor. Reformat: collapse consecutive duplicate lines into
+//! "<line>  (xN)". Offload: keep ERROR/WARN/FATAL + head/tail; stash full log.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::ccr::CcrStore;
+use crate::tokenizer::TokenCounter;
+use crate::types::{CompressCtx, CompressError, CompressOutput, ContentType};
+
+static IMPORTANT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)\b(ERROR|WARN|WARNING|FATAL|PANIC|FAIL)\b").unwrap());
+
+fn collapse_repeats(lines: &[String]) -> String {
+    let mut out = String::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let mut count = 1;
+        while i + count < lines.len() && lines[i + count] == lines[i] {
+            count += 1;
+        }
+        out.push_str(&lines[i]);
+        if count > 1 {
+            out.push_str(&format!("  (x{count})"));
+        }
+        out.push('\n');
+        i += count;
+    }
+    out
+}
+
+pub fn compress(
+    content: &str,
+    ctx: &CompressCtx,
+    store: &CcrStore,
+    tok: &dyn TokenCounter,
+) -> Result<CompressOutput, CompressError> {
+    let items: Vec<String> = content.lines().map(|s| s.to_string()).collect();
+    let cfg = ctx.config;
+    let mut transforms = vec!["log.collapse_repeats".to_string()];
+    let n = items.len();
+
+    let keep_idx: Vec<usize> = (0..n)
+        .filter(|&i| {
+            i < cfg.protect_head_lines
+                || i >= n.saturating_sub(cfg.protect_tail_lines)
+                || IMPORTANT.is_match(&items[i])
+        })
+        .collect();
+
+    if keep_idx.len() >= n {
+        return Ok(CompressOutput {
+            compressed: collapse_repeats(&items),
+            hash: None,
+            transforms,
+        });
+    }
+
+    let hash = store
+        .put_original(content, items.clone(), ContentType::BuildLog, tok)
+        .map_err(|e| CompressError::Store(e.to_string()))?;
+    transforms.push("log.offload".to_string());
+
+    let kept: Vec<String> = keep_idx.iter().map(|&i| items[i].clone()).collect();
+    let mut body = collapse_repeats(&kept);
+    body.push_str(&format!(
+        "[{} of {} log lines shown; {} offloaded. Full log: hash={}]\n",
+        kept.len(),
+        n,
+        n - kept.len(),
+        hash
+    ));
+    Ok(CompressOutput { compressed: body, hash: Some(hash), transforms })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CompressConfig;
+    use crate::tokenizer::HeuristicCounter;
+
+    #[test]
+    fn keeps_errors_offloads_noise() {
+        let mut cfg = CompressConfig::default();
+        cfg.protect_head_lines = 0;
+        cfg.protect_tail_lines = 0;
+        let dir = tempfile::tempdir().unwrap();
+        let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let mut lines = vec![];
+        for _ in 0..50 {
+            lines.push("DEBUG noise".to_string());
+        }
+        lines.push("ERROR boom".to_string());
+        let input = lines.join("\n");
+        let out = compress(&input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.compressed.contains("ERROR boom"));
+        assert!(out.hash.is_some());
+        assert!(out.compressed.contains("offloaded"));
+    }
+}

--- a/mur-compress/src/compressors/log.rs
+++ b/mur-compress/src/compressors/log.rs
@@ -71,7 +71,11 @@ pub fn compress(
         n - kept.len(),
         hash
     ));
-    Ok(CompressOutput { compressed: body, hash: Some(hash), transforms })
+    Ok(CompressOutput {
+        compressed: body,
+        hash: Some(hash),
+        transforms,
+    })
 }
 
 #[cfg(test)]
@@ -87,7 +91,10 @@ mod tests {
         cfg.protect_tail_lines = 0;
         let dir = tempfile::tempdir().unwrap();
         let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
-        let ctx = CompressCtx { query: None, config: &cfg };
+        let ctx = CompressCtx {
+            query: None,
+            config: &cfg,
+        };
         let mut lines = vec![];
         for _ in 0..50 {
             lines.push("DEBUG noise".to_string());

--- a/mur-compress/src/compressors/mod.rs
+++ b/mur-compress/src/compressors/mod.rs
@@ -1,0 +1,2 @@
+pub mod fallback;
+// search, log, diff, json added in Tasks 9–12.

--- a/mur-compress/src/compressors/mod.rs
+++ b/mur-compress/src/compressors/mod.rs
@@ -1,5 +1,5 @@
 pub mod diff;
 pub mod fallback;
+pub mod json;
 pub mod log;
 pub mod search;
-// json added in Task 12.

--- a/mur-compress/src/compressors/mod.rs
+++ b/mur-compress/src/compressors/mod.rs
@@ -1,3 +1,4 @@
 pub mod fallback;
+pub mod log;
 pub mod search;
-// log, diff, json added in Tasks 10–12.
+// diff, json added in Tasks 11–12.

--- a/mur-compress/src/compressors/mod.rs
+++ b/mur-compress/src/compressors/mod.rs
@@ -1,4 +1,5 @@
+pub mod diff;
 pub mod fallback;
 pub mod log;
 pub mod search;
-// diff, json added in Tasks 11–12.
+// json added in Task 12.

--- a/mur-compress/src/compressors/mod.rs
+++ b/mur-compress/src/compressors/mod.rs
@@ -1,2 +1,3 @@
 pub mod fallback;
-// search, log, diff, json added in Tasks 9–12.
+pub mod search;
+// log, diff, json added in Tasks 10–12.

--- a/mur-compress/src/compressors/search.rs
+++ b/mur-compress/src/compressors/search.rs
@@ -1,0 +1,112 @@
+//! Search-result compressor. Reformat: group hits by file. Offload: with a
+//! query keep top-K by BM25, else keep the head window; stash the rest.
+
+use crate::bm25::bm25_rank;
+use crate::ccr::CcrStore;
+use crate::tokenizer::TokenCounter;
+use crate::types::{CompressCtx, CompressError, CompressOutput, ContentType};
+
+fn file_of(line: &str) -> &str {
+    // "path:line:content" -> "path"
+    line.split(':').next().unwrap_or("")
+}
+
+fn group_by_file(items: &[String]) -> String {
+    let mut out = String::new();
+    let mut current = "";
+    for it in items {
+        let f = file_of(it);
+        if f != current {
+            out.push_str(&format!("{f}:\n"));
+            current = f;
+        }
+        // strip the leading "path:" so the file header carries it
+        let rest = it.strip_prefix(f).and_then(|r| r.strip_prefix(':')).unwrap_or(it);
+        out.push_str("  ");
+        out.push_str(rest);
+        out.push('\n');
+    }
+    out
+}
+
+pub fn compress(
+    content: &str,
+    ctx: &CompressCtx,
+    store: &CcrStore,
+    tok: &dyn TokenCounter,
+) -> Result<CompressOutput, CompressError> {
+    let items: Vec<String> = content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|s| s.to_string())
+        .collect();
+    let mut transforms = vec!["search.group_by_file".to_string()];
+    let cfg = ctx.config;
+
+    let keep_idx: Vec<usize> = if let Some(q) = ctx.query {
+        let ranked = bm25_rank(q, &items);
+        if ranked.is_empty() {
+            (0..items.len().min(cfg.protect_head_lines)).collect()
+        } else {
+            let mut idx: Vec<usize> =
+                ranked.into_iter().take(cfg.retrieve_top_k).map(|(i, _)| i).collect();
+            idx.sort_unstable();
+            idx
+        }
+    } else {
+        (0..items.len().min(cfg.protect_head_lines)).collect()
+    };
+
+    if keep_idx.len() >= items.len() {
+        return Ok(CompressOutput {
+            compressed: group_by_file(&items),
+            hash: None,
+            transforms,
+        });
+    }
+
+    let hash = store
+        .put_original(content, items.clone(), ContentType::SearchResults, tok)
+        .map_err(|e| CompressError::Store(e.to_string()))?;
+    transforms.push("search.offload".to_string());
+
+    let kept: Vec<String> = keep_idx.iter().map(|&i| items[i].clone()).collect();
+    let mut body = group_by_file(&kept);
+    body.push_str(&format!(
+        "[{} of {} hits shown; {} offloaded. Retrieve all with hash={}]\n",
+        kept.len(),
+        items.len(),
+        items.len() - kept.len(),
+        hash
+    ));
+    Ok(CompressOutput { compressed: body, hash: Some(hash), transforms })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CompressConfig;
+    use crate::tokenizer::HeuristicCounter;
+
+    fn mk(dir: &std::path::Path) -> CcrStore {
+        CcrStore::new(dir, 3600, 100, 1 << 30, false).unwrap()
+    }
+
+    #[test]
+    fn offloads_tail_and_keeps_query_relevant() {
+        let mut cfg = CompressConfig::default();
+        cfg.protect_head_lines = 1;
+        cfg.retrieve_top_k = 1;
+        let dir = tempfile::tempdir().unwrap();
+        let store = mk(dir.path());
+        let ctx = CompressCtx { query: Some("database"), config: &cfg };
+        let input = "a.rs:1:hello world\nb.rs:2:database connection\nc.rs:3:weather";
+        let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.hash.is_some());
+        assert!(out.compressed.contains("database connection"));
+        assert!(out.compressed.contains("hash="));
+        // original retrievable
+        let got = store.get(out.hash.as_ref().unwrap()).unwrap().unwrap();
+        assert_eq!(got.item_count, 3);
+    }
+}

--- a/mur-compress/src/compressors/search.rs
+++ b/mur-compress/src/compressors/search.rs
@@ -21,7 +21,10 @@ fn group_by_file(items: &[String]) -> String {
             current = f;
         }
         // strip the leading "path:" so the file header carries it
-        let rest = it.strip_prefix(f).and_then(|r| r.strip_prefix(':')).unwrap_or(it);
+        let rest = it
+            .strip_prefix(f)
+            .and_then(|r| r.strip_prefix(':'))
+            .unwrap_or(it);
         out.push_str("  ");
         out.push_str(rest);
         out.push('\n');
@@ -48,8 +51,11 @@ pub fn compress(
         if ranked.is_empty() {
             (0..items.len().min(cfg.protect_head_lines)).collect()
         } else {
-            let mut idx: Vec<usize> =
-                ranked.into_iter().take(cfg.retrieve_top_k).map(|(i, _)| i).collect();
+            let mut idx: Vec<usize> = ranked
+                .into_iter()
+                .take(cfg.retrieve_top_k)
+                .map(|(i, _)| i)
+                .collect();
             idx.sort_unstable();
             idx
         }
@@ -79,7 +85,11 @@ pub fn compress(
         items.len() - kept.len(),
         hash
     ));
-    Ok(CompressOutput { compressed: body, hash: Some(hash), transforms })
+    Ok(CompressOutput {
+        compressed: body,
+        hash: Some(hash),
+        transforms,
+    })
 }
 
 #[cfg(test)]
@@ -99,7 +109,10 @@ mod tests {
         cfg.retrieve_top_k = 1;
         let dir = tempfile::tempdir().unwrap();
         let store = mk(dir.path());
-        let ctx = CompressCtx { query: Some("database"), config: &cfg };
+        let ctx = CompressCtx {
+            query: Some("database"),
+            config: &cfg,
+        };
         let input = "a.rs:1:hello world\nb.rs:2:database connection\nc.rs:3:weather";
         let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
         assert!(out.hash.is_some());

--- a/mur-compress/src/config.rs
+++ b/mur-compress/src/config.rs
@@ -1,0 +1,122 @@
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompressConfig {
+    pub enabled: bool,
+    pub tokenizer: String,
+    pub target_ratio: f32,
+    pub bloat_threshold: f32,
+    pub protect_head_lines: usize,
+    pub protect_tail_lines: usize,
+    pub retrieve_top_k: usize,
+    pub retrieve_score_threshold: f32,
+    pub detect: DetectCfg,
+    pub store: StoreCfg,
+    pub stats: StatsCfg,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DetectCfg {
+    pub search_min_ratio: f32,
+    pub log_min_ratio: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoreCfg {
+    pub dir: Option<String>,
+    pub ttl_days: u64,
+    pub max_entries: usize,
+    pub max_bytes: u64,
+    pub compress_at_rest: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatsCfg {
+    pub cost_per_mtok_usd: f64,
+}
+
+impl Default for CompressConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            tokenizer: "cl100k_base".into(),
+            target_ratio: 0.30,
+            bloat_threshold: 0.20,
+            protect_head_lines: 20,
+            protect_tail_lines: 10,
+            retrieve_top_k: 20,
+            retrieve_score_threshold: 0.30,
+            detect: DetectCfg::default(),
+            store: StoreCfg::default(),
+            stats: StatsCfg::default(),
+        }
+    }
+}
+
+impl Default for DetectCfg {
+    fn default() -> Self {
+        Self {
+            search_min_ratio: 0.6,
+            log_min_ratio: 0.5,
+        }
+    }
+}
+
+impl Default for StoreCfg {
+    fn default() -> Self {
+        Self {
+            dir: None,
+            ttl_days: 7,
+            max_entries: 2000,
+            max_bytes: 536_870_912,
+            compress_at_rest: true,
+        }
+    }
+}
+
+impl Default for StatsCfg {
+    fn default() -> Self {
+        Self {
+            cost_per_mtok_usd: 3.0,
+        }
+    }
+}
+
+impl CompressConfig {
+    /// Load config from a directory, falling back to defaults if no file is found.
+    pub fn load(dir: &Path) -> Self {
+        let path = dir.join("compress.yaml");
+        if let Ok(text) = std::fs::read_to_string(&path) {
+            serde_yaml::from_str(&text).unwrap_or_default()
+        } else {
+            Self::default()
+        }
+    }
+
+    /// TTL in seconds derived from `store.ttl_days`.
+    pub fn ttl_secs(&self) -> u64 {
+        self.store.ttl_days * 86_400
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_sane() {
+        let c = CompressConfig::default();
+        assert_eq!(c.store.ttl_days, 7);
+        assert_eq!(c.ttl_secs(), 7 * 86_400);
+        assert_eq!(c.retrieve_top_k, 20);
+        assert!(c.store.compress_at_rest);
+    }
+
+    #[test]
+    fn missing_config_file_yields_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let c = CompressConfig::load(dir.path());
+        assert_eq!(c.protect_head_lines, 20);
+    }
+}

--- a/mur-compress/src/detect.rs
+++ b/mur-compress/src/detect.rs
@@ -1,0 +1,97 @@
+//! Deterministic content-type detection (regex heuristics, no ML).
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::config::CompressConfig;
+use crate::types::ContentType;
+
+static SEARCH_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[^\s:]+:\d+:").unwrap());
+static LOG_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)\b(ERROR|WARN|WARNING|INFO|DEBUG|TRACE|FATAL)\b").unwrap());
+
+pub fn detect_content_type(content: &str, cfg: &CompressConfig) -> ContentType {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return ContentType::Generic;
+    }
+
+    // JSON: must actually parse.
+    if (trimmed.starts_with('{') || trimmed.starts_with('['))
+        && serde_json::from_str::<serde_json::Value>(trimmed).is_ok()
+    {
+        return ContentType::Json;
+    }
+
+    // Git diff: structural markers.
+    if content.contains("diff --git")
+        || content
+            .lines()
+            .any(|l| l.starts_with("@@ ") || l.starts_with("@@-"))
+        || (content.contains("\n--- ") && content.contains("\n+++ "))
+    {
+        return ContentType::GitDiff;
+    }
+
+    let lines: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.is_empty() {
+        return ContentType::Generic;
+    }
+    let n = lines.len() as f32;
+
+    let search_hits = lines.iter().filter(|l| SEARCH_RE.is_match(l)).count() as f32;
+    if search_hits / n >= cfg.detect.search_min_ratio {
+        return ContentType::SearchResults;
+    }
+
+    let log_hits = lines.iter().filter(|l| LOG_RE.is_match(l)).count() as f32;
+    if log_hits / n >= cfg.detect.log_min_ratio {
+        return ContentType::BuildLog;
+    }
+
+    ContentType::Generic
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> CompressConfig {
+        CompressConfig::default()
+    }
+
+    #[test]
+    fn detects_json_array() {
+        assert_eq!(
+            detect_content_type(r#"[{"a":1},{"a":2}]"#, &cfg()),
+            ContentType::Json
+        );
+    }
+
+    #[test]
+    fn detects_search_results() {
+        let s = "src/a.rs:10:fn foo\nsrc/b.rs:22:let x\nsrc/c.rs:3:use bar";
+        assert_eq!(detect_content_type(s, &cfg()), ContentType::SearchResults);
+    }
+
+    #[test]
+    fn detects_git_diff() {
+        let s = "diff --git a/x b/x\n@@ -1,2 +1,2 @@\n-old\n+new";
+        assert_eq!(detect_content_type(s, &cfg()), ContentType::GitDiff);
+    }
+
+    #[test]
+    fn detects_build_log() {
+        let s = "INFO starting\nERROR boom\nWARN careful\nDEBUG trace";
+        assert_eq!(detect_content_type(s, &cfg()), ContentType::BuildLog);
+    }
+
+    #[test]
+    fn falls_back_to_generic() {
+        assert_eq!(
+            detect_content_type("just some prose here", &cfg()),
+            ContentType::Generic
+        );
+    }
+}

--- a/mur-compress/src/lib.rs
+++ b/mur-compress/src/lib.rs
@@ -44,7 +44,12 @@ impl CompressEngine {
             config.store.compress_at_rest,
         )?;
         let stats = StatsTracker::new(dir.join("stats.json"));
-        Ok(Self { store, tok: default_counter(), config, stats })
+        Ok(Self {
+            store,
+            tok: default_counter(),
+            config,
+            stats,
+        })
     }
 
     fn dispatch(
@@ -69,17 +74,26 @@ impl CompressEngine {
     /// Compress `content`. Never errors: any failure returns the original.
     pub fn compress(&self, content: &str, query: Option<&str>) -> CompressResult {
         let ct = detect_content_type(content, &self.config);
-        let ctx = CompressCtx { query, config: &self.config };
-        let out = self.dispatch(ct, content, &ctx).unwrap_or_else(|_| CompressOutput {
-            compressed: content.to_string(),
-            hash: None,
-            transforms: Vec::new(),
-        });
+        let ctx = CompressCtx {
+            query,
+            config: &self.config,
+        };
+        let out = self
+            .dispatch(ct, content, &ctx)
+            .unwrap_or_else(|_| CompressOutput {
+                compressed: content.to_string(),
+                hash: None,
+                transforms: Vec::new(),
+            });
 
         let before = self.tok.count(content);
         let after = self.tok.count(&out.compressed);
         let saved = before.saturating_sub(after);
-        let pct = if before > 0 { saved as f32 / before as f32 * 100.0 } else { 0.0 };
+        let pct = if before > 0 {
+            saved as f32 / before as f32 * 100.0
+        } else {
+            0.0
+        };
         self.stats.record_compression(before, after);
 
         CompressResult {
@@ -112,7 +126,11 @@ impl CompressEngine {
                     .take(self.config.retrieve_top_k)
                     .map(|(i, _)| entry.items[i].clone())
                     .collect();
-                RetrieveResult::Filtered { query: q.to_string(), count: results.len(), results }
+                RetrieveResult::Filtered {
+                    query: q.to_string(),
+                    count: results.len(),
+                    results,
+                }
             }
             None => RetrieveResult::Full {
                 content_type: entry.content_type,
@@ -124,6 +142,7 @@ impl CompressEngine {
 
     pub fn stats_snapshot(&self) -> StatsSnapshot {
         let (entries, bytes) = self.store.stats();
-        self.stats.snapshot(self.config.stats.cost_per_mtok_usd, entries, bytes)
+        self.stats
+            .snapshot(self.config.stats.cost_per_mtok_usd, entries, bytes)
     }
 }

--- a/mur-compress/src/lib.rs
+++ b/mur-compress/src/lib.rs
@@ -1,0 +1,13 @@
+pub mod bm25;
+pub mod ccr;
+pub mod config;
+pub mod detect;
+pub mod tokenizer;
+pub mod types;
+
+pub use bm25::bm25_rank;
+pub use ccr::{CcrStore, CompressedEntry};
+pub use detect::detect_content_type;
+pub use types::{
+    CompressCtx, CompressError, CompressOutput, CompressResult, ContentType, RetrieveResult,
+};

--- a/mur-compress/src/lib.rs
+++ b/mur-compress/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod bm25;
-pub mod compressors;
 pub mod ccr;
+pub mod compressors;
 pub mod config;
 pub mod detect;
 pub mod tokenizer;

--- a/mur-compress/src/lib.rs
+++ b/mur-compress/src/lib.rs
@@ -3,12 +3,16 @@ pub mod ccr;
 pub mod compressors;
 pub mod config;
 pub mod detect;
+pub mod stats;
 pub mod tokenizer;
 pub mod types;
 
 pub use bm25::bm25_rank;
 pub use ccr::{CcrStore, CompressedEntry};
+pub use config::CompressConfig;
 pub use detect::detect_content_type;
+pub use stats::{StatsSnapshot, StatsTracker};
+pub use tokenizer::{TokenCounter, default_counter};
 pub use types::{
     CompressCtx, CompressError, CompressOutput, CompressResult, ContentType, RetrieveResult,
 };

--- a/mur-compress/src/lib.rs
+++ b/mur-compress/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bm25;
+pub mod compressors;
 pub mod ccr;
 pub mod config;
 pub mod detect;

--- a/mur-compress/src/lib.rs
+++ b/mur-compress/src/lib.rs
@@ -16,3 +16,114 @@ pub use tokenizer::{TokenCounter, default_counter};
 pub use types::{
     CompressCtx, CompressError, CompressOutput, CompressResult, ContentType, RetrieveResult,
 };
+
+use std::path::PathBuf;
+
+use crate::compressors::{diff, fallback, json, log, search};
+// IMPORTANT: do NOT add `use crate::ccr::CcrStore;`, `use crate::config::CompressConfig;`,
+// `use crate::tokenizer::{default_counter, TokenCounter};`, etc. Those names are already
+// in crate-root scope via the `pub use` re-exports above. Re-`use`-ing them here causes
+// "the name `X` is defined multiple times" compile errors.
+
+/// Top-level engine: owns the store, tokenizer, config, and stats.
+pub struct CompressEngine {
+    store: CcrStore,
+    tok: Box<dyn TokenCounter>,
+    config: CompressConfig,
+    stats: StatsTracker,
+}
+
+impl CompressEngine {
+    pub fn new(dir: impl Into<PathBuf>, config: CompressConfig) -> std::io::Result<Self> {
+        let dir = dir.into();
+        let store = CcrStore::new(
+            &dir,
+            config.ttl_secs(),
+            config.store.max_entries,
+            config.store.max_bytes,
+            config.store.compress_at_rest,
+        )?;
+        let stats = StatsTracker::new(dir.join("stats.json"));
+        Ok(Self { store, tok: default_counter(), config, stats })
+    }
+
+    fn dispatch(
+        &self,
+        ct: ContentType,
+        content: &str,
+        ctx: &CompressCtx,
+    ) -> Result<CompressOutput, CompressError> {
+        match ct {
+            ContentType::SearchResults => {
+                search::compress(content, ctx, &self.store, self.tok.as_ref())
+            }
+            ContentType::BuildLog => log::compress(content, ctx, &self.store, self.tok.as_ref()),
+            ContentType::GitDiff => diff::compress(content, ctx, &self.store, self.tok.as_ref()),
+            ContentType::Json => json::compress(content, ctx, &self.store, self.tok.as_ref()),
+            ContentType::Generic => {
+                fallback::compress(content, ctx, &self.store, self.tok.as_ref())
+            }
+        }
+    }
+
+    /// Compress `content`. Never errors: any failure returns the original.
+    pub fn compress(&self, content: &str, query: Option<&str>) -> CompressResult {
+        let ct = detect_content_type(content, &self.config);
+        let ctx = CompressCtx { query, config: &self.config };
+        let out = self.dispatch(ct, content, &ctx).unwrap_or_else(|_| CompressOutput {
+            compressed: content.to_string(),
+            hash: None,
+            transforms: Vec::new(),
+        });
+
+        let before = self.tok.count(content);
+        let after = self.tok.count(&out.compressed);
+        let saved = before.saturating_sub(after);
+        let pct = if before > 0 { saved as f32 / before as f32 * 100.0 } else { 0.0 };
+        self.stats.record_compression(before, after);
+
+        CompressResult {
+            compressed: out.compressed,
+            hash: out.hash,
+            original_tokens: before,
+            compressed_tokens: after,
+            tokens_saved: saved,
+            savings_percent: pct,
+            transforms: out.transforms,
+            content_type: ct,
+        }
+    }
+
+    /// Retrieve a stored original by hash, optionally BM25-filtered by query.
+    pub fn retrieve(&self, hash: &str, query: Option<&str>) -> RetrieveResult {
+        let entry = match self.store.get(hash) {
+            Ok(Some(e)) => e,
+            _ => return RetrieveResult::NotFound,
+        };
+        self.stats.record_retrieval();
+        match query {
+            Some(q) => {
+                let ranked = bm25_rank(q, &entry.items);
+                let max = ranked.first().map(|(_, s)| *s).unwrap_or(1.0).max(1e-6);
+                let results: Vec<String> = ranked
+                    .into_iter()
+                    .map(|(i, s)| (i, s / max))
+                    .filter(|(_, s)| *s >= self.config.retrieve_score_threshold)
+                    .take(self.config.retrieve_top_k)
+                    .map(|(i, _)| entry.items[i].clone())
+                    .collect();
+                RetrieveResult::Filtered { query: q.to_string(), count: results.len(), results }
+            }
+            None => RetrieveResult::Full {
+                content_type: entry.content_type,
+                original_content: entry.original_text,
+                item_count: entry.item_count,
+            },
+        }
+    }
+
+    pub fn stats_snapshot(&self) -> StatsSnapshot {
+        let (entries, bytes) = self.store.stats();
+        self.stats.snapshot(self.config.stats.cost_per_mtok_usd, entries, bytes)
+    }
+}

--- a/mur-compress/src/stats.rs
+++ b/mur-compress/src/stats.rs
@@ -1,0 +1,115 @@
+//! Persistent savings stats (atomic JSON at <store>/stats.json).
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct StatsData {
+    compressions: u64,
+    retrievals: u64,
+    total_input_tokens: u64,
+    total_output_tokens: u64,
+    total_tokens_saved: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct StatsSnapshot {
+    pub compressions: u64,
+    pub retrievals: u64,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub total_tokens_saved: u64,
+    pub savings_percent: f32,
+    pub estimated_cost_saved_usd: f64,
+    pub store_entries: usize,
+    pub store_bytes: u64,
+}
+
+pub struct StatsTracker {
+    path: PathBuf,
+    inner: Mutex<StatsData>,
+}
+
+impl StatsTracker {
+    pub fn new(path: PathBuf) -> Self {
+        let inner = std::fs::read(&path)
+            .ok()
+            .and_then(|b| serde_json::from_slice::<StatsData>(&b).ok())
+            .unwrap_or_default();
+        Self { path, inner: Mutex::new(inner) }
+    }
+
+    fn flush(&self, d: &StatsData) {
+        if let Ok(bytes) = serde_json::to_vec(d) {
+            let tmp = self.path.with_extension("tmp");
+            if std::fs::write(&tmp, &bytes).is_ok() {
+                let _ = std::fs::rename(&tmp, &self.path);
+            }
+        }
+    }
+
+    pub fn record_compression(&self, before: usize, after: usize) {
+        let mut d = self.inner.lock().unwrap();
+        d.compressions += 1;
+        d.total_input_tokens += before as u64;
+        d.total_output_tokens += after as u64;
+        d.total_tokens_saved += before.saturating_sub(after) as u64;
+        self.flush(&d);
+    }
+
+    pub fn record_retrieval(&self) {
+        let mut d = self.inner.lock().unwrap();
+        d.retrievals += 1;
+        self.flush(&d);
+    }
+
+    pub fn snapshot(
+        &self,
+        cost_per_mtok_usd: f64,
+        store_entries: usize,
+        store_bytes: u64,
+    ) -> StatsSnapshot {
+        let d = self.inner.lock().unwrap().clone();
+        let pct = if d.total_input_tokens > 0 {
+            d.total_tokens_saved as f32 / d.total_input_tokens as f32 * 100.0
+        } else {
+            0.0
+        };
+        let cost = d.total_tokens_saved as f64 * cost_per_mtok_usd / 1_000_000.0;
+        StatsSnapshot {
+            compressions: d.compressions,
+            retrievals: d.retrievals,
+            total_input_tokens: d.total_input_tokens,
+            total_output_tokens: d.total_output_tokens,
+            total_tokens_saved: d.total_tokens_saved,
+            savings_percent: pct,
+            estimated_cost_saved_usd: cost,
+            store_entries,
+            store_bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accumulates_and_persists() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stats.json");
+        let t = StatsTracker::new(path.clone());
+        t.record_compression(100, 30);
+        t.record_retrieval();
+        let snap = t.snapshot(3.0, 1, 123);
+        assert_eq!(snap.compressions, 1);
+        assert_eq!(snap.total_tokens_saved, 70);
+        assert!((snap.savings_percent - 70.0).abs() < 0.01);
+        // reload from disk
+        let t2 = StatsTracker::new(path);
+        let snap2 = t2.snapshot(3.0, 0, 0);
+        assert_eq!(snap2.total_tokens_saved, 70);
+    }
+}

--- a/mur-compress/src/stats.rs
+++ b/mur-compress/src/stats.rs
@@ -38,7 +38,10 @@ impl StatsTracker {
             .ok()
             .and_then(|b| serde_json::from_slice::<StatsData>(&b).ok())
             .unwrap_or_default();
-        Self { path, inner: Mutex::new(inner) }
+        Self {
+            path,
+            inner: Mutex::new(inner),
+        }
     }
 
     fn flush(&self, d: &StatsData) {

--- a/mur-compress/src/tokenizer.rs
+++ b/mur-compress/src/tokenizer.rs
@@ -1,0 +1,59 @@
+use crate::types::CompressError;
+use tiktoken_rs::CoreBPE;
+
+pub trait TokenCounter: Send + Sync {
+    fn count(&self, text: &str) -> usize;
+}
+
+pub struct TiktokenCounter {
+    bpe: CoreBPE,
+}
+
+impl TiktokenCounter {
+    pub fn new() -> Result<Self, CompressError> {
+        let bpe =
+            tiktoken_rs::cl100k_base().map_err(|e| CompressError::Tokenizer(e.to_string()))?;
+        Ok(Self { bpe })
+    }
+}
+
+impl TokenCounter for TiktokenCounter {
+    fn count(&self, text: &str) -> usize {
+        self.bpe.encode_with_special_tokens(text).len()
+    }
+}
+
+pub struct HeuristicCounter;
+
+impl TokenCounter for HeuristicCounter {
+    fn count(&self, text: &str) -> usize {
+        text.len().div_ceil(4)
+    }
+}
+
+/// Returns best counter; never fails.
+pub fn default_counter() -> Box<dyn TokenCounter> {
+    match TiktokenCounter::new() {
+        Ok(c) => Box::new(c),
+        Err(_) => Box::new(HeuristicCounter),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tiktoken_counts_are_positive_and_subword() {
+        let c = TiktokenCounter::new().expect("cl100k_base loads");
+        // tiktoken may tokenize "hello world" as 2 tokens; allow >=2 for vocab flexibility
+        assert!(c.count("hello world") >= 2);
+    }
+
+    #[test]
+    fn heuristic_is_chars_over_four() {
+        let h = HeuristicCounter;
+        assert_eq!(h.count("abcd"), 1);
+        assert_eq!(h.count("abcde"), 2);
+    }
+}

--- a/mur-compress/src/types.rs
+++ b/mur-compress/src/types.rs
@@ -1,0 +1,74 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ContentType {
+    SearchResults,
+    BuildLog,
+    GitDiff,
+    Json,
+    Generic,
+}
+
+impl ContentType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ContentType::SearchResults => "search_results",
+            ContentType::BuildLog => "build_log",
+            ContentType::GitDiff => "git_diff",
+            ContentType::Json => "json",
+            ContentType::Generic => "generic",
+        }
+    }
+}
+
+pub struct CompressCtx<'a> {
+    pub query: Option<&'a str>,
+    pub config: &'a crate::config::CompressConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompressOutput {
+    pub compressed: String,
+    pub hash: Option<String>,
+    pub transforms: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetrieveResult {
+    pub hash: String,
+    pub original_text: String,
+    pub items: Vec<String>,
+    pub original_tokens: usize,
+    pub item_count: usize,
+}
+
+pub type CompressResult<T> = Result<T, CompressError>;
+
+#[derive(Debug, Error)]
+pub enum CompressError {
+    #[error("tokenizer error: {0}")]
+    Tokenizer(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("store error: {0}")]
+    Store(String),
+    #[error("parse error: {0}")]
+    Parse(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn content_type_as_str_roundtrips() {
+        assert_eq!(ContentType::Json.as_str(), "json");
+        assert_eq!(ContentType::SearchResults.as_str(), "search_results");
+        assert_eq!(ContentType::BuildLog.as_str(), "build_log");
+        assert_eq!(ContentType::GitDiff.as_str(), "git_diff");
+        assert_eq!(ContentType::Generic.as_str(), "generic");
+    }
+}

--- a/mur-compress/src/types.rs
+++ b/mur-compress/src/types.rs
@@ -61,8 +61,6 @@ pub struct CompressResult {
     pub content_type: ContentType,
 }
 
-pub type CompressResultErr<T> = Result<T, CompressError>;
-
 #[derive(Debug, Error)]
 pub enum CompressError {
     #[error("tokenizer error: {0}")]

--- a/mur-compress/src/types.rs
+++ b/mur-compress/src/types.rs
@@ -34,16 +34,34 @@ pub struct CompressOutput {
     pub transforms: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RetrieveResult {
-    pub hash: String,
-    pub original_text: String,
-    pub items: Vec<String>,
-    pub original_tokens: usize,
-    pub item_count: usize,
+#[derive(Debug, Clone)]
+pub enum RetrieveResult {
+    Full {
+        content_type: String,
+        original_content: String,
+        item_count: usize,
+    },
+    Filtered {
+        query: String,
+        count: usize,
+        results: Vec<String>,
+    },
+    NotFound,
 }
 
-pub type CompressResult<T> = Result<T, CompressError>;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompressResult {
+    pub compressed: String,
+    pub hash: Option<String>,
+    pub original_tokens: usize,
+    pub compressed_tokens: usize,
+    pub tokens_saved: usize,
+    pub savings_percent: f32,
+    pub transforms: Vec<String>,
+    pub content_type: ContentType,
+}
+
+pub type CompressResultErr<T> = Result<T, CompressError>;
 
 #[derive(Debug, Error)]
 pub enum CompressError {

--- a/mur-compress/tests/end_to_end.rs
+++ b/mur-compress/tests/end_to_end.rs
@@ -24,7 +24,11 @@ fn search_compress_then_retrieve_is_reversible() {
 
     // Full retrieve reproduces the original exactly.
     match eng.retrieve(res.hash.as_ref().unwrap(), None) {
-        RetrieveResult::Full { original_content, item_count, .. } => {
+        RetrieveResult::Full {
+            original_content,
+            item_count,
+            ..
+        } => {
             assert_eq!(original_content, input);
             assert_eq!(item_count, 40);
         }
@@ -56,7 +60,10 @@ fn fail_safe_passthrough_on_generic_prose() {
 fn retrieve_unknown_hash_is_not_found() {
     let dir = tempfile::tempdir().unwrap();
     let eng = engine(dir.path());
-    assert!(matches!(eng.retrieve("nope", None), RetrieveResult::NotFound));
+    assert!(matches!(
+        eng.retrieve("nope", None),
+        RetrieveResult::NotFound
+    ));
 }
 
 #[test]
@@ -67,7 +74,9 @@ fn json_array_roundtrips_through_store() {
     let res = eng.compress(input, None);
     assert!(res.hash.is_some());
     match eng.retrieve(res.hash.as_ref().unwrap(), None) {
-        RetrieveResult::Full { original_content, .. } => assert_eq!(original_content, input),
+        RetrieveResult::Full {
+            original_content, ..
+        } => assert_eq!(original_content, input),
         _ => panic!("expected Full"),
     }
 }

--- a/mur-compress/tests/end_to_end.rs
+++ b/mur-compress/tests/end_to_end.rs
@@ -1,0 +1,73 @@
+use mur_compress::{CompressConfig, CompressEngine, RetrieveResult};
+
+fn engine(dir: &std::path::Path) -> CompressEngine {
+    let mut cfg = CompressConfig::default();
+    cfg.protect_head_lines = 2;
+    cfg.protect_tail_lines = 1;
+    cfg.store.compress_at_rest = false;
+    CompressEngine::new(dir, cfg).unwrap()
+}
+
+#[test]
+fn search_compress_then_retrieve_is_reversible() {
+    let dir = tempfile::tempdir().unwrap();
+    let eng = engine(dir.path());
+    let mut lines = Vec::new();
+    for i in 0..40 {
+        lines.push(format!("src/file{i}.rs:{i}:some content number {i}"));
+    }
+    let input = lines.join("\n");
+
+    let res = eng.compress(&input, Some("content number 7"));
+    assert!(res.hash.is_some(), "large search output should offload");
+    assert!(res.tokens_saved > 0);
+
+    // Full retrieve reproduces the original exactly.
+    match eng.retrieve(res.hash.as_ref().unwrap(), None) {
+        RetrieveResult::Full { original_content, item_count, .. } => {
+            assert_eq!(original_content, input);
+            assert_eq!(item_count, 40);
+        }
+        _ => panic!("expected Full"),
+    }
+
+    // Query-filtered retrieve returns relevant items.
+    match eng.retrieve(res.hash.as_ref().unwrap(), Some("number 7")) {
+        RetrieveResult::Filtered { count, results, .. } => {
+            assert!(count > 0);
+            assert!(results.iter().any(|r| r.contains("number 7")));
+        }
+        _ => panic!("expected Filtered"),
+    }
+}
+
+#[test]
+fn fail_safe_passthrough_on_generic_prose() {
+    let dir = tempfile::tempdir().unwrap();
+    let eng = engine(dir.path());
+    let input = "This is ordinary prose that should not be aggressively compressed.";
+    let res = eng.compress(input, None);
+    // generic -> fallback, no offload, no data loss of words
+    assert!(res.hash.is_none());
+    assert!(res.compressed.contains("ordinary prose"));
+}
+
+#[test]
+fn retrieve_unknown_hash_is_not_found() {
+    let dir = tempfile::tempdir().unwrap();
+    let eng = engine(dir.path());
+    assert!(matches!(eng.retrieve("nope", None), RetrieveResult::NotFound));
+}
+
+#[test]
+fn json_array_roundtrips_through_store() {
+    let dir = tempfile::tempdir().unwrap();
+    let eng = engine(dir.path());
+    let input = r#"[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8}]"#;
+    let res = eng.compress(input, None);
+    assert!(res.hash.is_some());
+    match eng.retrieve(res.hash.as_ref().unwrap(), None) {
+        RetrieveResult::Full { original_content, .. } => assert_eq!(original_content, input),
+        _ => panic!("expected Full"),
+    }
+}

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 mur-common = { path = "../mur-common", version = "2.16" }
+mur-compress = { path = "../mur-compress" }
 mur-agent-runtime = { path = "../mur-agent-runtime" }  # for cmd::agent::cmd_export
 tar = "0.4"           # cmd::agent_export_gui template-mode identity stripping
 flate2 = "1"          # gzip wrapper for the same

--- a/mur-core/src/cli/mod.rs
+++ b/mur-core/src/cli/mod.rs
@@ -368,4 +368,23 @@ pub enum Commands {
         #[command(subcommand)]
         action: ProjectAction,
     },
+    /// Compress stdin or a file; print the result + token delta on stderr
+    #[command(hide = true)]
+    Compress {
+        /// File to compress; omit (or pass `-`) to read stdin
+        #[arg(long)]
+        file: Option<String>,
+        /// Optional semantic filter for scoring
+        #[arg(long)]
+        query: Option<String>,
+    },
+    /// Retrieve original content by blake3 hash
+    #[command(hide = true)]
+    Retrieve {
+        /// Blake3 hash returned by `mur compress`
+        hash: String,
+        /// Optional filter query (returns matching subset)
+        #[arg(long)]
+        query: Option<String>,
+    },
 }

--- a/mur-core/src/cmd/compress.rs
+++ b/mur-core/src/cmd/compress.rs
@@ -1,0 +1,55 @@
+//! `mur compress` / `mur retrieve` — thin CLI over mur-compress.
+
+use std::io::Read;
+
+use mur_compress::{CompressConfig, CompressEngine, RetrieveResult};
+
+fn engine() -> anyhow::Result<CompressEngine> {
+    let home = crate::cmd::agent::resolve_mur_home()?;
+    let cfg = CompressConfig::load(&home);
+    Ok(CompressEngine::new(home.join("compress"), cfg)?)
+}
+
+fn read_input(file: Option<&str>) -> anyhow::Result<String> {
+    match file {
+        Some("-") | None => {
+            let mut s = String::new();
+            std::io::stdin().read_to_string(&mut s)?;
+            Ok(s)
+        }
+        Some(path) => Ok(std::fs::read_to_string(path)?),
+    }
+}
+
+pub fn do_compress(file: Option<&str>, query: Option<&str>) -> anyhow::Result<()> {
+    let eng = engine()?;
+    let content = read_input(file)?;
+    let r = eng.compress(&content, query);
+    println!("{}", r.compressed);
+    eprintln!(
+        "[{} -> {} tokens ({:.1}% saved){}]",
+        r.original_tokens,
+        r.compressed_tokens,
+        r.savings_percent,
+        r.hash.map(|h| format!(", hash={h}")).unwrap_or_default()
+    );
+    Ok(())
+}
+
+pub fn do_retrieve(hash: &str, query: Option<&str>) -> anyhow::Result<()> {
+    let eng = engine()?;
+    match eng.retrieve(hash, query) {
+        RetrieveResult::Full {
+            original_content, ..
+        } => println!("{original_content}"),
+        RetrieveResult::Filtered { results, .. } => {
+            for r in results {
+                println!("{r}");
+            }
+        }
+        RetrieveResult::NotFound => {
+            anyhow::bail!("content not found or expired for hash={hash}");
+        }
+    }
+    Ok(())
+}

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -18,6 +18,7 @@ pub mod agent_schedule;
 pub mod agent_voice;
 /// Track C5 / M5.1 — webhook receiver config + CLI verbs.
 pub(crate) mod agent_webhook;
+pub mod compress;
 pub mod context;
 pub(crate) mod conversations_cmd;
 pub mod conversations_cost_report;

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1018,6 +1018,12 @@ pub async fn run(cli: Cli) -> Result<()> {
                 SleepAction::Status => cmd::sleep::cmd_sleep_status()?,
             },
         },
+        Commands::Compress { file, query } => {
+            cmd::compress::do_compress(file.as_deref(), query.as_deref())?
+        }
+        Commands::Retrieve { hash, query } => {
+            cmd::compress::do_retrieve(&hash, query.as_deref())?
+        }
     }
 
     Ok(())

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1021,9 +1021,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Commands::Compress { file, query } => {
             cmd::compress::do_compress(file.as_deref(), query.as_deref())?
         }
-        Commands::Retrieve { hash, query } => {
-            cmd::compress::do_retrieve(&hash, query.as_deref())?
-        }
+        Commands::Retrieve { hash, query } => cmd::compress::do_retrieve(&hash, query.as_deref())?,
     }
 
     Ok(())

--- a/mur-mcp-server/Cargo.toml
+++ b/mur-mcp-server/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 mur-common = { path = "../mur-common" }
+mur-compress = { path = "../mur-compress" }
 mur-core = { path = "../mur-core" }
 tokio = { workspace = true }
 serde = { workspace = true }
@@ -17,3 +18,6 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/mur-mcp-server/src/tools.rs
+++ b/mur-mcp-server/src/tools.rs
@@ -4,7 +4,16 @@ use std::collections::BTreeMap;
 use serde::Serialize;
 use serde_json::{Value, json};
 
+use mur_compress::{CompressConfig, CompressEngine, RetrieveResult};
 use mur_core::cmd::notes_cmd;
+
+/// Build a per-call compression engine rooted at <mur_home>/compress.
+fn compress_engine() -> Result<CompressEngine, String> {
+    let home = resolve_mur_home().map_err(|e| format!("compress engine unavailable: {e}"))?;
+    let cfg = CompressConfig::load(&home);
+    CompressEngine::new(home.join("compress"), cfg)
+        .map_err(|e| format!("compress engine unavailable: {e}"))
+}
 
 /// JSON Schema for a tool parameter (MCP uses JSON Schema subset).
 #[derive(Debug, Clone, Serialize)]
@@ -211,6 +220,56 @@ pub fn all_tools() -> Vec<Tool> {
                 required: None,
             },
         },
+        // ── compress tools ──
+        Tool {
+            name: "mur_compress".into(),
+            description: "Compress bulky agent text (tool output, logs, search results, diffs, JSON) before it reaches the LLM. Reversible: the original is stored locally and retrievable by hash via mur_retrieve.".into(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".into(),
+                properties: Some(BTreeMap::from([
+                    ("content".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "The text to compress.".into(),
+                        default: None,
+                    }),
+                    ("query".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "Optional query to bias which lines/items are kept.".into(),
+                        default: None,
+                    }),
+                ])),
+                required: Some(vec!["content".into()]),
+            },
+        },
+        Tool {
+            name: "mur_retrieve".into(),
+            description: "Retrieve the original content stored by mur_compress, by its hash. With a query, returns only the BM25-relevant items.".into(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".into(),
+                properties: Some(BTreeMap::from([
+                    ("hash".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "Hash from a prior mur_compress result (e.g. hash=abc123...).".into(),
+                        default: None,
+                    }),
+                    ("query".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "Optional query to filter the stored items.".into(),
+                        default: None,
+                    }),
+                ])),
+                required: Some(vec!["hash".into()]),
+            },
+        },
+        Tool {
+            name: "mur_compress_stats".into(),
+            description: "Show cumulative token-compression savings (compressions, tokens saved, % saved, estimated cost saved, store size).".into(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".into(),
+                properties: None,
+                required: None,
+            },
+        },
     ]
 }
 
@@ -390,6 +449,86 @@ pub async fn call_tool(name: &str, arguments: &Value) -> Result<Value, String> {
                 .await
                 .map_err(|e| format!("scene_explain failed: {}", e))?;
             Ok(json!({ "explanation": text }))
+        }
+
+        "mur_compress" => {
+            let content = arguments
+                .get("content")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "Missing required parameter: 'content' (string)".to_string())?;
+            let query = arguments.get("query").and_then(|v| v.as_str());
+
+            let eng = compress_engine()?;
+            let r = eng.compress(content, query);
+            let note = match &r.hash {
+                Some(h) => format!(
+                    "Original stored with hash={h}. Use mur_retrieve to fetch full content."
+                ),
+                None => "No content offloaded; nothing to retrieve.".to_string(),
+            };
+            Ok(json!({
+                "compressed": r.compressed,
+                "hash": r.hash,
+                "content_type": r.content_type.as_str(),
+                "original_tokens": r.original_tokens,
+                "compressed_tokens": r.compressed_tokens,
+                "tokens_saved": r.tokens_saved,
+                "savings_percent": r.savings_percent,
+                "transforms": r.transforms,
+                "note": note,
+            }))
+        }
+
+        "mur_retrieve" => {
+            let hash = arguments
+                .get("hash")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "Missing required parameter: 'hash' (string)".to_string())?;
+            let query = arguments.get("query").and_then(|v| v.as_str());
+
+            let eng = compress_engine()?;
+            match eng.retrieve(hash, query) {
+                RetrieveResult::Full {
+                    content_type,
+                    original_content,
+                    item_count,
+                } => Ok(json!({
+                    "hash": hash,
+                    "content_type": content_type,
+                    "original_content": original_content,
+                    "item_count": item_count,
+                })),
+                RetrieveResult::Filtered {
+                    query,
+                    results,
+                    count,
+                } => Ok(json!({
+                    "hash": hash,
+                    "query": query,
+                    "results": results,
+                    "count": count,
+                })),
+                RetrieveResult::NotFound => Ok(json!({
+                    "error": "Content not found or expired.",
+                    "hash": hash,
+                    "hint": "The hash may be wrong or the entry's TTL has elapsed.",
+                })),
+            }
+        }
+
+        "mur_compress_stats" => {
+            let eng = compress_engine()?;
+            let s = eng.stats_snapshot();
+            Ok(json!({
+                "compressions": s.compressions,
+                "retrievals": s.retrievals,
+                "total_input_tokens": s.total_input_tokens,
+                "total_output_tokens": s.total_output_tokens,
+                "total_tokens_saved": s.total_tokens_saved,
+                "savings_percent": s.savings_percent,
+                "estimated_cost_saved_usd": s.estimated_cost_saved_usd,
+                "store": { "entries": s.store_entries, "bytes": s.store_bytes },
+            }))
         }
 
         _ => Err(format!("Unknown tool: {}", name)),

--- a/mur-mcp-server/tests/integration.rs
+++ b/mur-mcp-server/tests/integration.rs
@@ -53,7 +53,7 @@ fn test_initialize_and_list_tools() {
     );
     let resp = read_response(&mut stdout);
     let tools = resp["result"]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 10, "Expected 10 tools");
+    assert_eq!(tools.len(), 13, "Expected 13 tools");
 
     // Verify properties is an object (not an array) — MCP spec requires JSON object
     let first_tool_with_props = tools
@@ -78,6 +78,9 @@ fn test_initialize_and_list_tools() {
     assert!(names.contains(&"vlc_playback"));
     assert!(names.contains(&"vlc_status"));
     assert!(names.contains(&"scene_explain"));
+    assert!(names.contains(&"mur_compress"));
+    assert!(names.contains(&"mur_retrieve"));
+    assert!(names.contains(&"mur_compress_stats"));
 
     child.kill().ok();
 }
@@ -165,4 +168,61 @@ fn lists_project_search_tool() {
     );
 
     let _ = child.kill();
+}
+
+#[test]
+fn calls_mur_compress_tool() {
+    // Isolate the CCR store in a throwaway MUR_HOME for the child process.
+    let home = tempfile::tempdir().unwrap();
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mur-mcp-server"))
+        .env("MUR_HOME", home.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = std::io::BufReader::new(child.stdout.take().unwrap());
+
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+    );
+    let _ = read_response(&mut stdout);
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+    );
+    let _ = read_response(&mut stdout);
+
+    // A long search-style payload that should compress and offload.
+    let mut lines = Vec::new();
+    for i in 0..40 {
+        lines.push(format!("src/f{i}.rs:{i}:token number {i}"));
+    }
+    let content = lines.join("\n");
+    let req = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": { "name": "mur_compress", "arguments": { "content": content, "query": "number 7" } }
+    })
+    .to_string();
+    send_request(&mut stdin, &req);
+    let resp = read_response(&mut stdout);
+
+    // The tool's JSON result is embedded in the MCP content array; rather than
+    // depend on the exact nesting, assert the markers appear anywhere in the response.
+    let resp_str = serde_json::to_string(&resp).unwrap();
+    assert!(
+        resp_str.contains("tokens_saved"),
+        "mur_compress result missing tokens_saved: {resp_str}"
+    );
+    assert!(
+        resp_str.contains("hash="),
+        "mur_compress result should include a retrieval-hash note: {resp_str}"
+    );
+
+    child.kill().ok();
 }


### PR DESCRIPTION
## Summary
- New **`mur-compress`** crate — offline, local-first, **reversible** token compression modeled on [headroom](https://github.com/chopratejas/headroom)'s two-stage (Reformat → Offload) architecture, reimplemented clean-room (MIT; headroom is Apache-2.0, credited in `lib.rs`).
- Content-routed compressors — **search / log / diff / json** (+ a safe fallback). Each lossless-densifies, then reversibly offloads originals into a **CCR store** at `~/.mur/compress/` (blake3-keyed, gzip-at-rest, TTL + LRU eviction). Drop from the prompt, keep on disk, retrieve on demand.
- Real token counting via **`tiktoken-rs`** (cl100k_base, fully offline) with a chars/4 fallback; self-contained **BM25** for query-filtered retrieve.
- **3 MCP tools** in `mur-mcp-server`: `mur_compress`, `mur_retrieve`, `mur_compress_stats` (tool count 10 → 13).
- Optional **`mur compress` / `mur retrieve`** CLI.
- Design spec + bite-sized TDD implementation plan under `docs/superpowers/{specs,plans}/2026-06-03-mur-compress-token*`.

Fail-safe by construction: any error in any stage returns the original content unchanged.

## Test Plan
- [x] CI `cargo nextest run --workspace` — green on macOS / Linux / Windows
- [x] `cargo test -p mur-compress` — **26 passing** (unit + reversibility / fail-safe end-to-end)
- [x] `cargo test -p mur-mcp-server` — **5 passing** (incl. stdio `mur_compress` tools/call)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Note for local testing
This workspace's CI uses **`cargo nextest run`** (one process per test). If you run plain **`cargo test --workspace`** instead, you'll see 7 unrelated `mur-core` failures (`conversations::summarize::rollup::*`, `paths::tests`, `cmd::agent::model_resolve`). Those tests share a global `conversations::ENV_LOCK` mutex + process-global env vars and only break under `cargo test`'s shared-process model (one panic poisons the mutex → `PoisonError` cascade; env-var races on the rest). They pass under nextest, are green in CI, and are untouched by this branch. TL;DR: verify locally with `cargo nextest run`, not `cargo test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)