### PR TITLE
murmur Panel P4 — recommendations + gated live stream

### DIFF
--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -169,14 +169,17 @@ cd mur-agent-gui/src-tauri && cargo tauri dev          # 6-tab settings window o
 
 ---
 
-## murmur Panel (Hub GUI data tabs, P1–P3)
+## murmur Panel (Hub GUI data tabs, P1–P4)
 
 The Hub's per-agent detail panel surfaces read-only operational data alongside the chat/CLI view. P2 (2026-07) shipped five tabs: **Information** (git status/branch + cost/token usage), **Activities** (recent tool calls/events), **Preview**, **Notifications** (pending workflow proposals), and **Schedule** (unified view across agent/workflow/fleet schedulers). Data flows from `mur-core` command output parsed into typed frames (`mur-core/src/panel.rs` — `frames_round_trip`/`unknown_frames_are_none` tests cover forward-compat with unrecognized frame kinds); the Hub calls `mur-core` directly rather than shelling out. Refresh is poll-based (~30s) with fail-soft rendering on missing/partial data.
 
 P3 (2026-07) filled the **Preview** tab: `/panel preview <path|url>` renders a Markdown file (via the shared `Markdown` component), an HTML file (sandboxed `srcDoc`, scripts only), or a localhost dev-server URL (sandboxed iframe, host restricted to `localhost`/`127.0.0.1`/`[::1]`). File previews auto-reload via a single-slot `notify` watcher on the file's parent directory (`mur-hub-gui/src-tauri/src/panel/preview.rs`, emitting `panel-preview-changed`); reads are capped at 2 MiB.
 
 - **`mur internals schedule-status`** — unified schedule query across the agent scheduler, workflow scheduler, and fleet loop triggers; emits JSON (no `--json` flag needed, always structured) consumed by the Schedule tab.
-- **Spec:** see `.superpowers/sdd/` task briefs on branch `feat/murmur-panel-p2` for the full task breakdown (Tasks 1-9).
+
+P4 (2026-07) added recommendations and a gated live stream. **`mur internals recommend`** reuses `score_and_rank_generic` to surface cwd-relevant skills/workflows as ready-to-run `mur` commands; the Panel's **Information** tab lists them, and clicking one inserts the command text for the user to review/edit before running (no auto-execution). The Preview tab gained a **Live/Target** sub-toggle: `/panel stream on|off` is a murmur-side, per-session, opt-in (default OFF) slash command that forwards the agent's live output as `PanelFrame::Stream { delta }` frames; when Live is selected the Preview tab renders a capped 20,000-character rolling tail of the streamed text. The stream gate can only be flipped from the terminal the user is sitting at — the Hub has no frame to enable it remotely.
+
+- **Specs & plans:** `docs/superpowers/specs/2026-07-06-murmur-panel-p2-data-tabs-design.md` and the `docs/superpowers/plans/2026-07-06-murmur-panel-p{2,3,4,5}-*.md` implementation plans.
 
 ---
 

--- a/mur-common/src/panel.rs
+++ b/mur-common/src/panel.rs
@@ -66,6 +66,10 @@ pub enum PanelFrame {
         kind: PreviewKind,
         target: String,
     },
+    /// Live agent-output delta (P4; sent only while the session gate is on).
+    Stream {
+        delta: String,
+    },
     Bye,
 }
 
@@ -125,6 +129,16 @@ mod tests {
         })
         .unwrap();
         assert!(line.contains("\"focus\":\"schedule\""));
