### PR TITLE
fix(hub): route GUI-spawned runtimes through cc-proxy for OAuth tokens

### DIFF
--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -73,6 +73,49 @@ pub struct Config {
 
     #[serde(default)]
     pub harvest: HarvestCfg,
+
+    // --- OAuth bridge (cc-proxy) routing for subscription tokens ---
+    #[serde(default)]
+    pub cc_proxy: CcProxyConfig,
+}
+
+/// Routing for Anthropic subscription-OAuth (`sk-ant-oat*`) tokens through a
+/// local bridge — cc-proxy — that swaps `x-api-key` for the Bearer +
+/// claude-code betas disguise the upstream requires.
+///
+/// The Hub injects `ANTHROPIC_BASE_URL` pointing at [`url`](Self::url) when it
+/// spawns an agent runtime, but only when [`enabled`](Self::enabled) is set and
+/// the bridge is actually listening; otherwise it leaves the runtime on the
+/// direct `api.anthropic.com` path (where an oat token would 401). A runtime
+/// launched with `ANTHROPIC_BASE_URL` already in its environment is never
+/// overridden.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CcProxyConfig {
+    /// Bridge base URL. Defaults to cc-proxy's default bind.
+    #[serde(default = "default_cc_proxy_url")]
+    pub url: String,
+
+    /// Master switch. When false the Hub never routes runtimes through the
+    /// bridge, regardless of reachability.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+fn default_cc_proxy_url() -> String {
+    "http://127.0.0.1:8088".to_string()
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for CcProxyConfig {
+    fn default() -> Self {
+        Self {
+            url: default_cc_proxy_url(),
+            enabled: true,
+        }
+    }
 }
 
 /// Configuration for the mobile relay (P4).
@@ -1916,5 +1959,34 @@ mod ambient_capture_cfg_tests {
             serde_yaml::from_str("session:\n  capture: off\n  retention_days: 3\n").unwrap();
         assert_eq!(cfg.session.capture, "off");
         assert_eq!(cfg.session.retention_days, 3);
+    }
+}
+
+#[cfg(test)]
+mod cc_proxy_cfg_tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_local_cc_proxy_enabled() {
+        let cfg: Config = serde_yaml_ng::from_str("{}").unwrap();
+        assert_eq!(cfg.cc_proxy.url, "http://127.0.0.1:8088");
+        assert!(cfg.cc_proxy.enabled);
+    }
+
+    #[test]
+    fn url_and_enabled_override_parse() {
+        let cfg: Config =
+            serde_yaml_ng::from_str("cc_proxy:\n  url: http://127.0.0.1:9999\n  enabled: false\n")
+                .unwrap();
+        assert_eq!(cfg.cc_proxy.url, "http://127.0.0.1:9999");
+        assert!(!cfg.cc_proxy.enabled);
+    }
+
+    #[test]
+    fn partial_section_keeps_other_default() {
+        // Only `enabled` given → url stays at the default.
+        let cfg: Config = serde_yaml_ng::from_str("cc_proxy:\n  enabled: false\n").unwrap();
+        assert_eq!(cfg.cc_proxy.url, "http://127.0.0.1:8088");
+        assert!(!cfg.cc_proxy.enabled);
     }
 }

