### PR TITLE
fix(hub): bundle vision-capable mlx-vlm server (not text-only mlx-lm)

### DIFF
--- a/mur-hub-gui/src-tauri/src/mlx_sidecar.rs
+++ b/mur-hub-gui/src-tauri/src/mlx_sidecar.rs
@@ -1,6 +1,7 @@
-//! MLX inference sidecar — spawns the bundled `mlx-server` (frozen mlx-lm,
-//! OpenAI-compatible) on an ephemeral port and publishes its base URL via the
-//! shared file so launchd-managed agents can reach it.
+//! MLX inference sidecar — spawns the bundled `mlx-server` (frozen mlx-vlm,
+//! OpenAI-compatible; serves both text and vision) on an ephemeral port and
+//! publishes its base URL via the shared file so launchd-managed agents can
+//! reach it.
 
 use std::net::TcpListener;
 

--- a/scripts/build-mlx-server.sh
+++ b/scripts/build-mlx-server.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Freeze mlx-lm's OpenAI-compatible server into a single `mlx-server` binary
+# Freeze mlx-vlm's OpenAI-compatible server into a single `mlx-server` binary
 # with the target-triple suffix Tauri expects, placed in src-tauri/binaries/.
 #
-# Requires: python3.11+, pip, pyinstaller, mlx-lm (Apple Silicon).
+# We bundle mlx-vlm (not text-only mlx-lm) because the Hub's media tools need
+# vision: `scene_explain` sends `image_url` content, which mlx_lm.server rejects
+# with `{"error":"Only 'text' content type is supported."}`. mlx_vlm.server serves
+# BOTH text (video_analyze) and vision (scene_explain) on one endpoint, so it is
+# the correct single sidecar. mlx-vlm depends on mlx-lm, so text generation is
+# unchanged.
+#
+# Requires: python3.11+, pip, pyinstaller, mlx-vlm (Apple Silicon).
 
 TRIPLE="${1:-aarch64-apple-darwin}"
 OUT_DIR="mur-hub-gui/src-tauri/binaries"
@@ -13,11 +20,11 @@ python3 -m venv .mlxbuild
 # shellcheck disable=SC1091
 source .mlxbuild/bin/activate
 pip install --upgrade pip
-pip install mlx-lm pyinstaller
+pip install mlx-vlm pyinstaller
 
-# Entry script: launch mlx_lm.server passing through CLI args.
+# Entry script: launch mlx_vlm.server passing through CLI args.
 cat > .mlxbuild/entry.py <<'PY'
-from mlx_lm.server import main
+from mlx_vlm.server import main
 if __name__ == "__main__":
     main()
 PY


### PR DESCRIPTION
## Why
The Hub bundles a frozen `mlx-server` sidecar built from **text-only `mlx-lm`**. But the media tools need vision: `scene_explain` sends `image_url` content, which `mlx_lm.server` rejects:

```
{"error": "Only 'text' content type is supported."}
```

So on a bundled Hub, `scene_explain` — and the proactive co-watching narration that calls it — cannot work at all. (Found during Watch-Together v2 E2E: had to `pip install mlx-vlm` and run `mlx_vlm.server` by hand to exercise vision.)

## Fix
Freeze **`mlx-vlm`** instead. `mlx_vlm.server` serves **both** text (`video_analyze`) and vision (`scene_explain`) on one OpenAI-compatible endpoint, so it's the correct single sidecar. `mlx-vlm` depends on `mlx-lm`, so text generation is unchanged, and the launcher's `--model/--port/--host` flags are accepted as-is.

- `scripts/build-mlx-server.sh`: install `mlx-vlm`, entry `from mlx_vlm.server import main`.
- Fix the now-stale "frozen mlx-lm" doc comment in `mlx_sidecar.rs`.

## Verified locally
`mlx_vlm.server` on this model answers a red-PNG `image_url` with 「紅色」 and a text-only chat with 「哈囉！」 — both text and vision on one endpoint. `from mlx_vlm.server import main` imports and is callable; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)