### PR TITLE
mur-compress: per-type stats ledger + code skeletonization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6463,6 +6463,16 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tiktoken-rs",
+ "tree-sitter",
+ "tree-sitter-dart",
+ "tree-sitter-go",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-php",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-swift",
+ "tree-sitter-typescript",
 ]
 
 [[package]]
@@ -10360,16 +10370,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-dart"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f1f70b80ce41343e14aafcef67b5ba2e9de89587535b4aabbabb8036f4e38a"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
+name = "tree-sitter-php"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f066e94e9272cfe4f1dcb07a1c50c66097eca648f2d7233d299c8ae9ed8c130c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-rust"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65aeb41726119416567d0333ec17580ac4abfb96db1f67c4bd638c65f9992fe"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/mur-compress/Cargo.toml
+++ b/mur-compress/Cargo.toml
@@ -17,6 +17,16 @@ flate2 = "1"
 fs2 = { workspace = true }
 tiktoken-rs = "0.6"
 regex = "1"
+tree-sitter = "0.24"
+tree-sitter-rust = "0.23"
+tree-sitter-python = "=0.23.6"
+tree-sitter-javascript = "=0.23.1"
+tree-sitter-typescript = "0.23.2"
+tree-sitter-go = "=0.23.4"
+tree-sitter-php = "=0.23.11"
+tree-sitter-java = "0.23.5"
+tree-sitter-swift = "=0.6.0"
+tree-sitter-dart = "=0.0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/mur-compress/src/lib.rs
+++ b/mur-compress/src/lib.rs
@@ -7,6 +7,7 @@ pub mod ccr;
 pub mod compressors;
 pub mod config;
 pub mod detect;
+pub mod skeleton;
 pub mod stats;
 pub mod tokenizer;
 pub mod types;
@@ -147,7 +148,7 @@ impl CompressEngine {
             return Self::passthrough(content, before, ct);
         }
 
-        self.stats.record_compression(before, after);
+        self.stats.record_compression(ct.as_str(), before, after);
 
         CompressResult {
             compressed: out.compressed,
@@ -159,6 +160,23 @@ impl CompressEngine {
             transforms: out.transforms,
             content_type: ct,
         }
+    }
+
+    /// Unconditionally store `content` in the CCR store and return its hash,
+    /// bypassing `compress()`'s content-type dispatch and payoff gating.
+    ///
+    /// `compress()` only offloads when the matched content-type compressor
+    /// chooses to (`fallback`/Generic — most prose and code — never does).
+    /// Callers that need a retrieval handle for content they are dropping for
+    /// reasons *other* than "it compresses well" (e.g. a superseded read, an
+    /// exact duplicate of a later tool result) use this instead, so the
+    /// original stays recoverable via [`Self::retrieve`] regardless of
+    /// content type. Best-effort: a store write failure returns `None`, and
+    /// the caller falls back to a non-retrievable stub.
+    pub fn archive(&self, content: &str) -> Option<String> {
+        self.store
+            .put_original(content, Vec::new(), ContentType::Generic, self.tok.as_ref())
+            .ok()
     }
 
     /// Retrieve a stored original by hash, optionally BM25-filtered by query.
