### PR TITLE
feat(agent-cli): paste screenshots into `mur agent cli` (inline vision)

### DIFF
--- a/mur-agent-runtime/src/llm/anthropic.rs
+++ b/mur-agent-runtime/src/llm/anthropic.rs
@@ -243,6 +243,28 @@ fn rich_messages_to_anthropic(
                     .collect();
                 convo.push(json!({"role": "user", "content": parts}));
             }
+            RichMessage::ImageText {
+                role,
+                media_type,
+                data,
+                text,
+            } => {
+                let r = if role == "agent" {
+                    "assistant"
+                } else {
+                    role.as_str()
+                };
+                // Image block first (Anthropic's recommended ordering), then
+                // the caption — skipped when empty so an image-only paste works.
+                let mut parts = vec![json!({
+                    "type": "image",
+                    "source": {"type": "base64", "media_type": media_type, "data": data},
+                })];
+                if !text.is_empty() {
+                    parts.push(json!({"type": "text", "text": text}));
+                }
+                convo.push(json!({"role": r, "content": parts}));
+            }
         }
     }
 
@@ -569,6 +591,39 @@ mod tests {
         assert_eq!(convo.len(), 1);
         assert_eq!(convo[0]["role"], "user");
         assert_eq!(convo[0]["content"], "hi");
+    }
+
+    #[test]
+    fn image_text_becomes_image_block_then_caption() {
+        let msgs = vec![RichMessage::ImageText {
+            role: "user".into(),
+            media_type: "image/png".into(),
+            data: "QkFTRTY0".into(),
+            text: "what is this?".into(),
+        }];
+        let (_, convo, _) = rich_messages_to_anthropic(&msgs);
+        assert_eq!(convo.len(), 1);
+        let content = convo[0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "image");
+        assert_eq!(content[0]["source"]["type"], "base64");
+        assert_eq!(content[0]["source"]["media_type"], "image/png");
+        assert_eq!(content[0]["source"]["data"], "QkFTRTY0");
+        assert_eq!(content[1]["type"], "text");
+        assert_eq!(content[1]["text"], "what is this?");
+    }
+
+    #[test]
+    fn image_text_without_caption_is_image_only() {
+        let msgs = vec![RichMessage::ImageText {
+            role: "user".into(),
+            media_type: "image/png".into(),
+            data: "QQ==".into(),
+            text: String::new(),
+        }];
+        let (_, convo, _) = rich_messages_to_anthropic(&msgs);
+        let content = convo[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1, "no empty text block");
+        assert_eq!(content[0]["type"], "image");
     }
 
     #[test]

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -77,6 +77,17 @@ pub enum RichMessage {
     ToolResults {
         results: Vec<ToolResultEntry>,
     },
+    /// A user turn carrying an inline image (base64) plus its text caption —
+    /// e.g. a screenshot pasted into `mur agent cli`. Only the Anthropic
+    /// adapter renders the image today; other adapters drop it to text.
+    ImageText {
+        role: String,
+        /// e.g. "image/png" — passed straight through to the provider.
+        media_type: String,
+        /// Base64-encoded image bytes (no data: prefix).
+        data: String,
+        text: String,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/mur-agent-runtime/src/llm/openai.rs
+++ b/mur-agent-runtime/src/llm/openai.rs
@@ -179,6 +179,17 @@ fn rich_messages_to_openai(msgs: &[RichMessage]) -> Vec<serde_json::Value> {
                     }));
                 }
             }
+            // ponytail: OpenAI vision not wired — keep the caption, drop the
+            // image. Emit image_url content blocks here if an OpenAI-backed
+            // vision agent ever needs to see pasted screenshots.
+            RichMessage::ImageText { role, text, .. } => {
+                let r = if role == "agent" {
+                    "assistant"
+                } else {
+                    role.as_str()
+                };
+                result.push(json!({"role": r, "content": text}));
+            }
         }
     }
     result

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -721,10 +721,7 @@ impl TaskRunner {
             });
         }
 
