### PR TITLE
fix(voice/mobile): locale-driven STT (Traditional Chinese) + iOS launch crash + ship murmurd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,14 +137,14 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ../../../${{ matrix.name }}.tar.gz mur mur-mcp-server
+          tar czf ../../../${{ matrix.name }}.tar.gz mur mur-mcp-server murmurd
           cd ../../..
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Compress-Archive -Path target/${{ matrix.target }}/release/mur.exe,target/${{ matrix.target }}/release/mur-mcp-server.exe -DestinationPath ${{ matrix.name }}.zip
+          Compress-Archive -Path target/${{ matrix.target }}/release/mur.exe,target/${{ matrix.target }}/release/mur-mcp-server.exe,target/${{ matrix.target }}/release/murmurd.exe -DestinationPath ${{ matrix.name }}.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -191,8 +191,10 @@ jobs:
           mkdir -p pkg-root/usr/local/share/doc/mur
           cp dist/mur pkg-root/usr/local/bin/mur
           cp dist/mur-mcp-server pkg-root/usr/local/bin/mur-mcp-server
+          cp dist/murmurd pkg-root/usr/local/bin/murmurd
           chmod +x pkg-root/usr/local/bin/mur
           chmod +x pkg-root/usr/local/bin/mur-mcp-server
+          chmod +x pkg-root/usr/local/bin/murmurd
           cp LICENSE pkg-root/usr/local/share/doc/mur/LICENSE
           mkdir -p scripts-pkg
           cat > scripts-pkg/postinstall <<'EOF'
@@ -208,9 +210,11 @@ jobs:
           codesign --force --options runtime --timestamp \
             --sign "Developer ID Application: $APPLE_TEAM_NAME ($APPLE_TEAM_ID)" \
             pkg-root/usr/local/bin/mur \
-            pkg-root/usr/local/bin/mur-mcp-server
+            pkg-root/usr/local/bin/mur-mcp-server \
+            pkg-root/usr/local/bin/murmurd
           codesign --verify --verbose pkg-root/usr/local/bin/mur \
