### PR TITLE
fix(agent-cli): stop kitty keyboard protocol leaking into shell on quit

### DIFF
--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -28,6 +28,7 @@ mod welcome;
 
 use std::io::{self, BufRead, IsTerminal, Stdout};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use std::time::Instant as StdInstant;
 
@@ -167,17 +168,31 @@ pub async fn cmd_cli(
 /// macOS Terminal.app) — silently skip there; Alt/Option+Enter remains a
 /// universal fallback for the newline binding since legacy terminals already
 /// report Alt via an ESC prefix with no protocol opt-in required.
+// Remembers whether the push below actually enabled the protocol, so pop
+// never re-queries the terminal (see `pop_keyboard_enhancement`).
+static KB_ENHANCEMENT_ACTIVE: AtomicBool = AtomicBool::new(false);
+
 fn push_keyboard_enhancement() {
-    if matches!(supports_keyboard_enhancement(), Ok(true)) {
-        let _ = execute!(
+    if matches!(supports_keyboard_enhancement(), Ok(true))
+        && execute!(
             io::stdout(),
             PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
-        );
+        )
+        .is_ok()
+    {
+        KB_ENHANCEMENT_ACTIVE.store(true, Ordering::Relaxed);
     }
 }
 
+// Deliberately does NOT call `supports_keyboard_enhancement()` again: that
+// sends a second terminal query-and-wait (up to crossterm's 2s timeout) at
+// shutdown. If the reply arrives after we've already disabled raw mode /
+// left the alternate screen, nothing reads it — the raw escape bytes fall
+// through to the shell's cooked-mode stdin and get echoed as garbage
+// (e.g. `^[[?1u^[[?62;22;52c`). We already know from the push above
+// whether the protocol is active, so just use that.
 fn pop_keyboard_enhancement() {
-    if matches!(supports_keyboard_enhancement(), Ok(true)) {
+    if KB_ENHANCEMENT_ACTIVE.swap(false, Ordering::Relaxed) {
         let _ = execute!(io::stdout(), PopKeyboardEnhancementFlags);
     }
 }


### PR DESCRIPTION
## Summary
- `pop_keyboard_enhancement()` re-queried the terminal (`supports_keyboard_enhancement`, a fresh write-and-wait-up-to-2s round trip) on every TUI exit instead of remembering whether the earlier startup push had activated the protocol
- If that reply arrived after raw mode was already disabled and the alt screen left, nothing read it — the raw escape bytes fell through to the shell's cooked-mode stdin and got echoed as garbage right after quitting `murmur` (e.g. `^[[?1u^[[?62;22;52c`)
- Fix: track push success in a static `AtomicBool` so pop never re-queries the terminal — eliminates the redundant, racy round trip entirely

## Root cause (systematic-debugging)
Byte-level capture in tmux confirmed it: the leaked flags value (`?1u`, flags=1) is only possible *after* a push is already active, proving the leak came from the shutdown-time re-query, not the startup one. Cross-checked against crossterm 0.28.1's actual `supports_keyboard_enhancement` source (docs.rs) — it does drain its own trailing DA1 reply within one call, so the bug is specifically the *second*, unnecessary call at teardown, not a partial-drain issue.

## Test plan
- [x] `cargo check -p mur-core` / `cargo clippy -p mur-core -- -D warnings` clean
- [x] Live-verified in tmux with raw pty byte capture:
  - Old binary: query sent 2× (once at startup, once at shutdown); `1;2;4c` leaked onto the shell prompt ~2s after quit
  - Fixed binary: query sent 1× (startup only); clean prompt across repeated quick-quit runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)