### PR TITLE
feat(panel): input-driven dynamic suggestions (murmur → Hub, insert-only)

### DIFF
--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -183,6 +183,8 @@ P5 (2026-07) made the panel **follow the terminal window**. A permission-free po
 
 - **Specs & plans:** `docs/superpowers/specs/2026-07-06-murmur-panel-p2-data-tabs-design.md` and the `docs/superpowers/plans/2026-07-06-murmur-panel-p{2,3,4,5}-*.md` implementation plans.
 
+P6 (input-driven suggestions): murmur debounces the message input (200 ms) and pushes redacted `PanelFrame::InputChanged` snapshots over the panel socket (proto v2). The Hub keeps the latest snapshot per pid in memory only and pings the Panel webview (pid-only — raw text never enters the webview), which re-queries `panel_recommend_input`: adaptive query→picked history (Firefox urlbar decay parameters, `~/.mur/panel/adaptive.yaml`) > name-prefix matches > the standard retrieval ranking, capped at 5. Clicking a suggestion stays insert-only and records the adaptive pair server-side. Spec: `docs/superpowers/specs/2026-07-06-murmur-panel-input-driven-suggestions-design.md`.
+
 ---
 
 ## Agent Runtime (murmur P0a)

--- a/mur-common/src/panel.rs
+++ b/mur-common/src/panel.rs
@@ -107,7 +107,7 @@ pub fn decode_line<T: serde::de::DeserializeOwned>(line: &str) -> Option<T> {
 /// (the tail is what the user is currently typing).
 pub fn input_snapshot(text: &str) -> String {
     let redacted: Vec<String> = text
-        .split(' ')
+        .split_whitespace()
         .map(|tok| {
             if looks_secret(tok) {
                 "[redacted]".to_string()
@@ -253,6 +253,12 @@ mod tests {
         assert_eq!(input_snapshot("fix the panel"), "fix the panel");
         let hex31 = "0123456789abcdef0123456789abcde";
         assert_eq!(input_snapshot(hex31), hex31);
+    }
+
+    #[test]
+    fn snapshot_redacts_across_newlines() {
+        let s = input_snapshot("line1\nsk-abcdefghijklmnop1234\tend");
+        assert_eq!(s, "line1 [redacted] end");
     }
 
     #[test]

--- a/mur-common/src/panel.rs
+++ b/mur-common/src/panel.rs
@@ -7,7 +7,15 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-pub const PANEL_PROTO_VERSION: u32 = 1;
+pub const PANEL_PROTO_VERSION: u32 = 2;
+
+/// Debounce for `InputChanged` snapshots (murmur side). ~200 ms is the
+/// autocomplete sweet spot; >300 ms degrades UX (Algolia guidance).
+pub const INPUT_DEBOUNCE_MS: u64 = 200;
+/// Below this many trimmed chars the Hub falls back to cwd recommendations.
+pub const MIN_QUERY_CHARS: usize = 2;
+/// Snapshot size bound; the tail (what the user is typing now) is kept.
+pub const INPUT_SNAPSHOT_MAX_CHARS: usize = 2000;
 
 /// Directory holding one `<pid>.json` + `<pid>.sock` per live murmur session.
 /// Under the existing `~/.mur/runtime` convention (see `media::runtime_dir`).
@@ -70,6 +78,12 @@ pub enum PanelFrame {
     Stream {
         delta: String,
     },
+    /// Debounced snapshot of the message input line (never per-keystroke
+    /// deltas). Local-socket only; must never be persisted or forwarded
+    /// (spec §3.2). Build the payload with [`input_snapshot`].
+    InputChanged {
+        text: String,
+    },
     Bye,
 }
 
@@ -86,6 +100,60 @@ pub enum HubFrame {
 /// (forward compatibility across proto versions).
 pub fn decode_line<T: serde::de::DeserializeOwned>(line: &str) -> Option<T> {
     serde_json::from_str(line).ok()
+}
+
+/// Build a privacy-safe `InputChanged` payload: redact secret-looking
+/// tokens, then keep only the trailing `INPUT_SNAPSHOT_MAX_CHARS` chars
+/// (the tail is what the user is currently typing).
+pub fn input_snapshot(text: &str) -> String {
+    let redacted: Vec<String> = text
+        .split(' ')
+        .map(|tok| {
+            if looks_secret(tok) {
+                "[redacted]".to_string()
+            } else {
+                tok.to_string()
+            }
+        })
+        .collect();
+    let joined = redacted.join(" ");
+    let n = joined.chars().count();
+    if n <= INPUT_SNAPSHOT_MAX_CHARS {
+        joined
+    } else {
+        joined.chars().skip(n - INPUT_SNAPSHOT_MAX_CHARS).collect()
+    }
+}
+
+/// Conservative secret heuristics: `sk-` API keys, AWS `AKIA` key ids,
+/// and long (32+) unbroken hex/base64-ish runs.
+fn looks_secret(tok: &str) -> bool {
+    let is_b64ish = |s: &str| {
+        !s.is_empty()
+            && s.chars().all(|c| {
+                c.is_ascii_alphanumeric()
+                    || c == '+'
+                    || c == '/'
+                    || c == '='
+                    || c == '_'
+                    || c == '-'
+            })
+    };
+    if let Some(rest) = tok.strip_prefix("sk-")
+        && rest.len() >= 16
+        && is_b64ish(rest)
+    {
+        return true;
+    }
+    if let Some(rest) = tok.strip_prefix("AKIA")
+        && rest.len() == 16
+        && rest
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
+    {
+        return true;
+    }
+    tok.len() >= 32 && is_b64ish(tok) && tok.chars().any(|c| c.is_ascii_digit())
 }
 
 #[cfg(test)]
@@ -155,5 +223,43 @@ mod tests {
         assert!(decode_line::<PanelFrame>(r#"{"type":"from_the_future"}"#).is_none());
         assert!(decode_line::<HubFrame>(r#"{"type":"execute","cmd":"rm"}"#).is_none());
         assert!(decode_line::<HubFrame>("not json").is_none());
+    }
+
+    #[test]
+    fn input_changed_round_trips() {
+        let line = serde_json::to_string(&PanelFrame::InputChanged {
+            text: "run book".into(),
+        })
+        .unwrap();
+        assert!(line.contains("\"type\":\"input_changed\""));
+        assert!(matches!(
+            decode_line::<PanelFrame>(&line),
+            Some(PanelFrame::InputChanged { text }) if text == "run book"
+        ));
+    }
+
+    #[test]
+    fn snapshot_redacts_secrets() {
+        // OpenAI-style key
+        let s = input_snapshot("use sk-abcdefghijklmnop1234 please");
+        assert_eq!(s, "use [redacted] please");
+        // AWS access key id
+        let s = input_snapshot("key AKIAIOSFODNN7EXAMPLE here");
+        assert_eq!(s, "key [redacted] here");
+        // 32+ char hex run
+        let s = input_snapshot("token 0123456789abcdef0123456789abcdef end");
+        assert_eq!(s, "token [redacted] end");
+        // Normal prose untouched, including 31-char hex (below threshold)
+        assert_eq!(input_snapshot("fix the panel"), "fix the panel");
+        let hex31 = "0123456789abcdef0123456789abcde";
+        assert_eq!(input_snapshot(hex31), hex31);
+    }
+
+    #[test]
+    fn snapshot_truncates_to_tail() {
+        let long = "a".repeat(INPUT_SNAPSHOT_MAX_CHARS + 100) + " tail";
+        let s = input_snapshot(&long);
+        assert!(s.chars().count() <= INPUT_SNAPSHOT_MAX_CHARS);
+        assert!(s.ends_with(" tail")); // keep what the user is typing now
     }
 }

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -340,6 +340,11 @@ pub struct App {
     pub pending_suggestions: Vec<String>,
     /// The single suggestion currently shown as ghost placeholder text, if any.
     pub suggestion_ghost: Option<String>,
+    /// Input-driven suggestions (spec §3.5): last input text observed by the
+    /// debounce, last snapshot actually sent, and the pending deadline.
+    pub panel_input_seen: String,
+    pub panel_input_sent: String,
+    pub panel_input_deadline: Option<std::time::Instant>,
 }
 
 impl App {
@@ -400,6 +405,9 @@ impl App {
             skills: Vec::new(),
             pending_suggestions: Vec::new(),
             suggestion_ghost: None,
+            panel_input_seen: String::new(),
+            panel_input_sent: String::new(),
+            panel_input_deadline: None,
         }
     }
 
@@ -872,6 +880,30 @@ fn new_input() -> TextArea<'static> {
     ta
 }
 
+/// Arm/reset the InputChanged debounce when the input text changed since the
+/// last observation. Called every event-loop iteration.
+pub(crate) fn arm_input_debounce(app: &mut App, now: std::time::Instant) {
+    let cur = app.input_text();
+    if cur != app.panel_input_seen {
+        app.panel_input_seen = cur;
+        app.panel_input_deadline =
+            Some(now + std::time::Duration::from_millis(mur_common::panel::INPUT_DEBOUNCE_MS));
+    }
+}
+
+/// If the debounce deadline has passed and the text differs from the last
+/// sent snapshot, consume the deadline and return the raw text to send.
+pub(crate) fn take_due_input(app: &mut App, now: std::time::Instant) -> Option<String> {
+    if app.panel_input_deadline.is_some_and(|d| now >= d) {
+        app.panel_input_deadline = None;
+        if app.panel_input_seen != app.panel_input_sent {
+            app.panel_input_sent = app.panel_input_seen.clone();
+            return Some(app.panel_input_sent.clone());
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 impl App {
     /// Minimal fixture for unit tests. Backed by a temporary directory that is
@@ -903,6 +935,41 @@ mod tests {
             session,
             &super::super::theme::DARK,
         )
+    }
+
+    #[test]
+    fn input_debounce_arms_and_fires_once() {
+        use std::time::{Duration, Instant};
+        let mut app = app();
+        let t0 = Instant::now();
+
+        // No edit → nothing armed, nothing due.
+        arm_input_debounce(&mut app, t0);
+        assert!(take_due_input(&mut app, t0 + Duration::from_secs(1)).is_none());
+
+        // Edit arms the deadline; before expiry nothing fires.
+        app.set_input("run boo");
+        arm_input_debounce(&mut app, t0);
+        assert!(take_due_input(&mut app, t0).is_none());
+
+        // Continued typing re-arms (debounce reset).
+        app.set_input("run book");
+        arm_input_debounce(&mut app, t0 + Duration::from_millis(100));
+
+        // After the (re-armed) deadline the latest snapshot fires exactly once.
+        let due = t0 + Duration::from_millis(100 + mur_common::panel::INPUT_DEBOUNCE_MS + 1);
+        assert_eq!(take_due_input(&mut app, due).as_deref(), Some("run book"));
+        assert!(take_due_input(&mut app, due).is_none()); // no repeat
+
+        // Unchanged text never re-fires even after another arm pass.
+        arm_input_debounce(&mut app, due);
+        assert!(take_due_input(&mut app, due + Duration::from_secs(1)).is_none());
+
+        // Clearing the input fires an empty snapshot (panel resets to cwd mode).
+        app.clear_input();
+        arm_input_debounce(&mut app, due);
+        let later = due + Duration::from_millis(mur_common::panel::INPUT_DEBOUNCE_MS + 1);
+        assert_eq!(take_due_input(&mut app, later).as_deref(), Some(""));
     }
 
     /// Helper that borrows an existing TempDir so the directory survives the test.

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -52,8 +52,8 @@ use tokio::sync::mpsc;
 use tokio::time::Instant as TokioInstant;
 
 use self::app::{
-    App, ESC_DOUBLE_WINDOW, EscAction, OverlayKeyAction, Role, SlashCmd, esc_action,
-    overlay_key_action, parse_slash,
+    App, ESC_DOUBLE_WINDOW, EscAction, OverlayKeyAction, Role, SlashCmd, arm_input_debounce,
+    esc_action, overlay_key_action, parse_slash, take_due_input,
 };
 use self::persist::Session;
 use self::stream::{StreamMsg, build_params, cancel_task, respond_hitl, spawn_stream};
@@ -367,6 +367,7 @@ async fn event_loop(
 
     loop {
         app.sync_input_block();
+        arm_input_debounce(app, StdInstant::now());
         if app.needs_full_redraw {
             terminal.clear()?;
             app.needs_full_redraw = false;
@@ -381,6 +382,11 @@ async fn event_loop(
         // Otherwise this arm is disabled and never wakes the loop.
         let blink_live = app.mascot_mode.animated() && app.messages.is_empty() && !app.streaming;
         let blink_at = TokioInstant::from_std(app.blink.next_deadline(StdInstant::now()));
+        let input_due = app
+            .panel_input_deadline
+            .map(TokioInstant::from_std)
+            .unwrap_or_else(|| TokioInstant::from_std(StdInstant::now()));
+        let input_armed = app.panel_input_deadline.is_some();
         tokio::select! {
             maybe = events.next() => match maybe {
                 Some(Ok(ev)) => handle_event(app, ev, &tx).await,
@@ -396,6 +402,15 @@ async fn event_loop(
             // Wake at the blink deadline; the loop redraws at the top of the
             // next iteration, advancing the eye frame. No state change needed.
             _ = tokio::time::sleep_until(blink_at), if blink_live => {}
+            _ = tokio::time::sleep_until(input_due), if input_armed => {
+                if let Some(raw) = take_due_input(app, StdInstant::now())
+                    && let Some(p) = &app.panel
+                {
+                    p.send(mur_common::panel::PanelFrame::InputChanged {
+                        text: mur_common::panel::input_snapshot(&raw),
+                    });
+                }
+            }
         }
     }
 }

--- a/mur-core/src/recommend.rs
+++ b/mur-core/src/recommend.rs
@@ -162,12 +162,133 @@ pub fn recommend_for_input(cwd: &Path, input: &str, limit: usize) -> Vec<Recomme
     if trimmed.chars().count() < mur_common::panel::MIN_QUERY_CHARS {
         return recommend_for_cwd(cwd, limit);
     }
+    let mur_dir = mur_common::trust::mur_home();
+    let adaptive = adaptive_best(&load_adaptive(&mur_dir), trimmed, now_secs());
     // Input words first so they dominate the word-overlap scoring; cwd
     // terms trail as context.
     let query = format!("{} {}", trimmed, cwd_query(cwd));
     let mut out = rank_input(trimmed, recommend_with_query(&query, limit * 2));
+    // Adaptive history outranks everything (Firefox: "infinite frecency").
+    if let Some(name) = adaptive
+        && let Some(idx) = out.iter().position(|r| r.name == name)
+        && idx > 0
+    {
+        let hit = out.remove(idx);
+        out.insert(0, hit);
+    }
     out.truncate(limit);
     out
+}
+
+// ── Adaptive query→picked history (Firefox urlbar parameters) ─────────────
+
+/// use_count = use_count * 0.9 + 1 on pick, saturating here.
+pub(crate) const ADAPTIVE_USE_CAP: f32 = 10.0;
+/// Effective score decays 0.975/day since last use.
+const ADAPTIVE_DAILY_DECAY: f32 = 0.975;
+/// Entries unused this long are dropped.
+const ADAPTIVE_EXPIRE_DAYS: f32 = 90.0;
+/// Normalized query length bound.
+const ADAPTIVE_QUERY_MAX: usize = 64;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct AdaptiveEntry {
+    pub query: String,
+    pub picked: String,
+    pub use_count: f32,
+    /// Unix seconds.
+    pub last_used: u64,
+}
+
+fn adaptive_path(mur_home: &Path) -> std::path::PathBuf {
+    mur_home.join("panel").join("adaptive.yaml")
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn normalize_query(q: &str) -> String {
+    q.trim()
+        .to_lowercase()
+        .chars()
+        .take(ADAPTIVE_QUERY_MAX)
+        .collect()
+}
+
+pub(crate) fn load_adaptive(mur_home: &Path) -> Vec<AdaptiveEntry> {
+    std::fs::read_to_string(adaptive_path(mur_home))
+        .ok()
+        .and_then(|s| serde_yaml::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+/// Best adaptive pick for `query`: prefix match either direction, expired
+/// entries skipped, ranked by decayed use_count.
+pub(crate) fn adaptive_best(
+    entries: &[AdaptiveEntry],
+    query: &str,
+    now_secs: u64,
+) -> Option<String> {
+    let q = normalize_query(query);
+    if q.is_empty() {
+        return None;
+    }
+    entries
+        .iter()
+        .filter_map(|e| {
+            let days = now_secs.saturating_sub(e.last_used) as f32 / 86_400.0;
+            if days > ADAPTIVE_EXPIRE_DAYS {
+                return None;
+            }
+            if !(q.starts_with(&e.query) || e.query.starts_with(&q)) {
+                return None;
+            }
+            Some((e.use_count * ADAPTIVE_DAILY_DECAY.powf(days), &e.picked))
+        })
+        .max_by(|a, b| a.0.total_cmp(&b.0))
+        .map(|(_, picked)| picked.clone())
+}
+
+/// Record that the user picked `picked` after typing `query`. Fail-soft:
+/// any I/O error is swallowed (suggestion quality, not correctness).
+pub fn record_pick(mur_home: &Path, query: &str, picked: &str) {
+    let q = normalize_query(query);
+    if q.is_empty() || picked.is_empty() {
+        return;
+    }
+    let mut entries = load_adaptive(mur_home);
+    let now = now_secs();
+    if let Some(e) = entries
+        .iter_mut()
+        .find(|e| e.query == q && e.picked == picked)
+    {
+        e.use_count = (e.use_count * 0.9 + 1.0).min(ADAPTIVE_USE_CAP);
+        e.last_used = now;
+    } else {
+        entries.push(AdaptiveEntry {
+            query: q,
+            picked: picked.to_string(),
+            use_count: 1.0,
+            last_used: now,
+        });
+    }
+    // Expire on write so the file can't grow unbounded.
+    entries.retain(|e| now.saturating_sub(e.last_used) as f32 / 86_400.0 <= ADAPTIVE_EXPIRE_DAYS);
+    let dir = adaptive_path(mur_home);
+    if let Some(parent) = dir.parent()
+        && std::fs::create_dir_all(parent).is_ok()
+        && let Ok(s) = serde_yaml::to_string(&entries)
+    {
+        // temp + rename for atomicity, same convention as store/yaml.rs
+        let tmp = dir.with_extension("yaml.tmp");
+        if std::fs::write(&tmp, s).is_ok() {
+            let _ = std::fs::rename(&tmp, &dir);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -225,5 +346,66 @@ mod tests {
         let out = rank_input("zzz", recs);
         assert_eq!(out[0].name, "aaa");
         assert_eq!(out[1].name, "bbb");
+    }
+
+    const DAY: u64 = 86_400;
+
+    fn entry(q: &str, p: &str, count: f32, last: u64) -> AdaptiveEntry {
+        AdaptiveEntry {
+            query: q.into(),
+            picked: p.into(),
+            use_count: count,
+            last_used: last,
+        }
+    }
+
+    #[test]
+    fn adaptive_prefix_match_wins() {
+        let now = 100 * DAY;
+        let es = vec![
+            entry("run boo", "book-search", 3.0, now - DAY),
+            entry("deploy", "deployer", 9.0, now - DAY),
+        ];
+        // typed query extends the stored one → match
+        assert_eq!(
+            adaptive_best(&es, "run book", now).as_deref(),
+            Some("book-search")
+        );
+        // stored query extends the typed one → also match
+        assert_eq!(
+            adaptive_best(&es, "run b", now).as_deref(),
+            Some("book-search")
+        );
+        assert_eq!(adaptive_best(&es, "xyz", now), None);
+    }
+
+    #[test]
+    fn adaptive_decays_and_expires() {
+        let now = 200 * DAY;
+        // 90+ days unused → expired
+        let es = vec![entry("run boo", "book-search", 9.0, now - 91 * DAY)];
+        assert_eq!(adaptive_best(&es, "run boo", now), None);
+        // Decay: fresher-but-smaller beats stale-but-bigger
+        let es = vec![
+            entry("run boo", "old-pick", 5.0, now - 60 * DAY), // 5 * 0.975^60 ≈ 1.1
+            entry("run boo", "new-pick", 2.0, now - DAY),      // 2 * 0.975   ≈ 1.95
+        ];
+        assert_eq!(
+            adaptive_best(&es, "run boo", now).as_deref(),
+            Some("new-pick")
+        );
+    }
+
+    #[test]
+    fn record_pick_saturates_and_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        for _ in 0..30 {
+            record_pick(dir.path(), "Run Book", "book-search");
+        }
+        let es = load_adaptive(dir.path());
+        assert_eq!(es.len(), 1);
+        assert_eq!(es[0].query, "run book"); // normalized
+        assert!(es[0].use_count <= ADAPTIVE_USE_CAP);
+        assert!(es[0].use_count > 9.0); // converges toward the cap
     }
 }

--- a/mur-core/src/recommend.rs
+++ b/mur-core/src/recommend.rs
@@ -65,14 +65,19 @@ pub fn recommend_for_cwd(cwd: &Path, limit: usize) -> Vec<Recommendation> {
     if query.trim().is_empty() {
         return Vec::new();
     }
+    recommend_with_query(&query, limit)
+}
 
+/// Run the skill + workflow retrieval for an arbitrary query string.
+/// (Shared by `recommend_for_cwd` and `recommend_for_input`.)
+fn recommend_with_query(query: &str, limit: usize) -> Vec<Recommendation> {
     let mur_dir = mur_common::trust::mur_home();
 
     // Skills: exact pipeline cmd_hook_prompt uses for its fallback path.
     let mut skills = Vec::new();
     if let Ok(mut candidates) = load_skill_candidates(&mur_dir.join("skills"), &mur_dir) {
         filter_by_scope(&mut candidates, &ActiveScope::detect());
-        for scored in score_and_rank_generic(&query, candidates) {
+        for scored in score_and_rank_generic(query, candidates) {
             skills.push(Recommendation {
                 name: scored.item.manifest.name.clone(),
                 kind: "skill".into(),
@@ -134,6 +139,37 @@ pub fn recommend_for_cwd(cwd: &Path, limit: usize) -> Vec<Recommendation> {
     out
 }
 
+/// Rank tier for input-driven suggestions: name prefix/exact matches first
+/// (VS Code Quick Open lesson — exact beats fuzzy), then retrieval score,
+/// then stable name tie-break.
+pub(crate) fn rank_input(query: &str, mut recs: Vec<Recommendation>) -> Vec<Recommendation> {
+    let q = query.trim().to_ascii_lowercase();
+    recs.sort_by(|a, b| {
+        let ap = a.name.to_ascii_lowercase().starts_with(&q);
+        let bp = b.name.to_ascii_lowercase().starts_with(&q);
+        bp.cmp(&ap) // prefix matches first
+            .then(b.score.total_cmp(&a.score))
+            .then(a.name.cmp(&b.name))
+    });
+    recs
+}
+
+/// Input-driven recommendations (spec §3.3). Input text is the query; cwd
+/// terms are appended as low-weight context. Below `MIN_QUERY_CHARS` this
+/// is exactly `recommend_for_cwd`. Fail-soft like everything else here.
+pub fn recommend_for_input(cwd: &Path, input: &str, limit: usize) -> Vec<Recommendation> {
+    let trimmed = input.trim();
+    if trimmed.chars().count() < mur_common::panel::MIN_QUERY_CHARS {
+        return recommend_for_cwd(cwd, limit);
+    }
+    // Input words first so they dominate the word-overlap scoring; cwd
+    // terms trail as context.
+    let query = format!("{} {}", trimmed, cwd_query(cwd));
+    let mut out = rank_input(trimmed, recommend_with_query(&query, limit * 2));
+    out.truncate(limit);
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -153,5 +189,41 @@ mod tests {
         // sandbox → must return without panicking or erroring.
         let recs = recommend_for_cwd(Path::new("/nonexistent/dir"), 5);
         assert!(recs.len() <= 5);
+    }
+
+    fn rec(name: &str, score: f32) -> Recommendation {
+        Recommendation {
+            name: name.into(),
+            kind: "skill".into(),
+            score,
+            description: String::new(),
+            command: format!("mur skill show {name}"),
+        }
+    }
+
+    #[test]
+    fn short_input_falls_back_to_cwd() {
+        // 1 trimmed char < MIN_QUERY_CHARS → identical to recommend_for_cwd
+        // (fail-soft: both empty in a test sandbox, and neither panics).
+        let a = recommend_for_input(Path::new("/nonexistent/dir"), "x", 5);
+        let b = recommend_for_cwd(Path::new("/nonexistent/dir"), 5);
+        assert_eq!(a.len(), b.len());
+    }
+
+    #[test]
+    fn prefix_matches_outrank_score() {
+        let recs = vec![rec("zeta-high", 0.9), rec("book-search", 0.5)];
+        let out = rank_input("book", recs);
+        // prefix match beats a higher retrieval score
+        assert_eq!(out[0].name, "book-search");
+        assert_eq!(out[1].name, "zeta-high");
+    }
+
+    #[test]
+    fn ties_break_by_name_ascending() {
+        let recs = vec![rec("bbb", 0.5), rec("aaa", 0.5)];
+        let out = rank_input("zzz", recs);
+        assert_eq!(out[0].name, "aaa");
+        assert_eq!(out[1].name, "bbb");
     }
 }

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -589,6 +589,7 @@ pub fn run() {
             panel::data::panel_git_info,
             panel::data::panel_activities,
             panel::data::panel_recommend,
+            panel::data::panel_recommend_input,
             start_agent,
             stop_agent,
             chat::agent_chat_send,

--- a/mur-hub-gui/src-tauri/src/panel/data.rs
+++ b/mur-hub-gui/src-tauri/src/panel/data.rs
@@ -69,6 +69,17 @@ pub fn panel_recommend(cwd: String) -> Vec<mur_core::recommend::Recommendation> 
     mur_core::recommend::recommend_for_cwd(Path::new(&cwd), 5)
 }
 
+/// Response for `panel_recommend_input`: the ranked items plus a boolean
+/// flag telling the webview whether ranking was driven by the live input
+/// (spec §3.4 "matching your input" caption). Raw input text stays in
+/// Rust; the webview only ever sees ranked results + this flag.
+#[derive(Debug, Clone, Serialize)]
+pub struct RecommendResponse {
+    /// True when the ranking used the live murmur input (>= MIN_QUERY_CHARS).
+    pub input_driven: bool,
+    pub items: Vec<mur_core::recommend::Recommendation>,
+}
+
 /// Recommendations driven by the live murmur input snapshot for `pid`
 /// (falls back to cwd-only when there is no/short input). The raw snapshot
 /// stays in Rust; the webview only ever sees ranked results.
@@ -77,9 +88,13 @@ pub fn panel_recommend_input(
     pid: u32,
     cwd: String,
     state: tauri::State<crate::panel::PanelState>,
-) -> Vec<mur_core::recommend::Recommendation> {
+) -> RecommendResponse {
     let input = state.inputs_snapshot(pid).unwrap_or_default();
-    mur_core::recommend::recommend_for_input(Path::new(&cwd), &input, 5)
+    let input_driven = input.trim().chars().count() >= mur_common::panel::MIN_QUERY_CHARS;
+    RecommendResponse {
+        input_driven,
+        items: mur_core::recommend::recommend_for_input(Path::new(&cwd), &input, 5),
+    }
 }
 
 /// Best-effort `git` shell-out; returns an empty `GitInfo` for non-repos.

--- a/mur-hub-gui/src-tauri/src/panel/data.rs
+++ b/mur-hub-gui/src-tauri/src/panel/data.rs
@@ -69,6 +69,19 @@ pub fn panel_recommend(cwd: String) -> Vec<mur_core::recommend::Recommendation> 
     mur_core::recommend::recommend_for_cwd(Path::new(&cwd), 5)
 }
 
+/// Recommendations driven by the live murmur input snapshot for `pid`
+/// (falls back to cwd-only when there is no/short input). The raw snapshot
+/// stays in Rust; the webview only ever sees ranked results.
+#[tauri::command]
+pub fn panel_recommend_input(
+    pid: u32,
+    cwd: String,
+    state: tauri::State<crate::panel::PanelState>,
+) -> Vec<mur_core::recommend::Recommendation> {
+    let input = state.inputs_snapshot(pid).unwrap_or_default();
+    mur_core::recommend::recommend_for_input(Path::new(&cwd), &input, 5)
+}
+
 /// Best-effort `git` shell-out; returns an empty `GitInfo` for non-repos.
 #[tauri::command]
 pub fn panel_git_info(cwd: String) -> GitInfo {

--- a/mur-hub-gui/src-tauri/src/panel/mod.rs
+++ b/mur-hub-gui/src-tauri/src/panel/mod.rs
@@ -21,6 +21,16 @@ pub const PANEL_LABEL: &str = "murmur-panel";
 pub struct PanelState {
     bridge: Mutex<Option<PanelBridge>>,
     sessions: Mutex<HashMap<u32, PanelSession>>,
+    /// Latest InputChanged snapshot per session. Local-only: never persisted,
+    /// never sent to the webview (it gets a pid-only ping), dropped on
+    /// SessionDown. Spec §3.2.
+    inputs: Mutex<HashMap<u32, String>>,
+}
+
+impl PanelState {
+    pub(crate) fn inputs_snapshot(&self, pid: u32) -> Option<String> {
+        self.inputs.lock().unwrap().get(&pid).cloned()
+    }
 }
 
 /// Start the bridge and the event pump. Called from Tauri setup, inside
@@ -40,11 +50,9 @@ pub fn spawn_bridge(app: AppHandle, mur_home: std::path::PathBuf) {
             match ev {
                 PanelEvent::Frame { pid, frame } => on_frame(&app, pid, frame),
                 PanelEvent::SessionDown { pid } => {
-                    app.state::<PanelState>()
-                        .sessions
-                        .lock()
-                        .unwrap()
-                        .remove(&pid);
+                    let st = app.state::<PanelState>();
+                    st.sessions.lock().unwrap().remove(&pid);
+                    st.inputs.lock().unwrap().remove(&pid);
                     emit_sessions(&app);
                 }
             }
@@ -98,6 +106,14 @@ fn on_frame(app: &AppHandle, pid: u32, frame: PanelFrame) {
                 "panel-stream",
                 serde_json::json!({ "pid": pid, "delta": delta }),
             );
+        }
+        PanelFrame::InputChanged { text } => {
+            app.state::<PanelState>()
+                .inputs
+                .lock()
+                .unwrap()
+                .insert(pid, text);
+            let _ = app.emit("panel-input-changed", serde_json::json!({ "pid": pid }));
         }
         PanelFrame::Bye => {}
     }
@@ -160,7 +176,19 @@ pub fn panel_sessions(state: State<PanelState>) -> Vec<PanelSession> {
 }
 
 #[tauri::command]
-pub fn panel_insert(pid: u32, text: String, state: State<PanelState>) -> Result<(), String> {
+pub fn panel_insert(
+    pid: u32,
+    text: String,
+    picked: Option<String>,
+    state: State<PanelState>,
+) -> Result<(), String> {
+    // Record BEFORE inserting: the insert clears/replaces the input, and the
+    // pairing must use the query that produced the suggestion.
+    if let Some(name) = picked.filter(|n| !n.is_empty())
+        && let Some(query) = state.inputs_snapshot(pid)
+    {
+        mur_core::recommend::record_pick(&crate::mur_home_path(), &query, &name);
+    }
     let ok = state
         .bridge
         .lock()

--- a/mur-hub-gui/ui/src/components/panel/PanelWindow.tsx
+++ b/mur-hub-gui/ui/src/components/panel/PanelWindow.tsx
@@ -136,6 +136,7 @@ export function PanelWindow() {
   const [schedule, setSchedule] = useState<ScheduleStatus | null>(null);
   const [proposals, setProposals] = useState<ProposalSummary[]>([]);
   const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
+  const [recInputDriven, setRecInputDriven] = useState(false);
   const [pinned, setPinned] = useState(true);
 
   const recGen = useRef(0);
@@ -209,11 +210,14 @@ export function PanelWindow() {
       void invoke<GitInfo>("panel_git_info", { cwd: sess.cwd }).then(setGitInfo);
       void invoke<TokenTotals>("panel_cost", { agent: sess.agent }).then(setCost);
       const gen = ++recGen.current;
-      void invoke<Recommendation[]>("panel_recommend_input", {
+      void invoke<{ input_driven: boolean; items: Recommendation[] }>("panel_recommend_input", {
         pid: sess.pid,
         cwd: sess.cwd,
       }).then((r) => {
-        if (gen === recGen.current) setRecommendations(r);
+        if (gen === recGen.current) {
+          setRecommendations(r.items);
+          setRecInputDriven(r.input_driven);
+        }
       });
     } else if (tab === "activities") {
       void invoke<Activities>("panel_activities", { agent: sess.agent }).then(setActivities);
@@ -357,7 +361,10 @@ export function PanelWindow() {
                 </>
               )}
             </dl>
-            <h3>Recommended</h3>
+            <h3>
+              Recommended
+              {recInputDriven && <span className="panel-empty"> matching your input</span>}
+            </h3>
             {recommendations.length === 0 ? (
               <p className="panel-empty">No recommendations.</p>
             ) : (

--- a/mur-hub-gui/ui/src/components/panel/PanelWindow.tsx
+++ b/mur-hub-gui/ui/src/components/panel/PanelWindow.tsx
@@ -138,6 +138,8 @@ export function PanelWindow() {
   const [recommendations, setRecommendations] = useState<Recommendation[]>([]);
   const [pinned, setPinned] = useState(true);
 
+  const recGen = useRef(0);
+
   useEffect(() => {
     void invoke<PanelSession[]>("panel_sessions").then((s) => {
       setSessions(s);
@@ -167,10 +169,17 @@ export function PanelWindow() {
         setPreviewMode("target");
       },
     );
+    const unInput = listen<{ pid: number }>("panel-input-changed", () => {
+      // Re-rank for whichever session is active; fetchTabData reads current
+      // state and the generation counter drops stale responses. Keep the
+      // current list rendered until the new one lands (no flash-to-empty).
+      fetchTabData.current();
+    });
     return () => {
       unSessions.then((f) => f());
       unFocus.then((f) => f());
       unPreview.then((f) => f());
+      unInput.then((f) => f());
     };
   }, []);
 
@@ -199,9 +208,13 @@ export function PanelWindow() {
     if (tab === "information") {
       void invoke<GitInfo>("panel_git_info", { cwd: sess.cwd }).then(setGitInfo);
       void invoke<TokenTotals>("panel_cost", { agent: sess.agent }).then(setCost);
-      void invoke<Recommendation[]>("panel_recommend", { cwd: sess.cwd }).then(
-        setRecommendations,
-      );
+      const gen = ++recGen.current;
+      void invoke<Recommendation[]>("panel_recommend_input", {
+        pid: sess.pid,
+        cwd: sess.cwd,
+      }).then((r) => {
+        if (gen === recGen.current) setRecommendations(r);
+      });
     } else if (tab === "activities") {
       void invoke<Activities>("panel_activities", { agent: sess.agent }).then(setActivities);
     } else if (tab === "notifications") {
@@ -232,8 +245,8 @@ export function PanelWindow() {
     return () => clearInterval(id);
   }, [tab]);
 
-  const insert = (text: string) => {
-    if (pid !== null) void invoke("panel_insert", { pid, text });
+  const insert = (text: string, picked?: string) => {
+    if (pid !== null) void invoke("panel_insert", { pid, text, picked: picked ?? null });
   };
 
   return (
@@ -353,7 +366,7 @@ export function PanelWindow() {
                   <li
                     key={`${r.kind}-${r.name}`}
                     className="panel-list-row panel-list-clickable"
-                    onClick={() => insert(r.command)}
+                    onClick={() => insert(r.command, r.name)}
                   >
                     <span className={`panel-badge panel-badge-${r.kind}`}>
                       {r.kind}


### PR DESCRIPTION
Implements docs/superpowers/specs/2026-07-06-murmur-panel-input-driven-suggestions-design.md

- PanelFrame::InputChanged (proto v2), 200ms debounce, secret redaction, 2000-char tail cap
- recommend_for_input: adaptive history > prefix > retrieval, stable tie-break
- Hub keeps snapshots in Rust only; webview gets pid-only pings
- insert-only preserved; suggestion clicks record adaptive picks

Live verify: pending (operator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)