### PR TITLE
feat(pet): desktop pet chat escalation — Phase 1 (fix double-jump + cramped CJK bubble)

### DIFF
--- a/docs/superpowers/plans/2026-06-25-pet-chat-escalation-phase1.md
+++ b/docs/superpowers/plans/2026-06-25-pet-chat-escalation-phase1.md
@@ -1,0 +1,666 @@
+# Pet Chat Escalation — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the two reported desktop-pet bugs (cramped CJK file-summary bubble; double-jump of Hub + chat on click) and build the glance→panel→full escalation skeleton.
+
+**Architecture:** The pet OS window grows so the bubble is no longer clipped and gets CJK-correct typography; the existing per-agent `chat-{agent}` window becomes the "compact panel" — positioned next to the pet via a pure geometry function, raised above the always-on-top pet, and shown without stealing focus. Single-click opens it; a header button expands it to full size. Spec: `docs/superpowers/specs/2026-06-25-mur-pet-chat-escalation-redesign.md`.
+
+**Tech Stack:** Rust + Tauri 2 (`mur-hub-gui/src-tauri`), React 18 + TypeScript + Vite (`mur-hub-gui/ui`). `mur-hub-gui` is workspace-EXCLUDED — build/test it via its own manifest.
+
+## Global Constraints
+
+- Brand name in any user-visible string is uppercase **MUR**; internal `name`/labels stay lowercase. (Not expected to appear in this phase.)
+- No hardcoded magic values without a named const.
+- `mur-hub-gui` is workspace-excluded: every cargo command uses `--manifest-path mur-hub-gui/src-tauri/Cargo.toml`.
+- The Tauri binary's `generate_context!` needs `mur-hub-gui/ui/dist/index.html` to exist or cargo compile fails. Before any cargo command, ensure it exists (a stub is fine for backend-only checks; do NOT commit the stub — it isn't gitignored). Per `mem:gotcha_hub_clippy_needs_ui_dist`.
+- Frontend type/build check: `cd mur-hub-gui/ui && npm run build`.
+- Coordinate space: all window-placement math is in **physical pixels** (monitor `.position()`/`.size()` are physical). Set positions with `tauri::PhysicalPosition`, never the builder's logical `.position(f64,f64)`, to stay consistent on Retina + external displays.
+- Reply language for prose to the user is zh-TW; code/comments/commits in English (`mem:feedback_language_chinese`).
+
+---
+
+### Task 1: Pure window-placement geometry (`geometry.rs`)
+
+A standalone module with **no Tauri types** so it unit-tests without the GUI stack. This is the only non-trivial logic in the phase and gets real TDD.
+
+**Files:**
+- Create: `mur-hub-gui/src-tauri/src/geometry.rs`
+- Modify: `mur-hub-gui/src-tauri/src/lib.rs` (add `mod geometry;` near the other `mod` declarations, ~top of file)
+- Test: inline `#[cfg(test)]` in `geometry.rs`
+
+**Interfaces:**
+- Produces:
+  - `pub struct Rect { pub x: i32, pub y: i32, pub w: i32, pub h: i32 }` with `pub fn right(&self)->i32`, `pub fn bottom(&self)->i32`
+  - `pub fn anchor_panel(pet: Rect, panel: (i32,i32), mon: Rect) -> (i32,i32)`
+  - `pub fn clamp_into(pos: (i32,i32), size: (i32,i32), mon: Rect) -> (i32,i32)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `mur-hub-gui/src-tauri/src/geometry.rs`:
+
+```rust
+//! Pure window-placement geometry for the desktop pet and its chat panel.
+//! Deliberately free of Tauri types so it unit-tests without the GUI stack.
+
+/// A screen rectangle in PHYSICAL pixels, origin top-left.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub w: i32,
+    pub h: i32,
+}
+
+impl Rect {
+    pub fn right(&self) -> i32 {
+        self.x + self.w
+    }
+    pub fn bottom(&self) -> i32 {
+        self.y + self.h
+    }
+}
+
+/// Horizontal gap between the pet and its panel, physical px.
+const PANEL_GAP: i32 = 8;
+
+/// Place a `panel`-sized window adjacent to `pet`, preferring the LEFT side.
+/// Flips to the right of the pet if the left placement would start before the
+/// monitor's left edge. The result is always clamped fully inside `mon`.
+pub fn anchor_panel(pet: Rect, panel: (i32, i32), mon: Rect) -> (i32, i32) {
+    let (pw, ph) = panel;
+    let left_x = pet.x - PANEL_GAP - pw;
+    let right_x = pet.right() + PANEL_GAP;
+    let x = if left_x >= mon.x { left_x } else { right_x };
+    // Align the panel's top with the pet's top, then clamp.
+    clamp_into((x, pet.y), (pw, ph), mon)
+}
+
+/// Clamp a window of `size` at `pos` so it stays fully inside `mon`.
+/// If the window is larger than the monitor, it pins to the monitor origin.
+pub fn clamp_into(pos: (i32, i32), size: (i32, i32), mon: Rect) -> (i32, i32) {
+    let (w, h) = size;
+    let max_x = (mon.right() - w).max(mon.x);
+    let max_y = (mon.bottom() - h).max(mon.y);
+    (pos.0.clamp(mon.x, max_x), pos.1.clamp(mon.y, max_y))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MON: Rect = Rect { x: 0, y: 0, w: 1440, h: 900 };
+
+    #[test]
+    fn anchors_to_left_of_pet_when_room() {
+        // pet at x=800; panel 380 wide fits to the left.
+        let pet = Rect { x: 800, y: 100, w: 300, h: 260 };
+        let (x, y) = anchor_panel(pet, (380, 520), MON);
+        assert_eq!(x, 800 - 8 - 380); // 412
+        assert_eq!(y, 100);
+    }
+
+    #[test]
+    fn flips_right_when_pet_near_left_edge() {
+        // pet hugging the left edge: no room on the left, open to the right.
+        let pet = Rect { x: 10, y: 100, w: 300, h: 260 };
+        let (x, _) = anchor_panel(pet, (380, 520), MON);
+        assert_eq!(x, 10 + 300 + 8); // 318
+    }
+
+    #[test]
+    fn clamps_y_so_panel_bottom_stays_on_screen() {
+        // pet low on screen: panel top would push the 520-tall panel off bottom.
+        let pet = Rect { x: 800, y: 700, w: 300, h: 260 };
+        let (_, y) = anchor_panel(pet, (380, 520), MON);
+        assert_eq!(y, 900 - 520); // 380
+    }
+
+    #[test]
+    fn clamp_pulls_offscreen_window_in() {
+        // bottom-right overflow.
+        assert_eq!(clamp_into((1400, 880), (300, 260), MON), (1140, 640));
+        // negative origin.
+        assert_eq!(clamp_into((-50, -30), (300, 260), MON), (0, 0));
+        // already in-bounds is unchanged.
+        assert_eq!(clamp_into((100, 100), (300, 260), MON), (100, 100));
+    }
+
+    #[test]
+    fn window_larger_than_monitor_pins_to_origin() {
+        let tiny = Rect { x: 0, y: 0, w: 200, h: 150 };
+        assert_eq!(clamp_into((50, 50), (300, 260), tiny), (0, 0));
+    }
+}
+```
+
+- [ ] **Step 2: Add the module declaration**
+
+In `mur-hub-gui/src-tauri/src/lib.rs`, add alongside the existing top-level `mod` lines (e.g. next to `mod chat_window;` / `mod pet;`):
+
+```rust
+mod geometry;
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Ensure the dist stub exists first, then test only this module:
+
+```bash
+[ -f mur-hub-gui/ui/dist/index.html ] || { mkdir -p mur-hub-gui/ui/dist && echo '<!doctype html><title>stub</title>' > mur-hub-gui/ui/dist/index.html; }
+cargo test --manifest-path mur-hub-gui/src-tauri/Cargo.toml geometry:: -- --nocapture
+```
+
+Expected: 5 tests pass (`anchors_to_left_of_pet_when_room`, `flips_right_when_pet_near_left_edge`, `clamps_y_so_panel_bottom_stays_on_screen`, `clamp_pulls_offscreen_window_in`, `window_larger_than_monitor_pins_to_origin`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-hub-gui/src-tauri/src/geometry.rs mur-hub-gui/src-tauri/src/lib.rs
+git commit -m "feat(pet): pure window-placement geometry (anchor + clamp)"
+```
+
+---
+
+### Task 2: Monitor-rect helper + clamp the pet on spawn
+
+Use Task 1's `clamp_into` so a corner drop can't push the (now larger) pet off-screen.
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/pet/mod.rs:165-183` (the `pos` block + `WebviewWindowBuilder`)
+
+**Interfaces:**
+- Consumes: `geometry::{Rect, clamp_into}` from Task 1.
+- Produces: `fn monitor_rect_for_point(app: &AppHandle, x: i32, y: i32) -> geometry::Rect` (file-private in `pet/mod.rs`), reused by Task 3.
+
+- [ ] **Step 1: Add the monitor helper**
+
+In `mur-hub-gui/src-tauri/src/pet/mod.rs`, add near the other file-private helpers (after `mur_home`, ~line 42). Uses `available_monitors` (physical coords) with a primary fallback, so it doesn't depend on `monitor_from_point` availability:
+
+```rust
+use crate::geometry;
+
+/// Physical-pixel rect of the monitor containing `(x, y)`, falling back to the
+/// primary monitor, then to a 1440x900 origin rect if no monitor is reported.
+fn monitor_rect_for_point(app: &AppHandle, x: i32, y: i32) -> geometry::Rect {
+    let to_rect = |m: &tauri::Monitor| {
+        let p = m.position();
+        let s = m.size();
+        geometry::Rect { x: p.x, y: p.y, w: s.width as i32, h: s.height as i32 }
+    };
+    if let Ok(mons) = app.available_monitors() {
+        if let Some(m) = mons.iter().find(|m| {
+            let r = to_rect(m);
+            x >= r.x && x < r.right() && y >= r.y && y < r.bottom()
+        }) {
+            return to_rect(m);
+        }
+    }
+    if let Ok(Some(m)) = app.primary_monitor() {
+        return to_rect(&m);
+    }
+    geometry::Rect { x: 0, y: 0, w: 1440, h: 900 }
+}
+```
+
+> `// ponytail: available_monitors + contains-check instead of monitor_from_point — fewer API assumptions, same result.`
+
+- [ ] **Step 2: Clamp the spawn position and set it physically**
+
+Replace the `pos`/builder position handling at `pet/mod.rs:165-183`. New pet size is `300x260` (Task 6 also changes `inner_size`). The clamp must use the SAME size as `inner_size`. Define a const and reuse:
+
+```rust
+const PET_W: i32 = 300;
+const PET_H: i32 = 260;
+```
+(place near the top-of-file consts, e.g. above `PET_DROP_MAX_FILES`)
+
+Then, in `pet_spawn_at`, replace the `pos` struct + builder `.inner_size(200.0,200.0).position(pos.x, pos.y)` usage with a clamped physical position:
+
+```rust
+let mon = monitor_rect_for_point(&app, screen_x as i32, screen_y as i32);
+let (cx, cy) = geometry::clamp_into((screen_x as i32, screen_y as i32), (PET_W, PET_H), mon);
+
+let url_path = format!("index.html#/pet/{}", urlenc(&agent_name));
+
+let win = WebviewWindowBuilder::new(&app, &label, WebviewUrl::App(url_path.into()))
+    .transparent(true)
+    .decorations(false)
+    .always_on_top(true)
+    .skip_taskbar(true)
+    .visible_on_all_workspaces(true)
+    .shadow(false)
+    .inner_size(PET_W as f64, PET_H as f64)
+    .visible(false) // Task 6: avoid the opaque-square entrance flash
+    .build()
+    .map_err(|e| e.to_string())?;
+let _ = win.set_position(tauri::PhysicalPosition::new(cx, cy));
+let _ = win.show();
+```
+
+(Delete the now-unused `PetPosition { ... }` `pos` binding here; the struct itself is removed in a later phase, leave it defined for now to avoid touching `pet_reposition`.)
+
+- [ ] **Step 3: Build to verify it compiles**
+
+```bash
+cargo build --manifest-path mur-hub-gui/src-tauri/Cargo.toml --bin mur-hub
+```
+(If the bin name differs, use `cargo build --manifest-path mur-hub-gui/src-tauri/Cargo.toml` to build all targets.)
+Expected: compiles clean (warnings about unused `PetPosition` field are acceptable this phase).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-hub-gui/src-tauri/src/pet/mod.rs
+git commit -m "feat(pet): clamp pet spawn into its monitor; physical positioning"
+```
+
+---
+
+### Task 3: Anchor the chat panel to the pet + raise it + don't steal focus
+
+Make `open_chat_window` open at a compact size positioned beside the pet, above the always-on-top pet, without stealing focus.
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/chat_window.rs:27-64`
+
+**Interfaces:**
+- Consumes: `geometry::anchor_panel`, `pet`-window label scheme (`pet-{safe}`), the existing `label()` (`chat-{safe}`).
+- Produces: unchanged public signature `open_chat_window(agent_name: String, app: AppHandle) -> Result<(), String>` (the JS relay caller is untouched).
+
+- [ ] **Step 1: Add panel size consts + a pet-label helper**
+
+At the top of `chat_window.rs`:
+
+```rust
+/// Compact ("panel") default size; the user can expand to full via the header.
+const PANEL_W: i32 = 380;
+const PANEL_H: i32 = 520;
+
+fn pet_label(agent_name: &str) -> String {
+    // Same safe-name transform as `label`, with the pet prefix.
+    let safe: String = agent_name
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' { c } else { '-' })
+        .collect();
+    format!("pet-{}", safe)
+}
+```
+
+- [ ] **Step 2: Rework `open_chat_window` body**
+
+Replace lines 27-64 with: compact size, no `set_focus` (so it never pulls focus / raises the wrong window), `always_on_top` so it sits above the pet, and anchored position computed from the pet window. The existing-window guard also drops `set_focus`.
+
+```rust
+#[tauri::command]
+pub fn open_chat_window(agent_name: String, app: AppHandle) -> Result<(), String> {
+    let lbl = label(&agent_name);
+
+    // Single-instance guard: just show (do NOT set_focus — that steals focus
+    // from the user's foreground app and previously raised the Hub too).
+    if let Some(win) = app.get_webview_window(&lbl) {
+        let _ = win.show();
+        let _ = win.set_focus(); // existing window: user explicitly re-opened it
+        return Ok(());
+    }
+
+    let url = format!("index.html#/chat/{}", urlenc(&agent_name));
+
+    let win = WebviewWindowBuilder::new(&app, &lbl, WebviewUrl::App(url.into()))
+        .title(&agent_name)
+        .inner_size(PANEL_W as f64, PANEL_H as f64)
+        .min_inner_size(320.0, 420.0)
+        .resizable(true)
+        .decorations(false)
+        .transparent(true)
+        .shadow(true)
+        .always_on_top(true) // sit above the always-on-top pet
+        .visible(false)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    #[cfg(target_os = "macos")]
+    let _ = win.set_effects(
+        EffectsBuilder::new()
+            .effect(Effect::HudWindow)
+            .state(EffectState::Active)
+            .radius(12.0)
+            .build(),
+    );
+
+    // Anchor next to the pet (if it exists) on the pet's monitor.
+    if let Some(pet) = app.get_webview_window(&pet_label(&agent_name)) {
+        if let (Ok(pp), Ok(ps)) = (pet.outer_position(), pet.outer_size()) {
+            let pet_rect = crate::geometry::Rect {
+                x: pp.x, y: pp.y, w: ps.width as i32, h: ps.height as i32,
+            };
+            let mon = crate::pet::monitor_rect_for_point(&app, pp.x, pp.y);
+            let (x, y) = crate::geometry::anchor_panel(pet_rect, (PANEL_W, PANEL_H), mon);
+            let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
+        }
+    }
+
+    win.show().map_err(|e| e.to_string())?;
+    Ok(())
+}
+```
+
+> Note: `monitor_rect_for_point` from Task 2 must be `pub(crate)` for this cross-module call. Change its `fn` to `pub(crate) fn` in `pet/mod.rs`.
+
+- [ ] **Step 3: Make the helper crate-visible**
+
+In `pet/mod.rs`, change `fn monitor_rect_for_point` → `pub(crate) fn monitor_rect_for_point`.
+
+- [ ] **Step 4: Build to verify it compiles**
+
+```bash
+cargo build --manifest-path mur-hub-gui/src-tauri/Cargo.toml
+```
+Expected: compiles clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-hub-gui/src-tauri/src/chat_window.rs mur-hub-gui/src-tauri/src/pet/mod.rs
+git commit -m "feat(pet): anchor chat panel to pet, raise above it, no focus steal"
+```
+
+---
+
+### Task 4: Stop the double-jump (remove dashboard show/focus)
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/pet/mod.rs:271-280` (`pet_open_chat`)
+
+**Interfaces:**
+- Consumes: nothing new. The hidden dashboard's `pet-open-chat` listener (`DashboardApp.tsx:506`) still relays to `open_chat_window` and stages the file-drop draft — verified the dashboard is hidden-not-destroyed on close (`lib.rs:394-396`).
+
+- [ ] **Step 1: Drop the dashboard raise**
+
+Replace `pet_open_chat` (271-280) with:
+
+```rust
+/// Open `agent_name`'s chat panel. The (hidden) dashboard webview relays the
+/// `pet-open-chat` event to `open_chat_window` and stages any `draft`; we must
+/// NOT show/focus the dashboard here — that caused the Hub to "jump" alongside
+/// the chat window.
+#[tauri::command]
+pub fn pet_open_chat(agent_name: String, draft: Option<String>, app: AppHandle) {
+    let _ = app.emit(
+        "pet-open-chat",
+        serde_json::json!({ "agent": agent_name, "draft": draft }),
+    );
+}
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cargo build --manifest-path mur-hub-gui/src-tauri/Cargo.toml
+```
+Expected: compiles clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-hub-gui/src-tauri/src/pet/mod.rs
+git commit -m "fix(pet): don't raise the Hub when opening chat (double-jump)"
+```
+
+---
+
+### Task 5: Enlarge the pet root + click-through transparent areas (CSS)
+
+The React side must match the new 300×260 OS window (Task 2) and the bubble must no longer be the click-catcher across the whole window.
+
+**Files:**
+- Modify: `mur-hub-gui/ui/src/styles/components/pet.css:7-14` (`.pet-root`), `:15-25` (`.pet-sprite` margin)
+
+**Interfaces:** none (pure CSS).
+
+- [ ] **Step 1: Resize the root and pass clicks through empty space**
+
+Replace `.pet-root` (lines 7-14):
+
+```css
+.pet-root {
+  width: 300px;
+  height: 260px;
+  background: transparent;
+  overflow: visible;
+  user-select: none;
+  -webkit-user-select: none;
+  /* Empty transparent area must not eat clicks meant for apps behind the pet. */
+  pointer-events: none;
+}
+/* Re-enable pointer events only on the actual interactive children. */
+.pet-sprite,
+.pet-bubble,
+.pet-context-menu { pointer-events: auto; }
+```
+
+Anchor the sprite to the bottom so the bubble has room above it. Change `.pet-sprite` `margin` (line 18) from `margin: 20px auto 0;` to:
+
+```css
+  margin: auto auto 0;  /* sprite sits at the bottom-center of the 260px window */
+```
+
+- [ ] **Step 2: Verify the frontend builds**
+
+```bash
+cd mur-hub-gui/ui && npm run build
+```
+Expected: build succeeds (no TS/CSS errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-hub-gui/ui/src/styles/components/pet.css
+git commit -m "feat(pet): enlarge pet root to 300x260, click-through empty area"
+```
+
+---
+
+### Task 6: CJK-correct bubble typography + faux-glass + html lang
+
+Fix the actual reported rendering: readable multi-character CJK lines.
+
+**Files:**
+- Modify: `mur-hub-gui/ui/src/styles/components/pet.css` (`.pet-bubble` block ~151-172, `.pet-bubble-text` 188-192, tail `::after` 178-187)
+- Modify: `mur-hub-gui/ui/src/i18n/index.tsx:40-42` (the lang effect)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Sync `<html lang>` to the active language**
+
+In `mur-hub-gui/ui/src/i18n/index.tsx`, extend the existing effect (currently only writes localStorage):
+
+```tsx
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, lang);
+    document.documentElement.lang = lang; // WebKit uses this to pick the
+    // correct Han glyph variant (TC vs SC/JP) and CJK line-breaking rules.
+  }, [lang]);
+```
+
+- [ ] **Step 2: CJK-safe bubble text + roomier bubble + faux-glass**
+
+In `pet.css`, update `.pet-bubble-text` (188-192):
+
+```css
+.pet-bubble-text {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  line-height: 1.7;            /* CJK needs more leading */
+  text-align: left;           /* never justify CJK */
+  overflow-wrap: anywhere;    /* replaces non-standard word-break: break-word */
+}
+```
+
+In the `.pet-bubble` rule (~151-172), widen the readable column to use the bigger window and make it frosted glass (consistent with the chat window's HudWindow). Set `max-width: 260px;` (fits the 300px window with padding) and ensure the background is translucent + blurred:
+
+```css
+  max-width: 260px;
+  min-width: 140px;
+  background: color-mix(in srgb, var(--surface-card) 78%, transparent);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  backdrop-filter: blur(18px) saturate(140%);
+  border: 1px solid color-mix(in srgb, var(--border-line) 60%, transparent);
+```
+(Keep the existing `position`, `padding`, `border-radius`, `box-shadow`, `z-index`, animation properties in that rule — only widen + reskin the fill.)
+
+Update the tail `::after` (line 185) so it matches the translucent fill instead of the opaque `--surface-card`:
+
+```css
+  border-top-color: color-mix(in srgb, var(--surface-card) 78%, transparent);
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd mur-hub-gui/ui && npm run build
+```
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-hub-gui/ui/src/styles/components/pet.css mur-hub-gui/ui/src/i18n/index.tsx
+git commit -m "fix(pet): CJK-correct bubble typography, faux-glass, html lang sync"
+```
+
+---
+
+### Task 7: Single-click opens chat; expand button on the panel
+
+Make single-click the primary action (research: double-click is a relic) and give the panel a header control to grow to full size.
+
+**Files:**
+- Modify: `mur-hub-gui/ui/src/components/PetApp.tsx:166-171` (`handleMouseUp`)
+- Modify: `mur-hub-gui/ui/src/components/chat/AgentChatWindow.tsx` (header area, ~88-103)
+
+**Interfaces:**
+- Consumes: existing `handleChat` (`PetApp.tsx:188-191`).
+
+- [ ] **Step 1: Single-click opens chat (and still greets)**
+
+In `PetApp.tsx`, update `handleMouseUp` (166-171) so a real click both fires the greeting event and opens the panel. Double-click still calls `handleChat` (idempotent via the single-instance guard), so no single/double disambiguation timer is needed:
+
+```tsx
+  function handleMouseUp() {
+    if (pressRef.current && Date.now() - clickTimeRef.current < CLICK_MS) {
+      // Greeting expression + open the chat panel (single-click is primary).
+      invoke("hub_emit_event", { agentName, eventName: "user.click.pet" }).catch(() => {});
+      void handleChat();
+    }
+    pressRef.current = null;
+  }
+```
+
+Update the sprite's `title` to reflect single-click (optional copy tweak) — leave `onDoubleClick={handleChat}` in place as a redundant shortcut.
+
+- [ ] **Step 2: Add an expand-to-full button in the chat window header**
+
+In `AgentChatWindow.tsx`, add a small header control that resizes this window to the full 780×660. Import at top:
+
+```tsx
+import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
+```
+
+Add a handler in the component body:
+
+```tsx
+  const expandToFull = () =>
+    void getCurrentWindow().setSize(new LogicalSize(780, 660)).catch(() => {});
+```
+
+Render an expand button in the existing header/toolbar region (near where `displayName`/`status` are shown, ~lines 88-103). Match the surrounding markup; e.g.:
+
+```tsx
+  <button
+    className="chat__expand"
+    onClick={expandToFull}
+    title={t("chat.expand")}
+    aria-label={t("chat.expand")}
+  >⤢</button>
+```
+
+Add the `chat.expand` i18n key (e.g. en: `"Expand"`, zh-TW: `"放大"`) in the translation tables the other `chat.*` keys live in. (Locate via `grep -rn '"chat.stop"' mur-hub-gui/ui/src/i18n`.)
+
+- [ ] **Step 3: Verify build (type-checks the i18n key + imports)**
+
+```bash
+cd mur-hub-gui/ui && npm run build
+```
+Expected: build succeeds. A failure about a missing `chat.expand` key means Step 2's i18n entry was not added to every locale table — add it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-hub-gui/ui/src/components/PetApp.tsx mur-hub-gui/ui/src/components/chat/AgentChatWindow.tsx mur-hub-gui/ui/src/i18n
+git commit -m "feat(pet): single-click opens chat panel; expand-to-full button"
+```
+
+---
+
+### Task 8: Build the full app and verify behavior (manual E2E)
+
+Window-server behavior (focus, z-order, anchoring, CJK rendering) can't be unit-tested; this task is the gate.
+
+**Files:** none (build + observe).
+
+- [ ] **Step 1: Build the real UI + app bundle**
+
+```bash
+cd mur-hub-gui/ui && npm run build && cd -
+cargo build --manifest-path mur-hub-gui/src-tauri/Cargo.toml --release
+```
+(For a runnable `.app` to drive with Computer Use, use `cargo tauri build --debug --bundles app` per `mem:gotcha_tauri_dev_null_bundleid_computeruse`; `cargo tauri dev` is invisible to screenshots.)
+
+- [ ] **Step 2: Verify each behavior**
+
+Spawn a pet (drag an agent out of the Hub) and confirm:
+
+- [ ] Pet spawns with **no opaque-square flash**.
+- [ ] **Single-click** the pet → chat panel opens (~380×520) **next to the pet**, the **Hub does NOT appear/jump**, and **focus stays** in whatever app was frontmost.
+- [ ] The panel sits **above** the pet (pet does not paint over it).
+- [ ] Drag the pet to a **second monitor** / screen corner → panel still opens on the **pet's** monitor, fully on-screen; pet itself never clips off-screen.
+- [ ] The **expand ⤢** button grows the panel to 780×660.
+- [ ] Drop a **Chinese text file** on the pet → the take bubble shows **readable multi-character lines** (not 3-4 glyphs/line). (Summary-in-panel is Phase 3; readable bubble is the Phase 1 bar.)
+
+- [ ] **Step 3: Lint (clippy + fmt for the excluded crate)**
+
+```bash
+cargo clippy --manifest-path mur-hub-gui/src-tauri/Cargo.toml -- -D warnings
+cargo fmt --manifest-path mur-hub-gui/src-tauri/Cargo.toml
+```
+(Per `mem:gotcha_ci_fmt_excluded_crates`, the excluded crate needs its own fmt invocation.)
+Expected: clippy clean, fmt makes no changes (or commit the formatting).
+
+- [ ] **Step 4: Commit any fmt/clippy fixups**
+
+```bash
+git add -A && git commit -m "chore(pet): clippy/fmt for chat escalation phase 1" || true
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 1 slice of `2026-06-25-mur-pet-chat-escalation-redesign.md`):**
+- §4 panel anchoring → Task 1 (geometry) + Task 3 (apply). ✓
+- §4 z-order (panel above pet) → Task 3 (`always_on_top`). ✓
+- §4 off-screen spawn clamp → Task 1 + Task 2. ✓
+- §4 pet window enlarge → Task 2 (OS size) + Task 5 (CSS). ✓
+- §5 double-jump / no focus steal → Task 3 (`open_chat_window` no set_focus) + Task 4 (`pet_open_chat`). ✓
+- §7 CJK typography + `html lang` → Task 6. ✓
+- §8 single-click primary → Task 7. ✓
+- §9 entrance flash → Task 2 (`visible(false)`+`show()`). ✓
+- §9 faux-glass bubble → Task 6. ✓
+- Deferred to later plans (intentional): file-summary→panel deep integration (§6), keyboard a11y / mute persistence / dead-code deletion (§8/§9 Phase 2), drag-over affordance / privacy disclosure / drop honesty / mascot motion (§6/§9 Phase 3). Noted, not dropped.
+
+**Placeholder scan:** No TBD/TODO; every code step shows real code; the one lookup ("locate the `chat.*` i18n table via grep") names the exact command and the failure signal that catches a miss.
+
+**Type consistency:** `geometry::Rect`/`anchor_panel`/`clamp_into` signatures match across Tasks 1→2→3; `monitor_rect_for_point` is defined in Task 2 and made `pub(crate)` before its cross-module use in Task 3; `PET_W/PET_H` (Task 2) and `PANEL_W/PANEL_H` (Task 3) are the single source for the sizes used in both OS-window and clamp math.
+
+**Coordinate space:** all placement uses physical px + `PhysicalPosition`; monitor rects come from `available_monitors()`/`primary_monitor()` (physical). Flagged in Global Constraints and verified on a second monitor in Task 8.

--- a/docs/superpowers/plans/2026-06-25-pet-chat-escalation-phase2.md
+++ b/docs/superpowers/plans/2026-06-25-pet-chat-escalation-phase2.md
@@ -1,0 +1,275 @@
+# Pet Chat Escalation — Phase 2 Implementation Plan (cheap wins + hardening)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the low-risk, high-value desktop-pet improvements deferred from Phase 1: keyboard/accessibility, mute persistence + indicator, contrast, and deletion of the write-only pet-position dead code.
+
+**Architecture:** Small, isolated edits to the existing pet UI (`PetApp.tsx`, `PetFace.tsx`, `pet.css`) and backend (`pet/mod.rs`, `lib.rs`). No new windows, no new dependencies. Builds on Phase 1 (branch `feat/pet-chat-escalation`); base = Phase 1 head.
+
+**Tech Stack:** Rust + Tauri 2 (`mur-hub-gui/src-tauri`), React 18 + TypeScript + Vite (`mur-hub-gui/ui`).
+
+## Global Constraints
+
+- `cargo` is NOT on PATH: prepend `export PATH="/Volumes/Firecuda4tb/.relocated-home/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"`.
+- `mur-hub-gui` is workspace-EXCLUDED: every cargo command uses `--manifest-path mur-hub-gui/src-tauri/Cargo.toml`; the bin is `mur-hub-gui`. Frontend check: `cd mur-hub-gui/ui && npm run build`.
+- Stage ONLY the files each task names — NEVER `git add -A`. The working tree may carry unrelated user changes (`.mcp.json`, `Cargo.lock`); leave them alone.
+- Never delete files or run disk cleanup; if a build fails on disk, stop and report.
+- Brand "MUR" uppercase in user-visible strings; internal `name`/labels lowercase.
+- Line numbers below are indicative (Phase 1 shifted them) — grep/read the current file to locate the exact spot before editing.
+
+---
+
+### Task 1: Keyboard-operable pet sprite + a11y
+
+Make the pet operable without a mouse (today the sprite is a plain `<div>` — no focus, no key handler), and fix the lowest-contrast control.
+
+**Files:**
+- Modify: `mur-hub-gui/ui/src/components/PetApp.tsx` (the `.pet-sprite` element; the Escape `keydown` effect; the context-menu render)
+- Modify: `mur-hub-gui/ui/src/components/PetFace.tsx` (`role="img"` aria-label)
+- Modify: `mur-hub-gui/ui/src/styles/components/pet.css` (`.pet-bubble-close` color; focus-visible style)
+
+- [ ] **Step 1: Make the sprite a real button**
+
+Find the `<div className={`pet-sprite ...`} ...>` element. Add keyboard semantics (keep the existing mouse handlers + `onDoubleClick`):
+
+```tsx
+      <div
+        className={`pet-sprite pet-sprite--${expression}`}
+        role="button"
+        tabIndex={0}
+        aria-label={t("pet.chat")}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onDoubleClick={handleChat}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            void handleChat();
+          }
+        }}
+      >
+```
+Remove the now-redundant `title={t("pet.chat")}` (the `aria-label` replaces it; keep it only if you want a hover tooltip).
+
+- [ ] **Step 2: Hide the inner PetFace/img from the a11y tree**
+
+The sprite button now carries the label; the inner graphic should not double-announce. On the `<PetFace .../>` usage and the `<img ... className="pet-image" .../>`, add `aria-hidden`:
+- `<img src={imageSrc} alt="" aria-hidden className="pet-image" draggable={false} />` (empty alt + aria-hidden)
+- For `<PetFace .../>`: in `PetFace.tsx`, change the root SVG `role="img" aria-label={...}` to `aria-hidden` (drop the unlocalized `${presetId} pet, ${expression}` label — the parent button is now the accessible name). Locate the `role="img"` line in PetFace.tsx and replace `role="img" aria-label={...}` with `aria-hidden`.
+
+- [ ] **Step 3: Escape also closes the context menu; focus first item on open**
+
+In the existing `keydown` effect that closes the bubble on Escape, also close the context menu:
+```tsx
+      if (e.key === "Escape") {
+        if (contextMenu.visible) setContextMenu((m) => ({ ...m, visible: false }));
+        if (bubble) setBubble(null);
+      }
+```
+(Adjust the effect's dependency array to include `contextMenu.visible`.) When the menu opens, focus its first item: add a `ref` to the first `.pet-menu-item` button and a `useEffect` on `contextMenu.visible` that calls `firstItemRef.current?.focus()`. Skip arrow-key roving (Tab already moves between the `<button>`s).
+
+- [ ] **Step 4: Bubble close-button contrast + focus-visible**
+
+In `pet.css`, `.pet-bubble-close` resting `color: var(--text-tertiary)` likely fails WCAG 4.5:1 — change to `color: var(--text-secondary);`. Add a visible keyboard focus ring for the sprite + menu items:
+```css
+.pet-sprite:focus-visible,
+.pet-menu-item:focus-visible,
+.pet-bubble-close:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 2px;
+}
+```
+
+- [ ] **Step 5: Verify build**
+
+```bash
+cd mur-hub-gui/ui && npm run build
+```
+Expected: success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-hub-gui/ui/src/components/PetApp.tsx mur-hub-gui/ui/src/components/PetFace.tsx mur-hub-gui/ui/src/styles/components/pet.css
+git commit -m "feat(pet): keyboard-operable sprite, a11y labels, Escape closes menu, contrast"
+```
+
+---
+
+### Task 2: Mute persistence + visible indicator
+
+Mute is React-state only today — every reload/respawn silently un-mutes, and the state is invisible.
+
+**Files:**
+- Modify: `mur-hub-gui/ui/src/components/PetApp.tsx` (`muted` state init + `handleToggleMute`)
+- Modify: `mur-hub-gui/ui/src/styles/components/pet.css` (a `.pet-sprite--muted` badge)
+
+- [ ] **Step 1: Persist mute to localStorage, keyed by agent**
+
+Replace the `muted` state initializer to read persisted state (lazy initializer), and write on toggle. The key includes `agentName` (from `getAgentName()`):
+```tsx
+  const muteKey = `pet-muted:${agentName}`;
+  const [muted, setMuted] = useState(() => localStorage.getItem(muteKey) === "1");
+  const mutedRef = useRef(muted);
+```
+In `handleToggleMute`, persist:
+```tsx
+  function handleToggleMute() {
+    closeMenu();
+    setMuted((m) => {
+      const next = !m;
+      mutedRef.current = next;
+      localStorage.setItem(muteKey, next ? "1" : "0");
+      if (next) setBubble(null);
+      return next;
+    });
+  }
+```
+(Also ensure `mutedRef.current` is seeded from the initial `muted` — set `const mutedRef = useRef(muted)` as above.)
+
+- [ ] **Step 2: Show a 🔇 badge on the sprite when muted**
+
+Add the muted class to the sprite container conditionally: `className={`pet-sprite pet-sprite--${expression}${muted ? " pet-sprite--muted" : ""}`}`. In `pet.css`:
+```css
+.pet-sprite--muted::after {
+  content: "🔇";
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  font-size: 16px;
+  filter: drop-shadow(0 1px 2px rgba(0,0,0,0.4));
+}
+```
+(Ensure `.pet-sprite` is `position: relative` so the badge anchors to it; add `position: relative` to `.pet-sprite` if absent.)
+
+- [ ] **Step 3: Verify build + commit**
+
+```bash
+cd mur-hub-gui/ui && npm run build
+git add mur-hub-gui/ui/src/components/PetApp.tsx mur-hub-gui/ui/src/styles/components/pet.css
+git commit -m "feat(pet): persist mute per-agent + muted badge"
+```
+
+---
+
+### Task 3: Delete the write-only pet-position dead code
+
+`pet_position.json` is written on every move but never read; the "restore on restart" it implies was never built and is intentionally not wanted (spec §12). Remove the whole path.
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/pet/mod.rs` (delete `PetPosition`, `pet_position_path`, `save_position`, `pet_reposition`)
+- Modify: `mur-hub-gui/src-tauri/src/lib.rs` (remove `pet::pet_reposition` from `tauri::generate_handler!`)
+- Modify: `mur-hub-gui/ui/src/components/PetApp.tsx` (remove the `tauri://move` → `pet_reposition` listener effect)
+
+- [ ] **Step 1: Confirm nothing else reads it**
+
+```bash
+export PATH="/Volumes/Firecuda4tb/.relocated-home/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"
+grep -rn "PetPosition\|pet_reposition\|pet_position\|save_position\|display_id" mur-hub-gui/src-tauri/src mur-hub-gui/ui/src
+```
+Expected references: only the definitions + the `tauri://move` listener + the handler registration (all to be removed). If anything else reads them, stop and report.
+
+- [ ] **Step 2: Delete the Rust dead code**
+
+In `pet/mod.rs`, delete the `PetPosition` struct, `pet_position_path()`, `save_position()`, and the `#[tauri::command] pub fn pet_reposition(...)`. Confirm `pet_spawn_at` no longer references `PetPosition` (Phase 1 already removed the local `pos` binding; if a stray reference remains, remove it). Remove the now-unused `dirs`/`serde` imports only if they become unused (check — they're likely used elsewhere; do not remove shared imports).
+
+- [ ] **Step 3: Remove the handler registration**
+
+In `lib.rs` `tauri::generate_handler![ ... ]`, delete the `pet::pet_reposition,` line.
+
+- [ ] **Step 4: Remove the frontend listener**
+
+In `PetApp.tsx`, delete the `useEffect` that listens to `win.listen("tauri://move", ...)` and invokes `pet_reposition` (the position-persistence effect).
+
+- [ ] **Step 5: Build (Rust + frontend) to verify nothing breaks**
+
+```bash
+cargo build --manifest-path mur-hub-gui/src-tauri/Cargo.toml
+cd mur-hub-gui/ui && npm run build && cd -
+```
+Expected: both compile clean (no "unused" errors from the deletion; if `pet_reposition` removal leaves a dangling reference, the build will catch it).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-hub-gui/src-tauri/src/pet/mod.rs mur-hub-gui/src-tauri/src/lib.rs mur-hub-gui/ui/src/components/PetApp.tsx
+git commit -m "refactor(pet): delete write-only pet_position persistence (dead code)"
+```
+
+---
+
+### Task 4: Minor cleanups (stale comment + geometry edge test)
+
+**Files:**
+- Modify: `mur-hub-gui/ui/src/styles/components/pet.css` (stale `.pet-bubble` comment)
+- Modify: `mur-hub-gui/src-tauri/src/geometry.rs` (add a non-zero-monitor-origin test)
+
+- [ ] **Step 1: Fix the stale bubble comment**
+
+The `.pet-bubble` comment still says "fixed transparent 200×200" — update to reflect the 300×260 window (Phase 1). Find the comment above `.pet-bubble` and correct the dimensions.
+
+- [ ] **Step 2: Add a secondary-display geometry test (TDD-style, real assertions)**
+
+In `geometry.rs` `#[cfg(test)] mod tests`, add a test exercising a monitor with a non-zero origin (e.g. a second display at x=1920), so `mon.x/mon.y` are used as the lower clamp bound:
+```rust
+    #[test]
+    fn anchors_on_a_secondary_monitor_origin() {
+        let mon = Rect { x: 1920, y: 0, w: 1440, h: 900 };
+        let pet = Rect { x: 2000, y: 100, w: 300, h: 260 };
+        // room on the left within this monitor: 2000 - 8 - 380 = 1612 >= 1920? no -> flip right
+        let (x, y) = anchor_panel(pet, (380, 520), mon);
+        assert_eq!(x, 2000 + 300 + 8); // 2308, opens right
+        assert_eq!(y, 100);
+    }
+
+    #[test]
+    fn clamps_within_secondary_monitor_bounds() {
+        let mon = Rect { x: 1920, y: 0, w: 1440, h: 900 };
+        // a point left of this monitor's origin clamps up to mon.x
+        assert_eq!(clamp_into((1900, 50), (300, 260), mon), (1920, 50));
+    }
+```
+
+- [ ] **Step 3: Run the geometry tests**
+
+```bash
+[ -f mur-hub-gui/ui/dist/index.html ] || { mkdir -p mur-hub-gui/ui/dist && echo '<!doctype html><title>stub</title>' > mur-hub-gui/ui/dist/index.html; }
+cargo test --manifest-path mur-hub-gui/src-tauri/Cargo.toml geometry:: -- --nocapture
+```
+Expected: all geometry tests pass (now including the two secondary-monitor cases).
+
+- [ ] **Step 4: Verify frontend build + commit**
+
+```bash
+cd mur-hub-gui/ui && npm run build && cd -
+git add mur-hub-gui/ui/src/styles/components/pet.css mur-hub-gui/src-tauri/src/geometry.rs
+git commit -m "chore(pet): fix stale bubble comment + secondary-monitor geometry tests"
+```
+
+---
+
+### Task 5: Verify + lint
+
+- [ ] **Step 1: clippy + fmt (excluded crate needs its own invocation)**
+
+```bash
+export PATH="/Volumes/Firecuda4tb/.relocated-home/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"
+cargo clippy --manifest-path mur-hub-gui/src-tauri/Cargo.toml
+cargo fmt --manifest-path mur-hub-gui/src-tauri/Cargo.toml -- --check
+```
+Expected: no clippy warnings in touched files; fmt clean. Fix any (collapse nested if-let into let-chains if clippy asks), then commit fmt fixups (`git add` the touched Rust files only).
+
+- [ ] **Step 2: Manual a11y check**
+
+Tab to the pet (focus ring visible), press Enter/Space → chat opens. Right-click → menu; press Escape → menu closes. Mute → 🔇 badge shows; reload the pet window → still muted.
+
+## Self-Review
+
+- §8 keyboard-operable sprite + Escape-closes-menu → Task 1. ✓
+- §8 mute persistence + badge → Task 2. ✓
+- §8 contrast (bubble close) → Task 1 Step 4. ✓
+- §9 delete write-only pet_position dead code → Task 3. ✓
+- Final-review minors: stale `.pet-bubble` comment (M2) → Task 4; non-zero-monitor geometry test (T1) → Task 4. ✓
+- No placeholders; every code step shows real code; the one lookup (Task 3 Step 1 grep) names the command + the stop condition.
+- Type consistency: `muteKey`/`mutedRef` consistent in Task 2; deletions in Task 3 are verified by the grep + the build catching dangling refs.

--- a/docs/superpowers/plans/2026-06-25-pet-chat-escalation-phase3.md
+++ b/docs/superpowers/plans/2026-06-25-pet-chat-escalation-phase3.md
@@ -1,0 +1,276 @@
+# Pet Chat Escalation — Phase 3 Implementation Plan (file-drop UX + liveness)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make file-drop a first-class chat interaction (summary streams into the panel, not the cramped bubble), disclose when file contents leave for a cloud model, give the drop a visible target, make truncation honest, and bring the mascot to life while it works.
+
+**Architecture:** The pet drop currently does an **ephemeral** `message/send` dial whose exchange is never persisted, so it can't reach the chat panel. Phase 3 routes the exchange into the agent's channel via `mur_core::mobile::persist_mobile_exchange` — the existing `channel-updated` watcher (`lib.rs:502-515`) then re-hydrates `ChatTab` (which loads via `channel_load`), so the dropped file + agent take appear as real messages. The rest is UI affordance (drag highlight, mascot motion) + safety (privacy disclosure, honest truncation). Branch `feat/pet-chat-escalation`; base = Phase 2 head.
+
+**Tech Stack:** Rust + Tauri 2 (`mur-hub-gui/src-tauri`, `mur-core`), React 18 + TS + Vite (`mur-hub-gui/ui`).
+
+## Global Constraints
+
+- `cargo` not on PATH: prepend `export PATH="/Volumes/Firecuda4tb/.relocated-home/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"`.
+- `mur-hub-gui` workspace-EXCLUDED: `--manifest-path mur-hub-gui/src-tauri/Cargo.toml`; bin `mur-hub-gui`. Frontend: `cd mur-hub-gui/ui && npm run build`.
+- Stage ONLY each task's named files — NEVER `git add -A`. Leave unrelated tree changes (`.mcp.json`, `Cargo.lock`) alone.
+- Never delete files / run disk cleanup; build fails on disk → stop and report.
+- Brand "MUR" uppercase in user-visible strings; reply/UX copy supports zh-TW (add both en + zh-TW i18n keys for any new user-visible string — the i18n table is type-checked for parity).
+- Line numbers indicative — grep/read the current file before editing.
+- `pet_drop_files` already has safety caps (`PET_DROP_MAX_FILES=5`, `PET_DROP_MAX_TOTAL_BYTES`, `PET_DROP_READ_BYTE_CAP`, char truncation) — preserve them; do not weaken the bounded-read protections.
+
+---
+
+### Task 1: Route the dropped-file exchange into the agent's channel
+
+So the take appears in the chat panel as a real message instead of being trapped in the bubble.
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/pet/mod.rs` (`pet_drop_files`)
+
+**Interfaces:**
+- Consumes: `mur_core::mobile::persist_mobile_exchange` (verify exact name/signature in `mur-core/src/mobile.rs` ~561-598 before calling — it appends a user+agent turn pair to the agent's latest channel, best-effort).
+- Consumes: the existing `channel-updated` watcher → `ChatTab` `channel_load(name)` re-hydration (no frontend change needed).
+
+- [ ] **Step 1: Confirm the persist API + that channel_load reads the same channel**
+
+```bash
+export PATH="/Volumes/Firecuda4tb/.relocated-home/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"
+grep -n "pub fn persist_mobile_exchange" mur-core/src/mobile.rs
+grep -n "pub fn persist_exchange\|latest_for_agent\|channel_load" mur-hub-gui/src-tauri/src/chat.rs mur-hub-gui/src-tauri/src/*.rs
+```
+Confirm: (a) the public `persist_mobile_exchange` signature (args: home, agent, user_text, reply — adapt to the real one); (b) it writes to the agent's latest channel; (c) `channel_load` (the command `ChatTab` calls) reads that same latest channel. If `persist_mobile_exchange` is not public or writes elsewhere, prefer `chat::persist_exchange` (chat.rs ~257-292) if callable, or report the mismatch. Do NOT proceed on a guess about which channel is read vs written.
+
+- [ ] **Step 2: Persist the exchange in `pet_drop_files`**
+
+After the inline take `reply` is computed (the `spawn_blocking` dial result), persist the exchange so it lands in the channel. Build a user message that references the dropped files (the "chip" is a 📎 filename prefix — a styled chip is deferred, YAGNI):
+```rust
+    // Make the dropped-file exchange a real channel turn so it shows in the
+    // chat panel (channel-updated → ChatTab re-hydrates), not just the bubble.
+    let file_names: Vec<String> = sections
+        .iter()
+        .filter_map(|s| s.lines().next().map(|l| l.trim_start_matches("=== ").trim_end_matches(" ===").to_string()))
+        .collect();
+    let user_msg = format!("📎 Dropped: {}\n\n{body}", file_names.join(", "));
+    let home2 = mur_home();
+    let agent2 = agent_name.clone();
+    let reply2 = reply.clone();
+    let _ = tokio::task::spawn_blocking(move || {
+        mur_core::mobile::persist_mobile_exchange(&home2, &agent2, &user_msg, &reply2)
+    })
+    .await;
+```
+(Adapt the call to the real signature from Step 1. `persist_mobile_exchange` is best-effort/no-op on error — fine.) Keep the existing `pet-open-chat` emit so the panel opens; the panel then shows the persisted exchange.
+
+- [ ] **Step 3: Reduce the bubble to a short pointer (the take now lives in the panel)**
+
+The full take no longer needs to fill the bubble. Change `pet_drop_files`'s `PetDropResult.reply` (shown in the bubble by `PetApp.tsx`) to a brief confirmation instead of the full multi-sentence take — e.g. return the take as before BUT the frontend bubble should show a short form. Simplest: keep returning `reply` (so a glance is available) but ALSO ensure it's short; the panel has the full version. (If `reply` is already 1-2 sentences per the prompt, leave it — the readable bubble from Phase 1 is fine as a glance; the durable copy is in the panel.) No frontend change required here if the bubble already shows the 1-2 sentence take.
+
+- [ ] **Step 4: Build + commit**
+
+```bash
+cargo build --manifest-path mur-hub-gui/src-tauri/Cargo.toml
+git add mur-hub-gui/src-tauri/src/pet/mod.rs
+git commit -m "feat(pet): persist dropped-file exchange to channel (shows in chat panel)"
+```
+
+- [ ] **Step 5: Live check (operator/computer-use)**
+
+Drop a text file on a pet → the chat panel opens → within ~1-2s the file message + agent take appear in the panel as a message pair. (Needs a running runtime for the agent.)
+
+---
+
+### Task 2: Privacy disclosure when file contents leave for a non-local model
+
+Dropped file contents (up to 256KB) are sent to the agent's model — often cloud. Disclose it.
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/pet/mod.rs` (resolve the agent's model provider; return a `cloud` flag or provider name in `PetDropResult`)
+- Modify: `mur-hub-gui/ui/src/components/PetApp.tsx` (the "reading…" bubble copy)
+- Modify: `mur-hub-gui/ui/src/i18n/en.ts` + `zh-TW.ts` (disclosure string)
+
+- [ ] **Step 1: Find an existing "is this model local?" check**
+
+```bash
+grep -rn "is_local\|local_model\|provider\|localhost\|127.0.0.1\|ollama\|mlx\|lmstudio" mur-core/src/ mur-hub-gui/src-tauri/src/ | grep -i "model\|provider\|local" | head -30
+```
+Determine how an agent's resolved model + provider is read (agent profile → model alias → `~/.mur/models.yaml` provider; "local" = provider points at a localhost/loopback base URL or a known local runtime). If a reusable helper exists, use it. If not, the FLOOR is a generic disclosure (Step 3) — do not build a model registry from scratch (YAGNI).
+
+- [ ] **Step 2: Surface a provider/cloud signal from the drop**
+
+Resolve the agent's model provider in `pet_drop_files` (before/around the dial) and add a field to `PetDropResult`, e.g. `pub remote_provider: Option<String>` (Some("Anthropic"/"OpenAI"/…) when non-local, None when local/unknown-local). Use the helper from Step 1; if none exists, set `remote_provider` to `Some("the agent's model")` whenever the model isn't demonstrably local (fail-toward-disclosure).
+
+- [ ] **Step 3: Disclose in the reading bubble**
+
+In `PetApp.tsx`, the `pet://drop` handler sets the "reading…" bubble. When `remote_provider` is present (returned in `PetDropResult`), the bubble (or the result bubble) includes a disclosure, e.g. `t("pet.dropSendingTo", { provider })`. Add i18n keys to BOTH locales:
+- en: `"pet.dropSendingTo": "Sending file contents to {provider}…"`
+- zh-TW: `"pet.dropSendingTo": "正在把檔案內容傳給 {provider}…"`
+No consent dialog (YAGNI) — disclosure only.
+
+- [ ] **Step 4: Build + commit**
+
+```bash
+cargo build --manifest-path mur-hub-gui/src-tauri/Cargo.toml
+cd mur-hub-gui/ui && npm run build && cd -
+git add mur-hub-gui/src-tauri/src/pet/mod.rs mur-hub-gui/ui/src/components/PetApp.tsx mur-hub-gui/ui/src/i18n/en.ts mur-hub-gui/ui/src/i18n/zh-TW.ts
+git commit -m "feat(pet): disclose when dropped file contents go to a non-local model"
+```
+
+---
+
+### Task 3: Drag-over drop affordance
+
+Today there is zero feedback that the pet is a drop target. Add a highlight.
+
+**Files:**
+- Modify: `mur-hub-gui/ui/src/components/PetApp.tsx` (drag handlers on `.pet-root`)
+- Modify: `mur-hub-gui/ui/src/styles/components/pet.css` (`.pet-root--drag` style)
+
+- [ ] **Step 1: Webview drag handlers (highlight only; the real drop still flows through the Tauri `pet://drop` path)**
+
+Add local state `const [dragOver, setDragOver] = useState(false)` and on the `.pet-root` div:
+```tsx
+      onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={() => setDragOver(false)}
+```
+Apply the class: `className={`pet-root${dragOver ? " pet-root--drag" : ""}`}`. Also clear it in the existing `pet://drop` listener (in case `dragleave` doesn't fire): call `setDragOver(false)` at the top of that handler.
+
+- [ ] **Step 2: Highlight style**
+
+In `pet.css`:
+```css
+.pet-root--drag .pet-sprite {
+  transform: scale(1.08);
+  filter: drop-shadow(0 0 0 2px var(--color-brand)) drop-shadow(0 4px 12px rgba(0,0,0,0.25));
+}
+@media (prefers-reduced-motion: reduce) {
+  .pet-root--drag .pet-sprite { transform: none; }
+}
+```
+
+- [ ] **Step 3: Build + commit**
+
+```bash
+cd mur-hub-gui/ui && npm run build
+git add mur-hub-gui/ui/src/components/PetApp.tsx mur-hub-gui/ui/src/styles/components/pet.css
+git commit -m "feat(pet): drag-over drop-target highlight"
+```
+
+---
+
+### Task 4: Honest truncation + non-dismissible pending + dial timeout
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/pet/mod.rs` (`pet_drop_files`)
+- Modify: `mur-hub-gui/ui/src/components/PetApp.tsx` (pending bubble)
+
+- [ ] **Step 1: Signal >5-file truncation + surface skipped names**
+
+In `pet_drop_files`, the `paths.iter().take(PET_DROP_MAX_FILES)` silently drops files 6+. Before/after the loop, if `paths.len() > PET_DROP_MAX_FILES`, push a synthetic entry into `skipped` (e.g. format!("+{} more (max {})", paths.len() - PET_DROP_MAX_FILES, PET_DROP_MAX_FILES)). Ensure `skipped` filenames (not just a count) reach the user: include them in the persisted channel user message (Task 1's `user_msg`) so they land in the panel, in addition to the bubble's count.
+
+- [ ] **Step 2: Bounded dial (timeout) so a hung runtime can't hang the bubble forever**
+
+Wrap the `spawn_blocking` dial join in a timeout, returning a clear message on elapse:
+```rust
+    let dialed = match tokio::time::timeout(
+        std::time::Duration::from_secs(45),
+        tokio::task::spawn_blocking(move || { /* existing dial */ }),
+    ).await {
+        Ok(join) => join.map_err(|e| e.to_string())?,
+        Err(_) => Ok("(timed out reaching the agent)".to_string()),
+    };
+```
+(45s is under the 60s bubble dwell. Adapt to the existing dial code shape.)
+
+- [ ] **Step 3: Non-dismissible pending bubble**
+
+In `PetApp.tsx`, while the `pet_drop_files` promise is in flight, the "reading…" bubble's ✕ shouldn't pretend to cancel (the dial keeps running). Track a `pending` boolean (set true before `invoke`, false in `.then/.catch/.finally`). Pass it to the `Bubble` so the close button is hidden (or disabled) while `pending`. Minimal: in the `pet://drop` handler set a `pending` state; render the bubble's close button only when `!pending`.
+
+- [ ] **Step 4: Build + commit**
+
+```bash
+cargo build --manifest-path mur-hub-gui/src-tauri/Cargo.toml
+cd mur-hub-gui/ui && npm run build && cd -
+git add mur-hub-gui/src-tauri/src/pet/mod.rs mur-hub-gui/ui/src/components/PetApp.tsx
+git commit -m "feat(pet): honest drop truncation, dial timeout, non-dismissible pending bubble"
+```
+
+---
+
+### Task 5: Thinking mascot state while the drop dial runs
+
+12 expression slots exist but only idle/smile/peek animate; a working agent looks frozen.
+
+**Files:**
+- Modify: `mur-hub-gui/ui/src/components/PetApp.tsx` (set a "thinking" expression while pending)
+- Modify: `mur-hub-gui/ui/src/components/PetFace.tsx` (animate non-calm states; add a thinking pulse)
+- Modify: `mur-hub-gui/ui/src/styles/components/pet.css` (`thinking` pulse keyframe, reduced-motion guarded)
+
+- [ ] **Step 1: Drive a thinking state from the drop pending flag**
+
+In `PetApp.tsx`, while the drop dial is pending (the `pending` flag from Task 4), set the local `expression` to `"think"` (or the existing thinking slot name — check `EXPR` in `PetFace.tsx` for the exact key), reverting to `"idle"` when done. Do not fight the backend `pet-expression` listener — gate the local override so the pending state wins only while pending.
+
+- [ ] **Step 2: Make the thinking state visibly animate**
+
+In `PetFace.tsx`, the breathe/blink classes are gated to calm states (idle|smile|peek). Add the `think` state to the set that keeps blinking, and add a subtle pulse. In `pet.css`:
+```css
+.petface--thinking .petface__body {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: petfaceThink 1.1s ease-in-out infinite;
+}
+@keyframes petfaceThink {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.03); opacity: 0.85; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .petface--thinking .petface__body { animation: none; }
+}
+```
+Wire the `petface--thinking` class in `PetFace.tsx` when `expression === "think"`. (Talk/mouth-flap while the reply streams is deferred — the pet window does not receive the chat-delta stream; revisit if pet-side streaming is added.)
+
+- [ ] **Step 2b: Self-check for the gating logic**
+
+Add a tiny assertion-style check (or a focused manual verification note) that the local thinking override reverts to the backend expression when not pending — a branch that, if broken, would leave the pet stuck "thinking". Manual: drop a file → mascot pulses while reading → returns to idle after the take arrives.
+
+- [ ] **Step 3: Build + commit**
+
+```bash
+cd mur-hub-gui/ui && npm run build
+git add mur-hub-gui/ui/src/components/PetApp.tsx mur-hub-gui/ui/src/components/PetFace.tsx mur-hub-gui/ui/src/styles/components/pet.css
+git commit -m "feat(pet): thinking mascot state while the drop dial runs"
+```
+
+---
+
+### Task 6: Verify + lint + live E2E
+
+- [ ] **Step 1: clippy + fmt**
+
+```bash
+export PATH="/Volumes/Firecuda4tb/.relocated-home/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"
+cargo clippy --manifest-path mur-hub-gui/src-tauri/Cargo.toml
+cargo fmt --manifest-path mur-hub-gui/src-tauri/Cargo.toml -- --check
+cd mur-hub-gui/ui && npm run build && cd -
+```
+Fix any warnings in touched files (let-chains for nested if-let), commit fmt fixups (touched Rust files only).
+
+- [ ] **Step 2: Live E2E (operator/computer-use; needs a running agent runtime)**
+
+- [ ] Drag a file toward the pet → pet highlights (drop-target affordance).
+- [ ] Drop a Chinese text file → mascot pulses "thinking"; bubble shows readable "reading…" then a short take; the **chat panel shows the file message + agent take as messages** (Task 1).
+- [ ] If the agent's model is non-local → the bubble discloses the provider (Task 2).
+- [ ] Drop >5 files → the count + skipped names are honest (in the panel message).
+- [ ] While reading, the bubble ✕ is hidden (can't fake-cancel).
+
+## Self-Review
+
+- §6 file-summary → panel (chip + take as messages) → Task 1 (+ 📎 filename "chip"; styled chip deferred YAGNI). ✓
+- §6 privacy disclosure (file → non-local model) → Task 2. ✓
+- §6 drag-over affordance → Task 3. ✓
+- §6 drop honesty (>5 files, skipped names) → Task 4 Step 1. ✓
+- §6 non-dismissible pending + dial timeout → Task 4 Steps 2-3. ✓
+- §9 thinking mascot motion → Task 5 (talk-while-streaming explicitly deferred — pet lacks the stream signal). ✓
+- Integration risk surfaced, not hidden: Task 1 Step 1 + Task 2 Step 1 are real-code verification steps with explicit stop conditions (don't-guess), because the channel-write-vs-read pairing and the local-model helper must be confirmed against current code. These are verification gates, not placeholders.
+- i18n parity: every new user-visible string (Task 2) adds both en + zh-TW keys.
+- Bounded-read safety caps preserved (Global Constraints + Task 4 wording).

--- a/docs/superpowers/specs/2026-06-25-mur-pet-chat-escalation-redesign.md
+++ b/docs/superpowers/specs/2026-06-25-mur-pet-chat-escalation-redesign.md
@@ -1,0 +1,88 @@
+# MUR Desktop Pet — Chat & Interaction Redesign
+
+**Date:** 2026-06-25
+**Status:** Design — pending implementation plan
+**Scope:** `mur-hub-gui` desktop pet (per-agent always-on-top macOS mascot, Tauri 2 + React/Vite)
+
+## 1. Problem
+
+Two reported bugs, plus a broader "make the pet chat the best it can be" ask backed by 2025-2026 desktop-companion UX research.
+
+- **Bug 1 — cramped file-summary bubble.** Dropping a text file shows the agent's summary in a bubble trapped inside the 200×200 pet window (`pet.css:151-172`). After `max-width:188px` minus padding, the text column is ~110-120px; CJK (no spaces) breaks to 3-4 glyphs/line. It's a window-size problem, not a font problem — no CSS escapes a 200px window (`pet.css:2-6` documents that anything painted outside is clipped).
+- **Bug 2 — double-jump.** Double-clicking the pet raises the **Hub dashboard AND** the chat window. `pet_open_chat` (`pet/mod.rs:270-280`) calls `dashboard.show()+set_focus()` only to use the dashboard as an event relay that then opens the chat window. The relay is unnecessary.
+
+## 2. Goals / Non-goals
+
+**Goals:** a coherent glance→panel→full escalation model; both bugs fixed at the root; CJK-correct and accessible by default; honest about where dropped data goes; one consistent material language.
+
+**Non-goals (explicit YAGNI):** frontend-stack rewrite (React/Vite/Tauri stays — every issue is CSS + window logic); `tauri-nspanel` native shim (deferred, see §5); voice; RTL; pet restore-on-restart; first-run tutorial; live display-disconnect handling; fullscreen-Space float guarantees. Rationale per finding in §10.
+
+## 3. The escalation model
+
+Three states; the lazy insight is that the panel **is the existing chat window, resized** — no new chat surface to build.
+
+1. **Glance bubble** — on the pet. Short ambient one-liners only (status, nudges). Never file summaries, never conversations.
+2. **Compact chat panel** — the existing `chat-{agent}` window opened small (~380×520), anchored beside the pet. Full `AgentChatWindow`/`ChatTab` inside (history + composer + streaming) — zero new UI.
+3. **Full** — same window, "expand" button → 780×660.
+
+> `// ponytail: one window, two sizes — not a separate panel window + a separate full window.`
+
+## 4. Window topology & positioning
+
+- **Pet window** grows from 200×200 to **~300×260** so the bubble has room. Sprite stays 160px anchored bottom-center; transparent non-sprite areas pass clicks through (`pointer-events:none` on root, `auto` on sprite + bubble). `body.pet-window` already transparent.
+- **Panel** = `chat-{agent}` window. New compact default size + the existing 780×660 reachable via expand.
+- **Anchoring (REQUIRED — currently missing).** `open_chat_window` sets no position → Tauri centers on the **primary** monitor, so the panel never lands by the pet, and lands on the wrong screen in multi-display setups. Fix: before `show()`, read the pet window's `outer_position()` + `outer_size()` and its monitor, place the panel adjacent (default to the left of the pet; flip right if it would cross the monitor edge), clamp into the monitor work area. Pass the agent/pet label into `open_chat_window` so it can find the pet. (`chat_window.rs:27-64`)
+- **Z-order (REQUIRED).** The pet is `always_on_top`; the chat window is not (`pet/mod.rs:176`). An anchored panel would be painted *under* the pet and lose clicks in the overlap. Fix: give the panel `always_on_top(true)` and raise it after the pet.
+- **Off-screen clamp on spawn.** `pet_spawn_at` positions at the raw drop point with no bounds check (`pet/mod.rs:165-181`); a corner drop clips the pet, worse at 300×260. Clamp x/y into the work area of the monitor under the drop point (reuse the `primary_monitor` fallback pattern from `lib.rs:118`).
+
+## 5. Focus / double-jump fix
+
+`pet_open_chat` calls `open_chat_window` **directly (Rust→Rust)** — no dashboard `show()/set_focus()`, no event relay. The `draft` reaches the chat window via a window-targeted event after it opens. The panel is shown **without `set_focus()`** so it never pulls focus from the user's foreground app. This removes the double-jump at the root.
+
+> `// ponytail: no tauri-nspanel dependency in v1. The focus-steal came from explicit dashboard.show()+set_focus(); removing those fixes the reported bug. Add a non-activating NSPanel only if testing shows residual focus-steal (keyboard-into-panel, cmd-tab exclusion).`
+
+## 6. File-drop redesign
+
+- **Summary leaves the bubble.** On drop: open the panel, post the dropped file(s) as a **chip**, and stream the agent's take as a real assistant message you can reply to. The bubble shows only a transient `📄 reading… → ✓ opened`. Bug 1 disappears — summaries live in the roomy panel. (`pet/mod.rs:424-461`)
+- **Drag-over affordance.** Today there is zero feedback that the pet is a drop target (`lib.rs:259-288` handles only `Drop`; no `Enter/Over/Leave`, no CSS). Add webview `onDragOver/onDragLeave/onDrop` on `.pet-root` toggling a `.pet-root--drag` highlight (ring/glow + slight scale). The real drop still flows through the existing Tauri `DragDrop` path; the DOM handlers are highlight-only. Clear the highlight on the drop listener too.
+- **Privacy disclosure.** Dropped file *contents* (up to 256KB/file) are sent via A2A `message/send` to the agent's model — commonly a **cloud** model — with no disclosure (`pet/mod.rs:434-461`). For a local-first product this is a footgun (`.env` is in the text allowlist). When the resolved model is non-local, the reading bubble / chat draft header states e.g. "Sending file to \<provider>…". No consent dialog (YAGNI) — disclosure only.
+- **Drop honesty.** `>5` files: the 6th is silently dropped (`.take(PET_DROP_MAX_FILES)`, `pet/mod.rs:366`); `skipped` collapses three reasons (non-text / unreadable / over-budget) into a bare count. Make the count reflect truncation and surface skipped filenames in the chat draft (already opened), not just a number in the tiny bubble.
+- **Non-dismissible pending bubble.** The `Reading…` bubble has a ✕ that doesn't cancel the in-flight dial (`pet/mod.rs:437`, no cancellation token); a fresh result bubble pops after the user dismissed it. Make the pending bubble non-dismissible (spinner, dwell governed by the promise not a timer); clear it when settled. True cancellation deferred. Add a `tokio::time::timeout` (~45s, under the 60s dwell) so a hung runtime yields "(timed out reaching \<agent>)".
+
+## 7. Bubble (glance state) correctness
+
+- **CJK-safe typography** on bubble + panel text: `line-height:1.7`, `text-align:left` (never justify), `max-width:~34em`, `overflow-wrap:anywhere` (replace the legacy `word-break:break-word` at `pet.css:192`, which also fixes long-URL overflow).
+- **`document.documentElement.lang = lang`** — `index.html` hardcodes `lang="en"` and nothing syncs it on language switch (`i18n/index.tsx:40`). WebKit uses `lang` to choose Han glyph variants (TC vs SC/JP) and CJK line-breaking. **One line, directly improves the reported CJK rendering.** Font stack is already CJK-capable (PingFang TC / JhengHei, `primitives.css:25`) — no change there.
+- **Contrast / hit-targets:** bubble close button resting color → `--text-secondary` (currently `--text-tertiary`, likely fails 4.5:1); nudge close + menu padding toward the 24px floor where it still fits the window.
+
+## 8. Interaction & accessibility
+
+- **Single-click opens the panel** (primary action; research: double-click is "a relic"). Double-click becomes the redundant "expand to full" shortcut. The greeting-wave moves to spawn/hover.
+- **Keyboard-operable sprite.** The sprite is a plain `<div>` — no `tabIndex`, `role`, or key handler; the pet is 100% keyboard/VoiceOver-inoperable (`PetApp.tsx:247-254`). Make it a real button: `role="button"`, `tabIndex={0}`, `aria-label={t('pet.chat')}`, `onKeyDown` Enter/Space → open chat. Set `aria-hidden` on the inner `PetFace`/img so the button label isn't double-announced.
+- **Escape also closes the context menu** (today it only closes the bubble, `PetApp.tsx:135-143`); focus the first menu item on open. Full arrow-key roving skipped — Tab already moves between the `<button>`s.
+- **Mute persistence + indicator.** Mute is React-state only; every reload/respawn/Hide-round-trip silently un-mutes, and the state is invisible (`PetApp.tsx:193`). Persist to `localStorage` keyed by agent; add a 🔇 corner badge on the sprite.
+
+## 9. Mascot liveness, material, lifecycle, deletion
+
+- **Liveness.** 12 expression slots exist but only idle/smile/peek animate; `thinking` (agent working) and `talk_open/close` (streaming) render frozen (`PetFace.tsx:274-275`). Add a subtle pulse while a dial is pending and a ~250ms mouth-flap while a reply streams (driver already sets `expression` via the `pet-expression` event). Honor `prefers-reduced-motion` (global catch-all already covers it; keep new states under it).
+- **Material consistency (faux-glass).** Chat uses native HudWindow vibrancy; the bubble + menu are flat opaque `--surface-card` (`pet.css:160-171, 90-100`). A webview can't get NSVisualEffectView, so use CSS faux-glass: `background: color-mix(... 78%, transparent)` + `backdrop-filter: blur(18px) saturate(140%)` + translucent border; the bubble tail must switch to the same translucent fill.
+- **Entrance flash.** The pet builds visible immediately; a transparent webview briefly paints an opaque square before React mounts. Add `.visible(false)` + `show()` after build, mirroring `chat_window.rs:47,61`.
+- **Hide-1h → Rust timer.** `handleHide1h` uses a JS `setTimeout(...,1h)` that dies on webview reload → pet hidden forever with no decorated UI to recover (`PetApp.tsx:203-209`). Move to a `pet_hide_for(agent, secs)` command that `spawn`s a `sleep().then(show())`, no-op if the pet was closed meanwhile. Drop the JS timer.
+- **Deletion (ponytail).** `pet_position.json` is **write-only dead code** — written on every move, never read back; `display_id` is always `None`; the implied "restore on restart" was never built and is intentionally not wanted. Delete `PetPosition`, the file writes, `pet_reposition`, and the `Moved` listener (`pet/mod.rs:30-36,230-239`, `PetApp.tsx:116-120`). Less code, identical behavior.
+
+## 10. Phasing (PR-sized, each independently shippable)
+
+- **Phase 1 — reported bugs + escalation foundation.** Double-jump fix (§5); file-summary → panel (§6 core); panel anchoring + z-order + compact size + expand (§4); pet window enlarge + CJK typography + `html lang` (§4, §7); single-click opens panel (§8). *Ships both screenshots fixed.*
+- **Phase 2 — hardening + cheap wins.** Keyboard sprite + Escape-menu + contrast (§8); mute persist + badge (§8); faux-glass + entrance flash (§9); off-screen clamp (§4); Hide-1h → Rust (§9); delete dead `pet_position` (§9).
+- **Phase 3 — file-drop UX + liveness.** Drag-over affordance, privacy disclosure, drop honesty, non-dismissible pending bubble + timeout (§6); thinking/talking motion (§9).
+
+## 11. Testing
+
+Per ponytail, one runnable check per piece of non-trivial logic:
+- **Rust unit tests** for the pure geometry: panel anchoring (adjacent placement, edge-flip, work-area clamp) and off-screen spawn clamp — table-driven over synthetic monitor rects.
+- **Manual / live E2E** for window behavior that needs a real WindowServer: double-click no longer raises the Hub; panel lands next to the pet on the pet's monitor; panel sits above the pet; CJK bubble renders multi-char lines; drag-over highlight; file-drop streams into the panel; mute survives reload.
+- **Visual** check of faux-glass in light/dark and the entrance-flash fix.
+
+## 12. Deferred / YAGNI (considered and rejected)
+
+`tauri-nspanel` non-activating panel (only if focus-steal persists); voice; RTL/`dir` support (no RTL locale ships); pet restore-on-restart (intentional "every start is user-initiated"); live display-disconnect handling (macOS reparents + Return-to-Hub covers it); fullscreen-Space float guarantees (needs `NSWindow.collectionBehavior` beyond Tauri); generic pet event-loop reaper (self-heals on respawn via dropped `oneshot::Sender`); per-animation reduced-motion guards (global catch-all already covers them); first-run tutorial (folded into spawn/hover greeting); byte/char unit-mixing in the drop budget (guards different things, harmless).

--- a/mur-hub-gui/src-tauri/src/chat_window.rs
+++ b/mur-hub-gui/src-tauri/src/chat_window.rs
@@ -79,9 +79,12 @@ pub fn open_chat_window(agent_name: String, app: AppHandle) -> Result<(), String
     );
 
     // Anchor next to the pet (if it exists) on the pet's monitor.
+    // pet.outer_position/outer_size are PHYSICAL; PANEL_W/H are LOGICAL.
+    // Convert with the pet window's scale factor before calling anchor_panel.
     if let Some(pet) = app.get_webview_window(&pet_label(&agent_name))
         && let (Ok(pp), Ok(ps)) = (pet.outer_position(), pet.outer_size())
     {
+        let scale = pet.scale_factor().unwrap_or(1.0);
         let pet_rect = crate::geometry::Rect {
             x: pp.x,
             y: pp.y,
@@ -89,7 +92,9 @@ pub fn open_chat_window(agent_name: String, app: AppHandle) -> Result<(), String
             h: ps.height as i32,
         };
         let mon = crate::pet::monitor_rect_for_point(&app, pp.x, pp.y);
-        let (x, y) = crate::geometry::anchor_panel(pet_rect, (PANEL_W, PANEL_H), mon);
+        let panel_w = (PANEL_W as f64 * scale) as i32;
+        let panel_h = (PANEL_H as f64 * scale) as i32;
+        let (x, y) = crate::geometry::anchor_panel(pet_rect, (panel_w, panel_h), mon);
         let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
     }
 

--- a/mur-hub-gui/src-tauri/src/chat_window.rs
+++ b/mur-hub-gui/src-tauri/src/chat_window.rs
@@ -27,7 +27,13 @@ fn pet_label(agent_name: &str) -> String {
     // Same safe-name transform as `label`, with the pet prefix.
     let safe: String = agent_name
         .chars()
-        .map(|c| if c.is_alphanumeric() || c == '-' { c } else { '-' })
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
         .collect();
     format!("pet-{}", safe)
 }
@@ -73,15 +79,18 @@ pub fn open_chat_window(agent_name: String, app: AppHandle) -> Result<(), String
     );
 
     // Anchor next to the pet (if it exists) on the pet's monitor.
