### PR TITLE
fix(sandbox): block IPv4-in-IPv6 metadata addresses in SSRF guard

### DIFF
--- a/mur-agent-runtime/src/sandbox/reqwest_guard.rs
+++ b/mur-agent-runtime/src/sandbox/reqwest_guard.rs
@@ -34,6 +34,15 @@ pub fn host_matches_pattern(host: &str, pattern: &str) -> bool {
 /// (127.0.0.1 Ollama) and LAN LLM endpoints. Blocking those would break core
 /// functionality; the metadata endpoint is the genuine SSRF target.
 fn is_link_local_or_unspecified(ip: IpAddr) -> bool {
+    // Normalize IPv4-in-IPv6 forms down to their embedded IPv4 first. Both the
+    // mapped form (`::ffff:a.b.c.d`) and the compatible form (`::a.b.c.d`) have
+    // `segments()[0] == 0`, so without this they slip past the IPv6 checks below
+    // (which only catch fe80::/10 and `::`) — e.g. `http://[::ffff:169.254.169.254]/`
+    // would otherwise reach the cloud-metadata endpoint.
+    let ip = match ip {
+        IpAddr::V6(v6) => v6.to_ipv4().map_or(IpAddr::V6(v6), IpAddr::V4),
+        v4 => v4,
+    };
     match ip {
         IpAddr::V4(v4) => v4.is_link_local() || v4.is_unspecified(),
         // IPv6 link-local is fe80::/10; no stable std helper, so mask manually.
@@ -196,6 +205,42 @@ mod tests {
         ));
         assert!(!is_link_local_or_unspecified("10.0.0.5".parse().unwrap()));
         assert!(!is_link_local_or_unspecified("1.1.1.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn ipv4_in_ipv6_metadata_blocked() {
+        // The metadata address must not slip through the IPv6 path via the
+        // mapped (`::ffff:`) or compatible (`::`) IPv4-in-IPv6 encodings.
+        assert!(is_link_local_or_unspecified(
+            "::ffff:169.254.169.254".parse().unwrap()
+        ));
+        assert!(is_link_local_or_unspecified(
+            "::169.254.169.254".parse().unwrap()
+        ));
+        assert!(is_link_local_or_unspecified(
+            "::ffff:169.254.0.1".parse().unwrap()
+        ));
+        // Mapped loopback/private/public stay reachable (local-first).
+        assert!(!is_link_local_or_unspecified(
+            "::ffff:127.0.0.1".parse().unwrap()
+        ));
+        assert!(!is_link_local_or_unspecified(
+            "::ffff:192.168.1.10".parse().unwrap()
+        ));
+        assert!(!is_link_local_or_unspecified(
+            "::ffff:1.1.1.1".parse().unwrap()
+        ));
+    }
+
+    #[test]
+    fn check_request_url_blocks_ipv6_mapped_metadata() {
+        // End-to-end through the connector-level guard wired into the LLM
+        // clients: an IP-literal URL embedding the metadata address is refused.
+        let url = reqwest::Url::parse("http://[::ffff:169.254.169.254]/latest/meta-data/").unwrap();
+        assert!(check_request_url(&url).is_err());
+        // A normal IP-literal to a public host is fine.
+        let ok = reqwest::Url::parse("http://1.1.1.1/").unwrap();
+        assert!(check_request_url(&ok).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
The known-deferred "IP-literal SSRF" item. The connector-level guard (`check_request_url`, wired into the ollama/anthropic/openai clients) already blocks plain IP-literal metadata URLs — but it relied on `is_link_local_or_unspecified`, whose IPv6 path only checked `fe80::/10` and `::`.

### The bypass
The IPv4-mapped (`::ffff:a.b.c.d`) and IPv4-compatible (`::a.b.c.d`) encodings both have `segments()[0] == 0`, so they sailed past the IPv6 checks. An LLM `base_url` of `http://[::ffff:169.254.169.254]/latest/meta-data/...` reached the cloud-metadata endpoint despite the guard. Since `base_url` comes from model config / a `.muragent`, this is a metadata-credential exfiltration vector (steal the host's cloud IAM creds).

### The fix
Normalize any IPv4-in-IPv6 address to its embedded IPv4 (`Ipv6Addr::to_ipv4`) before the range check. One-line change in the shared helper, so it covers **both** consumers: the connector-level `check_request_url` and the DNS-resolver address filter (which also defends hostname → metadata resolution / DNS rebinding). Local-first is preserved — mapped loopback/private (`::ffff:127.0.0.1`, `::ffff:192.168.x.x`) stay reachable.

**Tests:** mapped + compatible metadata blocked; mapped loopback/private/public still allowed; end-to-end through `check_request_url`. `mur-agent-runtime` builds; clippy + fmt clean.

Scope note: this is the metadata/link-local guard (the genuine SSRF target on a local-first platform). IP-literal URLs still bypass the *host allowlist* by design — `127.0.0.1` Ollama is an IP literal that must be allowed, so the allowlist can't blanket-block IP literals. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)