### PR TITLE
feat(skill): executable-DAG schema, unified Variable, enriched run ledger (workflow-engine v2 P2 / W3b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6364,6 +6364,7 @@ dependencies = [
  "quick-xml",
  "rand_core 0.6.4",
  "regex-lite",
+ "schemars 1.2.1",
  "secrecy",
  "semver",
  "serde",
@@ -6459,6 +6460,7 @@ dependencies = [
  "rpassword",
  "rusqlite",
  "rust-embed",
+ "schemars 1.2.1",
  "semver",
  "serde",
  "serde_jcs",
@@ -8516,10 +8518,24 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8703,6 +8719,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "fs
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+schemars = { version = "1", features = ["chrono04"] }
 clap = { version = "4", features = ["derive", "env"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking", "gzip"], default-features = false }
 tracing = "0.1"

--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -56,6 +56,25 @@ objects, harvest proposals are the candidate feed:
 - Spec: `docs/superpowers/specs/2026-05-28-mur-workflow-engine-design-v2.md`
 - Plan: `docs/superpowers/plans/2026-06-11-workflow-engine-w3a-pattern-removal.md`
 
+## Workflow engine P2 — DAG schema + run-ledger (2026-06-11)
+
+Schema/library layer for the v2 executor (P3 follows):
+
+- `ProcedureStep` gains executable-DAG fields: `id`, `depends_on`, `command`,
+  `on_failure`, `retry`, `timeout_secs`, `needs_approval` (all serde-default;
+  step order derives from the dependency topology, decision #1).
+- ONE `Variable` type in `skill::manifest` (typed `VarType`, string `default`
+  with `default_value` alias, `choices`); `workflow::Variable` re-exports it
+  (decision #3). `FailureAction`/`RetryConfig` moved to `skill::manifest`
+  (decision #6 prerequisite).
+- Run-ledger = enriched `SkillEvent::Execution` in the existing per-skill
+  `events.jsonl` (`duration_ms`, `exit_code`, `env_class`, `confidence`,
+  `trigger`); `record_run()` is the write path; `env_class.rs` classifies
+  workflow-vs-environment failures so a flaky network never marks a workflow
+  Broken. Fleet-sync dedup keys are unchanged.
+- `mur skill schema [--out path]` emits the manifest JSON Schema (Hub DAG
+  editor contract).
+
 ## Sources Pipeline (P1.4)
 
 All adapters shipped: Obsidian + Notion + Joplin; `--watch` + `install-schedule`; `format_notes_section` helper ready.

--- a/docs/superpowers/plans/2026-06-11-workflow-engine-w3b-p2-schema-ledger.md
+++ b/docs/superpowers/plans/2026-06-11-workflow-engine-w3b-p2-schema-ledger.md
@@ -1,0 +1,157 @@
+# Workflow Engine W3b-P2 — DAG Schema + Run-Ledger Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Workflow-engine v2 P2 — extend `ProcedureStep` with executable-DAG fields, unify the `Variable` type (v2 resolved decision #3), move `FailureAction`/`RetryConfig` into `skill::manifest` (prerequisite for the P3 executor lift), enrich `SkillEvent::Execution` into the full run-ledger record (duration/exit_code/env_class/confidence/trigger), add the env-class classifier, and emit a JSON Schema for the Hub DAG editor via `mur skill schema --json`.
+
+**Architecture:** Pure schema + library work, no executor yet (that's W3b-P3). Everything is additive/serde-defaulted so existing skill.yaml files and events.jsonl lines keep parsing, and fleet sync's set-union merge (dedup_key unchanged) keeps working. The run-ledger is NOT a new file: `~/.mur/skills/<name>/events.jsonl` with enriched `Execution` events IS the ledger (v2 amendment: "the run-ledger as a projection of per-skill events.jsonl") — `apply_new_events_to_stats` is already the stats reducer and `skill_lifecycle/sweep.rs::run_sweep` already applies `next_state` + the A1 provenance gate.
+
+**Verified current state (2026-06-11):**
+- `ProcedureStep` = {description, tool, intent, tool_hint} (`mur-common/src/skill/manifest.rs:150`)
+- `SkillEvent::Execution` = {ts, device_id, outcome, error, step} (`mur-common/src/skill/event_log.rs:25`); `append_event`/`read_events`/`union_events`/`apply_new_events_to_stats` all exist; writers: `sync/inbox.rs` (Commander signals)
+- `manifest::Variable` uses `var_type: String` + `default: Option<serde_yaml_ng::Value>`; `workflow::Variable` uses typed `VarType` + `default_value: Option<String>` — decision #3 merges them (typed enum + string default + alias)
+- `FailureAction`/`RetryConfig` live in `mur-common/src/workflow.rs:112-131`; `mur-common/src/pipeline.rs` imports them from there
+- Provenance gate + lifecycle sweep DONE (`skill_lifecycle/sweep.rs`, `lifecycle.rs::cap_for_provenance`)
+- schemars is NOT yet a dependency anywhere
+
+**Out of scope:** P3 unified executor; P4 thresholds-to-config + Broken fast-path + Archived hard-delete; P7 workflows/→skills/ migration.
+
+---
+
+### Task 1: Unify `Variable` in `skill::manifest` (decision #3)
+
+**Files:** `mur-common/src/skill/manifest.rs`, `mur-common/src/workflow.rs` (re-export), consumers via grep
+
+- [ ] Step 1: `grep -rn "manifest::Variable\|skill::manifest::Variable" mur-core/src mur-agent-runtime/src` and `grep -rn "\.default\b" <those files>` — list every consumer of the `serde_yaml_ng::Value` default before changing it.
+- [ ] Step 2: Replace `manifest::Variable` with the unified type:
+
+```rust
+/// Workflow/skill parameter (v2 resolved decision #3: ONE Variable type).
+/// `default` is string-encoded; runtime coerces per `var_type`
+/// (Number/Bool parsed, Array decoded as JSON or comma-separated).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct Variable {
+    pub name: String,
+    #[serde(rename = "type", default)]
+    pub var_type: VarType,
+    #[serde(default)]
+    pub required: bool,
+    /// String-encoded default. `default_value` accepted for legacy workflow YAML.
+    #[serde(default, alias = "default_value", skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Allowed values (renders as a dropdown in the Hub editor).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub choices: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum VarType {
+    #[default]
+    String,
+    Number,
+    Bool,
+    Array,
+}
+```
+
+  Migration shim for old manifests whose `default:` was a YAML value: a custom deserializer is NOT needed if we accept breakage only for non-string defaults — check Step 1's consumer list; if any shipped skill.yaml uses non-string defaults, add `#[serde(deserialize_with = "string_or_value")]` that stringifies scalars. Decide from evidence, not speculation.
+- [ ] Step 3: `workflow::Variable`/`VarType` become re-exports (`pub use crate::skill::manifest::{Variable, VarType};`) — delete the local definitions; fix `default_value` field accesses crate-wide (grep `default_value`).
+- [ ] Step 4: Tests: legacy workflow YAML with `default_value:` parses (alias); legacy skill YAML with string `default:` parses. Run `cargo nextest run -p mur-common -p mur-core -E 'test(/variable|manifest|workflow/)'`. Commit.
+
+### Task 2: Move `FailureAction` + `RetryConfig` into `skill::manifest`
+
+- [ ] Step 1: Move both types (bodies unchanged) from `workflow.rs` to `manifest.rs`; leave `pub use crate::skill::manifest::{FailureAction, RetryConfig};` in workflow.rs so `pipeline.rs` and executor imports keep compiling.
+- [ ] Step 2: `cargo nextest run -p mur-common -p mur-core -E 'test(/pipeline|workflow/)'`; clippy; commit.
+
+### Task 3: `ProcedureStep` DAG + exec fields
+
+- [ ] Step 1: Extend (all default — existing skill.yaml parses unchanged):
+
+```rust
+    // ── Executable-DAG fields (v2 P2; all Option/default) ──
+    /// Stable step id for `depends_on` references. Defaults to the step index
+    /// as a string when omitted (assigned at load, not serialized).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// Step ids this step depends on. Empty = root.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
+    /// Shell command (command-mode step). Intent-mode steps leave this None.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub on_failure: FailureAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry: Option<RetryConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+    /// Pause for human approval before running (TTY prompt; non-TTY skips
+    /// and marks `skipped_approval` — wired in P3).
+    #[serde(default)]
+    pub needs_approval: bool,
+```
+
+- [ ] Step 2: Sweep `ProcedureStep {` literals crate-wide (grep) adding `..Default::default()` where possible (derive `Default` on ProcedureStep). Round-trip test: yaml with depends_on parses; yaml without new fields parses. Commit.
+
+### Task 4: Enrich `SkillEvent::Execution` (run-ledger record)
+
+- [ ] Step 1: Add serde-defaulted fields to the `Execution` variant: `duration_ms: Option<u64>`, `exit_code: Option<i32>`, `env_class: Option<String>` ("workflow"|"env"), `confidence: Option<f64>`, `trigger: Option<String>` ("manual"|"schedule"|"agent"). `dedup_key()` unchanged (ts+kind+device) so fleet-sync union still dedups.
+- [ ] Step 2: Back-compat test: old jsonl line without new fields parses; new line round-trips. `apply_new_events_to_stats` unchanged (outcome drives counters). Commit.
+
+### Task 5: env-class classifier
+
+**Files:** Create `mur-common/src/skill/env_class.rs`
+
+- [ ] Step 1: Heuristic classifier per spec (workflow failure vs environment failure):
+
+```rust
+//! Classify a failed run as a *workflow* failure (the skill is broken) vs an
+//! *environment* failure (network/credentials/missing binary) so a flaky
+//! network never marks a workflow Broken (v2 spec, Layer 4).
+
+pub struct EnvClassification {
+    /// "workflow" | "env"
+    pub class: &'static str,
+    pub confidence: f64,
+}
+
+const ENV_MARKERS: &[&str] = &[
+    "connection refused", "connection reset", "timed out", "timeout",
+    "could not resolve", "dns", "network is unreachable", "tls", "certificate",
+    "401", "403", "unauthorized", "forbidden", "credential", "permission denied",
+    "no such file or directory", "command not found", "not found in path",
+    "rate limit", "429", "disk full", "no space left",
+];
+
+pub fn classify_failure(stderr: &str) -> EnvClassification {
+    let lower = stderr.to_lowercase();
+    let hits = ENV_MARKERS.iter().filter(|m| lower.contains(*m)).count();
+    match hits {
+        0 => EnvClassification { class: "workflow", confidence: 0.6 },
+        1 => EnvClassification { class: "env", confidence: 0.6 },
+        _ => EnvClassification { class: "env", confidence: 0.9 },
+    }
+}
+```
+
+  Plus `record_run` convenience in `event_log.rs` building an enriched Execution event from an outcome + optional stderr (calls classify_failure on failure). Tests for both. Commit.
+
+### Task 6: JSON Schema emit — `mur skill schema --json`
+
+- [ ] Step 1: Add `schemars = "1"` (workspace dep) to mur-common; derive `JsonSchema` on `SkillManifest` and every type it embeds (Content, ProcedureStep, Variable, VarType, FailureAction, RetryConfig, Trigger, Category, …). Types that can't derive (serde_yaml_ng::Value remnants) must be gone after Task 1 — if any remain, `#[schemars(with = "String")]`.
+- [ ] Step 2: New `SkillAction::Schema { json: bool }` → `cmd_skill_schema()`: `serde_json::to_string_pretty(&schemars::schema_for!(SkillManifest))`, written to stdout; `--out schema/skill.schema.json` optional flag writes the file.
+- [ ] Step 3: Smoke: `mur skill schema --json | python3 -m json.tool > /dev/null`. Commit.
+
+### Task 7: Final verification + PR
+
+- [ ] `cargo fmt --check`, `cargo clippy --workspace` (0 warnings), `cargo nextest run -p mur-common -p mur-core` (rollup env-flaky pair excepted), build mur-agent-runtime (`cargo build -p mur-agent-runtime`) since manifest types feed the runtime.
+- [ ] Docs: runtime-overview gets a short "P2 schema + ledger" subsection under the v2 heading; CLAUDE.md untouched (operational surface unchanged except `mur skill schema`).
+- [ ] PR: `feat(skill): executable-DAG step schema, unified Variable, enriched run ledger, JSON Schema emit (v2 P2 / W3b)`.
+
+## Self-review notes
+- Decision #3 (one Variable) ✓ T1; decision #6 prerequisite (FailureAction/RetryConfig moved) ✓ T2; Layer-4 ledger record ✓ T4+T5; Hub editor schema ✓ T6.
+- No executor changes; `mur run` behavior untouched (P3).
+- Every schema change serde-defaulted; fleet-sync dedup_key untouched.

--- a/mur-common/Cargo.toml
+++ b/mur-common/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true }
 serde_bytes = "0.11"
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+schemars = { workspace = true }
 serde_yaml_ng = "0.10"
 quick-xml = { workspace = true }
 chrono = { workspace = true }

--- a/mur-common/src/parameterize.rs
+++ b/mur-common/src/parameterize.rs
@@ -127,8 +127,9 @@ pub fn suggestions_to_variables(suggestions: &[ParameterSuggestion]) -> Vec<Vari
             name,
             var_type: VarType::String,
             required: s.category != DetectedCategory::Port,
-            default_value: Some(s.original_value.clone()),
-            description: s.description.clone(),
+            default: Some(s.original_value.clone()),
+            description: Some(s.description.clone()),
+            choices: vec![],
         });
     }
     vars

--- a/mur-common/src/skill/env_class.rs
+++ b/mur-common/src/skill/env_class.rs
@@ -1,0 +1,87 @@
+//! Classify a failed run as a *workflow* failure (the skill is broken) vs an
+//! *environment* failure (network/credentials/missing binary) so a flaky
+//! network never marks a workflow Broken (workflow-engine v2, Layer 4).
+//!
+//! Classification is heuristic; the confidence field lets the Broken
+//! fast-path (P4) require high-confidence workflow failures before demoting,
+//! and lets the user override via `mur run --env-class workflow|env`.
+
+/// Result of classifying a failure's stderr/output.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EnvClassification {
+    /// "workflow" | "env"
+    pub class: &'static str,
+    pub confidence: f64,
+}
+
+/// Substrings that indicate the *environment* failed, not the workflow.
+const ENV_MARKERS: &[&str] = &[
+    "connection refused",
+    "connection reset",
+    "timed out",
+    "timeout",
+    "could not resolve",
+    "temporary failure in name resolution",
+    "network is unreachable",
+    "tls",
+    "certificate",
+    "401",
+    "403",
+    "unauthorized",
+    "forbidden",
+    "credential",
+    "permission denied",
+    "no such file or directory",
+    "command not found",
+    "not found in path",
+    "rate limit",
+    "429",
+    "disk full",
+    "no space left",
+];
+
+/// Heuristic stderr classifier. Zero env markers → likely a workflow bug
+/// (moderate confidence); one marker → likely environmental; several → almost
+/// certainly environmental.
+pub fn classify_failure(stderr: &str) -> EnvClassification {
+    let lower = stderr.to_lowercase();
+    let hits = ENV_MARKERS.iter().filter(|m| lower.contains(*m)).count();
+    match hits {
+        0 => EnvClassification {
+            class: "workflow",
+            confidence: 0.6,
+        },
+        1 => EnvClassification {
+            class: "env",
+            confidence: 0.6,
+        },
+        _ => EnvClassification {
+            class: "env",
+            confidence: 0.9,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_assertion_failure_is_workflow() {
+        let c = classify_failure("assertion failed: expected 3 got 2");
+        assert_eq!(c.class, "workflow");
+    }
+
+    #[test]
+    fn network_error_is_env() {
+        let c = classify_failure("curl: (7) Connection refused");
+        assert_eq!(c.class, "env");
+    }
+
+    #[test]
+    fn multiple_markers_high_confidence_env() {
+        let c = classify_failure("error: timed out\ncurl: connection refused after retry");
+        assert_eq!(c.class, "env");
+        assert!(c.confidence > 0.8);
+    }
+}

--- a/mur-common/src/skill/event_log.rs
+++ b/mur-common/src/skill/event_log.rs
@@ -259,7 +259,9 @@ mod tests {
         )
         .unwrap();
         match &ev {
-            SkillEvent::Execution { env_class, trigger, .. } => {
+            SkillEvent::Execution {
+                env_class, trigger, ..
+            } => {
                 assert_eq!(env_class.as_deref(), Some("env"));
                 assert_eq!(trigger.as_deref(), Some("manual"));
             }
@@ -285,7 +287,9 @@ mod tests {
         )
         .unwrap();
         match &ev2 {
-            SkillEvent::Execution { env_class, outcome, .. } => {
+            SkillEvent::Execution {
+                env_class, outcome, ..
+            } => {
                 assert!(env_class.is_none());
                 assert_eq!(outcome, "success");
             }
@@ -299,7 +303,11 @@ mod tests {
         let legacy = r#"{"kind":"execution","ts":"2026-05-30T00:00:00Z","device_id":"d","outcome":"success"}"#;
         let ev: SkillEvent = serde_json::from_str(legacy).unwrap();
         match &ev {
-            SkillEvent::Execution { duration_ms, env_class, .. } => {
+            SkillEvent::Execution {
+                duration_ms,
+                env_class,
+                ..
+            } => {
                 assert!(duration_ms.is_none());
                 assert!(env_class.is_none());
             }

--- a/mur-common/src/skill/event_log.rs
+++ b/mur-common/src/skill/event_log.rs
@@ -31,6 +31,23 @@ pub enum SkillEvent {
         error: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         step: Option<String>,
+        // ── Run-ledger enrichment (workflow-engine v2 P2; all default so
+        //    existing events.jsonl lines keep parsing and fleet-sync's
+        //    dedup_key (ts+kind+device) is unaffected) ──
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        duration_ms: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        exit_code: Option<i32>,
+        /// "workflow" (the skill is broken) | "env" (network/credentials/…).
+        /// The Broken fast-path (P4) only triggers on "workflow" with
+        /// confidence ≥ threshold.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        env_class: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        confidence: Option<f64>,
+        /// "manual" | "schedule" | "agent"
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        trigger: Option<String>,
     },
     Dismissed {
         ts: DateTime<Utc>,
@@ -170,6 +187,39 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
+    #[test]
+    fn legacy_execution_line_parses_and_enriched_roundtrips() {
+        // Pre-P2 line without the run-ledger fields must keep parsing.
+        let legacy = r#"{"kind":"execution","ts":"2026-05-30T00:00:00Z","device_id":"d","outcome":"success"}"#;
+        let ev: SkillEvent = serde_json::from_str(legacy).unwrap();
+        match &ev {
+            SkillEvent::Execution { duration_ms, env_class, .. } => {
+                assert!(duration_ms.is_none());
+                assert!(env_class.is_none());
+            }
+            _ => panic!("wrong kind"),
+        }
+
+        // Enriched event round-trips.
+        let enriched = SkillEvent::Execution {
+            ts: chrono::DateTime::from_timestamp(1_748_000_000, 0).unwrap(),
+            device_id: "d".into(),
+            outcome: "failure".into(),
+            error: Some("boom".into()),
+            step: Some("deploy".into()),
+            duration_ms: Some(8421),
+            exit_code: Some(1),
+            env_class: Some("workflow".into()),
+            confidence: Some(0.6),
+            trigger: Some("manual".into()),
+        };
+        let line = serde_json::to_string(&enriched).unwrap();
+        let back: SkillEvent = serde_json::from_str(&line).unwrap();
+        assert_eq!(back, enriched);
+        // dedup_key shape unchanged (ts+kind+device) — fleet-sync compatible.
+        assert!(enriched.dedup_key().ends_with(":execution:d"));
+    }
+
     fn device() -> String {
         "dev-a".into()
     }
@@ -190,6 +240,11 @@ mod tests {
             outcome: "success".into(),
             error: None,
             step: None,
+            duration_ms: None,
+            exit_code: None,
+            env_class: None,
+            confidence: None,
+            trigger: None,
         }
     }
 
@@ -201,6 +256,11 @@ mod tests {
             outcome: "failure".into(),
             error: Some("oops".into()),
             step: None,
+            duration_ms: None,
+            exit_code: None,
+            env_class: None,
+            confidence: None,
+            trigger: None,
         }
     }
 

--- a/mur-common/src/skill/event_log.rs
+++ b/mur-common/src/skill/event_log.rs
@@ -165,6 +165,59 @@ pub fn apply_new_events_to_stats(stats: &mut SkillStats, new_events: &[SkillEven
     }
 }
 
+/// Outcome of one workflow/skill run, recorded into the per-skill ledger.
+pub struct RunRecord<'a> {
+    /// true = success
+    pub success: bool,
+    pub duration_ms: Option<u64>,
+    pub exit_code: Option<i32>,
+    /// stderr (or combined output) of the failing step; used to classify
+    /// workflow-vs-environment failure. Ignored on success.
+    pub stderr: Option<&'a str>,
+    /// Step id/description that failed, if any.
+    pub failed_step: Option<String>,
+    /// "manual" | "schedule" | "agent"
+    pub trigger: &'a str,
+    /// Explicit user override of the env classification
+    /// (`mur run --env-class workflow|env`).
+    pub env_class_override: Option<&'a str>,
+}
+
+/// Append one enriched Execution event for a completed run — the run-ledger
+/// write path (workflow-engine v2 P2). Returns the event written.
+pub fn record_run(
+    mur_home: &Path,
+    skill_name: &str,
+    device_id: &str,
+    rec: &RunRecord<'_>,
+) -> Result<SkillEvent> {
+    let (env_class, confidence) = if rec.success {
+        (None, None)
+    } else if let Some(forced) = rec.env_class_override {
+        (Some(forced.to_string()), Some(1.0))
+    } else {
+        let c = crate::skill::env_class::classify_failure(rec.stderr.unwrap_or(""));
+        (Some(c.class.to_string()), Some(c.confidence))
+    };
+
+    let event = SkillEvent::Execution {
+        ts: Utc::now(),
+        device_id: device_id.to_string(),
+        outcome: if rec.success { "success" } else { "failure" }.to_string(),
+        error: (!rec.success)
+            .then(|| rec.stderr.map(|s| s.chars().take(500).collect()))
+            .flatten(),
+        step: rec.failed_step.clone(),
+        duration_ms: rec.duration_ms,
+        exit_code: rec.exit_code,
+        env_class,
+        confidence,
+        trigger: Some(rec.trigger.to_string()),
+    };
+    append_event(&event_log_path(mur_home, skill_name), &event)?;
+    Ok(event)
+}
+
 /// Resolve manifest conflict via Last-Writer-Wins (LWW).
 /// Returns the winning skill and the reason (local_wins, remote_wins, or force_local).
 pub fn resolve_manifest_lww(
@@ -186,6 +239,59 @@ pub fn resolve_manifest_lww(
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn record_run_classifies_and_appends() {
+        let tmp = tempdir().unwrap();
+        let ev = record_run(
+            tmp.path(),
+            "deploy-api",
+            "dev-a",
+            &RunRecord {
+                success: false,
+                duration_ms: Some(1200),
+                exit_code: Some(7),
+                stderr: Some("curl: (7) Connection refused"),
+                failed_step: Some("health-check".into()),
+                trigger: "manual",
+                env_class_override: None,
+            },
+        )
+        .unwrap();
+        match &ev {
+            SkillEvent::Execution { env_class, trigger, .. } => {
+                assert_eq!(env_class.as_deref(), Some("env"));
+                assert_eq!(trigger.as_deref(), Some("manual"));
+            }
+            _ => panic!("wrong kind"),
+        }
+        let events = read_events(&event_log_path(tmp.path(), "deploy-api")).unwrap();
+        assert_eq!(events.len(), 1);
+
+        // Success run records no env_class.
+        let ev2 = record_run(
+            tmp.path(),
+            "deploy-api",
+            "dev-a",
+            &RunRecord {
+                success: true,
+                duration_ms: Some(900),
+                exit_code: Some(0),
+                stderr: None,
+                failed_step: None,
+                trigger: "schedule",
+                env_class_override: None,
+            },
+        )
+        .unwrap();
+        match &ev2 {
+            SkillEvent::Execution { env_class, outcome, .. } => {
+                assert!(env_class.is_none());
+                assert_eq!(outcome, "success");
+            }
+            _ => panic!("wrong kind"),
+        }
+    }
 
     #[test]
     fn legacy_execution_line_parses_and_enriched_roundtrips() {

--- a/mur-common/src/skill/evolution.rs
+++ b/mur-common/src/skill/evolution.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 pub const CURRENT_GENERATION: u32 = 0;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct EvolutionEvent {
     pub version: String,
     #[serde(default)]

--- a/mur-common/src/skill/gene.rs
+++ b/mur-common/src/skill/gene.rs
@@ -113,6 +113,7 @@ impl SkillGene {
                     tool: s.tool.clone(),
                     intent: s.intent.clone(),
                     tool_hint: None,
+                    ..Default::default()
                 })
                 .collect(),
         }
@@ -277,6 +278,7 @@ mod tests {
                 tool: Some("browser.go".into()),
                 intent: Some("open_page".into()),
                 tool_hint: None,
+                ..Default::default()
             }],
             vec![Trigger {
                 kind: TriggerKind::Command,
@@ -308,6 +310,7 @@ mod tests {
                 tool: None,
                 intent: Some("i1".into()),
                 tool_hint: None,
+                ..Default::default()
             }],
             vec![],
         );
@@ -318,12 +321,14 @@ mod tests {
                     tool: None,
                     intent: Some("i1".into()),
                     tool_hint: None,
+                    ..Default::default()
                 },
                 ProcedureStep {
                     description: "added".into(),
                     tool: None,
                     intent: Some("i2".into()),
                     tool_hint: None,
+                    ..Default::default()
                 },
             ],
             vec![],
@@ -344,6 +349,7 @@ mod tests {
                 tool: None,
                 intent: None,
                 tool_hint: None,
+                ..Default::default()
             }],
             vec![],
         );

--- a/mur-common/src/skill/manifest.rs
+++ b/mur-common/src/skill/manifest.rs
@@ -202,7 +202,7 @@ impl std::fmt::Display for VarType {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProcedureStep {
     pub description: String,
 
@@ -223,6 +223,39 @@ pub struct ProcedureStep {
     /// `mcp_requirements` match for the intent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_hint: Option<String>,
+
+    // ── Executable-DAG fields (workflow-engine v2 P2; all default so every
+    //    existing skill.yaml parses unchanged) ──
+    /// Stable step id for `depends_on` references. When omitted, executors
+    /// assign the zero-based step index as the id at load time (not serialized).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// Step ids this step depends on. Empty = root step. Step order derives
+    /// from the dependency topology, never from list position (v2 decision #1).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends_on: Vec<String>,
+
+    /// Shell command (command-mode step), run via `sh -c` with exit-code
+    /// gating. Intent-mode steps leave this None — in pure CLI runs they are
+    /// printed as instructions and marked skipped in the ledger (decision #2).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+
+    #[serde(default)]
+    pub on_failure: FailureAction,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry: Option<RetryConfig>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u64>,
+
+    /// Pause for human approval before running. TTY: prompt and wait.
+    /// Non-TTY: auto-skip and mark `skipped_approval` in the ledger; `--yes`
+    /// auto-approves (v2 decision #5). Wired by the P3 executor.
+    #[serde(default)]
+    pub needs_approval: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -258,6 +291,37 @@ fn default_any_version() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn procedure_step_dag_fields_roundtrip() {
+        let yaml = r#"
+description: deploy the app
+command: "fly deploy --app {{app_name}}"
+id: deploy
+depends_on: [build, test]
+on_failure: retry
+retry:
+  max_retries: 2
+  backoff_secs: 5
+timeout_secs: 300
+needs_approval: true
+"#;
+        let step: ProcedureStep = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(step.id.as_deref(), Some("deploy"));
+        assert_eq!(step.depends_on, vec!["build", "test"]);
+        assert_eq!(step.on_failure, FailureAction::Retry);
+        assert_eq!(step.retry.as_ref().unwrap().max_retries, 2);
+        assert_eq!(step.timeout_secs, Some(300));
+        assert!(step.needs_approval);
+
+        // Legacy step without any DAG fields parses with defaults.
+        let legacy: ProcedureStep =
+            serde_yaml_ng::from_str("description: run tests\ntool: Bash\n").unwrap();
+        assert!(legacy.id.is_none());
+        assert!(legacy.depends_on.is_empty());
+        assert_eq!(legacy.on_failure, FailureAction::Abort);
+        assert!(!legacy.needs_approval);
+    }
 
     #[test]
     fn variable_accepts_legacy_default_value_alias() {

--- a/mur-common/src/skill/manifest.rs
+++ b/mur-common/src/skill/manifest.rs
@@ -154,7 +154,6 @@ pub enum FailureAction {
     Retry,
 }
 
-
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, schemars::JsonSchema)]
 pub struct Variable {
     pub name: String,
@@ -165,7 +164,11 @@ pub struct Variable {
     /// String-encoded default. `default_value` accepted for legacy workflow YAML.
     /// Runtime coerces per `var_type` (Number/Bool parsed, Array decoded as
     /// JSON or comma-separated).
-    #[serde(default, alias = "default_value", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        alias = "default_value",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub default: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -343,8 +346,7 @@ needs_approval: true
     #[test]
     fn variable_all_vartypes_parse() {
         for t in ["string", "path", "url", "number", "bool", "array"] {
-            let v: Variable =
-                serde_yaml_ng::from_str(&format!("name: x\ntype: {t}\n")).unwrap();
+            let v: Variable = serde_yaml_ng::from_str(&format!("name: x\ntype: {t}\n")).unwrap();
             assert_eq!(v.var_type.to_string(), t);
         }
     }

--- a/mur-common/src/skill/manifest.rs
+++ b/mur-common/src/skill/manifest.rs
@@ -133,6 +133,28 @@ pub struct Procedure {
     pub steps: Vec<ProcedureStep>,
 }
 
+/// Commander extension: retry configuration for a workflow step.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetryConfig {
+    pub max_retries: u32,
+    #[serde(default)]
+    pub backoff_secs: Option<u64>,
+}
+
+/// What to do when a workflow step fails.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum FailureAction {
+    /// Skip this step and continue
+    Skip,
+    /// Abort the entire workflow
+    #[default]
+    Abort,
+    /// Retry the step
+    Retry,
+}
+
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct Variable {
     pub name: String,

--- a/mur-common/src/skill/manifest.rs
+++ b/mur-common/src/skill/manifest.rs
@@ -133,17 +133,51 @@ pub struct Procedure {
     pub steps: Vec<ProcedureStep>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct Variable {
     pub name: String,
-    #[serde(rename = "type")]
-    pub var_type: String,
+    #[serde(rename = "type", default)]
+    pub var_type: VarType,
     #[serde(default)]
     pub required: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub default: Option<serde_yaml_ng::Value>,
+    /// String-encoded default. `default_value` accepted for legacy workflow YAML.
+    /// Runtime coerces per `var_type` (Number/Bool parsed, Array decoded as
+    /// JSON or comma-separated).
+    #[serde(default, alias = "default_value", skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Allowed values (renders as a dropdown in the Hub DAG editor).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub choices: Vec<String>,
+}
+
+/// Variable types for workflow/skill parameters (v2 resolved decision #3:
+/// ONE `Variable` type lives here; `workflow::Variable` re-exports it).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum VarType {
+    #[default]
+    String,
+    Path,
+    Url,
+    Number,
+    Bool,
+    /// Array of strings (e.g., multiple URLs, multiple product names)
+    Array,
+}
+
+impl std::fmt::Display for VarType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VarType::String => write!(f, "string"),
+            VarType::Path => write!(f, "path"),
+            VarType::Url => write!(f, "url"),
+            VarType::Number => write!(f, "number"),
+            VarType::Bool => write!(f, "bool"),
+            VarType::Array => write!(f, "array"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -202,6 +236,32 @@ fn default_any_version() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn variable_accepts_legacy_default_value_alias() {
+        // Legacy workflow YAML used `default_value`; the unified type aliases it.
+        let v: Variable = serde_yaml_ng::from_str(
+            "name: app\ntype: string\nrequired: true\ndefault_value: my-api\n",
+        )
+        .unwrap();
+        assert_eq!(v.default.as_deref(), Some("my-api"));
+        assert_eq!(v.var_type, VarType::String);
+
+        // Modern form `default:` parses too, and choices default empty.
+        let v2: Variable =
+            serde_yaml_ng::from_str("name: env\ntype: string\ndefault: prod\n").unwrap();
+        assert_eq!(v2.default.as_deref(), Some("prod"));
+        assert!(v2.choices.is_empty());
+    }
+
+    #[test]
+    fn variable_all_vartypes_parse() {
+        for t in ["string", "path", "url", "number", "bool", "array"] {
+            let v: Variable =
+                serde_yaml_ng::from_str(&format!("name: x\ntype: {t}\n")).unwrap();
+            assert_eq!(v.var_type.to_string(), t);
+        }
+    }
 
     #[test]
     fn full_manifest_roundtrips() {

--- a/mur-common/src/skill/manifest.rs
+++ b/mur-common/src/skill/manifest.rs
@@ -33,7 +33,7 @@ pub struct Skill {
 
 /// Publisher-authored fields. This is what gets signed and is the unit of
 /// content hashing.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct SkillManifest {
     pub name: String,
     pub version: String,
@@ -88,7 +88,7 @@ pub struct SkillManifest {
     pub updated_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct Content {
     /// Layer 2 — injected into the system prompt at session start.
     pub r#abstract: String,
@@ -126,7 +126,7 @@ impl Content {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct Procedure {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub variables: Vec<Variable>,
@@ -134,7 +134,7 @@ pub struct Procedure {
 }
 
 /// Commander extension: retry configuration for a workflow step.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct RetryConfig {
     pub max_retries: u32,
     #[serde(default)]
@@ -142,7 +142,7 @@ pub struct RetryConfig {
 }
 
 /// What to do when a workflow step fails.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum FailureAction {
     /// Skip this step and continue
@@ -155,7 +155,7 @@ pub enum FailureAction {
 }
 
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, schemars::JsonSchema)]
 pub struct Variable {
     pub name: String,
     #[serde(rename = "type", default)]
@@ -176,7 +176,7 @@ pub struct Variable {
 
 /// Variable types for workflow/skill parameters (v2 resolved decision #3:
 /// ONE `Variable` type lives here; `workflow::Variable` re-exports it).
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum VarType {
     #[default]
@@ -202,7 +202,7 @@ impl std::fmt::Display for VarType {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ProcedureStep {
     pub description: String,
 
@@ -258,7 +258,7 @@ pub struct ProcedureStep {
     pub needs_approval: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct Trigger {
     #[serde(rename = "type")]
     pub kind: TriggerKind,
@@ -277,7 +277,7 @@ impl Trigger {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct Requirement {
     pub name: String,
     #[serde(default = "default_any_version")]

--- a/mur-common/src/skill/mcp.rs
+++ b/mur-common/src/skill/mcp.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 
 /// MCP capabilities a skill may declare it requires. Mirrors the six
 /// capabilities defined in mur-commander's `engine/src/mcp/trust.rs`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, schemars::JsonSchema)]
 pub enum SkillCapability {
     ReadFile,
     ListTools,
@@ -90,7 +90,7 @@ impl<'de> Deserialize<'de> for SkillCapability {
 
 /// A requirement that one or more MCP tools matching `tool_pattern` be
 /// reachable at runtime, and that they are safe to invoke under `capability`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, schemars::JsonSchema)]
 pub struct McpRequirement {
     /// Glob pattern matching tool names, e.g. `"browser.*"` or
     /// `"filesystem.write.*"`.

--- a/mur-common/src/skill/mod.rs
+++ b/mur-common/src/skill/mod.rs
@@ -4,6 +4,7 @@ pub mod aggregator;
 pub mod capability;
 pub mod constraint;
 pub mod credit;
+pub mod env_class;
 pub mod event_log;
 pub mod evolution;
 pub mod gene;

--- a/mur-common/src/skill/types.rs
+++ b/mur-common/src/skill/types.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Which host(s) may load a skill. See spec §2.3.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default, schemars::JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum HostId {
     MurAgent,
@@ -31,7 +31,7 @@ pub enum TrustLevel {
 }
 
 /// Top-level skill category.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Category {
     Context,
@@ -47,7 +47,7 @@ pub enum Category {
 /// Where a skill came from. Drives the curation gate: `Llm`-authored skills
 /// cannot auto-promote past `Emerging` until a human curates them
 /// (amendment A1, `2026-05-28-mur-workflow-engine-design-v2.md`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Provenance {
     /// Hand-authored by a person. Default — no gate.
@@ -69,7 +69,7 @@ pub enum ContentMode {
     Note,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Priority {
     Low,
@@ -79,7 +79,7 @@ pub enum Priority {
     Critical,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum TriggerKind {
     Command,

--- a/mur-common/src/skill/types.rs
+++ b/mur-common/src/skill/types.rs
@@ -3,7 +3,9 @@
 use serde::{Deserialize, Serialize};
 
 /// Which host(s) may load a skill. See spec §2.3.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Default, schemars::JsonSchema,
+)]
 #[serde(rename_all = "kebab-case")]
 pub enum HostId {
     MurAgent,
@@ -47,7 +49,9 @@ pub enum Category {
 /// Where a skill came from. Drives the curation gate: `Llm`-authored skills
 /// cannot auto-promote past `Emerging` until a human curates them
 /// (amendment A1, `2026-05-28-mur-workflow-engine-design-v2.md`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, schemars::JsonSchema,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum Provenance {
     /// Hand-authored by a person. Default — no gate.
@@ -69,7 +73,9 @@ pub enum ContentMode {
     Note,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, schemars::JsonSchema,
+)]
 #[serde(rename_all = "lowercase")]
 pub enum Priority {
     Low,
@@ -79,7 +85,9 @@ pub enum Priority {
     Critical,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, schemars::JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum TriggerKind {
     Command,

--- a/mur-common/src/variable.rs
+++ b/mur-common/src/variable.rs
@@ -241,7 +241,7 @@ pub fn collect_workflow_variables(workflow: &crate::workflow::Workflow) -> Vec<S
 pub fn workflow_defaults_map(workflow: &crate::workflow::Workflow) -> BTreeMap<String, String> {
     let mut defaults = BTreeMap::new();
     for v in &workflow.variables {
-        if let Some(ref dv) = v.default_value {
+        if let Some(ref dv) = v.default {
             defaults.insert(v.name.clone(), dv.clone());
         }
     }

--- a/mur-common/src/workflow.rs
+++ b/mur-common/src/workflow.rs
@@ -128,51 +128,7 @@ pub enum FailureAction {
     Retry,
 }
 
-/// A variable/parameter for a workflow.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Variable {
-    /// Variable name
-    pub name: String,
-    /// Type of the variable
-    #[serde(rename = "type", default)]
-    pub var_type: VarType,
-    /// Whether this variable must be provided
-    #[serde(default)]
-    pub required: bool,
-    /// Default value (as string)
-    #[serde(default)]
-    pub default_value: Option<String>,
-    /// Human-readable description
-    #[serde(default)]
-    pub description: String,
-}
-
-/// Variable types for workflow parameters.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum VarType {
-    #[default]
-    String,
-    Path,
-    Url,
-    Number,
-    Bool,
-    /// Array of strings (e.g., multiple URLs, multiple product names)
-    Array,
-}
-
-impl std::fmt::Display for VarType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            VarType::String => write!(f, "string"),
-            VarType::Path => write!(f, "path"),
-            VarType::Url => write!(f, "url"),
-            VarType::Number => write!(f, "number"),
-            VarType::Bool => write!(f, "bool"),
-            VarType::Array => write!(f, "array"),
-        }
-    }
-}
+pub use crate::skill::manifest::{Variable, VarType};
 
 /// Notification level for workflow events.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/mur-common/src/workflow.rs
+++ b/mur-common/src/workflow.rs
@@ -107,28 +107,8 @@ pub struct Step {
     pub timeout_secs: Option<u64>,
 }
 
-/// Commander extension: retry configuration for a workflow step.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RetryConfig {
-    pub max_retries: u32,
-    #[serde(default)]
-    pub backoff_secs: Option<u64>,
-}
+pub use crate::skill::manifest::{FailureAction, RetryConfig, Variable, VarType};
 
-/// What to do when a workflow step fails.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "lowercase")]
-pub enum FailureAction {
-    /// Skip this step and continue
-    Skip,
-    /// Abort the entire workflow
-    #[default]
-    Abort,
-    /// Retry the step
-    Retry,
-}
-
-pub use crate::skill::manifest::{Variable, VarType};
 
 /// Notification level for workflow events.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/mur-common/src/workflow.rs
+++ b/mur-common/src/workflow.rs
@@ -107,8 +107,7 @@ pub struct Step {
     pub timeout_secs: Option<u64>,
 }
 
-pub use crate::skill::manifest::{FailureAction, RetryConfig, Variable, VarType};
-
+pub use crate::skill::manifest::{FailureAction, RetryConfig, VarType, Variable};
 
 /// Notification level for workflow events.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+schemars = { workspace = true }
 serde_yaml_ng = "0.10"  # AgentProfile uses serde_yaml_ng::Value in model.params
 libc = "0.2"
 clap = { workspace = true, optional = true }

--- a/mur-core/src/cli/skill.rs
+++ b/mur-core/src/cli/skill.rs
@@ -11,6 +11,12 @@ pub enum SkillAction {
         #[arg(long)]
         warnings_only: bool,
     },
+    /// Emit the JSON Schema of the skill manifest (for the Hub DAG editor).
+    Schema {
+        /// Write to a file instead of stdout
+        #[arg(long)]
+        out: Option<String>,
+    },
     /// Convert between canonical YAML and markdown frontmatter.
     Fmt {
         path: String,

--- a/mur-core/src/cmd/fleet_sync.rs
+++ b/mur-core/src/cmd/fleet_sync.rs
@@ -689,6 +689,11 @@ mod tests {
             outcome: "success".into(),
             error: None,
             step: None,
+            duration_ms: None,
+            exit_code: None,
+            env_class: None,
+            confidence: None,
+            trigger: None,
         };
 
         // Union the events (simulating merge)

--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -1220,7 +1220,10 @@ async fn export_skill_llm(id: &str, events: &[session::SessionEvent]) -> Result<
             out.push_str(&format!(
                 "  - name: \"{}\"\n    description: \"{}\"\n",
                 var.name,
-                var.description.as_deref().unwrap_or("").replace('\"', "\\\""),
+                var.description
+                    .as_deref()
+                    .unwrap_or("")
+                    .replace('\"', "\\\""),
             ));
             if let Some(ref dv) = var.default {
                 out.push_str(&format!("    default: \"{}\"\n", dv));

--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -1220,10 +1220,10 @@ async fn export_skill_llm(id: &str, events: &[session::SessionEvent]) -> Result<
             out.push_str(&format!(
                 "  - name: \"{}\"\n    description: \"{}\"\n",
                 var.name,
-                var.description.replace('\"', "\\\""),
+                var.description.as_deref().unwrap_or("").replace('\"', "\\\""),
             ));
-            if let Some(ref dv) = var.default_value {
-                out.push_str(&format!("    default_value: \"{}\"\n", dv));
+            if let Some(ref dv) = var.default {
+                out.push_str(&format!("    default: \"{}\"\n", dv));
             }
         }
     }

--- a/mur-core/src/cmd/skill_cmd.rs
+++ b/mur-core/src/cmd/skill_cmd.rs
@@ -9,6 +9,24 @@ use mur_common::skill::{
 use std::fs;
 use std::path::Path;
 
+/// `mur skill schema [--out path]` — emit the JSON Schema of `SkillManifest`
+/// (consumed by the Hub DAG editor for node/edge rendering + per-step forms).
+pub fn cmd_schema(out: Option<&str>) -> Result<()> {
+    let schema = schemars::schema_for!(mur_common::skill::manifest::SkillManifest);
+    let json = serde_json::to_string_pretty(&schema)?;
+    match out {
+        Some(path) => {
+            if let Some(parent) = std::path::Path::new(path).parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(path, &json)?;
+            eprintln!("✓ schema written to {path}");
+        }
+        None => println!("{json}"),
+    }
+    Ok(())
+}
+
 pub fn cmd_validate(path: &str, warnings_only: bool) -> Result<()> {
     let m = read_any(path)?;
     if let Err(e) = validate(&m) {

--- a/mur-core/src/cmd/workflow.rs
+++ b/mur-core/src/cmd/workflow.rs
@@ -196,10 +196,10 @@ pub(crate) fn cmd_workflow_show(name: &str, markdown: bool) -> Result<()> {
                 println!(
                     "- `{}` ({}, {}): {} — default: `{}`",
                     v.name,
-                v.var_type,
-                req,
-                v.description.as_deref().unwrap_or(""),
-                default
+                    v.var_type,
+                    req,
+                    v.description.as_deref().unwrap_or(""),
+                    default
                 );
             }
             println!();

--- a/mur-core/src/cmd/workflow.rs
+++ b/mur-core/src/cmd/workflow.rs
@@ -121,10 +121,14 @@ fn print_workflow_prompt(w: &mur_common::workflow::Workflow) {
         println!("## Variables\n");
         for v in &w.variables {
             let req = if v.required { "required" } else { "optional" };
-            let default = v.default_value.as_deref().unwrap_or("-");
+            let default = v.default.as_deref().unwrap_or("-");
             println!(
                 "- `{}` ({}, {}): {} — default: `{}`",
-                v.name, v.var_type, req, v.description, default
+                v.name,
+                v.var_type,
+                req,
+                v.description.as_deref().unwrap_or(""),
+                default
             );
         }
         println!();
@@ -188,10 +192,14 @@ pub(crate) fn cmd_workflow_show(name: &str, markdown: bool) -> Result<()> {
             println!("## Variables\n");
             for v in &w.variables {
                 let req = if v.required { "required" } else { "optional" };
-                let default = v.default_value.as_deref().unwrap_or("-");
+                let default = v.default.as_deref().unwrap_or("-");
                 println!(
                     "- `{}` ({}, {}): {} — default: `{}`",
-                    v.name, v.var_type, req, v.description, default
+                    v.name,
+                v.var_type,
+                req,
+                v.description.as_deref().unwrap_or(""),
+                default
                 );
             }
             println!();
@@ -235,10 +243,14 @@ pub(crate) fn cmd_workflow_show(name: &str, markdown: bool) -> Result<()> {
             println!("\nVariables:");
             for v in &w.variables {
                 let req = if v.required { "required" } else { "optional" };
-                let default = v.default_value.as_deref().unwrap_or("-");
+                let default = v.default.as_deref().unwrap_or("-");
                 println!(
                     "  ${} ({}): {} [{}] default={}",
-                    v.name, v.var_type, v.description, req, default
+                    v.name,
+                    v.var_type,
+                    v.description.as_deref().unwrap_or(""),
+                    req,
+                    default
                 );
             }
         }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -284,9 +284,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 path,
                 warnings_only,
             } => cmd::skill_cmd::cmd_validate(&path, warnings_only)?,
-            crate::cli::SkillAction::Schema { out } => {
-                cmd::skill_cmd::cmd_schema(out.as_deref())?
-            }
+            crate::cli::SkillAction::Schema { out } => cmd::skill_cmd::cmd_schema(out.as_deref())?,
             crate::cli::SkillAction::Fmt { path, to, write } => {
                 cmd::skill_cmd::cmd_fmt(&path, to.as_deref(), write)?
             }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -284,6 +284,9 @@ pub async fn run(cli: Cli) -> Result<()> {
                 path,
                 warnings_only,
             } => cmd::skill_cmd::cmd_validate(&path, warnings_only)?,
+            crate::cli::SkillAction::Schema { out } => {
+                cmd::skill_cmd::cmd_schema(out.as_deref())?
+            }
             crate::cli::SkillAction::Fmt { path, to, write } => {
                 cmd::skill_cmd::cmd_fmt(&path, to.as_deref(), write)?
             }

--- a/mur-core/src/extract.rs
+++ b/mur-core/src/extract.rs
@@ -206,8 +206,9 @@ fn detect_variables(msg: Option<&str>, _tools: &[String]) -> Vec<Variable> {
             name: "product_name".to_string(),
             var_type: VarType::String,
             required: true,
-            default_value: Some(subject.clone()),
-            description: "Target product or search term".to_string(),
+            default: Some(subject.clone()),
+            description: Some("Target product or search term".to_string()),
+            choices: vec![],
         });
     }
 
@@ -222,8 +223,9 @@ fn detect_variables(msg: Option<&str>, _tools: &[String]) -> Vec<Variable> {
                 name: "url".to_string(),
                 var_type: VarType::Url,
                 required: true,
-                default_value: Some(w.to_string()),
-                description: "Target URL".to_string(),
+                default: Some(w.to_string()),
+                description: Some("Target URL".to_string()),
+                choices: vec![],
             });
         }
     }
@@ -255,8 +257,9 @@ fn detect_variables(msg: Option<&str>, _tools: &[String]) -> Vec<Variable> {
                 name: "target_site".to_string(),
                 var_type: VarType::String,
                 required: true,
-                default_value: Some(w.to_string()),
-                description: "Website or service to search in".to_string(),
+                default: Some(w.to_string()),
+                description: Some("Website or service to search in".to_string()),
+                choices: vec![],
             });
         }
     }
@@ -272,8 +275,9 @@ fn detect_variables(msg: Option<&str>, _tools: &[String]) -> Vec<Variable> {
                 name: "file_path".to_string(),
                 var_type: VarType::Path,
                 required: true,
-                default_value: Some(w.to_string()),
-                description: "File or directory path".to_string(),
+                default: Some(w.to_string()),
+                description: Some("File or directory path".to_string()),
+                choices: vec![],
             });
         }
     }
@@ -291,8 +295,9 @@ fn detect_variables(msg: Option<&str>, _tools: &[String]) -> Vec<Variable> {
                     name: "count".to_string(),
                     var_type: VarType::Number,
                     required: false,
-                    default_value: Some(w.to_string()),
-                    description: "Number of items to process".to_string(),
+                    default: Some(w.to_string()),
+                    description: Some("Number of items to process".to_string()),
+                    choices: vec![],
                 });
             }
         }
@@ -340,8 +345,9 @@ fn detect_variables(msg: Option<&str>, _tools: &[String]) -> Vec<Variable> {
                     name: "product_name".to_string(),
                     var_type: VarType::String,
                     required: true,
-                    default_value: Some(name),
-                    description: "Target product or search term".to_string(),
+                    default: Some(name),
+                    description: Some("Target product or search term".to_string()),
+                    choices: vec![],
                 });
             }
         }
@@ -370,7 +376,7 @@ fn generate_title(
     // Remove quoted strings (they're variables)
     let mut clean = msg.to_string();
     for qv in variables {
-        if let Some(ref dv) = qv.default_value {
+        if let Some(ref dv) = qv.default {
             clean = clean.replace(&format!("'{}'", dv), "");
             clean = clean.replace(&format!("\"{}\"", dv), "");
             clean = clean.replace(dv, "");
@@ -436,16 +442,16 @@ mod tests {
         );
         assert_eq!(vars.len(), 2);
         assert_eq!(vars[0].name, "product_name");
-        assert_eq!(vars[0].default_value, Some("AirPods Pro 3".to_string()));
+        assert_eq!(vars[0].default, Some("AirPods Pro 3".to_string()));
         assert_eq!(vars[1].name, "target_site");
-        assert_eq!(vars[1].default_value, Some("pchome".to_string()));
+        assert_eq!(vars[1].default, Some("pchome".to_string()));
     }
 
     #[test]
     fn test_detect_variables_smart_quotes() {
         let vars = detect_variables(Some("find \u{2018}AirPods\u{2019} in momo"), &[]);
         assert_eq!(vars.len(), 2);
-        assert_eq!(vars[0].default_value, Some("AirPods".to_string()));
+        assert_eq!(vars[0].default, Some("AirPods".to_string()));
     }
 
     #[test]
@@ -471,7 +477,7 @@ mod tests {
         let vars = detect_variables(Some("find top 5 results for shoes"), &[]);
         assert!(
             vars.iter()
-                .any(|v| v.name == "count" && v.default_value == Some("5".to_string()))
+                .any(|v| v.name == "count" && v.default == Some("5".to_string()))
         );
     }
 
@@ -487,7 +493,7 @@ mod tests {
         let vars = detect_variables(Some("search for prices on Amazon"), &[]);
         assert!(
             vars.iter()
-                .any(|v| v.name == "target_site" && v.default_value == Some("Amazon".to_string()))
+                .any(|v| v.name == "target_site" && v.default == Some("Amazon".to_string()))
         );
     }
 
@@ -497,8 +503,9 @@ mod tests {
             name: "product_name".to_string(),
             var_type: VarType::String,
             required: true,
-            default_value: Some("AirPods Pro 3".to_string()),
-            description: String::new(),
+            default: Some("AirPods Pro 3".to_string()),
+            description: Some(String::new()),
+            choices: vec![],
         }];
         let title = generate_title(
             Some("use agent-browser to find the prices of 'AirPods Pro 3' in pchome"),

--- a/mur-core/src/extract_llm.rs
+++ b/mur-core/src/extract_llm.rs
@@ -377,7 +377,7 @@ fn build_skeleton_summary(extracted: &ExtractedWorkflow) -> String {
                 "  - {} ({}): {}\n",
                 var.name,
                 format!("{:?}", var.var_type).to_lowercase(),
-                var.description
+                var.description.as_deref().unwrap_or("")
             ));
         }
     }
@@ -467,8 +467,9 @@ fn build_workflow_from_llm(
             name: v.name.clone(),
             var_type: VarType::String,
             required: true,
-            default_value: v.default_value.clone(),
-            description: v.description.clone(),
+            default: v.default_value.clone(),
+            description: Some(v.description.clone()),
+            choices: vec![],
         })
         .collect();
 

--- a/mur-core/src/inject/hook.rs
+++ b/mur-core/src/inject/hook.rs
@@ -340,7 +340,7 @@ pub fn format_workflow_entry(workflow: &Workflow, index: usize) -> String {
             .variables
             .iter()
             .map(|v| {
-                let default = v.default_value.as_deref().unwrap_or("?");
+                let default = v.default.as_deref().unwrap_or("?");
                 format!("`{}`={}", v.name, default)
             })
             .collect();

--- a/mur-core/src/skill_index/text.rs
+++ b/mur-core/src/skill_index/text.rs
@@ -124,12 +124,14 @@ mod tests {
                     tool: None,
                     intent: None,
                     tool_hint: None,
+                    ..Default::default()
                 },
                 ProcedureStep {
                     description: "Push to server".into(),
                     tool: Some("rsync".into()),
                     intent: None,
                     tool_hint: None,
+                    ..Default::default()
                 },
             ],
         });

--- a/mur-core/src/sync/inbox.rs
+++ b/mur-core/src/sync/inbox.rs
@@ -323,6 +323,11 @@ impl Inbox {
                 outcome: "success".into(),
                 error: None,
                 step: None,
+                duration_ms: None,
+                exit_code: None,
+                env_class: None,
+                confidence: None,
+                trigger: None,
             },
             SignalKind::SkillExecutionFailure { error } => SkillEvent::Execution {
                 ts: signal.emitted_at,
@@ -330,6 +335,11 @@ impl Inbox {
                 outcome: "failure".into(),
                 error: Some(error.clone()),
                 step: None,
+                duration_ms: None,
+                exit_code: None,
+                env_class: None,
+                confidence: None,
+                trigger: None,
             },
             _ => return Ok(false),
         };

--- a/mur-core/tests/skill_resolve_inject.rs
+++ b/mur-core/tests/skill_resolve_inject.rs
@@ -11,6 +11,7 @@ fn step(tool: Option<&str>, intent: Option<&str>, hint: Option<&str>) -> Procedu
         tool: tool.map(String::from),
         intent: intent.map(String::from),
         tool_hint: hint.map(String::from),
+        ..Default::default()
     }
 }
 

--- a/mur-core/tests/skill_resolve_unit.rs
+++ b/mur-core/tests/skill_resolve_unit.rs
@@ -8,6 +8,7 @@ fn step(tool: Option<&str>, intent: Option<&str>, hint: Option<&str>) -> Procedu
         tool: tool.map(String::from),
         intent: intent.map(String::from),
         tool_hint: hint.map(String::from),
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
## Summary

Workflow-engine v2 **P2** (`docs/superpowers/specs/2026-05-28-mur-workflow-engine-design-v2.md`) — the schema/library layer the P3 unified executor builds on. Plan: `docs/superpowers/plans/2026-06-11-workflow-engine-w3b-p2-schema-ledger.md`.

- **`ProcedureStep` executable-DAG fields** (all serde-default, every existing skill.yaml parses unchanged): `id`, `depends_on`, `command`, `on_failure`, `retry`, `timeout_secs`, `needs_approval`. Step order derives from dependency topology (resolved decision #1).
- **ONE `Variable` type** (resolved decision #3): typed `VarType` + string-encoded `default` with `serde(alias = "default_value")` for legacy workflow YAML + `choices`; lives in `skill::manifest`, `workflow::Variable` re-exports. `FailureAction`/`RetryConfig` also moved to `skill::manifest` (decision #6 prerequisite for the P3 executor lift from `executor/pipeline.rs`).
- **Run-ledger** = enriched `SkillEvent::Execution` in the existing per-skill `events.jsonl` (per the v2 amendment "run-ledger as a projection of events.jsonl" — no new file): `duration_ms`, `exit_code`, `env_class`, `confidence`, `trigger`. `dedup_key` (ts+kind+device) unchanged → fleet-sync set-union merge unaffected; old jsonl lines keep parsing (tested).
- **`record_run()`** write path + **`env_class.rs`** heuristic classifier (workflow-vs-environment failure, with confidence; user override hook for `mur run --env-class`) so a flaky network never marks a workflow Broken.
- **`mur skill schema [--out path]`** emits the manifest JSON Schema via schemars (Hub DAG editor contract; ProcedureStep DAG fields verified present in `$defs`).

No executor changes — `mur run` behavior untouched (P3). Stats reducer (`apply_new_events_to_stats`) and lifecycle sweep (incl. the A1 provenance gate, already implemented) consume the new events unchanged.

## Test Plan
- [x] `cargo nextest run -p mur-common -p mur-core` — all pass except the 2 known env-dependent `conversations::summarize::rollup` tests (×2 binaries; host LanceDB dimension mismatch, module untouched)
- [x] New tests: Variable legacy-alias parse, all VarTypes, ProcedureStep DAG round-trip + legacy parse, Execution event back-compat + enriched round-trip + dedup-key shape, env-class classification, record_run append
- [x] `cargo clippy --workspace` 0 warnings; `cargo fmt --check` clean; `cargo build -p mur-agent-runtime` clean
- [x] Smoke: `mur skill schema | python3 -m json.tool` valid; `$defs.ProcedureStep` contains id/depends_on/command/on_failure/needs_approval
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)