### PR TITLE
feat(harvest): accept proposal as category:Workflow skill (P5a)

### DIFF
--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -416,13 +416,7 @@ pub(crate) async fn cmd_out(action: Option<&str>, force: bool) -> anyhow::Result
             .unwrap_or(2);
         match choice {
             0 => {
-                crate::cmd::workflow::create_draft_workflow_with_steps(
-                    &p.suggested_name,
-                    &format!("Captured from session {}", &p.id[..8.min(p.id.len())]),
-                    &p.title,
-                    std::slice::from_ref(&p.id),
-                    &p.steps,
-                )?;
+                let skill_name = accept_proposal_as_skill(&p).await?;
                 crate::harvest::proposal::set_status_in_dir(
                     &inbox,
                     &p.id,
@@ -430,8 +424,8 @@ pub(crate) async fn cmd_out(action: Option<&str>, force: bool) -> anyhow::Result
                 )?;
                 mark_harvested(&p.id);
                 eprintln!(
-                    "  ✓ Draft saved — edit: ~/.mur/workflows/{}.yaml · run: mur run {}",
-                    p.suggested_name, p.suggested_name
+                    "  ✓ Skill saved as `{}` — edit: ~/.mur/skills/{}/skill.yaml · run: mur run {}",
+                    skill_name, skill_name, skill_name
                 );
             }
             1 => {
@@ -459,6 +453,115 @@ fn mark_harvested(id: &str) {
             let _ = std::fs::write(recordings.join(format!("{}.meta.json", id)), json);
         }
     }
+}
+
+/// Accept a harvest proposal as a `category: Workflow` skill (P5a).
+///
+/// Runs LLM extraction (fallback: logic-only) and writes
+/// `~/.mur/skills/<name>/skill.yaml` with `provenance: Llm`.
+/// Returns the skill name that was written.
+async fn accept_proposal_as_skill(
+    proposal: &crate::harvest::proposal::Proposal,
+) -> anyhow::Result<String> {
+    use mur_common::skill::{
+        SkillManifest,
+        manifest::{Content, Procedure, ProcedureStep},
+        store::{global_skill_dir, write_to_dir},
+        types::{Category, Priority, Provenance},
+    };
+
+    let id = &proposal.id;
+    let events = session::read_events(id).unwrap_or_default();
+
+    let extracted = if !events.is_empty() && crate::extract::has_llm_config() {
+        match crate::extract::extract_workflow_llm(id, &events).await {
+            Ok(e) => {
+                eprintln!("  ◆ LLM extracted workflow from {} events.", events.len());
+                e
+            }
+            Err(e) => {
+                eprintln!("  ⚠ LLM extraction failed ({e}); using logic-only extraction.");
+                crate::extract::extract_workflow(id, &events)
+            }
+        }
+    } else {
+        crate::extract::extract_workflow(id, &events)
+    };
+
+    let wf = &extracted.workflow;
+    let name = crate::harvest::proposal::suggest_name(&wf.base.name);
+
+    let mur_home = crate::paths::mur_root(None);
+    let skill_dir = global_skill_dir(&mur_home, &name);
+    if skill_dir.join("skill.yaml").exists() {
+        eprintln!("  ✓ Skill `{}` already exists — left unchanged.", name);
+        return Ok(name);
+    }
+
+    // Convert sequential workflow steps to a linear DAG chain.
+    let steps: Vec<ProcedureStep> = wf
+        .steps
+        .iter()
+        .enumerate()
+        .map(|(i, s)| ProcedureStep {
+            description: s.description.clone(),
+            id: Some(format!("step{i}")),
+            depends_on: if i == 0 {
+                vec![]
+            } else {
+                vec![format!("step{}", i - 1)]
+            },
+            command: s.command.clone(),
+            tool: s.tool.clone(),
+            ..Default::default()
+        })
+        .collect();
+
+    let abstract_text = if wf.trigger.is_empty() {
+        wf.base.description.clone()
+    } else {
+        format!("{}. Trigger: {}", wf.base.description, wf.trigger)
+    };
+
+    let mut tags = vec!["harvested".to_string()];
+    for t in &wf.tools {
+        let t_lower = t.to_lowercase();
+        if !tags.contains(&t_lower) {
+            tags.push(t_lower);
+        }
+    }
+
+    let manifest = SkillManifest {
+        name: name.clone(),
+        version: "1.0.0".to_string(),
+        publisher: "local".to_string(),
+        description: wf.base.description.clone(),
+        category: Category::Workflow,
+        provenance: Provenance::Llm,
+        hosts: vec![],
+        content: Content {
+            r#abstract: abstract_text,
+            procedure: Some(Procedure {
+                variables: wf.variables.clone(),
+                steps,
+            }),
+            context: None,
+            command: None,
+            note: None,
+        },
+        requires: vec![],
+        tags,
+        triggers: vec![],
+        priority: Priority::Normal,
+        evolution_log: vec![],
+        transfer_chain: vec![],
+        mcp_requirements: vec![],
+        updated_at: chrono::Utc::now(),
+    };
+
+    std::fs::create_dir_all(&skill_dir)?;
+    write_to_dir(&skill_dir, &manifest)?;
+    Ok(name)
 }
 
 /// Check if a session has enough substance to warrant LLM analysis.

