### PR TITLE
fix(server): reject path-traversal skill names on dashboard HTTP routes

### DIFF
--- a/mur-core/src/server/skills.rs
+++ b/mur-core/src/server/skills.rs
@@ -11,6 +11,32 @@ use mur_common::skill::{SkillManifest, read_from_dir, write_to_dir};
 
 use super::{AppError, AppState, notify, wrap};
 
+/// Resolve `skills_dir/<name>`, rejecting any request-supplied name that would
+/// escape the skills directory. The dashboard server binds a network interface
+/// without auth, so an unvalidated name on these routes is a remote
+/// path-traversal — most severely `delete_skill`, where a name of `..` would
+/// `remove_dir_all` the entire mur home. A skill name is a single directory
+/// component: separators, `.`/`..`, control chars, and empty/oversize are
+/// refused.
+fn safe_skill_dir(
+    skills_dir: &std::path::Path,
+    name: &str,
+) -> Result<std::path::PathBuf, AppError> {
+    if name.is_empty()
+        || name.len() > 64
+        || name == "."
+        || name == ".."
+        || name.contains('/')
+        || name.contains('\\')
+        || name.chars().any(|c| c == '\0' || c.is_control())
+    {
+        return Err(AppError::BadRequest(format!(
+            "invalid skill name: {name:?}"
+        )));
+    }
+    Ok(skills_dir.join(name))
+}
+
 #[derive(Deserialize, Default)]
 pub struct SkillFilter {
     pub category: Option<String>,
@@ -57,7 +83,7 @@ pub(super) async fn get_skill(
     Path(name): Path<String>,
 ) -> Result<impl IntoResponse, AppError> {
     let skills_dir = state.skills_dir();
-    let skill_dir = skills_dir.join(&name);
+    let skill_dir = safe_skill_dir(&skills_dir, &name)?;
     let skill = read_from_dir(&skill_dir)
         .map_err(|_| AppError::NotFound(format!("Skill '{}' not found", name)))?;
 
@@ -88,7 +114,7 @@ pub(super) async fn create_skill(
     }
 
     let skills_dir = state.skills_dir();
-    let skill_dir = skills_dir.join(&req.manifest.name);
+    let skill_dir = safe_skill_dir(&skills_dir, &req.manifest.name)?;
     if skill_dir.exists() {
         return Err(AppError::BadRequest(format!(
             "Skill '{}' already exists",
@@ -112,7 +138,7 @@ pub(super) async fn update_skill(
     }
 
     let skills_dir = state.skills_dir();
-    let skill_dir = skills_dir.join(&name);
+    let skill_dir = safe_skill_dir(&skills_dir, &name)?;
     let mut skill = read_from_dir(&skill_dir)
         .map_err(|_| AppError::NotFound(format!("Skill '{}' not found", name)))?;
 
@@ -148,7 +174,7 @@ pub(super) async fn delete_skill(
     }
 
     let skills_dir = state.skills_dir();
-    let skill_dir = skills_dir.join(&name);
+    let skill_dir = safe_skill_dir(&skills_dir, &name)?;
     if !skill_dir.exists() {
         return Err(AppError::NotFound(format!("Skill '{}' not found", name)));
     }

--- a/mur-core/src/server/tests.rs
+++ b/mur-core/src/server/tests.rs
@@ -116,6 +116,45 @@ async fn test_list_patterns_empty() {
 }
 
 #[tokio::test]
+async fn skill_routes_reject_path_traversal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let app = build_router(test_state(&tmp));
+
+    // DELETE with a traversal name must NOT remove_dir_all the parent (mur home):
+    // skills_dir is tmp/skills, so `..` would target tmp itself.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/v1/skills/..")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(resp.status(), StatusCode::OK);
+    assert!(
+        tmp.path().join("patterns").exists(),
+        "DELETE /skills/.. must not delete the mur home"
+    );
+
+    // GET with an encoded traversal (`..%2F..%2Fpatterns` → `../../patterns`)
+    // must be rejected, not read outside skills_dir.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/skills/..%2F..%2Fpatterns")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
 async fn test_create_and_get_pattern() {
     let tmp = tempfile::tempdir().unwrap();
     let state = test_state(&tmp);


### PR DESCRIPTION
Continuing the traversal sweep into the dashboard HTTP API — a **network-reachable, unauthenticated** surface (the server binds `0.0.0.0` and CORS is not an auth control). Pattern routes already go through the now-validated `YamlStore` (#360), but the **skill** routes join the name directly.

### The bug
```rust
// delete_skill — name from the {name} path param
let skill_dir = skills_dir.join(&name);
std::fs::remove_dir_all(&skill_dir)?;     // name = ".." → remove_dir_all(mur_home)
```

- `delete_skill`: `name = ".."` resolves to the mur home → `remove_dir_all` wipes **every agent, pattern, trust entry, and config**. Remotely. Unauthenticated.
- `create_skill` (name from JSON body) / `update_skill`: arbitrary file write.
- `get_skill`: arbitrary read.

Path params decode percent-encoding after routing, so `..%2F..%2F` reaches the handler as `../../`.

### The fix
A shared `safe_skill_dir` refuses separators (`/`, `\`), `.`/`..`, control/NUL, and empty/oversize names (a skill name is a single directory component) → 400. All four handlers route through it.

### Test
`skill_routes_reject_path_traversal`: `DELETE /skills/..` leaves the mur home intact (the parent dir survives), and `GET /skills/..%2F..%2Fpatterns` → 400. 47 server tests pass; clippy + fmt clean.

### ⚠️ Bigger exposure flagged (not changed here)
The server binds `0.0.0.0:{port}` with **no authentication** — every `/api/v1/*` route (read and write) is callable by any host on the LAN. That's a serious exposure independent of this traversal and should be hardened separately (bind `127.0.0.1` by default, and/or require a token). I scoped this PR to the concrete traversal fix; happy to do the bind/auth hardening as a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)