### PR TITLE
feat(addon): npm plugin sources in marketplaces (#1 follow-up)

### DIFF
--- a/mur-core/src/cmd/agent/addon/marketplace.rs
+++ b/mur-core/src/cmd/agent/addon/marketplace.rs
@@ -1,9 +1,10 @@
 //! Claude plugin **marketplace** support: a `.claude-plugin/marketplace.json`
 //! that indexes many plugins. `mur agent addon import <agent> <marketplace>
 //! --plugin <name>` clones the marketplace, finds the named plugin, resolves
-//! its source (a relative path inside the marketplace repo, or a separate
-//! `url`/`github`/`git-subdir` repo cloned into the addon cache), and imports
-//! that directory through the normal local-dir importer.
+//! its source (a relative path inside the marketplace repo; a separate
+//! `url`/`github`/`git-subdir` repo cloned into the addon cache; or an `npm`
+//! package installed into the cache), and imports that directory through the
+//! normal local-dir importer.
 
 use std::path::{Path, PathBuf};
 
@@ -44,6 +45,13 @@ pub struct RemotePluginSource {
     pub repo: Option<String>,
     #[serde(default)]
     pub path: Option<String>,
+    // npm source: {"source":"npm","package":"…","version":"…?","registry":"…?"}
+    #[serde(default)]
+    pub package: Option<String>,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub registry: Option<String>,
 }
 
 /// Parse a `.claude-plugin/marketplace.json`.
@@ -68,6 +76,7 @@ pub fn resolve_plugin_dir(
             let rel = rel.trim_start_matches("./").trim_start_matches('/');
             Ok(marketplace_root.join(rel))
         }
+        PluginSource::Remote(r) if r.source == "npm" => npm_install_to_cache(r, addon_cache),
         PluginSource::Remote(r) => {
             let clone_url = remote_clone_url(r)?;
             let key = super::import::cache_key_for(&clone_url);
@@ -79,6 +88,47 @@ pub fn resolve_plugin_dir(
             }
         }
     }
+}
+
+/// The `npm install` spec for a package: `package@version` if a version is
+/// given, else just `package`.
+fn npm_spec(package: &str, version: Option<&str>) -> String {
+    match version {
+        Some(v) => format!("{package}@{v}"),
+        None => package.to_string(),
+    }
+}
+
+/// `npm install` the package into a private prefix under the addon cache and
+/// return the installed package directory (`<prefix>/node_modules/<package>`).
+fn npm_install_to_cache(r: &RemotePluginSource, addon_cache: &Path) -> Result<PathBuf> {
+    let package = r
+        .package
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("npm plugin source has no 'package'"))?;
+    let prefix = addon_cache.join(format!("npm-{}", super::import::cache_key_for(package)));
+    std::fs::create_dir_all(&prefix)
+        .map_err(|e| anyhow::anyhow!("create {}: {e}", prefix.display()))?;
+    let mut cmd = std::process::Command::new("npm");
+    cmd.args([
+        "install",
+        "--prefix",
+        &prefix.to_string_lossy(),
+        "--no-audit",
+        "--no-fund",
+        "--silent",
+        &npm_spec(package, r.version.as_deref()),
+    ]);
+    if let Some(reg) = &r.registry {
+        cmd.args(["--registry", reg]);
+    }
+    let status = cmd
+        .status()
+        .map_err(|e| anyhow::anyhow!("npm install: {e}"))?;
+    if !status.success() {
+        anyhow::bail!("npm install '{package}' failed");
+    }
+    Ok(prefix.join("node_modules").join(package))
 }
 
 fn remote_clone_url(r: &RemotePluginSource) -> Result<String> {
@@ -94,6 +144,26 @@ fn remote_clone_url(r: &RemotePluginSource) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn npm_source_parses_and_specs() {
+        let json = r#"{"plugins":[
+            {"name":"p","source":{"source":"npm","package":"@org/plug","version":"1.2.3"}},
+            {"name":"q","source":{"source":"npm","package":"plain"}}
+        ]}"#;
+        let m = parse_marketplace(json).unwrap();
+        let PluginSource::Remote(r) = &find_plugin(&m, "p").unwrap().source else {
+            panic!("expected remote npm source");
+        };
+        assert_eq!(r.source, "npm");
+        assert_eq!(r.package.as_deref(), Some("@org/plug"));
+        assert_eq!(
+            npm_spec("@org/plug", r.version.as_deref()),
+            "@org/plug@1.2.3"
+        );
+        // No version → bare package.
+        assert_eq!(npm_spec("plain", None), "plain");
+    }
 
     const SAMPLE: &str = r#"{
       "name": "m",


### PR DESCRIPTION
Follow-up to #510 — completes the marketplace plugin-source matrix with **npm**.

## What

A marketplace `plugin.source` of `{"source":"npm","package":"…","version"?:"…","registry"?:"…"}` is now resolved by `npm install`ing the package into `~/.mur/cache/addons/npm-<pkg>` and importing from `node_modules/<package>`. Source types now covered: relative path / `url` / `github` / `git-subdir` / **`npm`**.

## Verification

- Unit: `npm_source_parses_and_specs` (parse npm source; `npm_spec` builds `pkg@version`).
- **Live (fetch path)**: a crafted marketplace with an npm source ran `npm install is-thirteen@2.0.0`, created the `npm-is-thirteen` cache dir, resolved to `node_modules/is-thirteen`, then correctly errored reading *that* `plugin.json` (is-thirteen isn't a Claude plugin — proves the fetch+resolve path; a real npm Claude plugin would import).
- CI-gate clippy clean.

## Note (YAGNI flag)

There is **no npm-published Claude plugin to fully E2E** (0 of 240 official marketplace plugins use npm). This is spec-completion per the Claude plugin-marketplace schema; full import is unit-tested + fetch-verified, not end-to-end with a real plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)