### PR TITLE
fix(agent-runtime): make the agentic loop usable for coding (budgets, doom-loop, graceful exit, output-cap)

### DIFF
--- a/mur-agent-runtime/src/llm/anthropic.rs
+++ b/mur-agent-runtime/src/llm/anthropic.rs
@@ -18,7 +18,14 @@ use mur_common::llm::anthropic_base_url;
 use serde_json::json;
 
 const DEFAULT_VERSION: &str = "2023-06-01";
-const DEFAULT_MAX_TOKENS: u32 = 1024;
+/// Output-token ceiling when a request leaves `max_tokens` unset. This is a
+/// CEILING, not a target — the model only generates what it needs, so cost
+/// rises only when output is genuinely large. Coding agents routinely write
+/// whole source files via large `bash` heredocs; the previous 1024 cap
+/// truncated those responses mid-tool_use, leaving the tool_use `input` JSON
+/// incomplete and the call unparseable. 16384 gives normal file writes room to
+/// complete without truncation.
+const DEFAULT_MAX_TOKENS: u32 = 16384;
 
 /// Total time allowed for a single LLM request (including server think time).
 const LLM_REQUEST_TIMEOUT_SECS: u64 = 60;

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -299,6 +299,8 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     let pending_approvals: Arc<Mutex<HashMap<String, oneshot::Sender<crate::hitl::HitlDecision>>>> =
         Arc::new(Mutex::new(HashMap::new()));
     let hitl_timeout_secs = profile.inner.hitl.timeout_secs;
