### PR TITLE
ci(release): ship mur-agent-runtime in brew/release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,14 +137,18 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ../../../${{ matrix.name }}.tar.gz mur mur-mcp-server murmurd
+          # Ship mur-agent-runtime too: brew installs it as a sibling of `mur`, so
+          # resolve_runtime_target finds the sibling and `brew upgrade` keeps the
+          # runtime in sync. Without it, brew CLI users have no runtime and running
+          # agents drift on a stale one (the runtime otherwise ships only in the Hub .app).
+          tar czf ../../../${{ matrix.name }}.tar.gz mur mur-mcp-server murmurd mur-agent-runtime
           cd ../../..
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Compress-Archive -Path target/${{ matrix.target }}/release/mur.exe,target/${{ matrix.target }}/release/mur-mcp-server.exe,target/${{ matrix.target }}/release/murmurd.exe -DestinationPath ${{ matrix.name }}.zip
+          Compress-Archive -Path target/${{ matrix.target }}/release/mur.exe,target/${{ matrix.target }}/release/mur-mcp-server.exe,target/${{ matrix.target }}/release/murmurd.exe,target/${{ matrix.target }}/release/mur-agent-runtime.exe -DestinationPath ${{ matrix.name }}.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -532,6 +536,7 @@ jobs:
               bin.install "mur"
               bin.install "mur-mcp-server"
               bin.install "murmurd"
+              bin.install "mur-agent-runtime"
               bin.install_symlink "mur" => "murmur"
             end
 


### PR DESCRIPTION
## Problem

The release tarball (`release.yml:140`) and the generated Homebrew formula (`bin.install`) shipped only `mur`, `mur-mcp-server`, `murmurd` — **never `mur-agent-runtime`**. Consequences:
- **brew CLI users had no runtime at all** (it travelled only inside the Hub `.app` bundle).
- `brew upgrade mur` never updated the runtime, so **running agents drift onto a stale runtime** — e.g. one that predates the #489 macOS DNS/sandbox fix, which broke an agent's outbound LLM call and an A2A `channel/delegate` dial in live testing.

## Fix

Ship `mur-agent-runtime` alongside the other binaries (it's already built by the workspace release build):
- add it to the macOS/Linux `tar.gz` and the Windows `.zip`
- `bin.install "mur-agent-runtime"` in the formula

It then installs as a **sibling of `mur`** in `/opt/homebrew/bin`, so `resolve_runtime_target` finds the sibling (next to the `mur` exe) and **`brew upgrade mur` keeps the runtime in sync** — no more drift. Hub (.app bundle) and dev (`build.sh` → `~/.local/bin`) paths already handle this; brew was the gap.

## Caveat (separate follow-up)

Updating the binary on disk does **not** restart already-running launchd agents — they keep their old process until restarted. The right policy for that (notify-to-restart vs version-skew detection vs auto-restart) is being researched and tracked separately; this PR only closes the *binary never shipped to brew* gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)