### PR TITLE
docs(readme): agent cli completion menu + suggested replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ murmur coach                                  # quick form (murmur symlink), ide
 
 <p align="center"><img src="assets/demo.gif" alt="mur agent cli — streaming TUI chat with a local agent" width="92%" /></p>
 
+In the chat, type `/` to open a completion menu of slash commands (with their subcommands) and the agent's skills — `↑↓` to move, `Tab`/`Enter` to accept, `Esc` to dismiss. And when the agent offers you choices, they appear as `Tab`-to-fill suggestions right in the input: a single one as greyed ghost text, several as a picker.
+
 ### Models & providers
 
 Agents draw from a local provider/model registry at `~/.mur/models.yaml`:


### PR DESCRIPTION
Documents the two `mur agent cli` autocomplete features shipped in #532 (Type 1, slash/skill completion menu) and #534 (Type 2, agent-suggested replies) — a concise note in the README right after the `mur agent cli` example.

- Type 1: `/` opens a filtered menu of slash commands (+ subcommands) and the agent's skills; ↑↓ move, Tab/Enter accept, Esc dismiss.
- Type 2: agent-offered choices appear as Tab-to-fill suggestions in the input — one as ghost text, several as a picker.

README-only. The dashboard docs (mur-server repo) have no `mur agent cli` chat section to extend; documenting it there would mean authoring a new agent-CLI guide (separate, larger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)