### PR TITLE
fix(runtime): allowlist VLC HTTP port in kernel sandbox for co-watching

### DIFF
--- a/mur-agent-runtime/src/sandbox/mod.rs
+++ b/mur-agent-runtime/src/sandbox/mod.rs
@@ -36,10 +36,14 @@ pub fn apply(
     entitlements: &Entitlements,
     agent_home: &Path,
     extra_ports: &[u16],
+    extra_write_paths: &[std::path::PathBuf],
 ) -> anyhow::Result<SandboxStatus> {
     let mut policy = SandboxPolicy::from_entitlements(entitlements, agent_home);
     // An agent must always be able to reach its own configured local LLM.
     policy.allow_extra_ports(extra_ports);
+    // …and to write the shared runtime media state it owns (co-watching:
+    // watch.json + VLC snapshot dir), which lives outside agent_home.
+    policy.allow_extra_write_paths(extra_write_paths);
     let status = apply_policy(&policy)?;
     // Store for attestation. OnceLock: if called twice, second call is ignored.
     let _ = SANDBOX_STATUS.set(status.clone());

--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -97,6 +97,18 @@ impl SandboxPolicy {
             }
         }
     }
+
+    /// Grant write access to additional paths the runtime owns but that live
+    /// outside `agent_home` — e.g. the shared `~/.mur/runtime` media state
+    /// (`watch.json`, VLC snapshot dir) that the co-watching scheduler must
+    /// persist to and clean up. Idempotent.
+    pub fn allow_extra_write_paths(&mut self, paths: &[PathBuf]) {
+        for p in paths {
+            if !self.fs_write.contains(p) {
+                self.fs_write.push(p.clone());
+            }
+        }
+    }
 }
 
 fn system_exec_paths(home: &Path) -> Vec<PathBuf> {
@@ -278,5 +290,18 @@ mod tests {
         let mut p_unr = SandboxPolicy::from_entitlements(&unr, &PathBuf::from("/tmp/a"));
         p_unr.allow_extra_ports(&[11434]);
         assert_eq!(p_unr.net_allow_ports, None);
+    }
+
+    #[test]
+    fn allow_extra_write_paths_adds_and_dedups() {
+        let ent = minimal_entitlements();
+        let agent_home = PathBuf::from("/tmp/a");
+        let mut policy = SandboxPolicy::from_entitlements(&ent, &agent_home);
+        let extra = PathBuf::from("/home/u/.mur/runtime/vlc-snapshots");
+        policy.allow_extra_write_paths(&[extra.clone()]);
+        assert!(policy.fs_write.contains(&extra));
+        // Idempotent — re-adding doesn't duplicate.
+        policy.allow_extra_write_paths(&[extra.clone()]);
+        assert_eq!(policy.fs_write.iter().filter(|p| **p == extra).count(), 1);
     }
 }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -192,10 +192,24 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     // On platforms without Landlock/SBPL support, returns enforcing=false — B0 still applies.
     let fail_closed = profile.inner.entitlements.fail_closed_on_sandbox_error;
     // Always allow the agent's own local LLM port through the kernel sandbox.
