### PR TITLE
ci(release): cache compiled tauri-cli to save ~10min/release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,6 +298,11 @@ jobs:
     name: Build MuR Hub (macOS arm64)
     needs: validate-version
     runs-on: macos-14
+    env:
+      # tauri-cli has no binstall-compatible prebuilt for this version, so a
+      # plain install recompiles it from source (~10 min) every release. Pin the
+      # version and cache the compiled binary; bump this to upgrade the CLI.
+      TAURI_CLI_VERSION: "2.11.3"
     steps:
       - uses: actions/checkout@v6
 
@@ -379,11 +384,21 @@ jobs:
       - name: Fetch bundled model
         run: bash scripts/fetch-bundle-model.sh mlx-community/Qwen3.5-2B-MLX-4bit
 
-      # Prebuilt tauri-cli instead of compiling it from source each release.
+      # Cache the compiled cargo-tauri so we pay the ~10-min source build only on
+      # a cache miss (first run / version bump), not every release. The binary is
+      # platform-specific, so the key is scoped to os + arch + pinned version.
+      - name: Cache tauri CLI
+        id: tauri_cli_cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-tauri
+          key: cargo-tauri-${{ env.TAURI_CLI_VERSION }}-${{ runner.os }}-${{ runner.arch }}
       - name: Install cargo-binstall
+        if: steps.tauri_cli_cache.outputs.cache-hit != 'true'
         uses: cargo-bins/cargo-binstall@main
       - name: Install tauri CLI
-        run: cargo binstall -y tauri-cli --version "^2"
+        if: steps.tauri_cli_cache.outputs.cache-hit != 'true'
+        run: cargo binstall -y tauri-cli --version "${{ env.TAURI_CLI_VERSION }}"
 
       - name: Import Apple signing certs
         uses: apple-actions/import-codesign-certs@v2


### PR DESCRIPTION
## Problem

The Hub release job's `Install tauri CLI` step takes **~10 minutes every release**. The release.yml comment claims it uses a prebuilt, but the 2.26.4 log shows it silently falls back to compiling from source:

```
WARN The package tauri-cli v2.11.3 will be installed from source (with cargo)
Compiling tauri-cli v2.11.3        ← 13:05 → 13:12, ~10 min
Installed package `tauri-cli v2.11.3`
```

`cargo binstall` has no binstall-compatible prebuilt for tauri-cli 2.11.3, so it compiles it.

## Fix

Pin the tauri-cli version (`TAURI_CLI_VERSION`) and cache the compiled `~/.cargo/bin/cargo-tauri`, keyed on `version + os + arch`. The install runs only on a cache miss (first run after this lands, or a version bump). `cargo tauri build` is unchanged.

- First release after merge: still ~10 min (warms the cache)
- Every release after: **~0s** (binary restored from cache)

To upgrade the CLI later, bump `TAURI_CLI_VERSION` — the new key misses, recompiles once, re-caches.

## Notes

This is the highest-confidence, lowest-risk item from a timing audit of the Hub job (~75 min total). It doesn't touch the app build output. A separate, riskier item (shared workspace crates compiled twice across two target dirs) is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)