### PR TITLE
fix(compress): deep-review correctness fixes (bloat guard, config, stats race, LRU)

### DIFF
--- a/mur-compress/Cargo.toml
+++ b/mur-compress/Cargo.toml
@@ -13,6 +13,7 @@ serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 blake3 = "1"
 flate2 = "1"
+fs2 = { workspace = true }
 tiktoken-rs = "0.6"
 regex = "1"
 

--- a/mur-compress/src/ccr/store.rs
+++ b/mur-compress/src/ccr/store.rs
@@ -1,5 +1,7 @@
 //! Persistent, bounded CCR store. One JSON(.gz) file per entry under
-//! <dir>/entries/. Atomic temp+rename writes. TTL on read, size/count eviction.
+//! <dir>/entries/. Atomic temp+rename writes. TTL on read; size/count eviction
+//! is LRU — `get()` touches an entry's mtime so frequently-retrieved originals
+//! outlive cold ones.
 
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -129,6 +131,11 @@ impl CcrStore {
             let _ = std::fs::remove_file(&path);
             return Ok(None);
         }
+        // Touch mtime so eviction (which orders by mtime) is LRU, not FIFO.
+        // Best-effort: a failure here only affects eviction ordering.
+        if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&path) {
+            let _ = f.set_modified(std::time::SystemTime::now());
+        }
         Ok(Some(entry))
     }
 