-            pkg-root/usr/local/bin/mur-mcp-server
+            pkg-root/usr/local/bin/mur-mcp-server \
+            pkg-root/usr/local/bin/murmurd
         env:
           APPLE_TEAM_NAME: ${{ secrets.APPLE_TEAM_NAME }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
@@ -474,6 +478,7 @@ jobs:
             def install
               bin.install "mur"
               bin.install "mur-mcp-server"
+              bin.install "murmurd"
               bin.install_symlink "mur" => "murmur"
             end
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6316,6 +6316,7 @@ dependencies = [
  "sled",
  "snow",
  "subtle",
+ "sys-locale",
  "tar",
  "teloxide",
  "tempfile",
@@ -6549,6 +6550,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sys-locale",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -9351,6 +9353,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/build.sh
+++ b/build.sh
@@ -64,5 +64,14 @@ if $INSTALL; then
     sudo cp "$MCP_BINARY" /opt/homebrew/bin/mur-mcp-server
     echo "Installed mur-mcp-server -> /opt/homebrew/bin/mur-mcp-server"
   fi
+
+  # The background daemon. `mur daemon start` looks for `murmurd` alongside
+  # `mur`, so install it too — otherwise the daemon (and the Hub/phone voice
+  # path that runs through it) is unavailable on a release install.
+  DAEMON_BINARY="$SCRIPT_DIR/target/release/murmurd"
+  if [ -f "$DAEMON_BINARY" ]; then
+    sudo cp "$DAEMON_BINARY" /opt/homebrew/bin/murmurd
+    echo "Installed murmurd -> /opt/homebrew/bin/murmurd"
+  fi
   echo "✅ Installed: $(mur --version 2>/dev/null || echo 'done')"
 fi

--- a/mur-agent-runtime/Cargo.toml
+++ b/mur-agent-runtime/Cargo.toml
@@ -114,6 +114,7 @@ ndarray = { version = "0.17", optional = true }            # tensor arrays for o
 espeak-ng = "0.1"                                           # espeak-ng G2P for Kokoro tokenizer (pure Rust, no bindgen)
 whisper-rs = { version = "0.11", features = [] }            # whisper.cpp STT bindings (CPU-only; no metal to keep CI clean)
 cpal = "0.15"                                               # cross-platform audio I/O (mic capture + speaker playback)
+sys-locale = "0.3"                                          # detect the OS locale so STT language/script follows the device, not a hard-coded value
 # B1 sandbox — MCP child process sandboxing (Task 7).
 # birdcage 0.8 does not compile on Windows (upstream bug); gated to unix-like targets.
 # child.rs already falls back to cmd.spawn() on Windows via #[cfg(not(unix))].

--- a/mur-agent-runtime/src/voice/stt.rs
+++ b/mur-agent-runtime/src/voice/stt.rs
@@ -90,18 +90,43 @@ impl WhisperStt {
         params.set_print_progress(false);
         params.set_print_realtime(false);
         params.set_print_timestamps(false);
-        // Language selection. The bundled model (large-v3-turbo) is multilingual,
-        // so default to auto-detection (`None`) — Whisper detects the spoken
-        // language and transcribes in it (Chinese stays Chinese, etc.). Forcing a
-        // single language here is what previously coerced all speech to English.
-        // `MUR_STT_LANGUAGE` overrides: a code like "zh"/"en" pins that language;
-        // unset / empty / "auto" means auto-detect.
-        let stt_lang_env = std::env::var("MUR_STT_LANGUAGE").ok();
-        let stt_lang: Option<&str> = stt_lang_env
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("auto"));
-        params.set_language(stt_lang);
+        // Language + script follow the DEVICE locale, never a hard-coded value.
+        // Precedence: `MUR_STT_LANGUAGE` override > the OS locale (sys-locale).
+        // A tag like "zh-Hant-TW" maps to Whisper language "zh"; for Traditional
+        // locales (script "Hant" or region TW/HK/MO) we also seed a Traditional
+        // `initial_prompt` so the decoder emits 繁體 rather than 简体 (Whisper's
+        // "zh" defaults to Simplified). Empty / "auto" => auto-detect.
+        let locale = std::env::var("MUR_STT_LANGUAGE")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .or_else(sys_locale::get_locale)
+            .filter(|s| !s.eq_ignore_ascii_case("auto"));
+
+        let lang: Option<String> = locale.as_deref().and_then(|l| {
+            l.split(['-', '_'])
+                .next()
+                .map(|s| s.to_ascii_lowercase())
+                .filter(|s| !s.is_empty())
+        });
+        let want_traditional = lang.as_deref() == Some("zh")
+            && locale
+                .as_deref()
+                .map(|l| {
+                    let lc = l.to_ascii_lowercase();
+                    lc.contains("hant")
+                        || ["tw", "hk", "mo"]
+                            .iter()
+                            .any(|r| lc.contains(&format!("-{r}")) || lc.contains(&format!("_{r}")))
+                })
+                .unwrap_or(false);
+
+        params.set_language(lang.as_deref());
+        if want_traditional {
+            // Seed Traditional characters so the decoder doesn't fall back to 简体.
+            params.set_initial_prompt("以下是繁體中文的內容。");
+        }
+        tracing::info!(?locale, ?lang, want_traditional, "STT language resolved");
 
         state.full(params, samples).context("whisper inference")?;
 

--- a/mur-agent-runtime/src/voice/stt.rs
+++ b/mur-agent-runtime/src/voice/stt.rs
@@ -90,8 +90,18 @@ impl WhisperStt {
         params.set_print_progress(false);
         params.set_print_realtime(false);
         params.set_print_timestamps(false);
-        // TODO(i18n): derive from agent locale config rather than hard-coding English
-        params.set_language(Some("en"));
+        // Language selection. The bundled model (large-v3-turbo) is multilingual,
+        // so default to auto-detection (`None`) — Whisper detects the spoken
+        // language and transcribes in it (Chinese stays Chinese, etc.). Forcing a
+        // single language here is what previously coerced all speech to English.
+        // `MUR_STT_LANGUAGE` overrides: a code like "zh"/"en" pins that language;
+        // unset / empty / "auto" means auto-detect.
+        let stt_lang_env = std::env::var("MUR_STT_LANGUAGE").ok();
+        let stt_lang: Option<&str> = stt_lang_env
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("auto"));
+        params.set_language(stt_lang);
 
         state.full(params, samples).context("whisper inference")?;
 

--- a/mur-gui-core/Cargo.toml
+++ b/mur-gui-core/Cargo.toml
@@ -15,6 +15,7 @@ serde_yaml_ng = "0.10"
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+sys-locale = "0.3"                  # read the OS locale to pass STT language down to spawned agents
 async-trait = "0.1"
 image = "0.25"
 reqwest = { workspace = true }

--- a/mur-gui-core/src/sidecar.rs
+++ b/mur-gui-core/src/sidecar.rs
@@ -250,6 +250,16 @@ fn spawn_runtime(slug: &str, mur_home: &Path) -> Result<Child, String> {
         info!(slug, %base_url, "routing agent runtime through cc-proxy bridge");
         cmd.env("ANTHROPIC_BASE_URL", base_url);
     }
+    // STT language follows the device. The Hub process can read the OS locale,
+    // but the sandboxed agent runtime cannot reach CFLocale — so pass it down as
+    // MUR_STT_LANGUAGE. The runtime maps e.g. "zh-Hant-TW" → Whisper language
+    // "zh" + Traditional output. An explicit env (user override) always wins.
+    if std::env::var_os("MUR_STT_LANGUAGE").is_none()
+        && let Some(locale) = sys_locale::get_locale()
+    {
+        info!(slug, %locale, "passing OS locale to agent runtime for STT");
+        cmd.env("MUR_STT_LANGUAGE", locale);
+    }
     cmd.spawn()
         .map_err(|e| format!("could not start the agent runtime: {e}"))
 }

--- a/mur-mobile-app/Sources/AppModel.swift
+++ b/mur-mobile-app/Sources/AppModel.swift
@@ -279,6 +279,13 @@ final class AppModel {
 
         let inputNode = audioEngine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
+        // A 0 Hz / 0-channel input format (mic permission not yet granted, or the
+        // session not ready) would make installTap / AVAudioConverter throw
+        // 'IsFormatSampleRateAndChannelCountValid'. Bail gracefully, never crash.
+        guard format.sampleRate > 0, format.channelCount > 0 else {
+            print("[MurVoice] capture: skipped — invalid input format \(format.sampleRate)Hz/\(format.channelCount)ch")
+            return
+        }
 
         recognitionTask = recognizer?.recognitionTask(with: request) { [weak self] result, error in
             Task { @MainActor [weak self] in
@@ -359,12 +366,14 @@ final class AppModel {
         let bytes = ttsBuffer
         ttsBuffer = Data()
         let sr = ttsSampleRate
-        guard !bytes.isEmpty else { return }
+        // Guard empty audio and an invalid (0 Hz) source rate — a 0 sample rate
+        // makes AVAudioFormat fail validation (the force-unwrap would trap).
+        guard !bytes.isEmpty, sr > 0 else { return }
 
-        // f32 LE PCM → AVAudioPCMBuffer at 24 kHz mono
-        let format = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: Double(sr), channels: 1, interleaved: false)!
+        // f32 LE PCM → AVAudioPCMBuffer at the source rate, mono.
+        guard let format = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: Double(sr), channels: 1, interleaved: false) else { return }
         let frameCount = AVAudioFrameCount(bytes.count / 4)
-        guard let buf = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else { return }
+        guard frameCount > 0, let buf = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else { return }
         buf.frameLength = frameCount
         bytes.withUnsafeBytes { ptr in
             if let f32 = ptr.baseAddress?.assumingMemoryBound(to: Float.self),
@@ -373,8 +382,26 @@ final class AppModel {
             }
         }
 
+        // Activate a playback audio session BEFORE touching the output node.
+        // Without an active route the output node reports a 0 Hz / 0-channel
+        // format, and AVAudioEngine.connect(_:to:format:) then throws
+        // 'IsFormatSampleRateAndChannelCountValid(format)' → SIGABRT.
+        let ttsSession = AVAudioSession.sharedInstance()
+        do {
+            try ttsSession.setCategory(.playback, mode: .default, options: [.duckOthers])
+            try ttsSession.setActive(true)
+        } catch {
+            print("[MurVoice] tts: audio session activate failed: \(error)")
+            return
+        }
+
         ttsEngine.attach(ttsPlayerNode)
         let outputFormat = ttsEngine.outputNode.inputFormat(forBus: 0)
+        // Defensive: never hand an invalid (0 Hz / 0-channel) format to the graph.
+        guard outputFormat.sampleRate > 0, outputFormat.channelCount > 0 else {
+            print("[MurVoice] tts: skipped — invalid output format \(outputFormat.sampleRate)Hz/\(outputFormat.channelCount)ch")
+            return
+        }
         ttsEngine.connect(ttsPlayerNode, to: ttsEngine.outputNode, format: outputFormat)
 
         do {


### PR DESCRIPTION
Three related voice/mobile fixes found while live-testing v2.25.0 on the Hub + a physical iPhone.

## 1. STT forced all speech to English → now follows the device locale
`WhisperStt::transcribe` hard-coded `set_language(Some("en"))`, so Chinese came out as English (Hub chat + phone). Fixes:
- **`transcribe()`** resolves the language from `MUR_STT_LANGUAGE` → OS locale (`sys-locale`), **script-aware**: a tag like `zh-Hant-TW` → Whisper language `zh` **plus a Traditional `initial_prompt`** so the decoder emits 繁體 not 简体. Empty/`auto` = auto-detect.
- **`mur-gui-core` sidecar**: the Hub reads the OS locale and passes `MUR_STT_LANGUAGE` to each spawned agent — the **sandboxed agent runtime can't reach `CFLocale`**, so the unsandboxed Hub must hand it down. murmurd (unsandboxed) resolves it itself.
- Verified live: Hub voice now transcribes spoken Chinese as **Traditional Chinese**.

> Architecture note discovered here: the Hub's voice STT runs through **murmurd**'s `stt_sink` (the frontend opens murmurd's mobile WS per utterance), not the agent runtime.

## 2. iOS app aborted on launch (AVFoundation)
`MurVoice` crashed every launch with `IsFormatSampleRateAndChannelCountValid(format)` (SIGABRT). `playTTSBuffer` called `ttsEngine.connect(_:to:format:)` with `outputNode.inputFormat` = **0 Hz** (no active playback session). Fix: activate a `.playback` session before touching the output node; guard the output format; guard a 0 Hz source rate (no force-unwrap); guard the mic input format in `startAudioCapture`. Verified on device.

## 3. murmurd was never shipped in releases
The release built the whole workspace but packaged only `mur` + `mur-mcp-server`, so `mur daemon start` failed with "murmurd binary not found" on every release install — and the voice path (which runs STT through murmurd) was unavailable. Added `murmurd` to the tarball, Windows zip, signed `.pkg`, Homebrew formula, and `build.sh --install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)