### PR TITLE
fix(hub): agent card button event bubbling + settings gear icon + fleet run button width

### DIFF
--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -65,7 +65,7 @@ interface GridCardProps {
 
 export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
   const { t } = useT();
-  const { setSelected, setDesiredDetailTab } = useAgents();
+  const { setSelected } = useAgents();
   const unread = useUnreadCount(agent.name);
   const color = CATEGORY_COLORS[agent.category] ?? "#6B7280";
   const pill = runtimePill(runtime?.state);
@@ -204,7 +204,7 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
         <div className="grid-card__actions">
           <button
             disabled={isRunning || isBusy}
-            onClick={handleRun}
+            onClick={(e) => { e.stopPropagation(); handleRun(); }}
             title={t("dashboard.run")}
             aria-label={t("dashboard.run")}
           >
@@ -212,13 +212,13 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
           </button>
           <button
             disabled={!isRunning && !isBusy}
-            onClick={handleStop}
+            onClick={(e) => { e.stopPropagation(); handleStop(); }}
             title={t("dashboard.stop")}
             aria-label={t("dashboard.stop")}
           >
             <Ico filled><rect x="6" y="6" width="12" height="12" rx="1.5" /></Ico>
           </button>
-          <button onClick={handleShare} title={t("dashboard.share")} aria-label={t("dashboard.share")}>
+          <button onClick={(e) => { e.stopPropagation(); handleShare(); }} title={t("dashboard.share")} aria-label={t("dashboard.share")}>
             <Ico>
               <path d="M4 12v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7" />
               <polyline points="16 7 12 3 8 7" />
@@ -237,24 +237,24 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
               <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
             </Ico>
           </button>
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setDesiredDetailTab("style");
-              setSelected(agent.name);
-            }}
-            title={t("dashboard.style")}
-            aria-label={t("dashboard.style")}
-          >
-            <Ico><path d="M17 3a2.85 2.85 0 0 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z" /></Ico>
-          </button>
+
         </div>
         <div className="grid-card__foot">
           <span className={pill.cls}>
             <span className="pill__dot" />
             {t(pill.key)}
           </span>
-          <span className="grid-card__open">{t("dashboard.open")} →</span>
+          <button
+            className="grid-card__settings"
+            onClick={(e) => { e.stopPropagation(); setSelected(agent.name); }}
+            title={t("dashboard.settings")}
+            aria-label={t("dashboard.settings")}
+          >
+            <Ico>
+              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+              <circle cx="12" cy="12" r="3" />
+            </Ico>
+          </button>
         </div>
       </div>
 
@@ -315,7 +315,17 @@ export function ListRow({ agent, runtime, isSelected }: ListRowProps) {
         <span className="pill__dot" />
         {t(pill.key)}
       </span>
-      <span className="list-row__open">{t("dashboard.open")} →</span>
+      <button
+        className="list-row__settings"
+        onClick={(e) => { e.stopPropagation(); setSelected(isSelected ? null : agent.name); }}
+        title={t("dashboard.settings")}
+        aria-label={t("dashboard.settings")}
+      >
+        <Ico>
+          <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+          <circle cx="12" cy="12" r="3" />
+        </Ico>
+      </button>
     </div>
   );
 }

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -17,7 +17,7 @@ export const en = {
   "dashboard.run": "Run",
   "dashboard.stop": "Stop",
   "dashboard.share": "Share",
-  "dashboard.open": "Open",
+  "dashboard.settings": "Settings",
   "dashboard.runTooltip": "Start agent runtime",
   "dashboard.startFailed": "Couldn’t start: {error}",
   "dashboard.stopFailed": "Couldn’t stop: {error}",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -19,7 +19,7 @@ export const zhTW: Table = {
   "dashboard.run": "啟動",
   "dashboard.stop": "停止",
   "dashboard.share": "分享",
-  "dashboard.open": "開啟",
+  "dashboard.settings": "設定",
   "dashboard.runTooltip": "啟動 agent runtime",
   "dashboard.startFailed": "啟動失敗：{error}",
   "dashboard.stopFailed": "停止失敗：{error}",

--- a/mur-hub-gui/ui/src/styles/components/fleet.css
+++ b/mur-hub-gui/ui/src/styles/components/fleet.css
@@ -431,7 +431,7 @@
 /* ── Detail action layout ────────────────────────────────────────────────── */
 
 .fleet-detail__run { margin-bottom: 12px; }
-.fleet-detail__run .toolbar-btn { width: 100%; padding: 8px 16px; font-size: 13px; font-weight: 600; justify-content: center; }
+.fleet-detail__run .toolbar-btn { padding: 8px 16px; font-size: 13px; font-weight: 600; }
 
 .fleet-detail__mgmt { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 20px; }
 


### PR DESCRIPTION
## Summary

- **Bug fix:** clicking start/stop/export on an agent card was also opening the detail panel — `e.stopPropagation()` was missing on all three buttons
- **Style button removed:** redundant with clicking the card or the new settings gear
- **"Open →" → gear icon:** replaced the passive text span with a proper icon-only settings button (Lucide Settings SVG, `title`/`aria-label`) in both grid and list views, following macOS/VS Code/Docker Desktop convention
- **i18n:** `dashboard.open` → `dashboard.settings` (`"Settings"` / `"設定"`)
- **Fleet detail:** removed `width: 100%` from the execute button so it sizes to content instead of spanning the full panel

## Test plan

- [ ] Click start/stop/export on an agent card — detail panel should NOT open
- [ ] Click the gear icon — detail panel opens
- [ ] Click anywhere else on the card — detail panel opens
- [ ] Grid view and list view both show the gear icon
- [ ] Fleet detail execute button is no longer full-width
- [ ] Hover on gear icon shows "Settings" tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)