### PR TITLE
fix(project): per-worktree codebase index + safe orphan sweep

### DIFF
--- a/mur-core/src/cmd/project.rs
+++ b/mur-core/src/cmd/project.rs
@@ -551,6 +551,9 @@ pub(crate) async fn cmd_project_index_worker(
             // auto-reindex hook on first successful index (idempotent).
             let _ = crate::codebase::ensure_git_hook(&project_path, true);
 
+            // Reclaim disk from indexes whose worktree was removed.
+            crate::codebase::prune_orphan_indexes();
+
             // Desktop notification
             send_notification(
                 &format!("mur: {} indexed", project_name),

--- a/mur-core/src/codebase/mod.rs
+++ b/mur-core/src/codebase/mod.rs
@@ -59,6 +59,12 @@ pub struct FileMeta {
 pub struct IndexMetadata {
     #[serde(default)]
     pub project_path: String,
+    /// Main repo root (== project_path for the primary worktree). Recorded so the
+    /// orphan sweep can tell "linked worktree removed" (repo present, worktree gone
+    /// → prune) from "drive unmounted / repo deleted" (repo gone → keep). Empty on
+    /// legacy metadata, which is therefore never auto-pruned.
+    #[serde(default)]
+    pub repo_root: String,
     pub files: HashMap<String, FileMeta>,
     pub last_indexed: String,
 }
@@ -487,6 +493,9 @@ impl CodebaseIndex {
 
         let mut new_meta = IndexMetadata {
             project_path: self.project_path.display().to_string(),
+            repo_root: scanner::main_repo_root(&self.project_path)
+                .map(|p| p.display().to_string())
+                .unwrap_or_default(),
             files: HashMap::new(),
             last_indexed: chrono::Utc::now().to_rfc3339(),
         };
@@ -658,7 +667,105 @@ impl CodebaseIndex {
     }
 }
 
+/// Pure decision for the orphan sweep, isolated for testing.
+///
+/// Prune iff we have both paths recorded AND the repo root still exists (drive
+/// mounted / repo present) AND the worktree path is gone. When the repo root is
+/// also missing the situation is ambiguous (unmounted external drive vs. deleted
+/// repo) so we KEEP — never delete an index just because its volume is offline.
+fn orphan_should_prune(
+    repo_root: &str,
+    project_path: &str,
+    repo_exists: bool,
+    worktree_exists: bool,
+) -> bool {
+    !repo_root.is_empty() && !project_path.is_empty() && repo_exists && !worktree_exists
+}
+
+/// Garbage-collect codebase indexes whose linked worktree was removed, reclaiming
+/// their disk. Safe on external drives (see [`orphan_should_prune`]). Skips any
+/// index whose lock is held by a live worker.
+pub fn prune_orphan_indexes() {
+    let indexes_dir = crate::paths::mur_root(None)
+        .join("indexes")
+        .join("codebase");
+    let Ok(entries) = std::fs::read_dir(&indexes_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        let Some(name) = p.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !name.ends_with(".lance") || !p.is_dir() {
+            continue;
+        }
+        let key = name.trim_end_matches(".lance");
+        let meta_path = indexes_dir.join(format!("{key}.meta.json"));
+        let Ok(data) = std::fs::read_to_string(&meta_path) else {
+            continue;
+        };
+        let Ok(meta) = serde_json::from_str::<IndexMetadata>(&data) else {
+            continue;
+        };
+        let repo_exists = Path::new(&meta.repo_root).exists();
+        let wt_exists = Path::new(&meta.project_path).exists();
+        if !orphan_should_prune(&meta.repo_root, &meta.project_path, repo_exists, wt_exists) {
+            continue;
+        }
+        // Don't yank an index out from under a live worker.
+        let lock_path = indexes_dir.join(format!("{key}.lock"));
+        if let Ok(ld) = std::fs::read_to_string(&lock_path)
+            && let Ok(lock) = serde_json::from_str::<IndexLock>(&ld)
+            && mur_common::lock_file::pid_alive(lock.pid)
+        {
+            continue;
+        }
+        let idx = CodebaseIndex::new(key, Path::new(&meta.project_path));
+        if idx.delete_index().is_ok() {
+            tracing::info!(
+                index = key,
+                "pruned orphan codebase index (worktree removed)"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod orphan_sweep_tests {
+    use super::orphan_should_prune;
+
+    #[test]
+    fn prunes_removed_worktree_but_never_on_unmount() {
+        // Linked worktree removed while the repo is still mounted → reclaim.
+        assert!(orphan_should_prune(
+            "/repo",
+            "/repo/.worktrees/x",
+            true,
+            false
+        ));
+        // External drive unmounted: the repo root is ALSO gone → ambiguous → KEEP.
+        assert!(!orphan_should_prune(
+            "/repo",
+            "/repo/.worktrees/x",
+            false,
+            false
+        ));
+        // Both present → nothing to GC.
+        assert!(!orphan_should_prune(
+            "/repo",
+            "/repo/.worktrees/x",
+            true,
+            true
+        ));
+        // Legacy metadata (no repo_root recorded) → never auto-prune.
+        assert!(!orphan_should_prune("", "/repo/.worktrees/x", true, false));
+    }
+}
+
 pub fn discover_all_indexes() -> Vec<DiscoveredIndex> {
+    // GC removed-worktree indexes before listing so callers see only live ones.
+    prune_orphan_indexes();
     let indexes_dir = crate::paths::mur_root(None)
         .join("indexes")
         .join("codebase");

--- a/mur-core/src/codebase/scanner.rs
+++ b/mur-core/src/codebase/scanner.rs
@@ -179,18 +179,62 @@ fn relative_path(root: &Path, path: &Path) -> String {
         .replace('\\', "/")
 }
 
-/// Project name = the codebase-index key (`<name>.lance`). For a git worktree
-/// this resolves to the MAIN working tree's directory name, so every
-/// worktree/branch of one repo shares a single index instead of re-indexing the
-/// whole tree per worktree. Falls back to the path's own basename when it isn't
-/// a git repo (or git is unavailable).
+/// Project name = the codebase-index key (`<name>.lance`).
+/// Index key for a path. The PRIMARY working tree keeps the bare repo basename
+/// (e.g. `mur`); each LINKED git worktree gets its own key
+/// `{repo}--{worktree_basename}-{hash8}` so divergent branches index into
+/// separate, isolated slots instead of thrashing one shared index.
 pub fn project_name_from_path(path: &Path) -> String {
-    git_main_repo_root(path)
+    let main_root = git_main_repo_root(path);
+    let wt_root = git_worktree_root(path);
+
+    let base = main_root
         .as_deref()
+        .or(wt_root.as_deref())
         .unwrap_or(path)
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "unknown".to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    match (main_root.as_deref(), wt_root.as_deref()) {
+        // Linked worktree: its own root differs from the main repo root.
+        (Some(main), Some(wt)) if main != wt => {
+            let wt_base = wt
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "wt".to_string());
+            let hash = blake3::hash(wt.to_string_lossy().as_bytes()).to_hex();
+            format!("{base}--{wt_base}-{}", &hash[..8])
+        }
+        // Primary worktree (or non-git path): unchanged, back-compatible key.
+        _ => base,
+    }
+}
+
+/// Main repo root for any path inside a git repo (incl. linked worktrees).
+/// Public so the index can record it in metadata for the orphan-sweep guard.
+pub fn main_repo_root(path: &Path) -> Option<PathBuf> {
+    git_main_repo_root(path)
+}
+
+/// This worktree's OWN top-level root (`git rev-parse --show-toplevel`).
+/// For the primary worktree this equals `git_main_repo_root`; for a linked
+/// worktree it is the worktree dir. `None` when not in a repo / git missing.
+fn git_worktree_root(path: &Path) -> Option<PathBuf> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .args(["rev-parse", "--path-format=absolute", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let top = std::str::from_utf8(&out.stdout).ok()?.trim();
+    if top.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(top))
 }
 
 /// Main working-tree root for any path inside a git repo (including linked
@@ -250,7 +294,7 @@ mod tests {
     }
 
     #[test]
-    fn worktree_shares_main_repo_name() {
+    fn linked_worktrees_get_distinct_keys() {
         use std::process::Command;
         let tmp = tempfile::tempdir().unwrap();
         let repo = tmp.path().join("myrepo");
@@ -269,12 +313,20 @@ mod tests {
         };
         git(&["init", "-q"]);
         git(&["commit", "-q", "--allow-empty", "-m", "init"]);
-        let wt = tmp.path().join("wt-foo");
-        git(&["worktree", "add", "-q", wt.to_str().unwrap()]);
+        let wt1 = tmp.path().join("wt-foo");
+        let wt2 = tmp.path().join("wt-bar");
+        git(&["worktree", "add", "-q", "-b", "b1", wt1.to_str().unwrap()]);
+        git(&["worktree", "add", "-q", "-b", "b2", wt2.to_str().unwrap()]);
 
-        // Both the main tree and the linked worktree key to the repo's name —
-        // one shared index instead of one per worktree.
-        assert_eq!(project_name_from_path(&repo), "myrepo");
-        assert_eq!(project_name_from_path(&wt), "myrepo");
+        // Option 2: primary tree keeps the bare repo name; each linked worktree
+        // gets its OWN namespaced key so divergent branches index into separate
+        // slots instead of thrashing one shared index.
+        let primary = project_name_from_path(&repo);
+        let k1 = project_name_from_path(&wt1);
+        let k2 = project_name_from_path(&wt2);
+        assert_eq!(primary, "myrepo", "primary keeps bare repo name");
+        assert!(k1.starts_with("myrepo--"), "worktree namespaced: {k1}");
+        assert_ne!(k1, primary);
+        assert_ne!(k1, k2, "distinct worktrees → distinct keys");
     }
 }


### PR DESCRIPTION
## Symptom

`mur project status` looped: indexing climbed to ~99% (`14272/14346`), then reset to `0/14495` (a **different** chunk total) and stalled — the reported "duplicate indexing".

## Root cause

`project_name_from_path` resolves **every git worktree to the main-repo basename** (via `git --git-common-dir`), so all of these collapse to project_name `mur`:

```
/Volumes/Firecuda4tb/Projects/mur                                   ← user polls status here
/Volumes/Firecuda4tb/Projects/mur/.worktrees/feat/parallel-p2.5-…   ← running worker
/Volumes/Firecuda4tb/Projects/mur/.claude/worktrees/fix+eval-…      ← wrote meta last
…+3 more
```

They share one `mur.lance` / `mur.lock` / `mur.progress.json` / `mur.meta.json`, but each `mur project index` scans its **own divergent working tree** (different file set → 14346 vs 14495 chunks). Two failures result:

1. **Progress thrash** — status from `main` reads whichever sibling worktree last wrote the shared progress file → the 99% → 0% jump.
2. **Cache poisoning** — the shared meta's `project_path` is overwritten by each tree, so cross-tree runs see "all files changed" and re-embed everything from 0 instead of reusing.

This was the intentional disk dedup ("one index per repo"), but the premise breaks because worktrees hold divergent branches, not identical content.

## Fix (Option 2 — per-worktree index + orphan sweep)

- **Per-worktree keying** (`scanner.rs`): primary tree keeps the bare repo basename; each linked worktree gets `{repo}--{worktree}-{hash8}` (blake3 of its canonical `--show-toplevel` path). Isolated, correct per-branch search.
- **Safe orphan sweep** (`mod.rs`): `IndexMetadata` records `repo_root`; an index is GC'd only when the **repo root still exists (drive mounted) but the worktree path is gone**. If the repo root is also missing (unmounted external drive vs. deleted repo → ambiguous) it is **kept** — unmounting `/Volumes/…` never nukes indexes. Legacy meta (no `repo_root`) is never auto-pruned; indexes with a live worker lock are skipped. Runs at the top of `discover_all_indexes()` and after each successful background index, so `git worktree remove` reclaims disk with no manual command.

## Tradeoff

Search from a feature-branch worktree now reflects **that branch**, at the cost of a separate index per active worktree — mitigated by the auto-sweep on worktree removal.

## Tests

- `orphan_should_prune` truth table, including the unmount-safety case.
- `linked_worktrees_get_distinct_keys` — primary bare, worktrees namespaced and mutually distinct.

`cargo test -p mur-core --lib codebase::` green (13/13); fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)