### PR TITLE
feat(compress): per-version/per-day stats segmentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6447,6 +6447,7 @@ name = "mur-compress"
 version = "2.36.0"
 dependencies = [
  "blake3",
+ "chrono",
  "flate2",
  "fs2",
  "regex",

--- a/mur-compress/Cargo.toml
+++ b/mur-compress/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/mur-compress/src/stats.rs
+++ b/mur-compress/src/stats.rs
@@ -5,14 +5,30 @@
 //! delta, and writes back. Without this, two engines (the MCP server builds a
 //! fresh one per call) would each read the same baseline and clobber each
 //! other's increment, undercounting savings.
+//!
+//! Two views are kept side by side:
+//! - The flat `StatsData` fields are **all-time totals**: every compression
+//!   and retrieval ever recorded, with no version or date attribution. They
+//!   keep accumulating exactly as they always have.
+//! - `StatsData::buckets` **additionally** segments the same events by
+//!   `(mur_version, local day)`, so releases can be compared against each
+//!   other. It is populated only from the moment this field shipped onward;
+//!   there is no raw event log to retroactively bucket older history into.
 
+use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
+use chrono::Local;
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 
+/// All-time running totals, exactly as before segmentation was added: every
+/// compression/retrieval increments these regardless of version or date, and
+/// they are never reset or migrated. This is the only place history from
+/// before per-version/per-day buckets existed lives -- `buckets` is purely
+/// additive and only ever populated going forward.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct StatsData {
     compressions: u64,
@@ -20,6 +36,27 @@ struct StatsData {
     total_input_tokens: u64,
     total_output_tokens: u64,
     total_tokens_saved: u64,
+
+    /// Per-version, per-day segmentation: `mur_version -> "YYYY-MM-DD"
+    /// (local date) -> counts for that version on that day`. Absent for any
+    /// activity recorded before this field existed (old `stats.json` files
+    /// deserialize with this empty via `#[serde(default)]`); that older
+    /// history is only reflected in the flat totals above, not retroactively
+    /// bucketed.
+    #[serde(default)]
+    buckets: HashMap<String, HashMap<String, BucketData>>,
+}
+
+/// Counts for one `(mur_version, day)` bucket. Mirrors the shape of the
+/// all-time totals, minus the derived fields (`savings_percent` etc.), which
+/// are computed from these at read time so they can never drift out of sync.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BucketData {
+    pub compressions: u64,
+    pub retrievals: u64,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub total_tokens_saved: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -33,6 +70,26 @@ pub struct StatsSnapshot {
     pub estimated_cost_saved_usd: f64,
     pub store_entries: usize,
     pub store_bytes: u64,
+
+    /// Raw per-`(mur_version, day)` segmentation, straight from
+    /// `StatsData::buckets`. Formatting/rollup (recent-N days, per-version
+    /// sums, etc.) is left to consumers (MCP tool, CLI) rather than computed
+    /// here, so this stays a thin, order-independent map.
+    pub buckets: HashMap<String, HashMap<String, BucketData>>,
+}
+
+/// Current crate version, used as the bucket's version key. `mur-compress`
+/// inherits the workspace version, so this is stable across every surface
+/// that links it (MCP server, CLI, PostToolUse hooks) without needing the
+/// version threaded in from each call site.
+fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// Today's bucket key in local time, `"YYYY-MM-DD"`. Local (not UTC) so a
+/// day boundary matches a release's users' wall-clock day.
+fn today_key() -> String {
+    Local::now().format("%Y-%m-%d").to_string()
 }
 
 pub struct StatsTracker {
@@ -92,16 +149,37 @@ impl StatsTracker {
     }
 
     pub fn record_compression(&self, before: usize, after: usize) {
+        let day = today_key();
         self.update(|d| {
             d.compressions += 1;
             d.total_input_tokens += before as u64;
             d.total_output_tokens += after as u64;
             d.total_tokens_saved += before.saturating_sub(after) as u64;
+
+            let bucket = d
+                .buckets
+                .entry(current_version().to_string())
+                .or_default()
+                .entry(day.clone())
+                .or_default();
+            bucket.compressions += 1;
+            bucket.total_input_tokens += before as u64;
+            bucket.total_output_tokens += after as u64;
+            bucket.total_tokens_saved += before.saturating_sub(after) as u64;
         });
     }
 
     pub fn record_retrieval(&self) {
-        self.update(|d| d.retrievals += 1);
+        let day = today_key();
+        self.update(|d| {
+            d.retrievals += 1;
+            d.buckets
+                .entry(current_version().to_string())
+                .or_default()
+                .entry(day)
+                .or_default()
+                .retrievals += 1;
+        });
     }
 
     pub fn snapshot(
@@ -131,6 +209,7 @@ impl StatsTracker {
             estimated_cost_saved_usd: cost,
             store_entries,
             store_bytes,
+            buckets: d.buckets,
         }
     }
 }
@@ -174,5 +253,71 @@ mod tests {
         assert_eq!(snap.retrievals, 2);
         assert_eq!(snap.total_input_tokens, 150);
         assert_eq!(snap.total_tokens_saved, 110);
+    }
+
+    #[test]
+    fn record_compression_updates_bucket() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stats.json");
+        let t = StatsTracker::new(path.clone());
+        t.record_compression(100, 30); // saved 70
+        t.record_compression(50, 10); // saved 40
+
+        let snap = t.snapshot(3.0, 0, 0);
+        assert_eq!(snap.compressions, 2);
+        assert_eq!(snap.total_input_tokens, 150);
+        assert_eq!(snap.total_tokens_saved, 110);
+
+        let day = today_key();
+        let bucket = snap
+            .buckets
+            .get(current_version())
+            .and_then(|days| days.get(&day))
+            .expect("bucket for current version/day should exist");
+        assert_eq!(bucket.compressions, 2);
+        assert_eq!(bucket.total_input_tokens, 150);
+        assert_eq!(bucket.total_output_tokens, 40);
+        assert_eq!(bucket.total_tokens_saved, 110);
+    }
+
+    #[test]
+    fn old_stats_json_without_buckets_deserializes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stats.json");
+        // Legacy on-disk shape: only the flat fields, no `buckets` key at all.
+        std::fs::write(
+            &path,
+            r#"{"compressions":7,"retrievals":3,"total_input_tokens":2150000,"total_output_tokens":120000,"total_tokens_saved":2030000}"#,
+        )
+        .unwrap();
+
+        let t = StatsTracker::new(path);
+        let snap = t.snapshot(3.0, 0, 0);
+        assert_eq!(snap.compressions, 7);
+        assert_eq!(snap.retrievals, 3);
+        assert_eq!(snap.total_input_tokens, 2150000);
+        assert_eq!(snap.total_output_tokens, 120000);
+        assert_eq!(snap.total_tokens_saved, 2030000);
+        assert!(snap.buckets.is_empty());
+    }
+
+    #[test]
+    fn snapshot_exposes_buckets() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stats.json");
+        let t = StatsTracker::new(path);
+        t.record_compression(200, 20); // saved 180
+        t.record_retrieval();
+
+        let snap = t.snapshot(3.0, 0, 0);
+        let day = today_key();
+        let bucket = snap
+            .buckets
+            .get(current_version())
+            .and_then(|days| days.get(&day))
+            .expect("bucket for current version/day should exist");
+        assert_eq!(bucket.compressions, 1);
+        assert_eq!(bucket.retrievals, 1);
+        assert_eq!(bucket.total_tokens_saved, 180);
     }
 }

