### PR TITLE
fix(slack-bridge): don't drop a message when the user-agent forward fails

### DIFF
--- a/mur-agent-runtime/src/bridge/slack/inbound.rs
+++ b/mur-agent-runtime/src/bridge/slack/inbound.rs
@@ -183,9 +183,10 @@ impl<B: SlackBotLike> SlackInboundLoop<B> {
         if deps.dedupe.is_seen(&dedupe_key).unwrap_or(false) {
             return Ok(TickResult { forwarded: false });
         }
-        deps.dedupe
-            .mark_seen(&dedupe_key)
-            .map_err(|e| SlackError::Network(e.to_string()))?;
+        // NOTE: do NOT mark seen here. We mark only after a successful forward
+        // (Phase 6) so a transient user-agent failure is retried on the next
+        // delivery instead of being silently dropped — matching the Telegram
+        // bridge and the AckTracker, which likewise only advances on a 2xx.
 
         // Phase 4: strip bot mention prefix "<@U…> " from text
         let raw_text = event.text.clone().unwrap_or_default();
@@ -233,12 +234,18 @@ impl<B: SlackBotLike> SlackInboundLoop<B> {
         if did_forward {
             deps.ack.start_pending(event.ts.clone());
             deps.ack.confirm();
+            // Mark seen only now — a successfully delivered message must not be
+            // forwarded again, but a failed one (below) must remain unseen so it
+            // is retried on redelivery.
+            deps.dedupe
+                .mark_seen(&dedupe_key)
+                .map_err(|e| SlackError::Network(e.to_string()))?;
         } else {
             tracing::warn!(
                 channel = %event.channel,
                 ts = %event.ts,
                 status,
-                "A2A forward failed — AckTracker not advanced"
+                "A2A forward failed — not marked seen, will retry on redelivery"
             );
         }
 

--- a/mur-agent-runtime/tests/c7_slack_inbound.rs
+++ b/mur-agent-runtime/tests/c7_slack_inbound.rs
@@ -207,6 +207,29 @@ async fn duplicate_event_skipped() {
     assert!(!r2.forwarded, "duplicate should be skipped");
 }
 
+#[tokio::test]
+async fn failed_forward_is_retried_not_dropped() {
+    // Regression: a transient user-agent failure must NOT mark the message
+    // seen, so it is retried on redelivery instead of being silently dropped.
+    let dir = TempDir::new().unwrap();
+    let bot = MockSlackBot::new();
+    let mut deps = make_deps(SlackPrivacyMode::DmAndMentions, vec![], &dir);
+    deps.user_agent = Some(MockUserAgentHandle::server_error()); // forward 5xx
+    let mut loop_ = SlackInboundLoop::new(bot, deps);
+    let env = mention_envelope("C_CHAN", "1000000099.000001", "<@U_BOT> retry me");
+
+    let r1 = loop_.tick_once(env.clone()).await.unwrap();
+    assert!(!r1.forwarded, "a 5xx forward should not report success");
+
+    // User agent recovers; the same message must be retried, not deduped away.
+    loop_.deps.as_mut().unwrap().user_agent = Some(MockUserAgentHandle::ok("ok now"));
+    let r2 = loop_.tick_once(env).await.unwrap();
+    assert!(
+        r2.forwarded,
+        "a previously-failed message must be retried on redelivery, not dropped"
+    );
+}
+
 // ── M-c7.4 tests ──────────────────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
Found while reviewing the bridge dedupe/replay path.

### The bug
`SlackInboundLoop::tick_once` marked a message `seen` in the dedupe store **before** forwarding it to the user agent:

```
is_seen? → no
mark_seen          ← here, unconditionally
forward → 5xx      ← fails
"AckTracker not advanced"  ← warns, expecting a retry
```

But the message is already in the dedupe store, so when Slack redelivers it (cursor/ack not advanced), the `is_seen` guard skips it — **silently dropped, never retried**. A transient user-agent failure causes permanent message loss, defeating the `AckTracker` retry design. The Telegram bridge does it correctly (marks seen only after a 2xx).

### The fix
Mark seen **only after a successful (2xx) forward**. A delivered message is still deduped (no double-delivery); a failed one stays unseen and is retried on redelivery. Now consistent with Telegram and the AckTracker (which also advances only on 2xx).

### Test
`failed_forward_is_retried_not_dropped`: a 5xx forward leaves the message unseen; once the mock user agent recovers, the same envelope forwards instead of being skipped. (`duplicate_event_skipped` still passes — successful deliveries are still deduped.) Build + 18 c7 tests green; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)