### PR TITLE
fix(hub): address desktop-pet review findings

### DIFF
--- a/mur-hub-gui/src-tauri/capabilities/pet.json
+++ b/mur-hub-gui/src-tauri/capabilities/pet.json
@@ -1,12 +1,14 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "identifier": "pet",
-  "description": "Capability set for desktop pet windows (one `pet-<agent>` window per agent). Least privilege: pets only need to receive expression/bubble events, read their position, and be dragged around the desktop.",
+  "description": "Capability set for desktop pet windows (one `pet-<agent>` window per agent). Least privilege: pets only need to receive expression/bubble events, read their position, be dragged around the desktop, and hide/show themselves (Hide-1h menu).",
   "windows": ["pet-*"],
   "permissions": [
     "core:event:allow-listen",
     "core:event:allow-unlisten",
     "core:window:allow-outer-position",
-    "core:window:allow-start-dragging"
+    "core:window:allow-start-dragging",
+    "core:window:allow-hide",
+    "core:window:allow-show"
   ]
 }

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -258,22 +258,23 @@ pub fn run() {
                 if !label.starts_with("pet-") {
                     return;
                 }
-                // macOS fires Drop twice per gesture (Tauri #14134); coalesce.
-                // ponytail: one global 150ms guard. If pets ever need to accept
-                // simultaneous drops, key this by (label, paths) instead.
+                // macOS fires Drop twice per gesture (Tauri #14134); coalesce
+                // PER WINDOW so a near-simultaneous drop on a *different* pet
+                // isn't swallowed by a global timer.
+                use std::collections::HashMap;
                 use std::sync::Mutex;
                 use std::time::{Duration, Instant};
-                static LAST_DROP: Mutex<Option<Instant>> = Mutex::new(None);
+                static LAST_DROP: Mutex<Option<HashMap<String, Instant>>> = Mutex::new(None);
                 let now = Instant::now();
                 {
-                    let mut last = LAST_DROP.lock().unwrap_or_else(|p| p.into_inner());
-                    if last
-                        .map(|t| now.duration_since(t) < Duration::from_millis(150))
-                        .unwrap_or(false)
+                    let mut guard = LAST_DROP.lock().unwrap_or_else(|p| p.into_inner());
+                    let map = guard.get_or_insert_with(HashMap::new);
+                    if let Some(prev) = map.get(&label)
+                        && now.duration_since(*prev) < Duration::from_millis(150)
                     {
                         return;
                     }
-                    *last = Some(now);
+                    map.insert(label.clone(), now);
                 }
                 let paths: Vec<String> = paths
                     .iter()

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -284,6 +284,19 @@ pub fn pet_open_chat(agent_name: String, draft: Option<String>, app: AppHandle) 
 const PET_DROP_MAX_FILES: usize = 5;
 const PET_DROP_MAX_TOTAL_BYTES: u64 = 2 * 1024 * 1024;
 const PET_DROP_MAX_CHARS_PER_FILE: usize = 8000;
+/// Hard per-file read ceiling (well above the char budget) so a pseudo/special
+/// file can never stream unbounded into memory.
+const PET_DROP_READ_BYTE_CAP: u64 = 256 * 1024;
+
+/// Read at most `max_bytes` from `path` as lossy UTF-8. Returns None if the file
+/// can't be opened/read. Bounded so a symlink to e.g. /dev/zero can't OOM us.
+fn read_text_capped(path: &std::path::Path, max_bytes: u64) -> Option<String> {
+    use std::io::Read as _;
+    let f = std::fs::File::open(path).ok()?;
+    let mut buf = Vec::new();
+    f.take(max_bytes).read_to_end(&mut buf).ok()?;
+    Some(String::from_utf8_lossy(&buf).into_owned())
+}
 
 /// Extensions we can safely read as UTF-8 text for an inline quick-take.
 fn is_text_like(path: &std::path::Path) -> bool {
@@ -360,25 +373,26 @@ pub async fn pet_drop_files(
             skipped.push(fname);
             continue;
         }
-        let len = std::fs::metadata(path).map(|m| m.len()).unwrap_or(u64::MAX);
-        total = total.saturating_add(len);
-        if total > PET_DROP_MAX_TOTAL_BYTES {
+        // Bounded read: never trust metadata().len() (pseudo-files like a
+        // symlink to /dev/zero report 0 yet read forever → OOM). Cap the bytes
+        // actually read, then truncate to the char budget.
+        let Some(mut c) = read_text_capped(path, PET_DROP_READ_BYTE_CAP) else {
             skipped.push(fname);
             continue;
+        };
+        total = total.saturating_add(c.len() as u64);
+        if total > PET_DROP_MAX_TOTAL_BYTES {
+            skipped.push(fname);
+            break;
         }
-        match std::fs::read_to_string(path) {
-            Ok(mut c) => {
-                if c.chars().count() > PET_DROP_MAX_CHARS_PER_FILE {
-                    c = c
-                        .chars()
-                        .take(PET_DROP_MAX_CHARS_PER_FILE)
-                        .collect::<String>();
-                    c.push_str("\n…(truncated)");
-                }
-                sections.push(format!("=== {fname} ===\n{c}"));
-            }
-            Err(_) => skipped.push(fname),
+        if c.chars().count() > PET_DROP_MAX_CHARS_PER_FILE {
+            c = c
+                .chars()
+                .take(PET_DROP_MAX_CHARS_PER_FILE)
+                .collect::<String>();
+            c.push_str("\n…(truncated)");
         }
+        sections.push(format!("=== {fname} ===\n{c}"));
     }
 
     // Nothing readable (images/binaries): open chat with a reference note only.
@@ -630,6 +644,9 @@ mod tests {
             "core:event:allow-unlisten",
             "core:window:allow-outer-position",
             "core:window:allow-start-dragging",
+            // hide/show back the Hide-1h menu item (ACL-gated, was a silent no-op).
+            "core:window:allow-hide",
+            "core:window:allow-show",
         ] {
             assert!(perms.contains(&perm), "pet windows need {perm}");
         }

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -189,6 +189,7 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
               family={familyOf(agent.style_preset)}
               expression="idle"
               size={44}
+              animate={false}
             />
             {unread > 0 && (
               <span className="unread-badge">{unread > 99 ? "99+" : unread}</span>

--- a/mur-hub-gui/ui/src/components/DetailPanel.tsx
+++ b/mur-hub-gui/ui/src/components/DetailPanel.tsx
@@ -432,7 +432,9 @@ function StyleTab({
     invoke<{ has_ai_art: boolean }>("pet_get_appearance", { agentName: detail.agent_name })
       .then((a) => setHasAiArt(a.has_ai_art))
       .catch(() => setHasAiArt(false));
-  }, [detail.agent_name, detail.render_status]);
+    // depend on the status STRING, not the render_status object (which gets a new
+    // identity every 1.5s poll tick → ~80 redundant IPC reads during a render).
+  }, [detail.agent_name, detail.render_status.status]);
 
   async function triggerRender() {
     setSaveError(null);

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -63,8 +63,12 @@ export function PetApp() {
         paths,
       })
         .then((res) => {
+          const base = res.reply || t("pet.dropOpened");
+          const skipped = res.skipped?.length
+            ? ` ${t("pet.dropSkipped", { count: res.skipped.length })}`
+            : "";
           setBubble({
-            text: res.reply || t("pet.dropOpened"),
+            text: base + skipped,
             dwell_ms: res.reply ? 12000 : 6000,
             ack_required: false,
           });
@@ -295,6 +299,14 @@ function Bubble({ text, dwellMs, onClose }: BubbleProps) {
   const [remaining, setRemaining] = useState(dwellMs);
   const hoveredRef = useRef(false);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // The same <Bubble> instance is reused when the message changes (e.g. the
+  // file-drop "reading…" 60s bubble → the 12s reply). useState only seeds
+  // `remaining` once, so reset it whenever the message/dwell changes — else the
+  // countdown (and the progress bar) keep the stale value and over-run.
+  useEffect(() => {
+    setRemaining(dwellMs);
+  }, [dwellMs, text]);
 
   useEffect(() => {
     intervalRef.current = setInterval(() => {

--- a/mur-hub-gui/ui/src/components/PetFace.tsx
+++ b/mur-hub-gui/ui/src/components/PetFace.tsx
@@ -15,6 +15,8 @@ interface PetFaceProps {
   /** One of the 12 canonical expression slots. */
   expression: string;
   size?: number;
+  /** Idle blink/breathe animation. Off for static thumbnails (agent cards). */
+  animate?: boolean;
 }
 
 type Shape = "ellipse" | "roundsquare" | "pixel" | "polaroid";
@@ -264,10 +266,13 @@ function EarTop({ style }: { style: Style }) {
   }
 }
 
-export function PetFace({ presetId, family, expression, size = 140 }: PetFaceProps) {
+export function PetFace({ presetId, family, expression, size = 140, animate = true }: PetFaceProps) {
   const style = resolveStyle(presetId, family);
   const recipe = EXPR[expression] ?? EXPR.idle;
-  const animatable = expression === "idle" || expression === "smile" || expression === "peek";
+  // Only the live pet window animates; card thumbnails pass animate={false} so
+  // N cards don't each run two infinite filtered transform animations.
+  const animatable =
+    animate && (expression === "idle" || expression === "smile" || expression === "peek");
 
   return (
     <svg

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -167,6 +167,7 @@ export const en = {
   "pet.settings": "Settings",
   "pet.dropThinking": "Reading…",
   "pet.dropOpened": "Opened in chat ↗",
+  "pet.dropSkipped": "({count} not read)",
   // ── Mascot speech ──
   "mascot.bubble.excited": "No flock yet! Create your first agent 🐦",
   "mascot.bubble.happy": "Your whole flock is flying! 🎉",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -169,6 +169,7 @@ export const zhTW: Table = {
   "pet.settings": "設定",
   "pet.dropThinking": "讀取中…",
   "pet.dropOpened": "已在聊天開啟 ↗",
+  "pet.dropSkipped": "（{count} 個未讀取）",
   // ── Mascot speech ──
   "mascot.bubble.excited": "還沒有鳥群！快建立你的第一隻 agent 🐦",
   "mascot.bubble.happy": "整個鳥群都在飛翔！🎉",

--- a/mur-hub-gui/ui/src/styles/components/pet.css
+++ b/mur-hub-gui/ui/src/styles/components/pet.css
@@ -149,16 +149,23 @@ body.pet-window {
 
 /* ── Pet Bubble ───────────────────────────────────────────────────────── */
 .pet-bubble {
+  /* The pet OS window is a fixed transparent 200×200; anything painted outside
+     it is clipped (the bubble used to sit at bottom:210px → fully off-window and
+     invisible). Anchor it INSIDE the window over the pet's head, cap the size,
+     and scroll long replies so a multi-sentence quick-take stays readable. */
   position: absolute;
-  bottom: 210px;
+  top: 2px;
   left: 50%;
   transform: translateX(-50%);
-  max-width: 280px;
-  min-width: 120px;
+  max-width: 188px;
+  min-width: 110px;
+  max-height: 150px;
+  overflow-y: auto;
+  overflow-x: hidden;
   background: var(--surface-card);
   border: 1px solid var(--border-line);
   border-radius: var(--radius-md);
-  padding: var(--space-5) 28px var(--space-5) var(--space-5);
+  padding: var(--space-3) 26px var(--space-3) var(--space-4);
   box-shadow: var(--shadow-pop);
   animation: bubbleFadeIn var(--dur-base) var(--ease-out);
   z-index: 100;


### PR DESCRIPTION
## Why
A multi-dimension adversarial review of the merged desktop-pet work (#462 + #463) surfaced 11 findings; all were verified real. This PR fixes the 8 unique issues (two findings were the same StyleTab effect). No existing reviewer left comments — this is a self-review pass.

## Fixes (severity ordered)
- **Bubble clipped off-window (high):** the pet speech bubble was positioned `bottom: 210px` on a fixed transparent **200×200** window, so it painted entirely outside the frame and was invisible — meaning the new file-drop quick-take reply (and every proactive bubble) never showed. Re-anchored inside the window over the pet's head, capped width/height, long replies scroll.
- **"Hide 1h" was a silent no-op (high):** `window.hide()/show()` are ACL-gated and `capabilities/pet.json` didn't grant them, so the click did nothing (rejection swallowed by `.catch`). Added `core:window:allow-hide` / `allow-show` + guarded them in the capability regression test.
- **Bubble countdown not reset (medium):** `<Bubble>` had no key and `remaining` was seeded once, so the 12 s reply bubble inherited the 60 s "reading…" countdown → lingered ~57 s with a >100 % progress bar. Reset on `[dwellMs, text]`.
- **Card avatar animations (low/perf):** every agent card ran two infinite CSS transform animations under an SVG drop-shadow filter. Added a `PetFace animate` prop; cards pass `animate={false}` (live pet still animates).
- **Drag dedupe too broad (low):** the 150 ms double-fire guard was a single global timer, so a near-simultaneous drop on a *second* pet was swallowed. Now keyed per window label.
- **Unbounded read (low/safety):** `pet_drop_files` trusted `metadata().len()`; a pseudo-file (symlink to `/dev/zero`) reports 0 and would stream forever. Switched to a bounded `File::take` read.
- **StyleTab over-fetch (low/perf):** the `pet_get_appearance` effect depended on the `render_status` object (new identity every 1.5 s poll) → ~80 redundant IPC reads during a render. Depend on the status string.
- **Skipped-file feedback:** the drop bubble now reports how many files were unreadable/unsupported.

## Deferred items (unchanged, by design)
Image/vision drop (runtime `message/send` only forwards text), companion-level mute (covered by pet mute), Hide-1h persistence across restart (YAGNI).

## Verification
`cargo check` + `clippy -D warnings` + `fmt` (hub-gui), `tsc -b`, `eslint`, PetFace vitest — all clean. The successful Tauri capability codegen validates the new permission ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
