### PR TITLE
fix(test): de-flake max_concurrency_bounds_parallel_steps (relative timing)

### DIFF
--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -1290,10 +1290,6 @@ mod tests {
             .await
             .unwrap();
         let bounded = t.elapsed();
-        assert!(
-            bounded.as_millis() >= 500,
-            "bounded run finished too fast ({bounded:?}); cap not applied"
-        );
 
         // Unbounded -> single wave -> ~0.2s.
         let opts2 = DagExecOptions {
@@ -1305,9 +1301,13 @@ mod tests {
             .await
             .unwrap();
         let unbounded = t2.elapsed();
+        // Compare RELATIVE to the unbounded run rather than against an absolute
+        // wall-clock threshold: a loaded CI runner inflates both, so the cap's
+        // effect (~3 waves vs 1) stays a stable ratio while absolute thresholds
+        // flake (this test chronically failed on slow Windows/macOS runners).
         assert!(
-            unbounded.as_millis() < 500,
-            "unbounded run too slow ({unbounded:?}); regression in default path"
+            bounded.as_millis() as f64 >= unbounded.as_millis() as f64 * 1.5,
+            "bounded ({bounded:?}) should be >=1.5x unbounded ({unbounded:?}); cap not applied"
         );
     }
 }


### PR DESCRIPTION
The `executor::dag::tests::max_concurrency_bounds_parallel_steps` test has flaked **3×** in recent CI (Test windows-latest on #508, Test macos-14 on #509, Test windows-latest on #510) — each time unrelated to the PR's changes, blocking merges.

## Cause

It asserts **absolute wall-clock thresholds**: bounded (cap=2) `>= 500ms` and unbounded `< 500ms`. The steps are 6 × `sleep 0.2`. On a loaded/slow CI runner, even the *unbounded* single wave (6 concurrent subprocess spawns + scheduling) exceeds 500ms, tripping `unbounded < 500`.

## Fix

Assert the cap's effect **relative** to the unbounded run instead: bounded (≈3 sequential waves) must be `>= 1.5×` the unbounded run (≈1 wave). Both scale with runner speed, so the ratio is stable while absolute thresholds are not. Still catches a broken cap (bounded ≈ unbounded → ratio ≈ 1 → fails). Verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)