### PR TITLE
feat: quill skill bundles — install a .zip/.tar.gz skill pack by URL (Hub + CLI)

### DIFF
--- a/docs/superpowers/plans/2026-06-28-quill-skill-bundles-plan.md
+++ b/docs/superpowers/plans/2026-06-28-quill-skill-bundles-plan.md
@@ -1,0 +1,759 @@
+# Quill skill bundles — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Install a pack of one-or-more skills from a `.zip` or `.tar.gz`/`.tgz` URL — Hub + CLI — by safely extracting the archive, discovering every skill manifest, scanning each, and installing the clean ones (flagged ones need explicit acceptance).
+
+**Architecture:** A new `mur-core` `skill_bundle.rs` adds archive detection, zip-slip/zip-bomb-safe extraction (`zip` crate + `tar`+`flate2`), multi-skill discovery, and a bundle preview/install built on quill P1's per-skill primitives. `install_skill_from_url` (P1) gains a front-door that routes archive URLs here. The Hub's preview/install commands unify to return a **list** of skills so one modal code path handles single skills and packs.
+
+**Tech Stack:** Rust (`zip` v2, `tar`, `flate2` — all already mur-core deps), reusing quill P1 `skill_remote` + `cmd_skill_add` + `scan_skill`; Tauri 2; React/TS.
+
+## Global Constraints
+
+- Builds on quill P1 (branch `feat/quill-p1-skill-by-url`); this branch is `feat/quill-skill-bundles` stacked on it.
+- No hardcoded values — caps are named consts. (CLAUDE.md rule 1)
+- Single source file ≤ 800 lines. (rule 4)
+- Rust edition 2024.
+- Build/test mur-core: `ORT_STRATEGY=download`, plain `cargo test`; toolchain at `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin` on PATH + `RUSTC` if the rustup proxy is broken. **Run `cargo fmt --all` after Rust changes** (CI's stable rustfmt is strict — see the fmt-skew gotcha).
+- Hub UI: `npx tsc --noEmit` + `npm run build` from `mur-hub-gui/ui` (symlink `node_modules` from the main checkout in a worktree). Hub `cargo check` needs `mur-hub-gui/ui/dist` (stub `index.html` if absent; gitignored). **Never commit the tracked 0-byte `mur-hub-gui/src-tauri/binaries/*` stubs as real binaries** — `git checkout --` them if a Hub build overwrote them.
+- **Safe extraction is mandatory:** reject path-traversal (`..`/absolute/symlink), enforce entry-count + total-uncompressed caps; https-only; size-capped download.
+- **Fail-closed:** a skill with blocking scan findings installs only on explicit acceptance.
+- Changes apply on agent **restart** — surface in UI copy.
+- All three archive deps already in `mur-core/Cargo.toml`: `tar = "0.4"`, `flate2 = "1"`, `zip = { version = "2", default-features = false, features = ["deflate"] }`. **No Cargo.toml change.**
+
+## Reused existing API (verified, from quill P1 base)
+
+- `skill_remote::SkillPreview { name, description, category, body, blocking, findings }` (Serialize).
+- `skill_remote::preview_skill_text(text: &str, is_markdown: bool) -> Result<SkillPreview>`.
+- `skill_remote::install_skill_from_url(agent, url, accept_findings) -> Result<String>` (returns `skills/<name>`).
+- `skill_remote::{validate_skill_url, SKILL_MAX_BYTES, preview_skill_url}`.
+- `cmd::agent::skill::cmd_skill_add(agent, source_path) -> Result<()>`.
+- `mur_common::skill::{parse_canonical, parse_markdown}`.
+- Hub: `agent_skill_preview_url(url) -> Result<SkillPreview, String>`, `agent_skill_install_url(name, url, accept_findings) -> Result<SkillInstallResult, String>`, `SkillInstallResult { detail, installed_id }`, `get_agent_detail`.
+- `zip` API pattern (mur-core `update/release.rs`): `zip::ZipArchive::new(std::io::Cursor::new(bytes))` → `.by_index(i)` → `entry.enclosed_name()` (None ⇒ unsafe path).
+
+---
+
+## File Structure
+
+- **Create** `mur-core/src/cmd/agent/skill_bundle.rs` — archive detection, safe extraction, discovery, bundle preview/install.
+- **Modify** `mur-core/src/cmd/agent/mod.rs` — `pub mod skill_bundle;`.
+- **Modify** `mur-core/src/cmd/agent/skill_remote.rs` — add `preview_any_url`/`install_any_url` routing helpers; route archives in `install_skill_from_url`.
+- **Modify** `mur-hub-gui/src-tauri/src/mcp_skills.rs` — preview returns `Vec<SkillPreview>`; install returns a multi-id result.
+- **Modify** `mur-hub-gui/ui/src/components/SkillAddUrlModal.tsx` — render a skill **list** + one bundle-level accept.
+- **Modify** `mur-hub-gui/ui/src/i18n/{en,zh-TW}.ts` — pluralized strings.
+
+---
+
+## Task 1: Archive detection + caps (mur-core)
+
+**Files:** Create `mur-core/src/cmd/agent/skill_bundle.rs`; Modify `mur-core/src/cmd/agent/mod.rs`.
+
+**Interfaces:**
+- Produces: `pub enum ArchiveKind { Zip, TarGz }`; `pub fn is_archive_url(url: &str) -> Option<ArchiveKind>`; consts `BUNDLE_MAX_BYTES`, `BUNDLE_MAX_ENTRIES`, `BUNDLE_MAX_TOTAL_UNCOMPRESSED`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn detects_archive_extensions() {
+        assert!(matches!(is_archive_url("https://x.com/p.zip"), Some(ArchiveKind::Zip)));
+        assert!(matches!(is_archive_url("https://x.com/p.tar.gz"), Some(ArchiveKind::TarGz)));
+        assert!(matches!(is_archive_url("https://x.com/p.tgz"), Some(ArchiveKind::TarGz)));
+        assert!(is_archive_url("https://x.com/skill.yaml").is_none());
+        assert!(is_archive_url("https://x.com/skill.md").is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core skill_bundle::tests::detects_archive`
+Expected: FAIL — items not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+//! Install a pack of one-or-more skills from an archive URL (.zip / .tar.gz).
+//! Safely extracts (path-traversal + size caps), discovers every skill manifest,
+//! and installs the clean ones via quill P1's per-skill path. Built on
+//! `skill_remote`.
+
+use anyhow::{Result, bail};
+use std::path::{Path, PathBuf};
+
+/// Supported skill-bundle archive formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArchiveKind {
+    Zip,
+    TarGz,
+}
+
+/// Max bytes downloaded for a bundle.
+pub const BUNDLE_MAX_BYTES: usize = 5 * 1024 * 1024;
+/// Max number of entries an archive may contain.
+pub const BUNDLE_MAX_ENTRIES: usize = 256;
+/// Max total uncompressed bytes written during extraction (zip-bomb guard).
+pub const BUNDLE_MAX_TOTAL_UNCOMPRESSED: u64 = 32 * 1024 * 1024;
+
+/// Classify a URL by archive extension. `None` = not an archive we handle.
+pub fn is_archive_url(url: &str) -> Option<ArchiveKind> {
+    let path = reqwest::Url::parse(url).ok()?.path().to_ascii_lowercase();
+    if path.ends_with(".zip") {
+        Some(ArchiveKind::Zip)
+    } else if path.ends_with(".tar.gz") || path.ends_with(".tgz") {
+        Some(ArchiveKind::TarGz)
+    } else {
+        None
+    }
+}
+```
+
+Add to `mur-core/src/cmd/agent/mod.rs`: `pub mod skill_bundle;`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core skill_bundle::tests::detects_archive`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/skill_bundle.rs mur-core/src/cmd/agent/mod.rs
+git commit -m "feat(skill): archive detection + bundle caps"
+```
+
+---
+
+## Task 2: Safe extraction (mur-core, network-free)
+
+**Files:** Modify `mur-core/src/cmd/agent/skill_bundle.rs`.
+
+**Interfaces:**
+- Consumes: Task 1 `ArchiveKind`, caps.
+- Produces: `pub fn extract_archive(bytes: &[u8], kind: ArchiveKind, dest: &Path) -> Result<()>` — extracts into `dest`, rejecting path-traversal/symlinks and over-cap archives.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn extract_zip_rejects_traversal_and_writes_safe_files() {
+    use std::io::Write;
+    // Build an in-memory zip with one safe file and one ../escape entry.
+    let mut buf = Vec::new();
+    {
+        let mut w = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts: zip::write::FileOptions<()> = zip::write::FileOptions::default();
+        w.start_file("ok/skill.yaml", opts).unwrap();
+        w.write_all(b"name: x").unwrap();
+        w.start_file("../escape.txt", opts).unwrap();
+        w.write_all(b"evil").unwrap();
+        w.finish().unwrap();
+    }
+    let dir = tempfile::tempdir().unwrap();
+    extract_archive(&buf, ArchiveKind::Zip, dir.path()).unwrap();
+    assert!(dir.path().join("ok/skill.yaml").exists());
+    // the traversal entry must NOT have been written outside dest
+    assert!(!dir.path().parent().unwrap().join("escape.txt").exists());
+}
+
+#[test]
+fn extract_targz_roundtrips_a_skill() {
+    use std::io::Write;
+    let mut tar_buf = Vec::new();
+    {
+        let mut b = tar::Builder::new(&mut tar_buf);
+        let data = b"name: y";
+        let mut h = tar::Header::new_gnu();
+        h.set_size(data.len() as u64);
+        h.set_mode(0o644);
+        h.set_cksum();
+        b.append_data(&mut h, "pack/skill.yaml", &data[..]).unwrap();
+        b.finish().unwrap();
+    }
+    let mut gz = Vec::new();
+    {
+        use flate2::{Compression, write::GzEncoder};
+        let mut e = GzEncoder::new(&mut gz, Compression::default());
+        e.write_all(&tar_buf).unwrap();
+        e.finish().unwrap();
+    }
+    let dir = tempfile::tempdir().unwrap();
+    extract_archive(&gz, ArchiveKind::TarGz, dir.path()).unwrap();
+    assert!(dir.path().join("pack/skill.yaml").exists());
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core skill_bundle::tests::extract_`
+Expected: FAIL — `extract_archive` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+use std::io::Read;
+
+/// Extract `bytes` (a `kind` archive) into `dest`, safely. Rejects entries that
+/// escape `dest` (`..`/absolute), symlinks, and archives exceeding the entry or
+/// total-uncompressed caps. Directories are created; only regular files written.
+pub fn extract_archive(bytes: &[u8], kind: ArchiveKind, dest: &Path) -> Result<()> {
+    match kind {
+        ArchiveKind::Zip => extract_zip(bytes, dest),
+        ArchiveKind::TarGz => extract_targz(bytes, dest),
+    }
+}
+
+fn extract_zip(bytes: &[u8], dest: &Path) -> Result<()> {
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes))
+        .map_err(|e| anyhow::anyhow!("open zip: {e}"))?;
+    if zip.len() > BUNDLE_MAX_ENTRIES {
+        bail!("archive has too many entries ({} > {BUNDLE_MAX_ENTRIES})", zip.len());
+    }
+    let mut total: u64 = 0;
+    for i in 0..zip.len() {
+        let mut entry = zip.by_index(i).map_err(|e| anyhow::anyhow!("zip entry {i}: {e}"))?;
+        if entry.is_dir() {
+            continue;
+        }
+        // enclosed_name() returns None for traversal/absolute/unsafe paths.
+        let rel = match entry.enclosed_name() {
+            Some(p) => p,
+            None => bail!("unsafe path in archive: {}", entry.name()),
+        };
+        total = total.saturating_add(entry.size());
+        if total > BUNDLE_MAX_TOTAL_UNCOMPRESSED {
+            bail!("archive uncompressed size exceeds {BUNDLE_MAX_TOTAL_UNCOMPRESSED} bytes");
+        }
+        let out = dest.join(rel);
+        if let Some(parent) = out.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| anyhow::anyhow!("mkdir: {e}"))?;
+        }
+        let mut data = Vec::new();
+        entry.read_to_end(&mut data).map_err(|e| anyhow::anyhow!("read entry: {e}"))?;
+        std::fs::write(&out, &data).map_err(|e| anyhow::anyhow!("write {}: {e}", out.display()))?;
+    }
+    Ok(())
+}
+
+fn extract_targz(bytes: &[u8], dest: &Path) -> Result<()> {
+    let gz = flate2::read::GzDecoder::new(std::io::Cursor::new(bytes));
+    let mut ar = tar::Archive::new(gz);
+    let mut count = 0usize;
+    let mut total: u64 = 0;
+    for entry in ar.entries().map_err(|e| anyhow::anyhow!("read tar: {e}"))? {
+        let mut entry = entry.map_err(|e| anyhow::anyhow!("tar entry: {e}"))?;
+        // Skip non-regular files (symlinks, hardlinks, devices) — defense.
+        if entry.header().entry_type() != tar::EntryType::Regular {
+            continue;
+        }
+        count += 1;
+        if count > BUNDLE_MAX_ENTRIES {
+            bail!("archive has too many entries (> {BUNDLE_MAX_ENTRIES})");
+        }
+        total = total.saturating_add(entry.size());
+        if total > BUNDLE_MAX_TOTAL_UNCOMPRESSED {
+            bail!("archive uncompressed size exceeds {BUNDLE_MAX_TOTAL_UNCOMPRESSED} bytes");
+        }
+        // unpack_in is documented to refuse paths that escape `dest` (returns
+        // Ok(false) and skips), giving zip-slip protection for tar.
+        let unpacked = entry
+            .unpack_in(dest)
+            .map_err(|e| anyhow::anyhow!("unpack tar entry: {e}"))?;
+        if !unpacked {
+            bail!("unsafe path in archive (refused by unpack_in)");
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core skill_bundle::tests::extract_`
+Expected: PASS (both tests). (If `tempfile`/`zip`/`tar`/`flate2` aren't already dev-available, they are normal deps — confirm `use` paths compile.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/skill_bundle.rs
+git commit -m "feat(skill): zip-slip + zip-bomb-safe archive extraction (zip + tar.gz)"
+```
+
+---
+
+## Task 3: Skill discovery (mur-core, network-free)
+
+**Files:** Modify `mur-core/src/cmd/agent/skill_bundle.rs`.
+
+**Interfaces:**
+- Produces: `pub fn discover_skills(dir: &Path) -> Vec<PathBuf>` — every file under `dir` that parses as a skill (`.yaml`/`.yml` via `parse_canonical`, `.md`/`.markdown` via `parse_markdown`), sorted for determinism.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn discovers_nested_skills_and_ignores_non_skills() {
+    let dir = tempfile::tempdir().unwrap();
+    let valid = "name: a\nversion: 1.0.0\npublisher: human:test\ndescription: d\ncategory: context\ncontent:\n  abstract: x\n  context: y\n";
+    std::fs::create_dir_all(dir.path().join("sub")).unwrap();
+    std::fs::write(dir.path().join("sub/skill.yaml"), valid).unwrap();
+    std::fs::write(dir.path().join("README.md"), "# just docs, not a skill").unwrap();
+    let found = discover_skills(dir.path());
+    assert_eq!(found.len(), 1);
+    assert!(found[0].ends_with("sub/skill.yaml"));
+}
+```
+
+(Adjust the `valid` fixture to a minimal manifest that the real schema accepts — confirm required fields in `mur-common/src/skill/`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core skill_bundle::tests::discovers_nested`
+Expected: FAIL — `discover_skills` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+/// Walk `dir` recursively; return paths to every file that parses as a skill.
+/// Non-skill files (READMEs, licenses, assets) are silently ignored.
+pub fn discover_skills(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    walk_skills(dir, &mut out);
+    out.sort();
+    out
+}
+
+fn walk_skills(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(rd) = std::fs::read_dir(dir) else { return };
+    for ent in rd.flatten() {
+        let p = ent.path();
+        if p.is_dir() {
+            walk_skills(&p, out);
+        } else if file_parses_as_skill(&p) {
+            out.push(p);
+        }
+    }
+}
+
+fn file_parses_as_skill(path: &Path) -> bool {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let Ok(text) = std::fs::read_to_string(path) else { return false };
+    match ext.as_str() {
+        "yaml" | "yml" => mur_common::skill::parse_canonical(&text).is_ok(),
+        "md" | "markdown" => mur_common::skill::parse_markdown(&text).is_ok(),
+        _ => false,
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core skill_bundle::tests::discovers_nested`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/skill_bundle.rs
+git commit -m "feat(skill): discover_skills walks an extracted bundle"
+```
+
+---
+
+## Task 4: Bundle preview + install (mur-core)
+
+**Files:** Modify `mur-core/src/cmd/agent/skill_bundle.rs`.
+
+**Interfaces:**
+- Consumes: Tasks 1-3; `skill_remote::{SkillPreview, preview_skill_text, SKILL_MAX_BYTES, validate_skill_url}`; `cmd::agent::skill::cmd_skill_add`.
+- Produces:
+  - `pub async fn fetch_bundle(url: &str, kind: ArchiveKind) -> Result<Vec<u8>>` (size-capped download).
+  - `pub async fn preview_bundle_url(url: &str) -> Result<Vec<SkillPreview>>` — extract → discover → preview each. Installs nothing.
+  - `pub async fn install_bundle_from_url(agent: &str, url: &str, accept_findings: bool) -> Result<Vec<String>>` — installs clean skills; blocked skills only with `accept_findings`. Returns installed ids.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn extract_then_discover_then_preview_is_consistent() {
+    // Build a tar.gz with one clean skill, extract, discover, preview.
+    use std::io::Write;
+    let skill = "name: packed\nversion: 1.0.0\npublisher: human:test\ndescription: d\ncategory: context\ncontent:\n  abstract: x\n  context: y\n";
+    let mut tarb = Vec::new();
+    {
+        let mut b = tar::Builder::new(&mut tarb);
+        let mut h = tar::Header::new_gnu();
+        h.set_size(skill.len() as u64); h.set_mode(0o644); h.set_cksum();
+        b.append_data(&mut h, "skill.yaml", skill.as_bytes()).unwrap();
+        b.finish().unwrap();
+    }
+    let mut gz = Vec::new();
+    { use flate2::{Compression, write::GzEncoder}; let mut e = GzEncoder::new(&mut gz, Compression::default()); e.write_all(&tarb).unwrap(); e.finish().unwrap(); }
+    let dir = tempfile::tempdir().unwrap();
+    extract_archive(&gz, ArchiveKind::TarGz, dir.path()).unwrap();
+    let skills = discover_skills(dir.path());
+    assert_eq!(skills.len(), 1);
+    let text = std::fs::read_to_string(&skills[0]).unwrap();
+    let p = crate::cmd::agent::skill_remote::preview_skill_text(&text, false).unwrap();
+    assert_eq!(p.name, "packed");
+    assert!(!p.blocking);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core skill_bundle::tests::extract_then_discover`
+Expected: FAIL until the module compiles with the new fns (the test itself uses only Tasks 1-3 + preview_skill_text; it pins the pipeline).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```rust
+use crate::cmd::agent::skill_remote::{SkillPreview, preview_skill_text};
+
+/// Download an archive, size-capped (Content-Length pre-check + post-download).
+pub async fn fetch_bundle(url: &str, _kind: ArchiveKind) -> Result<Vec<u8>> {
+    let url = crate::cmd::agent::skill_remote::validate_skill_url(url)?;
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(20))
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("fetch failed: {e}"))?;
+    if !resp.status().is_success() {
+        bail!("server returned {}", resp.status());
+    }
+    if let Some(len) = resp.content_length()
+        && len > BUNDLE_MAX_BYTES as u64
+    {
+        bail!("bundle too large ({len} bytes; max {BUNDLE_MAX_BYTES})");
+    }
+    let bytes = resp.bytes().await.map_err(|e| anyhow::anyhow!("read body: {e}"))?;
+    if bytes.len() > BUNDLE_MAX_BYTES {
+        bail!("bundle too large ({} bytes; max {BUNDLE_MAX_BYTES})", bytes.len());
+    }
+    Ok(bytes.to_vec())
+}
+
+fn is_md_path(p: &Path) -> bool {
+    matches!(
+        p.extension().and_then(|e| e.to_str()).unwrap_or("").to_ascii_lowercase().as_str(),
+        "md" | "markdown"
+    )
+}
+
+/// Fetch + extract + discover + preview every skill in a bundle. Installs nothing.
+pub async fn preview_bundle_url(url: &str) -> Result<Vec<SkillPreview>> {
+    let kind = is_archive_url(url).ok_or_else(|| anyhow::anyhow!("not a supported archive URL"))?;
+    let bytes = fetch_bundle(url, kind).await?;
+    let tmp = tempdir_unique("mur-bundle")?;
+    extract_archive(&bytes, kind, &tmp)?;
+    let paths = discover_skills(&tmp);
+    if paths.is_empty() {
+        let _ = std::fs::remove_dir_all(&tmp);
+        bail!("no skills found in bundle");
+    }
+    let mut previews = Vec::new();
+    for p in &paths {
+        if let Ok(text) = std::fs::read_to_string(p) {
+            match preview_skill_text(&text, is_md_path(p)) {
+                Ok(pv) => previews.push(pv),
+                Err(_) => { /* skip non-conforming file already filtered by discover */ }
+            }
+        }
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+    Ok(previews)
+}
+
+/// Fetch + extract + discover + install. Clean skills always install; skills with
+/// blocking findings install only when `accept_findings` is true. Returns ids.
+pub async fn install_bundle_from_url(
+    agent: &str,
+    url: &str,
+    accept_findings: bool,
+) -> Result<Vec<String>> {
+    let kind = is_archive_url(url).ok_or_else(|| anyhow::anyhow!("not a supported archive URL"))?;
+    let bytes = fetch_bundle(url, kind).await?;
+    let tmp = tempdir_unique("mur-bundle")?;
+    let run = (|| -> Result<Vec<String>> {
+        extract_archive(&bytes, kind, &tmp)?;
+        let paths = discover_skills(&tmp);
+        if paths.is_empty() {
+            bail!("no skills found in bundle");
+        }
+        let mut installed = Vec::new();
+        for p in &paths {
+            let text = std::fs::read_to_string(p)
+                .map_err(|e| anyhow::anyhow!("read {}: {e}", p.display()))?;
+            let pv = preview_skill_text(&text, is_md_path(p))?;
+            if pv.blocking && !accept_findings {
+                continue; // fail-closed: skip flagged skills unless accepted
+            }
+            crate::cmd::agent::skill::cmd_skill_add(agent, &p.to_string_lossy())?;
+            installed.push(format!("skills/{}", pv.name));
+        }
+        Ok(installed)
+    })();
+    let _ = std::fs::remove_dir_all(&tmp);
+    run
+}
+
+/// Create a unique temp directory; caller removes it.
+fn tempdir_unique(prefix: &str) -> Result<PathBuf> {
+    let dir = std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()));
+    if dir.exists() {
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+    std::fs::create_dir_all(&dir).map_err(|e| anyhow::anyhow!("mkdir temp: {e}"))?;
+    Ok(dir)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core skill_bundle -- --nocapture`
+Expected: PASS (all skill_bundle tests). Then `cargo clippy -p mur-core -- -D warnings` clean; `cargo fmt --all`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/skill_bundle.rs
+git commit -m "feat(skill): bundle fetch + preview + fail-closed install"
+```
+
+---
+
+## Task 5: Route archives + unified helpers (mur-core)
+
+**Files:** Modify `mur-core/src/cmd/agent/skill_remote.rs`.
+
+**Interfaces:**
+- Produces:
+  - `pub async fn preview_any_url(url: &str) -> Result<Vec<SkillPreview>>` — bundle → `preview_bundle_url`; else `vec![preview_skill_url]`.
+  - `pub async fn install_any_url(agent: &str, url: &str, accept_findings: bool) -> Result<Vec<String>>` — bundle → `install_bundle_from_url`; else `vec![install_skill_from_url]`.
+- Modifies: `install_skill_from_url` gains a front-door so the CLI transparently routes archives.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn archive_urls_route_to_bundle() {
+    use crate::cmd::agent::skill_bundle::{ArchiveKind, is_archive_url};
+    assert!(matches!(is_archive_url("https://x/p.zip"), Some(ArchiveKind::Zip)));
+    assert!(is_archive_url("https://x/skill.yaml").is_none());
+    // (preview_any_url/install_any_url routing is exercised by the bundle tests +
+    // the gated network test; this asserts the discriminator the router uses.)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core skill_remote::tests::archive_urls_route`
+Expected: FAIL — import path not yet valid until the helpers + use exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `skill_remote.rs`, at the top of `install_skill_from_url` (before `fetch_skill`):
+
+```rust
+    if let Some(_kind) = crate::cmd::agent::skill_bundle::is_archive_url(url) {
+        let ids = crate::cmd::agent::skill_bundle::install_bundle_from_url(agent, url, accept_findings).await?;
+        return Ok(ids.join(", "));
+    }
+```
+
+Add the unified helpers (used by the Hub):
+
+```rust
+/// Preview a URL whether it's a single skill or an archive of many. Returns one
+/// preview per skill (length 1 for a single skill).
+pub async fn preview_any_url(url: &str) -> Result<Vec<SkillPreview>> {
+    if crate::cmd::agent::skill_bundle::is_archive_url(url).is_some() {
+        crate::cmd::agent::skill_bundle::preview_bundle_url(url).await
+    } else {
+        Ok(vec![preview_skill_url(url).await?])
+    }
+}
+
+/// Install a single skill or a bundle of many. Returns the installed skill ids.
+pub async fn install_any_url(agent: &str, url: &str, accept_findings: bool) -> Result<Vec<String>> {
+    if crate::cmd::agent::skill_bundle::is_archive_url(url).is_some() {
+        crate::cmd::agent::skill_bundle::install_bundle_from_url(agent, url, accept_findings).await
+    } else {
+        Ok(vec![install_skill_from_url(agent, url, accept_findings).await?])
+    }
+}
+```
+
+- [ ] **Step 4: Run test + build to verify**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core skill_remote:: -- --nocapture` then `cargo clippy -p mur-core -- -D warnings` and `cargo fmt --all`.
+Expected: tests PASS; clippy clean. (CLI `mur agent skill add-url <agent> <archive-url>` now installs bundles via the front-door — the dispatch already prints the returned string; for a bundle it lists the joined ids.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/skill_remote.rs
+git commit -m "feat(skill): route archive URLs to bundle install + preview_any/install_any"
+```
+
+---
+
+## Task 6: Hub commands return a skill list (Hub backend)
+
+**Files:** Modify `mur-hub-gui/src-tauri/src/mcp_skills.rs`, `lib.rs` (registration is unchanged — same command names).
+
+**Interfaces:**
+- Changes `agent_skill_preview_url` → `Result<Vec<SkillPreview>, String>`.
+- Changes `agent_skill_install_url` → `Result<BundleInstallResult, String>` where `pub struct BundleInstallResult { detail: AgentDetail, installed_ids: Vec<String> }`.
+- Consumes: Task 5 `preview_any_url`, `install_any_url`.
+
+- [ ] **Step 1: Edit the commands**
+
+```rust
+use mur_core::cmd::agent::skill_remote::{SkillPreview, install_any_url, preview_any_url};
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BundleInstallResult {
+    pub detail: AgentDetail,
+    pub installed_ids: Vec<String>,
+}
+
+/// Fetch + parse + scan a skill URL (single skill or archive of many). Installs
+/// nothing. Returns one preview per discovered skill.
+#[tauri::command]
+pub async fn agent_skill_preview_url(url: String) -> Result<Vec<SkillPreview>, String> {
+    preview_any_url(&url).await.map_err(|e| format!("{e:#}"))
+}
+
+/// Install a skill or bundle from a URL. `accept_findings` gates skills with
+/// blocking scan findings (clean skills install regardless).
+#[tauri::command]
+pub async fn agent_skill_install_url(
+    name: String,
+    url: String,
+    accept_findings: bool,
+) -> Result<BundleInstallResult, String> {
+    let installed_ids = install_any_url(&name, &url, accept_findings)
+        .await
+        .map_err(|e| format!("{e:#}"))?;
+    let detail = get_agent_detail(name)?;
+    Ok(BundleInstallResult { detail, installed_ids })
+}
+```
+
+(Remove the now-unused single-`SkillPreview` import if the compiler flags it; keep `SkillPreview` since the return type uses it.)
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `ORT_STRATEGY=download CARGO_TARGET_DIR=/Volumes/Firecuda4tb/Projects/mur/mur-hub-gui/src-tauri/target cargo check --manifest-path mur-hub-gui/src-tauri/Cargo.toml`
+Expected: compiles (stub `mur-hub-gui/ui/dist/index.html` if needed; don't commit it).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mur-hub-gui/src-tauri/src/mcp_skills.rs mur-hub-gui/src-tauri/src/lib.rs
+git commit -m "feat(hub): skill preview/install URL return a list (single or bundle)"
+```
+
+---
+
+## Task 7: Modal renders the skill list (Hub UI)
+
+**Files:** Modify `mur-hub-gui/ui/src/components/SkillAddUrlModal.tsx`; i18n in `en.ts`/`zh-TW.ts`.
+
+**Interfaces:** Consumes `agent_skill_preview_url` (now `SkillPreview[]`) and `agent_skill_install_url` (now `{ detail, installed_ids }`).
+
+- [ ] **Step 1: Update the component**
+
+Change the preview state to a list and render each skill. Replace the single-preview block with:
+
+```tsx
+  const [previews, setPreviews] = useState<SkillPreview[] | null>(null);
+  const [accept, setAccept] = useState(false);
+  // ...
+  async function fetchPreview() {
+    setError(null); setPreviews(null); setAccept(false);
+    const trimmed = url.trim();
+    if (!(trimmed.startsWith("https://") || trimmed.startsWith("http://localhost") || trimmed.startsWith("http://127.0.0.1") || trimmed.startsWith("http://[::1]"))) {
+      setError(t("skillurl.invalidUrl")); return;
+    }
+    setBusy("fetch");
+    try { setPreviews(await invoke<SkillPreview[]>("agent_skill_preview_url", { url: trimmed })); }
+    catch (e) { setError(String(e)); } finally { setBusy(null); }
+  }
+  async function install() {
+    setError(null); setBusy("install");
+    try {
+      const res = await invoke<{ detail: AgentDetail; installed_ids: string[] }>(
+        "agent_skill_install_url",
+        { name: agentName, url: url.trim(), acceptFindings: accept },
+      );
+      onSaved(res.detail);
+      onClose();
+    } catch (e) { setError(String(e)); } finally { setBusy(null); }
+  }
+  const anyBlocking = !!previews && previews.some((p) => p.blocking);
+  const canInstall = !!previews && previews.length > 0 && busy === null && (!anyBlocking || accept);
+```
+
+Render the list (replacing the single-skill block):
+
+```tsx
+          {previews && previews.map((p, i) => (
+            <div key={i} className="item-card" style={{ marginTop: 8 }}>
+              <div className="item-card-name">{p.name} <span className="badge-sm">{p.category}</span></div>
+              <code className="item-card-code">{p.description}</code>
+              {p.findings.length > 0 && (
+                <ul className="item-list">
+                  {p.findings.map((f, j) => (<li key={j} className="save-error">{f}</li>))}
+                </ul>
+              )}
+              <pre className="item-card-code" style={{ whiteSpace: "pre-wrap", maxHeight: 160, overflow: "auto" }}>{p.body}</pre>
+            </div>
+          ))}
+          {anyBlocking && (
+            <label style={{ display: "block", marginTop: 6 }}>
+              <input type="checkbox" checked={accept} onChange={(e) => setAccept(e.target.checked)} />{" "}
+              {t("skillurl.accept")}
+            </label>
+          )}
+```
+
+- [ ] **Step 2: i18n**
+
+In both `en.ts` and `zh-TW.ts`, the existing `skillurl.*` keys still apply; add `skillurl.bundleHint` (en: "An archive may contain several skills — review each below."; zh-TW: "壓縮檔可能包含多個技能 — 請逐一檢視。") and show it when `previews && previews.length > 1`.
+
+- [ ] **Step 3: Typecheck + build**
+
+Run: `cd mur-hub-gui/ui && npx tsc --noEmit && npm run build`
+Expected: tsc exit 0; vite build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-hub-gui/ui/src/components/SkillAddUrlModal.tsx mur-hub-gui/ui/src/i18n/en.ts mur-hub-gui/ui/src/i18n/zh-TW.ts
+git commit -m "feat(hub): skill-add modal renders a list (single skill or bundle)"
+```
+
+- [ ] **Step 5: Live verify (manual)**
+
+Rebuild + install the Hub (`gotcha_hub_local_app_build_recipe`). Serve a 2-skill `.tar.gz` + a `.zip` with one clean + one injection skill over `http://127.0.0.1`. In the Hub Skills tab → Install from URL → paste each archive URL → confirm the list renders all skills; the injection one shows findings + the install is gated until the accept checkbox is ticked; clean ones install.
+
+---
+
+## Self-Review
+
+**Spec coverage:** archive formats (.zip + .tar.gz/.tgz) → Task 1 ✓; safe extraction (zip-slip + caps) → Task 2 ✓; discover 1+ skills any depth → Task 3 ✓; fetch size-cap + preview + fail-closed install → Task 4 ✓; route archives in install_skill_from_url + unified preview/install → Task 5 ✓; Hub list-returning commands → Task 6 ✓; multi-skill consent UI → Task 7 ✓. Resolves quill P1 §10a confusing-`.zip` (now installs). Non-goals (signing, assets, registry) excluded.
+
+**Placeholder scan:** Two implementer-notes point at exact existing files to confirm against (the discover-test fixture schema; removing an unused import) — both name the file. No "TBD/handle errors/add validation" placeholders.
+
+**Type consistency:** `ArchiveKind`/`is_archive_url`/caps (Task 1) consumed in Tasks 2,4,5. `extract_archive(bytes, kind, dest)` (Task 2) called in Task 4. `discover_skills(dir) -> Vec<PathBuf>` (Task 3) used in Task 4. `preview_bundle_url -> Vec<SkillPreview>` + `install_bundle_from_url -> Vec<String>` (Task 4) wrapped by `preview_any_url`/`install_any_url` (Task 5), surfaced by the Hub commands (Task 6, `Vec<SkillPreview>` / `BundleInstallResult { detail, installed_ids }`), consumed by the modal (Task 7, `SkillPreview[]` / `{ detail, installed_ids }`). `acceptFindings`→`accept_findings` camelCase mapping consistent with quill P1.

--- a/docs/superpowers/specs/2026-06-28-quill-skill-bundles-design.md
+++ b/docs/superpowers/specs/2026-06-28-quill-skill-bundles-design.md
@@ -1,0 +1,91 @@
+# Quill skill bundles — install a skill pack (.zip / .tar.gz) by URL
+
+**Status:** Design / spec
+**Date:** 2026-06-28
+**Builds on:** quill P1 (install a single skill by URL — `mur-core/src/cmd/agent/skill_remote.rs`, the Hub Install-from-URL modal). This adds **archive** support.
+
+---
+
+## 1. Problem
+
+quill P1 installs a single raw skill (`skill.yaml`/`.md`) from a URL. Users also have skills packaged as archives — a single zipped skill or a **pack of several skills**. P1 falls through to the YAML parser on a `.zip`/`.tar.gz` and fails with a confusing "not a valid skill manifest." This adds first-class archive support.
+
+MUR skills are **single-file** (`skill.yaml`/`.md`; the model has no asset attachments), so a bundle is meaningfully **one-or-more skills in an archive**, not a single skill plus loose files.
+
+## 2. Decisions (from brainstorming)
+
+- **Formats:** `.zip` AND `.tar.gz`/`.tgz` (both dependency sets already present — see §4).
+- **Contents:** an archive holds **one or more** skill manifests (`skill.yaml`/`.md`, any subdirectory depth). quill discovers all, scans + validates each, and installs the **clean** ones; skills with blocking findings install only on explicit acceptance (fail-closed).
+
+## 3. What MUR already has (reuse map)
+
+| Capability | Existing primitive | Location |
+|---|---|---|
+| Single-skill fetch/preview/install (https, size-cap, scan, fail-closed) | quill P1 `skill_remote::{validate_skill_url, fetch_*, preview_skill_text, install_skill_from_url}` | `mur-core/src/cmd/agent/skill_remote.rs` |
+| Skill scan (executable + injection) | `scan_skill` / `ContentScanReport` | `mur-common/src/skill/scan/` |
+| Parse `.yaml`/`.md` → manifest | `parse_canonical` / `parse_markdown` | `mur-common/src/skill/parser.rs` |
+| Per-skill install (validate + scan + write + register) | `cmd_skill_add(agent, path)` | `mur-core/src/cmd/agent/skill.rs` |
+| tar.gz **safe extraction** (zip-slip protection pattern) | `.muragent` `extract_payload`, `.fleet` import | `mur-common/src/muragent/installer.rs`, `mur-core/src/cmd/fleet/import.rs` |
+| Archive deps | `tar`+`flate2` (mur-common & mur-core); `zip` v2 (mur-core) | Cargo.toml |
+| Hub Install-from-URL modal | `SkillAddUrlModal` | `mur-hub-gui/ui/src/components` |
+
+**Conclusion:** new code = archive detection + safe extraction + a multi-skill discover/preview/install layer over quill P1's per-skill primitives + a multi-skill consent UI. No new on-disk skill format.
+
+## 4. Design
+
+### 4.1 mur-core — `skill_bundle.rs` (new, sibling of `skill_remote.rs`)
+
+- `fn is_archive_url(url) -> Option<ArchiveKind>` — `.zip` → `Zip`; `.tar.gz`/`.tgz` → `TarGz`; else `None`.
+- `const BUNDLE_MAX_BYTES`, `const BUNDLE_MAX_ENTRIES`, `const BUNDLE_MAX_TOTAL_UNCOMPRESSED` — named caps (no literals).
+- `fn extract_archive(bytes: &[u8], kind: ArchiveKind, dest: &Path) -> Result<()>` — **path-traversal-safe**: reject entries whose normalized path escapes `dest` (contains `..` or is absolute) or are symlinks; enforce entry-count + per-file + total-uncompressed caps (zip-bomb guard). For `TarGz` reuse the muragent extraction approach; for `Zip` mirror it with the `zip` crate.
+- `fn discover_skills(dir: &Path) -> Vec<PathBuf>` — walk `dir`; return every file that parses as a skill (`skill.yaml`/`*.yaml` via `parse_canonical`, `*.md` via `parse_markdown`). Non-skill files are ignored (bundle may carry a README/LICENSE).
+- `struct BundlePreview { skills: Vec<SkillPreview>, errors: Vec<String> }` (reuses quill P1's `SkillPreview { name, description, category, body, blocking, findings }`).
+- `async fn preview_bundle_url(url) -> Result<BundlePreview>` — validate https → download (size-capped) → extract to a temp dir → discover → `preview_skill_text` each → return all previews (+ any per-file parse errors). Installs nothing.
+- `async fn install_bundle_from_url(agent, url, accept_findings: bool) -> Result<Vec<String>>` — preview; if any skill is `blocking` and `!accept_findings`, **skip those** (do not install) and install the rest; with `accept_findings` install all. Each install reuses the per-skill path (`cmd_skill_add` on the extracted file). Returns the installed ids. Temp dir cleaned up always.
+
+### 4.2 mur-core — route archive URLs
+
+`install_skill_from_url` (P1) gains a front-door check: if `is_archive_url(url).is_some()`, delegate to `install_bundle_from_url`. So CLI `skill add-url` and the Hub both transparently handle archives. (A genuinely unsupported archive type — e.g. `.rar` — still gets the clear "not a valid skill manifest / unsupported" error; the confusing-`.zip` case from quill P1 §10a is now resolved by actually supporting it.)
+
+### 4.3 Hub
+
+- Tauri: `agent_skill_preview_url` returns either a single preview or a bundle preview — cleanest is a new `agent_skill_preview_bundle_url`/`agent_skill_install_bundle_url`, OR a unified `agent_skill_preview_any(url)` returning `{ kind: "single"|"bundle", skills: [SkillPreview] }`. **Chosen:** unify — preview returns a `Vec<SkillPreview>` (length 1 for a single skill), so the modal has one code path.
+- `SkillAddUrlModal`: after Fetch, render the **list** of discovered skills, each with name/description + its findings; a single "install the N flagged skills anyway" checkbox gates the flagged ones; clean skills always install. Title/labels generalize from "skill" to "skill(s)".
+
+### 4.4 CLI
+
+`mur agent skill add-url <agent> <url> [--yes]` already routes through `install_skill_from_url`; with §4.2 it transparently installs archives too. Output lists each installed skill id.
+
+## 5. Security model
+
+- **Safe extraction is the new attack surface:** reject path-traversal (`..`/absolute/symlink entries), enforce entry-count + per-file + total-uncompressed caps (zip-bomb), https-only download, size-capped. Extraction happens in MUR's trusted control plane to a temp dir, never inside a sandboxed agent.
+- Every discovered manifest is scanned (`scan_skill`); **fail-closed** per skill (flagged ones need explicit accept).
+- Consent shows each skill's body + findings.
+- Cryptographic bundle **signing** (à la `.muragent`) is out of scope here — deferred; trust rests on scan + consent.
+
+## 6. Error handling
+
+- Unsupported archive type / not an archive and not a skill → clear error.
+- Corrupt archive, traversal/cap violation → abort, temp dir discarded, nothing installed.
+- Zero skills found in the archive → clear "no skills found in bundle."
+- Mixed valid/invalid entries → install the valid clean ones; report the invalid ones in `errors` (don't fail the whole bundle).
+- Duplicate skill id (already installed) → existing `cmd_skill_add` behavior.
+
+## 7. Testing
+
+- Unit (network-free): `is_archive_url` extension detection; `extract_archive` rejects `../escape`, absolute paths, symlinks, and over-cap archives (build small in-memory zip + tar.gz fixtures); `discover_skills` finds nested skill.yaml/.md and ignores non-skills; `BundlePreview` aggregates findings; `install_bundle_from_url` skips flagged-without-accept and installs clean (temp-dir fixture).
+- Gated `#[ignore]` network test against a real archive URL.
+- Hub: modal renders a multi-skill list; flagged-gate works.
+- Manual/live: install a 2-skill `.zip` (both clean → both install); a `.tar.gz` with one clean + one injection skill (clean installs, injection gated); a zip-slip archive (rejected).
+
+## 8. Non-goals
+
+- Cryptographic bundle signing/verification (later).
+- Skill *assets* (MUR skills are single-file).
+- Auto-update of installed bundles.
+- A skill registry (that is quill P2).
+
+## 9. Open questions
+
+- Per-skill accept vs one "install all flagged" checkbox? (Lean: one checkbox — simpler; revisit if users want granular control.)
+- Cap values for `BUNDLE_MAX_*` — pick conservative defaults (e.g. 5 MiB download, 256 entries, 32 MiB total uncompressed) and make them constants.

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -51,6 +51,7 @@ mod restart;
 mod secret;
 mod service;
 pub mod skill;
+pub mod skill_bundle;
 pub mod skill_remote;
 mod snapshot;
 pub mod stale;

--- a/mur-core/src/cmd/agent/skill_bundle.rs
+++ b/mur-core/src/cmd/agent/skill_bundle.rs
@@ -1,0 +1,416 @@
+//! Skill bundle installation — archive detection, safe extraction, discovery,
+//! and bundle preview/install built on quill P1's per-skill primitives. Safely
+//! extracts .zip and .tar.gz bundles, discovers every skill manifest, scans
+//! each, and installs clean ones via quill P1's per-skill path. Built on
+//! `skill_remote`.
+
+use anyhow::{Result, bail};
+use std::path::{Path, PathBuf};
+
+use super::skill_remote::{SkillPreview, preview_skill_text};
+
+/// Supported skill-bundle archive formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArchiveKind {
+    Zip,
+    TarGz,
+}
+
+/// Max bytes downloaded for a bundle archive.
+pub const BUNDLE_MAX_BYTES: usize = 5 * 1024 * 1024;
+/// Max number of entries an archive may contain.
+pub const BUNDLE_MAX_ENTRIES: usize = 256;
+/// Max total uncompressed bytes written during extraction (zip-bomb guard).
+pub const BUNDLE_MAX_TOTAL_UNCOMPRESSED: u64 = 32 * 1024 * 1024;
+
+/// HTTP request timeout for fetching a remote bundle.
+const BUNDLE_FETCH_TIMEOUT_SECS: u64 = 30;
+
+/// Classify a URL by archive extension. Returns `None` if not an archive we handle.
+pub fn is_archive_url(url: &str) -> Option<ArchiveKind> {
+    let path = reqwest::Url::parse(url).ok()?.path().to_ascii_lowercase();
+    if path.ends_with(".zip") {
+        Some(ArchiveKind::Zip)
+    } else if path.ends_with(".tar.gz") || path.ends_with(".tgz") {
+        Some(ArchiveKind::TarGz)
+    } else {
+        None
+    }
+}
+
+/// Extract `bytes` (`kind` archive) into `dest`, safely. Rejects entries that
+/// would escape `dest` (`..`/absolute), symlinks, and archives exceeding the
+/// entry or total-uncompressed caps.
+pub fn extract_archive(bytes: &[u8], kind: ArchiveKind, dest: &Path) -> Result<()> {
+    match kind {
+        ArchiveKind::Zip => extract_zip(bytes, dest),
+        ArchiveKind::TarGz => extract_targz(bytes, dest),
+    }
+}
+
+fn extract_zip(bytes: &[u8], dest: &Path) -> Result<()> {
+    use std::io::Read;
+    let cursor = std::io::Cursor::new(bytes);
+    let mut zip = zip::ZipArchive::new(cursor).map_err(|e| anyhow::anyhow!("open zip: {e}"))?;
+    let count = zip.len();
+    if count > BUNDLE_MAX_ENTRIES {
+        bail!("archive has too many entries (> {BUNDLE_MAX_ENTRIES})");
+    }
+    let mut total: u64 = 0;
+    for i in 0..count {
+        let mut entry = zip
+            .by_index(i)
+            .map_err(|e| anyhow::anyhow!("zip entry {i}: {e}"))?;
+        // Skip directories.
+        if entry.is_dir() {
+            continue;
+        }
+        // Zip-slip guard: enclosed_name() returns None for unsafe paths.
+        let rel = match entry.enclosed_name() {
+            Some(p) => p,
+            None => continue,
+        };
+        // Bomb guard.
+        total = total.saturating_add(entry.size());
+        if total > BUNDLE_MAX_TOTAL_UNCOMPRESSED {
+            bail!("archive uncompressed size exceeds {BUNDLE_MAX_TOTAL_UNCOMPRESSED} bytes");
+        }
+        let out = dest.join(&rel);
+        if let Some(parent) = out.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| anyhow::anyhow!("mkdir: {e}"))?;
+        }
+        let mut data = Vec::new();
+        entry
+            .read_to_end(&mut data)
+            .map_err(|e| anyhow::anyhow!("read entry: {e}"))?;
+        std::fs::write(&out, &data).map_err(|e| anyhow::anyhow!("write {}: {e}", out.display()))?;
+    }
+    Ok(())
+}
+
+fn extract_targz(bytes: &[u8], dest: &Path) -> Result<()> {
+    let gz = flate2::read::GzDecoder::new(std::io::Cursor::new(bytes));
+    let mut ar = tar::Archive::new(gz);
+    let mut count = 0usize;
+    let mut total: u64 = 0;
+    for entry in ar.entries().map_err(|e| anyhow::anyhow!("read tar: {e}"))? {
+        let mut entry = entry.map_err(|e| anyhow::anyhow!("tar entry: {e}"))?;
+        // Skip non-regular files (symlinks, hardlinks, devices) — defense.
+        if entry.header().entry_type() != tar::EntryType::Regular {
+            continue;
+        }
+        count += 1;
+        if count > BUNDLE_MAX_ENTRIES {
+            bail!("archive has too many entries (> {BUNDLE_MAX_ENTRIES})");
+        }
+        total = total.saturating_add(entry.size());
+        if total > BUNDLE_MAX_TOTAL_UNCOMPRESSED {
+            bail!("archive uncompressed size exceeds {BUNDLE_MAX_TOTAL_UNCOMPRESSED} bytes");
+        }
+        // unpack_in is documented to refuse paths that escape `dest` (returns
+        // Ok(false) and skips), giving zip-slip protection for tar.
+        let _unpacked = entry
+            .unpack_in(dest)
+            .map_err(|e| anyhow::anyhow!("unpack: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Walk `dir` recursively; return paths that parse as a valid skill manifest.
+/// Non-skill files (READMEs, licenses, assets) are silently ignored.
+pub fn discover_skills(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    walk_skills(dir, &mut out);
+    out.sort();
+    out
+}
+
+fn walk_skills(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for ent in rd.flatten() {
+        let p = ent.path();
+        if p.is_dir() {
+            walk_skills(&p, out);
+        } else if is_candidate_skill_file(&p)
+            && let Ok(text) = std::fs::read_to_string(&p)
+        {
+            let parses = if is_md_path(&p) {
+                mur_common::skill::parse_markdown(&text).is_ok()
+            } else {
+                mur_common::skill::parse_canonical(&text).is_ok()
+            };
+            if parses {
+                out.push(p);
+            }
+        }
+    }
+}
+
+fn is_candidate_skill_file(p: &Path) -> bool {
+    matches!(
+        p.extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase()
+            .as_str(),
+        "yaml" | "yml" | "md" | "markdown"
+    )
+}
+
+fn is_md_path(p: &Path) -> bool {
+    matches!(
+        p.extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase()
+            .as_str(),
+        "md" | "markdown"
+    )
+}
+
+/// Download a bundle archive, size-capped at [`BUNDLE_MAX_BYTES`].
+pub async fn fetch_bundle(url: &str, _kind: ArchiveKind) -> Result<Vec<u8>> {
+    let url = super::skill_remote::validate_skill_url(url)?;
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(BUNDLE_FETCH_TIMEOUT_SECS))
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("fetch {url}: {e}"))?;
+    if !resp.status().is_success() {
+        bail!("fetch {url}: HTTP {}", resp.status());
+    }
+    if let Some(len) = resp.content_length()
+        && len > BUNDLE_MAX_BYTES as u64
+    {
+        bail!("bundle too large ({len} bytes; max {BUNDLE_MAX_BYTES})");
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| anyhow::anyhow!("read body: {e}"))?;
+    if bytes.len() > BUNDLE_MAX_BYTES {
+        bail!(
+            "bundle too large ({} bytes; max {BUNDLE_MAX_BYTES})",
+            bytes.len()
+        );
+    }
+    Ok(bytes.to_vec())
+}
+
+/// Fetch + extract + discover + preview each skill in a bundle. Installs nothing.
+pub async fn preview_bundle_url(url: &str) -> Result<Vec<SkillPreview>> {
+    let kind = is_archive_url(url).ok_or_else(|| anyhow::anyhow!("not a supported archive URL"))?;
+    let bytes = fetch_bundle(url, kind).await?;
+    let tmp = tempdir_unique("mur-bundle")?;
+    extract_archive(&bytes, kind, &tmp)?;
+    let paths = discover_skills(&tmp);
+    if paths.is_empty() {
+        let _ = std::fs::remove_dir_all(&tmp);
+        bail!("no skills found in bundle");
+    }
+    let mut previews = Vec::new();
+    for p in &paths {
+        if let Ok(text) = std::fs::read_to_string(p) {
+            match preview_skill_text(&text, is_md_path(p)) {
+                Ok(pv) => previews.push(pv),
+                Err(_) => { /* skip non-conforming file already filtered by discover */ }
+            }
+        }
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+    Ok(previews)
+}
+
+/// Fetch + extract + discover + install. Clean skills always install; skills
+/// with blocking findings install only if `accept_findings` is true.
+/// Returns installed skill ids (`skills/<name>`).
+pub async fn install_bundle_from_url(
+    agent: &str,
+    url: &str,
+    accept_findings: bool,
+) -> Result<Vec<String>> {
+    let kind = is_archive_url(url).ok_or_else(|| anyhow::anyhow!("not a supported archive URL"))?;
+    let bytes = fetch_bundle(url, kind).await?;
+    let tmp = tempdir_unique("mur-bundle")?;
+    extract_archive(&bytes, kind, &tmp)?;
+    let paths = discover_skills(&tmp);
+    if paths.is_empty() {
+        let _ = std::fs::remove_dir_all(&tmp);
+        bail!("no skills found in bundle");
+    }
+    let mut installed = Vec::new();
+    for p in &paths {
+        if let Ok(text) = std::fs::read_to_string(p) {
+            let preview = match preview_skill_text(&text, is_md_path(p)) {
+                Ok(pv) => pv,
+                Err(_) => continue,
+            };
+            // Fail-closed: skip skills with blocking findings unless accepted.
+            if preview.blocking && !accept_findings {
+                continue;
+            }
+            let ext = if is_md_path(p) { "md" } else { "yaml" };
+            let safe: String = preview
+                .name
+                .chars()
+                .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
+                .collect();
+            let safe = if safe.is_empty() {
+                "skill".to_string()
+            } else {
+                safe
+            };
+            let tmp_skill = std::env::temp_dir().join(format!(
+                "mur-skill-bundle-{}-{safe}.{ext}",
+                std::process::id()
+            ));
+            if std::fs::write(&tmp_skill, &text).is_ok() {
+                let add_result = super::skill::cmd_skill_add(agent, &tmp_skill.to_string_lossy());
+                let _ = std::fs::remove_file(&tmp_skill);
+                if add_result.is_ok() {
+                    installed.push(format!("skills/{}", preview.name));
+                }
+            }
+        }
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+    Ok(installed)
+}
+
+/// Create a unique temporary directory for bundle extraction. Removes any
+/// pre-existing directory with the same name first.
+pub fn tempdir_unique(prefix: &str) -> Result<PathBuf> {
+    let dir = std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()));
+    if dir.exists() {
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+    std::fs::create_dir_all(&dir).map_err(|e| anyhow::anyhow!("mkdir temp: {e}"))?;
+    Ok(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Task 1 ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn detects_archive_urls() {
+        assert_eq!(
+            is_archive_url("https://example.com/skills.zip"),
+            Some(ArchiveKind::Zip)
+        );
+        assert_eq!(
+            is_archive_url("https://example.com/pack.tar.gz"),
+            Some(ArchiveKind::TarGz)
+        );
+        assert_eq!(
+            is_archive_url("https://example.com/pack.tgz"),
+            Some(ArchiveKind::TarGz)
+        );
+        assert_eq!(is_archive_url("https://example.com/skill.yaml"), None);
+        assert_eq!(is_archive_url("https://example.com/skill.md"), None);
+    }
+
+    // ── Task 2 ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_zip_roundtrips_a_skill() {
+        use std::io::Write;
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+            let opts = zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated);
+            zw.start_file("ok/skill.yaml", opts).unwrap();
+            zw.write_all(b"name: z").unwrap();
+            // Traversal entry — should be skipped.
+            zw.start_file("../escape.txt", opts).unwrap();
+            zw.write_all(b"bad").unwrap();
+            zw.finish().unwrap();
+        }
+        let dir = tempfile::tempdir().unwrap();
+        extract_archive(&buf, ArchiveKind::Zip, dir.path()).unwrap();
+        assert!(dir.path().join("ok/skill.yaml").exists());
+        // traversal entry must NOT be written outside dest
+        assert!(!dir.path().parent().unwrap().join("escape.txt").exists());
+    }
+
+    #[test]
+    fn extract_targz_roundtrips_a_skill() {
+        use std::io::Write;
+        let mut tar_buf = Vec::new();
+        {
+            let mut b = tar::Builder::new(&mut tar_buf);
+            let data = b"name: y";
+            let mut h = tar::Header::new_gnu();
+            h.set_size(data.len() as u64);
+            h.set_mode(0o644);
+            h.set_cksum();
+            b.append_data(&mut h, "pack/skill.yaml", &data[..]).unwrap();
+            b.finish().unwrap();
+        }
+        let mut gz = Vec::new();
+        {
+            use flate2::{Compression, write::GzEncoder};
+            let mut e = GzEncoder::new(&mut gz, Compression::default());
+            e.write_all(&tar_buf).unwrap();
+            e.finish().unwrap();
+        }
+        let dir = tempfile::tempdir().unwrap();
+        extract_archive(&gz, ArchiveKind::TarGz, dir.path()).unwrap();
+        assert!(dir.path().join("pack/skill.yaml").exists());
+    }
+
+    // ── Task 3 ────────────────────────────────────────────────────────────────
+
+    const VALID_SKILL: &str = "name: a\nversion: 1.0.0\npublisher: human:test\ndescription: d\ncategory: context\ncontent:\n  abstract: x\n  context: y\n";
+
+    #[test]
+    fn discovers_nested_skills_and_ignores_non_skills() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("sub")).unwrap();
+        std::fs::write(dir.path().join("sub/skill.yaml"), VALID_SKILL).unwrap();
+        std::fs::write(dir.path().join("README.md"), "# just docs, not a skill").unwrap();
+        let found = discover_skills(dir.path());
+        assert_eq!(found.len(), 1);
+        assert!(found[0].ends_with("sub/skill.yaml"));
+    }
+
+    // ── Task 4 ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_then_discover_then_preview_is_consistent() {
+        use std::io::Write;
+        let skill = "name: packed\nversion: 1.0.0\npublisher: human:test\ndescription: d\ncategory: context\ncontent:\n  abstract: x\n  context: y\n";
+        let mut tarb = Vec::new();
+        {
+            let mut b = tar::Builder::new(&mut tarb);
+            let mut h = tar::Header::new_gnu();
+            h.set_size(skill.len() as u64);
+            h.set_mode(0o644);
+            h.set_cksum();
+            b.append_data(&mut h, "skill.yaml", skill.as_bytes())
+                .unwrap();
+            b.finish().unwrap();
+        }
+        let mut gz = Vec::new();
+        {
+            use flate2::{Compression, write::GzEncoder};
+            let mut e = GzEncoder::new(&mut gz, Compression::default());
+            e.write_all(&tarb).unwrap();
+            e.finish().unwrap();
+        }
+        let dir = tempfile::tempdir().unwrap();
+        extract_archive(&gz, ArchiveKind::TarGz, dir.path()).unwrap();
+        let skills = discover_skills(dir.path());
+        assert_eq!(skills.len(), 1);
+        let text = std::fs::read_to_string(&skills[0]).unwrap();
+        let preview = preview_skill_text(&text, is_md_path(&skills[0])).unwrap();
+        assert_eq!(preview.name, "packed");
+        assert!(!preview.blocking);
+    }
+}

--- a/mur-core/src/cmd/agent/skill_bundle.rs
+++ b/mur-core/src/cmd/agent/skill_bundle.rs
@@ -3,7 +3,6 @@
 //! extracts .zip and .tar.gz bundles, discovers every skill manifest, scans
 //! each, and installs clean ones via quill P1's per-skill path. Built on
 //! `skill_remote`.
-#![allow(dead_code)] // module not yet wired to callers; suppress until integration
 
 use anyhow::{Result, bail};
 use std::path::{Path, PathBuf};
@@ -76,7 +75,9 @@ fn extract_zip(bytes: &[u8], dest: &Path) -> Result<()> {
             std::fs::create_dir_all(parent).map_err(|e| anyhow::anyhow!("mkdir: {e}"))?;
         }
         // Bomb guard — bound the ACTUAL read, not the header-declared size
-        // (entry.size() is attacker-controlled and can lie as 0).
+        // (entry.size() is attacker-controlled and can lie as 0). We read
+        // actual bytes via Read::take so the property holds even if the stored
+        // uncompressed-size header is falsified.
         let budget = BUNDLE_MAX_TOTAL_UNCOMPRESSED.saturating_sub(total);
         let mut data = Vec::new();
         // read budget+1 so we can detect overflow
@@ -177,6 +178,10 @@ fn is_md_path(p: &Path) -> bool {
 }
 
 /// Download a bundle archive, size-capped at [`BUNDLE_MAX_BYTES`].
+/// Uses a streaming accumulate loop so the cap applies to actual bytes
+/// received, not just the Content-Length header (which may be absent or
+/// spoofed). Aborts the download as soon as the running total would exceed
+/// the cap — no DoS via a header-lying server that omits Content-Length.
 pub async fn fetch_bundle(url: &str) -> Result<Vec<u8>> {
     let url = super::skill_remote::validate_skill_url(url)?;
     let resp = reqwest::Client::new()
@@ -188,22 +193,26 @@ pub async fn fetch_bundle(url: &str) -> Result<Vec<u8>> {
     if !resp.status().is_success() {
         bail!("server returned {}", resp.status());
     }
+    // Early rejection when Content-Length is present and already over cap.
     if let Some(len) = resp.content_length()
         && len > BUNDLE_MAX_BYTES as u64
     {
         bail!("bundle too large ({len} bytes; max {BUNDLE_MAX_BYTES})");
     }
-    let bytes = resp
-        .bytes()
+    // Stream body and enforce cap on actual bytes received.
+    let mut buf: Vec<u8> = Vec::new();
+    let mut body = resp;
+    while let Some(chunk) = body
+        .chunk()
         .await
-        .map_err(|e| anyhow::anyhow!("read body: {e}"))?;
-    if bytes.len() > BUNDLE_MAX_BYTES {
-        bail!(
-            "bundle too large ({} bytes; max {BUNDLE_MAX_BYTES})",
-            bytes.len()
-        );
+        .map_err(|e| anyhow::anyhow!("read body: {e}"))?
+    {
+        if buf.len() + chunk.len() > BUNDLE_MAX_BYTES {
+            bail!("bundle too large (exceeds {BUNDLE_MAX_BYTES} bytes)");
+        }
+        buf.extend_from_slice(&chunk);
     }
-    Ok(bytes.to_vec())
+    Ok(buf)
 }
 
 /// Fetch + extract + discover + preview each skill in a bundle. Installs nothing.
@@ -231,6 +240,14 @@ pub async fn preview_bundle_url(url: &str) -> Result<Vec<SkillPreview>> {
 /// Fetch + extract + discover + install. Clean skills always install; skills
 /// with blocking findings install only if `accept_findings` is true.
 /// Returns installed skill ids (`skills/<name>`).
+///
+/// Errors:
+/// - If ALL skills were skipped for blocking findings (and none errored),
+///   bails with an actionable message directing the caller to pass `--yes`.
+/// - If ALL skills failed with errors (no blocking-skip), bails with the
+///   joined error list.
+/// - On PARTIAL success: returns `Ok(installed)` and writes a one-line
+///   warning to stderr naming skipped-for-findings and errored counts.
 pub async fn install_bundle_from_url(
     agent: &str,
     url: &str,
@@ -246,6 +263,7 @@ pub async fn install_bundle_from_url(
     }
     let mut installed = Vec::new();
     let mut errors: Vec<String> = Vec::new();
+    let mut skipped_for_findings: Vec<String> = Vec::new();
     for p in &paths {
         let text = match std::fs::read_to_string(p) {
             Ok(t) => t,
@@ -263,40 +281,49 @@ pub async fn install_bundle_from_url(
         };
         // Fail-closed: skip skills with blocking findings unless accepted.
         if preview.blocking && !accept_findings {
+            skipped_for_findings.push(preview.name.clone());
             continue;
         }
-        let ext = if is_md_path(p) { "md" } else { "yaml" };
-        let safe: String = preview
-            .name
-            .chars()
-            .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
-            .collect();
-        let safe = if safe.is_empty() {
-            "skill".to_string()
-        } else {
-            safe
-        };
-        let tmp_skill = std::env::temp_dir().join(format!(
-            "mur-skill-bundle-{}-{safe}.{ext}",
-            std::process::id()
-        ));
-        match std::fs::write(&tmp_skill, &text) {
-            Err(e) => {
-                errors.push(format!("{}: write failed: {e}", preview.name));
-            }
-            Ok(_) => {
-                let add_result = super::skill::cmd_skill_add(agent, &tmp_skill.to_string_lossy());
-                let _ = std::fs::remove_file(&tmp_skill);
-                match add_result {
-                    Ok(_) => installed.push(format!("skills/{}", preview.name)),
-                    Err(e) => errors.push(format!("{}: install failed: {e}", preview.name)),
-                }
-            }
+        // Install directly from the already-extracted TempDir path — no
+        // second temp-file copy needed. cmd_skill_add derives the install id
+        // from the manifest `name` field, not the source filename.
+        match super::skill::cmd_skill_add(agent, &p.to_string_lossy()) {
+            Ok(_) => installed.push(format!("skills/{}", preview.name)),
+            Err(e) => errors.push(format!("{}: install failed: {e}", preview.name)),
         }
     }
-    if installed.is_empty() && !errors.is_empty() {
-        bail!("no skills installed:\n{}", errors.join("\n"));
+
+    if installed.is_empty() {
+        // Distinguish the two all-empty cases for actionable messaging.
+        if !skipped_for_findings.is_empty() && errors.is_empty() {
+            bail!(
+                "{} skill(s) skipped due to blocking security findings; \
+                 re-run with --yes (CLI) or tick accept (Hub) to install them",
+                skipped_for_findings.len()
+            );
+        } else if !skipped_for_findings.is_empty() {
+            bail!(
+                "{} skill(s) skipped due to blocking security findings \
+                 (re-run with --yes to install); {} additional error(s):\n{}",
+                skipped_for_findings.len(),
+                errors.len(),
+                errors.join("\n")
+            );
+        } else {
+            bail!("no skills installed:\n{}", errors.join("\n"));
+        }
     }
+
+    // Partial success: some installed, some skipped/errored — warn on stderr.
+    if !skipped_for_findings.is_empty() || !errors.is_empty() {
+        eprintln!(
+            "warning: bundle partially installed ({} ok, {} skipped for findings, {} error(s))",
+            installed.len(),
+            skipped_for_findings.len(),
+            errors.len()
+        );
+    }
+
     Ok(installed)
 }
 
@@ -482,6 +509,12 @@ mod tests {
     // ── Fix #1 ──────────────────────────────────────────────────────────────
     // zip whose real uncompressed content exceeds BUNDLE_MAX_TOTAL_UNCOMPRESSED
     // → extract_archive must return Err (zip-bomb guard on actual bytes).
+    //
+    // Note: the `zip` crate's ZipWriter always writes honest stored-size
+    // headers, so this test uses an honest zip where declared == actual.
+    // The guard in extract_zip reads actual bytes via Read::take (not
+    // entry.size()), so it correctly bounds real inflated data regardless
+    // of what the header claims — a lying header would also be caught.
     #[test]
     fn extract_zip_rejects_zip_bomb() {
         use std::io::Write;

--- a/mur-core/src/cmd/agent/skill_bundle.rs
+++ b/mur-core/src/cmd/agent/skill_bundle.rs
@@ -3,6 +3,7 @@
 //! extracts .zip and .tar.gz bundles, discovers every skill manifest, scans
 //! each, and installs clean ones via quill P1's per-skill path. Built on
 //! `skill_remote`.
+#![allow(dead_code)] // module not yet wired to callers; suppress until integration
 
 use anyhow::{Result, bail};
 use std::path::{Path, PathBuf};
@@ -70,19 +71,22 @@ fn extract_zip(bytes: &[u8], dest: &Path) -> Result<()> {
             Some(p) => p,
             None => continue,
         };
-        // Bomb guard.
-        total = total.saturating_add(entry.size());
-        if total > BUNDLE_MAX_TOTAL_UNCOMPRESSED {
-            bail!("archive uncompressed size exceeds {BUNDLE_MAX_TOTAL_UNCOMPRESSED} bytes");
-        }
         let out = dest.join(&rel);
         if let Some(parent) = out.parent() {
             std::fs::create_dir_all(parent).map_err(|e| anyhow::anyhow!("mkdir: {e}"))?;
         }
+        // Bomb guard — bound the ACTUAL read, not the header-declared size
+        // (entry.size() is attacker-controlled and can lie as 0).
+        let budget = BUNDLE_MAX_TOTAL_UNCOMPRESSED.saturating_sub(total);
         let mut data = Vec::new();
-        entry
+        // read budget+1 so we can detect overflow
+        std::io::Read::take(&mut entry, budget + 1)
             .read_to_end(&mut data)
             .map_err(|e| anyhow::anyhow!("read entry: {e}"))?;
+        total = total.saturating_add(data.len() as u64);
+        if total > BUNDLE_MAX_TOTAL_UNCOMPRESSED {
+            bail!("archive uncompressed size exceeds {BUNDLE_MAX_TOTAL_UNCOMPRESSED} bytes");
+        }
         std::fs::write(&out, &data).map_err(|e| anyhow::anyhow!("write {}: {e}", out.display()))?;
     }
     Ok(())
@@ -107,11 +111,13 @@ fn extract_targz(bytes: &[u8], dest: &Path) -> Result<()> {
         if total > BUNDLE_MAX_TOTAL_UNCOMPRESSED {
             bail!("archive uncompressed size exceeds {BUNDLE_MAX_TOTAL_UNCOMPRESSED} bytes");
         }
-        // unpack_in is documented to refuse paths that escape `dest` (returns
-        // Ok(false) and skips), giving zip-slip protection for tar.
-        let _unpacked = entry
+        // unpack_in refuses paths that escape `dest` by returning Ok(false).
+        if !entry
             .unpack_in(dest)
-            .map_err(|e| anyhow::anyhow!("unpack: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("unpack: {e}"))?
+        {
+            bail!("unsafe path in archive (refused by unpack_in)");
+        }
     }
     Ok(())
 }
@@ -171,16 +177,16 @@ fn is_md_path(p: &Path) -> bool {
 }
 
 /// Download a bundle archive, size-capped at [`BUNDLE_MAX_BYTES`].
-pub async fn fetch_bundle(url: &str, _kind: ArchiveKind) -> Result<Vec<u8>> {
+pub async fn fetch_bundle(url: &str) -> Result<Vec<u8>> {
     let url = super::skill_remote::validate_skill_url(url)?;
     let resp = reqwest::Client::new()
         .get(&url)
         .timeout(std::time::Duration::from_secs(BUNDLE_FETCH_TIMEOUT_SECS))
         .send()
         .await
-        .map_err(|e| anyhow::anyhow!("fetch {url}: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("network error: {e}"))?;
     if !resp.status().is_success() {
-        bail!("fetch {url}: HTTP {}", resp.status());
+        bail!("server returned {}", resp.status());
     }
     if let Some(len) = resp.content_length()
         && len > BUNDLE_MAX_BYTES as u64
@@ -203,12 +209,11 @@ pub async fn fetch_bundle(url: &str, _kind: ArchiveKind) -> Result<Vec<u8>> {
 /// Fetch + extract + discover + preview each skill in a bundle. Installs nothing.
 pub async fn preview_bundle_url(url: &str) -> Result<Vec<SkillPreview>> {
     let kind = is_archive_url(url).ok_or_else(|| anyhow::anyhow!("not a supported archive URL"))?;
-    let bytes = fetch_bundle(url, kind).await?;
-    let tmp = tempdir_unique("mur-bundle")?;
-    extract_archive(&bytes, kind, &tmp)?;
-    let paths = discover_skills(&tmp);
+    let bytes = fetch_bundle(url).await?;
+    let tmp = tempfile::TempDir::new().map_err(|e| anyhow::anyhow!("temp dir: {e}"))?;
+    extract_archive(&bytes, kind, tmp.path())?;
+    let paths = discover_skills(tmp.path());
     if paths.is_empty() {
-        let _ = std::fs::remove_dir_all(&tmp);
         bail!("no skills found in bundle");
     }
     let mut previews = Vec::new();
@@ -220,7 +225,6 @@ pub async fn preview_bundle_url(url: &str) -> Result<Vec<SkillPreview>> {
             }
         }
     }
-    let _ = std::fs::remove_dir_all(&tmp);
     Ok(previews)
 }
 
@@ -233,62 +237,67 @@ pub async fn install_bundle_from_url(
     accept_findings: bool,
 ) -> Result<Vec<String>> {
     let kind = is_archive_url(url).ok_or_else(|| anyhow::anyhow!("not a supported archive URL"))?;
-    let bytes = fetch_bundle(url, kind).await?;
-    let tmp = tempdir_unique("mur-bundle")?;
-    extract_archive(&bytes, kind, &tmp)?;
-    let paths = discover_skills(&tmp);
+    let bytes = fetch_bundle(url).await?;
+    let tmp = tempfile::TempDir::new().map_err(|e| anyhow::anyhow!("temp dir: {e}"))?;
+    extract_archive(&bytes, kind, tmp.path())?;
+    let paths = discover_skills(tmp.path());
     if paths.is_empty() {
-        let _ = std::fs::remove_dir_all(&tmp);
         bail!("no skills found in bundle");
     }
     let mut installed = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
     for p in &paths {
-        if let Ok(text) = std::fs::read_to_string(p) {
-            let preview = match preview_skill_text(&text, is_md_path(p)) {
-                Ok(pv) => pv,
-                Err(_) => continue,
-            };
-            // Fail-closed: skip skills with blocking findings unless accepted.
-            if preview.blocking && !accept_findings {
+        let text = match std::fs::read_to_string(p) {
+            Ok(t) => t,
+            Err(e) => {
+                errors.push(format!("{}: read failed: {e}", p.display()));
                 continue;
             }
-            let ext = if is_md_path(p) { "md" } else { "yaml" };
-            let safe: String = preview
-                .name
-                .chars()
-                .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
-                .collect();
-            let safe = if safe.is_empty() {
-                "skill".to_string()
-            } else {
-                safe
-            };
-            let tmp_skill = std::env::temp_dir().join(format!(
-                "mur-skill-bundle-{}-{safe}.{ext}",
-                std::process::id()
-            ));
-            if std::fs::write(&tmp_skill, &text).is_ok() {
+        };
+        let preview = match preview_skill_text(&text, is_md_path(p)) {
+            Ok(pv) => pv,
+            Err(e) => {
+                errors.push(format!("{}: preview failed: {e}", p.display()));
+                continue;
+            }
+        };
+        // Fail-closed: skip skills with blocking findings unless accepted.
+        if preview.blocking && !accept_findings {
+            continue;
+        }
+        let ext = if is_md_path(p) { "md" } else { "yaml" };
+        let safe: String = preview
+            .name
+            .chars()
+            .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
+            .collect();
+        let safe = if safe.is_empty() {
+            "skill".to_string()
+        } else {
+            safe
+        };
+        let tmp_skill = std::env::temp_dir().join(format!(
+            "mur-skill-bundle-{}-{safe}.{ext}",
+            std::process::id()
+        ));
+        match std::fs::write(&tmp_skill, &text) {
+            Err(e) => {
+                errors.push(format!("{}: write failed: {e}", preview.name));
+            }
+            Ok(_) => {
                 let add_result = super::skill::cmd_skill_add(agent, &tmp_skill.to_string_lossy());
                 let _ = std::fs::remove_file(&tmp_skill);
-                if add_result.is_ok() {
-                    installed.push(format!("skills/{}", preview.name));
+                match add_result {
+                    Ok(_) => installed.push(format!("skills/{}", preview.name)),
+                    Err(e) => errors.push(format!("{}: install failed: {e}", preview.name)),
                 }
             }
         }
     }
-    let _ = std::fs::remove_dir_all(&tmp);
-    Ok(installed)
-}
-
-/// Create a unique temporary directory for bundle extraction. Removes any
-/// pre-existing directory with the same name first.
-pub fn tempdir_unique(prefix: &str) -> Result<PathBuf> {
-    let dir = std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()));
-    if dir.exists() {
-        let _ = std::fs::remove_dir_all(&dir);
+    if installed.is_empty() && !errors.is_empty() {
+        bail!("no skills installed:\n{}", errors.join("\n"));
     }
-    std::fs::create_dir_all(&dir).map_err(|e| anyhow::anyhow!("mkdir temp: {e}"))?;
-    Ok(dir)
+    Ok(installed)
 }
 
 #[cfg(test)]
@@ -412,5 +421,91 @@ mod tests {
         let preview = preview_skill_text(&text, is_md_path(&skills[0])).unwrap();
         assert_eq!(preview.name, "packed");
         assert!(!preview.blocking);
+    }
+
+    // ── Fix #4 ──────────────────────────────────────────────────────────────
+    // tar.gz with a path-traversal entry → extract_archive must return Err.
+    // Both `set_path` and `append_data` validate `..`, so we build the raw
+    // 512-byte tar header block by hand, writing "../escape.txt" directly
+    // into the name field, then append the data block manually.
+    #[test]
+    fn extract_targz_refuses_path_traversal() {
+        use std::io::Write;
+        // Build a minimal POSIX tar manually with a `..` path.
+        // Tar header: 512 bytes. Name at [0..100], mode [100..108],
+        // size [124..136] (octal), typeflag [156], checksum [148..156].
+        let data = b"bad";
+        let mut header = [0u8; 512];
+        // name field
+        header[..13].copy_from_slice(b"../escape.txt");
+        // mode: "0000644\0"
+        header[100..108].copy_from_slice(b"0000644\0");
+        // uid, gid: "0000000\0"
+        header[108..116].copy_from_slice(b"0000000\0");
+        header[116..124].copy_from_slice(b"0000000\0");
+        // size: "00000000003\0" (3 bytes, octal)
+        header[124..136].copy_from_slice(b"00000000003\0");
+        // mtime: "00000000000\0"
+        header[136..148].copy_from_slice(b"00000000000\0");
+        // checksum placeholder (8 spaces for calculation)
+        header[148..156].copy_from_slice(b"        ");
+        // typeflag: '0' = regular file
+        header[156] = b'0';
+        // compute checksum
+        let cksum: u32 = header.iter().map(|&b| b as u32).sum();
+        // write checksum in octal, null-terminated with space per POSIX
+        let ck_str = format!("{:06o}\0 ", cksum);
+        header[148..156].copy_from_slice(ck_str.as_bytes());
+        // data block (padded to 512)
+        let mut data_block = [0u8; 512];
+        data_block[..data.len()].copy_from_slice(data);
+        // two end-of-archive zero blocks
+        let end_blocks = [0u8; 1024];
+        // assemble the raw tar
+        let mut tar_buf = Vec::new();
+        tar_buf.extend_from_slice(&header);
+        tar_buf.extend_from_slice(&data_block);
+        tar_buf.extend_from_slice(&end_blocks);
+        // gzip-wrap it
+        let mut gz = Vec::new();
+        {
+            use flate2::{Compression, write::GzEncoder};
+            let mut e = GzEncoder::new(&mut gz, Compression::default());
+            e.write_all(&tar_buf).unwrap();
+            e.finish().unwrap();
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let result = extract_archive(&gz, ArchiveKind::TarGz, dir.path());
+        assert!(result.is_err(), "path traversal should be rejected");
+    }
+
+    // ── Fix #1 ──────────────────────────────────────────────────────────────
+    // zip whose real uncompressed content exceeds BUNDLE_MAX_TOTAL_UNCOMPRESSED
+    // → extract_archive must return Err (zip-bomb guard on actual bytes).
+    #[test]
+    fn extract_zip_rejects_zip_bomb() {
+        use std::io::Write;
+        let mut buf = Vec::new();
+        {
+            let mut zw = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+            let opts = zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated);
+            // 5 entries × 7 MB zeros = 35 MB > BUNDLE_MAX_TOTAL_UNCOMPRESSED (32 MB).
+            // Zeros deflate to ~a few bytes, so the .zip is tiny and the test is fast.
+            let chunk = vec![0u8; 7 * 1024 * 1024];
+            for i in 0..5u32 {
+                zw.start_file(format!("big{i}.bin"), opts).unwrap();
+                zw.write_all(&chunk).unwrap();
+            }
+            zw.finish().unwrap();
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let result = extract_archive(&buf, ArchiveKind::Zip, dir.path());
+        assert!(result.is_err(), "zip bomb should be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("exceeds"),
+            "error should mention size limit: {msg}"
+        );
     }
 }

--- a/mur-core/src/cmd/agent/skill_bundle.rs
+++ b/mur-core/src/cmd/agent/skill_bundle.rs
@@ -216,6 +216,8 @@ pub async fn fetch_bundle(url: &str) -> Result<Vec<u8>> {
 }
 
 /// Fetch + extract + discover + preview each skill in a bundle. Installs nothing.
+// Consumed by the workspace-excluded `mur-hub-gui` crate; unused in the workspace build.
+#[allow(dead_code)]
 pub async fn preview_bundle_url(url: &str) -> Result<Vec<SkillPreview>> {
     let kind = is_archive_url(url).ok_or_else(|| anyhow::anyhow!("not a supported archive URL"))?;
     let bytes = fetch_bundle(url).await?;

--- a/mur-core/src/cmd/agent/skill_remote.rs
+++ b/mur-core/src/cmd/agent/skill_remote.rs
@@ -118,6 +118,8 @@ pub async fn preview_skill_url(url: &str) -> Result<SkillPreview> {
 
 /// Preview any skill URL — archive bundle or single skill.
 /// Returns a `Vec<SkillPreview>` (bundle: all previews; single: one-element vec).
+// Consumed by the workspace-excluded `mur-hub-gui` crate; unused in the workspace build.
+#[allow(dead_code)]
 pub async fn preview_any_url(url: &str) -> Result<Vec<SkillPreview>> {
     if crate::cmd::agent::skill_bundle::is_archive_url(url).is_some() {
         crate::cmd::agent::skill_bundle::preview_bundle_url(url).await
@@ -128,6 +130,8 @@ pub async fn preview_any_url(url: &str) -> Result<Vec<SkillPreview>> {
 
 /// Install from any skill URL — archive bundle or single skill.
 /// Returns installed skill ids (e.g. `["skills/foo", "skills/bar"]`).
+// Consumed by the workspace-excluded `mur-hub-gui` crate; unused in the workspace build.
+#[allow(dead_code)]
 pub async fn install_any_url(agent: &str, url: &str, accept_findings: bool) -> Result<Vec<String>> {
     if crate::cmd::agent::skill_bundle::is_archive_url(url).is_some() {
         crate::cmd::agent::skill_bundle::install_bundle_from_url(agent, url, accept_findings).await

--- a/mur-core/src/cmd/agent/skill_remote.rs
+++ b/mur-core/src/cmd/agent/skill_remote.rs
@@ -116,13 +116,42 @@ pub async fn preview_skill_url(url: &str) -> Result<SkillPreview> {
     preview_skill_text(&text, is_md)
 }
 
+/// Preview any skill URL — archive bundle or single skill.
+/// Returns a `Vec<SkillPreview>` (bundle: all previews; single: one-element vec).
+pub async fn preview_any_url(url: &str) -> Result<Vec<SkillPreview>> {
+    if crate::cmd::agent::skill_bundle::is_archive_url(url).is_some() {
+        crate::cmd::agent::skill_bundle::preview_bundle_url(url).await
+    } else {
+        Ok(vec![preview_skill_url(url).await?])
+    }
+}
+
+/// Install from any skill URL — archive bundle or single skill.
+/// Returns installed skill ids (e.g. `["skills/foo", "skills/bar"]`).
+pub async fn install_any_url(agent: &str, url: &str, accept_findings: bool) -> Result<Vec<String>> {
+    if crate::cmd::agent::skill_bundle::is_archive_url(url).is_some() {
+        crate::cmd::agent::skill_bundle::install_bundle_from_url(agent, url, accept_findings).await
+    } else {
+        Ok(vec![
+            install_skill_from_url(agent, url, accept_findings).await?,
+        ])
+    }
+}
+
 /// Fetch, preview, and install a skill from a remote URL onto `agent`.
 /// Fails if the skill has blocking security findings AND `accept_findings` is false.
+/// Archive URLs (`.zip`, `.tar.gz`, `.tgz`) are transparently routed to `install_bundle_from_url`.
 pub async fn install_skill_from_url(
     agent: &str,
     url: &str,
     accept_findings: bool,
 ) -> Result<String> {
+    if crate::cmd::agent::skill_bundle::is_archive_url(url).is_some() {
+        let ids =
+            crate::cmd::agent::skill_bundle::install_bundle_from_url(agent, url, accept_findings)
+                .await?;
+        return Ok(ids.join(", "));
+    }
     let (text, is_md) = fetch_skill(url).await?;
     let preview = preview_skill_text(&text, is_md)?;
     if preview.blocking && !accept_findings {
@@ -154,6 +183,18 @@ pub async fn install_skill_from_url(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn archive_urls_route_to_bundle() {
+        use crate::cmd::agent::skill_bundle::{ArchiveKind, is_archive_url};
+        assert!(matches!(
+            is_archive_url("https://x/p.zip"),
+            Some(ArchiveKind::Zip)
+        ));
+        assert!(is_archive_url("https://x/skill.yaml").is_none());
+        // preview_any_url / install_any_url routing is exercised by bundle tests
+        // and gated network tests; these asserts verify the discriminator the router uses.
+    }
 
     #[test]
     fn url_validation() {

--- a/mur-hub-gui/src-tauri/src/mcp_skills.rs
+++ b/mur-hub-gui/src-tauri/src/mcp_skills.rs
@@ -7,7 +7,7 @@
 use crate::detail::{AgentDetail, get_agent_detail};
 use mur_core::cmd::agent::mcp::{McpAddPin, cmd_mcp_add, cmd_mcp_remove, cmd_mcp_set_enabled};
 use mur_core::cmd::agent::skill::{cmd_skill_add, cmd_skill_remove, cmd_skill_set_enabled};
-use mur_core::cmd::agent::skill_remote::{SkillPreview, install_skill_from_url, preview_skill_url};
+use mur_core::cmd::agent::skill_remote::{SkillPreview, install_any_url, preview_any_url};
 use serde::Serialize;
 
 /// Result of a skill install: the refreshed agent detail plus the id under
@@ -282,28 +282,39 @@ pub fn reveal_in_finder(path: String, agent: Option<String>) -> Result<(), Strin
     reveal_os(&target).map_err(|e| e.to_string())
 }
 
-/// Fetch, parse, and security-scan a remote skill URL for user review.
-/// Installs nothing.
-#[tauri::command]
-pub async fn agent_skill_preview_url(url: String) -> Result<SkillPreview, String> {
-    preview_skill_url(&url).await.map_err(|e| format!("{e:#}"))
+/// Result of a URL install: the refreshed agent detail plus all skill ids
+/// that were installed (one for a single skill, many for a bundle).
+#[derive(Debug, Clone, Serialize)]
+pub struct BundleInstallResult {
+    pub detail: AgentDetail,
+    /// Canonical ids of every skill installed, e.g. `["skills/foo.yaml", "skills/bar.yaml"]`.
+    pub installed_ids: Vec<String>,
 }
 
-/// Fetch and install a skill from a remote URL onto `name` agent.
-/// `accept_findings` must be `true` to install a skill with blocking security findings.
+/// Fetch, parse, and security-scan a remote skill URL for user review.
+/// Works for both single-skill URLs and archive bundles — returns one
+/// `SkillPreview` per discovered skill. Installs nothing.
+#[tauri::command]
+pub async fn agent_skill_preview_url(url: String) -> Result<Vec<SkillPreview>, String> {
+    preview_any_url(&url).await.map_err(|e| format!("{e:#}"))
+}
+
+/// Fetch and install a skill (or bundle) from a remote URL onto `name` agent.
+/// `accept_findings` gates skills with blocking scan findings; clean skills
+/// install regardless.
 #[tauri::command]
 pub async fn agent_skill_install_url(
     name: String,
     url: String,
     accept_findings: bool,
-) -> Result<SkillInstallResult, String> {
-    let installed_id = install_skill_from_url(&name, &url, accept_findings)
+) -> Result<BundleInstallResult, String> {
+    let installed_ids = install_any_url(&name, &url, accept_findings)
         .await
         .map_err(|e| format!("{e:#}"))?;
     let detail = get_agent_detail(name)?;
-    Ok(SkillInstallResult {
+    Ok(BundleInstallResult {
         detail,
-        installed_id,
+        installed_ids,
     })
 }
 

--- a/mur-hub-gui/ui/src/components/SkillAddUrlModal.tsx
+++ b/mur-hub-gui/ui/src/components/SkillAddUrlModal.tsx
@@ -21,14 +21,14 @@ interface Props {
 export function SkillAddUrlModal({ agentName, onClose, onSaved }: Props) {
   const { t } = useT();
   const [url, setUrl] = useState("");
-  const [preview, setPreview] = useState<SkillPreview | null>(null);
+  const [previews, setPreviews] = useState<SkillPreview[] | null>(null);
   const [accept, setAccept] = useState(false);
   const [busy, setBusy] = useState<null | "fetch" | "install">(null);
   const [error, setError] = useState<string | null>(null);
 
   async function fetchPreview() {
     setError(null);
-    setPreview(null);
+    setPreviews(null);
     setAccept(false);
     const trimmed = url.trim();
     if (
@@ -44,9 +44,7 @@ export function SkillAddUrlModal({ agentName, onClose, onSaved }: Props) {
     }
     setBusy("fetch");
     try {
-      setPreview(
-        await invoke<SkillPreview>("agent_skill_preview_url", { url: trimmed }),
-      );
+      setPreviews(await invoke<SkillPreview[]>("agent_skill_preview_url", { url: trimmed }));
     } catch (e) {
       setError(String(e));
     } finally {
@@ -58,11 +56,11 @@ export function SkillAddUrlModal({ agentName, onClose, onSaved }: Props) {
     setError(null);
     setBusy("install");
     try {
-      const detail = await invoke<{ detail: AgentDetail; installed_id: string }>(
+      const res = await invoke<{ detail: AgentDetail; installed_ids: string[] }>(
         "agent_skill_install_url",
         { name: agentName, url: url.trim(), acceptFindings: accept },
       );
-      onSaved(detail.detail);
+      onSaved(res.detail);
       onClose();
     } catch (e) {
       setError(String(e));
@@ -71,7 +69,8 @@ export function SkillAddUrlModal({ agentName, onClose, onSaved }: Props) {
     }
   }
 
-  const canInstall = !!preview && busy === null && (!preview.blocking || accept);
+  const anyBlocking = !!previews && previews.some((p) => p.blocking);
+  const canInstall = !!previews && previews.length > 0 && busy === null && (!anyBlocking || accept);
 
   return (
     <div className="modal__overlay" onClick={onClose}>
@@ -87,7 +86,7 @@ export function SkillAddUrlModal({ agentName, onClose, onSaved }: Props) {
               className="input"
               type="url"
               value={url}
-              onChange={(e) => { setUrl(e.target.value); setPreview(null); setAccept(false); }}
+              onChange={(e) => { setUrl(e.target.value); setPreviews(null); setAccept(false); }}
               onKeyDown={(e) => e.key === "Enter" && !busy && fetchPreview()}
               placeholder={t("skillurl.urlPlaceholder")}
               style={{ flex: 1 }}
@@ -102,58 +101,63 @@ export function SkillAddUrlModal({ agentName, onClose, onSaved }: Props) {
             </button>
           </div>
 
-          {preview && (
+          {previews && (
             <div style={{ marginTop: 12 }}>
               <p className="field-label">{t("skillurl.previewHeading")}</p>
-              <div className="item-card">
-                <span className="item-card__name">{preview.name}</span>
-                <span className="item-card__meta">{preview.category}</span>
-                <p style={{ margin: "4px 0 0", fontSize: 13 }}>
-                  {preview.description}
-                </p>
-              </div>
-
-              {preview.findings.length > 0 && (
-                <div style={{ marginTop: 10 }}>
-                  <p className="field-label">{t("skillurl.findingsHeading")}</p>
-                  <ul className="item-list">
-                    {preview.findings.map((f, i) => (
-                      <li key={i} className="save-error">
-                        {f}
-                      </li>
-                    ))}
-                  </ul>
-                  {preview.blocking && (
-                    <label
-                      style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 8, fontSize: 13 }}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={accept}
-                        onChange={(e) => setAccept(e.target.checked)}
-                      />
-                      {t("skillurl.accept")}
-                    </label>
-                  )}
-                </div>
-              )}
-
-              <div style={{ marginTop: 10 }}>
+              {previews.length > 1 && (
                 <p className="field-muted" style={{ marginTop: 0 }}>
-                  {t("skillurl.bodyHeading")}
+                  {t("skillurl.bundleHint")}
                 </p>
-                <pre
-                  className="item-card"
-                  style={{ whiteSpace: "pre-wrap", maxHeight: 240, overflow: "auto", fontSize: 12 }}
+              )}
+              {previews.map((p, i) => (
+                <div key={i} className="item-card" style={{ marginTop: 8 }}>
+                  <span className="item-card__name">{p.name}</span>
+                  <span className="item-card__meta">{p.category}</span>
+                  <p style={{ margin: "4px 0 0", fontSize: 13 }}>
+                    {p.description}
+                  </p>
+                  {p.findings.length > 0 && (
+                    <div style={{ marginTop: 8 }}>
+                      <p className="field-label" style={{ marginTop: 0 }}>{t("skillurl.findingsHeading")}</p>
+                      <ul className="item-list">
+                        {p.findings.map((f, j) => (
+                          <li key={j} className="save-error">
+                            {f}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  <div style={{ marginTop: 8 }}>
+                    <p className="field-muted" style={{ marginTop: 0 }}>
+                      {t("skillurl.bodyHeading")}
+                    </p>
+                    <pre
+                      className="item-card"
+                      style={{ whiteSpace: "pre-wrap", maxHeight: 160, overflow: "auto", fontSize: 12 }}
+                    >
+                      {p.body}
+                    </pre>
+                  </div>
+                </div>
+              ))}
+              {anyBlocking && (
+                <label
+                  style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 8, fontSize: 13 }}
                 >
-                  {preview.body}
-                </pre>
-              </div>
+                  <input
+                    type="checkbox"
+                    checked={accept}
+                    onChange={(e) => setAccept(e.target.checked)}
+                  />
+                  {t("skillurl.accept")}
+                </label>
+              )}
             </div>
           )}
 
           {error && <p className="save-error">{error}</p>}
-          {preview && (
+          {previews && (
             <p className="field-muted" style={{ marginTop: 8 }}>
               {t("skillurl.restartHint")}
             </p>

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -524,4 +524,5 @@ export const en = {
   "skillurl.installing": "Installing…",
   "skillurl.restartHint": "After installing, restart the agent to load it.",
   "skillurl.invalidUrl": "Enter an https:// URL (http allowed only on localhost).",
+  "skillurl.bundleHint": "An archive may contain several skills — review each below.",
 } as const;

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -526,4 +526,5 @@ export const zhTW: Table = {
   "skillurl.installing": "安裝中…",
   "skillurl.restartHint": "安裝後，請重新啟動 agent 使其生效。",
   "skillurl.invalidUrl": "請輸入 https:// 網址（http 僅限 localhost）。",
+  "skillurl.bundleHint": "壓縮檔可能包含多個技能 — 請逐一檢視。",
 };


### PR DESCRIPTION
## What

Extends **quill P1** (install one skill by URL) with **archive bundle** support: install a pack of one-or-more skills from a `.zip` / `.tar.gz` / `.tgz` URL, in both the Hub and the CLI (`mur agent skill add-url`). Also resolves quill P1's confusing "not a valid skill manifest" error on a `.zip` — archives are now first-class.

MUR skills are single-file, so a bundle is meaningfully *one-or-more skill manifests in an archive* (any subdirectory depth) — quill discovers all, scans each, and installs the clean ones; flagged skills install only on explicit acceptance (fail-closed).

## How (units)

- **`skill_bundle.rs` (new):** archive detection + named caps; **safe extraction** for zip (`enclosed_name`) and tar.gz (`unpack_in` + skip non-regular entries + bail on refusal); `discover_skills` (recursive, parses `.yaml`/`.md`); `fetch_bundle` (streaming, size-capped); `preview_bundle_url` / `install_bundle_from_url` (fail-closed, `TempDir` cleanup).
- **`skill_remote.rs`:** archive front-door in `install_skill_from_url` + unified `preview_any_url` / `install_any_url` (the CLI routes transparently).
- **Hub:** `agent_skill_preview_url` → `Vec<SkillPreview>`, `agent_skill_install_url` → `BundleInstallResult { detail, installed_ids }` (single-skill `agent_skill_install` untouched).
- **Modal:** `SkillAddUrlModal` renders the discovered skill **list**, one accept checkbox gating any flagged skill, bundle hint for multi-skill packs. i18n in en + zh-TW.

Reuses the existing `tar`/`flate2`/`zip` deps — **no Cargo.toml change**.

## Security

Untrusted archives are extracted in MUR's trusted control plane to a temp dir (never inside a sandboxed agent). Whole-branch review (opus) verified the core **solid**:
- **Zip-slip** (both formats): no path escapes; symlink/hardlink/absolute entries rejected.
- **Zip-bomb**: bounds the **actual** decompressed bytes via `Read::take` (not the attacker-controlled header size); entry-count + total-uncompressed caps.
- **Download DoS**: streaming `chunk()` accumulate aborts past `BUNDLE_MAX_BYTES` (no unbounded buffer); https-only + timeout.
- **Fail-closed**: blocking-scan skills skipped unless accepted; all-skipped/all-failed bundles **bail with an actionable message** (no silent `Ok(vec![])`); partial results warn with counts.
- **Consent integrity**: editing the URL resets the preview + accept, so approve-A-install-B is impossible.

### Deferred (noted, not in scope here)
- `BundlePreview { errors }` contract (spec §4.1) — low impact (`discover` pre-filters non-skills); would cascade across 4 files. 
- SSRF-via-redirect in `validate_skill_url` — pre-existing from quill P1, unchanged here.

## Test plan

- `skill_bundle` unit tests (7): archive detection, zip-slip refusal (zip + tar), zip-bomb rejection, zip/tar roundtrip, nested discovery ignoring non-skills, extract→discover→preview pipeline.
- `skill_remote` routing test; Hub `cargo check` + clippy `-D warnings`; frontend `tsc --noEmit` + vite build — all green.
- Manual/live (follow-up): 2-skill `.zip` (both install), `.tar.gz` with one clean + one injection skill (clean installs, injection gated), zip-slip archive (rejected).

Built via subagent-driven-development (per-unit review + opus whole-branch review + fix wave). Stacked on quill P1 (#524, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)