### PR TITLE
fix(agent cli): stop murmur multi-agent from double-dispatching `agent cli`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,13 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Scope the cache to the runner image. GitHub image upgrades can
+          # change the bundled MSVC/CMake generator (e.g. VS 17 2022 ->
+          # VS 18 2026); without this, a restored target/ carries a stale
+          # whisper-rs-sys CMakeCache.txt and CMake aborts on generator
+          # mismatch. Keying on ImageVersion forces a fresh build on bump.
+          key: ${{ env.ImageOS }}-${{ env.ImageVersion }}
       - name: Install Linux system deps
         if: runner.os == 'Linux'
         run: |
@@ -143,6 +150,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ env.ImageOS }}-${{ env.ImageVersion }}
       - name: Install Linux system deps
         run: |
           sudo apt-get update
@@ -186,6 +195,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: mur-agent-gui/src-tauri
+          key: ${{ env.ImageOS }}-${{ env.ImageVersion }}
       - uses: actions/setup-node@v4
         with:
           node-version-file: 'mur-agent-gui/ui/.nvmrc'
@@ -245,6 +255,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: mur-hub-gui/src-tauri
+          key: ${{ env.ImageOS }}-${{ env.ImageVersion }}
       - uses: actions/setup-node@v4
         with:
           node-version-file: 'mur-hub-gui/ui/.nvmrc'
@@ -292,6 +303,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ env.ImageOS }}-${{ env.ImageVersion }}
       - name: Install protobuf
         run: brew install protobuf
       - name: Run quick e2e smoke

--- a/mur-core/src/cmd/agent/cli/multiplex.rs
+++ b/mur-core/src/cmd/agent/cli/multiplex.rs
@@ -1,7 +1,8 @@
 //! Multi-agent orchestration for `mur agent cli a b c` — one multiplexer
 //! pane per agent, each running single-name `mur agent cli <name>`.
 
