### PR TITLE
fix(media): code-review follow-ups to #382/#383 (Landlock dir grant, mlx-vlm freeze robustness)

### DIFF
--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -298,10 +298,10 @@ mod tests {
         let agent_home = PathBuf::from("/tmp/a");
         let mut policy = SandboxPolicy::from_entitlements(&ent, &agent_home);
         let extra = PathBuf::from("/home/u/.mur/runtime/vlc-snapshots");
-        policy.allow_extra_write_paths(&[extra.clone()]);
+        policy.allow_extra_write_paths(std::slice::from_ref(&extra));
         assert!(policy.fs_write.contains(&extra));
         // Idempotent — re-adding doesn't duplicate.
-        policy.allow_extra_write_paths(&[extra.clone()]);
+        policy.allow_extra_write_paths(std::slice::from_ref(&extra));
         assert_eq!(policy.fs_write.iter().filter(|p| **p == extra).count(), 1);
     }
 }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -196,29 +196,38 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         crate::supervisor_runner::local_llm_port(&profile.inner, &mur_home)
             .into_iter()
             .collect();
-    // Also allow the persisted VLC HTTP port so the proactive co-watching
-    // WatchScheduler can snapshot VLC under the enforced sandbox. The macOS SBPL
-    // (and Landlock) allowlist is port-based, and the VLC port is random-but-sticky
-    // in vlc.json — so without this the scheduler's HTTP to VLC is kernel-denied
-    // and co-watching silently captures nothing. If VLC has never been set up,
-    // vlc.json is absent at seal time; a restart picks the port up once it exists.
-    // The scheduler also persists co-watching state and prunes snapshots under
-    // the shared `~/.mur/runtime` dir (outside agent_home), so allow writing
-    // those specific paths — otherwise consent/last_scene never persist and
-    // snapshots accumulate (B5). watch.json is written via temp+rename, so allow
-    // the `.tmp` sibling too.
+    // Also allow the persisted VLC HTTP port + the shared runtime-state directory
+    // so the proactive co-watching WatchScheduler can operate under the enforced
+    // sandbox. Gated on co-watching being set up (vlc.json present): a non-media
+    // agent keeps its narrower sandbox rather than being widened to a shared,
+    // cross-agent state file it never uses. The VLC port (port-based allowlist on
+    // both SBPL and Landlock NetPort) is random-but-sticky in vlc.json, so if VLC
+    // has never been set up vlc.json is absent at seal time and a restart picks it
+    // up once it exists.
+    //
+    // We grant the WHOLE `~/.mur/runtime` directory (a sibling of agent_home), not
+    // the individual files. The scheduler reads vlc.json, prunes snapshots, and
+    // persists watch.json via temp-file + rename. Under Landlock a temp create +
+    // rename needs directory-level rights (MAKE_REG/REFER) on the *parent* that a
+    // per-file grant cannot confer, and path-beneath rules are silently skipped for
+    // paths that don't exist at seal time (watch.json.tmp is transient). Granting
+    // the existing directory is both necessary and sufficient on Landlock and
+    // matches the macOS SBPL subpath grant — so co-watching works on both kernels,
+    // not just macOS. (We create the dir first so the Landlock rule sticks.)
     let mut extra_write_paths: Vec<std::path::PathBuf> = Vec::new();
     if let Some(vlc) = mur_common::media::load_runtime(&mur_home) {
         extra_ports.push(vlc.port);
+        let runtime_dir = mur_common::media::runtime_dir(&mur_home);
+        let _ = std::fs::create_dir_all(&runtime_dir);
+        extra_write_paths.push(runtime_dir);
+        // snapshot_dir normally lives under runtime/, but vlc.json may point it
+        // elsewhere — grant it explicitly so snapshot read/prune works regardless.
         extra_write_paths.push(vlc.snapshot_dir.clone());
         tracing::info!(
             vlc_port = vlc.port,
-            "B1 sandbox: allowing VLC HTTP port for co-watching"
+            "B1 sandbox: allowing VLC HTTP port + runtime dir for co-watching"
         );
     }
