### PR TITLE
fix(rollup): embed-dim split-brain between writer and rollup paths (#594)

### DIFF
--- a/mur-core/src/conversations/summarize/rollup.rs
+++ b/mur-core/src/conversations/summarize/rollup.rs
@@ -122,7 +122,12 @@ pub async fn rollup_week(
         .timestamp();
 
     let cfg_loaded = crate::store::config::load_config().ok().unwrap_or_default();
-    let embed_cfg = crate::store::embedding::EmbeddingConfig::from_config(&cfg_loaded);
+    let mut embed_cfg = crate::store::embedding::EmbeddingConfig::from_config(&cfg_loaded);
+    // Pin to the layer-2 writer's default (summarize/mod.rs): the index is
+    // created at 1024 dims, so honoring a different config dim here
+    // split-brains the index and fails every weekly rollup (issue #594).
+    // Phase 3 unifies BOTH paths via cfg.
+    embed_cfg.dimensions = 1024;
     let embed_dims = embed_cfg.dimensions as i32;
     let idx =
         crate::conversations::index::ConversationIndex::open(embed_dims, root_override).await?;
@@ -373,7 +378,12 @@ pub async fn rollup_month(
         .timestamp();
 
     let cfg_loaded = crate::store::config::load_config().ok().unwrap_or_default();
-    let embed_cfg = crate::store::embedding::EmbeddingConfig::from_config(&cfg_loaded);
+    let mut embed_cfg = crate::store::embedding::EmbeddingConfig::from_config(&cfg_loaded);
+    // Pin to the layer-2 writer's default (summarize/mod.rs): the index is
+    // created at 1024 dims, so honoring a different config dim here
+    // split-brains the index and fails every weekly rollup (issue #594).
+    // Phase 3 unifies BOTH paths via cfg.
+    embed_cfg.dimensions = 1024;
     let embed_dims = embed_cfg.dimensions as i32;
     let idx =
         crate::conversations::index::ConversationIndex::open(embed_dims, root_override).await?;


### PR DESCRIPTION
**Diagnosis journey:** the two rollup test failures were first suspected as date-rot, then timezone (CI/UTC green, local UTC+8 red) — the `--no-capture` panic finally showed the truth: `lance error: Append with different schema: vector … 1024 … was 2560`. `rollup_week`/`rollup_month` read embedding dims from the USER's global config while the layer-2 writer hardcodes 1024 — a machine with a 2560-dim embedding config fails every weekly/monthly rollup **in production**, not just tests. CI was green only because CI has no user config.

**Fix:** pin both rollup paths to the writer's default (1024) with a comment pointing at the Phase-3 unification. The fleet's CHECK step caught the `rollup_month` twin site beyond the specced `rollup_week`.

**Verification:** full rollup family 38/38 on this 2560-dim machine (previously 2 hard failures); fmt clean. Completes #594 together with the merged part A (#601, hermetic worktree tests).

Built by the skillsmith MUR fleet (rustsmith), supervised. Fixes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)