### PR TITLE
feat(fleet): B-full — thread active_fleet so fleet-scoped skills inject (membership-verified)

### DIFF
--- a/mur-agent-runtime/src/idle_scheduler.rs
+++ b/mur-agent-runtime/src/idle_scheduler.rs
@@ -138,6 +138,7 @@ async fn run_idle_loop(scheduler: IdleScheduler, cancel: CancellationToken) {
                         input,
                         context_task_id: None,
                         task_id: None,
+                        active_fleet: None,
                     })
                     .await;
 

--- a/mur-agent-runtime/src/protocol/methods/channel_delegate.rs
+++ b/mur-agent-runtime/src/protocol/methods/channel_delegate.rs
@@ -125,6 +125,11 @@ impl MethodHandler for ChannelDelegateHandler {
             input: message,
             context_task_id,
             task_id,
+            // A fleet's shared channel is `fleet-<name>`; derive the active fleet
+            // so the runtime injects this fleet's fleet-scoped skills for the turn.
+            // A non-fleet or malformed channel id yields None (fail-closed).
+            active_fleet: mur_common::fleet::fleet_name_from_channel_id(&channel_id)
+                .map(str::to_string),
         };
 
         // Run the turn (non-streaming path; v3d-2 does not need per-delta

--- a/mur-agent-runtime/src/protocol/methods/channel_delegate.rs
+++ b/mur-agent-runtime/src/protocol/methods/channel_delegate.rs
@@ -14,6 +14,29 @@ use serde_json::Value;
 use crate::protocol::a2a_server::{HandlerError, MethodHandler, RequestContext};
 use crate::task_runner::{TaskOutcome, TaskRunner, TaskSpec};
 
+/// Derive the active fleet for a delegated turn from the (caller-supplied)
+/// `channel_id`, **verified against the local fleet record**.
+///
+/// The channel id arrives in untrusted JSON-RPC params, so a string match on
+/// `fleet-<name>` is not enough: a peer could dial with `channel_id="fleet-X"`
+/// to make a non-member surface fleet-X-scoped skills (a confused deputy).
+/// We therefore stamp `active_fleet` only when this agent is actually a member
+/// (or the router) of an existing local fleet `<name>` — making `active_fleet`
+/// a verified-local fact, like `active_project` (the cwd repo root). Any miss
+/// (non-fleet channel, no such fleet on disk, not a member) yields `None`
+/// (fail-closed), so fleet-scoped skills stay hidden outside their fleet.
+fn verified_active_fleet(mur_home: &Path, agent: &str, channel_id: &str) -> Option<String> {
+    let name = mur_common::fleet::fleet_name_from_channel_id(channel_id)?;
+    let path = mur_home.join("fleets").join(name).join("fleet.yaml");
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let fleet: mur_common::fleet::Fleet = serde_yaml_ng::from_str(&raw).ok()?;
+    // Members and router are stored canonicalized (lowercase on-disk names), as
+    // is `agent`, so an exact match is correct here.
+    let is_member =
+        fleet.members.iter().any(|m| m == agent) || fleet.router_or_concierge() == agent;
+    is_member.then(|| name.to_string())
+}
+
 /// Append the specialist's reply to `channel_id` as `Agent{self}`, signed by the
 /// specialist's identity (v3d-2 peer-writes-own).
 #[allow(clippy::too_many_arguments)]
@@ -125,11 +148,11 @@ impl MethodHandler for ChannelDelegateHandler {
             input: message,
             context_task_id,
             task_id,
-            // A fleet's shared channel is `fleet-<name>`; derive the active fleet
-            // so the runtime injects this fleet's fleet-scoped skills for the turn.
-            // A non-fleet or malformed channel id yields None (fail-closed).
-            active_fleet: mur_common::fleet::fleet_name_from_channel_id(&channel_id)
-                .map(str::to_string),
+            // A fleet's shared channel is `fleet-<name>`; derive (and verify
+            // membership of) the active fleet so the runtime injects only this
+            // agent's own fleet's fleet-scoped skills. Untrusted/non-member/
+            // non-fleet channel ids yield None (fail-closed).
+            active_fleet: verified_active_fleet(&self.mur_home, &self.agent, &channel_id),
         };
 
         // Run the turn (non-streaming path; v3d-2 does not need per-delta
