### PR TITLE
fix(skill): 'agent skill add' installs a loadable subdir, not a silent dead flat file

### DIFF
--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -614,20 +614,25 @@ pub enum AgentPermAction {
 pub enum AgentSkillAction {
     /// List attached skill ids
     List { name: String },
-    /// Copy a skill markdown file into the agent and register it.
-    /// The skill is stored under `skills/<basename>` inside the agent dir.
+    /// Validate a skill and install it into the agent, then register it.
+    /// The source is parsed (`.yaml`/`.yml`, or `.md` which is accepted and
+    /// converted to canonical YAML), schema-validated and security-scanned,
+    /// then written into a per-skill subdir as `skills/<name>/skill.yaml`
+    /// (name taken from the manifest). Sources that aren't valid skill
+    /// manifests are rejected rather than stored as dead files.
     Add {
         name: String,
-        /// Path to a skill .md file. Stored id is `skills/<basename>`.
+        /// Path to a skill source (`.yaml`/`.yml` or `.md`). Stored id is
+        /// `skills/<manifest-name>`.
         source: String,
     },
-    /// Remove a skill entry; deletes the backing file if orphaned.
-    /// `skill_id` may be the full id (`skills/foo.md`), the basename (`foo.md`),
-    /// or the basename without extension (`foo`).
+    /// Remove a skill entry; deletes the backing subdir if orphaned.
+    /// `skill_id` may be the full id (`skills/foo`), the basename (`foo`),
+    /// or the basename without extension.
     Remove { name: String, skill_id: String },
-    /// Print the contents of a skill file.
-    /// `skill_id` may be the full id (`skills/foo.md`), the basename (`foo.md`),
-    /// or the basename without extension (`foo`).
+    /// Print the canonical contents of an installed skill.
+    /// `skill_id` may be the full id (`skills/foo`), the basename (`foo`),
+    /// or the basename without extension.
     Show { name: String, skill_id: String },
 }
 

--- a/mur-core/src/cmd/agent/cli/manage.rs
+++ b/mur-core/src/cmd/agent/cli/manage.rs
@@ -138,7 +138,7 @@ pub fn skill_remove(agent: &str, query: &str) -> Result<String> {
 /// Usage strings shown for bad arguments.
 pub const MCP_USAGE: &str =
     "usage: /mcp [list] · /mcp add <name> <command> [args…] · /mcp remove <name>";
-pub const SKILL_USAGE: &str = "usage: /skill [list] · /skill add <path> · /skill remove <name>";
+pub const SKILL_USAGE: &str = "usage: /skill [list] · /skill add <path> (validates + installs a .yaml/.md skill into skills/<name>/skill.yaml) · /skill remove <name>";
 
 /// Dispatch a parsed `/mcp` invocation.
 pub fn run_mcp(agent: &str, args: &[String]) -> Result<String> {

--- a/mur-core/src/cmd/agent/skill.rs
+++ b/mur-core/src/cmd/agent/skill.rs
@@ -51,30 +51,57 @@ pub fn cmd_skill_add(name: &str, source: &str) -> Result<()> {
     if !src.exists() {
         bail!("skill source '{source}' not found");
     }
-    let basename = src
-        .file_name()
-        .and_then(|s| s.to_str())
-        .ok_or_else(|| anyhow!("skill source has no basename"))?;
 
-    // Validate YAML skills before adding
-    if let Some(ext) = src.extension().and_then(|e| e.to_str())
-        && (ext == "yaml" || ext == "yml")
-    {
-        let text = fs::read_to_string(&src)?;
-        let m = mur_common::skill::parse_canonical(&text)?;
-        mur_common::skill::validate(&m).map_err(|e| anyhow!("skill validation failed: {e}"))?;
+    let text = fs::read_to_string(&src)
+        .with_context(|| format!("read skill source '{}'", src.display()))?;
+
+    // Parse the input into a canonical manifest regardless of extension:
+    // `.yaml`/`.yml` via the canonical parser, anything else (`.md`, no ext)
+    // via the markdown-frontmatter parser. A source that does not parse into a
+    // manifest is rejected — we never copy a dead file that the loader would
+    // silently ignore.
+    let ext = src
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let manifest = if ext == "yaml" || ext == "yml" {
+        mur_common::skill::parse_canonical(&text)
+            .map_err(|e| anyhow!("not a valid skill manifest: {e}. See `mur skill new`."))?
+    } else {
+        mur_common::skill::parse_markdown(&text)
+            .map_err(|e| anyhow!("not a valid skill manifest: {e}. See `mur skill new`."))?
+    };
+
+    // Schema validation + security content scan for ALL inputs.
+    mur_common::skill::validate(&manifest).map_err(|e| anyhow!("skill validation failed: {e}"))?;
+    let report =
+        mur_common::skill::scan::scan_skill(&manifest).map_err(|e| anyhow!("scan skill: {e}"))?;
+
+    // The subdir name equals the manifest name; the loader/validator require a
+    // single safe path component (lowercase-kebab) here.
+    let skill_name = manifest.name.clone();
+    if !mur_common::skill::loader::is_valid_skill_name(&skill_name) {
+        bail!("refusing to install skill with unsafe name {skill_name:?}");
     }
 
     let (path, mut profile) = load_profile_for_edit(name)?;
 
+    // Write into the loadable layout: agents/<agent>/skills/<name>/skill.yaml,
+    // reusing the same canonical writer the runtime loader reads from.
     let agent_home = path.parent().unwrap_or(Path::new(""));
-    let skills_dir = agent_home.join("skills");
-    fs::create_dir_all(&skills_dir).with_context(|| format!("create {}", skills_dir.display()))?;
-    let dest = skills_dir.join(basename);
-    fs::copy(&src, &dest)
-        .with_context(|| format!("copy {} -> {}", src.display(), dest.display()))?;
+    let dest_dir = agent_home.join("skills").join(&skill_name);
+    mur_common::skill::write_to_dir(&dest_dir, &manifest)
+        .map_err(|e| anyhow!("write skill to {}: {e}", dest_dir.display()))?;
 
-    let skill_id = format!("skills/{basename}");
+    if report.has_blocking_findings() {
+        eprintln!("⚠ {skill_name}: security findings — review before trusting");
+        for line in report.human_summary() {
+            eprintln!("    {line}");
+        }
+    }
+
+    let skill_id = format!("skills/{skill_name}");
     if !profile.skills.iter().any(|s| s == &skill_id) {
         profile.skills.push(skill_id);
     }
@@ -89,11 +116,17 @@ pub fn cmd_skill_remove(name: &str, query: &str) -> Result<()> {
     profile.skills.retain(|s| s != &resolved);
     save_profile(&path, &mut profile)?;
 
-    // Delete the backing file if no other skill entry references it.
+    // Delete the backing artifact if no other skill entry references it.
+    // Modern skills are per-skill subdirectories (`skills/<name>/skill.yaml`);
+    // legacy entries may still be a flat file (`skills/<name>.md`).
     let agent_home = resolve_mur_home()?.join("agents").join(name);
-    let file_path = agent_home.join(&resolved);
-    if file_path.exists() && !profile.skills.iter().any(|s| s == &resolved) {
-        let _ = fs::remove_file(&file_path);
+    let backing = agent_home.join(&resolved);
+    if backing.exists() && !profile.skills.iter().any(|s| s == &resolved) {
+        if backing.is_dir() {
+            let _ = fs::remove_dir_all(&backing);
+        } else {
+            let _ = fs::remove_file(&backing);
+        }
     }
     Ok(())
 }
@@ -103,16 +136,27 @@ pub fn cmd_skill_show(name: &str, query: &str) -> Result<()> {
     let resolved = resolve_skill_id(&profile, query)
         .ok_or_else(|| anyhow!("skill '{query}' not registered on '{name}'"))?;
     let agent_home = resolve_mur_home()?.join("agents").join(name);
-    let file_path = agent_home.join(resolved);
-    let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let backing = agent_home.join(resolved);
+
+    if backing.is_dir() {
+        // Modern per-skill subdir — read the canonical manifest the loader uses.
+        let m = mur_common::skill::read_from_dir(&backing)
+            .map_err(|e| anyhow!("read skill {}: {e}", backing.display()))?;
+        let out = mur_common::skill::serialize_canonical(&m)?;
+        print!("{out}");
+        return Ok(());
+    }
+
+    // Legacy flat file.
+    let ext = backing.extension().and_then(|e| e.to_str()).unwrap_or("");
     if matches!(ext, "yaml" | "yml") {
-        let text = std::fs::read_to_string(&file_path)?;
+        let text = std::fs::read_to_string(&backing)?;
         let m = mur_common::skill::parse_canonical(&text)?;
         let out = mur_common::skill::serialize_canonical(&m)?;
         print!("{out}");
     } else {
         // Legacy .md — print raw
-        let body = std::fs::read_to_string(&file_path)?;
+        let body = std::fs::read_to_string(&backing)?;
         print!("{body}");
     }
     Ok(())

--- a/mur-core/tests/agent_skill.rs
+++ b/mur-core/tests/agent_skill.rs
@@ -36,14 +36,38 @@ fn run(mur_home: &std::path::Path, args: &[&str]) -> std::process::Output {
         .expect("spawn mur")
 }
 
+/// Canonical-YAML skill source body (valid manifest, name = "research").
+fn valid_yaml_skill() -> &'static str {
+    "name: research\n\
+     version: 1.0.0\n\
+     publisher: human:t\n\
+     description: research helper\n\
+     category: context\n\
+     content:\n  \
+       abstract: research things\n  \
+       context: how to research things\n"
+}
+
+/// Markdown-frontmatter skill source body (valid manifest, name = "research").
+fn valid_md_skill() -> &'static str {
+    "---\n\
+     name: research\n\
+     version: 1.0.0\n\
+     publisher: human:t\n\
+     description: research helper\n\
+     category: context\n\
+     ---\n\
+     How to research things thoroughly.\n"
+}
+
 #[test]
-fn skill_add_copies_file_and_appends_id() {
+fn skill_add_installs_subdir_and_appends_id() {
     let mur_home = TempDir::new().unwrap();
     let bin_dir = TempDir::new().unwrap();
     mur_create(mur_home.path(), bin_dir.path(), "agent_x");
     let src = TempDir::new().unwrap();
-    let skill_src = src.path().join("research.md");
-    std::fs::write(&skill_src, "# Research\nbody").unwrap();
+    let skill_src = src.path().join("research.yaml");
+    std::fs::write(&skill_src, valid_yaml_skill()).unwrap();
 
     let out = run(
         mur_home.path(),
@@ -61,10 +85,110 @@ fn skill_add_copies_file_and_appends_id() {
         String::from_utf8_lossy(&out.stderr)
     );
 
-    let dest = mur_home.path().join("agents/agent_x/skills/research.md");
-    assert!(dest.exists(), "skill file should have been copied");
+    // New, correct behavior: a per-skill subdir holding canonical skill.yaml,
+    // named after the manifest (not the file basename).
+    let dest = mur_home
+        .path()
+        .join("agents/agent_x/skills/research/skill.yaml");
+    assert!(
+        dest.exists(),
+        "skill should be installed as a per-skill subdir with skill.yaml"
+    );
+    // And NO flat dead file at skills/<basename>.
+    let flat = mur_home.path().join("agents/agent_x/skills/research.yaml");
+    assert!(!flat.exists(), "no flat file should be created");
+
     let p = read_profile(mur_home.path(), "agent_x");
-    assert_eq!(p.skills, vec!["skills/research.md".to_string()]);
+    assert_eq!(p.skills, vec!["skills/research".to_string()]);
+}
+
+/// The added skill must actually be loadable by the runtime loader (the bug:
+/// flat files were registered but never enumerated). Covers BOTH a `.yaml`
+/// input and a `.md` input — each must land at `skills/<name>/skill.yaml` and
+/// be enumerated + parsed by the loader.
+#[test]
+fn added_skill_is_loadable() {
+    for (filename, body) in [
+        ("research.yaml", valid_yaml_skill()),
+        ("research.md", valid_md_skill()),
+    ] {
+        let mur_home = TempDir::new().unwrap();
+        let bin_dir = TempDir::new().unwrap();
+        mur_create(mur_home.path(), bin_dir.path(), "agent_x");
+        let src = TempDir::new().unwrap();
+        let skill_src = src.path().join(filename);
+        std::fs::write(&skill_src, body).unwrap();
+
+        let out = run(
+            mur_home.path(),
+            &[
+                "agent",
+                "skill",
+                "add",
+                "agent_x",
+                skill_src.to_str().unwrap(),
+            ],
+        );
+        assert!(
+            out.status.success(),
+            "add {filename} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+
+        // The loader enumerates subdirs of agents/<agent>/skills.
+        let names = mur_common::skill::local::list_installed_agent(mur_home.path(), "agent_x")
+            .expect("list_installed_agent");
+        assert!(
+            names.contains(&"research".to_string()),
+            "loader should enumerate the added skill for {filename}, got {names:?}"
+        );
+
+        // And it must parse via the loader's read path.
+        let m =
+            mur_common::skill::local::load_installed_agent(mur_home.path(), "agent_x", "research")
+                .expect("load_installed_agent should parse the installed skill");
+        assert_eq!(m.name, "research", "loaded manifest name for {filename}");
+    }
+}
+
+/// A plain markdown file that is not a valid skill manifest must be rejected
+/// with an error, and nothing should be written.
+#[test]
+fn add_rejects_non_manifest_md() {
+    let mur_home = TempDir::new().unwrap();
+    let bin_dir = TempDir::new().unwrap();
+    mur_create(mur_home.path(), bin_dir.path(), "agent_x");
+    let src = TempDir::new().unwrap();
+    let skill_src = src.path().join("notes.md");
+    std::fs::write(&skill_src, "# Just some notes\nNo frontmatter here.").unwrap();
+
+    let out = run(
+        mur_home.path(),
+        &[
+            "agent",
+            "skill",
+            "add",
+            "agent_x",
+            skill_src.to_str().unwrap(),
+        ],
+    );
+    assert!(
+        !out.status.success(),
+        "adding a non-manifest .md should fail, stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    // Nothing registered, nothing written.
+    let p = read_profile(mur_home.path(), "agent_x");
+    assert!(p.skills.is_empty(), "profile should have no skills");
+    let skills_dir = mur_home.path().join("agents/agent_x/skills");
+    if skills_dir.exists() {
+        let entries: Vec<_> = std::fs::read_dir(&skills_dir).unwrap().collect();
+        assert!(
+            entries.is_empty(),
+            "no skill artifacts should be written, found {entries:?}"
+        );
+    }
 }
 
 #[test]
@@ -73,8 +197,8 @@ fn skill_list_show_remove_roundtrip() {
     let bin_dir = TempDir::new().unwrap();
     mur_create(mur_home.path(), bin_dir.path(), "agent_x");
     let src = TempDir::new().unwrap();
-    let skill_src = src.path().join("research.md");
-    std::fs::write(&skill_src, "body-only").unwrap();
+    let skill_src = src.path().join("research.yaml");
+    std::fs::write(&skill_src, valid_yaml_skill()).unwrap();
     let _ = run(
         mur_home.path(),
         &[
@@ -89,11 +213,11 @@ fn skill_list_show_remove_roundtrip() {
     let list_out = run(mur_home.path(), &["agent", "skill", "list", "agent_x"]);
     assert!(list_out.status.success());
     let body = String::from_utf8(list_out.stdout).unwrap();
-    assert!(body.contains("skills/research.md"));
+    assert!(body.contains("skills/research"));
 
     let show_out = run(
         mur_home.path(),
-        &["agent", "skill", "show", "agent_x", "skills/research.md"],
+        &["agent", "skill", "show", "agent_x", "skills/research"],
     );
     assert!(
         show_out.status.success(),
@@ -101,11 +225,11 @@ fn skill_list_show_remove_roundtrip() {
         String::from_utf8_lossy(&show_out.stderr)
     );
     let shown = String::from_utf8(show_out.stdout).unwrap();
-    assert!(shown.contains("body-only"));
+    assert!(shown.contains("research"));
 
     let rm_out = run(
         mur_home.path(),
-        &["agent", "skill", "remove", "agent_x", "skills/research.md"],
+        &["agent", "skill", "remove", "agent_x", "skills/research"],
     );
     assert!(
         rm_out.status.success(),
@@ -114,21 +238,23 @@ fn skill_list_show_remove_roundtrip() {
     );
     let p = read_profile(mur_home.path(), "agent_x");
     assert!(p.skills.is_empty());
-    let dest = mur_home.path().join("agents/agent_x/skills/research.md");
-    assert!(!dest.exists(), "orphaned skill file should be deleted");
+    let dest = mur_home
+        .path()
+        .join("agents/agent_x/skills/research/skill.yaml");
+    assert!(!dest.exists(), "orphaned skill should be deleted");
 }
 
 /// E3 regression: `skill show` and `skill remove` accept the basename
-/// (`research.md`) and the stem (`research`) in addition to the full
-/// stored id (`skills/research.md`).
+/// (`research`) and the stem in addition to the full stored id
+/// (`skills/research`).
 #[test]
 fn skill_show_and_remove_accept_basename_and_stem() {
     let mur_home = TempDir::new().unwrap();
     let bin_dir = TempDir::new().unwrap();
     mur_create(mur_home.path(), bin_dir.path(), "agent_x");
     let src = TempDir::new().unwrap();
-    let skill_src = src.path().join("research.md");
-    std::fs::write(&skill_src, "skill-body").unwrap();
+    let skill_src = src.path().join("research.yaml");
+    std::fs::write(&skill_src, valid_yaml_skill()).unwrap();
     let _ = run(
         mur_home.path(),
         &[
@@ -140,38 +266,26 @@ fn skill_show_and_remove_accept_basename_and_stem() {
         ],
     );
 
-    // show by basename
-    let out = run(
-        mur_home.path(),
-        &["agent", "skill", "show", "agent_x", "research.md"],
-    );
-    assert!(
-        out.status.success(),
-        "show by basename failed: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    assert!(String::from_utf8_lossy(&out.stdout).contains("skill-body"));
-
-    // show by stem (without .md)
+    // show by basename (last path component of the stored id `skills/research`)
     let out = run(
         mur_home.path(),
         &["agent", "skill", "show", "agent_x", "research"],
     );
     assert!(
         out.status.success(),
-        "show by stem failed: {}",
+        "show by basename failed: {}",
         String::from_utf8_lossy(&out.stderr)
     );
-    assert!(String::from_utf8_lossy(&out.stdout).contains("skill-body"));
+    assert!(String::from_utf8_lossy(&out.stdout).contains("research"));
 
-    // remove by stem
+    // remove by basename
     let out = run(
         mur_home.path(),
         &["agent", "skill", "remove", "agent_x", "research"],
     );
     assert!(
         out.status.success(),
-        "remove by stem failed: {}",
+        "remove by basename failed: {}",
         String::from_utf8_lossy(&out.stderr)
     );
     let p = read_profile(mur_home.path(), "agent_x");


### PR DESCRIPTION
## Problem (user-reported, high severity)
`mur agent skill add <agent> <file>` copied the source to a FLAT path `agents/<agent>/skills/<basename>` and only validated `.yaml`/`.yml` (`.md` copied unvalidated). But the runtime loader (`local.rs::list_installed_agent`) enumerates only SUBDIRECTORIES (`<dir>/skill.yaml|skill.md`). So the file was registered in profile.yaml, printed success (exit 0), yet could NEVER load — a silent dead file. The Hub "Install skill" button shares this path.

## Fix
`cmd_skill_add` now:
- Parses the input into a `SkillManifest` regardless of extension (`.yaml`/`.yml` → canonical; `.md` → markdown parser), and **bails with a clear error** if it is not a valid manifest (no more dead-file copy).
- Runs schema validation + security content scan for ALL inputs (was yaml-only).
- Installs into the loadable layout `agents/<agent>/skills/<name>/skill.yaml` via the shared `write_to_dir`, registering id `skills/<name>`.
- `show`/`remove` updated for the subdir layout (legacy flat fallback retained).
- Misleading `skill add` help/usage text corrected.

## Testing (TDD)
Updated the test that codified the broken flat-file behavior; added `added_skill_is_loadable` (adds a `.yaml` and a `.md`, then asserts the loader enumerates + parses them) and `add_rejects_non_manifest_md`. `cargo test -p mur-core --test agent_skill`: 5 passed, 0 failed. Install-suite regression tests still pass. fmt/clippy clean on changed files.

Pairs well with #422 (parser round-trip) so the `.md` conversion path is faithful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)