### PR TITLE
chore(release): bump workspace version to 2.24.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6259,7 +6259,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.24.4"
+version = "2.24.5"
 dependencies = [
  "libc",
 ]
@@ -6335,7 +6335,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.24.4"
+version = "2.24.5"
 dependencies = [
  "age",
  "anyhow",
@@ -6383,7 +6383,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.24.4"
+version = "2.24.5"
 dependencies = [
  "blake3",
  "flate2",
@@ -6399,7 +6399,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.24.4"
+version = "2.24.5"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.24.4"
+version = "2.24.5"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6511,7 +6511,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.24.4"
+version = "2.24.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6533,7 +6533,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.24.4"
+version = "2.24.5"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6549,7 +6549,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.24.4"
+version = "2.24.5"
 dependencies = [
  "base64 0.22.1",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.24.4"
+version = "2.24.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"


### PR DESCRIPTION
Release **2.24.5**.

Bumps `[workspace.package].version` 2.24.4 → 2.24.5 (and the 8 workspace members in Cargo.lock).

Ships changes merged after v2.24.4 was published:
- #429 — fix(agent cli): stop murmur multi-agent from double-dispatching `agent cli`
- #428 — ci(release): speed up MuR Hub + Windows builds

After merge, `v2.24.5` will be tagged at main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)