### PR TITLE
feat(channel): v3d-1 — per-event Ed25519 signing + authority-bearing HITL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,13 +116,13 @@ For detailed agent / companion / GUI export / runtime internals, read `docs/arch
 - YAML writes use temp file + rename for atomicity (`store/yaml.rs`)
 - `tracing` for structured logging; enable with `RUST_LOG=debug`
 - Plans live in `plans/` and `docs/superpowers/plans/`. OpenSpec change specs in `openspec/changes/`.
-- **Unified Channel v3a–v3c** implemented on branch `feat/unified-channel-v3b`:
+- **Unified Channel v3a–v3d** implemented on branch `feat/unified-channel-v3b` (v3d on `feat/unified-channel-v3d`):
   - v3a: DAG executor emits attributed `StateChange`/`ToolCall`/`ToolResult` events as `ChannelActor::System`.
   - v3b: Deterministic `idem_key`, `run_id` per workflow run.
   - v3c: Risk-tiered, SHA-256-pinned HITL gate (`mur-common/src/hitl.rs`; `mur-core/src/hitl/`). Steps with `risk: write` or higher pause before execution, write a `HitlRequest` channel event, and wait for `mur channel approve <channel_id> <hitl_id>` (or `--deny`). The executor re-verifies the hash at the execute boundary (fail-closed on drift). `append_event` is dedup-aware (idempotency key under exclusive lock). Crashed runs resume via a `ToolResult` cursor check.
   - `CHANNEL_SCHEMA_VERSION = 2` (v2: `HitlResponse` events carry approval authority).
   - Use `mur workflow run --channel-new <skill>` or `--channel <id>` to attach execution; `mur channel approve <channel_id> <hitl_id> [--deny] [--reason <msg>]` to act on HITL gates.
-  - v3d (signing: `ChannelEvent.sig`/`key_version`) still pending. See `mem:project_unified_channel_pr433`.
+  - v3d: Channel events are Ed25519-signed by the channel's writer (`mur_channel::sign`; `ChannelEvent.sig`/`key_version`), verified on fold. The canonical sign-input EXCLUDES `seq`/`ts`. `MUR_CHANNEL_REQUIRE_SIG` enforces verification (default off = migration-safe: legacy unsigned events tolerated). A2 peer-writes-own (specialist runtimes signing their own events) is the v3d-2 follow-on. See `mem:project_unified_channel_pr433`.
 
 ## Release Process
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6339,7 +6339,9 @@ version = "2.24.5"
 dependencies = [
  "anyhow",
  "chrono",
+ "ed25519-dalek",
  "fs2",
+ "multibase",
  "mur-common",
  "notify",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6349,6 +6349,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "tracing",
  "uuid",
 ]
 

--- a/docs/superpowers/plans/2026-06-16-unified-channel-v3d-event-signing.md
+++ b/docs/superpowers/plans/2026-06-16-unified-channel-v3d-event-signing.md
@@ -1,0 +1,577 @@
+# Unified Channel v3d — Per-Event Signing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> Implements the v3d signing primitive from `2026-06-16-unified-channel-v3-design.md` §7 v3d. Builds on v3a (the reserved `ChannelEvent.sig`/`key_version`) + v3c (the HITL gate that consumes a `HitlResponse`). **The full A2 "peer-writes-own" runtime rework is carved out as v3d-2** (see §scope) — this plan delivers the signing/verify primitive + makes the channel `HitlResponse` authority-bearing, which is what v4b's phone HITL needs.
+
+**Goal:** sign every channel event with the writer's Ed25519 identity at append, and verify-on-fold against the writer's pubkey (resolved through the rotation chain at the event's `key_version`). This closes the v3 trust-model residual ("any local process can append forged events into the shared log") and makes a channel `HitlResponse` **authority-bearing** (a forged response fails verification), unblocking authoritative high-risk approval from the Hub/phone.
+
+**Architecture:** the **writer signs** (A1 sole-writer): the process that appends an event signs the canonical sign-input with the channel's router/owner agent identity (`~/.mur/agents/<router>/identity.key`). The sign-input is the canonical JSON of `{v, channel_id, actor, kind, payload, idempotency_key}` — **excluding the store-assigned `seq` and `ts`** so the caller can sign *before* `append_event` assigns them (this corrects the v3a doc-comment, which wrongly said `seq||ts||actor||kind||payload`). Verify-on-fold recomputes that input and checks `sig` against the writer's pubkey at `key_version` (via `verify_chain` over `rotations.jsonl`). Verification is **advisory during a migration window** (unsigned/legacy events pass with a logged warning), then **enforced** for trust-critical reads (the HITL gate first). `mur-channel` already depends on `mur-common` (where `AgentIdentity` lives), so the crypto stays in `mur-channel` with no new crate edges.
+
+**Tech Stack:** Rust — `mur-common` (`AgentIdentity`/`verify_chain`, already shipped), `mur-channel` (new `sign` module + signed append + verify-on-fold), `mur-core` (wire the writer-signs into the executor/CLI/mobile append paths + verify into the HITL gate). No `mur-agent-runtime` change in this plan (that is v3d-2).
+
+**Scope (this plan = v3d-1, the primitive):**
+- **In:** sign-input canonicalization (corrected); `sign_event`/`verify_event_sig`; signed `append`; rotation-chain pubkey resolution; `verify_log` fold helper; writer-signs wired into the local append paths; verify enforced in the v3c HITL gate; migration flag (advisory→enforce).
+- **Out (→ v3d-2, a separate plan):** A2 "peer-writes-own" — adding `mur-channel` to `mur-agent-runtime`, a `channel/delegate` dispatcher method, and specialists appending+signing their own events. Until v3d-2, delegated-agent events remain **concierge-written + concierge-signed** (A1); the sig proves "the trusted concierge recorded this," which is the anti-forgery property we need now.
+- **Out:** the `task_runner.rs` pre-execution reorder + cached-tail `next_seq` (separate perf/HITL items the v3 spec also parked under v3d).
+
+**Scope guardrails:**
+- Sign-input **excludes `seq`/`ts`** (caller signs before append). **Correct the v3a doc-comment.**
+- Writer signs with the channel's **router/owner agent identity** (A1); verify against that writer's pubkey, NOT the `actor` field's (in A1 the actor may be a specialist the concierge is attributing).
+- Migration: unsigned events are **accepted with a warning** while `MUR_CHANNEL_REQUIRE_SIG` (config) is off; flip to enforce once the log is signed end-to-end.
+- A forged/invalid-sig event on a trust-critical read (HITL) is **dropped fail-closed**.
+
+**Key facts locked during exploration (do not re-derive):**
+- `AgentIdentity` (`mur-common/src/identity.rs`): `load(dir)->Result<Self>` (`:71`), `sign_bytes(&[u8])->[u8;64]` (`:108`), `verifying_key_bytes()->[u8;32]` (`:117`), `pubkey_text()->String` (multibase base58btc, `:121`), `decode_pubkey(text)->[u8;32]` (`:149`). Keys at `<agent_home>/identity.{key,pub}`.
+- Rotation: `RotationAttestation` + `verify_chain(&[RotationAttestation], ChainOptions)->Result<ChainOutcome{head_key_version,head_pubkey,length},ChainError>` (`:416`); chain stored append-only at `<agent_home>/rotations.jsonl`; `profile.identity.key_version` (`agent.rs IdentityConfig`) is the current version.
+- `ChannelEvent.sig: Option<String>` + `key_version: Option<u32>` (`channel.rs:150,154`) — reserved, currently always `None`; `append_event` (`store.rs:73`) hardcodes them `None`. The doc-comment's sign-input (`seq||ts||actor||kind||payload`) is **wrong** and must be corrected.
+- `load_events` (`store.rs:56`) silently skips unparseable lines. Consumers: Hub `work.rs`, CLI `persist.rs`, mobile `mobile.rs::channel_query`, the v3c `hitl/gate.rs` (the trust-critical one), executor `dag.rs` resume cursor.
+- v3c HITL gate (`mur-core/src/hitl/gate.rs`): `wait_for_response` finds a `HitlResponse` event by `hitl_id` and trusts `allow`. This is where authority must become signature-checked.
+- `ed25519_dalek` is already a dep (via `mur-common`); `multibase` is used for pubkey/sig encoding.
+
+---
+
+## File Structure
+
+**Created:**
+- `mur-channel/src/sign.rs` — `sign_input`, `sign_event`, `verify_event_sig`, `resolve_writer_pubkey`, `verify_log`.
+
+**Modified:**
+- `mur-common/src/channel.rs` — correct the `sig` doc-comment (exclude seq/ts; name the canonical input).
+- `mur-channel/src/store.rs` — `append_event` accepts optional `sig`/`key_version`.
+- `mur-channel/src/service.rs` — `append_signed(...)` (sign then append) + `verify_events(...)`.
+- `mur-channel/src/lib.rs` — `pub mod sign;`.
+- `mur-core/src/...` (executor `dag.rs`, CLI `persist.rs`, `mobile.rs`) — route local appends through `append_signed` with the router identity (behind the migration flag).
+- `mur-core/src/hitl/gate.rs` — verify the `HitlResponse` signature (authority-bearing).
+
+---
+
+## Task 1: Canonical sign-input (+ correct the doc-comment)
+
+**Files:**
+- Create: `mur-channel/src/sign.rs`; Modify: `mur-common/src/channel.rs:148-154`, `mur-channel/src/lib.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-channel/src/sign.rs`:
+
+```rust
+//! Per-event Ed25519 signing (v3d). The WRITER signs the canonical sign-input —
+//! `{v, channel_id, actor, kind, payload, idempotency_key}` — EXCLUDING the
+//! store-assigned `seq` and `ts` (the signer does not know `seq`; the store
+//! restamps `ts` under the append lock), so the caller can sign BEFORE append.
+//! Verify-on-fold recomputes this input and checks `sig` against the writer's
+//! pubkey at `key_version` (resolved via the rotation chain).
+
+use mur_common::channel::{ChannelActor, EventKind};
+
+/// Canonicalization version — bump if the sign-input shape changes so an old
+/// signature is never silently checked against a new canonicalization.
+pub const SIG_INPUT_VERSION: u32 = 1;
+
+/// Canonical bytes signed for an event. `serde_json` sorts object keys (no
+/// preserve_order), so this is deterministic for a given input.
+pub fn sign_input(
+    channel_id: &str,
+    actor: &ChannelActor,
+    kind: EventKind,
+    payload: &serde_json::Value,
+    idempotency_key: Option<&str>,
+) -> Vec<u8> {
+    let canon = serde_json::json!({
+        "v": SIG_INPUT_VERSION,
+        "channel_id": channel_id,
+        "actor": actor,
+        "kind": kind,
+        "payload": payload,
+        "idempotency_key": idempotency_key,
+    });
+    serde_json::to_vec(&canon).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sign_input_excludes_seq_ts_and_is_stable() {
+        let actor = ChannelActor::Agent { id: "qa".into() };
+        let p = serde_json::json!({ "text": "hi" });
+        let a = sign_input("c1", &actor, EventKind::Message, &p, Some("k1"));
+        let b = sign_input("c1", &actor, EventKind::Message, &p, Some("k1"));
+        assert_eq!(a, b, "deterministic");
+        // Different channel / payload / key → different input.
+        assert_ne!(a, sign_input("c2", &actor, EventKind::Message, &p, Some("k1")));
+        assert_ne!(a, sign_input("c1", &actor, EventKind::Message, &serde_json::json!({"text":"yo"}), Some("k1")));
+        assert_ne!(a, sign_input("c1", &actor, EventKind::Message, &p, None));
+        // It must NOT contain seq/ts tokens.
+        let s = String::from_utf8_lossy(&a);
+        assert!(!s.contains("\"seq\""));
+        assert!(!s.contains("\"ts\""));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mur-channel sign::tests::sign_input_excludes_seq_ts_and_is_stable` — Expected: FAIL (module not declared).
+
+- [ ] **Step 3: Declare the module + correct the doc-comment**
+
+In `mur-channel/src/lib.rs` add `pub mod sign;`. In `mur-common/src/channel.rs`, replace the `sig` field doc-comment (the wrong `seq||ts||actor||kind||payload`) with:
+
+```rust
+    /// Detached Ed25519 signature (multibase) by the channel's WRITER over the
+    /// canonical sign-input `{v, channel_id, actor, kind, payload,
+    /// idempotency_key}` — EXCLUDING the store-assigned `seq`/`ts` (see
+    /// `mur-channel` `sign::sign_input`). `None` for legacy/unsigned events.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sig: Option<String>,
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p mur-channel sign::` — Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-channel/src/sign.rs mur-channel/src/lib.rs mur-common/src/channel.rs
+git commit -m "feat(channel): canonical event sign-input (excludes seq/ts); fix v3a doc (v3d)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+## Task 2: `sign_event` + `verify_event_sig`
+
+**Files:**
+- Modify: `mur-channel/src/sign.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sign.rs` tests:
+
+```rust
+    use mur_common::identity::AgentIdentity;
+    use tempfile::TempDir;
+
+    #[test]
+    fn sign_then_verify_roundtrips_and_rejects_tamper() {
+        let tmp = TempDir::new().unwrap();
+        let id = AgentIdentity::generate();
+        id.save(tmp.path()).unwrap();
+        let actor = ChannelActor::Agent { id: "mur".into() };
+        let payload = serde_json::json!({ "text": "approved" });
+
+        let sig = sign_event(&id, "c1", &actor, EventKind::HitlResponse, &payload, Some("k1"));
+        let pub_bytes = id.verifying_key_bytes();
+        assert!(verify_event_sig("c1", &actor, EventKind::HitlResponse, &payload, Some("k1"), &sig, &pub_bytes));
+        // Tampered payload → fails.
+        let tampered = serde_json::json!({ "text": "DENIED" });
+        assert!(!verify_event_sig("c1", &actor, EventKind::HitlResponse, &tampered, Some("k1"), &sig, &pub_bytes));
+        // Wrong key → fails.
+        let other = AgentIdentity::generate();
+        assert!(!verify_event_sig("c1", &actor, EventKind::HitlResponse, &payload, Some("k1"), &sig, &other.verifying_key_bytes()));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mur-channel sign::tests::sign_then_verify_roundtrips_and_rejects_tamper` — Expected: FAIL (functions not found).
+
+- [ ] **Step 3: Implement sign/verify**
+
+Add to `sign.rs`:
+
+```rust
+use mur_common::identity::AgentIdentity;
+
+/// Sign an event's canonical input with `identity`; returns the multibase sig.
+pub fn sign_event(
+    identity: &AgentIdentity,
+    channel_id: &str,
+    actor: &ChannelActor,
+    kind: EventKind,
+    payload: &serde_json::Value,
+    idempotency_key: Option<&str>,
+) -> String {
+    let input = sign_input(channel_id, actor, kind, payload, idempotency_key);
+    let sig = identity.sign_bytes(&input);
+    multibase::encode(multibase::Base::Base58Btc, sig)
+}
+
+/// Verify a multibase signature over an event's canonical input against a raw
+/// Ed25519 pubkey. Returns false on any decode/verify failure (fail-closed).
+pub fn verify_event_sig(
+    channel_id: &str,
+    actor: &ChannelActor,
+    kind: EventKind,
+    payload: &serde_json::Value,
+    idempotency_key: Option<&str>,
+    sig_multibase: &str,
+    pubkey: &[u8; 32],
+) -> bool {
+    let Ok((_b, sig_bytes)) = multibase::decode(sig_multibase) else { return false };
+    let Ok(sig_arr): Result<[u8; 64], _> = sig_bytes.as_slice().try_into() else { return false };
+    let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
+    let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(pubkey) else { return false };
+    let input = sign_input(channel_id, actor, kind, payload, idempotency_key);
+    use ed25519_dalek::Verifier;
+    vk.verify(&input, &sig).is_ok()
+}
+```
+
+(Add `ed25519_dalek` + `multibase` to `mur-channel/Cargo.toml` if not already present — `grep -n "ed25519\|multibase" mur-channel/Cargo.toml`; both are transitively available via `mur-common`, add explicit deps if the crate doesn't see them.)
+
+- [ ] **Step 4: Run + commit**
+
+Run: `cargo test -p mur-channel sign::` — Expected: PASS.
+
+```bash
+git add mur-channel/src/sign.rs mur-channel/Cargo.toml
+git commit -m "feat(channel): sign_event/verify_event_sig (Ed25519 over sign-input) (v3d)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+## Task 3: Signed append
+
+**Files:**
+- Modify: `mur-channel/src/store.rs` (`append_event` gains sig/key_version), `mur-channel/src/service.rs` (`append_signed`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `service.rs` tests:
+
+```rust
+    #[test]
+    fn append_signed_stores_verifiable_sig() {
+        let tmp = TempDir::new().unwrap();
+        let id = mur_common::identity::AgentIdentity::generate();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("signed").unwrap();
+        let ev = svc.append_signed(
+            &ch.id, &id, 0,
+            ChannelActor::Agent { id: "mur".into() },
+            EventKind::Message,
+            serde_json::json!({ "text": "hi" }),
+            None,
+        ).unwrap();
+        assert!(ev.sig.is_some());
+        assert_eq!(ev.key_version, Some(0));
+        // The stored sig verifies against the signer's pubkey.
+        let loaded = svc.load_events(&ch.id).unwrap();
+        let e = &loaded[0];
+        assert!(crate::sign::verify_event_sig(
+            &ch.id, &e.actor, e.kind, &e.payload, e.idempotency_key.as_deref(),
+            e.sig.as_ref().unwrap(), &id.verifying_key_bytes()
+        ));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mur-channel service::tests::append_signed_stores_verifiable_sig` — Expected: FAIL (no `append_signed`).
+
+- [ ] **Step 3: Extend `append_event` + add `append_signed`**
+
+In `store.rs`, change `append_event` to accept the two optional fields (add params at the end, default `None` from existing callers). Replace its signature + the `ChannelEvent` literal:
+
+```rust
+    pub fn append_event(
+        &self,
+        id: &str,
+        actor: ChannelActor,
+        kind: EventKind,
+        payload: serde_json::Value,
+        idempotency_key: Option<String>,
+        sig: Option<String>,
+        key_version: Option<u32>,
+    ) -> Result<ChannelEvent> {
+        // … unchanged lock + dedup + next_seq …
+        let ev = ChannelEvent { seq: next_seq, ts: Utc::now(), actor, kind, payload, idempotency_key, sig, key_version };
+        // … unchanged write + unlock …
+    }
+```
+
+Update the existing `append_event` call sites (in `service.rs::append`) to pass `None, None`. (`grep -n "append_event(" mur-channel/src` to find them — only `service.rs::append` and tests.)
+
+In `service.rs`, add:
+
+```rust
+    /// Sign an event with `identity` (key_version `kv`) and append it. Used by
+    /// the channel's writer (the router/owner) so the log is forgery-resistant.
+    pub fn append_signed(
+        &self,
+        channel_id: &str,
+        identity: &mur_common::identity::AgentIdentity,
+        kv: u32,
+        actor: ChannelActor,
+        kind: EventKind,
+        payload: serde_json::Value,
+        idempotency_key: Option<String>,
+    ) -> Result<ChannelEvent> {
+        let sig = crate::sign::sign_event(identity, channel_id, &actor, kind, &payload, idempotency_key.as_deref());
+        let ev = self.store.append_event(
+            channel_id, actor, kind, payload, idempotency_key, Some(sig), Some(kv),
+        )?;
+        if let Ok(mut ch) = self.store.load_manifest(channel_id) {
+            ch.updated_at = ev.ts;
+            self.store.save_manifest(&ch)?;
+            self.index.upsert(&ch)?;
+        }
+        Ok(ev)
+    }
+```
+
+(Make `append` delegate to `append_event(..., None, None)` for the unsigned path; both stay.)
+
+- [ ] **Step 4: Run + commit**
+
+Run: `cargo test -p mur-channel` — Expected: PASS (new + existing; existing callers now pass `None,None`).
+
+```bash
+git add mur-channel/src/store.rs mur-channel/src/service.rs
+git commit -m "feat(channel): append_signed — sign-on-append with writer identity (v3d)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+## Task 4: Writer-pubkey resolution + verify-on-fold
+
+**Files:**
+- Modify: `mur-channel/src/sign.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sign.rs` tests:
+
+```rust
+    #[test]
+    fn verify_log_drops_forged_keeps_valid_and_tolerates_legacy() {
+        let tmp = TempDir::new().unwrap();
+        let writer = AgentIdentity::generate();
+        let svc_home = tmp.path();
+        // Build three events: a valid signed one, a forged (wrong-key) one, and a
+        // legacy unsigned one.
+        let actor = ChannelActor::Agent { id: "mur".into() };
+        let p = serde_json::json!({ "text": "ok" });
+        let good_sig = sign_event(&writer, "c1", &actor, EventKind::Message, &p, None);
+        let forged_sig = sign_event(&AgentIdentity::generate(), "c1", &actor, EventKind::Message, &p, None);
+        let mk = |sig: Option<String>| mur_common::channel::ChannelEvent {
+            seq: 0, ts: chrono::Utc::now(), actor: actor.clone(),
+            kind: EventKind::Message, payload: p.clone(), idempotency_key: None,
+            sig, key_version: sig_kv(),
+        };
+        let _ = svc_home;
+        let pubkey = writer.verifying_key_bytes();
+        // valid
+        assert!(verify_one("c1", &mk(Some(good_sig)), &pubkey, false));
+        // forged → fails (enforce or not, a present-but-bad sig is always rejected)
+        assert!(!verify_one("c1", &mk(Some(forged_sig)), &pubkey, false));
+        // legacy unsigned: tolerated when !require_sig, rejected when require_sig
+        assert!(verify_one("c1", &mk(None), &pubkey, false));
+        assert!(!verify_one("c1", &mk(None), &pubkey, true));
+    }
+    fn sig_kv() -> Option<u32> { Some(0) }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mur-channel sign::tests::verify_log_drops_forged_keeps_valid_and_tolerates_legacy` — Expected: FAIL (`verify_one` not found).
+
+- [ ] **Step 3: Implement resolution + verify**
+
+Add to `sign.rs`:
+
+```rust
+use mur_common::channel::ChannelEvent;
+use std::path::Path;
+
+/// Verify a single event against a known writer pubkey. A present sig must be
+/// valid (always). A missing sig is tolerated only when `!require_sig`.
+pub fn verify_one(channel_id: &str, ev: &ChannelEvent, writer_pubkey: &[u8; 32], require_sig: bool) -> bool {
+    match ev.sig.as_deref() {
+        Some(sig) => verify_event_sig(
+            channel_id, &ev.actor, ev.kind, &ev.payload, ev.idempotency_key.as_deref(), sig, writer_pubkey,
+        ),
+        None => !require_sig,
+    }
+}
+
+/// Resolve the writer's pubkey for a given `key_version` by folding the agent's
+/// rotation chain (`<agent_home>/rotations.jsonl`). Falls back to the current
+/// `identity.pub` when no chain / version match (single-host bootstrap).
+pub fn resolve_writer_pubkey(agent_home: &Path, key_version: Option<u32>) -> Option<[u8; 32]> {
+    use mur_common::identity::{decode_pubkey, verify_chain, ChainOptions, RotationAttestation};
+    let chain_path = agent_home.join("rotations.jsonl");
+    if let Ok(text) = std::fs::read_to_string(&chain_path) {
+        let chain: Vec<RotationAttestation> = text
+            .lines().filter(|l| !l.trim().is_empty())
+            .filter_map(|l| serde_json::from_str(l).ok())
+            .collect();
+        if let Ok(outcome) = verify_chain(&chain, ChainOptions { allow_emergency: false }) {
+            // For the head version use head_pubkey; for older versions, find the
+            // attestation whose new_key_version matches.
+            if key_version == Some(outcome.head_key_version) || key_version.is_none() {
+                if let Ok(b) = decode_pubkey(&outcome.head_pubkey) { return Some(b); }
+            }
+            if let Some(kv) = key_version {
+                if let Some(att) = chain.iter().find(|a| a.new_key_version == kv) {
+                    if let Ok(b) = decode_pubkey(&att.new_pubkey) { return Some(b); }
+                }
+            }
+        }
+    }
+    // Fallback: current identity.pub.
+    let txt = std::fs::read_to_string(agent_home.join("identity.pub")).ok()?;
+    decode_pubkey(txt.trim()).ok()
+}
+
+/// Verify-on-fold: filter a log to the events that pass verification against the
+/// channel's writer. Forged (bad-sig) events are dropped + logged; unsigned
+/// events pass only when `!require_sig`.
+pub fn verify_log(channel_id: &str, events: Vec<ChannelEvent>, writer_pubkey: &[u8; 32], require_sig: bool) -> Vec<ChannelEvent> {
+    events.into_iter().filter(|ev| {
+        let ok = verify_one(channel_id, ev, writer_pubkey, require_sig);
+        if !ok { tracing::warn!(channel = channel_id, seq = ev.seq, "dropping unverifiable channel event"); }
+        ok
+    }).collect()
+}
+```
+
+- [ ] **Step 4: Run + commit**
+
+Run: `cargo test -p mur-channel sign::` — Expected: PASS.
+
+```bash
+git add mur-channel/src/sign.rs
+git commit -m "feat(channel): verify-on-fold + rotation-chain pubkey resolution (v3d)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+## Task 5: Wire writer-signs + verify the HITL response (authority)
+
+**Files:**
+- Modify: `mur-core/src/hitl/gate.rs`; the local append writers (`executor/dag.rs`, `cmd/agent/cli/persist.rs`, `mobile.rs`); a config flag.
+
+- [ ] **Step 1: Writer-signs on the local append paths (behind the migration flag)**
+
+Add a `mur-core` helper that resolves the channel's router/owner identity and signs:
+
+```rust
+// mur-core/src/channel_writer.rs (new): load the router agent's identity once and
+// append signed. The router is the channel owner agent ("mur" for the concierge);
+// for a workflow channel the executing agent. Falls back to unsigned append if the
+// identity is unavailable (migration-safe).
+pub fn append_as_writer(
+    svc: &mur_channel::ChannelService, home: &std::path::Path, channel_id: &str, router_agent: &str,
+    actor: mur_common::channel::ChannelActor, kind: mur_common::channel::EventKind,
+    payload: serde_json::Value, idem: Option<String>,
+) -> anyhow::Result<mur_common::channel::ChannelEvent> {
+    let agent_home = home.join("agents").join(router_agent);
+    if let Ok(id) = mur_common::identity::AgentIdentity::load(&agent_home) {
+        let kv = read_key_version(&agent_home).unwrap_or(0);
+        return svc.append_signed(channel_id, &id, kv, actor, kind, payload, idem);
+    }
+    svc.append(channel_id, actor, kind, payload, idem) // unsigned fallback
+}
+```
+
+Route the existing local appends (executor `dag.rs` step events + delegation, CLI `persist.rs`, `mobile.rs::persist_mobile_exchange`, the v3c gate's `HitlRequest`/`HitlResponse`) through `append_as_writer` with the channel's router agent. (Mechanical: replace `svc.append(...)`/`svc.append_message(...)` at the writer sites; reads are unchanged.)
+
+- [ ] **Step 2: Verify the `HitlResponse` signature in the gate**
+
+In `mur-core/src/hitl/gate.rs::wait_for_response`, when a matching `HitlResponse` is found, verify its sig before trusting `allow` (fail-closed when `MUR_CHANNEL_REQUIRE_SIG` is on). Resolve the approver pubkey: for a phone approval, the paired phone pubkey; for a local CLI/Hub approval, the local human/router. v3d-1 verifies against the **channel writer** (the router that wrote it); a phone-originated response is the v4b/v4c + paired-pubkey path (note it):
+
+```rust
+            // Authority check (v3d): a present sig must verify against the writer;
+            // unsigned tolerated only while require_sig is off (migration).
+            let require = std::env::var("MUR_CHANNEL_REQUIRE_SIG").is_ok();
+            let writer_pub = mur_channel::sign::resolve_writer_pubkey(&home.join("agents").join("mur"), resp.key_version);
+            if let Some(pk) = writer_pub {
+                if !mur_channel::sign::verify_one(channel_id, resp, &pk, require) {
+                    tracing::warn!("HitlResponse failed signature verification — ignoring");
+                    continue; // keep waiting; a forged response cannot release the gate
+                }
+            }
+```
+
+> Note: in v3d-1 the writer (concierge/router) signs the `HitlResponse` it records on the human's behalf (local trust). Phone-originated authoritative responses (signed by the paired phone key) are wired when v4c adds the phone write path — the gate's resolver is extended to also try the paired-pubkey set then.
+
+- [ ] **Step 3: Build + test**
+
+Run:
+```bash
+cargo build -p mur-core
+cargo nextest run -p mur-channel -p mur-core
+```
+Expected: green. With `MUR_CHANNEL_REQUIRE_SIG` unset, legacy/unsigned logs still work (migration-safe).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/channel_writer.rs mur-core/src/hitl/gate.rs mur-core/src/executor/dag.rs mur-core/src/cmd/agent/cli/persist.rs mur-core/src/mobile.rs mur-core/src/lib.rs
+git commit -m "feat(hitl): writer-signs channel events; gate verifies HitlResponse (v3d)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+## Task 6: Quality gates + docs + flag rollout
+
+- [ ] **Step 1: Gates**
+
+```bash
+cargo fmt && cargo fmt --check
+cargo clippy -p mur-common -p mur-channel -p mur-core -- -D warnings
+cargo nextest run -p mur-common -p mur-channel -p mur-core
+```
+
+- [ ] **Step 2: Migration check (advisory → enforce)**
+
+```bash
+# 1. With sig OFF (default), exercise a workflow/chat → events now carry a sig.
+mur agent cli mur   # send a turn; then:
+tail -2 ~/.mur/channels/*/events.jsonl   # expect "sig":"z…","key_version":0
+# 2. Confirm verify-on-fold tolerates a pre-v3d (unsigned) channel without dropping turns.
+# 3. Flip enforce and confirm a hand-forged event is dropped:
+MUR_CHANNEL_REQUIRE_SIG=1 mur internals reindex   # forged/unsigned Agent lines dropped+warned
+```
+
+- [ ] **Step 3: Docs + memory**
+
+- `CLAUDE.md`: note channel events are Ed25519-signed by the writer (v3d); `MUR_CHANNEL_REQUIRE_SIG` enforces verify-on-fold. Sign-input excludes seq/ts.
+- Memory: v3d-1 (signing primitive + verify + HITL authority) done on `feat/unified-channel-v3b`; **v3d-2 (A2 peer-writes-own: runtime `mur-channel` dep + `channel/delegate` method + specialists sign their own events) is the remaining piece**, plus the `task_runner` pre-exec reorder + cached-tail `next_seq`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: per-event channel signing + MUR_CHANNEL_REQUIRE_SIG (v3d)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (`2026-06-16-unified-channel-v3-design.md` §7 v3d):**
+- "sign-on-append via AgentIdentity::sign_bytes over {channel_id,actor,kind,payload,idempotency_key} EXCLUDING seq/ts" → Tasks 1-3; **corrects the v3a doc-comment** that wrongly included seq/ts. ✓
+- "verify-on-fold against identity.pub resolved by key_version through verify_chain; drop forged/unsigned at fold with logged anomaly" → Task 4 (`resolve_writer_pubkey` + `verify_log`/`verify_one`). ✓
+- "unlocks authority-bearing channel HitlResponse" → Task 5 (gate verifies the response sig). ✓ (phone-paired-key authority noted as the v4c wire-up.)
+- "unlocks A2 peer-writes-own" → **explicitly carved out to v3d-2** (runtime `mur-channel` dep + `channel/delegate` method + specialist signs). v3d-1 keeps A1 (writer/concierge signs), which already delivers the anti-forgery property. Flagged. ✓
+- "task_runner reorder + cached-tail next_seq" → out of scope (parked), per §scope. ✓
+
+**2. Placeholder scan:** No "TBD"/"handle later". The crypto core (sign-input, sign/verify, signed append, verify-on-fold) is complete code. Task 5's writer-site rewiring is mechanical ("replace `svc.append` at the writer sites") with the helper given; a `grep` locates the sites. The A2 rework is a named deferral (v3d-2), not a placeholder.
+
+**3. Type consistency:**
+- `sign_input(channel_id, actor, kind, payload, idempotency_key)` (Task 1) reused by `sign_event`/`verify_event_sig` (Task 2) and `verify_one`/`verify_log` (Task 4) with identical argument order.
+- `append_event` gains `sig: Option<String>, key_version: Option<u32>` (Task 3) — all existing callers updated to pass `None, None`; `append_signed` passes `Some(sig), Some(kv)`.
+- `verify_event_sig(..., sig_multibase: &str, pubkey: &[u8;32]) -> bool` and `resolve_writer_pubkey(agent_home, key_version) -> Option<[u8;32]>` compose in `verify_one`/the gate (Task 5).
+- Pubkey is `[u8;32]` everywhere (`verifying_key_bytes` / `decode_pubkey`); sig is multibase `String`.
+
+**4. Scope check:** v3d-1 = the signing primitive + verify + HITL authority, in `mur-common`/`mur-channel`/`mur-core` (no runtime change). The crypto core is fully unit-tested; the writer-rewiring + gate verify are build/integration-verified with a migration flag (advisory→enforce) so it ships without breaking pre-v3d logs. A2 peer-writes-own (the runtime-touching half) is a named follow-on (v3d-2). Focused. ✓
+
+No gaps found.

--- a/mur-channel/Cargo.toml
+++ b/mur-channel/Cargo.toml
@@ -16,6 +16,7 @@ uuid = { workspace = true }
 notify = { workspace = true }
 ed25519-dalek = { version = "2", features = ["rand_core", "pkcs8", "pem"] }
 multibase = "0.9"
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/mur-channel/Cargo.toml
+++ b/mur-channel/Cargo.toml
@@ -14,6 +14,8 @@ fs2 = { workspace = true }
 rusqlite = { workspace = true }
 uuid = { workspace = true }
 notify = { workspace = true }
+ed25519-dalek = { version = "2", features = ["rand_core", "pkcs8", "pem"] }
+multibase = "0.9"
 
 [dev-dependencies]
 tempfile = "3"

--- a/mur-channel/src/lib.rs
+++ b/mur-channel/src/lib.rs
@@ -3,6 +3,7 @@
 //! (`mur-core`) and the Hub (`mur-hub-gui`).
 pub mod index;
 pub mod service;
+pub mod sign;
 pub mod store;
 pub mod watch;
 

--- a/mur-channel/src/service.rs
+++ b/mur-channel/src/service.rs
@@ -96,7 +96,7 @@ impl ChannelService {
         }
         let ev = self
             .store
-            .append_event(channel_id, actor, kind, payload, None)?;
+            .append_event(channel_id, actor, kind, payload, None, None, None)?;
         if let Ok(mut ch) = self.store.load_manifest(channel_id) {
             ch.updated_at = ev.ts;
             self.store.save_manifest(&ch)?;
@@ -134,9 +134,53 @@ impl ChannelService {
         payload: serde_json::Value,
         idempotency_key: Option<String>,
     ) -> Result<ChannelEvent> {
-        let ev = self
-            .store
-            .append_event(channel_id, actor, kind, payload, idempotency_key)?;
+        let ev = self.store.append_event(
+            channel_id,
+            actor,
+            kind,
+            payload,
+            idempotency_key,
+            None,
+            None,
+        )?;
+        if let Ok(mut ch) = self.store.load_manifest(channel_id) {
+            ch.updated_at = ev.ts;
+            self.store.save_manifest(&ch)?;
+            self.index.upsert(&ch)?;
+        }
+        Ok(ev)
+    }
+
+    /// Sign an event with `identity` (key_version `kv`) and append it. Used by
+    /// the channel's writer (the router/owner) so the log is forgery-resistant.
+    #[allow(clippy::too_many_arguments)]
+    pub fn append_signed(
+        &self,
+        channel_id: &str,
+        identity: &mur_common::identity::AgentIdentity,
+        kv: u32,
+        actor: ChannelActor,
+        kind: EventKind,
+        payload: serde_json::Value,
+        idempotency_key: Option<String>,
+    ) -> Result<ChannelEvent> {
+        let sig = crate::sign::sign_event(
+            identity,
+            channel_id,
+            &actor,
+            kind,
+            &payload,
+            idempotency_key.as_deref(),
+        );
+        let ev = self.store.append_event(
+            channel_id,
+            actor,
+            kind,
+            payload,
+            idempotency_key,
+            Some(sig),
+            Some(kv),
+        )?;
         if let Ok(mut ch) = self.store.load_manifest(channel_id) {
             ch.updated_at = ev.ts;
             self.store.save_manifest(&ch)?;
@@ -185,9 +229,15 @@ impl ChannelService {
             "from": state_str(old_state),
             "to":   state_str(new_state),
         });
-        let ev =
-            self.store
-                .append_event(channel_id, actor, EventKind::StateChange, payload, None)?;
+        let ev = self.store.append_event(
+            channel_id,
+            actor,
+            EventKind::StateChange,
+            payload,
+            None,
+            None,
+            None,
+        )?;
         if let Ok(mut ch) = self.store.load_manifest(channel_id) {
             ch.state = new_state;
             ch.updated_at = ev.ts;
@@ -279,6 +329,38 @@ mod tests {
             svc.store().load_manifest(&ch.id).unwrap().state,
             ChannelState::Completed
         );
+    }
+
+    #[test]
+    fn append_signed_stores_verifiable_sig() {
+        let tmp = TempDir::new().unwrap();
+        let id = mur_common::identity::AgentIdentity::generate();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("signed").unwrap();
+        let ev = svc
+            .append_signed(
+                &ch.id,
+                &id,
+                0,
+                ChannelActor::Agent { id: "mur".into() },
+                EventKind::Message,
+                serde_json::json!({ "text": "hi" }),
+                None,
+            )
+            .unwrap();
+        assert!(ev.sig.is_some());
+        assert_eq!(ev.key_version, Some(0));
+        let loaded = svc.load_events(&ch.id).unwrap();
+        let e = &loaded[0];
+        assert!(crate::sign::verify_event_sig(
+            &ch.id,
+            &e.actor,
+            e.kind,
+            &e.payload,
+            e.idempotency_key.as_deref(),
+            e.sig.as_ref().unwrap(),
+            &id.verifying_key_bytes()
+        ));
     }
 
     #[test]

--- a/mur-channel/src/service.rs
+++ b/mur-channel/src/service.rs
@@ -20,6 +20,23 @@ struct DelegationPayload<'a> {
     parent_channel_id: &'a str,
 }
 
+/// Build the canonical `Delegation` event payload (single-sourced schema). Used
+/// by [`ChannelService::append_delegation`] and by writers that want to SIGN the
+/// delegation event via `append_signed` (v3d) without duplicating the shape.
+/// Infallible: serializing a `&str`-only struct cannot fail.
+pub fn delegation_payload(
+    parent_channel_id: &str,
+    target_agent: &str,
+    child_task_id: &str,
+) -> serde_json::Value {
+    serde_json::to_value(DelegationPayload {
+        target_agent,
+        child_task_id,
+        parent_channel_id,
+    })
+    .expect("DelegationPayload serializes")
+}
+
 /// The single API both the CLI and the Hub call. Keeps the log + the index in
 /// sync on every mutation.
 fn state_str(s: ChannelState) -> &'static str {
@@ -199,11 +216,7 @@ impl ChannelService {
         child_task_id: &str,
         idempotency_key: Option<String>,
     ) -> Result<ChannelEvent> {
-        let payload = serde_json::to_value(DelegationPayload {
-            target_agent,
-            child_task_id,
-            parent_channel_id: channel_id,
-        })?;
+        let payload = delegation_payload(channel_id, target_agent, child_task_id);
         self.append(
             channel_id,
             ChannelActor::System,

--- a/mur-channel/src/sign.rs
+++ b/mur-channel/src/sign.rs
@@ -1,0 +1,64 @@
+//! Per-event Ed25519 signing (v3d). The WRITER signs the canonical sign-input —
+//! `{v, channel_id, actor, kind, payload, idempotency_key}` — EXCLUDING the
+//! store-assigned `seq` and `ts` (the signer does not know `seq`; the store
+//! restamps `ts` under the append lock), so the caller can sign BEFORE append.
+//! Verify-on-fold recomputes this input and checks `sig` against the writer's
+//! pubkey at `key_version` (resolved via the rotation chain).
+
+use mur_common::channel::{ChannelActor, EventKind};
+
+/// Canonicalization version — bump if the sign-input shape changes so an old
+/// signature is never silently checked against a new canonicalization.
+pub const SIG_INPUT_VERSION: u32 = 1;
+
+/// Canonical bytes signed for an event. `serde_json` sorts object keys (no
+/// preserve_order), so this is deterministic for a given input.
+pub fn sign_input(
+    channel_id: &str,
+    actor: &ChannelActor,
+    kind: EventKind,
+    payload: &serde_json::Value,
+    idempotency_key: Option<&str>,
+) -> Vec<u8> {
+    let canon = serde_json::json!({
+        "v": SIG_INPUT_VERSION,
+        "channel_id": channel_id,
+        "actor": actor,
+        "kind": kind,
+        "payload": payload,
+        "idempotency_key": idempotency_key,
+    });
+    serde_json::to_vec(&canon).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sign_input_excludes_seq_ts_and_is_stable() {
+        let actor = ChannelActor::Agent { id: "qa".into() };
+        let p = serde_json::json!({ "text": "hi" });
+        let a = sign_input("c1", &actor, EventKind::Message, &p, Some("k1"));
+        let b = sign_input("c1", &actor, EventKind::Message, &p, Some("k1"));
+        assert_eq!(a, b, "deterministic");
+        assert_ne!(
+            a,
+            sign_input("c2", &actor, EventKind::Message, &p, Some("k1"))
+        );
+        assert_ne!(
+            a,
+            sign_input(
+                "c1",
+                &actor,
+                EventKind::Message,
+                &serde_json::json!({"text":"yo"}),
+                Some("k1")
+            )
+        );
+        assert_ne!(a, sign_input("c1", &actor, EventKind::Message, &p, None));
+        let s = String::from_utf8_lossy(&a);
+        assert!(!s.contains("\"seq\""));
+        assert!(!s.contains("\"ts\""));
+    }
+}

--- a/mur-channel/src/sign.rs
+++ b/mur-channel/src/sign.rs
@@ -5,8 +5,9 @@
 //! Verify-on-fold recomputes this input and checks `sig` against the writer's
 //! pubkey at `key_version` (resolved via the rotation chain).
 
-use mur_common::channel::{ChannelActor, EventKind};
+use mur_common::channel::{ChannelActor, ChannelEvent, EventKind};
 use mur_common::identity::AgentIdentity;
+use std::path::Path;
 
 /// Canonicalization version — bump if the sign-input shape changes so an old
 /// signature is never silently checked against a new canonicalization.
@@ -70,6 +71,88 @@ pub fn verify_event_sig(
     let input = sign_input(channel_id, actor, kind, payload, idempotency_key);
     use ed25519_dalek::Verifier;
     vk.verify(&input, &sig).is_ok()
+}
+
+/// Verify a single event against a known writer pubkey. A present sig must be
+/// valid (always). A missing sig is tolerated only when `!require_sig`.
+pub fn verify_one(
+    channel_id: &str,
+    ev: &ChannelEvent,
+    writer_pubkey: &[u8; 32],
+    require_sig: bool,
+) -> bool {
+    match ev.sig.as_deref() {
+        Some(sig) => verify_event_sig(
+            channel_id,
+            &ev.actor,
+            ev.kind,
+            &ev.payload,
+            ev.idempotency_key.as_deref(),
+            sig,
+            writer_pubkey,
+        ),
+        None => !require_sig,
+    }
+}
+
+/// Resolve the writer's pubkey for a given `key_version` by folding the agent's
+/// rotation chain (`<agent_home>/rotations.jsonl`). Falls back to the current
+/// `identity.pub` when no chain / version match (single-host bootstrap).
+pub fn resolve_writer_pubkey(agent_home: &Path, key_version: Option<u32>) -> Option<[u8; 32]> {
+    use mur_common::identity::{ChainOptions, RotationAttestation, decode_pubkey, verify_chain};
+    let chain_path = agent_home.join("rotations.jsonl");
+    if let Ok(text) = std::fs::read_to_string(&chain_path) {
+        let chain: Vec<RotationAttestation> = text
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .filter_map(|l| serde_json::from_str(l).ok())
+            .collect();
+        if let Ok(outcome) = verify_chain(
+            &chain,
+            ChainOptions {
+                allow_emergency: false,
+            },
+        ) {
+            if (key_version == Some(outcome.head_key_version) || key_version.is_none())
+                && let Ok(b) = decode_pubkey(&outcome.head_pubkey)
+            {
+                return Some(b);
+            }
+            if let Some(kv) = key_version
+                && let Some(att) = chain.iter().find(|a| a.new_key_version == kv)
+                && let Ok(b) = decode_pubkey(&att.new_pubkey)
+            {
+                return Some(b);
+            }
+        }
+    }
+    let txt = std::fs::read_to_string(agent_home.join("identity.pub")).ok()?;
+    decode_pubkey(txt.trim()).ok()
+}
+
+/// Verify-on-fold: filter a log to the events that pass verification against the
+/// channel's writer. Forged (bad-sig) events are dropped + logged; unsigned
+/// events pass only when `!require_sig`.
+pub fn verify_log(
+    channel_id: &str,
+    events: Vec<ChannelEvent>,
+    writer_pubkey: &[u8; 32],
+    require_sig: bool,
+) -> Vec<ChannelEvent> {
+    events
+        .into_iter()
+        .filter(|ev| {
+            let ok = verify_one(channel_id, ev, writer_pubkey, require_sig);
+            if !ok {
+                tracing::warn!(
+                    channel = channel_id,
+                    seq = ev.seq,
+                    "dropping unverifiable channel event"
+                );
+            }
+            ok
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -154,5 +237,39 @@ mod tests {
             &sig,
             &other.verifying_key_bytes()
         ));
+    }
+
+    #[test]
+    fn verify_one_keeps_valid_drops_forged_tolerates_legacy() {
+        let writer = AgentIdentity::generate();
+        let actor = ChannelActor::Agent { id: "mur".into() };
+        let p = serde_json::json!({ "text": "ok" });
+        let good_sig = sign_event(&writer, "c1", &actor, EventKind::Message, &p, None);
+        let forged_sig = sign_event(
+            &AgentIdentity::generate(),
+            "c1",
+            &actor,
+            EventKind::Message,
+            &p,
+            None,
+        );
+        let mk = |sig: Option<String>| ChannelEvent {
+            seq: 0,
+            ts: chrono::Utc::now(),
+            actor: actor.clone(),
+            kind: EventKind::Message,
+            payload: p.clone(),
+            idempotency_key: None,
+            sig,
+            key_version: Some(0),
+        };
+        let pubkey = writer.verifying_key_bytes();
+        // valid signed → kept (any require_sig)
+        assert!(verify_one("c1", &mk(Some(good_sig)), &pubkey, false));
+        // forged signed → rejected (present-but-bad sig always fails)
+        assert!(!verify_one("c1", &mk(Some(forged_sig)), &pubkey, false));
+        // legacy unsigned → tolerated iff !require_sig
+        assert!(verify_one("c1", &mk(None), &pubkey, false));
+        assert!(!verify_one("c1", &mk(None), &pubkey, true));
     }
 }

--- a/mur-channel/src/sign.rs
+++ b/mur-channel/src/sign.rs
@@ -4,6 +4,12 @@
 //! restamps `ts` under the append lock), so the caller can sign BEFORE append.
 //! Verify-on-fold recomputes this input and checks `sig` against the writer's
 //! pubkey at `key_version` (resolved via the rotation chain).
+//!
+//! Enforcement scope (v3d-1): verification is enforced ONLY at the HITL gate
+//! (`mur-core::hitl::gate` via [`verify_one`]); `load_events` does NOT verify on
+//! every read. [`verify_log`] is the provided read-path verify-on-fold
+//! primitive, but wiring it into `load_events` needs a per-channel
+//! writer-resolution policy and is deferred to v3d-2.
 
 use mur_common::channel::{ChannelActor, ChannelEvent, EventKind};
 use mur_common::identity::AgentIdentity;
@@ -130,9 +136,14 @@ pub fn resolve_writer_pubkey(agent_home: &Path, key_version: Option<u32>) -> Opt
     decode_pubkey(txt.trim()).ok()
 }
 
-/// Verify-on-fold: filter a log to the events that pass verification against the
-/// channel's writer. Forged (bad-sig) events are dropped + logged; unsigned
-/// events pass only when `!require_sig`.
+/// Verify-on-fold primitive: filter a log to the events that pass verification
+/// against the channel's writer. Forged (bad-sig) events are dropped + logged;
+/// unsigned events pass only when `!require_sig`.
+///
+/// NOTE (v3d-1): this is NOT yet wired into `load_events` — v3d-1 enforces
+/// verification only at the HITL gate (via [`verify_one`]). Wiring this into the
+/// read path requires a per-channel writer-resolution policy and is deferred to
+/// v3d-2. It is exercised by this module's unit test, so it is not dead code.
 pub fn verify_log(
     channel_id: &str,
     events: Vec<ChannelEvent>,

--- a/mur-channel/src/sign.rs
+++ b/mur-channel/src/sign.rs
@@ -6,6 +6,7 @@
 //! pubkey at `key_version` (resolved via the rotation chain).
 
 use mur_common::channel::{ChannelActor, EventKind};
+use mur_common::identity::AgentIdentity;
 
 /// Canonicalization version — bump if the sign-input shape changes so an old
 /// signature is never silently checked against a new canonicalization.
@@ -29,6 +30,46 @@ pub fn sign_input(
         "idempotency_key": idempotency_key,
     });
     serde_json::to_vec(&canon).unwrap_or_default()
+}
+
+/// Sign an event's canonical input with `identity`; returns the multibase sig.
+pub fn sign_event(
+    identity: &AgentIdentity,
+    channel_id: &str,
+    actor: &ChannelActor,
+    kind: EventKind,
+    payload: &serde_json::Value,
+    idempotency_key: Option<&str>,
+) -> String {
+    let input = sign_input(channel_id, actor, kind, payload, idempotency_key);
+    let sig = identity.sign_bytes(&input);
+    multibase::encode(multibase::Base::Base58Btc, sig)
+}
+
+/// Verify a multibase signature over an event's canonical input against a raw
+/// Ed25519 pubkey. Returns false on any decode/verify failure (fail-closed).
+pub fn verify_event_sig(
+    channel_id: &str,
+    actor: &ChannelActor,
+    kind: EventKind,
+    payload: &serde_json::Value,
+    idempotency_key: Option<&str>,
+    sig_multibase: &str,
+    pubkey: &[u8; 32],
+) -> bool {
+    let Ok((_b, sig_bytes)) = multibase::decode(sig_multibase) else {
+        return false;
+    };
+    let Ok(sig_arr): Result<[u8; 64], _> = sig_bytes.as_slice().try_into() else {
+        return false;
+    };
+    let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
+    let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(pubkey) else {
+        return false;
+    };
+    let input = sign_input(channel_id, actor, kind, payload, idempotency_key);
+    use ed25519_dalek::Verifier;
+    vk.verify(&input, &sig).is_ok()
 }
 
 #[cfg(test)]
@@ -60,5 +101,58 @@ mod tests {
         let s = String::from_utf8_lossy(&a);
         assert!(!s.contains("\"seq\""));
         assert!(!s.contains("\"ts\""));
+    }
+
+    use mur_common::identity::AgentIdentity;
+    use tempfile::TempDir;
+
+    #[test]
+    fn sign_then_verify_roundtrips_and_rejects_tamper() {
+        let tmp = TempDir::new().unwrap();
+        let id = AgentIdentity::generate();
+        id.save(tmp.path()).unwrap();
+        let actor = ChannelActor::Agent { id: "mur".into() };
+        let payload = serde_json::json!({ "text": "approved" });
+
+        let sig = sign_event(
+            &id,
+            "c1",
+            &actor,
+            EventKind::HitlResponse,
+            &payload,
+            Some("k1"),
+        );
+        let pub_bytes = id.verifying_key_bytes();
+        assert!(verify_event_sig(
+            "c1",
+            &actor,
+            EventKind::HitlResponse,
+            &payload,
+            Some("k1"),
+            &sig,
+            &pub_bytes
+        ));
+        // Tampered payload → fails.
+        let tampered = serde_json::json!({ "text": "DENIED" });
+        assert!(!verify_event_sig(
+            "c1",
+            &actor,
+            EventKind::HitlResponse,
+            &tampered,
+            Some("k1"),
+            &sig,
+            &pub_bytes
+        ));
+        // Wrong key → fails.
+        let other = AgentIdentity::generate();
+        assert!(!verify_event_sig(
+            "c1",
+            &actor,
+            EventKind::HitlResponse,
+            &payload,
+            Some("k1"),
+            &sig,
+            &other.verifying_key_bytes()
+        ));
     }
 }

--- a/mur-channel/src/store.rs
+++ b/mur-channel/src/store.rs
@@ -70,6 +70,7 @@ impl ChannelStore {
     /// Append one event under an advisory lock so `seq` stays monotonic across
     /// processes (the Hub and the CLI may append concurrently). Returns the
     /// event with its assigned `seq` and timestamp.
+    #[allow(clippy::too_many_arguments)]
     pub fn append_event(
         &self,
         id: &str,
@@ -77,6 +78,8 @@ impl ChannelStore {
         kind: EventKind,
         payload: serde_json::Value,
         idempotency_key: Option<String>,
+        sig: Option<String>,
+        key_version: Option<u32>,
     ) -> Result<ChannelEvent> {
         let dir = self.channel_dir(id);
         fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
@@ -120,8 +123,8 @@ impl ChannelStore {
             kind,
             payload,
             idempotency_key,
-            sig: None,
-            key_version: None,
+            sig,
+            key_version,
         };
         let line = serde_json::to_string(&ev).context("serialize event")?;
         let mut data = OpenOptions::new()
@@ -197,6 +200,8 @@ mod tests {
                 EventKind::Message,
                 serde_json::json!({"text":"hi"}),
                 None,
+                None,
+                None,
             )
             .unwrap();
         let e1 = store
@@ -205,6 +210,8 @@ mod tests {
                 ChannelActor::Agent { id: "qa".into() },
                 EventKind::Message,
                 serde_json::json!({"text":"yo"}),
+                None,
+                None,
                 None,
             )
             .unwrap();
@@ -227,6 +234,8 @@ mod tests {
                 EventKind::ToolResult,
                 serde_json::json!({"x":1}),
                 Some("k1".into()),
+                None,
+                None,
             )
             .unwrap();
         // Same key again → returns the EXISTING event, does not append a 2nd row.
@@ -237,6 +246,8 @@ mod tests {
                 EventKind::ToolResult,
                 serde_json::json!({"x":2}),
                 Some("k1".into()),
+                None,
+                None,
             )
             .unwrap();
         assert_eq!(e0.seq, e0b.seq, "same idempotency_key → same event");
@@ -254,6 +265,8 @@ mod tests {
                 EventKind::Note,
                 serde_json::json!({}),
                 None,
+                None,
+                None,
             )
             .unwrap();
         store
@@ -262,6 +275,8 @@ mod tests {
                 ChannelActor::System,
                 EventKind::Note,
                 serde_json::json!({}),
+                None,
+                None,
                 None,
             )
             .unwrap();

--- a/mur-channel/src/watch.rs
+++ b/mur-channel/src/watch.rs
@@ -85,6 +85,8 @@ mod tests {
                 EventKind::Message,
                 serde_json::json!({"text":"hi"}),
                 None,
+                None,
+                None,
             )
             .unwrap();
 

--- a/mur-common/src/channel.rs
+++ b/mur-common/src/channel.rs
@@ -145,8 +145,10 @@ pub struct ChannelEvent {
     pub payload: serde_json::Value,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub idempotency_key: Option<String>,
-    /// RESERVED — `None` until per-event Ed25519 signing (v3d).
-    /// Sign-input: canonical `seq||ts||actor||kind||payload` bytes.
+    /// Detached Ed25519 signature (multibase) by the channel's WRITER over the
+    /// canonical sign-input `{v, channel_id, actor, kind, payload,
+    /// idempotency_key}` — EXCLUDING the store-assigned `seq`/`ts` (see
+    /// `mur-channel` `sign::sign_input`). `None` for legacy/unsigned events.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sig: Option<String>,
     /// RESERVED — key version for the signing key (v3d).

--- a/mur-core/src/channel_writer.rs
+++ b/mur-core/src/channel_writer.rs
@@ -1,0 +1,117 @@
+//! Append channel events signed by the channel's router/owner agent (v3d).
+//!
+//! The channel's WRITER (the router/owner agent, e.g. the `"mur"` concierge)
+//! signs the events it appends so a downstream reader can verify authority
+//! before trusting an event (notably the HITL gate verifying a `HitlResponse`).
+//!
+//! Migration-safe: if the router's identity is unavailable we fall back to an
+//! unsigned `append`, so existing channels (and tests that never created an
+//! identity) keep working. Enforcement is opt-in via `MUR_CHANNEL_REQUIRE_SIG`
+//! on the verification side.
+use std::path::Path;
+
+use mur_channel::ChannelService;
+use mur_common::channel::{ChannelActor, ChannelEvent, EventKind};
+
+/// The channel's router/owner agent — the trusted WRITER that signs the events
+/// appended to workflow/HITL channels (v3d). The concierge `"mur"` owns these
+/// channels; its on-disk identity (`<home>/agents/mur/`) signs `HitlRequest`/
+/// `HitlResponse`/workflow events, and the HITL gate verifies an incoming
+/// `HitlResponse` against this agent's pubkey before releasing. Internal
+/// directory slug, so lowercase (matches the on-disk `name`).
+pub const ROUTER_AGENT: &str = "mur";
+
+/// Read the router agent's current key version from its `profile.yaml`
+/// (`identity.key_version`). Returns 0 on any failure (missing profile,
+/// malformed YAML), matching the bootstrap key version.
+fn read_key_version(agent_home: &Path) -> u32 {
+    let profile_path = agent_home.join("profile.yaml");
+    let Ok(yaml) = std::fs::read_to_string(&profile_path) else {
+        return 0;
+    };
+    match serde_yaml_ng::from_str::<mur_common::AgentProfile>(&yaml) {
+        Ok(profile) => profile.identity.key_version,
+        Err(_) => 0,
+    }
+}
+
+/// Append `actor`/`kind`/`payload` to `channel_id`, SIGNED by `router_agent`'s
+/// identity when it is available, else unsigned (migration-safe).
+///
+/// `home` is the `~/.mur` root; the router identity is loaded from
+/// `<home>/agents/<router_agent>/identity.{key,pub}` and its key version from
+/// that agent's `profile.yaml`.
+#[allow(clippy::too_many_arguments)]
+pub fn append_as_writer(
+    svc: &ChannelService,
+    home: &Path,
+    channel_id: &str,
+    router_agent: &str,
+    actor: ChannelActor,
+    kind: EventKind,
+    payload: serde_json::Value,
+    idem: Option<String>,
+) -> anyhow::Result<ChannelEvent> {
+    let agent_home = home.join("agents").join(router_agent);
+    if let Ok(id) = mur_common::identity::AgentIdentity::load(&agent_home) {
+        let kv = read_key_version(&agent_home);
+        return svc.append_signed(channel_id, &id, kv, actor, kind, payload, idem);
+    }
+    svc.append(channel_id, actor, kind, payload, idem)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::identity::AgentIdentity;
+    use tempfile::TempDir;
+
+    #[test]
+    fn unsigned_when_identity_absent() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        let ev = append_as_writer(
+            &svc,
+            tmp.path(),
+            &ch.id,
+            "mur",
+            ChannelActor::System,
+            EventKind::Note,
+            serde_json::json!({ "text": "hi" }),
+            None,
+        )
+        .unwrap();
+        assert!(ev.sig.is_none(), "no identity → unsigned (migration-safe)");
+    }
+
+    #[test]
+    fn signed_when_identity_present_and_verifies() {
+        let tmp = TempDir::new().unwrap();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        // Plant the router identity under <home>/agents/mur/.
+        let agent_home = tmp.path().join("agents").join("mur");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        let id = AgentIdentity::generate();
+        id.save(&agent_home).unwrap();
+
+        let ev = append_as_writer(
+            &svc,
+            tmp.path(),
+            &ch.id,
+            "mur",
+            ChannelActor::System,
+            EventKind::HitlResponse,
+            serde_json::json!({ "allow": true }),
+            None,
+        )
+        .unwrap();
+        assert!(ev.sig.is_some(), "identity present → signed");
+        let pubkey = id.verifying_key_bytes();
+        assert!(
+            mur_channel::sign::verify_one(&ch.id, &ev, &pubkey, true),
+            "signed event must verify against the router pubkey even when require_sig"
+        );
+    }
+}

--- a/mur-core/src/cmd/agent/cli/persist.rs
+++ b/mur-core/src/cmd/agent/cli/persist.rs
@@ -1,7 +1,11 @@
 //! CLI transcript persistence, backed by the unified Channel store.
 //! The public surface (`Session`, `TurnRecord`, `SessionInfo`, `list_recent`,
 //! `load`, `latest`) is preserved so `app.rs`/`mod.rs` are barely touched.
-use std::path::Path;
+//!
+//! v3d: turns are SIGNED by the session's agent (the channel's writer) via
+//! `crate::channel_writer::append_as_writer`, falling back to unsigned when the
+//! agent has no on-disk identity (migration-safe).
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use mur_channel::ChannelService;
@@ -42,6 +46,8 @@ pub struct Session {
     /// `None` until the first append creates the channel.
     channel_id: Option<String>,
     agent: String,
+    /// `~/.mur` root — needed to resolve the agent's signing identity (v3d).
+    home: PathBuf,
 }
 
 impl Session {
@@ -52,6 +58,7 @@ impl Session {
             svc,
             channel_id: None,
             agent: agent.to_string(),
+            home: home.to_path_buf(),
         })
     }
 
@@ -62,6 +69,7 @@ impl Session {
             svc,
             channel_id: Some(channel_id.to_string()),
             agent: agent.to_string(),
+            home: home.to_path_buf(),
         })
     }
 
@@ -105,7 +113,22 @@ impl Session {
                 ch.id
             }
         };
-        self.svc.append_message(&id, actor, kind, text, task_id)?;
+        // Same payload shape as `append_message`, but SIGNED by the session's
+        // agent (the channel writer) when an identity exists (v3d).
+        let mut payload = serde_json::json!({ "text": text });
+        if let Some(t) = task_id {
+            payload["task_id"] = serde_json::Value::String(t.to_string());
+        }
+        crate::channel_writer::append_as_writer(
+            &self.svc,
+            &self.home,
+            &id,
+            &self.agent,
+            actor,
+            kind,
+            payload,
+            None,
+        )?;
         Ok(())
     }
 }

--- a/mur-core/src/cmd/channel.rs
+++ b/mur-core/src/cmd/channel.rs
@@ -7,6 +7,8 @@ use mur_channel::ChannelService;
 use mur_common::channel::{ChannelActor, EventKind};
 use mur_common::hitl::{HitlRequest, HitlResponse};
 
+use crate::channel_writer::ROUTER_AGENT;
+
 pub fn approve(channel_id: &str, hitl_id: &str, deny: bool, reason: Option<String>) -> Result<()> {
     let home = crate::paths::mur_root(None);
     let svc = ChannelService::open(&home)?;
@@ -29,8 +31,15 @@ pub fn approve(channel_id: &str, hitl_id: &str, deny: bool, reason: Option<Strin
         reason: reason.unwrap_or_default(),
         surface: "cli".into(),
     };
-    svc.append(
+    // The actor is the local human who approved, but the channel's WRITER signs
+    // the event (v3d) so the gate can verify authority before releasing — a
+    // forged HitlResponse from a non-router key is rejected. The router for
+    // workflow/HITL channels is the concierge "mur".
+    crate::channel_writer::append_as_writer(
+        &svc,
+        &home,
         channel_id,
+        ROUTER_AGENT,
         ChannelActor::local_human(),
         EventKind::HitlResponse,
         serde_json::to_value(&resp)?,

--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -354,7 +354,10 @@ async fn execute_step_inner(
 
 // ── Channel emit helper ─────────────────────────────────────────────────────
 
-/// Fire-and-forget: open the channel, append one System event, ignore errors.
+use crate::channel_writer::ROUTER_AGENT;
+
+/// Fire-and-forget: open the channel, append one System event SIGNED by the
+/// router (`"mur"`, falling back to unsigned when no identity), ignore errors.
 fn emit_channel(
     mur_home: &Path,
     channel_id: &str,
@@ -362,8 +365,11 @@ fn emit_channel(
     payload: serde_json::Value,
 ) {
     let _ = mur_channel::ChannelService::open(mur_home).and_then(|svc| {
-        svc.append(
+        crate::channel_writer::append_as_writer(
+            &svc,
+            mur_home,
             channel_id,
+            ROUTER_AGENT,
             mur_common::channel::ChannelActor::System,
             kind,
             payload,
@@ -418,9 +424,20 @@ async fn execute_step(
             .clone()
             .unwrap_or_else(|| step.description.clone());
 
-        // Record the delegation up front (System actor, deterministic key).
+        // Record the delegation up front (System actor, deterministic key),
+        // SIGNED by the router (v3d) via the single-sourced payload builder.
         if let Ok(svc) = ChannelService::open(mur_home) {
-            let _ = svc.append_delegation(cid, &canonical, &child_task_id, Some(deleg_key));
+            let payload = mur_channel::service::delegation_payload(cid, &canonical, &child_task_id);
+            let _ = crate::channel_writer::append_as_writer(
+                &svc,
+                mur_home,
+                cid,
+                ROUTER_AGENT,
+                ChannelActor::System,
+                mur_common::channel::EventKind::Delegation,
+                payload,
+                Some(deleg_key),
+            );
         }
         eprintln!("  Step {sid}: delegate → {canonical}: {goal_text}");
 
@@ -439,8 +456,11 @@ async fn execute_step(
                 // Mirror the specialist's approval request into the channel for
                 // visibility. v3c adds the interactive resolution path.
                 if let Ok(svc) = ChannelService::open(&home_for_hitl) {
-                    let _ = svc.append(
+                    let _ = crate::channel_writer::append_as_writer(
+                        &svc,
+                        &home_for_hitl,
                         &cid_for_hitl,
+                        ROUTER_AGENT,
                         ChannelActor::System,
                         mur_common::channel::EventKind::HitlRequest,
                         serde_json::json!({ "mirror": true, "from": "delegate", "params": hitl_params }),
@@ -456,8 +476,11 @@ async fn execute_step(
                 // Attribute the reply to the dialed agent; store the raw task
                 // snapshot alongside so attribution is auditable, not just asserted.
                 if let Ok(svc) = ChannelService::open(mur_home) {
-                    let _ = svc.append(
+                    let _ = crate::channel_writer::append_as_writer(
+                        &svc,
+                        mur_home,
                         cid,
+                        ROUTER_AGENT,
                         ChannelActor::Agent {
                             id: canonical.clone(),
                         },
@@ -487,8 +510,11 @@ async fn execute_step(
                 // Nothing partial is attributed; record a failure Note + fail the
                 // step so the DAG's on_failure (Abort/Skip/Retry) decides.
                 if let Ok(svc) = ChannelService::open(mur_home) {
-                    let _ = svc.append(
+                    let _ = crate::channel_writer::append_as_writer(
+                        &svc,
+                        mur_home,
                         cid,
+                        ROUTER_AGENT,
                         ChannelActor::System,
                         mur_common::channel::EventKind::Note,
                         serde_json::json!({ "text": format!("delegate to {canonical} failed: {e:#}") }),
@@ -618,8 +644,11 @@ async fn execute_step(
         // Use the deterministic idem_key so the resume cursor can match this row.
         let result_key = idem_key(cid, &opts.run_id, &sid, "result");
         let _ = ChannelService::open(mur_home).and_then(|svc| {
-            svc.append(
+            crate::channel_writer::append_as_writer(
+                &svc,
+                mur_home,
                 cid,
+                ROUTER_AGENT,
                 mur_common::channel::ChannelActor::System,
                 mur_common::channel::EventKind::ToolResult,
                 serde_json::json!({

--- a/mur-core/src/hitl/gate.rs
+++ b/mur-core/src/hitl/gate.rs
@@ -18,6 +18,7 @@ use mur_channel::ChannelService;
 use mur_common::channel::{ChannelActor, ChannelState, EventKind};
 use mur_common::hitl::{HitlMode, HitlRequest, HitlResponse, RiskTier, default_mode};
 
+use crate::channel_writer::ROUTER_AGENT;
 use crate::hitl::pin::action_hash;
 
 /// What the caller wants to do. `tool_input` must be POST-substitution.
@@ -88,10 +89,15 @@ pub async fn gate(
                 summary: req.summary.clone(),
             };
             // Open, write, drop — never cross an await with the service open.
+            // The router ("mur") signs the events it writes (v3d) so a reader
+            // can verify authority; falls back to unsigned when no identity.
             {
                 let svc = ChannelService::open(mur_home)?;
-                svc.append(
+                crate::channel_writer::append_as_writer(
+                    &svc,
+                    mur_home,
                     channel_id,
+                    ROUTER_AGENT,
                     ChannelActor::System,
                     EventKind::HitlRequest,
                     serde_json::to_value(&request)?,
@@ -114,8 +120,11 @@ pub async fn gate(
                 };
                 {
                     let svc = ChannelService::open(mur_home)?;
-                    svc.append(
+                    crate::channel_writer::append_as_writer(
+                        &svc,
+                        mur_home,
                         channel_id,
+                        ROUTER_AGENT,
                         ChannelActor::System,
                         EventKind::HitlResponse,
                         serde_json::to_value(&resp)?,
@@ -150,15 +159,55 @@ async fn wait_for_response(
     expected_hash: &str,
     timeout: Duration,
 ) -> Result<GateDecision> {
+    // When set, an unsigned (or absent-pubkey) HitlResponse is NOT trusted
+    // (fail-closed). When unset, an unsigned response is still accepted so
+    // pre-v3d channels keep working (migration-safe).
+    let require = std::env::var("MUR_CHANNEL_REQUIRE_SIG").is_ok();
+    let writer_pubkey =
+        mur_channel::sign::resolve_writer_pubkey(&mur_home.join("agents").join(ROUTER_AGENT), None);
     let start = Instant::now();
     loop {
-        // Open, read, drop — then await the sleep.
+        // Open, read, drop — then await the sleep. Verify each candidate's
+        // signature against the router's writer pubkey BEFORE trusting it: a
+        // forged/unsigned-when-required HitlResponse is ignored (filtered out)
+        // so it can never release the gate — the loop keeps waiting.
         let found = {
             let svc = ChannelService::open(mur_home)?;
             let evs = svc.load_events(channel_id)?;
             evs.into_iter().rev().find(|e| {
-                e.kind == EventKind::HitlResponse
-                    && e.payload.get("hitl_id").and_then(|v| v.as_str()) == Some(hitl_id)
+                if e.kind != EventKind::HitlResponse
+                    || e.payload.get("hitl_id").and_then(|v| v.as_str()) != Some(hitl_id)
+                {
+                    return false;
+                }
+                // Resolve the pubkey for THIS event's key_version; fall back to
+                // the head pubkey resolved once above.
+                let pk = mur_channel::sign::resolve_writer_pubkey(
+                    &mur_home.join("agents").join(ROUTER_AGENT),
+                    e.key_version,
+                )
+                .or(writer_pubkey);
+                match pk {
+                    Some(pk) if !mur_channel::sign::verify_one(channel_id, e, &pk, require) => {
+                        tracing::warn!(
+                            channel_id,
+                            hitl_id,
+                            "HitlResponse failed signature verification — ignoring"
+                        );
+                        false
+                    }
+                    // No pubkey to verify against (no router identity on disk):
+                    // only fail-closed when sigs are required.
+                    None if require => {
+                        tracing::warn!(
+                            channel_id,
+                            hitl_id,
+                            "no router pubkey and MUR_CHANNEL_REQUIRE_SIG set — ignoring HitlResponse"
+                        );
+                        false
+                    }
+                    _ => true,
+                }
             })
         };
         if let Some(resp) = found {
@@ -290,5 +339,136 @@ mod tests {
         assert!(!d.allow, "mismatched action_hash must fail-closed");
         assert!(d.reason.contains("drift"));
         let _ = r;
+    }
+
+    use mur_common::identity::AgentIdentity;
+
+    /// Plant a router identity at `<home>/agents/mur/` and return it.
+    fn plant_router_identity(home: &Path) -> AgentIdentity {
+        let agent_home = home.join("agents").join(ROUTER_AGENT);
+        std::fs::create_dir_all(&agent_home).unwrap();
+        let id = AgentIdentity::generate();
+        id.save(&agent_home).unwrap();
+        id
+    }
+
+    fn resp_with_hash(hitl_id: &str, hash: &str) -> HitlResponse {
+        HitlResponse {
+            hitl_id: hitl_id.into(),
+            action_hash: hash.into(),
+            allow: true,
+            reason: "".into(),
+            surface: "cli".into(),
+        }
+    }
+
+    /// A correctly-signed HitlResponse from the router releases the gate.
+    #[tokio::test]
+    async fn router_signed_response_releases() {
+        let tmp = TempDir::new().unwrap();
+        let id = plant_router_identity(tmp.path());
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        let resp = resp_with_hash("h-ok", "EXPECTED");
+        svc.append_signed(
+            &ch.id,
+            &id,
+            0,
+            ChannelActor::System,
+            EventKind::HitlResponse,
+            serde_json::to_value(&resp).unwrap(),
+            None,
+        )
+        .unwrap();
+        drop(svc);
+        let d = wait_for_response(
+            tmp.path(),
+            &ch.id,
+            "h-ok",
+            "EXPECTED",
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        assert!(
+            d.allow,
+            "router-signed response with matching hash releases"
+        );
+    }
+
+    /// A response signed by a NON-router (attacker) key must NOT release the
+    /// gate — a present-but-invalid signature is always rejected, regardless of
+    /// `MUR_CHANNEL_REQUIRE_SIG`.
+    #[tokio::test]
+    async fn forged_signature_does_not_release() {
+        let tmp = TempDir::new().unwrap();
+        let _router = plant_router_identity(tmp.path());
+        let attacker = AgentIdentity::generate();
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        let resp = resp_with_hash("h-forge", "EXPECTED");
+        // Signed by the attacker, not the router → verify_one rejects it.
+        svc.append_signed(
+            &ch.id,
+            &attacker,
+            0,
+            ChannelActor::System,
+            EventKind::HitlResponse,
+            serde_json::to_value(&resp).unwrap(),
+            None,
+        )
+        .unwrap();
+        drop(svc);
+        let d = wait_for_response(
+            tmp.path(),
+            &ch.id,
+            "h-forge",
+            "EXPECTED",
+            std::time::Duration::from_millis(900),
+        )
+        .await
+        .unwrap();
+        assert!(
+            !d.allow,
+            "a forged (wrong-key) signature must never release the gate"
+        );
+        assert!(d.reason.contains("timeout"), "ignored → waits → times out");
+    }
+
+    /// With `MUR_CHANNEL_REQUIRE_SIG` set, an UNSIGNED response is ignored
+    /// (fail-closed) even though `allow:true` — it cannot release the gate.
+    #[tokio::test]
+    async fn unsigned_when_required_does_not_release() {
+        // SAFETY: env is process-global; nextest runs each test in its own
+        // process. Set then clear to avoid leaking into a shared-process runner.
+        unsafe { std::env::set_var("MUR_CHANNEL_REQUIRE_SIG", "1") };
+        let tmp = TempDir::new().unwrap();
+        let _router = plant_router_identity(tmp.path());
+        let svc = ChannelService::open(tmp.path()).unwrap();
+        let ch = svc.create_for_workflow("g").unwrap();
+        let resp = resp_with_hash("h-unsigned", "EXPECTED");
+        svc.append(
+            &ch.id,
+            ChannelActor::System,
+            EventKind::HitlResponse,
+            serde_json::to_value(&resp).unwrap(),
+            None,
+        )
+        .unwrap();
+        drop(svc);
+        let d = wait_for_response(
+            tmp.path(),
+            &ch.id,
+            "h-unsigned",
+            "EXPECTED",
+            std::time::Duration::from_millis(900),
+        )
+        .await
+        .unwrap();
+        unsafe { std::env::remove_var("MUR_CHANNEL_REQUIRE_SIG") };
+        assert!(
+            !d.allow,
+            "unsigned response must not release when MUR_CHANNEL_REQUIRE_SIG is set"
+        );
     }
 }

--- a/mur-core/src/hitl/gate.rs
+++ b/mur-core/src/hitl/gate.rs
@@ -77,6 +77,13 @@ pub async fn gate(
         HitlMode::Ask => {
             let hitl_id = format!("hitl-{}", uuid::Uuid::now_v7());
             let timeout = timeout.unwrap_or(DEFAULT_TIMEOUT);
+            // Resolve signature-enforcement ONCE here (not deep in the poll
+            // loop) so `wait_for_response` is pure w.r.t. config and tests never
+            // race on a process-global env var. Only explicit truthy values
+            // enable enforcement: `=0` / `=false` must NOT turn it on.
+            let require_sig = std::env::var("MUR_CHANNEL_REQUIRE_SIG")
+                .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
+                .unwrap_or(false);
             let request = HitlRequest {
                 hitl_id: hitl_id.clone(),
                 action_hash: hash.clone(),
@@ -137,7 +144,8 @@ pub async fn gate(
                     action_hash: hash.clone(),
                 }
             } else {
-                wait_for_response(mur_home, channel_id, &hitl_id, &hash, timeout).await?
+                wait_for_response(mur_home, channel_id, &hitl_id, &hash, require_sig, timeout)
+                    .await?
             };
 
             {
@@ -157,12 +165,14 @@ async fn wait_for_response(
     channel_id: &str,
     hitl_id: &str,
     expected_hash: &str,
+    require: bool,
     timeout: Duration,
 ) -> Result<GateDecision> {
-    // When set, an unsigned (or absent-pubkey) HitlResponse is NOT trusted
-    // (fail-closed). When unset, an unsigned response is still accepted so
-    // pre-v3d channels keep working (migration-safe).
-    let require = std::env::var("MUR_CHANNEL_REQUIRE_SIG").is_ok();
+    // `require` (resolved once by the caller from `MUR_CHANNEL_REQUIRE_SIG`):
+    // when true, an unsigned (or absent-pubkey) HitlResponse is NOT trusted
+    // (fail-closed). When false, an unsigned response is still accepted so
+    // pre-v3d channels keep working (migration-safe). This fn reads no global
+    // config itself, so it is race-free under multi-threaded `cargo test`.
     let writer_pubkey =
         mur_channel::sign::resolve_writer_pubkey(&mur_home.join("agents").join(ROUTER_AGENT), None);
     let start = Instant::now();
@@ -332,6 +342,7 @@ mod tests {
             &ch.id,
             "h-x",
             "EXPECTED",
+            false,
             std::time::Duration::from_secs(1),
         )
         .await
@@ -386,6 +397,7 @@ mod tests {
             &ch.id,
             "h-ok",
             "EXPECTED",
+            false,
             std::time::Duration::from_secs(1),
         )
         .await
@@ -424,6 +436,7 @@ mod tests {
             &ch.id,
             "h-forge",
             "EXPECTED",
+            false,
             std::time::Duration::from_millis(900),
         )
         .await
@@ -435,13 +448,12 @@ mod tests {
         assert!(d.reason.contains("timeout"), "ignored → waits → times out");
     }
 
-    /// With `MUR_CHANNEL_REQUIRE_SIG` set, an UNSIGNED response is ignored
-    /// (fail-closed) even though `allow:true` — it cannot release the gate.
+    /// With signature enforcement on (`require = true`), an UNSIGNED response is
+    /// ignored (fail-closed) even though `allow:true` — it cannot release the
+    /// gate. Passing `require` as a parameter keeps this test free of any
+    /// process-global env mutation, so it never races sibling tests.
     #[tokio::test]
     async fn unsigned_when_required_does_not_release() {
-        // SAFETY: env is process-global; nextest runs each test in its own
-        // process. Set then clear to avoid leaking into a shared-process runner.
-        unsafe { std::env::set_var("MUR_CHANNEL_REQUIRE_SIG", "1") };
         let tmp = TempDir::new().unwrap();
         let _router = plant_router_identity(tmp.path());
         let svc = ChannelService::open(tmp.path()).unwrap();
@@ -461,14 +473,14 @@ mod tests {
             &ch.id,
             "h-unsigned",
             "EXPECTED",
+            true,
             std::time::Duration::from_millis(900),
         )
         .await
         .unwrap();
-        unsafe { std::env::remove_var("MUR_CHANNEL_REQUIRE_SIG") };
         assert!(
             !d.allow,
-            "unsigned response must not release when MUR_CHANNEL_REQUIRE_SIG is set"
+            "unsigned response must not release when signatures are required"
         );
     }
 }

--- a/mur-core/src/lib.rs
+++ b/mur-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod agent_wizard;
 pub mod auth;
 pub mod bridge_keychain;
 pub mod capture;
+pub mod channel_writer;
 pub mod character_card;
 pub mod codebase;
 pub mod daemon;

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -7,6 +7,7 @@ mod agent_wizard;
 mod auth;
 mod bridge_keychain;
 mod capture;
+mod channel_writer;
 mod codebase;
 // `--format card` is a D4 milestone; M2.7 only ships the schema + helper
 // (callable from the library), so the bin target sees the types as unused.


### PR DESCRIPTION
## Unified Channel v3d-1 — Per-Event Signing

Implements per-event Ed25519 signing for the Unified Channel (spec `docs/superpowers/specs/2026-06-16-unified-channel-v3-design.md` §7 v3d; plan `docs/superpowers/plans/2026-06-16-unified-channel-v3d-event-signing.md`). Closes the v3 trust-model residual ("any local process can append forged events into the shared log") and makes a channel `HitlResponse` **authority-bearing** — a forged response can no longer release a HITL gate.

**Base:** `feat/unified-channel-v3b` (v3c). This is a clean "v3c + signing" increment — no v4 mobile code.

### What's in it
- `mur-channel/src/sign.rs` — canonical sign-input over `{v, channel_id, actor, kind, payload, idempotency_key}` **excluding `seq`/`ts`** (corrects the v3a doc-comment); `sign_event`/`verify_event_sig` (Ed25519, multibase, fail-closed); `verify_one`/`resolve_writer_pubkey` (rotation-chain via `verify_chain`)/`verify_log`.
- `ChannelService::append_signed` (+ `store::append_event` gains `sig`/`key_version`).
- `mur-core/src/channel_writer.rs::append_as_writer` — the channel's router/owner agent signs; unsigned fallback = migration-safe. Routed: the HITL gate's writes, `mur channel approve`, the executor (`dag.rs`), and the CLI (`persist.rs`).
- **The v3c HITL gate now verifies the `HitlResponse`** before releasing. A forged / replayed / (when enforced) unsigned response is ignored — independently reviewed: no path lets a forged response release the gate. `hitl_id` is a fresh UUIDv7 bound into the signed input (no cross-gate replay).
- `MUR_CHANNEL_REQUIRE_SIG` (truthy) enforces verify-on-fold at the gate; **default off** tolerates legacy unsigned events.

### Quality
- Subagent-driven, 6 TDD tasks; per-task spec review + a final code-quality review (crypto judged correct, canonicalization unambiguous, fail-closed). Two review findings fixed: an env-var test race (`require_sig` now a parameter, so `cargo test` is green multi-threaded) and a doc/scope narrowing.
- `cargo nextest run -p mur-common -p mur-channel -p mur-core`: **3281 passed**; the only 4 failures are the pre-existing, unrelated `conversations::summarize::rollup` (LanceDB embedding-dim). `cargo fmt` clean; clippy clean on all touched files.

### Deferred (v3d-2)
A2 "peer-writes-own" (runtime `mur-channel` dep + a `channel/delegate` dispatcher method + specialists signing their own events), and wiring `verify_log` into the general read path (needs a per-channel writer-resolution policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
