### PR TITLE
feat(parallel_jobs): dynamic ephemeral fan-out + deny-by-default authz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-14 (not macos-latest): macos-latest moved to macOS 15 / Xcode 16.4,
-        # whose toolchain is missing the static clang_rt.osx path
-        # (clang/17/lib/darwin), breaking native-dep linking (whisper-rs-sys/espeak-ng)
-        # with "ld: library 'clang_rt.osx' not found". macos-14 (Xcode 15.x) has it.
+        # macos-14: its image bundles Xcode 15.4, which we select below. The
+        # default Xcode 16.4 (now on both macos-14 and macos-latest) breaks the
+        # old vendored whisper.cpp build two ways — clang treats it as pre-C++11
+        # ("no template 'function' in namespace std", ">>" errors) and the link
+        # can't find clang_rt.osx (clang/17/lib/darwin missing). 15.4 builds it.
         os: [ubuntu-latest, macos-14, windows-latest]
     steps:
       - uses: actions/checkout@v6
@@ -100,6 +101,13 @@ jobs:
           # whisper-rs-sys CMakeCache.txt and CMake aborts on generator
           # mismatch. Keying on ImageVersion forces a fresh build on bump.
           key: ${{ env.ImageOS }}-${{ env.ImageVersion }}
+      - name: Select Xcode 15.4 (macOS)
+        if: runner.os == 'macOS'
+        # The runner's default Xcode 16.4 breaks the old vendored whisper.cpp
+        # build (pre-C++11 clang errors) and the clang_rt.osx link. Xcode 15.4
+        # (bundled on macos-14) builds + links it cleanly. Set before any cargo
+        # build so build scripts (cc/cmake) use the right toolchain.
+        run: sudo xcode-select -s /Applications/Xcode_15.4.app
       - name: Install Linux system deps
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # macos-14 (not macos-latest): macos-latest moved to macOS 15 / Xcode 16.4,
+        # whose toolchain is missing the static clang_rt.osx path
+        # (clang/17/lib/darwin), breaking native-dep linking (whisper-rs-sys/espeak-ng)
+        # with "ld: library 'clang_rt.osx' not found". macos-14 (Xcode 15.x) has it.
+        os: [ubuntu-latest, macos-14, windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,29 +1081,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.13.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex 1.3.0",
- "syn 2.0.118",
- "which",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -1112,6 +1089,8 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
+ "log",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -1779,7 +1758,7 @@ version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
 ]
 
 [[package]]
@@ -4129,15 +4108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4901,15 +4871,6 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -5724,12 +5685,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lebe"
@@ -10836,36 +10791,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "whisper-rs"
-version = "0.11.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7a191078e189d96d029244ab1dff159775adec71dc89a222e9bb9d21a7d161"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
 dependencies = [
  "whisper-rs-sys",
 ]
 
 [[package]]
 name = "whisper-rs-sys"
-version = "0.9.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834f4ca6472b02748c6c282a60cea538f962428f79e685c3205a08efd711336"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "cfg-if",
  "cmake",
  "fs_extra",
+ "semver",
 ]
 
 [[package]]

