### PR TITLE
feat(hub): cross-tab search, detail button fix, smart upgrade hint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-latest, windows-latest]
+        # macOS pinned to 14 (Apple Silicon): the macos-latest → macOS-26 image
+        # migration breaks the system-configuration-sys / lance build scripts
+        # ("cannot execute binary file", exit 126). The Test job pins macos-14
+        # for stability for the same reason.
+        os: [ubuntu-22.04, macos-14, windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.32.0"
+version = "2.34.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6619,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.32.0"
+version = "2.34.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.32.0"
+version = "2.34.0"
 dependencies = [
  "blake3",
  "flate2",
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.32.0"
+version = "2.34.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6769,7 +6769,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.32.0"
+version = "2.34.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mur-hub-gui/src-tauri/src/cli_tools.rs
+++ b/mur-hub-gui/src-tauri/src/cli_tools.rs
@@ -144,17 +144,19 @@ mod tests {
 
     #[test]
     fn upgrade_hint_by_install_source() {
+        // A binary under the Homebrew prefix is brew-managed even when the
+        // symlink can't be resolved (this test path doesn't exist on disk).
         assert_eq!(
             upgrade_hint_for(Path::new("/opt/homebrew/bin/mur")),
-            // symlink resolves to self (no real Cellar in tests) → falls through
-            "mur update"
+            "brew upgrade mur"
         );
         // Homebrew Cellar path (what the symlink resolves to)
-        assert!(upgrade_hint_for(Path::new("/opt/homebrew/Cellar/mur/2.34.0/bin/mur"))
-            .contains("brew upgrade mur"));
+        assert!(
+            upgrade_hint_for(Path::new("/opt/homebrew/Cellar/mur/2.34.0/bin/mur"))
+                .contains("brew upgrade mur")
+        );
         // Cargo
-        assert!(upgrade_hint_for(Path::new("/Users/x/.cargo/bin/mur"))
-            .contains("cargo install"));
+        assert!(upgrade_hint_for(Path::new("/Users/x/.cargo/bin/mur")).contains("cargo install"));
         // Manual / unknown
         assert_eq!(
             upgrade_hint_for(Path::new("/usr/local/bin/mur")),

--- a/mur-hub-gui/src-tauri/src/cli_tools.rs
+++ b/mur-hub-gui/src-tauri/src/cli_tools.rs
@@ -76,18 +76,41 @@ fn is_older(a: &str, b: &str) -> bool {
 pub struct CliSkew {
     pub cli: String,
     pub hub: String,
+    pub upgrade_hint: String,
 }
 
-/// Report a version skew only when the PATH `mur` is OLDER than this Hub, so
-/// the UI can nudge the user to `brew upgrade mur`. Returns None when in sync,
-/// newer, missing, or a Hub-managed symlink (which reports the bundled version
-/// == the Hub version and so never skews). Read-only: never touches the CLI.
+/// Resolve the real path of `p` (following one symlink level), returning the
+/// canonicalized path or the original if resolution fails.
+fn resolve_symlink(p: &Path) -> PathBuf {
+    std::fs::read_link(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Derive the appropriate upgrade command by inspecting where the binary lives.
+fn upgrade_hint_for(mur: &Path) -> String {
+    let real = resolve_symlink(mur);
+    let s = real.to_string_lossy();
+    if s.contains("/Cellar/") || s.contains("/homebrew/") && s.contains("/bin/mur") {
+        "brew upgrade mur".to_string()
+    } else if s.contains("/.cargo/") {
+        "cargo install mur --force".to_string()
+    } else {
+        "mur update".to_string()
+    }
+}
+
+/// Report a version skew only when the PATH `mur` is OLDER than this Hub.
+/// Returns None when in sync, newer, missing, or a Hub-managed symlink.
 #[tauri::command]
 pub fn cli_version_skew(app: tauri::AppHandle) -> Option<CliSkew> {
     let home = dirs::home_dir()?;
-    let cli = read_cli_version(&path_mur(&home)?)?;
+    let mur_path = path_mur(&home)?;
+    let cli = read_cli_version(&mur_path)?;
     let hub = app.package_info().version.to_string();
-    is_older(&cli, &hub).then_some(CliSkew { cli, hub })
+    is_older(&cli, &hub).then_some(CliSkew {
+        upgrade_hint: upgrade_hint_for(&mur_path),
+        cli,
+        hub,
+    })
 }
 
 #[cfg(test)]
@@ -116,6 +139,26 @@ mod tests {
         assert_eq!(
             bundled_mur_path(exe).unwrap(),
             PathBuf::from("/Applications/MUR Hub.app/Contents/MacOS/mur")
+        );
+    }
+
+    #[test]
+    fn upgrade_hint_by_install_source() {
+        assert_eq!(
+            upgrade_hint_for(Path::new("/opt/homebrew/bin/mur")),
+            // symlink resolves to self (no real Cellar in tests) → falls through
+            "mur update"
+        );
+        // Homebrew Cellar path (what the symlink resolves to)
+        assert!(upgrade_hint_for(Path::new("/opt/homebrew/Cellar/mur/2.34.0/bin/mur"))
+            .contains("brew upgrade mur"));
+        // Cargo
+        assert!(upgrade_hint_for(Path::new("/Users/x/.cargo/bin/mur"))
+            .contains("cargo install"));
+        // Manual / unknown
+        assert_eq!(
+            upgrade_hint_for(Path::new("/usr/local/bin/mur")),
+            "mur update"
         );
     }
 

--- a/mur-hub-gui/ui/src/components/ChatsView.tsx
+++ b/mur-hub-gui/ui/src/components/ChatsView.tsx
@@ -7,6 +7,7 @@ import { useT } from "../i18n";
 
 interface Props {
   agents: AgentEntry[];
+  query?: string;
 }
 
 /**
@@ -15,7 +16,7 @@ interface Props {
  * continue in place). This is where 1:1 chats live now that Activity is scoped
  * to multi-agent runs.
  */
-export function ChatsView({ agents }: Props) {
+export function ChatsView({ agents, query }: Props) {
   const { t } = useT();
   const [selected, setSelected] = useState<string | null>(agents[0]?.name ?? null);
 
@@ -23,12 +24,16 @@ export function ChatsView({ agents }: Props) {
     return <div className="chats-view__empty">{t("chats.empty")}</div>;
   }
 
-  const entry = agents.find((a) => a.name === selected) ?? agents[0];
+  const q = query?.toLowerCase() ?? "";
+  const filtered = q
+    ? agents.filter((a) => a.name.toLowerCase().includes(q) || a.display_name.toLowerCase().includes(q))
+    : agents;
+  const entry = filtered.find((a) => a.name === selected) ?? filtered[0];
 
   return (
     <div className="chats-view">
       <nav className="chats-view__list">
-        {agents.map((a) => {
+        {filtered.map((a) => {
           const preset = avatarPreset(a);
           return (
             <button

--- a/mur-hub-gui/ui/src/components/DashboardApp.tsx
+++ b/mur-hub-gui/ui/src/components/DashboardApp.tsx
@@ -247,11 +247,11 @@ export function GridCard({ agent, runtime, isSelected }: GridCardProps) {
           <button
             className="grid-card__settings"
             onClick={(e) => { e.stopPropagation(); setSelected(agent.name); }}
-            title={t("dashboard.settings")}
-            aria-label={t("dashboard.settings")}
+            title={t("dashboard.detail")}
+            aria-label={t("dashboard.detail")}
           >
             <Ico>
-              <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+              <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
               <circle cx="12" cy="12" r="3" />
             </Ico>
           </button>
@@ -414,7 +414,7 @@ export function DashboardApp() {
   const [nudgeDismissed, setNudgeDismissed] = useState(false);
   // Passive nudge when the PATH `mur` CLI lags this Hub. The Hub never
   // auto-upgrades it (that would clobber a brew binary) — just surface it.
-  const [cliSkew, setCliSkew] = useState<{ cli: string; hub: string } | null>(null);
+  const [cliSkew, setCliSkew] = useState<{ cli: string; hub: string; upgrade_hint: string } | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
   // App auto-update. Detect on mount, but never download silently: a Hub update
@@ -608,7 +608,7 @@ export function DashboardApp() {
 
   // Surface a CLI/Hub version skew on mount (None unless `mur` lags the Hub).
   useEffect(() => {
-    invoke<{ cli: string; hub: string } | null>("cli_version_skew")
+    invoke<{ cli: string; hub: string; upgrade_hint: string } | null>("cli_version_skew")
       .then((s) => setCliSkew(s))
       .catch(() => {});
   }, []);
@@ -720,7 +720,7 @@ export function DashboardApp() {
         {cliSkew && (
           <div className="upgrade-nudge-banner">
             <span>
-              {t("dashboard.cliSkew", { cli: cliSkew.cli, hub: cliSkew.hub })}
+              {t("dashboard.cliSkew", { cli: cliSkew.cli, hub: cliSkew.hub, hint: cliSkew.upgrade_hint })}
             </span>
             <button
               className="toolbar-btn"
@@ -818,11 +818,11 @@ export function DashboardApp() {
         </div>
 
         {surface === "fleet" ? (
-          <FleetView />
+          <FleetView query={query} />
         ) : surface === "work" ? (
-          <WorkView agents={agents} />
+          <WorkView agents={agents} query={query} />
         ) : surface === "chats" ? (
-          <ChatsView agents={agents} />
+          <ChatsView agents={agents} query={query} />
         ) : (
           <div className="agents-view">
             <Sidebar activeRole={activeRole} agents={agents} onSelect={setActiveRole} />

--- a/mur-hub-gui/ui/src/components/fleet/FleetView.tsx
+++ b/mur-hub-gui/ui/src/components/fleet/FleetView.tsx
@@ -17,7 +17,7 @@ function showToast(msg: string, durationMs = 2500) {
   setTimeout(() => el.remove(), durationMs);
 }
 
-export function FleetView() {
+export function FleetView({ query }: { query?: string }) {
   const { t } = useT();
   const [fleets, setFleets] = useState<FleetSummary[]>([]);
   const [selectedName, setSelectedName] = useState<string | null>(null);
@@ -114,7 +114,10 @@ export function FleetView() {
   return (
     <div className="fleet-view">
       <FleetRail
-        fleets={fleets}
+        fleets={query ? fleets.filter((f) => {
+          const q = query.toLowerCase();
+          return f.name.toLowerCase().includes(q) || f.display_name.toLowerCase().includes(q) || f.goal.toLowerCase().includes(q);
+        }) : fleets}
         selectedName={selectedName}
         onSelect={handleSelect}
         onNew={() => setShowCreate(true)}

--- a/mur-hub-gui/ui/src/components/work/WorkView.tsx
+++ b/mur-hub-gui/ui/src/components/work/WorkView.tsx
@@ -10,6 +10,7 @@ import { WorkTrace } from "./WorkTrace";
 
 interface Props {
   agents: AgentEntry[];
+  query?: string;
 }
 
 /**
@@ -25,7 +26,7 @@ function isActivityChannel(ch: ChannelSummary): boolean {
   );
 }
 
-export function WorkView({ agents }: Props) {
+export function WorkView({ agents, query }: Props) {
   const [channels, setChannels] = useState<ChannelSummary[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [events, setEvents] = useState<ChannelEvent[]>([]);
@@ -102,7 +103,11 @@ export function WorkView({ agents }: Props) {
     <div className="work-view">
       <div className="work-view__rail">
         <WorkChannelList
-          channels={channels.filter(isActivityChannel)}
+          channels={channels.filter(isActivityChannel).filter((ch) => {
+            if (!query) return true;
+            const q = query.toLowerCase();
+            return ch.title.toLowerCase().includes(q) || ch.goal.toLowerCase().includes(q);
+          })}
           selectedId={selectedId}
           nowMs={nowMs}
           onSelect={setSelectedId}

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -18,6 +18,7 @@ export const en = {
   "dashboard.stop": "Stop",
   "dashboard.share": "Share",
   "dashboard.settings": "Settings",
+  "dashboard.detail": "Details",
   "dashboard.runTooltip": "Start agent runtime",
   "dashboard.startFailed": "Couldn’t start: {error}",
   "dashboard.stopFailed": "Couldn’t stop: {error}",
@@ -39,7 +40,7 @@ export const en = {
   "dashboard.updateError": "Update failed: {error}",
   "dashboard.updateRetry": "Retry",
   "dashboard.cliSkew":
-    "Command-line tools are v{cli}, but MUR Hub is v{hub}. Run `brew upgrade mur` to update them.",
+    "Command-line tools are v{cli}, but MUR Hub is v{hub}. Run `{hint}` to update them.",
   "dashboard.stat.running": "Flying",
   "dashboard.stat.idle": "Resting",
   "dashboard.col.agent": "Agent",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -20,6 +20,7 @@ export const zhTW: Table = {
   "dashboard.stop": "停止",
   "dashboard.share": "分享",
   "dashboard.settings": "設定",
+  "dashboard.detail": "詳細",
   "dashboard.runTooltip": "啟動 agent runtime",
   "dashboard.startFailed": "啟動失敗：{error}",
   "dashboard.stopFailed": "停止失敗：{error}",
@@ -41,7 +42,7 @@ export const zhTW: Table = {
   "dashboard.updateError": "更新失敗：{error}",
   "dashboard.updateRetry": "重試",
   "dashboard.cliSkew":
-    "命令列工具是 v{cli}，但 MUR Hub 是 v{hub}。執行 `brew upgrade mur` 來更新。",
+    "命令列工具是 v{cli}，但 MUR Hub 是 v{hub}。執行 `{hint}` 來更新。",
   "dashboard.stat.running": "飛行中",
   "dashboard.stat.idle": "休息中",
   "dashboard.col.agent": "Agent",

--- a/mur-hub-gui/ui/src/styles/components/dashboard.css
+++ b/mur-hub-gui/ui/src/styles/components/dashboard.css
@@ -379,6 +379,24 @@
   padding-top: 13px;
   border-top: 1px solid var(--border-line);
 }
+.grid-card__settings {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border-line);
+  border-radius: 7px;
+  background: var(--surface-card);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--dur-fast), color var(--dur-fast);
+}
+.grid-card__settings:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
 .grid-card__open {
   font-size: var(--text-sm);
   font-weight: var(--fw-bold);


### PR DESCRIPTION
## Summary

- **Cross-tab search**: The search bar now filters all tabs — Chats (by agent name), Activities (by title/goal), and Fleets (by name/goal). Previously only the Agents tab was filtered.
- **Detail button fix**: `grid-card__settings` had no CSS; WebKit dark theme was rendering it as a native gray pill. Added proper icon-button styles, switched the icon to an eye (matches "view details" intent), and corrected the label/aria from "Settings" to "Details".
- **Smart upgrade hint**: `CliSkew` now includes an `upgrade_hint` field derived by inspecting the real binary path — suggests `brew upgrade mur`, `cargo install mur --force`, or `mur update` instead of hardcoding brew.

## Test plan

- [ ] Search "david" in Agents tab → filters agent cards
- [ ] Switch to Chats tab, type a name → only matching agents appear in rail
- [ ] Switch to Activities tab, type a keyword → channels filter by title/goal
- [ ] Switch to Fleets tab, type a fleet name → only matching fleets appear in rail
- [ ] Clear search → all items reappear in each tab
- [ ] Hover the eye icon on any agent card → tooltip reads "詳細"/"Details"
- [ ] Click eye icon → Detail panel slides in
- [ ] Trigger CLI skew on a cargo-installed `mur` → hint says `cargo install mur --force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)