### PR TITLE
feat(skills): daily-jobs domain skills — 4 hubs + 8 on-demand leaves + topology guide

### DIFF
--- a/.task11-spec.md
+++ b/.task11-spec.md
@@ -1,0 +1,192 @@
+# Task 11 spec — register built-ins + budgets regression test (rustsmith)
+
+Target file: `/Volumes/Firecuda4tb/Projects/mur/.worktrees/skillsmith/mur-core/src/cmd/sync_cmd.rs`
+Mechanism: node -e exact literal string insertion. No cargo, no git, touch ONLY this file.
+
+## EDIT 1 — register 13 new built-ins
+
+Locate the `let skills: &[(&str, &str)] = &[` array inside `ensure_mur_skill` (~line 1070). Find its LAST entry:
+
+```rust
+        (
+            "parallel-decompose",
+            include_str!("../skills/parallel_decompose.yaml"),
+        ),
+```
+
+Immediately AFTER that entry's closing `),` (still inside the array, before `];`), insert:
+
+```rust
+        (
+            "mur-fleet-manage",
+            include_str!("../skills/mur_fleet_manage.yaml"),
+        ),
+        ("mur-fleet-loop", include_str!("../skills/mur_fleet_loop.yaml")),
+        (
+            "mur-fleet-share",
+            include_str!("../skills/mur_fleet_share.yaml"),
+        ),
+        (
+            "mur-workflow-author",
+            include_str!("../skills/mur_workflow_author.yaml"),
+        ),
+        (
+            "mur-workflow-hitl",
+            include_str!("../skills/mur_workflow_hitl.yaml"),
+        ),
+        (
+            "mur-workflow-delegate",
+            include_str!("../skills/mur_workflow_delegate.yaml"),
+        ),
+        (
+            "mur-agent-setup",
+            include_str!("../skills/mur_agent_setup.yaml"),
+        ),
+        (
+            "mur-agent-mcp-wire",
+            include_str!("../skills/mur_agent_mcp_wire.yaml"),
+        ),
+        (
+            "mur-agent-schedule",
+            include_str!("../skills/mur_agent_schedule.yaml"),
+        ),
+        (
+            "mur-parallel-exec",
+            include_str!("../skills/mur_parallel_exec.yaml"),
+        ),
+        (
+            "mur-parallel-tracks",
+            include_str!("../skills/mur_parallel_tracks.yaml"),
+        ),
+        (
+            "mur-parallel-merge",
+            include_str!("../skills/mur_parallel_merge.yaml"),
+        ),
+        (
+            "parallel-topology-guide",
+            include_str!("../skills/parallel_topology_guide.yaml"),
+        ),
+```
+
+## EDIT 2 — budgets regression test
+
+If the file has a `#[cfg(test)] mod tests` block, append the function below inside it; otherwise append this whole block at the END of the file:
+
+```rust
+#[cfg(test)]
+mod builtin_skill_tests {
+    #[test]
+    fn new_builtin_skills_parse_and_respect_disclosure_budgets() {
+        // (name, yaml, expect_on_demand)
+        let cases: &[(&str, &str, bool)] = &[
+            (
+                "mur-fleet-manage",
+                include_str!("../skills/mur_fleet_manage.yaml"),
+                false,
+            ),
+            (
+                "mur-fleet-loop",
+                include_str!("../skills/mur_fleet_loop.yaml"),
+                true,
+            ),
+            (
+                "mur-fleet-share",
+                include_str!("../skills/mur_fleet_share.yaml"),
+                true,
+            ),
+            (
+                "mur-workflow-author",
+                include_str!("../skills/mur_workflow_author.yaml"),
+                false,
+            ),
+            (
+                "mur-workflow-hitl",
+                include_str!("../skills/mur_workflow_hitl.yaml"),
+                true,
+            ),
+            (
+                "mur-workflow-delegate",
+                include_str!("../skills/mur_workflow_delegate.yaml"),
+                true,
+            ),
+            (
+                "mur-agent-setup",
+                include_str!("../skills/mur_agent_setup.yaml"),
+                false,
+            ),
+            (
+                "mur-agent-mcp-wire",
+                include_str!("../skills/mur_agent_mcp_wire.yaml"),
+                true,
+            ),
+            (
+                "mur-agent-schedule",
+                include_str!("../skills/mur_agent_schedule.yaml"),
+                true,
+            ),
+            (
+                "mur-parallel-exec",
+                include_str!("../skills/mur_parallel_exec.yaml"),
+                false,
+            ),
+            (
+                "mur-parallel-tracks",
+                include_str!("../skills/mur_parallel_tracks.yaml"),
+                true,
+            ),
+            (
+                "mur-parallel-merge",
+                include_str!("../skills/mur_parallel_merge.yaml"),
+                true,
+            ),
+            (
+                "parallel-topology-guide",
+                include_str!("../skills/parallel_topology_guide.yaml"),
+                true,
+            ),
+            (
+                "parallel-decompose",
+                include_str!("../skills/parallel_decompose.yaml"),
+                false,
+            ),
+            (
+                "parallel-code",
+                include_str!("../skills/parallel_code.yaml"),
+                false,
+            ),
+        ];
+        use mur_common::skill::manifest::Visibility;
+        for (name, yaml, on_demand) in cases {
+            let m = mur_common::skill::parse_canonical(yaml)
+                .unwrap_or_else(|e| panic!("{name}: parse failed: {e}"));
+            assert_eq!(&m.name, name);
+            assert_eq!(
+                m.visibility == Visibility::OnDemand,
+                *on_demand,
+                "{name}: wrong visibility"
+            );
+            assert!(
+                m.description.chars().count() <= 120,
+                "{name}: description over 120 chars"
+            );
+            assert!(
+                m.content.r#abstract.split_whitespace().count() <= 50,
+                "{name}: abstract over 50 words"
+            );
+            let body = m
+                .content
+                .context
+                .clone()
+                .or_else(|| m.content.note.clone())
+                .unwrap_or_default();
+            let body_lines = body.lines().count();
+            assert!(
+                body_lines <= 150,
+                "{name}: body {body_lines} lines (budget 150)"
+            );
+        }
+    }
+}
+```
+
+Reply with: the line number range of each insertion.

