### PR TITLE
feat(client): surface streaming task_id to dial callers (#14 PR-B)

### DIFF
--- a/mur-core/src/a2a_dial.rs
+++ b/mur-core/src/a2a_dial.rs
@@ -171,11 +171,16 @@ fn dial_socket(
 /// agent to be up (uses its unix socket); the runtime emits `message/delta`
 /// notifications during generation. Names resolve case-insensitively.
 #[allow(dead_code)] // used by workspace-excluded mur-hub-gui
+/// Stream a `message/send` turn. `on_delta` receives `(text, thinking,
+/// task_id)`, where `task_id` is the turn id the runtime stamps on each
+/// `message/delta` (empty string if the agent predates per-connection routing).
+/// The runtime already routes deltas to this connection only; the id lets a
+/// client defensively drop anything not matching the turn it issued.
 pub fn dial_message_streaming(
     home: &Path,
     agent_name: &str,
     params: Value,
-    mut on_delta: impl FnMut(&str, bool),
+    mut on_delta: impl FnMut(&str, bool, &str),
     mut on_hitl: impl FnMut(Value),
 ) -> Result<Value> {
     let agent_name = &canonicalize_agent_name(home, agent_name);
@@ -221,7 +226,11 @@ pub fn dial_message_streaming(
                         .and_then(|p| p.get("thinking"))
                         .and_then(Value::as_bool)
                         .unwrap_or(false);
-                    on_delta(t, thinking);
+                    let delta_task_id = params
+                        .and_then(|p| p.get("task_id"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    on_delta(t, thinking, delta_task_id);
                 }
                 continue;
             }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -428,7 +428,7 @@ fn run_plain(home: &Path, agent: &str) -> Result<()> {
             home,
             agent,
             params,
-            |delta, thinking| {
+            |delta, thinking, _task_id| {
                 if !thinking {
                     streamed.set(true);
                     let _ = write!(out, "{delta}");

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -124,7 +124,13 @@ pub fn spawn_stream(
             &home,
             &agent,
             params,
-            |delta, thinking| {
+            |delta, thinking, delta_task_id| {
+                // The runtime already routes deltas to this connection only;
+                // defensively drop any whose stamped id isn't this turn's (an
+                // empty id means a pre-routing runtime — accept it).
+                if !delta_task_id.is_empty() && delta_task_id != tid {
+                    return;
+                }
                 let _ = tx.blocking_send(StreamMsg::Delta {
                     task_id: tid.clone(),
                     text: delta.to_string(),

--- a/mur-hub-gui/src-tauri/src/chat.rs
+++ b/mur-hub-gui/src-tauri/src/chat.rs
@@ -51,6 +51,10 @@ pub struct ChatDelta {
     /// True for the model's transient reasoning (shown as a "thinking"
     /// indicator), false for the user-facing answer.
     pub thinking: bool,
+    /// The turn id the runtime stamps on each delta, so the UI can correlate a
+    /// delta to its conversation (empty for agents predating per-connection
+    /// routing).
+    pub task_id: String,
 }
 
 #[derive(Serialize)]
@@ -97,13 +101,14 @@ pub async fn agent_chat_send(
             &home,
             &name,
             params.clone(),
-            |delta, thinking| {
+            |delta, thinking, task_id| {
                 let _ = app.emit(
                     "chat-delta",
                     ChatDelta {
                         agent: agent.clone(),
                         text: delta.to_string(),
                         thinking,
+                        task_id: task_id.to_string(),
                     },
                 );
             },

--- a/mur-hub-gui/ui/src/components/ChatTab.tsx
+++ b/mur-hub-gui/ui/src/components/ChatTab.tsx
@@ -39,6 +39,8 @@ interface ChatDelta {
   agent: string;
   text: string;
   thinking: boolean;
+  /** Turn id the runtime stamps on each delta (empty for older agents). */
+  task_id: string;
 }
 
 interface Props {


### PR DESCRIPTION
## Summary

PR-B (final) of the streaming-isolation work. The runtime fix (#396) already closed finding #14 by routing each turn's deltas/HITL to the issuing connection. This surfaces the `task_id` the runtime now stamps on every `message/delta` to the clients, for correlation + defensive filtering.

## Changes
- **`dial_message_streaming`** `on_delta` callback: `FnMut(&str, bool)` → `FnMut(&str, bool, &str)` (the delta's `task_id`; empty for agents predating per-connection routing).
- **CLI** streaming worker defensively drops any delta whose stamped id ≠ the turn it issued (belt-and-suspenders — the runtime already routes per connection). Non-TTY plain path ignores the id.
- **Hub** `ChatDelta` (+ the `chat-delta` Tauri event and its TS interface) carry `task_id` so the UI can correlate a delta to its conversation.

Pure plumbing of the new field; single-client behavior is unchanged.

## Test plan
- `cargo build -p mur-core` ✓ · `cargo clippy -p mur-core -- -D warnings` ✓ (clean; the pre-existing `--tests` lints in unrelated modules are untouched) · `cargo fmt --check` ✓ · 24 `agent cli` unit tests ✓
- `cargo check` on the workspace-excluded `mur-hub-gui/src-tauri` ✓ (ChatDelta change compiles).
- Manual two-client isolation can now be demoed end-to-end: two `mur agent cli <name>` against one agent stream independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)