### PR TITLE
feat(fleet): scope-filter runtime skill injection (project-scope for agent turns)

### DIFF
--- a/mur-agent-runtime/src/skills/injector.rs
+++ b/mur-agent-runtime/src/skills/injector.rs
@@ -25,6 +25,8 @@ pub fn inject_layer2(
     cfg: &SkillsConfig,
     context_fill_ratio: f64,
     recently_fired: &HashSet<String>,
+    active_fleet: Option<&str>,
+    active_project: Option<&str>,
 ) -> InjectionResult {
     // Adaptive cutoff: skip entirely when remaining context is too small.
     if let Some(ad) = &cfg.adaptive {
@@ -52,6 +54,18 @@ pub fn inject_layer2(
                 .triggers
                 .iter()
                 .any(|t| matches!(t.kind, TriggerKind::SessionStart))
+        })
+        // Scope: fleet/project-scoped skills inject only when the active scope
+        // matches (fail-closed); user/enterprise always pass. active_project is
+        // the member's cwd repo root; active_fleet is None for now (deferred).
+        .filter(|s| {
+            mur_common::skill::manifest::scope_visible(
+                s.manifest.scope,
+                s.manifest.fleet.as_deref(),
+                s.manifest.project.as_deref(),
+                active_fleet,
+                active_project,
+            )
         })
         .collect();
 
@@ -142,6 +156,43 @@ content:
     }
 
     #[test]
+    fn project_scoped_skill_injects_only_when_project_matches() {
+        let mk = |name: &str, scope_yaml: &str| {
+            let yaml = format!(
+                "name: {name}\nversion: 1.0.0\npublisher: human:t\ndescription: test\n\
+                 category: context\n{scope_yaml}content:\n  abstract: \"a\"\n  context: body\n\
+                 triggers:\n  - type: session_start\n"
+            );
+            LoadedSkill {
+                name: name.to_string(),
+                manifest: parse_canonical(&yaml).unwrap(),
+                trust: TrustLevel::Verified,
+                scope: SkillScope::Global,
+                content_hash: String::new(),
+            }
+        };
+        let skills = vec![mk("u", ""), mk("p", "scope: project\nproject: /repo\n")];
+        let names = |active: Option<&str>| {
+            inject_layer2(
+                &skills,
+                &SkillsConfig::default(),
+                0.0,
+                &HashSet::new(),
+                None,
+                active,
+            )
+            .injected_names
+        };
+        // no active project → project skill fail-closed; user always injects
+        let n0 = names(None);
+        assert!(n0.contains(&"u".to_string()) && !n0.contains(&"p".to_string()));
+        // matching active project → project skill injects
+        assert!(names(Some("/repo")).contains(&"p".to_string()));
+        // wrong project → fail-closed
+        assert!(!names(Some("/other")).contains(&"p".to_string()));
+    }
+
+    #[test]
     fn no_session_start_not_injected() {
         let s = loaded(
             "cmd-only",
@@ -149,7 +200,14 @@ content:
             TrustLevel::Verified,
             "triggers:\n  - type: command\n    pattern: /x\n",
         );
-        let result = inject_layer2(&[s], &SkillsConfig::default(), 0.0, &HashSet::new());
+        let result = inject_layer2(
+            &[s],
+            &SkillsConfig::default(),
+            0.0,
+            &HashSet::new(),
+            None,
+            None,
+        );
         assert!(result.system_addendum.is_empty());
         assert!(result.injected_names.is_empty());
     }
@@ -168,7 +226,14 @@ content:
             TrustLevel::Trusted,
             "triggers:\n  - type: session_start\n",
         );
-        let result = inject_layer2(&[a, b], &SkillsConfig::default(), 0.0, &HashSet::new());
+        let result = inject_layer2(
+            &[a, b],
+            &SkillsConfig::default(),
+            0.0,
+            &HashSet::new(),
+            None,
+            None,
+        );
         assert_eq!(result.injected_names.len(), 2);
         assert_eq!(result.injected_names[0], "trust");
         assert_eq!(result.injected_names[1], "sand");
@@ -189,7 +254,7 @@ content:
             }),
             ..SkillsConfig::default()
         };
-        let result = inject_layer2(&[s], &cfg, 0.85, &HashSet::new());
+        let result = inject_layer2(&[s], &cfg, 0.85, &HashSet::new(), None, None);
         assert!(result.budget_skipped);
         assert!(result.injected_names.is_empty());
     }
@@ -210,7 +275,7 @@ content:
             max_skills_in_prompt: 2,
             ..SkillsConfig::default()
         };
-        let result = inject_layer2(&skills, &cfg, 0.0, &HashSet::new());
+        let result = inject_layer2(&skills, &cfg, 0.0, &HashSet::new(), None, None);
         assert_eq!(result.injected_names.len(), 2);
     }
 
@@ -230,7 +295,7 @@ content:
         );
         let mut fired = HashSet::new();
         fired.insert("b".to_string());
-        let result = inject_layer2(&[a, b], &SkillsConfig::default(), 0.0, &fired);
+        let result = inject_layer2(&[a, b], &SkillsConfig::default(), 0.0, &fired, None, None);
         assert_eq!(result.injected_names.len(), 2);
         assert_eq!(result.injected_names[0], "b");
     }

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -306,7 +306,19 @@ impl TaskRunner {
                 (cumulative as f64 / max as f64).clamp(0.0, 1.0)
             }
         };
