### PR TITLE
murmur Panel P5 — live window-follow (polling, no permissions)

### DIFF
--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -169,7 +169,7 @@ cd mur-agent-gui/src-tauri && cargo tauri dev          # 6-tab settings window o
 
 ---
 
-## murmur Panel (Hub GUI data tabs, P1–P4)
+## murmur Panel (Hub GUI data tabs, P1–P5)
 
 The Hub's per-agent detail panel surfaces read-only operational data alongside the chat/CLI view. P2 (2026-07) shipped five tabs: **Information** (git status/branch + cost/token usage), **Activities** (recent tool calls/events), **Preview**, **Notifications** (pending workflow proposals), and **Schedule** (unified view across agent/workflow/fleet schedulers). Data flows from `mur-core` command output parsed into typed frames (`mur-core/src/panel.rs` — `frames_round_trip`/`unknown_frames_are_none` tests cover forward-compat with unrecognized frame kinds); the Hub calls `mur-core` directly rather than shelling out. Refresh is poll-based (~30s) with fail-soft rendering on missing/partial data.
 
@@ -178,6 +178,8 @@ P3 (2026-07) filled the **Preview** tab: `/panel preview <path|url>` renders a M
 - **`mur internals schedule-status`** — unified schedule query across the agent scheduler, workflow scheduler, and fleet loop triggers; emits JSON (no `--json` flag needed, always structured) consumed by the Schedule tab.
 
 P4 (2026-07) added recommendations and a gated live stream. **`mur internals recommend`** reuses `score_and_rank_generic` to surface cwd-relevant skills/workflows as ready-to-run `mur` commands; the Panel's **Information** tab lists them, and clicking one inserts the command text for the user to review/edit before running (no auto-execution). The Preview tab gained a **Live/Target** sub-toggle: `/panel stream on|off` is a murmur-side, per-session, opt-in (default OFF) slash command that forwards the agent's live output as `PanelFrame::Stream { delta }` frames; when Live is selected the Preview tab renders a capped 20,000-character rolling tail of the streamed text. The stream gate can only be flipped from the terminal the user is sitting at — the Hub has no frame to enable it remotely.
