### PR TITLE
feat(parallel): fleet compare rich table + fleet cherry --promote

### DIFF
--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -538,6 +538,12 @@ pub enum FleetAction {
         /// Apply the assembly without prompting
         #[arg(long)]
         auto: bool,
+        /// Copy cherry-result into the live project tree (default: fleet's git root)
+        #[arg(long)]
+        promote: bool,
+        /// Override destination for --promote
+        #[arg(long)]
+        target: Option<std::path::PathBuf>,
     },
 }
 

--- a/mur-core/src/cmd/fleet/cherry_cmd.rs
+++ b/mur-core/src/cmd/fleet/cherry_cmd.rs
@@ -16,7 +16,13 @@ use crate::parallel::{
     track::TrackSet,
 };
 
-pub fn cmd_fleet_cherry(mur_home: &Path, fleet_name: &str, auto: bool) -> Result<()> {
+pub fn cmd_fleet_cherry(
+    mur_home: &Path,
+    fleet_name: &str,
+    auto: bool,
+    promote: bool,
+    target: Option<&Path>,
+) -> Result<()> {
     let fleet = load_fleet(mur_home, fleet_name)?;
     let parallel = fleet
         .parallel
@@ -174,8 +180,77 @@ pub fn cmd_fleet_cherry(mur_home: &Path, fleet_name: &str, auto: bool) -> Result
         Err(e) => eprintln!("cargo check could not run ({e}) — skipping validation"),
     }
 
-    println!("Use `mur fleet promote {fleet_name} cherry` to apply the result.");
+    if promote {
+        let dest = match target {
+            Some(p) => p.to_path_buf(),
+            None => project_root_from_worktree(&base_track.worktree_path)
+                .context("cannot determine project root — pass --target <path>")?,
+        };
+        promote_cherry_result(&result_dir, &dest)?;
+    } else {
+        println!(
+            "Run `mur fleet cherry {fleet_name} --promote` to copy the result into the project."
+        );
+    }
     Ok(())
+}
+
+/// Copy `result_dir` contents into `dest`, refusing if `dest` has uncommitted changes.
+fn promote_cherry_result(result_dir: &Path, dest: &Path) -> Result<()> {
+    // Guard: refuse if destination has uncommitted changes.
+    let status_out = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(dest)
+        .output();
+    match status_out {
+        Ok(out) if !out.stdout.is_empty() => {
+            anyhow::bail!(
+                "destination {} has uncommitted changes — commit or stash first",
+                dest.display()
+            );
+        }
+        Err(e) => eprintln!("warn: git status check failed ({e}); proceeding anyway"),
+        _ => {}
+    }
+
+    let mut copied = 0usize;
+    for entry in walkdir::WalkDir::new(result_dir)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+    {
+        let rel = entry.path().strip_prefix(result_dir)?;
+        let dst = dest.join(rel);
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(entry.path(), &dst)?;
+        copied += 1;
+    }
+    println!("Promoted {copied} files → {}", dest.display());
+    Ok(())
+}
+
+/// Resolve the main project root from a worktree path via git-common-dir.
+fn project_root_from_worktree(worktree: &Path) -> Option<PathBuf> {
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .current_dir(worktree)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let common_dir_str = String::from_utf8(out.stdout).ok()?;
+    let common_dir = PathBuf::from(common_dir_str.trim());
+    let common_dir = if common_dir.is_absolute() {
+        common_dir
+    } else {
+        worktree.join(common_dir)
+    };
+    // common_dir is <project>/.git — parent is the project root
+    common_dir.parent().map(|p| p.to_path_buf())
 }
 
 fn cherry_result_dir(mur_home: &Path, fleet_name: &str) -> PathBuf {

--- a/mur-core/src/cmd/fleet/compare.rs
+++ b/mur-core/src/cmd/fleet/compare.rs
@@ -33,8 +33,9 @@ pub fn cmd_fleet_compare(
         .map(|t| t.config.name.as_str())
         .collect();
 
+    type ScoreEntry = (String, Option<(f32, bool)>);
     // unit_name → Vec<(track_name, Option<(score, low_confidence)>)>
-    let mut score_map: std::collections::HashMap<String, Vec<(String, Option<(f32, bool)>)>> =
+    let mut score_map: std::collections::HashMap<String, Vec<ScoreEntry>> =
         std::collections::HashMap::new();
 
     for t in &tracks.tracks {
@@ -117,7 +118,7 @@ pub fn cmd_fleet_compare(
             let max_score = scores[wi].unwrap().0;
             scores
                 .iter()
-                .filter(|v| v.map_or(false, |(s, _)| s == max_score))
+                .filter(|v| v.is_some_and(|(s, _)| s == max_score))
                 .count()
                 > 1
         } else {
@@ -131,12 +132,7 @@ pub fn cmd_fleet_compare(
                 Some((s, false)) => format!("{:.1}", s),
                 None => "-".into(),
             };
-            // Bold the winner column
-            if winner_idx == Some(i) && !is_tie {
-                print!(" {:<col_w$}", cell);
-            } else {
-                print!(" {:<col_w$}", cell);
-            }
+            print!(" {:<col_w$}", cell);
 
             // accumulate averages
             if let Some((s, _)) = val {

--- a/mur-core/src/cmd/fleet/compare.rs
+++ b/mur-core/src/cmd/fleet/compare.rs
@@ -33,8 +33,8 @@ pub fn cmd_fleet_compare(
         .map(|t| t.config.name.as_str())
         .collect();
 
-    // unit_name → Vec<(track_name, Option<score>)>
-    let mut score_map: std::collections::HashMap<String, Vec<(String, Option<f32>)>> =
+    // unit_name → Vec<(track_name, Option<(score, low_confidence)>)>
+    let mut score_map: std::collections::HashMap<String, Vec<(String, Option<(f32, bool)>)>> =
         std::collections::HashMap::new();
 
     for t in &tracks.tracks {
@@ -54,15 +54,15 @@ pub fn cmd_fleet_compare(
                 if unit_filter.is_some_and(|f| !unit.name.contains(f)) {
                     continue;
                 }
-                let score_val = state_db
+                let val = state_db
                     .get_score(&unit.content_hash, &rubric_ver)
                     .ok()
                     .flatten()
-                    .map(|js| js.score);
+                    .map(|js| (js.score, js.low_confidence));
                 score_map
                     .entry(unit.name)
                     .or_default()
-                    .push((t.config.name.clone(), score_val));
+                    .push((t.config.name.clone(), val));
             }
         }
     }
@@ -72,51 +72,124 @@ pub fn cmd_fleet_compare(
         return Ok(());
     }
 
-    // Print header
     let col_w = 14usize;
     let name_w = 28usize;
-    print!("{:<name_w$}", "Unit");
+    let sep = "─".repeat(name_w + (col_w + 1) * track_names.len() + 12);
+
+    // Header
+    print!("{:<name_w$}", "unit");
     for tn in &track_names {
         print!(" {:<col_w$}", tn);
     }
-    println!(" Rec");
-    println!(
-        "{}",
-        "-".repeat(name_w + (col_w + 1) * track_names.len() + 6)
-    );
+    println!(" winner");
+    println!("{sep}");
 
-    // Print one row per unit
+    // Rows
     let mut unit_names: Vec<&String> = score_map.keys().collect();
     unit_names.sort();
-    for name in unit_names {
-        let by_track = score_map.get(name).unwrap();
-        let scores: Vec<(&str, Option<f32>)> = track_names
+
+    let mut track_sum = vec![0f32; track_names.len()];
+    let mut track_cnt = vec![0usize; track_names.len()];
+    let mut overall_winner: Option<usize> = None; // index into track_names
+
+    for name in &unit_names {
+        let by_track = score_map.get(*name).unwrap();
+        let scores: Vec<Option<(f32, bool)>> = track_names
             .iter()
             .map(|tn| {
-                let score = by_track
+                by_track
                     .iter()
                     .find(|(t, _)| t.as_str() == *tn)
-                    .and_then(|(_, s)| *s);
-                (*tn, score)
+                    .and_then(|(_, v)| *v)
             })
             .collect();
 
-        let rec = scores
+        // Find winner index (highest score)
+        let winner_idx = scores
             .iter()
-            .filter_map(|(tn, s)| s.map(|v| (tn, v)))
+            .enumerate()
+            .filter_map(|(i, v)| v.map(|(s, _)| (i, s)))
             .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
-            .map(|(tn, _)| *tn)
-            .unwrap_or("-");
+            .map(|(i, _)| i);
+
+        // Detect tie (two or more tracks share max score)
+        let is_tie = if let Some(wi) = winner_idx {
+            let max_score = scores[wi].unwrap().0;
+            scores
+                .iter()
+                .filter(|v| v.map_or(false, |(s, _)| s == max_score))
+                .count()
+                > 1
+        } else {
+            false
+        };
 
         print!("{:<name_w$}", truncate(name, name_w));
-        for (_, score) in &scores {
-            let cell = score
-                .map(|s| format!("{:.1}", s))
-                .unwrap_or_else(|| "-".into());
-            print!(" {:<col_w$}", cell);
+        for (i, val) in scores.iter().enumerate() {
+            let cell = match val {
+                Some((s, true)) => format!("{:.1} ⚠", s),
+                Some((s, false)) => format!("{:.1}", s),
+                None => "-".into(),
+            };
+            // Bold the winner column
+            if winner_idx == Some(i) && !is_tie {
+                print!(" {:<col_w$}", cell);
+            } else {
+                print!(" {:<col_w$}", cell);
+            }
+
+            // accumulate averages
+            if let Some((s, _)) = val {
+                track_sum[i] += s;
+                track_cnt[i] += 1;
+            }
         }
-        println!(" {rec} ★");
+
+        let winner_label = if is_tie {
+            "(tie)".into()
+        } else {
+            winner_idx
+                .map(|i| format!("{} ✓", track_names[i]))
+                .unwrap_or_else(|| "-".into())
+        };
+        println!(" {winner_label}");
     }
+
+    // Summary row
+    println!("{sep}");
+    print!("{:<name_w$}", "average");
+    let mut best_avg = f32::NEG_INFINITY;
+    for i in 0..track_names.len() {
+        let avg = if track_cnt[i] > 0 {
+            track_sum[i] / track_cnt[i] as f32
+        } else {
+            0.0
+        };
+        if avg > best_avg {
+            best_avg = avg;
+            overall_winner = Some(i);
+        }
+        print!(" {:<col_w$}", format!("{:.2}", avg));
+    }
+    // Tie on averages?
+    let avg_winners: Vec<usize> = (0..track_names.len())
+        .filter(|&i| {
+            let avg = if track_cnt[i] > 0 {
+                track_sum[i] / track_cnt[i] as f32
+            } else {
+                0.0
+            };
+            (avg - best_avg).abs() < 0.005
+        })
+        .collect();
+    let overall_label = if avg_winners.len() > 1 {
+        "(tie)".into()
+    } else {
+        overall_winner
+            .map(|i| format!("{} ✓", track_names[i]))
+            .unwrap_or_else(|| "-".into())
+    };
+    println!(" {overall_label}");
 
     Ok(())
 }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -356,9 +356,18 @@ pub async fn run(cli: Cli) -> Result<()> {
                 FleetAction::Judge { name, stats } => {
                     cmd::fleet::judge_cmd::cmd_fleet_judge(&mur_home, &name, stats)?
                 }
-                FleetAction::Cherry { name, auto } => {
-                    cmd::fleet::cherry_cmd::cmd_fleet_cherry(&mur_home, &name, auto)?
-                }
+                FleetAction::Cherry {
+                    name,
+                    auto,
+                    promote,
+                    target,
+                } => cmd::fleet::cherry_cmd::cmd_fleet_cherry(
+                    &mur_home,
+                    &name,
+                    auto,
+                    promote,
+                    target.as_deref(),
+                )?,
             }
         }
         Commands::Commander { action } => {

--- a/mur-core/src/parallel/mod.rs
+++ b/mur-core/src/parallel/mod.rs
@@ -196,6 +196,7 @@ pub async fn run_judge_pipeline_async(
                         .duration_since(std::time::UNIX_EPOCH)
                         .map(|d| d.as_secs())
                         .unwrap_or(0),
+                    low_confidence: score.low_confidence,
                 };
                 state_db.put_score(&imp.unit.content_hash, &rubric_version, &js)?;
             }

--- a/mur-core/src/parallel/state/lmdb.rs
+++ b/mur-core/src/parallel/state/lmdb.rs
@@ -83,6 +83,7 @@ mod tests {
             reasoning: "good design".into(),
             model: "claude-opus-4-8".into(),
             ts: 1_700_000_000,
+            low_confidence: false,
         };
         db.put_score(&hash, "v1", &score).unwrap();
         let retrieved = db.get_score(&hash, "v1").unwrap().unwrap();

--- a/mur-core/src/parallel/state/mod.rs
+++ b/mur-core/src/parallel/state/mod.rs
@@ -13,4 +13,7 @@ pub struct JudgeScore {
     pub reasoning: String,
     pub model: String,
     pub ts: u64,
+    /// True when cyclic judge's two rounds differed by > 2.0 on the 0-10 scale.
+    #[serde(default)]
+    pub low_confidence: bool,
 }


### PR DESCRIPTION
## Summary

- **`fleet compare`** (#554): aligned columns, `⚠` low_confidence cells (from cyclic judge round variance), tie detection per row, average summary row with overall winner. `JudgeScore` gains `low_confidence: bool` (`#[serde(default)]` — backwards compat with existing LMDB entries).
- **`fleet cherry --promote`** (#555): `--promote [--target <path>]` copies cherry-result into the live project tree. Default target resolves via `git rev-parse --git-common-dir` from the worktree. Refuses if destination has uncommitted changes.

## Test plan

- [ ] `mur fleet judge <fleet>` then `mur fleet compare <fleet>` — check aligned columns, average row, winner `✓`
- [ ] Introduce divergent scores — verify `⚠` appears on low-confidence cells
- [ ] `mur fleet cherry <fleet> --promote` — verify files copied into project root
- [ ] `mur fleet cherry <fleet> --promote --target /some/path` — verify custom target respected
- [ ] Dirty working tree → confirm refusal with clear error message
- [ ] Old LMDB entries (no `low_confidence` field) — verify `compare` works without error

Closes #554, #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)