### PR TITLE
feat(agent-cli): PWD project-access consent + dag/fleet/executor fixes

### DIFF
--- a/mur-core/src/cmd/agent/cli/access.rs
+++ b/mur-core/src/cmd/agent/cli/access.rs
@@ -1,0 +1,193 @@
+//! Project-access consent for `mur agent cli`.
+//!
+//! On launch, if the current working directory is outside the agent's
+//! filesystem entitlements, offer to grant it (read+write) and persist it to
+//! the profile. We grant the enclosing git repo root when there is one, so a
+//! single consent covers subdirs and `<repo>/.worktrees/` checkouts. The running
+//! agent's sandbox is sealed at startup (no hot reload), so a grant only takes
+//! effect after a restart — we say so.
+
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+/// `~`-expanded user home, used to resolve `~/...` entitlement paths the same
+/// way the runtime sandbox does (`dirs::home_dir()`, i.e. `$HOME` on unix).
+fn user_home() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/"))
+}
+
+/// Best-effort symlink-resolving canonicalize that falls back to the input when
+/// the path does not exist (a configured root may point at a missing dir).
+fn canon(p: &Path) -> PathBuf {
+    p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Is `target` inside any of `roots`, after `~` expansion + canonicalization?
+fn path_within_roots(target: &Path, roots: &[String], home: &Path) -> bool {
+    let target = canon(target);
+    roots.iter().any(|r| {
+        let root = if let Some(rest) = r.strip_prefix("~/") {
+            home.join(rest)
+        } else if r == "~" {
+            home.to_path_buf()
+        } else {
+            PathBuf::from(r)
+        };
+        target.starts_with(canon(&root))
+    })
+}
+
+/// Refuse to auto-grant an over-broad root: `/`, the user's whole home, or any
+/// path shallower than two normal components (e.g. `/Users`, `/Volumes`, `/tmp`).
+fn is_overbroad_root(p: &Path, home: &Path) -> bool {
+    if p == Path::new("/") || p == home {
+        return true;
+    }
+    let depth = p
+        .components()
+        .filter(|c| matches!(c, std::path::Component::Normal(_)))
+        .count();
+    depth < 2
+}
+
+/// The git toplevel containing `cwd`, if any.
+fn git_repo_root(cwd: &Path) -> Option<PathBuf> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?;
+    let s = s.trim();
+    (!s.is_empty()).then(|| PathBuf::from(s))
+}
+
+/// Ensure the agent may touch the current project dir; offer consent if not.
+///
+/// Returns `Ok(())` in every case the launch should continue (grant, decline,
+/// non-interactive, or already-allowed). Only a profile read/write *error*
+/// propagates.
+pub(super) fn ensure_cwd_access(agent: &str) -> Result<()> {
+    let Ok(cwd) = std::env::current_dir() else {
+        return Ok(());
+    };
+    let home = user_home();
+
+    // Read-only probe of the current entitlements.
+    let (_path, profile) = super::super::load_profile_for_edit(agent)?;
+    let fs = &profile.entitlements.filesystem;
+    if path_within_roots(&cwd, &fs.write, &home) || path_within_roots(&cwd, &fs.read, &home) {
+        return Ok(());
+    }
+
+    // Grant the enclosing repo root when there is one (covers subdirs +
+    // `.worktrees/` checkouts); else the cwd itself.
+    let grant = canon(&git_repo_root(&cwd).unwrap_or_else(|| cwd.clone()));
+
+    if is_overbroad_root(&grant, &home) {
+        eprintln!(
+            "note: '{agent}' has no access to {} and it is too broad to grant automatically.\n      Grant a specific dir with: mur agent perm allow-write {agent} <path>",
+            grant.display()
+        );
+        return Ok(());
+    }
+
+    // Non-interactive (piped) launch: never block on stdin; just inform.
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        eprintln!(
+            "note: '{agent}' has no filesystem access to {}.\n      Grant it with: mur agent perm allow-write {agent} {}",
+            grant.display(),
+            grant.display()
+        );
+        return Ok(());
+    }
+
+    eprintln!("'{agent}' has no filesystem access to this project:");
+    eprintln!("    {}", grant.display());
+    eprint!("Grant read+write and remember it for this agent? [y/N] ");
+    io::stdout().flush().ok();
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    if !matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+        eprintln!("Skipped — the agent cannot read or write here.");
+        return Ok(());
+    }
+
+    // One load/mutate/save (vs. two perm calls) keeps a single restart warning.
+    let grant_str = grant.to_string_lossy().to_string();
+    let (ppath, mut profile) = super::super::load_profile_for_edit(agent)?;
+    let fs = &mut profile.entitlements.filesystem;
+    if !fs.read.iter().any(|p| p == &grant_str) {
+        fs.read.push(grant_str.clone());
+    }
+    if !fs.write.iter().any(|p| p == &grant_str) {
+        fs.write.push(grant_str.clone());
+    }
+    super::super::save_profile(&ppath, &mut profile)?;
+    eprintln!("Granted {grant_str} (read + write).");
+    // Prints the canonical "restart required for changes to take effect" line
+    // when the agent is live — its sandbox is sealed at startup.
+    super::super::perm::warn_if_running(agent);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn within_roots_matches_nested_and_tilde() {
+        let home = PathBuf::from("/home/u");
+        // exact + nested (paths need not exist: canon() falls back to literal)
+        assert!(path_within_roots(
+            Path::new("/home/u/proj/src"),
+            &["/home/u/proj".into()],
+            &home
+        ));
+        assert!(path_within_roots(
+            Path::new("/home/u/proj"),
+            &["/home/u/proj".into()],
+            &home
+        ));
+        // tilde expansion resolves to the user home
+        assert!(path_within_roots(
+            Path::new("/home/u/proj/x"),
+            &["~/proj".into()],
+            &home
+        ));
+        // sibling outside the root
+        assert!(!path_within_roots(
+            Path::new("/home/u/other"),
+            &["/home/u/proj".into()],
+            &home
+        ));
+        // no roots at all
+        assert!(!path_within_roots(Path::new("/home/u/proj"), &[], &home));
+    }
+
+    #[test]
+    fn overbroad_blocks_shallow_and_home() {
+        let home = PathBuf::from("/Users/d");
+        assert!(is_overbroad_root(Path::new("/"), &home));
+        assert!(is_overbroad_root(Path::new("/Users"), &home));
+        assert!(is_overbroad_root(Path::new("/Volumes"), &home));
+        assert!(is_overbroad_root(&home, &home));
+        // a real project dir is fine
+        assert!(!is_overbroad_root(
+            Path::new("/Users/d/Projects/mur"),
+            &home
+        ));
+        assert!(!is_overbroad_root(
+            Path::new("/Volumes/Disk/Projects/mur"),
+            &home
+        ));
+    }
+}

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -182,6 +182,9 @@ pub struct App {
     pub channel: Option<ChannelMeta>,
     /// Lines scrolled up from the bottom (0 = pinned to newest).
     pub scroll_back: u16,
+    /// Transcript viewport height (rows), captured each render so PageUp/Down
+    /// move a screenful and `scroll_back` can be clamped to the real maximum.
+    pub scroll_page: u16,
     pub spinner: usize,
     pub should_quit: bool,
     /// Session-wide auto-approval of every tool call (`/auto` or `--auto`).
@@ -227,6 +230,7 @@ impl App {
             session,
             channel: None,
             scroll_back: 0,
+            scroll_page: 0,
             spinner: 0,
             should_quit: false,
             auto_approve: false,

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -6,6 +6,7 @@
 //! (state), [`ui`] (ratatui render), [`markdown`] (reply rendering), and
 //! [`persist`] (JSONL session log + resume).
 
+mod access;
 mod app;
 mod manage;
 mod markdown;
@@ -41,9 +42,8 @@ use crate::a2a_dial::{DialMode, canonicalize_agent_name, dial_method};
 
 /// How many recent conversations `/sessions` lists.
 const RECENT_LIMIT: usize = 10;
-/// How many transcript lines PageUp/PageDown scroll.
-const SCROLL_STEP: u16 = 5;
-/// Trackpad fires 10-20 events/sec so step=1 for mouse vs step=5 for keyboard PageUp/Down.
+/// Mouse wheel scrolls one line per event (trackpads fire 10-20 events/sec, so
+/// per-line granularity stays smooth); PageUp/PageDown move a full screenful.
 const MOUSE_SCROLL_STEP: u16 = 1;
 /// Spinner animation cadence.
 const SPINNER_MS: u64 = 90;
@@ -73,6 +73,10 @@ pub async fn cmd_cli(
         );
         return Ok(());
     }
+
+    // If this project dir is outside the agent's filesystem grants, offer to
+    // add it (explicit consent, persisted; sandbox applies it on next restart).
+    access::ensure_cwd_access(&agent)?;
 
     // Non-TTY (piped) → plain streamed text, preserving scriptability.
     if !io::stdout().is_terminal() {
@@ -269,8 +273,12 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
                 KeyCode::Char('d') if ctrl => request_quit(app, tx),
                 KeyCode::Char('c') if ctrl => handle_ctrl_c(app, tx),
                 KeyCode::Char('v') if ctrl => attach_clipboard_image(app),
-                KeyCode::PageUp => app.scroll_back = app.scroll_back.saturating_add(SCROLL_STEP),
-                KeyCode::PageDown => app.scroll_back = app.scroll_back.saturating_sub(SCROLL_STEP),
+                KeyCode::PageUp => {
+                    app.scroll_back = app.scroll_back.saturating_add(app.scroll_page.max(1))
+                }
+                KeyCode::PageDown => {
+                    app.scroll_back = app.scroll_back.saturating_sub(app.scroll_page.max(1))
+                }
                 KeyCode::Tab => complete_slash(app),
                 KeyCode::Enter if alt => {
                     app.input.insert_newline();

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -10,7 +10,7 @@ use super::app::{App, ChatMsg, Role, SPINNER};
 use super::markdown;
 
 /// Draw the whole UI for one frame.
-pub fn render(f: &mut Frame, app: &App) {
+pub fn render(f: &mut Frame, app: &mut App) {
     let input_lines = app.input.lines().len() as u16;
     let input_height = (input_lines + 2).clamp(3, 8);
     let chunks = Layout::default()
@@ -31,7 +31,7 @@ pub fn render(f: &mut Frame, app: &App) {
     }
 }
 
-fn render_transcript(f: &mut Frame, app: &App, area: Rect) {
+fn render_transcript(f: &mut Frame, app: &mut App, area: Rect) {
     let theme = app.theme;
     let block = Block::default()
         .borders(Borders::ALL)
@@ -76,6 +76,15 @@ fn render_transcript(f: &mut Frame, app: &App, area: Rect) {
         .wrap(Wrap { trim: false })
         .scroll((offset, 0));
     f.render_widget(output, area);
+
+    // Clamp away over-scroll so PageDown never needs "dead" presses, and record
+    // the page size for the key handler. Done after render: the immutable `lines`
+    // borrow of `app` ends when `output` is consumed above.
+    // ponytail: scroll_back counts logical (pre-wrap) lines while `.scroll()`
+    // takes post-wrap rows, so a page can be a row or two off under heavy
+    // wrapping. Upgrade to wrapped-row accounting if that ever feels wrong.
+    app.scroll_back = app.scroll_back.min(max_off);
+    app.scroll_page = visible;
 }
 
 fn push_message(

--- a/mur-core/src/cmd/fleet/plan.rs
+++ b/mur-core/src/cmd/fleet/plan.rs
@@ -34,12 +34,51 @@ struct PlanStep {
     depends_on: Vec<String>,
 }
 
-/// Extract the JSON object from a (possibly prose- or fence-wrapped) reply:
-/// the span from the first `{` to the last `}`.
-fn extract_json(text: &str) -> Option<&str> {
-    let start = text.find('{')?;
-    let end = text.rfind('}')?;
-    (end > start).then(|| &text[start..=end])
+/// End byte index of the balanced `{...}` beginning at `start` (a `{`),
+/// ignoring braces inside double-quoted JSON strings. `None` if never balanced.
+fn balanced_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut in_str = false;
+    let mut escaped = false;
+    for (i, &c) in bytes.iter().enumerate().skip(start) {
+        if in_str {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                in_str = false;
+            }
+            continue;
+        }
+        match c {
+            b'"' => in_str = true,
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// First balanced `{...}` span in `text` that parses into a non-empty router
+/// plan. Trying *every* `{` (not just the first, not first-to-last) means stray
+/// prose braces — `use {member}` — or a leading unrelated JSON object can't
+/// defeat extraction, and trailing prose braces aren't swallowed.
+fn extract_plan(text: &str) -> Option<RouterPlan> {
+    let bytes = text.as_bytes();
+    (0..bytes.len())
+        .filter(|&i| bytes[i] == b'{')
+        .find_map(|start| {
+            let end = balanced_end(bytes, start)?;
+            let plan: RouterPlan = serde_json::from_str(&text[start..=end]).ok()?;
+            (!plan.steps.is_empty()).then_some(plan)
+        })
 }
 
 /// Parse a router reply into a validated `Procedure`, or `None` to fall back to
@@ -47,8 +86,8 @@ fn extract_json(text: &str) -> Option<&str> {
 /// `member` is a real fleet member, and (via the executor's own validator)
 /// resolvable `depends_on` with no cycles.
 pub fn parse_router_plan(text: &str, members: &[String]) -> Option<Procedure> {
-    let plan: RouterPlan = serde_json::from_str(extract_json(text)?).ok()?;
-    if plan.steps.is_empty() || plan.steps.len() > MAX_PLAN_STEPS {
+    let plan = extract_plan(text)?;
+    if plan.steps.len() > MAX_PLAN_STEPS {
         return None;
     }
     let member_set: HashSet<&str> = members.iter().map(String::as_str).collect();
@@ -196,5 +235,24 @@ mod tests {
             {"id":"s1","member":"qa","task":"b"}
         ]}"#;
         assert!(parse_router_plan(txt, &members()).is_none());
+    }
+
+    #[test]
+    fn extracts_json_despite_prose_braces() {
+        // A stray brace before the real JSON (and trailing prose braces) must
+        // not defeat extraction — the greedy first-{ to last-} version failed.
+        let txt = "Plan: give work to {member} thus: {\"steps\":[{\"member\":\"pm\",\"task\":\"go\"}]} ok}";
+        let p = parse_router_plan(txt, &members()).unwrap();
+        assert_eq!(p.steps.len(), 1);
+        assert_eq!(p.steps[0].delegate_to.as_deref(), Some("pm"));
+    }
+
+    #[test]
+    fn ignores_braces_inside_strings() {
+        // `}{` inside a task string must not be read as object boundaries.
+        let txt = r#"{"steps":[{"member":"pm","task":"emit }{ verbatim"}]}"#;
+        let p = parse_router_plan(txt, &members()).unwrap();
+        assert_eq!(p.steps.len(), 1);
+        assert_eq!(p.steps[0].intent.as_deref(), Some("emit }{ verbatim"));
     }
 }

--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -421,14 +421,26 @@ async fn execute_step(
     step: &ProcedureStep,
     opts: &DagExecOptions<'_>,
     step_index: usize,
+    attempt: u32,
     mur_home: &Path,
 ) -> StepResult {
     let start = std::time::Instant::now();
     let sid = step.id.clone().unwrap_or_else(|| step_index.to_string());
+    // Retries reuse (run_id, step_id); without an attempt discriminator a
+    // succeeding retry's events collide with the failed attempt's idem keys and
+    // are dropped by the dedup-aware writer. attempt 0 keeps the original keys
+    // (back-compat with already-recorded events + the resume cursor).
+    let key = |base: &str| {
+        if attempt == 0 {
+            base.to_string()
+        } else {
+            format!("{base}#a{attempt}")
+        }
+    };
 
     // ── Resume cursor (v3c): skip steps whose ToolResult is already recorded ──
     if let Some(cid) = opts.channel_id.as_deref() {
-        let result_key = idem_key(cid, &opts.run_id, &sid, "result");
+        let result_key = idem_key(cid, &opts.run_id, &sid, &key("result"));
         if let Ok(svc) = ChannelService::open(mur_home)
             && let Ok(evs) = svc.load_events(cid)
             && evs.iter().any(|e| {
@@ -455,8 +467,8 @@ async fn execute_step(
         let start = std::time::Instant::now();
         let canonical = crate::a2a_dial::canonicalize_agent_name(mur_home, target);
         let child_task_id = format!("ct-{}", uuid::Uuid::now_v7());
-        let deleg_key = idem_key(cid, &opts.run_id, &sid, "delegate");
-        let reply_key = idem_key(cid, &opts.run_id, &sid, "reply");
+        let deleg_key = idem_key(cid, &opts.run_id, &sid, &key("delegate"));
+        let reply_key = idem_key(cid, &opts.run_id, &sid, &key("reply"));
 
         // Sub-goal text: explicit intent, else the step description.
         let goal_text = step
@@ -660,7 +672,7 @@ async fn execute_step(
         let mut excerpt = result.output_text.clone();
         excerpt.truncate(2048);
         // Use the deterministic idem_key so the resume cursor can match this row.
-        let result_key = idem_key(cid, &opts.run_id, &sid, "result");
+        let result_key = idem_key(cid, &opts.run_id, &sid, &key("result"));
         let _ = ChannelService::open(mur_home).and_then(|svc| {
             crate::channel_writer::append_as_writer(
                 &svc,
@@ -757,6 +769,7 @@ pub async fn execute_dag(
         let opt_dev_id = opts.device_id.clone();
         let opt_trigger = opts.trigger.to_string();
         let opt_chan_id = opts.channel_id.clone();
+        let opt_run_id = opts.run_id.clone();
         let mut handles = Vec::new();
         for &i in &indices {
             let step = graph.nodes[i].step.clone();
@@ -766,6 +779,7 @@ pub async fn execute_dag(
             let vars = opt_vars.clone();
             let tr = opt_trigger.clone();
             let chan_id = opt_chan_id.clone();
+            let run_id = opt_run_id.clone();
             let mh = mur_home.to_path_buf();
             handles.push(tokio::task::spawn(async move {
                 let opts_clone = DagExecOptions {
@@ -776,9 +790,9 @@ pub async fn execute_dag(
                     device_id: dev_id,
                     trigger: &tr,
                     channel_id: chan_id,
-                    run_id: String::new(),
+                    run_id,
                 };
-                execute_step(&step, &opts_clone, i, &mh).await
+                execute_step(&step, &opts_clone, i, 0, &mh).await
             }));
         }
 
@@ -878,7 +892,7 @@ pub async fn execute_dag(
                                 max_retries
                             );
                             let retry_result =
-                                execute_step(step, opts, indices[ri], mur_home).await;
+                                execute_step(step, opts, indices[ri], attempt + 1, mur_home).await;
                             // Each retry is additional real spend (the original
                             // attempt was already counted once at the per-step
                             // accumulation); count every attempt so the budget


### PR DESCRIPTION
Base branch that #483 (startup redesign) stacks on. Two commits:

## 1. feat(agent-cli): PWD project-access consent + smoother transcript scroll (`bd54d6d3`)
`mur agent cli` checks whether the launch dir is within the agent's filesystem entitlements; if not it prompts (interactive TTY only, **default No, fail-closed**) and on consent grants the enclosing git repo root — covering subdirs and `.worktrees/` — read+write, persisted to the profile. The runtime sandbox is sealed at startup, so the grant applies on restart. Over-broad roots (`/`, home, depth<2) are refused. New logic in `cli/access.rs` (`cli/mod.rs` was at the 800-line limit); `path_within_roots` / `is_overbroad_root` unit-tested.

Also fixes jumpy transcript scrolling: PageUp/PageDown move a full viewport screenful (was a magic step of 5) and `scroll_back` is clamped per render; the mouse wheel keeps per-line granularity.

## 2. fix(fleet,executor): per-run run_id, retry-distinct idem keys, balanced plan JSON (`7efc4925`)
- **dag**: the concurrent spawn path built step opts with `run_id: String::new()`, collapsing every channel idem key and defeating dedup/resume across iterations and concurrent `--loop` runs — now threads the real run_id.
- **dag**: `execute_step` gains an `attempt` discriminator; retry idem keys get a `#a{n}` suffix (attempt 0 unchanged) so a succeeding retry's events aren't dropped under the failed attempt's key.
- **fleet/plan**: `extract_json` greedily spanned first-`{` to last-`}` (broken by a stray prose brace or a trailing `}`); replaced with a string-aware balanced-brace scan. +2 regression tests.

## Files
`cli/access.rs` (new, 193), `cli/{app,mod,ui}.rs`, `fleet/plan.rs`, `executor/dag.rs` — +308 / −22.

## Note
Pre-existing work (committed by a prior session; both commits carry Co-Authored-By). Opened so #483 has a base to merge through — I have not re-verified the build/tests on this branch (CI will).

🤖 Generated with [Claude Code](https://claude.com/claude-code)