### PR TITLE
fix(muragent): block identity-key overwrite, cap decompression, parse rotation timestamps

### DIFF
--- a/mur-common/src/muragent/installer.rs
+++ b/mur-common/src/muragent/installer.rs
@@ -32,6 +32,18 @@ use crate::trust::{self, TrustEntry, TrustLevel, TrustStore};
 /// Files in the .muragent that belong to the package envelope (not payload).
 const ENVELOPE_FILES: &[&str] = &["manifest.yaml", "manifest.signed.json", "signatures.json"];
 
+/// Host-local files a `.muragent` must never carry. `identity.key` is the
+/// agent's *private* signing key, minted locally and stripped by export; a
+/// package that ships one of these is malformed or hostile, since extracting it
+/// would plant or overwrite the agent's identity (impersonation, or breaking
+/// re-export). Matched against the top-level extraction path.
+const RESERVED_LOCAL_FILES: &[&str] = &[
+    "identity.key",
+    "identity.pub",
+    "identity.key.prev",
+    "identity.pub.prev",
+];
+
 /// Result of a successful install or update.
 #[derive(Debug)]
 pub struct InstallOutcome {
@@ -61,6 +73,11 @@ pub fn install(
 ) -> Result<InstallOutcome, MuragentError> {
     // Step 1: validation pipeline — fatal on any failure per §7.5
     let result = validator::validate(archive)?;
+
+    // Step 1.5: reject host-local identity material in the payload. Extraction
+    // writes every payload file into the agent dir, so a package shipping
+    // `identity.key` would plant/overwrite the agent's private signing key.
+    reject_reserved_local_files(archive)?;
 
     // Step 2: slug shape
     let slug = result.manifest.agent.slug.clone();
@@ -150,6 +167,20 @@ pub fn install(
     })
 }
 
