### PR TITLE
feat(runtime): per-server MCP tool timeout; raise default 60s→120s

### DIFF
--- a/mur-agent-runtime/src/tools/mcp.rs
+++ b/mur-agent-runtime/src/tools/mcp.rs
@@ -12,7 +12,10 @@ use crate::llm::ToolDef;
 use crate::mcp::pool::McpPool;
 use crate::protocol::mcp_client::McpClient;
 
-pub const MCP_TOOL_TIMEOUT: Duration = Duration::from_secs(60);
+/// Default per-tool-call timeout when an MCP server entry sets no
+/// `timeout_secs`. Override per server via `McpServerEntry.timeout_secs`.
+pub const DEFAULT_MCP_TOOL_TIMEOUT_SECS: u64 = 120;
+pub const MCP_TOOL_TIMEOUT: Duration = Duration::from_secs(DEFAULT_MCP_TOOL_TIMEOUT_SECS);
 
 /// Convert an MCP `tools/call` result to a display string.
 pub fn render_mcp_result(result: &Value) -> String {

--- a/mur-agent-runtime/src/tools/registry.rs
+++ b/mur-agent-runtime/src/tools/registry.rs
@@ -42,10 +42,11 @@ pub async fn build_tools(
         .map(|entry| {
             let pool = pool.clone();
             let name = entry.name.clone();
+            let timeout_secs = entry.timeout_secs;
             async move {
                 let sanitized = sanitize_server(&name);
                 match pool.list_tools(&name).await {
-                    Ok(tools) => Some((name, sanitized, tools)),
+                    Ok(tools) => Some((name, sanitized, tools, timeout_secs)),
                     Err(e) => {
                         tracing::warn!(server = %name, "mcp tools/list failed: {e}");
                         None
@@ -58,7 +59,10 @@ pub async fn build_tools(
     let discovered = future::join_all(discovery_futs).await;
 
     for item in discovered.into_iter().flatten() {
-        let (server, sanitized, tools) = item;
+        let (server, sanitized, tools, timeout_secs) = item;
+        let timeout = timeout_secs
+            .map(|s| std::time::Duration::from_secs(s as u64))
+            .unwrap_or(super::mcp::MCP_TOOL_TIMEOUT);
         for t in tools {
             let wname = wire_name(&sanitized, &t.name);
             if resolve_tool_policy(rules, &wname) == ToolPolicy::Deny {
@@ -76,7 +80,7 @@ pub async fn build_tools(
                 tool: t.name.clone(),
                 def,
                 pool: pool.clone(),
-                timeout: super::mcp::MCP_TOOL_TIMEOUT,
+                timeout,
             });
             map.insert(wname, exec);
         }

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -249,6 +249,12 @@ pub struct McpServerEntry {
     /// rug-pull dialog UX. `None` for older entries. (B0 rule 6 / M9.1)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub installed_at: Option<chrono::DateTime<chrono::Utc>>,
+
+    /// Per-tool-call timeout for this server, in seconds. `None` uses the
+    /// runtime default. Slow tools (e.g. `video_analyze`: transcript fetch
+    /// + local-model map-reduce) need a longer budget than the default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u32>,
 }
 
 /// Display-only publisher metadata captured at install time. None of

--- a/mur-core/src/cmd/agent/mcp.rs
+++ b/mur-core/src/cmd/agent/mcp.rs
@@ -131,6 +131,7 @@ pub fn cmd_mcp_add(
         description_hash: None,
         publisher,
         installed_at: Some(chrono::Utc::now()),
+        timeout_secs: None,
     });
     // Sync spawn allowlist so the supervisor is permitted to launch this MCP.
     if !profile

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -197,6 +197,7 @@ pub fn build_pinned_entry(
         description_hash: Some(description_hash),
         publisher,
         installed_at: Some(chrono::Utc::now()),
+        timeout_secs: None,
     }
 }
 


### PR DESCRIPTION
## Problem

The MCP per-tool-call timeout was hardcoded at **60s**. Real tools like `video_analyze` (yt-dlp transcript fetch + local-model map-reduce over a full video) routinely exceed it and got killed mid-run — the agent reported "analysis tool timed out within 60 seconds."

## Fix

- Add `McpServerEntry.timeout_secs: Option<u32>` (serde default `None`, backward-compatible) so slow servers can opt into a longer budget (e.g. media → 300s) **without** loosening the timeout for fast tools.
- Thread it through `build_tools` discovery into each `McpToolExecutor`.
- Introduce `DEFAULT_MCP_TOOL_TIMEOUT_SECS` and raise the default 60s → **120s** for a more forgiving baseline while staying bounded.

## Context

Surfaced right after the MCP `initialize` handshake fix (#391): once `video_analyze` actually connected, it hit the 60s wall. This makes the budget tunable per server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)