### PR TITLE
fix(runtime): expand leading ~ in file-tool paths

### DIFF
--- a/mur-agent-runtime/src/tools/edit_file.rs
+++ b/mur-agent-runtime/src/tools/edit_file.rs
@@ -1,7 +1,7 @@
 //! First-party exact-literal edit tool (issue #591, PR2). No regex —
 //! ambiguity fails closed instead of guessing.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use mur_common::agent::FilesystemEntitlement;
 
@@ -59,11 +59,7 @@ impl ToolExecutor for EditFileTool {
                 "'old_string' must be non-empty".into(),
             ));
         }
-        let joined = if Path::new(raw).is_absolute() {
-            PathBuf::from(raw)
-        } else {
-            self.working_dir.join(raw)
-        };
+        let joined = crate::tools::fs_policy::resolve_path(&self.working_dir, raw);
         let canonical = std::fs::canonicalize(&joined)
             .map_err(|e| ToolError::Execution(format!("cannot edit {}: {e}", joined.display())))?;
         check_write_entitlement(&self.fs, &canonical)?;

--- a/mur-agent-runtime/src/tools/fs_policy.rs
+++ b/mur-agent-runtime/src/tools/fs_policy.rs
@@ -8,6 +8,26 @@ use mur_common::agent::FilesystemEntitlement;
 
 use crate::tools::ToolError;
 
+/// Resolve a tool-supplied path: expand a leading `~`/`~/` to the user's
+/// home, keep absolute paths as-is, and join relative paths onto
+/// `working_dir`. Entitlement checks run on the canonicalized result,
+/// so expansion never widens what a grant covers.
+pub(crate) fn resolve_path(working_dir: &Path, raw: &str) -> PathBuf {
+    if let Some(home) = dirs::home_dir() {
+        if raw == "~" {
+            return home;
+        }
+        if let Some(rest) = raw.strip_prefix("~/") {
+            return home.join(rest);
+        }
+    }
+    if Path::new(raw).is_absolute() {
+        PathBuf::from(raw)
+    } else {
+        working_dir.join(raw)
+    }
+}
+
 pub(crate) fn check_write_entitlement(
     fs: &FilesystemEntitlement,
     canonical: &Path,
@@ -31,4 +51,21 @@ pub(crate) fn check_write_entitlement(
         "path not write-entitled: {} (grant it via `mur agent perm allow-write`)",
         canonical.display()
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_path_expands_tilde() {
+        let home = dirs::home_dir().unwrap();
+        let wd = Path::new("/tmp/wd");
+        assert_eq!(resolve_path(wd, "~/.mur/skills"), home.join(".mur/skills"));
+        assert_eq!(resolve_path(wd, "~"), home);
+        assert_eq!(resolve_path(wd, "/abs/x"), PathBuf::from("/abs/x"));
+        assert_eq!(resolve_path(wd, "rel/x"), wd.join("rel/x"));
+        // `~user` form is not expanded — treated as a relative name.
+        assert_eq!(resolve_path(wd, "~other/x"), wd.join("~other/x"));
+    }
 }

--- a/mur-agent-runtime/src/tools/read_file.rs
+++ b/mur-agent-runtime/src/tools/read_file.rs
@@ -81,11 +81,7 @@ Paths resolve relative to the agent working directory; reads are checked against
         let raw = input["path"]
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput("missing 'path' field".into()))?;
-        let joined = if Path::new(raw).is_absolute() {
-            PathBuf::from(raw)
-        } else {
-            self.working_dir.join(raw)
-        };
+        let joined = crate::tools::fs_policy::resolve_path(&self.working_dir, raw);
         let canonical = std::fs::canonicalize(&joined)
             .map_err(|e| ToolError::Execution(format!("cannot read {}: {e}", joined.display())))?;
         self.check_entitlement(&canonical)?;

--- a/mur-agent-runtime/src/tools/write_file.rs
+++ b/mur-agent-runtime/src/tools/write_file.rs
@@ -1,6 +1,6 @@
 //! First-party full-file write tool (issue #591, PR2).
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use mur_common::agent::FilesystemEntitlement;
 
@@ -48,11 +48,7 @@ impl ToolExecutor for WriteFileTool {
         let content = input["content"]
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput("missing 'content' field".into()))?;
-        let joined = if Path::new(raw).is_absolute() {
-            PathBuf::from(raw)
-        } else {
-            self.working_dir.join(raw)
-        };
+        let joined = crate::tools::fs_policy::resolve_path(&self.working_dir, raw);
         let parent = joined
             .parent()
             .ok_or_else(|| ToolError::InvalidInput("path has no parent directory".into()))?;


### PR DESCRIPTION
## Problem
The agent's `read_file`/`write_file`/`edit_file` tools treat `~/...` as a relative path and join it onto the agent working dir, producing `/Users/david/.mur/agents/mur/~/.mur/skills/...` → ENOENT. Users (and the model) naturally pass tilde paths; every such call fails.

## Fix
Shared `resolve_path` helper in `fs_policy.rs`: expands `~` / `~/` to the user's home, absolute paths pass through, everything else joins the working dir (unchanged). All three tools now use it. `~user` forms are deliberately not expanded. Entitlement checks still run on the canonicalized result, so expansion can't widen a grant.

Unit test covers tilde / absolute / relative / `~user` cases; all 51 tool tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)