### PR TITLE
fix(hub): show canonical skills as loadable in agent detail panel

### DIFF
--- a/mur-hub-gui/src-tauri/src/detail.rs
+++ b/mur-hub-gui/src-tauri/src/detail.rs
@@ -88,27 +88,19 @@ pub struct SkillView {
     pub loadable: bool,
 }
 
-/// Best-effort check that a legacy per-agent skill path points at a file that
-/// the runtime can still load. Resolves `rel_path` under the agent home, then
-/// parses the file by extension and validates the resulting manifest. Any
-/// failure (missing file, unparseable, invalid) yields `false`.
+/// Best-effort check that a per-agent skill path points at something the
+/// runtime can still load. Delegates to `read_from_dir` — the exact resolver
+/// the runtime uses (`mur_common::skill::loader`) — so this badge never drifts
+/// from real load behavior. It handles all on-disk layouts: the canonical
+/// `skills/<name>/skill.yaml` directory, a nested `skill.md`, and legacy flat
+/// `skills/<name>.md`. Any failure (missing, unparseable, invalid) yields
+/// `false`.
 fn skill_path_is_loadable(agent_home: &std::path::Path, rel_path: &str) -> bool {
-    let file = agent_home.join(rel_path);
-    let Ok(text) = std::fs::read_to_string(&file) else {
-        return false;
-    };
-    let ext = file
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_ascii_lowercase();
-    let parsed = match ext.as_str() {
-        "yaml" | "yml" => mur_common::skill::parse_canonical(&text),
-        "md" | "markdown" => mur_common::skill::parse_markdown(&text)
-            .or_else(|_| mur_common::skill::parse_legacy_markdown(&text)),
-        _ => return false,
-    };
-    matches!(parsed, Ok(ref m) if mur_common::skill::validate(m).is_ok())
+    let path = agent_home.join(rel_path);
+    matches!(
+        mur_common::skill::read_from_dir(&path),
+        Ok(ref m) if mur_common::skill::validate(m).is_ok()
+    )
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -283,4 +275,34 @@ pub fn update_agent_detail(name: String, patch: DetailPatch) -> Result<AgentDeta
 
     // Return fresh detail after update
     get_agent_detail(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::skill_path_is_loadable;
+    use mur_common::skill::{parse_canonical, write_to_dir};
+    use tempfile::tempdir;
+
+    fn sample() -> mur_common::skill::SkillManifest {
+        parse_canonical(
+            "name: foo\nversion: 1.0.0\npublisher: human:t\ndescription: test skill foo\ncategory: context\ncontent:\n  abstract: hi\n  context: body\n",
+        )
+        .unwrap()
+    }
+
+    // Regression: canonical `skills/<name>/skill.yaml` directory layout must
+    // read as loadable. The old extension-based check returned false because
+    // the path is a directory with no extension.
+    #[test]
+    fn canonical_skill_dir_is_loadable() {
+        let home = tempdir().unwrap();
+        write_to_dir(&home.path().join("skills").join("foo"), &sample()).unwrap();
+        assert!(skill_path_is_loadable(home.path(), "skills/foo"));
+    }
+
+    #[test]
+    fn missing_path_is_not_loadable() {
+        let home = tempdir().unwrap();
+        assert!(!skill_path_is_loadable(home.path(), "skills/ghost.md"));
+    }
 }


### PR DESCRIPTION
## Problem

The Hub agent detail panel (Skills tab) flagged **every** skill of an agent like RustSmith as `無法載入 / cannot load` ("this legacy file no longer parses as a valid skill"), even though the runtime loads them fine.

## Root cause

`skill_path_is_loadable` (`mur-hub-gui/src-tauri/src/detail.rs`) reimplemented skill resolution as *extension-based file parsing*: `read_to_string(path)` then match on `.yaml`/`.md`. But agent skills live in the **canonical directory layout** `skills/<name>/skill.yaml`, and `profile.skills` lists the **directories** (`skills/rust-error-handling`). So:

- `read_to_string` on a directory fails → `false`, and
- the extensionless path would hit `_ => return false` anyway.

The runtime never had this problem — `loader::load_all` resolves each skill via `mur_common::skill::read_from_dir`, which handles the directory layout. This was purely a false UI status.

## Fix

Delegate `skill_path_is_loadable` to `read_from_dir` — the exact resolver the runtime uses — so the badge can never drift from real load behavior. It handles the canonical `skills/<name>/skill.yaml` dir, a nested `skill.md`, and legacy flat `skills/<name>.md` alike. Net **−20 / +6** logic lines (delete the reinvention, reuse the loader).

Genuinely-missing files (e.g. a `skills/foo.md` that no longer exists on disk) still correctly report `false`.

## Tests

Added two regression tests in `detail.rs`:
- `canonical_skill_dir_is_loadable` — the case that was broken
- `missing_path_is_not_loadable` — guards against an "always-true" over-correction

```
test detail::tests::missing_path_is_not_loadable ... ok
test detail::tests::canonical_skill_dir_is_loadable ... ok
test result: ok. 2 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)