--- a/mur-core/src/cmd/workflow.rs
+++ b/mur-core/src/cmd/workflow.rs
@@ -1066,90 +1066,10 @@ pub fn create_draft_workflow(
 }
 
 /// Draft workflow with skeleton steps (harvest accept path). Steps containing
-/// `<…>` placeholders are descriptions (the user fills variables on edit);
-/// fully-literal steps double as runnable commands.
-pub fn create_draft_workflow_with_steps_in(
-    store: &crate::store::workflow_yaml::WorkflowYamlStore,
-    name: &str,
-    description: &str,
-    trigger: &str,
-    source_sessions: &[String],
-    steps: &[String],
-) -> anyhow::Result<()> {
-    if store.exists(name) {
-        return Ok(());
-    }
-    let base = KnowledgeBase {
-        name: name.to_string(),
-        description: description.to_string(),
-        content: Content::Plain(trigger.to_string()),
-        maturity: mur_common::knowledge::Maturity::Draft,
-        ..Default::default()
-    };
-    let wf_steps = steps
-        .iter()
-        .enumerate()
-        .map(|(i, s)| mur_common::workflow::Step {
-            order: (i + 1) as u32,
-            description: s.clone(),
-            command: (!s.contains('<') && !s.starts_with("tool:")).then(|| s.clone()),
-            ..Default::default()
-        })
-        .collect();
-    let wf = mur_common::workflow::Workflow {
-        base,
-        steps: wf_steps,
-        variables: vec![],
-        source_sessions: source_sessions.to_vec(),
-        trigger: trigger.to_string(),
-        tools: vec![],
-        published_version: 0,
-        permission: Default::default(),
-        schedule: None,
-        id: None,
-        notify: None,
-        requires: vec![],
-    };
-    store.save(&wf)
-}
-
-/// Convenience over the default store.
-pub fn create_draft_workflow_with_steps(
-    name: &str,
-    description: &str,
-    trigger: &str,
-    source_sessions: &[String],
-    steps: &[String],
-) -> anyhow::Result<()> {
-    let store = crate::store::workflow_yaml::WorkflowYamlStore::default_store()?;
-    create_draft_workflow_with_steps_in(&store, name, description, trigger, source_sessions, steps)
-}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn create_draft_workflow_with_steps_persists_steps() {
-        let tmp = tempfile::tempdir().unwrap();
-        let store =
-            crate::store::workflow_yaml::WorkflowYamlStore::new(tmp.path().join("workflows"))
-                .unwrap();
-        create_draft_workflow_with_steps_in(
-            &store,
-            "deploy-api",
-            "Captured from session s1",
-            "when deploying the api",
-            &["s1".into()],
-            &["cargo build".into(), "fly deploy --app <STR>".into()],
-        )
-        .unwrap();
-        let wf = store.get("deploy-api").unwrap();
-        assert_eq!(wf.steps.len(), 2);
-        assert_eq!(wf.steps[0].order, 1);
-        assert_eq!(wf.steps[0].command.as_deref(), Some("cargo build"));
-        assert_eq!(wf.steps[1].command, None); // contains a placeholder → description only
-    }
 
     #[test]
     fn create_draft_workflow_persists_draft() {


### PR DESCRIPTION
## Summary

- `mur out` Accept now runs LLM extraction (fallback: logic-only) on session events and writes a `category: Workflow` skill to `~/.mur/skills/<name>/skill.yaml` with `provenance: Llm`
- Replaces the old accept flow that wrote `~/.mur/workflows/<name>.yaml` (legacy Workflow format)
- Sequential steps are converted to a linear DAG chain via `depends_on`; variables map directly (same type)
- Removes dead helpers `create_draft_workflow_with_steps[_in]` — their only caller was the old accept branch

## Implementation

New `accept_proposal_as_skill()` in `session.rs`:
1. Load events via `session::read_events()`
2. LLM extract (`extract_workflow_llm`) → fallback to `extract_workflow` if no LLM config or LLM fails
3. Convert to `SkillManifest { category: Workflow, provenance: Llm, … }`
4. `write_to_dir(global_skill_dir(mur_home, name), &manifest)`

Output: `✓ Skill saved as \`<name>\` — edit: ~/.mur/skills/<name>/skill.yaml · run: mur run <name>`

## Test plan

- [x] `cargo check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo nextest run -p mur-core -p mur-common` — 3850 passed; 4 pre-existing flaky rollup tests unrelated to P5a

🤖 Generated with [Claude Code](https://claude.com/claude-code)