### PR TITLE
fix(media): re-land review fixes that missed the #380/#381 squash-merge window

### DIFF
--- a/mur-common/src/skill/validate.rs
+++ b/mur-common/src/skill/validate.rs
@@ -174,6 +174,9 @@ fn mode_matches_category(cat: Category, mode: ContentMode) -> bool {
             | (Category::Context, ContentMode::Context)
             | (Category::Meta, ContentMode::Context)
             | (Category::Note, ContentMode::Note)
+            // Media skills carry a `context` body (the when/why prose the agent
+            // reads); there is no dedicated ContentMode::Media.
+            | (Category::Media, ContentMode::Context)
     )
 }
 
@@ -243,6 +246,25 @@ content:
             validate(&m),
             Err(ValidationError::ContentModeMismatch { .. })
         ));
+    }
+
+    #[test]
+    fn media_category_with_context_validates() {
+        // The shipped media skills (video-analyze/scene-explain/vlc-control/
+        // watch-together) declare `category: media` with a `context` body;
+        // validation must accept them so `mur agent skill add` doesn't reject them.
+        let yaml = r#"
+name: video-analyze
+version: 1.0.0
+publisher: human:test
+description: analyze a video
+category: media
+content:
+  abstract: hi
+  context: when and why to use video_analyze
+"#;
+        let m = parse_canonical(yaml).unwrap();
+        validate(&m).expect("media + context should validate");
     }
 
     // ── M6a: mcp_requirements ──

--- a/mur-core/src/cmd/media/scene.rs
+++ b/mur-core/src/cmd/media/scene.rs
@@ -22,13 +22,23 @@ pub fn newest_file(dir: &Path) -> Option<PathBuf> {
     best.map(|(_, p)| p)
 }
 
