### PR TITLE
fix(agent): atomic temp+rename for clone/import profile.yaml writes

### DIFF
--- a/mur-common/src/muragent/installer.rs
+++ b/mur-common/src/muragent/installer.rs
@@ -248,7 +248,11 @@ fn downgrade_profile_egress(agent_dir: &Path) -> Result<Vec<String>, MuragentErr
     if !downgraded.is_empty() {
         let out =
             serde_yaml_ng::to_string(&profile).map_err(|e| MuragentError::Other(e.to_string()))?;
-        fs::write(&profile_path, out).map_err(MuragentError::Io)?;
+        // Atomic write (temp + rename) so a crash mid-write never leaves a
+        // half-written profile.yaml; matches the repo YAML convention.
+        let tmp = profile_path.with_extension("yaml.tmp");
+        fs::write(&tmp, out).map_err(MuragentError::Io)?;
+        fs::rename(&tmp, &profile_path).map_err(MuragentError::Io)?;
     }
     Ok(downgraded)
 }

--- a/mur-core/src/cmd/agent/install.rs
+++ b/mur-core/src/cmd/agent/install.rs
@@ -84,8 +84,13 @@ fn clone_identity_and_profile(mur_home: &Path, clone_name: &str) -> Result<()> {
     profile.name = clone_name.to_string();
     profile.id = uuid::Uuid::now_v7().to_string();
 
-    std::fs::write(&profile_path, serde_yaml_ng::to_string(&profile)?)
-        .with_context(|| format!("write {}", profile_path.display()))?;
+    // Atomic write (temp + rename) so a crash mid-write never leaves a
+    // half-written profile.yaml for the clone; matches the repo YAML convention.
+    let tmp = profile_path.with_extension("yaml.tmp");
+    std::fs::write(&tmp, serde_yaml_ng::to_string(&profile)?)
+        .with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, &profile_path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), profile_path.display()))?;
 
     AgentIdentity::generate()
         .save(&agent_dir)


### PR DESCRIPTION
## Summary

Follow-up to #661 (egress governance). Two `profile.yaml` rewrites introduced there used a plain `fs::write`, deviating from the repo's atomic-YAML convention (`store/yaml.rs` — temp file + rename). This switches both to atomic temp+rename so a crash mid-write can never leave a half-written profile:

- **`install --as` clone** (`mur-core/src/cmd/agent/install.rs`) — after patching `name` + new UUID.
- **import broad-audited downgrade** (`mur-common/src/muragent/installer.rs`) — after resetting BroadAudited→Inherit.

Inline temp+rename at both sites (mur-common can't reach mur-core's `yaml_edit::write_atomic`, and `cmd/*` compiles into both the lib and the bin so the lib-only module path isn't usable there either).

## Testing

No behavior change — the existing clone and downgrade unit tests already assert the resulting `profile.yaml` content and exercise both write paths. `cargo build`, `fmt --check`, and `clippy` clean on `mur-core` + `mur-common`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)