### PR TITLE
fix(skill): restore import atomicity for bundles + ignore dotfiles in hint

### DIFF
--- a/mur-agent-runtime/src/skills/trigger_matcher.rs
+++ b/mur-agent-runtime/src/skills/trigger_matcher.rs
@@ -130,18 +130,23 @@ pub fn format_layer3(skill_name: &str, trust: TrustLevel, body: &str) -> String 
     )
 }
 
-/// If the skill's install directory holds anything besides `skill.yaml`,
-/// return a one-line hint telling the agent where the bundle lives so paths
-/// like `scripts/start-server.sh` resolve. Returns None for asset-free skills
-/// (and, fail-safe, when the directory can't be read).
+/// If the skill's install directory holds a real bundled file (anything besides
+/// `skill.yaml` and hidden dotfiles like `.DS_Store`), return a one-line hint
+/// telling the agent where the bundle lives so paths like
+/// `scripts/start-server.sh` resolve. Returns None for asset-free skills (and,
+/// fail-safe, when the directory can't be read).
 pub fn bundle_hint(dir: &std::path::Path) -> Option<String> {
     let mut has_bundle = false;
     for entry in std::fs::read_dir(dir).ok()? {
         let Ok(entry) = entry else { continue };
-        if entry.file_name() != "skill.yaml" {
-            has_bundle = true;
-            break;
+        let name = entry.file_name();
+        // Ignore the manifest and OS/editor junk (`.DS_Store`, swap files, …),
+        // which are dotfiles, not shipped bundle content.
+        if name == "skill.yaml" || name.to_string_lossy().starts_with('.') {
+            continue;
         }
+        has_bundle = true;
+        break;
     }
     if !has_bundle {
         return None;
@@ -174,6 +179,17 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         std::fs::write(tmp.path().join("skill.yaml"), "x").unwrap();
         assert!(bundle_hint(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn bundle_hint_ignores_dotfiles() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("skill.yaml"), "x").unwrap();
+        std::fs::write(tmp.path().join(".DS_Store"), "junk").unwrap();
+        assert!(
+            bundle_hint(tmp.path()).is_none(),
+            "a stray .DS_Store must not count as a bundle"
+        );
     }
 
     fn sample() -> LoadedSkill {

--- a/mur-core/src/cmd/agent/addon/import.rs
+++ b/mur-core/src/cmd/agent/addon/import.rs
@@ -32,10 +32,50 @@ pub fn safe_member_name(n: &str) -> Result<()> {
     Ok(())
 }
 
+/// Reject a bundle entry that could let a copy escape its install directory.
+/// Shared by the phase-1 validation walk (atomicity: fail before any write)
+/// and the phase-2 copy walk (TOCTOU: enforce again at the moment of copy).
+fn check_bundle_entry(name_str: &str, ft: &std::fs::FileType) -> anyhow::Result<()> {
+    // Reject `.`, `..`, path separators, absolute-ish names.
+    if name_str == "." || name_str == ".." || name_str.contains('/') {
+        anyhow::bail!("unsafe bundle entry name: {name_str}");
+    }
+    // Reject symlinks outright (escape vector).
+    if ft.is_symlink() {
+        anyhow::bail!("bundle contains a symlink ({name_str}); refusing import");
+    }
+    Ok(())
+}
+
+/// Phase-1 validation: walk the source bundle rejecting symlinks / unsafe names
+/// WITHOUT writing anything. Run before `write_to_dir`, this preserves the
+/// importer's "all checks must pass before a single byte is written" invariant —
+/// a bad bundle fails the whole import instead of orphaning a half-written dir.
+fn validate_bundle(src_dir: &Path) -> anyhow::Result<()> {
+    validate_bundle_inner(src_dir, true)
+}
+
+fn validate_bundle_inner(src: &Path, top: bool) -> anyhow::Result<()> {
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_str = name.to_str().context("non-UTF8 bundle filename")?;
+        if top && name_str == "SKILL.md" {
+            continue;
+        }
+        let ft = entry.file_type()?;
+        check_bundle_entry(name_str, &ft)?;
+        if ft.is_dir() {
+            validate_bundle_inner(&entry.path(), false)?;
+        }
+    }
+    Ok(())
+}
+
 /// Recursively copy every entry of `src_dir` into `dest_dir`, skipping a
-/// top-level `SKILL.md` (the manifest is written separately). Rejects any
-/// symlink and any entry whose name is unsafe, so a bundle can never write
-/// outside its own install directory.
+/// top-level `SKILL.md` (the manifest is written separately). Re-checks each
+/// entry (TOCTOU) so a symlink planted after phase-1 validation is still
+/// refused before it can escape the install directory.
 fn copy_bundle(src_dir: &Path, dest_dir: &Path) -> anyhow::Result<()> {
     copy_bundle_inner(src_dir, dest_dir, true)
 }
@@ -48,15 +88,8 @@ fn copy_bundle_inner(src: &Path, dest: &Path, top: bool) -> anyhow::Result<()> {
         if top && name_str == "SKILL.md" {
             continue;
         }
-        // Reject `.`, `..`, path separators, absolute-ish names.
-        if name_str == "." || name_str == ".." || name_str.contains('/') {
-            anyhow::bail!("unsafe bundle entry name: {name_str}");
-        }
-        // Reject symlinks outright (escape vector).
         let ft = entry.file_type()?;
-        if ft.is_symlink() {
-            anyhow::bail!("bundle contains a symlink ({name_str}); refusing import");
-        }
+        check_bundle_entry(name_str, &ft)?;
         let src_path = entry.path();
         let dest_path = dest.join(name_str);
         if ft.is_dir() {
@@ -165,6 +198,9 @@ pub fn cmd_addon_import(
             let manifest = skill_md_to_manifest(dir_name, &fs::read_to_string(&md)?, &plugin);
             safe_member_name(&manifest.name)?;
             scan_or_block(&manifest, force)?;
+            // Phase-1 bundle validation: reject symlink/unsafe entries before
+            // any write, so a bad bundle can't orphan a half-written skill dir.
+            validate_bundle(&d)?;
             let dest = agent_skills_dir.join(&manifest.name);
             if dest.exists() {
                 bail!(
@@ -566,6 +602,50 @@ mod tests {
 
         let err = copy_bundle(&src, &dest);
         assert!(err.is_err(), "symlink in bundle must be rejected");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_bundle_rejects_nested_symlink() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src");
+        fs::create_dir_all(src.join("scripts")).unwrap();
+        let secret = tmp.path().join("secret.txt");
+        fs::write(&secret, "s").unwrap();
+        // Symlink one level deep — must still be caught.
+        std::os::unix::fs::symlink(&secret, src.join("scripts/link")).unwrap();
+
+        assert!(
+            validate_bundle(&src).is_err(),
+            "a symlink nested in a subdir must be rejected"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn import_with_symlink_bundle_is_atomic_no_orphan() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        unsafe {
+            std::env::set_var("MUR_HOME", home);
+        }
+        write_agent(home, "alice");
+        let plugin = home.join("sample-plugin");
+        write_plugin(&plugin);
+        // Bundle carries a symlink → import must reject it.
+        fs::create_dir_all(plugin.join("skills/brainstorm/scripts")).unwrap();
+        let secret = home.join("secret.txt");
+        fs::write(&secret, "s").unwrap();
+        std::os::unix::fs::symlink(&secret, plugin.join("skills/brainstorm/scripts/link")).unwrap();
+
+        let res = cmd_addon_import("alice", plugin.to_str().unwrap(), None, false);
+        assert!(res.is_err(), "symlink bundle must fail the import");
+        // Atomicity: no half-written skill dir left behind.
+        assert!(
+            !home.join("agents/alice/skills/brainstorm").exists(),
+            "failed import must not orphan a skill dir"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #659. Two non-blocking review findings, best-practice fixes.

## 1. Restore two-phase import atomicity (the real one)

`copy_bundle` ran its symlink/unsafe-name check in **phase 2** (the write phase). A bundle containing a symlink would fail mid-copy — but `write_to_dir` had already written `skill.yaml`, orphaning a half-written skill dir and forcing a manual "remove it first" on retry. That punched a hole in the importer's stated invariant: *"All checks must pass before a single byte is written."*

Fix separates validation from mutation:
- **Phase 1** — `validate_bundle` walks the source tree rejecting symlinks/unsafe names **without writing**, right after `scan_or_block`. A bad bundle now fails the whole import before any disk write.
- **Phase 2** — `copy_bundle` keeps the per-entry check (now shared via `check_bundle_entry`) so a symlink **planted between phase 1 and phase 2 stays TOCTOU-safe**. The two checks have distinct jobs: phase 1 = atomicity, phase 2 = enforcement at the moment of copy.

Not a security fix — no write ever escaped the install dir. This is an atomicity/UX correctness fix.

## 2. `bundle_hint` ignores dotfiles

A stray `.DS_Store` (ubiquitous on macOS) made an asset-free skill emit a spurious "bundled files on disk" hint. `bundle_hint` now skips `skill.yaml` **and** hidden dotfiles — one predicate, no junk-file blocklist.

## Tests

- `validate_bundle_rejects_nested_symlink` — nested (subdir) symlink rejected
- `import_with_symlink_bundle_is_atomic_no_orphan` — symlink bundle fails import **and leaves no orphan skill dir**
- `bundle_hint_ignores_dotfiles` — `.DS_Store` does not count as a bundle
- existing bundle tests still green; clippy clean

## Deliberately skipped

The third review nit (extract a `skill.yaml` filename constant) — `store.rs` already hardcodes the literal 3×; adding a constant now is churn across 4 sites for zero behavior change. Fold in when that code is touched for another reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)