@@ -155,7 +162,10 @@ impl CcrStore {
         for e in std::fs::read_dir(&self.entries_dir)? {
             let e = e?;
             let md = e.metadata()?;
-            if !md.is_file() {
+            // Skip non-files and in-flight temp files: a `.tmp` belongs to an
+            // active writer (possibly another process) and must not be counted
+            // toward the budget or deleted out from under its rename.
+            if !md.is_file() || e.path().extension().is_some_and(|x| x == "tmp") {
                 continue;
             }
             let mtime = md.modified().unwrap_or(std::time::UNIX_EPOCH);

--- a/mur-compress/src/compressors/search.rs
+++ b/mur-compress/src/compressors/search.rs
@@ -7,7 +7,21 @@ use crate::tokenizer::TokenCounter;
 use crate::types::{CompressCtx, CompressError, CompressOutput, ContentType};
 
 fn file_of(line: &str) -> &str {
-    // "path:line:content" -> "path"
+    // grep emits "path:line:content". The path itself may contain a colon
+    // (e.g. a Windows drive `C:\src\x.rs`), so we can't just split on the first
+    // ':'. Instead find the first ":<digits>:" boundary and treat everything
+    // before it as the path.
+    let mut start = 0;
+    while let Some(rel) = line[start..].find(':') {
+        let colon = start + rel;
+        let after = &line[colon + 1..];
+        let digits = after.len() - after.trim_start_matches(|c: char| c.is_ascii_digit()).len();
+        if digits > 0 && after[digits..].starts_with(':') {
+            return &line[..colon];
+        }
+        start = colon + 1;
+    }
+    // No line-number marker found: fall back to the first colon segment.
     line.split(':').next().unwrap_or("")
 }
 
@@ -100,6 +114,13 @@ mod tests {
 
     fn mk(dir: &std::path::Path) -> CcrStore {
         CcrStore::new(dir, 3600, 100, 1 << 30, false).unwrap()
+    }
+
+    #[test]
+    fn file_of_handles_colons_in_path() {
+        assert_eq!(file_of("src/a.rs:10:fn foo"), "src/a.rs");
+        assert_eq!(file_of(r"C:\src\a.rs:10:fn foo"), r"C:\src\a.rs");
+        assert_eq!(file_of("no-marker-line"), "no-marker-line");
     }
 
     #[test]

--- a/mur-compress/src/config.rs
+++ b/mur-compress/src/config.rs
@@ -1,6 +1,24 @@
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+/// Deep-merge `overlay` onto `base` (user values win; missing keys keep base).
+fn merge_yaml(base: &mut serde_yaml::Value, overlay: serde_yaml::Value) {
+    use serde_yaml::Value;
+    match (base, overlay) {
+        (Value::Mapping(b), Value::Mapping(o)) => {
+            for (k, v) in o {
+                match b.get_mut(&k) {
+                    Some(bv) => merge_yaml(bv, v),
+                    None => {
+                        b.insert(k, v);
+                    }
+                }
+            }
+        }
+        (b, o) => *b = o,
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompressConfig {
     pub enabled: bool,
@@ -85,12 +103,35 @@ impl Default for StatsCfg {
 
 impl CompressConfig {
     /// Load config from a directory, falling back to defaults if no file is found.
+    ///
+    /// A partial `compress.yaml` is merged *onto* the defaults: any field the
+    /// user omits keeps its default value, rather than silently reverting the
+    /// whole config. Only a syntactically malformed file or a field with an
+    /// invalid value falls back to full defaults (with a stderr warning).
     pub fn load(dir: &Path) -> Self {
         let path = dir.join("compress.yaml");
-        if let Ok(text) = std::fs::read_to_string(&path) {
-            serde_yaml::from_str(&text).unwrap_or_default()
-        } else {
-            Self::default()
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            return Self::default();
+        };
+        let overlay: serde_yaml::Value = match serde_yaml::from_str(&text) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("[mur-compress] ignoring malformed {}: {e}", path.display());
+                return Self::default();
+            }
+        };
+        let mut merged =
+            serde_yaml::to_value(Self::default()).expect("CompressConfig is serializable");
+        merge_yaml(&mut merged, overlay);
+        match serde_yaml::from_value(merged) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "[mur-compress] {} has invalid values, using defaults: {e}",
+                    path.display()
+                );
+                Self::default()
+            }
         }
     }
 
@@ -116,6 +157,32 @@ mod tests {
     #[test]
     fn missing_config_file_yields_defaults() {
         let dir = tempfile::tempdir().unwrap();
+        let c = CompressConfig::load(dir.path());
+        assert_eq!(c.protect_head_lines, 20);
+    }
+
+    #[test]
+    fn partial_config_merges_onto_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("compress.yaml"),
+            "target_ratio: 0.5\nstore:\n  ttl_days: 30\n",
+        )
+        .unwrap();
+        let c = CompressConfig::load(dir.path());
+        // Overridden fields take the user value...
+        assert_eq!(c.target_ratio, 0.5);
+        assert_eq!(c.store.ttl_days, 30);
+        // ...while omitted fields keep their defaults instead of reverting.
+        assert_eq!(c.protect_head_lines, 20);
+        assert_eq!(c.store.max_entries, 2000);
+        assert!(c.enabled);
+    }
+
+    #[test]
+    fn malformed_config_falls_back_to_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("compress.yaml"), "this: [is: not: valid").unwrap();
         let c = CompressConfig::load(dir.path());
         assert_eq!(c.protect_head_lines, 20);
     }

--- a/mur-compress/src/lib.rs
+++ b/mur-compress/src/lib.rs
@@ -153,6 +153,12 @@ impl CompressEngine {
         self.stats.record_retrieval();
         match query {
             Some(q) => {
+                // `retrieve_score_threshold` filters on score *relative to the
+                // best match* (scores are max-normalized below), not an absolute
+                // BM25 value — raw BM25 is unbounded and corpus-dependent. The
+                // top hit always normalizes to 1.0, so a query that matches at
+                // all returns at least its best item; the threshold prunes the
+                // long tail of weakly-related items.
                 let ranked = bm25_rank(q, &entry.items);
                 let max = ranked.first().map(|(_, s)| *s).unwrap_or(1.0).max(1e-6);
                 let results: Vec<String> = ranked

--- a/mur-compress/src/lib.rs
+++ b/mur-compress/src/lib.rs
@@ -71,9 +71,34 @@ impl CompressEngine {
         }
     }
 
+    /// A no-op result that returns `content` unchanged.
+    fn passthrough(content: &str, before: usize, ct: ContentType) -> CompressResult {
+        CompressResult {
+            compressed: content.to_string(),
+            hash: None,
+            original_tokens: before,
+            compressed_tokens: before,
+            tokens_saved: 0,
+            savings_percent: 0.0,
+            transforms: vec!["passthrough".to_string()],
+            content_type: ct,
+        }
+    }
+
     /// Compress `content`. Never errors: any failure returns the original.
+    ///
+    /// The result is only kept if it actually pays off — it must be strictly
+    /// smaller than the input, and any result that offloaded to the store must
+    /// clear `bloat_threshold`. Otherwise the original is returned unchanged so
+    /// compression can never "help backwards". Disabled config is also a no-op.
     pub fn compress(&self, content: &str, query: Option<&str>) -> CompressResult {
         let ct = detect_content_type(content, &self.config);
+        let before = self.tok.count(content);
+
+        if !self.config.enabled {
+            return Self::passthrough(content, before, ct);
+        }
+
         let ctx = CompressCtx {
             query,
             config: &self.config,
@@ -86,14 +111,25 @@ impl CompressEngine {
                 transforms: Vec::new(),
             });
 
-        let before = self.tok.count(content);
         let after = self.tok.count(&out.compressed);
         let saved = before.saturating_sub(after);
-        let pct = if before > 0 {
-            saved as f32 / before as f32 * 100.0
+        let saved_frac = if before > 0 {
+            saved as f32 / before as f32
         } else {
             0.0
         };
+
+        // Reject results that don't pay off. Reformat-only output (no hash) just
+        // has to be smaller; offloaded output (hash present, paid a store write)
+        // must also clear the bloat gate. A rejected offload leaves an orphan
+        // store entry that ages out via TTL/eviction — a future estimate_bloat()
+        // pre-gate could avoid the wasted write entirely.
+        let worth_it =
+            after < before && (out.hash.is_none() || saved_frac >= self.config.bloat_threshold);
+        if !worth_it {
+            return Self::passthrough(content, before, ct);
+        }
+
         self.stats.record_compression(before, after);
 
         CompressResult {
@@ -102,7 +138,7 @@ impl CompressEngine {
             original_tokens: before,
             compressed_tokens: after,
             tokens_saved: saved,
-            savings_percent: pct,
+            savings_percent: saved_frac * 100.0,
             transforms: out.transforms,
             content_type: ct,
         }
@@ -144,5 +180,60 @@ impl CompressEngine {
         let (entries, bytes) = self.store.stats();
         self.stats
             .snapshot(self.config.stats.cost_per_mtok_usd, entries, bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn engine(dir: &std::path::Path, cfg: CompressConfig) -> CompressEngine {
+        CompressEngine::new(dir, cfg).unwrap()
+    }
+
+    #[test]
+    fn disabled_config_is_a_passthrough() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = CompressConfig::default();
+        cfg.enabled = false;
+        let eng = engine(dir.path(), cfg);
+        // A long search result that would normally offload.
+        let input = (0..40)
+            .map(|i| format!("src/f{i}.rs:{i}:line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let res = eng.compress(&input, Some("line 7"));
+        assert!(res.hash.is_none(), "disabled engine must not offload");
+        assert_eq!(
+            res.compressed, input,
+            "disabled engine returns input verbatim"
+        );
+        assert_eq!(res.tokens_saved, 0);
+        assert_eq!(
+            eng.stats_snapshot().compressions,
+            0,
+            "no-op is not recorded"
+        );
+    }
+
+    #[test]
+    fn expanding_result_passes_through_instead_of_helping_backwards() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = CompressConfig::default();
+        cfg.store.compress_at_rest = false;
+        cfg.protect_head_lines = 2;
+        let eng = engine(dir.path(), cfg);
+        // A tiny array just over the collapse threshold: the schema+sample+hash
+        // wrapper is larger than the original, so it must NOT be kept.
+        let input = r#"[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6}]"#;
+        let res = eng.compress(input, None);
+        assert!(
+            res.hash.is_none(),
+            "expanding compression must pass through"
+        );
+        assert_eq!(res.compressed, input);
+        assert_eq!(res.tokens_saved, 0);
+        assert!(res.compressed_tokens <= res.original_tokens);
+        assert_eq!(eng.stats_snapshot().compressions, 0);
     }
 }

--- a/mur-compress/src/stats.rs
+++ b/mur-compress/src/stats.rs
@@ -1,8 +1,16 @@
 //! Persistent savings stats (atomic JSON at <store>/stats.json).
+//!
+//! Updates are safe across processes/engines: every mutation takes an advisory
+//! lock on a sidecar `stats.lock`, re-reads the on-disk totals, applies its
+//! delta, and writes back. Without this, two engines (the MCP server builds a
+//! fresh one per call) would each read the same baseline and clobber each
+//! other's increment, undercounting savings.
 
+use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -53,19 +61,47 @@ impl StatsTracker {
         }
     }
 
+    fn read_disk(&self) -> Option<StatsData> {
+        std::fs::read(&self.path)
+            .ok()
+            .and_then(|b| serde_json::from_slice::<StatsData>(&b).ok())
+    }
+
+    /// Apply `delta` to the freshest on-disk totals under an advisory lock, so
+    /// concurrent engines accumulate instead of clobbering each other.
+    fn update(&self, delta: impl FnOnce(&mut StatsData)) {
+        let mut guard = self.inner.lock().unwrap();
+        // Sidecar lock file: the data file is replaced via rename (new inode),
+        // so it can't itself be a stable lock target.
+        let lock = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(self.path.with_extension("lock"))
+            .ok();
+        if let Some(l) = &lock {
+            let _ = l.lock_exclusive();
+        }
+        let mut data = self.read_disk().unwrap_or_else(|| guard.clone());
+        delta(&mut data);
+        self.flush(&data);
+        *guard = data;
+        if let Some(l) = &lock {
+            let _ = FileExt::unlock(l);
+        }
+    }
+
     pub fn record_compression(&self, before: usize, after: usize) {
-        let mut d = self.inner.lock().unwrap();
-        d.compressions += 1;
-        d.total_input_tokens += before as u64;
-        d.total_output_tokens += after as u64;
-        d.total_tokens_saved += before.saturating_sub(after) as u64;
-        self.flush(&d);
+        self.update(|d| {
+            d.compressions += 1;
+            d.total_input_tokens += before as u64;
+            d.total_output_tokens += after as u64;
+            d.total_tokens_saved += before.saturating_sub(after) as u64;
+        });
     }
 
     pub fn record_retrieval(&self) {
-        let mut d = self.inner.lock().unwrap();
-        d.retrievals += 1;
-        self.flush(&d);
+        self.update(|d| d.retrievals += 1);
     }
 
     pub fn snapshot(
@@ -74,7 +110,11 @@ impl StatsTracker {
         store_entries: usize,
         store_bytes: u64,
     ) -> StatsSnapshot {
-        let d = self.inner.lock().unwrap().clone();
+        // Prefer the on-disk totals so a snapshot reflects writes from other
+        // engines/processes, not just this instance's view.
+        let d = self
+            .read_disk()
+            .unwrap_or_else(|| self.inner.lock().unwrap().clone());
         let pct = if d.total_input_tokens > 0 {
             d.total_tokens_saved as f32 / d.total_input_tokens as f32 * 100.0
         } else {
@@ -114,5 +154,25 @@ mod tests {
         let t2 = StatsTracker::new(path);
         let snap2 = t2.snapshot(3.0, 0, 0);
         assert_eq!(snap2.total_tokens_saved, 70);
+    }
+
+    #[test]
+    fn concurrent_instances_accumulate_without_clobbering() {
+        // Two trackers on the same file (as the MCP server's per-call engines
+        // would be) must sum their deltas, not overwrite each other.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stats.json");
+        let a = StatsTracker::new(path.clone());
+        let b = StatsTracker::new(path.clone());
+        a.record_compression(100, 30); // saved 70
+        b.record_compression(50, 10); // saved 40
+        a.record_retrieval();
+        b.record_retrieval();
+
+        let snap = StatsTracker::new(path).snapshot(3.0, 0, 0);
+        assert_eq!(snap.compressions, 2);
+        assert_eq!(snap.retrievals, 2);
+        assert_eq!(snap.total_input_tokens, 150);
+        assert_eq!(snap.total_tokens_saved, 110);
     }
 }

--- a/mur-compress/tests/end_to_end.rs
+++ b/mur-compress/tests/end_to_end.rs
@@ -70,9 +70,15 @@ fn retrieve_unknown_hash_is_not_found() {
 fn json_array_roundtrips_through_store() {
     let dir = tempfile::tempdir().unwrap();
     let eng = engine(dir.path());
-    let input = r#"[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8}]"#;
-    let res = eng.compress(input, None);
+    // A large array of fat rows: the schema+sample+offload form is genuinely
+    // smaller than the original, so the bloat guard keeps the compressed result.
+    let rows: Vec<String> = (0..60)
+        .map(|i| format!(r#"{{"id":{i},"name":"item number {i}","value":{i}}}"#))
+        .collect();
+    let input = format!("[{}]", rows.join(","));
+    let res = eng.compress(&input, None);
     assert!(res.hash.is_some());
+    assert!(res.tokens_saved > 0);
     match eng.retrieve(res.hash.as_ref().unwrap(), None) {
         RetrieveResult::Full {
             original_content, ..


### PR DESCRIPTION
Fixes found in a deep review of the `mur-compress` crate (PR #348).

## Correctness
- **Bloat guard** — `compress()` could return output *larger* than the input (e.g. JSON row-collapse on a small array, or a log/search offload that kept almost everything), so swapping in the "compressed" form could increase tokens and write a useless store entry. The spec's `bloat_threshold`/`target_ratio` were defined but wired nowhere. A result is now kept only if it's strictly smaller, and any offloaded result must also clear `bloat_threshold`; otherwise the original passes through. Passthroughs no longer inflate stats.
- **`enabled` flag wired** — `enabled: false` had no effect; now short-circuits to passthrough.
- **Partial config merge** — `compress.yaml` is deep-merged onto defaults, so one missing field/typo no longer silently reverts the whole config. Malformed files fall back with a stderr warning.

## Robustness
- **Stats lost-update race** — the MCP server builds a fresh engine per call, so concurrent `StatsTracker`s clobbered each other. Mutations now take an advisory lock on a `stats.lock` sidecar, re-read on-disk totals, apply their delta, and write back; `snapshot()` reads fresh from disk.
- **LRU eviction** — `get()` touches mtime so frequently-retrieved originals outlive cold ones (was FIFO despite the "LRU" name).
- **`.tmp`-safe eviction** — in-flight temp files are no longer counted toward the budget or deleted out from under a concurrent writer's rename.
- **Colon-safe `file_of`** — search-result grouping handles Windows drive paths (`C:\src\x.rs:10:…`).
- Documented that `retrieve_score_threshold` is relative-to-best (max-normalized), not an absolute BM25 cutoff.

## Tests
32 tests pass (added engine passthrough, disabled-config, partial/malformed config merge, two-instance stats accumulation, colon-path cases). clippy + fmt clean; `mur-core` and `mur-mcp-server` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)