### PR TITLE
fix(index): key codebase index by main repo, not worktree dir

### DIFF
--- a/mur-core/src/cmd/inject_cmd.rs
+++ b/mur-core/src/cmd/inject_cmd.rs
@@ -34,9 +34,11 @@ pub(crate) async fn cmd_inject(query: &str) -> Result<()> {
 
     let results = score_and_rank_generic(query, active);
 
+    // Resolve git worktrees to the main repo name so injection-learning scopes
+    // per-repo (matching the codebase index), not per-branch-worktree.
     let project_name = std::env::current_dir()
         .ok()
-        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+        .map(|p| crate::codebase::scanner::project_name_from_path(&p))
         .unwrap_or_default();
     let injected_items: Vec<_> = results
         .into_iter()

--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -921,11 +921,9 @@ pub(crate) async fn cmd_sync(quiet: bool, project_aware: bool, team: Option<&str
     let cwd = std::env::current_dir()?;
     let targets = default_targets();
 
-    // Build project-aware query when --project is set
-    let project_name = cwd
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_default();
+    // Build project-aware query when --project is set. Resolve git worktrees to
+    // the main repo name so sync scopes per-repo, consistent with the index.
+    let project_name = crate::codebase::scanner::project_name_from_path(&cwd);
 
     let sync_query = if project_aware {
         build_project_sync_query(&cwd, &project_name)

--- a/mur-core/src/codebase/scanner.rs
+++ b/mur-core/src/codebase/scanner.rs
@@ -179,10 +179,38 @@ fn relative_path(root: &Path, path: &Path) -> String {
         .replace('\\', "/")
 }
 
+/// Project name = the codebase-index key (`<name>.lance`). For a git worktree
+/// this resolves to the MAIN working tree's directory name, so every
+/// worktree/branch of one repo shares a single index instead of re-indexing the
+/// whole tree per worktree. Falls back to the path's own basename when it isn't
+/// a git repo (or git is unavailable).
 pub fn project_name_from_path(path: &Path) -> String {
-    path.file_name()
+    git_main_repo_root(path)
+        .as_deref()
+        .unwrap_or(path)
+        .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Main working-tree root for any path inside a git repo (including linked
+/// worktrees), via `git --git-common-dir`. `None` when `path` isn't in a repo or
+/// git is unavailable — callers fall back to the path's own basename.
+fn git_main_repo_root(path: &Path) -> Option<PathBuf> {
+    // ponytail: shell out — avoids threading a git2 Repository through this pure
+    // path helper; one subprocess per CLI invocation is negligible.
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    // `--git-common-dir` points at `<main-repo>/.git`; its parent is the root.
+    let common = PathBuf::from(std::str::from_utf8(&out.stdout).ok()?.trim());
+    common.parent().map(Path::to_path_buf)
 }
 
 pub fn expand_tilde(path: &str) -> PathBuf {
@@ -216,7 +244,37 @@ mod tests {
 
     #[test]
     fn test_project_name() {
+        // Non-git path falls back to its own basename.
         let path = PathBuf::from("/home/user/Projects/my-app");
         assert_eq!(project_name_from_path(&path), "my-app");
+    }
+
+    #[test]
+    fn worktree_shares_main_repo_name() {
+        use std::process::Command;
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("myrepo");
+        std::fs::create_dir(&repo).unwrap();
+
+        let git = |args: &[&str]| {
+            let ok = Command::new("git")
+                .args(["-c", "user.email=t@t", "-c", "user.name=t"])
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .unwrap()
+                .status
+                .success();
+            assert!(ok, "git {args:?} failed");
+        };
+        git(&["init", "-q"]);
+        git(&["commit", "-q", "--allow-empty", "-m", "init"]);
+        let wt = tmp.path().join("wt-foo");
+        git(&["worktree", "add", "-q", wt.to_str().unwrap()]);
+
+        // Both the main tree and the linked worktree key to the repo's name —
+        // one shared index instead of one per worktree.
+        assert_eq!(project_name_from_path(&repo), "myrepo");
+        assert_eq!(project_name_from_path(&wt), "myrepo");
     }
 }


### PR DESCRIPTION
## Problem
`project_name_from_path` keyed the codebase index by **directory basename**, so every git worktree re-indexed the whole repo as a separate `<branch>.lance`. On this machine that produced **~2.5 GB of near-duplicate `mur` indexes** under `~/.mur/indexes/codebase/` — ~22 copies (~130–160 MB each), one per old branch worktree (unified-channel, workflow-engine-w3b, voice-mobile, hub-*, agent-cli-*, …).

This surfaced while reviewing the turbovec vector-backend spec: the spec proposed 8× quantization to cut "vector memory", but the real corpora it targets are tiny (`index/sources.lance` = 184 KB, `skills` = 156 KB). The only large vector data was the codebase index — and that was **duplication, not density**. Compressing duplicates is the wrong axis; not creating them is the fix.

## Change
- `project_name_from_path` resolves a worktree to its **main working tree** via `git rev-parse --path-format=absolute --git-common-dir` (parent of the common dir = repo root). All worktrees of a repo now share one index.
- Falls back to the path basename when not a git repo or git is unavailable (zero-risk degradation; existing non-git behavior preserved).
- Same resolution applied to `inject`/`sync` project scoping so injection-learning and the codebase index agree on project identity.
- Single chokepoint: `cmd/project.rs` index/search/remove all route through the helper.

## Test
`worktree_shares_main_repo_name` builds a repo + a linked worktree and asserts both resolve to the repo name. `cargo test -p mur-core codebase::scanner::` → 4 passed; clippy clean on touched files; fmt clean.

## Operator note
This stops *new* duplicates. Reclaiming the existing ~2.5 GB is a manual delete of the stale `*.lance` dirs under `~/.mur/indexes/codebase/` (the spec review listed the exact set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)