### PR TITLE
murmur Panel P3 — Preview tab (md/html/localhost + auto-reload)

### DIFF
--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -169,9 +169,11 @@ cd mur-agent-gui/src-tauri && cargo tauri dev          # 6-tab settings window o
 
 ---
 
-## murmur Panel (Hub GUI data tabs, P1+P2)
+## murmur Panel (Hub GUI data tabs, P1–P3)
 
-The Hub's per-agent detail panel surfaces read-only operational data alongside the chat/CLI view. P2 (2026-07) shipped five tabs: **Information** (git status/branch + cost/token usage), **Activities** (recent tool calls/events), **Preview** (deferred to P3 — placeholder tab), **Notifications** (pending workflow proposals), and **Schedule** (unified view across agent/workflow/fleet schedulers). Data flows from `mur-core` command output parsed into typed frames (`mur-core/src/panel.rs` — `frames_round_trip`/`unknown_frames_are_none` tests cover forward-compat with unrecognized frame kinds); the Hub calls `mur-core` directly rather than shelling out. Refresh is poll-based (~30s) with fail-soft rendering on missing/partial data.
+The Hub's per-agent detail panel surfaces read-only operational data alongside the chat/CLI view. P2 (2026-07) shipped five tabs: **Information** (git status/branch + cost/token usage), **Activities** (recent tool calls/events), **Preview**, **Notifications** (pending workflow proposals), and **Schedule** (unified view across agent/workflow/fleet schedulers). Data flows from `mur-core` command output parsed into typed frames (`mur-core/src/panel.rs` — `frames_round_trip`/`unknown_frames_are_none` tests cover forward-compat with unrecognized frame kinds); the Hub calls `mur-core` directly rather than shelling out. Refresh is poll-based (~30s) with fail-soft rendering on missing/partial data.
+
+P3 (2026-07) filled the **Preview** tab: `/panel preview <path|url>` renders a Markdown file (via the shared `Markdown` component), an HTML file (sandboxed `srcDoc`, scripts only), or a localhost dev-server URL (sandboxed iframe, host restricted to `localhost`/`127.0.0.1`/`[::1]`). File previews auto-reload via a single-slot `notify` watcher on the file's parent directory (`mur-hub-gui/src-tauri/src/panel/preview.rs`, emitting `panel-preview-changed`); reads are capped at 2 MiB.
 
 - **`mur internals schedule-status`** — unified schedule query across the agent scheduler, workflow scheduler, and fleet loop triggers; emits JSON (no `--json` flag needed, always structured) consumed by the Schedule tab.
 - **Spec:** see `.superpowers/sdd/` task briefs on branch `feat/murmur-panel-p2` for the full task breakdown (Tasks 1-9).

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -262,6 +262,7 @@ pub fn run() {
         .manage(EventBusState(EventBus::new(256)))
         .manage(BridgeState::default())
         .manage(panel::PanelState::default())
+        .manage(panel::preview::PreviewWatch::default())
         // OS file-drop onto a desktop pet (`pet-<agent>` window) → forward the
         // dropped paths to that pet's webview. App-level (not per-window) so it
         // covers pet windows created dynamically after launch.
@@ -578,6 +579,8 @@ pub fn run() {
             panel::panel_sessions,
             panel::panel_insert,
             panel::open_panel_window,
+            panel::preview::panel_read_preview_file,
+            panel::preview::panel_watch_preview,
             panel::data::panel_schedule_status,
             panel::data::panel_cost,
             panel::data::panel_proposals,

--- a/mur-hub-gui/src-tauri/src/panel/mod.rs
+++ b/mur-hub-gui/src-tauri/src/panel/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod data;
 pub mod pos;
+pub mod preview;
 
 use std::collections::HashMap;
 use std::sync::Mutex;

--- a/mur-hub-gui/src-tauri/src/panel/preview.rs
+++ b/mur-hub-gui/src-tauri/src/panel/preview.rs
@@ -73,13 +73,13 @@ pub fn panel_watch_preview(
     let watch_target = target.clone();
 
     let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
-        if let Ok(ev) = res {
-            if ev.paths.iter().any(|p| p == &watch_target) {
-                let _ = app.emit(
-                    "panel-preview-changed",
-                    serde_json::json!({ "path": watch_target.display().to_string() }),
-                );
-            }
+        if let Ok(ev) = res
+            && ev.paths.iter().any(|p| p == &watch_target)
+        {
+            let _ = app.emit(
+                "panel-preview-changed",
+                serde_json::json!({ "path": watch_target.display().to_string() }),
+            );
         }
     })
     .map_err(|e| e.to_string())?;

--- a/mur-hub-gui/src-tauri/src/panel/preview.rs
+++ b/mur-hub-gui/src-tauri/src/panel/preview.rs
@@ -1,0 +1,126 @@
+//! Panel preview backend: read a file for preview rendering, and watch
+//! it for external changes so the panel can auto-refresh.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use notify::{RecursiveMode, Watcher};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+
+/// Preview files larger than this are rejected to keep the panel snappy.
+const MAX_PREVIEW_BYTES: u64 = 2 * 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PreviewFile {
+    pub kind: &'static str,
+    pub content: String,
+    pub path: String,
+}
+
+pub(crate) fn kind_of(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("md") | Some("markdown") => "markdown",
+        Some("html") | Some("htm") => "html",
+        _ => "text",
+    }
+}
+
+pub(crate) fn read_preview(path: &Path) -> Result<PreviewFile, String> {
+    let meta = std::fs::metadata(path).map_err(|e| format!("{}: {e}", path.display()))?;
+    if meta.len() > MAX_PREVIEW_BYTES {
+        return Err(format!(
+            "file exceeds {MAX_PREVIEW_BYTES} bytes preview limit"
+        ));
+    }
+    let content = std::fs::read_to_string(path).map_err(|e| format!("{}: {e}", path.display()))?;
+    Ok(PreviewFile {
+        kind: kind_of(path),
+        content,
+        path: path.display().to_string(),
+    })
+}
+
+#[tauri::command]
+pub fn panel_read_preview_file(path: String) -> Result<PreviewFile, String> {
+    read_preview(Path::new(&path))
+}
+
+/// Single active watcher slot; replacing/stopping drops the previous watcher.
+#[derive(Default)]
+pub struct PreviewWatch(Mutex<Option<notify::RecommendedWatcher>>);
+
+#[tauri::command]
+pub fn panel_watch_preview(
+    app: AppHandle,
+    state: State<PreviewWatch>,
+    path: Option<String>,
+) -> Result<(), String> {
+    let mut slot = state.0.lock().map_err(|e| e.to_string())?;
+    *slot = None; // drop old watcher first
+    let Some(path) = path else {
+        return Ok(());
+    };
+    let target = PathBuf::from(&path);
+    // Watch the parent dir (editors often replace files atomically, which
+    // would orphan a file-level watch), filter events to our target.
+    let dir = target.parent().unwrap_or(Path::new(".")).to_path_buf();
+    let watch_target = target.clone();
+
+    let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        if let Ok(ev) = res {
+            if ev.paths.iter().any(|p| p == &watch_target) {
+                let _ = app.emit(
+                    "panel-preview-changed",
+                    serde_json::json!({ "path": watch_target.display().to_string() }),
+                );
+            }
+        }
+    })
+    .map_err(|e| e.to_string())?;
+    watcher
+        .watch(&dir, RecursiveMode::NonRecursive)
+        .map_err(|e| e.to_string())?;
+
+    *slot = Some(watcher);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_by_extension() {
+        assert_eq!(kind_of(std::path::Path::new("a.md")), "markdown");
+        assert_eq!(kind_of(std::path::Path::new("a.markdown")), "markdown");
+        assert_eq!(kind_of(std::path::Path::new("a.html")), "html");
+        assert_eq!(kind_of(std::path::Path::new("a.htm")), "html");
+        assert_eq!(kind_of(std::path::Path::new("a.rs")), "text");
+    }
+
+    #[test]
+    fn read_rejects_oversized() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("big.md");
+        let data = vec![b'x'; (MAX_PREVIEW_BYTES + 1) as usize];
+        std::fs::write(&file, data).unwrap();
+        let err = read_preview(&file).unwrap_err();
+        assert!(err.contains("exceeds"));
+    }
+
+    #[test]
+    fn read_returns_content_and_kind() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("doc.md");
+        std::fs::write(&file, "# Hello").unwrap();
+        let f = read_preview(&file).unwrap();
+        assert_eq!(f.kind, "markdown");
+        assert_eq!(f.content, "# Hello");
+    }
+}

