### PR TITLE
chore(release): bump workspace version to 2.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6194,7 +6194,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "libc",
 ]
@@ -6272,7 +6272,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6292,7 +6292,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6341,7 +6341,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "blake3",
  "flate2",
@@ -6357,7 +6357,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6445,7 +6445,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6473,7 +6473,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6496,7 +6496,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6512,7 +6512,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.28.2"
+version = "2.29.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6533,7 +6533,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6552,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "blake3",
  "flate2",
@@ -6616,7 +6616,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6698,7 +6698,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.28.2"
+version = "2.29.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
Version bump for **v2.29.0** (the batch merged since v2.28.2). Tag is **not** applied by this PR — after merge, run `git tag -a v2.29.0 && git push origin main --tags` to trigger `release.yml`.

## Changes
- `Cargo.toml` workspace version `2.28.2` → `2.29.0`
- `Cargo.lock` + `mur-hub-gui/src-tauri/Cargo.lock` — internal `mur-*` crates bumped to 2.29.0

## What this release ships (22 commits since v2.28.2)
- **quill** (remote skill install): P1 by-URL #524, `.zip`/`.tar.gz` bundles #528, per-agent registry install + verify-on-install #531, publisher trust-roots + TOFU + rug-pull drift #533, registry-index validator (P2.2 Part A) #535.
- **feather** P1 — add remote MCP servers by URL #519.
- **agent-cli "Glass Box" cockpit** — #517/#518/#522/#523/#525/#526/#527/#529/#530.
- **autocomplete** #532 + **agent-suggested replies** #534.

## Why now
Unblocks the new **`mur-run/skill-registry`** CI, which needs the released `mur` to include `mur skill registry-index` (added in #535).

🤖 Generated with [Claude Code](https://claude.com/claude-code)