### PR TITLE
feat(cli): shell-style ↑/↓ input history in the murmur composer

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -413,6 +413,12 @@ pub struct App {
     pub pending_suggestions: Vec<super::suggest::Suggestion>,
     /// The single suggestion currently shown as ghost placeholder text, if any.
     pub suggestion_ghost: Option<String>,
+    /// Sent-message history for shell-style ↑/↓ recall in the composer.
+    pub sent_history: Vec<String>,
+    /// Current position while browsing `sent_history` (None = not browsing).
+    pub hist_idx: Option<usize>,
+    /// Draft stashed when browsing starts; restored on ↓ past the newest.
+    pub hist_stash: String,
     /// Input-driven suggestions (spec §3.5): last input text observed by the
     /// debounce, last snapshot actually sent, and the pending deadline.
     pub panel_input_seen: String,
@@ -482,6 +488,9 @@ impl App {
             skills: Vec::new(),
             pending_suggestions: Vec::new(),
             suggestion_ghost: None,
+            sent_history: Vec::new(),
+            hist_idx: None,
+            hist_stash: String::new(),
             panel_input_seen: String::new(),
             panel_input_sent: String::new(),
             panel_input_deadline: None,
@@ -925,10 +934,63 @@ impl App {
                 }
                 self.messages.push(ChatMsg::agent_rendered(t.text));
             } else {
+                if role == Role::User {
+                    self.history_record(&t.text);
+                }
                 self.messages.push(ChatMsg::new(role, t.text));
             }
         }
         self.context_task_id = last_task;
+    }
+
+    // ── Composer input history (shell-style ↑/↓ recall) ────────────────────
+
+    /// Record a sent message for ↑ recall. Skips blanks and immediate
+    /// duplicates; always exits browsing mode.
+    pub fn history_record(&mut self, text: &str) {
+        if !text.trim().is_empty() && self.sent_history.last().map(String::as_str) != Some(text) {
+            self.sent_history.push(text.to_string());
+        }
+        self.hist_idx = None;
+        self.hist_stash.clear();
+    }
+
+    /// ↑ on the composer's first line: recall the previous sent message.
+    /// Returns false (key not consumed) when there is no history.
+    pub fn history_prev(&mut self) -> bool {
+        if self.sent_history.is_empty() {
+            return false;
+        }
+        let next = match self.hist_idx {
+            None => {
+                self.hist_stash = self.input_text();
+                self.sent_history.len() - 1
+            }
+            Some(0) => return true, // already at oldest — swallow the key
+            Some(i) => i - 1,
+        };
+        self.hist_idx = Some(next);
+        let text = self.sent_history[next].clone();
+        self.set_input(&text);
+        true
+    }
+
+    /// ↓ on the composer's last line while browsing: newer entry, or restore
+    /// the stashed draft past the newest. Returns false when not browsing.
+    pub fn history_next(&mut self) -> bool {
+        let Some(i) = self.hist_idx else {
+            return false;
+        };
+        if i + 1 < self.sent_history.len() {
+            self.hist_idx = Some(i + 1);
+            let text = self.sent_history[i + 1].clone();
+            self.set_input(&text);
+        } else {
+            self.hist_idx = None;
+            let stash = std::mem::take(&mut self.hist_stash);
+            self.set_input(&stash);
+        }
+        true
     }
 
     pub fn tick_spinner(&mut self) {
@@ -1265,6 +1327,29 @@ mod tests {
         );
         assert_eq!(parse_slash("/chan"), Some(SlashCmd::Channels(None)));
         assert_eq!(parse_slash("/channels x"), Some(SlashCmd::Channels(None)));
+    }
+
+    #[test]
+    fn input_history_recall_cycle() {
+        let home = tempdir().unwrap();
+        let mut a = app_at(&home);
+        a.history_record("first");
+        a.history_record("second");
+        a.history_record("second"); // consecutive dup skipped
+        assert_eq!(a.sent_history.len(), 2);
+
+        a.set_input("draft");
+        assert!(a.history_prev());
+        assert_eq!(a.input_text(), "second");
+        assert!(a.history_prev());
+        assert_eq!(a.input_text(), "first");
+        assert!(a.history_prev()); // at oldest — swallowed, unchanged
+        assert_eq!(a.input_text(), "first");
+        assert!(a.history_next());
+        assert_eq!(a.input_text(), "second");
+        assert!(a.history_next()); // past newest — draft restored
+        assert_eq!(a.input_text(), "draft");
+        assert!(!a.history_next()); // not browsing — key not consumed
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -845,6 +845,20 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
                     app.input.insert_newline();
                 }
                 KeyCode::Enter => submit(app, tx).await,
+                // Shell-style input history: ↑ on the first composer line
+                // recalls older sent messages; ↓ on the last line walks
+                // newer / restores the stashed draft. Anywhere else the
+                // arrows keep moving the cursor.
+                KeyCode::Up if app.input.cursor().0 == 0 => {
+                    if !app.history_prev() {
+                        app.input.input(key);
+                    }
+                }
+                KeyCode::Down if app.input.cursor().0 + 1 == app.input.lines().len() => {
+                    if !app.history_next() {
+                        app.input.input(key);
+                    }
+                }
                 KeyCode::Esc => {
                     let action =
                         esc_action(app.last_esc_at, app.streaming, app.input_text().is_empty());
@@ -1147,6 +1161,7 @@ async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
     if trimmed.is_empty() && app.pending_image.is_none() {
         return;
     }
+    app.history_record(&trimmed);
 
     if let Some(cmd) = parse_slash(&trimmed) {
         // Skills are surfaced in the completion menu as slash commands


### PR DESCRIPTION
murmur had no input-history recall at all — ↑/↓ only moved the composer cursor (or navigated the completion menu when open).

## Behavior
- **↑ on the first composer line** → recall previously sent messages, newest first; the in-progress draft is stashed.
- **↓ on the last line** → walk toward newer entries; past the newest, the stashed draft is restored.
- Arrows anywhere else keep moving the cursor; when the slash-menu / suggested-replies chooser is open it keeps owning ↑/↓ (dismiss with Esc, then browse history).
- Recorded on send (blank / consecutive-duplicate entries skipped); seeded from the loaded conversation's user turns on `--resume` and channel switches.

## Verification
Unit test covers the full recall cycle (record/dedup, prev to oldest, next past newest restores draft, not-browsing passthrough). tmux live test: send → ↑ shows the sent message in the composer → ↓ restores the empty draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)