### PR TITLE
fix: agent lifecycle — flock lock + honest install-service + respawn on restart (#7)

### DIFF
--- a/mur-agent-runtime/src/lock_file.rs
+++ b/mur-agent-runtime/src/lock_file.rs
@@ -45,7 +45,7 @@ impl LockHandle {
             fs::create_dir_all(parent)?;
         }
         let sentinel = sentinel_path(path);
-        let file = OpenOptions::new()
+        let mut file = OpenOptions::new()
             .create(true)
             .read(true)
             .write(true)
@@ -53,6 +53,11 @@ impl LockHandle {
             .open(&sentinel)?;
         file.try_lock_exclusive()
             .map_err(|_| LockError::AlreadyHeld)?;
+        // Record the holder pid in the sentinel, best-effort: failure to
+        // write must not tear down the lock we just acquired.
+        if file.set_len(0).is_ok() {
+            let _ = file.write_all(std::process::id().to_string().as_bytes());
+        }
         Ok(Self {
             _sentinel: file,
             path: path.to_path_buf(),

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -309,7 +309,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
 
     // 5. Acquire running.lock
     let lock_path = agent_home.join("running.lock");
-    let _lock_handle =
+    let lock_handle =
         LockHandle::acquire(&lock_path).map_err(|e| anyhow::anyhow!("already running ({e})"))?;
 
     // 6. Build dispatcher (shared Arc so multiple transports can read it)
@@ -707,7 +707,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         })
         .await;
     writer.flush().await;
-    let _ = std::fs::remove_file(&lock_path);
+    lock_handle.release();
     Ok(())
 }
 

--- a/mur-agent-runtime/tests/lock_file.rs
+++ b/mur-agent-runtime/tests/lock_file.rs
@@ -78,6 +78,10 @@ fn stale_sentinel_content_does_not_block_acquire() {
     let _handle = LockHandle::acquire(&path).unwrap();
 }
 
+// Windows LockFileEx is a mandatory lock, so reading the sentinel while the
+// flock is held from the same process is denied there (os error 33); unix
+// flock is advisory, so the read-back succeeds.
+#[cfg(unix)]
 #[test]
 fn sentinel_records_current_pid_after_acquire() {
     let tmp = TempDir::new().unwrap();

--- a/mur-agent-runtime/tests/lock_file.rs
+++ b/mur-agent-runtime/tests/lock_file.rs
@@ -66,3 +66,25 @@ fn live_lock_not_stale() {
     write_lock(&path, &sample_lock()).unwrap();
     assert!(!is_stale(&path).unwrap(), "held lock should not be stale");
 }
+
+#[test]
+fn stale_sentinel_content_does_not_block_acquire() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("running.lock");
+    let sentinel = tmp.path().join("running.sentinel");
+    // Bogus pid text with no flock holder: acquire must still succeed since
+    // ownership is determined by flock, not by file contents.
+    fs::write(&sentinel, b"999999").unwrap();
+    let _handle = LockHandle::acquire(&path).unwrap();
+}
+
+#[test]
+fn sentinel_records_current_pid_after_acquire() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("running.lock");
+    let sentinel = tmp.path().join("running.sentinel");
+    let _handle = LockHandle::acquire(&path).unwrap();
+    let contents = fs::read_to_string(&sentinel).unwrap();
+    let pid: u32 = contents.trim().parse().unwrap();
+    assert_eq!(pid, std::process::id());
+}

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -6,12 +6,14 @@
 //! launchd needs the process to exit, not the lock to disappear.
 
 use std::fs;
-use std::path::Path;
+use std::fs::OpenOptions;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 use anyhow::{Result, bail};
 use mur_common::{AgentProfile as _AgentProfile, LockFile};
 
-use super::{pid_alive, resolve_mur_home, stale};
+use super::{pid_alive, resolve_mur_home, resolve_runtime_target, stale};
 
 /// Extra grace period added on top of the runtime's `stop_timeout_secs` before
 /// the SIGKILL fallback fires.  The SIGKILL wait MUST outlast the runtime's own
