### PR TITLE
chore(hub): mission-control redesign Phase 5 — polish audit

### DIFF
--- a/mur-hub-gui/ui/src/components/inspector/AgentInspector.tsx
+++ b/mur-hub-gui/ui/src/components/inspector/AgentInspector.tsx
@@ -1,6 +1,6 @@
 //! Agent inspector — contextual right-pane column shown in the Shell's
 //! inspector slot when an agent is selected. Restyled from the former
-//! full-page slide-in DetailPanel; content (status header + the
+//! full-page detail panel; content (status header + the
 //! persona/style/behavior/skills/MCP/permissions/inbox/mobile/memory/plugins
 //! tabs) is unchanged. Tab bodies live in ./tabs/*.
 //!


### PR DESCRIPTION
Phase 5 (visual polish) of the Hub redesign ([spec](docs/superpowers/specs/2026-07-05-hub-mission-control-redesign.md) §5).

**Audit outcome: the redesign was already clean.** Each planned Phase-5 item was checked against the actual code and found already satisfied or not applicable:

- **Brand audit** — no user-visible "Mur"/"MuR" strings; already uppercase MUR.
- **Icon unification** — nav/sidebar already use `currentColor` SVG (Phase 1); no emoji glyphs to replace.
- **Reduced-motion** — already guarded (`@media (prefers-reduced-motion: reduce)` in `motion.css`).
- **Dead CSS** — `work.css` is still in use (Home's NowRunning/RecentActivity reuse its classes); not removed.
- **Vibrancy** — deliberate solid fallback; true macOS vibrancy needs a `transparent` window + `NSVisualEffectView`, a fiddly native change with regression risk and marginal gain. Deferred as an optional interactive follow-up.
- **Token/density sweep** — subjective, regression-prone, no headless verification; not pursued.

**The one concrete change:** correct a stale `//! full-page slide-in DetailPanel` doc comment in `AgentInspector.tsx` (the panel is now the contextual inspector).

This closes the 5-phase mission-control redesign. All prior phases (#623/#624/#625 + Plugins #627 + Chats/Inspector #630) are merged and `.app`-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)