-        let injection = inject_layer2(&skills.loaded, &self.skills_cfg, ctx_fill, &recently);
+        // Scope filter: project from the member's cwd repo root (shared detection
+        // with the CLI hook). active_fleet is None for now — fleet-scoped skills
+        // have no creation path yet, and threading a turn's fleet through the
+        // runtime is a deferred follow-on.
+        let active_project = mur_common::project::active_project_id();
+        let injection = inject_layer2(
+            &skills.loaded,
+            &self.skills_cfg,
+            ctx_fill,
+            &recently,
+            None,
+            active_project.as_deref(),
+        );
 
         let triggered = match_prompt(&skills.triggers, user_prompt);
 

--- a/mur-agent-runtime/tests/skill_runtime_e2e.rs
+++ b/mur-agent-runtime/tests/skill_runtime_e2e.rs
@@ -64,6 +64,8 @@ triggers:
         &SkillsConfig::default(),
         0.0,
         &HashSet::new(),
+        None,
+        None,
     );
     assert!(inj.system_addendum.contains("house-rules"));
     assert!(!inj.system_addendum.contains("find-price"));

--- a/mur-common/src/project.rs
+++ b/mur-common/src/project.rs
@@ -36,10 +36,32 @@ pub fn project_id(start: &Path) -> Option<String> {
     canon.to_str().map(str::to_owned)
 }
 
+/// The active project id for scope matching: `MUR_ACTIVE_PROJECT` env override,
+/// else the current working dir's repo root. `None` when neither resolves
+/// (→ only user/enterprise skills inject). Single source used by both the CLI
+/// injection hook and the agent runtime injector so they can't diverge.
+pub fn active_project_id() -> Option<String> {
+    if let Ok(v) = std::env::var("MUR_ACTIVE_PROJECT") {
+        let v = v.trim();
+        if !v.is_empty() {
+            return Some(v.to_string());
+        }
+    }
+    std::env::current_dir().ok().and_then(|d| project_id(&d))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
+
+    #[test]
+    fn active_project_id_prefers_env_override() {
+        // nextest isolates each test in its own process → env is safe to set.
+        unsafe { std::env::set_var("MUR_ACTIVE_PROJECT", "/explicit") };
+        assert_eq!(active_project_id().as_deref(), Some("/explicit"));
+        unsafe { std::env::remove_var("MUR_ACTIVE_PROJECT") };
+    }
 
     #[test]
     fn repo_root_found_from_subdir_and_none_outside() {

--- a/mur-core/src/retrieve/skill_candidates.rs
+++ b/mur-core/src/retrieve/skill_candidates.rs
@@ -76,14 +76,10 @@ impl ActiveScope {
     /// env-only until the fleet runtime supplies it (ActiveContext for fleets).
     pub fn detect() -> Self {
         let nonempty = |k: &str| std::env::var(k).ok().filter(|s| !s.trim().is_empty());
-        let project = nonempty("MUR_ACTIVE_PROJECT").or_else(|| {
-            std::env::current_dir()
-                .ok()
-                .and_then(|d| mur_common::project::project_id(&d))
-        });
         Self {
             fleet: nonempty("MUR_ACTIVE_FLEET"),
-            project,
+            // Shared detection (env override → cwd repo root) with the runtime injector.
+            project: mur_common::project::active_project_id(),
         }
     }
 }


### PR DESCRIPTION
The **runtime half** of skill scope (the CLI/harvest half shipped in #455). Agent turns now respect skill scope.

## What
`mur-agent-runtime`'s `inject_layer2` drops skills not visible in the active scope (via `mur_common::skill::manifest::scope_visible`):
- **active_project** = the turn's cwd repo root → a `scope: Project` skill (created by harvest in #455) injects in its repo and nowhere else.
- **active_fleet = None** for now (see below).
- **No regression:** every current skill is `scope: User` → always injects. Only project/fleet-scoped skills are filtered. **Fail-closed:** excluded unless the active scope matches.

## DRY
Active-project detection (env `MUR_ACTIVE_PROJECT` override → cwd repo root) is now a single `mur_common::project::active_project_id()` used by **both** the CLI hook (`ActiveScope::detect`) and the runtime injector — removing a divergence the review flagged.

## Deferred (chosen "lean" scope)
`active_fleet` propagation (threading a delegation's `fleet-<name>` channel through `TaskSpec`→`run_sync_inner`→`assemble_system_prompt`) is **not** built: it's a 4-level change in the critical runtime and would be **inert** — there's no path to *create* a fleet-scoped skill yet. The injector already accepts `active_fleet`; wiring it is a follow-on once fleet-scope creation exists.

## Notes
- mur-agent-runtime uses **mur-common only** (not mur-core) — `scope_visible` + `project_id`/`active_project_id` all live in mur-common.
- Tests: `project_scoped_skill_injects_only_when_project_matches`, `active_project_id_prefers_env_override`, all existing injector tests updated. clippy `-D warnings` + fmt clean. sonnet-reviewed (fail-closed + no-regression + dependency boundary confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)