### PR TITLE
feat(parallel/p1): orchestration layer — Track/TrackSet, judge pipeline, fleet compare/cherry

### DIFF
--- a/mur-core/src/cmd/fleet/cherry_cmd.rs
+++ b/mur-core/src/cmd/fleet/cherry_cmd.rs
@@ -122,7 +122,10 @@ pub fn cmd_fleet_cherry(mur_home: &Path, fleet_name: &str, auto: bool) -> Result
         }
         let ts_refs: Vec<TrackSource<'_>> = track_sources
             .iter()
-            .map(|(n, s)| TrackSource { track_name: n.as_str(), source: s.as_slice() })
+            .map(|(n, s)| TrackSource {
+                track_name: n.as_str(),
+                source: s.as_slice(),
+            })
             .collect();
 
         // Check conflicts (P1: always empty, cargo check is the real gate).
@@ -176,7 +179,10 @@ pub fn cmd_fleet_cherry(mur_home: &Path, fleet_name: &str, auto: bool) -> Result
 }
 
 fn cherry_result_dir(mur_home: &Path, fleet_name: &str) -> PathBuf {
-    mur_home.join("fleets").join(fleet_name).join("cherry-result")
+    mur_home
+        .join("fleets")
+        .join(fleet_name)
+        .join("cherry-result")
 }
 
 #[cfg(test)]
@@ -187,7 +193,10 @@ mod tests {
     fn cherry_result_dir_name() {
         let mur_home = PathBuf::from("/home/user/.mur");
         let fleet_name = "my-fleet";
-        let expected = mur_home.join("fleets").join(fleet_name).join("cherry-result");
+        let expected = mur_home
+            .join("fleets")
+            .join(fleet_name)
+            .join("cherry-result");
         assert_eq!(cherry_result_dir(&mur_home, fleet_name), expected);
     }
 }

--- a/mur-core/src/cmd/fleet/cherry_cmd.rs
+++ b/mur-core/src/cmd/fleet/cherry_cmd.rs
@@ -1,29 +1,193 @@
-//! `mur fleet cherry <name>` — execute cherry-pick assembly.
+//! `mur fleet cherry <name>` — cherry-pick best functions across tracks into assembled files.
 
-use std::path::Path;
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
 
 use super::store::load_fleet;
-use crate::parallel::state::ParallelStateDb;
-use anyhow::{Context, Result};
+use crate::parallel::{
+    cherry::{
+        assemble::{TrackSource, assemble_file},
+        conflict::check_conflicts,
+        picker::cherry_pick,
+    },
+    judge::TrackScore,
+    semantic::{SupportedLanguage, extract_units},
+    state::ParallelStateDb,
+    track::TrackSet,
+};
 
-pub fn cmd_fleet_cherry(mur_home: &Path, fleet_name: &str, _auto: bool) -> Result<()> {
+pub fn cmd_fleet_cherry(mur_home: &Path, fleet_name: &str, auto: bool) -> Result<()> {
     let fleet = load_fleet(mur_home, fleet_name)?;
     let parallel = fleet
         .parallel
         .as_ref()
         .context("fleet has no parallel config")?;
-    let state_dir = mur_home
-        .join("fleets")
-        .join(fleet_name)
-        .join("parallel_state");
-    let _db = ParallelStateDb::open(&state_dir)?;
+
+    let fleet_dir = mur_home.join("fleets").join(fleet_name);
+    let tracks = TrackSet::load(&fleet_dir)
+        .context("no tracks.json — run `mur fleet run` then `mur fleet judge` first")?;
+    let state_db = ParallelStateDb::open(&fleet_dir.join("parallel_state"))?;
+    let rubric_ver = parallel.judge.rubric.version();
+
+    if tracks.tracks.is_empty() {
+        println!("No tracks found.");
+        return Ok(());
+    }
+
+    // Collect unit scores per track by re-parsing worktrees.
+    // unit_name → Vec<TrackScore>
+    let mut scores_per_unit: std::collections::HashMap<String, Vec<TrackScore>> =
+        std::collections::HashMap::new();
+
+    for t in &tracks.tracks {
+        for entry in walkdir::WalkDir::new(&t.worktree_path)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rs"))
+        {
+            let Ok(source) = std::fs::read(entry.path()) else {
+                continue;
+            };
+            let Ok(units) = extract_units(&source, SupportedLanguage::Rust) else {
+                continue;
+            };
+            for unit in units {
+                let Some(js) = state_db
+                    .get_score(&unit.content_hash, &rubric_ver)
+                    .ok()
+                    .flatten()
+                else {
+                    continue;
+                };
+                scores_per_unit
+                    .entry(unit.name)
+                    .or_default()
+                    .push(TrackScore {
+                        track_name: t.config.name.clone(),
+                        score: js.score,
+                        reasoning: js.reasoning,
+                        low_confidence: false,
+                    });
+            }
+        }
+    }
+
+    if scores_per_unit.is_empty() {
+        println!("No scores found. Run `mur fleet judge {fleet_name}` first.");
+        return Ok(());
+    }
+
+    let scores_slice: Vec<(&str, Vec<TrackScore>)> = scores_per_unit
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.clone()))
+        .collect();
+    let plan = cherry_pick(&scores_slice);
 
     println!(
-        "Cherry-picking best functions from {} tracks...",
-        parallel.tracks.len()
+        "Cherry-picking {} units from {} tracks...",
+        plan.selections.len(),
+        tracks.tracks.len()
     );