@@ -182,6 +184,13 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<()> {
     let old_pid = lock.pid;
     let old_sha = lock.build_sha.clone();
 
+    // Whether a launchd/systemd service unit is installed for this agent —
+    // computed before signalling so we know, once the old pid is dead,
+    // whether to expect an automatic respawn or do it ourselves.
+    let has_service = service_unit_path(name)
+        .map(|p| service_unit_exists(&p))
+        .unwrap_or(false);
+
     // Load stop_timeout_secs from the agent's profile (mirrors cmd_stop).
     // The SIGKILL fallback must wait at least this long so the runtime's
     // cooperative drain can complete before we force-kill.
@@ -217,6 +226,44 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<()> {
             libc::kill(old_pid as libc::pid_t, libc::SIGKILL);
         }
         std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+
+    // ── No installed service → nothing will respawn us automatically ──
+    // Spawn the runtime directly, detached, so the respawn-poll loop below
+    // (shared with the service-managed path) has a fresh process to find.
+    if !has_service {
+        println!("agent '{name}' has no service installed; respawning runtime directly");
+        let target = resolve_runtime_target();
+        let mur_home = resolve_mur_home()?;
+        let stderr_log = agent_home.join("stderr.log");
+        let stdout_file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&stderr_log)
+            .map_err(|e| {
+                anyhow::anyhow!("open {} for respawn stdout: {e}", stderr_log.display())
+            })?;
+        let stderr_file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&stderr_log)
+            .map_err(|e| {
+                anyhow::anyhow!("open {} for respawn stderr: {e}", stderr_log.display())
+            })?;
+        Command::new(&target)
+            .arg("--profile")
+            .arg(name)
+            .env("MUR_HOME", &mur_home)
+            .stdin(Stdio::null())
+            .stdout(stdout_file)
+            .stderr(stderr_file)
+            .spawn()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to respawn runtime for '{name}' at {}: {e}",
+                    target.display()
+                )
+            })?;
     }
 
     // ── Poll for fresh running.lock with a different pid ──────────────
