### PR TITLE
fix(runtime): route streaming notifications per-connection (#14)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.22.16"
+version = "2.22.17"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-agent-runtime/src/protocol/a2a_server.rs
+++ b/mur-agent-runtime/src/protocol/a2a_server.rs
@@ -4,6 +4,33 @@ use async_trait::async_trait;
 use mur_common::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
 use serde_json::{Value, json};
 use std::collections::HashMap;
+use tokio::sync::mpsc;
+
+/// Per-request context handed to each handler. Carries the **issuing
+/// connection's** notification sink so streaming handlers (`message/send`) emit
+/// `message/delta` / `tool/approval_needed` to *that* connection only, instead
+/// of a runtime-wide broadcast that would leak one client's tokens to another.
+/// `notifier` is `None` for transports that don't stream per-connection (the
+/// handler then falls back to any baked-in notifier).
+#[derive(Clone, Default)]
+pub struct RequestContext {
+    pub notifier: Option<mpsc::Sender<Value>>,
+}
+
+impl RequestContext {
+    /// A context with no per-connection notifier (single-client / non-streaming
+    /// transports).
+    pub fn none() -> Self {
+        Self { notifier: None }
+    }
+
+    /// A context routing notifications to one connection's sink.
+    pub fn with_notifier(notifier: mpsc::Sender<Value>) -> Self {
+        Self {
+            notifier: Some(notifier),
+        }
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum HandlerError {
@@ -45,7 +72,11 @@ impl HandlerError {
 
 #[async_trait]
 pub trait MethodHandler: Send + Sync {
-    async fn handle(&self, params: Option<Value>) -> Result<Value, HandlerError>;
+    async fn handle(
+        &self,
+        params: Option<Value>,
+        ctx: &RequestContext,
+    ) -> Result<Value, HandlerError>;
 }
 
 pub struct Dispatcher {
@@ -69,13 +100,17 @@ impl Dispatcher {
         self.methods.insert(name.to_string(), handler);
     }
 
-    pub async fn dispatch(&self, req: JsonRpcRequest) -> Result<JsonRpcResponse, HandlerError> {
+    pub async fn dispatch(
+        &self,
+        req: JsonRpcRequest,
+        ctx: &RequestContext,
+    ) -> Result<JsonRpcResponse, HandlerError> {
         let id = req.id.clone().unwrap_or(json!(null));
         if req.jsonrpc != "2.0" {
             return Ok(Self::err_response(id, -32600, "jsonrpc must be '2.0'"));
         }
         match self.methods.get(&req.method) {
-            Some(handler) => match handler.handle(req.params).await {
+            Some(handler) => match handler.handle(req.params, ctx).await {
                 Ok(result) => Ok(JsonRpcResponse {
                     jsonrpc: "2.0".into(),
                     id,

--- a/mur-agent-runtime/src/protocol/methods/card.rs
+++ b/mur-agent-runtime/src/protocol/methods/card.rs
@@ -1,7 +1,7 @@
 //! agent/card method — project AgentProfile into an A2A Agent Card.
 
 use crate::profile::Profile;
-use crate::protocol::a2a_server::{HandlerError, MethodHandler};
+use crate::protocol::a2a_server::{HandlerError, MethodHandler, RequestContext};
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use std::sync::Arc;
@@ -18,7 +18,11 @@ impl CardHandler {
 
 #[async_trait]
 impl MethodHandler for CardHandler {
-    async fn handle(&self, _params: Option<Value>) -> Result<Value, HandlerError> {
+    async fn handle(
+        &self,
+        _params: Option<Value>,
+        _ctx: &RequestContext,
+    ) -> Result<Value, HandlerError> {
         let p = &self.profile.inner;
 
         let mut transports: Vec<&str> = vec![];

--- a/mur-agent-runtime/src/protocol/methods/message_send.rs
+++ b/mur-agent-runtime/src/protocol/methods/message_send.rs
@@ -1,6 +1,6 @@
 //! message/send handler.
 
-use crate::protocol::a2a_server::{HandlerError, MethodHandler};
+use crate::protocol::a2a_server::{HandlerError, MethodHandler, RequestContext};
 use crate::task_runner::{TaskOutcome, TaskRunner, TaskSpec};
 use crate::telemetry_writer::Event;
 use async_trait::async_trait;
@@ -8,6 +8,10 @@ use mur_common::a2a::Message;
 use serde_json::{Value, json};
 use std::sync::Arc;
 use tokio::sync::mpsc;
+
+/// Buffer of the LLM-token → notification forwarding channel. Bounded; overflow
+/// is lossy (a dropped delta beats stalling generation on a slow client).
+const STREAM_DELTA_CAP: usize = 256;
 
 pub struct MessageSendHandler {
     runner: Arc<TaskRunner>,
@@ -56,7 +60,11 @@ impl MessageSendHandler {
 
 #[async_trait]
 impl MethodHandler for MessageSendHandler {
-    async fn handle(&self, params: Option<Value>) -> Result<Value, HandlerError> {
+    async fn handle(
+        &self,
+        params: Option<Value>,
+        ctx: &RequestContext,
+    ) -> Result<Value, HandlerError> {
         let p = params.ok_or_else(|| HandlerError::InvalidParams("missing params".into()))?;
         let message: Message = serde_json::from_value(p["message"].clone())
             .map_err(|e| HandlerError::InvalidParams(format!("message: {e}")))?;
@@ -73,6 +81,10 @@ impl MethodHandler for MessageSendHandler {
             .get("task_id")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        // Kept for stamping deltas and routing this turn's HITL prompts after
+        // `spec` consumes the originals below.
+        let turn_task_id = task_id.clone();
+        let turn_context_id = context_task_id.clone();
         let spec = TaskSpec {
             input: message,
             context_task_id,
@@ -80,18 +92,39 @@ impl MethodHandler for MessageSendHandler {
         };
 
         self.emit_progress("pending", "llm_reasoning", None).await;
-        let outcome = match &self.notifier {
+        // Prefer the issuing connection's per-request sink (so deltas/HITL reach
+        // ONLY this client); fall back to any baked-in notifier for transports
+        // that don't route per-connection.
+        let stream_notifier = ctx.notifier.clone().or_else(|| self.notifier.clone());
+        let outcome = match stream_notifier {
             Some(notifier) => {
+                // Route this turn's HITL approval prompts back to this same
+                // connection (looked up by task id inside the runner).
+                if let Some(tid) = &turn_task_id {
+                    self.runner
+                        .register_client_notifier(tid, notifier.clone())
+                        .await;
+                }
                 // Forward each LLM token delta to the connected client as a
-                // `message/delta` notification while the reply generates.
-                let (delta_tx, mut delta_rx) = mpsc::channel::<crate::llm::StreamDelta>(256);
-                let notifier = notifier.clone();
+                // `message/delta` notification while the reply generates, stamped
+                // with task_id/context_id so the client can correlate the turn.
+                let (delta_tx, mut delta_rx) =
+                    mpsc::channel::<crate::llm::StreamDelta>(STREAM_DELTA_CAP);
+                let delta_task_id = turn_task_id.clone();
+                let delta_context_id = turn_context_id.clone();
                 let forward = tokio::spawn(async move {
                     while let Some(d) = delta_rx.recv().await {
+                        let mut delta_params = json!({ "text": d.text, "thinking": d.thinking });
+                        if let Some(t) = &delta_task_id {
+                            delta_params["task_id"] = json!(t);
+                        }
+                        if let Some(c) = &delta_context_id {
+                            delta_params["context_id"] = json!(c);
+                        }
                         let note = json!({
                             "jsonrpc": "2.0",
                             "method": "message/delta",
-                            "params": { "text": d.text, "thinking": d.thinking },
+                            "params": delta_params,
                         });
                         if notifier.send(note).await.is_err() {
                             break;
@@ -100,6 +133,9 @@ impl MethodHandler for MessageSendHandler {
                 });
                 let outcome = self.runner.run_sync_streaming(spec, delta_tx).await;
                 let _ = forward.await;
+                if let Some(tid) = &turn_task_id {
+                    self.runner.unregister_client_notifier(tid).await;
+                }
                 outcome
             }
             None => self.runner.run_sync(spec).await,
@@ -134,7 +170,10 @@ mod tests {
     async fn supplied_task_id_flows_into_returned_task() {
         let handler = MessageSendHandler::new(Arc::new(TaskRunner::new_stub_echo()));
         let out = handler
-            .handle(Some(user_params(Some("task-from-client"))))
+            .handle(
+                Some(user_params(Some("task-from-client"))),
+                &RequestContext::none(),
+            )
             .await
             .expect("handle ok");
         assert_eq!(
@@ -147,7 +186,7 @@ mod tests {
     async fn absent_task_id_is_back_compatible() {
         let handler = MessageSendHandler::new(Arc::new(TaskRunner::new_stub_echo()));
         let out = handler
-            .handle(Some(user_params(None)))
+            .handle(Some(user_params(None)), &RequestContext::none())
             .await
             .expect("handle ok");
         // Runner generated its own id (prefixed "task-"), not a client id.

--- a/mur-agent-runtime/src/protocol/methods/skills.rs
+++ b/mur-agent-runtime/src/protocol/methods/skills.rs
@@ -11,7 +11,7 @@ use mur_common::skill::{
 use serde_json::{Value, json};
 use std::path::PathBuf;
 
-use crate::protocol::a2a_server::{HandlerError, MethodHandler};
+use crate::protocol::a2a_server::{HandlerError, MethodHandler, RequestContext};
 
 pub struct SkillsGetHandler {
     /// Root of the skill store this handler serves from. In M4a this is
@@ -27,7 +27,11 @@ impl SkillsGetHandler {
 
 #[async_trait]
 impl MethodHandler for SkillsGetHandler {
-    async fn handle(&self, params: Option<Value>) -> Result<Value, HandlerError> {
+    async fn handle(
+        &self,
+        params: Option<Value>,
+        _ctx: &RequestContext,
+    ) -> Result<Value, HandlerError> {
         let params = params.ok_or_else(|| HandlerError::InvalidParams("missing params".into()))?;
 
         let skill_name = params
@@ -89,7 +93,10 @@ content:
 
         let handler = SkillsGetHandler::new(dir.path().to_path_buf());
         let result = handler
-            .handle(Some(json!({"skill": "test-skill"})))
+            .handle(
+                Some(json!({"skill": "test-skill"})),
+                &RequestContext::none(),
+            )
             .await
             .unwrap();
 
@@ -103,7 +110,7 @@ content:
         let dir = tempdir().unwrap();
         let handler = SkillsGetHandler::new(dir.path().to_path_buf());
         let err = handler
-            .handle(Some(json!({"skill": "nope"})))
+            .handle(Some(json!({"skill": "nope"})), &RequestContext::none())
             .await
             .unwrap_err();
         assert!(matches!(err, HandlerError::Internal(_)));
@@ -113,7 +120,10 @@ content:
     async fn missing_skill_param_returns_invalid_params() {
         let dir = tempdir().unwrap();
         let handler = SkillsGetHandler::new(dir.path().to_path_buf());
-        let err = handler.handle(Some(json!({}))).await.unwrap_err();
+        let err = handler
+            .handle(Some(json!({})), &RequestContext::none())
+            .await
+            .unwrap_err();
         assert!(matches!(err, HandlerError::InvalidParams(_)));
     }
 
@@ -132,7 +142,7 @@ content:
             "a\\b",
         ] {
             let err = handler
-                .handle(Some(json!({ "skill": bad })))
+                .handle(Some(json!({ "skill": bad })), &RequestContext::none())
                 .await
                 .unwrap_err();
             assert!(

--- a/mur-agent-runtime/src/protocol/methods/tasks.rs
+++ b/mur-agent-runtime/src/protocol/methods/tasks.rs
@@ -1,6 +1,6 @@
 //! tasks/* handlers.
 
-use crate::protocol::a2a_server::{HandlerError, MethodHandler};
+use crate::protocol::a2a_server::{HandlerError, MethodHandler, RequestContext};
 use crate::task_runner::TaskRunner;
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -18,7 +18,11 @@ impl TasksGetHandler {
 
 #[async_trait]
 impl MethodHandler for TasksGetHandler {
-    async fn handle(&self, params: Option<Value>) -> Result<Value, HandlerError> {
+    async fn handle(
+        &self,
+        params: Option<Value>,
+        _ctx: &RequestContext,
+    ) -> Result<Value, HandlerError> {
         let id = params
             .and_then(|p| p.get("id").and_then(|v| v.as_str().map(String::from)))
             .ok_or_else(|| HandlerError::InvalidParams("missing id".into()))?;
@@ -41,7 +45,11 @@ impl TasksCancelHandler {
 
 #[async_trait]
 impl MethodHandler for TasksCancelHandler {
-    async fn handle(&self, params: Option<Value>) -> Result<Value, HandlerError> {
+    async fn handle(
+        &self,
+        params: Option<Value>,
+        _ctx: &RequestContext,
+    ) -> Result<Value, HandlerError> {
         let id = params
             .and_then(|p| p.get("id").and_then(|v| v.as_str().map(String::from)))
             .ok_or_else(|| HandlerError::InvalidParams("missing id".into()))?;
@@ -65,7 +73,11 @@ impl TasksListHandler {
 
 #[async_trait]
 impl MethodHandler for TasksListHandler {
-    async fn handle(&self, _params: Option<Value>) -> Result<Value, HandlerError> {
+    async fn handle(
+        &self,
+        _params: Option<Value>,
+        _ctx: &RequestContext,
+    ) -> Result<Value, HandlerError> {
         // P0a: return empty list; full history comes when we persist TaskRunner state.
         Ok(json!([]))
     }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -387,7 +387,11 @@ pub async fn entrypoint() -> anyhow::Result<()> {
                 // Dispatcher::dispatch returns Result<JsonRpcResponse, HandlerError>;
                 // map HandlerError to a JSON-RPC error envelope so the caller
                 // always receives a well-formed response frame.
-                let resp = match d.dispatch(req).await {
+                // TCP is request/reply with no per-connection streaming sink.
+                let resp = match d
+                    .dispatch(req, &crate::protocol::a2a_server::RequestContext::none())
+                    .await
+                {
                     Ok(r) => r,
                     Err(e) => JsonRpcResponse {
                         jsonrpc: "2.0".into(),
@@ -669,6 +673,7 @@ impl crate::protocol::a2a_server::MethodHandler for HitlRespondHandler {
     async fn handle(
         &self,
         params: Option<serde_json::Value>,
+        _ctx: &crate::protocol::a2a_server::RequestContext,
     ) -> Result<serde_json::Value, crate::protocol::a2a_server::HandlerError> {
         let p = params.ok_or_else(|| {
             crate::protocol::a2a_server::HandlerError::InvalidParams("missing params".into())
@@ -706,6 +711,7 @@ impl crate::protocol::a2a_server::MethodHandler for HitlTestRequestHandler {
     async fn handle(
         &self,
         params: Option<serde_json::Value>,
+        ctx: &crate::protocol::a2a_server::RequestContext,
     ) -> Result<serde_json::Value, crate::protocol::a2a_server::HandlerError> {
         let p = params.unwrap_or(serde_json::json!({}));
         let tool_name = p["tool_name"].as_str().unwrap_or("bash").to_string();
@@ -728,7 +734,14 @@ impl crate::protocol::a2a_server::MethodHandler for HitlTestRequestHandler {
                 "timeout_ms": timeout_secs * 1000,
             }
         });
-        let _ = self.notifier.send(notification).await;
+        // Route to the issuing connection when present (diagnostic method, but
+        // it must not broadcast to other clients either); fall back otherwise.
+        let _ = ctx
+            .notifier
+            .as_ref()
+            .unwrap_or(&self.notifier)
+            .send(notification)
+            .await;
         Ok(serde_json::json!({"hitl_id": hitl_id}))
     }
 }
@@ -1086,9 +1099,10 @@ mod hitl_tests {
             pending_approvals: pending.clone(),
         };
         let result = handler
-            .handle(Some(
-                json!({"hitl_id": "test-id", "allow": true, "reason": "looks good"}),
-            ))
+            .handle(
+                Some(json!({"hitl_id": "test-id", "allow": true, "reason": "looks good"})),
+                &crate::protocol::a2a_server::RequestContext::none(),
+            )
             .await;
         assert!(result.is_ok());
 
@@ -1108,7 +1122,10 @@ mod hitl_tests {
             pending_approvals: pending.clone(),
         };
         let result = handler
-            .handle(Some(json!({"hitl_id": "test-id", "allow": false})))
+            .handle(
+                Some(json!({"hitl_id": "test-id", "allow": false})),
+                &crate::protocol::a2a_server::RequestContext::none(),
+            )
             .await;
         assert!(result.is_ok());
 
@@ -1125,7 +1142,10 @@ mod hitl_tests {
             pending_approvals: pending.clone(),
         };
         let result = handler
-            .handle(Some(json!({"hitl_id": "no-such-id", "allow": false})))
+            .handle(
+                Some(json!({"hitl_id": "no-such-id", "allow": false})),
+                &crate::protocol::a2a_server::RequestContext::none(),
+            )
             .await;
         assert!(result.is_err());
     }

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -71,6 +71,11 @@ pub struct TaskRunner {
     hook_cancel: Option<CancellationToken>,
     pending_approvals: Option<HitlApprovals>,
     notifier: Option<tokio::sync::mpsc::Sender<serde_json::Value>>,
+    /// Per-turn client notifiers keyed by task id, registered by `message/send`
+    /// so a tool-approval prompt is routed to the connection that issued the
+    /// turn instead of broadcast to every client. Falls back to `notifier`.
+    client_notifiers:
+        Arc<tokio::sync::Mutex<HashMap<String, tokio::sync::mpsc::Sender<serde_json::Value>>>>,
     hitl_timeout_secs: u32,
     max_iterations: u32,
     tools: Vec<Arc<dyn crate::tools::ToolExecutor>>,
@@ -115,6 +120,7 @@ impl TaskRunner {
             hook_cancel: None,
             pending_approvals: None,
             notifier: None,
+            client_notifiers: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             hitl_timeout_secs: 300,
             max_iterations: 10,
             tools: vec![],
@@ -172,6 +178,24 @@ impl TaskRunner {
     pub fn with_notifier(mut self, tx: tokio::sync::mpsc::Sender<serde_json::Value>) -> Self {
         self.notifier = Some(tx);
         self
+    }
+
+    /// Register the connection sink that should receive this turn's HITL
+    /// approval prompts, keyed by the turn's task id.
+    pub async fn register_client_notifier(
+        &self,
+        task_id: &str,
+        tx: tokio::sync::mpsc::Sender<serde_json::Value>,
+    ) {
+        self.client_notifiers
+            .lock()
+            .await
+            .insert(task_id.to_string(), tx);
+    }
+
+    /// Drop the per-turn HITL sink once the turn completes.
+    pub async fn unregister_client_notifier(&self, task_id: &str) {
+        self.client_notifiers.lock().await.remove(task_id);
     }
 
     pub fn with_hitl_timeout_secs(mut self, secs: u32) -> Self {
@@ -639,7 +663,7 @@ impl TaskRunner {
 
     async fn handle_tool_call(
         &self,
-        _task_id: &str,
+        task_id: &str,
         call: &crate::llm::ToolCallResult,
     ) -> Result<crate::llm::ToolResultEntry, TaskError> {
         use crate::llm::ToolResultEntry;
@@ -694,46 +718,51 @@ impl TaskRunner {
             Err(e) => (format!("tool error: {e}"), true),
         };
 
-        // 3. HITL gate (only after tool execution)
-        let decision = if let (Some(pa), Some(notifier)) = (&self.pending_approvals, &self.notifier)
-        {
-            let hitl_id = uuid::Uuid::now_v7().to_string();
-            let (tx, rx) = tokio::sync::oneshot::channel::<crate::hitl::HitlDecision>();
-            pa.lock().await.insert(hitl_id.clone(), tx);
-            let notification = serde_json::json!({
-                "jsonrpc": "2.0",
-                "method": "tool/approval_needed",
-                "params": {
-                    "hitl_id": hitl_id,
-                    "tool_name": call.tool_name,
-                    "tool_input": call.input,
-                    "output": output,
-                    "is_error": is_error,
-                    "timeout_ms": (self.hitl_timeout_secs as u64) * 1000,
-                }
-            });
-            let _ = notifier.send(notification).await;
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(self.hitl_timeout_secs as u64),
-                rx,
-            )
-            .await
-            {
-                Ok(Ok(d)) => d,
-                _ => {
-                    pa.lock().await.remove(&hitl_id);
-                    crate::hitl::HitlDecision {
-                        allow: false,
-                        reason: Some("timed out".into()),
+        // 3. HITL gate (only after tool execution). Route the approval prompt to
+        // the connection that issued this turn (looked up by task id), falling
+        // back to the baked notifier — never broadcast to other clients.
+        let routed = self.client_notifiers.lock().await.get(task_id).cloned();
+        let effective_notifier = routed.as_ref().or(self.notifier.as_ref());
+        let decision =
+            if let (Some(pa), Some(notifier)) = (&self.pending_approvals, effective_notifier) {
+                let hitl_id = uuid::Uuid::now_v7().to_string();
+                let (tx, rx) = tokio::sync::oneshot::channel::<crate::hitl::HitlDecision>();
+                pa.lock().await.insert(hitl_id.clone(), tx);
+                let notification = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "method": "tool/approval_needed",
+                    "params": {
+                        "hitl_id": hitl_id,
+                        "task_id": task_id,
+                        "tool_name": call.tool_name,
+                        "tool_input": call.input,
+                        "output": output,
+                        "is_error": is_error,
+                        "timeout_ms": (self.hitl_timeout_secs as u64) * 1000,
+                    }
+                });
+                let _ = notifier.send(notification).await;
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(self.hitl_timeout_secs as u64),
+                    rx,
+                )
+                .await
+                {
+                    Ok(Ok(d)) => d,
+                    _ => {
+                        pa.lock().await.remove(&hitl_id);
+                        crate::hitl::HitlDecision {
+                            allow: false,
+                            reason: Some("timed out".into()),
+                        }
                     }
                 }
-            }
-        } else {
-            crate::hitl::HitlDecision {
-                allow: true,
-                reason: None,
-            }
-        };
+            } else {
+                crate::hitl::HitlDecision {
+                    allow: true,
+                    reason: None,
+                }
+            };
 
         if !decision.allow {
             let reason_str = decision.reason.as_deref().unwrap_or("denied");

--- a/mur-agent-runtime/src/transport/stdio.rs
+++ b/mur-agent-runtime/src/transport/stdio.rs
@@ -1,6 +1,6 @@
 //! Newline-delimited JSON-RPC 2.0 over stdio.
 
-use crate::protocol::a2a_server::Dispatcher;
+use crate::protocol::a2a_server::{Dispatcher, RequestContext};
 use futures::StreamExt;
 use mur_common::JsonRpcRequest;
 use serde_json::Value;
@@ -55,7 +55,9 @@ where
             Ok(r) => r,
             Err(_) => continue, // silently drop malformed; dispatcher also guards
         };
-        let resp = match dispatcher.dispatch(req).await {
+        // stdio is a single peer; notifications already fan to this one stdout
+        // via the baked notifier, so no per-connection routing is needed.
+        let resp = match dispatcher.dispatch(req, &RequestContext::none()).await {
             Ok(r) => r,
             Err(_) => continue,
         };

--- a/mur-agent-runtime/src/transport/unix_socket.rs
+++ b/mur-agent-runtime/src/transport/unix_socket.rs
@@ -1,7 +1,7 @@
 //! Unix domain socket transport — JSON-RPC 2.0 newline-delimited,
 //! with SO_PEERCRED caller resolution (Task 22 consumes this).
 
-use crate::protocol::a2a_server::Dispatcher;
+use crate::protocol::a2a_server::{Dispatcher, RequestContext};
 use futures::StreamExt;
 use mur_common::JsonRpcRequest;
 use serde_json::Value;
@@ -16,6 +16,12 @@ use tokio_util::codec::{FramedRead, LinesCodec};
 /// this at read time — the internal buffer never exceeds this limit, giving
 /// true allocation-bounded reads. Aligned with `transport::noise::MAX_FRAME_BYTES`.
 const MAX_LINE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Capacity of the notification channels (telemetry broadcast and the
+/// per-connection request-scoped sink). Bounded so a slow client can't grow an
+/// unbounded backlog; overflow is lossy by design (a dropped token delta is
+/// preferable to blocking generation).
+const NOTIFY_CHANNEL_CAP: usize = 256;
 
 #[derive(Debug, Clone, Copy)]
 pub struct PeerInfo {
@@ -39,7 +45,12 @@ pub async fn serve_unix(
         perms.set_mode(0o600);
         std::fs::set_permissions(&path, perms)?;
     }
-    let (bcast_tx, _) = tokio::sync::broadcast::channel::<Value>(256);
+    // Broadcast carries only request-INDEPENDENT notifications (telemetry,
+    // skill-executed, progress) to every connection. Request-SCOPED streaming
+    // (token deltas + HITL prompts) is NOT broadcast — it is routed to the
+    // issuing connection via that connection's own sink (see below), so one
+    // client never receives another client's tokens.
+    let (bcast_tx, _) = tokio::sync::broadcast::channel::<Value>(NOTIFY_CHANNEL_CAP);
     let bcast_forward = bcast_tx.clone();
     tokio::spawn(async move {
         while let Some(n) = notifications.recv().await {
@@ -65,6 +76,25 @@ pub async fn serve_unix(
                     let _ = w.flush().await;
                 }
             });
+
+            // Per-connection sink for request-scoped notifications. Handlers
+            // receive this via `RequestContext` and stream `message/delta` /
+            // `tool/approval_needed` here — delivered ONLY to this socket.
+            let (conn_notif_tx, mut conn_notif_rx) =
+                tokio::sync::mpsc::channel::<Value>(NOTIFY_CHANNEL_CAP);
+            let w_req = write.clone();
+            let req_notif_task = tokio::spawn(async move {
+                while let Some(n) = conn_notif_rx.recv().await {
+                    let line = format!("{n}\n");
+                    let mut w = w_req.lock().await;
+                    if w.write_all(line.as_bytes()).await.is_err() {
+                        break;
+                    }
+                    let _ = w.flush().await;
+                }
+            });
+            let ctx = RequestContext::with_notifier(conn_notif_tx);
+
             let codec = LinesCodec::new_with_max_length(MAX_LINE_BYTES);
             let mut framed = FramedRead::new(read, codec);
             while let Some(result) = framed.next().await {
@@ -83,7 +113,7 @@ pub async fn serve_unix(
                     Ok(r) => r,
                     Err(_) => continue,
                 };
-                let resp = match dispatcher.dispatch(req).await {
+                let resp = match dispatcher.dispatch(req, &ctx).await {
                     Ok(r) => r,
                     Err(_) => continue,
                 };
@@ -99,6 +129,7 @@ pub async fn serve_unix(
             }
             let _ = peer; // passed to auth / communication_policy via request context in Task 22
             notif_task.abort();
+            req_notif_task.abort();
         });
     }
 }

--- a/mur-agent-runtime/tests/a2a_dispatch.rs
+++ b/mur-agent-runtime/tests/a2a_dispatch.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
-use mur_agent_runtime::protocol::a2a_server::{Dispatcher, HandlerError, MethodHandler};
+use mur_agent_runtime::protocol::a2a_server::{
+    Dispatcher, HandlerError, MethodHandler, RequestContext,
+};
 use mur_common::JsonRpcRequest;
 use serde_json::{Value, json};
 
@@ -7,7 +9,11 @@ struct Echo;
 
 #[async_trait]
 impl MethodHandler for Echo {
-    async fn handle(&self, params: Option<Value>) -> Result<Value, HandlerError> {
+    async fn handle(
+        &self,
+        params: Option<Value>,
+        _ctx: &RequestContext,
+    ) -> Result<Value, HandlerError> {
         Ok(params.unwrap_or(json!(null)))
     }
 }
@@ -22,7 +28,7 @@ async fn dispatches_known_method() {
         method: "echo".into(),
         params: Some(json!("hi")),
     };
-    let resp = d.dispatch(req).await.unwrap();
+    let resp = d.dispatch(req, &RequestContext::none()).await.unwrap();
     assert_eq!(resp.result, Some(json!("hi")));
     assert!(resp.error.is_none());
 }
@@ -36,7 +42,7 @@ async fn returns_method_not_found_with_code_neg32601() {
         method: "nope".into(),
         params: None,
     };
-    let resp = d.dispatch(req).await.unwrap();
+    let resp = d.dispatch(req, &RequestContext::none()).await.unwrap();
     assert_eq!(resp.error.as_ref().unwrap().code, -32601);
 }
 
@@ -45,7 +51,11 @@ async fn maps_handler_error_to_custom_code() {
     struct Fails;
     #[async_trait]
     impl MethodHandler for Fails {
-        async fn handle(&self, _p: Option<Value>) -> Result<Value, HandlerError> {
+        async fn handle(
+            &self,
+            _p: Option<Value>,
+            _ctx: &RequestContext,
+        ) -> Result<Value, HandlerError> {
             Err(HandlerError::CommunicationDenied("caller_x".into()))
         }
     }
@@ -57,6 +67,6 @@ async fn maps_handler_error_to_custom_code() {
         method: "x".into(),
         params: None,
     };
-    let resp = d.dispatch(req).await.unwrap();
+    let resp = d.dispatch(req, &RequestContext::none()).await.unwrap();
     assert_eq!(resp.error.as_ref().unwrap().code, -32011);
 }

--- a/mur-agent-runtime/tests/card_extended.rs
+++ b/mur-agent-runtime/tests/card_extended.rs
@@ -22,7 +22,13 @@ fn test_profile() -> Profile {
 async fn card_includes_pubkey_endpoints_deployment() {
     let p = Arc::new(test_profile());
     let handler = CardHandler::new(p);
-    let json = handler.handle(None).await.unwrap();
+    let json = handler
+        .handle(
+            None,
+            &mur_agent_runtime::protocol::a2a_server::RequestContext::none(),
+        )
+        .await
+        .unwrap();
 
     assert_eq!(json["pubkey"], "zTESTPUB");
     let eps = json["endpoints"].as_array().unwrap();
@@ -94,7 +100,13 @@ updated_at: "2026-04-25T10:00:00+08:00"
     std::mem::forget(tmp);
 
     let handler = CardHandler::new(Arc::new(profile));
-    let json = handler.handle(None).await.unwrap();
+    let json = handler
+        .handle(
+            None,
+            &mur_agent_runtime::protocol::a2a_server::RequestContext::none(),
+        )
+        .await
+        .unwrap();
     assert_eq!(json["pubkey"], "zNEWKEY");
     assert_eq!(json["previous_pubkey"], "zOLDKEY");
     assert_eq!(json["previous_key_version"], 1);
@@ -162,7 +174,13 @@ updated_at: "2026-04-25T10:00:00+08:00"
     std::mem::forget(tmp);
 
     let handler = CardHandler::new(Arc::new(profile));
-    let json = handler.handle(None).await.unwrap();
+    let json = handler
+        .handle(
+            None,
+            &mur_agent_runtime::protocol::a2a_server::RequestContext::none(),
+        )
+        .await
+        .unwrap();
     assert_eq!(json["pubkey"], "zNEWKEY");
     assert!(
         json.get("previous_pubkey").is_none(),

--- a/mur-agent-runtime/tests/card_method.rs
+++ b/mur-agent-runtime/tests/card_method.rs
@@ -6,7 +6,13 @@ use std::sync::Arc;
 async fn card_returns_agent_identity_and_card_fields() {
     let profile = load_test_profile();
     let handler = CardHandler::new(Arc::new(profile));
-    let result = handler.handle(None).await.unwrap();
+    let result = handler
+        .handle(
+            None,
+            &mur_agent_runtime::protocol::a2a_server::RequestContext::none(),
+        )
+        .await
+        .unwrap();
     assert_eq!(result["name"], "agent_a");
     assert_eq!(result["protocolVersion"], "a2a/0.3");
     assert!(
@@ -60,7 +66,13 @@ async fn card_emits_installed_skills_block() {
     std::mem::forget(tmp);
 
     let handler = CardHandler::new(Arc::new(profile));
-    let card = handler.handle(None).await.unwrap();
+    let card = handler
+        .handle(
+            None,
+            &mur_agent_runtime::protocol::a2a_server::RequestContext::none(),
+        )
+        .await
+        .unwrap();
     let entries = card["installed_skills"].as_array().unwrap();
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0]["name"], "find-prices");

--- a/mur-agent-runtime/tests/methods.rs
+++ b/mur-agent-runtime/tests/methods.rs
@@ -1,4 +1,4 @@
-use mur_agent_runtime::protocol::a2a_server::MethodHandler;
+use mur_agent_runtime::protocol::a2a_server::{MethodHandler, RequestContext};
 use mur_agent_runtime::protocol::methods::{
     message_send::MessageSendHandler,
     tasks::{TasksCancelHandler, TasksGetHandler, TasksListHandler},
@@ -13,9 +13,12 @@ async fn message_send_returns_completed_task() {
     let runner = Arc::new(TaskRunner::new_stub_echo());
     let h = MessageSendHandler::new(runner);
     let result = h
-        .handle(Some(json!({
-            "message": {"role": "user", "parts": [{"kind": "text", "text": "hi"}]}
-        })))
+        .handle(
+            Some(json!({
+                "message": {"role": "user", "parts": [{"kind": "text", "text": "hi"}]}
+            })),
+            &RequestContext::none(),
+        )
         .await
         .unwrap();
     assert_eq!(result["state"], "completed");
@@ -26,7 +29,7 @@ async fn tasks_get_returns_not_found_for_unknown_id() {
     let runner = Arc::new(TaskRunner::new_stub_echo());
     let h = TasksGetHandler::new(runner);
     let err = h
-        .handle(Some(json!({"id": "task-ghost"})))
+        .handle(Some(json!({"id": "task-ghost"})), &RequestContext::none())
         .await
         .unwrap_err();
     assert_eq!(err.code(), -32000);
@@ -37,7 +40,7 @@ async fn tasks_cancel_on_unknown_returns_not_found() {
     let runner = Arc::new(TaskRunner::new_stub_echo());
     let h = TasksCancelHandler::new(runner);
     let err = h
-        .handle(Some(json!({"id": "task-ghost"})))
+        .handle(Some(json!({"id": "task-ghost"})), &RequestContext::none())
         .await
         .unwrap_err();
     assert_eq!(err.code(), -32000);
@@ -47,7 +50,7 @@ async fn tasks_cancel_on_unknown_returns_not_found() {
 async fn tasks_list_returns_array() {
     let runner = Arc::new(TaskRunner::new_stub_echo());
     let h = TasksListHandler::new(runner);
-    let result = h.handle(None).await.unwrap();
+    let result = h.handle(None, &RequestContext::none()).await.unwrap();
     assert!(result.is_array());
 }
 
@@ -57,9 +60,12 @@ async fn message_send_emits_task_progress_before_response() {
     let (tx, mut rx) = tokio::sync::mpsc::channel(16);
     let h = MessageSendHandler::with_progress(runner, tx);
     let result = h
-        .handle(Some(json!({
-            "message": {"role": "user", "parts": [{"kind": "text", "text": "hi"}]}
-        })))
+        .handle(
+            Some(json!({
+                "message": {"role": "user", "parts": [{"kind": "text", "text": "hi"}]}
+            })),
+            &RequestContext::none(),
+        )
         .await
         .unwrap();
     assert_eq!(result["state"], "completed");

--- a/mur-agent-runtime/tests/transport_stdio.rs
+++ b/mur-agent-runtime/tests/transport_stdio.rs
@@ -12,13 +12,16 @@ async fn serves_dispatch_on_stdio_pipe() {
     let (notif_tx, notif_rx) = mpsc::channel(16);
     let dispatcher = {
         use async_trait::async_trait;
-        use mur_agent_runtime::protocol::a2a_server::{HandlerError, MethodHandler};
+        use mur_agent_runtime::protocol::a2a_server::{
+            HandlerError, MethodHandler, RequestContext,
+        };
         struct Ping;
         #[async_trait]
         impl MethodHandler for Ping {
             async fn handle(
                 &self,
                 _: Option<serde_json::Value>,
+                _ctx: &RequestContext,
             ) -> Result<serde_json::Value, HandlerError> {
                 Ok(json!({"pong": true}))
             }

--- a/mur-agent-runtime/tests/transport_unix.rs
+++ b/mur-agent-runtime/tests/transport_unix.rs
@@ -16,7 +16,9 @@ async fn roundtrip_over_unix_socket() {
     let (notif_tx, notif_rx) = mpsc::channel(16);
     let dispatcher = {
         use async_trait::async_trait;
-        use mur_agent_runtime::protocol::a2a_server::{HandlerError, MethodHandler};
+        use mur_agent_runtime::protocol::a2a_server::{
+            HandlerError, MethodHandler, RequestContext,
+        };
         let mut d = Dispatcher::new();
         struct Ping;
         #[async_trait]
@@ -24,6 +26,7 @@ async fn roundtrip_over_unix_socket() {
             async fn handle(
                 &self,
                 _: Option<serde_json::Value>,
+                _ctx: &RequestContext,
             ) -> Result<serde_json::Value, HandlerError> {
                 Ok(json!({"pong": true}))
             }
@@ -47,5 +50,109 @@ async fn roundtrip_over_unix_socket() {
     reader.read_line(&mut line).await.unwrap();
     let resp: serde_json::Value = serde_json::from_str(&line).unwrap();
     assert_eq!(resp["result"]["pong"], true);
+    drop(notif_tx);
+}
+
+/// Regression for the streaming-isolation fix (finding #14): a request-scoped
+/// notification emitted via `RequestContext::notifier` must reach ONLY the
+/// connection that issued the request, never other connected clients.
+#[tokio::test]
+async fn request_scoped_notification_routed_to_issuing_connection_only() {
+    use std::time::Duration;
+    let tmp = TempDir::new().unwrap();
+    let sock_path = tmp.path().join("iso.sock");
+    let (notif_tx, notif_rx) = mpsc::channel(16);
+    let dispatcher = {
+        use async_trait::async_trait;
+        use mur_agent_runtime::protocol::a2a_server::{
+            HandlerError, MethodHandler, RequestContext,
+        };
+        let mut d = Dispatcher::new();
+        // Emits a per-connection notification (the routing the real
+        // `message/delta` path uses) before returning its response.
+        struct Emit;
+        #[async_trait]
+        impl MethodHandler for Emit {
+            async fn handle(
+                &self,
+                params: Option<serde_json::Value>,
+                ctx: &RequestContext,
+            ) -> Result<serde_json::Value, HandlerError> {
+                let task_id = params
+                    .as_ref()
+                    .and_then(|p| p.get("task_id"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if let Some(n) = &ctx.notifier {
+                    let _ = n
+                        .send(json!({
+                            "jsonrpc": "2.0",
+                            "method": "test/delta",
+                            "params": { "task_id": task_id, "text": "hi" },
+                        }))
+                        .await;
+                }
+                Ok(json!({"ok": true}))
+            }
+        }
+        d.register("emit", Box::new(Emit));
+        d
+    };
+    let path = sock_path.clone();
+    let dispatcher = Arc::new(dispatcher);
+    tokio::spawn(async move {
+        let _ = serve_unix(dispatcher, path, notif_rx).await;
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Two independent connections to the same agent.
+    let (read_a, mut write_a) = UnixStream::connect(&sock_path).await.unwrap().into_split();
+    let (read_b, _write_b) = UnixStream::connect(&sock_path).await.unwrap().into_split();
+    let mut reader_a = BufReader::new(read_a);
+    let mut reader_b = BufReader::new(read_b);
+
+    // A issues the request → handler emits a notification on A's sink.
+    let req = json!({"jsonrpc": "2.0", "id": 1, "method": "emit", "params": {"task_id": "A"}})
+        .to_string()
+        + "\n";
+    write_a.write_all(req.as_bytes()).await.unwrap();
+
+    // A receives its own (stamped) notification AND the response, in either order.
+    let mut saw_delta = false;
+    let mut saw_resp = false;
+    for _ in 0..4 {
+        let mut l = String::new();
+        match tokio::time::timeout(Duration::from_millis(500), reader_a.read_line(&mut l)).await {
+            Ok(Ok(n)) if n > 0 => {
+                let v: serde_json::Value = serde_json::from_str(l.trim()).unwrap();
+                if v.get("method").and_then(|m| m.as_str()) == Some("test/delta") {
+                    assert_eq!(v["params"]["task_id"], "A");
+                    saw_delta = true;
+                }
+                if v.get("id") == Some(&json!(1)) {
+                    saw_resp = true;
+                }
+            }
+            _ => break,
+        }
+        if saw_delta && saw_resp {
+            break;
+        }
+    }
+    assert!(
+        saw_delta,
+        "issuing connection A must receive its notification"
+    );
+    assert!(saw_resp, "issuing connection A must receive its response");
+
+    // B issued nothing and must receive NO request-scoped notification.
+    let mut line_b = String::new();
+    let r = tokio::time::timeout(Duration::from_millis(300), reader_b.read_line(&mut line_b)).await;
+    assert!(
+        r.is_err() || line_b.is_empty(),
+        "connection B must not receive A's notification, got: {line_b:?}"
+    );
+
     drop(notif_tx);
 }


### PR DESCRIPTION
## Summary

Fixes the streaming-isolation defect surfaced by the `mur agent cli` review (finding #14). The agent runtime broadcast **every** `message/delta` and `tool/approval_needed` to **all** connected sockets, with no task id, so two clients driving one agent concurrently (Hub + CLI, two CLIs, a scheduled task) received each other's token deltas and tool-approval prompts. Because the runtime physically wrote one client's tokens to another's socket, this is a **privacy** bug, not just cosmetic interleaving.

This is **PR-A** of two: runtime routing + stamping. It is wire-compatible and needs no client change. PR-B adopts the new `task_id` field in `dial_message_streaming` + CLI + Hub.

## Approach — per-connection routing via `RequestContext`

- Add `RequestContext { notifier }`, threaded through `Dispatcher::dispatch` → `MethodHandler::handle`. The unix transport gives **each accepted connection its own notification sink** and passes it via the context; `message/send` streams deltas there instead of the shared broadcast.
- **HITL** routes the same way: `message/send` registers the turn's connection sink on the runner (keyed by task id); the tool-approval gate looks it up (falling back to the baked notifier).
- **Stamp** `task_id` + `context_id` on every `message/delta`, and `task_id` on `tool/approval_needed` (snake_case, matching the existing wire). Clients ignore unknown fields ⇒ no client change required.
- The **telemetry/progress broadcast is untouched** (request-independent; clients ignore it). `stdio`/`tcp` are single-client / non-streaming and pass `RequestContext::none()` — behavior unchanged.
- Buffer caps are named consts; overflow stays **lossy** (a dropped delta beats stalling generation).

## Why this shape
Per-connection routing is the actual privacy boundary; client-side filtering is not (tokens still reach the wrong process). Stamping is A2A-spec alignment (every streamed event carries `taskId`/`contextId`) + future multiplexing. Only `unix` is multi-connection, so it's the only transport that gains routing.

## Test plan
- `cargo build --workspace` ✓ · `cargo clippy -p mur-agent-runtime --tests -- -D warnings` ✓ · `cargo fmt --check` ✓
- Full runtime suite green (272 lib + integration tests).
- **New regression** (`tests/transport_unix.rs`): a notification emitted via the request context reaches **only** the issuing connection; a second connected client receives nothing.
- Manual two-client isolation lands with PR-B (needs the CLI's `task_id` surfacing to demo end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)