### PR TITLE
feat(agent-cli): shell mode border indicator + inject CWD into first turn

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -156,6 +156,13 @@ pub struct App {
     /// Set once we've warned the user that session writes are failing, so the
     /// warning isn't repeated every turn.
     persist_warned: bool,
+    /// Working directory captured at CLI startup; sent to the agent once per
+    /// session so it knows what project the user is in.
+    pub cwd: Option<PathBuf>,
+    /// True after CWD has been injected into the first outgoing message this
+    /// session. Reset on `/clear` or channel switch so each new session
+    /// re-establishes context.
+    pub cwd_sent: bool,
 }
 
 impl App {
@@ -178,6 +185,8 @@ impl App {
             session_tool_allow: HashSet::new(),
             pending_shell: Vec::new(),
             persist_warned: false,
+            cwd: std::env::current_dir().ok(),
+            cwd_sent: false,
         }
     }
 
@@ -323,6 +332,7 @@ impl App {
         self.current_task_id = None;
         self.streaming = false;
         self.hitl = None;
+        self.cwd_sent = false;
         self.push_system("started a new conversation");
     }
 
@@ -338,6 +348,7 @@ impl App {
         self.current_task_id = None;
         self.streaming = false;
         self.hitl = None;
+        self.cwd_sent = false;
         self.load_history(turns);
         self.refresh_channel();
         Ok(())
@@ -394,6 +405,24 @@ impl App {
 
     pub fn tick_spinner(&mut self) {
         self.spinner = (self.spinner + 1) % SPINNER.len();
+    }
+
+    /// Update the input textarea's border to reflect the current content mode.
+    /// Call once per render frame so the style stays in sync without needing
+    /// `&mut App` inside the draw closure.
+    pub fn sync_input_block(&mut self) {
+        let is_shell = self.input_text().trim_start().starts_with('!');
+        let block = if is_shell {
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Red))
+                .title(" ! shell command — output shared with agent ")
+        } else {
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" message — Enter to send · Alt+Enter newline · /help · Ctrl+D quit ")
+        };
+        self.input.set_block(block);
     }
 }
 

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -177,6 +177,7 @@ async fn event_loop(
     let mut spinner = tokio::time::interval(Duration::from_millis(SPINNER_MS));
 
     loop {
+        app.sync_input_block();
         terminal.draw(|f| ui::render(f, app))?;
         if app.should_quit {
             return Ok(());
@@ -360,12 +361,23 @@ async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
     app.clear_input();
 
     let task_id = app.begin_user_turn(&trimmed);
+    // On the first send of each session, prepend the user's working directory
+    // so the agent knows which project they're in.
+    let cwd_prefix = if !app.cwd_sent {
+        app.cwd_sent = true;
+        app.cwd
+            .as_ref()
+            .map(|d| format!("[working directory: {}]\n\n", d.display()))
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
     // Prefix any `!command` output the agent hasn't seen yet, so it has the
     // same context the user is looking at. The transcript shows only the
     // user's text; the shell blocks were already rendered when they ran.
     let outgoing = match app.take_pending_shell() {
-        Some(ctx) => format!("{ctx}\n\n{trimmed}"),
-        None => trimmed.clone(),
+        Some(ctx) => format!("{cwd_prefix}{ctx}\n\n{trimmed}"),
+        None => format!("{cwd_prefix}{trimmed}"),
     };
     let params = build_params(&outgoing, &task_id, app.context_task_id.as_deref());
     spawn_stream(


### PR DESCRIPTION
## Summary

- **`!` shell mode visual feedback**: input box border turns red and title changes to `! shell command — output shared with agent` the moment `!` is the first character, giving immediate feedback before sending. Reverts to default style when the `!` is removed.
- **Agent CWD context**: captures `current_dir()` at CLI startup and prepends `[working directory: /path]` to the first outgoing message of each session so the agent knows what project the user is in. Resets on `/clear` and channel switch so every new conversation re-establishes context.

## Root cause notes

- The `TextArea` block was set once in `new_input()` and never updated — fixed by `App::sync_input_block()` called each frame before `terminal.draw()`.
- The CLI sent no working-directory information to the agent runtime; the agent's `BashTool` runs from `agent_home`, not the user's CWD. The message-level injection gives the agent the context it needs to `cd` to the right directory in bash commands.
- The API 500 (`api_error` / "Internal server error", `req_011Cc7LZoqAD95hUg47RzTTz`) is a transient Anthropic server error — no fix on our end.

## Test plan

- [ ] Start `mur agent cli <agent>` from a project directory — first message should carry `[working directory: ...]`
- [ ] Type `!ls` — input border turns red with "! shell command" title
- [ ] Delete the `!` — border reverts to default white/default title
- [ ] `/clear` then send a message — CWD is injected again

🤖 Generated with [Claude Code](https://claude.com/claude-code)