### PR TITLE
feat(skill): bundled skill assets (scripts/) on import + injection

### DIFF
--- a/docs/superpowers/plans/2026-07-08-skill-bundled-assets.md
+++ b/docs/superpowers/plans/2026-07-08-skill-bundled-assets.md
@@ -1,0 +1,451 @@
+# Skill Bundled Assets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve a skill's sibling files (`scripts/`, assets) on import and tell the running agent where its skill lives on disk, so bundled scripts resolve and run.
+
+**Architecture:** Three isolated changes. (1) Import copies non-`SKILL.md` siblings into the installed skill dir with path-escape rejection. (2) `LoadedSkill` gains a `dir` field populated by the loader. (3) Layer-3 injection appends a one-line on-disk path hint when the skill dir carries a bundle. No new subsystem, no new CLI verb, no new security model — execution rides the agent's existing bash tool + trust gates.
+
+**Tech Stack:** Rust (edition 2024), `mur-core` (import), `mur-common` (loader/`LoadedSkill`), `mur-agent-runtime` (injection). Tests via `cargo nextest`.
+
+## Global Constraints
+
+- Rust edition 2024.
+- **No hardcoded values.** No hostile-extension blocklist (no threat basis); the shallow scan is path-escape + non-regular-file rejection only.
+- `mur-core` / `mur-common` test compile needs env: `ORT_STRATEGY=download` and `MUR_WEB_DIST=$HOME/Projects/mur-web/dist`. Prefix every test command with them.
+- Use `cargo nextest run`, **not** `cargo test` (plain `cargo test --workspace` fails ~7 tests spuriously in this repo).
+- Path-safety: a bundle entry must never write outside its own install dir. Reject `..` components, absolute paths, and symlinks resolving outside dest.
+- Nothing executes at import or injection time.
+- Single source file ≤ 800 lines — if `import.rs` crosses it, split the copy helper into a sibling module.
+
+**Env prefix used throughout (call it `$ENV`):**
+```bash
+ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist
+```
+
+---
+
+### Task 1: Import preserves skill siblings with path-safety
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/addon/import.rs` (phase-1 collect loop ~115-137; phase-2 write loop ~205-212; add `copy_bundle` helper + tests)
+
+**Interfaces:**
+- Consumes: existing `safe_member_name(&str) -> Result<()>`, `write_to_dir(&Path, &SkillManifest)`.
+- Produces: `fn copy_bundle(src_dir: &Path, dest_dir: &Path) -> anyhow::Result<()>` — copies every entry of `src_dir` except a top-level `SKILL.md` into `dest_dir`, recursively; returns `Err` on any path escape or symlink.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)] mod tests` block in `import.rs`:
+
+```rust
+#[test]
+fn copy_bundle_preserves_scripts_skips_skill_md() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(src.join("scripts")).unwrap();
+    std::fs::write(src.join("SKILL.md"), "body").unwrap();
+    std::fs::write(src.join("scripts/start-server.sh"), "#!/bin/sh\n").unwrap();
+    std::fs::write(src.join("helper.js"), "x").unwrap();
+
+    copy_bundle(&src, &dest).unwrap();
+
+    assert!(dest.join("scripts/start-server.sh").is_file());
+    assert!(dest.join("helper.js").is_file());
+    assert!(!dest.join("SKILL.md").exists(), "SKILL.md must not be copied");
+}
+
+#[test]
+fn copy_bundle_rejects_symlink_escape() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dest = tmp.path().join("dest");
+    std::fs::create_dir_all(&src).unwrap();
+    let secret = tmp.path().join("secret.txt");
+    std::fs::write(&secret, "s").unwrap();
+    std::os::unix::fs::symlink(&secret, src.join("link")).unwrap();
+
+    let err = copy_bundle(&src, &dest);
+    assert!(err.is_err(), "symlink in bundle must be rejected");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `$ENV cargo nextest run -p mur-core copy_bundle`
+Expected: FAIL — `cannot find function copy_bundle`.
+
+- [ ] **Step 3: Implement `copy_bundle`**
+
+Add near the other free functions in `import.rs` (after `safe_member_name`):
+
+```rust
+/// Recursively copy every entry of `src_dir` into `dest_dir`, skipping a
+/// top-level `SKILL.md` (the manifest is written separately). Rejects any
+/// symlink and any entry whose name is unsafe, so a bundle can never write
+/// outside its own install directory.
+fn copy_bundle(src_dir: &Path, dest_dir: &Path) -> anyhow::Result<()> {
+    copy_bundle_inner(src_dir, dest_dir, true)
+}
+
+fn copy_bundle_inner(src: &Path, dest: &Path, top: bool) -> anyhow::Result<()> {
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_str().context("non-UTF8 bundle filename")?;
+        if top && name_str == "SKILL.md" {
+            continue;
+        }
+        // Reject `.`, `..`, path separators, absolute-ish names.
+        if name_str == "." || name_str == ".." || name_str.contains('/') {
+            anyhow::bail!("unsafe bundle entry name: {name_str}");
+        }
+        // Reject symlinks outright (escape vector).
+        let ft = entry.file_type()?;
+        if ft.is_symlink() {
+            anyhow::bail!("bundle contains a symlink ({name_str}); refusing import");
+        }
+        let src_path = entry.path();
+        let dest_path = dest.join(name_str);
+        if ft.is_dir() {
+            fs::create_dir_all(&dest_path)?;
+            copy_bundle_inner(&src_path, &dest_path, false)?;
+        } else {
+            if let Some(parent) = dest_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(&src_path, &dest_path)?;
+        }
+    }
+    Ok(())
+}
+```
+
+Ensure `use anyhow::Context;` and `use std::path::Path;` are present (add if missing).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `$ENV cargo nextest run -p mur-core copy_bundle`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Carry the source dir into phase 2 and call `copy_bundle`**
+
+Change the pending vec to carry the source skill dir. At `import.rs:110`:
+
+```rust
+    let mut pending_skills: Vec<(PathBuf, SkillManifest, PathBuf)> = Vec::new();
+```
+
+In the phase-1 skills loop (~135), push the source dir `d`:
+
+```rust
+            pending_skills.push((dest, manifest, d.clone()));
+```
+
+In the phase-2 write loop (~205), copy the bundle after writing the manifest:
+
+```rust
+    for (dest, manifest, src_dir) in pending_skills {
+        write_to_dir(&dest, &manifest)
+            .with_context(|| format!("writing skill '{}'", manifest.name))?;
+        copy_bundle(&src_dir, &dest)
+            .with_context(|| format!("copying bundle for skill '{}'", manifest.name))?;
+    }
+```
+
+(Leave the `pending_cmds` loop unchanged — command skills carry no bundle in this first cut.)
+
+- [ ] **Step 6: Write the end-to-end import test**
+
+Add a test that drives the real import entry point with a skill dir containing `scripts/`. Follow the existing import-test pattern in this file (the one using `fs::create_dir_all(root.join("skills/brainstorm"))` at ~459). Assert the installed dest dir contains the script:
+
+```rust
+#[test]
+fn import_installs_skill_bundle_scripts() {
+    // Arrange a minimal plugin root with one skill that ships a script,
+    // mirroring the existing import test setup in this module, then invoke
+    // the same import function those tests call.
+    // After import, assert:
+    //   agents/<agent>/skills/<name>/scripts/run.sh exists.
+    // (Reuse the harness helper the sibling import tests use; do not
+    //  hand-roll a second harness.)
+}
+```
+
+Fill the body by copying the arrange/act lines from the nearest existing import test in the file and adding a `scripts/run.sh` to the source skill dir. Assert the file lands under the installed dir.
+
+- [ ] **Step 7: Run the full import test module**
+
+Run: `$ENV cargo nextest run -p mur-core addon::import`
+Expected: PASS (existing tests + the 3 new ones).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/addon/import.rs
+git commit -m "feat(skill): preserve skill bundle siblings on import"
+```
+
+---
+
+### Task 2: `LoadedSkill` carries its on-disk directory
+
+**Files:**
+- Modify: `mur-common/src/skill/loader.rs` (`LoadedSkill` struct ~35; `load_all` ~43-76; test helper `make`/callers)
+- Modify: `mur-agent-runtime/src/skills/injector.rs:140` (`loaded` test helper)
+- Modify: `mur-agent-runtime/src/skills/trigger_matcher.rs:139` (`sample` test helper)
+
+**Interfaces:**
+- Consumes: `agent_skills_dir(mur_home, agent) -> PathBuf`, `global_skill_dir(mur_home, name) -> PathBuf` (both in `mur_common::skill::store`).
+- Produces: `LoadedSkill.dir: PathBuf` — absolute path of the skill's install directory. Every construction site sets it.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `loader.rs` tests:
+
+```rust
+#[test]
+fn load_all_sets_agent_skill_dir() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path();
+    let sdir = home.join("agents").join("a1").join("skills").join("demo");
+    write_to_dir(&sdir, &make("demo")).unwrap();
+
+    let loaded = load_all(home, "a1");
+    let demo = loaded.iter().find(|s| s.name == "demo").unwrap();
+    assert_eq!(demo.dir, sdir);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `$ENV cargo nextest run -p mur-common load_all_sets_agent_skill_dir`
+Expected: FAIL — `no field dir on LoadedSkill`.
+
+- [ ] **Step 3: Add the field**
+
+In `LoadedSkill` (loader.rs:35):
+
+```rust
+pub struct LoadedSkill {
+    pub name: String,
+    pub manifest: SkillManifest,
+    pub trust: TrustLevel,
+    pub scope: SkillScope,
+    pub content_hash: String,
+    /// Absolute install directory of this skill (holds skill.yaml + any bundle).
+    pub dir: std::path::PathBuf,
+}
+```
+
+- [ ] **Step 4: Populate `dir` in `load_all`**
+
+`load_one` doesn't know the agent name, so set `dir` in `load_all` after each `load_one` returns. In the agent loop (~51-56):
+
+```rust
+            if let Some(mut loaded) = load_one(mur_home, &name, SkillScope::Agent, &trust, |m, n| {
+                local::load_installed_agent(m, agent_name, n)
+            }) {
+                loaded.dir = crate::skill::store::agent_skills_dir(mur_home, agent_name).join(&name);
+                seen_names.insert(loaded.name.clone());
+                out.push(loaded);
+            }
+```
+
+In the global loop (~64-71):
+
+```rust
+            if let Some(mut loaded) = load_one(
+                mur_home, &name, SkillScope::Global, &trust, local::load_installed,
+            ) {
+                loaded.dir = crate::skill::store::global_skill_dir(mur_home, &name);
+                out.push(loaded);
+            }
+```
+
+In `load_one`, set a placeholder so both construction sites compile:
+
+```rust
+        Some(LoadedSkill {
+            name: name.into(),
+            manifest,
+            trust: pinned.level,
+            scope,
+            content_hash: hash,
+            dir: std::path::PathBuf::new(), // overwritten by load_all
+        })
+```
+
+Do the same for the unpinned `LoadedSkill { .. }` branch.
+
+- [ ] **Step 5: Fix the two runtime test helpers**
+
+`injector.rs:140` `loaded(...)` and `trigger_matcher.rs:139` `sample()` build `LoadedSkill` literals — add `dir: std::path::PathBuf::new(),` to each so they compile.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `$ENV cargo nextest run -p mur-common -p mur-agent-runtime skill`
+Expected: PASS (new test + existing skill tests compile and pass).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-common/src/skill/loader.rs \
+        mur-agent-runtime/src/skills/injector.rs \
+        mur-agent-runtime/src/skills/trigger_matcher.rs
+git commit -m "feat(skill): LoadedSkill carries its install directory"
+```
+
+---
+
+### Task 3: Layer-3 injection appends the bundle path hint
+
+**Files:**
+- Modify: `mur-agent-runtime/src/skills/trigger_matcher.rs` (add `bundle_hint` helper + test)
+- Modify: `mur-agent-runtime/src/task_runner.rs:546-550` (append hint to body)
+
+**Interfaces:**
+- Consumes: `LoadedSkill.dir` (Task 2), `layer3_body`, `format_layer3`.
+- Produces: `fn bundle_hint(dir: &Path) -> Option<String>` — `Some(line)` if `dir` contains any entry besides `skill.yaml`; else `None`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `trigger_matcher.rs` tests:
+
+```rust
+#[test]
+fn bundle_hint_present_when_extra_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("skill.yaml"), "x").unwrap();
+    std::fs::create_dir_all(tmp.path().join("scripts")).unwrap();
+    let hint = bundle_hint(tmp.path()).unwrap();
+    assert!(hint.contains(&tmp.path().display().to_string()));
+    assert!(hint.contains("scripts"));
+}
+
+#[test]
+fn bundle_hint_absent_when_only_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("skill.yaml"), "x").unwrap();
+    assert!(bundle_hint(tmp.path()).is_none());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `$ENV cargo nextest run -p mur-agent-runtime bundle_hint`
+Expected: FAIL — `cannot find function bundle_hint`.
+
+- [ ] **Step 3: Implement `bundle_hint`**
+
+Add to `trigger_matcher.rs` (with `use std::path::Path;` present):
+
+```rust
+/// If the skill's install directory holds anything besides `skill.yaml`,
+/// return a one-line hint telling the agent where the bundle lives so paths
+/// like `scripts/start-server.sh` resolve. Returns None for asset-free skills.
+pub fn bundle_hint(dir: &Path) -> Option<String> {
+    let mut has_bundle = false;
+    for entry in std::fs::read_dir(dir).ok()? {
+        let name = entry.ok()?.file_name();
+        if name != "skill.yaml" {
+            has_bundle = true;
+            break;
+        }
+    }
+    if !has_bundle {
+        return None;
+    }
+    Some(format!(
+        "\n\nBundled files for this skill are on disk at: {0}\n\
+         (e.g. run a script with the bash tool: `bash {0}/scripts/<file>`)",
+        dir.display()
+    ))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `$ENV cargo nextest run -p mur-agent-runtime bundle_hint`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire the hint into injection**
+
+In `task_runner.rs`, at the layer-3 build (~546-550), append the hint to `body` before formatting:
+
+```rust
+            let Some(mut body) = layer3_body(&loaded.manifest, &inventory) else {
+                continue;
+            };
+            if let Some(hint) = crate::skills::trigger_matcher::bundle_hint(&loaded.dir) {
+                body.push_str(&hint);
+            }
+            layer3.push('\n');
+            layer3.push_str(&format_layer3(&loaded.name, loaded.trust, &body));
+```
+
+- [ ] **Step 6: Run the runtime skill tests**
+
+Run: `$ENV cargo nextest run -p mur-agent-runtime skills`
+Expected: PASS.
+
+- [ ] **Step 7: Full check + clippy**
+
+Run: `$ENV cargo nextest run -p mur-core -p mur-common -p mur-agent-runtime`
+Run: `$ENV cargo clippy -p mur-core -p mur-common -p mur-agent-runtime -- -D warnings`
+Expected: PASS, no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mur-agent-runtime/src/skills/trigger_matcher.rs \
+        mur-agent-runtime/src/task_runner.rs
+git commit -m "feat(skill): inject bundle path hint for skills that ship assets"
+```
+
+---
+
+### Task 4: Manual end-to-end verification (concierge `mur`)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Re-import a bundled skill**
+
+```bash
+mur agent skill remove mur brainstorming 2>/dev/null || true
+mur agent skill import mur <path-to-superpowers/skills/brainstorming-plugin-root>
+```
+(Use whatever the existing import subcommand is — check `mur agent skill --help`.)
+
+- [ ] **Step 2: Confirm the bundle landed on disk**
+
+```bash
+ls -R ~/.mur/agents/mur/skills/brainstorming
+```
+Expected: `skill.yaml` **plus** `scripts/start-server.sh`, `helper.js`, etc.
+
+- [ ] **Step 3: Confirm the path hint reaches the agent**
+
+Trigger the skill in a `mur agent cli mur` session and confirm the injected skill text contains the `Bundled files for this skill are on disk at: …` line. If the agent can `bash <dir>/scripts/start-server.sh`, parity is proven for the concierge.
+
+- [ ] **Step 4: Note the documented limitation**
+
+No action — confirm the spec's non-goal holds: a headless agent runs the script but shows no browser. Nothing to fix.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 Storage (assets beside skill.yaml) → falls out of Task 1 (copy into dest dir).
+- §2 Import preserve + path-safety → Task 1 (`copy_bundle`, symlink/escape rejection, source-dir plumbing).
+- §2 shallow scan → Task 1: implemented as symlink + unsafe-name rejection (the honest form; no extension blocklist, per Global Constraints).
+- §3 Injection resolved line → Task 3 (`bundle_hint` + wiring); depends on Task 2 (`LoadedSkill.dir`).
+- §4 Security (reuse trust/HITL, path-safety new check, no auto-run) → Task 1 path-safety; no execution added anywhere.
+- §5 Testing (import-preserve, import-reject, inject-present, inject-absent) → Task 1 steps 1/6, Task 3 step 1.
+- §6 Non-goals → nothing in the plan adds a CLI verb, sandbox, or browser-forwarding.
+
+**Placeholder scan:** Task 1 Step 6 and Task 4 reference "the existing import-test harness / import subcommand" rather than inlining — deliberate, because the exact harness helper and subcommand name must be read from the file at execution time; the step says which sibling to copy. All code-bearing steps show real code.
+
+**Type consistency:** `copy_bundle(&Path, &Path) -> Result<()>`, `LoadedSkill.dir: PathBuf`, `bundle_hint(&Path) -> Option<String>` used identically across definition and call sites. `pending_skills` tuple widened to 3-arity consistently in push and consume.

--- a/docs/superpowers/specs/2026-07-08-skill-bundled-assets-design.md
+++ b/docs/superpowers/specs/2026-07-08-skill-bundled-assets-design.md
@@ -1,0 +1,158 @@
+# Skill Bundled Assets — Design
+
+**Date:** 2026-07-08
+**Status:** Design (approved for planning)
+**Approach:** A — "skill is a directory + resolved path"
+
+## Problem
+
+MUR flattens an imported skill down to a single `skill.yaml`. When a skill
+ships sibling files — e.g. obra/superpowers `brainstorming` carries
+`scripts/frame-template.html`, `scripts/helper.js`, `scripts/server.cjs`,
+`scripts/start-server.sh`, `scripts/stop-server.sh` — those files are **dropped
+at import**. The installed skill is a lone `skill.yaml`, so any instruction in
+the skill body that runs a bundled script (`bash scripts/start-server.sh`) has
+nothing to resolve against.
+
+Three facts cause this, across three layers:
+
+- **Import** (`mur-core/src/cmd/agent/addon/import.rs`): reads only `SKILL.md`
+  per skill dir; every sibling is ignored.
+- **Storage:** a skill installs to `~/.mur/agents/<agent>/skills/<name>/skill.yaml`
+  — one file, no co-located assets.
+- **Runtime:** skill content is injected as prompt text
+  (`mur-agent-runtime/src/skills/{injector,trigger_matcher}.rs`). The agent is
+  never told where its skill lives on disk, so no path resolves.
+
+## Goal
+
+A skill can ship sibling files; the running agent can **read and execute** them
+using its existing file and bash tools. This delivers full superpowers parity
+for the case that matters — the concierge `mur` agent, which runs on the user's
+Mac where a human and a browser are present.
+
+## Non-goals
+
+- **No browser-forwarding.** A headless agent (remote / fleet) will *run* a
+  bundled script and bind localhost, but no human sees a served page. This is a
+  documented limitation, not a defect. Fixing it would require a real
+  browser-forwarding subsystem and is explicitly out of scope.
+- **No new `mur agent skill run <name> <script>` verb.** Execution goes through
+  the agent's existing bash tool, not a new CLI surface.
+- **No new sandbox or entitlement concept** beyond the tool entitlements the
+  agent already runs under.
+
+## Approach A — why this is small
+
+"Full parity" sounds like "build a script-execution subsystem." It is not. A
+MUR agent already has:
+
+- a **bash tool with a per-call `cwd`** (the same mechanism fleet worktree
+  execution uses),
+- **node/bash on the host**,
+- an **import-time trust scan** (`scan_or_block`) and **bundle signing / TOFU**
+  (`skill_bundle`, `skill_verify`).
+
+The only missing facts are (1) the bundle files are discarded and (2) the agent
+doesn't know its skill's directory. Fix those two and parity falls out. No new
+subsystem, no new security model.
+
+## Design
+
+### 1. Storage — no new format
+
+A skill is already a directory. Bundled files live **beside** `skill.yaml` in
+that same directory, preserving the source layout:
+
+```
+~/.mur/agents/<agent>/skills/<name>/
+  skill.yaml            # content: source of truth (unchanged)
+  scripts/
+    start-server.sh
+    server.cjs
+    helper.js
+    frame-template.html
+    stop-server.sh
+```
+
+No manifest field, no asset registry, no separate store. `skill.yaml` remains
+the single source of truth for skill *content*; the directory is the *bundle*.
+
+### 2. Import — preserve siblings
+
+In `addon/import.rs`, after `skill_md_to_manifest` produces the manifest and
+`scan_or_block` clears it, recursively copy every entry in the **source** skill
+directory except `SKILL.md` into the install destination.
+
+- One recursive copy into `dest`.
+- **Path-safety check (new):** reject any bundle entry that would escape
+  `dest` — path components containing `..`, absolute paths, or symlinks that
+  resolve outside `dest`. Reuse the intent of `safe_member_name`. On a rejected
+  entry, fail the import with a clear error rather than silently skipping.
+- `scan_or_block` gains a **shallow** scan over copied file names/extensions so
+  an obviously-hostile payload can block the import. The *trust decision* is
+  unchanged: the bundle inherits the skill's install trust / signature, exactly
+  as the skill body already does.
+- The same copy applies to the `commands/` install path only if a command
+  skill ships siblings; in practice only `skills/<dir>/` bundles carry assets,
+  so the first cut wires the `skills/` loop and leaves `commands/` as-is.
+
+### 3. Injection — one resolved line
+
+At the layer-3 injection call site (`mur-agent-runtime` task_runner, where
+`mur_home`, agent name, and skill name are all in scope), the skill directory
+is `agent_skills_dir(mur_home, agent).join(name)` — already computable, no new
+field threaded through `layer3_body`.
+
+After building the layer-3 body: if the skill directory contains **anything
+besides `skill.yaml`**, append:
+
+```
+Bundled files for this skill are on disk at: <abs skill dir>
+(e.g. run a script with the bash tool: `bash <abs skill dir>/scripts/foo.sh`)
+```
+
+If the directory holds only `skill.yaml`, append nothing (byte-identical to
+today's behavior for asset-free skills).
+
+That is the entire runtime change. The agent's existing bash tool (`cwd`) and
+file tools do the rest.
+
+### 4. Security
+
+- **Reuse, don't invent.** Script execution is already gated by the agent's
+  bash-tool entitlements and the HITL risk gate. Imported scripts are
+  third-party code and inherit the skill's install trust (TOFU / signature via
+  the existing `skill_bundle` / `skill_verify` path) — the same trust basis the
+  injected skill *body* already relies on.
+- **Path safety at import** (§2) is the one genuinely new check: a bundle
+  cannot write outside its own install directory.
+- **No auto-run.** Nothing executes at import or at injection time. A script
+  runs only if the agent's own reasoning plus the bash-tool gate allow it.
+
+### 5. Testing
+
+Minimal, targeted:
+
+- **Import — preserve:** a source skill with `scripts/foo.sh` imports so that
+  `foo.sh` lands in the installed skill dir.
+- **Import — reject escape:** a bundle entry `../escape` (or an out-of-dir
+  symlink) fails the import.
+- **Injection — present:** a skill dir containing a bundled file yields a
+  layer-3 body that includes the on-disk path line.
+- **Injection — absent:** a skill dir with only `skill.yaml` yields no path
+  line.
+
+## Affected code
+
+| Layer | File | Change |
+|-------|------|--------|
+| Import | `mur-core/src/cmd/agent/addon/import.rs` | copy non-`SKILL.md` siblings into dest; path-safety check |
+| Import scan | `addon/import.rs` (`scan_or_block` call path) | shallow scan of copied file names |
+| Injection | `mur-agent-runtime/src/skills/` (layer-3 call site) | append resolved skill-dir path line when bundle present |
+
+## Limitation restated
+
+Parity is complete for agents co-located with a human (the concierge `mur`).
+For headless agents, bundled scripts execute but any browser-facing half is
+inert. Browser-forwarding is a separate, larger effort and is out of scope.

--- a/mur-agent-runtime/src/skills/injector.rs
+++ b/mur-agent-runtime/src/skills/injector.rs
@@ -157,6 +157,7 @@ content:
             trust,
             scope: SkillScope::Global,
             content_hash: String::new(),
+            dir: std::path::PathBuf::new(),
         }
     }
 
@@ -174,6 +175,7 @@ content:
                 trust: TrustLevel::Verified,
                 scope: SkillScope::Global,
                 content_hash: String::new(),
+                dir: std::path::PathBuf::new(),
             }
         };
         let skills = vec![mk("u", ""), mk("p", "scope: project\nproject: /repo\n")];
@@ -233,6 +235,7 @@ content:
                 trust: TrustLevel::Verified,
                 scope: SkillScope::Global,
                 content_hash: String::new(),
+                dir: std::path::PathBuf::new(),
             }
         };
         let skills = vec![mk("u", ""), mk("f", "scope: fleet\nfleet: dev\n")];
@@ -361,6 +364,7 @@ content:
                 trust: TrustLevel::Verified,
                 scope: SkillScope::Global,
                 content_hash: String::new(),
+                dir: std::path::PathBuf::new(),
             }
         };
         let skills = vec![mk("u", ""), mk("ts", "scope: team\nteam: org-x\n")];
@@ -398,6 +402,7 @@ content:
             trust: TrustLevel::Verified,
             scope: SkillScope::Global,
             content_hash: String::new(),
+            dir: std::path::PathBuf::new(),
         };
         let result = inject_layer2(
             &[s],

--- a/mur-agent-runtime/src/skills/trigger_matcher.rs
+++ b/mur-agent-runtime/src/skills/trigger_matcher.rs
@@ -159,6 +159,7 @@ triggers:
             trust: TrustLevel::Verified,
             scope: SkillScope::Global,
             content_hash: String::new(),
+            dir: std::path::PathBuf::new(),
         }
     }
 
@@ -199,6 +200,7 @@ triggers:
             trust: TrustLevel::Sandboxed,
             scope: SkillScope::Global,
             content_hash: String::new(),
+            dir: std::path::PathBuf::new(),
         };
         let triggers = register_from(&[s]);
         assert!(triggers.is_empty());

--- a/mur-agent-runtime/src/skills/trigger_matcher.rs
+++ b/mur-agent-runtime/src/skills/trigger_matcher.rs
@@ -130,11 +130,51 @@ pub fn format_layer3(skill_name: &str, trust: TrustLevel, body: &str) -> String 
     )
 }
 
+/// If the skill's install directory holds anything besides `skill.yaml`,
+/// return a one-line hint telling the agent where the bundle lives so paths
+/// like `scripts/start-server.sh` resolve. Returns None for asset-free skills
+/// (and, fail-safe, when the directory can't be read).
+pub fn bundle_hint(dir: &std::path::Path) -> Option<String> {
+    let mut has_bundle = false;
+    for entry in std::fs::read_dir(dir).ok()? {
+        let Ok(entry) = entry else { continue };
+        if entry.file_name() != "skill.yaml" {
+            has_bundle = true;
+            break;
+        }
+    }
+    if !has_bundle {
+        return None;
+    }
+    Some(format!(
+        "\n\nBundled files for this skill are on disk at: {0}\n\
+         (e.g. run a script with the bash tool: `bash {0}/scripts/<file>`)",
+        dir.display()
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use mur_common::skill::loader::SkillScope;
     use mur_common::skill::parse_canonical;
+
+    #[test]
+    fn bundle_hint_present_when_extra_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("skill.yaml"), "x").unwrap();
+        std::fs::create_dir_all(tmp.path().join("scripts")).unwrap();
+        let hint = bundle_hint(tmp.path()).unwrap();
+        assert!(hint.contains(&tmp.path().display().to_string()));
+        assert!(hint.contains("scripts"));
+    }
+
+    #[test]
+    fn bundle_hint_absent_when_only_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("skill.yaml"), "x").unwrap();
+        assert!(bundle_hint(tmp.path()).is_none());
+    }
 
     fn sample() -> LoadedSkill {
         let yaml = r#"

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -543,9 +543,12 @@ impl TaskRunner {
             let inventory = McpInventory::from_tool_names(
                 self.tools.iter().map(|t| t.name().to_string()).collect(),
             );
-            let Some(body) = layer3_body(&loaded.manifest, &inventory) else {
+            let Some(mut body) = layer3_body(&loaded.manifest, &inventory) else {
                 continue;
             };
+            if let Some(hint) = crate::skills::trigger_matcher::bundle_hint(&loaded.dir) {
+                body.push_str(&hint);
+            }
             layer3.push('\n');
             layer3.push_str(&format_layer3(&loaded.name, loaded.trust, &body));
             suppress_names.insert(loaded.name.as_str());

--- a/mur-common/src/skill/loader.rs
+++ b/mur-common/src/skill/loader.rs
@@ -38,6 +38,8 @@ pub struct LoadedSkill {
     pub trust: TrustLevel,
     pub scope: SkillScope,
     pub content_hash: String,
+    /// Absolute install directory of this skill (holds skill.yaml + any bundle).
+    pub dir: std::path::PathBuf,
 }
 
 pub fn load_all(mur_home: &Path, agent_name: &str) -> Vec<LoadedSkill> {
@@ -48,9 +50,12 @@ pub fn load_all(mur_home: &Path, agent_name: &str) -> Vec<LoadedSkill> {
     // Per-agent first (wins on name collision)
     if let Ok(names) = local::list_installed_agent(mur_home, agent_name) {
         for name in names {
-            if let Some(loaded) = load_one(mur_home, &name, SkillScope::Agent, &trust, |m, n| {
-                local::load_installed_agent(m, agent_name, n)
-            }) {
+            if let Some(mut loaded) =
+                load_one(mur_home, &name, SkillScope::Agent, &trust, |m, n| {
+                    local::load_installed_agent(m, agent_name, n)
+                })
+            {
+                loaded.dir = crate::skill::store::agent_skill_dir(mur_home, agent_name).join(&name);
                 seen_names.insert(loaded.name.clone());
                 out.push(loaded);
             }
@@ -61,13 +66,14 @@ pub fn load_all(mur_home: &Path, agent_name: &str) -> Vec<LoadedSkill> {
             if seen_names.contains(&name) {
                 continue;
             }
-            if let Some(loaded) = load_one(
+            if let Some(mut loaded) = load_one(
                 mur_home,
                 &name,
                 SkillScope::Global,
                 &trust,
                 local::load_installed,
             ) {
+                loaded.dir = crate::skill::store::global_skill_dir(mur_home, &name);
                 out.push(loaded);
             }
         }
@@ -129,6 +135,7 @@ where
             trust: pinned.level,
             scope,
             content_hash: hash,
+            dir: std::path::PathBuf::new(), // overwritten by load_all
         })
     } else {
         // Unpinned = first-load Sandboxed.
@@ -138,6 +145,7 @@ where
             trust: TrustLevel::Sandboxed,
             scope,
             content_hash: hash,
+            dir: std::path::PathBuf::new(), // overwritten by load_all
         })
     }
 }
@@ -147,6 +155,18 @@ mod tests {
     use super::*;
     use crate::skill::{parse_canonical, write_to_dir};
     use tempfile::tempdir;
+
+    #[test]
+    fn load_all_sets_agent_skill_dir() {
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        let sdir = home.join("agents").join("a1").join("skills").join("demo");
+        write_to_dir(&sdir, &make("demo")).unwrap();
+
+        let loaded = load_all(home, "a1");
+        let demo = loaded.iter().find(|s| s.name == "demo").unwrap();
+        assert_eq!(demo.dir, sdir);
+    }
 
     fn make(name: &str) -> SkillManifest {
         parse_canonical(&format!(

--- a/mur-core/src/cmd/agent/addon/import.rs
+++ b/mur-core/src/cmd/agent/addon/import.rs
@@ -5,7 +5,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 
 use mur_common::agent::{AddonRef, McpServerEntry};
 use mur_common::skill::SkillManifest;
@@ -28,6 +28,46 @@ pub fn safe_member_name(n: &str) -> Result<()> {
     if n.is_empty() || n.contains('/') || n.contains('\\') || n.contains("..") || n.starts_with('.')
     {
         bail!("unsafe add-on member name: {n:?}");
+    }
+    Ok(())
+}
+
+/// Recursively copy every entry of `src_dir` into `dest_dir`, skipping a
+/// top-level `SKILL.md` (the manifest is written separately). Rejects any
+/// symlink and any entry whose name is unsafe, so a bundle can never write
+/// outside its own install directory.
+fn copy_bundle(src_dir: &Path, dest_dir: &Path) -> anyhow::Result<()> {
+    copy_bundle_inner(src_dir, dest_dir, true)
+}
+
+fn copy_bundle_inner(src: &Path, dest: &Path, top: bool) -> anyhow::Result<()> {
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_str().context("non-UTF8 bundle filename")?;
+        if top && name_str == "SKILL.md" {
+            continue;
+        }
+        // Reject `.`, `..`, path separators, absolute-ish names.
+        if name_str == "." || name_str == ".." || name_str.contains('/') {
+            anyhow::bail!("unsafe bundle entry name: {name_str}");
+        }
+        // Reject symlinks outright (escape vector).
+        let ft = entry.file_type()?;
+        if ft.is_symlink() {
+            anyhow::bail!("bundle contains a symlink ({name_str}); refusing import");
+        }
+        let src_path = entry.path();
+        let dest_path = dest.join(name_str);
+        if ft.is_dir() {
+            fs::create_dir_all(&dest_path)?;
+            copy_bundle_inner(&src_path, &dest_path, false)?;
+        } else {
+            if let Some(parent) = dest_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(&src_path, &dest_path)?;
+        }
     }
     Ok(())
 }
@@ -107,7 +147,7 @@ pub fn cmd_addon_import(
     // All checks must pass before a single byte is written.
 
     // Pending skills/commands: (dest_path, manifest)
-    let mut pending_skills: Vec<(PathBuf, SkillManifest)> = Vec::new();
+    let mut pending_skills: Vec<(PathBuf, SkillManifest, PathBuf)> = Vec::new();
     let mut pending_cmds: Vec<(PathBuf, SkillManifest)> = Vec::new();
     // Pending MCP entries.
     let mut pending_mcp: Vec<PendingMcp> = Vec::new();
@@ -132,7 +172,7 @@ pub fn cmd_addon_import(
                     manifest.name
                 );
             }
-            pending_skills.push((dest, manifest));
+            pending_skills.push((dest, manifest, d.clone()));
         }
     }
 
@@ -202,10 +242,12 @@ pub fn cmd_addon_import(
 
     // 2a. Write skills.
     let mut skill_members: Vec<String> = Vec::new();
-    for (dest, manifest) in pending_skills {
+    for (dest, manifest, src_dir) in pending_skills {
         let skill_name = manifest.name.clone();
         write_to_dir(&dest, &manifest)
             .map_err(|e| anyhow::anyhow!("write skill {}: {e}", skill_name))?;
+        copy_bundle(&src_dir, &dest)
+            .with_context(|| format!("copying bundle for skill '{skill_name}'"))?;
         skill_members.push(skill_name);
     }
 
@@ -489,6 +531,67 @@ mod tests {
             }
         });
         fs::write(root.join(".mcp.json"), serde_json::to_string(&mcp).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn copy_bundle_preserves_scripts_skips_skill_md() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let dest = tmp.path().join("dest");
+        fs::create_dir_all(src.join("scripts")).unwrap();
+        fs::write(src.join("SKILL.md"), "body").unwrap();
+        fs::write(src.join("scripts/start-server.sh"), "#!/bin/sh\n").unwrap();
+        fs::write(src.join("helper.js"), "x").unwrap();
+
+        copy_bundle(&src, &dest).unwrap();
+
+        assert!(dest.join("scripts/start-server.sh").is_file());
+        assert!(dest.join("helper.js").is_file());
+        assert!(
+            !dest.join("SKILL.md").exists(),
+            "SKILL.md must not be copied"
+        );
+    }
+
+    #[test]
+    fn copy_bundle_rejects_symlink_escape() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        let dest = tmp.path().join("dest");
+        fs::create_dir_all(&src).unwrap();
+        let secret = tmp.path().join("secret.txt");
+        fs::write(&secret, "s").unwrap();
+        std::os::unix::fs::symlink(&secret, src.join("link")).unwrap();
+
+        let err = copy_bundle(&src, &dest);
+        assert!(err.is_err(), "symlink in bundle must be rejected");
+    }
+
+    #[test]
+    fn import_installs_skill_bundle_scripts() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        unsafe {
+            std::env::set_var("MUR_HOME", home);
+        }
+        write_agent(home, "alice");
+        let plugin = home.join("sample-plugin");
+        write_plugin(&plugin);
+        // Add a bundled script sibling next to SKILL.md.
+        fs::create_dir_all(plugin.join("skills/brainstorm/scripts")).unwrap();
+        fs::write(
+            plugin.join("skills/brainstorm/scripts/run.sh"),
+            "#!/bin/sh\necho hi\n",
+        )
+        .unwrap();
+
+        cmd_addon_import("alice", plugin.to_str().unwrap(), None, false).unwrap();
+
+        assert!(
+            home.join("agents/alice/skills/brainstorm/scripts/run.sh")
+                .is_file()
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/addon/import.rs
+++ b/mur-core/src/cmd/agent/addon/import.rs
@@ -553,6 +553,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn copy_bundle_rejects_symlink_escape() {
         let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Lets an imported skill ship sibling files (`scripts/`, assets) and makes them usable by the running agent. Superpowers skills like `brainstorming` carry `scripts/start-server.sh`, `helper.js`, etc.; today MUR flattens a skill to a lone `skill.yaml` and **drops** the bundle. This restores full parity for agents co-located with a human (the concierge `mur`) with **no new subsystem** — execution rides the agent's existing bash tool + trust gates (design approach A).

Three focused changes:

1. **Import preserves siblings** (`addon/import.rs`) — `copy_bundle` copies every non-`SKILL.md` entry into the installed skill dir, rejecting symlinks and unsafe names so a bundle can never write outside its own dir. `pending_skills` widened to carry the source dir into the phase-2 write loop.
2. **`LoadedSkill.dir`** (`mur-common` loader) — skills now know their on-disk directory, set in `load_all` for both agent and global scope.
3. **Bundle path hint** (`trigger_matcher` + `task_runner`) — `bundle_hint` appends a one-line on-disk-path line inside the `<skill-instruction>` element when the skill dir carries a bundle, so `bash <dir>/scripts/foo.sh` resolves. Fail-safe `None` on I/O error.

## Non-goals (unchanged)

No new CLI verb, no sandbox, no hostile-extension blocklist, no browser-forwarding. Headless agents run bundled scripts but show no browser — documented limitation.

## Tests

- `nextest -p mur-core addon::import` → 18 passed (incl. new `copy_bundle_preserves_scripts_skips_skill_md`, `copy_bundle_rejects_symlink_escape`, `import_installs_skill_bundle_scripts` driving the real `cmd_addon_import`)
- `nextest -p mur-common -p mur-agent-runtime skill` → 236 passed (incl. `load_all_sets_agent_skill_dir`)
- `nextest -p mur-agent-runtime skills` → 26 passed (incl. `bundle_hint` present/absent)
- clippy clean on the runtime

## Follow-ups (non-blocking, from final review)

- Hoist the bundle symlink/unsafe pre-scan into import phase 1 so the "all checks before any write" invariant also covers bundles (currently a failed bundle copy can orphan a skill dir).
- `bundle_hint` counts `.DS_Store` etc. as a bundle (cosmetic spurious hint).
- Extract a `skill.yaml` filename constant (matches existing store.rs convention).

## Not yet done

Live-agent E2E (re-import into the running concierge and confirm the hint appears in a session) — needs this branch installed onto the production concierge; logic is covered by the automated tests above.

Design: `docs/superpowers/specs/2026-07-08-skill-bundled-assets-design.md`
Plan: `docs/superpowers/plans/2026-07-08-skill-bundled-assets.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)