### PR TITLE
feat(skill): doctor --fix rebuilds missing/unreadable stats sidecars

### DIFF
--- a/mur-core/src/cli/skill.rs
+++ b/mur-core/src/cli/skill.rs
@@ -246,10 +246,10 @@ pub enum SkillAction {
         /// CI-friendly mode where warnings exit 1.
         #[arg(long)]
         strict: bool,
-        /// Accepted for forward CLI stability; no-op in M5a.
+        /// Repair fixable findings (dry-run unless --apply is also given).
         #[arg(long)]
         fix: bool,
-        /// Accepted for forward CLI stability; no-op in M5a.
+        /// With --fix: actually write the repairs instead of dry-running.
         #[arg(long)]
         apply: bool,
         /// Enable LLM-augmented checks (api-drift, coverage-gap).

--- a/mur-core/src/cmd/notes_cmd.rs
+++ b/mur-core/src/cmd/notes_cmd.rs
@@ -630,7 +630,6 @@ mod tests {
                 days_back: 1,
             },
         )
-        .await
         .unwrap();
 
         let stats_path = SkillStats::path(tmp.path(), "rust-errors");

--- a/mur-core/src/cmd/skill_doctor.rs
+++ b/mur-core/src/cmd/skill_doctor.rs
@@ -218,6 +218,7 @@ pub fn cmd_doctor(
         let repairs: Vec<Box<dyn crate::skill_repair::Repair>> = vec![
             Box::new(crate::skill_repair::tool_availability::ToolAvailabilityRepair),
             Box::new(crate::skill_repair::dep_freshness::DepFreshnessRepair),
+            Box::new(crate::skill_repair::stats_sidecar::StatsSidecarRepair),
         ];
         let repair_ctx = crate::skill_repair::RepairCtx {
             home: &ctx.home,

--- a/mur-core/src/cmd/skill_stats.rs
+++ b/mur-core/src/cmd/skill_stats.rs
@@ -60,8 +60,7 @@ pub async fn cmd_reindex_stats(skill_filter: Option<&str>, days_back: u32) -> Re
             since: None,
             days_back,
         },
-    )
-    .await?;
+    )?;
     println!(
         "Reindexed {} skill(s) from {} trace line(s)",
         report.skills_touched, report.lines_consumed

--- a/mur-core/src/skill_repair/mod.rs
+++ b/mur-core/src/skill_repair/mod.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use crate::cmd::skill_doctor::Finding;
 
 pub mod dep_freshness;
+pub mod stats_sidecar;
 pub mod tool_availability;
 
 pub enum RepairOutcome {

--- a/mur-core/src/skill_repair/stats_sidecar.rs
+++ b/mur-core/src/skill_repair/stats_sidecar.rs
@@ -1,0 +1,114 @@
+//! Repair impl for `execution-recency` sidecar findings.
+//!
+//! A missing or unreadable stats sidecar is a cache miss — the JSONL trace
+//! log is the source of truth — so the repair is a rebuild via
+//! `reindex_stats`, exactly what the finding's remediation tells a human
+//! to run by hand.
+
+use crate::cmd::skill_doctor::Finding;
+use crate::skill_repair::{Repair, RepairCtx, RepairOutcome};
+use crate::skill_stats::reindex::{DEFAULT_DAYS_BACK, ReindexOptions, reindex_stats};
+
+pub struct StatsSidecarRepair;
+
+impl Repair for StatsSidecarRepair {
+    fn check_id(&self) -> &'static str {
+        "execution-recency"
+    }
+
+    fn applicable(&self, finding: &Finding) -> bool {
+        finding.check_id == "execution-recency" && finding.fixable
+    }
+
+    fn run(&self, finding: &Finding, ctx: &RepairCtx, apply: bool) -> RepairOutcome {
+        if !apply {
+            return RepairOutcome::DryRun(format!(
+                "would rebuild stats sidecar for {} from traces",
+                finding.skill_name
+            ));
+        }
+        let opts = ReindexOptions {
+            skill_filter: Some(finding.skill_name.clone()),
+            since: None,
+            days_back: DEFAULT_DAYS_BACK,
+        };
+        match reindex_stats(ctx.home, opts) {
+            Ok(_) => RepairOutcome::Fixed,
+            Err(e) => RepairOutcome::Failed(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmd::skill_doctor::{Finding, Severity};
+    use mur_common::skill::stats::SkillStats;
+
+    fn sidecar_finding(skill: &str) -> Finding {
+        Finding {
+            check_id: "execution-recency".into(),
+            category: "recency".into(),
+            severity: Severity::Unknown,
+            skill_name: skill.into(),
+            message: "No stats sidecar — run `mur skill reindex-stats` to rebuild.".into(),
+            remediation: Some(format!("mur skill reindex-stats {skill}")),
+            fixable: true,
+        }
+    }
+
+    #[test]
+    fn rebuilds_missing_sidecar_from_traces() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        std::fs::create_dir_all(home.join("skills").join("my-skill")).unwrap();
+        std::fs::write(
+            home.join("skills").join("my-skill").join("skill.yaml"),
+            "name: my-skill\nversion: \"1\"\npublisher: me\ndescription: d\ncategory: note\ncontent:\n  abstract: a\n  note: b\n",
+        )
+        .unwrap();
+        let now = chrono::Utc::now();
+        let traces = home.join("traces");
+        std::fs::create_dir_all(&traces).unwrap();
+        std::fs::write(
+            traces
+                .join(now.format("%Y-%m-%d").to_string())
+                .with_extension("jsonl"),
+            format!(
+                "{{\"ts\":\"{}\",\"method\":\"mur.skill.executed\",\"mur.skill.name\":\"my-skill\",\"mur.skill.outcome\":\"success\"}}\n",
+                now.to_rfc3339()
+            ),
+        )
+        .unwrap();
+
+        let ctx = RepairCtx {
+            home,
+            registry_url: "unused",
+        };
+        let repair = StatsSidecarRepair;
+        let finding = sidecar_finding("my-skill");
+        assert!(repair.applicable(&finding));
+
+        // Dry-run writes nothing.
+        assert!(matches!(
+            repair.run(&finding, &ctx, false),
+            RepairOutcome::DryRun(_)
+        ));
+        assert!(
+            SkillStats::load(&SkillStats::path(home, "my-skill"))
+                .unwrap()
+                .is_none()
+        );
+
+        // Apply rebuilds the sidecar from the trace.
+        assert!(matches!(
+            repair.run(&finding, &ctx, true),
+            RepairOutcome::Fixed
+        ));
+        let stats = SkillStats::load(&SkillStats::path(home, "my-skill"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(stats.usage_count, 1);
+        assert_eq!(stats.success_count, 1);
+    }
+}

--- a/mur-core/src/skill_stats/reindex.rs
+++ b/mur-core/src/skill_stats/reindex.rs
@@ -6,6 +6,9 @@ use chrono::{DateTime, Utc};
 use mur_common::skill::stats::SkillStats;
 use std::path::Path;
 
+/// Default trace window for rebuilds (matches the CLI default).
+pub const DEFAULT_DAYS_BACK: u32 = 30;
+
 pub struct ReindexOptions {
     pub skill_filter: Option<String>,
     #[allow(dead_code)]
@@ -19,7 +22,7 @@ pub struct ReindexReport {
 }
 
 /// Rebuild stats for installed skills by scanning trace JSONL files.
-pub async fn reindex_stats(mur_home: &Path, opts: ReindexOptions) -> Result<ReindexReport> {
+pub fn reindex_stats(mur_home: &Path, opts: ReindexOptions) -> Result<ReindexReport> {
     let traces_dir = mur_home.join("traces");
     let today = Utc::now();
 
@@ -274,8 +277,8 @@ mod tests {
         assert!(!p.matches("test-ab"));
     }
 
-    #[tokio::test]
-    async fn reindex_counts_note_retrieval_events_as_usage_and_success() {
+    #[test]
+    fn reindex_counts_note_retrieval_events_as_usage_and_success() {
         use chrono::Utc;
         use mur_common::skill::stats::SkillStats;
         use tempfile::tempdir;
@@ -314,7 +317,6 @@ mod tests {
                 days_back: 1,
             },
         )
-        .await
         .unwrap();
 
         let stats = SkillStats::load(&SkillStats::path(tmp.path(), "my-note"))
@@ -324,8 +326,8 @@ mod tests {
         assert_eq!(stats.success_count, 3);
     }
 
-    #[tokio::test]
-    async fn reindex_sets_curated_at_without_counting_usage() {
+    #[test]
+    fn reindex_sets_curated_at_without_counting_usage() {
         use mur_common::skill::stats::SkillStats;
         let tmp = tempfile::tempdir().unwrap();
         let home = tmp.path();
@@ -362,7 +364,6 @@ mod tests {
                 days_back: 1,
             },
         )
-        .await
         .unwrap();
 
         let stats = SkillStats::load(&SkillStats::path(home, "my-skill"))


### PR DESCRIPTION
## Summary
`mur skill doctor`'s execution-recency check flags a missing/unreadable stats sidecar as `fixable: true` with remediation `mur skill reindex-stats <name>` — but no `Repair` impl existed, so `doctor --fix` silently skipped exactly the finding it tells the user to fix by hand.

- **StatsSidecarRepair**: rebuilds the sidecar from the JSONL trace log (source of truth) via `reindex_stats`; dry-run by default, writes with `--apply`
- **de-async `reindex_stats`**: it contained zero awaits; making it sync lets the sync `Repair` trait call it directly (callers/tests updated)
- **stale CLI docs fixed**: `--fix`/`--apply` still said "no-op in M5a" though the repair engine shipped in M5b

## Test plan
- New unit test `rebuilds_missing_sidecar_from_traces` (dry-run writes nothing; apply rebuilds counts)
- Affected reindex/notes tests pass; clippy green
- E2E in a temp `MUR_HOME`: `doctor demo --check execution-recency --fix` reports the pending rebuild; `--fix --apply` writes `stats.json` with usage/success recovered from traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)