### PR TITLE
fix(hub): scrollable MCP discover modal + keyword search

### DIFF
--- a/mur-hub-gui/ui/src/components/McpDiscoverModal.tsx
+++ b/mur-hub-gui/ui/src/components/McpDiscoverModal.tsx
@@ -64,7 +64,7 @@ export function McpDiscoverModal({ agentName, onClose, onImported }: Props) {
 
   return (
     <div className="modal__overlay" onClick={onClose}>
-      <div className="modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal modal--wide" onClick={(e) => e.stopPropagation()}>
         <div className="modal__header">
           <h2 className="modal__title">{t("detail.discoverTitle")}</h2>
           <button className="modal__close" onClick={onClose} aria-label={t("detail.close")}>

--- a/mur-hub-gui/ui/src/components/McpDiscoverModal.tsx
+++ b/mur-hub-gui/ui/src/components/McpDiscoverModal.tsx
@@ -29,6 +29,17 @@ export function McpDiscoverModal({ agentName, onClose, onImported }: Props) {
   const [busy, setBusy] = useState<string | null>(null);
   const [imported, setImported] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+
+  const q = query.trim().toLowerCase();
+  const filtered = (servers ?? []).filter(
+    (s) =>
+      !q ||
+      s.name.toLowerCase().includes(q) ||
+      s.client.toLowerCase().includes(q) ||
+      s.command.toLowerCase().includes(q) ||
+      s.args.some((a) => a.toLowerCase().includes(q)),
+  );
 
   useEffect(() => {
     invoke<DiscoveredServer[]>("mcp_discover")
@@ -71,15 +82,30 @@ export function McpDiscoverModal({ agentName, onClose, onImported }: Props) {
             ×
           </button>
         </div>
+        {servers && servers.length > 0 && (
+          <div className="modal__search">
+            <input
+              className="input"
+              type="text"
+              placeholder={t("detail.discoverSearch")}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              autoFocus
+            />
+          </div>
+        )}
         <div className="modal__body">
           {servers === null && <p className="field-muted">{t("detail.discoverScanning")}</p>}
           {servers !== null && servers.length === 0 && !error && (
             <p className="field-muted">{t("detail.discoverEmpty")}</p>
           )}
           {error && <p className="save-error">{error}</p>}
-          {servers && servers.length > 0 && (
+          {servers && servers.length > 0 && filtered.length === 0 && (
+            <p className="field-muted">{t("detail.discoverNoMatch")}</p>
+          )}
+          {filtered.length > 0 && (
             <ul className="item-list">
-              {servers.map((s) => {
+              {filtered.map((s) => {
                 const key = `${s.client}/${s.name}`;
                 const done = imported.has(key);
                 const remote = s.command.length === 0;

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -126,6 +126,8 @@ export const en = {
   "detail.discoverTitle": "MCP servers found in other tools",
   "detail.discoverScanning": "Scanning other tools…",
   "detail.discoverEmpty": "No MCP servers found in other tools.",
+  "detail.discoverSearch": "Search MCP servers (name or command)…",
+  "detail.discoverNoMatch": "No matching MCP servers.",
   "detail.import": "Import",
   "detail.imported": "Imported",
   "detail.reveal": "Reveal in Finder",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -128,6 +128,8 @@ export const zhTW: Table = {
   "detail.discoverTitle": "在其他工具找到的 MCP 伺服器",
   "detail.discoverScanning": "正在掃描其他工具…",
   "detail.discoverEmpty": "其他工具中沒有找到 MCP 伺服器。",
+  "detail.discoverSearch": "搜尋 MCP 伺服器（名稱或指令）…",
+  "detail.discoverNoMatch": "沒有符合的 MCP 伺服器。",
   "detail.import": "匯入",
   "detail.imported": "已匯入",
   "detail.reveal": "在 Finder 中顯示",

--- a/mur-hub-gui/ui/src/styles/components/modal.css
+++ b/mur-hub-gui/ui/src/styles/components/modal.css
@@ -48,6 +48,13 @@
   margin: 0;
 }
 
+/* Pinned filter row above the scrolling body (stays visible while the list
+   scrolls). The input itself reuses the .input primitive. */
+.modal__search {
+  flex: 0 0 auto;
+  padding: 12px 20px 0;
+}
+
 .modal__close {
   background: transparent;
   border: none;

--- a/mur-hub-gui/ui/src/styles/components/modal.css
+++ b/mur-hub-gui/ui/src/styles/components/modal.css
@@ -14,6 +14,11 @@
 .modal {
   width: 360px;
   max-width: calc(100vw - 32px);
+  /* Cap to the viewport so a long body scrolls instead of overflowing
+     off-screen (header + footer stay pinned, body flexes + scrolls). */
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
   background: var(--surface-card);
   border: 1px solid var(--border-line);
   border-radius: var(--radius-xl);
@@ -21,7 +26,14 @@
   overflow: hidden;
 }
 
+/* Wider variant for modals whose content is wide (e.g. MCP command strings)
+   so they wrap less and the list stays short enough to scan. */
+.modal--wide {
+  width: 560px;
+}
+
 .modal__header {
+  flex: 0 0 auto;
   padding: 18px 20px;
   border-bottom: 1px solid var(--border-line);
   display: flex;
@@ -52,10 +64,31 @@
 }
 
 .modal__body {
+  /* The scroll region. min-height:0 lets this flex child shrink below its
+     content height so overflow-y can actually kick in inside the capped modal. */
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
   padding: 20px;
 }
 
+/* Slim, theme-matched scrollbar (WebKit / Tauri macOS) so the list reads as
+   intentionally scrollable, not like a default chunky bar. */
+.modal__body::-webkit-scrollbar {
+  width: 10px;
+}
+.modal__body::-webkit-scrollbar-thumb {
+  background: var(--border-line);
+  border-radius: 6px;
+  border: 2px solid var(--surface-card);
+}
+.modal__body::-webkit-scrollbar-thumb:hover {
+  background: var(--text-secondary);
+}
+
 .modal__footer {
+  flex: 0 0 auto;
   display: flex;
   justify-content: flex-end;
   gap: 8px;


### PR DESCRIPTION
## Problem

The Hub's "discover MCP servers from other tools" dialog could list more servers than fit on screen, but `.modal` had `overflow: hidden` with no `max-height` — so it grew past the viewport and the body never scrolled, leaving servers below the fold **unreachable**.

## Changes

1. **Scrollable, bounded modal (fixes every modal):** `.modal` capped at `calc(100vh - 48px)` laid out as a flex column so header/footer stay pinned; `.modal__body` becomes the scroll region (`flex: 1; min-height: 0; overflow-y: auto`) with a slim theme-matched scrollbar. `.modal--wide` (560px) on the discover modal so long command strings wrap less.
2. **Keyword search:** a pinned search box at the top of the discover modal filters as you type — case-insensitive substring across **name, client, command, and args** — with a "no matches" state. i18n added (en + zh-TW).

## Test plan

- `tsc --noEmit` exit 0; `vite build` succeeds.
- **Live-verified via computer-use** in a locally-rebuilt Hub: the discover list scrolls top-to-bottom (previously-hidden servers reachable, header/footer pinned); search `serena` → 2 results, `homebrew` → the server matched by its command path, gibberish → "no matching servers".

🤖 Generated with [Claude Code](https://claude.com/claude-code)