### PR TITLE
feat(runtime): write_file + edit_file tools (#591 PR2)

### DIFF
--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -289,10 +289,24 @@ pub async fn build_provider_runner(
             profile.inner.entitlements.filesystem.clone(),
         ));
     let read_file_def = read_file_exec.def();
+    let write_file_exec: Arc<dyn crate::tools::ToolExecutor> =
+        Arc::new(crate::tools::write_file::WriteFileTool::new(
+            agent_home.to_path_buf(),
+            profile.inner.entitlements.filesystem.clone(),
+        ));
+    let write_file_def = write_file_exec.def();
+    let edit_file_exec: Arc<dyn crate::tools::ToolExecutor> =
+        Arc::new(crate::tools::edit_file::EditFileTool::new(
+            agent_home.to_path_buf(),
+            profile.inner.entitlements.filesystem.clone(),
+        ));
+    let edit_file_def = edit_file_exec.def();
     let tools_policy = profile.inner.entitlements.tools.clone();
     let (_defs, tool_map) = build_tools(
         Some((bash_def, bash_exec)),
         Some((read_file_def, read_file_exec)),
+        Some((write_file_def, write_file_exec)),
+        Some((edit_file_def, edit_file_exec)),
         &enabled_mcp,
         &tools_policy,
         pool.clone(),

--- a/mur-agent-runtime/src/tools/edit_file.rs
+++ b/mur-agent-runtime/src/tools/edit_file.rs
@@ -1,0 +1,185 @@
+//! First-party exact-literal edit tool (issue #591, PR2). No regex —
+//! ambiguity fails closed instead of guessing.
+
+use std::path::{Path, PathBuf};
+
+use mur_common::agent::FilesystemEntitlement;
+
+use crate::llm::ToolDef;
+use crate::tools::fs_policy::check_write_entitlement;
+use crate::tools::{ToolError, ToolExecutor};
+
+pub struct EditFileTool {
+    pub working_dir: PathBuf,
+    pub fs: FilesystemEntitlement,
+}
+
+impl EditFileTool {
+    pub fn new(working_dir: PathBuf, fs: FilesystemEntitlement) -> Self {
+        Self { working_dir, fs }
+    }
+}
+
+#[async_trait::async_trait]
+impl ToolExecutor for EditFileTool {
+    fn name(&self) -> &str {
+        "edit_file"
+    }
+
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: "edit_file".into(),
+            description: "Replace an exact literal substring in a UTF-8 text file (no regex). By default the old_string must match exactly once — pass expected_count to replace N known occurrences. Edits are checked against the agent's filesystem write entitlements."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "File to edit (absolute, or relative to the agent working dir)" },
+                    "old_string": { "type": "string", "description": "Exact literal text to replace" },
+                    "new_string": { "type": "string", "description": "Replacement text" },
+                    "expected_count": { "type": "integer", "description": "Exact number of occurrences to replace; omit to require exactly one" }
+                },
+                "required": ["path", "old_string", "new_string"]
+            }),
+        }
+    }
+
+    async fn execute(&self, input: serde_json::Value) -> Result<String, ToolError> {
+        let raw = input["path"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("missing 'path' field".into()))?;
+        let old = input["old_string"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("missing 'old_string' field".into()))?;
+        let new = input["new_string"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("missing 'new_string' field".into()))?;
+        if old.is_empty() {
+            return Err(ToolError::InvalidInput(
+                "'old_string' must be non-empty".into(),
+            ));
+        }
+        let joined = if Path::new(raw).is_absolute() {
+            PathBuf::from(raw)
+        } else {
+            self.working_dir.join(raw)
+        };
+        let canonical = std::fs::canonicalize(&joined)
+            .map_err(|e| ToolError::Execution(format!("cannot edit {}: {e}", joined.display())))?;
+        check_write_entitlement(&self.fs, &canonical)?;
+
+        let text = std::fs::read_to_string(&canonical).map_err(|e| {
+            ToolError::Execution(format!("cannot read {}: {e}", canonical.display()))
+        })?;
+        let found = text.match_indices(old).count();
+        let expected = input["expected_count"].as_i64().filter(|v| *v >= 1);
+        match expected {
+            Some(n) if found as i64 != n => {
+                return Err(ToolError::InvalidInput(format!(
+                    "expected {n} occurrence(s) of old_string, found {found}"
+                )));
+            }
+            None if found == 0 => {
+                return Err(ToolError::InvalidInput("old_string not found".into()));
+            }
+            None if found > 1 => {
+                return Err(ToolError::InvalidInput(format!(
+                    "ambiguous edit: old_string matches {found} times — pass expected_count or a longer anchor"
+                )));
+            }
+            _ => {}
+        }
+        let updated = text.replace(old, new);
+        std::fs::write(&canonical, &updated).map_err(|e| {
+            ToolError::Execution(format!("cannot write {}: {e}", canonical.display()))
+        })?;
+        Ok(format!(
+            "replaced {found} occurrence(s) in {}",
+            canonical.display()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool(td: &tempfile::TempDir) -> EditFileTool {
+        let root = td.path().to_str().unwrap();
+        EditFileTool::new(
+            td.path().into(),
+            FilesystemEntitlement {
+                read: vec![],
+                write: vec![root.to_string()],
+                deny: vec![],
+                ..Default::default()
+            },
+        )
+    }
+
+    fn seed(td: &tempfile::TempDir, content: &str) {
+        std::fs::write(td.path().join("f.txt"), content).unwrap();
+    }
+
+    #[tokio::test]
+    async fn single_match_replaces() {
+        let td = tempfile::tempdir().unwrap();
+        seed(&td, "aaa X bbb");
+        tool(&td)
+            .execute(serde_json::json!({"path": "f.txt", "old_string": "X", "new_string": "Y"}))
+            .await
+            .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(td.path().join("f.txt")).unwrap(),
+            "aaa Y bbb"
+        );
+    }
+
+    #[tokio::test]
+    async fn zero_matches_is_invalid_input() {
+        let td = tempfile::tempdir().unwrap();
+        seed(&td, "nothing here");
+        let err = tool(&td)
+            .execute(serde_json::json!({"path": "f.txt", "old_string": "X", "new_string": "Y"}))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolError::InvalidInput(_)));
+    }
+
+    #[tokio::test]
+    async fn multi_match_without_count_is_ambiguous() {
+        let td = tempfile::tempdir().unwrap();
+        seed(&td, "X and X");
+        let err = tool(&td)
+            .execute(serde_json::json!({"path": "f.txt", "old_string": "X", "new_string": "Y"}))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("ambiguous"));
+    }
+
+    #[tokio::test]
+    async fn expected_count_replaces_all_n() {
+        let td = tempfile::tempdir().unwrap();
+        seed(&td, "X and X");
+        let r = tool(&td)
+            .execute(serde_json::json!({"path": "f.txt", "old_string": "X", "new_string": "Y", "expected_count": 2}))
+            .await
+            .unwrap();
+        assert!(r.contains("replaced 2"));
+        assert_eq!(
+            std::fs::read_to_string(td.path().join("f.txt")).unwrap(),
+            "Y and Y"
+        );
+    }
+
+    #[tokio::test]
+    async fn expected_count_mismatch_rejected() {
+        let td = tempfile::tempdir().unwrap();
+        seed(&td, "X and X");
+        let err = tool(&td)
+            .execute(serde_json::json!({"path": "f.txt", "old_string": "X", "new_string": "Y", "expected_count": 3}))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("expected 3"));
+    }
+}

