### PR TITLE
fix(sync): pristine home never installs built-in skills (#593)

### DIFF
--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -904,6 +904,15 @@ pub(crate) async fn cmd_sync(quiet: bool, project_aware: bool, team: Option<&str
         eprintln!("  ⚠ Device sync error: {}", e);
     }
 
+    // Ensure built-in skills are installed BEFORE loading the corpus — on a
+    // pristine home the corpus is empty and the early return below would
+    // otherwise skip installation forever (issue #593).
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("HOME directory not found"))?;
+    let skill_installed = ensure_mur_skill(&home)?;
+    if !quiet && skill_installed {
+        println!("  🎓 MUR skill installed/updated for AI tools");
+    }
+
     // Skills are the sync content source (workflow-engine v2 P1b).
     let mur_dir = mur_common::trust::mur_home();
     let candidates =
@@ -965,13 +974,6 @@ pub(crate) async fn cmd_sync(quiet: bool, project_aware: bool, team: Option<&str
                 target_path.display()
             );
         }
-    }
-
-    // ─── Ensure skills are installed ───────────────────────────
-    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("HOME directory not found"))?;
-    let skill_installed = ensure_mur_skill(&home)?;
-    if !quiet && skill_installed {
-        println!("  🎓 MUR skill installed/updated for AI tools");
     }
 
     // ─── Auto-reindex if dirty ───────────────────────────────


### PR DESCRIPTION
**Bug (#593):** `cmd_sync` early-returns with 'No skills to sync.' when the skill corpus is empty — exactly the state of a fresh install — so `ensure_mur_skill` was unreachable via `mur sync` on first run and built-ins never installed (chicken-and-egg; the `mur init` path was unaffected).

**Fix:** move the ensure block ahead of the corpus load (and drop the now-duplicate later block). Freshly installed built-ins then flow into the same sync pass instead of requiring a second run.

**Verification:**
- E2E: pristine `$HOME` + `mur sync` → 29 skills installed, sync completes (before: 0 installed, early return)
- `cargo nextest -p mur-core sync_cmd`: 3/3 · clippy 0 · fmt clean

Noted while here (not addressed): `ensure_mur_skill` installs to `~/.mur` via `dirs::home_dir()` while the corpus loads via `mur_common::trust::mur_home()` (respects `MUR_HOME`) — divergent roots if `MUR_HOME` is set; worth a follow-up.

Built by the skillsmith MUR fleet (rustsmith), supervised.

Fixes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)