### PR TITLE
fix(publish): embed publisher_signature in skill yaml instead of separate .sig.json

### DIFF
--- a/mur-core/src/cmd/skill_publish.rs
+++ b/mur-core/src/cmd/skill_publish.rs
@@ -94,11 +94,15 @@ pub fn cmd_publish(path: &str) -> Result<()> {
 
     let skill_dir = repo_dir.join("skills").join(&m.name).join("versions");
     std::fs::create_dir_all(&skill_dir)?;
+    // Embed the DSSE envelope as `publisher_signature` in the yaml (what registry-index expects).
+    let yaml = serialize_canonical(&m)?;
+    let signed = format!(
+        "{}publisher_signature: '{}'\n",
+        yaml,
+        envelope.replace('\'', "''")
+    );
     let skill_path = skill_dir.join(format!("{}.yaml", m.version));
-    std::fs::write(&skill_path, serialize_canonical(&m)?)?;
-
-    let sig_path = skill_dir.join(format!("{}.sig.json", m.version));
-    std::fs::write(&sig_path, &envelope)?;
+    std::fs::write(&skill_path, signed)?;
 
     Command::new("git")
         .args(["-C", &*repo_dir.to_string_lossy(), "add", "."])


### PR DESCRIPTION
## Problem
`mur skill publish` was writing the DSSE signature envelope to a sibling `.sig.json` file, but `mur skill registry-index --check` (and the registry CI) expects the envelope embedded in the skill yaml as a `publisher_signature` field. This caused every published skill to fail CI with:

```
unsigned — every registry skill must be signed
```

## Fix
Embed the envelope directly in the yaml:
```yaml
publisher_signature: '{"payload":...,"signatures":[...]}'
```

This matches the format produced by the `put_signed` test helper in `skill_registry_index.rs` and what `skill_verify.rs` reads from the installed file.

## Test plan
- [ ] CI passes
- [ ] E2E: `mur skill publish` → PR to skill-registry → CI validates without "unsigned" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)