### PR TITLE
fix(runtime): self-heal MUR's MCP server into ~/.mur/mcp-servers

### DIFF
--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -189,6 +189,31 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         warn!(error = %e, "grace-period cleanup failed");
     }
 
+    // 3c. Self-heal MUR's own copy of the MCP server binary. When an enabled
+    //     MCP server points at the bundled location (~/.mur/mcp-servers/...),
+    //     refresh it from the mur-mcp-server shipped next to `mur` so it tracks
+    //     the running version regardless of how mur was installed (brew/cargo/
+    //     source). Done BEFORE the sandbox seals (needs write to ~/.mur) and
+    //     before the MCP child is spawned. Best-effort: a non-media agent skips
+    //     it entirely, and a failure leaves any existing copy in place.
+    {
+        let bundled = mur_common::exec::bundled_mcp_server_path();
+        let uses_bundled = profile
+            .inner
+            .enabled_mcp_servers()
+            .iter()
+            .any(|e| std::path::Path::new(&e.command) == bundled);
+        if uses_bundled {
+            match mur_common::exec::ensure_bundled_mcp_server() {
+                Ok(p) => info!(path = %p.display(), "ensured bundled mcp-server"),
+                Err(e) => warn!(
+                    error = %e,
+                    "could not refresh bundled mcp-server; using existing copy if present"
+                ),
+            }
+        }
+    }
+
     // B1: apply OS-level kernel sandbox based on profile entitlements.
     // Called AFTER profile load (needs entitlements) and AFTER grace cleanup.
     // BEFORE telemetry writer (its file I/O must be within sandbox bounds).

--- a/mur-common/src/exec.rs
+++ b/mur-common/src/exec.rs
@@ -9,7 +9,109 @@
 //! check while `Command::new` runs the PATH-resolved binary.
 
 use anyhow::{Context, Result, bail};
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
+
+/// File name of the MUR MCP server binary.
+#[cfg(windows)]
+const MCP_SERVER_BIN: &str = "mur-mcp-server.exe";
+#[cfg(not(windows))]
+const MCP_SERVER_BIN: &str = "mur-mcp-server";
+
+/// Canonical location MUR keeps its own copy of the MCP server binary:
+/// `~/.mur/mcp-servers/mur-mcp-server` (honors `$MUR_HOME`). Stable across how
+/// `mur` itself was installed (brew / cargo / source) and across upgrades, so
+/// agent profiles can pin this path once and never go stale.
+pub fn bundled_mcp_server_path() -> PathBuf {
+    crate::trust::mur_home()
+        .join("mcp-servers")
+        .join(MCP_SERVER_BIN)
+}
+
+/// Ensure [`bundled_mcp_server_path`] exists and matches the `mur-mcp-server`
+/// shipped alongside the running `mur` binary, copying it into place when
+/// missing or out of date. Returns the canonical target path.
+///
+/// Source resolution: the sibling of the current executable first (brew, cargo
+/// and source builds all colocate the two binaries), then `mur-mcp-server` on
+/// `PATH`. If no source is found but a copy already exists, that copy is
+/// returned (usable, just can't self-update). Errors only when there is neither
+/// a source nor an existing copy.
+///
+/// Call this BEFORE the kernel sandbox seals — the copy needs write access to
+/// `~/.mur`.
+pub fn ensure_bundled_mcp_server() -> Result<PathBuf> {
+    let target = bundled_mcp_server_path();
+    match locate_mcp_server_source() {
+        Some(src) => {
+            install_if_stale(&src, &target)?;
+            Ok(target)
+        }
+        None if target.is_file() => Ok(target),
+        None => bail!(
+            "mur-mcp-server not found next to `mur` or on PATH, and no copy at {}",
+            target.display()
+        ),
+    }
+}
+
+/// The `mur-mcp-server` to copy from: sibling of `mur` first, then PATH.
+fn locate_mcp_server_source() -> Option<PathBuf> {
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        let sibling = dir.join(MCP_SERVER_BIN);
+        if sibling.is_file() {
+            return sibling.canonicalize().ok();
+        }
+    }
+    resolve_command(MCP_SERVER_BIN).ok()
+}
+
+/// Copy `src` to `target` unless `target` already byte-matches it. Idempotent;
+/// writes via a uniquely-named temp file + rename in the target dir so the swap
+/// is atomic and never leaves a half-written binary an agent might try to spawn;
+/// sets mode 0755 on unix.
+fn install_if_stale(src: &Path, target: &Path) -> Result<()> {
+    if target.is_file() && sha256_file(src)? == sha256_file(target)? {
+        return Ok(());
+    }
+    let dir = target
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("target {} has no parent", target.display()))?;
+    std::fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
+    // Unique temp name so two agents starting at once don't clobber each other.
+    let tmp = dir.join(format!(".{MCP_SERVER_BIN}.{}.tmp", std::process::id()));
+    std::fs::copy(src, &tmp)
+        .with_context(|| format!("copy {} -> {}", src.display(), tmp.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("chmod {}", tmp.display()))?;
+    }
+    std::fs::rename(&tmp, target)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), target.display()))?;
+    Ok(())
+}
+
+/// Stream-hash `path` SHA-256 (64 KiB chunks; lowercase hex).
+fn sha256_file(path: &Path) -> Result<String> {
+    use std::io::Read;
+    let mut f = std::fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 65536];
+    loop {
+        let n = f
+            .read(&mut buf)
+            .with_context(|| format!("read {}", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
 
 /// Resolve `command` to an absolute path on disk.
 ///
@@ -75,5 +177,32 @@ mod tests {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let resolved = resolve_command(tmp.path().to_str().unwrap()).unwrap();
         assert!(resolved.is_absolute());
+    }
+
+    #[test]
+    fn install_if_stale_copies_then_is_idempotent_and_updates() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src-bin");
+        let target = dir.path().join("mcp-servers/mur-mcp-server"); // parent must be created
+        std::fs::write(&src, b"v1").unwrap();
+
+        // Missing target -> copied.
+        install_if_stale(&src, &target).unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"v1");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&target).unwrap().permissions().mode();
+            assert_eq!(mode & 0o111, 0o111, "target must be executable");
+        }
+
+        // Unchanged source -> no-op, still v1.
+        install_if_stale(&src, &target).unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"v1");
+
+        // Updated source -> refreshed.
+        std::fs::write(&src, b"v2-newer").unwrap();
+        install_if_stale(&src, &target).unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"v2-newer");
     }
 }