-    let watch_json = mur_common::media::watch_path(&mur_home);
-    extra_write_paths.push(watch_json.with_extension("json.tmp"));
-    extra_write_paths.push(watch_json);
     match crate::sandbox::apply(
         &profile.inner.entitlements,
         &agent_home,

--- a/mur-agent-runtime/src/watch_scheduler.rs
+++ b/mur-agent-runtime/src/watch_scheduler.rs
@@ -155,7 +155,7 @@ use crate::task_runner::{TaskRunner, TaskSpec};
 use chrono::{Local, Timelike};
 use mur_common::a2a::{Message, MessagePart};
 use mur_common::agent::QuietHours;
-use mur_common::media::{VlcRuntime, load_watch, newest_file, runtime_path, save_watch};
+use mur_common::media::{VlcRuntime, load_runtime, load_watch, newest_file, save_watch};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -202,12 +202,6 @@ impl WatchScheduler {
             run_loop(self, cancel).await;
         })
     }
-}
-
-/// Read VLC runtime config, if present.
-fn vlc_runtime(mur_home: &std::path::Path) -> Option<VlcRuntime> {
-    let body = std::fs::read_to_string(runtime_path(mur_home)).ok()?;
-    serde_json::from_str(&body).ok()
 }
 
 /// Ask VLC for a snapshot, read the resulting PNG, delete it, and return its bytes.
@@ -327,7 +321,7 @@ async fn run_loop(s: WatchScheduler, cancel: CancellationToken) {
         if !session.active {
             continue;
         }
-        let Some(rt) = vlc_runtime(&s.mur_home) else {
+        let Some(rt) = load_runtime(&s.mur_home) else {
             continue;
         };
         let Some(png) = capture_png(&rt, &client).await else {
@@ -383,6 +377,11 @@ async fn run_loop(s: WatchScheduler, cancel: CancellationToken) {
             _ => {}
         }
         fresh.last_scene_phash = hash; // always track the latest frame
-        let _ = save_watch(&s.mur_home, &fresh);
+        if let Err(e) = save_watch(&s.mur_home, &fresh) {
+            // Persisting consent/cooldown/last_scene matters: a silent failure here
+            // makes the scheduler re-ask consent and re-narrate every tick. Surface
+            // it (e.g. a sandbox denial or full disk) rather than swallowing.
+            tracing::warn!(error = %e, "watch: failed to persist co-watching session");
+        }
     }
 }

--- a/mur-agent-runtime/tests/sandbox_e2e.rs
+++ b/mur-agent-runtime/tests/sandbox_e2e.rs
@@ -190,6 +190,81 @@ fn sandbox_write_deny_subprocess_main() {
     }
 }
 
+/// Inverse of the deny test: a directory passed via `extra_write_paths` (the
+/// `~/.mur/runtime` grant for co-watching) must actually permit the temp-file
+/// create + rename that `save_watch` does AND the unlink that snapshot-pruning
+/// does. Under Landlock a per-file grant cannot do this (creating/renaming needs
+/// directory-level MAKE_REG/REFER on the parent); only a directory grant can — so
+/// this guards the #382 follow-up fix. Runs in a subprocess so `restrict_self()`
+/// doesn't lock the test process. On macOS `/tmp` is write-exempt so the ops pass
+/// trivially; the load-bearing assertion is on Linux, where `/tmp` is default-denied
+/// and only the directory grant makes the writes succeed.
+#[test]
+#[cfg(unix)]
+fn sandbox_allows_granted_extra_write_dir() {
+    let exe = std::env::current_exe().unwrap();
+    let status = std::process::Command::new(&exe)
+        .env("MUR_TEST_SANDBOX_WRITE_ALLOW", "1")
+        .env_remove("MUR_AGENT_SKIP_SANDBOX")
+        .status()
+        .unwrap();
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "granted runtime dir must allow temp+rename+unlink under the sandbox"
+    );
+}
+
+/// Subprocess entry point for `sandbox_allows_granted_extra_write_dir`.
+#[cfg(unix)]
+#[ctor::ctor]
+fn sandbox_write_allow_subprocess_main() {
+    if std::env::var_os("MUR_TEST_SANDBOX_WRITE_ALLOW").is_none() {
+        return;
+    }
+    use mur_agent_runtime::sandbox;
+    use mur_common::agent::AgentProfile;
+
+    let profile = AgentProfile::default_for_tests();
+    let agent_home = std::path::PathBuf::from("/tmp/b1_test_allow_home");
+    std::fs::create_dir_all(&agent_home).unwrap();
+
+    // Granted directory standing in for `~/.mur/runtime`. Created before sealing so
+    // the Landlock path-beneath rule sticks; passed via `extra_write_paths`.
+    let runtime_dir = std::path::PathBuf::from("/tmp/b1_test_allow_runtime");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+
+    if sandbox::apply(
+        &profile.entitlements,
+        &agent_home,
+        &[],
+        std::slice::from_ref(&runtime_dir),
+    )
+    .is_err()
+    {
+        // Sandbox apply failed (e.g., no kernel support) — treat as pass.
+        std::process::exit(0);
+    }
+
+    // Mimic save_watch (temp write + rename) and snapshot prune (unlink) inside the
+    // granted dir — exactly the operations a per-file grant breaks under Landlock.
+    let target = runtime_dir.join("watch.json");
+    let tmp = runtime_dir.join("watch.json.tmp");
+    let snap = runtime_dir.join("snap.png");
+    let ok = std::fs::write(&tmp, b"{}").is_ok()
+        && std::fs::rename(&tmp, &target).is_ok()
+        && std::fs::write(&snap, b"x").is_ok()
+        && std::fs::remove_file(&snap).is_ok();
+    std::fs::remove_file(&target).ok();
+
+    if ok {
+        std::process::exit(0);
+    } else {
+        eprintln!("ERROR: granted runtime dir did NOT allow temp+rename+unlink");
+        std::process::exit(1);
+    }
+}
+
 /// Verify that the Landlock layer compiles and SandboxPolicy paths are all absolute.
 /// Does NOT call restrict_self() to avoid locking the test process.
 #[test]

