### PR TITLE
fix: murmur dogfood batch 2 (bash timeout_secs, object-shape compress, 429 backoff)

### DIFF
--- a/mur-agent-runtime/src/llm/anthropic.rs
+++ b/mur-agent-runtime/src/llm/anthropic.rs
@@ -556,7 +556,7 @@ impl LlmClient for AnthropicClient {
         if !status.is_success() {
             tracing::warn!(status = %status, body = %body_text, "anthropic non-2xx");
             if status == 429 {
-                return Err(LlmError::Http(format!("rate limit: {body_text}")));
+                return Err(LlmError::RateLimit);
             }
             return Err(LlmError::Http(format!("status {status}: {body_text}")));
         }
@@ -632,6 +632,9 @@ impl LlmClient for AnthropicClient {
             })?;
         let status = resp.status();
         if !status.is_success() {
+            if status == 429 {
+                return Err(LlmError::RateLimit);
+            }
             let body_text = resp.text().await.unwrap_or_default();
             return Err(LlmError::Http(format!("status {status}: {body_text}")));
         }

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -181,6 +181,15 @@ const LOOP_WINDOW: usize = 8;
 /// trips the doom-loop guard.
 const LOOP_REPEAT_THRESHOLD: usize = 3;
 
+/// Max number of times a single turn retries an `LlmError::RateLimit` (HTTP
+/// 429) before giving up and propagating the error. Separate from the
+/// empty-stream retry's own attempt counter.
+const MAX_RATE_LIMIT_RETRIES: u8 = 3;
+
+/// Base delay for the rate-limit backoff: attempt N sleeps
+/// `RATE_LIMIT_BACKOFF_BASE * 2^N` (1-indexed attempts give 2s, 4s, 8s, ...).
+const RATE_LIMIT_BACKOFF_BASE: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// Why the agentic loop stopped short of a natural end-turn. Carried out of the
 /// loop into the task's `usage` JSON so callers can tell a clean completion from
 /// a budget-truncated one.