+    let max_iterations = profile.inner.hitl.max_iterations;
+    let max_tokens = profile.inner.hitl.max_tokens;
     let (runner, llm_for_companion, mcp_pool) = crate::supervisor_runner::build_provider_runner(
         force_echo,
         &agent_home,
@@ -311,6 +313,8 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         Some(pending_approvals.clone()),
         Some(sock_notif_tx.clone()),
         hitl_timeout_secs,
+        max_iterations,
+        max_tokens,
     )
     .await?;
     let dispatcher = Arc::new(build_dispatcher(

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -117,6 +117,8 @@ pub fn build_runner(
     hitl_timeout_secs: u32,
     tools: Vec<std::sync::Arc<dyn crate::tools::ToolExecutor>>,
     tools_policy: Vec<mur_common::agent::ToolRule>,
+    max_iterations: Option<u32>,
+    max_tokens: Option<u64>,
 ) -> Arc<TaskRunner> {
     let mut runner = TaskRunner::with_llm(client)
         .with_system_prompt(base_system_prompt)
@@ -125,6 +127,12 @@ pub fn build_runner(
         .with_hitl_timeout_secs(hitl_timeout_secs)
         .with_tools(tools)
         .with_tools_policy(tools_policy);
+    if let Some(n) = max_iterations {
+        runner = runner.with_max_iterations(n);
+    }
+    if let Some(n) = max_tokens {
+        runner = runner.with_max_token_budget(n);
+    }
     if let (Some(chain), Some(ctx), Some(cancel)) = (hook_chain, hook_ctx, hook_cancel) {
         runner = runner.with_hook_chain(chain, ctx, cancel);
     }
@@ -152,6 +160,8 @@ pub async fn build_provider_runner(
     pending_approvals: Option<HitlApprovals>,
     notifier: Option<tokio::sync::mpsc::Sender<serde_json::Value>>,
     hitl_timeout_secs: u32,
+    max_iterations: Option<u32>,
+    max_tokens: Option<u64>,
 ) -> anyhow::Result<(
     Arc<TaskRunner>,
     Option<Arc<dyn LlmClient>>,
@@ -229,6 +239,8 @@ pub async fn build_provider_runner(
             hitl_timeout_secs,
             tools.clone(),
             tools_policy.clone(),
+            max_iterations,
+            max_tokens,
         );
         (r, Some(client), Some(pool.clone()))
     };

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -924,6 +924,34 @@ impl TaskRunner {
             self.cumulative_input_tokens
                 .fetch_add(resp.input_tokens, std::sync::atomic::Ordering::Relaxed);
 
+            // Truncation guard: a turn that hit the output-token ceiling AND
+            // carries tool_calls was cut off MID-tool_use — the tool_use
+            // `input` JSON is incomplete, so executing it (or appending it to
+            // history and re-looping) just replays a malformed call and trips
+            // the doom-loop guard. Instead of running the broken call, append a
+            // user-role guidance message and continue so the model can recover
+            // with a shorter, well-formed turn. This counts toward the
+            // iteration budget; the iteration cap + doom-loop guard remain the
+            // backstops against a model that truncates forever.
+            if resp.stop_reason == StopReason::MaxTokens && !resp.tool_calls.is_empty() {
+                if !resp.text.is_empty() {
+                    history.push(RichMessage::Text {
+                        role: "assistant".into(),
+                        content: resp.text.clone(),
+                    });
+                }
+                history.push(RichMessage::Text {
+                    role: "user".into(),
+                    content: "Your previous response reached the output token limit \
+                              and was truncated mid tool-call. Produce a shorter \
+                              response, or write large files in smaller pieces \
+                              (append in multiple steps)."
+                        .into(),
+                });
+                iteration += 1;
+                continue;
+            }
+
             history.push(RichMessage::ToolUse {
                 text: if resp.text.is_empty() {
                     None
@@ -1395,6 +1423,108 @@ mod tests {
             tool_calls: vec![],
             stop_reason: crate::llm::StopReason::EndTurn,
         }
+    }
+
+    /// A response truncated mid-tool_use: `stop_reason == MaxTokens` while a
+    /// tool_call is present. The `input` is the empty `{}` that
+    /// `parse_response_body` yields when the assistant turn was cut off before
+    /// the tool_use JSON finished — i.e. the malformed call the loop must NOT
+    /// execute blindly.
+    fn truncated_tool_call_response(call_id: &str) -> crate::llm::LlmResponse {
+        crate::llm::LlmResponse {
+            text: String::new(),
+            input_tokens: 5,
+            output_tokens: 5,
+            model: "test".into(),
+            tool_calls: vec![crate::llm::ToolCallResult {
+                call_id: call_id.into(),
+                tool_name: "bash".into(),
+                // Empty input — the hallmark of a truncated tool_use.
+                input: serde_json::json!({}),
+            }],
+            stop_reason: crate::llm::StopReason::MaxTokens,
+        }
+    }
+
+    /// Counting `bash` tool: records how many times it executes so a test can
+    /// assert a (truncated) tool call was NOT run.
+    struct CountingBashTool {
+        calls: Arc<AtomicU64>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::tools::ToolExecutor for CountingBashTool {
+        fn name(&self) -> &str {
+            "bash"
+        }
+        fn def(&self) -> crate::llm::ToolDef {
+            crate::llm::ToolDef {
+                name: "bash".into(),
+                description: "test bash tool".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+        async fn execute(
+            &self,
+            _input: serde_json::Value,
+        ) -> Result<String, crate::tools::ToolError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok("ran".into())
+        }
+    }
+
+    /// Fix B — truncation is self-correcting, not a silent loop. When a turn
+    /// stops with `MaxTokens` AND carries tool_calls (cut off mid-tool_use),
+    /// the loop must NOT execute the malformed call. Instead it appends a
+    /// truncation-guidance user message and continues, letting the model
+    /// recover with a shorter, well-formed turn.
+    #[tokio::test]
+    async fn truncated_tool_use_injects_guidance_and_recovers() {
+        use crate::llm::stub::SequenceLlm;
+        // Turn 0: truncated mid-tool_use (MaxTokens + a tool_call).
+        // Turn 1: a clean end-turn — the recovery the model produces after the
+        // guidance nudge.
+        let responses: Vec<crate::llm::LlmResponse> = vec![
+            truncated_tool_call_response("trunc-0"),
+            end_turn_response("RECOVERED: produced a shorter response."),
+        ];
+        let calls = Arc::new(AtomicU64::new(0));
+        let runner = Arc::new(
+            TaskRunner::with_llm(Arc::new(SequenceLlm::new(responses)))
+                .with_tools(vec![Arc::new(CountingBashTool {
+                    calls: calls.clone(),
+                })])
+                .with_tools_policy(vec![mur_common::agent::ToolRule {
+                    pattern: "bash".into(),
+                    policy: mur_common::agent::ToolPolicy::Allow,
+                }])
+                .with_pending_approvals(empty_pending_approvals())
+                .with_notifier(tokio::sync::mpsc::channel(16).0)
+                .with_hitl_timeout_secs(1)
+                .with_max_iterations(50),
+        );
+        let outcome = runner.run_sync(loop_spec("truncate")).await;
+        let TaskOutcome::Completed(task) = outcome else {
+            panic!("expected Completed (recovered turn), got {outcome:?}");
+        };
+        // The malformed (truncated) tool call must NOT have been executed.
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            0,
+            "truncated tool_use must not be executed"
+        );
+        // The following well-formed turn proceeds and is the natural terminus —
+        // no budget tripped, so usage is None (natural end_turn).
+        let reply_text = task.messages.last().map(text_of).unwrap_or_default();
+        assert!(
+            reply_text.contains("RECOVERED"),
+            "expected the recovery turn's reply, got: {reply_text}"
+        );
+        assert!(
+            task.usage.is_none(),
+            "natural end_turn after recovery must not populate a budget stop_reason; usage={:?}",
+            task.usage
+        );
     }
 
     #[tokio::test]

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -881,8 +881,13 @@ impl TaskRunner {
             .cumulative_input_tokens
             .load(std::sync::atomic::Ordering::Relaxed);
         // Rolling window of recent tool-call fingerprints for doom-loop
-        // detection: (tool_name, deterministic hash of canonical args).
-        let mut fingerprints: VecDeque<(String, u64)> = VecDeque::with_capacity(LOOP_WINDOW);
+        // detection: (tool_name, hash(canonical args), hash(result content)).
+        // Keying on the RESULT too means a command repeated with identical
+        // output (genuinely stuck) trips the guard, while the same command
+        // returning changing output (e.g. `cargo build` between edits) does
+        // NOT — that's progress, not a loop. Requires fingerprinting AFTER
+        // the tool runs, since the result isn't known until then.
+        let mut fingerprints: VecDeque<(String, u64, u64)> = VecDeque::with_capacity(LOOP_WINDOW);
 
         let mut iteration: u32 = 0;
         while iteration < self.max_iterations {
@@ -938,18 +943,38 @@ impl TaskRunner {
                 ));
             }
 
-            // Doom-loop detection (safety layer): fingerprint every tool call
-            // and abort if any single fingerprint repeats `LOOP_REPEAT_THRESHOLD`
-            // times within the rolling window — catches blind identical retries
-            // in ~3 iterations regardless of the iteration cap.
+            // Execute tools and collect results.
+            let mut results = Vec::new();
             for call in &resp.tool_calls {
-                let fp = (call.tool_name.clone(), fingerprint_args(&call.input));
+                match self.handle_tool_call(task_id, call).await {
+                    Ok(entry) => results.push(entry),
+                    Err(e) => return Err(e),
+                }
+            }
+
+            // Doom-loop detection (safety layer): fingerprint every tool call
+            // by (tool, args, RESULT) and abort if any single fingerprint
+            // repeats `LOOP_REPEAT_THRESHOLD` times within the rolling window.
+            // Keying on the result is the crux: "same command + same output,
+            // repeated" = stuck (abort); "same command, changing output" =
+            // making progress (don't abort). Fingerprinting happens here,
+            // AFTER execution, because the result is needed.
+            for (call, entry) in resp.tool_calls.iter().zip(results.iter()) {
+                let fp = (
+                    call.tool_name.clone(),
+                    fingerprint_args(&call.input),
+                    fingerprint_str(&entry.content),
+                );
                 fingerprints.push_back(fp.clone());
                 while fingerprints.len() > LOOP_WINDOW {
                     fingerprints.pop_front();
                 }
                 let repeats = fingerprints.iter().filter(|f| **f == fp).count();
                 if repeats >= LOOP_REPEAT_THRESHOLD {
+                    // Append the results gathered this turn before exiting so
+                    // the dangling tool_use is closed; graceful_exit also
+                    // sanitizes, but keeping history consistent is cheap.
+                    history.push(RichMessage::ToolResults { results });
                     let msg = self
                         .graceful_exit(client, &history, LoopStop::LoopDetected)
                         .await;
@@ -963,14 +988,6 @@ impl TaskRunner {
                 }
             }
 
-            // Execute tools and collect results
-            let mut results = Vec::new();
-            for call in &resp.tool_calls {
-                match self.handle_tool_call(task_id, call).await {
-                    Ok(entry) => results.push(entry),
-                    Err(e) => return Err(e),
-                }
-            }
             history.push(RichMessage::ToolResults { results });
             iteration += 1;
         }
@@ -1005,7 +1022,13 @@ impl TaskRunner {
              remaining steps so work can resume later.",
             reason.as_str()
         );
-        let mut messages = history.to_vec();
+        // When a budget aborts MID-iteration (e.g. the doom-loop guard fires
+        // after the model emitted a tool_use but before its tool_result was
+        // appended), `history` ends with a tool_use that has no matching
+        // tool_result. The Anthropic API rejects such a request with HTTP 400.
+        // Close every dangling tool_use with a synthetic tool_result so the
+        // summary request is well-formed.
+        let mut messages = sanitize_dangling_tool_uses(history, reason);
         messages.push(RichMessage::Text {
             role: "user".into(),
             content: nudge,
@@ -1042,11 +1065,59 @@ impl TaskRunner {
 /// (sorted keys via `serde_json::Value`'s BTreeMap-backed object) before hashing
 /// so logically-identical args always fingerprint the same.
 fn fingerprint_args(args: &serde_json::Value) -> u64 {
+    fingerprint_str(&args.to_string())
+}
+
+/// Deterministic hash of an arbitrary string (used for canonical tool-result
+/// content in the doom-loop fingerprint). `DefaultHasher` is fixed-seed, so the
+/// same input always yields the same value within a build — sufficient for
+/// equality-within-window comparison, no randomness.
+fn fingerprint_str(s: &str) -> u64 {
     use std::hash::{Hash, Hasher};
-    let canonical = args.to_string();
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    canonical.hash(&mut hasher);
+    s.hash(&mut hasher);
     hasher.finish()
+}
+
+/// Return a copy of `history` in which every `ToolUse` call is guaranteed to be
+/// followed by a matching `tool_result`. For any `tool_use` id not covered by
+/// the message immediately after its `ToolUse` turn, a synthetic
+/// `ToolResults` entry is inserted right after that turn with content
+/// `"[stopped: <reason>]"`. This keeps the resulting `LlmRequest` well-formed so
+/// the Anthropic API does not reject it with "tool_use ids without tool_result".
+fn sanitize_dangling_tool_uses(
+    history: &[crate::llm::RichMessage],
+    reason: LoopStop,
+) -> Vec<crate::llm::RichMessage> {
+    use crate::llm::{RichMessage, ToolResultEntry};
+
+    let mut out: Vec<RichMessage> = Vec::with_capacity(history.len() + 1);
+    for (i, msg) in history.iter().enumerate() {
+        out.push(msg.clone());
+        if let RichMessage::ToolUse { calls, .. } = msg {
+            // Ids the very next message already answers (the API requires the
+            // tool_result block to come immediately after the tool_use turn).
+            let covered: HashSet<&str> = match history.get(i + 1) {
+                Some(RichMessage::ToolResults { results }) => {
+                    results.iter().map(|r| r.call_id.as_str()).collect()
+                }
+                _ => HashSet::new(),
+            };
+            let missing: Vec<ToolResultEntry> = calls
+                .iter()
+                .filter(|c| !covered.contains(c.call_id.as_str()))
+                .map(|c| ToolResultEntry {
+                    call_id: c.call_id.clone(),
+                    content: format!("[stopped: {}]", reason.as_str()),
+                    is_error: true,
+                })
+                .collect();
+            if !missing.is_empty() {
+                out.push(RichMessage::ToolResults { results: missing });
+            }
+        }
+    }
+    out
 }
 
 /// Best-effort recovery of the most recent assistant-authored text from the
@@ -1456,8 +1527,11 @@ mod tests {
     #[tokio::test]
     async fn doom_loop_detected_yields_completed_with_summary() {
         use crate::llm::stub::SequenceLlm;
-        // Identical args every turn. The 3rd identical fingerprint trips the
-        // guard on iteration index 2; the 4th call is the graceful summary.
+        // Identical args every turn. With no tool registered, every call
+        // resolves to the same "unknown tool" result, so the full
+        // (tool, args, RESULT) fingerprint is identical each turn. The 3rd
+        // identical fingerprint trips the guard on iteration index 2; the 4th
+        // call is the graceful summary.
         let responses: Vec<crate::llm::LlmResponse> = vec![
             tool_call_response("same-0", "echo identical"),
             tool_call_response("same-1", "echo identical"),
@@ -1576,5 +1650,250 @@ mod tests {
             "expected the loop capped near 3 iterations, got {n} generate() calls"
         );
         assert!(n >= 3, "expected at least 3 iterations, got {n}");
+    }
+
+    /// A tool whose output CHANGES on every call even when the args are
+    /// identical — models e.g. `cargo build` returning new diagnostics after
+    /// each intervening edit. Used to prove the doom-loop guard keys on the
+    /// (tool, args, result) triple, not (tool, args) alone.
+    struct VaryingResultTool {
+        calls: Arc<AtomicU64>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::tools::ToolExecutor for VaryingResultTool {
+        fn name(&self) -> &str {
+            "build"
+        }
+        fn def(&self) -> crate::llm::ToolDef {
+            crate::llm::ToolDef {
+                name: "build".into(),
+                description: "test build tool".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+        async fn execute(
+            &self,
+            _input: serde_json::Value,
+        ) -> Result<String, crate::tools::ToolError> {
+            let n = self.calls.fetch_add(1, Ordering::Relaxed);
+            // Distinct content each call -> distinct result fingerprint.
+            Ok(format!("build output #{n}"))
+        }
+    }
+
+    /// A tool whose output is CONSTANT on every call (same args -> same
+    /// result), modelling a genuinely stuck retry. Trips the doom-loop guard.
+    struct ConstantResultTool;
+
+    #[async_trait::async_trait]
+    impl crate::tools::ToolExecutor for ConstantResultTool {
+        fn name(&self) -> &str {
+            "build"
+        }
+        fn def(&self) -> crate::llm::ToolDef {
+            crate::llm::ToolDef {
+                name: "build".into(),
+                description: "test build tool".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+        async fn execute(
+            &self,
+            _input: serde_json::Value,
+        ) -> Result<String, crate::tools::ToolError> {
+            Ok("identical build output".into())
+        }
+    }
+
+    fn build_tool_call_response(call_id: &str) -> crate::llm::LlmResponse {
+        crate::llm::LlmResponse {
+            text: String::new(),
+            input_tokens: 5,
+            output_tokens: 5,
+            model: "test".into(),
+            tool_calls: vec![crate::llm::ToolCallResult {
+                call_id: call_id.into(),
+                tool_name: "build".into(),
+                // IDENTICAL args every turn: only the result varies.
+                input: serde_json::json!({}),
+            }],
+            stop_reason: crate::llm::StopReason::ToolUse,
+        }
+    }
+
+    /// Fix #1a — progress is NOT a loop: the SAME tool call (identical args)
+    /// every turn, but whose execution returns a DIFFERENT result each time,
+    /// must NOT trip the doom-loop guard. Under the old (tool, args)-only
+    /// fingerprint this aborts with "loop_detected"; under the (tool, args,
+    /// result) fingerprint it runs to the iteration cap instead.
+    #[tokio::test]
+    async fn varying_tool_results_are_not_a_doom_loop() {
+        use crate::llm::stub::SequenceLlm;
+        // Always emits the same call; the loop only ever stops on a budget.
+        let responses: Vec<crate::llm::LlmResponse> = vec![
+            build_tool_call_response("c-0"),
+            build_tool_call_response("c-1"),
+            build_tool_call_response("c-2"),
+            build_tool_call_response("c-3"),
+            build_tool_call_response("c-4"),
+            build_tool_call_response("c-5"),
+            end_turn_response("ITER SUMMARY: capped by iteration budget."),
+        ];
+        let calls = Arc::new(AtomicU64::new(0));
+        let runner = Arc::new(
+            TaskRunner::with_llm(Arc::new(SequenceLlm::new(responses)))
+                .with_tools(vec![Arc::new(VaryingResultTool {
+                    calls: calls.clone(),
+                })])
+                .with_tools_policy(vec![mur_common::agent::ToolRule {
+                    pattern: "build".into(),
+                    policy: mur_common::agent::ToolPolicy::Allow,
+                }])
+                .with_pending_approvals(empty_pending_approvals())
+                .with_notifier(tokio::sync::mpsc::channel(16).0)
+                .with_hitl_timeout_secs(1)
+                // Small cap so the test terminates fast; doom-loop must NOT
+                // fire before the cap is reached.
+                .with_max_iterations(5),
+        );
+        let outcome = runner.run_sync(loop_spec("progress")).await;
+        let TaskOutcome::Completed(task) = outcome else {
+            panic!("expected Completed, got {outcome:?}");
+        };
+        let usage = task.usage.expect("budget exit must populate usage");
+        assert_ne!(
+            usage["stop_reason"], "loop_detected",
+            "changing results must NOT be a doom loop; usage={usage}"
+        );
+        assert_eq!(
+            usage["stop_reason"], "max_iterations",
+            "expected the iteration cap to be the terminus; usage={usage}"
+        );
+    }
+
+    /// Fix #1b — genuine stuck IS a loop: the SAME tool call AND identical
+    /// result each turn still aborts with stop_reason "loop_detected" within
+    /// ~3 iterations, well below the iteration cap.
+    #[tokio::test]
+    async fn identical_tool_results_still_trip_doom_loop() {
+        use crate::llm::stub::SequenceLlm;
+        let responses: Vec<crate::llm::LlmResponse> = vec![
+            build_tool_call_response("s-0"),
+            build_tool_call_response("s-1"),
+            build_tool_call_response("s-2"),
+            end_turn_response("LOOP SUMMARY: stuck; identical output."),
+        ];
+        let runner = Arc::new(
+            TaskRunner::with_llm(Arc::new(SequenceLlm::new(responses)))
+                .with_tools(vec![Arc::new(ConstantResultTool)])
+                .with_tools_policy(vec![mur_common::agent::ToolRule {
+                    pattern: "build".into(),
+                    policy: mur_common::agent::ToolPolicy::Allow,
+                }])
+                .with_pending_approvals(empty_pending_approvals())
+                .with_notifier(tokio::sync::mpsc::channel(16).0)
+                .with_hitl_timeout_secs(1)
+                .with_max_iterations(50),
+        );
+        let outcome = runner.run_sync(loop_spec("stuck")).await;
+        let TaskOutcome::Completed(task) = outcome else {
+            panic!("expected Completed (doom-loop graceful exit), got {outcome:?}");
+        };
+        let usage = task.usage.expect("doom-loop exit must populate usage");
+        assert_eq!(usage["stop_reason"], "loop_detected", "usage={usage}");
+        let iters = usage["iterations"]
+            .as_u64()
+            .expect("iterations is a number");
+        assert!(iters < 5, "expected early abort, got {iters} iterations");
+    }
+
+    /// Fix #2 — graceful_exit must sanitize a dangling tool_use before the
+    /// final summary turn. We build a `history` ending in a `ToolUse` whose
+    /// call has NO following `ToolResults` (mid-iteration abort), then run
+    /// `graceful_exit`. A recording LLM captures the request it receives; we
+    /// assert every tool_use call_id in that request has a matching
+    /// tool_result, so the Anthropic API would not 400 on it.
+    #[tokio::test]
+    async fn graceful_exit_sanitizes_dangling_tool_use() {
+        use crate::llm::{RichMessage, ToolCallResult};
+
+        /// Captures the messages of the request passed to it and replies with
+        /// a benign end-turn summary.
+        struct RecordingLlm {
+            seen: Arc<Mutex<Vec<RichMessage>>>,
+        }
+        #[async_trait::async_trait]
+        impl crate::llm::LlmClient for RecordingLlm {
+            async fn generate(
+                &self,
+                req: crate::llm::LlmRequest,
+            ) -> Result<crate::llm::LlmResponse, crate::llm::LlmError> {
+                *self.seen.lock().unwrap() = req.messages.clone();
+                Ok(end_turn_response("SUMMARY: done."))
+            }
+            fn model_name(&self) -> &str {
+                "recording"
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let client: Arc<dyn crate::llm::LlmClient> = Arc::new(RecordingLlm { seen: seen.clone() });
+        let runner = TaskRunner::with_llm(client.clone());
+
+        // History ends with a tool_use that has no following tool_result.
+        let history = vec![
+            RichMessage::Text {
+                role: "system".into(),
+                content: "sys".into(),
+            },
+            RichMessage::Text {
+                role: "user".into(),
+                content: "do the thing".into(),
+            },
+            RichMessage::ToolUse {
+                text: Some("calling build".into()),
+                calls: vec![ToolCallResult {
+                    call_id: "dangling-1".into(),
+                    tool_name: "build".into(),
+                    input: serde_json::json!({}),
+                }],
+            },
+        ];
+
+        let msg = runner
+            .graceful_exit(client.as_ref(), &history, LoopStop::LoopDetected)
+            .await;
+        // Summary turn succeeded (not the fallback path).
+        assert_eq!(text_of(&msg), "SUMMARY: done.");
+
+        // Inspect what the LLM actually received: collect every tool_use id and
+        // every tool_result id, then assert no tool_use id is unmatched.
+        let messages = seen.lock().unwrap().clone();
+        let mut use_ids: Vec<String> = Vec::new();
+        let mut result_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for m in &messages {
+            match m {
+                RichMessage::ToolUse { calls, .. } => {
+                    for c in calls {
+                        use_ids.push(c.call_id.clone());
+                    }
+                }
+                RichMessage::ToolResults { results } => {
+                    for r in results {
+                        result_ids.insert(r.call_id.clone());
+                    }
+                }
+                RichMessage::Text { .. } => {}
+            }
+        }
+        assert!(!use_ids.is_empty(), "expected at least one tool_use");
+        for id in &use_ids {
+            assert!(
+                result_ids.contains(id),
+                "tool_use id {id} has no matching tool_result; request would 400. \
+                 result_ids={result_ids:?}"
+            );
+        }
     }
 }

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -78,8 +78,58 @@ pub struct TaskRunner {
         Arc<tokio::sync::Mutex<HashMap<String, tokio::sync::mpsc::Sender<serde_json::Value>>>>,
     hitl_timeout_secs: u32,
     max_iterations: u32,
+    /// Per-task ceiling on cumulative input tokens for the agentic loop. The
+    /// loop snapshots the (per-runner) counter at entry and stops gracefully
+    /// once `current - start >= max_token_budget`.
+    max_token_budget: u64,
     tools: Vec<Arc<dyn crate::tools::ToolExecutor>>,
     tools_policy: Vec<mur_common::agent::ToolRule>,
+}
+
+/// Default agentic-loop iteration cap when `HitlConfig.max_iterations` is unset.
+/// A layered set of budgets (token + loop-detection) is the real safety net, so
+/// this can be generous without risking runaway cost.
+const DEFAULT_MAX_ITERATIONS: u32 = 25;
+
+/// Default cumulative-input-token budget per task when `HitlConfig.max_tokens`
+/// is unset. ≈ a few dollars on Sonnet; override per profile to bound spend.
+const DEFAULT_MAX_TOKEN_BUDGET: u64 = 750_000;
+
+/// Rolling-window size for doom-loop detection: the last N tool-call
+/// fingerprints are retained.
+const LOOP_WINDOW: usize = 8;
+
+/// Number of identical tool-call fingerprints within the rolling window that
+/// trips the doom-loop guard.
+const LOOP_REPEAT_THRESHOLD: usize = 3;
+
+/// Why the agentic loop stopped short of a natural end-turn. Carried out of the
+/// loop into the task's `usage` JSON so callers can tell a clean completion from
+/// a budget-truncated one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoopStop {
+    MaxIterations,
+    TokenBudget,
+    LoopDetected,
+}
+
+impl LoopStop {
+    fn as_str(self) -> &'static str {
+        match self {
+            LoopStop::MaxIterations => "max_iterations",
+            LoopStop::TokenBudget => "token_budget",
+            LoopStop::LoopDetected => "loop_detected",
+        }
+    }
+}
+
+/// An early, graceful termination of the agentic loop: which budget tripped and
+/// how many iterations had completed. `None` (no `LoopExit`) means the model
+/// ended the turn naturally.
+#[derive(Debug, Clone, Copy)]
+struct LoopExit {
+    reason: LoopStop,
+    iterations: u32,
 }
 
 impl TaskRunner {
@@ -122,7 +172,8 @@ impl TaskRunner {
             notifier: None,
             client_notifiers: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             hitl_timeout_secs: 300,
-            max_iterations: 10,
+            max_iterations: DEFAULT_MAX_ITERATIONS,
+            max_token_budget: DEFAULT_MAX_TOKEN_BUDGET,
             tools: vec![],
             tools_policy: vec![],
         }
@@ -205,6 +256,12 @@ impl TaskRunner {
 
     pub fn with_max_iterations(mut self, n: u32) -> Self {
         self.max_iterations = n;
+        self
+    }
+
+    /// Set the per-task cumulative input-token budget for the agentic loop.
+    pub fn with_max_token_budget(mut self, n: u64) -> Self {
+        self.max_token_budget = n;
         self
     }
 
@@ -349,12 +406,12 @@ impl TaskRunner {
 
         let generation = async {
             match &self.backend {
-                RunnerBackend::StubEcho => Ok(echo_response(&spec.input)),
+                RunnerBackend::StubEcho => Ok((echo_response(&spec.input), None)),
                 RunnerBackend::StubSlow => {
                     tokio::time::sleep(std::time::Duration::from_secs(60)).await;
-                    Ok(echo_response(&spec.input))
+                    Ok((echo_response(&spec.input), None))
                 }
-                RunnerBackend::Misconfigured(message) => Ok(text_response(message)),
+                RunnerBackend::Misconfigured(message) => Ok((text_response(message), None)),
                 RunnerBackend::Llm(client) => {
                     if self.pending_approvals.is_some() {
                         let system = self
@@ -364,7 +421,9 @@ impl TaskRunner {
                         self.run_agentic_loop(&id, client.as_ref(), system, &spec.input, sink)
                             .await
                     } else {
-                        self.run_llm(&id, client.as_ref(), &spec.input, sink).await
+                        self.run_llm(&id, client.as_ref(), &spec.input, sink)
+                            .await
+                            .map(|m| (m, None))
                     }
                 }
             }
@@ -374,7 +433,7 @@ impl TaskRunner {
         // future is dropped (Rust async cancellation aborts the in-flight LLM
         // call) and we return a Cancelled task so message/send terminates the
         // stream cleanly.
-        let result: Option<Result<Message, TaskError>> = tokio::select! {
+        let result: Option<Result<(Message, Option<LoopExit>), TaskError>> = tokio::select! {
             r = generation => Some(r),
             _ = &mut rx_cancel => None,
         };
@@ -403,8 +462,18 @@ impl TaskRunner {
             Some(r) => r,
         };
         match result {
-            Ok(reply) => {
+            Ok((reply, stop)) => {
                 self.set_state(&id, TaskState::Completed);
+                // When a budget forced an early, graceful exit, surface the
+                // reason + iteration count in `usage` so callers can tell a
+                // truncated completion from a natural one (the task still
+                // reports Completed — work is preserved, not failed).
+                let usage = stop.map(|exit| {
+                    serde_json::json!({
+                        "stop_reason": exit.reason.as_str(),
+                        "iterations": exit.iterations,
+                    })
+                });
                 TaskOutcome::Completed(Task {
                     id,
                     state: TaskState::Completed,
@@ -412,7 +481,7 @@ impl TaskRunner {
                     created_at: now.clone(),
                     completed_at: Some(now),
                     error: None,
-                    usage: None,
+                    usage,
                 })
             }
             Err(err) => {
@@ -780,6 +849,9 @@ impl TaskRunner {
         })
     }
 
+    /// Run the agentic loop. Returns the final agent message plus an optional
+    /// `LoopStop` describing which budget (if any) forced an early, graceful
+    /// exit. `None` means the model ended the turn naturally.
     async fn run_agentic_loop(
         &self,
         task_id: &str,
@@ -787,7 +859,7 @@ impl TaskRunner {
         system_prompt: String,
         input: &Message,
         _sink: Option<tokio::sync::mpsc::Sender<crate::llm::StreamDelta>>,
-    ) -> Result<Message, TaskError> {
+    ) -> Result<(Message, Option<LoopExit>), TaskError> {
         use crate::llm::{LlmRequest, RichMessage, StopReason};
 
         let tool_defs: Vec<_> = self.tools_for_loop().iter().map(|t| t.def()).collect();
@@ -803,7 +875,36 @@ impl TaskRunner {
             },
         ];
 
-        for _iteration in 0..self.max_iterations {
+        // Snapshot the (per-runner, shared-across-tasks) token counter so the
+        // budget measures THIS task's spend, not the runner's lifetime total.
+        let start_tokens = self
+            .cumulative_input_tokens
+            .load(std::sync::atomic::Ordering::Relaxed);
+        // Rolling window of recent tool-call fingerprints for doom-loop
+        // detection: (tool_name, deterministic hash of canonical args).
+        let mut fingerprints: VecDeque<(String, u64)> = VecDeque::with_capacity(LOOP_WINDOW);
+
+        let mut iteration: u32 = 0;
+        while iteration < self.max_iterations {
+            // Token budget (primary control): stop before spending more once
+            // this task's cumulative input tokens cross the ceiling.
+            let spent = self
+                .cumulative_input_tokens
+                .load(std::sync::atomic::Ordering::Relaxed)
+                .saturating_sub(start_tokens);
+            if spent >= self.max_token_budget {
+                let msg = self
+                    .graceful_exit(client, &history, LoopStop::TokenBudget)
+                    .await;
+                return Ok((
+                    msg,
+                    Some(LoopExit {
+                        reason: LoopStop::TokenBudget,
+                        iterations: iteration,
+                    }),
+                ));
+            }
+
             let req = LlmRequest {
                 messages: history.clone(),
                 temperature: None,
@@ -828,10 +929,38 @@ impl TaskRunner {
             });
 
             if resp.tool_calls.is_empty() || resp.stop_reason == StopReason::EndTurn {
-                return Ok(Message {
-                    role: "agent".into(),
-                    parts: vec![mur_common::a2a::MessagePart::Text { text: resp.text }],
-                });
+                return Ok((
+                    Message {
+                        role: "agent".into(),
+                        parts: vec![mur_common::a2a::MessagePart::Text { text: resp.text }],
+                    },
+                    None,
+                ));
+            }
+
+            // Doom-loop detection (safety layer): fingerprint every tool call
+            // and abort if any single fingerprint repeats `LOOP_REPEAT_THRESHOLD`
+            // times within the rolling window — catches blind identical retries
+            // in ~3 iterations regardless of the iteration cap.
+            for call in &resp.tool_calls {
+                let fp = (call.tool_name.clone(), fingerprint_args(&call.input));
+                fingerprints.push_back(fp.clone());
+                while fingerprints.len() > LOOP_WINDOW {
+                    fingerprints.pop_front();
+                }
+                let repeats = fingerprints.iter().filter(|f| **f == fp).count();
+                if repeats >= LOOP_REPEAT_THRESHOLD {
+                    let msg = self
+                        .graceful_exit(client, &history, LoopStop::LoopDetected)
+                        .await;
+                    return Ok((
+                        msg,
+                        Some(LoopExit {
+                            reason: LoopStop::LoopDetected,
+                            iterations: iteration,
+                        }),
+                    ));
+                }
             }
 
             // Execute tools and collect results
@@ -843,17 +972,94 @@ impl TaskRunner {
                 }
             }
             history.push(RichMessage::ToolResults { results });
+            iteration += 1;
         }
 
-        Err(task_error(
-            "max_iterations",
-            format!(
-                "agentic loop exceeded {} iteration limit",
-                self.max_iterations
-            ),
-            false,
+        let msg = self
+            .graceful_exit(client, &history, LoopStop::MaxIterations)
+            .await;
+        Ok((
+            msg,
+            Some(LoopExit {
+                reason: LoopStop::MaxIterations,
+                iterations: iteration,
+            }),
         ))
     }
+
+    /// One final, tools-DISABLED LLM turn asking the model to summarize what it
+    /// completed, the current build/test state, and the remaining steps. If that
+    /// call fails, fall back to the last assistant text already in `history` so
+    /// accumulated work is never lost.
+    async fn graceful_exit(
+        &self,
+        client: &dyn crate::llm::LlmClient,
+        history: &[crate::llm::RichMessage],
+        reason: LoopStop,
+    ) -> Message {
+        use crate::llm::{LlmRequest, RichMessage};
+
+        let nudge = format!(
+            "You have hit the {} budget for this task. Stop calling tools. \
+             Summarize what you completed, the current build/test state, and the \
+             remaining steps so work can resume later.",
+            reason.as_str()
+        );
+        let mut messages = history.to_vec();
+        messages.push(RichMessage::Text {
+            role: "user".into(),
+            content: nudge,
+        });
+        let req = LlmRequest {
+            messages,
+            temperature: None,
+            max_tokens: None,
+            tools: vec![], // tools disabled: force a textual summary
+        };
+        match client.generate(req).await {
+            Ok(resp) => {
+                self.cumulative_input_tokens
+                    .fetch_add(resp.input_tokens, std::sync::atomic::Ordering::Relaxed);
+                Message {
+                    role: "agent".into(),
+                    parts: vec![mur_common::a2a::MessagePart::Text { text: resp.text }],
+                }
+            }
+            Err(_) => {
+                // Never lose work: return the last assistant text from history.
+                let text = last_assistant_text(history)
+                    .unwrap_or_else(|| format!("Stopped: {} budget reached.", reason.as_str()));
+                Message {
+                    role: "agent".into(),
+                    parts: vec![mur_common::a2a::MessagePart::Text { text }],
+                }
+            }
+        }
+    }
+}
+
+/// Deterministic hash of a tool call's arguments. Serializes to canonical JSON
+/// (sorted keys via `serde_json::Value`'s BTreeMap-backed object) before hashing
+/// so logically-identical args always fingerprint the same.
+fn fingerprint_args(args: &serde_json::Value) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let canonical = args.to_string();
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    canonical.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Best-effort recovery of the most recent assistant-authored text from the
+/// loop history (the inline reasoning attached to a tool-use turn).
+fn last_assistant_text(history: &[crate::llm::RichMessage]) -> Option<String> {
+    use crate::llm::RichMessage;
+    history.iter().rev().find_map(|m| match m {
+        RichMessage::ToolUse { text: Some(t), .. } if !t.is_empty() => Some(t.clone()),
+        RichMessage::Text { role, content } if role == "agent" || role == "assistant" => {
+            Some(content.clone())
+        }
+        _ => None,
+    })
 }
 
 /// Build a `TaskError` for a failed task outcome.
@@ -1097,6 +1303,18 @@ mod tests {
         }
     }
 
+    /// Like `tool_call_response` but with a caller-specified input-token count,
+    /// for exercising the token budget.
+    fn tool_call_response_tokens(
+        call_id: &str,
+        command: &str,
+        input_tokens: u64,
+    ) -> crate::llm::LlmResponse {
+        let mut r = tool_call_response(call_id, command);
+        r.input_tokens = input_tokens;
+        r
+    }
+
     fn end_turn_response(text: &str) -> crate::llm::LlmResponse {
         crate::llm::LlmResponse {
             text: text.into(),
@@ -1138,12 +1356,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn max_iterations_exceeded_yields_failed() {
+    async fn max_iterations_exceeded_yields_completed_with_summary() {
         use crate::llm::stub::SequenceLlm;
-        // Always returns tool_use — loop never ends naturally
-        let responses: Vec<crate::llm::LlmResponse> = (0..12)
-            .map(|i| tool_call_response(&format!("id-{i}"), "echo loop"))
-            .collect();
+        // Three tool_use turns fill the cap; the fourth call is the graceful,
+        // tools-disabled summary turn. SequenceLlm wraps modulo len, so a
+        // 4-element vector maps loop turns to indices 0,1,2 and the summary
+        // turn to index 3 deterministically.
+        // Distinct commands per turn so the doom-loop guard (identical-call
+        // detection) does NOT fire first — this test must exercise the
+        // iteration cap specifically.
+        let responses: Vec<crate::llm::LlmResponse> = vec![
+            tool_call_response("id-0", "echo step-0"),
+            tool_call_response("id-1", "echo step-1"),
+            tool_call_response("id-2", "echo step-2"),
+            end_turn_response("SUMMARY: completed nothing; build untouched; remaining: all."),
+        ];
         let llm = SequenceLlm::new(responses);
         let (notif_tx, _rx) = tokio::sync::mpsc::channel(16);
         let pa: Arc<
@@ -1169,13 +1396,185 @@ mod tests {
             task_id: None,
         };
         let outcome = runner.run_sync(spec).await;
+        let TaskOutcome::Completed(task) = outcome else {
+            panic!("expected Completed (graceful exit), got {outcome:?}");
+        };
+        // The returned reply carries the summarizing turn's text.
+        let reply_text = task.messages.last().map(text_of).unwrap_or_default();
         assert!(
-            matches!(outcome, TaskOutcome::Failed(_)),
-            "expected Failed, got {outcome:?}"
+            reply_text.contains("SUMMARY:"),
+            "expected summary in reply, got: {reply_text}"
         );
-        if let TaskOutcome::Failed(task) = outcome {
-            let err = task.error.unwrap();
-            assert!(err.message.contains("iteration"), "got: {}", err.message);
+        // The stop reason is surfaced in usage for callers to inspect.
+        let usage = task.usage.expect("graceful exit must populate usage");
+        assert_eq!(usage["stop_reason"], "max_iterations", "usage={usage}");
+        assert_eq!(usage["iterations"], 3, "usage={usage}");
+    }
+
+    /// Step 3 (token budget): with a tiny `max_tokens` ceiling and an LLM that
+    /// reports input tokens, the loop stops early — before the iteration cap —
+    /// with stop_reason "token_budget", returning a Completed task carrying the
+    /// summary. The budget is checked at loop entry (current - start), so the
+    /// first turn always runs; the second turn trips the ceiling.
+    #[tokio::test]
+    async fn token_budget_exceeded_yields_completed_with_summary() {
+        use crate::llm::stub::SequenceLlm;
+        // idx0: one tool turn reporting 100 input tokens (>budget of 10).
+        // idx1: the graceful, tools-disabled summary turn.
+        let responses: Vec<crate::llm::LlmResponse> = vec![
+            tool_call_response_tokens("id-0", "echo work", 100),
+            end_turn_response("TOKEN SUMMARY: ran one step; build untouched; remaining: rest."),
+        ];
+        let runner = Arc::new(
+            TaskRunner::with_llm(Arc::new(SequenceLlm::new(responses)))
+                .with_pending_approvals(empty_pending_approvals())
+                .with_notifier(tokio::sync::mpsc::channel(16).0)
+                .with_hitl_timeout_secs(1)
+                // High iteration cap so only the token budget can stop us.
+                .with_max_iterations(50)
+                .with_max_token_budget(10),
+        );
+        let outcome = runner.run_sync(loop_spec("budget")).await;
+        let TaskOutcome::Completed(task) = outcome else {
+            panic!("expected Completed (token-budget graceful exit), got {outcome:?}");
+        };
+        let reply_text = task.messages.last().map(text_of).unwrap_or_default();
+        assert!(
+            reply_text.contains("TOKEN SUMMARY"),
+            "expected summary in reply, got: {reply_text}"
+        );
+        let usage = task.usage.expect("token-budget exit must populate usage");
+        assert_eq!(usage["stop_reason"], "token_budget", "usage={usage}");
+        // Stopped after exactly one completed iteration, far below the cap of 50.
+        assert_eq!(usage["iterations"], 1, "usage={usage}");
+    }
+
+    /// Step 4 (doom-loop detection): an LLM that emits the SAME tool call every
+    /// turn must be aborted after ~3 identical calls with stop_reason
+    /// "loop_detected" — well before the iteration cap (50 here). This catches
+    /// blind identical retries quickly regardless of how high the cap is.
+    #[tokio::test]
+    async fn doom_loop_detected_yields_completed_with_summary() {
+        use crate::llm::stub::SequenceLlm;
+        // Identical args every turn. The 3rd identical fingerprint trips the
+        // guard on iteration index 2; the 4th call is the graceful summary.
+        let responses: Vec<crate::llm::LlmResponse> = vec![
+            tool_call_response("same-0", "echo identical"),
+            tool_call_response("same-1", "echo identical"),
+            tool_call_response("same-2", "echo identical"),
+            end_turn_response("LOOP SUMMARY: stuck retrying; build untouched; need new approach."),
+        ];
+        let runner = Arc::new(
+            TaskRunner::with_llm(Arc::new(SequenceLlm::new(responses)))
+                .with_pending_approvals(empty_pending_approvals())
+                .with_notifier(tokio::sync::mpsc::channel(16).0)
+                .with_hitl_timeout_secs(1)
+                // High cap so only doom-loop detection can stop us this fast.
+                .with_max_iterations(50),
+        );
+        let outcome = runner.run_sync(loop_spec("doom")).await;
+        let TaskOutcome::Completed(task) = outcome else {
+            panic!("expected Completed (doom-loop graceful exit), got {outcome:?}");
+        };
+        let reply_text = task.messages.last().map(text_of).unwrap_or_default();
+        assert!(
+            reply_text.contains("LOOP SUMMARY"),
+            "expected summary in reply, got: {reply_text}"
+        );
+        let usage = task.usage.expect("doom-loop exit must populate usage");
+        assert_eq!(usage["stop_reason"], "loop_detected", "usage={usage}");
+        // Aborted within ~3 iterations, far below the cap of 50.
+        let iters = usage["iterations"]
+            .as_u64()
+            .expect("iterations is a number");
+        assert!(iters < 5, "expected early abort, got {iters} iterations");
+    }
+
+    /// Test LLM that records how many times `generate` was called and always
+    /// emits a tool_use response (so the agentic loop never ends naturally).
+    struct CountingToolLlm {
+        calls: Arc<AtomicU64>,
+        input_tokens_per_call: u64,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::llm::LlmClient for CountingToolLlm {
+        async fn generate(
+            &self,
+            _req: crate::llm::LlmRequest,
+        ) -> Result<crate::llm::LlmResponse, crate::llm::LlmError> {
+            let n = self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(crate::llm::LlmResponse {
+                text: String::new(),
+                input_tokens: self.input_tokens_per_call,
+                output_tokens: 1,
+                model: "counting".into(),
+                tool_calls: vec![crate::llm::ToolCallResult {
+                    call_id: format!("id-{n}"),
+                    tool_name: "bash".into(),
+                    input: serde_json::json!({"command": "echo loop"}),
+                }],
+                stop_reason: crate::llm::StopReason::ToolUse,
+            })
         }
+        fn model_name(&self) -> &str {
+            "counting"
+        }
+    }
+
+    fn loop_spec(text: &str) -> TaskSpec {
+        TaskSpec {
+            input: mur_common::a2a::Message {
+                role: "user".into(),
+                parts: vec![mur_common::a2a::MessagePart::Text { text: text.into() }],
+            },
+            context_task_id: None,
+            task_id: None,
+        }
+    }
+
+    fn empty_pending_approvals() -> HitlApprovals {
+        Arc::new(tokio::sync::Mutex::new(HashMap::new()))
+    }
+
+    /// Step 1 (config wiring): the PRODUCTION wiring function `build_runner`
+    /// must honour a `max_iterations` of 3 — proving `HitlConfig.max_iterations`
+    /// is threaded through, not just the test-only builder. The counting LLM
+    /// emits tool_use every turn, so without the cap the loop would run forever
+    /// (well, until the default). We assert generate() is called at most 3+1
+    /// times (3 loop turns plus one graceful-summary turn).
+    #[tokio::test]
+    async fn build_runner_caps_loop_at_configured_max_iterations() {
+        let calls = Arc::new(AtomicU64::new(0));
+        let client: Arc<dyn crate::llm::LlmClient> = Arc::new(CountingToolLlm {
+            calls: calls.clone(),
+            input_tokens_per_call: 1,
+        });
+        let (notif_tx, _rx) = tokio::sync::mpsc::channel(64);
+        let runner = crate::supervisor_runner::build_runner(
+            client,
+            None,
+            Arc::new(RuntimeSkills::build(vec![])),
+            SkillsConfig::default(),
+            None,
+            None,
+            None,
+            Some(empty_pending_approvals()),
+            Some(notif_tx),
+            1,
+            vec![],
+            vec![],
+            Some(3),
+            None,
+        );
+        let _ = runner.run_sync(loop_spec("loop")).await;
+        let n = calls.load(Ordering::Relaxed);
+        // 3 loop iterations; the graceful summary turn (step 4) adds at most one
+        // more. Before wiring, the default cap (25) lets it run far past this.
+        assert!(
+            n <= 4,
+            "expected the loop capped near 3 iterations, got {n} generate() calls"
+        );
+        assert!(n >= 3, "expected at least 3 iterations, got {n}");
     }
 }

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -907,8 +907,17 @@ pub struct VoiceConfig {
 pub struct HitlConfig {
     #[serde(default = "default_hitl_timeout_secs")]
     pub timeout_secs: u32,
+    /// Hard cap on agentic-loop iterations (one LLM turn + its tool calls).
+    /// `None` falls back to the runner default (25). On exceeding the cap the
+    /// loop exits gracefully with a summary, not a hard error.
     #[serde(default)]
     pub max_iterations: Option<u32>,
+    /// Per-task ceiling on cumulative *input* tokens for the agentic loop. When
+    /// crossed before a turn, the loop stops gracefully with a summary.
+    /// `None` falls back to the runner default (750_000 ≈ a few dollars on
+    /// Sonnet); set a lower value per profile to bound spend tightly.
+    #[serde(default)]
+    pub max_tokens: Option<u64>,
 }
 
 fn default_hitl_timeout_secs() -> u32 {
@@ -920,6 +929,7 @@ impl Default for HitlConfig {
         Self {
             timeout_secs: default_hitl_timeout_secs(),
             max_iterations: None,
+            max_tokens: None,
         }
     }
 }
@@ -938,6 +948,18 @@ mod hitl_tests {
     fn hitl_config_max_iterations_explicit() {
         let cfg: HitlConfig = serde_yaml::from_str("timeout_secs: 60\nmax_iterations: 5").unwrap();
         assert_eq!(cfg.max_iterations, Some(5));
+    }
+
+    #[test]
+    fn hitl_config_default_max_tokens_is_none() {
+        let cfg = HitlConfig::default();
+        assert!(cfg.max_tokens.is_none());
+    }
+
+    #[test]
+    fn hitl_config_max_tokens_explicit() {
+        let cfg: HitlConfig = serde_yaml::from_str("timeout_secs: 60\nmax_tokens: 250000").unwrap();
+        assert_eq!(cfg.max_tokens, Some(250_000));
     }
 }
 


### PR DESCRIPTION
Makes the agent runtime's agentic loop actually complete multi-step coding tasks. Found while building a Rust-coding agent that could do one-line edits but failed/looped on any from-scratch file write.

## Root cause (the headline fix)
`DEFAULT_MAX_TOKENS` was **1024**, and the loop always passed `max_tokens: None`. Writing a normal source file (a large `bash` heredoc) truncated the assistant response **mid-`tool_use`**, so the tool input parsed as empty `{}` → bash errored "missing 'command'" → the model retried identically → loop. Raised to **16384** (a ceiling; cost only rises with real output). Confirmed via a runtime trace: tool args were empty exactly when the model went to write the file.

## Changes
1. **Output cap**: `DEFAULT_MAX_TOKENS` 1024 → 16384.
2. **Truncation self-correction**: on `stop_reason == MaxTokens` with tool_calls, don't execute the malformed call — inject a "your output was truncated; write in smaller pieces" message and continue.
3. **Configurable iteration cap**: wire the previously-dead `HitlConfig.max_iterations` end-to-end; default 10 → **25** (None-fallback).
4. **Per-task token budget**: new `HitlConfig.max_tokens` + runtime enforcement via a loop-entry snapshot of cumulative input tokens (default 750_000).
5. **Graceful exit**: on hitting any bound, do one final tools-disabled summary turn and return `Completed` with a `stop_reason` in `usage` (was a hard `Failed` that discarded all work); falls back to last assistant text if the summary call errors.
6. **Doom-loop detection**: result-aware fingerprint `(tool, args, result)` — aborts only when the same call yields the same result 3×, so legitimate repeated `cargo build`/`test` between edits is NOT flagged.
7. **Dangling-tool_use sanitization** in the graceful-exit path (prevents a 400 when aborting mid-iteration).

## Testing
- `cargo test -p mur-agent-runtime`: **602 passed, 0 failed**.
- `cargo fmt --all -- --check` clean; `cargo clippy -p mur-agent-runtime --all-targets -- -D warnings` clean.
- End-to-end: an agent wrote a 267-line duration parser (impl + typed error enum + tests) passing build + clippy + tests, solo under the enforcing sandbox — the exact task that previously looped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)