### PR TITLE
fix(cli): /clear and /channels switch wipe the on-screen transcript

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -413,6 +413,10 @@ pub struct App {
     pub pending_suggestions: Vec<super::suggest::Suggestion>,
     /// The single suggestion currently shown as ghost placeholder text, if any.
     pub suggestion_ghost: Option<String>,
+    /// Set when the visible transcript no longer matches the conversation
+    /// (/clear, /channels switch): the event loop wipes screen + scrollback
+    /// and re-anchors a fresh viewport before the next draw.
+    pub wants_screen_wipe: bool,
     /// Sent-message history for shell-style ↑/↓ recall in the composer.
     pub sent_history: Vec<String>,
     /// Current position while browsing `sent_history` (None = not browsing).
@@ -488,6 +492,7 @@ impl App {
             skills: Vec::new(),
             pending_suggestions: Vec::new(),
             suggestion_ghost: None,
+            wants_screen_wipe: false,
             sent_history: Vec::new(),
             hist_idx: None,
             hist_stash: String::new(),
@@ -869,6 +874,7 @@ impl App {
         self.esc_hint = false;
         self.last_ctrl_c_at = None;
         self.ctrl_c_hint = false;
+        self.wants_screen_wipe = true;
         self.push_system("started a new conversation");
     }
 
@@ -886,6 +892,7 @@ impl App {
         self.streaming = false;
         self.hitl = None;
         self.cwd_sent = false;
+        self.wants_screen_wipe = true;
         self.load_history(turns);
         self.refresh_channel();
         Ok(())

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -496,8 +496,6 @@ fn rebuild_after_resize(
     app: &mut App,
     h: u16,
 ) -> Result<()> {
-    use crossterm::cursor::MoveTo;
-    use crossterm::terminal::{Clear, ClearType};
     // Let the reflow storm settle so we rebuild once, not per event.
     let mut size = crossterm::terminal::size()?;
     loop {
@@ -508,6 +506,18 @@ fn rebuild_after_resize(
         }
         size = now;
     }
+    purge_and_reanchor(terminal, h)?;
+    app.flushed_upto = 0;
+    Ok(())
+}
+
+/// Wipe the screen AND scrollback, then re-anchor a fresh Inline viewport
+/// of height `h` at the top-left. Shared by the resize rebuild and the
+/// /clear / channel-switch screen wipe. Caller must drop any live
+/// `EventStream` first.
+fn purge_and_reanchor(terminal: &mut Terminal<CrosstermBackend<Stdout>>, h: u16) -> Result<()> {
+    use crossterm::cursor::MoveTo;
+    use crossterm::terminal::{Clear, ClearType};
     crossterm::execute!(
         io::stdout(),
         MoveTo(0, 0),
@@ -527,7 +537,6 @@ fn rebuild_after_resize(
         ) {
             Ok(t) => {
                 *terminal = t;
-                app.flushed_upto = 0;
                 return Ok(());
             }
             Err(e) => {
@@ -576,6 +585,17 @@ async fn event_loop(
             }
         }
         app.sync_input_block();
+        // /clear or channel switch: the on-screen transcript no longer
+        // matches the conversation — wipe screen + scrollback and re-anchor
+        // so the fresh state (welcome or replayed channel) renders clean.
+        if app.render_mode == RenderMode::Inline && std::mem::take(&mut app.wants_screen_wipe) {
+            drop(events);
+            let desired = desired_viewport_h(app);
+            if purge_and_reanchor(terminal, desired).is_ok() {
+                viewport_h = desired;
+            }
+            events = EventStream::new();
+        }
         arm_input_debounce(app, StdInstant::now());
         // Flush settled messages into native scrollback BEFORE the draw so
         // the live viewport only ever paints the current streaming tail (or


### PR DESCRIPTION
## Problem
`/clear` reset the conversation state but the old transcript stayed on screen (native scrollback), with the "started a new conversation" line appended below — confusing mix of old and new. `/channels` switches had the same issue: the switched-to transcript replayed below the previous channel's messages.

## Fix
`start_new_session` / `switch_channel` set a `wants_screen_wipe` flag; the event loop (which owns the terminal + EventStream) wipes screen + scrollback and re-anchors a fresh Inline viewport before the next draw. The wipe reuses `purge_and_reanchor`, extracted from the #650 resize rebuild — same EventStream-drop + cursor-query-retry discipline, fail-open.

## Verification (tmux, live agent)
send → reply → `/clear`: scrollback capture is exactly the window height (zero residue), fresh conversation renders clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)