### PR TITLE
fix(mcp): PATH-resolve MCP command so binary pin + signature checks enforce

### DIFF
--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -167,17 +167,29 @@ impl Hook for B0SafetyHook {
                 // `mur agent mcp pin <name>` as the migration verb.
                 continue;
             };
-            // Same resolution as M9.2 install: the runtime's already-
-            // resolved `mcp_server_binaries` are paths derived from
-            // `command.split_whitespace().next()`. We mirror that here
-            // so install-side and verify-side hash the same bytes.
-            let path = std::path::PathBuf::from(
-                entry
-                    .command
-                    .split_whitespace()
-                    .next()
-                    .unwrap_or(&entry.command),
-            );
+            // Resolve via PATH exactly as install does (mur_common::exec) so
+            // both passes hash the same binary `Command::new` will spawn. A bare
+            // `node`/`npx` opened verbatim is a CWD-relative path that doesn't
+            // exist, which previously soft-failed and skipped the pin entirely.
+            let prog = entry
+                .command
+                .split_whitespace()
+                .next()
+                .unwrap_or(&entry.command);
+            let path = match mur_common::exec::resolve_command(prog) {
+                Ok(p) => p,
+                Err(e) => {
+                    // Can't locate the binary (likely the user uninstalled the
+                    // MCP without removing the profile entry) — soft fail, same
+                    // as BinaryMissing below.
+                    tracing::warn!(
+                        mcp = %entry.name,
+                        error = %e,
+                        "B0 rule 6: pin verify soft-failed (command not resolvable); continuing",
+                    );
+                    continue;
+                }
+            };
             match crate::hooks::b0_helpers::verify_mcp_binary_hash(expected, &path) {
                 Ok(()) => {
                     tracing::debug!(mcp = %entry.name, "B0 rule 6: pin verified");

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -303,10 +303,13 @@ pub(crate) async fn prepare_runtime(
         .mcp_servers
         .iter()
         .filter_map(|s| {
-            s.command
-                .split_whitespace()
-                .next()
-                .map(std::path::PathBuf::from)
+            // PATH-resolve so the B0 signature/pin checks (rules 6 & 11) inspect
+            // the same binary `Command::new` will spawn. A bare `node`/`npx`
+            // taken verbatim is a CWD-relative path that doesn't exist, which
+            // silently skips both checks. Unresolvable → drop (treated as
+            // "uninstalled", matching the soft-fail behaviour in rule 6).
+            let prog = s.command.split_whitespace().next().unwrap_or(&s.command);
+            mur_common::exec::resolve_command(prog).ok()
         })
         .collect();
     let hook_ctx = HookCtx {

--- a/mur-common/src/exec.rs
+++ b/mur-common/src/exec.rs
@@ -1,0 +1,79 @@
+//! Shared executable-path resolution.
+//!
+//! A single source of truth for turning a command (bare program name or path)
+//! into the absolute, symlink-resolved binary that will actually be executed.
+//! Used by both install-time MCP pinning (`mur agent mcp pin`) and the runtime
+//! startup verification (B0 rules 6 & 11) so a bare `command` like `node`
+//! resolves identically across the two passes — otherwise the runtime hashes a
+//! CWD-relative path that doesn't exist and silently skips the pin/signature
+//! check while `Command::new` runs the PATH-resolved binary.
+
+use anyhow::{Context, Result, bail};
+use std::path::{Path, PathBuf};
+
+/// Resolve `command` to an absolute path on disk.
+///
+/// - If `command` is already absolute or contains a path separator, canonicalize
+///   it (resolves symlinks).
+/// - Otherwise consult `PATH` (and try a `.exe` suffix on Windows). Returns the
+///   first match found, canonicalized.
+///
+/// Returns an error if the binary can't be located.
+pub fn resolve_command(command: &str) -> Result<PathBuf> {
+    let p = Path::new(command);
+    if p.is_absolute() || command.contains('/') || command.contains('\\') {
+        return p
+            .canonicalize()
+            .with_context(|| format!("canonicalize {command}"));
+    }
+    let path_var = std::env::var_os("PATH")
+        .ok_or_else(|| anyhow::anyhow!("PATH env var unset; cannot resolve `{command}`"))?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(command);
+        if candidate.is_file() {
+            return candidate
+                .canonicalize()
+                .with_context(|| format!("canonicalize {}", candidate.display()));
+        }
+        #[cfg(target_os = "windows")]
+        {
+            let with_exe = dir.join(format!("{command}.exe"));
+            if with_exe.is_file() {
+                return with_exe
+                    .canonicalize()
+                    .with_context(|| format!("canonicalize {}", with_exe.display()));
+            }
+        }
+    }
+    bail!("could not find `{command}` on PATH");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn errors_on_missing_binary() {
+        assert!(resolve_command("definitely-not-a-real-binary-xyz123").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolves_bare_program_on_path_to_absolute() {
+        // The whole point: a bare program name resolves to an absolute path.
+        // (The runtime pin check used to open it relative to CWD and soft-fail.)
+        let resolved = resolve_command("sh").expect("sh is on PATH");
+        assert!(
+            resolved.is_absolute(),
+            "expected absolute, got {resolved:?}"
+        );
+        assert!(resolved.exists());
+    }
+
+    #[test]
+    fn absolute_path_is_canonicalized() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let resolved = resolve_command(tmp.path().to_str().unwrap()).unwrap();
+        assert!(resolved.is_absolute());
+    }
+}

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -14,6 +14,7 @@ pub mod error;
 /// B0 M11 — JSONL output schema for the eval harness.
 pub mod eval;
 pub mod event;
+pub mod exec;
 pub mod expression;
 pub mod guard;
 pub mod hooks_config;

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -34,34 +34,9 @@ use std::path::{Path, PathBuf};
 /// install-time hashing and startup verification so a bare `command`
 /// like "mcp-weather" stays consistent across the two passes.
 pub fn resolve_command(command: &str) -> Result<PathBuf> {
-    let p = Path::new(command);
-    if p.is_absolute() || command.contains('/') || command.contains('\\') {
-        return p
-            .canonicalize()
-            .with_context(|| format!("canonicalize {command}"));
-    }
-    // Walk PATH (or %PATH% on Windows) looking for `command`.
-    let path_var = std::env::var_os("PATH")
-        .ok_or_else(|| anyhow::anyhow!("PATH env var unset; cannot resolve `{command}`"))?;
-    for dir in std::env::split_paths(&path_var) {
-        let candidate = dir.join(command);
-        if candidate.is_file() {
-            return candidate
-                .canonicalize()
-                .with_context(|| format!("canonicalize {}", candidate.display()));
-        }
-        // Windows: try with .exe suffix.
-        #[cfg(target_os = "windows")]
-        {
-            let with_exe = dir.join(format!("{command}.exe"));
-            if with_exe.is_file() {
-                return with_exe
-                    .canonicalize()
-                    .with_context(|| format!("canonicalize {}", with_exe.display()));
-            }
-        }
-    }
-    bail!("could not find `{command}` on PATH");
+    // Single source of truth in mur-common so install-time pinning and the
+    // runtime startup verification (B0 rules 6 & 11) resolve identically.
+    mur_common::exec::resolve_command(command)
 }
 
 /// Stream-hash the file at `path` with SHA-256. Returns lowercase


### PR DESCRIPTION
Found auditing subprocess spawns in the agent runtime. The spawn itself is safe (no shell, separate args, sandboxed) — but the **integrity checks around it were silently bypassed.**

### The bug
B0 rule 6 (M9 binary pin — "the MCP binary changed since you approved it") and rule 11 (MCP signature check) both resolved the binary as `command.split_whitespace().next()` opened **relative to CWD**:

```rust
let path = PathBuf::from(entry.command.split_whitespace().next()...); // "node"
verify_mcp_binary_hash(expected, &path)  // File::open("node") → NotFound
```

For a bare command — `node`, `python`, `npx`, `uvx` (the common case) — that file doesn't exist, so:
- **rule 6** → `BinaryMissing` → soft-fail → continue (**pin never enforced**)
- **rule 11** → `mcp_server_binaries` are bare names → signature check runs on a missing/wrong file

…while `Command::new(&entry.command)` PATH-resolves and spawns the **real** binary. So both integrity controls were skipped for most real MCP servers, and a swapped binary earlier on PATH would not be detected — defeating the purpose of pinning a `.muragent`-supplied MCP.

The install side (`mur agent mcp pin`) already PATH-resolves + canonicalizes; its own doc says install and startup verification must resolve identically — but the runtime had diverged.

### The fix
Move `resolve_command` to `mur_common::exec` (single source of truth, so they can't re-diverge) and use it in:
- mur-core install (re-exported — callers unchanged),
- the supervisor's `mcp_server_binaries` (rule 11),
- B0 rule 6 (unresolvable → soft-fail, matching the "uninstalled" case).

Now both checks hash the same binary `Command::new` will spawn, so a bare-command MCP is actually verified.

### Tests
`mur_common::exec` resolves a bare program to an absolute path and errors on a missing one; existing `agent_mcp_pin` tests pass unchanged through the re-export. mur-common/core/runtime build; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)