### PR TITLE
feat(agent-cli): redesign startup screen — starling mascot + idle blink

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -1,6 +1,7 @@
 //! TUI application state and the pure (non-IO) state transitions.
 
 use std::collections::HashSet;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 
 use ratatui::style::{Color, Style};
@@ -12,6 +13,7 @@ use super::markdown;
 use super::persist::{ChannelMeta, Session, TurnRecord};
 use super::stream::HitlRequest;
 use super::theme::Theme;
+use super::welcome::{Blink, MascotMode, resolve_mascot_mode};
 
 /// Spinner frames shown while the agent is generating.
 pub const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -214,6 +216,12 @@ pub struct App {
     /// Base64 PNG staged by Ctrl+V (a pasted screenshot), sent as an inline
     /// image with the next message and cleared on send. macOS-only capture.
     pub pending_image: Option<String>,
+    /// Mascot blink driver for the startup welcome screen. Render is a pure
+    /// function of elapsed time; the event loop wakes on its next deadline.
+    pub blink: Blink,
+    /// Mascot color/animation mode, resolved once at startup from the theme
+    /// and terminal capabilities (NO_COLOR / non-TTY / TERM=dumb → static).
+    pub mascot_mode: MascotMode,
 }
 
 impl App {
@@ -244,6 +252,9 @@ impl App {
             esc_hint: false,
             last_sent: None,
             pending_image: None,
+            blink: Blink::new(),
+            // Resolve color/animation once: env + TTY don't change mid-session.
+            mascot_mode: resolve_mascot_mode(theme, std::io::stdout().is_terminal()),
         }
     }
 

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -15,10 +15,12 @@ pub mod persist;
 mod stream;
 mod theme;
 mod ui;
