### PR TITLE
fix(runtime): land delegate self-replies + keep canonical runtime fresh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,5 +73,19 @@ if $INSTALL; then
     sudo cp "$DAEMON_BINARY" /opt/homebrew/bin/murmurd
     echo "Installed murmurd -> /opt/homebrew/bin/murmurd"
   fi
+
+  # mur-agent-runtime (already built by the workspace build above) is what new
+  # agents symlink to via PATH (resolve_runtime_target). Keep the canonical copy at
+  # ~/.local/bin fresh, else newly-created/restarted agents inherit a STALE runtime
+  # (e.g. one missing channel/delegate). Atomic cp+mv avoids ETXTBSY for agents
+  # running off it; they pick up the new binary on their next restart.
+  RUNTIME_BINARY="$(dirname "$BINARY")/mur-agent-runtime"
+  LOCAL_BIN="$HOME/.local/bin"; mkdir -p "$LOCAL_BIN"
+  if [ -f "$RUNTIME_BINARY" ]; then
+    cp "$RUNTIME_BINARY" "$LOCAL_BIN/.mur-agent-runtime.new"
+    mv -f "$LOCAL_BIN/.mur-agent-runtime.new" "$LOCAL_BIN/mur-agent-runtime"
+    echo "Installed mur-agent-runtime -> $LOCAL_BIN/mur-agent-runtime (canonical; keeps new agents current)"
+  fi
+
   echo "✅ Installed: $(mur --version 2>/dev/null || echo 'done')"
 fi

--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -46,6 +46,20 @@ impl SandboxPolicy {
             fs_write.push(agent_home.to_path_buf());
         }
 
+        // The shared channel store (`<mur_home>/channels`) is runtime-owned: a
+        // delegated agent appends its OWN signed reply there (peer-writes-own,
+        // v3d-2). Always grant write regardless of the user's fs entitlement,
+        // else `channel/delegate` self-reply silently fails on agents whose write
+        // allowlist omits ~/.mur/channels (agent_home is <mur_home>/agents/<name>).
+        if let Some(channels) = agent_home
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|m| m.join("channels"))
+            && !fs_write.contains(&channels)
+        {
+            fs_write.push(channels);
+        }
+
         // Standard system read paths: libraries, certs, DNS config.
         let system_read = system_read_paths();
         for p in system_read {
@@ -197,6 +211,19 @@ mod tests {
         let home = PathBuf::from("/tmp/agent_home");
         let policy = SandboxPolicy::from_entitlements(&minimal_entitlements(), &home);
         assert!(policy.fs_write.contains(&home));
+    }
+
+    #[test]
+    fn channels_dir_always_in_write() {
+        // agent_home = <mur_home>/agents/<name> → channels = <mur_home>/channels,
+        // granted even though minimal_entitlements lists no write paths.
+        let home = PathBuf::from("/tmp/mur/agents/rs");
+        let policy = SandboxPolicy::from_entitlements(&minimal_entitlements(), &home);
+        assert!(
+            policy
+                .fs_write
+                .contains(&PathBuf::from("/tmp/mur/channels"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Two small, independent fixes surfaced while validating parallel multi-agent coding via `channel/delegate` (workflow DAG delegation). Both are about making delegation work reliably across agents.

## Changes

**1. `fix(runtime)` — agents can write their own signed reply to the channel**
A delegated agent (v3d-2 peer-writes-own) appends its own Ed25519-signed reply into the shared channel under `~/.mur/channels`. Agents whose filesystem write entitlement omits that path had the self-reply **silently fail** (best-effort warn): the delegated work still succeeded and the `Delegation` events were signed, but the channel audit trail lost the specialist's attributed `Agent{…}` reply. e.g. `rustsmith` (write allowlist = only its own working dir) hit `failed to append self-reply … open ~/.mur/channels/<id>/events.lock`.

Fix: always grant write to `<mur_home>/channels` in the sandbox policy, mirroring the existing `agent_home`-always-writable invariant — channel appends are runtime mechanics, not user-grantable FS access. Adds a regression test.

**2. `chore(build)` — keep the canonical runtime fresh on install**
New agents symlink to whatever `mur-agent-runtime` resolves to on PATH (`resolve_runtime_target`). The CLI (`mur`) and the runtime are built/installed separately and drift, so newly-created or restarted agents could inherit a **stale** runtime (e.g. one predating `channel/delegate`, which returns `-32601 method not found`). `build.sh --install` now refreshes `~/.local/bin/mur-agent-runtime` (atomic cp+mv) from the just-built binary.

## Verification
- `cargo test -p mur-agent-runtime --lib sandbox::policy` → 10 passed (incl. new `channels_dir_always_in_write`)
- `cargo fmt -p mur-agent-runtime -- --check` clean; `cargo clippy -p mur-agent-runtime --lib` clean
- Live: after deploying the fix to all running agents, a 3-way distinct-coder delegate fan-out produced 3 distinct signed `Agent{…}` replies in the channel (was 0 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)