### PR TITLE
docs(review): deep code review of the v2.32.0 release

### DIFF
--- a/docs/superpowers/reviews/2026-06-30-v2.32.0-deep-review.md
+++ b/docs/superpowers/reviews/2026-06-30-v2.32.0-deep-review.md
@@ -1,0 +1,91 @@
+# Deep Code Review — mur v2.32.0
+
+- **Range:** `v2.31.1..v2.32.0` (HEAD `82529ef3`)
+- **Scope:** 70 files / ~9.5k insertions. Almost entirely the **parallel-tracks** stack (P1 orchestration, P2 ZFS backend, P3 concurrent-merge), the new privileged crate `mur-zfs-agent`, the per-worktree codebase-index fix (#560), and a DAG-executor de-flake.
+- **Method:** 10 focused subsystem reviewers → adversarial verifier per finding (2 skeptics per critical/high, 1 per lesser). 48 agents, ~1.96M tokens. **32 findings survived verification; 1 refuted.**
+
+> **TL;DR:** 31 of 32 findings live inside parallel-tracks — an **experimental, default-OFF** feature (`MUR_PARALLEL_CONCURRENT=1` / explicit fleet config), much of it still unwired `#![allow(dead_code)]` scaffolding. The only finding a real shipped user sees today is the Hub GUI unstyled buttons (medium, cosmetic). Real-world risk is low — but the items below must be fixed before parallel-tracks leaves the experimental gate.
+
+---
+
+## 🔴 High (1)
+
+### 1. Partition keys on `SemanticUnit.name`, which is NOT unique — idiomatic Rust files double-assign / drop units
+`mur-core/src/parallel/partition/planner.rs:56` + `semantic/tree_sitter_parse.rs:57-67` — **confirmed**
+
+`extract_name` returns `"Foo"` for both `struct Foo {}` and `impl Foo {}` (and every extra `impl Foo` collides). `plan_partition` buckets by bare name; `validate_coverage`'s `HashSet<&str>` bails `unit Foo assigned to more than one track` on the second `"Foo"`. → **partition mode hard-errors on any file with a struct + its impl** — i.e. essentially all idiomatic Rust, the only supported language. If validation were bypassed, `partition_to_cherry_plan`'s `HashMap<String,_>` last-writer-wins silently drops the other track's changes.
+
+- Live path: `run.rs:97-98` / `partition_cmd.rs:50-51` (both new in v2.32.0).
+- **Fix:** key the whole pipeline on `(kind, name, byte_range.start)` or `content_hash` (both already on `SemanticUnit`); add a `struct Foo {}` + `impl Foo {}` 2-track split→merge test.
+- Only mitigation: feature is experimental, needs explicit config.
+
+---
+
+## 🟠 Medium (7)
+
+| # | Location | Issue | Status |
+|---|----------|-------|--------|
+| 2 | `mur-zfs-agent/src/main.rs:97` | Privileged ZFS socket **unauthenticated**: `UnixListener::bind` sets no perms (inherits umask), `peer_addr` used only for logging, no `SO_PEERCRED`. Root daemon runs `zfs destroy -r` / `fs::copy`. Verifier correction: under default umask 022 the socket is owner-only (connect needs write perm), so this is a **defense-in-depth gap**, not default-open. Fix: `set_permissions(0o600)` + tighten umask, ideally `SO_PEERCRED`. | uncertain |
+| 3 | `mur-core/src/parallel/mod.rs:171-176` | Judge cache probes only `impls[0].content_hash` and `continue`s the whole group on hit, but `put_score` writes **per-impl** (`:203`). Read/write keys are asymmetric → other tracks never get a JudgeScore row → `mur fleet compare` shows blank scores. Fix: probe per-impl. | confirmed |
+| 4 | `mur-core/src/cmd/fleet/concurrent_cmd.rs:167-173` | `--promote` revert is **incomplete**: `promote_cherry_result` copies the entire shared `cherry-result` dir (never cleared; shared by cherry/merge), but revert only restores `written`; and `git checkout --` can't remove **newly-added** files. Bail message "reverted promoted files" is false → dirty tree. Violates the CLAUDE.md promote guarantee. Fix: `remove_dir_all` result_dir up front + revert all dest + `git clean` untracked. | confirmed |
+| 5 | `mur-core/src/cmd/fleet/concurrent_cmd.rs:160-163` | Promote's `cargo check` **omits `ORT_STRATEGY=download`** (sibling `cherry_cmd.rs:169-172` sets it). On the mur repo itself (the primary target) onnxruntime link fails → a clean, overlap-free merge gets reverted → `--promote` is effectively unusable. Fix: add `.env("ORT_STRATEGY","download")`. | confirmed |
+| 6 | `mur-core/src/cmd/fleet/cherry_cmd.rs:171` | Cherry's `cargo check --manifest-path <result_dir>/Cargo.toml` points at a manifest **never written** (only `.rs` files are). cargo always errors; the "cargo check: OK" arm is unreachable; every run prints "failed (non-fatal)". Looks like validation, validates nothing. Fix: check the real project manifest, or delete the misleading check. | confirmed |
+| 7 | `scripts/eval/agentdojo/run.py:89-96` | Real-LLM path **discards `utility_ok`**, decides on `security_ok` alone. A broken/empty backend never runs the injection task → `security_ok` is trivially True → 50/50 cases PASS = "100% injection-resistant" (**false green**). Fail-safe only catches exceptions; silent no-op slips through. Fix: record utility, fail/warn when utility≈0 across all cases. | uncertain |
+| 8 | `mur-hub-gui/ui/src/components/DashboardApp.tsx:248,319` | New `.grid-card__settings` / `.list-row__settings` buttons have **no CSS rule anywhere** — only `base.css:15`'s global reset (no `appearance:none`) → render as native WebKit grey rounded buttons, a visible regression vs the prior brand-colored link. Old `.grid-card__open`/`.list-row__open` rules now dead. **The only user-visible finding today.** | confirmed |
+
+---
+
+## 🟡 Low (11)
+
+- **9.** `mur-zfs-agent/src/main.rs:42-47` — dataset/snapshot/label names have no charset / leading-`-` validation → `zfs diff` arg injection (argv not shell; low exploitability — `zfs diff` has no destructive flags). Fix: allowlist `^[A-Za-z0-9_.:-]{1,64}$` + reject leading dash.
+- **10.** `parallel/backend/zfs_socket.rs:27-38` — `call()` does `read_line()` with **no timeout**; a hung agent wedges the whole parallel run. Fix: `set_read_timeout`/`set_write_timeout`.
+- **11.** `parallel/backend/zfs_native.rs:128` — `promote()` only acts on `src.is_file()`, so it **silently drops deletions and renames** (`split_once('\t')` mishandles `R\told\tnew`). Currently dead-code path.
+- **12.** `parallel/backend/git_worktree.rs:21-23` — `take_local_snapshot()` comment says "before first track" but it runs **per-track** (`tmutil localsnapshot` N times); and it's only on the git backend, not the ZFS one that does destructive promote.
+- **13.** `parallel/backend/detect.rs:18-46` — native-ZFS + OrbStack + Lima + WSL2 detection + two backends (~600 lines) with **no non-test caller** (`create_tracks` is only called from tests). Spike-1 itself says worktree-execution is "decoupled + deferred" → speculative breadth. Land it with the PR that wires a live caller.
+- **14.** `parallel/concurrent/stats.rs:33-58` — `count_groups` **re-runs the entire merge pipeline** just to get overlap counts `merge()` already computed; the `_merger` param is never used. Two independent code paths compute the figure that gates the Loro STOP/GO decision → drift hazard. Fix: have `merge()` also return the clean-group count; delete `count_groups`.
+- **15.** `parallel/concurrent/stats.rs:43` — `from_utf8(..).unwrap_or_default()` (while `merge()` hard-errors) → a non-UTF8 version is silently treated as empty, counted as one clean group, **biasing overlap_rate toward 0** — the exact direction that would wrongly justify STOP-on-Loro. Latent today (caller `merge()?` first). Fix: propagate via `?`.
+- **16.** `parallel/concurrent/mod.rs:60-62` — `MergeOutcome::summary()` has no production caller and `.filter(|s| !s.is_empty())` drops **every blank line** → undercounts clean lines. Fix: delete it.
+- **17.** `parallel/track/worktree.rs:14-21` — `create_tracks` **leaks already-created worktrees** when track N fails (`destroy_tracks` exists right below but isn't called), and same-name retry hits "already exists" and wedges. No live caller yet. Fix: best-effort destroy on the error path.
+- **18.** `mur-core/src/cmd/fleet/run.rs:33` — partition `target_file` read via `fs::read` (relative to CWD), but `partition_cmd.rs:42-43` resolves it against `cwd_git_root()`. Running `mur fleet run` from a subdir reads the wrong file. Fix: resolve against git toplevel in both.
+- **19.** `mur-core/src/codebase/mod.rs:711-713` — orphan sweep infers "worktree removed" from path existence: repo on internal disk + worktree on an **ejected external volume** → mistaken for an orphan and swept → full re-index on remount. Defeats its own "never delete an index just because its volume is offline" invariant (only holds because `.worktrees/` is normally co-resident). Fix: ask `git worktree list --porcelain` (mount-agnostic).
+
+---
+
+## ⚪ Nit (13)
+
+`zfs_promote()` dead (`main.rs` uses `fs::copy`) · `zfs_diff`/`zfs_diff_ref` duplicate · concurrent order-independence asserted for merged bytes but not for `overlaps` · `prompt.rs:18-19` end-line off-by-one · `PartitionPlan::owner_of` dead · `partition_cmd.rs:1` blanket `#![allow(dead_code, unused_imports)]` masks a real unused import (`RegionAssignment`) · `compare.rs:194` `truncate` uses `&s[..max]` (panics on multibyte; ASCII idents only today) · `scanner.rs:216` `main_repo_root` is a redundant re-export of `git_main_repo_root` · `dag.rs:1344` `unbounded_peak >= 3` is still a timing assertion (the comment's "deterministic" claim holds only for the `<= 2` upper bound) · `harmbench/run.py:127` `_call_openai` has no `api_key` None guard (AgentDojo has one) · `eval.yml:179-193` backend-selection bash duplicated across two steps (InjecAgent hardcodes anthropic) · `en.ts:25-26`/`zh-TW.ts:27-28` `dashboard.style` keys now dead · grid vs list settings buttons toggle inconsistently (`setSelected(name)` vs `setSelected(isSelected ? null : name)`).
+
+---
+
+## ✅ Refuted (1, for transparency)
+
+**zfs-agent Promote: absolute diff path escapes target via `Path::join` → arbitrary root-file overwrite** — refuted. The reviewer missed that the same `rel` is used for `src = track.join(rel)`; in the strip_prefix-fails branch `rel` is absolute, so **both** joins discard their base → `src == dst` → `fs::copy` is a self-copy (no-op). The real capability (copy clone files to an attacker-chosen `target`) is a property of the unauthenticated root socket (which also exposes `zfs destroy -r`), not the path-escape this finding described.
+
+---
+
+## What looked solid
+
+- **concurrent-merge core is correct** for the line model: right hunk boundaries, `overlap()` + sorted-by-`(start,end)` clustering catches transitive / replacement-vs-insertion overlaps without missing any, divergent overlaps are **always escalated (base preserved, never silently interleaved)**, merged bytes are provably order-independent. Crown jewel holds.
+- **fleet-cli gate is fail-closed** (`MUR_PARALLEL_CONCURRENT != "1"` bails, unit-tested); `--promote` refuses before copying when `any_overlap` is set.
+- **codebase-index per-worktree keying is collision-free**; sweep KEEPS legacy/ambiguous cases; deletes the right slot (#560 done right).
+- **DAG executor** uses one run-wide semaphore, permit held for the whole step → truly bounds peak; test now measures the real invariant via filesystem markers instead of a flaky wall-clock ratio.
+- COW path is genuine copy-on-write (APFS `cp -cR` / Linux `--reflink=always`); LMDB `low_confidence` is `#[serde(default)]` (back-compat); wire layer answers bad JSON with Error (no panic); all subprocess calls are argv (no shell injection).
+
+---
+
+## Recommended priority
+
+1. **Must-fix before parallel-tracks leaves experimental:** #1 (partition name key — guaranteed failure), #4/#5/#6 (`--promote`/`cherry` validation & revert guarantees are currently broken or fake).
+2. **Quick wins (a few lines, real impact — do now):** #8 (Hub CSS, only user-visible), #5 (one-line `ORT_STRATEGY`), #7 (eval false-green), delete dead code #13/#16/#20/#24.
+3. **Handle when wiring the ZFS live path:** #2 (socket perms + `SO_PEERCRED`), #10 (timeout), #11/#17 (promote drops deletions; partial-failure leak).
+
+---
+
+## ⚠️ Overlap with the in-flight Tier 1 worktree-execution work
+
+These findings sit **directly in the surface Tier 1 is building on** — hand this doc to that session so the same bugs aren't reintroduced:
+
+- **#17** `create_tracks` leaks worktrees on partial failure — *this is the Tier 1 worktree-execution code.*
+- **#13** `detect.rs` four-backend detection has no live caller — Tier 1 is presumably wiring that caller.
+- **#11** `zfs_native::promote()` drops deletions/renames.
+- **#2 / #9 / #10** zfs-agent socket perms / arg validation / timeout — relevant once the ZFS socket backend is wired.


### PR DESCRIPTION
Multi-agent deep code review of **v2.32.0** (`v2.31.1..v2.32.0`), adversarially verified — every surviving finding was put through an independent skeptic before landing. Full report in `docs/superpowers/reviews/2026-06-30-v2.32.0-deep-review.md`.

**Scope:** the parallel-tracks stack (P1 orchestration / P2 ZFS backend / P3 concurrent-merge), the new privileged `mur-zfs-agent` crate, the per-worktree codebase-index fix (#560), and the DAG-executor de-flake.

**Result:** 32 findings survived (1 High · 7 Medium · 11 Low · 13 Nit); 1 refuted. 31/32 sit inside the experimental, default-OFF parallel-tracks feature, so live-user risk is low — but several must be fixed before it leaves the experimental gate.

**Must-fix before parallel-tracks leaves experimental**
- **#1 (High)** partition keys on non-unique `SemanticUnit.name` → idiomatic Rust (`struct Foo` + `impl Foo`) hard-errors / silent-drops.
- **#4/#5/#6 (Medium)** `--promote`/`cherry` validation & revert guarantees are currently broken or fake (incomplete revert, missing `ORT_STRATEGY`, `cargo check` against a manifest never written).

**Quick wins**
- **#8** Hub dashboard settings buttons have no CSS (only user-visible finding).
- **#7** AgentDojo real-LLM eval discards `utility_ok` → a broken backend scores "100% injection-resistant" (false green).

**⚠️ Overlaps the in-flight Tier 1 worktree-execution work** — findings **#17** (`create_tracks` leaks worktrees on partial failure), **#13** (`detect.rs` four-backend detection has no live caller), **#11** (`zfs_native::promote()` drops deletions/renames), and **#2/#9/#10** (zfs-agent socket perms / arg validation / timeout) sit directly in that surface. Hand this doc to that session so the same bugs aren't reintroduced.

This PR adds documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)