+mod welcome;
 
 use std::io::{self, IsTerminal, Stdout, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use std::time::Instant as StdInstant;
 
 use anyhow::{Context, Result};
 use crossterm::event::{
@@ -34,6 +36,7 @@ use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use serde_json::Value;
 use tokio::sync::mpsc;
+use tokio::time::Instant as TokioInstant;
 
 use self::app::{App, EscAction, Role, SlashCmd, esc_action, parse_slash};
 use self::persist::Session;
@@ -184,7 +187,7 @@ fn build_app(home: &Path, agent: &str, resume: bool, theme: &'static theme::Them
             app.load_history(turns);
             app.refresh_channel();
             app.push_system(format!(
-                "resumed conversation ({} turns) — {HELP}",
+                "resumed conversation ({} turns) · type /help for commands",
                 app.messages.len()
             ));
             return Ok(app);
@@ -195,18 +198,20 @@ fn build_app(home: &Path, agent: &str, resume: bool, theme: &'static theme::Them
             Session::create(home, agent)?,
             theme,
         );
-        app.push_system(format!(
-            "no saved conversation to resume; starting fresh. {HELP}"
-        ));
+        app.push_system(
+            "no saved conversation to resume; starting fresh · type /help for commands".to_string(),
+        );
         return Ok(app);
     }
-    let mut app = App::new(
+    let app = App::new(
         home.to_path_buf(),
         agent.to_string(),
         Session::create(home, agent)?,
         theme,
     );
-    app.push_system(HELP);
+    // No startup HELP dump: an empty transcript renders the welcome screen
+    // (mascot + identity + one example + /help hint). The full cheatsheet stays
+    // reachable via the /help command (SlashCmd::Help below).
     Ok(app)
 }
 
@@ -224,6 +229,12 @@ async fn event_loop(
         if app.should_quit {
             return Ok(());
         }
+        // The idle welcome blinks: schedule a redraw exactly at the next blink
+        // boundary, but ONLY when the mascot animates, the transcript is empty
+        // (so the welcome is actually on screen), and nothing is streaming.
+        // Otherwise this arm is disabled and never wakes the loop.
+        let blink_live = app.mascot_mode.animated() && app.messages.is_empty() && !app.streaming;
+        let blink_at = TokioInstant::from_std(app.blink.next_deadline(StdInstant::now()));
         tokio::select! {
             maybe = events.next() => match maybe {
                 Some(Ok(ev)) => handle_event(app, ev, &tx).await,
@@ -231,6 +242,9 @@ async fn event_loop(
             },
             Some(msg) = rx.recv() => handle_stream(app, msg, &tx),
             _ = spinner.tick(), if app.streaming => app.tick_spinner(),
+            // Wake at the blink deadline; the loop redraws at the top of the
+            // next iteration, advancing the eye frame. No state change needed.
+            _ = tokio::time::sleep_until(blink_at), if blink_live => {}
         }
     }
 }
@@ -674,6 +688,8 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
                     app.push_system(format!("unknown skin '{name}' — valid: dark, light, mur"));
                 } else {
                     app.theme = theme::resolve_skin(&name);
+                    app.mascot_mode =
+                        welcome::resolve_mascot_mode(app.theme, std::io::stdout().is_terminal());
                     let h = app.home.clone();
                     match persist_skin(&h, &name) {
                         Ok(()) => app.push_system(format!("skin changed to {name}")),

--- a/mur-core/src/cmd/agent/cli/theme.rs
+++ b/mur-core/src/cmd/agent/cli/theme.rs
@@ -7,9 +7,10 @@ use ratatui::widgets::BorderType;
 
 pub struct Theme {
     // ── labels (bold, identifies speaker) ────────────────────────────────────
-    pub user: Color,  // "› you" label
-    pub agent: Color, // "● agent" label
-    pub shell: Color, // "$ cmd" label for !command output
+    pub user: Color,   // "› you" label
+    pub agent: Color,  // "● agent" label
+    pub accent: Color, // mascot / brand accent (always color-capable)
+    pub shell: Color,  // "$ cmd" label for !command output
     // ── body text ─────────────────────────────────────────────────────────────
     pub user_text: Color,  // continuation lines of a user turn
     pub agent_text: Color, // continuation lines of an agent reply
@@ -33,6 +34,7 @@ pub struct Theme {
 pub const DARK: Theme = Theme {
     user: Color::Green,
     agent: Color::Cyan,
+    accent: Color::Cyan,
     shell: Color::Green,
     user_text: Color::Gray,
     agent_text: Color::White,
@@ -53,6 +55,7 @@ pub const DARK: Theme = Theme {
 pub const LIGHT: Theme = Theme {
     user: Color::Rgb(0x16, 0x65, 0x34),
     agent: Color::Rgb(0x0e, 0x6b, 0x8c),
+    accent: Color::Rgb(0x0e, 0x6b, 0x8c),
     shell: Color::Rgb(0x16, 0x65, 0x34),
     user_text: Color::Rgb(0x22, 0x22, 0x33),
     agent_text: Color::Rgb(0x22, 0x22, 0x33),
@@ -73,6 +76,7 @@ pub const LIGHT: Theme = Theme {
 pub const MUR: Theme = Theme {
     user: Color::Rgb(0xa7, 0x8b, 0xfa),
     agent: Color::Rgb(0xfb, 0xbf, 0x24),
+    accent: Color::Rgb(0xfb, 0xbf, 0x24),
     shell: Color::Rgb(0x88, 0x88, 0xcc),
     user_text: Color::Rgb(0xc8, 0xc8, 0xe8),
     agent_text: Color::Rgb(0xe0, 0xe0, 0xf0),

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -6,8 +6,11 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph, Wrap};
 
+use std::time::Instant;
+
 use super::app::{App, ChatMsg, Role, SPINNER};
 use super::markdown;
+use super::welcome::welcome_lines;
 
 /// Draw the whole UI for one frame.
 pub fn render(f: &mut Frame, app: &mut App) {
@@ -60,10 +63,17 @@ fn render_transcript(f: &mut Frame, app: &mut App, area: Rect) {
     }
 
     if lines.is_empty() {
-        lines.push(Line::styled(
-            "Say hello — type below and press Enter.",
-            Style::default().fg(theme.system),
-        ));
+        // Empty transcript → progressive-disclosure welcome (mascot + identity +
+        // one example + /help hint) instead of a bare prompt. The eye frame is a
+        // pure function of wall-clock time; the event loop schedules redraws on
+        // the blink deadline so an idle welcome animates without busy-looping.
+        lines = welcome_lines(
+            theme,
+            app.mascot_mode,
+            &app.agent,
+            app.cwd.as_deref(),
+            app.blink.eye_open(Instant::now()),
+        );
     }
 
     let total = lines.len() as u16;

--- a/mur-core/src/cmd/agent/cli/welcome.rs
+++ b/mur-core/src/cmd/agent/cli/welcome.rs
@@ -1,0 +1,382 @@
+//! Startup welcome screen: ASCII starling mascot ("Star") + concise identity.
+//!
+//! Progressive-disclosure design: instead of dumping the full command cheatsheet
+//! at startup, we show the mascot, a one-line identity, ONE example, and a single
+//! `/help` hint. The full reference stays reachable via the `/help` command.
+//!
+//! The mascot's eye blinks as a wall-clock *event* (open ~4s, blink ~180ms), so
+//! an idle session schedules a redraw only when the next blink is actually due —
+//! the event loop bounds its select timeout on [`Blink::next_deadline`]. Color is
+//! resolved once at startup into [`MascotMode`]; we render in the theme accent
+//! when color is available and go fully static (no color, no animation) when
+//! `NO_COLOR` is set, stdout isn't a TTY, or `TERM=dumb`.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use super::theme::Theme;
+
+// ── Mascot frames ─────────────────────────────────────────────────────────────
+// `REST` and `BLINK` are byte-identical except the single eye glyph on
+// [`EYE_ROW`] (`o` → `-`), which guarantees zero layout shift across a blink.
+
+/// Eye-open mascot rows (pure 7-bit ASCII, fixed width).
+pub const MASCOT_REST: [&str; 5] = [
+    r#"   .-"-."#,
+    r#"  ( o  )>"#,
+    r#"   `\_/`,"#,
+    r#"    | |"#,
+    r#" ~~~~~~~~~"#,
+];
+
+/// Eye-closed mascot rows — identical to [`MASCOT_REST`] but the eye is `-`.
+pub const MASCOT_BLINK: [&str; 5] = [
+    r#"   .-"-."#,
+    r#"  ( -  )>"#,
+    r#"   `\_/`,"#,
+    r#"    | |"#,
+    r#" ~~~~~~~~~"#,
+];
+
+/// Row index of the blinking eye (0-based). Test-only invariant anchor: the
+/// frames are byte-identical except this row, and the render reads the frames
+/// directly (`MASCOT_REST`/`MASCOT_BLINK`), so these consts exist purely to let
+/// the layout-shift tests pin the eye position.
+#[cfg(test)]
+const EYE_ROW: usize = 1;
+/// Glyph shown when the eye is open / closed (see [`EYE_ROW`]).
+#[cfg(test)]
+const EYE_OPEN: char = 'o';
+#[cfg(test)]
+const EYE_CLOSED: char = '-';
+
+// ── Blink timing ──────────────────────────────────────────────────────────────
+
+/// How long the eye stays open between blinks (ms).
+const EYE_OPEN_MS: u64 = 4000;
+/// How long a single blink lasts (ms).
+const BLINK_MS: u64 = 180;
+
+/// How long the eye stays open between blinks.
+const EYE_OPEN_FOR: Duration = Duration::from_millis(EYE_OPEN_MS);
+/// How long a single blink lasts.
+const BLINK_FOR: Duration = Duration::from_millis(BLINK_MS);
+/// Full blink cycle (open + closed): the eye is open for [`EYE_OPEN_FOR`], then
+/// closed for [`BLINK_FOR`]. Derived from the two segment durations so the cycle
+/// length is never a duplicated literal.
+const CYCLE: Duration = EYE_OPEN_FOR.saturating_add(BLINK_FOR);
+
+/// Wall-clock blink driver. Render is a pure function of elapsed time, and the
+/// event loop only needs to wake at [`Blink::next_deadline`].
+#[derive(Debug, Clone, Copy)]
+pub struct Blink {
+    start: Instant,
+}
+
+impl Default for Blink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Blink {
+    pub fn new() -> Self {
+        Self {
+            start: Instant::now(),
+        }
+    }
+
+    /// Position within the current cycle for a given instant.
+    fn phase(&self, now: Instant) -> Duration {
+        let elapsed = now.saturating_duration_since(self.start);
+        // `Duration` rem is exact; CYCLE is non-zero.
+        Duration::from_nanos((elapsed.as_nanos() % CYCLE.as_nanos()) as u64)
+    }
+
+    /// True if the eye is open at `now` (open for [`EYE_OPEN_FOR`], then closed).
+    pub fn eye_open(&self, now: Instant) -> bool {
+        self.phase(now) < EYE_OPEN_FOR
+    }
+
+    /// Instant at which the frame after `now` becomes due — the boundary into
+    /// the next open/closed segment. The event loop bounds its select timeout on
+    /// this so an idle welcome redraws only when a blink actually changes.
+    pub fn next_deadline(&self, now: Instant) -> Instant {
+        let phase = self.phase(now);
+        let remaining = if phase < EYE_OPEN_FOR {
+            EYE_OPEN_FOR - phase
+        } else {
+            CYCLE - phase
+        };
+        now + remaining
+    }
+}
+
+// ── Color mode ────────────────────────────────────────────────────────────────
+
+/// How the mascot is colored, resolved ONCE at startup. There is no fake
+/// gradient: either we render flat in the theme accent, or we render plain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MascotMode {
+    /// No color and no animation (NO_COLOR / non-TTY / TERM=dumb).
+    Off,
+    /// Flat color in the theme accent; animation enabled.
+    Accent(Color),
+}
+
+impl MascotMode {
+    /// True if the blink animation should run in this mode.
+    pub fn animated(self) -> bool {
+        matches!(self, MascotMode::Accent(_))
+    }
+}
+
+/// Resolve the mascot color/animation mode once at startup.
+///
+/// Honors the de-facto env conventions: `NO_COLOR` (present at any value, per the
+/// no-color.org spec) and `TERM=dumb` suppress color; a non-interactive stdout
+/// suppresses both color and animation.
+pub fn resolve_mascot_mode(theme: &Theme, is_tty: bool) -> MascotMode {
+    if !is_tty || no_color_env() || term_is_dumb() {
+        return MascotMode::Off;
+    }
+    MascotMode::Accent(theme.accent)
+}
+
+fn no_color_env() -> bool {
+    std::env::var_os("NO_COLOR").is_some()
+}
+
+fn term_is_dumb() -> bool {
+    std::env::var_os("TERM").is_some_and(|v| v == "dumb")
+}
+
+// ── Render ────────────────────────────────────────────────────────────────────
+
+/// Max trailing path components shown on the identity line; deeper paths are
+/// truncated with a leading `…/` so a long cwd can't overflow the line.
+const MAX_CWD_COMPONENTS: usize = 3;
+
+/// Shorten an absolute path for the identity line: home-relative with `~`, then
+/// keep only the last [`MAX_CWD_COMPONENTS`] components (prefixed with `…/` when
+/// truncated) so a deep path can't blow the line width.
+fn pretty_cwd(cwd: Option<&Path>) -> String {
+    let Some(cwd) = cwd else {
+        return "·".to_string();
+    };
+    let full = match dirs_home() {
+        Some(home) => match cwd.strip_prefix(&home) {
+            Ok(rel) if rel.as_os_str().is_empty() => return "~".to_string(),
+            Ok(rel) => format!("~/{}", rel.display()),
+            Err(_) => cwd.display().to_string(),
+        },
+        None => cwd.display().to_string(),
+    };
+    let parts: Vec<&str> = full.split('/').filter(|s| !s.is_empty()).collect();
+    if parts.len() > MAX_CWD_COMPONENTS {
+        format!("…/{}", parts[parts.len() - MAX_CWD_COMPONENTS..].join("/"))
+    } else {
+        full
+    }
+}
+
+fn dirs_home() -> Option<std::path::PathBuf> {
+    std::env::var_os("HOME").map(std::path::PathBuf::from)
+}
+
+/// Build the welcome transcript lines: mascot + identity + one example + hint.
+///
+/// `blink` drives the eye frame; when `mode` is [`MascotMode::Off`] the eye is
+/// always open and rendered without color.
+pub fn welcome_lines(
+    theme: &Theme,
+    mode: MascotMode,
+    agent: &str,
+    cwd: Option<&Path>,
+    eye_open: bool,
+) -> Vec<Line<'static>> {
+    let mascot_style = match mode {
+        MascotMode::Accent(c) => Style::default().fg(c),
+        MascotMode::Off => Style::default().fg(theme.system),
+    };
+    // In Off mode the eye is always open (truly static — no animation); otherwise
+    // the eye frame follows the wall-clock blink phase passed by the caller.
+    let rows = if eye_open || matches!(mode, MascotMode::Off) {
+        MASCOT_REST
+    } else {
+        MASCOT_BLINK
+    };
+
+    let mut lines: Vec<Line<'static>> = Vec::with_capacity(rows.len() + 6);
+    lines.push(Line::default());
+    for row in rows {
+        lines.push(Line::styled(row.to_string(), mascot_style));
+    }
+    lines.push(Line::default());
+
+    // One-line identity: agent · cwd.
+    lines.push(Line::from(vec![
+        Span::styled(
+            agent.to_string(),
+            Style::default()
+                .fg(theme.agent)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("  ·  ", Style::default().fg(theme.separator)),
+        Span::styled(pretty_cwd(cwd), Style::default().fg(theme.system)),
+    ]));
+    lines.push(Line::default());
+
+    // ONE example to seed the first message.
+    lines.push(Line::from(vec![
+        Span::styled("Try  ", Style::default().fg(theme.system)),
+        Span::styled(
+            "\"explain this repo\"",
+            Style::default()
+                .fg(theme.user_text)
+                .add_modifier(Modifier::ITALIC),
+        ),
+    ]));
+
+    // Single discoverability hint — full reference lives behind /help. Surface
+    // Ctrl+V image paste here too (it was previously undiscoverable).
+    lines.push(Line::from(vec![
+        Span::styled("Type ", Style::default().fg(theme.system)),
+        Span::styled(
+            "/help",
+            Style::default()
+                .fg(theme.agent)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            " for commands · Ctrl+V pastes a screenshot",
+            Style::default().fg(theme.system),
+        ),
+    ]));
+
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frames_same_row_count() {
+        assert_eq!(MASCOT_REST.len(), MASCOT_BLINK.len());
+    }
+
+    #[test]
+    fn frames_same_width_per_row() {
+        for (rest, blink) in MASCOT_REST.iter().zip(MASCOT_BLINK.iter()) {
+            assert_eq!(
+                rest.chars().count(),
+                blink.chars().count(),
+                "row width must match so a blink never shifts layout"
+            );
+        }
+    }
+
+    #[test]
+    fn frames_differ_in_exactly_one_eye_char() {
+        let mut diffs = 0usize;
+        for (ri, (rest, blink)) in MASCOT_REST.iter().zip(MASCOT_BLINK.iter()).enumerate() {
+            for (ci, (rc, bc)) in rest.chars().zip(blink.chars()).enumerate() {
+                if rc != bc {
+                    diffs += 1;
+                    assert_eq!(ri, EYE_ROW, "the only differing row is the eye row");
+                    assert_eq!(rc, EYE_OPEN);
+                    assert_eq!(bc, EYE_CLOSED);
+                    // The eye column is wherever the open glyph sits on the eye row.
+                    assert_eq!(MASCOT_REST[EYE_ROW].chars().nth(ci), Some(EYE_OPEN));
+                }
+            }
+        }
+        assert_eq!(diffs, 1, "rest and blink differ in exactly one char");
+    }
+
+    #[test]
+    fn eye_open_then_closed_within_cycle() {
+        let b = Blink::new();
+        let t0 = b.start;
+        assert!(b.eye_open(t0), "eye open at cycle start");
+        assert!(
+            b.eye_open(t0 + EYE_OPEN_FOR - Duration::from_millis(1)),
+            "still open just before blink"
+        );
+        assert!(
+            !b.eye_open(t0 + EYE_OPEN_FOR + Duration::from_millis(1)),
+            "closed during blink"
+        );
+        assert!(
+            b.eye_open(t0 + CYCLE + Duration::from_millis(1)),
+            "open again next cycle"
+        );
+    }
+
+    #[test]
+    fn next_deadline_is_segment_boundary() {
+        let b = Blink::new();
+        let t0 = b.start;
+        // Mid-open: next deadline is when the eye closes.
+        let d1 = b.next_deadline(t0 + Duration::from_millis(100));
+        assert_eq!(d1, t0 + EYE_OPEN_FOR);
+        // Mid-blink: next deadline is the end of the cycle.
+        let d2 = b.next_deadline(t0 + EYE_OPEN_FOR + Duration::from_millis(10));
+        assert_eq!(d2, t0 + CYCLE);
+        // Deadlines are always in the future relative to `now`.
+        assert!(b.next_deadline(t0) > t0);
+    }
+
+    #[test]
+    fn off_mode_disables_animation() {
+        assert!(!MascotMode::Off.animated());
+        assert!(MascotMode::Accent(Color::Cyan).animated());
+    }
+
+    #[test]
+    fn resolve_off_when_not_tty() {
+        let m = resolve_mascot_mode(&super::super::theme::DARK, false);
+        assert_eq!(m, MascotMode::Off);
+    }
+
+    #[test]
+    fn pretty_cwd_truncates_deep_path() {
+        // A deep path keeps only the last MAX_CWD_COMPONENTS components.
+        assert_eq!(
+            pretty_cwd(Some(std::path::Path::new("/a/b/c/d/e/f"))),
+            "…/d/e/f"
+        );
+        // A shallow path (not under HOME in the test env) is shown as-is.
+        assert_eq!(pretty_cwd(Some(std::path::Path::new("/a/b"))), "/a/b");
+        // None renders a neutral placeholder.
+        assert_eq!(pretty_cwd(None), "·");
+    }
+
+    #[test]
+    fn off_mode_eye_always_open() {
+        // Off mode is truly static: even with eye_open=false, render the REST
+        // (open-eye) frame — never the blink frame.
+        let lines = welcome_lines(
+            &super::super::theme::DARK,
+            MascotMode::Off,
+            "a",
+            None,
+            false,
+        );
+        // Mascot rows start at index 1 (after a leading blank line).
+        let eye_line: String = lines[1 + EYE_ROW]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert_eq!(
+            eye_line, MASCOT_REST[EYE_ROW],
+            "Off mode shows the open eye"
+        );
+        assert_ne!(eye_line, MASCOT_BLINK[EYE_ROW]);
+    }
+}


### PR DESCRIPTION
## Summary
Replaces the dense one-line command cheatsheet on `mur agent cli` startup with a progressive-disclosure welcome: an ASCII starling mascot ("Star") with a subtle blinking eye, a one-line identity (`agent · cwd`), one example, and a single `/help` hint that also surfaces the previously-undiscoverable **Ctrl+V image paste**.

## What changed
- **New `cli/welcome.rs`** — mascot frames (eye-only blink → zero layout shift); a wall-clock `Blink` driver whose `next_deadline` bounds the event-loop `select!` timeout so an idle welcome animates at **~0 CPU** (gated on `animated() && empty transcript && !streaming`); a `MascotMode` resolver (Off under `NO_COLOR` / non-TTY / `TERM=dumb`, else flat theme accent); `welcome_lines`; 9 unit tests.
- `ui.rs` renders `welcome_lines` on an empty transcript.
- `mod.rs` adds the gated idle-blink select arm and drops the startup HELP dump (full list stays via `/help`); `/skin` recomputes the mascot accent.
- `theme.rs` gains an `accent` field (dark=cyan, light=teal, mur=gold).
- cwd truncated to its last 3 components; Off mode renders a truly static eye.

## Verification
- `cargo fmt --check` clean · `cargo clippy -p mur-core -- -D warnings` clean · welcome unit tests **9/9** pass.
- Rendered live in dark + mur skins; blink and cwd-truncation confirmed.

## Notes
- **Stacked on `feat/agent-cli-cwd-consent`** — land/rebase that first.
- Out of scope / follow-up: runtime image-forwarding so agents actually *see* pasted images (the cli attaches via Ctrl+V; the runtime currently stubs the image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)