### PR TITLE
feat(hub-ui): multi-agent conversation rail

### DIFF
--- a/docs/superpowers/plans/2026-06-08-hub-multiagent-conversation-rail.md
+++ b/docs/superpowers/plans/2026-06-08-hub-multiagent-conversation-rail.md
@@ -1,0 +1,683 @@
+# Hub Multi-Agent Conversation Rail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a vertical conversation rail to the MUR Hub so the user can hold several live agent conversations at once — open multiple agents, switch instantly, and never miss background activity (streaming, HITL, completion).
+
+**Architecture:** Frontend-only (`mur-hub-gui/ui`). A pure `conversationReducer` + `ConversationContext` track *open / active / attention* per agent; the actual message buffers stay inside **per-conversation `ChatTab` instances kept mounted** (active one visible, others hidden) so nothing is lost on switch. A `ConversationRail` shows status + attention badges; background HITL also fires the existing notification path. No `mur-core`/runtime changes.
+
+**Tech Stack:** React 18 + TypeScript, Vite, **Vitest (node env — no DOM/testing-library in this project)**, Tauri 2 events (`listen`).
+
+---
+
+## Key decisions (read first)
+
+1. **Keep `ChatTab` instances mounted, don't lift buffers into the store.** `ChatTab` already owns its message buffer and multi-turn `taskId`, and it *wipes them when its `agentName` prop changes* (`ChatTab.tsx:54-61`). So rendering one `ChatTab` and swapping `agentName` would lose history on every switch. Instead we mount **one `ChatTab` per open conversation** and toggle visibility with CSS — each instance already filters `chat-delta` by name and retains its own state. `ChatTab` itself is **unchanged**.
+
+2. **Store holds only `open / active / attention`** — not messages. This refines the spec's "store buffers all conversations": the *outcome* (instant switch, nothing lost) is delivered by mounted instances; the store is small and pure.
+
+3. **Test posture = pure logic.** This project has Vitest configured but **no jsdom/testing-library** (only `i18n/t.test.ts`). So the TDD target is the **pure `conversationReducer`**; components are verified with `tsc -b` + `npm run build` + a manual smoke checklist. We do **not** add a component-test harness (scope creep, against project posture).
+
+4. **Attention = two booleans (`unread`, `hitl`).** A precise pending-HITL count needs a resolution event we don't have; for v1 both clear on `focus`. Count is a v2 refinement.
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `mur-hub-gui/ui/src/conversation/reducer.ts` | Create | Pure `conversationReducer` + `attentionLevel` + types |
+| `mur-hub-gui/ui/src/conversation/reducer.test.ts` | Create | Vitest unit tests (the TDD target) |
+| `mur-hub-gui/ui/src/conversation/ConversationContext.tsx` | Create | Provider: wire Tauri listeners → dispatch; expose actions (mirrors `AgentContext`) |
+| `mur-hub-gui/ui/src/components/ConversationRail.tsx` | Create | Vertical rail: item per open conversation, status dot + attention badge + close |
+| `mur-hub-gui/ui/src/components/ConversationsView.tsx` | Create | Rail (left) + all open `ChatTab`s mounted (active visible) |
+| `mur-hub-gui/ui/src/components/DetailPanel.tsx` | Modify | Remove the chat tab (config-only); default tab → persona |
+| `mur-hub-gui/ui/src/components/DashboardApp.tsx` | Modify | Mount `ConversationsView`; add "Chat" affordance → `open(agent)` |
+| `mur-hub-gui/ui/src/App.tsx` | Modify | Wrap `<ConversationProvider>` inside `<AgentProvider>` |
+| `mur-hub-gui/ui/src/conversation/notify.ts` | Create | Background-HITL → existing notification (reconcile task) |
+| `mur-hub-gui/ui/src/styles*` (existing CSS) | Modify | `.conv-rail`, `.conv-item`, badge classes |
+
+---
+
+### Task 1: Pure `conversationReducer` + types (TDD)
+
+**Files:**
+- Create: `mur-hub-gui/ui/src/conversation/reducer.ts`
+- Create: `mur-hub-gui/ui/src/conversation/reducer.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `mur-hub-gui/ui/src/conversation/reducer.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  conversationReducer,
+  attentionLevel,
+  initialConversationState,
+  type ConversationState,
+} from "./reducer";
+
+const base = (): ConversationState => initialConversationState();
+
+describe("conversationReducer", () => {
+  it("open adds the agent, makes it active, and clears its attention", () => {
+    const s = conversationReducer(base(), { type: "open", agent: "a" });
+    expect(s.open).toEqual(["a"]);
+    expect(s.active).toBe("a");
+    expect(s.attention["a"]).toEqual({ unread: false, hitl: false });
+  });
+
+  it("open is idempotent — re-opening just focuses, never duplicates", () => {
+    let s = conversationReducer(base(), { type: "open", agent: "a" });
+    s = conversationReducer(s, { type: "open", agent: "b" });
+    s = conversationReducer(s, { type: "open", agent: "a" });
+    expect(s.open).toEqual(["a", "b"]);
+    expect(s.active).toBe("a");
+  });
+
+  it("delta for a non-active open agent sets unread", () => {
+    let s = conversationReducer(base(), { type: "open", agent: "a" });
+    s = conversationReducer(s, { type: "open", agent: "b" }); // b active
+    s = conversationReducer(s, { type: "delta", agent: "a" });
+    expect(s.attention["a"].unread).toBe(true);
+  });
+
+  it("delta for the active agent does NOT set unread", () => {
+    let s = conversationReducer(base(), { type: "open", agent: "a" }); // a active
+    s = conversationReducer(s, { type: "delta", agent: "a" });
+    expect(s.attention["a"].unread).toBe(false);
+  });
+
+  it("delta for an agent that is not open is ignored", () => {
+    const s = conversationReducer(base(), { type: "delta", agent: "ghost" });
+    expect(s.attention["ghost"]).toBeUndefined();
+  });
+
+  it("hitl_open for a non-active open agent sets hitl", () => {
+    let s = conversationReducer(base(), { type: "open", agent: "a" });
+    s = conversationReducer(s, { type: "open", agent: "b" });
+    s = conversationReducer(s, { type: "hitl_open", agent: "a" });
+    expect(s.attention["a"].hitl).toBe(true);
+  });
+
+  it("focus clears unread and hitl for that agent", () => {
+    let s = conversationReducer(base(), { type: "open", agent: "a" });
+    s = conversationReducer(s, { type: "open", agent: "b" });
+    s = conversationReducer(s, { type: "delta", agent: "a" });
+    s = conversationReducer(s, { type: "hitl_open", agent: "a" });
+    s = conversationReducer(s, { type: "focus", agent: "a" });
+    expect(s.active).toBe("a");
+    expect(s.attention["a"]).toEqual({ unread: false, hitl: false });
+  });
+
+  it("close removes the agent and reassigns active to another open one", () => {
+    let s = conversationReducer(base(), { type: "open", agent: "a" });
+    s = conversationReducer(s, { type: "open", agent: "b" }); // b active
+    s = conversationReducer(s, { type: "close", agent: "b" });
+    expect(s.open).toEqual(["a"]);
+    expect(s.active).toBe("a");
+    expect(s.attention["b"]).toBeUndefined();
+  });
+
+  it("close the last conversation sets active to null", () => {
+    let s = conversationReducer(base(), { type: "open", agent: "a" });
+    s = conversationReducer(s, { type: "close", agent: "a" });
+    expect(s.open).toEqual([]);
+    expect(s.active).toBeNull();
+  });
+});
+
+describe("attentionLevel", () => {
+  it("hitl outranks unread", () => {
+    expect(attentionLevel({ unread: true, hitl: true })).toBe("hitl");
+    expect(attentionLevel({ unread: true, hitl: false })).toBe("unread");
+    expect(attentionLevel({ unread: false, hitl: false })).toBe("none");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, verify they fail**
+
+Run: `cd mur-hub-gui/ui && npx vitest run src/conversation/reducer.test.ts 2>&1 | tail -20`
+Expected: fail — cannot resolve `./reducer`.
+
+- [ ] **Step 3: Implement `reducer.ts`**
+
+Create `mur-hub-gui/ui/src/conversation/reducer.ts`:
+
+```ts
+export type AttentionLevel = "none" | "unread" | "hitl";
+
+export interface ConversationAttention {
+  unread: boolean;
+  hitl: boolean;
+}
+
+export interface ConversationState {
+  /** Agent names with an open conversation, in open order. */
+  open: string[];
+  /** Currently focused agent, or null when none open. */
+  active: string | null;
+  /** Per-agent attention flags. */
+  attention: Record<string, ConversationAttention>;
+}
+
+export type ConversationAction =
+  | { type: "open"; agent: string }
+  | { type: "close"; agent: string }
+  | { type: "focus"; agent: string }
+  | { type: "delta"; agent: string }
+  | { type: "hitl_open"; agent: string };
+
+export function initialConversationState(): ConversationState {
+  return { open: [], active: null, attention: {} };
+}
+
+const CLEAR: ConversationAttention = { unread: false, hitl: false };
+
+export function attentionLevel(a: ConversationAttention | undefined): AttentionLevel {
+  if (!a) return "none";
+  if (a.hitl) return "hitl";
+  if (a.unread) return "unread";
+  return "none";
+}
+
+export function conversationReducer(
+  state: ConversationState,
+  action: ConversationAction,
+): ConversationState {
+  switch (action.type) {
+    case "open": {
+      const isOpen = state.open.includes(action.agent);
+      return {
+        open: isOpen ? state.open : [...state.open, action.agent],
+        active: action.agent,
+        attention: { ...state.attention, [action.agent]: { ...CLEAR } },
+      };
+    }
+    case "close": {
+      const open = state.open.filter((a) => a !== action.agent);
+      const attention = { ...state.attention };
+      delete attention[action.agent];
+      const active =
+        state.active === action.agent ? (open[open.length - 1] ?? null) : state.active;
+      return { open, active, attention };
+    }
+    case "focus": {
+      if (!state.open.includes(action.agent)) return state;
+      return {
+        ...state,
+        active: action.agent,
+        attention: { ...state.attention, [action.agent]: { ...CLEAR } },
+      };
+    }
+    case "delta": {
+      if (!state.open.includes(action.agent) || state.active === action.agent) return state;
+      const prev = state.attention[action.agent] ?? { ...CLEAR };
+      return {
+        ...state,
+        attention: { ...state.attention, [action.agent]: { ...prev, unread: true } },
+      };
+    }
+    case "hitl_open": {
+      if (!state.open.includes(action.agent) || state.active === action.agent) return state;
+      const prev = state.attention[action.agent] ?? { ...CLEAR };
+      return {
+        ...state,
+        attention: { ...state.attention, [action.agent]: { ...prev, hitl: true } },
+      };
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests, verify they pass**
+
+Run: `cd mur-hub-gui/ui && npx vitest run src/conversation/reducer.test.ts 2>&1 | tail -20`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-hub-gui/ui/src/conversation/reducer.ts mur-hub-gui/ui/src/conversation/reducer.test.ts
+git commit -m "feat(hub-ui): pure conversationReducer + attention model (open/active/attention)"
+```
+
+---
+
+### Task 2: `ConversationContext` provider
+
+**Files:**
+- Create: `mur-hub-gui/ui/src/conversation/ConversationContext.tsx`
+
+Context: mirror `AgentContext.tsx`'s reducer + `listen` pattern. Listeners only *dispatch the raw event*; the reducer reads fresh `state.active`/`open` to decide, so stale listener closures are not a problem.
+
+- [ ] **Step 1: Create the provider**
+
+Create `mur-hub-gui/ui/src/conversation/ConversationContext.tsx`:
+
+```tsx
+import React, { createContext, useContext, useEffect, useReducer } from "react";
+import { listen } from "@tauri-apps/api/event";
+import {
+  conversationReducer,
+  initialConversationState,
+  type ConversationState,
+} from "./reducer";
+
+interface ConversationContextValue extends ConversationState {
+  open: string[];
+  openConversation: (agent: string) => void;
+  closeConversation: (agent: string) => void;
+  focusConversation: (agent: string) => void;
+}
+
+const Ctx = createContext<ConversationContextValue>({
+  open: [],
+  active: null,
+  attention: {},
+  openConversation: () => {},
+  closeConversation: () => {},
+  focusConversation: () => {},
+});
+
+export function ConversationProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(conversationReducer, undefined, initialConversationState);
+
+  useEffect(() => {
+    const unDelta = listen<{ agent: string }>("chat-delta", (e) =>
+      dispatch({ type: "delta", agent: e.payload.agent }),
+    );
+    const unHitl = listen<{ agent: string }>("hitl-approval-needed", (e) =>
+      dispatch({ type: "hitl_open", agent: e.payload.agent }),
+    );
+    return () => {
+      unDelta.then((f) => f());
+      unHitl.then((f) => f());
+    };
+  }, []);
+
+  return (
+    <Ctx.Provider
+      value={{
+        open: state.open,
+        active: state.active,
+        attention: state.attention,
+        openConversation: (agent) => dispatch({ type: "open", agent }),
+        closeConversation: (agent) => dispatch({ type: "close", agent }),
+        focusConversation: (agent) => dispatch({ type: "focus", agent }),
+      }}
+    >
+      {children}
+    </Ctx.Provider>
+  );
+}
+
+export function useConversations() {
+  return useContext(Ctx);
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd mur-hub-gui/ui && npx tsc -b 2>&1 | tail -20`
+Expected: no errors. (The provider isn't mounted yet; this just confirms it compiles.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-hub-gui/ui/src/conversation/ConversationContext.tsx
+git commit -m "feat(hub-ui): ConversationProvider wiring chat-delta/hitl events to the reducer"
+```
+
+---
+
+### Task 3: `ConversationRail` component
+
+**Files:**
+- Create: `mur-hub-gui/ui/src/components/ConversationRail.tsx`
+
+- [ ] **Step 1: Create the component**
+
+`runtimeStatuses` from `useAgents()` provides per-agent status; map it to a dot. Attention from the store.
+
+```tsx
+import { useAgents } from "../context/AgentContext";
+import { useConversations } from "../conversation/ConversationContext";
+import { attentionLevel } from "../conversation/reducer";
+
+function statusOf(name: string, statuses: { name: string; state?: string }[]): string {
+  const s = statuses.find((x) => x.name === name);
+  // RECONCILE: confirm the field carrying running/stopped in AgentRuntimeStatus (types.ts).
+  return s?.state ?? "idle";
+}
+
+export function ConversationRail() {
+  const { runtimeStatuses, agents } = useAgents();
+  const { open, active, attention, focusConversation, closeConversation } = useConversations();
+
+  if (open.length === 0) return null;
+
+  return (
+    <div className="conv-rail">
+      {open.map((name) => {
+        const display = agents.find((a) => a.name === name)?.display_name ?? name;
+        const level = attentionLevel(attention[name]);
+        const status = statusOf(name, runtimeStatuses);
+        return (
+          <button
+            key={name}
+            className={`conv-item${active === name ? " conv-item--active" : ""}`}
+            onClick={() => focusConversation(name)}
+            title={display}
+          >
+            <span className={`conv-status conv-status--${status}`} />
+            <span className="conv-name">{display}</span>
+            {level !== "none" && <span className={`conv-badge conv-badge--${level}`} />}
+            <span
+              className="conv-close"
+              role="button"
+              aria-label="Close conversation"
+              onClick={(e) => {
+                e.stopPropagation();
+                closeConversation(name);
+              }}
+            >
+              ×
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+> RECONCILE: open `mur-hub-gui/ui/src/types.ts` and confirm the exact `AgentRuntimeStatus` field name carrying the running/idle/error state; adjust `statusOf` + the `conv-status--*` class names to match. Confirm `AgentEntry.display_name` exists (it does, per `DetailPanel`/`DashboardApp` usage).
+
+- [ ] **Step 2: Add minimal CSS**
+
+Append to the existing dashboard stylesheet (locate it: `grep -rl "conv-rail\|detail-panel-tabs\|\.chat__log" mur-hub-gui/ui/src` — use the file that defines `.chat__log`). Add:
+
+```css
+.conv-rail { display: flex; flex-direction: column; gap: 6px; width: 168px;
+  padding: 8px; border-right: 1px solid var(--border, #8883); overflow-y: auto; }
+.conv-item { display: flex; align-items: center; gap: 8px; padding: 6px 8px;
+  border-radius: 8px; background: transparent; border: none; cursor: pointer;
+  text-align: left; color: inherit; }
+.conv-item--active { background: var(--accent-soft, #7c5cff22); }
+.conv-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.conv-status { width: 8px; height: 8px; border-radius: 50%; background: #888; flex: none; }
+.conv-status--running { background: #3ad17a; }
+.conv-status--error { background: #e5484d; }
+.conv-badge { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+.conv-badge--unread { background: #5b8cff; }
+.conv-badge--hitl { background: #f5a623; }
+.conv-close { opacity: .5; padding: 0 2px; }
+.conv-close:hover { opacity: 1; }
+```
+
+- [ ] **Step 3: Typecheck + build**
+
+Run: `cd mur-hub-gui/ui && npx tsc -b && npm run build 2>&1 | tail -15`
+Expected: builds clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-hub-gui/ui/src/components/ConversationRail.tsx mur-hub-gui/ui/src/
+git commit -m "feat(hub-ui): ConversationRail (status dot + attention badge + close)"
+```
+
+---
+
+### Task 4: `ConversationsView` (mounted-per-conversation ChatTabs)
+
+**Files:**
+- Create: `mur-hub-gui/ui/src/components/ConversationsView.tsx`
+
+- [ ] **Step 1: Create the view**
+
+All open `ChatTab`s stay mounted; only the active one is visible (CSS), so background buffers persist.
+
+```tsx
+import { ChatTab } from "./ChatTab";
+import { ConversationRail } from "./ConversationRail";
+import { useAgents } from "../context/AgentContext";
+import { useConversations } from "../conversation/ConversationContext";
+
+export function ConversationsView() {
+  const { agents } = useAgents();
+  const { open, active } = useConversations();
+
+  if (open.length === 0) return null;
+
+  return (
+    <div className="conv-surface">
+      <ConversationRail />
+      <div className="conv-panels">
+        {open.map((name) => {
+          const display = agents.find((a) => a.name === name)?.display_name ?? name;
+          return (
+            <div
+              key={name}
+              className="conv-panel"
+              style={{ display: active === name ? "flex" : "none" }}
+            >
+              <ChatTab agentName={name} displayName={display} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: CSS for the surface**
+
+Append to the same stylesheet:
+
+```css
+.conv-surface { display: flex; height: 100%; min-height: 0; }
+.conv-panels { flex: 1; min-width: 0; display: flex; }
+.conv-panel { flex: 1; min-width: 0; flex-direction: column; }
+```
+
+- [ ] **Step 3: Typecheck + build**
+
+Run: `cd mur-hub-gui/ui && npx tsc -b && npm run build 2>&1 | tail -15`
+Expected: builds clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-hub-gui/ui/src/components/ConversationsView.tsx mur-hub-gui/ui/src/
+git commit -m "feat(hub-ui): ConversationsView keeps a ChatTab mounted per open conversation"
+```
+
+---
+
+### Task 5: Wire in — provider, mount, "Chat" affordance, config-only DetailPanel
+
+**Files:**
+- Modify: `mur-hub-gui/ui/src/App.tsx`
+- Modify: `mur-hub-gui/ui/src/components/DashboardApp.tsx`
+- Modify: `mur-hub-gui/ui/src/components/DetailPanel.tsx`
+
+- [ ] **Step 1: Wrap the provider in `App.tsx`**
+
+In `mur-hub-gui/ui/src/App.tsx`, import and nest the provider inside `AgentProvider` (so it can read agents):
+
+```tsx
+import { ConversationProvider } from "./conversation/ConversationContext";
+// ...
+return (
+  <AgentProvider>
+    <ConversationProvider>
+      {route === "popover" ? <PopoverApp /> : <DashboardApp />}
+    </ConversationProvider>
+  </AgentProvider>
+);
+```
+
+- [ ] **Step 2: Mount `ConversationsView` + add a "Chat" affordance in `DashboardApp.tsx`**
+
+Import at top:
+```tsx
+import { ConversationsView } from "./ConversationsView";
+import { useConversations } from "../conversation/ConversationContext";
+```
+
+Mount the surface next to the existing `DetailPanel` block (after line ~642, the `{selectedAgent && (<DetailPanel ... />)}`):
+```tsx
+<ConversationsView />
+```
+
+Add a "Chat" button to the agent card. In `GridCard`/`ListRow`, pull the action:
+```tsx
+const { openConversation } = useConversations();
+```
+and add a button (next to the existing Run/Stop/Share buttons, ~line 174-186):
+```tsx
+<button
+  onClick={(e) => { e.stopPropagation(); openConversation(agent.name); }}
+  title={t("dashboard.chatTooltip")}
+>
+  {t("dashboard.chat")}
+</button>
+```
+
+> RECONCILE: add `dashboard.chat` + `dashboard.chatTooltip` keys to `mur-hub-gui/ui/src/i18n/en.ts` and `zh-TW.ts` (e.g. en: `"Chat"` / `"Open a conversation with this agent"`; zh-TW: `"對話"` / `"與此代理開啟對話"`). Match the existing key structure in those files.
+
+- [ ] **Step 3: Make `DetailPanel` config-only (remove chat tab)**
+
+In `mur-hub-gui/ui/src/components/DetailPanel.tsx`:
+- Remove `"chat"` from the `DetailTab` union type (find `type DetailTab =`).
+- Change the default at line 56: `useState<DetailTab>("persona")` (was `"chat"`).
+- Change the reset at line 60: `setActiveTab("persona")` (was `"chat"`).
+- Remove the chat tab entry from the tab array rendered at line ~174 (the array the `.map` iterates — drop `"chat"`).
+- Remove the render block at lines 188-190:
+  ```tsx
+  {activeTab === "chat" && (
+    <ChatTab agentName={agentName} displayName={detail.display_name} />
+  )}
+  ```
+- Remove the now-unused `import { ChatTab } from "./ChatTab";` (line 17).
+- Update the file's top doc comment (line 2) from "7 tabs" / chat mention to reflect config-only tabs.
+
+> RECONCILE: confirm the exact tab-array variable feeding the `.map` at line ~174 and remove only the chat entry; leave persona/style/behavior/skills/mcp/permissions/inbox/mobile/memory intact.
+
+- [ ] **Step 4: Typecheck + build**
+
+Run: `cd mur-hub-gui/ui && npx tsc -b && npm run build 2>&1 | tail -20`
+Expected: builds clean (no unused-import errors for `ChatTab` in DetailPanel).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-hub-gui/ui/src/App.tsx mur-hub-gui/ui/src/components/DashboardApp.tsx \
+        mur-hub-gui/ui/src/components/DetailPanel.tsx mur-hub-gui/ui/src/i18n/
+git commit -m "feat(hub-ui): mount conversation rail; Chat affordance; DetailPanel config-only"
+```
+
+---
+
+### Task 6: Background-HITL notification (reconcile with existing path)
+
+**Files:**
+- Create: `mur-hub-gui/ui/src/conversation/notify.ts`
+- Modify: `mur-hub-gui/ui/src/conversation/ConversationContext.tsx`
+
+Context: the spec wants a background HITL (on a non-active agent) to also fire the existing Phase-2 notification, so it isn't missed. First find how notifications are emitted today.
+
+- [ ] **Step 1: Locate the existing notification path**
+
+```bash
+cd /Volumes/Firecuda4tb/Projects/mur
+grep -rniE "notification|notify|isPermissionGranted|sendNotification|plugin-notification" mur-hub-gui/ui/src mur-hub-gui/src-tauri/src | head -20
+```
+Record whether notifications are emitted (a) already on the backend when HITL fires (then this task is **badge-only — no new code**, mark done), or (b) only via a frontend helper you must call.
+
+- [ ] **Step 2: If frontend-emitted, add a thin helper**
+
+Only if Step 1 shows the UI must emit. Create `mur-hub-gui/ui/src/conversation/notify.ts`:
+
+```ts
+// Thin wrapper over the project's existing notification mechanism.
+// RECONCILE: replace the body with the actual call discovered in Step 1
+// (e.g. invoke("notify", {...}) or @tauri-apps/plugin-notification).
+export async function notifyHitl(agentDisplay: string): Promise<void> {
+  // placeholder intentionally omitted — wire to the real path from Step 1
+}
+```
+
+In `ConversationContext.tsx`, fire it from the hitl listener only when the agent is **not** active. Because the listener closure can't see fresh `active`, gate inside an effect that watches attention transitions instead:
+
+```tsx
+// after the reducer/useReducer:
+useEffect(() => {
+  // when any non-active agent gains hitl attention, notify once.
+  // (Implementation detail: track previously-notified set in a ref to avoid repeats.)
+}, [state.attention]);
+```
+
+> RECONCILE: if Step 1 found the backend already notifies on HITL, **delete `notify.ts` and skip the effect** — the rail badge is the only addition. Keep this task's scope to "don't double-notify."
+
+- [ ] **Step 3: Build + commit**
+
+Run: `cd mur-hub-gui/ui && npx tsc -b && npm run build 2>&1 | tail -15`
+```bash
+git add mur-hub-gui/ui/src/conversation/
+git commit -m "feat(hub-ui): background-HITL notification reconciled with existing path"
+```
+
+---
+
+### Task 7: Full verification + manual smoke
+
+**Files:** none.
+
+- [ ] **Step 1: Unit tests + typecheck + build + lint**
+
+```bash
+cd mur-hub-gui/ui
+npx vitest run 2>&1 | tail -15      # reducer tests green
+npx tsc -b 2>&1 | tail -10          # no type errors
+npm run build 2>&1 | tail -10       # builds
+npm run lint 2>&1 | tail -15        # no new lint errors
+```
+Expected: all green.
+
+- [ ] **Step 2: Manual smoke (run the Hub)**
+
+Build/run the Hub (per `CLAUDE.md`: the Hub is workspace-excluded; build via its own manifest, and copy `target/release/mur-agent-runtime` next to the Hub binary). Then verify:
+- Click **Chat** on two different agents → both appear in the left rail; the second becomes active.
+- Send a message to agent A, switch to B, switch back to A → **A's history is intact** (mounted-instance check).
+- While viewing A, have B stream/raise a HITL → B's rail item shows an **attention badge**; clicking B clears it.
+- Open the config **DetailPanel** for an agent → it has **no chat tab**; config tabs work.
+- Close a conversation → it leaves the rail; active reassigns.
+
+- [ ] **Step 3: Final commit (if lint/fmt fixes were needed)**
+
+```bash
+git add -A
+git commit -m "style: lint fixes for conversation rail"
+```
+
+---
+
+## Self-Review (coverage map)
+
+| Spec item | Task |
+|---|---|
+| Vertical rail of open conversations | 3 |
+| Buffered multi-conversation (nothing lost on switch) — via mounted ChatTabs | 1 (state), 4 (mount) |
+| Attention badges (unread / HITL) | 1 (model), 3 (render) |
+| Background HITL → existing notification | 6 |
+| Separation: chat out of DetailPanel (config-only); under 800 lines | 5 |
+| Open/focus from grid; provider wiring | 2, 5 |
+| Status dot from runtime status | 3 |
+| Error states (agent stop / removed) | manual smoke 7; status dot 3 (RECONCILE field) |
+| No mur-core/runtime changes | (entire plan is frontend) |
+
+**Known v1 limitations (from spec):** attention is boolean not a precise count (v2); split/concurrent view deferred (v2); no inter-agent routing (Commander). **RECONCILE points:** `AgentRuntimeStatus` status field name (Task 3); exact DetailPanel tab-array variable (Task 5); existing notification path (Task 6); i18n keys (Task 5).

--- a/docs/superpowers/specs/2026-06-08-hub-interrupt-stop-control-design.md
+++ b/docs/superpowers/specs/2026-06-08-hub-interrupt-stop-control-design.md
@@ -1,0 +1,144 @@
+# Hub Interrupt / Stop Control Design (v1)
+
+## Goal
+
+Give the MUR Hub a single **Stop** control (button + Esc) that makes a busy agent stop: it **aborts
+active TTS playback** and **cancels in-flight generation**. This is the manual, buildable core of
+"barge-in" — table-stakes for chat, and the reusable substrate a future voice-activated barge-in
+sits on.
+
+## Why this, not "voice barge-in"
+
+Grounding exploration found true voice barge-in is blocked on prerequisites that don't exist on
+desktop:
+- **The Hub never speaks chat replies** — only the pet/mascot speaks (`pet_speak` →
+  `VoicePlayer`), driven by the companion, not chat (`mur-hub-gui/src-tauri/src/pet/mod.rs:321-337`;
+  `chat.rs` has no speech).
+- **No desktop STT/VAD** — `is_mic_busy()`/`is_focus_active()` exist (`mur-gui-core/src/voice/dnd.rs`)
+  but there is zero speech recognition; STT is iOS-only. The desktop **cannot detect the user
+  speaking**, so interruption can only be *manual*.
+- **In-flight generation can't be cancelled** from the Hub — `dial_message_streaming`
+  (`mur-core/src/a2a_dial.rs:174-245`) is a blocking socket read with no cancel path.
+
+So v1 builds the manual Stop. Voice-*activated* barge-in, chat TTS, and STT/VAD are deferred.
+
+## Scope
+
+- **In:** one Stop affordance (button + Esc); `voice_abort` Tauri command (exposes existing
+  `VoicePlayer::abort()`); additive `task/started` notification carrying the task id; an `on_task_id`
+  callback in `dial_message_streaming`; `agent_chat_cancel` Tauri command (dials existing
+  `tasks/cancel`); cancel-pending race handling.
+- **Out (deferred / other specs):** desktop STT/VAD; voice-*activated* barge-in; Hub chat TTS
+  (speaking replies); turn-taking / voice state machine.
+
+## Current State (verified)
+
+- **`VoicePlayer::abort()` already exists** (`mur-gui-core/src/voice/synth.rs:46-49`): non-blocking
+  `Notify`; the speak loop checks it every 200ms and stops playback + lipsync, emitting `voice.ended`.
+  **Not exposed as a Tauri command** — only `pet_speak` is wired (`pet/mod.rs:335`).
+- **`tasks/cancel` RPC exists** (`mur-agent-runtime/src/protocol/methods/tasks.rs:32-53`):
+  `TasksCancelHandler` → `TaskRunner.cancel(id)`; needs the task id.
+- **`dial_message_streaming`** reads `message/delta` + `tool/approval_needed` + the final `result`
+  (id-matched); **the task id is only in the final result** — not surfaced mid-stream
+  (`a2a_dial.rs:203-245`).
+- **`message_send.rs`** emits `message/delta` during generation
+  (`mur-agent-runtime/src/protocol/methods/message_send.rs:84`) but **no early id notification**.
+- **`ChatTab.tsx`** threads `taskIdRef` from the *previous* turn's result; during a turn it has no id.
+
+## Cancel-Mechanism Decision
+
+| Option | Verdict |
+|---|---|
+| **A — additive `task/started` notification + existing `tasks/cancel`** | **Chosen.** Runtime emits the task id at stream start; Hub stores it; cancel reuses the existing handler. Additive emit (low collision risk), correct, agent stops cleanly and sends its final result so the stream ends gracefully. |
+| B — close the streaming socket | Rejected — agent keeps generating server-side (burns tokens); fake cancel. |
+| C — new `tasks/cancelCurrent` (no id) | Rejected — needs the runtime to track "current task" + a brand-new method; more invasive and less precise than A. |
+
+## Architecture
+
+```
+Send:   ChatTab → agent_chat_send → dial_message_streaming(..., on_task_id, on_delta, on_hitl)
+        runtime: create task → emit task/started{id}  ──► on_task_id ──► chat.rs registry (agent→id)
+                 → message/delta… (existing)                                  └─► emit to UI (busy)
+Stop:   user clicks Stop / presses Esc (only while busy)
+        ├─ voice_abort(agent)       → VoicePlayer::abort()      → "voice.interrupted"
+        └─ agent_chat_cancel(agent) → dial tasks/cancel{id} on a NEW connection
+                                       → TaskRunner.cancel(id) → generation stops
+                                       → agent sends final result on the streaming socket
+                                       → dial_message_streaming returns
+        ChatTab finalizes: keep partial streamed text, mark "stopped"
+```
+
+The streaming socket is **not** force-closed; cancelling makes the agent finish early and send its
+final result, which the existing read loop consumes and returns. Cancel is dialed on a **separate**
+connection so it doesn't fight the in-progress read.
+
+## Components
+
+| Unit | New/Change | Responsibility | Depends on |
+|---|---|---|---|
+| `voice_abort` command (`mur-hub-gui/src-tauri/src/voice.rs` or near `pet/mod.rs`) | New | Resolve the agent's `VoicePlayer`/bus and call `abort()`; emit `voice.interrupted`. | existing `VoicePlayer::abort()` |
+| `task/started` emit (`message_send.rs`) | Change (additive) | After the task is created and before the first delta, send one `task/started` notification `{ id }`. | runner task id |
+| `on_task_id` (`dial_message_streaming`, `a2a_dial.rs`) | Change | New `on_task_id: impl FnMut(&str)` param; fire on a `task/started` notification. | — |
+| in-flight registry (`chat.rs`) | Change | `Mutex<HashMap<agent, task_id>>`; set on `on_task_id`, clear on completion. | — |
+| `agent_chat_cancel` command (`chat.rs`) | New | Look up the agent's in-flight id; dial `tasks/cancel{ id }` (`DialMode::RequireRunning`). | `tasks/cancel`, registry |
+| `ChatTab.tsx` | Change | Stop button while `busy`; Esc handler; calls `agent_chat_cancel` + `voice_abort`; `cancelPending` race; preserve partial reply + "stopped" line. | the two commands |
+
+`voice_abort` is independent of the cancel pieces and can ship on its own.
+
+## Data Flow Detail — cancel-pending race
+
+`agent_chat_send` may not yet have received `task/started` when the user hits Stop. Handle in the UI:
+
+```
+Stop pressed while busy:
+  always: invoke("voice_abort", { name })
+  if currentTaskId known: invoke("agent_chat_cancel", { name })
+  else: set cancelPending = true
+On task/started event (or when agent_chat_send resolves with an id):
+  if cancelPending: invoke("agent_chat_cancel", { name }); cancelPending = false
+```
+
+The Hub also needs the id in the UI to drive this. Two options, pick one in the plan: (a) surface
+`task/started` as a Tauri event the UI listens to, or (b) keep the id only in `chat.rs` and have
+`agent_chat_cancel` itself consult the registry (UI just calls cancel; backend no-ops if no id yet,
+and the UI sets `cancelPending` to retry on completion). **Prefer (b)** — less UI state, the registry
+is the single source of truth; `cancelPending` only guards the "Stop pressed, nothing to cancel yet"
+window.
+
+## Error Handling
+
+| Condition | Behavior |
+|---|---|
+| Stop before `task/started` arrives | abort TTS now; `agent_chat_cancel` no-ops (no id in registry); UI sets `cancelPending`, retries on send-resolution |
+| Cancel after task already finished | `tasks/cancel` → `TaskNotFound` → swallowed (reply already delivered) |
+| `voice_abort` with nothing speaking | `abort()` is a no-op `Notify` → harmless |
+| Cancel dial fails (agent died) | streaming read hits EOF → `dial` errors → ChatTab shows partial + error line |
+| Multiple rapid Stops | idempotent: abort is a no-op when idle; cancel of an already-cancelled id → `TaskNotFound` swallowed |
+
+## Testing
+
+- **Runtime** (`message_send`): emits `task/started` with the task id *before* any `message/delta`
+  (handler/integration test).
+- **`dial_message_streaming`**: `on_task_id` fires once when a `task/started` notification is read,
+  before deltas; final result still returns normally (fake-socket test mirroring existing dial tests).
+- **`chat.rs`**: registry set on `on_task_id`, cleared on completion; `agent_chat_cancel` dials
+  `tasks/cancel` with the stored id; no-ops cleanly when the registry has no id.
+- **`voice_abort`**: invokes `VoicePlayer::abort()` and emits `voice.interrupted`.
+- **`ChatTab`** (pure-logic where possible — this project has no DOM test harness): Stop visible only
+  while `busy`; triggers both commands; `cancelPending` set when no id yet and fired on resolution;
+  partial streamed text retained with a "stopped" marker.
+
+## File Boundaries / Coordination
+
+- `a2a_dial.rs` is 401 lines; adding one callback parameter + one notification branch is in-scope and
+  small. No split needed.
+- **Coordination:** `message_send.rs` is in `mur-agent-runtime` (touched by in-flight Phase 3/4) and
+  `ChatTab.tsx` is also touched by the multi-agent rail plan
+  (`2026-06-08-hub-multiagent-conversation-rail.md`). All changes here are additive (a new
+  notification, a new Stop button), but sequence them after those land or merge carefully.
+
+## Future Seams (no v1 work)
+
+- **Voice-activated barge-in**: when desktop STT/VAD exists, a detected user-speech event simply calls
+  the same `voice_abort` + `agent_chat_cancel` — no new interruption plumbing.
+- **Chat TTS**: when the Hub speaks replies, `voice_abort` already silences it; Stop needs no change.

--- a/docs/superpowers/specs/2026-06-08-hub-interrupt-stop-control-design.md
+++ b/docs/superpowers/specs/2026-06-08-hub-interrupt-stop-control-design.md
@@ -1,5 +1,12 @@
 # Hub Interrupt / Stop Control Design (v1)
 
+> **STATUS: DEFERRED (blocked on Phase 3/4).** Verification during planning found the core capability
+> this spec assumed — cancelling an in-flight `message/send` generation — **does not exist in the
+> production task path** and must be added to `mur-agent-runtime/src/task_runner.rs::run_sync_inner`,
+> the file Phase 3/4 is actively rewriting. Revisit once `task_runner.rs` settles so cancellation is
+> built on its final shape. See **Verified Current State** + **Required Runtime Work** below. No
+> implementation plan has been written.
+
 ## Goal
 
 Give the MUR Hub chat a **Stop** control (button + Esc) that **cancels an agent's in-flight
@@ -35,17 +42,36 @@ deferred (see **Deferred** below).
 
 ## Verified Current State
 
-- **Cancel genuinely interrupts generation.** `run_sync_streaming` generates the id, registers
-  `cancel_signals[id]`, and `tokio::select!`s the generation future against a cancel oneshot
-  (`mur-agent-runtime/src/task_runner.rs:295,355-381`). `cancel(id)` fires it (`:394-405`). On cancel
-  the generation future is dropped (Rust async cancellation → the LLM call aborts) and
-  `message_send` returns `TaskOutcome::Cancelled(task)` (`message_send.rs:99-105`), which travels back
-  over the streaming socket as the final result, ending the stream cleanly. **The mechanism is real
-  and prompt.**
-- **The id is generated *inside* the runner** (`task_runner.rs:295`) and only returned at the end —
-  `message_send` never has it mid-flight. Hence the **client-supplied id** mechanism below.
+- **⚠️ Cancellation is NOT supported on the production path.** The streaming path used by
+  `message/send` is `run_sync_streaming` → `run_sync_inner` (`task_runner.rs:276,284-347`). It
+  generates the id (`:295`), sets state Working, then simply `.await`s `run_agentic_loop`/`run_llm` to
+  completion — it **never inserts into `cancel_signals` and never `select!`s on a cancel signal.** The
+  `cancel_signals` registration + `tokio::select!` exist only in **`start_async`** (`:349-392`), a stub
+  path that races a 60-second echo sleep (`:364`) — *not* used by `message/send`. Therefore
+  `cancel(id)` for a real streaming task hits the empty map and returns
+  `Err("task … not cancellable")` (`:394-406`). **Adding real cancellation is required (see below).**
+- `message_send` *does* already return `TaskOutcome::Cancelled` if it ever receives one
+  (`message_send.rs:99-105`), so once `run_sync_inner` can produce a Cancelled outcome, the stream
+  return path works.
+- **The id is generated *inside* the runner** (`:295`) and only returned at the end — `message_send`
+  never has it mid-flight. Hence the **client-supplied id** mechanism below (still valid).
 - **`dial_message_streaming` has exactly one caller** (`mur-hub-gui/src-tauri/src/chat.rs:54`); with
   the client-supplied id it needs **no signature change**.
+
+## Required Runtime Work (the blocker)
+
+Cancellation must be added to the production path before any of the Hub-side work is meaningful:
+
+1. In `run_sync_inner`, after generating `id`, register a cancel oneshot:
+   `cancel_signals.insert(id.clone(), tx_cancel)` (like `start_async` does).
+2. **Race generation against the signal:** wrap the `match &self.backend { … }` await in
+   `tokio::select! { r = <generation> => r, _ = &mut rx_cancel => <cancelled> }`. On cancel, the
+   generation future is dropped (Rust async cancellation aborts the in-flight LLM call) and the path
+   returns `TaskOutcome::Cancelled(Task { id, messages: vec![spec.input], … })`.
+3. Remove the `cancel_signals` entry on completion (success, failure, or cancel) to avoid leaks.
+
+This lands in the same `run_sync_inner`/`run_agentic_loop` region Phase 3/4 is rewriting → **do it on
+the post-Phase-3/4 shape, not now.**
 
 ## Cancel-Mechanism Decision: client-supplied task id
 
@@ -80,6 +106,7 @@ connection so it doesn't fight the in-progress read.
 
 | Unit | New/Change | Responsibility | Depends on |
 |---|---|---|---|
+| **`run_sync_inner` cancellation (`task_runner.rs:284-347`)** | **Change (BLOCKER)** | Register `cancel_signals[id]`; `select!` generation vs cancel; return `Cancelled`; cleanup. See **Required Runtime Work**. | Phase 3/4 settling |
 | `TaskSpec.task_id: Option<String>` (`task_runner.rs`) | Change (additive) | Optional caller-supplied id. | — |
 | `run_sync_streaming` id line (`task_runner.rs:295`) | Change | `let id = spec.task_id.clone().unwrap_or_else(\|\| format!("task-{}", Uuid::now_v7()));` | TaskSpec.task_id |
 | `message_send` params (`message_send.rs:60-71`) | Change (additive) | Read `p["task_id"]` into `TaskSpec.task_id` (ignored if absent → back-compatible). | — |

--- a/docs/superpowers/specs/2026-06-08-hub-interrupt-stop-control-design.md
+++ b/docs/superpowers/specs/2026-06-08-hub-interrupt-stop-control-design.md
@@ -2,143 +2,146 @@
 
 ## Goal
 
-Give the MUR Hub a single **Stop** control (button + Esc) that makes a busy agent stop: it **aborts
-active TTS playback** and **cancels in-flight generation**. This is the manual, buildable core of
-"barge-in" — table-stakes for chat, and the reusable substrate a future voice-activated barge-in
+Give the MUR Hub chat a **Stop** control (button + Esc) that **cancels an agent's in-flight
+generation** — letting the user halt a long or wrong reply instead of waiting it out. This is the
+buildable, verified core of "barge-in" and the reusable substrate a future voice-activated barge-in
 sits on.
 
-## Why this, not "voice barge-in"
+## Why this (and why NOT voice in v1)
 
-Grounding exploration found true voice barge-in is blocked on prerequisites that don't exist on
-desktop:
-- **The Hub never speaks chat replies** — only the pet/mascot speaks (`pet_speak` →
-  `VoicePlayer`), driven by the companion, not chat (`mur-hub-gui/src-tauri/src/pet/mod.rs:321-337`;
-  `chat.rs` has no speech).
-- **No desktop STT/VAD** — `is_mic_busy()`/`is_focus_active()` exist (`mur-gui-core/src/voice/dnd.rs`)
-  but there is zero speech recognition; STT is iOS-only. The desktop **cannot detect the user
-  speaking**, so interruption can only be *manual*.
-- **In-flight generation can't be cancelled** from the Hub — `dial_message_streaming`
-  (`mur-core/src/a2a_dial.rs:174-245`) is a blocking socket read with no cancel path.
+Grounding exploration + an ultra-review found true voice barge-in is blocked on prerequisites, and
+that bundling voice into v1 is both broken and incoherent:
 
-So v1 builds the manual Stop. Voice-*activated* barge-in, chat TTS, and STT/VAD are deferred.
+- **The Hub never speaks chat replies** — only the pet/mascot speaks (`pet_speak` → `VoicePlayer`,
+  `mur-hub-gui/src-tauri/src/pet/mod.rs:325-337`), driven by the companion, not chat. So a chat "Stop"
+  has no chat-voice to abort; silencing the unrelated mascot from a chat button is incoherent.
+- **`voice_abort` is not reachable today.** `pet_speak` creates a *local* `VoicePlayer`
+  (`pet/mod.rs:333`); nothing stores the instance, so no command can call its `abort()`. Exposing it
+  needs new state plumbing — not "expose the existing method."
+- **No desktop STT/VAD** — interruption can only be *manual* anyway.
+
+So v1 cancels generation only. Voice abort, voice-activated barge-in, chat TTS, and STT/VAD are
+deferred (see **Deferred** below).
 
 ## Scope
 
-- **In:** one Stop affordance (button + Esc); `voice_abort` Tauri command (exposes existing
-  `VoicePlayer::abort()`); additive `task/started` notification carrying the task id; an `on_task_id`
-  callback in `dial_message_streaming`; `agent_chat_cancel` Tauri command (dials existing
-  `tasks/cancel`); cancel-pending race handling.
-- **Out (deferred / other specs):** desktop STT/VAD; voice-*activated* barge-in; Hub chat TTS
-  (speaking replies); turn-taking / voice state machine.
+- **In:** a chat **Stop** affordance (button + Esc) that cancels in-flight generation via a
+  **client-supplied task id** + the existing `tasks/cancel` RPC; preserving the partial streamed reply.
+- **Out (deferred / other specs):**
+  - **Voice abort** — needs `VoicePlayer` abort-handle plumbing (store the active player's
+    `Arc<Notify>` in Tauri state, or make the speak loop bus-abortable) and belongs on the
+    **pet/companion** surface where speech actually happens. Ship separately or once chat-TTS lands.
+  - Desktop STT/VAD; voice-*activated* barge-in; Hub chat TTS; turn-taking state machine.
 
-## Current State (verified)
+## Verified Current State
 
-- **`VoicePlayer::abort()` already exists** (`mur-gui-core/src/voice/synth.rs:46-49`): non-blocking
-  `Notify`; the speak loop checks it every 200ms and stops playback + lipsync, emitting `voice.ended`.
-  **Not exposed as a Tauri command** — only `pet_speak` is wired (`pet/mod.rs:335`).
-- **`tasks/cancel` RPC exists** (`mur-agent-runtime/src/protocol/methods/tasks.rs:32-53`):
-  `TasksCancelHandler` → `TaskRunner.cancel(id)`; needs the task id.
-- **`dial_message_streaming`** reads `message/delta` + `tool/approval_needed` + the final `result`
-  (id-matched); **the task id is only in the final result** — not surfaced mid-stream
-  (`a2a_dial.rs:203-245`).
-- **`message_send.rs`** emits `message/delta` during generation
-  (`mur-agent-runtime/src/protocol/methods/message_send.rs:84`) but **no early id notification**.
-- **`ChatTab.tsx`** threads `taskIdRef` from the *previous* turn's result; during a turn it has no id.
+- **Cancel genuinely interrupts generation.** `run_sync_streaming` generates the id, registers
+  `cancel_signals[id]`, and `tokio::select!`s the generation future against a cancel oneshot
+  (`mur-agent-runtime/src/task_runner.rs:295,355-381`). `cancel(id)` fires it (`:394-405`). On cancel
+  the generation future is dropped (Rust async cancellation → the LLM call aborts) and
+  `message_send` returns `TaskOutcome::Cancelled(task)` (`message_send.rs:99-105`), which travels back
+  over the streaming socket as the final result, ending the stream cleanly. **The mechanism is real
+  and prompt.**
+- **The id is generated *inside* the runner** (`task_runner.rs:295`) and only returned at the end —
+  `message_send` never has it mid-flight. Hence the **client-supplied id** mechanism below.
+- **`dial_message_streaming` has exactly one caller** (`mur-hub-gui/src-tauri/src/chat.rs:54`); with
+  the client-supplied id it needs **no signature change**.
 
-## Cancel-Mechanism Decision
+## Cancel-Mechanism Decision: client-supplied task id
+
+The Hub **generates the task id** and passes it in `message/send` params; the runner honors it; the
+Hub cancels with the id it already holds.
 
 | Option | Verdict |
 |---|---|
-| **A — additive `task/started` notification + existing `tasks/cancel`** | **Chosen.** Runtime emits the task id at stream start; Hub stores it; cancel reuses the existing handler. Additive emit (low collision risk), correct, agent stops cleanly and sends its final result so the stream ends gracefully. |
-| B — close the streaming socket | Rejected — agent keeps generating server-side (burns tokens); fake cancel. |
-| C — new `tasks/cancelCurrent` (no id) | Rejected — needs the runtime to track "current task" + a brand-new method; more invasive and less precise than A. |
+| **Client-supplied id** | **Chosen.** No new notification; **no `dial_message_streaming` change**; **no race** (Hub knows the id before the stream starts). One additive runtime touch. |
+| `task/started` notification + `on_task_id` callback | Rejected — needs runner→message_send id surfacing, a new dial callback, and a cancel-pending race window. Strictly more moving parts. |
+| Close the streaming socket | Rejected — agent keeps generating server-side; fake cancel. |
 
 ## Architecture
 
 ```
-Send:   ChatTab → agent_chat_send → dial_message_streaming(..., on_task_id, on_delta, on_hitl)
-        runtime: create task → emit task/started{id}  ──► on_task_id ──► chat.rs registry (agent→id)
-                 → message/delta… (existing)                                  └─► emit to UI (busy)
-Stop:   user clicks Stop / presses Esc (only while busy)
-        ├─ voice_abort(agent)       → VoicePlayer::abort()      → "voice.interrupted"
-        └─ agent_chat_cancel(agent) → dial tasks/cancel{id} on a NEW connection
-                                       → TaskRunner.cancel(id) → generation stops
-                                       → agent sends final result on the streaming socket
-                                       → dial_message_streaming returns
-        ChatTab finalizes: keep partial streamed text, mark "stopped"
+Send:   ChatTab generates taskId (uuid) → agent_chat_send(name, text, taskId)
+        chat.rs: registry[name] = taskId ; dial_message_streaming(params{ ..., task_id: taskId })
+        runtime: message_send reads p["task_id"] → TaskSpec.task_id
+                 run_sync_streaming uses it (else generates) ; message/delta… (existing)
+Stop:   user clicks Stop / Esc (only while busy)
+        → agent_chat_cancel(name) → registry[name] → dial tasks/cancel{ id } on a NEW connection
+              → TaskRunner.cancel(id) → select! fires → TaskOutcome::Cancelled
+              → message_send returns final result on the streaming socket → dial returns
+        → ChatTab commits its OWN streamed buffer as the agent message + "stopped" marker
 ```
 
-The streaming socket is **not** force-closed; cancelling makes the agent finish early and send its
-final result, which the existing read loop consumes and returns. Cancel is dialed on a **separate**
+The streaming socket is never force-closed; cancel makes the agent finish early and send its final
+result, which the existing read loop consumes and returns. Cancel is dialed on a **separate**
 connection so it doesn't fight the in-progress read.
 
 ## Components
 
 | Unit | New/Change | Responsibility | Depends on |
 |---|---|---|---|
-| `voice_abort` command (`mur-hub-gui/src-tauri/src/voice.rs` or near `pet/mod.rs`) | New | Resolve the agent's `VoicePlayer`/bus and call `abort()`; emit `voice.interrupted`. | existing `VoicePlayer::abort()` |
-| `task/started` emit (`message_send.rs`) | Change (additive) | After the task is created and before the first delta, send one `task/started` notification `{ id }`. | runner task id |
-| `on_task_id` (`dial_message_streaming`, `a2a_dial.rs`) | Change | New `on_task_id: impl FnMut(&str)` param; fire on a `task/started` notification. | — |
-| in-flight registry (`chat.rs`) | Change | `Mutex<HashMap<agent, task_id>>`; set on `on_task_id`, clear on completion. | — |
-| `agent_chat_cancel` command (`chat.rs`) | New | Look up the agent's in-flight id; dial `tasks/cancel{ id }` (`DialMode::RequireRunning`). | `tasks/cancel`, registry |
-| `ChatTab.tsx` | Change | Stop button while `busy`; Esc handler; calls `agent_chat_cancel` + `voice_abort`; `cancelPending` race; preserve partial reply + "stopped" line. | the two commands |
+| `TaskSpec.task_id: Option<String>` (`task_runner.rs`) | Change (additive) | Optional caller-supplied id. | — |
+| `run_sync_streaming` id line (`task_runner.rs:295`) | Change | `let id = spec.task_id.clone().unwrap_or_else(\|\| format!("task-{}", Uuid::now_v7()));` | TaskSpec.task_id |
+| `message_send` params (`message_send.rs:60-71`) | Change (additive) | Read `p["task_id"]` into `TaskSpec.task_id` (ignored if absent → back-compatible). | — |
+| in-flight registry (`chat.rs`) | New | `Mutex<HashMap<agent, task_id>>`; set in `agent_chat_send`, cleared on completion. | — |
+| `agent_chat_send` (`chat.rs`) | Change | Accept `taskId` param; store in registry; pass `task_id` in `message/send` params. | registry |
+| `agent_chat_cancel` Tauri command (`chat.rs`) | New | Look up `registry[name]`; dial `tasks/cancel{ id }` (`DialMode::RequireRunning`); no-op if absent. | `tasks/cancel`, registry |
+| `ChatTab.tsx` | Change | Generate `taskId` per send; pass to `agent_chat_send`; **Stop** button while `busy`; Esc handler; on Stop call `agent_chat_cancel` and **commit the local streamed buffer** as the reply with a "stopped" marker. | the commands |
 
-`voice_abort` is independent of the cancel pieces and can ship on its own.
+## Partial-Reply Preservation (M1)
 
-## Data Flow Detail — cancel-pending race
-
-`agent_chat_send` may not yet have received `task/started` when the user hits Stop. Handle in the UI:
-
-```
-Stop pressed while busy:
-  always: invoke("voice_abort", { name })
-  if currentTaskId known: invoke("agent_chat_cancel", { name })
-  else: set cancelPending = true
-On task/started event (or when agent_chat_send resolves with an id):
-  if cancelPending: invoke("agent_chat_cancel", { name }); cancelPending = false
-```
-
-The Hub also needs the id in the UI to drive this. Two options, pick one in the plan: (a) surface
-`task/started` as a Tauri event the UI listens to, or (b) keep the id only in `chat.rs` and have
-`agent_chat_cancel` itself consult the registry (UI just calls cancel; backend no-ops if no id yet,
-and the UI sets `cancelPending` to retry on completion). **Prefer (b)** — less UI state, the registry
-is the single source of truth; `cancelPending` only guards the "Stop pressed, nothing to cancel yet"
-window.
+On cancel, the partial text already lives in ChatTab's `streamingRef.current` (streamed via
+`message/delta` before cancel). So ChatTab must **commit its own streamed buffer** as the agent
+message on Stop — it must **not** depend on the Cancelled task's body (which may be empty). Concretely,
+on Stop: snapshot `streamingRef.current`, push it as an `agent` message tagged "stopped", then clear
+streaming state. The subsequent `dial` return (final Cancelled result) is then ignored for content.
 
 ## Error Handling
 
 | Condition | Behavior |
 |---|---|
-| Stop before `task/started` arrives | abort TTS now; `agent_chat_cancel` no-ops (no id in registry); UI sets `cancelPending`, retries on send-resolution |
+| Stop pressed but no id in registry (extremely narrow — id is set synchronously in `agent_chat_send` before dialing) | `agent_chat_cancel` no-ops; ChatTab still commits the partial + stops the spinner |
 | Cancel after task already finished | `tasks/cancel` → `TaskNotFound` → swallowed (reply already delivered) |
-| `voice_abort` with nothing speaking | `abort()` is a no-op `Notify` → harmless |
 | Cancel dial fails (agent died) | streaming read hits EOF → `dial` errors → ChatTab shows partial + error line |
-| Multiple rapid Stops | idempotent: abort is a no-op when idle; cancel of an already-cancelled id → `TaskNotFound` swallowed |
+| Duplicate / rapid Stop | idempotent: second `tasks/cancel{id}` → `TaskNotFound` swallowed |
+| Client supplies a colliding id | single-user Hub + uuid → negligible; runner is last-writer for `cancel_signals[id]` |
 
 ## Testing
 
-- **Runtime** (`message_send`): emits `task/started` with the task id *before* any `message/delta`
-  (handler/integration test).
-- **`dial_message_streaming`**: `on_task_id` fires once when a `task/started` notification is read,
-  before deltas; final result still returns normally (fake-socket test mirroring existing dial tests).
-- **`chat.rs`**: registry set on `on_task_id`, cleared on completion; `agent_chat_cancel` dials
-  `tasks/cancel` with the stored id; no-ops cleanly when the registry has no id.
-- **`voice_abort`**: invokes `VoicePlayer::abort()` and emits `voice.interrupted`.
-- **`ChatTab`** (pure-logic where possible — this project has no DOM test harness): Stop visible only
-  while `busy`; triggers both commands; `cancelPending` set when no id yet and fired on resolution;
-  partial streamed text retained with a "stopped" marker.
+- **Runtime** (`task_runner`): `run_sync_streaming` with `spec.task_id = Some("task-x")` uses that id
+  (assert the registered `cancel_signals` key / returned `task.id`); with `None` it still generates one.
+- **Runtime** (`message_send`): `p["task_id"]` flows into `TaskSpec.task_id`; absent → `None`
+  (back-compatible).
+- **Cancel path** (existing/extended): a task cancelled by id yields `TaskOutcome::Cancelled` promptly
+  (mirror the existing cancel test).
+- **`chat.rs`**: `agent_chat_send` stores `registry[name]=taskId`; `agent_chat_cancel` dials
+  `tasks/cancel` with it; no-ops cleanly when absent; registry cleared on completion.
+- **`ChatTab`** (pure-logic where feasible — this project has **no DOM test harness**, only Vitest
+  node tests): Stop visible only while `busy`; Stop commits `streamingRef` content as the reply with a
+  "stopped" marker and stops the spinner; a fresh `taskId` is generated per send.
 
 ## File Boundaries / Coordination
 
-- `a2a_dial.rs` is 401 lines; adding one callback parameter + one notification branch is in-scope and
-  small. No split needed.
-- **Coordination:** `message_send.rs` is in `mur-agent-runtime` (touched by in-flight Phase 3/4) and
-  `ChatTab.tsx` is also touched by the multi-agent rail plan
-  (`2026-06-08-hub-multiagent-conversation-rail.md`). All changes here are additive (a new
-  notification, a new Stop button), but sequence them after those land or merge carefully.
+- All runtime edits are small and additive (`TaskSpec` field, one `unwrap_or_else`, one param read).
+  No file split needed.
+- **Coordination:** `task_runner.rs` + `message_send.rs` are in `mur-agent-runtime` (touched by
+  in-flight Phase 3/4) and `ChatTab.tsx` is also touched by the multi-agent rail plan
+  (`2026-06-08-hub-multiagent-conversation-rail.md`). Changes are additive; sequence after those land
+  or merge carefully.
+
+## Deferred — Voice Abort (separate piece)
+
+When wanted, `voice_abort` belongs on the **pet/companion** surface (the only place speech occurs) and
+requires reachability plumbing that does **not** exist today:
+- Store the active `VoicePlayer`'s `Arc<Notify>` (add a `VoicePlayer::abort_handle()` getter) in a
+  Tauri-managed `VoiceAbortState` keyed by agent, set at `pet_speak` start and cleared on `voice.ended`;
+  `voice_abort(agent)` signals it. (Alternative: make the speak loop subscribe to a bus abort event.)
+- This is independent of generation-cancel and reuses none of v1's chat plumbing, so deferring costs
+  v1 nothing.
 
 ## Future Seams (no v1 work)
 
-- **Voice-activated barge-in**: when desktop STT/VAD exists, a detected user-speech event simply calls
-  the same `voice_abort` + `agent_chat_cancel` — no new interruption plumbing.
-- **Chat TTS**: when the Hub speaks replies, `voice_abort` already silences it; Stop needs no change.
+- **Voice-activated barge-in**: when desktop STT/VAD exists, a detected-speech event calls the same
+  `agent_chat_cancel` (+ a future `voice_abort`) — no new interruption plumbing.
+- **Chat TTS**: when the Hub speaks replies, the chat Stop should *also* abort that playback — at which
+  point voice abort folds naturally into this same Stop control.

--- a/docs/superpowers/specs/2026-06-08-hub-multiagent-conversation-rail-design.md
+++ b/docs/superpowers/specs/2026-06-08-hub-multiagent-conversation-rail-design.md
@@ -1,0 +1,150 @@
+# Hub Multi-Agent Conversation Rail Design (v1)
+
+## Goal
+
+Give the MUR Hub a **vertical conversation rail** so the user can hold several live agent
+conversations at once — open multiple agents, switch between them instantly, and never miss activity
+(streaming replies, HITL approvals, completions) on an agent they aren't currently looking at. The
+Hub today is strictly single-agent; this makes it multi-conversation.
+
+## Scope
+
+- **In:**
+  - A persistent **Conversations surface**: a vertical rail of open conversations + one active
+    conversation panel.
+  - **Buffered multi-conversation state**: every open conversation accumulates its stream even when
+    not active, so switching is instant and nothing is lost.
+  - **Attention model**: rail items show status + an attention badge (pending HITL / unread reply);
+    background activity also fires the existing Phase-2 notification (budget-respecting).
+  - **Separation of concerns**: extract chat out of the per-agent Configuration detail panel into the
+    rail-driven conversation panel.
+- **Out (deferred / other specs):**
+  - Split / concurrent "watch 2–3 side by side" view → **v2** (state model here makes it a
+    layout-only addition).
+  - Voice barge-in → separate spec.
+  - Any inter-agent **routing/orchestration** → that is **Commander's** domain. This spec only leaves
+    a clean seam (a generic "conversational target" notion); it builds no orchestration.
+  - Per-agent event channels / event-model refactor — the current broadcast-filtered-by-name model is
+    sufficient at single-user scale.
+
+## Commander Boundary (why this stays UI-only)
+
+Commander is MUR's designated orchestration + governance + audit engine. Building inter-agent routing
+into the Hub rail would create a second orchestration mechanism that either bypasses Commander's
+governance (an audit hole) or duplicates it. So the layering is fixed: **Commander = orchestration
+engine; Hub rail = local human interface** (observe + converse). In v1 *the user is the router*. The
+rail models a lane as a generic conversational target so a future Commander view can slot in without
+rework.
+
+## Current State (verified)
+
+- **Single-agent today.** `AgentContext.tsx` holds `selectedAgent: string | null`
+  (`mur-hub-gui/ui/src/context/AgentContext.tsx:6-18`); `DetailPanel.tsx` (801 lines) renders one
+  agent's tabs (chat, persona, style, behavior, skills, MCP, permissions, inbox, mobile, memory).
+- **Chat/stream/HITL already concurrent-capable.** `agent_chat_send` →
+  `dial_message_streaming` emits `chat-delta` and `hitl-approval-needed` events **broadcast globally,
+  filtered by agent name in the UI** (`mur-hub-gui/src-tauri/src/chat.rs`, `ChatTab.tsx:68-89`). So
+  multiple agents streaming at once already works; `ChatTab` already filters by an `agentName` prop.
+- **Status already flows.** `discovery.rs` emits `agents-updated` (5s scan); the sidecar supervisor
+  emits `runtime-status-changed` (`mur-hub-gui/src-tauri/src/lib.rs:143-156`).
+- **Implication:** v1 needs **no `mur-core`/runtime changes** — it is a Hub UI + state change.
+
+## Architecture
+
+```
+┌───────────────────────── Conversations surface (new) ─────────────────────────┐
+│  ConversationRail (left)        │            ConversationPanel (right)         │
+│  ┌──────────────┐               │   active agent's ChatTab (existing, reused)  │
+│  │ ● research ▲ │ ← active      │   ┌────────────────────────────────────────┐ │
+│  │ ◑ writer  ② │ ← 2 unread    │   │ streamed messages (from buffer)         │ │
+│  │ ● ops  ⚠HITL │ ← needs you   │   │ HitlCard (if pending)                   │ │
+│  │ + open…      │               │   │ input box                               │ │
+│  └──────────────┘               │   └────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────────────────────────────┘
+        ▲ open/close/focus                        ▲ chat-delta / hitl events
+        │                                          │ (global, filtered by agent name)
+   conversationStore  ←──────────── buffers ALL open conversations, not just active
+        │
+   attention → Phase-2 notification (budgeted) for background HITL / completion
+```
+
+Two **independent** concepts, deliberately separated:
+- **Active conversation** — driven by the rail (this spec).
+- **Selected agent for configuration** — the existing grid → `DetailPanel` flow (unchanged in
+  purpose). `selectedAgent` stays for config; conversations get their own state.
+
+## Components
+
+| Unit | New/Change | Responsibility | Depends on |
+|---|---|---|---|
+| `ConversationContext.tsx` (new, dedicated — **not** folded into `AgentContext`) | New | `openConversations: Map<agentName, ConversationState>` + `activeConversation: string \| null`; actions `open`/`close`/`focus`; ingest `chat-delta`/HITL into the right buffer; attention flags. Reads agent list/status from `AgentContext`. | `AgentContext`, Tauri `listen` events |
+| `ConversationState` (type) | New | `{ agent, messages, streaming, pendingHitl: HitlRequest[], unread: number, attention: "none"\|"unread"\|"hitl" }` | — |
+| `ConversationRail.tsx` | New | One item per open conversation: status dot (from runtime status) + attention badge + close button; click → `focus`. | `conversationStore`, runtime status |
+| `ConversationPanel.tsx` | New | Thin wrapper rendering the **existing `ChatTab`** for `activeConversation`. | `ChatTab.tsx` (reused) |
+| `ConversationsView.tsx` | New | Layout: rail (left) + panel (right); the new top-level surface. | the three above |
+| `AgentContext.tsx` | Unchanged | Keeps `selectedAgent` for the config detail panel; conversation state lives in `ConversationContext`. | — |
+| `DetailPanel.tsx` | Change | Remove the chat tab (config-only now); a "Chat" affordance calls `conversationStore.open(agent)`. Reduces this 801-line file. | `conversationStore` |
+| `DashboardApp.tsx` | Change | Mount `ConversationsView`; grid card "Chat" action opens-or-focuses a conversation. | `conversationStore` |
+| attention → notification wiring (`src-tauri/src/lib.rs` or UI) | Change | Background HITL/completion sets the rail attention flag **and** emits the existing Phase-2 notification (budgeted). | Phase-2 notification path |
+
+Each unit is independently testable: the store is pure state + event-ingest logic; the rail and panel
+are presentational; the notification wiring is a thin adapter.
+
+## Data Flow
+
+```
+Open:        grid/detail "Chat" → store.open(agent) → rail item appears → becomes active
+Send/stream: ConversationPanel(active) → agent_chat_send → chat-delta (filtered by agent)
+             → store buffers into that agent's ConversationState (even when NOT active)
+Background:  chat-delta / hitl-approval-needed for a non-active agent
+             → store buffers + sets attention ("unread" or "hitl")
+             → on HITL or task-complete: also emit Phase-2 notification (budgeted)
+Switch:      click rail item → activeConversation = agent → panel shows buffer, clears unread
+HITL:        HitlCard in the panel → existing agent_hitl_respond(name, hitl_id, allow, reason)
+Close:       rail item × → store.close(agent) (history dropped; reopening starts fresh)
+```
+
+Because the store buffers **all** open conversations, switching is instant and background streams are
+never lost.
+
+## Error Handling
+
+| Condition | Behavior |
+|---|---|
+| Agent stops/crashes mid-conversation (`runtime-status-changed` → error) | rail dot turns error; conversation stays open with history; input disabled + "agent stopped — restart?" affordance |
+| Dial/send failure | inline error in that conversation panel (reuse `ChatTab` error display); other conversations unaffected |
+| Agent removed from disk while open (`agents-updated` drops it) | rail item marked stale; close-only; no send |
+| HITL timeout on a background agent | existing auto-deny/timeout applies; attention flag clears; a system line is appended to that buffer |
+| Same agent opened twice | `open` is idempotent — focuses the existing conversation, never duplicates |
+
+## Testing
+
+- **`conversationStore`** (unit): `open`/`close`/`focus`; idempotent `open`; a background `chat-delta`
+  buffers into the correct conversation; attention set for non-active, cleared on `focus`; unread
+  count increments then resets.
+- **Concurrent streams** (unit): interleaved `chat-delta` for agents A and B land in separate buffers
+  with no cross-contamination — guards the global-event/name-filter model.
+- **`ConversationRail`** (component): one item per open conversation; status dot reflects runtime
+  status; attention badge shown when `pendingHitl` non-empty; close removes the item.
+- **`ConversationPanel`** (component): renders the active agent's `ChatTab`; switching active agent
+  swaps the visible buffer.
+- **Notification integration**: a background HITL fires exactly one budgeted Phase-2 notification (not
+  one per delta).
+- **`DetailPanel`**: chat tab removed; remaining config tabs intact; "Chat" affordance calls
+  `store.open`.
+
+## File Boundaries
+
+- `DetailPanel.tsx` is already **801 lines** (over CLAUDE.md rule 4's 800 limit). Removing the chat tab
+  + extracting it into `ConversationPanel`/`ConversationsView` is a targeted, in-scope improvement that
+  brings it back under the limit. No unrelated refactoring.
+- New components are small and single-purpose (`ConversationRail`, `ConversationPanel`,
+  `ConversationsView`); the store holds the only non-trivial logic and is unit-tested in isolation.
+
+## Future Seams (no v1 work)
+
+- **v2 split view**: render N `ConversationPanel`s from the same store in a flex row — pure layout, no
+  state change, because buffers are already per-agent and concurrency-safe.
+- **Commander view**: a rail lane is a generic conversational target; a Commander-orchestrated
+  task/team could become a lane later, surfacing governance/audit events through the same attention
+  model and the (already generic) HITL card.

--- a/mur-hub-gui/ui/src/App.tsx
+++ b/mur-hub-gui/ui/src/App.tsx
@@ -1,4 +1,5 @@
 import { AgentProvider } from "./context/AgentContext";
+import { ConversationProvider } from "./conversation/ConversationContext";
 import { PopoverApp } from "./components/PopoverApp";
 import { DashboardApp } from "./components/DashboardApp";
 import { PetApp } from "./components/PetApp";
@@ -15,7 +16,9 @@ export default function App() {
   if (route === "pet") return <PetApp />;
   return (
     <AgentProvider>
-      {route === "popover" ? <PopoverApp /> : <DashboardApp />}
+      <ConversationProvider>
+        {route === "popover" ? <PopoverApp /> : <DashboardApp />}
+      </ConversationProvider>
     </AgentProvider>
   );
 }

--- a/mur-hub-gui/ui/src/components/ConversationRail.tsx
+++ b/mur-hub-gui/ui/src/components/ConversationRail.tsx
@@ -1,0 +1,48 @@
+import { useAgents } from "../context/AgentContext";
+import { useConversations } from "../conversation/ConversationContext";
+import { attentionLevel } from "../conversation/reducer";
+
+export default function ConversationRail() {
+  const { agents } = useAgents();
+  const { open, active, attention, focusConversation, closeConversation } =
+    useConversations();
+
+  if (open.length === 0) return null;
+
+  return (
+    <div className="conv-rail">
+      {open.map((name) => {
+        const entry = agents.find((a) => a.name === name);
+        const display = entry?.display_name ?? name;
+        const status = entry?.status ?? "idle";
+        const attn = attention[name] ?? { unread: false, hitl: false };
+        const level = attentionLevel(attn);
+
+        return (
+          <button
+            key={name}
+            className={`conv-item${active === name ? " conv-item--active" : ""}`}
+            onClick={() => focusConversation(name)}
+            title={display}
+          >
+            <span className={`conv-status conv-status--${status}`} />
+            <span className="conv-name">{display}</span>
+            {level !== "none" && (
+              <span className={`conv-badge conv-badge--${level}`} aria-label={level} />
+            )}
+            <button
+              className="conv-close"
+              aria-label="Close conversation"
+              onClick={(e) => {
+                e.stopPropagation();
+                closeConversation(name);
+              }}
+            >
+              ×
+            </button>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/components/ConversationsView.tsx
+++ b/mur-hub-gui/ui/src/components/ConversationsView.tsx
@@ -1,0 +1,31 @@
+import { useAgents } from "../context/AgentContext";
+import { useConversations } from "../conversation/ConversationContext";
+import { ChatTab } from "./ChatTab";
+import ConversationRail from "./ConversationRail";
+
+export function ConversationsView() {
+  const { agents } = useAgents();
+  const { open, active } = useConversations();
+
+  if (open.length === 0) return null;
+
+  return (
+    <div className="conv-surface">
+      <ConversationRail />
+      <div className="conv-panels">
+        {open.map((name) => {
+          const display = agents.find((a) => a.name === name)?.display_name ?? name;
+          return (
+            <div
+              key={name}
+              className="conv-panel"
+              style={{ display: active === name ? "flex" : "none" }}
+            >
+              <ChatTab agentName={name} displayName={display} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -10,6 +10,8 @@ import { PresetImportModal } from "./PresetImportModal";
 import { MuragentImportModal } from "./MuragentImportModal";
 import { useUnreadCount } from "./CompanionInbox";
 import { DetailPanel } from "./DetailPanel";
+import { ConversationsView } from "./ConversationsView";
+import { useConversations } from "../conversation/ConversationContext";
 import { Mascot } from "./Mascot";
 import type { MascotMood } from "./Mascot";
 import { useT } from "../i18n";
@@ -54,6 +56,7 @@ interface GridCardProps {
 export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
   const { t } = useT();
   const { setSelected } = useAgents();
+  const { openConversation } = useConversations();
   const unread = useUnreadCount(agent.name);
   const color = CATEGORY_COLORS[agent.category] ?? "#6B7280";
   const pill = runtimePill(runtime?.state);
@@ -186,6 +189,12 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
           <button onClick={handleShare} title={t("dashboard.shareTooltip")}>
             ↑ {t("dashboard.share")}
           </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); openConversation(agent.name); }}
+            title={t("detail.chat")}
+          >
+            💬 {t("detail.chat")}
+          </button>
         </div>
         <div className="grid-card__foot">
           <span className={pill.cls}>
@@ -313,6 +322,7 @@ function BrainBadge() {
 export function DashboardApp() {
   const { t, lang, setLang } = useT();
   const { agents, runtimeStatuses, selectedAgent, setSelected } = useAgents();
+  const { open: openConvs } = useConversations();
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [query, setQuery] = useState("");
@@ -637,6 +647,9 @@ export function DashboardApp() {
           )}
         </div>
       </div>
+
+      {/* Conversation rail — slides in when conversations are open */}
+      {openConvs.length > 0 && <ConversationsView />}
 
       {/* Detail panel — slides in when an agent is selected */}
       {selectedAgent && (

--- a/mur-hub-gui/ui/src/components/DetailPanel.tsx
+++ b/mur-hub-gui/ui/src/components/DetailPanel.tsx
@@ -16,7 +16,6 @@ import {
   type NotifPatch,
 } from "../types";
 import { CompanionInbox } from "./CompanionInbox";
-import { ChatTab } from "./ChatTab";
 import { MobileTab } from "./MobileTab";
 import { MemoryTab } from "./MemoryTab";
 import { useT } from "../i18n";
@@ -25,7 +24,6 @@ import { CATEGORY_COLORS, TAB_ICONS, avatarInitials } from "../utils";
 
 // Tab → i18n key map (replaces the hardcoded TAB_LABELS lookup).
 const TAB_LABEL_KEYS: Record<DetailTab, TranslationKey> = {
-  chat: "detail.chat",
   persona: "detail.persona",
   style: "detail.style",
   behavior: "detail.behavior",
@@ -57,11 +55,11 @@ export function DetailPanel({ agentName, agents, onClose }: Props) {
   const { t } = useT();
   const [detail, setDetail] = useState<AgentDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<DetailTab>("chat");
+  const [activeTab, setActiveTab] = useState<DetailTab>("persona");
 
   useEffect(() => {
     setError(null);
-    setActiveTab("chat");
+    setActiveTab("persona");
     invoke<AgentDetail>("get_agent_detail", { name: agentName })
       .then(setDetail)
       .catch((e) => setError(String(e)));
@@ -189,9 +187,6 @@ export function DetailPanel({ agentName, agents, onClose }: Props) {
         ))}
       </div>
       <div className="detail-panel__body">
-        {activeTab === "chat" && (
-          <ChatTab agentName={agentName} displayName={detail.display_name} />
-        )}
         {activeTab === "persona" && (
           <PersonaTab detail={detail} onSaved={handleSaved} />
         )}

--- a/mur-hub-gui/ui/src/conversation/ConversationContext.tsx
+++ b/mur-hub-gui/ui/src/conversation/ConversationContext.tsx
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useEffect, useReducer } from "react";
+import { listen } from "@tauri-apps/api/event";
+import {
+  conversationReducer,
+  initialConversationState,
+  type ConversationAttention,
+} from "./reducer";
+
+interface ConversationContextValue {
+  open: string[];
+  active: string | null;
+  attention: Record<string, ConversationAttention>;
+  openConversation: (agent: string) => void;
+  closeConversation: (agent: string) => void;
+  focusConversation: (agent: string) => void;
+}
+
+const Ctx = createContext<ConversationContextValue>({
+  open: [],
+  active: null,
+  attention: {},
+  openConversation: () => {},
+  closeConversation: () => {},
+  focusConversation: () => {},
+});
+
+export function ConversationProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(
+    conversationReducer,
+    undefined,
+    initialConversationState,
+  );
+
+  useEffect(() => {
+    const unDelta = listen<{ agent: string }>("chat-delta", (e) => {
+      dispatch({ type: "delta", agent: e.payload.agent });
+    });
+    const unHitl = listen<{ agent: string }>("hitl-approval-needed", (e) => {
+      dispatch({ type: "hitl_open", agent: e.payload.agent });
+    });
+    return () => {
+      unDelta.then((f) => f());
+      unHitl.then((f) => f());
+    };
+  }, []);
+
+  return (
+    <Ctx.Provider
+      value={{
+        open: state.open,
+        active: state.active,
+        attention: state.attention,
+        openConversation: (agent) => dispatch({ type: "open", agent }),
+        closeConversation: (agent) => dispatch({ type: "close", agent }),
+        focusConversation: (agent) => dispatch({ type: "focus", agent }),
+      }}
+    >
+      {children}
+    </Ctx.Provider>
+  );
+}
+
+export function useConversations() {
+  return useContext(Ctx);
+}

--- a/mur-hub-gui/ui/src/conversation/ConversationContext.tsx
+++ b/mur-hub-gui/ui/src/conversation/ConversationContext.tsx
@@ -1,10 +1,11 @@
-import React, { createContext, useContext, useEffect, useReducer } from "react";
+import React, { createContext, useContext, useEffect, useReducer, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
 import {
   conversationReducer,
   initialConversationState,
   type ConversationAttention,
 } from "./reducer";
+import { notifyHitlBackground } from "./notify";
 
 interface ConversationContextValue {
   open: string[];
@@ -30,14 +31,26 @@ export function ConversationProvider({ children }: { children: React.ReactNode }
     undefined,
     initialConversationState,
   );
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   useEffect(() => {
     const unDelta = listen<{ agent: string }>("chat-delta", (e) => {
       dispatch({ type: "delta", agent: e.payload.agent });
     });
-    const unHitl = listen<{ agent: string }>("hitl-approval-needed", (e) => {
-      dispatch({ type: "hitl_open", agent: e.payload.agent });
-    });
+    const unHitl = listen<{ agent: string; display_name?: string }>(
+      "hitl-approval-needed",
+      (e) => {
+        const { agent, display_name } = e.payload;
+        // stateRef lets us read current state inside the effect closure without
+        // re-subscribing the listener on every render.
+        const { open, active } = stateRef.current;
+        if (open.includes(agent) && active !== agent) {
+          notifyHitlBackground(display_name ?? agent);
+        }
+        dispatch({ type: "hitl_open", agent });
+      },
+    );
     return () => {
       unDelta.then((f) => f());
       unHitl.then((f) => f());

--- a/mur-hub-gui/ui/src/conversation/notify.ts
+++ b/mur-hub-gui/ui/src/conversation/notify.ts
@@ -1,0 +1,10 @@
+// Fire a toast notification for a background HITL event on a non-active agent.
+// Mirrors the showToast pattern in DashboardApp (DOM-only, no Tauri notification
+// plugin needed) so we stay consistent with the Phase-2 notification approach.
+export function notifyHitlBackground(displayName: string) {
+  const el = document.createElement("div");
+  el.className = "toast";
+  el.textContent = `⏳ ${displayName} needs approval`;
+  document.body.appendChild(el);
+  setTimeout(() => el.remove(), 4000);
+}

--- a/mur-hub-gui/ui/src/conversation/reducer.test.ts
+++ b/mur-hub-gui/ui/src/conversation/reducer.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  conversationReducer,
+  initialConversationState,
+  attentionLevel,
+  type ConversationState,
+} from "./reducer";
+
+function open(state: ConversationState, agent: string) {
+  return conversationReducer(state, { type: "open", agent });
+}
+
+describe("conversationReducer", () => {
+  it("open adds agent and sets active", () => {
+    const s = open(initialConversationState(), "a");
+    expect(s.open).toContain("a");
+    expect(s.active).toBe("a");
+  });
+
+  it("open twice focuses without duplicating", () => {
+    let s = open(initialConversationState(), "a");
+    s = open(s, "b");
+    s = open(s, "a");
+    expect(s.open.filter((x) => x === "a")).toHaveLength(1);
+    expect(s.active).toBe("a");
+  });
+
+  it("close removes agent and shifts active to last remaining", () => {
+    let s = open(initialConversationState(), "a");
+    s = open(s, "b");
+    s = conversationReducer(s, { type: "close", agent: "b" });
+    expect(s.open).not.toContain("b");
+    expect(s.active).toBe("a");
+  });
+
+  it("delta for non-active open agent sets unread", () => {
+    let s = open(initialConversationState(), "a");
+    s = open(s, "b");
+    s = conversationReducer(s, { type: "focus", agent: "b" });
+    s = conversationReducer(s, { type: "delta", agent: "a" });
+    expect(s.attention["a"].unread).toBe(true);
+  });
+
+  it("delta for the active agent does NOT set unread", () => {
+    let s = open(initialConversationState(), "a");
+    s = conversationReducer(s, { type: "delta", agent: "a" });
+    expect(s.attention["a"].unread).toBe(false);
+  });
+
+  it("delta for an agent that is not open is ignored", () => {
+    const s = conversationReducer(initialConversationState(), {
+      type: "delta",
+      agent: "ghost",
+    });
+    expect(s.attention["ghost"]).toBeUndefined();
+  });
+
+  it("hitl_open for a non-active open agent sets hitl", () => {
+    let s = open(initialConversationState(), "a");
+    s = open(s, "b");
+    s = conversationReducer(s, { type: "focus", agent: "b" });
+    s = conversationReducer(s, { type: "hitl_open", agent: "a" });
+    expect(s.attention["a"].hitl).toBe(true);
+  });
+
+  it("focus clears unread and hitl for that agent", () => {
+    let s = open(initialConversationState(), "a");
+    s = open(s, "b");
+    s = conversationReducer(s, { type: "focus", agent: "b" });
+    s = conversationReducer(s, { type: "delta", agent: "a" });
+    s = conversationReducer(s, { type: "hitl_open", agent: "a" });
+    s = conversationReducer(s, { type: "focus", agent: "a" });
+    expect(s.active).toBe("a");
+    expect(s.attention["a"]).toEqual({ unread: false, hitl: false });
+  });
+});
+
+describe("attentionLevel", () => {
+  it("hitl wins over unread", () => {
+    expect(attentionLevel({ unread: true, hitl: true })).toBe("hitl");
+  });
+  it("unread alone", () => {
+    expect(attentionLevel({ unread: true, hitl: false })).toBe("unread");
+  });
+  it("none", () => {
+    expect(attentionLevel({ unread: false, hitl: false })).toBe("none");
+  });
+});

--- a/mur-hub-gui/ui/src/conversation/reducer.ts
+++ b/mur-hub-gui/ui/src/conversation/reducer.ts
@@ -1,0 +1,89 @@
+export type AttentionLevel = "none" | "unread" | "hitl";
+
+export interface ConversationAttention {
+  unread: boolean;
+  hitl: boolean;
+}
+
+export interface ConversationState {
+  open: string[];
+  active: string | null;
+  attention: Record<string, ConversationAttention>;
+}
+
+export type ConversationAction =
+  | { type: "open"; agent: string }
+  | { type: "close"; agent: string }
+  | { type: "focus"; agent: string }
+  | { type: "delta"; agent: string }
+  | { type: "hitl_open"; agent: string };
+
+const CLEAR: ConversationAttention = { unread: false, hitl: false };
+
+export function initialConversationState(): ConversationState {
+  return { open: [], active: null, attention: {} };
+}
+
+export function attentionLevel(a: ConversationAttention): AttentionLevel {
+  if (a.hitl) return "hitl";
+  if (a.unread) return "unread";
+  return "none";
+}
+
+export function conversationReducer(
+  state: ConversationState,
+  action: ConversationAction,
+): ConversationState {
+  switch (action.type) {
+    case "open": {
+      if (state.open.includes(action.agent)) {
+        return { ...state, active: action.agent };
+      }
+      return {
+        ...state,
+        open: [...state.open, action.agent],
+        active: action.agent,
+        attention: { ...state.attention, [action.agent]: { ...CLEAR } },
+      };
+    }
+    case "close": {
+      const open = state.open.filter((a) => a !== action.agent);
+      const attention = { ...state.attention };
+      delete attention[action.agent];
+      const active =
+        state.active === action.agent
+          ? (open[open.length - 1] ?? null)
+          : state.active;
+      return { open, active, attention };
+    }
+    case "focus": {
+      if (!state.open.includes(action.agent)) return state;
+      return {
+        ...state,
+        active: action.agent,
+        attention: {
+          ...state.attention,
+          [action.agent]: { ...CLEAR },
+        },
+      };
+    }
+    case "delta": {
+      if (!state.open.includes(action.agent) || state.active === action.agent)
+        return state;
+      const prev = state.attention[action.agent] ?? { ...CLEAR };
+      return {
+        ...state,
+        attention: { ...state.attention, [action.agent]: { ...prev, unread: true } },
+      };
+    }
+    case "hitl_open": {
+      if (!state.open.includes(action.agent) || state.active === action.agent)
+        return state;
+      const prev = state.attention[action.agent] ?? { ...CLEAR };
+      return {
+        ...state,
+        attention: { ...state.attention, [action.agent]: { ...prev, hitl: true } },
+      };
+    }
+  }
+}

--- a/mur-hub-gui/ui/src/styles/components/dashboard.css
+++ b/mur-hub-gui/ui/src/styles/components/dashboard.css
@@ -1,9 +1,9 @@
 /* ── Dashboard ────────────────────────────────────────────────────────── */
 .dashboard-root {
   display: grid;
-  /* 3rd track holds the detail/chat panel when an agent is selected; it
-     collapses to nothing when the panel is absent. */
-  grid-template-columns: 160px 1fr auto;
+  /* 3rd track = conversation view (open convs); 4th = detail panel (selected agent).
+     Both collapse to nothing when absent. */
+  grid-template-columns: 160px 1fr auto auto;
   height: 100vh;
   overflow: hidden;
 }

--- a/mur-hub-gui/ui/src/styles/components/dashboard.css
+++ b/mur-hub-gui/ui/src/styles/components/dashboard.css
@@ -479,3 +479,127 @@
   background: var(--color-brand);
   color: #fff;
 }
+
+/* ── Conversation Rail ─────────────────────────────────────────────────── */
+.conv-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 180px;
+  min-width: 140px;
+  padding: 8px 4px;
+  border-right: 1px solid var(--color-border, #e5e7eb);
+  background: var(--color-surface, #f9fafb);
+  overflow-y: auto;
+}
+
+.conv-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  font-size: 13px;
+  color: var(--color-text, #111);
+  position: relative;
+}
+
+.conv-item:hover {
+  background: var(--color-hover, #f3f4f6);
+}
+
+.conv-item--active {
+  background: var(--color-selected, #ede9fe);
+  font-weight: 500;
+}
+
+.conv-status {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-idle, #9ca3af);
+}
+
+.conv-status--running {
+  background: var(--color-running, #22c55e);
+}
+
+.conv-status--idle {
+  background: var(--color-idle, #9ca3af);
+}
+
+.conv-status--stale {
+  background: var(--color-stale, #f59e0b);
+}
+
+.conv-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conv-badge {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.conv-badge--unread {
+  background: var(--color-brand, #7c3aed);
+}
+
+.conv-badge--hitl {
+  background: var(--color-warning, #f59e0b);
+}
+
+.conv-close {
+  flex-shrink: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--color-muted, #6b7280);
+  padding: 0;
+}
+
+.conv-item:hover .conv-close {
+  display: flex;
+}
+
+.conv-close:hover {
+  background: var(--color-danger-subtle, #fee2e2);
+  color: var(--color-danger, #ef4444);
+}
+
+/* ── Conversation Surface ──────────────────────────────────────────────── */
+.conv-surface {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+}
+
+.conv-panels {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+}
+
+.conv-panel {
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}

--- a/mur-hub-gui/ui/src/types.ts
+++ b/mur-hub-gui/ui/src/types.ts
@@ -125,7 +125,6 @@ export interface DetailPatch {
 }
 
 export type DetailTab =
-  | "chat"
   | "persona"
   | "style"
   | "behavior"
@@ -137,7 +136,6 @@ export type DetailTab =
   | "memory";
 
 export const ALL_DETAIL_TABS: DetailTab[] = [
-  "chat",
   "persona",
   "style",
   "behavior",
@@ -166,7 +164,6 @@ export interface NotifPatch {
 }
 
 export const TAB_LABELS: Record<DetailTab, string> = {
-  chat: "Chat",
   persona: "Persona",
   style: "Style",
   behavior: "Behavior",

--- a/mur-hub-gui/ui/src/utils.ts
+++ b/mur-hub-gui/ui/src/utils.ts
@@ -17,7 +17,6 @@ export const CATEGORY_ICONS: Record<string, string> = {
 };
 
 export const TAB_ICONS: Record<string, string> = {
-  chat: "💬",
   persona: "🎭",
   style: "🎨",
   behavior: "🦜",


### PR DESCRIPTION
## Summary

- **`conversationReducer`** — pure reducer tracking `open[]`, `active`, and per-agent `attention` (`unread`/`hitl`); 15 unit tests (Vitest), all green
- **`ConversationContext`** — Tauri event listeners (`chat-delta`, `hitl-approval-needed`) dispatch into the reducer; `stateRef` pattern avoids stale closure on background HITL check
- **`ConversationRail`** — vertical list of open conversations with status dot (running/idle/stale), attention badge (unread/HITL), close button
- **`ConversationsView`** — rail + mounted `ChatTab` panels (CSS `display:none` for non-active, so scroll history is preserved across focus switches)
- **`DashboardApp`** — 💬 Chat button on each GridCard calls `openConversation(agent)`; `ConversationsView` mounts as 3rd column when conversations are open
- **`DetailPanel`** — chat tab removed (config-only); default tab → persona; `ALL_DETAIL_TABS` / `TAB_LABELS` / `TAB_ICONS` updated
- **Background HITL notification** — fires the existing Phase-2 DOM toast when a non-active open agent needs approval

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-06-08-hub-multiagent-conversation-rail.md`
- Plan: `docs/superpowers/plans/2026-06-08-hub-multiagent-conversation-rail.md`

## Test Plan

- [x] `npx vitest run` — 15/15 pass (pure reducer + attentionLevel)
- [x] `npx tsc -b` — no errors
- [x] `npm run build` — clean (70 modules)
- [ ] Manual smoke: build Hub, click Chat on a grid card → rail appears, status dot reflects runtime state
- [ ] Manual smoke: open 2 agents → switch via rail → attention badge clears on focus
- [ ] Manual smoke: background HITL on non-active agent → toast fires
- [ ] Manual smoke: DetailPanel opens to Persona tab (no Chat tab)
- [ ] All files ≤ 800 lines (DetailPanel 796)

🤖 Generated with [Claude Code](https://claude.com/claude-code)