### PR TITLE
feat(skill): role skill packs (Tasks 1-3 of 4)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-builtin-brainstorming-skill.md
+++ b/docs/superpowers/plans/2026-07-04-builtin-brainstorming-skill.md
@@ -1,0 +1,87 @@
+# Built-in Brainstorming Skill Implementation Plan (2/4)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every fresh Hub install seeds the default concierge with an official, origin-stamped brainstorming skill; existing installs gain it on next Hub upgrade without touching anything they already have.
+
+**Architecture:** Port `superpowers:brainstorming` to a MUR skill (derived work, MIT attribution), add it to the bundled concierge template (`mur-hub-gui/src-tauri/resources/mur-agent-template/`), stamp it with `origin: registry:mur-official/brainstorming` so Plan 1's pipeline upgrades it, and extend the seeder with a seed-missing-skills pass that never overwrites. Spec §A. **Depends on Plan 1 (origin fields).**
+
+**Tech Stack:** Rust, MUR skill YAML schema (`mur-common/src/skill`), existing `seed_mur.rs` seeder + its regression tests.
+
+## Global Constraints
+
+- Same as Plan 1 (nextest, ORT_STRATEGY, fmt+clippy, ≤800 lines/file).
+- Seeder invariant: **seed only what is absent; never overwrite** — upgrades belong to the registry pipeline.
+- Brand copy uses uppercase "MUR"; skill `name` stays lowercase (`brainstorming`).
+
+---
+
+### Task 1: Author the brainstorming skill
+
+**Files:**
+- Create: `mur-hub-gui/src-tauri/resources/mur-agent-template/skills/brainstorming/skill.yaml`
+- Modify: `mur-hub-gui/src-tauri/resources/mur-agent-template/profile.yaml` (append `- skills/brainstorming` to `skills:`)
+
+**Interfaces:**
+- Produces: a valid `SkillManifest` (passes `mur_common::skill::validate`) named `brainstorming`, `publisher: mur-official`, `version: 1.0.0`, category matching an existing `Category` variant (use the same one the concierge skill uses; check `skills/concierge/skill.yaml`), with `origin: registry:mur-official/brainstorming`, `origin_version: 1.0.0`, `origin_hash` computed via `content_hash_for_origin` (compute with a tiny one-off: `cargo run -p mur-core --example` is overkill — add a `#[test]` in Task 2 that recomputes and asserts the stamp, and paste the value it prints on first failure).
+
+- [ ] **Step 1: Write the content.** Port from `/Users/david/.claude/plugins/cache/claude-plugins-official/superpowers/6.1.1/skills/brainstorming/SKILL.md`, adapted to the MUR fleet context. Required adaptations (the port is a rewrite, not a copy):
+  - Dialogue partner is the human via `murmur`; one question at a time; multiple-choice preferred; 2–3 approaches with a recommendation; sectioned design presentation with per-section confirmation.
+  - Terminal state: hand the agreed design summary to the `pm` agent (via fleet channel/delegation) for spec/plan authoring — NOT Claude Code's writing-plans skill, NOT any implementation action.
+  - Remove everything harness-specific: subagent dispatch, plan mode, Skill tool, visual companion, `docs/superpowers/specs` paths.
+  - Triggers: "brainstorm", "腦暴", "頭腦風暴", "design discussion", "設計討論", "幫我想".
+  - Footer note in the yaml `description` or content: "Derived from obra/superpowers brainstorming (MIT)."
+- [ ] **Step 2: Validate.** `cargo nextest run -p mur-hub-gui bundled_template` — the existing loader regression test (`seed_mur.rs:377` area) must still pass; it validates template skills load. If it only checks `concierge`, that's fine — Task 2 adds the sibling test.
+- [ ] **Step 3: Commit** — `git add mur-hub-gui/src-tauri/resources/mur-agent-template && git commit -m "feat(hub): bundled brainstorming skill for default concierge"`
+
+### Task 2: Template regression test for the new skill
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/seed_mur.rs` (test module, next to `bundled_template_concierge_skill_is_loadable`)
+
+- [ ] **Step 1: Write the test** (mirror the concierge test at `seed_mur.rs:377`):
+
+```rust
+#[test]
+fn bundled_template_brainstorming_skill_is_loadable_and_stamped() {
+    use mur_common::skill::{read_from_dir, validate, hash::content_hash_for_origin};
+    let tpl = /* same template-dir resolution the concierge test uses */;
+    assert!(std::fs::read_to_string(tpl.join("profile.yaml")).unwrap()
+        .contains("- skills/brainstorming"));
+    let skill = read_from_dir(&tpl.join("skills/brainstorming")).expect("loads");
+    validate(&skill).expect("validates");
+    assert_eq!(skill.origin.as_deref(), Some("registry:mur-official/brainstorming"));
+    assert_eq!(skill.origin_version.as_deref(), skill.version.as_str().into());
+    assert_eq!(skill.origin_hash.as_deref().unwrap(),
+        content_hash_for_origin(&skill).unwrap());
+}
+```
+
+- [ ] **Step 2: Run** — first run fails if the pasted `origin_hash` is wrong; the assertion message shows the computed value — fix the yaml, re-run to PASS. (`cargo nextest run -p mur-hub-gui brainstorming` — needs the Hub test env; if the hub crate won't build workspace-side, run via its own manifest: `cargo nextest run --manifest-path mur-hub-gui/src-tauri/Cargo.toml brainstorming`.)
+- [ ] **Step 3: Commit** — `git commit -am "test(hub): template brainstorming skill regression"`
+
+### Task 3: Seed-missing-skills pass for existing installs
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/seed_mur.rs` (`seed_mur_if_missing`, ~line 276, plus its caller)
+- Test: same file's test module
+
+**Interfaces:**
+- Produces: `pub fn seed_missing_template_skills(template_dir: &Path, mur_home: &Path) -> std::io::Result<Vec<String>>` — for each `template_dir/skills/<name>`, if `<mur_home>/agents/mur/skills/<name>` does NOT exist, copy the dir and append `- skills/<name>` to the agent's `profile.yaml` skills list (only if not already referenced). Existing dirs are untouched byte-for-byte. Returns the seeded names. Called on every Hub launch right after the existing seed check (cheap no-op when nothing is missing).
+
+- [ ] **Step 1: Write the failing tests:**
+  - `seeds_missing_skill_into_existing_agent` — agent exists with only `concierge`; run; `brainstorming` dir appears, profile gains the reference, returns `["brainstorming"]`.
+  - `never_overwrites_existing_skill` — pre-create `skills/brainstorming/skill.yaml` with sentinel content `name: brainstorming\n# USER EDIT`; run; file byte-identical, returns `[]`.
+  - `idempotent_profile_reference` — run twice; profile contains the reference exactly once.
+- [ ] **Step 2: Run to verify they fail.**
+- [ ] **Step 3: Implement** (reuse the file-copy helper `copy_tree` already in `seed_mur.rs`; profile edit = read yaml, parse skills list, append, atomic write same as the seeder's existing profile handling).
+- [ ] **Step 4: Run tests** — PASS; clippy clean.
+- [ ] **Step 5: Commit** — `git commit -am "feat(hub): seed missing bundled skills on upgrade (never overwrite)"`
+
+### Task 4: Publish to the official registry
+
+**Files (external repo):** `https://github.com/mur-run/skill-registry` — add `skills/brainstorming/1.0.0/skill.yaml` (identical content, WITHOUT the origin stamp — the stamp is applied at install; registry copies are canonical unstamped) and an `index.yaml` entry (`latest: 1.0.0`, `publisher: mur-official`, `content_sha256` per the registry's existing convention).
+
+- [ ] **Step 1:** Clone registry repo, add files following an existing skill's layout exactly.
+- [ ] **Step 2:** Verify locally: `mur skill upgrade --check` on a machine with the template-seeded skill reports `UpToDate` (stamp version == registry latest).
+- [ ] **Step 3:** Commit + push to the registry repo (PR if it has branch protection).

--- a/docs/superpowers/plans/2026-07-04-relay-one-click-install.md
+++ b/docs/superpowers/plans/2026-07-04-relay-one-click-install.md
@@ -1,0 +1,83 @@
+# Relay One-Click Install Implementation Plan (4/4)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A logged-in Dashboard user clicks "Install to Hub" on a Skill/MCP/Workflow/Plugin card and the item arrives at their Mac's Hub behind a consent modal.
+
+**Architecture:** Dashboard POST → mur-server relay `install_request` command to the user's connected Mac daemon (existing `Hub.SendCommand` machinery) → daemon writes an install-request event → Hub GUI live-tail opens the consent modal → on consent, Hub fetches the item with the configured API key and routes to the existing type-specific installer. Spec §B. Cross-repo: `mur-server` (Go + dashboard) and `mur` (daemon + hub-gui). **Depends on Plan 1 (origin stamping for skill installs).**
+
+**Tech Stack:** Go (mur-server `internal/relay`, `internal/api/handlers`), Next.js dashboard, Rust (`mur-daemon/src/relay_client.rs`, `mur-hub-gui`).
+
+## Global Constraints
+
+- Fail-closed: the Hub NEVER auto-installs; every request passes fetch → preview → security-scan → consent modal.
+- No queue in P1: no connected Mac ⇒ API returns 409 `hub_offline`; Dashboard shows it.
+- mur-server repo conventions per `/Volumes/Firecuda4tb/Projects/mur-server/CLAUDE.md` (read it before Task 1).
+- Rust side: same build/test constraints as Plan 1.
+
+---
+
+### Task 1 (mur-server, Go): `POST /api/v1/install-request`
+
+**Files:**
+- Create: `internal/api/handlers/install_request.go`
+- Modify: `internal/api/server.go` (route registration, session-authenticated group)
+- Test: `internal/api/handlers/install_request_test.go`
+
+**Interfaces:**
+- Consumes: existing session auth middleware (same as other logged-in dashboard APIs), `Hub.SendCommand(userID, action, params, timeout)` (`internal/relay/hub.go:254`).
+- Produces: request `{ "type": "skill|mcp|workflow|plugin", "id": "mur-official/brainstorming" }`; responses `200 {"status":"delivered"}`, `409 {"error":"hub_offline"}`, `400` on bad type/id.
+
+- [ ] **Step 1: Failing tests** — table-driven: (a) valid request with a fake hub that records the command → 200 and the hub saw `action="install_request"`, params containing type+id+requesting user; (b) hub returns no-agent error → 409; (c) `type: "exe"` → 400; (d) unauthenticated → 401 (middleware test, follow the repo's existing handler-test pattern).
+- [ ] **Step 2:** `go test ./internal/api/handlers/ -run TestInstallRequest` → fail.
+- [ ] **Step 3:** Implement: validate `type` against the four-value whitelist, validate `id` as `<publisher>/<name>` slug (lowercase, `[a-z0-9-]`, one slash), then `h.hub.SendCommand(user.ID, "install_request", params, 10*time.Second)`; map the "no agent connected" error to 409.
+- [ ] **Step 4:** Tests pass; `go vet ./...`.
+- [ ] **Step 5:** Commit in mur-server: `feat(api): install-request relay endpoint`.
+
+### Task 2 (mur, Rust): daemon handles the `install_request` command
+
+**Files:**
+- Modify: `mur-daemon/src/relay_client.rs` (frame dispatch in the read loop of `run_once`)
+- Create: `mur-core/src/install_request.rs` (event write + dedup) — declared in both `lib.rs` and `main.rs` module trees (known gotcha)
+- Test: `#[cfg(test)]` in `install_request.rs`
+
+**Interfaces:**
+- Consumes: whatever envelope `Hub.SendCommand` wraps commands in — read `relay_handler.go`'s agent-side command marshaling FIRST and mirror its field names exactly; the daemon must reply with the ack shape `SendCommand` waits for (that's how "delivered" becomes true).
+- Produces: `pub fn record_install_request(mur_home: &Path, req: &InstallRequest) -> Result<PathBuf>` appending a JSON line `{"kind":"install_request","type":…,"id":…,"requested_at":<unix>,"request_id":<uuid from server>}` to `<mur_home>/hub/install-requests.jsonl` (same dir family the Hub already tails for mobile events), deduped by `request_id`.
+
+- [ ] **Step 1: Failing tests** — (a) `record_install_request` appends one line, fields round-trip; (b) same `request_id` twice appends once; (c) rejects `type` outside the four-value whitelist (defense in depth — the server validated, the daemon re-validates).
+- [ ] **Step 2:** fail to compile.
+- [ ] **Step 3:** Implement + wire the relay_client dispatch branch: parse command envelope → `record_install_request` → send ack. Unknown/invalid payload → log warn, ack with error, never crash the relay loop.
+- [ ] **Step 4:** `cargo nextest run -p mur-core install_request` + `-p mur-daemon` PASS.
+- [ ] **Step 5:** Commit: `feat(daemon): receive install_request over relay`.
+
+### Task 3 (mur, Rust+TS): Hub consent modal + install routing
+
+**Files:**
+- Modify: `mur-hub-gui/src-tauri/src/mcp_skills.rs` (or a new `install_inbox.rs` if mcp_skills nears 800 lines): tauri commands `install_inbox_list`, `install_inbox_consent(request_id, approve)`
+- Modify: Hub UI (mur-hub-gui/ui): watcher on `install-requests.jsonl` (same live-tail mechanism as mobile events), consent modal
+- Test: Rust-side routing tests
+
+**Interfaces:**
+- Consumes: Task 2's jsonl; existing installers — skill: registry install path (`cmd/agent/skill.rs`, stamps origin); mcp: feather `mcp add-remote` engine; plugin: Hub plugin import; workflow: **new** `install_workflow(mur_home, yaml) -> Result<PathBuf>` (validate `Workflow` parse + reuse quill's security scan, write `~/.mur/workflows/<name>.yaml`, refuse overwrite without explicit flag).
+- Produces: consent modal showing type, id, publisher, description, scan result, "official" badge when publisher == `mur-official`; Approve → download from mur-server with the configured API key (`mobile_relay.api_key` config) → route by type; Deny → mark the jsonl entry consumed. Processed request_ids recorded in `install-requests.done` so restarts don't re-prompt.
+
+- [ ] **Step 1: Failing tests (Rust)** — (a) `install_workflow` writes a valid workflow yaml and refuses an invalid one; (b) refuses overwrite of an existing workflow; (c) route-by-type dispatch table rejects unknown type.
+- [ ] **Step 2:** fail.
+- [ ] **Step 3:** Implement Rust commands + routing; then UI modal (follow the existing HITL/consent modal component patterns in the Hub UI; reuse `modal.css` conventions).
+- [ ] **Step 4:** `cargo nextest run` (hub manifest path) PASS; `npm run build` in ui.
+- [ ] **Step 5:** Commit: `feat(hub): install-request consent modal + type routing`.
+
+### Task 4 (mur-server, dashboard): "Install to Hub" buttons
+
+**Files:**
+- Modify: dashboard library pages (Skills / MCP Servers / Workflows cards — e.g. the MCP page shown in the design session screenshot) in `/Volumes/Firecuda4tb/Projects/mur-server/dashboard/`
+- Test: component test per the dashboard's existing test setup (check for one before inventing)
+
+- [ ] **Step 1:** Button on each card → `POST /api/v1/install-request`; states: loading → "Sent to your Hub ✓" / "Hub offline — is MUR running on your Mac?" (409) / error toast. Keep a "copy CLI command" secondary action (`mur agent skill install <id>` etc.).
+- [ ] **Step 2:** `npm run build` green; commit in mur-server: `feat(dashboard): one-click Install to Hub`.
+
+### Task 5: Live E2E
+
+- [ ] With daemon connected to the relay (API key configured): click Install on a skill card → consent modal appears on the Hub → approve → `mur agent skill list mur` shows it origin-stamped → `mur skill upgrade --check` says UpToDate.
+- [ ] Negative: stop the daemon → click → Dashboard shows hub-offline. Deny path: modal Deny → nothing installed, request marked done, no re-prompt after Hub restart.

--- a/docs/superpowers/plans/2026-07-04-role-skill-packs.md
+++ b/docs/superpowers/plans/2026-07-04-role-skill-packs.md
@@ -1,0 +1,93 @@
+# Role Skill Packs Implementation Plan (3/4)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fleet role agents get methodology skill packs (superpowers derivatives) installable as one action, tagged by role in the registry.
+
+**Architecture:** Port nine superpowers skills to MUR skills, publish under `mur-official`, add `recommended_roles` to the registry entry model, and add `mur agent skill install-pack <role>` (the Hub wizard consumes the same engine later). Spec §D. **Depends on Plan 1 (origin pipeline) and Plan 2 Task 4 (registry publishing pattern).**
+
+**Tech Stack:** MUR skill YAML, `mur-common/src/skill/registry.rs`, `mur-core/src/cmd/agent/skill.rs`.
+
+## Global Constraints
+
+- Same as Plan 1 (nextest, ORT_STRATEGY, fmt+clippy).
+- Ports are rewrites for the MUR runtime: replace "dispatch subagent" with fleet delegation or sequential execution; replace Claude-Code tool names with the agent runtime's tools (bash, file ops); strip plan-mode/Skill-tool/TodoWrite references. Attribution: "Derived from obra/superpowers <name> (MIT)."
+- All published skills are canonical-unstamped in the registry; origin stamps apply at install (Plan 1 Task 2).
+
+## Skill → Role Map (source: superpowers 6.1.1 plugin cache)
+
+| Registry name | Source skill | recommended_roles | Port notes |
+|---|---|---|---|
+| brainstorming | brainstorming | concierge | done in Plan 2 |
+| writing-plans | writing-plans | pm | terminal state = write plan file + report path to router; consumes brainstorming's design summary |
+| executing-plans | executing-plans | coder | batch/checkpoint execution of a plan file; no subagents — sequential tasks |
+| test-driven-development | test-driven-development | coder | keep RED-GREEN-REFACTOR verbatim; map commands to `cargo nextest` example |
+| using-git-worktrees | using-git-worktrees | coder | worktrees under repo `.worktrees/` (project convention), never `~/.mur` |
+| systematic-debugging | systematic-debugging | coder | phase-gated root-cause process; drop subagent dispatch |
+| verification-before-completion | verification-before-completion | coder | "run the verification command and read its output before claiming done" |
+| receiving-code-review | receiving-code-review | coder | verify feedback technically before applying; no performative agreement |
+| code-review | requesting-code-review | qa | **semantics inverted**: qa IS the reviewer — how to review a diff against a plan/spec and report severity-ranked findings |
+| finishing-a-development-branch | finishing-a-development-branch | repo | merge/PR decision flow; merge-commit for stacked bases (project convention) |
+
+---
+
+### Task 1: `recommended_roles` on the registry entry
+
+**Files:**
+- Modify: `mur-common/src/skill/registry.rs` (`RegistrySkillEntry`)
+- Test: existing registry tests in the same file/module
+
+- [ ] **Step 1: Failing test** — parse an `index.yaml` snippet with `recommended_roles: [coder, qa]` into `RegistrySkillEntry` and assert the vec; assert an entry without the key parses to `[]` (back-compat).
+- [ ] **Step 2:** Run `cargo nextest run -p mur-common registry` → fails.
+- [ ] **Step 3:** Add to `RegistrySkillEntry`:
+
+```rust
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub recommended_roles: Vec<String>,
+```
+
+Role vocabulary (validate loosely, don't enum-lock the registry format): `concierge|pm|coder|qa|repo`.
+- [ ] **Step 4:** Tests pass; commit `feat(skill): recommended_roles on registry entries`.
+
+### Task 2: Port the nine skills
+
+One sub-step per skill, same recipe as Plan 2 Task 1 (read source SKILL.md from the superpowers 6.1.1 plugin cache, rewrite per the Port-notes column, `version: 1.0.0`, `publisher: mur-official`, validate with `mur_common::skill::validate`). Work in a scratch dir `registry-work/skills/<name>/1.0.0/skill.yaml`.
+
+- [ ] writing-plans
+- [ ] executing-plans
+- [ ] test-driven-development
+- [ ] using-git-worktrees
+- [ ] systematic-debugging
+- [ ] verification-before-completion
+- [ ] receiving-code-review
+- [ ] code-review (inverted)
+- [ ] finishing-a-development-branch
+- [ ] **Validation gate:** a small `#[test]` (temporary, or a `tests/` file in mur-common pointed at the scratch dir via env) that `read_from_dir` + `validate` passes for all nine. Alternative: `mur agent skill install --file <dir> --dry-run` if that exists — check `mur agent skill --help` first.
+- [ ] Commit the scratch dir? No — registry files live in the registry repo (Task 4). Nothing in this repo to commit for this task.
+
+### Task 3: `mur agent skill install-pack <role> --agent <name>`
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/skill.rs` (new subcommand beside the existing install)
+- Test: `#[cfg(test)]` in the same file
+
+**Interfaces:**
+- Consumes: `skill_registry::{fetch_and_load}`, Task 1's `recommended_roles`, the existing single-skill registry install path (which stamps origin per Plan 1 Task 2).
+- Produces: installs every registry skill whose `recommended_roles` contains `<role>` into the agent, skipping ones already present (report `installed: [...] skipped: [...]`).
+
+- [ ] **Step 1: Failing test** — with a fake registry index (three entries: two `coder`, one `qa`), `pack_members(&index, "coder")` returns exactly the two coder names, sorted.
+- [ ] **Step 2:** fails to compile.
+- [ ] **Step 3:** Implement `pack_members` (pure filter) + the subcommand loop reusing the existing install fn per name; already-installed check = `agent_skill_dir(...).join(name).exists()`.
+- [ ] **Step 4:** `cargo nextest run -p mur-core pack` PASS; clippy clean.
+- [ ] **Step 5:** Commit `feat(cli): mur agent skill install-pack <role>`.
+
+### Task 4: Publish + wire the fleet
+
+- [ ] Publish all nine to the registry repo (same recipe as Plan 2 Task 4) with `recommended_roles` in `index.yaml`.
+- [ ] Dogfood on this machine: `mur agent skill install-pack coder --agent rustsmith`, `install-pack coder --agent frontend`, `install-pack qa --agent qa`, `install-pack repo --agent repomanager`, `install-pack pm --agent pm`. Verify: `mur agent skill list <agent>` shows the pack; `mur skill upgrade --check` reports all `UpToDate`.
+- [ ] Restart the affected runtimes (never auto-restart — `mur agent restart` per agent, concierge is Hub-managed).
+
+## Deferred
+
+- Hub agent-creation-wizard pack picker UI (consumes `install-pack` engine; fold into the next Hub UI batch).
+- Dashboard role filtering (Plan 4's surface).

--- a/docs/superpowers/plans/2026-07-04-skill-origin-upgrade-pipeline.md
+++ b/docs/superpowers/plans/2026-07-04-skill-origin-upgrade-pipeline.md
@@ -1,0 +1,319 @@
+# Skill Origin Stamps + Upgrade Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Registry-installed and built-in skills carry an origin stamp and auto-upgrade through one pipeline; user-modified skills are never overwritten.
+
+**Architecture:** Three origin fields on `SkillManifest` + an origin-stable content hash in `mur-common`; an upgrade engine in `mur-core` that compares installed origin-stamped skills against the git registry cache and applies upgrades only when the local content is unmodified; a `mur skill upgrade` CLI; a daily daemon tick. Spec: `docs/superpowers/specs/2026-07-04-builtin-skills-registry-install-design.md` §C.
+
+**Tech Stack:** Rust (edition 2024), serde/serde_yaml_ng, existing `mur_common::skill` module, existing git-based registry client (`mur-core/src/cmd/skill_registry.rs`).
+
+## Global Constraints
+
+- No hardcoded values — registry URL comes from `skill_registry::DEFAULT_REGISTRY` / config.
+- Single source file ≤ 800 lines.
+- Fail-closed: any error during upgrade of one skill skips that skill and continues; never write a partially-upgraded manifest (use existing atomic `write_to_dir`).
+- Never overwrite a user-modified skill (drift hash mismatch ⇒ skip + report).
+- Test with `cargo nextest run -p <crate>` (plain `cargo test --workspace` is flaky); build env needs `ORT_STRATEGY=download` and, for `mur-core` lib, `MUR_WEB_DIST=$HOME/Projects/mur-web/dist`.
+- Run `cargo fmt --all` and `cargo clippy --workspace -- -D warnings` before each commit.
+
+---
+
+### Task 1: Origin fields on `SkillManifest` + origin-stable hash
+
+**Files:**
+- Modify: `mur-common/src/skill/manifest.rs` (struct `SkillManifest`, ~line 124)
+- Modify: `mur-common/src/skill/hash.rs`
+- Test: inline `#[cfg(test)]` in `mur-common/src/skill/hash.rs`
+
+**Interfaces:**
+- Produces: `SkillManifest.origin: Option<String>`, `origin_version: Option<String>`, `origin_hash: Option<String>` (all serde-default, skipped when `None`), and `pub fn content_hash_for_origin(m: &SkillManifest) -> Result<String, ParseError>` in `hash.rs`.
+- Key invariant: `content_hash_for_origin` excludes `origin`/`origin_version`/`origin_hash` (plus `transfer_chain`/`evolution_log`, like `content_hash_for_trust`) so restamping after an upgrade does not change the hash it is compared against.
+
+- [ ] **Step 1: Write the failing test** (append to `hash.rs` tests)
+
+```rust
+#[test]
+fn origin_hash_stable_across_restamp() {
+    let yaml = "name: t\nversion: 1.0.0\npublisher: mur-official\ndescription: d\ncategory: workflow\n";
+    let mut m: SkillManifest = crate::skill::parse_str(yaml).unwrap();
+    let before = content_hash_for_origin(&m).unwrap();
+    m.origin = Some("registry:mur-official/t".into());
+    m.origin_version = Some("1.1.0".into());
+    m.origin_hash = Some(before.clone());
+    assert_eq!(content_hash_for_origin(&m).unwrap(), before);
+    // but real content changes DO change it
+    m.description = "changed".into();
+    assert_ne!(content_hash_for_origin(&m).unwrap(), before);
+}
+```
+
+(Use whatever the crate's existing yaml-parse entry point is — the same
+one `read_from_dir` uses in `store.rs:48` — if `parse_str` isn't its name.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run -p mur-common origin_hash_stable`
+Expected: compile error — fields/function don't exist.
+
+- [ ] **Step 3: Implement**
+
+In `manifest.rs`, after the `visibility` field (follow the `scope` field's serde style):
+
+```rust
+/// Registry origin stamp: `registry:<publisher>/<name>`. Present on
+/// built-in and registry-installed skills; drives the upgrade pipeline.
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub origin: Option<String>,
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub origin_version: Option<String>,
+/// `content_hash_for_origin` of the content as shipped; mismatch with
+/// the current content means the user modified the skill locally.
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub origin_hash: Option<String>,
+```
+
+In `hash.rs`:
+
+```rust
+/// Origin-stable content hash: excludes the origin stamp itself (and the
+/// trust-excluded fields) so restamping never changes the hash.
+pub fn content_hash_for_origin(m: &SkillManifest) -> Result<String, crate::skill::ParseError> {
+    let mut clone = m.clone();
+    clone.transfer_chain = vec![];
+    clone.evolution_log = vec![];
+    clone.origin = None;
+    clone.origin_version = None;
+    clone.origin_hash = None;
+    content_sha256(&clone)
+}
+```
+
+If `SkillManifest` construction sites break (struct literals), add `..Default::default()` or the three `None` fields as needed.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo nextest run -p mur-common`
+Expected: all PASS (including existing hash/sign tests — origin fields are `None` by default so canonical serialization of old manifests is unchanged; if a sign/trust-hash test fails, that's a regression to fix, not to accept).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/skill/manifest.rs mur-common/src/skill/hash.rs
+git commit -m "feat(skill): origin stamp fields + origin-stable content hash"
+```
+
+---
+
+### Task 2: Stamp origin at registry install time
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/skill.rs` (registry-resolved install path that calls `write_to_dir` at ~line 94)
+- Test: existing test module in the same file (or sibling test file if none)
+
+**Interfaces:**
+- Consumes: Task 1 fields + `content_hash_for_origin`.
+- Produces: every skill installed FROM THE REGISTRY lands on disk with `origin: registry:<publisher>/<name>`, `origin_version: <installed version>`, `origin_hash: <hash>`. Non-registry installs (local path, remote URL via quill) are NOT stamped in this task.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn registry_install_stamps_origin() {
+    // arrange a manifest as the install path has it just before write_to_dir
+    let yaml = "name: t\nversion: 1.2.0\npublisher: mur-official\ndescription: d\ncategory: workflow\n";
+    let mut m: mur_common::skill::SkillManifest = /* crate's parse entry */;
+    stamp_registry_origin(&mut m);
+    assert_eq!(m.origin.as_deref(), Some("registry:mur-official/t"));
+    assert_eq!(m.origin_version.as_deref(), Some("1.2.0"));
+    assert_eq!(
+        m.origin_hash.as_deref().unwrap(),
+        mur_common::skill::hash::content_hash_for_origin(&m).unwrap()
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cargo nextest run -p mur-core registry_install_stamps_origin` → compile error.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// Stamp a registry-sourced manifest with its origin identity so the
+/// upgrade pipeline can track it. Idempotent.
+pub fn stamp_registry_origin(m: &mut SkillManifest) {
+    m.origin = Some(format!("registry:{}/{}", m.publisher, m.name));
+    m.origin_version = Some(m.version.clone());
+    m.origin_hash = None; // exclude stamp fields, then hash
+    m.origin_hash = mur_common::skill::hash::content_hash_for_origin(m).ok();
+}
+```
+
+Call it in the registry-install path in `agent/skill.rs` immediately before `write_to_dir(&dest_dir, &manifest)` — only on the branch where the manifest was resolved via `skill_resolver`/`skill_registry` (trace the caller; do not stamp local-file or quill-URL installs).
+
+- [ ] **Step 4: Run tests** — `cargo nextest run -p mur-core` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/skill.rs
+git commit -m "feat(skill): stamp registry origin on install"
+```
+
+---
+
+### Task 3: Upgrade engine (`skill_upgrade.rs`)
+
+**Files:**
+- Create: `mur-core/src/cmd/skill_upgrade.rs`
+- Modify: `mur-core/src/cmd/mod.rs` (add `pub mod skill_upgrade;`) — mind the known gotcha: mur-core modules must be declared in BOTH `lib.rs` and `main.rs` module trees if both exist.
+- Test: `#[cfg(test)]` in `skill_upgrade.rs` using `tempfile::TempDir`
+
+**Interfaces:**
+- Consumes: `skill_registry::{load_index, skill_yaml_path, available_versions}`, `store::{read_from_dir, write_to_dir, global_skill_dir, agent_skill_dir}`, `hash::content_hash_for_origin`, Task 2's stamp.
+- Produces:
+
+```rust
+pub enum UpgradeStatus { UpToDate, Upgraded { from: String, to: String },
+                         BlockedModified { local: String, latest: String },
+                         NotInRegistry, Error(String) }
+pub struct UpgradeItem { pub name: String, pub dir: PathBuf, pub status: UpgradeStatus }
+pub struct UpgradeReport { pub items: Vec<UpgradeItem> }
+/// Scan all origin-stamped skills (global `~/.mur/skills/*` and every
+/// `~/.mur/agents/*/skills/*`) against the registry cache.
+/// `apply=false` = check only.
+pub fn upgrade_all(mur_home: &Path, registry_dir: &Path, apply: bool) -> UpgradeReport
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // helper: write a skill dir + a fake registry dir (index.yaml +
+    // skills/<name>/<version>/skill.yaml) in a TempDir, mirroring the
+    // layout skill_yaml_path() expects.
+
+    #[test]
+    fn unmodified_skill_upgrades_and_restamps() {
+        // local: v1.0.0 stamped, content untouched; registry latest: 1.1.0
+        // expect: status Upgraded{1.0.0→1.1.0}; on-disk manifest is the
+        // registry 1.1.0 content, origin_version=1.1.0,
+        // origin_hash == content_hash_for_origin(new)
+    }
+
+    #[test]
+    fn modified_skill_is_never_overwritten() {
+        // local: v1.0.0 stamped, then description edited (hash drifts)
+        // registry latest: 1.1.0
+        // expect: BlockedModified; on-disk file byte-identical to before
+    }
+
+    #[test]
+    fn check_mode_writes_nothing() { /* apply=false, upgradable skill, file unchanged */ }
+
+    #[test]
+    fn unstamped_and_unknown_skills_are_skipped() {
+        // one skill without origin (ignored entirely),
+        // one stamped but absent from index (NotInRegistry)
+    }
+}
+```
+
+Write the four tests fully (arrange/act/assert with real yaml strings) before any implementation.
+
+- [ ] **Step 2: Run to verify they fail** — `cargo nextest run -p mur-core skill_upgrade` → compile error.
+
+- [ ] **Step 3: Implement**
+
+Core loop, per skill dir found:
+
+```rust
+let Ok(mut local) = read_from_dir(&dir) else { continue };
+let Some(origin) = local.origin.clone() else { continue };
+let Some(key) = origin.strip_prefix("registry:") else { continue };
+let (_, name) = key.rsplit_once('/').unwrap_or(("", key));
+let Some(entry) = index.skills.get(name) else { push(NotInRegistry); continue };
+let local_ver = local.origin_version.clone().unwrap_or_default();
+if entry.latest == local_ver { push(UpToDate); continue }
+let modified = local.origin_hash.as_deref()
+    != content_hash_for_origin(&local).ok().as_deref();
+if modified { push(BlockedModified{..}); continue }
+if !apply { push(Upgraded{..}); continue } // check mode reports what WOULD happen
+let new_yaml_path = skill_yaml_path(registry_dir, name, &entry.latest);
+// parse, validate, stamp_registry_origin, write_to_dir(&dir, &new); fail → Error(..), continue
+```
+
+Skill-dir discovery: `global_skill_dir`'s parent (`~/.mur/skills/`) plus each `~/.mur/agents/<a>/skills/` — plain `read_dir`, skip non-dirs and dirs without `skill.yaml`.
+
+- [ ] **Step 4: Run tests** — `cargo nextest run -p mur-core skill_upgrade` → 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/skill_upgrade.rs mur-core/src/cmd/mod.rs mur-core/src/lib.rs mur-core/src/main.rs
+git commit -m "feat(skill): origin-aware upgrade engine (drift-safe)"
+```
+
+---
+
+### Task 4: `mur skill upgrade` CLI
+
+**Files:**
+- Modify: `mur-core/src/cmd/skill_cmd.rs` (add subcommand where the existing `skill` subcommands are declared — follow the pattern of `skill scope`)
+- Test: `#[cfg(test)]` covering the report formatter
+
+**Interfaces:**
+- Consumes: `skill_upgrade::upgrade_all`, `skill_registry::{fetch_registry, DEFAULT_REGISTRY, registry_cache_dir}`.
+- Produces: `mur skill upgrade [--check] [--json]`. Default applies; `--check` reports only; `--json` emits the report as JSON (derive `Serialize` on the report types) for the Hub to consume later.
+
+- [ ] **Step 1: Write the failing test** — formatter test: an `UpgradeReport` with one item of each status renders one line per item, e.g. `upgraded brainstorming 1.0.0 → 1.1.0`, `blocked (locally modified) foo: local 1.0.0, latest 1.2.0`, and a summary line `2 upgraded, 1 blocked, 3 up-to-date`.
+
+- [ ] **Step 2: Run to verify it fails** — `cargo nextest run -p mur-core upgrade_report_format` → compile error.
+
+- [ ] **Step 3: Implement** — subcommand handler: `fetch_registry(mur_home, DEFAULT_REGISTRY)` (respect the existing registry-URL config override if `skill_cmd.rs` has one — grep before hardcoding), then `upgrade_all(...)`, then print via the formatter or `serde_json::to_string_pretty`. Registry fetch failure = clean error exit, not a panic.
+
+- [ ] **Step 4: Run** — `cargo nextest run -p mur-core` PASS, then a manual smoke: `cargo run -- skill upgrade --check` on the dev machine prints a report (likely all skills unstamped → empty report; that's correct).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/skill_cmd.rs mur-core/src/cmd/skill_upgrade.rs
+git commit -m "feat(cli): mur skill upgrade (--check/--json)"
+```
+
+---
+
+### Task 5: Daily auto-upgrade tick in the daemon
+
+**Files:**
+- Create: `mur-daemon/src/skill_upgrade_tick.rs` (mirror the structure of `mur-daemon/src/fleet_tick.rs`)
+- Modify: `mur-daemon/src/main.rs` (spawn alongside `fleet_tick`)
+- Test: `#[cfg(test)]` in `skill_upgrade_tick.rs` for the due-check
+
+**Interfaces:**
+- Consumes: `mur_core::cmd::skill_upgrade::upgrade_all`, `skill_registry::fetch_registry`.
+- Produces: once per 24h (stamp file `~/.mur/cache/.skill-upgrade-last-run`, same pattern as fleets' `.last_run`), the daemon fetches the registry and runs `upgrade_all(apply=true)`. Config gate `skills.auto_upgrade: bool` in `config.yaml`, **default true** (matches plugin auto-update expectations; upgrades touch only unmodified official-origin skills, and drift-blocking makes it non-destructive). Log one `tracing::info!` summary; blocked items logged at `warn` so the Hub/user can see them.
+
+- [ ] **Step 1: Write the failing test** — due-check: stamp file absent → due; stamped now → not due; stamped 25h ago (write a fake old timestamp) → due.
+
+- [ ] **Step 2: Run to verify it fails** — `cargo nextest run -p mur-daemon skill_upgrade` → compile error.
+
+- [ ] **Step 3: Implement** — `is_due(mur_home) -> bool` reading the stamp file (unix-seconds text, like fleet `.last_run`); tick task on the existing 30s cycle: if config flag on and due → `std::thread::spawn` the fetch+upgrade (registry fetch shells out to git — keep it off the async runtime, same reasoning as fleet loops), write stamp after completion.
+
+- [ ] **Step 4: Run tests** — `cargo nextest run -p mur-daemon` → PASS; `cargo clippy --workspace -- -D warnings`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-daemon/src/skill_upgrade_tick.rs mur-daemon/src/main.rs
+git commit -m "feat(daemon): daily auto-upgrade for origin-stamped skills"
+```
+
+---
+
+## Deferred to later plans (per spec order)
+
+- Plan 2 (A): port brainstorming skill, publish to registry, seed in Hub template with origin stamp, seed-missing-only on Hub upgrade.
+- Plan 3 (D): role skill packs + `recommended_roles` + wizard integration.
+- Plan 4 (B): relay install_request frame, daemon handler, Hub consent UI (which will also surface Task 5's blocked-modified items), Dashboard buttons.

--- a/docs/superpowers/specs/2026-07-04-builtin-skills-registry-install-design.md
+++ b/docs/superpowers/specs/2026-07-04-builtin-skills-registry-install-design.md
@@ -1,0 +1,142 @@
+# Built-in Role Skills + Registry One-Click Install — Design
+
+**Date:** 2026-07-04
+**Status:** Approved (brainstormed with David)
+
+## Problem
+
+1. Design conversations (brainstorming) happen outside the fleet — in the
+   supervisor's head — so the default MUR concierge should ship with a
+   brainstorming skill built in, for every Hub user, not just this machine.
+2. The Dashboard (app.mur.run) lists official Skills / MCP Servers /
+   Workflows, and the Hub has Plugins — four install surfaces with no
+   unified "click on Dashboard → installed in my Hub" path.
+3. Built-in skills baked into the app bundle would be frozen; they need the
+   same auto-upgrade behavior plugins already have.
+4. Fleet role agents (coder, pm, qa, repo) should come with methodology
+   skills (superpowers derivatives) matched to their role.
+
+## Design
+
+### A. Built-in brainstorming skill (default concierge)
+
+- Rewrite `superpowers:brainstorming` as a MUR skill (derived work, MIT
+  attribution) — human-in-the-loop dialogue: one question at a time,
+  2–3 approaches with a recommendation, sectioned design presentation,
+  ends by handing the agreed design to `pm` for spec/plan authoring.
+- Placement rationale: in a fleet only the concierge (`mur`) has a human
+  conversation surface; dialogue skills on members degrade into
+  self-talk and router relays compress >2–3KB content (proven gotcha).
+  `pm` keeps its meaning as the artifact/tracking role — it is NOT the
+  brainstormer. BMAD-method is not adopted (it duplicates what MUR fleet
+  already is); only its phase structure is borrowed:
+  brainstorm (mur↔human) → spec (pm) → implement (coders) → qa → repo.
+- Ship in the bundled concierge template (`mur-hub-gui` `seed_mur.rs`
+  template dir): `skills/brainstorming/skill.yaml` + profile reference +
+  regression test mirroring the existing concierge-skill test.
+- Template snapshot is an **offline first-run seed only**. It seeds a
+  skill only when absent; it never overwrites anything. Upgrades flow
+  through the registry channel (C).
+
+### B. Dashboard one-click install (web → Hub bridge)
+
+**Deep link** (the vscode:// pattern), via the Tauri deep-link plugin:
+
+```
+mur://install?type=skill|mcp|workflow|plugin&url=<https source>&name=<display>
+```
+
+- Dashboard cards get an "Install to Hub" button = a `mur://` anchor,
+  plus a "copy CLI command" fallback (`mur agent skill install <url>`,
+  `mur agent mcp add-remote …`) for users without the Hub.
+  Dashboard side is UI-only; no server backend needed.
+- Rejected alternatives: localhost HTTP from dashboard JS (CORS, port
+  probing by arbitrary pages — worst security); relay-based install
+  queue (cross-device, needs account/queue/poll — deferred to P2).
+
+**Security (fail-closed, non-negotiable):** any web page can forge a
+`mur://` link, therefore:
+
+- The Hub NEVER auto-installs from a deep link. Every install routes
+  through the existing fetch → preview → consent modal (source URL,
+  content summary, security-scan result) before anything is written.
+- `url` must be https (reuse `validate_skill_url`; http only for
+  localhost dev). Official registry domains show an "official" badge;
+  any other domain shows a prominent warning.
+- Cold start: if the Hub isn't running the OS launches it; the
+  deep-link plugin delivers the pending URL, consent modal opens then.
+
+**Routing per type — all reuse existing installers:**
+
+| type | pipeline |
+|---|---|
+| `skill` | quill remote-skill pipeline (`mur-core/src/cmd/agent/skill_remote.rs`): validate → fetch → parse+scan preview → consent → install to chosen agent or user scope |
+| `mcp` | feather pipeline (`mcp add-remote` engine: probe, OAuth/bearer, keychain, consent) |
+| `plugin` | Hub's existing plugin discover/import |
+| `workflow` | the one new installer: fetch yaml → reuse quill's scan/consent shell → write `~/.mur/workflows/` |
+
+### C. Upgrade pipeline for built-in / registry skills
+
+Built-in ≠ a fork baked into the binary. Built-in = **pre-installed
+official registry skill**. The registry copy is the source of truth;
+the bundled template is an offline snapshot.
+
+Skill manifests gain origin stamps:
+
+```yaml
+origin: registry:mur-official/brainstorming
+origin_version: 1.0.0
+origin_hash: sha256:…        # content hash as shipped
+```
+
+The Hub's existing plugin update check extends to every skill with an
+`origin: registry:*` stamp:
+
+- registry version > local `origin_version` AND local content hash ==
+  `origin_hash` (user has not modified) → auto-upgrade, restamp.
+- user-modified (hash mismatch) → never overwrite; notify "official
+  update available, you have local changes" with keep / overwrite /
+  diff choices. Reuses quill's drift detection.
+- Hub app upgrades re-run the seeder: seed only missing skills; the
+  template never overwrites.
+
+Upstream (github.com/obra/superpowers) updates do NOT auto-sync: our
+skills are rewritten derivatives; the publisher reviews upstream
+changes and bumps the registry version manually.
+
+One mechanism covers built-in skills, Dashboard-installed skills, and
+plugins — no second upgrade system.
+
+### D. Role skill packs (superpowers derivatives for fleet roles)
+
+All published in the official registry as rewritten MUR skills (same
+origin/upgrade pipeline as C). Superpowers skills target the Claude
+Code harness (subagent dispatch, plan mode, Skill tool); each must be
+**ported**, mapping "dispatch subagent" onto fleet delegation or plain
+sequential execution — not copy-pasted.
+
+| Role | Skills | Notes |
+|---|---|---|
+| concierge (`mur`) | brainstorming | dialogue surface |
+| pm | writing-plans | brainstorming's terminal state; joins pm's existing spec/PRD skills |
+| coder (rustsmith, frontend) | executing-plans, test-driven-development, using-git-worktrees, systematic-debugging, verification-before-completion, receiving-code-review | last three added in review: debug methodology, "verify before claiming done" (counters false completion reports), rigor when receiving review feedback |
+| qa | code-review (ported from requesting-code-review, **semantics inverted**: in superpowers the implementer requests a review; in a fleet qa IS the reviewer, so qa's skill is "how to perform a review") | |
+| repomanager | finishing-a-development-branch | merge/PR decisions belong to the repo role per fleet division of labor (David initially suggested rustsmith; changeable at review) |
+
+Registry skills carry `recommended_roles: [concierge|pm|coder|qa|repo]`.
+The Hub agent-creation wizard and Dashboard filter by role so a new
+agent gets its role pack in one action instead of per-skill installs.
+
+## Out of scope (deferred)
+
+- Relay-based cross-device install queue (P2)
+- Installed-state feedback on the Dashboard (needs a return channel, P2)
+- Signature verification beyond quill's existing TOFU
+- Auto-tracking upstream superpowers releases
+
+## Implementation order
+
+1. **C first** (origin stamps + update check) — A and D depend on it
+2. **A** (port brainstorming, seed template, registry publish)
+3. **D** (port the remaining role skills, `recommended_roles`, wizard pack UI)
+4. **B** (deep link plugin + consent routing + workflow installer + Dashboard buttons)

--- a/docs/superpowers/specs/2026-07-04-builtin-skills-registry-install-design.md
+++ b/docs/superpowers/specs/2026-07-04-builtin-skills-registry-install-design.md
@@ -38,33 +38,46 @@
   skill only when absent; it never overwrites anything. Upgrades flow
   through the registry channel (C).
 
-### B. Dashboard one-click install (web → Hub bridge)
+### B. Dashboard one-click install (web → Hub, relay-direct)
 
-**Deep link** (the vscode:// pattern), via the Tauri deep-link plugin:
+The account-level authenticated chain already exists: the Mac daemon
+connects to the relay with the user's MUR API key
+(`mur-daemon/src/relay_client.rs`, Bearer auth); the server resolves
+the user and routes per user ID (`internal/relay/hub.go`). Install
+requests ride that same channel — no new auth system, no URL scheme.
 
-```
-mur://install?type=skill|mcp|workflow|plugin&url=<https source>&name=<display>
-```
+Flow:
 
-- Dashboard cards get an "Install to Hub" button = a `mur://` anchor,
-  plus a "copy CLI command" fallback (`mur agent skill install <url>`,
-  `mur agent mcp add-remote …`) for users without the Hub.
-  Dashboard side is UI-only; no server backend needed.
-- Rejected alternatives: localhost HTTP from dashboard JS (CORS, port
-  probing by arbitrary pages — worst security); relay-based install
-  queue (cross-device, needs account/queue/poll — deferred to P2).
+1. Dashboard (logged-in session) → `POST /api/v1/install-request`
+   `{type: skill|mcp|workflow|plugin, id: mur-official/…}`.
+2. mur-server relay hub forwards a new frame type
+   (`install_request`) to that user's connected Mac daemon.
+   If no Mac is connected, the API returns "Hub offline" and the
+   Dashboard shows it (no queue in P1).
+3. Daemon `relay_client` handles the frame by writing an
+   install-request event; the Hub GUI picks it up via the existing
+   `mobile-events.jsonl` live-tail and opens the consent modal.
+4. On consent, the Hub downloads the item from mur-server using the
+   already-configured API key (content is auth-gated) and routes to
+   the type-specific installer below.
 
-**Security (fail-closed, non-negotiable):** any web page can forge a
-`mur://` link, therefore:
+**Security (fail-closed):** requests originate only from the user's
+authenticated Dashboard session — not forgeable by arbitrary web pages
+(the reason `mur://` deep links were rejected). The Hub still NEVER
+auto-installs: every request goes through fetch → preview →
+security-scan → consent modal before anything is written.
 
-- The Hub NEVER auto-installs from a deep link. Every install routes
-  through the existing fetch → preview → consent modal (source URL,
-  content summary, security-scan result) before anything is written.
-- `url` must be https (reuse `validate_skill_url`; http only for
-  localhost dev). Official registry domains show an "official" badge;
-  any other domain shows a prominent warning.
-- Cold start: if the Hub isn't running the OS launches it; the
-  deep-link plugin delivers the pending URL, consent modal opens then.
+Rejected alternatives: `mur://` deep link (forgeable by any page,
+can't fetch auth-gated content without a grant-token side system,
+3-platform scheme registration, same-machine only, no status
+feedback); localhost HTTP from dashboard JS (CORS, port probing —
+worst security).
+
+Prerequisite: user logged in / API key configured + daemon running —
+already required since registry content is login-gated. The Dashboard
+button guides unpaired users to the Devices pairing flow. A "copy CLI
+command" fallback remains on each card
+(`mur agent skill install <url>`, `mur agent mcp add-remote …`).
 
 **Routing per type — all reuse existing installers:**
 
@@ -129,8 +142,7 @@ agent gets its role pack in one action instead of per-skill installs.
 
 ## Out of scope (deferred)
 
-- Relay-based cross-device install queue (P2)
-- Installed-state feedback on the Dashboard (needs a return channel, P2)
+- Offline install queue (Hub offline → Dashboard just reports it, P2)
 - Signature verification beyond quill's existing TOFU
 - Auto-tracking upstream superpowers releases
 
@@ -139,4 +151,4 @@ agent gets its role pack in one action instead of per-skill installs.
 1. **C first** (origin stamps + update check) — A and D depend on it
 2. **A** (port brainstorming, seed template, registry publish)
 3. **D** (port the remaining role skills, `recommended_roles`, wizard pack UI)
-4. **B** (deep link plugin + consent routing + workflow installer + Dashboard buttons)
+4. **B** (relay install_request frame + daemon handler + Hub consent routing + workflow installer + Dashboard buttons)

--- a/mur-common/src/skill/registry.rs
+++ b/mur-common/src/skill/registry.rs
@@ -25,6 +25,8 @@ pub struct RegistrySkillEntry {
     pub content_sha256: String,
     #[serde(default)]
     pub install_count: u64,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recommended_roles: Vec<String>,
 }
 
 impl RegistryIndex {
@@ -116,6 +118,29 @@ skills:
     fn no_match_returns_empty() {
         let idx = RegistryIndex::from_yaml(SAMPLE).unwrap();
         assert!(idx.search("zzz").is_empty());
+    }
+
+    #[test]
+    fn recommended_roles_parses_and_defaults_empty() {
+        let idx = RegistryIndex::from_yaml(SAMPLE).unwrap();
+        assert!(idx.skills["research-prices"].recommended_roles.is_empty());
+
+        let with_roles = RegistryIndex::from_yaml(
+            r#"
+skills:
+  writing-plans:
+    latest: 1.0.0
+    description: d
+    publisher: mur-official
+    category: workflow
+    recommended_roles: [pm]
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            with_roles.skills["writing-plans"].recommended_roles,
+            vec!["pm".to_string()]
+        );
     }
 
     #[test]

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -748,6 +748,19 @@ pub enum AgentSkillAction {
         #[arg(long)]
         yes: bool,
     },
+    /// Install every registry skill recommended for a fleet role onto an
+    /// agent (e.g. `install-pack coder`), skipping ones already installed.
+    InstallPack {
+        /// Agent name
+        #[arg(long)]
+        agent: String,
+        /// Role (e.g. concierge, pm, coder, qa, repo)
+        role: String,
+        /// Accept unsigned/unhashed skills (hash mismatch / invalid signature
+        /// is refused unconditionally)
+        #[arg(long)]
+        yes: bool,
+    },
     /// Search the MUR skill registry (for skills installable onto an agent).
     Search {
         /// Agent name

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -52,6 +52,7 @@ mod secret;
 mod service;
 pub mod skill;
 pub mod skill_bundle;
+pub mod skill_install_pack;
 pub mod skill_registry_add;
 pub mod skill_remote;
 pub mod skill_signer_trust;

--- a/mur-core/src/cmd/agent/skill_install_pack.rs
+++ b/mur-core/src/cmd/agent/skill_install_pack.rs
@@ -23,7 +23,11 @@ pub fn pack_members(idx: &RegistryIndex, role: &str) -> Vec<String> {
 
 /// Installs `pack_members(role)` onto `agent`, skipping already-installed
 /// skills. Returns `(installed, skipped)` names.
-pub async fn cmd_skill_install_pack(agent: &str, role: &str, yes: bool) -> Result<(Vec<String>, Vec<String>)> {
+pub async fn cmd_skill_install_pack(
+    agent: &str,
+    role: &str,
+    yes: bool,
+) -> Result<(Vec<String>, Vec<String>)> {
     let mur_home = super::resolve_mur_home()?;
     let (_dir, idx) = skill_registry::fetch_and_load(&mur_home, skill_registry::DEFAULT_REGISTRY)?;
     let members = pack_members(&idx, role);
@@ -67,8 +71,10 @@ mod tests {
             skills: Default::default(),
         };
         idx.skills.insert("writing-plans".into(), entry(&["pm"]));
-        idx.skills.insert("test-driven-development".into(), entry(&["coder"]));
-        idx.skills.insert("systematic-debugging".into(), entry(&["coder"]));
+        idx.skills
+            .insert("test-driven-development".into(), entry(&["coder"]));
+        idx.skills
+            .insert("systematic-debugging".into(), entry(&["coder"]));
 
         let mut coder = pack_members(&idx, "coder");
         coder.sort();

--- a/mur-core/src/cmd/agent/skill_install_pack.rs
+++ b/mur-core/src/cmd/agent/skill_install_pack.rs
@@ -1,0 +1,83 @@
+//! `mur agent skill install-pack <role>` — installs every registry skill
+//! tagged `recommended_roles: [<role>]` onto an agent, skipping ones already
+//! installed. Thin batch wrapper over `skill_registry_add::cmd_skill_registry_add`.
+
+use anyhow::Result;
+
+use super::skill_registry_add::cmd_skill_registry_add;
+use crate::cmd::skill_registry;
+use mur_common::skill::registry::RegistryIndex;
+use mur_common::skill::store::agent_skill_dir;
+
+/// Registry skill names whose `recommended_roles` contains `role`, sorted.
+pub fn pack_members(idx: &RegistryIndex, role: &str) -> Vec<String> {
+    let mut names: Vec<String> = idx
+        .skills
+        .iter()
+        .filter(|(_, e)| e.recommended_roles.iter().any(|r| r == role))
+        .map(|(name, _)| name.clone())
+        .collect();
+    names.sort();
+    names
+}
+
+/// Installs `pack_members(role)` onto `agent`, skipping already-installed
+/// skills. Returns `(installed, skipped)` names.
+pub async fn cmd_skill_install_pack(agent: &str, role: &str, yes: bool) -> Result<(Vec<String>, Vec<String>)> {
+    let mur_home = super::resolve_mur_home()?;
+    let (_dir, idx) = skill_registry::fetch_and_load(&mur_home, skill_registry::DEFAULT_REGISTRY)?;
+    let members = pack_members(&idx, role);
+
+    let mut installed = Vec::new();
+    let mut skipped = Vec::new();
+    for name in members {
+        if agent_skill_dir(&mur_home, agent).join(&name).exists() {
+            skipped.push(name);
+            continue;
+        }
+        cmd_skill_registry_add(agent, &name, None, yes).await?;
+        installed.push(name);
+    }
+    Ok((installed, skipped))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::skill::registry::RegistrySkillEntry;
+
+    fn entry(roles: &[&str]) -> RegistrySkillEntry {
+        RegistrySkillEntry {
+            latest: "1.0.0".into(),
+            description: "d".into(),
+            publisher: "mur-official".into(),
+            category: "workflow".into(),
+            tags: vec![],
+            content_sha256: String::new(),
+            install_count: 0,
+            recommended_roles: roles.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn pack_members_filters_and_sorts_by_role() {
+        let mut idx = RegistryIndex {
+            schema_version: 1,
+            updated_at: String::new(),
+            skills: Default::default(),
+        };
+        idx.skills.insert("writing-plans".into(), entry(&["pm"]));
+        idx.skills.insert("test-driven-development".into(), entry(&["coder"]));
+        idx.skills.insert("systematic-debugging".into(), entry(&["coder"]));
+
+        let mut coder = pack_members(&idx, "coder");
+        coder.sort();
+        assert_eq!(
+            coder,
+            vec![
+                "systematic-debugging".to_string(),
+                "test-driven-development".to_string()
+            ]
+        );
+    }
+}

--- a/mur-core/src/cmd/skill_registry_index.rs
+++ b/mur-core/src/cmd/skill_registry_index.rs
@@ -121,6 +121,11 @@ pub fn build_registry_index(repo_dir: &Path) -> Result<RegistryIndex> {
                         .and_then(|i| i.skills.get(&manifest.name))
                         .map(|e| e.install_count)
                         .unwrap_or(0),
+                    recommended_roles: prior
+                        .as_ref()
+                        .and_then(|i| i.skills.get(&manifest.name))
+                        .map(|e| e.recommended_roles.clone())
+                        .unwrap_or_default(),
                 };
 
                 match best.get(&manifest.name) {

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1499,6 +1499,16 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 .await?;
                 println!("Installed {id} onto '{name}' (Sandboxed). Restart the agent to load it.");
             }
+            AgentSkillAction::InstallPack { agent, role, yes } => {
+                let (installed, skipped) =
+                    cmd::agent::skill_install_pack::cmd_skill_install_pack(&agent, &role, yes)
+                        .await?;
+                println!("installed: {:?}", installed);
+                println!("skipped:   {:?}", skipped);
+                if !installed.is_empty() {
+                    println!("Restart '{agent}' to load the new skills.");
+                }
+            }
             AgentSkillAction::Search { name: _, query } => {
                 let mur_home = cmd::agent::resolve_mur_home()?;
                 let results =

--- a/mur-core/tests/common/mod.rs
+++ b/mur-core/tests/common/mod.rs
@@ -80,6 +80,7 @@ fn bump_index_latest(reg_root: &Path, name: &str, version: &str) {
         tags: vec![],
         content_sha256: String::new(),
         install_count: 0,
+        recommended_roles: vec![],
     });
     entry.latest = version.into();
     std::fs::write(&p, idx.to_yaml().unwrap()).unwrap();

--- a/registry-work/skills/code-review/1.0.0/skill.yaml
+++ b/registry-work/skills/code-review/1.0.0/skill.yaml
@@ -1,0 +1,29 @@
+# Derived from obra/superpowers requesting-code-review (MIT).
+name: code-review
+version: "1.0.0"
+publisher: human:mur-official
+description: "Review a diff against its plan/spec and report severity-ranked findings — the qa role IS the reviewer"
+category: workflow
+content:
+  abstract: |
+    Act as the reviewer, not the requester: given a diff (or commit range) and
+    the plan/spec it's supposed to satisfy, evaluate the work product in
+    isolation and report ranked findings back over the channel. Review early,
+    review often — after each task, after a major feature, before a merge.
+  procedure:
+    steps:
+      - description: "Gather exactly the context needed to evaluate the work in isolation: the base/head commit SHAs (or diff), a one-line description of what was built, and the plan or spec section it's meant to satisfy. Do not pull in the requester's session history or chat — evaluate the artifact on its own."
+      - description: "Read the diff between base and head in full. For a fleet review request delivered over `channel/delegate`, treat the delegated message's SHAs/description/plan reference as the entire brief."
+      - description: "Check correctness first: does the diff actually implement what the plan/spec section asked for? Note any requirement in the spec with no corresponding change."
+      - description: "Check for regressions and missed edge cases: run or read the affected tests, verify error handling exists for the failure modes the spec implies, and confirm the change doesn't silently break an adjacent feature."
+      - description: "Rank every finding by severity — Critical (breaks correctness/security), Important (should fix before proceeding), Minor (note for later, non-blocking) — one line each: what's wrong, where, why it matters."
+      - description: "Also flag reuse/simplification opportunities and YAGNI violations (unused 'professional' additions) as a separate, lower-priority note — this is a quality signal, not a blocking finding, unless it hides a real bug."
+      - description: "Report findings back to the requester (or the fleet channel) as a structured list, most severe first, with an overall assessment (ready to proceed / fix Critical first / needs another pass). Never soften or omit a Critical finding to be agreeable."
+      - description: "If asked to review again after fixes, re-check specifically that the previously Critical/Important findings were addressed before signing off."
+tags: [qa, code-review, workflow, superpowers-derived]
+triggers:
+  - type: keyword
+    pattern: "code-review"
+  - type: command
+    pattern: "/code-review"
+priority: normal

--- a/registry-work/skills/code-review/1.0.0/skill.yaml
+++ b/registry-work/skills/code-review/1.0.0/skill.yaml
@@ -1,7 +1,7 @@
 # Derived from obra/superpowers requesting-code-review (MIT).
 name: code-review
 version: "1.0.0"
-publisher: human:mur-official
+publisher: human:david
 description: "Review a diff against its plan/spec and report severity-ranked findings — the qa role IS the reviewer"
 category: workflow
 content:

--- a/registry-work/skills/executing-plans/1.0.0/skill.yaml
+++ b/registry-work/skills/executing-plans/1.0.0/skill.yaml
@@ -1,7 +1,7 @@
 # Derived from obra/superpowers executing-plans (MIT).
 name: executing-plans
 version: "1.0.0"
-publisher: human:mur-official
+publisher: human:david
 description: "Load a written plan, execute its tasks sequentially with checkpoints, stop when blocked"
 category: workflow
 content:

--- a/registry-work/skills/executing-plans/1.0.0/skill.yaml
+++ b/registry-work/skills/executing-plans/1.0.0/skill.yaml
@@ -1,0 +1,27 @@
+# Derived from obra/superpowers executing-plans (MIT).
+name: executing-plans
+version: "1.0.0"
+publisher: human:mur-official
+description: "Load a written plan, execute its tasks sequentially with checkpoints, stop when blocked"
+category: workflow
+content:
+  abstract: |
+    Batch/checkpoint execution of an already-written plan file: load it, review
+    critically, run each task's steps in order, verify as specified, and stop
+    to ask rather than guess when blocked. No sub-agent fan-out — sequential.
+  procedure:
+    steps:
+      - description: "Read the plan file. If no plan file exists yet, the pm role's writing-plans skill produces one first — do not improvise a plan here."
+      - description: "Review the plan critically: identify gaps, unclear instructions, or concerns. If any exist, raise them with the human partner or the fleet router before starting; if none, track each task as a checklist item."
+      - description: "For each task in order: mark it in-progress (in the checklist you're tracking, or by reporting status into the channel), follow each bite-sized step exactly, run the verifications the plan specifies, then mark it complete."
+      - description: "STOP immediately and ask for clarification (never guess) on: a missing dependency, an unclear instruction, a verification that fails repeatedly, or a plan with a critical gap that blocks starting."
+      - description: "If the plan changes mid-execution (partner feedback) or the approach needs fundamental rethinking, return to the load-and-review step rather than forcing through."
+      - description: "After all tasks are complete and verified, hand off to the repo role's finishing-a-development-branch skill to decide how to integrate the work (merge / PR / keep / discard)."
+      - description: "Never start implementation directly on main/master without explicit consent; verify the working tree is on a feature branch or isolated worktree first (see the using-git-worktrees skill)."
+tags: [coder, execution, workflow, superpowers-derived]
+triggers:
+  - type: keyword
+    pattern: "executing-plans"
+  - type: keyword
+    pattern: "execute the plan"
+priority: normal

--- a/registry-work/skills/finishing-a-development-branch/1.0.0/skill.yaml
+++ b/registry-work/skills/finishing-a-development-branch/1.0.0/skill.yaml
@@ -1,7 +1,7 @@
 # Derived from obra/superpowers finishing-a-development-branch (MIT).
 name: finishing-a-development-branch
 version: "1.0.0"
-publisher: human:mur-official
+publisher: human:david
 description: "Verify tests, then present merge/PR/keep/discard options to finish a development branch"
 category: workflow
 content:

--- a/registry-work/skills/finishing-a-development-branch/1.0.0/skill.yaml
+++ b/registry-work/skills/finishing-a-development-branch/1.0.0/skill.yaml
@@ -1,0 +1,28 @@
+# Derived from obra/superpowers finishing-a-development-branch (MIT).
+name: finishing-a-development-branch
+version: "1.0.0"
+publisher: human:mur-official
+description: "Verify tests, then present merge/PR/keep/discard options to finish a development branch"
+category: workflow
+content:
+  abstract: |
+    Verify tests → detect environment → present exactly the right options →
+    execute the choice → clean up. This project's convention is a merge
+    commit (never squash) when the base of a stacked PR chain is involved.
+  procedure:
+    steps:
+      - description: "Verify tests pass first: run the project's full test command (e.g. `cargo test --workspace` or `cargo nextest run`). If any fail, report the failures and stop — do not present integration options until tests are green."
+      - description: "Detect the workspace environment: compare `git rev-parse --git-dir` vs `--git-common-dir` to tell whether this is a normal checkout, a named-branch worktree, or a detached-HEAD worktree — this determines which menu and which cleanup rules apply."
+      - description: "Determine the base branch (`git merge-base HEAD main` or ask if ambiguous)."
+      - description: "Present exactly these options for a normal repo or named-branch worktree: 1) merge back to the base branch locally, 2) push and open a PR, 3) keep the branch as-is, 4) discard the work. For detached HEAD, present only options 1 (as 'push as new branch + PR'), 2 (keep), 3 (discard) — no local merge."
+      - description: "Merge option: cd to the main repo root first, merge the feature branch into base, re-run the full test suite on the merged result, and only after that succeeds remove the worktree and delete the branch. If the base of a stacked PR chain is being merged, use a merge commit — never squash-merge a base branch, since squashing severs ancestry for its child branches."
+      - description: "PR option: push the branch; do NOT clean up the worktree — the user needs it alive to iterate on review feedback."
+      - description: "Discard option: require the literal typed word 'discard' as confirmation before force-deleting the branch and removing the worktree."
+      - description: "Only clean up a worktree if it lives under this repo's `.worktrees/` (or `worktrees/`) directory — that's the marker that this tooling created it. Never remove a worktree the harness or a different session owns; always `cd` to the main repo root before running `git worktree remove`, then `git worktree prune`."
+tags: [repo, git, merge, workflow, superpowers-derived]
+triggers:
+  - type: keyword
+    pattern: "finishing-a-development-branch"
+  - type: keyword
+    pattern: "finish this branch"
+priority: normal

--- a/registry-work/skills/receiving-code-review/1.0.0/skill.yaml
+++ b/registry-work/skills/receiving-code-review/1.0.0/skill.yaml
@@ -1,0 +1,29 @@
+# Derived from obra/superpowers receiving-code-review (MIT).
+name: receiving-code-review
+version: "1.0.0"
+publisher: human:mur-official
+description: "Verify code review feedback technically before implementing it — no performative agreement"
+category: workflow
+content:
+  abstract: |
+    Code review requires technical evaluation, not emotional performance.
+    Read feedback fully, verify it against the actual codebase, then either
+    implement or push back with reasoning — never agree performatively and
+    never blind-implement unverified suggestions.
+  procedure:
+    steps:
+      - description: "Read the complete feedback without reacting or starting to implement yet. If any item is unclear, stop and ask for clarification on the unclear items before touching anything — partial understanding across related items produces wrong implementations."
+      - description: "Restate the technical requirement in your own words (to yourself or the reviewer) rather than opening with agreement phrases like 'you're absolutely right' or 'great point' — those are forbidden performative responses."
+      - description: "Verify the suggestion against codebase reality: does it break existing functionality, is there a documented reason for the current implementation, does it hold across the platforms/versions this code must support?"
+      - description: "If the reviewer suggests a 'proper' or 'production-grade' addition, grep the codebase for actual usage first (YAGNI check) — if the code path is unused, propose removing it instead of gold-plating it."
+      - description: "If the suggestion is technically wrong for this codebase, push back with concrete technical reasoning (reference the working code/tests), rather than silently complying or silently ignoring it."
+      - description: "When feedback is correct, just fix it and state what changed factually ('Fixed. <what changed>') — no gratitude phrasing, no over-explaining."
+      - description: "Implement one item at a time in this order: blocking issues (breaks/security) first, then simple fixes, then complex refactors — testing each fix individually before moving to the next."
+      - description: "If your own earlier pushback turns out wrong, state the correction factually ('Verified this and you're correct because X. Fixing.') without a long apology."
+tags: [coder, code-review, workflow, superpowers-derived]
+triggers:
+  - type: keyword
+    pattern: "receiving-code-review"
+  - type: keyword
+    pattern: "review feedback"
+priority: normal

--- a/registry-work/skills/receiving-code-review/1.0.0/skill.yaml
+++ b/registry-work/skills/receiving-code-review/1.0.0/skill.yaml
@@ -1,7 +1,7 @@
 # Derived from obra/superpowers receiving-code-review (MIT).
 name: receiving-code-review
 version: "1.0.0"
-publisher: human:mur-official
+publisher: human:david
 description: "Verify code review feedback technically before implementing it — no performative agreement"
 category: workflow
 content:

--- a/registry-work/skills/systematic-debugging/1.0.0/skill.yaml
+++ b/registry-work/skills/systematic-debugging/1.0.0/skill.yaml
@@ -1,0 +1,28 @@
+# Derived from obra/superpowers systematic-debugging (MIT).
+name: systematic-debugging
+version: "1.0.0"
+publisher: human:mur-official
+description: "Phase-gated root-cause investigation before proposing any fix"
+category: workflow
+content:
+  abstract: |
+    No fixes without root-cause investigation first. Four gated phases: read
+    the evidence, find the pattern, form and test one hypothesis, then
+    implement the fix at the root — never patch symptoms.
+  procedure:
+    steps:
+      - description: "Phase 1 — Root cause: read the full error/stack trace, reproduce the issue consistently (exact steps, every time; if not reproducible, gather more evidence instead of guessing), and check recent changes (git diff, new deps, config/env drift)."
+      - description: "Phase 1 — Multi-component evidence: if the failure spans component boundaries (e.g. CI → build → sign, or agent → channel → runtime), add diagnostic logging at each boundary and run once to see exactly where it breaks before analyzing further."
+      - description: "Phase 1 — Trace data flow: for errors deep in a call stack, trace backward from the bad value to its origin; fix at the source, not where the symptom surfaces."
+      - description: "Phase 2 — Pattern analysis: find a working example similar to the broken one, read any reference implementation completely (not skimmed), and list every difference between working and broken, however small."
+      - description: "Phase 3 — Hypothesis: state a single, specific hypothesis ('I think X is the root cause because Y'). Make the smallest possible change to test it, one variable at a time. If it doesn't confirm, form a new hypothesis — don't stack a second fix on top."
+      - description: "Phase 4 — Implementation: write a failing test that reproduces the bug first (see test-driven-development), implement one fix addressing the root cause, then verify the test passes and no other tests broke."
+      - description: "If 3 or more fix attempts have failed, stop attempting further point fixes. Each new failure surfacing in a different place is a signal the architecture itself is unsound — raise this with the human partner or router before trying fix #4."
+      - description: "Once fixed, hand off to verification-before-completion before claiming the bug resolved."
+tags: [coder, debugging, root-cause, workflow, superpowers-derived]
+triggers:
+  - type: keyword
+    pattern: "systematic-debugging"
+  - type: keyword
+    pattern: "root cause"
+priority: normal

--- a/registry-work/skills/systematic-debugging/1.0.0/skill.yaml
+++ b/registry-work/skills/systematic-debugging/1.0.0/skill.yaml
@@ -1,7 +1,7 @@
 # Derived from obra/superpowers systematic-debugging (MIT).
 name: systematic-debugging
 version: "1.0.0"
-publisher: human:mur-official
+publisher: human:david
 description: "Phase-gated root-cause investigation before proposing any fix"
 category: workflow
 content:

--- a/registry-work/skills/test-driven-development/1.0.0/skill.yaml
+++ b/registry-work/skills/test-driven-development/1.0.0/skill.yaml
@@ -1,0 +1,27 @@
+# Derived from obra/superpowers test-driven-development (MIT).
+name: test-driven-development
+version: "1.0.0"
+publisher: human:mur-official
+description: "Red-Green-Refactor — write the failing test first, watch it fail, then implement"
+category: workflow
+content:
+  abstract: |
+    No production code without a failing test first. Write one minimal test,
+    watch it fail for the right reason, write the smallest code to pass, then
+    refactor while staying green. Applies to every feature, bugfix, and refactor.
+  procedure:
+    steps:
+      - description: "RED: Write one minimal test for one behavior, with a clear name showing intent. Use real code paths, not mocks, unless a dependency is genuinely unavoidable to fake."
+      - description: "Verify RED: run the test (e.g. `cargo nextest run -p <crate> <test_name>` or `cargo test <test_name>`) and confirm it fails for the expected reason — feature missing, not a typo or setup error. If it passes immediately, you're testing existing behavior; fix the test."
+      - description: "GREEN: write the simplest code that makes the test pass. Don't add unrequested options, refactor unrelated code, or generalize beyond what the test demands (YAGNI)."
+      - description: "Verify GREEN: re-run the test and the full suite. Confirm the target test passes, no other tests broke, and output is clean (no warnings/errors)."
+      - description: "REFACTOR: with tests green, remove duplication, improve names, extract helpers. Do not add new behavior during refactor; keep re-running tests to stay green."
+      - description: "Repeat the cycle for the next behavior. For a discovered bug: write a failing test that reproduces it first, then follow the same RED-GREEN-REFACTOR cycle — never patch a bug without a regression test."
+      - description: "Before claiming a task done, confirm every new function has a test, every test was watched failing before the fix, and the full test command's fresh output shows 0 failures (see verification-before-completion)."
+tags: [coder, testing, tdd, workflow, superpowers-derived]
+triggers:
+  - type: keyword
+    pattern: "test-driven-development"
+  - type: keyword
+    pattern: "TDD"
+priority: normal

--- a/registry-work/skills/test-driven-development/1.0.0/skill.yaml
+++ b/registry-work/skills/test-driven-development/1.0.0/skill.yaml
@@ -1,7 +1,7 @@
 # Derived from obra/superpowers test-driven-development (MIT).
 name: test-driven-development
 version: "1.0.0"
-publisher: human:mur-official
+publisher: human:david
 description: "Red-Green-Refactor — write the failing test first, watch it fail, then implement"
 category: workflow
 content:

--- a/registry-work/skills/using-git-worktrees/1.0.0/skill.yaml
+++ b/registry-work/skills/using-git-worktrees/1.0.0/skill.yaml
@@ -1,0 +1,28 @@
+# Derived from obra/superpowers using-git-worktrees (MIT).
+name: using-git-worktrees
+version: "1.0.0"
+publisher: human:mur-official
+description: "Ensure feature work happens in an isolated git worktree under the repo's .worktrees/ dir"
+category: workflow
+content:
+  abstract: |
+    Detect existing isolation first, then create an isolated workspace only if
+    needed. MUR's convention is a worktree under the repo's own `.worktrees/`
+    directory — never under `~/.mur` (that path is reserved for MUR's runtime
+    data and would collide with agent state).
+  procedure:
+    steps:
+      - description: "Detect existing isolation: compare `git rev-parse --git-dir` and `--git-common-dir`. If they differ and you're not inside a git submodule (`git rev-parse --show-superproject-working-tree` returns empty), you're already in a linked worktree — skip creation and go straight to project setup."
+      - description: "If in a normal checkout and no worktree preference was already declared, ask for consent before creating one: it protects the current branch from in-progress changes."
+      - description: "Check for an existing project-local worktree directory: prefer `.worktrees/` at the repo root (MUR's convention); fall back to `worktrees/` only if `.worktrees/` doesn't exist. Never use `~/.mur/worktrees` — that collides with the MUR runtime home."
+      - description: "Verify the chosen directory is git-ignored (`git check-ignore -q .worktrees`); if not, add it to `.gitignore` and commit that change before creating the worktree."
+      - description: "Create the worktree: `git worktree add .worktrees/<branch-name> -b <branch-name>`, then operate with that path as cwd for all subsequent file and bash operations. If the sandbox denies worktree creation, report the denial and work in place instead."
+      - description: "Run project setup in the new worktree (e.g. `cargo build --workspace` for this repo) and verify a clean baseline test run before starting feature work; if baseline tests fail, report the failures and ask whether to proceed."
+      - description: "Report readiness: worktree path, baseline test result, and which feature is about to be implemented."
+tags: [coder, git, worktree, workflow, superpowers-derived]
+triggers:
+  - type: keyword
+    pattern: "using-git-worktrees"
+  - type: keyword
+    pattern: "isolated workspace"
+priority: normal

--- a/registry-work/skills/using-git-worktrees/1.0.0/skill.yaml
+++ b/registry-work/skills/using-git-worktrees/1.0.0/skill.yaml
@@ -1,7 +1,7 @@
 # Derived from obra/superpowers using-git-worktrees (MIT).
 name: using-git-worktrees
 version: "1.0.0"
-publisher: human:mur-official
+publisher: human:david
 description: "Ensure feature work happens in an isolated git worktree under the repo's .worktrees/ dir"
 category: workflow
 content:

--- a/registry-work/skills/verification-before-completion/1.0.0/skill.yaml
+++ b/registry-work/skills/verification-before-completion/1.0.0/skill.yaml
@@ -1,7 +1,7 @@
 # Derived from obra/superpowers verification-before-completion (MIT).
 name: verification-before-completion
 version: "1.0.0"
-publisher: human:mur-official
+publisher: human:david
 description: "Run the verification command and read its fresh output before claiming anything is done"
 category: workflow
 content:

--- a/registry-work/skills/verification-before-completion/1.0.0/skill.yaml
+++ b/registry-work/skills/verification-before-completion/1.0.0/skill.yaml
@@ -1,0 +1,27 @@
+# Derived from obra/superpowers verification-before-completion (MIT).
+name: verification-before-completion
+version: "1.0.0"
+publisher: human:mur-official
+description: "Run the verification command and read its fresh output before claiming anything is done"
+category: workflow
+content:
+  abstract: |
+    Claiming work is complete without running a fresh verification is dishonest,
+    not efficient. Identify the exact command that proves the claim, run it in
+    this turn, read the full output, and only then state the result — with the
+    evidence attached.
+  procedure:
+    steps:
+      - description: "Before any completion claim, identify the exact command that proves it: the test command for 'tests pass', the build command for 'build succeeds', the linter for 'lint clean', a re-run of the original failing repro for 'bug fixed'."
+      - description: "Run that full command fresh, in this turn — never reuse a previous run's output, and never substitute a partial or related check (e.g. linter output does not prove the build compiles)."
+      - description: "Read the complete output: exit code, failure count, warnings. Confirm it actually supports the claim before saying anything positive."
+      - description: "State the claim only with the evidence attached (e.g. 'cargo nextest run -p mur-common: 42/42 passed' — not 'should pass now' or 'looks correct')."
+      - description: "Never trust a delegated agent's or subagent's self-reported success at face value — after delegation, independently check the diff/VCS state or re-run the verification yourself."
+      - description: "Apply this before every completion-adjacent moment: committing, opening a PR, moving to the next task, or reporting a milestone back to a fleet router."
+tags: [coder, verification, workflow, superpowers-derived]
+triggers:
+  - type: keyword
+    pattern: "verification-before-completion"
+  - type: keyword
+    pattern: "claim complete"
+priority: normal

--- a/registry-work/skills/writing-plans/1.0.0/skill.yaml
+++ b/registry-work/skills/writing-plans/1.0.0/skill.yaml
@@ -1,7 +1,7 @@
 # Derived from obra/superpowers writing-plans (MIT).
 name: writing-plans
 version: "1.0.0"
-publisher: human:mur-official
+publisher: human:david
 description: "Write a bite-sized, file-path-exact implementation plan before touching code"
 category: workflow
 content:

--- a/registry-work/skills/writing-plans/1.0.0/skill.yaml
+++ b/registry-work/skills/writing-plans/1.0.0/skill.yaml
@@ -1,0 +1,29 @@
+# Derived from obra/superpowers writing-plans (MIT).
+name: writing-plans
+version: "1.0.0"
+publisher: human:mur-official
+description: "Write a bite-sized, file-path-exact implementation plan before touching code"
+category: workflow
+content:
+  abstract: |
+    Turn a spec or design summary into a comprehensive implementation plan: exact
+    file paths, bite-sized (2-5 minute) steps, no placeholders. Terminal state is
+    a saved plan file whose path gets reported back, not code written in this pass.
+  procedure:
+    steps:
+      - description: "Consume the design summary (e.g. from a concierge brainstorming pass) and confirm the spec is scoped to one subsystem; if it spans several independent subsystems, split into one plan per subsystem."
+      - description: "Map out which files will be created or modified and what each one is responsible for — decompose by responsibility, not technical layer; prefer several small focused files over one large file."
+      - description: "Draft the plan header: Goal (one sentence), Architecture (2-3 sentences), Tech Stack, and a Global Constraints section copying the spec's project-wide requirements verbatim (versions, naming rules, platform requirements)."
+      - description: "Break work into tasks. A task is the smallest unit that carries its own test cycle and deserves an independent review gate — fold setup/config/docs into the task that needs them; split only where a task could be approved independently of its neighbor."
+      - description: "For each task, write bite-sized steps (one action each, ~2-5 minutes): write the failing test, run it to confirm it fails, write minimal implementation, run tests to confirm pass, commit. Include exact file paths, complete code (no 'TODO'/'similar to Task N'/'add appropriate error handling'), exact commands with expected output."
+      - description: "For each task, record an Interfaces block: what it Consumes from earlier tasks (exact signatures) and what it Produces for later tasks (exact function/type names) — the implementer of a later task may only see its own task text."
+      - description: "Self-review with fresh eyes: check every spec requirement maps to a task (list gaps), scan for placeholder red flags, and verify method/type names used in later tasks match names defined in earlier tasks. Fix inline; don't re-review."
+      - description: "Write the plan to `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md` (or the user's declared location) and report the saved path back to the router/human — this is the terminal state of this skill; do not begin implementation here."
+      - description: "State the two follow-on options: the coder role's executing-plans skill for sequential batch execution with checkpoints, or fanning tasks out concurrently via `mur fleet run` / a `parallel_jobs` MCP call when tasks are genuinely independent."
+tags: [pm, planning, workflow, superpowers-derived]
+triggers:
+  - type: keyword
+    pattern: "writing-plans"
+  - type: keyword
+    pattern: "implementation plan"
+priority: normal


### PR DESCRIPTION
## Summary
- `RegistrySkillEntry.recommended_roles: Vec<String>` (back-compat default empty) — Task 1
- `mur agent skill install-pack <role> --agent <name> [--yes]`, backed by pure `pack_members()` — Task 3
- 9 superpowers methodology skills ported to MUR skill.yaml under `registry-work/skills/` (writing-plans, executing-plans, test-driven-development, using-git-worktrees, systematic-debugging, verification-before-completion, receiving-code-review, code-review, finishing-a-development-branch) — Task 2, Claude Code tool refs replaced with MUR fleet/channel-delegate equivalents, attribution comment on each file

Plan: `docs/superpowers/plans/2026-07-04-role-skill-packs.md`

## Not in this PR (Task 4, needs external review)
The 9 skills are published as PRs #3-#11 on `mur-run/skill-registry`, signed under `human:david` (not `mur-official` — that signing key isn't available on this machine). Once those are reviewed/merged:
- add `recommended_roles` to the registry's `index.yaml` for each
- dogfood `mur agent skill install-pack <role> --agent <name>` against real running agents

## Test plan
- [x] `cargo check -p mur-common -p mur-core`
- [x] `cargo clippy -p mur-common -p mur-core -- -D warnings`
- [x] `cargo nextest run -p mur-common registry -p mur-core pack` (87/89 pass; 2 pre-existing failures unrelated to this change — reproduced on unmodified `main`, a stack overflow in `cli::agent::tests::mcp_registry_add_*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)