--- a/mur-agent-runtime/src/tools/fs_policy.rs
+++ b/mur-agent-runtime/src/tools/fs_policy.rs
@@ -1,0 +1,34 @@
+//! Shared call-time filesystem-entitlement gate for the mutating file tools
+//! (issue #591 PR2). `deny` always wins; writes require a `write` grant.
+//! read_file keeps its own equivalent check — dedup is a follow-up.
+
+use std::path::{Path, PathBuf};
+
+use mur_common::agent::FilesystemEntitlement;
+
+use crate::tools::ToolError;
+
+pub(crate) fn check_write_entitlement(
+    fs: &FilesystemEntitlement,
+    canonical: &Path,
+) -> Result<(), ToolError> {
+    let under = |roots: &[String]| {
+        roots.iter().any(|r| {
+            let root = std::fs::canonicalize(r).unwrap_or_else(|_| PathBuf::from(r));
+            canonical.starts_with(&root)
+        })
+    };
+    if under(&fs.deny) {
+        return Err(ToolError::Execution(format!(
+            "path denied by entitlement: {}",
+            canonical.display()
+        )));
+    }
+    if under(&fs.write) {
+        return Ok(());
+    }
+    Err(ToolError::Execution(format!(
+        "path not write-entitled: {} (grant it via `mur agent perm allow-write`)",
+        canonical.display()
+    )))
+}

--- a/mur-agent-runtime/src/tools/mod.rs
+++ b/mur-agent-runtime/src/tools/mod.rs
@@ -1,9 +1,12 @@
 pub mod bash;
+pub mod edit_file;
+pub(crate) mod fs_policy;
 pub mod mcp;
 pub mod naming;
 pub mod read_file;
 pub mod registry;
 pub(crate) mod suggest;
