### PR TITLE
feat: quill P2.1 — publisher trust-roots, TOFU & rug-pull drift detection

### DIFF
--- a/docs/superpowers/plans/2026-06-28-quill-p21-trust-roots-plan.md
+++ b/docs/superpowers/plans/2026-06-28-quill-p21-trust-roots-plan.md
@@ -1,0 +1,578 @@
+# Quill P2.1 — Publisher trust-roots, TOFU & drift detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn P2's "signature is internally consistent" into "signature is from a *trusted* publisher" — via a client-pinned publisher keyring + TOFU + rug-pull drift detection — without TUF or Sigstore.
+
+**Architecture:** Add a `PublisherKeyring` (mur-common) pinned with the MUR-official key; classify a P2 `Verified` signature into `Trusted/Untrusted/Revoked`; fold that into the existing fail-closed gate (Revoked→unconditional block, Untrusted→`--yes`); pin `content_sha256`+signer at install in `SkillTrustStore` and re-prompt on drift / version rollback; add a TOFU `trust-publisher` command + Hub badge.
+
+**Tech Stack:** Rust (reuses the existing Ed25519/DSSE stack `mur-common/src/muragent/dsse.rs`, `skill_verify.rs`, `SkillTrustStore`, `semver`); Tauri 2; React/TS.
+
+## Global Constraints
+
+- Builds on quill C/P2 (merged #531). Branch: `feat/quill-p21-trust-roots` off main.
+- **Pinned-root + TOFU + drift only** — NO TUF, NO Sigstore keyless (would need online verify; breaks local-first).
+- **Gate stays fail-closed, now three buckets:** unconditional-block (not `--yes`-overridable) = hash `Mismatch` OR signature `Invalid` OR signer `Revoked`; needs-ack (`--yes`) = signer `Untrusted` OR `Unsigned` OR absent hash OR scan-findings OR drift; clean (silent) = hash `Match` + signer `Trusted` + no findings + no drift.
+- Do NOT change P2's cryptographic check (`verify_skill_install`) — trust classification is a *layer on top*.
+- No hardcoded values except the one pinned root: `MUR_OFFICIAL_PUBLISHER_KEY_FP` (a deliberate compiled-in trust anchor, documented as such). Rust edition 2024. Single file ≤ 800 lines.
+- Backward-compatible data: new `TrustEntry` fields use `#[serde(default)]`; `publishers.yaml` seeds on first run.
+- Brand "MUR" uppercase in user-facing strings; Traditional Chinese for zh-TW i18n.
+- Build/test mur-core/common: `export PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"`, `ORT_STRATEGY=download`, plain `cargo test -p <crate> --lib <filter>` (NOT nextest; slow external drive — let builds finish, don't run two cargo at once). After Rust: `cargo fmt --all` + **`cargo clippy --all --no-deps -- -D warnings`** (workspace, not `--lib` — Hub-only `pub` fns appear dead → `#[allow(dead_code)]` with a one-line rationale).
+- Hub: `cargo check --manifest-path mur-hub-gui/src-tauri/Cargo.toml` (needs `mur-hub-gui/ui/dist/index.html` stub — gitignored, don't commit; never commit `src-tauri/binaries/*`). UI: `cd mur-hub-gui/ui && npx tsc --noEmit && npm run build` (symlink `node_modules`).
+
+## Reused existing API (verified)
+
+- `mur_common::muragent::dsse`: keyid format is `format!("ed25519-{}", &hex[..8])` of SHA-256(pubkey); `DsseEnvelope.signatures[0].keyid`.
+- `mur-core/src/cmd/agent/skill_verify.rs`: `verify_skill_install(manifest:&SkillManifest, file_text:&str, expected_sha256:&str) -> VerifyOutcome { hash: HashStatus, signature: SignatureStatus }`; `SignatureStatus::Verified { publisher: String, key_fp: String } | Unsigned | Invalid`; `VerifyOutcome::{is_blocking, needs_ack}`.
+- `mur-core/src/cmd/agent/skill_registry_add.rs`: `ConsentInfo { name, version, publisher, category, signature: SigView{status,publisher,key_fp}, hash:String, mcp_requirements, findings, blocking, needs_ack, scan_blocking, trust_level, body }`; `fn gate(consent:&ConsentInfo, accept:bool) -> Result<()>`; `resolve_consent_in(registry_dir:&Path, skill:&str, version:Option<&str>) -> Result<ConsentInfo>`; `resolve_consent(mur_home:&Path, …)`; `cmd_skill_registry_add(agent, skill, version, accept)` (calls `fetch_and_load` → `resolve_consent_in` → `gate` → `cmd_skill_add`); `registry_search_for_agent`.
+- `mur-common/src/trust/skills.rs`: `SkillTrustStore { entries: BTreeMap<String,TrustEntry>, revoked: Vec<String> }` at `<mur_home>/trust/skills.json`; `TrustEntry { name, version, level: TrustLevel, installed_at: String, publisher: Option<String> }`; `load(mur_home)`, `save(mur_home)`.
+- `skill_registry::{available_versions(dir,name)->Vec<semver::Version>, skill_yaml_path, fetch_and_load, DEFAULT_REGISTRY}`.
+- Hub `mcp_skills.rs`: `#[tauri::command]` async fns; `agent_skill_registry_preview/install/search`; registered in `lib.rs`.
+
+---
+
+## File Structure
+
+- **Create** `mur-common/src/skill/publisher_trust.rs` — `PublisherKeyring`, `TrustedPublisher`, `PublisherTrust`, `classify`, load/seed, `MUR_OFFICIAL_PUBLISHER_KEY_FP`.
+- **Modify** `mur-common/src/skill/mod.rs` — `pub mod publisher_trust;` + re-exports.
+- **Modify** `mur-common/src/trust/skills.rs` — add `content_sha256` + `signer_key_fp` to `TrustEntry`.
+- **Create** `mur-core/src/cmd/agent/skill_signer_trust.rs` — `SignerTrust`, `classify_signer`, `check_drift` (pure).
+- **Modify** `mur-core/src/cmd/agent/skill_registry_add.rs` — load keyring + classify signer + fold into blocking/needs_ack; pin on install; drift/rollback check; `ConsentInfo` gains `signer_trust`.
+- **Modify** `mur-core/src/cmd/agent/mod.rs` — `pub mod skill_signer_trust;`.
+- **Modify** `mur-core/src/cli/agent.rs` + `dispatch.rs` — `AgentSkillAction::TrustPublisher` + trust badge in consent printout.
+- **Modify** Hub `mcp_skills.rs` + `lib.rs` + `SkillRegistryModal.tsx` + i18n — trust badge + "Trust this publisher" action.
+
+---
+
+## Task 1: PublisherKeyring (mur-common, pinned trust root)
+
+**Files:** Create `mur-common/src/skill/publisher_trust.rs`; Modify `mur-common/src/skill/mod.rs`.
+
+**Interfaces:**
+- Produces: `pub enum PublisherTrust { Trusted, Revoked, Unknown }`; `pub struct TrustedPublisher { pub name: String, pub key_fp: String, pub comment: String }`; `pub struct PublisherKeyring { pub schema_version: u32, pub publishers: Vec<TrustedPublisher>, pub revoked: Vec<String> }` with `pub fn classify(&self, key_fp: &str) -> PublisherTrust`, `pub fn path(mur_home:&Path)->PathBuf`, `pub fn load_or_seed(mur_home:&Path)->Result<Self>`, `pub fn save(&self,mur_home:&Path)->Result<()>`; `pub const MUR_OFFICIAL_PUBLISHER_KEY_FP: &str`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn kr() -> PublisherKeyring {
+        PublisherKeyring {
+            schema_version: 1,
+            publishers: vec![TrustedPublisher { name: "mur".into(), key_fp: "ed25519-aabbccdd".into(), comment: "official".into() }],
+            revoked: vec!["ed25519-deadbeef".into()],
+        }
+    }
+    #[test]
+    fn classify_trusted_revoked_unknown() {
+        let k = kr();
+        assert_eq!(k.classify("ed25519-aabbccdd"), PublisherTrust::Trusted);
+        assert_eq!(k.classify("ed25519-deadbeef"), PublisherTrust::Revoked);
+        assert_eq!(k.classify("ed25519-00000000"), PublisherTrust::Unknown);
+    }
+    #[test]
+    fn revoked_beats_trusted() {
+        // A key both listed AND revoked must classify Revoked (fail-closed).
+        let k = PublisherKeyring { schema_version:1,
+            publishers: vec![TrustedPublisher{name:"x".into(),key_fp:"ed25519-aabbccdd".into(),comment:String::new()}],
+            revoked: vec!["ed25519-aabbccdd".into()] };
+        assert_eq!(k.classify("ed25519-aabbccdd"), PublisherTrust::Revoked);
+    }
+    #[test]
+    fn seed_contains_official_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let k = PublisherKeyring::load_or_seed(dir.path()).unwrap();
+        assert!(k.publishers.iter().any(|p| p.key_fp == MUR_OFFICIAL_PUBLISHER_KEY_FP));
+        // round-trips from disk on second load
+        let k2 = PublisherKeyring::load_or_seed(dir.path()).unwrap();
+        assert_eq!(k2.classify(MUR_OFFICIAL_PUBLISHER_KEY_FP), PublisherTrust::Trusted);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-common --lib publisher_trust`
+Expected: FAIL — module/items not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```rust
+//! Publisher keyring — the client-pinned trust root for skill signatures.
+//! Turns P2's "signature is internally consistent" into "signed by a trusted
+//! publisher". Offline (SSH-known_hosts / apt-keyring style); no TUF, no Sigstore.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Fingerprint of the MUR-official publisher key, compiled in as the pinned
+/// trust anchor. (Placeholder until the registry CI publishes the real key;
+/// the registry-side signing task replaces this with the production fingerprint.)
+pub const MUR_OFFICIAL_PUBLISHER_KEY_FP: &str = "ed25519-0fficial";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PublisherTrust {
+    Trusted,
+    Revoked,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrustedPublisher {
+    pub name: String,
+    pub key_fp: String,
+    #[serde(default)]
+    pub comment: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PublisherKeyring {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub publishers: Vec<TrustedPublisher>,
+    #[serde(default)]
+    pub revoked: Vec<String>,
+}
+
+impl PublisherKeyring {
+    pub fn path(mur_home: &Path) -> PathBuf {
+        mur_home.join("trust").join("publishers.yaml")
+    }
+
+    fn seed() -> Self {
+        PublisherKeyring {
+            schema_version: 1,
+            publishers: vec![TrustedPublisher {
+                name: "mur".to_string(),
+                key_fp: MUR_OFFICIAL_PUBLISHER_KEY_FP.to_string(),
+                comment: "MUR official publisher (pinned trust root)".to_string(),
+            }],
+            revoked: Vec::new(),
+        }
+    }
+
+    /// Load the keyring; if absent, seed it with the pinned official key and persist.
+    pub fn load_or_seed(mur_home: &Path) -> anyhow::Result<Self> {
+        let p = Self::path(mur_home);
+        if p.exists() {
+            let text = std::fs::read_to_string(&p)
+                .map_err(|e| anyhow::anyhow!("read {}: {e}", p.display()))?;
+            serde_yaml_ng::from_str(&text).map_err(|e| anyhow::anyhow!("parse keyring: {e}"))
+        } else {
+            let k = Self::seed();
+            k.save(mur_home)?;
+            Ok(k)
+        }
+    }
+
+    pub fn save(&self, mur_home: &Path) -> anyhow::Result<()> {
+        let p = Self::path(mur_home);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| anyhow::anyhow!("mkdir: {e}"))?;
+        }
+        let text = serde_yaml_ng::to_string(self).map_err(|e| anyhow::anyhow!("serialize: {e}"))?;
+        std::fs::write(&p, text).map_err(|e| anyhow::anyhow!("write {}: {e}", p.display()))?;
+        Ok(())
+    }
+
+    /// Classify a signer key fingerprint. Revoked takes precedence (fail-closed).
+    pub fn classify(&self, key_fp: &str) -> PublisherTrust {
+        if self.revoked.iter().any(|r| r == key_fp) {
+            PublisherTrust::Revoked
+        } else if self.publishers.iter().any(|p| p.key_fp == key_fp) {
+            PublisherTrust::Trusted
+        } else {
+            PublisherTrust::Unknown
+        }
+    }
+}
+```
+
+Add to `mur-common/src/skill/mod.rs`: `pub mod publisher_trust;` (+ optional `pub use publisher_trust::{PublisherKeyring, PublisherTrust, TrustedPublisher, MUR_OFFICIAL_PUBLISHER_KEY_FP};`). Confirm `tempfile` is a dev-dep of mur-common (it is used elsewhere) and `serde_yaml_ng` is a dep.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-common --lib publisher_trust` → PASS. Then `cargo clippy --all --no-deps -- -D warnings`; `cargo fmt --all`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/skill/publisher_trust.rs mur-common/src/skill/mod.rs
+git commit -m "feat(skill): publisher keyring (pinned trust root + revoke + TOFU storage)"
+```
+
+---
+
+## Task 2: Signer trust classification + gate fold-in (mur-core)
+
+**Files:** Create `mur-core/src/cmd/agent/skill_signer_trust.rs`; Modify `mur-core/src/cmd/agent/{mod.rs,skill_registry_add.rs}`.
+
+**Interfaces:**
+- Consumes: Task 1 `PublisherKeyring`/`PublisherTrust`; `skill_verify::SignatureStatus`.
+- Produces: `pub enum SignerTrust { Trusted, Untrusted, Revoked, Unsigned, Invalid }`; `pub fn classify_signer(sig:&SignatureStatus, keyring:&PublisherKeyring) -> SignerTrust`. `ConsentInfo` gains `pub signer_trust: String` ("trusted"|"untrusted"|"revoked"|"unsigned"|"invalid"). `resolve_consent_in` gains a `keyring: &PublisherKeyring` param; folds signer trust into `blocking` (+= Revoked) and `needs_ack` (+= Untrusted). `gate()` is UNCHANGED.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::skill::publisher_trust::{PublisherKeyring, TrustedPublisher};
+    use crate::cmd::agent::skill_verify::SignatureStatus;
+
+    fn keyring(trusted: &str, revoked: &str) -> PublisherKeyring {
+        PublisherKeyring { schema_version:1,
+            publishers: vec![TrustedPublisher{name:"mur".into(),key_fp:trusted.into(),comment:String::new()}],
+            revoked: vec![revoked.into()] }
+    }
+    fn verified(fp: &str) -> SignatureStatus { SignatureStatus::Verified { publisher:"mur".into(), key_fp:fp.into() } }
+
+    #[test]
+    fn verified_known_key_is_trusted() {
+        let k = keyring("ed25519-trusted0", "ed25519-revoked0");
+        assert_eq!(classify_signer(&verified("ed25519-trusted0"), &k), SignerTrust::Trusted);
+    }
+    #[test]
+    fn verified_unknown_key_is_untrusted() {
+        let k = keyring("ed25519-trusted0", "ed25519-revoked0");
+        assert_eq!(classify_signer(&verified("ed25519-stranger"), &k), SignerTrust::Untrusted);
+    }
+    #[test]
+    fn verified_revoked_key_is_revoked() {
+        let k = keyring("ed25519-trusted0", "ed25519-revoked0");
+        assert_eq!(classify_signer(&verified("ed25519-revoked0"), &k), SignerTrust::Revoked);
+    }
+    #[test]
+    fn unsigned_and_invalid_passthrough() {
+        let k = keyring("a","b");
+        assert_eq!(classify_signer(&SignatureStatus::Unsigned, &k), SignerTrust::Unsigned);
+        assert_eq!(classify_signer(&SignatureStatus::Invalid, &k), SignerTrust::Invalid);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib skill_signer_trust` → FAIL.
+
+- [ ] **Step 3: Write the implementation**
+
+```rust
+//! Layer P2's `SignatureStatus` (self-consistent crypto check) onto the
+//! publisher keyring to decide whether a valid signature comes from a TRUSTED
+//! publisher. Pure — the gate consumes the result.
+
+use mur_common::skill::publisher_trust::{PublisherKeyring, PublisherTrust};
+
+use super::skill_verify::SignatureStatus;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignerTrust {
+    Trusted,   // valid signature, key in keyring
+    Untrusted, // valid signature, unknown key (TOFU candidate) — needs --yes
+    Revoked,   // valid signature, revoked key — unconditional block
+    Unsigned,
+    Invalid,
+}
+
+impl SignerTrust {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SignerTrust::Trusted => "trusted",
+            SignerTrust::Untrusted => "untrusted",
+            SignerTrust::Revoked => "revoked",
+            SignerTrust::Unsigned => "unsigned",
+            SignerTrust::Invalid => "invalid",
+        }
+    }
+}
+
+/// Classify a verified signature against the trust keyring.
+pub fn classify_signer(sig: &SignatureStatus, keyring: &PublisherKeyring) -> SignerTrust {
+    match sig {
+        SignatureStatus::Unsigned => SignerTrust::Unsigned,
+        SignatureStatus::Invalid => SignerTrust::Invalid,
+        SignatureStatus::Verified { key_fp, .. } => match keyring.classify(key_fp) {
+            PublisherTrust::Trusted => SignerTrust::Trusted,
+            PublisherTrust::Revoked => SignerTrust::Revoked,
+            PublisherTrust::Unknown => SignerTrust::Untrusted,
+        },
+    }
+}
+```
+
+Add `pub mod skill_signer_trust;` to `mur-core/src/cmd/agent/mod.rs`.
+
+Then in `skill_registry_add.rs`: add `pub signer_trust: String` to `ConsentInfo`; change `resolve_consent_in` to take `keyring: &PublisherKeyring`, and after building `VerifyOutcome`:
+
+```rust
+use super::skill_signer_trust::{SignerTrust, classify_signer};
+// ... inside resolve_consent_in, after `let outcome = verify_skill_install(...)`:
+let signer = classify_signer(&outcome.signature, keyring);
+let blocking = outcome.is_blocking() || matches!(signer, SignerTrust::Revoked);
+let needs_ack = outcome.needs_ack() || matches!(signer, SignerTrust::Untrusted);
+// set ConsentInfo { signer_trust: signer.as_str().to_string(), blocking, needs_ack, ... }
+```
+
+Update `resolve_consent` (the wrapper) to `let keyring = PublisherKeyring::load_or_seed(mur_home)?;` then pass `&keyring` into `resolve_consent_in`. Update `cmd_skill_registry_add` similarly (it already has `mur_home`). The `gate()` fn is untouched — it reads `blocking`/`needs_ack`/`scan_blocking` which now already account for signer trust.
+
+- [ ] **Step 4: Run tests**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib "skill_signer_trust"` and `... skill_registry_add` (update its tests to pass a fixture keyring to `resolve_consent_in`). PASS. Then `cargo clippy --all --no-deps -- -D warnings`; `cargo fmt --all`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/skill_signer_trust.rs mur-core/src/cmd/agent/mod.rs mur-core/src/cmd/agent/skill_registry_add.rs
+git commit -m "feat(skill): three-state signer trust (Trusted/Untrusted/Revoked) folded into the gate"
+```
+
+---
+
+## Task 3: Drift pin + detection + rollback (mur-common + mur-core)
+
+**Files:** Modify `mur-common/src/trust/skills.rs` (TrustEntry fields), `mur-core/src/cmd/agent/skill_signer_trust.rs` (pure `check_drift`), `mur-core/src/cmd/agent/skill_registry_add.rs` (pin on install + drift/rollback before gate).
+
+**Interfaces:**
+- Produces: `TrustEntry` gains `pub content_sha256: String` and `pub signer_key_fp: Option<String>` (both `#[serde(default)]`). `pub enum DriftDecision { None, Changed { what: String }, Rollback { installed: String, offered: String } }`; `pub fn check_drift(prior: Option<(&str /*hash*/, Option<&str> /*signer*/, &str /*ver*/)>, new_hash:&str, new_signer:Option<&str>, new_ver:&str) -> DriftDecision`.
+
+- [ ] **Step 1: Write the failing test** (pure drift logic)
+
+```rust
+#[cfg(test)]
+mod drift_tests {
+    use super::*;
+    #[test]
+    fn no_prior_is_no_drift() {
+        assert!(matches!(check_drift(None, "h1", Some("k1"), "1.0.0"), DriftDecision::None));
+    }
+    #[test]
+    fn same_everything_is_no_drift() {
+        assert!(matches!(check_drift(Some(("h1", Some("k1"), "1.0.0")), "h1", Some("k1"), "1.1.0"), DriftDecision::None));
+    }
+    #[test]
+    fn changed_hash_is_drift() {
+        assert!(matches!(check_drift(Some(("h1", Some("k1"), "1.0.0")), "h2", Some("k1"), "1.1.0"), DriftDecision::Changed{..}));
+    }
+    #[test]
+    fn changed_signer_is_drift() {
+        assert!(matches!(check_drift(Some(("h1", Some("k1"), "1.0.0")), "h1", Some("k2"), "1.1.0"), DriftDecision::Changed{..}));
+    }
+    #[test]
+    fn lower_version_is_rollback() {
+        assert!(matches!(check_drift(Some(("h1", Some("k1"), "2.0.0")), "h1", Some("k1"), "1.0.0"), DriftDecision::Rollback{..}));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib drift_tests` → FAIL.
+
+- [ ] **Step 3: Write the implementation**
+
+In `skill_signer_trust.rs`:
+
+```rust
+use semver::Version;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DriftDecision {
+    None,
+    Changed { what: String },                       // content or signer changed
+    Rollback { installed: String, offered: String },// offered version < installed
+}
+
+/// Compare a prior install record to the version about to be installed.
+/// `prior` = (installed content_sha256, installed signer key_fp, installed version).
+pub fn check_drift(
+    prior: Option<(&str, Option<&str>, &str)>,
+    new_hash: &str,
+    new_signer: Option<&str>,
+    new_ver: &str,
+) -> DriftDecision {
+    let Some((old_hash, old_signer, old_ver)) = prior else { return DriftDecision::None };
+    // Rollback: offered semver strictly lower than installed.
+    if let (Ok(o), Ok(n)) = (Version::parse(old_ver), Version::parse(new_ver))
+        && n < o
+    {
+        return DriftDecision::Rollback { installed: old_ver.to_string(), offered: new_ver.to_string() };
+    }
+    if !new_hash.is_empty() && !old_hash.is_empty() && new_hash != old_hash {
+        return DriftDecision::Changed { what: "content".to_string() };
+    }
+    if old_signer.is_some() && new_signer != old_signer {
+        return DriftDecision::Changed { what: "publisher".to_string() };
+    }
+    DriftDecision::None
+}
+```
+
+In `mur-common/src/trust/skills.rs`, extend `TrustEntry`:
+
+```rust
+    #[serde(default)]
+    pub content_sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signer_key_fp: Option<String>,
+```
+(Update any `TrustEntry { .. }` literal constructors in that file to include the new fields, or add `..Default::default()` if it derives Default — confirm and adapt.)
+
+In `skill_registry_add.rs::cmd_skill_registry_add`, BEFORE `gate(&consent, accept)`:
+
+```rust
+// Rug-pull / rollback: compare to the prior install record (if any).
+let store = mur_common::trust::skills::SkillTrustStore::load(&mur_home).unwrap_or_default();
+let prior = store.entries.values().find(|e| e.name == consent.name);
+let prior_tuple = prior.map(|e| (e.content_sha256.as_str(), e.signer_key_fp.as_deref(), e.version.as_str()));
+let new_signer_fp = if consent.signature.status == "verified" { Some(consent.signature.key_fp.as_str()) } else { None };
+match check_drift(prior_tuple, /*new_hash=*/&resolved_sha256, new_signer_fp, &consent.version) {
+    DriftDecision::None => {}
+    DriftDecision::Changed { what } if !accept => bail!(
+        "'{}' {} changed since you installed it — re-run with --yes to reinstall.", consent.name, what),
+    DriftDecision::Rollback { installed, offered } if !accept => bail!(
+        "refusing to downgrade '{}' {installed} → {offered} (rollback) — re-run with --yes to override.", consent.name),
+    _ => {}
+}
+
+gate(&consent, accept)?;
+// ... after cmd_skill_add succeeds, pin the record:
+let mut store = mur_common::trust::skills::SkillTrustStore::load(&mur_home).unwrap_or_default();
+store.entries.insert(consent.name.clone(), mur_common::trust::skills::TrustEntry {
+    name: consent.name.clone(),
+    version: consent.version.clone(),
+    level: mur_common::skill::TrustLevel::Sandboxed,
+    installed_at: /* reuse the existing timestamp helper used elsewhere in the crate */ now_rfc3339(),
+    publisher: Some(consent.publisher.clone()),
+    content_sha256: resolved_sha256.clone(),
+    signer_key_fp: new_signer_fp.map(|s| s.to_string()),
+});
+let _ = store.save(&mur_home);
+```
+(`resolved_sha256` = sha256 of the resolved file text — compute once where the file is read, or expose it on `ConsentInfo` as `pub resolved_sha256: String`; cleanest is to add that field in Task 2's `resolve_consent_in` since it already reads the file. Confirm the crate's existing RFC3339 timestamp helper — `cmd_skill_add`/TrustEntry construction elsewhere uses one — and reuse it rather than adding a dep.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-core --lib "skill_signer_trust"` + `cargo test -p mur-common --lib trust` + `... skill_registry_add`. PASS. Then `cargo clippy --all --no-deps -- -D warnings`; `cargo fmt --all`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/trust/skills.rs mur-core/src/cmd/agent/skill_signer_trust.rs mur-core/src/cmd/agent/skill_registry_add.rs
+git commit -m "feat(skill): pin content+signer on install; rug-pull drift + rollback re-prompt"
+```
+
+---
+
+## Task 4: CLI — trust-publisher (TOFU) + trust badge in consent
+
+**Files:** Modify `mur-core/src/cli/agent.rs` (`AgentSkillAction::TrustPublisher`), `mur-core/src/dispatch.rs`.
+
+**Interfaces:** Consumes Task 1 `PublisherKeyring`; Task 2 `ConsentInfo.signer_trust`.
+
+- [ ] **Step 1: Add the CLI variant** in `enum AgentSkillAction` (after `Search`):
+
+```rust
+    /// Trust a skill publisher key (TOFU) — adds it to ~/.mur/trust/publishers.yaml
+    /// so future installs signed by this key are treated as Trusted.
+    TrustPublisher {
+        /// Publisher key fingerprint (e.g. `ed25519-abcd1234`), shown in the
+        /// install consent screen for an unknown-but-verified signer.
+        key_fp: String,
+        /// Friendly name to record alongside the key.
+        #[arg(long)]
+        name: Option<String>,
+    },
+```
+
+- [ ] **Step 2: Wire dispatch** in `dispatch.rs` (next to the other `AgentSkillAction` arms):
+
+```rust
+            AgentSkillAction::TrustPublisher { key_fp, name } => {
+                let mur_home = cmd::agent::resolve_mur_home()?;
+                let mut kr = mur_common::skill::publisher_trust::PublisherKeyring::load_or_seed(&mur_home)?;
+                if kr.revoked.iter().any(|r| *r == key_fp) {
+                    anyhow::bail!("refusing to trust a revoked key: {key_fp}");
+                }
+                if !kr.publishers.iter().any(|p| p.key_fp == key_fp) {
+                    kr.publishers.push(mur_common::skill::publisher_trust::TrustedPublisher {
+                        name: name.clone().unwrap_or_else(|| "user-trusted".to_string()),
+                        key_fp: key_fp.clone(),
+                        comment: "added via trust-publisher (TOFU)".to_string(),
+                    });
+                    kr.save(&mur_home)?;
+                    println!("Trusted publisher {key_fp}. Skills signed by this key now install without --yes.");
+                } else {
+                    println!("Publisher {key_fp} is already trusted.");
+                }
+            }
+```
+
+Also augment the existing `RegistryAdd` consent printout to show the signer trust: in the consent-print block add `println!("Trust:     {}", c.signer_trust);` (so an unknown signer is visible, with the `key_fp` already printed by P2).
+
+- [ ] **Step 3: Build + verify**
+
+Run: `ORT_STRATEGY=download cargo build -p mur-core --bin mur` then `./target/debug/mur agent skill trust-publisher --help`. Then `cargo clippy --all --no-deps -- -D warnings`; `cargo fmt --all`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-core/src/cli/agent.rs mur-core/src/dispatch.rs
+git commit -m "feat(cli): mur agent skill trust-publisher (TOFU) + signer-trust in consent"
+```
+
+---
+
+## Task 5: Hub — trust badge + "Trust this publisher" action
+
+**Files:** Modify `mur-hub-gui/src-tauri/src/{mcp_skills.rs,lib.rs}`, `mur-hub-gui/ui/src/components/SkillRegistryModal.tsx`, i18n `en.ts`/`zh-TW.ts`.
+
+**Interfaces:** Consumes Task 1 keyring; Task 2 `ConsentInfo.signer_trust`.
+
+- [ ] **Step 1: Tauri command** in `mcp_skills.rs`:
+
+```rust
+/// Trust a publisher key (TOFU) from the Hub consent screen.
+#[tauri::command]
+pub async fn agent_skill_trust_publisher(key_fp: String, name: Option<String>) -> Result<(), String> {
+    let home = mur_core::cmd::agent::resolve_mur_home().map_err(|e| format!("{e:#}"))?;
+    let mut kr = mur_common::skill::publisher_trust::PublisherKeyring::load_or_seed(&home).map_err(|e| format!("{e:#}"))?;
+    if kr.revoked.iter().any(|r| *r == key_fp) { return Err(format!("key {key_fp} is revoked")); }
+    if !kr.publishers.iter().any(|p| p.key_fp == key_fp) {
+        kr.publishers.push(mur_common::skill::publisher_trust::TrustedPublisher {
+            name: name.unwrap_or_else(|| "user-trusted".to_string()), key_fp, comment: "TOFU (Hub)".to_string() });
+        kr.save(&home).map_err(|e| format!("{e:#}"))?;
+    }
+    Ok(())
+}
+```
+Register it in `lib.rs`'s `generate_handler![]`. (`ConsentInfo` already serialises `signer_trust` from Task 2 — no backend change to preview/install.)
+
+- [ ] **Step 2: Build** — `cargo check --manifest-path mur-hub-gui/src-tauri/Cargo.toml` (stub dist; don't commit) then clippy + fmt for that manifest.
+
+- [ ] **Step 3: UI** in `SkillRegistryModal.tsx` consent view: add a trust badge from `consent.signer_trust` (`trusted` → `✓ {t("skillreg.trusted")}`, `untrusted` → `⚠ {t("skillreg.untrusted")}` + a "Trust this publisher" button calling `invoke("agent_skill_trust_publisher", { keyFp: consent.signature.key_fp, name: consent.publisher })` then re-preview, `revoked` → `✗ {t("skillreg.revoked")}`). Add the `signer_trust` field to the TS `ConsentInfo` type. Gating already follows `blocking`/`needs_ack` from Task 2 (no change). i18n: add `skillreg.{trusted,untrusted,revoked,trustPublisher,trusted_done}` to BOTH `en.ts` + `zh-TW.ts` (Traditional Chinese).
+
+- [ ] **Step 4: Typecheck + build** — `cd mur-hub-gui/ui && npx tsc --noEmit && npm run build` (tsc 0; vite ok).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-hub-gui/src-tauri/src/mcp_skills.rs mur-hub-gui/src-tauri/src/lib.rs mur-hub-gui/ui/src/components/SkillRegistryModal.tsx mur-hub-gui/ui/src/i18n/en.ts mur-hub-gui/ui/src/i18n/zh-TW.ts
+git commit -m "feat(hub): publisher trust badge + Trust-this-publisher (TOFU) action"
+```
+
+- [ ] **Step 6: Live verify (manual)**
+
+Extend the P2 fixture registry with three signed skills: one signed by a key in `publishers.yaml` (installs silently — Trusted), one by an unknown key (needs `--yes`; `trust-publisher` then makes it silent — TOFU), one by a key listed in `revoked` (blocked unconditionally). Then reinstall a skill whose content changed (drift re-prompt) and a lower version (rollback refusal). Run via `mur agent skill registry-add` + the Hub Browse flow.
+
+---
+
+## Self-Review
+
+**Spec coverage:** §3.1 keyring → Task 1 ✓; §3.2 three-state signer trust → Task 2 ✓; §3.3 gate (Revoked→block, Untrusted→ack) → Task 2 folds into blocking/needs_ack, `gate()` unchanged ✓; §3.4 TOFU → Task 4 (CLI) + Task 5 (Hub) ✓; §3.5 drift pin + detection + rollback → Task 3 ✓; §3.6 registry CI → spec companion (out of plan scope, noted) ✓; §6 UX badges → Task 4/5 ✓. Revocation list (embedded + registry-fetched) — embedded via keyring `revoked` (Task 1); registry-fetched union is a noted follow-on (open question §9, not a task).
+
+**Placeholder scan:** the "confirm" notes (TrustEntry literal constructors, the crate's RFC3339 timestamp helper, `resolved_sha256` exposure) each name the exact file/symbol to check — implementer guidance, not vague placeholders. `MUR_OFFICIAL_PUBLISHER_KEY_FP` is a documented placeholder fingerprint the registry-CI companion replaces (called out in Global Constraints + the const doc-comment).
+
+**Type consistency:** `PublisherKeyring::classify -> PublisherTrust{Trusted,Revoked,Unknown}` (Task 1) consumed by `classify_signer -> SignerTrust{Trusted,Untrusted,Revoked,Unsigned,Invalid}` (Task 2); `SignerTrust` folded into `ConsentInfo.{blocking,needs_ack,signer_trust:String}` (Task 2) → surfaced CLI (Task 4) + Hub (Task 5). `check_drift -> DriftDecision{None,Changed,Rollback}` (Task 3) consumed in `cmd_skill_registry_add`. `TrustEntry.{content_sha256,signer_key_fp}` (Task 3) written on install + read for drift. `resolve_consent_in(registry_dir, skill, version, keyring)` signature consistent across Task 2/3 and the `resolve_consent` wrapper.

--- a/docs/superpowers/specs/2026-06-28-quill-p21-trust-roots-design.md
+++ b/docs/superpowers/specs/2026-06-28-quill-p21-trust-roots-design.md
@@ -1,0 +1,106 @@
+# Quill P2.1 — Publisher trust-roots, TOFU pinning & rug-pull drift detection
+
+**Status:** Design / spec
+**Date:** 2026-06-28
+**Codename:** quill (skills sibling of feather)
+**Builds on:** quill C / P2 (merged #531) — `skill_verify.rs` (DSSE/Ed25519 verify-on-install + content-hash), `skill_registry_add.rs` (per-agent install, fail-closed gate), `SkillTrustStore`.
+
+---
+
+## 1. Problem
+
+P2's verify-on-install proves a signature is **internally consistent** (the manifest was signed by the key embedded in its own DSSE envelope) — `SignatureStatus::Verified` means "self-signed correctly", **not** "signed by someone you trust". An attacker can mint their own Ed25519 key, sign a malicious skill with it, and it shows `Verified ✓`. The cosign rule from the research applies directly: **verifying that *a* key signed is insufficient — you must verify *which* identity signed.** P2.1 adds that missing layer, plus rug-pull/drift defense and the registry-side signing companion.
+
+## 2. Decision (research-grounded)
+
+Adopt **pinned-root + TOFU + drift detection** — NOT full TUF, NOT Sigstore keyless.
+
+### Why (deep-research 2026; primary sources)
+
+- **TUF** (root/targets/snapshot/timestamp roles, offline root, rollback/freeze protection) is the gold standard but **too heavy** for a curated git registry — 4 signing roles + metadata management + key ceremony. [TUF spec]
+- **Sigstore keyless** (Fulcio short-lived certs + Rekor transparency log + OIDC) **requires network at verify time** — breaks MUR's local-first / offline-capable requirement. Verification must also assert *both* identity *and* issuer. [cosign / Sigstore docs]
+- **Trusted Publishing** (npm/crates.io/PyPI: OIDC short-lived, workflow-bound CI credentials + auto provenance) is the right model for the **registry side** (how skills get *into* the repo) — and maps naturally onto MUR's git registry (PR + GitHub identity + CI). [crates.io RFC 3691, npm trusted publishers, SLSA]
+- **Content-hash pinning alone cannot distinguish a legitimate update from a malicious one** — that's exactly why a signer-identity layer is needed on top. [npm/OWASP]
+- **Pinned-key + TOFU** is the mature, offline, simple model (SSH `known_hosts`, apt keyrings). It reuses MUR's existing Ed25519/DSSE stack and adds the signer-identity layer that hash-pinning lacks.
+
+The verdict: a **client-pinned publisher keyring** (offline root of trust) + **TOFU** for unknown-but-valid publishers + **drift detection** (pin content-hash *and* signer at install, re-prompt on change) + **rollback protection** (monotonic version) — with registry-side CI signing as the companion.
+
+## 3. Design
+
+### 3.1 Publisher keyring (the trust root) — mur-common
+
+A client-side keyring of trusted publisher identities, `mur-common/src/skill/publisher_trust.rs`:
+- `PublisherKeyring { schema_version: u32, publishers: Vec<TrustedPublisher>, revoked: Vec<String> }` where `TrustedPublisher { name: String, key_fp: String, comment: String }` and `revoked` holds revoked `key_fp`s.
+- Loaded from `~/.mur/trust/publishers.yaml`; **seeded on first run** with the bundled MUR-official publisher key (a const `MUR_OFFICIAL_PUBLISHER_KEY_FP` compiled into the client — the pinned root). Users/teams may add entries.
+- `fn classify(keyring, key_fp) -> PublisherTrust` → `Trusted` (in `publishers`, not in `revoked`) / `Revoked` / `Unknown`.
+
+### 3.2 Three-state signature trust (extend P2's `SignatureStatus`)
+
+`skill_verify::verify_skill_install` already returns `SignatureStatus::Verified { publisher, key_fp }`. Add a trust classification on top (do NOT change the cryptographic check):
+- New `SignerTrust { Trusted, Untrusted, Revoked, Unsigned, Invalid }` computed by combining `SignatureStatus` with `PublisherKeyring::classify(key_fp)`:
+  - `Verified` + key in keyring → `Trusted`
+  - `Verified` + key unknown → `Untrusted` (TOFU candidate)
+  - `Verified` + key revoked → `Revoked`
+  - `Invalid`/`Unsigned` unchanged.
+- `verify_skill_install` gains a keyring parameter (or a sibling `classify_signer(outcome, &keyring)`), so the gate can distinguish "signed by a trusted publisher" from "signed by a stranger".
+
+### 3.3 Gate (extend P2's two-tier, fail-closed)
+
+The P2 gate stays; P2.1 refines the `needs_ack` tier and adds `Revoked` to the unconditional-block tier:
+- **Unconditional block** (not `--yes`-overridable): hash `Mismatch`, signature `Invalid`, **or signer `Revoked`** (a revoked key = proven-bad).
+- **Needs ack** (`--yes`): `Untrusted` signer (TOFU — valid sig, unknown publisher), `Unsigned`, absent hash, scan findings.
+- **Clean** (no prompt): hash `Match` + signer `Trusted` + no scan findings.
+
+### 3.4 TOFU pinning
+
+When a user installs an `Untrusted`-but-`Verified` skill with `--yes`, **offer to pin** that publisher: write `{name, key_fp}` into `publishers.yaml` (CLI: a follow-up `mur agent skill trust-publisher <key_fp> [--name]` or an interactive prompt; Hub: a "Trust this publisher" checkbox in consent). Subsequent installs from that publisher are `Trusted`. First-use pins it; later changes are caught by §3.5.
+
+### 3.5 Rug-pull / drift detection (on update / reinstall)
+
+Pin **both** `content_sha256` and `signer key_fp` at install into `SkillTrustStore::TrustEntry` (add `content_sha256: String` and `signer_key_fp: Option<String>` fields — they don't exist today). On `mur skill update` / re-`registry-add`:
+- Recompute; if `content_sha256` OR `signer_key_fp` differs from the pinned value → **re-prompt** ("This skill's content/publisher changed since you installed it: <old> → <new>. Reinstall?"), fail-closed without `--yes`.
+- **Rollback protection:** reject a registry `latest` whose semver is **lower** than the installed version (monotonic — TUF's cheap rollback defense), unless `--yes`.
+
+### 3.6 Registry-side signing (companion, repo-side — separate task)
+
+In `mur-run/skill-registry` CI (documented, not built here): on PR merge, GitHub identity authenticates the publisher (CODEOWNERS / PR author); CI computes `content_sha256` into `index.yaml` and signs each manifest's DSSE envelope with the **MUR-official key** (whose fingerprint the client pins). This is the "trusted publishing" model adapted to a git registry. Sigstore keyless is a *future* option (deferred — needs online verify).
+
+## 4. Data model
+
+- New: `~/.mur/trust/publishers.yaml` (`PublisherKeyring`).
+- Extend `TrustEntry` (mur-common/src/trust/skills.rs) with `content_sha256: String` (+ `#[serde(default)]`) and `signer_key_fp: Option<String>` — for drift detection. Backward-compatible (defaults).
+- Const `MUR_OFFICIAL_PUBLISHER_KEY_FP` (the pinned root) in mur-common.
+
+## 5. Security model
+
+- **Trust root:** a client-pinned official publisher key (offline; ships with the binary). `Verified` is no longer sufficient — only `Trusted` (in keyring) installs without a prompt.
+- **What this stops:** malicious-but-self-signed skills (now `Untrusted`, gated); a compromised registry host swapping a skill (content-hash mismatch → blocked; or signer changes → drift re-prompt); a revoked key (blocked); downgrade/rollback (monotonic version).
+- **What it does NOT stop** (documented): a compromised *official* signing key (mitigated by revocation-list shipped with client updates); a malicious skill from a publisher the user explicitly chose to trust (TOFU is trust-on-*first*-use — the user vouched). No transparency log (Sigstore/Rekor) — accepted for local-first.
+- Fail-closed throughout; `Revoked` joins the unconditional-block tier.
+
+## 6. UX (avoid alert fatigue)
+
+- `Trusted` + hash match + clean → **silent install** (no prompt) — the common path stays frictionless.
+- Only `Untrusted` / `Unsigned` / scan-findings / drift prompt for `--yes` (CLI) or a checkbox (Hub). Consent shows the signer `key_fp` + whether it's the official key.
+- Hub consent: a clear badge — `✓ Trusted publisher (MUR official)` / `⚠ Unknown publisher (key abcd…) — trust on install?` / `✗ Revoked` — plus a "Trust this publisher" action for TOFU.
+
+## 7. Testing
+
+- Unit: `PublisherKeyring::classify` (trusted/unknown/revoked); `classify_signer` matrix (Verified×{in-keyring, unknown, revoked} → Trusted/Untrusted/Revoked); gate (Revoked → unconditional block; Untrusted → needs `--yes`; Trusted+match+clean → no prompt); drift (changed hash or signer → re-prompt; rollback version → blocked).
+- Integration: fixture registry + fixture keyring → registry-add a trusted-signed skill (silent), an unknown-signer skill (needs `--yes`, TOFU pins), a revoked-signer skill (blocked), then a drifted update (re-prompt).
+- Hub: consent renders the trust badge + TOFU action; gate honored.
+- Manual/live: extend the P2 fixture with a signed skill from a keyring'd key vs an unknown key vs a revoked key.
+
+## 8. Non-goals
+
+- Full TUF (roles/snapshot/timestamp metadata).
+- Sigstore keyless / Rekor transparency log (needs online verify; future option).
+- Web-of-trust / key endorsement graphs.
+- The registry-repo CI itself (§3.6 is a companion task in `mur-run/skill-registry`).
+- Automatic key distribution beyond shipping the pinned root + revocation list with client updates.
+
+## 9. Open questions
+
+- TOFU prompt vs explicit `mur agent skill trust-publisher` only? (Lean: Hub checkbox + CLI explicit command; no silent auto-pin.)
+- Ship the revocation list embedded in the client, or fetch a signed `revocations.yaml` from the registry? (Lean: embedded + registry-fetched union, both signed by the pinned root.)
+- Should `Untrusted` (valid sig, unknown publisher) require `--yes` *and* a TOFU pin, or just `--yes`? (Lean: `--yes` installs; pinning is a separate opt-in so a one-off install doesn't grow the keyring.)

--- a/mur-common/src/skill/mod.rs
+++ b/mur-common/src/skill/mod.rs
@@ -18,6 +18,7 @@ pub mod manifest;
 pub mod mcp;
 pub mod parser;
 pub mod peers;
+pub mod publisher_trust;
 pub mod registry;
 pub mod resolve;
 pub mod scan;
@@ -52,6 +53,9 @@ pub use mcp::{McpRequirement, ParseCapabilityError, SkillCapability, validate_re
 pub use parser::{
     ParseError, parse_canonical, parse_legacy_markdown, parse_markdown, serialize_canonical,
     serialize_markdown, yaml_to_markdown,
+};
+pub use publisher_trust::{
+    MUR_OFFICIAL_PUBLISHER_KEY_FP, PublisherKeyring, PublisherTrust, TrustedPublisher,
 };
 pub use resolve::{Resolution, resolve_step};
 pub use sign::{SKILL_PAYLOAD_TYPE, SignError, sign_manifest, verify_manifest};

--- a/mur-common/src/skill/publisher_trust.rs
+++ b/mur-common/src/skill/publisher_trust.rs
@@ -1,0 +1,174 @@
+//! Publisher trust keyring — SSH-style pinned trust roots for skill signature verification.
+//!
+//! `PublisherKeyring` lives at `~/.mur/trust/publishers.yaml` and is seeded on first
+//! use with the MUR official publisher fingerprint.  Downstream units consult
+//! `classify()` to decide whether a DSSE signer is Trusted / Revoked / Unknown.
+
+use anyhow::Context as _;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Pinned MUR official publisher key fingerprint (trust anchor).
+/// This is a placeholder; the registry-side signing task replaces it with the real fingerprint.
+/// No other values are hardcoded — all trust decisions flow through the keyring.
+pub const MUR_OFFICIAL_PUBLISHER_KEY_FP: &str = "ed25519-0fficial";
+
+/// Trust classification for a signer fingerprint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PublisherTrust {
+    Trusted,
+    Revoked,
+    Unknown,
+}
+
+/// A single trusted publisher entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrustedPublisher {
+    pub name: String,
+    pub key_fp: String,
+    #[serde(default)]
+    pub comment: String,
+}
+
+/// Serialisable publisher keyring stored at `~/.mur/trust/publishers.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PublisherKeyring {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub publishers: Vec<TrustedPublisher>,
+    #[serde(default)]
+    pub revoked: Vec<String>,
+}
+
+impl PublisherKeyring {
+    /// Canonical on-disk path for the keyring.
+    // Used by later units (install / verify paths); suppress until wired.
+    #[allow(dead_code)]
+    pub fn path(mur_home: &Path) -> PathBuf {
+        mur_home.join("trust").join("publishers.yaml")
+    }
+
+    /// Classify a key fingerprint.
+    ///
+    /// **Revoked always takes precedence over Trusted (fail-closed):** a key that
+    /// appears in both `publishers` and `revoked` is classified `Revoked`.
+    // Used by later units (verify step); suppress until wired.
+    #[allow(dead_code)]
+    pub fn classify(&self, key_fp: &str) -> PublisherTrust {
+        if self.revoked.iter().any(|r| r == key_fp) {
+            return PublisherTrust::Revoked;
+        }
+        if self.publishers.iter().any(|p| p.key_fp == key_fp) {
+            return PublisherTrust::Trusted;
+        }
+        PublisherTrust::Unknown
+    }
+
+    /// Build the seeded keyring containing only the pinned official publisher key.
+    fn seed() -> Self {
+        PublisherKeyring {
+            schema_version: 1,
+            publishers: vec![TrustedPublisher {
+                name: "mur".to_string(),
+                key_fp: MUR_OFFICIAL_PUBLISHER_KEY_FP.to_string(),
+                comment: "MUR official publisher (pinned trust root)".to_string(),
+            }],
+            revoked: Vec::new(),
+        }
+    }
+
+    /// Load the keyring from disk; if absent, seed with the pinned official key and persist.
+    // Used by later units (install / verify paths); suppress until wired.
+    #[allow(dead_code)]
+    pub fn load_or_seed(mur_home: &Path) -> anyhow::Result<Self> {
+        let p = Self::path(mur_home);
+        if p.exists() {
+            let text =
+                std::fs::read_to_string(&p).with_context(|| format!("read {}", p.display()))?;
+            serde_yaml_ng::from_str(&text)
+                .map_err(|e| anyhow::anyhow!("parse publisher keyring: {e}"))
+        } else {
+            let kr = Self::seed();
+            kr.save(mur_home)?;
+            Ok(kr)
+        }
+    }
+
+    /// Persist the keyring to disk using temp-file + rename for atomicity.
+    // Used by later units (TOFU write-back); suppress until wired.
+    #[allow(dead_code)]
+    pub fn save(&self, mur_home: &Path) -> anyhow::Result<()> {
+        let p = Self::path(mur_home);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create dir {}", parent.display()))?;
+        }
+        let yaml = serde_yaml_ng::to_string(self)
+            .map_err(|e| anyhow::anyhow!("serialize publisher keyring: {e}"))?;
+        // Atomic write: write to a sibling .tmp then rename.
+        let tmp_path = p.with_extension("yaml.tmp");
+        std::fs::write(&tmp_path, yaml.as_bytes())
+            .with_context(|| format!("write {}", tmp_path.display()))?;
+        std::fs::rename(&tmp_path, &p)
+            .with_context(|| format!("rename {} -> {}", tmp_path.display(), p.display()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kr() -> PublisherKeyring {
+        PublisherKeyring {
+            schema_version: 1,
+            publishers: vec![TrustedPublisher {
+                name: "mur".into(),
+                key_fp: "ed25519-aabbccdd".into(),
+                comment: "official".into(),
+            }],
+            revoked: vec!["ed25519-deadbeef".into()],
+        }
+    }
+
+    #[test]
+    fn classify_trusted_revoked_unknown() {
+        let k = kr();
+        assert_eq!(k.classify("ed25519-aabbccdd"), PublisherTrust::Trusted);
+        assert_eq!(k.classify("ed25519-deadbeef"), PublisherTrust::Revoked);
+        assert_eq!(k.classify("ed25519-00000000"), PublisherTrust::Unknown);
+    }
+
+    #[test]
+    fn revoked_beats_trusted() {
+        // A key both listed AND revoked must classify Revoked (fail-closed).
+        let k = PublisherKeyring {
+            schema_version: 1,
+            publishers: vec![TrustedPublisher {
+                name: "mur".into(),
+                key_fp: "ed25519-aabbccdd".into(),
+                comment: String::new(),
+            }],
+            revoked: vec!["ed25519-aabbccdd".into()],
+        };
+        assert_eq!(k.classify("ed25519-aabbccdd"), PublisherTrust::Revoked);
+    }
+
+    #[test]
+    fn load_or_seed_creates_file_with_official_key() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let kr = PublisherKeyring::load_or_seed(tmp.path()).expect("load_or_seed");
+        assert_eq!(
+            kr.classify(MUR_OFFICIAL_PUBLISHER_KEY_FP),
+            PublisherTrust::Trusted
+        );
+        // File must now exist on disk.
+        assert!(PublisherKeyring::path(tmp.path()).exists());
+        // Round-trip: reload → same result.
+        let kr2 = PublisherKeyring::load_or_seed(tmp.path()).expect("reload");
+        assert_eq!(
+            kr2.classify(MUR_OFFICIAL_PUBLISHER_KEY_FP),
+            PublisherTrust::Trusted
+        );
+    }
+}

--- a/mur-common/src/skill/publisher_trust.rs
+++ b/mur-common/src/skill/publisher_trust.rs
@@ -42,8 +42,6 @@ pub struct PublisherKeyring {
 
 impl PublisherKeyring {
     /// Canonical on-disk path for the keyring.
-    // Used by later units (install / verify paths); suppress until wired.
-    #[allow(dead_code)]
     pub fn path(mur_home: &Path) -> PathBuf {
         mur_home.join("trust").join("publishers.yaml")
     }
@@ -52,8 +50,6 @@ impl PublisherKeyring {
     ///
     /// **Revoked always takes precedence over Trusted (fail-closed):** a key that
     /// appears in both `publishers` and `revoked` is classified `Revoked`.
-    // Used by later units (verify step); suppress until wired.
-    #[allow(dead_code)]
     pub fn classify(&self, key_fp: &str) -> PublisherTrust {
         if self.revoked.iter().any(|r| r == key_fp) {
             return PublisherTrust::Revoked;
@@ -78,8 +74,6 @@ impl PublisherKeyring {
     }
 
     /// Load the keyring from disk; if absent, seed with the pinned official key and persist.
-    // Used by later units (install / verify paths); suppress until wired.
-    #[allow(dead_code)]
     pub fn load_or_seed(mur_home: &Path) -> anyhow::Result<Self> {
         let p = Self::path(mur_home);
         if p.exists() {
@@ -95,8 +89,6 @@ impl PublisherKeyring {
     }
 
     /// Persist the keyring to disk using temp-file + rename for atomicity.
-    // Used by later units (TOFU write-back); suppress until wired.
-    #[allow(dead_code)]
     pub fn save(&self, mur_home: &Path) -> anyhow::Result<()> {
         let p = Self::path(mur_home);
         if let Some(parent) = p.parent() {

--- a/mur-common/src/trust/skills.rs
+++ b/mur-common/src/trust/skills.rs
@@ -17,7 +17,7 @@ pub struct SkillTrustStore {
     pub revoked: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TrustEntry {
     pub name: String,
     pub version: String,
@@ -25,6 +25,12 @@ pub struct TrustEntry {
     pub installed_at: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub publisher: Option<String>,
+    /// SHA-256 hex of the installed skill YAML; used for rug-pull detection.
+    #[serde(default)]
+    pub content_sha256: String,
+    /// Key fingerprint of the signer at install time; used for publisher-change detection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signer_key_fp: Option<String>,
 }
 
 #[derive(Debug)]
@@ -147,6 +153,7 @@ mod tests {
             level: TrustLevel::Verified,
             installed_at: "2026-05-24T00:00:00Z".into(),
             publisher: Some("human:t".into()),
+            ..Default::default()
         }
     }
 

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -755,6 +755,17 @@ pub enum AgentSkillAction {
         /// Search query
         query: String,
     },
+    /// Trust a skill publisher key (TOFU) — adds it to `~/.mur/trust/publishers.yaml`
+    /// so future installs signed by that key are treated as Trusted.
+    /// The fingerprint is shown in the install consent screen for
+    /// unknown-but-verified signers.
+    TrustPublisher {
+        /// Publisher key fingerprint (e.g. `ed25519-abcd1234`)
+        key_fp: String,
+        /// Friendly name recorded alongside the key
+        #[arg(long)]
+        name: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -54,6 +54,7 @@ pub mod skill;
 pub mod skill_bundle;
 pub mod skill_registry_add;
 pub mod skill_remote;
+pub mod skill_signer_trust;
 pub mod skill_verify;
 mod snapshot;
 pub mod stale;

--- a/mur-core/src/cmd/agent/skill_registry_add.rs
+++ b/mur-core/src/cmd/agent/skill_registry_add.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use anyhow::{Result, bail};
 use semver::Version;
 
-use super::skill_signer_trust::{SignerTrust, classify_signer};
+use super::skill_signer_trust::{DriftDecision, SignerTrust, check_drift, classify_signer};
 use super::skill_verify::{HashStatus, SignatureStatus, VerifyOutcome, verify_skill_install};
 use crate::cmd::skill_registry;
 use mur_common::skill::loader::is_valid_skill_name;
@@ -51,6 +51,8 @@ pub struct ConsentInfo {
     pub signer_trust: String,
     /// Raw YAML body of the resolved skill file (for Hub preview / consent display).
     pub body: String,
+    /// SHA-256 hex of the resolved skill YAML file (pinned at install; used for rug-pull detection).
+    pub resolved_sha256: String,
 }
 
 /// Serialisable view of `SignatureStatus`.
@@ -193,6 +195,12 @@ pub fn resolve_consent_in(
     let manifest =
         parse_canonical(&text).map_err(|e| anyhow::anyhow!("parse skill manifest: {e}"))?;
 
+    // Compute the actual sha256 of the resolved file for drift-pinning.
+    let resolved_sha256 = {
+        use sha2::{Digest, Sha256};
+        hex::encode(Sha256::digest(text.as_bytes()))
+    };
+
     let outcome: VerifyOutcome = verify_skill_install(&manifest, &text, &entry.content_sha256);
     let signer = classify_signer(&outcome.signature, keyring);
     // Fold publisher keyring trust into the gate flags:
@@ -223,6 +231,7 @@ pub fn resolve_consent_in(
         trust_level: "sandboxed".to_string(),
         signer_trust: signer.as_str().to_string(),
         body: text,
+        resolved_sha256,
     })
 }
 
@@ -258,14 +267,87 @@ pub async fn cmd_skill_registry_add(
     let keyring = PublisherKeyring::load_or_seed(&mur_home)?;
     let consent = resolve_consent_in(&dir, skill, version, &keyring)?;
 
+    // ── Rug-pull / rollback: compare against any prior install record ────────
+    let trust_store =
+        mur_common::trust::skills::SkillTrustStore::load(&mur_home).unwrap_or_default();
+    let prior = trust_store
+        .entries
+        .values()
+        .find(|e| e.name == consent.name);
+    let prior_tuple = prior.map(|e| {
+        (
+            e.content_sha256.as_str(),
+            e.signer_key_fp.as_deref(),
+            e.version.as_str(),
+        )
+    });
+    let new_signer_fp = if consent.signature.status == "verified" {
+        Some(consent.signature.key_fp.as_str())
+    } else {
+        None
+    };
+    match check_drift(
+        prior_tuple,
+        &consent.resolved_sha256,
+        new_signer_fp,
+        &consent.version,
+    ) {
+        DriftDecision::None => {}
+        DriftDecision::Changed { what } => {
+            if !accept {
+                anyhow::bail!(
+                    "skill '{}' has changed {} since last install; pass --yes to accept the update.",
+                    consent.name,
+                    what
+                );
+            }
+        }
+        DriftDecision::Rollback { installed, offered } => {
+            if !accept {
+                anyhow::bail!(
+                    "skill '{}' downgrade refused (installed={installed}, offered={offered}); pass --yes to force.",
+                    consent.name
+                );
+            }
+        }
+    }
+
     gate(&consent, accept)?;
 
     let path = skill_registry::skill_yaml_path(&dir, skill, &consent.version);
     super::skill::cmd_skill_add(agent, &path.to_string_lossy())?;
 
-    // Registry skills load at the loader's default TrustLevel::Sandboxed (no
-    // explicit pin). A hash-keyed Sandboxed pin (+ rug-pull drift detection) is
-    // a P2.1 follow-on.
+    // Pin content hash + signer key in the trust store for future drift detection.
+    {
+        use mur_common::skill::TrustLevel;
+        use mur_common::trust::skills::{SkillTrustStore, TrustEntry};
+        let mut ts = SkillTrustStore::load(&mur_home).unwrap_or_default();
+        // Key the entry by the skill name so we can find it by name on the next
+        // install (the hash-keyed lookup is for load-time allow-listing; the
+        // name-keyed find is for drift detection).
+        ts.entries.insert(
+            consent.name.clone(),
+            TrustEntry {
+                name: consent.name.clone(),
+                version: consent.version.clone(),
+                level: TrustLevel::Sandboxed,
+                installed_at: chrono::Utc::now().to_rfc3339(),
+                publisher: if consent.publisher.is_empty() {
+                    None
+                } else {
+                    Some(consent.publisher.clone())
+                },
+                content_sha256: consent.resolved_sha256.clone(),
+                signer_key_fp: if consent.signature.key_fp.is_empty() {
+                    None
+                } else {
+                    Some(consent.signature.key_fp.clone())
+                },
+            },
+        );
+        ts.save(&mur_home)
+            .map_err(|e| anyhow::anyhow!("save trust store: {e}"))?;
+    }
 
     Ok(format!("skills/{}", consent.name))
 }
@@ -509,6 +591,7 @@ mcp_requirements:
             trust_level: "sandboxed".into(),
             signer_trust: "trusted".into(),
             body: "".into(),
+            resolved_sha256: "aabbcc".into(),
         }
     }
 

--- a/mur-core/src/cmd/agent/skill_registry_add.rs
+++ b/mur-core/src/cmd/agent/skill_registry_add.rs
@@ -10,9 +10,11 @@ use std::path::Path;
 use anyhow::{Result, bail};
 use semver::Version;
 
+use super::skill_signer_trust::{SignerTrust, classify_signer};
 use super::skill_verify::{HashStatus, SignatureStatus, VerifyOutcome, verify_skill_install};
 use crate::cmd::skill_registry;
 use mur_common::skill::loader::is_valid_skill_name;
+use mur_common::skill::publisher_trust::PublisherKeyring;
 use mur_common::skill::{parse_canonical, scan::scan_skill};
 
 // ─── Consent / view types ──────────────────────────────────────────────────
@@ -44,6 +46,9 @@ pub struct ConsentInfo {
     pub scan_blocking: bool,
     /// Trust level that will be applied on install (always `"sandboxed"`).
     pub trust_level: String,
+    /// Publisher keyring classification of the signer:
+    /// `"trusted"` | `"untrusted"` | `"revoked"` | `"unsigned"` | `"invalid"`.
+    pub signer_trust: String,
     /// Raw YAML body of the resolved skill file (for Hub preview / consent display).
     pub body: String,
 }
@@ -139,12 +144,17 @@ pub fn gate(consent: &ConsentInfo, accept: bool) -> Result<()> {
 /// Resolve a skill from a local registry directory into a `ConsentInfo`
 /// (hash-check + signature-verify + content-scan). Does **not** install.
 ///
+/// `keyring` is the caller's publisher trust keyring; signer trust is folded
+/// into `blocking` (Revoked → unconditional block) and `needs_ack` (Untrusted
+/// → requires `--yes`).
+///
 /// This is the network-free test seam. `resolve_consent` wraps it after
 /// calling `fetch_and_load` to obtain the registry dir.
 pub fn resolve_consent_in(
     registry_dir: &Path,
     skill: &str,
     version: Option<&str>,
+    keyring: &PublisherKeyring,
 ) -> Result<ConsentInfo> {
     // Fix D: reject index-controlled path traversal in skill name.
     if !is_valid_skill_name(skill) {
@@ -184,6 +194,12 @@ pub fn resolve_consent_in(
         parse_canonical(&text).map_err(|e| anyhow::anyhow!("parse skill manifest: {e}"))?;
 
     let outcome: VerifyOutcome = verify_skill_install(&manifest, &text, &entry.content_sha256);
+    let signer = classify_signer(&outcome.signature, keyring);
+    // Fold publisher keyring trust into the gate flags:
+    // - Revoked → unconditional block (proven unsafe signer).
+    // - Untrusted → requires --yes (signature valid but signer not in keyring).
+    let blocking = outcome.is_blocking() || matches!(signer, SignerTrust::Revoked);
+    let needs_ack = outcome.needs_ack() || matches!(signer, SignerTrust::Untrusted);
     let report = scan_skill(&manifest).map_err(|e| anyhow::anyhow!("content scan: {e}"))?;
     let scan_blocking = report.has_blocking_findings();
 
@@ -201,10 +217,11 @@ pub fn resolve_consent_in(
             .collect(),
         // ContentScanReport has no flat `findings` field — use human_summary().
         findings: report.human_summary(),
-        blocking: outcome.is_blocking(),
-        needs_ack: outcome.needs_ack(),
+        blocking,
+        needs_ack,
         scan_blocking,
         trust_level: "sandboxed".to_string(),
+        signer_trust: signer.as_str().to_string(),
         body: text,
     })
 }
@@ -216,7 +233,8 @@ pub fn resolve_consent_in(
 #[allow(dead_code)] // wired by the CLI/Hub units
 pub fn resolve_consent(mur_home: &Path, skill: &str, version: Option<&str>) -> Result<ConsentInfo> {
     let (dir, _idx) = skill_registry::fetch_and_load(mur_home, skill_registry::DEFAULT_REGISTRY)?;
-    resolve_consent_in(&dir, skill, version)
+    let keyring = PublisherKeyring::load_or_seed(mur_home)?;
+    resolve_consent_in(&dir, skill, version, &keyring)
 }
 
 /// Install a registry skill onto a specific agent at `TrustLevel::Sandboxed`.
@@ -237,7 +255,8 @@ pub async fn cmd_skill_registry_add(
     // Keep `dir` in scope so the already-resolved file stays on disk while we
     // pass its path to `cmd_skill_add` — no redundant temp copy needed.
     let (dir, _idx) = skill_registry::fetch_and_load(&mur_home, skill_registry::DEFAULT_REGISTRY)?;
-    let consent = resolve_consent_in(&dir, skill, version)?;
+    let keyring = PublisherKeyring::load_or_seed(&mur_home)?;
+    let consent = resolve_consent_in(&dir, skill, version, &keyring)?;
 
     gate(&consent, accept)?;
 
@@ -276,9 +295,19 @@ pub fn registry_search_for_agent(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mur_common::skill::publisher_trust::PublisherKeyring;
     use std::fs;
 
     // ── fixture helpers ─────────────────────────────────────────────────
+
+    /// Keyring with no trusted or revoked entries (all signers → Unsigned/Untrusted).
+    fn empty_keyring() -> PublisherKeyring {
+        PublisherKeyring {
+            schema_version: 1,
+            publishers: vec![],
+            revoked: vec![],
+        }
+    }
 
     const SKILL_YAML: &str = r#"name: test-skill
 version: 1.0.0
@@ -316,7 +345,7 @@ content:
         let tmp = tempfile::tempdir().unwrap();
         fixture_registry(tmp.path(), "");
 
-        let consent = resolve_consent_in(tmp.path(), "test-skill", None).unwrap();
+        let consent = resolve_consent_in(tmp.path(), "test-skill", None, &empty_keyring()).unwrap();
 
         assert_eq!(consent.name, "test-skill");
         assert_eq!(consent.version, "1.0.0");
@@ -336,7 +365,7 @@ content:
         let sha = sha256_hex(SKILL_YAML);
         fixture_registry(tmp.path(), &sha);
 
-        let consent = resolve_consent_in(tmp.path(), "test-skill", None).unwrap();
+        let consent = resolve_consent_in(tmp.path(), "test-skill", None, &empty_keyring()).unwrap();
 
         assert_eq!(consent.hash, "match");
         assert_eq!(consent.signature.status, "unsigned");
@@ -350,7 +379,7 @@ content:
         let tmp = tempfile::tempdir().unwrap();
         fixture_registry(tmp.path(), "deadbeef0000000000000000bad");
 
-        let consent = resolve_consent_in(tmp.path(), "test-skill", None).unwrap();
+        let consent = resolve_consent_in(tmp.path(), "test-skill", None, &empty_keyring()).unwrap();
 
         assert_eq!(consent.hash, "mismatch");
         assert!(consent.blocking, "mismatch must be blocking");
@@ -362,7 +391,8 @@ content:
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("index.yaml"), "skills: {}\n").unwrap();
 
-        let err = resolve_consent_in(tmp.path(), "nonexistent", None).unwrap_err();
+        let err =
+            resolve_consent_in(tmp.path(), "nonexistent", None, &empty_keyring()).unwrap_err();
         assert!(err.to_string().contains("not found in registry"));
     }
 
@@ -373,7 +403,8 @@ content:
         fixture_registry(tmp.path(), "");
 
         // Request a version that doesn't exist and is not `latest`.
-        let err = resolve_consent_in(tmp.path(), "test-skill", Some("9.9.9")).unwrap_err();
+        let err = resolve_consent_in(tmp.path(), "test-skill", Some("9.9.9"), &empty_keyring())
+            .unwrap_err();
         assert!(
             err.to_string().contains("not in registry"),
             "unexpected error: {err}"
@@ -386,7 +417,8 @@ content:
         fixture_registry(tmp.path(), "");
 
         // Requesting the exact version that exists should succeed.
-        let consent = resolve_consent_in(tmp.path(), "test-skill", Some("1.0.0")).unwrap();
+        let consent =
+            resolve_consent_in(tmp.path(), "test-skill", Some("1.0.0"), &empty_keyring()).unwrap();
         assert_eq!(consent.version, "1.0.0");
     }
 
@@ -395,7 +427,7 @@ content:
         let tmp = tempfile::tempdir().unwrap();
         fixture_registry(tmp.path(), "");
 
-        let consent = resolve_consent_in(tmp.path(), "test-skill", None).unwrap();
+        let consent = resolve_consent_in(tmp.path(), "test-skill", None, &empty_keyring()).unwrap();
         assert!(
             consent.findings.is_empty(),
             "clean skill should have no findings"
@@ -424,7 +456,7 @@ mcp_requirements:
         fs::create_dir_all(&versions_dir).unwrap();
         fs::write(versions_dir.join("1.0.0.yaml"), skill_with_mcp).unwrap();
 
-        let consent = resolve_consent_in(tmp.path(), "mcp-skill", None).unwrap();
+        let consent = resolve_consent_in(tmp.path(), "mcp-skill", None, &empty_keyring()).unwrap();
         assert_eq!(consent.mcp_requirements.len(), 1);
         assert!(consent.mcp_requirements[0].contains("browser.*"));
         assert!(consent.mcp_requirements[0].contains("network_http"));
@@ -436,7 +468,7 @@ mcp_requirements:
         let tmp = tempfile::tempdir().unwrap();
         fixture_registry(tmp.path(), "");
 
-        let err = resolve_consent_in(tmp.path(), "../evil", None).unwrap_err();
+        let err = resolve_consent_in(tmp.path(), "../evil", None, &empty_keyring()).unwrap_err();
         assert!(
             err.to_string().contains("invalid skill name"),
             "unexpected: {err}"
@@ -448,7 +480,8 @@ mcp_requirements:
         let tmp = tempfile::tempdir().unwrap();
         fixture_registry(tmp.path(), "");
 
-        let err = resolve_consent_in(tmp.path(), "test-skill", Some("../evil")).unwrap_err();
+        let err = resolve_consent_in(tmp.path(), "test-skill", Some("../evil"), &empty_keyring())
+            .unwrap_err();
         assert!(
             err.to_string().contains("invalid version"),
             "unexpected: {err}"
@@ -474,6 +507,7 @@ mcp_requirements:
             needs_ack: false,
             scan_blocking: false,
             trust_level: "sandboxed".into(),
+            signer_trust: "trusted".into(),
             body: "".into(),
         }
     }

--- a/mur-core/src/cmd/agent/skill_registry_add.rs
+++ b/mur-core/src/cmd/agent/skill_registry_add.rs
@@ -53,6 +53,12 @@ pub struct ConsentInfo {
     pub body: String,
     /// SHA-256 hex of the resolved skill YAML file (pinned at install; used for rug-pull detection).
     pub resolved_sha256: String,
+    /// Short human description of detected drift since the last install:
+    /// `"content changed"`, `"publisher changed"`, `"downgrade X → Y"`, or `None`.
+    /// When set, `needs_ack` is also `true` (in `resolve_consent`; not in `resolve_consent_in`
+    /// which has no trust store).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub drift: Option<String>,
 }
 
 /// Serialisable view of `SignatureStatus`.
@@ -232,18 +238,85 @@ pub fn resolve_consent_in(
         signer_trust: signer.as_str().to_string(),
         body: text,
         resolved_sha256,
+        // Drift is computed only by resolve_consent (has mur_home) and
+        // cmd_skill_registry_add; left None here (test seam has no trust store).
+        drift: None,
     })
+}
+
+// ─── Drift helper (shared by resolve_consent + cmd_skill_registry_add) ──────
+
+/// Load the trust store and check for drift against the prior install.
+///
+/// Returns `(description, decision)`:
+/// - `description` — a short human string (`"content changed"`, `"publisher changed"`,
+///   `"downgrade X → Y"`), or `None` for first install or no drift.
+/// - `decision` — the raw `DriftDecision` for control flow in `cmd_skill_registry_add`.
+///
+/// Uses `entries.get(name)` — registry-add pins its entry keyed by name; other install
+/// paths (`mur skill install` etc.) write hash-keyed entries. Iterating `.values()` and
+/// matching on `.name` may return a stale hash-keyed entry whose empty `content_sha256`
+/// makes `check_drift` skip both comparisons → silent rug-pull (C1 fix).
+fn drift_status(
+    mur_home: &Path,
+    name: &str,
+    new_hash: &str,
+    new_signer: Option<&str>,
+    new_ver: &str,
+) -> (Option<String>, DriftDecision) {
+    let trust_store =
+        mur_common::trust::skills::SkillTrustStore::load(mur_home).unwrap_or_default();
+    // Registry-add pins by name; other paths key by hash — look up by name.
+    let prior = trust_store.entries.get(name);
+    let prior_tuple = prior.map(|e| {
+        (
+            e.content_sha256.as_str(),
+            e.signer_key_fp.as_deref(),
+            e.version.as_str(),
+        )
+    });
+    let decision = check_drift(prior_tuple, new_hash, new_signer, new_ver);
+    let description = match &decision {
+        DriftDecision::None => None,
+        DriftDecision::Changed { what } => Some(format!("{what} changed")),
+        DriftDecision::Rollback { installed, offered } => {
+            Some(format!("downgrade {installed} → {offered}"))
+        }
+    };
+    (description, decision)
 }
 
 // ─── Public entry points ───────────────────────────────────────────────────
 
 /// Fetch the registry (git) then resolve consent. Hub preview + CLI confirm
 /// both call this; neither installs until the gate passes.
+///
+/// Drift against a prior install is computed here (we have `mur_home`), folded
+/// into `needs_ack`, and surfaced as `consent.drift` for the Hub modal.
 #[allow(dead_code)] // wired by the CLI/Hub units
 pub fn resolve_consent(mur_home: &Path, skill: &str, version: Option<&str>) -> Result<ConsentInfo> {
     let (dir, _idx) = skill_registry::fetch_and_load(mur_home, skill_registry::DEFAULT_REGISTRY)?;
     let keyring = PublisherKeyring::load_or_seed(mur_home)?;
-    resolve_consent_in(&dir, skill, version, &keyring)
+    let mut consent = resolve_consent_in(&dir, skill, version, &keyring)?;
+
+    // Compute drift and surface it so the Hub accept-checkbox appears on updates.
+    let new_signer_fp = if consent.signature.status == "verified" {
+        Some(consent.signature.key_fp.clone())
+    } else {
+        None
+    };
+    let (drift_desc, _) = drift_status(
+        mur_home,
+        &consent.name,
+        &consent.resolved_sha256,
+        new_signer_fp.as_deref(),
+        &consent.version,
+    );
+    if drift_desc.is_some() {
+        consent.needs_ack = true;
+    }
+    consent.drift = drift_desc;
+    Ok(consent)
 }
 
 /// Install a registry skill onto a specific agent at `TrustLevel::Sandboxed`.
@@ -268,30 +341,22 @@ pub async fn cmd_skill_registry_add(
     let consent = resolve_consent_in(&dir, skill, version, &keyring)?;
 
     // ── Rug-pull / rollback: compare against any prior install record ────────
-    let trust_store =
-        mur_common::trust::skills::SkillTrustStore::load(&mur_home).unwrap_or_default();
-    let prior = trust_store
-        .entries
-        .values()
-        .find(|e| e.name == consent.name);
-    let prior_tuple = prior.map(|e| {
-        (
-            e.content_sha256.as_str(),
-            e.signer_key_fp.as_deref(),
-            e.version.as_str(),
-        )
-    });
+    // Use drift_status (C1 fix): registry-add pins by name; other paths key by
+    // hash. entries.get(name) avoids returning a stale hash-keyed entry whose
+    // empty content_sha256 would make check_drift skip the comparison → silent rug-pull.
     let new_signer_fp = if consent.signature.status == "verified" {
-        Some(consent.signature.key_fp.as_str())
+        Some(consent.signature.key_fp.clone())
     } else {
         None
     };
-    match check_drift(
-        prior_tuple,
+    let (_, drift_decision) = drift_status(
+        &mur_home,
+        &consent.name,
         &consent.resolved_sha256,
-        new_signer_fp,
+        new_signer_fp.as_deref(),
         &consent.version,
-    ) {
+    );
+    match drift_decision {
         DriftDecision::None => {}
         DriftDecision::Changed { what } => {
             if !accept {
@@ -592,6 +657,7 @@ mcp_requirements:
             signer_trust: "trusted".into(),
             body: "".into(),
             resolved_sha256: "aabbcc".into(),
+            drift: None,
         }
     }
 
@@ -631,5 +697,158 @@ mcp_requirements:
         let consent = clean_consent();
         assert!(gate(&consent, false).is_ok());
         assert!(gate(&consent, true).is_ok());
+    }
+
+    // ── I3: signer-trust fold tests (signed skill fixture) ─────────────────
+
+    /// Build a signed skill YAML fixture under `dir` (index + 1.0.0.yaml).
+    /// Returns the `key_fp` (DSSE `keyid`) for use in keyring construction.
+    fn fixture_registry_signed(dir: &std::path::Path) -> String {
+        use mur_common::identity::AgentIdentity;
+        use mur_common::muragent::dsse::DsseEnvelope;
+        use mur_common::skill::{Skill, TrustLevel, parse_canonical, sign::sign_manifest};
+
+        let id = AgentIdentity::generate();
+        let m = parse_canonical(SKILL_YAML).unwrap();
+        let env_json = sign_manifest(&m, &id).unwrap();
+
+        // Extract key_fp from the DSSE envelope signatures[0].keyid.
+        let envelope: DsseEnvelope = serde_json::from_str(&env_json).unwrap();
+        let key_fp = envelope.signatures.first().unwrap().keyid.clone();
+
+        // Serialize the full Skill struct (manifest + publisher_signature).
+        let skill = Skill {
+            manifest: m,
+            content_sha256: None,
+            trust_level: TrustLevel::Sandboxed,
+            capabilities_declared: vec![],
+            publisher_signature: Some(env_json),
+        };
+        let skill_yaml = serde_yaml_ng::to_string(&skill).unwrap();
+        let sha = sha256_hex(&skill_yaml);
+
+        let index_yaml = format!(
+            "skills:\n  test-skill:\n    latest: 1.0.0\n    description: test skill\n    publisher: human:tester\n    category: context\n    tags: []\n    content_sha256: \"{sha}\"\n    install_count: 0\n"
+        );
+        fs::write(dir.join("index.yaml"), &index_yaml).unwrap();
+        let versions_dir = dir.join("skills").join("test-skill").join("versions");
+        fs::create_dir_all(&versions_dir).unwrap();
+        fs::write(versions_dir.join("1.0.0.yaml"), &skill_yaml).unwrap();
+
+        key_fp
+    }
+
+    #[test]
+    fn signer_trusted_in_keyring_is_clean() {
+        use mur_common::skill::publisher_trust::TrustedPublisher;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let key_fp = fixture_registry_signed(tmp.path());
+
+        let keyring = PublisherKeyring {
+            schema_version: 1,
+            publishers: vec![TrustedPublisher {
+                name: "tester".into(),
+                key_fp: key_fp.clone(),
+                comment: String::new(),
+            }],
+            revoked: vec![],
+        };
+
+        let consent = resolve_consent_in(tmp.path(), "test-skill", None, &keyring).unwrap();
+        assert!(!consent.blocking, "trusted+hash-match must not be blocking");
+        assert!(!consent.needs_ack, "trusted+verified must not need ack");
+        assert_eq!(consent.signer_trust, "trusted");
+    }
+
+    #[test]
+    fn signer_revoked_is_blocking() {
+        let tmp = tempfile::tempdir().unwrap();
+        let key_fp = fixture_registry_signed(tmp.path());
+
+        let keyring = PublisherKeyring {
+            schema_version: 1,
+            publishers: vec![],
+            revoked: vec![key_fp],
+        };
+
+        let consent = resolve_consent_in(tmp.path(), "test-skill", None, &keyring).unwrap();
+        assert!(consent.blocking, "revoked signer must be blocking");
+        assert_eq!(consent.signer_trust, "revoked");
+    }
+
+    #[test]
+    fn signer_unknown_key_needs_ack() {
+        let tmp = tempfile::tempdir().unwrap();
+        fixture_registry_signed(tmp.path()); // key_fp discarded — not in keyring
+
+        // Empty keyring → signer is Untrusted (valid sig but unknown key).
+        let consent = resolve_consent_in(tmp.path(), "test-skill", None, &empty_keyring()).unwrap();
+        assert!(
+            !consent.blocking,
+            "unknown signer must not be hard-blocking"
+        );
+        assert!(consent.needs_ack, "unknown signer must require ack");
+        assert_eq!(consent.signer_trust, "untrusted");
+    }
+
+    // ── C1 regression: drift lookup must use name-key, not hash-key ─────────
+
+    #[test]
+    fn c1_drift_lookup_uses_name_key_not_hash_key() {
+        use mur_common::skill::TrustLevel;
+        use mur_common::trust::skills::{SkillTrustStore, TrustEntry};
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mur_home = tmp.path();
+
+        // Insert TWO entries for "test-skill":
+        //  - hash-keyed (as written by `mur skill install`): key = 64-hex chars,
+        //    content_sha256 is empty. If returned, check_drift skips comparison → None.
+        //  - name-keyed (as written by cmd_skill_registry_add): key = "test-skill",
+        //    content_sha256 = "old_hash_value". If returned, drift is detected.
+        //
+        // In a BTreeMap, "a".repeat(64) sorts before "test-skill" (ASCII 'a' < 't'),
+        // so the buggy .values().find() returns the hash-keyed entry first → silent fail.
+        let mut ts = SkillTrustStore::default();
+        let hash_key = "a".repeat(64);
+        ts.entries.insert(
+            hash_key,
+            TrustEntry {
+                name: "test-skill".into(),
+                version: "1.0.0".into(),
+                level: TrustLevel::Sandboxed,
+                installed_at: "2026-01-01T00:00:00Z".into(),
+                publisher: None,
+                content_sha256: String::new(), // empty — would cause check_drift to skip
+                signer_key_fp: None,
+            },
+        );
+        ts.entries.insert(
+            "test-skill".into(),
+            TrustEntry {
+                name: "test-skill".into(),
+                version: "1.0.0".into(),
+                level: TrustLevel::Sandboxed,
+                installed_at: "2026-01-01T00:00:00Z".into(),
+                publisher: None,
+                content_sha256: "old_hash_value".into(), // real pin
+                signer_key_fp: None,
+            },
+        );
+        ts.save(mur_home).unwrap();
+
+        // drift_status uses entries.get("test-skill") → name-keyed entry →
+        // "old_hash_value" vs "new_different_hash" → DriftDecision::Changed.
+        let (desc, decision) =
+            drift_status(mur_home, "test-skill", "new_different_hash", None, "1.0.0");
+        assert!(
+            desc.is_some(),
+            "C1 regression: name-keyed entry must be found so drift is detected (not silently None)"
+        );
+        assert!(
+            matches!(decision, DriftDecision::Changed { .. }),
+            "C1 regression: expected Changed, got {decision:?}"
+        );
     }
 }

--- a/mur-core/src/cmd/agent/skill_signer_trust.rs
+++ b/mur-core/src/cmd/agent/skill_signer_trust.rs
@@ -3,6 +3,9 @@
 //!
 //! Used by `skill_registry_add::resolve_consent_in` to fold publisher trust
 //! into the fail-closed install gate.
+//!
+//! Also provides `check_drift` / `DriftDecision` for rug-pull and rollback
+//! detection at reinstall time.
 
 use mur_common::skill::publisher_trust::{PublisherKeyring, PublisherTrust};
 
@@ -52,6 +55,146 @@ pub fn classify_signer(sig: &SignatureStatus, keyring: &PublisherKeyring) -> Sig
             PublisherTrust::Revoked => SignerTrust::Revoked,
             PublisherTrust::Unknown => SignerTrust::Untrusted,
         },
+    }
+}
+
+// ─── Drift detection ──────────────────────────────────────────────────────
+
+/// Result of comparing a prior install record against a new install attempt.
+#[derive(Debug, PartialEq)]
+pub enum DriftDecision {
+    /// No prior record, or everything matches — proceed normally.
+    None,
+    /// Content hash or publisher key changed between installs.
+    Changed { what: String },
+    /// Offered version is an older semver than the installed one (downgrade).
+    Rollback { installed: String, offered: String },
+}
+
+/// Compare a prior install record against the incoming version, hash, and signer.
+///
+/// `prior` is `(content_sha256, signer_key_fp, installed_version)`.
+///
+/// Priority (fail-closed, first match wins):
+/// 1. **Rollback**: offered semver < installed semver → `Rollback`.
+/// 2. **Content drift**: hashes differ (both non-empty) → `Changed { what: "content" }`.
+/// 3. **Publisher drift**: signer key changed (prior had a signer) → `Changed { what: "publisher" }`.
+/// 4. Otherwise → `None`.
+pub fn check_drift(
+    prior: Option<(&str, Option<&str>, &str)>,
+    new_hash: &str,
+    new_signer: Option<&str>,
+    new_ver: &str,
+) -> DriftDecision {
+    let (old_hash, old_signer, old_ver) = match prior {
+        None => return DriftDecision::None,
+        Some(t) => t,
+    };
+    // 1. Rollback check — only if both parse as valid semver.
+    if let (Ok(n), Ok(o)) = (
+        semver::Version::parse(new_ver),
+        semver::Version::parse(old_ver),
+    ) && n < o
+    {
+        return DriftDecision::Rollback {
+            installed: old_ver.to_string(),
+            offered: new_ver.to_string(),
+        };
+    }
+    // 2. Content drift — both hashes must be non-empty to compare.
+    if !new_hash.is_empty() && !old_hash.is_empty() && new_hash != old_hash {
+        return DriftDecision::Changed {
+            what: "content".to_string(),
+        };
+    }
+    // 3. Publisher drift — only fires if the prior install had a known signer.
+    if old_signer.is_some() && new_signer != old_signer {
+        return DriftDecision::Changed {
+            what: "publisher".to_string(),
+        };
+    }
+    DriftDecision::None
+}
+
+#[cfg(test)]
+mod drift_tests {
+    use super::*;
+
+    #[test]
+    fn no_prior_is_no_drift() {
+        assert!(matches!(
+            check_drift(None, "h1", Some("k1"), "1.0.0"),
+            DriftDecision::None
+        ));
+    }
+
+    #[test]
+    fn same_everything_is_no_drift() {
+        // version advances — same hash + signer is fine
+        assert!(matches!(
+            check_drift(Some(("h1", Some("k1"), "1.0.0")), "h1", Some("k1"), "1.1.0"),
+            DriftDecision::None
+        ));
+    }
+
+    #[test]
+    fn changed_hash_is_drift() {
+        assert!(matches!(
+            check_drift(Some(("h1", Some("k1"), "1.0.0")), "h2", Some("k1"), "1.1.0"),
+            DriftDecision::Changed { what } if what == "content"
+        ));
+    }
+
+    #[test]
+    fn changed_signer_is_drift() {
+        assert!(matches!(
+            check_drift(Some(("h1", Some("k1"), "1.0.0")), "h1", Some("k2"), "1.1.0"),
+            DriftDecision::Changed { what } if what == "publisher"
+        ));
+    }
+
+    #[test]
+    fn version_rollback_is_detected() {
+        assert!(matches!(
+            check_drift(Some(("h1", Some("k1"), "1.1.0")), "h1", Some("k1"), "1.0.0"),
+            DriftDecision::Rollback { .. }
+        ));
+    }
+
+    #[test]
+    fn rollback_beats_content_change() {
+        // Even if hash differs, rollback is reported first.
+        assert!(matches!(
+            check_drift(Some(("h1", Some("k1"), "1.1.0")), "h2", Some("k2"), "1.0.0"),
+            DriftDecision::Rollback { .. }
+        ));
+    }
+
+    #[test]
+    fn no_signer_change_when_prior_had_none() {
+        // Prior had no signer; new install is also unsigned — no publisher drift.
+        assert!(matches!(
+            check_drift(Some(("h1", None, "1.0.0")), "h1", None, "1.1.0"),
+            DriftDecision::None
+        ));
+    }
+
+    #[test]
+    fn empty_hashes_skip_content_check() {
+        // Both hashes empty → can't compare content — no drift.
+        assert!(matches!(
+            check_drift(Some(("", Some("k1"), "1.0.0")), "", Some("k1"), "1.1.0"),
+            DriftDecision::None
+        ));
+    }
+
+    #[test]
+    fn non_semver_versions_skip_rollback_check() {
+        // Non-semver versions cannot be compared, so no rollback detected.
+        assert!(matches!(
+            check_drift(Some(("h1", Some("k1"), "main")), "h1", Some("k1"), "dev"),
+            DriftDecision::None
+        ));
     }
 }
 

--- a/mur-core/src/cmd/agent/skill_signer_trust.rs
+++ b/mur-core/src/cmd/agent/skill_signer_trust.rs
@@ -1,0 +1,128 @@
+//! Signer trust classification — layers the publisher keyring onto a DSSE
+//! `SignatureStatus` to produce a three-state trust decision.
+//!
+//! Used by `skill_registry_add::resolve_consent_in` to fold publisher trust
+//! into the fail-closed install gate.
+
+use mur_common::skill::publisher_trust::{PublisherKeyring, PublisherTrust};
+
+use crate::cmd::agent::skill_verify::SignatureStatus;
+
+/// Trust classification of a skill's signer, relative to the local publisher keyring.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignerTrust {
+    /// Signer is in the keyring's `publishers` list and not revoked.
+    Trusted,
+    /// Signature is valid but signer is not in the keyring (Unknown).
+    Untrusted,
+    /// Signer key appears in the keyring's `revoked` list. Hard block.
+    Revoked,
+    /// No publisher signature present.
+    Unsigned,
+    /// Publisher signature present but failed to verify (tampering / malformed).
+    Invalid,
+}
+
+impl SignerTrust {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SignerTrust::Trusted => "trusted",
+            SignerTrust::Untrusted => "untrusted",
+            SignerTrust::Revoked => "revoked",
+            SignerTrust::Unsigned => "unsigned",
+            SignerTrust::Invalid => "invalid",
+        }
+    }
+}
+
+/// Classify a DSSE `SignatureStatus` against the local publisher keyring.
+///
+/// - `Verified { key_fp }` → look up the fingerprint in the keyring:
+///   - `Trusted` if the key is in `publishers` (and not revoked).
+///   - `Revoked` if the key appears in `revoked` (fail-closed; revoked beats trusted).
+///   - `Untrusted` if the key is not in the keyring.
+/// - `Unsigned` → `Unsigned` (no publisher signature present).
+/// - `Invalid` → `Invalid` (signature present but cryptographic check failed).
+pub fn classify_signer(sig: &SignatureStatus, keyring: &PublisherKeyring) -> SignerTrust {
+    match sig {
+        SignatureStatus::Unsigned => SignerTrust::Unsigned,
+        SignatureStatus::Invalid => SignerTrust::Invalid,
+        SignatureStatus::Verified { key_fp, .. } => match keyring.classify(key_fp) {
+            PublisherTrust::Trusted => SignerTrust::Trusted,
+            PublisherTrust::Revoked => SignerTrust::Revoked,
+            PublisherTrust::Unknown => SignerTrust::Untrusted,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::skill::publisher_trust::{PublisherKeyring, TrustedPublisher};
+
+    use crate::cmd::agent::skill_verify::SignatureStatus;
+
+    fn keyring(trusted: &str, revoked: &str) -> PublisherKeyring {
+        PublisherKeyring {
+            schema_version: 1,
+            publishers: vec![TrustedPublisher {
+                name: "mur".into(),
+                key_fp: trusted.into(),
+                comment: String::new(),
+            }],
+            revoked: vec![revoked.into()],
+        }
+    }
+
+    fn verified(fp: &str) -> SignatureStatus {
+        SignatureStatus::Verified {
+            publisher: "mur".into(),
+            key_fp: fp.into(),
+        }
+    }
+
+    #[test]
+    fn verified_known_key_is_trusted() {
+        let k = keyring("ed25519-trusted0", "ed25519-revoked0");
+        assert_eq!(
+            classify_signer(&verified("ed25519-trusted0"), &k),
+            SignerTrust::Trusted
+        );
+    }
+
+    #[test]
+    fn verified_revoked_key_is_revoked() {
+        let k = keyring("ed25519-trusted0", "ed25519-revoked0");
+        assert_eq!(
+            classify_signer(&verified("ed25519-revoked0"), &k),
+            SignerTrust::Revoked
+        );
+    }
+
+    #[test]
+    fn verified_unknown_key_is_untrusted() {
+        let k = keyring("ed25519-trusted0", "ed25519-revoked0");
+        assert_eq!(
+            classify_signer(&verified("ed25519-unknown0"), &k),
+            SignerTrust::Untrusted
+        );
+    }
+
+    #[test]
+    fn unsigned_is_unsigned() {
+        let k = keyring("ed25519-trusted0", "ed25519-revoked0");
+        assert_eq!(
+            classify_signer(&SignatureStatus::Unsigned, &k),
+            SignerTrust::Unsigned
+        );
+    }
+
+    #[test]
+    fn invalid_is_invalid() {
+        let k = keyring("ed25519-trusted0", "ed25519-revoked0");
+        assert_eq!(
+            classify_signer(&SignatureStatus::Invalid, &k),
+            SignerTrust::Invalid
+        );
+    }
+}

--- a/mur-core/src/cmd/agent/skill_verify.rs
+++ b/mur-core/src/cmd/agent/skill_verify.rs
@@ -31,14 +31,12 @@ pub struct VerifyOutcome {
 
 impl VerifyOutcome {
     /// Hard failure — positive sign of tampering. Abort unless explicitly overridden.
-    #[allow(dead_code)] // first consumer; called by Task 2 (per-agent install gate)
     pub fn is_blocking(&self) -> bool {
         matches!(self.hash, HashStatus::Mismatch)
             || matches!(self.signature, SignatureStatus::Invalid)
     }
 
     /// Not proven-bad, but not proven-good (unsigned / unhashed). Require `--yes`.
-    #[allow(dead_code)] // first consumer; called by Task 2 (per-agent install gate)
     pub fn needs_ack(&self) -> bool {
         !self.is_blocking()
             && (matches!(self.hash, HashStatus::Absent)
@@ -63,7 +61,6 @@ fn sha256_hex(bytes: &[u8]) -> String {
 /// - `Mismatch` or `Invalid` ⇒ `is_blocking()` — abort unless operator overrides.
 /// - `Absent` or `Unsigned` ⇒ `needs_ack()` — warn and require `--yes`.
 /// - `Match` + `Verified`   ⇒ neither — install silently.
-#[allow(dead_code)] // first consumer; wired in Task 2 (per-agent install gate)
 pub fn verify_skill_install(
     manifest: &SkillManifest,
     file_text: &str,

--- a/mur-core/src/cmd/fleet/import.rs
+++ b/mur-core/src/cmd/fleet/import.rs
@@ -274,6 +274,7 @@ pub fn cmd_fleet_import(mur_home: &Path, file: &Path, opts: ImportOpts) -> Resul
                 level: TrustLevel::Sandboxed,
                 installed_at: chrono::Utc::now().to_rfc3339(),
                 publisher: Some(m.publisher.clone()),
+                ..Default::default()
             },
         );
         trust

--- a/mur-core/src/cmd/skill_cmd.rs
+++ b/mur-core/src/cmd/skill_cmd.rs
@@ -471,6 +471,7 @@ pub fn cmd_trust(name: &str, level_str: &str) -> Result<()> {
             level,
             installed_at: chrono::Utc::now().to_rfc3339(),
             publisher: Some(m.publisher.clone()),
+            ..Default::default()
         },
     );
     trust

--- a/mur-core/src/cmd/skill_generate.rs
+++ b/mur-core/src/cmd/skill_generate.rs
@@ -95,6 +95,7 @@ pub async fn cmd_generate<L: LlmClient + 'static>(
             level: TrustLevel::Sandboxed,
             installed_at: chrono::Utc::now().to_rfc3339(),
             publisher: Some(manifest.publisher.clone()),
+            ..Default::default()
         },
     );
     trust.save(home).map_err(|e| anyhow!("save trust: {e}"))?;

--- a/mur-core/src/cmd/skill_install.rs
+++ b/mur-core/src/cmd/skill_install.rs
@@ -204,6 +204,7 @@ fn install_resolved_node(home: &Path, node: &ResolvedNode) -> Result<()> {
             level,
             installed_at: chrono::Utc::now().to_rfc3339(),
             publisher: Some(node.manifest.publisher.clone()),
+            ..Default::default()
         },
     );
     trust
@@ -306,6 +307,7 @@ fn install_from_agent(home: &Path, agent_name: &str, skill_name: &str) -> Result
             level: effective_level,
             installed_at: chrono::Utc::now().to_rfc3339(),
             publisher: Some(manifest.publisher.clone()),
+            ..Default::default()
         },
     );
     trust.save(home).map_err(|e| anyhow!("save trust: {e}"))?;

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1396,6 +1396,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                     println!("Publisher: {}", c.publisher);
                     println!("Signature: {} [{}]", c.signature.status, c.signature.key_fp);
                     println!("Hash:      {}", c.hash);
+                    println!("Trust:     {}", c.signer_trust);
                     if !c.mcp_requirements.is_empty() {
                         println!("MCP requirements: {}", c.mcp_requirements.join(", "));
                     }
@@ -1433,6 +1434,26 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                             r.name, r.category, r.publisher, r.latest, sig
                         );
                     }
+                }
+            }
+            AgentSkillAction::TrustPublisher { key_fp, name } => {
+                let mur_home = cmd::agent::resolve_mur_home()?;
+                let mut kr =
+                    mur_common::skill::publisher_trust::PublisherKeyring::load_or_seed(&mur_home)?;
+                if kr.revoked.contains(&key_fp) {
+                    anyhow::bail!("refusing to trust a revoked key: {key_fp}");
+                }
+                if kr.publishers.iter().any(|p| p.key_fp == key_fp) {
+                    println!("already trusted: {key_fp}");
+                } else {
+                    kr.publishers
+                        .push(mur_common::skill::publisher_trust::TrustedPublisher {
+                            name: name.clone().unwrap_or_else(|| "user-trusted".to_string()),
+                            key_fp: key_fp.clone(),
+                            comment: "added via trust-publisher (TOFU)".to_string(),
+                        });
+                    kr.save(&mur_home)?;
+                    println!("Trusted publisher key added: {key_fp}");
                 }
             }
         },

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -611,6 +611,7 @@ pub fn run() {
             mcp_skills::agent_skill_registry_search,
             mcp_skills::agent_skill_registry_preview,
             mcp_skills::agent_skill_registry_install,
+            mcp_skills::agent_skill_trust_publisher,
             mobile::mobile_events_read,
             notif::agent_get_notif_config,
             notif::agent_set_notif_config,

--- a/mur-hub-gui/src-tauri/src/mcp_skills.rs
+++ b/mur-hub-gui/src-tauri/src/mcp_skills.rs
@@ -362,6 +362,33 @@ pub async fn agent_skill_registry_install(
     get_agent_detail(name)
 }
 
+/// Trust a publisher key via TOFU from the Hub consent screen.
+///
+/// Fail-closed: a revoked key is never trustable regardless of the caller.
+/// Idempotent: if the key is already in the trusted list nothing is written.
+#[tauri::command]
+pub async fn agent_skill_trust_publisher(
+    key_fp: String,
+    name: Option<String>,
+) -> Result<(), String> {
+    let home = mur_core::cmd::agent::resolve_mur_home().map_err(|e| format!("{e:#}"))?;
+    let mut kr = mur_common::skill::publisher_trust::PublisherKeyring::load_or_seed(&home)
+        .map_err(|e| format!("{e:#}"))?;
+    if kr.revoked.contains(&key_fp) {
+        return Err(format!("key {key_fp} revoked"));
+    }
+    if !kr.publishers.iter().any(|p| p.key_fp == key_fp) {
+        kr.publishers
+            .push(mur_common::skill::publisher_trust::TrustedPublisher {
+                name: name.unwrap_or_else(|| "user-trusted".to_string()),
+                key_fp,
+                comment: "TOFU (Hub)".to_string(),
+            });
+        kr.save(&home).map_err(|e| format!("{e:#}"))?;
+    }
+    Ok(())
+}
+
 fn reveal_os(path: &Path) -> std::io::Result<()> {
     #[cfg(target_os = "macos")]
     {

--- a/mur-hub-gui/ui/src/components/SkillRegistryModal.tsx
+++ b/mur-hub-gui/ui/src/components/SkillRegistryModal.tsx
@@ -26,6 +26,8 @@ interface ConsentInfo {
   publisher: string;
   category: string;
   signature: SigView;
+  /** Three-state signer trust: "trusted" | "untrusted" | "revoked" | "unsigned" | "invalid" */
+  signer_trust: string;
   hash: string;
   mcp_requirements: string[];
   findings: string[];
@@ -53,8 +55,9 @@ export function SkillRegistryModal({ agentName, onClose, onSaved }: Props) {
   const [results, setResults] = useState<RegistrySkillEntryView[] | null>(null);
   const [consent, setConsent] = useState<ConsentInfo | null>(null);
   const [accept, setAccept]   = useState(false);
-  const [busy, setBusy]       = useState<null | "search" | "preview" | "install">(null);
+  const [busy, setBusy]       = useState<null | "search" | "preview" | "install" | "trust">(null);
   const [error, setError]     = useState<string | null>(null);
+  const [trustDone, setTrustDone] = useState(false);
 
   async function search() {
     setError(null);
@@ -71,10 +74,33 @@ export function SkillRegistryModal({ agentName, onClose, onSaved }: Props) {
     }
   }
 
+  async function trustPublisher() {
+    if (!consent || !consent.signature.key_fp) return;
+    setError(null);
+    setBusy("trust");
+    try {
+      await invoke("agent_skill_trust_publisher", {
+        keyFp: consent.signature.key_fp,
+        name: consent.publisher || undefined,
+      });
+      setTrustDone(true);
+      // Re-run preview so signer_trust refreshes to "trusted".
+      const updated = await invoke<ConsentInfo>("agent_skill_registry_preview", {
+        skill: consent.name,
+      });
+      setConsent(updated);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
   async function preview(skillName: string) {
     setError(null);
     setConsent(null);
     setAccept(false);
+    setTrustDone(false);
     setBusy("preview");
     try {
       setConsent(await invoke<ConsentInfo>("agent_skill_registry_preview", { skill: skillName }));
@@ -207,6 +233,16 @@ export function SkillRegistryModal({ agentName, onClose, onSaved }: Props) {
                   <span className="item-card__meta">{consent.category}</span>
                   <span className="item-card__meta">v{consent.version}</span>
                   <span className={sigCls}>{sigLabel}</span>
+                  {/* ── Signer trust badge ── */}
+                  {consent.signer_trust === "trusted" && (
+                    <span className="badge badge--ok">✓ {t("skillreg.trusted")}</span>
+                  )}
+                  {consent.signer_trust === "untrusted" && (
+                    <span className="badge badge--warn">⚠ {t("skillreg.untrusted")}</span>
+                  )}
+                  {consent.signer_trust === "revoked" && (
+                    <span className="badge badge--err">✗ {t("skillreg.revoked")}</span>
+                  )}
                   {consent.signature.status === "verified" && consent.signature.key_fp && (
                     <span className="field-muted" style={{ fontSize: 11, fontFamily: "monospace" }}>
                       {consent.signature.key_fp}
@@ -217,6 +253,22 @@ export function SkillRegistryModal({ agentName, onClose, onSaved }: Props) {
                   <span className="field-label" style={{ marginRight: 4 }}>{t("skillreg.publisher")}:</span>
                   {consent.publisher}
                 </p>
+                {/* ── TOFU action: only for unknown (untrusted) signed skills ── */}
+                {consent.signer_trust === "untrusted" && consent.signature.key_fp && (
+                  <div style={{ marginTop: 6 }}>
+                    {trustDone ? (
+                      <span className="badge badge--ok">{t("skillreg.trustedDone")}</span>
+                    ) : (
+                      <button
+                        className="btn btn--sm btn--secondary"
+                        disabled={busy !== null}
+                        onClick={trustPublisher}
+                      >
+                        {busy === "trust" ? "…" : t("skillreg.trustPublisher")}
+                      </button>
+                    )}
+                  </div>
+                )}
                 <p style={{ margin: "2px 0 0", fontSize: 12 }}>
                   <span className="field-label" style={{ marginRight: 4 }}>{t("skillreg.hash")}:</span>
                   <code style={{ fontSize: 11 }}>{consent.hash || t("skillreg.hashAbsent")}</code>

--- a/mur-hub-gui/ui/src/components/SkillRegistryModal.tsx
+++ b/mur-hub-gui/ui/src/components/SkillRegistryModal.tsx
@@ -37,6 +37,8 @@ interface ConsentInfo {
   scan_blocking: boolean;
   trust_level: string;
   body: string;
+  /** Short description of detected drift since last install, or null/absent if none. */
+  drift?: string | null;
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -85,8 +87,10 @@ export function SkillRegistryModal({ agentName, onClose, onSaved }: Props) {
       });
       setTrustDone(true);
       // Re-run preview so signer_trust refreshes to "trusted".
+      // Pass version to avoid silently jumping to latest (M4 fix).
       const updated = await invoke<ConsentInfo>("agent_skill_registry_preview", {
         skill: consent.name,
+        version: consent.version,
       });
       setConsent(updated);
     } catch (e) {
@@ -299,6 +303,12 @@ export function SkillRegistryModal({ agentName, onClose, onSaved }: Props) {
                     ))}
                   </ul>
                 </div>
+              )}
+
+              {consent.drift && (
+                <p className="badge badge--warn" style={{ marginTop: 8 }}>
+                  {t("skillreg.driftWarn")}: {consent.drift}
+                </p>
               )}
 
               {consent.blocking && (

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -547,4 +547,9 @@ export const en = {
   "skillreg.installAnyway": "I reviewed the findings — install anyway",
   "skillreg.install": "Install skill",
   "skillreg.backToResults": "Back to results",
+  "skillreg.trusted": "trusted",
+  "skillreg.untrusted": "untrusted",
+  "skillreg.revoked": "revoked",
+  "skillreg.trustPublisher": "Trust this publisher",
+  "skillreg.trustedDone": "MUR publisher trusted",
 } as const;

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -552,4 +552,5 @@ export const en = {
   "skillreg.revoked": "revoked",
   "skillreg.trustPublisher": "Trust this publisher",
   "skillreg.trustedDone": "MUR publisher trusted",
+  "skillreg.driftWarn": "⚠ Skill changed since last install",
 } as const;

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -554,4 +554,5 @@ export const zhTW: Table = {
   "skillreg.revoked": "已撤銷",
   "skillreg.trustPublisher": "信任此發布者",
   "skillreg.trustedDone": "MUR 發布者已信任",
+  "skillreg.driftWarn": "⚠ 技能自上次安裝後已變更",
 };

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -549,4 +549,9 @@ export const zhTW: Table = {
   "skillreg.installAnyway": "我已檢視這些發現，仍要安裝",
   "skillreg.install": "安裝技能",
   "skillreg.backToResults": "返回結果",
+  "skillreg.trusted": "已信任",
+  "skillreg.untrusted": "未信任",
+  "skillreg.revoked": "已撤銷",
+  "skillreg.trustPublisher": "信任此發布者",
+  "skillreg.trustedDone": "MUR 發布者已信任",
 };


### PR DESCRIPTION
## What

Turns quill P2's "signature is internally consistent" into "signature is from a **trusted** publisher", and adds rug-pull defense. Builds on P2 (#531, merged).

- **Publisher keyring** (`~/.mur/trust/publishers.yaml`, pinned with the MUR-official key) — the client-side trust root.
- **Three-state signer trust** layered on P2's `Verified`: **Trusted** (key in keyring) / **Untrusted** (valid sig, unknown key) / **Revoked**.
- **TOFU** — `mur agent skill trust-publisher <key_fp>` (CLI) + a "Trust this publisher" action (Hub) to pin an unknown-but-valid signer.
- **Rug-pull drift detection** — pins `content_sha256` + signer at install; a later install with changed content/publisher, or a version rollback, **re-prompts** (fail-closed).

## Gate (fail-closed, three buckets)

| | |
|---|---|
| **Unconditional block** (not `--yes`-overridable) | hash `Mismatch` · signature `Invalid` · signer `Revoked` |
| **Needs `--yes`** | signer `Untrusted` · `Unsigned` · absent hash · scan findings · **drift** (content/publisher change, rollback) |
| **Silent** | hash `Match` + signer `Trusted` + no findings + no drift |

Verified end-to-end (core / CLI / Hub) by the final review: a `Revoked` signer can never install; an `Untrusted` signer can never install silently; the Hub install **re-verifies server-side** (no TOCTOU on the renderer).

## Why this model (not TUF / Sigstore)

Deep-research grounding: a registry is an **identity authority, not a signing authority**; **content-hash pinning alone can't tell a legit update from a malicious one** (needs a signer-identity layer); cosign's rule — verify *which* identity signed, not just *that* something signed. **TUF** is too heavy for a curated git registry; **Sigstore keyless** needs online verify (breaks local-first). **Pinned-root + TOFU + drift** (SSH-known_hosts / apt-keyring style) reuses MUR's existing Ed25519/DSSE stack and adds exactly the missing identity layer.

## Notable review catches (opus whole-branch)

- **Critical (fixed):** the drift lookup used `entries.values().find(by name)`, which could match a **stale hash-keyed entry** from other install paths (empty hash/signer) → BTreeMap ordering made it win → **silent rug-pull**. Fixed to `entries.get(&name)` via a shared `drift_status` helper.
- **Important (fixed):** drift wasn't surfaced to the Hub → a legit update on a Trusted skill was un-installable; now `ConsentInfo.drift` + `needs_ack` so the Hub checkbox covers it.
- **Important (fixed):** the signer-trust fold wasn't tested end-to-end; added trusted/revoked/unknown `resolve_consent_in` tests + a C1 regression test.

## Deferred (companion / P2.2)

- The pinned `MUR_OFFICIAL_PUBLISHER_KEY_FP` is a **placeholder** — until the **registry-CI signing companion** (`mur-run/skill-registry`: GitHub-identity publisher auth + sign each manifest + emit `content_sha256`) ships the real fingerprint, every real key is `Untrusted` (fail-safe: over-prompts). Registry CI is a separate repo-side task.
- Registry-fetched (vs embedded) revocation list; Sigstore/transparency-log (not for local-first).

## Test plan

- `publisher_trust` (3), `skill_signer_trust` incl 9 drift + signer matrix, `mur-common trust` (30), `skill_registry_add` (18, incl signer-fold + C1 regression) — all pass; mur-core build + clippy `--all`; Hub `cargo check` + clippy; frontend `tsc` + vite.
- Rebased onto current main (post-#532) — build + tests re-verified green after rebase.

Built via subagent-driven-development (5 TDD tasks, per-unit + opus whole-branch review + fix wave). Stacked conceptually on quill P2 (#531).

🤖 Generated with [Claude Code](https://claude.com/claude-code)