### PR TITLE
fix(cli): mur agent cli operations — HITL lost-turn bug, auto-approve modes, !cmd, /mcp, /skill, tool-detection fallback

### DIFF
--- a/docs/superpowers/specs/2026-06-10-agent-cli-operations-design.md
+++ b/docs/superpowers/specs/2026-06-10-agent-cli-operations-design.md
@@ -1,0 +1,58 @@
+# `mur agent cli` Operations Fixes — Design
+
+Date: 2026-06-10. Status: approved.
+
+Live-testing the TUI (`mur agent cli mur`) via tmux surfaced 9 issues. Fix in three
+batches. Findings log: `/tmp/mur-cli-test-ops.log`.
+
+## Issues
+
+| # | Issue | Root cause (where known) |
+|---|-------|--------------------------|
+| 1 | No auto-approve permission mode | HITL modal offers only y/n |
+| 2 | YouTube analysis fails | GUI-launched runtime PATH lacks `/opt/homebrew/bin`; `detect_ytdlp()` only searches PATH → `MediaError::YtdlpMissing` |
+| 3 | `!cmd` shell escape missing | Sent to agent as chat text |
+| 4 | `/mcp` slash command missing | — |
+| 5 | `/skill` slash command missing | — |
+| 6 | **After HITL approve, the turn is lost**: spinner freezes, final reply never renders, tool result absent from context, session JSONL has no agent turn | TBD — diagnose runtime resume path vs TUI stream handling |
+| 7 | Keystrokes during HITL modal silently swallowed | Modal drops all non-y/n keys |
+| 8 | Hub.app bundles stale runtime: skill loader rejects `category: media` | Repo already has `Category::Media`; redeploy needed (ops, not code) |
+| 9 | `stderr.log` spammed with "Operation not permitted" exec failures | Sidecar respawn loop execing from `/Volumes` (macOS blocks); investigate |
+
+## Batches
+
+- **Batch 1 (HITL/permissions core):** #6 bug fix, #1 auto mode, #7 input buffering
+- **Batch 2 (toolchain/env):** #2 tool-detection fallback dirs, #3 `!` escape, #8+#9 deploy/investigation
+- **Batch 3 (TUI management):** #4 `/mcp`, #5 `/skill`, help/tab-completion updates
+
+## Designs
+
+### Auto permission mode (#1)
+
+Modeled on Claude Code permission modes, adapted to MUR's HITL protocol:
+
+- HITL modal gains a third key: `[y]` allow once · `[a]` always allow **this tool**
+  for this session · `[n]` deny. Session allowlist lives in TUI `App` state; matching
+  requests auto-approve with a `· auto-approved <tool> (session)` notice.
+- `/auto` slash command + `--auto` CLI flag: session-scoped approve-all. Status bar
+  shows a warning-colored `AUTO` tag. `/auto off` disables. Never persisted —
+  restart returns to ask-first. Persistent grants stay in `mur agent perm`.
+
+### `!` shell escape (#3)
+
+`!cmd` runs locally via `$SHELL -c` (30 s timeout, output truncated ~100 lines/8 KB),
+renders as a distinct bubble, persists to the session JSONL, and accumulated
+command+output blocks are prefixed to the next user message so the agent sees them
+(Claude Code behavior).
+
+### `/mcp`, `/skill` (#4, #5)
+
+Reuse `cmd/agent/mcp.rs` / `skill.rs` logic in-process: `/mcp` list|add|remove,
+`/skill` list|install|remove. After mutation, notify that the agent needs a restart
+to pick up profile changes (unless runtime hot-reloads — verify).
+
+### Tool detection fallback (#2)
+
+`detect_tool()` falls back to well-known dirs (`/opt/homebrew/bin`, `/usr/local/bin`,
+`~/.local/bin`) after PATH search fails. Fixes every GUI-launched runtime, not just
+yt-dlp (ffmpeg too).

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -78,6 +78,9 @@ pub enum AgentAction {
         /// Resume the most recent saved conversation for this agent
         #[arg(long)]
         resume: bool,
+        /// Auto-approve every tool call for this session (no HITL prompts)
+        #[arg(long)]
+        auto: bool,
     },
     /// Rotate an agent's Ed25519 identity keypair (P0a.6).
     Rekey {

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -1,5 +1,6 @@
 //! TUI application state and the pure (non-IO) state transitions.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use ratatui::style::{Color, Style};
@@ -70,6 +71,8 @@ pub enum SlashCmd {
     Clear,
     Card,
     Sessions,
+    /// `/auto [on|off]` — toggle (None) or set session-wide auto-approval.
+    Auto(Option<bool>),
     Quit,
     Unknown(String),
 }
@@ -78,19 +81,33 @@ pub enum SlashCmd {
 pub fn parse_slash(line: &str) -> Option<SlashCmd> {
     let line = line.trim();
     let rest = line.strip_prefix('/')?;
-    let word = rest.split_whitespace().next().unwrap_or("");
+    let mut words = rest.split_whitespace();
+    let word = words.next().unwrap_or("");
     Some(match word {
         "help" | "h" | "?" => SlashCmd::Help,
         "clear" | "new" => SlashCmd::Clear,
         "card" => SlashCmd::Card,
         "sessions" | "ls" => SlashCmd::Sessions,
+        "auto" => SlashCmd::Auto(match words.next() {
+            Some("on") => Some(true),
+            Some("off") => Some(false),
+            _ => None,
+        }),
         "exit" | "quit" | "q" => SlashCmd::Quit,
         other => SlashCmd::Unknown(other.to_string()),
     })
 }
 
 /// The set of slash commands offered by tab-completion / `/help`.
-pub const SLASH_COMMANDS: [&str; 6] = ["/help", "/clear", "/card", "/sessions", "/exit", "/quit"];
+pub const SLASH_COMMANDS: [&str; 7] = [
+    "/help",
+    "/clear",
+    "/card",
+    "/sessions",
+    "/auto",
+    "/exit",
+    "/quit",
+];
 
 /// All mutable TUI state.
 pub struct App {
@@ -107,6 +124,12 @@ pub struct App {
     pub scroll_back: u16,
     pub spinner: usize,
     pub should_quit: bool,
+    /// Session-wide auto-approval of every tool call (`/auto` or `--auto`).
+    /// Never persisted: a new `mur agent cli` starts back at ask-first.
+    pub auto_approve: bool,
+    /// Tools the user marked "always allow" for THIS session via the HITL
+    /// modal's `[a]` key. Same lifetime rules as `auto_approve`.
+    pub session_tool_allow: HashSet<String>,
     /// Set once we've warned the user that session writes are failing, so the
     /// warning isn't repeated every turn.
     persist_warned: bool,
@@ -127,8 +150,22 @@ impl App {
             scroll_back: 0,
             spinner: 0,
             should_quit: false,
+            auto_approve: false,
+            session_tool_allow: HashSet::new(),
             persist_warned: false,
         }
+    }
+
+    /// The in-flight agent bubble, if any. Searched from the back instead of
+    /// only checking `last()`: a system note pushed mid-turn (HITL "approved
+    /// `tool`", a hint, a warning) lands AFTER the streaming bubble, and the
+    /// turn's deltas/finish must still find their message (see #6: approving a
+    /// tool call used to lose the whole reply).
+    fn streaming_agent_mut(&mut self) -> Option<&mut ChatMsg> {
+        self.messages
+            .iter_mut()
+            .rev()
+            .find(|m| m.role == Role::Agent && m.streaming)
     }
 
     /// Append a turn to the session log, surfacing a write failure once.
@@ -179,10 +216,7 @@ impl App {
     }
 
     pub fn append_delta(&mut self, text: &str, thinking: bool) {
-        if let Some(m) = self.messages.last_mut()
-            && m.role == Role::Agent
-            && m.streaming
-        {
+        if let Some(m) = self.streaming_agent_mut() {
             if thinking {
                 m.thinking.push_str(text);
             } else {
@@ -201,10 +235,7 @@ impl App {
     /// phantom line or thread a stale context id.
     pub fn finish_agent_turn(&mut self, reply: String, task_id: Option<String>) {
         let mut body = None;
-        if let Some(m) = self.messages.last_mut()
-            && m.role == Role::Agent
-            && m.streaming
-        {
+        if let Some(m) = self.streaming_agent_mut() {
             if !reply.is_empty() {
                 m.text = reply;
             }
@@ -225,10 +256,7 @@ impl App {
 
     /// Mark a partial (cancelled) turn as finished without persisting a reply.
     pub fn finish_partial(&mut self) {
-        if let Some(m) = self.messages.last_mut()
-            && m.role == Role::Agent
-            && m.streaming
-        {
+        if let Some(m) = self.streaming_agent_mut() {
             m.thinking.clear();
             m.streaming = false;
             if m.text.is_empty() {
@@ -240,8 +268,12 @@ impl App {
     }
 
     pub fn fail_turn(&mut self, err: &str) {
-        if matches!(self.messages.last(), Some(m) if m.role == Role::Agent && m.streaming) {
-            self.messages.pop();
+        if let Some(i) = self
+            .messages
+            .iter()
+            .rposition(|m| m.role == Role::Agent && m.streaming)
+        {
+            self.messages.remove(i);
         }
         self.push_system(format!("error: {err}"));
         self.streaming = false;
@@ -385,6 +417,42 @@ mod tests {
         a.begin_user_turn("hi");
         a.finish_agent_turn("**bold**".into(), Some("t1".into()));
         assert!(a.messages.last().unwrap().rendered.is_some());
+    }
+
+    #[test]
+    fn finish_agent_turn_survives_mid_turn_system_note() {
+        // Regression (#6): a system note pushed while streaming (e.g. HITL
+        // "approved `bash`") lands after the agent bubble; the turn's finish
+        // must still find that bubble instead of silently dropping the reply.
+        let mut a = app();
+        let tid = a.begin_user_turn("run ls");
+        a.append_delta("partial", false);
+        a.push_system("approved `bash`");
+        a.append_delta(" more", false);
+        a.finish_agent_turn("final reply".into(), Some(tid.clone()));
+        let agent = a
+            .messages
+            .iter()
+            .find(|m| m.role == Role::Agent)
+            .expect("agent bubble");
+        assert_eq!(agent.text, "final reply");
+        assert!(!agent.streaming);
+        assert_eq!(a.context_task_id.as_deref(), Some(tid.as_str()));
+        assert!(!a.streaming);
+    }
+
+    #[test]
+    fn fail_turn_drops_displaced_streaming_placeholder() {
+        let mut a = app();
+        a.begin_user_turn("hi");
+        a.push_system("note lands after the placeholder");
+        a.fail_turn("boom");
+        assert!(
+            !a.messages
+                .iter()
+                .any(|m| m.role == Role::Agent && m.streaming)
+        );
+        assert!(!a.streaming);
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -467,7 +467,10 @@ mod tests {
         let mut a = app();
         a.push_shell("ls", "foo\nbar");
         a.push_shell("true", "");
-        assert_eq!(a.messages.iter().filter(|m| m.role == Role::Shell).count(), 2);
+        assert_eq!(
+            a.messages.iter().filter(|m| m.role == Role::Shell).count(),
+            2
+        );
         let ctx = a.take_pending_shell().expect("pending blocks");
         assert!(ctx.contains("$ ls\nfoo\nbar"));
         assert!(ctx.contains("$ true"));

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -76,6 +76,10 @@ pub enum SlashCmd {
     Sessions,
     /// `/auto [on|off]` — toggle (None) or set session-wide auto-approval.
     Auto(Option<bool>),
+    /// `/mcp [list|add|remove] …` — manage the agent's MCP servers.
+    Mcp(Vec<String>),
+    /// `/skill [list|add|remove] …` — manage the agent's skills.
+    Skill(Vec<String>),
     Quit,
     Unknown(String),
 }
@@ -96,18 +100,22 @@ pub fn parse_slash(line: &str) -> Option<SlashCmd> {
             Some("off") => Some(false),
             _ => None,
         }),
+        "mcp" => SlashCmd::Mcp(words.map(str::to_string).collect()),
+        "skill" | "skills" => SlashCmd::Skill(words.map(str::to_string).collect()),
         "exit" | "quit" | "q" => SlashCmd::Quit,
         other => SlashCmd::Unknown(other.to_string()),
     })
 }
 
 /// The set of slash commands offered by tab-completion / `/help`.
-pub const SLASH_COMMANDS: [&str; 7] = [
+pub const SLASH_COMMANDS: [&str; 9] = [
     "/help",
     "/clear",
     "/card",
     "/sessions",
     "/auto",
+    "/mcp",
+    "/skill",
     "/exit",
     "/quit",
 ];

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -22,6 +22,9 @@ pub enum Role {
     Agent,
     /// Local UI notice (slash-command output, errors, hints) — not persisted.
     System,
+    /// A `!command` the user ran locally, plus its output. Persisted, and
+    /// queued so the agent sees it with the next message.
+    Shell,
 }
 
 /// One message in the visible transcript.
@@ -130,6 +133,9 @@ pub struct App {
     /// Tools the user marked "always allow" for THIS session via the HITL
     /// modal's `[a]` key. Same lifetime rules as `auto_approve`.
     pub session_tool_allow: HashSet<String>,
+    /// `!command` blocks (command + output) not yet shown to the agent; they
+    /// are prefixed onto the next user message so the agent has the context.
+    pub pending_shell: Vec<String>,
     /// Set once we've warned the user that session writes are failing, so the
     /// warning isn't repeated every turn.
     persist_warned: bool,
@@ -152,6 +158,7 @@ impl App {
             should_quit: false,
             auto_approve: false,
             session_tool_allow: HashSet::new(),
+            pending_shell: Vec::new(),
             persist_warned: false,
         }
     }
@@ -294,11 +301,39 @@ impl App {
 
     /// Load prior turns into the transcript (resume), threading the last agent
     /// task id as context.
+    /// Record a completed `!command` run: show it, persist it, and queue it
+    /// for the agent's next turn.
+    pub fn push_shell(&mut self, cmd: &str, output: &str) {
+        let text = if output.is_empty() {
+            format!("$ {cmd}")
+        } else {
+            format!("$ {cmd}\n{output}")
+        };
+        self.messages.push(ChatMsg::new(Role::Shell, text.clone()));
+        self.persist_turn("shell", &text, None);
+        self.pending_shell.push(text);
+        self.scroll_back = 0;
+    }
+
+    /// Drain queued `!command` blocks into a context prefix for the next
+    /// message, or `None` if there is nothing pending.
+    pub fn take_pending_shell(&mut self) -> Option<String> {
+        if self.pending_shell.is_empty() {
+            return None;
+        }
+        let blocks = self.pending_shell.join("\n\n");
+        self.pending_shell.clear();
+        Some(format!(
+            "[shell commands the user just ran locally in this chat]\n{blocks}\n[end of shell context]"
+        ))
+    }
+
     pub fn load_history(&mut self, turns: Vec<TurnRecord>) {
         let mut last_task = None;
         for t in turns {
             let role = match t.role.as_str() {
                 "agent" => Role::Agent,
+                "shell" => Role::Shell,
                 _ => Role::User,
             };
             if role == Role::Agent {
@@ -417,6 +452,18 @@ mod tests {
         a.begin_user_turn("hi");
         a.finish_agent_turn("**bold**".into(), Some("t1".into()));
         assert!(a.messages.last().unwrap().rendered.is_some());
+    }
+
+    #[test]
+    fn shell_blocks_queue_and_drain_into_prefix() {
+        let mut a = app();
+        a.push_shell("ls", "foo\nbar");
+        a.push_shell("true", "");
+        assert_eq!(a.messages.iter().filter(|m| m.role == Role::Shell).count(), 2);
+        let ctx = a.take_pending_shell().expect("pending blocks");
+        assert!(ctx.contains("$ ls\nfoo\nbar"));
+        assert!(ctx.contains("$ true"));
+        assert!(a.take_pending_shell().is_none(), "drained");
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/manage.rs
+++ b/mur-core/src/cmd/agent/cli/manage.rs
@@ -13,7 +13,8 @@ use crate::cmd::agent::{load_profile_for_edit, save_profile};
 
 /// Reminder appended after any profile mutation: the supervisor only reads
 /// the profile at startup.
-pub const RESTART_HINT: &str = "profile updated — restart the agent to apply (mur agent stop <name>, then start it again)";
+pub const RESTART_HINT: &str =
+    "profile updated — restart the agent to apply (mur agent stop <name>, then start it again)";
 
 pub fn mcp_list(agent: &str) -> Result<String> {
     let (_path, profile) = load_profile_for_edit(agent)?;
@@ -54,7 +55,10 @@ pub fn mcp_add(agent: &str, server_id: &str, command: &str, args: &[String]) -> 
                 Some(h)
             }
             Err(e) => {
-                notes.push(format!("warning: could not hash {} ({e}); no binary pin", p.display()));
+                notes.push(format!(
+                    "warning: could not hash {} ({e}); no binary pin",
+                    p.display()
+                ));
                 None
             }
         },
@@ -93,7 +97,10 @@ pub fn mcp_add(agent: &str, server_id: &str, command: &str, args: &[String]) -> 
     }
     save_profile(&path, &mut profile)?;
 
-    let mut out = format!("added MCP server '{server_id}' ({command} {})", args.join(" "));
+    let mut out = format!(
+        "added MCP server '{server_id}' ({command} {})",
+        args.join(" ")
+    );
     for n in notes {
         out.push_str(&format!("\n  {n}"));
     }
@@ -131,8 +138,7 @@ pub fn skill_remove(agent: &str, query: &str) -> Result<String> {
 /// Usage strings shown for bad arguments.
 pub const MCP_USAGE: &str =
     "usage: /mcp [list] · /mcp add <name> <command> [args…] · /mcp remove <name>";
-pub const SKILL_USAGE: &str =
-    "usage: /skill [list] · /skill add <path> · /skill remove <name>";
+pub const SKILL_USAGE: &str = "usage: /skill [list] · /skill add <path> · /skill remove <name>";
 
 /// Dispatch a parsed `/mcp` invocation.
 pub fn run_mcp(agent: &str, args: &[String]) -> Result<String> {

--- a/mur-core/src/cmd/agent/cli/manage.rs
+++ b/mur-core/src/cmd/agent/cli/manage.rs
@@ -1,0 +1,155 @@
+//! TUI-safe agent management for `/mcp` and `/skill` slash commands.
+//!
+//! The `mur agent mcp|skill` CLI handlers print to stdout and (for installs)
+//! prompt on stdin — both unusable inside a raw-mode alternate screen. These
+//! variants return the text to render and never touch the terminal; the
+//! silent CLI helpers (`cmd_mcp_remove`, `cmd_skill_add`, `cmd_skill_remove`)
+//! are reused as-is.
+
+use anyhow::{Result, bail};
+use mur_common::agent::McpServerEntry;
+
+use crate::cmd::agent::{load_profile_for_edit, save_profile};
+
+/// Reminder appended after any profile mutation: the supervisor only reads
+/// the profile at startup.
+pub const RESTART_HINT: &str = "profile updated — restart the agent to apply (mur agent stop <name>, then start it again)";
+
+pub fn mcp_list(agent: &str) -> Result<String> {
+    let (_path, profile) = load_profile_for_edit(agent)?;
+    if profile.mcp_servers.is_empty() {
+        return Ok("(no MCP servers configured)".into());
+    }
+    let mut out = String::from("MCP servers:\n");
+    for s in &profile.mcp_servers {
+        let pinned = if s.binary_sha256.is_some() {
+            " (pinned)"
+        } else {
+            ""
+        };
+        out.push_str(&format!(
+            "  {} — {} {}{}\n",
+            s.name,
+            s.command,
+            s.args.join(" "),
+            pinned
+        ));
+    }
+    Ok(out.trim_end().to_string())
+}
+
+/// Non-interactive port of `cmd_mcp_add` (force semantics): best-effort
+/// binary pin, spawn-allowlist sync, warnings folded into the returned text.
+pub fn mcp_add(agent: &str, server_id: &str, command: &str, args: &[String]) -> Result<String> {
+    let (path, mut profile) = load_profile_for_edit(agent)?;
+    if profile.mcp_servers.iter().any(|s| s.name == server_id) {
+        bail!("MCP server '{server_id}' already exists on '{agent}'");
+    }
+
+    let mut notes = Vec::new();
+    let binary_sha256 = match crate::cmd::agent_mcp_pin::resolve_command(command) {
+        Ok(p) => match crate::cmd::agent_mcp_pin::compute_binary_sha256(&p) {
+            Ok(h) => {
+                notes.push(format!("binary sha256 {}…", &h[..16.min(h.len())]));
+                Some(h)
+            }
+            Err(e) => {
+                notes.push(format!("warning: could not hash {} ({e}); no binary pin", p.display()));
+                None
+            }
+        },
+        Err(_) => {
+            notes.push(format!(
+                "warning: `{command}` not found on PATH; no binary pin"
+            ));
+            None
+        }
+    };
+
+    profile.mcp_servers.push(McpServerEntry {
+        name: server_id.to_string(),
+        command: command.to_string(),
+        args: args.to_vec(),
+        binary_sha256,
+        description_hash: None,
+        publisher: None,
+        installed_at: Some(chrono::Utc::now()),
+        timeout_secs: None,
+    });
+    if !profile
+        .entitlements
+        .processes
+        .spawn
+        .allowed
+        .iter()
+        .any(|a| a == command)
+    {
+        profile
+            .entitlements
+            .processes
+            .spawn
+            .allowed
+            .push(command.to_string());
+    }
+    save_profile(&path, &mut profile)?;
+
+    let mut out = format!("added MCP server '{server_id}' ({command} {})", args.join(" "));
+    for n in notes {
+        out.push_str(&format!("\n  {n}"));
+    }
+    out.push_str(&format!("\n{RESTART_HINT}"));
+    Ok(out)
+}
+
+pub fn mcp_remove(agent: &str, server_id: &str) -> Result<String> {
+    crate::cmd::agent::mcp::cmd_mcp_remove(agent, server_id)?;
+    Ok(format!("removed MCP server '{server_id}'\n{RESTART_HINT}"))
+}
+
+pub fn skill_list(agent: &str) -> Result<String> {
+    let (_path, profile) = load_profile_for_edit(agent)?;
+    if profile.skills.is_empty() {
+        return Ok("(no skills attached)".into());
+    }
+    let mut out = String::from("skills:\n");
+    for s in &profile.skills {
+        out.push_str(&format!("  {s}\n"));
+    }
+    Ok(out.trim_end().to_string())
+}
+
+pub fn skill_add(agent: &str, source: &str) -> Result<String> {
+    crate::cmd::agent::skill::cmd_skill_add(agent, source)?;
+    Ok(format!("installed skill from '{source}'\n{RESTART_HINT}"))
+}
+
+pub fn skill_remove(agent: &str, query: &str) -> Result<String> {
+    crate::cmd::agent::skill::cmd_skill_remove(agent, query)?;
+    Ok(format!("removed skill '{query}'\n{RESTART_HINT}"))
+}
+
+/// Usage strings shown for bad arguments.
+pub const MCP_USAGE: &str =
+    "usage: /mcp [list] · /mcp add <name> <command> [args…] · /mcp remove <name>";
+pub const SKILL_USAGE: &str =
+    "usage: /skill [list] · /skill add <path> · /skill remove <name>";
+
+/// Dispatch a parsed `/mcp` invocation.
+pub fn run_mcp(agent: &str, args: &[String]) -> Result<String> {
+    match args.first().map(String::as_str) {
+        None | Some("list") => mcp_list(agent),
+        Some("add") if args.len() >= 3 => mcp_add(agent, &args[1], &args[2], &args[3..]),
+        Some("remove") | Some("rm") if args.len() == 2 => mcp_remove(agent, &args[1]),
+        _ => Ok(MCP_USAGE.into()),
+    }
+}
+
+/// Dispatch a parsed `/skill` invocation.
+pub fn run_skill(agent: &str, args: &[String]) -> Result<String> {
+    match args.first().map(String::as_str) {
+        None | Some("list") => skill_list(agent),
+        Some("add") | Some("install") if args.len() == 2 => skill_add(agent, &args[1]),
+        Some("remove") | Some("rm") if args.len() == 2 => skill_remove(agent, &args[1]),
+        _ => Ok(SKILL_USAGE.into()),
+    }
+}

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -7,6 +7,7 @@
 //! [`persist`] (JSONL session log + resume).
 
 mod app;
+mod manage;
 mod markdown;
 mod persist;
 mod stream;
@@ -41,7 +42,7 @@ const SCROLL_STEP: u16 = 5;
 /// Spinner animation cadence.
 const SPINNER_MS: u64 = 90;
 
-const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /auto [on|off]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Alt+Enter newline · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
+const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /auto [on|off]  /mcp  /skill  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Alt+Enter newline · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
 
 /// Entry point dispatched from `AgentAction::Cli`.
 pub async fn cmd_cli(name: &str, resume: bool, auto: bool) -> Result<()> {
@@ -428,7 +429,25 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
                 app.push_system("auto-approve OFF — tool calls ask again");
             }
         }
+        SlashCmd::Mcp(args) => run_manage(app, move |agent| manage::run_mcp(&agent, &args)).await,
+        SlashCmd::Skill(args) => {
+            run_manage(app, move |agent| manage::run_skill(&agent, &args)).await
+        }
         SlashCmd::Unknown(c) => app.push_system(format!("unknown command: /{c} — try /help")),
+    }
+}
+
+/// Run a blocking profile-management closure off the event loop and render
+/// its outcome as a system note.
+async fn run_manage<F>(app: &mut App, f: F)
+where
+    F: FnOnce(String) -> Result<String> + Send + 'static,
+{
+    let agent = app.agent.clone();
+    match tokio::task::spawn_blocking(move || f(agent)).await {
+        Ok(Ok(text)) => app.push_system(text),
+        Ok(Err(e)) => app.push_system(format!("error: {e:#}")),
+        Err(e) => app.push_system(format!("task failed: {e}")),
     }
 }
 

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -525,7 +525,9 @@ fn run_plain(home: &Path, agent: &str, auto: bool) -> Result<()> {
                 if auto {
                     eprintln!("[non-interactive: auto-approving tool-approval request (--auto)]");
                 } else {
-                    eprintln!("[non-interactive: auto-denying tool-approval request (use --auto to allow)]");
+                    eprintln!(
+                        "[non-interactive: auto-denying tool-approval request (use --auto to allow)]"
+                    );
                 }
                 let _ = dial_method(
                     home,

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -41,10 +41,10 @@ const SCROLL_STEP: u16 = 5;
 /// Spinner animation cadence.
 const SPINNER_MS: u64 = 90;
 
-const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /exit · keys: Enter send · Alt+Enter newline · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
+const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /auto [on|off]  /exit · keys: Enter send · Alt+Enter newline · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
 
 /// Entry point dispatched from `AgentAction::Cli`.
-pub async fn cmd_cli(name: &str, resume: bool) -> Result<()> {
+pub async fn cmd_cli(name: &str, resume: bool, auto: bool) -> Result<()> {
     let home = super::resolve_mur_home()?;
     let agent = canonicalize_agent_name(&home, name);
 
@@ -61,10 +61,10 @@ pub async fn cmd_cli(name: &str, resume: bool) -> Result<()> {
     if !io::stdout().is_terminal() {
         let home2 = home.clone();
         let agent2 = agent.clone();
-        return tokio::task::spawn_blocking(move || run_plain(&home2, &agent2)).await?;
+        return tokio::task::spawn_blocking(move || run_plain(&home2, &agent2, auto)).await?;
     }
 
-    run_tui(home, agent, resume).await
+    run_tui(home, agent, resume, auto).await
 }
 
 // ── TUI mode ────────────────────────────────────────────────────────────────
@@ -93,7 +93,7 @@ impl Drop for TerminalGuard {
     }
 }
 
-async fn run_tui(home: PathBuf, agent: String, resume: bool) -> Result<()> {
+async fn run_tui(home: PathBuf, agent: String, resume: bool, auto: bool) -> Result<()> {
     // Restore the terminal even if a later panic unwinds past the guard.
     let prev_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -112,6 +112,10 @@ async fn run_tui(home: PathBuf, agent: String, resume: bool) -> Result<()> {
         Terminal::new(CrosstermBackend::new(io::stdout())).context("init terminal")?;
 
     let mut app = build_app(&home, &agent, resume)?;
+    if auto {
+        app.auto_approve = true;
+        app.push_system("auto-approve is ON for this session (--auto) — every tool call will be allowed without asking");
+    }
     let result = event_loop(&mut terminal, &mut app).await;
 
     drop(_guard);
@@ -172,7 +176,7 @@ async fn event_loop(
                 Some(Ok(ev)) => handle_event(app, ev, &tx).await,
                 Some(Err(_)) | None => return Ok(()),
             },
-            Some(msg) = rx.recv() => handle_stream(app, msg),
+            Some(msg) = rx.recv() => handle_stream(app, msg, &tx),
             _ = spinner.tick(), if app.streaming => app.tick_spinner(),
         }
     }
@@ -182,17 +186,28 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
     match ev {
         Event::Key(key) if key.kind == KeyEventKind::Press || key.kind == KeyEventKind::Repeat => {
             let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
-            // HITL prompt takes over the keyboard — but Ctrl+C/Ctrl+D must stay
-            // live so the user is never trapped by a stale/unanswerable modal.
+            // HITL prompt owns the decision keys — but Ctrl+C/Ctrl+D must stay
+            // live so the user is never trapped by a stale/unanswerable modal,
+            // and any other key keeps going to the composer so typed text isn't
+            // silently swallowed while the modal is up.
             if app.hitl.is_some() {
                 match key.code {
                     KeyCode::Char('d') if ctrl => request_quit(app, tx),
                     KeyCode::Char('c') if ctrl => decide_hitl(app, tx, false),
                     KeyCode::Char('y') | KeyCode::Char('Y') => decide_hitl(app, tx, true),
+                    KeyCode::Char('a') | KeyCode::Char('A') => {
+                        if let Some(req) = &app.hitl {
+                            app.session_tool_allow.insert(req.tool_name.clone());
+                        }
+                        decide_hitl(app, tx, true);
+                    }
                     KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
                         decide_hitl(app, tx, false)
                     }
-                    _ => {}
+                    KeyCode::Enter => {} // no submit while the modal is open
+                    _ => {
+                        app.input.input(key);
+                    }
                 }
                 return;
             }
@@ -213,11 +228,6 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
             }
         }
         Event::Paste(text) => {
-            // Don't let a paste leak into the (occluded) composer while the HITL
-            // modal owns the screen.
-            if app.hitl.is_some() {
-                return;
-            }
             app.input.insert_str(text);
         }
         _ => {}
@@ -281,6 +291,10 @@ fn handle_ctrl_c(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
 /// Answer the open HITL prompt, surfacing a dial failure (so a lost decision
 /// isn't reported to the user as success).
 fn decide_hitl(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: bool) {
+    decide_hitl_with_note(app, tx, allow, false);
+}
+
+fn decide_hitl_with_note(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: bool, auto: bool) {
     if let Some(req) = app.hitl.take() {
         let (h, a) = (app.home.clone(), app.agent.clone());
         let (id, tool) = (req.hitl_id.clone(), req.tool_name.clone());
@@ -294,10 +308,10 @@ fn decide_hitl(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: bool) {
                     .await;
             }
         });
-        app.push_system(if allow {
-            format!("approved `{}`", req.tool_name)
-        } else {
-            format!("denied `{}`", req.tool_name)
+        app.push_system(match (allow, auto) {
+            (true, true) => format!("auto-approved `{}` (session)", req.tool_name),
+            (true, false) => format!("approved `{}`", req.tool_name),
+            (false, _) => format!("denied `{}`", req.tool_name),
         });
     }
 }
@@ -379,11 +393,25 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
                 Err(e) => app.push_system(format!("card task failed: {e}")),
             }
         }
+        SlashCmd::Auto(set) => {
+            app.auto_approve = set.unwrap_or(!app.auto_approve);
+            if app.auto_approve {
+                app.push_system(
+                    "auto-approve ON — every tool call is allowed without asking (this session only; /auto off to disable)",
+                );
+                // A prompt may already be waiting — resolve it under the new mode.
+                if app.hitl.is_some() {
+                    decide_hitl_with_note(app, tx, true, true);
+                }
+            } else {
+                app.push_system("auto-approve OFF — tool calls ask again");
+            }
+        }
         SlashCmd::Unknown(c) => app.push_system(format!("unknown command: /{c} — try /help")),
     }
 }
 
-fn handle_stream(app: &mut App, msg: StreamMsg) {
+fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
     // Drop events from a turn that is no longer current (cancelled, cleared, or
     // already finished) so a still-running worker can't splice its tokens/reply
     // into a later turn. `Note` carries no task id and is always shown.
@@ -394,7 +422,15 @@ fn handle_stream(app: &mut App, msg: StreamMsg) {
     }
     match msg {
         StreamMsg::Delta { text, thinking, .. } => app.append_delta(&text, thinking),
-        StreamMsg::Hitl { req, .. } => app.hitl = Some(req),
+        StreamMsg::Hitl { req, .. } => {
+            // Session auto-approval: `/auto`/`--auto` covers every tool; the
+            // modal's [a] key covers a single tool name.
+            let auto = app.auto_approve || app.session_tool_allow.contains(&req.tool_name);
+            app.hitl = Some(req);
+            if auto {
+                decide_hitl_with_note(app, tx, true, true);
+            }
+        }
         StreamMsg::Done { task, .. } => match stream::task_outcome(&task) {
             Ok((reply, task_id)) => app.finish_agent_turn(reply, task_id),
             Err(cause) => app.fail_turn(&cause),
@@ -408,7 +444,7 @@ fn handle_stream(app: &mut App, msg: StreamMsg) {
 
 /// Pipe-safe fallback: read a line from stdin, stream the reply as plain text to
 /// stdout, repeat. No ANSI, no TUI. Threads conversation context across turns.
-fn run_plain(home: &Path, agent: &str) -> Result<()> {
+fn run_plain(home: &Path, agent: &str, auto: bool) -> Result<()> {
     use std::cell::Cell;
     use std::io::BufRead;
     let stdin = io::stdin();
@@ -436,20 +472,25 @@ fn run_plain(home: &Path, agent: &str) -> Result<()> {
                 }
             },
             |hitl| {
-                // No TTY to prompt on: auto-deny immediately (on a separate
-                // connection) so the turn resolves instead of blocking for the
-                // full HITL timeout, and tell the user on stderr.
+                // No TTY to prompt on: resolve immediately (on a separate
+                // connection) so the turn doesn't block for the full HITL
+                // timeout — allow under --auto, deny otherwise — and tell the
+                // user on stderr.
                 let id = hitl
                     .get("hitl_id")
                     .and_then(|v| v.as_str())
                     .unwrap_or_default()
                     .to_string();
-                eprintln!("[non-interactive: auto-denying tool-approval request]");
+                if auto {
+                    eprintln!("[non-interactive: auto-approving tool-approval request (--auto)]");
+                } else {
+                    eprintln!("[non-interactive: auto-denying tool-approval request (use --auto to allow)]");
+                }
                 let _ = dial_method(
                     home,
                     agent,
                     "tool/hitl_respond",
-                    serde_json::json!({ "hitl_id": id, "allow": false }),
+                    serde_json::json!({ "hitl_id": id, "allow": auto }),
                     DialMode::RequireRunning,
                 );
             },

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -41,7 +41,7 @@ const SCROLL_STEP: u16 = 5;
 /// Spinner animation cadence.
 const SPINNER_MS: u64 = 90;
 
-const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /auto [on|off]  /exit · keys: Enter send · Alt+Enter newline · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
+const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /auto [on|off]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Alt+Enter newline · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
 
 /// Entry point dispatched from `AgentAction::Cli`.
 pub async fn cmd_cli(name: &str, resume: bool, auto: bool) -> Result<()> {
@@ -327,6 +327,20 @@ async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
         handle_slash(app, cmd, tx).await;
         return;
     }
+    // `!command` — run locally (like Claude Code's bang escape). Allowed while
+    // a turn is generating: it never touches the agent connection.
+    if let Some(cmd) = trimmed.strip_prefix('!').map(str::trim)
+        && !cmd.is_empty()
+    {
+        app.clear_input();
+        app.push_system(format!("running `{cmd}`…"));
+        let (cmd, t) = (cmd.to_string(), tx.clone());
+        tokio::spawn(async move {
+            let output = stream::run_local_shell(cmd.clone()).await;
+            let _ = t.send(StreamMsg::ShellDone { cmd, output }).await;
+        });
+        return;
+    }
     // Reject (but DON'T discard) a message typed while a turn is generating —
     // clearing the input here would silently lose what the user composed.
     if app.streaming {
@@ -336,7 +350,14 @@ async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
     app.clear_input();
 
     let task_id = app.begin_user_turn(&trimmed);
-    let params = build_params(&trimmed, &task_id, app.context_task_id.as_deref());
+    // Prefix any `!command` output the agent hasn't seen yet, so it has the
+    // same context the user is looking at. The transcript shows only the
+    // user's text; the shell blocks were already rendered when they ran.
+    let outgoing = match app.take_pending_shell() {
+        Some(ctx) => format!("{ctx}\n\n{trimmed}"),
+        None => trimmed.clone(),
+    };
+    let params = build_params(&outgoing, &task_id, app.context_task_id.as_deref());
     spawn_stream(
         app.home.clone(),
         app.agent.clone(),
@@ -437,6 +458,7 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
         },
         StreamMsg::Err { error, .. } => app.fail_turn(&error),
         StreamMsg::Note(text) => app.push_system(text),
+        StreamMsg::ShellDone { cmd, output } => app.push_shell(&cmd, &output),
     }
 }
 

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -41,6 +41,8 @@ pub enum StreamMsg {
     /// An out-of-band notice not tied to a turn (e.g. a failed HITL/cancel
     /// dial). Always shown regardless of the active turn.
     Note(String),
+    /// A local `!command` finished. Turn-independent like `Note`.
+    ShellDone { cmd: String, output: String },
 }
 
 impl StreamMsg {
@@ -51,9 +53,59 @@ impl StreamMsg {
             | StreamMsg::Hitl { task_id, .. }
             | StreamMsg::Done { task_id, .. }
             | StreamMsg::Err { task_id, .. } => Some(task_id),
-            StreamMsg::Note(_) => None,
+            StreamMsg::Note(_) | StreamMsg::ShellDone { .. } => None,
         }
     }
+}
+
+/// Cap on captured `!command` output forwarded to the transcript/agent.
+pub const SHELL_MAX_BYTES: usize = 8 * 1024;
+/// Wall-clock limit for a `!command`.
+pub const SHELL_TIMEOUT_SECS: u64 = 30;
+
+/// Run a local `!command` via `$SHELL -c` (fallback `/bin/sh`), merging
+/// stderr into stdout, with a timeout and output cap.
+pub async fn run_local_shell(cmd: String) -> String {
+    use tokio::process::Command;
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+    let fut = Command::new(shell)
+        .arg("-c")
+        .arg(&cmd)
+        .kill_on_drop(true)
+        .output();
+    let out = match tokio::time::timeout(
+        std::time::Duration::from_secs(SHELL_TIMEOUT_SECS),
+        fut,
+    )
+    .await
+    {
+        Err(_) => return format!("[timed out after {SHELL_TIMEOUT_SECS}s]"),
+        Ok(Err(e)) => return format!("[failed to run: {e}]"),
+        Ok(Ok(out)) => out,
+    };
+    let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+    let err = String::from_utf8_lossy(&out.stderr);
+    if !err.trim().is_empty() {
+        if !text.is_empty() && !text.ends_with('\n') {
+            text.push('\n');
+        }
+        text.push_str(&err);
+    }
+    if !out.status.success() {
+        if !text.is_empty() && !text.ends_with('\n') {
+            text.push('\n');
+        }
+        text.push_str(&format!("[exit {}]", out.status.code().unwrap_or(-1)));
+    }
+    if text.len() > SHELL_MAX_BYTES {
+        let mut cut = SHELL_MAX_BYTES;
+        while !text.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        text.truncate(cut);
+        text.push_str("\n[output truncated]");
+    }
+    text.trim_end().to_string()
 }
 
 /// A human-in-the-loop tool-approval request, parsed from a
@@ -302,6 +354,21 @@ mod tests {
         let (reply, id) = task_outcome(&task).unwrap();
         assert_eq!(reply, "hi");
         assert_eq!(id.as_deref(), Some("t9"));
+    }
+
+    #[tokio::test]
+    async fn run_local_shell_captures_output_and_exit() {
+        let out = run_local_shell("echo hi; echo err >&2; exit 3".into()).await;
+        assert!(out.contains("hi"));
+        assert!(out.contains("err"));
+        assert!(out.contains("[exit 3]"));
+    }
+
+    #[tokio::test]
+    async fn run_local_shell_truncates_huge_output() {
+        let out = run_local_shell("yes x | head -c 100000".into()).await;
+        assert!(out.len() <= SHELL_MAX_BYTES + 64);
+        assert!(out.ends_with("[output truncated]"));
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -73,16 +73,12 @@ pub async fn run_local_shell(cmd: String) -> String {
         .arg(&cmd)
         .kill_on_drop(true)
         .output();
-    let out = match tokio::time::timeout(
-        std::time::Duration::from_secs(SHELL_TIMEOUT_SECS),
-        fut,
-    )
-    .await
-    {
-        Err(_) => return format!("[timed out after {SHELL_TIMEOUT_SECS}s]"),
-        Ok(Err(e)) => return format!("[failed to run: {e}]"),
-        Ok(Ok(out)) => out,
-    };
+    let out =
+        match tokio::time::timeout(std::time::Duration::from_secs(SHELL_TIMEOUT_SECS), fut).await {
+            Err(_) => return format!("[timed out after {SHELL_TIMEOUT_SECS}s]"),
+            Ok(Err(e)) => return format!("[failed to run: {e}]"),
+            Ok(Ok(out)) => out,
+        };
     let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
     let err = String::from_utf8_lossy(&out.stderr);
     if !err.trim().is_empty() {

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -63,13 +63,23 @@ pub const SHELL_MAX_BYTES: usize = 8 * 1024;
 /// Wall-clock limit for a `!command`.
 pub const SHELL_TIMEOUT_SECS: u64 = 30;
 
-/// Run a local `!command` via `$SHELL -c` (fallback `/bin/sh`), merging
-/// stderr into stdout, with a timeout and output cap.
+/// Run a local `!command` through the user's shell (`$SHELL -c`, fallback
+/// `/bin/sh`; `cmd /C` on Windows), merging stderr into stdout, with a
+/// timeout and output cap.
 pub async fn run_local_shell(cmd: String) -> String {
     use tokio::process::Command;
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+    #[cfg(unix)]
+    let (shell, flag) = (
+        std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into()),
+        "-c",
+    );
+    #[cfg(windows)]
+    let (shell, flag) = (
+        std::env::var("COMSPEC").unwrap_or_else(|_| "cmd".into()),
+        "/C",
+    );
     let fut = Command::new(shell)
-        .arg("-c")
+        .arg(flag)
         .arg(&cmd)
         .kill_on_drop(true)
         .output();
@@ -352,6 +362,8 @@ mod tests {
         assert_eq!(id.as_deref(), Some("t9"));
     }
 
+    // sh-syntax test commands — unix only; Windows goes through `cmd /C`.
+    #[cfg(unix)]
     #[tokio::test]
     async fn run_local_shell_captures_output_and_exit() {
         let out = run_local_shell("echo hi; echo err >&2; exit 3".into()).await;
@@ -360,6 +372,7 @@ mod tests {
         assert!(out.contains("[exit 3]"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn run_local_shell_truncates_huge_output() {
         let out = run_local_shell("yes x | head -c 100000".into()).await;

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -80,6 +80,23 @@ fn push_message(lines: &mut Vec<Line<'static>>, m: &ChatMsg, spinner: usize) {
             ));
             lines.push(Line::default());
         }
+        Role::Shell => {
+            // `$ cmd` highlighted, output dim — visually a local terminal block.
+            let mut it = m.text.lines();
+            if let Some(first) = it.next() {
+                lines.push(Line::styled(
+                    first.to_string(),
+                    Style::default().fg(USER).add_modifier(Modifier::BOLD),
+                ));
+            }
+            for l in it {
+                lines.push(Line::styled(
+                    l.to_string(),
+                    Style::default().fg(SYSTEM),
+                ));
+            }
+            lines.push(Line::default());
+        }
         Role::Agent => {
             lines.push(Line::from(Span::styled(
                 "● agent",

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -74,10 +74,13 @@ fn push_message(lines: &mut Vec<Line<'static>>, m: &ChatMsg, spinner: usize) {
             lines.push(Line::default());
         }
         Role::System => {
-            lines.push(Line::styled(
-                format!("· {}", m.text),
-                Style::default().fg(SYSTEM).add_modifier(Modifier::ITALIC),
-            ));
+            for (i, l) in m.text.lines().enumerate() {
+                let prefix = if i == 0 { "· " } else { "  " };
+                lines.push(Line::styled(
+                    format!("{prefix}{l}"),
+                    Style::default().fg(SYSTEM).add_modifier(Modifier::ITALIC),
+                ));
+            }
             lines.push(Line::default());
         }
         Role::Shell => {
@@ -90,10 +93,7 @@ fn push_message(lines: &mut Vec<Line<'static>>, m: &ChatMsg, spinner: usize) {
                 ));
             }
             for l in it {
-                lines.push(Line::styled(
-                    l.to_string(),
-                    Style::default().fg(SYSTEM),
-                ));
+                lines.push(Line::styled(l.to_string(), Style::default().fg(SYSTEM)));
             }
             lines.push(Line::default());
         }

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -122,7 +122,7 @@ fn push_message(lines: &mut Vec<Line<'static>>, m: &ChatMsg, spinner: usize) {
 fn render_status(f: &mut Frame, app: &App, area: Rect) {
     let (msg, color) = if app.hitl.is_some() {
         (
-            "tool approval needed — [y] approve · [n] deny".to_string(),
+            "tool approval needed — [y] approve · [a] always (session) · [n] deny".to_string(),
             Color::Yellow,
         )
     } else if app.streaming {
@@ -136,15 +136,25 @@ fn render_status(f: &mut Frame, app: &App, area: Rect) {
         };
         (format!("ready{ctx}"), SYSTEM)
     };
-    let line = Line::from(vec![
+    let mut spans = vec![
         Span::styled(
             format!(" {} ", app.agent),
             Style::default().fg(Color::Black).bg(AGENT),
         ),
         Span::raw("  "),
-        Span::styled(msg, Style::default().fg(color)),
-    ]);
-    f.render_widget(Paragraph::new(line), area);
+    ];
+    if app.auto_approve {
+        spans.push(Span::styled(
+            " AUTO ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw("  "));
+    }
+    spans.push(Span::styled(msg, Style::default().fg(color)));
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
 fn render_hitl(f: &mut Frame, hitl: &super::stream::HitlRequest) {
@@ -173,6 +183,13 @@ fn render_hitl(f: &mut Frame, hitl: &super::stream::HitlRequest) {
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw(" approve    "),
+        Span::styled(
+            "[a]",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" always allow this tool (session)    "),
         Span::styled(
             "[n]",
             Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -31,7 +31,7 @@ pub mod export;
 mod hub;
 mod install;
 pub mod lifecycle;
-mod mcp;
+pub(crate) mod mcp;
 pub mod model_resolve;
 mod peers;
 mod perm;
@@ -39,7 +39,7 @@ mod prompt;
 mod reconnect;
 mod secret;
 mod service;
-mod skill;
+pub(crate) mod skill;
 mod snapshot;
 mod stats;
 

--- a/mur-core/src/cmd/media/resolve.rs
+++ b/mur-core/src/cmd/media/resolve.rs
@@ -46,9 +46,7 @@ fn which_in_well_known_dirs(bin: &str) -> Option<PathBuf> {
         dirs.push(home.join(".local/bin")); // pipx / pip --user
         dirs.push(home.join("bin"));
     }
-    dirs.into_iter()
-        .map(|d| d.join(bin))
-        .find(|c| c.is_file())
+    dirs.into_iter().map(|d| d.join(bin)).find(|c| c.is_file())
 }
 
 /// Heuristic: does this URL host a DRM-protected streaming service we cannot capture?

--- a/mur-core/src/cmd/media/resolve.rs
+++ b/mur-core/src/cmd/media/resolve.rs
@@ -17,7 +17,7 @@ fn detect_tool(env_key: &str, bin: &str) -> Option<PathBuf> {
         let p = PathBuf::from(p);
         return p.exists().then_some(p);
     }
-    which_on_path(bin)
+    which_on_path(bin).or_else(|| which_in_well_known_dirs(bin))
 }
 
 /// Minimal PATH search (avoids a new `which` crate dependency).
@@ -30,6 +30,25 @@ fn which_on_path(bin: &str) -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// Fallback for GUI-launched processes (Hub sidecar, launchd services): their
+/// PATH is the system default and misses package-manager prefixes, so a tool
+/// that works fine from a terminal "disappears" inside the runtime. Probe the
+/// standard install locations directly.
+fn which_in_well_known_dirs(bin: &str) -> Option<PathBuf> {
+    let mut dirs = vec![
+        PathBuf::from("/opt/homebrew/bin"), // Homebrew (Apple Silicon)
+        PathBuf::from("/usr/local/bin"),    // Homebrew (Intel) / manual installs
+    ];
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        dirs.push(home.join(".local/bin")); // pipx / pip --user
+        dirs.push(home.join("bin"));
+    }
+    dirs.into_iter()
+        .map(|d| d.join(bin))
+        .find(|c| c.is_file())
 }
 
 /// Heuristic: does this URL host a DRM-protected streaming service we cannot capture?

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1043,7 +1043,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
         AgentAction::Rename { old, new } => cmd::agent::cmd_rename(&old, &new)?,
         AgentAction::Send { name, message } => cmd::agent::cmd_send(&name, &message)?,
         AgentAction::Card { name } => cmd::agent::cmd_card(&name)?,
-        AgentAction::Cli { name, resume } => cmd::agent::cmd_cli(&name, resume).await?,
+        AgentAction::Cli { name, resume, auto } => cmd::agent::cmd_cli(&name, resume, auto).await?,
         AgentAction::Pair { name } => cmd::agent_pair::cmd_pair(&name)?,
         AgentAction::Rekey {
             name,


### PR DESCRIPTION
## Summary

Live-testing `mur agent cli` via tmux surfaced 9 operational issues (spec: `docs/superpowers/specs/2026-06-10-agent-cli-operations-design.md`). This PR fixes the 6 code-level ones in three batches; the rest are deploy/environment items documented in the spec.

### Batch 1 — HITL / permissions core
- **Bug: approving a tool call lost the whole turn.** `decide_hitl`'s `push_system("approved `tool`")` displaced the streaming agent bubble from `messages.last()`, so `finish_agent_turn`/`append_delta`/`finish_partial`/`fail_turn` missed it: reply silently dropped, bubble frozen on a spinner, turn never persisted, `context_task_id` stale (next turn lost the tool result). Verified runtime+protocol were fine via a raw-socket repro; all four methods now locate the streaming bubble by reverse search. Regression tests added.
- **Auto-approve permission modes** (modeled on Claude Code): HITL modal gains `[a]` always-allow-this-tool (session); `/auto [on|off]` + `--auto` flag for session-scoped approve-all with a warning `AUTO` status tag. Never persisted. Plain (piped) mode honors `--auto` (approve instead of deny).
- Keystrokes during the HITL modal now reach the composer instead of being swallowed.

### Batch 2 — toolchain / environment
- **`!cmd` local shell escape** (Claude Code behavior): runs via `$SHELL -c` (30 s timeout, 8 KB cap), renders as a shell block, persists (`role: shell`), and queued blocks are prefixed onto the next user message so the agent sees what the user ran.
- **Tool detection fallback**: `detect_ytdlp`/`detect_ffmpeg` probe `/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin`, `~/bin` after PATH search fails. GUI-launched runtimes (Hub sidecar, launchd) get the system-default PATH, which made `video_analyze` fail with `YtdlpMissing` while the same MCP server worked from a terminal.

### Batch 3 — in-TUI management
- **`/mcp [list] | add <name> <command> [args…] | remove <name>`** and **`/skill [list] | add <path> | remove <name>`** via new `cli/manage.rs` (string-returning — the CLI handlers print/prompt, unusable in a raw-mode alternate screen). `/mcp add` keeps the binary-sha256 pin + spawn-allowlist sync. Mutations remind the user to restart the agent.

## Test plan
- 31 unit tests in the touched modules pass (`cmd::agent::cli`, `cmd::media`), incl. new regressions for the displaced-bubble bug, shell capture/truncation, and pending-shell drain.
- Live-verified E2E in tmux against a local-model agent: `[a]` approve renders the reply, second call auto-approves, `/auto` shows the AUTO tag, `!echo` output round-trips into the agent's context, `/mcp`+`/skill` add/list/remove round-trip.
- `cargo clippy` clean, `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)