@@ -212,6 +230,22 @@ mod tests {
 
     fn engine(dir: &std::path::Path, cfg: CompressConfig) -> CompressEngine {
         CompressEngine::new(dir, cfg).unwrap()
+    }
+
+    #[test]
+    fn archive_stores_generic_content_compress_would_skip() {
+        let dir = tempfile::tempdir().unwrap();
+        let eng = engine(dir.path(), CompressConfig::default());
+        let prose = "fn main() {\n    println!(\"hi\");\n}\n".repeat(50);
+        // compress() on plain code/prose (Generic) never offloads.
+        assert!(eng.compress(&prose, None).hash.is_none());
+        let hash = eng.archive(&prose).expect("archive should store");
+        match eng.retrieve(&hash, None) {
+            RetrieveResult::Full { original_content, .. } => {
+                assert_eq!(original_content, prose);
+            }
+            other => panic!("expected Full, got {other:?}"),
+        }
     }
 
     #[test]

--- a/mur-compress/src/lib.rs
+++ b/mur-compress/src/lib.rs
@@ -241,7 +241,9 @@ mod tests {
         assert!(eng.compress(&prose, None).hash.is_none());
         let hash = eng.archive(&prose).expect("archive should store");
         match eng.retrieve(&hash, None) {
-            RetrieveResult::Full { original_content, .. } => {
+            RetrieveResult::Full {
+                original_content, ..
+            } => {
                 assert_eq!(original_content, prose);
             }
             other => panic!("expected Full, got {other:?}"),

--- a/mur-compress/src/skeleton.rs
+++ b/mur-compress/src/skeleton.rs
@@ -117,7 +117,12 @@ fn lang_spec_for(ext: &str) -> Option<LangSpec> {
         "java" => LangSpec {
             language: || tree_sitter_java::LANGUAGE.into(),
             function_kinds: &["method_declaration", "constructor_declaration"],
-            container_kinds: &["program", "class_declaration", "class_body", "interface_body"],
+            container_kinds: &[
+                "program",
+                "class_declaration",
+                "class_body",
+                "interface_body",
+            ],
         },
         "swift" => LangSpec {
             language: || tree_sitter_swift::LANGUAGE.into(),
@@ -321,6 +326,9 @@ mod tests {
         let once = skeletonize(src, "a.rs").expect("first pass elides the body");
         assert!(once.len() < src.len());
         let twice = skeletonize(&once, "a.rs");
-        assert!(twice.is_none(), "already-elided body has nothing left to shrink");
+        assert!(
+            twice.is_none(),
+            "already-elided body has nothing left to shrink"
+        );
     }
 }

--- a/mur-compress/src/skeleton.rs
+++ b/mur-compress/src/skeleton.rs
@@ -1,0 +1,326 @@
+//! Code skeletonization: parse a source file with tree-sitter and collapse
+//! every function/method body to a short elision marker, keeping imports,
+//! signatures, type/class declarations, and doc comments byte-for-byte.
+//!
+//! Used only for content that is already provably stale (see
+//! `cc-proxy`'s supersession pass) — it never touches the most recent view
+//! of a file, which is where an in-flight `Edit`'s `old_string` anchors. The
+//! full original stays separately recoverable via the caller's own
+//! retrieval hash; a skeleton is a denser *inline* summary, not the sole
+//! copy of anything.
+//!
+//! Recognizes: Rust, Python, JavaScript, TypeScript (incl. TSX), Go, PHP,
+//! Java, Swift, Dart. Other languages fall through to `None`; the caller
+//! keeps its plain stub.
+//!
+//! Each grammar crate is pinned to whatever version emits the ABI the
+//! workspace's shared `tree-sitter` core (`0.24`, set by `mur-core`'s
+//! pre-existing Rust-only code-graph indexer) can load — newer grammar
+//! releases target a newer core ABI and fail `Parser::set_language` at
+//! runtime with no compile-time signal, so don't bump a grammar version
+//! without re-running the language's skeletonize test.
+
+use tree_sitter::{Language, Node, Parser};
+
+struct LangSpec {
+    language: fn() -> Language,
+    /// Node kinds whose `body` field gets collapsed; recursion stops here.
+    function_kinds: &'static [&'static str],
+    /// Node kinds whose children are still worth walking into looking for
+    /// nested function-like nodes (modules, classes, impl blocks, ...).
+    container_kinds: &'static [&'static str],
+}
+
+fn lang_spec_for(ext: &str) -> Option<LangSpec> {
+    Some(match ext {
+        "rs" => LangSpec {
+            language: || tree_sitter_rust::LANGUAGE.into(),
+            function_kinds: &["function_item"],
+            container_kinds: &[
+                "source_file",
+                "impl_item",
+                "trait_item",
+                "mod_item",
+                "declaration_list",
+            ],
+        },
+        "py" | "pyi" => LangSpec {
+            language: || tree_sitter_python::LANGUAGE.into(),
+            function_kinds: &["function_definition"],
+            container_kinds: &["module", "class_definition", "block"],
+        },
+        "js" | "jsx" | "mjs" | "cjs" => LangSpec {
+            language: || tree_sitter_javascript::LANGUAGE.into(),
+            function_kinds: &[
+                "function_declaration",
+                "method_definition",
+                "function_expression",
+                "arrow_function",
+            ],
+            container_kinds: &[
+                "program",
+                "class_body",
+                "class_declaration",
+                "export_statement",
+                "statement_block",
+            ],
+        },
+        "ts" | "mts" | "cts" => LangSpec {
+            language: || tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            function_kinds: &[
+                "function_declaration",
+                "method_definition",
+                "function_expression",
+                "arrow_function",
+            ],
+            container_kinds: &[
+                "program",
+                "class_body",
+                "class_declaration",
+                "interface_declaration",
+                "export_statement",
+                "statement_block",
+            ],
+        },
+        "tsx" => LangSpec {
+            language: || tree_sitter_typescript::LANGUAGE_TSX.into(),
+            function_kinds: &[
+                "function_declaration",
+                "method_definition",
+                "function_expression",
+                "arrow_function",
+            ],
+            container_kinds: &[
+                "program",
+                "class_body",
+                "class_declaration",
+                "interface_declaration",
+                "export_statement",
+                "statement_block",
+            ],
+        },
+        "go" => LangSpec {
+            language: || tree_sitter_go::LANGUAGE.into(),
+            function_kinds: &["function_declaration", "method_declaration", "func_literal"],
+            container_kinds: &["source_file"],
+        },
+        "php" | "phtml" => LangSpec {
+            language: || tree_sitter_php::LANGUAGE_PHP.into(),
+            function_kinds: &[
+                "function_definition",
+                "method_declaration",
+                "anonymous_function",
+                "arrow_function",
+            ],
+            container_kinds: &["program", "class_declaration", "declaration_list"],
+        },
+        "java" => LangSpec {
+            language: || tree_sitter_java::LANGUAGE.into(),
+            function_kinds: &["method_declaration", "constructor_declaration"],
+            container_kinds: &["program", "class_declaration", "class_body", "interface_body"],
+        },
+        "swift" => LangSpec {
+            language: || tree_sitter_swift::LANGUAGE.into(),
+            function_kinds: &["function_declaration"],
+            container_kinds: &["source_file", "class_declaration", "class_body"],
+        },
+        "dart" => LangSpec {
+            language: tree_sitter_dart::language,
+            function_kinds: &["lambda_expression"],
+            container_kinds: &["program", "class_definition", "class_body"],
+        },
+        _ => return None,
+    })
+}
+
+/// Recursively collect `(start_byte, end_byte)` ranges of every
+/// function-like node's `body` field, in document order. Stops descending
+/// once it enters a function-like node — nested closures/methods are
+/// already inside the elided range.
+fn collect_body_ranges(node: Node, spec: &LangSpec, out: &mut Vec<(usize, usize)>) {
+    let kind = node.kind();
+    if spec.function_kinds.contains(&kind) {
+        if let Some(body) = node.child_by_field_name("body") {
+            out.push((body.start_byte(), body.end_byte()));
+        }
+        return;
+    }
+    // Only descend through recognized containers (module/class/impl/...);
+    // everything else (plain statements, expressions, decorators, ...) is
+    // left as-is and not searched for nested function definitions. This
+    // keeps arbitrary top-level code verbatim rather than risking a
+    // misidentified elision inside it. The tree root is always one of
+    // `container_kinds` for every language table above.
+    if !spec.container_kinds.contains(&kind) {
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_body_ranges(child, spec, out);
+    }
+}
+
+/// Guess a tree-sitter language from a file path's extension. Returns the
+/// bare extension (lowercased) for use as the cache/lookup key elsewhere.
+pub fn language_hint(file_path: &str) -> Option<String> {
+    let ext = file_path.rsplit('.').next()?.to_ascii_lowercase();
+    lang_spec_for(&ext).map(|_| ext)
+}
+
+/// Skeletonize `source`, whose language is inferred from `file_path`'s
+/// extension. Returns `None` if the extension is unrecognized, the source
+/// fails to parse, or the result wouldn't actually be smaller than the
+/// input (nothing to elide — e.g. no functions, or all one-liners).
+pub fn skeletonize(source: &str, file_path: &str) -> Option<String> {
+    let ext = file_path.rsplit('.').next()?.to_ascii_lowercase();
+    let spec = lang_spec_for(&ext)?;
+    let mut parser = Parser::new();
+    parser.set_language(&(spec.language)()).ok()?;
+    let tree = parser.parse(source, None)?;
+
+    let mut ranges = Vec::new();
+    collect_body_ranges(tree.root_node(), &spec, &mut ranges);
+    if ranges.is_empty() {
+        return None;
+    }
+
+    // Apply replacements back-to-front so earlier byte offsets stay valid.
+    let mut out = source.to_string();
+    for (start, end) in ranges.into_iter().rev() {
+        if start >= end || end > out.len() {
+            continue;
+        }
+        out.replace_range(start..end, "{ /* elided */ }");
+    }
+    (out.len() < source.len()).then_some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn language_hint_recognizes_supported_extensions() {
+        assert_eq!(language_hint("src/main.rs").as_deref(), Some("rs"));
+        assert_eq!(language_hint("app.py").as_deref(), Some("py"));
+        assert_eq!(language_hint("index.tsx").as_deref(), Some("tsx"));
+        assert_eq!(language_hint("README.md"), None);
+    }
+
+    #[test]
+    fn skeletonizes_rust_function_bodies() {
+        let src = "use std::fmt;\n\nfn add(a: i32, b: i32) -> i32 {\n    let sum = a + b;\n    sum\n}\n\nstruct Point { x: i32, y: i32 }\n";
+        let out = skeletonize(src, "src/lib.rs").expect("should skeletonize");
+        assert!(out.contains("use std::fmt;"));
+        assert!(out.contains("fn add(a: i32, b: i32) -> i32"));
+        assert!(out.contains("{ /* elided */ }"));
+        assert!(!out.contains("let sum"));
+        assert!(out.contains("struct Point { x: i32, y: i32 }"));
+        assert!(out.len() < src.len());
+    }
+
+    #[test]
+    fn skeletonizes_rust_impl_methods() {
+        let src = "impl Point {\n    fn new() -> Self {\n        Self { x: 0, y: 0 }\n    }\n\n    fn dist(&self) -> f64 {\n        ((self.x * self.x + self.y * self.y) as f64).sqrt()\n    }\n}\n";
+        let out = skeletonize(src, "src/lib.rs").expect("should skeletonize");
+        assert!(out.contains("fn new() -> Self"));
+        assert!(out.contains("fn dist(&self) -> f64"));
+        assert!(!out.contains("sqrt"));
+        assert_eq!(out.matches("{ /* elided */ }").count(), 2);
+    }
+
+    #[test]
+    fn skeletonizes_python_functions_and_classes() {
+        let src = "import os\n\n\ndef greet(name):\n    message = f\"hi {name}\"\n    return message\n\n\nclass Greeter:\n    def hello(self):\n        return greet(\"world\")\n";
+        let out = skeletonize(src, "app.py").expect("should skeletonize");
+        assert!(out.contains("import os"));
+        assert!(out.contains("def greet(name):"));
+        assert!(out.contains("class Greeter:"));
+        assert!(out.contains("def hello(self):"));
+        assert!(!out.contains("f\"hi {name}\""));
+    }
+
+    #[test]
+    fn skeletonizes_javascript_functions() {
+        let src = "import fs from 'fs';\n\nfunction add(a, b) {\n    const sum = a + b;\n    return sum;\n}\n\nclass Foo {\n    bar() {\n        return 1;\n    }\n}\n";
+        let out = skeletonize(src, "src/foo.js").expect("should skeletonize");
+        assert!(out.contains("import fs from 'fs';"));
+        assert!(out.contains("function add(a, b)"));
+        assert!(out.contains("bar()"));
+        assert!(!out.contains("const sum"));
+    }
+
+    #[test]
+    fn skeletonizes_typescript_with_types() {
+        let src = "export function add(a: number, b: number): number {\n    const sum = a + b;\n    return sum;\n}\n";
+        let out = skeletonize(src, "src/foo.ts").expect("should skeletonize");
+        assert!(out.contains("function add(a: number, b: number): number"));
+        assert!(!out.contains("const sum"));
+    }
+
+    #[test]
+    fn skeletonizes_go_functions_and_methods() {
+        let src = "package main\n\nfunc Add(a, b int) int {\n\tsum := a + b\n\treturn sum\n}\n\ntype T struct{ x int }\n\nfunc (t T) Double() int {\n\treturn t.x * 2\n}\n";
+        let out = skeletonize(src, "main.go").expect("should skeletonize");
+        assert!(out.contains("func Add(a, b int) int"));
+        assert!(out.contains("func (t T) Double() int"));
+        assert!(out.contains("type T struct{ x int }"));
+        assert!(!out.contains("sum := a + b"));
+    }
+
+    #[test]
+    fn skeletonizes_php_functions_and_methods() {
+        let src = "<?php\n\nfunction add($a, $b) {\n    $sum = $a + $b;\n    return $sum;\n}\n\nclass Foo {\n    function bar() {\n        return 1;\n    }\n}\n";
+        let out = skeletonize(src, "index.php").expect("should skeletonize");
+        assert!(out.contains("function add($a, $b)"));
+        assert!(out.contains("class Foo"));
+        assert!(out.contains("function bar()"));
+        assert!(!out.contains("$sum = $a + $b;"));
+    }
+
+    #[test]
+    fn skeletonizes_java_methods() {
+        let src = "public class Foo {\n    public int add(int a, int b) {\n        int sum = a + b;\n        return sum;\n    }\n}\n";
+        let out = skeletonize(src, "Foo.java").expect("should skeletonize");
+        assert!(out.contains("public int add(int a, int b)"));
+        assert!(!out.contains("int sum = a + b;"));
+    }
+
+    #[test]
+    fn skeletonizes_swift_functions() {
+        let src = "func add(a: Int, b: Int) -> Int {\n    let sum = a + b\n    return sum\n}\n";
+        let out = skeletonize(src, "Foo.swift").expect("should skeletonize");
+        assert!(out.contains("func add(a: Int, b: Int) -> Int"));
+        assert!(!out.contains("let sum = a + b"));
+    }
+
+    #[test]
+    fn skeletonizes_dart_functions() {
+        let src = "int add(int a, int b) {\n  int sum = a + b;\n  return sum;\n}\n";
+        let out = skeletonize(src, "main.dart").expect("should skeletonize");
+        assert!(out.contains("int add(int a, int b)"));
+        assert!(!out.contains("int sum = a + b;"));
+    }
+
+    #[test]
+    fn unsupported_extension_returns_none() {
+        assert!(skeletonize("# just markdown\nsome text\n", "README.md").is_none());
+    }
+
+    #[test]
+    fn no_functions_returns_none() {
+        assert!(skeletonize("const X = 1;\nconst Y = 2;\n", "consts.js").is_none());
+    }
+
+    #[test]
+    fn is_idempotent_shaped() {
+        // Re-skeletonizing already-elided source finds no (further
+        // shrinkable) function bodies of substance and should not blow up
+        // or infinitely nest markers.
+        let src = "fn f() {\n    let x = 1;\n    let y = 2;\n    x + y\n}\n";
+        let once = skeletonize(src, "a.rs").expect("first pass elides the body");
+        assert!(once.len() < src.len());
+        let twice = skeletonize(&once, "a.rs");
+        assert!(twice.is_none(), "already-elided body has nothing left to shrink");
+    }
+}

--- a/mur-compress/src/stats.rs
+++ b/mur-compress/src/stats.rs
@@ -45,6 +45,22 @@ struct StatsData {
     /// bucketed.
     #[serde(default)]
     buckets: HashMap<String, HashMap<String, BucketData>>,
+
+    /// Per-`ContentType::as_str()` totals (code/json/search_results/build_log/
+    /// git_diff/generic), so we can see where tokens actually sit and which
+    /// content types compress well vs. barely at all. Additive only, same
+    /// backfill rule as `buckets`.
+    #[serde(default)]
+    by_type: HashMap<String, TypeStats>,
+}
+
+/// Running totals for one content type across all-time compressions.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TypeStats {
+    pub compressions: u64,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub total_tokens_saved: u64,
 }
 
 /// Counts for one `(mur_version, day)` bucket. Mirrors the shape of the
@@ -76,6 +92,9 @@ pub struct StatsSnapshot {
     /// sums, etc.) is left to consumers (MCP tool, CLI) rather than computed
     /// here, so this stays a thin, order-independent map.
     pub buckets: HashMap<String, HashMap<String, BucketData>>,
+
+    /// Raw per-content-type totals, straight from `StatsData::by_type`.
+    pub by_type: HashMap<String, TypeStats>,
 }
 
 /// Current crate version, used as the bucket's version key. `mur-compress`
@@ -148,13 +167,14 @@ impl StatsTracker {
         }
     }
 
-    pub fn record_compression(&self, before: usize, after: usize) {
+    pub fn record_compression(&self, content_type: &str, before: usize, after: usize) {
         let day = today_key();
+        let saved = before.saturating_sub(after) as u64;
         self.update(|d| {
             d.compressions += 1;
             d.total_input_tokens += before as u64;
             d.total_output_tokens += after as u64;
-            d.total_tokens_saved += before.saturating_sub(after) as u64;
+            d.total_tokens_saved += saved;
 
             let bucket = d
                 .buckets
@@ -165,7 +185,13 @@ impl StatsTracker {
             bucket.compressions += 1;
             bucket.total_input_tokens += before as u64;
             bucket.total_output_tokens += after as u64;
-            bucket.total_tokens_saved += before.saturating_sub(after) as u64;
+            bucket.total_tokens_saved += saved;
+
+            let ts = d.by_type.entry(content_type.to_string()).or_default();
+            ts.compressions += 1;
+            ts.total_input_tokens += before as u64;
+            ts.total_output_tokens += after as u64;
+            ts.total_tokens_saved += saved;
         });
     }
 
@@ -210,6 +236,7 @@ impl StatsTracker {
             store_entries,
             store_bytes,
             buckets: d.buckets,
+            by_type: d.by_type,
         }
     }
 }
@@ -223,7 +250,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("stats.json");
         let t = StatsTracker::new(path.clone());
-        t.record_compression(100, 30);
+        t.record_compression("generic", 100, 30);
         t.record_retrieval();
         let snap = t.snapshot(3.0, 1, 123);
         assert_eq!(snap.compressions, 1);
@@ -243,8 +270,8 @@ mod tests {
         let path = dir.path().join("stats.json");
         let a = StatsTracker::new(path.clone());
         let b = StatsTracker::new(path.clone());
-        a.record_compression(100, 30); // saved 70
-        b.record_compression(50, 10); // saved 40
+        a.record_compression("generic", 100, 30); // saved 70
+        b.record_compression("generic", 50, 10); // saved 40
         a.record_retrieval();
         b.record_retrieval();
 
@@ -260,8 +287,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("stats.json");
         let t = StatsTracker::new(path.clone());
-        t.record_compression(100, 30); // saved 70
-        t.record_compression(50, 10); // saved 40
+        t.record_compression("generic", 100, 30); // saved 70
+        t.record_compression("generic", 50, 10); // saved 40
 
         let snap = t.snapshot(3.0, 0, 0);
         assert_eq!(snap.compressions, 2);
@@ -306,7 +333,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("stats.json");
         let t = StatsTracker::new(path);
-        t.record_compression(200, 20); // saved 180
+        t.record_compression("generic", 200, 20); // saved 180
         t.record_retrieval();
 
         let snap = t.snapshot(3.0, 0, 0);
@@ -319,5 +346,25 @@ mod tests {
         assert_eq!(bucket.compressions, 1);
         assert_eq!(bucket.retrievals, 1);
         assert_eq!(bucket.total_tokens_saved, 180);
+    }
+
+    #[test]
+    fn snapshot_exposes_by_type_breakdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stats.json");
+        let t = StatsTracker::new(path);
+        t.record_compression("code", 1000, 900); // saved 100, barely compresses
+        t.record_compression("json", 1000, 100); // saved 900, compresses well
+        t.record_compression("json", 500, 50); // saved 450
+
+        let snap = t.snapshot(3.0, 0, 0);
+        let code = snap.by_type.get("code").expect("code entry");
+        assert_eq!(code.compressions, 1);
+        assert_eq!(code.total_tokens_saved, 100);
+
+        let json = snap.by_type.get("json").expect("json entry");
+        assert_eq!(json.compressions, 2);
+        assert_eq!(json.total_input_tokens, 1500);
+        assert_eq!(json.total_tokens_saved, 1350);
     }
 }


