### PR TITLE
feat(cli): mur agent cli "Glass Box" — step transparency (P1)

### DIFF
--- a/docs/superpowers/plans/2026-06-27-mur-agent-cli-glass-box-p1.md
+++ b/docs/superpowers/plans/2026-06-27-mur-agent-cli-glass-box-p1.md
@@ -1,0 +1,1693 @@
+# mur agent cli — Glass Box P1 (Step Transparency Spine) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every tool the agent runs a visible step in `mur agent cli` — name, args, result, duration — plus keep reasoning on screen and add a token/cost/context/timer footer.
+
+**Architecture:** The runtime (`mur-agent-runtime`) emits two new JSON-RPC notifications (`step/started`, `step/completed`) around each tool execution. The cli's stream bridge parses them into new `StreamMsg` variants; the transcript gains tool-card entries (a new `StepCard` rendered inline, expanded-by-default but bounded). Reasoning stops being erased on turn-finish. A new `footer` module computes tokens/cost/context from `Task.usage` + the agent's `models.yaml` pricing.
+
+**Tech Stack:** Rust (edition 2024), ratatui + crossterm (TUI), serde_json (A2A JSON-RPC), tokio (async), `mur_common::model::ModelRegistry` (pricing).
+
+## Global Constraints
+
+- **Rust edition 2024** — `let` chains stable.
+- **No hardcoded values** — every cap/threshold/width is a named `const` (Mandatory Rule 1).
+- **Brand "MUR" uppercase** in any user-facing string; internal `name`/dirs stay lowercase.
+- **Single source file ≤ 800 lines** — `mod.rs` (857) and `app.rs` are already large; add new code in new modules (`cli/step.rs`, `cli/footer.rs`), not by growing `mod.rs`.
+- **Tests run under nextest with `ORT_STRATEGY=download`** for `mur-core` (plain `cargo test --workspace` and `cargo build --workspace` fail on the onnxruntime link). Use `cargo check -p <crate>` and `cargo nextest run -p <crate>` per task.
+- **Lint gate:** `cargo clippy -p <crate> -- -D warnings` and `cargo fmt` must pass.
+- **mur-core MUST NOT depend on mur-agent-runtime** (forbidden dep edge). Pricing resolution is replicated in mur-core from `mur_common` + the agent profile.
+- **Backward-compat:** an older runtime that never sends `step/*` must still work (no cards, no panic) — see Task 10.
+
+---
+
+### Task 1: Runtime emits `step/started` + `step/completed` (+ `context_tokens`)
+
+**Files:**
+- Modify: `mur-agent-runtime/src/task_runner.rs` (`handle_tool_call`, ~1008–1125; the usage JSON closure, ~672–682)
+- Test: `mur-agent-runtime/src/task_runner.rs` (inline `#[cfg(test)] mod step_tests`)
+
+**Interfaces:**
+- Produces (wire): notification `step/started` `{ jsonrpc, method, params: { step_id, task_id, kind:"tool", name, args } }` and `step/completed` `{ ..., params: { step_id, task_id, ok, output, truncated, full_len, error, duration_ms } }`, sent on the existing `tokio::sync::mpsc::Sender<serde_json::Value>` notifier.
+- Produces (wire): the per-turn usage JSON gains `context_tokens` (u64) = the input-token count of the **last** LLM request in the loop (≈ current context fill, unlike cumulative `input_tokens`).
+- Consumes: `call.tool_name: String`, `call.input: serde_json::Value`, `output: String`, `is_error: bool`, `task_id: &str` (all already in scope in `handle_tool_call`).
+
+- [ ] **Step 1: Write the failing test** (pure helpers — the wiring is verified by build + manual run; the logic risk is the JSON shape + output cap)
+
+Add at the bottom of `task_runner.rs`:
+
+```rust
+#[cfg(test)]
+mod step_tests {
+    use super::{cap_step_output, step_notification, STEP_MAX_BYTES};
+
+    #[test]
+    fn notification_has_jsonrpc_envelope_and_method() {
+        let n = step_notification("step/started", serde_json::json!({ "step_id": "s1" }));
+        assert_eq!(n["jsonrpc"], "2.0");
+        assert_eq!(n["method"], "step/started");
+        assert_eq!(n["params"]["step_id"], "s1");
+    }
+
+    #[test]
+    fn cap_truncates_oversized_output_on_char_boundary() {
+        let big = "é".repeat(STEP_MAX_BYTES); // 2 bytes/char → over the cap
+        let (out, truncated, full_len) = cap_step_output(&big);
+        assert!(truncated);
+        assert_eq!(full_len, big.len());
+        assert!(out.len() <= STEP_MAX_BYTES + "\n[truncated]".len());
+        assert!(out.is_char_boundary(out.len())); // never split a char
+    }
+
+    #[test]
+    fn cap_passes_small_output_through() {
+        let (out, truncated, full_len) = cap_step_output("hello");
+        assert!(!truncated);
+        assert_eq!(out, "hello");
+        assert_eq!(full_len, 5);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo nextest run -p mur-agent-runtime step_tests 2>&1 | tail -20`
+Expected: FAIL — `cannot find function cap_step_output` / `step_notification` / `STEP_MAX_BYTES`.
+
+- [ ] **Step 3: Add the helpers** (near the top of `task_runner.rs`, after the `use` block)
+
+```rust
+/// Max bytes of a tool's output forwarded inline in a `step/completed`
+/// notification. Larger output is truncated with a marker; full recovery is a
+/// later phase (reads from the final task JSON).
+pub(crate) const STEP_MAX_BYTES: usize = 8 * 1024;
+
+/// Wrap step params in the JSON-RPC notification envelope the streaming socket
+/// expects (mirrors the existing `tool/approval_needed` shape).
+pub(crate) fn step_notification(method: &str, params: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({ "jsonrpc": "2.0", "method": method, "params": params })
+}
+
+/// Cap tool output to `STEP_MAX_BYTES` on a char boundary. Returns
+/// `(capped, was_truncated, full_byte_len)`.
+pub(crate) fn cap_step_output(output: &str) -> (String, bool, usize) {
+    let full_len = output.len();
+    if full_len <= STEP_MAX_BYTES {
+        return (output.to_string(), false, full_len);
+    }
+    let mut cut = STEP_MAX_BYTES;
+    while !output.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let mut s = output[..cut].to_string();
+    s.push_str("\n[truncated]");
+    (s, true, full_len)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo nextest run -p mur-agent-runtime step_tests 2>&1 | tail -20`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Wire the emissions into `handle_tool_call`** (both the `ToolPolicy::Allow` arm ~1044 and the `ToolPolicy::Ask` arm ~1060)
+
+Resolve the notifier once near the top of `handle_tool_call` (after the unknown-tool guard, before the policy match) so both arms can use it:
+
+```rust
+        // Step events go to the same connection as approvals (route by task id,
+        // fall back to the baked notifier). None → nobody is listening; skip.
+        let step_notifier = {
+            let routed = self.client_notifiers.lock().await.get(task_id).cloned();
+            routed.or_else(|| self.notifier.clone())
+        };
+        let step_id = uuid::Uuid::now_v7().to_string();
+```
+
+Add a small async closure helper just below it (captures `task_id`, `call`, `step_id`, `step_notifier`):
+
+```rust
+        macro_rules! emit_step {
+            (started) => {
+                if let Some(n) = &step_notifier {
+                    let _ = n
+                        .send(step_notification(
+                            "step/started",
+                            serde_json::json!({
+                                "step_id": step_id, "task_id": task_id, "kind": "tool",
+                                "name": call.tool_name, "args": call.input,
+                            }),
+                        ))
+                        .await;
+                }
+            };
+            (completed, $output:expr, $is_error:expr, $dur_ms:expr) => {
+                if let Some(n) = &step_notifier {
+                    let (out, truncated, full_len) = cap_step_output($output);
+                    let _ = n
+                        .send(step_notification(
+                            "step/completed",
+                            serde_json::json!({
+                                "step_id": step_id, "task_id": task_id,
+                                "ok": !$is_error, "output": out,
+                                "truncated": truncated, "full_len": full_len,
+                                "error": if $is_error { Some($output) } else { None },
+                                "duration_ms": $dur_ms,
+                            }),
+                        ))
+                        .await;
+                }
+            };
+        }
+```
+
+In the **Allow arm**, replace the execute block:
+
+```rust
+                ToolPolicy::Allow => {
+                    let tool = tool.unwrap();
+                    emit_step!(started);
+                    let t0 = std::time::Instant::now();
+                    let (output, is_error) = match tool.execute(call.input.clone()).await {
+                        Ok(out) => (out, false),
+                        Err(e) => (format!("tool error: {e}"), true),
+                    };
+                    emit_step!(completed, &output, is_error, t0.elapsed().as_millis() as u64);
+                    return Ok(ToolResultEntry {
+                        call_id: call.call_id.clone(),
+                        content: output,
+                        is_error,
+                    });
+                }
+```
+
+In the **Ask arm** (the `// 2. Execute the tool` block after the policy match), bracket the execute the same way:
+
+```rust
+        let tool = tool.unwrap();
+        emit_step!(started);
+        let t0 = std::time::Instant::now();
+        let (output, is_error) = match tool.execute(call.input.clone()).await {
+            Ok(out) => (out, false),
+            Err(e) => (format!("tool error: {e}"), true),
+        };
+        emit_step!(completed, &output, is_error, t0.elapsed().as_millis() as u64);
+```
+
+- [ ] **Step 6: Add `context_tokens` to the usage JSON**
+
+Grep for where input tokens are recorded per LLM call:
+
+Run: `rg -n "cumulative_input_tokens" mur-agent-runtime/src/task_runner.rs`
+
+Find the line that updates `cumulative_input_tokens` after each LLM call (a `.fetch_add(...)`). Add a sibling atomic that stores (not adds) the **last** call's input count. Near the struct's other atomics (grep `cumulative_input_tokens` in the struct def), add:
+
+```rust
+    /// Input tokens of the most recent LLM request — ≈ current context fill
+    /// (cumulative_input_tokens over-counts across tool-loop iterations).
+    last_input_tokens: std::sync::atomic::AtomicU64,
+```
+
+Initialize it `AtomicU64::new(0)` wherever the struct is constructed. At the `fetch_add` site, also:
+
+```rust
+    self.last_input_tokens
+        .store(this_call_input, std::sync::atomic::Ordering::Relaxed);
+```
+
+(`this_call_input` is whatever local holds the current call's input token count at the `fetch_add`.) Then in the `token_usage` closure (~672–682), add the field:
+
+```rust
+    serde_json::json!({
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "context_tokens": self.last_input_tokens.load(std::sync::atomic::Ordering::Relaxed),
+    })
+```
+
+> If `last_input_tokens` proves entangled (no clean single-call input count at the `fetch_add`), STOP this step, drop `context_tokens`, and note that the footer context bar moves to P2. The rest of P1 is unaffected.
+
+- [ ] **Step 7: Verify build + lint, then commit**
+
+Run: `cargo check -p mur-agent-runtime && cargo clippy -p mur-agent-runtime -- -D warnings && cargo fmt`
+Expected: clean.
+
+```bash
+git add mur-agent-runtime/src/task_runner.rs
+git commit -m "feat(runtime): emit step/started + step/completed + context_tokens for cli step view"
+```
+
+---
+
+### Task 2: cli stream bridge parses `step/*` into `StreamMsg`
+
+**Files:**
+- Modify: `mur-core/src/a2a_dial.rs` (`dial_message_streaming` ~204–273; add `StepEvent`, `parse_step`, `on_step` param, dispatch arms)
+- Modify: `mur-core/src/cmd/agent/cli/stream.rs` (`StreamMsg` enum ~26–46; `task_id()` ~56; `spawn_stream` closure ~197–225)
+- Test: `mur-core/src/a2a_dial.rs` (inline `#[cfg(test)] mod step_parse_tests`)
+
+**Interfaces:**
+- Produces: `a2a_dial::StepEvent::{Started{step_id,task_id,name,args}, Completed{step_id,task_id,ok,output,truncated,full_len,error,duration_ms}}`.
+- Produces: `dial_message_streaming(home, agent_name, params, on_delta, on_hitl, on_step)` — one new `on_step: impl FnMut(StepEvent)` param appended.
+- Produces: `StreamMsg::StepStarted{task_id,step_id,name,args}` and `StreamMsg::StepCompleted{task_id,step_id,ok,output,truncated,full_len,error,duration_ms}`.
+- Consumes: Task 1's wire notifications.
+
+- [ ] **Step 1: Write the failing test** (in `a2a_dial.rs`)
+
+```rust
+#[cfg(test)]
+mod step_parse_tests {
+    use super::{parse_step, StepEvent};
+
+    #[test]
+    fn parses_started() {
+        let p = serde_json::json!({
+            "step_id": "s1", "task_id": "t1", "name": "edit",
+            "args": { "path": "a.rs" }
+        });
+        match parse_step(&p, false) {
+            StepEvent::Started { step_id, name, args, .. } => {
+                assert_eq!(step_id, "s1");
+                assert_eq!(name, "edit");
+                assert_eq!(args["path"], "a.rs");
+            }
+            _ => panic!("expected Started"),
+        }
+    }
+
+    #[test]
+    fn parses_completed_with_defaults() {
+        let p = serde_json::json!({
+            "step_id": "s1", "task_id": "t1", "ok": false,
+            "output": "boom", "truncated": false, "full_len": 4,
+            "error": "exit 1", "duration_ms": 12
+        });
+        match parse_step(&p, true) {
+            StepEvent::Completed { ok, output, error, duration_ms, .. } => {
+                assert!(!ok);
+                assert_eq!(output, "boom");
+                assert_eq!(error.as_deref(), Some("exit 1"));
+                assert_eq!(duration_ms, 12);
+            }
+            _ => panic!("expected Completed"),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core step_parse_tests 2>&1 | tail -20`
+Expected: FAIL — `cannot find function parse_step` / `StepEvent`.
+
+- [ ] **Step 3: Add `StepEvent` + `parse_step` to `a2a_dial.rs`** (above `dial_message_streaming`)
+
+```rust
+/// A per-tool step event streamed from the runtime during a turn.
+#[derive(Debug, Clone)]
+pub enum StepEvent {
+    Started {
+        step_id: String,
+        task_id: String,
+        name: String,
+        args: serde_json::Value,
+    },
+    Completed {
+        step_id: String,
+        task_id: String,
+        ok: bool,
+        output: String,
+        truncated: bool,
+        full_len: usize,
+        error: Option<String>,
+        duration_ms: u64,
+    },
+}
+
+/// Parse the `params` of a `step/started` (`completed = false`) or
+/// `step/completed` (`completed = true`) notification.
+pub fn parse_step(p: &serde_json::Value, completed: bool) -> StepEvent {
+    use serde_json::Value;
+    let s = |k: &str| p.get(k).and_then(Value::as_str).unwrap_or("").to_string();
+    let step_id = s("step_id");
+    let task_id = s("task_id");
+    if completed {
+        StepEvent::Completed {
+            step_id,
+            task_id,
+            ok: p.get("ok").and_then(Value::as_bool).unwrap_or(true),
+            output: s("output"),
+            truncated: p.get("truncated").and_then(Value::as_bool).unwrap_or(false),
+            full_len: p.get("full_len").and_then(Value::as_u64).unwrap_or(0) as usize,
+            error: p.get("error").and_then(Value::as_str).map(str::to_string),
+            duration_ms: p.get("duration_ms").and_then(Value::as_u64).unwrap_or(0),
+        }
+    } else {
+        StepEvent::Started {
+            step_id,
+            task_id,
+            name: s("name"),
+            args: p.get("args").cloned().unwrap_or(Value::Null),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core step_parse_tests 2>&1 | tail -20`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Add the `on_step` param + dispatch arms to `dial_message_streaming`**
+
+Change the signature (append one param):
+
+```rust
+pub fn dial_message_streaming(
+    home: &Path,
+    agent_name: &str,
+    params: Value,
+    mut on_delta: impl FnMut(&str, bool, &str),
+    mut on_hitl: impl FnMut(Value),
+    mut on_step: impl FnMut(StepEvent),
+) -> Result<Value>
+```
+
+In the dispatch loop, **after** the `tool/approval_needed` arm and **before** the `if v.get("id") == Some(&request_id)` arm, add:
+
+```rust
+            if v.get("method").and_then(Value::as_str) == Some("step/started") {
+                if let Some(p) = v.get("params") {
+                    on_step(parse_step(p, false));
+                }
+                continue;
+            }
+            if v.get("method").and_then(Value::as_str) == Some("step/completed") {
+                if let Some(p) = v.get("params") {
+                    on_step(parse_step(p, true));
+                }
+                continue;
+            }
+```
+
+- [ ] **Step 6: Update every `dial_message_streaming` caller**
+
+Run: `rg -n "dial_message_streaming\(" mur-core/src`
+For each caller that doesn't need steps, pass a no-op `|_| {}` as the final arg. For `stream.rs::spawn_stream`, do Step 7 instead.
+
+- [ ] **Step 7: Add the `StreamMsg` variants + `task_id()` arms + forward from `spawn_stream`**
+
+In `stream.rs`, extend the `StreamMsg` enum:
+
+```rust
+    /// A tool call started running (name + args).
+    StepStarted {
+        task_id: String,
+        step_id: String,
+        name: String,
+        args: Value,
+    },
+    /// A tool call finished (result/error + duration).
+    StepCompleted {
+        task_id: String,
+        step_id: String,
+        ok: bool,
+        output: String,
+        truncated: bool,
+        full_len: usize,
+        error: Option<String>,
+        duration_ms: u64,
+    },
+```
+
+In `task_id()`, add the two variants to the `Some(task_id)` side (they carry a `task_id`, so they must be filtered by the current-turn guard):
+
+```rust
+            StreamMsg::StepStarted { task_id, .. } | StreamMsg::StepCompleted { task_id, .. } => {
+                Some(task_id)
+            }
+```
+
+In `spawn_stream`, pass an `on_step` closure to `dial_message_streaming` that maps `StepEvent` → `StreamMsg` and sends on `tx`:
+
+```rust
+            |step| {
+                let msg = match step {
+                    crate::a2a_dial::StepEvent::Started { step_id, task_id, name, args } => {
+                        StreamMsg::StepStarted { task_id, step_id, name, args }
+                    }
+                    crate::a2a_dial::StepEvent::Completed {
+                        step_id, task_id, ok, output, truncated, full_len, error, duration_ms,
+                    } => StreamMsg::StepCompleted {
+                        task_id, step_id, ok, output, truncated, full_len, error, duration_ms,
+                    },
+                };
+                let _ = tx.blocking_send(msg);
+            },
+```
+
+- [ ] **Step 8: Verify, then commit**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core step_parse_tests && cargo check -p mur-core && cargo clippy -p mur-core -- -D warnings && cargo fmt`
+Expected: clean.
+
+```bash
+git add mur-core/src/a2a_dial.rs mur-core/src/cmd/agent/cli/stream.rs
+git commit -m "feat(cli): parse step/started + step/completed into StreamMsg"
+```
+
+---
+
+### Task 3: `StepCard` model (`cli/step.rs`)
+
+**Files:**
+- Create: `mur-core/src/cmd/agent/cli/step.rs`
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs` (add `mod step;` / `pub mod step;` next to the other `mod` decls)
+- Test: `mur-core/src/cmd/agent/cli/step.rs` (inline `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `StepCard { id, name, args, state, output, truncated, full_len, error, started, duration_ms }`, `StepState::{Running, Done, Error}`.
+- Produces: `StepCard::new(id, name, args) -> Self`, `StepCard::complete(&mut self, ok, output, truncated, full_len, error, duration_ms)`, `StepCard::summary(&self) -> String`, `StepCard::glyph(&self) -> &'static str`.
+- Consumes: nothing.
+
+- [ ] **Step 1: Write the failing test** (create the file with test first)
+
+```rust
+//! A single tool-call step rendered inline in the cli transcript.
+
+#[cfg(test)]
+mod tests {
+    use super::{StepCard, StepState};
+
+    fn card() -> StepCard {
+        StepCard::new("s1".into(), "read".into(), serde_json::json!({ "path": "auth.rs" }))
+    }
+
+    #[test]
+    fn new_card_is_running() {
+        let c = card();
+        assert_eq!(c.state, StepState::Running);
+        assert_eq!(c.glyph(), "◐");
+    }
+
+    #[test]
+    fn complete_ok_sets_done_and_glyph() {
+        let mut c = card();
+        c.complete(true, "412 lines".into(), false, 9, None, 8);
+        assert_eq!(c.state, StepState::Done);
+        assert_eq!(c.glyph(), "✔");
+        assert_eq!(c.duration_ms, Some(8));
+    }
+
+    #[test]
+    fn complete_err_sets_error_and_keeps_message() {
+        let mut c = card();
+        c.complete(false, "boom".into(), false, 4, Some("exit 1".into()), 3);
+        assert_eq!(c.state, StepState::Error);
+        assert_eq!(c.glyph(), "✗");
+        assert_eq!(c.error.as_deref(), Some("exit 1"));
+    }
+
+    #[test]
+    fn summary_is_one_line_name_plus_arg_hint() {
+        let c = card();
+        let s = c.summary();
+        assert!(s.contains("read"));
+        assert!(!s.contains('\n'));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core cmd::agent::cli::step 2>&1 | tail -20`
+Expected: FAIL — module/types not found (after adding `mod step;` in Step 4 it compiles; before that the file isn't included). First add `mod step;` to `mod.rs`, then re-run to get a real compile failure on missing types.
+
+- [ ] **Step 3: Implement `step.rs`** (above the test module)
+
+```rust
+use std::time::Instant;
+
+/// Lifecycle of a tool-call step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepState {
+    Running,
+    Done,
+    Error,
+}
+
+/// Max args lines shown inside an expanded card (mirrors the old HITL modal cap).
+pub const ARGS_MAX_LINES: usize = 12;
+
+/// One tool call, shown inline in the transcript.
+#[derive(Debug, Clone)]
+pub struct StepCard {
+    pub id: String,
+    pub name: String,
+    pub args: serde_json::Value,
+    pub state: StepState,
+    pub output: String,
+    pub truncated: bool,
+    pub full_len: usize,
+    pub error: Option<String>,
+    pub started: Instant,
+    pub duration_ms: Option<u64>,
+}
+
+impl StepCard {
+    pub fn new(id: String, name: String, args: serde_json::Value) -> Self {
+        Self {
+            id,
+            name,
+            args,
+            state: StepState::Running,
+            output: String::new(),
+            truncated: false,
+            full_len: 0,
+            error: None,
+            started: Instant::now(),
+            duration_ms: None,
+        }
+    }
+
+    pub fn complete(
+        &mut self,
+        ok: bool,
+        output: String,
+        truncated: bool,
+        full_len: usize,
+        error: Option<String>,
+        duration_ms: u64,
+    ) {
+        self.state = if ok { StepState::Done } else { StepState::Error };
+        self.output = output;
+        self.truncated = truncated;
+        self.full_len = full_len;
+        self.error = error;
+        self.duration_ms = Some(duration_ms);
+    }
+
+    pub fn glyph(&self) -> &'static str {
+        match self.state {
+            StepState::Running => "◐",
+            StepState::Done => "✔",
+            StepState::Error => "✗",
+        }
+    }
+
+    /// One-line header summary: a compact hint of the first scalar arg, if any.
+    pub fn summary(&self) -> String {
+        let hint = self
+            .args
+            .as_object()
+            .and_then(|m| m.values().find_map(|v| v.as_str()))
+            .unwrap_or("");
+        if hint.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}  {}", self.name, hint)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Register the module** in `mod.rs` (next to `mod app;`, `mod stream;`, etc.)
+
+```rust
+mod step;
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core cmd::agent::cli::step 2>&1 | tail -20`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/step.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(cli): StepCard model for inline tool-call steps"
+```
+
+---
+
+### Task 4: Transcript holds tool cards + segment interleaving (`app.rs`)
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/app.rs` (`ChatMsg` struct + ctors ~35–70; `append_delta` ~329–341; `finish_agent_turn` ~347–366; add `push_step_started` / `update_step_completed`)
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs` (`handle_stream` ~749–777: route the two new `StreamMsg` variants)
+- Test: `mur-core/src/cmd/agent/cli/app.rs` (inline `#[cfg(test)] mod step_app_tests`)
+
+**Interfaces:**
+- Produces: `ChatMsg.step: Option<StepCard>`; `ChatMsg::tool(StepCard) -> Self`.
+- Produces: `App::push_step_started(&mut self, step_id, name, args)`, `App::update_step_completed(&mut self, step_id, ok, output, truncated, full_len, error, duration_ms)`.
+- Consumes: `StepCard` (Task 3), `streaming_agent_mut()` (existing), `markdown::render` (existing).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod step_app_tests {
+    use super::*;
+
+    fn app() -> App {
+        // Reuse whatever the file's other tests use to build an App; if none,
+        // construct via App::new(...) with a temp home. See existing tests in app.rs.
+        App::test_fixture()
+    }
+
+    #[test]
+    fn step_interleaves_between_text_segments() {
+        let mut a = app();
+        a.begin_user_turn("hi");
+        a.append_delta("reading the file", false);
+        a.push_step_started("s1".into(), "read".into(), serde_json::json!({ "path": "a.rs" }));
+        a.append_delta("done, here is the summary", false);
+
+        // Expect: user, agent-seg-1 (frozen), tool card, agent-seg-2 (streaming)
+        let roles: Vec<_> = a.messages.iter().map(|m| (m.role, m.step.is_some())).collect();
+        assert_eq!(roles[0], (Role::User, false));
+        assert_eq!(roles[1], (Role::Agent, false)); // text seg 1
+        assert!(!a.messages[1].streaming);
+        assert!(a.messages[2].step.is_some()); // the card
+        assert_eq!(roles[3], (Role::Agent, false));
+        assert!(a.messages[3].streaming); // text seg 2 still live
+        assert_eq!(a.messages[3].text, "done, here is the summary");
+    }
+
+    #[test]
+    fn completed_updates_the_matching_card() {
+        let mut a = app();
+        a.begin_user_turn("hi");
+        a.push_step_started("s1".into(), "read".into(), serde_json::json!({}));
+        a.update_step_completed("s1", true, "412 lines".into(), false, 9, None, 8);
+        let card = a.messages.iter().find_map(|m| m.step.as_ref()).unwrap();
+        assert_eq!(card.state, crate::cmd::agent::cli::step::StepState::Done);
+        assert_eq!(card.output, "412 lines");
+    }
+
+    #[test]
+    fn empty_leading_segment_is_dropped_not_frozen() {
+        let mut a = app();
+        a.begin_user_turn("hi"); // creates an empty streaming agent placeholder
+        a.push_step_started("s1".into(), "read".into(), serde_json::json!({}));
+        // The empty placeholder must not survive as a blank agent bubble.
+        let agent_text_msgs = a
+            .messages
+            .iter()
+            .filter(|m| m.role == Role::Agent && m.step.is_none())
+            .count();
+        assert_eq!(agent_text_msgs, 0);
+    }
+}
+```
+
+> If `app.rs` has no existing test constructor, add a minimal `#[cfg(test)] impl App { pub fn test_fixture() -> Self { /* mirror App::new with a tempdir home */ } }` — copy the field initializers from the real constructor (grep `impl App` / `fn new`). Keep it in the test module's parent so tests can call it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core step_app_tests 2>&1 | tail -20`
+Expected: FAIL — `no field step` / `no method push_step_started`.
+
+- [ ] **Step 3: Add the `step` field + `tool` ctor to `ChatMsg`**
+
+In the struct (after `rendered`):
+
+```rust
+    /// When set, this message renders as a tool-call step card instead of by
+    /// role. `None` for ordinary user/agent/system/shell messages.
+    pub step: Option<super::step::StepCard>,
+```
+
+In `ChatMsg::new` and `ChatMsg::agent_rendered`, add `step: None,` to the struct literals. Add a ctor:
+
+```rust
+    /// A transcript entry that renders as a tool-call step card.
+    fn tool(card: super::step::StepCard) -> Self {
+        Self {
+            role: Role::Agent,
+            text: String::new(),
+            thinking: String::new(),
+            streaming: false,
+            rendered: None,
+            step: Some(card),
+        }
+    }
+```
+
+- [ ] **Step 4: Make `append_delta` create a streaming segment when none exists**
+
+Replace `append_delta` body:
+
+```rust
+    pub fn append_delta(&mut self, text: &str, thinking: bool) {
+        if self.streaming_agent_mut().is_none() {
+            // The prior segment was frozen by a step card; start a new one.
+            let mut m = ChatMsg::new(Role::Agent, "");
+            m.streaming = true;
+            self.messages.push(m);
+        }
+        if let Some(m) = self.streaming_agent_mut() {
+            if thinking {
+                m.thinking.push_str(text);
+            } else {
+                m.text.push_str(text);
+            }
+        }
+        // NB: do not reset scroll_back here (see original note).
+    }
+```
+
+- [ ] **Step 5: Add `push_step_started` + `update_step_completed`**
+
+```rust
+    /// Freeze the current streaming text segment (or drop it if empty) and push
+    /// a new running tool-call card.
+    pub fn push_step_started(
+        &mut self,
+        step_id: String,
+        name: String,
+        args: serde_json::Value,
+    ) {
+        if let Some(m) = self.streaming_agent_mut() {
+            if m.text.is_empty() && m.thinking.is_empty() {
+                // Empty placeholder (agent called a tool before any text) — drop it.
+                if let Some(i) = self
+                    .messages
+                    .iter()
+                    .rposition(|m| m.role == Role::Agent && m.streaming)
+                {
+                    self.messages.remove(i);
+                }
+            } else {
+                m.streaming = false;
+                m.rendered = Some(markdown::render(&m.text).lines);
+            }
+        }
+        self.messages
+            .push(ChatMsg::tool(super::step::StepCard::new(step_id, name, args)));
+        self.scroll_back = 0;
+    }
+
+    /// Mark the matching card complete.
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_step_completed(
+        &mut self,
+        step_id: &str,
+        ok: bool,
+        output: String,
+        truncated: bool,
+        full_len: usize,
+        error: Option<String>,
+        duration_ms: u64,
+    ) {
+        if let Some(card) = self
+            .messages
+            .iter_mut()
+            .rev()
+            .find_map(|m| m.step.as_mut().filter(|c| c.id == step_id))
+        {
+            card.complete(ok, output, truncated, full_len, error, duration_ms);
+        }
+    }
+```
+
+- [ ] **Step 6: Route the new `StreamMsg` variants in `handle_stream`** (`mod.rs`)
+
+Add arms to the `match msg` (after `StreamMsg::Delta`):
+
+```rust
+        StreamMsg::StepStarted { step_id, name, args, .. } => {
+            app.saw_step_this_turn = true;
+            app.push_step_started(step_id, name, args);
+        }
+        StreamMsg::StepCompleted {
+            step_id, ok, output, truncated, full_len, error, duration_ms, ..
+        } => app.update_step_completed(
+            &step_id, ok, output, truncated, full_len, error, duration_ms,
+        ),
+```
+
+> `app.saw_step_this_turn` is added in Task 8. If implementing Task 4 before Task 8, temporarily drop that line and re-add it in Task 8.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core step_app_tests 2>&1 | tail -20`
+Expected: PASS (3 tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/app.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(cli): interleave tool-call step cards into the transcript"
+```
+
+---
+
+### Task 5: Reasoning is kept, not erased (`app.rs` + `ui.rs`)
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/app.rs` (`finish_agent_turn` ~347–366 — remove `m.thinking.clear()`)
+- Modify: `mur-core/src/cmd/agent/cli/ui.rs` (`push_message` Agent branch ~143–190 — render `thinking` for finished agent messages too)
+- Test: `mur-core/src/cmd/agent/cli/app.rs` (inline test)
+
+**Interfaces:**
+- Consumes: existing `ChatMsg.thinking`, `streaming_agent_mut()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod reasoning_kept_tests {
+    use super::*;
+
+    #[test]
+    fn thinking_survives_turn_finish() {
+        let mut a = App::test_fixture();
+        a.begin_user_turn("hi");
+        a.append_delta("let me think", true); // thinking delta
+        a.append_delta("the answer", false);
+        a.finish_agent_turn("the answer".into(), Some("t1".into()));
+        let last = a.messages.last().unwrap();
+        assert_eq!(last.role, Role::Agent);
+        assert_eq!(last.thinking, "let me think"); // not cleared
+        assert!(!last.streaming);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core reasoning_kept_tests 2>&1 | tail -20`
+Expected: FAIL — `assert_eq!(last.thinking, "let me think")` fails (thinking is cleared).
+
+- [ ] **Step 3: Remove the erase in `finish_agent_turn`**
+
+Delete this line:
+
+```rust
+        m.thinking.clear();
+```
+
+- [ ] **Step 4: Render thinking for finished agent messages in `ui.rs`**
+
+In `push_message`, the Agent branch currently only renders `m.thinking` inside `if m.streaming`. Hoist the thinking render so it runs for both states. Replace the Agent branch's opening:
+
+```rust
+        Role::Agent => {
+            lines.push(Line::from(Span::styled(
+                "● agent",
+                Style::default().fg(theme.agent).add_modifier(Modifier::BOLD),
+            )));
+            // Reasoning stays visible after the turn finishes (D5).
+            if !m.thinking.is_empty() {
+                for l in m.thinking.lines() {
+                    lines.push(Line::styled(
+                        l.to_string(),
+                        Style::default()
+                            .fg(theme.thinking)
+                            .add_modifier(Modifier::ITALIC | Modifier::DIM),
+                    ));
+                }
+            }
+            if m.streaming {
+                // (spinner + streaming body — unchanged, but WITHOUT the
+                // now-hoisted thinking block)
+                let mut body: Vec<Line> =
+                    m.text.lines().map(|l| Line::raw(l.to_string())).collect();
+                let spin = SPINNER[spinner % SPINNER.len()];
+                match body.last_mut() {
+                    Some(last) => last.spans.push(Span::styled(
+                        format!(" {spin}"),
+                        Style::default().fg(theme.agent),
+                    )),
+                    None => body.push(Line::styled(
+                        spin.to_string(),
+                        Style::default().fg(theme.agent),
+                    )),
+                }
+                lines.extend(body);
+            } else if let Some(cached) = &m.rendered {
+                lines.extend(cached.iter().cloned());
+            } else {
+                lines.extend(markdown::render(&m.text).lines);
+            }
+        }
+```
+
+- [ ] **Step 5: Run test + visual check**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core reasoning_kept_tests && cargo check -p mur-core`
+Expected: PASS + clean build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/app.rs mur-core/src/cmd/agent/cli/ui.rs
+git commit -m "feat(cli): keep reasoning visible after the turn finishes"
+```
+
+---
+
+### Task 6: Render the tool card (`ui.rs`)
+
+**Files:**
+- Create: `mur-core/src/cmd/agent/cli/render_card.rs` (card → `Vec<Line>`; keeps `ui.rs` from growing)
+- Modify: `mur-core/src/cmd/agent/cli/ui.rs` (`push_message` ~100–105 — branch on `m.step` first)
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs` (add `mod render_card;`)
+- Test: `mur-core/src/cmd/agent/cli/render_card.rs` (inline test)
+
+**Interfaces:**
+- Produces: `render_card::card_lines(card: &StepCard, theme: &Theme) -> Vec<Line<'static>>`.
+- Consumes: `StepCard` (Task 3), `theme::Theme`.
+
+- [ ] **Step 1: Write the failing test** (create the file test-first)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::card_lines;
+    use crate::cmd::agent::cli::step::StepCard;
+    use crate::cmd::agent::cli::theme;
+
+    #[test]
+    fn running_card_shows_glyph_name_and_no_result() {
+        let c = StepCard::new("s1".into(), "read".into(), serde_json::json!({ "path": "a.rs" }));
+        let lines = card_lines(&c, theme::resolve("dark"));
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("|");
+        assert!(text.contains("read"));
+        assert!(text.contains('◐'));
+    }
+
+    #[test]
+    fn done_card_shows_output_and_duration() {
+        let mut c = StepCard::new("s1".into(), "read".into(), serde_json::json!({}));
+        c.complete(true, "412 lines".into(), false, 9, None, 8);
+        let lines = card_lines(&c, theme::resolve("dark"));
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("412 lines"));
+        assert!(text.contains("8ms"));
+        assert!(text.contains('✔'));
+    }
+}
+```
+
+> Confirm the theme accessor name with `rg -n "pub fn resolve|fn resolve" mur-core/src/cmd/agent/cli/theme.rs`; the welcome/skin code resolves a `&'static Theme` by name. Use that exact function in the test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core cmd::agent::cli::render_card 2>&1 | tail -20`
+Expected: FAIL — module/function missing.
+
+- [ ] **Step 3: Implement `render_card.rs`**
+
+```rust
+//! Render a `StepCard` to ratatui lines. Cards are expanded-by-default but
+//! bounded: args capped at `ARGS_MAX_LINES`, output already capped upstream.
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use super::step::{StepCard, StepState, ARGS_MAX_LINES};
+use super::theme::Theme;
+
+/// Lines after the header to show of a tool's output.
+const OUTPUT_MAX_LINES: usize = 20;
+
+pub fn card_lines(card: &StepCard, theme: &'static Theme) -> Vec<Line<'static>> {
+    let mut out: Vec<Line<'static>> = Vec::new();
+    let accent = match card.state {
+        StepState::Error => ratatui::style::Color::Red,
+        _ => theme.agent,
+    };
+
+    // Header: glyph · name+arg-hint · state/duration
+    let dur = card
+        .duration_ms
+        .map(|ms| format!(" · {ms}ms"))
+        .unwrap_or_default();
+    let header = format!("{} {} {}", card.glyph(), card.name, arg_hint(card));
+    out.push(Line::from(vec![
+        Span::styled(header, Style::default().fg(accent).add_modifier(Modifier::BOLD)),
+        Span::styled(dur, Style::default().fg(theme.system)),
+    ]));
+
+    // Args (bounded)
+    if !card.args.is_null() {
+        let pretty = serde_json::to_string_pretty(&card.args).unwrap_or_default();
+        for l in pretty.lines().take(ARGS_MAX_LINES) {
+            out.push(Line::styled(
+                format!("  {l}"),
+                Style::default().fg(theme.system),
+            ));
+        }
+        if pretty.lines().count() > ARGS_MAX_LINES {
+            out.push(Line::styled(
+                format!("  … +{} more", pretty.lines().count() - ARGS_MAX_LINES),
+                Style::default().fg(theme.system).add_modifier(Modifier::DIM),
+            ));
+        }
+    }
+
+    // Result / error (bounded)
+    if let Some(err) = &card.error {
+        out.push(Line::styled(
+            format!("  ✗ {err}"),
+            Style::default().fg(ratatui::style::Color::Red),
+        ));
+    }
+    if !card.output.is_empty() {
+        for l in card.output.lines().take(OUTPUT_MAX_LINES) {
+            out.push(Line::styled(
+                format!("  {l}"),
+                Style::default().fg(theme.text),
+            ));
+        }
+        let shown = card.output.lines().count().min(OUTPUT_MAX_LINES);
+        if card.output.lines().count() > OUTPUT_MAX_LINES || card.truncated {
+            out.push(Line::styled(
+                format!("  … {} more line(s) hidden", hidden_hint(card, shown)),
+                Style::default().fg(theme.system).add_modifier(Modifier::DIM),
+            ));
+        }
+    }
+    out
+}
+
+fn arg_hint(card: &StepCard) -> String {
+    card.args
+        .as_object()
+        .and_then(|m| m.values().find_map(|v| v.as_str()))
+        .unwrap_or("")
+        .to_string()
+}
+
+fn hidden_hint(card: &StepCard, shown: usize) -> String {
+    let total = card.output.lines().count();
+    if card.truncated {
+        "(output capped)".to_string()
+    } else {
+        (total - shown).to_string()
+    }
+}
+```
+
+- [ ] **Step 4: Register module + branch on `m.step` in `push_message`**
+
+In `mod.rs`: `mod render_card;`
+
+In `ui.rs::push_message`, add at the very top of the function (before the `match m.role`):
+
+```rust
+    if let Some(card) = &m.step {
+        lines.extend(super::render_card::card_lines(card, theme));
+        return;
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core cmd::agent::cli::render_card 2>&1 | tail -20`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/render_card.rs mur-core/src/cmd/agent/cli/ui.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(cli): render tool-call step cards inline"
+```
+
+---
+
+### Task 7: Footer math (`cli/footer.rs`)
+
+**Files:**
+- Create: `mur-core/src/cmd/agent/cli/footer.rs`
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs` (`mod footer;`)
+- Test: `mur-core/src/cmd/agent/cli/footer.rs` (inline test)
+
+**Interfaces:**
+- Produces: `UsageCounts { input, output }`, `Pricing { in_per_1k, out_per_1k, window }`.
+- Produces: `parse_usage(&Value) -> UsageCounts`, `context_tokens(&Value) -> Option<u64>`, `turn_cost(&Pricing, &UsageCounts) -> Option<f64>`, `context_pct(used, window) -> u8`, `CtxColor::{Green,Yellow,Red}`, `ctx_color(u8) -> CtxColor`, `ctx_bar(pct, width) -> String`.
+- Consumes: `serde_json::Value` (the `Task.usage` JSON).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_usage_fields() {
+        let u = parse_usage(&serde_json::json!({ "input_tokens": 1000, "output_tokens": 240 }));
+        assert_eq!(u.input, 1000);
+        assert_eq!(u.output, 240);
+    }
+
+    #[test]
+    fn context_pct_is_input_over_window() {
+        assert_eq!(context_pct(32_000, 100_000), 32);
+        assert_eq!(context_pct(0, 100_000), 0);
+        assert_eq!(context_pct(100, 0), 0); // no window → 0, never divide by zero
+    }
+
+    #[test]
+    fn ctx_color_thresholds() {
+        assert!(matches!(ctx_color(69), CtxColor::Green));
+        assert!(matches!(ctx_color(70), CtxColor::Yellow));
+        assert!(matches!(ctx_color(89), CtxColor::Yellow));
+        assert!(matches!(ctx_color(90), CtxColor::Red));
+    }
+
+    #[test]
+    fn cost_none_when_unpriced() {
+        let u = UsageCounts { input: 1000, output: 1000 };
+        let unpriced = Pricing { in_per_1k: None, out_per_1k: None, window: None };
+        assert!(turn_cost(&unpriced, &u).is_none());
+        let priced = Pricing { in_per_1k: Some(0.003), out_per_1k: Some(0.015), window: Some(200_000) };
+        let c = turn_cost(&priced, &u).unwrap();
+        assert!((c - 0.018).abs() < 1e-9);
+    }
+
+    #[test]
+    fn bar_fills_proportionally() {
+        assert_eq!(ctx_bar(50, 6), "▓▓▓░░░");
+        assert_eq!(ctx_bar(0, 6), "░░░░░░");
+        assert_eq!(ctx_bar(100, 6), "▓▓▓▓▓▓");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core cmd::agent::cli::footer 2>&1 | tail -20`
+Expected: FAIL — module/types missing.
+
+- [ ] **Step 3: Implement `footer.rs`**
+
+```rust
+//! Pure footer math: tokens, cost, and context-window fill from `Task.usage`
+//! plus the agent's `models.yaml` pricing. No ratatui, no I/O — unit-tested.
+
+use serde_json::Value;
+
+/// Context bar thresholds (percent) and width.
+pub const CTX_YELLOW_PCT: u8 = 70;
+pub const CTX_RED_PCT: u8 = 90;
+pub const CTX_BAR_WIDTH: usize = 6;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UsageCounts {
+    pub input: u64,
+    pub output: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Pricing {
+    pub in_per_1k: Option<f64>,
+    pub out_per_1k: Option<f64>,
+    pub window: Option<u64>,
+}
+
+pub enum CtxColor {
+    Green,
+    Yellow,
+    Red,
+}
+
+pub fn parse_usage(usage: &Value) -> UsageCounts {
+    UsageCounts {
+        input: usage.get("input_tokens").and_then(Value::as_u64).unwrap_or(0),
+        output: usage.get("output_tokens").and_then(Value::as_u64).unwrap_or(0),
+    }
+}
+
+/// Clean per-context fill emitted by the runtime (Task 1). `None` on older
+/// runtimes — the caller falls back to hiding the bar.
+pub fn context_tokens(usage: &Value) -> Option<u64> {
+    usage.get("context_tokens").and_then(Value::as_u64)
+}
+
+pub fn turn_cost(p: &Pricing, u: &UsageCounts) -> Option<f64> {
+    match (p.in_per_1k, p.out_per_1k) {
+        (Some(i), Some(o)) => Some(u.input as f64 / 1000.0 * i + u.output as f64 / 1000.0 * o),
+        _ => None,
+    }
+}
+
+pub fn context_pct(used: u64, window: u64) -> u8 {
+    if window == 0 {
+        return 0;
+    }
+    ((used as f64 / window as f64) * 100.0).round().clamp(0.0, 100.0) as u8
+}
+
+pub fn ctx_color(pct: u8) -> CtxColor {
+    if pct < CTX_YELLOW_PCT {
+        CtxColor::Green
+    } else if pct < CTX_RED_PCT {
+        CtxColor::Yellow
+    } else {
+        CtxColor::Red
+    }
+}
+
+pub fn ctx_bar(pct: u8, width: usize) -> String {
+    let filled = (pct as usize * width) / 100;
+    format!("{}{}", "▓".repeat(filled), "░".repeat(width - filled))
+}
+```
+
+- [ ] **Step 4: Register module + run test**
+
+`mod.rs`: `mod footer;`
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core cmd::agent::cli::footer 2>&1 | tail -20`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/footer.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(cli): footer token/cost/context math module"
+```
+
+---
+
+### Task 8: Footer state on `App` (timing, tokens, pricing)
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/app.rs` (`App` struct ~172–226; constructor; `begin_user_turn` ~314–327; `finish_agent_turn` ~347–366)
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs` (startup: load pricing once and pass to `App`)
+- Test: `mur-core/src/cmd/agent/cli/app.rs` (inline test)
+
+**Interfaces:**
+- Produces: `App.turn_started: Option<Instant>`, `App.session_in/session_out/turn_in/turn_out: u64`, `App.ctx_tokens: u64`, `App.pricing: footer::Pricing`, `App.saw_step_this_turn: bool`.
+- Produces: `App::apply_usage(&mut self, usage: &Value)`.
+- Produces (mod.rs): `fn load_pricing(home: &Path, agent: &str) -> footer::Pricing`.
+- Consumes: `footer::{Pricing, parse_usage, context_tokens}`, `mur_common::model::ModelRegistry`, `load_profile_for_edit`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod footer_state_tests {
+    use super::*;
+
+    #[test]
+    fn apply_usage_accumulates_session_and_sets_turn() {
+        let mut a = App::test_fixture();
+        a.apply_usage(&serde_json::json!({ "input_tokens": 100, "output_tokens": 20, "context_tokens": 100 }));
+        a.apply_usage(&serde_json::json!({ "input_tokens": 50, "output_tokens": 10, "context_tokens": 150 }));
+        assert_eq!(a.turn_in, 50);
+        assert_eq!(a.turn_out, 10);
+        assert_eq!(a.session_in, 150);
+        assert_eq!(a.session_out, 30);
+        assert_eq!(a.ctx_tokens, 150);
+    }
+
+    #[test]
+    fn begin_turn_resets_turn_counters_and_starts_clock() {
+        let mut a = App::test_fixture();
+        a.apply_usage(&serde_json::json!({ "input_tokens": 100, "output_tokens": 20 }));
+        a.begin_user_turn("hi");
+        assert_eq!(a.turn_in, 0);
+        assert_eq!(a.turn_out, 0);
+        assert!(a.turn_started.is_some());
+        assert!(!a.saw_step_this_turn);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core footer_state_tests 2>&1 | tail -20`
+Expected: FAIL — fields/method missing.
+
+- [ ] **Step 3: Add the fields to `App`** (in the struct)
+
+```rust
+    /// Wall-clock start of the in-flight turn (footer timer).
+    pub turn_started: Option<std::time::Instant>,
+    pub session_in: u64,
+    pub session_out: u64,
+    pub turn_in: u64,
+    pub turn_out: u64,
+    /// Input tokens of the latest request ≈ current context fill.
+    pub ctx_tokens: u64,
+    /// Per-1k pricing + window for the agent's model (`—`/no bar when absent).
+    pub pricing: super::footer::Pricing,
+    /// Whether any step event arrived this turn (proto-degrade hint, Task 10).
+    pub saw_step_this_turn: bool,
+```
+
+In the `App` constructor (grep `fn new` in app.rs), initialize them:
+
+```rust
+            turn_started: None,
+            session_in: 0,
+            session_out: 0,
+            turn_in: 0,
+            turn_out: 0,
+            ctx_tokens: 0,
+            pricing: super::footer::Pricing::default(),
+            saw_step_this_turn: false,
+```
+
+> The constructor must accept `pricing`. Add a `pricing: footer::Pricing` parameter to `App::new` (or set `app.pricing = ...` right after construction in `mod.rs`). The latter is the smaller diff — prefer it.
+
+- [ ] **Step 4: Add `apply_usage` + wire `begin_user_turn` / `finish_agent_turn`**
+
+```rust
+    pub fn apply_usage(&mut self, usage: &serde_json::Value) {
+        let u = super::footer::parse_usage(usage);
+        self.turn_in = u.input;
+        self.turn_out = u.output;
+        self.session_in += u.input;
+        self.session_out += u.output;
+        if let Some(c) = super::footer::context_tokens(usage) {
+            self.ctx_tokens = c;
+        }
+    }
+```
+
+In `begin_user_turn`, after `self.streaming = true;`:
+
+```rust
+        self.turn_started = Some(std::time::Instant::now());
+        self.turn_in = 0;
+        self.turn_out = 0;
+        self.saw_step_this_turn = false;
+```
+
+In `finish_agent_turn`, the `Done` handler must call `apply_usage`. Easiest: in `mod.rs::handle_stream`, before `app.finish_agent_turn(...)`, pull usage from the task JSON:
+
+```rust
+        StreamMsg::Done { task, .. } => {
+            if let Some(u) = task.get("usage") {
+                app.apply_usage(u);
+            }
+            match stream::task_outcome(&task) {
+                Ok((reply, task_id)) => app.finish_agent_turn(reply, task_id),
+                Err(cause) => app.fail_turn(&cause),
+            }
+        }
+```
+
+Also clear the clock at finish (end of `finish_agent_turn`):
+
+```rust
+        self.turn_started = None;
+```
+
+- [ ] **Step 5: Add `load_pricing` in `mod.rs` and set it at startup**
+
+```rust
+/// Resolve the agent's per-1k pricing + context window from its profile and
+/// `~/.mur/models.yaml`. Replicated here because mur-core must NOT depend on
+/// mur-agent-runtime. Inline-model agents (no `model_ref`) have no pricing.
+fn load_pricing(_home: &std::path::Path, agent: &str) -> super::cli::footer::Pricing {
+    use mur_common::model::ModelRegistry;
+    let pricing = super::cli::footer::Pricing::default();
+    let Ok((_, profile)) = crate::cmd::agent::load_profile_for_edit(agent) else {
+        return pricing;
+    };
+    let Some(model_ref) = profile.model_ref.as_deref() else {
+        return pricing; // inline model: no registry pricing
+    };
+    let Ok(path) = ModelRegistry::default_path() else { return pricing };
+    let Ok(reg) = ModelRegistry::load_from(&path) else { return pricing };
+    let Some(entry) = reg.models.get(model_ref) else { return pricing };
+    let (input, output) = entry.effective_costs();
+    super::cli::footer::Pricing {
+        in_per_1k: input,
+        out_per_1k: output,
+        window: entry.context_window,
+    }
+}
+```
+
+> Adjust the module path (`super::cli::footer` vs `footer`) to match where this fn lives relative to the `footer` module. If `mod.rs` IS the cli module root, use `footer::Pricing`. Confirm the import path for `load_profile_for_edit` with `rg -n "fn load_profile_for_edit" mur-core/src`.
+
+After constructing `App` in the cli entry (`run_tui` / wherever `App::new` is called), set:
+
+```rust
+    app.pricing = load_pricing(&app.home, &app.agent);
+```
+
+- [ ] **Step 6: Run test + build**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core footer_state_tests && cargo check -p mur-core`
+Expected: PASS + clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/app.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(cli): track per-turn/session tokens + pricing + turn clock on App"
+```
+
+---
+
+### Task 9: Render the parity footer (`ui.rs`)
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/ui.rs` (`render_status` ~192–270)
+- Test: manual (render assertions on a status are awkward; the math is already unit-tested in Task 7). Add a small pure helper test for the assembled left-segment string.
+
+**Interfaces:**
+- Consumes: `App.{streaming, hitl, turn_started, turn_in, turn_out, session_in, session_out, ctx_tokens, pricing}`, `footer::{turn_cost, context_pct, ctx_color, ctx_bar, CTX_BAR_WIDTH, UsageCounts}`.
+
+- [ ] **Step 1: Write the failing test** (pure formatter)
+
+Add to `ui.rs`:
+
+```rust
+#[cfg(test)]
+mod footer_fmt_tests {
+    use super::footer_segments;
+    use crate::cmd::agent::cli::footer::Pricing;
+
+    #[test]
+    fn shows_tokens_and_dash_cost_when_unpriced() {
+        let s = footer_segments(
+            1240, 0, 1240, 0, 0,
+            &Pricing::default(),
+        );
+        assert!(s.contains("1,240 tok") || s.contains("1240 tok"));
+        assert!(s.contains("—")); // no price → em dash
+    }
+
+    #[test]
+    fn shows_cost_and_ctx_when_priced() {
+        let p = Pricing { in_per_1k: Some(0.003), out_per_1k: Some(0.015), window: Some(100_000) };
+        let s = footer_segments(1000, 1000, 1000, 1000, 32_000, &p);
+        assert!(s.contains("$0.018"));
+        assert!(s.contains("32%"));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core footer_fmt_tests 2>&1 | tail -20`
+Expected: FAIL — `footer_segments` missing.
+
+- [ ] **Step 3: Add `footer_segments` + rewrite the status bar**
+
+Add the pure formatter to `ui.rs`:
+
+```rust
+/// Build the footer's observability text (state glyph is added by the caller).
+/// `turn_in/turn_out` = this turn; `sess_in/sess_out` = running; `ctx` = fill.
+fn footer_segments(
+    turn_in: u64,
+    turn_out: u64,
+    sess_in: u64,
+    sess_out: u64,
+    ctx: u64,
+    pricing: &super::footer::Pricing,
+) -> String {
+    use super::footer::{context_pct, ctx_bar, turn_cost, UsageCounts, CTX_BAR_WIDTH};
+    let turn_tok = turn_in + turn_out;
+    let sess_tok = sess_in + sess_out;
+    let cost = turn_cost(pricing, &UsageCounts { input: turn_in, output: turn_out })
+        .map(|c| format!("${c:.3} est"))
+        .unwrap_or_else(|| "—".to_string());
+    let ctx_part = match pricing.window {
+        Some(w) if w > 0 => {
+            let pct = context_pct(ctx, w);
+            format!(" · ctx {} {}%", ctx_bar(pct, CTX_BAR_WIDTH), pct)
+        }
+        _ => String::new(),
+    };
+    format!("{turn_tok}/{sess_tok} tok · {cost}{ctx_part}")
+}
+```
+
+In `render_status`, keep the existing `(msg, color)` state logic, but append the footer segments + a wall timer when streaming. After the `spans.push(Span::styled(msg, ...))` line, add:
+
+```rust
+    // Glass Box observability: tokens · cost · ctx · timer.
+    let obs = footer_segments(
+        app.turn_in, app.turn_out, app.session_in, app.session_out, app.ctx_tokens, &app.pricing,
+    );
+    spans.push(Span::raw("  ·  "));
+    spans.push(Span::styled(obs, Style::default().fg(theme.system)));
+    if let Some(t0) = app.turn_started {
+        let secs = t0.elapsed().as_secs();
+        spans.push(Span::styled(
+            format!(" · {}m{:02}s · esc=stop", secs / 60, secs % 60),
+            Style::default().fg(theme.system),
+        ));
+    }
+```
+
+> The status row is `Constraint::Length(1)` — a single line. If the combined text overflows narrow terminals, ratatui clips it (acceptable for P1). Widening to two rows is a P2 polish; do NOT change the layout here.
+
+- [ ] **Step 4: Run test + visual build**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core footer_fmt_tests && cargo check -p mur-core && cargo clippy -p mur-core -- -D warnings`
+Expected: PASS + clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/ui.rs
+git commit -m "feat(cli): parity footer — tokens, cost, context bar, turn timer"
+```
+
+---
+
+### Task 10: Proto-degrade hint for old runtimes
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs` (`handle_stream` `Done` arm)
+- Modify: `mur-core/src/cmd/agent/cli/stream.rs` (add `task_used_tools(task: &Value) -> bool` helper)
+- Test: `mur-core/src/cmd/agent/cli/stream.rs` (inline test)
+
+**Interfaces:**
+- Produces: `stream::task_used_tools(&Value) -> bool` (did the final task contain any tool_use messages?).
+- Consumes: `App.saw_step_this_turn` (Task 8), `App.push_system` (existing).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod degrade_tests {
+    use super::task_used_tools;
+
+    #[test]
+    fn detects_tool_use_in_messages() {
+        let task = serde_json::json!({
+            "messages": [
+                { "role": "assistant", "parts": [ { "kind": "tool_use", "name": "read" } ] }
+            ]
+        });
+        assert!(task_used_tools(&task));
+    }
+
+    #[test]
+    fn false_when_no_tools() {
+        let task = serde_json::json!({
+            "messages": [ { "role": "assistant", "parts": [ { "kind": "text", "text": "hi" } ] } ]
+        });
+        assert!(!task_used_tools(&task));
+    }
+}
+```
+
+> Confirm the message/part shape with `rg -n "tool_use|ToolUse|kind" mur-common/src/a2a.rs` and adjust the predicate to match the real serialized form (it may be `type`/`tool_call` rather than `kind`/`tool_use`). The test must reflect the actual JSON.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core degrade_tests 2>&1 | tail -20`
+Expected: FAIL — `task_used_tools` missing.
+
+- [ ] **Step 3: Implement `task_used_tools`** (in `stream.rs`)
+
+```rust
+/// True if the final task JSON contains any tool-use message part — used to
+/// detect an old runtime that ran tools but never streamed `step/*` events.
+pub fn task_used_tools(task: &Value) -> bool {
+    task.get("messages")
+        .and_then(Value::as_array)
+        .map(|msgs| {
+            msgs.iter().any(|m| {
+                m.get("parts")
+                    .and_then(Value::as_array)
+                    .map(|parts| {
+                        parts.iter().any(|p| {
+                            p.get("kind").and_then(Value::as_str) == Some("tool_use")
+                        })
+                    })
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+```
+
+- [ ] **Step 4: Emit the one-time hint in `handle_stream`'s `Done` arm**
+
+After `app.apply_usage(...)` and before/around `finish_agent_turn`, add:
+
+```rust
+            if !app.saw_step_this_turn && stream::task_used_tools(&task) && !app.step_hint_shown {
+                app.step_hint_shown = true;
+                app.push_system(
+                    "↻ this agent ran tools but didn't stream step detail — restart it (mur agent restart <name>) for the Glass Box step view",
+                );
+            }
+```
+
+Add `pub step_hint_shown: bool,` to `App` (init `false`) so the hint shows at most once per session.
+
+- [ ] **Step 5: Run test + build**
+
+Run: `ORT_STRATEGY=download cargo nextest run -p mur-core degrade_tests && cargo check -p mur-core`
+Expected: PASS + clean.
+
+- [ ] **Step 6: Final P1 verification + commit**
+
+Run:
+```bash
+ORT_STRATEGY=download cargo nextest run -p mur-core cmd::agent::cli
+cargo nextest run -p mur-agent-runtime step_tests
+cargo clippy -p mur-core -p mur-agent-runtime -- -D warnings
+cargo fmt --check
+```
+Expected: all green.
+
+```bash
+git add mur-core/src/cmd/agent/cli/stream.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(cli): one-time hint when an old runtime omits step events"
+```
+
+---
+
+## Manual verification (after all tasks)
+
+1. Build + install: `./build.sh --install` (or `cargo build --release -p mur-core`).
+2. Start an agent with a `model_ref` set (so pricing shows): `mur agent cli <name>`.
+3. Ask it to read a file and run a shell command. Confirm:
+   - Each tool appears as a `◐ name …` card that flips to `✔`/`✗` with a duration.
+   - Args + (bounded) output render under the card.
+   - Reasoning stays on screen after the reply (doesn't vanish).
+   - Footer shows `turn/session tok`, `$cost est` (or `—` for an inline-model agent), `ctx ▓▓░░ N%` (priced agent), and a live `0m08s · esc=stop` timer while streaming.
+4. Point the cli at an **old** runtime binary (pre-Task-1). Confirm: no cards, no panic, and the one-time "restart for step view" hint appears after a tool-using turn.
+
+## Self-Review (completed)
+
+- **Spec coverage:** D0 (T1–T2), D1 reasoning-unchanged-protocol (T2 keeps `thinking` deltas; T5 keeps them on screen), D2 truncate-inline (T1 `cap_step_output`, full-expand deferred per spec), D3 proto-degrade (T10), D6 footer input-only/`est`/`—` (T7–T9), card render (T6). D4 (inline HITL), D5 toggle, D7 compaction hook, diff viewer, mid-turn steer, budget, plain-mode → **P2/P3, not this plan** (per spec phasing). ✔
+- **Placeholder scan:** none — every step has runnable code/commands. The three "confirm with `rg`" notes are verification anchors against real code, not logic placeholders. ✔
+- **Type consistency:** `StepEvent`/`StepCard`/`StreamMsg::Step*`/`footer::*`/`apply_usage`/`saw_step_this_turn`/`step_hint_shown` names match across T1–T10. ✔

--- a/docs/superpowers/specs/2026-06-27-mur-agent-cli-glass-box-design.md
+++ b/docs/superpowers/specs/2026-06-27-mur-agent-cli-glass-box-design.md
@@ -1,0 +1,215 @@
+# `mur agent cli` — Glass Box (Step Transparency) — Design Spec
+
+- **Date:** 2026-06-27
+- **Status:** Draft (design); pending user review → writing-plans
+- **Author:** David Chang (with Claude Code, ultracode research)
+- **Scope:** `mur-agent-runtime` (step-event emission) + `mur-core/src/cmd/agent/cli/` (render). No GUI.
+- **Research basis:** Workflow `wf_a523621f-e2b` (6 web-research agents on 2026 terminal-AI-agent UX + deep-read + synthesis), a codebase map of the current cli TUI, and a verified brief on Claude Code long-session handling. Competitive baseline: Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode/Crush, Warp.
+- **Supersedes nothing.** Orthogonal to `2026-06-17-agent-cli-ux-improvements-design.md` (keyboard/skin polish) and `2026-06-24-agent-runtime-upgrade-restart-design.md` (whose proto-version gate this reuses).
+
+## Thesis
+
+> The user must always know exactly what the LLM is doing right now — streaming text, full reasoning, which tool with which args, what it returned, what it decided, what it cost, how long it took, and where it's blocked.
+
+The current cli is **blind to auto-approved tool steps.** The runtime streams only `message/delta` (text + `thinking` flag) + `tool/approval_needed` (HITL) + a final task JSON the cli mostly discards. Tools that don't need approval are never surfaced as steps — they're buried in the final JSON, of which the cli keeps only the last text block.
+
+So step-transparency is **not a frontend job.** The load-bearing change is a runtime **step-event stream** (Codex's `started → … → completed` lifecycle, minimized). The tool cards, footer, and controls all hang off that spine. Everything the cli can already see (streamed text, reasoning deltas, HITL, `Task.usage`) is reused — we stop *throwing it away*, we don't re-plumb it.
+
+## North star → concrete goals
+
+1. **Every tool call is a visible step** — name + args + result + error + duration — live, for *all* tools (not just HITL-gated ones).
+2. **Reasoning is never erased.** Today it streams then vanishes on turn-finish; keep it.
+3. **A persistent footer** answering "what state, how many tokens, what cost, how full is the window, how long" at a glance.
+4. **Inline progressive disclosure** (Hybrid model, not a separate pane): summary by default, one key to expand args / result / diff / reasoning.
+5. **Control:** single-key interrupt with a live timer, inline risk-tiered approvals, mid-turn steering, scrollback escape hatch.
+6. **Graceful degradation** against older runtimes (the known stale-binary drift) — no hard break.
+
+## Non-goals (explicit YAGNI — do NOT build)
+
+- **Context compaction / auto-compact / `/compact` / `/clear` / `/rewind`.** Real and valuable, but a *different feature area* (context management, not step-transparency). Sibling spec — see [Related work](#related-work--sibling-specs). This spec only **reserves a footer hook** so it composes later.
+- **A separate "mission control" multi-pane layout.** Rejected during brainstorm in favor of the inline Hybrid model. The inline step stream *is* the timeline.
+- **A new persistent store for full tool output.** Full output for expansion comes from the final task JSON (already complete) + the existing compress/`mur_retrieve` path. No new on-disk object.
+- **A new A2A transport or method family.** Reuse the existing JSON-RPC streaming socket; add notifications, not a protocol.
+- **Reasoning-summarization model** (Claude's `display:"summarized"` second-model trick). MUR shows raw reasoning as-is; summarization is out of scope.
+- **Per-provider rate-limit fabrication.** Render quota meters *only* when the provider actually surfaces quota; otherwise omit the field. No invented numbers.
+
+## Decisions (locked)
+
+| ID | Decision |
+|----|----------|
+| **D0** | The spine is a **runtime change**: two new JSON-RPC notifications (`step/started`, `step/completed`) emitted at the tool call-site in `mur-agent-runtime`. Non-negotiable — the requirement is unreachable frontend-only. |
+| **D1** | **Reasoning protocol is unchanged.** Reuse the existing `message/delta` `thinking:true` stream; the only change is `App` stops clearing `thinking` on `finish_agent_turn`. No `step/started` for reasoning. |
+| **D2** | **Full-output expansion reads from the final task JSON**, mapped `step_id → tool_result`. Inline `step/completed` carries only a truncated `output` + `full_len`. No new storage in v1. Oversized output during a *running* turn stays truncated until completion. |
+| **D3** | **Backward-compat via the existing proto-version gate** (`2026-06-24-agent-runtime-upgrade-restart`). New cli + old runtime → no step events arrive → fall back to today's text+HITL rendering + a one-line "restart this agent for step view" hint. Never a hard error. |
+| **D4** | **HITL moves inline onto the tool card** (state `AwaitingApproval`), replacing the centered modal. Keys `[y]/[a]/[n]` unchanged; approval still rides the existing separate responder connection. |
+| **D5** | **Reasoning default = always fully visible** (user choice), with a `/reasoning [full\|collapsed]` toggle and auto-collapse under `--plain`/screen-reader mode. The toggle is a knob, not a re-litigation. |
+| **D6** | **Footer = full statusline parity.** Cost is from `models.yaml` rates, labeled `est`, `—` when the model has no price. Context bar is **input-only** (`input + cache_creation + cache_read`) over the model's window, 3-threshold (green<70 / yellow / red≥90). Rate-limit field renders only when provider quota is available. |
+| **D7** | **Compaction is a sibling spec.** This spec reserves exactly one integration point: when `ctx ≥ threshold` the footer shows a `● /compact` affordance (no-op stub until the context-management spec lands). |
+| **D8** | **Phased delivery.** P1 (spine + cards + footer), P2 (control + diffs), P3 (power extras). Each phase is its own plan → PR, independently shippable. P1 alone delivers the north star. |
+
+## A. Runtime step-event protocol (the spine)
+
+Two notifications on the existing streaming socket (`~/.mur/agents/<name>/running.lock` JSON-RPC), emitted around the tool call-site (the same site that already emits `tool/approval_needed`):
+
+```jsonc
+// server → client, during a turn
+{ "method": "step/started",   "params": {
+    "step_id": "s-1", "kind": "tool", "name": "edit", "args": { ... }, "ts": 1782... } }
+
+{ "method": "step/completed", "params": {
+    "step_id": "s-1", "ok": true,
+    "output": "…first N lines…", "truncated": true, "full_len": 412,
+    "error": null, "duration_ms": 86, "ts": 1782... } }
+```
+
+- **Lifecycle.** Plain tool: `started → completed`. HITL-gated tool: `started → tool/approval_needed → completed` (the card shows running → awaiting approval → done). Denied: `started → completed{ok:false, error:"denied"}`.
+- **Reasoning** (D1): no step event — keep `message/delta{thinking:true}`.
+- **Usage.** Read `input_tokens / output_tokens / cache_creation_input_tokens / cache_read_input_tokens` from the final task (`Task.usage`, already flowing — proven by the fleet budget work). During streaming, show a live *estimate* (`output ≈ chars/4`) and reconcile to the accurate value at `Done`. An optional incremental `turn/usage` notification is a P3 nicety, not required.
+
+### `dial_message_streaming` signature change
+
+Current (`a2a_dial` / `stream.rs`):
+
+```rust
+pub fn dial_message_streaming(
+    home: &Path, agent_name: &str, params: Value,
+    on_delta: impl FnMut(&str, bool, &str),   // (text, thinking, task_id)
+    on_hitl:  impl FnMut(Value),
+) -> Result<Value>
+```
+
+Add one callback, mirroring the existing pattern (smallest diff that fits house style):
+
+```rust
+    on_step: impl FnMut(StepEvent),            // StepEvent::{Started, Completed}
+```
+
+`stream.rs` parses `step/started` / `step/completed` into `StepEvent` and forwards new `StreamMsg` variants to the cli's mpsc channel.
+
+### `StreamMsg` additions (`stream.rs`)
+
+Existing: `Delta`, `Hitl`, `Done`, `Err`, `Note`, `ShellDone`. Add:
+
+```rust
+StepStarted   { task_id: String, step_id: String, name: String, args: Value },
+StepCompleted { task_id: String, step_id: String, ok: bool,
+                output: String, truncated: bool, full_len: usize,
+                error: Option<String>, duration_ms: u64 },
+```
+
+## B. cli render model — inline step stream
+
+The transcript becomes a list of typed, foldable nodes (replacing flat text accumulation), rendered **inline** (Hybrid, no pane):
+
+```rust
+enum Node {
+    User(String),
+    Reasoning(String),         // D5: expanded by default
+    Assistant(ChatMsg),        // streamed markdown (existing ChatMsg reused)
+    Tool(StepNode),
+    System(String),            // errors, notes, retry/wait banners
+}
+
+struct StepNode {
+    id: String, name: String, args: Value,
+    state: StepState,          // Running | AwaitingApproval | Done | Error
+    output: String, full_len: usize, error: Option<String>,
+    started: Instant, duration: Option<Duration>,
+    expanded: bool, is_edit: bool,   // is_edit → render diff body
+}
+```
+
+**Tool card.** Header: `{glyph} {name} {arg-summary} · {state} · {elapsed}`. Body (expandable): pretty-printed full args + result (`… +N lines`, expand pulls full from task JSON) + red error. Edit tools render a diff body (§E).
+
+```
+╭ 🔧 edit  src/auth.rs · running · 0m08s ──────────╮   ← collapsed: header only
+│ approve?  [y]es  [a]lways  [n]o                  │   ← AwaitingApproval: inline
+╰──────────────────────────────────────────────────╯
+✔ read  src/auth.rs · 412 lines · 8ms          [tab] ← Done, collapsed
+✗ bash  cargo test · exit 101 · 2.3s           [tab] ← Error (red)
+```
+
+**Append-only stability** (the screen-reader / redraw-churn fix the research flagged): only the *running* node mutates; completed nodes are stable blocks. Apply diff-before-repaint in the normal renderer too.
+
+**Keys.** `↑/↓` move a selection cursor across step cards (and scroll); `tab`/`enter` expand/collapse the focused card; `y/a/n` inline HITL; `r` retry recently-denied; `esc` interrupt (double-esc semantics from the 0617 spec preserved); `Ctrl+O` scrollback dump (§D); typing + `enter` while running = mid-turn steer (§D).
+
+## C. Footer — full statusline parity (D6)
+
+Persistent row above the input box:
+
+```
+{◇/◐/✋ state} · {turn}/{sess} tok · ${cost} est · ctx ▓▓▓░░░ 32% · {wall}/{api} · {5h 41%} · esc=stop
+```
+
+- **state glyph:** Ready `◇` / Working `◐`(spinner) / Action-Required `✋`.
+- **context %** = `(input + cache_creation + cache_read) / window` (input-only), window from `models.yaml`; bar color green<70 / yellow<90 / red≥90.
+- **cost** = `input·in_rate + output·out_rate` from `models.yaml`; `—` when unpriced (local/proxy). Always labeled `est`.
+- **dual clock:** `wall = now − turn_start`; `api ≈ Σ step durations + model stream time`.
+- **rate-limit:** rendered only if the provider surfaces quota (e.g. Anthropic headers via cc-proxy); omitted otherwise.
+- **D7 hook:** at `ctx ≥ threshold`, append a `● /compact` affordance (stub).
+
+`footer.rs` owns this math; unit-tested in isolation.
+
+## D. Control & power extras
+
+| Feature | Behavior | Notes |
+|---------|----------|-------|
+| **Interrupt + timer** | `esc` cancels in-flight; running card shows `· 0m12s · esc=stop`. | Reuses existing cancel path. |
+| **Mid-turn steering** | Type + `enter` while running → inject guidance without killing the turn (`turn/steer` runtime method appends a user message to in-flight context). | Proto-gated; degrades to "queued, sent next turn" on old runtimes. |
+| **Risk-tiered approvals** | Reuse mur's SHA-256-pinned HITL gate: reads/searches auto-execute + log; write/destructive gate inline on the card. Recently-denied list + `r` to retry. | No new gate; new *surfacing* of the existing one. |
+| **Scrollback escape hatch** | `Ctrl+O` dumps the full expanded transcript to native scrollback / `$EDITOR` so `Cmd+f` / tmux copy works. | Live view stays virtualized. |
+| **Notify-on-blur** | Desktop notification only when the terminal is unfocused (OpenCode + Crush converged default). | Reuses companion/notify if present; else OS bell. |
+| **Active budget** | `--budget-usd X` / `--budget-tokens N`: footer shows remaining; turn aborts when exhausted. | Reuses fleet's real per-token accounting. Off by default. |
+| **Plain / screen-reader mode** | `--plain` (or auto-detect): finalized append-only blocks, no spinner/timer churn, reasoning auto-collapsed. | Fixes the line-mutation announcement bug. |
+| **Retry / wait banners** | Non-failure `System` node: "waiting for API… will retry · attempt x/y" after stream silence / on backoff. | So a stall never reads as a hang. |
+
+## E. Diff viewer
+
+Edit-tool cards render a syntax-highlighted unified diff as the body (the diff *is* the approval surface). Built from the edit tool's `old`/`new` args — no extra runtime data. `/diff` opens a per-turn navigable view (Current vs prior turns) with per-file `+/-` stats and state tags (`new`/`deleted`/`binary`/`truncated`). Viewport-responsive (inline unified default; stacked when narrow).
+
+## Module layout (ponytail: split, don't bloat)
+
+`mod.rs` is already **857 lines** (over the 800-line rule) and `ui.rs` is 345. New code lands as:
+
+- `cli/step.rs` — `Node` / `StepNode` model + state machine (started/delta/completed, expand toggles, truncation). **Unit-tested.**
+- `cli/footer.rs` — token/cost/context/timer math. **Unit-tested.**
+- `cli/budget.rs` — active-budget guard (reuse fleet accounting).
+- `cli/render/{transcript,card,footer,diff}.rs` — split out of `ui.rs` as it crosses 800.
+- `stream.rs` — `StepEvent`, new `StreamMsg` variants, notification parsing.
+- `mur-agent-runtime` — emit `step/started` / `step/completed` at the tool call-site; `turn/steer` method (P3).
+
+`mod.rs` itself only gains arms for the new `StreamMsg` variants; the logic lives in the new modules.
+
+## Backward-compat & proto-gating
+
+Reuse `2026-06-24-agent-runtime-upgrade-restart`'s proto-version gate. If the dialed runtime predates step events, the cli receives no `step/*` notifications → renders today's text + HITL behavior, and shows a single dismissible `System` hint: `↻ restart this agent (mur agent restart <name>) to see per-step detail`. Never auto-restart (the memory'd needrestart-style rule).
+
+## Phasing
+
+| Phase | Contents | Delivers |
+|-------|----------|----------|
+| **P1 — Spine** | runtime `step/started`+`step/completed`; `StreamMsg` variants; `cli/step.rs` cards (name/args/result/error, truncate+expand); reasoning-kept (D1); `cli/footer.rs` (tokens/cost/context/timers); `esc`+timer; proto-degrade (D3). | The north star — "know each step" — standalone. |
+| **P2 — Control & diffs** | inline risk-tiered HITL on cards (D4) + recently-denied/`r`; `/diff` per-turn diff viewer (§E); `Ctrl+O` scrollback hatch; notify-on-blur. | Rounds out the 2026 baseline. |
+| **P3 — Power extras** | `turn/steer` mid-turn steering; `--budget-*` active budget; `--plain`/screen-reader mode; retry/wait banners; optional incremental `turn/usage`. | Maximal transparency + control. |
+
+## Testing
+
+- **Runtime:** a tool call emits `step/started`+`step/completed` with correct args/output/`duration_ms`; an HITL-gated tool emits `started → approval → completed`; a denied tool emits `completed{ok:false}`.
+- **cli `step.rs`:** state machine (started→completed→expand toggle), truncation + `full_len`, full-expand maps to task-JSON result.
+- **cli `footer.rs`:** context % is input-only; threshold colors at 69/70/89/90; cost `—` when unpriced; dual-clock split.
+- **Proto-degrade:** a stream with zero `step/*` events renders text + the upgrade hint, no panic.
+- One runnable `assert`-based check per non-trivial unit; no framework, no fixtures (ponytail).
+
+## Related work & sibling specs
+
+- **Context management (compaction) — future sibling spec.** Claude Code's long-session model is auto-compact at ~83.5% (`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`, ~33K reserved buffer) + manual `/compact [focus]` + `/clear` + `/rewind` (warm-cache truncate) + `/context` itemization + durable `CLAUDE.md`/memory + layered prompt caching + session resume. MUR is well-positioned: the **channel** already persists every turn (signed, resumable), tool outputs already **compress/`mur_retrieve`**, and delegate/fleet already isolate context like subagents. That spec wires those into a sense → compact → continue loop; this spec only reserves the footer `● /compact` hook (D7).
+- `2026-06-17-agent-cli-ux-improvements-design.md` — keyboard/skin polish; double-esc semantics preserved here.
+- `2026-06-24-agent-runtime-upgrade-restart-design.md` — proto-version gate reused for D3.
+
+## Open risks
+
+1. **Stale-runtime drift** (memory: `project_agent_runtime_upgrade_restart`) — mitigated by D3 proto-gate + upgrade hint.
+2. **Cost accuracy** for local/proxy models — labeled `est`, `—` when unpriced; never presented as the real bill.
+3. **Rate-limit data availability** — field is conditional, not fabricated.
+4. **Always-visible reasoning noise** in long sessions — mitigated by `/reasoning collapsed` + `--plain` auto-collapse (D5).
+5. **Dual-clock `api` time is approximate** (Σ step durations + stream time) — acceptable; labeled, not billed.

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -2811,11 +2811,10 @@ mod step_tests {
 
     #[test]
     fn cap_step_output_long_is_truncated() {
-        let big = "x".repeat(STEP_MAX_BYTES + 100);
+        let big = "é".repeat(STEP_MAX_BYTES); // 2 bytes/char → over the cap
         let (out, truncated, full_len) = cap_step_output(&big);
         assert!(truncated);
-        assert_eq!(full_len, STEP_MAX_BYTES + 100);
-        assert!(out.ends_with("\n[truncated]"));
-        assert!(out.len() <= STEP_MAX_BYTES + "\n[truncated]".len());
+        assert_eq!(full_len, big.len());
+        assert!(out.is_char_boundary(out.len())); // never split a char
     }
 }

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -129,6 +129,11 @@ pub struct TaskRunner {
     /// `run_sync_inner` can snapshot-delta both counters and report a turn's
     /// real input+output token usage in `Task.usage` (fleet cost accounting).
     cumulative_output_tokens: AtomicU64,
+    /// Input-token count of the most recent single LLM call. Approximates the
+    /// current context window fill, unlike the cumulative total. Read by the
+    /// `token_usage` closure to populate `context_tokens` in per-turn usage JSON
+    /// so the CLI glass-box bar can show a live context gauge.
+    last_input_tokens: AtomicU64,
     hook_chain: Option<Arc<HookChain>>,
     hook_ctx: Option<HookCtx>,
     hook_cancel: Option<CancellationToken>,
@@ -235,6 +240,7 @@ impl TaskRunner {
             turn_counter: AtomicU64::new(0),
             cumulative_input_tokens: AtomicU64::new(0),
             cumulative_output_tokens: AtomicU64::new(0),
+            last_input_tokens: AtomicU64::new(0),
             hook_chain: None,
             hook_ctx: None,
             hook_cancel: None,
@@ -678,7 +684,11 @@ impl TaskRunner {
                 .cumulative_output_tokens
                 .load(Ordering::Relaxed)
                 .saturating_sub(tok_out0);
-            serde_json::json!({ "input_tokens": input_tokens, "output_tokens": output_tokens })
+            serde_json::json!({
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "context_tokens": self.last_input_tokens.load(Ordering::Relaxed),
+            })
         };
 
         let now = chrono::Utc::now().to_rfc3339();
@@ -934,6 +944,8 @@ impl TaskRunner {
                 let _prev = self
                     .cumulative_input_tokens
                     .fetch_add(resp.input_tokens, Ordering::Relaxed);
+                self.last_input_tokens
+                    .store(resp.input_tokens, Ordering::Relaxed);
                 self.cumulative_output_tokens
                     .fetch_add(resp.output_tokens, Ordering::Relaxed);
                 if let Some(tx) = &self.telemetry {
@@ -1027,6 +1039,14 @@ impl TaskRunner {
             });
         }
 
+        // Resolve step notifier once (route by task id, fall back to baked notifier).
+        // Used for step/started + step/completed in both Allow and Ask arms.
+        let step_notifier: Option<tokio::sync::mpsc::Sender<serde_json::Value>> = {
+            let routed = self.client_notifiers.lock().await.get(task_id).cloned();
+            routed.or_else(|| self.notifier.clone())
+        };
+        let step_id = uuid::Uuid::now_v7().to_string();
+
         // 1b. Policy gate: check before executing.
         {
             use mur_common::agent::{ToolPolicy, resolve_tool_policy};
@@ -1041,10 +1061,47 @@ impl TaskRunner {
                 ToolPolicy::Allow => {
                     // Execute without HITL gate below.
                     let tool = tool.unwrap();
+                    if let Some(ref n) = step_notifier {
+                        let _ = n
+                            .send(step_notification(
+                                "step/started",
+                                serde_json::json!({
+                                    "step_id": step_id,
+                                    "task_id": task_id,
+                                    "kind": "tool",
+                                    "name": call.tool_name,
+                                    "args": call.input,
+                                }),
+                            ))
+                            .await;
+                    }
+                    let t0 = std::time::Instant::now();
                     let (output, is_error) = match tool.execute(call.input.clone()).await {
                         Ok(out) => (out, false),
                         Err(e) => (format!("tool error: {e}"), true),
                     };
+                    if let Some(ref n) = step_notifier {
+                        let (out, truncated, full_len) = cap_step_output(&output);
+                        let _ = n
+                            .send(step_notification(
+                                "step/completed",
+                                serde_json::json!({
+                                    "step_id": step_id,
+                                    "task_id": task_id,
+                                    "ok": !is_error,
+                                    "output": out,
+                                    "truncated": truncated,
+                                    "full_len": full_len,
+                                    "error": if is_error {
+                                        serde_json::Value::String(output.clone())
+                                    } else {
+                                        serde_json::Value::Null
+                                    },
+                                    "duration_ms": t0.elapsed().as_millis() as u64,
+                                }),
+                            ))
+                            .await;
+                    }
                     return Ok(ToolResultEntry {
                         call_id: call.call_id.clone(),
                         content: output,
@@ -1057,10 +1114,47 @@ impl TaskRunner {
 
         // 2. Execute the tool
         let tool = tool.unwrap();
+        if let Some(ref n) = step_notifier {
+            let _ = n
+                .send(step_notification(
+                    "step/started",
+                    serde_json::json!({
+                        "step_id": step_id,
+                        "task_id": task_id,
+                        "kind": "tool",
+                        "name": call.tool_name,
+                        "args": call.input,
+                    }),
+                ))
+                .await;
+        }
+        let t0_ask = std::time::Instant::now();
         let (output, is_error) = match tool.execute(call.input.clone()).await {
             Ok(out) => (out, false),
             Err(e) => (format!("tool error: {e}"), true),
         };
+        if let Some(ref n) = step_notifier {
+            let (out, truncated, full_len) = cap_step_output(&output);
+            let _ = n
+                .send(step_notification(
+                    "step/completed",
+                    serde_json::json!({
+                        "step_id": step_id,
+                        "task_id": task_id,
+                        "ok": !is_error,
+                        "output": out,
+                        "truncated": truncated,
+                        "full_len": full_len,
+                        "error": if is_error {
+                            serde_json::Value::String(output.clone())
+                        } else {
+                            serde_json::Value::Null
+                        },
+                        "duration_ms": t0_ask.elapsed().as_millis() as u64,
+                    }),
+                ))
+                .await;
+        }
 
         // 3. HITL gate (only after tool execution). Route the approval prompt to
         // the connection that issued this turn (looked up by task id), falling
@@ -1237,6 +1331,8 @@ impl TaskRunner {
 
             self.cumulative_input_tokens
                 .fetch_add(resp.input_tokens, std::sync::atomic::Ordering::Relaxed);
+            self.last_input_tokens
+                .store(resp.input_tokens, std::sync::atomic::Ordering::Relaxed);
             self.cumulative_output_tokens
                 .fetch_add(resp.output_tokens, std::sync::atomic::Ordering::Relaxed);
 
@@ -1395,6 +1491,8 @@ impl TaskRunner {
             Ok(resp) => {
                 self.cumulative_input_tokens
                     .fetch_add(resp.input_tokens, std::sync::atomic::Ordering::Relaxed);
+                self.last_input_tokens
+                    .store(resp.input_tokens, std::sync::atomic::Ordering::Relaxed);
                 self.cumulative_output_tokens
                     .fetch_add(resp.output_tokens, std::sync::atomic::Ordering::Relaxed);
                 Message {
@@ -1572,6 +1670,32 @@ impl AsyncTaskHandle {
             })
         })
     }
+}
+
+/// Maximum byte size of tool output included inline in a `step/completed`
+/// notification. Larger outputs are truncated; full recovery in a later phase.
+pub(crate) const STEP_MAX_BYTES: usize = 8 * 1024;
+
+/// Wrap params in a JSON-RPC notification envelope — mirrors the existing
+/// `tool/approval_needed` shape used on the streaming socket.
+pub(crate) fn step_notification(method: &str, params: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({ "jsonrpc": "2.0", "method": method, "params": params })
+}
+
+/// Cap tool output to `STEP_MAX_BYTES` on a char boundary.
+/// Returns `(capped_output, was_truncated, full_byte_len)`.
+pub(crate) fn cap_step_output(output: &str) -> (String, bool, usize) {
+    let full_len = output.len();
+    if full_len <= STEP_MAX_BYTES {
+        return (output.to_string(), false, full_len);
+    }
+    let mut cut = STEP_MAX_BYTES;
+    while !output.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let mut s = output[..cut].to_string();
+    s.push_str("\n[truncated]");
+    (s, true, full_len)
 }
 
 fn echo_response(input: &Message) -> Message {
@@ -2662,5 +2786,36 @@ mod tests {
             ok,
             "registry must have no Working entries after start_async drain rejection"
         );
+    }
+}
+
+#[cfg(test)]
+mod step_tests {
+    use super::{STEP_MAX_BYTES, cap_step_output, step_notification};
+
+    #[test]
+    fn notification_has_jsonrpc_envelope_and_method() {
+        let n = step_notification("step/started", serde_json::json!({ "step_id": "s1" }));
+        assert_eq!(n["jsonrpc"], "2.0");
+        assert_eq!(n["method"], "step/started");
+        assert_eq!(n["params"]["step_id"], "s1");
+    }
+
+    #[test]
+    fn cap_step_output_short_unchanged() {
+        let (out, truncated, full_len) = cap_step_output("hello");
+        assert_eq!(out, "hello");
+        assert!(!truncated);
+        assert_eq!(full_len, 5);
+    }
+
+    #[test]
+    fn cap_step_output_long_is_truncated() {
+        let big = "x".repeat(STEP_MAX_BYTES + 100);
+        let (out, truncated, full_len) = cap_step_output(&big);
+        assert!(truncated);
+        assert_eq!(full_len, STEP_MAX_BYTES + 100);
+        assert!(out.ends_with("\n[truncated]"));
+        assert!(out.len() <= STEP_MAX_BYTES + "\n[truncated]".len());
     }
 }

--- a/mur-core/src/a2a_dial.rs
+++ b/mur-core/src/a2a_dial.rs
@@ -191,6 +191,60 @@ fn dial_socket(
     }
 }
 
+/// A tool-step notification received from the runtime during a streaming turn.
+/// Emitted by the runtime as `step/started` and `step/completed` JSON-RPC
+/// notifications; parsed by [`parse_step`] and forwarded via the `on_step`
+/// callback of [`dial_message_streaming`].
+#[derive(Debug)]
+pub enum StepEvent {
+    /// The agent started executing a tool call.
+    Started {
+        step_id: String,
+        task_id: String,
+        name: String,
+        args: Value,
+    },
+    /// A tool call finished.
+    Completed {
+        step_id: String,
+        task_id: String,
+        ok: bool,
+        output: String,
+        truncated: bool,
+        full_len: usize,
+        error: Option<String>,
+        duration_ms: u64,
+    },
+}
+
+/// Parse the `params` of a `step/started` (`completed = false`) or
+/// `step/completed` (`completed = true`) JSON-RPC notification into a
+/// [`StepEvent`].
+pub fn parse_step(p: &Value, completed: bool) -> StepEvent {
+    let s = |k: &str| p.get(k).and_then(Value::as_str).unwrap_or("").to_string();
+    let step_id = s("step_id");
+    let task_id = s("task_id");
+    if completed {
+        StepEvent::Completed {
+            step_id,
+            task_id,
+            ok: p.get("ok").and_then(Value::as_bool).unwrap_or(true),
+            output: s("output"),
+            truncated: p.get("truncated").and_then(Value::as_bool).unwrap_or(false),
+            full_len: p.get("full_len").and_then(Value::as_u64).unwrap_or(0) as usize,
+            error: p.get("error").and_then(Value::as_str).map(str::to_string),
+            duration_ms: p.get("duration_ms").and_then(Value::as_u64).unwrap_or(0),
+        }
+    } else {
+        StepEvent::Started {
+            step_id,
+            task_id,
+            name: s("name"),
+            args: p.get("args").cloned().unwrap_or(Value::Null),
+        }
+    }
+}
+
 /// Dial a *running* agent's `message/send` and stream token deltas to
 /// `on_delta` as they arrive, returning the final task result. Requires the
 /// agent to be up (uses its unix socket); the runtime emits `message/delta`
@@ -201,12 +255,14 @@ fn dial_socket(
 /// `message/delta` (empty string if the agent predates per-connection routing).
 /// The runtime already routes deltas to this connection only; the id lets a
 /// client defensively drop anything not matching the turn it issued.
+/// `on_step` receives tool-step events (`step/started`, `step/completed`).
 pub fn dial_message_streaming(
     home: &Path,
     agent_name: &str,
     params: Value,
     mut on_delta: impl FnMut(&str, bool, &str),
     mut on_hitl: impl FnMut(Value),
+    mut on_step: impl FnMut(StepEvent),
 ) -> Result<Value> {
     let agent_name = &canonicalize_agent_name(home, agent_name);
     let lock_path = home.join("agents").join(agent_name).join("running.lock");
@@ -256,6 +312,18 @@ pub fn dial_message_streaming(
                         .and_then(Value::as_str)
                         .unwrap_or("");
                     on_delta(t, thinking, delta_task_id);
+                }
+                continue;
+            }
+            if v.get("method").and_then(Value::as_str) == Some("step/started") {
+                if let Some(params) = v.get("params") {
+                    on_step(parse_step(params, false));
+                }
+                continue;
+            }
+            if v.get("method").and_then(Value::as_str) == Some("step/completed") {
+                if let Some(params) = v.get("params") {
+                    on_step(parse_step(params, true));
                 }
                 continue;
             }
@@ -493,5 +561,70 @@ mod tests {
             !err.to_string().contains("stale runtime"),
             "must not gate message/send"
         );
+    }
+}
+
+#[cfg(test)]
+mod step_parse_tests {
+    use super::{StepEvent, parse_step};
+
+    #[test]
+    fn parses_started() {
+        let p = serde_json::json!({
+            "step_id": "s1",
+            "task_id": "t1",
+            "name": "edit",
+            "args": { "path": "a.rs" }
+        });
+        match parse_step(&p, false) {
+            StepEvent::Started {
+                step_id,
+                task_id,
+                name,
+                args,
+            } => {
+                assert_eq!(step_id, "s1");
+                assert_eq!(task_id, "t1");
+                assert_eq!(name, "edit");
+                assert_eq!(args["path"], "a.rs");
+            }
+            StepEvent::Completed { .. } => panic!("expected Started"),
+        }
+    }
+
+    #[test]
+    fn parses_completed() {
+        let p = serde_json::json!({
+            "step_id": "s2",
+            "task_id": "t2",
+            "ok": true,
+            "output": "done",
+            "truncated": false,
+            "full_len": 4u64,
+            "error": null,
+            "duration_ms": 123u64
+        });
+        match parse_step(&p, true) {
+            StepEvent::Completed {
+                step_id,
+                task_id,
+                ok,
+                output,
+                truncated,
+                full_len,
+                error,
+                duration_ms,
+            } => {
+                assert_eq!(step_id, "s2");
+                assert_eq!(task_id, "t2");
+                assert!(ok);
+                assert_eq!(output, "done");
+                assert!(!truncated);
+                assert_eq!(full_len, 4);
+                assert!(error.is_none());
+                assert_eq!(duration_ms, 123);
+            }
+            StepEvent::Started { .. } => panic!("expected Completed"),
+        }
     }
 }

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -373,7 +373,6 @@ impl App {
             if !reply.is_empty() {
                 m.text = reply;
             }
-            m.thinking.clear();
             m.streaming = false;
             m.rendered = Some(markdown::render(&m.text).lines);
             body = Some(m.text.clone());
@@ -1056,5 +1055,23 @@ mod esc_action_tests {
     #[test]
     fn esc_nothing_when_window_expired_not_streaming_empty() {
         assert_eq!(esc_action(expired(), false, true), EscAction::Nothing);
+    }
+}
+
+#[cfg(test)]
+mod reasoning_kept_tests {
+    use super::*;
+
+    #[test]
+    fn thinking_survives_turn_finish() {
+        let mut a = App::test_fixture();
+        a.begin_user_turn("hi");
+        a.append_delta("let me think", true); // thinking delta
+        a.append_delta("the answer", false);
+        a.finish_agent_turn("the answer".into(), Some("t1".into()));
+        let last = a.messages.last().unwrap();
+        assert_eq!(last.role, Role::Agent);
+        assert_eq!(last.thinking, "let me think"); // not cleared
+        assert!(!last.streaming);
     }
 }

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -240,6 +240,22 @@ pub struct App {
     /// Mascot color/animation mode, resolved once at startup from the theme
     /// and terminal capabilities (NO_COLOR / non-TTY / TERM=dumb → static).
     pub mascot_mode: MascotMode,
+    /// Wall-clock instant when the current agent turn began (set in
+    /// `begin_user_turn`, cleared in `finish_agent_turn` / `fail_turn`).
+    pub turn_started: Option<std::time::Instant>,
+    /// Cumulative token counts for this session (all turns combined).
+    pub session_in: u64,
+    pub session_out: u64,
+    /// Token counts for the most recent completed turn.
+    pub turn_in: u64,
+    pub turn_out: u64,
+    /// Last-known context fill from the runtime's `Task.usage.context_tokens`.
+    pub ctx_tokens: u64,
+    /// Agent's model pricing loaded at startup (used by the footer renderer).
+    pub pricing: super::footer::Pricing,
+    /// Set to `true` when `StepStarted` fires this turn; used by the footer
+    /// to distinguish "pure chat" from "agentic" turns.
+    pub saw_step_this_turn: bool,
 }
 
 impl App {
@@ -273,6 +289,14 @@ impl App {
             blink: Blink::new(),
             // Resolve color/animation once: env + TTY don't change mid-session.
             mascot_mode: resolve_mascot_mode(theme, std::io::stdout().is_terminal()),
+            turn_started: None,
+            session_in: 0,
+            session_out: 0,
+            turn_in: 0,
+            turn_out: 0,
+            ctx_tokens: 0,
+            pricing: super::footer::Pricing::default(),
+            saw_step_this_turn: false,
         }
     }
 
@@ -315,6 +339,19 @@ impl App {
         self.input = new_input();
     }
 
+    /// Ingest a `Task.usage` JSON object: update per-turn and session counters
+    /// and refresh `ctx_tokens` if the runtime emitted `context_tokens`.
+    pub fn apply_usage(&mut self, usage: &serde_json::Value) {
+        let u = super::footer::parse_usage(usage);
+        self.turn_in = u.input;
+        self.turn_out = u.output;
+        self.session_in += u.input;
+        self.session_out += u.output;
+        if let Some(c) = super::footer::context_tokens(usage) {
+            self.ctx_tokens = c;
+        }
+    }
+
     /// Replace the input buffer with `text` (used by slash-command completion).
     pub fn set_input(&mut self, text: &str) {
         self.input = new_input();
@@ -335,6 +372,10 @@ impl App {
         let task_id = uuid::Uuid::now_v7().to_string();
         self.current_task_id = Some(task_id.clone());
         self.streaming = true;
+        self.turn_started = Some(std::time::Instant::now());
+        self.turn_in = 0;
+        self.turn_out = 0;
+        self.saw_step_this_turn = false;
         self.scroll_back = 0;
         // Placeholder agent message that deltas accumulate into.
         let mut m = ChatMsg::new(Role::Agent, "");
@@ -395,6 +436,7 @@ impl App {
         }
         self.streaming = false;
         self.current_task_id = None;
+        self.turn_started = None;
     }
 
     /// Mark a partial (cancelled) turn as finished without persisting a reply.
@@ -469,6 +511,7 @@ impl App {
         self.push_system(format!("error: {err}"));
         self.streaming = false;
         self.current_task_id = None;
+        self.turn_started = None;
     }
 
     /// Reset to a brand-new conversation (drops server-side context). Any
@@ -1073,5 +1116,61 @@ mod reasoning_kept_tests {
         assert_eq!(last.role, Role::Agent);
         assert_eq!(last.thinking, "let me think"); // not cleared
         assert!(!last.streaming);
+    }
+}
+
+#[cfg(test)]
+mod footer_state_tests {
+    use super::*;
+
+    #[test]
+    fn apply_usage_accumulates_session_and_sets_turn() {
+        let mut a = App::test_fixture();
+        a.apply_usage(
+            &serde_json::json!({ "input_tokens": 100, "output_tokens": 20, "context_tokens": 100 }),
+        );
+        a.apply_usage(
+            &serde_json::json!({ "input_tokens": 50, "output_tokens": 10, "context_tokens": 150 }),
+        );
+        assert_eq!(a.turn_in, 50);
+        assert_eq!(a.turn_out, 10);
+        assert_eq!(a.session_in, 150);
+        assert_eq!(a.session_out, 30);
+        assert_eq!(a.ctx_tokens, 150);
+    }
+
+    #[test]
+    fn begin_user_turn_resets_turn_counters_and_arms_clock() {
+        let mut a = App::test_fixture();
+        // Prime some prior-turn state.
+        a.apply_usage(&serde_json::json!({ "input_tokens": 100, "output_tokens": 20 }));
+        a.begin_user_turn("hi");
+        assert_eq!(a.turn_in, 0, "turn_in reset");
+        assert_eq!(a.turn_out, 0, "turn_out reset");
+        assert!(!a.saw_step_this_turn, "saw_step reset");
+        assert!(a.turn_started.is_some(), "clock armed");
+        // session accumulators must NOT be cleared by begin_user_turn.
+        assert_eq!(a.session_in, 100, "session_in survives begin_user_turn");
+        assert_eq!(a.session_out, 20, "session_out survives begin_user_turn");
+    }
+
+    #[test]
+    fn finish_agent_turn_clears_clock() {
+        let mut a = App::test_fixture();
+        a.begin_user_turn("hi");
+        assert!(a.turn_started.is_some());
+        a.finish_agent_turn("ok".into(), None);
+        assert!(a.turn_started.is_none(), "clock cleared after finish");
+    }
+
+    #[test]
+    fn context_tokens_update_on_apply() {
+        let mut a = App::test_fixture();
+        a.apply_usage(&serde_json::json!({ "input_tokens": 10, "output_tokens": 5 }));
+        assert_eq!(a.ctx_tokens, 0, "no context_tokens field → unchanged");
+        a.apply_usage(
+            &serde_json::json!({ "input_tokens": 10, "output_tokens": 5, "context_tokens": 42000 }),
+        );
+        assert_eq!(a.ctx_tokens, 42000);
     }
 }

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -44,6 +44,9 @@ pub struct ChatMsg {
     /// per-frame redraw never re-parses finished messages. `None` while
     /// streaming and for user/system messages.
     pub rendered: Option<Vec<Line<'static>>>,
+    /// When set, this message renders a tool-call step card instead of text by
+    /// role. `None` for ordinary user/agent/system/shell messages.
+    pub step: Option<super::step::StepCard>,
 }
 
 impl ChatMsg {
@@ -54,6 +57,7 @@ impl ChatMsg {
             thinking: String::new(),
             streaming: false,
             rendered: None,
+            step: None,
         }
     }
 
@@ -66,6 +70,19 @@ impl ChatMsg {
             thinking: String::new(),
             streaming: false,
             rendered,
+            step: None,
+        }
+    }
+
+    /// A transcript entry that renders a tool-call step card.
+    fn tool(card: super::step::StepCard) -> Self {
+        Self {
+            role: Role::Agent,
+            text: String::new(),
+            thinking: String::new(),
+            streaming: false,
+            rendered: None,
+            step: Some(card),
         }
     }
 }
@@ -327,6 +344,12 @@ impl App {
     }
 
     pub fn append_delta(&mut self, text: &str, thinking: bool) {
+        if self.streaming_agent_mut().is_none() {
+            // Prior segment was frozen by a step card; start a new one.
+            let mut m = ChatMsg::new(Role::Agent, "");
+            m.streaming = true;
+            self.messages.push(m);
+        }
         if let Some(m) = self.streaming_agent_mut() {
             if thinking {
                 m.thinking.push_str(text);
@@ -376,6 +399,54 @@ impl App {
         }
         self.streaming = false;
         self.current_task_id = None;
+    }
+
+    /// Freeze the current streaming text segment (or drop it if empty) and push
+    /// a new running tool-call card.
+    pub fn push_step_started(&mut self, step_id: String, name: String, args: serde_json::Value) {
+        // Find the streaming agent segment, if any.
+        let idx = self
+            .messages
+            .iter()
+            .rposition(|m| m.role == Role::Agent && m.streaming);
+        if let Some(i) = idx {
+            let is_empty = self.messages[i].text.is_empty() && self.messages[i].thinking.is_empty();
+            if is_empty {
+                // Empty placeholder (agent called a tool before any text) — drop it.
+                self.messages.remove(i);
+            } else {
+                // Freeze the current text segment.
+                let rendered = Some(markdown::render(&self.messages[i].text).lines);
+                self.messages[i].streaming = false;
+                self.messages[i].rendered = rendered;
+            }
+        }
+        self.messages.push(ChatMsg::tool(super::step::StepCard::new(
+            step_id, name, args,
+        )));
+        self.scroll_back = 0;
+    }
+
+    /// Mark the matching step card as completed.
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_step_completed(
+        &mut self,
+        step_id: &str,
+        ok: bool,
+        output: String,
+        truncated: bool,
+        full_len: usize,
+        error: Option<String>,
+        duration_ms: u64,
+    ) {
+        if let Some(card) = self
+            .messages
+            .iter_mut()
+            .rev()
+            .find_map(|m| m.step.as_mut().filter(|c| c.id == step_id))
+        {
+            card.complete(ok, output, truncated, full_len, error, duration_ms);
+        }
     }
 
     pub fn fail_turn(&mut self, err: &str) {
@@ -520,6 +591,23 @@ fn new_input() -> TextArea<'static> {
     ta.set_placeholder_text("Type a message…");
     ta.set_placeholder_style(Style::default().fg(Color::DarkGray));
     ta
+}
+
+#[cfg(test)]
+impl App {
+    /// Minimal fixture for unit tests. Backed by a temporary directory that is
+    /// dropped on return — persist calls may fail silently (see `persist_turn`),
+    /// which is fine: all state-logic tests work on the in-memory transcript.
+    pub fn test_fixture() -> Self {
+        let home = tempfile::tempdir().unwrap();
+        let session = Session::create(home.path(), "a").unwrap();
+        App::new(
+            home.path().to_path_buf(),
+            "a".into(),
+            session,
+            &super::theme::DARK,
+        )
+    }
 }
 
 #[cfg(test)]
@@ -755,6 +843,91 @@ mod tests {
         assert!(a.last_sent.is_none());
         assert!(a.last_esc_at.is_none());
         assert!(!a.esc_hint);
+    }
+}
+
+#[cfg(test)]
+mod step_app_tests {
+    use super::*;
+    use crate::cmd::agent::cli::step::StepState;
+
+    fn app() -> App {
+        App::test_fixture()
+    }
+
+    #[test]
+    fn step_interleaves_between_text_segments() {
+        let mut a = app();
+        a.begin_user_turn("hi");
+        a.append_delta("reading file", false);
+        a.push_step_started(
+            "s1".into(),
+            "read".into(),
+            serde_json::json!({ "path": "a.rs" }),
+        );
+        // After push_step_started: prior segment frozen, step card pushed.
+        // append_delta now creates a new streaming segment.
+        a.append_delta("done, summary", false);
+
+        // Expect 3 agent-role messages: frozen text, step card, new streaming text.
+        let agent_msgs: Vec<_> = a
+            .messages
+            .iter()
+            .filter(|m| m.role == Role::Agent)
+            .collect();
+        assert_eq!(
+            agent_msgs.len(),
+            3,
+            "frozen segment + step card + new segment"
+        );
+        assert_eq!(agent_msgs[0].text, "reading file");
+        assert!(!agent_msgs[0].streaming, "first segment must be frozen");
+        assert!(
+            agent_msgs[1].step.is_some(),
+            "middle message must be a step card"
+        );
+        assert_eq!(agent_msgs[2].text, "done, summary");
+        assert!(agent_msgs[2].streaming, "new segment must be streaming");
+    }
+
+    #[test]
+    fn step_before_text_drops_empty_placeholder() {
+        let mut a = app();
+        a.begin_user_turn("hi");
+        // No delta yet — placeholder is empty.
+        a.push_step_started("s1".into(), "bash".into(), serde_json::json!({}));
+        // Empty placeholder dropped; only step card remains as agent message.
+        let agent_msgs: Vec<_> = a
+            .messages
+            .iter()
+            .filter(|m| m.role == Role::Agent)
+            .collect();
+        assert_eq!(
+            agent_msgs.len(),
+            1,
+            "empty placeholder dropped, only step card"
+        );
+        assert!(agent_msgs[0].step.is_some(), "must be step card");
+    }
+
+    #[test]
+    fn update_step_completed_marks_card_done() {
+        let mut a = app();
+        a.begin_user_turn("hi");
+        a.push_step_started(
+            "s1".into(),
+            "bash".into(),
+            serde_json::json!({ "cmd": "ls" }),
+        );
+        a.update_step_completed("s1", true, "foo.rs\n".into(), false, 7, None, 42);
+        let card = a
+            .messages
+            .iter()
+            .find_map(|m| m.step.as_ref())
+            .expect("step card");
+        assert_eq!(card.state, StepState::Done);
+        assert_eq!(card.duration_ms, Some(42));
+        assert_eq!(card.output, "foo.rs\n");
     }
 }
 

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -472,6 +472,7 @@ impl App {
         }
         self.streaming = false;
         self.current_task_id = None;
+        self.turn_started = None;
     }
 
     /// Freeze the current streaming text segment (or drop it if empty) and push
@@ -1183,6 +1184,15 @@ mod footer_state_tests {
         assert!(a.turn_started.is_some());
         a.finish_agent_turn("ok".into(), None);
         assert!(a.turn_started.is_none(), "clock cleared after finish");
+    }
+
+    #[test]
+    fn finish_partial_clears_clock() {
+        let mut a = App::test_fixture();
+        a.begin_user_turn("hi");
+        assert!(a.turn_started.is_some());
+        a.finish_partial();
+        assert!(a.turn_started.is_none());
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -256,6 +256,12 @@ pub struct App {
     /// Set to `true` when `StepStarted` fires this turn; used by the footer
     /// to distinguish "pure chat" from "agentic" turns.
     pub saw_step_this_turn: bool,
+    /// A HITL approval arrived this turn (any runtime). Paired with
+    /// `saw_step_this_turn` to detect an old runtime that ran a tool but
+    /// streamed no step events.
+    pub saw_hitl_this_turn: bool,
+    /// The "restart for step view" hint has been shown once this session.
+    pub step_hint_shown: bool,
 }
 
 impl App {
@@ -297,6 +303,8 @@ impl App {
             ctx_tokens: 0,
             pricing: super::footer::Pricing::default(),
             saw_step_this_turn: false,
+            saw_hitl_this_turn: false,
+            step_hint_shown: false,
         }
     }
 
@@ -376,6 +384,7 @@ impl App {
         self.turn_in = 0;
         self.turn_out = 0;
         self.saw_step_this_turn = false;
+        self.saw_hitl_this_turn = false;
         self.scroll_back = 0;
         // Placeholder agent message that deltas accumulate into.
         let mut m = ChatMsg::new(Role::Agent, "");
@@ -402,6 +411,19 @@ impl App {
         // to the bottom on every token, making it impossible to scroll up while
         // the agent streams. When the user hasn't scrolled (scroll_back == 0)
         // the render already stays pinned to the newest line as content grows.
+    }
+
+    /// If a tool needed approval this turn but no step events arrived, the agent
+    /// is running an old runtime that predates the Glass Box step stream. Nudge
+    /// the user to restart it — once per session.
+    pub fn maybe_step_hint(&mut self) {
+        if self.saw_hitl_this_turn && !self.saw_step_this_turn && !self.step_hint_shown {
+            self.step_hint_shown = true;
+            let agent = self.agent.clone();
+            self.push_system(format!(
+                "↻ this agent ran a tool without streaming step detail — restart it (mur agent restart {agent}) for the step view"
+            ));
+        }
     }
 
     /// Finalize the streaming agent turn with the authoritative reply. Persist
@@ -1172,5 +1194,41 @@ mod footer_state_tests {
             &serde_json::json!({ "input_tokens": 10, "output_tokens": 5, "context_tokens": 42000 }),
         );
         assert_eq!(a.ctx_tokens, 42000);
+    }
+
+    #[test]
+    fn old_runtime_hitl_without_steps_shows_hint_once() {
+        let mut a = App::test_fixture();
+        a.begin_user_turn("do it");
+        a.saw_hitl_this_turn = true; // hitl arrived, no step events => old runtime
+        a.maybe_step_hint();
+        assert!(a.step_hint_shown);
+        let n = a
+            .messages
+            .iter()
+            .filter(|m| m.role == Role::System && m.text.contains("restart"))
+            .count();
+        assert_eq!(n, 1);
+        // second such turn: not shown again
+        a.begin_user_turn("again");
+        a.saw_hitl_this_turn = true;
+        a.maybe_step_hint();
+        let n2 = a
+            .messages
+            .iter()
+            .filter(|m| m.role == Role::System && m.text.contains("restart"))
+            .count();
+        assert_eq!(n2, 1);
+    }
+
+    #[test]
+    fn new_runtime_with_steps_shows_no_hint() {
+        let mut a = App::test_fixture();
+        a.begin_user_turn("do it");
+        a.saw_hitl_this_turn = true;
+        a.saw_step_this_turn = true; // new runtime emitted step events
+        a.maybe_step_hint();
+        assert!(!a.step_hint_shown);
+        assert!(!a.messages.iter().any(|m| m.text.contains("restart")));
     }
 }

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -377,6 +377,16 @@ impl App {
             m.streaming = false;
             m.rendered = Some(markdown::render(&m.text).lines);
             body = Some(m.text.clone());
+        } else if self.streaming && !reply.is_empty() {
+            // Tool-using turns run the agentic loop, which doesn't stream text
+            // deltas — the empty placeholder was dropped when the first step card
+            // arrived, so there's no trailing segment. Push the final reply as its
+            // own finished message instead of dropping it.
+            // Guard: self.streaming is false after finish_partial() so stale
+            // Done events from cancelled tasks are still silently ignored.
+            self.messages.push(ChatMsg::agent_rendered(reply.clone()));
+            self.scroll_back = 0;
+            body = Some(reply);
         }
         if let Some(b) = body {
             if let Some(tid) = &task_id {
@@ -928,6 +938,45 @@ mod step_app_tests {
         assert_eq!(card.state, StepState::Done);
         assert_eq!(card.duration_ms, Some(42));
         assert_eq!(card.output, "foo.rs\n");
+    }
+
+    #[test]
+    fn tool_turn_reply_is_pushed_not_dropped() {
+        let mut a = app();
+        a.begin_user_turn("read the file");
+        a.push_step_started(
+            "s1".into(),
+            "read".into(),
+            serde_json::json!({"path":"a.rs"}),
+        );
+        a.update_step_completed("s1", true, "ok".into(), false, 2, None, 5);
+        // No streaming segment now (tool turn, no text deltas).
+        a.finish_agent_turn("here is the summary".into(), Some("t1".into()));
+        let last = a.messages.last().unwrap();
+        assert!(last.step.is_none());
+        assert_eq!(last.role, Role::Agent);
+        assert_eq!(last.text, "here is the summary");
+        assert!(!last.streaming);
+        assert!(last.rendered.is_some());
+    }
+
+    #[test]
+    fn multi_segment_finish_sets_trailing_keeps_frozen() {
+        let mut a = app();
+        a.begin_user_turn("hi");
+        a.append_delta("looking at it", false);
+        a.push_step_started("s1".into(), "read".into(), serde_json::json!({}));
+        a.append_delta("here is the answer", false);
+        // reply = final iteration text only
+        a.finish_agent_turn("here is the answer".into(), Some("t1".into()));
+        let segs: Vec<_> = a
+            .messages
+            .iter()
+            .filter(|m| m.role == Role::Agent && m.step.is_none())
+            .collect();
+        assert_eq!(segs[0].text, "looking at it"); // frozen, untouched
+        assert_eq!(segs[1].text, "here is the answer"); // trailing got reply
+        assert!(!segs[1].streaming);
     }
 }
 

--- a/mur-core/src/cmd/agent/cli/footer.rs
+++ b/mur-core/src/cmd/agent/cli/footer.rs
@@ -1,9 +1,5 @@
 //! Pure footer math: tokens, cost, and context-window fill from `Task.usage`
 //! plus the agent's `models.yaml` pricing. No ratatui, no I/O — unit-tested.
-//!
-//! Public items here are consumed by Task-9 footer renderer; suppress dead-code
-//! lint until that wiring lands.
-#![allow(dead_code)]
 
 use serde_json::Value;
 
@@ -25,6 +21,8 @@ pub struct Pricing {
     pub window: Option<u64>,
 }
 
+// P1 footer is monochrome; threshold color wires this in P2.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CtxColor {
     Green,
@@ -67,6 +65,8 @@ pub fn context_pct(used: u64, window: u64) -> u8 {
         .clamp(0.0, 100.0) as u8
 }
 
+// P1 footer is monochrome; threshold color wires this in P2.
+#[allow(dead_code)]
 pub fn ctx_color(pct: u8) -> CtxColor {
     if pct < CTX_YELLOW_PCT {
         CtxColor::Green

--- a/mur-core/src/cmd/agent/cli/footer.rs
+++ b/mur-core/src/cmd/agent/cli/footer.rs
@@ -1,5 +1,9 @@
 //! Pure footer math: tokens, cost, and context-window fill from `Task.usage`
 //! plus the agent's `models.yaml` pricing. No ratatui, no I/O — unit-tested.
+//!
+//! Public items here are consumed by Task-9 footer renderer; suppress dead-code
+//! lint until that wiring lands.
+#![allow(dead_code)]
 
 use serde_json::Value;
 
@@ -21,6 +25,7 @@ pub struct Pricing {
     pub window: Option<u64>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CtxColor {
     Green,
     Yellow,
@@ -73,7 +78,7 @@ pub fn ctx_color(pct: u8) -> CtxColor {
 }
 
 pub fn ctx_bar(pct: u8, width: usize) -> String {
-    let filled = (pct as usize * width) / 100;
+    let filled = (pct as usize * width / 100).min(width);
     format!("{}{}", "▓".repeat(filled), "░".repeat(width - filled))
 }
 
@@ -126,8 +131,8 @@ mod tests {
 
     #[test]
     fn bar_fills_proportionally() {
-        assert_eq!(ctx_bar(50, 6), "▓▓▓░░░");
-        assert_eq!(ctx_bar(0, 6), "░░░░░░");
-        assert_eq!(ctx_bar(100, 6), "▓▓▓▓▓▓");
+        assert_eq!(ctx_bar(50, CTX_BAR_WIDTH), "▓▓▓░░░");
+        assert_eq!(ctx_bar(0, CTX_BAR_WIDTH), "░░░░░░");
+        assert_eq!(ctx_bar(100, CTX_BAR_WIDTH), "▓▓▓▓▓▓");
     }
 }

--- a/mur-core/src/cmd/agent/cli/footer.rs
+++ b/mur-core/src/cmd/agent/cli/footer.rs
@@ -1,0 +1,133 @@
+//! Pure footer math: tokens, cost, and context-window fill from `Task.usage`
+//! plus the agent's `models.yaml` pricing. No ratatui, no I/O — unit-tested.
+
+use serde_json::Value;
+
+/// Context bar thresholds (percent) and width.
+pub const CTX_YELLOW_PCT: u8 = 70;
+pub const CTX_RED_PCT: u8 = 90;
+pub const CTX_BAR_WIDTH: usize = 6;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UsageCounts {
+    pub input: u64,
+    pub output: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Pricing {
+    pub in_per_1k: Option<f64>,
+    pub out_per_1k: Option<f64>,
+    pub window: Option<u64>,
+}
+
+pub enum CtxColor {
+    Green,
+    Yellow,
+    Red,
+}
+
+pub fn parse_usage(usage: &Value) -> UsageCounts {
+    UsageCounts {
+        input: usage
+            .get("input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        output: usage
+            .get("output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+    }
+}
+
+/// Clean per-context fill emitted by the runtime (Task 1). `None` on older
+/// runtimes — the caller falls back to hiding the bar.
+pub fn context_tokens(usage: &Value) -> Option<u64> {
+    usage.get("context_tokens").and_then(Value::as_u64)
+}
+
+pub fn turn_cost(p: &Pricing, u: &UsageCounts) -> Option<f64> {
+    match (p.in_per_1k, p.out_per_1k) {
+        (Some(i), Some(o)) => Some(u.input as f64 / 1000.0 * i + u.output as f64 / 1000.0 * o),
+        _ => None,
+    }
+}
+
+pub fn context_pct(used: u64, window: u64) -> u8 {
+    if window == 0 {
+        return 0;
+    }
+    ((used as f64 / window as f64) * 100.0)
+        .round()
+        .clamp(0.0, 100.0) as u8
+}
+
+pub fn ctx_color(pct: u8) -> CtxColor {
+    if pct < CTX_YELLOW_PCT {
+        CtxColor::Green
+    } else if pct < CTX_RED_PCT {
+        CtxColor::Yellow
+    } else {
+        CtxColor::Red
+    }
+}
+
+pub fn ctx_bar(pct: u8, width: usize) -> String {
+    let filled = (pct as usize * width) / 100;
+    format!("{}{}", "▓".repeat(filled), "░".repeat(width - filled))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_usage_fields() {
+        let u = parse_usage(&serde_json::json!({ "input_tokens": 1000, "output_tokens": 240 }));
+        assert_eq!(u.input, 1000);
+        assert_eq!(u.output, 240);
+    }
+
+    #[test]
+    fn context_pct_is_input_over_window() {
+        assert_eq!(context_pct(32_000, 100_000), 32);
+        assert_eq!(context_pct(0, 100_000), 0);
+        assert_eq!(context_pct(100, 0), 0); // no window → 0, never divide by zero
+    }
+
+    #[test]
+    fn ctx_color_thresholds() {
+        assert!(matches!(ctx_color(69), CtxColor::Green));
+        assert!(matches!(ctx_color(70), CtxColor::Yellow));
+        assert!(matches!(ctx_color(89), CtxColor::Yellow));
+        assert!(matches!(ctx_color(90), CtxColor::Red));
+    }
+
+    #[test]
+    fn cost_none_when_unpriced() {
+        let u = UsageCounts {
+            input: 1000,
+            output: 1000,
+        };
+        let unpriced = Pricing {
+            in_per_1k: None,
+            out_per_1k: None,
+            window: None,
+        };
+        assert!(turn_cost(&unpriced, &u).is_none());
+        let priced = Pricing {
+            in_per_1k: Some(0.003),
+            out_per_1k: Some(0.015),
+            window: Some(200_000),
+        };
+        let c = turn_cost(&priced, &u).unwrap();
+        assert!((c - 0.018).abs() < 1e-9);
+    }
+
+    #[test]
+    fn bar_fills_proportionally() {
+        assert_eq!(ctx_bar(50, 6), "▓▓▓░░░");
+        assert_eq!(ctx_bar(0, 6), "░░░░░░");
+        assert_eq!(ctx_bar(100, 6), "▓▓▓▓▓▓");
+    }
+}

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -789,6 +789,7 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
     match msg {
         StreamMsg::Delta { text, thinking, .. } => app.append_delta(&text, thinking),
         StreamMsg::Hitl { req, .. } => {
+            app.saw_hitl_this_turn = true;
             // Session auto-approval: `/auto`/`--auto` covers every tool; the
             // modal's [a] key covers a single tool name.
             let auto = app.auto_approve || app.session_tool_allow.contains(&req.tool_name);
@@ -801,6 +802,7 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
             if let Some(u) = task.get("usage") {
                 app.apply_usage(u);
             }
+            app.maybe_step_hint();
             match stream::task_outcome(&task) {
                 Ok((reply, task_id)) => app.finish_agent_turn(reply, task_id),
                 Err(cause) => app.fail_turn(&cause),

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -47,6 +47,33 @@ use self::persist::Session;
 use self::stream::{StreamMsg, build_params, cancel_task, respond_hitl, spawn_stream};
 use crate::a2a_dial::{DialMode, canonicalize_agent_name, dial_method};
 
+/// Load the agent's model pricing from `~/.mur/models.yaml`. Falls back to
+/// `Pricing::default()` (all `None` fields) on any error or when the agent
+/// uses an inline model rather than a `model_ref:` registry alias. The footer
+/// renderer treats `None` costs/window as "unknown" and shows `—`.
+fn load_pricing(home: &std::path::Path, agent: &str) -> footer::Pricing {
+    let pricing = footer::Pricing::default();
+    let Ok((_, profile)) = crate::cmd::agent::load_profile_for_edit(agent) else {
+        return pricing;
+    };
+    let Some(model_ref) = profile.model_ref else {
+        return pricing;
+    };
+    let reg_path = home.join("models.yaml");
+    let Ok(reg) = mur_common::model::ModelRegistry::load_from(&reg_path) else {
+        return pricing;
+    };
+    let Some(entry) = reg.models.get(&model_ref) else {
+        return pricing;
+    };
+    let (input, output) = entry.effective_costs();
+    footer::Pricing {
+        in_per_1k: input,
+        out_per_1k: output,
+        window: entry.context_window,
+    }
+}
+
 /// How many recent conversations `/sessions` lists.
 const RECENT_LIMIT: usize = 10;
 /// Mouse wheel scrolls one line per event (trackpads fire 10-20 events/sec, so
@@ -162,6 +189,7 @@ async fn run_tui(
         Terminal::new(CrosstermBackend::new(io::stdout())).context("init terminal")?;
 
     let mut app = build_app(&home, &agent, resume, active_theme)?;
+    app.pricing = load_pricing(&home, &agent);
     if unknown_skin {
         app.push_system(format!(
             "unknown skin '{skin_name}', using dark — valid: dark, light, mur"
@@ -769,10 +797,15 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
                 decide_hitl_with_note(app, tx, true, true);
             }
         }
-        StreamMsg::Done { task, .. } => match stream::task_outcome(&task) {
-            Ok((reply, task_id)) => app.finish_agent_turn(reply, task_id),
-            Err(cause) => app.fail_turn(&cause),
-        },
+        StreamMsg::Done { task, .. } => {
+            if let Some(u) = task.get("usage") {
+                app.apply_usage(u);
+            }
+            match stream::task_outcome(&task) {
+                Ok((reply, task_id)) => app.finish_agent_turn(reply, task_id),
+                Err(cause) => app.fail_turn(&cause),
+            }
+        }
         StreamMsg::Err { error, .. } => app.fail_turn(&error),
         StreamMsg::Note(text) => app.push_system(text),
         StreamMsg::ShellDone { cmd, output } => app.push_shell(&cmd, &output),
@@ -782,7 +815,7 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
             args,
             ..
         } => {
-            // NOTE: saw_step_this_turn is added in Task 8.
+            app.saw_step_this_turn = true;
             app.push_step_started(step_id, name, args);
         }
         StreamMsg::StepCompleted {

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -8,6 +8,7 @@
 
 mod access;
 mod app;
+mod footer;
 mod manage;
 mod markdown;
 mod multiplex;

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -773,6 +773,8 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
         StreamMsg::Err { error, .. } => app.fail_turn(&error),
         StreamMsg::Note(text) => app.push_system(text),
         StreamMsg::ShellDone { cmd, output } => app.push_shell(&cmd, &output),
+        // Step events are parsed and forwarded; rendering is handled in Task 3.
+        StreamMsg::StepStarted { .. } | StreamMsg::StepCompleted { .. } => {}
     }
 }
 
@@ -832,6 +834,7 @@ fn run_plain(home: &Path, agent: &str, auto: bool) -> Result<()> {
                     DialMode::RequireRunning,
                 );
             },
+            |_step| {},
         );
         match result {
             Ok(task) => match stream::task_outcome(&task) {

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -774,8 +774,35 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
         StreamMsg::Err { error, .. } => app.fail_turn(&error),
         StreamMsg::Note(text) => app.push_system(text),
         StreamMsg::ShellDone { cmd, output } => app.push_shell(&cmd, &output),
-        // Step events are parsed and forwarded; rendering is handled in Task 3.
-        StreamMsg::StepStarted { .. } | StreamMsg::StepCompleted { .. } => {}
+        StreamMsg::StepStarted {
+            step_id,
+            name,
+            args,
+            ..
+        } => {
+            // NOTE: saw_step_this_turn is added in Task 8.
+            app.push_step_started(step_id, name, args);
+        }
+        StreamMsg::StepCompleted {
+            step_id,
+            ok,
+            output,
+            truncated,
+            full_len,
+            error,
+            duration_ms,
+            ..
+        } => {
+            app.update_step_completed(
+                &step_id,
+                ok,
+                output,
+                truncated,
+                full_len,
+                error,
+                duration_ms,
+            );
+        }
     }
 }
 

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -13,6 +13,7 @@ mod markdown;
 mod multiplex;
 mod paste;
 pub mod persist;
+mod step;
 mod stream;
 mod theme;
 mod ui;

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -13,6 +13,7 @@ mod markdown;
 mod multiplex;
 mod paste;
 pub mod persist;
+mod render_card;
 mod step;
 mod stream;
 mod theme;

--- a/mur-core/src/cmd/agent/cli/render_card.rs
+++ b/mur-core/src/cmd/agent/cli/render_card.rs
@@ -93,15 +93,20 @@ pub fn card_lines(card: &StepCard, theme: &'static Theme) -> Vec<Line<'static>> 
     out
 }
 
+/// Maximum byte length of the arg hint before truncation.
+const ARG_HINT_MAX: usize = 40;
+
 /// Compact first-scalar-arg hint for the header line (e.g. file path, query).
-/// Clips at 40 chars so long paths don't wrap the header.
+/// Clips at `ARG_HINT_MAX` chars so long paths don't wrap the header.
+/// Uses `floor_char_boundary` to avoid panicking on multi-byte chars (CJK, emoji).
 fn arg_hint(card: &StepCard) -> String {
     card.args
         .as_object()
         .and_then(|m| m.values().find_map(|v| v.as_str()))
         .map(|s| {
-            if s.len() > 40 {
-                format!("{}…", &s[..40])
+            if s.len() > ARG_HINT_MAX {
+                let end = s.floor_char_boundary(ARG_HINT_MAX);
+                format!("{}…", &s[..end])
             } else {
                 s.to_string()
             }
@@ -148,5 +153,30 @@ mod tests {
         );
         assert!(text.contains("8ms"), "expected '8ms' in: {text}");
         assert!(text.contains('✔'), "expected '✔' in: {text}");
+    }
+
+    #[test]
+    fn arg_hint_does_not_panic_on_long_multibyte_path() {
+        let long_cjk = "檔".repeat(50); // 3 bytes/char → ~150 bytes, well past 40
+        let c = StepCard::new(
+            "s1".into(),
+            "read".into(),
+            serde_json::json!({ "path": long_cjk }),
+        );
+        let _ = card_lines(&c, theme::resolve_skin("dark")); // must NOT panic
+    }
+
+    #[test]
+    fn error_card_shows_red_marker_and_message() {
+        let mut c = StepCard::new("s1".into(), "bash".into(), serde_json::json!({}));
+        c.complete(false, "boom".into(), false, 4, Some("exit 101".into()), 3);
+        let lines = card_lines(&c, theme::resolve_skin("dark"));
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("exit 101"), "expected 'exit 101' in: {text}");
+        assert!(text.contains('✗'), "expected '✗' in: {text}");
     }
 }

--- a/mur-core/src/cmd/agent/cli/render_card.rs
+++ b/mur-core/src/cmd/agent/cli/render_card.rs
@@ -1,0 +1,152 @@
+//! Ratatui lines for one in-transcript tool-call step card.
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+
+use super::step::{ARGS_MAX_LINES, StepCard, StepState};
+use super::theme::Theme;
+
+/// Maximum output lines shown inside a card before a "…+N more" truncation hint.
+pub const OUTPUT_MAX_LINES: usize = 20;
+
+/// Turn a `StepCard` into renderable `Line`s for the transcript.
+///
+/// Each card is expanded by default (full args + result) but bounded by
+/// `ARGS_MAX_LINES` and `OUTPUT_MAX_LINES` so a huge tool response can't
+/// flood the transcript.
+pub fn card_lines(card: &StepCard, theme: &'static Theme) -> Vec<Line<'static>> {
+    let mut out: Vec<Line<'static>> = Vec::new();
+
+    let accent = match card.state {
+        StepState::Error => ratatui::style::Color::Red,
+        _ => theme.agent,
+    };
+
+    // ── Header: glyph · name · arg-hint · duration ───────────────────────────
+    let dur = card
+        .duration_ms
+        .map(|ms| format!(" · {ms}ms"))
+        .unwrap_or_default();
+    let header = format!("{} {} {}", card.glyph(), card.name, arg_hint(card));
+    out.push(Line::from(vec![
+        Span::styled(
+            header,
+            Style::default().fg(accent).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(dur, Style::default().fg(theme.system)),
+    ]));
+
+    // ── Args (bounded) ────────────────────────────────────────────────────────
+    if !card.args.is_null() {
+        let pretty = serde_json::to_string_pretty(&card.args).unwrap_or_default();
+        let total_lines = pretty.lines().count();
+        for l in pretty.lines().take(ARGS_MAX_LINES) {
+            out.push(Line::styled(
+                format!(" {l}"),
+                Style::default().fg(theme.system),
+            ));
+        }
+        if total_lines > ARGS_MAX_LINES {
+            out.push(Line::styled(
+                format!(" … +{} more", total_lines - ARGS_MAX_LINES),
+                Style::default()
+                    .fg(theme.system)
+                    .add_modifier(Modifier::DIM),
+            ));
+        }
+    }
+
+    // ── Result / error (bounded) ──────────────────────────────────────────────
+    if let Some(err) = &card.error {
+        out.push(Line::styled(
+            format!(" ✗ {err}"),
+            Style::default().fg(ratatui::style::Color::Red),
+        ));
+    }
+
+    if !card.output.is_empty() {
+        let output_line_count = card.output.lines().count();
+        for l in card.output.lines().take(OUTPUT_MAX_LINES) {
+            out.push(Line::styled(
+                format!(" {l}"),
+                Style::default().fg(theme.agent_text),
+            ));
+        }
+        let shown = output_line_count.min(OUTPUT_MAX_LINES);
+        // Show "+N more" either when we clipped locally OR the runtime
+        // already truncated the output (full_len > what we received).
+        let total = if card.truncated {
+            card.full_len
+        } else {
+            output_line_count
+        };
+        if card.truncated || output_line_count > OUTPUT_MAX_LINES {
+            out.push(Line::styled(
+                format!(" … +{} more", total.saturating_sub(shown)),
+                Style::default()
+                    .fg(theme.system)
+                    .add_modifier(Modifier::DIM),
+            ));
+        }
+    }
+
+    out
+}
+
+/// Compact first-scalar-arg hint for the header line (e.g. file path, query).
+/// Clips at 40 chars so long paths don't wrap the header.
+fn arg_hint(card: &StepCard) -> String {
+    card.args
+        .as_object()
+        .and_then(|m| m.values().find_map(|v| v.as_str()))
+        .map(|s| {
+            if s.len() > 40 {
+                format!("{}…", &s[..40])
+            } else {
+                s.to_string()
+            }
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::card_lines;
+    use crate::cmd::agent::cli::step::StepCard;
+    use crate::cmd::agent::cli::theme;
+
+    #[test]
+    fn running_card_shows_glyph_name_and_no_result() {
+        let c = StepCard::new(
+            "s1".into(),
+            "read".into(),
+            serde_json::json!({ "path": "a.rs" }),
+        );
+        let lines = card_lines(&c, theme::resolve_skin("dark"));
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("|");
+        assert!(text.contains("read"), "expected 'read' in: {text}");
+        assert!(text.contains('◐'), "expected '◐' in: {text}");
+    }
+
+    #[test]
+    fn done_card_shows_output_and_duration() {
+        let mut c = StepCard::new("s1".into(), "read".into(), serde_json::json!({}));
+        c.complete(true, "412 lines".into(), false, 9, None, 8);
+        let lines = card_lines(&c, theme::resolve_skin("dark"));
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("|");
+        assert!(
+            text.contains("412 lines"),
+            "expected '412 lines' in: {text}"
+        );
+        assert!(text.contains("8ms"), "expected '8ms' in: {text}");
+        assert!(text.contains('✔'), "expected '✔' in: {text}");
+    }
+}

--- a/mur-core/src/cmd/agent/cli/step.rs
+++ b/mur-core/src/cmd/agent/cli/step.rs
@@ -1,0 +1,127 @@
+//! A single tool-call step rendered inline in the cli transcript.
+
+use std::time::Instant;
+
+/// Lifecycle of a tool-call step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepState {
+    Running,
+    Done,
+    Error,
+}
+
+/// Max args lines shown inside an expanded card (mirrors the old HITL modal cap).
+pub const ARGS_MAX_LINES: usize = 12;
+
+/// One tool call, shown inline in the transcript.
+#[derive(Debug, Clone)]
+pub struct StepCard {
+    pub id: String,
+    pub name: String,
+    pub args: serde_json::Value,
+    pub state: StepState,
+    pub output: String,
+    pub truncated: bool,
+    pub full_len: usize,
+    pub error: Option<String>,
+    pub started: Instant,
+    pub duration_ms: Option<u64>,
+}
+
+impl StepCard {
+    pub fn new(id: String, name: String, args: serde_json::Value) -> Self {
+        Self {
+            id,
+            name,
+            args,
+            state: StepState::Running,
+            output: String::new(),
+            truncated: false,
+            full_len: 0,
+            error: None,
+            started: Instant::now(),
+            duration_ms: None,
+        }
+    }
+
+    pub fn complete(
+        &mut self,
+        ok: bool,
+        output: String,
+        truncated: bool,
+        full_len: usize,
+        error: Option<String>,
+        duration_ms: u64,
+    ) {
+        self.state = if ok { StepState::Done } else { StepState::Error };
+        self.output = output;
+        self.truncated = truncated;
+        self.full_len = full_len;
+        self.error = error;
+        self.duration_ms = Some(duration_ms);
+    }
+
+    pub fn glyph(&self) -> &'static str {
+        match self.state {
+            StepState::Running => "◐",
+            StepState::Done => "✔",
+            StepState::Error => "✗",
+        }
+    }
+
+    /// One-line header summary: a compact hint of the first scalar arg, if any.
+    pub fn summary(&self) -> String {
+        let hint = self
+            .args
+            .as_object()
+            .and_then(|m| m.values().find_map(|v| v.as_str()))
+            .unwrap_or("");
+        if hint.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}  {}", self.name, hint)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StepCard, StepState};
+
+    fn card() -> StepCard {
+        StepCard::new("s1".into(), "read".into(), serde_json::json!({ "path": "auth.rs" }))
+    }
+
+    #[test]
+    fn new_card_is_running() {
+        let c = card();
+        assert_eq!(c.state, StepState::Running);
+        assert_eq!(c.glyph(), "◐");
+    }
+
+    #[test]
+    fn complete_ok_sets_done_and_glyph() {
+        let mut c = card();
+        c.complete(true, "412 lines".into(), false, 9, None, 8);
+        assert_eq!(c.state, StepState::Done);
+        assert_eq!(c.glyph(), "✔");
+        assert_eq!(c.duration_ms, Some(8));
+    }
+
+    #[test]
+    fn complete_err_sets_error_and_keeps_message() {
+        let mut c = card();
+        c.complete(false, "boom".into(), false, 4, Some("exit 1".into()), 3);
+        assert_eq!(c.state, StepState::Error);
+        assert_eq!(c.glyph(), "✗");
+        assert_eq!(c.error.as_deref(), Some("exit 1"));
+    }
+
+    #[test]
+    fn summary_is_one_line_name_plus_arg_hint() {
+        let c = card();
+        let s = c.summary();
+        assert!(s.contains("read"));
+        assert!(!s.contains('\n'));
+    }
+}

--- a/mur-core/src/cmd/agent/cli/step.rs
+++ b/mur-core/src/cmd/agent/cli/step.rs
@@ -11,8 +11,7 @@ pub enum StepState {
 }
 
 /// Max args lines shown inside an expanded card (mirrors the old HITL modal cap).
-// Used by the step card UI renderer (Task 5).
-#[allow(dead_code)]
+// Used by the step card UI renderer (render_card.rs).
 pub const ARGS_MAX_LINES: usize = 12;
 
 /// One tool call, shown inline in the transcript.
@@ -69,8 +68,7 @@ impl StepCard {
         self.duration_ms = Some(duration_ms);
     }
 
-    // glyph and summary are consumed by the step card UI renderer (Task 5).
-    #[allow(dead_code)]
+    // glyph is called by render_card::card_lines.
     pub fn glyph(&self) -> &'static str {
         match self.state {
             StepState::Running => "◐",

--- a/mur-core/src/cmd/agent/cli/step.rs
+++ b/mur-core/src/cmd/agent/cli/step.rs
@@ -18,7 +18,7 @@ pub const ARGS_MAX_LINES: usize = 12;
 #[derive(Debug, Clone)]
 pub struct StepCard {
     pub id: String,
-    // name, args, started consumed by the step card UI renderer (Task 5).
+    // name, args, started consumed by the step card UI renderer (render_card::card_lines).
     pub name: String,
     pub args: serde_json::Value,
     pub state: StepState,

--- a/mur-core/src/cmd/agent/cli/step.rs
+++ b/mur-core/src/cmd/agent/cli/step.rs
@@ -11,12 +11,15 @@ pub enum StepState {
 }
 
 /// Max args lines shown inside an expanded card (mirrors the old HITL modal cap).
+// Used by the step card UI renderer (Task 5).
+#[allow(dead_code)]
 pub const ARGS_MAX_LINES: usize = 12;
 
 /// One tool call, shown inline in the transcript.
 #[derive(Debug, Clone)]
 pub struct StepCard {
     pub id: String,
+    // name, args, started consumed by the step card UI renderer (Task 5).
     pub name: String,
     pub args: serde_json::Value,
     pub state: StepState,
@@ -24,6 +27,7 @@ pub struct StepCard {
     pub truncated: bool,
     pub full_len: usize,
     pub error: Option<String>,
+    #[allow(dead_code)]
     pub started: Instant,
     pub duration_ms: Option<u64>,
 }
@@ -53,7 +57,11 @@ impl StepCard {
         error: Option<String>,
         duration_ms: u64,
     ) {
-        self.state = if ok { StepState::Done } else { StepState::Error };
+        self.state = if ok {
+            StepState::Done
+        } else {
+            StepState::Error
+        };
         self.output = output;
         self.truncated = truncated;
         self.full_len = full_len;
@@ -61,6 +69,8 @@ impl StepCard {
         self.duration_ms = Some(duration_ms);
     }
 
+    // glyph and summary are consumed by the step card UI renderer (Task 5).
+    #[allow(dead_code)]
     pub fn glyph(&self) -> &'static str {
         match self.state {
             StepState::Running => "◐",
@@ -70,6 +80,7 @@ impl StepCard {
     }
 
     /// One-line header summary: a compact hint of the first scalar arg, if any.
+    #[allow(dead_code)]
     pub fn summary(&self) -> String {
         let hint = self
             .args
@@ -89,7 +100,11 @@ mod tests {
     use super::{StepCard, StepState};
 
     fn card() -> StepCard {
-        StepCard::new("s1".into(), "read".into(), serde_json::json!({ "path": "auth.rs" }))
+        StepCard::new(
+            "s1".into(),
+            "read".into(),
+            serde_json::json!({ "path": "auth.rs" }),
+        )
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/step.rs
+++ b/mur-core/src/cmd/agent/cli/step.rs
@@ -1,7 +1,5 @@
 //! A single tool-call step rendered inline in the cli transcript.
 
-use std::time::Instant;
-
 /// Lifecycle of a tool-call step.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StepState {
@@ -26,8 +24,6 @@ pub struct StepCard {
     pub truncated: bool,
     pub full_len: usize,
     pub error: Option<String>,
-    #[allow(dead_code)]
-    pub started: Instant,
     pub duration_ms: Option<u64>,
 }
 
@@ -42,7 +38,6 @@ impl StepCard {
             truncated: false,
             full_len: 0,
             error: None,
-            started: Instant::now(),
             duration_ms: None,
         }
     }
@@ -74,21 +69,6 @@ impl StepCard {
             StepState::Running => "◐",
             StepState::Done => "✔",
             StepState::Error => "✗",
-        }
-    }
-
-    /// One-line header summary: a compact hint of the first scalar arg, if any.
-    #[allow(dead_code)]
-    pub fn summary(&self) -> String {
-        let hint = self
-            .args
-            .as_object()
-            .and_then(|m| m.values().find_map(|v| v.as_str()))
-            .unwrap_or("");
-        if hint.is_empty() {
-            self.name.clone()
-        } else {
-            format!("{}  {}", self.name, hint)
         }
     }
 }
@@ -128,13 +108,5 @@ mod tests {
         assert_eq!(c.state, StepState::Error);
         assert_eq!(c.glyph(), "✗");
         assert_eq!(c.error.as_deref(), Some("exit 1"));
-    }
-
-    #[test]
-    fn summary_is_one_line_name_plus_arg_hint() {
-        let c = card();
-        let s = c.summary();
-        assert!(s.contains("read"));
-        assert!(!s.contains('\n'));
     }
 }

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -44,8 +44,6 @@ pub enum StreamMsg {
     /// A local `!command` finished. Turn-independent like `Note`.
     ShellDone { cmd: String, output: String },
     /// A tool call started running (name + args).
-    // Fields consumed by the Task 3 renderer; allow dead_code until then.
-    #[allow(dead_code)]
     StepStarted {
         task_id: String,
         step_id: String,
@@ -53,8 +51,6 @@ pub enum StreamMsg {
         args: Value,
     },
     /// A tool call finished (result/error + duration).
-    // Fields consumed by the Task 3 renderer; allow dead_code until then.
-    #[allow(dead_code)]
     StepCompleted {
         task_id: String,
         step_id: String,

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -43,6 +43,28 @@ pub enum StreamMsg {
     Note(String),
     /// A local `!command` finished. Turn-independent like `Note`.
     ShellDone { cmd: String, output: String },
+    /// A tool call started running (name + args).
+    // Fields consumed by the Task 3 renderer; allow dead_code until then.
+    #[allow(dead_code)]
+    StepStarted {
+        task_id: String,
+        step_id: String,
+        name: String,
+        args: Value,
+    },
+    /// A tool call finished (result/error + duration).
+    // Fields consumed by the Task 3 renderer; allow dead_code until then.
+    #[allow(dead_code)]
+    StepCompleted {
+        task_id: String,
+        step_id: String,
+        ok: bool,
+        output: String,
+        truncated: bool,
+        full_len: usize,
+        error: Option<String>,
+        duration_ms: u64,
+    },
 }
 
 impl StreamMsg {
@@ -52,7 +74,9 @@ impl StreamMsg {
             StreamMsg::Delta { task_id, .. }
             | StreamMsg::Hitl { task_id, .. }
             | StreamMsg::Done { task_id, .. }
-            | StreamMsg::Err { task_id, .. } => Some(task_id),
+            | StreamMsg::Err { task_id, .. }
+            | StreamMsg::StepStarted { task_id, .. }
+            | StreamMsg::StepCompleted { task_id, .. } => Some(task_id),
             StreamMsg::Note(_) | StreamMsg::ShellDone { .. } => None,
         }
     }
@@ -216,6 +240,41 @@ pub fn spawn_stream(
                     task_id: tid.clone(),
                     req: HitlRequest::from_value(hitl),
                 });
+            },
+            |step| {
+                let msg = match step {
+                    crate::a2a_dial::StepEvent::Started {
+                        step_id,
+                        task_id,
+                        name,
+                        args,
+                    } => StreamMsg::StepStarted {
+                        task_id,
+                        step_id,
+                        name,
+                        args,
+                    },
+                    crate::a2a_dial::StepEvent::Completed {
+                        step_id,
+                        task_id,
+                        ok,
+                        output,
+                        truncated,
+                        full_len,
+                        error,
+                        duration_ms,
+                    } => StreamMsg::StepCompleted {
+                        task_id,
+                        step_id,
+                        ok,
+                        output,
+                        truncated,
+                        full_len,
+                        error,
+                        duration_ms,
+                    },
+                };
+                let _ = tx.blocking_send(msg);
             },
         );
         let _ = match result {

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -240,6 +240,25 @@ fn render_status(f: &mut Frame, app: &App, area: Rect) {
     }
     spans.push(Span::styled(msg, Style::default().fg(color)));
 
+    // Glass Box observability: tokens · cost · ctx · timer.
+    let obs = footer_segments(
+        app.turn_in,
+        app.turn_out,
+        app.session_in,
+        app.session_out,
+        app.ctx_tokens,
+        &app.pricing,
+    );
+    spans.push(Span::raw(" · "));
+    spans.push(Span::styled(obs, Style::default().fg(theme.system)));
+    if let Some(t0) = app.turn_started {
+        let secs = t0.elapsed().as_secs();
+        spans.push(Span::styled(
+            format!(" · {}m{:02}s · esc=stop", secs / 60, secs % 60),
+            Style::default().fg(theme.system),
+        ));
+    }
+
     let right_hint: Option<(String, Color)> = if app.scroll_back > 0 {
         Some((
             format!("↑ {} lines · ⬇ to bottom", app.scroll_back),
@@ -331,6 +350,63 @@ fn render_hitl(f: &mut Frame, hitl: &super::stream::HitlRequest) {
     );
 }
 
+/// Format a token count with thousands separator (e.g. 1240 → "1,240").
+fn fmt_tok(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!(
+            "{},{:03},{:03}",
+            n / 1_000_000,
+            (n / 1_000) % 1_000,
+            n % 1_000
+        )
+    } else if n >= 1_000 {
+        format!("{},{:03}", n / 1_000, n % 1_000)
+    } else {
+        n.to_string()
+    }
+}
+
+/// Pure footer formatter: `"{turn}/{sess} tok · {cost} · ctx <bar> N%"`.
+/// Cost shows `—` when unpriced; ctx part is omitted when no window is known.
+fn footer_segments(
+    turn_in: u64,
+    turn_out: u64,
+    sess_in: u64,
+    sess_out: u64,
+    ctx_tokens: u64,
+    pricing: &super::footer::Pricing,
+) -> String {
+    use super::footer::{CTX_BAR_WIDTH, UsageCounts, context_pct, ctx_bar, turn_cost};
+
+    let turn_tok = turn_in + turn_out;
+    let sess_tok = sess_in + sess_out;
+
+    let u = UsageCounts {
+        input: turn_in,
+        output: turn_out,
+    };
+    let cost = match turn_cost(pricing, &u) {
+        Some(c) => format!("${:.3} est", c),
+        None => "\u{2014}".to_string(), // em dash
+    };
+
+    let ctx_part = match pricing.window {
+        Some(w) if w > 0 => {
+            let pct = context_pct(ctx_tokens, w);
+            format!(" · ctx {} {}%", ctx_bar(pct, CTX_BAR_WIDTH), pct)
+        }
+        _ => String::new(),
+    };
+
+    format!(
+        "{}/{} tok · {}{}",
+        fmt_tok(turn_tok),
+        fmt_tok(sess_tok),
+        cost,
+        ctx_part
+    )
+}
+
 fn centered_rect(pct_x: u16, pct_y: u16, area: Rect) -> Rect {
     let v = Layout::default()
         .direction(Direction::Vertical)
@@ -348,4 +424,29 @@ fn centered_rect(pct_x: u16, pct_y: u16, area: Rect) -> Rect {
             Constraint::Percentage((100 - pct_x) / 2),
         ])
         .split(v[1])[1]
+}
+
+#[cfg(test)]
+mod footer_fmt_tests {
+    use super::footer_segments;
+    use crate::cmd::agent::cli::footer::Pricing;
+
+    #[test]
+    fn shows_tokens_and_dash_cost_when_unpriced() {
+        let s = footer_segments(1240, 0, 1240, 0, 0, &Pricing::default());
+        assert!(s.contains("1,240 tok") || s.contains("1240 tok"));
+        assert!(s.contains('\u{2014}')); // em dash — no price
+    }
+
+    #[test]
+    fn shows_cost_and_ctx_when_priced() {
+        let p = Pricing {
+            in_per_1k: Some(0.003),
+            out_per_1k: Some(0.015),
+            window: Some(100_000),
+        };
+        let s = footer_segments(1000, 1000, 1000, 1000, 32_000, &p);
+        assert!(s.contains("$0.018"));
+        assert!(s.contains("32%"));
+    }
 }

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -152,17 +152,18 @@ fn push_message(
                     .fg(theme.agent)
                     .add_modifier(Modifier::BOLD),
             )));
-            if m.streaming {
-                if !m.thinking.is_empty() {
-                    for l in m.thinking.lines() {
-                        lines.push(Line::styled(
-                            l.to_string(),
-                            Style::default()
-                                .fg(theme.thinking)
-                                .add_modifier(Modifier::ITALIC | Modifier::DIM),
-                        ));
-                    }
+            // Reasoning stays visible after the turn finishes (D5).
+            if !m.thinking.is_empty() {
+                for l in m.thinking.lines() {
+                    lines.push(Line::styled(
+                        l.to_string(),
+                        Style::default()
+                            .fg(theme.thinking)
+                            .add_modifier(Modifier::ITALIC | Modifier::DIM),
+                    ));
                 }
+            }
+            if m.streaming {
                 let mut body: Vec<Line> =
                     m.text.lines().map(|l| Line::raw(l.to_string())).collect();
                 // Trailing spinner so the user sees liveness.

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -103,6 +103,11 @@ fn push_message(
     spinner: usize,
     theme: &'static super::theme::Theme,
 ) {
+    // Step cards replace role-based rendering entirely for that message.
+    if let Some(card) = &m.step {
+        lines.extend(super::render_card::card_lines(card, theme));
+        return;
+    }
     match m.role {
         Role::User => {
             lines.push(Line::from(Span::styled(

--- a/mur-core/src/cmd/fleet/loop_run.rs
+++ b/mur-core/src/cmd/fleet/loop_run.rs
@@ -515,6 +515,7 @@ fn ask_router_done(mur_home: &Path, fleet: &Fleet, events: &[ChannelEvent]) -> R
         params,
         |delta, _thinking, _id| out.push_str(delta),
         |_hitl| {},
+        |_step| {},
     )?;
     Ok(is_converged(&out))
 }

--- a/mur-core/src/cmd/fleet/plan.rs
+++ b/mur-core/src/cmd/fleet/plan.rs
@@ -144,6 +144,7 @@ pub fn plan_via_router(
         params,
         |delta, _thinking, _id| out.push_str(delta),
         |_hitl| {},
+        |_step| {},
     )
     .ok()?;
     parse_router_plan(&out, &fleet.members)

--- a/mur-hub-gui/src-tauri/src/chat.rs
+++ b/mur-hub-gui/src-tauri/src/chat.rs
@@ -137,6 +137,7 @@ pub async fn agent_chat_send(
                     }),
                 );
             },
+            |_step| {},
         ) {
             Ok(v) => Ok((v, true)),
             Err(e) if e.to_string().contains("is not running") => {


### PR DESCRIPTION
## Summary

Makes `mur agent cli` show **every step the LLM does**. Today the cli is blind to auto-approved tool calls (the runtime streams only text + HITL + a final task JSON it mostly discards). P1 adds a runtime **step-event spine** and renders each tool call as an inline card, keeps reasoning on screen, and adds a token/cost/context/timer footer.

North star: at every moment the user knows what the model is doing — streaming, reasoning, which tool with which args, what it returned, what it cost, how long it took, where it's blocked.

## What's in P1

- **Runtime spine** — `mur-agent-runtime` emits `step/started` / `step/completed` around each `tool.execute` (both the Allow and Ask policy arms) + a `context_tokens` field on the usage JSON.
- **Inline tool cards** — `name · args · result · error · duration`, expanded-by-default but **bounded** (args/output capped), interleaved correctly with streaming text segments; UTF-8-safe (no byte-slice panics on CJK paths).
- **Reasoning kept** — no longer erased on turn finish; rendered on finished messages too.
- **Full-parity footer** — `T/S tok · $cost est · ctx ▓▓░░ N% · {m}m{ss}s · esc=stop`. Cost from `models.yaml` (labeled `est`, `—` when unpriced); context bar input-only; turn timer.
- **Graceful degrade** — an old runtime (pre-step-events) gets a one-time "restart this agent for the step view" hint; no cards, no crash. Detected via `saw_hitl && !saw_step` (a new runtime emits both; an old one emits only the HITL).

## Architecture

`task_runner.rs` (emit) → `a2a_dial.rs::parse_step` → `StreamMsg::Step*` (`stream.rs`) → `handle_stream` (`mod.rs`) → `App::push_step_started`/`update_step_completed` → `ChatMsg.step: Option<StepCard>` → `render_card.rs`. Footer math in `footer.rs` + `App` fields → `ui.rs::render_status`. Pricing resolved **in mur-core** (the `mur-core → mur-agent-runtime` dep edge is forbidden).

## Bugs caught by review (all fixed)

- **Tool-turn final reply dropped** — the agentic loop doesn't stream text, so the empty placeholder was dropped on the first card and the answer was discarded at finish. Fixed with a cancel-safe `else`-branch.
- **Cancel-path footer-timer leak** — `finish_partial` didn't clear `turn_started`, so the timer ticked after ESC/`/channels`. Fixed + regression test.
- **2 UTF-8 byte-slice panics** (`cap_step_output`, `arg_hint`) — char-boundary-safe now.
- Dead-code cleanup (`StepCard::summary`/`started`).

## Scope notes (deliberate)

- Reasoning is visible only on **no-tool turns** — the runtime's agentic loop uses non-streaming `generate`, so it streams no text/reasoning during tool use (only step events). Full reasoning-during-tools is a P2/P3 runtime-streaming change.
- Context bar is **monochrome** in P1; green/yellow/red threshold color is P2.
- **Not yet live-verified** in a real terminal (all unit-tested + reviewed). Building and driving it once is the natural next step.
- P2 (inline risk-tiered HITL on cards, per-turn diff viewer, scrollback dump, notify-on-blur) and P3 (mid-turn steering, active budget, plain/screen-reader mode, retry banners) have their own spec sections.

## Testing

- `cargo clippy -p mur-core -p mur-agent-runtime -- -D warnings` — clean.
- 101/101 `mur-core` cli tests pass; `mur-agent-runtime` suite green.
- Every task TDD'd, individually reviewed (spec + quality), and the whole branch passed a final adversarial whole-branch review.

## Docs

- Spec: `docs/superpowers/specs/2026-06-27-mur-agent-cli-glass-box-design.md`
- Plan: `docs/superpowers/plans/2026-06-27-mur-agent-cli-glass-box-p1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)