### PR DESCRIPTION
## Problem

Agent profiles pin `mur-mcp-server` by absolute path (e.g. `~/.cargo/bin/mur-mcp-server`). When `mur` is later installed a different way (brew → `/opt/homebrew/bin`), the pinned path no longer resolves: the Hub showed **"path not found"** and the runtime's B0 rule-6 pin verify soft-failed with *"command not resolvable"*.

## Fix

Give MUR a stable, install-method-independent home for its own copy of the MCP server binary and keep it current automatically:

- **`mur-common/src/exec.rs`** — `bundled_mcp_server_path()` → `~/.mur/mcp-servers/mur-mcp-server` (honors `$MUR_HOME`), and `ensure_bundled_mcp_server()` which copies the `mur-mcp-server` shipped next to `mur` (sibling of `current_exe`, then PATH) into that path when missing or sha-stale. Atomic temp+rename, 0755, idempotent — survives brew/cargo/source upgrades.
- **`mur-agent-runtime/src/supervisor.rs`** — calls it early in `entrypoint()`, before the kernel sandbox seals and before the MCP child spawns. Gated so only agents whose enabled MCP servers point at the bundled path do the copy; a non-media agent keeps a clean home.

Agents can now pin the stable `~/.mur/mcp-servers` path once and never go stale across upgrades.

## Test plan

- Unit test `exec::tests::install_if_stale_copies_then_is_idempotent_and_updates` (copy → idempotent no-op → refresh-on-change → executable bit). `cargo test -p mur-common exec` green.
- Live-verified on the maintainer's machine: re-pointed the `mur` concierge's `media` MCP to the bundled path, restarted, confirmed the runtime spawns it cleanly with no path/pin warnings (Hub MCP tab shows the new path, no error banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)