### PR TITLE
fix(hub): don't panic when profile.yaml skills list is inline or missing

### DIFF
--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6619,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -6680,11 +6680,21 @@ dependencies = [
  "serde_yaml",
  "thiserror 2.0.18",
  "tiktoken-rs",
+ "tree-sitter",
+ "tree-sitter-dart",
+ "tree-sitter-go",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-php",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-swift",
+ "tree-sitter-typescript",
 ]
 
 [[package]]
 name = "mur-core"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6770,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.40.0"
+version = "2.40.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11488,16 +11498,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-dart"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f1f70b80ce41343e14aafcef67b5ba2e9de89587535b4aabbabb8036f4e38a"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
+name = "tree-sitter-php"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f066e94e9272cfe4f1dcb07a1c50c66097eca648f2d7233d299c8ae9ed8c130c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-rust"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65aeb41726119416567d0333ec17580ac4abfb96db1f67c4bd638c65f9992fe"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/mur-hub-gui/src-tauri/src/seed_mur.rs
+++ b/mur-hub-gui/src-tauri/src/seed_mur.rs
@@ -365,18 +365,48 @@ pub fn seed_missing_bundled_skills(
 }
 
 /// Append `- <reference>` as the last entry of the `skills:` list in `profile`.
+///
+/// This edits the *user's* live profile.yaml textually (to preserve their
+/// formatting), so it must accept every form the key can take and never
+/// panic: block lists, inline flow lists (`skills: []`, `skills: [a, b]` —
+/// converted to block style), and a missing key (a section is appended).
 fn append_skill_reference(profile: &str, reference: &str) -> String {
-    let mut lines: Vec<&str> = profile.lines().collect();
-    let skills_idx = lines
-        .iter()
-        .position(|l| l.trim_end() == "skills:")
-        .expect("template profile.yaml must have a skills: list");
-    let mut insert_at = skills_idx + 1;
-    while insert_at < lines.len() && lines[insert_at].trim_start().starts_with("- ") {
-        insert_at += 1;
+    let mut lines: Vec<String> = profile.lines().map(str::to_owned).collect();
+    let new_entry = format!("  - {reference}");
+
+    if let Some(idx) = lines.iter().position(|l| {
+        let t = l.trim_end();
+        t == "skills:" || t.starts_with("skills: ") || t.starts_with("skills:\t")
+    }) {
+        let rest = lines[idx].trim_end()["skills:".len()..].trim().to_owned();
+        if !rest.is_empty() {
+            // Inline flow list: convert to block style, keeping existing entries.
+            let items: Vec<String> = rest
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned)
+                .collect();
+            if items.iter().any(|i| i == reference) {
+                return profile.to_owned();
+            }
+            lines[idx] = "skills:".to_owned();
+            for (offset, item) in items.iter().enumerate() {
+                lines.insert(idx + 1 + offset, format!("  - {item}"));
+            }
+        }
+        let mut insert_at = idx + 1;
+        while insert_at < lines.len() && lines[insert_at].trim_start().starts_with("- ") {
+            insert_at += 1;
+        }
+        lines.insert(insert_at, new_entry);
+    } else {
+        lines.push("skills:".to_owned());
+        lines.push(new_entry);
     }
-    let new_line = format!("  - {reference}");
-    lines.insert(insert_at, &new_line);
+
     let mut out = lines.join("\n");
     if profile.ends_with('\n') {
         out.push('\n');
@@ -507,6 +537,94 @@ mod tests {
         seed_missing_bundled_skills(tpl.path(), home.path()).unwrap();
         let profile = std::fs::read_to_string(agent_dir.join("profile.yaml")).unwrap();
         assert_eq!(profile.matches("- skills/brainstorming").count(), 1);
+    }
+
+    #[test]
+    fn appends_into_inline_empty_skills_list() {
+        // Older seeders wrote `skills: []` (inline flow list). Must not panic.
+        let home = TempDir::new().unwrap();
+        let tpl = TempDir::new().unwrap();
+        make_dir_skill_template(tpl.path());
+
+        let agent_dir = home.path().join("agents/mur");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(
+            agent_dir.join("profile.yaml"),
+            "name: Mur\nskills: []\ntransport:\n  stdio: true\n",
+        )
+        .unwrap();
+
+        let seeded = seed_missing_bundled_skills(tpl.path(), home.path()).unwrap();
+        assert_eq!(seeded.len(), 2);
+        let profile = std::fs::read_to_string(agent_dir.join("profile.yaml")).unwrap();
+        assert!(!profile.contains("skills: []"), "profile: {profile}");
+        assert!(
+            profile.contains("skills:\n  - skills/"),
+            "profile: {profile}"
+        );
+        assert!(profile.contains("- skills/concierge"), "profile: {profile}");
+        assert!(
+            profile.contains("- skills/brainstorming"),
+            "profile: {profile}"
+        );
+        assert!(
+            profile.contains("transport:\n  stdio: true"),
+            "profile: {profile}"
+        );
+    }
+
+    #[test]
+    fn appends_into_inline_nonempty_skills_list() {
+        // Hand-edited flow list: keep existing entries, no duplicates, no panic.
+        let home = TempDir::new().unwrap();
+        let tpl = TempDir::new().unwrap();
+        make_dir_skill_template(tpl.path());
+
+        let agent_dir = home.path().join("agents/mur");
+        std::fs::create_dir_all(agent_dir.join("skills/concierge")).unwrap();
+        std::fs::write(
+            agent_dir.join("skills/concierge/skill.yaml"),
+            "name: concierge\n",
+        )
+        .unwrap();
+        std::fs::write(
+            agent_dir.join("profile.yaml"),
+            "name: Mur\nskills: [skills/concierge]\n",
+        )
+        .unwrap();
+
+        seed_missing_bundled_skills(tpl.path(), home.path()).unwrap();
+        let profile = std::fs::read_to_string(agent_dir.join("profile.yaml")).unwrap();
+        assert_eq!(
+            profile.matches("- skills/concierge").count(),
+            1,
+            "profile: {profile}"
+        );
+        assert_eq!(
+            profile.matches("- skills/brainstorming").count(),
+            1,
+            "profile: {profile}"
+        );
+        assert!(!profile.contains('['), "profile: {profile}");
+    }
+
+    #[test]
+    fn appends_skills_section_when_key_missing() {
+        // A profile with no skills key at all must not panic the Hub.
+        let home = TempDir::new().unwrap();
+        let tpl = TempDir::new().unwrap();
+        make_dir_skill_template(tpl.path());
+
+        let agent_dir = home.path().join("agents/mur");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(agent_dir.join("profile.yaml"), "name: Mur\n").unwrap();
+
+        seed_missing_bundled_skills(tpl.path(), home.path()).unwrap();
+        let profile = std::fs::read_to_string(agent_dir.join("profile.yaml")).unwrap();
+        assert!(
+            profile.contains("skills:\n  - skills/"),
+            "profile: {profile}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

MUR Hub 2.40.1 crashes at launch with SIGABRT (`abort() called`) on machines whose `~/.mur/agents/mur/profile.yaml` has `skills: []` (inline empty flow list, written by older seeders).

Root cause: `append_skill_reference()` in `seed_mur.rs` only matched a block-style `skills:` line and panicked via `.expect()` for any other form. The panic fires inside tao's `did_finish_launching` callback — a non-unwindable extern "C" boundary — so it becomes `abort()` and the app dies before showing a window.

The `.expect()` message blamed the "template", but the string being edited is the **user's live profile.yaml**, which is user-editable data and must never panic.

## Fix

`append_skill_reference()` is now total over every form the key can take:

- block-style `skills:` list — unchanged behavior (append after last entry)
- `skills: []` — converted to a block list with the new entry
- non-empty inline flow list (`skills: [a, b]`) — converted to block style, existing entries kept, deduplicated
- missing `skills:` key — a section is appended instead of panicking

`Cargo.lock`: refreshes the workspace-excluded hub lockfile, stale since the 2.40.1 bump and the mur-compress tree-sitter deps (#632).

## Testing

- 3 new tests (TDD: each reproduced the exact production panic before the fix): `appends_into_inline_empty_skills_list`, `appends_into_inline_nonempty_skills_list`, `appends_skills_section_when_key_missing`
- Full `mur-hub-gui` lib suite: 93/94 pass; the one failure (`cli_tools::tests::upgrade_hint_by_install_source`) is pre-existing on main and environment-dependent (asserts on the local install source), unrelated to this change
- End-to-end: built the hub and ran it against a copy of the exact crashing profile in an isolated `MUR_HOME` — launched cleanly, seeded `concierge` + `brainstorming`, rewrote `skills: []` to a block list preserving the rest of the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)