### PR TITLE
feat(egress): per-server broad-audited egress governance + CLI hardening

### DIFF
--- a/docs/superpowers/plans/2026-07-08-agent-egress-governance.md
+++ b/docs/superpowers/plans/2026-07-08-agent-egress-governance.md
@@ -1,0 +1,479 @@
+# Agent Egress Governance (Phase 1) + CLI Hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the `broad-audited` network egress mode (deny-overlay + explicit consent + on-profile authorization record + telemetry) as the first rung of MUR's egress-governance ladder, plus fix 8 CLI bugs + the install-service PATH gap surfaced by the AURA build.
+
+**Architecture:** Part A extends the existing entitlements data model (`OutboundNetwork` / `NetworkOutboundMode` in `mur-common`), the runtime sbpl enforcer (`mur-agent-runtime`), and the `mur agent perm` CLI (`mur-core`). The Phase-1 authorization record lives on the **agent profile** (not the fleet-loop `GovernanceState`, which is ephemeral) so it persists, travels with export, and is re-approved on import. Part B is independent mechanical fixes.
+
+**Tech Stack:** Rust (edition 2024), serde, clap, macOS sbpl sandbox. Tests: `cargo test -p <crate> <name>` (nextest or plain; per repo memory, prefer `cargo test -p mur-common <name>` for unit scope, `ORT_STRATEGY=download` if mur-core lib is pulled).
+
+## Global Constraints
+
+- Do NOT change `restricted` / `unrestricted` / `off` semantics — additive only. — spec §6.
+- New mode is named exactly `broad-audited` (serde `rename_all = "lowercase"` → the serialized token is `broad-audited`; use `#[serde(rename = "broad-audited")]` on the variant). — spec §2.2.
+- `broad-audited` = allow all outbound MINUS `deny_hosts`; fail-closed on a denied host. — spec §2.6.
+- Enabling `broad-audited` requires explicit operator consent and records `authorized_by` + `authorized_at_ms` on the profile; emits one telemetry event. — spec §2.6.
+- Policy schema carries the `(agent, tool)` scoping binding from Phase 1 even though enforcement is Phase 4 — add the field, don't enforce it yet. — spec §2.3.
+- Import never auto-grants `broad-audited`+ — downgrade to `restricted` on import. — spec §2.3.
+- Phases 2–4 are roadmap only (§ Roadmap), not tasks. — spec §2.5.
+- No hardcoded values (PATH derivation in G2 uses `npm config get prefix`, not a literal). — CLAUDE.md rule 1.
+
+---
+
+## File map
+
+| File | Change |
+|------|--------|
+| `mur-common/src/agent.rs` | Add `BroadAudited` variant; add `deny_hosts`, `tool_scope`, `authorization` to `OutboundNetwork`; `EgressAuthorization` struct |
+| `mur-agent-runtime/src/entitlements.rs` | Map `BroadAudited` → allow-all-minus-deny sbpl network policy |
+| `mur-core/src/cmd/agent/perm.rs` | `set-mode` accepts `broad-audited` (writes authorization + telemetry); `show` prints warning; `deny-host` writes `deny_hosts` |
+| `mur-core/src/cmd/agent/import*.rs` | Downgrade `broad-audited`+ → `restricted` on import |
+| `mur-core/src/cmd/agent/lifecycle.rs` | Bug 1: alias→model_ref |
+| `mur-core/src/cmd/agent/mcp.rs` | Bug 2: `allow_hyphen_values` on `--arg` |
+| `mur-core/src/cmd/fleet/*.rs` | Bug 3: `fleet add` comma-split + validation |
+| `mur-core/src/cmd/skill_cmd.rs` | Bug 4: `skill new` default `--dir ~/.mur/skills`; Bug 8: better `--fleet` error |
+| `mur-core/src/cmd/agent/{import,lifecycle}.rs` | Bug 5: `agent import --as` / clone |
+| `mur-core/src/cmd/agent/doctor.rs` (or mod) | Bug 6: per-agent `doctor <name>` |
+| `mur-core/src/cmd/agent/restart.rs` | Bug 7: variadic (reconcile with #657 `start`) |
+| `mur-core/src/agent_admin/lifecycle.rs` | G2: plist `EnvironmentVariables.PATH` |
+
+---
+
+## Part A — Phase 1: `broad-audited` egress mode
+
+### Task 1: Data model — `BroadAudited` variant + `OutboundNetwork` fields
+
+**Files:**
+- Modify: `mur-common/src/agent.rs` (`NetworkOutboundMode` enum ~line 556; `OutboundNetwork` struct ~line 540)
+- Test: same file `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Produces: `NetworkOutboundMode::BroadAudited`; `OutboundNetwork { deny_hosts: Vec<String>, tool_scope: Option<String>, authorization: Option<EgressAuthorization> }`; `struct EgressAuthorization { mode: NetworkOutboundMode, authorized_by: String, authorized_at_ms: u64 }`. Consumed by Tasks 2–5.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn broad_audited_serde_roundtrip_and_defaults() {
+    let ob = OutboundNetwork {
+        mode: NetworkOutboundMode::BroadAudited,
+        allow_hosts: vec![],
+        deny_hosts: vec!["evil.example".into()],
+        protocols: default_protocols(),
+        resolve_dns: ResolveDnsConfig::default(),
+        tool_scope: Some("agent-browser".into()),
+        authorization: Some(EgressAuthorization {
+            mode: NetworkOutboundMode::BroadAudited,
+            authorized_by: "david".into(),
+            authorized_at_ms: 1_750_000_000_000,
+        }),
+    };
+    let y = serde_yaml::to_string(&ob).unwrap();
+    assert!(y.contains("broad-audited"));
+    let back: OutboundNetwork = serde_yaml::from_str(&y).unwrap();
+    assert_eq!(back, ob);
+    // legacy profiles without the new fields still parse (serde default)
+    let legacy: OutboundNetwork =
+        serde_yaml::from_str("mode: restricted\nallow_hosts: []\n").unwrap();
+    assert_eq!(legacy.deny_hosts, Vec::<String>::new());
+    assert!(legacy.authorization.is_none());
+}
+```
+
+- [ ] **Step 2: Run — expect fail** `cargo test -p mur-common broad_audited_serde_roundtrip -- --nocapture` → FAIL (variant/fields missing).
+
+- [ ] **Step 3: Implement**
+
+Add to the enum:
+```rust
+pub enum NetworkOutboundMode {
+    Unrestricted,
+    #[serde(rename = "broad-audited")]
+    BroadAudited,
+    Restricted,
+    Off,
+}
+```
+Add fields to `OutboundNetwork` (all `#[serde(default)]` for back-compat):
+```rust
+    #[serde(default)]
+    pub deny_hosts: Vec<String>,
+    #[serde(default)]
+    pub tool_scope: Option<String>,
+    #[serde(default)]
+    pub authorization: Option<EgressAuthorization>,
+```
+Add the struct:
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EgressAuthorization {
+    pub mode: NetworkOutboundMode,
+    pub authorized_by: String,
+    pub authorized_at_ms: u64,
+}
+```
+Update any struct-literal constructors of `OutboundNetwork` in the crate (grep `OutboundNetwork {`) to include the new fields (or switch them to `..Default::default()` if a `Default` exists; if not, add the three fields explicitly).
+
+- [ ] **Step 4: Run — expect pass.** Also `cargo build -p mur-common` to catch other construction sites.
+
+- [ ] **Step 5: Commit** `git commit -am "feat(egress): add BroadAudited mode + deny_hosts/tool_scope/authorization to OutboundNetwork"`
+
+---
+
+### Task 2: sbpl enforcement — `BroadAudited` allows all-minus-deny
+
+**Files:**
+- Modify: `mur-agent-runtime/src/entitlements.rs` (imports `NetworkOutboundMode`, builds the network policy)
+- Test: same file
+
+**Interfaces:**
+- Consumes: `NetworkOutboundMode::BroadAudited`, `OutboundNetwork.deny_hosts` (Task 1).
+- Produces: sbpl network rules that allow arbitrary hosts except `deny_hosts`.
+
+- [ ] **Step 1: Read the current network-policy builder.** In `entitlements.rs`, find where `NetworkOutboundMode` is matched (the `UnrestrictedNetwork` capability / restricted host-list branch). Note the exact function that emits sbpl `(allow network* ...)` rules.
+
+- [ ] **Step 2: Write the failing test**
+
+```rust
+#[test]
+fn broad_audited_allows_all_but_denies_listed_hosts() {
+    let ob = OutboundNetwork {
+        mode: NetworkOutboundMode::BroadAudited,
+        allow_hosts: vec![],
+        deny_hosts: vec!["blocked.example".into()],
+        protocols: default_protocols(),
+        resolve_dns: Default::default(),
+        tool_scope: None,
+        authorization: None,
+    };
+    let policy = build_network_sbpl(&ob); // name per the actual builder fn
+    assert!(policy.allows_arbitrary_outbound());     // e.g. contains an allow-all network rule
+    assert!(policy.denies_host("blocked.example"));  // deny overlay present
+}
+```
+(Adapt assertions to the builder's real return type — if it returns an sbpl `String`, assert on the emitted rule text: an unrestricted `(allow network-outbound)` plus a `(deny ... blocked.example)`.)
+
+- [ ] **Step 3: Run — expect fail** `cargo test -p mur-agent-runtime broad_audited_allows_all -- --nocapture`.
+
+- [ ] **Step 4: Implement.** Add a `BroadAudited` match arm alongside `Unrestricted`: emit the same allow-all outbound rules as `Unrestricted`, then append explicit `deny` rules for each `deny_hosts` entry (deny after allow → deny wins in sbpl). Reuse the existing host-matching helper used by `Restricted`/`allow_hosts` to render each deny host.
+
+- [ ] **Step 5: Run — expect pass.** Commit `git commit -am "feat(egress): enforce BroadAudited = allow-all minus deny_hosts in sbpl"`
+
+---
+
+### Task 3: `perm set-mode broad-audited` — consent + authorization record + telemetry
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/perm.rs` (`cmd_perm_set_mode` line 59; add value parse + record)
+- Test: `mur-core` test module for perm
+
+**Interfaces:**
+- Consumes: `EgressAuthorization` (Task 1).
+- Produces: setting mode `broad-audited` writes `outbound.mode = BroadAudited` AND `outbound.authorization = Some(EgressAuthorization{..})`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn set_mode_broad_audited_records_authorization() {
+    let dir = tempdir().unwrap();
+    let name = seed_test_agent(&dir);        // helper: writes a minimal profile.yaml
+    cmd_perm_set_mode(name, "network.outbound", "broad-audited").unwrap();
+    let p = load_profile(name).unwrap();
+    assert_eq!(p.entitlements.network.outbound.mode, NetworkOutboundMode::BroadAudited);
+    let auth = p.entitlements.network.outbound.authorization.expect("record");
+    assert_eq!(auth.mode, NetworkOutboundMode::BroadAudited);
+    assert!(!auth.authorized_by.is_empty());
+    assert!(auth.authorized_at_ms > 0);
+}
+```
+
+- [ ] **Step 2: Run — expect fail** (`broad-audited` currently unsupported → error).
+
+- [ ] **Step 3: Implement.** In `cmd_perm_set_mode`, the `"network.outbound"` arm parses `value`: extend it to accept `"broad-audited"` → `NetworkOutboundMode::BroadAudited`. When the new mode is `BroadAudited`, set `outbound.authorization = Some(EgressAuthorization { mode: BroadAudited, authorized_by: current_operator(), authorized_at_ms: now_ms() })`. Use the existing operator/user resolution used elsewhere (grep for how `authorized_by`-like values are sourced; fall back to `$USER`). Emit one telemetry event (reuse the crate's telemetry emit; event name `egress.broad_audited.enabled` with the agent name). When switching AWAY from `BroadAudited`, clear `authorization`.
+
+- [ ] **Step 4: Run — expect pass.** Commit `git commit -am "feat(egress): perm set-mode broad-audited records authorization + emits telemetry"`
+
+---
+
+### Task 4: `perm show` prints the BROAD EGRESS warning; `deny-host` persists
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/perm.rs` (`cmd_perm_show` line 33; `cmd_perm_deny_host` line 116; `cmd_perm_list_hosts` line 129)
+
+**Interfaces:**
+- Consumes: `OutboundNetwork.mode`, `deny_hosts` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn perm_show_warns_on_broad_audited_and_deny_host_persists() {
+    let dir = tempdir().unwrap();
+    let name = seed_test_agent(&dir);
+    cmd_perm_set_mode(name, "network.outbound", "broad-audited").unwrap();
+    cmd_perm_deny_host(name, "blocked.example").unwrap();
+    let p = load_profile(name).unwrap();
+    assert!(p.entitlements.network.outbound.deny_hosts.iter().any(|h| h == "blocked.example"));
+    let out = capture_stdout(|| cmd_perm_show(name, Some("network")).unwrap());
+    assert!(out.contains("BROAD EGRESS ON"));
+}
+```
+
+- [ ] **Step 2: Run — expect fail.**
+
+- [ ] **Step 3: Implement.** (a) `cmd_perm_deny_host`: push the glob into `outbound.deny_hosts` (verify it currently writes nowhere useful — grep; if it wrote to a phantom list, repoint it) and save; `cmd_perm_list_hosts` prints both allow and deny lists. (b) `cmd_perm_show`: when `outbound.mode == BroadAudited`, print a prominent line, e.g. `⚠ BROAD EGRESS ON — this agent may reach any host except its deny_hosts (authorized by <by> at <ts>)`.
+
+- [ ] **Step 4: Run — expect pass.** Commit `git commit -am "feat(egress): perm show warns on broad-audited; deny-host persists to deny_hosts"`
+
+---
+
+### Task 5: Import downgrades `broad-audited`+ to `restricted`
+
+**Files:**
+- Modify: the agent import path (`mur-core/src/cmd/agent/import*.rs` or wherever `.muragent` profiles are installed)
+- Test: same
+
+**Interfaces:**
+- Consumes: `NetworkOutboundMode` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn import_downgrades_broad_and_unrestricted_to_restricted() {
+    let profile = profile_with_outbound(NetworkOutboundMode::BroadAudited);
+    let installed = sanitize_imported_profile(profile);   // the import hook
+    assert_eq!(installed.entitlements.network.outbound.mode, NetworkOutboundMode::Restricted);
+    assert!(installed.entitlements.network.outbound.authorization.is_none());
+    let u = sanitize_imported_profile(profile_with_outbound(NetworkOutboundMode::Unrestricted));
+    assert_eq!(u.entitlements.network.outbound.mode, NetworkOutboundMode::Restricted);
+}
+```
+
+- [ ] **Step 2: Run — expect fail.**
+
+- [ ] **Step 3: Implement.** In the import/install path, after deserializing the incoming profile, if `outbound.mode` is `BroadAudited` or `Unrestricted`, set it to `Restricted` and clear `authorization`. If no single sanitize function exists, add `fn sanitize_imported_profile(mut p: AgentProfile) -> AgentProfile` and call it at the install boundary. Print a notice: `imported agent's broad egress downgraded to restricted — re-grant locally with 'mur agent perm set-mode'`.
+
+- [ ] **Step 4: Run — expect pass.** Commit `git commit -am "feat(egress): import downgrades broad-audited/unrestricted to restricted (lowest trust)"`
+
+---
+
+## Part B — CLI hardening
+
+### Task 6: Bug 1 — `agent create --model <alias>` sets `model_ref`
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/lifecycle.rs` (`resolve_model_ref_for_create` ~line 218; `cmd_create` ~line 17)
+- Test: same
+
+**Interfaces:**
+- Consumes: the models.yaml registry loader (already used in `resolve_model_ref_for_create`).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn create_with_bare_alias_sets_model_ref() {
+    let home = tempdir().unwrap();
+    seed_models_yaml(&home, "claude_sonnet", "anthropic", "claude-sonnet-5");
+    let mr = resolve_model_ref_for_create(home.path(), /*provider*/ None, /*model*/ "claude_sonnet").unwrap();
+    assert_eq!(mr, Some("claude_sonnet".to_string()));
+}
+```
+(Match the real signature of `resolve_model_ref_for_create`; the point is: a bare value equal to a registry alias yields that alias as `model_ref`.)
+
+- [ ] **Step 2: Run — expect fail** (bare alias currently returns `None` / ollama default).
+
+- [ ] **Step 3: Implement.** In `resolve_model_ref_for_create`, before defaulting provider to `ollama`: if the `--model` value exactly matches an alias key in `~/.mur/models.yaml`, return `Some(alias)` and derive provider/name from that registry entry (so the inline block matches too). Keep the existing reverse-map (`--provider X --model realname`) path.
+
+- [ ] **Step 4: Run — expect pass.** Commit `git commit -am "fix(agent): create --model <alias> resolves to model_ref instead of ollama default"`
+
+---
+
+### Task 7: Bug 2 — `mcp add --arg` accepts `--`-prefixed values
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/mcp.rs` (the clap `--arg` definition)
+
+- [ ] **Step 1: Write/confirm the failing case.** From a shell in the worktree: `cargo run -p mur-core -- agent mcp add t x --command foo --arg --engine 2>&1` → currently `unexpected argument '--engine'`. Record as the failing baseline.
+
+- [ ] **Step 2: Implement.** Add `#[arg(long = "arg", allow_hyphen_values = true)]` (or `.allow_hyphen_values(true)` in the builder) to the `args` option so a value starting with `--` is consumed as the value. Add a help example: `--arg=--engine or --arg --engine`.
+
+- [ ] **Step 3: Verify.** Re-run the Step-1 command → the entry is added with `--engine` stored. Also `cargo test -p mur-core` for no regressions.
+
+- [ ] **Step 4: Commit** `git commit -am "fix(agent): mcp add --arg allows hyphen-prefixed values"`
+
+---
+
+### Task 8: Bug 3 — `fleet add` comma-splits + validates members
+
+**Files:**
+- Modify: `mur-core/src/cmd/fleet/` (the `add` handler)
+- Test: same
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn fleet_add_splits_commas_and_rejects_unknown() {
+    let names = parse_member_args(&["a,b".to_string(), "c".to_string()]);
+    assert_eq!(names, vec!["a", "b", "c"]);   // comma + space both split
+    // unknown-agent rejection is covered by the add path returning Err for a missing agent
+}
+```
+
+- [ ] **Step 2: Run — expect fail** (currently `"a,b"` stays one token).
+
+- [ ] **Step 3: Implement.** Add `fn parse_member_args(raw: &[String]) -> Vec<String>` that flat-maps each token on `,`, trims, drops empties. Use it in the `fleet add` handler; then validate each resolved name exists (reuse `a2a_dial::canonicalize_agent_name` / the agent-exists check) and return a clear `Err` listing unknown names before writing membership.
+
+- [ ] **Step 4: Run — expect pass.** Commit `git commit -am "fix(fleet): add splits comma-separated members and validates existence"`
+
+---
+
+### Task 9: Bug 4 + Bug 8 — `skill new` default dir; `skill scope --fleet` error
+
+**Files:**
+- Modify: `mur-core/src/cmd/skill_cmd.rs` (`cmd_new` / `NewOptions`; the `scope` handler)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn skill_new_defaults_to_mur_skills_dir() {
+    let home = tempdir().unwrap();
+    let path = scaffold_skill(NewOptions { name: "t".into(), dir: None, mur_home: Some(home.path().into()), ..default_new_opts() }).unwrap();
+    assert!(path.starts_with(home.path().join("skills")));
+}
+```
+
+- [ ] **Step 2: Run — expect fail** (currently defaults to CWD).
+
+- [ ] **Step 3: Implement.** (Bug 4) In `scaffold_skill`/`cmd_new`, when `dir` is `None`, default the output root to `<mur_home>/skills` instead of CWD. (Bug 8) In the `scope` handler, when `--fleet` is passed without a value / no fleet name resolvable, return `Err("--fleet requires a fleet NAME, e.g. --fleet aura-research; the fleet need not exist yet")`.
+
+- [ ] **Step 4: Run — expect pass.** Commit `git commit -am "fix(skill): new defaults to ~/.mur/skills; scope --fleet error is actionable"`
+
+---
+
+### Task 10: Bug 5 — `agent import --as <name>` / clone
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/import*.rs` + the clap `import` args
+- Test: same
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn import_as_renames_and_regenerates_identity() {
+    let bundle = export_agent_to_bundle("aura");
+    let installed = import_agent(&bundle, /*as_name*/ Some("aura-w1")).unwrap();
+    assert_eq!(installed.name, "aura-w1");
+    assert!(installed.identity_pub != source_identity("aura")); // fresh identity
+    // private key never copied — assert the source key file was not read into the new dir
+}
+```
+
+- [ ] **Step 2: Run — expect fail** (`--as` unsupported).
+
+- [ ] **Step 3: Implement.** Add `--as <NAME>` to the `import` clap args. In the import handler, when `as_name` is `Some`, install under that directory/name, set `profile.name`, regenerate the agent identity (reuse the create-time identity generation), and NEVER copy the source private key. Refuse if the target name already exists.
+
+- [ ] **Step 4: Run — expect pass.** Commit `git commit -am "feat(agent): import --as clones an agent under a new name with fresh identity"`
+
+---
+
+### Task 11: Bug 6 — per-agent `agent doctor <name>`
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/` doctor handler + clap args
+- Test: same
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn agent_doctor_named_checks_model_ref_and_mcp() {
+    let name = seed_test_agent_with_bad_model_ref();
+    let report = agent_doctor(Some(name)).unwrap();
+    assert!(report.iter().any(|c| c.name == "model_ref" && !c.ok));
+}
+```
+
+- [ ] **Step 2: Run — expect fail** (doctor takes no name arg).
+
+- [ ] **Step 3: Implement.** Make the `doctor` arg an `Option<String>`. With `Some(name)`: run per-agent checks — `model_ref` resolves in models.yaml; each MCP `command` resolves on PATH (reuse `agent_mcp_pin::resolve_command`); entitlements parse. Return a `Vec<Check { name, ok, detail }>`. With `None`: keep the existing export-prereq behavior unchanged.
+
+- [ ] **Step 4: Run — expect pass.** Commit `git commit -am "feat(agent): doctor <name> runs per-agent health checks"`
+
+---
+
+### Task 12: Bug 7 — `agent restart` variadic (reconcile with #657)
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/restart.rs`
+
+- [ ] **Step 1: Check current state.** #657 merged a `mur agent start` subcommand; run `cargo run -p mur-core -- agent restart --help` to see if `restart` already takes `--all`/multiple. If it already accepts multiple names, mark this task done (no change) and note it.
+
+- [ ] **Step 2: Write the failing test (only if still single-name).**
+
+```rust
+#[test]
+fn restart_accepts_multiple_names() {
+    let parsed = RestartArgs::try_parse_from(["restart", "a", "b"]).unwrap();
+    assert_eq!(parsed.names, vec!["a", "b"]);
+}
+```
+
+- [ ] **Step 3: Implement (if needed).** Change the positional from `Option<String>` to `Vec<String>` (variadic), loop the restart over each, keep `--all`/`--stale` mutually exclusive.
+
+- [ ] **Step 4: Run — expect pass (or note no-op).** Commit `git commit -am "fix(agent): restart accepts multiple names"`
+
+---
+
+### Task 13: G2 — `install-service` writes `EnvironmentVariables.PATH`
+
+**Files:**
+- Modify: `mur-core/src/agent_admin/lifecycle.rs` (launchd plist template)
+- Test: same
+
+**Interfaces:**
+- Produces: the generated plist contains an `EnvironmentVariables` dict with a `PATH` including the user's tool bins.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn plist_includes_path_env() {
+    let plist = render_launchd_plist("aura", "/path/to/binary", &derive_service_path());
+    assert!(plist.contains("<key>EnvironmentVariables</key>"));
+    assert!(plist.contains("<key>PATH</key>"));
+    assert!(plist.contains("/bin"));   // system dirs present
+}
+```
+
+- [ ] **Step 2: Run — expect fail** (no EnvironmentVariables in the template).
+
+- [ ] **Step 3: Implement.** Add `fn derive_service_path() -> String` = join of `<npm prefix>/bin` (from `npm config get prefix`, falling back gracefully if npm absent), `/opt/homebrew/bin`, `/usr/local/bin`, and the launchd defaults `/usr/bin:/bin:/usr/sbin:/sbin`. Inject an `EnvironmentVariables` dict with that `PATH` into the plist template. Not hardcoded — derived at generation time.
+
+- [ ] **Step 4: Run — expect pass.** Commit `git commit -am "fix(agent): install-service plist sets EnvironmentVariables.PATH so PATH-installed MCP binaries resolve"`
+
+---
+
+## Roadmap (NOT tasks — future phases)
+
+- **Phase 2 — Audit plane:** structured per-egress event log reduced into a network-wide view; a Commander `revoke-egress` directive honored by runtime + daemon (fail-closed). Reuse the `authorization` records from Phase 1 as the grant ledger.
+- **Phase 3 — Managed egress proxy:** DLP inspection, rate limiting, per-request allow/deny; sbpl pins egress to the proxy so it cannot be bypassed.
+- **Phase 4 — Per-tool scoping enforcement:** enforce `tool_scope` (added to the schema in Task 1) so only the named MCP subprocess may egress.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §2.2 `broad-audited` mode → Tasks 1–4. §2.3 scoping field → Task 1 (`tool_scope`, schema-only). §2.3 Commander → roadmap (Phase 2). §2.3 portability/import downgrade → Task 5. §2.4 data model → Task 1 (authorization on profile, NOT `GovernanceState` — grounded correction, noted in Architecture). §2.6 acceptance → Tasks 2–4. §3 Part B (8 bugs + G2) → Tasks 6–13. §2.5 phasing → Roadmap section.
+- Gap check: spec §2.4 said "GovernanceState gains an egress section" — reconciled: `GovernanceState` is ephemeral fleet-loop state, so the persistent record lives on the profile (`EgressAuthorization`) + a telemetry event; a network-wide reduction is Phase 2. This is a deliberate, documented deviation, not a miss.
+
+**Placeholder scan:** No TBD/TODO. Test bodies are concrete; where a real signature must be matched (e.g. `resolve_model_ref_for_create`, the sbpl builder fn), the step says "match the actual signature" and gives the assertion intent — acceptable because the exact name is discoverable in the named file and the behavior is fully specified.
+
+**Type consistency:** `NetworkOutboundMode::BroadAudited`, `OutboundNetwork.{deny_hosts,tool_scope,authorization}`, `EgressAuthorization{mode,authorized_by,authorized_at_ms}` used consistently across Tasks 1–5.

--- a/docs/superpowers/plans/2026-07-08-agent-egress-governance.md
+++ b/docs/superpowers/plans/2026-07-08-agent-egress-governance.md
@@ -40,225 +40,70 @@
 
 ---
 
-## Part A — Phase 1: `broad-audited` egress mode
+## Part A — Phase 1: per-server `broad-audited` egress mode
 
-### Task 1: Data model — `BroadAudited` variant + `OutboundNetwork` fields
+> **REVISED to per-server (2026-07-08).** Grounding showed MUR already enforces egress
+> PER MCP-SERVER via `McpNetMode` + the loopback egress proxy (`sandbox/egress_proxy.rs`,
+> wired at `supervisor_runner.rs:261`; design doc `2026-06-26-mcp-per-server-egress.md`).
+> So `broad-audited` is a new **`McpNetMode` variant on the tool that needs web**, NOT an
+> agent-level mode. More least-privilege (only that tool gets the web); audit + scoping
+> come from the proxy choke point. File-map rows referencing `perm.rs`/`policy.rs`/sbpl
+> are superseded by the anchors in each task below.
 
-**Files:**
-- Modify: `mur-common/src/agent.rs` (`NetworkOutboundMode` enum ~line 556; `OutboundNetwork` struct ~line 540)
-- Test: same file `#[cfg(test)] mod tests`
+### Task 1 — DONE (commit `46de8ac8`)
 
-**Interfaces:**
-- Produces: `NetworkOutboundMode::BroadAudited`; `OutboundNetwork { deny_hosts: Vec<String>, tool_scope: Option<String>, authorization: Option<EgressAuthorization> }`; `struct EgressAuthorization { mode: NetworkOutboundMode, authorized_by: String, authorized_at_ms: u64 }`. Consumed by Tasks 2–5.
+`McpNetMode::BroadAudited` (serde `broad_audited`) added to `mur-common/src/agent.rs`;
+`McpServerNetwork` gained `deny_hosts: Vec<String>` + `authorization: Option<EgressAuthorization>`;
+`EgressAuthorization { authorized_by, authorized_at_ms }`. Legacy per-server policies still
+parse. Test `broad_audited_mcp_net_serde_roundtrip_and_defaults` passes; `cargo build -p
+mur-common` clean. The mis-aimed agent-level `NetworkOutboundMode` change was reverted.
 
-- [ ] **Step 1: Write the failing test**
+### Task 2: egress proxy enforces `BroadAudited` = allow-all-except-deny + audit
 
-```rust
-#[test]
-fn broad_audited_serde_roundtrip_and_defaults() {
-    let ob = OutboundNetwork {
-        mode: NetworkOutboundMode::BroadAudited,
-        allow_hosts: vec![],
-        deny_hosts: vec!["evil.example".into()],
-        protocols: default_protocols(),
-        resolve_dns: ResolveDnsConfig::default(),
-        tool_scope: Some("agent-browser".into()),
-        authorization: Some(EgressAuthorization {
-            mode: NetworkOutboundMode::BroadAudited,
-            authorized_by: "david".into(),
-            authorized_at_ms: 1_750_000_000_000,
-        }),
-    };
-    let y = serde_yaml::to_string(&ob).unwrap();
-    assert!(y.contains("broad-audited"));
-    let back: OutboundNetwork = serde_yaml::from_str(&y).unwrap();
-    assert_eq!(back, ob);
-    // legacy profiles without the new fields still parse (serde default)
-    let legacy: OutboundNetwork =
-        serde_yaml::from_str("mode: restricted\nallow_hosts: []\n").unwrap();
-    assert_eq!(legacy.deny_hosts, Vec::<String>::new());
-    assert!(legacy.authorization.is_none());
-}
-```
+**Files:** `mur-agent-runtime/src/sandbox/egress_proxy.rs` (registry currently
+`HashMap<token, Vec<allow_hosts>>` — extend the value to carry mode + `deny_hosts`, e.g.
+`PolicyEntry { allow: Vec<String>, deny: Vec<String>, broad: bool }`);
+`sandbox/reqwest_guard.rs` (reuse `host_allowed`/`host_matches_pattern`);
+`supervisor_runner.rs:261-274` (`needs_egress` + the per-server `register(...)` call).
 
-- [ ] **Step 2: Run — expect fail** `cargo test -p mur-common broad_audited_serde_roundtrip -- --nocapture` → FAIL (variant/fields missing).
+- [ ] Failing test in `egress_proxy.rs`: a `broad` entry with `deny=["blocked.example"]`
+  → allows `"anything.example"`, denies `"blocked.example"`.
+- [ ] Implement: `BroadAudited` allows a host unless it matches a `deny_hosts` pattern
+  (reuse `host_matches_pattern`). Emit a `tracing`/telemetry audit line per CONNECT
+  (host, server, allowed|denied). Extend `needs_egress` to trigger on `BroadAudited` and
+  pass the deny list + broad flag into `register`. Run → pass. Commit.
 
-- [ ] **Step 3: Implement**
+### Task 3: CLI to set a server's `broad-audited` policy (consent + authorization)
 
-Add to the enum:
-```rust
-pub enum NetworkOutboundMode {
-    Unrestricted,
-    #[serde(rename = "broad-audited")]
-    BroadAudited,
-    Restricted,
-    Off,
-}
-```
-Add fields to `OutboundNetwork` (all `#[serde(default)]` for back-compat):
-```rust
-    #[serde(default)]
-    pub deny_hosts: Vec<String>,
-    #[serde(default)]
-    pub tool_scope: Option<String>,
-    #[serde(default)]
-    pub authorization: Option<EgressAuthorization>,
-```
-Add the struct:
-```rust
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct EgressAuthorization {
-    pub mode: NetworkOutboundMode,
-    pub authorized_by: String,
-    pub authorized_at_ms: u64,
-}
-```
-Update any struct-literal constructors of `OutboundNetwork` in the crate (grep `OutboundNetwork {`) to include the new fields (or switch them to `..Default::default()` if a `Default` exists; if not, add the three fields explicitly).
+**Files:** `mur-core/src/cmd/agent/mcp*.rs`. FIRST check for an existing `mur agent mcp`
+net/egress subcommand (from the per-server-egress feature) and extend it; else add
+`mur agent mcp set-net <agent> <server> <inherit|restricted|broad-audited> [--allow <h>]... [--deny <h>]...`.
 
-- [ ] **Step 4: Run — expect pass.** Also `cargo build -p mur-common` to catch other construction sites.
+- [ ] Failing test: setting `broad-audited` writes `server.network = McpServerNetwork {
+  mode: BroadAudited, deny_hosts, authorization: Some(EgressAuthorization{authorized_by,
+  authorized_at_ms}) }`.
+- [ ] Implement: require explicit consent (permission-required action); source
+  `authorized_by` from operator/`$USER`; stamp `authorized_at_ms`; emit one telemetry
+  event `egress.broad_audited.enabled` (agent+server); clear `authorization` when the mode
+  changes away from `BroadAudited`. Run → pass. Commit.
 
-- [ ] **Step 5: Commit** `git commit -am "feat(egress): add BroadAudited mode + deny_hosts/tool_scope/authorization to OutboundNetwork"`
+### Task 4: `mur agent mcp list` surfaces the broad-egress warning
 
----
+**Files:** `mur-core/src/cmd/agent/mcp.rs` (`list`/`inspect` output).
 
-### Task 2: sbpl enforcement — `BroadAudited` allows all-minus-deny
+- [ ] Failing test/snapshot: a `BroadAudited` server renders `⚠ BROAD EGRESS (audited) —
+  allows any host except deny_hosts; authorized by <by>`.
+- [ ] Implement + run → pass. Commit.
 
-**Files:**
-- Modify: `mur-agent-runtime/src/entitlements.rs` (imports `NetworkOutboundMode`, builds the network policy)
-- Test: same file
+### Task 5: Import downgrades a server's `broad-audited` to `inherit`
 
-**Interfaces:**
-- Consumes: `NetworkOutboundMode::BroadAudited`, `OutboundNetwork.deny_hosts` (Task 1).
-- Produces: sbpl network rules that allow arbitrary hosts except `deny_hosts`.
+**Files:** the agent import/install path (`mur-core/src/cmd/agent/import*.rs`).
 
-- [ ] **Step 1: Read the current network-policy builder.** In `entitlements.rs`, find where `NetworkOutboundMode` is matched (the `UnrestrictedNetwork` capability / restricted host-list branch). Note the exact function that emits sbpl `(allow network* ...)` rules.
-
-- [ ] **Step 2: Write the failing test**
-
-```rust
-#[test]
-fn broad_audited_allows_all_but_denies_listed_hosts() {
-    let ob = OutboundNetwork {
-        mode: NetworkOutboundMode::BroadAudited,
-        allow_hosts: vec![],
-        deny_hosts: vec!["blocked.example".into()],
-        protocols: default_protocols(),
-        resolve_dns: Default::default(),
-        tool_scope: None,
-        authorization: None,
-    };
-    let policy = build_network_sbpl(&ob); // name per the actual builder fn
-    assert!(policy.allows_arbitrary_outbound());     // e.g. contains an allow-all network rule
-    assert!(policy.denies_host("blocked.example"));  // deny overlay present
-}
-```
-(Adapt assertions to the builder's real return type — if it returns an sbpl `String`, assert on the emitted rule text: an unrestricted `(allow network-outbound)` plus a `(deny ... blocked.example)`.)
-
-- [ ] **Step 3: Run — expect fail** `cargo test -p mur-agent-runtime broad_audited_allows_all -- --nocapture`.
-
-- [ ] **Step 4: Implement.** Add a `BroadAudited` match arm alongside `Unrestricted`: emit the same allow-all outbound rules as `Unrestricted`, then append explicit `deny` rules for each `deny_hosts` entry (deny after allow → deny wins in sbpl). Reuse the existing host-matching helper used by `Restricted`/`allow_hosts` to render each deny host.
-
-- [ ] **Step 5: Run — expect pass.** Commit `git commit -am "feat(egress): enforce BroadAudited = allow-all minus deny_hosts in sbpl"`
-
----
-
-### Task 3: `perm set-mode broad-audited` — consent + authorization record + telemetry
-
-**Files:**
-- Modify: `mur-core/src/cmd/agent/perm.rs` (`cmd_perm_set_mode` line 59; add value parse + record)
-- Test: `mur-core` test module for perm
-
-**Interfaces:**
-- Consumes: `EgressAuthorization` (Task 1).
-- Produces: setting mode `broad-audited` writes `outbound.mode = BroadAudited` AND `outbound.authorization = Some(EgressAuthorization{..})`.
-
-- [ ] **Step 1: Write the failing test**
-
-```rust
-#[test]
-fn set_mode_broad_audited_records_authorization() {
-    let dir = tempdir().unwrap();
-    let name = seed_test_agent(&dir);        // helper: writes a minimal profile.yaml
-    cmd_perm_set_mode(name, "network.outbound", "broad-audited").unwrap();
-    let p = load_profile(name).unwrap();
-    assert_eq!(p.entitlements.network.outbound.mode, NetworkOutboundMode::BroadAudited);
-    let auth = p.entitlements.network.outbound.authorization.expect("record");
-    assert_eq!(auth.mode, NetworkOutboundMode::BroadAudited);
-    assert!(!auth.authorized_by.is_empty());
-    assert!(auth.authorized_at_ms > 0);
-}
-```
-
-- [ ] **Step 2: Run — expect fail** (`broad-audited` currently unsupported → error).
-
-- [ ] **Step 3: Implement.** In `cmd_perm_set_mode`, the `"network.outbound"` arm parses `value`: extend it to accept `"broad-audited"` → `NetworkOutboundMode::BroadAudited`. When the new mode is `BroadAudited`, set `outbound.authorization = Some(EgressAuthorization { mode: BroadAudited, authorized_by: current_operator(), authorized_at_ms: now_ms() })`. Use the existing operator/user resolution used elsewhere (grep for how `authorized_by`-like values are sourced; fall back to `$USER`). Emit one telemetry event (reuse the crate's telemetry emit; event name `egress.broad_audited.enabled` with the agent name). When switching AWAY from `BroadAudited`, clear `authorization`.
-
-- [ ] **Step 4: Run — expect pass.** Commit `git commit -am "feat(egress): perm set-mode broad-audited records authorization + emits telemetry"`
-
----
-
-### Task 4: `perm show` prints the BROAD EGRESS warning; `deny-host` persists
-
-**Files:**
-- Modify: `mur-core/src/cmd/agent/perm.rs` (`cmd_perm_show` line 33; `cmd_perm_deny_host` line 116; `cmd_perm_list_hosts` line 129)
-
-**Interfaces:**
-- Consumes: `OutboundNetwork.mode`, `deny_hosts` (Task 1).
-
-- [ ] **Step 1: Write the failing test**
-
-```rust
-#[test]
-fn perm_show_warns_on_broad_audited_and_deny_host_persists() {
-    let dir = tempdir().unwrap();
-    let name = seed_test_agent(&dir);
-    cmd_perm_set_mode(name, "network.outbound", "broad-audited").unwrap();
-    cmd_perm_deny_host(name, "blocked.example").unwrap();
-    let p = load_profile(name).unwrap();
-    assert!(p.entitlements.network.outbound.deny_hosts.iter().any(|h| h == "blocked.example"));
-    let out = capture_stdout(|| cmd_perm_show(name, Some("network")).unwrap());
-    assert!(out.contains("BROAD EGRESS ON"));
-}
-```
-
-- [ ] **Step 2: Run — expect fail.**
-
-- [ ] **Step 3: Implement.** (a) `cmd_perm_deny_host`: push the glob into `outbound.deny_hosts` (verify it currently writes nowhere useful — grep; if it wrote to a phantom list, repoint it) and save; `cmd_perm_list_hosts` prints both allow and deny lists. (b) `cmd_perm_show`: when `outbound.mode == BroadAudited`, print a prominent line, e.g. `⚠ BROAD EGRESS ON — this agent may reach any host except its deny_hosts (authorized by <by> at <ts>)`.
-
-- [ ] **Step 4: Run — expect pass.** Commit `git commit -am "feat(egress): perm show warns on broad-audited; deny-host persists to deny_hosts"`
-
----
-
-### Task 5: Import downgrades `broad-audited`+ to `restricted`
-
-**Files:**
-- Modify: the agent import path (`mur-core/src/cmd/agent/import*.rs` or wherever `.muragent` profiles are installed)
-- Test: same
-
-**Interfaces:**
-- Consumes: `NetworkOutboundMode` (Task 1).
-
-- [ ] **Step 1: Write the failing test**
-
-```rust
-#[test]
-fn import_downgrades_broad_and_unrestricted_to_restricted() {
-    let profile = profile_with_outbound(NetworkOutboundMode::BroadAudited);
-    let installed = sanitize_imported_profile(profile);   // the import hook
-    assert_eq!(installed.entitlements.network.outbound.mode, NetworkOutboundMode::Restricted);
-    assert!(installed.entitlements.network.outbound.authorization.is_none());
-    let u = sanitize_imported_profile(profile_with_outbound(NetworkOutboundMode::Unrestricted));
-    assert_eq!(u.entitlements.network.outbound.mode, NetworkOutboundMode::Restricted);
-}
-```
-
-- [ ] **Step 2: Run — expect fail.**
-
-- [ ] **Step 3: Implement.** In the import/install path, after deserializing the incoming profile, if `outbound.mode` is `BroadAudited` or `Unrestricted`, set it to `Restricted` and clear `authorization`. If no single sanitize function exists, add `fn sanitize_imported_profile(mut p: AgentProfile) -> AgentProfile` and call it at the install boundary. Print a notice: `imported agent's broad egress downgraded to restricted — re-grant locally with 'mur agent perm set-mode'`.
-
-- [ ] **Step 4: Run — expect pass.** Commit `git commit -am "feat(egress): import downgrades broad-audited/unrestricted to restricted (lowest trust)"`
-
----
+- [ ] Failing test: importing a profile whose MCP server has `mode: BroadAudited` yields an
+  installed server with `mode: Inherit` and `authorization: None`.
+- [ ] Implement: in the import sanitize step, for each `mcp_servers[*].network`, if
+  `mode == BroadAudited` set `Inherit` and clear `authorization`; print a re-grant notice.
+  Run → pass. Commit.
 
 ## Part B — CLI hardening
 

--- a/docs/superpowers/specs/2026-07-08-agent-egress-governance-design.md
+++ b/docs/superpowers/specs/2026-07-08-agent-egress-governance-design.md
@@ -1,0 +1,134 @@
+# Agent Egress Governance + CLI Hardening (Design)
+
+Date: 2026-07-08
+Status: Design — implementation scoped to Phase 1 (+ CLI hardening); Phases 2–4 are roadmap.
+
+## 1. Context
+
+Building the AURA web-research agent surfaced one load-bearing gap and a batch of CLI
+defects. The gap — an agent that legitimately needs broad web egress has no safe way to
+get it — is not a one-off; it is the seed of MUR's long-term, enterprise-grade **agent
+egress governance**. This spec designs that governance model in full but scopes the
+*implementation* to Phase 1, and folds in the mechanical CLI fixes as a separate part.
+
+The enterprise concern is not "can an agent reach the internet" but **"can sensitive
+data leave, to where, and can we prove/stop it."** A static host allowlist does not
+answer that (data can exfiltrate to an allowed host). So egress governance must be
+least-privilege, centrally policyable, fully audited, instantly revocable, and mappable
+to compliance (SOC2/ISO).
+
+## 2. Part A — Agent Egress Governance
+
+### 2.1 Principle: separate policy, enforcement, and audit
+
+Three planes, deliberately decoupled so each can evolve independently:
+
+1. **Policy plane (control).** Declarative egress policy bound to `(agent, tool)`,
+   versioned and Ed25519-signed, distributable via Commander / signed channels (central
+   governance in enterprise; a local file for solo users). Answers "who / which tool /
+   may go where, at what tier."
+2. **Enforcement plane (data path).** Two enforcers:
+   - **sbpl kernel** — coarse: `deny` / `allow-to-host-list` / `allow-to-proxy`. Exists today.
+   - **managed egress proxy** — fine: per-request allow/deny, DLP inspection, rate limit.
+     Later phase; sbpl pins egress so it can *only* reach the proxy (un-bypassable).
+3. **Audit plane (evidence).** Every grant and every egress event appends to an
+   immutable log tied to the existing `GovernanceState` and channel signing.
+
+### 2.2 Mode ladder (least-privilege, escalating authority)
+
+```
+off  →  allowlist(static hosts)  →  broad-audited  →  unrestricted
+```
+
+- Each higher tier requires higher authority to enable: `self < operator-consent <
+  Commander-signed policy`.
+- **`broad-audited` (Phase 1, the research-agent unblock):** permits all outbound, BUT
+  (1) overlays the existing deny-host list, (2) requires explicit operator opt-in,
+  (3) renders a loud `BROAD EGRESS ON` line in `mur agent perm show`, (4) emits a
+  telemetry/`GovernanceState` event on enable and (Phase 2) per egress.
+- `unrestricted` stays as the un-audited escape hatch (unchanged), but is now the top of
+  a labeled ladder rather than the only alternative to `restricted`.
+
+### 2.3 Cross-cutting dimensions
+
+- **Scoping (defense in depth).** Policy binds to `(agent, tool)`: "agent-browser may
+  reach the web; the rest of the agent may not." Enforced fully in Phase 4; the policy
+  schema carries the `tool` binding from Phase 1 so nothing is re-modeled later.
+- **Commander integration.** Egress becomes a governed capability alongside `kill` and
+  `budget-ceiling`. A Commander directive can revoke or cap egress network-wide (an
+  exfiltration kill-switch). Governance errors are **fail-closed** (matches the existing
+  loop/daemon pattern).
+- **Portability.** Exported `.muragent` bundles carry egress policy, but **import always
+  re-approves locally and never auto-grants `broad-audited`+** (matches the fleet-import
+  "install at lowest trust" rule).
+
+### 2.4 Data model (Phase 1 lands the full shape)
+
+Extend `entitlements.network.outbound` in `mur-common/src/agent.rs`:
+
+- `NetworkOutboundMode` gains `BroadAudited` (between `Restricted` and `Unrestricted`).
+- `outbound` gains: `tool_scope: Option<String>` (the MCP server name egress is bound to;
+  `None` = whole agent), and `deny_hosts: Vec<String>` (overlay; already partly present).
+- `GovernanceState` gains an `egress` section: current mode, who authorized it, when,
+  and (Phase 2) an append-only egress-event cursor. **Phase 1 writes the authorization
+  record even though enforcement is still coarse**, so Phase 2 revocation wires straight in.
+
+### 2.5 Phasing (implement Phase 1 only; rest is roadmap)
+
+| Phase | Scope | Delivers |
+|-------|-------|----------|
+| **1 (this plan)** | `broad-audited` mode + deny-list overlay + explicit opt-in + `perm show` warning + `GovernanceState` authorization record + telemetry-on-enable | Research-agent unblock; least-privilege skeleton; audit hook present |
+| 2 | Audit plane: structured per-egress event log tied to `GovernanceState`; Commander `revoke-egress` directive | Auditability + instant revocation (enterprise entry line) |
+| 3 | Managed egress proxy (DLP, rate limit, per-request allow/deny); sbpl pins egress to proxy | Data-exfiltration control (true enterprise grade) |
+| 4 | Per-tool egress scoping enforcement | Defense in depth |
+
+### 2.6 Phase 1 acceptance
+
+- `mur agent perm set-mode <a> network.outbound broad-audited` succeeds, requires the
+  existing consent path, and records authorizer + timestamp in `GovernanceState`.
+- `mur agent perm show <a>` prints a prominent `BROAD EGRESS ON` warning for that mode.
+- A `broad-audited` agent can reach arbitrary hosts EXCEPT those on `deny_hosts`; a
+  denied host is blocked (fail-closed).
+- Enabling emits one telemetry/GovernanceState event.
+- `unrestricted` and `restricted` behavior is unchanged (no regression).
+
+## 3. Part B — CLI hardening (mechanical fixes)
+
+Independent of Part A; clear correct-behavior fixes. One PR-sized batch.
+
+| # | Fix | Correct behavior |
+|---|-----|------------------|
+| 1 | **`mur agent create --model <alias>` drops `model_ref`** (`cmd/agent/lifecycle.rs`, `resolve_model_ref_for_create`). It only reverse-maps `--provider X --model <realname>`; a bare alias falls to the `ollama` default with no `model_ref`. | If `--model <value>` matches a `~/.mur/models.yaml` alias, set `model_ref = <value>` and derive provider/name from the registry. |
+| 2 | **`mur agent mcp add --arg --engine` clap-fails** on values starting with `--`. | Set `allow_hyphen_values` on the `--arg` option so `--arg --engine` parses natively; keep `--arg=<value>` working too. Add an example to the help.
+| 3 | **`mur fleet add a,b` stores one bogus member.** | Split on commas as well as spaces; validate each name resolves to an existing agent; reject unknown names loudly. |
+| 4 | **`mur skill new` scaffolds into CWD**, polluting the repo. | Default output to `~/.mur/skills/` (with `--dir` to override), matching where `skill list`/`scope` read from. |
+| 5 | **No `mur agent import --as <name>`** — can't clone/rename. | Add `--as <name>` to `mur agent import` (or a `mur agent clone <src> <dst>`), regenerating identity, never copying the private key. |
+| 6 | **No per-agent `mur agent doctor <name>`.** | Accept an optional agent arg that runs per-agent checks (model_ref resolves, MCP commands resolve on PATH, entitlements sane); keep the no-arg export-prereq behavior. |
+| 7 | **`mur agent restart` non-variadic** (docs implied multi). NOTE: verify against current `main` — a `mur agent start` subcommand landed in #657; reconcile. | Accept multiple names (variadic), consistent with `fleet add`. |
+| 8 | **`mur skill scope --fleet` errors unhelpfully** when no fleet name is given. | Improve the error to state `--fleet <NAME>` is required and the fleet need not exist yet. |
+| G2 | **`install-service` plist has no `EnvironmentVariables.PATH`** (`agent_admin/lifecycle.rs`), so the launchd runtime can't find PATH-installed MCP binaries. | Write `EnvironmentVariables.PATH` into the plist, derived from the user's login-shell PATH (e.g. `npm config get prefix`/bin + common dirs), so bare-command MCP servers resolve. |
+
+## 4. Component boundaries
+
+| Unit | Responsibility |
+|------|----------------|
+| `NetworkOutboundMode` + `outbound` schema (`mur-common/agent.rs`) | Policy data model (Part A) |
+| `GovernanceState.egress` (`mur-common`) | Authorization record + audit hook |
+| sbpl policy builder (`mur-agent-runtime/sandbox`) | Enforce `broad-audited` = allow-all-minus-deny_hosts |
+| `mur agent perm set-mode` / `show` (`mur-core/cmd/agent/perm`) | Enable + surface the mode |
+| `cmd/agent/lifecycle.rs`, `cmd/agent/mcp.rs`, `cmd/fleet`, `cmd/skill_cmd.rs`, `agent_admin/lifecycle.rs` | Part B fixes |
+
+## 5. Testing
+
+- Part A: unit-test the sbpl policy builder for `broad-audited` (allows arbitrary host,
+  blocks a `deny_hosts` entry); test `set-mode` writes the `GovernanceState` record;
+  snapshot-test `perm show` output shows the warning.
+- Part B: one focused test per fix — e.g. `create --model <alias>` yields `model_ref` set;
+  `fleet add a,b` yields two validated members; `install-service` plist contains a PATH.
+
+## 6. Out of scope
+
+- Egress proxy / DLP / rate limiting (Phase 3).
+- Per-request egress logging and Commander `revoke-egress` (Phase 2).
+- Per-tool scoping enforcement (Phase 4) — schema carries the binding, enforcement later.
+- Any change to `restricted` / `unrestricted` semantics.

--- a/docs/superpowers/specs/2026-07-08-agent-egress-governance-design.md
+++ b/docs/superpowers/specs/2026-07-08-agent-egress-governance-design.md
@@ -34,33 +34,45 @@ Three planes, deliberately decoupled so each can evolve independently:
 3. **Audit plane (evidence).** Every grant and every egress event appends to an
    immutable log tied to the existing `GovernanceState` and channel signing.
 
-### 2.2 Mode ladder (least-privilege, escalating authority)
+### 2.2 Mode ladder — enforced PER MCP-SERVER (revised after grounding)
 
+> **Grounding correction (2026-07-08):** MUR already has per-MCP-server egress
+> (`McpServerNetwork { mode: McpNetMode, allow_hosts }` on each server; `Restricted`
+> routes the child through a loopback CONNECT egress proxy via `HTTP_PROXY`;
+> `mur-agent-runtime/src/sandbox/egress_proxy.rs` + `supervisor_runner.rs:261` wire it;
+> design doc `2026-06-26-mcp-per-server-egress.md`). So `broad-audited` is NOT an
+> agent-level mode — it is a **new `McpNetMode` variant** on the tool that needs web.
+> This is strictly better: **least-privilege** (only that tool gets the web, the agent's
+> own LLM egress stays `restricted`), and **audit + scoping ride the proxy choke point**
+> that already sees every subprocess destination.
+
+Per-server mode ladder:
 ```
-off  →  allowlist(static hosts)  →  broad-audited  →  unrestricted
+inherit  →  restricted(allow_hosts)  →  broad-audited(all−deny_hosts, audited)  →  (off)
 ```
 
-- Each higher tier requires higher authority to enable: `self < operator-consent <
-  Commander-signed policy`.
-- **`broad-audited` (Phase 1, the research-agent unblock):** permits all outbound, BUT
-  (1) overlays the existing deny-host list, (2) requires explicit operator opt-in,
-  (3) renders a loud `BROAD EGRESS ON` line in `mur agent perm show`, (4) emits a
-  telemetry/`GovernanceState` event on enable and (Phase 2) per egress.
-- `unrestricted` stays as the un-audited escape hatch (unchanged), but is now the top of
-  a labeled ladder rather than the only alternative to `restricted`.
+- **`McpNetMode::BroadAudited` (Phase 1, the research-agent unblock):** the proxy allows
+  every host for that server EXCEPT `deny_hosts`, and audits every CONNECT (host / server
+  / allowed|denied). Requires explicit operator consent, which records an
+  `EgressAuthorization { authorized_by, authorized_at_ms }` on the server's
+  `McpServerNetwork`. Enforcement is **advisory** (a cooperating child honors `HTTP_PROXY`;
+  airtight containment = Phase 3, Linux netns / macOS pre-fork launcher) — documented, not
+  overclaimed.
+- The agent-level `NetworkOutboundMode` (`restricted`/`unrestricted`/`off`) is unchanged
+  and governs only the runtime's own LLM egress. `broad-audited` does not touch it.
 
 ### 2.3 Cross-cutting dimensions
 
-- **Scoping (defense in depth).** Policy binds to `(agent, tool)`: "agent-browser may
-  reach the web; the rest of the agent may not." Enforced fully in Phase 4; the policy
-  schema carries the `tool` binding from Phase 1 so nothing is re-modeled later.
+- **Scoping (defense in depth) — already native.** The proxy is per-server (per-tool
+  token) by construction, so `(agent, tool)` scoping is inherent, not a Phase-4 add-on.
+- **Audit — nearly free.** The proxy is the single choke point for subprocess egress;
+  logging each CONNECT delivers the audit plane in Phase 1, not Phase 2.
 - **Commander integration.** Egress becomes a governed capability alongside `kill` and
-  `budget-ceiling`. A Commander directive can revoke or cap egress network-wide (an
-  exfiltration kill-switch). Governance errors are **fail-closed** (matches the existing
-  loop/daemon pattern).
-- **Portability.** Exported `.muragent` bundles carry egress policy, but **import always
-  re-approves locally and never auto-grants `broad-audited`+** (matches the fleet-import
-  "install at lowest trust" rule).
+  `budget-ceiling`; a directive can revoke a server's `broad-audited` grant network-wide.
+  Governance errors are **fail-closed**.
+- **Portability.** Exported `.muragent` bundles carry the per-server policy, but **import
+  downgrades any `broad-audited` server to `inherit` and clears `authorization`** (lowest
+  trust; re-grant locally).
 
 ### 2.4 Data model (Phase 1 lands the full shape)
 

--- a/mur-agent-runtime/src/protocol/mcp_client.rs
+++ b/mur-agent-runtime/src/protocol/mcp_client.rs
@@ -349,10 +349,14 @@ pub fn proxy_env_for(
     let (Some(net), Some(proxy)) = (entry.network.as_ref(), proxy) else {
         return vec![];
     };
-    if net.mode != mur_common::agent::McpNetMode::Restricted {
-        return vec![];
-    }
-    let token = proxy.register(net.allow_hosts.clone());
+    let broad = match net.mode {
+        mur_common::agent::McpNetMode::Restricted => false,
+        mur_common::agent::McpNetMode::BroadAudited => true,
+        mur_common::agent::McpNetMode::Inherit | mur_common::agent::McpNetMode::Off => {
+            return vec![];
+        }
+    };
+    let token = proxy.register_policy(net.allow_hosts.clone(), net.deny_hosts.clone(), broad);
     let url = format!("http://{token}:x@{}", proxy.addr);
     let no_proxy = "127.0.0.1,localhost,::1".to_string();
     vec![
@@ -387,6 +391,8 @@ mod tests {
         restricted.network = Some(McpServerNetwork {
             mode: McpNetMode::Restricted,
             allow_hosts: vec!["example.com".into()],
+            deny_hosts: vec![],
+            authorization: None,
         });
         assert!(proxy_env_for(&restricted, None).is_empty());
 
@@ -406,6 +412,8 @@ mod tests {
         inherit.network = Some(McpServerNetwork {
             mode: McpNetMode::Inherit,
             allow_hosts: vec![],
+            deny_hosts: vec![],
+            authorization: None,
         });
         assert!(proxy_env_for(&inherit, Some(&handle)).is_empty());
     }

--- a/mur-agent-runtime/src/sandbox/egress_proxy.rs
+++ b/mur-agent-runtime/src/sandbox/egress_proxy.rs
@@ -16,9 +16,20 @@ use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
-use super::reqwest_guard::host_allowed;
+use super::reqwest_guard::{host_allowed, host_matches_pattern};
 
-type Registry = Arc<Mutex<HashMap<String, Vec<String>>>>;
+/// A registered per-server policy: either a `Restricted` allowlist, or a
+/// `BroadAudited` allow-all-except-`deny` policy.
+#[derive(Clone, Default)]
+struct PolicyEntry {
+    allow: Vec<String>,
+    deny: Vec<String>,
+    /// `true` for `BroadAudited` (allow-all-except-`deny`); `false` for
+    /// `Restricted` (allow-only-`allow`).
+    broad: bool,
+}
+
+type Registry = Arc<Mutex<HashMap<String, PolicyEntry>>>;
 
 #[derive(Clone)]
 pub struct EgressProxyHandle {
@@ -36,14 +47,31 @@ impl EgressProxyHandle {
         }
     }
 
-    /// Register a per-server allowlist; returns the bearer token to embed in the
-    /// child's `HTTP_PROXY` credentials.
+    /// Register a per-server allowlist (`Restricted`); returns the bearer
+    /// token to embed in the child's `HTTP_PROXY` credentials.
     pub fn register(&self, allow_hosts: Vec<String>) -> String {
+        self.register_policy(allow_hosts, Vec::new(), false)
+    }
+
+    /// Register a per-server policy: `broad = true` is `BroadAudited`
+    /// (allow-all-except-`deny_hosts`); `broad = false` is `Restricted`
+    /// (allow-only-`allow_hosts`). Returns the bearer token to embed in the
+    /// child's `HTTP_PROXY` credentials.
+    pub fn register_policy(
+        &self,
+        allow_hosts: Vec<String>,
+        deny_hosts: Vec<String>,
+        broad: bool,
+    ) -> String {
         let token = uuid::Uuid::now_v7().simple().to_string();
-        self.registry
-            .lock()
-            .unwrap()
-            .insert(token.clone(), allow_hosts);
+        self.registry.lock().unwrap().insert(
+            token.clone(),
+            PolicyEntry {
+                allow: allow_hosts,
+                deny: deny_hosts,
+                broad,
+            },
+        );
         token
     }
 }
@@ -100,18 +128,29 @@ async fn handle_conn(mut client: TcpStream, registry: Registry) -> std::io::Resu
         .and_then(decode_basic_user);
 
     let host = target.rsplit_once(':').map(|(h, _)| h).unwrap_or(target);
-    let allowed = token
+    let entry = token
         .as_deref()
-        .and_then(|t| registry.lock().unwrap().get(t).cloned())
-        .map(|allow| host_allowed(host, &allow))
-        .unwrap_or(false);
+        .and_then(|t| registry.lock().unwrap().get(t).cloned());
+    let allowed = match &entry {
+        Some(e) if e.broad => !e.deny.iter().any(|p| host_matches_pattern(host, p)),
+        Some(e) => host_allowed(host, &e.allow),
+        None => false,
+    };
 
     if !allowed {
-        tracing::info!(host, "egress proxy DENY");
+        tracing::info!(
+            host,
+            broad = entry.as_ref().map(|e| e.broad),
+            "egress proxy CONNECT DENY"
+        );
         client.write_all(b"HTTP/1.1 403 Forbidden\r\n\r\n").await?;
         return Ok(());
     }
-    tracing::info!(host, "egress proxy ALLOW");
+    tracing::info!(
+        host,
+        broad = entry.as_ref().map(|e| e.broad),
+        "egress proxy CONNECT ALLOW"
+    );
     let mut upstream = TcpStream::connect(target).await?;
     client
         .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
@@ -187,6 +226,32 @@ mod tests {
         assert!(
             bad.starts_with("HTTP/1.1 403"),
             "unknown token is 403: {bad}"
+        );
+    }
+
+    #[tokio::test]
+    async fn broad_audited_allows_all_except_deny() {
+        let up = upstream().await;
+        let proxy = start_egress_proxy().await.unwrap();
+
+        // BroadAudited: deny only "blocked.example"; everything else allowed,
+        // including a host never mentioned in any list.
+        let token = proxy.register_policy(vec![], vec!["blocked.example".to_string()], true);
+
+        // "anything.example" isn't on any list but broad-audited allows it —
+        // dial the real loopback upstream so the CONNECT can complete.
+        let allowed = connect_via(proxy.addr, &token, &up.to_string()).await;
+        assert!(
+            allowed.starts_with("HTTP/1.1 200"),
+            "broad-audited allows a host not on any list: {allowed}"
+        );
+
+        // "blocked.example" is in deny_hosts → 403 even though broad allows
+        // everything else.
+        let denied = connect_via(proxy.addr, &token, "blocked.example:443").await;
+        assert!(
+            denied.starts_with("HTTP/1.1 403"),
+            "broad-audited still denies deny_hosts: {denied}"
         );
     }
 }

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -259,11 +259,13 @@ pub async fn build_provider_runner(
     // are never spawned and never advertised in tools/list.
     let enabled_mcp = profile.inner.enabled_mcp_servers();
     // Start the per-server egress proxy only if some server declares a
-    // Restricted network policy (opt-in; otherwise no proxy, no change).
+    // Restricted or BroadAudited network policy (opt-in; otherwise no proxy,
+    // no change).
     let needs_egress = enabled_mcp.iter().any(|e| {
         matches!(
             e.network.as_ref().map(|n| n.mode),
             Some(mur_common::agent::McpNetMode::Restricted)
+                | Some(mur_common::agent::McpNetMode::BroadAudited)
         )
     });
     let egress = if needs_egress {

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -333,6 +333,12 @@ pub enum McpNetMode {
     Inherit,
     /// Allow only `allow_hosts`, routed through the runtime egress proxy.
     Restricted,
+    /// Allow ALL hosts EXCEPT `deny_hosts`, routed through the runtime egress
+    /// proxy, with every CONNECT audited. For trusted-but-broad tools (e.g. a
+    /// web-research browser) that cannot enumerate their destinations. Requires
+    /// explicit operator consent (records `authorization`); downgraded to
+    /// `Inherit` on import (lowest trust). Advisory enforcement (see egress_proxy).
+    BroadAudited,
     /// No outbound for this server at all.
     Off,
 }
@@ -344,6 +350,13 @@ pub struct McpServerNetwork {
     pub mode: McpNetMode,
     #[serde(default)]
     pub allow_hosts: Vec<String>,
+    /// Deny overlay for `BroadAudited` mode: hosts blocked even though all
+    /// others are allowed. Ignored by `Restricted`/`Inherit`/`Off`.
+    #[serde(default)]
+    pub deny_hosts: Vec<String>,
+    /// Who authorized a `BroadAudited` grant, and when. `None` for other modes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authorization: Option<EgressAuthorization>,
 }
 
 /// A plugin-group imported by one agent (add-on Phase 2). Self-contained:
@@ -542,24 +555,20 @@ pub struct OutboundNetwork {
     pub mode: NetworkOutboundMode,
     #[serde(default)]
     pub allow_hosts: Vec<String>,
-    #[serde(default)]
-    pub deny_hosts: Vec<String>,
     #[serde(default = "default_protocols")]
     pub protocols: Vec<String>,
     #[serde(default)]
     pub resolve_dns: ResolveDnsConfig,
-    #[serde(default)]
-    pub tool_scope: Option<String>,
-    #[serde(default)]
-    pub authorization: Option<EgressAuthorization>,
 }
 fn default_protocols() -> Vec<String> {
     vec!["tcp".to_string()]
 }
 
+/// Record of who authorized a broad egress grant, and when. Attached to a
+/// per-MCP-server `McpServerNetwork` when its mode is `BroadAudited`, so the
+/// grant is persisted, portable, and re-approvable on import.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct EgressAuthorization {
-    pub mode: NetworkOutboundMode,
     pub authorized_by: String,
     pub authorized_at_ms: u64,
 }
@@ -568,8 +577,6 @@ pub struct EgressAuthorization {
 #[serde(rename_all = "lowercase")]
 pub enum NetworkOutboundMode {
     Unrestricted,
-    #[serde(rename = "broad-audited")]
-    BroadAudited,
     Restricted,
     Off,
 }
@@ -1461,26 +1468,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn broad_audited_serde_roundtrip_and_defaults() {
-        let ob = OutboundNetwork {
-            mode: NetworkOutboundMode::BroadAudited,
+    fn broad_audited_mcp_net_serde_roundtrip_and_defaults() {
+        let net = McpServerNetwork {
+            mode: McpNetMode::BroadAudited,
             allow_hosts: vec![],
             deny_hosts: vec!["evil.example".into()],
-            protocols: default_protocols(),
-            resolve_dns: ResolveDnsConfig::default(),
-            tool_scope: Some("agent-browser".into()),
             authorization: Some(EgressAuthorization {
-                mode: NetworkOutboundMode::BroadAudited,
                 authorized_by: "david".into(),
                 authorized_at_ms: 1_750_000_000_000,
             }),
         };
-        let y = serde_yaml::to_string(&ob).unwrap();
-        assert!(y.contains("broad-audited"));
-        let back: OutboundNetwork = serde_yaml::from_str(&y).unwrap();
-        assert_eq!(back, ob);
-        // legacy profiles without the new fields still parse (serde default)
-        let legacy: OutboundNetwork =
+        let y = serde_yaml::to_string(&net).unwrap();
+        assert!(y.contains("broad_audited"));
+        let back: McpServerNetwork = serde_yaml::from_str(&y).unwrap();
+        assert_eq!(back, net);
+        // legacy per-server policy without the new fields still parses (serde default)
+        let legacy: McpServerNetwork =
             serde_yaml::from_str("mode: restricted\nallow_hosts: []\n").unwrap();
         assert_eq!(legacy.deny_hosts, Vec::<String>::new());
         assert!(legacy.authorization.is_none());

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -542,19 +542,34 @@ pub struct OutboundNetwork {
     pub mode: NetworkOutboundMode,
     #[serde(default)]
     pub allow_hosts: Vec<String>,
+    #[serde(default)]
+    pub deny_hosts: Vec<String>,
     #[serde(default = "default_protocols")]
     pub protocols: Vec<String>,
     #[serde(default)]
     pub resolve_dns: ResolveDnsConfig,
+    #[serde(default)]
+    pub tool_scope: Option<String>,
+    #[serde(default)]
+    pub authorization: Option<EgressAuthorization>,
 }
 fn default_protocols() -> Vec<String> {
     vec!["tcp".to_string()]
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EgressAuthorization {
+    pub mode: NetworkOutboundMode,
+    pub authorized_by: String,
+    pub authorized_at_ms: u64,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum NetworkOutboundMode {
     Unrestricted,
+    #[serde(rename = "broad-audited")]
+    BroadAudited,
     Restricted,
     Off,
 }
@@ -1444,6 +1459,32 @@ impl AgentProfile {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn broad_audited_serde_roundtrip_and_defaults() {
+        let ob = OutboundNetwork {
+            mode: NetworkOutboundMode::BroadAudited,
+            allow_hosts: vec![],
+            deny_hosts: vec!["evil.example".into()],
+            protocols: default_protocols(),
+            resolve_dns: ResolveDnsConfig::default(),
+            tool_scope: Some("agent-browser".into()),
+            authorization: Some(EgressAuthorization {
+                mode: NetworkOutboundMode::BroadAudited,
+                authorized_by: "david".into(),
+                authorized_at_ms: 1_750_000_000_000,
+            }),
+        };
+        let y = serde_yaml::to_string(&ob).unwrap();
+        assert!(y.contains("broad-audited"));
+        let back: OutboundNetwork = serde_yaml::from_str(&y).unwrap();
+        assert_eq!(back, ob);
+        // legacy profiles without the new fields still parse (serde default)
+        let legacy: OutboundNetwork =
+            serde_yaml::from_str("mode: restricted\nallow_hosts: []\n").unwrap();
+        assert_eq!(legacy.deny_hosts, Vec::<String>::new());
+        assert!(legacy.authorization.is_none());
+    }
 
     #[test]
     fn mcp_entry_network_is_optional_and_round_trips() {

--- a/mur-common/src/muragent/installer.rs
+++ b/mur-common/src/muragent/installer.rs
@@ -22,6 +22,7 @@ use std::path::{Path, PathBuf};
 use base64::{Engine, engine::general_purpose::STANDARD as B64};
 
 use crate::AgentProfile;
+use crate::agent::McpNetMode;
 use crate::muragent::MuragentError;
 use crate::muragent::manifest::MuragentManifest;
 use crate::muragent::reader::MuragentArchive;
@@ -55,6 +56,12 @@ pub struct InstallOutcome {
     /// the agent already existed at the slug with matching UUID and the
     /// payload was replaced in place (preserving `data/`).
     pub was_update: bool,
+    /// Names of MCP servers whose `network.mode` was downgraded from
+    /// `BroadAudited` to `Inherit` (with `authorization` cleared) during this
+    /// install. A bundle author's broad-egress grant is tied to a local
+    /// operator (Task 3) and must not travel with the bundle; empty when
+    /// nothing was downgraded.
+    pub downgraded_broad_egress: Vec<String>,
 }
 
 /// Install or update a `.muragent` archive. See module docs for the flow.
@@ -146,6 +153,8 @@ pub fn install(
 
     extract_payload(archive, &agent_dir)?;
 
+    let downgraded_broad_egress = downgrade_profile_egress(&agent_dir)?;
+
     // Step 6: trust upsert
     let fingerprint_hex = trust::short_fingerprint(&result.author_pubkey);
     let fingerprint_words = trust::word_list_fingerprint(&result.author_pubkey);
@@ -164,7 +173,46 @@ pub fn install(
         fingerprint_hex,
         fingerprint_words,
         was_update,
+        downgraded_broad_egress,
     })
+}
+
+/// For every MCP server whose `network.mode == BroadAudited`, resets the mode
+/// to `Inherit` and clears `authorization`. A bundle author's broad-audited
+/// grant is tied to their local operator consent (Task 3); it must not travel
+/// with the bundle, so the importer must explicitly re-grant it. Returns the
+/// names of the downgraded servers, in profile order. Pure / filesystem-free
+/// so it's unit-testable directly.
+fn downgrade_broad_egress(profile: &mut AgentProfile) -> Vec<String> {
+    let mut downgraded = Vec::new();
+    for server in &mut profile.mcp_servers {
+        if let Some(network) = server.network.as_mut()
+            && network.mode == McpNetMode::BroadAudited
+        {
+            network.mode = McpNetMode::Inherit;
+            network.authorization = None;
+            downgraded.push(server.name.clone());
+        }
+    }
+    downgraded
+}
+
+/// Reads the just-extracted `profile.yaml`, downgrades any `BroadAudited` MCP
+/// egress grants, and — only if anything changed — re-serializes it back to
+/// disk. Returns the names of downgraded servers (empty if none).
+fn downgrade_profile_egress(agent_dir: &Path) -> Result<Vec<String>, MuragentError> {
+    let profile_path = agent_dir.join("profile.yaml");
+    let raw = fs::read_to_string(&profile_path).map_err(MuragentError::Io)?;
+    let mut profile: AgentProfile =
+        serde_yaml_ng::from_str(&raw).map_err(|e| MuragentError::Other(e.to_string()))?;
+
+    let downgraded = downgrade_broad_egress(&mut profile);
+    if !downgraded.is_empty() {
+        let out =
+            serde_yaml_ng::to_string(&profile).map_err(|e| MuragentError::Other(e.to_string()))?;
+        fs::write(&profile_path, out).map_err(MuragentError::Io)?;
+    }
+    Ok(downgraded)
 }
 
 /// Refuse a package that carries any [`RESERVED_LOCAL_FILES`] entry at its top
@@ -374,6 +422,50 @@ mod tests {
     use crate::identity::AgentIdentity;
     use crate::muragent::writer::{MuragentWriter, build_manifest_from_profile};
     use tempfile::TempDir;
+
+    #[test]
+    fn downgrade_broad_egress_resets_mode_and_clears_authorization() {
+        use crate::agent::{EgressAuthorization, McpServerEntry, McpServerNetwork};
+
+        let mut profile = AgentProfile::default_for_tests();
+        profile.mcp_servers = vec![
+            McpServerEntry {
+                name: "broad-server".to_string(),
+                command: "true".to_string(),
+                network: Some(McpServerNetwork {
+                    mode: McpNetMode::BroadAudited,
+                    authorization: Some(EgressAuthorization {
+                        authorized_by: "operator".to_string(),
+                        authorized_at_ms: 1,
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            McpServerEntry {
+                name: "restricted-server".to_string(),
+                command: "true".to_string(),
+                network: Some(McpServerNetwork {
+                    mode: McpNetMode::Restricted,
+                    allow_hosts: vec!["example.com".to_string()],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        ];
+
+        let downgraded = downgrade_broad_egress(&mut profile);
+
+        assert_eq!(downgraded, vec!["broad-server".to_string()]);
+
+        let broad = &profile.mcp_servers[0].network.as_ref().unwrap();
+        assert_eq!(broad.mode, McpNetMode::Inherit);
+        assert_eq!(broad.authorization, None);
+
+        let restricted = &profile.mcp_servers[1].network.as_ref().unwrap();
+        assert_eq!(restricted.mode, McpNetMode::Restricted);
+        assert_eq!(restricted.allow_hosts, vec!["example.com".to_string()]);
+    }
 
     fn make_test_package(tmp: &TempDir) -> std::path::PathBuf {
         let out = tmp.path().join("test.muragent");

--- a/mur-common/src/muragent/installer.rs
+++ b/mur-common/src/muragent/installer.rs
@@ -78,6 +78,27 @@ pub fn install(
     mur_home: &Path,
     surface: &str,
 ) -> Result<InstallOutcome, MuragentError> {
+    install_with_name(archive, mur_home, surface, None)
+}
+
+/// Install or update a `.muragent` archive, optionally under an explicit
+/// install name (directory + slug) rather than the manifest's own slug.
+///
+/// When `install_name` is `Some(n)`, the archive is installed at
+/// `<mur_home>/agents/<n>/` regardless of the manifest's slug. This powers
+/// `mur agent install <bundle> --as <name>` clones: a clone is always a
+/// fresh install (never an update-in-place), so this path REFUSES if the
+/// target directory already exists rather than taking the same-UUID update
+/// path that `install` uses.
+///
+/// `install(...)` is a thin wrapper around this function with `None`, so its
+/// behavior is unchanged for existing callers.
+pub fn install_with_name(
+    archive: &MuragentArchive,
+    mur_home: &Path,
+    surface: &str,
+    install_name: Option<&str>,
+) -> Result<InstallOutcome, MuragentError> {
     // Step 1: validation pipeline — fatal on any failure per §7.5
     let result = validator::validate(archive)?;
 
@@ -87,11 +108,20 @@ pub fn install(
     reject_reserved_local_files(archive)?;
 
     // Step 2: slug shape
-    let slug = result.manifest.agent.slug.clone();
+    let manifest_slug = result.manifest.agent.slug.clone();
     let display_name = result.manifest.agent.display_name.clone();
-    crate::validate_agent_name(&slug).map_err(|e| {
-        MuragentError::Other(format!("invalid agent slug '{slug}' in manifest: {e}"))
+    crate::validate_agent_name(&manifest_slug).map_err(|e| {
+        MuragentError::Other(format!(
+            "invalid agent slug '{manifest_slug}' in manifest: {e}"
+        ))
     })?;
+    let slug = if let Some(n) = install_name {
+        crate::validate_agent_name(n)
+            .map_err(|e| MuragentError::Other(format!("invalid install name '{n}': {e}")))?;
+        n.to_string()
+    } else {
+        manifest_slug
+    };
 
     // Step 3: trust store key-change check
     let mut trust_store = TrustStore::load()?;
@@ -126,6 +156,14 @@ pub fn install(
 
     // Step 4-5: detect update vs collision; extract payload
     let agent_dir = mur_home.join("agents").join(&slug);
+    if install_name.is_some() && agent_dir.exists() {
+        // A clone (`--as <name>`) is always a fresh install — never an
+        // update-in-place, even if the UUID happened to match.
+        return Err(MuragentError::Other(format!(
+            "agent '{slug}' already exists at {} — refusing to overwrite",
+            agent_dir.display()
+        )));
+    }
     let was_update = if agent_dir.exists() {
         let existing_profile = agent_dir.join("profile.yaml");
         let mut is_same_agent = false;
@@ -682,6 +720,41 @@ mod tests {
         );
 
         // Cleanup
+        unsafe {
+            if let Some(p) = prev {
+                std::env::set_var("MUR_HOME", p);
+            } else {
+                std::env::remove_var("MUR_HOME");
+            }
+        }
+    }
+
+    #[test]
+    fn install_with_name_installs_under_override_name_and_refuses_collision() {
+        let _guard = crate::trust::test_env_lock::MUR_HOME_LOCK.lock().unwrap();
+        let tmp = TempDir::new().unwrap();
+        let mur_home = tmp.path().join("mur");
+        let prev = std::env::var_os("MUR_HOME");
+        unsafe { std::env::set_var("MUR_HOME", &mur_home) };
+
+        let pkg = make_test_package(&tmp);
+        let archive = MuragentArchive::read(&pkg).unwrap();
+
+        let outcome = install_with_name(&archive, &mur_home, "test", Some("clone-x")).unwrap();
+        assert!(!outcome.was_update);
+        let clone_dir = mur_home.join("agents").join("clone-x");
+        assert!(clone_dir.join("profile.yaml").exists());
+
+        // Installing again under the same override name must refuse — a
+        // clone is always a fresh install, never an update-in-place.
+        let archive2 = MuragentArchive::read(&pkg).unwrap();
+        let err = install_with_name(&archive2, &mur_home, "test", Some("clone-x")).unwrap_err();
+        assert!(
+            matches!(err, MuragentError::Other(_)),
+            "expected refuse-on-collision error, got: {:?}",
+            err
+        );
+
         unsafe {
             if let Some(p) = prev {
                 std::env::set_var("MUR_HOME", p);

--- a/mur-common/src/telemetry.rs
+++ b/mur-common/src/telemetry.rs
@@ -68,6 +68,11 @@ pub const METHOD_NOTE_RETRIEVED: &str = "mur.note.retrieved";
 /// Reduced into `SkillStats::curated_at`; opens the A1 provenance gate.
 pub const METHOD_SKILL_CURATED: &str = "mur.skill.curated";
 
+/// Emitted by `mur agent mcp set-network --broad-audited` — an operator
+/// granted a per-server BroadAudited egress policy (advisory-enforced,
+/// audited-CONNECT). Records which agent+server was authorized.
+pub const METHOD_EGRESS_BROAD_AUDITED_ENABLED: &str = "mur.egress.broad_audited.enabled";
+
 pub const MUR_SKILL_NAME: &str = "mur.skill.name";
 pub const MUR_SKILL_VERSION: &str = "mur.skill.version";
 pub const MUR_SKILL_OUTCOME: &str = "mur.skill.outcome";

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -797,7 +797,9 @@ pub enum AgentMcpAction {
         server_id: String,
         #[arg(long)]
         command: String,
-        #[arg(long = "arg")]
+        /// A single argument for the MCP command (repeatable). Values may
+        /// start with `-`/`--`, e.g. `--arg --engine` or `--arg=--engine`.
+        #[arg(long = "arg", allow_hyphen_values = true)]
         args: Vec<String>,
         /// Skip the y/N install confirmation prompt (B0 rule 6 / M9.2).
         /// Use for scripted / non-interactive installs.
@@ -1098,5 +1100,34 @@ mod tests {
             panic!("expected Mcp::RegistryAdd variant");
         };
         assert!(!force);
+    }
+
+    #[test]
+    fn mcp_add_arg_accepts_hyphen_prefixed_values() {
+        // Regression: `--arg --engine` must be consumed as the value, not
+        // rejected as an unknown flag (allow_hyphen_values).
+        let cli = Cli::try_parse_from([
+            "mur",
+            "agent",
+            "mcp",
+            "add",
+            "t",
+            "x",
+            "--command",
+            "foo",
+            "--arg",
+            "--engine",
+        ])
+        .expect("parse argv");
+        let Commands::Agent {
+            action: AgentAction::Mcp { action },
+        } = cli.command
+        else {
+            panic!("expected Agent::Mcp variant");
+        };
+        let crate::cli::agent::AgentMcpAction::Add { args, .. } = action else {
+            panic!("expected Mcp::Add variant");
+        };
+        assert_eq!(args, vec!["--engine".to_string()]);
     }
 }

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -51,8 +51,9 @@ pub enum AgentAction {
     /// upgraded runtime binary. Sends SIGTERM (drains in-flight turn), waits
     /// for exit, then polls for the launchd-respawned process.
     Restart {
-        /// Agent name (mutually exclusive with --all / --stale)
-        name: Option<String>,
+        /// Agent name(s) (mutually exclusive with --all / --stale)
+        #[arg(num_args = 0..)]
+        names: Vec<String>,
         /// Restart all running agents
         #[arg(long)]
         all: bool,

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -245,8 +245,13 @@ pub enum AgentAction {
         /// Device fingerprint (see `mur agent devices`) or full pubkey.
         fingerprint: String,
     },
-    /// Run prereq checks for export targets (no build, just diagnostics)
+    /// Run prereq checks for export targets (no build, just diagnostics).
+    /// With NAME, runs per-agent health checks (model_ref, MCP command
+    /// resolution, entitlements) instead.
     Doctor {
+        /// Agent name to run per-agent health checks for. Omit for the
+        /// existing export-prereq checks.
+        name: Option<String>,
         /// What format the doctor should validate prereqs for: "gui" / "bin" / "pkg" / "all"
         #[arg(long, default_value = "all")]
         format: String,

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -874,9 +874,22 @@ pub enum AgentMcpAction {
         /// Allowed host (repeatable), e.g. `--allow-host example.com --allow-host '*.api.example.com'`.
         #[arg(long = "allow-host")]
         allow_hosts: Vec<String>,
+        /// Denied host (repeatable). With `--broad-audited`, these are the
+        /// deny-overlay hosts; ignored otherwise.
+        #[arg(long = "deny-host")]
+        deny_hosts: Vec<String>,
         /// Deny this server all outbound network.
         #[arg(long)]
         off: bool,
+        /// Grant allow-ALL-except-`--deny-host` egress, routed through the
+        /// audited proxy. Permission-required: requires operator consent
+        /// (prompts unless `--yes`) and records who authorized it and when.
+        #[arg(long = "broad-audited", conflicts_with = "off")]
+        broad_audited: bool,
+        /// Skip the y/N consent prompt for `--broad-audited`. Use for
+        /// scripted / non-interactive grants.
+        #[arg(long)]
+        yes: bool,
     },
     /// Scan other installed tools (Claude Desktop/Code, Cursor, VS Code,
     /// Windsurf, Antigravity, Gemini CLI, Codex) for MCP servers you can import.

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -195,6 +195,12 @@ pub enum AgentAction {
         /// Example: --model ollama_llama3_2_3b
         #[arg(long)]
         model: Option<String>,
+        /// Install as a NEW, distinct agent under this name — a fresh
+        /// profile.id (uuid v7) and a freshly minted, persisted Ed25519
+        /// identity (never the source's private key). Refuses if an agent
+        /// already exists at this name.
+        #[arg(long = "as", value_name = "NAME")]
+        as_name: Option<String>,
     },
     /// Uninstall an agent (data preserved at <home>/data unless --purge)
     Uninstall {

--- a/mur-core/src/cmd/agent/install.rs
+++ b/mur-core/src/cmd/agent/install.rs
@@ -36,6 +36,15 @@ pub fn cmd_install(path: &Path, model_ref_override: Option<&str>) -> Result<()> 
     println!("  fingerprint: {}", outcome.fingerprint_hex);
     println!("  words:       {}", outcome.fingerprint_words);
 
+    if !outcome.downgraded_broad_egress.is_empty() {
+        let names = outcome.downgraded_broad_egress.join(", ");
+        let slug = &outcome.manifest.agent.slug;
+        println!(
+            "⚠ broad-audited egress was reset to inherit for: {names}. \
+             Re-grant locally with: mur agent mcp set-network {slug} <server> --broad-audited"
+        );
+    }
+
     if let Some(model_ref) = model_ref_override {
         apply_model_ref_override(&mur_home, &outcome.manifest.agent.slug, model_ref)?;
     } else {

--- a/mur-core/src/cmd/agent/install.rs
+++ b/mur-core/src/cmd/agent/install.rs
@@ -8,6 +8,8 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
+use mur_common::agent::AgentProfile;
+use mur_common::identity::AgentIdentity;
 use mur_common::muragent::installer::{self, InstallOutcome};
 use mur_common::muragent::manifest::MuragentManifest;
 use mur_common::muragent::reader::MuragentArchive;
@@ -16,40 +18,79 @@ use mur_common::trust;
 
 use super::resolve_mur_home;
 
-pub fn cmd_install(path: &Path, model_ref_override: Option<&str>) -> Result<()> {
+pub fn cmd_install(
+    path: &Path,
+    model_ref_override: Option<&str>,
+    as_name: Option<&str>,
+) -> Result<()> {
     let archive = MuragentArchive::read(path)
         .with_context(|| format!("read .muragent file at {}", path.display()))?;
     let mur_home = resolve_mur_home()?;
-    let outcome: InstallOutcome =
-        installer::install(&archive, &mur_home, "cli").context("install .muragent")?;
+    let outcome: InstallOutcome = installer::install_with_name(&archive, &mur_home, "cli", as_name)
+        .context("install .muragent")?;
 
-    let verb = if outcome.was_update {
-        "Updated"
+    // The install/dispatch name: the clone's name when `--as` was given,
+    // else the manifest's own slug (unchanged from prior behavior).
+    let installed_name: &str = as_name.unwrap_or(&outcome.manifest.agent.slug);
+
+    if let Some(clone_name) = as_name {
+        clone_identity_and_profile(&mur_home, clone_name)?;
+        println!("Cloned agent as '{clone_name}'");
     } else {
-        "Installed"
-    };
-    println!(
-        "{verb} agent '{}' ({})",
-        outcome.manifest.agent.display_name, outcome.manifest.agent.slug
-    );
+        let verb = if outcome.was_update {
+            "Updated"
+        } else {
+            "Installed"
+        };
+        println!(
+            "{verb} agent '{}' ({})",
+            outcome.manifest.agent.display_name, outcome.manifest.agent.slug
+        );
+    }
     println!("  trust:       {:?}", outcome.trust_level);
     println!("  fingerprint: {}", outcome.fingerprint_hex);
     println!("  words:       {}", outcome.fingerprint_words);
 
     if !outcome.downgraded_broad_egress.is_empty() {
         let names = outcome.downgraded_broad_egress.join(", ");
-        let slug = &outcome.manifest.agent.slug;
         println!(
             "⚠ broad-audited egress was reset to inherit for: {names}. \
-             Re-grant locally with: mur agent mcp set-network {slug} <server> --broad-audited"
+             Re-grant locally with: mur agent mcp set-network {installed_name} <server> --broad-audited"
         );
     }
 
     if let Some(model_ref) = model_ref_override {
-        apply_model_ref_override(&mur_home, &outcome.manifest.agent.slug, model_ref)?;
+        apply_model_ref_override(&mur_home, installed_name, model_ref)?;
     } else {
-        maybe_resolve_model(&mur_home, &outcome.manifest.agent.slug, &archive)?;
+        maybe_resolve_model(&mur_home, installed_name, &archive)?;
     }
+    Ok(())
+}
+
+/// After a `--as <name>` clone install, give the clone a new identity: a
+/// fresh UUIDv7 `profile.id`, `profile.name` set to the clone's directory
+/// name, and a freshly minted + persisted Ed25519 identity (never the
+/// source agent's private key — the installer already strips
+/// `identity.key` from any incoming payload).
+fn clone_identity_and_profile(mur_home: &Path, clone_name: &str) -> Result<()> {
+    let agent_dir = mur_home.join("agents").join(clone_name);
+    let profile_path = agent_dir.join("profile.yaml");
+    let mut profile: AgentProfile = serde_yaml_ng::from_str(
+        &std::fs::read_to_string(&profile_path)
+            .with_context(|| format!("read {}", profile_path.display()))?,
+    )
+    .with_context(|| format!("parse {}", profile_path.display()))?;
+
+    profile.name = clone_name.to_string();
+    profile.id = uuid::Uuid::now_v7().to_string();
+
+    std::fs::write(&profile_path, serde_yaml_ng::to_string(&profile)?)
+        .with_context(|| format!("write {}", profile_path.display()))?;
+
+    AgentIdentity::generate()
+        .save(&agent_dir)
+        .map_err(|e| anyhow::anyhow!("save fresh identity for clone '{clone_name}': {e}"))?;
+
     Ok(())
 }
 
@@ -308,5 +349,44 @@ mod tests {
         )
         .unwrap();
         assert_eq!(profile.model_ref.as_deref(), Some("ollama_llama3_2_3b"));
+    }
+
+    #[test]
+    fn cmd_install_as_clones_with_new_id_and_fresh_identity() {
+        use mur_common::agent::AgentProfile as Profile;
+        use mur_common::identity::AgentIdentity as Identity;
+        use mur_common::muragent::writer::{MuragentWriter, build_manifest_from_profile};
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let mur_home = tmp.path().join("mur");
+        unsafe {
+            std::env::set_var("MUR_HOME", &mur_home);
+        }
+
+        // Build a source .muragent bundle with a known source profile id.
+        let mut source_profile = Profile::default_for_tests();
+        source_profile.name = "aura".to_string();
+        let source_id = source_profile.id.clone();
+        let manifest = build_manifest_from_profile(&source_profile, "2.13.0");
+        let profile_yaml = serde_yaml_ng::to_string(&source_profile).unwrap();
+        let writer = MuragentWriter::new(manifest, profile_yaml, Identity::generate());
+        let bundle_path = tmp.path().join("aura.muragent");
+        writer.write(&bundle_path).unwrap();
+
+        cmd_install(&bundle_path, None, Some("clone-x")).unwrap();
+
+        let clone_dir = mur_home.join("agents").join("clone-x");
+        let profile: Profile = serde_yaml_ng::from_str(
+            &std::fs::read_to_string(clone_dir.join("profile.yaml")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(profile.name, "clone-x");
+        assert_ne!(profile.id, source_id, "clone must get a new profile.id");
+        assert!(
+            clone_dir.join("identity.key").exists(),
+            "clone must have a freshly minted identity.key"
+        );
+        assert!(clone_dir.join("identity.pub").exists());
     }
 }

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -225,17 +225,6 @@ pub fn cmd_create(
     Ok(())
 }
 
-/// Resolve the `model_ref` an agent should carry so the runtime loads real
-/// credentials from `~/.mur/models.yaml`. Cloud providers (anthropic, openai,
-/// …) require a registry entry to supply the secret + proxy base URL; without
-/// one the runtime falls back to StubEcho. Local backends (`ollama`, `local`)
-/// authenticate without a secret, so they stay on the inline `model:` block.
-///
-/// Preference order for cloud providers:
-///   1. Reuse an existing registry entry whose provider+model match (inherits
-///      its secret + base_url — this is how the working agents are wired).
-///   2. Otherwise upsert a new secretless entry keyed by provider+model so the
-///      binding at least exists and the user has a single place to add a secret.
 /// Look up an exact registry key match for a bare `--model` value (e.g.
 /// `claude_sonnet`). Returns the entry's `(provider, model)` when found.
 fn registry_alias_entry(mur_home: &Path, key: &str) -> Result<Option<(String, String)>> {
@@ -250,6 +239,17 @@ fn registry_alias_entry(mur_home: &Path, key: &str) -> Result<Option<(String, St
         .map(|entry| (entry.provider.clone(), entry.model.clone())))
 }
 
+/// Resolve the `model_ref` an agent should carry so the runtime loads real
+/// credentials from `~/.mur/models.yaml`. Cloud providers (anthropic, openai,
+/// …) require a registry entry to supply the secret + proxy base URL; without
+/// one the runtime falls back to StubEcho. Local backends (`ollama`, `local`)
+/// authenticate without a secret, so they stay on the inline `model:` block.
+///
+/// Preference order for cloud providers:
+///   1. Reuse an existing registry entry whose provider+model match (inherits
+///      its secret + base_url — this is how the working agents are wired).
+///   2. Otherwise upsert a new secretless entry keyed by provider+model so the
+///      binding at least exists and the user has a single place to add a secret.
 fn resolve_model_ref_for_create(
     mur_home: &Path,
     provider: Option<&str>,

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -44,22 +44,43 @@ pub fn cmd_create(
     let raw_model = model.unwrap_or_else(|| "llama3.2:3b".to_string());
     // E2 fix: support `provider/model` shorthand in --model. Explicit --provider
     // wins. Default provider is `ollama` for backward compatibility.
-    let (resolved_provider, resolved_model) = match provider {
-        Some(p) => (p, raw_model),
-        None => match raw_model.split_once('/') {
-            Some((p, rest)) if !p.is_empty() && !rest.is_empty() && is_known_provider(p) => {
-                (p.to_string(), rest.to_string())
-            }
-            _ => ("ollama".to_string(), raw_model),
-        },
+    //
+    // Bug fix: a bare `--model` value (no `--provider`, no `provider/model`
+    // slash form) that exactly matches an existing `models.yaml` registry key
+    // binds the agent to that entry directly, instead of silently falling
+    // through to the ollama default and leaving `model_ref` unset (StubEcho).
+    let alias_entry = if provider.is_none() {
+        registry_alias_entry(&mur_home, &raw_model)?
+    } else {
+        None
     };
-    // Bind the agent to a models.yaml registry entry so the runtime can
-    // resolve real credentials + base_url via `model_ref` (the path working
-    // agents use). Writing only the inline `model:` block leaves the runtime
-    // with no secret for cloud providers, which silently degrades to StubEcho.
-    // Local backends (ollama/local) need no secret, so we leave them inline.
-    let resolved_model_ref =
-        resolve_model_ref_for_create(&mur_home, &resolved_provider, &resolved_model)?;
+    let (resolved_provider, resolved_model, resolved_model_ref) =
+        if let Some((entry_provider, entry_model)) = alias_entry {
+            (entry_provider, entry_model, Some(raw_model.clone()))
+        } else {
+            let (resolved_provider, resolved_model) = match provider {
+                Some(p) => (p, raw_model),
+                None => match raw_model.split_once('/') {
+                    Some((p, rest))
+                        if !p.is_empty() && !rest.is_empty() && is_known_provider(p) =>
+                    {
+                        (p.to_string(), rest.to_string())
+                    }
+                    _ => ("ollama".to_string(), raw_model),
+                },
+            };
+            // Bind the agent to a models.yaml registry entry so the runtime can
+            // resolve real credentials + base_url via `model_ref` (the path working
+            // agents use). Writing only the inline `model:` block leaves the runtime
+            // with no secret for cloud providers, which silently degrades to StubEcho.
+            // Local backends (ollama/local) need no secret, so we leave them inline.
+            let model_ref = resolve_model_ref_for_create(
+                &mur_home,
+                Some(resolved_provider.as_str()),
+                &resolved_model,
+            )?;
+            (resolved_provider, resolved_model, model_ref)
+        };
 
     let now = chrono::Utc::now().to_rfc3339();
     let id = uuid::Uuid::now_v7().to_string();
@@ -215,12 +236,35 @@ pub fn cmd_create(
 ///      its secret + base_url — this is how the working agents are wired).
 ///   2. Otherwise upsert a new secretless entry keyed by provider+model so the
 ///      binding at least exists and the user has a single place to add a secret.
+/// Look up an exact registry key match for a bare `--model` value (e.g.
+/// `claude_sonnet`). Returns the entry's `(provider, model)` when found.
+fn registry_alias_entry(mur_home: &Path, key: &str) -> Result<Option<(String, String)>> {
+    use mur_common::model::ModelRegistry;
+
+    let reg_path = mur_home.join("models.yaml");
+    let reg = ModelRegistry::load_from(&reg_path)
+        .with_context(|| format!("load model registry {}", reg_path.display()))?;
+    Ok(reg
+        .models
+        .get(key)
+        .map(|entry| (entry.provider.clone(), entry.model.clone())))
+}
+
 fn resolve_model_ref_for_create(
     mur_home: &Path,
-    provider: &str,
+    provider: Option<&str>,
     model: &str,
 ) -> Result<Option<String>> {
     use mur_common::model::{ModelEntry, ModelRegistry};
+
+    // Bare model, no explicit provider: if it's an exact registry key, bind
+    // to that entry directly rather than falling through to the ollama
+    // default (which would silently leave model_ref unset / StubEcho).
+    if provider.is_none() && registry_alias_entry(mur_home, model)?.is_some() {
+        return Ok(Some(model.to_string()));
+    }
+
+    let provider = provider.unwrap_or("ollama");
 
     // Local backends do not need a registry-supplied secret.
     if matches!(provider, "ollama" | "local") {
@@ -849,6 +893,66 @@ fn is_unread(body: &str) -> bool {
         .rev()
         .find_map(|l| l.strip_prefix(marker).map(|v| v.trim() == "<unset>"))
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests_resolve_model_ref_for_create {
+    use super::*;
+    use mur_common::model::{ModelEntry, ModelRegistry};
+    use std::collections::BTreeMap;
+    use tempfile::TempDir;
+
+    fn seed_models_yaml(home: &TempDir, key: &str, provider: &str, model: &str) {
+        let mut models = BTreeMap::new();
+        models.insert(
+            key.to_string(),
+            ModelEntry {
+                provider: provider.to_string(),
+                model: model.to_string(),
+                ..Default::default()
+            },
+        );
+        let reg = ModelRegistry {
+            schema_version: 1,
+            models,
+            roles: BTreeMap::new(),
+        };
+        reg.save_to(&home.path().join("models.yaml")).unwrap();
+    }
+
+    #[test]
+    fn create_with_bare_alias_sets_model_ref() {
+        let home = TempDir::new().unwrap();
+        seed_models_yaml(&home, "claude_sonnet", "anthropic", "claude-sonnet-5");
+
+        let mr = resolve_model_ref_for_create(home.path(), None, "claude_sonnet").unwrap();
+
+        assert_eq!(mr, Some("claude_sonnet".to_string()));
+    }
+
+    #[test]
+    fn create_with_unknown_bare_model_leaves_model_ref_unset() {
+        let home = TempDir::new().unwrap();
+        seed_models_yaml(&home, "claude_sonnet", "anthropic", "claude-sonnet-5");
+
+        // Not a registry key, and provider is None -> caller defaults to
+        // ollama before ever calling this function, so this case should not
+        // be reached with a non-alias bare model; verify no false alias hit.
+        let mr = resolve_model_ref_for_create(home.path(), None, "llama3.2:3b").unwrap();
+
+        assert_eq!(mr, None);
+    }
+
+    #[test]
+    fn explicit_provider_still_matches_registry_entry() {
+        let home = TempDir::new().unwrap();
+        seed_models_yaml(&home, "claude_sonnet", "anthropic", "claude-sonnet-5");
+
+        let mr = resolve_model_ref_for_create(home.path(), Some("anthropic"), "claude-sonnet-5")
+            .unwrap();
+
+        assert_eq!(mr, Some("claude_sonnet".to_string()));
+    }
 }
 
 #[cfg(test)]

--- a/mur-core/src/cmd/agent/mcp.rs
+++ b/mur-core/src/cmd/agent/mcp.rs
@@ -22,6 +22,30 @@ pub struct McpAddPin {
     pub publisher_registry_id: Option<String>,
 }
 
+/// Render a single MCP server entry as a formatted line, with warning for BroadAudited mode.
+fn render_server_line(s: &McpServerEntry) -> String {
+    let base_line = format!("{}\t{} {}", s.name, s.command, s.args.join(" "))
+        .trim_end()
+        .to_string();
+
+    if let Some(net) = &s.network {
+        if net.mode == McpNetMode::BroadAudited {
+            let authorized_by = net
+                .authorization
+                .as_ref()
+                .map(|a| a.authorized_by.as_str())
+                .unwrap_or("unknown");
+            let warning = format!(
+                "\n  ⚠ BROAD EGRESS (audited) — allows any host except deny_hosts; authorized by {}",
+                authorized_by
+            );
+            return base_line + &warning;
+        }
+    }
+
+    base_line
+}
+
 pub fn cmd_mcp_list(name: &str) -> Result<()> {
     let (_path, profile) = load_profile_for_edit(name)?;
     if profile.mcp_servers.is_empty() {
@@ -29,7 +53,7 @@ pub fn cmd_mcp_list(name: &str) -> Result<()> {
         return Ok(());
     }
     for s in &profile.mcp_servers {
-        println!("{}\t{} {}", s.name, s.command, s.args.join(" "));
+        println!("{}", render_server_line(s));
     }
     Ok(())
 }
@@ -601,5 +625,107 @@ mod tests {
         let net = e.network.as_ref().expect("network should be set");
         assert_eq!(net.mode, McpNetMode::Restricted);
         assert_eq!(net.allow_hosts, vec!["mcp.example.com"]);
+    }
+
+    #[test]
+    fn render_server_line_broad_audited_with_authorization() {
+        let server = McpServerEntry {
+            name: "browser".to_string(),
+            command: "firefox".to_string(),
+            args: vec!["--mcp".to_string()],
+            binary_sha256: None,
+            description_hash: None,
+            publisher: None,
+            installed_at: None,
+            timeout_secs: None,
+            network: Some(McpServerNetwork {
+                mode: McpNetMode::BroadAudited,
+                allow_hosts: vec![],
+                deny_hosts: vec!["badhost.com".to_string()],
+                authorization: Some(EgressAuthorization {
+                    authorized_by: "alice".to_string(),
+                    authorized_at_ms: 1_700_000_000_000,
+                }),
+            }),
+            url: None,
+            auth: None,
+        };
+        let output = render_server_line(&server);
+        assert!(output.contains("browser\tfirefox --mcp"));
+        assert!(output.contains("BROAD EGRESS (audited)"));
+        assert!(output.contains("authorized by alice"));
+    }
+
+    #[test]
+    fn render_server_line_broad_audited_without_authorization_fallback() {
+        let server = McpServerEntry {
+            name: "browser".to_string(),
+            command: "firefox".to_string(),
+            args: vec![],
+            binary_sha256: None,
+            description_hash: None,
+            publisher: None,
+            installed_at: None,
+            timeout_secs: None,
+            network: Some(McpServerNetwork {
+                mode: McpNetMode::BroadAudited,
+                allow_hosts: vec![],
+                deny_hosts: vec![],
+                authorization: None,
+            }),
+            url: None,
+            auth: None,
+        };
+        let output = render_server_line(&server);
+        assert!(output.contains("browser\tfirefox"));
+        assert!(output.contains("BROAD EGRESS (audited)"));
+        assert!(output.contains("authorized by unknown"));
+    }
+
+    #[test]
+    fn render_server_line_restricted_no_warning() {
+        let server = McpServerEntry {
+            name: "api".to_string(),
+            command: "mcp-api".to_string(),
+            args: vec![],
+            binary_sha256: None,
+            description_hash: None,
+            publisher: None,
+            installed_at: None,
+            timeout_secs: None,
+            network: Some(McpServerNetwork {
+                mode: McpNetMode::Restricted,
+                allow_hosts: vec!["example.com".to_string()],
+                deny_hosts: vec![],
+                authorization: None,
+            }),
+            url: None,
+            auth: None,
+        };
+        let output = render_server_line(&server);
+        assert!(output.contains("api\tmcp-api"));
+        assert!(!output.contains("BROAD EGRESS"));
+        assert!(!output.contains("authorized by"));
+    }
+
+    #[test]
+    fn render_server_line_no_network_no_warning() {
+        let server = McpServerEntry {
+            name: "local".to_string(),
+            command: "local-mcp".to_string(),
+            args: vec![],
+            binary_sha256: None,
+            description_hash: None,
+            publisher: None,
+            installed_at: None,
+            timeout_secs: None,
+            network: None,
+            url: None,
+            auth: None,
+        };
+        let output = render_server_line(&server);
+        assert!(output.contains("local\tlocal-mcp"));
+        assert!(!output.contains("BROAD EGRESS"));
+        assert!(!output.contains("authorized by"));
     }
 }

--- a/mur-core/src/cmd/agent/mcp.rs
+++ b/mur-core/src/cmd/agent/mcp.rs
@@ -2,9 +2,10 @@
 //! an agent profile.
 
 use anyhow::{Context, Result, bail};
-use mur_common::agent::{McpNetMode, McpServerEntry, McpServerNetwork};
+use mur_common::agent::{EgressAuthorization, McpNetMode, McpServerEntry, McpServerNetwork};
+use mur_common::telemetry::METHOD_EGRESS_BROAD_AUDITED_ENABLED;
 
-use super::{load_profile_for_edit, save_profile};
+use super::{load_profile_for_edit, resolve_mur_home, save_profile};
 
 /// Optional install-time pinning fields for `cmd_mcp_add` (B0 rule 6 / M9.2).
 ///
@@ -213,7 +214,8 @@ pub fn cmd_mcp_set_enabled(name: &str, server_id: &str, enabled: bool) -> Result
 
 /// Pure mapping from CLI args to a per-server network policy:
 /// `off` ⇒ `Off`; a non-empty allowlist ⇒ `Restricted`; empty + !off ⇒ clear
-/// to `None` (inherit the agent-level policy).
+/// to `None` (inherit the agent-level policy). Non-`BroadAudited` modes never
+/// carry an `authorization` record.
 fn network_policy_from_args(allow_hosts: Vec<String>, off: bool) -> Option<McpServerNetwork> {
     if off {
         Some(McpServerNetwork {
@@ -234,13 +236,72 @@ fn network_policy_from_args(allow_hosts: Vec<String>, off: bool) -> Option<McpSe
     }
 }
 
+/// Pure builder for a `BroadAudited` grant: allow-ALL except `deny_hosts`,
+/// stamped with who authorized it and when. Requires explicit operator
+/// consent upstream (`cmd_mcp_set_network` prompts unless `yes`).
+fn broad_audited_network(
+    deny_hosts: Vec<String>,
+    authorized_by: String,
+    authorized_at_ms: u64,
+) -> McpServerNetwork {
+    McpServerNetwork {
+        mode: McpNetMode::BroadAudited,
+        allow_hosts: vec![],
+        deny_hosts,
+        authorization: Some(EgressAuthorization {
+            authorized_by,
+            authorized_at_ms,
+        }),
+    }
+}
+
+/// Append a `mur.egress.broad_audited.enabled` event to today's trace log,
+/// mirroring `skill_curate::record_curation`.
+fn record_broad_audited_enabled(
+    mur_home: &std::path::Path,
+    agent: &str,
+    server_id: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<()> {
+    let traces_dir = mur_home.join("traces");
+    std::fs::create_dir_all(&traces_dir)
+        .with_context(|| format!("create {}", traces_dir.display()))?;
+    let path = traces_dir
+        .join(now.format("%Y-%m-%d").to_string())
+        .with_extension("jsonl");
+
+    let line = serde_json::json!({
+        "ts": now.to_rfc3339(),
+        "method": METHOD_EGRESS_BROAD_AUDITED_ENABLED,
+        "mur.agent.name": agent,
+        "mur.mcp.server_id": server_id,
+    });
+
+    use std::io::Write;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("open {}", path.display()))?;
+    writeln!(f, "{}", serde_json::to_string(&line)?)?;
+    Ok(())
+}
+
 /// Set (or clear) a per-server egress policy on `server_id`. Restart the agent
 /// to apply (the sandbox + proxy are wired at supervisor startup).
+///
+/// `broad_audited=true` requests an allow-ALL-except-`deny_hosts` grant,
+/// routed through the audited egress proxy — a permission-required action.
+/// Unless `yes` is set, prompts for explicit `[y/N]` consent on stdin before
+/// writing the authorization record and emitting telemetry.
 pub fn cmd_mcp_set_network(
     agent: &str,
     server_id: &str,
     allow_hosts: Vec<String>,
+    deny_hosts: Vec<String>,
     off: bool,
+    broad_audited: bool,
+    yes: bool,
 ) -> Result<()> {
     let (path, mut profile) = load_profile_for_edit(agent)?;
     let srv = profile
@@ -248,8 +309,51 @@ pub fn cmd_mcp_set_network(
         .iter_mut()
         .find(|s| s.name == server_id)
         .ok_or_else(|| anyhow::anyhow!("MCP server '{server_id}' not found on '{agent}'"))?;
-    srv.network = network_policy_from_args(allow_hosts, off);
-    save_profile(&path, &mut profile)?;
+
+    if broad_audited {
+        println!(
+            "This grants MCP server '{server_id}' on agent '{agent}' outbound access to ALL hosts \
+             except: {}\nEvery CONNECT is audited, but this is a broad trust grant — only use it \
+             for tools that legitimately need unenumerable destinations (e.g. a research browser).",
+            if deny_hosts.is_empty() {
+                "(none)".to_string()
+            } else {
+                deny_hosts.join(", ")
+            }
+        );
+        if !yes {
+            print!("\nApprove broad-audited egress? [y/N] ");
+            use std::io::{self, Write};
+            io::stdout().flush().ok();
+            let mut answer = String::new();
+            io::stdin()
+                .read_line(&mut answer)
+                .with_context(|| "read confirmation from stdin")?;
+            if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+                bail!("broad-audited egress grant cancelled");
+            }
+        }
+
+        let authorized_by = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
+        let authorized_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        srv.network = Some(broad_audited_network(
+            deny_hosts,
+            authorized_by,
+            authorized_at_ms,
+        ));
+        save_profile(&path, &mut profile)?;
+
+        let mur_home = resolve_mur_home()?;
+        record_broad_audited_enabled(&mur_home, agent, server_id, chrono::Utc::now())?;
+    } else {
+        // Any non-BroadAudited mode change clears a prior authorization.
+        srv.network = network_policy_from_args(allow_hosts, off);
+        save_profile(&path, &mut profile)?;
+    }
+
     println!("Updated egress policy for '{server_id}'. Restart the agent to apply.");
     Ok(())
 }
@@ -314,6 +418,60 @@ mod tests {
         let r = network_policy_from_args(vec!["example.com".into()], false).unwrap();
         assert_eq!(r.mode, McpNetMode::Restricted);
         assert_eq!(r.allow_hosts, vec!["example.com"]);
+    }
+
+    #[test]
+    fn broad_audited_network_carries_authorization_and_deny_hosts() {
+        let net = broad_audited_network(
+            vec!["evil.example".into()],
+            "dave".into(),
+            1_700_000_000_000,
+        );
+        assert_eq!(net.mode, McpNetMode::BroadAudited);
+        assert!(net.allow_hosts.is_empty());
+        assert_eq!(net.deny_hosts, vec!["evil.example"]);
+        let auth = net.authorization.expect("authorization must be set");
+        assert_eq!(auth.authorized_by, "dave");
+        assert_eq!(auth.authorized_at_ms, 1_700_000_000_000);
+    }
+
+    #[test]
+    fn network_policy_from_args_never_carries_authorization() {
+        // Non-BroadAudited modes must never carry an authorization record,
+        // even if one existed before (mode-change-away-from-BroadAudited
+        // clears it — enforced by cmd_mcp_set_network always calling this
+        // path when broad_audited=false).
+        assert!(
+            network_policy_from_args(vec!["example.com".into()], false)
+                .unwrap()
+                .authorization
+                .is_none()
+        );
+        assert!(
+            network_policy_from_args(vec![], true)
+                .unwrap()
+                .authorization
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn record_broad_audited_enabled_appends_an_event() {
+        let _lock = MUR_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mur_home = tmp.path();
+        let now = chrono::Utc::now();
+
+        record_broad_audited_enabled(mur_home, "carol", "browser", now).unwrap();
+
+        let path = mur_home
+            .join("traces")
+            .join(now.format("%Y-%m-%d").to_string())
+            .with_extension("jsonl");
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains(mur_common::telemetry::METHOD_EGRESS_BROAD_AUDITED_ENABLED));
+        assert!(contents.contains("carol"));
+        assert!(contents.contains("browser"));
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/mcp.rs
+++ b/mur-core/src/cmd/agent/mcp.rs
@@ -219,6 +219,8 @@ fn network_policy_from_args(allow_hosts: Vec<String>, off: bool) -> Option<McpSe
         Some(McpServerNetwork {
             mode: McpNetMode::Off,
             allow_hosts: vec![],
+            deny_hosts: vec![],
+            authorization: None,
         })
     } else if allow_hosts.is_empty() {
         None
@@ -226,6 +228,8 @@ fn network_policy_from_args(allow_hosts: Vec<String>, off: bool) -> Option<McpSe
         Some(McpServerNetwork {
             mode: McpNetMode::Restricted,
             allow_hosts,
+            deny_hosts: vec![],
+            authorization: None,
         })
     }
 }
@@ -272,6 +276,8 @@ pub fn cmd_mcp_add_remote(
     let network = egress_host.map(|host| mur_common::agent::McpServerNetwork {
         mode: McpNetMode::Restricted,
         allow_hosts: vec![host.to_string()],
+        deny_hosts: vec![],
+        authorization: None,
     });
     profile.mcp_servers.push(mur_common::agent::McpServerEntry {
         name: name.to_string(),

--- a/mur-core/src/cmd/agent/mcp.rs
+++ b/mur-core/src/cmd/agent/mcp.rs
@@ -28,19 +28,19 @@ fn render_server_line(s: &McpServerEntry) -> String {
         .trim_end()
         .to_string();
 
-    if let Some(net) = &s.network {
-        if net.mode == McpNetMode::BroadAudited {
-            let authorized_by = net
-                .authorization
-                .as_ref()
-                .map(|a| a.authorized_by.as_str())
-                .unwrap_or("unknown");
-            let warning = format!(
-                "\n  ⚠ BROAD EGRESS (audited) — allows any host except deny_hosts; authorized by {}",
-                authorized_by
-            );
-            return base_line + &warning;
-        }
+    if let Some(net) = &s.network
+        && net.mode == McpNetMode::BroadAudited
+    {
+        let authorized_by = net
+            .authorization
+            .as_ref()
+            .map(|a| a.authorized_by.as_str())
+            .unwrap_or("unknown");
+        let warning = format!(
+            "\n  ⚠ BROAD EGRESS (audited) — allows any host except deny_hosts; authorized by {}",
+            authorized_by
+        );
+        return base_line + &warning;
     }
 
     base_line

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -36,17 +36,20 @@ pub(crate) fn kill_wait_secs(stop_timeout_secs: u64) -> u64 {
 /// Return the names of running agents to restart.
 ///
 /// Selection rules (exactly one must be active):
-/// - `name = Some(_)` → that single agent (must have a running.lock)
+/// - `names` non-empty → those agents (each must have a running.lock;
+///   validated before any restart happens — no partial action)
 /// - `all = true` → all agents with a running.lock
 /// - `stale_only = true` → only running agents where `is_stale(lock, on_disk_sha())`
 ///
 /// If none of the three selectors is active an error is returned — bare
 /// `mur agent restart` (no args) must never silently restart everything.
+/// Passing explicit `names` together with `--all`/`--stale` is also an error
+/// (mutually exclusive selectors).
 ///
 /// `home` is the MUR_HOME path (e.g. `~/.mur`). Testable with a temp dir.
 pub(crate) fn select_targets(
     home: &Path,
-    name: Option<&str>,
+    names: &[&str],
     all: bool,
     stale_only: bool,
 ) -> Result<Vec<String>> {
@@ -57,26 +60,36 @@ pub(crate) fn select_targets(
     } else {
         String::new()
     };
-    select_targets_with_on_disk(home, name, all, stale_only, &on_disk)
+    select_targets_with_on_disk(home, names, all, stale_only, &on_disk)
 }
 
 /// Inner implementation that accepts the on-disk sha as a parameter so tests
 /// can inject a synthetic value without needing a real runtime binary.
 pub(crate) fn select_targets_with_on_disk(
     home: &Path,
-    name: Option<&str>,
+    names: &[&str],
     all: bool,
     stale_only: bool,
     on_disk: &str,
 ) -> Result<Vec<String>> {
     let agents_dir = home.join("agents");
 
-    if let Some(n) = name {
-        let lock_path = agents_dir.join(n).join("running.lock");
-        if !lock_path.exists() {
-            bail!("agent '{n}' is not running");
+    if !names.is_empty() {
+        if all || stale_only {
+            bail!("cannot combine an agent name with --all or --stale");
         }
-        return Ok(vec![n.to_string()]);
+        // Validate ALL names before restarting any — no partial action.
+        let mut not_running: Vec<&str> = Vec::new();
+        for n in names {
+            let lock_path = agents_dir.join(n).join("running.lock");
+            if !lock_path.exists() {
+                not_running.push(n);
+            }
+        }
+        if !not_running.is_empty() {
+            bail!("agent(s) not running: {}", not_running.join(", "));
+        }
+        return Ok(names.iter().map(|n| n.to_string()).collect());
     }
 
     // Require an explicit selector — never enumerate implicitly.
@@ -118,13 +131,14 @@ pub(crate) fn select_targets_with_on_disk(
 
 /// Gracefully restart one or more agents.
 ///
-/// - `name` / `all` / `stale`: select targets (mirror `cmd_stop`).
+/// - `names` / `all` / `stale`: select targets (mirror `cmd_stop`).
 /// - `dry_run`: print targets and return without acting.
-pub fn cmd_restart(name: Option<&str>, all: bool, stale: bool, dry_run: bool) -> Result<()> {
+pub fn cmd_restart(names: &[String], all: bool, stale: bool, dry_run: bool) -> Result<()> {
     let mur_home = resolve_mur_home()?;
     let agents_dir = mur_home.join("agents");
 
-    let targets = select_targets(&mur_home, name, all, stale)?;
+    let names_ref: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+    let targets = select_targets(&mur_home, &names_ref, all, stale)?;
 
     if targets.is_empty() {
         println!("No agents to restart.");
@@ -396,7 +410,7 @@ mod tests {
         fs::create_dir_all(&alpha_dir).unwrap();
         write_lock(&alpha_dir.join("running.lock"), 1111, "somesha");
 
-        let result = select_targets_with_on_disk(home, None, false, false, "somesha");
+        let result = select_targets_with_on_disk(home, &[], false, false, "somesha");
         assert!(result.is_err(), "bare restart with no selector must error");
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -423,7 +437,7 @@ mod tests {
         fs::create_dir_all(&beta_dir).unwrap();
         write_lock(&beta_dir.join("running.lock"), 2222, "cur000000000");
 
-        let result = select_targets_with_on_disk(home, None, false, true, "cur000000000").unwrap();
+        let result = select_targets_with_on_disk(home, &[], false, true, "cur000000000").unwrap();
         assert_eq!(
             result,
             vec!["alpha"],
@@ -437,8 +451,52 @@ mod tests {
         let home = tmp.path();
         fs::create_dir_all(home.join("agents").join("ghost")).unwrap();
         // No running.lock
-        let result = select_targets(home, Some("ghost"), false, false);
+        let result = select_targets(home, &["ghost"], false, false);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn select_targets_multiple_names_both_running() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let a_dir = home.join("agents").join("a");
+        let b_dir = home.join("agents").join("b");
+        fs::create_dir_all(&a_dir).unwrap();
+        fs::create_dir_all(&b_dir).unwrap();
+        write_lock(&a_dir.join("running.lock"), 1111, "shaaaaaaaaaa");
+        write_lock(&b_dir.join("running.lock"), 2222, "shabbbbbbbb");
+
+        let mut result = select_targets_with_on_disk(home, &["a", "b"], false, false, "").unwrap();
+        result.sort();
+        assert_eq!(result, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn select_targets_multiple_names_one_not_running_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let a_dir = home.join("agents").join("a");
+        let b_dir = home.join("agents").join("b");
+        fs::create_dir_all(&a_dir).unwrap();
+        fs::create_dir_all(&b_dir).unwrap();
+        write_lock(&a_dir.join("running.lock"), 1111, "shaaaaaaaaaa");
+        // No running.lock for 'b'
+
+        let result = select_targets_with_on_disk(home, &["a", "b"], false, false, "");
+        assert!(
+            result.is_err(),
+            "must fail-closed when any name isn't running"
+        );
+    }
+
+    #[test]
+    fn select_targets_names_and_all_mutually_exclusive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        fs::create_dir_all(home.join("agents")).unwrap();
+
+        let result = select_targets_with_on_disk(home, &["a"], true, false, "");
+        assert!(result.is_err(), "names + --all must be rejected");
     }
 
     #[test]
@@ -446,7 +504,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let home = tmp.path();
         fs::create_dir_all(home.join("agents")).unwrap();
-        let result = select_targets(home, None, true, false).unwrap();
+        let result = select_targets(home, &[], true, false).unwrap();
         assert!(result.is_empty());
     }
 

--- a/mur-core/src/cmd/agent/service.rs
+++ b/mur-core/src/cmd/agent/service.rs
@@ -18,7 +18,7 @@ pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {
 
     #[cfg(target_os = "macos")]
     {
-        let plist = darwin_plist(name, &symlink);
+        let plist = darwin_plist(name, &symlink, &derive_service_path());
         if dry_run {
             print!("{plist}");
             return Ok(());
@@ -46,7 +46,7 @@ pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {
     }
     #[cfg(target_os = "linux")]
     {
-        let unit = linux_unit(name, &symlink);
+        let unit = linux_unit(name, &symlink, &derive_service_path());
         if dry_run {
             print!("{unit}");
             return Ok(());
@@ -82,8 +82,41 @@ pub fn cmd_install_service(name: &str, dry_run: bool) -> Result<()> {
     Ok(())
 }
 
+/// Directories launchd hands every process by default (its minimal PATH),
+/// used as the tail of the derived service PATH.
+const LAUNCHD_DEFAULT_PATH_DIRS: &[&str] = &["/usr/bin", "/bin", "/usr/sbin", "/sbin"];
+
+/// Derive a PATH string for the installed service so PATH-installed MCP
+/// binaries (npm/homebrew) resolve when launchd/systemd starts the agent
+/// with its minimal default PATH.
+///
+/// Includes, in order: `<npm global prefix>/bin` (best-effort, skipped
+/// gracefully if npm is absent or fails), `/opt/homebrew/bin`,
+/// `/usr/local/bin`, then the launchd default dirs.
+fn derive_service_path() -> String {
+    let mut dirs: Vec<String> = Vec::new();
+
+    if let Ok(output) = std::process::Command::new("npm")
+        .args(["config", "get", "prefix"])
+        .output()
+    {
+        if output.status.success() {
+            let prefix = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !prefix.is_empty() {
+                dirs.push(format!("{prefix}/bin"));
+            }
+        }
+    }
+
+    dirs.push("/opt/homebrew/bin".to_string());
+    dirs.push("/usr/local/bin".to_string());
+    dirs.extend(LAUNCHD_DEFAULT_PATH_DIRS.iter().map(|d| d.to_string()));
+
+    dirs.join(":")
+}
+
 #[cfg(target_os = "macos")]
-fn darwin_plist(name: &str, symlink: &Path) -> String {
+fn darwin_plist(name: &str, symlink: &Path, service_path: &str) -> String {
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -100,6 +133,11 @@ fn darwin_plist(name: &str, symlink: &Path) -> String {
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>{path}</string>
+    </dict>
     <key>StandardErrorPath</key>
     <string>/tmp/mur-agent-{name}.err.log</string>
     <key>StandardOutPath</key>
@@ -108,11 +146,12 @@ fn darwin_plist(name: &str, symlink: &Path) -> String {
 </plist>
 "#,
         sym = symlink.display(),
+        path = service_path,
     )
 }
 
 #[cfg(target_os = "linux")]
-fn linux_unit(name: &str, symlink: &Path) -> String {
+fn linux_unit(name: &str, symlink: &Path, service_path: &str) -> String {
     format!(
         r#"[Unit]
 Description=murmur agent {name}
@@ -120,6 +159,7 @@ After=default.target
 
 [Service]
 Type=simple
+Environment=PATH={path}
 ExecStart={sym} start
 Restart=on-failure
 RestartSec=3
@@ -128,5 +168,31 @@ RestartSec=3
 WantedBy=default.target
 "#,
         sym = symlink.display(),
+        path = service_path,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plist_includes_path_env() {
+        let plist = darwin_plist(
+            "aura",
+            Path::new("/path/to/mur_agent_aura"),
+            "/opt/homebrew/bin:/usr/bin:/bin",
+        );
+        assert!(plist.contains("<key>EnvironmentVariables</key>"));
+        assert!(plist.contains("<key>PATH</key>"));
+        assert!(plist.contains("/opt/homebrew/bin"));
+    }
+
+    #[test]
+    fn derive_service_path_always_has_launchd_defaults() {
+        let path = derive_service_path();
+        for dir in LAUNCHD_DEFAULT_PATH_DIRS {
+            assert!(path.contains(dir), "missing {dir} in {path}");
+        }
+    }
 }

--- a/mur-core/src/cmd/agent/service.rs
+++ b/mur-core/src/cmd/agent/service.rs
@@ -176,6 +176,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(target_os = "macos")]
     fn plist_includes_path_env() {
         let plist = darwin_plist(
             "aura",

--- a/mur-core/src/cmd/agent/service.rs
+++ b/mur-core/src/cmd/agent/service.rs
@@ -99,12 +99,11 @@ fn derive_service_path() -> String {
     if let Ok(output) = std::process::Command::new("npm")
         .args(["config", "get", "prefix"])
         .output()
+        && output.status.success()
     {
-        if output.status.success() {
-            let prefix = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !prefix.is_empty() {
-                dirs.push(format!("{prefix}/bin"));
-            }
+        let prefix = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !prefix.is_empty() {
+            dirs.push(format!("{prefix}/bin"));
         }
     }
 

--- a/mur-core/src/cmd/doctor.rs
+++ b/mur-core/src/cmd/doctor.rs
@@ -380,6 +380,90 @@ fn check_signing_credentials() -> CheckResult {
     }
 }
 
+/// A single per-agent health-check result. Distinct from [`CheckResult`]
+/// (export-prereq checks) — this is a simpler ok/detail pair suited to
+/// unit testing without the Ok/Missing/Skipped tri-state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Check {
+    pub name: String,
+    pub ok: bool,
+    pub detail: String,
+}
+
+impl Check {
+    fn new(name: impl Into<String>, ok: bool, detail: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            ok,
+            detail: detail.into(),
+        }
+    }
+}
+
+/// Per-agent health checks: `model_ref` resolves in `models.yaml`, each
+/// MCP server's `command` resolves on PATH, and entitlements parsed
+/// cleanly (implied by `load_profile_for_edit` succeeding).
+pub fn agent_doctor(mur_home: &std::path::Path, name: &str) -> Result<Vec<Check>> {
+    let (_path, profile) = crate::cmd::agent::load_profile_for_edit(name)?;
+    let mut out = Vec::new();
+
+    match &profile.model_ref {
+        Some(model_ref) => {
+            let reg_path = mur_home.join("models.yaml");
+            let reg = mur_common::model::ModelRegistry::load_from(&reg_path)?;
+            if reg.models.contains_key(model_ref) {
+                out.push(Check::new(
+                    "model_ref",
+                    true,
+                    format!("'{model_ref}' resolves in models.yaml"),
+                ));
+            } else {
+                out.push(Check::new(
+                    "model_ref",
+                    false,
+                    format!("'{model_ref}' missing from models.yaml"),
+                ));
+            }
+        }
+        None => out.push(Check::new("model_ref", true, "inline model (no ref)")),
+    }
+
+    for server in &profile.mcp_servers {
+        let check_name = format!("mcp:{}", server.name);
+        match crate::cmd::agent_mcp_pin::resolve_command(&server.command) {
+            Ok(resolved) => out.push(Check::new(check_name, true, resolved.display().to_string())),
+            Err(e) => out.push(Check::new(check_name, false, e.to_string())),
+        }
+    }
+
+    out.push(Check::new("entitlements", true, "parsed"));
+
+    Ok(out)
+}
+
+/// Public entry point for `mur agent doctor <name>`. Prints a human table
+/// (or JSON with `--json`) and returns a non-zero exit (via `Err`) if any
+/// check failed — mirroring the export-prereq `run()` convention.
+pub fn run_agent(name: &str, json: bool) -> Result<()> {
+    let mur_home = crate::cmd::agent::resolve_mur_home()?;
+    let results = agent_doctor(&mur_home, name)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&results)?);
+    } else {
+        for c in &results {
+            let glyph = if c.ok { "✓" } else { "✗" };
+            println!("{glyph} {} ({})", c.name, c.detail);
+        }
+    }
+
+    let any_failed = results.iter().any(|c| !c.ok);
+    if any_failed {
+        anyhow::bail!("doctor found unhealthy checks for agent '{name}'");
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -410,5 +494,36 @@ mod tests {
             arch.status,
             CheckStatus::Ok | CheckStatus::Skipped
         ));
+    }
+
+    #[test]
+    fn agent_doctor_named_checks_model_ref_and_mcp() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mur_home = tmp.path().to_path_buf();
+        let agent_dir = mur_home.join("agents").join("coach");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+
+        let mut profile = mur_common::AgentProfile::default_for_tests();
+        profile.model_ref = Some("nonexistent_ref".into());
+        std::fs::write(
+            agent_dir.join("profile.yaml"),
+            serde_yaml_ng::to_string(&profile).unwrap(),
+        )
+        .unwrap();
+
+        // Isolate resolve_mur_home()/ModelRegistry::default_path() to the
+        // temp home; empty models.yaml means "nonexistent_ref" won't resolve.
+        unsafe {
+            std::env::set_var("MUR_HOME", &mur_home);
+        }
+        let report = agent_doctor(&mur_home, "coach").unwrap();
+        unsafe {
+            std::env::remove_var("MUR_HOME");
+        }
+
+        assert!(
+            report.iter().any(|c| c.name == "model_ref" && !c.ok),
+            "expected a failing model_ref check, got: {report:?}"
+        );
     }
 }

--- a/mur-core/src/cmd/fleet/create.rs
+++ b/mur-core/src/cmd/fleet/create.rs
@@ -23,8 +23,11 @@ pub fn cmd_fleet_create(
         bail!("fleet '{name}' already exists");
     }
 
-    // Canonicalize member names and router to match the agent runtime's on-disk ids.
-    let members: Vec<String> = members
+    // Comma-split (mirrors `mur fleet add`'s handling of "--members a,b c")
+    // then canonicalize member names and router to match the agent
+    // runtime's on-disk ids. `create` does not validate agent existence
+    // today; this change only adds splitting, not a new failure mode.
+    let members: Vec<String> = super::roster::parse_member_args(&members)
         .into_iter()
         .map(|m| crate::a2a_dial::canonicalize_agent_name(mur_home, &m))
         .collect();

--- a/mur-core/src/cmd/fleet/roster.rs
+++ b/mur-core/src/cmd/fleet/roster.rs
@@ -8,13 +8,60 @@ use mur_common::channel::ParticipantRole;
 
 use super::store;
 
+/// Split CLI-supplied member tokens on commas, trim whitespace, and drop
+/// empties. The CLI help advertises "comma-separated member agent names"
+/// (`mur-core/src/cli/actions.rs`) but clap alone doesn't split on `,` — this
+/// makes that promise real. Accepts either `--members a,b c` or repeated
+/// `--members a --members b`.
+pub(crate) fn parse_member_args(raw: &[String]) -> Vec<String> {
+    raw.iter()
+        .flat_map(|s| s.split(','))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// True iff `agent` exists on disk under `<mur_home>/agents/<agent>/profile.yaml`,
+/// matching the existence idiom used by `a2a_dial::canonicalize_agent_name`.
+fn agent_exists(mur_home: &Path, agent: &str) -> bool {
+    mur_home
+        .join("agents")
+        .join(agent)
+        .join("profile.yaml")
+        .is_file()
+}
+
 /// Add one or more agents as Delegate members. Idempotent per agent.
+///
+/// `agents` may contain comma-separated tokens (`"a,b"`) as well as
+/// individually-passed names; both are flattened via [`parse_member_args`].
+/// Every resolved name must exist as a real agent — unknown names are
+/// rejected up front, before any membership mutation, so a batch containing
+/// one bad name never partially applies.
 pub fn cmd_fleet_add(mur_home: &Path, name: &str, agents: Vec<String>) -> Result<()> {
     let mut fleet = store::load_fleet(mur_home, name)?;
+
+    let canonical: Vec<String> = parse_member_args(&agents)
+        .into_iter()
+        .map(|raw| crate::a2a_dial::canonicalize_agent_name(mur_home, &raw))
+        .collect();
+
+    let unknown: Vec<&str> = canonical
+        .iter()
+        .filter(|a| !agent_exists(mur_home, a))
+        .map(|a| a.as_str())
+        .collect();
+    if !unknown.is_empty() {
+        bail!(
+            "unknown agent(s), not found in '{}': {}",
+            mur_home.join("agents").display(),
+            unknown.join(", ")
+        );
+    }
+
     let svc = mur_channel::ChannelService::open(mur_home)?;
     // ponytail: not transactional across N agents; channel ops are idempotent so re-running reconciles
-    for raw in agents {
-        let agent = crate::a2a_dial::canonicalize_agent_name(mur_home, &raw);
+    for agent in canonical {
         if fleet.members.contains(&agent) {
             println!("'{agent}' is already a member of '{name}'.");
             continue;
@@ -31,6 +78,7 @@ pub fn cmd_fleet_add(mur_home: &Path, name: &str, agents: Vec<String>) -> Result
 pub fn cmd_fleet_remove(mur_home: &Path, name: &str, agents: Vec<String>) -> Result<()> {
     let mut fleet = store::load_fleet(mur_home, name)?;
     let router = fleet.router_or_concierge().to_string();
+    let agents = parse_member_args(&agents);
 
     // Upfront validation: reject the entire batch if ANY agent is the router,
     // before touching the channel or manifest.
@@ -62,10 +110,33 @@ mod tests {
     use super::super::{create, store};
     use super::*;
 
+    /// Create a minimal on-disk agent profile so `agent_exists`/
+    /// `canonicalize_agent_name` see it as a real agent.
+    fn touch_agent(home: &Path, name: &str) {
+        let dir = home.join("agents").join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("profile.yaml"), format!("name: {name}\n")).unwrap();
+    }
+
+    #[test]
+    fn parse_member_args_splits_commas_and_trims_whitespace() {
+        let names = parse_member_args(&["a,b".to_string(), "c".to_string()]);
+        assert_eq!(names, vec!["a", "b", "c"]);
+
+        let names = parse_member_args(&[" a , b ".to_string()]);
+        assert_eq!(names, vec!["a", "b"]);
+
+        // empties dropped
+        let names = parse_member_args(&["a,,b".to_string(), "".to_string()]);
+        assert_eq!(names, vec!["a", "b"]);
+    }
+
     #[test]
     fn add_then_remove_member_syncs_fleet_and_is_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
         let home = tmp.path();
+        touch_agent(home, "pm");
+        touch_agent(home, "qa");
         create::cmd_fleet_create(home, "dev", vec!["pm".into()], None, Some("g".into()), None)
             .unwrap();
 
@@ -77,6 +148,41 @@ mod tests {
         cmd_fleet_remove(home, "dev", vec!["qa".into()]).unwrap();
         let f = store::load_fleet(home, "dev").unwrap();
         assert!(!f.members.contains(&"qa".to_string()));
+    }
+
+    #[test]
+    fn add_splits_comma_separated_members() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        touch_agent(home, "a");
+        touch_agent(home, "b");
+        touch_agent(home, "c");
+        create::cmd_fleet_create(home, "dev", vec![], None, Some("g".into()), None).unwrap();
+
+        cmd_fleet_add(home, "dev", vec!["a,b".into(), "c".into()]).unwrap();
+        let f = store::load_fleet(home, "dev").unwrap();
+        assert!(f.members.contains(&"a".to_string()));
+        assert!(f.members.contains(&"b".to_string()));
+        assert!(f.members.contains(&"c".to_string()));
+    }
+
+    #[test]
+    fn add_rejects_unknown_agent_without_partial_mutation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        touch_agent(home, "pm");
+        create::cmd_fleet_create(home, "dev", vec![], None, Some("g".into()), None).unwrap();
+
+        // "pm" is real, "ghost" is not — batch must be rejected wholesale,
+        // before either name is added to the channel/manifest.
+        let result = cmd_fleet_add(home, "dev", vec!["pm,ghost".into()]);
+        assert!(result.is_err(), "should reject batch with an unknown agent");
+
+        let f = store::load_fleet(home, "dev").unwrap();
+        assert!(
+            !f.members.contains(&"pm".to_string()),
+            "pm should not have been added; upfront validation must prevent partial mutation"
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/skill_cmd.rs
+++ b/mur-core/src/cmd/skill_cmd.rs
@@ -196,6 +196,11 @@ pub(crate) fn set_manifest_scope(
         m.project = None;
         m.team = None;
     } else if let Some(f) = fleet {
+        if f.trim().is_empty() {
+            return Err(anyhow!(
+                "--fleet requires a fleet NAME, e.g. --fleet aura-research; the fleet need not exist yet"
+            ));
+        }
         if !mur_common::fleet::valid_fleet_name(f) {
             return Err(anyhow!(
                 "invalid fleet name '{f}': lowercase letters, digits, '-' or '_'"
@@ -619,12 +624,26 @@ fn category_yaml_value(category: mur_common::skill::Category) -> &'static str {
     }
 }
 
+/// Pure helper: when scaffolding a new skill with neither `--agent` nor
+/// `--dir`, default the output root to `<mur_home>/skills` instead of the
+/// current directory (`resolve_skill_subdir`'s CWD fallback, which `cmd_edit`
+/// still relies on and must keep). Returns `dir` unchanged in all other cases.
+fn new_skill_dir(mur_home: &Path, agent: Option<&str>, dir: Option<&str>) -> Option<String> {
+    if agent.is_none() && dir.is_none() {
+        Some(mur_home.join("skills").to_string_lossy().into_owned())
+    } else {
+        dir.map(str::to_string)
+    }
+}
+
 /// Core scaffold logic for `mur skill new` — returns the written path.
 /// Split out from `cmd_new` so it can be unit-tested without going through CLI
 /// dispatch or touching the real `$MUR_HOME`.
 fn scaffold_skill(opts: NewOptions) -> Result<std::path::PathBuf> {
     let category = parse_authoring_category(&opts.category)?;
-    let subdir = resolve_skill_subdir(&opts.name, opts.agent.as_deref(), opts.dir.as_deref())?;
+    let mur_home = resolve_mur_home()?;
+    let dir = new_skill_dir(&mur_home, opts.agent.as_deref(), opts.dir.as_deref());
+    let subdir = resolve_skill_subdir(&opts.name, opts.agent.as_deref(), dir.as_deref())?;
     let target = subdir.join("skill.yaml");
 
     if target.exists() && !opts.force {
@@ -778,6 +797,31 @@ mod tests {
         assert!(set_manifest_scope(&mut m, None, None, None, false).is_err());
         assert!(set_manifest_scope(&mut m, Some("x"), None, None, true).is_err());
         assert!(set_manifest_scope(&mut m, Some("Bad Name"), None, None, false).is_err());
+    }
+
+    #[test]
+    fn set_manifest_scope_fleet_empty_name_is_actionable() {
+        let yaml = "name: s\nversion: 1.0.0\npublisher: human:t\ndescription: d\n\
+                    category: context\ncontent:\n  abstract: a\n  context: c\n";
+        let mut m = mur_common::skill::parser::parse_canonical(yaml).unwrap();
+        let err = set_manifest_scope(&mut m, Some(""), None, None, false).unwrap_err();
+        assert!(err.to_string().contains("requires a fleet NAME"));
+        let err = set_manifest_scope(&mut m, Some("   "), None, None, false).unwrap_err();
+        assert!(err.to_string().contains("requires a fleet NAME"));
+    }
+
+    #[test]
+    fn new_skill_dir_defaults_to_mur_home_skills() {
+        let home = tempdir().unwrap();
+        assert_eq!(
+            new_skill_dir(home.path(), None, None),
+            Some(home.path().join("skills").to_string_lossy().into_owned())
+        );
+        assert_eq!(
+            new_skill_dir(home.path(), None, Some("/x")),
+            Some("/x".to_string())
+        );
+        assert_eq!(new_skill_dir(home.path(), Some("a"), None), None);
     }
 
     #[test]

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1670,9 +1670,15 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             });
             cmd::agent::cmd_export(&name, &out, &format)?;
         }
-        AgentAction::Install { path, model } => {
-            cmd::agent::cmd_install(std::path::Path::new(&path), model.as_deref())?
-        }
+        AgentAction::Install {
+            path,
+            model,
+            as_name,
+        } => cmd::agent::cmd_install(
+            std::path::Path::new(&path),
+            model.as_deref(),
+            as_name.as_deref(),
+        )?,
         AgentAction::Uninstall { name, purge } => cmd::agent::cmd_uninstall(&name, purge)?,
         AgentAction::Inspect { path } => cmd::agent::cmd_inspect(std::path::Path::new(&path))?,
         AgentAction::Stats { name } => cmd::agent::cmd_stats(&name)?,

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1422,8 +1422,19 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 name,
                 server_id,
                 allow_hosts,
+                deny_hosts,
                 off,
-            } => cmd::agent::cmd_mcp_set_network(&name, &server_id, allow_hosts, off)?,
+                broad_audited,
+                yes,
+            } => cmd::agent::cmd_mcp_set_network(
+                &name,
+                &server_id,
+                allow_hosts,
+                deny_hosts,
+                off,
+                broad_audited,
+                yes,
+            )?,
             AgentMcpAction::Discover => cmd::agent::mcp_discover::cmd_mcp_discover()?,
             AgentMcpAction::Search { query } => {
                 cmd::agent::mcp_registry::cmd_mcp_search(&query).await?

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1316,11 +1316,11 @@ async fn run_agent(action: AgentAction) -> Result<()> {
         AgentAction::Start { name } => cmd::agent::cmd_start(&name)?,
         AgentAction::Stop { name } => cmd::agent::cmd_stop(&name)?,
         AgentAction::Restart {
-            name,
+            names,
             all,
             stale,
             dry_run,
-        } => cmd::agent::cmd_restart(name.as_deref(), all, stale, dry_run)?,
+        } => cmd::agent::cmd_restart(&names, all, stale, dry_run)?,
         AgentAction::Remove { name, purge, force } => cmd::agent::cmd_remove(&name, purge, force)?,
         AgentAction::Rename { old, new } => cmd::agent::cmd_rename(&old, &new)?,
         AgentAction::Send { name, message } => cmd::agent::cmd_send(&name, &message)?,

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1684,7 +1684,10 @@ async fn run_agent(action: AgentAction) -> Result<()> {
         AgentAction::Stats { name } => cmd::agent::cmd_stats(&name)?,
         AgentAction::Logs { name, tail } => cmd::agent::cmd_logs(&name, tail)?,
         AgentAction::Companion(args) => cmd::agent_companion::run(args).await?,
-        AgentAction::Doctor { format, json } => cmd::doctor::run(&format, json)?,
+        AgentAction::Doctor { name, format, json } => match name {
+            Some(name) => cmd::doctor::run_agent(&name, json)?,
+            None => cmd::doctor::run(&format, json)?,
+        },
         AgentAction::RuntimeDoctor { json } => cmd::agent::cmd_doctor(json)?,
         AgentAction::Secret { agent, action } => match action {
             AgentSecretAction::Set { key, value } => {

--- a/mur-core/tests/cli_fleet.rs
+++ b/mur-core/tests/cli_fleet.rs
@@ -151,7 +151,11 @@ fn fleet_job_and_roster_round_trip() {
     )
     .unwrap();
 
-    // add member → fleet manifest stays in sync
+    // add member → fleet manifest stays in sync (the member must exist on
+    // disk: `fleet add` validates agent existence, unlike `create`).
+    let qa_dir = home.join("agents").join("qa");
+    std::fs::create_dir_all(&qa_dir).unwrap();
+    std::fs::write(qa_dir.join("profile.yaml"), "name: qa\n").unwrap();
     roster::cmd_fleet_add(home, "dev", vec!["qa".into()]).unwrap();
     assert!(
         store::load_fleet(home, "dev")


### PR DESCRIPTION
## Summary

Turns the AURA research-agent build's findings into shipped MUR fixes: the first rung of an **egress-governance ladder** (per-MCP-server `broad-audited` mode) plus **8 CLI-hardening fixes** and the install-service PATH gap.

Executed subagent-driven against the plan (`docs/superpowers/plans/2026-07-08-agent-egress-governance.md`); every task is TDD with per-task review, and a final whole-branch review returned **READY TO MERGE** (no Critical/Important findings). `cargo fmt --check` and `cargo clippy -D warnings` are clean on the changed crates.

## Part A — per-server `broad-audited` egress

`broad-audited` is a per-MCP-server `McpNetMode`, not an agent-level mode — it rides MUR's existing loopback egress proxy so least-privilege holds (only the tool that needs the web gets it; the agent's own LLM egress stays restricted).

- **Proxy enforcement** — `BroadAudited` = allow every host **except** `deny_hosts` (fail-closed; unknown token denied), with a per-CONNECT audit line. `needs_egress` now starts the proxy for broad-audited servers too.
- **CLI** — `mur agent mcp set-network <agent> <server> --broad-audited [--deny-host …]` requires explicit operator consent (`[y/N]`, `--yes` to script), records an on-profile `EgressAuthorization { authorized_by, authorized_at_ms }`, and emits one `mur.egress.broad_audited.enabled` telemetry event. `--broad-audited` conflicts with `--off`; switching mode away clears the authorization.
- **Visibility** — `mcp list` renders a `⚠ BROAD EGRESS (audited)` warning naming the authorizer.
- **Portability** — `.muragent` import **downgrades** any `broad-audited` server to `inherit` and clears its authorization (never silently grants broad egress), printing a re-grant hint.

## Part B — CLI hardening

- `agent create --model <alias>` binds to the matching `models.yaml` entry instead of silently defaulting to ollama/StubEcho.
- `agent mcp add --arg` accepts hyphen-prefixed values (`--arg --engine`).
- `fleet add`/`create` comma-split members **and** validate existence up-front (no partial mutation).
- `skill new` defaults to `~/.mur/skills`; `skill scope --fleet ""` gives an actionable error (`skill edit`'s CWD default untouched).
- `agent install --as <name>` clones a bundle under a new name with a **new UUID + a freshly minted, persisted Ed25519 identity** (source private key never copied); refuses if the name exists.
- `agent doctor <name>` runs per-agent health checks (model_ref resolves, each MCP command on PATH, entitlements parse); no-arg behavior unchanged.
- `agent restart` is variadic (`restart a b c`); mutually exclusive with `--all`/`--stale`; fail-closed if any name isn't running.
- `install-service` plist sets `EnvironmentVariables.PATH` (derived from `npm config get prefix` + homebrew + launchd defaults) so PATH-installed MCP binaries resolve under launchd.

## Testing

- Every task ships unit tests (TDD, failing-first). Affected suites verified green: egress proxy, mcp set-network/list, installer downgrade + clone, model-ref alias, fleet roster, skill scaffold, restart selection, service plist.
- `cargo build -p mur-core --bin mur` / `--tests`, `cargo fmt --check`, and `cargo clippy -D warnings` clean on `mur-common` / `mur-core` / `mur-agent-runtime`.

## Deliberate deviations (from final review)

- The Phase-1 egress grant lives on the **agent profile** (`EgressAuthorization`) + telemetry, not the ephemeral fleet-loop `GovernanceState` — so it persists, travels with export, and is re-approved on import. A network-wide reduction is Phase 2.
- `tool_scope` (schema-only placeholder) was descoped during grounding; enforcement is Phase 4.
- Broad-audited is **advisory** (child honors `HTTP_PROXY`); airtight sbpl/netns pinning is Phase 3.

## Follow-up (deferred, non-blocking)

- `install --as` clone and import-downgrade write `profile.yaml` via plain `fs::write`; switch to the repo's atomic temp+rename writer in a cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