-use std::path::Path;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -155,7 +156,7 @@ pub fn run(names: &[String], resume: bool, auto: bool) -> Result<()> {
     let home = crate::cmd::agent::resolve_mur_home()?;
     let canon = validate(&home, names)?;
     let exe = std::env::current_exe().context("resolve current executable")?;
-    let exe = exe.to_string_lossy().into_owned();
+    let exe = canonical_mur_exe(exe).to_string_lossy().into_owned();
     let backend = detect(|k| std::env::var(k).ok(), on_path).ok_or_else(|| {
         anyhow!(
             "multi-agent split needs a terminal multiplexer.\n\
@@ -163,6 +164,40 @@ pub fn run(names: &[String], resume: bool, auto: bool) -> Result<()> {
         )
     })?;
     execute(backend, &exe, &canon, resume, auto)
+}
+
+/// Normalize the launching binary to the canonical `mur` for pane commands.
+///
+/// Every pane command is built as `<exe> agent cli <name>` (see `pane_argv`),
+/// which is only correct when `<exe>` is the `mur` binary. We may instead be
+/// launched via the `murmur` alias — a symlink to the same binary, BusyBox
+/// convention — in which case `current_exe()` reports the `murmur` path. But
+/// `murmur <args>` already expands to `mur agent cli <args>` (see
+/// `crate::cli::murmur`), so appending `agent cli` would double-dispatch into
+/// `mur agent cli agent cli <name>`, failing with `unknown agent(s): agent,
+/// cli`. That kills the pane process immediately, tmux reaps the now-empty
+/// session, and the trailing `attach-session` reports "no sessions" / exits 1.
+///
+/// Rewrite a `murmur` invocation to its sibling `mur`, preserving directory
+/// and extension. The stem check mirrors `cli::murmur::is_murmur_invocation`,
+/// duplicated here because that module lives in the binary crate only and this
+/// pane-planning code compiles as part of the library crate.
+fn canonical_mur_exe(exe: PathBuf) -> PathBuf {
+    let is_murmur = exe
+        .file_stem()
+        .is_some_and(|s| s.to_string_lossy().eq_ignore_ascii_case("murmur"));
+    if !is_murmur {
+        return exe;
+    }
+    let new_name = match exe.extension() {
+        Some(ext) => {
+            let mut s = OsString::from("mur.");
+            s.push(ext);
+            s
+        }
+        None => OsString::from("mur"),
+    };
+    exe.with_file_name(new_name)
 }
 
 fn execute(backend: Backend, exe: &str, names: &[String], resume: bool, auto: bool) -> Result<()> {
@@ -526,6 +561,38 @@ mod tests {
             "'/Volumes/My Drive/mur'"
         );
         assert_eq!(shell_quote("it's"), r#"'it'\''s'"#);
+    }
+
+    #[test]
+    fn murmur_exe_is_normalized_to_mur_sibling() {
+        // Launched via the `murmur` alias, current_exe() reports the murmur
+        // path. Pane commands must use the sibling `mur`, never `murmur agent
+        // cli …`, which double-dispatches to "unknown agent(s): agent, cli"
+        // and tears down the session before attach.
+        assert_eq!(
+            canonical_mur_exe(PathBuf::from("/opt/homebrew/bin/murmur")),
+            PathBuf::from("/opt/homebrew/bin/mur")
+        );
+        // Case-insensitive stem match (mirrors is_murmur_invocation).
+        assert_eq!(
+            canonical_mur_exe(PathBuf::from("/tools/MURMUR")),
+            PathBuf::from("/tools/mur")
+        );
+        // Extension is preserved (Windows `murmur.exe` → `mur.exe`).
+        assert_eq!(
+            canonical_mur_exe(PathBuf::from("/tools/murmur.exe")),
+            PathBuf::from("/tools/mur.exe")
+        );
+        // A plain `mur` path is left untouched.
+        assert_eq!(
+            canonical_mur_exe(PathBuf::from("/usr/local/bin/mur")),
+            PathBuf::from("/usr/local/bin/mur")
+        );
+        // A non-murmur stem that merely contains "mur" is untouched.
+        assert_eq!(
+            canonical_mur_exe(PathBuf::from("/usr/local/bin/murex")),
+            PathBuf::from("/usr/local/bin/murex")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Multi-agent chat fails to launch — both `murmur a b` and `mur agent cli a b`. Every pane dies instantly and tmux's `attach-session` reports **"no sessions"** (exit 1). Reproduces under iTerm2, Ghostty, etc. — it's terminal-independent.

```
$ murmur mur rustsmith
no sessions
Error: `tmux attach-session -t =mur-chat` exited with exit status: 1
```

## Root cause

`multiplex::run` builds each pane command as `<exe> agent cli <name>` from `std::env::current_exe()`. When launched via the `murmur` alias (a symlink to the same binary), `current_exe()` reports the **`murmur`** path — and `murmur <args>` already expands to `mur agent cli <args>` (see `cli::murmur`). So the pane command becomes:

```
mur agent cli  agent cli  <name>
```

which injects the literal words `agent` and `cli` as agent names → `unknown agent(s): agent, cli` → the pane process exits immediately → tmux reaps the now-empty session → `attach-session` finds nothing.

Instrumented tmux trace from the failing run:

```
tmux new-session  -d -s mur-chat  murmur agent cli mur          -> 0  (created)
tmux split-window -t =mur-chat:.0 murmur agent cli rustsmith    -> 0
tmux select-layout -t =mur-chat:.0 tiled                        -> 0
tmux attach-session -t =mur-chat                                -> 1  ← "no sessions"
```

The existing plan-shape tests passed a hardcoded `/bin/mur`, so they never exercised the `murmur` invocation path.

## Fix

Normalize the resolved executable to the canonical `mur` sibling when invoked as `murmur`, before any pane command is built (`canonical_mur_exe`). Because every backend (tmux / zellij / wezterm / kitty) routes through `pane_argv`, fixing it at the single `exe` source covers all of them.

The stem check mirrors `cli::murmur::is_murmur_invocation`; it's duplicated locally because that module lives in the binary crate while this pane-planning code compiles as part of the library crate.

After the fix, the same run emits `…/mur agent cli <name>`, the detached session stays alive, and `attach` succeeds in a real terminal.

## Tests

- New `murmur_exe_is_normalized_to_mur_sibling` (murmur→mur sibling, case-insensitive stem, extension preserved, plain `mur` and `murex` untouched).
- All 15 `multiplex::` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)