### PR TITLE
fix(hub): make the desktop pet functional — ACL capability, transparency, gestures

### DIFF
--- a/mur-hub-gui/src-tauri/capabilities/pet.json
+++ b/mur-hub-gui/src-tauri/capabilities/pet.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "identifier": "pet",
+  "description": "Capability set for desktop pet windows (one `pet-<agent>` window per agent). Least privilege: pets only need to receive expression/bubble events, read their position, and be dragged around the desktop.",
+  "windows": ["pet-*"],
+  "permissions": [
+    "core:event:allow-listen",
+    "core:event:allow-unlisten",
+    "core:window:allow-outer-position",
+    "core:window:allow-start-dragging"
+  ]
+}

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -54,14 +54,6 @@ fn valid_agent(agent_name: &str) -> bool {
     mur_common::agent_name::validate_agent_name(agent_name).is_ok()
 }
 
-fn load_position(agent_name: &str) -> Option<PetPosition> {
-    if !valid_agent(agent_name) {
-        return None;
-    }
-    let data = std::fs::read_to_string(pet_position_path(agent_name)).ok()?;
-    serde_json::from_str(&data).ok()
-}
-
 fn save_position(agent_name: &str, pos: &PetPosition) {
     if !valid_agent(agent_name) {
         return;
@@ -167,11 +159,14 @@ pub fn pet_spawn_at(
         pets.remove(&agent_name);
     }
 
-    let pos = load_position(&agent_name).unwrap_or(PetPosition {
+    // The explicit drop point always wins over a previously saved position — a
+    // stale save could point at a display that no longer exists. Persistence is
+    // left to pet_reposition, the single writer.
+    let pos = PetPosition {
         x: screen_x,
         y: screen_y,
         display_id: None,
-    });
+    };
 
     let url_path = format!("index.html#/pet/{}", urlenc(&agent_name));
 
@@ -347,4 +342,45 @@ fn urlenc(s: &str) -> String {
             }
         })
         .collect()
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    /// Pet windows live outside the `dashboard`/`popover` capabilities; without
+    /// their own capability the ACL silently denies `listen()`/`startDragging()`
+    /// and the pet is inert. Guard the capability file so it can't regress.
+    #[test]
+    fn pet_capability_covers_pet_windows() {
+        let text = include_str!("../../capabilities/pet.json");
+        let cap: serde_json::Value = serde_json::from_str(text).unwrap();
+
+        let windows: Vec<&str> = cap["windows"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|w| w.as_str())
+            .collect();
+        assert!(
+            windows.contains(&"pet-*"),
+            "capability must match pet-* windows"
+        );
+
+        let perms: Vec<&str> = cap["permissions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|p| p.as_str())
+            .collect();
+        // Every plugin command PetApp.tsx calls; app-defined commands need no ACL.
+        for perm in [
+            "core:event:allow-listen",
+            "core:event:allow-unlisten",
+            "core:window:allow-outer-position",
+            "core:window:allow-start-dragging",
+        ] {
+            assert!(perms.contains(&perm), "pet windows need {perm}");
+        }
+    }
 }

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -95,6 +95,7 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
     if (e.button !== 0) return;
     mouseDownPosRef.current = { x: e.clientX, y: e.clientY };
     holdTimer.current = setTimeout(() => {
+      holdTimer.current = null;
       setDragging(true);
       setGhostPos({ x: e.screenX, y: e.screenY });
       cursorOutsideRef.current = false;
@@ -106,6 +107,19 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
       clearTimeout(holdTimer.current);
       holdTimer.current = null;
     }
+  }
+
+  // A natural press-and-drag leaves the card before the hold timer fires; treat
+  // that as entering the drag instead of cancelling, or the pet can never spawn.
+  function leaveCard(e: React.MouseEvent) {
+    if (holdTimer.current && (e.buttons & 1) !== 0) {
+      cancelHold();
+      setDragging(true);
+      setGhostPos({ x: e.screenX, y: e.screenY });
+      cursorOutsideRef.current = false;
+      return;
+    }
+    cancelHold();
   }
 
   useEffect(() => {
@@ -156,7 +170,7 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
         data-agent={agent.name}
         onMouseDown={startHold}
         onMouseUp={cancelHold}
-        onMouseLeave={cancelHold}
+        onMouseLeave={leaveCard}
         onClick={() => setSelected(isSelected ? null : agent.name)}
       >
         <div className="grid-card__head">

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useT } from "../i18n";
 
@@ -22,6 +21,7 @@ interface BubbleState {
 }
 
 const CLICK_MS = 300;
+const DRAG_THRESHOLD_PX = 4;
 
 export function PetApp() {
   const { t } = useT();
@@ -31,7 +31,7 @@ export function PetApp() {
   const [bubble, setBubble] = useState<BubbleState | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenu>({ visible: false, x: 0, y: 0 });
   const clickTimeRef = useRef<number>(0);
-  const isDraggingRef = useRef(false);
+  const pressRef = useRef<{ x: number; y: number } | null>(null);
 
   // Load expression image whenever expression changes.
   useEffect(() => {
@@ -40,9 +40,11 @@ export function PetApp() {
     });
   }, [agentName, expression]);
 
-  // Listen for expression changes from the backend state machine.
+  // Listen for expression changes from the backend state machine. The listener
+  // must be window-targeted: a global listen() (target Any) would also receive
+  // the events emit_to() sends to every other pet.
   useEffect(() => {
-    const unsub = listen<string>("pet-expression", (ev) => {
+    const unsub = getCurrentWindow().listen<string>("pet-expression", (ev) => {
       setExpression(ev.payload);
     });
     return () => { unsub.then((f) => f()); };
@@ -50,7 +52,7 @@ export function PetApp() {
 
   // Listen for bubble messages from the backend.
   useEffect(() => {
-    const unsub = listen<string>("pet-bubble", (ev) => {
+    const unsub = getCurrentWindow().listen<string>("pet-bubble", (ev) => {
       if (ev.payload) {
         setBubble({ text: ev.payload, dwell_ms: 6000, ack_required: false });
       } else {
@@ -90,20 +92,32 @@ export function PetApp() {
     return () => window.removeEventListener("keydown", onKey);
   }, [bubble]);
 
+  // Click vs drag: a native startDragging() on mousedown would swallow the
+  // mouseup (the window server owns the drag loop), so clicks could never be
+  // detected. Only hand off to the native drag once the cursor actually moves.
   function handleMouseDown(e: React.MouseEvent) {
     if (e.button !== 0) return;
     clickTimeRef.current = Date.now();
-    isDraggingRef.current = false;
-    getCurrentWindow().startDragging().then(() => {
-      isDraggingRef.current = true;
-    }).catch(() => {});
+    pressRef.current = { x: e.screenX, y: e.screenY };
+  }
+
+  function handleMouseMove(e: React.MouseEvent) {
+    const press = pressRef.current;
+    if (!press || (e.buttons & 1) === 0) return;
+    if (
+      Math.abs(e.screenX - press.x) + Math.abs(e.screenY - press.y) >
+      DRAG_THRESHOLD_PX
+    ) {
+      pressRef.current = null;
+      getCurrentWindow().startDragging().catch(() => {});
+    }
   }
 
   function handleMouseUp() {
-    if (!isDraggingRef.current && Date.now() - clickTimeRef.current < CLICK_MS) {
+    if (pressRef.current && Date.now() - clickTimeRef.current < CLICK_MS) {
       invoke("hub_emit_event", { agentName, eventName: "user.click.pet" }).catch(() => {});
     }
-    isDraggingRef.current = false;
+    pressRef.current = null;
   }
 
   function handleContextMenu(e: React.MouseEvent) {
@@ -145,6 +159,7 @@ export function PetApp() {
       <div
         className={`pet-sprite pet-sprite--${expression}`}
         onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
       >
         {imageSrc ? (

--- a/mur-hub-gui/ui/src/main.tsx
+++ b/mur-hub-gui/ui/src/main.tsx
@@ -5,6 +5,12 @@ import { LanguageProvider } from "./i18n";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import "./styles/index.css";
 
+// Pet windows are transparent; the themed body background would otherwise
+// paint them as an opaque square. Tag before the first render to avoid a flash.
+if (window.location.hash.startsWith("#/pet/")) {
+  document.body.classList.add("pet-window");
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ErrorBoundary>

--- a/mur-hub-gui/ui/src/styles/components/pet.css
+++ b/mur-hub-gui/ui/src/styles/components/pet.css
@@ -1,4 +1,9 @@
 /* ── Pet Window ───────────────────────────────────────────────────────── */
+/* The pet webview window is created transparent; without this override the
+   themed body background paints it as an opaque square. */
+body.pet-window {
+  background: transparent;
+}
 .pet-root {
   width: 200px;
   height: 200px;


### PR DESCRIPTION
## Problem

桌面寵物功能沒有作用 — dragging an agent card to the desktop either did nothing, or produced an inert opaque dark square that never changed expression, couldn't be moved, and never showed bubbles.

## Root causes (all live-verified on the installed 2.22.20 Hub before fixing)

1. **`pet-*` windows had no Tauri capability.** `capabilities/` only covered `dashboard` and `popover`, so the ACL denied every core-plugin IPC call from pet windows: `listen()` → expression/bubble events never arrived; `startDragging()` → pet unmovable; `outerPosition()` → position never saved. App-defined commands still passed (local origin, no app ACL manifest — `tauri-2.11.2/src/webview/mod.rs` skips the ACL gate for them), which is why the right-click menu's Close worked while everything else was dead.
2. **Opaque background.** `base.css` `body { background: var(--surface-bg) }` painted the transparent pet window as a solid dark square.
3. **Spawn gesture cancelled by natural drags.** Leaving the card before the 300 ms hold timer fired cancelled the gesture, so press-and-drag (the natural motion) could never spawn a pet.
4. **Stale position beat the drop point.** `pet_spawn_at` preferred saved `pet_position.json` over the explicit drop coordinates (latent until #1 is fixed, then it would visibly teleport respawned pets — possibly onto a disconnected display).
5. **Click-to-react structurally dead.** PetApp called native `startDragging()` on mousedown; macOS then swallows the mouseup, so the click branch (`user.click.pet` → smile) could never fire once dragging worked. While dragging was ACL-broken, clicks worked but drags didn't — the two were never functional together.

## Fixes

- New `capabilities/pet.json` for `windows: ["pet-*"]` with least-privilege permissions (event listen/unlisten, window outer-position, start-dragging) + a regression test guarding the file.
- `body.pet-window { background: transparent }`, tagged in `main.tsx` before first render.
- Leaving the card with the button held enters the drag immediately; a fired hold timer clears its own handle so the leave path can't double-engage.
- Drop point always wins; `pet_reposition` is the single position writer (removes the logical-vs-physical mixed-unit write the review flagged).
- Native drag engages only after a 4 px movement threshold; in-place release counts as a click. Expression/bubble listeners are window-targeted (`getCurrentWindow().listen`) so multiple pets don't mirror each other's events (global `listen()` has target `Any`, which receives `emit_to` traffic for every label).

## Verification (live, debug bundle, sandboxed MUR_HOME, cliclick + pixel sampling)

- Natural press-and-drag (no hold) spawns the pet exactly at the drop point
- Window transparent: corner pixels over the Hub banner match the banner color exactly
- Event pipeline: spawn → wave (peach) for 2 s → idle (lavender); click → smile (green) → idle
- Pet drags with the window; `pet_position.json` written on move
- `cargo test` (incl. new capability test), `clippy -D warnings`, `cargo fmt --check`, vitest 18/18 — all green

Known cosmetic issue left out of scope: the dashboard drag ghost renders offset by roughly the title-bar height (pre-existing).

Note: the expression art itself is still the offline mock render (512×512 solid-color placeholders), so a fully working pet is a flat pastel circle that changes color per expression — real sprites need the render pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)