### PR TITLE
feat(agent): mur agent start — start a stopped agent

### DIFF
--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -36,6 +36,12 @@ pub enum AgentAction {
         /// Agent name
         name: String,
     },
+    /// Start a stopped agent: via its launchd/systemd service when one is
+    /// installed, else a detached (unsupervised) spawn of its runtime
+    Start {
+        /// Agent name
+        name: String,
+    },
     /// Stop a running agent (SIGTERM, then SIGKILL after timeout)
     Stop {
         /// Agent name

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -137,7 +137,7 @@ pub async fn cmd_cli(
     let lock = home.join("agents").join(&agent).join("running.lock");
     if !lock.exists() {
         eprintln!(
-            "Agent '{agent}' is not running. Start it first with:\n    mur agent install-service {agent}\nthen retry: mur agent cli {agent}"
+            "Agent '{agent}' is not running. Start it first with:\n    mur agent start {agent}\nthen retry: mur agent cli {agent}"
         );
         return Ok(());
     }

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -38,6 +38,7 @@ pub mod mcp;
 pub mod mcp_discover;
 pub mod mcp_login;
 pub mod mcp_registry;
+pub mod start;
 // Items exported for the Hub GUI (mur-hub-gui crate) — not used from the
 // mur binary itself, so suppress dead_code for the binary target.
 #[allow(dead_code)]
@@ -112,6 +113,7 @@ pub use skill::{
 };
 #[allow(unused_imports)]
 pub use snapshot::{cmd_snapshot_pull, cmd_snapshot_show};
+pub use start::cmd_start;
 #[allow(unused_imports)]
 pub use stats::{cmd_logs, cmd_stats};
 mod pending;

--- a/mur-core/src/cmd/agent/start.rs
+++ b/mur-core/src/cmd/agent/start.rs
@@ -1,0 +1,124 @@
+//! `mur agent start` — start a stopped agent.
+//!
+//! Three paths, in order:
+//! 1. already running (live `running.lock` pid) → no-op;
+//! 2. a service unit exists (launchd plist / systemd --user unit) → start it
+//!    through the service manager so supervision stays with launchd/systemd;
+//! 3. no unit (Hub-managed or ad-hoc agents) → spawn the per-agent runtime
+//!    symlink detached, with stdout/stderr appended to the agent's logs.
+//!    This is the escape hatch when the Hub isn't around to respawn its
+//!    sidecar — the process runs UNSUPERVISED (no auto-restart).
+
+use std::fs;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use mur_common::LockFile;
+
+use super::{pid_alive, resolve_bin_dir, resolve_mur_home};
+
+pub fn cmd_start(name: &str) -> Result<()> {
+    let mur_home = resolve_mur_home()?;
+    let agent_home = mur_home.join("agents").join(name);
+    if !agent_home.exists() {
+        bail!("agent '{name}' not found under {}", mur_home.display());
+    }
+
+    // 1. Already running?
+    let lock_path = agent_home.join("running.lock");
+    if let Ok(bytes) = fs::read(&lock_path)
+        && let Ok(lock) = serde_json::from_slice::<LockFile>(&bytes)
+        && pid_alive(lock.pid)
+    {
+        println!("agent '{name}' is already running (pid {})", lock.pid);
+        return Ok(());
+    }
+
+    // 2. Service manager owns it?
+    #[cfg(target_os = "macos")]
+    {
+        let plist = dirs::home_dir()
+            .context("no home dir")?
+            .join(format!("Library/LaunchAgents/run.mur.agent.{name}.plist"));
+        if plist.exists() {
+            let label = format!("run.mur.agent.{name}");
+            let uid = unsafe { libc::getuid() };
+            let kick = Command::new("launchctl")
+                .args(["kickstart", &format!("gui/{uid}/{label}")])
+                .output()?;
+            if kick.status.success() {
+                println!("started '{name}' via launchd ({label})");
+                return Ok(());
+            }
+            // Not loaded (e.g. after a manual bootout) — load brings it up
+            // by itself thanks to RunAtLoad.
+            let load = Command::new("launchctl")
+                .args(["load", "-w"])
+                .arg(&plist)
+                .output()?;
+            if load.status.success() {
+                println!("loaded + started '{name}' via launchd ({label})");
+                return Ok(());
+            }
+            bail!(
+                "launchd refused to start '{name}': kickstart: {} / load: {}",
+                String::from_utf8_lossy(&kick.stderr).trim(),
+                String::from_utf8_lossy(&load.stderr).trim()
+            );
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let unit = dirs::config_dir()
+            .context("no config dir")?
+            .join(format!("systemd/user/mur-agent-{name}.service"));
+        if unit.exists() {
+            let out = Command::new("systemctl")
+                .args(["--user", "start", &format!("mur-agent-{name}.service")])
+                .output()?;
+            if !out.status.success() {
+                bail!(
+                    "systemd refused to start '{name}': {}",
+                    String::from_utf8_lossy(&out.stderr).trim()
+                );
+            }
+            println!("started '{name}' via systemd --user");
+            return Ok(());
+        }
+    }
+
+    // 3. No unit — detached spawn of the per-agent symlink.
+    let symlink = resolve_bin_dir()?.join(format!("mur_agent_{name}"));
+    if !symlink.exists() {
+        bail!(
+            "no service unit and no runtime symlink at {} — create it with `mur agent create` or install a service with `mur agent install-service {name}`",
+            symlink.display()
+        );
+    }
+    let stdout = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(agent_home.join("stdout.log"))?;
+    let stderr = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(agent_home.join("stderr.log"))?;
+    let mut cmd = Command::new(&symlink);
+    cmd.arg("start")
+        .stdin(std::process::Stdio::null())
+        .stdout(stdout)
+        .stderr(stderr);
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0); // detach from our session so it survives us
+    }
+    let child = cmd
+        .spawn()
+        .with_context(|| format!("spawn {}", symlink.display()))?;
+    println!(
+        "started '{name}' (pid {}) — UNSUPERVISED: no auto-restart on crash or login.\nFor a persistent service run: mur agent install-service {name}",
+        child.id()
+    );
+    Ok(())
+}

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1313,6 +1313,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
         } => cmd::agent::cmd_create(&name, no_interactive, display_name, model, provider)?,
         AgentAction::List { json } => cmd::agent::cmd_list(json)?,
         AgentAction::Status { name } => cmd::agent::cmd_status(&name)?,