--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -1118,7 +1118,10 @@ pub(crate) fn ensure_mur_skill(home: &std::path::Path) -> Result<bool> {
             "mur-fleet-manage",
             include_str!("../skills/mur_fleet_manage.yaml"),
         ),
-        ("mur-fleet-loop", include_str!("../skills/mur_fleet_loop.yaml")),
+        (
+            "mur-fleet-loop",
+            include_str!("../skills/mur_fleet_loop.yaml"),
+        ),
         (
             "mur-fleet-share",
             include_str!("../skills/mur_fleet_share.yaml"),
@@ -1576,7 +1579,6 @@ mod sync_skill_tests {
         std::fs::remove_dir_all(&home).ok();
     }
 }
-
 
 #[cfg(test)]
 mod builtin_skill_tests {

--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -1114,6 +1114,55 @@ pub(crate) fn ensure_mur_skill(home: &std::path::Path) -> Result<bool> {
             "parallel-decompose",
             include_str!("../skills/parallel_decompose.yaml"),
         ),
+        (
+            "mur-fleet-manage",
+            include_str!("../skills/mur_fleet_manage.yaml"),
+        ),
+        ("mur-fleet-loop", include_str!("../skills/mur_fleet_loop.yaml")),
+        (
+            "mur-fleet-share",
+            include_str!("../skills/mur_fleet_share.yaml"),
+        ),
+        (
+            "mur-workflow-author",
+            include_str!("../skills/mur_workflow_author.yaml"),
+        ),
+        (
+            "mur-workflow-hitl",
+            include_str!("../skills/mur_workflow_hitl.yaml"),
+        ),
+        (
+            "mur-workflow-delegate",
+            include_str!("../skills/mur_workflow_delegate.yaml"),
+        ),
+        (
+            "mur-agent-setup",
+            include_str!("../skills/mur_agent_setup.yaml"),
+        ),
+        (
+            "mur-agent-mcp-wire",
+            include_str!("../skills/mur_agent_mcp_wire.yaml"),
+        ),
+        (
+            "mur-agent-schedule",
+            include_str!("../skills/mur_agent_schedule.yaml"),
+        ),
+        (
+            "mur-parallel-exec",
+            include_str!("../skills/mur_parallel_exec.yaml"),
+        ),
+        (
+            "mur-parallel-tracks",
+            include_str!("../skills/mur_parallel_tracks.yaml"),
+        ),
+        (
+            "mur-parallel-merge",
+            include_str!("../skills/mur_parallel_merge.yaml"),
+        ),
+        (
+            "parallel-topology-guide",
+            include_str!("../skills/parallel_topology_guide.yaml"),
+        ),
     ];
 
     let mur_skills_dir = home.join(".mur").join("skills");
@@ -1525,5 +1574,121 @@ mod sync_skill_tests {
         assert!(body.contains("name: mur-project-search"));
 
         std::fs::remove_dir_all(&home).ok();
+    }
+}
+
+
+#[cfg(test)]
+mod builtin_skill_tests {
+    #[test]
+    fn new_builtin_skills_parse_and_respect_disclosure_budgets() {
+        // (name, yaml, expect_on_demand)
+        let cases: &[(&str, &str, bool)] = &[
+            (
+                "mur-fleet-manage",
+                include_str!("../skills/mur_fleet_manage.yaml"),
+                false,
+            ),
+            (
+                "mur-fleet-loop",
+                include_str!("../skills/mur_fleet_loop.yaml"),
+                true,
+            ),
+            (
+                "mur-fleet-share",
+                include_str!("../skills/mur_fleet_share.yaml"),
+                true,
+            ),
+            (
+                "mur-workflow-author",
+                include_str!("../skills/mur_workflow_author.yaml"),
+                false,
+            ),
+            (
+                "mur-workflow-hitl",
+                include_str!("../skills/mur_workflow_hitl.yaml"),
+                true,
+            ),
+            (
+                "mur-workflow-delegate",
+                include_str!("../skills/mur_workflow_delegate.yaml"),
+                true,
+            ),
+            (
+                "mur-agent-setup",
+                include_str!("../skills/mur_agent_setup.yaml"),
+                false,
+            ),
+            (
+                "mur-agent-mcp-wire",
+                include_str!("../skills/mur_agent_mcp_wire.yaml"),
+                true,
+            ),
+            (
+                "mur-agent-schedule",
+                include_str!("../skills/mur_agent_schedule.yaml"),
+                true,
+            ),
+            (
+                "mur-parallel-exec",
+                include_str!("../skills/mur_parallel_exec.yaml"),
+                false,
+            ),
+            (
+                "mur-parallel-tracks",
+                include_str!("../skills/mur_parallel_tracks.yaml"),
+                true,
+            ),
+            (
+                "mur-parallel-merge",
+                include_str!("../skills/mur_parallel_merge.yaml"),
+                true,
+            ),
+            (
+                "parallel-topology-guide",
+                include_str!("../skills/parallel_topology_guide.yaml"),
+                true,
+            ),
+            (
+                "parallel-decompose",
+                include_str!("../skills/parallel_decompose.yaml"),
+                false,
+            ),
+            (
+                "parallel-code",
+                include_str!("../skills/parallel_code.yaml"),
+                false,
+            ),
+        ];
+        use mur_common::skill::manifest::Visibility;
+        for (name, yaml, on_demand) in cases {
+            let m = mur_common::skill::parse_canonical(yaml)
+                .unwrap_or_else(|e| panic!("{name}: parse failed: {e}"));
+            assert_eq!(&m.name, name);
+            assert_eq!(
+                m.visibility == Visibility::OnDemand,
+                *on_demand,
+                "{name}: wrong visibility"
+            );
+            assert!(
+                m.description.chars().count() <= 120,
+                "{name}: description over 120 chars"
+            );
+            assert!(
+                m.content.r#abstract.split_whitespace().count() <= 50,
+                "{name}: abstract over 50 words"
+            );
+            let body = m
+                .content
+                .context
+                .clone()
+                .or_else(|| m.content.note.clone())
+                .unwrap_or_default();
+            let body_lines = body.lines().count();
+            assert!(
+                body_lines <= 150,
+                "{name}: body {body_lines} lines (budget 150)"
+            );
+        }
     }
 }

