### PR TITLE
feat(agent): runtime upgrade — stale-detect + A2A version-gate + graceful restart

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -87,5 +87,14 @@ if $INSTALL; then
     echo "Installed mur-agent-runtime -> $LOCAL_BIN/mur-agent-runtime (canonical; keeps new agents current)"
   fi
 
+  # Nudge: running agents keep their OLD process until restarted, so they're
+  # still on the pre-upgrade runtime. Tell the operator (print-only; never auto-restart).
+  if command -v mur >/dev/null 2>&1; then
+    STALE=$(mur agent runtime-doctor --json 2>/dev/null | grep -c '"stale": *true' || true)
+    if [ "${STALE:-0}" -gt 0 ]; then
+      echo "⚠ $STALE agent(s) are running a stale runtime — run 'mur agent restart --stale' (--dry-run to list)"
+    fi
+  fi
+
   echo "✅ Installed: $(mur --version 2>/dev/null || echo 'done')"
 fi

--- a/docs/superpowers/plans/2026-06-24-agent-runtime-upgrade-restart.md
+++ b/docs/superpowers/plans/2026-06-24-agent-runtime-upgrade-restart.md
@@ -1,0 +1,669 @@
+# Agent Runtime Upgrade — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect stale agent runtimes, version-gate the A2A dial so version skew fails with an actionable error (not opaque `-32601`), and graceful-restart agents (drain in-flight work; never auto-bounce).
+
+**Architecture:** Embed a build-id (git sha) + a semantic `A2A_PROTO_VERSION` in `mur-common`; carry both in `running.lock` + the AgentCard. The dial pre-checks the peer's proto and refuses unsupported methods with a `StaleRuntime` error. A `doctor`/`status`/post-build nudge compares build-ids to flag stale agents. SIGTERM drains the in-flight turn before teardown; `mur agent restart` SIGTERMs the pid and lets launchd respawn on the fresh binary.
+
+**Tech Stack:** Rust (edition 2024), `mur-common` (constants + LockFile), `mur-agent-runtime` (supervisor/TaskRunner/card), `mur-core` (`a2a_dial`, `cmd/agent`), launchd `KeepAlive`.
+
+## Global Constraints
+
+- **Rust edition 2024.** No hardcoded behaviour values — version numbers are named consts.
+- **mur-core / mur-agent-runtime tests need `ORT_STRATEGY=download`** and run under `cargo nextest`, not `cargo test`. All commands below use it.
+- **Back-compat is mandatory:** new `LockFile` fields are `#[serde(default)]` so old locks parse (absent → `""` / `0` = "stale / unsupported", which is the intended reading). `method_min_proto == 0` methods (`message/send`) are NEVER gated.
+- **Never auto-restart a running agent.** Notify is print-only. Restart is explicit and graceful (SIGTERM-drain, never SIGKILL-first).
+- **Single source file ≤ 800 lines** — new commands go in their own `cmd/agent/{doctor,restart}.rs`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `mur-common/build.rs` | embed git sha at build time | **new** |
+| `mur-common/Cargo.toml` | declare `build = "build.rs"` | modify |
+| `mur-common/src/build.rs` + `lib.rs` | `SHORT_SHA`, `A2A_PROTO_VERSION`, `method_min_proto` | **new** module |
+| `mur-common/src/agent.rs:834` | `LockFile.build_sha` + `proto_version` | modify |
+| `mur-agent-runtime/src/supervisor.rs` | write new lock fields; `--build-id` flag; SIGTERM drain | modify |
+| `mur-agent-runtime/src/task_runner.rs` | `drain(timeout)`: stop-accepting + await active | modify |
+| `mur-agent-runtime/src/protocol/methods/card.rs:59` | advertise `proto_version` | modify |
+| `mur-core/src/a2a_dial.rs` | pre-flight proto gate + `StaleRuntime` error | modify |
+| `mur-core/src/cmd/agent/doctor.rs` | stale detection report | **new** |
+| `mur-core/src/cmd/agent/restart.rs` | graceful restart command | **new** |
+| `mur-core/src/cmd/agent/{mod,lifecycle}.rs` + `cli/{agent,actions}.rs` | wire commands + status marker | modify |
+| `build.sh` | post-install stale nudge | modify |
+
+---
+
+## Phase A — Foundation: build-id + proto version (Tasks 1–3)
+
+### Task 1: Embed git sha (`mur-common` build-id)
+
+**Files:**
+- Create: `mur-common/build.rs`
+- Modify: `mur-common/Cargo.toml` (add `build = "build.rs"` to `[package]`)
+- Create: `mur-common/src/build.rs`
+- Modify: `mur-common/src/lib.rs` (add `pub mod build;`)
+- Test: `mur-common/src/build.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Produces: `mur_common::build::SHORT_SHA: &str` (12-char git sha, or `"unknown"`).
+
+- [ ] **Step 1: Add the build script**
+
+Create `mur-common/build.rs`:
+```rust
+use std::process::Command;
+
+fn main() {
+    // Re-run when HEAD moves (a new commit changes the sha).
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs");
+    let sha = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=MUR_GIT_SHA={sha}");
+}
+```
+
+- [ ] **Step 2: Declare the build script**
+
+In `mur-common/Cargo.toml`, add to `[package]` (after `version.workspace = true`):
+```toml
+build = "build.rs"
+```
+
+- [ ] **Step 3: Create the build module with a test**
+
+Create `mur-common/src/build.rs`:
+```rust
+//! Compile-time build identity. `SHORT_SHA` is the git commit the binary was
+//! built from (set by build.rs), or "unknown" for git-less builds (crates.io).
+//! Used to detect when a running agent's binary differs from the installed one.
+
+/// 12-char git sha of this build, or "unknown".
+pub const SHORT_SHA: &str = env!("MUR_GIT_SHA");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_sha_is_set() {
+        // Either a real 12-char hex sha, or the "unknown" fallback.
+        assert!(SHORT_SHA == "unknown" || SHORT_SHA.len() == 12, "got {SHORT_SHA:?}");
+    }
+}
+```
+
+In `mur-common/src/lib.rs`, add alongside the other `pub mod` lines (alphabetical, after `pub mod bundle;`):
+```rust
+pub mod build;
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-common short_sha_is_set`
+Expected: **PASS**.
+
+- [ ] **Step 5: Commit**
+```bash
+git add mur-common/build.rs mur-common/Cargo.toml mur-common/src/build.rs mur-common/src/lib.rs
+git commit -m "feat(common): embed git sha as build identity (SHORT_SHA)"
+```
+
+---
+
+### Task 2: Proto-version constants
+
+**Files:**
+- Modify: `mur-common/src/build.rs`
+- Test: `mur-common/src/build.rs`
+
+**Interfaces:**
+- Produces: `A2A_PROTO_VERSION: u32` and `fn method_min_proto(method: &str) -> u32`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `mur-common/src/build.rs` tests:
+```rust
+    #[test]
+    fn method_min_proto_gates_channel_delegate_only() {
+        // channel/delegate requires the proto that introduced it.
+        assert_eq!(method_min_proto("channel/delegate"), 1);
+        // Always-available methods are ungated (min 0).
+        assert_eq!(method_min_proto("message/send"), 0);
+        assert_eq!(method_min_proto("agent/card"), 0);
+        // The current proto is at least the highest gated method.
+        assert!(A2A_PROTO_VERSION >= 1);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-common method_min_proto_gates`
+Expected: **compile error** — `method_min_proto` / `A2A_PROTO_VERSION` not found.
+
+- [ ] **Step 3: Implement**
+
+Add to `mur-common/src/build.rs` (above the tests):
+```rust
+/// A2A method-surface version. Bump ONLY on an incompatible change to a dialed
+/// method (added method, changed params/result contract). Carried in
+/// `running.lock` + the AgentCard; the dial refuses a method whose
+/// `method_min_proto` exceeds the peer's advertised proto.
+pub const A2A_PROTO_VERSION: u32 = 1;
+
+/// Minimum proto a peer must advertise to be dialed for `method`. `0` = always
+/// available (never gated). Add an entry when a method is introduced/changed.
+pub fn method_min_proto(method: &str) -> u32 {
+    match method {
+        "channel/delegate" => 1,
+        _ => 0,
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-common method_min_proto_gates`
+Expected: **PASS**.
+
+- [ ] **Step 5: Commit**
+```bash
+git add mur-common/src/build.rs
+git commit -m "feat(common): A2A_PROTO_VERSION + method_min_proto gate table"
+```
+
+---
+
+### Task 3: LockFile + AgentCard carry build_sha & proto_version
+
+**Files:**
+- Modify: `mur-common/src/agent.rs:834-846`
+- Modify: `mur-agent-runtime/src/supervisor.rs:507-518` (write fields) + add `--build-id` flag
+- Modify: `mur-agent-runtime/src/protocol/methods/card.rs:59`
+- Test: `mur-common/src/agent.rs`
+
+**Interfaces:**
+- Produces: `LockFile.build_sha: String`, `LockFile.proto_version: u32` (both `#[serde(default)]`).
+- Consumed by Tasks 4 (dial gate), 8 (doctor).
+
+- [ ] **Step 1: Write the failing test (back-compat default)**
+
+Add to `mur-common/src/agent.rs` `#[cfg(test)]`:
+```rust
+    #[test]
+    fn lockfile_new_fields_default_for_old_locks() {
+        // An old lock JSON without build_sha/proto_version must still parse,
+        // defaulting to "" / 0 (= "predates this feature → stale/unsupported").
+        let old = r#"{"schema":1,"uuid":"u","name":"a","pid":1,"ppid":1,
+          "started_at":"t","binary_version":"mur-agent-runtime 2.26.9",
+          "transports":{"stdio":true},"card_digest":"d","capabilities":[]}"#;
+        let lock: LockFile = serde_json::from_str(old).unwrap();
+        assert_eq!(lock.build_sha, "");
+        assert_eq!(lock.proto_version, 0);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-common lockfile_new_fields_default`
+Expected: **compile error** — no field `build_sha`.
+
+- [ ] **Step 3: Add the fields**
+
+In `mur-common/src/agent.rs`, in `pub struct LockFile` (after `capabilities: Vec<String>,`):
+```rust
+    /// Git sha the running binary was built from (mur_common::build::SHORT_SHA).
+    /// Empty = an old lock predating this field. Drives stale detection.
+    #[serde(default)]
+    pub build_sha: String,
+    /// A2A method-surface version this runtime supports (A2A_PROTO_VERSION).
+    /// 0 = an old lock; the dial gates versioned methods on it.
+    #[serde(default)]
+    pub proto_version: u32,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-common lockfile_new_fields_default`
+Expected: **PASS**.
+
+- [ ] **Step 5: Write the fields at runtime startup**
+
+In `mur-agent-runtime/src/supervisor.rs`, the `LockFile { … }` literal (~`:507`) — add the two fields before the closing brace:
+```rust
+        build_sha: mur_common::build::SHORT_SHA.to_string(),
+        proto_version: mur_common::build::A2A_PROTO_VERSION,
+```
+
+- [ ] **Step 6: Add the `--build-id` flag**
+
+In `mur-agent-runtime/src/supervisor.rs`, near the existing `--version` handling (`:62` prints `mur-agent-runtime {CARGO_PKG_VERSION}`), add a `--build-id` arm that prints just the sha and exits 0:
+```rust
+        if arg == "--build-id" {
+            println!("{}", mur_common::build::SHORT_SHA);
+            return Ok(());
+        }
+```
+(Match the surrounding arg-parse style; `return Ok(())` consistent with the `--version` early return.)
+
+- [ ] **Step 7: Advertise proto_version on the card**
+
+In `mur-agent-runtime/src/protocol/methods/card.rs`, the `json!({ … })` card (~`:60`), add after `"protocolVersion": "a2a/0.3",`:
+```rust
+            "proto_version": mur_common::build::A2A_PROTO_VERSION,
+```
+
+- [ ] **Step 8: Verify the runtime crate compiles**
+
+Run: `ORT_STRATEGY=download cargo check -p mur-agent-runtime`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+```bash
+git add mur-common/src/agent.rs mur-agent-runtime/src/supervisor.rs mur-agent-runtime/src/protocol/methods/card.rs
+git commit -m "feat(runtime): stamp build_sha + proto_version into lock + card; --build-id"
+```
+
+---
+
+## Phase B — ① Dial version-gate (Task 4)
+
+### Task 4: Pre-flight proto gate in `a2a_dial`
+
+**Files:**
+- Modify: `mur-core/src/a2a_dial.rs` (`dial_method` ~`:68-123`)
+- Test: `mur-core/src/a2a_dial.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `mur_common::build::method_min_proto`, `LockFile.proto_version`.
+- Produces: a `StaleRuntime`-shaped error from `dial_method` when a running peer's proto is below the method's min.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mur-core/src/a2a_dial.rs` `#[cfg(test)]` (use a temp home + a hand-written stale lock; no socket needed — the gate fires before any dial):
+```rust
+    #[test]
+    fn dial_gates_channel_delegate_on_stale_proto() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let adir = tmp.path().join("agents").join("rustsmith");
+        std::fs::create_dir_all(&adir).unwrap();
+        // Old lock: proto_version absent → 0 < channel/delegate's min (1).
+        std::fs::write(adir.join("running.lock"), r#"{"schema":1,"uuid":"u",
+          "name":"rustsmith","pid":1,"ppid":1,"started_at":"t",
+          "binary_version":"old","transports":{"stdio":true,
+          "unix_socket":"/nonexistent.sock"},"card_digest":"d","capabilities":[]}"#).unwrap();
+
+        let err = dial_method(tmp.path(), "rustsmith", "channel/delegate",
+            serde_json::json!({}), DialMode::RequireRunning).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("stale runtime"), "got: {msg}");
+        assert!(msg.contains("mur agent restart rustsmith"), "got: {msg}");
+        // It must NOT have tried to connect to the (nonexistent) socket.
+        assert!(!msg.contains("connect"), "gate should fire before dialing: {msg}");
+    }
+
+    #[test]
+    fn dial_does_not_gate_ungated_method() {
+        // message/send (min 0) on the same stale lock must NOT be proto-gated
+        // (it will fail later for a different reason — socket — which is fine).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let adir = tmp.path().join("agents").join("a");
+        std::fs::create_dir_all(&adir).unwrap();
+        std::fs::write(adir.join("running.lock"), r#"{"schema":1,"uuid":"u","name":"a",
+          "pid":1,"ppid":1,"started_at":"t","binary_version":"old",
+          "transports":{"stdio":true,"unix_socket":"/nonexistent.sock"},
+          "card_digest":"d","capabilities":[]}"#).unwrap();
+        let err = dial_method(tmp.path(), "a", "message/send",
+            serde_json::json!({}), DialMode::RequireRunning).unwrap_err();
+        assert!(!err.to_string().contains("stale runtime"), "must not gate message/send");
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core dial_gates_channel_delegate`
+Expected: **FAIL** — no stale-runtime gating; the call proceeds to socket-connect.
+
+- [ ] **Step 3: Implement the gate**
+
+In `mur-core/src/a2a_dial.rs`, in `dial_method`, AFTER `let is_running = lock_path.exists();` (~`:92`) and BEFORE the `match (mode, is_running)` block, add the pre-flight gate for running peers:
+```rust
+    // Pre-flight version gate: refuse a versioned method against a running peer
+    // whose advertised proto is too low — with an actionable error, not -32601.
+    // Reads the peer's running.lock (cheap, local). Ungated methods (min 0) skip.
+    if is_running {
+        let needed = mur_common::build::method_min_proto(method);
+        if needed > 0 {
+            if let Ok(bytes) = fs::read(&lock_path) {
+                if let Ok(lock) = serde_json::from_slice::<LockFile>(&bytes) {
+                    if lock.proto_version < needed {
+                        let sha = if lock.build_sha.is_empty() { "unknown" } else { &lock.build_sha };
+                        bail!(
+                            "agent '{agent_name}' is running a stale runtime (proto {}, build {}); \
+                             the requested capability '{method}' needs proto {needed}. \
+                             Run 'mur agent restart {agent_name}' to apply the installed runtime.",
+                            lock.proto_version, sha
+                        );
+                    }
+                }
+            }
+        }
+    }
+```
+(`LockFile`, `fs`, `bail` are already imported in this file.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core dial_gates_channel_delegate dial_does_not_gate`
+Expected: **PASS** both.
+
+- [ ] **Step 5: Regression — existing dial tests**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core a2a_dial`
+Expected: **PASS** (the gate only fires for running peers on versioned methods).
+
+- [ ] **Step 6: Commit**
+```bash
+git add mur-core/src/a2a_dial.rs
+git commit -m "feat(a2a): pre-flight proto gate — stale runtime → actionable error not -32601"
+```
+
+---
+
+## Phase C — ③ Graceful drain + restart (Tasks 5–6)
+
+### Task 5: TaskRunner drain + SIGTERM integration
+
+**Files:**
+- Modify: `mur-agent-runtime/src/task_runner.rs` (the `TaskRunner` struct ~`:112` + `run_sync_inner`)
+- Modify: `mur-agent-runtime/src/supervisor.rs:647-672` (replace the `:655` TODO)
+- Test: `mur-agent-runtime/src/task_runner.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Produces: `TaskRunner::begin_drain()` (stop accepting new turns) + `async fn await_idle(&self, timeout: Duration) -> bool` (true = drained, false = timed out). `run_sync`/`run_sync_inner` reject with a transient error once draining.
+
+**Implementation note for the implementer:** read `task_runner.rs` first. `TaskRunner` already tracks live turns via `registry: Arc<Mutex<HashMap<String, TaskState>>>` + `registry_keys: Arc<Mutex<VecDeque<String>>>` (`:114-117`). Add an `Arc<AtomicBool> draining` field (default false). `run_sync_inner` (`:495`) returns a transient failure `TaskOutcome` when `draining` is set, before registering a turn. `await_idle` polls `registry_keys` empty (every ~50ms) up to `timeout`. This is the bounded, cooperative drain — no SIGKILL, no mid-turn abort.
+
+- [ ] **Step 1: Write the failing test**
+```rust
+    #[tokio::test]
+    async fn drain_rejects_new_turns_and_reports_idle() {
+        let runner = /* construct a minimal TaskRunner — mirror existing runner tests */;
+        // Idle runner drains immediately.
+        assert!(runner.await_idle(std::time::Duration::from_millis(200)).await);
+        // After begin_drain, a new run_sync is rejected (transient), not executed.
+        runner.begin_drain();
+        let outcome = runner.run_sync(/* a trivial TaskSpec */).await;
+        assert!(matches!(outcome, TaskOutcome::Failed { .. }),
+            "draining runner must reject new turns");
+    }
+```
+(Mirror the existing TaskRunner test harness for construction + `TaskSpec`/`TaskOutcome` shapes — read the `#[cfg(test)]` block already in `task_runner.rs`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-agent-runtime drain_rejects_new_turns`
+Expected: **compile error** — no `begin_drain`/`await_idle`.
+
+- [ ] **Step 3: Implement `draining` + `begin_drain` + `await_idle` + the run_sync guard**
+
+Add an `draining: Arc<std::sync::atomic::AtomicBool>` field to `TaskRunner` (init `false` in its constructor). Add:
+```rust
+    pub fn begin_drain(&self) {
+        self.draining.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Wait until no turns are in flight, bounded by `timeout`. true = drained.
+    pub async fn await_idle(&self, timeout: std::time::Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if self.registry_keys.lock().await.is_empty() {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+```
+At the TOP of `run_sync_inner` (`:495`), before any turn registration, reject when draining:
+```rust
+        if self.draining.load(std::sync::atomic::Ordering::SeqCst) {
+            return TaskOutcome::Failed { /* transient: "agent draining, retry" — match TaskOutcome::Failed's fields */ };
+        }
+```
+(Use the exact `TaskOutcome::Failed` field shape from the enum definition; message: `"agent is draining for restart; retry shortly"`.)
+
+> The `registry_keys` lock type: confirm it's `tokio::sync::Mutex` (async `.lock().await`) vs `std::sync::Mutex`; `:117` shows the field — match it. If it's `std::sync::Mutex`, drop the `.await` and use `try_lock`/`lock().unwrap()`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-agent-runtime drain_rejects_new_turns`
+Expected: **PASS**.
+
+- [ ] **Step 5: Wire the drain into SIGTERM shutdown**
+
+In `mur-agent-runtime/src/supervisor.rs`, replace the TODO block (`:655-656`) — BEFORE `for t in transport_tasks { t.abort(); }`:
+```rust
+    // Drain the in-flight turn cooperatively before tearing down transports:
+    // stop accepting new dials, then wait for the active turn to finish, bounded
+    // by stop_timeout_secs. Never SIGKILL a turn mid-flight.
+    runner.begin_drain();
+    let drained = runner
+        .await_idle(std::time::Duration::from_secs(profile.inner.lifecycle.stop_timeout_secs))
+        .await;
+    if !drained {
+        warn!("drain timed out after {}s; tearing down with a turn still in flight",
+            profile.inner.lifecycle.stop_timeout_secs);
+    }
+```
+(`runner` is the `TaskRunner` Arc already in scope in this function; `warn!` is imported.)
+
+- [ ] **Step 6: Compile + full runtime test sweep**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-agent-runtime task_runner`
+Expected: **PASS** (drain tests + existing runner tests).
+
+- [ ] **Step 7: Commit**
+```bash
+git add mur-agent-runtime/src/task_runner.rs mur-agent-runtime/src/supervisor.rs
+git commit -m "feat(runtime): graceful drain — SIGTERM awaits the in-flight turn (closes P0b TODO)"
+```
+
+---
+
+### Task 6: `mur agent restart` command
+
+**Files:**
+- Create: `mur-core/src/cmd/agent/restart.rs`
+- Modify: `mur-core/src/cmd/agent/mod.rs` (declare `mod restart;` + re-export)
+- Modify: `mur-core/src/cli/agent.rs` + `mur-core/src/cli/actions.rs` (new subcommand — mirror `Stop`)
+- Test: `mur-core/src/cmd/agent/restart.rs`
+
+**Interfaces:**
+- Consumes: `resolve_mur_home`, `LockFile` (pid), the stale predicate from Task 8 (or inline build-sha compare — see note).
+- Produces: `pub fn cmd_restart(name: Option<&str>, all: bool, stale_only: bool, dry_run: bool) -> Result<()>`.
+
+**Mechanism:** for each target agent, read `running.lock.pid`, send SIGTERM (the runtime drains via Task 5), wait for the pid to exit, then poll for a NEW `running.lock` (different pid — launchd `KeepAlive` respawns on the fresh binary), bounded ~30s. Report `old_sha → new_sha`. `--dry-run` lists targets without acting. Reuse the SIGTERM + pid-wait logic from `cmd_stop` (`lifecycle.rs:590-608`) but do NOT remove the lock (launchd respawns).
+
+- [ ] **Step 1: Write the failing test** (dry-run target selection — no real kill)
+```rust
+    #[test]
+    fn restart_dry_run_selects_stale_only() {
+        // temp MUR_HOME with two running locks: one stale (build "old"), one
+        // current (build == on-disk). --stale --dry-run names exactly the stale.
+        // (Construct synthetic running.lock files; assert the printed/returned
+        // target list. Factor target-selection into a pure helper
+        // `select_targets(home, name, all, stale_only) -> Vec<String>` and test that.)
+    }
+```
+(Write `select_targets` as a pure function and assert it returns only the stale agent for `stale_only=true`; the SIGTERM/respawn path is covered by the live operator test.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core restart_dry_run_selects_stale`
+Expected: **compile error** — `select_targets`/`cmd_restart` missing.
+
+- [ ] **Step 3: Implement `cmd_restart` + `select_targets`**
+
+Create `mur-core/src/cmd/agent/restart.rs` with:
+- `fn select_targets(home, name: Option<&str>, all: bool, stale_only: bool) -> Result<Vec<String>>` — enumerate running agents (those with a `running.lock`); filter to the named one, or all, or stale-only (stale = `lock.build_sha != on_disk_sha()`; see Task 8 for `on_disk_sha`).
+- `pub fn cmd_restart(...)` — `select_targets`; if `dry_run`, print the list (+ stale reason) and return; else for each: SIGTERM the pid (mirror `lifecycle.rs:590-608`), wait for exit, poll for a fresh `running.lock` with a different pid (bounded 30s, 200ms poll), print `agent X restarted (old_sha → new_sha)`; continue past per-agent failures.
+
+- [ ] **Step 4: Wire the CLI**
+
+In `mur-core/src/cli/agent.rs` add a `Restart { name: Option<String>, #[arg(long)] all: bool, #[arg(long="stale")] stale: bool, #[arg(long="dry-run")] dry_run: bool }` variant (mirror the existing `Stop` variant), and in `cli/actions.rs` add the match arm dispatching to `cmd_restart`. Declare `mod restart;` + `pub use restart::cmd_restart;` in `cmd/agent/mod.rs`.
+
+- [ ] **Step 5: Run test + compile**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core restart_dry_run_selects_stale && ORT_STRATEGY=download cargo check -p mur-core`
+Expected: **PASS** + clean.
+
+- [ ] **Step 6: Commit**
+```bash
+git add mur-core/src/cmd/agent/restart.rs mur-core/src/cmd/agent/mod.rs mur-core/src/cli/agent.rs mur-core/src/cli/actions.rs
+git commit -m "feat(agent): mur agent restart <name>|--stale|--all [--dry-run] (graceful)"
+```
+
+---
+
+## Phase D — ② Notify (Tasks 7–8)
+
+### Task 7: `mur agent doctor` + on-disk sha helper
+
+**Files:**
+- Create: `mur-core/src/cmd/agent/doctor.rs`
+- Modify: `mur-core/src/cmd/agent/mod.rs` + `cli/{agent,actions}.rs`
+- Test: `mur-core/src/cmd/agent/doctor.rs`
+
+**Interfaces:**
+- Produces: `pub fn on_disk_sha() -> String` (build-id of the runtime a restart would launch); `fn is_stale(lock: &LockFile, on_disk: &str) -> bool`; `pub fn cmd_doctor(json: bool) -> Result<()>`.
+
+`on_disk_sha()`: resolve the runtime path via the existing `resolve_runtime_target()` (`cmd/agent/mod.rs:125`), run `<path> --build-id` (Task 3), trim stdout. Fallback `"unknown"` if the exec fails.
+
+- [ ] **Step 1: Write the failing test (pure stale predicate)**
+```rust
+    #[test]
+    fn is_stale_compares_build_sha() {
+        let mut lock = sample_lock();        // helper: a LockFile with build_sha
+        lock.build_sha = "abc123def456".into();
+        assert!(is_stale(&lock, "999999999999"));      // differ → stale
+        assert!(!is_stale(&lock, "abc123def456"));     // same → current
+        // Two "unknown"s (git-less builds) compare equal → NOT stale (no spam).
+        lock.build_sha = "unknown".into();
+        assert!(!is_stale(&lock, "unknown"));
+        // Old lock (empty build_sha) vs a known on-disk sha → stale.
+        lock.build_sha = String::new();
+        assert!(is_stale(&lock, "abc123def456"));
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core is_stale_compares_build_sha`
+Expected: **compile error**.
+
+- [ ] **Step 3: Implement**
+
+`is_stale(lock, on_disk) -> bool { !lock.build_sha.is_empty() && lock.build_sha != on_disk || (lock.build_sha.is_empty() && on_disk != "unknown") }` — i.e. stale when the running build differs from on-disk, treating an empty (pre-feature) lock as stale against a known on-disk sha, and two `"unknown"`s as equal. (Write it to satisfy the four assertions exactly.) Plus `on_disk_sha()` (exec `--build-id`) and `cmd_doctor` (iterate running agents, print `name: running, current|STALE (lock <sha8> vs disk <sha8>)` + the `→ run 'mur agent restart <name>'` hint for stale ones; `--json` emits an array; exit non-zero if any stale).
+
+- [ ] **Step 4: Run test + wire CLI**
+
+Add a `Doctor { #[arg(long)] json: bool }` variant (mirror `Status`) in `cli/agent.rs` + `actions.rs`; `mod doctor;` + re-export in `mod.rs`.
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core is_stale_compares_build_sha && ORT_STRATEGY=download cargo check -p mur-core`
+Expected: **PASS** + clean.
+
+- [ ] **Step 5: Commit**
+```bash
+git add mur-core/src/cmd/agent/doctor.rs mur-core/src/cmd/agent/mod.rs mur-core/src/cli/agent.rs mur-core/src/cli/actions.rs
+git commit -m "feat(agent): mur agent doctor — flag stale runtimes (build-sha compare)"
+```
+
+---
+
+### Task 8: `status` marker + post-build nudge
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/lifecycle.rs` (`cmd_status` ~`:462`)
+- Modify: `build.sh` (after the `~/.local/bin/mur-agent-runtime` copy, ~`:87`)
+- Test: covered by Task 7's `is_stale`; this task is wiring.
+
+- [ ] **Step 1: Add the stale marker to `status`**
+
+In `cmd_status` (`lifecycle.rs:462`), for each running agent, compute `is_stale(&lock, &on_disk_sha())` (reuse Task 7) and append ` — stale runtime (restart to apply)` to the agent's status line when stale.
+
+- [ ] **Step 2: Post-build nudge in build.sh**
+
+In `build.sh`, after the block that copies the runtime to `~/.local/bin/mur-agent-runtime` (~`:87`), add a print-only nudge:
+```sh
+  # Nudge: running agents keep their OLD process until restarted, so they're
+  # still on the pre-upgrade runtime. Tell the operator (print-only; never auto-restart).
+  if command -v mur >/dev/null 2>&1; then
+    STALE=$(mur agent doctor --json 2>/dev/null | grep -c '"stale":true' || true)
+    if [ "${STALE:-0}" -gt 0 ]; then
+      echo "⚠ $STALE agent(s) are running a stale runtime — run 'mur agent restart --stale' (--dry-run to list)"
+    fi
+  fi
+```
+(Ensure `mur agent doctor --json` emits a `"stale":true|false` field per agent — adjust the grep to the actual JSON key from Task 7.)
+
+- [ ] **Step 3: Verify**
+
+Run: `ORT_STRATEGY=download cargo check -p mur-core`
+Expected: clean. (The build.sh nudge is shell; verify by inspection — it's print-only and guarded by `command -v mur`.)
+
+- [ ] **Step 4: Commit**
+```bash
+git add mur-core/src/cmd/agent/lifecycle.rs build.sh
+git commit -m "feat(agent): stale-runtime marker in status + post-build nudge"
+```
+
+---
+
+### Task 9: Workspace verification
+
+- [ ] **Step 1: Lint + format**
+
+Run: `cargo fmt --check && ORT_STRATEGY=download cargo clippy -p mur-common -p mur-core -p mur-agent-runtime -- -D warnings`
+Expected: clean. (If fmt fails, `cargo fmt` + amend.)
+
+- [ ] **Step 2: Targeted test sweep**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-common -p mur-core a2a_dial && ORT_STRATEGY=download cargo nextest run -p mur-agent-runtime task_runner`
+Expected: **PASS**.
+
+- [ ] **Step 3: Commit (if fmt changed anything)**
+```bash
+git add -A && git commit -m "chore: fmt"
+```
+
+---
+
+## Live / operator verification (post-merge; needs running agents)
+
+1. Build + install (`./install.sh`) so `mur` + `mur-agent-runtime` are on the same fresh sha.
+2. `mur agent doctor` → agents started before this build show **STALE**.
+3. `mur agent restart --stale` → each drains, launchd respawns; `doctor` flips them to **current**.
+4. A `parallel_jobs`/`channel/delegate` dial that previously returned `-32601`/silent-fail now either succeeds (restarted) or returns the actionable **"run mur agent restart X"** error (not restarted).
+
+---
+
+## Self-Review
+
+**Spec coverage:** §0 infra → Tasks 1-3; §① dial gate → Task 4; §③ drain → Task 5, restart → Task 6; §② doctor → Task 7, status+nudge → Task 8. One-time cutover (proto-0 gated) → Task 4 tests + the actionable error. Non-goals (auto-restart/re-exec/multi-version) → not implemented. ✓
+
+**Placeholder scan:** The drain (Task 5) and restart/doctor CLI wiring (Tasks 6-7) reference reading the live `task_runner.rs` / `cli/*.rs` for exact `TaskOutcome`/enum shapes — these are integration points whose surrounding types must be read, not invented; the contract, integration line, and tests are exact. All bounded code (build.rs, constants, lock fields, dial gate, predicates) is complete.
+
+**Type consistency:** `SHORT_SHA`/`A2A_PROTO_VERSION`/`method_min_proto` (Task 1-2) → used verbatim in Tasks 3-4. `LockFile.build_sha`/`proto_version` (Task 3) → read in Tasks 4,6,7. `is_stale`/`on_disk_sha` (Task 7) → reused in Tasks 6,8. `begin_drain`/`await_idle` (Task 5) → called in supervisor. ✓

--- a/docs/superpowers/specs/2026-06-24-agent-runtime-upgrade-restart-design.md
+++ b/docs/superpowers/specs/2026-06-24-agent-runtime-upgrade-restart-design.md
@@ -1,0 +1,124 @@
+# Agent runtime upgrade: stale-detection + version-gating + graceful restart
+
+- **Date:** 2026-06-24
+- **Status:** Design (approved for plan)
+- **Topic:** When a `mur-agent-runtime` upgrade lands on disk, get running agents onto the new binary safely — **detect** stale runtimes, **version-gate** the A2A wire so version skew fails with an actionable error (not opaque `-32601`), and **gracefully restart** agents on demand (drain in-flight work; never auto-bounce).
+
+## Problem
+
+Per-agent runtimes run as long-lived launchd-managed processes (`KeepAlive=true`). A package upgrade (brew, dev install, Hub `.app`) replaces `mur-agent-runtime` **on disk**, but a running agent keeps executing its **old** process until restarted — so it drifts onto a stale binary.
+
+This bit us live:
+1. A running agent (started after the #489 macOS DNS fix merged) was still executing a **pre-#489 binary**, so its sandbox blocked DNS and its outbound LLM call failed.
+2. A freshly-built MCP client dialing `channel/delegate` against an **old runtime that never registered that method** failed with a bare JSON-RPC `-32601`, surfaced as a generic `"agent X returned error"` — undiagnosable.
+
+The fix isn't "auto-restart everything on upgrade" — that silently kills in-flight agent turns (an autonomous-loop-safety violation; see `feedback_autonomous_loop_safety_audit`). Mature tools (`needrestart`, systemd) **detect and notify; restart deliberately; auto-restart only opt-in.**
+
+## Goals
+
+- **Detect** stale runtimes (a running agent's binary differs from the installed one) and surface it in `mur agent doctor` / `status` + a post-upgrade nudge. Print-only; never acts.
+- **Version-gate** the A2A dial: refuse a versioned method against a peer that doesn't support it, with an actionable `run 'mur agent restart X'` error instead of `-32601`. Never silently downgrade.
+- **Graceful restart**: `mur agent restart` drains the in-flight turn (bounded), then lets launchd respawn on the fresh binary. Fleet loops bail at the iteration boundary.
+
+## Non-goals (deferred)
+
+- **Auto-restart on upgrade** (`MUR_AGENT_AUTORESTART` opt-in env switch). Out of this spec by the user's scoping (① + ② + ③ only). When built, it mirrors `MUR_FLEET_AUTORUN`: OFF by default, post-transaction, via the graceful path.
+- **In-place re-exec / hot state hand-off** (`systemctl daemon-reexec`-style serialize→re-exec→deserialize). Large lift; graceful drain + respawn suffices.
+- **Multi-version A2A negotiation matrix** (running mixed-version fleets). Ship detect-and-refuse first.
+- **`needrestart`-style per-file `/proc/maps` allow/denylist.** Our check is a single build-id compare, no spurious stale-file hits to suppress.
+
+## Best-practice grounding (2026)
+
+- **Detect always; restart never-by-default; auto-restart opt-in.** `needrestart` (Debian/Ubuntu default) defaults to list-only under automation, default answer "no", and excludes stateful/connectivity-critical services from auto-restart. systemd RFE #32099 deliberately separates *detection* from *automatic action*. → MUR notifies; never bounces a running agent.
+- **Fail explicit on version skew at the wire; never silently mismatch.** A2A mandates a version handshake + `VersionNotSupportedError` over best-effort; RFC 9368 (QUIC) abandons cleanly when there's no common version. → the dial refuses with an actionable error, not `-32601`.
+- **Restart cooperatively via graceful drain, not SIGKILL.** SIGTERM → stop new work → finish in-flight within a bounded grace → exit 0; treat SIGTERM exit as success. The OS won't drain for you. → the runtime must drain the in-flight turn.
+
+## Key decision: the dial gates on a semantic proto-version, not the git-sha
+
+The git-sha changes **every commit**, so gating the dial on it would refuse *protocol-compatible* peers needlessly. The dial gates on **`A2A_PROTO_VERSION`** — an integer (like `CHANNEL_SCHEMA_VERSION`) bumped **only on incompatible A2A method-surface changes**. The git-sha drives the **notify** (stale detection) only. Two signals, two jobs.
+
+## Design
+
+### 0. Shared infra — build-id + proto version
+
+**Build-id (`mur-common`):**
+- `mur-common/build.rs` runs `git rev-parse --short=12 HEAD`, emits `cargo:rustc-env=MUR_GIT_SHA=<sha>` (+ `cargo:rerun-if-changed=.git/HEAD` so a new commit forces a rebuild). Fallback to `"unknown"` when git is unavailable (crates.io publish / no `.git`).
+- `mur-common/src/build.rs` (new module): `pub const SHORT_SHA: &str = env!("MUR_GIT_SHA");`. Both `mur-core` (CLI) and `mur-agent-runtime` read `mur_common::build::SHORT_SHA`.
+- `mur-agent-runtime --build-id` prints `SHORT_SHA` (one-line, for the doctor compare).
+
+**Proto version (`mur-common`):**
+- `pub const A2A_PROTO_VERSION: u32 = 1;` — the current A2A method-surface version. Bump on any incompatible change to a dialed method.
+- `pub fn method_min_proto(method: &str) -> u32` — the minimum proto a peer must advertise for a method. `"channel/delegate" => 1`; default `0` (unversioned/always-available methods like `message/send`).
+
+**Carrier fields:**
+- `LockFile` (`mur-common/src/agent.rs:835`) gains `#[serde(default)] pub build_sha: String` + `#[serde(default)] pub proto_version: u32`. Written at `supervisor.rs:507` from `mur_common::build::SHORT_SHA` and `A2A_PROTO_VERSION`. `#[serde(default)]` so an **old** lock (no field) reads as `""` / `0` — which is exactly "predates this feature → stale / unsupported".
+- `AgentCard` (`protocol/methods/card.rs:60`) gains `"proto_version": A2A_PROTO_VERSION` alongside the existing `"protocolVersion": "a2a/0.3"` string.
+
+### ① Dial version-gate (`mur-core/src/a2a_dial.rs`)
+
+In `dial_method`, before sending a request for a versioned method:
+1. Read the peer's advertised `proto_version` — from its `running.lock` (cheap, already on disk) — defaulting to `0` when absent.
+2. If `peer_proto < method_min_proto(method)` → return a structured error (new `A2aDialError::StaleRuntime { agent, peer_proto, needed, build_sha, method }`) surfaced as:
+   ```
+   agent 'rustsmith' is running a stale runtime (proto 0, build unknown);
+   the requested capability 'channel/delegate' needs proto 1.
+   Run 'mur agent restart rustsmith' to apply the installed runtime.
+   ```
+3. Methods with `method_min_proto == 0` are never gated (back-compat: `message/send` etc. dial unchanged).
+
+This is a **pre-flight** check (no wasted dial), the A2A `VersionNotSupportedError` pattern: refuse cleanly, never silently downgrade, never auto-restart the peer. Where the dial currently surfaces `-32601` generically (`a2a_dial.rs:154`), a registered-but-incompatible peer is now caught *before* the call; a genuinely-unknown method still surfaces its `-32601` (unchanged).
+
+**One-time cutover (intended, not a bug):** every runtime that predates this feature writes no `proto_version` → reads as `0` → is gated for `channel/delegate` (min 1) until restarted, *including* ones that technically registered the method. This is correct: those runtimes are stale by definition (they also lack #489 etc.), and the gate converts today's silent/opaque failure into one actionable nudge — "upgrade, then `mur agent restart --stale`". After the first restart onto a proto-1 binary, the gate only fires again on a *future* incompatible bump. `method_min_proto == 0` methods (`message/send`, …) are never gated, so basic agent comms keep working through the cutover.
+
+### ② Notify — `doctor` + `status` + post-upgrade nudge (print-only)
+
+**Stale rule:** an agent is stale iff `running.lock.build_sha != <on-disk runtime>.build_sha`. The on-disk build-id comes from one exec of `resolve_runtime_target() --build-id` (the binary a restart would actually launch — the precise "would restart change anything?" question).
+
+- **`mur agent doctor`** (new, `cmd/agent/doctor.rs`): for each agent, report `running` + `stale|current` + lock proto/build vs on-disk. Stale agents get the `→ run 'mur agent restart <name>'` hint. Exit non-zero if any stale (scriptable). Supports `--json`.
+- **`mur agent status`** (`lifecycle.rs:462`): add a `stale runtime — restart to apply` marker to the existing per-agent line.
+- **Post-upgrade nudge:** `install.sh` (after it replaces the binary) and a one-shot check on the next `mur` invocation print: `N agent(s) are running a stale runtime. Run 'mur agent restart --stale' (--dry-run to list).` Print-only, like `needrestart -r l` — never prompts-to-restart.
+
+### ③ Graceful restart — runtime drain + new command
+
+**Runtime drain (the one runtime behavior change, `supervisor.rs:648-672`, closes the `:655` TODO):**
+On SIGTERM, before aborting transports: tell the `TaskRunner` to **stop accepting new dials** (new `channel/delegate`/`message/send` get a transient `"agent draining, retry"` error) and **await the in-flight turn**, bounded by `lifecycle.stop_timeout_secs`. On timeout, proceed with teardown (don't hang forever). Then the existing teardown (hooks → transports → MCP pool → flush → remove lock). SIGTERM-driven exit stays exit 0 (not a crash).
+
+**`mur agent restart` (new, `cmd/agent/restart.rs`):** `mur agent restart <name> | --stale | --all [--dry-run]`.
+- Resolve targets: a named agent, `--stale` (all stale per ②), or `--all` (all running).
+- For each: read pid from `running.lock`, send `SIGTERM` (graceful drain above). launchd `KeepAlive=true` respawns the agent on the **fresh** on-disk binary; poll the new socket/lock for readiness (bounded), report old→new build-id.
+- `--dry-run`: list what would be restarted (and why), act on nothing.
+- **`--stale` is the upgrade-apply command** (only restarts agents where the binary would actually change → least disruption); `--all` is the blunt force-all. The nudge points at `--stale`.
+- Fleet `--loop` iterations already bail at the boundary via `LoopStop` (`loop_run.rs`) — no mid-loop kill; reuse as-is.
+
+## Error handling
+
+- Dial gate: `StaleRuntime` is a typed variant with a human-actionable `Display`; callers (workflow executor, fleet, MCP `parallel_jobs`) surface it verbatim. It does **not** abort sibling steps that target *supported* peers.
+- `build.rs` git failure → `SHORT_SHA = "unknown"`; stale-detection treats `"unknown" != "unknown"`? No — two `"unknown"`s compare equal → "current" (no false-stale spam on git-less installs). Proto-gate still works (proto_version is independent of git).
+- Restart: a missing/again-stale `running.lock`, a pid that's already gone, or a respawn that doesn't come up within the poll window → reported per-agent, never silently swallowed; `--all`/`--stale` continue past one failure.
+
+## Testing
+
+- **Pure unit:** `method_min_proto` mapping; the stale predicate (`build_sha` compare incl. the `"unknown"==... ` case); `proto_version` serde default (old lock → 0); the dial-gate decision (`peer_proto < needed` → `StaleRuntime`, `== 0 min` → pass).
+- **Dial gate:** a lock with `proto_version: 0` + a `channel/delegate` dial → `StaleRuntime` error naming the agent + restart hint; `proto_version: 1` → proceeds.
+- **Drain:** runtime under SIGTERM with a stub in-flight task → awaits it (up to `stop_timeout_secs`) before teardown; with no task → exits promptly; over-timeout → tears down anyway.
+- **doctor/restart:** against a temp `MUR_HOME` with synthetic `running.lock`s (one stale, one current) → doctor lists exactly the stale one; `restart --dry-run --stale` names exactly it.
+- **Live (operator):** restart a real running agent → it drains, launchd respawns on the fresh binary, doctor flips it `stale→current`, and the `channel/delegate` dial that previously errored now succeeds.
+
+## File touch list
+
+- `mur-common/build.rs` (new) — embed `MUR_GIT_SHA`.
+- `mur-common/src/build.rs` (new) + `lib.rs` — `SHORT_SHA`, `A2A_PROTO_VERSION`, `method_min_proto`.
+- `mur-common/src/agent.rs` — `LockFile.build_sha` + `proto_version`.
+- `mur-agent-runtime/src/supervisor.rs` — write the new lock fields; `--build-id` flag; SIGTERM drain.
+- `mur-agent-runtime/src/protocol/methods/card.rs` — advertise `proto_version`.
+- `mur-agent-runtime/src/task_runner.rs` (or wherever the run loop lives) — `drain(timeout)`: stop-accepting + await active turn.
+- `mur-core/src/a2a_dial.rs` — pre-flight proto-gate + `StaleRuntime` error.
+- `mur-core/src/cmd/agent/{doctor.rs,restart.rs}` (new) + `mod.rs`/CLI wiring; `lifecycle.rs` status marker.
+- `install.sh` — post-install stale nudge.
+
+## Build order (one plan, by value)
+
+1. **Shared infra (0)** — build-id, proto constant, lock/card fields. Foundation for everything.
+2. **① Dial gate** — highest value; turns the opaque `-32601` into an actionable error immediately, even before any restart.
+3. **③ Graceful drain + `restart`** — so the actionable error has a safe action to point at.
+4. **② Notify** — `doctor`/`status`/nudge, which lean on (0) and point at (③).

--- a/mur-agent-runtime/src/protocol/methods/card.rs
+++ b/mur-agent-runtime/src/protocol/methods/card.rs
@@ -58,6 +58,7 @@ impl MethodHandler for CardHandler {
         // grace window.
         let mut card = json!({
             "protocolVersion": "a2a/0.3",
+            "proto_version": mur_common::build::A2A_PROTO_VERSION,
             "name": p.name,
             "id": p.id,
             "pubkey": p.identity.pubkey,

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -660,8 +660,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     // Stop accepting new turns, then cooperatively wait for any in-flight turn
     // to finish before tearing down transports. Never SIGKILL mid-flight work.
     runner.begin_drain();
-    let drain_timeout =
-        std::time::Duration::from_secs(profile.inner.lifecycle.stop_timeout_secs);
+    let drain_timeout = std::time::Duration::from_secs(profile.inner.lifecycle.stop_timeout_secs);
     if runner.await_idle(drain_timeout).await {
         info!("task runner drained cleanly");
     } else {

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -62,6 +62,10 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         println!("mur-agent-runtime {}", env!("CARGO_PKG_VERSION"));
         return Ok(());
     }
+    if crate::subcommand::has_flag(&argv, &["--build-id"]) {
+        println!("{}", mur_common::build::SHORT_SHA);
+        return Ok(());
+    }
 
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
@@ -515,6 +519,8 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         transports: lock_transports,
         card_digest: profile.digest.clone(),
         capabilities: profile.inner.capabilities.clone(),
+        build_sha: mur_common::build::SHORT_SHA.to_string(),
+        proto_version: mur_common::build::A2A_PROTO_VERSION,
     };
     write_lock(&lock_path, &lock)?;
     info!("agent {} ({}) ready", profile.inner.name, profile.inner.id);

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -652,14 +652,24 @@ pub async fn entrypoint() -> anyhow::Result<()> {
 
     // 11. Graceful shutdown
     info!("begin graceful shutdown");
-    let _deadline = std::time::Duration::from_secs(profile.inner.lifecycle.stop_timeout_secs);
     // Fire observe-hooks before transport teardown so the telemetry
     // event makes it into the JSONL file.
     hook_chain
         .on_shutdown(&hook_ctx, ShutdownReason::Sigterm, &hook_cancel)
         .await;
-    // TaskRunner active-task cancellation is future work (P0b); for now
-    // we just tear down transports and drain telemetry.
+    // Stop accepting new turns, then cooperatively wait for any in-flight turn
+    // to finish before tearing down transports. Never SIGKILL mid-flight work.
+    runner.begin_drain();
+    let drain_timeout =
+        std::time::Duration::from_secs(profile.inner.lifecycle.stop_timeout_secs);
+    if runner.await_idle(drain_timeout).await {
+        info!("task runner drained cleanly");
+    } else {
+        warn!(
+            "task runner did not drain within {}s; tearing down anyway",
+            profile.inner.lifecycle.stop_timeout_secs
+        );
+    }
     for t in transport_tasks {
         t.abort();
     }

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -259,13 +259,13 @@ impl TaskRunner {
         self.draining.store(true, Ordering::SeqCst);
     }
 
-    /// Returns `true` when there are no turns registered in the in-flight
-    /// registry (i.e. every turn has completed/failed/cancelled), or `false`
+    /// Returns `true` when no task is in `TaskState::Working`, or `false`
     /// if `timeout` elapses first.
     ///
-    /// Uses the `registry` length as a proxy for in-flight turns: `set_state`
-    /// always inserts before execution begins and the final outcome always
-    /// updates state, so an empty registry means the runner is fully idle.
+    /// The registry retains completed/failed/cancelled entries, so the length
+    /// is NOT a reliable idle indicator. Instead this polls for the absence of
+    /// any `TaskState::Working` entry — which is inserted before a turn begins
+    /// and transitioned to a terminal state when it ends (or is cancelled).
     /// Polls every 50 ms to stay responsive under a typical stop_timeout_secs.
     pub async fn await_idle(&self, timeout: std::time::Duration) -> bool {
         let deadline = tokio::time::Instant::now() + timeout;
@@ -752,6 +752,29 @@ impl TaskRunner {
     }
 
     pub fn start_async(&self, spec: TaskSpec) -> AsyncTaskHandle {
+        // Drain guard: reject new tasks when the runtime is draining for restart.
+        // Must run BEFORE any set_state(_, Working) so await_idle is never blocked
+        // by a phantom Working entry.
+        if self.draining.load(Ordering::SeqCst) {
+            tracing::debug!("start_async called while draining — returning transient failure without registering a Working entry");
+            let id = format!("task-{}", Uuid::now_v7());
+            let now = chrono::Utc::now().to_rfc3339();
+            let (tx_done, rx_done) = oneshot::channel::<TaskOutcome>();
+            let _ = tx_done.send(TaskOutcome::Failed(Task {
+                id: id.clone(),
+                state: TaskState::Failed,
+                messages: vec![spec.input],
+                created_at: now.clone(),
+                completed_at: Some(now),
+                error: Some(task_error(
+                    "draining",
+                    "agent is draining for restart; retry shortly".into(),
+                    true,
+                )),
+                usage: None,
+            }));
+            return AsyncTaskHandle { id, done: rx_done };
+        }
         self.last_activity_at
             .store(chrono::Utc::now().timestamp(), Ordering::Relaxed);
         let id = format!("task-{}", Uuid::now_v7());
@@ -2605,5 +2628,36 @@ mod tests {
             .await_idle(std::time::Duration::from_millis(100))
             .await;
         assert!(ok, "registry must be clean after a rejected (draining) turn");
+    }
+
+    #[tokio::test]
+    async fn drain_start_async_does_not_register_working_entry() {
+        // After begin_drain(), start_async must NOT leave a Working entry, so
+        // await_idle returns true immediately (no phantom task blocks shutdown).
+        let runner = TaskRunner::new_stub_echo();
+        runner.begin_drain();
+        let handle = runner.start_async(ping_spec());
+        // The handle resolves to Failed (transient rejection).
+        let outcome = handle.await_completion().await;
+        match outcome {
+            TaskOutcome::Failed(task) => {
+                let err = task.error.expect("drained async turn must have an error");
+                assert!(err.recoverable, "async drain rejection must be recoverable");
+                assert!(
+                    err.message.contains("draining"),
+                    "error message must mention draining, got: {}",
+                    err.message
+                );
+            }
+            other => panic!("expected Failed from start_async after drain, got {other:?}"),
+        }
+        // await_idle must not hang — no Working entry was registered.
+        let ok = runner
+            .await_idle(std::time::Duration::from_millis(100))
+            .await;
+        assert!(
+            ok,
+            "registry must have no Working entries after start_async drain rejection"
+        );
     }
 }

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -12,7 +12,7 @@ use mur_common::a2a::{Message, MessagePart, Task, TaskError, TaskState};
 use mur_common::config::SkillsConfig;
 use mur_common::skill::McpInventory;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
@@ -149,6 +149,10 @@ pub struct TaskRunner {
     tools_policy: Vec<mur_common::agent::ToolRule>,
     /// Multi-turn chat memory keyed by `context.task_id` (see `ConversationStore`).
     conversations: Mutex<ConversationStore>,
+    /// Set by `begin_drain()` during graceful shutdown. When true, `run_sync_inner`
+    /// rejects new turns immediately with a transient failure so in-flight work
+    /// can finish before transports are torn down.
+    draining: Arc<AtomicBool>,
 }
 
 /// Default agentic-loop iteration cap when `HitlConfig.max_iterations` is unset.
@@ -243,6 +247,42 @@ impl TaskRunner {
             tools: vec![],
             tools_policy: vec![],
             conversations: Mutex::new(ConversationStore::default()),
+            draining: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Signal this runner to stop accepting new turns. Any turn that arrives
+    /// after `begin_drain()` returns a transient `TaskOutcome::Failed` so the
+    /// caller can retry after the runtime restarts. In-flight turns are NOT
+    /// aborted; they complete normally.
+    pub fn begin_drain(&self) {
+        self.draining.store(true, Ordering::SeqCst);
+    }
+
+    /// Returns `true` when there are no turns registered in the in-flight
+    /// registry (i.e. every turn has completed/failed/cancelled), or `false`
+    /// if `timeout` elapses first.
+    ///
+    /// Uses the `registry` length as a proxy for in-flight turns: `set_state`
+    /// always inserts before execution begins and the final outcome always
+    /// updates state, so an empty registry means the runner is fully idle.
+    /// Polls every 50 ms to stay responsive under a typical stop_timeout_secs.
+    pub async fn await_idle(&self, timeout: std::time::Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            {
+                let reg = self.registry.lock().unwrap_or_else(|e| e.into_inner());
+                let working = reg
+                    .values()
+                    .any(|s| matches!(s, TaskState::Working));
+                if !working {
+                    return true;
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
     }
 
@@ -512,6 +552,30 @@ impl TaskRunner {
         spec: TaskSpec,
         sink: Option<tokio::sync::mpsc::Sender<crate::llm::StreamDelta>>,
     ) -> TaskOutcome {
+        // Reject new turns immediately when the runtime is draining for restart.
+        // This is a transient failure — callers should retry after the agent
+        // comes back up. We do NOT register the task in the registry, so
+        // `await_idle` will not be blocked by this rejection.
+        if self.draining.load(Ordering::SeqCst) {
+            let id = spec
+                .task_id
+                .clone()
+                .unwrap_or_else(|| format!("task-{}", Uuid::now_v7()));
+            let now = chrono::Utc::now().to_rfc3339();
+            return TaskOutcome::Failed(Task {
+                id,
+                state: TaskState::Failed,
+                messages: vec![spec.input],
+                created_at: now.clone(),
+                completed_at: Some(now),
+                error: Some(task_error(
+                    "draining",
+                    "agent is draining for restart; retry shortly".into(),
+                    true,
+                )),
+                usage: None,
+            });
+        }
         // Record real inbound activity so idle triggers measure genuine
         // quiescence. Previously only `start_async` (a non-production path)
         // bumped this, leaving `last_activity_at` permanently 0 and causing
@@ -2494,5 +2558,52 @@ mod tests {
             user_message(&msg),
             crate::llm::RichMessage::Text { .. }
         ));
+    }
+
+    // ── Drain tests ───────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn drain_idle_runner_returns_true_immediately() {
+        let runner = TaskRunner::new_stub_echo();
+        // An idle runner (no in-flight tasks) must return true within the timeout.
+        let ok = runner
+            .await_idle(std::time::Duration::from_millis(200))
+            .await;
+        assert!(ok, "idle runner should drain immediately");
+    }
+
+    #[tokio::test]
+    async fn drain_rejects_new_turns_after_begin_drain() {
+        let runner = TaskRunner::new_stub_echo();
+        runner.begin_drain();
+        // New turns must be rejected with a transient Failed outcome.
+        let outcome = runner.run_sync(ping_spec()).await;
+        match outcome {
+            TaskOutcome::Failed(task) => {
+                let err = task.error.expect("drained turn must have an error");
+                assert!(
+                    err.recoverable,
+                    "drain rejection must be marked recoverable"
+                );
+                assert!(
+                    err.message.contains("draining"),
+                    "error message must mention draining, got: {}",
+                    err.message
+                );
+            }
+            other => panic!("expected Failed after drain, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_still_idle_after_rejected_turn() {
+        // A rejected turn must NOT register in the registry, so await_idle stays true.
+        let runner = TaskRunner::new_stub_echo();
+        runner.begin_drain();
+        let _ = runner.run_sync(ping_spec()).await;
+        let ok = runner
+            .await_idle(std::time::Duration::from_millis(100))
+            .await;
+        assert!(ok, "registry must be clean after a rejected (draining) turn");
     }
 }

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -272,9 +272,7 @@ impl TaskRunner {
         loop {
             {
                 let reg = self.registry.lock().unwrap_or_else(|e| e.into_inner());
-                let working = reg
-                    .values()
-                    .any(|s| matches!(s, TaskState::Working));
+                let working = reg.values().any(|s| matches!(s, TaskState::Working));
                 if !working {
                     return true;
                 }
@@ -756,7 +754,9 @@ impl TaskRunner {
         // Must run BEFORE any set_state(_, Working) so await_idle is never blocked
         // by a phantom Working entry.
         if self.draining.load(Ordering::SeqCst) {
-            tracing::debug!("start_async called while draining — returning transient failure without registering a Working entry");
+            tracing::debug!(
+                "start_async called while draining — returning transient failure without registering a Working entry"
+            );
             let id = format!("task-{}", Uuid::now_v7());
             let now = chrono::Utc::now().to_rfc3339();
             let (tx_done, rx_done) = oneshot::channel::<TaskOutcome>();
@@ -2627,7 +2627,10 @@ mod tests {
         let ok = runner
             .await_idle(std::time::Duration::from_millis(100))
             .await;
-        assert!(ok, "registry must be clean after a rejected (draining) turn");
+        assert!(
+            ok,
+            "registry must be clean after a rejected (draining) turn"
+        );
     }
 
     #[tokio::test]

--- a/mur-agent-runtime/tests/lock_file.rs
+++ b/mur-agent-runtime/tests/lock_file.rs
@@ -20,6 +20,8 @@ fn sample_lock() -> LockFile {
         },
         card_digest: "sha256:abc".into(),
         capabilities: vec!["a2a.message.send".into()],
+        build_sha: String::new(),
+        proto_version: 0,
     }
 }
 

--- a/mur-common/Cargo.toml
+++ b/mur-common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mur-common"
 description = "Shared types and traits for the MUR ecosystem"
 version.workspace = true
+build = "build.rs"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/mur-common/build.rs
+++ b/mur-common/build.rs
@@ -1,0 +1,17 @@
+use std::process::Command;
+
+fn main() {
+    // Re-run when HEAD moves (a new commit changes the sha).
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs");
+    let sha = Command::new("git")
+        .args(["rev-parse", "--short=12", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=MUR_GIT_SHA={sha}");
+}

--- a/mur-common/build.rs
+++ b/mur-common/build.rs
@@ -2,6 +2,9 @@ use std::process::Command;
 
 fn main() {
     // Re-run when HEAD moves (a new commit changes the sha).
+    // Note: in a git *worktree* `.git` is a file, not a directory, so these
+    // paths may not exist — Cargo degrades gracefully (notify-only signal; last
+    // known SHORT_SHA / "unknown" is reused, which is acceptable).
     println!("cargo:rerun-if-changed=../.git/HEAD");
     println!("cargo:rerun-if-changed=../.git/refs");
     let sha = Command::new("git")

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -843,6 +843,14 @@ pub struct LockFile {
     pub transports: LockTransports,
     pub card_digest: String,
     pub capabilities: Vec<String>,
+    /// Git sha the running binary was built from (mur_common::build::SHORT_SHA).
+    /// Empty = an old lock predating this field. Drives stale detection.
+    #[serde(default)]
+    pub build_sha: String,
+    /// A2A method-surface version this runtime supports (A2A_PROTO_VERSION).
+    /// 0 = an old lock; the dial gates versioned methods on it.
+    #[serde(default)]
+    pub proto_version: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1909,5 +1917,22 @@ mod tool_policy_tests {
 
         set_denylist(&mut list, "b", true); // enabling an absent name is a no-op
         assert!(list.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod lockfile_compat_tests {
+    use super::*;
+
+    #[test]
+    fn lockfile_new_fields_default_for_old_locks() {
+        // An old lock JSON without build_sha/proto_version must still parse,
+        // defaulting to "" / 0 (= "predates this feature → stale/unsupported").
+        let old = r#"{"schema":1,"uuid":"u","name":"a","pid":1,"ppid":1,
+          "started_at":"t","binary_version":"mur-agent-runtime 2.26.9",
+          "transports":{"stdio":true},"card_digest":"d","capabilities":[]}"#;
+        let lock: LockFile = serde_json::from_str(old).unwrap();
+        assert_eq!(lock.build_sha, "");
+        assert_eq!(lock.proto_version, 0);
     }
 }

--- a/mur-common/src/build.rs
+++ b/mur-common/src/build.rs
@@ -27,7 +27,10 @@ mod tests {
     #[test]
     fn short_sha_is_set() {
         // Either a real 12-char hex sha, or the "unknown" fallback.
-        assert!(SHORT_SHA == "unknown" || SHORT_SHA.len() == 12, "got {SHORT_SHA:?}");
+        assert!(
+            SHORT_SHA == "unknown" || SHORT_SHA.len() == 12,
+            "got {SHORT_SHA:?}"
+        );
     }
 
     #[test]

--- a/mur-common/src/build.rs
+++ b/mur-common/src/build.rs
@@ -5,6 +5,21 @@
 /// 12-char git sha of this build, or "unknown".
 pub const SHORT_SHA: &str = env!("MUR_GIT_SHA");
 
+/// A2A method-surface version. Bump ONLY on incompatible change to a dialed
+/// method (added method, changed params/result contract). Carried in
+/// `running.lock` AgentCard; dial refuses a method whose
+/// `method_min_proto` exceeds the peer's advertised proto.
+pub const A2A_PROTO_VERSION: u32 = 1;
+
+/// Minimum proto a peer must advertise to accept the dialed `method`. `0` means
+/// always available (never gated). Add an entry per method introduced/changed.
+pub fn method_min_proto(method: &str) -> u32 {
+    match method {
+        "channel/delegate" => 1,
+        _ => 0,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -13,5 +28,16 @@ mod tests {
     fn short_sha_is_set() {
         // Either a real 12-char hex sha, or the "unknown" fallback.
         assert!(SHORT_SHA == "unknown" || SHORT_SHA.len() == 12, "got {SHORT_SHA:?}");
+    }
+
+    #[test]
+    fn method_min_proto_gates_channel_delegate_only() {
+        // channel/delegate requires the proto that introduced it.
+        assert_eq!(method_min_proto("channel/delegate"), 1);
+        // Always-available methods are ungated (min 0).
+        assert_eq!(method_min_proto("message/send"), 0);
+        assert_eq!(method_min_proto("agent/card"), 0);
+        // The current proto is at least the highest gated method.
+        assert!(A2A_PROTO_VERSION >= 1);
     }
 }

--- a/mur-common/src/build.rs
+++ b/mur-common/src/build.rs
@@ -1,0 +1,17 @@
+//! Compile-time build identity. `SHORT_SHA` is the git commit the binary was
+//! built from (set by build.rs), or "unknown" for git-less builds (crates.io).
+//! Used to detect when a running agent's binary differs from the installed one.
+
+/// 12-char git sha of this build, or "unknown".
+pub const SHORT_SHA: &str = env!("MUR_GIT_SHA");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_sha_is_set() {
+        // Either a real 12-char hex sha, or the "unknown" fallback.
+        assert!(SHORT_SHA == "unknown" || SHORT_SHA.len() == 12, "got {SHORT_SHA:?}");
+    }
+}

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -4,6 +4,7 @@ pub mod actor;
 pub mod agent;
 pub mod agent_name;
 pub mod bridge;
+pub mod build;
 pub mod bundle;
 pub mod canonical;
 pub mod channel;

--- a/mur-common/src/lock_file.rs
+++ b/mur-common/src/lock_file.rs
@@ -154,6 +154,8 @@ mod tests {
             },
             card_digest: "sha256:abc".into(),
             capabilities: vec!["a2a.message.send".into()],
+            build_sha: String::new(),
+            proto_version: 0,
         }
     }
 

--- a/mur-core/src/a2a_dial.rs
+++ b/mur-core/src/a2a_dial.rs
@@ -96,20 +96,23 @@ pub fn dial_method(
     // Reads the peer's running.lock (cheap, local). Ungated methods (min 0) skip.
     if is_running {
         let needed = mur_common::build::method_min_proto(method);
-        if needed > 0 {
-            if let Ok(bytes) = fs::read(&lock_path) {
-                if let Ok(lock) = serde_json::from_slice::<LockFile>(&bytes) {
-                    if lock.proto_version < needed {
-                        let sha = if lock.build_sha.is_empty() { "unknown" } else { &lock.build_sha };
-                        bail!(
-                            "agent '{agent_name}' is running a stale runtime (proto {}, build {}); \
-                             the requested capability '{method}' needs proto {needed}. \
-                             Run 'mur agent restart {agent_name}' to apply the installed runtime.",
-                            lock.proto_version, sha
-                        );
-                    }
-                }
-            }
+        if needed > 0
+            && let Ok(bytes) = fs::read(&lock_path)
+            && let Ok(lock) = serde_json::from_slice::<LockFile>(&bytes)
+            && lock.proto_version < needed
+        {
+            let sha = if lock.build_sha.is_empty() {
+                "unknown"
+            } else {
+                &lock.build_sha
+            };
+            bail!(
+                "agent '{agent_name}' is running a stale runtime (proto {}, build {}); \
+                 the requested capability '{method}' needs proto {needed}. \
+                 Run 'mur agent restart {agent_name}' to apply the installed runtime.",
+                lock.proto_version,
+                sha
+            );
         }
     }
 
@@ -436,18 +439,31 @@ mod tests {
         let adir = tmp.path().join("agents").join("rustsmith");
         std::fs::create_dir_all(&adir).unwrap();
         // Old lock: proto_version absent → 0 < channel/delegate's min (1).
-        std::fs::write(adir.join("running.lock"), r#"{"schema":1,"uuid":"u",
+        std::fs::write(
+            adir.join("running.lock"),
+            r#"{"schema":1,"uuid":"u",
           "name":"rustsmith","pid":1,"ppid":1,"started_at":"t",
           "binary_version":"old","transports":{"stdio":true,
-          "unix_socket":"/nonexistent.sock"},"card_digest":"d","capabilities":[]}"#).unwrap();
+          "unix_socket":"/nonexistent.sock"},"card_digest":"d","capabilities":[]}"#,
+        )
+        .unwrap();
 
-        let err = dial_method(tmp.path(), "rustsmith", "channel/delegate",
-            serde_json::json!({}), DialMode::RequireRunning).unwrap_err();
+        let err = dial_method(
+            tmp.path(),
+            "rustsmith",
+            "channel/delegate",
+            serde_json::json!({}),
+            DialMode::RequireRunning,
+        )
+        .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("stale runtime"), "got: {msg}");
         assert!(msg.contains("mur agent restart rustsmith"), "got: {msg}");
         // It must NOT have tried to connect to the (nonexistent) socket.
-        assert!(!msg.contains("connect"), "gate should fire before dialing: {msg}");
+        assert!(
+            !msg.contains("connect"),
+            "gate should fire before dialing: {msg}"
+        );
     }
 
     #[test]
@@ -457,12 +473,25 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let adir = tmp.path().join("agents").join("a");
         std::fs::create_dir_all(&adir).unwrap();
-        std::fs::write(adir.join("running.lock"), r#"{"schema":1,"uuid":"u","name":"a",
+        std::fs::write(
+            adir.join("running.lock"),
+            r#"{"schema":1,"uuid":"u","name":"a",
           "pid":1,"ppid":1,"started_at":"t","binary_version":"old",
           "transports":{"stdio":true,"unix_socket":"/nonexistent.sock"},
-          "card_digest":"d","capabilities":[]}"#).unwrap();
-        let err = dial_method(tmp.path(), "a", "message/send",
-            serde_json::json!({}), DialMode::RequireRunning).unwrap_err();
-        assert!(!err.to_string().contains("stale runtime"), "must not gate message/send");
+          "card_digest":"d","capabilities":[]}"#,
+        )
+        .unwrap();
+        let err = dial_method(
+            tmp.path(),
+            "a",
+            "message/send",
+            serde_json::json!({}),
+            DialMode::RequireRunning,
+        )
+        .unwrap_err();
+        assert!(
+            !err.to_string().contains("stale runtime"),
+            "must not gate message/send"
+        );
     }
 }

--- a/mur-core/src/a2a_dial.rs
+++ b/mur-core/src/a2a_dial.rs
@@ -91,6 +91,28 @@ pub fn dial_method(
     let lock_path = home.join("agents").join(agent_name).join("running.lock");
     let is_running = lock_path.exists();
 
+    // Pre-flight version gate: refuse a versioned method against a running peer
+    // whose advertised proto is too low — with an actionable error, not -32601.
+    // Reads the peer's running.lock (cheap, local). Ungated methods (min 0) skip.
+    if is_running {
+        let needed = mur_common::build::method_min_proto(method);
+        if needed > 0 {
+            if let Ok(bytes) = fs::read(&lock_path) {
+                if let Ok(lock) = serde_json::from_slice::<LockFile>(&bytes) {
+                    if lock.proto_version < needed {
+                        let sha = if lock.build_sha.is_empty() { "unknown" } else { &lock.build_sha };
+                        bail!(
+                            "agent '{agent_name}' is running a stale runtime (proto {}, build {}); \
+                             the requested capability '{method}' needs proto {needed}. \
+                             Run 'mur agent restart {agent_name}' to apply the installed runtime.",
+                            lock.proto_version, sha
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     match (mode, is_running) {
         (DialMode::RequireRunning, false) => bail!(
             "agent '{agent_name}' is not running (no {})",
@@ -406,5 +428,41 @@ mod tests {
             msg.contains("runtime binary not found") || msg.contains("spawn"),
             "unexpected error: {msg}"
         );
+    }
+
+    #[test]
+    fn dial_gates_channel_delegate_on_stale_proto() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let adir = tmp.path().join("agents").join("rustsmith");
+        std::fs::create_dir_all(&adir).unwrap();
+        // Old lock: proto_version absent → 0 < channel/delegate's min (1).
+        std::fs::write(adir.join("running.lock"), r#"{"schema":1,"uuid":"u",
+          "name":"rustsmith","pid":1,"ppid":1,"started_at":"t",
+          "binary_version":"old","transports":{"stdio":true,
+          "unix_socket":"/nonexistent.sock"},"card_digest":"d","capabilities":[]}"#).unwrap();
+
+        let err = dial_method(tmp.path(), "rustsmith", "channel/delegate",
+            serde_json::json!({}), DialMode::RequireRunning).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("stale runtime"), "got: {msg}");
+        assert!(msg.contains("mur agent restart rustsmith"), "got: {msg}");
+        // It must NOT have tried to connect to the (nonexistent) socket.
+        assert!(!msg.contains("connect"), "gate should fire before dialing: {msg}");
+    }
+
+    #[test]
+    fn dial_does_not_gate_ungated_method() {
+        // message/send (min 0) on the same stale lock must NOT be proto-gated
+        // (it will fail later for a different reason — socket — which is fine).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let adir = tmp.path().join("agents").join("a");
+        std::fs::create_dir_all(&adir).unwrap();
+        std::fs::write(adir.join("running.lock"), r#"{"schema":1,"uuid":"u","name":"a",
+          "pid":1,"ppid":1,"started_at":"t","binary_version":"old",
+          "transports":{"stdio":true,"unix_socket":"/nonexistent.sock"},
+          "card_digest":"d","capabilities":[]}"#).unwrap();
+        let err = dial_method(tmp.path(), "a", "message/send",
+            serde_json::json!({}), DialMode::RequireRunning).unwrap_err();
+        assert!(!err.to_string().contains("stale runtime"), "must not gate message/send");
     }
 }

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -41,6 +41,22 @@ pub enum AgentAction {
         /// Agent name
         name: String,
     },
+    /// Gracefully restart one or more running agents so they pick up an
+    /// upgraded runtime binary. Sends SIGTERM (drains in-flight turn), waits
+    /// for exit, then polls for the launchd-respawned process.
+    Restart {
+        /// Agent name (mutually exclusive with --all / --stale)
+        name: Option<String>,
+        /// Restart all running agents
+        #[arg(long)]
+        all: bool,
+        /// Restart only agents running a stale binary (build-id differs from on-disk)
+        #[arg(long = "stale")]
+        stale: bool,
+        /// Print targets without restarting
+        #[arg(long = "dry-run")]
+        dry_run: bool,
+    },
     /// Remove an agent (symlink + optionally data)
     Remove {
         /// Agent name

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -229,6 +229,14 @@ pub enum AgentAction {
         #[arg(long)]
         json: bool,
     },
+    /// Check running agents for stale runtime binaries (build-sha compare).
+    /// Exits non-zero if any agent is stale.
+    #[command(name = "runtime-doctor")]
+    RuntimeDoctor {
+        /// Emit JSON array instead of human text
+        #[arg(long)]
+        json: bool,
+    },
     /// Manage an agent's keychain-backed secrets (set/list/delete)
     Secret {
         /// Agent name

--- a/mur-core/src/cmd/agent/doctor.rs
+++ b/mur-core/src/cmd/agent/doctor.rs
@@ -1,0 +1,173 @@
+//! `mur agent runtime-doctor` — flag running agents whose binary differs from
+//! the on-disk runtime (build-sha compare).
+
+use anyhow::Result;
+use mur_common::LockFile;
+
+use super::{resolve_mur_home, stale};
+
+/// One row in the doctor report.
+pub struct AgentRow {
+    pub name: String,
+    pub lock_sha: String,
+    pub disk_sha: String,
+    pub stale: bool,
+}
+
+/// Build a doctor row for a single agent from its parsed lock file.
+///
+/// Pure function — no I/O — so it is cheap to unit-test.
+pub fn build_row(name: &str, lock: &LockFile, disk_sha: &str) -> AgentRow {
+    let lock_sha = if lock.build_sha.is_empty() {
+        "unknown".to_string()
+    } else {
+        lock.build_sha.clone()
+    };
+    AgentRow {
+        name: name.to_string(),
+        lock_sha,
+        disk_sha: disk_sha.to_string(),
+        stale: stale::is_stale(lock, disk_sha),
+    }
+}
+
+/// `mur agent runtime-doctor [--json]`
+///
+/// Enumerates all agents that have a `running.lock`, compares each one's
+/// recorded `build_sha` against the on-disk runtime binary, and reports
+/// which ones are stale.  Exits non-zero when at least one agent is stale.
+pub fn cmd_doctor(json: bool) -> Result<()> {
+    let mur_home = resolve_mur_home()?;
+    let agents_dir = mur_home.join("agents");
+
+    // Compute the on-disk sha ONCE — avoids redundant subprocess calls.
+    let disk_sha = stale::on_disk_sha();
+
+    let mut rows: Vec<AgentRow> = Vec::new();
+
+    if agents_dir.is_dir() {
+        let mut entries: Vec<_> = std::fs::read_dir(&agents_dir)
+            .unwrap_or_else(|_| panic!("cannot read {}", agents_dir.display()))
+            .filter_map(|e| e.ok())
+            .collect();
+        // Stable, deterministic output order.
+        entries.sort_by_key(|e| e.file_name());
+
+        for entry in entries {
+            let agent_name = entry.file_name().to_string_lossy().to_string();
+            let lock_path = entry.path().join("running.lock");
+            if !lock_path.exists() {
+                continue; // agent not running
+            }
+            let bytes = match std::fs::read(&lock_path) {
+                Ok(b) => b,
+                Err(_) => continue, // unreadable — skip
+            };
+            let lock: LockFile = match serde_json::from_slice(&bytes) {
+                Ok(l) => l,
+                Err(_) => continue, // malformed lock — skip
+            };
+            rows.push(build_row(&agent_name, &lock, &disk_sha));
+        }
+    }
+
+    // ── Output ──────────────────────────────────────────────────────────────
+    let any_stale = rows.iter().any(|r| r.stale);
+
+    if json {
+        let arr: Vec<serde_json::Value> = rows
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "name":     r.name,
+                    "running":  true,
+                    "stale":    r.stale,
+                    "lock_sha": r.lock_sha,
+                    "disk_sha": r.disk_sha,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&arr)?);
+    } else {
+        if rows.is_empty() {
+            println!("No running agents found.");
+        }
+        for r in &rows {
+            if r.stale {
+                let lock8 = r.lock_sha.chars().take(8).collect::<String>();
+                let disk8 = r.disk_sha.chars().take(8).collect::<String>();
+                println!(
+                    "{}: running, STALE (lock {} vs disk {}) \u{2192} run 'mur agent restart {}'",
+                    r.name, lock8, disk8, r.name
+                );
+            } else {
+                println!("{}: running, current", r.name);
+            }
+        }
+    }
+
+    if any_stale {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::LockFile;
+
+    fn make_lock(build_sha: &str) -> LockFile {
+        LockFile {
+            schema: 1,
+            uuid: "test-uuid".to_string(),
+            name: "test-agent".to_string(),
+            pid: 12345,
+            ppid: 1,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            binary_version: "1.0.0".to_string(),
+            transports: mur_common::agent::LockTransports {
+                stdio: true,
+                unix_socket: None,
+                tcp: None,
+                webhook: None,
+            },
+            card_digest: "abc".to_string(),
+            capabilities: vec![],
+            build_sha: build_sha.to_string(),
+            proto_version: 1,
+        }
+    }
+
+    #[test]
+    fn build_row_stale_when_shas_differ() {
+        let lock = make_lock("abc123def456");
+        let row = build_row("myagent", &lock, "999999999999");
+        assert!(row.stale);
+        assert_eq!(row.name, "myagent");
+        assert_eq!(row.lock_sha, "abc123def456");
+        assert_eq!(row.disk_sha, "999999999999");
+    }
+
+    #[test]
+    fn build_row_current_when_shas_match() {
+        let lock = make_lock("abc123def456");
+        let row = build_row("myagent", &lock, "abc123def456");
+        assert!(!row.stale);
+    }
+
+    #[test]
+    fn build_row_empty_lock_sha_shown_as_unknown() {
+        let lock = make_lock("");
+        let row = build_row("myagent", &lock, "abc123def456");
+        assert!(row.stale);
+        assert_eq!(row.lock_sha, "unknown");
+    }
+
+    #[test]
+    fn build_row_two_unknowns_not_stale() {
+        let lock = make_lock("unknown");
+        let row = build_row("myagent", &lock, "unknown");
+        assert!(!row.stale);
+    }
+}

--- a/mur-core/src/cmd/agent/doctor.rs
+++ b/mur-core/src/cmd/agent/doctor.rs
@@ -1,7 +1,7 @@
 //! `mur agent runtime-doctor` — flag running agents whose binary differs from
 //! the on-disk runtime (build-sha compare).
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use mur_common::LockFile;
 
 use super::{resolve_mur_home, stale};
@@ -47,7 +47,7 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
 
     if agents_dir.is_dir() {
         let mut entries: Vec<_> = std::fs::read_dir(&agents_dir)
-            .unwrap_or_else(|_| panic!("cannot read {}", agents_dir.display()))
+            .with_context(|| format!("read {}", agents_dir.display()))?
             .filter_map(|e| e.ok())
             .collect();
         // Stable, deterministic output order.

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -262,6 +262,10 @@ fn default_entitlements_custom() -> Entitlements {
 
 // ─── list / status ───────────────────────────────────────────────────────
 
+/// Trailing annotation appended to human-readable output when a running agent's
+/// binary is outdated.  Kept out of --json output.
+const STALE_SUFFIX: &str = " — stale runtime (restart to apply)";
+
 #[derive(Debug, serde::Serialize)]
 struct AgentRow {
     name: String,
@@ -453,24 +457,22 @@ pub fn cmd_list(json: bool) -> Result<()> {
                 .map(|p| p.to_string())
                 .unwrap_or_else(|| "-".to_string());
             let uptime = r.uptime.clone().unwrap_or_else(|| "-".to_string());
-            // Append stale marker for running agents whose binary is outdated.
-            let status = if r.status == "running" {
+            // Detect stale-runtime for running agents. The STATUS column stays
+            // plain "running" so fixed-width alignment is preserved; the marker
+            // is appended as a trailing annotation after the last column.
+            let stale_annotation = if r.status == "running" {
                 let lock_path = mur_home.join("agents").join(&r.name).join("running.lock");
                 let stale = mur_common::lock_file::read(&lock_path)
                     .ok()
                     .flatten()
                     .is_some_and(|lock| super::stale::is_stale(&lock, &on_disk));
-                if stale {
-                    "running — stale runtime (restart to apply)".to_string()
-                } else {
-                    r.status.to_string()
-                }
+                if stale { format!(" ⚠{STALE_SUFFIX}") } else { String::new() }
             } else {
-                r.status.to_string()
+                String::new()
             };
             println!(
-                "{:<20} {:<6} {:<10} {:<20} {:<10} {:<12}",
-                r.name, r.emoji, status, uptime, pid, r.category
+                "{:<20} {:<6} {:<10} {:<20} {:<10} {:<12}{}",
+                r.name, r.emoji, r.status, uptime, pid, r.category, stale_annotation
             );
         }
     }
@@ -497,7 +499,7 @@ pub fn cmd_status(name: &str) -> Result<()> {
             .ok()
             .flatten()
             .is_some_and(|lock| super::stale::is_stale(&lock, &on_disk));
-        if stale { " — stale runtime (restart to apply)" } else { "" }
+        if stale { STALE_SUFFIX } else { "" }
     } else {
         ""
     };

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -466,7 +466,11 @@ pub fn cmd_list(json: bool) -> Result<()> {
                     .ok()
                     .flatten()
                     .is_some_and(|lock| super::stale::is_stale(&lock, &on_disk));
-                if stale { format!(" ⚠{STALE_SUFFIX}") } else { String::new() }
+                if stale {
+                    format!(" ⚠{STALE_SUFFIX}")
+                } else {
+                    String::new()
+                }
             } else {
                 String::new()
             };

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -440,6 +440,9 @@ pub fn cmd_list(json: bool) -> Result<()> {
     if json {
         println!("{}", serde_json::to_string(&rows)?);
     } else {
+        let mur_home = resolve_mur_home()?;
+        // Compute on-disk sha ONCE — avoids a subprocess call per agent.
+        let on_disk = super::stale::on_disk_sha();
         println!(
             "{:<20} {:<6} {:<10} {:<20} {:<10} {:<12}",
             "NAME", "EMOJI", "STATUS", "UPTIME", "PID", "CATEGORY"
@@ -450,9 +453,24 @@ pub fn cmd_list(json: bool) -> Result<()> {
                 .map(|p| p.to_string())
                 .unwrap_or_else(|| "-".to_string());
             let uptime = r.uptime.clone().unwrap_or_else(|| "-".to_string());
+            // Append stale marker for running agents whose binary is outdated.
+            let status = if r.status == "running" {
+                let lock_path = mur_home.join("agents").join(&r.name).join("running.lock");
+                let stale = mur_common::lock_file::read(&lock_path)
+                    .ok()
+                    .flatten()
+                    .is_some_and(|lock| super::stale::is_stale(&lock, &on_disk));
+                if stale {
+                    "running — stale runtime (restart to apply)".to_string()
+                } else {
+                    r.status.to_string()
+                }
+            } else {
+                r.status.to_string()
+            };
             println!(
                 "{:<20} {:<6} {:<10} {:<20} {:<10} {:<12}",
-                r.name, r.emoji, r.status, uptime, pid, r.category
+                r.name, r.emoji, status, uptime, pid, r.category
             );
         }
     }
@@ -460,6 +478,7 @@ pub fn cmd_list(json: bool) -> Result<()> {
 }
 
 pub fn cmd_status(name: &str) -> Result<()> {
+    let mur_home = resolve_mur_home()?;
     let rows = collect_agents()?;
     let row = rows
         .iter()
@@ -468,9 +487,21 @@ pub fn cmd_status(name: &str) -> Result<()> {
     println!("● {} - {}", row.name, row.category);
     println!(
         "   Loaded: {}",
-        resolve_mur_home()?.join("agents").join(name).display()
+        mur_home.join("agents").join(name).display()
     );
-    println!("   Active: {}", row.status);
+    // Check for stale runtime when the agent is running.
+    let stale_suffix = if row.status == "running" {
+        let on_disk = super::stale::on_disk_sha();
+        let lock_path = mur_home.join("agents").join(name).join("running.lock");
+        let stale = mur_common::lock_file::read(&lock_path)
+            .ok()
+            .flatten()
+            .is_some_and(|lock| super::stale::is_stale(&lock, &on_disk));
+        if stale { " — stale runtime (restart to apply)" } else { "" }
+    } else {
+        ""
+    };
+    println!("   Active: {}{stale_suffix}", row.status);
     if let Some(pid) = row.pid {
         println!("     Main PID: {pid}");
     }

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -38,11 +38,13 @@ mod peers;
 mod perm;
 mod prompt;
 mod reconnect;
+mod restart;
 mod secret;
 mod service;
 pub mod skill;
 mod snapshot;
 mod stats;
+pub mod stale;
 
 // `pub use` re-exports for the public CLI dispatch API. The lib crate doesn't
 // reference these names internally; consumers (main.rs, agent_admin) reach them
@@ -80,6 +82,8 @@ pub(crate) use prompt::prompt_path_for;
 pub use prompt::{cmd_prompt_edit, cmd_prompt_set, cmd_prompt_show};
 #[allow(unused_imports)]
 pub use reconnect::cmd_agent_reconnect;
+#[allow(unused_imports)]
+pub use restart::cmd_restart;
 #[allow(unused_imports)]
 pub use secret::{cmd_secret_delete, cmd_secret_list, cmd_secret_set};
 #[allow(unused_imports)]

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -28,6 +28,7 @@ mod apply;
 pub mod channel_import;
 pub mod cli;
 mod comm;
+mod doctor;
 pub mod export;
 mod hub;
 mod install;
@@ -43,9 +44,8 @@ mod secret;
 mod service;
 pub mod skill;
 mod snapshot;
-mod stats;
 pub mod stale;
-mod doctor;
+mod stats;
 
 // `pub use` re-exports for the public CLI dispatch API. The lib crate doesn't
 // reference these names internally; consumers (main.rs, agent_admin) reach them
@@ -56,6 +56,8 @@ pub use apply::cmd_agent_apply;
 #[allow(unused_imports)]
 pub use cli::cmd_cli;
 pub use comm::{cmd_card, cmd_send};
+#[allow(unused_imports)]
+pub use doctor::cmd_doctor;
 #[allow(unused_imports)]
 pub use export::cmd_export;
 #[allow(unused_imports)]
@@ -85,8 +87,6 @@ pub use prompt::{cmd_prompt_edit, cmd_prompt_set, cmd_prompt_show};
 pub use reconnect::cmd_agent_reconnect;
 #[allow(unused_imports)]
 pub use restart::cmd_restart;
-#[allow(unused_imports)]
-pub use doctor::cmd_doctor;
 #[allow(unused_imports)]
 pub use secret::{cmd_secret_delete, cmd_secret_list, cmd_secret_set};
 #[allow(unused_imports)]

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -45,6 +45,7 @@ pub mod skill;
 mod snapshot;
 mod stats;
 pub mod stale;
+mod doctor;
 
 // `pub use` re-exports for the public CLI dispatch API. The lib crate doesn't
 // reference these names internally; consumers (main.rs, agent_admin) reach them
@@ -84,6 +85,8 @@ pub use prompt::{cmd_prompt_edit, cmd_prompt_set, cmd_prompt_show};
 pub use reconnect::cmd_agent_reconnect;
 #[allow(unused_imports)]
 pub use restart::cmd_restart;
+#[allow(unused_imports)]
+pub use doctor::cmd_doctor;
 #[allow(unused_imports)]
 pub use secret::{cmd_secret_delete, cmd_secret_list, cmd_secret_set};
 #[allow(unused_imports)]

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -6,7 +6,7 @@
 //! launchd needs the process to exit, not the lock to disappear.
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{Result, bail};
 use mur_common::LockFile;
@@ -93,12 +93,7 @@ pub(crate) fn select_targets_with_on_disk(
 ///
 /// - `name` / `all` / `stale`: select targets (mirror `cmd_stop`).
 /// - `dry_run`: print targets and return without acting.
-pub fn cmd_restart(
-    name: Option<&str>,
-    all: bool,
-    stale: bool,
-    dry_run: bool,
-) -> Result<()> {
+pub fn cmd_restart(name: Option<&str>, all: bool, stale: bool, dry_run: bool) -> Result<()> {
     let mur_home = resolve_mur_home()?;
     let agents_dir = mur_home.join("agents");
 
@@ -110,7 +105,11 @@ pub fn cmd_restart(
     }
 
     if dry_run {
-        let on_disk = if stale { stale::on_disk_sha() } else { String::new() };
+        let on_disk = if stale {
+            stale::on_disk_sha()
+        } else {
+            String::new()
+        };
         for t in &targets {
             if stale {
                 let lock_path = agents_dir.join(t).join("running.lock");
@@ -144,7 +143,7 @@ pub fn cmd_restart(
 }
 
 /// Restart a single agent: SIGTERM, wait for exit, poll for fresh lock.
-fn restart_one(name: &str, agents_dir: &PathBuf, on_disk_sha: &str) -> Result<()> {
+fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<()> {
     let agent_home = agents_dir.join(name);
     let lock_path = agent_home.join("running.lock");
 
@@ -152,8 +151,7 @@ fn restart_one(name: &str, agents_dir: &PathBuf, on_disk_sha: &str) -> Result<()
         bail!("agent '{name}' is not running");
     }
 
-    let bytes = fs::read(&lock_path)
-        .map_err(|e| anyhow::anyhow!("read lock for '{name}': {e}"))?;
+    let bytes = fs::read(&lock_path).map_err(|e| anyhow::anyhow!("read lock for '{name}': {e}"))?;
     let lock: LockFile = serde_json::from_slice(&bytes)
         .map_err(|e| anyhow::anyhow!("parse lock for '{name}': {e}"))?;
     let old_pid = lock.pid;
@@ -166,8 +164,7 @@ fn restart_one(name: &str, agents_dir: &PathBuf, on_disk_sha: &str) -> Result<()
     }
 
     // Wait for old pid to exit (timeout 30 s, 100 ms poll)
-    let term_deadline =
-        std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let term_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
     while std::time::Instant::now() < term_deadline {
         if !pid_alive(old_pid) {
             break;
@@ -186,17 +183,16 @@ fn restart_one(name: &str, agents_dir: &PathBuf, on_disk_sha: &str) -> Result<()
     // ── Poll for fresh running.lock with a different pid ──────────────
     // launchd KeepAlive=true respawns on process exit; we wait up to 30 s
     // for the new lock to appear.
-    let respawn_deadline =
-        std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let respawn_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
     let new_pid = loop {
         std::thread::sleep(std::time::Duration::from_millis(200));
         if std::time::Instant::now() >= respawn_deadline {
             break None;
         }
-        if let Ok(Some(new_lock)) = read_lock(&lock_path) {
-            if new_lock.pid != old_pid {
-                break Some((new_lock.pid, new_lock.build_sha));
-            }
+        if let Ok(Some(new_lock)) = read_lock(&lock_path)
+            && new_lock.pid != old_pid
+        {
+            break Some((new_lock.pid, new_lock.build_sha));
         }
     };
 
@@ -205,7 +201,11 @@ fn restart_one(name: &str, agents_dir: &PathBuf, on_disk_sha: &str) -> Result<()
             println!(
                 "agent '{name}' restarted ({} → {})",
                 short8(&old_sha),
-                short8(if new_sha.is_empty() { on_disk_sha } else { &new_sha }),
+                short8(if new_sha.is_empty() {
+                    on_disk_sha
+                } else {
+                    &new_sha
+                }),
             );
         }
         None => {
@@ -252,7 +252,12 @@ mod tests {
             ppid: 1,
             started_at: "2026-01-01T00:00:00Z".to_string(),
             binary_version: "0.0.0".to_string(),
-            transports: LockTransports { stdio: true, unix_socket: None, tcp: None, webhook: None },
+            transports: LockTransports {
+                stdio: true,
+                unix_socket: None,
+                tcp: None,
+                webhook: None,
+            },
             card_digest: "abc".to_string(),
             capabilities: vec![],
             build_sha: build_sha.to_string(),
@@ -301,9 +306,12 @@ mod tests {
         fs::create_dir_all(&beta_dir).unwrap();
         write_lock(&beta_dir.join("running.lock"), 2222, "cur000000000");
 
-        let result =
-            select_targets_with_on_disk(home, None, false, true, "cur000000000").unwrap();
-        assert_eq!(result, vec!["alpha"], "only the stale agent should be returned");
+        let result = select_targets_with_on_disk(home, None, false, true, "cur000000000").unwrap();
+        assert_eq!(
+            result,
+            vec!["alpha"],
+            "only the stale agent should be returned"
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -15,24 +15,32 @@ use super::{pid_alive, resolve_mur_home, stale};
 
 /// Return the names of running agents to restart.
 ///
-/// Selection rules:
+/// Selection rules (exactly one must be active):
 /// - `name = Some(_)` → that single agent (must have a running.lock)
 /// - `all = true` → all agents with a running.lock
 /// - `stale_only = true` → only running agents where `is_stale(lock, on_disk_sha())`
 ///
-/// Exactly one of the three cases is expected to be active; `stale_only`
-/// overrides `all` if both are true.
+/// If none of the three selectors is active an error is returned — bare
+/// `mur agent restart` (no args) must never silently restart everything.
 ///
 /// `home` is the MUR_HOME path (e.g. `~/.mur`). Testable with a temp dir.
 pub(crate) fn select_targets(
     home: &Path,
     name: Option<&str>,
-    // When true enumerate all running agents (the default when not stale_only).
-    // The parameter is present for call-site symmetry with the CLI args;
-    // the loop always enumerates running agents, so the value is logically
-    // used even when `stale_only` narrows the result further.
-    _all: bool,
+    all: bool,
     stale_only: bool,
+) -> Result<Vec<String>> {
+    select_targets_with_on_disk(home, name, all, stale_only, &stale::on_disk_sha())
+}
+
+/// Inner implementation that accepts the on-disk sha as a parameter so tests
+/// can inject a synthetic value without needing a real runtime binary.
+pub(crate) fn select_targets_with_on_disk(
+    home: &Path,
+    name: Option<&str>,
+    all: bool,
+    stale_only: bool,
+    on_disk: &str,
 ) -> Result<Vec<String>> {
     let agents_dir = home.join("agents");
 
@@ -44,16 +52,16 @@ pub(crate) fn select_targets(
         return Ok(vec![n.to_string()]);
     }
 
+    // Require an explicit selector — never enumerate implicitly.
+    if !all && !stale_only {
+        bail!("specify an agent name, --all, or --stale");
+    }
+
     // Enumerate all agents with a running.lock
     let mut targets: Vec<String> = Vec::new();
     if !agents_dir.exists() {
         return Ok(targets);
     }
-    let on_disk = if stale_only {
-        stale::on_disk_sha()
-    } else {
-        String::new()
-    };
 
     for entry in fs::read_dir(&agents_dir)? {
         let entry = entry?;
@@ -71,7 +79,7 @@ pub(crate) fn select_targets(
                 Ok(l) => l,
                 Err(_) => continue,
             };
-            if !stale::is_stale(&lock, &on_disk) {
+            if !stale::is_stale(&lock, on_disk) {
                 continue;
             }
         }
@@ -253,8 +261,30 @@ mod tests {
         fs::write(path, serde_json::to_vec(&lock).unwrap()).unwrap();
     }
 
-    /// `select_targets` with `stale_only=true` returns exactly the agent
-    /// whose `build_sha` differs from `on_disk`.
+    /// Fix 1: bare `mur agent restart` (no name, no --all, no --stale) must
+    /// return an error — never silently enumerate all running agents.
+    #[test]
+    fn select_targets_no_args_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let agents = home.join("agents");
+
+        // Even with a running agent present, no-args must bail.
+        let alpha_dir = agents.join("alpha");
+        fs::create_dir_all(&alpha_dir).unwrap();
+        write_lock(&alpha_dir.join("running.lock"), 1111, "somesha");
+
+        let result = select_targets_with_on_disk(home, None, false, false, "somesha");
+        assert!(result.is_err(), "bare restart with no selector must error");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("--all") || msg.contains("--stale"),
+            "error message should mention --all or --stale, got: {msg}"
+        );
+    }
+
+    /// Fix 2: `select_targets_with_on_disk` stale_only branch returns exactly
+    /// the agent whose build_sha differs from the injected on-disk sha.
     #[test]
     fn select_targets_stale_only_returns_stale_agent() {
         let tmp = tempfile::tempdir().unwrap();
@@ -264,43 +294,16 @@ mod tests {
         // Agent "alpha": stale sha
         let alpha_dir = agents.join("alpha");
         fs::create_dir_all(&alpha_dir).unwrap();
-        write_lock(&alpha_dir.join("running.lock"), 1111, "oldshaold");
+        write_lock(&alpha_dir.join("running.lock"), 1111, "oldsha000000");
 
-        // Agent "beta": up-to-date sha (matches "on_disk" we'll inject)
+        // Agent "beta": up-to-date sha (matches injected on_disk)
         let beta_dir = agents.join("beta");
         fs::create_dir_all(&beta_dir).unwrap();
-        write_lock(&beta_dir.join("running.lock"), 2222, "newsha123");
+        write_lock(&beta_dir.join("running.lock"), 2222, "cur000000000");
 
-        // Temporarily override the runtime path so on_disk_sha() returns "newsha123"
-        // We can't easily mock the binary, so we'll call select_targets with a
-        // manual on_disk override by using a helper that accepts it directly.
-        // Instead, test via the internal is_stale logic + a crafted known sha.
-        // We monkey-patch by testing `select_targets_with_on_disk` if available,
-        // or we can test `is_stale` + manual enumeration.
-        //
-        // Since select_targets calls stale::on_disk_sha() internally (which needs
-        // the real binary), we test the pure filtering path: enumerate locks
-        // and call is_stale manually to verify the logic works.
-        let on_disk = "newsha123";
-        let lock_alpha = {
-            let b = fs::read(alpha_dir.join("running.lock")).unwrap();
-            serde_json::from_slice::<LockFile>(&b).unwrap()
-        };
-        let lock_beta = {
-            let b = fs::read(beta_dir.join("running.lock")).unwrap();
-            serde_json::from_slice::<LockFile>(&b).unwrap()
-        };
-
-        assert!(stale::is_stale(&lock_alpha, on_disk), "alpha should be stale");
-        assert!(!stale::is_stale(&lock_beta, on_disk), "beta should not be stale");
-
-        // Also verify select_targets with stale_only=false (all running) picks both
-        // and select_targets with a specific name works.
-        let all_targets = select_targets(home, None, true, false).unwrap();
-        assert_eq!(all_targets, vec!["alpha", "beta"]);
-
-        let named = select_targets(home, Some("alpha"), false, false).unwrap();
-        assert_eq!(named, vec!["alpha"]);
+        let result =
+            select_targets_with_on_disk(home, None, false, true, "cur000000000").unwrap();
+        assert_eq!(result, vec!["alpha"], "only the stale agent should be returned");
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -18,8 +18,11 @@ use super::{pid_alive, resolve_mur_home, stale};
 /// drain bound so we never abort a turn mid-flight.
 const RESTART_KILL_GRACE_SECS: u64 = 5;
 
-/// Named constant for the wait to see the respawned lock (no SIGKILL risk here).
-const RESTART_RESPAWN_WAIT_SECS: u64 = 30;
+/// Wait to see the respawned lock (no SIGKILL risk here). Generous on purpose:
+/// real launchd respawn latency = the old process's shutdown + ExitTimeOut + any
+/// ThrottleInterval, observed at ~2 min after rapid restarts. A shorter wait
+/// false-warns "did not respawn" on a restart that actually succeeded.
+const RESTART_RESPAWN_WAIT_SECS: u64 = 120;
 
 /// Compute the total seconds to wait before firing the SIGKILL fallback.
 ///
@@ -247,8 +250,9 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<()> {
         }
         None => {
             eprintln!(
-                "warning: '{name}' was stopped but did not respawn within {RESTART_RESPAWN_WAIT_SECS} s \
-                 (is launchd KeepAlive enabled?)"
+                "note: '{name}' was stopped; its respawn was not seen within {RESTART_RESPAWN_WAIT_SECS} s — \
+                 launchd may still be bringing it up. Check 'mur agent runtime-doctor' shortly; \
+                 if it stays down, confirm launchd KeepAlive is enabled."
             );
         }
     }

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -9,9 +9,24 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::{Result, bail};
-use mur_common::LockFile;
+use mur_common::{AgentProfile as _AgentProfile, LockFile};
 
 use super::{pid_alive, resolve_mur_home, stale};
+
+/// Extra grace period added on top of the runtime's `stop_timeout_secs` before
+/// the SIGKILL fallback fires.  The SIGKILL wait MUST outlast the runtime's own
+/// drain bound so we never abort a turn mid-flight.
+const RESTART_KILL_GRACE_SECS: u64 = 5;
+
+/// Named constant for the wait to see the respawned lock (no SIGKILL risk here).
+const RESTART_RESPAWN_WAIT_SECS: u64 = 30;
+
+/// Compute the total seconds to wait before firing the SIGKILL fallback.
+///
+/// Pure helper so the math can be unit-tested independently of live processes.
+pub(crate) fn kill_wait_secs(stop_timeout_secs: u64) -> u64 {
+    stop_timeout_secs + RESTART_KILL_GRACE_SECS
+}
 
 /// Return the names of running agents to restart.
 ///
@@ -30,7 +45,14 @@ pub(crate) fn select_targets(
     all: bool,
     stale_only: bool,
 ) -> Result<Vec<String>> {
-    select_targets_with_on_disk(home, name, all, stale_only, &stale::on_disk_sha())
+    // Only invoke the subprocess that computes the on-disk sha when we actually
+    // need it for the stale filter; pass an empty placeholder otherwise.
+    let on_disk = if stale_only {
+        stale::on_disk_sha()
+    } else {
+        String::new()
+    };
+    select_targets_with_on_disk(home, name, all, stale_only, &on_disk)
 }
 
 /// Inner implementation that accepts the on-disk sha as a parameter so tests
@@ -157,14 +179,28 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<()> {
     let old_pid = lock.pid;
     let old_sha = lock.build_sha.clone();
 
+    // Load stop_timeout_secs from the agent's profile (mirrors cmd_stop).
+    // The SIGKILL fallback must wait at least this long so the runtime's
+    // cooperative drain can complete before we force-kill.
+    let stop_timeout = {
+        let pp = agent_home.join("profile.yaml");
+        fs::read_to_string(&pp)
+            .ok()
+            .and_then(|y| serde_yaml_ng::from_str::<_AgentProfile>(&y).ok())
+            .map(|p| p.lifecycle.stop_timeout_secs)
+            .unwrap_or(15)
+    };
+
     // ── SIGTERM (drain) ───────────────────────────────────────────────
     #[cfg(unix)]
     unsafe {
         libc::kill(old_pid as libc::pid_t, libc::SIGTERM);
     }
 
-    // Wait for old pid to exit (timeout 30 s, 100 ms poll)
-    let term_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    // Wait for the old pid to exit.  Timeout = stop_timeout_secs + RESTART_KILL_GRACE_SECS
+    // so the SIGKILL fallback never fires while the runtime is still draining.
+    let term_deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(kill_wait_secs(stop_timeout));
     while std::time::Instant::now() < term_deadline {
         if !pid_alive(old_pid) {
             break;
@@ -181,9 +217,10 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<()> {
     }
 
     // ── Poll for fresh running.lock with a different pid ──────────────
-    // launchd KeepAlive=true respawns on process exit; we wait up to 30 s
-    // for the new lock to appear.
-    let respawn_deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    // launchd KeepAlive=true respawns on process exit; we wait up to
+    // RESTART_RESPAWN_WAIT_SECS for the new lock to appear.
+    let respawn_deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(RESTART_RESPAWN_WAIT_SECS);
     let new_pid = loop {
         std::thread::sleep(std::time::Duration::from_millis(200));
         if std::time::Instant::now() >= respawn_deadline {
@@ -210,7 +247,7 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<()> {
         }
         None => {
             eprintln!(
-                "warning: '{name}' was stopped but did not respawn within 30 s \
+                "warning: '{name}' was stopped but did not respawn within {RESTART_RESPAWN_WAIT_SECS} s \
                  (is launchd KeepAlive enabled?)"
             );
         }
@@ -331,5 +368,21 @@ mod tests {
         fs::create_dir_all(home.join("agents")).unwrap();
         let result = select_targets(home, None, true, false).unwrap();
         assert!(result.is_empty());
+    }
+
+    /// Fix 1: SIGKILL-fallback wait must be derived from stop_timeout_secs so
+    /// it always outlasts the runtime's cooperative drain bound.
+    #[test]
+    fn kill_wait_secs_exceeds_stop_timeout() {
+        // Default: 15 s drain + 5 s grace = 20 s
+        assert_eq!(kill_wait_secs(15), 20);
+        // Raised: 60 s drain + 5 s grace = 65 s  (never truncated to 30)
+        assert_eq!(kill_wait_secs(60), 65);
+        // Grace is always exactly RESTART_KILL_GRACE_SECS
+        assert_eq!(kill_wait_secs(0), RESTART_KILL_GRACE_SECS);
+        // Result always strictly exceeds the drain bound
+        for t in [1u64, 15, 30, 60, 120] {
+            assert!(kill_wait_secs(t) > t, "kill wait must exceed drain bound");
+        }
     }
 }

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -1,0 +1,324 @@
+//! `mur agent restart` — graceful restart for upgraded runtime binaries.
+//!
+//! Mechanism: SIGTERM the running pid (Task 5 drains the in-flight turn),
+//! wait for exit, then poll for a fresh `running.lock` with a DIFFERENT pid
+//! (launchd `KeepAlive=true` respawns on exit). Lock is NOT pre-removed —
+//! launchd needs the process to exit, not the lock to disappear.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, bail};
+use mur_common::LockFile;
+
+use super::{pid_alive, resolve_mur_home, stale};
+
+/// Return the names of running agents to restart.
+///
+/// Selection rules:
+/// - `name = Some(_)` → that single agent (must have a running.lock)
+/// - `all = true` → all agents with a running.lock
+/// - `stale_only = true` → only running agents where `is_stale(lock, on_disk_sha())`
+///
+/// Exactly one of the three cases is expected to be active; `stale_only`
+/// overrides `all` if both are true.
+///
+/// `home` is the MUR_HOME path (e.g. `~/.mur`). Testable with a temp dir.
+pub(crate) fn select_targets(
+    home: &Path,
+    name: Option<&str>,
+    // When true enumerate all running agents (the default when not stale_only).
+    // The parameter is present for call-site symmetry with the CLI args;
+    // the loop always enumerates running agents, so the value is logically
+    // used even when `stale_only` narrows the result further.
+    _all: bool,
+    stale_only: bool,
+) -> Result<Vec<String>> {
+    let agents_dir = home.join("agents");
+
+    if let Some(n) = name {
+        let lock_path = agents_dir.join(n).join("running.lock");
+        if !lock_path.exists() {
+            bail!("agent '{n}' is not running");
+        }
+        return Ok(vec![n.to_string()]);
+    }
+
+    // Enumerate all agents with a running.lock
+    let mut targets: Vec<String> = Vec::new();
+    if !agents_dir.exists() {
+        return Ok(targets);
+    }
+    let on_disk = if stale_only {
+        stale::on_disk_sha()
+    } else {
+        String::new()
+    };
+
+    for entry in fs::read_dir(&agents_dir)? {
+        let entry = entry?;
+        let agent_name = entry.file_name().to_string_lossy().to_string();
+        let lock_path = entry.path().join("running.lock");
+        if !lock_path.exists() {
+            continue;
+        }
+        if stale_only {
+            let bytes = match fs::read(&lock_path) {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+            let lock: LockFile = match serde_json::from_slice(&bytes) {
+                Ok(l) => l,
+                Err(_) => continue,
+            };
+            if !stale::is_stale(&lock, &on_disk) {
+                continue;
+            }
+        }
+        targets.push(agent_name);
+    }
+    targets.sort();
+    Ok(targets)
+}
+
+/// Gracefully restart one or more agents.
+///
+/// - `name` / `all` / `stale`: select targets (mirror `cmd_stop`).
+/// - `dry_run`: print targets and return without acting.
+pub fn cmd_restart(
+    name: Option<&str>,
+    all: bool,
+    stale: bool,
+    dry_run: bool,
+) -> Result<()> {
+    let mur_home = resolve_mur_home()?;
+    let agents_dir = mur_home.join("agents");
+
+    let targets = select_targets(&mur_home, name, all, stale)?;
+
+    if targets.is_empty() {
+        println!("No agents to restart.");
+        return Ok(());
+    }
+
+    if dry_run {
+        let on_disk = if stale { stale::on_disk_sha() } else { String::new() };
+        for t in &targets {
+            if stale {
+                let lock_path = agents_dir.join(t).join("running.lock");
+                let old_sha = read_build_sha(&lock_path).unwrap_or_else(|| "(unknown)".to_string());
+                println!(
+                    "[dry-run] would restart '{t}' (running={}, on-disk={})",
+                    short8(&old_sha),
+                    short8(&on_disk)
+                );
+            } else {
+                println!("[dry-run] would restart '{t}'");
+            }
+        }
+        return Ok(());
+    }
+
+    let on_disk = stale::on_disk_sha();
+    let mut any_err = false;
+
+    for agent_name in &targets {
+        if let Err(e) = restart_one(agent_name, &agents_dir, &on_disk) {
+            eprintln!("error restarting '{agent_name}': {e}");
+            any_err = true;
+        }
+    }
+
+    if any_err {
+        bail!("one or more agents failed to restart");
+    }
+    Ok(())
+}
+
+/// Restart a single agent: SIGTERM, wait for exit, poll for fresh lock.
+fn restart_one(name: &str, agents_dir: &PathBuf, on_disk_sha: &str) -> Result<()> {
+    let agent_home = agents_dir.join(name);
+    let lock_path = agent_home.join("running.lock");
+
+    if !lock_path.exists() {
+        bail!("agent '{name}' is not running");
+    }
+
+    let bytes = fs::read(&lock_path)
+        .map_err(|e| anyhow::anyhow!("read lock for '{name}': {e}"))?;
+    let lock: LockFile = serde_json::from_slice(&bytes)
+        .map_err(|e| anyhow::anyhow!("parse lock for '{name}': {e}"))?;
+    let old_pid = lock.pid;
+    let old_sha = lock.build_sha.clone();
+
+    // ── SIGTERM (drain) ───────────────────────────────────────────────
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(old_pid as libc::pid_t, libc::SIGTERM);
+    }
+
+    // Wait for old pid to exit (timeout 30 s, 100 ms poll)
+    let term_deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(30);
+    while std::time::Instant::now() < term_deadline {
+        if !pid_alive(old_pid) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    // Fallback SIGKILL if drain timed out (mirrors cmd_stop)
+    if pid_alive(old_pid) {
+        #[cfg(unix)]
+        unsafe {
+            libc::kill(old_pid as libc::pid_t, libc::SIGKILL);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+
+    // ── Poll for fresh running.lock with a different pid ──────────────
+    // launchd KeepAlive=true respawns on process exit; we wait up to 30 s
+    // for the new lock to appear.
+    let respawn_deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let new_pid = loop {
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        if std::time::Instant::now() >= respawn_deadline {
+            break None;
+        }
+        if let Ok(Some(new_lock)) = read_lock(&lock_path) {
+            if new_lock.pid != old_pid {
+                break Some((new_lock.pid, new_lock.build_sha));
+            }
+        }
+    };
+
+    match new_pid {
+        Some((_pid, new_sha)) => {
+            println!(
+                "agent '{name}' restarted ({} → {})",
+                short8(&old_sha),
+                short8(if new_sha.is_empty() { on_disk_sha } else { &new_sha }),
+            );
+        }
+        None => {
+            eprintln!(
+                "warning: '{name}' was stopped but did not respawn within 30 s \
+                 (is launchd KeepAlive enabled?)"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+fn read_lock(path: &Path) -> std::io::Result<Option<LockFile>> {
+    mur_common::lock_file::read(path)
+}
+
+fn read_build_sha(lock_path: &Path) -> Option<String> {
+    let bytes = fs::read(lock_path).ok()?;
+    let lock: LockFile = serde_json::from_slice(&bytes).ok()?;
+    Some(lock.build_sha)
+}
+
+/// First 8 chars of a sha, or the whole string if shorter.
+fn short8(s: &str) -> &str {
+    let end = s.char_indices().nth(8).map(|(i, _)| i).unwrap_or(s.len());
+    &s[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::{LockFile, agent::LockTransports};
+    use std::fs;
+
+    fn write_lock(path: &Path, pid: u32, build_sha: &str) {
+        let lock = LockFile {
+            schema: 1,
+            uuid: "test-uuid".to_string(),
+            name: "test-agent".to_string(),
+            pid,
+            ppid: 1,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            binary_version: "0.0.0".to_string(),
+            transports: LockTransports { stdio: true, unix_socket: None, tcp: None, webhook: None },
+            card_digest: "abc".to_string(),
+            capabilities: vec![],
+            build_sha: build_sha.to_string(),
+            proto_version: 1,
+        };
+        fs::write(path, serde_json::to_vec(&lock).unwrap()).unwrap();
+    }
+
+    /// `select_targets` with `stale_only=true` returns exactly the agent
+    /// whose `build_sha` differs from `on_disk`.
+    #[test]
+    fn select_targets_stale_only_returns_stale_agent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let agents = home.join("agents");
+
+        // Agent "alpha": stale sha
+        let alpha_dir = agents.join("alpha");
+        fs::create_dir_all(&alpha_dir).unwrap();
+        write_lock(&alpha_dir.join("running.lock"), 1111, "oldshaold");
+
+        // Agent "beta": up-to-date sha (matches "on_disk" we'll inject)
+        let beta_dir = agents.join("beta");
+        fs::create_dir_all(&beta_dir).unwrap();
+        write_lock(&beta_dir.join("running.lock"), 2222, "newsha123");
+
+        // Temporarily override the runtime path so on_disk_sha() returns "newsha123"
+        // We can't easily mock the binary, so we'll call select_targets with a
+        // manual on_disk override by using a helper that accepts it directly.
+        // Instead, test via the internal is_stale logic + a crafted known sha.
+        // We monkey-patch by testing `select_targets_with_on_disk` if available,
+        // or we can test `is_stale` + manual enumeration.
+        //
+        // Since select_targets calls stale::on_disk_sha() internally (which needs
+        // the real binary), we test the pure filtering path: enumerate locks
+        // and call is_stale manually to verify the logic works.
+        let on_disk = "newsha123";
+        let lock_alpha = {
+            let b = fs::read(alpha_dir.join("running.lock")).unwrap();
+            serde_json::from_slice::<LockFile>(&b).unwrap()
+        };
+        let lock_beta = {
+            let b = fs::read(beta_dir.join("running.lock")).unwrap();
+            serde_json::from_slice::<LockFile>(&b).unwrap()
+        };
+
+        assert!(stale::is_stale(&lock_alpha, on_disk), "alpha should be stale");
+        assert!(!stale::is_stale(&lock_beta, on_disk), "beta should not be stale");
+
+        // Also verify select_targets with stale_only=false (all running) picks both
+        // and select_targets with a specific name works.
+        let all_targets = select_targets(home, None, true, false).unwrap();
+        assert_eq!(all_targets, vec!["alpha", "beta"]);
+
+        let named = select_targets(home, Some("alpha"), false, false).unwrap();
+        assert_eq!(named, vec!["alpha"]);
+    }
+
+    #[test]
+    fn select_targets_named_not_running_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        fs::create_dir_all(home.join("agents").join("ghost")).unwrap();
+        // No running.lock
+        let result = select_targets(home, Some("ghost"), false, false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn select_targets_empty_agents_dir_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        fs::create_dir_all(home.join("agents")).unwrap();
+        let result = select_targets(home, None, true, false).unwrap();
+        assert!(result.is_empty());
+    }
+}

--- a/mur-core/src/cmd/agent/stale.rs
+++ b/mur-core/src/cmd/agent/stale.rs
@@ -1,0 +1,100 @@
+//! Shared staleness helpers — used by `mur agent restart` (Task 6)
+//! and `mur agent doctor` (Task 7).
+//!
+//! A running agent is "stale" when the binary on disk has a different
+//! `--build-id` than the sha recorded in its `running.lock`.
+
+use std::process::Command;
+
+use mur_common::LockFile;
+
+use super::resolve_runtime_target;
+
+/// Run `<runtime> --build-id` and return the trimmed stdout, or `"unknown"`
+/// if the binary is missing / the sub-command fails.
+pub fn on_disk_sha() -> String {
+    let runtime = resolve_runtime_target();
+    let out = Command::new(&runtime).arg("--build-id").output();
+    match out {
+        Ok(o) if o.status.success() => {
+            let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            if s.is_empty() { "unknown".to_string() } else { s }
+        }
+        _ => "unknown".to_string(),
+    }
+}
+
+/// Return `true` when the agent whose lock is `lock` is running a stale binary.
+///
+/// Rules:
+/// - Different non-empty, non-unknown shas → stale.
+/// - Both `"unknown"` → NOT stale (we can't tell, assume equal).
+/// - Empty `build_sha` in lock (old pre-feature lock) AND on-disk sha is known → stale.
+/// - Same sha → NOT stale.
+pub fn is_stale(lock: &LockFile, on_disk: &str) -> bool {
+    let running = lock.build_sha.as_str();
+    match (running, on_disk) {
+        // Both unknown → treat as equal (no information)
+        ("unknown", "unknown") => false,
+        // Empty running sha (old lock) + known on-disk → stale
+        ("", od) if od != "unknown" => true,
+        // Empty running sha + on-disk also unknown → can't tell, not stale
+        ("", _) => false,
+        // Same sha → not stale
+        (r, od) if r == od => false,
+        // Different shas → stale
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::LockFile;
+
+    fn make_lock(build_sha: &str) -> LockFile {
+        LockFile {
+            schema: 1,
+            uuid: "test-uuid".to_string(),
+            name: "test-agent".to_string(),
+            pid: 12345,
+            ppid: 1,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            binary_version: "1.0.0".to_string(),
+            transports: mur_common::agent::LockTransports {
+                stdio: true,
+                unix_socket: None,
+                tcp: None,
+                webhook: None,
+            },
+            card_digest: "abc".to_string(),
+            capabilities: vec![],
+            build_sha: build_sha.to_string(),
+            proto_version: 1,
+        }
+    }
+
+    #[test]
+    fn is_stale_different_shas_is_true() {
+        let lock = make_lock("abc123def456");
+        assert!(is_stale(&lock, "999999999999"));
+    }
+
+    #[test]
+    fn is_stale_same_sha_is_false() {
+        let lock = make_lock("abc123def456");
+        assert!(!is_stale(&lock, "abc123def456"));
+    }
+
+    #[test]
+    fn is_stale_two_unknowns_is_false() {
+        let lock = make_lock("unknown");
+        assert!(!is_stale(&lock, "unknown"));
+    }
+
+    #[test]
+    fn is_stale_empty_lock_sha_with_known_on_disk_is_true() {
+        let lock = make_lock("");
+        assert!(is_stale(&lock, "abc123def456"));
+    }
+}

--- a/mur-core/src/cmd/agent/stale.rs
+++ b/mur-core/src/cmd/agent/stale.rs
@@ -18,7 +18,11 @@ pub fn on_disk_sha() -> String {
     match out {
         Ok(o) if o.status.success() => {
             let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
-            if s.is_empty() { "unknown".to_string() } else { s }
+            if s.is_empty() {
+                "unknown".to_string()
+            } else {
+                s
+            }
         }
         _ => "unknown".to_string(),
     }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1218,6 +1218,9 @@ async fn run_agent(action: AgentAction) -> Result<()> {
         AgentAction::List { json } => cmd::agent::cmd_list(json)?,
         AgentAction::Status { name } => cmd::agent::cmd_status(&name)?,
         AgentAction::Stop { name } => cmd::agent::cmd_stop(&name)?,
+        AgentAction::Restart { name, all, stale, dry_run } => {
+            cmd::agent::cmd_restart(name.as_deref(), all, stale, dry_run)?
+        }
         AgentAction::Remove { name, purge, force } => cmd::agent::cmd_remove(&name, purge, force)?,
         AgentAction::Rename { old, new } => cmd::agent::cmd_rename(&old, &new)?,
         AgentAction::Send { name, message } => cmd::agent::cmd_send(&name, &message)?,

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1402,6 +1402,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
         AgentAction::Logs { name, tail } => cmd::agent::cmd_logs(&name, tail)?,
         AgentAction::Companion(args) => cmd::agent_companion::run(args).await?,
         AgentAction::Doctor { format, json } => cmd::doctor::run(&format, json)?,
+        AgentAction::RuntimeDoctor { json } => cmd::agent::cmd_doctor(json)?,
         AgentAction::Secret { agent, action } => match action {
             AgentSecretAction::Set { key, value } => {
                 cmd::agent::cmd_secret_set(&agent, &key, value.as_deref()).await?

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1218,9 +1218,12 @@ async fn run_agent(action: AgentAction) -> Result<()> {
         AgentAction::List { json } => cmd::agent::cmd_list(json)?,
         AgentAction::Status { name } => cmd::agent::cmd_status(&name)?,
         AgentAction::Stop { name } => cmd::agent::cmd_stop(&name)?,
-        AgentAction::Restart { name, all, stale, dry_run } => {
-            cmd::agent::cmd_restart(name.as_deref(), all, stale, dry_run)?
-        }
+        AgentAction::Restart {
+            name,
+            all,
+            stale,
+            dry_run,
+        } => cmd::agent::cmd_restart(name.as_deref(), all, stale, dry_run)?,
         AgentAction::Remove { name, purge, force } => cmd::agent::cmd_remove(&name, purge, force)?,
         AgentAction::Rename { old, new } => cmd::agent::cmd_rename(&old, &new)?,
         AgentAction::Send { name, message } => cmd::agent::cmd_send(&name, &message)?,

--- a/mur-core/src/server_agents/list.rs
+++ b/mur-core/src/server_agents/list.rs
@@ -101,6 +101,8 @@ pub(crate) mod tests {
             },
             card_digest: "sha256:abc123".to_string(),
             capabilities: vec!["a2a.message.send".to_string()],
+            build_sha: String::new(),
+            proto_version: 0,
         }
     }
 

--- a/mur-core/tests/agent_lifecycle.rs
+++ b/mur-core/tests/agent_lifecycle.rs
@@ -45,6 +45,8 @@ fn write_lock_with_pid(mur_home: &std::path::Path, name: &str, pid: u32) {
         },
         card_digest: "sha256:x".into(),
         capabilities: vec![],
+        build_sha: String::new(),
+        proto_version: 0,
     };
     std::fs::write(path, serde_json::to_vec_pretty(&lock).unwrap()).unwrap();
 }

--- a/mur-core/tests/agent_list_status.rs
+++ b/mur-core/tests/agent_list_status.rs
@@ -40,6 +40,8 @@ fn write_running_lock(mur_home: &std::path::Path, name: &str, pid: u32) {
         },
         card_digest: "sha256:test".into(),
         capabilities: vec!["a2a.message.send".into()],
+        build_sha: String::new(),
+        proto_version: 0,
     };
     let bytes = serde_json::to_vec_pretty(&lock).unwrap();
     std::fs::write(agent_home.join("running.lock"), bytes).unwrap();

--- a/mur-core/tests/agent_send.rs
+++ b/mur-core/tests/agent_send.rs
@@ -42,6 +42,8 @@ fn write_running_lock(mur_home: &Path, name: &str, sock: &str) {
         },
         card_digest: "sha256:mock".into(),
         capabilities: vec!["a2a.message.send".into()],
+        build_sha: String::new(),
+        proto_version: 0,
     };
     std::fs::write(lock_path, serde_json::to_vec_pretty(&lock).unwrap()).unwrap();
 }


### PR DESCRIPTION
## Problem

Per-agent runtimes run as long-lived launchd processes (`KeepAlive=true`). A `mur-agent-runtime` upgrade lands **on disk**, but a running agent keeps executing its **old** binary until restarted — so it drifts onto a stale runtime. This bit us live: a running agent missed a merged sandbox/DNS fix, and a fresh client dialing `channel/delegate` against an old runtime got an **opaque `-32601`** surfaced as a generic "agent returned error".

"Auto-restart everything on upgrade" is the wrong fix — it silently kills in-flight agent turns. Mature tools (`needrestart`, systemd) **detect + notify; restart deliberately; auto-restart only opt-in.** This implements that.

## What

- **Build identity + proto version** (`mur-common`): `build.rs` embeds a git sha (`SHORT_SHA`); `A2A_PROTO_VERSION` + a `method_min_proto` gate table. Both carried in `running.lock` (`#[serde(default)]` — old locks still parse) + the AgentCard. `mur-agent-runtime --build-id`.
- **① Dial version-gate** (`a2a_dial`): pre-flight check — a versioned method (`channel/delegate`) against a running peer whose advertised proto is too low is refused with **`agent X is running a stale runtime … run 'mur agent restart X'`** instead of `-32601`. Fires before any connect; fail-**open** on an unreadable lock; ungated methods (`message/send`) unaffected.
- **③ Graceful drain** (`task_runner` + `supervisor`): on SIGTERM the runtime stops accepting new turns and **awaits the in-flight turn** (bounded by `stop_timeout_secs`) before teardown — closing the `supervisor.rs:655` "active-task cancellation is future work" TODO. Never SIGKILL-first, never abort mid-turn.
- **`mur agent restart <name>|--stale|--all [--dry-run]`** — graceful (SIGTERM-drain → launchd respawns on the fresh binary; SIGKILL fallback scales with `stop_timeout_secs`). Requires an explicit target — no implicit mass-restart.
- **② Notify (print-only)** — `mur agent runtime-doctor [--json]` flags stale runtimes (build-sha compare); a `status` marker; a post-build nudge in `build.sh`. Never acts.
- **Out of scope (deferred):** ④ auto-restart (`MUR_AGENT_AUTORESTART`), in-place re-exec/hot-state, multi-version negotiation.

Spec: `docs/superpowers/specs/2026-06-24-agent-runtime-upgrade-restart-design.md` · Plan: `docs/superpowers/plans/2026-06-24-agent-runtime-upgrade-restart.md`

## ⚠️ One-time cutover (intended)

Every runtime predating this feature writes no `proto_version` (reads as 0) → is gated for `channel/delegate` until restarted, *including* ones that registered the method (they're stale by definition). So after this ships, run **`mur agent restart --stale`** once to get existing agents onto a proto-1 runtime, or `channel/delegate`/`parallel_jobs`/fleet-delegation return the actionable "restart" error until you do. `message/send` and other ungated comms work through the cutover.

## How it was built

Research (needrestart / A2A version-negotiation / SIGTERM graceful-shutdown / Debian/Fedora/Edge restart policy) → brainstorm → spec → plan → subagent-driven (9 tasks, fresh implementer + two-verdict review each) → **whole-branch adversarial review on the most-capable model** (0 Critical; the 6 cross-cutting seams — fail-open gate, closed drain race, no mid-turn abort, serde migration, explicit-target restart, print-only nudge — all verified) → 3 fixes (the notable one: the restart SIGKILL-fallback now scales with `stop_timeout_secs` so it can't SIGKILL a still-draining runtime under a raised timeout, with a regression test).

## Tests

`mur-common` 764/764 · `mur-core a2a_dial` 8/8 (incl. the 2 gate tests) · `mur-agent-runtime task_runner` 25/25 (drain) · agent-cmd 26/26 (is_stale, select_targets, build_row, kill-wait). `cargo fmt --check` + `cargo clippy -p mur-common -p mur-core -p mur-agent-runtime -- -D warnings` clean. (The 4 `summarize::rollup` failures are pre-existing date-spurious flakes, unrelated.)

## Operator-pending

Live E2E (drain a real running turn, confirm launchd respawn flips `runtime-doctor` `stale→current`, confirm a previously-`-32601` delegate dial now succeeds) — can't be done from the diff; needs running runtimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
