### PR TITLE
feat(pet): desktop pet chat escalation — Phase 3 (file-drop UX + liveness)

### DIFF
--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -258,35 +258,47 @@ pub fn run() {
         // dropped paths to that pet's webview. App-level (not per-window) so it
         // covers pet windows created dynamically after launch.
         .on_window_event(|window, event| {
-            if let tauri::WindowEvent::DragDrop(tauri::DragDropEvent::Drop { paths, .. }) = event {
+            if let tauri::WindowEvent::DragDrop(drag_event) = event {
                 let label = window.label().to_string();
                 if !label.starts_with("pet-") {
                     return;
                 }
-                // macOS fires Drop twice per gesture (Tauri #14134); coalesce
-                // PER WINDOW so a near-simultaneous drop on a *different* pet
-                // isn't swallowed by a global timer.
-                use std::collections::HashMap;
-                use std::sync::Mutex;
-                use std::time::{Duration, Instant};
-                static LAST_DROP: Mutex<Option<HashMap<String, Instant>>> = Mutex::new(None);
-                let now = Instant::now();
-                {
-                    let mut guard = LAST_DROP.lock().unwrap_or_else(|p| p.into_inner());
-                    let map = guard.get_or_insert_with(HashMap::new);
-                    if let Some(prev) = map.get(&label)
-                        && now.duration_since(*prev) < Duration::from_millis(150)
-                    {
-                        return;
+                match drag_event {
+                    tauri::DragDropEvent::Enter { .. } | tauri::DragDropEvent::Over { .. } => {
+                        let _ = window.emit_to(&label, "pet://drag-active", true);
                     }
-                    map.insert(label.clone(), now);
+                    tauri::DragDropEvent::Leave => {
+                        let _ = window.emit_to(&label, "pet://drag-active", false);
+                    }
+                    tauri::DragDropEvent::Drop { paths, .. } => {
+                        // macOS fires Drop twice per gesture (Tauri #14134); coalesce
+                        // PER WINDOW so a near-simultaneous drop on a *different* pet
+                        // isn't swallowed by a global timer.
+                        use std::collections::HashMap;
+                        use std::sync::Mutex;
+                        use std::time::{Duration, Instant};
+                        static LAST_DROP: Mutex<Option<HashMap<String, Instant>>> =
+                            Mutex::new(None);
+                        let now = Instant::now();
+                        {
+                            let mut guard = LAST_DROP.lock().unwrap_or_else(|p| p.into_inner());
+                            let map = guard.get_or_insert_with(HashMap::new);
+                            if let Some(prev) = map.get(&label)
+                                && now.duration_since(*prev) < Duration::from_millis(150)
+                            {
+                                return;
+                            }
+                            map.insert(label.clone(), now);
+                        }
+                        let paths: Vec<String> = paths
+                            .iter()
+                            .map(|p| p.to_string_lossy().into_owned())
+                            .collect();
+                        // emit_to the pet's own label so only that pet reacts.
+                        let _ = window.emit_to(&label, "pet://drop", paths);
+                    }
+                    _ => {}
                 }
-                let paths: Vec<String> = paths
-                    .iter()
-                    .map(|p| p.to_string_lossy().into_owned())
-                    .collect();
-                // emit_to the pet's own label so only that pet reacts.
-                let _ = window.emit_to(&label, "pet://drop", paths);
             }
         })
         .setup(move |app| {

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -467,6 +467,28 @@ pub async fn pet_drop_files(
     .map_err(|e| format!("pet drop task panicked: {e}"))?;
 
     let reply = dialed.unwrap_or_else(|e| format!("(couldn't reach {agent_name}: {e})"));
+
+    // Persist the exchange into the agent's channel so ChatTab re-hydrates and
+    // shows the full take as a real panel message (best-effort, never blocks).
+    {
+        let agent_name2 = agent_name.clone();
+        let file_label = paths
+            .iter()
+            .filter_map(|p| {
+                std::path::Path::new(p)
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let user_msg = format!("📎 {file_label}");
+        let agent_reply = reply.clone();
+        tokio::task::spawn_blocking(move || {
+            let home = mur_home();
+            mur_core::mobile::persist_mobile_exchange(&home, &agent_name2, &user_msg, &agent_reply);
+        });
+    }
+
     Ok(PetDropResult {
         reply,
         text_files: sections.len(),

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -392,10 +392,13 @@ fn resolve_remote_provider(agent_name: &str) -> Option<String> {
     };
 
     // A base_url pointing at loopback is always local regardless of provider name.
-    if let Some(ref url) = base_url {
-        if url.contains("127.0.0.1") || url.contains("localhost") || url.contains("[::1]") || url.contains("0.0.0.0") {
-            return None;
-        }
+    if let Some(ref url) = base_url
+        && (url.contains("127.0.0.1")
+            || url.contains("localhost")
+            || url.contains("[::1]")
+            || url.contains("0.0.0.0"))
+    {
+        return None;
     }
 
     // Known local runtimes.

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -349,6 +349,60 @@ pub struct PetDropResult {
     pub reply: String,
     pub text_files: usize,
     pub skipped: Vec<String>,
+    /// Display name of the non-local provider receiving the file contents, or
+    /// `None` when the agent is using a demonstrably local model (ollama, mlx,
+    /// lmstudio, or a loopback base_url). Used for the privacy disclosure bubble.
+    pub remote_provider: Option<String>,
+}
+
+/// Return a friendly provider display name when the provider is known to be
+/// a cloud service, or `None` when it is demonstrably local.
+///
+/// "Demonstrably local" = provider key is a known local runtime, OR the
+/// resolved base_url is a loopback address. If we cannot determine locality
+/// (e.g. an unknown custom provider), we disclose generically — fail toward
+/// disclosure.
+fn resolve_remote_provider(agent_name: &str) -> Option<String> {
+    let home = mur_home();
+    let profile_path = home.join("agents").join(agent_name).join("profile.yaml");
+    let yaml = std::fs::read_to_string(&profile_path).ok()?;
+    let profile: mur_common::AgentProfile = serde_yaml_ng::from_str(&yaml).ok()?;
+
+    // If the profile has a model_ref, look it up in models.yaml for a richer
+    // base_url check; fall back to inline model.provider.
+    let (provider, base_url): (String, Option<String>) = if let Some(ref mref) = profile.model_ref {
+        let registry_path = home.join("models.yaml");
+        if let Ok(registry) = mur_common::model::ModelRegistry::load_from(&registry_path) {
+            if let Some(entry) = registry.models.get(mref) {
+                (entry.provider.clone(), entry.base_url.clone())
+            } else {
+                (profile.model.provider.clone(), None)
+            }
+        } else {
+            (profile.model.provider.clone(), None)
+        }
+    } else {
+        (profile.model.provider.clone(), None)
+    };
+
+    // A base_url pointing at loopback is always local regardless of provider name.
+    if let Some(ref url) = base_url {
+        if url.contains("127.0.0.1") || url.contains("localhost") {
+            return None;
+        }
+    }
+
+    // Known local runtimes.
+    match provider.as_str() {
+        "ollama" | "mlx" | "lmstudio" => None,
+        // Known cloud providers — return a friendly display name.
+        "anthropic" => Some("Anthropic".into()),
+        "openai" => Some("OpenAI".into()),
+        "openrouter" => Some("OpenRouter".into()),
+        "gemini" => Some("Google Gemini".into()),
+        // Unknown provider with no loopback URL: disclose generically.
+        _ => Some("the agent's model".into()),
+    }
 }
 
 /// Handle file(s) dropped onto `agent_name`'s pet. Reads text-like files, stages
@@ -424,6 +478,7 @@ pub async fn pet_drop_files(
             reply: String::new(),
             text_files: 0,
             skipped,
+            remote_provider: None,
         });
     }
 
@@ -489,10 +544,13 @@ pub async fn pet_drop_files(
         });
     }
 
+    let remote_provider = resolve_remote_provider(&agent_name);
+
     Ok(PetDropResult {
         reply,
         text_files: sections.len(),
         skipped,
+        remote_provider,
     })
 }
 

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -365,8 +365,14 @@ pub struct PetDropResult {
 fn resolve_remote_provider(agent_name: &str) -> Option<String> {
     let home = mur_home();
     let profile_path = home.join("agents").join(agent_name).join("profile.yaml");
-    let yaml = std::fs::read_to_string(&profile_path).ok()?;
-    let profile: mur_common::AgentProfile = serde_yaml_ng::from_str(&yaml).ok()?;
+    let yaml = match std::fs::read_to_string(&profile_path) {
+        Ok(y) => y,
+        Err(_) => return Some("the agent's model".into()), // fail-toward-disclosure
+    };
+    let profile: mur_common::AgentProfile = match serde_yaml_ng::from_str(&yaml) {
+        Ok(p) => p,
+        Err(_) => return Some("the agent's model".into()),
+    };
 
     // If the profile has a model_ref, look it up in models.yaml for a richer
     // base_url check; fall back to inline model.provider.
@@ -387,7 +393,7 @@ fn resolve_remote_provider(agent_name: &str) -> Option<String> {
 
     // A base_url pointing at loopback is always local regardless of provider name.
     if let Some(ref url) = base_url {
-        if url.contains("127.0.0.1") || url.contains("localhost") {
+        if url.contains("127.0.0.1") || url.contains("localhost") || url.contains("[::1]") || url.contains("0.0.0.0") {
             return None;
         }
     }

--- a/mur-hub-gui/src-tauri/src/pet/mod.rs
+++ b/mur-hub-gui/src-tauri/src/pet/mod.rs
@@ -429,6 +429,15 @@ pub async fn pet_drop_files(
     let mut sections = Vec::new();
     let mut skipped = Vec::new();
     let mut total = 0u64;
+    // Honest truncation: if the drop exceeds the file cap, push a synthetic entry
+    // so the user sees "+N more (max M)" rather than a silent drop.
+    if paths.len() > PET_DROP_MAX_FILES {
+        skipped.push(format!(
+            "+{} more (max {})",
+            paths.len() - PET_DROP_MAX_FILES,
+            PET_DROP_MAX_FILES
+        ));
+    }
     for p in paths.iter().take(PET_DROP_MAX_FILES) {
         let path = std::path::Path::new(p);
         let fname = path
@@ -501,7 +510,7 @@ pub async fn pet_drop_files(
     let prompt =
         format!("Give me a brief (1-2 sentence) take on the following dropped file(s):\n\n{body}");
     let agent = agent_name.clone();
-    let dialed = tokio::task::spawn_blocking(move || {
+    let join = tokio::task::spawn_blocking(move || {
         let home = mur_home();
         let task_id = format!(
             "pet-drop-{}",
@@ -523,9 +532,12 @@ pub async fn pet_drop_files(
         )
         .map(|task| extract_reply(&task))
         .map_err(|e| e.to_string())
-    })
-    .await
-    .map_err(|e| format!("pet drop task panicked: {e}"))?;
+    });
+    // Bounded dial: a hung runtime can't leave the bubble spinning forever.
+    let dialed = match tokio::time::timeout(std::time::Duration::from_secs(45), join).await {
+        Ok(join_result) => join_result.map_err(|e| format!("pet drop task panicked: {e}"))?,
+        Err(_) => Ok(format!("(timed out reaching {agent_name})")),
+    };
 
     let reply = dialed.unwrap_or_else(|e| format!("(couldn't reach {agent_name}: {e})"));
 
@@ -542,7 +554,13 @@ pub async fn pet_drop_files(
             })
             .collect::<Vec<_>>()
             .join(", ");
-        let user_msg = format!("📎 {file_label}");
+        // Include any skipped names so the channel record is honest.
+        let skipped_suffix = if skipped.is_empty() {
+            String::new()
+        } else {
+            format!(" (skipped: {})", skipped.join(", "))
+        };
+        let user_msg = format!("📎 {file_label}{skipped_suffix}");
         let agent_reply = reply.clone();
         tokio::task::spawn_blocking(move || {
             let home = mur_home();

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -253,6 +253,11 @@ export function PetApp() {
     .map((w) => w[0]?.toUpperCase() ?? "")
     .join("");
 
+  // While the drop dial is in flight, override the backend expression with
+  // "think" so the mascot visibly pulses. The override reverts automatically
+  // when pending goes false (computed at render time — no setState needed).
+  const shownExpression = pending ? "think" : expression;
+
   return (
     <div
       className={`pet-root${dragOver ? " pet-root--drag" : ""}`}
@@ -268,7 +273,7 @@ export function PetApp() {
       )}
 
       <div
-        className={`pet-sprite pet-sprite--${expression}${muted ? " pet-sprite--muted" : ""}`}
+        className={`pet-sprite pet-sprite--${shownExpression}${muted ? " pet-sprite--muted" : ""}`}
         role="button"
         tabIndex={0}
         aria-label={t("pet.chat")}
@@ -289,7 +294,7 @@ export function PetApp() {
           <PetFace
             presetId={appearance.style_preset}
             family={appearance.family}
-            expression={expression}
+            expression={shownExpression}
             size={150}
           />
         ) : (

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -60,7 +60,7 @@ export function PetApp() {
       const paths = ev.payload;
       if (!paths || paths.length === 0) return;
       setBubble({ text: t("pet.dropThinking"), dwell_ms: 60000, ack_required: false });
-      invoke<{ reply: string; text_files: number; skipped: string[] }>("pet_drop_files", {
+      invoke<{ reply: string; text_files: number; skipped: string[]; remote_provider?: string }>("pet_drop_files", {
         agentName,
         paths,
       })
@@ -69,8 +69,11 @@ export function PetApp() {
           const skipped = res.skipped?.length
             ? ` ${t("pet.dropSkipped", { count: res.skipped.length })}`
             : "";
+          const disclosure = res.remote_provider
+            ? `\n${t("pet.dropSendingTo", { provider: res.remote_provider })}`
+            : "";
           setBubble({
-            text: base + skipped,
+            text: base + skipped + disclosure,
             dwell_ms: res.reply ? 12000 : 6000,
             ack_required: false,
           });

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -39,6 +39,7 @@ export function PetApp() {
   const [bubble, setBubble] = useState<BubbleState | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenu>({ visible: false, x: 0, y: 0 });
   const [dragOver, setDragOver] = useState(false);
+  const [pending, setPending] = useState(false);
   const muteKey = `pet-muted:${agentName}`;
   const [muted, setMuted] = useState(() => localStorage.getItem(muteKey) === "1");
   const mutedRef = useRef(muted); // read inside the bubble listener (stable closure)
@@ -62,6 +63,7 @@ export function PetApp() {
       const paths = ev.payload;
       if (!paths || paths.length === 0) return;
       setBubble({ text: t("pet.dropThinking"), dwell_ms: 60000, ack_required: false });
+      setPending(true);
       invoke<{ reply: string; text_files: number; skipped: string[]; remote_provider?: string }>("pet_drop_files", {
         agentName,
         paths,
@@ -80,7 +82,8 @@ export function PetApp() {
             ack_required: false,
           });
         })
-        .catch((e) => setBubble({ text: String(e), dwell_ms: 6000, ack_required: false }));
+        .catch((e) => setBubble({ text: String(e), dwell_ms: 6000, ack_required: false }))
+        .finally(() => setPending(false));
     });
     return () => { unsub.then((f) => f()); };
   }, [agentName, t]);
@@ -141,7 +144,7 @@ export function PetApp() {
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
         if (contextMenu.visible) setContextMenu((m) => ({ ...m, visible: false }));
-        if (bubble) setBubble(null);
+        if (bubble && !pending) setBubble(null);
       }
     }
     window.addEventListener("keydown", onKey);
@@ -260,6 +263,7 @@ export function PetApp() {
           text={bubble.text}
           dwellMs={bubble.dwell_ms}
           onClose={handleBubbleAck}
+          pending={pending}
         />
       )}
 
@@ -319,9 +323,11 @@ interface BubbleProps {
   text: string;
   dwellMs: number;
   onClose: () => void;
+  /** While true, the dial is in flight — hide the close button so it can't pretend to cancel. */
+  pending?: boolean;
 }
 
-function Bubble({ text, dwellMs, onClose }: BubbleProps) {
+function Bubble({ text, dwellMs, onClose, pending }: BubbleProps) {
   const { t } = useT();
   const [remaining, setRemaining] = useState(dwellMs);
   const hoveredRef = useRef(false);
@@ -361,7 +367,9 @@ function Bubble({ text, dwellMs, onClose }: BubbleProps) {
       <div className="pet-bubble-progress">
         <div className="pet-bubble-bar" style={{ width: `${pct}%` }} />
       </div>
-      <button className="pet-bubble-close" onClick={onClose} aria-label={t("pet.dismiss")}>✕</button>
+      {!pending && (
+        <button className="pet-bubble-close" onClick={onClose} aria-label={t("pet.dismiss")}>✕</button>
+      )}
     </div>
   );
 }

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -38,6 +38,7 @@ export function PetApp() {
   const [appearance, setAppearance] = useState<PetAppearance | null>(null);
   const [bubble, setBubble] = useState<BubbleState | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenu>({ visible: false, x: 0, y: 0 });
+  const [dragOver, setDragOver] = useState(false);
   const muteKey = `pet-muted:${agentName}`;
   const [muted, setMuted] = useState(() => localStorage.getItem(muteKey) === "1");
   const mutedRef = useRef(muted); // read inside the bubble listener (stable closure)
@@ -57,6 +58,7 @@ export function PetApp() {
   // This is user-initiated, so it shows even when muted.
   useEffect(() => {
     const unsub = getCurrentWindow().listen<string[]>("pet://drop", (ev) => {
+      setDragOver(false);
       const paths = ev.payload;
       if (!paths || paths.length === 0) return;
       setBubble({ text: t("pet.dropThinking"), dwell_ms: 60000, ack_required: false });
@@ -240,7 +242,13 @@ export function PetApp() {
     .join("");
 
   return (
-    <div className="pet-root" onContextMenu={handleContextMenu}>
+    <div
+      className={`pet-root${dragOver ? " pet-root--drag" : ""}`}
+      onContextMenu={handleContextMenu}
+      onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={() => setDragOver(false)}
+    >
       {bubble && (
         <Bubble
           text={bubble.text}

--- a/mur-hub-gui/ui/src/components/PetApp.tsx
+++ b/mur-hub-gui/ui/src/components/PetApp.tsx
@@ -58,7 +58,7 @@ export function PetApp() {
   // This is user-initiated, so it shows even when muted.
   useEffect(() => {
     const unsub = getCurrentWindow().listen<string[]>("pet://drop", (ev) => {
-      setDragOver(false);
+      setDragOver(false); // clear highlight on drop
       const paths = ev.payload;
       if (!paths || paths.length === 0) return;
       setBubble({ text: t("pet.dropThinking"), dwell_ms: 60000, ack_required: false });
@@ -84,6 +84,15 @@ export function PetApp() {
     });
     return () => { unsub.then((f) => f()); };
   }, [agentName, t]);
+
+  // Drive drag-over highlight from native Tauri drag events (HTML5 drag handlers
+  // don't fire for OS file drags when Tauri native drag-drop is enabled).
+  useEffect(() => {
+    const unsub = getCurrentWindow().listen<boolean>("pet://drag-active", (ev) => {
+      setDragOver(ev.payload);
+    });
+    return () => { unsub.then((f) => f()); };
+  }, []);
 
   // Load the AI expression image when (and only when) real art exists; otherwise
   // the vector PetFace renders the expression and no fetch is needed.
@@ -245,9 +254,6 @@ export function PetApp() {
     <div
       className={`pet-root${dragOver ? " pet-root--drag" : ""}`}
       onContextMenu={handleContextMenu}
-      onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
-      onDragLeave={() => setDragOver(false)}
-      onDrop={() => setDragOver(false)}
     >
       {bubble && (
         <Bubble

--- a/mur-hub-gui/ui/src/components/PetFace.tsx
+++ b/mur-hub-gui/ui/src/components/PetFace.tsx
@@ -272,11 +272,12 @@ export function PetFace({ presetId, family, expression, size = 140, animate = tr
   // Only the live pet window animates; card thumbnails pass animate={false} so
   // N cards don't each run two infinite filtered transform animations.
   const animatable =
-    animate && (expression === "idle" || expression === "smile" || expression === "peek");
+    animate && (expression === "idle" || expression === "smile" || expression === "peek" || expression === "think");
+  const thinking = expression === "think";
 
   return (
     <svg
-      className={`petface${animatable ? " petface--breathe" : ""}`}
+      className={`petface${animatable ? " petface--breathe" : ""}${thinking ? " petface--thinking" : ""}`}
       width={size}
       height={size}
       viewBox="0 0 100 100"

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -189,6 +189,7 @@ export const en = {
   "pet.dropThinking": "Reading…",
   "pet.dropOpened": "Opened in chat ↗",
   "pet.dropSkipped": "({count} not read)",
+  "pet.dropSendingTo": "Sending file contents to {provider}…",
   // ── Mascot speech ──
   "mascot.bubble.excited": "No flock yet! Create your first agent 🐦",
   "mascot.bubble.happy": "Your whole flock is flying! 🎉",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -191,6 +191,7 @@ export const zhTW: Table = {
   "pet.dropThinking": "讀取中…",
   "pet.dropOpened": "已在聊天開啟 ↗",
   "pet.dropSkipped": "（{count} 個未讀取）",
+  "pet.dropSendingTo": "正在把檔案內容傳給 {provider}…",
   // ── Mascot speech ──
   "mascot.bubble.excited": "還沒有鳥群！快建立你的第一隻 agent 🐦",
   "mascot.bubble.happy": "整個鳥群都在飛翔！🎉",

--- a/mur-hub-gui/ui/src/styles/components/pet.css
+++ b/mur-hub-gui/ui/src/styles/components/pet.css
@@ -250,7 +250,7 @@ body.pet-window {
 /* ── Drag-over highlight ──────────────────────────────────────────────────── */
 .pet-root--drag .pet-sprite {
   transform: scale(1.08);
-  filter: drop-shadow(0 0 0 2px var(--color-brand)) drop-shadow(0 4px 12px rgba(0,0,0,0.25));
+  filter: drop-shadow(0 0 4px var(--color-brand)) drop-shadow(0 4px 12px rgba(0,0,0,0.25));
 }
 @media (prefers-reduced-motion: reduce) {
   .pet-root--drag .pet-sprite { transform: none; }

--- a/mur-hub-gui/ui/src/styles/components/pet.css
+++ b/mur-hub-gui/ui/src/styles/components/pet.css
@@ -105,6 +105,19 @@ body.pet-window {
   .petface--breathe .petface__body,
   .petface--breathe .petface__eyes { animation: none; }
 }
+/* Thinking pulse: gentle scale + opacity cycle while the drop dial is in flight. */
+.petface--thinking .petface__body {
+  transform-box: fill-box;
+  transform-origin: center bottom;
+  animation: petfaceThink 1.1s ease-in-out infinite;
+}
+@keyframes petfaceThink {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.03); opacity: 0.85; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .petface--thinking .petface__body { animation: none; }
+}
 .pet-context-menu {
   position: fixed;
   background: var(--surface-card);

--- a/mur-hub-gui/ui/src/styles/components/pet.css
+++ b/mur-hub-gui/ui/src/styles/components/pet.css
@@ -246,3 +246,12 @@ body.pet-window {
   outline: 2px solid var(--color-brand);
   outline-offset: 2px;
 }
+
+/* ── Drag-over highlight ──────────────────────────────────────────────────── */
+.pet-root--drag .pet-sprite {
+  transform: scale(1.08);
+  filter: drop-shadow(0 0 0 2px var(--color-brand)) drop-shadow(0 4px 12px rgba(0,0,0,0.25));
+}
+@media (prefers-reduced-motion: reduce) {
+  .pet-root--drag .pet-sprite { transform: none; }
+}


### PR DESCRIPTION
**Stacked on #501 (Phase 2), which is stacked on #500 (Phase 1).** Merge order: #500 → #501 → #503. This PR's base is `feat/pet-chat-escalation-phase2`, so its diff is only the Phase 3 changes.

## What & why (spec §6 file-drop, §9 mascot)
- **Dropped file → chat panel** — the file-drop dial was ephemeral (never persisted), so the take only hit the tiny bubble. Now the exchange is persisted to the agent's channel (`persist_mobile_exchange`), so `ChatTab` re-hydrates (`channel-updated` watcher) and shows the file (`📎 names`) + the agent's take as real panel messages.
- **Privacy disclosure** — dropped file *contents* are sent to the agent's model (often cloud). `resolve_remote_provider` classifies local (loopback / ollama / mlx / lmstudio) vs cloud; when non-local, the reading bubble discloses the provider. Fail-toward-disclosure on unknown provider / unreadable profile (the content already left).
- **Drag-over affordance** — the pet now highlights as a drop target. Driven by Tauri's **native** `DragDropEvent::Enter/Over/Leave` (HTML5 drag events don't fire under native drag-drop), emitted from `lib.rs` as `pet://drag-active`.
- **Honest + bounded drop** — `>5` files now reported (`+N more` + skipped names in the channel message, not silently dropped); a 45s dial timeout so a hung runtime can't spin forever; the "Reading…" bubble is non-dismissible while the dial is in flight (its ✕ no longer fakes a cancel).
- **Liveness** — the mascot shows a "thinking" pulse while the drop dial runs (`shownExpression = pending ? "think" : expression`, pure derived; reduced-motion guarded).

## Verification
- Rust + frontend builds clean; `clippy` clean (let-chain); `cargo fmt` clean. SDD: 5 tasks, each per-task reviewed (T2 + T3 had fix waves — T3's review caught that the HTML5 drag approach was dead under Tauri native DnD and it was rewired to native events); opus whole-branch review verdict **merge as-is** (0 Critical/Important, security paths intact).
- **Live-verification operator-pending** (needs a running agent runtime + a real Finder drag): the take appearing in the panel, the drag highlight firing, the timeout bubble, and the cloud-vs-local disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)