@@ -1382,6 +1391,7 @@ impl TaskRunner {
             // or a second consecutive empty-stream, propagates as before.
             let resp = {
                 let mut attempt = 0u8;
+                let mut rate_limit_attempt = 0u8;
                 loop {
                     let req_try = req.clone();
                     let result = match &sink {
@@ -1394,6 +1404,20 @@ impl TaskRunner {
                             if attempt == 0 && msg.contains("empty streamed response") =>
                         {
                             attempt += 1;
+                            continue;
+                        }
+                        // Transient 429: back off exponentially and retry, up to
+                        // MAX_RATE_LIMIT_RETRIES times, so a momentary burst
+                        // across parallel agents doesn't kill the turn outright.
+                        Err(LlmError::RateLimit) if rate_limit_attempt < MAX_RATE_LIMIT_RETRIES => {
+                            rate_limit_attempt += 1;
+                            let delay = rate_limit_backoff_delay(rate_limit_attempt);
+                            tracing::warn!(
+                                attempt = rate_limit_attempt,
+                                delay_secs = delay.as_secs(),
+                                "llm rate limited (429); backing off and retrying"
+                            );
+                            tokio::time::sleep(delay).await;
                             continue;
                         }
                         Err(e) => {
@@ -1601,6 +1625,13 @@ impl TaskRunner {
             }
         }
     }
+}
+
+/// Backoff delay for rate-limit retry attempt `attempt` (1-indexed: the first
+/// retry is attempt 1). Doubles `RATE_LIMIT_BACKOFF_BASE` per attempt, giving
+/// 2s, 4s, 8s for attempts 1, 2, 3 with the current base of 1s.
+fn rate_limit_backoff_delay(attempt: u8) -> std::time::Duration {
+    RATE_LIMIT_BACKOFF_BASE * (1u32 << u32::from(attempt))
 }
 
 /// Deterministic hash of a tool call's arguments. Serializes to canonical JSON
@@ -2997,6 +3028,34 @@ mod tests {
         assert!(runner.inject_steering("nope", "x".into()).await.is_err());
         runner.unregister_steering("t1").await;
         assert!(runner.inject_steering("t1", "y".into()).await.is_err());
+    }
+
+    #[test]
+    fn rate_limit_backoff_delay_matches_spec() {
+        assert_eq!(
+            rate_limit_backoff_delay(1),
+            std::time::Duration::from_secs(2)
+        );
+        assert_eq!(
+            rate_limit_backoff_delay(2),
+            std::time::Duration::from_secs(4)
+        );
+        assert_eq!(
+            rate_limit_backoff_delay(3),
+            std::time::Duration::from_secs(8)
+        );
+    }
+
+    #[test]
+    fn rate_limit_retry_constants_are_sane() {
+        // Must retry at least once for the backoff to matter, and stay small
+        // enough that a still-limited account fails a turn in a bounded time
+        // (2s + 4s + 8s = 14s at the current base) rather than hanging.
+        assert!(MAX_RATE_LIMIT_RETRIES >= 1);
+        assert!(MAX_RATE_LIMIT_RETRIES <= 5);
+        assert!(RATE_LIMIT_BACKOFF_BASE >= std::time::Duration::from_millis(1));
+        let max_delay = rate_limit_backoff_delay(MAX_RATE_LIMIT_RETRIES);
+        assert!(max_delay <= std::time::Duration::from_secs(60));
     }
 }
 

--- a/mur-agent-runtime/src/tools/bash.rs
+++ b/mur-agent-runtime/src/tools/bash.rs
@@ -4,6 +4,17 @@ use tokio::process::Command;
 use super::{ToolError, ToolExecutor};
 use crate::llm::ToolDef;
 
+/// Default timeout (in seconds) applied to a bash command when the caller
+/// doesn't supply `timeout_secs` in the tool input.
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+/// Upper bound (in seconds) on the `timeout_secs` a caller may request.
+/// Requests above this (or invalid/non-positive values) are clamped down to
+/// this ceiling, so agents can run long builds without the risk of an
+/// effectively unbounded command (dogfood issue 8: the old hardcoded 30s cap
+/// made the `nohup` workaround undiscoverable for anything longer).
+const MAX_TIMEOUT_SECS: u64 = 600;
+
 /// Directories that must be on `PATH` for the bash tool's spawned commands,
 /// even when the agent-runtime process itself was launched by a service
 /// manager (launchd/systemd) with a minimal default `PATH`
@@ -49,6 +60,18 @@ pub struct BashTool {
     pub working_dir: PathBuf,
 }
 
+/// Resolve the effective timeout (in seconds) from the tool input's optional
+/// `timeout_secs` field: missing or non-positive/invalid values fall back to
+/// [`DEFAULT_TIMEOUT_SECS`], and anything above [`MAX_TIMEOUT_SECS`] is
+/// clamped down to it, so a caller can never request an effectively
+/// unbounded command.
+fn resolve_timeout_secs(requested: Option<i64>) -> u64 {
+    match requested {
+        Some(secs) if secs >= 1 => (secs as u64).min(MAX_TIMEOUT_SECS),
+        _ => DEFAULT_TIMEOUT_SECS,
+    }
+}
+
 impl BashTool {
     pub fn new(working_dir: PathBuf) -> Self {
         Self { working_dir }
@@ -64,7 +87,11 @@ impl ToolExecutor for BashTool {
     fn def(&self) -> ToolDef {
         ToolDef {
             name: "bash".into(),
-            description: "Run a bash shell command. Returns combined stdout+stderr. Non-zero exit codes appear in the output but are not errors.".into(),
+            description: format!(
+                "Run a bash shell command. Returns combined stdout+stderr. Non-zero exit codes appear in the output but are not errors. \
+Commands are killed after `timeout_secs` (default {DEFAULT_TIMEOUT_SECS}s, max {MAX_TIMEOUT_SECS}s) \
+— pass a larger `timeout_secs` for long-running commands like builds instead of resorting to `nohup`."
+            ),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -75,6 +102,13 @@ impl ToolExecutor for BashTool {
                     "cwd": {
                         "type": "string",
                         "description": "Working directory for the command. Defaults to the agent home directory."
+                    },
+                    "timeout_secs": {
+                        "type": "integer",
+                        "description": format!(
+                            "Maximum seconds to let the command run before it is killed. Defaults to {DEFAULT_TIMEOUT_SECS} \
+            if omitted or invalid, clamped to the range 1-{MAX_TIMEOUT_SECS}. Use a larger value for slow commands such as builds or test suites."
+                        )
                     }
                 },
                 "required": ["command"]
@@ -93,6 +127,8 @@ impl ToolExecutor for BashTool {
             .map(PathBuf::from)
             .unwrap_or_else(|| self.working_dir.clone());
 
+        let timeout_secs = resolve_timeout_secs(input["timeout_secs"].as_i64());
+
         let path = augmented_path(std::env::var("PATH").ok().as_deref());
 
         let child = Command::new("bash")
@@ -108,7 +144,7 @@ impl ToolExecutor for BashTool {
             .map_err(|e| ToolError::Execution(format!("spawn failed: {e}")))?;
 
         let output = match tokio::time::timeout(
-            std::time::Duration::from_secs(30),
+            std::time::Duration::from_secs(timeout_secs),
             child.wait_with_output(),
         )
         .await
@@ -120,7 +156,9 @@ impl ToolExecutor for BashTool {
                 // above ensures tokio's process driver still sends the kill
                 // and reaps the exit status in the background instead of
                 // leaving a zombie behind (dogfood issue 11).
-                return Err(ToolError::Execution("command timed out after 30s".into()));
+                return Err(ToolError::Execution(format!(
+                    "command timed out after {timeout_secs}s"
+                )));
             }
         };
 
@@ -155,6 +193,25 @@ mod tests {
 
     fn make_tool() -> BashTool {
         BashTool::new(std::env::temp_dir())
+    }
+
+    #[test]
+    fn resolve_timeout_secs_defaults_clamps_and_passes_through() {
+        // Absent -> default.
+        assert_eq!(resolve_timeout_secs(None), DEFAULT_TIMEOUT_SECS);
+        // Non-positive/invalid -> default.
+        assert_eq!(resolve_timeout_secs(Some(0)), DEFAULT_TIMEOUT_SECS);
+        assert_eq!(resolve_timeout_secs(Some(-5)), DEFAULT_TIMEOUT_SECS);
+        // In-range value passes through unchanged.
+        assert_eq!(resolve_timeout_secs(Some(120)), 120);
+        // Above the ceiling is clamped down to it.
+        assert_eq!(resolve_timeout_secs(Some(10_000)), MAX_TIMEOUT_SECS);
+        // Exactly at the boundaries.
+        assert_eq!(resolve_timeout_secs(Some(1)), 1);
+        assert_eq!(
+            resolve_timeout_secs(Some(MAX_TIMEOUT_SECS as i64)),
+            MAX_TIMEOUT_SECS
+        );
     }
 
     #[cfg(unix)]

--- a/mur-compress/src/auto.rs
+++ b/mur-compress/src/auto.rs
@@ -152,13 +152,24 @@ pub fn auto_compress_value(
             o.fired.then(|| value_replacement(&o, query))
         }
         Value::Object(map) => {
+            // Candidate fields are arrays (e.g. MCP list results) or strings
+            // (e.g. a real Bash tool_response's `stdout`/`stderr`), since
+            // Claude Code's PostToolUse stdin wraps tool output as an object
+            // like `{stdout: <string>, stderr: <string>, interrupted: bool}`.
             let key = map
                 .iter()
-                .filter(|(_, v)| v.is_array())
+                .filter(|(_, v)| v.is_array() || v.is_string())
                 .max_by_key(|(_, v)| v.to_string().len())
                 .map(|(k, _)| k.clone())?;
-            let arr_text = map.get(&key).map(|v| v.to_string()).unwrap_or_default();
-            let o = auto_compress(engine, &arr_text, query, min_tokens);
+            let field = map.get(&key)?;
+            // Pass a string field's raw contents (not its JSON-quoted
+            // `to_string()`) so the engine sees the real text to compress;
+            // arrays still go through `to_string()` since they're already
+            // top-level-array-shaped JSON.
+            let o = match field {
+                Value::String(s) => auto_compress(engine, s, query, min_tokens),
+                _ => auto_compress(engine, &field.to_string(), query, min_tokens),
+            };
             if !o.fired {
                 return None;
             }
@@ -295,6 +306,35 @@ mod tests {
     fn value_small_object_returns_none() {
         let (_dir, eng) = engine();
         let v = serde_json::json!({"results": ["a", "b"], "count": 2});
+        assert!(auto_compress_value(&eng, &v, None, 1500).is_none());
+    }
+
+    // Real Claude Code PostToolUse stdin wraps Bash tool output as an
+    // object: `{stdout: <string>, stderr: <string>, interrupted: bool}`.
+    // The Object branch must consider string fields too, not just arrays.
+    #[test]
+    fn value_object_tool_response_compresses_large_stdout_string() {
+        let (_dir, eng) = engine();
+        let v = serde_json::json!({
+            "stdout": big_json_array(),
+            "stderr": "",
+            "interrupted": false,
+        });
+        let out = auto_compress_value(&eng, &v, None, 50).expect("should fire");
+        assert_eq!(out["interrupted"], serde_json::json!(false));
+        assert_eq!(out["stderr"], serde_json::json!(""));
+        assert_eq!(out["stdout"]["compressed"], serde_json::json!(true));
+        assert!(out["stdout"]["hash"].as_str().is_some());
+    }
+
+    #[test]
+    fn value_object_tool_response_small_stdout_returns_none() {
+        let (_dir, eng) = engine();
+        let v = serde_json::json!({
+            "stdout": "ok",
+            "stderr": "",
+            "interrupted": false,
+        });
         assert!(auto_compress_value(&eng, &v, None, 1500).is_none());
     }
 }


### PR DESCRIPTION
Second batch of fixes from the drs-vision dogfood supervision sessions (ledger: drs-vision `.supervisor/ISSUES.md`). Follows #576.

## Fixes

- **Issue #8 — `7a0929bd`**: the agent bash tool hardcoded a 30s kill timeout, so agents could not run builds/tests inline. Adds an optional `timeout_secs` tool param (default 30, max 600, clamped), advertised in the tool schema/description so agents discover it instead of resorting to `nohup`.
- **Issue #14B — `8ea264c3`**: live install-verification found `auto_compress_value`'s Object branch only considered **array** fields, so Claude Code's real object-shaped `tool_response` (`{stdout, stderr, interrupted}`) was never compressed. Candidate fields now include string fields (longest serialized wins); tests use the real hook stdin shape. Verified end-to-end against the installed binary.
- **Issue #9 — `9f71580b`**: a transient upstream 429 killed the agent turn immediately (three parallel agents died at once bursting the account limit). Unifies anthropic.rs onto the existing `LlmError::RateLimit` variant (openai/ollama already used it) and adds bounded exponential backoff (2s/4s/8s, max 3 retries, `tracing::warn` per attempt) in the task_runner turn loop, alongside the existing empty-stream retry.

## Verification

- 348/348 mur-agent-runtime lib tests, 40/40 mur-compress, 13/13 mur-core hook tests
- `cargo fmt --all --check` + CI-exact `cargo clippy --all --no-deps --locked -- -D warnings` + workspace-wide `cargo test --no-run --locked` all green locally
- 14B verified live: object-shaped 8KB response now compresses through the installed hook chain (40 rows → schema+sample envelope with retrieval hash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)