### PR TITLE
feat(hub): Phase 4 tool ecosystem — McpPool, ToolPolicy gate, perm tool CLI

### DIFF
--- a/mur-agent-runtime/src/hooks/types.rs
+++ b/mur-agent-runtime/src/hooks/types.rs
@@ -161,6 +161,7 @@ fn test_default_entitlements() -> Entitlements {
         syscalls: SyscallsEntitlement::default(),
         limits: LimitsEntitlement::default(),
         llm: Default::default(),
+        tools: vec![],
         fail_closed_on_sandbox_error: true,
     }
 }

--- a/mur-agent-runtime/src/lib.rs
+++ b/mur-agent-runtime/src/lib.rs
@@ -23,6 +23,7 @@ pub mod idle_scheduler;
 pub mod import;
 pub mod llm;
 pub mod lock_file;
+pub mod mcp;
 pub mod multi_call;
 pub mod multimodal;
 pub mod profile;

--- a/mur-agent-runtime/src/mcp/mod.rs
+++ b/mur-agent-runtime/src/mcp/mod.rs
@@ -1,0 +1,1 @@
+pub mod pool;

--- a/mur-agent-runtime/src/mcp/pool.rs
+++ b/mur-agent-runtime/src/mcp/pool.rs
@@ -1,0 +1,94 @@
+//! Lazy-cached MCP subprocess pool. One `McpPool` per agent; servers are
+//! spawned on first use and reused for the agent's lifetime.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use mur_common::agent::McpServerEntry;
+use tokio::sync::Mutex;
+
+use crate::protocol::mcp_client::{McpClient, McpError, ToolInfo};
+use crate::sandbox::SandboxPolicy;
+
+pub struct McpPool {
+    entries: HashMap<String, McpServerEntry>,
+    policy: SandboxPolicy,
+    clients: Mutex<HashMap<String, Arc<Mutex<McpClient>>>>,
+}
+
+impl McpPool {
+    pub fn new(entries: Vec<McpServerEntry>, policy: SandboxPolicy) -> Arc<Self> {
+        let map = entries.into_iter().map(|e| (e.name.clone(), e)).collect();
+        Arc::new(Self {
+            entries: map,
+            policy,
+            clients: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Return (or lazily spawn) the client for `server`.
+    pub async fn client(&self, server: &str) -> Result<Arc<Mutex<McpClient>>, McpError> {
+        let mut guard = self.clients.lock().await;
+        if let Some(c) = guard.get(server) {
+            return Ok(c.clone());
+        }
+
+        let entry = self.entries.get(server).ok_or_else(|| {
+            McpError::Server(format!("no MCP server named `{server}` on this agent"))
+        })?;
+        let mut client = McpClient::spawn(entry, &self.policy).await?;
+        client.initialize().await?;
+
+        // Drain child stderr in a background thread so the pipe never fills.
+        if let Some(stderr) = client.take_stderr().await {
+            let server_name = server.to_string();
+            tokio::task::spawn_blocking(move || {
+                use std::io::{BufRead, BufReader};
+                for line in BufReader::new(stderr).lines().flatten() {
+                    tracing::debug!(server = %server_name, "mcp stderr: {line}");
+                }
+            });
+        }
+
+        let shared = Arc::new(Mutex::new(client));
+        guard.insert(server.to_string(), shared.clone());
+        Ok(shared)
+    }
+
+    /// List tools exposed by `server`, spawning it if needed.
+    pub async fn list_tools(&self, server: &str) -> Result<Vec<ToolInfo>, McpError> {
+        let c = self.client(server).await?;
+        c.lock().await.list_tools().await
+    }
+
+    /// Shut down all warm clients gracefully.
+    pub async fn shutdown(&self) {
+        let mut guard = self.clients.lock().await;
+        let clients: Vec<_> = guard.drain().map(|(_, v)| v).collect();
+        drop(guard);
+        for arc in clients {
+            // Only shut down if we hold the last Arc reference.
+            if let Ok(mutex) = Arc::try_unwrap(arc) {
+                mutex.into_inner().shutdown().await;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::SandboxPolicy;
+
+    #[tokio::test]
+    async fn unknown_server_returns_error() {
+        let pool = McpPool::new(vec![], SandboxPolicy::default());
+        match pool.client("nonexistent").await {
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(msg.contains("nonexistent"), "error should name the server: {msg}");
+            }
+            Ok(_) => panic!("expected error for unknown server"),
+        }
+    }
+}

--- a/mur-agent-runtime/src/mcp/pool.rs
+++ b/mur-agent-runtime/src/mcp/pool.rs
@@ -44,8 +44,11 @@ impl McpPool {
             let server_name = server.to_string();
             tokio::task::spawn_blocking(move || {
                 use std::io::{BufRead, BufReader};
-                for line in BufReader::new(stderr).lines().flatten() {
-                    tracing::debug!(server = %server_name, "mcp stderr: {line}");
+                for line in BufReader::new(stderr).lines() {
+                    match line {
+                        Ok(l) => tracing::debug!(server = %server_name, "mcp stderr: {l}"),
+                        Err(_) => break,
+                    }
                 }
             });
         }
@@ -86,7 +89,10 @@ mod tests {
         match pool.client("nonexistent").await {
             Err(e) => {
                 let msg = e.to_string();
-                assert!(msg.contains("nonexistent"), "error should name the server: {msg}");
+                assert!(
+                    msg.contains("nonexistent"),
+                    "error should name the server: {msg}"
+                );
             }
             Ok(_) => panic!("expected error for unknown server"),
         }

--- a/mur-agent-runtime/src/protocol/mcp_client.rs
+++ b/mur-agent-runtime/src/protocol/mcp_client.rs
@@ -13,6 +13,9 @@ pub struct McpClient {
     child: Mutex<std::process::Child>,
     stdin: Mutex<ChildStdin>,
     stdout: Mutex<Lines<BufReader<ChildStdout>>>,
+    /// Piped stderr, available once via `take_stderr()`. Callers should drain
+    /// this in a background task to prevent the child's stderr buffer filling.
+    stderr: Mutex<Option<std::process::ChildStderr>>,
     next_id: Mutex<u64>,
     pub server_name: String,
 }
@@ -61,6 +64,7 @@ impl McpClient {
 
         let raw_stdin = child.stdin.take().ok_or(McpError::StreamClosed)?;
         let raw_stdout = child.stdout.take().ok_or(McpError::StreamClosed)?;
+        let raw_stderr = child.stderr.take();
         let stdin = ChildStdin::from_std(raw_stdin)?;
         let stdout = ChildStdout::from_std(raw_stdout)?;
 
@@ -68,9 +72,16 @@ impl McpClient {
             child: Mutex::new(child),
             stdin: Mutex::new(stdin),
             stdout: Mutex::new(BufReader::new(stdout).lines()),
+            stderr: Mutex::new(raw_stderr),
             next_id: Mutex::new(1),
             server_name: entry.name.clone(),
         })
+    }
+
+    /// Take the child's stderr handle for background draining. Returns `None`
+    /// if already taken or if the child was spawned without a piped stderr.
+    pub async fn take_stderr(&self) -> Option<std::process::ChildStderr> {
+        self.stderr.lock().await.take()
     }
 
     async fn request(&self, method: &str, params: Value) -> Result<Value, McpError> {

--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -175,6 +175,7 @@ mod tests {
             syscalls: Default::default(),
             limits: Default::default(),
             llm: Default::default(),
+            tools: vec![],
             fail_closed_on_sandbox_error: true,
         }
     }

--- a/mur-agent-runtime/src/skills/sandbox_map.rs
+++ b/mur-agent-runtime/src/skills/sandbox_map.rs
@@ -71,6 +71,7 @@ mod tests {
             syscalls: SyscallsEntitlement::default(),
             limits: LimitsEntitlement::default(),
             llm: Default::default(),
+            tools: vec![],
             fail_closed_on_sandbox_error: true,
         }
     }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -260,8 +260,9 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     let pending_approvals: Arc<Mutex<HashMap<String, oneshot::Sender<crate::hitl::HitlDecision>>>> =
         Arc::new(Mutex::new(HashMap::new()));
     let hitl_timeout_secs = profile.inner.hitl.timeout_secs;
-    let (runner, llm_for_companion) = crate::supervisor_runner::build_provider_runner(
+    let (runner, llm_for_companion, mcp_pool) = crate::supervisor_runner::build_provider_runner(
         force_echo,
+        &agent_home,
         &profile,
         runtime_skills.clone(),
         skills_cfg.clone(),
@@ -593,6 +594,9 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     // we just tear down transports and drain telemetry.
     for t in transport_tasks {
         t.abort();
+    }
+    if let Some(pool) = mcp_pool {
+        pool.shutdown().await;
     }
     writer
         .emit(Event::Warning {

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -10,11 +10,15 @@ use crate::hitl::HitlApprovals;
 use crate::hooks::{HookChain, HookCtx, TelemetryEmitter};
 use crate::llm::LlmClient;
 use crate::llm::{anthropic::AnthropicClient, ollama::OllamaClient, openai::OpenAiClient};
+use crate::mcp::pool::McpPool;
 use crate::profile::Profile;
+use crate::sandbox::SandboxPolicy;
 use crate::sandbox::reqwest_guard::HostGuard;
 use crate::skills::RuntimeSkills;
 use crate::task_runner::TaskRunner;
 use crate::telemetry_writer::{TelemetryWriter, WriterTelemetryEmitter};
+use crate::tools::bash::BashTool;
+use crate::tools::registry::build_tools;
 use mur_common::agent::NetworkOutboundMode;
 use mur_common::config::SkillsConfig;
 use mur_common::model::ModelEntry;
@@ -111,12 +115,16 @@ pub fn build_runner(
     pending_approvals: Option<HitlApprovals>,
     notifier: Option<tokio::sync::mpsc::Sender<serde_json::Value>>,
     hitl_timeout_secs: u32,
+    tools: Vec<std::sync::Arc<dyn crate::tools::ToolExecutor>>,
+    tools_policy: Vec<mur_common::agent::ToolRule>,
 ) -> Arc<TaskRunner> {
     let mut runner = TaskRunner::with_llm(client)
         .with_system_prompt(base_system_prompt)
         .with_skills(skills)
         .with_skills_cfg(skills_cfg)
-        .with_hitl_timeout_secs(hitl_timeout_secs);
+        .with_hitl_timeout_secs(hitl_timeout_secs)
+        .with_tools(tools)
+        .with_tools_policy(tools_policy);
     if let (Some(chain), Some(ctx), Some(cancel)) = (hook_chain, hook_ctx, hook_cancel) {
         runner = runner.with_hook_chain(chain, ctx, cancel);
     }
@@ -130,10 +138,11 @@ pub fn build_runner(
 }
 
 /// Build the LLM-backed TaskRunner for a resolved model entry.
-/// Returns (runner, optional LLM client for companion sharing).
+/// Returns (runner, optional LLM client for companion sharing, optional McpPool for shutdown).
 #[allow(clippy::too_many_arguments)]
 pub async fn build_provider_runner(
     force_echo: bool,
+    agent_home: &std::path::Path,
     profile: &Profile,
     runtime_skills: Arc<RuntimeSkills>,
     skills_cfg: SkillsConfig,
@@ -143,9 +152,13 @@ pub async fn build_provider_runner(
     pending_approvals: Option<HitlApprovals>,
     notifier: Option<tokio::sync::mpsc::Sender<serde_json::Value>>,
     hitl_timeout_secs: u32,
-) -> anyhow::Result<(Arc<TaskRunner>, Option<Arc<dyn LlmClient>>)> {
+) -> anyhow::Result<(
+    Arc<TaskRunner>,
+    Option<Arc<dyn LlmClient>>,
+    Option<Arc<McpPool>>,
+)> {
     if force_echo {
-        return Ok((Arc::new(TaskRunner::new_stub_echo()), None));
+        return Ok((Arc::new(TaskRunner::new_stub_echo()), None, None));
     }
 
     let resolved = crate::supervisor::resolve_model_entry(&profile.inner);
@@ -185,6 +198,23 @@ pub async fn build_provider_runner(
         .build()
         .context("failed to build guarded HTTP client")?;
 
+    // Build MCP pool from the agent profile's configured servers, then discover
+    // and filter tools concurrently before constructing the runner.
+    let sandbox_policy = SandboxPolicy::from_entitlements(&profile.inner.entitlements, agent_home);
+    let pool = McpPool::new(profile.inner.mcp_servers.clone(), sandbox_policy);
+    let bash_exec: Arc<dyn crate::tools::ToolExecutor> =
+        Arc::new(BashTool::new(agent_home.to_path_buf()));
+    let bash_def = bash_exec.def();
+    let tools_policy = profile.inner.entitlements.tools.clone();
+    let (_defs, tool_map) = build_tools(
+        Some((bash_def, bash_exec)),
+        &profile.inner.mcp_servers,
+        &tools_policy,
+        pool.clone(),
+    )
+    .await;
+    let tools: Vec<Arc<dyn crate::tools::ToolExecutor>> = tool_map.into_values().collect();
+
     let build = |client: Arc<dyn LlmClient>| {
         let r = crate::supervisor_runner::build_runner(
             client.clone(),
@@ -197,8 +227,10 @@ pub async fn build_provider_runner(
             pending_approvals.clone(),
             notifier.clone(),
             hitl_timeout_secs,
+            tools.clone(),
+            tools_policy.clone(),
         );
-        (r, Some(client))
+        (r, Some(client), Some(pool.clone()))
     };
 
     Ok(match entry.provider.as_str() {
@@ -253,7 +285,11 @@ pub async fn build_provider_runner(
                 Ok(client) => build(client),
                 Err(e) => {
                     warn!(error = %e, "anthropic client unavailable; falling back to echo");
-                    (Arc::new(TaskRunner::new_stub_echo()), None)
+                    (
+                        Arc::new(TaskRunner::new_stub_echo()),
+                        None,
+                        Some(pool.clone()),
+                    )
                 }
             }
         }
@@ -278,13 +314,21 @@ pub async fn build_provider_runner(
                 Ok(client) => build(client),
                 Err(e) => {
                     warn!(error = %e, "openai client unavailable; falling back to echo");
-                    (Arc::new(TaskRunner::new_stub_echo()), None)
+                    (
+                        Arc::new(TaskRunner::new_stub_echo()),
+                        None,
+                        Some(pool.clone()),
+                    )
                 }
             }
         }
         other => {
             warn!(provider = %other, "no LLM client implemented; falling back to echo");
-            (Arc::new(TaskRunner::new_stub_echo()), None)
+            (
+                Arc::new(TaskRunner::new_stub_echo()),
+                None,
+                Some(pool.clone()),
+            )
         }
     })
 }

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -107,6 +107,11 @@ impl TaskRunner {
         }
     }
 
+    pub fn with_tools(mut self, tools: Vec<Arc<dyn crate::tools::ToolExecutor>>) -> Self {
+        self.tools = tools;
+        self
+    }
+
     pub fn with_tools_policy(mut self, rules: Vec<mur_common::agent::ToolRule>) -> Self {
         self.tools_policy = rules;
         self

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -65,6 +65,7 @@ pub struct TaskRunner {
     hitl_timeout_secs: u32,
     max_iterations: u32,
     tools: Vec<Arc<dyn crate::tools::ToolExecutor>>,
+    tools_policy: Vec<mur_common::agent::ToolRule>,
 }
 
 impl TaskRunner {
@@ -102,7 +103,13 @@ impl TaskRunner {
             hitl_timeout_secs: 300,
             max_iterations: 10,
             tools: vec![],
+            tools_policy: vec![],
         }
+    }
+
+    pub fn with_tools_policy(mut self, rules: Vec<mur_common::agent::ToolRule>) -> Self {
+        self.tools_policy = rules;
+        self
     }
 
     pub fn with_telemetry(mut self, tx: mpsc::Sender<Event>) -> Self {
@@ -208,7 +215,9 @@ impl TaskRunner {
             let Some(loaded) = skills.loaded.iter().find(|s| s.name == t.skill_name) else {
                 continue;
             };
-            let inventory = McpInventory::default(); // TODO: wire to MCP registry
+            let inventory = McpInventory::from_tool_names(
+                self.tools.iter().map(|t| t.name().to_string()).collect(),
+            );
             let Some(body) = layer3_body(&loaded.manifest, &inventory) else {
                 continue;
             };
@@ -579,6 +588,34 @@ impl TaskRunner {
                 content: format!("unknown tool: {}", call.tool_name),
                 is_error: true,
             });
+        }
+
+        // 1b. Policy gate: check before executing.
+        {
+            use mur_common::agent::{ToolPolicy, resolve_tool_policy};
+            match resolve_tool_policy(&self.tools_policy, &call.tool_name) {
+                ToolPolicy::Deny => {
+                    return Ok(ToolResultEntry {
+                        call_id: call.call_id.clone(),
+                        content: format!("Tool `{}` is denied by policy.", call.tool_name),
+                        is_error: true,
+                    });
+                }
+                ToolPolicy::Allow => {
+                    // Execute without HITL gate below.
+                    let tool = tool.unwrap();
+                    let (output, is_error) = match tool.execute(call.input.clone()).await {
+                        Ok(out) => (out, false),
+                        Err(e) => (format!("tool error: {e}"), true),
+                    };
+                    return Ok(ToolResultEntry {
+                        call_id: call.call_id.clone(),
+                        content: output,
+                        is_error,
+                    });
+                }
+                ToolPolicy::Ask => {}
+            }
         }
 
         // 2. Execute the tool

--- a/mur-agent-runtime/src/tools/mcp.rs
+++ b/mur-agent-runtime/src/tools/mcp.rs
@@ -1,0 +1,132 @@
+//! MCP-backed ToolExecutor: dispatches a single MCP tool via the pool.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use super::{ToolError, ToolExecutor};
+use crate::llm::ToolDef;
+use crate::mcp::pool::McpPool;
+use crate::protocol::mcp_client::McpClient;
+
+pub const MCP_TOOL_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Convert an MCP `tools/call` result to a display string.
+pub fn render_mcp_result(result: &Value) -> String {
+    let Some(content) = result.get("content").and_then(|c| c.as_array()) else {
+        return serde_json::to_string(result).unwrap_or_default();
+    };
+    if content.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    for block in content {
+        match block.get("type").and_then(|t| t.as_str()) {
+            Some("text") => {
+                if let Some(t) = block.get("text").and_then(|t| t.as_str()) {
+                    out.push_str(t);
+                    out.push('\n');
+                }
+            }
+            Some("image") => out.push_str("[image]\n"),
+            Some("resource") => {
+                let uri = block
+                    .get("resource")
+                    .and_then(|r| r.get("uri"))
+                    .and_then(|u| u.as_str())
+                    .unwrap_or("?");
+                out.push_str(&format!("[resource: {uri}]\n"));
+            }
+            _ => {}
+        }
+    }
+    out.trim_end().to_string()
+}
+
+/// A [`ToolExecutor`] backed by a single MCP tool, dispatched via the shared pool.
+pub struct McpToolExecutor {
+    pub wire_name: String,
+    pub server: String,
+    pub tool: String,
+    pub def: ToolDef,
+    pub pool: Arc<McpPool>,
+    pub timeout: Duration,
+}
+
+#[async_trait]
+impl ToolExecutor for McpToolExecutor {
+    fn name(&self) -> &str {
+        &self.wire_name
+    }
+
+    fn def(&self) -> ToolDef {
+        self.def.clone()
+    }
+
+    async fn execute(&self, input: Value) -> Result<String, ToolError> {
+        let client_arc: Arc<Mutex<McpClient>> = self
+            .pool
+            .client(&self.server)
+            .await
+            .map_err(|e| ToolError::Execution(e.to_string()))?;
+
+        let result = tokio::time::timeout(self.timeout, async {
+            client_arc
+                .lock()
+                .await
+                .call_tool(&self.tool, input)
+                .await
+                .map_err(|e| ToolError::Execution(e.to_string()))
+        })
+        .await
+        .map_err(|_| {
+            ToolError::Execution(format!("tool `{}` timed out after {:?}", self.wire_name, self.timeout))
+        })??;
+
+        let is_error = result.get("isError").and_then(|v| v.as_bool()).unwrap_or(false);
+        let text = render_mcp_result(&result);
+        if is_error {
+            Err(ToolError::Execution(text))
+        } else {
+            Ok(text)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn render_text_block() {
+        let r = json!({"content": [{"type": "text", "text": "hello world"}]});
+        assert_eq!(render_mcp_result(&r), "hello world");
+    }
+
+    #[test]
+    fn render_image_block() {
+        let r = json!({"content": [{"type": "image"}]});
+        assert_eq!(render_mcp_result(&r), "[image]");
+    }
+
+    #[test]
+    fn render_multi_block() {
+        let r = json!({"content": [
+            {"type": "text", "text": "line1"},
+            {"type": "image"}
+        ]});
+        let out = render_mcp_result(&r);
+        assert!(out.contains("line1"));
+        assert!(out.contains("[image]"));
+    }
+
+    #[test]
+    fn render_fallback_json() {
+        let r = json!({"notContent": "foo"});
+        assert!(!render_mcp_result(&r).is_empty());
+    }
+}

--- a/mur-agent-runtime/src/tools/mcp.rs
+++ b/mur-agent-runtime/src/tools/mcp.rs
@@ -83,10 +83,16 @@ impl ToolExecutor for McpToolExecutor {
         })
         .await
         .map_err(|_| {
-            ToolError::Execution(format!("tool `{}` timed out after {:?}", self.wire_name, self.timeout))
+            ToolError::Execution(format!(
+                "tool `{}` timed out after {:?}",
+                self.wire_name, self.timeout
+            ))
         })??;
 
-        let is_error = result.get("isError").and_then(|v| v.as_bool()).unwrap_or(false);
+        let is_error = result
+            .get("isError")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
         let text = render_mcp_result(&result);
         if is_error {
             Err(ToolError::Execution(text))

--- a/mur-agent-runtime/src/tools/mod.rs
+++ b/mur-agent-runtime/src/tools/mod.rs
@@ -1,4 +1,5 @@
 pub mod bash;
+pub mod naming;
 
 use crate::llm::ToolDef;
 

--- a/mur-agent-runtime/src/tools/mod.rs
+++ b/mur-agent-runtime/src/tools/mod.rs
@@ -1,5 +1,7 @@
 pub mod bash;
+pub mod mcp;
 pub mod naming;
+pub mod registry;
 
 use crate::llm::ToolDef;
 

--- a/mur-agent-runtime/src/tools/naming.rs
+++ b/mur-agent-runtime/src/tools/naming.rs
@@ -1,0 +1,64 @@
+//! MCP wire-name encoding: `mcp__<server>__<tool>`.
+//!
+//! The LLM tool-name field must match `^[a-zA-Z0-9_-]{1,64}$`.
+//! Server names are sanitised by collapsing non-alphanumeric/dash chars into `_`.
+
+/// Sanitise an MCP server name so it's safe to embed in a wire name.
+///
+/// Collapses any run of non-`[a-zA-Z0-9-]` chars into a single `_`.
+pub fn sanitize_server(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut prev_us = false;
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() || c == '-' {
+            out.push(c);
+            prev_us = false;
+        } else if !prev_us {
+            out.push('_');
+            prev_us = true;
+        }
+    }
+    // Trim trailing underscore that would make the boundary look odd.
+    out.trim_end_matches('_').to_string()
+}
+
+/// Encode a server + tool name into the `mcp__<server>__<tool>` wire format.
+pub fn wire_name(server_sanitized: &str, tool: &str) -> String {
+    format!("mcp__{server_sanitized}__{tool}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_normal() {
+        assert_eq!(sanitize_server("github"), "github");
+    }
+
+    #[test]
+    fn sanitize_slash_to_underscore() {
+        assert_eq!(sanitize_server("my/server"), "my_server");
+    }
+
+    #[test]
+    fn sanitize_collapse_runs() {
+        assert_eq!(sanitize_server("my//server"), "my_server");
+    }
+
+    #[test]
+    fn sanitize_dash_preserved() {
+        assert_eq!(sanitize_server("my-server"), "my-server");
+    }
+
+    #[test]
+    fn wire_name_format() {
+        assert_eq!(wire_name("github", "merge_pr"), "mcp__github__merge_pr");
+    }
+
+    #[test]
+    fn wire_name_with_sanitized() {
+        let s = sanitize_server("my/server");
+        assert_eq!(wire_name(&s, "do_thing"), "mcp__my_server__do_thing");
+    }
+}

--- a/mur-agent-runtime/src/tools/registry.rs
+++ b/mur-agent-runtime/src/tools/registry.rs
@@ -1,0 +1,126 @@
+//! `build_tools`: concurrent MCP tool discovery → (defs, executor map).
+//!
+//! Call once at agent start to enumerate all non-denied tools across bash
+//! and all configured MCP servers.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use futures::future;
+use mur_common::agent::{McpServerEntry, ToolPolicy, ToolRule, resolve_tool_policy};
+
+use super::{ToolExecutor, mcp::McpToolExecutor};
+use super::naming::{sanitize_server, wire_name};
+use crate::llm::ToolDef;
+use crate::mcp::pool::McpPool;
+
+/// Discover bash + all MCP tools, apply policy filter, return (defs, map).
+///
+/// - `bash`: optional `(def, executor)` pair for the bash tool. Pass `None`
+///   if bash is already registered elsewhere.
+/// - `servers`: list of MCP server entries to probe.
+/// - `rules`: per-tool policy rules from `Entitlements.tools`.
+/// - `pool`: shared `McpPool` for the agent.
+pub async fn build_tools(
+    bash: Option<(ToolDef, Arc<dyn ToolExecutor>)>,
+    servers: &[McpServerEntry],
+    rules: &[ToolRule],
+    pool: Arc<McpPool>,
+) -> (Vec<ToolDef>, HashMap<String, Arc<dyn ToolExecutor>>) {
+    let mut defs: Vec<ToolDef> = Vec::new();
+    let mut map: HashMap<String, Arc<dyn ToolExecutor>> = HashMap::new();
+
+    if let Some((def, exec)) = bash {
+        if resolve_tool_policy(rules, "bash") != ToolPolicy::Deny {
+            defs.push(def);
+            map.insert("bash".to_string(), exec);
+        }
+    }
+
+    let discovery_futs: Vec<_> = servers
+        .iter()
+        .map(|entry| {
+            let pool = pool.clone();
+            let name = entry.name.clone();
+            async move {
+                let sanitized = sanitize_server(&name);
+                match pool.list_tools(&name).await {
+                    Ok(tools) => Some((name, sanitized, tools)),
+                    Err(e) => {
+                        tracing::warn!(server = %name, "mcp tools/list failed: {e}");
+                        None
+                    }
+                }
+            }
+        })
+        .collect();
+
+    let discovered = future::join_all(discovery_futs).await;
+
+    for item in discovered.into_iter().flatten() {
+        let (server, sanitized, tools) = item;
+        for t in tools {
+            let wname = wire_name(&sanitized, &t.name);
+            if resolve_tool_policy(rules, &wname) == ToolPolicy::Deny {
+                continue;
+            }
+            let def = ToolDef {
+                name: wname.clone(),
+                description: t.description.clone(),
+                input_schema: t.input_schema.clone(),
+            };
+            defs.push(def.clone());
+            let exec: Arc<dyn ToolExecutor> = Arc::new(McpToolExecutor {
+                wire_name: wname.clone(),
+                server: server.clone(),
+                tool: t.name.clone(),
+                def,
+                pool: pool.clone(),
+                timeout: super::mcp::MCP_TOOL_TIMEOUT,
+            });
+            map.insert(wname, exec);
+        }
+    }
+
+    (defs, map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::SandboxPolicy;
+
+    #[tokio::test]
+    async fn no_servers_empty_result() {
+        let pool = McpPool::new(vec![], SandboxPolicy::default());
+        let (defs, map) = build_tools(None, &[], &[], pool).await;
+        assert!(defs.is_empty());
+        assert!(map.is_empty());
+    }
+
+    #[tokio::test]
+    async fn bash_tool_included_when_allowed() {
+        use crate::tools::bash::BashTool;
+        let bash_exec: Arc<dyn ToolExecutor> = Arc::new(BashTool { working_dir: std::path::PathBuf::from("/tmp") });
+        let bash_def = bash_exec.def();
+        let pool = McpPool::new(vec![], SandboxPolicy::default());
+        let (defs, map) = build_tools(Some((bash_def, bash_exec)), &[], &[], pool).await;
+        assert_eq!(defs.len(), 1);
+        assert!(map.contains_key("bash"));
+    }
+
+    #[tokio::test]
+    async fn bash_tool_excluded_when_denied() {
+        use crate::tools::bash::BashTool;
+        let bash_exec: Arc<dyn ToolExecutor> = Arc::new(BashTool { working_dir: std::path::PathBuf::from("/tmp") });
+        let bash_def = bash_exec.def();
+        let rules = vec![ToolRule {
+            pattern: "bash".to_string(),
+            policy: ToolPolicy::Deny,
+        }];
+        let pool = McpPool::new(vec![], SandboxPolicy::default());
+        let (defs, map) = build_tools(Some((bash_def, bash_exec)), &[], &rules, pool).await;
+        assert!(defs.is_empty());
+        assert!(!map.contains_key("bash"));
+    }
+}

--- a/mur-agent-runtime/src/tools/registry.rs
+++ b/mur-agent-runtime/src/tools/registry.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use futures::future;
 use mur_common::agent::{McpServerEntry, ToolPolicy, ToolRule, resolve_tool_policy};
 
-use super::{ToolExecutor, mcp::McpToolExecutor};
 use super::naming::{sanitize_server, wire_name};
+use super::{ToolExecutor, mcp::McpToolExecutor};
 use crate::llm::ToolDef;
 use crate::mcp::pool::McpPool;
 
@@ -30,11 +30,11 @@ pub async fn build_tools(
     let mut defs: Vec<ToolDef> = Vec::new();
     let mut map: HashMap<String, Arc<dyn ToolExecutor>> = HashMap::new();
 
-    if let Some((def, exec)) = bash {
-        if resolve_tool_policy(rules, "bash") != ToolPolicy::Deny {
-            defs.push(def);
-            map.insert("bash".to_string(), exec);
-        }
+    if let Some((def, exec)) = bash
+        && resolve_tool_policy(rules, "bash") != ToolPolicy::Deny
+    {
+        defs.push(def);
+        map.insert("bash".to_string(), exec);
     }
 
     let discovery_futs: Vec<_> = servers
@@ -101,7 +101,9 @@ mod tests {
     #[tokio::test]
     async fn bash_tool_included_when_allowed() {
         use crate::tools::bash::BashTool;
-        let bash_exec: Arc<dyn ToolExecutor> = Arc::new(BashTool { working_dir: std::path::PathBuf::from("/tmp") });
+        let bash_exec: Arc<dyn ToolExecutor> = Arc::new(BashTool {
+            working_dir: std::path::PathBuf::from("/tmp"),
+        });
         let bash_def = bash_exec.def();
         let pool = McpPool::new(vec![], SandboxPolicy::default());
         let (defs, map) = build_tools(Some((bash_def, bash_exec)), &[], &[], pool).await;
@@ -112,7 +114,9 @@ mod tests {
     #[tokio::test]
     async fn bash_tool_excluded_when_denied() {
         use crate::tools::bash::BashTool;
-        let bash_exec: Arc<dyn ToolExecutor> = Arc::new(BashTool { working_dir: std::path::PathBuf::from("/tmp") });
+        let bash_exec: Arc<dyn ToolExecutor> = Arc::new(BashTool {
+            working_dir: std::path::PathBuf::from("/tmp"),
+        });
         let bash_def = bash_exec.def();
         let rules = vec![ToolRule {
             pattern: "bash".to_string(),

--- a/mur-agent-runtime/tests/b0_rule2_network_allowlist.rs
+++ b/mur-agent-runtime/tests/b0_rule2_network_allowlist.rs
@@ -38,6 +38,7 @@ fn ent_with_outbound(mode: NetworkOutboundMode, allow: Vec<String>) -> Entitleme
         syscalls: SyscallsEntitlement::default(),
         limits: LimitsEntitlement::default(),
         llm: Default::default(),
+        tools: vec![],
         fail_closed_on_sandbox_error: true,
     }
 }

--- a/mur-agent-runtime/tests/b0_rule5_spawn_deny.rs
+++ b/mur-agent-runtime/tests/b0_rule5_spawn_deny.rs
@@ -29,6 +29,7 @@ fn ent_with_spawn(mode: SpawnMode, allowed: Vec<String>) -> Entitlements {
         syscalls: SyscallsEntitlement::default(),
         limits: LimitsEntitlement::default(),
         llm: Default::default(),
+        tools: vec![],
         fail_closed_on_sandbox_error: true,
     }
 }

--- a/mur-agent-runtime/tests/sandbox_e2e.rs
+++ b/mur-agent-runtime/tests/sandbox_e2e.rs
@@ -128,6 +128,7 @@ fn spawn_sandboxed_runs_true() {
         syscalls: Default::default(),
         limits: Default::default(),
         llm: Default::default(),
+        tools: vec![],
         fail_closed_on_sandbox_error: true,
     };
     let home = PathBuf::from("/tmp");
@@ -225,6 +226,7 @@ fn linux_ruleset_paths_are_absolute() {
         syscalls: Default::default(),
         limits: Default::default(),
         llm: Default::default(),
+        tools: vec![],
         fail_closed_on_sandbox_error: true,
     };
 

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -521,18 +521,13 @@ fn default_procs() -> u32 {
     32
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum ToolPolicy {
     Allow,
+    #[default]
     Ask,
     Deny,
-}
-
-impl Default for ToolPolicy {
-    fn default() -> Self {
-        ToolPolicy::Ask
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -552,12 +547,12 @@ pub fn resolve_tool_policy(rules: &[ToolRule], tool_name: &str) -> ToolPolicy {
     }
     let mut best: Option<(&ToolRule, usize)> = None;
     for rule in rules {
-        if let Some(prefix) = rule.pattern.strip_suffix('*') {
-            if tool_name.starts_with(prefix) {
-                let len = prefix.len();
-                if best.map_or(true, |(_, best_len)| len > best_len) {
-                    best = Some((rule, len));
-                }
+        if let Some(prefix) = rule.pattern.strip_suffix('*')
+            && tool_name.starts_with(prefix)
+        {
+            let len = prefix.len();
+            if best.is_none_or(|(_, best_len)| len > best_len) {
+                best = Some((rule, len));
             }
         }
     }
@@ -1715,26 +1710,47 @@ mod tool_policy_tests {
 
     fn rules() -> Vec<ToolRule> {
         vec![
-            ToolRule { pattern: "mcp__github__merge_pr".into(), policy: ToolPolicy::Ask },
-            ToolRule { pattern: "mcp__github__*".into(), policy: ToolPolicy::Allow },
-            ToolRule { pattern: "mcp__*".into(), policy: ToolPolicy::Deny },
-            ToolRule { pattern: "bash".into(), policy: ToolPolicy::Allow },
+            ToolRule {
+                pattern: "mcp__github__merge_pr".into(),
+                policy: ToolPolicy::Ask,
+            },
+            ToolRule {
+                pattern: "mcp__github__*".into(),
+                policy: ToolPolicy::Allow,
+            },
+            ToolRule {
+                pattern: "mcp__*".into(),
+                policy: ToolPolicy::Deny,
+            },
+            ToolRule {
+                pattern: "bash".into(),
+                policy: ToolPolicy::Allow,
+            },
         ]
     }
 
     #[test]
     fn exact_beats_glob() {
-        assert_eq!(resolve_tool_policy(&rules(), "mcp__github__merge_pr"), ToolPolicy::Ask);
+        assert_eq!(
+            resolve_tool_policy(&rules(), "mcp__github__merge_pr"),
+            ToolPolicy::Ask
+        );
     }
 
     #[test]
     fn longer_glob_wins() {
-        assert_eq!(resolve_tool_policy(&rules(), "mcp__github__create_issue"), ToolPolicy::Allow);
+        assert_eq!(
+            resolve_tool_policy(&rules(), "mcp__github__create_issue"),
+            ToolPolicy::Allow
+        );
     }
 
     #[test]
     fn shorter_glob_fallback() {
-        assert_eq!(resolve_tool_policy(&rules(), "mcp__slack__send"), ToolPolicy::Deny);
+        assert_eq!(
+            resolve_tool_policy(&rules(), "mcp__slack__send"),
+            ToolPolicy::Deny
+        );
     }
 
     #[test]
@@ -1744,7 +1760,10 @@ mod tool_policy_tests {
 
     #[test]
     fn unknown_tool_defaults_ask() {
-        assert_eq!(resolve_tool_policy(&rules(), "unknown_tool"), ToolPolicy::Ask);
+        assert_eq!(
+            resolve_tool_policy(&rules(), "unknown_tool"),
+            ToolPolicy::Ask
+        );
     }
 
     #[test]

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -395,6 +395,9 @@ pub struct Entitlements {
     /// so the supervisor refuses to construct an LLM client.
     #[serde(default)]
     pub llm: crate::bridge::llm_entitlement::LlmEntitlement,
+    /// Per-tool allow/ask/deny policy. Empty = all tools use default (Ask).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ToolRule>,
     /// When `true` (the default), a sandbox apply failure is fatal: the agent
     /// refuses to start rather than running advisory-only (unconfined).
     /// Set to `false` only for development or trusted-workstation agents that
@@ -516,6 +519,52 @@ fn default_fds() -> u32 {
 }
 fn default_procs() -> u32 {
     32
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolPolicy {
+    Allow,
+    Ask,
+    Deny,
+}
+
+impl Default for ToolPolicy {
+    fn default() -> Self {
+        ToolPolicy::Ask
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolRule {
+    pub pattern: String,
+    pub policy: ToolPolicy,
+}
+
+/// Resolve the effective policy for `tool_name` against an ordered rule list.
+///
+/// Precedence: exact-name match > longest-prefix glob (trailing `*`) > default (`Ask`).
+pub fn resolve_tool_policy(rules: &[ToolRule], tool_name: &str) -> ToolPolicy {
+    for rule in rules {
+        if rule.pattern == tool_name {
+            return rule.policy;
+        }
+    }
+    let mut best: Option<(&ToolRule, usize)> = None;
+    for rule in rules {
+        if let Some(prefix) = rule.pattern.strip_suffix('*') {
+            if tool_name.starts_with(prefix) {
+                let len = prefix.len();
+                if best.map_or(true, |(_, best_len)| len > best_len) {
+                    best = Some((rule, len));
+                }
+            }
+        }
+    }
+    if let Some((rule, _)) = best {
+        return rule.policy;
+    }
+    ToolPolicy::default()
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -1657,5 +1706,72 @@ mod skill_card_tests {
             !yaml.contains("abstract:"),
             "empty abstract must be skipped: {yaml}"
         );
+    }
+}
+
+#[cfg(test)]
+mod tool_policy_tests {
+    use super::*;
+
+    fn rules() -> Vec<ToolRule> {
+        vec![
+            ToolRule { pattern: "mcp__github__merge_pr".into(), policy: ToolPolicy::Ask },
+            ToolRule { pattern: "mcp__github__*".into(), policy: ToolPolicy::Allow },
+            ToolRule { pattern: "mcp__*".into(), policy: ToolPolicy::Deny },
+            ToolRule { pattern: "bash".into(), policy: ToolPolicy::Allow },
+        ]
+    }
+
+    #[test]
+    fn exact_beats_glob() {
+        assert_eq!(resolve_tool_policy(&rules(), "mcp__github__merge_pr"), ToolPolicy::Ask);
+    }
+
+    #[test]
+    fn longer_glob_wins() {
+        assert_eq!(resolve_tool_policy(&rules(), "mcp__github__create_issue"), ToolPolicy::Allow);
+    }
+
+    #[test]
+    fn shorter_glob_fallback() {
+        assert_eq!(resolve_tool_policy(&rules(), "mcp__slack__send"), ToolPolicy::Deny);
+    }
+
+    #[test]
+    fn exact_bash() {
+        assert_eq!(resolve_tool_policy(&rules(), "bash"), ToolPolicy::Allow);
+    }
+
+    #[test]
+    fn unknown_tool_defaults_ask() {
+        assert_eq!(resolve_tool_policy(&rules(), "unknown_tool"), ToolPolicy::Ask);
+    }
+
+    #[test]
+    fn empty_rules_defaults_ask() {
+        assert_eq!(resolve_tool_policy(&[], "bash"), ToolPolicy::Ask);
+    }
+
+    fn minimal_entitlements_yaml() -> &'static str {
+        "network:\n  inbound: {}\n  outbound:\n    mode: off\nfilesystem: {}\nprocesses:\n  spawn:\n    mode: none\n"
+    }
+
+    #[test]
+    fn entitlements_tools_defaults_empty() {
+        let e: Entitlements = serde_yaml_ng::from_str(minimal_entitlements_yaml()).unwrap();
+        assert!(e.tools.is_empty());
+    }
+
+    #[test]
+    fn entitlements_tools_roundtrip() {
+        let base = minimal_entitlements_yaml();
+        let yaml = format!("{base}tools:\n  - pattern: \"mcp__github__*\"\n    policy: allow\n");
+        let e: Entitlements = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(e.tools.len(), 1);
+        assert_eq!(e.tools[0].policy, ToolPolicy::Allow);
+        let y = serde_yaml_ng::to_string(&e).unwrap();
+        let back: Entitlements = serde_yaml_ng::from_str(&y).unwrap();
+        assert_eq!(back.tools.len(), 1);
+        assert_eq!(back.tools[0].policy, ToolPolicy::Allow);
     }
 }

--- a/mur-core/src/agent_admin/perm.rs
+++ b/mur-core/src/agent_admin/perm.rs
@@ -5,7 +5,7 @@
 //! need structured data (e.g. GUI Permissions tab) instead of stdout.
 
 use anyhow::Result;
-use mur_common::agent::Entitlements;
+use mur_common::agent::{Entitlements, ToolPolicy, ToolRule};
 
 use crate::cmd::agent;
 
@@ -45,6 +45,19 @@ pub fn deny_spawn(name: &str, binary: &str) -> Result<()> {
 
 pub fn set_limit(name: &str, key: &str, value: u64) -> Result<()> {
     agent::cmd_perm_set_limit(name, key, value)
+}
+
+pub fn set_tool_policy(name: &str, policy: ToolPolicy, pattern: &str) -> Result<()> {
+    agent::cmd_perm_set_tool(name, policy, pattern)
+}
+
+pub fn clear_tool_rule(name: &str, pattern: &str) -> Result<()> {
+    agent::cmd_perm_clear_tool(name, pattern)
+}
+
+pub fn list_tool_rules(name: &str) -> Result<Vec<ToolRule>> {
+    let (_path, profile) = agent::load_profile_for_edit(name)?;
+    Ok(profile.entitlements.tools)
 }
 
 // ─── queries (typed views) ─────────────────────────────────────────

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -585,6 +585,16 @@ pub enum AgentPermAction {
         key: String,
         value: u64,
     },
+    /// Set tool policy: allow | ask | deny
+    ToolAllow { name: String, pattern: String },
+    /// Set tool policy to ask (HITL prompt before execution)
+    ToolAsk { name: String, pattern: String },
+    /// Deny a tool pattern entirely
+    ToolDeny { name: String, pattern: String },
+    /// Remove a tool rule
+    ToolClear { name: String, pattern: String },
+    /// List all tool rules
+    ToolList { name: String },
 }
 
 #[derive(Subcommand)]

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -252,6 +252,7 @@ fn default_entitlements_custom() -> Entitlements {
             processes: 32,
         },
         llm: Default::default(),
+        tools: vec![],
         fail_closed_on_sandbox_error: true,
     }
 }

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -65,8 +65,9 @@ pub use peers::cmd_peers;
 #[allow(unused_imports)]
 pub use perm::{
     cmd_perm_allow_host, cmd_perm_allow_read, cmd_perm_allow_spawn, cmd_perm_allow_write,
-    cmd_perm_deny_host, cmd_perm_deny_path, cmd_perm_deny_spawn, cmd_perm_list_hosts,
-    cmd_perm_set_limit, cmd_perm_set_mode, cmd_perm_show,
+    cmd_perm_clear_tool, cmd_perm_deny_host, cmd_perm_deny_path, cmd_perm_deny_spawn,
+    cmd_perm_list_hosts, cmd_perm_list_tools, cmd_perm_set_limit, cmd_perm_set_mode,
+    cmd_perm_set_tool, cmd_perm_show,
 };
 #[allow(unused_imports)]
 pub(crate) use prompt::prompt_path_for;

--- a/mur-core/src/cmd/agent/perm.rs
+++ b/mur-core/src/cmd/agent/perm.rs
@@ -4,7 +4,7 @@ use std::fs;
 
 use anyhow::{Context, Result, anyhow, bail};
 use mur_common::LockFile;
-use mur_common::agent::NetworkOutboundMode;
+use mur_common::agent::{NetworkOutboundMode, ToolPolicy, ToolRule};
 
 use super::{load_profile_for_edit, pid_alive, resolve_mur_home, save_profile};
 
@@ -232,5 +232,39 @@ pub fn cmd_perm_set_limit(name: &str, key: &str, value: u64) -> Result<()> {
     }
     save_profile(&path, &mut profile)?;
     warn_if_running(name);
+    Ok(())
+}
+
+pub fn cmd_perm_set_tool(name: &str, policy: ToolPolicy, pattern: &str) -> Result<()> {
+    let (path, mut profile) = load_profile_for_edit(name)?;
+    let rules = &mut profile.entitlements.tools;
+    if let Some(r) = rules.iter_mut().find(|r| r.pattern == pattern) {
+        r.policy = policy;
+    } else {
+        rules.push(ToolRule { pattern: pattern.to_string(), policy });
+    }
+    save_profile(&path, &mut profile)?;
+    warn_if_running(name);
+    Ok(())
+}
+
+pub fn cmd_perm_clear_tool(name: &str, pattern: &str) -> Result<()> {
+    let (path, mut profile) = load_profile_for_edit(name)?;
+    profile.entitlements.tools.retain(|r| r.pattern != pattern);
+    save_profile(&path, &mut profile)?;
+    warn_if_running(name);
+    Ok(())
+}
+
+pub fn cmd_perm_list_tools(name: &str) -> Result<()> {
+    let (_path, profile) = load_profile_for_edit(name)?;
+    let rules = &profile.entitlements.tools;
+    if rules.is_empty() {
+        println!("(no tool rules — all tools use default policy: ask)");
+    } else {
+        for r in rules {
+            println!("{:10}  {}", format!("{:?}", r.policy).to_lowercase(), r.pattern);
+        }
+    }
     Ok(())
 }

--- a/mur-core/src/cmd/agent/perm.rs
+++ b/mur-core/src/cmd/agent/perm.rs
@@ -241,7 +241,10 @@ pub fn cmd_perm_set_tool(name: &str, policy: ToolPolicy, pattern: &str) -> Resul
     if let Some(r) = rules.iter_mut().find(|r| r.pattern == pattern) {
         r.policy = policy;
     } else {
-        rules.push(ToolRule { pattern: pattern.to_string(), policy });
+        rules.push(ToolRule {
+            pattern: pattern.to_string(),
+            policy,
+        });
     }
     save_profile(&path, &mut profile)?;
     warn_if_running(name);
@@ -263,7 +266,11 @@ pub fn cmd_perm_list_tools(name: &str) -> Result<()> {
         println!("(no tool rules — all tools use default policy: ask)");
     } else {
         for r in rules {
-            println!("{:10}  {}", format!("{:?}", r.policy).to_lowercase(), r.pattern);
+            println!(
+                "{:10}  {}",
+                format!("{:?}", r.policy).to_lowercase(),
+                r.pattern
+            );
         }
     }
     Ok(())

--- a/mur-core/src/cmd/agent_companion/connector.rs
+++ b/mur-core/src/cmd/agent_companion/connector.rs
@@ -591,6 +591,7 @@ pub(crate) async fn scaffold_stub_bridge(name: &str, default_route: &str) -> Res
                 processes: 16,
             },
             llm: LlmEntitlement { mode: LlmMode::Off },
+            tools: vec![],
             fail_closed_on_sandbox_error: true,
         },
         notifications: NotificationsConfig::default(),

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1162,9 +1162,11 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             AgentPermAction::SetLimit { name, key, value } => {
                 cmd::agent::cmd_perm_set_limit(&name, &key, value)?
             }
-            AgentPermAction::ToolAllow { name, pattern } => {
-                cmd::agent::cmd_perm_set_tool(&name, mur_common::agent::ToolPolicy::Allow, &pattern)?
-            }
+            AgentPermAction::ToolAllow { name, pattern } => cmd::agent::cmd_perm_set_tool(
+                &name,
+                mur_common::agent::ToolPolicy::Allow,
+                &pattern,
+            )?,
             AgentPermAction::ToolAsk { name, pattern } => {
                 cmd::agent::cmd_perm_set_tool(&name, mur_common::agent::ToolPolicy::Ask, &pattern)?
             }
@@ -1174,9 +1176,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             AgentPermAction::ToolClear { name, pattern } => {
                 cmd::agent::cmd_perm_clear_tool(&name, &pattern)?
             }
-            AgentPermAction::ToolList { name } => {
-                cmd::agent::cmd_perm_list_tools(&name)?
-            }
+            AgentPermAction::ToolList { name } => cmd::agent::cmd_perm_list_tools(&name)?,
         },
         AgentAction::Export { name, out, format } => {
             cmd::agent::cmd_export(&name, &out, &format)?;

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1162,6 +1162,21 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             AgentPermAction::SetLimit { name, key, value } => {
                 cmd::agent::cmd_perm_set_limit(&name, &key, value)?
             }
+            AgentPermAction::ToolAllow { name, pattern } => {
+                cmd::agent::cmd_perm_set_tool(&name, mur_common::agent::ToolPolicy::Allow, &pattern)?
+            }
+            AgentPermAction::ToolAsk { name, pattern } => {
+                cmd::agent::cmd_perm_set_tool(&name, mur_common::agent::ToolPolicy::Ask, &pattern)?
+            }
+            AgentPermAction::ToolDeny { name, pattern } => {
+                cmd::agent::cmd_perm_set_tool(&name, mur_common::agent::ToolPolicy::Deny, &pattern)?
+            }
+            AgentPermAction::ToolClear { name, pattern } => {
+                cmd::agent::cmd_perm_clear_tool(&name, &pattern)?
+            }
+            AgentPermAction::ToolList { name } => {
+                cmd::agent::cmd_perm_list_tools(&name)?
+            }
         },
         AgentAction::Export { name, out, format } => {
             cmd::agent::cmd_export(&name, &out, &format)?;

--- a/mur-hub-gui/ui/src/components/HitlCard.tsx
+++ b/mur-hub-gui/ui/src/components/HitlCard.tsx
@@ -50,10 +50,13 @@ export function HitlCard({ request }: Props) {
     }
   }
 
-  const inputSummary = Object.entries(request.tool_input)
-    .slice(0, 2)
-    .map(([k, v]) => `${k}: ${String(v).slice(0, 40)}`)
-    .join(", ");
+  function toolLabel(name: string): string {
+    const m = name.match(/^mcp__([^_]+(?:_[^_]+)*)__(.+)$/);
+    if (m) return `${m[1].replace(/_/g, "-")} · ${m[2]}`;
+    return name;
+  }
+
+  const hasArgs = Object.keys(request.tool_input).length > 0;
 
   if (responded === "timeout") {
     return (
@@ -88,9 +91,10 @@ export function HitlCard({ request }: Props) {
         <span className="hitl-card__title">Approval needed</span>
         <span className="hitl-card__timer">{countdown}</span>
       </div>
+      <div className="hitl-card__tool">{toolLabel(request.tool_name)}</div>
       <div className="hitl-card__prompt">{request.prompt}</div>
-      {inputSummary && (
-        <div className="hitl-card__input">{inputSummary}</div>
+      {hasArgs && (
+        <pre className="hitl-args">{JSON.stringify(request.tool_input, null, 2)}</pre>
       )}
       {showReasonInput ? (
         <div className="hitl-card__reason-form">


### PR DESCRIPTION
## Summary

- **Per-tool entitlement model** (`ToolPolicy`/`ToolRule`/`resolve_tool_policy` in `mur-common`): exact match > longest-prefix glob > default `Ask`; wired into `Entitlements.tools`
- **`McpPool`** (`mur-agent-runtime/src/mcp/pool.rs`): lazy-cached MCP subprocess pool, `spawn_blocking` stderr drain, graceful `shutdown()`
- **`McpToolExecutor`** + **`build_tools()`** registry: concurrent `tools/list` discovery, Deny-filtered, wire-name `mcp__<server>__<tool>` (`^[a-zA-Z0-9_-]{1,64}`)
- **`TaskRunner` policy gate**: Deny=block with error, Allow=skip HITL, Ask=existing flow; `McpInventory` seeded from real tool names (replaces `default()` stub)
- **Supervisor wiring**: `build_provider_runner` builds pool + tools before runner construction, returns `Arc<McpPool>` for `pool.shutdown().await` on teardown
- **`mur agent perm tool`** CLI: `allow / ask / deny / clear / list` subcommands
- **`HitlCard.tsx`**: `toolLabel()` reformats `mcp__server__tool` → `server · tool`; JSON args in `<pre className="hitl-args">`

## Test plan

- [ ] `cargo test -p mur-common -p mur-agent-runtime -p mur-core` passes
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `mur agent perm tool allow <agent> mcp__*` sets allow rule, persists to `profile.yaml`
- [ ] `mur agent perm tool list <agent>` shows configured rules
- [ ] HITL card for MCP tool call shows `server · tool` label and formatted JSON args

🤖 Generated with [Claude Code](https://claude.com/claude-code)