### PR TITLE
feat(panel): lifecycle tracing for the panel bridge

### DIFF
--- a/mur-gui-core/src/panel_bridge/client.rs
+++ b/mur-gui-core/src/panel_bridge/client.rs
@@ -32,10 +32,12 @@ pub(crate) fn spawn(
         }
         let Ok(stream) = UnixStream::connect(&sess.sock).await else {
             // Socket gone but record present: crashed murmur. Reap.
+            tracing::debug!("panel_bridge: reaping dead session pid={pid}");
             let _ = std::fs::remove_file(&json_path);
             let _ = std::fs::remove_file(&sess.sock);
             return;
         };
+        tracing::info!("panel_bridge: connected to murmur session pid={pid}");
         let (out_tx, mut out_rx) = mpsc::channel::<HubFrame>(16);
         senders.lock().unwrap().insert(pid, out_tx);
         let (r, mut w) = stream.into_split();

--- a/mur-gui-core/src/panel_bridge/mod.rs
+++ b/mur-gui-core/src/panel_bridge/mod.rs
@@ -52,6 +52,7 @@ impl PanelBridge {
     #[cfg(unix)]
     pub fn start(mur_home: PathBuf, tx: mpsc::Sender<PanelEvent>) -> Result<Self> {
         let dir = murmur_run_dir(&mur_home);
+        tracing::info!("panel bridge: watching {}", dir.display());
         std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
         let senders: Senders = Arc::new(Mutex::new(HashMap::new()));
         let rt = tokio::runtime::Handle::current();

--- a/mur-hub-gui/src-tauri/src/panel/mod.rs
+++ b/mur-hub-gui/src-tauri/src/panel/mod.rs
@@ -26,6 +26,7 @@ pub struct PanelState {
 /// Start the bridge and the event pump. Called from Tauri setup, inside
 /// the runtime (`PanelBridge::start` requires it).
 pub fn spawn_bridge(app: AppHandle, mur_home: std::path::PathBuf) {
+    tracing::info!("panel: spawn_bridge starting (home {})", mur_home.display());
     let (tx, mut rx) = mpsc::channel::<PanelEvent>(64);
     match PanelBridge::start(mur_home, tx) {
         Ok(bridge) => *app.state::<PanelState>().bridge.lock().unwrap() = Some(bridge),


### PR DESCRIPTION
## Summary
Three tracing lines (bridge start / session connect / dead-session reap) in the murmur panel bridge.

During today's live `.app` verification of Panel P2–P5, the bridge's silence was indistinguishable from failure — a connected unix-socket **client** fd doesn't carry the socket path in `lsof`, so "is the Hub connected?" was unanswerable from outside, and the working bridge was misdiagnosed as dead for a long stretch. These lines make the bridge's lifecycle observable at `RUST_LOG=info`.

Found while live-verifying: all Panel phases confirmed working in the real app (5 tabs with real data, schedule table, insert round-trip, preview render, live-follow + pause-on-drag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)