### PR TITLE
fix(sandbox): restricted outbound silently blocked DNS on macOS

### DIFF
--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -129,6 +129,17 @@ pub fn build_sbpl_profile(policy: &SandboxPolicy) -> String {
         }
         Some(ports) => {
             lines.push("(deny network-outbound)".to_string());
+            // macOS resolves hostnames by talking to mDNSResponder over this
+            // UNIX socket, which is itself a `network-outbound` op. Under the
+            // blanket deny it must be re-allowed or ALL name resolution fails —
+            // every external host errors with "Could not resolve host", so only
+            // loopback IPs (which need no DNS) are reachable. HostGuard still
+            // gates which hostnames the runtime client resolves; this restores
+            // resolution only, not arbitrary egress (TCP stays port-gated).
+            const MDNSRESPONDER_SOCKET: &str = "/private/var/run/mDNSResponder";
+            lines.push(format!(
+                "(allow network-outbound (remote unix-socket (path-literal \"{MDNSRESPONDER_SOCKET}\")))"
+            ));
             for port in ports {
                 lines.push(format!(
                     "(allow network-outbound (remote tcp \"*:{port}\"))"
@@ -238,6 +249,34 @@ mod tests {
         assert!(
             !sbpl.contains("api.anthropic.com"),
             "SBPL must not contain hostnames (invalid `remote tcp` host):\n{sbpl}"
+        );
+    }
+
+    #[test]
+    fn restricted_allows_dns_resolution() {
+        // Without the mDNSResponder socket allowance the `(deny network-outbound)`
+        // baseline blocks macOS name resolution, so no external host resolves
+        // and only loopback IPs work. Regression guard for that gap.
+        let mut policy = policy_with(vec![], vec![]);
+        policy.net_allow_ports = Some(vec![443]);
+        let sbpl = build_sbpl_profile(&policy);
+        assert!(
+            sbpl.contains(
+                "(allow network-outbound (remote unix-socket (path-literal \"/private/var/run/mDNSResponder\")))"
+            ),
+            "restricted profile must permit DNS via the mDNSResponder socket:\n{sbpl}"
+        );
+    }
+
+    #[test]
+    fn off_mode_still_blocks_dns() {
+        // Off (deny-all) must NOT get the DNS exception — it stays air-gapped.
+        let mut policy = policy_with(vec![], vec![]);
+        policy.net_allow_ports = Some(vec![]);
+        let sbpl = build_sbpl_profile(&policy);
+        assert!(
+            !sbpl.contains("mDNSResponder"),
+            "Off mode must not allow DNS:\n{sbpl}"
         );
     }
 

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -39,6 +39,19 @@ pub(crate) const LOCAL_LLM_DEFAULT_BASE_URL: &str = "http://127.0.0.1:50320/v1";
 /// not authenticate. Not a secret.
 pub(crate) const LOCAL_LLM_PLACEHOLDER_KEY: &str = "local-no-key";
 
+/// The external host the agent's configured model talks to, for auto-allowing
+/// it under restricted outbound (so a user never has to `allow-host` their own
+/// provider). `None` for loopback base_urls (handled by `local_llm_port`) and
+/// for entries without a base_url.
+fn provider_host(entry: &ModelEntry) -> Option<String> {
+    let base = entry.base_url.as_deref()?;
+    let host = base.parse::<reqwest::Url>().ok()?.host_str()?.to_string();
+    match host.as_str() {
+        "127.0.0.1" | "localhost" | "::1" => None,
+        _ => Some(host),
+    }
+}
+
 /// The TCP port of the agent's own local LLM endpoint, if its resolved model
 /// points at a loopback address. The runtime grants this port through the B1
 /// sandbox so an agent can always reach its configured model — whatever the
@@ -219,7 +232,19 @@ pub async fn build_provider_runner(
     let outbound = &profile.inner.entitlements.network.outbound;
     let host_guard = match outbound.mode {
         NetworkOutboundMode::Unrestricted => HostGuard::unrestricted(),
-        NetworkOutboundMode::Restricted => HostGuard::restricted(outbound.allow_hosts.clone()),
+        NetworkOutboundMode::Restricted => {
+            // Auto-allow the agent's configured LLM provider host: choosing a
+            // provider implies permission to reach it, so the user never has to
+            // `mur agent perm allow-host` their own model endpoint. Mirrors the
+            // loopback-port auto-grant for local models (`local_llm_port`).
+            let mut hosts = outbound.allow_hosts.clone();
+            if let Some(h) = provider_host(&entry)
+                && !hosts.iter().any(|x| x == &h)
+            {
+                hosts.push(h);
+            }
+            HostGuard::restricted(hosts)
+        }
         NetworkOutboundMode::Off => HostGuard::off(),
     };
     let guarded_http = reqwest::ClientBuilder::new()
@@ -511,6 +536,28 @@ pub(crate) async fn prepare_runtime(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn provider_host_extracts_external_host_only() {
+        let mk = |b: Option<&str>| ModelEntry {
+            base_url: b.map(Into::into),
+            ..Default::default()
+        };
+        assert_eq!(
+            provider_host(&mk(Some("https://api.deepseek.com"))).as_deref(),
+            Some("api.deepseek.com")
+        );
+        // path on the base_url doesn't change the host
+        assert_eq!(
+            provider_host(&mk(Some("https://api.deepseek.com/v1"))).as_deref(),
+            Some("api.deepseek.com")
+        );
+        // loopback endpoints are handled by local_llm_port, not allow_hosts
+        assert_eq!(provider_host(&mk(Some("http://127.0.0.1:8088"))), None);
+        assert_eq!(provider_host(&mk(Some("http://localhost:8000/v1"))), None);
+        // no base_url => nothing to auto-allow
+        assert_eq!(provider_host(&mk(None)), None);
+    }
 
     #[test]
     fn local_base_url_prefers_entry_then_env_then_file_then_default() {


### PR DESCRIPTION
## Problem

`network.outbound: restricted` was **silently broken for every external host on macOS**. macOS resolves hostnames by talking to `mDNSResponder` over the UNIX socket `/private/var/run/mDNSResponder` — which is a `network-outbound` operation. The restricted SBPL profile does `(deny network-outbound)` and re-allows **only** `(remote tcp "*:<port>")`, so that socket was denied → **DNS resolution failed for any name** → only loopback IPs (which need no DNS) were reachable.

Consequences:
- `mur agent perm allow-host <external-host>` was a **silent no-op** on macOS — HostGuard (the userspace reqwest resolver) allowed the hostname, but `getaddrinfo` died underneath.
- Any external LLM provider (DeepSeek, OpenAI, …) was unreachable under `restricted` without routing through a loopback proxy. That's why every working model in practice uses a loopback endpoint.

## Root cause (empirically confirmed)

Reproduced with a faithful `sandbox-exec` replica of the restricted profile:
- external host → `curl: (6) Could not resolve host`; Python `gethostbyname` → `gaierror`
- adding `(allow network-outbound (remote unix-socket (path-literal "/private/var/run/mDNSResponder")))` → **HTTP 401** (resolves, connects, reaches the API)
- `udp/53` / `tcp/53` allowances do **nothing** — macOS doesn't do raw UDP DNS from the process; it's the mDNSResponder socket.

## Fix

1. **`sandbox/macos.rs`** — re-allow the mDNSResponder UNIX socket in the **restricted** branch (Off/deny-all stays air-gapped). This restores name *resolution* only; the actual connection is still TCP-port-gated by SBPL and hostname-gated by HostGuard for the runtime's client.
2. **`supervisor_runner.rs`** — auto-allow the agent's configured provider host (derived from the resolved model `base_url`) into the HostGuard allowlist, so choosing a provider implies permission to reach it — no manual `allow-host`. Mirrors the existing loopback-port auto-grant (`local_llm_port`). Loopback base_urls return `None` (handled by that port grant).

## Verification

- New unit tests: `restricted_allows_dns_resolution`, `off_mode_still_blocks_dns`, `provider_host_extracts_external_host_only` — all pass; `clippy -D warnings` clean.
- End-to-end behavior proven by the sandbox-exec replica above (Could-not-resolve → HTTP 401).

## Known boundary (follow-up, not in this PR)

macOS seatbelt can only filter outbound by **port**, not hostname (`macos.rs` comment). So hostname least-privilege is enforced by HostGuard **only for the runtime's own reqwest client** — **subprocess egress** (bash tool, MCP servers) shares the port-only kernel boundary and can reach any host on the allowed ports after this fix. True per-path hostname isolation needs a per-agent network namespace (Linux) or a runtime-managed transparent egress proxy, plus hardening `check_request_url` to enforce the allowlist post-resolution. Tracking separately. (Linux Landlock path also needs an analogous DNS check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)