### PR TITLE
chore(release): bump workspace version to 2.24.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6269,7 +6269,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.24.2"
+version = "2.24.3"
 dependencies = [
  "libc",
 ]
@@ -6345,7 +6345,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.24.2"
+version = "2.24.3"
 dependencies = [
  "age",
  "anyhow",
@@ -6393,7 +6393,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.24.2"
+version = "2.24.3"
 dependencies = [
  "blake3",
  "flate2",
@@ -6409,7 +6409,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.24.2"
+version = "2.24.3"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6494,7 +6494,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.24.2"
+version = "2.24.3"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6521,7 +6521,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.24.2"
+version = "2.24.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6543,7 +6543,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.24.2"
+version = "2.24.3"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6559,7 +6559,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.24.2"
+version = "2.24.3"
 dependencies = [
  "base64 0.22.1",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.24.2"
+version = "2.24.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"


### PR DESCRIPTION
Release bump for **v2.24.3**, covering everything merged since `v2.24.2`:

- #418 — auto-wire `mur-compress` into MCP + agent-runtime (on by default, reversible)
- #417 — project-search defaults to current project + warm embedding model

Bumps `[workspace.package] version` 2.24.2 → 2.24.3 (+ `Cargo.lock`). Tag `v2.24.3` will be pushed on the merge commit, triggering `release.yml`.