### PR TITLE
fix(agent-runtime): consume post_tool_use replace_output so compression actually fires

### DIFF
--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -566,12 +566,9 @@ impl Hook for B0SafetyHook {
         // is unchanged. The redactor is permissive (catches obvious
         // email/SSN/cc/phone patterns) and the patch is consumed by
         // the supervisor to rewrite `ToolResult.output` before the
-        // value lands in the persisted memory store.
-        //
-        // NOTE: this hook returns the patch; wiring `chain.post_tool_use`'s
-        // returned `PostToolUsePatch` into the persistence path is
-        // tracked separately. M7.6 only covers the hook + chain folding;
-        // the supervisor caller does not yet act on `replace_output`.
+        // value lands in the persisted memory store. The returned patch is
+        // consumed by `TaskRunner::apply_post_tool_use` in the agentic loop,
+        // which rewrites `ToolResult.output` (folded with CompressHook).
         if !call.name().starts_with("memory.") {
             return Ok(PostToolUsePatch::default());
         }

--- a/mur-agent-runtime/src/hooks/compress.rs
+++ b/mur-agent-runtime/src/hooks/compress.rs
@@ -1,10 +1,9 @@
 //! `CompressHook` — size-gated auto-compression of agent tool outputs (Surface 2).
 //!
 //! Mirrors `B0SafetyHook::post_tool_use`: returns a `PostToolUsePatch.replace_output`
-//! so the supervisor can rewrite `ToolResult.output` before it is recorded / shown
-//! to the agent. Like B0 rule 8, the end-to-end effect depends on the supervisor
-//! consuming `replace_output` (tracked separately); the hook + chain folding are
-//! complete and tested here.
+//! so the supervisor rewrites `ToolResult.output` before it is recorded / shown to
+//! the agent. The patch is consumed by `TaskRunner::apply_post_tool_use` in the
+//! agentic loop (same path as B0 rule 8), so the end-to-end offload is now effective.
 
 use std::path::PathBuf;
 

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -2,7 +2,7 @@
 //! P0a only implements `run_sync` fully; streaming is P0b.
 
 use crate::hitl::HitlApprovals;
-use crate::hooks::{HookChain, HookCtx, PromptView};
+use crate::hooks::{HookChain, HookCtx, PromptView, ToolCall, ToolResult};
 use crate::llm::{LlmClient, LlmRequest, RichMessage};
 use crate::skills::RuntimeSkills;
 use crate::skills::injector::inject_layer2;
@@ -929,6 +929,50 @@ impl TaskRunner {
         })
     }
 
+    /// Fold the hook chain's `post_tool_use` patch into each tool result,
+    /// rewriting `content` when a hook returns `replace_output` — e.g.
+    /// `CompressHook` offloading an oversized output (size-gated by
+    /// `compress.yaml` `auto.min_tokens`) or B0 rule 8 PII redaction.
+    /// Mutates in place; no-op when no chain is wired or every hook returns
+    /// `None`. Closes the M7.6 gap where the patch was computed but discarded.
+    async fn apply_post_tool_use(
+        &self,
+        calls: &[crate::llm::ToolCallResult],
+        results: &mut [crate::llm::ToolResultEntry],
+    ) {
+        let (Some(chain), Some(ctx), Some(cancel)) =
+            (&self.hook_chain, &self.hook_ctx, &self.hook_cancel)
+        else {
+            return;
+        };
+        let mut turn_ctx = ctx.clone();
+        turn_ctx.turn_id = self.turn_counter.load(Ordering::Relaxed);
+        for (call, entry) in calls.iter().zip(results.iter_mut()) {
+            let tc = ToolCall {
+                tool_name: call.tool_name.clone(),
+                mcp_server: None,
+                call_id: call.call_id.clone(),
+                input: call.input.clone(),
+            };
+            let tr = ToolResult {
+                call_id: entry.call_id.clone(),
+                ok: !entry.is_error,
+                output: serde_json::Value::String(entry.content.clone()),
+                duration_ms: 0,
+            };
+            if let Some(v) = chain
+                .post_tool_use(&turn_ctx, &tc, &tr, cancel)
+                .await
+                .replace_output
+            {
+                entry.content = match v {
+                    serde_json::Value::String(s) => s,
+                    other => other.to_string(),
+                };
+            }
+        }
+    }
+
     /// Run the agentic loop. Returns the final agent message plus an optional
     /// `LoopStop` describing which budget (if any) forced an early, graceful
     /// exit. `None` means the model ended the turn naturally.
@@ -1057,6 +1101,14 @@ impl TaskRunner {
                     Err(e) => return Err(e),
                 }
             }