-/// Like [`newest_file`], but only considers files modified at or after `since`.
-/// Used to require a *freshly captured* snapshot rather than silently falling
-/// back to a stale frame left over from a previous session.
-pub fn newest_file_after(dir: &Path, since: std::time::SystemTime) -> Option<PathBuf> {
-    let path = newest_file(dir)?;
-    let mtime = std::fs::metadata(&path).ok()?.modified().ok()?;
-    (mtime >= since).then_some(path)
+/// Like [`newest_file`], but returns `None` when the newest file equals `exclude`
+/// — the snapshot that already existed before a capture was requested. This
+/// requires a *freshly captured* frame rather than silently falling back to a
+/// stale snapshot from a previous session.
+///
+/// VLC names each snapshot uniquely (`vlcsnap-<timestamp>.png`), so "the newest
+/// file is a different path than the pre-capture one" is a reliable freshness
+/// signal that is independent of filesystem mtime granularity. (Comparing a file
+/// mtime against a wall-clock `SystemTime::now()` would spuriously reject genuinely
+/// fresh frames on coarse-mtime volumes — HFS+/exFAT/FAT/network mounts floor mtime
+/// to whole seconds, below a sub-second `now()`.)
+pub fn newest_file_excluding(dir: &Path, exclude: Option<&Path>) -> Option<PathBuf> {
+    let newest = newest_file(dir)?;
+    match exclude {
+        Some(prev) if newest == prev => None,
+        _ => Some(newest),
+    }
 }
 
 #[cfg(test)]
@@ -55,24 +65,40 @@ mod tests {
     }
 
     #[test]
-    fn newest_file_after_rejects_stale_and_accepts_fresh() {
+    fn newest_file_excluding_rejects_stale_and_accepts_fresh() {
         let dir = TempDir::new().unwrap();
-        // A stale snapshot left from "before".
+        // A stale snapshot left from a prior session.
         std::fs::write(dir.path().join("stale.png"), b"old").unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        // The capture boundary.
-        let since = std::time::SystemTime::now();
-        // Nothing newer than `since` yet → no fresh frame.
-        assert!(newest_file_after(dir.path(), since).is_none());
-        // A freshly captured snapshot lands after `since`.
+        let baseline = newest_file(dir.path());
+        assert_eq!(
+            baseline.as_deref().unwrap().file_name().unwrap(),
+            "stale.png"
+        );
+        // The newest file is still the baseline → no fresh frame yet.
+        assert!(newest_file_excluding(dir.path(), baseline.as_deref()).is_none());
+        // A freshly captured (uniquely-named) snapshot lands.
         std::thread::sleep(std::time::Duration::from_millis(20));
         std::fs::write(dir.path().join("fresh.png"), b"new").unwrap();
         assert_eq!(
-            newest_file_after(dir.path(), since)
+            newest_file_excluding(dir.path(), baseline.as_deref())
                 .unwrap()
                 .file_name()
                 .unwrap(),
             "fresh.png"
+        );
+    }
+
+    #[test]
+    fn newest_file_excluding_empty_baseline_accepts_any() {
+        let dir = TempDir::new().unwrap();
+        // No prior snapshot; first capture is always fresh.
+        std::fs::write(dir.path().join("first.png"), b"x").unwrap();
+        assert_eq!(
+            newest_file_excluding(dir.path(), None)
+                .unwrap()
+                .file_name()
+                .unwrap(),
+            "first.png"
         );
     }
 }
@@ -168,15 +194,16 @@ pub async fn explain(prompt: Option<&str>) -> Result<String> {
 
     // 1. Ensure VLC is up and take a snapshot.
     let rt = super::vlc::ensure_for_snapshot(client).await?;
-    // Mark the instant before requesting the snapshot so we can require a frame
-    // captured *after* this call — never an older snapshot from a prior session.
-    let since = std::time::SystemTime::now();
+    // Record the pre-capture snapshot so we can require a *newer* (differently
+    // named) frame — never an older snapshot from a prior session. Path-based so
+    // it's robust to filesystem mtime granularity (see `newest_file_excluding`).
+    let baseline = newest_file(&rt.snapshot_dir);
     super::vlc::snapshot_command(&rt, client).await?;
 
     // 2. Read the newest snapshot file (retry briefly for the file to land).
     let mut img_path = None;
     for i in 0..10 {
-        if let Some(p) = newest_file_after(&rt.snapshot_dir, since) {
+        if let Some(p) = newest_file_excluding(&rt.snapshot_dir, baseline.as_deref()) {
             img_path = Some(p);
             break;
         }
@@ -205,7 +232,7 @@ pub async fn explain(prompt: Option<&str>) -> Result<String> {
         Ok(b) => b,
         Err(_) => {
             tokio::time::sleep(Duration::from_millis(300)).await;
-            let retry = newest_file_after(&rt.snapshot_dir, since)
+            let retry = newest_file_excluding(&rt.snapshot_dir, baseline.as_deref())
                 .context("no snapshot (file vanished and no replacement found)")?;
             std::fs::read(&retry).context("read snapshot")?
         }

--- a/mur-core/src/cmd/media/vlc.rs
+++ b/mur-core/src/cmd/media/vlc.rs
@@ -57,25 +57,37 @@ pub fn parse_status_xml(xml: &str) -> VlcStatus {
     let mut volume = 0i64;
     let mut buf = Vec::new();
     let mut in_tag = String::new();
+    // Element depth: <root> is depth 1, so the top-level playback fields' text
+    // sits at depth 2. Gating on this prevents identically-named tags nested
+    // deeper in VLC's <information>/<stats> subtrees from clobbering the real
+    // top-level values.
+    let mut depth = 0i32;
 
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref e)) => {
+                depth += 1;
                 in_tag = String::from_utf8_lossy(e.name().as_ref()).into_owned();
             }
             // Clear the active tag when it closes. Without this, the pretty-printed
             // whitespace VLC emits *after* `</state>` arrives as a Text event while
             // `in_tag` is still "state" and clobbers the value (e.g. state == "\n").
             Ok(Event::End(_)) => {
+                depth -= 1;
                 in_tag.clear();
             }
-            Ok(Event::Text(ref e)) => {
+            // Self-closing element (e.g. `<state/>`): no text to read; just reset
+            // the active tag so a later Text isn't attributed to it.
+            Ok(Event::Empty(_)) => {
+                in_tag.clear();
+            }
+            Ok(Event::Text(ref e)) if depth == 2 => {
                 let text = e.unescape().unwrap_or_default().to_string();
                 match in_tag.as_str() {
                     "state" => state = text,
-                    "time" => time = text.parse().unwrap_or(0),
-                    "length" => length = text.parse().unwrap_or(0),
-                    "volume" => volume = text.parse().unwrap_or(0),
+                    "time" => time = text.trim().parse().unwrap_or(0),
+                    "length" => length = text.trim().parse().unwrap_or(0),
+                    "volume" => volume = text.trim().parse().unwrap_or(0),
                     _ => {}
                 }
             }
@@ -131,6 +143,26 @@ mod tests {
         assert_eq!(s.time, 42);
         assert_eq!(s.length, 3600);
         assert_eq!(s.volume, 256);
+    }
+
+    #[test]
+    fn parse_status_ignores_nested_same_named_tags() {
+        // VLC's <information>/<stats> subtree can carry tags named like the
+        // top-level fields; nested occurrences (depth > 2) must NOT clobber the
+        // real top-level values.
+        let xml = "<root>\n\
+            \x20 <state>playing</state>\n\
+            \x20 <length>3600</length>\n\
+            \x20 <information>\n\
+            \x20   <category name=\"meta\">\n\
+            \x20     <length>0</length>\n\
+            \x20     <state>stopped</state>\n\
+            \x20   </category>\n\
+            \x20 </information>\n\
+            </root>";
+        let s = parse_status_xml(xml);
+        assert_eq!(s.state, "playing");
+        assert_eq!(s.length, 3600);
     }
 }
 
@@ -244,10 +276,12 @@ pub async fn open(source: &str) -> Result<VlcStatus> {
     let _ = super::resolve::save_last_source(&home, source);
     let rt = ensure_vlc_running(&home, client).await?;
     let status = send_command(&rt, client, "in_play", &[("input", source)]).await?;
-    // `in_play` enqueues and *should* autoplay, but on a freshly-launched VLC it
-    // can land in `stopped`. Nudge it into playback so callers (and especially
-    // `scene_explain`, which snapshots the current frame) have a live frame.
-    if status.state != "playing" {
+    // `in_play` enqueues and *should* autoplay, but a freshly-launched VLC can
+    // land in `stopped`. Nudge it into playback ONLY from a genuinely idle state
+    // — not from `paused` (the user paused), `opening`/`buffering` (already
+    // progressing), or `playing` — so we don't fight a transient state or
+    // override an intentional pause. `pl_play` resumes the just-enqueued item.
+    if matches!(status.state.as_str(), "stopped" | "") {
         return send_command(&rt, client, "pl_play", &[]).await;
     }
     Ok(status)

--- a/mur-core/src/retrieve/skill_candidates.rs
+++ b/mur-core/src/retrieve/skill_candidates.rs
@@ -40,7 +40,12 @@ impl LoadedSkill {
             | mur_common::skill::types::Category::Note => KindGroup::Knowledge,
             mur_common::skill::types::Category::Workflow => KindGroup::Procedures,
             mur_common::skill::types::Category::Command => KindGroup::Procedures,
-            // Media skills drive the runtime's media tools — procedure-like.
+            // `KindGroup` is a *formatting* taxonomy (it only selects the injected
+            // section header + entry formatter), not a domain taxonomy. A media
+            // skill injects as procedural guidance ("to analyze a video, use
+            // video_analyze when…"), so it belongs under Procedures. We deliberately
+            // do NOT add a `KindGroup::Media`: that would push a domain label into a
+            // formatting enum (the same altitude mistake as a media-specific Category).
             mur_common::skill::types::Category::Media => KindGroup::Procedures,
         };
         InjectedItem {


### PR DESCRIPTION
PRs #380 and #381 were squash-merged **before** their code-review follow-up commits were pushed, so three reviewed fixes never reached `main`. This re-lands them (cherry-picked verbatim). #382's fs_write fix and #383 did make it in; #384 is still open.

### From the #380 review (skill category)
- **`validate()` must accept `category: media`** — the merged #380 added `Category::Media` to the enum + the compiler-checked match, but `mode_matches_category()` (a boolean `matches!`) had no Media arm, so `validate()` rejects every media skill with `ContentModeMismatch`. **This is currently broken in main**: `mur agent skill add <media-skill>`, notes, and install/publish validators all fail. Adds `(Category::Media, ContentMode::Context)` + test.
- Doc: why `Category::Media → KindGroup::Procedures` and why *not* a `KindGroup::Media` (formatting vs domain taxonomy).

### From the #381 review (VLC/scene)
- **Granularity-free freshness**: replace wall-clock `newest_file_after(dir, since)` with path-based `newest_file_excluding(dir, baseline)` — comparing a file mtime to a sub-second `now()` spuriously rejected fresh frames on coarse-mtime volumes (HFS+/exFAT/network).
- **parse_status_xml**: depth-gate the playback fields (only direct children of `<root>`) + handle `Event::Empty` + trim numeric fields, so nested same-named tags in VLC's `<information>`/`<stats>` can't clobber the top-level values.
- **open()**: nudge `pl_play` only from a genuinely idle state (`stopped`/empty), not from `paused`/`opening`/`buffering`.

## Test
mur-common skill::validate (incl. `media_category_with_context_validates`) + mur-core media (37 tests, incl. `parse_status_ignores_nested_same_named_tags`, `newest_file_excluding_*`). clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)