-        messages.push(RichMessage::Text {
-            role: input.role.clone(),
-            content: prompt.clone(),
-        });
+        messages.push(user_message(input));
         let req = LlmRequest {
             messages,
             temperature: None,
@@ -946,16 +943,12 @@ impl TaskRunner {
         use crate::llm::{LlmRequest, RichMessage, StopReason};
 
         let tool_defs: Vec<_> = self.tools_for_loop().iter().map(|t| t.def()).collect();
-        let prompt = text_of(input);
         let mut history: Vec<RichMessage> = vec![
             RichMessage::Text {
                 role: "system".into(),
                 content: system_prompt,
             },
-            RichMessage::Text {
-                role: input.role.clone(),
-                content: prompt,
-            },
+            user_message(input),
         ];
 
         // Snapshot the (per-runner, shared-across-tasks) token counter so the
@@ -1266,6 +1259,34 @@ fn text_of(m: &Message) -> String {
             _ => None,
         })
         .unwrap_or_default()
+}
+
+/// Build the user-turn message: image+text when `input` carries a pasted
+/// image (a screenshot from `mur agent cli`), else plain text. Images skip the
+/// B0 text hook (they're binary, not prompt-injectable). ponytail: OCR-scan
+/// inbound images later if needed.
+fn user_message(input: &Message) -> crate::llm::RichMessage {
+    use crate::llm::RichMessage;
+    let text = text_of(input);
+    let image = input.parts.iter().find_map(|p| match p {
+        MessagePart::Data { mime_type, data } if mime_type.starts_with("image/") => data
+            .get("base64")
+            .and_then(|v| v.as_str())
+            .map(|b64| (mime_type.clone(), b64.to_string())),
+        _ => None,
+    });
+    match image {
+        Some((media_type, data)) => RichMessage::ImageText {
+            role: input.role.clone(),
+            media_type,
+            data,
+            text,
+        },
+        None => RichMessage::Text {
+            role: input.role.clone(),
+            content: text,
+        },
+    }
 }
 
 fn strip_lines_for(text: &str, names: &HashSet<&str>) -> String {
@@ -2124,7 +2145,7 @@ mod tests {
                         result_ids.insert(r.call_id.clone());
                     }
                 }
-                RichMessage::Text { .. } => {}
+                RichMessage::Text { .. } | RichMessage::ImageText { .. } => {}
             }
         }
         assert!(!use_ids.is_empty(), "expected at least one tool_use");
@@ -2135,5 +2156,46 @@ mod tests {
                  result_ids={result_ids:?}"
             );
         }
