### PR TITLE
feat(agent-cli): mouse scroll + double-ESC clear/cancel-restore + status bar hints

### DIFF
--- a/docs/superpowers/plans/2026-06-17-agent-cli-ux-pr1-behaviour.md
+++ b/docs/superpowers/plans/2026-06-17-agent-cli-ux-pr1-behaviour.md
@@ -1,0 +1,602 @@
+# Agent CLI UX — PR 1: Keyboard & Mouse Behaviour
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add mouse-wheel scroll, double-ESC to clear input, and double-ESC to cancel-and-restore a submitted message while the agent is streaming.
+
+**Architecture:** Pure state machine (`esc_action()`) extracted for testability. New fields on `App` track ESC timing and last sent text. Mouse capture enabled via crossterm. Status bar updated to show ESC hint and scroll position.
+
+**Tech Stack:** Rust, ratatui 0.29, crossterm 0.28, tui-textarea 0.7, tokio
+
+**Spec:** `docs/superpowers/specs/2026-06-17-agent-cli-ux-improvements-design.md` — PR 1 section
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `mur-core/src/cmd/agent/cli/app.rs` | Add `EscAction` enum, `esc_action()` fn, `ESC_DOUBLE_WINDOW` const, new `App` fields, update `start_new_session()` |
+| `mur-core/src/cmd/agent/cli/mod.rs` | Add `MOUSE_SCROLL_STEP`, `EnableMouseCapture`/`DisableMouseCapture`, ESC handler, `Event::Mouse` arm |
+| `mur-core/src/cmd/agent/cli/ui.rs` | Update `render_status()` for scroll indicator and ESC hint |
+
+---
+
+### Task 1: Add EscAction enum and esc_action() pure function
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/app.rs`
+
+- [ ] **Step 1: Add ESC_DOUBLE_WINDOW constant and EscAction enum**
+
+Open `app.rs`. After the `SLASH_COMMANDS` const (around line 116), add:
+
+```rust
+pub const ESC_DOUBLE_WINDOW: std::time::Duration = std::time::Duration::from_millis(400);
+
+/// Result of pressing Escape — computed from current app state without mutation.
+#[derive(Debug, PartialEq, Eq)]
+pub enum EscAction {
+    /// First ESC (or window expired) — arm the double-ESC window.
+    Arm,
+    /// Second ESC while not streaming and input non-empty — clear the input box.
+    ClearInput,
+    /// Second ESC while streaming — cancel in-flight turn and restore last sent text.
+    CancelAndRestore,
+    /// Nothing to act on (e.g. double-ESC but nothing to cancel or clear).
+    Nothing,
+}
+
+/// Pure double-ESC state machine. Extracted so it can be unit-tested without
+/// wall-clock dependency.
+pub fn esc_action(
+    last_esc_at: Option<std::time::Instant>,
+    streaming: bool,
+    input_empty: bool,
+) -> EscAction {
+    if let Some(t) = last_esc_at {
+        if t.elapsed() < ESC_DOUBLE_WINDOW {
+            // Second press within window
+            return if streaming {
+                EscAction::CancelAndRestore
+            } else if !input_empty {
+                EscAction::ClearInput
+            } else {
+                EscAction::Nothing
+            };
+        }
+    }
+    // First press (or window expired): arm if there is something to act on
+    if streaming || !input_empty {
+        EscAction::Arm
+    } else {
+        EscAction::Nothing
+    }
+}
+```
+
+- [ ] **Step 2: Write unit tests for esc_action()**
+
+Inside the `#[cfg(test)]` block at the bottom of `app.rs`, add after the last existing test:
+
+```rust
+    // ── ESC state machine ────────────────────────────────────────────────────
+
+    #[test]
+    fn esc_arm_when_streaming_and_empty_input() {
+        assert_eq!(esc_action(None, true, true), EscAction::Arm);
+    }
+
+    #[test]
+    fn esc_arm_when_not_streaming_and_has_text() {
+        assert_eq!(esc_action(None, false, false), EscAction::Arm);
+    }
+
+    #[test]
+    fn esc_nothing_when_not_streaming_and_empty() {
+        assert_eq!(esc_action(None, false, true), EscAction::Nothing);
+    }
+
+    #[test]
+    fn esc_cancel_restore_on_second_press_while_streaming() {
+        let t = std::time::Instant::now() - std::time::Duration::from_millis(100);
+        assert_eq!(esc_action(Some(t), true, true), EscAction::CancelAndRestore);
+    }
+
+    #[test]
+    fn esc_cancel_restore_on_second_press_streaming_has_text() {
+        let t = std::time::Instant::now() - std::time::Duration::from_millis(100);
+        assert_eq!(esc_action(Some(t), true, false), EscAction::CancelAndRestore);
+    }
+
+    #[test]
+    fn esc_clear_on_second_press_not_streaming_has_text() {
+        let t = std::time::Instant::now() - std::time::Duration::from_millis(100);
+        assert_eq!(esc_action(Some(t), false, false), EscAction::ClearInput);
+    }
+
+    #[test]
+    fn esc_nothing_on_second_press_not_streaming_empty() {
+        let t = std::time::Instant::now() - std::time::Duration::from_millis(100);
+        assert_eq!(esc_action(Some(t), false, true), EscAction::Nothing);
+    }
+
+    #[test]
+    fn esc_expired_window_rearms() {
+        // 500ms > ESC_DOUBLE_WINDOW (400ms) → treated as first press, not second
+        let t = std::time::Instant::now() - std::time::Duration::from_millis(500);
+        assert_eq!(esc_action(Some(t), true, true), EscAction::Arm);
+    }
+```
+
+- [ ] **Step 3: Run tests — expect PASS**
+
+```bash
+cd /Volumes/Firecuda4tb/Projects/mur
+cargo nextest run -p mur-core esc_ 2>&1
+```
+
+Expected: 8 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/app.rs
+git commit -m "feat(agent-cli): add EscAction enum + esc_action() pure function"
+```
+
+---
+
+### Task 2: Add ESC-related fields to App and update lifecycle methods
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/app.rs`
+
+- [ ] **Step 1: Add three new fields to the App struct**
+
+Inside `pub struct App { ... }`, add these three fields after `cwd_sent: bool`:
+
+```rust
+    /// When the user last pressed ESC; used to detect a double-ESC within
+    /// ESC_DOUBLE_WINDOW. `None` means no pending ESC.
+    pub last_esc_at: Option<std::time::Instant>,
+    /// True while we want the status bar to show an ESC hint.
+    pub esc_hint: bool,
+    /// The most recently submitted (non-slash, non-shell) chat message.
+    /// Double-ESC while streaming restores this into the input box.
+    pub last_sent: Option<String>,
+```
+
+- [ ] **Step 2: Initialize new fields in App::new()**
+
+Inside `App::new()`, in the `Self { ... }` initializer, add after `cwd_sent: false`:
+
+```rust
+            last_esc_at: None,
+            esc_hint: false,
+            last_sent: None,
+```
+
+- [ ] **Step 3: Clear ESC state and last_sent in start_new_session()**
+
+In `start_new_session()`, add these three lines after `self.cwd_sent = false;`:
+
+```rust
+        self.last_sent = None;
+        self.last_esc_at = None;
+        self.esc_hint = false;
+```
+
+- [ ] **Step 4: Write a test for start_new_session clearing last_sent**
+
+In the `#[cfg(test)]` block, add:
+
+```rust
+    #[test]
+    fn start_new_session_clears_last_sent() {
+        let home = tempdir().unwrap();
+        let mut a = app_at(&home);
+        a.last_sent = Some("hello".into());
+        a.last_esc_at = Some(std::time::Instant::now());
+        a.esc_hint = true;
+        let s = Session::create(home.path(), "a").unwrap();
+        a.start_new_session(s);
+        assert!(a.last_sent.is_none());
+        assert!(a.last_esc_at.is_none());
+        assert!(!a.esc_hint);
+    }
+```
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+```bash
+cargo nextest run -p mur-core start_new_session 2>&1
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/app.rs
+git commit -m "feat(agent-cli): add last_esc_at/esc_hint/last_sent fields to App"
+```
+
+---
+
+### Task 3: Capture last_sent in submit()
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs`
+
+The regular-chat path in `submit()` is around line 355–390. The code currently reads:
+
+```rust
+    app.clear_input();             // line 361
+
+    let task_id = app.begin_user_turn(&trimmed);  // line 363
+```
+
+- [ ] **Step 1: Add last_sent assignment before clear_input**
+
+Change those two lines to:
+
+```rust
+    app.last_sent = Some(trimmed.clone());
+    app.clear_input();
+
+    let task_id = app.begin_user_turn(&trimmed);
+```
+
+(No other changes to `submit()`.)
+
+- [ ] **Step 2: Write a test for last_sent being set**
+
+There's no direct test for `submit()` (it's async and uses mpsc). Instead, add an `App`-level helper test in `app.rs` — the logic is that `last_sent` is set before `clear_input`. We can verify this manually with the TUI once the handler is wired.
+
+Skip automated test here; rely on manual verification in Task 5.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(agent-cli): capture last_sent before clearing input on submit"
+```
+
+---
+
+### Task 4: Wire ESC handler in handle_event
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs`
+
+- [ ] **Step 1: Add EscAction to the use statement**
+
+At the top of `mod.rs`, line 36:
+
+```rust
+use self::app::{App, EscAction, Role, SlashCmd, esc_action, parse_slash};
+```
+
+(Add `EscAction` and `esc_action` to the existing import.)
+
+- [ ] **Step 2: Add non-ESC key clears ESC state**
+
+Inside `handle_event`, the `Event::Key` arm contains a `match key.code { ... }` block. Add these lines as the FIRST statement inside the `Event::Key` arm, before the `match key.code`:
+
+```rust
+        // Any key other than ESC cancels a pending double-ESC window.
+        if key.code != KeyCode::Esc {
+            app.last_esc_at = None;
+            app.esc_hint = false;
+        }
+```
+
+- [ ] **Step 3: Add ESC arm to the key code match**
+
+Inside `match key.code { ... }`, add the `KeyCode::Esc` arm BEFORE the `_ => { app.input.input(key); }` catch-all:
+
+```rust
+            KeyCode::Esc => {
+                let action = esc_action(
+                    app.last_esc_at,
+                    app.streaming,
+                    app.input_text().is_empty(),
+                );
+                match action {
+                    EscAction::Arm => {
+                        app.last_esc_at = Some(std::time::Instant::now());
+                        app.esc_hint = true;
+                    }
+                    EscAction::ClearInput => {
+                        app.clear_input();
+                        app.last_esc_at = None;
+                        app.esc_hint = false;
+                    }
+                    EscAction::CancelAndRestore => {
+                        cancel_in_flight(app, tx);
+                        if let Some(text) = app.last_sent.clone() {
+                            app.set_input(&text);
+                        }
+                        app.push_system("cancelled — message restored");
+                        app.last_esc_at = None;
+                        app.esc_hint = false;
+                    }
+                    EscAction::Nothing => {
+                        app.last_esc_at = None;
+                        app.esc_hint = false;
+                    }
+                }
+            }
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+```bash
+cargo build -p mur-core 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(agent-cli): wire double-ESC clear + cancel-restore handler"
+```
+
+---
+
+### Task 5: Add mouse scroll support
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs`
+
+- [ ] **Step 1: Add mouse events to crossterm imports**
+
+Line 22–25 currently:
+
+```rust
+use crossterm::event::{
+    DisableBracketedPaste, EnableBracketedPaste, Event, EventStream, KeyCode, KeyEventKind,
+    KeyModifiers,
+};
+```
+
+Change to:
+
+```rust
+use crossterm::event::{
+    DisableBracketedPaste, EnableBracketedPaste, EnableMouseCapture, DisableMouseCapture,
+    Event, EventStream, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind,
+};
+```
+
+- [ ] **Step 2: Add MOUSE_SCROLL_STEP constant**
+
+Find the existing `const SCROLL_STEP: u16 = 5;` (around line 44). Add the new constant directly after it:
+
+```rust
+const SCROLL_STEP: u16 = 5;         // PageUp / PageDown
+const MOUSE_SCROLL_STEP: u16 = 1;   // mouse wheel / trackpad (fires 10–20×/sec on trackpad)
+```
+
+- [ ] **Step 3: Enable mouse capture in TerminalGuard::enter()**
+
+The current `enter()` body:
+
+```rust
+    fn enter() -> Result<Self> {
+        enable_raw_mode().context("enable raw mode")?;
+        execute!(io::stdout(), EnterAlternateScreen, EnableBracketedPaste)
+            .context("enter alternate screen")?;
+        Ok(Self)
+    }
+```
+
+Change the `execute!` line to:
+
+```rust
+        execute!(io::stdout(), EnterAlternateScreen, EnableBracketedPaste, EnableMouseCapture)
+            .context("enter alternate screen")?;
+```
+
+- [ ] **Step 4: Disable mouse capture in TerminalGuard::drop()**
+
+The current `drop()` body:
+
+```rust
+    fn drop(&mut self) {
+        let _ = execute!(
+            io::stdout(),
+            LeaveAlternateScreen,
+            DisableBracketedPaste,
+            cursor::Show
+        );
+        let _ = disable_raw_mode();
+    }
+```
+
+Change to:
+
+```rust
+    fn drop(&mut self) {
+        let _ = execute!(
+            io::stdout(),
+            LeaveAlternateScreen,
+            DisableBracketedPaste,
+            DisableMouseCapture,
+            cursor::Show
+        );
+        let _ = disable_raw_mode();
+    }
+```
+
+- [ ] **Step 5: Add Event::Mouse arm in handle_event**
+
+In `handle_event`, there is currently an `Event::Paste(text)` arm and a final `_ => {}` catch-all. Add the `Event::Mouse` arm after `Event::Paste`:
+
+```rust
+        Event::Mouse(mouse_ev) => match mouse_ev.kind {
+            MouseEventKind::ScrollUp => {
+                app.scroll_back = app.scroll_back.saturating_add(MOUSE_SCROLL_STEP);
+            }
+            MouseEventKind::ScrollDown => {
+                app.scroll_back = app.scroll_back.saturating_sub(MOUSE_SCROLL_STEP);
+            }
+            _ => {}
+        },
+```
+
+- [ ] **Step 6: Build**
+
+```bash
+cargo build -p mur-core 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(agent-cli): mouse wheel scroll support (MOUSE_SCROLL_STEP=1)"
+```
+
+---
+
+### Task 6: Update status bar — scroll indicator and ESC hint
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/ui.rs`
+
+- [ ] **Step 1: Update render_status() to show scroll and ESC hints**
+
+The `render_status` function (line 139–183). Replace the body entirely with:
+
+```rust
+fn render_status(f: &mut Frame, app: &App, area: Rect) {
+    let (msg, color) = if app.hitl.is_some() {
+        (
+            "tool approval needed — [y] approve · [a] always (session) · [n] deny".to_string(),
+            Color::Yellow,
+        )
+    } else if app.streaming {
+        let spin = SPINNER[app.spinner % SPINNER.len()];
+        (format!("{spin} generating… Ctrl+C to cancel"), AGENT)
+    } else {
+        let ctx = if app.context_task_id.is_some() {
+            " · context kept"
+        } else {
+            ""
+        };
+        (format!("ready{ctx}"), SYSTEM)
+    };
+
+    // Right-side hint: scroll indicator takes priority over ESC hint.
+    let right_hint: Option<(String, Color)> = if app.scroll_back > 0 {
+        Some((
+            format!("↑ {} lines · ⬇ to bottom", app.scroll_back),
+            SYSTEM,
+        ))
+    } else if app.esc_hint {
+        let hint = if app.streaming {
+            "ESC again to cancel"
+        } else {
+            "ESC again to clear"
+        };
+        Some((hint.to_string(), SYSTEM))
+    } else {
+        None
+    };
+
+    let mut spans = vec![
+        Span::styled(
+            format!(" {} ", app.agent),
+            Style::default().fg(Color::Black).bg(AGENT),
+        ),
+        Span::raw("  "),
+    ];
+    if app.auto_approve {
+        spans.push(Span::styled(
+            " AUTO ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw("  "));
+    }
+    if let Some(meta) = &app.channel {
+        let short: String = meta.id.chars().take(8).collect();
+        spans.push(Span::styled(
+            format!(" ⏵ {}:{} ", short, meta.state),
+            Style::default().fg(Color::Cyan),
+        ));
+        spans.push(Span::raw("  "));
+    }
+    spans.push(Span::styled(msg, Style::default().fg(color)));
+    if let Some((hint, hint_color)) = right_hint {
+        spans.push(Span::styled(
+            format!("  ·  {hint}"),
+            Style::default().fg(hint_color).add_modifier(Modifier::DIM),
+        ));
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cargo build -p mur-core 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+cargo nextest run -p mur-core 2>&1
+```
+
+Expected: all tests pass (the 2 `summarize::rollup` week tests may fail spuriously — unrelated, known issue).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/ui.rs
+git commit -m "feat(agent-cli): scroll indicator + ESC hint in status bar"
+```
+
+---
+
+### Task 7: Manual verification
+
+- [ ] **Step 1: Build and run**
+
+```bash
+cargo build -p mur-core
+mur agent cli <any-running-agent>
+```
+
+- [ ] **Step 2: Test mouse scroll**
+
+Scroll up in the chat pane with the trackpad or mouse wheel. Expected: transcript scrolls up 1 line per scroll event. Scrolling down returns to bottom. Status bar shows `↑ N lines · ⬇ to bottom` while scrolled.
+
+- [ ] **Step 3: Test double-ESC clear (not streaming)**
+
+Type some text in the input box. Press ESC once: status bar should show `ESC again to clear`. Press ESC again within 400ms: input clears.
+
+- [ ] **Step 4: Test double-ESC cancel-restore (streaming)**
+
+Send a message. While the agent is generating: press ESC once (status bar shows `ESC again to cancel`), press ESC again: agent stream cancels, your original message reappears in the input box. Status bar shows `cancelled — message restored` system notice.
+
+- [ ] **Step 5: Test double-ESC window expiry**
+
+Press ESC, wait 500ms, press ESC again: should NOT cancel/clear (window expired, second press is treated as first press of a new window).
+
+- [ ] **Step 6: Final commit if any fixups needed**
+
+```bash
+git add -p
+git commit -m "fix(agent-cli): <describe any fixup>"
+```

--- a/docs/superpowers/plans/2026-06-17-agent-cli-ux-pr2-skins.md
+++ b/docs/superpowers/plans/2026-06-17-agent-cli-ux-pr2-skins.md
@@ -1,0 +1,1084 @@
+# Agent CLI UX — PR 2: Skin System + UI Polish
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a three-skin theming system (dark/light/mur) to the agent CLI, with per-skin colour, border style, padding, and separator settings. Skin is selected via `--skin` flag or `/skin` slash command and persisted to `~/.mur/config.yaml`.
+
+**Architecture:** `Theme` is a pure data struct (`&'static` const) threaded through all render functions. `App` holds `theme: &'static Theme`. `/skin` updates `app.theme` at runtime and writes config. `ui.rs` reads theme fields instead of hardcoded color constants. PR 1 must be merged first.
+
+**Tech Stack:** Rust, ratatui 0.29 (`BorderType`, `Padding`), serde_yaml, clap
+
+**Spec:** `docs/superpowers/specs/2026-06-17-agent-cli-ux-improvements-design.md` — PR 2 section
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `mur-common/src/config.rs` | Add `CliConfig` struct + `cli` field to `Config` |
+| `mur-core/src/cmd/agent/cli/theme.rs` | **NEW** — `Theme` struct, 3 const instances, `resolve_skin()`, `skin_name()` |
+| `mur-core/src/cli/agent.rs` | Add `--skin` to `AgentAction::Cli` |
+| `mur-core/src/dispatch.rs` | Thread `skin` from `AgentAction::Cli` to `cmd_cli()` |
+| `mur-core/src/cmd/agent/cli/mod.rs` | Accept `skin`, load from config/flag, pass to `App`; add `/skin` handler; add `persist_skin()` |
+| `mur-core/src/cmd/agent/cli/app.rs` | Add `theme` field to `App`, `App::new()` takes `theme`; add `Skin(Option<String>)` to `SlashCmd` |
+| `mur-core/src/cmd/agent/cli/ui.rs` | Thread `theme` through all render fns; remove hardcoded color consts; use `border_type`, `Padding`, separators |
+
+---
+
+### Task 1: Add CliConfig to mur-common
+
+**Files:**
+- Modify: `mur-common/src/config.rs`
+
+- [ ] **Step 1: Add CliConfig struct**
+
+Open `mur-common/src/config.rs`. Find the `Config` struct (around line 14). Add this new struct somewhere before `Config` (e.g., just before it):
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CliConfig {
+    /// Active skin for `mur agent cli`. Values: "dark" | "light" | "mur".
+    /// `None` means use the built-in default ("dark").
+    pub skin: Option<String>,
+}
+```
+
+- [ ] **Step 2: Add `cli` field to Config struct**
+
+Inside `pub struct Config { ... }`, add at the end (before the closing `}`):
+
+```rust
+    #[serde(default)]
+    pub cli: CliConfig,
+```
+
+`#[serde(default)]` ensures old `~/.mur/config.yaml` files without a `[cli]` section deserialise cleanly without errors.
+
+- [ ] **Step 3: Build mur-common**
+
+```bash
+cargo build -p mur-common 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-common/src/config.rs
+git commit -m "feat(config): add CliConfig with skin field"
+```
+
+---
+
+### Task 2: Create theme.rs
+
+**Files:**
+- Create: `mur-core/src/cmd/agent/cli/theme.rs`
+
+- [ ] **Step 1: Create the file**
+
+```rust
+//! Skin/theme definitions for the agent CLI TUI.
+
+use ratatui::style::Color;
+use ratatui::widgets::BorderType;
+
+pub struct Theme {
+    // ── labels (bold, identifies speaker) ────────────────────────────────────
+    pub user:         Color,  // "› you" label
+    pub agent:        Color,  // "● agent" label
+    pub shell:        Color,  // "$ cmd" label for !command output
+    // ── body text ─────────────────────────────────────────────────────────────
+    pub user_text:    Color,  // continuation lines of a user turn
+    pub agent_text:   Color,  // continuation lines of an agent reply
+    pub thinking:     Color,  // streaming thinking tokens (italic+dim)
+    // ── chrome ────────────────────────────────────────────────────────────────
+    pub system:       Color,  // system hints, errors, slash-cmd output
+    pub border:       Color,  // transcript + input box borders
+    pub border_title: Color,  // text inside the border title
+    pub separator:    Color,  // inter-message separator line
+    // ── status bar ────────────────────────────────────────────────────────────
+    pub status_bg:    Color,  // status bar background
+    pub badge_fg:     Color,  // agent-name badge foreground
+    pub badge_bg:     Color,  // agent-name badge background
+    // ── layout ────────────────────────────────────────────────────────────────
+    pub border_type:    BorderType,  // Plain | Rounded | Double
+    pub inner_padding:  u8,          // horizontal padding inside panes (0–2)
+    pub show_separator: bool,        // true = ─── line; false = blank line
+    pub compact_input:  bool,        // shorten input box hint text
+}
+
+pub const DARK: Theme = Theme {
+    user:         Color::Green,
+    agent:        Color::Cyan,
+    shell:        Color::Green,
+    user_text:    Color::Gray,
+    agent_text:   Color::White,
+    thinking:     Color::DarkGray,
+    system:       Color::DarkGray,
+    border:       Color::DarkGray,
+    border_title: Color::DarkGray,
+    separator:    Color::DarkGray,
+    status_bg:    Color::Reset,
+    badge_fg:     Color::Black,
+    badge_bg:     Color::Cyan,
+    border_type:    BorderType::Plain,
+    inner_padding:  0,
+    show_separator: false,
+    compact_input:  false,
+};
+
+pub const LIGHT: Theme = Theme {
+    user:         Color::Rgb(0x16, 0x65, 0x34),  // forest green  6.7:1 on white ✓
+    agent:        Color::Rgb(0x0e, 0x6b, 0x8c),  // dark cyan     5.7:1 on white ✓
+    shell:        Color::Rgb(0x16, 0x65, 0x34),
+    user_text:    Color::Rgb(0x22, 0x22, 0x33),  // near-black   17:1 ✓
+    agent_text:   Color::Rgb(0x22, 0x22, 0x33),
+    thinking:     Color::Rgb(0x88, 0x88, 0x99),
+    system:       Color::Rgb(0x77, 0x77, 0x88),  // 3.5:1 — acceptable for hints
+    border:       Color::Rgb(0xd0, 0xd0, 0xe0),
+    border_title: Color::Rgb(0x99, 0x99, 0x99),
+    separator:    Color::Rgb(0xd8, 0xd8, 0xe8),
+    status_bg:    Color::Rgb(0xef, 0xef, 0xf5),
+    badge_fg:     Color::Rgb(0x0e, 0x6b, 0x8c),
+    badge_bg:     Color::Rgb(0xe0, 0xf0, 0xf8),
+    border_type:    BorderType::Rounded,
+    inner_padding:  1,
+    show_separator: true,
+    compact_input:  false,
+};
+
+pub const MUR: Theme = Theme {
+    user:         Color::Rgb(0xa7, 0x8b, 0xfa),  // violet   7.1:1 ✓ WCAG AAA
+    agent:        Color::Rgb(0xfb, 0xbf, 0x24),  // amber   11.5:1 ✓ WCAG AAA
+    shell:        Color::Rgb(0x88, 0x88, 0xcc),
+    user_text:    Color::Rgb(0xc8, 0xc8, 0xe8),  // soft lavender 11.8:1 ✓
+    agent_text:   Color::Rgb(0xe0, 0xe0, 0xf0),  // near-white    13.5:1 ✓
+    thinking:     Color::Rgb(0x44, 0x44, 0x77),
+    system:       Color::Rgb(0x77, 0x77, 0xaa),  // muted violet  4.6:1 ✓ WCAG AA
+    border:       Color::Rgb(0x2a, 0x2a, 0x5a),
+    border_title: Color::Rgb(0x55, 0x55, 0x99),
+    separator:    Color::Rgb(0x22, 0x22, 0x44),
+    status_bg:    Color::Rgb(0x09, 0x09, 0x1a),
+    badge_fg:     Color::Rgb(0xfb, 0xbf, 0x24),
+    badge_bg:     Color::Rgb(0x22, 0x1a, 0x06),
+    border_type:    BorderType::Rounded,
+    inner_padding:  1,
+    show_separator: true,
+    compact_input:  true,
+};
+
+const KNOWN: [(&str, &Theme); 3] = [("dark", &DARK), ("light", &LIGHT), ("mur", &MUR)];
+
+/// Resolve a skin name to a theme. Falls back to `&DARK` for unknown names.
+/// Callers should warn the user when the name is not recognised.
+pub fn resolve_skin(name: &str) -> &'static Theme {
+    KNOWN
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, t)| *t)
+        .unwrap_or(&DARK)
+}
+
+/// Return the canonical name of a theme instance, or "dark" as fallback.
+pub fn skin_name(theme: &'static Theme) -> &'static str {
+    KNOWN
+        .iter()
+        .find(|(_, t)| std::ptr::eq(*t, theme))
+        .map(|(n, _)| *n)
+        .unwrap_or("dark")
+}
+
+/// True if `name` is a valid skin name.
+pub fn is_known_skin(name: &str) -> bool {
+    KNOWN.iter().any(|(n, _)| *n == name)
+}
+```
+
+- [ ] **Step 2: Declare the module in mod.rs**
+
+Open `mur-core/src/cmd/agent/cli/mod.rs`. Find the module declarations at the top (lines 9–15):
+
+```rust
+mod app;
+mod manage;
+mod markdown;
+mod multiplex;
+pub mod persist;
+mod stream;
+mod ui;
+```
+
+Add `mod theme;` to this list (alphabetical order, before `mod ui`):
+
+```rust
+mod app;
+mod manage;
+mod markdown;
+mod multiplex;
+pub mod persist;
+mod stream;
+mod theme;
+mod ui;
+```
+
+- [ ] **Step 3: Write unit tests for theme helpers**
+
+Add a `#[cfg(test)]` block at the bottom of `theme.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_known_skins() {
+        assert!(std::ptr::eq(resolve_skin("dark"),  &DARK));
+        assert!(std::ptr::eq(resolve_skin("light"), &LIGHT));
+        assert!(std::ptr::eq(resolve_skin("mur"),   &MUR));
+    }
+
+    #[test]
+    fn resolve_unknown_falls_back_to_dark() {
+        assert!(std::ptr::eq(resolve_skin("neon"), &DARK));
+        assert!(std::ptr::eq(resolve_skin(""),     &DARK));
+    }
+
+    #[test]
+    fn skin_name_round_trips() {
+        assert_eq!(skin_name(&DARK),  "dark");
+        assert_eq!(skin_name(&LIGHT), "light");
+        assert_eq!(skin_name(&MUR),   "mur");
+    }
+
+    #[test]
+    fn is_known_skin_validates_names() {
+        assert!(is_known_skin("dark"));
+        assert!(is_known_skin("light"));
+        assert!(is_known_skin("mur"));
+        assert!(!is_known_skin("neon"));
+        assert!(!is_known_skin("DARK"));
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo nextest run -p mur-core theme 2>&1
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/theme.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(agent-cli): add Theme struct and DARK/LIGHT/MUR skin constants"
+```
+
+---
+
+### Task 3: Add --skin CLI flag and thread it through to run_tui
+
+**Files:**
+- Modify: `mur-core/src/cli/agent.rs`
+- Modify: `mur-core/src/dispatch.rs`
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs`
+
+- [ ] **Step 1: Add --skin to AgentAction::Cli**
+
+Open `mur-core/src/cli/agent.rs`. Find `AgentAction::Cli { ... }` (line 75–85):
+
+```rust
+    Cli {
+        #[arg(required = true, num_args = 1..)]
+        names: Vec<String>,
+        #[arg(long)]
+        resume: bool,
+        #[arg(long)]
+        auto: bool,
+    },
+```
+
+Change to:
+
+```rust
+    Cli {
+        /// Agent name(s) — more than one opens each chat in its own split pane
+        #[arg(required = true, num_args = 1..)]
+        names: Vec<String>,
+        /// Resume the most recent saved conversation for this agent
+        #[arg(long)]
+        resume: bool,
+        /// Auto-approve every tool call for this session (no HITL prompts)
+        #[arg(long)]
+        auto: bool,
+        /// Visual skin: dark (default) | light | mur
+        #[arg(long)]
+        skin: Option<String>,
+    },
+```
+
+- [ ] **Step 2: Thread skin through dispatch.rs**
+
+Open `mur-core/src/dispatch.rs` around line 1108. Change:
+
+```rust
+        AgentAction::Cli {
+            names,
+            resume,
+            auto,
+        } => cmd::agent::cmd_cli(&names, resume, auto).await?,
+```
+
+To:
+
+```rust
+        AgentAction::Cli {
+            names,
+            resume,
+            auto,
+            skin,
+        } => cmd::agent::cmd_cli(&names, resume, auto, skin).await?,
+```
+
+- [ ] **Step 3: Update cmd_cli signature and pass skin to run_tui**
+
+Open `mur-core/src/cmd/agent/cli/mod.rs`. Change line 51:
+
+```rust
+pub async fn cmd_cli(names: &[String], resume: bool, auto: bool) -> Result<()> {
+```
+
+To:
+
+```rust
+pub async fn cmd_cli(names: &[String], resume: bool, auto: bool, skin: Option<String>) -> Result<()> {
+```
+
+Inside `cmd_cli`, the final line is:
+
+```rust
+    run_tui(home, agent, resume, auto).await
+```
+
+Change to:
+
+```rust
+    run_tui(home, agent, resume, auto, skin).await
+```
+
+Also update the multiplex path at line 54:
+
+```rust
+        return tokio::task::spawn_blocking(move || multiplex::run(&names, resume, auto)).await?;
+```
+
+Change to (multiplex ignores skin for now — uses dark):
+
+```rust
+        return tokio::task::spawn_blocking(move || multiplex::run(&names, resume, auto)).await?;
+```
+
+(No change needed for multiplex in this PR.)
+
+- [ ] **Step 4: Update run_tui signature and add skin loading**
+
+Find `async fn run_tui(home: PathBuf, agent: String, resume: bool, auto: bool) -> Result<()>` (around line 105). Change signature to:
+
+```rust
+async fn run_tui(
+    home: PathBuf,
+    agent: String,
+    resume: bool,
+    auto: bool,
+    skin: Option<String>,
+) -> Result<()> {
+```
+
+At the TOP of `run_tui`, before any existing code, add:
+
+```rust
+    // Resolve skin: CLI flag > config > "dark"
+    let cfg = mur_common::Config::load_or_default(&home.join("config.yaml"));
+    let skin_name = skin.as_deref()
+        .or_else(|| cfg.cli.skin.as_deref())
+        .unwrap_or("dark");
+    let unknown_skin = !theme::is_known_skin(skin_name);
+    let active_theme = theme::resolve_skin(skin_name);
+```
+
+- [ ] **Step 5: Build**
+
+```bash
+cargo build -p mur-core 2>&1
+```
+
+Expected: no errors. (There will be errors about `App::new` receiving wrong argument count — those are fixed in Task 4.)
+
+- [ ] **Step 6: Commit (partial — will fix App::new in Task 4)**
+
+```bash
+git add mur-core/src/cli/agent.rs mur-core/src/dispatch.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(agent-cli): add --skin flag and thread through to run_tui"
+```
+
+---
+
+### Task 4: Add theme field to App and update App::new callers
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/app.rs`
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs`
+
+- [ ] **Step 1: Add use for Theme in app.rs**
+
+At the top of `app.rs`, add:
+
+```rust
+use super::theme::Theme;
+```
+
+- [ ] **Step 2: Add theme field to App struct**
+
+Inside `pub struct App { ... }`, add after `cwd_sent: bool` (but before the ESC fields added in PR 1):
+
+```rust
+    /// Active visual skin, resolved at startup. Updated live by `/skin`.
+    pub theme: &'static Theme,
+```
+
+- [ ] **Step 3: Update App::new() signature**
+
+Change:
+
+```rust
+    pub fn new(home: PathBuf, agent: String, session: Session) -> Self {
+```
+
+To:
+
+```rust
+    pub fn new(home: PathBuf, agent: String, session: Session, theme: &'static Theme) -> Self {
+```
+
+Inside `Self { ... }`, add after `cwd_sent: false`:
+
+```rust
+            theme,
+```
+
+- [ ] **Step 4: Update App::new() callers in mod.rs**
+
+In `run_tui`, find the calls to `App::new(...)`. There are two — one for resume and one for fresh start. Both look like:
+
+```rust
+App::new(home.to_path_buf(), agent.to_string(), Session::create(home, agent)?)
+```
+
+Change each to pass `active_theme`:
+
+```rust
+App::new(home.to_path_buf(), agent.to_string(), Session::create(home, agent)?, active_theme)
+```
+
+Do the same for the resume path:
+
+```rust
+App::new(home.to_path_buf(), agent.to_string(), session, active_theme)
+```
+
+(Search for all `App::new(` calls in `mod.rs` and add `active_theme` as the last argument to each.)
+
+- [ ] **Step 5: Add the unknown skin warning after App creation**
+
+In `run_tui`, after `let mut app = ...` (or after `init_app(...)` depending on the resume path), add:
+
+```rust
+    if unknown_skin {
+        app.push_system(format!(
+            "unknown skin '{skin_name}', using dark — valid: dark, light, mur"
+        ));
+    }
+```
+
+- [ ] **Step 6: Update tests in app.rs**
+
+The `app()` and `app_at()` test helpers call `App::new(...)`. Add `&super::theme::DARK` as the last argument:
+
+Find:
+
+```rust
+    fn app() -> App {
+        let home = tempdir().unwrap();
+        let session = Session::create(home.path(), "a").unwrap();
+        App::new(home.path().to_path_buf(), "a".into(), session)
+    }
+
+    fn app_at(home: &tempfile::TempDir) -> App {
+        let session = Session::create(home.path(), "a").unwrap();
+        App::new(home.path().to_path_buf(), "a".into(), session)
+    }
+```
+
+Change both to:
+
+```rust
+    fn app() -> App {
+        let home = tempdir().unwrap();
+        let session = Session::create(home.path(), "a").unwrap();
+        App::new(home.path().to_path_buf(), "a".into(), session, &super::theme::DARK)
+    }
+
+    fn app_at(home: &tempfile::TempDir) -> App {
+        let session = Session::create(home.path(), "a").unwrap();
+        App::new(home.path().to_path_buf(), "a".into(), session, &super::theme::DARK)
+    }
+```
+
+- [ ] **Step 7: Build and run tests**
+
+```bash
+cargo build -p mur-core 2>&1
+cargo nextest run -p mur-core 2>&1
+```
+
+Expected: builds clean, all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/app.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(agent-cli): add theme field to App, thread active_theme through"
+```
+
+---
+
+### Task 5: Add Skin slash command + persist_skin
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/app.rs`
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs`
+
+- [ ] **Step 1: Add Skin variant to SlashCmd enum**
+
+In `app.rs`, add to the `SlashCmd` enum:
+
+```rust
+    /// `/skin [dark|light|mur]` — show or switch the active skin (persists to config).
+    Skin(Option<String>),
+```
+
+- [ ] **Step 2: Add skin to parse_slash()**
+
+In `parse_slash()`, add after the `"auto"` arm:
+
+```rust
+        "skin" | "theme" => SlashCmd::Skin(words.next().map(str::to_string)),
+```
+
+- [ ] **Step 3: Add "/skin" to SLASH_COMMANDS**
+
+The current array has 10 entries. Change to 11:
+
+```rust
+pub const SLASH_COMMANDS: [&str; 11] = [
+    "/help",
+    "/clear",
+    "/card",
+    "/sessions",
+    "/channels",
+    "/auto",
+    "/mcp",
+    "/skill",
+    "/skin",
+    "/exit",
+    "/quit",
+];
+```
+
+- [ ] **Step 4: Write a unit test for parse_slash skin**
+
+In the `#[cfg(test)]` block:
+
+```rust
+    #[test]
+    fn parse_slash_skin_variants() {
+        assert_eq!(parse_slash("/skin"), Some(SlashCmd::Skin(None)));
+        assert_eq!(parse_slash("/skin mur"), Some(SlashCmd::Skin(Some("mur".into()))));
+        assert_eq!(parse_slash("/theme light"), Some(SlashCmd::Skin(Some("light".into()))));
+    }
+```
+
+- [ ] **Step 5: Run the test**
+
+```bash
+cargo nextest run -p mur-core parse_slash_skin 2>&1
+```
+
+Expected: 1 test passes.
+
+- [ ] **Step 6: Add persist_skin() function in mod.rs**
+
+In `mod.rs`, add this function near the other helper functions (e.g., after `complete_slash`):
+
+```rust
+/// Write `cli.skin = name` to `~/.mur/config.yaml` atomically.
+fn persist_skin(home: &std::path::Path, name: &str) -> anyhow::Result<()> {
+    use mur_common::Config;
+    let path = home.join("config.yaml");
+    let mut cfg = Config::load_or_default(&path);
+    cfg.cli.skin = Some(name.to_string());
+    let text = serde_yaml::to_string(&cfg).context("serialise config")?;
+    let tmp = path.with_extension("yaml.tmp");
+    std::fs::write(&tmp, &text).context("write config tmp")?;
+    std::fs::rename(&tmp, &path).context("rename config")?;
+    Ok(())
+}
+```
+
+- [ ] **Step 7: Handle SlashCmd::Skin in handle_slash()**
+
+In `handle_slash()`, add the `Skin` arm:
+
+```rust
+        SlashCmd::Skin(name_opt) => match name_opt {
+            None => {
+                let current = theme::skin_name(app.theme);
+                app.push_system(format!("current skin: {current} — valid: dark, light, mur"));
+            }
+            Some(name) => {
+                if !theme::is_known_skin(&name) {
+                    app.push_system(format!(
+                        "unknown skin '{name}' — valid: dark, light, mur"
+                    ));
+                } else {
+                    app.theme = theme::resolve_skin(&name);
+                    let h = app.home.clone();
+                    match persist_skin(&h, &name) {
+                        Ok(()) => app.push_system(format!("skin changed to {name}")),
+                        Err(e) => app.push_system(format!(
+                            "skin changed to {name} (could not persist: {e})"
+                        )),
+                    }
+                }
+            }
+        },
+```
+
+- [ ] **Step 8: Build**
+
+```bash
+cargo build -p mur-core 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/app.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(agent-cli): /skin slash command + persist to config"
+```
+
+---
+
+### Task 6: Update ui.rs to use Theme
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/ui.rs`
+
+This is the main visual refactor. The current file uses three hardcoded constants `USER`, `AGENT`, `SYSTEM`. We replace those with per-call lookups from `app.theme`.
+
+- [ ] **Step 1: Add imports for BorderType and Padding**
+
+At the top of `ui.rs`, the current ratatui imports are:
+
+```rust
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+```
+
+Change to:
+
+```rust
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap};
+```
+
+- [ ] **Step 2: Remove the three hardcoded color constants**
+
+Delete lines 12–14:
+
+```rust
+const USER: Color = Color::Green;
+const AGENT: Color = Color::Cyan;
+const SYSTEM: Color = Color::DarkGray;
+```
+
+(The compiler will now error on every use of `USER`, `AGENT`, `SYSTEM` — each error points to where a theme reference needs to go.)
+
+- [ ] **Step 3: Update render_transcript() to use theme**
+
+The current `render_transcript` signature is `fn render_transcript(f: &mut Frame, app: &App, area: Rect)`. It accesses `app.theme`. No signature change needed.
+
+Replace the function body:
+
+```rust
+fn render_transcript(f: &mut Frame, app: &App, area: Rect) {
+    let theme = app.theme;
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(theme.border_type)
+        .border_style(Style::default().fg(theme.border))
+        .padding(Padding::horizontal(theme.inner_padding as u16))
+        .title(format!(" chat · {} ", app.agent))
+        .title_style(Style::default().fg(theme.border_title));
+    let inner = block.inner(area);
+
+    let mut lines: Vec<Line> = Vec::new();
+    let msg_count = app.messages.len();
+    for (i, m) in app.messages.iter().enumerate() {
+        push_message(&mut lines, m, app.spinner, theme);
+        // Separator between messages (not after the last one)
+        if i + 1 < msg_count {
+            if theme.show_separator {
+                let sep_width = inner.width as usize;
+                lines.push(Line::styled(
+                    "─".repeat(sep_width),
+                    Style::default().fg(theme.separator),
+                ));
+            } else {
+                lines.push(Line::default());
+            }
+        }
+    }
+
+    if lines.is_empty() {
+        lines.push(Line::styled(
+            "Say hello — type below and press Enter.",
+            Style::default().fg(theme.system),
+        ));
+    }
+
+    let total = lines.len() as u16;
+    let visible = inner.height;
+    let max_off = total.saturating_sub(visible);
+    let offset = max_off.saturating_sub(app.scroll_back);
+
+    let output = Paragraph::new(Text::from(lines))
+        .block(block)
+        .wrap(Wrap { trim: false })
+        .scroll((offset, 0));
+    f.render_widget(output, area);
+}
+```
+
+- [ ] **Step 4: Update push_message() to accept and use theme**
+
+Change the signature from `fn push_message(lines: &mut Vec<Line<'static>>, m: &ChatMsg, spinner: usize)` to:
+
+```rust
+fn push_message(
+    lines: &mut Vec<Line<'static>>,
+    m: &ChatMsg,
+    spinner: usize,
+    theme: &'static super::theme::Theme,
+) {
+```
+
+Then update all color references inside the function. The complete new body:
+
+```rust
+    match m.role {
+        Role::User => {
+            let mut it = m.text.lines();
+            if let Some(first) = it.next() {
+                lines.push(Line::styled(
+                    first.to_string(),
+                    Style::default().fg(theme.user).add_modifier(Modifier::BOLD),
+                ));
+            }
+            for l in it {
+                lines.push(Line::styled(l.to_string(), Style::default().fg(theme.user_text)));
+            }
+        }
+        Role::Shell => {
+            let mut it = m.text.lines();
+            if let Some(first) = it.next() {
+                lines.push(Line::styled(
+                    first.to_string(),
+                    Style::default().fg(theme.shell).add_modifier(Modifier::BOLD),
+                ));
+            }
+            for l in it {
+                lines.push(Line::styled(l.to_string(), Style::default().fg(theme.user_text)));
+            }
+        }
+        Role::System => {
+            for l in m.text.lines() {
+                lines.push(Line::styled(
+                    l.to_string(),
+                    Style::default().fg(theme.system).add_modifier(Modifier::ITALIC),
+                ));
+            }
+        }
+        Role::Agent => {
+            lines.push(Line::from(Span::styled(
+                "● agent",
+                Style::default().fg(theme.agent).add_modifier(Modifier::BOLD),
+            )));
+            if m.streaming {
+                if !m.thinking.is_empty() {
+                    for l in m.thinking.lines() {
+                        lines.push(Line::styled(
+                            l.to_string(),
+                            Style::default()
+                                .fg(theme.thinking)
+                                .add_modifier(Modifier::ITALIC | Modifier::DIM),
+                        ));
+                    }
+                }
+                let mut body: Vec<Line> = m.text.lines().map(|l| Line::raw(l.to_string())).collect();
+                let spin = SPINNER[spinner % SPINNER.len()];
+                match body.last_mut() {
+                    Some(last) => last
+                        .spans
+                        .push(Span::styled(format!(" {spin}"), Style::default().fg(theme.agent))),
+                    None => body.push(Line::styled(spin.to_string(), Style::default().fg(theme.agent))),
+                }
+                lines.extend(body);
+            } else if let Some(cached) = &m.rendered {
+                lines.extend(cached.iter().cloned());
+            } else {
+                lines.extend(super::markdown::render(&m.text).lines);
+            }
+        }
+    }
+```
+
+Note: the trailing `lines.push(Line::default())` that used to be at the end of each branch is REMOVED — separator logic is now in `render_transcript`.
+
+- [ ] **Step 5: Update render_status() to use theme**
+
+The `render_status` function was updated in PR 1 to use the `AGENT` and `SYSTEM` constants — replace those with `theme` lookups.
+
+Change `fn render_status(f: &mut Frame, app: &App, area: Rect)` body:
+
+Replace `AGENT` with `app.theme.agent`, `SYSTEM` with `app.theme.system`, and update the badge to use `app.theme.badge_fg`/`badge_bg`:
+
+```rust
+fn render_status(f: &mut Frame, app: &App, area: Rect) {
+    let theme = app.theme;
+    let (msg, color) = if app.hitl.is_some() {
+        (
+            "tool approval needed — [y] approve · [a] always (session) · [n] deny".to_string(),
+            Color::Yellow,
+        )
+    } else if app.streaming {
+        let spin = SPINNER[app.spinner % SPINNER.len()];
+        (format!("{spin} generating… Ctrl+C to cancel"), theme.agent)
+    } else {
+        let ctx = if app.context_task_id.is_some() { " · context kept" } else { "" };
+        (format!("ready{ctx}"), theme.system)
+    };
+
+    let right_hint: Option<(String, Color)> = if app.scroll_back > 0 {
+        Some((format!("↑ {} lines · ⬇ to bottom", app.scroll_back), theme.system))
+    } else if app.esc_hint {
+        let hint = if app.streaming { "ESC again to cancel" } else { "ESC again to clear" };
+        Some((hint.to_string(), theme.system))
+    } else {
+        None
+    };
+
+    let mut spans = vec![
+        Span::styled(
+            format!(" {} ", app.agent),
+            Style::default().fg(theme.badge_fg).bg(theme.badge_bg),
+        ),
+        Span::raw("  "),
+    ];
+    if app.auto_approve {
+        spans.push(Span::styled(
+            " AUTO ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw("  "));
+    }
+    if let Some(meta) = &app.channel {
+        let short: String = meta.id.chars().take(8).collect();
+        spans.push(Span::styled(
+            format!(" ⏵ {}:{} ", short, meta.state),
+            Style::default().fg(theme.agent),
+        ));
+        spans.push(Span::raw("  "));
+    }
+    spans.push(Span::styled(msg, Style::default().fg(color)));
+    if let Some((hint, hint_color)) = right_hint {
+        spans.push(Span::styled(
+            format!("  ·  {hint}"),
+            Style::default().fg(hint_color).add_modifier(Modifier::DIM),
+        ));
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+```
+
+- [ ] **Step 6: Update sync_input_block() in app.rs to use theme**
+
+In `app.rs`, `sync_input_block()` currently builds blocks with hardcoded `Color::Red` for shell mode. The method now accesses `self.theme`:
+
+```rust
+    pub fn sync_input_block(&mut self) {
+        let theme = self.theme;
+        let hint = if theme.compact_input {
+            " message — Enter · Alt+Enter · /help "
+        } else {
+            " message — Enter to send · Alt+Enter newline · /help · Ctrl+D quit "
+        };
+        let is_shell = self.input_text().trim_start().starts_with('!');
+        let block = if is_shell {
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(theme.border_type)
+                .border_style(Style::default().fg(Color::Red))
+                .padding(Padding::horizontal(theme.inner_padding as u16))
+                .title(" ! shell command — output shared with agent ")
+        } else {
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(theme.border_type)
+                .border_style(Style::default().fg(theme.border))
+                .padding(Padding::horizontal(theme.inner_padding as u16))
+                .title(hint)
+                .title_style(Style::default().fg(theme.border_title))
+        };
+        self.input.set_block(block);
+    }
+```
+
+Also update `new_input()` (which sets the initial block before the theme is available) to use plain/dark defaults:
+
+```rust
+fn new_input() -> TextArea<'static> {
+    let mut ta = TextArea::default();
+    ta.set_block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" message — Enter to send · Alt+Enter newline · /help · Ctrl+D quit "),
+    );
+    ta.set_cursor_line_style(Style::default());
+    ta.set_placeholder_text("Type a message…");
+    ta.set_placeholder_style(Style::default().fg(Color::DarkGray));
+    ta
+}
+```
+
+(The block is immediately replaced by `sync_input_block()` on the first render loop tick, so the initial block is only visible for one frame and doesn't need theming.)
+
+- [ ] **Step 7: Add Padding import to app.rs**
+
+At top of `app.rs`:
+
+```rust
+use ratatui::widgets::{Block, Borders, Padding};
+```
+
+- [ ] **Step 8: Build — expect clean**
+
+```bash
+cargo build -p mur-core 2>&1
+```
+
+Expected: no errors.
+
+- [ ] **Step 9: Run full test suite**
+
+```bash
+cargo nextest run -p mur-core 2>&1
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/ui.rs mur-core/src/cmd/agent/cli/app.rs
+git commit -m "feat(agent-cli): thread Theme through ui.rs — border_type, padding, separator, colors"
+```
+
+---
+
+### Task 7: Manual verification of all three skins
+
+- [ ] **Step 1: Start an agent and test dark skin (default)**
+
+```bash
+cargo build -p mur-core && mur agent cli <name>
+```
+
+Expected: UI looks identical to before this PR (zero regression).
+
+- [ ] **Step 2: Test light skin via flag**
+
+```bash
+mur agent cli <name> --skin light
+```
+
+Expected: white/ivory background, rounded borders, forest-green user label, navy agent label, separator lines between messages.
+
+- [ ] **Step 3: Test MUR skin via flag**
+
+```bash
+mur agent cli <name> --skin mur
+```
+
+Expected: deep navy/indigo background, violet user labels, amber agent label, rounded borders, separator lines.
+
+- [ ] **Step 4: Test /skin command at runtime**
+
+Inside the CLI, type `/skin mur`. Expected: skin switches live, system message "skin changed to mur", config written.
+
+- [ ] **Step 5: Verify config persistence**
+
+```bash
+grep -A2 'cli:' ~/.mur/config.yaml
+```
+
+Expected: shows `skin: mur`.
+
+- [ ] **Step 6: Verify persisted skin loads on restart**
+
+Exit the CLI and re-open without `--skin`. Expected: MUR skin loads.
+
+- [ ] **Step 7: Test unknown skin warning**
+
+```bash
+mur agent cli <name> --skin neon
+```
+
+Expected: TUI opens with dark skin and shows system message: `unknown skin 'neon', using dark — valid: dark, light, mur`.
+
+- [ ] **Step 8: Run lint**
+
+```bash
+cargo clippy -p mur-core -- -D warnings 2>&1
+```
+
+Fix any warnings before the final commit.
+
+- [ ] **Step 9: Final commit if fixups needed**
+
+```bash
+git add -p
+git commit -m "fix(agent-cli): <describe fixup>"
+```

--- a/docs/superpowers/specs/2026-06-17-agent-cli-ux-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-17-agent-cli-ux-improvements-design.md
@@ -108,6 +108,7 @@ New file: `mur-core/src/cmd/agent/cli/theme.rs`
 
 ```rust
 pub struct Theme {
+    // ── colours ──────────────────────────────────────────────
     pub user:           Color,   // user turn label + text
     pub agent:          Color,   // agent turn label
     pub system:         Color,   // system/hint messages
@@ -117,10 +118,61 @@ pub struct Theme {
     pub badge_fg:       Color,   // agent-name badge foreground
     pub badge_bg:       Color,   // agent-name badge background
     pub separator:      Color,   // inter-message separator line
-}
 
-pub const DARK: Theme = Theme { /* refined dark palette */ };
-pub const LIGHT: Theme = Theme { /* light palette */ };
+    // ── layout / spacing ─────────────────────────────────────
+    pub border_type:      BorderType, // Plain | Rounded | Double
+    pub inner_padding:    u16,        // horizontal padding inside panes (0 or 1)
+    pub show_separator:   bool,       // show ─── line between messages
+                                      // false = blank line (current style)
+    pub compact_input:    bool,       // single-line hint vs full hint in input title
+}
+```
+
+Each skin gets a distinct layout feel:
+
+| Skin  | `border_type` | `inner_padding` | `show_separator` | `compact_input` |
+|-------|--------------|-----------------|------------------|-----------------|
+| Dark  | `Plain`      | 0               | false (blank)    | false           |
+| Light | `Rounded`    | 1               | true (─── line)  | false           |
+| MUR   | `Rounded`    | 1               | true (─── line)  | true            |
+
+`Dark` keeps the current square borders and blank-line spacing — zero visual regression for existing users. `Light` and `MUR` both get rounded borders, 1-cell inner padding, and the separator line.
+
+```rust
+pub const DARK: Theme = Theme {
+    // colours: refined version of current palette
+    user:         Color::Green,
+    agent:        Color::Cyan,
+    system:       Color::DarkGray,
+    border:       Color::DarkGray,
+    border_title: Color::DarkGray,
+    status_bg:    Color::Reset,
+    badge_fg:     Color::Cyan,
+    badge_bg:     Color::Reset,
+    separator:    Color::DarkGray,
+    // layout
+    border_type:    BorderType::Plain,
+    inner_padding:  0,
+    show_separator: false,
+    compact_input:  false,
+};
+
+pub const LIGHT: Theme = Theme {
+    user:         Color::Rgb(0x16, 0x65, 0x34),  // forest green
+    agent:        Color::Rgb(0x0e, 0x6b, 0x8c),  // dark cyan
+    system:       Color::Rgb(0xaa, 0xaa, 0xaa),
+    border:       Color::Rgb(0xd0, 0xd0, 0xe0),
+    border_title: Color::Rgb(0x99, 0x99, 0x99),
+    status_bg:    Color::Rgb(0xef, 0xef, 0xf5),
+    badge_fg:     Color::Rgb(0x0e, 0x6b, 0x8c),
+    badge_bg:     Color::Rgb(0xe0, 0xf0, 0xf8),
+    separator:    Color::Rgb(0xd8, 0xd8, 0xe8),
+    border_type:    BorderType::Rounded,
+    inner_padding:  1,
+    show_separator: true,
+    compact_input:  false,
+};
+
 pub const MUR: Theme = Theme {
     user:         Color::Rgb(0xa7, 0x8b, 0xfa),  // violet
     agent:        Color::Rgb(0xfb, 0xbf, 0x24),  // amber
@@ -131,6 +183,10 @@ pub const MUR: Theme = Theme {
     badge_fg:     Color::Rgb(0xfb, 0xbf, 0x24),
     badge_bg:     Color::Rgb(0x1a, 0x14, 0x0a),
     separator:    Color::Rgb(0x1e, 0x1e, 0x44),
+    border_type:    BorderType::Rounded,
+    inner_padding:  1,
+    show_separator: true,
+    compact_input:  true,
 };
 ```
 
@@ -168,19 +224,21 @@ Handler:
 - With a valid name: call `resolve_skin`, update `app.theme`, write `cli.skin` to `~/.mur/config.yaml`.
 - With an unknown name: show error listing valid names.
 
-### UI Layout Changes (all skins)
+### UI Layout Changes (skin-driven)
 
-**Borders:** Switch from `Borders::ALL` to `Borders::ROUNDED` for both the transcript pane and the input box. Ratatui provides rounded Unicode corners (`╭ ╮ ╰ ╯`) via `BorderType::Rounded`.
+**Borders:** `render_transcript` and the input `Block` read `theme.border_type` to set `BorderType`. Dark keeps `Plain`; Light and MUR use `Rounded` (`╭ ╮ ╰ ╯`).
 
-**Message separators:** Remove the blank `Line::default()` spacer between messages. Replace with a single `Line::styled("─".repeat(width), dim_style)` where `width` is the inner pane width minus 2. This keeps the visual break without eating vertical space.
+**Inner padding:** When `theme.inner_padding > 0`, wrap the inner content area with `Layout` horizontal margins of `theme.inner_padding` cells on each side.
 
-**Status bar:** Replace plain text with:
+**Message separators:** If `theme.show_separator` is true, push `Line::styled("─".repeat(inner_width), Style::default().fg(theme.separator))` between messages instead of `Line::default()`. `inner_width` is the pane's inner rect width. Dark keeps the blank line spacer to avoid any visual change for existing users.
+
+**Status bar (all skins):** Replace plain text with:
 ```
 [badge: agent-name]  ▶ state  ·  channel-short  (right-align: context kept / not saved)
 ```
-Badge rendered as `Span` with `bg(badge_bg).fg(badge_fg)` style.
+Badge rendered as `Span` with `bg(theme.badge_bg).fg(theme.badge_fg)` style.
 
-**Input box title:** Shortened hint text: `message — Enter · Alt+Enter newline · /help`.
+**Input box title:** If `theme.compact_input`, use shortened hint `message — Enter · Alt+Enter · /help`; otherwise keep the current full hint text.
 
 ### File Size Check
 

--- a/docs/superpowers/specs/2026-06-17-agent-cli-ux-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-17-agent-cli-ux-improvements-design.md
@@ -17,9 +17,9 @@ Two-PR series improving the `mur agent cli` TUI:
 
 ### 1. Mouse Scroll
 
-**Where:** `TerminalGuard` (enter/drop) and `handle_event` in `mod.rs`.
+**Files:** `TerminalGuard` (enter/drop) and `handle_event` in `mod.rs`.
 
-Enable mouse capture on TUI entry and release it on exit:
+Enable mouse capture on TUI entry and release on exit:
 
 ```rust
 // TerminalGuard::enter()
@@ -33,70 +33,135 @@ Add a mouse arm to `handle_event`:
 
 ```rust
 Event::Mouse(mouse_ev) => match mouse_ev.kind {
-    MouseEventKind::ScrollUp   => app.scroll_back = app.scroll_back.saturating_add(SCROLL_STEP),
-    MouseEventKind::ScrollDown => app.scroll_back = app.scroll_back.saturating_sub(SCROLL_STEP),
+    MouseEventKind::ScrollUp   => app.scroll_back = app.scroll_back.saturating_add(MOUSE_SCROLL_STEP),
+    MouseEventKind::ScrollDown => app.scroll_back = app.scroll_back.saturating_sub(MOUSE_SCROLL_STEP),
     _ => {}
 }
 ```
 
-No other mouse events (clicks, drag) are handled.
-
-### 2. Double-ESC to Clear Input
-
-**New `App` field:**
+Use a **separate constant** from page-scroll:
 
 ```rust
-last_esc_at: Option<std::time::Instant>,
+const SCROLL_STEP: u16       = 5;   // PageUp / PageDown
+const MOUSE_SCROLL_STEP: u16 = 1;   // mouse wheel / trackpad
 ```
 
-**Constant:**
+`SCROLL_STEP = 5` for PageUp/PageDown is correct. `MOUSE_SCROLL_STEP = 1` prevents the trackpad from firing 10–20 events/sec × 5 = jumping 50–100 lines per gesture.
+
+No other mouse events (clicks, drag) are handled. Terminal text selection still works in terminals that restore it on Shift (e.g. iTerm2, Ghostty).
+
+### 2. Double-ESC: Clear Input and Cancel+Restore
+
+Both behaviours share one state machine. The key insight: the first ESC always arms the window regardless of input state, so the cancel-while-streaming path is reachable even when the input is empty after submission.
+
+**New `App` fields:**
 
 ```rust
-const ESC_DOUBLE_WINDOW: Duration = Duration::from_millis(400);
+last_esc_at: Option<std::time::Instant>,   // armed after first ESC
+esc_hint:    bool,                          // show hint in status bar
+last_sent:   Option<String>,               // last successfully submitted text
 ```
 
-**ESC key handler in `handle_event`:**
-
-```
-on ESC press:
-  if input is empty → do nothing
-  if last_esc_at is Some(t) && t.elapsed() < ESC_DOUBLE_WINDOW:
-    clear input
-    last_esc_at = None
-  else:
-    last_esc_at = Some(Instant::now())
-    (optional: show dim hint in status "ESC again to clear")
-
-on any non-ESC key press:
-  last_esc_at = None
-```
-
-Status bar hint is ephemeral — stored as `App.esc_hint: bool`, cleared on next keypress.
-
-### 3. Double-ESC to Cancel-and-Restore (while streaming)
-
-**New `App` field:**
+**New constant:**
 
 ```rust
-last_sent: Option<String>,
+const ESC_DOUBLE_WINDOW: std::time::Duration = std::time::Duration::from_millis(400);
 ```
 
-Set in `submit()` immediately before `app.clear_input()`.
+**ESC key handler (pure state-machine logic — extracted for testability):**
 
-**Modified double-ESC second-press logic:**
+```rust
+enum EscAction { Arm, ClearInput, CancelAndRestore, Nothing }
 
+fn esc_action(
+    last_esc_at: Option<std::time::Instant>,
+    streaming: bool,
+    input_empty: bool,
+) -> EscAction {
+    if let Some(t) = last_esc_at {
+        if t.elapsed() < ESC_DOUBLE_WINDOW {
+            // second ESC within window
+            return if streaming {
+                EscAction::CancelAndRestore
+            } else if !input_empty {
+                EscAction::ClearInput
+            } else {
+                EscAction::Nothing
+            };
+        }
+    }
+    // first ESC (or window expired): arm if there's anything to act on
+    if streaming || !input_empty {
+        EscAction::Arm
+    } else {
+        EscAction::Nothing
+    }
+}
 ```
-on double-ESC second press:
-  if app.streaming:
-    cancel_in_flight(app, tx)           // same path as Ctrl+C
-    if let Some(text) = app.last_sent:
-      app.set_input(&text)              // restore message to input box
-    app.push_system("cancelled — message restored")
-  else:
-    clear input                         // standard clear
+
+**Dispatch in `handle_event`:**
+
+```rust
+KeyCode::Esc => {
+    let action = esc_action(app.last_esc_at, app.streaming, app.input_text().is_empty());
+    match action {
+        EscAction::Arm => {
+            app.last_esc_at = Some(std::time::Instant::now());
+            app.esc_hint = true;
+        }
+        EscAction::ClearInput => {
+            app.clear_input();
+            app.last_esc_at = None;
+            app.esc_hint = false;
+        }
+        EscAction::CancelAndRestore => {
+            cancel_in_flight(app, tx);
+            if let Some(text) = app.last_sent.clone() {
+                app.set_input(&text);
+            }
+            app.push_system("cancelled — message restored");
+            app.last_esc_at = None;
+            app.esc_hint = false;
+        }
+        EscAction::Nothing => {
+            app.last_esc_at = None;
+            app.esc_hint = false;
+        }
+    }
+}
 ```
 
-`last_sent` is NOT cleared by `start_new_session` or `/clear` (a stale restore after session reset is harmless; user can just ESC again to clear).
+**On any non-ESC key press** (add to the top of the `Event::Key` arm, before routing to `app.input.input(key)`):
+
+```rust
+if key.code != KeyCode::Esc {
+    app.last_esc_at = None;
+    app.esc_hint = false;
+}
+```
+
+**`last_sent` lifecycle:**
+- Set in `submit()` immediately before `app.clear_input()`.
+- Cleared in `start_new_session()` — if the user does `/clear` to start fresh, restoring a message from the old session would be surprising.
+- NOT cleared by a streaming `Done`/`Err` event — the message is still the last thing the user sent.
+
+**Edge case — streaming finishes between ESC 1 and ESC 2:**
+If the agent finishes streaming in the ~400ms between the two ESCs, `streaming` is false on the second press, so `ClearInput` fires instead of `CancelAndRestore`. This is the correct behaviour: there is nothing left to cancel.
+
+**Status bar ESC hint:**
+When `app.esc_hint` is true, append a dim span to the status bar:
+- If `streaming`: ` · ESC again to cancel`
+- Otherwise: ` · ESC again to clear`
+
+### 3. Scroll Position Indicator
+
+When `scroll_back > 0`, users need visual feedback that they are not at the bottom.
+
+**Status bar change:** when `scroll_back > 0`, right-side of status bar shows:
+```
+↑ {scroll_back} lines · ⬇ to bottom
+```
+This replaces the `context kept` label while scrolled. When back at bottom (`scroll_back == 0`), `context kept` returns.
 
 ---
 
@@ -107,50 +172,64 @@ on double-ESC second press:
 New file: `mur-core/src/cmd/agent/cli/theme.rs`
 
 ```rust
+use ratatui::style::{Color, Style};
+use ratatui::widgets::{BorderType, Padding};
+
 pub struct Theme {
-    // ── colours ──────────────────────────────────────────────
-    pub user:           Color,   // user turn label + text
-    pub agent:          Color,   // agent turn label
-    pub system:         Color,   // system/hint messages
+    // ── labels (bold, identifies speaker) ────────────────────
+    pub user:           Color,   // "› you" label
+    pub agent:          Color,   // "● agent" label
+    pub shell:          Color,   // "$ cmd" label in !command output
+    // ── body text (normal weight, the actual message) ─────────
+    pub user_text:      Color,   // continuation lines of user turn
+    pub agent_text:     Color,   // continuation lines of agent reply
+    pub thinking:       Color,   // streaming thinking tokens (italic + dim)
+    // ── chrome ───────────────────────────────────────────────
+    pub system:         Color,   // system hints, errors, slash-cmd output
     pub border:         Color,   // transcript + input borders
     pub border_title:   Color,   // border title text
+    pub separator:      Color,   // inter-message separator line (if show_separator)
+    // ── status bar ───────────────────────────────────────────
     pub status_bg:      Color,   // status bar background
     pub badge_fg:       Color,   // agent-name badge foreground
     pub badge_bg:       Color,   // agent-name badge background
-    pub separator:      Color,   // inter-message separator line
 
     // ── layout / spacing ─────────────────────────────────────
-    pub border_type:      BorderType, // Plain | Rounded | Double
-    pub inner_padding:    u16,        // horizontal padding inside panes (0 or 1)
-    pub show_separator:   bool,       // show ─── line between messages
-                                      // false = blank line (current style)
-    pub compact_input:    bool,       // single-line hint vs full hint in input title
+    pub border_type:    BorderType, // Plain | Rounded | Double
+    pub inner_padding:  u8,         // horizontal padding inside panes; valid range 0–2
+    pub show_separator: bool,       // true = ─── line between messages
+                                    // false = blank line (current Dark behaviour)
+    pub compact_input:  bool,       // shortened hint in input box title
 }
 ```
 
-Each skin gets a distinct layout feel:
+**Rationale for split `user` / `user_text`:** the label uses the accent color at full saturation; the body is a lighter/dimmer tint. This prevents large blocks of vivid color while keeping speaker identity clear at a glance. Same split for `agent` / `agent_text`.
+
+Each skin has a distinct layout feel:
 
 | Skin  | `border_type` | `inner_padding` | `show_separator` | `compact_input` |
-|-------|--------------|-----------------|------------------|-----------------|
+|-------|:------------:|:---------------:|:----------------:|:---------------:|
 | Dark  | `Plain`      | 0               | false (blank)    | false           |
 | Light | `Rounded`    | 1               | true (─── line)  | false           |
 | MUR   | `Rounded`    | 1               | true (─── line)  | true            |
 
-`Dark` keeps the current square borders and blank-line spacing — zero visual regression for existing users. `Light` and `MUR` both get rounded borders, 1-cell inner padding, and the separator line.
+`Dark` is zero-regression for existing users.
 
 ```rust
 pub const DARK: Theme = Theme {
-    // colours: refined version of current palette
     user:         Color::Green,
     agent:        Color::Cyan,
+    shell:        Color::Green,
+    user_text:    Color::Gray,           // lighter than DarkGray for readability
+    agent_text:   Color::White,
+    thinking:     Color::DarkGray,
     system:       Color::DarkGray,
     border:       Color::DarkGray,
     border_title: Color::DarkGray,
+    separator:    Color::DarkGray,
     status_bg:    Color::Reset,
     badge_fg:     Color::Cyan,
     badge_bg:     Color::Reset,
-    separator:    Color::DarkGray,
-    // layout
     border_type:    BorderType::Plain,
     inner_padding:  0,
     show_separator: false,
@@ -158,15 +237,19 @@ pub const DARK: Theme = Theme {
 };
 
 pub const LIGHT: Theme = Theme {
-    user:         Color::Rgb(0x16, 0x65, 0x34),  // forest green
-    agent:        Color::Rgb(0x0e, 0x6b, 0x8c),  // dark cyan
-    system:       Color::Rgb(0xaa, 0xaa, 0xaa),
+    user:         Color::Rgb(0x16, 0x65, 0x34),  // forest green      6.7:1 on white ✓
+    agent:        Color::Rgb(0x0e, 0x6b, 0x8c),  // dark cyan         5.7:1 on white ✓
+    shell:        Color::Rgb(0x16, 0x65, 0x34),
+    user_text:    Color::Rgb(0x22, 0x22, 0x33),  // near-black        17:1 on white ✓
+    agent_text:   Color::Rgb(0x22, 0x22, 0x33),
+    thinking:     Color::Rgb(0x88, 0x88, 0x99),
+    system:       Color::Rgb(0x77, 0x77, 0x88),  // 3.5:1 on white — acceptable for hints
     border:       Color::Rgb(0xd0, 0xd0, 0xe0),
     border_title: Color::Rgb(0x99, 0x99, 0x99),
+    separator:    Color::Rgb(0xd8, 0xd8, 0xe8),
     status_bg:    Color::Rgb(0xef, 0xef, 0xf5),
     badge_fg:     Color::Rgb(0x0e, 0x6b, 0x8c),
     badge_bg:     Color::Rgb(0xe0, 0xf0, 0xf8),
-    separator:    Color::Rgb(0xd8, 0xd8, 0xe8),
     border_type:    BorderType::Rounded,
     inner_padding:  1,
     show_separator: true,
@@ -174,15 +257,19 @@ pub const LIGHT: Theme = Theme {
 };
 
 pub const MUR: Theme = Theme {
-    user:         Color::Rgb(0xa7, 0x8b, 0xfa),  // violet
-    agent:        Color::Rgb(0xfb, 0xbf, 0x24),  // amber
-    system:       Color::Rgb(0x33, 0x33, 0x5a),
+    user:         Color::Rgb(0xa7, 0x8b, 0xfa),  // violet    7.1:1 on #0d0d1a ✓ WCAG AAA
+    agent:        Color::Rgb(0xfb, 0xbf, 0x24),  // amber     11.5:1            ✓ WCAG AAA
+    shell:        Color::Rgb(0x88, 0x88, 0xcc),
+    user_text:    Color::Rgb(0xc8, 0xc8, 0xe8),  // soft lavender  11.8:1        ✓
+    agent_text:   Color::Rgb(0xe0, 0xe0, 0xf0),  // near-white     13.5:1        ✓
+    thinking:     Color::Rgb(0x44, 0x44, 0x77),  // dim indigo
+    system:       Color::Rgb(0x77, 0x77, 0xaa),  // muted violet  4.6:1          ✓ WCAG AA
     border:       Color::Rgb(0x2a, 0x2a, 0x5a),  // indigo
-    border_title: Color::Rgb(0x33, 0x33, 0x7a),
+    border_title: Color::Rgb(0x55, 0x55, 0x99),
+    separator:    Color::Rgb(0x22, 0x22, 0x44),
     status_bg:    Color::Rgb(0x09, 0x09, 0x1a),
     badge_fg:     Color::Rgb(0xfb, 0xbf, 0x24),
-    badge_bg:     Color::Rgb(0x1a, 0x14, 0x0a),
-    separator:    Color::Rgb(0x1e, 0x1e, 0x44),
+    badge_bg:     Color::Rgb(0x22, 0x1a, 0x06),
     border_type:    BorderType::Rounded,
     inner_padding:  1,
     show_separator: true,
@@ -190,71 +277,185 @@ pub const MUR: Theme = Theme {
 };
 ```
 
+All foreground/background contrast ratios verified against WCAG AA (4.5:1 for normal text). Previously `system` color in MUR was `(0x33,0x33,0x5a)` = **1.6:1** — corrected to `(0x77,0x77,0xaa)` = **4.6:1**.
+
 `App` gains `theme: &'static Theme`. Resolved once at startup; `/skin` updates it live.
+
+### Config Change
+
+**File:** `mur-common/src/config.rs`
+
+Add a new section at the end of `Config`:
+
+```rust
+#[serde(default)]
+pub cli: CliConfig,
+```
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CliConfig {
+    /// Active skin name: "dark" | "light" | "mur". Defaults to "dark".
+    pub skin: Option<String>,
+}
+```
+
+`#[serde(default)]` ensures old config files without a `[cli]` section deserialize cleanly.
 
 ### Skin Loading (precedence chain)
 
 1. `--skin <name>` CLI flag (highest)
-2. `cli.skin` key in `~/.mur/config.yaml`
-3. `"dark"` (default)
+2. `config.cli.skin` from `~/.mur/config.yaml`
+3. `"dark"` (hardcoded default)
 
-Helper:
+**File:** `mur-core/src/cmd/agent/cli/mod.rs` — add `--skin` to the clap subcommand for `agent cli` (defined in `mur-core/src/cmd/agent/mod.rs`).
 
 ```rust
 fn resolve_skin(name: &str) -> &'static Theme {
     match name {
         "light" => &theme::LIGHT,
         "mur"   => &theme::MUR,
-        _       => &theme::DARK,
+        "dark"  => &theme::DARK,
+        other   => {
+            // caller is responsible for showing a warning before calling resolve_skin
+            eprintln!("unknown skin '{other}', using dark");
+            &theme::DARK
+        }
     }
 }
 ```
 
+At startup in `run_tui`, if the resolved skin name came from config and is unknown, push a system message: `"unknown skin '{name}' in config, using dark"`.
+
 ### `/skin` Slash Command
 
-Added to `SlashCmd` enum:
-
 ```rust
-/// `/skin [dark|light|mur]` — switch theme live and persist to config.
+/// `/skin [dark|light|mur]` — show or switch active skin.
 Skin(Option<String>),
 ```
 
 Handler:
-- With no arg: print current skin name.
-- With a valid name: call `resolve_skin`, update `app.theme`, write `cli.skin` to `~/.mur/config.yaml`.
-- With an unknown name: show error listing valid names.
+- No arg → print current skin name.
+- Valid name → `resolve_skin`, update `app.theme`, write `config.cli.skin` to `~/.mur/config.yaml`. If the config write fails, still apply the theme in-memory and show: `"skin changed to {name} (could not persist: {e})"`.
+- Unknown name → `"unknown skin '{name}' — valid: dark, light, mur"`.
 
 ### UI Layout Changes (skin-driven)
 
-**Borders:** `render_transcript` and the input `Block` read `theme.border_type` to set `BorderType`. Dark keeps `Plain`; Light and MUR use `Rounded` (`╭ ╮ ╰ ╯`).
+**Borders:** `render_transcript` and the input `Block` read `theme.border_type`:
 
-**Inner padding:** When `theme.inner_padding > 0`, wrap the inner content area with `Layout` horizontal margins of `theme.inner_padding` cells on each side.
-
-**Message separators:** If `theme.show_separator` is true, push `Line::styled("─".repeat(inner_width), Style::default().fg(theme.separator))` between messages instead of `Line::default()`. `inner_width` is the pane's inner rect width. Dark keeps the blank line spacer to avoid any visual change for existing users.
-
-**Status bar (all skins):** Replace plain text with:
+```rust
+Block::default()
+    .borders(Borders::ALL)
+    .border_type(theme.border_type)
+    .border_style(Style::default().fg(theme.border))
+    .title(...)
 ```
-[badge: agent-name]  ▶ state  ·  channel-short  (right-align: context kept / not saved)
-```
-Badge rendered as `Span` with `bg(theme.badge_bg).fg(theme.badge_fg)` style.
 
-**Input box title:** If `theme.compact_input`, use shortened hint `message — Enter · Alt+Enter · /help`; otherwise keep the current full hint text.
+**Inner padding:** Use `Block::padding()` (available in ratatui 0.29) — no extra Layout split needed:
+
+```rust
+block.padding(Padding::horizontal(theme.inner_padding as u16))
+```
+
+**Message separators:** If `theme.show_separator`, push a separator line between messages:
+
+```rust
+let sep_width = inner.width
+    .saturating_sub(theme.inner_padding as u16 * 2) as usize;
+lines.push(Line::styled(
+    "─".repeat(sep_width),
+    Style::default().fg(theme.separator),
+));
+```
+
+`inner` is the rect after `block.inner(area)`, computed once at the top of `render_transcript`. If `!show_separator`, keep the existing `Line::default()` blank spacer.
+
+**Status bar (all skins):**
+
+```
+[badge: agent-name] ▶ state · 019ed3  (right-aligned: ↑ N lines · ⬇ to bottom | context kept)
+```
+
+- Badge: `Span::styled(format!(" {} ", agent), Style::default().fg(theme.badge_fg).bg(theme.badge_bg))`
+- Channel short: first 6 hex chars of the channel UUID (e.g. `019ed3`), or `—` if no channel yet.
+- Right side: when `scroll_back > 0` show `↑ {scroll_back} lines · ⬇ to bottom`; otherwise `context kept` or `not saved` (existing logic).
+- ESC hint: when `app.esc_hint`, append ` · ESC again to {cancel|clear}` as a dim span on the right.
+
+**Input box title:** If `theme.compact_input`: `" message — Enter · Alt+Enter · /help "`. Otherwise current full text.
+
+**HITL modal colors:** Remain hardcoded for now (Yellow border, Green/Yellow/Red action keys). Tracked as future work: add `hitl_border`, `hitl_approve`, `hitl_deny` to `Theme`.
 
 ### File Size Check
 
-`ui.rs` (255 lines) and `app.rs` (640 lines) stay under the 800-line limit after this work. Adding `theme.rs` (~80 lines) keeps the split clean. If `app.rs` grows, split `SlashCmd` + `parse_slash` into `slash.rs`.
+After this work:
+- `theme.rs` ~110 lines (new)
+- `ui.rs` ~290 lines (was 255, small additions)
+- `app.rs` ~670 lines (was 640, new fields + `EscAction`)
+- `mod.rs` ~660 lines (was 632, ESC handler + skin flag)
+
+All under the 800-line limit. If `app.rs` approaches the limit, split `SlashCmd` + `parse_slash` into `slash.rs`.
 
 ---
 
 ## Testing
 
-**PR 1:**
-- Unit tests in `app.rs` for `last_esc_at` transitions (single ESC, double within window, double outside window, non-ESC clears flag).
-- Unit test: double-ESC while streaming sets input to `last_sent`.
-- Manual: mouse scroll in `mur agent cli` in iTerm2/Ghostty.
+### PR 1
 
-**PR 2:**
-- Unit test: `resolve_skin` returns correct theme for each name and unknown fallback.
-- Unit test: `/skin` slash command parses correctly.
-- Manual: visual check of each skin with `mur agent cli --skin dark|light|mur`.
-- Manual: `/skin mur` persists to `~/.mur/config.yaml` and survives restart.
+**Unit tests in `app.rs`:**
+
+```rust
+// esc_action is a pure function — no timing dependency
+#[test]
+fn esc_arm_when_streaming_and_empty() {
+    assert_eq!(esc_action(None, true, true), EscAction::Arm);
+}
+#[test]
+fn esc_cancel_restore_on_second_press() {
+    let t = Instant::now() - Duration::from_millis(100);
+    assert_eq!(esc_action(Some(t), true, true), EscAction::CancelAndRestore);
+}
+#[test]
+fn esc_window_expired_rearms() {
+    let t = Instant::now() - Duration::from_millis(500);
+    assert_eq!(esc_action(Some(t), true, true), EscAction::Arm);
+}
+#[test]
+fn esc_clear_when_not_streaming_and_has_text() {
+    let t = Instant::now() - Duration::from_millis(100);
+    assert_eq!(esc_action(Some(t), false, false), EscAction::ClearInput);
+}
+#[test]
+fn esc_nothing_when_not_streaming_and_empty() {
+    let t = Instant::now() - Duration::from_millis(100);
+    assert_eq!(esc_action(Some(t), false, true), EscAction::Nothing);
+}
+```
+
+`esc_action` takes `Option<Instant>` — tests construct the `Instant` as `Instant::now() - offset` to simulate timing without wall-clock dependency.
+
+**Additional unit tests in `app.rs`:**
+- `last_sent` is set to submitted text after `submit()`.
+- `last_sent` is cleared after `start_new_session()`.
+- `scroll_back` increments on simulated `Event::Mouse(ScrollUp)` via `handle_event` (use `tokio::sync::mpsc::channel` to provide the `tx`).
+
+**Manual:**
+- Mouse scroll in iTerm2 and Ghostty.
+- Scroll up mid-stream, verify `↑ N lines` indicator appears; submit a new message, verify indicator disappears.
+
+### PR 2
+
+**Unit tests in `theme.rs`:**
+- `resolve_skin("light")` returns `&LIGHT`.
+- `resolve_skin("mur")` returns `&MUR`.
+- `resolve_skin("unknown")` returns `&DARK`.
+
+**Unit tests in `app.rs`:**
+- `/skin` slash command parses to `SlashCmd::Skin(Some("mur".into()))`.
+- `/skin` with no arg parses to `SlashCmd::Skin(None)`.
+
+**Manual:**
+- `mur agent cli <agent> --skin dark|light|mur` — visual check of each skin.
+- `/skin mur` → persists to `~/.mur/config.yaml`, survives restart.
+- `/skin muur` (typo) → shows error message, skin unchanged.
+- `config.cli.skin: "muur"` → startup shows warning, uses dark.
+- Old config without `[cli]` section → no parse error, defaults to dark.

--- a/docs/superpowers/specs/2026-06-17-agent-cli-ux-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-17-agent-cli-ux-improvements-design.md
@@ -1,0 +1,202 @@
+# Agent CLI UX Improvements Design
+
+**Date:** 2026-06-17
+**Status:** Approved for implementation
+**Scope:** `mur-core/src/cmd/agent/cli/`
+
+## Summary
+
+Two-PR series improving the `mur agent cli` TUI:
+
+- **PR 1** — keyboard/input behaviour (mouse scroll, double-ESC clear, double-ESC cancel+restore)
+- **PR 2** — skin system + UI polish (three themes, rounded layout, badge status bar)
+
+---
+
+## PR 1: Keyboard & Mouse Behaviour
+
+### 1. Mouse Scroll
+
+**Where:** `TerminalGuard` (enter/drop) and `handle_event` in `mod.rs`.
+
+Enable mouse capture on TUI entry and release it on exit:
+
+```rust
+// TerminalGuard::enter()
+execute!(io::stdout(), EnterAlternateScreen, EnableBracketedPaste, EnableMouseCapture)?;
+
+// TerminalGuard::drop()
+execute!(io::stdout(), LeaveAlternateScreen, DisableBracketedPaste, DisableMouseCapture, cursor::Show);
+```
+
+Add a mouse arm to `handle_event`:
+
+```rust
+Event::Mouse(mouse_ev) => match mouse_ev.kind {
+    MouseEventKind::ScrollUp   => app.scroll_back = app.scroll_back.saturating_add(SCROLL_STEP),
+    MouseEventKind::ScrollDown => app.scroll_back = app.scroll_back.saturating_sub(SCROLL_STEP),
+    _ => {}
+}
+```
+
+No other mouse events (clicks, drag) are handled.
+
+### 2. Double-ESC to Clear Input
+
+**New `App` field:**
+
+```rust
+last_esc_at: Option<std::time::Instant>,
+```
+
+**Constant:**
+
+```rust
+const ESC_DOUBLE_WINDOW: Duration = Duration::from_millis(400);
+```
+
+**ESC key handler in `handle_event`:**
+
+```
+on ESC press:
+  if input is empty → do nothing
+  if last_esc_at is Some(t) && t.elapsed() < ESC_DOUBLE_WINDOW:
+    clear input
+    last_esc_at = None
+  else:
+    last_esc_at = Some(Instant::now())
+    (optional: show dim hint in status "ESC again to clear")
+
+on any non-ESC key press:
+  last_esc_at = None
+```
+
+Status bar hint is ephemeral — stored as `App.esc_hint: bool`, cleared on next keypress.
+
+### 3. Double-ESC to Cancel-and-Restore (while streaming)
+
+**New `App` field:**
+
+```rust
+last_sent: Option<String>,
+```
+
+Set in `submit()` immediately before `app.clear_input()`.
+
+**Modified double-ESC second-press logic:**
+
+```
+on double-ESC second press:
+  if app.streaming:
+    cancel_in_flight(app, tx)           // same path as Ctrl+C
+    if let Some(text) = app.last_sent:
+      app.set_input(&text)              // restore message to input box
+    app.push_system("cancelled — message restored")
+  else:
+    clear input                         // standard clear
+```
+
+`last_sent` is NOT cleared by `start_new_session` or `/clear` (a stale restore after session reset is harmless; user can just ESC again to clear).
+
+---
+
+## PR 2: Skin System + UI Polish
+
+### Theme Data Model
+
+New file: `mur-core/src/cmd/agent/cli/theme.rs`
+
+```rust
+pub struct Theme {
+    pub user:           Color,   // user turn label + text
+    pub agent:          Color,   // agent turn label
+    pub system:         Color,   // system/hint messages
+    pub border:         Color,   // transcript + input borders
+    pub border_title:   Color,   // border title text
+    pub status_bg:      Color,   // status bar background
+    pub badge_fg:       Color,   // agent-name badge foreground
+    pub badge_bg:       Color,   // agent-name badge background
+    pub separator:      Color,   // inter-message separator line
+}
+
+pub const DARK: Theme = Theme { /* refined dark palette */ };
+pub const LIGHT: Theme = Theme { /* light palette */ };
+pub const MUR: Theme = Theme {
+    user:         Color::Rgb(0xa7, 0x8b, 0xfa),  // violet
+    agent:        Color::Rgb(0xfb, 0xbf, 0x24),  // amber
+    system:       Color::Rgb(0x33, 0x33, 0x5a),
+    border:       Color::Rgb(0x2a, 0x2a, 0x5a),  // indigo
+    border_title: Color::Rgb(0x33, 0x33, 0x7a),
+    status_bg:    Color::Rgb(0x09, 0x09, 0x1a),
+    badge_fg:     Color::Rgb(0xfb, 0xbf, 0x24),
+    badge_bg:     Color::Rgb(0x1a, 0x14, 0x0a),
+    separator:    Color::Rgb(0x1e, 0x1e, 0x44),
+};
+```
+
+`App` gains `theme: &'static Theme`. Resolved once at startup; `/skin` updates it live.
+
+### Skin Loading (precedence chain)
+
+1. `--skin <name>` CLI flag (highest)
+2. `cli.skin` key in `~/.mur/config.yaml`
+3. `"dark"` (default)
+
+Helper:
+
+```rust
+fn resolve_skin(name: &str) -> &'static Theme {
+    match name {
+        "light" => &theme::LIGHT,
+        "mur"   => &theme::MUR,
+        _       => &theme::DARK,
+    }
+}
+```
+
+### `/skin` Slash Command
+
+Added to `SlashCmd` enum:
+
+```rust
+/// `/skin [dark|light|mur]` — switch theme live and persist to config.
+Skin(Option<String>),
+```
+
+Handler:
+- With no arg: print current skin name.
+- With a valid name: call `resolve_skin`, update `app.theme`, write `cli.skin` to `~/.mur/config.yaml`.
+- With an unknown name: show error listing valid names.
+
+### UI Layout Changes (all skins)
+
+**Borders:** Switch from `Borders::ALL` to `Borders::ROUNDED` for both the transcript pane and the input box. Ratatui provides rounded Unicode corners (`╭ ╮ ╰ ╯`) via `BorderType::Rounded`.
+
+**Message separators:** Remove the blank `Line::default()` spacer between messages. Replace with a single `Line::styled("─".repeat(width), dim_style)` where `width` is the inner pane width minus 2. This keeps the visual break without eating vertical space.
+
+**Status bar:** Replace plain text with:
+```
+[badge: agent-name]  ▶ state  ·  channel-short  (right-align: context kept / not saved)
+```
+Badge rendered as `Span` with `bg(badge_bg).fg(badge_fg)` style.
+
+**Input box title:** Shortened hint text: `message — Enter · Alt+Enter newline · /help`.
+
+### File Size Check
+
+`ui.rs` (255 lines) and `app.rs` (640 lines) stay under the 800-line limit after this work. Adding `theme.rs` (~80 lines) keeps the split clean. If `app.rs` grows, split `SlashCmd` + `parse_slash` into `slash.rs`.
+
+---
+
+## Testing
+
+**PR 1:**
+- Unit tests in `app.rs` for `last_esc_at` transitions (single ESC, double within window, double outside window, non-ESC clears flag).
+- Unit test: double-ESC while streaming sets input to `last_sent`.
+- Manual: mouse scroll in `mur agent cli` in iTerm2/Ghostty.
+
+**PR 2:**
+- Unit test: `resolve_skin` returns correct theme for each name and unknown fallback.
+- Unit test: `/skin` slash command parses correctly.
+- Manual: visual check of each skin with `mur agent cli --skin dark|light|mur`.
+- Manual: `/skin mur` persists to `~/.mur/config.yaml` and survives restart.

--- a/docs/superpowers/specs/2026-06-17-turbovec-integration-design.md
+++ b/docs/superpowers/specs/2026-06-17-turbovec-integration-design.md
@@ -1,0 +1,200 @@
+# turbovec Integration Design
+
+**Date:** 2026-06-17
+**Branch:** feat/turbovec-vector-backend
+
+## Goals
+
+Replace LanceDB's vector ANN role with turbovec for both the sources corpus and the skill/pattern corpus, reducing memory usage ~8× (4-bit quantization) and improving search latency on Apple Silicon via SIMD acceleration. LanceDB remains available as the default; turbovec is opt-in via config + Cargo feature.
+
+## Background
+
+mur has two separate vector search paths:
+
+1. **Sources path** — `Arc<dyn VectorStore>` trait, used by `retrieve_unified` for Obsidian/Notion/Joplin chunks.
+2. **Skill/pattern path** — `LanceDbStore` used directly (not via trait) in `server/context.rs`, `cmd/reindex.rs`, `cmd/workflow.rs`, `server/workflows.rs`.
+
+turbovec is a published Rust crate (`cargo add turbovec`) implementing TurboQuant (ICLR 2026): SIMD-accelerated ANN with 8× memory compression at 4-bit. It provides `IdMapIndex` (stable u64 IDs, O(1) deletion, filtered search via allowlist) and `TurboQuantIndex` (simpler, no stable IDs). The allowlist feature runs filter logic inside the SIMD kernel — no post-hoc pruning overhead.
+
+rusqlite (bundled) is already in mur-core, so no new heavy dependency is needed for the metadata sidecar.
+
+## Architecture
+
+### New Types
+
+**`TurboVecStore`** — implements the existing `VectorStore` trait (sources path).
+- `IdMapIndex` (behind `Arc<Mutex<…>>`) for ANN
+- SQLite connection (behind `Arc<Mutex<…>>`, WAL mode) for chunk metadata
+- On-disk: `{data_dir}/tv_sources.tvim` + `{data_dir}/tv_sources.db`
+
+**`TurboSkillIndex`** — implements a new `SkillIndex` trait (skill/pattern path).
+- `IdMapIndex` for ANN
+- In-memory `Vec<SkillEntry>` sidecar (name, description, item_type, tier, importance)
+- On-disk: `{data_dir}/tv_skills.tvim` + `{data_dir}/tv_skills_meta.json`
+
+### New Trait
+
+```rust
+// mur-core/src/store/vector/skill_index.rs
+#[async_trait]
+pub trait SkillIndex: Send + Sync {
+    async fn build_unified_index(
+        &self,
+        patterns: &[(Pattern, Vec<f32>)],
+        workflows: &[(Workflow, Vec<f32>)],
+    ) -> Result<()>;
+
+    async fn search(
+        &self,
+        query_embedding: &[f32],
+        limit: usize,
+        item_type: Option<&str>,
+    ) -> Result<Vec<SearchResult>>;
+}
+```
+
+`LanceDbStore` gains a `SkillIndex` impl (zero behavior change). `TurboSkillIndex` is the new impl.
+
+### Factory
+
+```rust
+// factory.rs additions
+pub async fn get_skill_index(cfg: &Config, index_dir: &Path) -> Result<Arc<dyn SkillIndex>>;
+```
+
+Dispatches on `cfg.storage.vector_backend`. Existing `get_vector_store` gains a `"turbovec"` arm alongside `"lancedb"` and `"qdrant"`.
+
+## Data Flow
+
+### Sources — `TurboVecStore::upsert(chunks)`
+
+1. Open SQLite transaction.
+2. For each chunk: `DELETE FROM chunks WHERE chunk_id = ?` then `INSERT` → get `rowid` (u64 ID).
+3. Call `index.remove(old_id)` for deleted rows; `index.add_with_ids(&vecs, &ids)` for new rows.
+4. Commit transaction; write `index.write("tv_sources.tvim.tmp")` then `fs::rename` (atomic).
+
+### Sources — `TurboVecStore::search(query_vec, k, filter)`
+
+1. If `filter.source_ids` or `filter.since` is set: `SELECT id FROM chunks WHERE source_id IN (…) AND updated_at_ms >= ?` → `Vec<u64>` allowlist.
+2. `index.search(query_vec, k, allowlist_or_none)` → `(scores, ids)`.
+3. `SELECT * FROM chunks WHERE id IN (…)` → build `Vec<Hit>` sorted by score.
+
+When no filter applies, allowlist is `None` and turbovec searches all vectors.
+
+### Skills — `TurboSkillIndex::build_unified_index(patterns, workflows)`
+
+1. Construct a fresh `IdMapIndex::new(dim, bit_width)` (replaces old index wholesale — simpler than incremental removal, safe because build is always a full rebuild).
+2. Assign sequential u64 IDs (0..n).
+3. `index.add_with_ids(&all_vecs, &ids)`.
+4. Populate sidecar Vec with `SkillEntry` per item.
+5. Swap new index into `Arc<Mutex<…>>`; write `.tvim.tmp` → rename; write `tv_skills_meta.json`.
+
+### Skills — `TurboSkillIndex::search(query_vec, limit, item_type)`
+
+1. `index.search(query_vec, limit * 4)` → `(scores, ids)` (4× over-fetch; skills corpus ≤ 500 items).
+2. Filter results by `item_type` if Some; take first `limit`.
+3. Map ids → sidecar Vec → `Vec<SearchResult>`.
+
+No SQL needed for skills — corpus is small, item_type post-filter on Vec is negligible.
+
+## SQLite Schema (sources)
+
+```sql
+CREATE TABLE IF NOT EXISTS chunks (
+    id          INTEGER PRIMARY KEY,   -- turbovec u64 ID (rowid)
+    chunk_id    TEXT    NOT NULL UNIQUE,
+    source_id   TEXT    NOT NULL,
+    external_id TEXT    NOT NULL,
+    ordinal     INTEGER NOT NULL,
+    text        TEXT    NOT NULL,
+    heading_path TEXT   NOT NULL,      -- JSON-encoded string[]
+    char_start  INTEGER NOT NULL,
+    char_end    INTEGER NOT NULL,
+    updated_at_ms INTEGER NOT NULL,
+    vector      BLOB    NOT NULL       -- raw little-endian f32 bytes for index rebuild
+);
+CREATE INDEX IF NOT EXISTS idx_source    ON chunks(source_id);
+CREATE INDEX IF NOT EXISTS idx_source_ext ON chunks(source_id, external_id);
+PRAGMA journal_mode = WAL;
+```
+
+The `vector BLOB` column enables index rebuild from SQLite alone when `.tvim` is missing (crash recovery, migration).
+
+## Error Handling
+
+**Missing `.tvim` at startup** — if SQLite DB exists, rebuild `IdMapIndex` by reading all rows and calling `add_with_ids`. Logs `tracing::info!("rebuilding turbovec index from SQLite")`. If neither file exists, starts empty (first run or fresh install).
+
+**`.tvim` write atomicity** — write to `*.tvim.tmp` then `fs::rename` (atomic on POSIX/macOS). Same for `tv_skills_meta.json`.
+
+**Concurrent access** — `Arc<Mutex<IdMapIndex>>` + `Arc<Mutex<rusqlite::Connection>>`. SQLite WAL mode allows concurrent reads without blocking writes. Mutex held only during the index update + file write, not during the SQLite query phase.
+
+**`mur internals reindex`** — `TurboSkillIndex::rebuild_index()` clears state and calls `build_unified_index`. `TurboVecStore::rebuild_index()` drops the SQLite table and `.tvim`, re-upserts from YAML source of truth.
+
+## Configuration
+
+```yaml
+# ~/.mur/config.yaml
+storage:
+  vector_backend: turbovec   # "lancedb" (default) | "turbovec" | "qdrant"
+  turbovec:
+    bit_width: 4             # 2 (16× compression) or 4 (8× compression, better recall)
+```
+
+New `TurboVecConfig` sub-struct in `mur-common/src/config.rs` under `StorageConfig`.
+
+## Cargo Feature
+
+```toml
+# mur-core/Cargo.toml
+turbovec = { version = "0.9", optional = true }
+
+[features]
+turbovec = ["dep:turbovec"]
+```
+
+Factory arms for `"turbovec"` are `#[cfg(feature = "turbovec")]`. Attempting `vector_backend = "turbovec"` without the feature gives the same helpful error as the existing Qdrant gate. Default builds are unaffected — no compile cost.
+
+## Files Changed
+
+### New
+| File | Purpose |
+|------|---------|
+| `mur-core/src/store/vector/turbo.rs` | `TurboVecStore` (VectorStore impl) |
+| `mur-core/src/store/vector/turbo_skill.rs` | `TurboSkillIndex` + `SkillEntry` |
+| `mur-core/src/store/vector/skill_index.rs` | `SkillIndex` trait |
+
+### Modified
+| File | Change |
+|------|--------|
+| `mur-core/Cargo.toml` | Add `turbovec` optional dep + feature |
+| `mur-core/src/store/vector/mod.rs` | Add `pub mod turbo`, `turbo_skill`, `skill_index` |
+| `mur-core/src/store/vector/factory.rs` | Add `get_skill_index()` fn; `"turbovec"` arms in both fns |
+| `mur-core/src/store/vector/lancedb.rs` | Add `impl SkillIndex for LanceDbStore`; move `SearchResult` to `skill_index.rs` (re-export from lancedb for compat) |
+| `mur-core/src/server/context.rs` | Use `get_skill_index()` instead of `LanceDbStore as VectorStore` |
+| `mur-core/src/cmd/reindex.rs` | Same substitution |
+| `mur-core/src/cmd/workflow.rs` | Same substitution |
+| `mur-core/src/server/workflows.rs` | Same substitution |
+| `mur-common/src/config.rs` | Add `TurboVecConfig`, `turbovec` field in `StorageConfig` |
+
+## Testing
+
+**`VectorStore` conformance suite** — `turbo.rs` adds `make_store_for_conformance()` fixture + `vector_store_conformance!` macro invocation. Covers upsert, search, delete, list, count with synthetic embeddings.
+
+**`TurboSkillIndex` unit tests** (in `turbo_skill.rs`):
+- `build_and_search_roundtrip` — 3 patterns + 1 workflow, top result is correct
+- `item_type_filter` — `Some("workflow")` returns only workflows
+- `rebuild_clears_old` — rebuild with different items, old items absent
+- `persist_and_reload` — write + reconstruct, search still correct
+
+**Factory tests** — `factory_returns_turbovec_when_configured` (behind `#[cfg(feature = "turbovec")]`), matching existing lancedb/qdrant factory test pattern.
+
+All tests use synthetic `Vec<f32>` — no real embedding calls.
+
+## Compression Numbers (reference)
+
+At 1536-dim (OpenAI text-embedding-3-small):
+
+| Corpus | Items | float32 | 4-bit turbovec |
+|--------|-------|---------|----------------|
+| Skills | 200 | ~1.2 MB | ~150 KB |
+| Sources | 10,000 | ~59 MB | ~7.5 MB |

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -731,12 +731,18 @@ mod esc_action_tests {
 
     #[test]
     fn esc_cancel_restore_on_second_press_while_streaming() {
-        assert_eq!(esc_action(recent(), true, true), EscAction::CancelAndRestore);
+        assert_eq!(
+            esc_action(recent(), true, true),
+            EscAction::CancelAndRestore
+        );
     }
 
     #[test]
     fn esc_cancel_restore_on_second_press_streaming_has_text() {
-        assert_eq!(esc_action(recent(), true, false), EscAction::CancelAndRestore);
+        assert_eq!(
+            esc_action(recent(), true, false),
+            EscAction::CancelAndRestore
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -201,6 +201,9 @@ pub struct App {
     /// session. Reset on `/clear` or channel switch so each new session
     /// re-establishes context.
     pub cwd_sent: bool,
+    pub last_esc_at: Option<std::time::Instant>,
+    pub esc_hint: bool,
+    pub last_sent: Option<String>,
 }
 
 impl App {
@@ -225,6 +228,9 @@ impl App {
             persist_warned: false,
             cwd: std::env::current_dir().ok(),
             cwd_sent: false,
+            last_esc_at: None,
+            esc_hint: false,
+            last_sent: None,
         }
     }
 
@@ -371,6 +377,9 @@ impl App {
         self.streaming = false;
         self.hitl = None;
         self.cwd_sent = false;
+        self.last_sent = None;
+        self.last_esc_at = None;
+        self.esc_hint = false;
         self.push_system("started a new conversation");
     }
 
@@ -674,6 +683,20 @@ mod tests {
             a.messages.iter().any(|m| m.text == "first question"),
             "history rehydrated after switch"
         );
+    }
+
+    #[test]
+    fn start_new_session_clears_last_sent() {
+        let home = tempdir().unwrap();
+        let mut a = app_at(&home);
+        a.last_sent = Some("hello".into());
+        a.last_esc_at = Some(std::time::Instant::now());
+        a.esc_hint = true;
+        let s = Session::create(home.path(), "a").unwrap();
+        a.start_new_session(s);
+        assert!(a.last_sent.is_none());
+        assert!(a.last_esc_at.is_none());
+        assert!(!a.esc_hint);
     }
 }
 

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -126,10 +126,8 @@ pub const SLASH_COMMANDS: [&str; 10] = [
     "/quit",
 ];
 
-#[allow(dead_code)]
 pub const ESC_DOUBLE_WINDOW: std::time::Duration = std::time::Duration::from_millis(500);
 
-#[allow(dead_code)]
 #[derive(Debug, PartialEq, Eq)]
 pub enum EscAction {
     Arm,
@@ -139,7 +137,6 @@ pub enum EscAction {
 }
 
 /// Pure function — no wall-clock calls, fully testable.
-#[allow(dead_code)]
 pub fn esc_action(
     last_esc_at: Option<std::time::Instant>,
     streaming: bool,

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -126,6 +126,44 @@ pub const SLASH_COMMANDS: [&str; 10] = [
     "/quit",
 ];
 
+#[allow(dead_code)]
+pub const ESC_DOUBLE_WINDOW: std::time::Duration = std::time::Duration::from_millis(500);
+
+#[allow(dead_code)]
+#[derive(Debug, PartialEq, Eq)]
+pub enum EscAction {
+    Arm,
+    ClearInput,
+    CancelAndRestore,
+    Nothing,
+}
+
+/// Pure function — no wall-clock calls, fully testable.
+#[allow(dead_code)]
+pub fn esc_action(
+    last_esc_at: Option<std::time::Instant>,
+    streaming: bool,
+    input_empty: bool,
+) -> EscAction {
+    if let Some(t) = last_esc_at
+        && t.elapsed() < ESC_DOUBLE_WINDOW
+    {
+        return if streaming {
+            EscAction::CancelAndRestore
+        } else if !input_empty {
+            EscAction::ClearInput
+        } else {
+            EscAction::Nothing
+        };
+    }
+    // First press (or window expired)
+    if streaming || !input_empty {
+        EscAction::Arm
+    } else {
+        EscAction::Nothing
+    }
+}
+
 /// All mutable TUI state.
 pub struct App {
     pub home: PathBuf,
@@ -636,5 +674,78 @@ mod tests {
             a.messages.iter().any(|m| m.text == "first question"),
             "history rehydrated after switch"
         );
+    }
+}
+
+#[cfg(test)]
+mod esc_action_tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    fn recent() -> Option<Instant> {
+        Some(Instant::now() - Duration::from_millis(100))
+    }
+
+    fn expired() -> Option<Instant> {
+        Some(Instant::now() - Duration::from_millis(600))
+    }
+
+    fn at_boundary() -> Option<Instant> {
+        Some(Instant::now() - ESC_DOUBLE_WINDOW)
+    }
+
+    #[test]
+    fn esc_arm_when_streaming_and_empty_input() {
+        assert_eq!(esc_action(None, true, true), EscAction::Arm);
+    }
+
+    #[test]
+    fn esc_arm_when_not_streaming_and_has_text() {
+        assert_eq!(esc_action(None, false, false), EscAction::Arm);
+    }
+
+    #[test]
+    fn esc_nothing_when_not_streaming_and_empty() {
+        assert_eq!(esc_action(None, false, true), EscAction::Nothing);
+    }
+
+    #[test]
+    fn esc_cancel_restore_on_second_press_while_streaming() {
+        assert_eq!(esc_action(recent(), true, true), EscAction::CancelAndRestore);
+    }
+
+    #[test]
+    fn esc_cancel_restore_on_second_press_streaming_has_text() {
+        assert_eq!(esc_action(recent(), true, false), EscAction::CancelAndRestore);
+    }
+
+    #[test]
+    fn esc_clear_input_on_second_press_not_streaming_has_text() {
+        assert_eq!(esc_action(recent(), false, false), EscAction::ClearInput);
+    }
+
+    #[test]
+    fn esc_nothing_on_second_press_not_streaming_empty() {
+        assert_eq!(esc_action(recent(), false, true), EscAction::Nothing);
+    }
+
+    #[test]
+    fn esc_arm_when_window_expired_streaming() {
+        assert_eq!(esc_action(expired(), true, true), EscAction::Arm);
+    }
+
+    #[test]
+    fn esc_arm_when_window_expired_has_text() {
+        assert_eq!(esc_action(expired(), false, false), EscAction::Arm);
+    }
+
+    #[test]
+    fn esc_arm_at_exact_boundary() {
+        assert_eq!(esc_action(at_boundary(), false, false), EscAction::Arm);
+    }
+
+    #[test]
+    fn esc_nothing_when_window_expired_not_streaming_empty() {
+        assert_eq!(esc_action(expired(), false, true), EscAction::Nothing);
     }
 }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -358,6 +358,7 @@ async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
         app.push_system("still generating — press Ctrl+C to cancel first");
         return;
     }
+    app.last_sent = Some(trimmed.clone());
     app.clear_input();
 
     let task_id = app.begin_user_turn(&trimmed);

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -33,7 +33,7 @@ use ratatui::backend::CrosstermBackend;
 use serde_json::Value;
 use tokio::sync::mpsc;
 
-use self::app::{App, Role, SlashCmd, parse_slash};
+use self::app::{App, EscAction, Role, SlashCmd, esc_action, parse_slash};
 use self::persist::Session;
 use self::stream::{StreamMsg, build_params, cancel_task, respond_hitl, spawn_stream};
 use crate::a2a_dial::{DialMode, canonicalize_agent_name, dial_method};
@@ -222,6 +222,10 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
                 }
                 return;
             }
+            if key.code != KeyCode::Esc {
+                app.last_esc_at = None;
+                app.esc_hint = false;
+            }
             let alt = key.modifiers.contains(KeyModifiers::ALT);
             match key.code {
                 KeyCode::Char('d') if ctrl => request_quit(app, tx),
@@ -233,6 +237,37 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
                     app.input.insert_newline();
                 }
                 KeyCode::Enter => submit(app, tx).await,
+                KeyCode::Esc => {
+                    let action = esc_action(
+                        app.last_esc_at,
+                        app.streaming,
+                        app.input_text().is_empty(),
+                    );
+                    match action {
+                        EscAction::Arm => {
+                            app.last_esc_at = Some(std::time::Instant::now());
+                            app.esc_hint = true;
+                        }
+                        EscAction::ClearInput => {
+                            app.clear_input();
+                            app.last_esc_at = None;
+                            app.esc_hint = false;
+                        }
+                        EscAction::CancelAndRestore => {
+                            cancel_in_flight(app, tx);
+                            if let Some(text) = app.last_sent.clone() {
+                                app.set_input(&text);
+                            }
+                            app.push_system("cancelled — message restored");
+                            app.last_esc_at = None;
+                            app.esc_hint = false;
+                        }
+                        EscAction::Nothing => {
+                            app.last_esc_at = None;
+                            app.esc_hint = false;
+                        }
+                    }
+                }
                 _ => {
                     app.input.input(key);
                 }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -247,11 +247,8 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
                 }
                 KeyCode::Enter => submit(app, tx).await,
                 KeyCode::Esc => {
-                    let action = esc_action(
-                        app.last_esc_at,
-                        app.streaming,
-                        app.input_text().is_empty(),
-                    );
+                    let action =
+                        esc_action(app.last_esc_at, app.streaming, app.input_text().is_empty());
                     match action {
                         EscAction::Arm => {
                             app.last_esc_at = Some(std::time::Instant::now());

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -20,8 +20,8 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use crossterm::event::{
-    DisableBracketedPaste, EnableBracketedPaste, Event, EventStream, KeyCode, KeyEventKind,
-    KeyModifiers,
+    DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture, Event,
+    EventStream, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind,
 };
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -42,6 +42,8 @@ use crate::a2a_dial::{DialMode, canonicalize_agent_name, dial_method};
 const RECENT_LIMIT: usize = 10;
 /// How many transcript lines PageUp/PageDown scroll.
 const SCROLL_STEP: u16 = 5;
+/// Trackpad fires 10-20 events/sec so step=1 for mouse vs step=5 for keyboard PageUp/Down.
+const MOUSE_SCROLL_STEP: u16 = 1;
 /// Spinner animation cadence.
 const SPINNER_MS: u64 = 90;
 
@@ -84,8 +86,13 @@ struct TerminalGuard;
 impl TerminalGuard {
     fn enter() -> Result<Self> {
         enable_raw_mode().context("enable raw mode")?;
-        execute!(io::stdout(), EnterAlternateScreen, EnableBracketedPaste)
-            .context("enter alternate screen")?;
+        execute!(
+            io::stdout(),
+            EnterAlternateScreen,
+            EnableBracketedPaste,
+            EnableMouseCapture
+        )
+        .context("enter alternate screen")?;
         Ok(Self)
     }
 }
@@ -96,6 +103,7 @@ impl Drop for TerminalGuard {
             io::stdout(),
             LeaveAlternateScreen,
             DisableBracketedPaste,
+            DisableMouseCapture,
             cursor::Show
         );
         let _ = disable_raw_mode();
@@ -110,6 +118,7 @@ async fn run_tui(home: PathBuf, agent: String, resume: bool, auto: bool) -> Resu
             io::stdout(),
             LeaveAlternateScreen,
             DisableBracketedPaste,
+            DisableMouseCapture,
             cursor::Show
         );
         let _ = disable_raw_mode();
@@ -276,6 +285,15 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
         Event::Paste(text) => {
             app.input.insert_str(text);
         }
+        Event::Mouse(mouse_ev) => match mouse_ev.kind {
+            MouseEventKind::ScrollUp => {
+                app.scroll_back = app.scroll_back.saturating_add(MOUSE_SCROLL_STEP);
+            }
+            MouseEventKind::ScrollDown => {
+                app.scroll_back = app.scroll_back.saturating_sub(MOUSE_SCROLL_STEP);
+            }
+            _ => {}
+        },
         _ => {}
     }
 }

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -181,10 +181,7 @@ fn render_status(f: &mut Frame, app: &App, area: Rect) {
     spans.push(Span::styled(msg, Style::default().fg(color)));
 
     let right_hint: Option<(String, Color)> = if app.scroll_back > 0 {
-        Some((
-            format!("↑ {} lines · ⬇ to bottom", app.scroll_back),
-            SYSTEM,
-        ))
+        Some((format!("↑ {} lines · ⬇ to bottom", app.scroll_back), SYSTEM))
     } else if app.esc_hint {
         let hint = if app.streaming {
             "ESC again to cancel"
@@ -199,10 +196,7 @@ fn render_status(f: &mut Frame, app: &App, area: Rect) {
     if let Some((hint_text, hint_color)) = right_hint {
         let hint_display = format!(" {} ", hint_text);
         let hint_width = hint_display.chars().count() as u16;
-        let left_width: u16 = spans
-            .iter()
-            .map(|s| s.content.chars().count() as u16)
-            .sum();
+        let left_width: u16 = spans.iter().map(|s| s.content.chars().count() as u16).sum();
         let bar_width = area.width;
         // Only right-align if there's room; otherwise skip the hint.
         if bar_width > left_width + hint_width {

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -179,6 +179,30 @@ fn render_status(f: &mut Frame, app: &App, area: Rect) {
         spans.push(Span::raw("  "));
     }
     spans.push(Span::styled(msg, Style::default().fg(color)));
+
+    let right_hint: Option<(String, Color)> = if app.scroll_back > 0 {
+        Some((
+            format!("↑ {} lines · ⬇ to bottom", app.scroll_back),
+            SYSTEM,
+        ))
+    } else if app.esc_hint {
+        let hint = if app.streaming {
+            "ESC again to cancel"
+        } else {
+            "ESC again to clear"
+        };
+        Some((hint.to_string(), SYSTEM))
+    } else {
+        None
+    };
+
+    if let Some((hint_text, hint_color)) = right_hint {
+        spans.push(Span::styled(
+            format!(" {} ", hint_text),
+            Style::default().fg(hint_color).add_modifier(Modifier::DIM),
+        ));
+    }
+
     f.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -197,10 +197,22 @@ fn render_status(f: &mut Frame, app: &App, area: Rect) {
     };
 
     if let Some((hint_text, hint_color)) = right_hint {
-        spans.push(Span::styled(
-            format!(" {} ", hint_text),
-            Style::default().fg(hint_color).add_modifier(Modifier::DIM),
-        ));
+        let hint_display = format!(" {} ", hint_text);
+        let hint_width = hint_display.chars().count() as u16;
+        let left_width: u16 = spans
+            .iter()
+            .map(|s| s.content.chars().count() as u16)
+            .sum();
+        let bar_width = area.width;
+        // Only right-align if there's room; otherwise skip the hint.
+        if bar_width > left_width + hint_width {
+            let pad = bar_width - left_width - hint_width;
+            spans.push(Span::raw(" ".repeat(pad as usize)));
+            spans.push(Span::styled(
+                hint_display,
+                Style::default().fg(hint_color).add_modifier(Modifier::DIM),
+            ));
+        }
     }
 
     f.render_widget(Paragraph::new(Line::from(spans)), area);


### PR DESCRIPTION
## Summary

- **Mouse scroll** — `EnableMouseCapture` wired into `TerminalGuard`; `Event::Mouse(ScrollUp/Down)` scrolls 1 line per tick (separate from keyboard `SCROLL_STEP=5` to handle trackpad event rate)
- **Double-ESC** — pure `esc_action()` state machine (fully unit-tested, 11 cases): first ESC arms a 500 ms window; second ESC either clears the input box (not streaming) or cancels in-flight streaming and restores the sent message text to the input box
- **Status bar hints** — right-aligned; scroll indicator (`↑ N lines · ⬇ to bottom`) takes priority over ESC hint (`ESC again to cancel/clear`); silently suppressed on narrow terminals

## Files changed

- `mur-core/src/cmd/agent/cli/app.rs` — `EscAction` enum, `esc_action()` pure fn, `ESC_DOUBLE_WINDOW`, new `App` fields (`last_esc_at`, `esc_hint`, `last_sent`)
- `mur-core/src/cmd/agent/cli/mod.rs` — ESC handler, non-ESC guard, mouse capture, `Event::Mouse` arm, `last_sent` capture in `submit()`
- `mur-core/src/cmd/agent/cli/ui.rs` — right-aligned status bar hints

## Test Plan

- [ ] `cargo nextest run -p mur-core` — 3320/3324 pass (4 pre-existing `rollup_week` date-spurious failures)
- [ ] Mouse trackpad scroll up/down in `mur agent cli` chat
- [ ] Double-ESC clears input when not streaming
- [ ] Double-ESC during streaming cancels and restores message to input box
- [ ] Status bar shows `↑ N lines · ⬇ to bottom` when scrolled back
- [ ] Status bar shows `ESC again to cancel/clear` after first ESC press

🤖 Generated with [Claude Code](https://claude.com/claude-code)