### PR TITLE
feat(pet): desktop pet chat escalation — Phase 2 (a11y, mute persistence, dead-code cleanup)

### DIFF
--- a/mur-hub-gui/src-tauri/src/geometry.rs
+++ b/mur-hub-gui/src-tauri/src/geometry.rs
@@ -114,4 +114,19 @@ mod tests {
         };
         assert_eq!(clamp_into((50, 50), (300, 260), tiny), (0, 0));
     }
+
+    #[test]
+    fn anchors_on_a_secondary_monitor_origin() {
+        let mon = Rect { x: 1920, y: 0, w: 1440, h: 900 };
+        let pet = Rect { x: 2000, y: 100, w: 300, h: 260 };
+        let (x, y) = anchor_panel(pet, (380, 520), mon);
+        assert_eq!(x, 2000 + 300 + 8); // 2308, opens right (no room on the left within this monitor)
+        assert_eq!(y, 100);
+    }
+
+    #[test]
+    fn clamps_within_secondary_monitor_bounds() {
+        let mon = Rect { x: 1920, y: 0, w: 1440, h: 900 };
+        assert_eq!(clamp_into((1900, 50), (300, 260), mon), (1920, 50));
+    }
 }

--- a/mur-hub-gui/src-tauri/src/geometry.rs
+++ b/mur-hub-gui/src-tauri/src/geometry.rs
@@ -117,8 +117,18 @@ mod tests {
 
     #[test]
     fn anchors_on_a_secondary_monitor_origin() {
-        let mon = Rect { x: 1920, y: 0, w: 1440, h: 900 };
-        let pet = Rect { x: 2000, y: 100, w: 300, h: 260 };
+        let mon = Rect {
+            x: 1920,
+            y: 0,
+            w: 1440,
+            h: 900,
+        };
+        let pet = Rect {
+            x: 2000,
+            y: 100,
+            w: 300,
+            h: 260,
+        };
         let (x, y) = anchor_panel(pet, (380, 520), mon);
         assert_eq!(x, 2000 + 300 + 8); // 2308, opens right (no room on the left within this monitor)
         assert_eq!(y, 100);
@@ -126,7 +136,12 @@ mod tests {
 
     #[test]
     fn clamps_within_secondary_monitor_bounds() {
-        let mon = Rect { x: 1920, y: 0, w: 1440, h: 900 };
+        let mon = Rect {
+            x: 1920,
+            y: 0,
+            w: 1440,
+            h: 900,
+        };
         assert_eq!(clamp_into((1900, 50), (300, 260), mon), (1920, 50));
     }
 }

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -545,7 +545,6 @@ pub fn run() {
             onboarding::first_launch::mark_first_launch_done,
             pet::pet_spawn_at,
             pet::pet_close,
-            pet::pet_reposition,
             pet::pet_return_to_hub,
             pet::pet_list,
             pet::pet_get_expression,

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -7,7 +7,7 @@ use base64::Engine as _;
 use mur_common::hub::trigger::load_triggers;
 use mur_gui_core::event_bus::{EventBus, HubEvent};
 use mur_gui_core::expression::{ExpressionChange, ExpressionStateMachine};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindowBuilder};
 use tokio::sync::oneshot;
 
@@ -26,16 +26,6 @@ pub struct PetState(pub Mutex<HashMap<String, PetHandle>>);
 
 /// Application-wide event bus (broadcast).
 pub struct EventBusState(pub EventBus);
-
-// ─── Position persistence ────────────────────────────────────────────────────
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PetPosition {
-    pub x: f64,
-    pub y: f64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub display_id: Option<String>,
-}
 
 fn mur_home() -> PathBuf {
     std::env::var("MUR_HOME")
@@ -77,30 +67,10 @@ pub(crate) fn monitor_rect_for_point(app: &AppHandle, x: i32, y: i32) -> geometr
     }
 }
 
-fn pet_position_path(agent_name: &str) -> PathBuf {
-    mur_home()
-        .join("agents")
-        .join(agent_name)
-        .join("pet_position.json")
-}
-
 /// True if `agent_name` is safe to use as a path component under
 /// `~/.mur/agents/` (canonical agent-name rules).
 fn valid_agent(agent_name: &str) -> bool {
     mur_common::agent_name::validate_agent_name(agent_name).is_ok()
-}
-
-fn save_position(agent_name: &str, pos: &PetPosition) {
-    if !valid_agent(agent_name) {
-        return;
-    }
-    let path = pet_position_path(agent_name);
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Ok(json) = serde_json::to_string_pretty(pos) {
-        let _ = std::fs::write(path, json);
-    }
 }
 
 fn window_label(agent_name: &str) -> String {
@@ -195,11 +165,8 @@ pub fn pet_spawn_at(
         pets.remove(&agent_name);
     }
 
-    // The explicit drop point always wins over a previously saved position — a
-    // stale save could point at a display that no longer exists. Persistence is
-    // left to pet_reposition, the single writer.
-    //
-    // DOM drop coords (screen_x/y) and PET_W/PET_H are LOGICAL; the geometry
+    // The explicit drop point always wins. DOM drop coords (screen_x/y) and
+    // PET_W/PET_H are LOGICAL; the geometry
     // module + monitor rects are PHYSICAL. Convert with the monitor scale.
     // ponytail: uniform-scale assumption (primary monitor's factor); mixed-DPI
     // multi-monitor would need per-monitor scale, rare — revisit if it bites.
@@ -274,18 +241,6 @@ pub fn pet_close(
         }
     }
     Ok(())
-}
-
-#[tauri::command]
-pub fn pet_reposition(agent_name: String, x: f64, y: f64) {
-    save_position(
-        &agent_name,
-        &PetPosition {
-            x,
-            y,
-            display_id: None,
-        },
-    );
 }
 
 #[tauri::command]

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -114,17 +114,6 @@ export function PetApp() {
     return () => { unsub.then((f) => f()); };
   }, []);
 
