### PR TITLE
feat(voice): model download, honest STT hints, working Kokoro TTS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1535,7 +1535,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.9",
+ "libloading",
 ]
 
 [[package]]
@@ -5871,16 +5871,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libloading"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7021,7 +7011,6 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
- "libloading 0.9.0",
  "ndarray 0.17.2",
  "ort-sys",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_json = "1"
 serde_yaml = "0.9"
 schemars = { version = "1", features = ["chrono04"] }
 clap = { version = "4", features = ["derive", "env"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking", "gzip"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking", "gzip", "stream"], default-features = false }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/mur-agent-gui/src-tauri/Cargo.toml
+++ b/mur-agent-gui/src-tauri/Cargo.toml
@@ -70,7 +70,12 @@ tar = "0.4"
 tempfile = "3"
 
 # ───── voice (D1 / M1) ─────
-ort = { version = "=2.0.0-rc.12", default-features = false, features = ["copy-dylibs", "load-dynamic"] }
+# `api-24` matches ort's default OrtApi level (the EP bindings, e.g. VitisAI,
+# require it). It previously came transitively via mur-agent-runtime's ort
+# defaults; it is now explicit because mur-agent-runtime gates `ort` behind its
+# off-by-default `tts` feature. `load-dynamic` keeps onnxruntime out of the
+# link (no static lib → no glibc-2.38 dependency).
+ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "copy-dylibs", "load-dynamic", "api-24"] }
 whisper-rs = { version = "0.11", default-features = false }
 cpal = "0.16"
 hound = "3"

--- a/mur-agent-runtime/Cargo.toml
+++ b/mur-agent-runtime/Cargo.toml
@@ -8,6 +8,11 @@ build = "build.rs"
 # Bundle an agent profile into the binary at compile time; set
 # MUR_EXPORT_AGENT_DIR=<path> alongside `cargo build --features=embedded-agent`.
 embedded-agent = []
+# Kokoro TTS via ONNX Runtime. Off by default so crates that only use STT /
+# the rest of the runtime (the CLI, the Tauri GUIs via mur-gui-core) don't
+# static-link onnxruntime — which both bloats them and fails to link on older
+# glibc (ubuntu-22.04). Enabled by mur-daemon, which actually synthesizes.
+tts = ["dep:ort", "dep:ndarray"]
 
 [build-dependencies]
 tar = "0.4"