+        AgentAction::Start { name } => cmd::agent::cmd_start(&name)?,
         AgentAction::Stop { name } => cmd::agent::cmd_stop(&name)?,
         AgentAction::Restart {
             name,


### PR DESCRIPTION
## Why
`mur agent` had `stop` and `restart` but no `start`. The design bet was "agents run as launchd services, the supervisor starts them" — but that breaks down for **Hub-managed agents** (the concierge `mur` has no plist) and when the Hub GUI is wedged. Tonight the concierge died twice and the only recovery was a manual `nohup mur-agent-runtime --profile mur`. That manual step is exactly the missing `start`.

The old not-running hint in `mur agent cli` made it worse: it advised `install-service`, which would bolt a launchd supervisor onto a Hub-managed agent (double supervision). Now it says `mur agent start`.

## Behavior (three paths, in order)
1. **Already running** (live `running.lock` pid) → no-op.
2. **Service unit exists** (launchd plist / systemd --user unit) → start through the service manager (`launchctl kickstart`, falling back to `load -w`; `systemctl --user start`) so supervision stays where it belongs.
3. **No unit** (Hub-managed / ad-hoc) → detached spawn of the `mur_agent_<name>` symlink: own process group, PPID reparents to init, stdout/stderr appended to the agent's logs, and an explicit **UNSUPERVISED — no auto-restart** warning pointing at `install-service`.

Single-instance safety is unchanged: the flock guard + #648 lock owner-check make a redundant `start` fail cleanly.

## Verified live
- no-op on the running concierge (`already running (pid …)`);
- detached spawn: PID==PGID, PPID==1, `running.lock` written, startup logged to stderr.log, UNSUPERVISED warning printed;
- service path: exercised against real `aura-w*` fleet-worker plists.

## Follow-up (not in this PR)
`stop` on a **serviced** agent only SIGTERMs the pid, but the plist is `KeepAlive=true`, so launchd immediately respawns it — `stop` is effectively `restart` for launchd agents. A real stop needs `launchctl bootout`. Flagged for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)