### PR DESCRIPTION
## Summary
- `stats.rs`: per-`ContentType` compression ledger (compressions/tokens/savings) alongside the existing all-time and per-version-day buckets — lets us see where tokens actually sit before tuning strategy.
- `CompressEngine::archive()`: unconditionally stores content in the CCR store and returns a retrieval hash, bypassing `compress()`'s payoff gating (the fallback/Generic compressor — most prose and code — never offloads there). Needed for content dropped for reasons other than "it compresses well" (stale, duplicate).
- `skeleton.rs`: tree-sitter based code skeletonization for **Rust, Python, JavaScript, TypeScript/TSX, Go, PHP, Java, Swift, Dart**. Collapses function/method bodies to an elision marker, keeps imports/signatures/type-class declarations verbatim.

These back a new transcript-level "collapse stale tool results" pass in `cc-proxy` (separate repo) that supersedes/dedups Read results and inlines a code skeleton for already-dead content, without ever touching the most recent view of a file (Edit anchor safety).

Grammar crate ABI note: the workspace's shared `tree-sitter` core is pinned to `0.24` (set by `mur-core`'s pre-existing Rust-only code-graph indexer). Several grammar crates' latest releases target a newer ABI and fail `set_language` silently at runtime (no compile error) — pinned each to the newest version still compatible (see `skeleton.rs` module doc for exact versions and how to re-verify when bumping).

## Test plan
- [x] `cargo test -p mur-compress` — 63 tests pass (54 existing + 9 new skeleton-language tests, 14 total in `skeleton.rs`)
- [x] `cargo clippy -p mur-compress --all-targets` — clean
- [x] `cargo check` on the full workspace — no downstream breakage from the grammar deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)