### PR TITLE
fix(a2a): validate skill name in skills/get handler to block traversal read

### DIFF
--- a/mur-agent-runtime/src/protocol/methods/skills.rs
+++ b/mur-agent-runtime/src/protocol/methods/skills.rs
@@ -35,6 +35,16 @@ impl MethodHandler for SkillsGetHandler {
             .and_then(|v| v.as_str())
             .ok_or_else(|| HandlerError::InvalidParams("missing 'skill' field".into()))?;
 
+        // `skill` comes from a remote A2A peer and is joined into
+        // `<store_root>/skills/<name>`. Reject path-traversal so a peer can't
+        // read another agent's skill (or any `skill.yaml`/`skill.md`) outside
+        // the store via `../…`.
+        if !mur_common::skill::loader::is_valid_skill_name(skill_name) {
+            return Err(HandlerError::InvalidParams(format!(
+                "invalid skill name: {skill_name:?}"
+            )));
+        }
+
         let dir = global_skill_dir(&self.store_root, skill_name);
         let manifest = read_from_dir(&dir)
             .map_err(|e| HandlerError::Internal(format!("skill '{skill_name}' not found: {e}")))?;
@@ -105,5 +115,30 @@ content:
         let handler = SkillsGetHandler::new(dir.path().to_path_buf());
         let err = handler.handle(Some(json!({}))).await.unwrap_err();
         assert!(matches!(err, HandlerError::InvalidParams(_)));
+    }
+
+    #[tokio::test]
+    async fn rejects_path_traversal_skill_name() {
+        // A remote peer must not read a skill outside the store via `../…`. The
+        // dangerous (cross-agent / arbitrary-dir) forms all contain a separator,
+        // which is_valid_skill_name refuses.
+        let dir = tempdir().unwrap();
+        let handler = SkillsGetHandler::new(dir.path().to_path_buf());
+        for bad in [
+            "../secret",
+            "a/b",
+            "../../etc/passwd",
+            "../agents/victim/skills/x",
+            "a\\b",
+        ] {
+            let err = handler
+                .handle(Some(json!({ "skill": bad })))
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(err, HandlerError::InvalidParams(_)),
+                "{bad:?} should be rejected, got {err:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Continuing the traversal sweep into the A2A protocol surface (remote-peer input).

### The bug
The A2A `skills/get` method handler took the `skill` field from a remote peer's request and joined it into `<store_root>/skills/<name>` with no validation, then returned that directory's `skill.yaml`/`skill.md` to the peer:

```rust
let skill_name = params.get("skill").and_then(|v| v.as_str())...;
let dir = global_skill_dir(&self.store_root, skill_name);   // "../agents/victim/skills/x"
let manifest = read_from_dir(&dir)?;                          // → returned to the peer
```

A name like `../agents/<victim>/skills/x` (or any `../…`) lets a remote peer **read another agent's skill manifest** — or any `skill.yaml`/`skill.md` on disk — outside the store. Information disclosure over A2A.

### The fix
Validate `skill` with `is_valid_skill_name` before resolving the path (→ `InvalidParams`). Its character set excludes path separators, so a name is confined to a single component.

The handler is registered but the live socket round-trip is M4b-pending, so this hardens the primitive before it's reachable. Test: separator/traversal names are refused while a normal skill still serves. 18 skill-handler tests pass; clippy + fmt clean.

(Companion to #359/#360/#361 — same traversal class, now on the A2A method surface.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)