--- a/mur-core/src/skills/mur_agent_mcp_wire.yaml
+++ b/mur-core/src/skills/mur_agent_mcp_wire.yaml
@@ -1,0 +1,30 @@
+name: mur-agent-mcp-wire
+category: context
+visibility: on_demand
+publisher: human:mur
+version: 1.0.0
+description: "Give agents MCP tools: local stdio servers, remote HTTP with bearer/OAuth, registry installs, drift audits."
+content:
+  abstract: |
+    Give agents MCP tools three ways: local stdio servers (auto-synced into the
+    process spawn allowlist), remote HTTP servers with bearer tokens or OAuth
+    2.1, and registry installs via search. Audit wiring with inspect --probe to
+    catch drift, unpinned, or missing servers before agents run.
+  context: |
+    ## Local stdio
+    `mur agent mcp add <agent> <id> --command npx --arg -y --arg <pkg> [--force]`
+    This auto-syncs the command into the agent's `processes.spawn` allowlist,
+    OS-enforced.
+    `mur agent mcp remove <agent> <id>` | `enable` | `disable` | `rename`
+
+    ## Remote
+    `mur agent mcp add-remote <agent> <id> <url> [--bearer-env VAR | --bearer-keychain svc/acct]`
+    OAuth 2.1: `mur agent mcp login <agent> <id>`
+    Registry: `mur agent mcp search <q>` then `mur agent mcp registry-add <agent> <server>`
+
+    ## Audit
+    `mur agent mcp list <agent>`
+    `mur agent mcp inspect <agent> --probe` (exit 0 clean / 1 drift / 4 unpinned / 5 missing)
+    `mur agent mcp pin <agent> <id>`
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html

--- a/mur-core/src/skills/mur_agent_schedule.yaml
+++ b/mur-core/src/skills/mur_agent_schedule.yaml
@@ -1,0 +1,31 @@
+name: mur-agent-schedule
+category: context
+visibility: on_demand
+publisher: human:mur
+version: 1.0.0
+description: "Wake agents on cron beats or idle triggers — message injection, next-fire preview, cooldowns."
+content:
+  abstract: |
+    Wake agents on cron beats or idle timers by injecting messages into a
+    running agent — not saved procedures. Add cron schedules, preview next
+    fire times, or set idle triggers with cooldowns. Distinguishes agent
+    schedule from workflow schedule (OS cron) and fleet loop.trigger for
+    unattended squads.
+  context: |
+    ## Cron messages
+    `mur agent schedule add <agent> --cron "30 9 * * 1-5" --message "…" [--sends-to <agent>]`
+    `mur agent schedule list <agent>`
+    `mur agent schedule next <agent> --count 3`
+    `mur agent schedule remove <agent> <index>` (0-based)
+
+    ## Idle triggers
+    `mur agent schedule idle-add <agent> --after-secs 3600 --message "…" [--cooldown-secs 600]`
+    `mur agent schedule idle-list <agent>`
+    `mur agent schedule idle-remove <agent> <index>`
+
+    ## Which scheduler?
+    Agent schedule = message injection into a running agent.
+    `mur workflow schedule` = saved procedure via OS cron.
+    Fleet `loop.trigger` + `MUR_FLEET_AUTORUN` = unattended squads.
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html

--- a/mur-core/src/skills/mur_agent_setup.yaml
+++ b/mur-core/src/skills/mur_agent_setup.yaml
@@ -1,0 +1,43 @@
+name: mur-agent-setup
+category: context
+publisher: human:mur
+version: 1.0.0
+triggers:
+  - type: keyword
+    pattern: "model registry"
+  - type: keyword
+    pattern: "api key"
+  - type: keyword
+    pattern: "mur model"
+description: "Wire up agents: model registry + secrets (StubEcho gotcha), verification; MCP tools and schedules via leaves."
+content:
+  abstract: |
+    A cloud agent created without a registered secret silently degrades into an
+    echo stub — it never calls the model. This skill covers the model registry,
+    the two-step secret setup, and verification commands. Leaf skills
+    mur-agent-mcp-wire and mur-agent-schedule cover MCP tool wiring and
+    cron/idle schedules.
+  context: |
+    ## Model registry
+    `mur model add <alias> --provider anthropic --model <id> --secret env:VAR --tier frontier`
+    Secret refs: `env:VAR` | `keychain:svc/acct` | `file:/path` | `cmd:./script`
+    `mur model list` | `mur model show <alias>` | `mur model remove <alias>`
+    `mur model prices refresh` | `mur model prices show`
+
+    ## Cloud agent = TWO steps (StubEcho gotcha)
+    1. `mur agent create assistant --provider anthropic --model <id>`
+    2. `mur agent secret assistant set ANTHROPIC_API_KEY`
+    Without the secret, the agent silently echoes (StubEcho) instead of
+    calling the model. Diagnose with `mur agent secret <name> list`.
+
+    ## Verify
+    `mur agent status <name>` | `mur agent card <name>` | `mur agent logs <name> --tail 100`
+    `mur agent send` sends raw A2A JSON for a single turn with NO tools —
+    probe only. For real tool use, run `mur agent cli <name>` or `murmur`.
+
+    ## Deep-dive
+    Run `mur skill show mur-agent-mcp-wire` and `mur skill show mur-agent-schedule`
+    for MCP wiring and schedules. Lifecycle (create/stop/restart/export)
+    lives in the `mur-agent-manage` skill.
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html

