### PR TITLE
chore(release): bump workspace version to 2.22.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.22.16"
+version = "2.22.17"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"


### PR DESCRIPTION
Bump workspace version 2.22.16 → 2.22.17 ahead of tagging `v2.22.17`.

Ships the media + MCP runtime fixes merged since v2.22.16:
- #390 recover YouTube captions when one sub-lang hits HTTP 429
- #391 complete MCP `initialize` handshake so all MCP tools connect
- #392 surface unsupported model provider instead of silently echoing
- #393 per-server MCP tool timeout; default 60s→120s

Per CLAUDE.md, the workspace version must match the tag before pushing it (CI `validate-version` enforces this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)