### PR TITLE
fix(runtime): complete MCP initialize handshake so all MCP tools connect

### DIFF
--- a/mur-agent-runtime/src/protocol/mcp_client.rs
+++ b/mur-agent-runtime/src/protocol/mcp_client.rs
@@ -84,6 +84,17 @@ impl McpClient {
         self.stderr.lock().await.take()
     }
 
+    /// Send a JSON-RPC *notification* (no `id`, no response expected).
+    /// Used for the MCP lifecycle `notifications/initialized` handshake step.
+    async fn notify(&self, method: &str, params: Value) -> Result<(), McpError> {
+        let req = json!({"jsonrpc": "2.0", "method": method, "params": params});
+        let line = format!("{req}\n");
+        let mut s = self.stdin.lock().await;
+        s.write_all(line.as_bytes()).await?;
+        s.flush().await?;
+        Ok(())
+    }
+
     async fn request(&self, method: &str, params: Value) -> Result<Value, McpError> {
         let id = {
             let mut g = self.next_id.lock().await;
@@ -124,6 +135,11 @@ impl McpClient {
                 }),
             )
             .await?;
+        // MCP lifecycle step 3: the client MUST send `notifications/initialized`
+        // after the `initialize` response, otherwise spec-compliant servers
+        // reject every subsequent request (`tools/list`, `tools/call`) with
+        // "Not initialized". Universal — required by all MCP servers, not just ours.
+        self.notify("notifications/initialized", json!({})).await?;
         Ok(InitializeInfo {
             server_name: res["serverInfo"]["name"]
                 .as_str()


### PR DESCRIPTION
## Problem

`McpClient` sent the `initialize` request but **never the follow-up `notifications/initialized` notification** (MCP lifecycle step 3). Spec-compliant MCP servers — including our own `mur-mcp-server` (`server.rs` flips `initialized=true` only on that notification) — stay un-initialized until they receive it and reject every subsequent `tools/list` / `tools/call` with JSON-RPC `-32002 "Not initialized. Call 'initialize' first."`

**Effect:** agents silently discovered **zero** tools from *every* MCP server. The model then fell back to bash or returned a tool-less reply. This blocked **all** MCP tools universally, not just `video_analyze`.

## Fix

Add an id-less `notify()` helper and send `notifications/initialized` at the end of `initialize()`, completing the MCP lifecycle. Applies to every MCP server the runtime spawns — not a one-off.

## Verification

End-to-end with a Sonnet agent + `mur-mcp-server` attached:
- Before: boot logs `mcp tools/list failed: -32002 Not initialized`; the model worked around it via bash.
- After: the `-32002` warning is gone, `tools/list` succeeds, and the agent invokes `video_analyze` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)