+    }
+
+    #[test]
+    fn user_message_carries_pasted_image() {
+        let msg = Message {
+            role: "user".into(),
+            parts: vec![
+                MessagePart::Text {
+                    text: "what is this?".into(),
+                },
+                MessagePart::Data {
+                    mime_type: "image/png".into(),
+                    data: serde_json::json!({ "base64": "QkFTRTY0" }),
+                },
+            ],
+        };
+        match user_message(&msg) {
+            crate::llm::RichMessage::ImageText {
+                media_type,
+                data,
+                text,
+                ..
+            } => {
+                assert_eq!(media_type, "image/png");
+                assert_eq!(data, "QkFTRTY0");
+                assert_eq!(text, "what is this?");
+            }
+            other => panic!("expected ImageText, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn user_message_text_only_when_no_image() {
+        let msg = Message {
+            role: "user".into(),
+            parts: vec![MessagePart::Text { text: "hi".into() }],
+        };
+        assert!(matches!(
+            user_message(&msg),
+            crate::llm::RichMessage::Text { .. }
+        ));
     }
 }

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -208,6 +208,9 @@ pub struct App {
     pub last_esc_at: Option<std::time::Instant>,
     pub esc_hint: bool,
     pub last_sent: Option<String>,
+    /// Base64 PNG staged by Ctrl+V (a pasted screenshot), sent as an inline
+    /// image with the next message and cleared on send. macOS-only capture.
+    pub pending_image: Option<String>,
 }
 
 impl App {
@@ -236,6 +239,7 @@ impl App {
             last_esc_at: None,
             esc_hint: false,
             last_sent: None,
+            pending_image: None,
         }
     }
 

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -268,6 +268,7 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
             match key.code {
                 KeyCode::Char('d') if ctrl => request_quit(app, tx),
                 KeyCode::Char('c') if ctrl => handle_ctrl_c(app, tx),
+                KeyCode::Char('v') if ctrl => attach_clipboard_image(app),
                 KeyCode::PageUp => app.scroll_back = app.scroll_back.saturating_add(SCROLL_STEP),
                 KeyCode::PageDown => app.scroll_back = app.scroll_back.saturating_sub(SCROLL_STEP),
                 KeyCode::Tab => complete_slash(app),
@@ -335,6 +336,58 @@ fn persist_skin(home: &std::path::Path, name: &str) -> anyhow::Result<()> {
     std::fs::write(&tmp, &text).context("write config tmp")?;
     std::fs::rename(&tmp, &path).context("rename config")?;
     Ok(())
+}
+
+/// Ctrl+V: stage a screenshot from the system clipboard for the next message.
+/// An image-only clipboard produces no bracketed-paste event (no text to
+/// send), so this needs its own key rather than riding `Event::Paste`.
+fn attach_clipboard_image(app: &mut App) {
+    match clipboard_png() {
+        Some(b64) => {
+            app.pending_image = Some(b64);
+            app.push_system("📎 screenshot attached — sent with your next message");
+        }
+        None => app.push_system("no image in clipboard (Ctrl+V attaches a screenshot)"),
+    }
+}
+
+/// Read a PNG off the macOS clipboard and return it base64-encoded.
+///
+/// ponytail: macOS-only via `osascript` (zero new deps — the clipboard already
+/// carries a PNG flavor). Add `arboard` + an encoder for Linux/Windows if asked.
+#[cfg(target_os = "macos")]
+fn clipboard_png() -> Option<String> {
+    use base64::{Engine, engine::general_purpose::STANDARD};
+    let tmp = std::env::temp_dir().join("mur-cli-paste.png");
+    let path = tmp.to_str()?;
+    // Dump the clipboard's PNG flavor to `path`; `the clipboard as «class PNGf»`
+    // throws when there's no image, which the handler maps to "NOIMG".
+    let script = format!(
+        "try\n\
+           set f to open for access (POSIX file \"{path}\") with write permission\n\
+           set eof f to 0\n\
+           write (the clipboard as «class PNGf») to f\n\
+           close access f\n\
+         on error\n\
+           return \"NOIMG\"\n\
+         end try"
+    );
+    let out = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .ok()?;
+    if !out.status.success() || String::from_utf8_lossy(&out.stdout).contains("NOIMG") {
+        return None;
+    }
+    let bytes = std::fs::read(&tmp).ok()?;
+    let _ = std::fs::remove_file(&tmp);
+    (!bytes.is_empty()).then(|| STANDARD.encode(&bytes))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn clipboard_png() -> Option<String> {
+    None
 }
 
 /// Tab completes a leading-slash command to the first matching name.
@@ -421,7 +474,8 @@ fn decide_hitl_with_note(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: boo
 
 async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
     let trimmed = app.input_text().trim().to_string();
-    if trimmed.is_empty() {
+    // Allow an image-only send (caption optional) when a screenshot is staged.
+    if trimmed.is_empty() && app.pending_image.is_none() {
         return;
     }
 
@@ -472,7 +526,13 @@ async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
         Some(ctx) => format!("{cwd_prefix}{ctx}\n\n{trimmed}"),
         None => format!("{cwd_prefix}{trimmed}"),
     };
-    let params = build_params(&outgoing, &task_id, app.context_task_id.as_deref());
+    let params = build_params(
+        &outgoing,
+        &task_id,
+        app.context_task_id.as_deref(),
+        app.pending_image.as_deref(),
+    );
+    app.pending_image = None;
     spawn_stream(
         app.home.clone(),
         app.agent.clone(),
@@ -682,7 +742,7 @@ fn run_plain(home: &Path, agent: &str, auto: bool) -> Result<()> {
             continue;
         }
         let task_id = uuid::Uuid::now_v7().to_string();
-        let params = build_params(text, &task_id, context.as_deref());
+        let params = build_params(text, &task_id, context.as_deref(), None);
         let streamed = Cell::new(false);
         let result = crate::a2a_dial::dial_message_streaming(
             home,

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -148,11 +148,30 @@ impl HitlRequest {
     }
 }
 
+/// Mime type for pasted screenshots. The macOS clipboard capture only yields
+/// PNG, so this is fixed; widen if other capture backends are added.
+pub const PASTE_IMAGE_MIME: &str = "image/png";
+
 /// Build the `message/send` params for one turn, threading the previous turn's
 /// task id as `context.task_id` so the agent keeps conversation history.
-pub fn build_params(text: &str, task_id: &str, context_task_id: Option<&str>) -> Value {
+/// `image_b64`, when set, is attached as a second A2A `data` part (an inline
+/// screenshot) that the runtime forwards to the model as a vision input.
+pub fn build_params(
+    text: &str,
+    task_id: &str,
+    context_task_id: Option<&str>,
+    image_b64: Option<&str>,
+) -> Value {
+    let mut parts = vec![json!({ "kind": "text", "text": text })];
+    if let Some(b64) = image_b64 {
+        parts.push(json!({
+            "kind": "data",
+            "mimeType": PASTE_IMAGE_MIME,
+            "data": { "base64": b64 },
+        }));
+    }
     let mut params = json!({
-        "message": { "role": "user", "parts": [{ "kind": "text", "text": text }] },
+        "message": { "role": "user", "parts": parts },
         "task_id": task_id,
     });
     if let Some(tid) = context_task_id {
@@ -309,7 +328,7 @@ mod tests {
 
     #[test]
     fn build_params_threads_context() {
-        let p = build_params("hi", "t-2", Some("t-1"));
+        let p = build_params("hi", "t-2", Some("t-1"), None);
         assert_eq!(p["message"]["parts"][0]["text"], "hi");
         assert_eq!(p["task_id"], "t-2");
         assert_eq!(p["context"]["task_id"], "t-1");
@@ -317,8 +336,22 @@ mod tests {
 
     #[test]
     fn build_params_first_turn_has_no_context() {
-        let p = build_params("hi", "t-1", None);
+        let p = build_params("hi", "t-1", None, None);
         assert!(p.get("context").is_none());
+    }
+
+    #[test]
+    fn build_params_attaches_image_as_data_part() {
+        let p = build_params("what is this?", "t-3", None, Some("QkFTRTY0"));
+        let parts = p["message"]["parts"].as_array().unwrap();
+        assert_eq!(parts.len(), 2, "text part + image data part");
+        assert_eq!(parts[0]["kind"], "text");
+        assert_eq!(parts[1]["kind"], "data");
+        assert_eq!(parts[1]["mimeType"], PASTE_IMAGE_MIME);
+        assert_eq!(parts[1]["data"]["base64"], "QkFTRTY0");
+        // No image → no data part (back-compat).
+        let plain = build_params("hi", "t-4", None, None);
+        assert_eq!(plain["message"]["parts"].as_array().unwrap().len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## What

Paste a screenshot into `mur agent cli` and the agent actually **sees** it. Press **Ctrl+V** to attach the clipboard image to your next message; the runtime forwards it to the model as an inline Anthropic image block.

## Why

Pasting a screenshot was a silent black hole. Two independent gaps:

1. **TUI input** — the chat only handled `Event::Paste(text)` (bracketed paste is text-only). An image-only clipboard exposes 10 image flavors (PNG, JPEG, TIFF…) but **0 text bytes**, so pressing Cmd+V fired no event at all and the screenshot vanished.
2. **Whole-stack vision gap** — even a captured image had no path to the model: `build_params` only emitted `text` parts, the runtime's `RichMessage` was text-only, and the Anthropic adapter emitted only text blocks. (The existing "multimodal pipeline" stages image bytes to disk with an *empty* sidecar — the model never saw pixels.)

## How

| Layer | Change |
|---|---|
| Capture | `Ctrl+V` → `osascript` reads the clipboard's PNG flavor (**zero new deps**) → base64, staged on `App.pending_image` |
| Send | `build_params` appends a `{kind:"data", mimeType:"image/png", data:{base64}}` A2A part |
| Parse | `user_message()` extracts the image part → new `RichMessage::ImageText` (image + caption in one user turn) |
| Model | Anthropic adapter emits an `{type:"image", source:{base64}}` block; OpenAI degrades to text; ollama/stub unaffected |

- Ctrl+V (not Cmd+V) because an image-only clipboard produces no bracketed-paste event to hook.
- Image-only sends allowed (caption optional).

## Tests

`build_params` data-part, `user_message`/image extraction, Anthropic image-block + image-only caption. `cargo check` / `clippy` / `fmt` clean.

## Scope / follow-ups (marked `ponytail:` in-code)

- macOS-only capture (osascript). Add `arboard` + an encoder for Linux/Windows when asked.
- OpenAI/Gemini vision, inbound-image OCR for the B0 safety hook, multi-image/turn, cross-turn image persistence — out of scope.
- Anthropic-vision agents only. Live end-to-end needs a rebuilt+reinstalled runtime, restarted agents, and a vision-capable model (terminal "click-only" tier blocked a keystroke-level Computer-use repro; verified per-layer + a real osascript capture instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