+pub mod write_file;
 
 use crate::llm::ToolDef;
 

--- a/mur-agent-runtime/src/tools/registry.rs
+++ b/mur-agent-runtime/src/tools/registry.rs
@@ -24,6 +24,8 @@ use crate::mcp::pool::McpPool;
 pub async fn build_tools(
     bash: Option<(ToolDef, Arc<dyn ToolExecutor>)>,
     read_file: Option<(ToolDef, Arc<dyn ToolExecutor>)>,
+    write_file: Option<(ToolDef, Arc<dyn ToolExecutor>)>,
+    edit_file: Option<(ToolDef, Arc<dyn ToolExecutor>)>,
     servers: &[McpServerEntry],
     rules: &[ToolRule],
     pool: Arc<McpPool>,
@@ -43,6 +45,20 @@ pub async fn build_tools(
     {
         defs.push(def);
         map.insert("read_file".to_string(), exec);
+    }
+
+    if let Some((def, exec)) = write_file
+        && resolve_tool_policy(rules, "write_file") != ToolPolicy::Deny
+    {
+        defs.push(def);
+        map.insert("write_file".to_string(), exec);
+    }
+
+    if let Some((def, exec)) = edit_file
+        && resolve_tool_policy(rules, "edit_file") != ToolPolicy::Deny
+    {
+        defs.push(def);
+        map.insert("edit_file".to_string(), exec);
     }
 
     // Built-in no-op suggest_replies. Always in the executor map (so a call can
@@ -114,7 +130,7 @@ mod tests {
     #[tokio::test]
     async fn no_servers_empty_result() {
         let pool = McpPool::new(vec![], SandboxPolicy::default(), None);
-        let (defs, map) = build_tools(None, None, &[], &[], pool).await;
+        let (defs, map) = build_tools(None, None, None, None, &[], &[], pool).await;
         // suggest_replies is always registered as a built-in.
         assert_eq!(defs.len(), 1);
         assert!(map.contains_key("suggest_replies"));
@@ -128,7 +144,16 @@ mod tests {
         });
         let bash_def = bash_exec.def();
         let pool = McpPool::new(vec![], SandboxPolicy::default(), None);
-        let (defs, map) = build_tools(Some((bash_def, bash_exec)), None, &[], &[], pool).await;
+        let (defs, map) = build_tools(
+            Some((bash_def, bash_exec)),
+            None,
+            None,
+            None,
+            &[],
+            &[],
+            pool,
+        )
+        .await;
         // bash + suggest_replies
         assert_eq!(defs.len(), 2);
         assert!(map.contains_key("bash"));
@@ -137,7 +162,7 @@ mod tests {
     #[tokio::test]
     async fn suggest_replies_is_registered() {
         let pool = McpPool::new(vec![], SandboxPolicy::default(), None);
-        let (defs, map) = build_tools(None, None, &[], &[], pool).await;
+        let (defs, map) = build_tools(None, None, None, None, &[], &[], pool).await;
         assert!(map.contains_key("suggest_replies"));
         assert!(defs.iter().any(|d| d.name == "suggest_replies"));
     }
@@ -155,7 +180,16 @@ mod tests {
             risk: None,
         }];
         let pool = McpPool::new(vec![], SandboxPolicy::default(), None);
-        let (defs, map) = build_tools(Some((bash_def, bash_exec)), None, &[], &rules, pool).await;
+        let (defs, map) = build_tools(
+            Some((bash_def, bash_exec)),
+            None,
+            None,
+            None,
+            &[],
+            &rules,
+            pool,
+        )
+        .await;
         // bash is denied; suggest_replies is still registered.
         assert_eq!(defs.len(), 1);
         assert!(!map.contains_key("bash"));
@@ -171,8 +205,16 @@ mod tests {
         ));
         let read_file_def = read_file_exec.def();
         let pool = McpPool::new(vec![], SandboxPolicy::default(), None);
-        let (defs, map) =
-            build_tools(None, Some((read_file_def, read_file_exec)), &[], &[], pool).await;
+        let (defs, map) = build_tools(
+            None,
+            Some((read_file_def, read_file_exec)),
+            None,
+            None,
+            &[],
+            &[],
+            pool,
+        )
+        .await;
         // read_file + suggest_replies
         assert_eq!(defs.len(), 2);
         assert!(map.contains_key("read_file"));
@@ -195,6 +237,8 @@ mod tests {
         let (defs, map) = build_tools(
             None,
             Some((read_file_def, read_file_exec)),
+            None,
+            None,
             &[],
             &rules,
             pool,
@@ -203,6 +247,114 @@ mod tests {
         // read_file is denied; suggest_replies is still registered.
         assert_eq!(defs.len(), 1);
         assert!(!map.contains_key("read_file"));
+        assert!(map.contains_key("suggest_replies"));
+    }
+
+    #[tokio::test]
+    async fn write_file_tool_included_when_allowed() {
+        use crate::tools::write_file::WriteFileTool;
+        let write_file_exec: Arc<dyn ToolExecutor> = Arc::new(WriteFileTool::new(
+            std::path::PathBuf::from("/tmp"),
+            mur_common::agent::FilesystemEntitlement::default(),
+        ));
+        let write_file_def = write_file_exec.def();
+        let pool = McpPool::new(vec![], SandboxPolicy::default(), None);
+        let (defs, map) = build_tools(
+            None,
+            None,
+            Some((write_file_def, write_file_exec)),
+            None,
+            &[],
+            &[],
+            pool,
+        )
+        .await;
+        // write_file + suggest_replies
+        assert_eq!(defs.len(), 2);
+        assert!(map.contains_key("write_file"));
+    }
+
+    #[tokio::test]
+    async fn write_file_tool_excluded_when_denied() {
+        use crate::tools::write_file::WriteFileTool;
+        let write_file_exec: Arc<dyn ToolExecutor> = Arc::new(WriteFileTool::new(
+            std::path::PathBuf::from("/tmp"),
+            mur_common::agent::FilesystemEntitlement::default(),
+        ));
+        let write_file_def = write_file_exec.def();
+        let rules = vec![ToolRule {
+            pattern: "write_file".to_string(),
+            policy: ToolPolicy::Deny,
+            risk: None,
+        }];
+        let pool = McpPool::new(vec![], SandboxPolicy::default(), None);
+        let (defs, map) = build_tools(
+            None,
+            None,
+            Some((write_file_def, write_file_exec)),
+            None,
+            &[],
+            &rules,
+            pool,
+        )
+        .await;
+        // write_file is denied; suggest_replies is still registered.
+        assert_eq!(defs.len(), 1);
+        assert!(!map.contains_key("write_file"));
+        assert!(map.contains_key("suggest_replies"));
+    }
+
+    #[tokio::test]
+    async fn edit_file_tool_included_when_allowed() {
+        use crate::tools::edit_file::EditFileTool;
+        let edit_file_exec: Arc<dyn ToolExecutor> = Arc::new(EditFileTool::new(
+            std::path::PathBuf::from("/tmp"),
+            mur_common::agent::FilesystemEntitlement::default(),
+        ));
+        let edit_file_def = edit_file_exec.def();
+        let pool = McpPool::new(vec![], SandboxPolicy::default(), None);
+        let (defs, map) = build_tools(
+            None,
+            None,
+            None,
+            Some((edit_file_def, edit_file_exec)),
+            &[],
+            &[],
+            pool,
+        )
+        .await;
+        // edit_file + suggest_replies
+        assert_eq!(defs.len(), 2);
+        assert!(map.contains_key("edit_file"));
+    }
+
+    #[tokio::test]
+    async fn edit_file_tool_excluded_when_denied() {
+        use crate::tools::edit_file::EditFileTool;
+        let edit_file_exec: Arc<dyn ToolExecutor> = Arc::new(EditFileTool::new(
+            std::path::PathBuf::from("/tmp"),
+            mur_common::agent::FilesystemEntitlement::default(),
+        ));
+        let edit_file_def = edit_file_exec.def();
+        let rules = vec![ToolRule {
+            pattern: "edit_file".to_string(),
+            policy: ToolPolicy::Deny,
+            risk: None,
+        }];
+        let pool = McpPool::new(vec![], SandboxPolicy::default(), None);
+        let (defs, map) = build_tools(
+            None,
+            None,
+            None,
+            Some((edit_file_def, edit_file_exec)),
+            &[],
+            &rules,
+            pool,
+        )
+        .await;
+        // edit_file is denied; suggest_replies is still registered.
+        assert_eq!(defs.len(), 1);
+        assert!(!map.contains_key("edit_file"));
         assert!(map.contains_key("suggest_replies"));
     }
 }

--- a/mur-agent-runtime/src/tools/write_file.rs
+++ b/mur-agent-runtime/src/tools/write_file.rs
@@ -1,0 +1,141 @@
+//! First-party full-file write tool (issue #591, PR2).
+
+use std::path::{Path, PathBuf};
+
+use mur_common::agent::FilesystemEntitlement;
+
+use crate::llm::ToolDef;
+use crate::tools::fs_policy::check_write_entitlement;
+use crate::tools::{ToolError, ToolExecutor};
+
+pub struct WriteFileTool {
+    pub working_dir: PathBuf,
+    pub fs: FilesystemEntitlement,
+}
+
+impl WriteFileTool {
+    pub fn new(working_dir: PathBuf, fs: FilesystemEntitlement) -> Self {
+        Self { working_dir, fs }
+    }
+}
+
+#[async_trait::async_trait]
+impl ToolExecutor for WriteFileTool {
+    fn name(&self) -> &str {
+        "write_file"
+    }
+
+    fn def(&self) -> ToolDef {
+        ToolDef {
+            name: "write_file".into(),
+            description: "Create or fully overwrite a UTF-8 text file. Parent directories are NOT auto-created — create them explicitly first. Writes are checked against the agent's filesystem write entitlements."
+                .into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "Target file (absolute, or relative to the agent working dir)" },
+                    "content": { "type": "string", "description": "Full file contents to write" }
+                },
+                "required": ["path", "content"]
+            }),
+        }
+    }
+
+    async fn execute(&self, input: serde_json::Value) -> Result<String, ToolError> {
+        let raw = input["path"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("missing 'path' field".into()))?;
+        let content = input["content"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("missing 'content' field".into()))?;
+        let joined = if Path::new(raw).is_absolute() {
+            PathBuf::from(raw)
+        } else {
+            self.working_dir.join(raw)
+        };
+        let parent = joined
+            .parent()
+            .ok_or_else(|| ToolError::InvalidInput("path has no parent directory".into()))?;
+        let canonical_parent = std::fs::canonicalize(parent).map_err(|_| {
+            ToolError::Execution(format!(
+                "parent directory does not exist: {} (create it explicitly first)",
+                parent.display()
+            ))
+        })?;
+        let file_name = joined
+            .file_name()
+            .ok_or_else(|| ToolError::InvalidInput("path has no file name".into()))?;
+        let target = canonical_parent.join(file_name);
+        check_write_entitlement(&self.fs, &target)?;
+        std::fs::write(&target, content)
+            .map_err(|e| ToolError::Execution(format!("cannot write {}: {e}", target.display())))?;
+        Ok(format!(
+            "wrote {} bytes to {}",
+            content.len(),
+            target.display()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fs_ent(write: &[&str], deny: &[&str]) -> FilesystemEntitlement {
+        FilesystemEntitlement {
+            read: vec![],
+            write: write.iter().map(|s| s.to_string()).collect(),
+            deny: deny.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn creates_and_overwrites() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path().to_str().unwrap();
+        let t = WriteFileTool::new(td.path().into(), fs_ent(&[root], &[]));
+        let r = t
+            .execute(serde_json::json!({"path": "a.txt", "content": "one"}))
+            .await
+            .unwrap();
+        assert!(r.contains("wrote 3 bytes"));
+        t.execute(serde_json::json!({"path": "a.txt", "content": "two2"}))
+            .await
+            .unwrap();
+        assert_eq!(
+            std::fs::read_to_string(td.path().join("a.txt")).unwrap(),
+            "two2"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_parent_fails_loud() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path().to_str().unwrap();
+        let t = WriteFileTool::new(td.path().into(), fs_ent(&[root], &[]));
+        let err = t
+            .execute(serde_json::json!({"path": "no/such/dir/a.txt", "content": "x"}))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("parent directory does not exist"));
+    }
+
+    #[tokio::test]
+    async fn write_requires_write_grant_and_deny_wins() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path().to_str().unwrap();
+        let none = WriteFileTool::new(td.path().into(), fs_ent(&[], &[]));
+        let err = none
+            .execute(serde_json::json!({"path": "a.txt", "content": "x"}))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not write-entitled"));
+        let denied = WriteFileTool::new(td.path().into(), fs_ent(&[root], &[root]));
+        let err2 = denied
+            .execute(serde_json::json!({"path": "a.txt", "content": "x"}))
+            .await
+            .unwrap_err();
+        assert!(err2.to_string().contains("denied"));
+    }
+}


### PR DESCRIPTION
Re-opened as a fresh PR: #606 was auto-closed when its stacked base branch was deleted on the parent merge (#605). Mutating half of the #591 design: write_file (full overwrite, no auto-mkdir, fail loud) and edit_file (exact-literal, no regex, exactly-one match by default, expected_count for known-N), shared call-time write-entitlement gate (deny wins). HITL note: runtime gate is uniform post-execution, no per-tier wiring — matches bash. mur-agent-runtime 717/717, clippy 0. Built by the skillsmith MUR fleet (rustsmith), supervised; PR by repomanager. Fixes #591