### PR TITLE
fix(sync): validate synced skill name to block path traversal into other agents

### DIFF
--- a/mur-common/src/skill/loader.rs
+++ b/mur-common/src/skill/loader.rs
@@ -14,6 +14,12 @@ use std::path::Path;
 pub fn is_valid_skill_name(name: &str) -> bool {
     !name.is_empty()
         && name.len() <= 64
+        // Reserved path components: a skill name is joined into
+        // `<mur_home>/skills/<name>`, so `.`/`..` must never be accepted.
+        && name != "."
+        && name != ".."
+        // The character set already excludes `/` and `\`, which keeps a name to
+        // a single path component (no traversal into sibling/parent dirs).
         && name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))
@@ -162,6 +168,24 @@ content:
         let dir = tempdir().unwrap();
         let loaded = load_all(dir.path(), "alice");
         assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn is_valid_skill_name_rejects_traversal_and_reserved() {
+        // Legit names.
+        assert!(is_valid_skill_name("web-search"));
+        assert!(is_valid_skill_name("my.skill_v2"));
+        // Reserved path components.
+        assert!(!is_valid_skill_name("."));
+        assert!(!is_valid_skill_name(".."));
+        // Path separators (the dangerous traversal form) and absolutes.
+        assert!(!is_valid_skill_name("../agents/victim/skills/evil"));
+        assert!(!is_valid_skill_name("a/b"));
+        assert!(!is_valid_skill_name("a\\b"));
+        assert!(!is_valid_skill_name("/etc/passwd"));
+        // Bounds.
+        assert!(!is_valid_skill_name(""));
+        assert!(!is_valid_skill_name(&"x".repeat(65)));
     }
 
     #[test]

--- a/mur-common/src/skill/mod.rs
+++ b/mur-common/src/skill/mod.rs
@@ -43,7 +43,7 @@ pub use inventory::McpInventory;
 pub use lifecycle::{
     calculate_decay, half_life_days, next_state, on_promotion, transition_allowed,
 };
-pub use loader::{LoadedSkill, SkillScope, load_all};
+pub use loader::{LoadedSkill, SkillScope, is_valid_skill_name, load_all};
 pub use lockfile::{LockfileError, SkillLock};
 pub use manifest::*;
 pub use mcp::{McpRequirement, ParseCapabilityError, SkillCapability, validate_requirements};

--- a/mur-core/src/sync/inbox.rs
+++ b/mur-core/src/sync/inbox.rs
@@ -226,6 +226,18 @@ impl Inbox {
                 Ok(true)
             }
             SignalTarget::NewDraftSkill { payload } => {
+                // Reject a path-traversal name from a remote peer before it
+                // touches the filesystem: the name is joined into
+                // `<mur_home>/skills/<name>`, so an unvalidated value like
+                // `../agents/<other>/skills/x` would let a peer plant an
+                // instruction-bearing skill into another agent's context.
+                if !mur_common::skill::is_valid_skill_name(&payload.name) {
+                    tracing::warn!(
+                        name = %payload.name,
+                        "rejecting synced NewDraftSkill: invalid skill name"
+                    );
+                    return Ok(false);
+                }
                 // Never overwrite a skill the user may have edited
                 use mur_common::skill::global_skill_dir;
                 let skill_dir = global_skill_dir(&self.mur_home, &payload.name);


### PR DESCRIPTION
Found reviewing the skill trust path. (Note: skill DSSE signatures — `verify_manifest` — are never called; skill trust is content-hash-pinned via the registry: `revocation > registry-hash-match > Sandboxed`. So the storage path is the attack surface, not signatures.)

### The bug
The fleet-sync inbox handles a remote peer's `NewDraftSkill` signal by writing it to disk:

```rust
SignalTarget::NewDraftSkill { payload } => {
    let skill_dir = global_skill_dir(&self.mur_home, &payload.name); // mur_home/skills/<name>
    fs::create_dir_all(&skill_dir)?;
    write_to_dir(&skill_dir, payload)?;                              // writes skill.yaml
}
```

`payload.name` comes straight from a remote peer with **no validation**. A name like `../agents/<victim>/skills/evil` escapes the skills dir and plants a skill into **another agent's** context — and a skill's content is injected into that agent's prompt, so this is remote instruction injection (not just a stray file write).

### The fix
Validate `payload.name` with `is_valid_skill_name` before it reaches the filesystem; reject the signal (warn + skip) otherwise. The allowed character set already excludes `/` and `\`, so a valid name is a single path component — no traversal into sibling/parent dirs. Also hardened the shared validator to reject the reserved `.`/`..` components (this likewise protects the skill loader, the validator's other caller).

### Tests
`is_valid_skill_name_rejects_traversal_and_reserved` covers `.`, `..`, separator/absolute forms, and length bounds. Full skill (180) and sync (62) suites pass; clippy + fmt clean.

### Noted for the team (not changed)
Other `global_skill_dir(home, name)` write sinks (`skill_install`, `skill_generate`, server `skills` routes, `skill_evolve`) take names from user-initiated or local sources, so they're lower-risk — but a consistent `is_valid_skill_name` gate at each write boundary would be worthwhile defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)