@@ -204,5 +227,57 @@ mod tests {
             &id.verifying_key_bytes(),
             true
         ));
+    }
+
+    fn write_fleet(home: &Path, name: &str, members: &[&str], router: Option<&str>) {
+        let dir = home.join("fleets").join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut yaml = format!("name: {name}\nchannel_id: fleet-{name}\nmembers:\n");
+        for m in members {
+            yaml.push_str(&format!("  - {m}\n"));
+        }
+        if let Some(r) = router {
+            yaml.push_str(&format!("router: {r}\n"));
+        }
+        std::fs::write(dir.join("fleet.yaml"), yaml).unwrap();
+    }
+
+    #[test]
+    fn verified_active_fleet_requires_membership() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        write_fleet(home, "dev", &["qa", "pm"], None);
+
+        // member → Some
+        assert_eq!(
+            verified_active_fleet(home, "qa", "fleet-dev").as_deref(),
+            Some("dev")
+        );
+        // non-member → None (confused-deputy defense): a crafted channel id for a
+        // real fleet must not surface that fleet's skills to a non-member.
+        assert_eq!(verified_active_fleet(home, "eve", "fleet-dev"), None);
+        // non-fleet / malformed channel id → None
+        assert_eq!(verified_active_fleet(home, "qa", "agent:foo:uuid"), None);
+        assert_eq!(verified_active_fleet(home, "qa", "fleet-../etc"), None);
+        // fleet not on disk → None (fail-closed)
+        assert_eq!(verified_active_fleet(home, "qa", "fleet-ghost"), None);
+    }
+
+    #[test]
+    fn verified_active_fleet_accepts_router() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        // explicit router that is not in the members list
+        write_fleet(home, "ops", &["qa"], Some("lead"));
+        assert_eq!(
+            verified_active_fleet(home, "lead", "fleet-ops").as_deref(),
+            Some("ops")
+        );
+        // default router (concierge "mur") when none is set
+        write_fleet(home, "sq", &["qa"], None);
+        assert_eq!(
+            verified_active_fleet(home, "mur", "fleet-sq").as_deref(),
+            Some("sq")
+        );
     }
 }

--- a/mur-agent-runtime/src/protocol/methods/message_send.rs
+++ b/mur-agent-runtime/src/protocol/methods/message_send.rs
@@ -89,6 +89,9 @@ impl MethodHandler for MessageSendHandler {
             input: message,
             context_task_id,
             task_id,
+            // Direct message/send carries no fleet context — only channel/delegate
+            // does, so fleet-scoped skills stay hidden on this path (fail-closed).
+            active_fleet: None,
         };
 
         self.emit_progress("pending", "llm_reasoning", None).await;

--- a/mur-agent-runtime/src/scheduler.rs
+++ b/mur-agent-runtime/src/scheduler.rs
@@ -105,6 +105,7 @@ async fn run_entry(entry: ScheduleEntry, runner: Arc<TaskRunner>, cancel: Cancel
                 input,
                 context_task_id: None,
                 task_id: None,
+                active_fleet: None,
             })
             .await;
 

--- a/mur-agent-runtime/src/skills/injector.rs
+++ b/mur-agent-runtime/src/skills/injector.rs
@@ -193,6 +193,44 @@ content:
     }
 
     #[test]
