### PR TITLE
feat(hub): bundled brainstorming skill + seed-missing-skills upgrade path

### DIFF
--- a/mur-core/src/retrieve/skill_candidates.rs
+++ b/mur-core/src/retrieve/skill_candidates.rs
@@ -536,7 +536,7 @@ mod tests {
 
     #[test]
     fn text_includes_note_body_when_present() {
-        use mur_common::skill::manifest::{Content, Visibility};
+        use mur_common::skill::manifest::Content;
         use mur_common::skill::types::Category;
 
         let mut s = fake_loaded("note-skill", Priority::Normal);

--- a/mur-hub-gui/src-tauri/resources/mur-agent-template/profile.yaml
+++ b/mur-hub-gui/src-tauri/resources/mur-agent-template/profile.yaml
@@ -20,6 +20,7 @@ model:
     max_tokens: 1024
 skills:
   - skills/concierge
+  - skills/brainstorming
 transport:
   stdio: true
   socket:

--- a/mur-hub-gui/src-tauri/resources/mur-agent-template/skills/brainstorming/skill.yaml
+++ b/mur-hub-gui/src-tauri/resources/mur-agent-template/skills/brainstorming/skill.yaml
@@ -1,0 +1,71 @@
+name: brainstorming
+version: 1.0.0
+publisher: human:mur-official
+description: >-
+  Turns a rough idea into an approved design through one-question-at-a-time,
+  multiple-choice-first dialogue, then hands the agreed design to the `pm`
+  agent to author the spec/plan — never writes or scaffolds code itself.
+  Derived from obra/superpowers brainstorming (MIT).
+category: workflow
+origin: registry:mur-official/brainstorming
+origin_version: 1.0.0
+origin_hash: bf800c07b9ebf01d236d504ec26d62c325a60dd4892ada5a38893ecc163321e4
+content:
+  abstract: >-
+    Use before any new feature, component, or design decision: explores intent,
+    constraints, and trade-offs one question at a time before any spec gets
+    written, then delegates spec/plan authoring to the `pm` agent.
+  procedure:
+    steps:
+      - description: >-
+          HARD GATE: do not propose scaffolding, code, or any implementation
+          action at any point in this skill, however simple the request looks.
+          A one-paragraph design is fine for a simple request, but skipping
+          the process is not. The terminal action is handing the agreed
+          design summary to the `pm` agent for spec/plan authoring — nothing
+          more.
+      - description: >-
+          Explore context first: look at what already exists (relevant files,
+          prior notes/specs, recent history) before asking anything, so
+          questions build on what's already known instead of re-asking it.
+      - description: >-
+          Scope check: if the request bundles several independent subsystems,
+          say so up front and offer to split it into separate design passes —
+          one sub-project per brainstorming cycle — rather than spending
+          questions refining a project that first needs decomposing.
+      - description: >-
+          Ask exactly one question per turn. Prefer presenting 2-3 concrete
+          options (A/B/C, multiple-choice style) with a recommended default
+          over open-ended questions; open-ended is a fallback only. Cover
+          purpose, constraints, and success criteria before moving on.
+      - description: >-
+          Once purpose and constraints are clear, present 2-3 possible
+          approaches as a short multiple-choice list, trade-offs included,
+          leading with the recommended one and why.
+      - description: >-
+          Present the design in sections sized to their complexity — a
+          sentence or two for a simple piece, more for a nuanced one. Ask
+          after each section whether it looks right before moving to the
+          next. Cover shape, components, data/control flow, error handling,
+          and how it will be verified.
+      - description: >-
+          If the human pushes back on a section, revise that section and
+          re-confirm before continuing — never plow ahead with an
+          unconfirmed section.
+      - description: >-
+          Once every section is confirmed, summarize the agreed design and
+          delegate it to the `pm` agent to author the actual spec/plan
+          document, via a fleet channel/delegation (e.g. `mur fleet run` or
+          a channel `delegate_to` step targeting `pm`) — do not write the
+          spec/plan yourself and do not take any implementation action.
+          Tell the human where to find the spec/plan pm produces so they can
+          review it before any implementation work starts.
+triggers:
+  - type: keyword
+    pattern: "brainstorm|design discussion|幫我想|腦暴|頭腦風暴|設計討論"
+  - type: manual
+priority: normal
+tags:
+  - design
+  - planning
+  - dialogue

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -463,6 +463,13 @@ pub fn run() {
                         }
                         Err(e) => tracing::warn!("seed Mur failed: {e}"),
                     }
+                    match seed_mur::seed_missing_bundled_skills(&template_dir, &mur_home) {
+                        Ok(seeded) if !seeded.is_empty() => {
+                            tracing::info!("seeded missing bundled skills: {seeded:?}");
+                        }
+                        Ok(_) => {}
+                        Err(e) => tracing::warn!("seed missing bundled skills failed: {e}"),
+                    }
                 }
                 None => tracing::warn!(
                     "seed Mur: bundled mur-agent-template resource not found; skipping"

--- a/mur-hub-gui/src-tauri/src/seed_mur.rs
+++ b/mur-hub-gui/src-tauri/src/seed_mur.rs
@@ -315,6 +315,75 @@ pub fn seed_mur_if_missing(template_dir: &Path, mur_home: &Path) -> std::io::Res
     Ok(true)
 }
 