-    let llm_ports: Vec<u16> = crate::supervisor_runner::local_llm_port(&profile.inner, &mur_home)
-        .into_iter()
-        .collect();
-    match crate::sandbox::apply(&profile.inner.entitlements, &agent_home, &llm_ports) {
+    let mut extra_ports: Vec<u16> =
+        crate::supervisor_runner::local_llm_port(&profile.inner, &mur_home)
+            .into_iter()
+            .collect();
+    // Also allow the persisted VLC HTTP port so the proactive co-watching
+    // WatchScheduler can snapshot VLC under the enforced sandbox. The macOS SBPL
+    // (and Landlock) allowlist is port-based, and the VLC port is random-but-sticky
+    // in vlc.json — so without this the scheduler's HTTP to VLC is kernel-denied
+    // and co-watching silently captures nothing. If VLC has never been set up,
+    // vlc.json is absent at seal time; a restart picks the port up once it exists.
+    if let Some(vlc) = mur_common::media::load_runtime(&mur_home) {
+        extra_ports.push(vlc.port);
+        tracing::info!(
+            vlc_port = vlc.port,
+            "B1 sandbox: allowing VLC HTTP port for co-watching"
+        );
+    }
+    match crate::sandbox::apply(&profile.inner.entitlements, &agent_home, &extra_ports) {
         Ok(status) => {
             if !status.enforcing && fail_closed {
                 anyhow::bail!(

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -202,14 +202,29 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     // in vlc.json — so without this the scheduler's HTTP to VLC is kernel-denied
     // and co-watching silently captures nothing. If VLC has never been set up,
     // vlc.json is absent at seal time; a restart picks the port up once it exists.
+    // The scheduler also persists co-watching state and prunes snapshots under
+    // the shared `~/.mur/runtime` dir (outside agent_home), so allow writing
+    // those specific paths — otherwise consent/last_scene never persist and
+    // snapshots accumulate (B5). watch.json is written via temp+rename, so allow
+    // the `.tmp` sibling too.
+    let mut extra_write_paths: Vec<std::path::PathBuf> = Vec::new();
     if let Some(vlc) = mur_common::media::load_runtime(&mur_home) {
         extra_ports.push(vlc.port);
+        extra_write_paths.push(vlc.snapshot_dir.clone());
         tracing::info!(
             vlc_port = vlc.port,
             "B1 sandbox: allowing VLC HTTP port for co-watching"
         );
     }
-    match crate::sandbox::apply(&profile.inner.entitlements, &agent_home, &extra_ports) {
+    let watch_json = mur_common::media::watch_path(&mur_home);
+    extra_write_paths.push(watch_json.with_extension("json.tmp"));
+    extra_write_paths.push(watch_json);
+    match crate::sandbox::apply(
+        &profile.inner.entitlements,
+        &agent_home,
+        &extra_ports,
+        &extra_write_paths,
+    ) {
         Ok(status) => {
             if !status.enforcing && fail_closed {
                 anyhow::bail!(

--- a/mur-agent-runtime/tests/sandbox_e2e.rs
+++ b/mur-agent-runtime/tests/sandbox_e2e.rs
@@ -84,7 +84,7 @@ fn sandbox_apply_does_not_panic() {
     let profile = AgentProfile::default_for_tests();
     let agent_home = PathBuf::from("/tmp/b1_test_agent_apply");
     std::fs::create_dir_all(&agent_home).unwrap();
-    let result = sandbox::apply(&profile.entitlements, &agent_home, &[]);
+    let result = sandbox::apply(&profile.entitlements, &agent_home, &[], &[]);
     assert!(result.is_ok(), "sandbox::apply must not error: {result:?}");
 }
 
@@ -174,7 +174,7 @@ fn sandbox_write_deny_subprocess_main() {
     let agent_home = std::path::PathBuf::from("/tmp/b1_test_deny_home");
     std::fs::create_dir_all(&agent_home).unwrap();
 
-    if sandbox::apply(&profile.entitlements, &agent_home, &[]).is_err() {
+    if sandbox::apply(&profile.entitlements, &agent_home, &[], &[]).is_err() {
         // Sandbox apply failed (e.g., no kernel support) — treat as pass.
         std::process::exit(0);
     }

--- a/mur-common/src/media.rs
+++ b/mur-common/src/media.rs
@@ -19,14 +19,42 @@ pub fn runtime_path(mur_home: &Path) -> PathBuf {
     mur_home.join("runtime").join("vlc.json")
 }
 
+/// Load the persisted VLC runtime (`vlc.json`), or `None` if absent/unparseable.
+/// Used by the runtime supervisor to allowlist VLC's HTTP port in the kernel
+/// sandbox, and anywhere else that needs the current VLC connection details.
+pub fn load_runtime(mur_home: &Path) -> Option<VlcRuntime> {
+    let raw = std::fs::read_to_string(runtime_path(mur_home)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn runtime_path_under_runtime_dir() {
         let p = runtime_path(Path::new("/tmp/h"));
         assert!(p.ends_with("runtime/vlc.json"));
+    }
+
+    #[test]
+    fn load_runtime_absent_is_none() {
+        let home = TempDir::new().unwrap();
+        assert!(load_runtime(home.path()).is_none());
+    }
+
+    #[test]
+    fn load_runtime_roundtrips_port() {
+        let home = TempDir::new().unwrap();
+        let dir = home.path().join("runtime");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            runtime_path(home.path()),
+            r#"{"port":61886,"password":"pw","snapshot_dir":"/tmp/s"}"#,
+        )
+        .unwrap();
+        assert_eq!(load_runtime(home.path()).unwrap().port, 61886);
     }
 }
 


### PR DESCRIPTION
Makes Watch-Together v2 proactive co-watching actually work under the runtime's enforced kernel sandbox. Two halves, both required.

## Root cause (found during manual E2E)
The runtime seals a **kernel sandbox (B1, ENFORCING)** at startup. With the default `network.outbound.mode: restricted`, its allowlists are narrow and **port/path-based**, and the supervisor only punched through the local LLM port + agent_home. The `WatchScheduler`:
1. **snapshots VLC over HTTP** on VLC's port (random, persisted in `vlc.json`) — *not* allowlisted → kernel-denied → `capture_png` returns None → loop `continue`s silently.
2. **persists `watch.json` and prunes snapshots** under the shared `~/.mur/runtime` dir — *outside* `agent_home`, and fs_write is `deny file-write* /` + agent_home → denied.

So even after fixing (1), consent/last_scene never persisted (re-asked every tick) and snapshots accumulated unbounded (violating B5). `allow_hosts` doesn't help — it's a userspace reqwest HostGuard, not the kernel.

## Fix
- **Network:** read the VLC port from `vlc.json` (new `mur_common::media::load_runtime`) → add to sandbox `extra_ports`.
- **Filesystem:** new `SandboxPolicy::allow_extra_write_paths`, threaded through `sandbox::apply`; the supervisor grants write to exactly the VLC snapshot dir + `watch.json` (+ temp sibling) — least-privilege.

**Limitation:** the VLC port/snapshot dir are known at seal time only if `vlc.json` already exists. It's random-but-sticky (persisted across runs), so this holds after VLC's first use; a brand-new install picks it up on the next restart.

## Verified live
With `mode: restricted` and the sandbox **ENFORCING**: `B1 sandbox: allowing VLC HTTP port for co-watching vlc_port=…` logged; `watch_start` flips `consent` unasked→**granted** (persisted), `last_scene_phash` tracks real frames across ticks, snapshots stay at **0–1** (deleted after hashing), and a mid-loop `watch_mute` survives the scheduler's `save_watch` (no narration while muted). Before this PR the same setup never mutated `watch.json` and leaked 15+ snapshots.

## Tests
`load_runtime` round-trip + `allow_extra_write_paths` unit tests; updated `sandbox_e2e.rs` call sites; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)