+    fn fleet_scoped_skill_injects_only_when_fleet_matches() {
+        let mk = |name: &str, scope_yaml: &str| {
+            let yaml = format!(
+                "name: {name}\nversion: 1.0.0\npublisher: human:t\ndescription: test\n\
+                 category: context\n{scope_yaml}content:\n  abstract: \"a\"\n  context: body\n\
+                 triggers:\n  - type: session_start\n"
+            );
+            LoadedSkill {
+                name: name.to_string(),
+                manifest: parse_canonical(&yaml).unwrap(),
+                trust: TrustLevel::Verified,
+                scope: SkillScope::Global,
+                content_hash: String::new(),
+            }
+        };
+        let skills = vec![mk("u", ""), mk("f", "scope: fleet\nfleet: dev\n")];
+        // active_fleet is the 5th arg; active_project stays None throughout.
+        let names = |active_fleet: Option<&str>| {
+            inject_layer2(
+                &skills,
+                &SkillsConfig::default(),
+                0.0,
+                &HashSet::new(),
+                active_fleet,
+                None,
+            )
+            .injected_names
+        };
+        // no active fleet → fleet skill fail-closed; user always injects
+        let n0 = names(None);
+        assert!(n0.contains(&"u".to_string()) && !n0.contains(&"f".to_string()));
+        // matching active fleet → fleet skill injects
+        assert!(names(Some("dev")).contains(&"f".to_string()));
+        // wrong fleet → fail-closed
+        assert!(!names(Some("other")).contains(&"f".to_string()));
+    }
+
+    #[test]
     fn no_session_start_not_injected() {
         let s = loaded(
             "cmd-only",

--- a/mur-agent-runtime/src/skills/injector.rs
+++ b/mur-agent-runtime/src/skills/injector.rs
@@ -57,7 +57,8 @@ pub fn inject_layer2(
         })
         // Scope: fleet/project-scoped skills inject only when the active scope
         // matches (fail-closed); user/enterprise always pass. active_project is
-        // the member's cwd repo root; active_fleet is None for now (deferred).
+        // the member's cwd repo root; active_fleet is the turn's `fleet-<name>`
+        // channel (membership-verified by the channel/delegate handler).
         .filter(|s| {
             mur_common::skill::manifest::scope_visible(
                 s.manifest.scope,

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -26,6 +26,11 @@ pub struct TaskSpec {
     /// client can cancel by an id it already holds; when `None` the runner
     /// generates one (back-compatible).
     pub task_id: Option<String>,
+    /// Active fleet name for this turn, derived from a `fleet-<name>` channel id
+    /// by the `channel/delegate` handler. Drives fleet-scoped skill injection;
+    /// `None` for non-fleet turns, so fleet-scoped skills stay hidden outside
+    /// their fleet (fail-closed).
+    pub active_fleet: Option<String>,
 }
 
 #[derive(Debug)]
@@ -265,7 +270,11 @@ impl TaskRunner {
         self
     }
 
-    fn assemble_system_prompt(&self, user_prompt: &str) -> (String, Vec<String>) {
+    fn assemble_system_prompt(
+        &self,
+        user_prompt: &str,
+        active_fleet: Option<&str>,
+    ) -> (String, Vec<String>) {
         let base = self.system_prompt.clone().unwrap_or_default();
         let Some(skills) = &self.skills else {
             return (base, vec![]);
@@ -307,16 +316,16 @@ impl TaskRunner {
             }
         };
         // Scope filter: project from the member's cwd repo root (shared detection
-        // with the CLI hook). active_fleet is None for now — fleet-scoped skills
-        // have no creation path yet, and threading a turn's fleet through the
-        // runtime is a deferred follow-on.
+        // with the CLI hook); fleet from the turn's `fleet-<name>` channel id,
+        // threaded in by the `channel/delegate` handler. Fleet- and project-scoped
+        // skills only surface in their matching context; user/enterprise always.
         let active_project = mur_common::project::active_project_id();
         let injection = inject_layer2(
             &skills.loaded,
             &self.skills_cfg,
             ctx_fill,
             &recently,
-            None,
+            active_fleet,
             active_project.as_deref(),
         );
 
@@ -427,15 +436,21 @@ impl TaskRunner {
                 RunnerBackend::Llm(client) => {
                     if self.pending_approvals.is_some() {
                         let system = self
-                            .prepare_system_prompt(&spec.input)
+                            .prepare_system_prompt(&spec.input, spec.active_fleet.as_deref())
                             .await
                             .unwrap_or_default();
                         self.run_agentic_loop(&id, client.as_ref(), system, &spec.input, sink)
                             .await
                     } else {
-                        self.run_llm(&id, client.as_ref(), &spec.input, sink)
-                            .await
-                            .map(|m| (m, None))
+                        self.run_llm(
+                            &id,
+                            client.as_ref(),
+                            &spec.input,
+                            spec.active_fleet.as_deref(),
+                            sink,
+                        )
+                        .await
+                        .map(|m| (m, None))
                     }
                 }
             }
@@ -611,12 +626,13 @@ impl TaskRunner {
         task_id: &str,
         client: &dyn LlmClient,
         input: &Message,
+        active_fleet: Option<&str>,
         sink: Option<tokio::sync::mpsc::Sender<crate::llm::StreamDelta>>,
     ) -> Result<Message, TaskError> {
         let prompt = text_of(input);
         let mut messages: Vec<RichMessage> = Vec::new();
 
-        let (system, fired) = self.assemble_system_prompt(&prompt);
+        let (system, fired) = self.assemble_system_prompt(&prompt, active_fleet);
 
         // Apply hook chain on_prompt_submit if wired.
         let system = if let (Some(chain), Some(ctx), Some(cancel)) =
@@ -731,9 +747,13 @@ impl TaskRunner {
         &self.tools
     }
 
-    async fn prepare_system_prompt(&self, input: &Message) -> Result<String, TaskError> {
+    async fn prepare_system_prompt(
+        &self,
+        input: &Message,
+        active_fleet: Option<&str>,
+    ) -> Result<String, TaskError> {
         let prompt = text_of(input);
-        let (system, _fired) = self.assemble_system_prompt(&prompt);
+        let (system, _fired) = self.assemble_system_prompt(&prompt, active_fleet);
         if let (Some(chain), Some(ctx), Some(cancel)) =
             (&self.hook_chain, &self.hook_ctx, &self.hook_cancel)
         {
@@ -1272,6 +1292,7 @@ mod tests {
             },
             context_task_id: None,
             task_id: None,
+            active_fleet: None,
         }
     }
 
@@ -1318,6 +1339,7 @@ mod tests {
             },
             context_task_id: None,
             task_id: Some("task-fixed-1".to_string()),
+            active_fleet: None,
         };
         assert_eq!(spec.task_id.as_deref(), Some("task-fixed-1"));
     }
@@ -1332,6 +1354,7 @@ mod tests {
             },
             context_task_id: None,
             task_id: Some("task-supplied-9".to_string()),
+            active_fleet: None,
         };
         let outcome = runner.run_sync(spec).await;
         let TaskOutcome::Completed(task) = outcome else {
@@ -1354,6 +1377,7 @@ mod tests {
             },
             context_task_id: None,
             task_id: Some("task-cancelme".to_string()),
+            active_fleet: None,
         };
         let r2 = runner.clone();
         let handle = tokio::spawn(async move { r2.run_sync_streaming(spec, tx).await });
@@ -1564,6 +1588,7 @@ mod tests {
             },
             context_task_id: None,
             task_id: None,
+            active_fleet: None,
         };
         let outcome = runner.run_sync(spec).await;
         assert!(matches!(outcome, TaskOutcome::Completed(_)));
@@ -1608,6 +1633,7 @@ mod tests {
             },
             context_task_id: None,
             task_id: None,
+            active_fleet: None,
         };
         let outcome = runner.run_sync(spec).await;
         let TaskOutcome::Completed(task) = outcome else {
@@ -1747,6 +1773,7 @@ mod tests {
             },
             context_task_id: None,
             task_id: None,
+            active_fleet: None,
         }
     }
 

--- a/mur-agent-runtime/src/watch_scheduler.rs
+++ b/mur-agent-runtime/src/watch_scheduler.rs
@@ -257,6 +257,7 @@ fn inject(runner: &Arc<TaskRunner>, text: &str) {
                 input,
                 context_task_id: None,
                 task_id: None,
+                active_fleet: None,
             })
             .await;
     });

