### PR TITLE
feat(hub): themed vector avatars in the agent list

### DIFF
--- a/mur-gui-core/src/discovery.rs
+++ b/mur-gui-core/src/discovery.rs
@@ -41,6 +41,8 @@ pub struct AgentEntry {
     pub category: PersonaCategory,
     pub status: AgentStatus,
     pub model_id: String,
+    /// Active pet style preset id (e.g. "chiikawa"); drives the card avatar.
+    pub style_preset: String,
 }
 
 /// Background scanner that polls `$mur_home/agents/*/profile.yaml` at 5s intervals.
@@ -104,6 +106,7 @@ pub fn scan_agents(mur_home: &Path) -> Vec<AgentEntry> {
                 category: profile.persona.category,
                 status,
                 model_id: format!("{}/{}", profile.model.provider, profile.model.name),
+                style_preset: profile.appearance.style_preset.clone(),
             })
         })
         .collect();

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -15,12 +15,20 @@ import { WorkView } from "./work/WorkView";
 import { useConversations } from "../conversation/ConversationContext";
 import { Mascot } from "./Mascot";
 import type { MascotMood } from "./Mascot";
+import { PetFace } from "./PetFace";
 import { useT } from "../i18n";
+import { BUILTIN_PRESETS } from "../types";
 import { CATEGORY_COLORS, CATEGORY_ICONS, avatarInitials, timeGreetingKey } from "../utils";
 
 // ─── Shared helpers ────────────────────────────────────────────────────────
 
 const ALL_CATEGORIES = ["research", "automation", "monitor", "notify", "commerce", "custom"];
+
+// preset id → family, for theming the card avatar's vector mascot.
+const PRESET_FAMILY: Record<string, string> = Object.fromEntries(
+  BUILTIN_PRESETS.map((p) => [p.id, p.family]),
+);
+const familyOf = (presetId: string): string => PRESET_FAMILY[presetId] ?? "chibi";
 
 function showToast(msg: string, durationMs = 2000) {
   const el = document.createElement("div");
@@ -175,8 +183,13 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
         onClick={() => setSelected(isSelected ? null : agent.name)}
       >
         <div className="grid-card__head">
-          <div className="grid-card__avatar" style={{ background: color }}>
-            {avatarInitials(agent.display_name)}
+          <div className="grid-card__avatar grid-card__avatar--pet" title={agent.style_preset}>
+            <PetFace
+              presetId={agent.style_preset}
+              family={familyOf(agent.style_preset)}
+              expression="idle"
+              size={44}
+            />
             {unread > 0 && (
               <span className="unread-badge">{unread > 99 ? "99+" : unread}</span>
             )}

--- a/mur-hub-gui/ui/src/styles/components/dashboard.css
+++ b/mur-hub-gui/ui/src/styles/components/dashboard.css
@@ -260,6 +260,9 @@
   transition: transform var(--dur-base) var(--ease-out);
 }
 .grid-card:hover .grid-card__avatar { transform: scale(1.12) translateY(-1px); }
+/* Holds the themed vector mascot (PetFace) instead of a flat colour + initials. */
+.grid-card__avatar--pet { background: transparent; overflow: visible; }
+.grid-card__avatar--pet > svg { width: 44px; height: 44px; }
 .grid-card__name {
   margin: 0;
   font-size: var(--text-base);

--- a/mur-hub-gui/ui/src/types.ts
+++ b/mur-hub-gui/ui/src/types.ts
@@ -8,6 +8,8 @@ export interface AgentEntry {
   category: "research" | "automation" | "monitor" | "notify" | "commerce" | "custom";
   status: AgentStatus;
   model_id: string;
+  /** Active pet style preset id (e.g. "chiikawa"); drives the card avatar. */
+  style_preset: string;
 }
 
 // RuntimeState matches mur-gui-core::sidecar::RuntimeState (#[serde(tag = "state")])


### PR DESCRIPTION
## Why
Follow-up to #462. After shipping the offline vector pet (`PetFace`) and the 🎨 style picker, the agent-list cards still showed a flat category-color circle with initials — so the list didn't reflect each agent's chosen style. This was the one deferred item from #462 that's genuinely valuable and Hub-UI-scoped.

## What changed
- Thread `style_preset` through `AgentEntry` (`mur-gui-core/discovery.rs`, populated from `profile.appearance`) + the UI `AgentEntry` type.
- Each GridCard avatar now renders the themed **`PetFace`** mascot (family resolved from `BUILTIN_PRESETS`, fallback `chibi`) instead of initials + color. The agent list now matches the desktop pet's style at a glance.

## Deferred items from #462 — intentionally left, with reasons
- **Image/vision drop:** the runtime's `message/send` path only forwards `MessagePart::Text` to the model (`mur-agent-runtime/task_runner.rs`); image input is a runtime feature (wire the multimodal pipeline into that path + a vision model), not a Hub-UI change.
- **Companion-level mute:** already covered — companion nudges surface to the user only as pet bubbles/voice, which the pet **Mute** already suppresses.
- **Hide-1h persistence:** YAGNI — pets don't auto-restore on Hub restart, so there's no state to persist.

## Verification
`cargo check` + `clippy -D warnings` + `fmt` (mur-gui-core), `tsc -b`, `eslint` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
