### PR TITLE
fix(hub): Settings modal was stuck at 360px, model rows overlapped

### DIFF
--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.35.0"
+version = "2.36.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6619,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.35.0"
+version = "2.36.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.35.0"
+version = "2.36.0"
 dependencies = [
  "blake3",
  "flate2",
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.35.0"
+version = "2.36.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6769,7 +6769,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.35.0"
+version = "2.36.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mur-hub-gui/ui/src/styles/components/dashboard.css
+++ b/mur-hub-gui/ui/src/styles/components/dashboard.css
@@ -801,7 +801,14 @@
 }
 
 /* ── Settings two-pane layout ── */
-.settings-modal--paned { width: 880px; max-width: 94vw; }
+/* Scales with the Hub window instead of capping out at a fixed 880px, which
+   left the content pane too narrow on smaller windows (model registry rows
+   designed for the ~900px-wide Model Library modal wrapped/overlapped).
+   Compound selector (not just `.settings-modal--paned`) is required: this
+   rule and `.modal`'s `width: 360px` (modal.css) have equal specificity, and
+   modal.css loads after dashboard.css, so a single-class selector here always
+   lost the cascade — the 880px/90vw width was dead CSS. */
+.modal.settings-modal--paned { width: 90vw; max-width: 1200px; }
 .settings-modal__panes {
   display: flex;
   min-height: 360px;


### PR DESCRIPTION
## Summary
- `.settings-modal--paned` and `.modal`'s base `width: 360px` (modal.css, loaded after dashboard.css) had equal CSS specificity — the base rule always won the cascade, so the Settings modal's width has been silently stuck at 360px this whole time, regardless of the 880px the paned variant declared
- At that width, Models tab registry rows (designed for the ~900px-wide Model Library modal) wrapped mid-word (`claude-opus-4-8` → 3 lines) and the price badges visually overlapped the model name
- Fix: compound selector `.modal.settings-modal--paned` so the override reliably wins regardless of file load order, sized to 90% of the Hub window (`90vw`, capped `max-width: 1200px`)

Screenshots from the report:

| Before | |
|---|---|
| Updates & CLI tab cramped | Models tab: names wrap, badges overlap |

## Also fixed
`mur-hub-gui/src-tauri/Cargo.lock` — stale since the workspace version bump to 2.36.0; regenerated by the local rebuild used to verify this fix.

## Gotcha found along the way
`tauri_build`'s build script only watches `tauri.conf.json`, `capabilities/`, `binaries/`, and `resources/` — **not** the frontend `dist/` directory. A frontend-only change can get silently swallowed by cargo's incremental cache (no Rust source changed → no recompile → stale embedded assets ship). Had to `touch src/main.rs` to force a real rebuild before the fix actually showed up live. Worth keeping in mind for future Hub UI changes verified via local `.app` builds.

## Test plan
- [x] `npm run build` in `mur-hub-gui/ui` picks up the new CSS (verified compound selector present in output bundle)
- [x] Local `.app` rebuilt (forced recompile) and reinstalled
- [x] Live-verified in the running Hub at both default (960px) and large (1600px) window sizes: Models tab registry rows render on one line, no wrapping or badge overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)