--- a/mur-hub-gui/ui/src/components/panel/PanelWindow.tsx
+++ b/mur-hub-gui/ui/src/components/panel/PanelWindow.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import PreviewPane from "./PreviewPane";
 import "./panel.css";
 
 type PanelSession = {
@@ -114,7 +115,10 @@ export function PanelWindow() {
   const [sessions, setSessions] = useState<PanelSession[]>([]);
   const [pid, setPid] = useState<number | null>(null);
   const [tab, setTab] = useState<Tab>("information");
-  const [previewTarget, setPreviewTarget] = useState<string | null>(null);
+  const [preview, setPreview] = useState<{
+    kind: "file" | "url";
+    target: string;
+  } | null>(null);
   const [showAll, setShowAll] = useState(false);
 
   const [gitInfo, setGitInfo] = useState<GitInfo | null>(null);
@@ -144,7 +148,11 @@ export function PanelWindow() {
     });
     const unPreview = listen<{ pid: number; kind: string; target: string }>(
       "panel-preview",
-      (e) => setPreviewTarget(e.payload.target),
+      (e) =>
+        setPreview({
+          kind: e.payload.kind === "url" ? "url" : "file",
+          target: e.payload.target,
+        }),
     );
     return () => {
       unSessions.then((f) => f());
@@ -389,10 +397,15 @@ export function PanelWindow() {
               </footer>
             )}
           </div>
-        ) : tab === "preview" && previewTarget ? (
-          <p className="panel-empty">
-            Preview target: <code>{previewTarget}</code> (rendering lands in P3)
-          </p>
+        ) : tab === "preview" ? (
+          preview ? (
+            <PreviewPane target={preview.target} kind={preview.kind} />
+          ) : (
+            <p className="panel-empty">
+              No preview target — type{" "}
+              <code>/panel preview &lt;path|url&gt;</code> in murmur.
+            </p>
+          )
         ) : (
           <p className="panel-empty">{TAB_LABEL[tab]} lands in a later phase.</p>
         )}