--- a/mur-gui-core/src/autostart/macos.rs
+++ b/mur-gui-core/src/autostart/macos.rs
@@ -17,7 +17,18 @@ fn plist_contents(
     mur_home: &Path,
     stdout_log: &Path,
     stderr_log: &Path,
+    anthropic_base_url: Option<&str>,
 ) -> String {
+    // Optional extra env entry routing the runtime through the cc-proxy bridge
+    // so subscription-OAuth tokens get the Bearer disguise (else an oat token
+    // 401s as `x-api-key`). launchd agents are long-lived, so we inject when the
+    // bridge is configured-on rather than probing reachability at register time.
+    let base_url_entry = match anthropic_base_url {
+        Some(url) => {
+            format!("\n        <key>ANTHROPIC_BASE_URL</key>\n        <string>{url}</string>")
+        }
+        None => String::new(),
+    };
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -39,7 +50,7 @@ fn plist_contents(
     <key>EnvironmentVariables</key>
     <dict>
         <key>MUR_HOME</key>
-        <string>{mur_home}</string>
+        <string>{mur_home}</string>{base_url_entry}
     </dict>
     <key>KeepAlive</key>
     <true/>
@@ -57,6 +68,7 @@ fn plist_contents(
         mur_home = mur_home.display(),
         stdout = stdout_log.display(),
         stderr = stderr_log.display(),
+        base_url_entry = base_url_entry,
     )
 }
 
@@ -91,7 +103,16 @@ pub fn register(
     let stderr_log = log_dir.join("stderr.log");
 
     let _ = display_name; // stored in the plist label, not needed in the body
-    let plist = plist_contents(slug, runtime_binary, mur_home, &stdout_log, &stderr_log);
+    let cfg = mur_common::config::Config::load_or_default(&mur_home.join("config.yaml"));
+    let base_url = cfg.cc_proxy.enabled.then(|| cfg.cc_proxy.url.clone());
+    let plist = plist_contents(
+        slug,
+        runtime_binary,
+        mur_home,
+        &stdout_log,
+        &stderr_log,
+        base_url.as_deref(),
+    );
 
     std::fs::write(&plist_path, &plist).context("write launchd plist")?;
 
@@ -200,7 +221,7 @@ mod tests {
         let stdout_log = log_dir.join("stdout.log");
         let stderr_log = log_dir.join("stderr.log");
 
-        let plist = plist_contents("coach", runtime, mur_home, &stdout_log, &stderr_log);
+        let plist = plist_contents("coach", runtime, mur_home, &stdout_log, &stderr_log, None);
 
         assert!(plist.contains("AssociatedBundleIdentifiers"));
         assert!(plist.contains("run.mur.host"));
@@ -221,10 +242,29 @@ mod tests {
             Path::new("/tmp/custom-mur-home"),
             Path::new("/tmp/custom-mur-home/agents/coach/stdout.log"),
             Path::new("/tmp/custom-mur-home/agents/coach/stderr.log"),
+            None,
         );
         assert!(plist.contains("<key>EnvironmentVariables</key>"));
         assert!(plist.contains("<key>MUR_HOME</key>"));
         assert!(plist.contains("<string>/tmp/custom-mur-home</string>"));
+        // No bridge URL passed → no ANTHROPIC_BASE_URL entry.
+        assert!(!plist.contains("ANTHROPIC_BASE_URL"));
+    }
+
+    #[test]
+    fn plist_injects_bridge_base_url_when_present() {
+        let plist = plist_contents(
+            "coach",
+            Path::new("/usr/local/bin/mur-agent-runtime"),
+            Path::new("/tmp/h"),
+            Path::new("/tmp/h/o.log"),
+            Path::new("/tmp/h/e.log"),
+            Some("http://127.0.0.1:8088"),
+        );
+        assert!(plist.contains("<key>ANTHROPIC_BASE_URL</key>"));
+        assert!(plist.contains("<string>http://127.0.0.1:8088</string>"));
+        // Still well-formed: the new entry lives inside the env dict.
+        assert!(plist.contains("<key>MUR_HOME</key>"));
     }
 
     #[test]

--- a/mur-gui-core/src/lib.rs
+++ b/mur-gui-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod event_bus;
 pub mod expression;
 pub mod image_gen;
 pub mod ipc;
+pub mod oauth_bridge;
 pub mod render;
 pub mod revocations;
 pub mod sidecar;

--- a/mur-gui-core/src/oauth_bridge.rs
+++ b/mur-gui-core/src/oauth_bridge.rs
@@ -1,0 +1,175 @@
+//! Decide whether a Hub-spawned agent runtime should route its Anthropic
+//! traffic through the local OAuth bridge (cc-proxy).
+//!
+//! Subscription tokens (`sk-ant-oat*`) are rejected by api.anthropic.com when
+//! sent as `x-api-key`; they must traverse cc-proxy, which swaps the header for
+//! the Bearer + claude-code betas disguise. The Hub therefore injects
+//! `ANTHROPIC_BASE_URL` pointing at the bridge when it spawns a runtime — but
+//! only when the bridge is configured-on and actually listening, so a stopped
+//! cc-proxy degrades to the direct path instead of failing every request with a
+//! confusing 401.
+
+use mur_common::config::CcProxyConfig;
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+/// How long to wait for the bridge TCP handshake before deciding it's down.
+/// The bridge is loopback, so a live one answers in well under a millisecond;
+/// this only bounds the wait when nothing is listening.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(300);
+
+/// Resolve the `ANTHROPIC_BASE_URL` to inject into a spawned runtime, or `None`
+/// to leave it on its inherited/default (direct) path.
+///
+/// `env_override` is the Hub process's own `ANTHROPIC_BASE_URL` (if any): when
+/// the operator has set one explicitly we respect it and inject nothing — the
+/// runtime inherits it. `probe` reports whether the bridge is reachable, taken
+/// as a parameter so the decision is unit-testable without a live socket.
+pub fn resolve_bridge_url(
+    cfg: &CcProxyConfig,
+    env_override: Option<&str>,
+    probe: impl Fn(&str) -> bool,
+) -> Option<String> {
+    // An explicit ANTHROPIC_BASE_URL on the Hub wins — don't second-guess it.
+    if env_override.is_some_and(|v| !v.trim().is_empty()) {
+        return None;
+    }
+    if !cfg.enabled {
+        return None;
+    }
+    if !probe(&cfg.url) {
+        return None; // bridge down → fall back to the direct path
+    }
+    Some(cfg.url.clone())
+}
+
+/// Real reachability probe: a short-timeout TCP connect to the bridge's
+/// host:port. Any parse or connect failure reads as "not listening".
+pub fn bridge_is_listening(url: &str) -> bool {
+    let Some(authority) = authority(url) else {
+        return false;
+    };
+    match authority.to_socket_addrs() {
+        Ok(addrs) => {
+            let mut addrs = addrs;
+            addrs.any(|addr| TcpStream::connect_timeout(&addr, PROBE_TIMEOUT).is_ok())
+        }
+        Err(_) => false,
+    }
+}
+
+/// Extract `host:port` from a URL, defaulting the port from the scheme when
+/// absent. Returns `None` for anything we can't confidently turn into an
+/// address (no scheme, empty host, unknown scheme without an explicit port).
+fn authority(url: &str) -> Option<String> {
+    let (scheme, rest) = url.split_once("://")?;
+    let host_port = rest.split(['/', '?', '#']).next()?.trim();
+    if host_port.is_empty() {
+        return None;
+    }
+    if host_port.contains(':') {
+        // Already has an explicit port (covers `host:port` and `[::1]:port`).
+        Some(host_port.to_string())
+    } else {
+        let port = match scheme {
+            "https" => 443,
+            "http" => 80,
+            _ => return None,
+        };
+        Some(format!("{host_port}:{port}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(url: &str, enabled: bool) -> CcProxyConfig {
+        CcProxyConfig {
+            url: url.to_string(),
+            enabled,
+        }
+    }
+
+    #[test]
+    fn injects_when_enabled_and_listening() {
+        let c = cfg("http://127.0.0.1:8088", true);
+        assert_eq!(
+            resolve_bridge_url(&c, None, |_| true),
+            Some("http://127.0.0.1:8088".to_string())
+        );
+    }
+
+    #[test]
+    fn none_when_disabled() {
+        let c = cfg("http://127.0.0.1:8088", false);
+        assert_eq!(resolve_bridge_url(&c, None, |_| true), None);
+    }
+
+    #[test]
+    fn none_when_bridge_down() {
+        let c = cfg("http://127.0.0.1:8088", true);
+        assert_eq!(resolve_bridge_url(&c, None, |_| false), None);
+    }
+
+    #[test]
+    fn explicit_env_override_wins() {
+        let c = cfg("http://127.0.0.1:8088", true);
+        // Even with the bridge up, an operator-set base URL is left untouched.
+        assert_eq!(
+            resolve_bridge_url(&c, Some("https://corp-egress.local"), |_| true),
+            None
+        );
+    }
+
+    #[test]
+    fn blank_env_override_is_ignored() {
+        let c = cfg("http://127.0.0.1:8088", true);
+        assert_eq!(
+            resolve_bridge_url(&c, Some("   "), |_| true),
+            Some("http://127.0.0.1:8088".to_string())
+        );
+    }
+
+    #[test]
+    fn authority_keeps_explicit_port() {
+        assert_eq!(
+            authority("http://127.0.0.1:8088").as_deref(),
+            Some("127.0.0.1:8088")
+        );
+    }
+
+    #[test]
+    fn authority_defaults_scheme_port() {
+        assert_eq!(
+            authority("https://api.anthropic.com").as_deref(),
+            Some("api.anthropic.com:443")
+        );
+        assert_eq!(
+            authority("http://localhost").as_deref(),
+            Some("localhost:80")
+        );
+    }
+
+    #[test]
+    fn authority_strips_path() {
+        assert_eq!(
+            authority("http://127.0.0.1:8088/v1/messages").as_deref(),
+            Some("127.0.0.1:8088")
+        );
+    }
+
+    #[test]
+    fn authority_rejects_garbage() {
+        assert_eq!(authority("not-a-url"), None);
+        assert_eq!(authority("ftp://host"), None); // unknown scheme, no explicit port
+        assert_eq!(authority("http://"), None);
+    }
+
+    #[test]
+    fn down_bridge_probe_is_false() {
+        // Port 1 on loopback is not listening in any sane test env.
+        assert!(!bridge_is_listening("http://127.0.0.1:1"));
+        assert!(!bridge_is_listening("garbage"));
+    }
+}

--- a/mur-gui-core/src/sidecar.rs
+++ b/mur-gui-core/src/sidecar.rs
@@ -229,14 +229,28 @@ fn spawn_runtime(slug: &str, mur_home: &Path) -> Result<Child, String> {
         .open(mur_home.join("agents").join(slug).join("stderr.log"))
         .map(Stdio::from)
         .unwrap_or_else(|_| Stdio::null());
-    Command::new(&runtime_bin)
-        .arg("--profile")
+    let mut cmd = Command::new(&runtime_bin);
+    cmd.arg("--profile")
         .arg(slug)
         .env("MUR_HOME", mur_home)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(log)
-        .spawn()
+        .stderr(log);
+    // Route subscription-OAuth (`sk-ant-oat*`) traffic through the local
+    // cc-proxy bridge when it's enabled and listening, otherwise leave the
+    // runtime on the direct api.anthropic.com path. Without this a GUI-spawned
+    // runtime (which doesn't inherit the user's shell env) sends an oat token as
+    // `x-api-key` and gets a 401. See `oauth_bridge`.
+    let cfg = mur_common::config::Config::load_or_default(&mur_home.join("config.yaml"));
+    if let Some(base_url) = crate::oauth_bridge::resolve_bridge_url(
+        &cfg.cc_proxy,
+        std::env::var("ANTHROPIC_BASE_URL").ok().as_deref(),
+        crate::oauth_bridge::bridge_is_listening,
+    ) {
+        info!(slug, %base_url, "routing agent runtime through cc-proxy bridge");
+        cmd.env("ANTHROPIC_BASE_URL", base_url);
+    }
+    cmd.spawn()
         .map_err(|e| format!("could not start the agent runtime: {e}"))
 }
 


### PR DESCRIPTION
## Problem

Chats fail with `401 invalid x-api-key` for users on the Anthropic **subscription** path:

```json
{"error":{"type":"authentication_error","message":"invalid x-api-key"}}
```

**Root cause:** a Hub-spawned agent runtime does **not** inherit the user's shell environment — a macOS GUI app launched from Finder/Dock gets a minimal launchd env (`PATH=/usr/bin:/bin:/usr/sbin:/sbin`, no `ANTHROPIC_BASE_URL`). So the runtime falls back to `https://api.anthropic.com` and sends the subscription-OAuth token (`sk-ant-oat*`) as `x-api-key`. Anthropic only accepts those tokens via the Bearer + claude-code betas disguise that **cc-proxy** applies — but the request never reached cc-proxy.

```
Hub GUI (no ANTHROPIC_BASE_URL)
 └─ spawn_runtime (only MUR_HOME set)
     └─ runtime → https://api.anthropic.com  x-api-key: sk-ant-oat… → 401
```

## Fix

Route runtime traffic through the local cc-proxy bridge when it's enabled and listening.

- **mur-common**: new `cc_proxy` config section `{ url, enabled }`, defaulting to cc-proxy's bind (`http://127.0.0.1:8088`), enabled.
- **mur-gui-core::oauth_bridge** (new): pure `resolve_bridge_url(cfg, env_override, probe)` — returns `None` (leave on direct path) when an explicit `ANTHROPIC_BASE_URL` is already set, when disabled, or when the bridge isn't listening (**fallback**); otherwise the configured URL. Plus a 300ms TCP reachability probe.
- **sidecar `spawn_runtime`**: inject the resolved `ANTHROPIC_BASE_URL` into the child env — fixes the failing default-agent path.
- **autostart launchd plist**: inject `ANTHROPIC_BASE_URL` when the bridge is enabled — the imported-agent path.

A runtime launched with `ANTHROPIC_BASE_URL` already in its environment is never overridden.

## Config

Defaults work out of the box (cc-proxy running → auto-routed). To customize / opt out, in `~/.mur/config.yaml`:

```yaml
cc_proxy:
  url: http://127.0.0.1:8088
  enabled: true
```

## Verification

End-to-end, same oat token:

| path | result |
|------|--------|
| direct `api.anthropic.com` (x-api-key oat) | **401** |
| via cc-proxy :8088 | **200** |

Tests: `mur-common` cc_proxy (3), `oauth_bridge` (10), plist injection (2). Full lib suites green: **614 + 54**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)