### PR TITLE
feat(fleet): delegate reply contract + iteration-cap marker (#595)

### DIFF
--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1601,7 +1601,7 @@ impl TaskRunner {
             max_tokens: None,
             tools: vec![], // tools disabled: force a textual summary
         };
-        match client.generate(req).await {
+        let mut text = match client.generate(req).await {
             Ok(resp) => {
                 self.cumulative_input_tokens
                     .fetch_add(resp.input_tokens, std::sync::atomic::Ordering::Relaxed);
@@ -1609,20 +1609,24 @@ impl TaskRunner {
                     .store(resp.input_tokens, std::sync::atomic::Ordering::Relaxed);
                 self.cumulative_output_tokens
                     .fetch_add(resp.output_tokens, std::sync::atomic::Ordering::Relaxed);
-                Message {
-                    role: "agent".into(),
-                    parts: vec![mur_common::a2a::MessagePart::Text { text: resp.text }],
-                }
+                resp.text
             }
             Err(_) => {
                 // Never lose work: return the last assistant text from history.
-                let text = last_assistant_text(history)
-                    .unwrap_or_else(|| format!("Stopped: {} budget reached.", reason.as_str()));
-                Message {
-                    role: "agent".into(),
-                    parts: vec![mur_common::a2a::MessagePart::Text { text }],
-                }
+                last_assistant_text(history)
+                    .unwrap_or_else(|| format!("Stopped: {} budget reached.", reason.as_str()))
             }
+        };
+        // #595: mark output that ended at the iteration cap so partial
+        // execution is visible instead of silently reported as clean.
+        if matches!(reason, LoopStop::MaxIterations) {
+            text.push_str(
+                "\n\n[runtime: turn ended at the iteration cap — output may be incomplete]",
+            );
+        }
+        Message {
+            role: "agent".into(),
+            parts: vec![mur_common::a2a::MessagePart::Text { text }],
         }
     }
 }
@@ -2890,6 +2894,43 @@ mod tests {
                  result_ids={result_ids:?}"
             );
         }
+    }
+
+    /// #595 — graceful_exit must append the iteration-cap marker to the
+    /// output text ONLY when the stop reason is `MaxIterations`, so partial
+    /// execution at the cap is visible instead of looking like a clean
+    /// completion. A sibling reason (`LoopDetected`) must NOT carry it.
+    #[tokio::test]
+    async fn graceful_exit_marks_output_only_at_iteration_cap() {
+        use crate::llm::stub::SequenceLlm;
+        let client: Arc<dyn crate::llm::LlmClient> = Arc::new(SequenceLlm::new(vec![
+            end_turn_response("partial work done"),
+            end_turn_response("partial work done"),
+        ]));
+        let runner = TaskRunner::with_llm(client.clone());
+        let history = vec![crate::llm::RichMessage::Text {
+            role: "user".into(),
+            content: "do the thing".into(),
+        }];
+
+        let capped = runner
+            .graceful_exit(client.as_ref(), &history, LoopStop::MaxIterations)
+            .await;
+        assert!(
+            text_of(&capped)
+                .contains("[runtime: turn ended at the iteration cap — output may be incomplete]"),
+            "MaxIterations exit must carry the iteration-cap marker: {}",
+            text_of(&capped)
+        );
+
+        let other = runner
+            .graceful_exit(client.as_ref(), &history, LoopStop::LoopDetected)
+            .await;
+        assert!(
+            !text_of(&other).contains("iteration cap"),
+            "LoopDetected exit must NOT carry the iteration-cap marker: {}",
+            text_of(&other)
+        );
     }
 
     #[test]

--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -23,6 +23,10 @@ use mur_common::skill::manifest::{FailureAction, Procedure, ProcedureStep};
 use sha2::{Digest, Sha256};
 use tokio::time::{Duration, sleep, timeout as tokio_timeout};
 
+/// Appended to every delegated sub-goal so partial execution is declared
+/// instead of silent (issue #595).
+pub const DELEGATE_REPLY_CONTRACT: &str = "\n\n---\nReply contract: end with a 'Completion:' checklist naming EVERY requested item as done / skipped / blocked. If you run low on turns, deliver partial work and declare the shortfall — never report clean completion over partial execution.";
+
 /// Options for a single DAG execution.
 pub struct DagExecOptions<'a> {
     /// Piped input from a previous pipeline stage (for `{{input}}` substitution).
@@ -87,6 +91,7 @@ fn build_channel_delegate_params(
     child_task_id: &str,
     idempotency_key: &str,
 ) -> serde_json::Value {
+    let text = format!("{}{}", text, DELEGATE_REPLY_CONTRACT);
     serde_json::json!({
         "message": { "role": "user", "parts": [{ "kind": "text", "text": text }] },
         "channel_id": channel_id,
@@ -1001,7 +1006,9 @@ mod tests {
         assert_eq!(p["task_id"], "child-1");
         assert_eq!(p["idempotency_key"], "rk-deadbeef");
         assert_eq!(p["message"]["role"], "user");
-        assert_eq!(p["message"]["parts"][0]["text"], "find the bug");
+        let text = p["message"]["parts"][0]["text"].as_str().unwrap();
+        assert!(text.starts_with("find the bug"));
+        assert!(text.contains("Completion:"));
     }
 
     #[test]


### PR DESCRIPTION
Two shallow visibility fixes for silent partial execution: (1) every delegate message appends a reply contract (per-item Completion checklist, declare shortfalls); (2) `graceful_exit` marks output that ended at the iteration cap. dag 26/26, task_runner 34/34, fmt clean. Built by the skillsmith MUR fleet (qa), supervised. Fixes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)