### PR TITLE
feat(agent): `mur agent cli` — interactive streaming TUI chat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ LanceDB vector index is always rebuildable via `mur reindex`.
 ## CLI Surface (top level)
 
 - `mur verify [--file path] [--all]` — scan docs for stale claims (paths, commands, code refs)
-- `mur agent <subcommand>` — manage murmur agents (create / list / status / send / card / export / doctor / prompt / mcp / skill / perm / secret / companion / rekey / schedule). Full surface in `docs/architecture/runtime-overview.md`.
+- `mur agent <subcommand>` — manage murmur agents (create / list / status / send / card / cli / export / doctor / prompt / mcp / skill / perm / secret / companion / rekey / schedule). `cli <name>` opens an interactive streaming TUI chat with a running agent (`--resume` to continue the last conversation). Full surface in `docs/architecture/runtime-overview.md`.
 - `mur model {add|list|show|remove|migrate}` — `~/.mur/models.yaml` provider/model registry. See `docs/superpowers/specs/2026-04-29-model-registry-and-secret-refs-design.md`.
 
 For detailed agent / companion / GUI export / runtime internals, read `docs/architecture/runtime-overview.md` only when the task requires it.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.22.16"
+version = "2.22.17"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -28,7 +28,7 @@ An alternate input to `store/` lives in `mur-core/src/sources/` — `KnowledgeSo
 
 ### `mur agent <subcommand>` — full surface
 
-Subcommands: `create`, `list`, `status`, `stop`, `remove`, `rename`, `send`, `card`, `install-service`, `prompt {show|edit|set}`, `mcp {add|list|remove|rename}`, `skill {add|list|remove|show}`, `perm {show|set-mode|allow-host|deny-host|list-hosts|allow-read|allow-write|deny-path|allow-spawn|deny-spawn|set-limit}`, `secret {set|list|delete}`, `export {--format=pkg|bin|gui}`, `doctor [--format ...]`, `stats`, `logs`. The runtime binary that backs each agent lives in `mur-agent-runtime/`.
+Subcommands: `create`, `list`, `status`, `stop`, `remove`, `rename`, `send`, `card`, `cli [--resume]` (interactive streaming TUI chat with a running agent; non-TTY stdin/stdout falls back to plain streamed text), `install-service`, `prompt {show|edit|set}`, `mcp {add|list|remove|rename}`, `skill {add|list|remove|show}`, `perm {show|set-mode|allow-host|deny-host|list-hosts|allow-read|allow-write|deny-path|allow-spawn|deny-spawn|set-limit}`, `secret {set|list|delete}`, `export {--format=pkg|bin|gui}`, `doctor [--format ...]`, `stats`, `logs`. The runtime binary that backs each agent lives in `mur-agent-runtime/`.
 
 ### `mur agent doctor [--format pkg|bin|gui|all] [--json]`
 

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -95,6 +95,16 @@ base64 = "0.22"          # cmd::agent_companion::card::png chara/ccv3 chunk deco
 quick-xml = { workspace = true }
 ulid = { workspace = true }  # cmd::agent_companion::card::import inbox id
 
+# `mur agent cli <name>` — interactive TUI chat. mur-core is the only crate
+# that uses crossterm, so there is no risk of a second crossterm major in the
+# workspace (mur-hub-gui, which also uses ratatui, is workspace-EXCLUDED).
+# Markdown rendering reuses the existing `pulldown-cmark` dep — no new crate.
+# `unstable-rendered-line-info` exposes `Paragraph::line_count`, used to anchor
+# the transcript to the bottom (newest message) accounting for wrapping.
+ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
+crossterm = { version = "0.28", features = ["event-stream"] }
+tui-textarea = "0.7"
+
 [features]
 default = ["cli", "server", "sources"]
 cli = ["dialoguer", "console", "clap"]

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -71,6 +71,14 @@ pub enum AgentAction {
         /// Agent name
         name: String,
     },
+    /// Interactive streaming TUI chat with an agent (the agent must be running)
+    Cli {
+        /// Agent name
+        name: String,
+        /// Resume the most recent saved conversation for this agent
+        #[arg(long)]
+        resume: bool,
+    },
     /// Rotate an agent's Ed25519 identity keypair (P0a.6).
     Rekey {
         /// Agent name

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -1,0 +1,410 @@
+//! TUI application state and the pure (non-IO) state transitions.
+
+use std::path::PathBuf;
+
+use ratatui::style::{Color, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders};
+use tui_textarea::TextArea;
+
+use super::markdown;
+use super::persist::{Session, TurnRecord};
+use super::stream::HitlRequest;
+
+/// Spinner frames shown while the agent is generating.
+pub const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Who authored a message in the transcript.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    User,
+    Agent,
+    /// Local UI notice (slash-command output, errors, hints) — not persisted.
+    System,
+}
+
+/// One message in the visible transcript.
+#[derive(Debug, Clone)]
+pub struct ChatMsg {
+    pub role: Role,
+    /// Visible body. For a streaming agent turn this accumulates token deltas;
+    /// it is replaced by the authoritative final reply on completion.
+    pub text: String,
+    /// Reasoning tokens accumulated while streaming (shown dimmed, then dropped).
+    pub thinking: String,
+    pub streaming: bool,
+    /// Markdown rendered once when an agent turn finishes (or on resume), so the
+    /// per-frame redraw never re-parses finished messages. `None` while
+    /// streaming and for user/system messages.
+    pub rendered: Option<Vec<Line<'static>>>,
+}
+
+impl ChatMsg {
+    fn new(role: Role, text: impl Into<String>) -> Self {
+        Self {
+            role,
+            text: text.into(),
+            thinking: String::new(),
+            streaming: false,
+            rendered: None,
+        }
+    }
+
+    /// A finished agent message whose markdown is pre-rendered (resume path).
+    fn agent_rendered(text: String) -> Self {
+        let rendered = Some(markdown::render(&text).lines);
+        Self {
+            role: Role::Agent,
+            text,
+            thinking: String::new(),
+            streaming: false,
+            rendered,
+        }
+    }
+}
+
+/// A parsed slash command.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SlashCmd {
+    Help,
+    Clear,
+    Card,
+    Sessions,
+    Quit,
+    Unknown(String),
+}
+
+/// Parse a leading-slash command. Returns `None` for ordinary chat input.
+pub fn parse_slash(line: &str) -> Option<SlashCmd> {
+    let line = line.trim();
+    let rest = line.strip_prefix('/')?;
+    let word = rest.split_whitespace().next().unwrap_or("");
+    Some(match word {
+        "help" | "h" | "?" => SlashCmd::Help,
+        "clear" | "new" => SlashCmd::Clear,
+        "card" => SlashCmd::Card,
+        "sessions" | "ls" => SlashCmd::Sessions,
+        "exit" | "quit" | "q" => SlashCmd::Quit,
+        other => SlashCmd::Unknown(other.to_string()),
+    })
+}
+
+/// The set of slash commands offered by tab-completion / `/help`.
+pub const SLASH_COMMANDS: [&str; 6] = ["/help", "/clear", "/card", "/sessions", "/exit", "/quit"];
+
+/// All mutable TUI state.
+pub struct App {
+    pub home: PathBuf,
+    pub agent: String,
+    pub messages: Vec<ChatMsg>,
+    pub input: TextArea<'static>,
+    pub context_task_id: Option<String>,
+    pub current_task_id: Option<String>,
+    pub streaming: bool,
+    pub hitl: Option<HitlRequest>,
+    pub session: Session,
+    /// Lines scrolled up from the bottom (0 = pinned to newest).
+    pub scroll_back: u16,
+    pub spinner: usize,
+    pub should_quit: bool,
+    /// Set once we've warned the user that session writes are failing, so the
+    /// warning isn't repeated every turn.
+    persist_warned: bool,
+}
+
+impl App {
+    pub fn new(home: PathBuf, agent: String, session: Session) -> Self {
+        Self {
+            home,
+            agent,
+            messages: Vec::new(),
+            input: new_input(),
+            context_task_id: None,
+            current_task_id: None,
+            streaming: false,
+            hitl: None,
+            session,
+            scroll_back: 0,
+            spinner: 0,
+            should_quit: false,
+            persist_warned: false,
+        }
+    }
+
+    /// Append a turn to the session log, surfacing a write failure once.
+    fn persist_turn(&mut self, role: &str, text: &str, task_id: Option<&str>) {
+        if let Err(e) = self.session.append(role, text, task_id)
+            && !self.persist_warned
+        {
+            self.persist_warned = true;
+            self.push_system(format!("warning: session is not being saved: {e}"));
+        }
+    }
+
+    /// Current input text (joined multiline).
+    pub fn input_text(&self) -> String {
+        self.input.lines().join("\n")
+    }
+
+    pub fn clear_input(&mut self) {
+        self.input = new_input();
+    }
+
+    /// Replace the input buffer with `text` (used by slash-command completion).
+    pub fn set_input(&mut self, text: &str) {
+        self.input = new_input();
+        self.input.insert_str(text);
+    }
+
+    pub fn push_system(&mut self, text: impl Into<String>) {
+        self.messages.push(ChatMsg::new(Role::System, text));
+        self.scroll_back = 0;
+    }
+
+    /// Record a user turn (visible + persisted) and return the new task id for
+    /// the request.
+    pub fn begin_user_turn(&mut self, text: &str) -> String {
+        self.messages.push(ChatMsg::new(Role::User, text));
+        self.persist_turn("user", text, None);
+        // A fresh client-side task id per turn (used for cancellation).
+        let task_id = uuid::Uuid::now_v7().to_string();
+        self.current_task_id = Some(task_id.clone());
+        self.streaming = true;
+        self.scroll_back = 0;
+        // Placeholder agent message that deltas accumulate into.
+        let mut m = ChatMsg::new(Role::Agent, "");
+        m.streaming = true;
+        self.messages.push(m);
+        task_id
+    }
+
+    pub fn append_delta(&mut self, text: &str, thinking: bool) {
+        if let Some(m) = self.messages.last_mut()
+            && m.role == Role::Agent
+            && m.streaming
+        {
+            if thinking {
+                m.thinking.push_str(text);
+            } else {
+                m.text.push_str(text);
+            }
+        }
+        // NB: do not reset scroll_back here — that would yank the viewport back
+        // to the bottom on every token, making it impossible to scroll up while
+        // the agent streams. When the user hasn't scrolled (scroll_back == 0)
+        // the render already stays pinned to the newest line as content grows.
+    }
+
+    /// Finalize the streaming agent turn with the authoritative reply. Persist
+    /// and context-threading happen ONLY if a streaming agent message was
+    /// matched, so a late event that no longer has a live turn can't write a
+    /// phantom line or thread a stale context id.
+    pub fn finish_agent_turn(&mut self, reply: String, task_id: Option<String>) {
+        let mut body = None;
+        if let Some(m) = self.messages.last_mut()
+            && m.role == Role::Agent
+            && m.streaming
+        {
+            if !reply.is_empty() {
+                m.text = reply;
+            }
+            m.thinking.clear();
+            m.streaming = false;
+            m.rendered = Some(markdown::render(&m.text).lines);
+            body = Some(m.text.clone());
+        }
+        if let Some(b) = body {
+            if let Some(tid) = &task_id {
+                self.context_task_id = Some(tid.clone());
+            }
+            self.persist_turn("agent", &b, task_id.as_deref());
+        }
+        self.streaming = false;
+        self.current_task_id = None;
+    }
+
+    /// Mark a partial (cancelled) turn as finished without persisting a reply.
+    pub fn finish_partial(&mut self) {
+        if let Some(m) = self.messages.last_mut()
+            && m.role == Role::Agent
+            && m.streaming
+        {
+            m.thinking.clear();
+            m.streaming = false;
+            if m.text.is_empty() {
+                m.text = "(cancelled)".to_string();
+            }
+        }
+        self.streaming = false;
+        self.current_task_id = None;
+    }
+
+    pub fn fail_turn(&mut self, err: &str) {
+        if matches!(self.messages.last(), Some(m) if m.role == Role::Agent && m.streaming) {
+            self.messages.pop();
+        }
+        self.push_system(format!("error: {err}"));
+        self.streaming = false;
+        self.current_task_id = None;
+    }
+
+    /// Reset to a brand-new conversation (drops server-side context). Any
+    /// in-flight turn must already have been cancelled by the caller.
+    pub fn start_new_session(&mut self, session: Session) {
+        self.session = session;
+        self.messages.clear();
+        self.context_task_id = None;
+        self.current_task_id = None;
+        self.streaming = false;
+        self.hitl = None;
+        self.push_system("started a new conversation");
+    }
+
+    /// Load prior turns into the transcript (resume), threading the last agent
+    /// task id as context.
+    pub fn load_history(&mut self, turns: Vec<TurnRecord>) {
+        let mut last_task = None;
+        for t in turns {
+            let role = match t.role.as_str() {
+                "agent" => Role::Agent,
+                _ => Role::User,
+            };
+            if role == Role::Agent {
+                if let Some(id) = &t.task_id {
+                    last_task = Some(id.clone());
+                }
+                self.messages.push(ChatMsg::agent_rendered(t.text));
+            } else {
+                self.messages.push(ChatMsg::new(role, t.text));
+            }
+        }
+        self.context_task_id = last_task;
+    }
+
+    pub fn tick_spinner(&mut self) {
+        self.spinner = (self.spinner + 1) % SPINNER.len();
+    }
+}
+
+/// Build the styled multiline input widget.
+fn new_input() -> TextArea<'static> {
+    let mut ta = TextArea::default();
+    ta.set_block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" message — Enter to send · Alt+Enter newline · /help · Ctrl+D quit "),
+    );
+    ta.set_cursor_line_style(Style::default());
+    ta.set_placeholder_text("Type a message…");
+    ta.set_placeholder_style(Style::default().fg(Color::DarkGray));
+    ta
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn app() -> App {
+        let home = tempdir().unwrap();
+        let session = Session::create(home.path(), "a").unwrap();
+        App::new(home.path().to_path_buf(), "a".into(), session)
+    }
+
+    #[test]
+    fn parse_slash_variants() {
+        assert_eq!(parse_slash("/help"), Some(SlashCmd::Help));
+        assert_eq!(parse_slash("/new"), Some(SlashCmd::Clear));
+        assert_eq!(parse_slash("/card"), Some(SlashCmd::Card));
+        assert_eq!(parse_slash("/q"), Some(SlashCmd::Quit));
+        assert_eq!(
+            parse_slash("/bogus"),
+            Some(SlashCmd::Unknown("bogus".into()))
+        );
+        assert_eq!(parse_slash("hello"), None);
+        assert_eq!(parse_slash("  not/a/cmd"), None);
+    }
+
+    #[test]
+    fn turn_lifecycle_threads_context() {
+        let mut a = app();
+        let tid = a.begin_user_turn("hi");
+        assert!(a.streaming);
+        assert_eq!(a.current_task_id.as_deref(), Some(tid.as_str()));
+        a.append_delta("Hel", false);
+        a.append_delta("lo", false);
+        a.append_delta("(thinking)", true);
+        assert_eq!(a.messages.last().unwrap().text, "Hello");
+        a.finish_agent_turn("Hello!".into(), Some("server-task-1".into()));
+        assert!(!a.streaming);
+        assert_eq!(a.context_task_id.as_deref(), Some("server-task-1"));
+        assert_eq!(a.messages.last().unwrap().text, "Hello!");
+        assert!(!a.messages.last().unwrap().streaming);
+    }
+
+    #[test]
+    fn late_finish_after_cancel_does_not_persist_or_thread() {
+        // After Ctrl+C (finish_partial), a stale worker's Done must not rewrite
+        // the bubble, persist a phantom line, or thread the cancelled task id.
+        let mut a = app();
+        a.begin_user_turn("hi");
+        a.append_delta("partial", false);
+        a.finish_partial();
+        let ctx_before = a.context_task_id.clone();
+        let len_before = a.messages.len();
+
+        a.finish_agent_turn("the real answer".into(), Some("late-task".into()));
+
+        assert_eq!(
+            a.context_task_id, ctx_before,
+            "stale task id must not be threaded"
+        );
+        assert_eq!(a.messages.len(), len_before, "no phantom message appended");
+        assert_eq!(
+            a.messages.last().unwrap().text,
+            "partial",
+            "bubble keeps partial text"
+        );
+    }
+
+    #[test]
+    fn append_delta_preserves_user_scroll() {
+        let mut a = app();
+        a.begin_user_turn("hi");
+        a.scroll_back = 7;
+        a.append_delta("tok", false);
+        assert_eq!(
+            a.scroll_back, 7,
+            "streaming must not yank the viewport to bottom"
+        );
+    }
+
+    #[test]
+    fn finished_agent_turn_caches_markdown() {
+        let mut a = app();
+        a.begin_user_turn("hi");
+        a.finish_agent_turn("**bold**".into(), Some("t1".into()));
+        assert!(a.messages.last().unwrap().rendered.is_some());
+    }
+
+    #[test]
+    fn fail_turn_drops_streaming_placeholder() {
+        let mut a = app();
+        a.begin_user_turn("hi");
+        a.fail_turn("boom");
+        // user msg + system error; the empty agent placeholder is removed.
+        assert_eq!(a.messages.last().unwrap().role, Role::System);
+        assert!(!a.streaming);
+    }
+
+    #[test]
+    fn new_session_resets_context() {
+        let mut a = app();
+        a.begin_user_turn("hi");
+        a.finish_agent_turn("ok".into(), Some("t1".into()));
+        let s = Session::create(&a.home, &a.agent).unwrap();
+        a.start_new_session(s);
+        assert!(a.context_task_id.is_none());
+        assert_eq!(a.messages.last().unwrap().role, Role::System);
+    }
+}

--- a/mur-core/src/cmd/agent/cli/markdown.rs
+++ b/mur-core/src/cmd/agent/cli/markdown.rs
@@ -1,0 +1,277 @@
+//! Minimal Markdown → ratatui `Text` renderer.
+//!
+//! Completed agent replies are re-rendered through this so the TUI shows
+//! headings, bold/italic, lists, blockquotes, and fenced code instead of raw
+//! Markdown. It reuses the workspace's existing `pulldown-cmark` dependency, so
+//! no new crate is pulled in. It is deliberately small: it targets the subset of
+//! Markdown an assistant actually emits, not full CommonMark fidelity.
+
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+
+const HEADING: Color = Color::Cyan;
+const CODE: Color = Color::Yellow;
+const QUOTE: Color = Color::DarkGray;
+const RULE: &str = "────────────────────────";
+const INDENT: &str = "  ";
+
+/// Render Markdown source into owned ratatui `Text`.
+pub fn render(src: &str) -> Text<'static> {
+    let mut r = Renderer::default();
+    let parser = Parser::new_ext(src, Options::ENABLE_STRIKETHROUGH | Options::ENABLE_TABLES);
+    for ev in parser {
+        r.event(ev);
+    }
+    r.finish()
+}
+
+#[derive(Default)]
+struct Renderer {
+    lines: Vec<Line<'static>>,
+    cur: Vec<Span<'static>>,
+    bold: bool,
+    italic: bool,
+    code: bool,
+    in_code_block: bool,
+    quote: bool,
+    /// One entry per open list; `Some(n)` = ordered list next number.
+    list_stack: Vec<Option<u64>>,
+}
+
+impl Renderer {
+    fn span_style(&self) -> Style {
+        let mut s = Style::default();
+        if self.bold {
+            s = s.add_modifier(Modifier::BOLD);
+        }
+        if self.italic {
+            s = s.add_modifier(Modifier::ITALIC);
+        }
+        if self.code {
+            s = s.fg(CODE);
+        }
+        s
+    }
+
+    fn push_text(&mut self, text: &str) {
+        let style = self.span_style();
+        self.cur.push(Span::styled(text.to_string(), style));
+    }
+
+    /// Push the in-progress spans as a line. A no-op when there is nothing
+    /// buffered — blank/spacer lines are added only via [`blank_line`], so a
+    /// `flush_line` between two list items never injects a stray blank (which
+    /// previously rendered tight lists double-spaced with a leading blank).
+    fn flush_line(&mut self) {
+        if self.cur.is_empty() {
+            return;
+        }
+        let spans = std::mem::take(&mut self.cur);
+        self.lines.push(Line::from(spans));
+    }
+
+    fn blank_line(&mut self) {
+        if !matches!(self.lines.last(), Some(l) if l.spans.is_empty()) {
+            self.lines.push(Line::default());
+        }
+    }
+
+    fn indent(&mut self) {
+        let depth = self.list_stack.len().saturating_sub(1);
+        if self.quote {
+            self.cur
+                .push(Span::styled("▏ ".to_string(), Style::default().fg(QUOTE)));
+        }
+        for _ in 0..depth {
+            self.cur.push(Span::raw(INDENT.to_string()));
+        }
+    }
+
+    fn event(&mut self, ev: Event) {
+        match ev {
+            Event::Start(tag) => self.start(tag),
+            Event::End(tag) => self.end(tag),
+            Event::Text(t) => {
+                if self.in_code_block {
+                    // Code text may contain newlines; render each as its own line.
+                    for (i, part) in t.split('\n').enumerate() {
+                        if i > 0 {
+                            self.flush_line();
+                        }
+                        self.cur
+                            .push(Span::styled(part.to_string(), Style::default().fg(CODE)));
+                    }
+                } else {
+                    self.push_text(&t);
+                }
+            }
+            Event::Code(t) => {
+                self.cur
+                    .push(Span::styled(t.to_string(), Style::default().fg(CODE)));
+            }
+            Event::SoftBreak => self.cur.push(Span::raw(" ".to_string())),
+            Event::HardBreak => self.flush_line(),
+            Event::Rule => {
+                self.flush_line();
+                self.lines
+                    .push(Line::styled(RULE.to_string(), Style::default().fg(QUOTE)));
+            }
+            _ => {}
+        }
+    }
+
+    fn start(&mut self, tag: Tag) {
+        match tag {
+            Tag::Heading { .. } => {
+                self.flush_line();
+                self.bold = true;
+            }
+            Tag::Strong => self.bold = true,
+            Tag::Emphasis => self.italic = true,
+            Tag::CodeBlock(_) => {
+                self.flush_line();
+                self.in_code_block = true;
+            }
+            Tag::BlockQuote(_) => self.quote = true,
+            Tag::List(start) => self.list_stack.push(start),
+            Tag::Item => {
+                self.flush_line();
+                self.indent();
+                let marker = match self.list_stack.last_mut() {
+                    Some(Some(n)) => {
+                        let m = format!("{n}. ");
+                        *n += 1;
+                        m
+                    }
+                    _ => "• ".to_string(),
+                };
+                self.cur
+                    .push(Span::styled(marker, Style::default().fg(HEADING)));
+            }
+            Tag::Paragraph => {
+                if self.list_stack.is_empty() {
+                    self.flush_line();
+                }
+                self.indent();
+            }
+            _ => {}
+        }
+    }
+
+    fn end(&mut self, tag: TagEnd) {
+        match tag {
+            TagEnd::Heading(level) => {
+                self.bold = false;
+                self.flush_line();
+                if matches!(level, HeadingLevel::H1 | HeadingLevel::H2) {
+                    self.blank_line();
+                }
+            }
+            TagEnd::Strong => self.bold = false,
+            TagEnd::Emphasis => self.italic = false,
+            TagEnd::CodeBlock => {
+                self.flush_line();
+                self.in_code_block = false;
+                self.blank_line();
+            }
+            TagEnd::BlockQuote(_) => {
+                self.quote = false;
+                self.flush_line();
+            }
+            TagEnd::List(_) => {
+                self.list_stack.pop();
+                if self.list_stack.is_empty() {
+                    self.blank_line();
+                }
+            }
+            TagEnd::Item => self.flush_line(),
+            TagEnd::Paragraph => {
+                self.flush_line();
+                if self.list_stack.is_empty() {
+                    self.blank_line();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn finish(mut self) -> Text<'static> {
+        self.flush_line();
+        // Trim a trailing blank line.
+        while matches!(self.lines.last(), Some(l) if l.spans.is_empty()) {
+            self.lines.pop();
+        }
+        Text::from(self.lines)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plain(text: &Text) -> String {
+        text.lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn renders_heading_and_paragraph() {
+        let t = render("# Title\n\nHello world");
+        let s = plain(&t);
+        assert!(s.contains("Title"));
+        assert!(s.contains("Hello world"));
+    }
+
+    #[test]
+    fn renders_bullets_and_ordered() {
+        let t = render("- a\n- b\n\n1. one\n2. two");
+        let s = plain(&t);
+        assert!(s.contains("• a"));
+        assert!(s.contains("• b"));
+        assert!(s.contains("1. one"));
+        assert!(s.contains("2. two"));
+    }
+
+    fn rows(text: &Text) -> Vec<String> {
+        text.lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn tight_list_has_no_blank_or_phantom_lines() {
+        // Regression: items used to render double-spaced with a leading blank.
+        assert_eq!(rows(&render("- a\n- b")), vec!["• a", "• b"]);
+        assert_eq!(rows(&render("1. one\n2. two")), vec!["1. one", "2. two"]);
+    }
+
+    #[test]
+    fn renders_code_block_contents() {
+        let t = render("```\nlet x = 1;\n```");
+        assert!(plain(&t).contains("let x = 1;"));
+    }
+
+    #[test]
+    fn inline_code_and_bold_do_not_panic() {
+        let t = render("This is `code` and **bold** and *italic*.");
+        let s = plain(&t);
+        assert!(s.contains("code"));
+        assert!(s.contains("bold"));
+        assert!(s.contains("italic"));
+    }
+}

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -1,0 +1,478 @@
+//! `mur agent cli <name>` — interactive streaming TUI chat with an agent.
+//!
+//! This is a terminal front-end over the already-working A2A streaming client
+//! (`crate::a2a_dial::dial_message_streaming`); it adds no protocol surface. See
+//! the sibling modules: [`stream`] (blocking-dial ↔ async bridge), [`app`]
+//! (state), [`ui`] (ratatui render), [`markdown`] (reply rendering), and
+//! [`persist`] (JSONL session log + resume).
+
+mod app;
+mod markdown;
+mod persist;
+mod stream;
+mod ui;
+
+use std::io::{self, IsTerminal, Stdout, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use crossterm::event::{
+    DisableBracketedPaste, EnableBracketedPaste, Event, EventStream, KeyCode, KeyEventKind,
+    KeyModifiers,
+};
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use crossterm::{cursor, execute};
+use futures::StreamExt;
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use self::app::{App, SlashCmd, parse_slash};
+use self::persist::Session;
+use self::stream::{StreamMsg, build_params, cancel_task, respond_hitl, spawn_stream};
+use crate::a2a_dial::{DialMode, canonicalize_agent_name, dial_method};
+
+/// How many transcript lines PageUp/PageDown scroll.
+const SCROLL_STEP: u16 = 5;
+/// Spinner animation cadence.
+const SPINNER_MS: u64 = 90;
+
+const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /exit · keys: Enter send · Alt+Enter newline · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
+
+/// Entry point dispatched from `AgentAction::Cli`.
+pub async fn cmd_cli(name: &str, resume: bool) -> Result<()> {
+    let home = super::resolve_mur_home()?;
+    let agent = canonicalize_agent_name(&home, name);
+
+    // Streaming requires a live socket; fail early with a friendly hint.
+    let lock = home.join("agents").join(&agent).join("running.lock");
+    if !lock.exists() {
+        eprintln!(
+            "Agent '{agent}' is not running. Start it first, e.g.:\n    mur agent run {agent}\nthen retry: mur agent cli {agent}"
+        );
+        return Ok(());
+    }
+
+    // Non-TTY (piped) → plain streamed text, preserving scriptability.
+    if !io::stdout().is_terminal() {
+        let home2 = home.clone();
+        let agent2 = agent.clone();
+        return tokio::task::spawn_blocking(move || run_plain(&home2, &agent2)).await?;
+    }
+
+    run_tui(home, agent, resume).await
+}
+
+// ── TUI mode ────────────────────────────────────────────────────────────────
+
+/// RAII terminal restore — runs on every exit path including unwind.
+struct TerminalGuard;
+
+impl TerminalGuard {
+    fn enter() -> Result<Self> {
+        enable_raw_mode().context("enable raw mode")?;
+        execute!(io::stdout(), EnterAlternateScreen, EnableBracketedPaste)
+            .context("enter alternate screen")?;
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = execute!(
+            io::stdout(),
+            LeaveAlternateScreen,
+            DisableBracketedPaste,
+            cursor::Show
+        );
+        let _ = disable_raw_mode();
+    }
+}
+
+async fn run_tui(home: PathBuf, agent: String, resume: bool) -> Result<()> {
+    // Restore the terminal even if a later panic unwinds past the guard.
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = execute!(
+            io::stdout(),
+            LeaveAlternateScreen,
+            DisableBracketedPaste,
+            cursor::Show
+        );
+        let _ = disable_raw_mode();
+        prev_hook(info);
+    }));
+
+    let _guard = TerminalGuard::enter()?;
+    let mut terminal =
+        Terminal::new(CrosstermBackend::new(io::stdout())).context("init terminal")?;
+
+    let mut app = build_app(&home, &agent, resume)?;
+    let result = event_loop(&mut terminal, &mut app).await;
+
+    drop(_guard);
+    let _ = terminal.show_cursor();
+    result
+}
+
+fn build_app(home: &Path, agent: &str, resume: bool) -> Result<App> {
+    if resume {
+        if let Some(info) = persist::latest(home, agent)? {
+            let turns = persist::load(&info.path)?;
+            let mut app = App::new(
+                home.to_path_buf(),
+                agent.to_string(),
+                Session::from_path(info.path),
+            );
+            app.load_history(turns);
+            app.push_system(format!(
+                "resumed conversation ({} turns) — {HELP}",
+                app.messages.len()
+            ));
+            return Ok(app);
+        }
+        let mut app = App::new(
+            home.to_path_buf(),
+            agent.to_string(),
+            Session::create(home, agent)?,
+        );
+        app.push_system(format!(
+            "no saved conversation to resume; starting fresh. {HELP}"
+        ));
+        return Ok(app);
+    }
+    let mut app = App::new(
+        home.to_path_buf(),
+        agent.to_string(),
+        Session::create(home, agent)?,
+    );
+    app.push_system(HELP);
+    Ok(app)
+}
+
+async fn event_loop(
+    terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    app: &mut App,
+) -> Result<()> {
+    let (tx, mut rx) = mpsc::channel::<StreamMsg>(stream::STREAM_CHANNEL_CAP);
+    let mut events = EventStream::new();
+    let mut spinner = tokio::time::interval(Duration::from_millis(SPINNER_MS));
+
+    loop {
+        terminal.draw(|f| ui::render(f, app))?;
+        if app.should_quit {
+            return Ok(());
+        }
+        tokio::select! {
+            maybe = events.next() => match maybe {
+                Some(Ok(ev)) => handle_event(app, ev, &tx).await,
+                Some(Err(_)) | None => return Ok(()),
+            },
+            Some(msg) = rx.recv() => handle_stream(app, msg),
+            _ = spinner.tick(), if app.streaming => app.tick_spinner(),
+        }
+    }
+}
+
+async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
+    match ev {
+        Event::Key(key) if key.kind == KeyEventKind::Press || key.kind == KeyEventKind::Repeat => {
+            let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+            // HITL prompt takes over the keyboard — but Ctrl+C/Ctrl+D must stay
+            // live so the user is never trapped by a stale/unanswerable modal.
+            if app.hitl.is_some() {
+                match key.code {
+                    KeyCode::Char('d') if ctrl => request_quit(app, tx),
+                    KeyCode::Char('c') if ctrl => decide_hitl(app, tx, false),
+                    KeyCode::Char('y') | KeyCode::Char('Y') => decide_hitl(app, tx, true),
+                    KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                        decide_hitl(app, tx, false)
+                    }
+                    _ => {}
+                }
+                return;
+            }
+            let alt = key.modifiers.contains(KeyModifiers::ALT);
+            match key.code {
+                KeyCode::Char('d') if ctrl => request_quit(app, tx),
+                KeyCode::Char('c') if ctrl => handle_ctrl_c(app, tx),
+                KeyCode::PageUp => app.scroll_back = app.scroll_back.saturating_add(SCROLL_STEP),
+                KeyCode::PageDown => app.scroll_back = app.scroll_back.saturating_sub(SCROLL_STEP),
+                KeyCode::Tab => complete_slash(app),
+                KeyCode::Enter if alt => {
+                    app.input.insert_newline();
+                }
+                KeyCode::Enter => submit(app, tx).await,
+                _ => {
+                    app.input.input(key);
+                }
+            }
+        }
+        Event::Paste(text) => {
+            // Don't let a paste leak into the (occluded) composer while the HITL
+            // modal owns the screen.
+            if app.hitl.is_some() {
+                return;
+            }
+            app.input.insert_str(text);
+        }
+        _ => {}
+    }
+}
+
+/// Tab completes a leading-slash command to the first matching name.
+fn complete_slash(app: &mut App) {
+    let cur = app.input_text();
+    let trimmed = cur.trim();
+    if !trimmed.starts_with('/') {
+        return;
+    }
+    if let Some(m) = app::SLASH_COMMANDS
+        .iter()
+        .find(|c| c.starts_with(trimmed) && **c != trimmed)
+    {
+        app.set_input(m);
+    }
+}
+
+/// Cancel the in-flight turn (if any) on a separate connection and mark the
+/// streaming bubble done locally. After this, `current_task_id` is `None`, so
+/// the orphaned worker's late events are dropped by `handle_stream`.
+fn cancel_in_flight(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
+    if !app.streaming {
+        return;
+    }
+    if let Some(task_id) = app.current_task_id.clone() {
+        let (h, a, t) = (app.home.clone(), app.agent.clone(), tx.clone());
+        tokio::spawn(async move {
+            if let Err(e) = cancel_task(h, a, task_id).await {
+                let _ = t
+                    .send(StreamMsg::Note(format!("cancel failed: {e:#}")))
+                    .await;
+            }
+        });
+    }
+    app.finish_partial();
+}
+
+/// Cancel any in-flight turn, then request TUI shutdown. Cancelling first lets
+/// the runtime close the stream so the (detached) worker unblocks promptly and
+/// stops doing abandoned server-side work.
+fn request_quit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
+    cancel_in_flight(app, tx);
+    app.should_quit = true;
+}
+
+fn handle_ctrl_c(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
+    if app.streaming {
+        cancel_in_flight(app, tx);
+        app.push_system("cancelled");
+    } else if app.input_text().trim().is_empty() {
+        app.should_quit = true;
+    } else {
+        app.clear_input();
+    }
+}
+
+/// Answer the open HITL prompt, surfacing a dial failure (so a lost decision
+/// isn't reported to the user as success).
+fn decide_hitl(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: bool) {
+    if let Some(req) = app.hitl.take() {
+        let (h, a) = (app.home.clone(), app.agent.clone());
+        let (id, tool) = (req.hitl_id.clone(), req.tool_name.clone());
+        let t = tx.clone();
+        tokio::spawn(async move {
+            if let Err(e) = respond_hitl(h, a, id, allow).await {
+                let _ = t
+                    .send(StreamMsg::Note(format!(
+                        "failed to deliver decision for `{tool}`: {e:#}"
+                    )))
+                    .await;
+            }
+        });
+        app.push_system(if allow {
+            format!("approved `{}`", req.tool_name)
+        } else {
+            format!("denied `{}`", req.tool_name)
+        });
+    }
+}
+
+async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
+    let trimmed = app.input_text().trim().to_string();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    if let Some(cmd) = parse_slash(&trimmed) {
+        app.clear_input();
+        handle_slash(app, cmd, tx).await;
+        return;
+    }
+    // Reject (but DON'T discard) a message typed while a turn is generating —
+    // clearing the input here would silently lose what the user composed.
+    if app.streaming {
+        app.push_system("still generating — press Ctrl+C to cancel first");
+        return;
+    }
+    app.clear_input();
+
+    let task_id = app.begin_user_turn(&trimmed);
+    let params = build_params(&trimmed, &task_id, app.context_task_id.as_deref());
+    spawn_stream(
+        app.home.clone(),
+        app.agent.clone(),
+        params,
+        task_id,
+        tx.clone(),
+    );
+}
+
+async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>) {
+    match cmd {
+        SlashCmd::Help => app.push_system(HELP),
+        SlashCmd::Quit => request_quit(app, tx),
+        SlashCmd::Clear => {
+            // Stop the in-flight turn first so its worker can't write into the
+            // fresh conversation after the reset.
+            cancel_in_flight(app, tx);
+            match Session::create(&app.home, &app.agent) {
+                Ok(s) => app.start_new_session(s),
+                Err(e) => app.push_system(format!("could not start new session: {e}")),
+            }
+        }
+        SlashCmd::Sessions => {
+            match persist::list_recent(&app.home, &app.agent, persist::RECENT_LIMIT) {
+                Ok(list) if !list.is_empty() => {
+                    let mut out = String::from(
+                        "recent conversations (resume the latest with `mur agent cli --resume`):\n",
+                    );
+                    for s in list {
+                        out.push_str(&format!(
+                            "  {} · {} turns · {}\n",
+                            &s.id[..s.id.len().min(8)],
+                            s.turns,
+                            s.preview
+                        ));
+                    }
+                    app.push_system(out.trim_end().to_string());
+                }
+                Ok(_) => app.push_system("no saved conversations yet"),
+                Err(e) => app.push_system(format!("could not list sessions: {e}")),
+            }
+        }
+        SlashCmd::Card => {
+            let (h, a) = (app.home.clone(), app.agent.clone());
+            let res = tokio::task::spawn_blocking(move || {
+                dial_method(&h, &a, "agent/card", Value::Null, DialMode::Auto)
+            })
+            .await;
+            match res {
+                Ok(Ok(card)) => app.push_system(
+                    serde_json::to_string_pretty(&card).unwrap_or_else(|_| card.to_string()),
+                ),
+                Ok(Err(e)) => app.push_system(format!("card error: {e:#}")),
+                Err(e) => app.push_system(format!("card task failed: {e}")),
+            }
+        }
+        SlashCmd::Unknown(c) => app.push_system(format!("unknown command: /{c} — try /help")),
+    }
+}
+
+fn handle_stream(app: &mut App, msg: StreamMsg) {
+    // Drop events from a turn that is no longer current (cancelled, cleared, or
+    // already finished) so a still-running worker can't splice its tokens/reply
+    // into a later turn. `Note` carries no task id and is always shown.
+    if let Some(tid) = msg.task_id()
+        && app.current_task_id.as_deref() != Some(tid)
+    {
+        return;
+    }
+    match msg {
+        StreamMsg::Delta { text, thinking, .. } => app.append_delta(&text, thinking),
+        StreamMsg::Hitl { req, .. } => app.hitl = Some(req),
+        StreamMsg::Done { task, .. } => match stream::task_outcome(&task) {
+            Ok((reply, task_id)) => app.finish_agent_turn(reply, task_id),
+            Err(cause) => app.fail_turn(&cause),
+        },
+        StreamMsg::Err { error, .. } => app.fail_turn(&error),
+        StreamMsg::Note(text) => app.push_system(text),
+    }
+}
+
+// ── Non-TTY plain mode ────────────────────────────────────────────────────────
+
+/// Pipe-safe fallback: read a line from stdin, stream the reply as plain text to
+/// stdout, repeat. No ANSI, no TUI. Threads conversation context across turns.
+fn run_plain(home: &Path, agent: &str) -> Result<()> {
+    use std::cell::Cell;
+    use std::io::BufRead;
+    let stdin = io::stdin();
+    let mut out = io::stdout();
+    let mut context: Option<String> = None;
+
+    for line in stdin.lock().lines() {
+        let line = line?;
+        let text = line.trim();
+        if text.is_empty() {
+            continue;
+        }
+        let task_id = uuid::Uuid::now_v7().to_string();
+        let params = build_params(text, &task_id, context.as_deref());
+        let streamed = Cell::new(false);
+        let result = crate::a2a_dial::dial_message_streaming(
+            home,
+            agent,
+            params,
+            |delta, thinking| {
+                if !thinking {
+                    streamed.set(true);
+                    let _ = write!(out, "{delta}");
+                    let _ = out.flush();
+                }
+            },
+            |hitl| {
+                // No TTY to prompt on: auto-deny immediately (on a separate
+                // connection) so the turn resolves instead of blocking for the
+                // full HITL timeout, and tell the user on stderr.
+                let id = hitl
+                    .get("hitl_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                eprintln!("[non-interactive: auto-denying tool-approval request]");
+                let _ = dial_method(
+                    home,
+                    agent,
+                    "tool/hitl_respond",
+                    serde_json::json!({ "hitl_id": id, "allow": false }),
+                    DialMode::RequireRunning,
+                );
+            },
+        );
+        match result {
+            Ok(task) => match stream::task_outcome(&task) {
+                Ok((reply, tid)) => {
+                    // Fall back to the final reply if the agent didn't stream deltas.
+                    if !streamed.get() && !reply.trim().is_empty() {
+                        write!(out, "{reply}")?;
+                    }
+                    writeln!(out)?;
+                    out.flush()?;
+                    context = tid;
+                }
+                Err(cause) => {
+                    writeln!(out, "\nerror: {cause}")?;
+                }
+            },
+            Err(e) => {
+                writeln!(out, "\nerror: {e:#}")?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/mur-core/src/cmd/agent/cli/persist.rs
+++ b/mur-core/src/cmd/agent/cli/persist.rs
@@ -1,0 +1,214 @@
+//! Per-conversation session persistence as append-only JSONL.
+//!
+//! Mirrors the runtime's `Ledger` convention (one JSON object per line, append
+//! mode) but uses one file per conversation under
+//! `~/.mur/agents/<agent>/cli-sessions/<session-id>.jsonl`. Session ids are
+//! UUID v7 (time-sortable), so the lexically greatest filename is the newest —
+//! that is what `--resume` loads.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Subdirectory under an agent's home that holds CLI chat transcripts.
+pub const SESSIONS_SUBDIR: &str = "cli-sessions";
+/// File extension for a saved conversation.
+pub const SESSION_EXT: &str = "jsonl";
+/// How many recent sessions `/sessions` lists.
+pub const RECENT_LIMIT: usize = 10;
+
+/// One persisted turn. `system` UI notes are not persisted — only the real
+/// user/agent exchange that resume needs to reconstruct.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnRecord {
+    /// RFC 3339 timestamp.
+    pub ts: String,
+    /// "user" or "agent".
+    pub role: String,
+    pub text: String,
+    /// The agent turn's task id (used to thread context on resume).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+}
+
+/// A handle to one conversation's transcript file.
+pub struct Session {
+    path: PathBuf,
+}
+
+/// Summary of a saved session for listing/resume.
+#[derive(Debug, Clone)]
+pub struct SessionInfo {
+    pub id: String,
+    pub path: PathBuf,
+    /// First user message, for a human-readable preview.
+    pub preview: String,
+    pub turns: usize,
+}
+
+fn sessions_dir(home: &Path, agent: &str) -> PathBuf {
+    home.join("agents").join(agent).join(SESSIONS_SUBDIR)
+}
+
+impl Session {
+    /// Create a fresh conversation file with a new time-sortable id.
+    pub fn create(home: &Path, agent: &str) -> Result<Self> {
+        let dir = sessions_dir(home, agent);
+        fs::create_dir_all(&dir)
+            .with_context(|| format!("create session dir {}", dir.display()))?;
+        let id = uuid::Uuid::now_v7().to_string();
+        let path = dir.join(format!("{id}.{SESSION_EXT}"));
+        Ok(Self { path })
+    }
+
+    /// Wrap an existing transcript file (used by resume).
+    pub fn from_path(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    /// Append one turn. Append-only; durability matches the runtime ledger
+    /// convention (the OS flushes; a crash loses at most the last line).
+    pub fn append(&self, role: &str, text: &str, task_id: Option<&str>) -> Result<()> {
+        let rec = TurnRecord {
+            ts: chrono::Local::now().to_rfc3339(),
+            role: role.to_string(),
+            text: text.to_string(),
+            task_id: task_id.map(str::to_string),
+        };
+        let mut f = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .with_context(|| format!("open session file {}", self.path.display()))?;
+        let line = serde_json::to_string(&rec)?;
+        writeln!(f, "{line}").with_context(|| format!("write {}", self.path.display()))?;
+        Ok(())
+    }
+
+    /// Path to the transcript file (used by resume tooling and tests).
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Read all turns from a transcript file, skipping malformed lines.
+pub fn load(path: &Path) -> Result<Vec<TurnRecord>> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("read session {}", path.display()))?;
+    Ok(content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<TurnRecord>(l).ok())
+        .collect())
+}
+
+/// List recent sessions for an agent, newest first.
+pub fn list_recent(home: &Path, agent: &str, limit: usize) -> Result<Vec<SessionInfo>> {
+    let dir = sessions_dir(home, agent);
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut ids: Vec<(String, PathBuf)> = fs::read_dir(&dir)
+        .with_context(|| format!("read session dir {}", dir.display()))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some(SESSION_EXT))
+        .filter_map(|p| {
+            p.file_stem()
+                .and_then(|s| s.to_str())
+                .map(|id| (id.to_string(), p.clone()))
+        })
+        .collect();
+    // UUID v7 ids sort chronologically; reverse for newest-first.
+    ids.sort_by(|a, b| b.0.cmp(&a.0));
+    ids.truncate(limit);
+
+    Ok(ids
+        .into_iter()
+        .map(|(id, path)| {
+            let turns = load(&path).unwrap_or_default();
+            let preview = turns
+                .iter()
+                .find(|t| t.role == "user")
+                .map(|t| t.text.clone())
+                .unwrap_or_default();
+            SessionInfo {
+                id,
+                path,
+                preview,
+                turns: turns.len(),
+            }
+        })
+        .collect())
+}
+
+/// The most recent session for an agent, if any.
+pub fn latest(home: &Path, agent: &str) -> Result<Option<SessionInfo>> {
+    Ok(list_recent(home, agent, 1)?.into_iter().next())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn append_and_load_roundtrip() {
+        let home = tempdir().unwrap();
+        let s = Session::create(home.path(), "agentx").unwrap();
+        s.append("user", "hello", None).unwrap();
+        s.append("agent", "hi there", Some("task-1")).unwrap();
+
+        let turns = load(s.path()).unwrap();
+        assert_eq!(turns.len(), 2);
+        assert_eq!(turns[0].role, "user");
+        assert_eq!(turns[0].text, "hello");
+        assert_eq!(turns[1].role, "agent");
+        assert_eq!(turns[1].task_id.as_deref(), Some("task-1"));
+    }
+
+    #[test]
+    fn list_recent_orders_newest_first_with_preview() {
+        let home = tempdir().unwrap();
+        let s1 = Session::create(home.path(), "a").unwrap();
+        s1.append("user", "first convo", None).unwrap();
+        // v7 ids are monotonic within a process; s2 is newer than s1.
+        let s2 = Session::create(home.path(), "a").unwrap();
+        s2.append("user", "second convo", None).unwrap();
+
+        let recent = list_recent(home.path(), "a", RECENT_LIMIT).unwrap();
+        assert_eq!(recent.len(), 2);
+        assert_eq!(recent[0].preview, "second convo");
+        assert_eq!(recent[1].preview, "first convo");
+        assert_eq!(recent[0].turns, 1);
+    }
+
+    #[test]
+    fn list_recent_empty_when_no_dir() {
+        let home = tempdir().unwrap();
+        assert!(
+            list_recent(home.path(), "nobody", RECENT_LIMIT)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn load_skips_malformed_lines() {
+        let home = tempdir().unwrap();
+        let s = Session::create(home.path(), "a").unwrap();
+        s.append("user", "ok", None).unwrap();
+        // Corrupt append.
+        {
+            let mut f = OpenOptions::new().append(true).open(s.path()).unwrap();
+            writeln!(f, "{{not valid json").unwrap();
+        }
+        s.append("agent", "still works", Some("t")).unwrap();
+        let turns = load(s.path()).unwrap();
+        assert_eq!(turns.len(), 2);
+    }
+}

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -1,0 +1,324 @@
+//! Streaming bridge between the blocking A2A client and the async TUI loop.
+//!
+//! `dial_message_streaming` (see [`crate::a2a_dial`]) is synchronous and blocks
+//! its thread until the task completes, invoking `FnMut` callbacks for token
+//! deltas and HITL prompts. We run it on a `spawn_blocking` worker and forward
+//! every event over an mpsc channel as a [`StreamMsg`], so the UI's
+//! `tokio::select!` loop stays responsive. HITL approval and cancellation are
+//! issued on *separate* connections via `dial_method` (they must not wait on the
+//! streaming socket, which is busy reading) — mirroring the MUR Hub design.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use serde_json::{Value, json};
+use tokio::sync::mpsc;
+
+use crate::a2a_dial::{DialMode, dial_message_streaming, dial_method};
+
+/// Bounded capacity of the worker→UI event channel. Deltas are tiny and the UI
+/// drains them every frame; this only bounds a runaway burst.
+pub const STREAM_CHANNEL_CAP: usize = 512;
+
+/// One event from the streaming worker to the UI loop. Every turn-scoped
+/// variant carries the originating `task_id` so the UI can drop late events
+/// from a cancelled / superseded worker (the channel is shared across turns).
+#[derive(Debug)]
+pub enum StreamMsg {
+    /// A token (or token batch) of the agent's reply. `thinking` marks
+    /// reasoning tokens, which the UI renders dimmed.
+    Delta {
+        task_id: String,
+        text: String,
+        thinking: bool,
+    },
+    /// The agent paused to ask the user to approve a tool call.
+    Hitl { task_id: String, req: HitlRequest },
+    /// The task finished; carries the final A2A Task value.
+    Done { task_id: String, task: Box<Value> },
+    /// The dial failed (or the agent errored). Carries a display string.
+    Err { task_id: String, error: String },
+    /// An out-of-band notice not tied to a turn (e.g. a failed HITL/cancel
+    /// dial). Always shown regardless of the active turn.
+    Note(String),
+}
+
+impl StreamMsg {
+    /// The turn this event belongs to, or `None` for turn-independent notices.
+    pub fn task_id(&self) -> Option<&str> {
+        match self {
+            StreamMsg::Delta { task_id, .. }
+            | StreamMsg::Hitl { task_id, .. }
+            | StreamMsg::Done { task_id, .. }
+            | StreamMsg::Err { task_id, .. } => Some(task_id),
+            StreamMsg::Note(_) => None,
+        }
+    }
+}
+
+/// A human-in-the-loop tool-approval request, parsed from a
+/// `tool/approval_needed` notification's params.
+#[derive(Debug, Clone)]
+pub struct HitlRequest {
+    pub hitl_id: String,
+    pub tool_name: String,
+    pub tool_input: Value,
+    pub prompt: String,
+}
+
+impl HitlRequest {
+    fn from_value(v: Value) -> Self {
+        let tool_name = v
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .unwrap_or("tool")
+            .to_string();
+        Self {
+            hitl_id: v
+                .get("hitl_id")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            prompt: v
+                .get("prompt")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("Run `{tool_name}`?")),
+            tool_input: v.get("tool_input").cloned().unwrap_or(Value::Null),
+            tool_name,
+        }
+    }
+}
+
+/// Build the `message/send` params for one turn, threading the previous turn's
+/// task id as `context.task_id` so the agent keeps conversation history.
+pub fn build_params(text: &str, task_id: &str, context_task_id: Option<&str>) -> Value {
+    let mut params = json!({
+        "message": { "role": "user", "parts": [{ "kind": "text", "text": text }] },
+        "task_id": task_id,
+    });
+    if let Some(tid) = context_task_id {
+        params["context"] = json!({ "task_id": tid });
+    }
+    params
+}
+
+/// Spawn the blocking streaming dial on a **detached OS thread**, forwarding
+/// deltas, HITL prompts, and the terminal Done/Err event over `tx`, each tagged
+/// with `task_id`.
+///
+/// A plain `std::thread` (not `tokio::task::spawn_blocking`) is deliberate: the
+/// dial parks in a blocking socket read until the task completes, and a detached
+/// thread is not tracked by the tokio runtime, so quitting the TUI mid-stream
+/// cannot hang process shutdown waiting for it (the OS reclaims it on exit).
+pub fn spawn_stream(
+    home: PathBuf,
+    agent: String,
+    params: Value,
+    task_id: String,
+    tx: mpsc::Sender<StreamMsg>,
+) {
+    std::thread::spawn(move || {
+        let tid = task_id.clone();
+        let result = dial_message_streaming(
+            &home,
+            &agent,
+            params,
+            |delta, thinking| {
+                let _ = tx.blocking_send(StreamMsg::Delta {
+                    task_id: tid.clone(),
+                    text: delta.to_string(),
+                    thinking,
+                });
+            },
+            |hitl| {
+                let _ = tx.blocking_send(StreamMsg::Hitl {
+                    task_id: tid.clone(),
+                    req: HitlRequest::from_value(hitl),
+                });
+            },
+        );
+        let _ = match result {
+            Ok(task) => tx.blocking_send(StreamMsg::Done {
+                task_id,
+                task: Box::new(task),
+            }),
+            Err(e) => tx.blocking_send(StreamMsg::Err {
+                task_id,
+                error: format!("{e:#}"),
+            }),
+        };
+    });
+}
+
+/// Answer a pending HITL request on a fresh connection. Does not block the
+/// streaming worker; the agent resumes once the runtime receives this.
+pub async fn respond_hitl(
+    home: PathBuf,
+    agent: String,
+    hitl_id: String,
+    allow: bool,
+) -> Result<()> {
+    tokio::task::spawn_blocking(move || {
+        dial_method(
+            &home,
+            &agent,
+            "tool/hitl_respond",
+            json!({ "hitl_id": hitl_id, "allow": allow }),
+            DialMode::RequireRunning,
+        )
+    })
+    .await??;
+    Ok(())
+}
+
+/// Cancel the in-flight task by id on a fresh connection. Best-effort: the
+/// partial reply already streamed is kept by the caller.
+pub async fn cancel_task(home: PathBuf, agent: String, task_id: String) -> Result<()> {
+    tokio::task::spawn_blocking(move || {
+        dial_method(
+            &home,
+            &agent,
+            "tasks/cancel",
+            json!({ "id": task_id }),
+            DialMode::RequireRunning,
+        )
+    })
+    .await??;
+    Ok(())
+}
+
+/// Extract the agent's reply text and the task id from a final Task value,
+/// matching the Hub's logic: walk `messages` backwards for the most recent
+/// `agent` message and concatenate its text parts.
+pub fn extract_reply(task: &Value) -> (String, Option<String>) {
+    let task_id = task.get("id").and_then(Value::as_str).map(str::to_string);
+    let reply = task
+        .get("messages")
+        .and_then(Value::as_array)
+        .and_then(|msgs| {
+            msgs.iter()
+                .rev()
+                .find(|m| m.get("role").and_then(Value::as_str) == Some("agent"))
+        })
+        .map(extract_text)
+        .unwrap_or_default();
+    (reply, task_id)
+}
+
+/// Interpret a final Task: `Ok((reply, task_id))` for a completed task, or
+/// `Err(cause)` for a failed/cancelled one. The runtime returns failed tasks as
+/// a *successful* JSON-RPC result with the cause in `task.error`, so callers
+/// must inspect `state`/`error` rather than assuming `Ok` means success.
+pub fn task_outcome(task: &Value) -> Result<(String, Option<String>), String> {
+    let state = task.get("state").and_then(Value::as_str).unwrap_or("");
+    if state == "failed" || state == "cancelled" {
+        let cause = task
+            .get("error")
+            .and_then(|e| e.get("message"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("agent task {state}"));
+        return Err(cause);
+    }
+    let (reply, task_id) = extract_reply(task);
+    Ok((reply, task_id))
+}
+
+fn extract_text(message: &Value) -> String {
+    message
+        .get("parts")
+        .and_then(Value::as_array)
+        .map(|parts| {
+            parts
+                .iter()
+                .filter_map(|p| p.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_params_threads_context() {
+        let p = build_params("hi", "t-2", Some("t-1"));
+        assert_eq!(p["message"]["parts"][0]["text"], "hi");
+        assert_eq!(p["task_id"], "t-2");
+        assert_eq!(p["context"]["task_id"], "t-1");
+    }
+
+    #[test]
+    fn build_params_first_turn_has_no_context() {
+        let p = build_params("hi", "t-1", None);
+        assert!(p.get("context").is_none());
+    }
+
+    #[test]
+    fn extract_reply_finds_last_agent_message() {
+        let task = json!({
+            "id": "task-9",
+            "messages": [
+                { "role": "user", "parts": [{ "kind": "text", "text": "q" }] },
+                { "role": "agent", "parts": [
+                    { "kind": "text", "text": "Hello " },
+                    { "kind": "text", "text": "world" }
+                ]}
+            ]
+        });
+        let (reply, id) = extract_reply(&task);
+        assert_eq!(reply, "Hello world");
+        assert_eq!(id.as_deref(), Some("task-9"));
+    }
+
+    #[test]
+    fn task_outcome_failed_surfaces_error() {
+        let task = json!({ "id": "t", "state": "failed", "error": { "message": "rate limited" }, "messages": [] });
+        assert_eq!(task_outcome(&task).unwrap_err(), "rate limited");
+    }
+
+    #[test]
+    fn task_outcome_cancelled_without_error_message() {
+        let task = json!({ "id": "t", "state": "cancelled", "messages": [] });
+        assert_eq!(task_outcome(&task).unwrap_err(), "agent task cancelled");
+    }
+
+    #[test]
+    fn task_outcome_completed_returns_reply() {
+        let task = json!({
+            "id": "t9",
+            "state": "completed",
+            "messages": [{ "role": "agent", "parts": [{ "kind": "text", "text": "hi" }] }]
+        });
+        let (reply, id) = task_outcome(&task).unwrap();
+        assert_eq!(reply, "hi");
+        assert_eq!(id.as_deref(), Some("t9"));
+    }
+
+    #[test]
+    fn stream_msg_task_id_accessor() {
+        let d = StreamMsg::Delta {
+            task_id: "x".into(),
+            text: "a".into(),
+            thinking: false,
+        };
+        assert_eq!(d.task_id(), Some("x"));
+        assert_eq!(StreamMsg::Note("n".into()).task_id(), None);
+    }
+
+    #[test]
+    fn hitl_request_parses_fields_with_fallback() {
+        let h = HitlRequest::from_value(json!({
+            "hitl_id": "h1",
+            "tool_name": "bash",
+            "tool_input": { "command": "ls" }
+        }));
+        assert_eq!(h.hitl_id, "h1");
+        assert_eq!(h.tool_name, "bash");
+        assert_eq!(h.prompt, "Run `bash`?");
+        assert_eq!(h.tool_input["command"], "ls");
+    }
+}

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -1,0 +1,213 @@
+//! Ratatui rendering: transcript pane, input box, status bar, HITL modal.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+
+use super::app::{App, ChatMsg, Role, SPINNER};
+use super::markdown;
+
+const USER: Color = Color::Green;
+const AGENT: Color = Color::Cyan;
+const SYSTEM: Color = Color::DarkGray;
+
+/// Draw the whole UI for one frame.
+pub fn render(f: &mut Frame, app: &App) {
+    let input_lines = app.input.lines().len() as u16;
+    let input_height = (input_lines + 2).clamp(3, 8);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(3),
+            Constraint::Length(input_height),
+            Constraint::Length(1),
+        ])
+        .split(f.area());
+
+    render_transcript(f, app, chunks[0]);
+    f.render_widget(&app.input, chunks[1]);
+    render_status(f, app, chunks[2]);
+
+    if let Some(hitl) = &app.hitl {
+        render_hitl(f, hitl);
+    }
+}
+
+fn render_transcript(f: &mut Frame, app: &App, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" chat · {} ", app.agent));
+    let inner = block.inner(area);
+
+    let mut lines: Vec<Line> = Vec::new();
+    for m in &app.messages {
+        push_message(&mut lines, m, app.spinner);
+    }
+    if lines.is_empty() {
+        lines.push(Line::styled(
+            "Say hello — type below and press Enter.",
+            Style::default().fg(SYSTEM),
+        ));
+    }
+
+    let para = Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false });
+    let total = para.line_count(inner.width) as u16;
+    let max_off = total.saturating_sub(inner.height);
+    let offset = max_off.saturating_sub(app.scroll_back);
+
+    f.render_widget(block, area);
+    f.render_widget(para.scroll((offset, 0)), inner);
+}
+
+fn push_message(lines: &mut Vec<Line<'static>>, m: &ChatMsg, spinner: usize) {
+    match m.role {
+        Role::User => {
+            lines.push(Line::from(Span::styled(
+                "you ›",
+                Style::default().fg(USER).add_modifier(Modifier::BOLD),
+            )));
+            for l in m.text.lines() {
+                lines.push(Line::raw(l.to_string()));
+            }
+            lines.push(Line::default());
+        }
+        Role::System => {
+            lines.push(Line::styled(
+                format!("· {}", m.text),
+                Style::default().fg(SYSTEM).add_modifier(Modifier::ITALIC),
+            ));
+            lines.push(Line::default());
+        }
+        Role::Agent => {
+            lines.push(Line::from(Span::styled(
+                "● agent",
+                Style::default().fg(AGENT).add_modifier(Modifier::BOLD),
+            )));
+            if m.streaming {
+                if !m.thinking.is_empty() {
+                    for l in m.thinking.lines() {
+                        lines.push(Line::styled(
+                            l.to_string(),
+                            Style::default()
+                                .fg(SYSTEM)
+                                .add_modifier(Modifier::ITALIC | Modifier::DIM),
+                        ));
+                    }
+                }
+                let mut body: Vec<Line> =
+                    m.text.lines().map(|l| Line::raw(l.to_string())).collect();
+                // Trailing spinner so the user sees liveness.
+                let spin = SPINNER[spinner % SPINNER.len()];
+                match body.last_mut() {
+                    Some(last) => last
+                        .spans
+                        .push(Span::styled(format!(" {spin}"), Style::default().fg(AGENT))),
+                    None => body.push(Line::styled(spin.to_string(), Style::default().fg(AGENT))),
+                }
+                lines.extend(body);
+            } else if let Some(cached) = &m.rendered {
+                // Finished reply: reuse the markdown rendered once at finish time.
+                lines.extend(cached.iter().cloned());
+            } else {
+                // Fallback (should not happen): render on the fly.
+                lines.extend(markdown::render(&m.text).lines);
+            }
+            lines.push(Line::default());
+        }
+    }
+}
+
+fn render_status(f: &mut Frame, app: &App, area: Rect) {
+    let (msg, color) = if app.hitl.is_some() {
+        (
+            "tool approval needed — [y] approve · [n] deny".to_string(),
+            Color::Yellow,
+        )
+    } else if app.streaming {
+        let spin = SPINNER[app.spinner % SPINNER.len()];
+        (format!("{spin} generating… Ctrl+C to cancel"), AGENT)
+    } else {
+        let ctx = if app.context_task_id.is_some() {
+            " · context kept"
+        } else {
+            ""
+        };
+        (format!("ready{ctx}"), SYSTEM)
+    };
+    let line = Line::from(vec![
+        Span::styled(
+            format!(" {} ", app.agent),
+            Style::default().fg(Color::Black).bg(AGENT),
+        ),
+        Span::raw("  "),
+        Span::styled(msg, Style::default().fg(color)),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn render_hitl(f: &mut Frame, hitl: &super::stream::HitlRequest) {
+    let area = centered_rect(70, 50, f.area());
+    let input = serde_json::to_string_pretty(&hitl.tool_input).unwrap_or_default();
+    let mut lines = vec![
+        Line::from(Span::styled(
+            hitl.prompt.clone(),
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::default(),
+        Line::from(vec![
+            Span::styled("tool: ", Style::default().fg(SYSTEM)),
+            Span::styled(hitl.tool_name.clone(), Style::default().fg(Color::Yellow)),
+        ]),
+    ];
+    for l in input.lines().take(12) {
+        lines.push(Line::styled(l.to_string(), Style::default().fg(SYSTEM)));
+    }
+    lines.push(Line::default());
+    lines.push(Line::from(vec![
+        Span::styled(
+            "[y]",
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" approve    "),
+        Span::styled(
+            "[n]",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" deny / Esc"),
+    ]));
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow))
+        .title(" approve tool call ");
+    f.render_widget(Clear, area);
+    f.render_widget(
+        Paragraph::new(Text::from(lines))
+            .wrap(Wrap { trim: false })
+            .block(block),
+        area,
+    );
+}
+
+fn centered_rect(pct_x: u16, pct_y: u16, area: Rect) -> Rect {
+    let v = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - pct_y) / 2),
+            Constraint::Percentage(pct_y),
+            Constraint::Percentage((100 - pct_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - pct_x) / 2),
+            Constraint::Percentage(pct_x),
+            Constraint::Percentage((100 - pct_x) / 2),
+        ])
+        .split(v[1])[1]
+}

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -25,6 +25,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use mur_common::{AgentProfile as _AgentProfile, LockFile};
 
 mod apply;
+mod cli;
 mod comm;
 pub mod export;
 mod hub;
@@ -49,6 +50,7 @@ mod stats;
 #[allow(unused_imports)]
 pub use apply::cmd_agent_apply;
 #[allow(unused_imports)]
+pub use cli::cmd_cli;
 pub use comm::{cmd_card, cmd_send};
 #[allow(unused_imports)]
 pub use export::cmd_export;

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1043,6 +1043,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
         AgentAction::Rename { old, new } => cmd::agent::cmd_rename(&old, &new)?,
         AgentAction::Send { name, message } => cmd::agent::cmd_send(&name, &message)?,
         AgentAction::Card { name } => cmd::agent::cmd_card(&name)?,
+        AgentAction::Cli { name, resume } => cmd::agent::cmd_cli(&name, resume).await?,
         AgentAction::Pair { name } => cmd::agent_pair::cmd_pair(&name)?,
         AgentAction::Rekey {
             name,


### PR DESCRIPTION
## Summary

Adds `mur agent cli <name>` — a full **ratatui TUI chat** with a running MUR agent (Pi/Claude-Code style), as the terminal-native counterpart to the Hub GUI. It's a thin front-end over the existing A2A streaming client (`dial_message_streaming`) — **no protocol or runtime changes**. Works over SSH/headless, is pipeable, and starts instantly (no WebKit/Tauri).

## Features
- Live token streaming with dimmed "thinking" tokens; **markdown re-render** on completion (reuses the existing `pulldown-cmark` dep — no new crate).
- **Slash commands** `/help /clear /card /sessions /exit` with tab-completion.
- **Inline HITL** tool-approval modal, answered on a separate connection.
- **Session persistence** as JSONL under `~/.mur/agents/<name>/cli-sessions/`, with `--resume`.
- **Non-TTY** stdin/stdout falls back to plain streamed text (pipe-safe / scriptable).

## Structure
New submodule `mur-core/src/cmd/agent/cli/` (`mod`/`app`/`stream`/`ui`/`markdown`/`persist`), each file <800 lines. 3-line wiring into `cli/agent.rs`, `dispatch.rs`, `cmd/agent/mod.rs`. New deps (mur-core only): `ratatui`, `crossterm`, `tui-textarea`.

## Hardening
The first cut went through a max-effort multi-agent code review (50 agents, 65 candidates → 15 confirmed). All correctness/UX findings are fixed in this PR:
- **Turn identity:** every `StreamMsg` is tagged with its `task_id`; stale events from a cancelled/cleared/finished turn are dropped, and persist + context-threading are gated on the matched turn — a still-running worker can no longer corrupt a later turn.
- **No hang on quit:** the blocking dial runs on a detached `std::thread`; `/clear` and quit cancel the in-flight task.
- **Failures surfaced:** Failed/Cancelled tasks (`task.error`) show a real error instead of a blank bubble; session-write failures warn once; HITL/cancel dial errors route back as notices.
- **Input routing:** typed input isn't lost when busy; paste is guarded and Ctrl+C/Ctrl+D stay live while the HITL modal is open; streaming no longer yanks scroll.
- **Rendering:** tight markdown lists no longer double-space; finished messages cache their rendered markdown (no re-parse per frame).

### Known limitation (follow-up)
The runtime broadcasts `message/delta` to **all** connected sockets, so a concurrent client driving the same agent can interleave tokens into the live bubble. This is inherent to `dial_message_streaming` and **Hub has the identical behavior**; a proper fix needs a runtime-side per-connection/task filter (out of scope here).

## Test plan
- `cargo build -p mur-core` ✓ · `cargo clippy -p mur-core -- -D warnings` ✓ (zero issues in `cli/`) · `cargo fmt --check` ✓
- **24 unit tests** pass, incl. regressions for stale-event gating, failed-task→error, tight-list rendering, scroll preservation, markdown caching.
- Non-TTY streaming verified end-to-end against a live `mur` agent.
- TUI itself needs a real terminal: `mur agent run <name>` then `mur agent cli <name>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)