--- a/mur-core/src/skills/mur_fleet_loop.yaml
+++ b/mur-core/src/skills/mur_fleet_loop.yaml
@@ -1,0 +1,56 @@
+name: mur-fleet-loop
+version: 0.1.0
+publisher: human:mur
+description: "Guarded fleet loops: iteration caps, deadlines, real budgets, done markers, kill-switch, unattended autorun."
+category: context
+visibility: on_demand
+content:
+  abstract: |
+    Fleet loops are guarded, not open-ended: an iteration cap, a wall-clock
+    deadline, a real USD budget, and a done-when marker can each stop a
+    run early. A kill-switch halts loops and blocks autorun; unattended
+    autorun requires an explicit safety triad before it fires on its own.
+  context: |
+    ## Guarded loop
+
+    - `mur fleet run <name> --loop --max-iterations 5 --deadline 30m --budget-usd 5.0`
+
+    `--deadline` is a RELATIVE duration (`30s`/`5m`/`2h`/`1d`), never a
+    calendar date. There is no `--yes` flag for loops. Guards are enforced
+    outside the agents themselves: an iteration cap (default 8), the
+    deadline, stuck-detection, and the budget.
+
+    ## Convergence
+
+    - `mur fleet set-loop <name> --done-when "marker:ALL_GREEN"`
+
+    The loop converges only when a member emits the marker alone on its
+    own line during that run. If `--done-when` is unset, the router judges
+    DONE vs CONTINUE each iteration, fail-safe defaulting to continue.
+
+    ## Budget
+
+    Budget tracking uses real token accounting, summed from Task usage.
+    The cost rate resolves from `MUR_FLEET_COST_PER_1K`, else the highest
+    output rate in `models.yaml`, else a documented default. Iterations
+    reporting zero tokens fall back to a projection so cost is never
+    under-counted.
+
+    ## Kill-switch
+
+    - `mur fleet stop <name>` writes `~/.mur/fleets/<name>/.stopped` — a
+      running loop bails at its next iteration, the daemon skips the
+      fleet, and a manual `run` refuses to start.
+    - `mur fleet start <name>` clears the kill-switch.
+
+    ## Unattended autorun
+
+    - `mur fleet set-loop <name> --trigger interval:30m|"cron:0 9 * * 1-5" --budget-usd 3`
+
+    Autorun requires a safety triad: `MUR_FLEET_AUTORUN=1` (or config
+    `fleet.autorun: true`) AND a per-fleet budget greater than 0 AND the
+    fleet not stopped. A `.last_run` stamp tracks intervals; cron fleets
+    are baseline-stamped on first sight so they never fire spuriously the
+    moment autorun is enabled.
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html

--- a/mur-core/src/skills/mur_fleet_manage.yaml
+++ b/mur-core/src/skills/mur_fleet_manage.yaml
@@ -1,0 +1,56 @@
+name: mur-fleet-manage
+version: 0.1.0
+publisher: human:mur
+description: "Run agent squads on a shared goal — create/show fleets, run iterations, queue jobs; loops/budgets/sharing via leaves."
+category: context
+triggers:
+  - type: keyword
+    pattern: "mur fleet"
+  - type: keyword
+    pattern: "agent squad"
+content:
+  abstract: |
+    Fleets are named agent squads working one shared goal over a single
+    signed fleet-<name> channel with a router. Members must already be
+    running. Runs are fail-closed. Load this body for create/run/queue
+    commands; load the leaf skills for guarded loops, budgets, and
+    sharing/governance.
+  context: |
+    ## Create & inspect
+
+    - `mur fleet create <name> --members pm,qa --router mur --goal "…"`
+    - `mur fleet list`
+    - `mur fleet show <name>`
+    - `mur fleet add <name> <agents…>` / `mur fleet remove <name> <agents…>`
+    - `mur fleet delete <name> --yes`
+
+    Gotchas: `<name>` is a lowercase slug; the `fleet-<name>` channel is
+    created automatically on `create`; member agents are NOT deleted when
+    the fleet is deleted.
+
+    ## Run & queue
+
+    - `mur fleet run <name> ["one-shot job"]`
+    - `mur fleet send <name> "job"`
+    - `mur fleet jobs <name> --all`
+
+    Gotchas: every member must already be running — check with
+    `mur agent status`; queued jobs persist as
+    `~/.mur/fleets/<name>/jobs/<uuidv7>.yaml` and drain FIFO via `run` or
+    the daemon.
+
+    ## Router planning
+
+    Planning runs automatically inside `run`. The router validates the
+    member list, dependencies, and cycles; an invalid plan falls back to
+    broadcast-to-all. Observe planning and execution on the channel at
+    `~/.mur/channels/fleet-<name>/events.jsonl`.
+
+    ## Deep-dive
+
+    - `mur skill show mur-fleet-loop` — guarded loops, budgets,
+      kill-switch, unattended autorun
+    - `mur skill show mur-fleet-share` — signed .fleet bundles and
+      commander governance
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html

