### PR TITLE
fix(agent): correct mur agent run to mur agent install-service in error messages

### DIFF
--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -69,7 +69,7 @@ pub async fn cmd_cli(
     let lock = home.join("agents").join(&agent).join("running.lock");
     if !lock.exists() {
         eprintln!(
-            "Agent '{agent}' is not running. Start it first, e.g.:\n    mur agent run {agent}\nthen retry: mur agent cli {agent}"
+            "Agent '{agent}' is not running. Start it first with:\n    mur agent install-service {agent}\nthen retry: mur agent cli {agent}"
         );
         return Ok(());
     }

--- a/mur-core/src/cmd/agent/cli/multiplex.rs
+++ b/mur-core/src/cmd/agent/cli/multiplex.rs
@@ -80,7 +80,7 @@ fn validate(home: &Path, names: &[String]) -> Result<Vec<String>> {
     }
     if !stopped.is_empty() {
         bail!(
-            "agent(s) not running: {} — start them first, e.g. `mur agent run {}`",
+            "agent(s) not running: {} — start them first, e.g. `mur agent install-service {}`",
             stopped.join(", "),
             stopped[0]
         );
@@ -887,7 +887,7 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("a2") && err.contains("mur agent run"),
+            err.contains("a2") && err.contains("mur agent install-service"),
             "got: {err}"
         );
     }


### PR DESCRIPTION
## Summary
- `mur agent run` was never a real subcommand, but two error messages pointed users to it
- Updated `cli/mod.rs` and `multiplex.rs` error strings to use `mur agent install-service`
- Fixed the test asserting the old error string

## Test plan
- [ ] `cargo test -p mur-core cmd::agent::cli` — 35 passed, 0 failed