### PR TITLE
ci: fix ubuntu apt 404 (refresh index) + clear node20 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         # packages so the cache invalidates.
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          version: 1.0
+          version: "1.1"
           packages: >-
             libwebkit2gtk-4.1-dev
             libsoup-3.0-dev
@@ -303,7 +303,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          version: 1.0
+          version: "1.1"
           packages: >-
             libwebkit2gtk-4.1-dev
             libsoup-3.0-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,11 +220,17 @@ jobs:
         with:
           workspaces: mur-agent-gui/src-tauri
           key: ${{ env.ImageOS }}-${{ env.ImageVersion }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: 'mur-agent-gui/ui/.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'mur-agent-gui/ui/package-lock.json'
+      - name: Refresh apt lists (avoid stale-index 404 on transitive deps)
+        # The runner image ships a snapshot apt index; when Ubuntu security-
+        # updates a transitive dep (e.g. libnghttp2-dev) the old version's .deb
+        # is pulled from the mirror and the pinned index 404s. cache-apt-pkgs
+        # does not `apt-get update` first, so refresh the index here.
+        run: sudo apt-get update
       - name: Install Linux system libraries (Tauri 2 + voice + OCR)
         # cache-apt-pkgs-action caches the apt download tarball at
         # ~/.apt-cache and replays installs from there on subsequent runs.
@@ -285,11 +291,14 @@ jobs:
         with:
           workspaces: mur-hub-gui/src-tauri
           key: ${{ env.ImageOS }}-${{ env.ImageVersion }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: 'mur-hub-gui/ui/.nvmrc'
           cache: 'npm'
           cache-dependency-path: 'mur-hub-gui/ui/package-lock.json'
+      - name: Refresh apt lists (avoid stale-index 404 on transitive deps)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update
       - name: Install Linux system libraries (Tauri 2)
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@latest
@@ -351,7 +360,7 @@ jobs:
     # Always run — 5s, runs against any source change so safe to keep.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run gate
         run: scripts/check-required-reason-apis.sh
 

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -43,7 +43,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
       - uses: actions/setup-python@v6


### PR DESCRIPTION
## Problem
The ubuntu-22.04 CI jobs (Hub GUI + agent GUI) fail intermittently — currently red on `main` and on every open PR. Root cause is **not source code**: Ubuntu security-updated a transitive dep (`libnghttp2-dev`), the runner image's snapshot apt index still references the removed `.deb`, so `cache-apt-pkgs-action`'s download 404s and the GTK/WebKit dev libraries install incompletely → `gdk-3.0 not found` → `gdk-sys` build fails. macOS and Windows are unaffected.

## Fix
1. **`sudo apt-get update` before each `cache-apt-pkgs-action` step** (the action doesn't refresh the index itself). The `test`/`clippy` jobs already do this before their direct installs; this brings the two action-based steps in line.
2. **Bump the four actions still on the deprecated node20 runtime** — `actions/setup-node@v4` (×3) and `actions/checkout@v4` (×1) → `@v6` (node24), matching the majors already used ×20+ elsewhere in the repo. Clears the "Node.js 20 is deprecated" warnings. Left `upload/download-artifact@v4` and `cache@v4` (current majors, no newer target) and third-party actions untouched.

## Scope
Independent infra fix — unblocks `main` and the Hub-redesign PR stack (#623/#624/#625), whose ubuntu red is this same pre-existing breakage, not their diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)