### PR TITLE
fix(runtime): surface unsupported model provider instead of silently echoing

### DIFF
--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::Context;
-use tracing::warn;
+use tracing::{error, warn};
 
 use crate::companion::clock::SystemClock;
 use crate::hitl::HitlApprovals;
@@ -322,10 +322,28 @@ pub async fn build_provider_runner(
                 }
             }
         }
-        other => {
-            warn!(provider = %other, "no LLM client implemented; falling back to echo");
+        "echo" => {
+            // Intentional fallback: model resolution failed or the agent has no
+            // model configured. Degrade to echo (warned at resolution time).
             (
                 Arc::new(TaskRunner::new_stub_echo()),
+                None,
+                Some(pool.clone()),
+            )
+        }
+        other => {
+            // A real provider was configured but this runtime ships no client for
+            // it (e.g. `deepseek`). Do NOT silently echo — that looks alive but
+            // parrots input. Surface the misconfiguration in the logs AND in every
+            // chat reply so the user sees exactly what to change.
+            let msg = format!(
+                "⚠️ This agent's model provider '{other}' is not supported by the \
+                 MUR runtime (supported: local, ollama, anthropic, openai). \
+                 Update the agent's model to a supported provider in ~/.mur/models.yaml."
+            );
+            error!(provider = %other, "unsupported model provider — replying with misconfiguration notice instead of echo");
+            (
+                Arc::new(TaskRunner::new_stub_misconfigured(msg)),
                 None,
                 Some(pool.clone()),
             )

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -39,6 +39,11 @@ pub enum TaskOutcome {
 pub enum RunnerBackend {
     StubEcho,
     StubSlow,
+    /// The agent's configured model provider has no client in this runtime
+    /// (e.g. `deepseek`). Rather than silently echoing input — which looks
+    /// alive but parrots — every turn replies with this misconfiguration
+    /// message so the user sees exactly what to fix.
+    Misconfigured(String),
     Llm(Arc<dyn LlmClient>),
 }
 
@@ -79,6 +84,12 @@ impl TaskRunner {
 
     pub fn new_stub_slow() -> Self {
         Self::with_backend(RunnerBackend::StubSlow)
+    }
+
+    /// Runner that replies to every turn with a misconfiguration notice instead
+    /// of calling a model. Used when the configured provider has no client.
+    pub fn new_stub_misconfigured(message: impl Into<String>) -> Self {
+        Self::with_backend(RunnerBackend::Misconfigured(message.into()))
     }
 
     pub fn with_llm(client: Arc<dyn LlmClient>) -> Self {
@@ -319,6 +330,7 @@ impl TaskRunner {
                     tokio::time::sleep(std::time::Duration::from_secs(60)).await;
                     Ok(echo_response(&spec.input))
                 }
+                RunnerBackend::Misconfigured(message) => Ok(text_response(message)),
                 RunnerBackend::Llm(client) => {
                     if self.pending_approvals.is_some() {
                         let system = self
@@ -888,6 +900,14 @@ fn echo_response(input: &Message) -> Message {
         parts: vec![MessagePart::Text {
             text: format!("echo: {text}"),
         }],
+    }
+}
+
+/// Build a plain agent reply carrying `text` verbatim (no model call).
+fn text_response(text: &str) -> Message {
+    Message {
+        role: "agent".into(),
+        parts: vec![MessagePart::Text { text: text.into() }],
     }
 }
 


### PR DESCRIPTION
## Problem

`build_provider_runner`'s provider dispatch fell through to an **echo stub** for any provider without a client (e.g. `deepseek`) with only a `WARN`. The agent then looked alive but just **parroted input** — a silent footgun. A user who configured a deepseek agent got echoes with no visible reason.

## Fix

Split the *intentional* `echo` fallback (model resolution failed / no model) from a *genuinely-unsupported configured provider*. The latter now logs an `error!` and replies on every turn with a clear misconfiguration notice naming the provider and the supported set (`local`, `ollama`, `anthropic`, `openai`), via a new `RunnerBackend::Misconfigured(message)`.

## Notes

Discovered while diagnosing why a Hub agent couldn't analyze a video — a `deepseek` test agent silently echoed instead of erroring. Follow-up option: add a first-class deepseek client (OpenAI-compatible) rather than just rejecting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)