### PR TITLE
chore(release): v2.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6269,7 +6269,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.24.0"
+version = "2.24.1"
 dependencies = [
  "libc",
 ]
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.24.0"
+version = "2.24.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6392,7 +6392,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.24.0"
+version = "2.24.1"
 dependencies = [
  "blake3",
  "flate2",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.24.0"
+version = "2.24.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6493,7 +6493,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.24.0"
+version = "2.24.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6520,7 +6520,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.24.0"
+version = "2.24.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6542,7 +6542,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.24.0"
+version = "2.24.1"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6558,7 +6558,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.24.0"
+version = "2.24.1"
 dependencies = [
  "base64 0.22.1",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.24.0"
+version = "2.24.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"


### PR DESCRIPTION
Bumps the workspace version **2.24.0 → 2.24.1** and refreshes `Cargo.lock`.

Cuts the **v2.24.1** release, which includes the Hub cc-proxy OAuth-routing fix (#411): GUI-spawned agent runtimes no longer send subscription-OAuth tokens (`sk-ant-oat*`) straight to `api.anthropic.com` as `x-api-key` (→ `401 invalid x-api-key`); they route through the local cc-proxy bridge when it's enabled and listening.

Once merged, tagging `v2.24.1` triggers the Release workflow (which validates `tag == Cargo.toml version`).

Scope note: `release.yml` ships the `mur` CLI (signed/notarized macOS DMG/PKG + Linux/Windows zips). The Hub `.app` is built separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)