@@ -98,8 +103,13 @@ teloxide = { version = "0.13", default-features = false, features = ["rustls", "
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
 # D1 voice — TTS + STT (Tasks 3-8)
 indicatif = "0.17"   # progress bar for download
-ort = { version = "2.0.0-rc.12", features = ["load-dynamic", "ndarray"] }   # ONNX Runtime for Kokoro TTS
-ndarray = "0.17"                                           # tensor arrays for ort
+# ONNX Runtime for Kokoro TTS. Use the default `download-binaries` (static link
+# the ABI-matched prebuilt at build time) rather than `load-dynamic` (runtime
+# dlopen): the static lib can't drift from ort's expected ABI, covers all
+# platforms via upstream prebuilts, and works offline — no runtime voice-pack
+# dylib to provision. See `docs` / memory `project_voice_mobile_runtime_gotchas`.
+ort = { version = "2.0.0-rc.12", features = ["ndarray"], optional = true }
+ndarray = { version = "0.17", optional = true }            # tensor arrays for ort
 espeak-ng = "0.1"                                           # espeak-ng G2P for Kokoro tokenizer (pure Rust, no bindgen)
 whisper-rs = { version = "0.11", features = [] }            # whisper.cpp STT bindings (CPU-only; no metal to keep CI clean)
 cpal = "0.15"                                               # cross-platform audio I/O (mic capture + speaker playback)

--- a/mur-agent-runtime/src/voice/mod.rs
+++ b/mur-agent-runtime/src/voice/mod.rs
@@ -7,7 +7,12 @@
 pub mod audio;
 pub mod download;
 pub mod network_audit;
-pub mod notifier;
 pub mod stt;
-pub mod tts;
 pub mod types;
+
+// Kokoro ONNX TTS + the companion VoiceNotifier that drives it. Only built
+// with the `tts` feature (pulls onnxruntime); see the feature note in Cargo.toml.
+#[cfg(feature = "tts")]
+pub mod notifier;
+#[cfg(feature = "tts")]
+pub mod tts;

--- a/mur-agent-runtime/src/voice/tts.rs
+++ b/mur-agent-runtime/src/voice/tts.rs
@@ -13,8 +13,10 @@ use std::sync::Mutex;
 
 use anyhow::{Context, Result};
 use mur_common::agent::VoiceId;
-use ndarray::Array2;
+use ndarray::{Array1, Array2};
 use ort::{session::Session, value::Tensor};
+
+use crate::voice::types::{N_VOICES, STYLE_DIM, STYLE_ROWS, VOICES_BIN_LEN};
 
 // Target: 178 entries matching hexgrad/Kokoro-82M tokenizer_config.json
 // Current: ~80 entries covering common English IPA — good enough for v1
@@ -55,18 +57,20 @@ impl KokoroTokenizer {
 
 // ─── TTS engine ──────────────────────────────────────────────────────────────
 
-/// Loaded Kokoro ONNX session + style matrix.
+/// Loaded Kokoro ONNX session + per-voice style matrices.
 pub struct KokoroTts {
     /// Wrapped in `Mutex` so `synthesize` can take `&self` (required for
     /// `Box<dyn KokoroTtsTrait>` usage); `ort::Session::run` needs `&mut self`.
     session: Mutex<Session>,
-    /// Style matrix: 5 rows × 256 columns (one row per VoiceId).
-    style_matrix: [[f32; 256]; 5],
+    /// Per-voice style tensors: `N_VOICES` voices × `STYLE_ROWS` length-buckets
+    /// × `STYLE_DIM` columns. Indexed `[voice][phoneme_count]` — Kokoro selects
+    /// the style row by the number of phoneme tokens in the utterance.
+    style: Vec<Vec<[f32; STYLE_DIM]>>,
     voice_id: VoiceId,
 }
 
 impl KokoroTts {
-    /// Load the Kokoro ONNX model from `onnx_path` and style matrix from
+    /// Load the Kokoro ONNX model from `onnx_path` and the style matrix from
     /// `voices_path`. Returns an error if either file is missing or corrupt.
     pub fn new(onnx_path: &Path, voices_path: &Path, voice_id: VoiceId) -> Result<Self> {
         let session = Session::builder()
@@ -75,26 +79,31 @@ impl KokoroTts {
             .context("load kokoro onnx")?;
 
         let style_bytes = std::fs::read(voices_path).context("read kokoro-voices.bin")?;
-
-        const STYLE_DIM: usize = 256;
-        const N_VOICES: usize = 5;
         anyhow::ensure!(
-            style_bytes.len() == N_VOICES * STYLE_DIM * 4,
-            "kokoro-voices.bin has unexpected size {} (expected {} bytes)",
+            style_bytes.len() == VOICES_BIN_LEN,
+            "kokoro-voices.bin has unexpected size {} (expected {VOICES_BIN_LEN} bytes)",
             style_bytes.len(),
-            N_VOICES * STYLE_DIM * 4
         );
 
-        let mut style_matrix = [[0f32; STYLE_DIM]; N_VOICES];
-        for (i, chunk) in style_bytes.chunks_exact(4).enumerate() {
-            let row = i / STYLE_DIM;
-            let col = i % STYLE_DIM;
-            style_matrix[row][col] = f32::from_le_bytes(chunk.try_into().unwrap());
+        let floats: Vec<f32> = style_bytes
+            .chunks_exact(4)
+            .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+            .collect();
+        let mut style = Vec::with_capacity(N_VOICES);
+        for v in 0..N_VOICES {
+            let mut rows = Vec::with_capacity(STYLE_ROWS);
+            for r in 0..STYLE_ROWS {
+                let base = (v * STYLE_ROWS + r) * STYLE_DIM;
+                let mut row = [0f32; STYLE_DIM];
+                row.copy_from_slice(&floats[base..base + STYLE_DIM]);
+                rows.push(row);
+            }
+            style.push(rows);
         }
 
         Ok(Self {
             session: Mutex::new(session),
-            style_matrix,
+            style,
             voice_id,
         })
     }
@@ -107,21 +116,46 @@ impl KokoroTts {
             return Ok(vec![]);
         }
 
-        let n = token_ids.len();
-        let tokens_arr = Array2::from_shape_vec((1, n), token_ids).context("build tokens array")?;
+        // Kokoro selects the style row by phoneme count, and the model expects
+        // the token sequence wrapped with a leading/trailing pad (id 0). Clamp
+        // to STYLE_ROWS-2 phonemes so the padded length stays within the model's
+        // positional range (longer replies are truncated — sentence chunking is
+        // a follow-up).
+        let mut phonemes = token_ids;
+        let max_phonemes = STYLE_ROWS - 2;
+        if phonemes.len() > max_phonemes {
+            tracing::warn!(
+                len = phonemes.len(),
+                max = max_phonemes,
+                "TTS input truncated to fit Kokoro positional range"
+            );
+            phonemes.truncate(max_phonemes);
+        }
+        let n = phonemes.len();
+
+        let mut wrapped = Vec::with_capacity(n + 2);
+        wrapped.push(0i64);
+        wrapped.extend_from_slice(&phonemes);
+        wrapped.push(0i64);
+        let tokens_arr =
+            Array2::from_shape_vec((1, n + 2), wrapped).context("build tokens array")?;
         let tokens = Tensor::from_array(tokens_arr).context("build tokens tensor")?;
 
-        let style_row = self.style_matrix[self.voice_id.style_index()].to_vec();
-        let style_arr = Array2::from_shape_vec((1, 256), style_row).context("build style array")?;
+        let style_row = self.style[self.voice_id.style_index()][n].to_vec();
+        let style_arr =
+            Array2::from_shape_vec((1, STYLE_DIM), style_row).context("build style array")?;
         let style = Tensor::from_array(style_arr).context("build style tensor")?;
 
-        let speed_arr = Array2::from_elem((1, 1), 1.0f32);
+        // `speed` is rank-1 `[1]` in the v0.19 export (not `[1,1]`).
+        let speed_arr = Array1::from_elem(1, 1.0f32);
         let speed = Tensor::from_array(speed_arr).context("build speed tensor")?;
 
+        // Input/output names match the onnx-community Kokoro v0.19 export:
+        // inputs `input_ids`/`style`/`speed`, output `waveform`.
         let inputs = ort::inputs![
-            "tokens" => tokens,
-            "style"  => style,
-            "speed"  => speed,
+            "input_ids" => tokens,
+            "style"     => style,
+            "speed"     => speed,
         ];
         // `session_guard` must be declared before `outputs` so it outlives the
         // borrow: `SessionOutputs<'s>` holds a reference into the session.
@@ -131,7 +165,7 @@ impl KokoroTts {
             .map_err(|_| anyhow::anyhow!("TTS session mutex poisoned"))?;
         let outputs = session_guard.run(inputs)?;
 
-        let (_shape, audio_slice) = outputs["audio"]
+        let (_shape, audio_slice) = outputs["waveform"]
             .try_extract_tensor::<f32>()
             .context("extract audio tensor")?;
 

--- a/mur-agent-runtime/src/voice/types.rs
+++ b/mur-agent-runtime/src/voice/types.rs
@@ -1,16 +1,32 @@
 //! Model path helpers and download specs.
+//!
+//! The whisper STT weights and the Kokoro TTS ONNX model are downloaded
+//! verbatim from Hugging Face. The Kokoro **voice style matrix**
+//! (`kokoro-voices.bin`) is not an upstream artifact — it is built locally by
+//! the CLI by concatenating five per-voice `[512, 256]` style tensors (one per
+//! [`mur_common::agent::VoiceId`], in `style_index()` order). See
+//! `mur-core` `cmd::agent_voice::cmd_voice_download`.
 
 use crate::voice::download::ModelSpec;
 use std::path::PathBuf;
 
-/// Resolved on-disk paths for both voice models.
+/// Number of voices packed into `kokoro-voices.bin` (matches `VoiceId`).
+pub const N_VOICES: usize = 5;
+/// Rows per voice style tensor (Kokoro v0.19 token-length buckets).
+pub const STYLE_ROWS: usize = 512;
+/// Style vector dimension.
+pub const STYLE_DIM: usize = 256;
+/// Total byte length of a valid `kokoro-voices.bin` (`5 × 512 × 256 × f32`).
+pub const VOICES_BIN_LEN: usize = N_VOICES * STYLE_ROWS * STYLE_DIM * 4;
+
+/// Resolved on-disk paths for the voice models.
 #[derive(Debug)]
 pub struct VoiceModelPaths {
-    /// Path to ggml-large-v3-turbo-q5_1.bin (whisper.cpp format).
+    /// Path to ggml-large-v3-turbo-q5_0.bin (whisper.cpp format).
     pub whisper: PathBuf,
     /// Path to kokoro-v0_19.onnx.
     pub kokoro_onnx: PathBuf,
-    /// Path to kokoro-voices.bin (style matrix, 5 × 256 f32).
+    /// Path to kokoro-voices.bin (style matrix, 5 × 512 × 256 f32).
     pub kokoro_voices: PathBuf,
 }
 
@@ -19,7 +35,7 @@ impl VoiceModelPaths {
     pub fn from_mur_root(mur_root: &std::path::Path) -> Self {
         let models = mur_root.join("models");
         Self {
-            whisper: models.join("whisper/ggml-large-v3-turbo-q5_1.bin"),
+            whisper: models.join("whisper/ggml-large-v3-turbo-q5_0.bin"),
             kokoro_onnx: models.join("kokoro/kokoro-v0_19.onnx"),
             kokoro_voices: models.join("kokoro/kokoro-voices.bin"),
         }
@@ -31,28 +47,75 @@ impl VoiceModelPaths {
     }
 }
 
-/// Download spec for whisper large-v3-turbo q5_1 (~930 MB).
+/// Download spec for whisper large-v3-turbo q5_0 (~574 MB).
 ///
-/// SHA-256 is a placeholder — update to the real artifact hash before shipping.
+/// whisper.cpp autodetects the quantization from the GGML header, so the
+/// on-disk file name is cosmetic; q5_0 is the smallest turbo build upstream
+/// ships (there is no q5_1 artifact).
 pub const WHISPER_SPEC: ModelSpec = ModelSpec {
-    name: "ggml-large-v3-turbo-q5_1.bin",
-    url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/4774d2f/ggml-large-v3-turbo-q5_1.bin",
-    sha256: "d01b2d1d2d1b2d1d2d1b2d1d2d1b2d1d2d1b2d1d2d1b2d1d2d1b2d1d2d1b2d1d",
+    name: "ggml-large-v3-turbo-q5_0.bin",
+    url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin",
+    sha256: "394221709cd5ad1f40c46e6031ca61bce88931e6e088c188294c6d5a55ffa7e2",
     subdir: "whisper",
 };
 
-/// Download spec for Kokoro v0.19 ONNX (~85 MB).
+/// Download spec for the Kokoro v0.19 ONNX model (quantized, ~92 MB).
+///
+/// Saved on disk as `kokoro-v0_19.onnx`. Inputs: `tokens` int64[1,N],
+/// `style` f32[1,256], `speed` f32[1,1]; output `audio` f32[samples].
 pub const KOKORO_ONNX_SPEC: ModelSpec = ModelSpec {
     name: "kokoro-v0_19.onnx",
-    url: "https://huggingface.co/hexgrad/Kokoro-82M/resolve/c4b6c96/kokoro-v0_19.onnx",
-    sha256: "e01b2d1d2d1b2d1d2d1b2d1d2d1b2d1d2d1b2d1d2d1b2d1d2d1b2d1d2d1b2d1d",
+    url: "https://huggingface.co/onnx-community/Kokoro-82M-ONNX/resolve/main/onnx/model_quantized.onnx",
+    sha256: "0d55b15d4b735d61a21b0105136bc81b8768c4db94753193c19354fa863cd556",
     subdir: "kokoro",
 };
 
-/// Download spec for Kokoro style matrix (~5 KB).
-pub const KOKORO_VOICES_SPEC: ModelSpec = ModelSpec {
-    name: "kokoro-voices.bin",
-    url: "https://huggingface.co/hexgrad/Kokoro-82M/resolve/c4b6c96/kokoro-voices.bin",
-    sha256: "f01b2d1d2d1b2d1d2d1b2d1d2d1b2d1d2d1b2d1d2d1b2d1d2d1b2d1d2d1b2d1d",
-    subdir: "kokoro",
-};
+/// Per-voice style tensors that are concatenated into `kokoro-voices.bin`.
+///
+/// **Order is significant**: the array index must equal
+/// [`mur_common::agent::VoiceId::style_index`]. Each source file is a
+/// `[512, 256]` f32 tensor (524288 bytes).
+///
+/// The default `AfHeart` slot is backed by the v0.19 `af` voice: af_heart is a
+/// v1.0 voice and has no v0.19 tensor, and Kokoro style vectors are not
+/// interchangeable across model versions (they live in the decoder's latent
+/// space). `af` is af_heart's v0.19 lineage (the default American female), so
+/// it is the correct version-consistent choice for the v0.19 ONNX model.
+/// When/if this stack moves to v1.0 ONNX, swap in the real `af_heart.bin`.
+pub const KOKORO_VOICE_SOURCES: [ModelSpec; N_VOICES] = [
+    // slot 0 — VoiceId::AfHeart (served by v0.19 `af`)
+    ModelSpec {
+        name: "af.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-ONNX/resolve/main/voices/af.bin",
+        sha256: "a4f11d9d055a12bfa0db2668a3e4f0ef8fd1f1ccca69494479718e44dbf9e41a",
+        subdir: "kokoro/voices",
+    },
+    // slot 1 — VoiceId::AfBella
+    ModelSpec {
+        name: "af_bella.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-ONNX/resolve/main/voices/af_bella.bin",
+        sha256: "38e12d4b9b31a751282ab9154fb083dad3df3a749772687cde7873da107160fa",
+        subdir: "kokoro/voices",
+    },
+    // slot 2 — VoiceId::AfNicole
+    ModelSpec {
+        name: "af_nicole.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-ONNX/resolve/main/voices/af_nicole.bin",
+        sha256: "f27666996f2d227711e97ff27374099df6f619f3bfb60cd67fc0d114f5384d13",
+        subdir: "kokoro/voices",
+    },
+    // slot 3 — VoiceId::AmAdam
+    ModelSpec {
+        name: "am_adam.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-ONNX/resolve/main/voices/am_adam.bin",
+        sha256: "6d5255a4b4803f594bfa0c0d7539c4d8bb0829c7f190f0f6a8fa0afa0023b6e4",
+        subdir: "kokoro/voices",
+    },
+    // slot 4 — VoiceId::AmMichael
+    ModelSpec {
+        name: "am_michael.bin",
+        url: "https://huggingface.co/onnx-community/Kokoro-82M-ONNX/resolve/main/voices/am_michael.bin",
+        sha256: "9c3be118019ddb41b6b529a7f75c7a3dc92613f573ca03b037748b9383b0d9d0",
+        subdir: "kokoro/voices",
+    },
+];

--- a/mur-agent-runtime/tests/tts_real_model_smoke.rs
+++ b/mur-agent-runtime/tests/tts_real_model_smoke.rs
@@ -1,0 +1,68 @@
+//! Real-model TTS smoke test (ignored by default — needs `~/.mur/models`).
+//!
+//! Run after `mur agent voice <name> download` (needs the `tts` feature):
+//!   cargo test -p mur-agent-runtime --features tts --test tts_real_model_smoke -- --ignored --nocapture
+//!
+//! Verifies the v0.19 ONNX I/O contract (`input_ids`/`style`/`speed` → `waveform`)
+//! and the locally-built `kokoro-voices.bin`, and that synthesis yields non-silent PCM.
+#![cfg(feature = "tts")]
+
+use mur_agent_runtime::voice::tts::KokoroTts;
+use mur_agent_runtime::voice::types::VoiceModelPaths;
+use mur_common::agent::VoiceId;
+
+#[test]
+#[ignore = "requires downloaded models in ~/.mur/models"]
+fn synthesizes_non_silent_audio() {
+    let home = dirs::home_dir().unwrap().join(".mur");
+    let paths = VoiceModelPaths::from_mur_root(&home);
+    assert!(
+        paths.all_present(),
+        "models missing: run `mur agent voice mur download`"
+    );
+
+    let tts = KokoroTts::new(&paths.kokoro_onnx, &paths.kokoro_voices, VoiceId::AfHeart)
+        .expect("load Kokoro TTS");
+    let samples = tts
+        .synthesize("Hello, this is a voice test.")
+        .expect("synthesize");
+
+    assert!(!samples.is_empty(), "no audio produced");
+    let rms = (samples.iter().map(|s| s * s).sum::<f32>() / samples.len() as f32).sqrt();
+    let peak = samples.iter().fold(0f32, |m, s| m.max(s.abs()));
+    eprintln!("samples={} rms={rms:.5} peak={peak:.5}", samples.len());
+    assert!(rms > 1e-3, "audio is effectively silent (rms={rms})");
+
+    // Dump a listenable WAV when MUR_TTS_WAV is set (manual evidence).
+    if let Ok(path) = std::env::var("MUR_TTS_WAV") {
+        write_wav_16k(&path, &samples, 24_000);
+        eprintln!("wrote {path}");
+    }
+}
+
+/// Minimal 16-bit PCM WAV writer (mono).
+fn write_wav_16k(path: &str, samples: &[f32], sample_rate: u32) {
+    use std::io::Write as _;
+    let n = samples.len() as u32;
+    let data_len = n * 2;
+    let mut f = std::fs::File::create(path).unwrap();
+    let mut h = Vec::new();
+    h.extend_from_slice(b"RIFF");
+    h.extend_from_slice(&(36 + data_len).to_le_bytes());
+    h.extend_from_slice(b"WAVE");
+    h.extend_from_slice(b"fmt ");
+    h.extend_from_slice(&16u32.to_le_bytes());
+    h.extend_from_slice(&1u16.to_le_bytes()); // PCM
+    h.extend_from_slice(&1u16.to_le_bytes()); // mono
+    h.extend_from_slice(&sample_rate.to_le_bytes());
+    h.extend_from_slice(&(sample_rate * 2).to_le_bytes()); // byte rate
+    h.extend_from_slice(&2u16.to_le_bytes()); // block align
+    h.extend_from_slice(&16u16.to_le_bytes()); // bits
+    h.extend_from_slice(b"data");
+    h.extend_from_slice(&data_len.to_le_bytes());
+    f.write_all(&h).unwrap();
+    for s in samples {
+        let v = (s.clamp(-1.0, 1.0) * 32767.0) as i16;
+        f.write_all(&v.to_le_bytes()).unwrap();
+    }
+}

--- a/mur-core/src/cmd/agent_voice.rs
+++ b/mur-core/src/cmd/agent_voice.rs
@@ -4,8 +4,18 @@
 //! same shape: when `voice.enabled = true`, the supervisor initialises the
 //! Kokoro TTS engine and the whisper.cpp STT pipeline.
 
-use anyhow::Result;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use futures::StreamExt as _;
+use mur_agent_runtime::voice::download::ModelSpec;
+use mur_agent_runtime::voice::types::{
+    KOKORO_ONNX_SPEC, KOKORO_VOICE_SOURCES, N_VOICES, VOICES_BIN_LEN, VoiceModelPaths, WHISPER_SPEC,
+};
 use mur_common::agent::VoiceId;
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt as _;
 
 use super::agent::{load_profile_for_edit, save_profile};
 
@@ -42,4 +52,137 @@ pub fn cmd_voice_disable(name: &str) -> Result<()> {
     save_profile(&path, &mut profile)?;
     println!("Voice I/O disabled for agent '{name}'.");
     Ok(())
+}
+
+/// Download + verify the voice model weights (whisper STT + Kokoro TTS).
+///
+/// Models live under `~/.mur/models/` and are shared by all agents (`name` is
+/// only used in messages). Each file is streamed from Hugging Face and verified
+/// against a pinned SHA-256. The Kokoro voice style matrix (`kokoro-voices.bin`)
+/// is built locally by concatenating the five per-voice tensors in
+/// `VoiceId::style_index()` order — see `voice::types::KOKORO_VOICE_SOURCES`.
+pub async fn cmd_voice_download(name: &str) -> Result<()> {
+    let home = crate::paths::mur_root(None);
+    println!("Downloading voice models for agent '{name}' (~1.4 GB; SHA-256 verified)…");
+
+    fetch_verify(&home, &WHISPER_SPEC).await?;
+    fetch_verify(&home, &KOKORO_ONNX_SPEC).await?;
+    for spec in KOKORO_VOICE_SOURCES.iter() {
+        fetch_verify(&home, spec).await?;
+    }
+    build_voices_bin(&home)?;
+
+    let paths = VoiceModelPaths::from_mur_root(&home);
+    println!("✓ Voice models ready:");
+    println!("    {}", paths.whisper.display());
+    println!("    {}", paths.kokoro_onnx.display());
+    println!("    {}", paths.kokoro_voices.display());
+    println!("Restart the daemon (`mur daemon stop && mur daemon start`) to load the models.");
+    Ok(())
+}
+
+/// Stream `spec.url` to `~/.mur/models/<subdir>/<name>`, hashing as we go, and
+/// atomically rename once the SHA-256 matches. Skips the download when a cached
+/// file already matches.
+async fn fetch_verify(home: &Path, spec: &ModelSpec) -> Result<PathBuf> {
+    let dir = home.join("models").join(spec.subdir);
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("create models dir {}", dir.display()))?;
+    let final_path = dir.join(spec.name);
+
+    if final_path.exists() && sha256_file(&final_path)? == spec.sha256 {
+        println!("  ✓ {} (cached)", spec.name);
+        return Ok(final_path);
+    }
+
+    print!("  ↓ {} ", spec.name);
+    std::io::stdout().flush().ok();
+
+    let resp = reqwest::get(spec.url)
+        .await
+        .with_context(|| format!("GET {}", spec.url))?
+        .error_for_status()
+        .with_context(|| format!("fetch {}", spec.name))?;
+    let total = resp.content_length().unwrap_or(0);
+
+    let tmp_path = final_path.with_extension("tmp");
+    let mut file = tokio::fs::File::create(&tmp_path)
+        .await
+        .with_context(|| format!("create {}", tmp_path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut downloaded: u64 = 0;
+    let mut last_pct: u64 = 0;
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context("download stream")?;
+        file.write_all(&chunk).await.context("write chunk")?;
+        hasher.update(&chunk);
+        downloaded += chunk.len() as u64;
+        if let Some(pct) = (downloaded * 100).checked_div(total)
+            && pct >= last_pct + 10
+        {
+            print!("{pct}% ");
+            std::io::stdout().flush().ok();
+            last_pct = pct;
+        }
+    }
+    file.flush().await.ok();
+    drop(file);
+
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != spec.sha256 {
+        std::fs::remove_file(&tmp_path).ok();
+        bail!(
+            "sha256 mismatch for {}: expected {}, got {}",
+            spec.name,
+            spec.sha256,
+            actual
+        );
+    }
+    std::fs::rename(&tmp_path, &final_path)
+        .with_context(|| format!("rename {} → {}", tmp_path.display(), final_path.display()))?;
+    println!("done");
+    Ok(final_path)
+}
+
+/// Concatenate the five downloaded per-voice tensors into `kokoro-voices.bin`
+/// (`N_VOICES × 512 × 256` f32), written atomically.
+fn build_voices_bin(home: &Path) -> Result<()> {
+    let voices_dir = home.join("models").join("kokoro").join("voices");
+    let per_voice_len = VOICES_BIN_LEN / N_VOICES;
+    let mut out: Vec<u8> = Vec::with_capacity(VOICES_BIN_LEN);
+
+    for spec in KOKORO_VOICE_SOURCES.iter() {
+        let p = voices_dir.join(spec.name);
+        let bytes = std::fs::read(&p).with_context(|| format!("read {}", p.display()))?;
+        if bytes.len() != per_voice_len {
+            bail!(
+                "voice source {} has unexpected size {} (expected {per_voice_len})",
+                spec.name,
+                bytes.len()
+            );
+        }
+        out.extend_from_slice(&bytes);
+    }
+    if out.len() != VOICES_BIN_LEN {
+        bail!(
+            "assembled voices.bin is {} bytes (expected {VOICES_BIN_LEN})",
+            out.len()
+        );
+    }
+
+    let dest = VoiceModelPaths::from_mur_root(home).kokoro_voices;
+    let tmp = dest.with_extension("tmp");
+    std::fs::write(&tmp, &out).with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, &dest)
+        .with_context(|| format!("rename {} → {}", tmp.display(), dest.display()))?;
+    println!("  ✓ kokoro-voices.bin (built from {N_VOICES} voices)");
+    Ok(())
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut f = std::fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut f, &mut hasher).with_context(|| format!("hash {}", path.display()))?;
+    Ok(format!("{:x}", hasher.finalize()))
 }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1272,9 +1272,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 cmd::agent_voice::cmd_voice_enable(&name, voice_id.as_deref())?
             }
             VoiceAction::Disable => cmd::agent_voice::cmd_voice_disable(&name)?,
-            VoiceAction::Download => {
-                anyhow::bail!("voice download not yet implemented; will ship in D1 Task 3");
-            }
+            VoiceAction::Download => cmd::agent_voice::cmd_voice_download(&name).await?,
         },
         AgentAction::Schedule { action } => match action {
             AgentScheduleAction::Add {

--- a/mur-daemon/Cargo.toml
+++ b/mur-daemon/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 [dependencies]
 mur-common = { path = "../mur-common" }
 mur-core = { path = "../mur-core" }
-mur-agent-runtime = { path = "../mur-agent-runtime" }
+mur-agent-runtime = { path = "../mur-agent-runtime", features = ["tts"] }
 base64 = "0.22"
 mdns-sd = "0.20"
 hostname = "0.4"

--- a/mur-daemon/src/mobile_server.rs
+++ b/mur-daemon/src/mobile_server.rs
@@ -220,15 +220,39 @@ async fn handle_socket(mut socket: WebSocket, state: MobileState) {
                 let home = state.mur_home.clone();
 
                 // STT: whisper.cpp (blocking) → authoritative transcript.
-                let transcript_opt =
+                let outcome =
                     tokio::task::spawn_blocking(move || crate::stt_sink::transcribe(&home, &pcm))
                         .await
-                        .unwrap_or(None);
+                        .unwrap_or(crate::stt_sink::SttOutcome::Empty);
 
-                let transcript_text = match transcript_opt {
-                    Some(t) => t,
-                    None => {
-                        tracing::debug!("mobile: STT returned empty; skipping turn");
+                let transcript_text = match outcome {
+                    crate::stt_sink::SttOutcome::Text(t) => t,
+                    crate::stt_sink::SttOutcome::Empty => {
+                        tracing::debug!("mobile: STT no speech; skipping turn");
+                        continue;
+                    }
+                    crate::stt_sink::SttOutcome::ModelsMissing => {
+                        // Honest feedback instead of a silent drop: tell the user
+                        // how to install the voice model. The phone renders
+                        // `mobile.reply` events as agent chat bubbles.
+                        let hint = format!(
+                            "語音模型尚未安裝。請在 Mac 上執行 `mur agent voice {agent} download`（約 1.4 GB），完成後重啟 daemon 再用語音對話。"
+                        );
+                        tracing::info!("mobile: STT models missing — sent install hint to phone");
+                        mirror(
+                            state.mur_home.as_path(),
+                            &agent,
+                            "mobile.reply",
+                            &json!({ "text": hint }),
+                        );
+                        let _ = send_frame(
+                            &mut socket,
+                            &ServerFrame::Event {
+                                name: "mobile.reply".to_string(),
+                                payload: json!({ "text": hint }),
+                            },
+                        )
+                        .await;
                         continue;
                     }
                 };

--- a/mur-daemon/src/relay_client.rs
+++ b/mur-daemon/src/relay_client.rs
@@ -193,14 +193,29 @@ async fn handle_frame(
         ClientFrame::AudioStreamEnd => {
             let pcm = std::mem::take(audio_buf);
             let home_c = home.to_path_buf();
-            let transcript_opt =
+            let outcome =
                 tokio::task::spawn_blocking(move || crate::stt_sink::transcribe(&home_c, &pcm))
                     .await
-                    .unwrap_or(None);
+                    .unwrap_or(crate::stt_sink::SttOutcome::Empty);
 
-            let text = match transcript_opt {
-                Some(t) => t,
-                None => return Ok(()),
+            let text = match outcome {
+                crate::stt_sink::SttOutcome::Text(t) => t,
+                crate::stt_sink::SttOutcome::Empty => return Ok(()),
+                crate::stt_sink::SttOutcome::ModelsMissing => {
+                    let agent = canonicalize_agent_name(home, "mur");
+                    let hint = format!(
+                        "語音模型尚未安裝。請在 Mac 上執行 `mur agent voice {agent} download`（約 1.4 GB），完成後重啟 daemon 再用語音對話。"
+                    );
+                    relay_send(
+                        write,
+                        &ServerFrame::Event {
+                            name: "mobile.reply".to_string(),
+                            payload: serde_json::json!({ "text": hint }),
+                        },
+                    )
+                    .await?;
+                    return Ok(());
+                }
             };
 
             relay_send(

--- a/mur-daemon/src/stt_sink.rs
+++ b/mur-daemon/src/stt_sink.rs
@@ -1,45 +1,57 @@
 //! Lazy whisper.cpp STT wrapper for the mobile voice server.
-//! Returns `None` silently when the model is absent (first run) or on error.
+//!
+//! Models are a one-time CLI install (`mur agent voice <name> download`); the
+//! daemon never downloads at runtime (privacy invariant). [`transcribe`]
+//! distinguishes "models not installed" from "no speech" so the caller can give
+//! the phone honest feedback instead of silently dropping the turn.
 
-use mur_agent_runtime::voice::{
-    download::ensure_model,
-    stt::WhisperStt,
-    types::{VoiceModelPaths, WHISPER_SPEC},
-};
+use mur_agent_runtime::voice::{stt::WhisperStt, types::VoiceModelPaths};
 use std::path::Path;
 use std::sync::OnceLock;
 
 static STT: OnceLock<Option<WhisperStt>> = OnceLock::new();
 
-/// Transcribe f32 LE PCM (16 kHz mono) bytes → trimmed text.
-/// Returns `None` if the model is absent, the audio is silent, or STT fails.
-pub fn transcribe(mur_home: &Path, pcm_f32le: &[u8]) -> Option<String> {
+/// Result of an STT attempt.
+pub enum SttOutcome {
+    /// Whisper produced non-empty text.
+    Text(String),
+    /// Audio decoded but no speech was recognized (silence / noise).
+    Empty,
+    /// The whisper model is not installed (or failed to initialize). The caller
+    /// should prompt the user to run `mur agent voice <name> download`.
+    ModelsMissing,
+}
+
+/// Transcribe f32 LE PCM (16 kHz mono) bytes.
+pub fn transcribe(mur_home: &Path, pcm_f32le: &[u8]) -> SttOutcome {
+    let paths = VoiceModelPaths::from_mur_root(mur_home);
+    if !paths.whisper.exists() {
+        return SttOutcome::ModelsMissing;
+    }
+
     let stt = STT.get_or_init(|| load_stt(mur_home));
-    let stt = stt.as_ref()?;
+    let Some(stt) = stt.as_ref() else {
+        // Model file exists but init failed (corrupt download, etc.) — treat as
+        // needs-setup so the user re-runs the verified download.
+        return SttOutcome::ModelsMissing;
+    };
+
     let samples: Vec<f32> = pcm_f32le
         .chunks_exact(4)
         .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
         .collect();
     match stt.transcribe(&samples) {
-        Ok(t) if !t.is_empty() => Some(t),
-        Ok(_) => None,
+        Ok(t) if !t.is_empty() => SttOutcome::Text(t),
+        Ok(_) => SttOutcome::Empty,
         Err(e) => {
             tracing::warn!(error = %e, "mobile: STT transcription failed");
-            None
+            SttOutcome::Empty
         }
     }
 }
 
 fn load_stt(mur_home: &Path) -> Option<WhisperStt> {
     let paths = VoiceModelPaths::from_mur_root(mur_home);
-    if !paths.whisper.exists() {
-        let home = mur_home.to_path_buf();
-        std::thread::spawn(move || {
-            let _ = ensure_model(&home, &WHISPER_SPEC, |_, _| {});
-            tracing::info!("mobile: whisper model downloaded — restart daemon to enable voice STT");
-        });
-        return None;
-    }
     match WhisperStt::new(&paths.whisper) {
         Ok(s) => {
             tracing::info!("mobile: WhisperStt ready");

--- a/mur-daemon/src/tts_sink.rs
+++ b/mur-daemon/src/tts_sink.rs
@@ -1,11 +1,13 @@
 //! Lazy Kokoro TTS wrapper for the mobile server.
-//! Returns `None` silently when models are absent (first run) or ONNX Runtime unavailable.
+//!
+//! Returns `None` when models are absent or synthesis fails. Models are a
+//! one-time CLI install (`mur agent voice <name> download`); the daemon never
+//! downloads at runtime (privacy invariant).
 
 use base64::Engine as _;
 use mur_agent_runtime::voice::{
-    download::ensure_model,
     tts::{KOKORO_SAMPLE_RATE, KokoroTts},
-    types::{KOKORO_ONNX_SPEC, KOKORO_VOICES_SPEC, VoiceModelPaths},
+    types::VoiceModelPaths,
 };
 use mur_common::agent::VoiceId;
 use std::path::Path;
@@ -33,22 +35,22 @@ pub fn synthesize(mur_home: &Path, text: &str) -> Option<(String, u32)> {
 
 fn load_tts(mur_home: &Path) -> Option<KokoroTts> {
     let paths = VoiceModelPaths::from_mur_root(mur_home);
-    if !paths.all_present() {
-        let home = mur_home.to_path_buf();
-        std::thread::spawn(move || {
-            let _ = ensure_model(&home, &KOKORO_ONNX_SPEC, |_, _| {});
-            let _ = ensure_model(&home, &KOKORO_VOICES_SPEC, |_, _| {});
-            tracing::info!("mobile: Kokoro models downloaded — restart daemon to enable TTS");
-        });
+    if !paths.kokoro_onnx.exists() || !paths.kokoro_voices.exists() {
+        tracing::info!(
+            "mobile: Kokoro models absent — run `mur agent voice <name> download` to enable TTS"
+        );
         return None;
     }
+
+    // ONNX Runtime is statically linked (ort `download-binaries`), so init can
+    // only succeed or error quickly — no runtime dlopen to hang on.
     match KokoroTts::new(&paths.kokoro_onnx, &paths.kokoro_voices, VoiceId::AfHeart) {
         Ok(t) => {
             tracing::info!("mobile: Kokoro TTS ready");
             Some(t)
         }
         Err(e) => {
-            tracing::warn!(error = %e, "mobile: Kokoro TTS init failed");
+            tracing::warn!(error = %e, "mobile: Kokoro TTS init failed — text-only replies");
             None
         }
     }


### PR DESCRIPTION
Closes the original bug — *\"can't talk to the agent by voice on the phone\"* — and completes the deferred D1 voice pipeline so the agent both **hears** and **speaks**.

## What was broken
- `mur agent voice <name> download` was a `bail!(\"not yet implemented\")` stub; `voice/types.rs` had placeholder URLs/hashes. STT never had a model, so the daemon **silently dropped** every voice utterance.
- TTS had never actually run: `ort` used `load-dynamic`, which `dlopen`s a `libonnxruntime.dylib` that no install path ever provisioned → `KokoroTts::new` hung at 0% CPU in ONNX Runtime env-init.

## What this does
**1. Real `mur agent voice <name> download`** — streams + SHA-256-verifies whisper `large-v3-turbo-q5_0`, Kokoro v0.19 `model_quantized.onnx`, and 5 voice tensors, then builds `kokoro-voices.bin` (`5×512×256` f32) locally. The default **AfHeart** slot is backed by the v0.19 `af` voice: af_heart is v1.0-only and Kokoro style vectors are not portable across model versions, so `af` (its v0.19 lineage) is the version-consistent choice.

**2. Honest failure feedback** — `stt_sink::transcribe` now returns `SttOutcome {Text, Empty, ModelsMissing}` instead of collapsing everything to `None`. On `ModelsMissing` the mobile/relay paths send a `mobile.reply` install hint (rendered as a chat bubble) instead of silently dropping the turn. The daemon's lying background auto-download is removed.

**3. Working Kokoro TTS** — switch `ort` to the default `download-binaries` (static-link the ABI-matched ONNX Runtime) instead of `load-dynamic`. This structurally eliminates the env-init hang, needs no runtime dylib, works offline, and covers all platforms via upstream prebuilts. Also fixes the real v0.19 ONNX I/O contract — inputs `input_ids`/`style`/`speed` (not `tokens`), output `waveform` (not `audio`), `speed` as rank-1 `[1]` — and length-indexes the per-voice style matrix with pad-wrapped tokens.

## Verification
- `mur agent voice mur download` runs end-to-end; all files verify, `kokoro-voices.bin` is exactly 2,621,440 bytes.
- New ignored test `tts_real_model_smoke` (needs downloaded models) synthesizes real audio: 51000 samples @ 24 kHz, rms 0.05, peak 0.43 for *\"Hello, this is a voice test.\"* (`MUR_TTS_WAV=<path>` dumps a playable WAV).
- `cargo clippy -D warnings` + `cargo fmt --check` clean on the three changed crates; runtime + daemon unit tests pass.

## Notes
- Binary size grows ~22 MB (murmurd 10→32 MB) from the static ONNX Runtime — marginal vs the existing binaries, and removes the runtime-dylib provisioning problem entirely.
- Known limitation: `PHONEME_VOCAB` is still the partial English subset (existing `TODO(D1.v2)`); uncommon words degrade. Long replies are truncated to the model's positional range — sentence chunking is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)