### PR TITLE
fix(agent-cli): chooser as layout band + inline scroll + manual resize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6560,6 +6560,7 @@ dependencies = [
  "tree-sitter-rust",
  "tui-textarea",
  "ulid",
+ "unicode-width 0.1.14",
  "urlencoding",
  "uuid",
  "walkdir",

--- a/docs/superpowers/specs/2026-07-07-delegation-routing-design.md
+++ b/docs/superpowers/specs/2026-07-07-delegation-routing-design.md
@@ -1,0 +1,170 @@
+# MUR Delegation Routing — Design Spec
+
+- **Date:** 2026-07-07
+- **Status:** Draft (design); grounded in codebase, ready for review → writing-plans
+- **Author:** David Chang (with Claude Code)
+- **Research basis:** 3 codebase-mapping agents (cost-router/orchestrator spec, parallel-decomposition lens, real delegation primitives) + roster/entitlement inspection of the live `mur` concierge.
+
+## Thesis
+
+When a task arrives, the MUR concierge must decide **who does it and how many** — do it
+itself, hand it to one specialist, or fan it out to a squad. Today MUR has *two* routing
+frameworks and **neither answers that question**:
+
+- **Cost-router** (`models.yaml` layer) decides *which model tier* runs a sub-task — local
+  (cheap) vs frontier (governed external spawn). Orthogonal to who/how-many.
+- **Parallel-decomposition lens** (`parallel_decompose.yaml`) decides *parallel vs serial* by
+  task topology. Says nothing about *which role* or *single-vs-squad*.
+
+The missing axis — **Scope: self / single specialist / fleet** — is exactly the one users hit
+("assign the plan job to `pm`"). This spec models that axis, unifies it with the existing two
+into one **soft, layered routing framework**, and — following MUR's `soft-direction-over-hard-
+control` principle — encodes it as a governor **skill plus existing primitives**, not a
+hard-coded router. It also names the concrete wiring gaps that make delegation unreliable today.
+
+## The three orthogonal axes
+
+| Axis | Question | Existing model | Status |
+|------|----------|----------------|--------|
+| **A. Scope** | self / single specialist / fleet? | none | ❌ gap (this spec) |
+| **B. Topology** | serial / fan-out / best-of-N? | parallel-decomposition lens (4 topologies) | ✓ skill exists |
+| **C. Cost/Capability** | local cheap / frontier costly? | cost-router (`RouteDecision::{Local,Escalate}`) | ⚠ decision+ledger only; spawn deferred |
+
+A routing decision is a **point in this 3-axis space**. The concierge picks it softly; hard
+gates apply only for safety.
+
+## Current primitives (grounded, with file:line)
+
+| Mechanism | What it is | How the model triggers it today | Status |
+|-----------|-----------|--------------------------------|--------|
+| **self** | finish in one turn | built-in tools | ✓ |
+| **`parallel_jobs`** | ephemeral agent fan-out; all rank-0 `delegate_to` steps, one per job; deny-by-default target allowlist (`executor/jobs.rs:28`, authz `:83`) | **MCP tool, model-callable** (`mur-mcp-server/src/tools.rs:340`) | ✓ only model-callable orchestration tool |
+| **`channel/delegate`** | single-target A2A; specialist runs a turn and **signs its own reply** into the channel (`channel_delegate.rs:56`) | **only dialed internally by the DAG executor** (`executor/dag.rs:523`); **not** a model tool | ✓ indirect |
+| **`mur fleet run`** | squad on a shared goal; router agent emits a **member-selection DAG** (`fleet/plan.rs:88`), broadcast fallback (`run.rs:62`) | **bash** | ✓ |
+| **`mur agent send <name>`** | single-agent send | **bash** | ✓ |
+| **frontier spawn** | governed claude/codex/agy subprocess | cost-router | ⛔ deferred (Phase 2, gated on P0b) |
+
+### Why delegation is fragile today (the real constraints)
+
+1. **No model-callable single-delegate tool.** `channel/delegate` is dialed only by the DAG
+   executor. To "hand this to `pm`," the concierge must detour through `parallel_jobs` (one
+   job), a fleet, a workflow, or bash `mur agent send`.
+2. **`mur` is not in the concierge's spawn allowlist** (`processes.spawn.allowed` =
+   yt-dlp/deno/ffmpeg/mur-mcp-server). Under strict spawn mode, bash `mur fleet run` /
+   `mur agent send` is blocked — so "delegate via bash" is unreliable.
+3. **`parallel_jobs` is deny-by-default.** If `config.parallel_jobs.targets` omits pm/qa/…,
+   every delegation is rejected before any dial.
+
+**Net:** the concierge's only *reliable* delegation path today is the `parallel_jobs` MCP tool,
+and only to pre-authorized targets. Everything else rides unreliable bash. This is the deeper
+cause behind "it used to delegate, now it doesn't."
+
+## The decision procedure (soft, layered)
+
+Ordered cheapest-and-most-reversible first. Each rung is model-weighed guidance, not a branch
+in code.
+
+```
+0. Can I finish this in one turn?                    → do it myself (never delegate trivia)
+1. Does it need a specific ROLE's expertise?         → single specialist delegate
+     spec/plan → pm · code review → qa · git/PR → repomanager · Rust impl → rustsmith
+2. Is it decomposable into independent parallel units? (Axis B lens)
+     explore  (read / gather)          → parallel_jobs (ephemeral fan-out, no worktree)
+     compete  (best-of-N variants)     → mur fleet run --worktree + judge / cherry
+     coupled-write (interdependent)    → parallel-code gate (6 conditions); pass → workflow of
+                                          delegate_to steps / partition; else single writer
+     coherence-bound (one design)      → single agent
+3. Is it a standing / looping shared goal for a squad? → mur fleet run [--loop] (+guards/budget/kill)
+4. Is a sub-task too hard for the local model?        → cost-router escalate to frontier (future)
+```
+
+### Ambiguity rule (the crux of the best practice)
+
+> **Prefer the cheapest, most reversible option:**
+> `self > single delegate > ephemeral parallel_jobs > standing fleet > frontier spawn`.
+> On writes, when unsure → single writer. On reads, when unsure → collect, don't reduce.
+> (Extends the existing rule in `parallel_decompose.yaml:12`.)
+
+This keeps `fleet` — the heaviest option — reserved for *multiple agents collaborating on one
+persistent goal*. A single-role hand-off (brainstorming → `pm`) must **never** escalate to a
+fleet.
+
+## Axis B — topology detail (already shipped)
+
+From `parallel_decompose.yaml:14-28`:
+
+- **explore** — independent additive reads → `parallel_jobs` (no worktree).
+- **compete** — same goal, best of N heterogeneous attempts → fleet `--worktree` + judge, archive losers.
+- **coupled-write** — interdependent edits → `parallel-code` gate (all 6 must hold: disjoint
+  files; frozen contract; no sequential dep; mechanical-not-design; ≥3 units worth ~3–15× token
+  premium; reviewable as fast as produced) → else single writer.
+- **coherence-bound** — one coherent design or a sequential chain → **do not parallelize**, one writer.
+
+Shape rule (`:27`): known decomposition → a saved **Workflow**; emergent → **orchestrator +
+parallel_jobs**; not parallel → **single agent**.
+
+## Axis C — cost/capability (partial)
+
+Cost-router (`RouteTier::{Local,Frontier}`, threshold ≥0.55 default / ≥0.75 under PreferLocal;
+`DefaultHeuristic` weighting task-type 0.50 + context-size 0.35 + keyword 0.15) decides
+local-vs-frontier-**spawn** and writes a per-spawn audit ledger. **Phase 1 = decision + ledger
+only; the actual governed spawn (Phase 2) is deferred, gated on the unbuilt P0b agentic loop.**
+A2A is explicitly reserved for MUR↔MUR (spec:84), so this axis composes with — never replaces —
+fleet/delegate.
+
+## Proposed encoding (phased, minimal-new-code)
+
+**P1 — the governor skill (highest leverage, cheapest).** Author an `orchestration-router`
+skill on the concierge encoding §"decision procedure" + the primitive map + the ambiguity rule.
+Soft only. This is what actually fixes "agent vs fleet" judgement. Reuses the same
+`soft-direction` pattern as the `mur-native-tools` skill.
+
+**P2 — a first-class single-delegate entry.** Either (a) add a `delegate` MCP tool (single
+target, reusing `parallel_jobs`' deny-by-default authz), or **(recommended, zero new code)**
+canonicalize "single delegate = `parallel_jobs` with exactly one job." Make the skill say so, so
+role hand-offs use the one already-authorized, model-callable path.
+
+**P3 — fix the preconditions.** Add pm/qa/repomanager/rustsmith to the concierge's
+`parallel_jobs.targets`; restart stale specialists (most of the roster is on a stale runtime);
+decide the role of the (currently stopped) dedicated **`orchestrator`** agent — it is the
+natural home for Axis-B step 2/3 so the concierge only owns step 0/1.
+
+**P4 — wire Axis C.** When cost-router Phase 2 ships governed spawn, connect step 4.
+
+## Security / governance (hard gates — kept hard on purpose)
+
+Per `soft-direction-over-hard-control`, only these stay hard-coded:
+
+- **Deny-by-default targets** for `parallel_jobs` (and any future `delegate` tool) — `authorize_targets` (`jobs.rs:83`).
+- **Fleet budget + kill-switch + iteration/deadline guards**, `MUR_FLEET_AUTORUN` opt-in.
+- **HITL risk-tiered gates** on write+ steps.
+- **Cost-router audit ledger** for every frontier spawn.
+
+Everything else — which rung, which role, single-vs-squad — is the model's soft call.
+
+## Gaps & open questions
+
+1. **Single-delegate path:** new `delegate` MCP tool vs "1-job `parallel_jobs`"? (Rec: the latter.)
+2. **Concierge vs orchestrator division of labour:** should the concierge delegate step-2/3
+   orchestration to the standing `orchestrator` agent, or own it? Affects where the router skill lives.
+3. **Bash `mur` access:** grant the concierge `mur` in its spawn allowlist, or force everything
+   through MCP tools? (MCP-tool path is cleaner — deny-by-default authz already exists.)
+4. **Roster health:** delegation needs targets running on a compatible runtime; the current
+   fleet of stale specialists will fail proto-gated dials.
+
+## Non-goals
+
+- Not building a hard auto-router that picks scope/role for the model.
+- Not changing the cost-router or the parallel-decomposition lens — this spec *unifies and
+  extends* them with Axis A.
+- Not implementing frontier spawn (that is cost-router Phase 2).
+
+## Appendix — key files
+
+`mur-mcp-server/src/tools.rs:340,712` · `mur-core/src/executor/jobs.rs:28-142` ·
+`mur-core/src/cmd/fleet/plan.rs:88-178` · `mur-core/src/cmd/fleet/run.rs:24-74` ·
+`mur-core/src/executor/dag.rs:477-540` · `mur-agent-runtime/src/protocol/methods/channel_delegate.rs:56-215` ·
+`mur-core/src/skills/parallel_decompose.yaml` · `mur-core/src/skills/mur_parallel_exec.yaml` ·
+`docs/superpowers/specs/2026-06-01-cost-router-orchestrator-design.md` ·
+`docs/superpowers/specs/2026-06-19-mur-fleet-design.md` ·
+`docs/superpowers/specs/2026-06-30-parallel-decomposition-lens-design.md`

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1540,6 +1540,14 @@ impl TaskRunner {
             }
 
             history.push(RichMessage::ToolResults { results });
+
+            // Note: `suggest_replies` does NOT hard-end the turn. Whether to stop
+            // and wait for the user's pick, or keep going, is the model's call —
+            // it ends the turn by emitting `stop_reason: end_turn` after offering
+            // the options (soft-guided by the tool description) when it needs the
+            // answer, and continues when it already knows the next step. Forcing
+            // an end here would rob the model of that judgement.
+
             // Mid-turn steering: pick up any user interjection sent via turn/steer
             // since the last LLM call and append it before the next iteration.
             // Race-free: history is mutated only here; try_recv never blocks.

--- a/mur-agent-runtime/src/tools/suggest.rs
+++ b/mur-agent-runtime/src/tools/suggest.rs
@@ -23,9 +23,15 @@ impl ToolExecutor for SuggestRepliesTool {
             description: "Offer the user 1-5 short quick-reply options when they \
                 would likely pick from a small set — e.g. after you ask a question \
                 or propose a choice. Each option is a complete message the user \
-                could send verbatim. The options are shown as Tab-to-fill \
-                suggestions in the user's input; calling this does NOT end your \
-                turn. Do not call it for open-ended turns with no natural shortlist."
+                could send verbatim, with an optional one-line description of the \
+                trade-off. The options appear as a chooser in the user's input. \
+                You decide what happens next: if you genuinely need their answer \
+                before proceeding, end your turn after offering the options and \
+                wait for their reply; if you already know the next step (e.g. a \
+                plan they've approved), just take it — don't offer a chooser in \
+                place of acting. Do NOT number the options yourself (no \"A:\" / \
+                \"1.\" prefixes) — the UI marks and spaces them. Skip it on \
+                open-ended turns with no natural shortlist."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -33,10 +39,32 @@ impl ToolExecutor for SuggestRepliesTool {
                 "properties": {
                     "replies": {
                         "type": "array",
-                        "items": { "type": "string" },
+                        "items": {
+                            "oneOf": [
+                                {
+                                    "type": "string",
+                                    "description": "A complete message the user could send."
+                                },
+                                {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "text": {
+                                            "type": "string",
+                                            "description": "The message the user sends if they pick this option."
+                                        },
+                                        "description": {
+                                            "type": "string",
+                                            "description": "Optional one-line rationale / trade-off shown under the option."
+                                        }
+                                    },
+                                    "required": ["text"]
+                                }
+                            ]
+                        },
                         "minItems": 1,
                         "maxItems": 5,
-                        "description": "1-5 short complete messages the user could send."
+                        "description": "1-5 options, each a string or {text, description}."
                     }
                 },
                 "required": ["replies"]

--- a/mur-core/Cargo.toml
+++ b/mur-core/Cargo.toml
@@ -112,6 +112,10 @@ ulid = { workspace = true }  # cmd::agent_companion::card::import inbox id
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 tui-textarea = "0.7"
+# Measure grapheme display width so we can blank the continuation cell after a
+# wide (CJK) char in the `insert_before` scrollback path — ratatui 0.29's
+# `draw_lines` prints those cells verbatim (a space), spacing out CJK text.
+unicode-width = "0.1"
 
 [features]
 default = ["cli", "server", "sources"]

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -149,6 +149,8 @@ pub enum SlashCmd {
     Channels(Option<usize>),
     /// `/auto [on|off]` — toggle (None) or set session-wide auto-approval.
     Auto(Option<bool>),
+    /// `/verbose [on|off]` — toggle (None) or set expanded tool-card rendering.
+    Verbose(Option<bool>),
     /// `/mcp [list|add|remove] …` — manage the agent's MCP servers.
     Mcp(Vec<String>),
     /// `/skill [list|add|remove] …` — manage the agent's skills.
@@ -176,6 +178,11 @@ pub fn parse_slash(line: &str) -> Option<SlashCmd> {
             SlashCmd::Channels(words.next().and_then(|s| s.parse::<usize>().ok()))
         }
         "auto" => SlashCmd::Auto(match words.next() {
+            Some("on") => Some(true),
+            Some("off") => Some(false),
+            _ => None,
+        }),
+        "verbose" => SlashCmd::Verbose(match words.next() {
             Some("on") => Some(true),
             Some("off") => Some(false),
             _ => None,
@@ -292,6 +299,10 @@ pub struct App {
     /// Transcript viewport height (rows), captured each render so PageUp/Down
     /// move a screenful and `scroll_back` can be clamped to the real maximum.
     pub scroll_page: u16,
+    /// User adjustment to the chooser band height (Ctrl+↑/↓ while the
+    /// chooser is open), in rows relative to the auto-computed height.
+    /// Persists for the session so a preferred size sticks between turns.
+    pub chooser_grow: i16,
     pub spinner: usize,
     pub should_quit: bool,
     /// Session-wide auto-approval of every tool call (`/auto` or `--auto`).
@@ -389,6 +400,9 @@ pub struct App {
     /// Opt-in, off by default. The classifier is conservative (fail-safe false
     /// on anything uncertain). Every auto-approval is tagged on the step card.
     pub auto_reads: bool,
+    /// When true, tool-call step cards render fully (args + result) instead of
+    /// the default one-line collapsed summary. Toggled with `/verbose`.
+    pub cards_expanded: bool,
     /// Live completion menu (slash commands / agent skills). `None` = closed.
     /// Derived from the input text — recomputed on every edit by `mod.rs`.
     pub completion: Option<CompletionState>,
@@ -396,7 +410,7 @@ pub struct App {
     pub skills: Vec<Candidate>,
     /// Replies captured from a `suggest_replies` tool call this turn, revealed
     /// after the turn finishes (see `reveal_suggestions`).
-    pub pending_suggestions: Vec<String>,
+    pub pending_suggestions: Vec<super::suggest::Suggestion>,
     /// The single suggestion currently shown as ghost placeholder text, if any.
     pub suggestion_ghost: Option<String>,
     /// Input-driven suggestions (spec §3.5): last input text observed by the
@@ -421,6 +435,7 @@ impl App {
             channel: None,
             scroll_back: 0,
             scroll_page: 0,
+            chooser_grow: 0,
             spinner: 0,
             should_quit: false,
             auto_approve: false,
@@ -462,6 +477,7 @@ impl App {
             step_hint_shown: false,
             budget_usd: None,
             auto_reads: false,
+            cards_expanded: false,
             completion: None,
             skills: Vec::new(),
             pending_suggestions: Vec::new(),
@@ -562,15 +578,16 @@ impl App {
                 let candidates: Vec<super::complete::Candidate> = items
                     .into_iter()
                     .map(|s| super::complete::Candidate {
-                        display: s.clone(),
-                        insert: s,
-                        desc: String::new(),
+                        display: s.text.clone(),
+                        insert: s.text,
+                        desc: s.desc.unwrap_or_default(),
                         has_children: false,
                     })
                     .collect();
                 self.completion = Some(super::complete::CompletionState {
                     items: candidates,
                     selected: 0,
+                    spaced: true,
                 });
             }
         }
@@ -1633,7 +1650,10 @@ mod footer_state_tests {
         let mut a = App::test_fixture();
         // Simulate a prior turn that set suggestions but never revealed them
         // (e.g., the turn ended in Err or was cancelled via Ctrl+C).
-        a.pending_suggestions = vec!["stale suggestion".to_string()];
+        a.pending_suggestions = vec![super::super::suggest::Suggestion {
+            text: "stale suggestion".to_string(),
+            desc: None,
+        }];
         a.begin_user_turn("new turn");
         assert!(
             a.pending_suggestions.is_empty(),

--- a/mur-core/src/cmd/agent/cli/complete.rs
+++ b/mur-core/src/cmd/agent/cli/complete.rs
@@ -28,6 +28,10 @@ pub struct Candidate {
 pub struct CompletionState {
     pub items: Vec<Candidate>,
     pub selected: usize,
+    /// True when this menu is the agent's suggested-reply chooser rather than
+    /// the slash-command menu. The chooser renders each option with a blank
+    /// spacer row so the choices don't crowd each other.
+    pub spaced: bool,
 }
 
 /// Built-in commands: (word without slash, description, subcommands).
@@ -66,6 +70,7 @@ const COMMANDS: &[(&str, &str, &[&str])] = &[
     ("sessions", "list past sessions", &[]),
     ("skill", "manage agent skills", &["list", "add", "remove"]),
     ("skin", "switch theme", &["dark", "light", "mur"]),
+    ("verbose", "expand tool cards", &["on", "off"]),
 ];
 
 /// Subcommands for `cmd` (without leading slash), or `None` if `cmd` is unknown
@@ -144,7 +149,11 @@ pub fn compute(input: &str, skills: &[Candidate]) -> Option<CompletionState> {
     if items.is_empty() {
         return None;
     }
-    Some(CompletionState { items, selected: 0 })
+    Some(CompletionState {
+        items,
+        selected: 0,
+        spaced: false,
+    })
 }
 
 /// Best-effort display name for a skill source string: a path like
@@ -181,25 +190,44 @@ pub fn load_agent_skills(agent: &str) -> Vec<Candidate> {
             continue;
         }
         out.push(Candidate {
-            display: s.name.clone(),
-            insert: s.name.clone(),
+            display: format!("/{}", s.name),
+            insert: format!("/{} ", s.name),
             desc: s.description.clone(),
             has_children: false,
         });
     }
     for raw in &profile.skills {
         let name = skill_display_name(raw);
-        if disabled.contains(name.as_str()) || out.iter().any(|c| c.display == name) {
+        let display = format!("/{name}");
+        if disabled.contains(name.as_str()) || out.iter().any(|c| c.display == display) {
             continue;
         }
         out.push(Candidate {
-            display: name.clone(),
-            insert: name,
+            display,
+            insert: format!("/{name} "),
             desc: String::new(),
             has_children: false,
         });
     }
     out
+}
+
+/// If `line` is a leading-slash invocation whose command word matches one of
+/// the agent's `skills` (surfaced in the menu as `/name`), return
+/// `(skill_name, trailing_args)`. Callers route this to the agent as a skill
+/// invocation instead of the "unknown command" branch. Returns `None` for
+/// ordinary input or built-in commands.
+pub fn matched_skill(line: &str, skills: &[Candidate]) -> Option<(String, String)> {
+    let rest = line.trim().strip_prefix('/')?;
+    let (word, args) = match rest.split_once(char::is_whitespace) {
+        Some((w, a)) => (w, a.trim()),
+        None => (rest, ""),
+    };
+    let want = format!("/{word}");
+    skills
+        .iter()
+        .find(|c| c.display == want)
+        .map(|_| (word.to_string(), args.to_string()))
 }
 
 #[cfg(test)]
@@ -222,6 +250,23 @@ mod tests {
     #[test]
     fn no_menu_without_leading_slash() {
         assert!(compute("hello", &[skill("create-pr")]).is_none());
+    }
+
+    #[test]
+    fn matched_skill_resolves_slash_form_and_args() {
+        // Real skill candidates carry a leading slash (see load_agent_skills).
+        let skills = [skill("/brainstorming"), skill("/create-pr")];
+        assert_eq!(
+            matched_skill("/brainstorming", &skills),
+            Some(("brainstorming".into(), String::new()))
+        );
+        assert_eq!(
+            matched_skill("/create-pr fix the bug", &skills),
+            Some(("create-pr".into(), "fix the bug".into()))
+        );
+        // Non-skill slash words and plain text don't match.
+        assert_eq!(matched_skill("/help", &skills), None);
+        assert_eq!(matched_skill("hello", &skills), None);
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -103,7 +103,7 @@ const SPINNER_MS: u64 = 90;
 /// Max chars of an arg hint shown on a step line in `--plain` mode.
 const PLAIN_STEP_HINT_MAX: usize = 120;
 
-const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /auto [on|off]  /skin [dark|light|mur]  /mcp  /skill  /panel [tab]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
+const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /auto [on|off]  /verbose [on|off] (expand tool cards)  /skin [dark|light|mur]  /mcp  /skill  /panel [tab]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
 
 /// Entry point dispatched from `AgentAction::Cli`.
 pub async fn cmd_cli(
@@ -564,6 +564,41 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
             // re-filters the menu at the end of this handler.
             if app.completion.is_some() {
                 match key.code {
+                    // Chooser (suggested replies): a digit picks that option and
+                    // sends it straight away — the fast path fzf/gum/Claude Code
+                    // all offer. Only in `spaced` mode and only for an in-range
+                    // index, so digit-typing still works in the slash menu.
+                    KeyCode::Char(d @ '1'..='9')
+                        if !ctrl
+                            && !alt
+                            && app.completion.as_ref().is_some_and(|c| {
+                                c.spaced && (d as usize - '1' as usize) < c.items.len()
+                            }) =>
+                    {
+                        let idx = d as usize - '1' as usize;
+                        if let Some(c) = app.completion.as_mut() {
+                            c.selected = idx;
+                        }
+                        let sends = app
+                            .completion
+                            .as_ref()
+                            .and_then(|c| c.items.get(idx))
+                            .is_some_and(|cand| !cand.has_children);
+                        completion_accept(app);
+                        if sends {
+                            submit(app, tx).await;
+                        }
+                        return;
+                    }
+                    // Ctrl+↑/↓ resizes the chooser band (agent chooser only).
+                    KeyCode::Up if ctrl && app.completion.as_ref().is_some_and(|c| c.spaced) => {
+                        app.chooser_grow = app.chooser_grow.saturating_add(1);
+                        return;
+                    }
+                    KeyCode::Down if ctrl && app.completion.as_ref().is_some_and(|c| c.spaced) => {
+                        app.chooser_grow = app.chooser_grow.saturating_sub(1);
+                        return;
+                    }
                     KeyCode::Up => {
                         completion_move(app, -1);
                         return;
@@ -938,16 +973,32 @@ fn decide_hitl_with_note(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: boo
 
 async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
     app.clear_suggestion_ghost();
-    let trimmed = app.input_text().trim().to_string();
+    let mut trimmed = app.input_text().trim().to_string();
     // Allow an image-only send (caption optional) when a screenshot is staged.
     if trimmed.is_empty() && app.pending_image.is_none() {
         return;
     }
 
     if let Some(cmd) = parse_slash(&trimmed) {
-        app.clear_input();
-        handle_slash(app, cmd, tx).await;
-        return;
+        // Skills are surfaced in the completion menu as slash commands
+        // (`/brainstorming`) but are not built-ins, so parse_slash reports them
+        // as Unknown. Route a matched skill to the agent as an invocation (the
+        // runtime's trigger matcher picks it up) rather than erroring.
+        if matches!(cmd, SlashCmd::Unknown(_))
+            && let Some((skill, args)) = complete::matched_skill(&trimmed, &app.skills)
+        {
+            let extra = if args.is_empty() {
+                String::new()
+            } else {
+                format!(" {args}")
+            };
+            trimmed = format!("Use the `{skill}` skill.{extra}");
+            // fall through into the normal send path below
+        } else {
+            app.clear_input();
+            handle_slash(app, cmd, tx).await;
+            return;
+        }
     }
     // `!command` — run locally (like Claude Code's bang escape). Allowed while
     // a turn is generating: it never touches the agent connection.
@@ -1148,6 +1199,16 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
                 }
             } else {
                 app.push_system("auto-approve OFF — tool calls ask again");
+            }
+        }
+        SlashCmd::Verbose(set) => {
+            app.cards_expanded = set.unwrap_or(!app.cards_expanded);
+            if app.cards_expanded {
+                app.push_system(
+                    "verbose ON — tool cards show full args + result (Ctrl+O for the transcript any time)",
+                );
+            } else {
+                app.push_system("verbose OFF — tool cards collapse to a one-line summary");
             }
         }
         SlashCmd::Mcp(args) => run_manage(app, move |agent| manage::run_mcp(&agent, &args)).await,

--- a/mur-core/src/cmd/agent/cli/render_card.rs
+++ b/mur-core/src/cmd/agent/cli/render_card.rs
@@ -11,10 +11,14 @@ pub const OUTPUT_MAX_LINES: usize = 20;
 
 /// Turn a `StepCard` into renderable `Line`s for the transcript.
 ///
-/// Each card is expanded by default (full args + result) but bounded by
-/// `ARGS_MAX_LINES` and `OUTPUT_MAX_LINES` so a huge tool response can't
-/// flood the transcript.
-pub fn card_lines(card: &StepCard, theme: &'static Theme) -> Vec<Line<'static>> {
+/// `expanded` controls verbosity. Collapsed (the default) shows a single
+/// summary line — glyph, tool name, arg hint, a one-line result gist, and
+/// duration — so a transcript of many tool calls stays scannable. Expanded
+/// shows the full args + result (still bounded by `ARGS_MAX_LINES` /
+/// `OUTPUT_MAX_LINES`). Errors and pending HITL rows always render in both
+/// modes so nothing actionable is hidden. Full detail for a collapsed card is
+/// always available in the Ctrl+O transcript overlay.
+pub fn card_lines(card: &StepCard, theme: &'static Theme, expanded: bool) -> Vec<Line<'static>> {
     let mut out: Vec<Line<'static>> = Vec::new();
 
     let accent = match card.state {
@@ -38,14 +42,30 @@ pub fn card_lines(card: &StepCard, theme: &'static Theme) -> Vec<Line<'static>> 
     } else {
         Span::raw("")
     };
-    out.push(Line::from(vec![
-        Span::styled(
-            header,
-            Style::default().fg(accent).add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(dur, Style::default().fg(theme.system)),
-        auto_tag,
-    ]));
+    let mut header_spans = vec![Span::styled(
+        header,
+        Style::default().fg(accent).add_modifier(Modifier::BOLD),
+    )];
+    // Collapsed: fold a one-line result gist into the header so the whole card
+    // is a single scannable line (unless there's a detailed error to show).
+    if !expanded
+        && card.error.is_none()
+        && let Some(gist) = result_gist(card)
+    {
+        header_spans.push(Span::styled(
+            format!("  → {gist}"),
+            Style::default().fg(theme.system),
+        ));
+    }
+    header_spans.push(Span::styled(dur, Style::default().fg(theme.system)));
+    header_spans.push(auto_tag);
+    out.push(Line::from(header_spans));
+
+    // Collapsed cards stop after the header (plus any error / HITL rows below).
+    if !expanded {
+        push_error_and_hitl(&mut out, card, theme);
+        return out;
+    }
 
     // ── Args: diff for edit tools, else bounded JSON ─────────────────────────
     if let Some(diff_lines) = super::diff::edit_diff_lines(&card.name, &card.args, theme) {
@@ -70,11 +90,8 @@ pub fn card_lines(card: &StepCard, theme: &'static Theme) -> Vec<Line<'static>> 
     }
 
     // ── Result / error (bounded) ──────────────────────────────────────────────
-    if let Some(err) = &card.error {
-        out.push(Line::styled(
-            format!(" ✗ {err}"),
-            Style::default().fg(ratatui::style::Color::Red),
-        ));
+    if let Some(line) = error_line(card) {
+        out.push(line);
     }
 
     if !card.output.is_empty() {
@@ -105,32 +122,92 @@ pub fn card_lines(card: &StepCard, theme: &'static Theme) -> Vec<Line<'static>> 
 
     // ── Inline HITL approval (P2) ────────────────────────────────────────────
     if card.awaiting_hitl {
-        out.push(Line::from(vec![
-            Span::styled(
-                "  [y]",
-                Style::default()
-                    .fg(ratatui::style::Color::Green)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" approve  ", Style::default().fg(theme.system)),
-            Span::styled(
-                "[a]",
-                Style::default()
-                    .fg(ratatui::style::Color::Yellow)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" always  ", Style::default().fg(theme.system)),
-            Span::styled(
-                "[n]",
-                Style::default()
-                    .fg(ratatui::style::Color::Red)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(" deny / Esc", Style::default().fg(theme.system)),
-        ]));
+        out.push(hitl_row(theme));
     }
 
     out
+}
+
+/// Error line for a card, or `None` when the tool succeeded. Shown in both
+/// collapsed and expanded modes.
+fn error_line(card: &StepCard) -> Option<Line<'static>> {
+    card.error.as_ref().map(|err| {
+        Line::styled(
+            format!(" ✗ {err}"),
+            Style::default().fg(ratatui::style::Color::Red),
+        )
+    })
+}
+
+/// The `[y] approve [a] always [n] deny` inline-HITL prompt row.
+fn hitl_row(theme: &'static Theme) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            "  [y]",
+            Style::default()
+                .fg(ratatui::style::Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" approve  ", Style::default().fg(theme.system)),
+        Span::styled(
+            "[a]",
+            Style::default()
+                .fg(ratatui::style::Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" always  ", Style::default().fg(theme.system)),
+        Span::styled(
+            "[n]",
+            Style::default()
+                .fg(ratatui::style::Color::Red)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" deny / Esc", Style::default().fg(theme.system)),
+    ])
+}
+
+/// Collapsed-card tail: error line (if any) + pending-HITL row (if any). The
+/// success gist is folded into the header instead.
+fn push_error_and_hitl(out: &mut Vec<Line<'static>>, card: &StepCard, theme: &'static Theme) {
+    if let Some(line) = error_line(card) {
+        out.push(line);
+    }
+    if card.awaiting_hitl {
+        out.push(hitl_row(theme));
+    }
+}
+
+/// One-line gist of a successful tool result for the collapsed header. Best
+/// effort: for JSON results, count the obvious result set (`count`, or the
+/// length of a `results`/`matches`/`items` array); otherwise fall back to a
+/// short inline value or a line/char count. `None` when there's nothing useful
+/// to say (empty output).
+fn result_gist(card: &StepCard) -> Option<String> {
+    let out = card.output.trim();
+    if out.is_empty() {
+        return None;
+    }
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(out) {
+        if let Some(n) = v.get("count").and_then(serde_json::Value::as_u64) {
+            return Some(format!("{n} results"));
+        }
+        for key in ["results", "matches", "items"] {
+            if let Some(arr) = v.get(key).and_then(serde_json::Value::as_array) {
+                return Some(format!("{} {key}", arr.len()));
+            }
+        }
+    }
+    // Non-JSON (or unrecognised shape): single short line inline, else counts.
+    let lines = out.lines().count();
+    if lines <= 1 {
+        let end = out.floor_char_boundary(ARG_HINT_MAX);
+        return Some(if out.len() > ARG_HINT_MAX {
+            format!("{}…", &out[..end])
+        } else {
+            out.to_string()
+        });
+    }
+    Some(format!("{lines} lines"))
 }
 
 /// Maximum byte length of the arg hint before truncation.
@@ -167,7 +244,7 @@ mod tests {
             "read".into(),
             serde_json::json!({ "path": "a.rs" }),
         );
-        let lines = card_lines(&c, theme::resolve_skin("dark"));
+        let lines = card_lines(&c, theme::resolve_skin("dark"), true);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
@@ -181,7 +258,7 @@ mod tests {
     fn done_card_shows_output_and_duration() {
         let mut c = StepCard::new("s1".into(), "read".into(), serde_json::json!({}));
         c.complete(true, "412 lines".into(), false, 9, None, 8);
-        let lines = card_lines(&c, theme::resolve_skin("dark"));
+        let lines = card_lines(&c, theme::resolve_skin("dark"), true);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
@@ -203,14 +280,14 @@ mod tests {
             "read".into(),
             serde_json::json!({ "path": long_cjk }),
         );
-        let _ = card_lines(&c, theme::resolve_skin("dark")); // must NOT panic
+        let _ = card_lines(&c, theme::resolve_skin("dark"), true); // must NOT panic
     }
 
     #[test]
     fn error_card_shows_red_marker_and_message() {
         let mut c = StepCard::new("s1".into(), "bash".into(), serde_json::json!({}));
         c.complete(false, "boom".into(), false, 4, Some("exit 101".into()), 3);
-        let lines = card_lines(&c, theme::resolve_skin("dark"));
+        let lines = card_lines(&c, theme::resolve_skin("dark"), true);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
@@ -227,7 +304,7 @@ mod tests {
             "edit".into(),
             serde_json::json!({"file_path":"a.rs","old_string":"old","new_string":"new"}),
         );
-        let lines = card_lines(&c, theme::resolve_skin("dark"));
+        let lines = card_lines(&c, theme::resolve_skin("dark"), true);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
@@ -242,6 +319,55 @@ mod tests {
         );
     }
 
+    fn joined(lines: &[ratatui::text::Line]) -> String {
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn collapsed_card_folds_result_count_into_one_line() {
+        let mut c = StepCard::new(
+            "s1".into(),
+            "mur_project_search".into(),
+            serde_json::json!({ "query": "workflow" }),
+        );
+        c.complete(
+            true,
+            r#"{"count":0,"results":[]}"#.into(),
+            false,
+            24,
+            None,
+            328,
+        );
+        let lines = card_lines(&c, theme::resolve_skin("dark"), false);
+        assert_eq!(lines.len(), 1, "collapsed card must be one line: {lines:?}");
+        let text = joined(&lines);
+        assert!(text.contains("0 results"), "expected gist in: {text}");
+        assert!(text.contains("328ms"), "expected duration in: {text}");
+        assert!(!text.contains("\"results\""), "raw JSON leaked: {text}");
+    }
+
+    #[test]
+    fn collapsed_card_still_shows_errors_and_hitl() {
+        let mut c = StepCard::new("s1".into(), "bash".into(), serde_json::json!({}));
+        c.complete(false, "boom".into(), false, 4, Some("exit 101".into()), 3);
+        c.awaiting_hitl = true;
+        let text = joined(&card_lines(&c, theme::resolve_skin("dark"), false));
+        assert!(
+            text.contains("exit 101"),
+            "error must show collapsed: {text}"
+        );
+        assert!(text.contains("[y]"), "HITL must show collapsed: {text}");
+    }
+
     #[test]
     fn awaiting_card_shows_inline_approval_row() {
         let mut c = StepCard::new(
@@ -251,7 +377,7 @@ mod tests {
         );
         c.complete(true, "patched".into(), false, 1, None, 4);
         c.awaiting_hitl = true;
-        let lines = card_lines(&c, theme::resolve_skin("dark"));
+        let lines = card_lines(&c, theme::resolve_skin("dark"), true);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))

--- a/mur-core/src/cmd/agent/cli/suggest.rs
+++ b/mur-core/src/cmd/agent/cli/suggest.rs
@@ -9,18 +9,47 @@ pub const MAX_SUGGESTIONS: usize = 5;
 /// literal string "suggest_replies".
 pub const SUGGEST_REPLIES_NAME: &str = "suggest_replies";
 
-/// Extract non-empty reply strings from the tool-call args, capped. Fail-soft:
-/// any malformed shape yields an empty vec.
-pub fn parse_suggestions(args: &serde_json::Value) -> Vec<String> {
+/// One quick-reply option: the message the user would send, plus an optional
+/// one-line description of the trade-off (Claude-Code-style option list).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Suggestion {
+    /// The message sent verbatim if the user picks this option.
+    pub text: String,
+    /// Optional one-line rationale shown dimmed under the option.
+    pub desc: Option<String>,
+}
+
+/// Extract quick-reply options from the tool-call args, capped. Each item may be
+/// a bare string (legacy) or `{text, description?}`. Fail-soft: any malformed
+/// shape yields an empty vec, and malformed individual items are skipped.
+pub fn parse_suggestions(args: &serde_json::Value) -> Vec<Suggestion> {
     let Some(arr) = args.get("replies").and_then(|v| v.as_array()) else {
         return Vec::new();
     };
     arr.iter()
-        .filter_map(|v| v.as_str())
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
+        .filter_map(|v| {
+            let (text, desc) = if let Some(s) = v.as_str() {
+                (s, None)
+            } else {
+                let text = v.get("text").and_then(|t| t.as_str())?;
+                let desc = v
+                    .get("description")
+                    .and_then(|d| d.as_str())
+                    .map(str::trim)
+                    .filter(|d| !d.is_empty())
+                    .map(str::to_string);
+                (text, desc)
+            };
+            let text = text.trim();
+            if text.is_empty() {
+                return None;
+            }
+            Some(Suggestion {
+                text: text.to_string(),
+                desc,
+            })
+        })
         .take(MAX_SUGGESTIONS)
-        .map(str::to_string)
         .collect()
 }
 
@@ -29,19 +58,19 @@ pub fn parse_suggestions(args: &serde_json::Value) -> Vec<String> {
 pub enum Reveal {
     /// Nothing to show (empty, or the composer already has text).
     None,
-    /// A single suggestion → ghost placeholder text.
+    /// A single suggestion → ghost placeholder text (the `text`, no description).
     Ghost(String),
     /// Two or more → a chooser overlay.
-    Chooser(Vec<String>),
+    Chooser(Vec<Suggestion>),
 }
 
 /// Decide how to reveal `pending` given whether the composer is empty.
-pub fn plan_reveal(pending: Vec<String>, input_empty: bool) -> Reveal {
+pub fn plan_reveal(pending: Vec<Suggestion>, input_empty: bool) -> Reveal {
     if pending.is_empty() || !input_empty {
         return Reveal::None;
     }
     if pending.len() == 1 {
-        Reveal::Ghost(pending.into_iter().next().unwrap())
+        Reveal::Ghost(pending.into_iter().next().unwrap().text)
     } else {
         Reveal::Chooser(pending)
     }
@@ -52,10 +81,37 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn sugg(text: &str) -> Suggestion {
+        Suggestion {
+            text: text.into(),
+            desc: None,
+        }
+    }
+
     #[test]
     fn parse_extracts_trims_and_drops_empties() {
         let v = parse_suggestions(&json!({ "replies": ["  open PR  ", "", "push"] }));
-        assert_eq!(v, vec!["open PR".to_string(), "push".to_string()]);
+        assert_eq!(v, vec![sugg("open PR"), sugg("push")]);
+    }
+
+    #[test]
+    fn parse_object_shape_carries_description() {
+        let v = parse_suggestions(&json!({ "replies": [
+            { "text": "  merge  ", "description": "  fast-forward  " },
+            { "text": "rebase" },
+            "squash",
+        ] }));
+        assert_eq!(
+            v,
+            vec![
+                Suggestion {
+                    text: "merge".into(),
+                    desc: Some("fast-forward".into())
+                },
+                sugg("rebase"),
+                sugg("squash"),
+            ]
+        );
     }
 
     #[test]
@@ -68,13 +124,17 @@ mod tests {
     fn parse_malformed_is_empty() {
         assert!(parse_suggestions(&json!({})).is_empty());
         assert!(parse_suggestions(&json!({ "replies": "nope" })).is_empty());
+        // Numbers / objects without `text` are skipped individually.
         assert!(parse_suggestions(&json!({ "replies": [1, 2] })).is_empty());
+        assert!(
+            parse_suggestions(&json!({ "replies": [{ "description": "no text" }] })).is_empty()
+        );
     }
 
     #[test]
     fn reveal_single_is_ghost() {
         assert_eq!(
-            plan_reveal(vec!["only".into()], true),
+            plan_reveal(vec![sugg("only")], true),
             Reveal::Ghost("only".into())
         );
     }
@@ -82,14 +142,14 @@ mod tests {
     #[test]
     fn reveal_many_is_chooser() {
         assert_eq!(
-            plan_reveal(vec!["a".into(), "b".into()], true),
-            Reveal::Chooser(vec!["a".into(), "b".into()])
+            plan_reveal(vec![sugg("a"), sugg("b")], true),
+            Reveal::Chooser(vec![sugg("a"), sugg("b")])
         );
     }
 
     #[test]
     fn reveal_skips_when_input_not_empty_or_pending_empty() {
-        assert_eq!(plan_reveal(vec!["a".into()], false), Reveal::None);
+        assert_eq!(plan_reveal(vec![sugg("a")], false), Reveal::None);
         assert_eq!(plan_reveal(Vec::new(), true), Reveal::None);
     }
 }

--- a/mur-core/src/cmd/agent/cli/theme.rs
+++ b/mur-core/src/cmd/agent/cli/theme.rs
@@ -53,7 +53,7 @@ pub const DARK: Theme = Theme {
     badge_fg: Color::Black,
     badge_bg: Color::Cyan,
     border_type: BorderType::Plain,
-    inner_padding: 0,
+    inner_padding: 1,
     show_separator: false,
     compact_input: false,
 };

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -22,6 +22,16 @@ use super::welcome::welcome_lines;
 /// unhandled into the input box.
 const OVERLAY_HINT: &str = " press Enter or Esc to return · Ctrl+D quit ";
 
+/// Body indent under a role header ("you ›" / "● agent") so a message's content
+/// reads as belonging to its speaker rather than sitting flush with the header.
+const MSG_INDENT: &str = "  ";
+
+/// Prepend the body indent to an already-styled line (e.g. cached markdown).
+fn indent_line(mut line: Line<'static>) -> Line<'static> {
+    line.spans.insert(0, Span::raw(MSG_INDENT));
+    line
+}
+
 /// Draw the whole UI for one frame.
 pub fn render(f: &mut Frame, app: &mut App) {
     // Full-screen transcript overlay (Ctrl+O) takes over the whole frame and
@@ -33,19 +43,29 @@ pub fn render(f: &mut Frame, app: &mut App) {
     }
     let input_lines = app.input.lines().len() as u16;
     let input_height = (input_lines + 2).clamp(3, 8);
+    // The agent chooser (suggested replies) renders as its own layout band
+    // between transcript and composer — never a Clear-overlay popup — so it
+    // can't cover the reply the user must read to choose. The slash-command
+    // menu keeps the compact popup (the user is typing, not reading).
+    let chooser_h = chooser_band_height(app, f.area().height, input_height);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(3),
+            Constraint::Length(chooser_h),
             Constraint::Length(input_height),
             Constraint::Length(1),
         ])
         .split(f.area());
 
     render_transcript(f, app, chunks[0]);
-    f.render_widget(&app.input, chunks[1]);
-    render_completion(f, app, chunks[1]);
-    render_status(f, app, chunks[2]);
+    if chooser_h > 0 {
+        render_chooser_band(f, app, chunks[1]);
+    } else {
+        render_completion(f, app, chunks[2]);
+    }
+    f.render_widget(&app.input, chunks[2]);
+    render_status(f, app, chunks[3]);
 
     // Inline approval lives on the card (Task 4) when the runtime sent a
     // step_id. Fall back to the centered modal only for older runtimes.
@@ -108,27 +128,52 @@ fn render_completion(f: &mut Frame, app: &App, input_area: Rect) {
     }
     let theme = app.theme;
 
+    // The suggested-reply chooser (`spaced`) is a Claude-Code-style option list:
+    // each option gets a label line, an optional dimmed description line, and a
+    // blank spacer row so the choices breathe. The slash-command menu stays
+    // one-line-per-row and reverse-highlighted.
     let rows: Vec<ListItem> = state
         .items
         .iter()
-        .map(|c| {
-            let mut spans = vec![Span::styled(
-                c.display.clone(),
-                Style::default().fg(theme.border_title),
-            )];
-            if !c.desc.is_empty() {
-                spans.push(Span::raw(" "));
-                spans.push(Span::styled(
-                    c.desc.clone(),
-                    Style::default().fg(Color::DarkGray),
-                ));
+        .enumerate()
+        .map(|(i, c)| {
+            if state.spaced {
+                // Numbered option: "N  label" + a dimmed, aligned description +
+                // a spacer. The number is a quiet affordance for digit-select.
+                let mut lines = vec![Line::from(vec![
+                    Span::styled(format!("{}  ", i + 1), Style::default().fg(theme.system)),
+                    Span::styled(c.display.clone(), Style::default().fg(theme.agent_text)),
+                ])];
+                if !c.desc.is_empty() {
+                    lines.push(Line::from(Span::styled(
+                        format!("   {}", c.desc), // align under the label (past "N  ")
+                        Style::default().fg(Color::DarkGray),
+                    )));
+                }
+                lines.push(Line::default()); // spacer between options
+                ListItem::new(lines)
+            } else {
+                let mut spans = vec![Span::styled(
+                    c.display.clone(),
+                    Style::default().fg(theme.border_title),
+                )];
+                if !c.desc.is_empty() {
+                    spans.push(Span::raw(" "));
+                    spans.push(Span::styled(
+                        c.desc.clone(),
+                        Style::default().fg(Color::DarkGray),
+                    ));
+                }
+                ListItem::new(Line::from(spans))
             }
-            ListItem::new(Line::from(spans))
         })
         .collect();
 
-    let visible = rows.len().min(complete::MAX_MENU_ROWS) as u16;
-    let popup_height = visible + 2; // +2 for borders
+    // Height = actual rendered lines of the shown items (+2 borders). Spaced
+    // items span several lines each, so a flat item count would clip them.
+    let shown = rows.len().min(complete::MAX_MENU_ROWS);
+    let content_lines: usize = rows.iter().take(shown).map(ListItem::height).sum();
+    let popup_height = (content_lines as u16).saturating_add(2);
 
     // Anchor above the input box, then clamp to the frame so a popup taller
     // than the space above the input (short / stacked-pane terminals) can never
@@ -142,21 +187,146 @@ fn render_completion(f: &mut Frame, app: &App, input_area: Rect) {
     }
     .intersection(f.area());
 
+    let title = if state.spaced {
+        " 1-9 pick · ↑↓ move · Enter accept · Esc close "
+    } else {
+        " ↑↓ move · Tab accept · Esc close "
+    };
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(theme.border))
-        .title(" ↑↓ move · Tab accept · Esc close ")
+        .padding(Padding::horizontal(state.spaced as u16))
+        .title(title)
         .title_style(Style::default().fg(theme.border_title));
 
     let mut list_state = ListState::default();
     list_state.select(Some(state.selected));
 
+    // Spaced items are multi-line; a full reverse bar would paint the spacer and
+    // description too. Mark the selection with a caret + accent-bold label
+    // instead. The slash menu keeps its compact reverse highlight.
+    let (highlight_style, highlight_symbol) = if state.spaced {
+        (
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
+            "❯ ",
+        )
+    } else {
+        (Style::default().add_modifier(Modifier::REVERSED), "")
+    };
+
     f.render_widget(Clear, popup_area);
     f.render_stateful_widget(
         List::new(rows)
             .block(block)
-            .highlight_style(Style::default().add_modifier(Modifier::REVERSED)),
+            .highlight_style(highlight_style)
+            .highlight_symbol(highlight_symbol),
         popup_area,
+        &mut list_state,
+    );
+}
+
+/// Height of the chooser band, or 0 when no agent chooser is open (slash
+/// menu stays a popup). Full spaced rows (label + optional desc + spacer)
+/// when they fit above the composer while leaving the transcript at least
+/// `MIN_TRANSCRIPT_ROWS`; otherwise compact one-line rows; never taller
+/// than the space available (the List scrolls the selection into view).
+const MIN_TRANSCRIPT_ROWS: u16 = 3;
+
+fn chooser_band_height(app: &App, total_h: u16, input_height: u16) -> u16 {
+    let Some(state) = &app.completion else {
+        return 0;
+    };
+    if !state.spaced || state.items.is_empty() {
+        return 0;
+    }
+    let available = total_h
+        .saturating_sub(input_height + 1) // composer + status line
+        .saturating_sub(MIN_TRANSCRIPT_ROWS);
+    let full: u16 = state
+        .items
+        .iter()
+        .map(|c| 2 + u16::from(!c.desc.is_empty())) // label + spacer (+ desc)
+        .sum::<u16>()
+        .saturating_add(2); // borders
+    let compact = (state.items.len() as u16).saturating_add(2);
+    let auto = full.min(available).max(compact.min(available)).max(3);
+    // Ctrl+↑/↓ while the chooser is open grows/shrinks the band on top of
+    // the auto height, clamped so the transcript keeps its minimum rows.
+    (i32::from(auto) + i32::from(app.chooser_grow)).clamp(3, i32::from(available.max(3))) as u16
+}
+
+/// Draw the agent chooser into its own layout band. Falls back to compact
+/// one-line rows ("N label — desc") when the band is shorter than the full
+/// spaced form.
+fn render_chooser_band(f: &mut Frame, app: &App, area: Rect) {
+    let Some(state) = &app.completion else {
+        return;
+    };
+    let theme = app.theme;
+    let full: u16 = state
+        .items
+        .iter()
+        .map(|c| 2 + u16::from(!c.desc.is_empty()))
+        .sum::<u16>()
+        .saturating_add(2);
+    let compact = area.height < full;
+
+    let rows: Vec<ListItem> = state
+        .items
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            if compact {
+                let mut spans = vec![
+                    Span::styled(format!("{} ", i + 1), Style::default().fg(theme.system)),
+                    Span::styled(c.display.clone(), Style::default().fg(theme.agent_text)),
+                ];
+                if !c.desc.is_empty() {
+                    spans.push(Span::styled(
+                        format!(" — {}", c.desc),
+                        Style::default().fg(Color::DarkGray),
+                    ));
+                }
+                ListItem::new(Line::from(spans))
+            } else {
+                let mut lines = vec![Line::from(vec![
+                    Span::styled(format!("{} ", i + 1), Style::default().fg(theme.system)),
+                    Span::styled(c.display.clone(), Style::default().fg(theme.agent_text)),
+                ])];
+                if !c.desc.is_empty() {
+                    lines.push(Line::from(Span::styled(
+                        format!("   {}", c.desc),
+                        Style::default().fg(Color::DarkGray),
+                    )));
+                }
+                lines.push(Line::default());
+                ListItem::new(lines)
+            }
+        })
+        .collect();
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.border))
+        .padding(Padding::horizontal(1))
+        .title(" 1-9 pick · ↑↓ move · Enter accept · Esc close · Ctrl+↑↓ resize ")
+        .title_style(Style::default().fg(theme.border_title));
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(state.selected));
+
+    f.render_stateful_widget(
+        List::new(rows)
+            .block(block)
+            .highlight_style(
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol("❯ "),
+        area,
         &mut list_state,
     );
 }
@@ -214,18 +384,64 @@ pub fn flush_finished<B: Backend>(
                 lines.push(Line::default());
             }
         }
-        push_message(&mut lines, &app.messages[i], app.spinner, theme);
+        push_message(
+            &mut lines,
+            &app.messages[i],
+            app.spinner,
+            theme,
+            app.cards_expanded,
+        );
     }
 
-    let height = lines.len() as u16;
+    // Height must be the WRAPPED (physical) row count, not the logical line
+    // count: `insert_before` renders into a buffer exactly `height` rows tall,
+    // and `Wrap` soft-wraps any line wider than the pane into extra rows. Using
+    // `lines.len()` clips every wrapped overflow row — a long message loses its
+    // tail into the void (never reaches scrollback, so it can't be scrolled
+    // back to). `Paragraph::line_count(width)` accounts for wrap + the padding
+    // block. (Enabled by the `unstable-rendered-line-info` ratatui feature.)
+    let pad = theme.inner_padding as u16;
+    let width = terminal.size()?.width.max(1);
+    let text = Text::from(lines);
+    let block = || Block::default().padding(Padding::horizontal(pad));
+    let height = (Paragraph::new(text.clone())
+        .wrap(Wrap { trim: false })
+        .block(block())
+        .line_count(width) as u16)
+        .max(1);
     terminal.insert_before(height, |buf| {
-        let area = buf.area;
-        Paragraph::new(Text::from(lines))
+        Paragraph::new(text)
             .wrap(Wrap { trim: false })
-            .render(area, buf);
+            .block(block())
+            .render(buf.area, buf);
+        blank_wide_char_continuations(buf);
     })?;
     app.flushed_upto = end;
     Ok(())
+}
+
+/// Work around a ratatui 0.29 bug: `Terminal::insert_before` flushes the whole
+/// buffer through `draw_lines`, which (unlike the normal diff-based flush) does
+/// NOT skip the trailing continuation cell of a wide (CJK) grapheme. That cell
+/// holds a space, so every wide char prints as "char " — spacing out CJK text
+/// in scrollback. Blank the continuation cell's symbol so the backend prints
+/// nothing there; the cursor has already advanced two columns for the wide
+/// char, so the next glyph lands correctly. (Live-viewport draws use the diff
+/// path and are unaffected.)
+fn blank_wide_char_continuations(buf: &mut ratatui::buffer::Buffer) {
+    use unicode_width::UnicodeWidthStr;
+    let area = buf.area;
+    for y in area.top()..area.bottom() {
+        let mut x = area.left();
+        while x + 1 < area.right() {
+            if buf[(x, y)].symbol().width() >= 2 {
+                buf[(x + 1, y)].set_symbol("");
+                x += 2;
+            } else {
+                x += 1;
+            }
+        }
+    }
 }
 
 /// Draws the *live* region only: everything at index `< app.flushed_upto` has
@@ -250,7 +466,7 @@ fn render_transcript(f: &mut Frame, app: &mut App, area: Rect) {
     let start = app.flushed_upto.min(app.messages.len());
     let mut lines: Vec<Line> = Vec::new();
     for m in &app.messages[start..] {
-        push_message(&mut lines, m, app.spinner, theme);
+        push_message(&mut lines, m, app.spinner, theme, app.cards_expanded);
     }
 
     if lines.is_empty() && start == 0 {
@@ -267,12 +483,17 @@ fn render_transcript(f: &mut Frame, app: &mut App, area: Rect) {
         );
     }
 
-    // Same wrapped-row accounting as before (`line_count`, not `lines.len()`),
-    // just always auto-following the bottom instead of reading `scroll_back`.
+    // Same wrapped-row accounting as before (`line_count`, not `lines.len()`).
+    // `scroll_back` counts lines up from the bottom (0 = follow the tail);
+    // PageUp/PageDown and the chooser both rely on this so a long unflushed
+    // reply stays reachable even while an option list is open.
     let output = Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false });
     let total = output.line_count(inner_width) as u16;
     let visible = inner.height;
-    let offset = total.saturating_sub(visible);
+    app.scroll_page = visible.max(1);
+    let max_scroll = total.saturating_sub(visible);
+    app.scroll_back = app.scroll_back.min(max_scroll);
+    let offset = max_scroll - app.scroll_back;
 
     f.render_widget(output.block(block).scroll((offset, 0)), area);
 }
@@ -282,10 +503,11 @@ fn push_message(
     m: &ChatMsg,
     spinner: usize,
     theme: &'static super::theme::Theme,
+    cards_expanded: bool,
 ) {
     // Step cards replace role-based rendering entirely for that message.
     if let Some(card) = &m.step {
-        lines.extend(super::render_card::card_lines(card, theme));
+        lines.extend(super::render_card::card_lines(card, theme, cards_expanded));
         return;
     }
     match m.role {
@@ -296,7 +518,7 @@ fn push_message(
             )));
             for l in m.text.lines() {
                 lines.push(Line::styled(
-                    l.to_string(),
+                    format!("{MSG_INDENT}{l}"),
                     Style::default().fg(theme.user_text),
                 ));
             }
@@ -361,7 +583,7 @@ fn push_message(
             if !m.thinking.is_empty() {
                 for l in m.thinking.lines() {
                     lines.push(Line::styled(
-                        l.to_string(),
+                        format!("{MSG_INDENT}{l}"),
                         Style::default()
                             .fg(theme.thinking)
                             .add_modifier(Modifier::ITALIC | Modifier::DIM),
@@ -369,8 +591,11 @@ fn push_message(
                 }
             }
             if m.streaming {
-                let mut body: Vec<Line> =
-                    m.text.lines().map(|l| Line::raw(l.to_string())).collect();
+                let mut body: Vec<Line> = m
+                    .text
+                    .lines()
+                    .map(|l| Line::raw(format!("{MSG_INDENT}{l}")))
+                    .collect();
                 // Trailing spinner so the user sees liveness.
                 let spin = SPINNER[spinner % SPINNER.len()];
                 match body.last_mut() {
@@ -386,10 +611,10 @@ fn push_message(
                 lines.extend(body);
             } else if let Some(cached) = &m.rendered {
                 // Finished reply: reuse the markdown rendered once at finish time.
-                lines.extend(cached.iter().cloned());
+                lines.extend(cached.iter().cloned().map(indent_line));
             } else {
                 // Fallback (should not happen): render on the fly.
-                lines.extend(markdown::render(&m.text).lines);
+                lines.extend(markdown::render(&m.text).lines.into_iter().map(indent_line));
             }
         }
     }
@@ -656,6 +881,37 @@ fn centered_rect(pct_x: u16, pct_y: u16, area: Rect) -> Rect {
             Constraint::Percentage((100 - pct_x) / 2),
         ])
         .split(v[1])[1]
+}
+
+#[cfg(test)]
+mod wide_char_tests {
+    use super::blank_wide_char_continuations;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use ratatui::widgets::{Paragraph, Widget, Wrap};
+
+    #[test]
+    fn cjk_continuation_cells_are_blanked() {
+        let area = Rect::new(0, 0, 20, 1);
+        let mut buf = Buffer::empty(area);
+        Paragraph::new("有既有workflow")
+            .wrap(Wrap { trim: false })
+            .render(area, &mut buf);
+        // ratatui fills wide-char continuation cells with a space.
+        assert_eq!(buf[(1, 0)].symbol(), " ");
+        blank_wide_char_continuations(&mut buf);
+        // After the fix: each CJK glyph is followed by an empty (skipped) cell,
+        // so the backend prints "有既有" with no interleaved spaces.
+        assert_eq!(buf[(0, 0)].symbol(), "有");
+        assert_eq!(buf[(1, 0)].symbol(), "");
+        assert_eq!(buf[(2, 0)].symbol(), "既");
+        assert_eq!(buf[(3, 0)].symbol(), "");
+        assert_eq!(buf[(4, 0)].symbol(), "有");
+        assert_eq!(buf[(5, 0)].symbol(), "");
+        // ASCII run is untouched.
+        assert_eq!(buf[(6, 0)].symbol(), "w");
+        assert_eq!(buf[(7, 0)].symbol(), "o");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem
The agent chooser (suggested replies) rendered as a `Clear`-overlay popup ~17 rows tall over a 20-row inline viewport — it covered the reply the user needs to read to choose, closing it left a blank band where text seemed to vanish, and the transcript could not be scrolled (inline render ignored `scroll_back`; `scroll_page` was never assigned so PageUp moved 1 line).

## Fix
- **Chooser is now its own layout band** (transcript / chooser / composer / status) — it can never cover content; transcript keeps ≥3 rows; compact one-line rows when the full spaced form doesn't fit. Slash-command menu keeps the popup (user is typing, not reading).
- **Manual resize:** Ctrl+↑/↓ grows/shrinks the band while open; sticks for the session.
- **Inline scroll works:** transcript consumes `scroll_back` (PageUp/PageDown, clamped, chooser-compatible); `scroll_page` = visible rows.
- Collapsed tool cards fold a one-line result gist into the header (carried from this branch's earlier work).

## Verification
- `cargo test -p mur-core --lib cli` — 179 passed
- `cargo clippy -p mur-core --lib` — clean; `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)