--- a/mur-core/src/skills/mur_fleet_share.yaml
+++ b/mur-core/src/skills/mur_fleet_share.yaml
@@ -1,0 +1,37 @@
+name: mur-fleet-share
+version: 0.1.0
+publisher: human:mur
+description: "Share fleets as signed .fleet bundles and govern them with commander kill/budget directives."
+category: context
+visibility: on_demand
+content:
+  abstract: |
+    Fleets export as signed .fleet bundles for import elsewhere — verified,
+    security-scanned, installed at low trust, never overwriting existing
+    agents or auto-running. A pinned commander key can then issue signed
+    kill/resume/budget-ceiling directives that govern a fleet's loops.
+  context: |
+    ## Share bundles
+
+    - `mur fleet export <name> --with-members -o <name>.fleet`
+    - `mur fleet import <file> [--force] [--no-members] [--yes]`
+
+    Import verifies the bundle signature, security-scans included skills,
+    installs at the lowest trust level (peer TOFU), and regenerates member
+    agent identities — private keys are never copied. Import never
+    overwrites an existing agent or fleet of the same name unless
+    `--force`, and never auto-runs the imported fleet.
+
+    ## Commander governance
+
+    - `mur commander pin <pubkey> [--force]`
+    - `mur commander status`
+    - `mur commander directive <fleet> kill|resume|budget-ceiling --budget-usd 2.50`
+
+    Directives are Ed25519-signed channel events. `kill` halts running
+    loops and blocks autorun; `resume` clears it. A `budget-ceiling` of
+    0.0 is a hard halt; any other value is min'd against the fleet's own
+    and any CLI-supplied budget. Governance folding is fail-closed: a
+    channel read error refuses rather than silently allowing the run.
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html

--- a/mur-core/src/skills/mur_parallel_exec.yaml
+++ b/mur-core/src/skills/mur_parallel_exec.yaml
@@ -1,0 +1,42 @@
+name: mur-parallel-exec
+version: 1.0.0
+publisher: human:mur
+description: "Map a chosen topology to the MUR command that executes it — fan-out, tracks, partition, merges, parallel_jobs."
+category: context
+triggers:
+  - type: keyword
+    pattern: "parallel"
+  - type: keyword
+    pattern: "fan out"
+content:
+  abstract: |
+    parallel-decompose picks the topology; this skill maps each topology to the MUR mechanism and command; body holds the matrix and the parallel_jobs allowlist config.
+  context: |
+    ## Topology → command matrix
+    - DAG rank fan-out → same-rank steps in a workflow skill.
+    - Delegation fan-out → delegate_to + --channel-new.
+    - Fleet broadcast → mur fleet run.
+    - Routed plan → automatic inside run.
+    - Ephemeral fan-out → parallel_jobs MCP tool.
+    - Speculative tracks → mur fleet run --worktree + judge/cherry.
+    - Partition → partition-plan / merge.
+    - Concurrent merge → merge-concurrent.
+    Coherence-bound work stays with ONE agent.
+
+    ## parallel_jobs (ephemeral fan-out)
+    Allowlist REQUIRED in ~/.mur/config.yaml:
+    ```
+    parallel_jobs:
+      targets: [pm, qa]
+    ```
+    Deny-by-default, checked before any channel is minted.
+    Call shape: jobs: [{description, agent?}] (1–32), optional default agent,
+    max_concurrency 1–32 (default 8), yes (default false, fail-closed).
+    Returns {channel_id, output}.
+    vs fleet: N distinct one-shot prompts vs one standing loopable goal.
+
+    ## Deep-dive
+    Run `mur skill show mur-parallel-tracks`, `mur skill show mur-parallel-merge`,
+    `mur skill show parallel-topology-guide`.
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html

--- a/mur-core/src/skills/mur_parallel_merge.yaml
+++ b/mur-core/src/skills/mur_parallel_merge.yaml
@@ -1,0 +1,24 @@
+name: mur-parallel-merge
+version: 1.0.0
+publisher: human:mur
+description: "Reassemble parallel work: deterministic partition merges and experimental concurrent N-way merges."
+category: context
+visibility: on_demand
+content:
+  abstract: |
+    Reassemble output from parallel fan-out: deterministic partition merges for disjoint-file splits, and an experimental concurrent N-way merge that reports overlaps instead of silently merging them.
+  context: |
+    ## Partition mode
+    parallel.mode: partition plus partition: {target_file: src/widget.rs}.
+    Preview `mur fleet partition-plan <name>` (from repo root); run `--worktree`;
+    reassemble `mur fleet merge <name> --promote [--target <repo>]` —
+    deterministic, no LLM in the merge.
+
+    ## Concurrent N-way merge (experimental)
+    `MUR_PARALLEL_CONCURRENT=1 mur fleet merge-concurrent <name> [--stats] [--promote] [--target <repo>]`.
+    Disjoint hunks auto-merge order-independently; overlaps are REPORTED, never
+    silently merged; --promote refuses on unresolved overlaps, runs cargo check
+    in the destination and reverts on failure; results staged in
+    ~/.mur/fleets/<name>/cherry-result/.
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html

--- a/mur-core/src/skills/mur_parallel_tracks.yaml
+++ b/mur-core/src/skills/mur_parallel_tracks.yaml
@@ -1,0 +1,42 @@
+name: mur-parallel-tracks
+version: 1.0.0
+publisher: human:mur
+description: "Speculative best-of-N: isolated worktree tracks per approach, judge scoring, cherry promotion."
+category: context
+visibility: on_demand
+content:
+  abstract: |
+    Run speculative best-of-N tracks in isolated git worktrees, one per approach, then score with a judge rubric and cherry-pick the winner into the target repo.
+  context: |
+    ## parallel: block (fleet.yaml, hand-edit)
+    ```
+    parallel:
+      mode: speculative
+      tracks:
+        - name: <track>
+          approach: <approach>
+          model: <model?>
+      judge:
+        model: <model>
+        rubric:
+          correctness: 0.40
+          design: 0.30
+          maintainability: 0.20
+          security: 0.10
+      pre_filter: [cargo_check|cargo_clippy_deny]
+    ```
+    NO max_concurrency field — fan-out auto-caps at min(tracks, cores−2).
+
+    ## Run in worktrees
+    `mur fleet run <name> --worktree` (or MUR_PARALLEL_EXEC=1).
+    One-shot only — incompatible with --loop; requires a git repo root +
+    parallel: block. Creates .worktrees/<track>/ + .parallel-base + tracks.json;
+    a collision guard reports strays into the main checkout; worktrees persist
+    after the run.
+
+    ## Pick a winner
+    `mur fleet compare <name> [--unit <prefix>]`;
+    `mur fleet judge <name> --stats`;
+    `mur fleet cherry <name> --auto --promote --target <repo>`.
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html

