### PR TITLE
feat(hub): passive CLI/Hub version-skew nudge

### DIFF
--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.30.0"
+version = "2.32.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6619,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.30.0"
+version = "2.32.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.30.0"
+version = "2.32.0"
 dependencies = [
  "blake3",
  "flate2",
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.30.0"
+version = "2.32.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6769,7 +6769,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.30.0"
+version = "2.32.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mur-hub-gui/src-tauri/src/cli_tools.rs
+++ b/mur-hub-gui/src-tauri/src/cli_tools.rs
@@ -1,6 +1,9 @@
-//! "Install command-line tools" — symlink the bundled `mur` into a PATH dir.
+//! "Install command-line tools" — symlink the bundled `mur` into a PATH dir,
+//! plus a passive version-skew check (nudge only; the Hub never auto-upgrades
+//! the CLI — that would clobber a brew-managed binary with a symlink).
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 /// Preferred PATH install dir: /opt/homebrew/bin if writable, else ~/.local/bin.
 pub fn install_dir(homebrew_writable: bool, home: &Path) -> PathBuf {
@@ -40,6 +43,53 @@ pub fn install_cli_tools() -> Result<String, String> {
     Ok(dst.display().to_string())
 }
 
+/// The PATH `mur` the user would invoke in a terminal. GUI apps don't inherit
+/// the shell PATH, so we probe the canonical install locations directly (the
+/// same two `install_cli_tools` targets, which also cover brew + build.sh).
+fn path_mur(home: &Path) -> Option<PathBuf> {
+    [
+        PathBuf::from("/opt/homebrew/bin/mur"),
+        home.join(".local/bin/mur"),
+    ]
+    .into_iter()
+    .find(|p| p.exists())
+}
+
+/// `mur --version` → "mur X.Y.Z" → "X.Y.Z".
+fn read_cli_version(mur: &Path) -> Option<String> {
+    let out = Command::new(mur).arg("--version").output().ok()?;
+    let s = String::from_utf8_lossy(&out.stdout);
+    s.split_whitespace().nth(1).map(str::to_string)
+}
+
+/// True when semver `a` is strictly older than `b`. Naive numeric X.Y.Z
+/// compare — MUR versions have no pre-release tags.
+// ponytail: numeric tuple compare, swap in a semver crate only if tags appear.
+fn is_older(a: &str, b: &str) -> bool {
+    fn parts(v: &str) -> Vec<u64> {
+        v.split('.').map(|n| n.parse().unwrap_or(0)).collect()
+    }
+    parts(a) < parts(b)
+}
+
+#[derive(serde::Serialize)]
+pub struct CliSkew {
+    pub cli: String,
+    pub hub: String,
+}
+
+/// Report a version skew only when the PATH `mur` is OLDER than this Hub, so
+/// the UI can nudge the user to `brew upgrade mur`. Returns None when in sync,
+/// newer, missing, or a Hub-managed symlink (which reports the bundled version
+/// == the Hub version and so never skews). Read-only: never touches the CLI.
+#[tauri::command]
+pub fn cli_version_skew(app: tauri::AppHandle) -> Option<CliSkew> {
+    let home = dirs::home_dir()?;
+    let cli = read_cli_version(&path_mur(&home)?)?;
+    let hub = app.package_info().version.to_string();
+    is_older(&cli, &hub).then_some(CliSkew { cli, hub })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -67,5 +117,13 @@ mod tests {
             bundled_mur_path(exe).unwrap(),
             PathBuf::from("/Applications/MUR Hub.app/Contents/MacOS/mur")
         );
+    }
+
+    #[test]
+    fn skew_only_when_cli_is_older() {
+        assert!(is_older("2.31.1", "2.32.0")); // CLI lagging → nudge
+        assert!(is_older("2.31.1", "2.31.2"));
+        assert!(!is_older("2.32.0", "2.32.0")); // in sync → no nudge
+        assert!(!is_older("2.33.0", "2.32.0")); // CLI ahead → no nudge
     }
 }

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -582,6 +582,7 @@ pub fn run() {
             companion::companion_proactive,
             companion::companion_quiet,
             cli_tools::install_cli_tools,
+            cli_tools::cli_version_skew,
             brain_badge::nudge_status,
             brain_badge::nudge_dismiss,
             detail::get_agent_detail,

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -412,6 +412,9 @@ export function DashboardApp() {
   const [showAppsBanner, setShowAppsBanner] = useState(false);
   const [showUpgradeNudge, setShowUpgradeNudge] = useState(false);
   const [nudgeDismissed, setNudgeDismissed] = useState(false);
+  // Passive nudge when the PATH `mur` CLI lags this Hub. The Hub never
+  // auto-upgrades it (that would clobber a brew binary) — just surface it.
+  const [cliSkew, setCliSkew] = useState<{ cli: string; hub: string } | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
   // App auto-update. Detect on mount, but never download silently: a Hub update
@@ -603,6 +606,13 @@ export function DashboardApp() {
       .catch(() => {});
   }, []);
 
+  // Surface a CLI/Hub version skew on mount (None unless `mur` lags the Hub).
+  useEffect(() => {
+    invoke<{ cli: string; hub: string } | null>("cli_version_skew")
+      .then((s) => setCliSkew(s))
+      .catch(() => {});
+  }, []);
+
 
 
   // ⌘K focus search.
@@ -705,6 +715,20 @@ export function DashboardApp() {
                 </button>
               </div>
             )}
+          </div>
+        )}
+        {cliSkew && (
+          <div className="upgrade-nudge-banner">
+            <span>
+              {t("dashboard.cliSkew", { cli: cliSkew.cli, hub: cliSkew.hub })}
+            </span>
+            <button
+              className="toolbar-btn"
+              onClick={() => setCliSkew(null)}
+              title={t("dashboard.dismiss")}
+            >
+              ✕
+            </button>
           </div>
         )}
 

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -38,6 +38,8 @@ export const en = {
   "dashboard.updateDownloading": "Downloading MUR Hub {version}… {pct}%",
   "dashboard.updateError": "Update failed: {error}",
   "dashboard.updateRetry": "Retry",
+  "dashboard.cliSkew":
+    "Command-line tools are v{cli}, but MUR Hub is v{hub}. Run `brew upgrade mur` to update them.",
   "dashboard.stat.running": "Flying",
   "dashboard.stat.idle": "Resting",
   "dashboard.col.agent": "Agent",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -40,6 +40,8 @@ export const zhTW: Table = {
   "dashboard.updateDownloading": "正在下載 MUR Hub {version}… {pct}%",
   "dashboard.updateError": "更新失敗：{error}",
   "dashboard.updateRetry": "重試",
+  "dashboard.cliSkew":
+    "命令列工具是 v{cli}，但 MUR Hub 是 v{hub}。執行 `brew upgrade mur` 來更新。",
   "dashboard.stat.running": "飛行中",
   "dashboard.stat.idle": "休息中",
   "dashboard.col.agent": "Agent",


### PR DESCRIPTION
## What

When the MUR Hub auto-updates, it swaps **only** the `.app` bundle. The `mur` CLI on PATH (installed via Homebrew or `build.sh --install`) is upgraded **separately** with `brew upgrade mur`. When the two drift, nothing told the user.

This adds a **passive, dismissible banner**: on mount the Hub reads the PATH `mur --version`, compares it to its own version, and — only when the CLI is **older** — shows a one-line nudge to run `brew upgrade mur`.

Deliberately **not** auto-upgrading: the existing `install_cli_tools` symlinks the bundled `mur` over the PATH location, which would clobber a brew-managed binary and break `brew upgrade`. A nudge respects whatever install method the user chose.

## How

- **`cli_tools::cli_version_skew`** (new `#[tauri::command]`, read-only): probes the canonical install locations (`/opt/homebrew/bin/mur`, `~/.local/bin/mur` — GUI apps don't inherit the shell PATH), parses `mur --version`, and returns `Some {cli, hub}` **only** when the CLI is strictly older than the Hub. In-sync / newer / missing / Hub-managed-symlink (which reports the bundled version == Hub version) → `None`, no banner.
- **`DashboardApp.tsx`**: invokes it once on mount, renders a dismiss-only banner reusing the existing `upgrade-nudge-banner` style. No action button that mutates PATH.
- **i18n**: `dashboard.cliSkew` in `en` + `zh-TW`.

## Test

`cli_tools::tests::skew_only_when_cli_is_older` covers the semver compare (older → nudge; equal/newer → none). `npm run build` (tsc + vite) and `cargo test -p` (4/4 cli_tools tests) both green.

## Notes / scope

- Build-time, Hub and brew CLI ship from the same release tag; this only covers the runtime drift between them.
- `ponytail:` numeric X.Y.Z compare (no semver crate — MUR versions carry no pre-release tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)