+/// For an already-seeded `mur` agent, copy in any bundled template skill dirs
+/// missing from `<mur_home>/agents/mur/skills/` and append them to the
+/// agent's `profile.yaml` `skills:` list. Existing skill dirs are left
+/// completely untouched (never overwritten). Returns the names seeded.
+///
+/// Called on Hub launch right after `seed_mur_if_missing` — a cheap no-op
+/// when nothing is missing, so upgrades pick up new bundled skills (e.g.
+/// brainstorming) without touching an agent the user already customized.
+pub fn seed_missing_bundled_skills(
+    template_dir: &Path,
+    mur_home: &Path,
+) -> std::io::Result<Vec<String>> {
+    let agent_dir = mur_home.join("agents").join("mur");
+    let template_skills = template_dir.join("skills");
+    if !agent_dir.join("profile.yaml").is_file() || !template_skills.is_dir() {
+        return Ok(vec![]);
+    }
+
+    let profile_path = agent_dir.join("profile.yaml");
+    let mut profile = std::fs::read_to_string(&profile_path)?;
+    let mut seeded = Vec::new();
+
+    for entry in std::fs::read_dir(&template_skills)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let dst = agent_dir.join("skills").join(&name);
+        let was_missing = !dst.exists();
+        if was_missing {
+            copy_tree(&entry.path(), &dst)?;
+        }
+        let reference = format!("skills/{name}");
+        if !profile
+            .lines()
+            .any(|l| l.trim() == format!("- {reference}"))
+        {
+            profile = append_skill_reference(&profile, &reference);
+        }
+        if was_missing {
+            seeded.push(name);
+        }
+    }
+
+    std::fs::write(&profile_path, profile)?;
+    Ok(seeded)
+}
+
+/// Append `- <reference>` as the last entry of the `skills:` list in `profile`.
+fn append_skill_reference(profile: &str, reference: &str) -> String {
+    let mut lines: Vec<&str> = profile.lines().collect();
+    let skills_idx = lines
+        .iter()
+        .position(|l| l.trim_end() == "skills:")
+        .expect("template profile.yaml must have a skills: list");
+    let mut insert_at = skills_idx + 1;
+    while insert_at < lines.len() && lines[insert_at].trim_start().starts_with("- ") {
+        insert_at += 1;
+    }
+    let new_line = format!("  - {reference}");
+    lines.insert(insert_at, &new_line);
+    let mut out = lines.join("\n");
+    if profile.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,6 +408,105 @@ mod tests {
                 .join("agents/mur/skills/concierge.yaml")
                 .exists()
         );
+    }
+
+    fn make_dir_skill_template(dir: &Path) {
+        std::fs::create_dir_all(dir.join("skills/concierge")).unwrap();
+        std::fs::create_dir_all(dir.join("skills/brainstorming")).unwrap();
+        std::fs::write(
+            dir.join("profile.yaml"),
+            "name: Mur\nskills:\n  - skills/concierge\n  - skills/brainstorming\n",
+        )
+        .unwrap();
+        std::fs::write(dir.join("sys_prompt.md"), "# Mur\n").unwrap();
+        std::fs::write(dir.join("skills/concierge/skill.yaml"), "name: concierge\n").unwrap();
+        std::fs::write(
+            dir.join("skills/brainstorming/skill.yaml"),
+            "name: brainstorming\n",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn seeds_missing_skill_into_existing_agent() {
+        let home = TempDir::new().unwrap();
+        let tpl = TempDir::new().unwrap();
+        make_dir_skill_template(tpl.path());
+
+        // Agent already seeded with only the concierge skill (pre-upgrade state).
+        let agent_dir = home.path().join("agents/mur");
+        std::fs::create_dir_all(agent_dir.join("skills/concierge")).unwrap();
+        std::fs::write(
+            agent_dir.join("profile.yaml"),
+            "name: Mur\nskills:\n  - skills/concierge\n",
+        )
+        .unwrap();
+        std::fs::write(
+            agent_dir.join("skills/concierge/skill.yaml"),
+            "name: concierge\n",
+        )
+        .unwrap();
+
+        let seeded = seed_missing_bundled_skills(tpl.path(), home.path()).unwrap();
+        assert_eq!(seeded, vec!["brainstorming".to_string()]);
+        assert!(agent_dir.join("skills/brainstorming/skill.yaml").exists());
+        let profile = std::fs::read_to_string(agent_dir.join("profile.yaml")).unwrap();
+        assert!(profile.contains("- skills/brainstorming"));
+    }
+
+    #[test]
+    fn never_overwrites_existing_skill() {
+        let home = TempDir::new().unwrap();
+        let tpl = TempDir::new().unwrap();
+        make_dir_skill_template(tpl.path());
+
+        let agent_dir = home.path().join("agents/mur");
+        std::fs::create_dir_all(agent_dir.join("skills/brainstorming")).unwrap();
+        std::fs::create_dir_all(agent_dir.join("skills/concierge")).unwrap();
+        std::fs::write(
+            agent_dir.join("skills/concierge/skill.yaml"),
+            "name: concierge\n",
+        )
+        .unwrap();
+        let sentinel = "name: brainstorming\n# USER EDIT\n";
+        std::fs::write(agent_dir.join("skills/brainstorming/skill.yaml"), sentinel).unwrap();
+        std::fs::write(
+            agent_dir.join("profile.yaml"),
+            "name: Mur\nskills:\n  - skills/concierge\n  - skills/brainstorming\n",
+        )
+        .unwrap();
+
+        let seeded = seed_missing_bundled_skills(tpl.path(), home.path()).unwrap();
+        assert_eq!(seeded, Vec::<String>::new());
+        assert_eq!(
+            std::fs::read_to_string(agent_dir.join("skills/brainstorming/skill.yaml")).unwrap(),
+            sentinel
+        );
+    }
+
+    #[test]
+    fn idempotent_profile_reference() {
+        let home = TempDir::new().unwrap();
+        let tpl = TempDir::new().unwrap();
+        make_dir_skill_template(tpl.path());
+
+        let agent_dir = home.path().join("agents/mur");
+        std::fs::create_dir_all(agent_dir.join("skills/concierge")).unwrap();
+        std::fs::write(
+            agent_dir.join("skills/concierge/skill.yaml"),
+            "name: concierge\n",
+        )
+        .unwrap();
+        std::fs::write(
+            agent_dir.join("profile.yaml"),
+            "name: Mur\nskills:\n  - skills/concierge\n",
+        )
+        .unwrap();
+
+        seed_missing_bundled_skills(tpl.path(), home.path()).unwrap();
+        seed_missing_bundled_skills(tpl.path(), home.path()).unwrap();
+        let profile = std::fs::read_to_string(agent_dir.join("profile.yaml")).unwrap();
+        assert_eq!(profile.matches("- skills/brainstorming").count(), 1);
     }
 
     #[test]
@@ -394,6 +562,35 @@ mod tests {
         let skill = read_from_dir(&tpl.join("skills/concierge")).expect("concierge skill loads");
         validate(&skill).expect("concierge skill validates");
         assert_eq!(skill.name, "concierge");
+    }
+
+    #[test]
+    fn bundled_template_brainstorming_skill_is_loadable_and_stamped() {
+        // Regression guard: the bundled brainstorming skill loads, validates,
+        // and carries the origin stamp the upgrade pipeline needs.
+        use mur_common::skill::{content_hash_for_origin, read_from_dir, validate};
+        let tpl = Path::new(env!("CARGO_MANIFEST_DIR")).join("resources/mur-agent-template");
+        let profile = std::fs::read_to_string(tpl.join("profile.yaml")).unwrap();
+        assert!(
+            profile.contains("- skills/brainstorming"),
+            "profile must reference the brainstorming skill"
+        );
+        let skill =
+            read_from_dir(&tpl.join("skills/brainstorming")).expect("brainstorming skill loads");
+        validate(&skill).expect("brainstorming skill validates");
+        assert_eq!(skill.name, "brainstorming");
+        assert_eq!(
+            skill.origin.as_deref(),
+            Some("registry:mur-official/brainstorming")
+        );
+        assert_eq!(
+            skill.origin_version.as_deref(),
+            Some(skill.version.as_str())
+        );
+        assert_eq!(
+            skill.origin_hash.as_deref(),
+            Some(content_hash_for_origin(&skill).unwrap().as_str())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Ports `superpowers:brainstorming` into a bundled MUR skill (`skills/brainstorming`) for the default concierge, stripped of harness-specific bits and adapted to MUR (pm-fleet-delegation, MC-style questions, zh triggers). MIT attribution noted in the description.
- Adds `origin`/`origin_version`/`origin_hash` fields to `SkillManifest` + `content_hash_for_origin()`, stamping the bundled skill as `registry:mur-official/brainstorming` (needed for the upgrade pipeline; Plan 1 dependency wasn't present in this checkout so added the minimal fields here).
- Adds `seed_missing_bundled_skills()`: on Hub launch, copies any bundled template skill dir missing from an already-seeded `mur` agent and appends the profile reference — never touches an existing skill dir. Lets existing installs pick up brainstorming (and future bundled skills) without a fresh seed.

Implements Tasks 1-3 of `docs/superpowers/plans/2026-07-04-builtin-brainstorming-skill.md` (Plan 2/4). Task 4 (publish to the external skill-registry repo) is out of scope here.

## Test plan
- [x] `cargo nextest run --manifest-path mur-hub-gui/src-tauri/Cargo.toml seed_mur` — 13/13 pass
- [x] `cargo clippy --manifest-path mur-hub-gui/src-tauri/Cargo.toml -- -D warnings` — clean
- [x] `cargo fmt --check` on touched files — clean