--- a/docs/superpowers/plans/2026-06-24-mur-fleet-job-intake-and-management.md
+++ b/docs/superpowers/plans/2026-06-24-mur-fleet-job-intake-and-management.md
@@ -1,0 +1,1495 @@
+# MUR Fleet — Job Intake & Roster Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an operator dispatch work to a fleet by command (`send` / `run "<job>"` / `jobs`) instead of hand-editing `fleet.yaml`'s `goal`, and add first-class `add` / `remove` / `delete` plus a scannable `list`.
+
+**Architecture:** A fleet stays a durable squad; `goal` becomes the standing-mission default. Work enters as a **job** — a small YAML record under `~/.mur/fleets/<name>/jobs/<uuidv7>.yaml` whose status enum mirrors the A2A Task lifecycle. The existing `run` / `run --loop` / daemon `fleet_tick` executors drain the queue (oldest first) — no new daemon, no new loop. Roster commands keep `fleet.yaml` and the shared channel `fleet-<name>` in sync via new `ChannelService` participant/delete primitives.
+
+**Tech Stack:** Rust (edition 2024), `serde` / `serde_yaml`, `uuid` (v7, time-sortable), `chrono`, `clap` (derive), `anyhow`. Tests via `cargo nextest`.
+
+## Global Constraints
+
+- **No hardcoded values** — constants/config/env, never literals for tunables (Mandatory Rule 1).
+- **Single source file ≤ 800 lines** — new surface goes in new sibling modules, never bolted onto the already-large `import.rs` / `loop_run.rs` (Mandatory Rule 4).
+- **mur-core build/test requires `ORT_STRATEGY=download`** and **`cargo nextest`** (plain `cargo test --workspace` fails spuriously). mur-common / mur-channel don't need the env var.
+- **Fleet name is validated everywhere** it forms a path — call `mur_common::fleet::valid_fleet_name` at every job-store entry point (defense-in-depth, matches `store::save_fleet`).
+- **Fail-closed execution** — every DAG run passes `DagExecOptions { yes: false, .. }`. A job is a plain goal string; it grants no new authority and is never shell/path-interpolated.
+- **Brand:** user-facing text says "MUR"; the CLI/command/dir slug stays lowercase `mur`.
+
+---
+
+## File Structure
+
+- `mur-common/src/fleet.rs` — **modify**: add `Job` struct + `JobStatus` enum (pure data, no I/O).
+- `mur-core/src/cmd/fleet/jobs.rs` — **create**: job store API + `send` / `jobs` commands.
+- `mur-core/src/cmd/fleet/store.rs` — **modify**: nothing required (jobs.rs derives paths from `fleet_dir`).
+- `mur-core/src/cmd/fleet/run.rs` — **modify**: goal resolution (arg > queued > standing goal) + job lifecycle stamping.
+- `mur-core/src/cmd/fleet/loop_run.rs` — **modify**: per-iteration queue drain (this also covers the daemon, which calls `cmd_fleet_run_loop`).
+- `mur-core/src/cmd/fleet/list.rs` — **modify**: aligned-table renderer.
+- `mur-core/src/cmd/fleet/roster.rs` — **create**: `add` / `remove`.
+- `mur-core/src/cmd/fleet/delete.rs` — **create**: `delete`.
+- `mur-core/src/cmd/fleet/mod.rs` — **modify**: declare `jobs`, `roster`, `delete`.
+- `mur-channel/src/service.rs` — **modify**: `add_participant` / `remove_participant` / `delete_channel`.
+- `mur-channel/src/store.rs` — **modify**: `delete` (remove channel dir).
+- `mur-channel/src/index.rs` — **modify**: `remove` (delete the read-model row).
+- `mur-core/src/cli/actions.rs` — **modify**: `FleetAction::{Send, Jobs, Add, Remove, Delete}` + `Run.job`.
+- `mur-core/src/dispatch.rs` — **modify**: wire the new actions.
+- `mur-core/tests/cli_fleet.rs` — **modify**: end-to-end round-trip.
+
+---
+
+## Task 1: Job model (`Job` + `JobStatus`)
+
+**Files:**
+- Modify: `mur-common/src/fleet.rs` (append after the `FleetLoop` block)
+- Test: `mur-common/src/fleet.rs` (the existing `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `mur_common::fleet::Job { id, text, source, status, created_at, started_at, finished_at, run_id, result, error }`; `mur_common::fleet::JobStatus::{Queued, Running, Done, Failed, Canceled}` with `is_terminal(&self) -> bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` block in `mur-common/src/fleet.rs`:
+
+```rust
+#[test]
+fn job_status_serde_is_lowercase_and_terminal_predicate() {
+    assert_eq!(serde_yaml::to_string(&JobStatus::Queued).unwrap().trim(), "queued");
+    assert_eq!(serde_yaml::to_string(&JobStatus::Done).unwrap().trim(), "done");
+    assert!(!JobStatus::Queued.is_terminal());
+    assert!(!JobStatus::Running.is_terminal());
+    assert!(JobStatus::Done.is_terminal());
+    assert!(JobStatus::Failed.is_terminal());
+    assert!(JobStatus::Canceled.is_terminal());
+}
+
+#[test]
+fn job_yaml_roundtrip_with_optional_fields_skipped() {
+    let j = Job {
+        id: "0190f3a2-0000-7000-8000-000000000000".into(),
+        text: "ship it".into(),
+        source: "cli".into(),
+        status: JobStatus::Queued,
+        created_at: "2026-06-24T00:00:00Z".into(),
+        started_at: None,
+        finished_at: None,
+        run_id: None,
+        result: None,
+        error: None,
+    };
+    let yaml = serde_yaml::to_string(&j).unwrap();
+    assert!(!yaml.contains("started_at"), "None optionals must be skipped: {yaml}");
+    let back: Job = serde_yaml::from_str(&yaml).unwrap();
+    assert_eq!(back, j);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run -p mur-common job_status_serde job_yaml_roundtrip`
+Expected: FAIL — `cannot find type Job` / `JobStatus`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `mur-common/src/fleet.rs` (before the `#[cfg(test)]` block):
+
+```rust
+/// A unit of work handed to a fleet. Status mirrors the A2A Task lifecycle so
+/// A2A intake (follow-on) can treat a job AS an A2A Task with no model change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JobStatus {
+    Queued,   // A2A: submitted
+    Running,  // A2A: working
+    Done,     // A2A: completed
+    Failed,   // A2A: failed
+    Canceled, // A2A: canceled
+}
+
+impl JobStatus {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, JobStatus::Done | JobStatus::Failed | JobStatus::Canceled)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Job {
+    /// UUIDv7 — time-sortable, so FIFO ordering is just a filename sort.
+    pub id: String,
+    pub text: String,
+    /// "cli" | "a2a:<agent-id>" (a2a is follow-on).
+    pub source: String,
+    pub status: JobStatus,
+    /// RFC3339 timestamps.
+    pub created_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<String>,
+    /// Channel run that executed the job (results live there).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run -p mur-common job_status_serde job_yaml_roundtrip`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/fleet.rs
+git commit -m "feat(fleet): Job + JobStatus model (A2A-aligned lifecycle)"
+```
+
+---
+
+## Task 2: Jobs store API
+
+**Files:**
+- Create: `mur-core/src/cmd/fleet/jobs.rs`
+- Modify: `mur-core/src/cmd/fleet/mod.rs` (add `pub mod jobs;`)
+- Test: in `jobs.rs` `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Consumes: `mur_common::fleet::{Job, JobStatus, valid_fleet_name}`; `super::store::fleet_dir`.
+- Produces: `jobs::jobs_dir(home,&str)->PathBuf`; `jobs::enqueue_job(home,&str,text:&str,source:&str)->Result<Job>`; `jobs::save_job(home,&str,&Job)->Result<()>`; `jobs::list_jobs(home,&str)->Result<Vec<Job>>`; `jobs::next_queued(home,&str)->Result<Option<Job>>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-core/src/cmd/fleet/jobs.rs` with ONLY the test module first (the impl comes in Step 3):
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::fleet::JobStatus;
+
+    #[test]
+    fn enqueue_list_next_fifo_and_update() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let a = enqueue_job(home, "dev", "first", "cli").unwrap();
+        let b = enqueue_job(home, "dev", "second", "cli").unwrap();
+        assert_ne!(a.id, b.id);
+
+        let all = list_jobs(home, "dev").unwrap();
+        assert_eq!(all.len(), 2);
+        // uuid v7 => creation order
+        assert_eq!(all[0].text, "first");
+        assert_eq!(all[1].text, "second");
+
+        // oldest queued is `a`
+        assert_eq!(next_queued(home, "dev").unwrap().unwrap().id, a.id);
+
+        // mark `a` running => next_queued skips it
+        let mut a2 = a.clone();
+        a2.status = JobStatus::Running;
+        save_job(home, "dev", &a2).unwrap();
+        assert_eq!(next_queued(home, "dev").unwrap().unwrap().id, b.id);
+    }
+
+    #[test]
+    fn invalid_fleet_name_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(enqueue_job(tmp.path(), "../evil", "x", "cli").is_err());
+    }
+
+    #[test]
+    fn list_empty_when_no_jobs_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(list_jobs(tmp.path(), "dev").unwrap().is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core enqueue_list_next_fifo`
+Expected: FAIL — `cannot find function enqueue_job`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Prepend to `mur-core/src/cmd/fleet/jobs.rs` (above the test module):
+
+```rust
+//! Fleet job queue — small YAML records under `~/.mur/fleets/<name>/jobs/`.
+//! A job is a unit of work handed to a fleet by command; it becomes the goal
+//! for one run. FIFO ordering is the UUIDv7 filename sort (no index file).
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use mur_common::fleet::{Job, JobStatus, valid_fleet_name};
+
+use super::store;
+
+pub fn jobs_dir(mur_home: &Path, fleet: &str) -> PathBuf {
+    store::fleet_dir(mur_home, fleet).join("jobs")
+}
+
+fn job_path(mur_home: &Path, fleet: &str, id: &str) -> PathBuf {
+    jobs_dir(mur_home, fleet).join(format!("{id}.yaml"))
+}
+
+/// Write a new queued job and return it.
+pub fn enqueue_job(mur_home: &Path, fleet: &str, text: &str, source: &str) -> Result<Job> {
+    let job = Job {
+        id: uuid::Uuid::now_v7().to_string(),
+        text: text.to_string(),
+        source: source.to_string(),
+        status: JobStatus::Queued,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        started_at: None,
+        finished_at: None,
+        run_id: None,
+        result: None,
+        error: None,
+    };
+    save_job(mur_home, fleet, &job)?;
+    Ok(job)
+}
+
+/// Atomic write (temp + rename), matching `store::save_fleet`.
+pub fn save_job(mur_home: &Path, fleet: &str, job: &Job) -> Result<()> {
+    if !valid_fleet_name(fleet) {
+        bail!("invalid fleet name '{fleet}': use lowercase letters, digits, '-' or '_'");
+    }
+    let dir = jobs_dir(mur_home, fleet);
+    std::fs::create_dir_all(&dir).with_context(|| format!("create jobs dir {}", dir.display()))?;
+    let path = job_path(mur_home, fleet, &job.id);
+    let yaml = serde_yaml::to_string(job).context("serialize job")?;
+    let tmp = path.with_extension("yaml.tmp");
+    std::fs::write(&tmp, yaml).with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, &path).with_context(|| format!("rename to {}", path.display()))?;
+    Ok(())
+}
+
+/// All jobs sorted oldest-first (UUIDv7 lexical sort == time order).
+pub fn list_jobs(mur_home: &Path, fleet: &str) -> Result<Vec<Job>> {
+    if !valid_fleet_name(fleet) {
+        bail!("invalid fleet name '{fleet}'");
+    }
+    let dir = jobs_dir(mur_home, fleet);
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut jobs = Vec::new();
+    for entry in std::fs::read_dir(&dir).with_context(|| format!("read {}", dir.display()))? {
+        let path = entry?.path();
+        // Skip the *.yaml.tmp atomic-write staging files (extension == "tmp").
+        if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+            continue;
+        }
+        if let Ok(s) = std::fs::read_to_string(&path)
+            && let Ok(j) = serde_yaml::from_str::<Job>(&s)
+        {
+            jobs.push(j);
+        }
+    }
+    jobs.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(jobs)
+}
+
+/// The oldest `Queued` job, if any.
+pub fn next_queued(mur_home: &Path, fleet: &str) -> Result<Option<Job>> {
+    Ok(list_jobs(mur_home, fleet)?
+        .into_iter()
+        .find(|j| j.status == JobStatus::Queued))
+}
+```
+
+Add to `mur-core/src/cmd/fleet/mod.rs`:
+
+```rust
+pub mod jobs;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core -E 'test(/enqueue_list_next_fifo|invalid_fleet_name_refused|list_empty_when_no_jobs_dir/)'`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/fleet/jobs.rs mur-core/src/cmd/fleet/mod.rs
+git commit -m "feat(fleet): job queue store API (enqueue/list/next_queued/save)"
+```
+
+---
+
+## Task 3: `mur fleet send` + `mur fleet jobs` commands + CLI wiring
+
+**Files:**
+- Modify: `mur-core/src/cmd/fleet/jobs.rs` (add the two command fns + tests)
+- Modify: `mur-core/src/cli/actions.rs` (`FleetAction::Send`, `FleetAction::Jobs`)
+- Modify: `mur-core/src/dispatch.rs` (wire them)
+
+**Interfaces:**
+- Consumes: `store::load_fleet`, `jobs::{enqueue_job, list_jobs}`.
+- Produces: `jobs::cmd_fleet_send(home,fleet,text)->Result<()>`; `jobs::cmd_fleet_jobs(home,fleet,all:bool)->Result<()>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` in `jobs.rs`:
+
+```rust
+#[test]
+fn send_requires_existing_fleet_then_enqueues() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    // no fleet yet → error
+    assert!(cmd_fleet_send(home, "dev", "do it").is_err());
+    super::super::create::cmd_fleet_create(home, "dev", vec!["pm".into()], None, None).unwrap();
+    cmd_fleet_send(home, "dev", "do it").unwrap();
+    let jobs = list_jobs(home, "dev").unwrap();
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].text, "do it");
+    assert_eq!(jobs[0].source, "cli");
+    // jobs view runs without panicking on an existing fleet
+    cmd_fleet_jobs(home, "dev", true).unwrap();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core send_requires_existing_fleet`
+Expected: FAIL — `cannot find function cmd_fleet_send`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `mur-core/src/cmd/fleet/jobs.rs` (above the test module):
+
+```rust
+/// `mur fleet send <name> "<job>"` — enqueue a job (asynchronous).
+pub fn cmd_fleet_send(mur_home: &Path, fleet: &str, text: &str) -> Result<()> {
+    let _ = store::load_fleet(mur_home, fleet)?; // validates name + existence
+    let job = enqueue_job(mur_home, fleet, text, "cli")?;
+    println!(
+        "Queued job {} for fleet '{fleet}'. Drain it with `mur fleet run {fleet}` (or the daemon).",
+        job.id
+    );
+    Ok(())
+}
+
+/// `mur fleet jobs <name> [--all]` — list jobs and their status.
+pub fn cmd_fleet_jobs(mur_home: &Path, fleet: &str, all: bool) -> Result<()> {
+    let _ = store::load_fleet(mur_home, fleet)?;
+    let jobs = list_jobs(mur_home, fleet)?;
+    let shown: Vec<&Job> = jobs
+        .iter()
+        .filter(|j| all || !j.status.is_terminal())
+        .collect();
+    if shown.is_empty() {
+        println!("No jobs. Queue one: mur fleet send {fleet} \"<job>\"");
+        return Ok(());
+    }
+    for j in shown {
+        let short = &j.id[..j.id.len().min(8)];
+        let status = format!("{:?}", j.status).to_lowercase();
+        let note = j.error.as_deref().or(j.result.as_deref()).unwrap_or("");
+        let text = if j.text.chars().count() > 50 {
+            format!("{}…", j.text.chars().take(49).collect::<String>())
+        } else {
+            j.text.clone()
+        };
+        println!("{short}  {status:<9}  {text}  {note}");
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core send_requires_existing_fleet`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the CLI**
+
+In `mur-core/src/cli/actions.rs`, add to `enum FleetAction` (after `Run`):
+
+```rust
+    /// Queue a job for a fleet (async; drained by `run` or the daemon)
+    Send {
+        /// Fleet name
+        name: String,
+        /// The job text (becomes the goal for one run)
+        job: String,
+    },
+    /// List a fleet's jobs and their status
+    Jobs {
+        /// Fleet name
+        name: String,
+        /// Include terminal (done/failed/canceled) jobs
+        #[arg(long)]
+        all: bool,
+    },
+```
+
+In `mur-core/src/dispatch.rs`, add to the `match action` arms:
+
+```rust
+                FleetAction::Send { name, job } => {
+                    cmd::fleet::jobs::cmd_fleet_send(&mur_home, &name, &job)?
+                }
+                FleetAction::Jobs { name, all } => {
+                    cmd::fleet::jobs::cmd_fleet_jobs(&mur_home, &name, all)?
+                }
+```
+
+- [ ] **Step 6: Verify it builds + lints**
+
+Run: `ORT_STRATEGY=download cargo clippy -p mur-core -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-core/src/cmd/fleet/jobs.rs mur-core/src/cli/actions.rs mur-core/src/dispatch.rs
+git commit -m "feat(fleet): mur fleet send + jobs commands"
+```
+
+---
+
+## Task 4: `mur fleet run [<job>]` goal resolution + job lifecycle
+
+**Files:**
+- Modify: `mur-core/src/cmd/fleet/run.rs`
+- Modify: `mur-core/src/cli/actions.rs` (`Run.job`)
+- Modify: `mur-core/src/dispatch.rs` (pass `job`; loop path enqueues then loops)
+
+**Interfaces:**
+- Consumes: `jobs::{enqueue_job, next_queued, save_job}`, `mur_common::fleet::{Fleet, Job, JobStatus}`.
+- Produces: `run::cmd_fleet_run(home, name, job_arg: Option<String>) -> Result<()>` (signature change — add the `job_arg` param).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` in `run.rs`:
+
+```rust
+#[test]
+fn resolve_goal_prefers_arg_then_queued_then_standing() {
+    // pure resolution helper — no execution
+    use mur_common::fleet::JobStatus;
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    super::super::create::cmd_fleet_create(home, "dev", vec!["pm".into()], None, Some("standing".into())).unwrap();
+
+    // no arg, empty queue => standing goal
+    let (goal, job) = resolve_run_goal(home, "dev", None, "standing").unwrap();
+    assert_eq!(goal, "standing");
+    assert!(job.is_none());
+
+    // queued job => that job's text, marked running
+    super::super::jobs::enqueue_job(home, "dev", "queued-work", "cli").unwrap();
+    let (goal, job) = resolve_run_goal(home, "dev", None, "standing").unwrap();
+    assert_eq!(goal, "queued-work");
+    assert_eq!(job.as_ref().unwrap().status, JobStatus::Running);
+
+    // explicit arg jumps ahead of the queue
+    let (goal, job) = resolve_run_goal(home, "dev", Some("urgent".into()), "standing").unwrap();
+    assert_eq!(goal, "urgent");
+    assert_eq!(job.unwrap().text, "urgent");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core resolve_goal_prefers_arg`
+Expected: FAIL — `cannot find function resolve_run_goal`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `mur-core/src/cmd/fleet/run.rs`, add this helper (above `cmd_fleet_run`):
+
+```rust
+use mur_common::fleet::{Job, JobStatus};
+
+/// Resolve this run's goal: explicit arg > oldest queued job > standing goal.
+/// When a job backs the run it is enqueued (arg) and marked `Running` here so
+/// the queue cursor advances atomically before execution.
+pub fn resolve_run_goal(
+    mur_home: &Path,
+    name: &str,
+    job_arg: Option<String>,
+    standing_goal: &str,
+) -> Result<(String, Option<Job>)> {
+    let mut active: Option<Job> = match job_arg {
+        Some(text) => Some(super::jobs::enqueue_job(mur_home, name, &text, "cli")?),
+        None => super::jobs::next_queued(mur_home, name)?,
+    };
+    let goal = active
+        .as_ref()
+        .map(|j| j.text.clone())
+        .unwrap_or_else(|| standing_goal.to_string());
+    if let Some(job) = active.as_mut() {
+        job.status = JobStatus::Running;
+        job.started_at = Some(chrono::Utc::now().to_rfc3339());
+        super::jobs::save_job(mur_home, name, job)?;
+    }
+    Ok((goal, active))
+}
+```
+
+Now change `cmd_fleet_run`'s signature and body. Replace the current `pub async fn cmd_fleet_run(mur_home: &Path, name: &str) -> Result<()> {` through the `let proc = ...; let opts = ...;` section with:
+
+```rust
+pub async fn cmd_fleet_run(mur_home: &Path, name: &str, job_arg: Option<String>) -> Result<()> {
+    let fleet = store::load_fleet(mur_home, name)?;
+    if fleet.members.is_empty() {
+        bail!("fleet '{name}' has no members");
+    }
+    if super::control::is_stopped(mur_home, name) {
+        bail!("fleet '{name}' is stopped (kill-switch). Run `mur fleet start {name}` to re-enable.");
+    }
+    let (goal, mut active_job) = resolve_run_goal(mur_home, name, job_arg, &fleet.goal)?;
+    if goal.is_empty() {
+        bail!("fleet '{name}' has no goal and no queued job; pass one: mur fleet run {name} \"<job>\"");
+    }
+    let svc = mur_channel::ChannelService::open(mur_home)?;
+    let events = svc.load_events(&fleet.channel_id)?;
+    let since = events.last().map(|e| e.seq).unwrap_or(0);
+    // Plan with the resolved goal (override the standing goal for this run).
+    let planning_fleet = mur_common::fleet::Fleet { goal: goal.clone(), ..fleet.clone() };
+    let proc = super::plan::plan_via_router(mur_home, &planning_fleet, &events)
+        .unwrap_or_else(|| build_fleet_procedure(&goal, &fleet.members));
+    let run_id = format!("run-{}", uuid::Uuid::now_v7());
+    let opts = crate::executor::dag::DagExecOptions {
+        yes: false,
+        channel_id: Some(fleet.channel_id.clone()),
+        run_id: run_id.clone(),
+        ..Default::default()
+    };
+    let result =
+        crate::executor::dag::execute_dag(mur_home, &format!("fleet:{}", fleet.name), &proc, &opts)
+            .await;
+
+    // Stamp the job terminal (if a job backed this run).
+    if let Some(job) = active_job.as_mut() {
+        job.run_id = Some(run_id);
+        job.finished_at = Some(chrono::Utc::now().to_rfc3339());
+        match &result {
+            Ok(out) => {
+                job.status = JobStatus::Done;
+                job.result = out.output_text.clone().filter(|t| !t.is_empty());
+            }
+            Err(e) => {
+                job.status = JobStatus::Failed;
+                job.error = Some(format!("{e:#}"));
+            }
+        }
+        super::jobs::save_job(mur_home, name, job)?;
+    }
+    let out = result?;
+    if let Some(t) = out.output_text.filter(|t| !t.is_empty()) {
+        println!("{t}");
+    }
+```
+
+The existing reply-tail loop (filtering `e.seq > since`) and the closing `Ok(())` stay unchanged below this point.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core resolve_goal_prefers_arg`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the CLI arg**
+
+In `mur-core/src/cli/actions.rs`, add the optional positional to `FleetAction::Run`:
+
+```rust
+        /// Optional job text — runs this as a one-shot (jumps ahead of the queue)
+        job: Option<String>,
+```
+
+(Place it after `name` and before `loop_flag` so the positional binds correctly.)
+
+In `mur-core/src/dispatch.rs`, update the `FleetAction::Run` arm — destructure `job` and route it:
+
+```rust
+                FleetAction::Run {
+                    name,
+                    job,
+                    loop_flag,
+                    max_iterations,
+                    deadline,
+                    budget_usd,
+                } => {
+                    if loop_flag {
+                        // A job arg with --loop is enqueued, then the loop drains it.
+                        if let Some(text) = job {
+                            cmd::fleet::jobs::enqueue_job(&mur_home, &name, &text, "cli")?;
+                        }
+                        cmd::fleet::loop_run::cmd_fleet_run_loop(
+                            &mur_home, &name, max_iterations, deadline, budget_usd,
+                        )
+                        .await?
+                    } else {
+                        cmd::fleet::run::cmd_fleet_run(&mur_home, &name, job).await?
+                    }
+                }
+```
+
+- [ ] **Step 6: Verify build + lint**
+
+Run: `ORT_STRATEGY=download cargo clippy -p mur-core -- -D warnings`
+Expected: clean (also confirms the new `cmd_fleet_run` arity matches every caller).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-core/src/cmd/fleet/run.rs mur-core/src/cli/actions.rs mur-core/src/dispatch.rs
+git commit -m "feat(fleet): run [<job>] resolves arg>queued>goal + stamps job lifecycle"
+```
+
+---
+
+## Task 5: Per-iteration queue drain in `run --loop` (covers the daemon)
+
+**Files:**
+- Modify: `mur-core/src/cmd/fleet/loop_run.rs`
+
+**Interfaces:**
+- Consumes: `jobs::{next_queued, save_job}`, `mur_common::fleet::{Fleet, Job, JobStatus}`.
+- Produces: no new public symbol; behavior change only. (The daemon `fleet_tick` calls `cmd_fleet_run_loop`, so this drain is automatically active for daemon auto-run too.)
+
+- [ ] **Step 1: Write the failing test**
+
+Add a focused unit test to the `mod tests` in `loop_run.rs` that exercises the per-iteration goal resolution in isolation (no executor). First extract the resolution into a tiny helper so it is testable:
+
+```rust
+#[test]
+fn iteration_goal_drains_queue_then_falls_back_to_standing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    super::super::create::cmd_fleet_create(home, "dev", vec!["pm".into()], None, Some("standing".into())).unwrap();
+
+    // empty queue => standing goal, no job
+    let (g, j) = iteration_goal(home, "dev", "standing").unwrap();
+    assert_eq!(g, "standing");
+    assert!(j.is_none());
+
+    // queued job => its text, marked running
+    super::super::jobs::enqueue_job(home, "dev", "job-1", "cli").unwrap();
+    let (g, j) = iteration_goal(home, "dev", "standing").unwrap();
+    assert_eq!(g, "job-1");
+    assert_eq!(j.unwrap().status, mur_common::fleet::JobStatus::Running);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core iteration_goal_drains_queue`
+Expected: FAIL — `cannot find function iteration_goal`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add this helper to `loop_run.rs` (module level, above `cmd_fleet_run_loop`):
+
+```rust
+use mur_common::fleet::{Job, JobStatus};
+
+/// Resolve one loop iteration's goal: oldest queued job > standing goal.
+/// Marks the chosen job `Running` so the queue cursor advances before the run.
+fn iteration_goal(mur_home: &Path, name: &str, standing_goal: &str) -> Result<(String, Option<Job>)> {
+    let mut job = super::jobs::next_queued(mur_home, name)?;
+    let goal = job
+        .as_ref()
+        .map(|j| j.text.clone())
+        .unwrap_or_else(|| standing_goal.to_string());
+    if let Some(j) = job.as_mut() {
+        j.status = JobStatus::Running;
+        j.started_at = Some(chrono::Utc::now().to_rfc3339());
+        super::jobs::save_job(mur_home, name, j)?;
+    }
+    Ok((goal, job))
+}
+```
+
+Now wire it into the loop body. Replace the planning lines (currently):
+
+```rust
+        let pre_events = svc.load_events(&fleet.channel_id).unwrap_or_default();
+        let proc = super::plan::plan_via_router(mur_home, &fleet, &pre_events)
+            .unwrap_or_else(|| build_fleet_procedure(&fleet.goal, &fleet.members));
+```
+
+with:
+
+```rust
+        let pre_events = svc.load_events(&fleet.channel_id).unwrap_or_default();
+        // Drain the job queue: oldest queued job is this iteration's goal; else the standing goal.
+        let (iter_goal, mut active_job) = iteration_goal(mur_home, name, &fleet.goal)?;
+        let planning_fleet = mur_common::fleet::Fleet { goal: iter_goal.clone(), ..fleet.clone() };
+        let proc = super::plan::plan_via_router(mur_home, &planning_fleet, &pre_events)
+            .unwrap_or_else(|| build_fleet_procedure(&iter_goal, &fleet.members));
+```
+
+After the `execute_dag(...).await?` line and the `iteration += 1;` line, add the terminal stamp:
+
+```rust
+        if let Some(job) = active_job.as_mut() {
+            job.run_id = Some(opts.run_id.clone());
+            job.finished_at = Some(chrono::Utc::now().to_rfc3339());
+            job.status = JobStatus::Done;
+            job.result = out.output_text.clone().filter(|t| !t.is_empty());
+            let _ = super::jobs::save_job(mur_home, name, job);
+        }
+```
+
+(`out` is the `execute_dag` result already bound in the loop; `opts.run_id` is still in scope. Note: the loop propagates executor errors via `?` today, so a failed iteration aborts the loop before this stamp — the job stays `Running`, which is correct: it was not completed. No silent retry.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core iteration_goal_drains_queue`
+Expected: PASS.
+
+- [ ] **Step 5: Verify build + lint**
+
+Run: `ORT_STRATEGY=download cargo clippy -p mur-core -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/cmd/fleet/loop_run.rs
+git commit -m "feat(fleet): drain job queue per loop iteration (also covers daemon auto-run)"
+```
+
+---
+
+## Task 6: `mur fleet list` aligned table
+
+**Files:**
+- Modify: `mur-core/src/cmd/fleet/list.rs`
+
+**Interfaces:**
+- Consumes: `store::{list_fleets, load_fleet}`, `control::is_stopped`, `jobs::list_jobs`, `mur_common::fleet::JobStatus`.
+- Produces: `list::status_symbol(stopped: bool, running: bool) -> &'static str`; `list::truncate_goal(goal: &str, width: usize) -> String` (testable pure helpers).
+
+- [ ] **Step 1: Write the failing test**
+
+Add a `#[cfg(test)] mod tests` to `list.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_symbol_precedence() {
+        assert_eq!(status_symbol(true, true), "⏸");   // stopped wins over running
+        assert_eq!(status_symbol(true, false), "⏸");
+        assert_eq!(status_symbol(false, true), "▶");
+        assert_eq!(status_symbol(false, false), "●");
+    }
+
+    #[test]
+    fn truncate_goal_collapses_newlines_and_caps_width() {
+        assert_eq!(truncate_goal("a\nb\nc", 80), "a b c");
+        let long = "x".repeat(100);
+        let out = truncate_goal(&long, 10);
+        assert!(out.chars().count() <= 10, "got {} chars", out.chars().count());
+        assert!(out.ends_with('…'));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core status_symbol_precedence truncate_goal_collapses`
+Expected: FAIL — `cannot find function status_symbol`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the body of `mur-core/src/cmd/fleet/list.rs` with:
+
+```rust
+//! `mur fleet list` — aligned table: NAME / ST / MEM / JOBS / ROUTER / GOAL.
+
+use std::path::Path;
+
+use anyhow::Result;
+use mur_common::fleet::JobStatus;
+
+use super::{control, jobs, store};
+
+/// Status glyph: stopped (kill-switch) wins over running, else idle.
+pub fn status_symbol(stopped: bool, running: bool) -> &'static str {
+    if stopped {
+        "⏸"
+    } else if running {
+        "▶"
+    } else {
+        "●"
+    }
+}
+
+/// Collapse newlines to spaces and truncate to `width` chars with an ellipsis.
+pub fn truncate_goal(goal: &str, width: usize) -> String {
+    let one_line = goal.split_whitespace().collect::<Vec<_>>().join(" ");
+    if one_line.chars().count() <= width {
+        return one_line;
+    }
+    let keep = width.saturating_sub(1);
+    format!("{}…", one_line.chars().take(keep).collect::<String>())
+}
+
+/// Terminal width from $COLUMNS, default 80.
+fn term_width() -> usize {
+    std::env::var("COLUMNS")
+        .ok()
+        .and_then(|c| c.parse::<usize>().ok())
+        .filter(|w| *w >= 40)
+        .unwrap_or(80)
+}
+
+pub fn cmd_fleet_list(mur_home: &Path) -> Result<()> {
+    let names = store::list_fleets(mur_home)?;
+    if names.is_empty() {
+        println!("No fleets. Create one: mur fleet create <name> --members a,b,c --goal \"...\"");
+        return Ok(());
+    }
+
+    // Gather rows first so column widths fit the data.
+    struct Row {
+        name: String,
+        st: &'static str,
+        mem: usize,
+        queued: usize,
+        router: String,
+        goal: String,
+    }
+    let mut rows = Vec::new();
+    for n in &names {
+        let f = store::load_fleet(mur_home, n)?;
+        let job_list = jobs::list_jobs(mur_home, n).unwrap_or_default();
+        let running = job_list.iter().any(|j| j.status == JobStatus::Running);
+        let queued = job_list.iter().filter(|j| j.status == JobStatus::Queued).count();
+        rows.push(Row {
+            name: f.name.clone(),
+            st: status_symbol(control::is_stopped(mur_home, n), running),
+            mem: f.members.len(),
+            queued,
+            router: f.router_or_concierge().to_string(),
+            goal: f.goal.clone(),
+        });
+    }
+
+    let name_w = rows.iter().map(|r| r.name.chars().count()).max().unwrap_or(4).max(4);
+    let router_w = rows.iter().map(|r| r.router.chars().count()).max().unwrap_or(6).max(6);
+    // GOAL gets the terminal remainder after the fixed columns and their
+    // 2-space gaps: ST(2)+MEM(4)+JOBS(4)=10 fixed-width cols, plus NAME +
+    // ROUTER, plus five 2-space gaps (=10).
+    let fixed = name_w + router_w + 10 + 10;
+    let goal_w = term_width().saturating_sub(fixed).max(20);
+
+    println!(
+        "{:<name_w$}  {:<2}  {:<4}  {:<4}  {:<router_w$}  {}",
+        "NAME", "ST", "MEM", "JOBS", "ROUTER", "GOAL"
+    );
+    for r in &rows {
+        println!(
+            "{:<name_w$}  {:<2}  {:<4}  {:<4}  {:<router_w$}  {}",
+            r.name,
+            r.st,
+            r.mem,
+            r.queued,
+            r.router,
+            truncate_goal(&r.goal, goal_w),
+        );
+    }
+    println!("\n● idle   ⏸ stopped   ▶ running");
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core status_symbol_precedence truncate_goal_collapses`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Verify build + lint**
+
+Run: `ORT_STRATEGY=download cargo clippy -p mur-core -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/cmd/fleet/list.rs
+git commit -m "feat(fleet): aligned list table with status + job count, truncated goal"
+```
+
+---
+
+## Task 7: Channel primitives — add/remove participant + delete
+
+**Files:**
+- Modify: `mur-channel/src/store.rs` (`delete`)
+- Modify: `mur-channel/src/index.rs` (`remove`)
+- Modify: `mur-channel/src/service.rs` (`add_participant`, `remove_participant`, `delete_channel`)
+
+**Interfaces:**
+- Consumes: `ChannelStore::{load_manifest, save_manifest}`, `ChannelIndex::upsert`, `mur_common::channel::{ChannelActor, Participant, ParticipantRole}`.
+- Produces:
+  - `ChannelStore::delete(&self, id:&str) -> Result<()>`
+  - `ChannelIndex::remove(&self, id:&str) -> Result<()>`
+  - `ChannelService::add_participant(&self, channel_id:&str, agent_id:&str, role:ParticipantRole) -> Result<()>`
+  - `ChannelService::remove_participant(&self, channel_id:&str, agent_id:&str) -> Result<()>`
+  - `ChannelService::delete_channel(&self, channel_id:&str) -> Result<()>`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` in `mur-channel/src/service.rs`:
+
+```rust
+#[test]
+fn add_remove_participant_and_delete_channel() {
+    use mur_common::channel::ParticipantRole;
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    let svc = ChannelService::open(home).unwrap();
+    let ch = svc.create_for_fleet("dev", "mur", &["pm".to_string()]).unwrap();
+
+    // add a Delegate member (idempotent)
+    svc.add_participant(&ch.id, "qa", ParticipantRole::Delegate).unwrap();
+    svc.add_participant(&ch.id, "qa", ParticipantRole::Delegate).unwrap();
+    let m = svc.store().load_manifest(&ch.id).unwrap();
+    let qa_count = m
+        .participants
+        .iter()
+        .filter(|p| matches!(&p.actor, mur_common::channel::ChannelActor::Agent { id } if id == "qa"))
+        .count();
+    assert_eq!(qa_count, 1, "add must be idempotent");
+
+    // remove it
+    svc.remove_participant(&ch.id, "qa").unwrap();
+    let m = svc.store().load_manifest(&ch.id).unwrap();
+    assert!(!m.participants.iter().any(
+        |p| matches!(&p.actor, mur_common::channel::ChannelActor::Agent { id } if id == "qa")
+    ));
+
+    // delete the whole channel
+    svc.delete_channel(&ch.id).unwrap();
+    assert!(svc.store().load_manifest(&ch.id).is_err());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run -p mur-channel add_remove_participant_and_delete_channel`
+Expected: FAIL — `no method named add_participant`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `mur-channel/src/store.rs` add:
+
+```rust
+    /// Remove a channel's directory entirely (manifest + events). Idempotent.
+    pub fn delete(&self, id: &str) -> Result<()> {
+        let dir = self.channel_dir(id);
+        if dir.exists() {
+            fs::remove_dir_all(&dir).with_context(|| format!("remove {}", dir.display()))?;
+        }
+        Ok(())
+    }
+```
+
+In `mur-channel/src/index.rs` add:
+
+```rust
+    /// Drop a channel row from the read-model. Idempotent.
+    pub fn remove(&self, id: &str) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM channels WHERE id = ?1", [id])?;
+        Ok(())
+    }
+```
+
+In `mur-channel/src/service.rs` add (alongside the other `pub fn`s, e.g. after `create_for_fleet`):
+
+```rust
+    /// Add an agent participant to a channel (idempotent on agent id). Re-indexes.
+    pub fn add_participant(
+        &self,
+        channel_id: &str,
+        agent_id: &str,
+        role: ParticipantRole,
+    ) -> Result<()> {
+        let mut ch = self.store.load_manifest(channel_id)?;
+        let exists = ch.participants.iter().any(
+            |p| matches!(&p.actor, ChannelActor::Agent { id } if id == agent_id),
+        );
+        if !exists {
+            ch.participants.push(Participant {
+                actor: ChannelActor::Agent { id: agent_id.to_string() },
+                role,
+                joined_at: Utc::now(),
+            });
+            ch.updated_at = Utc::now();
+            self.store.save_manifest(&ch)?;
+            self.index.upsert(&ch)?;
+        }
+        Ok(())
+    }
+
+    /// Remove an agent participant from a channel (no-op if absent). Re-indexes.
+    pub fn remove_participant(&self, channel_id: &str, agent_id: &str) -> Result<()> {
+        let mut ch = self.store.load_manifest(channel_id)?;
+        let before = ch.participants.len();
+        ch.participants.retain(
+            |p| !matches!(&p.actor, ChannelActor::Agent { id } if id == agent_id),
+        );
+        if ch.participants.len() != before {
+            ch.updated_at = Utc::now();
+            self.store.save_manifest(&ch)?;
+            self.index.upsert(&ch)?;
+        }
+        Ok(())
+    }
+
+    /// Delete a channel entirely (store dir + read-model row). Idempotent.
+    pub fn delete_channel(&self, channel_id: &str) -> Result<()> {
+        self.store.delete(channel_id)?;
+        self.index.remove(channel_id)?;
+        Ok(())
+    }
+```
+
+Ensure the imports at the top of `service.rs` include `Participant` and `ParticipantRole` from `mur_common::channel` (add to the existing `use` if missing).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run -p mur-channel add_remove_participant_and_delete_channel`
+Expected: PASS.
+
+- [ ] **Step 5: Verify build + lint**
+
+Run: `cargo clippy -p mur-channel -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-channel/src/store.rs mur-channel/src/index.rs mur-channel/src/service.rs
+git commit -m "feat(channel): add/remove participant + delete_channel primitives"
+```
+
+---
+
+## Task 8: `mur fleet add` / `mur fleet remove`
+
+**Files:**
+- Create: `mur-core/src/cmd/fleet/roster.rs`
+- Modify: `mur-core/src/cmd/fleet/mod.rs` (`pub mod roster;`)
+- Modify: `mur-core/src/cli/actions.rs` (`Add`, `Remove`)
+- Modify: `mur-core/src/dispatch.rs`
+
+**Interfaces:**
+- Consumes: `store::{load_fleet, save_fleet}`, `crate::a2a_dial::canonicalize_agent_name`, `mur_channel::ChannelService::{add_participant, remove_participant}`, `mur_common::channel::ParticipantRole`.
+- Produces: `roster::cmd_fleet_add(home, name, agents: Vec<String>) -> Result<()>`; `roster::cmd_fleet_remove(home, name, agents: Vec<String>) -> Result<()>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-core/src/cmd/fleet/roster.rs` with the test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::{create, store};
+
+    #[test]
+    fn add_then_remove_member_syncs_fleet_and_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        create::cmd_fleet_create(home, "dev", vec!["pm".into()], None, Some("g".into())).unwrap();
+
+        cmd_fleet_add(home, "dev", vec!["qa".into()]).unwrap();
+        cmd_fleet_add(home, "dev", vec!["qa".into()]).unwrap(); // idempotent
+        let f = store::load_fleet(home, "dev").unwrap();
+        assert_eq!(f.members.iter().filter(|m| *m == "qa").count(), 1);
+
+        cmd_fleet_remove(home, "dev", vec!["qa".into()]).unwrap();
+        let f = store::load_fleet(home, "dev").unwrap();
+        assert!(!f.members.contains(&"qa".to_string()));
+    }
+
+    #[test]
+    fn remove_router_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        // router defaults to the concierge "mur"; make it a member too
+        create::cmd_fleet_create(home, "dev", vec!["mur".into(), "pm".into()], None, Some("g".into())).unwrap();
+        assert!(cmd_fleet_remove(home, "dev", vec!["mur".into()]).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core add_then_remove_member_syncs remove_router_is_refused`
+Expected: FAIL — `cannot find function cmd_fleet_add`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Prepend to `mur-core/src/cmd/fleet/roster.rs`:
+
+```rust
+//! `mur fleet add` / `mur fleet remove` — mutate membership in BOTH the fleet
+//! manifest and the shared channel `fleet-<name>` so they never drift.
+
+use std::path::Path;
+
+use anyhow::{Result, bail};
+use mur_common::channel::ParticipantRole;
+
+use super::store;
+
+/// Add one or more agents as Delegate members. Idempotent per agent.
+pub fn cmd_fleet_add(mur_home: &Path, name: &str, agents: Vec<String>) -> Result<()> {
+    let mut fleet = store::load_fleet(mur_home, name)?;
+    let svc = mur_channel::ChannelService::open(mur_home)?;
+    for raw in agents {
+        let agent = crate::a2a_dial::canonicalize_agent_name(mur_home, &raw);
+        if fleet.members.contains(&agent) {
+            println!("'{agent}' is already a member of '{name}'.");
+            continue;
+        }
+        svc.add_participant(&fleet.channel_id, &agent, ParticipantRole::Delegate)?;
+        fleet.members.push(agent.clone());
+        println!("Added '{agent}' to fleet '{name}'.");
+    }
+    store::save_fleet(mur_home, &fleet)?;
+    Ok(())
+}
+
+/// Remove one or more agents. Refuses the current router; no-ops on non-members.
+pub fn cmd_fleet_remove(mur_home: &Path, name: &str, agents: Vec<String>) -> Result<()> {
+    let mut fleet = store::load_fleet(mur_home, name)?;
+    let router = fleet.router_or_concierge().to_string();
+    let svc = mur_channel::ChannelService::open(mur_home)?;
+    for raw in agents {
+        let agent = crate::a2a_dial::canonicalize_agent_name(mur_home, &raw);
+        if agent == router {
+            bail!("router '{agent}' cannot be removed from '{name}'; set a new router first");
+        }
+        if !fleet.members.contains(&agent) {
+            println!("'{agent}' is not a member of '{name}'.");
+            continue;
+        }
+        svc.remove_participant(&fleet.channel_id, &agent)?;
+        fleet.members.retain(|m| m != &agent);
+        println!("Removed '{agent}' from fleet '{name}'.");
+    }
+    store::save_fleet(mur_home, &fleet)?;
+    Ok(())
+}
+```
+
+Add to `mur-core/src/cmd/fleet/mod.rs`:
+
+```rust
+pub mod roster;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core add_then_remove_member_syncs remove_router_is_refused`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire the CLI**
+
+In `mur-core/src/cli/actions.rs`, add to `enum FleetAction`:
+
+```rust
+    /// Add agent(s) to a fleet (member + channel role)
+    Add {
+        /// Fleet name
+        name: String,
+        /// Agent name(s) to add
+        #[arg(required = true)]
+        agents: Vec<String>,
+    },
+    /// Remove agent(s) from a fleet (member + channel)
+    Remove {
+        /// Fleet name
+        name: String,
+        /// Agent name(s) to remove
+        #[arg(required = true)]
+        agents: Vec<String>,
+    },
+```
+
+In `mur-core/src/dispatch.rs`:
+
+```rust
+                FleetAction::Add { name, agents } => {
+                    cmd::fleet::roster::cmd_fleet_add(&mur_home, &name, agents)?
+                }
+                FleetAction::Remove { name, agents } => {
+                    cmd::fleet::roster::cmd_fleet_remove(&mur_home, &name, agents)?
+                }
+```
+
+- [ ] **Step 6: Verify build + lint**
+
+Run: `ORT_STRATEGY=download cargo clippy -p mur-core -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-core/src/cmd/fleet/roster.rs mur-core/src/cmd/fleet/mod.rs mur-core/src/cli/actions.rs mur-core/src/dispatch.rs
+git commit -m "feat(fleet): add/remove members (fleet manifest + channel in sync)"
+```
+
+---
+
+## Task 9: `mur fleet delete`
+
+**Files:**
+- Create: `mur-core/src/cmd/fleet/delete.rs`
+- Modify: `mur-core/src/cmd/fleet/mod.rs` (`pub mod delete;`)
+- Modify: `mur-core/src/cli/actions.rs` (`Delete`)
+- Modify: `mur-core/src/dispatch.rs`
+
+**Interfaces:**
+- Consumes: `store::{load_fleet, fleet_dir}`, `mur_channel::ChannelService::delete_channel`.
+- Produces: `delete::cmd_fleet_delete(home, name, yes: bool) -> Result<()>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mur-core/src/cmd/fleet/delete.rs` with the test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::{create, store};
+
+    #[test]
+    fn delete_removes_fleet_dir_and_channel_keeps_nothing_else() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        create::cmd_fleet_create(home, "dev", vec!["pm".into()], None, Some("g".into())).unwrap();
+        assert!(store::fleet_path(home, "dev").exists());
+        let svc = mur_channel::ChannelService::open(home).unwrap();
+        assert!(svc.store().load_manifest("fleet-dev").is_ok());
+
+        cmd_fleet_delete(home, "dev", true).unwrap();
+
+        assert!(!store::fleet_dir(home, "dev").exists(), "fleet dir must be gone");
+        let svc = mur_channel::ChannelService::open(home).unwrap();
+        assert!(svc.store().load_manifest("fleet-dev").is_err(), "channel must be gone");
+    }
+
+    #[test]
+    fn delete_unknown_fleet_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(cmd_fleet_delete(tmp.path(), "nope", true).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core delete_removes_fleet_dir delete_unknown_fleet`
+Expected: FAIL — `cannot find function cmd_fleet_delete`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Prepend to `mur-core/src/cmd/fleet/delete.rs`:
+
+```rust
+//! `mur fleet delete <name> [--yes]` — remove the fleet dir (manifest, jobs,
+//! sentinels) AND the shared channel `fleet-<name>`. Member agents are NEVER
+//! touched — they are independent, shared resources.
+
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Result, bail};
+
+use super::store;
+
+pub fn cmd_fleet_delete(mur_home: &Path, name: &str, yes: bool) -> Result<()> {
+    let fleet = store::load_fleet(mur_home, name)?; // validates name + existence
+    if !yes && !confirm(name)? {
+        println!("Aborted.");
+        return Ok(());
+    }
+    // Channel first (its own audit history goes with it), then the fleet dir.
+    let svc = mur_channel::ChannelService::open(mur_home)?;
+    svc.delete_channel(&fleet.channel_id)?;
+    let dir = store::fleet_dir(mur_home, name);
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir)?;
+    }
+    println!("Deleted fleet '{name}' and its channel '{}'. Member agents were left intact.", fleet.channel_id);
+    Ok(())
+}
+
+/// Interactive y/N confirmation (skipped with --yes). Destructive: also removes
+/// the channel's audit history.
+fn confirm(name: &str) -> Result<bool> {
+    print!("Delete fleet '{name}' and its channel history? Members are NOT deleted. [y/N] ");
+    std::io::stdout().flush()?;
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    Ok(matches!(input.trim().to_lowercase().as_str(), "y" | "yes"))
+}
+```
+
+Add to `mur-core/src/cmd/fleet/mod.rs`:
+
+```rust
+pub mod delete;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core delete_removes_fleet_dir delete_unknown_fleet`
+Expected: PASS (2 tests). (Tests pass `yes=true`, so `confirm` is not exercised by stdin.)
+
+- [ ] **Step 5: Wire the CLI**
+
+In `mur-core/src/cli/actions.rs`, add to `enum FleetAction`:
+
+```rust
+    /// Delete a fleet + its shared channel (members are NOT deleted)
+    Delete {
+        /// Fleet name
+        name: String,
+        /// Skip the confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+```
+
+In `mur-core/src/dispatch.rs`:
+
+```rust
+                FleetAction::Delete { name, yes } => {
+                    cmd::fleet::delete::cmd_fleet_delete(&mur_home, &name, yes)?
+                }
+```
+
+- [ ] **Step 6: Verify build + lint**
+
+Run: `ORT_STRATEGY=download cargo clippy -p mur-core -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-core/src/cmd/fleet/delete.rs mur-core/src/cmd/fleet/mod.rs mur-core/src/cli/actions.rs mur-core/src/dispatch.rs
+git commit -m "feat(fleet): mur fleet delete (fleet dir + channel; members untouched)"
+```
+
+---
+
+## Task 10: End-to-end round-trip test (function-level, hermetic)
+
+**Files:**
+- Modify: `mur-core/tests/cli_fleet.rs` (append one `#[test]`)
+
+**Interfaces:**
+- Consumes the public command functions (`mur_core::cmd::fleet::{create, jobs, roster, delete, store}`) directly with a temp home. This matches the codebase's existing pattern — every `cmd_fleet_*` unit test calls the function with a temp home; there is **no** binary-spawning harness (`assert_cmd`/`predicates` are not dependencies). The test asserts on persisted state, not captured stdout, and does **not** call `run`/`run --loop` (those need live member agents — covered by the manual smoke below).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `mur-core/tests/cli_fleet.rs`:
+
+```rust
+// ── Fleet command round-trip (job intake + roster management) ─────────
+
+#[test]
+fn fleet_job_and_roster_round_trip() {
+    use mur_common::fleet::JobStatus;
+    use mur_core::cmd::fleet::{create, delete, jobs, roster, store};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+
+    // create (members need not exist on disk; names canonicalize to themselves)
+    create::cmd_fleet_create(home, "dev", vec!["pm".into()], None, Some("standing".into()))
+        .unwrap();
+
+    // add a member → fleet manifest + channel stay in sync
+    roster::cmd_fleet_add(home, "dev", vec!["qa".into()]).unwrap();
+    assert!(store::load_fleet(home, "dev").unwrap().members.contains(&"qa".to_string()));
+
+    // send a job → it lands queued (no execution)
+    jobs::cmd_fleet_send(home, "dev", "first job").unwrap();
+    let q = jobs::list_jobs(home, "dev").unwrap();
+    assert_eq!(q.len(), 1);
+    assert_eq!(q[0].status, JobStatus::Queued);
+    assert_eq!(q[0].text, "first job");
+
+    // remove the member
+    roster::cmd_fleet_remove(home, "dev", vec!["qa".into()]).unwrap();
+    assert!(!store::load_fleet(home, "dev").unwrap().members.contains(&"qa".to_string()));
+
+    // delete the fleet → fleet dir + channel gone
+    delete::cmd_fleet_delete(home, "dev", true).unwrap();
+    assert!(store::list_fleets(home).unwrap().is_empty());
+    let svc = mur_channel::ChannelService::open(home).unwrap();
+    assert!(svc.store().load_manifest("fleet-dev").is_err());
+}
+```
+
+(Confirm `mur-channel` is a dev-dependency of `mur-core`; the existing tests already use `mur_common`/`mur_core` — if `mur_channel` isn't in `[dev-dependencies]`, add it. It is already a normal dependency of `mur-core`, so it resolves.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core fleet_job_and_roster_round_trip`
+Expected: FAIL — won't compile until Tasks 2/3/8/9 land the `jobs`/`roster`/`delete` functions (or, if run after them, passes).
+
+- [ ] **Step 3: Make it pass**
+
+With Tasks 1–9 implemented, re-run until green.
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core fleet_job_and_roster_round_trip`
+Expected: PASS.
+
+- [ ] **Step 4: Full fleet test sweep + lint**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core -E 'test(fleet)'`
+Run: `ORT_STRATEGY=download cargo clippy -p mur-core -- -D warnings && cargo fmt --check`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/tests/cli_fleet.rs
+git commit -m "test(fleet): end-to-end send/jobs/add/remove/delete round-trip"
+```
+
+---
+
+## Final verification
+
+- [ ] **Workspace build + lint:** `ORT_STRATEGY=download cargo clippy --workspace -- -D warnings && cargo fmt --check`
+- [ ] **Fleet + channel + common test sweep:** `ORT_STRATEGY=download cargo nextest run -p mur-common -p mur-channel && ORT_STRATEGY=download cargo nextest run -p mur-core -E 'test(fleet)'`
+- [ ] **Manual smoke (operator):**
+  - `mur fleet create demo --members pm,qa --goal "standing mission"`
+  - `mur fleet send demo "actually do X"` → `mur fleet jobs demo` (shows queued)
+  - `mur fleet run demo` → drains the job; `mur fleet jobs demo --all` shows it `done` with a `run_id`
+  - `mur fleet list` → aligned table, JOBS column reflects the queue
+  - `mur fleet add demo repomanager` / `mur fleet remove demo qa` → `mur fleet show demo` reflects roster
+  - `mur fleet delete demo --yes` → gone; agents `pm`/`qa` still exist (`mur agent list`)
+
+## Docs to update after merge
+
+- `CLAUDE.md` fleet section — add `send` / `jobs` / `add` / `remove` / `delete` to the command list; note "jobs replace hand-editing `goal`; `goal` is the standing default".
+- The fleet design spec is already committed (`docs/superpowers/specs/2026-06-24-mur-fleet-job-intake-and-management-design.md`).

--- a/docs/superpowers/plans/2026-06-24-parallel-jobs-dynamic-fanout.md
+++ b/docs/superpowers/plans/2026-06-24-parallel-jobs-dynamic-fanout.md
@@ -1,0 +1,754 @@
+# Parallel Jobs — Dynamic Fan-out Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the concierge fan N distinct ad-hoc jobs out to running agents over an ephemeral in-memory DAG — no per-job YAML/skill — via one `parallel_jobs` MCP tool.
+
+**Architecture:** Generalize the existing fleet-broadcast machinery. A new `build_jobs_procedure` builds an in-memory `Procedure` of rank-0 `delegate_to` steps (one per job, per-job prompt + free assignee) and runs it through the unchanged `execute_dag`. A `max_concurrency` option (semaphore) bounds total in-flight steps. A `parallel_jobs` MCP tool resolves assignees and calls a thin `run_parallel_jobs` entry that mints a throwaway channel and invokes `execute_dag`.
+
+**Tech Stack:** Rust (edition 2024), tokio (`spawn` + `Semaphore`), `mur-core` (`executor::dag`, `a2a_dial`), `mur-channel` (`ChannelService`), `mur-mcp-server` (stdio JSON-RPC tools), `serde_json`.
+
+## Global Constraints
+
+- **Rust edition 2024** — `let` chains stable.
+- **No hardcoded values** — fan-out width / concurrency ceilings are **named `const`s** (input guardrails, not config wiring; see spec §3).
+- **Single source file ≤ 800 lines.** `dag.rs` is already large; do **not** add the new builder to it — new `executor/jobs.rs`.
+- **Brand is uppercase "MUR"** in any user-facing string (the tool `description`). Tool `name` stays lowercase `parallel_jobs`.
+- **Fail-closed:** `yes` defaults to `false`; risk-tiered steps still hit the existing HITL gate.
+- **mur-core tests need `ORT_STRATEGY=download`** and run under **`cargo nextest`**, not `cargo test` (plain `cargo test --workspace` fails ~7 mur-core tests spuriously). All test commands below use nextest.
+- **Backward compatibility:** `max_concurrency: None` must preserve today's unbounded executor behaviour exactly — every existing `DagExecOptions` caller is unchanged.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `mur-core/src/executor/dag.rs` | DAG executor | Add `max_concurrency: Option<usize>` to `DagExecOptions` (3 sites) + a `Semaphore` in the rank loop. |
+| `mur-core/src/executor/jobs.rs` | **New.** Ephemeral job fan-out primitive + entry point. | `Job`, `build_jobs_procedure`, `RawJob`, `resolve_jobs`, `run_parallel_jobs` + unit tests. |
+| `mur-core/src/executor/mod.rs` | executor module index | Add `pub mod jobs;`. |
+| `mur-mcp-server/src/tools.rs` | MCP tool list + dispatch | Add `parallel_jobs` to `all_tools()` and a dispatch arm. |
+| `mur-mcp-server/tests/integration.rs` | MCP integration tests | Bump tool count; add validation-path test. |
+
+**Why `executor/jobs.rs` and not `cmd/fleet/run.rs`:** the MCP crate calls `mur_core::executor::jobs::…` (cross-crate, needs `pub`), and `dag.rs` is already >800 lines. `executor` is `pub` (lib.rs:33). `build_fleet_procedure` is left untouched — its mapping (`intent = goal`, `description = "{member}: {goal}"`) differs from per-job (`intent == description`), so sharing would silently change the fleet delegate prompt.
+
+---
+
+### Task 1: Bounded concurrency (`max_concurrency` on the DAG executor)
+
+**Files:**
+- Modify: `mur-core/src/executor/dag.rs` (struct `:27-47`, `Default` `:49-62`, spawn loop `:752-797`)
+- Test: `mur-core/src/executor/dag.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `DagExecOptions.max_concurrency: Option<usize>` — `None` = unbounded (default); `Some(n)` bounds total concurrent steps to `n.max(1)`. Consumed by Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` block in `mur-core/src/executor/dag.rs`:
+
+```rust
+    #[tokio::test]
+    async fn max_concurrency_bounds_parallel_steps() {
+        // 6 independent rank-0 steps, each sleeping 0.2s.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let proc = Procedure {
+            variables: vec![],
+            steps: (0..6)
+                .map(|i| ProcedureStep {
+                    description: format!("s{i}"),
+                    command: Some("sleep 0.2".to_string()),
+                    id: Some(format!("s{i}")),
+                    ..Default::default()
+                })
+                .collect(),
+        };
+
+        // Bounded to 2 -> at least 3 sequential waves -> >= ~0.6s.
+        let opts = DagExecOptions {
+            max_concurrency: Some(2),
+            ..Default::default()
+        };
+        let t = std::time::Instant::now();
+        execute_dag(tmp.path(), "cc-bounded", &proc, &opts)
+            .await
+            .unwrap();
+        let bounded = t.elapsed();
+        assert!(
+            bounded.as_millis() >= 400,
+            "bounded run finished too fast ({bounded:?}); cap not applied"
+        );
+
+        // Unbounded -> single wave -> ~0.2s.
+        let opts2 = DagExecOptions {
+            max_concurrency: None,
+            ..Default::default()
+        };
+        let t2 = std::time::Instant::now();
+        execute_dag(tmp.path(), "cc-unbounded", &proc, &opts2)
+            .await
+            .unwrap();
+        let unbounded = t2.elapsed();
+        assert!(
+            unbounded.as_millis() < 400,
+            "unbounded run too slow ({unbounded:?}); regression in default path"
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core max_concurrency_bounds_parallel_steps`
+Expected: **compile error** — `DagExecOptions` has no field `max_concurrency`.
+
+- [ ] **Step 3: Add the struct field (site a)**
+
+In `mur-core/src/executor/dag.rs`, inside `pub struct DagExecOptions<'a>` (after the `run_id` field, ~`:46`):
+
+```rust
+    /// Cap on the number of steps running concurrently across the whole DAG.
+    /// `None` = unbounded (every same-rank step spawned at once — prior
+    /// behaviour). `Some(n)` bounds total in-flight steps to `n.max(1)` via a
+    /// shared semaphore. The 2026 dynamic-fan-out hard precondition: cap
+    /// concurrency, not just cost, or parallel delegations cascade past API
+    /// rate limits.
+    pub max_concurrency: Option<usize>,
+```
+
+- [ ] **Step 4: Add the `Default` field (site b)**
+
+In `impl<'a> Default for DagExecOptions<'a>` (after `run_id: String::new(),` ~`:59`):
+
+```rust
+            max_concurrency: None,
+```
+
+- [ ] **Step 5: Add a semaphore and fix the spawn-loop literal (site c)**
+
+In `execute_dag`, immediately after `let mut overall_tokens: u64 = 0;` (~`:752`), add:
+
+```rust
+    // Optional global concurrency cap. One semaphore for the whole run bounds
+    // total in-flight steps (across all ranks). `None` => no permit, unbounded.
+    let sem = opts
+        .max_concurrency
+        .map(|n| std::sync::Arc::new(tokio::sync::Semaphore::new(n.max(1))));
+```
+
+Then inside the `for &i in &indices {` loop, just before `let mh = mur_home.to_path_buf();` (~`:783`), add:
+
+```rust
+            let sem = sem.clone();
+```
+
+And replace the spawned closure (the `tokio::task::spawn(async move { … })` at `:784-796`) with:
+
+```rust
+            handles.push(tokio::task::spawn(async move {
+                // Hold a permit for the whole step when a cap is set.
+                let _permit = match sem {
+                    Some(s) => Some(s.acquire_owned().await.expect("semaphore open")),
+                    None => None,
+                };
+                let opts_clone = DagExecOptions {
+                    yes: opt_yes,
+                    input: inp,
+                    env_class_override: env_override.as_deref(),
+                    variables: vars,
+                    device_id: dev_id,
+                    trigger: &tr,
+                    channel_id: chan_id,
+                    run_id,
+                    max_concurrency: None,
+                };
+                execute_step(&step, &opts_clone, i, 0, &mh).await
+            }));
+```
+
+> If compilation fails on `tokio::sync::Semaphore`, add `"sync"` to the `tokio` features in `mur-core/Cargo.toml`.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core max_concurrency_bounds_parallel_steps`
+Expected: **PASS** (bounded run ≥ 400ms, unbounded < 400ms).
+
+- [ ] **Step 7: Verify no existing caller broke**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core executor::`
+Expected: **PASS** — all existing dag/pipeline tests green (the spawn-loop literal and both fleet callers compile; `..Default::default()` supplies `max_concurrency: None`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mur-core/src/executor/dag.rs mur-core/Cargo.toml
+git commit -m "feat(executor): optional max_concurrency cap on DagExecOptions
+
+Semaphore-bounded total in-flight steps; None preserves unbounded behaviour.
+Hard precondition for safe parallel fan-out (2026 best practice)."
+```
+
+---
+
+### Task 2: `Job` + `build_jobs_procedure`
+
+**Files:**
+- Create: `mur-core/src/executor/jobs.rs`
+- Modify: `mur-core/src/executor/mod.rs`
+- Test: `mur-core/src/executor/jobs.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Produces:
+  - `pub struct Job { pub description: String, pub assignee: String }`
+  - `pub fn build_jobs_procedure(jobs: &[Job]) -> Procedure` — one rank-0 `ProcedureStep` per job: `intent = Some(description)` (the delegate prompt, `dag.rs:474`), `description = description` (channel/ledger/failure labels), `id = "job-{i}"` (stable+unique), `depends_on = []`.
+- Consumed by Tasks 3 & 4.
+
+- [ ] **Step 1: Register the module**
+
+In `mur-core/src/executor/mod.rs`, add after `pub mod pipeline;`:
+
+```rust
+pub mod jobs;
+```
+
+- [ ] **Step 2: Create the file with the failing test**
+
+Create `mur-core/src/executor/jobs.rs`:
+
+```rust
+//! Ephemeral parallel-jobs fan-out: build an in-memory DAG of rank-0
+//! `delegate_to` steps (one per job) and run it through `execute_dag` — no
+//! authored workflow/skill file. Generalizes fleet broadcast (`cmd/fleet/run.rs`)
+//! to per-job prompts with a free assignee. See
+//! `docs/superpowers/specs/2026-06-24-parallel-jobs-dynamic-fanout-design.md`.
+
+use mur_common::skill::manifest::{Procedure, ProcedureStep};
+
+/// A single job: a prompt and the (canonicalized) agent to delegate it to.
+pub struct Job {
+    pub description: String,
+    pub assignee: String,
+}
+
+/// One rank-0 `ProcedureStep` per job (all parallel, no deps). Sets BOTH
+/// `intent` (the delegate prompt) and `description` (channel/ledger labels)
+/// to the job text, and a stable unique `id` for idempotency / crash-resume.
+pub fn build_jobs_procedure(jobs: &[Job]) -> Procedure {
+    Procedure {
+        variables: vec![],
+        steps: jobs
+            .iter()
+            .enumerate()
+            .map(|(i, j)| ProcedureStep {
+                description: j.description.clone(),
+                intent: Some(j.description.clone()),
+                delegate_to: Some(j.assignee.clone()),
+                id: Some(format!("job-{i}")),
+                ..Default::default()
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_jobs_procedure_one_rank0_step_per_job() {
+        let jobs = vec![
+            Job { description: "add caching to fetch".into(), assignee: "rustsmith".into() },
+            Job { description: "write the README".into(), assignee: "frontend".into() },
+        ];
+        let p = build_jobs_procedure(&jobs);
+        assert_eq!(p.steps.len(), 2);
+        // delegate target per job
+        assert_eq!(p.steps[0].delegate_to.as_deref(), Some("rustsmith"));
+        assert_eq!(p.steps[1].delegate_to.as_deref(), Some("frontend"));
+        // BOTH intent (prompt) and description (labels) carry the job text
+        assert_eq!(p.steps[0].intent.as_deref(), Some("add caching to fetch"));
+        assert_eq!(p.steps[0].description, "add caching to fetch");
+        // stable, unique ids
+        assert_eq!(p.steps[0].id.as_deref(), Some("job-0"));
+        assert_eq!(p.steps[1].id.as_deref(), Some("job-1"));
+        // all rank-0 (no dependencies => all parallel)
+        assert!(p.steps.iter().all(|s| s.depends_on.is_empty()));
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core build_jobs_procedure_one_rank0_step_per_job`
+Expected: **PASS** (the implementation is in the same file — this step proves the module compiles and the shape is correct).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/executor/jobs.rs mur-core/src/executor/mod.rs
+git commit -m "feat(executor): build_jobs_procedure ephemeral fan-out primitive"
+```
+
+---
+
+### Task 3: `RawJob` + `resolve_jobs` (assignee resolution)
+
+**Files:**
+- Modify: `mur-core/src/executor/jobs.rs`
+- Test: `mur-core/src/executor/jobs.rs`
+
+**Interfaces:**
+- Consumes: `Job` (Task 2), `crate::a2a_dial::canonicalize_agent_name(home, typed) -> String`.
+- Produces:
+  - `pub struct RawJob { pub description: String, pub agent: Option<String> }`
+  - `pub fn resolve_jobs(mur_home: &Path, raw: &[RawJob], default_agent: Option<&str>) -> anyhow::Result<Vec<Job>>` — per job: `agent` → else `default_agent` → else error; rejects empty descriptions; canonicalizes assignee names.
+- Consumed by Task 5 (the MCP handler).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `#[cfg(test)] mod tests` in `mur-core/src/executor/jobs.rs`:
+
+```rust
+    #[test]
+    fn resolve_jobs_precedence_and_validation() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+
+        // per-job agent wins over the default
+        let raw = vec![RawJob { description: "A".into(), agent: Some("rustsmith".into()) }];
+        let jobs = resolve_jobs(home, &raw, Some("frontend")).unwrap();
+        assert_eq!(jobs[0].assignee, "rustsmith");
+
+        // falls back to the default agent when a job omits its own
+        let raw = vec![RawJob { description: "B".into(), agent: None }];
+        let jobs = resolve_jobs(home, &raw, Some("frontend")).unwrap();
+        assert_eq!(jobs[0].assignee, "frontend");
+
+        // error when neither a per-job nor a default agent is set
+        let raw = vec![RawJob { description: "C".into(), agent: None }];
+        assert!(resolve_jobs(home, &raw, None).is_err());
+
+        // error on an empty description
+        let raw = vec![RawJob { description: "  ".into(), agent: Some("rustsmith".into()) }];
+        assert!(resolve_jobs(home, &raw, None).is_err());
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core resolve_jobs_precedence_and_validation`
+Expected: **compile error** — `RawJob` / `resolve_jobs` not found.
+
+- [ ] **Step 3: Implement**
+
+In `mur-core/src/executor/jobs.rs`, extend the top-of-file `use` lines to:
+
+```rust
+use std::path::Path;
+
+use anyhow::{Result, anyhow, bail};
+use mur_common::skill::manifest::{Procedure, ProcedureStep};
+
+use crate::a2a_dial::canonicalize_agent_name;
+```
+
+Then add, after `build_jobs_procedure`:
+
+```rust
+/// Untyped job as it arrives from the MCP tool: a description and an optional
+/// explicit assignee. Resolved into a `Job` by `resolve_jobs`.
+pub struct RawJob {
+    pub description: String,
+    pub agent: Option<String>,
+}
+
+/// Resolve each `RawJob` to a `Job` with a concrete, canonicalized assignee.
+/// Precedence per job: explicit `agent` -> `default_agent` -> error.
+/// Rejects empty descriptions. Names are canonicalized so the runtime
+/// spoof check passes (case-insensitive on-disk match, else used verbatim).
+pub fn resolve_jobs(
+    mur_home: &Path,
+    raw: &[RawJob],
+    default_agent: Option<&str>,
+) -> Result<Vec<Job>> {
+    if raw.is_empty() {
+        bail!("no jobs provided");
+    }
+    raw.iter()
+        .enumerate()
+        .map(|(i, j)| {
+            if j.description.trim().is_empty() {
+                bail!("job {i} has an empty description");
+            }
+            let assignee = j
+                .agent
+                .as_deref()
+                .or(default_agent)
+                .ok_or_else(|| {
+                    anyhow!("job {i} has no assignee: pass per-job `agent` or a top-level default `agent`")
+                })?;
+            Ok(Job {
+                description: j.description.clone(),
+                assignee: canonicalize_agent_name(mur_home, assignee),
+            })
+        })
+        .collect()
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core resolve_jobs_precedence_and_validation`
+Expected: **PASS** (canonicalize returns the typed name verbatim in an empty temp home — no `agents/` dir).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/executor/jobs.rs
+git commit -m "feat(executor): resolve_jobs assignee resolution + validation"
+```
+
+---
+
+### Task 4: `run_parallel_jobs` entry point
+
+**Files:**
+- Modify: `mur-core/src/executor/jobs.rs`
+- Test: `mur-core/src/executor/jobs.rs`
+
+**Interfaces:**
+- Consumes: `build_jobs_procedure` (Task 2); `mur_channel::ChannelService::{open, create_for_workflow}`; `crate::executor::dag::{execute_dag, DagExecOptions}` (incl. `max_concurrency` from Task 1).
+- Produces: `pub async fn run_parallel_jobs(mur_home: &Path, jobs: &[Job], max_concurrency: Option<usize>, yes: bool) -> anyhow::Result<(String, PipelineOutput)>` — mints a throwaway channel, runs the ephemeral DAG, returns `(channel_id, output)`.
+- Consumed by Task 5.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `#[cfg(test)] mod tests` in `mur-core/src/executor/jobs.rs`:
+
+```rust
+    #[tokio::test]
+    async fn run_parallel_jobs_mints_channel_even_when_delegate_unreachable() {
+        // No runtime is running, so the delegate dial fails fast (RequireRunning).
+        // run_parallel_jobs must still mint the channel and return Ok (the
+        // executor turns a failed delegate into a failed step, not an Err).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let jobs = vec![Job {
+            description: "do A".into(),
+            assignee: "nonexistent-agent-xyz".into(),
+        }];
+        let (channel_id, _out) = run_parallel_jobs(tmp.path(), &jobs, Some(2), false)
+            .await
+            .expect("must not error when the delegate is unreachable");
+        assert!(!channel_id.is_empty(), "a channel should have been minted");
+        // The minted channel is persisted and loadable.
+        let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+        assert!(svc.load_events(&channel_id).is_ok());
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core run_parallel_jobs_mints_channel`
+Expected: **compile error** — `run_parallel_jobs` not found.
+
+- [ ] **Step 3: Implement**
+
+In `mur-core/src/executor/jobs.rs`, extend the `use` block to add:
+
+```rust
+use mur_channel::ChannelService;
+use mur_common::pipeline::PipelineOutput;
+
+use crate::executor::dag::{DagExecOptions, execute_dag};
+```
+
+Then add, after `resolve_jobs`:
+
+```rust
+/// Run N jobs as one ephemeral, channel-recorded DAG. Mints a throwaway
+/// workflow channel, fans the jobs out (bounded by `max_concurrency`), and
+/// returns `(channel_id, output)`. Per-job replies are persisted on the
+/// channel; the caller reads them back via `channel_id`. `yes` is passed
+/// straight through — `false` keeps risk-tiered steps fail-closed at the HITL gate.
+pub async fn run_parallel_jobs(
+    mur_home: &Path,
+    jobs: &[Job],
+    max_concurrency: Option<usize>,
+    yes: bool,
+) -> Result<(String, PipelineOutput)> {
+    let proc = build_jobs_procedure(jobs);
+    let svc = ChannelService::open(mur_home)?;
+    let channel_id = svc.create_for_workflow("parallel-jobs")?.id;
+    let opts = DagExecOptions {
+        yes,
+        trigger: "agent",
+        channel_id: Some(channel_id.clone()),
+        run_id: format!("run-{}", uuid::Uuid::now_v7()),
+        max_concurrency,
+        ..Default::default()
+    };
+    let out = execute_dag(mur_home, "parallel-jobs", &proc, &opts).await?;
+    Ok((channel_id, out))
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core run_parallel_jobs_mints_channel`
+Expected: **PASS** (channel minted; delegate-unreachable becomes a failed step inside `Ok`, not an `Err`).
+
+- [ ] **Step 5: Run the whole jobs module + clippy**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core executor::jobs`
+Expected: **PASS** (all 3 jobs tests).
+
+Run: `ORT_STRATEGY=download cargo clippy -p mur-core -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/executor/jobs.rs
+git commit -m "feat(executor): run_parallel_jobs entry — ephemeral channel + DAG fan-out"
+```
+
+---
+
+### Task 5: `parallel_jobs` MCP tool
+
+**Files:**
+- Modify: `mur-mcp-server/src/tools.rs` (`all_tools()` ~`:48-340`, `dispatch_tool()` ~`:384-683`)
+- Modify: `mur-mcp-server/tests/integration.rs` (tool-count assert ~`:80`)
+- Test: `mur-mcp-server/tests/integration.rs`
+
+**Interfaces:**
+- Consumes: `mur_core::executor::jobs::{RawJob, resolve_jobs, run_parallel_jobs}` (Tasks 3-4); `resolve_mur_home()` (existing util, `tools.rs:685`).
+- Produces: MCP tool `parallel_jobs` returning `{ "channel_id": String, "output": String }`.
+
+- [ ] **Step 1: Bump the integration tool-count assertion (failing test first)**
+
+In `mur-mcp-server/tests/integration.rs`, change the existing assertion (currently `assert_eq!(tools.len(), 18, "Expected 18 tools");`) to:
+
+```rust
+    assert_eq!(tools.len(), 19, "Expected 19 tools");
+```
+
+- [ ] **Step 2: Add the validation-path integration test**
+
+Append to `mur-mcp-server/tests/integration.rs` (mirror the `calls_mur_compress_tool` setup):
+
+```rust
+#[test]
+fn parallel_jobs_rejects_empty_jobs() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mur-mcp-server"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = std::io::BufReader::new(child.stdout.take().unwrap());
+
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+    );
+    let _ = read_response(&mut stdout);
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+    );
+
+    // Empty jobs array -> tool returns an error envelope (isError), never panics.
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"parallel_jobs","arguments":{"jobs":[],"agent":"rustsmith"}}}"#,
+    );
+    let resp = read_response(&mut stdout);
+    let resp_str = serde_json::to_string(&resp).unwrap();
+    assert!(
+        resp_str.contains("isError") || resp_str.to_lowercase().contains("error"),
+        "empty jobs should yield an error envelope: {resp_str}"
+    );
+
+    child.kill().ok();
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cargo nextest run -p mur-mcp-server parallel_jobs_rejects_empty_jobs test_initialize_and_list_tools`
+Expected: **FAIL** — count assert fails (still 18) / `parallel_jobs` unknown tool.
+
+- [ ] **Step 4: Register the tool schema**
+
+In `mur-mcp-server/src/tools.rs`, add this `Tool { … }` to the vec returned by `all_tools()` (place it alongside the other tools, before the closing `]`):
+
+```rust
+        Tool {
+            name: "parallel_jobs".into(),
+            description: "Fan out N distinct jobs to running MUR agents in parallel over an ephemeral channel — no workflow file. Each job is delegated as its own concurrent turn. Before coding fan-out, apply the parallel-code gate: disjoint files (no shared registry/lockfile), contracts frozen first, one writer per file. Targets the agents you name; runtimes must already be running.".into(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".into(),
+                properties: Some(BTreeMap::from([
+                    ("jobs".into(), ToolParam {
+                        param_type: "array".into(),
+                        description: "Jobs to run in parallel. Each: { description: string, agent?: string }.".into(),
+                        default: None,
+                    }),
+                    ("agent".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "Default assignee agent name for jobs that omit their own `agent`.".into(),
+                        default: None,
+                    }),
+                    ("max_concurrency".into(), ToolParam {
+                        param_type: "integer".into(),
+                        description: "Max jobs in flight at once, 1-32 (default 8).".into(),
+                        default: Some(json!(8)),
+                    }),
+                    ("yes".into(), ToolParam {
+                        param_type: "boolean".into(),
+                        description: "Auto-approve risk-tiered steps. Default false (fail-closed).".into(),
+                        default: Some(json!(false)),
+                    }),
+                ])),
+                required: Some(vec!["jobs".into()]),
+            },
+        },
+```
+
+- [ ] **Step 5: Add the dispatch arm**
+
+In `mur-mcp-server/src/tools.rs`, add a match arm inside `dispatch_tool` (before the `_ => Err(...)` fallback):
+
+```rust
+        "parallel_jobs" => {
+            // Input guardrails (not behaviour config — see spec §3).
+            const MAX_JOBS: usize = 32;
+            const DEFAULT_MAX_CONCURRENCY: u64 = 8;
+
+            let raw = arguments
+                .get("jobs")
+                .and_then(|v| v.as_array())
+                .ok_or_else(|| "Missing required parameter: 'jobs' (array)".to_string())?;
+            if raw.is_empty() || raw.len() > MAX_JOBS {
+                return Err(format!(
+                    "'jobs' must have 1..={MAX_JOBS} entries (got {})",
+                    raw.len()
+                ));
+            }
+            let jobs_in: Vec<mur_core::executor::jobs::RawJob> = raw
+                .iter()
+                .map(|j| mur_core::executor::jobs::RawJob {
+                    description: j
+                        .get("description")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    agent: j
+                        .get("agent")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                })
+                .collect();
+            let default_agent = arguments.get("agent").and_then(|v| v.as_str());
+            let max_concurrency = arguments
+                .get("max_concurrency")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(DEFAULT_MAX_CONCURRENCY)
+                .clamp(1, MAX_JOBS as u64) as usize;
+            let yes = arguments
+                .get("yes")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            let home = resolve_mur_home().map_err(|e| format!("parallel_jobs failed: {e}"))?;
+            let jobs = mur_core::executor::jobs::resolve_jobs(&home, &jobs_in, default_agent)
+                .map_err(|e| format!("parallel_jobs: {e}"))?;
+            let (channel_id, out) =
+                mur_core::executor::jobs::run_parallel_jobs(&home, &jobs, Some(max_concurrency), yes)
+                    .await
+                    .map_err(|e| format!("parallel_jobs failed: {e}"))?;
+            Ok(json!({
+                "channel_id": channel_id,
+                "output": out.output_text.unwrap_or_default(),
+            }))
+        }
+```
+
+> `BTreeMap` and `json!` are already imported in `tools.rs`. If `json!` is not in scope in the `all_tools` region, it is `serde_json::json!` (already `use`d for the existing `default: Some(json!(5))`).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo nextest run -p mur-mcp-server parallel_jobs_rejects_empty_jobs test_initialize_and_list_tools`
+Expected: **PASS** — 19 tools listed; empty-jobs call returns an error envelope.
+
+- [ ] **Step 7: Clippy the MCP crate**
+
+Run: `cargo clippy -p mur-mcp-server -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mur-mcp-server/src/tools.rs mur-mcp-server/tests/integration.rs
+git commit -m "feat(mcp): parallel_jobs tool — concierge-triggered parallel fan-out
+
+First mutating tool in mur-mcp-server. Resolves assignees, runs an ephemeral
+DAG via mur_core::executor::jobs::run_parallel_jobs, returns {channel_id, output}."
+```
+
+---
+
+### Task 6: Workspace verification + docs
+
+**Files:**
+- Modify: `mur-mcp-server` skill/docs if the tool list is enumerated anywhere user-facing (check only).
+
+- [ ] **Step 1: Full lint + format**
+
+Run: `cargo fmt --check && ORT_STRATEGY=download cargo clippy -p mur-core -p mur-mcp-server -- -D warnings`
+Expected: clean. (If `fmt --check` fails, run `cargo fmt` and amend.)
+
+- [ ] **Step 2: Targeted test sweep**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core executor:: && cargo nextest run -p mur-mcp-server`
+Expected: **PASS**.
+
+- [ ] **Step 3: Check for a user-facing tool enumeration to update**
+
+Run: `rg -n "mur_project_search|mur_notes_search" --glob '!target' docs README.md mur-mcp-server 2>/dev/null | rg -iv "src/tools.rs|tests/"`
+Expected: if any docs file lists the MCP tools, add a one-line `parallel_jobs` entry (uppercase **MUR** in prose). If none, skip.
+
+- [ ] **Step 4: Commit (only if Step 1 or 3 changed files)**
+
+```bash
+git add -A && git commit -m "chore: fmt + docs for parallel_jobs tool"
+```
+
+---
+
+## Live / Operator verification (post-merge, needs running runtimes + cc-proxy)
+
+Not an automated task — the integration gates from spec §"Integration risks". Run manually:
+
+1. Ensure a target agent runtime is running and fresh (registers `channel/delegate`; the stale-binary `-32601` gotcha) and its `entitlements.filesystem.write` includes `~/.mur/channels` (peer-self-reply lands in the audit trail).
+2. From the concierge (or an MCP client), call `parallel_jobs` with 3 distinct jobs to one running agent; confirm 3 concurrent delegate turns and `{channel_id, output}` back, and that per-job replies are on the channel (`mur channel show <id>` or events).
+3. Call with two explicitly-named agents (the "jobs across a fleet" v1 shape) — confirm each job lands on its named agent.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 core primitive → Task 2 (`build_jobs_procedure`) + Task 4 (`run_parallel_jobs`). ✓
+- §2 concurrency cap (3 sites + semaphore) → Task 1. ✓
+- §3 MCP tool (`{jobs, agent, max_concurrency, yes}` → `{channel_id, output}`, `MAX_JOBS` const) → Task 5. ✓
+- §4 assignee resolution (per-job → default → error, canonicalized) → Task 3. ✓
+- §5 safety (fail-closed `yes:false`, HITL via executor, disjoint-ownership note in description, input validation) → Tasks 3+5. ✓
+- §6 result handling (`{channel_id, output}`, per-step failure isolation via executor) → Tasks 4+5. ✓
+- Non-goals (fleet auto-distribute, typed per-job envelope, router, fan-in verify, budget) → not implemented, by design. ✓
+- Integration risks (first mutating MCP tool; runtimes-running; channels entitlement) → Live verification section. ✓
+
+**Placeholder scan:** none — every code step shows full code; every run step shows the command + expected output.
+
+**Type consistency:** `Job{description,assignee}`, `RawJob{description,agent}`, `build_jobs_procedure(&[Job])`, `resolve_jobs(&Path,&[RawJob],Option<&str>)->Result<Vec<Job>>`, `run_parallel_jobs(&Path,&[Job],Option<usize>,bool)->Result<(String,PipelineOutput)>`, `DagExecOptions.max_concurrency: Option<usize>` — names/signatures identical across Tasks 1-5. ✓

--- a/docs/superpowers/specs/2026-06-24-mur-fleet-job-intake-and-management-design.md
+++ b/docs/superpowers/specs/2026-06-24-mur-fleet-job-intake-and-management-design.md
@@ -1,0 +1,227 @@
+# MUR Fleet — Job Intake & Roster Management Design
+
+**Date:** 2026-06-24
+**Status:** Design (approved for planning)
+**Scope:** `mur fleet` CLI + store + daemon `fleet_tick`
+
+## Problem
+
+A fleet today is a goal-driven squad: the `goal` field in `~/.mur/fleets/<name>/fleet.yaml`
+is the work, and `run` / `run --loop` / the daemon `fleet_tick` all execute that one stored
+goal. Consequences:
+
+1. **Dispatching a task means hand-editing `fleet.yaml`.** To give a fleet a new job you open
+   the file and rewrite `goal`. This is the core pain point — a fleet is a durable squad, but
+   the *work* you hand it is ephemeral, and the two are conflated in one file.
+2. **`mur fleet list` is unreadable.** Each fleet prints one long wrapped line ending in the
+   full multi-line goal, so the list wraps into an illegible block.
+3. **Roster management is missing.** No `add` / `remove` / `delete` — editing membership also
+   means hand-editing YAML (and the channel roles drift out of sync).
+
+## Goals
+
+- Dispatch a job to a fleet **by command**, never by editing a file.
+- Keep `goal` as the fleet's *standing mission* (default work) — not the dispatch mechanism.
+- A scannable `mur fleet list`.
+- First-class `add` / `remove` / `delete`.
+- Job model aligned with the **A2A Task lifecycle** so A2A intake is a thin follow-on, not a
+  rewrite.
+
+## Non-Goals (this phase)
+
+- **A2A job intake.** A fleet exposing an A2A endpoint that external/other agents dial to hand
+  it a job is a documented follow-on (see "A2A follow-on" below). This phase is CLI-only.
+- Per-job streaming / push notifications.
+- Multi-job parallelism. Jobs are processed **one at a time, oldest first** (FIFO). A fleet's
+  internal member fan-out is already parallel; the *queue* is serial.
+
+## Core model
+
+A fleet is a **durable squad**. Work is **ephemeral** and enters as a **job**.
+
+- `goal` (fleet.yaml) = **standing mission / default job**. Used when no job is queued and no
+  job arg is given (i.e. daemon auto-run and bare `mur fleet run <name>`). It is no longer the
+  way you dispatch ad-hoc work.
+- A **job** = a unit of work handed to the fleet by command. It becomes the goal *for one run*.
+
+### Job record
+
+Path: `~/.mur/fleets/<name>/jobs/<id>.yaml`
+`id` = UUIDv7 (time-sortable — FIFO ordering is filename sort, no index file).
+
+```yaml
+id: 0190f3a2-...            # uuid v7
+text: "Refactor the model-registry module for clarity"
+source: cli                 # cli | a2a:<agent-id>   (a2a is follow-on)
+status: queued              # queued | running | done | failed | canceled
+created_at: 2026-06-24T...  # RFC3339
+started_at: ~               # set when picked up
+finished_at: ~              # set on terminal state
+run_id: ~                   # links to the channel run that executed it (results live there)
+result: ~                   # short summary on done
+error: ~                    # message on failed
+```
+
+**Status ↔ A2A `TaskState` mapping** (deliberate, for the follow-on):
+
+| job status | A2A TaskState |
+|------------|---------------|
+| queued     | submitted     |
+| running    | working       |
+| done       | completed     |
+| failed     | failed        |
+| canceled   | canceled      |
+
+`input-required` / `auth-required` are out of scope this phase (no interactive pause); a future
+job can grow an `input-required` status without breaking the enum (serde-tolerant).
+
+### Store API (`cmd/fleet/jobs.rs`, new)
+
+```
+jobs_dir(home, name) -> PathBuf                      // ~/.mur/fleets/<name>/jobs
+enqueue_job(home, name, text, source) -> Job          // write <id>.yaml, status=queued
+list_jobs(home, name) -> Vec<Job>                     // sorted by id (FIFO)
+next_queued(home, name) -> Option<Job>                // oldest status==queued
+update_job(home, name, &Job)                          // atomic temp+rename, like save_fleet
+```
+
+Atomic write (temp + rename), same pattern as `store::save_fleet`. Fleet-name validated via
+`valid_fleet_name` (defense-in-depth, like the store layer).
+
+### Commands
+
+- **`mur fleet send <name> "<job>"`** — enqueue a job (`status=queued`, `source=cli`), print
+  the job id. Asynchronous: it does **not** run. Drained by `mur fleet run` or the daemon.
+- **`mur fleet run <name> ["<job>"]`** — synchronous, one iteration. Goal resolution order:
+  1. explicit `<job>` arg → run it as a one-shot (also persisted as a job, `done` on finish);
+  2. else oldest `queued` job → run it, mark `running` → `done`/`failed`;
+  3. else the standing `goal`.
+  (Bare `mur fleet run <name>` keeps today's behavior when the queue is empty.)
+- **`mur fleet jobs <name>`** — list jobs with status, id (short), age, and result/error.
+  `--all` to include terminal jobs; default shows queued + running + recent.
+
+### Queue draining
+
+The queue is drained by the existing executors — no new daemon, no new loop:
+
+- **`mur fleet run`** (above) pops one job per invocation.
+- **`mur fleet run --loop`** (`loop_run.rs`): each iteration first checks for a queued job;
+  if present it runs that job (marking running→terminal), else falls back to the standing goal
+  (today's behavior). All existing guards (iteration cap / deadline / budget-usd / stuck /
+  kill-switch / commander governance) apply unchanged.
+- **daemon `fleet_tick`** (`mur-daemon/src/fleet_tick.rs`): when a fleet is due, if it has
+  queued jobs it drains the oldest (gated by the same `MUR_FLEET_AUTORUN` + positive budget +
+  kill-switch triad). Empty queue → today's standing-goal auto-run behavior.
+
+Failure handling: an executor error marks the job `failed` with the error message and stamps
+`finished_at`; the loop/daemon continues per its existing guard policy (fail-safe). A job
+whose run is killed mid-flight stays `running` and is re-picked only if explicitly retried
+(no silent infinite retry — name the ceiling in code).
+
+## `mur fleet list` — aligned table
+
+Replace the wrapped one-liner with a column-aligned table (one row per fleet, goal truncated to
+the remaining terminal width):
+
+```
+NAME          ST  MEM  JOBS  ROUTER  GOAL
+model-reg     ●   3    0     mur     Refactor the model-registry module for clarity
+develop-rust  ●   6    2     mur     Implement the plan at /Volumes/…/phase1.md task by …
+rust-solo     ⏸   1    0     mur     Implement ONLY Task 3 from the plan at /Volumes/…
+
+● idle   ⏸ stopped   ▶ running
+```
+
+- `ST`: `⏸` if kill-switch (`control::is_stopped`); `▶` if a job is `running`; else `●` idle.
+- `MEM`: member count (full roster is in `show`).
+- `JOBS`: count of `queued` jobs — surfaces who has pending work at a glance.
+- `GOAL`: standing goal, truncated with `…` to fit the line. Newlines collapsed to spaces.
+- Column widths computed from the rows; goal gets the remainder of `$COLUMNS` (fallback 80).
+
+`mur fleet show <name>` is unchanged — it remains the full-detail view (and can additionally
+print the job list).
+
+## add / remove / delete
+
+All three keep `fleet.yaml` and the shared channel `fleet-<name>` in sync (membership lives in
+both; today only `create` writes them together).
+
+- **`mur fleet add <name> <agent>...`** — canonicalize each name
+  (`a2a_dial::canonicalize_agent_name`), append to `members` if not already present, and add the
+  member to the channel with the `Delegate` role. Idempotent (existing member is skipped). Save.
+- **`mur fleet remove <name> <agent>...`** — remove from `members` and from the channel.
+  Refuse to remove the current `router` (error: "router 'x' cannot be removed; set a new router
+  first"). Removing a non-member is a no-op warning, not an error. Save.
+- **`mur fleet delete <name> [--yes]`** — delete the fleet directory
+  (`~/.mur/fleets/<name>/`, including `jobs/` and sentinels) **and** the shared channel
+  `fleet-<name>`. **Member agents are never touched** — they are independent, shared resources.
+  Prompts for confirmation unless `--yes`. `delete` does not check for a running loop — the
+  kill-switch sentinel is the stop mechanism, and the running loop bails when its files vanish
+  at the next guard check. Deleting a fleet with a running loop is the operator's call.
+
+Channel role constants and the add/remove channel mutation reuse `mur_channel::ChannelService`
+(the same API `create::create_for_fleet` already uses). If the service lacks an
+add-member/remove-member primitive, add the minimal one there.
+
+## A2A follow-on (documented, not built this phase)
+
+When built, A2A intake reuses everything above:
+
+- The fleet's router/concierge accepts an A2A `message/send` whose message text is the job.
+- The handler calls `enqueue_job(..., source = "a2a:<caller-id>")` and returns an A2A **Task**
+  whose `id` is the job id and whose state mirrors the job status (`submitted`/`working`/…).
+- `tasks/get` maps to reading the job record; the result artifact is the job's `result` +
+  the channel run referenced by `run_id`.
+- Blocking (`return_immediately:false`) vs async maps to drain-now vs enqueue.
+
+No storage or model change is needed — the job IS the A2A Task. That is the point of aligning
+the status enum now.
+
+## Security & safety
+
+- **No blanket approval.** `send`/`run`/drain pass `yes:false` to the DAG executor exactly as
+  today (fail-closed; risk-tiered steps still gate). A job is just a goal string — it grants no
+  new authority.
+- **Name validation** on every job-store path (`valid_fleet_name`) — a job file can never be
+  written outside `~/.mur/fleets/<name>/jobs/`.
+- **`delete` is destructive and confirmed** (`--yes` to skip). It removes the channel (and its
+  audit history) — call this out in the confirmation prompt.
+- **Auto-run triad unchanged.** Daemon queue-drain is still gated by `MUR_FLEET_AUTORUN` +
+  positive `budget_usd` + kill-switch. The queue does not create a new unattended path.
+- **Job text is untrusted input** once A2A intake lands; this phase is CLI-only (operator is the
+  source) but the job text is treated as a plain goal string, never shell/path-interpolated.
+
+## Testing
+
+Unit (`cargo nextest`, `ORT_STRATEGY=download`):
+
+- jobs store: enqueue → list (FIFO by uuid v7) → next_queued → update → terminal; atomic write;
+  invalid fleet name refused.
+- `run` goal-resolution order: arg > queued > standing goal; empty-queue back-compat.
+- `list` rendering: truncation, status symbol selection, job count, newline collapse.
+- `add`: idempotent, canonicalizes, syncs channel role.
+- `remove`: refuses router, no-op on non-member, syncs channel.
+- `delete`: removes dir + channel, leaves member agents, honors `--yes`/confirmation.
+
+CLI integration (`tests/cli_fleet.rs`): `create → add → send → run (drains job) → jobs (done)
+→ remove → delete` round-trip on a temp home.
+
+Live (operator): `send` then `run --loop` drains across iterations; daemon drain with autorun
+triad set.
+
+## Files touched
+
+- `mur-common/src/fleet.rs` — `Job` struct + status enum (new; or a `fleet_job.rs` sibling).
+- `mur-core/src/cmd/fleet/jobs.rs` — new (store API + `send`/`jobs` commands).
+- `mur-core/src/cmd/fleet/run.rs` — goal resolution (arg > queued > goal); persist one-shot.
+- `mur-core/src/cmd/fleet/loop_run.rs` — per-iteration queue check.
+- `mur-core/src/cmd/fleet/list.rs` — table renderer.
+- `mur-core/src/cmd/fleet/roster.rs` — new (`add`/`remove`); or extend `control.rs`.
+- `mur-core/src/cmd/fleet/delete.rs` — new (or in `control.rs`).
+- `mur-core/src/cli/actions.rs` — `FleetAction::{Send, Jobs, Add, Remove, Delete}` + `run` job arg.
+- `mur-core/src/dispatch.rs` — wire the new actions.
+- `mur-daemon/src/fleet_tick.rs` — queue-drain branch.
+- `mur-core/src/cmd/fleet/store.rs` — `jobs_dir`; channel add/remove member helper if needed.
+
+Keep each file ≤ 800 lines (Mandatory Rule 4) — `import.rs`/`loop_run.rs` are already large;
+new surface goes in new sibling modules, not bolted onto them.

--- a/docs/superpowers/specs/2026-06-24-parallel-jobs-dynamic-fanout-design.md
+++ b/docs/superpowers/specs/2026-06-24-parallel-jobs-dynamic-fanout-design.md
@@ -1,0 +1,151 @@
+# Dynamic Parallel Jobs — ephemeral fan-out without per-job workflows
+
+- **Date:** 2026-06-24
+- **Status:** Design (approved for plan)
+- **Topic:** A `parallel_jobs` MCP action tool that fans N distinct ad-hoc jobs out to running agents over an ephemeral, in-memory DAG — no YAML/skill authored per job.
+
+## Problem
+
+Running N parallel implementation jobs today means authoring a `category:Workflow` skill (or workflow YAML) whose `content.procedure.steps` are rank-0 `delegate_to` steps, then `mur workflow run <skill>`. Authoring a static definition per fan-out is heavy and is exactly the per-job-static-template anti-pattern the 2026 literature says to leave behind.
+
+The machinery to avoid it already exists: `mur-core/src/cmd/fleet/run.rs::build_fleet_procedure()` (lines 14–28) builds a `Procedure` **in memory** (one rank-0 `delegate_to` step per target) and runs it through `mur-core/src/executor/dag.rs::execute_dag()` — zero files. It only hardcodes *one shared goal broadcast to fleet members*. Generalizing it to **per-step descriptions with a free assignee** is the whole feature.
+
+## Goals
+
+- Fan **N distinct jobs** (each its own prompt) to **one running agent** as concurrent `channel/delegate` turns — the demo path, generalized, with no authored file.
+- Triggerable by the **concierge mid-conversation** via an MCP tool (the concierge cannot shell `mur`).
+- Bounded concurrency, fail-closed risk gating.
+- The same primitive can also target **distinct named agents** per job (so "jobs across a fleet's members" works in v1 by naming the members) — see the fleet deep-think below.
+
+## Non-goals (deferred)
+
+- **Auto-distribute across a fleet** (`fleet` param + round-robin/router assignment). v1 targets agents by explicit name; auto-spreading N jobs over a fleet's member list is v2 sugar on top of the same primitive.
+- **Typed per-job result envelope.** `execute_dag` returns one `PipelineOutput` whose `tokens_used` is the **summed** total and whose `output_text` is all step outputs concatenated — per-step results are **not** surfaced today (`StepResult` is private, `dag.rs:240`). v1 returns `{channel_id, output_text}` and lets the concierge read per-job replies off the channel. A structured `Vec<StepResult>` on `PipelineOutput` is a separate, deliberate change if ever wanted.
+- **Router-assigned** jobs (LLM picks the best member per job). The planner exists (`cmd/fleet/plan.rs`); expose later as `assign:"router"`.
+- **Fan-in verify step** (auto build/test gating merge). v2 — the concierge can issue a follow-up verify job today.
+- **Budget ceiling.** A one-shot, concierge-triggered fan-out is attended (human in the loop), unlike the unattended `mur fleet run --loop`. The existing HITL gate is the brake in v1.
+- **Parallel-edit merge reconciliation.** The 2026 survey confirms no framework has one; out of scope. Disjoint ownership is the discipline instead.
+
+## Best-practice grounding (2026)
+
+Filtered to what shapes this design:
+
+- **Pre-execution generation, lowest plasticity that works.** "More flexibility is not intrinsically better" — for "N parallel coders" the structure is knowable, so generate one flat rank-0 DAG and fan out; do **not** do in-run spawn-as-you-go graph editing (RPI/IBM survey, arXiv 2603.22386).
+- **Bounded concurrency is a hard precondition** — cap concurrency, not just cost: "15 concurrent agents consuming 150 req/s against a 100 req/s limit causes cascading failures" (Zylos, 2026-04-26). → `max_concurrency` below.
+- **Disjoint ownership** — one file = one writer; "state corruption scales quadratically." MUR's `parallel-code` skill already encodes the gate (disjoint files, contracts frozen first).
+- **Execution-grounded verify at fan-in** — run the build/tests, don't trust an LLM self-score (deferred to v2 here).
+
+## Design
+
+### 1. Core primitive + entry point (`mur-core`)
+
+Lives in a small new `mur-core/src/executor/jobs.rs` (next to `execute_dag`, **not** under `cmd/fleet/` — the MCP tool is a separate crate and needs a `pub` path, and `dag.rs` is already >800 lines so it can't absorb more):
+
+```rust
+pub struct Job {
+    pub description: String,   // the per-job prompt / task
+    pub assignee: String,      // canonicalized agent name (delegate target)
+}
+
+/// One rank-0 ProcedureStep per job. Sets BOTH:
+///   intent      = Some(description)  -> the delegate prompt   (dag.rs:474 = intent.unwrap_or(description))
+///   description = description        -> channel/ledger/failure labels (dag.rs:573-586,855)
+///   id          = "job-{i}"          -> stable+unique for idem-key / ToolResult crash-resume
+///   depends_on  = []                 -> all rank-0, all parallel
+pub fn build_jobs_procedure(jobs: &[Job]) -> Procedure
+
+/// Public entry the MCP tool calls. Mints a throwaway channel, builds the
+/// procedure, constructs DagExecOptions (owned backing strings — DagExecOptions<'a>
+/// borrows trigger/env_class_override), runs execute_dag, returns (channel_id, output).
+pub async fn run_parallel_jobs(
+    mur_home: &Path,
+    jobs: &[Job],
+    max_concurrency: Option<usize>,
+    yes: bool,
+) -> Result<(String, PipelineOutput)>
+```
+
+Channel minted via the existing `ChannelService::create_for_workflow` path (used by `--channel-new`, `cmd/workflow.rs:196-197`). `run_parallel_jobs` passes `yes` straight to `DagExecOptions` and `run_id = format!("run-{}", Uuid::now_v7())`.
+
+**`build_fleet_procedure` is left as-is** — its mapping differs (`intent = goal`, `description = "{member}: {goal}"`), so routing it through `build_jobs_procedure` would change the fleet delegate *prompt* from `goal` to `"{member}: {goal}"`. Behaviour-preserving > DRY; the ~12 shared lines aren't worth a silent prompt change.
+
+### 2. Concurrency cap (the one executor change — 3 sites)
+
+`execute_dag` spawns **all** same-rank steps via `tokio::task::spawn` then awaits them in a manual `for h in handles { h.await }` loop (`dag.rs:784` spawn, `:800-815` await — no `join_all`). Add an opt-in bound:
+
+```rust
+// DagExecOptions  (touch 3 sites or it won't compile)
+//   (a) struct field:        pub max_concurrency: Option<usize>,
+//   (b) Default impl:        max_concurrency: None,
+//   (c) field-by-field reconstruction inside the spawn closure (dag.rs:785-794)
+pub max_concurrency: Option<usize>,   // None = today's unbounded behaviour (back-compat)
+```
+
+When `Some(n)`, gate each spawned task on an `Arc<tokio::sync::Semaphore>` of `n` permits (`let _permit = sem.acquire().await;` inside each task, before the delegate dial). `None` preserves current behaviour exactly, so the fleet path and every existing caller are untouched. This is the research's hard precondition and it retro-fits fleet for free.
+
+### 3. MCP tool `parallel_jobs` (`mur-mcp-server`)
+
+The home flagged in prior project memory for `code_fanout`. `mur-mcp-server` already depends on `mur-core` (`Cargo.toml:14`), so reaching `run_parallel_jobs` is **not** a new dependency. It *is* the first **mutating** tool there (the current 9 are read-only) — see Integration risk #1.
+
+```jsonc
+// input
+{
+  "jobs": [ { "description": "string", "agent": "string?" } ],  // 1 ≤ len ≤ MAX_JOBS
+  "agent": "string?",            // default assignee when a job omits `agent`
+  "max_concurrency": 8,          // default; -> DagExecOptions.max_concurrency
+  "yes": false                   // fail-closed; never blanket-approves risk-tiered steps
+}
+// output
+{ "channel_id": "string", "output": "string" }   // concatenated step outputs; per-job replies live on the channel
+```
+
+Flow: validate input → resolve assignees (§4) → `run_parallel_jobs(home, &jobs, max_concurrency, yes)` → return `{channel_id, output}`. `MAX_JOBS` is a named `const` in the tool handler (an input guardrail, not a behaviour-shaping value — no config wiring).
+
+### 4. Assignee resolution
+
+A pure, unit-testable helper in `mur-core` (`resolve_jobs(raw, default_agent) -> Result<Vec<Job>>`), per job:
+
+1. `job.agent` set → use it.
+2. else top-level `agent` set → use it.
+3. else → error (`"job N has no assignee: pass per-job `agent` or a top-level default `agent`"`).
+
+All names go through `a2a_dial::canonicalize_agent_name` (`a2a_dial.rs:45`; case-insensitive, downstream uses the canonical name so the runtime spoof check passes).
+
+### 5. Safety
+
+- **Bounded concurrency** — §2 cap, default 8 from the tool.
+- **Fail-closed** — `yes:false` always; risk-tiered (`risk: write`+) steps pause at the existing SHA-256-pinned HITL gate (`mur-core/src/hitl/`). The concierge cannot auto-approve destructive work.
+- **Disjoint ownership** — the tool description references the `parallel-code` skill's gate (disjoint files, no shared registry/lockfile, contracts frozen read-only before fan-out). No merge-reconciler is built.
+- **Input validation at the trust boundary** — MCP input is untrusted: enforce `1 ≤ jobs.len() ≤ MAX_JOBS`, non-empty descriptions, and a resolvable assignee for every job before any dial (fail-closed on any miss).
+
+### 6. Result handling
+
+v1 returns `{channel_id, output}` where `output` is the executor's concatenated `output_text` (`dag.rs:845-850`). The concierge reads **per-job** replies off `channel_id` (every delegate reply is a per-actor channel event with attribution). One failed job becomes an error entry in `output` and is recorded on the channel; it does **not** abort the batch — the executor isolates per-step failures (`on_failure`, per-task results in the await loop). This is the LangGraph "per-branch error marker, don't raise" rule.
+
+## The "N distinct jobs → one fleet" deep-think (requested)
+
+A fleet today = a named squad over one shared channel, run via `build_fleet_procedure(goal, members)` = **one goal broadcast to all members**. The user's "N distinct jobs → one fleet" is a different shape: **distinct work per member**.
+
+Conclusion: this is **not a second mechanism** — it is `build_jobs_procedure` with assignees set to the fleet's member names. In **v1** you express it directly by passing per-job `agent` values that name those members. What's deferred to **v2** is only the *convenience*: a `fleet` param that reads `~/.mur/fleets/<name>/fleet.yaml`, validates membership, auto-spreads jobs across members (round-robin or router), and runs on the fleet's own channel (`fleet-<name>`) so the work lands in the fleet's audit trail and `active_fleet` scope-injection applies. No new types or executor path — just member-list resolution + the fleet channel. Cutting it from v1 removes a real trust-boundary surface (fleet-name validation, membership checks) for no loss of capability.
+
+## Integration risks & gates (must clear in the plan)
+
+1. **First mutating tool in `mur-mcp-server`.** The dependency on `mur-core` already exists (`Cargo.toml:14`); the open question is policy, not wiring: is it acceptable for the MCP process to execute delegations directly, or should it route through the daemon/action-pipeline? Decide explicitly in the plan.
+2. **Target runtimes must be running and fresh.** `channel/delegate` needs each assignee's runtime alive and on a binary that registers `channel/delegate` (the demo's stale-Jun-1-binary `-32601`). Surface a clear, per-assignee error when a target isn't dialable.
+3. **Coder fs-write entitlement must include `~/.mur/channels`** or the v3d-2 peer-self-reply silently drops from the audit trail (known bug, fixed for some agents). Note in the tool's guidance.
+
+## Testing
+
+- **Pure unit (`mur-core`):**
+  - `build_jobs_procedure` — N jobs → N rank-0 steps; each step has `intent == Some(description)` **and** `description == job text` (regression guard for correction #4), unique `id`, empty `depends_on`, correct `delegate_to`.
+  - `resolve_jobs` — per-job agent wins; falls back to default; errors when neither is set; canonicalization applied.
+  - Input-validation rejections: 0 jobs, > MAX_JOBS, empty description.
+- **Concurrency cap (`dag.rs`):** with `max_concurrency = Some(2)` and a counting stub delegate, peak in-flight ≤ 2; `None` preserves unbounded behaviour (regression guard for existing callers).
+- **Live (operator):** real fan-out of distinct jobs to one running agent, and to two explicitly-named agents; needs runtimes + cc-proxy.
+
+## File touch list (v1)
+
+- `mur-core/src/executor/jobs.rs` (new, ~small) — `Job`, `build_jobs_procedure`, `resolve_jobs`, `run_parallel_jobs`, unit tests. Add `pub mod jobs;` to the executor module.
+- `mur-core/src/executor/dag.rs` — `max_concurrency` on `DagExecOptions` (struct + `Default` + spawn-closure reconstruction) + semaphore in the rank loop.
+- `mur-mcp-server/…` — register `parallel_jobs` tool: schema, `resolve_jobs`, `run_parallel_jobs` call, `{channel_id, output}` result, `const MAX_JOBS`. (Exact module mapped in the plan.)
+- Tool description references the `parallel-code` skill gate.

--- a/docs/superpowers/specs/2026-06-24-parallel-jobs-dynamic-fanout-design.md
+++ b/docs/superpowers/specs/2026-06-24-parallel-jobs-dynamic-fanout-design.md
@@ -113,6 +113,7 @@ All names go through `a2a_dial::canonicalize_agent_name` (`a2a_dial.rs:45`; case
 
 ### 5. Safety
 
+- **Target authorization (deny-by-default)** — `parallel_jobs` may only delegate to agents listed in `parallel_jobs.targets` in `~/.mur/config.yaml`; an empty or absent list makes the tool inert. The check is deterministic and runs pre-action (before any channel mint or dial) in `run_parallel_jobs` via `authorize_targets` + `check_authorization`. A prompt-injected concierge cannot widen the target set (OWASP Agentic ASI02/03/04). Grounded in Open Agent Passport (arXiv 2603.20953).
 - **Bounded concurrency** — §2 cap, default 8 from the tool.
 - **Fail-closed** — `yes:false` always; risk-tiered (`risk: write`+) steps pause at the existing SHA-256-pinned HITL gate (`mur-core/src/hitl/`). The concierge cannot auto-approve destructive work.
 - **Disjoint ownership** — the tool description references the `parallel-code` skill's gate (disjoint files, no shared registry/lockfile, contracts frozen read-only before fan-out). No merge-reconciler is built.

--- a/mur-agent-gui/src-tauri/Cargo.toml
+++ b/mur-agent-gui/src-tauri/Cargo.toml
@@ -76,7 +76,7 @@ tempfile = "3"
 # off-by-default `tts` feature. `load-dynamic` keeps onnxruntime out of the
 # link (no static lib → no glibc-2.38 dependency).
 ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "copy-dylibs", "load-dynamic", "api-24"] }
-whisper-rs = { version = "0.11", default-features = false }
+whisper-rs = { version = "0.16", default-features = false }
 cpal = "0.16"
 hound = "3"
 dasp_ring_buffer = "0.11"
@@ -118,7 +118,7 @@ libc = "0.2"
 [target.'cfg(target_os = "macos")'.dependencies]
 # whisper.cpp Metal backend — Apple-only; enabling on Linux/Windows breaks
 # CMake (it looks for the Foundation framework which only exists on macOS).
-whisper-rs = { version = "0.11", default-features = false, features = ["metal"] }
+whisper-rs = { version = "0.16", default-features = false, features = ["metal"] }
 # Track C3 / M-c3.3 — Services menu channel. `objc2` exposes the
 # Objective-C runtime; `objc2-app-kit` and `objc2-foundation` give us
 # NSPasteboard / NSApplication / NSString bindings used by the

--- a/mur-agent-gui/src-tauri/src/voice/stt/whisper.rs
+++ b/mur-agent-gui/src-tauri/src/voice/stt/whisper.rs
@@ -45,11 +45,13 @@ impl WhisperBackend {
             .collect();
         state.full(params, &samples_f32).context("whisper full")?;
 
-        let n = state.full_n_segments().context("whisper full_n_segments")?;
+        // whisper-rs 0.16: full_n_segments() -> i32; text via get_segment(i) +
+        // to_str_lossy() (was full_get_segment_text -> Result<String>).
+        let n = state.full_n_segments();
         let mut out = String::new();
         for i in 0..n {
-            if let Ok(seg) = state.full_get_segment_text(i) {
-                out.push_str(&seg);
+            if let Some(Ok(text)) = state.get_segment(i).map(|seg| seg.to_str_lossy()) {
+                out.push_str(&text);
             }
         }
         Ok(out.trim().to_string())

--- a/mur-agent-runtime/Cargo.toml
+++ b/mur-agent-runtime/Cargo.toml
@@ -112,7 +112,7 @@ indicatif = "0.17"   # progress bar for download
 ort = { version = "2.0.0-rc.12", features = ["ndarray"], optional = true }
 ndarray = { version = "0.17", optional = true }            # tensor arrays for ort
 espeak-ng = "0.1"                                           # espeak-ng G2P for Kokoro tokenizer (pure Rust, no bindgen)
-whisper-rs = { version = "0.11", features = [] }            # whisper.cpp STT bindings (CPU-only; no metal to keep CI clean)
+whisper-rs = { version = "0.16", default-features = false } # whisper.cpp STT bindings (CPU-only; no metal to keep CI clean). 0.16 vendors a modern whisper.cpp that builds under Xcode 16; 0.11 (whisper-rs-sys 0.9) does not.
 cpal = "0.15"                                               # cross-platform audio I/O (mic capture + speaker playback)
 sys-locale = "0.3"                                          # detect the OS locale so STT language/script follows the device, not a hard-coded value
 # B1 sandbox — MCP child process sandboxing (Task 7).

--- a/mur-agent-runtime/src/voice/stt.rs
+++ b/mur-agent-runtime/src/voice/stt.rs
@@ -130,12 +130,16 @@ impl WhisperStt {
 
         state.full(params, samples).context("whisper inference")?;
 
-        let n = state.full_n_segments().context("segment count")?;
+        // whisper-rs 0.16: full_n_segments() -> i32 (no longer Result); segment
+        // text via get_segment(i) -> Option<WhisperSegment> then to_str_lossy().
+        let n = state.full_n_segments();
         let mut transcript = String::new();
         for i in 0..n {
-            match state.full_get_segment_text(i) {
-                Ok(text) => transcript.push_str(&text),
-                Err(_) => tracing::warn!(segment = i, "whisper segment text unavailable; skipping"),
+            match state.get_segment(i).map(|seg| seg.to_str_lossy()) {
+                Some(Ok(text)) => transcript.push_str(&text),
+                Some(Err(_)) | None => {
+                    tracing::warn!(segment = i, "whisper segment text unavailable; skipping")
+                }
             }
         }
         Ok(transcript.trim().to_string())

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -81,6 +81,23 @@ pub struct Config {
     // --- Agent CLI TUI ---
     #[serde(default)]
     pub cli: CliConfig,
+
+    // --- parallel_jobs MCP tool ---
+    #[serde(default)]
+    pub parallel_jobs: ParallelJobsConfig,
+}
+
+/// Authorization gate for the `parallel_jobs` MCP tool. Stored under `parallel_jobs:`
+/// in `~/.mur/config.yaml`. Deny-by-default: an empty `targets` list means the
+/// tool cannot delegate to ANY agent (inert until the user opts specific
+/// agents in). This is a deterministic, out-of-model gate that a
+/// prompt-injected concierge cannot widen (OWASP Agentic ASI02/03/04).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ParallelJobsConfig {
+    /// Canonical agent names the `parallel_jobs` tool is allowed to delegate to.
+    /// Empty = deny all.
+    #[serde(default)]
+    pub targets: Vec<String>,
 }
 
 /// Routing for Anthropic subscription-OAuth (`sk-ant-oat*`) tokens through a

--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -1278,7 +1278,9 @@ mod tests {
                 .collect(),
         };
 
-        // Bounded to 2 -> at least 3 sequential waves -> >= ~0.6s.
+        // Bounded to 2 -> at least 3 sequential waves -> >= ~0.6s (hard floor).
+        // Split threshold is 500ms: well below the ~600ms floor, well above the
+        // ~200-300ms unbounded single-wave time.
         let opts = DagExecOptions {
             max_concurrency: Some(2),
             ..Default::default()
@@ -1289,7 +1291,7 @@ mod tests {
             .unwrap();
         let bounded = t.elapsed();
         assert!(
-            bounded.as_millis() >= 400,
+            bounded.as_millis() >= 500,
             "bounded run finished too fast ({bounded:?}); cap not applied"
         );
 
@@ -1304,7 +1306,7 @@ mod tests {
             .unwrap();
         let unbounded = t2.elapsed();
         assert!(
-            unbounded.as_millis() < 400,
+            unbounded.as_millis() < 500,
             "unbounded run too slow ({unbounded:?}); regression in default path"
         );
     }

--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -44,6 +44,13 @@ pub struct DagExecOptions<'a> {
     /// `idempotency_key`s for channel events. v3b sets keys; v3c enforces dedup,
     /// at which point a crash-rerun MUST reuse the same `run_id`. Empty = none.
     pub run_id: String,
+    /// Cap on the number of steps running concurrently across the whole DAG.
+    /// `None` = unbounded (every same-rank step spawned at once — prior
+    /// behaviour). `Some(n)` bounds total in-flight steps to `n.max(1)` via a
+    /// shared semaphore. The 2026 dynamic-fan-out hard precondition: cap
+    /// concurrency, not just cost, or parallel delegations cascade past API
+    /// rate limits.
+    pub max_concurrency: Option<usize>,
 }
 
 impl<'a> Default for DagExecOptions<'a> {
@@ -57,6 +64,7 @@ impl<'a> Default for DagExecOptions<'a> {
             trigger: "manual",
             channel_id: None,
             run_id: String::new(),
+            max_concurrency: None,
         }
     }
 }
@@ -751,6 +759,12 @@ pub async fn execute_dag(
     // others contribute 0) → the run's PipelineOutput.tokens_used.
     let mut overall_tokens: u64 = 0;
 
+    // Optional global concurrency cap. One semaphore for the whole run bounds
+    // total in-flight steps (across all ranks). `None` => no permit, unbounded.
+    let sem = opts
+        .max_concurrency
+        .map(|n| std::sync::Arc::new(tokio::sync::Semaphore::new(n.max(1))));
+
     for rank in 0..=max_rank {
         let indices: Vec<usize> = (0..graph.nodes.len())
             .filter(|i| graph.nodes[*i].rank == rank)
@@ -780,8 +794,14 @@ pub async fn execute_dag(
             let tr = opt_trigger.clone();
             let chan_id = opt_chan_id.clone();
             let run_id = opt_run_id.clone();
+            let sem = sem.clone();
             let mh = mur_home.to_path_buf();
             handles.push(tokio::task::spawn(async move {
+                // Hold a permit for the whole step when a cap is set.
+                let _permit = match sem {
+                    Some(s) => Some(s.acquire_owned().await.expect("semaphore open")),
+                    None => None,
+                };
                 let opts_clone = DagExecOptions {
                     yes: opt_yes,
                     input: inp,
@@ -791,6 +811,7 @@ pub async fn execute_dag(
                     trigger: &tr,
                     channel_id: chan_id,
                     run_id,
+                    max_concurrency: None,
                 };
                 execute_step(&step, &opts_clone, i, 0, &mh).await
             }));
@@ -1239,5 +1260,52 @@ mod tests {
             .find(|e| e.kind == EventKind::ToolResult)
             .unwrap();
         assert_eq!(tr.payload["exit_code"], 0);
+    }
+
+    #[tokio::test]
+    async fn max_concurrency_bounds_parallel_steps() {
+        // 6 independent rank-0 steps, each sleeping 0.2s.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let proc = Procedure {
+            variables: vec![],
+            steps: (0..6)
+                .map(|i| ProcedureStep {
+                    description: format!("s{i}"),
+                    command: Some("sleep 0.2".to_string()),
+                    id: Some(format!("s{i}")),
+                    ..Default::default()
+                })
+                .collect(),
+        };
+
+        // Bounded to 2 -> at least 3 sequential waves -> >= ~0.6s.
+        let opts = DagExecOptions {
+            max_concurrency: Some(2),
+            ..Default::default()
+        };
+        let t = std::time::Instant::now();
+        execute_dag(tmp.path(), "cc-bounded", &proc, &opts)
+            .await
+            .unwrap();
+        let bounded = t.elapsed();
+        assert!(
+            bounded.as_millis() >= 400,
+            "bounded run finished too fast ({bounded:?}); cap not applied"
+        );
+
+        // Unbounded -> single wave -> ~0.2s.
+        let opts2 = DagExecOptions {
+            max_concurrency: None,
+            ..Default::default()
+        };
+        let t2 = std::time::Instant::now();
+        execute_dag(tmp.path(), "cc-unbounded", &proc, &opts2)
+            .await
+            .unwrap();
+        let unbounded = t2.elapsed();
+        assert!(
+            unbounded.as_millis() < 400,
+            "unbounded run too slow ({unbounded:?}); regression in default path"
+        );
     }
 }

--- a/mur-core/src/executor/jobs.rs
+++ b/mur-core/src/executor/jobs.rs
@@ -4,7 +4,12 @@
 //! to per-job prompts with a free assignee. See
 //! `docs/superpowers/specs/2026-06-24-parallel-jobs-dynamic-fanout-design.md`.
 
+use std::path::Path;
+
+use anyhow::{Result, anyhow, bail};
 use mur_common::skill::manifest::{Procedure, ProcedureStep};
+
+use crate::a2a_dial::canonicalize_agent_name;
 
 /// A single job: a prompt and the (canonicalized) agent to delegate it to.
 pub struct Job {
@@ -32,6 +37,46 @@ pub fn build_jobs_procedure(jobs: &[Job]) -> Procedure {
     }
 }
 
+/// Untyped job as it arrives from the MCP tool: a description and an optional
+/// explicit assignee. Resolved into a `Job` by `resolve_jobs`.
+pub struct RawJob {
+    pub description: String,
+    pub agent: Option<String>,
+}
+
+/// Resolve each `RawJob` to a `Job` with a concrete, canonicalized assignee.
+/// Precedence per job: explicit `agent` -> `default_agent` -> error.
+/// Rejects empty descriptions. Names are canonicalized so the runtime
+/// spoof check passes (case-insensitive on-disk match, else used verbatim).
+pub fn resolve_jobs(
+    mur_home: &Path,
+    raw: &[RawJob],
+    default_agent: Option<&str>,
+) -> Result<Vec<Job>> {
+    if raw.is_empty() {
+        bail!("no jobs provided");
+    }
+    raw.iter()
+        .enumerate()
+        .map(|(i, j)| {
+            if j.description.trim().is_empty() {
+                bail!("job {i} has an empty description");
+            }
+            let assignee = j
+                .agent
+                .as_deref()
+                .or(default_agent)
+                .ok_or_else(|| {
+                    anyhow!("job {i} has no assignee: pass per-job `agent` or a top-level default `agent`")
+                })?;
+            Ok(Job {
+                description: j.description.clone(),
+                assignee: canonicalize_agent_name(mur_home, assignee),
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -55,5 +100,29 @@ mod tests {
         assert_eq!(p.steps[1].id.as_deref(), Some("job-1"));
         // all rank-0 (no dependencies => all parallel)
         assert!(p.steps.iter().all(|s| s.depends_on.is_empty()));
+    }
+
+    #[test]
+    fn resolve_jobs_precedence_and_validation() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+
+        // per-job agent wins over the default
+        let raw = vec![RawJob { description: "A".into(), agent: Some("rustsmith".into()) }];
+        let jobs = resolve_jobs(home, &raw, Some("frontend")).unwrap();
+        assert_eq!(jobs[0].assignee, "rustsmith");
+
+        // falls back to the default agent when a job omits its own
+        let raw = vec![RawJob { description: "B".into(), agent: None }];
+        let jobs = resolve_jobs(home, &raw, Some("frontend")).unwrap();
+        assert_eq!(jobs[0].assignee, "frontend");
+
+        // error when neither a per-job nor a default agent is set
+        let raw = vec![RawJob { description: "C".into(), agent: None }];
+        assert!(resolve_jobs(home, &raw, None).is_err());
+
+        // error on an empty description
+        let raw = vec![RawJob { description: "  ".into(), agent: Some("rustsmith".into()) }];
+        assert!(resolve_jobs(home, &raw, None).is_err());
     }
 }

--- a/mur-core/src/executor/jobs.rs
+++ b/mur-core/src/executor/jobs.rs
@@ -4,10 +4,12 @@
 //! to per-job prompts with a free assignee. See
 //! `docs/superpowers/specs/2026-06-24-parallel-jobs-dynamic-fanout-design.md`.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use anyhow::{Result, anyhow, bail};
 use mur_channel::ChannelService;
+use mur_common::config::Config;
 use mur_common::pipeline::PipelineOutput;
 use mur_common::skill::manifest::{Procedure, ProcedureStep};
 
@@ -78,6 +80,38 @@ pub fn resolve_jobs(
         .collect()
 }
 
+/// Pure deterministic gate: every job's assignee must be in `allow`.
+/// Fail-closed: any miss returns an Err immediately. Called before any
+/// channel mint or dial so a prompt-injected concierge cannot widen the
+/// target set (OWASP Agentic ASI02/03/04).
+fn check_authorization(allow: &HashSet<String>, jobs: &[Job]) -> Result<()> {
+    for j in jobs {
+        if !allow.contains(&j.assignee) {
+            bail!(
+                "target '{}' not authorized for parallel_jobs — add it to `parallel_jobs.targets` \
+                 in ~/.mur/config.yaml (deny-by-default)",
+                j.assignee
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Load the allowlist from config, canonicalize each entry, then verify all
+/// jobs' targets are in the allowlist. Deterministic, pre-action, fail-closed.
+/// Mirrors the `verified_active_fleet` pattern (any miss is a denial, never
+/// fail-open).
+fn authorize_targets(mur_home: &Path, jobs: &[Job]) -> Result<()> {
+    let cfg = Config::load_or_default(&mur_home.join("config.yaml"));
+    let allow: HashSet<String> = cfg
+        .parallel_jobs
+        .targets
+        .iter()
+        .map(|t| canonicalize_agent_name(mur_home, t))
+        .collect();
+    check_authorization(&allow, jobs)
+}
+
 /// Run N jobs as one ephemeral, channel-recorded DAG. Mints a throwaway
 /// workflow channel, fans the jobs out (bounded by `max_concurrency`), and
 /// returns `(channel_id, output)`. Per-job replies are persisted on the
@@ -89,6 +123,7 @@ pub async fn run_parallel_jobs(
     max_concurrency: Option<usize>,
     yes: bool,
 ) -> Result<(String, PipelineOutput)> {
+    authorize_targets(mur_home, jobs)?;
     let proc = build_jobs_procedure(jobs);
     let svc = ChannelService::open(mur_home)?;
     let channel_id = svc.create_for_workflow("parallel-jobs")?.id;
@@ -100,7 +135,9 @@ pub async fn run_parallel_jobs(
         max_concurrency,
         ..Default::default()
     };
-    let out = execute_dag(mur_home, "parallel-jobs", &proc, &opts).await?;
+    let out = execute_dag(mur_home, "parallel-jobs", &proc, &opts)
+        .await
+        .map_err(|e| anyhow::anyhow!("parallel_jobs run on channel {channel_id} failed: {e}"))?;
     Ok((channel_id, out))
 }
 
@@ -171,12 +208,111 @@ mod tests {
         assert!(resolve_jobs(home, &raw, None).is_err());
     }
 
+    // ── check_authorization unit tests ───────────────────────────────────────
+
+    #[test]
+    fn check_authorization_is_deny_by_default() {
+        // Empty allowlist => every target is rejected.
+        let allow: HashSet<String> = HashSet::new();
+        let jobs = vec![Job {
+            description: "a".into(),
+            assignee: "rustsmith".into(),
+        }];
+        assert!(
+            check_authorization(&allow, &jobs).is_err(),
+            "empty allowlist must reject any target"
+        );
+    }
+
+    #[test]
+    fn check_authorization_permits_listed_target() {
+        let allow: HashSet<String> = ["rustsmith".to_string()].into();
+        let jobs = vec![Job {
+            description: "a".into(),
+            assignee: "rustsmith".into(),
+        }];
+        assert!(
+            check_authorization(&allow, &jobs).is_ok(),
+            "allowlisted target must be permitted"
+        );
+    }
+
+    #[test]
+    fn check_authorization_rejects_unlisted_target() {
+        let allow: HashSet<String> = ["rustsmith".to_string()].into();
+        let jobs = vec![Job {
+            description: "a".into(),
+            assignee: "unknown-agent".into(),
+        }];
+        let err = check_authorization(&allow, &jobs).unwrap_err();
+        assert!(
+            err.to_string().contains("not authorized"),
+            "error must mention authorization: {err}"
+        );
+    }
+
+    #[test]
+    fn check_authorization_rejects_first_unlisted_in_mixed_list() {
+        // First job is allowed, second is not — gate must fail on the unlisted one.
+        let allow: HashSet<String> = ["rustsmith".to_string()].into();
+        let jobs = vec![
+            Job {
+                description: "a".into(),
+                assignee: "rustsmith".into(),
+            },
+            Job {
+                description: "b".into(),
+                assignee: "intruder".into(),
+            },
+        ];
+        assert!(
+            check_authorization(&allow, &jobs).is_err(),
+            "must reject when any target is not in the allowlist"
+        );
+    }
+
+    // ── run_parallel_jobs integration: gate blocks before channel mint ───────
+
+    #[tokio::test]
+    async fn run_parallel_jobs_blocked_by_empty_allowlist() {
+        // No config.yaml => empty allowlist => gate rejects before any channel is minted.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let jobs = vec![Job {
+            description: "do A".into(),
+            assignee: "nonexistent-agent-xyz".into(),
+        }];
+        let result = run_parallel_jobs(tmp.path(), &jobs, Some(2), false).await;
+        assert!(
+            result.is_err(),
+            "empty allowlist must block run_parallel_jobs"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("not authorized"),
+            "error must mention authorization: {err}"
+        );
+        // No channel should have been minted.
+        let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+        let channels = svc.list(100).unwrap_or_default();
+        assert!(
+            channels.is_empty(),
+            "no channel must be minted when the gate rejects"
+        );
+    }
+
     #[tokio::test]
     async fn run_parallel_jobs_mints_channel_even_when_delegate_unreachable() {
-        // No runtime is running, so the delegate dial fails fast (RequireRunning).
-        // run_parallel_jobs must still mint the channel and return Ok (the
-        // executor turns a failed delegate into a failed step, not an Err).
+        // Write an allowlisting config.yaml so the gate passes, then verify the
+        // channel is minted even though the delegate is unreachable at runtime.
+        // (No runtime is running, so the delegate dial fails fast (RequireRunning).
+        // run_parallel_jobs must still mint the channel and return Ok — the
+        // executor turns a failed delegate into a failed step, not an Err.)
         let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            tmp.path().join("config.yaml"),
+            "parallel_jobs:\n  targets:\n    - nonexistent-agent-xyz\n",
+        )
+        .unwrap();
         let jobs = vec![Job {
             description: "do A".into(),
             assignee: "nonexistent-agent-xyz".into(),

--- a/mur-core/src/executor/jobs.rs
+++ b/mur-core/src/executor/jobs.rs
@@ -1,0 +1,59 @@
+//! Ephemeral parallel-jobs fan-out: build an in-memory DAG of rank-0
+//! `delegate_to` steps (one per job) and run it through `execute_dag` — no
+//! authored workflow/skill file. Generalizes fleet broadcast (`cmd/fleet/run.rs`)
+//! to per-job prompts with a free assignee. See
+//! `docs/superpowers/specs/2026-06-24-parallel-jobs-dynamic-fanout-design.md`.
+
+use mur_common::skill::manifest::{Procedure, ProcedureStep};
+
+/// A single job: a prompt and the (canonicalized) agent to delegate it to.
+pub struct Job {
+    pub description: String,
+    pub assignee: String,
+}
+
+/// One rank-0 `ProcedureStep` per job (all parallel, no deps). Sets BOTH
+/// `intent` (the delegate prompt) and `description` (channel/ledger labels)
+/// to the job text, and a stable unique `id` for idempotency / crash-resume.
+pub fn build_jobs_procedure(jobs: &[Job]) -> Procedure {
+    Procedure {
+        variables: vec![],
+        steps: jobs
+            .iter()
+            .enumerate()
+            .map(|(i, j)| ProcedureStep {
+                description: j.description.clone(),
+                intent: Some(j.description.clone()),
+                delegate_to: Some(j.assignee.clone()),
+                id: Some(format!("job-{i}")),
+                ..Default::default()
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_jobs_procedure_one_rank0_step_per_job() {
+        let jobs = vec![
+            Job { description: "add caching to fetch".into(), assignee: "rustsmith".into() },
+            Job { description: "write the README".into(), assignee: "frontend".into() },
+        ];
+        let p = build_jobs_procedure(&jobs);
+        assert_eq!(p.steps.len(), 2);
+        // delegate target per job
+        assert_eq!(p.steps[0].delegate_to.as_deref(), Some("rustsmith"));
+        assert_eq!(p.steps[1].delegate_to.as_deref(), Some("frontend"));
+        // BOTH intent (prompt) and description (labels) carry the job text
+        assert_eq!(p.steps[0].intent.as_deref(), Some("add caching to fetch"));
+        assert_eq!(p.steps[0].description, "add caching to fetch");
+        // stable, unique ids
+        assert_eq!(p.steps[0].id.as_deref(), Some("job-0"));
+        assert_eq!(p.steps[1].id.as_deref(), Some("job-1"));
+        // all rank-0 (no dependencies => all parallel)
+        assert!(p.steps.iter().all(|s| s.depends_on.is_empty()));
+    }
+}

--- a/mur-core/src/executor/jobs.rs
+++ b/mur-core/src/executor/jobs.rs
@@ -7,9 +7,12 @@
 use std::path::Path;
 
 use anyhow::{Result, anyhow, bail};
+use mur_channel::ChannelService;
+use mur_common::pipeline::PipelineOutput;
 use mur_common::skill::manifest::{Procedure, ProcedureStep};
 
 use crate::a2a_dial::canonicalize_agent_name;
+use crate::executor::dag::{DagExecOptions, execute_dag};
 
 /// A single job: a prompt and the (canonicalized) agent to delegate it to.
 pub struct Job {
@@ -77,6 +80,32 @@ pub fn resolve_jobs(
         .collect()
 }
 
+/// Run N jobs as one ephemeral, channel-recorded DAG. Mints a throwaway
+/// workflow channel, fans the jobs out (bounded by `max_concurrency`), and
+/// returns `(channel_id, output)`. Per-job replies are persisted on the
+/// channel; the caller reads them back via `channel_id`. `yes` is passed
+/// straight through — `false` keeps risk-tiered steps fail-closed at the HITL gate.
+pub async fn run_parallel_jobs(
+    mur_home: &Path,
+    jobs: &[Job],
+    max_concurrency: Option<usize>,
+    yes: bool,
+) -> Result<(String, PipelineOutput)> {
+    let proc = build_jobs_procedure(jobs);
+    let svc = ChannelService::open(mur_home)?;
+    let channel_id = svc.create_for_workflow("parallel-jobs")?.id;
+    let opts = DagExecOptions {
+        yes,
+        trigger: "agent",
+        channel_id: Some(channel_id.clone()),
+        run_id: format!("run-{}", uuid::Uuid::now_v7()),
+        max_concurrency,
+        ..Default::default()
+    };
+    let out = execute_dag(mur_home, "parallel-jobs", &proc, &opts).await?;
+    Ok((channel_id, out))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -124,5 +153,24 @@ mod tests {
         // error on an empty description
         let raw = vec![RawJob { description: "  ".into(), agent: Some("rustsmith".into()) }];
         assert!(resolve_jobs(home, &raw, None).is_err());
+    }
+
+    #[tokio::test]
+    async fn run_parallel_jobs_mints_channel_even_when_delegate_unreachable() {
+        // No runtime is running, so the delegate dial fails fast (RequireRunning).
+        // run_parallel_jobs must still mint the channel and return Ok (the
+        // executor turns a failed delegate into a failed step, not an Err).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let jobs = vec![Job {
+            description: "do A".into(),
+            assignee: "nonexistent-agent-xyz".into(),
+        }];
+        let (channel_id, _out) = run_parallel_jobs(tmp.path(), &jobs, Some(2), false)
+            .await
+            .expect("must not error when the delegate is unreachable");
+        assert!(!channel_id.is_empty(), "a channel should have been minted");
+        // The minted channel is persisted and loadable.
+        let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+        assert!(svc.load_events(&channel_id).is_ok());
     }
 }

--- a/mur-core/src/executor/jobs.rs
+++ b/mur-core/src/executor/jobs.rs
@@ -65,13 +65,11 @@ pub fn resolve_jobs(
             if j.description.trim().is_empty() {
                 bail!("job {i} has an empty description");
             }
-            let assignee = j
-                .agent
-                .as_deref()
-                .or(default_agent)
-                .ok_or_else(|| {
-                    anyhow!("job {i} has no assignee: pass per-job `agent` or a top-level default `agent`")
-                })?;
+            let assignee = j.agent.as_deref().or(default_agent).ok_or_else(|| {
+                anyhow!(
+                    "job {i} has no assignee: pass per-job `agent` or a top-level default `agent`"
+                )
+            })?;
             Ok(Job {
                 description: j.description.clone(),
                 assignee: canonicalize_agent_name(mur_home, assignee),
@@ -113,8 +111,14 @@ mod tests {
     #[test]
     fn build_jobs_procedure_one_rank0_step_per_job() {
         let jobs = vec![
-            Job { description: "add caching to fetch".into(), assignee: "rustsmith".into() },
-            Job { description: "write the README".into(), assignee: "frontend".into() },
+            Job {
+                description: "add caching to fetch".into(),
+                assignee: "rustsmith".into(),
+            },
+            Job {
+                description: "write the README".into(),
+                assignee: "frontend".into(),
+            },
         ];
         let p = build_jobs_procedure(&jobs);
         assert_eq!(p.steps.len(), 2);
@@ -137,21 +141,33 @@ mod tests {
         let home = tmp.path();
 
         // per-job agent wins over the default
-        let raw = vec![RawJob { description: "A".into(), agent: Some("rustsmith".into()) }];
+        let raw = vec![RawJob {
+            description: "A".into(),
+            agent: Some("rustsmith".into()),
+        }];
         let jobs = resolve_jobs(home, &raw, Some("frontend")).unwrap();
         assert_eq!(jobs[0].assignee, "rustsmith");
 
         // falls back to the default agent when a job omits its own
-        let raw = vec![RawJob { description: "B".into(), agent: None }];
+        let raw = vec![RawJob {
+            description: "B".into(),
+            agent: None,
+        }];
         let jobs = resolve_jobs(home, &raw, Some("frontend")).unwrap();
         assert_eq!(jobs[0].assignee, "frontend");
 
         // error when neither a per-job nor a default agent is set
-        let raw = vec![RawJob { description: "C".into(), agent: None }];
+        let raw = vec![RawJob {
+            description: "C".into(),
+            agent: None,
+        }];
         assert!(resolve_jobs(home, &raw, None).is_err());
 
         // error on an empty description
-        let raw = vec![RawJob { description: "  ".into(), agent: Some("rustsmith".into()) }];
+        let raw = vec![RawJob {
+            description: "  ".into(),
+            agent: Some("rustsmith".into()),
+        }];
         assert!(resolve_jobs(home, &raw, None).is_err());
     }
 

--- a/mur-core/src/executor/mod.rs
+++ b/mur-core/src/executor/mod.rs
@@ -1,2 +1,3 @@
 pub mod dag;
+pub mod jobs;
 pub mod pipeline;

--- a/mur-core/src/executor/mod.rs
+++ b/mur-core/src/executor/mod.rs
@@ -1,3 +1,4 @@
 pub mod dag;
+#[allow(dead_code)] // jobs.rs's pub API consumed cross-crate by mur-mcp-server, not by mur binary
 pub mod jobs;
 pub mod pipeline;

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -35,7 +35,6 @@ mod action_pipeline;
 #[allow(dead_code)]
 mod discovery;
 mod evolve;
-#[allow(dead_code)]
 mod executor;
 mod extract;
 mod extract_llm;

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -35,6 +35,7 @@ mod action_pipeline;
 #[allow(dead_code)]
 mod discovery;
 mod evolve;
+#[allow(dead_code)]
 mod executor;
 mod extract;
 mod extract_llm;

--- a/mur-mcp-server/src/tools.rs
+++ b/mur-mcp-server/src/tools.rs
@@ -336,6 +336,36 @@ pub fn all_tools() -> Vec<Tool> {
                 required: None,
             },
         },
+        Tool {
+            name: "parallel_jobs".into(),
+            description: "Fan out N distinct jobs to running MUR agents in parallel over an ephemeral channel — no workflow file. Each job is delegated as its own concurrent turn. Before coding fan-out, apply the parallel-code gate: disjoint files (no shared registry/lockfile), contracts frozen first, one writer per file. Targets the agents you name; runtimes must already be running.".into(),
+            input_schema: ToolInputSchema {
+                schema_type: "object".into(),
+                properties: Some(BTreeMap::from([
+                    ("jobs".into(), ToolParam {
+                        param_type: "array".into(),
+                        description: "Jobs to run in parallel. Each: { description: string, agent?: string }.".into(),
+                        default: None,
+                    }),
+                    ("agent".into(), ToolParam {
+                        param_type: "string".into(),
+                        description: "Default assignee agent name for jobs that omit their own `agent`.".into(),
+                        default: None,
+                    }),
+                    ("max_concurrency".into(), ToolParam {
+                        param_type: "integer".into(),
+                        description: "Max jobs in flight at once, 1-32 (default 8).".into(),
+                        default: Some(json!(8)),
+                    }),
+                    ("yes".into(), ToolParam {
+                        param_type: "boolean".into(),
+                        description: "Auto-approve risk-tiered steps. Default false (fail-closed).".into(),
+                        default: Some(json!(false)),
+                    }),
+                ])),
+                required: Some(vec!["jobs".into()]),
+            },
+        },
     ]
 }
 
@@ -675,6 +705,59 @@ async fn dispatch_tool(name: &str, arguments: &Value) -> Result<Value, String> {
                 "savings_percent": s.savings_percent,
                 "estimated_cost_saved_usd": s.estimated_cost_saved_usd,
                 "store": { "entries": s.store_entries, "bytes": s.store_bytes },
+            }))
+        }
+
+        "parallel_jobs" => {
+            // Input guardrails (not behaviour config — see spec §3).
+            const MAX_JOBS: usize = 32;
+            const DEFAULT_MAX_CONCURRENCY: u64 = 8;
+
+            let raw = arguments
+                .get("jobs")
+                .and_then(|v| v.as_array())
+                .ok_or_else(|| "Missing required parameter: 'jobs' (array)".to_string())?;
+            if raw.is_empty() || raw.len() > MAX_JOBS {
+                return Err(format!(
+                    "'jobs' must have 1..={MAX_JOBS} entries (got {})",
+                    raw.len()
+                ));
+            }
+            let jobs_in: Vec<mur_core::executor::jobs::RawJob> = raw
+                .iter()
+                .map(|j| mur_core::executor::jobs::RawJob {
+                    description: j
+                        .get("description")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    agent: j
+                        .get("agent")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                })
+                .collect();
+            let default_agent = arguments.get("agent").and_then(|v| v.as_str());
+            let max_concurrency = arguments
+                .get("max_concurrency")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(DEFAULT_MAX_CONCURRENCY)
+                .clamp(1, MAX_JOBS as u64) as usize;
+            let yes = arguments
+                .get("yes")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            let home = resolve_mur_home().map_err(|e| format!("parallel_jobs failed: {e}"))?;
+            let jobs = mur_core::executor::jobs::resolve_jobs(&home, &jobs_in, default_agent)
+                .map_err(|e| format!("parallel_jobs: {e}"))?;
+            let (channel_id, out) =
+                mur_core::executor::jobs::run_parallel_jobs(&home, &jobs, Some(max_concurrency), yes)
+                    .await
+                    .map_err(|e| format!("parallel_jobs failed: {e}"))?;
+            Ok(json!({
+                "channel_id": channel_id,
+                "output": out.output_text.unwrap_or_default(),
             }))
         }
 

--- a/mur-mcp-server/src/tools.rs
+++ b/mur-mcp-server/src/tools.rs
@@ -751,10 +751,14 @@ async fn dispatch_tool(name: &str, arguments: &Value) -> Result<Value, String> {
             let home = resolve_mur_home().map_err(|e| format!("parallel_jobs failed: {e}"))?;
             let jobs = mur_core::executor::jobs::resolve_jobs(&home, &jobs_in, default_agent)
                 .map_err(|e| format!("parallel_jobs: {e}"))?;
-            let (channel_id, out) =
-                mur_core::executor::jobs::run_parallel_jobs(&home, &jobs, Some(max_concurrency), yes)
-                    .await
-                    .map_err(|e| format!("parallel_jobs failed: {e}"))?;
+            let (channel_id, out) = mur_core::executor::jobs::run_parallel_jobs(
+                &home,
+                &jobs,
+                Some(max_concurrency),
+                yes,
+            )
+            .await
+            .map_err(|e| format!("parallel_jobs failed: {e}"))?;
             Ok(json!({
                 "channel_id": channel_id,
                 "output": out.output_text.unwrap_or_default(),

--- a/mur-mcp-server/tests/integration.rs
+++ b/mur-mcp-server/tests/integration.rs
@@ -52,7 +52,7 @@ fn test_initialize_and_list_tools() {
     );
     let resp = read_response(&mut stdout);
     let tools = resp["result"]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 18, "Expected 18 tools");
+    assert_eq!(tools.len(), 19, "Expected 19 tools");
 
     // Verify properties is an object (not an array) — MCP spec requires JSON object
     let first_tool_with_props = tools
@@ -85,6 +85,7 @@ fn test_initialize_and_list_tools() {
     assert!(names.contains(&"mur_compress"));
     assert!(names.contains(&"mur_retrieve"));
     assert!(names.contains(&"mur_compress_stats"));
+    assert!(names.contains(&"parallel_jobs"));
 
     child.kill().ok();
 }
@@ -226,6 +227,42 @@ fn calls_mur_compress_tool() {
     assert!(
         resp_str.contains("hash="),
         "mur_compress result should include a retrieval-hash note: {resp_str}"
+    );
+
+    child.kill().ok();
+}
+
+#[test]
+fn parallel_jobs_rejects_empty_jobs() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_mur-mcp-server"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = std::io::BufReader::new(child.stdout.take().unwrap());
+
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}"#,
+    );
+    let _ = read_response(&mut stdout);
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+    );
+
+    // Empty jobs array -> tool returns an error envelope (isError), never panics.
+    send_request(
+        &mut stdin,
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"parallel_jobs","arguments":{"jobs":[],"agent":"rustsmith"}}}"#,
+    );
+    let resp = read_response(&mut stdout);
+    let resp_str = serde_json::to_string(&resp).unwrap();
+    assert!(
+        resp_str.contains("isError") || resp_str.to_lowercase().contains("error"),
+        "empty jobs should yield an error envelope: {resp_str}"
     );
 
     child.kill().ok();


### PR DESCRIPTION
## What

A new `parallel_jobs` MCP tool that lets the concierge fan **N distinct ad-hoc jobs** out to running agents over an **ephemeral, in-memory DAG** — no per-job workflow YAML/skill authored. This generalizes the existing fleet-broadcast machinery (`build_fleet_procedure` → `execute_dag`) from "one shared goal → all members" to "per-job prompt → free assignee".

Solves the pain that running N parallel jobs previously required authoring a `category:Workflow` skill per fan-out (the per-job-static-template anti-pattern the 2026 literature flags). It's the `code_fanout` tool prior project notes flagged as the deferred "v2" of the `parallel-code` skill.

## Design

Spec: `docs/superpowers/specs/2026-06-24-parallel-jobs-dynamic-fanout-design.md`
Plan: `docs/superpowers/plans/2026-06-24-parallel-jobs-dynamic-fanout.md`

- **`mur-core/src/executor/jobs.rs`** (new) — `Job`, `build_jobs_procedure` (one rank-0 `delegate_to` step per job, `intent`+`description` both set, stable ids), `RawJob` + `resolve_jobs` (assignee precedence: per-job → default → error, canonicalized), and `run_parallel_jobs` (mints a throwaway channel, runs the ephemeral DAG, returns `{channel_id, output}`).
- **`mur-core/src/executor/dag.rs`** — one additive change: `max_concurrency: Option<usize>` on `DagExecOptions`, bounded via a `tokio::Semaphore` in the rank loop. `None` = today's unbounded behaviour (every existing caller unchanged); retro-fits the fleet path for free. Hard precondition from the 2026 concurrency literature (cap concurrency, not just cost).
- **`mur-mcp-server`** — the `parallel_jobs` tool (schema + dispatch arm). First **mutating** tool in that server. Returns `{channel_id, output}`; per-job replies are read back off the channel.

## Security — deny-by-default target authorization

`parallel_jobs` is the first path where the concierge can **autonomously** delegate to other agents, so a prompt-injected concierge is the threat. A whole-branch adversarial review flagged the absence of any target gate; resolved with a **deny-by-default allowlist**:

- Targets must be listed in `parallel_jobs.targets` in `~/.mur/config.yaml`. **Empty/absent ⇒ the tool is inert** (deny all).
- Enforced **deterministically, out-of-model, pre-action** at the top of `run_parallel_jobs` — before the channel is minted or any agent dialed — **fail-closed** (any miss → `Err`), after canonicalization (so a config entry matches the on-disk agent name).
- Grounded in OWASP Agentic 2026 (ASI02 least-agency / ASI03 unauthorized-delegation / ASI04 vetted allowlist) + Open Agent Passport (arXiv:2603.20953, deny-by-default pre-action authz) + Cerbos MCP authorization.
- No env master-switch (deliberate): unlike the *unattended* daemon's `MUR_FLEET_AUTORUN`, `parallel_jobs` is *attended* (concierge-triggered), so the empty-by-default allowlist already provides opt-in-OFF + a config kill-switch.

Other safety: `yes` defaults `false` (risk-tiered steps stay HITL-gated); input bounded (`MAX_JOBS`, `max_concurrency` clamp); the tool description points at the `parallel-code` disjoint-ownership gate.

## Process

Built brainstorm → spec → plan → subagent-driven execution (6 tasks, fresh implementer + two-verdict review each) → **whole-branch adversarial review** (4 lenses → skeptic-verify → triage): 2 confirmed must-fixes (the authz gate + an over-broad dead-code allow) → fixed → security-focused re-review → **ready to merge**. The authorization design was chosen via a dedicated deep-research pass.

## Tests

- `mur-core` `executor::` — 72/72 (incl. concurrency-cap, `build_jobs_procedure`, `resolve_jobs`, `check_authorization` deny-by-default, `run_parallel_jobs` gate + channel-mint).
- `mur-mcp-server` — 10/10 (tool registration 18→19, empty-jobs rejection).
- `cargo fmt --check` clean; `cargo clippy -p mur-core -p mur-mcp-server -- -D warnings` clean.

## Deferred to v2

Fleet-roster auto-distribute (`fleet` param + round-robin/router), typed per-job result envelope, fan-in verify step, budget ceiling, env master-switch, channel-participant declaration for delegated targets, per-content scoping.

## Operator-pending

Live end-to-end fan-out (concurrent delegation, HITL fail-closed at `yes:false`, channel read-back) needs running runtimes + cc-proxy — not covered by the automated tests.

## ⚠️ Note for the reviewer

This branch also contains **`61b9feae docs(spec): mur fleet job intake + roster management design`** — an **unrelated** doc from a concurrent session (no code overlap with this feature). It can be split out on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
