### PR TITLE
fix(skill): accept `category: media` so media skills load

### DIFF
--- a/mur-common/src/skill/types.rs
+++ b/mur-common/src/skill/types.rs
@@ -39,6 +39,9 @@ pub enum Category {
     Command,
     Meta,
     Note,
+    /// Media skills (video-analyze, scene-explain, vlc-control, watch-together):
+    /// they drive the runtime's media tools rather than the four-stage pipeline.
+    Media,
 }
 
 /// Where a skill came from. Drives the curation gate: `Llm`-authored skills
@@ -112,6 +115,14 @@ mod tests {
         assert_eq!(yaml.trim(), "note");
         let parsed: Category = serde_yaml_ng::from_str("note").unwrap();
         assert_eq!(parsed, Category::Note);
+    }
+
+    #[test]
+    fn media_category_serialises_lowercase_and_roundtrips() {
+        let yaml = serde_yaml_ng::to_string(&Category::Media).unwrap();
+        assert_eq!(yaml.trim(), "media");
+        let parsed: Category = serde_yaml_ng::from_str("media").unwrap();
+        assert_eq!(parsed, Category::Media);
     }
 
     #[test]

--- a/mur-core/src/retrieve/skill_candidates.rs
+++ b/mur-core/src/retrieve/skill_candidates.rs
@@ -40,6 +40,8 @@ impl LoadedSkill {
             | mur_common::skill::types::Category::Note => KindGroup::Knowledge,
             mur_common::skill::types::Category::Workflow => KindGroup::Procedures,
             mur_common::skill::types::Category::Command => KindGroup::Procedures,
+            // Media skills drive the runtime's media tools — procedure-like.
+            mur_common::skill::types::Category::Media => KindGroup::Procedures,
         };
         InjectedItem {
             name: self.manifest.name.clone(),


### PR DESCRIPTION
## Why
The media skills (`video-analyze`, `scene-explain`, `vlc-control`, `watch-together`) declare `category: media` in their frontmatter. The `Category` enum only knew `context`/`workflow`/`command`/`meta`/`note`, so the skill loader rejected all four with `unknown variant 'media'`. Observed at runtime-agent boot as four repeated warnings:

```
WARN skill load failed; skipping skill=watch-together error=parse: yaml parse: category: unknown variant `media` ...
```

→ the runtime agent silently runs without any of its media skills.

## Fix
- Add the `Media` variant to `Category` (serialises lowercase to `media`).
- Map it to `KindGroup::Procedures` in skill-candidate ranking (media skills drive tools, like command/workflow skills).

## Test
- New round-trip test `media_category_serialises_lowercase_and_roundtrips`.
- `cargo build` across mur-common/mur-core/mur-agent-runtime/mur-mcp-server (caught + fixed a non-exhaustive match in `skill_candidates.rs`); clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)