### PR TITLE
fix(sandbox): scoped AF_UNIX allows for temp and agent sockets (#10)

### DIFF
--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -1,6 +1,7 @@
 use super::{SandboxPolicy, SandboxStatus};
 use anyhow::Context;
 use std::ffi::CString;
+use std::path::PathBuf;
 
 pub fn apply_macos(policy: &SandboxPolicy) -> anyhow::Result<SandboxStatus> {
     let profile = build_sbpl_profile(policy);
@@ -79,6 +80,39 @@ fn sbpl_escape(s: &str) -> String {
     out
 }
 
+/// Resolve MUR_HOME the same way the supervisor does (`supervisor.rs`'s
+/// startup resolution): the `MUR_HOME` env var if set, else `$HOME/.mur`.
+/// Needed so the per-agent `agents/` directory (peer `agent.sock` files,
+/// dialed for A2A) can be subpath-allowed for unix-socket network-outbound
+/// below — mirrors how `SandboxPolicy::from_entitlements` derives home-based
+/// paths, but falls back to `/tmp` instead of panicking (this runs inside
+/// the already-sandboxing process, where a hard `.expect` would be fatal).
+fn resolved_mur_home() -> PathBuf {
+    std::env::var_os("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join(".mur")
+        })
+}
+
+/// AF_UNIX socket paths the restricted network profile must not blanket-deny.
+/// Unix-socket `connect` is itself a `network-outbound` operation under SBPL,
+/// so the `(deny network-outbound)` baseline (see below) would otherwise
+/// reject any process- or test-owned domain socket. Scoped to: the macOS
+/// per-user temp root and `/tmp` (where test/tool sockets land — same dirs
+/// `system_read_paths` re-allows for reads in `policy.rs`), and this agent's
+/// own `<mur_home>/agents` directory (peer `agent.sock` files dialed for
+/// A2A). Subpaths, not path-literals, since exact socket filenames vary.
+fn unix_socket_allow_paths() -> Vec<PathBuf> {
+    vec![
+        PathBuf::from("/private/var/folders"),
+        PathBuf::from("/private/tmp"),
+        resolved_mur_home().join("agents"),
+    ]
+}
+
 /// Build an SBPL profile string from the policy.
 ///
 /// Strategy: default-allow for reads/exec/network (so the process can load
@@ -140,6 +174,16 @@ pub fn build_sbpl_profile(policy: &SandboxPolicy) -> String {
             lines.push(format!(
                 "(allow network-outbound (remote unix-socket (path-literal \"{MDNSRESPONDER_SOCKET}\")))"
             ));
+            // Scoped AF_UNIX carve-out (see unix_socket_allow_paths doc): test/tool
+            // sockets under the temp dirs, and peer agent.sock dialing under
+            // <mur_home>/agents. Does NOT widen general network-outbound access —
+            // TCP stays port-gated by the loop below.
+            for p in unix_socket_allow_paths() {
+                let p = sbpl_escape(&p.to_string_lossy());
+                lines.push(format!(
+                    "(allow network-outbound (remote unix-socket (subpath \"{p}\")))"
+                ));
+            }
             for port in ports {
                 lines.push(format!(
                     "(allow network-outbound (remote tcp \"*:{port}\"))"
@@ -285,5 +329,50 @@ mod tests {
         let policy = policy_with(vec![], vec![]); // net_allow_ports defaults to None
         let sbpl = build_sbpl_profile(&policy);
         assert!(!sbpl.contains("network-outbound"));
+    }
+
+    #[test]
+    fn restricted_allows_scoped_unix_sockets() {
+        // AF_UNIX connect is itself `network-outbound` under SBPL, so the
+        // `(deny network-outbound)` baseline would otherwise break any
+        // domain socket (test sockets, peer agent.sock dialing). These three
+        // subpath carve-outs must be present without widening general
+        // network access (TCP stays port-gated — see the next test).
+        let mut policy = policy_with(vec![], vec![]);
+        policy.net_allow_ports = Some(vec![443]);
+        let sbpl = build_sbpl_profile(&policy);
+        assert!(
+            sbpl.contains(
+                "(allow network-outbound (remote unix-socket (subpath \"/private/var/folders\")))"
+            ),
+            "restricted profile must allow unix sockets under macOS per-user temp:\n{sbpl}"
+        );
+        assert!(
+            sbpl.contains(
+                "(allow network-outbound (remote unix-socket (subpath \"/private/tmp\")))"
+            ),
+            "restricted profile must allow unix sockets under /private/tmp:\n{sbpl}"
+        );
+        let agents_dir = resolved_mur_home().join("agents");
+        let agents_dir = sbpl_escape(&agents_dir.to_string_lossy());
+        assert!(
+            sbpl.contains(&format!(
+                "(allow network-outbound (remote unix-socket (subpath \"{agents_dir}\")))"
+            )),
+            "restricted profile must allow unix sockets under <mur_home>/agents (A2A agent.sock):\n{sbpl}"
+        );
+    }
+
+    #[test]
+    fn off_mode_does_not_allow_unix_sockets() {
+        // Off (deny-all) must not get the scoped AF_UNIX carve-out either —
+        // it stays fully air-gapped, matching off_mode_denies_network.
+        let mut policy = policy_with(vec![], vec![]);
+        policy.net_allow_ports = Some(vec![]);
+        let sbpl = build_sbpl_profile(&policy);
+        assert!(
+            !sbpl.contains("(allow network-outbound"),
+            "Off mode must not allow any outbound, including unix sockets:\n{sbpl}"
+        );
     }
 }


### PR DESCRIPTION
Dogfood ledger Issue #10 (drs-vision `.supervisor/ISSUES.md`), fourth wave. Follows #576/#577/#578.

## Fix

The restricted Seatbelt profile's `(deny network-outbound)` also denies AF_UNIX connects, so any test or child process an agent runs that touches unix sockets dies with `Operation not permitted` — "agents testing MUR" was structurally blocked for socket tests (the Issue-5 regression test had to be env-gated because of this).

`7bc6efd2` adds three **scoped** unix-socket carve-outs in the restricted branch, mirroring the existing mDNSResponder `path-literal` precedent:

- `subpath /private/var/folders` — macOS per-user temp, where test sockets land
- `subpath /private/tmp`
- `subpath <mur_home>/agents` — A2A `agent.sock` dialing

General network posture is unchanged: no new TCP allows, and **off mode keeps its full `(deny network-outbound)`** with no allows (tested).

## Verification

- sandbox::macos tests 11/11 (two new: restricted profile contains the three scoped allows; off mode contains no `allow network-outbound`)
- `cargo fmt --all --check`, CI-exact `cargo clippy --all --no-deps --locked -- -D warnings`, workspace `cargo test --no-run --locked` all green locally
- The one red during development (`egress_proxy::tests::allowed_host_tunnels_denied_host_403`) was confirmed pre-existing via a clean-tree rerun — unrelated environment failure, untouched by this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)