--- a/mur-common/src/media.rs
+++ b/mur-common/src/media.rs
@@ -16,9 +16,17 @@ pub struct VlcRuntime {
     pub snapshot_dir: PathBuf,
 }
 
+/// The shared runtime state directory (`~/.mur/runtime`). Holds `vlc.json`,
+/// `watch.json`, and the VLC snapshot dir — all owned by the runtime and lying
+/// outside any single agent's home, so the sandbox must grant this directory
+/// (not the individual files) for co-watching to work under enforced confinement.
+pub fn runtime_dir(mur_home: &Path) -> PathBuf {
+    mur_home.join("runtime")
+}
+
 /// Path to the persisted VLC runtime config.
 pub fn runtime_path(mur_home: &Path) -> PathBuf {
-    mur_home.join("runtime").join("vlc.json")
+    runtime_dir(mur_home).join("vlc.json")
 }
 
 /// Load the persisted VLC runtime (`vlc.json`), or `None` if absent/unparseable.
@@ -147,6 +155,12 @@ mod tests {
     fn runtime_path_under_runtime_dir() {
         let p = runtime_path(Path::new("/tmp/h"));
         assert!(p.ends_with("runtime/vlc.json"));
+        // vlc.json, watch.json and the dir grant must agree on the same parent.
+        assert_eq!(p.parent().unwrap(), runtime_dir(Path::new("/tmp/h")));
+        assert_eq!(
+            watch_path(Path::new("/tmp/h")).parent().unwrap(),
+            runtime_dir(Path::new("/tmp/h"))
+        );
     }
 
     #[test]
@@ -258,7 +272,7 @@ pub struct WatchSession {
 
 /// Path to the persisted watch session.
 pub fn watch_path(mur_home: &Path) -> PathBuf {
-    mur_home.join("runtime").join("watch.json")
+    runtime_dir(mur_home).join("watch.json")
 }
 
 /// Load the watch session, or a default (all-off) session if absent/unparseable.

--- a/mur-hub-gui/src-tauri/src/mlx_sidecar.rs
+++ b/mur-hub-gui/src-tauri/src/mlx_sidecar.rs
@@ -4,6 +4,7 @@
 //! reach it.
 
 use std::net::TcpListener;
+use std::time::Duration;
 
 /// Reserve a free localhost TCP port by binding to :0 and reading the assigned
 /// port. The listener is dropped immediately; a tiny race window exists before
@@ -77,16 +78,26 @@ pub fn start(app: &AppHandle) {
         }
     };
 
-    // Publish base URL for launchd-managed agents (Task 1 helper).
     let mur_home = crate::mur_home_path();
-    if let Err(e) = mur_common::local_llm::write_base_url(&mur_home, &base_url(port)) {
-        warn!("mlx sidecar: failed to write base url: {e}");
-    }
+
+    // The bundled model dir must be valid UTF-8 to pass as a CLI arg. Fail soft
+    // (matching the is_dir() guard above) rather than spawning with `--model ""`,
+    // which would be a silent misconfiguration that's hard to diagnose downstream.
+    let model_arg = match model_dir.to_str() {
+        Some(s) => s.to_string(),
+        None => {
+            warn!(
+                "mlx sidecar: model path is not valid UTF-8 ({}); skipping local inference",
+                model_dir.display()
+            );
+            return;
+        }
+    };
 
     let cmd = app.shell().sidecar("mlx-server").map(|c| {
         c.args([
             "--model",
-            model_dir.to_str().unwrap_or_default(),
+            &model_arg,
             "--host",
             "127.0.0.1",
             "--port",
@@ -103,7 +114,8 @@ pub fn start(app: &AppHandle) {
 
     match cmd.spawn() {
         Ok((mut rx, _child)) => {
-            info!(port, "mlx sidecar spawned");
+            info!(port, "mlx sidecar spawned; waiting for readiness");
+            // Stream the sidecar's stderr to our logs.
             tauri::async_runtime::spawn(async move {
                 while let Some(ev) = rx.recv().await {
                     if let CommandEvent::Stderr(line) = ev {
@@ -111,8 +123,55 @@ pub fn start(app: &AppHandle) {
                     }
                 }
             });
+            // Publish the base URL only once the server actually accepts
+            // connections. uvicorn binds/accepts only AFTER its lifespan startup
+            // (which loads the model) succeeds, so a successful connect is a true
+            // readiness signal — and if the frozen binary crashes during model
+            // load it never accepts, so we never publish a dead URL that agents
+            // would fall against with no fallback.
+            tauri::async_runtime::spawn(async move {
+                if wait_until_ready(port, MLX_READINESS_TIMEOUT).await {
+                    match mur_common::local_llm::write_base_url(&mur_home, &base_url(port)) {
+                        Ok(()) => info!(port, "mlx sidecar ready; base url published"),
+                        Err(e) => warn!("mlx sidecar: failed to write base url: {e}"),
+                    }
+                } else {
+                    warn!(
+                        port,
+                        "mlx sidecar did not accept connections within timeout; \
+                         not publishing base url (agents fall back to echo/cloud)"
+                    );
+                }
+            });
         }
         Err(e) => warn!("mlx sidecar: spawn failed: {e}"),
+    }
+}
+
+/// How long to wait for the sidecar to start accepting connections before
+/// giving up and leaving the base URL unpublished.
+const MLX_READINESS_TIMEOUT: Duration = Duration::from_secs(180);
+/// Interval between readiness probes.
+const MLX_READINESS_POLL: Duration = Duration::from_millis(500);
+
+/// Poll until the sidecar accepts a TCP connection on `port`, or `timeout`
+/// elapses (returns false). uvicorn only begins accepting connections after its
+/// lifespan startup — which loads the model — completes, so a successful connect
+/// doubles as a model-ready signal.
+async fn wait_until_ready(port: u16, timeout: Duration) -> bool {
+    use tokio::net::TcpStream;
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if TcpStream::connect((std::net::Ipv4Addr::LOCALHOST, port))
+            .await
+            .is_ok()
+        {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(MLX_READINESS_POLL).await;
     }
 }
 

--- a/scripts/build-mlx-server.sh
+++ b/scripts/build-mlx-server.sh
@@ -16,11 +16,17 @@ TRIPLE="${1:-aarch64-apple-darwin}"
 OUT_DIR="mur-hub-gui/src-tauri/binaries"
 mkdir -p "$OUT_DIR"
 
+# Pin mlx-vlm for reproducible release builds. The pinned version MUST support the
+# bundled model's architecture (the `model_type` in resources/models/default/
+# config.json) — a too-old mlx-vlm raises `ValueError: Model type <t> not supported`
+# at load. Bump this alongside the bundled model; override for local experiments.
+MLX_VLM_VERSION="${MLX_VLM_VERSION:-0.6.2}"
+
 python3 -m venv .mlxbuild
 # shellcheck disable=SC1091
 source .mlxbuild/bin/activate
 pip install --upgrade pip
-pip install mlx-vlm pyinstaller
+pip install "mlx-vlm==${MLX_VLM_VERSION}" pyinstaller
 
 # Entry script: launch mlx_vlm.server passing through CLI args.
 cat > .mlxbuild/entry.py <<'PY'
@@ -29,8 +35,28 @@ if __name__ == "__main__":
     main()
 PY
 
+# mlx-vlm selects the model implementation at runtime via
+# `importlib.import_module(f"mlx_vlm.models.{model_type}")`, and transformers loads
+# processor/tokenizer classes (e.g. the bundled Qwen image processor) dynamically by
+# name. PyInstaller's static analysis cannot see these, so without --collect-all the
+# frozen binary builds clean but dies at model load with ModuleNotFoundError. Collect
+# every submodule + data file (and metadata, which transformers reads at import) for
+# the dynamic-import packages. --copy-metadata is required because transformers does
+# importlib.metadata.version() checks on itself and its deps at import time.
 pyinstaller --onefile --name mlx-server .mlxbuild/entry.py \
+  --collect-all mlx_vlm \
+  --collect-all mlx_lm \
+  --collect-all transformers \
+  --copy-metadata transformers \
+  --copy-metadata mlx-vlm \
+  --copy-metadata mlx-lm \
   --distpath "$OUT_DIR-dist"
+
+# Smoke-check that the frozen binary at least imports and runs (catches gross
+# PyInstaller breakage). A full model-load smoke needs the bundled model and is
+# done in the E2E harness, not here.
+"$OUT_DIR-dist/mlx-server" --help >/dev/null 2>&1 \
+  || echo "WARN: frozen mlx-server --help failed; check PyInstaller collection" >&2
 mv "$OUT_DIR-dist/mlx-server" "$OUT_DIR/mlx-server-$TRIPLE"
 chmod +x "$OUT_DIR/mlx-server-$TRIPLE"
 echo "Built $OUT_DIR/mlx-server-$TRIPLE"


### PR DESCRIPTION
Code-review follow-ups to the merged #382 (sandbox VLC allowlist) and #383 (bundle mlx-vlm). Addresses all 13 findings from `/code-review max`.

## PR #382 — Linux/Landlock correctness + altitude
The merged fix granted **individual files** in `~/.mur/runtime`. Under Landlock that is broken: a per-file grant cannot create+rename a temp file (needs `MAKE_REG`/`REFER` on the parent dir) and `path_beneath_rules` silently skips paths absent at seal time (`watch.json.tmp` is transient). So the co-watching scheduler's `vlc.json` read, `save_watch` temp+rename, and snapshot prune were all kernel-denied on Linux (macOS SBPL subpath happened to work).

- **Grant the whole `~/.mur/runtime` directory** (created before seal so the Landlock rule sticks) — fixes the read/temp-rename/prune denials at once and removes the `.tmp` suffix coupling between supervisor and `save_watch`.
- **Gate the grant on `vlc.json` presence** so non-media agents keep a narrower sandbox instead of being widened to the shared, cross-agent `watch.json`.
- **Dedup** `vlc_runtime` → `mur_common::media::load_runtime`; add `media::runtime_dir()`.
- **Log `save_watch` failures** instead of swallowing (silent failure = repeated consent prompts / narration every tick).
- **New enforcing-sandbox integration test** exercising temp+rename+unlink in a granted dir (subprocess, mirrors the deny test).

## PR #383 — frozen-binary robustness + publish timing
- **PyInstaller `--collect-all mlx_vlm/mlx_lm/transformers` + `--copy-metadata`** so the dynamically-imported model module (`importlib.import_module(f"mlx_vlm.models.{model_type}")`) and transformers processor classes are bundled — otherwise `--onefile` builds clean but crashes at model load, killing **all** local inference. **Pin `mlx-vlm`** (env-overridable `MLX_VLM_VERSION`) for reproducible builds; add a `--help` smoke check.
- **Publish the sidecar base URL only after readiness** (TCP-connect poll; uvicorn accepts only after the lifespan model-load completes), so a load failure no longer leaves agents pointed at a dead port with no fallback.
- **Fail soft on a non-UTF-8 model path** instead of spawning with `--model ""`.

## Verification
- `cargo check` (mur-common, mur-agent-runtime, **mur-hub-gui src-tauri**, all targets) ✅
- `cargo test`: media (10), policy + watch_scheduler (18), sandbox_e2e incl. new test ✅
- `cargo clippy -p mur-agent-runtime --all-targets -D warnings` ✅ and hub-gui clippy ✅

## Notes / assumptions
- `MLX_VLM_VERSION` defaults to `0.6.2` (confirmed to support the bundled `qwen3_5` arch + the `--model/--host/--port` CLI). Confirm on the release builder or override.
- Pre-existing clippy-1.95 lints in `mur-common` (`reader.rs`, `stats.rs`) are out of scope (present on `main`, unrelated to these PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)