### PR TITLE
fix(hub): re-check for updates on window focus, not just mount

### DIFF
--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -416,17 +416,24 @@ export function DashboardApp() {
 
   useEffect(() => {
     let cancelled = false;
-    import("@tauri-apps/plugin-updater")
-      .then(({ check }) => check())
-      .then((u) => {
-        if (u && !cancelled) {
-          updateRef.current = u;
-          setAppUpdate({ version: u.version });
-        }
-      })
-      .catch((e) => console.warn("Update check failed:", e));
+    // Check on mount, and again whenever the window regains focus — a Hub left
+    // open for days would otherwise never notice a release published meanwhile.
+    // ponytail: focus-only, no timer; add an interval if it must notice while focused for hours.
+    const runCheck = () =>
+      import("@tauri-apps/plugin-updater")
+        .then(({ check }) => check())
+        .then((u) => {
+          if (u && !cancelled) {
+            updateRef.current = u;
+            setAppUpdate({ version: u.version });
+          }
+        })
+        .catch((e) => console.warn("Update check failed:", e));
+    runCheck();
+    window.addEventListener("focus", runCheck);
     return () => {
       cancelled = true;
+      window.removeEventListener("focus", runCheck);
     };
   }, []);
 


### PR DESCRIPTION
## Problem

The Hub's auto-update check ran **once, on mount** (`DashboardApp.tsx`, `useEffect(…, [])` — no polling, no re-check on focus). A Hub instance left open never notices a release published after it launched.

Concretely: a **2.26.9** instance open before **v2.27.0** went live checked once, saw nothing newer, and never looked again — so no update banner, even though `latest.json` correctly advertised `2.27.0`. (`brew upgrade mur` only updates the CLI; the Hub `.app` is a separate Tauri bundle that self-updates.)

## Fix

Re-run the same check whenever the window regains focus — the common case (user comes back to the app). Listener is cleaned up on unmount.

- skipped: a polling timer. `focus` covers coming back to the app; add an interval only if it must notice while the window stays focused for hours.

## Test

`tsc --noEmit` clean. Manual: open Hub on an older version, publish a newer `latest.json`, switch away and back → banner appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)