@@ -261,6 +308,35 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<()> {
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────
+
+/// Whether a service-unit file exists at `path`. Pure and OS-agnostic —
+/// callers build the path with [`service_unit_path`], which is the only
+/// cfg-gated piece.
+fn service_unit_exists(path: &Path) -> bool {
+    path.exists()
+}
+
+/// Build the expected service-unit path for `name`, mirroring the exact
+/// paths `cmd_install_service` writes in `service.rs`:
+///   - macOS: `~/Library/LaunchAgents/run.mur.agent.<name>.plist`
+///   - Linux: `$XDG_CONFIG_HOME/systemd/user/mur-agent-<name>.service`
+///
+/// Returns `None` when the home/config dir can't be resolved, or on
+/// unsupported platforms (mirrors `install-service`'s platform gate).
+#[cfg(target_os = "macos")]
+fn service_unit_path(name: &str) -> Option<PathBuf> {
+    Some(dirs::home_dir()?.join(format!("Library/LaunchAgents/run.mur.agent.{name}.plist")))
+}
+
+#[cfg(target_os = "linux")]
+fn service_unit_path(name: &str) -> Option<PathBuf> {
+    Some(dirs::config_dir()?.join(format!("systemd/user/mur-agent-{name}.service")))
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn service_unit_path(_name: &str) -> Option<PathBuf> {
+    None
+}
 
 fn read_lock(path: &Path) -> std::io::Result<Option<LockFile>> {
     mur_common::lock_file::read(path)
@@ -372,6 +448,21 @@ mod tests {
         fs::create_dir_all(home.join("agents")).unwrap();
         let result = select_targets(home, None, true, false).unwrap();
         assert!(result.is_empty());
+    }
+
+    /// The pure exists-helper simply reflects on-disk state for the path
+    /// it's given — path construction is cfg-gated separately and not
+    /// exercised here (this test is OS-agnostic).
+    #[test]
+    fn service_unit_exists_reflects_disk_state() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("run.mur.agent.test.plist");
+        assert!(!service_unit_exists(&path), "must be false before creation");
+        fs::write(&path, b"unit").unwrap();
+        assert!(
+            service_unit_exists(&path),
+            "must be true once the file exists"
+        );
     }
 
     /// Fix 1: SIGKILL-fallback wait must be derived from stop_timeout_secs so

--- a/mur-core/src/cmd/agent/service.rs
+++ b/mur-core/src/cmd/agent/service.rs
@@ -30,10 +30,18 @@ pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {
             fs::create_dir_all(parent)?;
         }
         write_atomic(&dest, plist.as_bytes())?;
-        let _ = std::process::Command::new("launchctl")
+        let load_output = std::process::Command::new("launchctl")
             .args(["load", "-w"])
             .arg(&dest)
-            .status();
+            .output()?;
+        if !load_output.status.success() {
+            let stderr = String::from_utf8_lossy(&load_output.stderr);
+            bail!(
+                "wrote plist to {} but `launchctl load -w` failed: {stderr}; the plist is still on disk, try `launchctl bootstrap gui/$UID {}` to load it manually",
+                dest.display(),
+                dest.display()
+            );
+        }
         println!("Installed launchd service at {}", dest.display());
     }
     #[cfg(target_os = "linux")]
@@ -53,10 +61,17 @@ pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {
         let _ = std::process::Command::new("systemctl")
             .args(["--user", "daemon-reload"])
             .status();
-        let _ = std::process::Command::new("systemctl")
+        let enable_output = std::process::Command::new("systemctl")
             .args(["--user", "enable", "--now"])
             .arg(format!("mur-agent-{name}.service"))
-            .status();
+            .output()?;
+        if !enable_output.status.success() {
+            let stderr = String::from_utf8_lossy(&enable_output.stderr);
+            bail!(
+                "wrote unit to {} but `systemctl --user enable --now` failed: {stderr}; the unit file is still on disk, try `systemctl --user enable --now mur-agent-{name}.service` to retry manually",
+                dest.display()
+            );
+        }
         println!("Installed systemd --user unit at {}", dest.display());
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]


### PR DESCRIPTION
Dogfood ledger Issue #7 (drs-vision `.supervisor/ISSUES.md`), third wave. Follows #576/#577.

## Fixes

- **7A — `892c0a6a`**: agent lock correctness. Live evidence: a dead runtime's leftover `running.sentinel` made the next start fail with "already running (lock already held)" despite no process existing, and a clean SIGTERM drain never removed the sentinel. The flock itself was already correct (`0e53191d`); the real defects were (1) `LockHandle::release()` was never called — the supervisor dropped the handle at setup scope and its manual shutdown cleanup removed `running.lock` but not the sentinel; (2) no holder pid in the sentinel for diagnostics. Now: the handle lives until graceful shutdown and `release()` removes both files; `acquire` writes the holder pid into the sentinel. +3 lock tests (6/6).
- **7B — `ecb47a44`**: lifecycle honesty. (a) `mur agent install-service` discarded the `launchctl load -w` exit status (`let _`) and printed "Installed…" even on `Load failed: 5` — now it bails with launchctl's stderr and a manual-bootstrap recovery hint (same fix for the linux `systemctl enable --now` branch). (b) `mur agent restart` relied solely on launchd KeepAlive to respawn, stranding service-less (nohup-started) agents stopped — now it detects whether a service unit exists and, if not, respawns the runtime directly (canonical binary resolution, detached, output appended to the agent's stderr.log) before the normal fresh-lock poll. Pure `service_unit_path`/`exists` helpers with a tempdir test.

## Verification

- lock_file integration tests 6/6; agent cmd tests 340/340 (single-threaded; the 4 parallel failures are the pre-existing env-sensitive flaky set, untouched by this diff)
- `cargo fmt --all --check`, CI-exact `cargo clippy --all --no-deps --locked -- -D warnings`, workspace-wide `cargo test --no-run --locked` all green locally
- 7A's defect was reproduced live during the Hub #11 deployment earlier today (stale qa sentinel blocked startup; removing it unblocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)