### PR TITLE
chore(release): bump workspace version to 2.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6227,7 +6227,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.30.0"
+version = "2.30.1"
 dependencies = [
  "libc",
 ]
@@ -6305,7 +6305,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.30.0"
+version = "2.30.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6325,7 +6325,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.30.0"
+version = "2.30.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.30.0"
+version = "2.30.1"
 dependencies = [
  "blake3",
  "flate2",
@@ -6390,7 +6390,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.30.0"
+version = "2.30.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.30.0"
+version = "2.30.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6506,7 +6506,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.30.0"
+version = "2.30.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6529,7 +6529,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.30.0"
+version = "2.30.1"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.30.0"
+version = "2.30.1"
 dependencies = [
  "base64 0.22.1",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.30.0"
+version = "2.30.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6533,7 +6533,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.29.0"
+version = "2.30.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6552,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.29.0"
+version = "2.30.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.29.0"
+version = "2.30.1"
 dependencies = [
  "blake3",
  "flate2",
@@ -6616,7 +6616,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.29.0"
+version = "2.30.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6698,7 +6698,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.29.0"
+version = "2.30.1"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
Version bump for **v2.30.1** (hotfix). Tag applied after merge.

## Changes
- `Cargo.toml` workspace version `2.30.0` → `2.30.1`
- `Cargo.lock` + `mur-hub-gui/src-tauri/Cargo.lock` — mur-* crates bumped to 2.30.1

## What this hotfix ships (1 commit since v2.30.0)
- **fix(publish)**: `mur skill publish` now embeds `publisher_signature` directly in the skill yaml instead of a separate `.sig.json`, matching what `mur skill registry-index --check` expects. Without this fix, every published skill failed skill-registry CI with "unsigned — every registry skill must be signed". (#540)

🤖 Generated with [Claude Code](https://claude.com/claude-code)