### PR TITLE
fix(parallel): CAS score key includes the competitor set (#545)

### DIFF
--- a/mur-core/src/cmd/fleet/cherry_cmd.rs
+++ b/mur-core/src/cmd/fleet/cherry_cmd.rs
@@ -45,6 +45,13 @@ pub fn cmd_fleet_cherry(
     let mut scores_per_unit: std::collections::HashMap<String, Vec<TrackScore>> =
         std::collections::HashMap::new();
 
+    // Pass 1: collect (track_name, content_hash) per unit.name across all
+    // tracks. The competitor set for a unit is only known once every
+    // track's implementation has been collected (issue #545: CyclicJudge
+    // scores are relative to the competitor set).
+    let mut by_name: std::collections::BTreeMap<String, Vec<(String, [u8; 32])>> =
+        std::collections::BTreeMap::new();
+
     for t in &tracks.tracks {
         for entry in walkdir::WalkDir::new(&t.worktree_path)
             .follow_links(false)
@@ -59,23 +66,36 @@ pub fn cmd_fleet_cherry(
                 continue;
             };
             for unit in units {
-                let Some(js) = state_db
-                    .get_score(&unit.content_hash, &rubric_ver)
-                    .ok()
-                    .flatten()
-                else {
-                    continue;
-                };
-                scores_per_unit
+                by_name
                     .entry(unit.name)
                     .or_default()
-                    .push(TrackScore {
-                        track_name: t.config.name.clone(),
-                        score: js.score,
-                        reasoning: js.reasoning,
-                        low_confidence: false,
-                    });
+                    .push((t.config.name.clone(), unit.content_hash));
             }
+        }
+    }
+
+    // Pass 2: now that the full competitor set per unit is known, compute
+    // its set hash and look up each track's score against that exact set.
+    for (name, members) in &by_name {
+        let set_hash =
+            ParallelStateDb::competitor_set_hash(&members.iter().map(|m| m.1).collect::<Vec<_>>());
+        for (track, hash) in members {
+            let Some(js) = state_db
+                .get_score(hash, &set_hash, &rubric_ver)
+                .ok()
+                .flatten()
+            else {
+                continue;
+            };
+            scores_per_unit
+                .entry(name.clone())
+                .or_default()
+                .push(TrackScore {
+                    track_name: track.clone(),
+                    score: js.score,
+                    reasoning: js.reasoning,
+                    low_confidence: false,
+                });
         }
     }
 

--- a/mur-core/src/cmd/fleet/compare.rs
+++ b/mur-core/src/cmd/fleet/compare.rs
@@ -38,6 +38,13 @@ pub fn cmd_fleet_compare(
     let mut score_map: std::collections::HashMap<String, Vec<ScoreEntry>> =
         std::collections::HashMap::new();
 
+    // Pass 1: collect (track_name, content_hash) per unit.name across all
+    // tracks. We cannot look up scores yet — the competitor set for a unit
+    // is only known once every track's implementation has been collected
+    // (issue #545: CyclicJudge scores are relative to the competitor set).
+    let mut by_name: std::collections::BTreeMap<String, Vec<(String, [u8; 32])>> =
+        std::collections::BTreeMap::new();
+
     for t in &tracks.tracks {
         for entry in walkdir::WalkDir::new(&t.worktree_path)
             .follow_links(false)
@@ -55,16 +62,29 @@ pub fn cmd_fleet_compare(
                 if unit_filter.is_some_and(|f| !unit.name.contains(f)) {
                     continue;
                 }
-                let val = state_db
-                    .get_score(&unit.content_hash, &rubric_ver)
-                    .ok()
-                    .flatten()
-                    .map(|js| (js.score, js.low_confidence));
-                score_map
+                by_name
                     .entry(unit.name)
                     .or_default()
-                    .push((t.config.name.clone(), val));
+                    .push((t.config.name.clone(), unit.content_hash));
             }
+        }
+    }
+
+    // Pass 2: now that the full competitor set per unit is known, compute
+    // its set hash and look up each track's score against that exact set.
+    for (name, members) in &by_name {
+        let set_hash =
+            ParallelStateDb::competitor_set_hash(&members.iter().map(|m| m.1).collect::<Vec<_>>());
+        for (track, hash) in members {
+            let val = state_db
+                .get_score(hash, &set_hash, &rubric_ver)
+                .ok()
+                .flatten()
+                .map(|js| (js.score, js.low_confidence));
+            score_map
+                .entry(name.clone())
+                .or_default()
+                .push((track.clone(), val));
         }
     }
 

--- a/mur-core/src/parallel/mod.rs
+++ b/mur-core/src/parallel/mod.rs
@@ -167,9 +167,16 @@ pub async fn run_judge_pipeline_async(
             continue;
         }
 
+        let set_hash = crate::parallel::state::ParallelStateDb::competitor_set_hash(
+            &impls
+                .iter()
+                .map(|i| i.unit.content_hash)
+                .collect::<Vec<_>>(),
+        );
+
         // Cache check: use first impl's hash as group representative.
         if state_db
-            .get_score(&impls[0].unit.content_hash, &rubric_version)?
+            .get_score(&impls[0].unit.content_hash, &set_hash, &rubric_version)?
             .is_some()
         {
             cache_hits += 1;
@@ -200,7 +207,7 @@ pub async fn run_judge_pipeline_async(
                         .unwrap_or(0),
                     low_confidence: score.low_confidence,
                 };
-                state_db.put_score(&imp.unit.content_hash, &rubric_version, &js)?;
+                state_db.put_score(&imp.unit.content_hash, &set_hash, &rubric_version, &js)?;
             }
         }
     }

