### PR TITLE
fix(media): stop vlc_open racing VLC's async item-open with a premature pl_play

### DIFF
--- a/mur-core/src/cmd/media/vlc.rs
+++ b/mur-core/src/cmd/media/vlc.rs
@@ -8,6 +8,15 @@ use std::time::Duration;
 /// Default macOS VLC binary path.
 const DEFAULT_VLC_PATH: &str = "/Applications/VLC.app/Contents/MacOS/VLC";
 
+/// After `in_play`, VLC autoplays asynchronously: the command's own status response
+/// can still read `stopped` before the item-open state machine reaches `playing`.
+/// Firing the `pl_play` nudge in that window races VLC's open and can leave playback
+/// stopped (flaky, timing-dependent). So when the immediate state is idle we poll the
+/// status a few times — giving in_play's autoplay a chance — and only nudge if it is
+/// *still* idle (the genuine freshly-launched-VLC case the nudge exists for).
+const AUTOPLAY_GRACE_POLLS: u32 = 6;
+const AUTOPLAY_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
 /// Locate VLC binary: env override `MUR_VLC_PATH`, else default path.
 pub fn detect_vlc() -> Option<PathBuf> {
     if let Some(p) = std::env::var_os("MUR_VLC_PATH") {
@@ -171,12 +180,21 @@ pub async fn open(source: &str) -> Result<VlcStatus> {
     let _ = super::resolve::save_last_source(&home, source);
     let rt = ensure_vlc_running(&home, client).await?;
     let status = send_command(&rt, client, "in_play", &[("input", source)]).await?;
-    // `in_play` enqueues and *should* autoplay, but a freshly-launched VLC can
-    // land in `stopped`. Nudge it into playback ONLY from a genuinely idle state
-    // — not from `paused` (the user paused), `opening`/`buffering` (already
-    // progressing), or `playing` — so we don't fight a transient state or
-    // override an intentional pause. `pl_play` resumes the just-enqueued item.
+    // `in_play` enqueues and *should* autoplay, but its immediate status response can
+    // still read `stopped` before VLC's asynchronous item-open reaches `playing`, and a
+    // freshly-launched VLC can land in `stopped` for real. Nudge ONLY from a genuinely
+    // idle state — not `paused` (user paused), `opening`/`buffering` (already
+    // progressing), or `playing`. To avoid racing the item-open (a premature `pl_play`
+    // can leave playback stopped — flaky and timing-dependent), first give in_play's own
+    // autoplay a brief grace window, polling the status; only nudge if still idle after.
     if matches!(status.state.as_str(), "stopped" | "") {
+        for _ in 0..AUTOPLAY_GRACE_POLLS {
+            tokio::time::sleep(AUTOPLAY_POLL_INTERVAL).await;
+            let s = get_status(&rt, client).await?;
+            if !matches!(s.state.as_str(), "stopped" | "") {
+                return Ok(s); // in_play autoplayed on its own — no nudge needed
+            }
+        }
         return send_command(&rt, client, "pl_play", &[]).await;
     }
     Ok(status)


### PR DESCRIPTION
## Problem

`media::vlc::open()` reads VLC's status **once** immediately after `in_play` and, if it sees `stopped`/``, fires a `pl_play` nudge (added in #381 for freshly-launched VLC). But `in_play` autoplays **asynchronously** — the command's own status response often still reads `stopped` before VLC's item-open state machine reaches `playing`. Firing `pl_play` in that window **races VLC's open and can leave playback stopped**.

This is flaky and timing-dependent: it reproduced reliably only inside the long-lived `mur-mcp-server` process; raw `curl` / fresh processes usually dodged the bad window — which is why manual testing appeared to "work".

User-visible impact: opening a video via this path (e.g. the Hub / watch-together) could see playback stop immediately/flakily. `scene_explain` / `video_analyze` are unaffected (snapshot / captions).

## Diagnosis

Proxied the VLC HTTP port and diffed full request headers between a run that **stopped** (mcp-server) and one that **sustained** (standalone): both sent byte-identical `probe → in_play → pl_play` ~22 ms apart on one keep-alive connection — **same bytes, same timing, different outcome** ⇒ the race is inside VLC, triggered by the premature nudge, not anything client-side.

## Fix

When `in_play`'s immediate state is idle, give its own autoplay a brief grace window — poll status up to `AUTOPLAY_GRACE_POLLS (6) × AUTOPLAY_POLL_INTERVAL (100 ms)` — and only nudge `pl_play` if it is **still** idle. This preserves the freshly-launched-VLC nudge from #381 while removing the race. The grace loop returns early the instant playback is observed, so the common warm-VLC path adds ~100–200 ms at most.

## Verification

- Drove the **fixed** `mur-mcp-server` binary as a real mcp-server process via JSON-RPC (`initialize` → 5× `tools/call vlc_open` against a warm VLC) → **5/5 sustained playback** (the exact long-lived-process condition where the bug reproduced).
- Via a mur-core example calling the real `open()`: **8/8** opens sustain, with **zero** `pl_play` sent once `in_play` autoplays (race eliminated at the request level).
- `cargo test -p mur-core --lib media` → 33 passed; `cargo fmt --check` + `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)