### PR TITLE
fix(bridge): bind key_version + domain separation into A2A envelope signature

### DIFF
--- a/mur-common/src/bridge/envelope.rs
+++ b/mur-common/src/bridge/envelope.rs
@@ -33,18 +33,41 @@ pub enum EnvelopeError {
     UntrustedPeer,
 }
 
+/// Domain-separation tag for bridge envelope signatures.
+///
+/// The agent's identity key also signs other things (notably `.muragent` DSSE
+/// statements), so a distinct, fixed-length prefix keeps a signature made in one
+/// context from ever verifying in another. It also lets us fold `key_version`
+/// into the signed bytes — `key_version` lives outside `payload` on the wire, so
+/// without this an attacker could replay a captured envelope with `key_version`
+/// flipped and defeat a `TrustedPeer` version pin.
+const ENVELOPE_DOMAIN: &[u8] = b"mur-bridge-envelope-v1";
+
+/// The exact bytes covered by an envelope signature: a fixed-length domain tag,
+/// the little-endian `key_version`, then the canonical payload. All fields ahead
+/// of `payload` are fixed-length, so the encoding is unambiguous.
+fn signing_bytes(payload: &[u8], key_version: u32) -> Vec<u8> {
+    let mut out = Vec::with_capacity(ENVELOPE_DOMAIN.len() + 4 + payload.len());
+    out.extend_from_slice(ENVELOPE_DOMAIN);
+    out.extend_from_slice(&key_version.to_le_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
 /// Sign a canonical-JSON payload with the bridge's identity key.
 ///
 /// `payload` MUST already be canonicalized (sorted keys, no whitespace) —
-/// this function does NOT re-canonicalize. Verifiers re-use the exact bytes
-/// stored in the resulting `SignedEnvelope.payload`; never re-canonicalize on
-/// receive.
+/// this function does NOT re-canonicalize. The signature covers the domain tag,
+/// `key_version`, and `payload` (see [`signing_bytes`]); verifiers reconstruct
+/// those exact bytes and never re-canonicalize the payload on receive.
 pub fn sign_payload(
     payload: Vec<u8>,
     identity: &crate::identity::AgentIdentity,
     key_version: u32,
 ) -> SignedEnvelope {
-    let sig = identity.signing_key().sign(&payload);
+    let sig = identity
+        .signing_key()
+        .sign(&signing_bytes(&payload, key_version));
     SignedEnvelope {
         payload,
         sig: sig.to_bytes().to_vec(),
@@ -70,7 +93,11 @@ pub fn verify_envelope_with_pubkey(
     let vk = VerifyingKey::from_bytes(&pub_bytes).map_err(|_| EnvelopeError::SignatureMismatch)?;
     let sig_arr: [u8; 64] = env.sig.as_slice().try_into().unwrap();
     let sig = Signature::from_bytes(&sig_arr);
-    vk.verify_strict(&env.payload, &sig)
+    // Reconstruct the exact signed bytes (domain || key_version || payload).
+    // Because key_version is folded in here, mutating it on the wire breaks the
+    // signature — which is what makes a TrustedPeer version pin enforceable.
+    let msg = signing_bytes(&env.payload, env.key_version);
+    vk.verify_strict(&msg, &sig)
         .map_err(|_| EnvelopeError::SignatureMismatch)?;
     Ok(())
 }
@@ -119,6 +146,22 @@ mod tests {
         let mut env = sign_payload(b"orig".to_vec(), &id, 0);
         env.payload = b"tamper".to_vec();
         let pub_ = env.bridge_pubkey_multibase.clone();
+        assert!(matches!(
+            verify_envelope_with_pubkey(&env, &pub_).unwrap_err(),
+            EnvelopeError::SignatureMismatch
+        ));
+    }
+
+    #[test]
+    fn tampered_key_version_fails() {
+        // key_version is now covered by the signature, so flipping it on the
+        // wire (to slip past a TrustedPeer version pin) invalidates the envelope.
+        use crate::identity::AgentIdentity;
+        let id = AgentIdentity::generate();
+        let mut env = sign_payload(b"orig".to_vec(), &id, 3);
+        let pub_ = env.bridge_pubkey_multibase.clone();
+        verify_envelope_with_pubkey(&env, &pub_).expect("untampered verifies");
+        env.key_version = 4;
         assert!(matches!(
             verify_envelope_with_pubkey(&env, &pub_).unwrap_err(),
             EnvelopeError::SignatureMismatch


### PR DESCRIPTION
From a deep review of the A2A bridge envelope / peer-auth path — the *network* untrusted-input boundary (complementing the `.muragent` file-import work in #352–#354).

### The bug
`sign_payload` signed only `payload`. `key_version` rode **outside** the signature, but `verify_inbound_envelope` gates on it (a `TrustedPeer` version pin, meant to quarantine a rotation). So an attacker replaying a captured valid envelope could flip `key_version` and slip past the pin — the sig over `payload` still verifies. Separately, the agent identity key **also** signs `.muragent` DSSE statements, with no domain separation on the bridge side.

### The fix
Sign over `"mur-bridge-envelope-v1" || key_version_le || payload`:
- folds `key_version` into the signed bytes → flipping it invalidates the signature, making the version pin actually enforceable;
- fixed-length domain tag → a signature from another context (DSSE statement, etc.) can never verify as a bridge envelope.

Payload bytes are still reused verbatim on verify (no re-canonicalization). Safe to change the construction: sign/verify always go through this one pair, and no envelopes are persisted on the wire yet. Regression test added (flipped `key_version` ⇒ `SignatureMismatch`). `mur-common` + `mur-agent-runtime` build; bridge tests green; clippy + fmt clean.

### What the review found but this PR does *not* change (flagging for the team)
- **Envelope replay (no nonce/timestamp/seq).** A captured, *unmodified* envelope re-verifies forever. For the bridge path this is largely blunted by `bridge::dedupe` (sled-backed `(bridge_id, platform_msg_id)`, 7-day TTL). A general signed-nonce + bounded dedup at the verify layer is worth adding when the production bridge↔agent transport is wired.
- **`verify_inbound_envelope` has zero callers.** The module doc says every inbound bridge envelope *MUST* be verified against `trusted_peers[]` "regardless of transport", but the function implementing that mandate is not wired into any inbound path (telegram inbound *signs*; the receive side forwards to a **mock** user agent and never verifies). This is a build-but-not-wired gap, not a live bypass — but it must be connected before the bridge↔agent path goes to production, ideally so a plain (unverified) payload can't be forwarded by construction.

The TCP transport path is unaffected and looks sound: Noise-XK authenticates the static key + a fail-closed trusted-peer allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)