### PR TITLE
fix(codebase): resolve mur from PATH in auto-index git hook

### DIFF
--- a/mur-core/src/codebase/mod.rs
+++ b/mur-core/src/codebase/mod.rs
@@ -718,7 +718,7 @@ pub fn ensure_git_hook(project_path: &Path, quiet: bool) -> Result<bool> {
     // Resolve mur at hook-run time from PATH (covers brew, cargo, etc.),
     // falling back to the ~/.mur/bin installer location.
     let hook_content = format!(
-        "\n{marker}\nMUR_BIN=\"$(command -v mur || true)\"\n[ -z \"$MUR_BIN\" ] && [ -x \"$HOME/.mur/bin/mur\" ] && MUR_BIN=\"$HOME/.mur/bin/mur\"\nif [ -n \"$MUR_BIN\" ]; then\n  \"$MUR_BIN\" project index \"{path}\" --quiet --background\nfi\n",
+        "\n{marker}\nMUR_BIN=\"$(command -v mur || true)\"\n[ -z \"$MUR_BIN\" ] && [ -x \"$HOME/.mur/bin/mur\" ] && MUR_BIN=\"$HOME/.mur/bin/mur\"\nif [ -n \"$MUR_BIN\" ]; then\n  \"$MUR_BIN\" project index --path \"{path}\" --quiet --background\nfi\n",
         path = project_path.display(),
     );
     if existing.is_empty() {

--- a/mur-core/src/codebase/mod.rs
+++ b/mur-core/src/codebase/mod.rs
@@ -715,15 +715,11 @@ pub fn ensure_git_hook(project_path: &Path, quiet: bool) -> Result<bool> {
     if existing.contains(marker) {
         return Ok(false);
     }
-    let mur_bin = dirs::home_dir()
-        .map(|d| d.join(".mur").join("bin").join("mur"))
-        .unwrap_or_else(|| PathBuf::from("mur"));
+    // Resolve mur at hook-run time from PATH (covers brew, cargo, etc.),
+    // falling back to the ~/.mur/bin installer location.
     let hook_content = format!(
-        "\n{}\nif command -v {} &>/dev/null; then\n  {} project index \"{}\" --quiet --background\nfi\n",
-        marker,
-        mur_bin.display(),
-        mur_bin.display(),
-        project_path.display(),
+        "\n{marker}\nMUR_BIN=\"$(command -v mur || true)\"\n[ -z \"$MUR_BIN\" ] && [ -x \"$HOME/.mur/bin/mur\" ] && MUR_BIN=\"$HOME/.mur/bin/mur\"\nif [ -n \"$MUR_BIN\" ]; then\n  \"$MUR_BIN\" project index \"{path}\" --quiet --background\nfi\n",
+        path = project_path.display(),
     );
     if existing.is_empty() {
         std::fs::write(&hook_path, format!("#!/bin/sh\n{}", hook_content))?;


### PR DESCRIPTION
## What

The generated `post-commit` auto-index hook hardcoded `~/.mur/bin/mur`, so installs that don't use the `~/.mur/bin` installer (brew, cargo) never triggered project auto-indexing.

The hook now resolves the binary at commit time:

```sh
MUR_BIN="$(command -v mur || true)"
[ -z "$MUR_BIN" ] && [ -x "$HOME/.mur/bin/mur" ] && MUR_BIN="$HOME/.mur/bin/mur"
```

PATH lookup covers brew/cargo; the `~/.mur/bin/mur` fallback preserves the legacy installer path.

## Notes

- Existing hook tests (marker / idempotency / append) still cover the change; it's a string swap.
- Pre-existing committed hooks won't self-rewrite (idempotency marker blocks it) — delete the `# mur auto-index` block and re-run `mur project index` once to regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)