### PR TITLE
fix: resolve QA findings (workflow-run safety, skill/doc drift, exit codes, MCP)

### DIFF
--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -333,7 +333,10 @@ pub enum SessionAction {
         #[arg(long)]
         all: bool,
     },
-    /// Start session recording and inject context (shorthand for start + context)
+    /// Mark the current session important (ambient capture mode), or start
+    /// recording + inject context (legacy manual mode). Behavior depends on
+    /// `session.capture`: with ambient capture (default) recording is always on,
+    /// so this flags the session so the harvest gate keeps it.
     In {
         /// Source identifier (e.g. claude-code)
         #[arg(long, default_value = "claude-code")]
@@ -727,8 +730,8 @@ pub enum DeployAction {
         /// Follow log output
         #[arg(short, long)]
         follow: bool,
-        /// Path to a docker-compose file
-        #[arg(short, long)]
+        /// Path to a docker-compose file (long form only; `-f` is --follow)
+        #[arg(long)]
         file: Option<String>,
     },
     /// Build or rebuild service images (docker compose build)

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -140,9 +140,10 @@ pub enum AgentAction {
     Export {
         /// Agent name
         name: String,
-        /// Output path (e.g. agent.muragent or agent.murpkg)
+        /// Output path (e.g. agent.muragent or agent.murpkg).
+        /// Defaults to `<name>.muragent` (or `.murpkg`) in the current directory.
         #[arg(long, short = 'o')]
-        out: String,
+        out: Option<String>,
         /// Format: "muragent" (default — signed v2 portable) or "pkg" (legacy v1)
         #[arg(long, default_value = "muragent")]
         format: String,

--- a/mur-core/src/cli/mod.rs
+++ b/mur-core/src/cli/mod.rs
@@ -241,7 +241,8 @@ pub enum Commands {
         #[arg(long)]
         all: bool,
     },
-    /// Start session recording and inject context (shorthand for session start + context)
+    /// Mark the current session important (ambient capture), or start recording +
+    /// inject context (legacy manual mode) — depends on `session.capture`.
     #[command(hide = true)]
     In {
         /// Source identifier (e.g. claude-code)

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -309,14 +309,18 @@ pub fn do_list() -> Result<Vec<AgentListEntry>> {
     for entry in std::fs::read_dir(&agents_dir)? {
         let entry = entry?;
         if entry.file_type()?.is_dir() {
-            let name = entry.file_name().to_string_lossy().to_string();
             let profile_path = entry.path().join("profile.yaml");
+            // Only real agent directories have a profile.yaml. Without this guard,
+            // non-agent entries under ~/.mur/agents (e.g. the `.git` dir when that
+            // folder is a git repo, or legacy dirs like `Author/` with no
+            // profile.yaml) get listed as phantom agents. Matches the CLI's
+            // `collect_agents` filter so `mur_agent_status` and `mur agent list` agree.
+            if !profile_path.exists() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
             let running = check_running(&entry.path());
-            let transport = if profile_path.exists() {
-                load_transport(&profile_path).unwrap_or_else(|_| "stdio".into())
-            } else {
-                "unknown".into()
-            };
+            let transport = load_transport(&profile_path).unwrap_or_else(|_| "stdio".into());
             entries.push(AgentListEntry {
                 name,
                 running,

--- a/mur-core/src/cmd/fleet_sync.rs
+++ b/mur-core/src/cmd/fleet_sync.rs
@@ -512,7 +512,12 @@ pub async fn fleet_sync_cmd(direction: DeviceSyncDirection, force_local: bool) -
     let server_url = crate::auth::server_url();
     let tokens =
         crate::auth::load_tokens().context("not signed in — run `mur auth login` first")?;
-    let plan = crate::auth::fetch_effective_plan(&server_url, &tokens.access_token).await?;
+    let plan = crate::auth::fetch_effective_plan(&server_url, &tokens.access_token)
+        .await
+        .context(
+            "could not verify your plan for fleet sync — your login may have expired; \
+             run `mur auth login` again (fleet sync is a Pro feature)",
+        )?;
     if !crate::auth::plan_allows_fleet(&plan) {
         bail!("fleet sync requires a Pro plan (current: {plan}). Upgrade at https://app.mur.run");
     }

--- a/mur-core/src/cmd/hook.rs
+++ b/mur-core/src/cmd/hook.rs
@@ -305,7 +305,7 @@ pub(crate) async fn cmd_hook_session_start(tool: &str) -> Result<()> {
         && !pending.is_empty()
     {
         println!(
-            "📥 {} workflow proposal(s) pending — run `mur out` to review.",
+            "📥 {} workflow proposal(s) pending — run `mur session out` to review.",
             pending.len()
         );
     }

--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -381,7 +381,7 @@ pub(crate) async fn cmd_out(action: Option<&str>, force: bool) -> anyhow::Result
             );
         }
         eprintln!(
-            "Run `mur out` in a terminal to review, or `mur out --action analyze` for LLM analysis."
+            "Run `mur session out` in a terminal to review, or `mur session out --action analyze` for LLM analysis."
         );
         return Ok(());
     }
@@ -626,6 +626,14 @@ fn session_worth_analyzing(
 /// Execute a specific post-session action (called via `mur out --action <name>`)
 async fn cmd_out_execute(action: &str, force: bool) -> anyhow::Result<()> {
     let exe = std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("mur"));
+
+    // Ensure the active session is stopped first — `mur session out` (no action)
+    // stops it before the menu, and analyze/export operate on the most recent
+    // *stopped* session, so a direct `--action` call must stop it too (idempotent:
+    // a no-op when the prior no-action call already stopped it).
+    if let Ok(Some(id)) = crate::session::stop() {
+        eprintln!("■ Stopped session {}", &id[..8.min(id.len())]);
+    }
 
     match action {
         "analyze" => {

--- a/mur-core/src/cmd/skill_cmd.rs
+++ b/mur-core/src/cmd/skill_cmd.rs
@@ -92,7 +92,13 @@ pub fn cmd_list() -> Result<()> {
     }
     for name in &names {
         let level = local::get_trust_level(&home, name).unwrap_or(TrustLevel::Sandboxed);
-        println!("{name:30} [{level:?}]");
+        // Stay consistent with show/info/audit, which require a loadable manifest:
+        // flag directories that `list` would otherwise present as normal skills.
+        if local::load_installed(&home, name).is_ok() {
+            println!("{name:30} [{level:?}]");
+        } else {
+            println!("{name:30} [{level:?}]  ⚠ invalid: no readable manifest (run `mur skill remove {name}`)");
+        }
     }
     Ok(())
 }

--- a/mur-core/src/cmd/skill_cmd.rs
+++ b/mur-core/src/cmd/skill_cmd.rs
@@ -97,7 +97,9 @@ pub fn cmd_list() -> Result<()> {
         if local::load_installed(&home, name).is_ok() {
             println!("{name:30} [{level:?}]");
         } else {
-            println!("{name:30} [{level:?}]  ⚠ invalid: no readable manifest (run `mur skill remove {name}`)");
+            println!(
+                "{name:30} [{level:?}]  ⚠ invalid: no readable manifest (run `mur skill remove {name}`)"
+            );
         }
     }
     Ok(())

--- a/mur-core/src/cmd/skill_suggest.rs
+++ b/mur-core/src/cmd/skill_suggest.rs
@@ -23,7 +23,7 @@ pub fn cmd_suggest(home: &Path, opts: SuggestOptions) -> Result<()> {
 
     if candidates.is_empty() {
         println!(
-            "No pending workflow proposals. (Proposals appear after sessions pass the harvest gate — see `mur out`.)"
+            "No pending workflow proposals. (Proposals appear after sessions pass the harvest gate — see `mur session out`.)"
         );
         return Ok(());
     }
@@ -49,7 +49,7 @@ pub fn cmd_suggest(home: &Path, opts: SuggestOptions) -> Result<()> {
         }
         println!();
     }
-    println!("Review and accept with `mur out`.");
+    println!("Review and accept with `mur session out`.");
     Ok(())
 }
 

--- a/mur-core/src/cmd/verify.rs
+++ b/mur-core/src/cmd/verify.rs
@@ -80,6 +80,10 @@ pub(crate) fn cmd_verify(file: Option<&str>, show_all: bool) -> Result<()> {
             "\n  {} stale claim(s) found. Review and update documentation.",
             summary.invalid
         );
+        // Exit non-zero so `mur verify` is usable as a CI / pre-commit gate.
+        use std::io::Write;
+        let _ = std::io::stdout().flush();
+        std::process::exit(1);
     } else {
         println!("\n  All claims verified. Documentation is up to date.");
     }

--- a/mur-core/src/cmd/workflow.rs
+++ b/mur-core/src/cmd/workflow.rs
@@ -6,6 +6,38 @@ use std::io::{self, Write};
 use crate::evolve;
 use crate::store::workflow_yaml::WorkflowYamlStore;
 
+/// Confirm before executing a workflow resolved by fuzzy match (semantic / keyword
+/// / skill) rather than an exact name. Prevents a typo or near-miss query from
+/// silently launching the wrong — possibly destructive — workflow. Non-interactive
+/// callers must pass `--yes`; otherwise the run is refused (returns false).
+fn confirm_fuzzy_run(query: &str, resolved: &str, via: &str, score: Option<f32>, yes: bool) -> bool {
+    if yes {
+        return true;
+    }
+    let score_str = score
+        .map(|s| format!(", {:.0}% similar", s * 100.0))
+        .unwrap_or_default();
+    eprintln!(
+        "⚠ No workflow named \"{query}\". Closest match (via {via}{score_str}): \"{resolved}\"."
+    );
+    if !std::io::IsTerminal::is_terminal(&io::stdin()) {
+        eprintln!(
+            "Refusing to auto-run a fuzzy-matched workflow non-interactively. \
+             Re-run with the exact name, `--prompt` to inspect, or `--yes` to confirm."
+        );
+        return false;
+    }
+    eprint!("Run \"{resolved}\"? [y/N] ");
+    let _ = io::stderr().flush();
+    let mut line = String::new();
+    let _ = io::stdin().read_line(&mut line);
+    let ok = matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes");
+    if !ok {
+        eprintln!("Aborted.");
+    }
+    ok
+}
+
 /// Run a workflow — output as executable prompt for AI consumption.
 /// Accepts exact name, semantic query, or pipeline expression (w1 | w2 && w3, w4).
 pub(crate) async fn cmd_workflow_run(
@@ -24,7 +56,9 @@ pub(crate) async fn cmd_workflow_run(
             .map_err(|e| anyhow::anyhow!("pipeline parse error: {}", e))?;
         let store = WorkflowYamlStore::default_store()?;
         let executor =
-            crate::executor::pipeline::PipelineExecutor::new(store).with_fail_fast(fail_fast);
+            crate::executor::pipeline::PipelineExecutor::new(store)
+                .with_fail_fast(fail_fast)
+                .with_yes(yes);
         let output = executor.execute(&expr, None).await?;
         if output.exit_code != 0 {
             eprintln!(
@@ -43,7 +77,9 @@ pub(crate) async fn cmd_workflow_run(
             print_workflow_prompt(&w);
         } else {
             let executor =
-                crate::executor::pipeline::PipelineExecutor::new(store).with_fail_fast(fail_fast);
+                crate::executor::pipeline::PipelineExecutor::new(store)
+                .with_fail_fast(fail_fast)
+                .with_yes(yes);
             let expr = mur_common::pipeline::PipelineExpr::Single(w.name.clone());
             let output = executor.execute(&expr, None).await?;
             if output.exit_code != 0 {
@@ -57,6 +93,9 @@ pub(crate) async fn cmd_workflow_run(
     let index_path = crate::paths::mur_root(None).join("index");
 
     let mut best_name: Option<String> = None;
+    // Track HOW we resolved a non-exact match, so we can confirm before executing.
+    let mut match_via = "match";
+    let mut match_score: Option<f32> = None;
 
     if index_path.exists() {
         let cfg = crate::store::config::load_config()?;
@@ -71,6 +110,8 @@ pub(crate) async fn cmd_workflow_run(
                 && r.similarity > 0.6
             {
                 best_name = Some(r.name.clone());
+                match_via = "semantic search";
+                match_score = Some(r.similarity);
             }
         }
     }
@@ -79,14 +120,14 @@ pub(crate) async fn cmd_workflow_run(
     if best_name.is_none() {
         let all = store.list_all()?;
         let q = query.to_lowercase();
-        best_name = all
-            .iter()
-            .find(|w| {
-                let text =
-                    format!("{} {} {}", w.name, w.description, w.tools.join(" ")).to_lowercase();
-                text.contains(&q)
-            })
-            .map(|w| w.name.clone());
+        if let Some(w) = all.iter().find(|w| {
+            let text =
+                format!("{} {} {}", w.name, w.description, w.tools.join(" ")).to_lowercase();
+            text.contains(&q)
+        }) {
+            best_name = Some(w.name.clone());
+            match_via = "keyword match";
+        }
     }
 
     match best_name {
@@ -94,9 +135,12 @@ pub(crate) async fn cmd_workflow_run(
             if prompt {
                 let w = store.get(&name)?;
                 print_workflow_prompt(&w);
+            } else if !confirm_fuzzy_run(query, &name, match_via, match_score, yes) {
+                return Ok(());
             } else {
                 let executor = crate::executor::pipeline::PipelineExecutor::new(store)
-                    .with_fail_fast(fail_fast);
+                    .with_fail_fast(fail_fast)
+                    .with_yes(yes);
                 let expr = mur_common::pipeline::PipelineExpr::Single(name);
                 let output = executor.execute(&expr, None).await?;
                 if output.exit_code != 0 {
@@ -124,6 +168,12 @@ pub(crate) async fn cmd_workflow_run(
                             "# {} — {}",
                             matched.manifest.name, matched.manifest.description
                         );
+                        return Ok(());
+                    }
+                    // Confirm before executing a non-exact (fuzzy) skill match.
+                    if matched.manifest.name != query
+                        && !confirm_fuzzy_run(query, &matched.manifest.name, "skill match", None, yes)
+                    {
                         return Ok(());
                     }
                     // Only execute Workflow-category skills.

--- a/mur-core/src/cmd/workflow.rs
+++ b/mur-core/src/cmd/workflow.rs
@@ -10,7 +10,13 @@ use crate::store::workflow_yaml::WorkflowYamlStore;
 /// / skill) rather than an exact name. Prevents a typo or near-miss query from
 /// silently launching the wrong — possibly destructive — workflow. Non-interactive
 /// callers must pass `--yes`; otherwise the run is refused (returns false).
-fn confirm_fuzzy_run(query: &str, resolved: &str, via: &str, score: Option<f32>, yes: bool) -> bool {
+fn confirm_fuzzy_run(
+    query: &str,
+    resolved: &str,
+    via: &str,
+    score: Option<f32>,
+    yes: bool,
+) -> bool {
     if yes {
         return true;
     }
@@ -55,10 +61,9 @@ pub(crate) async fn cmd_workflow_run(
         let expr = parse_pipeline_expr(query)
             .map_err(|e| anyhow::anyhow!("pipeline parse error: {}", e))?;
         let store = WorkflowYamlStore::default_store()?;
-        let executor =
-            crate::executor::pipeline::PipelineExecutor::new(store)
-                .with_fail_fast(fail_fast)
-                .with_yes(yes);
+        let executor = crate::executor::pipeline::PipelineExecutor::new(store)
+            .with_fail_fast(fail_fast)
+            .with_yes(yes);
         let output = executor.execute(&expr, None).await?;
         if output.exit_code != 0 {
             eprintln!(
@@ -76,8 +81,7 @@ pub(crate) async fn cmd_workflow_run(
         if prompt {
             print_workflow_prompt(&w);
         } else {
-            let executor =
-                crate::executor::pipeline::PipelineExecutor::new(store)
+            let executor = crate::executor::pipeline::PipelineExecutor::new(store)
                 .with_fail_fast(fail_fast)
                 .with_yes(yes);
             let expr = mur_common::pipeline::PipelineExpr::Single(w.name.clone());
@@ -121,8 +125,7 @@ pub(crate) async fn cmd_workflow_run(
         let all = store.list_all()?;
         let q = query.to_lowercase();
         if let Some(w) = all.iter().find(|w| {
-            let text =
-                format!("{} {} {}", w.name, w.description, w.tools.join(" ")).to_lowercase();
+            let text = format!("{} {} {}", w.name, w.description, w.tools.join(" ")).to_lowercase();
             text.contains(&q)
         }) {
             best_name = Some(w.name.clone());
@@ -172,7 +175,13 @@ pub(crate) async fn cmd_workflow_run(
                     }
                     // Confirm before executing a non-exact (fuzzy) skill match.
                     if matched.manifest.name != query
-                        && !confirm_fuzzy_run(query, &matched.manifest.name, "skill match", None, yes)
+                        && !confirm_fuzzy_run(
+                            query,
+                            &matched.manifest.name,
+                            "skill match",
+                            None,
+                            yes,
+                        )
                     {
                         return Ok(());
                     }

--- a/mur-core/src/dashboard.rs
+++ b/mur-core/src/dashboard.rs
@@ -49,7 +49,9 @@ pub fn render_dashboard() -> Result<()> {
 
     if patterns.is_empty() {
         println!("{BOLD}MUR Dashboard{RESET}");
-        println!("{DIM}No patterns found. Run `mur new` to create one.{RESET}");
+        println!(
+            "{DIM}No patterns yet. They are harvested from your sessions — record one with `mur session in`, then review proposals with `mur session out`.{RESET}"
+        );
         return Ok(());
     }
 

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -169,7 +169,15 @@ pub async fn run(cli: Cli) -> Result<()> {
                 cmd::reindex::cmd_reindex().await?;
             }
         }
-        Commands::Update { check } => cmd::update::cmd_update(check)?,
+        Commands::Update { check } => {
+            // `update::run` uses `reqwest::blocking`, whose internal runtime panics
+            // when dropped inside this async context. Run it on a blocking thread
+            // (no entered runtime there). Manual installs (InstallSource::Other)
+            // reach the network path, so this must not panic for them.
+            tokio::task::spawn_blocking(move || cmd::update::cmd_update(check))
+                .await
+                .context("update task panicked")??
+        }
         // Deprecated: use `mur workflow suggest`
         Commands::Suggest {
             create,
@@ -1194,6 +1202,12 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             AgentPermAction::ToolList { name } => cmd::agent::cmd_perm_list_tools(&name)?,
         },
         AgentAction::Export { name, out, format } => {
+            // Default the output path to `<name>.muragent` (or `.murpkg`) when -o/--out
+            // is omitted, so the intuitive `mur agent export <name>` succeeds.
+            let out = out.unwrap_or_else(|| {
+                let ext = if format == "pkg" { "murpkg" } else { "muragent" };
+                format!("{name}.{ext}")
+            });
             cmd::agent::cmd_export(&name, &out, &format)?;
         }
         AgentAction::Install { path, model } => {

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1205,7 +1205,11 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             // Default the output path to `<name>.muragent` (or `.murpkg`) when -o/--out
             // is omitted, so the intuitive `mur agent export <name>` succeeds.
             let out = out.unwrap_or_else(|| {
-                let ext = if format == "pkg" { "murpkg" } else { "muragent" };
+                let ext = if format == "pkg" {
+                    "murpkg"
+                } else {
+                    "muragent"
+                };
                 format!("{name}.{ext}")
             });
             cmd::agent::cmd_export(&name, &out, &format)?;

--- a/mur-core/src/executor/pipeline.rs
+++ b/mur-core/src/executor/pipeline.rs
@@ -26,6 +26,8 @@ pub struct PipelineExecutor {
     store: WorkflowYamlStore,
     /// When true, cancel remaining parallel branches on first failure.
     fail_fast: bool,
+    /// When true, auto-approve steps marked `needs_approval` (the `--yes` flag).
+    yes: bool,
     /// Cancellation token for cooperative cancellation in fail-fast mode.
     cancel: CancellationToken,
 }
@@ -35,8 +37,15 @@ impl PipelineExecutor {
         Self {
             store,
             fail_fast: false,
+            yes: false,
             cancel: CancellationToken::new(),
         }
+    }
+
+    /// Auto-approve `needs_approval` steps (the `--yes` flag).
+    pub fn with_yes(mut self, yes: bool) -> Self {
+        self.yes = yes;
+        self
     }
 
     pub fn with_fail_fast(mut self, fail_fast: bool) -> Self {
@@ -157,6 +166,32 @@ impl PipelineExecutor {
             if let Some(ref cmd_template) = step.command {
                 // Shell step: substitute {{input}} and execute
                 let cmd = inject_input(cmd_template, input_text);
+
+                // Honor `needs_approval`: gate side-effecting steps unless `--yes`.
+                // (Previously the pipeline executor ran every step unconditionally,
+                // ignoring needs_approval — so `--yes` was a no-op on this path.)
+                if step.needs_approval && !self.yes {
+                    if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+                        eprint!(
+                            "  Step {} needs approval: {} (`{}`) — run it? [y/N] ",
+                            step.order, description, cmd
+                        );
+                        let _ = std::io::Write::flush(&mut std::io::stderr());
+                        let mut line = String::new();
+                        let _ = std::io::stdin().read_line(&mut line);
+                        if !matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+                            eprintln!("  Step {} skipped (not approved)", step.order);
+                            continue;
+                        }
+                    } else {
+                        eprintln!(
+                            "  Step {}: needs_approval — skipped (use `--yes` to auto-approve)",
+                            step.order
+                        );
+                        continue;
+                    }
+                }
+
                 eprintln!("  Step {}: {} (`{}`)", step.order, description, cmd);
 
                 let cmd_fut = tokio::process::Command::new("sh")

--- a/mur-core/src/inject/index.rs
+++ b/mur-core/src/inject/index.rs
@@ -153,7 +153,10 @@ mod tests {
             out.contains("Tokio async runtime patterns"),
             "must include descriptions"
         );
-        assert!(out.contains("mur skill show"), "must have skill-show footer");
+        assert!(
+            out.contains("mur skill show"),
+            "must have skill-show footer"
+        );
     }
 
     #[test]

--- a/mur-core/src/inject/index.rs
+++ b/mur-core/src/inject/index.rs
@@ -27,7 +27,7 @@ pub fn format_l0(index: &CapabilityIndex, budget_chars: usize) -> String {
         Some(proj) => format!("## mur learning index (project: {proj})\n"),
         None => "## mur learning index\n".to_owned(),
     };
-    let footer = "\nRun `mur recall <name>` to load full content of any item above.\n";
+    let footer = "\nRun `mur skill show <name>` to load the full content of any item above.\n";
 
     let overhead = header.len() + footer.len();
     let entry_budget = budget_chars.saturating_sub(overhead);
@@ -153,7 +153,7 @@ mod tests {
             out.contains("Tokio async runtime patterns"),
             "must include descriptions"
         );
-        assert!(out.contains("mur recall"), "must have recall footer");
+        assert!(out.contains("mur skill show"), "must have skill-show footer");
     }
 
     #[test]

--- a/mur-core/src/skills/mur_agent_manage.yaml
+++ b/mur-core/src/skills/mur_agent_manage.yaml
@@ -9,11 +9,14 @@ content:
   procedure:
     steps:
       - description: To list agents, run `mur agent list` or use the MCP tool `mur_agent_status` (no args = list all)
-      - description: To create a new agent, run `mur agent create <name>` and follow the wizard
-      - description: To run an agent as a managed launchd/systemd service, run `mur agent install-service <name>`
+      - description: To create a new agent, run `mur agent create <name>`. Interactive prompts appear only when stdin is a TTY; otherwise the defaults (provider ollama) are used, so pass `--provider`/`--model`/`--display-name` to choose them, or `--no-interactive` to accept defaults explicitly.
+      - description: To run an agent as a managed launchd/systemd service, run `mur agent install-service <name>` (add `--dry-run` to preview the unit file without writing it)
       - description: To stop a running agent, run `mur agent stop <name>` (SIGTERM, then SIGKILL after timeout)
       - description: To check agent health, use `mur_agent_status(name="<name>")` or run `mur agent status <name>`
-      - description: To export an agent as a portable .muragent, run `mur agent export <name>`
+      - description: To send a message to a running agent (A2A), run `mur agent send <name> <message>`; to print its agent card, run `mur agent card <name>`
+      - description: To export an agent as a portable .muragent, run `mur agent export <name> --out <name>.muragent` (the `--out`/`-o` path is required)
+      - description: To inspect an exported package (manifest + signature), run `mur agent inspect <path>.muragent`
+      - description: To remove an agent, run `mur agent remove <name>` (add `--purge` to also delete its data directory)
 tags: [mur, agent, builtin]
 triggers:
   - type: command

--- a/mur-core/src/skills/mur_out.yaml
+++ b/mur-core/src/skills/mur_out.yaml
@@ -6,12 +6,12 @@ category: workflow
 content:
   abstract: |
     Review pending workflow proposals harvested from recent sessions.
-    Accept turns a proposal into a draft workflow runnable via `mur run`.
+    Accept turns a proposal into a draft workflow runnable via `mur workflow run`.
   procedure:
     steps:
-      - description: Run `mur out` and show the output to the user.
+      - description: Run `mur session out` and show the output to the user (`mur out` is a deprecated alias).
       - description: If proposals are pending, summarize them and ask the user which to accept or skip.
-      - description: For LLM pattern extraction of the most recent session, run `mur out --action analyze`.
+      - description: For LLM pattern extraction of the most recent session, run `mur session out --action analyze`.
 tags: [mur, recording, extraction, builtin]
 triggers:
   - type: command

--- a/mur-core/src/skills/mur_project_search.yaml
+++ b/mur-core/src/skills/mur_project_search.yaml
@@ -26,6 +26,13 @@ content:
     - You need every occurrence (rename, find all callers, dead-code removal).
       Semantic search returns ranked top-k, not all matches — it will miss some.
 
+    ## Scope (important)
+    - By default `mur project search` searches across ALL indexed projects, not
+      just the current directory — top results may come from unrelated repos.
+      To restrict to one project, pass `--project <name>` (and `--limit <n>` to
+      widen/narrow the ranked results). The mur_project_search MCP tool takes the
+      same optional `project` argument.
+
     ## Hard rules (correctness)
     - Code you created or edited this session and have NOT committed/indexed is
       not in the index yet — use grep for it. Semantic results always lag

--- a/mur-core/src/skills/mur_run.yaml
+++ b/mur-core/src/skills/mur_run.yaml
@@ -14,9 +14,10 @@ content:
         required: true
         description: Workflow name or search query
     steps:
-      - description: Run `mur run <name-or-query>` to find and output the workflow
+      - description: "To READ a workflow (find + output it without running anything), use `mur workflow run <name-or-query> --prompt`. WARNING: omitting `--prompt` EXECUTES the workflow's command steps immediately."
       - description: Read the Variables section, use defaults or ask user for required values
-      - description: Follow Steps in order using listed Tools
+      - description: Follow Steps in order using listed Tools — or, to let mur execute them, run `mur workflow run <name> --yes` (auto-approves `needs_approval` steps; `--yes` only works on `mur workflow run`, not the deprecated `mur run` alias)
+      - description: If the query is not an exact workflow name it resolves by semantic/keyword match — confirm the resolved workflow name before executing, especially for deploy/destructive workflows
       - description: Adapt steps as needed — workflows are guides, not rigid scripts
       - description: If recording was active, suggest `mur session stop --analyze`
 tags: [mur, workflow, builtin]

--- a/mur-core/src/update/source.rs
+++ b/mur-core/src/update/source.rs
@@ -1,5 +1,6 @@
 //! Detect how `mur` was installed.
 
+use std::path::Path;
 use std::process::Command;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -23,6 +24,15 @@ impl InstallSource {
 /// Detect by querying system package managers. Lives behind a small layer so
 /// tests can inject fake command outputs via [`detect_from_outputs`].
 pub fn detect() -> InstallSource {
+    // The install method of the *running* binary is determined by where that
+    // binary actually lives — not by whether `brew`/`cargo` happen to also have
+    // a `mur` installed. (A manually-installed binary can shadow a brew one on
+    // PATH; `brew list mur` would still succeed and falsely advise `brew upgrade`,
+    // which could downgrade to the older Cellar version.)
+    let exe = std::env::current_exe()
+        .ok()
+        .and_then(|p| std::fs::canonicalize(&p).ok().or(Some(p)));
+
     let brew = Command::new("brew").args(["list", "mur"]).output().ok();
     let cargo = Command::new("cargo")
         .args(["install", "--list"])
@@ -30,6 +40,7 @@ pub fn detect() -> InstallSource {
         .ok();
 
     detect_from_outputs(
+        exe.as_deref(),
         brew.as_ref()
             .map(|o| (o.status.success(), o.stdout.as_slice())),
         cargo
@@ -39,9 +50,26 @@ pub fn detect() -> InstallSource {
 }
 
 pub fn detect_from_outputs(
+    exe: Option<&Path>,
     brew: Option<(bool, &[u8])>,
     cargo: Option<(bool, &[u8])>,
 ) -> InstallSource {
+    // Primary signal: the canonical path of the running executable.
+    if let Some(p) = exe {
+        let s = p.to_string_lossy();
+        // Homebrew (incl. Linuxbrew) always resolves binaries under a Cellar.
+        if s.contains("/Cellar/") {
+            return InstallSource::Homebrew;
+        }
+        // `cargo install` places binaries under <CARGO_HOME>/bin.
+        if s.contains("/.cargo/bin/") {
+            return InstallSource::Cargo;
+        }
+        // A real binary in any other location is a manual / self-managed install.
+        return InstallSource::Other;
+    }
+
+    // Fallback only when the running exe path is unavailable: package-manager queries.
     if let Some((true, _)) = brew {
         return InstallSource::Homebrew;
     }
@@ -61,28 +89,59 @@ mod tests {
     use super::*;
 
     #[test]
-    fn brew_success_wins() {
-        let s = detect_from_outputs(Some((true, b"mur")), Some((true, b"mur v2.16.0:\n")));
+    fn exe_in_cellar_is_homebrew() {
+        let s = detect_from_outputs(
+            Some(Path::new("/opt/homebrew/Cellar/mur/2.24.0/bin/mur")),
+            Some((true, b"mur")),
+            None,
+        );
         assert_eq!(s, InstallSource::Homebrew);
     }
 
     #[test]
-    fn cargo_when_brew_absent_or_failed() {
-        let s = detect_from_outputs(Some((false, b"")), Some((true, b"mur v2.16.0:\n")));
-        assert_eq!(s, InstallSource::Cargo);
-        let s = detect_from_outputs(None, Some((true, b"mur v2.16.0:\n")));
+    fn exe_in_cargo_bin_is_cargo() {
+        let s = detect_from_outputs(
+            Some(Path::new("/Users/x/.cargo/bin/mur")),
+            None,
+            Some((true, b"mur v2.16.0:\n")),
+        );
         assert_eq!(s, InstallSource::Cargo);
     }
 
     #[test]
-    fn cargo_list_must_mention_mur() {
-        let s = detect_from_outputs(None, Some((true, b"ripgrep v14.0.0:\n")));
+    fn manual_binary_shadowing_brew_is_other_not_homebrew() {
+        // Regression: a manually-installed binary at /opt/homebrew/bin/mur (a real
+        // file, NOT a Cellar symlink) must NOT be reported as Homebrew just because
+        // `brew list mur` succeeds — else `mur update --check` advises a downgrade.
+        let s = detect_from_outputs(
+            Some(Path::new("/opt/homebrew/bin/mur")),
+            Some((true, b"mur")),
+            None,
+        );
         assert_eq!(s, InstallSource::Other);
     }
 
     #[test]
-    fn other_when_both_missing() {
-        let s = detect_from_outputs(None, None);
+    fn fallback_brew_success_wins_when_exe_unknown() {
+        let s = detect_from_outputs(None, Some((true, b"mur")), Some((true, b"mur v2.16.0:\n")));
+        assert_eq!(s, InstallSource::Homebrew);
+    }
+
+    #[test]
+    fn fallback_cargo_when_brew_absent_and_exe_unknown() {
+        let s = detect_from_outputs(None, Some((false, b"")), Some((true, b"mur v2.16.0:\n")));
+        assert_eq!(s, InstallSource::Cargo);
+    }
+
+    #[test]
+    fn fallback_cargo_list_must_mention_mur() {
+        let s = detect_from_outputs(None, None, Some((true, b"ripgrep v14.0.0:\n")));
+        assert_eq!(s, InstallSource::Other);
+    }
+
+    #[test]
+    fn other_when_all_missing() {
+        let s = detect_from_outputs(None, None, None);
         assert_eq!(s, InstallSource::Other);
     }
 

--- a/mur-core/tests/session_start_integration.rs
+++ b/mur-core/tests/session_start_integration.rs
@@ -20,7 +20,7 @@ fn l0_output_fits_within_600_token_budget() {
     assert!(out.len() <= 2600, "L0 output too long: {} chars", out.len());
     assert!(out.contains("## mur learning index"));
     assert!(out.contains("project: myproject"));
-    assert!(out.contains("mur recall"));
+    assert!(out.contains("mur skill show"));
 }
 
 #[test]

--- a/mur-mcp-server/src/main.rs
+++ b/mur-mcp-server/src/main.rs
@@ -20,8 +20,7 @@ async fn main() {
     while let Some(request) = jsonrpc::read_request() {
         // JSON-RPC notifications (no `id`, e.g. `notifications/initialized`) must
         // NOT receive a response. Compute this before `request` is moved into handle.
-        let is_notification =
-            request.id.is_none() && request.method.starts_with("notifications/");
+        let is_notification = request.id.is_none() && request.method.starts_with("notifications/");
         let response = server.handle(request).await;
         if !is_notification {
             jsonrpc::write_response(&response);

--- a/mur-mcp-server/src/main.rs
+++ b/mur-mcp-server/src/main.rs
@@ -18,8 +18,14 @@ async fn main() {
     let mut server = server::McpServer::new();
 
     while let Some(request) = jsonrpc::read_request() {
+        // JSON-RPC notifications (no `id`, e.g. `notifications/initialized`) must
+        // NOT receive a response. Compute this before `request` is moved into handle.
+        let is_notification =
+            request.id.is_none() && request.method.starts_with("notifications/");
         let response = server.handle(request).await;
-        jsonrpc::write_response(&response);
+        if !is_notification {
+            jsonrpc::write_response(&response);
+        }
     }
 
     tracing::info!("mur-mcp-server shutting down");

--- a/mur-mcp-server/tests/integration.rs
+++ b/mur-mcp-server/tests/integration.rs
@@ -43,8 +43,7 @@ fn test_initialize_and_list_tools() {
         &mut stdin,
         r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
     );
-    // Consume the notification acknowledgment
-    let _ = read_response(&mut stdout);
+    // Notifications receive no response per JSON-RPC, so do not read one.
 
     // List tools
     send_request(
@@ -112,7 +111,7 @@ fn test_tools_list_response_under_token_budget() {
         &mut stdin,
         r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
     );
-    let _ = read_response(&mut stdout);
+    // Notifications receive no response per JSON-RPC, so do not read one.
     send_request(
         &mut stdin,
         r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
@@ -153,7 +152,7 @@ fn lists_project_search_tool() {
         &mut stdin,
         r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
     );
-    let _ = read_response(&mut stdout);
+    // Notifications receive no response per JSON-RPC, so do not read one.
 
     send_request(
         &mut stdin,
@@ -199,7 +198,7 @@ fn calls_mur_compress_tool() {
         &mut stdin,
         r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
     );
-    let _ = read_response(&mut stdout);
+    // Notifications receive no response per JSON-RPC, so do not read one.
 
     // A long search-style payload that should compress and offload.
     let mut lines = Vec::new();


### PR DESCRIPTION
## Summary

Fixes the issues surfaced by a full QA pass over the mur CLI, skills, and MCP server. Grouped by severity; each was reproduced before fixing and re-verified against a fresh build.

### 🔴 Critical
- **`mur workflow run` no longer auto-executes a fuzzy match.** When the query isn't an exact workflow name it resolves via semantic/keyword search; previously it ran the top hit immediately (a typo like `deploy-frontendx` routed to a 132-step production deploy). Now it **refuses non-interactively** and prompts in a TTY unless `--yes` is passed.

### 🟠 High
- Pipeline executor honors `needs_approval` and `--yes` on the YAML path (was ignored).
- `mur verify` exits non-zero on stale claims (CI-gateable).
- `mur update --check`: install-method detection now keys off the running binary's path, not `brew list` — fixes a false "Installed via Homebrew → brew upgrade" (a downgrade) for manual installs, and a panic on the self-update path (`reqwest::blocking` inside the async runtime → now `spawn_blocking`).
- Auto-injected hook/index text pointed at non-existent commands: `mur recall` → `mur skill show`, `mur out` → `mur session out`.
- Skill docs corrected (`agent export --out`, real `create` flags, `--prompt` vs execute).

### 🟡 Medium / low
- `agent export` `--out` now optional (`<name>.muragent`); `deploy logs` `-f`/`--file` collision; `skill list` flags manifest-less dirs; MCP `agent_status` no longer lists `.git`/non-agent dirs; MCP server doesn't reply to notifications; `session out --action skip` stops the session; fleet-sync 401 message; dashboard empty-state command.

### Deliberately not changed
- `mur sync` exit-0 on cloud 401 (expected when unauthenticated; runs in hooks).
- MCP `mur_compress` no-op on small/generic text (by design — only offloads when worthwhile).

## Testing
- `cargo test -p mur-core`: 1394 passed. The 6 failures (`conversations::summarize::rollup`, `paths::tests`) are **pre-existing** — verified identical on `main` with these changes stashed; both are env/date-dependent and touch none of this code.
- Behavior smoke-tested on a fresh build: fuzzy-run refusal, `verify` exit 1, `update --check` (no Homebrew claim, no panic), `agent export` default path, `deploy logs -f`, MCP notification + phantom-agent fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
