### PR TITLE
fix(hub): dark-mode soft/strong color tokens — unreadable selected rows

### DIFF
--- a/mur-hub-gui/ui/src/styles/tokens/primitives.css
+++ b/mur-hub-gui/ui/src/styles/tokens/primitives.css
@@ -1,9 +1,9 @@
 /* Raw scales. Never referenced directly by components — only by semantic.css. */
 :root {
   /* brand blue */
-  --blue-700:#2F6FB0; --blue-500:#4A90D9; --blue-soft:#EAF3FC;
+  --blue-700:#2F6FB0; --blue-500:#4A90D9; --blue-300:#8FC1EC; --blue-soft:#EAF3FC; --blue-soft-dark:rgba(74,144,217,.22);
   /* accent coral */
-  --coral-600:#F0563D; --coral-500:#FB6B53; --coral-soft:#FFF1EE;
+  --coral-600:#F0563D; --coral-500:#FB6B53; --coral-300:#FFA290; --coral-soft:#FFF1EE; --coral-soft-dark:rgba(251,107,83,.20);
   /* category */
   --cat-research:#4A90D9; --cat-automation:#10B981; --cat-monitor:#F59E0B;
   --cat-notify:#EF4444; --cat-commerce:#8B5CF6; --cat-custom:#64748B;

--- a/mur-hub-gui/ui/src/styles/tokens/semantic.css
+++ b/mur-hub-gui/ui/src/styles/tokens/semantic.css
@@ -16,6 +16,12 @@
 }
 @media (prefers-color-scheme: dark) {
   :root {
+    /* Soft tints must darken too: the light pastels (#EAF3FC / #FFF1EE)
+       under light text made selected rows unreadable in dark mode. The
+       paired -strong text colors lighten so they stay readable on the
+       dark tints. */
+    --color-brand-soft:var(--blue-soft-dark); --color-accent-soft:var(--coral-soft-dark);
+    --color-brand-strong:var(--blue-300); --color-accent-strong:var(--coral-300);
     --surface-bg:var(--d-bg); --surface-secondary:var(--d-secondary);
     --surface-card:var(--d-card); --surface-hover:var(--d-hover);
     --border-line:var(--d-line);
@@ -24,6 +30,8 @@
   }
 }
 :root[data-theme="dark"] {
+  --color-brand-soft:var(--blue-soft-dark); --color-accent-soft:var(--coral-soft-dark);
+  --color-brand-strong:var(--blue-300); --color-accent-strong:var(--coral-300);
   --surface-bg:var(--d-bg); --surface-secondary:var(--d-secondary);
   --surface-card:var(--d-card); --surface-hover:var(--d-hover);
   --border-line:var(--d-line);
@@ -31,6 +39,8 @@
   --sidebar-bg:var(--d-sidebar-vibrancy); --sidebar-bg-solid:var(--d-sidebar-solid);
 }
 :root[data-theme="light"] {
+  --color-brand-soft:var(--blue-soft); --color-accent-soft:var(--coral-soft);
+  --color-brand-strong:var(--blue-700); --color-accent-strong:var(--coral-600);
   --surface-bg:var(--n-bg); --surface-secondary:var(--n-secondary);
   --surface-card:var(--n-card); --surface-hover:var(--n-hover);
   --border-line:var(--n-line);


### PR DESCRIPTION
## Problem
Selected chat / fleet names in the Hub were invisible in dark mode (see report screenshots): `--color-brand-soft` / `--color-accent-soft` are light pastels (#EAF3FC / #FFF1EE) and were never overridden in the dark theme, while `--text-primary` flips to light — light text on a light highlight. Affects every soft-token consumer: selected chat row (`.chats-item.is-active`), selected fleet (`.fleet-rail__item.is-selected`), wizard cards, view toggles, modals — 12+ call sites, one token bug.

## Fix (token level, one place)
Dark theme (both the `prefers-color-scheme` block and `[data-theme=dark]`) now maps:
- `--color-brand-soft` → `rgba(74,144,217,.22)`, `--color-accent-soft` → `rgba(251,107,83,.20)` (translucent brand tints that read on dark surfaces)
- the paired text colors `--color-brand-strong` / `--color-accent-strong` → `blue-300` / `coral-300` so strong-on-soft pairings keep contrast both ways.

`[data-theme=light]` pins the original values so the explicit-light toggle wins over a dark OS preference, matching the existing token pattern.

UI tests + vite build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)