### PR TITLE
feat(cli): Glass Box P2a — inline HITL on cards + edit diffs

### DIFF
--- a/docs/superpowers/plans/2026-06-27-mur-agent-cli-glass-box-p2a.md
+++ b/docs/superpowers/plans/2026-06-27-mur-agent-cli-glass-box-p2a.md
@@ -1,0 +1,649 @@
+# mur agent cli — Glass Box P2a (Inline HITL + Edit Diffs) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move tool approval from a centered modal onto the tool-call card in context, and render a real `-`/`+` diff in the body of edit-tool cards.
+
+**Architecture:** The runtime adds the existing `step_id` to its `tool/approval_needed` notification so the cli can correlate an approval with the exact card that ran the tool; the cli marks that `StepCard` "awaiting approval" and renders `[y]/[a]/[n]` inline (the centered modal stays only as the old-runtime fallback). A new `cli/diff.rs` turns an edit tool's `{file_path, old_string, new_string}` args into red/removed, green/added, dim/context lines via the already-present `diff` crate; `render_card` draws that instead of raw JSON for edit-like tools.
+
+**Tech Stack:** Rust (edition 2024), ratatui + crossterm, serde_json, `diff = "0.1"` (already a mur-core dependency, currently unused).
+
+## Global Constraints
+
+- **Builds on P1** — branch from `feat/agent-cli-glass-box` (PR #517, not yet merged). All P1 types exist: `StepCard`, `card_lines`, `StreamMsg::Step*`, the footer, `HitlRequest`.
+- **Rust edition 2024**; no hardcoded values (named `const`); brand "MUR" uppercase in user-facing strings.
+- **Single source file ≤ 800 lines** — new code in new modules (`cli/diff.rs`), not by growing `mod.rs`/`ui.rs`.
+- **Tests:** rustup proxy is often broken in agent sessions — if `cargo` is not on PATH use `export PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$HOME/.cargo/bin:$PATH"` and plain `cargo test` (the `cargo-nextest` binary is absent). mur-core needs `ORT_STRATEGY=download`.
+- **Lint gate:** `cargo clippy -p mur-core -p mur-agent-runtime -- -D warnings` + `cargo fmt`.
+- **mur-core MUST NOT depend on mur-agent-runtime.**
+- **Backward-compat:** an old runtime that omits `step_id` in the approval must still get an approval prompt — the centered modal is the fallback when `step_id` is absent. The `y/a/n` keys act on `app.hitl` and are unchanged either way.
+- **Post-hoc HITL note (mur's existing model, not changed here):** the runtime *executes* a tool, emits `step/completed` (card shows `✔` + output), *then* requests approval. So the inline prompt appears on an already-completed card ("ran this — approve keeping it? [y/n]"). The diff is built from args regardless of timing.
+
+---
+
+### Task 1: Runtime adds `step_id` to the approval notification
+
+**Files:**
+- Modify: `mur-agent-runtime/src/task_runner.rs:1169-1181` (the `tool/approval_needed` json)
+
+**Interfaces:**
+- Produces (wire): `tool/approval_needed` params gain `"step_id"` (string) — the same `step_id` already emitted in `step/started`/`step/completed` for this call.
+- Consumes: `step_id` (already in scope, generated at `task_runner.rs:1048`).
+
+- [ ] **Step 1: Add the field**
+
+The notification currently is:
+```rust
+        let notification = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "tool/approval_needed",
+            "params": {
+                "hitl_id": hitl_id,
+                "task_id": task_id,
+                "tool_name": call.tool_name,
+                "tool_input": call.input,
+                "output": output,
+                "is_error": is_error,
+                "timeout_ms": (self.hitl_timeout_secs as u64) * 1000,
+            }
+        });
+```
+Add `"step_id": step_id,` as the first param (it's in scope from line 1048):
+```rust
+            "params": {
+                "step_id": step_id,
+                "hitl_id": hitl_id,
+                "task_id": task_id,
+                "tool_name": call.tool_name,
+                "tool_input": call.input,
+                "output": output,
+                "is_error": is_error,
+                "timeout_ms": (self.hitl_timeout_secs as u64) * 1000,
+            }
+```
+
+- [ ] **Step 2: Verify build + commit**
+
+Run: `cargo check -p mur-agent-runtime && cargo clippy -p mur-agent-runtime -- -D warnings && cargo fmt`
+Expected: clean. (This is a 1-field add to an existing notification; it's exercised end-to-end by the cli correlation tests in later tasks and manual run. No unit test for the inline json.)
+
+```bash
+git add mur-agent-runtime/src/task_runner.rs
+git commit -m "feat(runtime): include step_id in tool/approval_needed so the cli can attach approval to its card"
+```
+
+---
+
+### Task 2: `HitlRequest` carries `step_id`
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/stream.rs:140-168` (`HitlRequest` struct + `from_value`)
+- Test: `mur-core/src/cmd/agent/cli/stream.rs` (inline `#[cfg(test)] mod hitl_step_tests`)
+
+**Interfaces:**
+- Produces: `HitlRequest.step_id: Option<String>`.
+- Consumes: Task 1's wire field.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod hitl_step_tests {
+    use super::HitlRequest;
+
+    #[test]
+    fn parses_step_id_when_present() {
+        let v = serde_json::json!({
+            "step_id": "s-1", "hitl_id": "h-1", "tool_name": "edit",
+            "tool_input": { "file_path": "a.rs" }, "prompt": "Run `edit`?"
+        });
+        let req = HitlRequest::from_value(v);
+        assert_eq!(req.step_id.as_deref(), Some("s-1"));
+        assert_eq!(req.hitl_id, "h-1");
+    }
+
+    #[test]
+    fn step_id_none_on_old_runtime() {
+        let v = serde_json::json!({ "hitl_id": "h-1", "tool_name": "bash" });
+        let req = HitlRequest::from_value(v);
+        assert!(req.step_id.is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib cmd::agent::cli::stream::hitl_step_tests`
+Expected: FAIL — `no field step_id`.
+
+- [ ] **Step 3: Add the field + parse it**
+
+In the struct, add after `hitl_id`:
+```rust
+    /// The `step_id` of the card that ran this tool (P2: lets the cli show the
+    /// approval inline on that card). `None` on runtimes predating the field.
+    pub step_id: Option<String>,
+```
+In `from_value`, add to the `Self { … }`:
+```rust
+            step_id: v
+                .get("step_id")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib cmd::agent::cli::stream::hitl_step_tests`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/stream.rs
+git commit -m "feat(cli): HitlRequest carries step_id for inline approval correlation"
+```
+
+---
+
+### Task 3: `StepCard.awaiting_hitl` + App correlation
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/step.rs:16-71` (add `awaiting_hitl` field + init)
+- Modify: `mur-core/src/cmd/agent/cli/app.rs` (add `mark_card_awaiting` / `clear_card_awaiting`)
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs:791-800` (Hitl arm sets it) and `mod.rs:528-552` (`decide_hitl_with_note` clears it)
+- Test: `mur-core/src/cmd/agent/cli/app.rs` (inline `#[cfg(test)] mod awaiting_tests`)
+
+**Interfaces:**
+- Produces: `StepCard.awaiting_hitl: bool`; `App::mark_card_awaiting(&mut self, step_id: &str)`; `App::clear_card_awaiting(&mut self, step_id: &str)`.
+- Consumes: `HitlRequest.step_id` (Task 2), `StepCard.id` (existing).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod awaiting_tests {
+    use super::*;
+
+    #[test]
+    fn mark_and_clear_awaiting_by_step_id() {
+        let mut a = App::test_fixture();
+        a.begin_user_turn("edit it");
+        a.push_step_started("s1".into(), "edit".into(), serde_json::json!({"file_path":"a.rs"}));
+        a.update_step_completed("s1", true, "ok".into(), false, 2, None, 5);
+        a.mark_card_awaiting("s1");
+        let card = a.messages.iter().find_map(|m| m.step.as_ref()).unwrap();
+        assert!(card.awaiting_hitl);
+        a.clear_card_awaiting("s1");
+        let card = a.messages.iter().find_map(|m| m.step.as_ref()).unwrap();
+        assert!(!card.awaiting_hitl);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib cmd::agent::cli::app::awaiting_tests`
+Expected: FAIL — `no field awaiting_hitl` / `no method mark_card_awaiting`.
+
+- [ ] **Step 3: Add the field to `StepCard`**
+
+In the struct (after `duration_ms`):
+```rust
+    /// True while this card's tool call is waiting on a HITL decision (P2 inline
+    /// approval). Set when the matching `tool/approval_needed` arrives, cleared
+    /// on decision.
+    pub awaiting_hitl: bool,
+```
+In `StepCard::new`, add `awaiting_hitl: false,` to the struct literal.
+
+- [ ] **Step 4: Add the App methods** (in `impl App`, near `update_step_completed`)
+
+```rust
+    /// Flag the card with this `step_id` as awaiting a HITL decision.
+    pub fn mark_card_awaiting(&mut self, step_id: &str) {
+        if let Some(card) = self
+            .messages
+            .iter_mut()
+            .rev()
+            .find_map(|m| m.step.as_mut().filter(|c| c.id == step_id))
+        {
+            card.awaiting_hitl = true;
+        }
+    }
+
+    /// Clear the awaiting-HITL flag on the card with this `step_id`.
+    pub fn clear_card_awaiting(&mut self, step_id: &str) {
+        if let Some(card) = self
+            .messages
+            .iter_mut()
+            .rev()
+            .find_map(|m| m.step.as_mut().filter(|c| c.id == step_id))
+        {
+            card.awaiting_hitl = false;
+        }
+    }
+```
+
+- [ ] **Step 5: Wire the Hitl arm + decide path** (`mod.rs`)
+
+In `handle_stream`'s `StreamMsg::Hitl { req, .. }` arm, after `app.hitl = Some(req);` — but you need the `step_id` before moving `req`. Rewrite the arm so it marks the card first:
+```rust
+        StreamMsg::Hitl { req, .. } => {
+            app.saw_hitl_this_turn = true;
+            if let Some(sid) = req.step_id.clone() {
+                app.mark_card_awaiting(&sid);
+            }
+            let auto = app.auto_approve || app.session_tool_allow.contains(&req.tool_name);
+            app.hitl = Some(req);
+            if auto {
+                decide_hitl_with_note(app, tx, true, true);
+            }
+        }
+```
+In `decide_hitl_with_note`, after `if let Some(req) = app.hitl.take() {`, clear the card flag:
+```rust
+    if let Some(req) = app.hitl.take() {
+        if let Some(sid) = &req.step_id {
+            app.clear_card_awaiting(sid);
+        }
+        let (h, a) = (app.home.clone(), app.agent.clone());
+        // … rest unchanged …
+```
+
+- [ ] **Step 6: Run test + build**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib cmd::agent::cli::app::awaiting_tests && cargo check -p mur-core`
+Expected: PASS + clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/step.rs mur-core/src/cmd/agent/cli/app.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(cli): correlate HITL approval to its step card via step_id"
+```
+
+---
+
+### Task 4: Render the inline approval row on the card
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/render_card.rs:17-94` (`card_lines` — append approval row when `awaiting_hitl`)
+- Test: `mur-core/src/cmd/agent/cli/render_card.rs` (inline test)
+
+**Interfaces:**
+- Consumes: `StepCard.awaiting_hitl` (Task 3), `theme`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn awaiting_card_shows_inline_approval_row() {
+        let mut c = StepCard::new("s1".into(), "edit".into(), serde_json::json!({"file_path":"a.rs"}));
+        c.complete(true, "patched".into(), false, 1, None, 4);
+        c.awaiting_hitl = true;
+        let lines = card_lines(&c, theme::resolve_skin("dark"));
+        let text: String = lines.iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>().join("\n");
+        assert!(text.contains("[y]"));
+        assert!(text.contains("approve"));
+        assert!(text.contains("[n]"));
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib cmd::agent::cli::render_card::tests::awaiting_card_shows_inline_approval_row`
+Expected: FAIL — no `[y]` in output.
+
+- [ ] **Step 3: Append the approval row** in `card_lines`, just before the final `out`:
+
+```rust
+    // ── Inline HITL approval (P2) ────────────────────────────────────────────
+    if card.awaiting_hitl {
+        out.push(Line::from(vec![
+            Span::styled(
+                "  [y]",
+                Style::default().fg(ratatui::style::Color::Green).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" approve  ", Style::default().fg(theme.system)),
+            Span::styled(
+                "[a]",
+                Style::default().fg(ratatui::style::Color::Yellow).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" always  ", Style::default().fg(theme.system)),
+            Span::styled(
+                "[n]",
+                Style::default().fg(ratatui::style::Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" deny / Esc", Style::default().fg(theme.system)),
+        ]));
+    }
+
+    out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib cmd::agent::cli::render_card`
+Expected: PASS (all render_card tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/render_card.rs
+git commit -m "feat(cli): inline [y]/[a]/[n] approval row on the awaiting step card"
+```
+
+---
+
+### Task 5: Show the centered modal only as the old-runtime fallback
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/ui.rs:16-35` (`render` — gate `render_hitl` on absent `step_id`)
+- Test: manual (the modal-vs-inline decision is a one-line guard; the inline row is tested in Task 4).
+
+**Interfaces:**
+- Consumes: `App.hitl` → `HitlRequest.step_id`.
+
+- [ ] **Step 1: Gate the modal**
+
+The current tail of `render` is:
+```rust
+    if let Some(hitl) = &app.hitl {
+        render_hitl(f, hitl);
+    }
+```
+Change it so the modal only shows when the approval is NOT correlated to a card (old runtime, no `step_id`) — otherwise the card renders the prompt inline:
+```rust
+    // Inline approval lives on the card (Task 4) when the runtime sent a
+    // step_id. Fall back to the centered modal only for older runtimes.
+    if let Some(hitl) = &app.hitl
+        && hitl.step_id.is_none()
+    {
+        render_hitl(f, hitl);
+    }
+```
+
+- [ ] **Step 2: Verify build + lint**
+
+Run: `ORT_STRATEGY=download cargo check -p mur-core && cargo clippy -p mur-core -- -D warnings && cargo fmt`
+Expected: clean. (`render_hitl` is still used in the fallback path, so no dead-code warning.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/ui.rs
+git commit -m "feat(cli): centered HITL modal becomes the old-runtime fallback; inline by default"
+```
+
+---
+
+### Task 6: `cli/diff.rs` — edit args → diff lines
+
+**Files:**
+- Create: `mur-core/src/cmd/agent/cli/diff.rs`
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs` (`mod diff;`)
+- Modify: `mur-core/Cargo.toml` — confirm `diff = "0.1"` is present (it is, line 47, currently unused; this task makes it used)
+- Test: `mur-core/src/cmd/agent/cli/diff.rs` (inline test)
+
+**Interfaces:**
+- Produces: `edit_diff_lines(name: &str, args: &serde_json::Value, theme: &'static Theme) -> Option<Vec<Line<'static>>>` — `Some(diff lines)` for an edit-like tool whose args contain a recognizable change, else `None`.
+- Consumes: `diff` crate, `theme::Theme`.
+
+- [ ] **Step 1: Write the failing test** (create the file test-first)
+
+```rust
+//! Render an edit-tool's `{file_path, old_string, new_string}` args as a
+//! bounded -/+ diff, using the `diff` crate.
+
+#[cfg(test)]
+mod tests {
+    use super::edit_diff_lines;
+    use crate::cmd::agent::cli::theme;
+
+    fn text(lines: &[ratatui::text::Line]) -> String {
+        lines.iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>().join("\n")
+    }
+
+    #[test]
+    fn edit_args_produce_minus_plus_lines() {
+        let args = serde_json::json!({
+            "file_path": "src/lib.rs", "old_string": "let x = 1;", "new_string": "let x = 2;"
+        });
+        let lines = edit_diff_lines("edit", &args, theme::resolve_skin("dark")).unwrap();
+        let t = text(&lines);
+        assert!(t.contains("src/lib.rs"));
+        assert!(t.contains("- let x = 1;"));
+        assert!(t.contains("+ let x = 2;"));
+    }
+
+    #[test]
+    fn non_edit_tool_returns_none() {
+        let args = serde_json::json!({ "command": "ls" });
+        assert!(edit_diff_lines("bash", &args, theme::resolve_skin("dark")).is_none());
+    }
+
+    #[test]
+    fn write_tool_renders_content_as_added() {
+        let args = serde_json::json!({ "file_path": "new.rs", "content": "fn main() {}" });
+        let lines = edit_diff_lines("write", &args, theme::resolve_skin("dark")).unwrap();
+        assert!(text(&lines).contains("+ fn main() {}"));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+First add `mod diff;` to `mod.rs`, then:
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib cmd::agent::cli::diff`
+Expected: FAIL — module/function missing.
+
+- [ ] **Step 3: Implement `diff.rs`**
+
+```rust
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Line;
+
+use super::theme::Theme;
+
+/// Max diff lines shown inside a card body before truncating.
+const DIFF_MAX_LINES: usize = 40;
+
+/// Tool names (case-insensitive) whose args describe a file edit.
+fn is_edit_tool(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "edit" | "write" | "multiedit" | "str_replace" | "str_replace_editor"
+    )
+}
+
+fn str_field<'a>(args: &'a serde_json::Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter().find_map(|k| args.get(*k).and_then(|v| v.as_str()))
+}
+
+/// Build bounded -/+ diff lines for an edit-like tool, or `None` if this isn't
+/// an edit we can render.
+pub fn edit_diff_lines(
+    name: &str,
+    args: &serde_json::Value,
+    theme: &'static Theme,
+) -> Option<Vec<Line<'static>>> {
+    if !is_edit_tool(name) {
+        return None;
+    }
+    let path = str_field(args, &["file_path", "path"]).unwrap_or("");
+    let old = str_field(args, &["old_string", "old_str"]);
+    let new = str_field(args, &["new_string", "new_str", "content"]);
+    // Need at least a `new` side to render anything.
+    let new = new?;
+
+    let mut out: Vec<Line<'static>> = Vec::new();
+    if !path.is_empty() {
+        out.push(Line::styled(
+            format!("  {path}"),
+            Style::default().fg(theme.system).add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    let mut pushed = 0usize;
+    let mut push = |s: String, color: Color, dim: bool, out: &mut Vec<Line<'static>>| {
+        if pushed < DIFF_MAX_LINES {
+            let mut st = Style::default().fg(color);
+            if dim {
+                st = st.add_modifier(Modifier::DIM);
+            }
+            out.push(Line::styled(s, st));
+        }
+        pushed += 1;
+    };
+
+    match old {
+        // Replacement: real line diff old→new.
+        Some(old) => {
+            for d in diff::lines(old, new) {
+                match d {
+                    diff::Result::Left(l) => push(format!("  - {l}"), Color::Red, false, &mut out),
+                    diff::Result::Right(r) => push(format!("  + {r}"), Color::Green, false, &mut out),
+                    diff::Result::Both(l, _) => push(format!("    {l}"), theme.system, true, &mut out),
+                }
+            }
+        }
+        // Create/overwrite: all of `new` is added.
+        None => {
+            for l in new.lines() {
+                push(format!("  + {l}"), Color::Green, false, &mut out);
+            }
+        }
+    }
+    if pushed > DIFF_MAX_LINES {
+        out.push(Line::styled(
+            format!("  … +{} more diff line(s)", pushed - DIFF_MAX_LINES),
+            Style::default().fg(theme.system).add_modifier(Modifier::DIM),
+        ));
+    }
+    Some(out)
+}
+```
+
+> Note: `theme.system` is a `Color` (see other render code). If `Line::styled`'s closure capture of `pushed` trips the borrow checker, hoist `push` into a plain `fn` taking `&mut usize` — keep behavior identical.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib cmd::agent::cli::diff`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/diff.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(cli): edit-args → bounded -/+ diff lines (reuses the diff crate)"
+```
+
+---
+
+### Task 7: Render the diff in edit-tool cards
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/render_card.rs:17-94` (`card_lines` — render diff instead of raw args for edit tools)
+- Test: `mur-core/src/cmd/agent/cli/render_card.rs` (inline test)
+
+**Interfaces:**
+- Consumes: `diff::edit_diff_lines` (Task 6).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn edit_card_renders_diff_not_raw_json() {
+        let c = StepCard::new(
+            "s1".into(), "edit".into(),
+            serde_json::json!({"file_path":"a.rs","old_string":"old","new_string":"new"}),
+        );
+        let lines = card_lines(&c, theme::resolve_skin("dark"));
+        let text: String = lines.iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>().join("\n");
+        assert!(text.contains("- old"));
+        assert!(text.contains("+ new"));
+        // raw JSON key should NOT be shown for an edit card
+        assert!(!text.contains("\"old_string\""));
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib cmd::agent::cli::render_card::tests::edit_card_renders_diff_not_raw_json`
+Expected: FAIL — shows raw JSON, not the diff.
+
+- [ ] **Step 3: Branch the args section** in `card_lines`. Replace the `// ── Args (bounded) ──` block's opening so an edit tool renders a diff instead of JSON:
+
+```rust
+    // ── Args: diff for edit tools, else bounded JSON ─────────────────────────
+    if let Some(diff_lines) = super::diff::edit_diff_lines(&card.name, &card.args, theme) {
+        out.extend(diff_lines);
+    } else if !card.args.is_null() {
+        let pretty = serde_json::to_string_pretty(&card.args).unwrap_or_default();
+        let total_lines = pretty.lines().count();
+        for l in pretty.lines().take(ARGS_MAX_LINES) {
+            out.push(Line::styled(
+                format!(" {l}"),
+                Style::default().fg(theme.system),
+            ));
+        }
+        if total_lines > ARGS_MAX_LINES {
+            out.push(Line::styled(
+                format!(" … +{} more", total_lines - ARGS_MAX_LINES),
+                Style::default().fg(theme.system).add_modifier(Modifier::DIM),
+            ));
+        }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib cmd::agent::cli::render_card`
+Expected: PASS (all render_card tests, incl. the new one and the existing ones).
+
+- [ ] **Step 5: Final P2a verification + commit**
+
+Run:
+```bash
+ORT_STRATEGY=download cargo test -p mur-core --lib cmd::agent::cli
+cargo clippy -p mur-core -p mur-agent-runtime -- -D warnings
+cargo fmt --check
+```
+Expected: all green.
+
+```bash
+git add mur-core/src/cmd/agent/cli/render_card.rs
+git commit -m "feat(cli): edit-tool cards render an inline diff instead of raw JSON args"
+```
+
+---
+
+## Manual verification (after all tasks)
+
+1. Build: `cargo build --release -p mur-core -p mur-agent-runtime`.
+2. Restart a tool-using agent onto the new runtime (repoint `~/.local/bin/mur_agent_<name>` → `target/release/mur-agent-runtime`, then `mur agent restart <name>`).
+3. `./target/release/mur agent cli <name>`; ask it to **edit a file** (e.g. "change the version in Cargo.toml to 9.9.9"). Confirm:
+   - the edit card shows a `- old` / `+ new` **diff** (not raw JSON);
+   - the **inline `[y]/[a]/[n]`** row appears on that card (no centered modal);
+   - pressing `y` approves and the turn continues; pressing `n` denies.
+4. Point the cli at an **old** runtime (no `step_id` in approval) and confirm the **centered modal** still appears (fallback).
+
+## Out of scope (P2b — separate plan)
+
+- Risk-tiered approval *lanes* (needs a runtime `resolve_tool_rule` to surface `ToolRule.risk` in the approval).
+- Recently-denied list + `r`-to-retry.
+- Standalone `/diff` per-turn navigable viewer.
+- `Ctrl+O` scrollback dump to `$EDITOR`; notify-on-blur.
+
+## Self-Review (completed)
+
+- **Spec coverage:** D4 inline HITL (T1–T5), §E diff viewer inline-on-card (T6–T7). Risk lanes / recently-denied / `/diff` view / scrollback / notify → explicitly P2b. ✔
+- **Placeholder scan:** none — every step has runnable code/commands. ✔
+- **Type consistency:** `step_id`/`awaiting_hitl`/`mark_card_awaiting`/`clear_card_awaiting`/`edit_diff_lines` names match across tasks; `HitlRequest.step_id: Option<String>` consumed in T3/T5 as defined in T2. ✔

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1170,6 +1170,7 @@ impl TaskRunner {
                     "jsonrpc": "2.0",
                     "method": "tool/approval_needed",
                     "params": {
+                        "step_id": step_id,
                         "hitl_id": hitl_id,
                         "task_id": task_id,
                         "tool_name": call.tool_name,

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -523,6 +523,30 @@ impl App {
         }
     }
 
+    /// Flag the card with this `step_id` as awaiting a HITL decision.
+    pub fn mark_card_awaiting(&mut self, step_id: &str) {
+        if let Some(card) = self
+            .messages
+            .iter_mut()
+            .rev()
+            .find_map(|m| m.step.as_mut().filter(|c| c.id == step_id))
+        {
+            card.awaiting_hitl = true;
+        }
+    }
+
+    /// Clear the awaiting-HITL flag on the card with this `step_id`.
+    pub fn clear_card_awaiting(&mut self, step_id: &str) {
+        if let Some(card) = self
+            .messages
+            .iter_mut()
+            .rev()
+            .find_map(|m| m.step.as_mut().filter(|c| c.id == step_id))
+        {
+            card.awaiting_hitl = false;
+        }
+    }
+
     pub fn fail_turn(&mut self, err: &str) {
         if let Some(i) = self
             .messages
@@ -1121,6 +1145,29 @@ mod esc_action_tests {
     #[test]
     fn esc_nothing_when_window_expired_not_streaming_empty() {
         assert_eq!(esc_action(expired(), false, true), EscAction::Nothing);
+    }
+}
+
+#[cfg(test)]
+mod awaiting_tests {
+    use super::*;
+
+    #[test]
+    fn mark_and_clear_awaiting_by_step_id() {
+        let mut a = App::test_fixture();
+        a.begin_user_turn("edit it");
+        a.push_step_started(
+            "s1".into(),
+            "edit".into(),
+            serde_json::json!({"file_path":"a.rs"}),
+        );
+        a.update_step_completed("s1", true, "ok".into(), false, 2, None, 5);
+        a.mark_card_awaiting("s1");
+        let card = a.messages.iter().find_map(|m| m.step.as_ref()).unwrap();
+        assert!(card.awaiting_hitl);
+        a.clear_card_awaiting("s1");
+        let card = a.messages.iter().find_map(|m| m.step.as_ref()).unwrap();
+        assert!(!card.awaiting_hitl);
     }
 }
 

--- a/mur-core/src/cmd/agent/cli/diff.rs
+++ b/mur-core/src/cmd/agent/cli/diff.rs
@@ -26,6 +26,7 @@ fn str_field<'a>(args: &'a serde_json::Value, keys: &[&str]) -> Option<&'a str> 
 }
 
 /// Append one bounded diff line; no-op once `pushed` reaches `DIFF_MAX_LINES`.
+/// The counter always increments so it reflects the true total line count.
 fn push(out: &mut Vec<Line<'static>>, pushed: &mut usize, s: String, color: Color, dim: bool) {
     if *pushed < DIFF_MAX_LINES {
         let mut st = Style::default().fg(color);
@@ -33,8 +34,8 @@ fn push(out: &mut Vec<Line<'static>>, pushed: &mut usize, s: String, color: Colo
             st = st.add_modifier(Modifier::DIM);
         }
         out.push(Line::styled(s, st));
-        *pushed += 1;
     }
+    *pushed += 1; // always increment — drives the accurate "+N more" count
 }
 
 /// Build bounded `-`/`+` diff lines for an edit-like tool call, or `None` if
@@ -71,13 +72,25 @@ pub fn edit_diff_lines(
             for hunk in diff::lines(old_str, new) {
                 match hunk {
                     diff::Result::Left(l) => {
-                        push(&mut out, &mut pushed, format!("-{l}"), Color::Red, false);
+                        push(&mut out, &mut pushed, format!("  - {l}"), Color::Red, false);
                     }
                     diff::Result::Right(r) => {
-                        push(&mut out, &mut pushed, format!("+{r}"), Color::Green, false);
+                        push(
+                            &mut out,
+                            &mut pushed,
+                            format!("  + {r}"),
+                            Color::Green,
+                            false,
+                        );
                     }
                     diff::Result::Both(l, _) => {
-                        push(&mut out, &mut pushed, format!(" {l}"), theme.system, true);
+                        push(
+                            &mut out,
+                            &mut pushed,
+                            format!("    {l}"),
+                            theme.system,
+                            true,
+                        );
                     }
                 }
             }
@@ -88,7 +101,7 @@ pub fn edit_diff_lines(
                 push(
                     &mut out,
                     &mut pushed,
-                    format!("+{line}"),
+                    format!("  + {line}"),
                     Color::Green,
                     false,
                 );
@@ -96,10 +109,10 @@ pub fn edit_diff_lines(
         }
     }
 
-    // If we hit the cap, append a truncation hint.
-    if pushed == DIFF_MAX_LINES {
+    // If there were more lines than the cap, append a truncation hint.
+    if pushed > DIFF_MAX_LINES {
         out.push(Line::styled(
-            format!(" … diff capped at {DIFF_MAX_LINES} lines"),
+            format!("  … +{} more diff line(s)", pushed - DIFF_MAX_LINES),
             Style::default()
                 .fg(theme.system)
                 .add_modifier(Modifier::DIM),
@@ -130,11 +143,11 @@ mod tests {
         let lines = edit_diff_lines("edit", &args, theme::resolve_skin("dark")).unwrap();
         let t = text(&lines);
         assert!(
-            t.contains("-let x = 1;"),
+            t.contains("- let x = 1;"),
             "expected removal line, got:\n{t}"
         );
         assert!(
-            t.contains("+let x = 2;"),
+            t.contains("+ let x = 2;"),
             "expected addition line, got:\n{t}"
         );
     }
@@ -154,7 +167,41 @@ mod tests {
         });
         let lines = edit_diff_lines("write", &args, theme::resolve_skin("dark")).unwrap();
         let t = text(&lines);
-        assert!(t.contains("+line one"), "expected +line one, got:\n{t}");
-        assert!(t.contains("+line two"), "expected +line two, got:\n{t}");
+        assert!(t.contains("+ line one"), "expected + line one, got:\n{t}");
+        assert!(t.contains("+ line two"), "expected + line two, got:\n{t}");
+    }
+
+    #[test]
+    fn truncation_marker_only_past_cap_with_correct_count() {
+        // 50 added lines (write tool, no old_string) → 40 shown + "+10 more"
+        let content = (0..50)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let args = serde_json::json!({ "file_path": "big.rs", "content": content });
+        let lines = edit_diff_lines("write", &args, theme::resolve_skin("dark")).unwrap();
+        let t: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(t.contains("+10 more"), "expected '+10 more' in:\n{t}");
+
+        // exactly 40 lines must NOT fire the marker
+        let content40 = (0..40)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let args40 = serde_json::json!({ "file_path": "exact.rs", "content": content40 });
+        let lines40 = edit_diff_lines("write", &args40, theme::resolve_skin("dark")).unwrap();
+        let t40: String = lines40
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !t40.contains("more"),
+            "must NOT show marker at exactly 40 lines, got:\n{t40}"
+        );
     }
 }

--- a/mur-core/src/cmd/agent/cli/diff.rs
+++ b/mur-core/src/cmd/agent/cli/diff.rs
@@ -1,8 +1,7 @@
 //! Render an edit-tool's `{file_path, old_string, new_string}` args as a
 //! bounded `-`/`+`/context diff, using the `diff` crate.
 //!
-//! Consumed by Task 7 (`render_card`); allow dead_code until that wiring lands.
-#![allow(dead_code)]
+//! Consumed by `render_card::card_lines` to show an inline diff for edit-tool cards.
 
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Line;

--- a/mur-core/src/cmd/agent/cli/diff.rs
+++ b/mur-core/src/cmd/agent/cli/diff.rs
@@ -1,0 +1,160 @@
+//! Render an edit-tool's `{file_path, old_string, new_string}` args as a
+//! bounded `-`/`+`/context diff, using the `diff` crate.
+//!
+//! Consumed by Task 7 (`render_card`); allow dead_code until that wiring lands.
+#![allow(dead_code)]
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Line;
+
+use super::theme::Theme;
+
+/// Hard cap on diff lines rendered (keeps cards short even on large edits).
+const DIFF_MAX_LINES: usize = 40;
+
+/// Tool names (case-insensitive) whose args describe a file edit.
+fn is_edit_tool(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "edit" | "write" | "multiedit" | "str_replace" | "str_replace_editor"
+    )
+}
+
+fn str_field<'a>(args: &'a serde_json::Value, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|k| args.get(*k).and_then(|v| v.as_str()))
+}
+
+/// Append one bounded diff line; no-op once `pushed` reaches `DIFF_MAX_LINES`.
+fn push(out: &mut Vec<Line<'static>>, pushed: &mut usize, s: String, color: Color, dim: bool) {
+    if *pushed < DIFF_MAX_LINES {
+        let mut st = Style::default().fg(color);
+        if dim {
+            st = st.add_modifier(Modifier::DIM);
+        }
+        out.push(Line::styled(s, st));
+        *pushed += 1;
+    }
+}
+
+/// Build bounded `-`/`+` diff lines for an edit-like tool call, or `None` if
+/// this isn't an edit we can render.
+pub fn edit_diff_lines(
+    name: &str,
+    args: &serde_json::Value,
+    theme: &'static Theme,
+) -> Option<Vec<Line<'static>>> {
+    if !is_edit_tool(name) {
+        return None;
+    }
+    let path = str_field(args, &["file_path", "path"]).unwrap_or("");
+    let old = str_field(args, &["old_string", "old_str"]);
+    let new = str_field(args, &["new_string", "new_str", "content"]);
+    // Need at least the `new` side to render anything.
+    let new = new?;
+
+    let mut out: Vec<Line<'static>> = Vec::new();
+    if !path.is_empty() {
+        out.push(Line::styled(
+            format!(" {path}"),
+            Style::default()
+                .fg(theme.system)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+
+    let mut pushed = 0usize;
+
+    match old {
+        Some(old_str) => {
+            // Full diff: context lines (both), removed (Left), added (Right).
+            for hunk in diff::lines(old_str, new) {
+                match hunk {
+                    diff::Result::Left(l) => {
+                        push(&mut out, &mut pushed, format!("-{l}"), Color::Red, false);
+                    }
+                    diff::Result::Right(r) => {
+                        push(&mut out, &mut pushed, format!("+{r}"), Color::Green, false);
+                    }
+                    diff::Result::Both(l, _) => {
+                        push(&mut out, &mut pushed, format!(" {l}"), theme.system, true);
+                    }
+                }
+            }
+        }
+        None => {
+            // No old string: just show the new content as additions.
+            for line in new.lines() {
+                push(
+                    &mut out,
+                    &mut pushed,
+                    format!("+{line}"),
+                    Color::Green,
+                    false,
+                );
+            }
+        }
+    }
+
+    // If we hit the cap, append a truncation hint.
+    if pushed == DIFF_MAX_LINES {
+        out.push(Line::styled(
+            format!(" … diff capped at {DIFF_MAX_LINES} lines"),
+            Style::default()
+                .fg(theme.system)
+                .add_modifier(Modifier::DIM),
+        ));
+    }
+
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::edit_diff_lines;
+    use crate::cmd::agent::cli::theme;
+
+    fn text(lines: &[ratatui::text::Line]) -> String {
+        lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn edit_args_produce_minus_plus_lines() {
+        let args = serde_json::json!({
+            "file_path": "src/lib.rs", "old_string": "let x = 1;", "new_string": "let x = 2;"
+        });
+        let lines = edit_diff_lines("edit", &args, theme::resolve_skin("dark")).unwrap();
+        let t = text(&lines);
+        assert!(
+            t.contains("-let x = 1;"),
+            "expected removal line, got:\n{t}"
+        );
+        assert!(
+            t.contains("+let x = 2;"),
+            "expected addition line, got:\n{t}"
+        );
+    }
+
+    #[test]
+    fn non_edit_tool_returns_none() {
+        let args = serde_json::json!({ "old_string": "a", "new_string": "b" });
+        assert!(edit_diff_lines("bash", &args, theme::resolve_skin("dark")).is_none());
+        assert!(edit_diff_lines("read", &args, theme::resolve_skin("dark")).is_none());
+    }
+
+    #[test]
+    fn write_tool_no_old_string_shows_additions() {
+        let args = serde_json::json!({
+            "file_path": "out.txt",
+            "content": "line one\nline two"
+        });
+        let lines = edit_diff_lines("write", &args, theme::resolve_skin("dark")).unwrap();
+        let t = text(&lines);
+        assert!(t.contains("+line one"), "expected +line one, got:\n{t}");
+        assert!(t.contains("+line two"), "expected +line two, got:\n{t}");
+    }
+}

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -531,6 +531,9 @@ fn decide_hitl(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: bool) {
 
 fn decide_hitl_with_note(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: bool, auto: bool) {
     if let Some(req) = app.hitl.take() {
+        if let Some(sid) = &req.step_id {
+            app.clear_card_awaiting(sid);
+        }
         let (h, a) = (app.home.clone(), app.agent.clone());
         let (id, tool) = (req.hitl_id.clone(), req.tool_name.clone());
         let t = tx.clone();
@@ -790,6 +793,9 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
         StreamMsg::Delta { text, thinking, .. } => app.append_delta(&text, thinking),
         StreamMsg::Hitl { req, .. } => {
             app.saw_hitl_this_turn = true;
+            if let Some(sid) = req.step_id.clone() {
+                app.mark_card_awaiting(&sid);
+            }
             // Session auto-approval: `/auto`/`--auto` covers every tool; the
             // modal's [a] key covers a single tool name.
             let auto = app.auto_approve || app.session_tool_allow.contains(&req.tool_name);

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -8,6 +8,7 @@
 
 mod access;
 mod app;
+mod diff;
 mod footer;
 mod manage;
 mod markdown;

--- a/mur-core/src/cmd/agent/cli/render_card.rs
+++ b/mur-core/src/cmd/agent/cli/render_card.rs
@@ -90,6 +90,33 @@ pub fn card_lines(card: &StepCard, theme: &'static Theme) -> Vec<Line<'static>> 
         }
     }
 
+    // ── Inline HITL approval (P2) ────────────────────────────────────────────
+    if card.awaiting_hitl {
+        out.push(Line::from(vec![
+            Span::styled(
+                "  [y]",
+                Style::default()
+                    .fg(ratatui::style::Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" approve  ", Style::default().fg(theme.system)),
+            Span::styled(
+                "[a]",
+                Style::default()
+                    .fg(ratatui::style::Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" always  ", Style::default().fg(theme.system)),
+            Span::styled(
+                "[n]",
+                Style::default()
+                    .fg(ratatui::style::Color::Red)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" deny / Esc", Style::default().fg(theme.system)),
+        ]));
+    }
+
     out
 }
 
@@ -178,5 +205,25 @@ mod tests {
             .join("\n");
         assert!(text.contains("exit 101"), "expected 'exit 101' in: {text}");
         assert!(text.contains('✗'), "expected '✗' in: {text}");
+    }
+
+    #[test]
+    fn awaiting_card_shows_inline_approval_row() {
+        let mut c = StepCard::new(
+            "s1".into(),
+            "edit".into(),
+            serde_json::json!({"file_path":"a.rs"}),
+        );
+        c.complete(true, "patched".into(), false, 1, None, 4);
+        c.awaiting_hitl = true;
+        let lines = card_lines(&c, theme::resolve_skin("dark"));
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("[y]"));
+        assert!(text.contains("approve"));
+        assert!(text.contains("[n]"));
     }
 }

--- a/mur-core/src/cmd/agent/cli/render_card.rs
+++ b/mur-core/src/cmd/agent/cli/render_card.rs
@@ -36,8 +36,10 @@ pub fn card_lines(card: &StepCard, theme: &'static Theme) -> Vec<Line<'static>> 
         Span::styled(dur, Style::default().fg(theme.system)),
     ]));
 
-    // ── Args (bounded) ────────────────────────────────────────────────────────
-    if !card.args.is_null() {
+    // ── Args: diff for edit tools, else bounded JSON ─────────────────────────
+    if let Some(diff_lines) = super::diff::edit_diff_lines(&card.name, &card.args, theme) {
+        out.extend(diff_lines);
+    } else if !card.args.is_null() {
         let pretty = serde_json::to_string_pretty(&card.args).unwrap_or_default();
         let total_lines = pretty.lines().count();
         for l in pretty.lines().take(ARGS_MAX_LINES) {
@@ -205,6 +207,28 @@ mod tests {
             .join("\n");
         assert!(text.contains("exit 101"), "expected 'exit 101' in: {text}");
         assert!(text.contains('✗'), "expected '✗' in: {text}");
+    }
+
+    #[test]
+    fn edit_card_renders_diff_not_raw_json() {
+        let c = StepCard::new(
+            "s1".into(),
+            "edit".into(),
+            serde_json::json!({"file_path":"a.rs","old_string":"old","new_string":"new"}),
+        );
+        let lines = card_lines(&c, theme::resolve_skin("dark"));
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("- old"), "expected '- old' in:\n{text}");
+        assert!(text.contains("+ new"), "expected '+ new' in:\n{text}");
+        // raw JSON key must NOT appear for an edit card
+        assert!(
+            !text.contains("\"old_string\""),
+            "raw JSON key must not appear in:\n{text}"
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/step.rs
+++ b/mur-core/src/cmd/agent/cli/step.rs
@@ -25,6 +25,10 @@ pub struct StepCard {
     pub full_len: usize,
     pub error: Option<String>,
     pub duration_ms: Option<u64>,
+    /// True while this card's tool call is waiting on a HITL decision (P2 inline
+    /// approval). Set when the matching `tool/approval_needed` arrives, cleared
+    /// on decision.
+    pub awaiting_hitl: bool,
 }
 
 impl StepCard {
@@ -39,6 +43,7 @@ impl StepCard {
             full_len: 0,
             error: None,
             duration_ms: None,
+            awaiting_hitl: false,
         }
     }
 

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -139,6 +139,10 @@ pub async fn run_local_shell(cmd: String) -> String {
 #[derive(Debug, Clone)]
 pub struct HitlRequest {
     pub hitl_id: String,
+    /// The `step_id` of the card that ran this tool (P2: lets the cli show the
+    /// approval inline on that card). `None` on runtimes predating the field.
+    #[allow(dead_code)]
+    pub step_id: Option<String>,
     pub tool_name: String,
     pub tool_input: Value,
     pub prompt: String,
@@ -157,6 +161,7 @@ impl HitlRequest {
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_string(),
+            step_id: v.get("step_id").and_then(Value::as_str).map(str::to_string),
             prompt: v
                 .get("prompt")
                 .and_then(Value::as_str)
@@ -495,5 +500,28 @@ mod tests {
         assert_eq!(h.tool_name, "bash");
         assert_eq!(h.prompt, "Run `bash`?");
         assert_eq!(h.tool_input["command"], "ls");
+    }
+}
+
+#[cfg(test)]
+mod hitl_step_tests {
+    use super::HitlRequest;
+
+    #[test]
+    fn parses_step_id_when_present() {
+        let v = serde_json::json!({
+            "step_id": "s-1", "hitl_id": "h-1", "tool_name": "edit",
+            "tool_input": { "file_path": "a.rs" }, "prompt": "Run `edit`?"
+        });
+        let req = HitlRequest::from_value(v);
+        assert_eq!(req.step_id.as_deref(), Some("s-1"));
+        assert_eq!(req.hitl_id, "h-1");
+    }
+
+    #[test]
+    fn step_id_none_on_old_runtime() {
+        let v = serde_json::json!({ "hitl_id": "h-1", "tool_name": "bash" });
+        let req = HitlRequest::from_value(v);
+        assert!(req.step_id.is_none());
     }
 }

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -141,7 +141,6 @@ pub struct HitlRequest {
     pub hitl_id: String,
     /// The `step_id` of the card that ran this tool (P2: lets the cli show the
     /// approval inline on that card). `None` on runtimes predating the field.
-    #[allow(dead_code)]
     pub step_id: Option<String>,
     pub tool_name: String,
     pub tool_input: Value,

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -29,7 +29,11 @@ pub fn render(f: &mut Frame, app: &mut App) {
     f.render_widget(&app.input, chunks[1]);
     render_status(f, app, chunks[2]);
 
-    if let Some(hitl) = &app.hitl {
+    // Inline approval lives on the card (Task 4) when the runtime sent a
+    // step_id. Fall back to the centered modal only for older runtimes.
+    if let Some(hitl) = &app.hitl
+        && hitl.step_id.is_none()
+    {
         render_hitl(f, hitl);
     }
 }


### PR DESCRIPTION
**Stacked on #517 (P1).** Base is the P1 branch `feat/agent-cli-glass-box`; GitHub auto-retargets to `main` once #517 merges. Review #517 first.

## Summary

Two card-interaction upgrades on top of P1's Glass Box cards:

1. **Inline HITL approval** — tool approval moves from a centered modal onto the tool-call card itself. The runtime tags its `tool/approval_needed` with the card's `step_id`; the cli marks that card `awaiting_hitl` and renders `[y] approve · [a] always · [n] deny` in place. The centered modal stays as the **old-runtime fallback** (shown only when `step_id` is absent). The `y/a/n` keys are unchanged (they act on `app.hitl`).
2. **Edit diffs** — edit-tool cards (`edit`/`write`/`multiedit`) render a bounded `-`/`+`/context diff of `{file_path, old_string, new_string}` instead of raw JSON args, via the already-present `diff` crate (no new dependency).

## How it correlates (the key seam)

`step_id` in the approval is the **same UUID** the runtime already emits in `step/started`/`step/completed`, so the card lookup (`card.id == step_id`) is deterministic, not best-effort. Chain: runtime `step_id` → `HitlRequest.step_id` → `mark_card_awaiting` → inline render → `decide_hitl` clears it; old runtimes (no `step_id`) fall back to the modal so approval is never a silent no-op.

## Note on mur's post-hoc HITL (unchanged)

The runtime executes a tool, emits `step/completed` (card shows `✔` + output), *then* requests approval — so the inline prompt appears on an already-`✔` card ("ran this — approve keeping it?"). The diff is built from args regardless of timing.

## Review

Final opus whole-branch review: **READY TO MERGE** — 0 Critical, 0 Important. Traced the inline-HITL seam hop-by-hop; diff mapping verified not-swapped; truncation counts correctly (a review-caught bug, fixed); dead-code allow removed; panic-safe on arbitrary UTF-8.

- `cargo clippy -p mur-core -p mur-agent-runtime -- -D warnings` — clean.
- 110/110 mur-core cli tests; mur-agent-runtime suite green. Every task TDD'd + reviewed.

## Out of scope (P2b)

Risk-tiered approval *lanes* (needs runtime `resolve_tool_rule` to surface `ToolRule.risk`), recently-denied + `r`-retry, standalone `/diff` view, scrollback-dump, notify-on-blur. Also defer: nested `multiedit`/`str_replace_editor` (`file_text`) arg shapes — they currently fall back to JSON (correct, just not diffed).

## Docs

Plan: `docs/superpowers/plans/2026-06-27-mur-agent-cli-glass-box-p2a.md` (spec: the P1 design doc §D/§E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)