### PR TITLE
fix(addon): import MCP servers from bare-map .mcp.json (Claude plugins)

### DIFF
--- a/mur-core/src/cmd/agent/addon/import.rs
+++ b/mur-core/src/cmd/agent/addon/import.rs
@@ -136,6 +136,15 @@ pub fn cmd_addon_import(name: &str, plugin_dir: &str, force: bool) -> Result<()>
                     "MCP server '{server}' already exists on '{name}'; rename or remove it first"
                 );
             }
+            // Remote servers (type:"http"/"sse") carry a url, not a launch
+            // command — there's no local binary to pin, so skip with a notice
+            // rather than aborting the whole import.
+            if srv.command.trim().is_empty() {
+                println!(
+                    "note: MCP '{server}' is a remote (http/sse) server; NOT imported. Wire it manually with:\n  mur agent mcp add {name} {server} ..."
+                );
+                continue;
+            }
             // Resolve + hash the binary (rejects path-escape / missing binary).
             let resolved = resolve_command(&srv.command)
                 .map_err(|e| anyhow::anyhow!("MCP '{server}' command {:?}: {e}", srv.command))?;

--- a/mur-core/src/cmd/agent/addon/parse.rs
+++ b/mur-core/src/cmd/agent/addon/parse.rs
@@ -249,6 +249,11 @@ pub struct McpJson {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct McpServerJson {
+    /// stdio servers carry a launch command; `type: "http"`/`sse` servers
+    /// (e.g. github, linear) carry a `url` instead and leave this empty. The
+    /// importer pins stdio binaries by sha256 and cannot pin a remote server,
+    /// so it skips empty-command entries (see import.rs).
+    #[serde(default)]
     pub command: String,
     #[serde(default)]
     pub args: Vec<String>,
@@ -259,8 +264,21 @@ pub struct McpServerJson {
     pub env: BTreeMap<String, String>,
 }
 
+/// Parse a `.mcp.json` in either shape seen in the wild:
+///   - wrapped  — `{"mcpServers": {"<name>": {...}}}` (project/user `.mcp.json`)
+///   - bare map — `{"<name>": {...}}`                 (Claude plugin `.mcp.json`)
+///
+/// Every stock Claude marketplace plugin uses the bare-map form, so the old
+/// `mcpServers`-only parse silently imported zero servers from them.
 pub fn parse_mcp_json(src: &str) -> Result<McpJson> {
-    Ok(serde_json::from_str(src)?)
+    let root: serde_json::Value = serde_json::from_str(src)?;
+    let servers = match root.get("mcpServers") {
+        Some(wrapped) => wrapped.clone(),
+        None => root,
+    };
+    Ok(McpJson {
+        mcp_servers: serde_json::from_value(servers)?,
+    })
 }
 
 #[cfg(test)]
@@ -333,6 +351,28 @@ mod tests {
         assert_eq!(s.command, "weather-mcp");
         assert_eq!(s.args, vec!["--port", "9"]);
         assert!(s.env.contains_key("API_KEY"));
+    }
+
+    #[test]
+    fn parse_mcp_json_reads_bare_map_form() {
+        // Every stock Claude plugin .mcp.json is a bare server map with no
+        // `mcpServers` wrapper (e.g. context7, serena, playwright).
+        let src = r#"{"context7":{"command":"npx","args":["-y","@upstash/context7-mcp"]}}"#;
+        let j = parse_mcp_json(src).unwrap();
+        let s = j.mcp_servers.get("context7").unwrap();
+        assert_eq!(s.command, "npx");
+        assert_eq!(s.args, vec!["-y", "@upstash/context7-mcp"]);
+    }
+
+    #[test]
+    fn parse_mcp_json_tolerates_remote_http_server() {
+        // type:"http" servers (github, linear) carry a url, not a command —
+        // they must parse (empty command) so the importer can skip them
+        // instead of the whole parse blowing up.
+        let src = r#"{"github":{"type":"http","url":"https://api.example/mcp/"}}"#;
+        let j = parse_mcp_json(src).unwrap();
+        let s = j.mcp_servers.get("github").unwrap();
+        assert!(s.command.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #499.

## Problem

`parse_mcp_json` only accepted the **wrapped** `.mcp.json` shape:
```json
{ "mcpServers": { "<name>": { ... } } }
```
But **every stock Claude marketplace plugin** ships the **bare server map**:
```json
{ "context7": { "command": "npx", "args": ["-y", "@upstash/context7-mcp"] } }
```
(verified across context7, serena, playwright, github, linear). Because the parser's `mcpServers` field is `default`, a bare-map file deserialized to an **empty** map — so the importer silently pulled **zero MCP servers** from real plugins. An MCP-only plugin like context7 imported as a completely empty add-on (`mcp:0`).

## Fix

- `parse_mcp_json` now accepts **both** shapes: if a top-level `mcpServers` key is present it unwraps it, otherwise it treats the whole object as the server map.
- `McpServerJson.command` is now optional, so remote `type:"http"`/`"sse"` servers (github, linear — they carry a `url`, not a command) parse instead of aborting the whole import. The importer **skips** them with a note, since there's no local binary to sha256-pin.

## Verification

`cargo test -p mur-core addon::` → 18/18 pass, including:
- `parse_mcp_json_reads_bare_map_form` (context7-shaped)
- `parse_mcp_json_tolerates_remote_http_server` (github-shaped, empty command)
- existing `parse_mcp_json_reads_servers_and_env` (wrapped form) still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)