### PR TITLE
fix(muragent): harden manifest canonicalization + enforce revocation on install

### DIFF
--- a/mur-common/src/muragent/installer.rs
+++ b/mur-common/src/muragent/installer.rs
@@ -79,6 +79,13 @@ pub fn install(
     // `identity.key` would plant/overwrite the agent's private signing key.
     reject_reserved_local_files(archive)?;
 
+    // Step 1.6: revocation check (§7.4.1). The validator defers this; enforce it
+    // here against the locally-cached list. A missing cache is fail-open (v1
+    // best-effort, matching offline installs), but a cached list that names this
+    // author key or this package hash is a hard refusal — a compromised author
+    // key must not be re-accepted on import.
+    check_revocations(archive, mur_home, &result.author_pubkey)?;
+
     // Step 2: slug shape
     let slug = result.manifest.agent.slug.clone();
     let display_name = result.manifest.agent.display_name.clone();
@@ -165,6 +172,38 @@ pub fn install(
         fingerprint_words,
         was_update,
     })
+}
+
+/// Refuse to install a package whose author key or package hash appears in the
+/// locally-cached revocations list. No network fetch happens here; a missing or
+/// unparseable cache is treated as "nothing revoked" (v1 fail-open posture).
+fn check_revocations(
+    archive: &MuragentArchive,
+    mur_home: &Path,
+    author_pubkey: &[u8; 32],
+) -> Result<(), MuragentError> {
+    let Some(list) = trust::RevocationsList::load_cached(mur_home) else {
+        return Ok(());
+    };
+
+    let author = format!("ed25519:{}", B64.encode(author_pubkey));
+    if list.is_author_revoked(&author) {
+        return Err(MuragentError::TrustRefused(format!(
+            "author key {author} is revoked"
+        )));
+    }
+
+    if let Some(signed_json) = archive.get("manifest.signed.json") {
+        use sha2::Digest;
+        let manifest_hash = format!("sha256:{}", hex::encode(sha2::Sha256::digest(signed_json)));
+        if list.is_package_revoked(&manifest_hash) {
+            return Err(MuragentError::TrustRefused(format!(
+                "package {manifest_hash} is revoked"
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 /// Refuse a package that carries any [`RESERVED_LOCAL_FILES`] entry at its top
@@ -504,6 +543,46 @@ mod tests {
         files.insert("skills/demo.md".to_string(), b"skill".to_vec());
         let archive = MuragentArchive { files };
         assert!(reject_reserved_local_files(&archive).is_ok());
+    }
+
+    #[test]
+    fn revoked_author_key_is_refused() {
+        use std::collections::BTreeMap;
+        let tmp = TempDir::new().unwrap();
+        let mur_home = tmp.path();
+        let pk = [7u8; 32];
+        let author = format!("ed25519:{}", B64.encode(pk));
+        let list = trust::RevocationsList {
+            version: 1,
+            this_update: chrono::Utc::now(),
+            next_update: chrono::Utc::now(),
+            expires_at: chrono::Utc::now() + chrono::Duration::days(30),
+            crl_number: 1,
+            revoked: vec![trust::RevokedEntry::Author {
+                pubkey: author,
+                reason: "compromised".into(),
+                revoked_at: chrono::Utc::now(),
+            }],
+        };
+        std::fs::create_dir_all(mur_home.join("trust")).unwrap();
+        std::fs::write(
+            mur_home.join("trust").join("revocations.json"),
+            serde_json::to_vec(&list).unwrap(),
+        )
+        .unwrap();
+
+        let archive = MuragentArchive {
+            files: BTreeMap::new(),
+        };
+        assert!(matches!(
+            check_revocations(&archive, mur_home, &pk),
+            Err(MuragentError::TrustRefused(_))
+        ));
+        // A different (non-revoked) key passes.
+        assert!(check_revocations(&archive, mur_home, &[8u8; 32]).is_ok());
+        // No cached list → fail-open.
+        let empty = TempDir::new().unwrap();
+        assert!(check_revocations(&archive, empty.path(), &pk).is_ok());
     }
 
     #[test]

--- a/mur-common/src/muragent/installer.rs
+++ b/mur-common/src/muragent/installer.rs
@@ -249,6 +249,18 @@ fn try_apply_rotation(
     display_name: &str,
     mur_home: &Path,
 ) -> Result<(), String> {
+    // Revocation takes precedence over rotation. A revoked old key must not be
+    // able to authorize a rotation — otherwise an attacker holding a compromised
+    // (and therefore revoked) key could mint a rotation to a key they control
+    // and hijack the agent's identity. Checked before anything else so a revoked
+    // key fails fast, regardless of whether a rotation manifest is present.
+    if let Some(entry) = old_entry
+        && let Some(list) = trust::RevocationsList::load_cached(mur_home)
+        && list.is_author_revoked(&format!("ed25519:{}", entry.public_key))
+    {
+        return Err("previous signing key is revoked; rotation refused".into());
+    }
+
     let manifest_path = rotation_manifest_path(mur_home, display_name);
     if !manifest_path.exists() {
         return Err(
@@ -583,6 +595,65 @@ mod tests {
         // No cached list → fail-open.
         let empty = TempDir::new().unwrap();
         assert!(check_revocations(&archive, empty.path(), &pk).is_ok());
+    }
+
+    #[test]
+    fn revoked_old_key_cannot_authorize_rotation() {
+        // Revocation must beat rotation: a compromised+revoked old key cannot
+        // sign itself a successor, or it could hijack the agent identity.
+        let tmp = TempDir::new().unwrap();
+        let mur_home = tmp.path();
+        let old_pk_b64 = B64.encode([3u8; 32]);
+        let list = trust::RevocationsList {
+            version: 1,
+            this_update: chrono::Utc::now(),
+            next_update: chrono::Utc::now(),
+            expires_at: chrono::Utc::now() + chrono::Duration::days(30),
+            crl_number: 1,
+            revoked: vec![trust::RevokedEntry::Author {
+                pubkey: format!("ed25519:{old_pk_b64}"),
+                reason: "compromised".into(),
+                revoked_at: chrono::Utc::now(),
+            }],
+        };
+        std::fs::create_dir_all(mur_home.join("trust")).unwrap();
+        std::fs::write(
+            mur_home.join("trust").join("revocations.json"),
+            serde_json::to_vec(&list).unwrap(),
+        )
+        .unwrap();
+
+        let entry = |pk_b64: String| TrustEntry {
+            public_key: pk_b64,
+            display_name_seen: "Coach".into(),
+            first_seen: "2026-01-01T00:00:00Z".into(),
+            last_seen: "2026-01-01T00:00:00Z".into(),
+            last_seen_surface: "cli".into(),
+            trust_level: TrustLevel::Known,
+            fingerprint: "ff".into(),
+            word_list: "a b c d".into(),
+            rotated_from: None,
+            superseded_at: None,
+            last_rotation_at: None,
+        };
+        let mut ts = TrustStore::default();
+
+        // Revoked old key → refused with the revocation reason, before any
+        // rotation manifest is even consulted.
+        let revoked = entry(old_pk_b64);
+        let err =
+            try_apply_rotation(&mut ts, Some(&revoked), "NEWKEY", "Coach", mur_home).unwrap_err();
+        assert!(err.contains("revoked"), "got: {err}");
+
+        // A non-revoked old key falls through to the (absent) rotation manifest,
+        // i.e. it is NOT short-circuited by the revocation check.
+        let clean = entry(B64.encode([9u8; 32]));
+        let err2 =
+            try_apply_rotation(&mut ts, Some(&clean), "NEWKEY", "Coach", mur_home).unwrap_err();
+        assert!(
+            !err2.contains("revoked"),
+            "should fail for a different reason, got: {err2}"
+        );
     }
 
     #[test]

--- a/mur-common/src/muragent/jcs_canonical.rs
+++ b/mur-common/src/muragent/jcs_canonical.rs
@@ -9,7 +9,9 @@
 
 use crate::jcs;
 use crate::muragent::MuragentError;
+use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde_json::Value;
+use std::fmt;
 
 /// Errors specific to manifest canonicalization.
 #[derive(Debug, thiserror::Error)]
@@ -34,12 +36,167 @@ pub enum CanonicalizeError {
 ///
 /// Returns the bytes that should match `manifest.signed.json` byte-for-byte.
 pub fn derive_signed_json(manifest_yaml: &str) -> Result<Vec<u8>, MuragentError> {
-    let value: Value = serde_yaml_ng::from_str(manifest_yaml)
+    // Reject anchors/aliases/merge keys BEFORE deserializing. serde_yaml_ng
+    // expands aliases during deserialization (an O(3^n) "billion laughs" blow-up
+    // is reachable from a few hundred bytes), and an anchored manifest also lets
+    // a human read one shape while a different, expanded shape gets signed.
+    reject_unsafe_yaml(manifest_yaml).map_err(|e| MuragentError::ManifestParse(e.to_string()))?;
+
+    // Deserialize through a guard that rejects duplicate and non-string keys
+    // (serde_yaml_ng silently last-wins on duplicates), so the signed JSON can't
+    // disagree with what a reviewer sees in manifest.yaml.
+    let NoDupValue(value) = serde_yaml_ng::from_str(manifest_yaml)
         .map_err(|e| MuragentError::ManifestParse(e.to_string()))?;
 
     let normalized = nfc_normalize_value(&value);
 
     Ok(jcs::to_jcs(&normalized))
+}
+
+/// Scan raw YAML and reject anchors (`&a`), aliases (`*a`), and merge keys
+/// (`<<:`). Our exporter never emits these, so the check is strict: any
+/// occurrence at a node-start position is fatal. Characters inside quoted
+/// scalars and comments are ignored, so ordinary values like `Tom & Jerry` or
+/// `http://x` do not trip it.
+pub fn reject_unsafe_yaml(yaml: &str) -> Result<(), CanonicalizeError> {
+    let bytes = yaml.as_bytes();
+    let mut i = 0;
+    // `at_node_start` means the next non-space byte begins a node (a key, value,
+    // or sequence item) — the only place an anchor/alias indicator is valid.
+    let mut at_node_start = true;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match c {
+            b' ' | b'\t' | b'\r' => {}
+            b'\n' => at_node_start = true,
+            b'#' => {
+                // Comment to end of line (we only get here outside quotes).
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                at_node_start = true;
+                continue;
+            }
+            b'"' => {
+                at_node_start = false;
+                i += 1;
+                while i < bytes.len() {
+                    match bytes[i] {
+                        b'\\' => i += 2, // skip escaped char
+                        b'"' => break,
+                        _ => i += 1,
+                    }
+                }
+            }
+            b'\'' => {
+                at_node_start = false;
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\'' {
+                        if bytes.get(i + 1) == Some(&b'\'') {
+                            i += 2; // '' escaped quote
+                            continue;
+                        }
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            b'&' if at_node_start => return Err(CanonicalizeError::AnchorsForbidden),
+            b'*' if at_node_start => return Err(CanonicalizeError::AliasesForbidden),
+            b'<' if at_node_start && is_merge_key(&bytes[i..]) => {
+                return Err(CanonicalizeError::MergeKeysForbidden);
+            }
+            b'[' | b'{' | b',' | b'?' => at_node_start = true,
+            b':' | b'-' => {
+                // Only a structural indicator when followed by whitespace/EOL;
+                // otherwise it's part of a scalar (`http://x`, `-5`).
+                let next = bytes.get(i + 1);
+                at_node_start = matches!(
+                    next,
+                    None | Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r')
+                );
+            }
+            _ => at_node_start = false,
+        }
+        i += 1;
+    }
+    Ok(())
+}
+
+/// True if `rest` begins with a `<<` merge key (`<<` then optional spaces, `:`).
+fn is_merge_key(rest: &[u8]) -> bool {
+    if rest.len() < 3 || rest[0] != b'<' || rest[1] != b'<' {
+        return false;
+    }
+    let mut j = 2;
+    while j < rest.len() && (rest[j] == b' ' || rest[j] == b'\t') {
+        j += 1;
+    }
+    rest.get(j) == Some(&b':')
+}
+
+/// A `serde_json::Value` whose `Deserialize` rejects duplicate object keys and
+/// non-string keys (both of which serde_yaml_ng would otherwise accept).
+struct NoDupValue(Value);
+
+impl<'de> Deserialize<'de> for NoDupValue {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> Visitor<'de> for V {
+            type Value = Value;
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a YAML value with unique string keys")
+            }
+            fn visit_bool<E>(self, v: bool) -> Result<Value, E> {
+                Ok(Value::Bool(v))
+            }
+            fn visit_i64<E>(self, v: i64) -> Result<Value, E> {
+                Ok(Value::from(v))
+            }
+            fn visit_u64<E>(self, v: u64) -> Result<Value, E> {
+                Ok(Value::from(v))
+            }
+            fn visit_f64<E>(self, v: f64) -> Result<Value, E> {
+                Ok(Value::from(v))
+            }
+            fn visit_str<E>(self, v: &str) -> Result<Value, E> {
+                Ok(Value::String(v.to_owned()))
+            }
+            fn visit_unit<E>(self) -> Result<Value, E> {
+                Ok(Value::Null)
+            }
+            fn visit_none<E>(self) -> Result<Value, E> {
+                Ok(Value::Null)
+            }
+            fn visit_some<D2: Deserializer<'de>>(self, d: D2) -> Result<Value, D2::Error> {
+                Ok(NoDupValue::deserialize(d)?.0)
+            }
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Value, A::Error> {
+                let mut out = Vec::new();
+                while let Some(NoDupValue(e)) = seq.next_element()? {
+                    out.push(e);
+                }
+                Ok(Value::Array(out))
+            }
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Value, A::Error> {
+                let mut obj = serde_json::Map::new();
+                let mut seen = std::collections::HashSet::new();
+                // next_key::<String> errors on a non-string key (NonStringKey).
+                while let Some(k) = map.next_key::<String>()? {
+                    if !seen.insert(k.clone()) {
+                        return Err(de::Error::custom(format!(
+                            "duplicate key '{k}' in manifest.yaml"
+                        )));
+                    }
+                    let NoDupValue(v) = map.next_value()?;
+                    obj.insert(k, v);
+                }
+                Ok(Value::Object(obj))
+            }
+        }
+        d.deserialize_any(V).map(NoDupValue)
+    }
 }
 
 /// Recursively NFC-normalize all string values in a JSON tree.
@@ -131,6 +288,47 @@ sanitized:
             out_str.contains("caf\u{00E9}"),
             "expected NFC-composed é, got: {out_str}"
         );
+    }
+
+    #[test]
+    fn rejects_yaml_anchors_and_aliases() {
+        // The billion-laughs vector and any anchored manifest must be refused.
+        assert!(matches!(
+            reject_unsafe_yaml("base: &b\n  x: 1\nuse: *b\n"),
+            Err(CanonicalizeError::AnchorsForbidden)
+        ));
+        assert!(matches!(
+            reject_unsafe_yaml("use: *b\n"),
+            Err(CanonicalizeError::AliasesForbidden)
+        ));
+        assert!(matches!(
+            reject_unsafe_yaml("a: &a [1,1]\nb: [*a, *a]\n"),
+            Err(CanonicalizeError::AnchorsForbidden)
+        ));
+        // Merge key.
+        assert!(matches!(
+            reject_unsafe_yaml("child:\n  <<: x\n"),
+            Err(CanonicalizeError::MergeKeysForbidden)
+        ));
+        // derive_signed_json refuses them too.
+        assert!(derive_signed_json("base: &b\n  x: 1\nuse: *b\n").is_err());
+    }
+
+    #[test]
+    fn ampersand_and_star_in_scalars_are_fine() {
+        // `&`/`*` inside ordinary values must NOT trip the scanner.
+        assert!(reject_unsafe_yaml("desc: Tom & Jerry\n").is_ok());
+        assert!(reject_unsafe_yaml("math: 2 * 3 = 6\n").is_ok());
+        assert!(reject_unsafe_yaml("url: http://example.com/a*b\n").is_ok());
+        assert!(reject_unsafe_yaml("q: \"a * b & c\"\n").is_ok());
+        assert!(reject_unsafe_yaml("c: \"x\" # *not an alias\n").is_ok());
+        assert!(reject_unsafe_yaml("schema: mur-agent/2\nlist:\n  - hub\n").is_ok());
+    }
+
+    #[test]
+    fn rejects_duplicate_keys() {
+        let err = derive_signed_json("schema: mur-agent/2\nschema: evil\n").unwrap_err();
+        assert!(format!("{err}").contains("duplicate key"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
> **Stacked on #352** — review/merge that first; the base will retarget to `main` automatically once #352 lands.

Two verification-policy fixes for the untrusted `.muragent` path, from the same deep review.

### 🟡 Canonicalization hardening (`jcs_canonical`)
The documented §6.3 step-2 rejections were dead code — `derive_signed_json` only parsed + NFC + JCS, and the `CanonicalizeError` variants were never constructed. Probed `serde_yaml_ng` 0.10 directly:
- **anchors/aliases expand silently** → an O(3^n) billion-laughs blow-up is reachable from a few hundred bytes (OOM on import), and an anchored manifest lets a reviewer read one shape while a different, expanded shape gets signed.
- **duplicate keys silently last-win** → reviewer sees one value, a different one gets signed.

Now a pre-parse scanner rejects anchors/aliases/merge keys (quote- and comment-aware, so ordinary values like `Tom & Jerry` or `http://x` don't trip it), and a `NoDupValue` deserializer rejects duplicate and non-string keys.

### 🟡 Revocation enforcement (`installer`)
Validator Step 11 is skipped and install never consulted the revocations list, so a `.muragent` signed by a **revoked** author key installed fine (revocation *was* enforced for skills, not agents). `install()` now checks the locally-cached revocations list and refuses a revoked author key or package hash. A missing cache is fail-open (v1 best-effort / offline posture).

**Tests:** anchor/alias/merge/dup-key rejection, scalar `&`/`*` false-positive guards, revoked-author refusal. Full `mur-common` suite (676) green; clippy + fmt clean; `mur-core` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)