### PR TITLE
fix(media): VLC status parse, autoplay on open, fresh-snapshot guard

### DIFF
--- a/mur-core/src/cmd/media/scene.rs
+++ b/mur-core/src/cmd/media/scene.rs
@@ -22,6 +22,15 @@ pub fn newest_file(dir: &Path) -> Option<PathBuf> {
     best.map(|(_, p)| p)
 }
 
+/// Like [`newest_file`], but only considers files modified at or after `since`.
+/// Used to require a *freshly captured* snapshot rather than silently falling
+/// back to a stale frame left over from a previous session.
+pub fn newest_file_after(dir: &Path, since: std::time::SystemTime) -> Option<PathBuf> {
+    let path = newest_file(dir)?;
+    let mtime = std::fs::metadata(&path).ok()?.modified().ok()?;
+    (mtime >= since).then_some(path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -43,6 +52,28 @@ mod tests {
     fn newest_file_empty_dir_is_none() {
         let dir = TempDir::new().unwrap();
         assert!(newest_file(dir.path()).is_none());
+    }
+
+    #[test]
+    fn newest_file_after_rejects_stale_and_accepts_fresh() {
+        let dir = TempDir::new().unwrap();
+        // A stale snapshot left from "before".
+        std::fs::write(dir.path().join("stale.png"), b"old").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        // The capture boundary.
+        let since = std::time::SystemTime::now();
+        // Nothing newer than `since` yet → no fresh frame.
+        assert!(newest_file_after(dir.path(), since).is_none());
+        // A freshly captured snapshot lands after `since`.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::fs::write(dir.path().join("fresh.png"), b"new").unwrap();
+        assert_eq!(
+            newest_file_after(dir.path(), since)
+                .unwrap()
+                .file_name()
+                .unwrap(),
+            "fresh.png"
+        );
     }
 }
 
@@ -131,12 +162,15 @@ pub async fn explain(prompt: Option<&str>) -> Result<String> {
 
     // 1. Ensure VLC is up and take a snapshot.
     let rt = super::vlc::ensure_for_snapshot(client).await?;
+    // Mark the instant before requesting the snapshot so we can require a frame
+    // captured *after* this call — never an older snapshot from a prior session.
+    let since = std::time::SystemTime::now();
     super::vlc::snapshot_command(&rt, client).await?;
 
     // 2. Read the newest snapshot file (retry briefly for the file to land).
     let mut img_path = None;
     for i in 0..10 {
-        if let Some(p) = newest_file(&rt.snapshot_dir) {
+        if let Some(p) = newest_file_after(&rt.snapshot_dir, since) {
             img_path = Some(p);
             break;
         }
@@ -156,14 +190,16 @@ pub async fn explain(prompt: Option<&str>) -> Result<String> {
         }
         tokio::time::sleep(Duration::from_millis(150)).await;
     }
-    let img_path = img_path.context("no snapshot produced by VLC")?;
+    // No fresh frame means VLC produced no new snapshot (typically: nothing is
+    // playing). Fail rather than describe a stale frame from a previous session.
+    let img_path = img_path.context("no fresh snapshot produced by VLC (is something playing?)")?;
 
     // Handle race: VLC may replace the snapshot file between discovery and read.
     let bytes = match std::fs::read(&img_path) {
         Ok(b) => b,
         Err(_) => {
             tokio::time::sleep(Duration::from_millis(300)).await;
-            let retry = newest_file(&rt.snapshot_dir)
+            let retry = newest_file_after(&rt.snapshot_dir, since)
                 .context("no snapshot (file vanished and no replacement found)")?;
             std::fs::read(&retry).context("read snapshot")?
         }

--- a/mur-core/src/cmd/media/vlc.rs
+++ b/mur-core/src/cmd/media/vlc.rs
@@ -63,6 +63,12 @@ pub fn parse_status_xml(xml: &str) -> VlcStatus {
             Ok(Event::Start(ref e)) => {
                 in_tag = String::from_utf8_lossy(e.name().as_ref()).into_owned();
             }
+            // Clear the active tag when it closes. Without this, the pretty-printed
+            // whitespace VLC emits *after* `</state>` arrives as a Text event while
+            // `in_tag` is still "state" and clobbers the value (e.g. state == "\n").
+            Ok(Event::End(_)) => {
+                in_tag.clear();
+            }
             Ok(Event::Text(ref e)) => {
                 let text = e.unescape().unwrap_or_default().to_string();
                 match in_tag.as_str() {
@@ -108,6 +114,18 @@ mod tests {
     #[test]
     fn parse_status_extracts_fields() {
         let xml = "<root><volume>256</volume><state>playing</state><time>42</time><length>3600</length></root>";
+        let s = parse_status_xml(xml);
+        assert_eq!(s.state, "playing");
+        assert_eq!(s.time, 42);
+        assert_eq!(s.length, 3600);
+        assert_eq!(s.volume, 256);
+    }
+
+    #[test]
+    fn parse_status_pretty_printed_does_not_clobber_state() {
+        // Real VLC status.xml is indented; the newline after `</state>` must not
+        // overwrite the parsed value (regression: state came back as "\n").
+        let xml = "<root>\n  <volume>256</volume>\n  <state>playing</state>\n  <time>42</time>\n  <length>3600</length>\n</root>\n";
         let s = parse_status_xml(xml);
         assert_eq!(s.state, "playing");
         assert_eq!(s.time, 42);
@@ -225,7 +243,14 @@ pub async fn open(source: &str) -> Result<VlcStatus> {
     // VLC's status.xml does not expose a usable source URI. (Spec §4.2.)
     let _ = super::resolve::save_last_source(&home, source);
     let rt = ensure_vlc_running(&home, client).await?;
-    send_command(&rt, client, "in_play", &[("input", source)]).await
+    let status = send_command(&rt, client, "in_play", &[("input", source)]).await?;
+    // `in_play` enqueues and *should* autoplay, but on a freshly-launched VLC it
+    // can land in `stopped`. Nudge it into playback so callers (and especially
+    // `scene_explain`, which snapshots the current frame) have a live frame.
+    if status.state != "playing" {
+        return send_command(&rt, client, "pl_play", &[]).await;
+    }
+    Ok(status)
 }
 
 /// Playback control. `action` ∈ {play, pause, toggle, stop, seek, volume}.


### PR DESCRIPTION
Three independent live-path bugs found during Watch-Together v2 manual E2E (all in `mur-core/src/cmd/media`).

### 1. `vlc_status` returned `state: "\n"`
`parse_status_xml` set `in_tag` on `Event::Start` but never cleared it on `Event::End`. VLC's pretty-printed `status.xml` emits whitespace after `</state>`, which arrives as a `Text` event while `in_tag` is still `"state"` → clobbers the value. **Fix:** clear `in_tag` on `Event::End`. The existing test passed only because its XML had no inter-tag whitespace; added a pretty-printed regression test.

### 2. `vlc_open` left VLC `stopped`
`in_play` enqueues and *should* autoplay, but on a freshly-launched VLC it can land in `stopped` — so a following `scene_explain` finds nothing playing. **Fix:** follow up with `pl_play` when the post-open state isn't `playing`.

### 3. `scene_explain` could describe a STALE frame
When VLC produced no new snapshot (nothing playing), `explain` fell back to `newest_file` = an old snapshot from a previous session, and the model confidently described the wrong scene (observed: described a prior session's video instead of the current one). **Fix:** `newest_file_after(dir, since)` requires a frame captured *after* the snapshot request; otherwise errors `no fresh snapshot produced by VLC (is something playing?)`.

## Test
`cargo test -p mur-core --lib media::` — 32 pass, incl. new `parse_status_pretty_printed_does_not_clobber_state` and `newest_file_after_rejects_stale_and_accepts_fresh`. clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)