--- a/mur-mcp-server/src/tools.rs
+++ b/mur-mcp-server/src/tools.rs
@@ -704,6 +704,7 @@ async fn dispatch_tool(name: &str, arguments: &Value) -> Result<Value, String> {
                 "total_tokens_saved": s.total_tokens_saved,
                 "savings_percent": s.savings_percent,
                 "estimated_cost_saved_usd": s.estimated_cost_saved_usd,
+                "buckets": s.buckets,
                 "store": { "entries": s.store_entries, "bytes": s.store_bytes },
             }))
         }


### PR DESCRIPTION
`mur_compress_stats` only reported all-time aggregates (e.g. "7 compressions, 99.05% avg, 2.13M tokens saved"), so a release's compressor changes could never be evaluated against its predecessor — dogfood enhancement idea from the drs-vision rounds.

## Design

- `StatsData` gains `#[serde(default)] buckets: version → YYYY-MM-DD (local) → {compressions, retrievals, input/output tokens}` — **additive schema**: old `stats.json` files deserialize unchanged (covered by test).
- The existing flat counters keep accumulating as **all-time totals**; buckets segment from deployment forward — no raw events exist, so history cannot be re-bucketed (documented in the module comment).
- `record_compression`/`record_retrieval` update the bucket inside the same locked read-modify-write that already guards cross-process accumulation (MCP server + CLI + hook all share one file), keyed by `env!("CARGO_PKG_VERSION")` (workspace-uniform version) + `chrono::Local` date (`chrono` was already a workspace dependency; none added).
- `StatsSnapshot` and the `mur_compress_stats` MCP tool expose the buckets.

## Tests

`record_compression_updates_bucket` (totals AND bucket accumulate), `old_stats_json_without_buckets_deserializes` (backward-compat contract), `snapshot_exposes_buckets`. Full gate green: 43 mur-compress tests, clippy `--all --no-deps`, fmt, workspace test compile.

Design + implementation by the `rustsmith` agent via native file tools; supervisor ran git/gate outside the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)