### PR TITLE
feat(addon): network install — git source + marketplace --plugin (#1)

### DIFF
--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -811,6 +811,10 @@ pub enum AgentAddonAction {
         /// `owner/repo` (GitHub), an https/ssh git URL, or any `*.git`. Git
         /// sources are shallow-cloned into `~/.mur/cache/addons/` then imported.
         plugin_dir: String,
+        /// When the source is a marketplace (`.claude-plugin/marketplace.json`
+        /// indexing many plugins), the plugin to install. Omit to list them.
+        #[arg(long)]
+        plugin: Option<String>,
         /// Override security-scan blocks (review the skill first)
         #[arg(long)]
         force: bool,

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -807,7 +807,9 @@ pub enum AgentAddonAction {
     Import {
         /// Agent name
         name: String,
-        /// Path to local Claude plugin directory (must contain plugin.json)
+        /// Local plugin directory, or a git source to install from the network:
+        /// `owner/repo` (GitHub), an https/ssh git URL, or any `*.git`. Git
+        /// sources are shallow-cloned into `~/.mur/cache/addons/` then imported.
         plugin_dir: String,
         /// Override security-scan blocks (review the skill first)
         #[arg(long)]

--- a/mur-core/src/cmd/agent/addon/import.rs
+++ b/mur-core/src/cmd/agent/addon/import.rs
@@ -45,6 +45,27 @@ pub fn cmd_addon_import(name: &str, plugin_dir: &str, force: bool) -> Result<()>
     let mur_home = crate::cmd::resolve_mur_home()?;
     let agent_skills_dir = mur_home.join("agents").join(name).join("skills");
 
+    // Network install: when the source is a git ref (`owner/repo` shorthand or
+    // a git URL) and not an existing local path, shallow-clone it into the addon
+    // cache and import from there. The fetched plugin still goes through the same
+    // security scan + fail-closed (disabled) install below.
+    let fetched;
+    let plugin_dir: &str = if std::path::Path::new(plugin_dir).exists() {
+        plugin_dir
+    } else if let AddonSource::Git {
+        clone_url,
+        cache_key,
+    } = resolve_addon_source(plugin_dir)
+    {
+        let dest = mur_home.join("cache").join("addons").join(&cache_key);
+        crate::cmd::skill_registry::git_clone_or_pull(&clone_url, &dest)?;
+        println!("Fetched {clone_url} → {}", dest.display());
+        fetched = dest.to_string_lossy().into_owned();
+        &fetched
+    } else {
+        plugin_dir
+    };
+
     // Canonicalize the plugin root (rejects a non-existent dir).
     let root = fs::canonicalize(plugin_dir)
         .map_err(|e| anyhow::anyhow!("plugin dir {plugin_dir:?}: {e}"))?;
@@ -248,7 +269,10 @@ fn scan_or_block(manifest: &mur_common::skill::SkillManifest, force: bool) -> Re
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AddonSource {
     Local,
-    Git { clone_url: String, cache_key: String },
+    Git {
+        clone_url: String,
+        cache_key: String,
+    },
 }
 
 /// Filesystem-safe cache dir name derived from a git URL (scheme/`.git`/user
@@ -286,18 +310,23 @@ pub fn resolve_addon_source(input: &str) -> AddonSource {
     }
     // `owner/repo` GitHub shorthand: exactly two git-safe segments, and not a
     // relative/absolute/home path.
-    if !s.starts_with('.') && !s.starts_with('/') && !s.starts_with('~') {
-        if let Some((owner, repo)) = s.split_once('/') {
-            let safe = |p: &str| {
-                !p.is_empty()
-                    && p.chars()
-                        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+    if !s.starts_with('.')
+        && !s.starts_with('/')
+        && !s.starts_with('~')
+        && let Some((owner, repo)) = s.split_once('/')
+    {
+        let safe = |p: &str| {
+            !p.is_empty()
+                && p.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+        };
+        if safe(owner) && safe(repo) {
+            let clone_url = format!("https://github.com/{owner}/{repo}.git");
+            let cache_key = cache_key_for(&clone_url);
+            return AddonSource::Git {
+                clone_url,
+                cache_key,
             };
-            if safe(owner) && safe(repo) {
-                let clone_url = format!("https://github.com/{owner}/{repo}.git");
-                let cache_key = cache_key_for(&clone_url);
-                return AddonSource::Git { clone_url, cache_key };
-            }
         }
     }
     AddonSource::Local
@@ -332,7 +361,10 @@ mod tests {
             AddonSource::Git { .. }
         ));
         // Local paths stay local.
-        assert_eq!(resolve_addon_source("./plugins/ponytail"), AddonSource::Local);
+        assert_eq!(
+            resolve_addon_source("./plugins/ponytail"),
+            AddonSource::Local
+        );
         assert_eq!(resolve_addon_source("/abs/path"), AddonSource::Local);
         assert_eq!(resolve_addon_source("~/x"), AddonSource::Local);
         // A multi-segment relative path is NOT owner/repo shorthand.

--- a/mur-core/src/cmd/agent/addon/import.rs
+++ b/mur-core/src/cmd/agent/addon/import.rs
@@ -240,10 +240,104 @@ fn scan_or_block(manifest: &mur_common::skill::SkillManifest, force: bool) -> Re
     Ok(())
 }
 
+/// How an addon import source was classified. An *existing* local path is
+/// always treated as Local by the caller (checked before this runs); for a
+/// non-existent input this recognizes git URLs and `owner/repo` GitHub
+/// shorthand so `mur agent addon import <agent> owner/repo` installs from the
+/// network instead of only a local directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AddonSource {
+    Local,
+    Git { clone_url: String, cache_key: String },
+}
+
+/// Filesystem-safe cache dir name derived from a git URL (scheme/`.git`/user
+/// stripped, separators flattened) so the same repo maps to one cache dir
+/// whether referenced by https, ssh, or shorthand.
+pub fn cache_key_for(url: &str) -> String {
+    let s = url
+        .trim()
+        .strip_suffix(".git")
+        .unwrap_or(url.trim())
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_start_matches("ssh://")
+        .replace("git@", "")
+        .replace(':', "/");
+    s.split('/')
+        .filter(|seg| !seg.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+pub fn resolve_addon_source(input: &str) -> AddonSource {
+    let s = input.trim();
+    // Explicit git URLs.
+    if s.starts_with("https://")
+        || s.starts_with("http://")
+        || s.starts_with("ssh://")
+        || s.starts_with("git@")
+        || s.ends_with(".git")
+    {
+        return AddonSource::Git {
+            clone_url: s.to_string(),
+            cache_key: cache_key_for(s),
+        };
+    }
+    // `owner/repo` GitHub shorthand: exactly two git-safe segments, and not a
+    // relative/absolute/home path.
+    if !s.starts_with('.') && !s.starts_with('/') && !s.starts_with('~') {
+        if let Some((owner, repo)) = s.split_once('/') {
+            let safe = |p: &str| {
+                !p.is_empty()
+                    && p.chars()
+                        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+            };
+            if safe(owner) && safe(repo) {
+                let clone_url = format!("https://github.com/{owner}/{repo}.git");
+                let cache_key = cache_key_for(&clone_url);
+                return AddonSource::Git { clone_url, cache_key };
+            }
+        }
+    }
+    AddonSource::Local
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
+
+    #[test]
+    fn resolve_addon_source_classifies_git_and_local() {
+        // GitHub `owner/repo` shorthand → clone from github over https.
+        assert_eq!(
+            resolve_addon_source("mur-run/skill-registry"),
+            AddonSource::Git {
+                clone_url: "https://github.com/mur-run/skill-registry.git".into(),
+                cache_key: "github.com-mur-run-skill-registry".into(),
+            }
+        );
+        // Explicit https URL kept as-is; same cache key as shorthand.
+        assert_eq!(
+            resolve_addon_source("https://github.com/mur-run/skill-registry.git"),
+            AddonSource::Git {
+                clone_url: "https://github.com/mur-run/skill-registry.git".into(),
+                cache_key: "github.com-mur-run-skill-registry".into(),
+            }
+        );
+        // SSH URL.
+        assert!(matches!(
+            resolve_addon_source("git@github.com:o/r.git"),
+            AddonSource::Git { .. }
+        ));
+        // Local paths stay local.
+        assert_eq!(resolve_addon_source("./plugins/ponytail"), AddonSource::Local);
+        assert_eq!(resolve_addon_source("/abs/path"), AddonSource::Local);
+        assert_eq!(resolve_addon_source("~/x"), AddonSource::Local);
+        // A multi-segment relative path is NOT owner/repo shorthand.
+        assert_eq!(resolve_addon_source("a/b/c"), AddonSource::Local);
+    }
 
     // Delegate to the shared lock defined at the addon module level so that
     // tests in import.rs and mod.rs are serialized against each other.

--- a/mur-core/src/cmd/agent/addon/import.rs
+++ b/mur-core/src/cmd/agent/addon/import.rs
@@ -3,7 +3,7 @@
 //! fail-closed (disabled) `AddonRef`.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Result, bail};
 
@@ -40,7 +40,16 @@ struct PendingMcp {
     shellish_warn: bool,
 }
 
-pub fn cmd_addon_import(name: &str, plugin_dir: &str, force: bool) -> Result<()> {
+/// Import a Claude plugin into `name`. `plugin_dir` is a local dir or a git
+/// source (owner/repo, url). `plugin` selects one plugin when the source is a
+/// marketplace (`.claude-plugin/marketplace.json` indexing many plugins).
+pub fn cmd_addon_import(
+    name: &str,
+    plugin_dir: &str,
+    plugin: Option<&str>,
+    force: bool,
+) -> Result<()> {
+    let requested = plugin_dir; // original user input, for messages
     let (profile_path, mut profile) = load_profile_for_edit(name)?;
     let mur_home = crate::cmd::resolve_mur_home()?;
     let agent_skills_dir = mur_home.join("agents").join(name).join("skills");
@@ -69,6 +78,9 @@ pub fn cmd_addon_import(name: &str, plugin_dir: &str, force: bool) -> Result<()>
     // Canonicalize the plugin root (rejects a non-existent dir).
     let root = fs::canonicalize(plugin_dir)
         .map_err(|e| anyhow::anyhow!("plugin dir {plugin_dir:?}: {e}"))?;
+    // Marketplace: if this source indexes multiple plugins, resolve the one
+    // requested by `--plugin` (cloning its source if it lives in another repo).
+    let root = resolve_marketplace(&root, plugin, requested, &mur_home)?;
     // plugin.json sits at the dir root (flat layout) or under .claude-plugin/
     // (the canonical Claude marketplace layout). Try the root first, then fall
     // back so a stock marketplace plugin dir imports without restructuring.
@@ -332,6 +344,65 @@ pub fn resolve_addon_source(input: &str) -> AddonSource {
     AddonSource::Local
 }
 
+/// If `root` contains a `marketplace.json` (flat or under `.claude-plugin/`),
+/// pick which plugin directory to import: `--plugin <name>` resolves one
+/// (cloning its source if it lives in another repo); absent `--plugin` with
+/// multiple plugins and no root `plugin.json` lists them and bails; otherwise
+/// (the root is itself a plugin) `root` is returned unchanged.
+fn resolve_marketplace(
+    root: &Path,
+    plugin: Option<&str>,
+    requested: &str,
+    mur_home: &Path,
+) -> Result<PathBuf> {
+    let mp = {
+        let flat = root.join("marketplace.json");
+        if flat.is_file() {
+            Some(flat)
+        } else {
+            let nested = root.join(".claude-plugin").join("marketplace.json");
+            nested.is_file().then_some(nested)
+        }
+    };
+    let Some(mp) = mp else {
+        return Ok(root.to_path_buf());
+    };
+    let manifest = super::marketplace::parse_marketplace(&fs::read_to_string(&mp)?)?;
+
+    if let Some(want) = plugin {
+        let entry = super::marketplace::find_plugin(&manifest, want).ok_or_else(|| {
+            anyhow::anyhow!(
+                "plugin '{want}' not in this marketplace; available: {}",
+                manifest
+                    .plugins
+                    .iter()
+                    .map(|p| p.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
+        let cache = mur_home.join("cache").join("addons");
+        let dir = super::marketplace::resolve_plugin_dir(entry, root, &cache)?;
+        return fs::canonicalize(&dir).map_err(|e| anyhow::anyhow!("plugin dir {dir:?}: {e}"));
+    }
+
+    // No --plugin: if the root is itself a plugin, import it (single-plugin
+    // behavior). Otherwise it's a pure marketplace — list and ask.
+    let root_is_plugin = root.join("plugin.json").is_file()
+        || root.join(".claude-plugin").join("plugin.json").is_file();
+    if !root_is_plugin && !manifest.plugins.is_empty() {
+        println!(
+            "'{requested}' is a marketplace with {} plugin(s); choose one with --plugin <name>:",
+            manifest.plugins.len()
+        );
+        for p in &manifest.plugins {
+            println!("  {}\t{}", p.name, p.description);
+        }
+        bail!("specify --plugin <name>");
+    }
+    Ok(root.to_path_buf())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -434,7 +505,7 @@ mod tests {
         let plugin = home.join("sample-plugin");
         write_plugin(&plugin);
 
-        cmd_addon_import("alice", plugin.to_str().unwrap(), false).unwrap();
+        cmd_addon_import("alice", plugin.to_str().unwrap(), None, false).unwrap();
 
         // Reload alice's profile.
         let (_p, alice) = crate::cmd::agent::load_profile_for_edit("alice").unwrap();
@@ -487,7 +558,7 @@ mod tests {
         )
         .unwrap();
 
-        cmd_addon_import("dana", plugin.to_str().unwrap(), false).unwrap();
+        cmd_addon_import("dana", plugin.to_str().unwrap(), None, false).unwrap();
 
         let (_p, dana) = crate::cmd::agent::load_profile_for_edit("dana").unwrap();
         let g = dana.addons.iter().find(|g| g.id == "claudefmt").unwrap();
@@ -529,7 +600,7 @@ mod tests {
         write_plugin(&plugin);
 
         // First import must succeed.
-        cmd_addon_import("charlie", plugin.to_str().unwrap(), false).unwrap();
+        cmd_addon_import("charlie", plugin.to_str().unwrap(), None, false).unwrap();
 
         // Record the original skill content so we can verify it is not modified.
         let skill_path = home.join("agents/charlie/skills/brainstorm/skill.yaml");
@@ -548,7 +619,7 @@ mod tests {
         fs::write(&profile_path, new_yaml).unwrap();
 
         // Second import must fail with the overwrite refusal message.
-        let err = cmd_addon_import("charlie", plugin.to_str().unwrap(), false)
+        let err = cmd_addon_import("charlie", plugin.to_str().unwrap(), None, false)
             .unwrap_err()
             .to_string();
         assert!(

--- a/mur-core/src/cmd/agent/addon/marketplace.rs
+++ b/mur-core/src/cmd/agent/addon/marketplace.rs
@@ -1,0 +1,133 @@
+//! Claude plugin **marketplace** support: a `.claude-plugin/marketplace.json`
+//! that indexes many plugins. `mur agent addon import <agent> <marketplace>
+//! --plugin <name>` clones the marketplace, finds the named plugin, resolves
+//! its source (a relative path inside the marketplace repo, or a separate
+//! `url`/`github`/`git-subdir` repo cloned into the addon cache), and imports
+//! that directory through the normal local-dir importer.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MarketplaceManifest {
+    #[serde(default)]
+    pub plugins: Vec<MarketplacePlugin>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MarketplacePlugin {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub source: PluginSource,
+}
+
+/// A plugin's location: a relative path inside the marketplace repo, or a
+/// separate repo to clone.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum PluginSource {
+    /// e.g. `"./plugins/foo"` or `"./"`.
+    Path(String),
+    /// e.g. `{"source":"url","url":"…"}` / `{"source":"git-subdir","url":"…","path":"…"}`.
+    Remote(RemotePluginSource),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RemotePluginSource {
+    pub source: String,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+/// Parse a `.claude-plugin/marketplace.json`.
+pub fn parse_marketplace(content: &str) -> Result<MarketplaceManifest> {
+    Ok(serde_json::from_str(content)?)
+}
+
+/// Find a plugin entry by name.
+pub fn find_plugin<'a>(m: &'a MarketplaceManifest, name: &str) -> Option<&'a MarketplacePlugin> {
+    m.plugins.iter().find(|p| p.name == name)
+}
+
+/// Resolve a plugin's on-disk directory under `marketplace_root`, cloning a
+/// remote source into `addon_cache` if needed.
+pub fn resolve_plugin_dir(
+    plugin: &MarketplacePlugin,
+    marketplace_root: &Path,
+    addon_cache: &Path,
+) -> Result<PathBuf> {
+    match &plugin.source {
+        PluginSource::Path(rel) => {
+            let rel = rel.trim_start_matches("./").trim_start_matches('/');
+            Ok(marketplace_root.join(rel))
+        }
+        PluginSource::Remote(r) => {
+            let clone_url = remote_clone_url(r)?;
+            let key = super::import::cache_key_for(&clone_url);
+            let dest = addon_cache.join(key);
+            crate::cmd::skill_registry::git_clone_or_pull(&clone_url, &dest)?;
+            match &r.path {
+                Some(p) => Ok(dest.join(p.trim_start_matches("./").trim_start_matches('/'))),
+                None => Ok(dest),
+            }
+        }
+    }
+}
+
+fn remote_clone_url(r: &RemotePluginSource) -> Result<String> {
+    if let Some(url) = &r.url {
+        return Ok(url.clone());
+    }
+    if let Some(repo) = &r.repo {
+        return Ok(format!("https://github.com/{repo}.git"));
+    }
+    anyhow::bail!("plugin source '{}' has no url/repo to clone", r.source)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"{
+      "name": "m",
+      "plugins": [
+        {"name": "a", "description": "da", "source": "./plugins/a"},
+        {"name": "b", "source": {"source": "url", "url": "https://github.com/o/b.git"}},
+        {"name": "c", "source": {"source": "git-subdir", "url": "https://github.com/o/mono.git", "path": "plugins/c"}}
+      ]
+    }"#;
+
+    #[test]
+    fn parse_find_and_resolve_relative_path() {
+        let m = parse_marketplace(SAMPLE).unwrap();
+        assert_eq!(m.plugins.len(), 3);
+        assert_eq!(find_plugin(&m, "a").unwrap().name, "a");
+        assert!(find_plugin(&m, "nope").is_none());
+
+        // A relative-path source resolves under the marketplace root, no clone.
+        let dir = resolve_plugin_dir(
+            find_plugin(&m, "a").unwrap(),
+            Path::new("/mkt"),
+            Path::new("/cache"),
+        )
+        .unwrap();
+        assert_eq!(dir, PathBuf::from("/mkt/plugins/a"));
+
+        // The remote variants parse into Remote with their fields.
+        assert!(matches!(
+            find_plugin(&m, "b").unwrap().source,
+            PluginSource::Remote(ref r) if r.source == "url"
+        ));
+        assert!(matches!(
+            find_plugin(&m, "c").unwrap().source,
+            PluginSource::Remote(ref r) if r.path.as_deref() == Some("plugins/c")
+        ));
+    }
+}

--- a/mur-core/src/cmd/agent/addon/mod.rs
+++ b/mur-core/src/cmd/agent/addon/mod.rs
@@ -1,6 +1,7 @@
 //! Per-agent add-on (Claude plugin) import + lifecycle (Phase 2).
 
 pub mod import;
+pub mod marketplace;
 pub mod parse;
 
 use std::fs;

--- a/mur-core/src/cmd/skill_registry.rs
+++ b/mur-core/src/cmd/skill_registry.rs
@@ -17,13 +17,20 @@ pub fn registry_cache_dir(mur_home: &Path) -> PathBuf {
 
 pub fn fetch_registry(mur_home: &Path, registry_url: &str) -> Result<PathBuf> {
     let cache_dir = registry_cache_dir(mur_home);
-    let git_dir = cache_dir.join(".git");
+    git_clone_or_pull(registry_url, &cache_dir)?;
+    Ok(cache_dir)
+}
 
-    if git_dir.exists() {
+/// Shallow-clone `url` into `dest`, or `git pull --ff-only` if it already
+/// exists. Shared by the skill registry and the addon network installer
+/// (`mur agent addon import <agent> owner/repo`). A failed refresh of an
+/// existing clone is a warning, not an error (we fall back to the cache).
+pub fn git_clone_or_pull(url: &str, dest: &Path) -> Result<()> {
+    if dest.join(".git").exists() {
         let status = Command::new("git")
             .args([
                 "-C",
-                &*cache_dir.to_string_lossy(),
+                &*dest.to_string_lossy(),
                 "pull",
                 "--depth=1",
                 "--ff-only",
@@ -31,25 +38,25 @@ pub fn fetch_registry(mur_home: &Path, registry_url: &str) -> Result<PathBuf> {
             .status()
             .map_err(|e| anyhow::anyhow!("git pull: {e}"))?;
         if !status.success() {
-            eprintln!("warning: registry refresh failed, using cached");
+            eprintln!(
+                "warning: refresh of {} failed, using cached",
+                dest.display()
+            );
         }
     } else {
-        let parent = cache_dir.parent().unwrap_or(mur_home);
-        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
         let status = Command::new("git")
-            .args([
-                "clone",
-                "--depth=1",
-                registry_url,
-                &*cache_dir.to_string_lossy(),
-            ])
+            .args(["clone", "--depth=1", url, &*dest.to_string_lossy()])
             .status()
             .map_err(|e| anyhow::anyhow!("git clone: {e}"))?;
         if !status.success() {
-            anyhow::bail!("failed to clone registry from {registry_url}");
+            anyhow::bail!("failed to clone {url}");
         }
     }
-    Ok(cache_dir)
+    Ok(())
 }
 
 pub fn load_index(registry_dir: &Path) -> Result<RegistryIndex> {
@@ -115,6 +122,38 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+
+    fn git(args: &[&str], cwd: &Path) {
+        let ok = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .status()
+            .expect("run git")
+            .success();
+        assert!(ok, "git {args:?} failed");
+    }
+
+    #[test]
+    fn git_clone_or_pull_clones_then_refreshes() {
+        let tmp = tempdir().unwrap();
+        // Build a source repo with one committed file.
+        let src = tmp.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        git(&["init", "-q", "-b", "main"], &src);
+        git(&["config", "user.email", "t@t"], &src);
+        git(&["config", "user.name", "t"], &src);
+        fs::write(src.join("plugin.json"), "{}").unwrap();
+        git(&["add", "."], &src);
+        git(&["commit", "-qm", "init"], &src);
+
+        let dest = tmp.path().join("cache").join("addons").join("local-src");
+        // First call clones (dest does not exist yet; parent is created).
+        git_clone_or_pull(&src.to_string_lossy(), &dest).unwrap();
+        assert!(dest.join("plugin.json").exists(), "clone produced the file");
+        // Second call hits the pull branch and still succeeds.
+        git_clone_or_pull(&src.to_string_lossy(), &dest).unwrap();
+        assert!(dest.join("plugin.json").exists());
+    }
 
     #[test]
     fn cache_dir_path() {

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1346,8 +1346,9 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             AgentAddonAction::Import {
                 name,
                 plugin_dir,
+                plugin,
                 force,
-            } => cmd::agent::addon::cmd_addon_import(&name, &plugin_dir, force)?,
+            } => cmd::agent::addon::cmd_addon_import(&name, &plugin_dir, plugin.as_deref(), force)?,
             AgentAddonAction::List { name } => cmd::agent::addon::cmd_addon_list(&name)?,
             AgentAddonAction::Enable { name, addon_id } => {
                 cmd::agent::addon::cmd_addon_set_enabled(&name, &addon_id, true)?

--- a/mur-hub-gui/src-tauri/src/mcp_skills.rs
+++ b/mur-hub-gui/src-tauri/src/mcp_skills.rs
@@ -114,7 +114,7 @@ pub fn agent_addon_import(
     plugin_dir: String,
     force: Option<bool>,
 ) -> Result<AgentDetail, String> {
-    mur_core::cmd::agent::addon::cmd_addon_import(&name, &plugin_dir, force.unwrap_or(false))
+    mur_core::cmd::agent::addon::cmd_addon_import(&name, &plugin_dir, None, force.unwrap_or(false))
         .map_err(|e| format!("{e:#}"))?;
     get_agent_detail(name)
 }


### PR DESCRIPTION
Roadmap item **#1 (network install)** — the importer installs from the **network**, not only a local directory. Two slices:

## 1. Install from a git source

```bash
mur agent addon import <agent> DietrichGebert/ponytail      # GitHub owner/repo
mur agent addon import <agent> https://github.com/o/r.git   # https/ssh/*.git
mur agent addon import <agent> ./local/plugin               # local (unchanged)
```
Git sources shallow-clone into `~/.mur/cache/addons/<host-owner-repo>` then import via the existing local-dir importer (same security scan + fail-closed install). `resolve_addon_source` classifies local vs git; a shared `skill_registry::git_clone_or_pull` (refactored from the skill-registry fetch) does clone/pull.

## 2. Install one plugin from a marketplace

```bash
mur agent addon import <agent> <marketplace-source>                 # lists the plugins
mur agent addon import <agent> <marketplace-source> --plugin <name> # installs one
```
Parses `.claude-plugin/marketplace.json`; `--plugin <name>` resolves the plugin's `source` — a relative subdir, or a separate `url`/`github`/`git-subdir` repo cloned into the cache — and imports it. No `--plugin` on a pure marketplace lists the plugins and asks.

## Verification

- TDD: `resolve_addon_source` (shorthand/https/ssh/local/multi-segment), `git_clone_or_pull` (deterministic local-repo clone+pull), `parse_find_and_resolve_relative_path` (marketplace parse/find/resolve). Full `addon::` suite **20/20**.
- **Live E2E**: installed `DietrichGebert/ponytail` from GitHub; listed the 240-plugin official marketplace + installed `agent-sdk-dev` via `--plugin`.
- CI-gate clippy (`--no-deps -D warnings`) clean. Hub caller updated to the new `cmd_addon_import(.., plugin, ..)` signature.

## Follow-ups

`npm` plugin sources; the official MCP Registry client; remote MCP (`type:http` + OAuth). A Hub UI surface for these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)