+
+        let line = serde_json::to_string(&PanelFrame::Stream {
+            delta: "tok".into(),
+        })
+        .unwrap();
+        assert!(line.contains("\"type\":\"stream\""));
+        assert!(matches!(
+            decode_line::<PanelFrame>(&line),
+            Some(PanelFrame::Stream { delta }) if delta == "tok"
+        ));
 
         let line = serde_json::to_string(&HubFrame::Insert {
             text: "/help".into(),

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -171,6 +171,16 @@ pub enum InternalsAction {
         #[arg(long)]
         agent: Option<String>,
     },
+    /// Context recommendations working directory JSON — Panel data source
+    #[command(hide = true)]
+    Recommend {
+        /// Working directory recommend
+        #[arg(long)]
+        cwd: String,
+        /// Max items
+        #[arg(long, default_value_t = 5)]
+        limit: usize,
+    },
 }
 
 #[derive(Subcommand)]

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -258,6 +258,10 @@ pub struct App {
     /// Panel server handle (`/panel` companion window). None only in tests;
     /// dropping it removes the session record + socket.
     pub panel: Option<super::panel::PanelHandle>,
+    /// Per-session gate for forwarding agent-output deltas to the Panel.
+    /// Default OFF; toggled ONLY via `/panel stream on|off` from this
+    /// terminal — the Hub has no frame that can flip it (fail-closed).
+    pub panel_stream: bool,
     /// Working directory captured at CLI startup; sent to the agent once per
     /// session so it knows what project the user is in.
     pub cwd: Option<PathBuf>,
@@ -360,6 +364,7 @@ impl App {
             pending_shell: Vec::new(),
             persist_warned: false,
             panel: None,
+            panel_stream: false,
             cwd: std::env::current_dir().ok(),
             cwd_sent: false,
             theme,
@@ -556,6 +561,14 @@ impl App {
             } else {
                 m.text.push_str(text);
             }
+        }
+        if !thinking
+            && self.panel_stream
+            && let Some(panel) = &self.panel
+        {
+            panel.send(mur_common::panel::PanelFrame::Stream {
+                delta: text.to_string(),
+            });
         }
         // NB: do not reset scroll_back here — that would yank the viewport back
         // to the bottom on every token, making it impossible to scroll up while

--- a/mur-core/src/cmd/agent/cli/complete.rs
+++ b/mur-core/src/cmd/agent/cli/complete.rs
@@ -59,6 +59,7 @@ const COMMANDS: &[(&str, &str, &[&str])] = &[
             "preview",
             "notifications",
             "schedule",
+            "stream",
         ],
     ),
     ("quit", "exit the chat", &[]),
@@ -251,7 +252,7 @@ mod tests {
     fn panel_subcommands() {
         let s = compute("/panel ", &[]).unwrap();
         assert!(s.items.iter().any(|c| c.insert == "/panel preview "));
-        assert_eq!(s.items.len(), 5);
+        assert_eq!(s.items.len(), 6);
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/panel.rs
+++ b/mur-core/src/cmd/agent/cli/panel.rs
@@ -163,12 +163,26 @@ async fn pump(
     }
 }
 
-const PANEL_HINT: &str = "usage: /panel [information|activities|preview|notifications|schedule] · /panel preview <path|url>";
+const PANEL_HINT: &str = "usage: /panel [information|activities|preview|notifications|schedule|stream on|off] · /panel preview <path|url>";
 
 /// `/panel [tab] [target]` — fire-and-forget; opens/focuses the Hub Panel
 /// window on the given tab.
 pub fn handle_panel_command(app: &mut super::app::App, args: &[String]) {
     use mur_common::panel::{PanelTab, PreviewKind};
+    if args.first().map(String::as_str) == Some("stream") {
+        match args.get(1).map(String::as_str) {
+            Some("on") => {
+                app.panel_stream = true;
+                app.push_system("panel stream: on".to_string());
+            }
+            Some("off") => {
+                app.panel_stream = false;
+                app.push_system("panel stream: off".to_string());
+            }
+            _ => app.push_system(format!("usage: /panel stream on|off — {PANEL_HINT}")),
+        }
+        return;
+    }
     let frame = match args.first().map(String::as_str) {
         Some("information" | "info") => PanelFrame::Panel {
             focus: PanelTab::Information,

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1213,6 +1213,13 @@ pub async fn run(cli: Cli) -> Result<()> {
                 let st = crate::schedule_status::schedule_status(&home, agent.as_deref());
                 println!("{}", serde_json::to_string_pretty(&st)?);
             }
+            InternalsAction::Recommend { cwd, limit } => {
+                let recs = crate::recommend::recommend_for_cwd(std::path::Path::new(&cwd), limit);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({ "recommendations": recs }))?
+                );
+            }
         },
         // Deprecated: use `mur skill eval`
         Commands::Eval { action } => {

--- a/mur-core/src/lib.rs
+++ b/mur-core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod model_setup;
 pub mod nudge;
 pub mod parallel;
 pub mod paths;
+pub mod recommend;
 pub mod retrieve;
 pub mod route;
 pub mod schedule_status;

--- a/mur-core/src/main.rs
+++ b/mur-core/src/main.rs
@@ -52,6 +52,9 @@ mod interactive;
 mod nudge;
 mod parallel;
 mod paths;
+// wired via dispatch in the lib crate; this bin re-declaration is unused.
+#[allow(dead_code)]
+mod recommend;
 mod retrieve;
 mod route;
 // wired via dispatch in the lib crate; this bin re-declaration is unused.

--- a/mur-core/src/recommend.rs
+++ b/mur-core/src/recommend.rs
@@ -1,0 +1,154 @@
+//! cwd-based skill/workflow recommendations for the murmur Panel.
+//!
+//! Reuses the exact retrieve pipeline `cmd/hook.rs::cmd_hook_prompt` uses for
+//! its degraded-mode / cold-start skill fallback: `load_skill_candidates` +
+//! `filter_by_scope` + `score_and_rank_generic` (which applies the
+//! `retrieval.min_score` floor, default 0.42, internally). Workflows are not
+//! `Retrievable` in this codebase (only `Pattern` and `LoadedSkill` are), so
+//! they are loaded via the same `WorkflowYamlStore::default_store()` hook.rs
+//! uses and ranked with a lightweight word-overlap score instead.
+//!
+//! Fail-soft: any missing/unreadable store yields an empty result, never an
+//! error or panic.
+
+use std::path::Path;
+
+use crate::retrieve::scoring::score_and_rank_generic;
+use crate::retrieve::skill_candidates::{ActiveScope, filter_by_scope, load_skill_candidates};
+use crate::store::workflow_yaml::WorkflowYamlStore;
+
+/// A single recommended skill or workflow for the current working directory.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Recommendation {
+    pub name: String,
+    pub kind: String, // "skill" | "workflow"
+    pub score: f32,
+    pub description: String,
+    /// Ready-to-edit command insert-on-click.
+    pub command: String, // "mur run <name>" | "mur skill show <name>"
+}
+
+/// Build a query string from a cwd's trailing path components (project dir +
+/// parent dir name) — the only cwd signal a session itself carries.
+pub fn cwd_query(cwd: &Path) -> String {
+    let parts: Vec<String> = cwd
+        .components()
+        .rev()
+        .take(2)
+        .filter_map(|c| {
+            let s = c.as_os_str().to_string_lossy();
+            if s.is_empty() || s == "/" {
+                None
+            } else {
+                Some(s.to_string())
+            }
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    parts.join(" ")
+}
+
+/// Minimum word-overlap score for an unscored workflow to be considered
+/// relevant. Mirrors the score floor semantics `score_and_rank_generic` uses
+/// for skills, applied to the simpler workflow-name/description overlap.
+const WORKFLOW_SCORE_FLOOR: f32 = 0.0;
+
+/// Recommend skills/workflows relevant to the given working directory.
+///
+/// Fail-soft: any store error (missing `~/.mur`, unreadable skills dir,
+/// missing workflow store) yields an empty `Vec`, never a panic or `Err`.
+pub fn recommend_for_cwd(cwd: &Path, limit: usize) -> Vec<Recommendation> {
+    let query = cwd_query(cwd);
+    if query.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    let mur_dir = mur_common::trust::mur_home();
+
+    // Skills: exact pipeline cmd_hook_prompt uses for its fallback path.
+    if let Ok(mut candidates) = load_skill_candidates(&mur_dir.join("skills"), &mur_dir) {
+        filter_by_scope(&mut candidates, &ActiveScope::detect());
+        for scored in score_and_rank_generic(&query, candidates)
+            .into_iter()
+            .take(limit)
+        {
+            out.push(Recommendation {
+                name: scored.item.manifest.name.clone(),
+                kind: "skill".into(),
+                score: scored.score as f32,
+                description: scored.item.manifest.description.clone(),
+                command: format!("mur skill show {}", scored.item.manifest.name),
+            });
+        }
+    }
+
+    // Workflows: `Workflow` doesn't implement `Retrievable`, so there is no
+    // `score_and_rank_generic` path to reuse for it (only `Pattern` and
+    // `LoadedSkill` do). Load via the same store hook.rs uses and rank with a
+    // simple case-insensitive word-overlap score against the query.
+    if let Ok(store) = WorkflowYamlStore::default_store()
+        && let Ok(workflows) = store.list_all()
+    {
+        let query_words: Vec<String> = query
+            .to_ascii_lowercase()
+            .split_whitespace()
+            .map(str::to_owned)
+            .collect();
+        let mut scored_workflows: Vec<(f32, mur_common::workflow::Workflow)> = workflows
+            .into_iter()
+            .map(|w| {
+                let haystack = format!("{} {}", w.name, w.description).to_ascii_lowercase();
+                let hits = query_words
+                    .iter()
+                    .filter(|qw| haystack.contains(qw.as_str()))
+                    .count();
+                let score = if query_words.is_empty() {
+                    0.0
+                } else {
+                    hits as f32 / query_words.len() as f32
+                };
+                (score, w)
+            })
+            .filter(|(score, _)| *score > WORKFLOW_SCORE_FLOOR)
+            .collect();
+        scored_workflows.sort_by(|a, b| b.0.total_cmp(&a.0));
+        for (score, w) in scored_workflows.into_iter().take(limit) {
+            out.push(Recommendation {
+                name: w.name.clone(),
+                kind: "workflow".into(),
+                score,
+                description: w.description.clone(),
+                command: format!("mur run \"{}\"", w.name),
+            });
+        }
+    }
+
+    out.sort_by(|a, b| b.score.total_cmp(&a.score));
+    out.truncate(limit);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_uses_trailing_path_components() {
+        assert_eq!(
+            cwd_query(Path::new("/Volumes/x/Projects/mur")),
+            "Projects mur"
+        );
+        assert_eq!(cwd_query(Path::new("/")), "");
+    }
+
+    #[test]
+    fn recommend_is_fail_soft_on_empty_home() {
+        // No ~/.mur stores reachable for this nonsense cwd/env in a test
+        // sandbox → must return without panicking or erroring.
+        let recs = recommend_for_cwd(Path::new("/nonexistent/dir"), 5);
+        assert!(recs.len() <= 5);
+    }
+}

--- a/mur-core/src/recommend.rs
+++ b/mur-core/src/recommend.rs
@@ -50,32 +50,31 @@ pub fn cwd_query(cwd: &Path) -> String {
     parts.join(" ")
 }
 
-/// Minimum word-overlap score for an unscored workflow to be considered
-/// relevant. Mirrors the score floor semantics `score_and_rank_generic` uses
-/// for skills, applied to the simpler workflow-name/description overlap.
-const WORKFLOW_SCORE_FLOOR: f32 = 0.0;
-
 /// Recommend skills/workflows relevant to the given working directory.
 ///
 /// Fail-soft: any store error (missing `~/.mur`, unreadable skills dir,
 /// missing workflow store) yields an empty `Vec`, never a panic or `Err`.
+///
+/// Tiered by kind: skills are ranked among themselves by their real
+/// `score_and_rank_generic` score (0.42+ floor), then workflows are ranked
+/// among themselves by word-overlap (0.0–1.0). Skills appear first in the
+/// result, followed by workflows, then truncated to limit. This prevents
+/// high-overlap workflows from outranking lower-scored but more relevant
+/// skills across incompatible scoring scales.
 pub fn recommend_for_cwd(cwd: &Path, limit: usize) -> Vec<Recommendation> {
     let query = cwd_query(cwd);
     if query.trim().is_empty() {
         return Vec::new();
     }
 
-    let mut out = Vec::new();
     let mur_dir = mur_common::trust::mur_home();
 
     // Skills: exact pipeline cmd_hook_prompt uses for its fallback path.
+    let mut skills = Vec::new();
     if let Ok(mut candidates) = load_skill_candidates(&mur_dir.join("skills"), &mur_dir) {
         filter_by_scope(&mut candidates, &ActiveScope::detect());
-        for scored in score_and_rank_generic(&query, candidates)
-            .into_iter()
-            .take(limit)
-        {
-            out.push(Recommendation {
+        for scored in score_and_rank_generic(&query, candidates) {
+            skills.push(Recommendation {
                 name: scored.item.manifest.name.clone(),
                 kind: "skill".into(),
                 score: scored.score as f32,
@@ -89,34 +88,37 @@ pub fn recommend_for_cwd(cwd: &Path, limit: usize) -> Vec<Recommendation> {
     // `score_and_rank_generic` path to reuse for it (only `Pattern` and
     // `LoadedSkill` do). Load via the same store hook.rs uses and rank with a
     // simple case-insensitive word-overlap score against the query.
+    let mut workflows = Vec::new();
     if let Ok(store) = WorkflowYamlStore::default_store()
-        && let Ok(workflows) = store.list_all()
+        && let Ok(list) = store.list_all()
     {
         let query_words: Vec<String> = query
             .to_ascii_lowercase()
             .split_whitespace()
             .map(str::to_owned)
             .collect();
-        let mut scored_workflows: Vec<(f32, mur_common::workflow::Workflow)> = workflows
+        let mut scored_workflows: Vec<(f32, mur_common::workflow::Workflow)> = list
             .into_iter()
-            .map(|w| {
+            .filter_map(|w| {
                 let haystack = format!("{} {}", w.name, w.description).to_ascii_lowercase();
                 let hits = query_words
                     .iter()
                     .filter(|qw| haystack.contains(qw.as_str()))
                     .count();
+                if hits == 0 {
+                    return None;
+                }
                 let score = if query_words.is_empty() {
                     0.0
                 } else {
                     hits as f32 / query_words.len() as f32
                 };
-                (score, w)
+                Some((score, w))
             })
-            .filter(|(score, _)| *score > WORKFLOW_SCORE_FLOOR)
             .collect();
         scored_workflows.sort_by(|a, b| b.0.total_cmp(&a.0));
-        for (score, w) in scored_workflows.into_iter().take(limit) {
-            out.push(Recommendation {
+        for (score, w) in scored_workflows {
+            workflows.push(Recommendation {
                 name: w.name.clone(),
                 kind: "workflow".into(),
                 score,
@@ -126,7 +128,9 @@ pub fn recommend_for_cwd(cwd: &Path, limit: usize) -> Vec<Recommendation> {
         }
     }
 
-    out.sort_by(|a, b| b.score.total_cmp(&a.score));
+    // Tier: all sorted skills first, then all sorted workflows appended.
+    let mut out = skills;
+    out.extend(workflows);
     out.truncate(limit);
     out
 }

--- a/mur-core/src/recommend.rs
+++ b/mur-core/src/recommend.rs
@@ -31,17 +31,16 @@ pub struct Recommendation {
 /// Build a query string from a cwd's trailing path components (project dir +
 /// parent dir name) — the only cwd signal a session itself carries.
 pub fn cwd_query(cwd: &Path) -> String {
+    // Only real path segments (Component::Normal) — skips root/prefix/separator
+    // components in a platform-agnostic way (on Windows the root renders as
+    // "\\", not "/", so a string comparison would leak it into the query).
     let parts: Vec<String> = cwd
         .components()
         .rev()
         .take(2)
-        .filter_map(|c| {
-            let s = c.as_os_str().to_string_lossy();
-            if s.is_empty() || s == "/" {
-                None
-            } else {
-                Some(s.to_string())
-            }
+        .filter_map(|c| match c {
+            std::path::Component::Normal(s) => Some(s.to_string_lossy().into_owned()),
+            _ => None,
         })
         .collect::<Vec<_>>()
         .into_iter()

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -586,6 +586,7 @@ pub fn run() {
             panel::data::panel_proposals,
             panel::data::panel_git_info,
             panel::data::panel_activities,
+            panel::data::panel_recommend,
             start_agent,
             stop_agent,
             chat::agent_chat_send,

--- a/mur-hub-gui/src-tauri/src/panel/data.rs
+++ b/mur-hub-gui/src-tauri/src/panel/data.rs
@@ -1,6 +1,8 @@
 //! Panel P2 data commands: thin adapters over mur-core lib fns.
 //! Spec: docs/superpowers/specs/2026-07-06-murmur-panel-p2-data-tabs-design.md
 
+use std::path::Path;
+
 use serde::Serialize;
 
 use crate::mur_home_path;
@@ -60,6 +62,11 @@ pub async fn panel_activities(agent: String) -> Activities {
         .filter(|h| h.agent.eq_ignore_ascii_case(&agent))
         .collect();
     Activities { channels, hitl }
+}
+
+#[tauri::command]
+pub fn panel_recommend(cwd: String) -> Vec<mur_core::recommend::Recommendation> {
+    mur_core::recommend::recommend_for_cwd(Path::new(&cwd), 5)
 }
 
 /// Best-effort `git` shell-out; returns an empty `GitInfo` for non-repos.

--- a/mur-hub-gui/src-tauri/src/panel/mod.rs
+++ b/mur-hub-gui/src-tauri/src/panel/mod.rs
@@ -91,6 +91,12 @@ fn on_frame(app: &AppHandle, pid: u32, frame: PanelFrame) {
                 serde_json::json!({ "pid": pid, "kind": kind, "target": target }),
             );
         }
+        PanelFrame::Stream { delta } => {
+            let _ = app.emit(
+                "panel-stream",
+                serde_json::json!({ "pid": pid, "delta": delta }),
+            );
+        }
         PanelFrame::Bye => {}
     }
 }

--- a/mur-hub-gui/ui/src/components/panel/PanelWindow.tsx
+++ b/mur-hub-gui/ui/src/components/panel/PanelWindow.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import PreviewPane from "./PreviewPane";
+import StreamTail from "./StreamTail";
 import "./panel.css";
 
 type PanelSession = {
@@ -64,6 +65,13 @@ type GitInfo = {
   dirty: boolean;
 };
 type ProposalSummary = { file: string; modified: string };
+type Recommendation = {
+  name: string;
+  kind: "skill" | "workflow";
+  score: number;
+  description: string;
+  command: string;
+};
 
 type WorkParticipant = { id: string };
 type ChannelSummary = {
@@ -120,12 +128,14 @@ export function PanelWindow() {
     target: string;
   } | null>(null);
   const [showAll, setShowAll] = useState(false);
+  const [previewMode, setPreviewMode] = useState<"target" | "live">("target");
 
   const [gitInfo, setGitInfo] = useState<GitInfo | null>(null);
   const [cost, setCost] = useState<TokenTotals | null>(null);
   const [activities, setActivities] = useState<Activities | null>(null);
   const [schedule, setSchedule] = useState<ScheduleStatus | null>(null);
   const [proposals, setProposals] = useState<ProposalSummary[]>([]);
+  const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
 
   useEffect(() => {
     void invoke<PanelSession[]>("panel_sessions").then((s) => {
@@ -148,11 +158,13 @@ export function PanelWindow() {
     });
     const unPreview = listen<{ pid: number; kind: string; target: string }>(
       "panel-preview",
-      (e) =>
+      (e) => {
         setPreview({
           kind: e.payload.kind === "url" ? "url" : "file",
           target: e.payload.target,
-        }),
+        });
+        setPreviewMode("target");
+      },
     );
     return () => {
       unSessions.then((f) => f());
@@ -163,6 +175,10 @@ export function PanelWindow() {
 
   const sess = sessions.find((s) => s.pid === pid);
 
+  useEffect(() => {
+    setPreviewMode(preview ? "target" : "live");
+  }, [sess?.pid]);
+
   // Fetch data for the active tab whenever the session, tab, showAll toggle
   // change, or the window regains focus.
   const fetchTabData = useRef<() => void>(() => {});
@@ -171,6 +187,9 @@ export function PanelWindow() {
     if (tab === "information") {
       void invoke<GitInfo>("panel_git_info", { cwd: sess.cwd }).then(setGitInfo);
       void invoke<TokenTotals>("panel_cost", { agent: sess.agent }).then(setCost);
+      void invoke<Recommendation[]>("panel_recommend", { cwd: sess.cwd }).then(
+        setRecommendations,
+      );
     } else if (tab === "activities") {
       void invoke<Activities>("panel_activities", { agent: sess.agent }).then(setActivities);
     } else if (tab === "notifications") {
@@ -243,6 +262,24 @@ export function PanelWindow() {
           </label>
         </div>
       )}
+      {tab === "preview" && sess && (
+        <div className="panel-tab-header">
+          <div className="panel-subtoggle">
+            <button
+              className={previewMode === "target" ? "panel-subtoggle-btn active" : "panel-subtoggle-btn"}
+              onClick={() => setPreviewMode("target")}
+            >
+              Target
+            </button>
+            <button
+              className={previewMode === "live" ? "panel-subtoggle-btn active" : "panel-subtoggle-btn"}
+              onClick={() => setPreviewMode("live")}
+            >
+              Live
+            </button>
+          </div>
+        </div>
+      )}
       <main className="panel-body">
         {!sess ? (
           <p className="panel-empty">
@@ -288,6 +325,26 @@ export function PanelWindow() {
                 </>
               )}
             </dl>
+            <h3>Recommended</h3>
+            {recommendations.length === 0 ? (
+              <p className="panel-empty">No recommendations.</p>
+            ) : (
+              <ul className="panel-list">
+                {recommendations.map((r) => (
+                  <li
+                    key={`${r.kind}-${r.name}`}
+                    className="panel-list-row panel-list-clickable"
+                    onClick={() => insert(r.command)}
+                  >
+                    <span className={`panel-badge panel-badge-${r.kind}`}>
+                      {r.kind}
+                    </span>
+                    <span className="panel-list-name">{r.name}</span>
+                    <span className="panel-list-preview">{r.description}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         ) : tab === "activities" ? (
           <div className="panel-activities">
@@ -398,7 +455,9 @@ export function PanelWindow() {
             )}
           </div>
         ) : tab === "preview" ? (
-          preview ? (
+          previewMode === "live" ? (
+            <StreamTail pid={sess.pid} />
+          ) : preview ? (
             <PreviewPane target={preview.target} kind={preview.kind} />
           ) : (
             <p className="panel-empty">

--- a/mur-hub-gui/ui/src/components/panel/StreamTail.tsx
+++ b/mur-hub-gui/ui/src/components/panel/StreamTail.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+const STREAM_TAIL_CHARS = 20_000;
+
+export default function StreamTail({ pid }: { pid: number }) {
+  const [buf, setBuf] = useState("");
+  const ref = useRef<HTMLPreElement>(null);
+
+  useEffect(() => {
+    setBuf("");
+    const un = listen<{ pid: number; delta: string }>("panel-stream", (e) => {
+      if (e.payload.pid !== pid) return;
+      setBuf((b) => (b + e.payload.delta).slice(-STREAM_TAIL_CHARS));
+    });
+    return () => {
+      un.then((f) => f());
+    };
+  }, [pid]);
+
+  useEffect(() => {
+    ref.current?.scrollTo(0, ref.current.scrollHeight);
+  }, [buf]);
+
+  if (!buf) {
+    return (
+      <p className="panel-empty">
+        No live stream yet — type <code>/panel stream on</code> in murmur.
+      </p>
+    );
+  }
+
+  return (
+    <pre ref={ref} className="stream-tail">
+      {buf}
+    </pre>
+  );
+}

--- a/mur-hub-gui/ui/src/components/panel/panel.css
+++ b/mur-hub-gui/ui/src/components/panel/panel.css
@@ -143,3 +143,44 @@
   word-break: break-word;
   font-size: 12px;
 }
+
+.panel-badge-skill {
+  background: rgba(90, 130, 220, 0.2);
+  color: #4568c9;
+}
+.panel-badge-workflow {
+  background: rgba(160, 90, 220, 0.2);
+  color: #8c4dd4;
+}
+
+.panel-subtoggle {
+  display: flex;
+  gap: 4px;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid rgba(128, 128, 128, 0.25);
+}
+.panel-subtoggle-btn {
+  padding: 3px 10px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  opacity: 0.65;
+  color: inherit;
+  font-size: 12px;
+}
+.panel-subtoggle-btn.active {
+  opacity: 1;
+  font-weight: 600;
+  background: rgba(128, 128, 128, 0.15);
+}
+
+.stream-tail {
+  height: 100%;
+  margin: 0;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}


### PR DESCRIPTION
## Summary

P4 of the murmur Panel. Stacked on #635 (P3). Two features:

**Recommendations** — `mur-core/src/recommend.rs::recommend_for_cwd` reuses the retrieve pipeline (`score_and_rank_generic`, same loaders as `cmd_hook_prompt`) to surface cwd-relevant skills/workflows as ready-to-run `mur` commands. Exposed as hidden CLI `mur internals recommend --cwd <path>` and Tauri command `panel_recommend`. The **Information** tab lists them; clicking inserts the command text (insert-only — no auto-execution). Skills and workflows are tiered (scored within their own scale, concatenated), not cross-scale-sorted.

**Gated live stream** — additive `PanelFrame::Stream { delta }` wire variant. murmur forwards its agent-output deltas to the Hub **only** when `/panel stream on` — a per-session, **default-OFF**, terminal-only slash command. The Hub cannot enable it (HubFrame is insert-only). Hub republishes as a `panel-stream` webview event; the Preview tab has a **Live/Target** sub-toggle rendering a 20k-char rolling tail. Internal reasoning (thinking) deltas are excluded from the forwarded surface.

## Security
The stream gate is fail-closed: `panel_stream` defaults false, has exactly one write site (the `/panel stream on|off` terminal path), and no Hub frame or code can flip it. Independently verified in the per-task security review and the whole-branch review.

## Testing
- 7 commits; per-task spec+quality reviews all passed; whole-branch review: **ready to merge, security invariant intact**.
- `cargo fmt`/`clippy -D warnings` clean (mur-core, mur-common, Tauri crate); `npm run build` clean; `cargo test` 1934 pass. The 3 failures are pre-existing test-isolation flakes (`cmd::agent::addon` x2, `cmd::agent::mcp::add_remote`) — each passes in isolation, in code P4 never touches.

## Follow-ups (non-blocking, from review)
- Reset `panel_stream = false` on `/clear` for parity with `cwd_sent` (minor UX; stream currently survives a context switch within the same session).
- `cwd_query` uses only trailing 2 path components — may under-contextualize deep monorepo paths.

Plan: `docs/superpowers/plans/2026-07-06-murmur-panel-p4-recommend-stream.md`

Live `.app` UI verification pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)