-  // Persist position whenever the window is moved.
-  useEffect(() => {
-    const win = getCurrentWindow();
-    const unsub = win.listen("tauri://move", () => {
-      win.outerPosition().then((pos) => {
-        invoke("pet_reposition", { agentName, x: pos.x, y: pos.y }).catch(() => {});
-      });
-    });
-    return () => { unsub.then((f) => f()); };
-  }, [agentName]);
-
   // Close context menu on click outside.
   useEffect(() => {
     if (!contextMenu.visible) return;

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -38,8 +38,9 @@ export function PetApp() {
   const [appearance, setAppearance] = useState<PetAppearance | null>(null);
   const [bubble, setBubble] = useState<BubbleState | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenu>({ visible: false, x: 0, y: 0 });
-  const [muted, setMuted] = useState(false);
-  const mutedRef = useRef(false); // read inside the bubble listener (stable closure)
+  const muteKey = `pet-muted:${agentName}`;
+  const [muted, setMuted] = useState(() => localStorage.getItem(muteKey) === "1");
+  const mutedRef = useRef(muted); // read inside the bubble listener (stable closure)
   const clickTimeRef = useRef<number>(0);
   const pressRef = useRef<{ x: number; y: number } | null>(null);
   const firstMenuItemRef = useRef<HTMLButtonElement>(null);
@@ -206,6 +207,7 @@ export function PetApp() {
     setMuted((m) => {
       const next = !m;
       mutedRef.current = next;
+      localStorage.setItem(muteKey, next ? "1" : "0");
       if (next) setBubble(null);
       return next;
     });
@@ -256,7 +258,7 @@ export function PetApp() {
       )}
 
       <div
-        className={`pet-sprite pet-sprite--${expression}`}
+        className={`pet-sprite pet-sprite--${expression}${muted ? " pet-sprite--muted" : ""}`}
         role="button"
         tabIndex={0}
         aria-label={t("pet.chat")}

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -42,6 +42,7 @@ export function PetApp() {
   const mutedRef = useRef(false); // read inside the bubble listener (stable closure)
   const clickTimeRef = useRef<number>(0);
   const pressRef = useRef<{ x: number; y: number } | null>(null);
+  const firstMenuItemRef = useRef<HTMLButtonElement>(null);
 
   // Resolve the pet's style/family once; decides AI art vs. vector mascot.
   useEffect(() => {
@@ -131,16 +132,24 @@ export function PetApp() {
     return () => window.removeEventListener("click", close);
   }, [contextMenu.visible]);
 
-  // ESC closes bubble.
+  // ESC closes bubble and context menu.
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape" && bubble) {
-        setBubble(null);
+      if (e.key === "Escape") {
+        if (contextMenu.visible) setContextMenu((m) => ({ ...m, visible: false }));
+        if (bubble) setBubble(null);
       }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [bubble]);
+  }, [bubble, contextMenu.visible]);
+
+  // Focus first menu item when context menu opens.
+  useEffect(() => {
+    if (contextMenu.visible) {
+      firstMenuItemRef.current?.focus();
+    }
+  }, [contextMenu.visible]);
 
   // Click vs drag: a native startDragging() on mousedown would swallow the
   // mouseup (the window server owns the drag loop), so clicks could never be
@@ -248,14 +257,22 @@ export function PetApp() {
 
       <div
         className={`pet-sprite pet-sprite--${expression}`}
+        role="button"
+        tabIndex={0}
+        aria-label={t("pet.chat")}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
         onDoubleClick={handleChat}
-        title={t("pet.chat")}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            void handleChat();
+          }
+        }}
       >
         {imageSrc ? (
-          <img src={imageSrc} alt={agentName} className="pet-image" draggable={false} />
+          <img src={imageSrc} alt="" aria-hidden className="pet-image" draggable={false} />
         ) : appearance ? (
           <PetFace
             presetId={appearance.style_preset}
@@ -273,7 +290,7 @@ export function PetApp() {
           className="pet-context-menu"
           style={{ left: contextMenu.x, top: contextMenu.y }}
         >
-          <button className="pet-menu-item" onClick={handleChat}>💬 {t("pet.chat")}</button>
+          <button ref={firstMenuItemRef} className="pet-menu-item" onClick={handleChat}>💬 {t("pet.chat")}</button>
           <button className="pet-menu-item" onClick={handleToggleMute}>
             {muted ? `🔔 ${t("pet.unmute")}` : `🔇 ${t("pet.mute")}`}
           </button>

--- a/mur-hub-gui/ui/src/components/PetFace.tsx
+++ b/mur-hub-gui/ui/src/components/PetFace.tsx
@@ -280,8 +280,7 @@ export function PetFace({ presetId, family, expression, size = 140, animate = tr
       width={size}
       height={size}
       viewBox="0 0 100 100"
-      role="img"
-      aria-label={`${presetId} pet, ${expression}`}
+      aria-hidden
     >
       <g className="petface__body">
         <EarTop style={style} />

--- a/mur-hub-gui/ui/src/styles/components/pet.css
+++ b/mur-hub-gui/ui/src/styles/components/pet.css
@@ -223,7 +223,7 @@ body.pet-window {
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
   font-size: var(--text-xs);
   padding: 2px 4px;
   border-radius: var(--radius-sm);
@@ -231,3 +231,9 @@ body.pet-window {
   transition: background var(--dur-fast), color var(--dur-fast);
 }
 .pet-bubble-close:hover { color: var(--text-primary); background: var(--surface-hover); }
+.pet-sprite:focus-visible,
+.pet-menu-item:focus-visible,
+.pet-bubble-close:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 2px;
+}

--- a/mur-hub-gui/ui/src/styles/components/pet.css
+++ b/mur-hub-gui/ui/src/styles/components/pet.css
@@ -167,7 +167,7 @@ body.pet-window {
 
 /* ── Pet Bubble ───────────────────────────────────────────────────────── */
 .pet-bubble {
-  /* The pet OS window is a fixed transparent 200×200; anything painted outside
+  /* The pet OS window is a fixed transparent 300×260; anything painted outside
      it is clipped (the bubble used to sit at bottom:210px → fully off-window and
      invisible). Anchor it INSIDE the window over the pet's head, cap the size,
      and scroll long replies so a multi-sentence quick-take stays readable. */

--- a/mur-hub-gui/ui/src/styles/components/pet.css
+++ b/mur-hub-gui/ui/src/styles/components/pet.css
@@ -22,6 +22,7 @@ body.pet-window {
 .pet-bubble,
 .pet-context-menu { pointer-events: auto; }
 .pet-sprite {
+  position: relative;
   width: 160px;
   height: 160px;
   margin: 0;
@@ -35,6 +36,14 @@ body.pet-window {
 .pet-sprite:active { cursor: grabbing; transform: scale(0.95); }
 .pet-sprite--smile { animation: petBounce var(--dur-slow) var(--ease-spring); }
 .pet-sprite--wave  { animation: petWave 0.5s var(--ease-out) infinite alternate; }
+.pet-sprite--muted::after {
+  content: "🔇";
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  font-size: 16px;
+  filter: drop-shadow(0 1px 2px rgba(0,0,0,0.4));
+}
 @keyframes petBounce {
   0%   { transform: scale(1); }
   50%  { transform: scale(1.15); }


### PR DESCRIPTION
**Stacked on #500 (Phase 1).** Review/merge #500 first; this PR's base is `feat/pet-chat-escalation`, so its diff is only the Phase 2 changes.

## What & why
Low-risk hardening deferred from Phase 1 (spec §8/§9):

- **Keyboard-operable pet** — the sprite was a plain `<div>` (no focus, no key handler); now a real `role="button"` with `tabIndex`, `aria-label`, Enter/Space → open chat. Inner graphics `aria-hidden` (no double-announce). Escape closes the context menu (not just the bubble) + focuses the first menu item. Bubble close-button contrast bumped; `:focus-visible` outlines added.
- **Mute persistence + indicator** — mute was React-state only (silently reset on reload); now persisted per-agent in `localStorage` (`mutedRef` seeded from it so a muted pet never pops a bubble before first toggle), with a 🔇 badge on the sprite.
- **Delete write-only dead code** — `pet_position.json` was written on every move but never read (the "restore on restart" it implied was never built and is intentionally not wanted). Removed `PetPosition`, `save_position`, `pet_position_path`, the `pet_reposition` command + its handler registration, and the `tauri://move` listener. `Deserialize` import cleaned up.
- **Tests + tidy** — added two `geometry.rs` tests for non-zero monitor origins (secondary displays); fixed a stale `.pet-bubble` comment (200×200 → 300×260).

## Verification
- Rust + frontend builds clean; `clippy` clean (touched files); `cargo fmt` clean; **7/7 geometry tests** pass.
- SDD: 4 tasks, each per-task reviewed (3 clean, 1 with non-defect minors); opus whole-branch review verdict **merge as-is** (0 Critical/Important, muteKey collision ruled out, no cross-phase conflict).
- Manual a11y spot-check (Tab→focus ring→Enter opens; Escape closes menu; mute badge survives reload) is operator-pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)