### PR TITLE
feat(parallel/p1.5): platform COW build-cache copy for parallel tracks

### DIFF
--- a/mur-core/src/parallel/backend/cow.rs
+++ b/mur-core/src/parallel/backend/cow.rs
@@ -6,7 +6,7 @@
 //!
 //! Detection order:
 //!   macOS  → `cp -cR`  (APFS clone; always available on macOS 10.13+)
-//!   Linux  → `cp --reflink=auto -a`  (Btrfs/XFS if available, silent fallback otherwise)
+//!   Linux  → `cp --reflink=always -a`  (Btrfs/XFS only; fails fast on ext4 so no slow fallback copy)
 //!   other  → skip (no COW; callers still work, just no warm cache)
 
 use anyhow::Result;
@@ -21,7 +21,7 @@ const CACHE_DIRS: &[&str] = &["target"];
 pub enum CowMethod {
     /// macOS `cp -cR` — APFS block clone.
     ApfsClone,
-    /// Linux `cp --reflink=auto -a` — Btrfs/XFS reflink, silent fallback to regular.
+    /// Linux `cp --reflink=always -a` — Btrfs/XFS only; fails fast on ext4 (no slow fallback).
     Reflink,
     /// Platform has no known COW support; skip.
     Skip,
@@ -72,7 +72,7 @@ fn cow_copy_dir(method: &CowMethod, src: &Path, dst: &Path) -> Result<()> {
             .arg(dst)
             .status()?,
         CowMethod::Reflink => Command::new("cp")
-            .args(["--reflink=auto", "-a"])
+            .args(["--reflink=always", "-a"])
             .arg(src)
             .arg(dst)
             .status()?,

--- a/mur-core/src/parallel/backend/cow.rs
+++ b/mur-core/src/parallel/backend/cow.rs
@@ -1,0 +1,148 @@
+//! Platform-aware COW (Copy-on-Write) build-cache copy for parallel tracks.
+//!
+//! APFS on macOS and Btrfs on Linux support block-level clones: a `cp -c` /
+//! `cp --reflink` of a multi-GB `target/` directory completes in milliseconds
+//! because no bytes are physically copied until a page is actually modified.
+//!
+//! Detection order:
+//!   macOS  → `cp -cR`  (APFS clone; always available on macOS 10.13+)
+//!   Linux  → `cp --reflink=auto -a`  (Btrfs/XFS if available, silent fallback otherwise)
+//!   other  → skip (no COW; callers still work, just no warm cache)
+
+use anyhow::Result;
+use std::path::Path;
+use std::process::Command;
+
+/// Directories (relative to project root) that are worth COW-copying.
+const CACHE_DIRS: &[&str] = &["target"];
+
+/// COW copy method resolved at call time.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CowMethod {
+    /// macOS `cp -cR` — APFS block clone.
+    ApfsClone,
+    /// Linux `cp --reflink=auto -a` — Btrfs/XFS reflink, silent fallback to regular.
+    Reflink,
+    /// Platform has no known COW support; skip.
+    Skip,
+}
+
+pub fn detect_cow_method() -> CowMethod {
+    #[cfg(target_os = "macos")]
+    return CowMethod::ApfsClone;
+
+    #[cfg(target_os = "linux")]
+    return CowMethod::Reflink;
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    CowMethod::Skip
+}
+
+/// COW-copy each `CACHE_DIRS` entry from `src_project` into `dst_worktree`.
+/// Non-fatal: logs a warning and returns `Ok(())` on any per-dir failure so
+/// track creation is never blocked by a cache-copy error.
+pub fn copy_build_cache(src_project: &Path, dst_worktree: &Path) -> Result<()> {
+    let method = detect_cow_method();
+    if method == CowMethod::Skip {
+        return Ok(());
+    }
+    for dir in CACHE_DIRS {
+        let src = src_project.join(dir);
+        if !src.exists() {
+            continue;
+        }
+        let dst = dst_worktree.join(dir);
+        if dst.exists() {
+            continue; // already present — created by cargo or another call
+        }
+        if let Err(e) = cow_copy_dir(&method, &src, &dst) {
+            eprintln!("warn: COW copy of {dir}/ skipped ({e}); track will build from scratch");
+        } else {
+            eprintln!("COW-copied {dir}/ → track ({})", method_label(&method));
+        }
+    }
+    Ok(())
+}
+
+fn cow_copy_dir(method: &CowMethod, src: &Path, dst: &Path) -> Result<()> {
+    let status = match method {
+        CowMethod::ApfsClone => Command::new("cp")
+            .args(["-cR"])
+            .arg(src)
+            .arg(dst)
+            .status()?,
+        CowMethod::Reflink => Command::new("cp")
+            .args(["--reflink=auto", "-a"])
+            .arg(src)
+            .arg(dst)
+            .status()?,
+        CowMethod::Skip => return Ok(()),
+    };
+    if !status.success() {
+        anyhow::bail!("cp exited with {status}");
+    }
+    Ok(())
+}
+
+fn method_label(m: &CowMethod) -> &'static str {
+    match m {
+        CowMethod::ApfsClone => "APFS clone",
+        CowMethod::Reflink => "reflink",
+        CowMethod::Skip => "skip",
+    }
+}
+
+/// Take a Time Machine local snapshot before parallel track creation so the
+/// user can restore if something goes wrong.  No entitlement required.
+/// Non-fatal: if `tmutil` is unavailable or Time Machine is off, logs and
+/// continues.
+#[cfg(target_os = "macos")]
+pub fn take_local_snapshot() {
+    let result = Command::new("tmutil").arg("localsnapshot").status();
+    match result {
+        Ok(s) if s.success() => eprintln!("Time Machine local snapshot created"),
+        Ok(s) => eprintln!("warn: tmutil localsnapshot exited {s} — continuing"),
+        Err(e) => eprintln!("warn: tmutil not available ({e}) — continuing"),
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn take_local_snapshot() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_returns_known_variant() {
+        // Must return one of the three variants — just confirm it doesn't panic.
+        let m = detect_cow_method();
+        assert!(matches!(
+            m,
+            CowMethod::ApfsClone | CowMethod::Reflink | CowMethod::Skip
+        ));
+    }
+
+    #[test]
+    fn copy_build_cache_noop_when_src_missing() {
+        let tmp = tempdir();
+        // src_project has no target/ dir → copy_build_cache should return Ok silently
+        let result = copy_build_cache(tmp.path(), tmp.path());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn copy_build_cache_skips_existing_dst() {
+        let src = tempdir();
+        let dst = tempdir();
+        // Create src/target and dst/target — dst/target already present, should skip
+        std::fs::create_dir(src.path().join("target")).unwrap();
+        std::fs::create_dir(dst.path().join("target")).unwrap();
+        let result = copy_build_cache(src.path(), dst.path());
+        assert!(result.is_ok());
+    }
+
+    fn tempdir() -> tempfile::TempDir {
+        tempfile::TempDir::new().expect("tempdir")
+    }
+}

--- a/mur-core/src/parallel/backend/git_worktree.rs
+++ b/mur-core/src/parallel/backend/git_worktree.rs
@@ -19,6 +19,9 @@ impl GitWorktreeBackend {
 
 impl ParallelBackend for GitWorktreeBackend {
     fn create_track(&self, name: &str) -> Result<PathBuf> {
+        // Optional safety net: Time Machine local snapshot before first track.
+        super::cow::take_local_snapshot();
+
         let path = self.repo_root.join(WORKTREES_DIR).join(name);
         let status = Command::new("git")
             .args(["worktree", "add", "--detach"])
@@ -43,6 +46,10 @@ impl ParallelBackend for GitWorktreeBackend {
             );
         }
         std::fs::write(path.join(PARALLEL_BASE_FILE), base_head.stdout.as_slice())?;
+
+        // COW-copy build cache (e.g. target/) into the new track so agents
+        // start with a warm cache instead of a cold build.
+        super::cow::copy_build_cache(&self.repo_root, &path)?;
 
         Ok(path)
     }

--- a/mur-core/src/parallel/backend/mod.rs
+++ b/mur-core/src/parallel/backend/mod.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code, unused_imports)]
+pub mod cow;
 pub mod detect;
 pub mod git_worktree;
 pub mod zfs_native;

--- a/scripts/gate5_cow_latency.sh
+++ b/scripts/gate5_cow_latency.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Gate 5: COW vs regular copy latency.
+#
+# Creates a synthetic ~100 MB directory on the SAME filesystem as the project,
+# then clones it with APFS cp -c / Linux --reflink=auto and a regular cp.
+#
+# Pass criterion:
+#   macOS  APFS clone:    ≤ 100ms for 100 MB
+#   Linux  Btrfs reflink: ≤ 100ms for 100 MB
+#
+# To test against the real target/ dir (requires enough free space):
+#   bash scripts/gate5_cow_latency.sh --real
+#
+# Usage: bash scripts/gate5_cow_latency.sh [--real]
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+USE_REAL=0
+[ "${1:-}" = "--real" ] && USE_REAL=1
+
+# ── Prepare source directory ──────────────────────────────────────────────────
+TMPBASE="$REPO_ROOT/.gate5-tmp"
+mkdir -p "$TMPBASE"
+trap 'rm -rf "$TMPBASE"' EXIT
+
+if [ "$USE_REAL" -eq 1 ]; then
+  REAL_TARGET="$REPO_ROOT/target"
+  if [ ! -d "$REAL_TARGET" ]; then
+    echo "ERROR: $REAL_TARGET not found. Run: cargo build"
+    exit 1
+  fi
+  SRC="$REAL_TARGET"
+  SIZE_MB=$(du -sm "$SRC" 2>/dev/null | awk '{print $1}')
+  echo "Mode: real target/ (${SIZE_MB} MB) — requires ${SIZE_MB} MB free on same filesystem"
+else
+  # Synthetic: create ~100 MB of files (10×10 MB)
+  SRC="$TMPBASE/src"
+  mkdir -p "$SRC/deps" "$SRC/build"
+  echo -n "Creating synthetic 100 MB test dir... "
+  for i in $(seq 1 10); do
+    dd if=/dev/urandom bs=1m count=10 of="$SRC/deps/lib${i}.rlib" 2>/dev/null
+  done
+  dd if=/dev/urandom bs=1m count=5 of="$SRC/build/output" 2>/dev/null
+  SIZE_MB=$(du -sm "$SRC" 2>/dev/null | awk '{print $1}')
+  echo "${SIZE_MB} MB"
+fi
+
+echo "Source: $SRC  (${SIZE_MB} MB, same APFS volume)"
+echo ""
+
+PASS=0
+FAIL=0
+
+# ── macOS APFS clone ──────────────────────────────────────────────────────────
+if [[ "$(uname)" == "Darwin" ]]; then
+  DST="$TMPBASE/apfs-clone"
+  rm -rf "$DST"
+  echo -n "macOS cp -cR (APFS clone):        "
+  START=$(python3 -c "import time; print(int(time.time()*1000))")
+  cp -cR "$SRC" "$DST"
+  END=$(python3 -c "import time; print(int(time.time()*1000))")
+  MS=$((END - START))
+  THRESHOLD=100
+  if [ "$MS" -le "$THRESHOLD" ]; then
+    echo "${MS}ms  ✅  PASS (≤ ${THRESHOLD}ms for ${SIZE_MB} MB)"
+    PASS=$((PASS + 1))
+  else
+    echo "${MS}ms  ❌  FAIL (> ${THRESHOLD}ms — may not be on APFS, or cross-volume)"
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
+# ── Linux reflink ─────────────────────────────────────────────────────────────
+if [[ "$(uname)" == "Linux" ]]; then
+  DST="$TMPBASE/reflink"
+  rm -rf "$DST"
+  echo -n "Linux cp --reflink=auto (Btrfs):  "
+  START=$(date +%s%3N)
+  cp --reflink=auto -a "$SRC" "$DST"
+  END=$(date +%s%3N)
+  MS=$((END - START))
+  THRESHOLD=100
+  if [ "$MS" -le "$THRESHOLD" ]; then
+    echo "${MS}ms  ✅  PASS (≤ ${THRESHOLD}ms for ${SIZE_MB} MB)"
+    PASS=$((PASS + 1))
+  else
+    echo "${MS}ms  ⚠   SLOW (> ${THRESHOLD}ms — may not be Btrfs/XFS; copy_build_cache falls back gracefully)"
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
+# ── Baseline: regular cp (no COW) ────────────────────────────────────────────
+DST_REG="$TMPBASE/regular"
+rm -rf "$DST_REG"
+echo -n "Baseline regular cp -r:            "
+START_R=$(python3 -c "import time; print(int(time.time()*1000))" 2>/dev/null || date +%s%3N)
+cp -r "$SRC" "$DST_REG"
+END_R=$(python3 -c "import time; print(int(time.time()*1000))" 2>/dev/null || date +%s%3N)
+MS_REG=$((END_R - START_R))
+echo "${MS_REG}ms  (baseline — no pass/fail)"
+
+echo ""
+echo "─────────────────────────────────────────"
+if [ "$FAIL" -eq 0 ] && [ "$PASS" -gt 0 ]; then
+  echo "GATE 5: ✅ PASS"
+else
+  echo "GATE 5: ❌ FAIL  (pass=$PASS fail=$FAIL)"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- `cow.rs` — `detect_cow_method()` returns `ApfsClone` (macOS) / `Reflink` (Linux) / `Skip`
- `copy_build_cache(src_project, dst_worktree)` — COW-copies `target/` into each new track; non-fatal (logs warn and continues if COW fails, so track creation never blocks)
- `take_local_snapshot()` — `tmutil localsnapshot` safety net on macOS before track creation (no entitlement required)
- `git_worktree.rs create_track` — now calls both after `git worktree add`
- `scripts/gate5_cow_latency.sh` — benchmark with synthetic 100 MB dir + `--real` flag for the full `target/`

## Gate 5 result

```
macOS cp -cR (APFS clone):  19ms  ✅ PASS (≤ 100ms for 105 MB)
Baseline regular cp -r:    794ms  (baseline)
GATE 5: ✅ PASS  (42× faster)
```

## Test plan

- [x] 3 COW unit tests pass (`detect_returns_known_variant`, `noop_when_src_missing`, `skips_existing_dst`)
- [x] Gate 5 script passes on macOS APFS
- [ ] Gate 5 `--real` — blocked by 87 GB `target/` on full disk; mechanism proven with synthetic test

🤖 Generated with [Claude Code](https://claude.com/claude-code)