+
+            // Fold post-tool-use hook patches into the results before
+            // fingerprinting / history so the model sees the rewritten text:
+            // CompressHook offloads oversized output (size-gated) and B0 rule 8
+            // redacts PII. Patches are content-deterministic, so the doom-loop
+            // fingerprint below stays stable.
+            self.apply_post_tool_use(&resp.tool_calls, &mut results)
+                .await;
 
             // Doom-loop detection (safety layer): fingerprint every tool call
             // by (tool, args, RESULT) and abort if any single fingerprint
@@ -1357,6 +1409,74 @@ fn text_response(text: &str) -> Message {
 mod tests {
     use super::*;
     use mur_common::a2a::MessagePart;
+
+    /// Stub hook: replaces any tool output longer than 10 chars with
+    /// "OFFLOADED" (stands in for CompressHook's size-gated offload). Proves
+    /// the turn loop consumes `replace_output` rather than discarding it.
+    struct ReplaceBigHook;
+    #[async_trait::async_trait]
+    impl crate::hooks::Hook for ReplaceBigHook {
+        fn name(&self) -> &str {
+            "ReplaceBigHook"
+        }
+        async fn post_tool_use(
+            &self,
+            _ctx: &HookCtx,
+            _call: &ToolCall,
+            result: &ToolResult,
+            _tok: &CancellationToken,
+        ) -> Result<crate::hooks::PostToolUsePatch, crate::hooks::HookError> {
+            let big = result
+                .output
+                .as_str()
+                .map(|s| s.len() > 10)
+                .unwrap_or(false);
+            Ok(crate::hooks::PostToolUsePatch {
+                replace_output: big.then(|| serde_json::Value::String("OFFLOADED".into())),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_post_tool_use_rewrites_oversized_output() {
+        use crate::llm::{ToolCallResult, ToolResultEntry};
+        let chain = Arc::new(HookChain::new(vec![Arc::new(ReplaceBigHook)]));
+        let runner = TaskRunner::new_stub_echo().with_hook_chain(
+            chain,
+            HookCtx::for_test_with_home(std::path::PathBuf::from("."), 0),
+            CancellationToken::new(),
+        );
+        let calls = vec![
+            ToolCallResult {
+                call_id: "c1".into(),
+                tool_name: "big".into(),
+                input: serde_json::json!({}),
+            },
+            ToolCallResult {
+                call_id: "c2".into(),
+                tool_name: "small".into(),
+                input: serde_json::json!({}),
+            },
+        ];
+        let mut results = vec![
+            ToolResultEntry {
+                call_id: "c1".into(),
+                content: "this is a large tool output".into(),
+                is_error: false,
+            },
+            ToolResultEntry {
+                call_id: "c2".into(),
+                content: "ok".into(),
+                is_error: false,
+            },
+        ];
+        runner.apply_post_tool_use(&calls, &mut results).await;
+        assert_eq!(
+            results[0].content, "OFFLOADED",
+            "oversized output rewritten"
+        );
+        assert_eq!(results[1].content, "ok", "small output untouched");
+    }
 
     fn ping_spec() -> TaskSpec {
         TaskSpec {


### PR DESCRIPTION
## Problem

The agent runtime's agentic loop computed a `PostToolUsePatch` via the hook chain (`CompressHook` for oversized-output offload, `B0SafetyHook` rule 8 for PII redaction) but **never consumed it**. `ToolResultEntry.content` was pushed to history raw, so neither compression nor redaction ever took effect — the M7.6 wiring gap that `compress.rs` / `b0.rs` documented in comments.

Net effect: **`mur compress` did nothing when an agent ran.** Big tool outputs (`mur agent cli` bash/file/search results) hit the model uncompressed.

## Fix

Add `TaskRunner::apply_post_tool_use`, called after tool execution and before fingerprinting/history append, to fold the chain's `replace_output` back into each `ToolResultEntry`. One change lights up **both** hooks that ride this patch (compression + PII redaction).

- Covers `mur agent cli` — it runs through this same loop.
- Compression happens at source, so the already-compressed entry is what `history.clone()` re-sends every iteration (no per-iteration amplification).
- The compress envelope is content-addressed (deterministic), so the doom-loop fingerprint stays stable — the safety layer is unaffected (verified: no timestamp/uuid/random in the envelope path).
- Size-gated by existing `compress.yaml` `auto.{enabled,min_tokens,agent_runtime}`; no new config.

Also updates the two now-stale "supervisor does not yet consume `replace_output`" comments.

## Test

`task_runner::tests::apply_post_tool_use_rewrites_oversized_output` — a stub hook replaces >10-char output; asserts the oversized result is rewritten and the small one is untouched.

```
test task_runner::tests::apply_post_tool_use_rewrites_oversized_output ... ok
```

clippy clean.

## Scope

Deliberately limited to the agent-runtime tool-output surface. An audit of other LLM-facing surfaces found the rest either already compressed by a different intentional mechanism (`mur ask` Stage 1b abstractive), quality-risky to offload (user-pasted input, skill-gen recordings), or moot until multi-turn `context_task_id` loading lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)