-    if let Some(pet) = app.get_webview_window(&pet_label(&agent_name)) {
-        if let (Ok(pp), Ok(ps)) = (pet.outer_position(), pet.outer_size()) {
-            let pet_rect = crate::geometry::Rect {
-                x: pp.x, y: pp.y, w: ps.width as i32, h: ps.height as i32,
-            };
-            let mon = crate::pet::monitor_rect_for_point(&app, pp.x, pp.y);
-            let (x, y) = crate::geometry::anchor_panel(pet_rect, (PANEL_W, PANEL_H), mon);
-            let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
-        }
+    if let Some(pet) = app.get_webview_window(&pet_label(&agent_name))
+        && let (Ok(pp), Ok(ps)) = (pet.outer_position(), pet.outer_size())
+    {
+        let pet_rect = crate::geometry::Rect {
+            x: pp.x,
+            y: pp.y,
+            w: ps.width as i32,
+            h: ps.height as i32,
+        };
+        let mon = crate::pet::monitor_rect_for_point(&app, pp.x, pp.y);
+        let (x, y) = crate::geometry::anchor_panel(pet_rect, (PANEL_W, PANEL_H), mon);
+        let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
     }
 
     win.show().map_err(|e| e.to_string())?;

--- a/mur-hub-gui/src-tauri/src/chat_window.rs
+++ b/mur-hub-gui/src-tauri/src/chat_window.rs
@@ -5,6 +5,10 @@
 use tauri::window::{Effect, EffectState, EffectsBuilder};
 use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 
+/// Compact ("panel") default size; the user can expand to full via the header.
+const PANEL_W: i32 = 380;
+const PANEL_H: i32 = 520;
+
 fn label(agent_name: &str) -> String {
     let safe: String = agent_name
         .chars()
@@ -19,6 +23,15 @@ fn label(agent_name: &str) -> String {
     format!("chat-{}", safe)
 }
 
+fn pet_label(agent_name: &str) -> String {
+    // Same safe-name transform as `label`, with the pet prefix.
+    let safe: String = agent_name
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' { c } else { '-' })
+        .collect();
+    format!("pet-{}", safe)
+}
+
 fn urlenc(s: &str) -> String {
     s.chars().map(|c| if c == ' ' { '+' } else { c }).collect()
 }
@@ -27,10 +40,11 @@ fn urlenc(s: &str) -> String {
 pub fn open_chat_window(agent_name: String, app: AppHandle) -> Result<(), String> {
     let lbl = label(&agent_name);
 
-    // Single-instance guard: bring existing window to front.
+    // Single-instance guard: just show (do NOT set_focus — that steals focus
+    // from the user's foreground app and previously raised the Hub too).
     if let Some(win) = app.get_webview_window(&lbl) {
         let _ = win.show();
-        let _ = win.set_focus();
+        let _ = win.set_focus(); // existing window: user explicitly re-opened it
         return Ok(());
     }
 
@@ -38,17 +52,17 @@ pub fn open_chat_window(agent_name: String, app: AppHandle) -> Result<(), String
 
     let win = WebviewWindowBuilder::new(&app, &lbl, WebviewUrl::App(url.into()))
         .title(&agent_name)
-        .inner_size(780.0, 660.0)
-        .min_inner_size(560.0, 480.0)
+        .inner_size(PANEL_W as f64, PANEL_H as f64)
+        .min_inner_size(320.0, 420.0)
         .resizable(true)
         .decorations(false)
         .transparent(true)
         .shadow(true)
+        .always_on_top(true) // sit above the always-on-top pet
         .visible(false)
         .build()
         .map_err(|e| e.to_string())?;
 
-    // Apply macOS vibrancy — HudWindow gives the dark frosted-glass look.
     #[cfg(target_os = "macos")]
     let _ = win.set_effects(
         EffectsBuilder::new()
@@ -58,7 +72,18 @@ pub fn open_chat_window(agent_name: String, app: AppHandle) -> Result<(), String
             .build(),
     );
 
-    win.show().map_err(|e| e.to_string())?;
+    // Anchor next to the pet (if it exists) on the pet's monitor.
+    if let Some(pet) = app.get_webview_window(&pet_label(&agent_name)) {
+        if let (Ok(pp), Ok(ps)) = (pet.outer_position(), pet.outer_size()) {
+            let pet_rect = crate::geometry::Rect {
+                x: pp.x, y: pp.y, w: ps.width as i32, h: ps.height as i32,
+            };
+            let mon = crate::pet::monitor_rect_for_point(&app, pp.x, pp.y);
+            let (x, y) = crate::geometry::anchor_panel(pet_rect, (PANEL_W, PANEL_H), mon);
+            let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
+        }
+    }
 
+    win.show().map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/mur-hub-gui/src-tauri/src/geometry.rs
+++ b/mur-hub-gui/src-tauri/src/geometry.rs
@@ -47,12 +47,22 @@ pub fn clamp_into(pos: (i32, i32), size: (i32, i32), mon: Rect) -> (i32, i32) {
 mod tests {
     use super::*;
 
-    const MON: Rect = Rect { x: 0, y: 0, w: 1440, h: 900 };
+    const MON: Rect = Rect {
+        x: 0,
+        y: 0,
+        w: 1440,
+        h: 900,
+    };
 
     #[test]
     fn anchors_to_left_of_pet_when_room() {
         // pet at x=800; panel 380 wide fits to the left.
-        let pet = Rect { x: 800, y: 100, w: 300, h: 260 };
+        let pet = Rect {
+            x: 800,
+            y: 100,
+            w: 300,
+            h: 260,
+        };
         let (x, y) = anchor_panel(pet, (380, 520), MON);
         assert_eq!(x, 800 - 8 - 380); // 412
         assert_eq!(y, 100);
@@ -61,7 +71,12 @@ mod tests {
     #[test]
     fn flips_right_when_pet_near_left_edge() {
         // pet hugging the left edge: no room on the left, open to the right.
-        let pet = Rect { x: 10, y: 100, w: 300, h: 260 };
+        let pet = Rect {
+            x: 10,
+            y: 100,
+            w: 300,
+            h: 260,
+        };
         let (x, _) = anchor_panel(pet, (380, 520), MON);
         assert_eq!(x, 10 + 300 + 8); // 318
     }
@@ -69,7 +84,12 @@ mod tests {
     #[test]
     fn clamps_y_so_panel_bottom_stays_on_screen() {
         // pet low on screen: panel top would push the 520-tall panel off bottom.
-        let pet = Rect { x: 800, y: 700, w: 300, h: 260 };
+        let pet = Rect {
+            x: 800,
+            y: 700,
+            w: 300,
+            h: 260,
+        };
         let (_, y) = anchor_panel(pet, (380, 520), MON);
         assert_eq!(y, 900 - 520); // 380
     }
@@ -86,7 +106,12 @@ mod tests {
 
     #[test]
     fn window_larger_than_monitor_pins_to_origin() {
-        let tiny = Rect { x: 0, y: 0, w: 200, h: 150 };
+        let tiny = Rect {
+            x: 0,
+            y: 0,
+            w: 200,
+            h: 150,
+        };
         assert_eq!(clamp_into((50, 50), (300, 260), tiny), (0, 0));
     }
 }

--- a/mur-hub-gui/src-tauri/src/geometry.rs
+++ b/mur-hub-gui/src-tauri/src/geometry.rs
@@ -1,0 +1,92 @@
+//! Pure window-placement geometry for the desktop pet and its chat panel.
+//! Deliberately free of Tauri types so it unit-tests without the GUI stack.
+
+/// A screen rectangle in PHYSICAL pixels, origin top-left.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub w: i32,
+    pub h: i32,
+}
+
+impl Rect {
+    pub fn right(&self) -> i32 {
+        self.x + self.w
+    }
+    pub fn bottom(&self) -> i32 {
+        self.y + self.h
+    }
+}
+
+/// Horizontal gap between the pet and its panel, physical px.
+const PANEL_GAP: i32 = 8;
+
+/// Place a `panel`-sized window adjacent to `pet`, preferring the LEFT side.
+/// Flips to the right of the pet if the left placement would start before the
+/// monitor's left edge. The result is always clamped fully inside `mon`.
+pub fn anchor_panel(pet: Rect, panel: (i32, i32), mon: Rect) -> (i32, i32) {
+    let (pw, ph) = panel;
+    let left_x = pet.x - PANEL_GAP - pw;
+    let right_x = pet.right() + PANEL_GAP;
+    let x = if left_x >= mon.x { left_x } else { right_x };
+    // Align the panel's top with the pet's top, then clamp.
+    clamp_into((x, pet.y), (pw, ph), mon)
+}
+
+/// Clamp a window of `size` at `pos` so it stays fully inside `mon`.
+/// If the window is larger than the monitor, it pins to the monitor origin.
+pub fn clamp_into(pos: (i32, i32), size: (i32, i32), mon: Rect) -> (i32, i32) {
+    let (w, h) = size;
+    let max_x = (mon.right() - w).max(mon.x);
+    let max_y = (mon.bottom() - h).max(mon.y);
+    (pos.0.clamp(mon.x, max_x), pos.1.clamp(mon.y, max_y))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MON: Rect = Rect { x: 0, y: 0, w: 1440, h: 900 };
+
+    #[test]
+    fn anchors_to_left_of_pet_when_room() {
+        // pet at x=800; panel 380 wide fits to the left.
+        let pet = Rect { x: 800, y: 100, w: 300, h: 260 };
+        let (x, y) = anchor_panel(pet, (380, 520), MON);
+        assert_eq!(x, 800 - 8 - 380); // 412
+        assert_eq!(y, 100);
+    }
+
+    #[test]
+    fn flips_right_when_pet_near_left_edge() {
+        // pet hugging the left edge: no room on the left, open to the right.
+        let pet = Rect { x: 10, y: 100, w: 300, h: 260 };
+        let (x, _) = anchor_panel(pet, (380, 520), MON);
+        assert_eq!(x, 10 + 300 + 8); // 318
+    }
+
+    #[test]
+    fn clamps_y_so_panel_bottom_stays_on_screen() {
+        // pet low on screen: panel top would push the 520-tall panel off bottom.
+        let pet = Rect { x: 800, y: 700, w: 300, h: 260 };
+        let (_, y) = anchor_panel(pet, (380, 520), MON);
+        assert_eq!(y, 900 - 520); // 380
+    }
+
+    #[test]
+    fn clamp_pulls_offscreen_window_in() {
+        // bottom-right overflow.
+        assert_eq!(clamp_into((1400, 880), (300, 260), MON), (1140, 640));
+        // negative origin.
+        assert_eq!(clamp_into((-50, -30), (300, 260), MON), (0, 0));
+        // already in-bounds is unchanged.
+        assert_eq!(clamp_into((100, 100), (300, 260), MON), (100, 100));
+    }
+
+    #[test]
+    fn window_larger_than_monitor_pins_to_origin() {
+        let tiny = Rect { x: 0, y: 0, w: 200, h: 150 };
+        assert_eq!(clamp_into((50, 50), (300, 260), tiny), (0, 0));
+    }
+}

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod brain_badge;
 pub mod chat;
 pub mod chat_window;
+mod geometry;
 pub mod cli_tools;
 pub mod companion;
 pub mod detail;

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -8,11 +8,11 @@
 pub mod brain_badge;
 pub mod chat;
 pub mod chat_window;
-mod geometry;
 pub mod cli_tools;
 pub mod companion;
 pub mod detail;
 pub mod export_muragent;
+mod geometry;
 pub mod hitl;
 pub mod import_muragent;
 pub mod mcp_skills;

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -288,16 +288,12 @@ pub fn pet_list(state: State<'_, PetState>) -> Vec<String> {
     state.0.lock().unwrap().keys().cloned().collect()
 }
 
-/// Bring the Hub dashboard to the front and ask it to open `agent_name`'s
-/// conversation. `draft`, when present, is pre-filled into the chat input
-/// (used by file-drop). The dashboard webview listens for the `pet-open-chat`
-/// event and calls `openConversation`.
+/// Open `agent_name`'s chat panel. The (hidden) dashboard webview relays the
+/// `pet-open-chat` event to `open_chat_window` and stages any `draft`; we must
+/// NOT show/focus the dashboard here — that caused the Hub to "jump" alongside
+/// the chat window.
 #[tauri::command]
 pub fn pet_open_chat(agent_name: String, draft: Option<String>, app: AppHandle) {
-    if let Some(dash) = app.get_webview_window("dashboard") {
-        let _ = dash.show();
-        let _ = dash.set_focus();
-    }
     let _ = app.emit(
         "pet-open-chat",
         serde_json::json!({ "agent": agent_name, "draft": draft }),

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -198,8 +198,23 @@ pub fn pet_spawn_at(
     // The explicit drop point always wins over a previously saved position — a
     // stale save could point at a display that no longer exists. Persistence is
     // left to pet_reposition, the single writer.
-    let mon = monitor_rect_for_point(&app, screen_x as i32, screen_y as i32);
-    let (cx, cy) = geometry::clamp_into((screen_x as i32, screen_y as i32), (PET_W, PET_H), mon);
+    //
+    // DOM drop coords (screen_x/y) and PET_W/PET_H are LOGICAL; the geometry
+    // module + monitor rects are PHYSICAL. Convert with the monitor scale.
+    // ponytail: uniform-scale assumption (primary monitor's factor); mixed-DPI
+    // multi-monitor would need per-monitor scale, rare — revisit if it bites.
+    let scale = app
+        .primary_monitor()
+        .ok()
+        .flatten()
+        .map(|m| m.scale_factor())
+        .unwrap_or(1.0);
+    let phys_x = (screen_x * scale) as i32;
+    let phys_y = (screen_y * scale) as i32;
+    let mon = monitor_rect_for_point(&app, phys_x, phys_y);
+    let pet_w = (PET_W as f64 * scale) as i32;
+    let pet_h = (PET_H as f64 * scale) as i32;
+    let (cx, cy) = geometry::clamp_into((phys_x, phys_y), (pet_w, pet_h), mon);
 
     let url_path = format!("index.html#/pet/{}", urlenc(&agent_name));
 
@@ -299,9 +314,10 @@ pub fn pet_list(state: State<'_, PetState>) -> Vec<String> {
 }
 
 /// Open `agent_name`'s chat panel. The (hidden) dashboard webview relays the
-/// `pet-open-chat` event to `open_chat_window` and stages any `draft`; we must
-/// NOT show/focus the dashboard here — that caused the Hub to "jump" alongside
-/// the chat window.
+/// `pet-open-chat` event to `open_chat_window`. NOTE: the `draft` is emitted
+/// but not yet consumed by the chat composer (file-drop draft prefill is
+/// deferred to Phase 3); do NOT show/focus the dashboard here — that caused
+/// the Hub to "jump" alongside the chat window.
 #[tauri::command]
 pub fn pet_open_chat(agent_name: String, draft: Option<String>, app: AppHandle) {
     let _ = app.emit(

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -58,9 +58,9 @@ fn monitor_rect_for_point(app: &AppHandle, x: i32, y: i32) -> geometry::Rect {
         }) {
             return to_rect(m);
         }
-        // Fall back to primary monitor (first in the list).
-        if let Some(m) = mons.first() {
-            return to_rect(m);
+        // Fall back to the primary monitor.
+        if let Ok(Some(m)) = app.primary_monitor() {
+            return to_rect(&m);
         }
     }
     // Last-resort fallback: a sensible 1440×900 origin rect.
@@ -306,7 +306,7 @@ pub fn pet_open_chat(agent_name: String, draft: Option<String>, app: AppHandle) 
 
 // ─── File drop ─────────────────────────────────────────────────────────────
 
-/// Physical-pixel pet window dimensions (matches the 300×260 inner_size in pet_spawn_at).
+/// Physical-pixel pet window size; the single source for both inner_size and clamp_into.
 const PET_W: i32 = 300;
 const PET_H: i32 = 260;
 

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -49,7 +49,12 @@ pub(crate) fn monitor_rect_for_point(app: &AppHandle, x: i32, y: i32) -> geometr
     let to_rect = |m: &tauri::Monitor| {
         let p = m.position();
         let s = m.size();
-        geometry::Rect { x: p.x, y: p.y, w: s.width as i32, h: s.height as i32 }
+        geometry::Rect {
+            x: p.x,
+            y: p.y,
+            w: s.width as i32,
+            h: s.height as i32,
+        }
     };
     if let Ok(mons) = app.available_monitors() {
         if let Some(m) = mons.iter().find(|m| {
@@ -64,7 +69,12 @@ pub(crate) fn monitor_rect_for_point(app: &AppHandle, x: i32, y: i32) -> geometr
         }
     }
     // Last-resort fallback: a sensible 1440×900 origin rect.
-    geometry::Rect { x: 0, y: 0, w: 1440, h: 900 }
+    geometry::Rect {
+        x: 0,
+        y: 0,
+        w: 1440,
+        h: 900,
+    }
 }
 
 fn pet_position_path(agent_name: &str) -> PathBuf {

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -45,7 +45,7 @@ fn mur_home() -> PathBuf {
 
 /// Physical-pixel rect of the monitor containing `(x, y)`, falling back to the
 /// primary monitor, then a 1440×900 origin rect if no monitor is reported.
-fn monitor_rect_for_point(app: &AppHandle, x: i32, y: i32) -> geometry::Rect {
+pub(crate) fn monitor_rect_for_point(app: &AppHandle, x: i32, y: i32) -> geometry::Rect {
     let to_rect = |m: &tauri::Monitor| {
         let p = m.position();
         let s = m.size();

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 use tokio::sync::oneshot;
 
+use crate::geometry;
+
 // ─── Managed state ──────────────────────────────────────────────────────────
 
 pub struct PetHandle {
@@ -39,6 +41,30 @@ fn mur_home() -> PathBuf {
     std::env::var("MUR_HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".mur"))
+}
+
+/// Physical-pixel rect of the monitor containing `(x, y)`, falling back to the
+/// primary monitor, then a 1440×900 origin rect if no monitor is reported.
+fn monitor_rect_for_point(app: &AppHandle, x: i32, y: i32) -> geometry::Rect {
+    let to_rect = |m: &tauri::Monitor| {
+        let p = m.position();
+        let s = m.size();
+        geometry::Rect { x: p.x, y: p.y, w: s.width as i32, h: s.height as i32 }
+    };
+    if let Ok(mons) = app.available_monitors() {
+        if let Some(m) = mons.iter().find(|m| {
+            let r = to_rect(m);
+            x >= r.x && x < r.right() && y >= r.y && y < r.bottom()
+        }) {
+            return to_rect(m);
+        }
+        // Fall back to primary monitor (first in the list).
+        if let Some(m) = mons.first() {
+            return to_rect(m);
+        }
+    }
+    // Last-resort fallback: a sensible 1440×900 origin rect.
+    geometry::Rect { x: 0, y: 0, w: 1440, h: 900 }
 }
 
 fn pet_position_path(agent_name: &str) -> PathBuf {
@@ -162,25 +188,24 @@ pub fn pet_spawn_at(
     // The explicit drop point always wins over a previously saved position — a
     // stale save could point at a display that no longer exists. Persistence is
     // left to pet_reposition, the single writer.
-    let pos = PetPosition {
-        x: screen_x,
-        y: screen_y,
-        display_id: None,
-    };
+    let mon = monitor_rect_for_point(&app, screen_x as i32, screen_y as i32);
+    let (cx, cy) = geometry::clamp_into((screen_x as i32, screen_y as i32), (PET_W, PET_H), mon);
 
     let url_path = format!("index.html#/pet/{}", urlenc(&agent_name));
 
-    WebviewWindowBuilder::new(&app, &label, WebviewUrl::App(url_path.into()))
+    let win = WebviewWindowBuilder::new(&app, &label, WebviewUrl::App(url_path.into()))
         .transparent(true)
         .decorations(false)
         .always_on_top(true)
         .skip_taskbar(true)
         .visible_on_all_workspaces(true)
         .shadow(false)
-        .inner_size(200.0, 200.0)
-        .position(pos.x, pos.y)
+        .inner_size(PET_W as f64, PET_H as f64)
+        .visible(false) // Task 6: avoid opaque-square entrance flash
         .build()
         .map_err(|e| e.to_string())?;
+    let _ = win.set_position(tauri::PhysicalPosition::new(cx, cy));
+    let _ = win.show();
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     pets.insert(
@@ -280,6 +305,10 @@ pub fn pet_open_chat(agent_name: String, draft: Option<String>, app: AppHandle) 
 }
 
 // ─── File drop ─────────────────────────────────────────────────────────────
+
+/// Physical-pixel pet window dimensions (matches the 300×260 inner_size in pet_spawn_at).
+const PET_W: i32 = 300;
+const PET_H: i32 = 260;
 
 const PET_DROP_MAX_FILES: usize = 5;
 const PET_DROP_MAX_TOTAL_BYTES: u64 = 2 * 1024 * 1024;

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -165,7 +165,9 @@ export function PetApp() {
 
   function handleMouseUp() {
     if (pressRef.current && Date.now() - clickTimeRef.current < CLICK_MS) {
+      // Greeting expression + open the chat panel (single-click is primary).
       invoke("hub_emit_event", { agentName, eventName: "user.click.pet" }).catch(() => {});
+      void handleChat();
     }
     pressRef.current = null;
   }

--- a/mur-hub-gui/ui/src/components/chat/AgentChatWindow.tsx
+++ b/mur-hub-gui/ui/src/components/chat/AgentChatWindow.tsx
@@ -89,11 +89,10 @@ export function AgentChatWindow() {
         </div>
         <span className={`cw-title__status cw-title__status--${status}`} title={status} />
         <button
-          className="cw-title__dot"
+          className="cw-title__expand"
           onClick={expandToFull}
           title={t("chat.expand")}
           aria-label={t("chat.expand")}
-          style={{ background: "none", border: "none", cursor: "pointer", padding: "0 4px", fontSize: "14px", lineHeight: 1, color: "var(--text-secondary, #888)" }}
         >⤢</button>
       </div>
 

--- a/mur-hub-gui/ui/src/components/chat/AgentChatWindow.tsx
+++ b/mur-hub-gui/ui/src/components/chat/AgentChatWindow.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window";
 import { listen } from "@tauri-apps/api/event";
 import type { AgentEntry, AgentRuntimeStatus, RuntimeState } from "../../types";
 import { ChatTab } from "../ChatTab";
 import { ChatChannelRail } from "./ChatChannelRail";
 import { TaskPill } from "./TaskPill";
+import { useT } from "../../i18n";
 
 function agentNameFromHash(): string {
   const hash = window.location.hash; // #/chat/<name>
@@ -20,9 +21,13 @@ function runtimeStatus(rt: RuntimeState | undefined): "running" | "failed" | "id
 
 export function AgentChatWindow() {
   const agentName = agentNameFromHash();
+  const { t } = useT();
   const [displayName, setDisplayName] = useState(agentName);
   const [status, setStatus] = useState<"running" | "failed" | "idle">("idle");
   const [activeChannelId, setActiveChannelId] = useState<string | null>(null);
+
+  const expandToFull = () =>
+    void getCurrentWindow().setSize(new LogicalSize(780, 660)).catch(() => {});
 
   // Load display name from agent list.
   useEffect(() => {
@@ -83,6 +88,13 @@ export function AgentChatWindow() {
           )}
         </div>
         <span className={`cw-title__status cw-title__status--${status}`} title={status} />
+        <button
+          className="cw-title__dot"
+          onClick={expandToFull}
+          title={t("chat.expand")}
+          aria-label={t("chat.expand")}
+          style={{ background: "none", border: "none", cursor: "pointer", padding: "0 4px", fontSize: "14px", lineHeight: 1, color: "var(--text-secondary, #888)" }}
+        >⤢</button>
       </div>
 
       {/* Body: channel rail + main chat */}

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -73,6 +73,7 @@ export const en = {
   "chat.placeholder": "Message {name}…",
   "chat.send": "Send",
   "chat.stop": "Stop",
+  "chat.expand": "Expand",
   "chat.stopped": "stopped",
   "chat.thinking": "thinking",
   "chat.suggest.0": "What can you help me with?",

--- a/mur-hub-gui/ui/src/i18n/index.tsx
+++ b/mur-hub-gui/ui/src/i18n/index.tsx
@@ -39,6 +39,8 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   const [lang, setLangState] = useState<Lang>(detectDefault);
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, lang);
+    document.documentElement.lang = lang; // WebKit uses this to pick the
+    // correct Han glyph variant (TC vs SC/JP) and CJK line-breaking rules.
   }, [lang]);
   const setLang = (l: Lang) => setLangState(l);
   const t = (k: TranslationKey, vars?: Record<string, string | number>) =>

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -75,6 +75,7 @@ export const zhTW: Table = {
   "chat.placeholder": "傳訊息給 {name}…",
   "chat.send": "送出",
   "chat.stop": "停止",
+  "chat.expand": "放大",
   "chat.stopped": "已停止",
   "chat.thinking": "思考中",
   "chat.suggest.0": "你能幫我做什麼？",

--- a/mur-hub-gui/ui/src/styles/components/chat-window.css
+++ b/mur-hub-gui/ui/src/styles/components/chat-window.css
@@ -56,6 +56,16 @@
 .cw-title__dot--min    { background: #ffbd2e; }
 .cw-title__dot--max    { background: #28c840; }
 
+.cw-title__expand {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--text-secondary, #888);
+}
+
 /* Centered absolutely so traffic lights and status dot stay at edges. */
 .cw-title__info {
   position: absolute;

--- a/mur-hub-gui/ui/src/styles/components/pet.css
+++ b/mur-hub-gui/ui/src/styles/components/pet.css
@@ -166,13 +166,15 @@ body.pet-window {
   top: 2px;
   left: 50%;
   transform: translateX(-50%);
-  max-width: 188px;
-  min-width: 110px;
+  max-width: 260px;
+  min-width: 140px;
   max-height: 150px;
   overflow-y: auto;
   overflow-x: hidden;
-  background: var(--surface-card);
-  border: 1px solid var(--border-line);
+  background: color-mix(in srgb, var(--surface-card) 78%, transparent);
+  -webkit-backdrop-filter: blur(18px) saturate(140%);
+  backdrop-filter: blur(18px) saturate(140%);
+  border: 1px solid color-mix(in srgb, var(--border-line) 60%, transparent);
   border-radius: var(--radius-md);
   padding: var(--space-3) 26px var(--space-3) var(--space-4);
   box-shadow: var(--shadow-pop);
@@ -191,14 +193,15 @@ body.pet-window {
   left: 50%;
   transform: translateX(-50%);
   border: 8px solid transparent;
-  border-top-color: var(--surface-card);
+  border-top-color: color-mix(in srgb, var(--surface-card) 78%, transparent);
   border-bottom: none;
 }
 .pet-bubble-text {
   font-size: var(--text-sm);
   color: var(--text-primary);
-  line-height: 1.5;
-  word-break: break-word;
+  line-height: 1.7;            /* CJK needs more leading */
+  text-align: left;           /* never justify CJK */
+  overflow-wrap: anywhere;    /* replaces non-standard word-break: break-word */
 }
 .pet-bubble-progress {
   height: 2px;

--- a/mur-hub-gui/ui/src/styles/components/pet.css
+++ b/mur-hub-gui/ui/src/styles/components/pet.css
@@ -5,17 +5,26 @@ body.pet-window {
   background: transparent;
 }
 .pet-root {
-  width: 200px;
-  height: 200px;
+  width: 300px;
+  height: 260px;
   background: transparent;
   overflow: visible;
   user-select: none;
   -webkit-user-select: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  pointer-events: none;
 }
+/* Re-enable pointer events only on the actual interactive children. */
+.pet-sprite,
+.pet-bubble,
+.pet-context-menu { pointer-events: auto; }
 .pet-sprite {
   width: 160px;
   height: 160px;
-  margin: 20px auto 0;
+  margin: 0;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## What & why
Redesigns the MUR desktop-pet chat into a **glance bubble → compact anchored panel → full window** escalation model, and fixes the two reported bugs.

**Reported bugs (both fixed + live-verified on Retina):**
1. **Cramped file-summary bubble** — Chinese text broke to 3–4 glyphs/line because the bubble was trapped in the 200×200 pet window. Fixed: pet window enlarged to 300×260, CJK-correct typography (`line-height:1.7`, left-aligned, `overflow-wrap`), `<html lang>` sync (WebKit picks the right Han variant + line-breaking), faux-glass to match the chat window.
2. **Double-jump** — clicking the pet raised the Hub *and* the chat. `pet_open_chat` no longer shows/focuses the dashboard (its hidden relay listener still works); the panel opens without stealing focus.

**Escalation skeleton:** single-click opens the chat panel (the existing `chat-{agent}` window) at a compact size, **anchored beside the pet on the pet's monitor** and **raised above** the always-on-top pet; a ⤢ button expands it to full 780×660. Pure window-placement geometry (`geometry.rs`, anchor + clamp) is unit-tested.

## Scope
- **This PR = Phase 1 implementation** + the design spec + implementation plans for all three phases.
- Phase 2 (a11y, mute persistence, dead-code deletion) and Phase 3 (file-drop→panel via the channel, privacy disclosure, drag affordance, mascot motion) are **planned, not built** — see `docs/superpowers/plans/2026-06-25-pet-chat-escalation-phase{2,3}.md`.
- Spec: `docs/superpowers/specs/2026-06-25-mur-pet-chat-escalation-redesign.md`.

## Notable fix from review
A whole-branch review caught a **HiDPI bug**: positioning used `PhysicalPosition` with logical drop coords + logical size constants, so the pet mis-landed / under-clamped on Retina. Fixed by scaling via `scale_factor()` (commit `19096809`). Validated live — the panel lands precisely adjacent to the pet on a 2× display.

## Verification
- `geometry::` unit tests pass (anchor/clamp incl. edge-flip + off-screen clamp).
- Full Rust build links; `clippy` clean (touched files); `cargo fmt` clean; `tsc`+`vite` build clean. (`mur-hub-gui` is workspace-excluded → built via its own manifest.)
- **Live E2E (computer-use, Retina):** single-click → panel anchored left of the pet, same screen; Hub does **not** jump; compact size; CJK renders multi-char; ⤢ expand works; HiDPI placement precise.

## Deferred (tracked, not regressions)
- File-drop *draft* prefill is a pre-existing dead path (chat window renders outside `ConversationProvider`); the readable take still shows in the bubble. Real file-drop→panel wiring is Phase 3 (via `persist_mobile_exchange`).
- Minor: double-click currently opens (not "expand"); panel can overlap the pet only on a <~400px-wide monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)