--- a/mur-core/src/parallel/state/lmdb.rs
+++ b/mur-core/src/parallel/state/lmdb.rs
@@ -34,34 +34,56 @@ impl ParallelStateDb {
         Ok(Self { env, scores })
     }
 
-    /// Build the lookup key: `"{hex_of_hash}:{rubric_version}"` as UTF-8 bytes.
-    fn score_key(content_hash: &[u8; 32], rubric_version: &str) -> Vec<u8> {
+    /// Order-insensitive digest of the full competitor set for a judge group.
+    /// CyclicJudge scores are relative — a score is only valid against the
+    /// exact set it was judged in (issue #545).
+    pub fn competitor_set_hash(hashes: &[[u8; 32]]) -> [u8; 32] {
+        let mut sorted: Vec<[u8; 32]> = hashes.to_vec();
+        sorted.sort_unstable();
+        let mut h = blake3::Hasher::new();
+        for x in &sorted {
+            h.update(x);
+        }
+        *h.finalize().as_bytes()
+    }
+
+    /// Build the lookup key: `"{hex_of_hash}:{hex_of_set_hash}:{rubric_version}"` as UTF-8 bytes.
+    fn score_key(content_hash: &[u8; 32], set_hash: &[u8; 32], rubric_version: &str) -> Vec<u8> {
         let mut k = hex::encode(content_hash).into_bytes();
+        k.push(b':');
+        k.extend_from_slice(hex::encode(set_hash).as_bytes());
         k.push(b':');
         k.extend_from_slice(rubric_version.as_bytes());
         k
     }
 
     /// Retrieve a previously stored score, or `None` if not yet judged.
+    /// `set_hash` identifies the exact competitor set the score is relative to
+    /// (issue #545) — a stale set hash misses the cache rather than returning
+    /// a score judged against a different competitor set.
     pub fn get_score(
         &self,
         content_hash: &[u8; 32],
+        set_hash: &[u8; 32],
         rubric_version: &str,
     ) -> Result<Option<JudgeScore>> {
         let rtxn = self.env.read_txn()?;
-        let key = Self::score_key(content_hash, rubric_version);
+        let key = Self::score_key(content_hash, set_hash, rubric_version);
         Ok(self.scores.get(&rtxn, &key)?)
     }
 
-    /// Persist a judge score for the given content hash + rubric version.
+    /// Persist a judge score for the given content hash + competitor set +
+    /// rubric version. `set_hash` identifies the exact competitor set the
+    /// score is relative to (issue #545).
     pub fn put_score(
         &self,
         content_hash: &[u8; 32],
+        set_hash: &[u8; 32],
         rubric_version: &str,
         score: &JudgeScore,
     ) -> Result<()> {
         let mut wtxn = self.env.write_txn()?;
-        let key = Self::score_key(content_hash, rubric_version);
+        let key = Self::score_key(content_hash, set_hash, rubric_version);
         self.scores.put(&mut wtxn, &key, score)?;
         wtxn.commit()?;
         Ok(())
@@ -78,6 +100,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db = ParallelStateDb::open(dir.path()).unwrap();
         let hash = [7u8; 32];
+        let set_hash = [7u8; 32];
         let score = JudgeScore {
             score: 8.5,
             reasoning: "good design".into(),
@@ -85,8 +108,8 @@ mod tests {
             ts: 1_700_000_000,
             low_confidence: false,
         };
-        db.put_score(&hash, "v1", &score).unwrap();
-        let retrieved = db.get_score(&hash, "v1").unwrap().unwrap();
+        db.put_score(&hash, &set_hash, "v1", &score).unwrap();
+        let retrieved = db.get_score(&hash, &set_hash, "v1").unwrap().unwrap();
         assert!((retrieved.score - 8.5).abs() < 0.001);
         assert_eq!(retrieved.reasoning, "good design");
     }
@@ -95,6 +118,28 @@ mod tests {
     fn missing_score_returns_none() {
         let dir = tempfile::tempdir().unwrap();
         let db = ParallelStateDb::open(dir.path()).unwrap();
-        assert!(db.get_score(&[0u8; 32], "v1").unwrap().is_none());
+        assert!(
+            db.get_score(&[0u8; 32], &[7u8; 32], "v1")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn score_key_is_competitor_set_sensitive() {
+        let a = [1u8; 32];
+        let s1 = ParallelStateDb::competitor_set_hash(&[[1u8; 32], [2u8; 32]]);
+        let s2 = ParallelStateDb::competitor_set_hash(&[[1u8; 32], [3u8; 32]]);
+        assert_ne!(
+            ParallelStateDb::score_key(&a, &s1, "v1"),
+            ParallelStateDb::score_key(&a, &s2, "v1")
+        );
+    }
+
+    #[test]
+    fn competitor_set_hash_is_order_insensitive() {
+        let x = ParallelStateDb::competitor_set_hash(&[[1u8; 32], [2u8; 32], [3u8; 32]]);
+        let y = ParallelStateDb::competitor_set_hash(&[[3u8; 32], [1u8; 32], [2u8; 32]]);
+        assert_eq!(x, y);
     }
 }


### PR DESCRIPTION
CyclicJudge scores are relative — a cached score is only valid against the exact competitor set it was judged in. The LMDB key becomes {impl}:{sorted-set-digest}:{rubric} via a new order-insensitive competitor_set_hash; the judge write path threads the group set, and both readers (compare/cherry) restructure into two passes to reconstruct each unit's set before lookup. LMDB tests 8/8 incl. set-sensitivity + order-insensitivity; cargo check clean. Built by the skillsmith MUR fleet (rustsmith), supervised; PR by repomanager. Fixes #545