### PR TITLE
feat(murmur): Cmd+V / drag-drop image paste

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -213,9 +213,10 @@ pub struct App {
     pub last_esc_at: Option<std::time::Instant>,
     pub esc_hint: bool,
     pub last_sent: Option<String>,
-    /// Base64 PNG staged by Ctrl+V (a pasted screenshot), sent as an inline
-    /// image with the next message and cleared on send. macOS-only capture.
-    pub pending_image: Option<String>,
+    /// `(mime, base64)` of an image staged for the next message — either a
+    /// clipboard screenshot (Ctrl+V) or an image file the terminal pasted as a
+    /// path (Cmd+V / drag-drop). Sent as an inline image part, cleared on send.
+    pub pending_image: Option<(String, String)>,
     /// Mascot blink driver for the startup welcome screen. Render is a pure
     /// function of elapsed time; the event loop wakes on its next deadline.
     pub blink: Blink,

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -11,6 +11,7 @@ mod app;
 mod manage;
 mod markdown;
 mod multiplex;
+mod paste;
 pub mod persist;
 mod stream;
 mod theme;
@@ -286,7 +287,13 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
             match key.code {
                 KeyCode::Char('d') if ctrl => request_quit(app, tx),
                 KeyCode::Char('c') if ctrl => handle_ctrl_c(app, tx),
-                KeyCode::Char('v') if ctrl => attach_clipboard_image(app),
+                KeyCode::Char('v') if ctrl => {
+                    if !attach_clipboard_image(app) {
+                        app.push_system(
+                            "no image in clipboard — copy a screenshot then Ctrl+V (or Cmd+V / drag an image file)",
+                        );
+                    }
+                }
                 KeyCode::PageUp => {
                     app.scroll_back = app.scroll_back.saturating_add(app.scroll_page.max(1))
                 }
@@ -332,7 +339,20 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
             }
         }
         Event::Paste(text) => {
-            app.input.insert_str(text);
+            // How Cmd+V image paste works: the terminal eats Cmd+V and pastes
+            // the clipboard as bracketed text. For an image it pastes either the
+            // temp-file PATH it wrote (iTerm2/most) or nothing/whitespace. So:
+            //   image-file path  → load that file (covers Cmd+V & drag-drop)
+            //   empty/whitespace → try the clipboard image (covers raw paste)
+            //   otherwise        → ordinary text paste
+            let trimmed = text.trim();
+            if let Some((mime, b64)) = paste::image_from_paste(trimmed) {
+                stage_image(app, mime, b64);
+            } else if trimmed.is_empty() && attach_clipboard_image(app) {
+                // image grabbed off the clipboard
+            } else {
+                app.input.insert_str(text);
+            }
         }
         Event::Mouse(mouse_ev) => match mouse_ev.kind {
             MouseEventKind::ScrollUp => {
@@ -360,16 +380,22 @@ fn persist_skin(home: &std::path::Path, name: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Ctrl+V: stage a screenshot from the system clipboard for the next message.
-/// An image-only clipboard produces no bracketed-paste event (no text to
-/// send), so this needs its own key rather than riding `Event::Paste`.
-fn attach_clipboard_image(app: &mut App) {
+/// Stage a base64 image (with its mime) to send with the next message.
+fn stage_image(app: &mut App, mime: &str, b64: String) {
+    app.pending_image = Some((mime.to_string(), b64));
+    app.push_system("📎 image attached — sent with your next message");
+}
+
+/// Grab a screenshot off the system clipboard and stage it; returns whether an
+/// image was found. Used by Ctrl+V and by an empty bracketed paste (a Cmd+V of a
+/// raw clipboard image on terminals that emit an empty paste event).
+fn attach_clipboard_image(app: &mut App) -> bool {
     match clipboard_png() {
         Some(b64) => {
-            app.pending_image = Some(b64);
-            app.push_system("📎 screenshot attached — sent with your next message");
+            stage_image(app, "image/png", b64);
+            true
         }
-        None => app.push_system("no image in clipboard (Ctrl+V attaches a screenshot)"),
+        None => false,
     }
 }
 
@@ -552,7 +578,9 @@ async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
         &outgoing,
         &task_id,
         app.context_task_id.as_deref(),
-        app.pending_image.as_deref(),
+        app.pending_image
+            .as_ref()
+            .map(|(m, b)| (m.as_str(), b.as_str())),
     );
     app.pending_image = None;
     spawn_stream(

--- a/mur-core/src/cmd/agent/cli/paste.rs
+++ b/mur-core/src/cmd/agent/cli/paste.rs
@@ -1,0 +1,86 @@
+//! Bracketed-paste → image detection.
+//!
+//! Terminals eat Cmd+V and paste the clipboard as bracketed text. For an image
+//! that text is the temp-file PATH the terminal wrote (iTerm2 and most others)
+//! or a `file://` URL; drag-drop pastes the path too. So a paste that resolves
+//! to an existing image file is treated as an inline image, which is what makes
+//! Cmd+V (and drag-drop) image paste work without the app ever seeing Cmd+V.
+
+use std::path::{Path, PathBuf};
+
+/// If `text` is the path (or `file://` URL) to an image file, read it and
+/// return `(mime, base64)`. `None` for ordinary text, so the caller falls
+/// through to inserting it into the input box.
+pub fn image_from_paste(text: &str) -> Option<(&'static str, String)> {
+    use base64::{Engine, engine::general_purpose::STANDARD};
+    let path = normalize_paste_path(text)?;
+    let mime = image_mime_for(&path)?;
+    let bytes = std::fs::read(&path).ok()?;
+    (!bytes.is_empty()).then(|| (mime, STANDARD.encode(&bytes)))
+}
+
+/// Turn a pasted token into a real file path if it is one: strip a `file://`
+/// scheme (with minimal %-decoding), surrounding quotes, and drag-drop's
+/// backslash-escaped spaces; accept only an existing regular file.
+/// ponytail: decodes just `%20`; widen the %-decode if real paths need it.
+fn normalize_paste_path(text: &str) -> Option<PathBuf> {
+    let mut s = text.trim().trim_matches(['"', '\'']).to_string();
+    if let Some(rest) = s.strip_prefix("file://") {
+        s = rest.replace("%20", " ");
+    } else {
+        s = s.replace("\\ ", " ");
+    }
+    let path = PathBuf::from(s);
+    path.is_file().then_some(path)
+}
+
+/// Map an image file extension to its MIME type; `None` for non-images.
+fn image_mime_for(path: &Path) -> Option<&'static str> {
+    match path.extension()?.to_str()?.to_ascii_lowercase().as_str() {
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn image_from_paste_accepts_image_files_only() {
+        let dir = std::env::temp_dir();
+        // Unique per process so parallel test binaries don't collide.
+        let png = dir.join(format!("murmur-paste-{}.png", std::process::id()));
+        std::fs::write(&png, b"\x89PNG\r\n\x1a\nfake").unwrap();
+
+        // plain path and file:// URL both resolve to the image
+        assert!(matches!(
+            image_from_paste(png.to_str().unwrap()),
+            Some(("image/png", _))
+        ));
+        let url = format!("file://{}", png.display());
+        assert!(matches!(image_from_paste(&url), Some(("image/png", _))));
+
+        // non-image file and ordinary text fall through (None)
+        let txt = dir.join(format!("murmur-paste-{}.txt", std::process::id()));
+        std::fs::write(&txt, b"hi").unwrap();
+        assert_eq!(image_from_paste(txt.to_str().unwrap()), None);
+        assert_eq!(image_from_paste("just some pasted words"), None);
+
+        let _ = std::fs::remove_file(&png);
+        let _ = std::fs::remove_file(&txt);
+    }
+
+    #[test]
+    fn image_mime_covers_common_formats() {
+        assert_eq!(image_mime_for(Path::new("a.JPG")), Some("image/jpeg"));
+        assert_eq!(image_mime_for(Path::new("shot.jpeg")), Some("image/jpeg"));
+        assert_eq!(image_mime_for(Path::new("x.gif")), Some("image/gif"));
+        assert_eq!(image_mime_for(Path::new("x.webp")), Some("image/webp"));
+        assert_eq!(image_mime_for(Path::new("notes.txt")), None);
+        assert_eq!(image_mime_for(Path::new("noext")), None);
+    }
+}

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -148,25 +148,22 @@ impl HitlRequest {
     }
 }
 
-/// Mime type for pasted screenshots. The macOS clipboard capture only yields
-/// PNG, so this is fixed; widen if other capture backends are added.
-pub const PASTE_IMAGE_MIME: &str = "image/png";
-
 /// Build the `message/send` params for one turn, threading the previous turn's
 /// task id as `context.task_id` so the agent keeps conversation history.
-/// `image_b64`, when set, is attached as a second A2A `data` part (an inline
-/// screenshot) that the runtime forwards to the model as a vision input.
+/// `image`, when set, is `(mime, base64)` attached as a second A2A `data` part
+/// (an inline screenshot or pasted image file) that the runtime forwards to the
+/// model as a vision input.
 pub fn build_params(
     text: &str,
     task_id: &str,
     context_task_id: Option<&str>,
-    image_b64: Option<&str>,
+    image: Option<(&str, &str)>,
 ) -> Value {
     let mut parts = vec![json!({ "kind": "text", "text": text })];
-    if let Some(b64) = image_b64 {
+    if let Some((mime, b64)) = image {
         parts.push(json!({
             "kind": "data",
-            "mimeType": PASTE_IMAGE_MIME,
+            "mimeType": mime,
             "data": { "base64": b64 },
         }));
     }
@@ -342,13 +339,21 @@ mod tests {
 
     #[test]
     fn build_params_attaches_image_as_data_part() {
-        let p = build_params("what is this?", "t-3", None, Some("QkFTRTY0"));
+        let p = build_params(
+            "what is this?",
+            "t-3",
+            None,
+            Some(("image/png", "QkFTRTY0")),
+        );
         let parts = p["message"]["parts"].as_array().unwrap();
         assert_eq!(parts.len(), 2, "text part + image data part");
         assert_eq!(parts[0]["kind"], "text");
         assert_eq!(parts[1]["kind"], "data");
-        assert_eq!(parts[1]["mimeType"], PASTE_IMAGE_MIME);
+        assert_eq!(parts[1]["mimeType"], "image/png");
         assert_eq!(parts[1]["data"]["base64"], "QkFTRTY0");
+        // A non-PNG paste threads its own mime.
+        let jpg = build_params("x", "t-5", None, Some(("image/jpeg", "QQ==")));
+        assert_eq!(jpg["message"]["parts"][1]["mimeType"], "image/jpeg");
         // No image → no data part (back-compat).
         let plain = build_params("hi", "t-4", None, None);
         assert_eq!(plain["message"]["parts"].as_array().unwrap().len(), 1);


### PR DESCRIPTION
## What
Let `mur agent cli` (murmur) attach an image with **Cmd+V** or **drag-drop**, not just Ctrl+V.

## How
Terminals intercept Cmd+V and paste the clipboard as bracketed **text** — for an image that text is the temp-file **path** the terminal wrote (iTerm2 et al.) or a `file://` URL; the app never sees Cmd+V itself. (This is the same mechanism Claude Code's CLI relies on — it too binds Ctrl+V, and Cmd+V "works" only because the terminal pastes a path.)

New `cli/paste.rs` resolves a bracketed paste:
- an existing **image-file path / `file://` URL** → load it (covers **Cmd+V** and **drag-drop**)
- **empty** paste → try the clipboard image (raw screenshot, terminals that emit an empty paste)
- otherwise → ordinary text into the input

`pending_image` now carries `(mime, base64)` and `build_params` threads it, so **jpeg/gif/webp** send with the correct mime (not just PNG). **Ctrl+V** still grabs the raw clipboard screenshot.

## Verified live
Built the CLI, ran it against a running agent, and injected the exact bracketed-paste sequence a terminal emits on Cmd+V of an image (`ESC[200~<path>ESC[201~`):
- murmur staged it (**"📎 image attached"**), path not inserted as text
- sent to the vision model → it answered **"Blue"** for a blue PNG and **"White"** for a white one (image bytes reach the model end-to-end)

## Notes
- Whether Cmd+V works depends on the terminal pasting a path (iTerm2 ✓; Terminal.app may send nothing for a raw clipboard image → use Ctrl+V).
- Stacks on top of #490 (multi-turn context) but is independent; either can merge first.

## Tests
New `cli::paste` tests (path/file:///non-image/text) + `build_params` mime test. clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)