--- a/mur-hub-gui/ui/src/components/panel/PreviewPane.tsx
+++ b/mur-hub-gui/ui/src/components/panel/PreviewPane.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { Markdown } from "../Markdown";
+
+type PreviewFile = {
+  kind: "markdown" | "html" | "text";
+  content: string;
+  path: string;
+};
+
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+function isAllowedUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw);
+    return (
+      (u.protocol === "http:" || u.protocol === "https:") &&
+      LOCAL_HOSTS.has(u.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export default function PreviewPane({
+  target,
+  kind,
+}: {
+  target: string;
+  kind: "file" | "url";
+}) {
+  const [file, setFile] = useState<PreviewFile | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (kind !== "file") {
+      void invoke("panel_watch_preview", { path: null }).catch(() => {});
+      return;
+    }
+    let live = true;
+    const load = () =>
+      invoke<PreviewFile>("panel_read_preview_file", { path: target })
+        .then((f) => {
+          if (live) {
+            setFile(f);
+            setError(null);
+          }
+        })
+        .catch((e) => {
+          if (live) setError(String(e));
+        });
+    load();
+    void invoke("panel_watch_preview", { path: target }).catch(() => {});
+    const un = listen("panel-preview-changed", () => load());
+    return () => {
+      live = false;
+      un.then((f) => f());
+      void invoke("panel_watch_preview", { path: null }).catch(() => {});
+    };
+  }, [target, kind]);
+
+  if (kind === "url") {
+    return isAllowedUrl(target) ? (
+      <iframe
+        className="preview-frame"
+        src={target}
+        sandbox="allow-scripts allow-same-origin allow-forms"
+        title="preview"
+      />
+    ) : (
+      <p className="panel-empty">Only localhost URLs can be previewed.</p>
+    );
+  }
+  if (error) return <p className="panel-empty">{error}</p>;
+  if (!file) return <p className="panel-empty">Loading…</p>;
+  if (file.kind === "html")
+    return (
+      <iframe
+        className="preview-frame"
+        srcDoc={file.content}
+        sandbox="allow-scripts"
+        title="preview"
+      />
+    );
+  if (file.kind === "markdown")
+    return (
+      <div className="preview-md">
+        <Markdown>{file.content}</Markdown>
+      </div>
+    );
+  return <pre className="preview-text">{file.content}</pre>;
+}

--- a/mur-hub-gui/ui/src/components/panel/panel.css
+++ b/mur-hub-gui/ui/src/components/panel/panel.css
@@ -126,3 +126,20 @@
 .panel-warnings {
   margin-top: 12px;
 }
+
+.preview-frame {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+.preview-md,
+.preview-text {
+  height: 100%;
+  overflow: auto;
+  padding: 8px 10px;
+}
+.preview-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 12px;
+}


### PR DESCRIPTION
## Summary

Fills the Panel's **Preview** tab (P2 left it a stub). Stacked on #634 (P2) — both edit `PanelWindow.tsx`.

`/panel preview <path|url>` now renders:
- **Markdown** files via the shared `Markdown` component
- **HTML** files via sandboxed `srcDoc` (`allow-scripts` only — no same-origin, no top-nav, no downloads)
- **localhost dev-server URLs** via sandboxed iframe, host restricted to `localhost`/`127.0.0.1`/`[::1]`

File previews **auto-reload** on change via a single-slot `notify` watcher on the file's parent directory (survives editors' atomic-replace saves), emitting `panel-preview-changed`. Reads capped at 2 MiB.

## Files
- `mur-hub-gui/src-tauri/src/panel/preview.rs` — `read_preview`/`kind_of` (3 unit tests) + `panel_read_preview_file` + `PreviewWatch` state + `panel_watch_preview` commands
- `mur-hub-gui/ui/src/components/panel/PreviewPane.tsx` — render + watch lifecycle
- `PanelWindow.tsx` — preview state `{kind,target}`, `panel-preview` listener, tab arm
- `panel.css`, `runtime-overview.md`

## Testing
- 4 backend tests pass (`cargo test … preview`); `cargo clippy -D warnings` clean; `npm run build` clean (zero TS errors).
- murmur TUI side: **zero changes** (`/panel preview` shipped in P1).

Plan: `docs/superpowers/plans/2026-07-06-murmur-panel-p3-preview.md`

Live `.app` UI verification pending. Note: implemented inline (subagent auth was down); diff is small and self-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)