### PR TITLE
fix(hub): resolve dir-form skill ids so Hub skills tab loads

### DIFF
--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6578,7 +6578,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.26.3"
+version = "2.26.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6597,7 +6597,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.26.3"
+version = "2.26.4"
 dependencies = [
  "age",
  "anyhow",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.26.3"
+version = "2.26.4"
 dependencies = [
  "blake3",
  "flate2",
@@ -6661,7 +6661,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.26.3"
+version = "2.26.4"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6742,7 +6742,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.26.3"
+version = "2.26.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mur-hub-gui/src-tauri/src/detail.rs
+++ b/mur-hub-gui/src-tauri/src/detail.rs
@@ -95,7 +95,13 @@ pub struct SkillView {
 /// parses the file by extension and validates the resulting manifest. Any
 /// failure (missing file, unparseable, invalid) yields `false`.
 fn skill_path_is_loadable(agent_home: &std::path::Path, rel_path: &str) -> bool {
-    let file = agent_home.join(rel_path);
+    let mut file = agent_home.join(rel_path);
+    // Modern per-agent skills are stored as `skills/<name>/skill.yaml`, so the
+    // id in `profile.skills` points at the *directory*. Resolve to the manifest
+    // inside it; legacy ids that already point at a file pass through unchanged.
+    if file.is_dir() {
+        file = file.join("skill.yaml");
+    }
     let Ok(text) = std::fs::read_to_string(&file) else {
         return false;
     };
@@ -299,4 +305,30 @@ pub fn update_agent_detail(name: String, patch: DetailPatch) -> Result<AgentDeta
 
     // Return fresh detail after update
     get_agent_detail(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::skill_path_is_loadable;
+
+    // Regression: per-agent skill ids are directories (`skills/<name>`) holding
+    // a `skill.yaml`. The loadable check must resolve into the dir, not try to
+    // read the dir as a file (which flagged every skill "unloadable" in the Hub).
+    #[test]
+    fn directory_form_skill_is_loadable() {
+        let home = tempfile::tempdir().unwrap();
+        let skill_dir = home.path().join("skills").join("demo");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("skill.yaml"),
+            "name: demo\nversion: 1.0.0\npublisher: human:test\n\
+             description: a demo skill for the loadable check\ncategory: context\n\
+             provenance: human\nhosts:\n- mur-agent\n\
+             content:\n  abstract: demo abstract\n  context: demo context body\n",
+        )
+        .unwrap();
+
+        assert!(skill_path_is_loadable(home.path(), "skills/demo"));
+        assert!(!skill_path_is_loadable(home.path(), "skills/missing"));
+    }
 }


### PR DESCRIPTION
## Problem

Every agent's skills showed as **unloadable** in the Hub's Skills tab (reported: "Agent skill all can not load").

## Root cause

`profile.skills` stores **directory** ids like `skills/component-architecture`, and on disk that's a directory containing `skill.yaml` (`~/.mur/agents/<name>/skills/<name>/skill.yaml`). `skill_path_is_loadable` (`mur-hub-gui/src-tauri/src/detail.rs`) ran `std::fs::read_to_string()` on the path directly — reading a directory always errors → `false` → every skill flagged "unloadable".

The CLI (`mur agent skill list`) was unaffected because it only lists ids, never validates the backing file.

## Fix

Resolve a directory-form id to its `skill.yaml` before reading; legacy file ids (`.md`/`.yaml`) pass through unchanged.

```rust
let mut file = agent_home.join(rel_path);
if file.is_dir() {
    file = file.join("skill.yaml");
}
```

Added regression test `directory_form_skill_is_loadable` (passes with fix, fails without). `cargo fmt --check` clean on the excluded Tauri crate.

(Cargo.lock change is the incidental 2.26.3 → 2.26.4 workspace-version catch-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)