### PR TITLE
feat(server): add /api/v1/mobile/pair-uri for Hub QR pairing

### DIFF
--- a/mur-core/src/server/mobile.rs
+++ b/mur-core/src/server/mobile.rs
@@ -1,0 +1,57 @@
+//! GET /api/v1/mobile/pair-uri — pairing URI for the Hub QR screen.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+
+use super::{AppError, AppState};
+
+#[derive(Deserialize)]
+pub(super) struct PairUriQuery {
+    #[serde(default = "default_agent")]
+    agent: String,
+}
+
+fn default_agent() -> String {
+    crate::mobile::DEFAULT_MOBILE_AGENT.to_string()
+}
+
+#[derive(Serialize)]
+struct PairUriResponse {
+    uri: String,
+    host: String,
+    port: u16,
+    token: String,
+    agent: String,
+}
+
+pub(super) async fn get_pair_uri(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<PairUriQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    let home = state
+        .patterns_dir
+        .parent()
+        .ok_or_else(|| {
+            AppError::Internal(anyhow::anyhow!("cannot derive mur home from patterns_dir"))
+        })?
+        .to_path_buf();
+
+    let token = crate::mobile::ensure_pair_token(&home).map_err(AppError::Internal)?;
+    let port = crate::mobile::mobile_port();
+    let host = crate::mobile::lan_ip()
+        .map(|ip| ip.to_string())
+        .unwrap_or_else(|| "127.0.0.1".to_string());
+    let uri = crate::mobile::pairing_uri(&host, port, &token, &q.agent);
+
+    Ok(Json(PairUriResponse {
+        uri,
+        host,
+        port,
+        token,
+        agent: q.agent,
+    }))
+}

--- a/mur-core/src/server/mod.rs
+++ b/mur-core/src/server/mod.rs
@@ -31,6 +31,7 @@ use crate::store::workflow_yaml::WorkflowYamlStore;
 use crate::store::yaml::YamlStore;
 
 mod context;
+mod mobile;
 mod patterns;
 mod pipelines;
 mod search;
@@ -256,6 +257,7 @@ pub fn build_router_with_auth(state: AppState, auth_token: Option<Arc<str>>) -> 
         // Exchange rates (Frankfurter API proxy)
         .route("/api/v1/rates", get(get_rates))
         .route("/api/v1/rates/{currency}", get(get_rate))
+        .route("/api/v1/mobile/pair-uri", get(mobile::get_pair_uri))
         // WebSocket for real-time events
         .route("/api/v1/ws", get(ws_handler))
         // Agents (Phase 4 read-only routes)


### PR DESCRIPTION
Adds the backend route the Hub's QR pairing screen calls.

`GET /api/v1/mobile/pair-uri?agent=<name>` ensures a one-time pair token, resolves the LAN host/port, and returns `{ uri, host, port, token, agent }`. Without this route the pairing screen had no endpoint to hit — pairing failed.

The `crate::mobile` helpers it builds on (`ensure_pair_token`, `mobile_port`, `lan_ip`, `pairing_uri`, `DEFAULT_MOBILE_AGENT`) were already in tree; this just wires them into the server router (`mod mobile;` + one `.route(...)`).

Scope: 2 files, +59 lines. fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)