### PR TITLE
fix: hide mur verify from top-level --help

### DIFF
--- a/mur-core/src/cli/mod.rs
+++ b/mur-core/src/cli/mod.rs
@@ -238,6 +238,7 @@ pub enum Commands {
         patterns: bool,
     },
     /// Verify documentation claims (paths, commands, code refs) against actual codebase
+    #[command(hide = true)]
     Verify {
         /// Specific file to verify (default: scan all docs)
         #[arg(long)]


### PR DESCRIPTION
## Summary
- `mur verify` is a dev/CI doc-verification tool (see #612), not something end users need to discover in `mur --help`.
- Hides it via `#[command(hide = true)]`, the same pattern already used for `migrate` — still fully functional when invoked directly (`mur verify --all`).

## Test plan
- [x] `cargo build -p mur-core --bin mur`
- [x] `cargo fmt --check -p mur-core`
- [x] `mur --help` no longer lists `verify`; `mur verify --help` still works