--- a/mur-core/src/skills/mur_workflow_author.yaml
+++ b/mur-core/src/skills/mur_workflow_author.yaml
@@ -1,0 +1,75 @@
+name: mur-workflow-author
+version: 0.1.0
+publisher: human:mur
+description: "Author and run MUR workflows — flat sequences vs DAG skills, scheduling; HITL and delegation via leaves."
+category: context
+hosts: [all]
+content:
+  abstract: |
+    Two different things share the name "workflow": flat step sequences
+    (`mur workflow`) and DAG-based workflow skills. Only workflow skills
+    support DAG procedures, human-in-the-loop gates, and agent delegation.
+    Know which one you're authoring before you reach for those features.
+  context: |
+    # Authoring MUR Workflows
+
+    ## Two kinds (critical)
+    MUR has two things people call "workflows":
+    1. **Flat workflows** (`mur workflow`) — an ordered list of steps
+       saved from a session or written by hand. No branching, no HITL,
+       no delegation. Good for repeatable checklists.
+    2. **Workflow skills** — regular skills whose `content` encodes a
+       **DAG procedure** (nodes + edges). These are the only ones that
+       support conditional branching, human-in-the-loop approval gates,
+       and delegation of individual steps to other agents. If a task
+       needs a pause-for-approval step or fan-out to a specialist agent,
+       it must be a workflow skill, not a flat workflow.
+
+    ## Run
+    - `mur workflow show <name> --md` — view variables / tools / steps
+      of a flat workflow.
+    - `mur run <name>` — produce a ready-to-execute prompt for a flat
+      workflow or trigger a workflow skill by name.
+    - `mur workflow list` — enumerate saved flat workflows.
+
+    ## DAG procedure schema
+    A workflow-skill DAG procedure is expressed as:
+    ```
+    content:
+      procedure:
+        nodes:
+          - id: step_id
+            kind: task | approval | delegate
+            agent: <optional target agent for delegate nodes>
+        edges:
+          - from: step_id
+            to: next_step_id
+            when: <optional condition expression>
+    ```
+    `kind: approval` nodes pause execution for a human decision (see the
+    HITL companion doc). `kind: delegate` nodes hand the step to another
+    agent over A2A (see the delegation companion doc).
+
+    ## Schedule
+    Flat workflows and workflow skills can both be scheduled:
+    - `mur workflow schedule <name> --cron "<expr>"` — recurring runs.
+    - `mur workflow schedule <name> --at <time>` — one-shot run.
+    Scheduled runs execute non-interactively; any approval node in a
+    scheduled workflow skill still pauses and waits, so scheduling a
+    workflow with unresolved HITL gates just defers the wait, not the
+    approval itself.
+
+    ## Deep-dive
+    For risk-tiered approval gates, see the workflow-hitl doc. For
+    fan-out to specialist agents and trust/signing model, see the
+    workflow-delegate doc. Both are loaded on demand, not injected by
+    default, to keep this context lean.
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html
+tags: [mur, workflow, context]
+priority: normal
+triggers:
+  - type: keyword
+    pattern: "workflow"
+  - type: keyword
+    pattern: "mur workflow"