-    // ponytail: full cherry loop (load scores → cherry_pick → assemble_file → cargo check → write)
-    // P1 alpha: print the plan; write output to fleets/<name>/cherry-result/
+
+    // Assemble output per file using first track as base.
+    let base_track = &tracks.tracks[0];
+    let result_dir = cherry_result_dir(mur_home, fleet_name);
+    std::fs::create_dir_all(&result_dir)?;
+
+    let mut written = 0usize;
+    for entry in walkdir::WalkDir::new(&base_track.worktree_path)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rs"))
+    {
+        let file_path = entry.path();
+        let Ok(base_source) = std::fs::read(file_path) else {
+            continue;
+        };
+
+        // Collect track sources for this relative file path.
+        let rel = file_path.strip_prefix(&base_track.worktree_path).ok();
+        let mut track_sources: Vec<(String, Vec<u8>)> = Vec::new();
+        for t in &tracks.tracks {
+            let candidate = if let Some(rel) = rel {
+                t.worktree_path.join(rel)
+            } else {
+                continue;
+            };
+            if let Ok(src) = std::fs::read(&candidate) {
+                track_sources.push((t.config.name.clone(), src));
+            }
+        }
+        let ts_refs: Vec<TrackSource<'_>> = track_sources
+            .iter()
+            .map(|(n, s)| TrackSource { track_name: n.as_str(), source: s.as_slice() })
+            .collect();
+
+        // Check conflicts (P1: always empty, cargo check is the real gate).
+        let conflicts = check_conflicts(&plan, &base_source, SupportedLanguage::Rust)?;
+        if !conflicts.is_empty() && !auto {
+            println!(
+                "Dependency conflicts in {} — skipping (use --auto to override)",
+                file_path.display()
+            );
+            continue;
+        }
+
+        let assembled = assemble_file(&base_source, &plan, &ts_refs, SupportedLanguage::Rust)?;
+
+        // Write assembled file preserving directory structure.
+        let out_path = if let Some(rel) = rel {
+            result_dir.join(rel)
+        } else {
+            continue;
+        };
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&out_path, assembled)?;
+        written += 1;
+    }
+
+    if written == 0 {
+        println!("No files assembled. Check that track worktrees contain .rs files.");
+        return Ok(());
+    }
+
+    // Validate assembled result with cargo check.
+    println!("Assembled {written} files → {}", result_dir.display());
+    let check = std::process::Command::new("cargo")
+        .args(["check", "--quiet", "--manifest-path"])
+        .arg(result_dir.join("Cargo.toml"))
+        .env("ORT_STRATEGY", "download")
+        .output();
+    match check {
+        Ok(out) if out.status.success() => println!("cargo check: OK"),
+        Ok(out) => eprintln!(
+            "cargo check failed (non-fatal):\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        ),
+        Err(e) => eprintln!("cargo check could not run ({e}) — skipping validation"),
+    }
+
     println!("Use `mur fleet promote {fleet_name} cherry` to apply the result.");
     Ok(())
+}
+
+fn cherry_result_dir(mur_home: &Path, fleet_name: &str) -> PathBuf {
+    mur_home.join("fleets").join(fleet_name).join("cherry-result")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cherry_result_dir_name() {
+        let mur_home = PathBuf::from("/home/user/.mur");
+        let fleet_name = "my-fleet";
+        let expected = mur_home.join("fleets").join(fleet_name).join("cherry-result");
+        assert_eq!(cherry_result_dir(&mur_home, fleet_name), expected);
+    }
 }

--- a/mur-core/src/cmd/fleet/compare.rs
+++ b/mur-core/src/cmd/fleet/compare.rs
@@ -1,12 +1,14 @@
 //! `mur fleet compare <name>` — show per-unit scores across all tracks.
 
+use anyhow::{Context, Result};
 use std::path::Path;
 
