### PR TITLE
fix(test): Windows-robust LLM no_proxy isolation test (fix-forward for #508)

### DIFF
--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -217,7 +217,7 @@ mod tests {
 #[cfg(test)]
 mod proxy_isolation_tests {
     use super::*;
-    use tokio::io::AsyncWriteExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
     /// The cc-proxy guarantee: a client built via `llm_client_builder()` reaches
@@ -231,9 +231,19 @@ mod proxy_isolation_tests {
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {
             if let Ok((mut s, _)) = listener.accept().await {
+                // Drain the request so the client's send completes, then reply
+                // with an explicit close + flush + graceful shutdown. Without
+                // this, dropping the socket right after write_all races the OS
+                // flush and Windows aborts the connection (os error 10053).
+                let mut buf = [0u8; 1024];
+                let _ = s.read(&mut buf).await;
                 let _ = s
-                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+                    )
                     .await;
+                let _ = s.flush().await;
+                let _ = s.shutdown().await;
             }
         });
         // SAFETY: set/cleared within this test; reqwest reads proxy env at build.


### PR DESCRIPTION
Fix-forward: #508's `llm_client_builder_ignores_ambient_http_proxy` test failed `Test (windows-latest)` on main.

## Cause

The test's minimal loopback server wrote the HTTP response then dropped the socket immediately. On Windows that races the OS send-flush and aborts the connection (`os error 10053`, `ConnectionAborted`) before reqwest reads the body — so the client got an error even though it correctly reached the server directly (not the dead `HTTP_PROXY`). Passed on macOS/Linux (more lenient close semantics).

## Fix

Server now drains the request, replies with `Connection: close`, then `flush()` + graceful `shutdown()` before dropping. Strictly more robust; still passes macOS/Linux.

## Note (separate, not mine)

The same Windows run also flaked on `executor::dag::tests::max_concurrency_bounds_parallel_steps` (a pre-existing timing-based concurrency test, untouched by #508) — intermittent; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)