--- a/mur-agent-runtime/tests/task_runner.rs
+++ b/mur-agent-runtime/tests/task_runner.rs
@@ -13,6 +13,7 @@ async fn sync_task_reaches_completed_state() {
         },
         context_task_id: None,
         task_id: None,
+        active_fleet: None,
     };
     let outcome = runner.run_sync(spec).await;
     match outcome {
@@ -36,6 +37,7 @@ async fn cancellation_transitions_to_cancelled() {
         },
         context_task_id: None,
         task_id: None,
+        active_fleet: None,
     };
     let handle = runner.start_async(spec);
     let task_id = handle.task_id().to_string();

--- a/mur-agent-runtime/tests/task_runner_ollama.rs
+++ b/mur-agent-runtime/tests/task_runner_ollama.rs
@@ -31,6 +31,7 @@ async fn runner_with_llm_generates_and_emits_telemetry() {
         },
         context_task_id: None,
         task_id: None,
+        active_fleet: None,
     };
     let outcome = runner.run_sync(spec).await;
     let task = match outcome {

--- a/mur-common/src/fleet.rs
+++ b/mur-common/src/fleet.rs
@@ -60,6 +60,20 @@ pub fn valid_fleet_name(name: &str) -> bool {
             .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
 }
 
+/// Channel-id prefix for a fleet's shared channel (`fleet-<name>`).
+pub const CHANNEL_PREFIX: &str = "fleet-";
+
+/// Derive the fleet name from a channel id of the form `fleet-<name>`.
+///
+/// Returns `None` for non-fleet channels, and also for a `fleet-`-prefixed id
+/// whose remainder isn't a valid fleet name — so a crafted channel id can't
+/// smuggle a path-traversal segment or otherwise masquerade as a fleet to pull
+/// in fleet-scoped skills.
+pub fn fleet_name_from_channel_id(channel_id: &str) -> Option<&str> {
+    let name = channel_id.strip_prefix(CHANNEL_PREFIX)?;
+    valid_fleet_name(name).then_some(name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,6 +93,25 @@ mod tests {
         assert!(!valid_fleet_name("Dev")); // uppercase
         assert!(!valid_fleet_name("a b")); // space
         assert!(!valid_fleet_name(".hidden")); // dot
+    }
+
+    #[test]
+    fn fleet_name_from_channel_id_extracts_and_validates() {
+        // valid fleet channels
+        assert_eq!(fleet_name_from_channel_id("fleet-dev"), Some("dev"));
+        assert_eq!(
+            fleet_name_from_channel_id("fleet-my-squad"),
+            Some("my-squad")
+        );
+        assert_eq!(fleet_name_from_channel_id("fleet-ab12"), Some("ab12"));
+        // not a fleet channel
+        assert_eq!(fleet_name_from_channel_id("dev"), None);
+        assert_eq!(fleet_name_from_channel_id("agent:foo:uuid"), None);
+        // prefixed but invalid remainder → rejected (no masquerading)
+        assert_eq!(fleet_name_from_channel_id("fleet-"), None); // empty
+        assert_eq!(fleet_name_from_channel_id("fleet-../etc"), None); // traversal
+        assert_eq!(fleet_name_from_channel_id("fleet-a/b"), None); // slash
+        assert_eq!(fleet_name_from_channel_id("fleet-Dev"), None); // uppercase
     }
 
     #[test]


### PR DESCRIPTION
## What

Completes the fleet **scope story** (Phase-1 fields → #455 CLI filter + harvest stamp → #456 runtime project filter → #457 `mur skill scope` authoring → **this PR**). Fleet-scoped skills, authorable via `mur skill scope <name> --fleet <f>` since #457, now actually **inject** for a fleet member's turn.

## How

A fleet member's turn arrives at the `channel/delegate` A2A handler, which carries the `fleet-<name>` channel id. The handler derives the active fleet and threads it through the runtime:

```
TaskSpec.active_fleet
  → run_sync_inner → {run_llm, prepare_system_prompt}
    → assemble_system_prompt → inject_layer2  (scope_visible gates Fleet skills)
```

The agentic-loop path receives the already-assembled system prompt, so both prompt-build paths (the only two `assemble_system_prompt` call sites) are covered. Direct `message/send` and the schedulers carry no fleet context (`active_fleet: None`) — fleet-scoped skills stay hidden off the fleet edge. Project scope (#456) is unchanged; user/enterprise skills still always inject.

## Security: `active_fleet` is a verified-local fact

A 4-lens adversarial review workflow (10 agents) flagged a confused-deputy: the channel id is **untrusted JSON-RPC input**, so deriving visibility straight from it would let a trusted peer dial `channel_id="fleet-X"` and make a **non-member** surface fleet-X-scoped skills. Fixed: the handler stamps `active_fleet` only when this agent is a **member (or router) of an existing local fleet** (`~/.mur/fleets/<name>/fleet.yaml`), else `None` (fail-closed) — mirroring how `active_project` is the real cwd repo root, not a caller string.

## Tests

- `mur-common`: `fleet_name_from_channel_id` (valid + non-fleet + masquerade-rejection: empty/traversal/slash/uppercase).
- runtime injector: `fleet_scoped_skill_injects_only_when_fleet_matches` (None hidden / match shown / wrong hidden; user always injects).
- runtime delegate: `verified_active_fleet_requires_membership` (member→Some, non-member→None, non-fleet/malformed→None, fleet-not-on-disk→None) + `verified_active_fleet_accepts_router` (explicit + default concierge).
- Full sweep: **1343 passed, 0 failed**; clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)