### PR TITLE
feat(update): brew installs run 'brew upgrade mur' instead of just printing it

### DIFF
--- a/mur-core/src/update/mod.rs
+++ b/mur-core/src/update/mod.rs
@@ -17,6 +17,23 @@ pub struct UpdateOptions {
 
 pub fn run(opts: UpdateOptions) -> Result<()> {
     let src = source::detect();
+    // Homebrew installs are upgraded through brew itself so the Cellar and
+    // formula bookkeeping stay consistent — run it instead of self-swapping.
+    if src == source::InstallSource::Homebrew {
+        if opts.check_only {
+            println!("Installed via Homebrew. Run: brew upgrade mur");
+            return Ok(());
+        }
+        println!("Installed via Homebrew — running: brew upgrade mur");
+        let status = std::process::Command::new("brew")
+            .args(["upgrade", "mur"])
+            .status()
+            .context("failed to run brew — upgrade manually: brew upgrade mur")?;
+        if !status.success() {
+            anyhow::bail!("brew upgrade mur failed ({status})");
+        }
+        return Ok(());
+    }
     if let Some(hint) = src.upgrade_hint() {
         println!("{hint}");
         return Ok(());


### PR DESCRIPTION
`mur update` already detects the install source (Cellar-resolved binary → Homebrew); for brew installs it only printed "Run: brew upgrade mur". It now executes `brew upgrade mur` directly — brew keeps its own Cellar/formula bookkeeping consistent, and `brew upgrade` exits 0 when already up to date. `--check` keeps the print-only behavior; a failed/missing brew fails loud with the manual command as fallback. Cargo installs keep the hint (cargo re-install semantics are less safe to run implicitly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)