### PR TITLE
fix(skill): validate skill name on install to block path traversal

### DIFF
--- a/mur-core/src/cmd/skill_install.rs
+++ b/mur-core/src/cmd/skill_install.rs
@@ -174,9 +174,20 @@ pub fn cmd_install_ctx(
     Ok(())
 }
 
+/// Resolve `<home>/skills/<name>` for install, refusing a skill whose name
+/// would escape the skills dir. The name comes from a fetched manifest (a
+/// registry/git source the user chose, but not necessarily one they vetted),
+/// so an unsafe `../…` name must not be written to an arbitrary path.
+fn safe_skill_dir(home: &Path, name: &str) -> Result<std::path::PathBuf> {
+    if !mur_common::skill::loader::is_valid_skill_name(name) {
+        anyhow::bail!("refusing to install skill with unsafe name {name:?} (path traversal)");
+    }
+    Ok(global_skill_dir(home, name))
+}
+
 fn install_resolved_node(home: &Path, node: &ResolvedNode) -> Result<()> {
     let report = scan_skill(&node.manifest)?;
-    let dir = global_skill_dir(home, &node.name);
+    let dir = safe_skill_dir(home, &node.name)?;
     write_to_dir(&dir, &node.manifest)?;
     let hash = content_sha256(&node.manifest)?;
     let mut trust = SkillTrustStore::load(home).map_err(|e| anyhow::anyhow!("load trust: {e}"))?;
@@ -280,7 +291,7 @@ fn install_from_agent(home: &Path, agent_name: &str, skill_name: &str) -> Result
     };
 
     // 6. Install — write to the target store.
-    let dir = global_skill_dir(home, &manifest.name);
+    let dir = safe_skill_dir(home, &manifest.name)?;
     write_to_dir(&dir, &manifest).context("write installed skill")?;
 
     // 7. Record in trust store.
@@ -494,6 +505,21 @@ fn try_embed_skill(home: &Path, name: &str, version: &str, manifest: &SkillManif
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn safe_skill_dir_rejects_traversal_names() {
+        let home = tempdir().unwrap();
+        // Separator/absolute forms (the dangerous traversal) are refused.
+        for bad in ["../evil", "a/b", "../../etc/x", "a\\b", "/abs", ""] {
+            assert!(
+                safe_skill_dir(home.path(), bad).is_err(),
+                "{bad:?} should be rejected"
+            );
+        }
+        // A normal name resolves under the skills dir.
+        let dir = safe_skill_dir(home.path(), "web-search").unwrap();
+        assert!(dir.starts_with(home.path().join("skills")));
+    }
 
     #[test]
     fn valid_yaml_parses_and_validates() {


### PR DESCRIPTION
The local sink that completes the skill-name traversal sweep.

### The bug
`mur skill install` writes each resolved skill via `global_skill_dir(home, &manifest.name)` + `write_to_dir` with no name validation (the path runs `scan_skill` for content, but never validates the name format). `manifest.name` comes from a **fetched** manifest — a registry/git source the user chose but didn't necessarily vet — so a hostile `name = "../../<path>"` writes `skill.yaml` to an arbitrary location. An arbitrary `.yaml` write from "I installed a skill."

### The fix
A `safe_skill_dir` gate (rejects separators / absolute / empty via `is_valid_skill_name`), used at **both** write sites: the dependency-tree node install and the single-skill install.

### Sweep status
Remote skill-name sinks were already fixed — sync inbox (#359), dashboard routes (#361), A2A `skills/get` (#364); this covers the local install path. Pattern names are covered by #360 (`YamlStore`).

Test: separator/absolute/empty names refused; a normal name resolves under the skills dir. clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)