### PR TITLE
chore: bump version to 2.40.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "libc",
 ]
@@ -6381,7 +6381,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6401,7 +6401,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6450,7 +6450,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -6477,7 +6477,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6569,7 +6569,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6597,7 +6597,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6636,7 +6636,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6653,7 +6653,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.40.0"
+version = "2.40.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"


### PR DESCRIPTION
## Summary
Version bump for the v2.40.1 release, which ships the mur-compress supersession/stats/skeletonization work from #632.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>