### PR TITLE
fix: mur verify false positives + two stale doc claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,10 +155,10 @@ When making changes, check whether these need updating:
 1. **`README.md`** — `/Volumes/Firecuda4tb/Projects/mur/README.md`
 2. **Documents page** — https://app.mur.run/docs/core
    - Source: `/Volumes/Firecuda4tb/Projects/mur-server/dashboard/docs-content/`
-   - Page component: `dashboard/src/app/docs/core/[[...slug]]/page.tsx`
-   - Navigation: `dashboard/src/components/docs/coreNavigation.tsx`
-3. **Product page** — https://app.mur.run/products/core
-   - Source: `dashboard/src/app/products/core/page.tsx`
+   - Page component: `/Volumes/Firecuda4tb/Projects/mur-server/dashboard/src/app/docs/core/[[...slug]]/page.tsx`
+   - Navigation: `/Volumes/Firecuda4tb/Projects/mur-server/dashboard/src/components/docs/coreNavigation.tsx`
+3. **Product page** — https://app.mur.run/products/mur
+   - Source: `/Volumes/Firecuda4tb/Projects/mur-server/dashboard/src/app/products/mur/page.tsx`
 
 ## Mandatory Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,8 +99,8 @@ tests or commands without hitting a real provider, set:
 This is wired in `mur-agent-runtime/src/supervisor.rs`: when the variable is
 set, the supervisor skips provider initialisation and routes all LLM calls
 through a deterministic stub-echo runner. The integration tests (M8.*) all
-use it. Real-LLM smoke runs are nightly-only
-(`scripts/e2e/companion-ollama-nightly.sh`, optional).
+use it. There is no real-LLM nightly smoke script yet; run against a live
+provider manually by unsetting the variable.
 
 Note: `MUR_LLM_PROVIDER=stub` is NOT currently wired. Use
 `MUR_AGENT_FORCE_ECHO=1` instead.

--- a/mur-core/src/verify.rs
+++ b/mur-core/src/verify.rs
@@ -375,7 +375,18 @@ fn extract_code_refs(line: &str) -> Vec<String> {
         // Skip common non-code words
         if !matches!(
             name,
-            "README" | "CLAUDE" | "YAML" | "JSON" | "TOML" | "HTTP" | "HTTPS" | "UUID" | "UTC"
+            "README"
+                | "CLAUDE"
+                | "YAML"
+                | "JSON"
+                | "TOML"
+                | "HTTP"
+                | "HTTPS"
+                | "UUID"
+                | "UTC"
+                // External crate types discussed in docs, not local code
+                | "FromRequestParts"
+                | "ConnectInfo"
         ) {
             let r = name.to_string();
             if !refs.contains(&r) {
@@ -571,8 +582,10 @@ fn verify_code_ref(code_ref: &str, project_root: &Path) -> VerifyResult {
         }
         return VerifyResult::Invalid(format!("method `{method}` not found in source"));
     } else {
-        // Standalone PascalCase type name
-        format!(r"(struct|enum|trait|type)\s+{code_ref}\b")
+        // Standalone PascalCase name — bare word match. Covers enum variants
+        // (e.g. `StateChange`), which aren't declared via `enum StateChange`
+        // themselves — they live inside their enum's braces.
+        format!(r"\b{code_ref}\b")
     };
 
     if grep_source(project_root, &pattern) {


### PR DESCRIPTION
## Summary
- \`mur verify\`'s code-ref check only matched `struct/enum/trait/type NAME` declarations, so enum variants (`StateChange`, `ChannelQuery`) were false-flagged as missing — now falls back to a bare-word grep.
- Axum's own `FromRequestParts`/`ConnectInfo` (discussed in CONTRIBUTING.md re: an axum version conflict, not local code) added to the skip list.
- `CLAUDE.md`: `dashboard/...` paths actually live in the `mur-server` repo but were phrased relatively, so they resolved against this repo — made absolute. Also fixed a real stale claim: `products/core/page.tsx` doesn't exist; the page is `products/mur/page.tsx`.
- `CONTRIBUTING.md`: removed a reference to `scripts/e2e/companion-ollama-nightly.sh`, a nightly smoke script that was never created.

`mur verify` invalid count: 10 → 2. The remaining 2 are competitor tool filenames (`.cursor/rules/`, `.github/copilot-instructions.md`) quoted in a market-positioning doc, not paths in this repo — accepted false positive, not worth special-casing the linter for one research doc.

## Test plan
- [x] `cargo build -p mur-core --bin mur` succeeds
- [x] `mur verify` shows 2 invalid (down from 10), both accepted false positives
- [x] `cargo fmt --check -p mur-core` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)