+
+P5 (2026-07) made the panel **follow the terminal window**. A permission-free poll loop (`mur-hub-gui/src-tauri/src/panel/follow.rs`, `panel_follow` command) reads the terminal window's bounds via `CGWindowList` every 600 ms and re-invokes `reposition` when they change — no Accessibility/AXObserver permission needed. A pure `follow_tick` decides reposition/idle/pause; it **pauses when the user drags the panel** (never fights the user) and stays idle when the terminal is minimized/on another Space (no teleport). A 📌 pin toggle in the panel header starts/stops following (default on); re-pin restarts after a manual move. Chosen over AXObserver: zero permissions beat sub-second latency for a companion panel.
 
 - **Specs & plans:** `docs/superpowers/specs/2026-07-06-murmur-panel-p2-data-tabs-design.md` and the `docs/superpowers/plans/2026-07-06-murmur-panel-p{2,3,4,5}-*.md` implementation plans.
 

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -263,6 +263,7 @@ pub fn run() {
         .manage(BridgeState::default())
         .manage(panel::PanelState::default())
         .manage(panel::preview::PreviewWatch::default())
+        .manage(panel::follow::FollowState::default())
         // OS file-drop onto a desktop pet (`pet-<agent>` window) → forward the
         // dropped paths to that pet's webview. App-level (not per-window) so it
         // covers pet windows created dynamically after launch.
@@ -579,6 +580,7 @@ pub fn run() {
             panel::panel_sessions,
             panel::panel_insert,
             panel::open_panel_window,
+            panel::follow::panel_follow,
             panel::preview::panel_read_preview_file,
             panel::preview::panel_watch_preview,
             panel::data::panel_schedule_status,

--- a/mur-hub-gui/src-tauri/src/panel/follow.rs
+++ b/mur-hub-gui/src-tauri/src/panel/follow.rs
@@ -1,0 +1,143 @@
+//! P5 live-follow: permission-free polling of the terminal window's bounds.
+//! Decision (2026-07-06): polling over AXObserver — zero permissions, ~600ms
+//! worst-case lag is imperceptible for a companion panel.
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use tauri::{AppHandle, Manager, State};
+
+use crate::geometry::Rect;
+use crate::panel::pos::{reposition, terminal_window_bounds};
+
+pub const FOLLOW_INTERVAL_MS: u64 = 600;
+
+/// Generation counter: (re)starting bumps it; a running loop exits once its
+/// own generation is no longer current.
+#[derive(Default)]
+pub struct FollowState(pub Mutex<u64>);
+
+pub enum Tick {
+    Reposition(Rect),
+    Pause,
+    Idle,
+}
+
+/// Pure per-tick decision. `expected_panel` is where we last placed the panel
+/// (`None` on the first tick); `actual_panel` is where the window really is.
+pub fn follow_tick(
+    last_term: Option<Rect>,
+    term: Option<Rect>,
+    actual_panel: (i32, i32),
+    expected_panel: Option<(i32, i32)>,
+) -> Tick {
+    if let Some(exp) = expected_panel
+        && exp != actual_panel
+    {
+        return Tick::Pause; // user dragged the panel — stop fighting it
+    }
+    match (last_term, term) {
+        (_, None) => Tick::Idle,
+        (Some(a), Some(b)) if a == b => Tick::Idle,
+        (_, Some(b)) => Tick::Reposition(b),
+    }
+}
+
+#[tauri::command]
+pub fn panel_follow(app: AppHandle, state: State<FollowState>, term_program: Option<String>) {
+    let my_gen = {
+        let mut g = state.0.lock().unwrap_or_else(|e| e.into_inner());
+        *g += 1;
+        *g
+    };
+    let Some(tp) = term_program else {
+        return; // bump already invalidated any running loop
+    };
+    std::thread::spawn(move || {
+        let mut last_term: Option<Rect> = None;
+        let mut expected: Option<(i32, i32)> = None;
+        loop {
+            std::thread::sleep(Duration::from_millis(FOLLOW_INTERVAL_MS));
+            let st: State<FollowState> = app.state();
+            if *st.0.lock().unwrap_or_else(|e| e.into_inner()) != my_gen {
+                return;
+            }
+            let Some(win) = app.get_webview_window(super::PANEL_LABEL) else {
+                return;
+            };
+            let actual = match win.outer_position() {
+                Ok(p) => (p.x, p.y),
+                Err(_) => return,
+            };
+            let term = terminal_window_bounds(&win, &tp);
+            match follow_tick(last_term, term, actual, expected) {
+                Tick::Pause => return, // re-pin restarts via a fresh panel_follow call
+                Tick::Idle => {}
+                Tick::Reposition(t) => {
+                    reposition(&win, Some(t));
+                    expected = win.outer_position().ok().map(|p| (p.x, p.y));
+                }
+            }
+            last_term = term;
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn r(x: i32, y: i32) -> Rect {
+        Rect {
+            x,
+            y,
+            w: 800,
+            h: 600,
+        }
+    }
+
+    #[test]
+    fn reposition_when_terminal_moved() {
+        match follow_tick(Some(r(0, 0)), Some(r(50, 0)), (900, 0), Some((900, 0))) {
+            Tick::Reposition(t) => assert_eq!(t, r(50, 0)),
+            _ => panic!("expected Reposition"),
+        }
+    }
+
+    #[test]
+    fn idle_when_nothing_changed() {
+        assert!(matches!(
+            follow_tick(Some(r(0, 0)), Some(r(0, 0)), (900, 0), Some((900, 0))),
+            Tick::Idle
+        ));
+    }
+
+    #[test]
+    fn pause_when_user_dragged_panel() {
+        // actual (300,300) != expected (900,0): the user moved the panel.
+        assert!(matches!(
+            follow_tick(Some(r(0, 0)), Some(r(50, 0)), (300, 300), Some((900, 0))),
+            Tick::Pause
+        ));
+    }
+
+    #[test]
+    fn terminal_vanished_is_idle_not_fallback() {
+        // Terminal window gone mid-session: do nothing, don't snap to a
+        // fallback position.
+        assert!(matches!(
+            follow_tick(Some(r(0, 0)), None, (900, 0), Some((900, 0))),
+            Tick::Idle
+        ));
+    }
+
+    #[test]
+    fn first_tick_with_no_expected_pos_repositions() {
+        // No prior term bounds and no expected panel position yet (the very
+        // first tick after `panel_follow` starts): still reposition.
+        match follow_tick(None, Some(r(0, 0)), (0, 0), None) {
+            Tick::Reposition(t) => assert_eq!(t, r(0, 0)),
+            _ => panic!("expected Reposition"),
+        }
+    }
+}

--- a/mur-hub-gui/src-tauri/src/panel/mod.rs
+++ b/mur-hub-gui/src-tauri/src/panel/mod.rs
@@ -3,6 +3,7 @@
 //! here; clicks go back insert-only.
 
 pub mod data;
+pub mod follow;
 pub mod pos;
 pub mod preview;
 

--- a/mur-hub-gui/ui/src/components/panel/PanelWindow.tsx
+++ b/mur-hub-gui/ui/src/components/panel/PanelWindow.tsx
@@ -136,6 +136,7 @@ export function PanelWindow() {
   const [schedule, setSchedule] = useState<ScheduleStatus | null>(null);
   const [proposals, setProposals] = useState<ProposalSummary[]>([]);
   const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
+  const [pinned, setPinned] = useState(true);
 
   useEffect(() => {
     void invoke<PanelSession[]>("panel_sessions").then((s) => {
@@ -178,6 +179,17 @@ export function PanelWindow() {
   useEffect(() => {
     setPreviewMode(preview ? "target" : "live");
   }, [sess?.pid]);
+
+  // Live-follow: while pinned, poll the terminal window and reposition the
+  // panel beside it (Task 1's backend loop). Unpinning / session change stops
+  // it. A user-drag pauses the backend loop; re-pin (toggle off/on) restarts.
+  useEffect(() => {
+    const tp = pinned ? (sess?.terminal_program ?? null) : null;
+    invoke("panel_follow", { termProgram: tp }).catch(() => {});
+    return () => {
+      invoke("panel_follow", { termProgram: null }).catch(() => {});
+    };
+  }, [sess?.pid, sess?.terminal_program, pinned]);
 
   // Fetch data for the active tab whenever the session, tab, showAll toggle
   // change, or the window regains focus.
@@ -238,6 +250,13 @@ export function PanelWindow() {
             </option>
           ))}
         </select>
+        <button
+          className={pinned ? "panel-pin active" : "panel-pin"}
+          title="Follow terminal window (re-pin after moving the panel)"
+          onClick={() => setPinned((p) => !p)}
+        >
+          📌
+        </button>
       </header>
       <nav className="panel-tabs">
         {TABS.map((t) => (

--- a/mur-hub-gui/ui/src/components/panel/panel.css
+++ b/mur-hub-gui/ui/src/components/panel/panel.css
@@ -184,3 +184,18 @@
   font-size: 12px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
+
+.panel-pin {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-size: 14px;
+  opacity: 0.4;
+  filter: grayscale(1);
+  padding: 2px 4px;
+  line-height: 1;
+}
+.panel-pin.active {
+  opacity: 1;
+  filter: none;
+}


### PR DESCRIPTION
## Summary

Final Panel phase. The Hub PanelWindow now **follows the murmur terminal window** as it moves/resizes — permission-free polling, not AXObserver.

- `panel/follow.rs` — a 600 ms poll loop (`panel_follow` command) reads the terminal's bounds via `CGWindowList` and re-invokes the existing `reposition` when they change. **No Accessibility permission** needed (bounds don't require it).
- Pure `follow_tick(last_term, term, actual_panel, expected_panel) -> Tick` decides Reposition / Idle / Pause — 5 unit tests. Key behaviors: **pauses when the user drags the panel** (never fights the user), stays **Idle when the terminal is minimized / on another Space** (no teleport to a fallback), repositions on first tick and on terminal move.
- Generation-counter lifecycle: each `panel_follow` call bumps a counter; the old loop exits when its generation is stale (no JoinHandle bookkeeping).
- Frontend: a 📌 **pin toggle** in the panel header (default on) starts/stops following; re-pin restarts after a manual move.

Decision (brainstormed): polling over the parent spec's reserved AXObserver — zero permissions beat sub-second latency for a companion panel. AXObserver remains the upgrade path if polling proves insufficient.

## Testing
- 5/5 `follow_tick` unit tests pass; Hub `--lib` clippy clean; `cargo fmt` clean; `npm run build` clean.
- Verified against the exact CI clippy invocations locally (learned from #635/#637: CI clippy is `--lib` + fresh compile).
- murmur TUI side: **zero changes**.

Plan: `docs/superpowers/plans/2026-07-06-murmur-panel-p5-live-follow.md`

Live `.app` drag-follow verification pending (requires building + driving the Hub app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)