### PR TITLE
feat(agent-runtime): route agent-authored artifacts into ~/.mur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ research/
 mur-hub-gui/src-tauri/resources/models/default/
 eval-out/
 .tokensave/
+
+# Skill-authoring scratch dir (docs/superpowers/plans/2026-07-04-role-skill-packs.md)
+registry-work/

--- a/docs/superpowers/plans/2026-07-07-agent-output-locations.md
+++ b/docs/superpowers/plans/2026-07-07-agent-output-locations.md
@@ -1,0 +1,183 @@
+# Agent Output Locations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every file a MUR agent produces lands where MUR can read it (`~/.mur`), never dumped into the working directory / a source tree.
+
+**Architecture:** Inject a constant "Output locations" guidance block into every agent's system prompt from the runtime (`assemble_system_prompt`), so it ships in the binary and reaches every agent. Reinforce it in the `mur-workflow-author` skill. Clean up the one stray artifact this bug already produced.
+
+**Tech Stack:** Rust (`mur-agent-runtime`), YAML skill manifests, `mur` CLI.
+
+## Global Constraints
+
+- No enforcement — fs entitlements and `working_dir` are unchanged; the rule is injected text, not a filesystem guardrail. (spec Non-Goals)
+- No new CLI commands — reuse `mur skill install` / `mur workflow new`. (spec Non-Goals)
+- Run-artifact path is exactly `~/.mur/artifacts/<agent-name>/<run>/`. (spec)
+- Brand name in user-facing copy is uppercase **MUR**. (CLAUDE.md rule 7)
+- `cargo fmt` + `cargo clippy -D warnings` must pass; CI compiles with stable rustfmt. (CLAUDE.md)
+
+Spec: `docs/superpowers/specs/2026-07-07-agent-output-locations-design.md`
+
+---
+
+### Task 1: Inject the "Output locations" rule in the runtime
+
+**Files:**
+- Modify: `mur-agent-runtime/src/task_runner.rs` (add `const`; append to `base` inside `assemble_system_prompt`, ~line 471; add test in `mod tests`, ~line 1852)
+
+**Interfaces:**
+- Consumes: `TaskRunner::new_stub_echo()`, `.with_system_prompt(Option<String>)`, `TaskRunner::assemble_system_prompt(&self, user_prompt: &str, active_fleet: Option<&str>, active_team: Option<&str>) -> (String, Vec<String>)` (all already exist).
+- Produces: `const OUTPUT_LOCATIONS_RULE: &str` folded into the returned system prompt on every turn.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests` in `mur-agent-runtime/src/task_runner.rs`:
+
+```rust
+#[test]
+fn assemble_system_prompt_appends_output_locations_rule() {
+    let runner = TaskRunner::new_stub_echo().with_system_prompt(Some("BASE PROMPT".into()));
+    let (sys, _fired) = runner.assemble_system_prompt("hello", None, None);
+    assert!(sys.starts_with("BASE PROMPT"), "keeps the agent's own prompt first");
+    assert!(sys.contains("Output locations"), "injects the rule heading");
+    assert!(sys.contains("~/.mur/artifacts/"), "names the run-artifact dir");
+    assert!(sys.contains("mur skill install"), "names the register command");
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p mur-agent-runtime assemble_system_prompt_appends_output_locations_rule`
+Expected: FAIL — `sys` lacks "Output locations" (rule not injected yet).
+
+- [ ] **Step 3: Add the constant**
+
+Insert near the top of `mur-agent-runtime/src/task_runner.rs` (module-level, above `impl TaskRunner` — beside other consts):
+
+```rust
+/// Injected into every agent's system prompt so authored files land where MUR
+/// can read them instead of the working directory. Guidance, not enforcement.
+const OUTPUT_LOCATIONS_RULE: &str = "\n\n## Output locations\n\
+When you produce files, put them where MUR can read them — never write them into the current working directory (often a source tree):\n\
+- Knowledge objects (workflows, skills, notes): register with the real command so they land in ~/.mur and show up in MUR and the Hub — `mur skill install <path>` for a skill, `mur workflow new` for a workflow. Never leave the definition in the working directory.\n\
+- Run artifacts (reports, quarantined files, scratch output): write to ~/.mur/artifacts/<your-agent-name>/<run>/, where <run> is a short timestamp or task label. Never the working directory.\n\
+- The only reason to write into the working directory is to edit an existing file in a repository you have been granted access to.";
+```
+
+- [ ] **Step 4: Append the constant to `base`**
+
+In `assemble_system_prompt`, change the first line from:
+
+```rust
+        let base = self.system_prompt.clone().unwrap_or_default();
+```
+
+to:
+
+```rust
+        let mut base = self.system_prompt.clone().unwrap_or_default();
+        base.push_str(OUTPUT_LOCATIONS_RULE);
+```
+
+This covers both return paths — the early `return (base, vec![])` when the agent has no skills, and the `combined` path below.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cargo test -p mur-agent-runtime assemble_system_prompt_appends_output_locations_rule`
+Expected: PASS.
+
+- [ ] **Step 6: Full check + fmt + clippy**
+
+Run: `cargo test -p mur-agent-runtime && cargo fmt -p mur-agent-runtime --check && cargo clippy -p mur-agent-runtime -- -D warnings`
+Expected: all pass. (Env: `export PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist`)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-agent-runtime/src/task_runner.rs
+git commit -m "feat(agent-runtime): inject output-location rule into every agent prompt"
+```
+
+---
+
+### Task 2: Reinforce the rule in the `mur-workflow-author` skill
+
+**Files:**
+- Modify: `~/.mur/skills/mur-workflow-author/skill.yaml` (local install; not repo-tracked — this is a runtime data file)
+
+**Interfaces:**
+- Consumes: nothing. Produces: nothing code-facing. This is a content edit so the authoring flow itself states the destination rule.
+
+- [ ] **Step 1: Read the current skill body**
+
+Run: `mur skill show mur-workflow-author --md`
+Expected: prints the manifest; note where `content.context` (the body rules) ends.
+
+- [ ] **Step 2: Add a destination rule to the skill body**
+
+Edit `~/.mur/skills/mur-workflow-author/skill.yaml`, appending one rule to `content.context` (match the existing imperative "rule + why" style):
+
+```
+- Write the authored workflow/skill into ~/.mur (via `mur workflow new` or
+  `mur skill install <path>`), never into the current working directory.
+  *Why: only files under ~/.mur are visible to MUR retrieval and the Hub; a
+  definition left in a source tree is invisible and pollutes the checkout.*
+```
+
+- [ ] **Step 3: Validate the edited skill**
+
+Run: `mur skill validate ~/.mur/skills/mur-workflow-author/skill.yaml`
+Expected: prints `ok:` (schema + security scan pass).
+
+- [ ] **Step 4: Reindex so retrieval picks up the new body**
+
+Run: `mur skill reindex-vec`
+Expected: completes without error.
+
+No commit — this file lives under `~/.mur`, outside the repo.
+
+---
+
+### Task 3: Install the stray security-scan skill and confirm it is visible
+
+**Files:**
+- Source: `registry-work/skills/remote-security-scan/1.0.0/skill.yaml` (now gitignored)
+- Result: `~/.mur/skills/remote-security-scan/skill.yaml` (created by install)
+
+**Interfaces:**
+- Consumes: `mur skill install <path>`. Produces: an installed, registered skill.
+
+- [ ] **Step 1: Validate the draft before installing**
+
+Run: `mur skill validate registry-work/skills/remote-security-scan/1.0.0/skill.yaml`
+Expected: `ok:`. If it fails, fix the manifest per the validator message before continuing.
+
+- [ ] **Step 2: Install it**
+
+Run: `mur skill install registry-work/skills/remote-security-scan/1.0.0/skill.yaml`
+Expected: reports the skill installed into `~/.mur/skills/`.
+
+- [ ] **Step 3: Confirm MUR + Hub can see it**
+
+Run: `mur skill list | grep remote-security-scan`
+Expected: the skill appears in the list. (In the Hub, a refresh shows it under skills.)
+
+No repo commit — installs land under `~/.mur`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "Inject the rule once in the runtime" → Task 1.
+- "Reinforce in mur-workflow-author skill" → Task 2.
+- "Install the stray draft" → Task 3.
+- "gitignore registry-work/" → already done in commit `27c89cb4` (with the spec).
+- "Unit test on assemble_system_prompt" → Task 1 Step 1.
+- Verification points 1–3 (behavioral) are covered by Task 3 Step 3 plus manual murmur re-run — left as operator verification, noted in the spec.
+
+**Placeholders:** none — const text, test code, and exact commands are all inline.
+
+**Type consistency:** `assemble_system_prompt` signature and `with_system_prompt(Option<String>)` / `new_stub_echo()` match the existing code read during grounding.
+
+**Note:** Tasks 2 and 3 mutate `~/.mur` (runtime data), so only Task 1 produces a repo commit. The branch/PR for this plan is Task 1 plus the already-committed spec + gitignore.

--- a/docs/superpowers/specs/2026-07-07-agent-output-locations-design.md
+++ b/docs/superpowers/specs/2026-07-07-agent-output-locations-design.md
@@ -2,7 +2,8 @@
 
 **Date:** 2026-07-07
 **Status:** Design
-**Scope:** Guidance-only (prompt + skill), no `mur-agent-runtime` changes.
+**Scope:** Guidance (not enforcement), injected once in the runtime so every
+agent inherits it.
 
 ## Problem
 
@@ -35,9 +36,10 @@ Every file an agent *produces* lands where it belongs:
 
 ## Non-Goals
 
-- No runtime enforcement (no changes to fs entitlements or default
-  `working_dir`). This is guidance the agent follows; if it proves
-  insufficient, a runtime guardrail is a separate follow-up.
+- No *enforcement*: fs entitlements and the default `working_dir` are
+  unchanged. The rule is injected text the agent chooses to follow, not a
+  filesystem guardrail; if drift is observed, a runtime guardrail is a
+  separate follow-up.
 - No new CLI commands. We reuse existing authoring/registration commands.
 
 ## Design
@@ -64,14 +66,20 @@ successive runs don't clobber each other.
 
 ### Where the rule lives
 
-Two documentation/prompt edits, no code paths:
+Editing individual prompt files is too weak: the `mur agent create` default
+prompt is a bare `"You are an assistant."` stub, so a prompt edit reaches only
+new agents; editing the concierge's `~/.mur/agents/mur/sys_prompt.md` is a
+local, per-machine change that never ships. Instead inject the rule **once, in
+the runtime**, so every agent inherits it and it ships in the binary:
 
-1. **Concierge `sys_prompt.md`** and the **`mur agent create` default prompt
-   template** — add a short "Output locations" section stating the three
-   rules. Editing the template means every newly-created agent inherits the
-   rule, not just the concierge.
-2. **`mur-workflow-author` skill** (and the skill-authoring guidance) — carry
-   the same rule so the authoring flow itself points at `~/.mur`.
+1. **`mur-agent-runtime` `assemble_system_prompt`** (`task_runner.rs`) — append
+   a constant "Output locations" block to `base` (the agent's own system
+   prompt) on every turn. One `const`, one append. This is injection, not
+   enforcement — the agent still writes files itself; it now always knows
+   where they belong.
+2. **`mur-workflow-author` skill** (`~/.mur/skills/mur-workflow-author/
+   skill.yaml`, and the repo-tracked source if one exists) — carry the same
+   rule so the authoring flow itself points at `~/.mur`.
 
 ### Cleanup for the current instance
 
@@ -84,7 +92,8 @@ Two documentation/prompt edits, no code paths:
 
 ## Verification
 
-Guidance changes are verified by behavior, not tests:
+A unit test on `assemble_system_prompt` asserts the block is present in the
+assembled prompt. Behavior is then verified end-to-end:
 
 1. In `murmur`, ask the agent to build a workflow → its `skill.yaml` lands in
    `~/.mur/skills/` (confirmed via `mur skill list`), not the source tree.

--- a/docs/superpowers/specs/2026-07-07-agent-output-locations-design.md
+++ b/docs/superpowers/specs/2026-07-07-agent-output-locations-design.md
@@ -1,0 +1,99 @@
+# Agent Output Locations — Route Authored Artifacts into `~/.mur`
+
+**Date:** 2026-07-07
+**Status:** Design
+**Scope:** Guidance-only (prompt + skill), no `mur-agent-runtime` changes.
+
+## Problem
+
+When a user runs `murmur` (the agent CLI TUI) inside a project directory and
+asks the agent to "build a workflow", the produced artifact lands in the
+agent's current working directory — which is often a source tree — instead of
+a MUR-readable location. Concretely, a `/brainstorming` session that authored
+a security-scan skill wrote it to `registry-work/skills/remote-security-scan/
+1.0.0/skill.yaml` in the repo root. It was never installed into `~/.mur`,
+so `mur skill list`, the retrieval/injection pool, and the Hub could not see
+it, and it silently polluted the checkout.
+
+Root cause: the agent's file tools (`write_file` / `edit_file` / `bash`)
+resolve relative paths against `working_dir`. When `working_dir` is a repo,
+newly-authored files land there. Nothing tells the agent that MUR knowledge
+objects belong in `~/.mur` and that run artifacts do not belong in the source
+tree. The proper authoring commands (`mur skill install`, `mur workflow new`)
+exist but the agent is not directed to use them.
+
+## Goal
+
+Every file an agent *produces* lands where it belongs:
+
+- **Knowledge objects** (workflow / skill / note) → registered under `~/.mur`
+  so MUR + Hub see them.
+- **Run artifacts** (reports, quarantined files, scratch) → a findable
+  per-agent directory, never the source tree.
+- **Editing an existing repo file** stays the only reason to write into the
+  working directory, and only under the existing consent grant.
+
+## Non-Goals
+
+- No runtime enforcement (no changes to fs entitlements or default
+  `working_dir`). This is guidance the agent follows; if it proves
+  insufficient, a runtime guardrail is a separate follow-up.
+- No new CLI commands. We reuse existing authoring/registration commands.
+
+## Design
+
+### The three output-location rules
+
+| Produced | Destination | How |
+| --- | --- | --- |
+| Knowledge object (workflow / skill / note) | `~/.mur/{workflows,skills}/` | Register with the real command: skill → `mur skill install <path>`; workflow → `mur workflow new` (or write `~/.mur/workflows/<name>.yaml`). Never leave the definition in the working directory. |
+| Run artifact (report, quarantined file, scratch) | `~/.mur/artifacts/<agent-name>/<run>/` | Default here; never the working directory. |
+| Edit to an existing repo file | working directory (cwd) | The only case that touches source; requires the existing consent grant (`access::ensure_cwd_access`). |
+
+`<agent-name>` is the agent's own canonical name (it knows this). `<run>` is a
+short run label (e.g. a timestamp or task slug) chosen by the agent so
+successive runs don't clobber each other.
+
+### Why these commands
+
+- `mur skill install <path>` copies a skill into `~/.mur/skills/<name>/` and
+  registers it (reindex with `mur skill reindex-vec` if vector search is
+  needed). Direct-writing the YAML would make it exist but can miss the
+  vector index — using the command is the robust path.
+- `mur workflow new` creates a workflow under `~/.mur/workflows/`.
+
+### Where the rule lives
+
+Two documentation/prompt edits, no code paths:
+
+1. **Concierge `sys_prompt.md`** and the **`mur agent create` default prompt
+   template** — add a short "Output locations" section stating the three
+   rules. Editing the template means every newly-created agent inherits the
+   rule, not just the concierge.
+2. **`mur-workflow-author` skill** (and the skill-authoring guidance) — carry
+   the same rule so the authoring flow itself points at `~/.mur`.
+
+### Cleanup for the current instance
+
+- Install the stray draft properly:
+  `mur skill install registry-work/skills/remote-security-scan/1.0.0/skill.yaml`
+  so it appears in `~/.mur/skills/` and the Hub.
+- Add `registry-work/` to `.gitignore` — it is a repo scratch directory
+  (defined by `docs/superpowers/plans/2026-07-04-role-skill-packs.md`) and
+  should never be committed.
+
+## Verification
+
+Guidance changes are verified by behavior, not tests:
+
+1. In `murmur`, ask the agent to build a workflow → its `skill.yaml` lands in
+   `~/.mur/skills/` (confirmed via `mur skill list`), not the source tree.
+2. Run a workflow that emits a report → the report lands in
+   `~/.mur/artifacts/<agent-name>/…`, not the working directory.
+3. `git status` in the repo stays clean of agent-authored files.
+
+## Risks
+
+- **Self-discipline only.** A guidance rule can be ignored by the model. This
+  is the accepted trade-off for a small, immediate fix; escalate to a runtime
+  guardrail only if drift is observed in practice.

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -70,6 +70,14 @@ const MAX_CONVERSATIONS: usize = 256;
 /// cap — switch to a token budget if turn sizes vary wildly.
 const MAX_CONV_MESSAGES: usize = 40;
 
+/// Injected into every agent's system prompt so authored files land where MUR
+/// can read them instead of the working directory. Guidance, not enforcement.
+const OUTPUT_LOCATIONS_RULE: &str = "\n\n## Output locations\n\
+When you produce files, put them where MUR can read them — never write them into the current working directory (often a source tree):\n\
+- Knowledge objects (workflows, skills, notes): register with the real command so they land in ~/.mur and show up in MUR and the Hub — `mur skill install <path>` for a skill, `mur workflow new` for a workflow. Never leave the definition in the working directory.\n\
+- Run artifacts (reports, quarantined files, scratch output): write to ~/.mur/artifacts/<your-agent-name>/<run>/, where <run> is a short timestamp or task label. Never the working directory.\n\
+- The only reason to write into the working directory is to edit an existing file in a repository you have been granted access to.";
+
 /// In-memory multi-turn chat memory. The CLI and Hub thread `context.task_id` =
 /// the prior reply's id on every send, so we key stored history by the id of the
 /// turn that produced it; the next turn's `context.task_id` then recalls its
@@ -468,7 +476,8 @@ impl TaskRunner {
         active_fleet: Option<&str>,
         active_team: Option<&str>,
     ) -> (String, Vec<String>) {
-        let base = self.system_prompt.clone().unwrap_or_default();
+        let mut base = self.system_prompt.clone().unwrap_or_default();
+        base.push_str(OUTPUT_LOCATIONS_RULE);
         let Some(skills) = &self.skills else {
             return (base, vec![]);
         };
@@ -3097,6 +3106,25 @@ mod tests {
         assert!(RATE_LIMIT_BACKOFF_BASE >= std::time::Duration::from_millis(1));
         let max_delay = rate_limit_backoff_delay(MAX_RATE_LIMIT_RETRIES);
         assert!(max_delay <= std::time::Duration::from_secs(60));
+    }
+
+    #[test]
+    fn assemble_system_prompt_appends_output_locations_rule() {
+        let runner = TaskRunner::new_stub_echo().with_system_prompt(Some("BASE PROMPT".into()));
+        let (sys, _fired) = runner.assemble_system_prompt("hello", None, None);
+        assert!(
+            sys.starts_with("BASE PROMPT"),
+            "keeps the agent's own prompt first"
+        );
+        assert!(sys.contains("Output locations"), "injects the rule heading");
+        assert!(
+            sys.contains("~/.mur/artifacts/"),
+            "names the run-artifact dir"
+        );
+        assert!(
+            sys.contains("mur skill install"),
+            "names the register command"
+        );
     }
 }
 


### PR DESCRIPTION
## Problem
When a user runs `murmur` inside a project and asks the agent to build a workflow/skill, the artifact lands in the agent's working directory (a source tree) instead of a MUR-readable location. A `/brainstorming` session wrote a skill to `registry-work/skills/…/skill.yaml` in the repo root — never installed into `~/.mur`, so `mur skill list`, retrieval, and the Hub couldn't see it, and it polluted the checkout.

Root cause: the agent's file tools resolve relative paths against `working_dir`; nothing tells the agent that MUR knowledge objects belong in `~/.mur` and run artifacts don't belong in the source tree.

## Fix (guidance, not enforcement)
Inject a constant **Output locations** block into every agent's system prompt from the runtime (`assemble_system_prompt`), so it ships in the binary and reaches every agent:
- Knowledge objects (workflows/skills/notes) → register via `mur skill install` / `mur workflow new` (land in `~/.mur`, visible to MUR + Hub).
- Run artifacts (reports, quarantined files) → `~/.mur/artifacts/<agent-name>/<run>/`.
- The working directory is only for editing an existing repo file under the existing consent grant.

Also gitignores the `registry-work/` scratch dir.

Spec: `docs/superpowers/specs/2026-07-07-agent-output-locations-design.md`
Plan: `docs/superpowers/plans/2026-07-07-agent-output-locations.md`

## Verification
- New unit test `assemble_system_prompt_appends_output_locations_rule` — passes.
- Full `cargo test -p mur-agent-runtime` green; fmt + clippy clean.
- Reviewed clean against the spec's global constraints (no enforcement, exact artifact path, MUR brand casing, both return paths covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)