### PR TITLE
fix(ci): install libdbus-1-dev for GUI/Hub GUI ubuntu jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,7 @@ jobs:
             libayatana-appindicator3-dev
             librsvg2-dev
             libasound2-dev
+            libdbus-1-dev
             pkg-config
             protobuf-compiler
             libprotobuf-dev
@@ -303,6 +304,7 @@ jobs:
             protobuf-compiler
             libprotobuf-dev
             libasound2-dev
+            libdbus-1-dev
       - name: Install protobuf (macOS)
         if: runner.os == 'macOS'
         run: brew install protobuf


### PR DESCRIPTION
## Summary
- `gui` and `hub_gui` jobs in `ci.yml` build Tauri crates (via `libdbus-sys`) but never installed `libdbus-1-dev`, so both ubuntu jobs have been red on `main` for several runs.
- `release.yml` and `eval.yml` already install `libdbus-1-dev`; this brings `ci.yml` in line.

## Test plan
- [ ] CI green on `gui` and `Hub GUI crate — ubuntu-22.04` jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)