### PR TITLE
feat(mcp): remote MCP — Streamable HTTP transport + bearer (Phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,12 @@ jobs:
       # caps heavy-test (lance/qdrant/tantivy) concurrency to avoid OOM on
       # 16 GB Windows runners.
       - run: cargo nextest run --workspace --locked --profile ci
+        env:
+          # The large `mur` clap CLI needs a deeper per-thread stack to parse on
+          # Windows, whose 1 MB default thread stack overflows during clap's
+          # derive parsing (each test runs on its own thread). 16 MB is safe on
+          # every OS; Linux/macOS already default higher.
+          RUST_MIN_STACK: "16777216"
 
   clippy:
     name: Clippy

--- a/mur-agent-runtime/src/mcp/pool.rs
+++ b/mur-agent-runtime/src/mcp/pool.rs
@@ -45,7 +45,7 @@ impl McpPool {
         let entry = self.entries.get(server).ok_or_else(|| {
             McpError::Server(format!("no MCP server named `{server}` on this agent"))
         })?;
-        let mut client = McpClient::spawn(entry, &self.policy, self.proxy.as_ref()).await?;
+        let mut client = McpClient::connect(entry, &self.policy, self.proxy.as_ref()).await?;
         client.initialize().await?;
 
         // Drain child stderr in a background thread so the pipe never fills.

--- a/mur-agent-runtime/src/protocol/http_mcp_client.rs
+++ b/mur-agent-runtime/src/protocol/http_mcp_client.rs
@@ -1,0 +1,160 @@
+//! Streamable HTTP MCP transport.
+//!
+//! POSTs JSON-RPC 2.0 to a single endpoint and parses JSON-or-SSE responses,
+//! per the MCP Streamable HTTP spec.  Bearer auth and `Mcp-Session-Id` session
+//! tracking are both supported.
+//!
+// ponytail: reuse stdio client's existing JSON→type code — don't write second parser.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use serde_json::{Value, json};
+
+use super::mcp_client::{InitializeInfo, McpError, ToolInfo};
+use super::mcp_sse::{jsonrpc_result_for, parse_sse_events};
+
+const PROTOCOL_VERSION: &str = "2025-06-18";
+
+pub struct HttpMcpClient {
+    http: reqwest::Client,
+    url: String,
+    bearer: Option<String>,
+    session_id: Mutex<Option<String>>,
+    next_id: AtomicI64,
+}
+
+/// Build a JSON-RPC 2.0 request object.
+pub fn jsonrpc_request(id: i64, method: &str, params: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params,
+    })
+}
+
+impl HttpMcpClient {
+    /// Create a client pointed at `url`.  `bearer` is attached as
+    /// `Authorization: Bearer <token>` on every request when present.
+    pub async fn connect(url: &str, bearer: Option<String>) -> Result<Self, McpError> {
+        let http = reqwest::Client::builder()
+            .build()
+            .map_err(|e| McpError::Transport(e.to_string()))?;
+        Ok(Self {
+            http,
+            url: url.to_string(),
+            bearer,
+            session_id: Mutex::new(None),
+            next_id: AtomicI64::new(1),
+        })
+    }
+
+    async fn request(&self, method: &str, params: Value) -> Result<Value, McpError> {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let mut req = self
+            .http
+            .post(&self.url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header("MCP-Protocol-Version", PROTOCOL_VERSION)
+            .json(&jsonrpc_request(id, method, params));
+        if let Some(tok) = &self.bearer {
+            req = req.bearer_auth(tok);
+        }
+        if let Some(sid) = self.session_id.lock().unwrap().clone() {
+            req = req.header("Mcp-Session-Id", sid);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| McpError::Transport(e.to_string()))?;
+        if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(McpError::Unauthorized);
+        }
+        // Capture session id minted on initialize.
+        if let Some(sid) = resp
+            .headers()
+            .get("mcp-session-id")
+            .and_then(|v| v.to_str().ok())
+        {
+            *self.session_id.lock().unwrap() = Some(sid.to_string());
+        }
+        if !resp.status().is_success() {
+            return Err(McpError::Transport(format!("HTTP {}", resp.status())));
+        }
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| McpError::Transport(e.to_string()))?;
+        let events = parse_sse_events(&body);
+        // Check for a JSON-RPC error in the matched event.
+        if let Some(ev) = events
+            .iter()
+            .find(|e| e.get("id").and_then(|i| i.as_i64()) == Some(id))
+            && let Some(err) = ev.get("error")
+        {
+            return Err(McpError::Rpc(err.to_string()));
+        }
+        Ok(jsonrpc_result_for(&events, id)
+            .cloned()
+            .unwrap_or(Value::Null))
+    }
+
+    /// Exchange the MCP `initialize` handshake.
+    pub async fn initialize(&mut self) -> Result<InitializeInfo, McpError> {
+        let res = self
+            .request(
+                "initialize",
+                json!({
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "mur-agent-runtime", "version": env!("CARGO_PKG_VERSION")}
+                }),
+            )
+            .await?;
+        // MCP lifecycle: send `notifications/initialized` after the response.
+        let _ = self
+            .request("notifications/initialized", serde_json::json!({}))
+            .await;
+        InitializeInfo::from_result(&res).map_err(McpError::Protocol)
+    }
+
+    pub async fn list_tools(&self) -> Result<Vec<ToolInfo>, McpError> {
+        let res = self.request("tools/list", json!({})).await?;
+        ToolInfo::list_from_result(&res).map_err(McpError::Protocol)
+    }
+
+    pub async fn call_tool(&self, name: &str, args: Value) -> Result<Value, McpError> {
+        self.request("tools/call", json!({"name": name, "arguments": args}))
+            .await
+    }
+
+    /// Send an HTTP DELETE to terminate the session (best-effort).
+    pub async fn shutdown(self) {
+        if let Some(sid) = self.session_id.into_inner().unwrap() {
+            let mut req = self
+                .http
+                .delete(&self.url)
+                .header("Mcp-Session-Id", sid)
+                .header("MCP-Protocol-Version", PROTOCOL_VERSION);
+            if let Some(tok) = &self.bearer {
+                req = req.bearer_auth(tok);
+            }
+            let _ = req.send().await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_jsonrpc_request() {
+        let r = jsonrpc_request(3, "tools/list", serde_json::json!({}));
+        assert_eq!(r["jsonrpc"], "2.0");
+        assert_eq!(r["id"], 3);
+        assert_eq!(r["method"], "tools/list");
+    }
+}

--- a/mur-agent-runtime/src/protocol/mcp_client.rs
+++ b/mur-agent-runtime/src/protocol/mcp_client.rs
@@ -1,14 +1,18 @@
-//! MCP client — subprocess stdio JSON-RPC 2.0.
+//! MCP client — stdio (subprocess) and HTTP (Streamable HTTP) transports.
+//!
+//! `McpClient` is a dispatch enum over `StdioMcpClient` and `HttpMcpClient`.
+//! Use `McpClient::connect` to pick the right variant based on the server entry.
 
 use crate::sandbox::SandboxPolicy;
-use mur_common::agent::McpServerEntry;
+use mur_common::agent::{McpAuth, McpServerEntry};
 use serde_json::{Value, json};
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::process::{ChildStdin, ChildStdout};
 use tokio::sync::Mutex;
 
-pub struct McpClient {
+/// Stdio (subprocess) MCP transport.
+pub struct StdioMcpClient {
     /// Raw std child — used for kill/wait in `shutdown`.
     child: Mutex<std::process::Child>,
     stdin: Mutex<ChildStdin>,
@@ -18,6 +22,85 @@ pub struct McpClient {
     stderr: Mutex<Option<std::process::ChildStderr>>,
     next_id: Mutex<u64>,
     pub server_name: String,
+}
+
+/// Dispatch enum over stdio and HTTP MCP transports.
+///
+/// Use [`McpClient::connect`] to construct; callers hold `McpClient` and call
+/// the same `initialize` / `list_tools` / `call_tool` / `shutdown` surface
+/// regardless of transport.
+pub enum McpClient {
+    Stdio(Box<StdioMcpClient>),
+    Http(super::http_mcp_client::HttpMcpClient),
+}
+
+impl McpClient {
+    /// Connect to an MCP server, choosing the transport from the entry:
+    /// - `entry.url` is `Some` → Streamable HTTP transport (`HttpMcpClient`)
+    /// - `entry.url` is `None` → stdio subprocess (`StdioMcpClient`)
+    pub async fn connect(
+        entry: &McpServerEntry,
+        policy: &SandboxPolicy,
+        proxy: Option<&crate::sandbox::egress_proxy::EgressProxyHandle>,
+    ) -> Result<Self, McpError> {
+        if let Some(url) = &entry.url {
+            let bearer = resolve_bearer(&entry.auth).await?;
+            let client = super::http_mcp_client::HttpMcpClient::connect(url, bearer).await?;
+            Ok(McpClient::Http(client))
+        } else {
+            let client = StdioMcpClient::spawn(entry, policy, proxy).await?;
+            Ok(McpClient::Stdio(Box::new(client)))
+        }
+    }
+
+    pub async fn take_stderr(&self) -> Option<std::process::ChildStderr> {
+        match self {
+            McpClient::Stdio(c) => c.take_stderr().await,
+            McpClient::Http(_) => None,
+        }
+    }
+
+    pub async fn initialize(&mut self) -> Result<InitializeInfo, McpError> {
+        match self {
+            McpClient::Stdio(c) => c.initialize().await,
+            McpClient::Http(c) => c.initialize().await,
+        }
+    }
+
+    pub async fn list_tools(&self) -> Result<Vec<ToolInfo>, McpError> {
+        match self {
+            McpClient::Stdio(c) => c.list_tools().await,
+            McpClient::Http(c) => c.list_tools().await,
+        }
+    }
+
+    pub async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, McpError> {
+        match self {
+            McpClient::Stdio(c) => c.call_tool(name, arguments).await,
+            McpClient::Http(c) => c.call_tool(name, arguments).await,
+        }
+    }
+
+    pub async fn shutdown(self) {
+        match self {
+            McpClient::Stdio(c) => c.shutdown().await,
+            McpClient::Http(c) => c.shutdown().await,
+        }
+    }
+}
+
+/// Resolve a bearer token from the entry's auth config.
+/// Returns `Ok(Some(token))` for Bearer auth, `Ok(None)` for OAuth (Phase 2)
+/// or when no auth is configured.
+async fn resolve_bearer(auth: &Option<McpAuth>) -> Result<Option<String>, McpError> {
+    match auth {
+        Some(McpAuth::Bearer { token }) => Ok(token.resolve_to_string().await),
+        Some(McpAuth::Oauth(_)) => {
+            // Phase 2 (Task 10): resolve OAuth access token
+            Ok(None)
+        }
+        None => Ok(None),
+    }
 }
 
 #[derive(Debug)]
@@ -97,7 +180,7 @@ impl ToolInfo {
     }
 }
 
-impl McpClient {
+impl StdioMcpClient {
     /// Spawn an MCP server subprocess under the given sandbox policy.
     ///
     /// Uses `sandbox::child::spawn_sandboxed` so that on Linux and macOS the
@@ -293,5 +376,22 @@ mod tests {
             allow_hosts: vec![],
         });
         assert!(proxy_env_for(&inherit, Some(&handle)).is_empty());
+    }
+
+    /// `McpClient::connect` picks the HTTP variant when the entry has a `url`.
+    #[tokio::test]
+    async fn connect_picks_http_for_url_entry() {
+        let entry = McpServerEntry {
+            name: "remote".into(),
+            url: Some("https://example.com/mcp".into()),
+            ..Default::default()
+        };
+        let client = McpClient::connect(&entry, &SandboxPolicy::default(), None)
+            .await
+            .expect("connect should succeed for a url entry");
+        assert!(
+            matches!(client, McpClient::Http(_)),
+            "expected Http variant for url entry"
+        );
     }
 }

--- a/mur-agent-runtime/src/protocol/mcp_client.rs
+++ b/mur-agent-runtime/src/protocol/mcp_client.rs
@@ -44,6 +44,57 @@ pub enum McpError {
     StreamClosed,
     #[error("mcp error: {0}")]
     Server(String),
+    /// HTTP / network transport failure (Streamable HTTP transport).
+    #[error("transport: {0}")]
+    Transport(String),
+    /// JSON-RPC error object returned by the server.
+    #[error("rpc error: {0}")]
+    Rpc(String),
+    /// Unexpected response shape from the server.
+    #[error("protocol: {0}")]
+    Protocol(String),
+    /// Server returned HTTP 401 Unauthorized.
+    #[error("unauthorized")]
+    Unauthorized,
+}
+
+impl InitializeInfo {
+    /// Build from a JSON-RPC `result` value returned by the `initialize` method.
+    /// Returns `Err(reason)` if the shape is completely wrong (empty strings are
+    /// tolerated as the stdio path does via `unwrap_or_default`).
+    pub fn from_result(result: &Value) -> Result<Self, String> {
+        Ok(Self {
+            server_name: result["serverInfo"]["name"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+            server_version: result["serverInfo"]["version"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+            protocol_version: result["protocolVersion"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+        })
+    }
+}
+
+impl ToolInfo {
+    /// Build a list of `ToolInfo` from a JSON-RPC `result` value returned by
+    /// the `tools/list` method. Missing or malformed `tools` array yields an
+    /// empty list (mirrors the stdio path which uses `unwrap_or_default`).
+    pub fn list_from_result(result: &Value) -> Result<Vec<Self>, String> {
+        let tools = result["tools"].as_array().cloned().unwrap_or_default();
+        Ok(tools
+            .into_iter()
+            .map(|t| ToolInfo {
+                name: t["name"].as_str().unwrap_or_default().to_string(),
+                description: t["description"].as_str().unwrap_or_default().to_string(),
+                input_schema: t["inputSchema"].clone(),
+            })
+            .collect())
+    }
 }
 
 impl McpClient {
@@ -150,33 +201,12 @@ impl McpClient {
         // reject every subsequent request (`tools/list`, `tools/call`) with
         // "Not initialized". Universal — required by all MCP servers, not just ours.
         self.notify("notifications/initialized", json!({})).await?;
-        Ok(InitializeInfo {
-            server_name: res["serverInfo"]["name"]
-                .as_str()
-                .unwrap_or_default()
-                .to_string(),
-            server_version: res["serverInfo"]["version"]
-                .as_str()
-                .unwrap_or_default()
-                .to_string(),
-            protocol_version: res["protocolVersion"]
-                .as_str()
-                .unwrap_or_default()
-                .to_string(),
-        })
+        InitializeInfo::from_result(&res).map_err(McpError::Server)
     }
 
     pub async fn list_tools(&self) -> Result<Vec<ToolInfo>, McpError> {
         let res = self.request("tools/list", json!({})).await?;
-        let tools = res["tools"].as_array().cloned().unwrap_or_default();
-        Ok(tools
-            .into_iter()
-            .map(|t| ToolInfo {
-                name: t["name"].as_str().unwrap_or_default().to_string(),
-                description: t["description"].as_str().unwrap_or_default().to_string(),
-                input_schema: t["inputSchema"].clone(),
-            })
-            .collect())
+        ToolInfo::list_from_result(&res).map_err(McpError::Server)
     }
 
     pub async fn call_tool(&self, name: &str, arguments: Value) -> Result<Value, McpError> {

--- a/mur-agent-runtime/src/protocol/mcp_sse.rs
+++ b/mur-agent-runtime/src/protocol/mcp_sse.rs
@@ -6,10 +6,10 @@ use serde_json::Value;
 /// event, events separated by blank lines). Non-JSON `data:` lines are skipped.
 pub fn parse_sse_events(body: &str) -> Vec<Value> {
     let trimmed = body.trim_start();
-    if trimmed.starts_with('{') || trimmed.starts_with('[') {
-        if let Ok(v) = serde_json::from_str::<Value>(trimmed) {
-            return vec![v];
-        }
+    if (trimmed.starts_with('{') || trimmed.starts_with('['))
+        && let Ok(v) = serde_json::from_str::<Value>(trimmed)
+    {
+        return vec![v];
     }
     let mut out = Vec::new();
     for block in body.split("\n\n") {

--- a/mur-agent-runtime/src/protocol/mcp_sse.rs
+++ b/mur-agent-runtime/src/protocol/mcp_sse.rs
@@ -1,0 +1,60 @@
+//! Pure parsing for Streamable HTTP MCP responses (JSON or SSE).
+use serde_json::Value;
+
+/// Extract JSON payloads from an MCP HTTP response body. Handles both a bare
+/// JSON object and a `text/event-stream` body (one or more `data:` lines per
+/// event, events separated by blank lines). Non-JSON `data:` lines are skipped.
+pub fn parse_sse_events(body: &str) -> Vec<Value> {
+    let trimmed = body.trim_start();
+    if trimmed.starts_with('{') || trimmed.starts_with('[') {
+        if let Ok(v) = serde_json::from_str::<Value>(trimmed) {
+            return vec![v];
+        }
+    }
+    let mut out = Vec::new();
+    for block in body.split("\n\n") {
+        let data: String = block
+            .lines()
+            .filter_map(|l| l.strip_prefix("data:").map(|d| d.trim_start()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        if data.is_empty() {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<Value>(&data) {
+            out.push(v);
+        }
+    }
+    out
+}
+
+/// Return the `result` of the JSON-RPC response whose `id` matches, mapping a
+/// JSON-RPC `error` object into an `Err`.
+// ponytail: full-body read; server-initiated sampling mid-call is out of scope — add a streaming reader if a server needs it.
+pub fn jsonrpc_result_for(events: &[Value], id: i64) -> Option<&Value> {
+    events
+        .iter()
+        .find(|e| e.get("id").and_then(|i| i.as_i64()) == Some(id))
+        .map(|e| &e["result"])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn parses_sse_and_matches_id() {
+        let body = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n\
+                    data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/log\",\"params\":{}}\n\n";
+        let events = parse_sse_events(body);
+        assert_eq!(events.len(), 2);
+        let r = jsonrpc_result_for(&events, 1).unwrap();
+        assert!(r.get("tools").is_some());
+        assert!(jsonrpc_result_for(&events, 99).is_none());
+    }
+    #[test]
+    fn plain_json_body_is_one_event() {
+        let body = "{\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{\"ok\":true}}";
+        let events = parse_sse_events(body);
+        assert_eq!(jsonrpc_result_for(&events, 7).unwrap()["ok"], true);
+    }
+}

--- a/mur-agent-runtime/src/protocol/mcp_sse.rs
+++ b/mur-agent-runtime/src/protocol/mcp_sse.rs
@@ -5,6 +5,9 @@ use serde_json::Value;
 /// JSON object and a `text/event-stream` body (one or more `data:` lines per
 /// event, events separated by blank lines). Non-JSON `data:` lines are skipped.
 pub fn parse_sse_events(body: &str) -> Vec<Value> {
+    // Normalize CRLF so SSE event boundaries (a blank line) split correctly
+    // regardless of the server's line endings.
+    let body = body.replace("\r\n", "\n");
     let trimmed = body.trim_start();
     if (trimmed.starts_with('{') || trimmed.starts_with('['))
         && let Ok(v) = serde_json::from_str::<Value>(trimmed)
@@ -51,6 +54,22 @@ mod tests {
         assert!(r.get("tools").is_some());
         assert!(jsonrpc_result_for(&events, 99).is_none());
     }
+    #[test]
+    fn parses_crlf_sse_with_interleaved_events() {
+        // A spec-compliant server may use CRLF line endings and interleave a
+        // notification with the response. Event boundaries must still split.
+        let body = "event: message\r\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\r\n\r\n\
+                    event: message\r\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/log\",\"params\":{}}\r\n\r\n";
+        let events = parse_sse_events(body);
+        assert_eq!(events.len(), 2);
+        assert!(
+            jsonrpc_result_for(&events, 1)
+                .unwrap()
+                .get("tools")
+                .is_some()
+        );
+    }
+
     #[test]
     fn plain_json_body_is_one_event() {
         let body = "{\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{\"ok\":true}}";

--- a/mur-agent-runtime/src/protocol/mod.rs
+++ b/mur-agent-runtime/src/protocol/mod.rs
@@ -1,4 +1,5 @@
 //! A2A server + MCP client protocol surface.
 pub mod a2a_server;
 pub mod mcp_client;
+pub mod mcp_sse;
 pub mod methods;

--- a/mur-agent-runtime/src/protocol/mod.rs
+++ b/mur-agent-runtime/src/protocol/mod.rs
@@ -1,5 +1,6 @@
 //! A2A server + MCP client protocol surface.
 pub mod a2a_server;
+pub mod http_mcp_client;
 pub mod mcp_client;
 pub mod mcp_sse;
 pub mod methods;

--- a/mur-agent-runtime/tests/mcp_client.rs
+++ b/mur-agent-runtime/tests/mcp_client.rs
@@ -12,9 +12,9 @@ async fn initialize_and_tools_list() {
         ..Default::default()
     };
     let policy = SandboxPolicy::default();
-    let mut client = McpClient::spawn(&entry, &policy, None)
+    let mut client = McpClient::connect(&entry, &policy, None)
         .await
-        .expect("spawn");
+        .expect("connect");
     let info = client.initialize().await.expect("init");
     assert_eq!(info.server_name, "mock_mcp");
     let tools = client.list_tools().await.expect("list");

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -285,6 +285,43 @@ pub struct McpServerEntry {
     /// See `docs/superpowers/plans/2026-06-26-mcp-per-server-egress.md`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub network: Option<McpServerNetwork>,
+
+    /// HTTP(S) base URL for a remote (Streamable-HTTP or SSE) MCP server.
+    /// Mutually exclusive with `command` in practice; `None` = stdio transport.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    /// Authentication credentials for a remote MCP server.
+    /// `None` = no auth (or stdio transport).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth: Option<McpAuth>,
+}
+
+/// Authentication scheme for a remote (HTTP) MCP server.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum McpAuth {
+    /// Static bearer token stored as a secret reference.
+    Bearer { token: crate::secret::SecretRef },
+    /// OAuth 2.1 token, with dynamic client registration state.
+    Oauth(OauthAuth),
+}
+
+/// OAuth 2.1 state persisted alongside remote MCP entry.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct OauthAuth {
+    /// Authorization-server token endpoint (from discovery).
+    pub token_endpoint: String,
+    /// Client id from dynamic client registration.
+    pub client_id: String,
+    /// Keychain ref to access token.
+    pub access_token: crate::secret::SecretRef,
+    /// Keychain ref refresh token, if server issued one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<crate::secret::SecretRef>,
+    /// Unix-epoch seconds access token expires (0 = unknown).
+    #[serde(default)]
+    pub expires_at: u64,
 }
 
 /// How an MCP server's outbound network is scoped.
@@ -2098,5 +2135,35 @@ mod lockfile_compat_tests {
         let lock: LockFile = serde_json::from_str(old).unwrap();
         assert_eq!(lock.build_sha, "");
         assert_eq!(lock.proto_version, 0);
+    }
+}
+
+#[cfg(test)]
+mod remote_mcp_tests {
+    use super::*;
+
+    #[test]
+    fn mcp_entry_roundtrips_remote_bearer() {
+        let e = McpServerEntry {
+            name: "gh".into(),
+            command: String::new(),
+            url: Some("https://api.example.com/mcp".into()),
+            auth: Some(McpAuth::Bearer {
+                token: crate::secret::SecretRef::Env("GH_TOKEN".into()),
+            }),
+            ..Default::default()
+        };
+        let y = serde_yaml_ng::to_string(&e).unwrap();
+        let back: McpServerEntry = serde_yaml_ng::from_str(&y).unwrap();
+        assert_eq!(back.url.as_deref(), Some("https://api.example.com/mcp"));
+        assert!(matches!(
+            back.auth,
+            Some(McpAuth::Bearer { ref token }) if *token == crate::secret::SecretRef::Env("GH_TOKEN".into())
+        ));
+        // A legacy stdio entry (no url/auth) still parses.
+        let legacy: McpServerEntry =
+            serde_yaml_ng::from_str("name: fs\ncommand: npx\nargs: [\"-y\",\"fs\"]\n").unwrap();
+        assert!(legacy.url.is_none());
+        assert!(legacy.auth.is_none());
     }
 }

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -804,6 +804,21 @@ pub enum AgentMcpAction {
     /// Install a server from the MCP Registry onto an agent, by its registry
     /// name (e.g. `mur agent mcp registry-add rustsmith com.example/fs`).
     RegistryAdd { name: String, server: String },
+    /// Add a remote (Streamable HTTP) MCP server by URL.
+    AddRemote {
+        /// Agent name
+        name: String,
+        /// Server id (local nickname in the profile)
+        server_name: String,
+        /// HTTPS base URL of the remote MCP server
+        url: String,
+        /// Bearer token from an env var (e.g. `MY_TOKEN`).
+        #[arg(long)]
+        bearer_env: Option<String>,
+        /// Bearer token from the keychain (`service/account`).
+        #[arg(long)]
+        bearer_keychain: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/mur-core/src/cmd/agent/addon/mod.rs
+++ b/mur-core/src/cmd/agent/addon/mod.rs
@@ -166,6 +166,8 @@ mod tests {
                 installed_at: None,
                 timeout_secs: None,
                 network: None,
+                url: None,
+                auth: None,
             });
         }
 

--- a/mur-core/src/cmd/agent/cli/manage.rs
+++ b/mur-core/src/cmd/agent/cli/manage.rs
@@ -80,6 +80,8 @@ pub fn mcp_add(agent: &str, server_id: &str, command: &str, args: &[String]) -> 
         installed_at: Some(chrono::Utc::now()),
         timeout_secs: None,
         network: None,
+        url: None,
+        auth: None,
     });
     if !profile
         .entitlements

--- a/mur-core/src/cmd/agent/mcp.rs
+++ b/mur-core/src/cmd/agent/mcp.rs
@@ -133,6 +133,8 @@ pub fn cmd_mcp_add(
         installed_at: Some(chrono::Utc::now()),
         timeout_secs: None,
         network: None,
+        url: None,
+        auth: None,
     });
     // Sync spawn allowlist so the supervisor is permitted to launch this MCP.
     if !profile
@@ -248,6 +250,29 @@ pub fn cmd_mcp_set_network(
     Ok(())
 }
 
+/// Add a remote (Streamable HTTP) MCP server to `agent`. No binary pin — the
+/// server runs elsewhere; trust comes from the URL + bearer/OAuth auth.
+pub fn cmd_mcp_add_remote(
+    agent: &str,
+    name: &str,
+    url: &str,
+    bearer: Option<mur_common::secret::SecretRef>,
+) -> anyhow::Result<()> {
+    let (path, mut profile) = load_profile_for_edit(agent)?;
+    if profile.mcp_servers.iter().any(|m| m.name == name) {
+        anyhow::bail!("MCP server '{name}' already exists on '{agent}'; remove it first");
+    }
+    profile.mcp_servers.push(mur_common::agent::McpServerEntry {
+        name: name.to_string(),
+        url: Some(url.to_string()),
+        auth: bearer.map(|token| mur_common::agent::McpAuth::Bearer { token }),
+        ..Default::default()
+    });
+    save_profile(&path, &mut profile)?;
+    println!("Added remote MCP server '{name}' → {url} for agent '{agent}'.");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -265,5 +290,41 @@ mod tests {
         let r = network_policy_from_args(vec!["example.com".into()], false).unwrap();
         assert_eq!(r.mode, McpNetMode::Restricted);
         assert_eq!(r.allow_hosts, vec!["example.com"]);
+    }
+
+    #[test]
+    fn add_remote_writes_url_and_bearer() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mur_home = tmp.path();
+
+        // Create agent dir with a default profile so load_profile_for_edit works.
+        let agent_home = mur_home.join("agents").join("alice");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        let p = mur_common::agent::AgentProfile::default_for_tests();
+        std::fs::write(
+            agent_home.join("profile.yaml"),
+            serde_yaml_ng::to_string(&p).unwrap(),
+        )
+        .unwrap();
+
+        unsafe {
+            std::env::set_var("MUR_HOME", mur_home);
+        }
+
+        cmd_mcp_add_remote(
+            "alice",
+            "gh",
+            "https://api.example.com/mcp",
+            Some(mur_common::secret::SecretRef::Env("GH_TOKEN".into())),
+        )
+        .unwrap();
+
+        let (_p, profile) = load_profile_for_edit("alice").unwrap();
+        let e = profile.mcp_servers.iter().find(|m| m.name == "gh").unwrap();
+        assert_eq!(e.url.as_deref(), Some("https://api.example.com/mcp"));
+        assert!(matches!(
+            e.auth,
+            Some(mur_common::agent::McpAuth::Bearer { .. })
+        ));
     }
 }

--- a/mur-core/src/cmd/agent/mcp_registry.rs
+++ b/mur-core/src/cmd/agent/mcp_registry.rs
@@ -4,13 +4,13 @@
 //! registry-add <agent> <name>` resolves a server's stdio package (npm→npx,
 //! pypi→uvx) into a launch command and installs it via the normal
 //! `cmd_mcp_add` path (binary pin + approval prompt). Remote-only servers
-//! (Streamable HTTP, no package) are reported as needing the remote-MCP
-//! transport (not yet implemented).
+//! (Streamable HTTP, no package) are installed by URL via `cmd_mcp_add_remote`;
+//! run `mur agent mcp login <agent> <id>` afterward to add authentication.
 
 use anyhow::Result;
 use serde::Deserialize;
 
-use super::mcp::{McpAddPin, cmd_mcp_add};
+use super::mcp::{McpAddPin, cmd_mcp_add, cmd_mcp_add_remote};
 
 /// Base URL of the official registry. Documented endpoint, not a tunable.
 const REGISTRY_BASE: &str = "https://registry.modelcontextprotocol.io";
@@ -94,6 +94,15 @@ pub fn package_command(pkg: &RegistryPackage) -> Option<(String, Vec<String>)> {
     Some((cmd.to_string(), args))
 }
 
+/// Short local id from a registry server name: take the last `/`-segment and
+/// replace `.` with `-` so the result is a valid MCP server name token.
+///
+/// Examples: `"com.example/fs"` → `"fs"`, `"ac.foo.bar/my.server"` → `"my-server"`,
+/// `"plain"` → `"plain"`.
+fn short_id(name: &str) -> String {
+    name.rsplit('/').next().unwrap_or(name).replace('.', "-")
+}
+
 /// `mur agent mcp search <query>` — list registry servers matching `query`.
 pub async fn cmd_mcp_search(query: &str) -> Result<()> {
     let body = reqwest::Client::new()
@@ -143,33 +152,31 @@ pub async fn cmd_mcp_registry_add(agent: &str, server_name: &str) -> Result<()> 
         .find(|s| s.name == server_name)
         .ok_or_else(|| anyhow::anyhow!("server '{server_name}' not found in the registry"))?;
 
-    let (command, args) = srv.packages.iter().find_map(package_command).ok_or_else(|| {
-        if !srv.remotes.is_empty() {
-            anyhow::anyhow!(
-                "'{server_name}' is a remote (Streamable HTTP) server; remote MCP transport is not yet supported"
-            )
-        } else {
-            anyhow::anyhow!("'{server_name}' has no installable stdio package")
-        }
-    })?;
+    let id = short_id(server_name);
 
-    // Short local id from the server's last path segment.
-    let id = server_name
-        .rsplit('/')
-        .next()
-        .unwrap_or(server_name)
-        .replace('.', "-");
-    cmd_mcp_add(
-        agent,
-        &id,
-        &command,
-        &args,
-        McpAddPin {
-            publisher_name: Some("mcp-registry".to_string()),
-            publisher_registry_id: Some(server_name.to_string()),
-            ..Default::default()
-        },
-    )
+    if let Some((command, args)) = srv.packages.iter().find_map(package_command) {
+        // Stdio package — install via the normal cmd_mcp_add path.
+        cmd_mcp_add(
+            agent,
+            &id,
+            &command,
+            &args,
+            McpAddPin {
+                publisher_name: Some("mcp-registry".to_string()),
+                publisher_registry_id: Some(server_name.to_string()),
+                ..Default::default()
+            },
+        )
+    } else if let Some(remote) = srv.remotes.first() {
+        // Remote-only server (Streamable HTTP) — install by URL; no bearer token yet.
+        println!(
+            "'{server_name}' is a remote MCP server; installing by URL.\n\
+             To authenticate, run: mur agent mcp login {agent} {id}"
+        );
+        cmd_mcp_add_remote(agent, &id, &remote.url, None)
+    } else {
+        anyhow::bail!("'{server_name}' has no installable package or remote endpoint")
+    }
 }
 
 #[cfg(test)]
@@ -191,6 +198,13 @@ mod tests {
         }}
       ]
     }"#;
+
+    #[test]
+    fn short_id_takes_last_segment() {
+        assert_eq!(short_id("com.example/fs"), "fs");
+        assert_eq!(short_id("ac.foo.bar/my.server"), "my-server");
+        assert_eq!(short_id("plain"), "plain");
+    }
 
     #[test]
     fn parse_servers_reads_packages_and_remotes() {

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -155,7 +155,8 @@ pub async fn probe_mcp_descriptions(
         // the spawn to succeed for tool description hashing.
         let policy = mur_agent_runtime::sandbox::policy::SandboxPolicy::default();
         let mut client =
-            mur_agent_runtime::protocol::mcp_client::McpClient::spawn(entry, &policy, None).await?;
+            mur_agent_runtime::protocol::mcp_client::McpClient::connect(entry, &policy, None)
+                .await?;
         let _info = client.initialize().await?;
         let tools = client.list_tools().await?;
         client.shutdown().await;
@@ -199,6 +200,8 @@ pub fn build_pinned_entry(
         installed_at: Some(chrono::Utc::now()),
         timeout_secs: None,
         network: None,
+        url: None,
+        auth: None,
     }
 }
 

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1331,6 +1331,28 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             AgentMcpAction::RegistryAdd { name, server } => {
                 cmd::agent::mcp_registry::cmd_mcp_registry_add(&name, &server).await?
             }
+            AgentMcpAction::AddRemote {
+                name,
+                server_name,
+                url,
+                bearer_env,
+                bearer_keychain,
+            } => {
+                let bearer = match (bearer_env, bearer_keychain) {
+                    (Some(v), _) => Some(mur_common::secret::SecretRef::Env(v)),
+                    (_, Some(sa)) => {
+                        let (service, account) = sa.split_once('/').ok_or_else(|| {
+                            anyhow::anyhow!("--bearer-keychain expects service/account")
+                        })?;
+                        Some(mur_common::secret::SecretRef::Keychain {
+                            service: service.into(),
+                            account: account.into(),
+                        })
+                    }
+                    _ => None,
+                };
+                cmd::agent::mcp::cmd_mcp_add_remote(&name, &server_name, &url, bearer)?
+            }
         },
         AgentAction::Skill { action } => match action {
             AgentSkillAction::List { name } => cmd::agent::cmd_skill_list(&name)?,


### PR DESCRIPTION
**Phase 1** of the remote-MCP plan (`docs/superpowers/plans/2026-06-26-remote-mcp-http-oauth.md`) — agents can now use **remote MCP servers** over the MCP **Streamable HTTP** transport, not just local stdio subprocesses. (OAuth 2.1 is Phase 2, a separate PR.)

## What

```bash
mur agent mcp add-remote <agent> <name> <url> [--bearer-env VAR | --bearer-keychain svc/acct]
mur agent mcp registry-add <agent> <remote-server>   # installs remote-only registry servers by URL
```

- `McpServerEntry` gains `url` + `auth` (`McpAuth::Bearer { token: SecretRef }`); both `#[serde(default, skip_serializing_if)]` → legacy stdio entries deserialize unchanged.
- New `HttpMcpClient` (Streamable HTTP): POST JSON-RPC, JSON-or-SSE response parsing, `Mcp-Session-Id` tracking, `MCP-Protocol-Version: 2025-06-18`, bearer auth, 401→`Unauthorized`.
- `McpClient` is now an enum over `Stdio`/`Http`; `connect()` picks the transport from `entry.url`. The stdio client's JSON→type builders were extracted (`InitializeInfo::from_result`, `ToolInfo::list_from_result`) and shared — behavior-preserving.

## Built with subagent-driven TDD

6 tasks, each TDD'd with a fresh implementer + per-task spec/quality review + fix loop, then a final opus whole-branch review (verdict: **ready to merge, 0 blocking**).

- **Tests:** 305 mur-agent-runtime + 31 mur-core mcp tests green; `cargo check --workspace` clean; clippy `-D warnings` clean.
- **LIVE E2E:** `HttpMcpClient` connected to a real Streamable HTTP server (`@modelcontextprotocol/server-everything`) — `initialize` + `list_tools` returned **12 tools** + clean `shutdown`. The transport works against a real server.
- Final review found + this PR fixes one real bug: CRLF SSE streams now parse correctly (regression test added).

## Deferred to Phase 2 (tracked, non-blocking)
- OAuth 2.1 (discovery + DCR + PKCE + `mcp login`) — the whole of Phase 2.
- A no-id HTTP `notify()` (today `notifications/initialized` rides `request()`, carrying an id; result discarded, real servers accept it).
- Remote-URL host allow-listing vs the per-server egress proxy (remote transport inherently makes the network call directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)