### PR TITLE
fix(agent-wizard): kebab-case shipped role ids so dir slugs read naturally

### DIFF
--- a/docs/superpowers/plans/2026-06-15-agent-wizard-engine-and-cli.md
+++ b/docs/superpowers/plans/2026-06-15-agent-wizard-engine-and-cli.md
@@ -64,7 +64,7 @@ pub enum RiskLevel {
     Low,
     /// Writes code/tests, runs build tools (e.g. QA).
     Medium,
-    /// Performs irreversible repo/release ops (e.g. RepoManager). Triggers security eval suites.
+    /// Performs irreversible repo/release ops (e.g. Repo Manager). Triggers security eval suites.
     High,
 }
 
@@ -349,7 +349,7 @@ skill_topics:
   - mur-repo-pm-context
 ```
 
-Create `qa.yaml`, `repomanager.yaml`, `rustsmith.yaml` with the same shape (use the skill names already authored for those agents; risk: `medium` for qa, `high` for repomanager, `medium` for rustsmith).
+Create `qa.yaml`, `repomanager.yaml`, `rustsmith.yaml` with the same shape (use the skill names already authored for those agents; risk: `medium` for qa, `high` for repo-manager, `medium` for rustsmith).
 
 - [ ] **Step 5: Run, expect pass**
 
@@ -923,6 +923,6 @@ tracked here so later plans pick them up:
   HarmBench security suites run for high-risk agents), not in the base entitlement preset. Revisit
   if a per-tier entitlement difference is wanted.
 - **Guided `custom.yaml` template (→ Plan 2).** Custom roles already work in Plan 1 via a manifest
-  in `~/.mur/wizard/roles/` (the shipped pm/qa/repomanager/rustsmith manifests are the examples).
+  in `~/.mur/wizard/roles/` (the shipped pm/qa/repo-manager/rustsmith manifests are the examples).
   A first-class custom path (describe-a-role → LLM-generate) is the Plan 2 feature; ship a copyable
   `custom.yaml` template alongside it.

--- a/docs/superpowers/plans/2026-06-15-agent-wizard-hub-flow.md
+++ b/docs/superpowers/plans/2026-06-15-agent-wizard-hub-flow.md
@@ -548,7 +548,7 @@ Run: `cd mur-hub-gui/ui && npm run build && npx vitest run 2>&1 | tail -8` (buil
 
 Launch the Hub (`./build.sh` per CLAUDE.md, or the Hub's dev command), open create-Agent:
 1. Step 0 shows Companion / Specialist / Both.
-2. Specialist → Role picker lists pm/qa/repomanager/rustsmith (+risk). Pick one → Generating shows progress lines.
+2. Specialist → Role picker lists pm/qa/repo-manager/rustsmith (+risk). Pick one → Generating shows progress lines.
 3. Review screen shows editable prompt + skills + entitlement summary; edit a skill, click Approve.
 4. Agent is created (appears in the Hub agent list); Eval shows scores (or a graceful message if no model).
 5. Companion path is unchanged; Both runs specialist then the appearance steps.

--- a/docs/superpowers/specs/2026-06-15-agent-wizard-design.md
+++ b/docs/superpowers/specs/2026-06-15-agent-wizard-design.md
@@ -6,7 +6,7 @@ Status: Design (approved in brainstorming; pending spec review)
 ## Context
 
 We built a team of specialized MUR agents by hand — `rustsmith`, then `pm` / `qa` /
-`repomanager` — following a repeatable method: define the role → research 2026 best practice →
+`repo-manager` — following a repeatable method: define the role → research 2026 best practice →
 author 4–6 dense skills → write a "definition-of-done" system prompt with HITL gates → set
 least-privilege entitlements → create/attach/start → run a test→record→fix eval loop. That method
 is currently captured only as a human-followed skill (`specialized-agent-builder` in
@@ -117,7 +117,7 @@ The runner executes ordered stages; LLM stages are skippable and emit progress:
   `~/.mur/wizard/roles/` plus shipped defaults (in `mur-core` resources). Users/community add roles
   by dropping a manifest — **no hardcoded list** (honors CLAUDE.md Rule 1).
 - A role manifest references a skill set + DoD-prompt template + entitlement preset + risk level +
-  suggested eval tasks. Seed a categorized starter catalog (~10): PM, QA, RepoManager, RustSmith,
+  suggested eval tasks. Seed a categorized starter catalog (~10): PM, QA, Repo Manager, RustSmith,
   DevOps/SRE, Security reviewer, Tech writer, Data/ML, Frontend, Support-triage.
 
 ### CLI surface
@@ -161,7 +161,7 @@ dir before approval.
   scores to the human; offer to keep or discard the agent.
 - **Validation:** every generated skill must pass `mur skill validate` (schema + security scan)
   before it can appear in the review gate.
-- **Runtime HITL preserved:** the created agent keeps its own HITL gates (e.g. repomanager's
+- **Runtime HITL preserved:** the created agent keeps its own HITL gates (e.g. repo-manager's
   merge/release confirmations); the wizard's scope ends at create + start + eval.
 - **Least privilege:** entitlement preset is scoped to the role/risk; deny sensitive paths by
   default.

--- a/mur-core/resources/wizard-roles/dataml.yaml
+++ b/mur-core/resources/wizard-roles/dataml.yaml
@@ -1,4 +1,4 @@
-id: dataml
+id: data-ml
 display_name: Data/ML Engineer
 charter: "Builds data pipelines and ML workflows: pipeline design, feature engineering, training/eval, experiment tracking, reproducibility."
 risk: medium

--- a/mur-core/resources/wizard-roles/repomanager.yaml
+++ b/mur-core/resources/wizard-roles/repomanager.yaml
@@ -1,5 +1,5 @@
-id: repomanager
-display_name: RepoManager
+id: repo-manager
+display_name: Repo Manager
 charter: Performs safe, auditable repo and release operations across any git forge.
 risk: high
 category: devops

--- a/mur-core/resources/wizard-roles/secreviewer.yaml
+++ b/mur-core/resources/wizard-roles/secreviewer.yaml
@@ -1,4 +1,4 @@
-id: secreviewer
+id: sec-reviewer
 display_name: Security Reviewer
 charter: "Reviews code and dependencies for security: threat modeling, secure-code review, supply-chain and secret hygiene, vuln triage."
 risk: medium

--- a/mur-core/resources/wizard-roles/techwriter.yaml
+++ b/mur-core/resources/wizard-roles/techwriter.yaml
@@ -1,4 +1,4 @@
-id: techwriter
+id: tech-writer
 display_name: Tech Writer
 charter: "Produces clear, accurate, maintainable docs: information architecture, API reference, tutorials, style, and freshness."
 risk: low

--- a/mur-core/src/agent_wizard/catalog.rs
+++ b/mur-core/src/agent_wizard/catalog.rs
@@ -107,9 +107,9 @@ skill_topics: ["product-spec-and-prd-writing", "issue-authoring-and-hygiene"]
         // The Plan-5 additions are present.
         for id in [
             "devops",
-            "secreviewer",
-            "techwriter",
-            "dataml",
+            "sec-reviewer",
+            "tech-writer",
+            "data-ml",
             "frontend",
             "support",
         ] {


### PR DESCRIPTION
## What

Multi-word shipped wizard roles used **concatenated** ids, so an agent created from them landed at e.g. `~/.mur/agents/repomanager` instead of the natural `repo-manager`.

The on-disk slug is the role manifest's `id` **verbatim** — there's no auto-derivation from `display_name`, and `validate_agent_name` allows `-`/`_` but never inserts them. So this is a pure data fix:

| file | `id` | `display_name` |
|---|---|---|
| `repomanager.yaml` | `repo-manager` | `Repo Manager` (was `RepoManager`) |
| `secreviewer.yaml` | `sec-reviewer` | unchanged (Security Reviewer) |
| `techwriter.yaml` | `tech-writer` | unchanged (Tech Writer) |
| `dataml.yaml` | `data-ml` | unchanged (Data/ML Engineer) |

`catalog.rs` assertion list updated to match. `rustsmith` left as-is (established name); `pm`/`qa`/`devops`/`frontend`/`support` are single tokens.

## Scope / migration

- These are wizard **templates** — the change only affects **newly created** agents. Existing on-disk dirs are untouched; migrate one with `mur agent rename repomanager repo-manager` (renames dir + `profile.name` + symlink).
- Filenames keep their original names (just `include_str!` embed paths, not user-visible). No code keys off the old ids.

## Test

`cargo nextest run -p mur-core agent_wizard::catalog` → 6 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)