+/// Refuse a package that carries any [`RESERVED_LOCAL_FILES`] entry at its top
+/// level — extracting it would plant/overwrite host-minted identity material.
+fn reject_reserved_local_files(archive: &MuragentArchive) -> Result<(), MuragentError> {
+    for path in archive.files.keys() {
+        if RESERVED_LOCAL_FILES.contains(&path.as_str()) {
+            return Err(MuragentError::Other(format!(
+                "package contains reserved local file '{path}' \
+                 (private identity material is host-minted and must not be shipped)"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Convert a display name to a filesystem-safe slug for rotation manifest lookup.
 fn display_name_slug(name: &str) -> String {
     name.to_lowercase()
@@ -207,14 +238,22 @@ fn try_apply_rotation(
     manifest.verify()?;
 
     // Replay prevention: issued_at must be strictly newer than last_rotation_at.
+    // Compare parsed instants, not raw strings — RFC3339 is not lexicographically
+    // ordered across offsets/precision ("Z" vs "+00:00", fractional seconds), so a
+    // string compare could let a replayed manifest slip through.
     if let Some(entry) = old_entry
         && let Some(last_at) = &entry.last_rotation_at
-        && manifest.issued_at <= *last_at
     {
-        return Err(format!(
-            "rotation manifest issued_at ({}) is not newer than last_rotation_at ({})",
-            manifest.issued_at, last_at
-        ));
+        let issued = chrono::DateTime::parse_from_rfc3339(&manifest.issued_at)
+            .map_err(|e| format!("rotation manifest issued_at is not valid RFC3339: {e}"))?;
+        let last = chrono::DateTime::parse_from_rfc3339(last_at)
+            .map_err(|e| format!("stored last_rotation_at is not valid RFC3339: {e}"))?;
+        if issued <= last {
+            return Err(format!(
+                "rotation manifest issued_at ({}) is not newer than last_rotation_at ({})",
+                manifest.issued_at, last_at
+            ));
+        }
     }
 
     // Apply: mark old entry Superseded, insert new entry.
@@ -279,7 +318,8 @@ fn clear_except_data(dir: &Path) -> Result<(), MuragentError> {
 
 fn extract_payload(archive: &MuragentArchive, agent_dir: &Path) -> Result<(), MuragentError> {
     for (path, data) in &archive.files {
-        if ENVELOPE_FILES.contains(&path.as_str()) {
+        if ENVELOPE_FILES.contains(&path.as_str()) || RESERVED_LOCAL_FILES.contains(&path.as_str())
+        {
             continue;
         }
         let dest = agent_dir.join(path);
@@ -441,6 +481,29 @@ mod tests {
                 std::env::remove_var("MUR_HOME");
             }
         }
+    }
+
+    #[test]
+    fn reserved_local_files_are_rejected() {
+        // A package carrying private identity material must be refused before
+        // extraction (which would plant/overwrite the agent's signing key).
+        use std::collections::BTreeMap;
+        for reserved in RESERVED_LOCAL_FILES {
+            let mut files = BTreeMap::new();
+            files.insert("profile.yaml".to_string(), b"ok".to_vec());
+            files.insert((*reserved).to_string(), b"ATTACKER-KEY".to_vec());
+            let archive = MuragentArchive { files };
+            assert!(
+                reject_reserved_local_files(&archive).is_err(),
+                "must reject package carrying {reserved}"
+            );
+        }
+        // A clean payload passes.
+        let mut files = BTreeMap::new();
+        files.insert("profile.yaml".to_string(), b"ok".to_vec());
+        files.insert("skills/demo.md".to_string(), b"skill".to_vec());
+        let archive = MuragentArchive { files };
+        assert!(reject_reserved_local_files(&archive).is_ok());
     }
 
     #[test]

--- a/mur-common/src/muragent/reader.rs
+++ b/mur-common/src/muragent/reader.rs
@@ -7,6 +7,16 @@ use std::io::Read;
 use std::path::Path;
 use tar::Archive;
 
+/// Resource bounds for an untrusted `.muragent`. A `.muragent` is a tar.gz from
+/// an untrusted source (a friend, a download), so the reader must not let a tiny
+/// archive decompress into unbounded memory (a gzip/tar bomb). These caps are
+/// generous for a real agent bundle (manifest + a few icons/skills) but stop a
+/// malicious package from OOM-ing the host on import.
+const MAX_ENTRIES: usize = 10_000;
+const MAX_FILE_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB per file
+const MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB decompressed total
+
+#[derive(Debug)]
 pub struct MuragentArchive {
     /// All files in the tarball keyed by path → raw bytes.
     pub files: BTreeMap<String, Vec<u8>>,
@@ -15,15 +25,34 @@ pub struct MuragentArchive {
 impl MuragentArchive {
     /// Read and extract all files from a `.muragent` tar.gz.
     pub fn read(path: &Path) -> Result<Self, MuragentError> {
+        Self::read_with_limits(path, MAX_ENTRIES, MAX_FILE_BYTES, MAX_TOTAL_BYTES)
+    }
+
+    /// Implementation of [`read`](Self::read) with explicit resource caps, so
+    /// the bomb defenses can be exercised with small limits in tests.
+    fn read_with_limits(
+        path: &Path,
+        max_entries: usize,
+        max_file_bytes: u64,
+        max_total_bytes: u64,
+    ) -> Result<Self, MuragentError> {
         let file = std::fs::File::open(path).map_err(MuragentError::Io)?;
         let gz = GzDecoder::new(file);
         let mut archive = Archive::new(gz);
         let mut files = BTreeMap::new();
+        let mut entry_count = 0usize;
+        let mut total_bytes = 0u64;
 
         for entry in archive
             .entries()
             .map_err(|e| MuragentError::Other(format!("tar entries: {e}")))?
         {
+            entry_count += 1;
+            if entry_count > max_entries {
+                return Err(MuragentError::Other(format!(
+                    "too many entries in .muragent (>{max_entries})"
+                )));
+            }
             let mut entry = entry.map_err(|e| MuragentError::Other(format!("tar entry: {e}")))?;
 
             let entry_path = entry
@@ -64,8 +93,27 @@ impl MuragentArchive {
             crate::muragent::executable_ban::check_mode_bits(mode, false)
                 .map_err(MuragentError::ExecutableContent)?;
 
+            // Read with a per-file cap (read one byte past the limit to detect
+            // overflow), then enforce the running decompressed-total cap. This
+            // is what actually stops a gzip/tar bomb — the header size field is
+            // attacker-controlled and cannot be trusted.
             let mut data = Vec::new();
-            entry.read_to_end(&mut data).map_err(MuragentError::Io)?;
+            entry
+                .by_ref()
+                .take(max_file_bytes + 1)
+                .read_to_end(&mut data)
+                .map_err(MuragentError::Io)?;
+            if data.len() as u64 > max_file_bytes {
+                return Err(MuragentError::Other(format!(
+                    "file exceeds {max_file_bytes} bytes in .muragent: {entry_path}"
+                )));
+            }
+            total_bytes += data.len() as u64;
+            if total_bytes > max_total_bytes {
+                return Err(MuragentError::Other(format!(
+                    "decompressed .muragent exceeds {max_total_bytes} bytes total"
+                )));
+            }
 
             files.insert(entry_path, data);
         }
@@ -90,5 +138,62 @@ impl MuragentArchive {
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Build an in-memory `.muragent`-shaped tar.gz from (path, bytes) pairs.
+    fn make_targz(files: &[(&str, &[u8])]) -> std::path::PathBuf {
+        let mut builder = tar::Builder::new(flate2::write::GzEncoder::new(
+            Vec::new(),
+            flate2::Compression::fast(),
+        ));
+        for (name, data) in files {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append_data(&mut header, name, *data).unwrap();
+        }
+        let gz = builder.into_inner().unwrap().finish().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("t.muragent");
+        // Keep the tempdir alive by leaking it — fine for a unit test.
+        std::mem::forget(dir);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(&gz).unwrap();
+        path
+    }
+
+    #[test]
+    fn within_limits_reads_ok() {
+        let p = make_targz(&[("a.txt", b"hello"), ("b.txt", b"world")]);
+        let arc = MuragentArchive::read_with_limits(&p, 10, 1024, 4096).unwrap();
+        assert_eq!(arc.files.len(), 2);
+    }
+
+    #[test]
+    fn rejects_oversized_single_file() {
+        let p = make_targz(&[("big.bin", &vec![0u8; 200])]);
+        let err = MuragentArchive::read_with_limits(&p, 10, 100, 1_000_000).unwrap_err();
+        assert!(format!("{err}").contains("exceeds"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_oversized_total() {
+        let p = make_targz(&[("a.bin", &vec![0u8; 100]), ("b.bin", &vec![0u8; 100])]);
+        let err = MuragentArchive::read_with_limits(&p, 10, 1024, 150).unwrap_err();
+        assert!(format!("{err}").contains("total"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_too_many_entries() {
+        let p = make_targz(&[("a", b"1"), ("b", b"2"), ("c", b"3")]);
+        let err = MuragentArchive::read_with_limits(&p, 2, 1024, 4096).unwrap_err();
+        assert!(format!("{err}").contains("too many entries"), "got: {err}");
     }
 }


### PR DESCRIPTION
Hardening for the untrusted `.muragent` import path, from a deep review of the package verification chain.

### 🔴 Private-key overwrite
`ENVELOPE_FILES` excluded only the manifest/signature files, so a payload file named `identity.key` (or `.pub`/`.prev`) was extracted into the agent dir — planting or overwriting the agent's **private** signing key on both fresh installs and in-place updates (`clear_except_data` preserved it only for `extract_payload` to clobber it). `install()` now refuses such a package up front (`reject_reserved_local_files`), and `extract_payload` skips the names defensively.

### 🟡 Decompression bomb
The reader read a gzip+tar fully into memory with no caps, so a tiny package could decompress to many GB (OOM on import). Added per-file (64 MiB), total (256 MiB), and entry-count (10k) limits, enforced by reading one byte past the per-file cap (the tar size header is attacker-controlled). Factored into `read_with_limits()` so the caps are unit-tested.

### 🟢 Rotation replay timestamp
The replay check compared `issued_at` as raw strings; RFC3339 isn't lexicographically ordered across offsets/precision (`Z` vs `+00:00`, fractional seconds), so a replayed rotation manifest could slip through. Now compares parsed `chrono` instants.

**Tests:** reserved-file rejection, oversized-file/total/entry-count limits. Full `mur-common` suite green; clippy + fmt clean; `mur-core` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)