--- a/mur-core/src/skills/mur_workflow_delegate.yaml
+++ b/mur-core/src/skills/mur_workflow_delegate.yaml
@@ -1,0 +1,42 @@
+name: mur-workflow-delegate
+version: 0.1.0
+publisher: human:mur
+description: "Fan workflow steps out to specialist agents over A2A with signed, attributable replies."
+category: context
+visibility: on_demand
+hosts: [all]
+content:
+  abstract: |
+    Workflow-skill DAG nodes of kind `delegate` hand a step to another
+    agent over A2A instead of running it locally. Replies are signed
+    and attributable, so a delegated result's origin is always
+    verifiable before it's folded back into the run.
+  context: |
+    # Delegating Workflow Steps to Agents
+
+    ## Delegate steps
+    A `kind: delegate` node names a target `agent:` and a payload
+    (typically the node's own inputs/context). MUR sends the step over
+    A2A to that agent, marks the node as `awaiting_reply`, and blocks
+    the DAG edge until a reply arrives or the step times out. Delegate
+    nodes can run in parallel with independent branches of the DAG.
+
+    ## Trust model
+    Every A2A message and reply is signed by its originating agent's
+    key. The workflow engine verifies the signature before accepting a
+    delegate reply and records the signer identity alongside the result.
+    Unsigned or unverifiable replies are rejected and the node fails
+    rather than silently accepting untrusted output.
+
+    ## Observe
+    - `mur workflow show <run-id> --md` — see which nodes are delegated,
+      to whom, and their current state (awaiting_reply / done / failed).
+    - `mur agent inbox` — view pending delegate requests addressed to
+      the local agent.
+    - Delegate results are attributed in run history: each folded-back
+      result carries the signer identity, not just the node id, so
+      downstream review can trace exactly which agent produced it.
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html
+tags: [mur, workflow, delegate, context]
+priority: normal

--- a/mur-core/src/skills/mur_workflow_hitl.yaml
+++ b/mur-core/src/skills/mur_workflow_hitl.yaml
@@ -1,0 +1,53 @@
+name: mur-workflow-hitl
+version: 0.1.0
+publisher: human:mur
+description: "Risk-tiered human approval gates on channel workflow runs: pause, approve/deny, resume."
+category: context
+visibility: on_demand
+hosts: [all]
+content:
+  abstract: |
+    Workflow-skill DAGs can include approval nodes that pause a run and
+    wait on a human. Gates are risk-tiered so low-risk steps auto-pass
+    while high-risk ones require an explicit approve/deny before the
+    workflow resumes.
+  context: |
+    # Human-in-the-Loop Workflow Gates
+
+    ## Risk tiers
+    Approval nodes declare a risk tier that decides who must respond
+    and how long the run will wait:
+    - **low** — informational; auto-approved unless a reviewer opts in.
+    - **medium** — requires one approval from any authorized reviewer.
+    - **high** — requires explicit approval from a named owner/role;
+      no timeout auto-approve.
+    Tier is set per-node in the DAG (`kind: approval`, `risk: low |
+    medium | high`).
+
+    ## Channel runs
+    When a workflow skill with approval nodes runs, MUR posts the
+    pending decision to the configured channel (chat, CLI session, or
+    notification target) attached to that run. The message includes
+    the step context, the risk tier, and the exact command to respond.
+    Multiple concurrent runs are distinguishable by run ID in the
+    channel message.
+
+    ## Approve
+    - `mur workflow approve <run-id> [--step <id>]` — approve the
+      pending gate and let the DAG proceed to its next edge.
+    - `mur workflow deny <run-id> [--step <id>] [--reason "<text>"]` —
+      deny the gate; the run transitions to a failed/blocked state and
+      does not continue past that node.
+
+    ## Resume & auto
+    - `mur workflow resume <run-id>` — after approval, resumes execution
+      from the paused node if it didn't auto-continue.
+    - Low-tier gates may be configured with `auto_approve_after: <dur>`
+      to proceed automatically if no human responds within the window;
+      medium/high tiers never auto-approve regardless of timeout.
+    - A denied or timed-out high-tier gate leaves the run paused for
+      manual intervention rather than auto-failing silently.
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html
+tags: [mur, workflow, hitl, context]
+priority: normal

--- a/mur-core/src/skills/parallel_code.yaml
+++ b/mur-core/src/skills/parallel_code.yaml
@@ -1,25 +1,11 @@
 name: parallel-code
 version: 0.1.0
 publisher: human:mur
-description: "Decide whether a coding task should be fanned out across parallel coder sub-agents. Default is a single coherent writer; propose parallel ONLY for disjoint, mechanical, contract-pinned work, and only after the user approves."
+description: "Decide whether a coding task should fan out across parallel coder sub-agents — default is a single writer."
 category: workflow
 content:
   abstract: |
-    Most coding tasks should NOT be parallelized — default to one single-threaded
-    coherent writer. Use this to recognize the narrow class that genuinely benefits
-    and, only then, PROPOSE a parallel fan-out for the user's approval before running.
-
-    Single-writer principle (why serial is the default): parallel code WRITERS make
-    conflicting, context-starved decisions — mismatched styles, duplicated helpers,
-    semantic contradictions that compile + lint clean but break at runtime; a clean
-    textual merge is NOT proof of correctness. Both canonical sources converge:
-    Anthropic's multi-agent research system wins on breadth-first READ tasks and
-    explicitly excludes most coding; Cognition's "Don't Build Multi-Agents" attacks
-    parallel writers (the Flappy-Bird trap — mismatched styles). Both land on: fan
-    out reads/analysis/review, keep WRITES single-threaded — UNLESS the work is
-    genuinely disjoint files + mechanical, behind a contract frozen BEFORE fan-out
-    (N unrelated adapters, per-module boilerplate, a mechanical cross-file refactor)
-    — never one design whose pieces must share architectural taste.
+    Propose parallel coders ONLY for disjoint, mechanical, contract-pinned work, and only after user approval; otherwise keep one coherent writer. Load parallel-topology-guide for the criteria and escalation rules.
   procedure:
     steps:
       - description: "DEFAULT: do the change single-threaded. Only even consider parallel when the task is large AND obviously spans many files."

--- a/mur-core/src/skills/parallel_decompose.yaml
+++ b/mur-core/src/skills/parallel_decompose.yaml
@@ -1,32 +1,11 @@
 name: parallel-decompose
 version: 0.1.0
 publisher: human:mur
-description: "Classify ANY task's TOPOLOGY before deciding how to do it — explore (read/gather → fan out, recombine by union or careful synthesis), compete (best-of-N at one goal → fan out, SELECT with an independent judge), coupled-write (interdependent edits → serialize unless disjoint + contract-frozen, escalate overlaps), or coherence-bound (one shared-taste design → single writer). Parallelism as the default decomposition lens, gated read-parallelize / write-serialize."
+description: "Classify a task's topology (explore/compete/coupled-write/coherence-bound) before choosing serial or parallel."
 category: workflow
 content:
   abstract: |
-    Before deciding HOW to do a task, classify WHY it can (or cannot) be
-    parallelized — by its TOPOLOGY, not its domain. The hard part is
-    RECOMBINATION, not isolation: worktrees solve filesystem conflicts
-    trivially; the risk and the value are both in combining results.
-
-    Four topologies:
-    - explore (read/gather: search, find files, find content, collect evidence)
-      → outputs are ADDITIVE → fan out freely (no worktree) → recombine by
-      union/dedupe (collect) or careful synthesis (reduce).
-    - compete (best-of-N at the SAME goal: design variants, N approaches)
-      → outputs COMPETE → fan out N heterogeneous attempts → SELECT the best with
-      an INDEPENDENT judge. Never merge competing rewrites; never run a debate.
-    - coupled-write (editing interdependent code/state) → outputs CONFLICT →
-      serialize UNLESS disjoint files + contract frozen first → escalate overlaps.
-    - coherence-bound (one design whose pieces share architectural taste, or a
-      sequential dependency) → DO NOT parallelize → one coherent writer.
-
-    Grounding: Anthropic multi-agent research (breadth +90%, ~15x tokens, excludes
-    most coding); Cognition "Don't Build Multi-Agents" (share CONTEXT not STATE; the
-    Flappy-Bird trap of mismatched parallel writers); MAST (~79% of multi-agent
-    failures are specification + coordination, impossible single-agent);
-    Lost-in-the-Middle (naive concatenation of N results under-attends the middle).
+    Before decomposing any task, classify its topology: explore (fan out reads), compete (best-of-N with a judge), coupled-write (serialize unless disjoint), coherence-bound (single writer). Load parallel-topology-guide for the full method; mur-parallel-exec maps topologies to MUR commands.
   procedure:
     steps:
       - description: |

--- a/mur-core/src/skills/parallel_topology_guide.yaml
+++ b/mur-core/src/skills/parallel_topology_guide.yaml
@@ -1,0 +1,57 @@
+name: parallel-topology-guide
+version: 0.1.0
+publisher: human:mur
+description: "Full methodology behind parallel-decompose and parallel-code — load on demand when applying the topology lens."
+category: note
+visibility: on_demand
+content:
+  abstract: "Displaced methodology from the two parallel skills; load when you need the full criteria."
+  note: |
+    ## From parallel-decompose
+
+    Classify ANY task's TOPOLOGY before deciding how to do it — explore (read/gather → fan out, recombine by union or careful synthesis), compete (best-of-N at one goal → fan out, SELECT with an independent judge), coupled-write (interdependent edits → serialize unless disjoint + contract-frozen, escalate overlaps), or coherence-bound (one shared-taste design → single writer). Parallelism as the default decomposition lens, gated read-parallelize / write-serialize.
+
+    Before deciding HOW to do a task, classify WHY it can (or cannot) be
+    parallelized — by its TOPOLOGY, not its domain. The hard part is
+    RECOMBINATION, not isolation: worktrees solve filesystem conflicts
+    trivially; the risk and the value are both in combining results.
+
+    Four topologies:
+    - explore (read/gather: search, find files, find content, collect evidence)
+      → outputs are ADDITIVE → fan out freely (no worktree) → recombine by
+      union/dedupe (collect) or careful synthesis (reduce).
+    - compete (best-of-N at the SAME goal: design variants, N approaches)
+      → outputs COMPETE → fan out N heterogeneous attempts → SELECT the best with
+      an INDEPENDENT judge. Never merge competing rewrites; never run a debate.
+    - coupled-write (editing interdependent code/state) → outputs CONFLICT →
+      serialize UNLESS disjoint files + contract frozen first → escalate overlaps.
+    - coherence-bound (one design whose pieces share architectural taste, or a
+      sequential dependency) → DO NOT parallelize → one coherent writer.
+
+    Grounding: Anthropic multi-agent research (breadth +90%, ~15x tokens, excludes
+    most coding); Cognition "Don't Build Multi-Agents" (share CONTEXT not STATE; the
+    Flappy-Bird trap of mismatched parallel writers); MAST (~79% of multi-agent
+    failures are specification + coordination, impossible single-agent);
+    Lost-in-the-Middle (naive concatenation of N results under-attends the middle).
+
+    ## From parallel-code
+
+    Decide whether a coding task should be fanned out across parallel coder sub-agents. Default is a single coherent writer; propose parallel ONLY for disjoint, mechanical, contract-pinned work, and only after the user approves.
+
+    Most coding tasks should NOT be parallelized — default to one single-threaded
+    coherent writer. Use this to recognize the narrow class that genuinely benefits
+    and, only then, PROPOSE a parallel fan-out for the user's approval before running.
+
+    Single-writer principle (why serial is the default): parallel code WRITERS make
+    conflicting, context-starved decisions — mismatched styles, duplicated helpers,
+    semantic contradictions that compile + lint clean but break at runtime; a clean
+    textual merge is NOT proof of correctness. Both canonical sources converge:
+    Anthropic's multi-agent research system wins on breadth-first READ tasks and
+    explicitly excludes most coding; Cognition's "Don't Build Multi-Agents" attacks
+    parallel writers (the Flappy-Bird trap — mismatched styles). Both land on: fan
+    out reads/analysis/review, keep WRITES single-threaded — UNLESS the work is
+    genuinely disjoint files + mechanical, behind a contract frozen BEFORE fan-out
+    (N unrelated adapters, per-module boilerplate, a mechanical cross-file refactor)
+    — never one design whose pieces must share architectural taste.
+
+    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html


### PR DESCRIPTION
Content half of the progressive-disclosure spec (stacked on #589 — retarget to main after it merges, merge #589 with a MERGE COMMIT):

- **4 indexed hubs**: `mur-fleet-manage`, `mur-workflow-author`, `mur-agent-setup`, `mur-parallel-exec` — the learning index grows by exactly 4 lines
- **8 on-demand leaves** + `parallel-topology-guide`: fleet loop/share, workflow hitl/delegate, agent mcp-wire/schedule, parallel tracks/merge — loadable via `mur skill show`, hidden from the index
- `parallel-decompose`/`parallel-code` slimmed to budget (464→110 / 224→106 desc chars; 198→35 / 151→27 abstract words), methodology preserved verbatim in the guide
- Budgets regression test over all 15 files (desc ≤120 chars, abstract ≤50 words, body ≤150 lines, visibility roster)

Verified: `mur skill validate` ok ×13; sandbox-HOME dogfood via `mur init` → 29 installed, exactly 9 `[on-demand]` markers; nextest/clippy/fmt green (known-unrelated env failures documented in issues).

Found during dogfood: `mur sync` early-returns before `ensure_mur_skill` on a pristine home (built-ins never install on first run via sync; `mur init` path unaffected) — issue to follow.

Built by the skillsmith MUR fleet (pm/qa/rustsmith, router=orchestrator), supervised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)