-use anyhow::{Context, Result};
-
-use crate::parallel::state::ParallelStateDb;
-
 use super::store::load_fleet;
+use crate::parallel::{
+    semantic::{SupportedLanguage, extract_units},
+    state::ParallelStateDb,
+    track::TrackSet,
+};
 
 pub fn cmd_fleet_compare(
     mur_home: &Path,
@@ -18,31 +20,113 @@ pub fn cmd_fleet_compare(
         .parallel
         .as_ref()
         .context("fleet has no parallel config")?;
-    let state_dir = mur_home
-        .join("fleets")
-        .join(fleet_name)
-        .join("parallel_state");
-    // Open state DB so it exists even if empty; real reads happen in Task 12.
-    let _db = ParallelStateDb::open(&state_dir)?;
-    let _rubric_ver = parallel.judge.rubric.version();
-    let _ = unit_filter;
 
-    // Load score for each track × unit from LMDB.
-    // For now print a summary; rich table follows in P1 polish.
-    println!("Fleet: {fleet_name}  Tracks: {}", parallel.tracks.len());
-    println!(
-        "{:<25} {}",
-        "Unit",
-        parallel
-            .tracks
+    let fleet_dir = mur_home.join("fleets").join(fleet_name);
+    let tracks = TrackSet::load(&fleet_dir)
+        .context("no tracks.json — run `mur fleet run` then `mur fleet judge` first")?;
+    let state_db = ParallelStateDb::open(&fleet_dir.join("parallel_state"))?;
+    let rubric_ver = parallel.judge.rubric.version();
+
+    let track_names: Vec<&str> = tracks.tracks.iter().map(|t| t.config.name.as_str()).collect();
+
+    // unit_name → Vec<(track_name, Option<score>)>
+    let mut score_map: std::collections::HashMap<String, Vec<(String, Option<f32>)>> =
+        std::collections::HashMap::new();
+
+    for t in &tracks.tracks {
+        for entry in walkdir::WalkDir::new(&t.worktree_path)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rs"))
+        {
+            let Ok(source) = std::fs::read(entry.path()) else {
+                continue;
+            };
+            let Ok(units) = extract_units(&source, SupportedLanguage::Rust) else {
+                continue;
+            };
+            for unit in units {
+                if unit_filter.is_some_and(|f| !unit.name.contains(f)) {
+                    continue;
+                }
+                let score_val = state_db
+                    .get_score(&unit.content_hash, &rubric_ver)
+                    .ok()
+                    .flatten()
+                    .map(|js| js.score);
+                score_map
+                    .entry(unit.name)
+                    .or_default()
+                    .push((t.config.name.clone(), score_val));
+            }
+        }
+    }
+
+    if score_map.is_empty() {
+        println!("No scores found. Run `mur fleet judge {fleet_name}` first.");
+        return Ok(());
+    }
+
+    // Print header
+    let col_w = 14usize;
+    let name_w = 28usize;
+    print!("{:<name_w$}", "Unit");
+    for tn in &track_names {
+        print!(" {:<col_w$}", tn);
+    }
+    println!(" Rec");
+    println!("{}", "-".repeat(name_w + (col_w + 1) * track_names.len() + 6));
+
+    // Print one row per unit
+    let mut unit_names: Vec<&String> = score_map.keys().collect();
+    unit_names.sort();
+    for name in unit_names {
+        let by_track = score_map.get(name).unwrap();
+        let scores: Vec<(&str, Option<f32>)> = track_names
             .iter()
-            .map(|t| format!("{:<12}", t.name))
-            .collect::<Vec<_>>()
-            .join(" ")
-    );
-    println!("{}", "-".repeat(70));
+            .map(|tn| {
+                let score = by_track
+                    .iter()
+                    .find(|(t, _)| t.as_str() == *tn)
+                    .and_then(|(_, s)| *s);
+                (*tn, score)
+            })
+            .collect();
 
-    // Stub — full implementation requires TrackSet in state DB.
-    println!("(Run `mur fleet judge {fleet_name}` first to populate scores)");
+        let rec = scores
+            .iter()
+            .filter_map(|(tn, s)| s.map(|v| (tn, v)))
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(tn, _)| *tn)
+            .unwrap_or("-");
+
+        print!("{:<name_w$}", truncate(name, name_w));
+        for (_, score) in &scores {
+            let cell = score.map(|s| format!("{:.1}", s)).unwrap_or_else(|| "-".into());
+            print!(" {:<col_w$}", cell);
+        }
+        println!(" {rec} ★");
+    }
+
     Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> &str {
+    if s.len() <= max { s } else { &s[..max] }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_long_string_clips() {
+        assert_eq!(truncate("hello world", 5), "hello");
+    }
 }

--- a/mur-core/src/cmd/fleet/compare.rs
+++ b/mur-core/src/cmd/fleet/compare.rs
@@ -27,7 +27,11 @@ pub fn cmd_fleet_compare(
     let state_db = ParallelStateDb::open(&fleet_dir.join("parallel_state"))?;
     let rubric_ver = parallel.judge.rubric.version();
 
-    let track_names: Vec<&str> = tracks.tracks.iter().map(|t| t.config.name.as_str()).collect();
+    let track_names: Vec<&str> = tracks
+        .tracks
+        .iter()
+        .map(|t| t.config.name.as_str())
+        .collect();
 
     // unit_name → Vec<(track_name, Option<score>)>
     let mut score_map: std::collections::HashMap<String, Vec<(String, Option<f32>)>> =
@@ -76,7 +80,10 @@ pub fn cmd_fleet_compare(
         print!(" {:<col_w$}", tn);
     }
     println!(" Rec");
-    println!("{}", "-".repeat(name_w + (col_w + 1) * track_names.len() + 6));
+    println!(
+        "{}",
+        "-".repeat(name_w + (col_w + 1) * track_names.len() + 6)
+    );
 
     // Print one row per unit
     let mut unit_names: Vec<&String> = score_map.keys().collect();
@@ -103,7 +110,9 @@ pub fn cmd_fleet_compare(
 
         print!("{:<name_w$}", truncate(name, name_w));
         for (_, score) in &scores {
-            let cell = score.map(|s| format!("{:.1}", s)).unwrap_or_else(|| "-".into());
+            let cell = score
+                .map(|s| format!("{:.1}", s))
+                .unwrap_or_else(|| "-".into());
             print!(" {:<col_w$}", cell);
         }
         println!(" {rec} ★");

--- a/mur-core/src/cmd/fleet/judge_cmd.rs
+++ b/mur-core/src/cmd/fleet/judge_cmd.rs
@@ -1,13 +1,10 @@
 //! `mur fleet judge <name>` — run LLM judge across all tracks.
 
+use anyhow::{Context, Result};
 use std::path::Path;
 
 use super::store::load_fleet;
-use crate::parallel::{
-    state::ParallelStateDb,
-    track::filter::{FilterResult, run_pre_filter},
-};
-use anyhow::{Context, Result};
+use crate::parallel::{run_judge_pipeline_async, state::ParallelStateDb, track::TrackSet};
 
 pub fn cmd_fleet_judge(mur_home: &Path, fleet_name: &str) -> Result<()> {
     let fleet = load_fleet(mur_home, fleet_name)?;
@@ -16,42 +13,16 @@ pub fn cmd_fleet_judge(mur_home: &Path, fleet_name: &str) -> Result<()> {
         .as_ref()
         .context("fleet has no parallel config")?;
 
-    let state_dir = mur_home
-        .join("fleets")
-        .join(fleet_name)
-        .join("parallel_state");
-    let _db = ParallelStateDb::open(&state_dir)?;
+    let fleet_dir = mur_home.join("fleets").join(fleet_name);
 
-    for track_cfg in &parallel.tracks {
-        let worktree = mur_home
-            .join("fleets")
-            .join(fleet_name)
-            .join("tracks")
-            .join(&track_cfg.name);
-        if !worktree.exists() {
-            println!(
-                "⚠  track {} worktree not found — run `mur fleet run {fleet_name}` first",
-                track_cfg.name
-            );
-            continue;
-        }
+    let tracks = TrackSet::load(&fleet_dir)
+        .context("no tracks.json — run `mur fleet run` first to create track worktrees")?;
 
-        // Pre-filter
-        let filter_result = run_pre_filter(&worktree, &parallel.pre_filter);
-        if let FilterResult::Failed { filter, stderr } = filter_result {
-            println!(
-                "✗  track {} failed {:?} — discarded",
-                track_cfg.name, filter
-            );
-            eprintln!("{stderr}");
-            continue;
-        }
-        println!("✓  track {} passed pre-filter", track_cfg.name);
-    }
+    let state_db = ParallelStateDb::open(&fleet_dir.join("parallel_state"))?;
 
-    // Collect changed files from all passing tracks, run CAS, then judge
-    // ponytail: full implementation threads track sources through group_by_identity + CyclicJudge
-    // This is the minimal working shell; scoring loop goes here in P1 polish iteration
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(run_judge_pipeline_async(&tracks, parallel, &state_db))?;
+
     println!("Judge complete. Run `mur fleet compare {fleet_name}` to view scores.");
     Ok(())
 }

--- a/mur-core/src/parallel/mod.rs
+++ b/mur-core/src/parallel/mod.rs
@@ -1,4 +1,4 @@
-//! Speculative parallel agent execution — P0/P1 foundation.
+//! Speculative parallel agent execution — P0/P1 orchestrator.
 #![allow(dead_code, unused_imports)]
 
 pub mod backend;
@@ -7,3 +7,223 @@ pub mod judge;
 pub mod semantic;
 pub mod state;
 pub mod track;
+
+use anyhow::Result;
+use mur_common::{config::BackendConfig, parallel::ParallelConfig};
+use semantic::{SupportedLanguage, cas::group_by_identity, extract_units};
+use state::ParallelStateDb;
+use std::sync::Arc;
+use track::TrackSet;
+use walkdir::WalkDir;
+
+use crate::conversations::backend::factory::build_for_stage;
+use judge::{CyclicJudge, JudgeTask, TrackImpl};
+use track::filter::{FilterResult, run_pre_filter};
+
+/// Run the full judge pipeline over all tracks:
+/// pre-filter → semantic parse → CAS dedup → LLM judge (cached) → LMDB store.
+///
+/// Async because `CyclicJudge::score()` calls an LLM. Sync callers:
+/// `tokio::runtime::Runtime::new()?.block_on(run_judge_pipeline_async(...))`.
+pub async fn run_judge_pipeline_async(
+    tracks: &TrackSet,
+    config: &ParallelConfig,
+    state_db: &ParallelStateDb,
+) -> Result<()> {
+    // 1. Pre-filter: discard tracks that fail cargo check / clippy.
+    let live_tracks: Vec<&track::Track> = tracks
+        .tracks
+        .iter()
+        .filter(|t| {
+            let res = run_pre_filter(&t.worktree_path, &config.pre_filter);
+            if matches!(res, FilterResult::Failed { .. }) {
+                eprintln!(" track {} failed pre-filter — discarded", t.config.name);
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    if live_tracks.is_empty() {
+        eprintln!("all tracks failed pre-filter — nothing to judge");
+        return Ok(());
+    }
+
+    // 2. Parse .rs files in each surviving track; keep unit + its source bytes.
+    type TrackUnits = Vec<(String, Vec<(semantic::SemanticUnit, Vec<u8>)>)>;
+    let mut per_track: TrackUnits = Vec::new();
+    for t in &live_tracks {
+        let mut units_with_src: Vec<(semantic::SemanticUnit, Vec<u8>)> = Vec::new();
+        for entry in WalkDir::new(&t.worktree_path)
+            .follow_links(false)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("rs"))
+        {
+            if let Ok(source) = std::fs::read(entry.path())
+                && let Ok(units) = extract_units(&source, SupportedLanguage::Rust)
+            {
+                for u in units {
+                    let unit_src = source[u.byte_range.clone()].to_vec();
+                    units_with_src.push((u, unit_src));
+                }
+            }
+        }
+        per_track.push((t.config.name.clone(), units_with_src));
+    }
+
+    // 3. CAS dedup: group units by name+hash.
+    let for_grouping: Vec<(&str, Vec<semantic::SemanticUnit>)> = per_track
+        .iter()
+        .map(|(name, uws)| (name.as_str(), uws.iter().map(|(u, _)| u.clone()).collect()))
+        .collect();
+    let groups = group_by_identity(&for_grouping);
+
+    if groups.needs_judge.is_empty() {
+        eprintln!("all units identical across tracks (CAS hit) — no LLM calls needed");
+        return Ok(());
+    }
+
+    // 4. Build LLM backend + judge once.
+    let backend_cfg = BackendConfig {
+        provider: "anthropic".into(),
+        model: config.judge.model.clone(),
+        endpoint: None,
+        api_key_env: None,
+        timeout_secs: Some(120),
+    };
+    let backend = build_for_stage(&backend_cfg, "parallel.judge")?;
+    let judge = CyclicJudge::new(config.judge.clone(), Arc::clone(&backend));
+
+    let rubric_version = config.judge.rubric.version();
+    let mut cache_hits = 0usize;
+    let mut judge_calls = 0usize;
+
+    // 5. Judge each differing unit, using LMDB cache by content hash.
+    for jg in &groups.needs_judge {
+        let mut impls: Vec<TrackImpl> = Vec::new();
+        for (track_name, unit) in &jg.per_track {
+            let unit_src = per_track
+                .iter()
+                .find(|(tn, _)| tn == track_name)
+                .and_then(|(_, uws)| {
+                    uws.iter()
+                        .find(|(u, _)| u.name == unit.name && u.content_hash == unit.content_hash)
+                })
+                .map(|(_, src)| src.clone())
+                .unwrap_or_default();
+
+            let track_config = tracks
+                .tracks
+                .iter()
+                .find(|t| &t.config.name == track_name)
+                .map(|t| t.config.clone())
+                .unwrap_or_else(|| mur_common::parallel::TrackConfig {
+                    name: track_name.clone(),
+                    approach: String::new(),
+                    model: None,
+                });
+
+            impls.push(TrackImpl {
+                track_config,
+                unit: unit.clone(),
+                source: unit_src,
+            });
+        }
+
+        if impls.is_empty() {
+            continue;
+        }
+
+        // Cache check: use first impl's hash as group representative.
+        if state_db
+            .get_score(&impls[0].unit.content_hash, &rubric_version)?
+            .is_some()
+        {
+            cache_hits += 1;
+            continue;
+        }
+
+        let task = JudgeTask {
+            unit_name: jg.name.clone(),
+            implementations: impls,
+            rubric_version: rubric_version.clone(),
+        };
+        let scores = judge.score(&task).await?;
+        judge_calls += 1;
+
+        for score in &scores {
+            if let Some(imp) = task
+                .implementations
+                .iter()
+                .find(|i| i.track_config.name == score.track_name)
+            {
+                let js = state::JudgeScore {
+                    score: score.score,
+                    reasoning: score.reasoning.clone(),
+                    model: config.judge.model.clone(),
+                    ts: std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0),
+                };
+                state_db.put_score(&imp.unit.content_hash, &rubric_version, &js)?;
+            }
+        }
+    }
+
+    eprintln!(
+        "judge complete: {} units, {} cache hits, {} LLM calls",
+        groups.needs_judge.len(),
+        cache_hits,
+        judge_calls
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::parallel::{JudgeConfig, ParallelConfig, Rubric};
+
+    #[test]
+    fn pipeline_smoke_with_empty_tracks() {
+        let dir = tempfile::tempdir().unwrap();
+        let state_db = state::ParallelStateDb::open(dir.path()).unwrap();
+        let config = ParallelConfig {
+            mode: Default::default(),
+            tracks: vec![],
+            judge: JudgeConfig {
+                model: "claude-haiku-4-5".into(),
+                rubric: Rubric::default(),
+            },
+            pre_filter: vec![],
+        };
+        let tracks = TrackSet { tracks: vec![] };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(run_judge_pipeline_async(&tracks, &config, &state_db));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn gate0_tree_sitter_extraction_on_real_source() {
+        // A6 validation: tree-sitter reliably extracts semantic units from real mur-core source.
+        let filter_src = include_bytes!("../parallel/track/filter.rs");
+        let units = extract_units(filter_src, SupportedLanguage::Rust).unwrap();
+        assert!(
+            units.len() >= 2,
+            "expected ≥2 semantic units in filter.rs, got {}",
+            units.len()
+        );
+        for u in &units {
+            assert!(!u.name.is_empty(), "unit has empty name");
+            assert!(
+                u.byte_range.end > u.byte_range.start,
+                "unit {} has empty byte range",
+                u.name
+            );
+            assert_ne!(u.content_hash, [0u8; 32], "unit {} has zero hash", u.name);
+        }
+    }
+}

--- a/mur-core/src/parallel/track/diversity.rs
+++ b/mur-core/src/parallel/track/diversity.rs
@@ -1,0 +1,43 @@
+//! Approach suffix injected into agent system prompts for track diversity.
+
+use mur_common::parallel::TrackConfig;
+
+/// Returns a block of text to append to an agent's system prompt,
+/// steering it toward the desired approach for this track.
+pub fn approach_system_suffix(tc: &TrackConfig) -> String {
+    format!(
+        "\n---\n## Parallel Track: {}\n\nYou are implementing in track `{}`. Approach:\n{}\n",
+        tc.name,
+        tc.name,
+        tc.approach.trim()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::parallel::TrackConfig;
+
+    #[test]
+    fn suffix_contains_approach_text() {
+        let tc = TrackConfig {
+            name: "track-functional".into(),
+            approach: "Prefer functional style: Iterator combinators, avoid mutable state.".into(),
+            model: None,
+        };
+        let suffix = approach_system_suffix(&tc);
+        assert!(suffix.contains("track-functional"));
+        assert!(suffix.contains("Iterator combinators"));
+        assert!(suffix.ends_with('\n'));
+    }
+
+    #[test]
+    fn suffix_is_stable_across_calls() {
+        let tc = TrackConfig {
+            name: "t".into(),
+            approach: "performance first".into(),
+            model: None,
+        };
+        assert_eq!(approach_system_suffix(&tc), approach_system_suffix(&tc));
+    }
+}

--- a/mur-core/src/parallel/track/mod.rs
+++ b/mur-core/src/parallel/track/mod.rs
@@ -1,3 +1,76 @@
-//! Per-track execution driver — P0/P1 stub.
+//! Per-track execution driver — P1 types.
 
+pub mod diversity;
 pub mod filter;
+pub mod worktree;
+
+use anyhow::Result;
+use mur_common::parallel::TrackConfig;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Track {
+    pub config: TrackConfig,
+    pub worktree_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrackSet {
+    pub tracks: Vec<Track>,
+}
+
+impl TrackSet {
+    pub fn save(&self, dir: &Path) -> Result<()> {
+        let path = dir.join("tracks.json");
+        let json = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, json)?;
+        Ok(())
+    }
+
+    pub fn load(dir: &Path) -> Result<Self> {
+        let path = dir.join("tracks.json");
+        let json = std::fs::read_to_string(&path)
+            .map_err(|e| anyhow::anyhow!("cannot read tracks.json at {path:?}: {e}"))?;
+        Ok(serde_json::from_str(&json)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::parallel::TrackConfig;
+
+    #[test]
+    fn trackset_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let ts = TrackSet {
+            tracks: vec![
+                Track {
+                    config: TrackConfig {
+                        name: "track-a".into(),
+                        approach: "functional".into(),
+                        model: None,
+                    },
+                    worktree_path: PathBuf::from("/tmp/track-a"),
+                },
+                Track {
+                    config: TrackConfig {
+                        name: "track-b".into(),
+                        approach: "performance".into(),
+                        model: None,
+                    },
+                    worktree_path: PathBuf::from("/tmp/track-b"),
+                },
+            ],
+        };
+        ts.save(dir.path()).unwrap();
+        let loaded = TrackSet::load(dir.path()).unwrap();
+        assert_eq!(loaded.tracks.len(), 2);
+        assert_eq!(loaded.tracks[0].config.name, "track-a");
+        assert_eq!(
+            loaded.tracks[1].worktree_path,
+            PathBuf::from("/tmp/track-b")
+        );
+    }
+}

--- a/mur-core/src/parallel/track/worktree.rs
+++ b/mur-core/src/parallel/track/worktree.rs
@@ -1,0 +1,110 @@
+//! Worktree lifecycle for parallel tracks.
+
+use anyhow::Result;
+use std::path::Path;
+
+use crate::parallel::backend::detect_backend;
+use mur_common::parallel::ParallelConfig;
+
+use super::{Track, TrackSet};
+
+pub fn create_tracks(config: &ParallelConfig, project: &Path) -> Result<TrackSet> {
+    let backend = detect_backend(project);
+    let mut tracks = Vec::with_capacity(config.tracks.len());
+    for tc in &config.tracks {
+        let worktree_path = backend.create_track(&tc.name)?;
+        tracks.push(Track {
+            config: tc.clone(),
+            worktree_path,
+        });
+    }
+    Ok(TrackSet { tracks })
+}
+
+pub fn destroy_tracks(tracks: &TrackSet, project: &Path) {
+    let backend = detect_backend(project);
+    for t in &tracks.tracks {
+        if let Err(e) = backend.destroy(&t.worktree_path) {
+            eprintln!(
+                "warn: failed to destroy track {} at {:?}: {e}",
+                t.config.name, t.worktree_path
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::parallel::{JudgeConfig, ParallelConfig, PreFilterKind, Rubric, TrackConfig};
+    use std::path::PathBuf;
+
+    /// Walk up from `from` looking for a `.git` DIRECTORY (main repo root, not a worktree).
+    fn find_main_repo(from: &Path) -> Option<PathBuf> {
+        let mut cur = from.to_path_buf();
+        loop {
+            if cur.join(".git").is_dir() {
+                return Some(cur);
+            }
+            if !cur.pop() {
+                return None;
+            }
+        }
+    }
+
+    fn make_config(suffix: &str) -> ParallelConfig {
+        ParallelConfig {
+            mode: Default::default(),
+            tracks: vec![
+                TrackConfig {
+                    name: format!("p1-test-{suffix}-a"),
+                    approach: "functional".into(),
+                    model: None,
+                },
+                TrackConfig {
+                    name: format!("p1-test-{suffix}-b"),
+                    approach: "performance".into(),
+                    model: None,
+                },
+            ],
+            judge: JudgeConfig {
+                model: "claude-haiku-4-5".into(),
+                rubric: Rubric::default(),
+            },
+            pre_filter: vec![PreFilterKind::CargoCheck],
+        }
+    }
+
+    #[test]
+    fn create_tracks_returns_one_track_per_config() {
+        let cwd = std::env::current_dir().unwrap();
+        let Some(repo) = find_main_repo(&cwd) else {
+            eprintln!("skip: not in git repo");
+            return;
+        };
+        let cfg = make_config("create");
+        let ts = create_tracks(&cfg, &repo).unwrap();
+        assert_eq!(ts.tracks.len(), 2);
+        assert!(ts.tracks[0].config.name.contains("create"));
+        for t in &ts.tracks {
+            assert!(t.worktree_path.exists(), "{:?} should exist", t.worktree_path);
+        }
+        destroy_tracks(&ts, &repo);
+    }
+
+    #[test]
+    fn destroy_tracks_removes_worktrees() {
+        let cwd = std::env::current_dir().unwrap();
+        let Some(repo) = find_main_repo(&cwd) else {
+            eprintln!("skip: not in git repo");
+            return;
+        };
+        let cfg = make_config("destroy");
+        let ts = create_tracks(&cfg, &repo).unwrap();
+        let paths: Vec<_> = ts.tracks.iter().map(|t| t.worktree_path.clone()).collect();
+        destroy_tracks(&ts, &repo);
+        for p in &paths {
+            assert!(!p.exists(), "{p:?} should be removed");
+        }
+    }
+}

--- a/mur-core/src/parallel/track/worktree.rs
+++ b/mur-core/src/parallel/track/worktree.rs
@@ -87,7 +87,11 @@ mod tests {
         assert_eq!(ts.tracks.len(), 2);
         assert!(ts.tracks[0].config.name.contains("create"));
         for t in &ts.tracks {
-            assert!(t.worktree_path.exists(), "{:?} should exist", t.worktree_path);
+            assert!(
+                t.worktree_path.exists(),
+                "{:?} should exist",
+                t.worktree_path
+            );
         }
         destroy_tracks(&ts, &repo);
     }

--- a/scripts/parallel_poc.sh
+++ b/scripts/parallel_poc.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Gate 0 — Parallel Tracks PoC validation
+# Validates A6 (tree-sitter extraction reliability); documents A1 (approach diversity) as a manual step.
+#
+# Usage: bash scripts/parallel_poc.sh
+# Prereqs: ORT_STRATEGY=download, mur-core builds
+
+set -euo pipefail
+
+echo "=== Gate 0: Parallel Tracks PoC Validation ==="
+echo ""
+echo "--- A6: tree-sitter extraction reliability ---"
+ORT_STRATEGY=download cargo test -p mur-core --lib parallel::tests::gate0_tree_sitter_extraction_on_real_source 2>&1 | tail -5
+echo "A6 PASS: tree-sitter extraction verified on real mur-core source."
+echo ""
+echo "--- A1: approach diversity (manual step) ---"
+echo "To validate that diverse approach prompts produce different implementations:"
+echo "  1. Run: mur fleet run <fleet-name>  (with 2+ tracks configured)"
+echo "  2. Run: mur fleet judge <fleet-name>"
+echo "  3. Run: mur fleet compare <fleet-name>"
+echo "  4. Check that scores differ across tracks (similarity <= 0.60)"
+echo ""
+echo "Save results to: docs/superpowers/validation/parallel-poc-results.md"


### PR DESCRIPTION
## Summary

- **Track/TrackSet types** with JSON save/load at `~/.mur/fleets/<name>/tracks.json`
- **Worktree lifecycle** (`create_tracks` / `destroy_tracks`) via `detect_backend()` with `find_main_repo` (`.is_dir()` to skip worktree `.git` files)
- **Diversity injection** (`approach_system_suffix`) — inserts per-track approach text into agent system prompts
- **`run_judge_pipeline_async`** orchestrator: pre-filter → tree-sitter parse → CAS dedup → CyclicJudge → LMDB cache
- **`fleet judge`** CLI wiring — loads TrackSet + ParallelStateDb, runs pipeline, prints next step
- **`fleet compare`** — reads LMDB scores, prints aligned score table per semantic unit per track
- **`fleet cherry`** — calls `cherry_pick` + `assemble_file`, validates with `cargo check`, writes result to `cherry-result/`
- **Gate 0 validation** — `gate0_tree_sitter_extraction_on_real_source` test + `scripts/parallel_poc.sh`

## Test plan

- [ ] `cargo test --lib -p mur-core parallel` — 38 tests, 0 failures (verified in prior session; disk full blocked re-run)
- [ ] `cargo clippy -p mur-core -- -D warnings` — zero warnings
- [ ] `cargo fmt --check` — clean
- [ ] `scripts/parallel_poc.sh` — Gate 0 tree-sitter smoke test

## Notes

- Branches from `feat/parallel-tracks-p2` (the P0 skeletons); this PR wires them into a working pipeline
- Disk on Firecuda4tb is 100% full — pre-existing environment issue, not caused by these changes; `cargo check` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)