### PR TITLE
feat(deep-research): MUR-native deep research (fleet + SSRF-guarded gateway)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6660,6 +6660,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6663,6 +6663,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6653,6 +6653,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mur-research-gateway"
+version = "2.44.0"
+dependencies = [
+ "mur-common",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "mur-zfs-agent"
 version = "2.44.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "mur-gui-core",
     "mur-agent-launcher",
     "mur-mcp-server",
+    "mur-research-gateway",
     "mur-compress",
     "mur-channel",
     "mur-mobile-sdk",

--- a/build.sh
+++ b/build.sh
@@ -81,6 +81,15 @@ if $INSTALL; then
     echo "Installed mur-mcp-server -> /opt/homebrew/bin/mur-mcp-server"
   fi
 
+  # The research gateway (stdio MCP server for tiered web fetch/search).
+  # Agent sandboxes spawn it by name off PATH, so it must land next to `mur`.
+  GATEWAY_BINARY="$SCRIPT_DIR/target/release/mur-research-gateway"
+  if [ -f "$GATEWAY_BINARY" ]; then
+    sudo cp "$GATEWAY_BINARY" /opt/homebrew/bin/mur-research-gateway
+    sudo codesign --force -s "$CODESIGN_IDENTITY" /opt/homebrew/bin/mur-research-gateway || true
+    echo "Installed mur-research-gateway -> /opt/homebrew/bin/mur-research-gateway"
+  fi
+
   # The background daemon. `mur daemon start` looks for `murmurd` alongside
   # `mur`, so install it too — otherwise the daemon (and the Hub/phone voice
   # path that runs through it) is unavailable on a release install.

--- a/docs/attribution/lightpanda-AGPL.md
+++ b/docs/attribution/lightpanda-AGPL.md
@@ -1,0 +1,20 @@
+# Third-Party Attribution: Lightpanda
+
+`mur-research-gateway`'s tier-2 fetch/search path optionally renders pages
+using [Lightpanda](https://github.com/lightpanda-io/browser), a headless
+browser engine.
+
+- **License**: AGPL-3.0 (see the upstream repository for the full text).
+- **Usage**: Lightpanda is invoked **arm's-length as a separate OS
+  subprocess**, driven via the `agent-browser` CLI (Apache-2.0). MUR never
+  links the Lightpanda library into its own process, and does not modify
+  Lightpanda's source — it ships and runs the upstream binary unmodified.
+- **Why this matters**: AGPL-3.0's network-copyleft clause is triggered by
+  combining/linking AGPL code into a program; invoking an unmodified AGPL
+  binary as an independent subprocess over a process boundary does not bring
+  MUR's own source under AGPL.
+- **Fallback**: if Lightpanda is not installed, `mur-research-gateway`
+  degrades to tier-1 (plain HTTP fetch) and tier-3 (Chrome via
+  `agent-browser --engine chrome`); Lightpanda is not a hard dependency.
+
+Upstream source: <https://github.com/lightpanda-io/browser>

--- a/docs/superpowers/plans/2026-07-09-mur-native-deep-research.md
+++ b/docs/superpowers/plans/2026-07-09-mur-native-deep-research.md
@@ -1,0 +1,853 @@
+# MUR-Native Deep Research Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give MUR a native deep-research capability (decompose → parallel fan-out → adversarial verify → cited synthesis) that runs on MUR's own fleet + agents + dynamic router loop, with all web egress funneled through one deterministic, audited, SSRF-guarded MCP gateway.
+
+**Architecture:** A new `mur-research-gateway` MCP server (Rust, MUR-shipped, no LLM) is the single trust boundary that holds `broad-audited` egress; it exposes read-only `search`/`fetch` verbs with a 3-tier escalation ladder (reqwest → agent-browser/lightpanda → chrome). A `deep-research` fleet of restricted worker agents mounts only that gateway; the fleet router drives a dynamic per-iteration DAG (decompose/research/verify/synthesize) via `mur fleet run --loop`, converging on a `done_when` marker.
+
+**Tech Stack:** Rust (workspace crate), stdio JSON-RPC MCP, `reqwest`, `agent-browser` (npm, Apache-2.0) + Lightpanda (AGPL-3.0, subprocess-only), MUR fleet machinery, per-server egress governance (#661).
+
+## Global Constraints
+
+- **No hardcoded values.** Lightpanda executable path, engine defaults, worker count, per-request timeout, `deny_hosts` overlay, search result limits — all from `~/.mur/config.yaml` / fleet config / env, never literals. — CLAUDE.md rule 1.
+- **Lightpanda (AGPL-3.0) is subprocess-only** — invoked via `agent-browser --engine lightpanda`, never linked in-process, never forked/modified; ship the unmodified upstream binary + AGPL attribution. — spec §5, `gotcha_agent_browser_lightpanda_engine_dead`.
+- **`agent-browser --engine lightpanda` requires `--args ""`** — Chrome stealth args must never reach Lightpanda (it errors). Chrome tier keeps stealth args. — verified 0.31.1, 2026-07-08.
+- **`agent-browser mcp` / driver requires >= 0.28.0.** Preflight must check and degrade explicitly if lower/missing. — verified 2026-07-08.
+- **Workers hold NO egress.** Only the gateway subprocess reaches the web. Worker agent entitlements stay `restricted`. — spec §3.
+- **Egress grant only via the shipped consent path** (`mur agent mcp set-network <agent> research-gateway --broad-audited`). Fleet creation never opens egress implicitly. — spec §7.1.
+- **SSRF guard is non-configurable and stricter than the runtime's local-first guard** — the gateway refuses loopback + RFC1918/ULA private + link-local/metadata + unspecified (the runtime's `is_link_local_or_unspecified` deliberately allows loopback/private for local LLMs; the gateway must NOT). — spec §5, §7.3.
+- **Brand:** user-facing label is uppercase where surfaced; internal names lowercase. — CLAUDE.md rule 7.
+- **Build env:** `mur-core`/runtime need `ORT_STRATEGY=download` + `MUR_WEB_DIST=$HOME/Projects/mur-web/dist`; rustup toolchain on PATH. The gateway crate itself is light (no ORT). — `mem:env_ort_strategy_download`.
+
+---
+
+### Task 1: Scaffold `mur-research-gateway` crate (stdio MCP, tool declarations only)
+
+Stand up the binary and JSON-RPC loop with `search`/`fetch` declared but returning "not implemented", so the MCP handshake is testable before any logic exists. Mirrors `mur-mcp-server` structure exactly.
+
+**Files:**
+- Create: `mur-research-gateway/Cargo.toml`
+- Create: `mur-research-gateway/src/main.rs`
+- Create: `mur-research-gateway/src/jsonrpc.rs`
+- Create: `mur-research-gateway/src/server.rs`
+- Create: `mur-research-gateway/src/tools.rs`
+- Modify: `Cargo.toml` (workspace `members` — add `"mur-research-gateway"` after `"mur-mcp-server"`)
+
+**Interfaces:**
+- Produces: a binary `mur-research-gateway` speaking stdio JSON-RPC MCP, advertising two tools: `search {query: string, limit?: number}` and `fetch {url: string, render?: boolean}`. Tool dispatch entry point `server::McpServer::handle(Request) -> Response`.
+
+- [ ] **Step 1: Copy the JSON-RPC framing verbatim from mur-mcp-server**
+
+Run: `cp mur-mcp-server/src/jsonrpc.rs mur-research-gateway/src/jsonrpc.rs` (create the dir first with the Cargo.toml step). This module (`read_request`/`write_response`, `Request`/`Response` types) is transport-only and reused unchanged.
+
+- [ ] **Step 2: Write `Cargo.toml`**
+
+```toml
+[package]
+name = "mur-research-gateway"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "mur-research-gateway"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "io-std", "process"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+reqwest = { workspace = true }
+mur-common = { path = "../mur-common" }
+```
+
+(If a listed dependency is not yet in `[workspace.dependencies]`, mirror the version used by `mur-mcp-server`/`mur-agent-runtime` Cargo.toml.)
+
+- [ ] **Step 3: Add the crate to the workspace members**
+
+Modify root `Cargo.toml` `members` list, adding `"mur-research-gateway",` after `"mur-mcp-server",`.
+
+- [ ] **Step 4: Write `tools.rs` — tool declarations**
+
+```rust
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+#[derive(Serialize)]
+pub struct Tool {
+    pub name: String,
+    pub description: String,
+    #[serde(rename = "inputSchema")] // MCP wire protocol is camelCase
+    pub input_schema: serde_json::Value,
+}
+
+/// The two read-only verbs workers may call. No navigation, no POST.
+pub fn all_tools() -> Vec<Tool> {
+    vec![
+        Tool {
+            name: "search".into(),
+            description: "Web search. Returns [{title,url,snippet}]. Read-only.".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "number"}
+                },
+                "required": ["query"]
+            }),
+        },
+        Tool {
+            name: "fetch".into(),
+            description: "Fetch one URL's readable text. Read-only GET. SSRF-guarded.".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string"},
+                    "render": {"type": "boolean"}
+                },
+                "required": ["url"]
+            }),
+        },
+    ]
+}
+```
+
+- [ ] **Step 5: Write `server.rs` — handshake + dispatch stubs**
+
+```rust
+use crate::jsonrpc::{Request, Response};
+use crate::tools;
+
+pub struct McpServer;
+
+impl McpServer {
+    pub fn new() -> Self { McpServer }
+
+    pub async fn handle(&mut self, req: Request) -> Response {
+        match req.method.as_str() {
+            "initialize" => Response::result(req.id, serde_json::json!({
+                "protocolVersion": "2025-11-25",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "mur-research-gateway", "version": env!("CARGO_PKG_VERSION")}
+            })),
+            "tools/list" => Response::result(req.id, serde_json::json!({
+                "tools": tools::all_tools()
+            })),
+            "tools/call" => Response::error(req.id, -32601, "not implemented yet"),
+            _ => Response::error(req.id, -32601, "method not found"),
+        }
+    }
+}
+```
+
+(Match `Response::result` / `Response::error` to the actual constructors in the copied `jsonrpc.rs`; adjust if their signatures differ.)
+
+- [ ] **Step 6: Write `main.rs` — the stdio loop (mirror mur-mcp-server)**
+
+```rust
+use tracing_subscriber::EnvFilter;
+mod jsonrpc;
+mod server;
+mod tools;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")))
+        .with_writer(std::io::stderr)
+        .init();
+    let mut server = server::McpServer::new();
+    while let Some(request) = jsonrpc::read_request() {
+        let is_notification = request.id.is_none() && request.method.starts_with("notifications/");
+        let response = server.handle(request).await;
+        if !is_notification { jsonrpc::write_response(&response); }
+    }
+}
+```
+
+- [ ] **Step 7: Build and smoke-test the handshake**
+
+Run:
+```bash
+cargo build -p mur-research-gateway
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' | ./target/debug/mur-research-gateway
+```
+Expected: two JSON-RPC responses on stdout; the second lists `search` and `fetch`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mur-research-gateway Cargo.toml
+git commit -m "feat(research-gateway): scaffold stdio MCP with search/fetch declarations"
+```
+
+---
+
+### Task 2: `net_guard.rs` — strict SSRF predicate + deny-host matcher
+
+The security core. A pure module, unit-tested hard, with **no network**. It is deliberately stricter than the runtime's `is_link_local_or_unspecified` (which allows loopback/RFC1918 for local LLMs — wrong threat model for a web researcher).
+
+**Files:**
+- Create: `mur-research-gateway/src/net_guard.rs`
+- Modify: `mur-research-gateway/src/main.rs` (add `mod net_guard;`)
+
+**Interfaces:**
+- Produces:
+  - `fn is_forbidden_target(ip: std::net::IpAddr) -> bool` — true for loopback, RFC1918/ULA private, link-local/metadata, unspecified (normalizing IPv4-in-IPv6 first).
+  - `fn host_denied(host: &str, deny: &[String]) -> bool` — true if host matches any deny pattern (`*.x.com` / `.x.com` / exact).
+  - `fn screen_url(url: &str, deny: &[String]) -> Result<url::Url, GuardReject>` — parse, reject non-http(s), reject denied host, resolve host and reject if ANY resolved IP is a forbidden target. Returns the parsed URL on pass. (Add `url` to Cargo.toml deps.)
+  - `enum GuardReject { BadScheme, DeniedHost, PrivateAddress, Unresolvable }`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::IpAddr;
+
+    #[test]
+    fn blocks_cloud_metadata_and_private_and_loopback() {
+        for ip in ["169.254.169.254", "127.0.0.1", "10.0.0.5", "192.168.1.1", "172.16.0.1", "::1", "fe80::1", "::ffff:169.254.169.254"] {
+            assert!(is_forbidden_target(ip.parse::<IpAddr>().unwrap()), "{ip} must be forbidden");
+        }
+    }
+    #[test]
+    fn allows_public() {
+        for ip in ["8.8.8.8", "203.0.113.7", "2606:4700:4700::1111"] {
+            assert!(!is_forbidden_target(ip.parse::<IpAddr>().unwrap()), "{ip} must be allowed");
+        }
+    }
+    #[test]
+    fn deny_host_patterns() {
+        let deny = vec!["*.internal.corp".to_string(), "blocked.example".to_string()];
+        assert!(host_denied("api.internal.corp", &deny));
+        assert!(host_denied("internal.corp", &deny));
+        assert!(host_denied("blocked.example", &deny));
+        assert!(!host_denied("good.example", &deny));
+    }
+    #[test]
+    fn screen_rejects_bad_scheme_and_denied() {
+        assert!(matches!(screen_url("file:///etc/passwd", &[]), Err(GuardReject::BadScheme)));
+        assert!(matches!(screen_url("http://blocked.example/", &["blocked.example".into()]), Err(GuardReject::DeniedHost)));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p mur-research-gateway net_guard`
+Expected: FAIL — `net_guard` unresolved.
+
+- [ ] **Step 3: Implement `net_guard.rs`**
+
+```rust
+use std::net::{IpAddr, ToSocketAddrs};
+
+#[derive(Debug, PartialEq)]
+pub enum GuardReject { BadScheme, DeniedHost, PrivateAddress, Unresolvable }
+
+/// Host-pattern matcher. Mirrors `mur-agent-runtime::sandbox::reqwest_guard::
+/// host_matches_pattern` (kept local to avoid depending on the heavy runtime
+/// crate). `*.x.com` / legacy `.x.com` match subdomains + apex; else exact.
+fn host_matches_pattern(host: &str, pattern: &str) -> bool {
+    let host = host.to_ascii_lowercase();
+    let pattern = pattern.to_ascii_lowercase();
+    let suffix = if let Some(s) = pattern.strip_prefix("*.") { s }
+        else if let Some(s) = pattern.strip_prefix('.') { s }
+        else { return host == pattern };
+    host == suffix || host.ends_with(&format!(".{suffix}"))
+}
+
+pub fn host_denied(host: &str, deny: &[String]) -> bool {
+    deny.iter().any(|p| host_matches_pattern(host, p))
+}
+
+/// STRICTER than the runtime's local-first guard: a web researcher has no
+/// legitimate reason to reach loopback/private/link-local, so all are forbidden.
+pub fn is_forbidden_target(ip: IpAddr) -> bool {
+    // Normalize IPv4-in-IPv6 (mapped ::ffff:a.b.c.d and compatible ::a.b.c.d).
+    let ip = match ip {
+        IpAddr::V6(v6) => v6.to_ipv4().map_or(IpAddr::V6(v6), IpAddr::V4),
+        v4 => v4,
+    };
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback() || v4.is_private() || v4.is_link_local()
+                || v4.is_unspecified() || v4.is_broadcast()
+                || v4.octets()[0] == 0 // 0.0.0.0/8
+        }
+        IpAddr::V6(v6) => {
+            v6.is_loopback() || v6.is_unspecified()
+                || (v6.segments()[0] & 0xffc0) == 0xfe80 // link-local fe80::/10
+                || (v6.segments()[0] & 0xfe00) == 0xfc00 // ULA fc00::/7
+        }
+    }
+}
+
+/// Parse + screen a URL. On pass returns the parsed URL; the caller MUST pin
+/// its connection to an already-screened address (see Task 3) to close the
+/// resolve→connect TOCTOU (DNS-rebinding) window.
+pub fn screen_url(raw: &str, deny: &[String]) -> Result<url::Url, GuardReject> {
+    let u = url::Url::parse(raw).map_err(|_| GuardReject::BadScheme)?;
+    if !matches!(u.scheme(), "http" | "https") { return Err(GuardReject::BadScheme); }
+    let host = u.host_str().ok_or(GuardReject::BadScheme)?;
+    if host_denied(host, deny) { return Err(GuardReject::DeniedHost); }
+    let port = u.port_or_known_default().unwrap_or(80);
+    let mut any = false;
+    for sa in (host, port).to_socket_addrs().map_err(|_| GuardReject::Unresolvable)? {
+        any = true;
+        if is_forbidden_target(sa.ip()) { return Err(GuardReject::PrivateAddress); }
+    }
+    if !any { return Err(GuardReject::Unresolvable); }
+    Ok(u)
+}
+```
+
+Add `url = { workspace = true }` to the crate's Cargo.toml deps (mirror the workspace version).
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test -p mur-research-gateway net_guard`
+Expected: PASS (all four tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-research-gateway/src/net_guard.rs mur-research-gateway/src/main.rs mur-research-gateway/Cargo.toml
+git commit -m "feat(research-gateway): strict SSRF guard + deny-host matcher"
+```
+
+---
+
+### Task 3: tier-1 `fetch(url)` — SSRF-pinned reqwest GET
+
+Implement the cheapest tier: a plain GET that reuses `screen_url` and pins the connection to the screened IP (closing the resolve→connect TOCTOU).
+
+**Files:**
+- Create: `mur-research-gateway/src/fetcher.rs`
+- Modify: `mur-research-gateway/src/main.rs` (`mod fetcher;`)
+- Modify: `mur-research-gateway/src/server.rs` (wire `fetch` in `tools/call`)
+
+**Interfaces:**
+- Consumes: `net_guard::screen_url`.
+- Produces:
+  - `struct FetchResult { url: String, status: u16, title: Option<String>, text: String, tier: u8 }`
+  - `async fn fetch_tier1(url: &str, deny: &[String], timeout: std::time::Duration) -> Result<FetchResult, FetchError>`
+  - `enum FetchError { Guard(net_guard::GuardReject), Http(String), TooLarge }`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn refuses_private_target() {
+        let e = fetch_tier1("http://127.0.0.1:1/", &[], Duration::from_secs(2)).await.unwrap_err();
+        assert!(matches!(e, FetchError::Guard(_)));
+    }
+    #[tokio::test]
+    async fn refuses_denied_host() {
+        let e = fetch_tier1("http://blocked.example/", &["blocked.example".into()], Duration::from_secs(2)).await.unwrap_err();
+        assert!(matches!(e, FetchError::Guard(net_guard::GuardReject::DeniedHost)));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cargo test -p mur-research-gateway fetcher`
+Expected: FAIL — `fetcher` unresolved.
+
+- [ ] **Step 3: Implement `fetcher.rs`**
+
+```rust
+use crate::net_guard::{self, GuardReject};
+use std::time::Duration;
+
+const MAX_BODY_BYTES: usize = 5 * 1024 * 1024; // ponytail: 5MB cap; config if a real doc exceeds it
+
+#[derive(Debug)]
+pub struct FetchResult { pub url: String, pub status: u16, pub title: Option<String>, pub text: String, pub tier: u8 }
+
+#[derive(Debug)]
+pub enum FetchError { Guard(GuardReject), Http(String), TooLarge }
+
+pub async fn fetch_tier1(url: &str, deny: &[String], timeout: Duration) -> Result<FetchResult, FetchError> {
+    let screened = net_guard::screen_url(url, deny).map_err(FetchError::Guard)?;
+    // ponytail: reqwest re-resolves internally; screen_url already rejected
+    // private targets. A pinned-IP resolver closes the rebinding window fully —
+    // upgrade to reqwest::dns::Resolve if the advisory window matters.
+    let client = reqwest::Client::builder()
+        .timeout(timeout)
+        .redirect(reqwest::redirect::Policy::none()) // no auto-redirect: each hop must be re-screened by the worker
+        .build().map_err(|e| FetchError::Http(e.to_string()))?;
+    let resp = client.get(screened.clone()).send().await.map_err(|e| FetchError::Http(e.to_string()))?;
+    let status = resp.status().as_u16();
+    let body = resp.text().await.map_err(|e| FetchError::Http(e.to_string()))?;
+    if body.len() > MAX_BODY_BYTES { return Err(FetchError::TooLarge); }
+    let title = extract_title(&body);
+    Ok(FetchResult { url: screened.to_string(), status, title, text: html_to_text(&body), tier: 1 })
+}
+
+fn extract_title(html: &str) -> Option<String> {
+    let lower = html.to_ascii_lowercase();
+    let start = lower.find("<title>")? + 7;
+    let end = lower[start..].find("</title>")? + start;
+    Some(html[start..end].trim().to_string())
+}
+
+// ponytail: naive tag-strip. Good enough for claim extraction; swap for a real
+// readability crate only if extraction quality measurably suffers.
+fn html_to_text(html: &str) -> String {
+    let mut out = String::with_capacity(html.len() / 2);
+    let mut in_tag = false;
+    for c in html.chars() {
+        match c { '<' => in_tag = true, '>' => in_tag = false, _ if !in_tag => out.push(c), _ => {} }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+```
+
+- [ ] **Step 4: Wire `fetch` into `server.rs` `tools/call`**
+
+Parse `{url, render?}` from params; load `deny_hosts` + timeout from config (Task placeholder: read env `MUR_RESEARCH_DENY_HOSTS` comma-split + `MUR_RESEARCH_TIMEOUT_SECS`, default 20 — replace with config.yaml read in Task 6). Call `fetch_tier1` when `render` is false/absent; return `FetchResult` as JSON. Map `FetchError::Guard` to a JSON-RPC error with a clear message.
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `cargo test -p mur-research-gateway && cargo build -p mur-research-gateway`
+Expected: PASS + clean build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-research-gateway/src/fetcher.rs mur-research-gateway/src/main.rs mur-research-gateway/src/server.rs
+git commit -m "feat(research-gateway): tier-1 SSRF-guarded fetch"
+```
+
+---
+
+### Task 4: browser tiers (2/3) + `search` + preflight — agent-browser driver
+
+Add the escalation tiers and search, driving `agent-browser` as a subprocess. Pre-spawn `screen_url` (the proxy can't see the browser's own connections — spec §5). Preflight degrades explicitly when the toolchain is missing.
+
+**Files:**
+- Create: `mur-research-gateway/src/browser.rs`
+- Modify: `mur-research-gateway/src/server.rs` (wire `search`; `fetch` with `render=true` → tier 2/3)
+
+**Interfaces:**
+- Consumes: `net_guard::screen_url`, `fetcher::FetchResult`.
+- Produces:
+  - `struct BrowserCfg { agent_browser_bin: String, lightpanda_path: Option<String>, chrome_stealth_args: String }`
+  - `fn preflight(cfg: &BrowserCfg) -> Preflight` where `enum Preflight { Full, LightpandaMissing, AgentBrowserTooOld(String), AgentBrowserMissing }`
+  - `async fn fetch_rendered(url: &str, deny: &[String], cfg: &BrowserCfg, want_chrome: bool) -> Result<FetchResult, FetchError>`
+  - `async fn search(query: &str, limit: usize, cfg: &BrowserCfg) -> Result<Vec<SearchHit>, FetchError>`; `struct SearchHit { title: String, url: String, snippet: String }`
+
+- [ ] **Step 1: Write the failing tests (command construction + preflight, no real browser)**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn lightpanda_command_forces_empty_args() {
+        let cfg = BrowserCfg { agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: Some("/x/lightpanda".into()), chrome_stealth_args: "--no-sandbox".into() };
+        let argv = build_fetch_argv("https://example.com", &cfg, false);
+        // lightpanda tier MUST pass --args "" and --executable-path, and MUST NOT carry stealth args
+        assert!(argv.windows(2).any(|w| w[0] == "--args" && w[1] == ""));
+        assert!(argv.windows(2).any(|w| w[0] == "--executable-path" && w[1] == "/x/lightpanda"));
+        assert!(argv.windows(2).any(|w| w[0] == "--engine" && w[1] == "lightpanda"));
+        assert!(!argv.iter().any(|a| a.contains("no-sandbox")));
+    }
+    #[test]
+    fn chrome_tier_carries_stealth_args() {
+        let cfg = BrowserCfg { agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: Some("/x/lightpanda".into()), chrome_stealth_args: "--no-sandbox".into() };
+        let argv = build_fetch_argv("https://example.com", &cfg, true);
+        assert!(argv.windows(2).any(|w| w[0] == "--engine" && w[1] == "chrome"));
+        assert!(argv.iter().any(|a| a == "--no-sandbox"));
+    }
+    #[test]
+    fn preflight_degrades_when_lightpanda_missing() {
+        let cfg = BrowserCfg { agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: None, chrome_stealth_args: String::new() };
+        // With no lightpanda path, preflight must not claim Full.
+        assert!(!matches!(preflight_from_versions(true, Some("0.31.1"), &cfg), Preflight::Full));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cargo test -p mur-research-gateway browser`
+Expected: FAIL — `browser` unresolved.
+
+- [ ] **Step 3: Implement `browser.rs`**
+
+```rust
+use crate::fetcher::{FetchError, FetchResult};
+use crate::net_guard;
+
+pub struct BrowserCfg {
+    pub agent_browser_bin: String,
+    pub lightpanda_path: Option<String>,
+    pub chrome_stealth_args: String, // comma-separated; empty = none
+}
+
+pub enum Preflight { Full, LightpandaMissing, AgentBrowserTooOld(String), AgentBrowserMissing }
+pub struct SearchHit { pub title: String, pub url: String, pub snippet: String }
+
+/// Build the agent-browser argv for a single fetch. Pure → unit-testable.
+/// lightpanda tier: --engine lightpanda --executable-path PATH --args "" (MANDATORY:
+/// stealth args must never reach lightpanda). chrome tier: --engine chrome + stealth.
+pub fn build_fetch_argv(url: &str, cfg: &BrowserCfg, want_chrome: bool) -> Vec<String> {
+    let mut a = Vec::new();
+    if want_chrome || cfg.lightpanda_path.is_none() {
+        a.push("--engine".into()); a.push("chrome".into());
+        for s in cfg.chrome_stealth_args.split(',').filter(|s| !s.is_empty()) { a.push(s.to_string()); }
+    } else {
+        a.push("--engine".into()); a.push("lightpanda".into());
+        a.push("--executable-path".into()); a.push(cfg.lightpanda_path.clone().unwrap());
+        a.push("--args".into()); a.push(String::new()); // MANDATORY empty
+    }
+    a.push("--session".into()); a.push(session_id(url)); // per-fetch isolation
+    a.push("open".into()); a.push(url.to_string()); a.push("snapshot".into());
+    a
+}
+
+fn session_id(url: &str) -> String {
+    // ponytail: deterministic per-URL session so concurrent fetches don't share
+    // cookie jars; hash keeps it filesystem-safe.
+    let mut h: u64 = 1469598103934665603;
+    for b in url.bytes() { h ^= b as u64; h = h.wrapping_mul(1099511628211); }
+    format!("rg-{h:016x}")
+}
+
+pub fn preflight_from_versions(ab_present: bool, ab_version: Option<&str>, cfg: &BrowserCfg) -> Preflight {
+    if !ab_present { return Preflight::AgentBrowserMissing; }
+    if let Some(v) = ab_version { if !version_ge(v, 0, 28) { return Preflight::AgentBrowserTooOld(v.into()); } }
+    if cfg.lightpanda_path.is_none() { return Preflight::LightpandaMissing; }
+    Preflight::Full
+}
+
+fn version_ge(v: &str, maj: u32, min: u32) -> bool {
+    let mut it = v.trim_start_matches('v').split('.');
+    let a: u32 = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let b: u32 = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    a > maj || (a == maj && b >= min)
+}
+
+/// Fetch a JS-rendered page. Pre-spawn SSRF/deny screen (proxy can't see the
+/// browser's connections — spec §5), then drive agent-browser.
+pub async fn fetch_rendered(url: &str, deny: &[String], cfg: &BrowserCfg, want_chrome: bool) -> Result<FetchResult, FetchError> {
+    let screened = net_guard::screen_url(url, deny).map_err(FetchError::Guard)?;
+    let argv = build_fetch_argv(screened.as_str(), cfg, want_chrome);
+    let out = tokio::process::Command::new(&cfg.agent_browser_bin)
+        .args(&argv)
+        .output().await.map_err(|e| FetchError::Http(format!("spawn agent-browser: {e}")))?;
+    if !out.status.success() {
+        return Err(FetchError::Http(String::from_utf8_lossy(&out.stderr).into()));
+    }
+    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    let tier = if want_chrome || cfg.lightpanda_path.is_none() { 3 } else { 2 };
+    Ok(FetchResult { url: screened.to_string(), status: 200, title: None, text, tier })
+}
+```
+
+Implement `search(query, limit, cfg)` by driving agent-browser to a search-results page (engine per preflight) and parsing hits; keep the parser small and behind the same pre-spawn screen. (Ponytail: v1 search quality rides the upstream engine; a dedicated search API is Out of Scope per spec §11.)
+
+- [ ] **Step 4: Wire `search` + rendered `fetch` into `server.rs`**
+
+`search` → `browser::search`. `fetch` with `render=true` → `fetch_rendered` (chrome only when a caller-supplied `chrome` flag or a tier-2 failure escalates). Load `BrowserCfg` from config/env (Lightpanda path from `MUR_RESEARCH_LIGHTPANDA_PATH`, default to the installed `~/.mur/…/lightpanda`; finalized in Task 6).
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `cargo test -p mur-research-gateway && cargo build -p mur-research-gateway`
+Expected: PASS + clean build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-research-gateway/src/browser.rs mur-research-gateway/src/server.rs
+git commit -m "feat(research-gateway): browser tiers 2/3 + search + preflight (pre-spawn SSRF)"
+```
+
+---
+
+### Task 5: URL-level audit
+
+Every `search`/`fetch` emits a structured audit record (`worker`, `url`/`query`, `tier`, `outcome`). This is the sole request-level evidence for the browser tiers (proxy is blind to them — spec §7.2/§7.4).
+
+**Files:**
+- Create: `mur-research-gateway/src/audit.rs`
+- Modify: `mur-research-gateway/src/server.rs` (emit on every call)
+
+**Interfaces:**
+- Produces: `fn audit(record: AuditRecord)` emitting a single-line JSON `tracing::info!(target: "research_gateway_audit", ...)`; `struct AuditRecord { worker: Option<String>, verb: &'static str, target: String, tier: Option<u8>, outcome: &'static str }`. `worker` is read from the `MUR_AGENT_NAME` env the runtime sets on the child (fallback `None`).
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn audit_line_is_single_json_object() {
+    let line = super::render_audit(&AuditRecord {
+        worker: Some("worker_3".into()), verb: "fetch",
+        target: "https://example.com".into(), tier: Some(1), outcome: "ok" });
+    let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+    assert_eq!(v["verb"], "fetch");
+    assert_eq!(v["tier"], 1);
+    assert_eq!(v["outcome"], "ok");
+}
+```
+
+- [ ] **Step 2: Run to verify fail** — `cargo test -p mur-research-gateway audit` → FAIL.
+
+- [ ] **Step 3: Implement `audit.rs`** — `render_audit(&AuditRecord) -> String` (serde_json), and `audit(rec)` that logs `tracing::info!(target: "research_gateway_audit", "{}", render_audit(&rec))`. Read `worker` from `std::env::var("MUR_AGENT_NAME").ok()`.
+
+- [ ] **Step 4: Emit in `server.rs`** — call `audit(...)` at the end of each `search`/`fetch` branch with the real outcome (`ok` / `denied` / `error`), tier from the result (denied → `tier: None`).
+
+- [ ] **Step 5: Run + build** — `cargo test -p mur-research-gateway && cargo build -p mur-research-gateway` → PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-research-gateway/src/audit.rs mur-research-gateway/src/server.rs mur-research-gateway/src/main.rs
+git commit -m "feat(research-gateway): URL-level audit for every search/fetch"
+```
+
+---
+
+### Task 6: config + install wiring — ship the gateway binary and read config.yaml
+
+Finalize config (no hardcoded values) and make the binary discoverable/shippable so agent sandboxes can spawn it.
+
+**Files:**
+- Create: `mur-research-gateway/src/config.rs`
+- Modify: `mur-research-gateway/src/server.rs` (load config once at startup)
+- Modify: `build.sh` (install `mur-research-gateway` alongside `mur`)
+- Create: `docs/attribution/lightpanda-AGPL.md` (AGPL notice + upstream source link)
+
+**Interfaces:**
+- Produces: `struct GatewayConfig { deny_hosts: Vec<String>, timeout: Duration, browser: BrowserCfg, search_limit: usize }`; `fn load(mur_home: &Path) -> GatewayConfig` reading `~/.mur/config.yaml` key `research_gateway:` with documented defaults; env vars override.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn config_defaults_and_env_override() {
+    std::env::set_var("MUR_RESEARCH_TIMEOUT_SECS", "45");
+    let c = load_from_yaml("", /*mur_home*/ std::path::Path::new("/nonexistent"));
+    assert_eq!(c.timeout.as_secs(), 45);        // env override
+    assert!(c.search_limit >= 1);                // documented default present
+    std::env::remove_var("MUR_RESEARCH_TIMEOUT_SECS");
+}
+```
+
+- [ ] **Step 2: Run → FAIL** — `cargo test -p mur-research-gateway config`.
+
+- [ ] **Step 3: Implement `config.rs`** — parse the optional `research_gateway:` block (serde_yaml, mirror how other crates read config.yaml); defaults: `timeout=20s`, `search_limit=8`, `chrome_stealth_args` = the documented stealth set, `lightpanda_path` = first existing of env → configured → `~/.mur/browser/lightpanda`. Every default is a named `const`, not an inline literal.
+
+- [ ] **Step 4: Wire startup** — `server::McpServer::new()` loads config once; store on the struct; pass `&config` into fetch/search.
+
+- [ ] **Step 5: Install in `build.sh`** — after the `mur` install line, add `cargo build --release -p mur-research-gateway` and copy `target/release/mur-research-gateway` to the same bin dir as `mur`. Add the AGPL attribution doc.
+
+- [ ] **Step 6: Run + build + install smoke**
+
+Run: `cargo test -p mur-research-gateway && cargo build --release -p mur-research-gateway`
+Expected: PASS; the release binary exists.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mur-research-gateway/src/config.rs mur-research-gateway/src/server.rs build.sh docs/attribution/lightpanda-AGPL.md
+git commit -m "feat(research-gateway): config.yaml + env config, ship binary, AGPL attribution"
+```
+
+---
+
+### Task 7: worker profile template + provisioning command
+
+Create the restricted worker agents, each mounting only the gateway MCP server (egress still `Inherit` — grant is Task 8, the explicit consent step).
+
+**Files:**
+- Create: `mur-core/src/cmd/deep_research/mod.rs` (subcommand module)
+- Create: `mur-core/src/cmd/deep_research/provision.rs`
+- Modify: `mur-core/src/cmd/mod.rs` + CLI arg enum (register `mur deep-research provision`)
+- Test: `mur-core/src/cmd/deep_research/provision.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `mur_common::agent::{AgentProfile, McpServerEntry}`; `cmd_fleet_create`.
+- Produces: `fn provision(mur_home, name_prefix: &str, count: usize) -> Result<Vec<String>>` — creates `count` agents `<prefix>_1..<prefix>_N`, each with entitlements `network.outbound = restricted` (empty allow) and one `mcp_servers` entry `{name:"research-gateway", command:"mur-research-gateway", args:[], network: None}`. Returns the created names.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn provision_creates_restricted_workers_with_gateway() {
+    let tmp = tempfile::tempdir().unwrap();
+    let names = provision(tmp.path(), "dr_worker", 3).unwrap();
+    assert_eq!(names.len(), 3);
+    let p = mur_common::agent::AgentProfile::load(tmp.path(), &names[0]).unwrap();
+    assert!(p.mcp_servers.iter().any(|s| s.name == "research-gateway"));
+    // egress NOT granted here — must be Inherit/restricted until the consent step
+    let gw = p.mcp_servers.iter().find(|s| s.name == "research-gateway").unwrap();
+    assert!(gw.network.is_none());
+}
+```
+
+- [ ] **Step 2: Run → FAIL** — `cargo test -p mur-core --bin mur provision` (bin tests need `RUST_MIN_STACK=33554432` — `mem:gotcha_mur_core_bin_nextest_stack_overflow`).
+
+- [ ] **Step 3: Implement `provision.rs`** — loop `1..=count`, build an `AgentProfile` with the restricted entitlement + gateway `McpServerEntry`, write via the existing profile writer (atomic temp+rename). Use the real profile-construction path `mur agent create` uses (call the same helper, don't hand-roll YAML).
+
+- [ ] **Step 4: Run → PASS**, then `cargo build -p mur-core` (needs `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/deep_research mur-core/src/cmd/mod.rs
+git commit -m "feat(deep-research): provision restricted worker agents mounting the gateway"
+```
+
+---
+
+### Task 8: egress grant step (explicit consent) in provisioning
+
+Grant `broad-audited` to each worker's gateway server via the shipped consent path — a separate, explicit step so it can never be implicit.
+
+**Files:**
+- Modify: `mur-core/src/cmd/deep_research/provision.rs` (add `--grant-egress` flag path)
+- Test: same file.
+
+**Interfaces:**
+- Consumes: the shipped `cmd_mcp_set_network(agent, "research-gateway", broad_audited=true, deny_hosts, yes)` (from #661, `cmd/agent/mcp.rs`).
+- Produces: `fn grant_egress(mur_home, worker: &str, deny_hosts: &[String], yes: bool) -> Result<()>` — sets the gateway server to `BroadAudited` with an `EgressAuthorization`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn grant_sets_broad_audited_with_authorization() {
+    let tmp = tempfile::tempdir().unwrap();
+    let names = provision(tmp.path(), "dr_worker", 1).unwrap();
+    grant_egress(tmp.path(), &names[0], &["evil.example".into()], /*yes=*/true).unwrap();
+    let p = mur_common::agent::AgentProfile::load(tmp.path(), &names[0]).unwrap();
+    let gw = p.mcp_servers.iter().find(|s| s.name == "research-gateway").unwrap();
+    let net = gw.network.as_ref().unwrap();
+    assert!(matches!(net.mode, mur_common::agent::McpNetMode::BroadAudited));
+    assert!(net.authorization.is_some());
+    assert!(net.deny_hosts.contains(&"evil.example".to_string()));
+}
+```
+
+- [ ] **Step 2: Run → FAIL** — `RUST_MIN_STACK=33554432 cargo test -p mur-core --bin mur grant_sets_broad`.
+
+- [ ] **Step 3: Implement `grant_egress`** — call the shipped `cmd_mcp_set_network` with `broad_audited=true`; when invoked from `provision --grant-egress`, prompt for consent per worker unless `--yes`. Never call this from fleet create.
+
+- [ ] **Step 4: Run → PASS**, `cargo build -p mur-core`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/deep_research/provision.rs
+git commit -m "feat(deep-research): explicit broad-audited egress grant per worker (consent-gated)"
+```
+
+---
+
+### Task 9: fleet-scoped research skills (router + worker prompts)
+
+Reshape the five `aura-*` skills into fleet roles. Content only (YAML); the escalation-ladder skill is retired (now gateway code).
+
+**Files:**
+- Create: `~/.mur/skills/…` is runtime data — instead create source templates: `mur-core/src/skills/deep_research_router.yaml`, `deep_research_worker.yaml`, `deep_research_verify.yaml` (mirror where `mur_parallel_exec.yaml` etc. live).
+- Modify: skill loader registration if source skills are compiled in (follow the pattern of the existing `*.yaml` in `mur-core/src/skills/`).
+
+**Interfaces:**
+- Produces: three skills with `scope: Fleet`, triggers/tags wired so they inject only for `deep-research` members. Router skill states the decompose→assign→synthesize procedure incl. emitting `RESEARCH_COMPLETE` on its own line. Worker skill: `search`/`fetch` via the gateway + citation discipline. Verify skill: adversarial refutation under one lens.
+
+- [ ] **Step 1: Write the failing test** — a loader test asserting the three YAML files parse into `SkillManifest` with `scope: Fleet` and non-empty procedure (mirror the existing skill-loader test).
+
+- [ ] **Step 2: Run → FAIL**.
+
+- [ ] **Step 3: Author the three YAMLs** — reuse the prose from `aura-citation-discipline`, `aura-source-triangulation`, `aura-parallel-fanout`; drop `aura-research-escalation-ladder` (superseded by gateway code) and note the retirement in the worker skill.
+
+- [ ] **Step 4: Run → PASS** (`cargo test -p mur-core --bin mur skills`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/skills/deep_research_*.yaml
+git commit -m "feat(deep-research): fleet-scoped router/worker/verify skills"
+```
+
+---
+
+### Task 10: orchestration TDD against a stub gateway
+
+Prove the full loop (decompose→research→verify→synthesize→marker convergence) with NO network, using a stub gateway binary that returns a fixed corpus. This is the load-bearing integration test.
+
+**Files:**
+- Create: `mur-research-gateway/src/bin/stub_gateway.rs` (a fixed-corpus MCP server for tests)
+- Create: `mur-core/tests/deep_research_loop.rs` (integration test)
+
+**Interfaces:**
+- Consumes: `provision`, `cmd_fleet_create`, `mur fleet run --loop` executor entry (`cmd/fleet/loop_run.rs`).
+- Produces: an integration test that provisions 2 workers pointed at `stub_gateway`, creates a `deep-research` fleet with `done_when: marker:RESEARCH_COMPLETE`, runs one bounded loop, and asserts a synthesized report with ≥1 cited claim appears in the channel.
+
+- [ ] **Step 1: Write `stub_gateway.rs`** — same MCP handshake as the real one; `search` returns 2 fixed hits, `fetch` returns fixed text containing a known fact + a citable URL. Deterministic.
+
+- [ ] **Step 2: Write the failing integration test**
+
+```rust
+#[tokio::test]
+async fn deep_research_loop_converges_with_stub_gateway() {
+    // provision 2 workers whose gateway command = the built stub_gateway binary
+    // create fleet "dr-test", router=mur, done_when marker:RESEARCH_COMPLETE, budget small
+    // run_loop with max_iterations bounded
+    // assert: channel contains a synthesis event with a citation URL from the stub corpus
+}
+```
+
+- [ ] **Step 3: Run → FAIL** (`cargo test -p mur-core --test deep_research_loop`).
+
+- [ ] **Step 4: Implement the wiring** — a thin `mur deep-research run <fleet>` that calls the existing loop executor; make the test drive it. Keep new code minimal — reuse `loop_run`.
+
+- [ ] **Step 5: Run → PASS**.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-research-gateway/src/bin/stub_gateway.rs mur-core/tests/deep_research_loop.rs mur-core/src/cmd/deep_research
+git commit -m "test(deep-research): full loop converges against stub gateway (no network)"
+```
+
+---
+
+### Task 11: real E2E — one small question
+
+Swap in the real gateway with a real broad-audited grant; run one narrow question end-to-end; verify cited report + per-claim signed-channel provenance + audit reconciliation.
+
+**Files:**
+- Create: `docs/superpowers/plans/artifacts/mur-native-deep-research-e2e.md` (record the run + evidence)
+
+- [ ] **Step 1:** `MUR_WEB_DIST=… ORT_STRATEGY=download ./build.sh --install` (ships `mur` + `mur-research-gateway`).
+- [ ] **Step 2:** `mur deep-research provision --count 4 --grant-egress` (consent per worker).
+- [ ] **Step 3:** `mur fleet create deep-research --members dr_worker_1,dr_worker_2,dr_worker_3,dr_worker_4 --router mur --goal "<a narrow, verifiable question>"`; set `done_when: marker:RESEARCH_COMPLETE` + a small `--budget-usd`.
+- [ ] **Step 4:** `MUR_FLEET_AUTORUN=0 mur fleet run deep-research --loop --budget-usd 3 --deadline 30m`.
+- [ ] **Step 5: Verify (evidence before claims)** — the channel holds a synthesized cited report; every citation reconciles to a `research_gateway_audit` line; claims are signed by their producing worker (per-actor `channel_verify`). Record all of it in the artifact doc. If any citation lacks an audit line, STOP — that's an egress-bypass bug.
+- [ ] **Step 6: Commit** the artifact.
+
+---
+
+## Notes for the implementer
+
+- **Build the gateway crate first and in isolation** — it has no ORT/web-dist deps, so `cargo build -p mur-research-gateway` is fast. The `mur-core` tasks (7–10) need `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist` and the rustup toolchain on PATH, and are SLOW to compile cold (~20min) — build FOREGROUND, don't background+poll. — `mem:project_agent_egress_governance`.
+- **bin tests** (`cmd/*`) run under `cargo test -p mur-core --bin mur` with `RUST_MIN_STACK=33554432`. — `mem:gotcha_mur_core_bin_nextest_stack_overflow`.
+- **Never grant egress from fleet create** — only the explicit `--grant-egress` consent step (Task 8). — spec §7.1.
+- **agent-browser preflight**: `npm i -g agent-browser@latest` (>=0.28.0); Lightpanda binary is already installed (`~/.mur/…/lightpanda`, verified 2026-07-08); `pkill -f agent-browser` if the daemon is stale. — `mem:gotcha_agent_browser_lightpanda_engine_dead`.

--- a/docs/superpowers/plans/2026-07-09-mur-native-deep-research.md
+++ b/docs/superpowers/plans/2026-07-09-mur-native-deep-research.md
@@ -16,7 +16,7 @@
 - **`agent-browser mcp` / driver requires >= 0.28.0.** Preflight must check and degrade explicitly if lower/missing. — verified 2026-07-08.
 - **Workers hold NO egress.** Only the gateway subprocess reaches the web. Worker agent entitlements stay `restricted`. — spec §3.
 - **Egress grant only via the shipped consent path** (`mur agent mcp set-network <agent> research-gateway --broad-audited`). Fleet creation never opens egress implicitly. — spec §7.1.
-- **SSRF guard is non-configurable and stricter than the runtime's local-first guard** — the gateway refuses loopback + RFC1918/ULA private + link-local/metadata + unspecified (the runtime's `is_link_local_or_unspecified` deliberately allows loopback/private for local LLMs; the gateway must NOT). — spec §5, §7.3.
+- **SSRF guard is non-configurable and stricter than the runtime's local-first guard** — the gateway refuses loopback + RFC1918/ULA private + link-local/metadata + unspecified (the runtime's `is_link_local_or_unspecified` deliberately allows loopback/private for local LLMs; the gateway must NOT). The two IP predicates stay separate (different policies); the host-pattern **matcher** is single-sourced in `mur-common::net` (shared by the egress proxy and the gateway — a security boundary must not have two copies that can drift). — spec §5, §7.3.
 - **Brand:** user-facing label is uppercase where surfaced; internal names lowercase. — CLAUDE.md rule 7.
 - **Build env:** `mur-core`/runtime need `ORT_STRATEGY=download` + `MUR_WEB_DIST=$HOME/Projects/mur-web/dist`; rustup toolchain on PATH. The gateway crate itself is light (no ORT). — `mem:env_ort_strategy_download`.
 
@@ -185,22 +185,51 @@ git commit -m "feat(research-gateway): scaffold stdio MCP with search/fetch decl
 
 ---
 
-### Task 2: `net_guard.rs` — strict SSRF predicate + deny-host matcher
+### Task 2: shared host-matching (mur-common) + strict SSRF guard
 
-The security core. A pure module, unit-tested hard, with **no network**. It is deliberately stricter than the runtime's `is_link_local_or_unspecified` (which allows loopback/RFC1918 for local LLMs — wrong threat model for a web researcher).
+The security core. Two phases: (A) hoist the host-pattern matcher to `mur-common`
+so the egress proxy and this gateway share ONE matcher (a security boundary must
+not have two copies that can drift); (B) build the gateway's guard on top. The
+SSRF **IP** predicate is deliberately NOT shared — the runtime's
+`is_link_local_or_unspecified` allows loopback/RFC1918 (local LLMs) while the
+gateway forbids them; these are two different policies, not one duplicated block.
 
 **Files:**
+- Create: `mur-common/src/net.rs` (pure host-pattern matcher, shared)
+- Modify: `mur-common/src/lib.rs` (`pub mod net;`)
+- Modify: `mur-agent-runtime/src/sandbox/reqwest_guard.rs` (delete local `host_matches_pattern`/`host_allowed`; `pub use mur_common::net::{host_matches_pattern, host_allowed};` so existing callers are unchanged)
 - Create: `mur-research-gateway/src/net_guard.rs`
 - Modify: `mur-research-gateway/src/main.rs` (add `mod net_guard;`)
+- Modify: `mur-research-gateway/Cargo.toml` (add `url = { workspace = true }`)
 
 **Interfaces:**
-- Produces:
+- Produces (mur-common):
+  - `pub fn host_matches_pattern(host: &str, pattern: &str) -> bool` — `*.x.com` / legacy `.x.com` match subdomains + apex; else exact. Byte-identical to the current reqwest_guard version.
+  - `pub fn host_allowed(host: &str, allow: &[String]) -> bool` — true if any pattern matches (empty = false).
+- Produces (gateway `net_guard`):
   - `fn is_forbidden_target(ip: std::net::IpAddr) -> bool` — true for loopback, RFC1918/ULA private, link-local/metadata, unspecified (normalizing IPv4-in-IPv6 first).
-  - `fn host_denied(host: &str, deny: &[String]) -> bool` — true if host matches any deny pattern (`*.x.com` / `.x.com` / exact).
-  - `fn screen_url(url: &str, deny: &[String]) -> Result<url::Url, GuardReject>` — parse, reject non-http(s), reject denied host, resolve host and reject if ANY resolved IP is a forbidden target. Returns the parsed URL on pass. (Add `url` to Cargo.toml deps.)
+  - `fn host_denied(host: &str, deny: &[String]) -> bool` — thin wrapper: `mur_common::net::host_allowed(host, deny)` (same matcher; the deny LIST gives it deny semantics).
+  - `fn screen_url(url: &str, deny: &[String]) -> Result<url::Url, GuardReject>` — parse, reject non-http(s), reject denied host, resolve host and reject if ANY resolved IP is a forbidden target. Returns the parsed URL on pass.
   - `enum GuardReject { BadScheme, DeniedHost, PrivateAddress, Unresolvable }`
 
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1: Move the matcher to mur-common**
+
+Create `mur-common/src/net.rs` with `host_matches_pattern` + `host_allowed` copied **verbatim** from `mur-agent-runtime/src/sandbox/reqwest_guard.rs` (lines ~12-33), plus a unit test for each. Add `pub mod net;` to `mur-common/src/lib.rs`.
+
+- [ ] **Step 2: Point reqwest_guard at the shared matcher**
+
+In `reqwest_guard.rs`, delete the two local fns and add `pub use mur_common::net::{host_matches_pattern, host_allowed};` at the top (callers in `egress_proxy.rs` import them from here — unchanged). This is behavior-preserving.
+
+- [ ] **Step 3: Verify no egress regression, commit the extraction**
+
+Run: `ORT_STRATEGY=download cargo test -p mur-common net:: && ORT_STRATEGY=download cargo test -p mur-agent-runtime egress_proxy`
+Expected: PASS (matcher moved, egress-proxy allow/deny behavior identical).
+```bash
+git add mur-common/src/net.rs mur-common/src/lib.rs mur-agent-runtime/src/sandbox/reqwest_guard.rs
+git commit -m "refactor(net): hoist host-pattern matcher to mur-common (single source for egress + gateway)"
+```
+
+- [ ] **Step 4: Write the failing gateway-guard tests**
 
 ```rust
 #[cfg(test)]
@@ -236,12 +265,12 @@ mod tests {
 }
 ```
 
-- [ ] **Step 2: Run to verify they fail**
+- [ ] **Step 5: Run to verify they fail**
 
 Run: `cargo test -p mur-research-gateway net_guard`
 Expected: FAIL — `net_guard` unresolved.
 
-- [ ] **Step 3: Implement `net_guard.rs`**
+- [ ] **Step 6: Implement `net_guard.rs`**
 
 ```rust
 use std::net::{IpAddr, ToSocketAddrs};
@@ -249,20 +278,11 @@ use std::net::{IpAddr, ToSocketAddrs};
 #[derive(Debug, PartialEq)]
 pub enum GuardReject { BadScheme, DeniedHost, PrivateAddress, Unresolvable }
 
-/// Host-pattern matcher. Mirrors `mur-agent-runtime::sandbox::reqwest_guard::
-/// host_matches_pattern` (kept local to avoid depending on the heavy runtime
-/// crate). `*.x.com` / legacy `.x.com` match subdomains + apex; else exact.
-fn host_matches_pattern(host: &str, pattern: &str) -> bool {
-    let host = host.to_ascii_lowercase();
-    let pattern = pattern.to_ascii_lowercase();
-    let suffix = if let Some(s) = pattern.strip_prefix("*.") { s }
-        else if let Some(s) = pattern.strip_prefix('.') { s }
-        else { return host == pattern };
-    host == suffix || host.ends_with(&format!(".{suffix}"))
-}
-
+/// Deny semantics via the shared matcher (single source of truth with the
+/// egress proxy — `mur_common::net`). Same matcher; the deny LIST is what
+/// makes a match mean "blocked".
 pub fn host_denied(host: &str, deny: &[String]) -> bool {
-    deny.iter().any(|p| host_matches_pattern(host, p))
+    mur_common::net::host_allowed(host, deny)
 }
 
 /// STRICTER than the runtime's local-first guard: a web researcher has no
@@ -306,18 +326,16 @@ pub fn screen_url(raw: &str, deny: &[String]) -> Result<url::Url, GuardReject> {
 }
 ```
 
-Add `url = { workspace = true }` to the crate's Cargo.toml deps (mirror the workspace version).
-
-- [ ] **Step 4: Run to verify they pass**
+- [ ] **Step 7: Run to verify they pass**
 
 Run: `cargo test -p mur-research-gateway net_guard`
 Expected: PASS (all four tests).
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
 git add mur-research-gateway/src/net_guard.rs mur-research-gateway/src/main.rs mur-research-gateway/Cargo.toml
-git commit -m "feat(research-gateway): strict SSRF guard + deny-host matcher"
+git commit -m "feat(research-gateway): strict SSRF guard reusing mur-common host matcher"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md
+++ b/docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md
@@ -128,6 +128,15 @@ that holds egress.
 - **SSRF guard (hard rule, non-configurable)** — refuse any URL resolving to a
   private / link-local / loopback / unique-local address; re-resolve after DNS and
   re-check (DNS-rebinding defense). Applied to every tier.
+- **Where `deny_hosts` + SSRF are enforced (tier-dependent — load-bearing).** The
+  egress proxy only sees tier-1 (`reqwest`) connections; the tier-2/3 browser
+  subprocesses open their own connections the proxy cannot observe. Therefore, for
+  the browser tiers, `deny_hosts` and the SSRF guard are enforced **in gateway code
+  before spawning the browser** (URL pre-filtered; refused URLs never reach
+  agent-browser). Proxy-layer deny/audit is a backstop for tier 1 only; the gateway's
+  own pre-spawn check + URL-level audit is the sole enforcement/evidence for tiers
+  2/3. This is not a dependency on egress-governance Phase 3 — it is the gateway
+  doing its own job; Phase 3 (sbpl pin-to-proxy) later makes it airtight.
 - **URL-level audit** — every call logs `{worker, url, tier, outcome}` to the channel
   and telemetry, giving request-level auditability above the proxy's host-level
   CONNECT log.
@@ -162,7 +171,9 @@ must honor it exactly (cross-checked against `2026-07-08-agent-egress-governance
 2. **Two-layer audit.** Proxy per-CONNECT (host-level) + gateway per-call (URL-level).
    Every report citation reconciles to one gateway audit record.
 3. **SSRF guard** (§5) — broad-audited's "all" must exclude internal networks;
-   non-negotiable, on top of `deny_hosts`.
+   non-negotiable, on top of `deny_hosts`. For the browser tiers, both `deny_hosts`
+   and SSRF are enforced **in gateway code pre-spawn** (§5) — the proxy cannot see
+   browser-subprocess connections, so it is not the enforcement point there.
 4. **Advisory-enforcement honesty.** tier 1 (reqwest) honors the proxy; tier 2/3
    browser subprocesses may not — mitigated by universal gateway URL audit, and
    documented (not overclaimed) as "airtight = Phase 3 sbpl pin-to-proxy, which then

--- a/docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md
+++ b/docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md
@@ -125,9 +125,11 @@ that holds egress.
   isolated, 2026-07-08) so concurrent worker fetches never cross-contaminate state.
 - **Daemon lifecycle** — manage agent-browser's persistent daemon; detect version
   mismatch; `pkill -f agent-browser` on staleness.
-- **SSRF guard (hard rule, non-configurable)** — refuse any URL resolving to a
-  private / link-local / loopback / unique-local address; re-resolve after DNS and
-  re-check (DNS-rebinding defense). Applied to every tier.
+- **SSRF guard (hard rule, non-configurable)** — refuse any URL whose resolved IP is
+  private / link-local / loopback / unique-local, checked at screen time on every
+  tier. Connect-time re-resolution (the DNS-rebinding window between screen and
+  connect) is NOT closed yet — same advisory-enforcement framing as §7 item 4:
+  deferred to Phase 3, not rebind-proof today.
 - **Where `deny_hosts` + SSRF are enforced (tier-dependent — load-bearing).** The
   egress proxy only sees tier-1 (`reqwest`) connections; the tier-2/3 browser
   subprocesses open their own connections the proxy cannot observe. Therefore, for

--- a/docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md
+++ b/docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md
@@ -1,0 +1,219 @@
+# MUR-Native Deep Research (Design)
+
+Date: 2026-07-09
+Status: Design approved; ready for implementation plan.
+
+## 1. Goal
+
+Give MUR a **native** deep-research capability — query decomposition → parallel
+fan-out → adversarial verification → cited synthesis — that runs on MUR's own
+orchestration primitives (**dynamic workflow + fleet + agents**), not on Claude
+Code's built-in `deep-research` skill.
+
+**Why native (the motivation that fixes the architecture):** the Claude Code
+built-in already does this research well, but it runs as *host subagents* — the
+work is Claude's, MUR only labels it (proven: yesterday's "AURA Mode 1" security
+report was 100% Claude host subagents; the `aura` MUR agent lived 34 seconds and
+touched nothing). Native buys three things the built-in structurally cannot:
+
+1. **MUR orchestration owns it** — a fleet of MUR agents, driven by the router's
+   dynamic per-iteration DAG (`cmd/fleet/plan.rs`), is the thing doing the research.
+2. **Cryptographic provenance** — every claim is written into an Ed25519-signed
+   channel by the worker that produced it (Unified Channel v3d per-actor signing).
+   "AURA did this research" becomes provable, not a label.
+3. **Platform integration** — budget accounting, kill-switch, Commander governance,
+   scheduling, and long-term memory all ride the existing fleet/agent machinery.
+
+**Non-goal:** out-parallelizing the built-in. Real concurrency is bounded either
+way (~min(16, cores-2)). Native wins on ownership/provenance/governance, not speed.
+
+## 2. What this replaces and reuses
+
+Grounding (2026-07-09) established the exact reuse surface:
+
+- **Reuse — fleet dynamic loop.** `mur fleet run --loop` with the router emitting a
+  DAG each iteration (`cmd/fleet/plan.rs`), convergence via `done_when: marker:<TEXT>`,
+  guards (iteration/deadline/stuck), real per-token budget, kill-switch, Commander
+  hooks (`cmd/fleet/loop_run.rs`). This IS the "dynamic workflow" the user wants.
+- **Reuse — per-server egress governance (#661, on main).** `McpNetMode::BroadAudited`
+  = allow-all-except-`deny_hosts`, routed through the loopback CONNECT egress proxy
+  (`sandbox/egress_proxy.rs`) with per-CONNECT audit; granted via
+  `mur agent mcp set-network --broad-audited` (consent + `EgressAuthorization` +
+  telemetry). See `2026-07-08-agent-egress-governance-design.md`.
+- **Reuse — agent-browser + Lightpanda** (verified 0.31.1, 2026-07-08; see
+  `gotcha_agent_browser_lightpanda_engine_dead`). Lightpanda binary already installed
+  at a configurable path.
+- **New — exactly two units:** a `research-gateway` MCP server (§5) and the
+  research prompts/skills (§6). Everything else is composition.
+
+**Rejected alternatives:**
+- *Static DAG workflow + delegate* — the DAG is authored ahead of time; dynamic
+  fan-out (sub-question count unknown until decomposition) doesn't fit.
+- *Single agent + `parallel_jobs`* — its fan-out target is a CLI subprocess
+  (claude/codex); either it has no reasoning (agent-browser = fetch, no research) or
+  it spawns claude (back to non-native). The LLM worker must be a MUR fleet agent.
+
+## 3. Architecture
+
+```
+┌─────────────────────────── fleet "deep-research" ───────────────────────────┐
+│  router (mur)                                                                │
+│   └─ per-iteration DAG (plan.rs):  decompose → research×N → verify → synth   │
+│                                                                              │
+│  worker_1..worker_k   (k = 8–16, configurable; ALL entitlements: restricted) │
+│   each mounts ONE broad-audited MCP server:  research-gateway                 │
+└──────────────────────────────────────────────────────────────────────────────┘
+        │ MCP: search(query) / fetch(url)   ← read-only verbs, no free navigation
+        ▼
+┌──────────── research-gateway (Rust, MUR-shipped, broad-audited egress) ───────┐
+│  preflight: agent-browser >= 0.28.0? lightpanda present?  (missing → degrade) │
+│  SSRF guard: refuse private/link-local/loopback IPs (post-DNS recheck)         │
+│  tier 1: reqwest GET                              (most pages, cheapest)       │
+│  tier 2: agent-browser --engine lightpanda --args "" --session <per-fetch>    │
+│  tier 3: agent-browser --engine chrome (+stealth)  (anti-bot / screenshot)    │
+│  URL-level audit per call → channel/telemetry                                 │
+└───────────────────────────────────────────────────────────────────────────────┘
+```
+
+Workers are the injectable surface and hold **no egress**. Only the deterministic
+(no-LLM) gateway reaches the web. A prompt-injected worker can at most ask the
+gateway to fetch a URL — logged, SSRF-guarded, and incapable of POSTing arbitrary
+data to arbitrary hosts (the API is `fetch`, not "open a socket").
+
+## 4. Dynamic flow (fleet run --loop)
+
+The router emits a fresh DAG each iteration; the loop runs until the synthesis
+marker appears. Sub-question count is decided dynamically at decompose time.
+
+1. **Decompose** — router splits the question into sub-questions (may be 100+),
+   writes them to the channel as a work queue.
+2. **Research (×N iterations)** — router assigns a batch of sub-questions to workers
+   (bounded by `max_concurrency`); each worker `search()`s, `fetch()`es top sources,
+   extracts **claims each bound to a URL + supporting quote**, writes them to the
+   channel. Repeats until the queue drains.
+3. **Verify (3-vote adversarial)** — each claim is dispatched to 3 workers, each with
+   a distinct refutation lens (correctness / source-independence / recency). A claim
+   survives on a 2-of-3 confirm; else it is dropped (fail-safe = drop).
+4. **Synthesize** — router folds confirmed claims into a cited report and emits
+   `done_when: marker:RESEARCH_COMPLETE` on its own line → deterministic convergence.
+
+Inherited for free: `--budget-usd` (real token accounting), kill-switch
+(`mur fleet stop`), Commander kill/budget hooks (fail-closed), signed-channel
+provenance per claim.
+
+## 5. Component: `research-gateway` MCP server
+
+A new, small, deterministic Rust MCP server shipped with MUR (BusyBox-style or a
+dedicated binary; decided in the plan). **No LLM.** This is the single trust boundary
+that holds egress.
+
+**Tools exposed to workers (read-only):**
+- `search(query, limit?) -> [{title, url, snippet}]`
+- `fetch(url, render?) -> {url, status, title, text, fetched_at}`
+
+**Internals:**
+- **Preflight** — verify `agent-browser >= 0.28.0` and the Lightpanda binary exist;
+  if missing, degrade to tier 1 and surface an explicit warning (never silently).
+- **Escalation ladder (deterministic code, not a skill):**
+  - tier 1 `reqwest` GET — default; most pages.
+  - tier 2 `agent-browser --engine lightpanda --executable-path <cfg> --args "" --session <per-fetch>`
+    — JS pages. `--args ""` is mandatory (Chrome stealth args break Lightpanda).
+  - tier 3 `agent-browser --engine chrome` (+stealth args) — anti-bot / screenshot.
+  - Search backend: `agent-browser` (default engine lightpanda) drives a search
+    results page; tier-1 HTML search as the cheap path. No API key required for v1.
+- **Per-fetch session isolation** — each fetch uses a unique `--session` id (verified
+  isolated, 2026-07-08) so concurrent worker fetches never cross-contaminate state.
+- **Daemon lifecycle** — manage agent-browser's persistent daemon; detect version
+  mismatch; `pkill -f agent-browser` on staleness.
+- **SSRF guard (hard rule, non-configurable)** — refuse any URL resolving to a
+  private / link-local / loopback / unique-local address; re-resolve after DNS and
+  re-check (DNS-rebinding defense). Applied to every tier.
+- **URL-level audit** — every call logs `{worker, url, tier, outcome}` to the channel
+  and telemetry, giving request-level auditability above the proxy's host-level
+  CONNECT log.
+
+**Config (no hardcoded values):** Lightpanda executable path, engine defaults,
+worker count, per-request timeout, `deny_hosts` overlay — all from
+`~/.mur/config.yaml` / fleet config / env, never literals.
+
+## 6. Component: research prompts / skills
+
+Reshape the five existing `aura-*` skills into the fleet roles (scope: **Fleet**, so
+they inject only for `deep-research` members):
+
+- **Router** — decompose prompt (breadth → sub-questions), assignment prompt (batch →
+  workers), synthesis prompt (confirmed claims → cited report + marker).
+- **Worker (research)** — `search`/`fetch` via gateway, extract claims with citations
+  (reuse `aura-citation-discipline`, `aura-source-triangulation`).
+- **Worker (verify)** — adversarial refutation under one assigned lens.
+
+The escalation ladder that was `aura-research-escalation-ladder` (advisory, LLM-facing)
+becomes **deterministic gateway code** (§5) — a strict upgrade; the skill is retired.
+
+## 7. Egress governance alignment
+
+This fleet is the **first real workload** for the #661 egress governance model, and
+must honor it exactly (cross-checked against `2026-07-08-agent-egress-governance-design.md`):
+
+1. **Grant via the shipped consent path only.** Provisioning runs
+   `mur agent mcp set-network <agent> research-gateway --broad-audited` per worker —
+   one explicit operator consent, recorded as `EgressAuthorization`. Fleet creation
+   NEVER opens egress implicitly ("it's a research fleet" is not consent).
+2. **Two-layer audit.** Proxy per-CONNECT (host-level) + gateway per-call (URL-level).
+   Every report citation reconciles to one gateway audit record.
+3. **SSRF guard** (§5) — broad-audited's "all" must exclude internal networks;
+   non-negotiable, on top of `deny_hosts`.
+4. **Advisory-enforcement honesty.** tier 1 (reqwest) honors the proxy; tier 2/3
+   browser subprocesses may not — mitigated by universal gateway URL audit, and
+   documented (not overclaimed) as "airtight = Phase 3 sbpl pin-to-proxy, which then
+   pins only this one gateway."
+5. **Export/import safety (free, shipped).** `.fleet` import downgrades broad-audited
+   → `inherit` and clears authorization; a shared deep-research fleet has no egress
+   until re-granted locally.
+6. **Commander revocation point.** Reserve the single gateway entry as the revocation
+   target for the future `revoke-egress` directive (Phase 2); no code now.
+
+Net: one gateway choke point means Phase 2 (request-level audit) is partially realized
+here today, and Phase 3 (DLP / pin-to-proxy) later touches exactly one point.
+
+## 8. Component boundaries
+
+| Unit | Responsibility | Depends on |
+|------|----------------|------------|
+| fleet `deep-research` (config) | roster (router + k workers), goal, `done_when`, budget | fleet machinery (existing) |
+| router prompts | decompose / assign / synthesize | LLM; channel |
+| worker prompts (research/verify) | search+fetch+extract; adversarial verify | `research-gateway` MCP |
+| `research-gateway` MCP (new Rust) | search/fetch, escalation, SSRF, audit, daemon | agent-browser + Lightpanda subprocess |
+| egress grant (config) | per-worker broad-audited on the gateway server | `mcp set-network` (#661) |
+
+Each is independently testable (§9).
+
+## 9. Testing
+
+- **Gateway (unit)** — tier selection; `--args ""` on lightpanda; SSRF guard blocks
+  private/link-local/loopback + post-DNS recheck; `deny_hosts` respected; audit line
+  emitted per call; preflight degrades on missing binary.
+- **Orchestration (integration)** — run the full loop against a **stub gateway**
+  (fixed corpus, deterministic) to TDD decompose→fan-out→verify→synthesize and marker
+  convergence, with no network.
+- **E2E (one small real question)** — swap in the real broad-audited gateway; confirm
+  a cited report with per-claim provenance in the signed channel; confirm every
+  citation has a matching gateway audit record.
+
+## 10. Delivery sequencing (de-risk)
+
+1. `research-gateway` MCP (tier 1 + SSRF + audit + stub search) — unit-tested alone.
+2. Fleet config + prompts; orchestration TDD against the stub gateway.
+3. Wire agent-browser tiers 2/3 into the gateway.
+4. Grant broad-audited per worker (consent path); E2E on one real question.
+5. Optional later: shared single-instance gateway (remote MCP + fetch cache) if
+   duplicate-fetch waste is measured; scheduling + long-term memory (the Mode-2
+   persistence story) as a follow-on.
+
+## 11. Out of scope (this spec)
+
+- Search-provider API backends (Brave/SerpAPI) — v1 uses agent-browser-driven search.
+- Shared single-process gateway / cross-worker fetch cache (measure first).
+- Scheduling + long-term research memory (follow-on; the fleet runs one job at a time).
+- DLP / rate-limiting / sbpl pin-to-proxy (egress governance Phase 3).
+- Commander `revoke-egress` directive (egress governance Phase 2).

--- a/mur-agent-runtime/src/protocol/mcp_client.rs
+++ b/mur-agent-runtime/src/protocol/mcp_client.rs
@@ -4,7 +4,7 @@
 //! Use `McpClient::connect` to pick the right variant based on the server entry.
 
 use crate::sandbox::SandboxPolicy;
-use mur_common::agent::{McpAuth, McpServerEntry};
+use mur_common::agent::{ENV_MCP_DENY_HOSTS, McpAuth, McpServerEntry};
 use serde_json::{Value, json};
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
@@ -359,14 +359,25 @@ pub fn proxy_env_for(
     let token = proxy.register_policy(net.allow_hosts.clone(), net.deny_hosts.clone(), broad);
     let url = format!("http://{token}:x@{}", proxy.addr);
     let no_proxy = "127.0.0.1,localhost,::1".to_string();
-    vec![
+    let mut env = vec![
         ("HTTP_PROXY".into(), url.clone()),
         ("HTTPS_PROXY".into(), url.clone()),
         ("http_proxy".into(), url.clone()),
         ("https_proxy".into(), url),
         ("NO_PROXY".into(), no_proxy.clone()),
         ("no_proxy".into(), no_proxy),
-    ]
+    ];
+    // Also hand the deny list to the child directly (not just the proxy):
+    // the proxy only sees this child's tier-1 (reqwest-style) connections.
+    // A cooperating child that opens its own connections the proxy can't
+    // observe (e.g. mur-research-gateway's tier-2/3 browser subprocesses —
+    // see its `browser.rs` module doc) reads this env var to self-enforce
+    // the SAME operator deny-hosts overlay. See mur-common's
+    // `ENV_MCP_DENY_HOSTS` doc for the shared-const rationale.
+    if !net.deny_hosts.is_empty() {
+        env.push((ENV_MCP_DENY_HOSTS.to_string(), net.deny_hosts.join(",")));
+    }
+    env
 }
 
 #[cfg(test)]
@@ -416,6 +427,47 @@ mod tests {
             authorization: None,
         });
         assert!(proxy_env_for(&inherit, Some(&handle)).is_empty());
+    }
+
+    /// The operator's `--deny-host` overlay must reach the child directly
+    /// (not just the proxy), so a cooperating child whose own subprocesses
+    /// bypass the proxy (mur-research-gateway's browser tiers) can
+    /// self-enforce it. See mur-common's `ENV_MCP_DENY_HOSTS` doc.
+    #[test]
+    fn proxy_env_includes_deny_hosts_for_cooperating_children() {
+        let base = McpServerEntry {
+            name: "research-gateway".into(),
+            command: "mur-research-gateway".into(),
+            ..Default::default()
+        };
+        let mut broad_audited = base.clone();
+        broad_audited.network = Some(McpServerNetwork {
+            mode: McpNetMode::BroadAudited,
+            allow_hosts: vec![],
+            deny_hosts: vec!["blocked.example".into()],
+            authorization: None,
+        });
+        let handle = crate::sandbox::egress_proxy::EgressProxyHandle::for_test(
+            "127.0.0.1:9".parse().unwrap(),
+        );
+        let env: HashMap<_, _> = proxy_env_for(&broad_audited, Some(&handle))
+            .into_iter()
+            .collect();
+        assert_eq!(
+            env.get(ENV_MCP_DENY_HOSTS).map(String::as_str),
+            Some("blocked.example")
+        );
+
+        // Empty deny_hosts → no env var emitted at all (nothing to enforce).
+        let mut no_deny = base.clone();
+        no_deny.network = Some(McpServerNetwork {
+            mode: McpNetMode::BroadAudited,
+            allow_hosts: vec![],
+            deny_hosts: vec![],
+            authorization: None,
+        });
+        let env: HashMap<_, _> = proxy_env_for(&no_deny, Some(&handle)).into_iter().collect();
+        assert!(!env.contains_key(ENV_MCP_DENY_HOSTS));
     }
 
     /// `McpClient::connect` picks the HTTP variant when the entry has a `url`.

--- a/mur-agent-runtime/src/sandbox/reqwest_guard.rs
+++ b/mur-agent-runtime/src/sandbox/reqwest_guard.rs
@@ -1,36 +1,11 @@
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 
-/// Match a host against an allowlist pattern.
-///
-/// Canonical wildcard syntax is `*.example.com` (matches `api.example.com`
-/// and `example.com`).  For backward compatibility the legacy leading-dot
-/// form `.example.com` is also accepted and treated identically.
-///
-/// Both layers that perform host-allowlist checks (`HostGuard` DNS resolver
-/// and the B0 safety hook) must call this function so they share a single
-/// interpretation of wildcard patterns.
-pub fn host_matches_pattern(host: &str, pattern: &str) -> bool {
-    let host = host.to_ascii_lowercase();
-    let pattern = pattern.to_ascii_lowercase();
-    // Strip leading `*.` (canonical) or leading `.` (legacy) to get the suffix.
-    let suffix = if let Some(s) = pattern.strip_prefix("*.") {
-        s
-    } else if let Some(s) = pattern.strip_prefix('.') {
-        s
-    } else {
-        // Exact match only.
-        return host == pattern;
-    };
-    host == suffix || host.ends_with(&format!(".{suffix}"))
-}
-
-/// True if `host` matches any allowlist pattern. An empty allowlist denies all
-/// (fail-closed). Reuses the same matcher the agent's reqwest guard uses, so
-/// per-MCP-server egress allowlisting behaves identically to agent-level hosts.
-pub fn host_allowed(host: &str, allow: &[String]) -> bool {
-    allow.iter().any(|p| host_matches_pattern(host, p))
-}
+/// Host-pattern matcher, hoisted to `mur-common` as the single source of
+/// truth shared by the egress proxy (this module) and the research
+/// gateway's SSRF guard. Re-exported here so existing callers
+/// (`egress_proxy.rs` et al.) are unchanged.
+pub use mur_common::net::{host_allowed, host_matches_pattern};
 
 /// True for IP ranges an outbound request must never reach: the link-local /
 /// cloud-metadata range (IPv4 169.254.0.0/16 — includes 169.254.169.254 — and

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -343,6 +343,16 @@ pub enum McpNetMode {
     Off,
 }
 
+/// Env var name a sandboxed MCP child reads to self-enforce the operator's
+/// `deny_hosts` overlay on connections the egress proxy cannot observe (e.g.
+/// `mur-research-gateway`'s tier-2/3 browser subprocesses — the proxy only
+/// sees tier-1 `reqwest` traffic). `mur-agent-runtime`'s `proxy_env_for` sets
+/// this on the child's env alongside the proxy vars; a cooperating child
+/// (currently `mur-research-gateway`, via `config::load`) reads it to source
+/// its own deny list. Single definition shared by both crates (CLAUDE.md
+/// rule 1: no duplicated literal).
+pub const ENV_MCP_DENY_HOSTS: &str = "MUR_RESEARCH_DENY_HOSTS";
+
 /// Per-MCP-server outbound egress policy.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct McpServerNetwork {

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -1398,6 +1398,20 @@ impl AgentProfile {
             .expect("minimal profile fixture")
     }
 
+    /// Load an agent's profile from `<mur_home>/agents/<name>/profile.yaml`.
+    ///
+    /// Canonical read-path counterpart to the atomic-write path used by
+    /// `mur agent create`/`mur agent mcp add` (`write_atomic` in
+    /// `mur-core::cmd::agent`) — callers that already have `mur_home` in
+    /// hand (e.g. provisioning flows, tests) can load a profile without
+    /// going through the `MUR_HOME`-env-var-based `resolve_mur_home`.
+    pub fn load(mur_home: &std::path::Path, name: &str) -> anyhow::Result<Self> {
+        let path = mur_home.join("agents").join(name).join("profile.yaml");
+        let yaml = std::fs::read_to_string(&path)
+            .map_err(|e| anyhow::anyhow!("read {}: {e}", path.display()))?;
+        serde_yaml_ng::from_str(&yaml).map_err(|e| anyhow::anyhow!("parse {}: {e}", path.display()))
+    }
+
     /// The imported add-on group a skill/mcp/command name belongs to.
     pub fn group_of(&self, name: &str) -> Option<&AddonRef> {
         self.addons.iter().find(|g| {

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -39,6 +39,7 @@ pub mod model;
 pub mod model_resolve;
 pub mod multimodal;
 pub mod muragent;
+pub mod net;
 pub mod panel;
 pub mod parallel;
 pub mod parameterize;

--- a/mur-common/src/net.rs
+++ b/mur-common/src/net.rs
@@ -1,0 +1,72 @@
+//! Shared host-pattern matcher for outbound-network allow/deny checks.
+//!
+//! This is the single source of truth for host-pattern matching used by every
+//! layer that gates outbound requests: the agent runtime's egress proxy
+//! (`mur-agent-runtime::sandbox::reqwest_guard`) and the research gateway's
+//! SSRF guard (`mur-research-gateway::net_guard`). A security boundary must
+//! not have two copies of this logic that can silently drift apart.
+//!
+//! IP-range predicates (loopback/private/link-local/unspecified) are
+//! deliberately NOT shared here — different callers apply different IP
+//! policies (e.g. the runtime allows loopback/RFC1918 for local LLMs while
+//! the research gateway forbids them). Only the host-pattern string matcher
+//! is common.
+
+/// Match a host against an allowlist pattern.
+///
+/// Canonical wildcard syntax is `*.example.com` (matches `api.example.com`
+/// and `example.com`).  For backward compatibility the legacy leading-dot
+/// form `.example.com` is also accepted and treated identically.
+///
+/// Both layers that perform host-allowlist checks (`HostGuard` DNS resolver
+/// and the B0 safety hook) must call this function so they share a single
+/// interpretation of wildcard patterns.
+pub fn host_matches_pattern(host: &str, pattern: &str) -> bool {
+    let host = host.to_ascii_lowercase();
+    let pattern = pattern.to_ascii_lowercase();
+    // Strip leading `*.` (canonical) or leading `.` (legacy) to get the suffix.
+    let suffix = if let Some(s) = pattern.strip_prefix("*.") {
+        s
+    } else if let Some(s) = pattern.strip_prefix('.') {
+        s
+    } else {
+        // Exact match only.
+        return host == pattern;
+    };
+    host == suffix || host.ends_with(&format!(".{suffix}"))
+}
+
+/// True if `host` matches any allowlist pattern. An empty allowlist denies all
+/// (fail-closed). Reuses the same matcher the agent's reqwest guard uses, so
+/// per-MCP-server egress allowlisting behaves identically to agent-level hosts.
+pub fn host_allowed(host: &str, allow: &[String]) -> bool {
+    allow.iter().any(|p| host_matches_pattern(host, p))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_matches_pattern_wildcard_legacy_and_exact() {
+        assert!(host_matches_pattern("api.example.com", "*.example.com"));
+        assert!(host_matches_pattern("example.com", "*.example.com"));
+        assert!(host_matches_pattern("api.example.com", ".example.com"));
+        assert!(host_matches_pattern("example.com", ".example.com"));
+        assert!(host_matches_pattern("example.com", "example.com"));
+        assert!(!host_matches_pattern("evil.com", "example.com"));
+        assert!(!host_matches_pattern(
+            "example.com.evil.com",
+            "*.example.com"
+        ));
+    }
+
+    #[test]
+    fn host_allowed_is_fail_closed_and_pattern_aware() {
+        let allow = vec!["example.com".to_string(), "*.api.example.com".to_string()];
+        assert!(host_allowed("example.com", &allow));
+        assert!(host_allowed("v1.api.example.com", &allow));
+        assert!(!host_allowed("evil.com", &allow));
+        assert!(!host_allowed("example.com", &[]), "empty allowlist denies");
+    }
+}

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -653,6 +653,12 @@ pub enum DeepResearchAction {
         /// (default: DEFAULT_WORKER_PREFIX)
         #[arg(long)]
         prefix: Option<String>,
+        /// `models.yaml` registry alias each worker's `model_ref` is bound
+        /// to (default: DEFAULT_WORKER_MODEL, currently `claude_haiku`).
+        /// Without this, workers fall to the `ollama/llama3.2:3b` StubEcho
+        /// default with no real reasoning.
+        #[arg(long)]
+        model: Option<String>,
         /// After provisioning, also grant each worker's `research-gateway`
         /// server `BroadAudited` egress (allow-ALL-except-deny-list, routed
         /// through the audited proxy). A separate, explicit-consent step —

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -641,6 +641,22 @@ pub enum CommanderAction {
 }
 
 #[derive(Subcommand)]
+pub enum DeepResearchAction {
+    /// Create restricted worker agents that each mount the
+    /// `research-gateway` MCP server (no egress of their own — the
+    /// per-server egress grant is a separate consent step).
+    Provision {
+        /// Number of worker agents to create (default: DEFAULT_WORKER_COUNT)
+        #[arg(long)]
+        count: Option<usize>,
+        /// Agent name prefix; workers are named `<prefix>_1..N`
+        /// (default: DEFAULT_WORKER_PREFIX)
+        #[arg(long)]
+        prefix: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum TeamAction {
     /// List your teams (or patterns in a specific team)
     List {

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -653,6 +653,21 @@ pub enum DeepResearchAction {
         /// (default: DEFAULT_WORKER_PREFIX)
         #[arg(long)]
         prefix: Option<String>,
+        /// After provisioning, also grant each worker's `research-gateway`
+        /// server `BroadAudited` egress (allow-ALL-except-deny-list, routed
+        /// through the audited proxy). A separate, explicit-consent step —
+        /// omit this flag and workers keep NO outbound egress. Prompts
+        /// `[y/N]` per worker unless `--yes`.
+        #[arg(long)]
+        grant_egress: bool,
+        /// Denied host (repeatable) for the `--grant-egress` grant; ignored
+        /// otherwise.
+        #[arg(long = "deny-host")]
+        deny_hosts: Vec<String>,
+        /// Skip the `--grant-egress` consent prompt. Use for scripted /
+        /// non-interactive grants.
+        #[arg(long)]
+        yes: bool,
     },
 }
 

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -669,6 +669,25 @@ pub enum DeepResearchAction {
         #[arg(long)]
         yes: bool,
     },
+    /// Run a deep-research fleet's guarded loop (thin wrapper over
+    /// `mur fleet run --loop` — see `cmd/fleet/loop_run.rs`). This drives
+    /// only the loop's guard rails (iteration cap / deadline / budget /
+    /// kill-switch / marker convergence); it does NOT reimplement or
+    /// bypass anything the plain fleet loop already does.
+    Run {
+        /// Fleet name (as created by `mur fleet create`, typically after
+        /// `mur deep-research provision`)
+        name: String,
+        /// Max iterations (overrides fleet.yaml `loop.max_iterations`)
+        #[arg(long)]
+        max_iterations: Option<u32>,
+        /// Wall-clock deadline, e.g. 30s/5m/2h (overrides fleet.yaml)
+        #[arg(long)]
+        deadline: Option<String>,
+        /// Budget ceiling in USD (overrides fleet.yaml `loop.budget_usd`)
+        #[arg(long)]
+        budget_usd: Option<f64>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/mur-core/src/cli/mod.rs
+++ b/mur-core/src/cli/mod.rs
@@ -422,6 +422,11 @@ see `mur skill <command> --help`.")]
         #[command(subcommand)]
         action: CommanderAction,
     },
+    /// MUR-native deep research: gateway-mounted worker agent provisioning
+    DeepResearch {
+        #[command(subcommand)]
+        action: DeepResearchAction,
+    },
 }
 
 #[cfg(test)]

--- a/mur-core/src/cmd/deep_research/mod.rs
+++ b/mur-core/src/cmd/deep_research/mod.rs
@@ -1,0 +1,9 @@
+//! `mur deep-research` command module.
+//!
+//! Provisions restricted worker agents (Task 7 of the MUR-native
+//! deep-research plan) that each mount the `research-gateway` MCP server
+//! (`mur-research-gateway`, Tasks 1-6). Workers hold no outbound egress of
+//! their own — only the gateway process does — and the per-server MCP
+//! egress grant is a separate, explicit-consent step (Task 8).
+
+pub mod provision;

--- a/mur-core/src/cmd/deep_research/mod.rs
+++ b/mur-core/src/cmd/deep_research/mod.rs
@@ -7,3 +7,4 @@
 //! egress grant is a separate, explicit-consent step (Task 8).
 
 pub mod provision;
+pub mod run;

--- a/mur-core/src/cmd/deep_research/provision.rs
+++ b/mur-core/src/cmd/deep_research/provision.rs
@@ -34,14 +34,38 @@ const GATEWAY_MCP_NAME: &str = "research-gateway";
 /// `build.sh`, shipped by Tasks 1-6).
 const GATEWAY_MCP_COMMAND: &str = "mur-research-gateway";
 
+/// Upper bound on `--count`: provisioning creates one agent dir + Ed25519
+/// identity + runtime symlink per worker, so an unbounded count is a foot-gun.
+/// Named to avoid an inline literal (mandatory rule 1).
+const MAX_WORKER_COUNT: usize = 64;
+
 /// Create `count` restricted worker agents named `<name_prefix>_1..N`, each
 /// mounting the `research-gateway` MCP server with no egress grant of its
 /// own. Returns the created agent names, in order.
+///
+/// # Concurrency
+///
+/// This function sets the **process-global** `MUR_HOME` env var for its whole
+/// duration (and does NOT restore it), because the reused `cmd_create` /
+/// `cmd_mcp_add` helpers re-derive their home directory from that env var
+/// rather than taking a parameter. It is therefore **CLI-only and NOT
+/// concurrency-safe**: it must not run while another thread/task reads or
+/// writes `MUR_HOME`. Safe for the single-threaded CLI dispatch path today.
+// TODO(follow-up): parameterize cmd_create/cmd_mcp_add with mur_home instead of
+// mutating the global env, before any daemon/async caller uses provision().
 pub fn provision(mur_home: &Path, name_prefix: &str, count: usize) -> Result<Vec<String>> {
+    if count == 0 {
+        anyhow::bail!("count must be at least 1");
+    }
+    if count > MAX_WORKER_COUNT {
+        anyhow::bail!("count {count} exceeds the maximum of {MAX_WORKER_COUNT} workers");
+    }
+
     // `cmd_create` and `cmd_mcp_add` resolve their home directory via the
     // `MUR_HOME` env var (`resolve_mur_home` / `load_profile_for_edit`), so
     // provisioning against an explicit `mur_home` means pointing that env
     // var at it first — the same pattern `cmd::agent::mcp::tests` uses.
+    // See the `# Concurrency` note above: this permanently mutates process env.
     unsafe {
         std::env::set_var("MUR_HOME", mur_home);
     }
@@ -127,5 +151,19 @@ mod tests {
             mur_common::agent::NetworkOutboundMode::Restricted
         );
         assert!(p.entitlements.network.outbound.allow_hosts.is_empty());
+    }
+
+    #[test]
+    fn provision_rejects_zero_and_over_max_count() {
+        // Count validation happens before any env mutation, so no lock/tmp
+        // plumbing is needed — but take the lock anyway for hygiene.
+        let _lock = MUR_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+
+        let zero = provision(tmp.path(), "dr_worker", 0);
+        assert!(zero.is_err(), "count==0 must error");
+
+        let too_many = provision(tmp.path(), "dr_worker", MAX_WORKER_COUNT + 1);
+        assert!(too_many.is_err(), "count > MAX_WORKER_COUNT must error");
     }
 }

--- a/mur-core/src/cmd/deep_research/provision.rs
+++ b/mur-core/src/cmd/deep_research/provision.rs
@@ -226,6 +226,10 @@ mod tests {
         reg.save_to(&mur_home.join("models.yaml")).unwrap();
     }
 
+    // Unix-only: provision() -> cmd_create() writes a per-agent runtime symlink
+    // (busybox-style) which requires privileges Windows CI lacks ("os error 2").
+    // The whole agent runtime is Unix-socket based, so the feature is Unix-only.
+    #[cfg(unix)]
     #[test]
     fn provision_creates_restricted_workers_with_gateway() {
         let _lock = MUR_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -286,6 +290,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)] // provision() writes a Unix runtime symlink; not runnable on Windows CI
     #[test]
     fn provision_threads_explicit_model_alias() {
         let _lock = MUR_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -301,6 +306,7 @@ mod tests {
         assert_eq!(p.model_ref, Some("claude_sonnet".to_string()));
     }
 
+    #[cfg(unix)] // provision()/grant_egress() write Unix runtime artifacts; not runnable on Windows CI
     #[test]
     fn grant_sets_broad_audited_with_authorization() {
         let _lock = MUR_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());

--- a/mur-core/src/cmd/deep_research/provision.rs
+++ b/mur-core/src/cmd/deep_research/provision.rs
@@ -19,6 +19,7 @@ use anyhow::Result;
 
 use crate::cmd::agent::lifecycle::cmd_create;
 use crate::cmd::agent::mcp::{McpAddPin, cmd_mcp_add, cmd_mcp_set_network};
+use crate::cmd::agent::{load_profile_for_edit, save_profile};
 
 /// Default number of workers `mur deep-research provision` creates when
 /// `--count` is omitted.
@@ -26,6 +27,21 @@ pub const DEFAULT_WORKER_COUNT: usize = 3;
 
 /// Default agent-name prefix when `--prefix` is omitted.
 pub const DEFAULT_WORKER_PREFIX: &str = "dr_worker";
+
+/// Default `models.yaml` alias each worker's `model_ref` is bound to when
+/// `--model` is omitted from `mur deep-research provision`: cheap enough for
+/// disposable worker fan-out, still capable of real reasoning (never the
+/// `ollama/llama3.2:3b` StubEcho fallback `cmd_create` uses with no model
+/// passed at all).
+pub const DEFAULT_WORKER_MODEL: &str = "claude_haiku";
+
+/// Loopback hosts every worker's agent-level `entitlements.network.outbound`
+/// is seeded with at provision time, so the worker can reach its own LLM
+/// endpoint (local cc-proxy) to reason. This is NOT web-research egress —
+/// that remains exclusively the gateway MCP's separate, explicit-consent
+/// `--grant-egress` step (`grant_egress` below). `mode` stays `restricted`;
+/// this only widens the allow-list off empty.
+const WORKER_LLM_ALLOW_HOSTS: [&str; 2] = ["localhost", "127.0.0.1"];
 
 /// Name of the gateway MCP server entry mounted on every worker.
 const GATEWAY_MCP_NAME: &str = "research-gateway";
@@ -53,7 +69,12 @@ const MAX_WORKER_COUNT: usize = 64;
 /// writes `MUR_HOME`. Safe for the single-threaded CLI dispatch path today.
 // TODO(follow-up): parameterize cmd_create/cmd_mcp_add with mur_home instead of
 // mutating the global env, before any daemon/async caller uses provision().
-pub fn provision(mur_home: &Path, name_prefix: &str, count: usize) -> Result<Vec<String>> {
+pub fn provision(
+    mur_home: &Path,
+    name_prefix: &str,
+    count: usize,
+    model: &str,
+) -> Result<Vec<String>> {
     if count == 0 {
         anyhow::bail!("count must be at least 1");
     }
@@ -73,7 +94,10 @@ pub fn provision(mur_home: &Path, name_prefix: &str, count: usize) -> Result<Vec
     let mut names = Vec::with_capacity(count);
     for i in 1..=count {
         let name = format!("{name_prefix}_{i}");
-        cmd_create(&name, true, None, None, None)?;
+        // Fix 1: bind model_ref to `model` (default DEFAULT_WORKER_MODEL) so
+        // the worker resolves real credentials via the models.yaml registry
+        // instead of falling to the ollama/llama3.2:3b StubEcho default.
+        cmd_create(&name, true, None, Some(model.to_string()), None)?;
         cmd_mcp_add(
             &name,
             GATEWAY_MCP_NAME,
@@ -84,6 +108,20 @@ pub fn provision(mur_home: &Path, name_prefix: &str, count: usize) -> Result<Vec
                 ..Default::default()
             },
         )?;
+
+        // Fix 2: seed the agent-level outbound allow-list with loopback so
+        // the worker can reach its own LLM endpoint (local cc-proxy) to
+        // reason. Stays `restricted` — this only widens the allow-list off
+        // empty, never touches the gateway MCP entry's own `network` block
+        // (that stays `None`/Inherit until the separate `--grant-egress`
+        // step in `grant_egress` below).
+        let (path, mut profile) = load_profile_for_edit(&name)?;
+        profile.entitlements.network.outbound.allow_hosts = WORKER_LLM_ALLOW_HOSTS
+            .iter()
+            .map(|h| h.to_string())
+            .collect();
+        save_profile(&path, &mut profile)?;
+
         names.push(name);
     }
     Ok(names)
@@ -132,13 +170,15 @@ pub fn cmd_provision(
     mur_home: &Path,
     name_prefix: Option<&str>,
     count: Option<usize>,
+    model: Option<&str>,
     grant_egress_flag: bool,
     deny_hosts: &[String],
     yes: bool,
 ) -> Result<()> {
     let prefix = name_prefix.unwrap_or(DEFAULT_WORKER_PREFIX);
     let count = count.unwrap_or(DEFAULT_WORKER_COUNT);
-    let names = provision(mur_home, prefix, count)?;
+    let model = model.unwrap_or(DEFAULT_WORKER_MODEL);
+    let names = provision(mur_home, prefix, count, model)?;
     println!("Provisioned {} deep-research worker agent(s):", names.len());
     for name in &names {
         println!("  {name}");
@@ -154,12 +194,37 @@ pub fn cmd_provision(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
     use std::sync::Mutex;
 
     /// Serialize tests that mutate the process-wide `MUR_HOME` /
     /// `MUR_AGENT_BIN_DIR` env vars (established pattern, see
     /// `cmd::agent::mcp::tests::MUR_HOME_LOCK`).
     static MUR_HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Seed `<mur_home>/models.yaml` with a registry alias, mirroring
+    /// `cmd::agent::lifecycle::tests::seed_models_yaml` — `cmd_create`
+    /// (PR #661) only binds `model_ref` when the bare `--model` value is an
+    /// exact registry key.
+    fn seed_models_yaml(mur_home: &Path, key: &str, provider: &str, model: &str) {
+        use mur_common::model::{ModelEntry, ModelRegistry};
+
+        let mut models = BTreeMap::new();
+        models.insert(
+            key.to_string(),
+            ModelEntry {
+                provider: provider.to_string(),
+                model: model.to_string(),
+                ..Default::default()
+            },
+        );
+        let reg = ModelRegistry {
+            schema_version: 1,
+            models,
+            roles: BTreeMap::new(),
+        };
+        reg.save_to(&mur_home.join("models.yaml")).unwrap();
+    }
 
     #[test]
     fn provision_creates_restricted_workers_with_gateway() {
@@ -171,8 +236,14 @@ mod tests {
         unsafe {
             std::env::set_var("MUR_AGENT_BIN_DIR", &bin_dir);
         }
+        seed_models_yaml(
+            tmp.path(),
+            DEFAULT_WORKER_MODEL,
+            "anthropic",
+            "claude-haiku-4-5",
+        );
 
-        let names = provision(tmp.path(), "dr_worker", 3).unwrap();
+        let names = provision(tmp.path(), "dr_worker", 3, DEFAULT_WORKER_MODEL).unwrap();
         assert_eq!(names.len(), 3);
         assert_eq!(names, vec!["dr_worker_1", "dr_worker_2", "dr_worker_3"]);
 
@@ -189,12 +260,45 @@ mod tests {
         assert_eq!(gw.command, "mur-research-gateway");
         assert!(gw.args.is_empty());
 
-        // Worker holds no egress of its own either.
+        // Fix 1: model_ref is bound to the (default) worker model alias, not
+        // left unset (which would silently fall to StubEcho).
+        assert_eq!(p.model_ref, Some(DEFAULT_WORKER_MODEL.to_string()));
+
+        // Fix 2: worker keeps `restricted` mode but the allow-list now
+        // includes loopback so it can reach its own LLM endpoint.
         assert_eq!(
             p.entitlements.network.outbound.mode,
             mur_common::agent::NetworkOutboundMode::Restricted
         );
-        assert!(p.entitlements.network.outbound.allow_hosts.is_empty());
+        assert!(
+            p.entitlements
+                .network
+                .outbound
+                .allow_hosts
+                .contains(&"127.0.0.1".to_string())
+        );
+        assert!(
+            p.entitlements
+                .network
+                .outbound
+                .allow_hosts
+                .contains(&"localhost".to_string())
+        );
+    }
+
+    #[test]
+    fn provision_threads_explicit_model_alias() {
+        let _lock = MUR_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let bin_dir = tmp.path().join("bin");
+        unsafe {
+            std::env::set_var("MUR_AGENT_BIN_DIR", &bin_dir);
+        }
+        seed_models_yaml(tmp.path(), "claude_sonnet", "anthropic", "claude-sonnet-5");
+
+        let names = provision(tmp.path(), "dr_worker", 1, "claude_sonnet").unwrap();
+        let p = mur_common::agent::AgentProfile::load(tmp.path(), &names[0]).unwrap();
+        assert_eq!(p.model_ref, Some("claude_sonnet".to_string()));
     }
 
     #[test]
@@ -205,8 +309,14 @@ mod tests {
         unsafe {
             std::env::set_var("MUR_AGENT_BIN_DIR", &bin_dir);
         }
+        seed_models_yaml(
+            tmp.path(),
+            DEFAULT_WORKER_MODEL,
+            "anthropic",
+            "claude-haiku-4-5",
+        );
 
-        let names = provision(tmp.path(), "dr_worker", 1).unwrap();
+        let names = provision(tmp.path(), "dr_worker", 1, DEFAULT_WORKER_MODEL).unwrap();
         grant_egress(tmp.path(), &names[0], &["evil.example".into()], true).unwrap();
         let p = mur_common::agent::AgentProfile::load(tmp.path(), &names[0]).unwrap();
         let gw = p
@@ -230,10 +340,15 @@ mod tests {
         let _lock = MUR_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
 
-        let zero = provision(tmp.path(), "dr_worker", 0);
+        let zero = provision(tmp.path(), "dr_worker", 0, DEFAULT_WORKER_MODEL);
         assert!(zero.is_err(), "count==0 must error");
 
-        let too_many = provision(tmp.path(), "dr_worker", MAX_WORKER_COUNT + 1);
+        let too_many = provision(
+            tmp.path(),
+            "dr_worker",
+            MAX_WORKER_COUNT + 1,
+            DEFAULT_WORKER_MODEL,
+        );
         assert!(too_many.is_err(), "count > MAX_WORKER_COUNT must error");
     }
 }

--- a/mur-core/src/cmd/deep_research/provision.rs
+++ b/mur-core/src/cmd/deep_research/provision.rs
@@ -1,0 +1,131 @@
+//! `mur deep-research provision` — creates restricted worker agents that
+//! each mount the `research-gateway` MCP server.
+//!
+//! Reuses the exact profile-construction path `mur agent create` uses
+//! (`cmd::agent::lifecycle::cmd_create`, whose default entitlements already
+//! set `network.outbound = restricted` with an empty allow-list) and the
+//! exact MCP-attach path `mur agent mcp add` uses
+//! (`cmd::agent::mcp::cmd_mcp_add`, which persists through the existing
+//! load/save-atomic helpers) — no hand-rolled profile YAML here.
+//!
+//! Egress for the gateway MCP entry itself is left `None` (Inherit): the
+//! per-server `BroadAudited` grant that actually lets the gateway reach the
+//! network is a separate, explicit-consent step (Task 8). Provisioning
+//! alone must never grant egress.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::cmd::agent::lifecycle::cmd_create;
+use crate::cmd::agent::mcp::{McpAddPin, cmd_mcp_add};
+
+/// Default number of workers `mur deep-research provision` creates when
+/// `--count` is omitted.
+pub const DEFAULT_WORKER_COUNT: usize = 3;
+
+/// Default agent-name prefix when `--prefix` is omitted.
+pub const DEFAULT_WORKER_PREFIX: &str = "dr_worker";
+
+/// Name of the gateway MCP server entry mounted on every worker.
+const GATEWAY_MCP_NAME: &str = "research-gateway";
+
+/// Binary invoked for the gateway MCP server (installed on PATH by
+/// `build.sh`, shipped by Tasks 1-6).
+const GATEWAY_MCP_COMMAND: &str = "mur-research-gateway";
+
+/// Create `count` restricted worker agents named `<name_prefix>_1..N`, each
+/// mounting the `research-gateway` MCP server with no egress grant of its
+/// own. Returns the created agent names, in order.
+pub fn provision(mur_home: &Path, name_prefix: &str, count: usize) -> Result<Vec<String>> {
+    // `cmd_create` and `cmd_mcp_add` resolve their home directory via the
+    // `MUR_HOME` env var (`resolve_mur_home` / `load_profile_for_edit`), so
+    // provisioning against an explicit `mur_home` means pointing that env
+    // var at it first — the same pattern `cmd::agent::mcp::tests` uses.
+    unsafe {
+        std::env::set_var("MUR_HOME", mur_home);
+    }
+
+    let mut names = Vec::with_capacity(count);
+    for i in 1..=count {
+        let name = format!("{name_prefix}_{i}");
+        cmd_create(&name, true, None, None, None)?;
+        cmd_mcp_add(
+            &name,
+            GATEWAY_MCP_NAME,
+            GATEWAY_MCP_COMMAND,
+            &[],
+            McpAddPin {
+                force: true,
+                ..Default::default()
+            },
+        )?;
+        names.push(name);
+    }
+    Ok(names)
+}
+
+/// CLI-facing wrapper for `mur deep-research provision`: applies
+/// [`DEFAULT_WORKER_PREFIX`]/[`DEFAULT_WORKER_COUNT`] when the flags are
+/// omitted, provisions the workers, and prints their names.
+pub fn cmd_provision(
+    mur_home: &Path,
+    name_prefix: Option<&str>,
+    count: Option<usize>,
+) -> Result<()> {
+    let prefix = name_prefix.unwrap_or(DEFAULT_WORKER_PREFIX);
+    let count = count.unwrap_or(DEFAULT_WORKER_COUNT);
+    let names = provision(mur_home, prefix, count)?;
+    println!("Provisioned {} deep-research worker agent(s):", names.len());
+    for name in &names {
+        println!("  {name}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serialize tests that mutate the process-wide `MUR_HOME` /
+    /// `MUR_AGENT_BIN_DIR` env vars (established pattern, see
+    /// `cmd::agent::mcp::tests::MUR_HOME_LOCK`).
+    static MUR_HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn provision_creates_restricted_workers_with_gateway() {
+        let _lock = MUR_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        // Redirect the runtime-symlink dir cmd_create() also writes into,
+        // so the test never touches the developer's real ~/.local/bin.
+        let bin_dir = tmp.path().join("bin");
+        unsafe {
+            std::env::set_var("MUR_AGENT_BIN_DIR", &bin_dir);
+        }
+
+        let names = provision(tmp.path(), "dr_worker", 3).unwrap();
+        assert_eq!(names.len(), 3);
+        assert_eq!(names, vec!["dr_worker_1", "dr_worker_2", "dr_worker_3"]);
+
+        let p = mur_common::agent::AgentProfile::load(tmp.path(), &names[0]).unwrap();
+        assert!(p.mcp_servers.iter().any(|s| s.name == "research-gateway"));
+        // Egress NOT granted here — must be Inherit/restricted until the
+        // consent step (Task 8).
+        let gw = p
+            .mcp_servers
+            .iter()
+            .find(|s| s.name == "research-gateway")
+            .unwrap();
+        assert!(gw.network.is_none());
+        assert_eq!(gw.command, "mur-research-gateway");
+        assert!(gw.args.is_empty());
+
+        // Worker holds no egress of its own either.
+        assert_eq!(
+            p.entitlements.network.outbound.mode,
+            mur_common::agent::NetworkOutboundMode::Restricted
+        );
+        assert!(p.entitlements.network.outbound.allow_hosts.is_empty());
+    }
+}

--- a/mur-core/src/cmd/deep_research/provision.rs
+++ b/mur-core/src/cmd/deep_research/provision.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::cmd::agent::lifecycle::cmd_create;
-use crate::cmd::agent::mcp::{McpAddPin, cmd_mcp_add};
+use crate::cmd::agent::mcp::{McpAddPin, cmd_mcp_add, cmd_mcp_set_network};
 
 /// Default number of workers `mur deep-research provision` creates when
 /// `--count` is omitted.
@@ -89,13 +89,52 @@ pub fn provision(mur_home: &Path, name_prefix: &str, count: usize) -> Result<Vec
     Ok(names)
 }
 
+/// Grant `worker`'s `research-gateway` MCP server `BroadAudited` egress —
+/// the ONE place a deep-research worker actually gains outbound network
+/// access. This is a separate, explicit-consent step: it is never called
+/// from [`provision`] itself and must never be called from fleet creation.
+///
+/// Reuses the shipped consent path verbatim
+/// (`cmd::agent::mcp::cmd_mcp_set_network`, PR #661) rather than
+/// re-implementing BroadAudited-setting or authorization-recording: that
+/// function already prompts for `[y/N]` consent on stdin unless `yes` is
+/// set, records the `EgressAuthorization { authorized_by, authorized_at_ms }`,
+/// emits the `mur.egress.broad_audited.enabled` telemetry event, and clears
+/// any prior authorization when the mode changes away from `BroadAudited`.
+///
+/// Sets the process-global `MUR_HOME` env var for its duration, same
+/// caveat as [`provision`]'s `# Concurrency` note (`cmd_mcp_set_network`
+/// re-derives its home directory from that env var).
+pub fn grant_egress(mur_home: &Path, worker: &str, deny_hosts: &[String], yes: bool) -> Result<()> {
+    unsafe {
+        std::env::set_var("MUR_HOME", mur_home);
+    }
+    cmd_mcp_set_network(
+        worker,
+        GATEWAY_MCP_NAME,
+        vec![],
+        deny_hosts.to_vec(),
+        false,
+        true,
+        yes,
+    )
+}
+
 /// CLI-facing wrapper for `mur deep-research provision`: applies
 /// [`DEFAULT_WORKER_PREFIX`]/[`DEFAULT_WORKER_COUNT`] when the flags are
-/// omitted, provisions the workers, and prints their names.
+/// omitted, provisions the workers, prints their names, and — ONLY when
+/// `grant_egress_flag` is set via the explicit `--grant-egress` CLI flag —
+/// grants each worker's gateway `BroadAudited` egress via [`grant_egress`]
+/// (consent-prompted per worker unless `yes`). Plain `provision` (the
+/// default) never grants egress.
+#[allow(clippy::too_many_arguments)]
 pub fn cmd_provision(
     mur_home: &Path,
     name_prefix: Option<&str>,
     count: Option<usize>,
+    grant_egress_flag: bool,
+    deny_hosts: &[String],
+    yes: bool,
 ) -> Result<()> {
     let prefix = name_prefix.unwrap_or(DEFAULT_WORKER_PREFIX);
     let count = count.unwrap_or(DEFAULT_WORKER_COUNT);
@@ -103,6 +142,11 @@ pub fn cmd_provision(
     println!("Provisioned {} deep-research worker agent(s):", names.len());
     for name in &names {
         println!("  {name}");
+    }
+    if grant_egress_flag {
+        for name in &names {
+            grant_egress(mur_home, name, deny_hosts, yes)?;
+        }
     }
     Ok(())
 }
@@ -151,6 +195,32 @@ mod tests {
             mur_common::agent::NetworkOutboundMode::Restricted
         );
         assert!(p.entitlements.network.outbound.allow_hosts.is_empty());
+    }
+
+    #[test]
+    fn grant_sets_broad_audited_with_authorization() {
+        let _lock = MUR_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let bin_dir = tmp.path().join("bin");
+        unsafe {
+            std::env::set_var("MUR_AGENT_BIN_DIR", &bin_dir);
+        }
+
+        let names = provision(tmp.path(), "dr_worker", 1).unwrap();
+        grant_egress(tmp.path(), &names[0], &["evil.example".into()], true).unwrap();
+        let p = mur_common::agent::AgentProfile::load(tmp.path(), &names[0]).unwrap();
+        let gw = p
+            .mcp_servers
+            .iter()
+            .find(|s| s.name == "research-gateway")
+            .unwrap();
+        let net = gw.network.as_ref().unwrap();
+        assert!(matches!(
+            net.mode,
+            mur_common::agent::McpNetMode::BroadAudited
+        ));
+        assert!(net.authorization.is_some());
+        assert!(net.deny_hosts.contains(&"evil.example".to_string()));
     }
 
     #[test]

--- a/mur-core/src/cmd/deep_research/run.rs
+++ b/mur-core/src/cmd/deep_research/run.rs
@@ -1,0 +1,131 @@
+//! `mur deep-research run <fleet>` — thin wrapper over the EXISTING guarded
+//! fleet loop (`cmd/fleet/loop_run.rs`, the same entry point
+//! `mur fleet run --loop` uses). Deliberately does not reimplement any loop
+//! logic: it resolves the named fleet and calls
+//! [`crate::cmd::fleet::loop_run::cmd_fleet_run_loop`] with the caller's
+//! guard overrides.
+//!
+//! ## What this proves vs. what it does not (Task 10 re-scope)
+//!
+//! The guard rails (iteration cap, deadline, budget ceiling, kill-switch,
+//! commander governance) run BEFORE any delegation and are fully
+//! deterministic — see the `tests` module below, which drives this wrapper
+//! through a commander-kill short-circuit exactly as
+//! `cmd/fleet/loop_run.rs`'s own `commander_kill_halts_loop_and_local_start_cannot_clear_it`
+//! test does, proving `cmd_deep_research_run` correctly reaches
+//! `run_guarded` and that the guard stops the loop before any work happens.
+//!
+//! What this does NOT and CANNOT prove without live infrastructure: the
+//! full decompose → research → verify → synthesize → marker-convergence
+//! loop. `run_guarded`'s per-iteration delegation
+//! (`cmd/fleet/loop_run.rs:execute_dag`) dials **live agent runtime
+//! sockets** via `crate::a2a_dial::dial_message_streaming`; a worker
+//! actually researching (calling the stub/real gateway, having an LLM
+//! decide to emit the `RESEARCH_COMPLETE` marker) requires a RUNNING
+//! `mur-agent-runtime` process with an LLM backend attached. That
+//! live-agent convergence run — workers hitting `stub_gateway`, an LLM
+//! synthesizing a cited report, the marker landing on the channel — is
+//! Task 11's operator E2E, not something this automated test suite can
+//! exercise headlessly.
+
+use std::path::Path;
+
+use anyhow::Result;
+
+/// Resolve `name` as a fleet and run its guarded loop. Identical semantics
+/// to `mur fleet run <name> --loop`; see
+/// [`crate::cmd::fleet::loop_run::cmd_fleet_run_loop`] for the guard
+/// precedence (CLI flag > fleet.yaml > default) and stop reasons.
+pub async fn cmd_deep_research_run(
+    mur_home: &Path,
+    name: &str,
+    max_iterations: Option<u32>,
+    deadline: Option<String>,
+    budget_usd: Option<f64>,
+) -> Result<()> {
+    crate::cmd::fleet::loop_run::cmd_fleet_run_loop(
+        mur_home,
+        name,
+        max_iterations,
+        deadline,
+        budget_usd,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::fleet::Fleet;
+
+    /// Mirrors `cmd/fleet/loop_run.rs`'s
+    /// `commander_kill_halts_loop_and_local_start_cannot_clear_it` setup,
+    /// but drives it through `mur deep-research run` (this module's
+    /// wrapper) rather than `run_guarded` directly — proving the new
+    /// command actually reaches the guarded loop and its kill-switch,
+    /// without requiring any live agent runtime or gateway process.
+    #[tokio::test]
+    async fn deep_research_run_stops_on_commander_kill_before_any_delegation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+
+        // commander identity + pinned key
+        let cdir = home.join("commander");
+        std::fs::create_dir_all(&cdir).unwrap();
+        mur_common::identity::AgentIdentity::generate()
+            .save(&cdir)
+            .unwrap();
+
+        // a deep-research-flavored fleet + channel (2 workers, structured
+        // marker convergence — never reached because the kill fires first).
+        let fleet = Fleet {
+            name: "dr-test".into(),
+            display_name: String::new(),
+            goal: "Research topic X and produce a cited report".into(),
+            router: None,
+            members: vec!["research_worker_1".into(), "research_worker_2".into()],
+            team_id: None,
+            channel_id: "fleet-dr-test".into(),
+            rules: vec![],
+            skills: vec![],
+            loop_cfg: Some(mur_common::fleet::FleetLoop {
+                trigger: "manual".into(),
+                max_iterations: 4,
+                budget_usd: 1.0,
+                deadline: String::new(),
+                done_when: "marker:RESEARCH_COMPLETE".into(),
+            }),
+            parallel: None,
+        };
+        crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();
+        mur_channel::ChannelService::open(home)
+            .unwrap()
+            .create_for_fleet(
+                "dr-test",
+                "mur",
+                &["research_worker_1".into(), "research_worker_2".into()],
+            )
+            .unwrap();
+
+        // plant a commander kill for this fleet
+        crate::cmd::commander::cmd_commander_directive(home, "dr-test", "kill", None, 1000)
+            .unwrap();
+
+        // `mur deep-research run dr-test` must stop before any delegation —
+        // if it reached execute_dag it would try to dial nonexistent live
+        // agent sockets and this test would hang or error, not return Ok.
+        cmd_deep_research_run(home, "dr-test", Some(1), None, None)
+            .await
+            .expect("guarded loop stop is a clean Ok(()), not an Err");
+
+        // an audit Governance entry was recorded — same evidence the
+        // loop_run.rs unit test checks, proving the real guard fired
+        // (not a no-op wrapper that swallowed the kill).
+        let audit =
+            std::fs::read_to_string(home.join("conversations").join("audit.jsonl")).unwrap();
+        assert!(
+            audit.contains("\"kind\":\"governance\"") && audit.contains("\"decision\":\"halted\""),
+            "expected a governance halt audit row, got: {audit}"
+        );
+    }
+}

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -25,6 +25,7 @@ pub mod compress;
 pub mod context;
 pub(crate) mod conversations_cmd;
 pub mod conversations_cost_report;
+pub mod deep_research;
 pub(crate) mod deploy;
 pub mod doctor;
 pub(crate) mod drafts;

--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -1168,6 +1168,18 @@ pub(crate) fn ensure_mur_skill(home: &std::path::Path, mur_root: &std::path::Pat
             "parallel-topology-guide",
             include_str!("../skills/parallel_topology_guide.yaml"),
         ),
+        (
+            "deep-research-router",
+            include_str!("../skills/deep_research_router.yaml"),
+        ),
+        (
+            "deep-research-worker",
+            include_str!("../skills/deep_research_worker.yaml"),
+        ),
+        (
+            "deep-research-verify",
+            include_str!("../skills/deep_research_verify.yaml"),
+        ),
     ];
 
     let mur_skills_dir = mur_root.join("skills");
@@ -1694,5 +1706,86 @@ mod builtin_skill_tests {
                 "{name}: body {body_lines} lines (budget 150)"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod deep_research_skill_tests {
+    /// Loader test (Task 9): the three deep-research fleet skills must parse
+    /// into `SkillManifest`, be scoped to the `deep-research` fleet (not the
+    /// default `User` scope), and carry a non-empty procedure — mirrors
+    /// `builtin_skill_tests::new_builtin_skills_parse_and_respect_disclosure_budgets`
+    /// above, adapted for `scope: fleet` + procedure-mode content instead of
+    /// the CLI-tool-hint disclosure budgets those skills use.
+    #[test]
+    fn deep_research_skills_parse_scope_fleet_with_nonempty_procedure() {
+        let cases: &[(&str, &str)] = &[
+            (
+                "deep-research-router",
+                include_str!("../skills/deep_research_router.yaml"),
+            ),
+            (
+                "deep-research-worker",
+                include_str!("../skills/deep_research_worker.yaml"),
+            ),
+            (
+                "deep-research-verify",
+                include_str!("../skills/deep_research_verify.yaml"),
+            ),
+        ];
+        use mur_common::skill::manifest::SkillScope;
+        for (name, yaml) in cases {
+            let m = mur_common::skill::parse_canonical(yaml)
+                .unwrap_or_else(|e| panic!("{name}: parse failed: {e}"));
+            assert_eq!(&m.name, name);
+            assert_eq!(m.scope, SkillScope::Fleet, "{name}: scope must be Fleet");
+            assert_eq!(
+                m.fleet.as_deref(),
+                Some("deep-research"),
+                "{name}: fleet selector must be deep-research"
+            );
+            let steps = &m
+                .content
+                .procedure
+                .as_ref()
+                .unwrap_or_else(|| panic!("{name}: content.procedure must be Some"))
+                .steps;
+            assert!(
+                !steps.is_empty(),
+                "{name}: procedure steps must be non-empty"
+            );
+            for step in steps {
+                assert!(
+                    !step.description.trim().is_empty(),
+                    "{name}: every step needs a non-empty description"
+                );
+            }
+        }
+
+        // The retired escalation-ladder skill must not be recreated under
+        // either its old aura-* name or a deep-research-* rename.
+        for (name, yaml) in cases {
+            assert!(
+                !yaml.to_lowercase().contains("aura-"),
+                "{name}: must not reference the retired aura-* skills"
+            );
+        }
+    }
+
+    #[test]
+    fn deep_research_router_emits_own_line_convergence_marker() {
+        let yaml = include_str!("../skills/deep_research_router.yaml");
+        let m = mur_common::skill::parse_canonical(yaml).unwrap();
+        let steps = m.content.procedure.unwrap().steps;
+        let body: String = steps
+            .iter()
+            .map(|s| s.description.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            body.lines()
+                .any(|l| l.trim() == "RESEARCH_COMPLETE" || l.trim() == "`RESEARCH_COMPLETE`"),
+            "router skill must instruct emitting RESEARCH_COMPLETE alone on its own line"
+        );
     }
 }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -448,6 +448,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 DeepResearchAction::Provision {
                     count,
                     prefix,
+                    model,
                     grant_egress,
                     deny_hosts,
                     yes,
@@ -455,6 +456,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                     &mur_home,
                     prefix.as_deref(),
                     count,
+                    model.as_deref(),
                     grant_egress,
                     &deny_hosts,
                     yes,

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -445,13 +445,20 @@ pub async fn run(cli: Cli) -> Result<()> {
         Commands::DeepResearch { action } => {
             let mur_home = crate::paths::mur_root(None);
             match action {
-                DeepResearchAction::Provision { count, prefix } => {
-                    cmd::deep_research::provision::cmd_provision(
-                        &mur_home,
-                        prefix.as_deref(),
-                        count,
-                    )?
-                }
+                DeepResearchAction::Provision {
+                    count,
+                    prefix,
+                    grant_egress,
+                    deny_hosts,
+                    yes,
+                } => cmd::deep_research::provision::cmd_provision(
+                    &mur_home,
+                    prefix.as_deref(),
+                    count,
+                    grant_egress,
+                    &deny_hosts,
+                    yes,
+                )?,
             }
         }
         Commands::Team { action } => match action {

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -459,6 +459,21 @@ pub async fn run(cli: Cli) -> Result<()> {
                     &deny_hosts,
                     yes,
                 )?,
+                DeepResearchAction::Run {
+                    name,
+                    max_iterations,
+                    deadline,
+                    budget_usd,
+                } => {
+                    cmd::deep_research::run::cmd_deep_research_run(
+                        &mur_home,
+                        &name,
+                        max_iterations,
+                        deadline,
+                        budget_usd,
+                    )
+                    .await?
+                }
             }
         }
         Commands::Team { action } => match action {

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -11,9 +11,9 @@ use crate::cli::{
     AgentPendingAction, AgentPermAction, AgentPromptAction, AgentQueueAction, AgentScheduleAction,
     AgentSecretAction, AgentSkillAction, AgentTrashAction, AgentWebhookAction, AuthAction,
     ChannelAction, ChatAction, Cli, CommanderAction, Commands, ConversationsAction, DaemonAction,
-    DeployAction, DraftsAction, EvalAction, ExchangeAction, FleetAction, HookEvent,
-    InternalsAction, MurmurdAction, ProjectAction, ScheduleAction, SessionAction, SleepAction,
-    SyncAction, TeamAction, VoiceAction, WorkflowAction,
+    DeepResearchAction, DeployAction, DraftsAction, EvalAction, ExchangeAction, FleetAction,
+    HookEvent, InternalsAction, MurmurdAction, ProjectAction, ScheduleAction, SessionAction,
+    SleepAction, SyncAction, TeamAction, VoiceAction, WorkflowAction,
 };
 use crate::store::config as store_config;
 use crate::{cmd, dashboard, team, verify};
@@ -438,6 +438,18 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
                     cmd::commander::cmd_commander_directive(
                         &mur_home, &fleet, k, budget_usd, now_ms,
+                    )?
+                }
+            }
+        }
+        Commands::DeepResearch { action } => {
+            let mur_home = crate::paths::mur_root(None);
+            match action {
+                DeepResearchAction::Provision { count, prefix } => {
+                    cmd::deep_research::provision::cmd_provision(
+                        &mur_home,
+                        prefix.as_deref(),
+                        count,
                     )?
                 }
             }

--- a/mur-core/src/skills/deep_research_router.yaml
+++ b/mur-core/src/skills/deep_research_router.yaml
@@ -1,0 +1,65 @@
+name: deep-research-router
+version: 0.1.0
+publisher: human:mur
+description: "Decompose -> assign -> synthesize procedure for the deep-research fleet router; synthesis emits RESEARCH_COMPLETE on its own line to converge the fleet loop."
+category: workflow
+scope: fleet
+fleet: deep-research
+content:
+  abstract: |
+    You are the router of the `deep-research` fleet. Each loop iteration:
+    decompose the goal into sub-questions, assign them to research/verify
+    workers, then once claims come back, synthesize a cited report and
+    signal completion with the RESEARCH_COMPLETE marker on its own line.
+  procedure:
+    steps:
+      - description: |
+          DECOMPOSE: break the operator's research goal into a small set of
+          independent, narrowly-scoped sub-questions (not vague topics — each
+          must be answerable from a handful of sources). Prefer fewer,
+          sharper sub-questions over many overlapping ones; each sub-question
+          becomes one worker's assignment for this iteration.
+      - description: |
+          ASSIGN: fan the sub-questions out to available `deep-research`
+          workers via `delegate_to` — one sub-question per research worker.
+          Pair every claim-producing assignment with a verify assignment on a
+          DIFFERENT worker, and give that verify worker exactly ONE lens
+          (correctness / source-independence / recency) per claim batch —
+          never let the same worker both research and verify its own claim.
+          Give each worker a specific, bounded question; a vague delegation
+          produces duplicated or unfocused work.
+      - description: |
+          COLLECT: wait for research replies (claims + citations) and verify
+          replies (per-lens CONFIRM/REFUTE) to land in the shared channel
+          before synthesizing. A claim is reportable only once it has
+          survived verification (2-of-3 confirm across the three lenses,
+          per the verify skill) — never fold in an unverified or refuted
+          claim just to fill out the report.
+      - description: |
+          SYNTHESIZE: once enough sub-questions have confirmed claims (or the
+          iteration budget/deadline is close), weave the surviving claims
+          into a cited report. Every statement in the report must trace back
+          to a specific claim's URL + supporting quote — no uncited
+          sentences. Note open sub-questions or conflicting sources
+          explicitly rather than silently dropping them.
+      - description: |
+          CONVERGE: when the report is complete (or no further iteration
+          would materially improve it within budget), end your synthesis
+          turn with the marker completely alone on its own line, exactly
+          like this — nothing else on that line, not embedded in a
+          sentence, not quoted, not negated:
+
+          RESEARCH_COMPLETE
+
+          The fleet's `done_when: marker:RESEARCH_COMPLETE` only matches an
+          own-line sentinel emitted this run, so mentioning the word in
+          prose elsewhere (e.g. explaining this rule) will NOT falsely
+          converge the loop. If the report is not yet done, do NOT emit the
+          marker — instead state what remains and let the loop continue to
+          the next iteration.
+tags: [deep-research, fleet, router, decompose, synthesis, convergence]
+triggers:
+  - type: session_start
+  - type: keyword
+    pattern: "(decompose|assign|synthesize).*(research|sub-question|question)"
+priority: normal

--- a/mur-core/src/skills/deep_research_verify.yaml
+++ b/mur-core/src/skills/deep_research_verify.yaml
@@ -1,0 +1,58 @@
+name: deep-research-verify
+version: 0.1.0
+publisher: human:mur
+description: "Adversarially refute one claim under a single assigned lens (correctness / source-independence / recency); a claim survives only on a 2-of-3 confirm."
+category: workflow
+scope: fleet
+fleet: deep-research
+content:
+  abstract: |
+    You are a verify worker in the `deep-research` fleet. You are assigned
+    exactly ONE lens on ONE claim; your job is to actively try to REFUTE it
+    under that lens, not to confirm it — a claim only survives into the
+    report when 2 of its 3 lens verdicts are CONFIRM.
+  procedure:
+    steps:
+      - description: |
+          RECEIVE your assignment: one claim (with its cited URL + quote)
+          and exactly ONE lens — correctness, source-independence, or
+          recency. Do not evaluate the claim under any lens other than the
+          one you were assigned; other verify workers cover the other
+          lenses in parallel.
+      - description: |
+          Under LENS = correctness: re-fetch the cited URL yourself and
+          check that the supporting quote actually appears on the page and
+          actually supports the claim as stated (not a stretch, not taken
+          out of context). If the quote is missing, altered, or does not
+          support the claim, that is a REFUTE.
+      - description: |
+          Under LENS = source-independence: check whether the claim's
+          citations are genuinely independent sources — different
+          publishers/domains, not mirrors, syndication, or the same wire
+          copy republished. A claim resting on sources that all trace back
+          to one origin is a REFUTE on this lens even if the quotes check
+          out.
+      - description: |
+          Under LENS = recency: check the cited page's publish/update date
+          against what the claim asserts. A claim presented as current fact
+          but sourced only from stale/superseded material (or dated content
+          contradicted by a more recent source you find) is a REFUTE on this
+          lens.
+      - description: |
+          ADVERSARIAL STANCE: actively look for reasons to refute — try to
+          break the claim under your lens rather than defaulting to
+          agreement. Only emit CONFIRM if you genuinely could not find a
+          problem after actually checking (re-fetching, comparing sources,
+          checking dates), not because it "looks plausible."
+      - description: |
+          REPORT your verdict as CONFIRM or REFUTE for your assigned
+          lens, with a one-line reason, back to the router. The router
+          tallies all three lens verdicts per claim; the claim survives into
+          the synthesized report only on a 2-of-3 CONFIRM — otherwise it is
+          dropped, never shipped as an unverified claim.
+tags: [deep-research, fleet, verify, adversarial, refutation, citation]
+triggers:
+  - type: session_start
+  - type: keyword
+    pattern: "(verify|refute|confirm).*(claim|lens|source)"
+priority: normal

--- a/mur-core/src/skills/deep_research_worker.yaml
+++ b/mur-core/src/skills/deep_research_worker.yaml
@@ -1,0 +1,58 @@
+name: deep-research-worker
+version: 0.1.0
+publisher: human:mur
+description: "Search/fetch the research-gateway MCP with citation discipline and source triangulation for one assigned deep-research sub-question."
+category: workflow
+scope: fleet
+fleet: deep-research
+content:
+  abstract: |
+    You are a research worker in the `deep-research` fleet. Use the
+    gateway's `search`/`fetch` tools to answer your assigned sub-question,
+    binding every claim to a URL + supporting quote and cross-checking it
+    across at least two independent sources before reporting it back.
+  procedure:
+    steps:
+      - description: |
+          SEARCH: call the `search` tool on the `research-gateway` MCP
+          server with your assigned sub-question (not the whole research
+          goal — stay narrowly scoped to what you were delegated). Read the
+          returned title/url/snippet results and pick the most promising
+          candidates rather than fetching everything indiscriminately.
+        intent: "search the web for sources answering the assigned sub-question"
+        tool_hint: search
+      - description: |
+          FETCH: call the `fetch` tool on promising results to read the
+          actual page content. You do not choose or manage escalation
+          tiers yourself — that ladder (plain fetch -> lightpanda ->
+          chrome) is now deterministic gateway code, not your job; just
+          call `fetch` and let the gateway degrade internally, surfacing
+          whatever text/title it returns.
+        intent: "fetch a candidate source's page content"
+        tool_hint: fetch
+      - description: |
+          EXTRACT WITH CITATION DISCIPLINE: for every claim you draw from a
+          fetched page, bind it to that page's URL AND a short supporting
+          quote copied verbatim from the fetched text. A claim with no URL
+          or no supporting quote is DROPPED, not shipped — never report an
+          unsourced claim just to look thorough.
+      - description: |
+          TRIANGULATE: before reporting a claim, cross-check it against a
+          SECOND, independent source (a different domain/publisher, not a
+          mirror or syndication of the first). If the two sources agree,
+          cite both. If they conflict, surface the conflict explicitly in
+          your reply (state both versions and both citations) instead of
+          silently picking one — the router and verify workers need to see
+          the disagreement, not a smoothed-over answer.
+      - description: |
+          REPORT: reply with your claims, each as
+          {claim, url, quote, corroborating_url?} for the router to collect
+          and hand to a verify worker. Keep the reply scoped to your
+          assigned sub-question; do not attempt to synthesize the whole
+          report yourself — that is the router's job.
+tags: [deep-research, fleet, worker, citation, triangulation, search, fetch]
+triggers:
+  - type: session_start
+  - type: keyword
+    pattern: "(search|fetch|cite|source).*(claim|research|question)"
+priority: normal

--- a/mur-research-gateway/Cargo.toml
+++ b/mur-research-gateway/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mur-research-gateway"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "mur-research-gateway"
+path = "src/main.rs"
+
+[dependencies]
+mur-common = { path = "../mur-common" }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/mur-research-gateway/Cargo.toml
+++ b/mur-research-gateway/Cargo.toml
@@ -13,6 +13,7 @@ mur-common = { path = "../mur-common" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 reqwest = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/mur-research-gateway/Cargo.toml
+++ b/mur-research-gateway/Cargo.toml
@@ -16,3 +16,5 @@ serde_json = { workspace = true }
 reqwest = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+# Not in [workspace.dependencies]; pinned to match mur-agent-runtime's `url = "2"`.
+url = "2"

--- a/mur-research-gateway/Cargo.toml
+++ b/mur-research-gateway/Cargo.toml
@@ -8,6 +8,13 @@ license.workspace = true
 name = "mur-research-gateway"
 path = "src/main.rs"
 
+# Deterministic, network-free MCP stdio fixture for Task 10 tests / Task 11's
+# operator E2E — same handshake as the real gateway, fixed corpus, no
+# agent-browser, no net_guard.
+[[bin]]
+name = "stub_gateway"
+path = "src/bin/stub_gateway.rs"
+
 [dependencies]
 mur-common = { path = "../mur-common" }
 tokio = { workspace = true }

--- a/mur-research-gateway/src/audit.rs
+++ b/mur-research-gateway/src/audit.rs
@@ -1,0 +1,86 @@
+// mur-research-gateway/src/audit.rs
+//
+// URL-level audit: every `search`/`fetch` call emits ONE structured
+// single-line JSON record via `tracing::info!(target: "research_gateway_audit", ...)`.
+// This is the sole request-level evidence for the browser tiers (the egress
+// proxy is blind to browser-subprocess connections — spec §7.2/§7.4), so the
+// audit must fire on EVERY call: success, denied, AND error — not just the
+// happy path.
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct AuditRecord {
+    pub worker: Option<String>,
+    pub verb: &'static str,
+    pub target: String,
+    pub tier: Option<u8>,
+    pub outcome: &'static str,
+}
+
+impl AuditRecord {
+    /// Build a record, reading `worker` from the `MUR_AGENT_NAME` env var the
+    /// runtime sets on the child (fallback `None` when absent, e.g. local dev).
+    pub fn new(
+        verb: &'static str,
+        target: String,
+        tier: Option<u8>,
+        outcome: &'static str,
+    ) -> Self {
+        AuditRecord {
+            worker: std::env::var("MUR_AGENT_NAME").ok(),
+            verb,
+            target,
+            tier,
+            outcome,
+        }
+    }
+}
+
+/// Render a record as a single-line JSON object. Pure function — kept
+/// separate from `audit()` so it's unit-testable without capturing logs.
+fn render_audit(record: &AuditRecord) -> String {
+    serde_json::to_string(record).unwrap_or_else(|_| "{}".to_string())
+}
+
+/// Log the rendered audit line at `tracing::info!(target: "research_gateway_audit", ...)`.
+pub fn audit(record: AuditRecord) {
+    tracing::info!(target: "research_gateway_audit", "{}", render_audit(&record));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audit_line_is_single_json_object() {
+        let line = super::render_audit(&AuditRecord {
+            worker: Some("worker_3".into()),
+            verb: "fetch",
+            target: "https://example.com".into(),
+            tier: Some(1),
+            outcome: "ok",
+        });
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["verb"], "fetch");
+        assert_eq!(v["tier"], 1);
+        assert_eq!(v["outcome"], "ok");
+    }
+
+    #[test]
+    fn audit_line_omits_nothing_when_worker_and_tier_absent() {
+        // denied/error paths: tier is None, worker may be None outside a
+        // runtime-managed child — both must still serialize to valid JSON.
+        let line = render_audit(&AuditRecord {
+            worker: None,
+            verb: "search",
+            target: "swift testing".into(),
+            tier: None,
+            outcome: "denied",
+        });
+        let v: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(v["worker"], serde_json::Value::Null);
+        assert_eq!(v["tier"], serde_json::Value::Null);
+        assert_eq!(v["outcome"], "denied");
+    }
+}

--- a/mur-research-gateway/src/bin/stub_gateway.rs
+++ b/mur-research-gateway/src/bin/stub_gateway.rs
@@ -1,0 +1,370 @@
+// mur-research-gateway/src/bin/stub_gateway.rs
+//!
+//! Deterministic test fixture for Task 10 of the MUR-native deep-research
+//! plan: a second binary that speaks the SAME stdio MCP handshake as the
+//! real `mur-research-gateway` (`initialize` / `tools/list` / `tools/call`
+//! for `search` / `fetch`) but returns a FIXED corpus — no network, no
+//! agent-browser, no SSRF guard. This is what a later operator E2E
+//! (Task 11) points provisioned workers at to exercise decompose → research
+//! → verify → synthesize → marker-convergence end to end against a known,
+//! reproducible fact + citation, without depending on live web access.
+//!
+//! Deliberately self-contained (does not depend on the real gateway's
+//! `server`/`fetcher`/`browser`/`net_guard` modules, none of which are
+//! exposed from a lib target): the whole point of a stub is that it MUST
+//! NOT be able to reach the network even by accident.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::io::{BufRead, Write};
+
+/// JSON-RPC 2.0 request (what the client sends us). Mirrors
+/// `mur-research-gateway`'s `jsonrpc::Request` wire shape.
+#[derive(Debug, Deserialize)]
+struct Request {
+    #[allow(dead_code)]
+    #[serde(default)]
+    jsonrpc: String,
+    id: Option<Value>,
+    #[serde(default)]
+    method: String,
+    #[serde(default)]
+    params: Option<Value>,
+}
+
+/// JSON-RPC 2.0 response.
+#[derive(Debug, Serialize, PartialEq)]
+struct Response {
+    jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct JsonRpcError {
+    code: i32,
+    message: String,
+}
+
+impl Response {
+    fn success(id: Option<Value>, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    fn error(id: Option<Value>, code: i32, message: String) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: None,
+            error: Some(JsonRpcError { code, message }),
+        }
+    }
+}
+
+/// The fixed, citable fact every `fetch` in this stub corpus resolves to.
+/// Task 11's E2E can assert a synthesized report cites this exact URL.
+const STUB_FACT_URL: &str = "https://stub.mur.test/deep-research-fixture";
+const STUB_FACT_TEXT: &str = "Fixed fixture fact: the MUR deep-research gateway routes every worker's outbound web access through a single audited proxy process (source: stub.mur.test/deep-research-fixture, corpus revision 1).";
+
+const STUB_HIT_2_URL: &str = "https://stub.mur.test/deep-research-fixture-2";
+
+/// Fixed `tools/list` schema — same shape as the real gateway's `search`/`fetch`.
+fn tools_list() -> Value {
+    serde_json::json!([
+        {
+            "name": "search",
+            "description": "Web search. Returns [{title,url,snippet}]. Read-only.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "number"}
+                },
+                "required": ["query"]
+            }
+        },
+        {
+            "name": "fetch",
+            "description": "Fetch one URL's readable text. Read-only GET. SSRF-guarded.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string"},
+                    "render": {"type": "boolean"}
+                },
+                "required": ["url"]
+            }
+        }
+    ])
+}
+
+/// Fixed 2-hit corpus returned by `search`, regardless of the query.
+fn search_hits() -> Value {
+    serde_json::json!([
+        {
+            "title": "MUR Deep Research Fixture — Primary Source",
+            "url": STUB_FACT_URL,
+            "snippet": "Fixed fixture fact: the MUR deep-research gateway routes every worker's outbound web access through a single audited proxy process."
+        },
+        {
+            "title": "MUR Deep Research Fixture — Secondary Source",
+            "url": STUB_HIT_2_URL,
+            "snippet": "Corroborating fixture source for the deterministic stub corpus."
+        }
+    ])
+}
+
+/// Fixed fetch body for any URL: this stub never makes a real request, so it
+/// always returns the same known fact + citable URL regardless of what was
+/// asked for. Good enough to prove the wiring; NOT a substitute for testing
+/// against real, varied content (that's Task 11's job).
+fn fetch_result(url: &str) -> Value {
+    serde_json::json!({
+        "url": url,
+        "status": 200,
+        "title": "MUR Deep Research Fixture",
+        "text": STUB_FACT_TEXT,
+        "tier": 1
+    })
+}
+
+/// Handle one JSON-RPC request against the fixed corpus. Pure — no I/O — so
+/// it is directly unit-testable without spawning the process.
+fn handle(request: &Request) -> Response {
+    match request.method.as_str() {
+        "initialize" => Response::success(
+            request.id.clone(),
+            serde_json::json!({
+                "protocolVersion": "2025-11-25",
+                "capabilities": {"tools": {}},
+                "serverInfo": {
+                    "name": "mur-research-gateway-stub",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            }),
+        ),
+        "tools/list" => Response::success(
+            request.id.clone(),
+            serde_json::json!({ "tools": tools_list() }),
+        ),
+        "tools/call" => handle_tool_call(request.id.clone(), request.params.clone()),
+        "notifications/initialized" => Response {
+            jsonrpc: "2.0",
+            id: None,
+            result: None,
+            error: None,
+        },
+        "" => Response::error(request.id.clone(), -32700, "Parse error".to_string()),
+        other => Response::error(
+            request.id.clone(),
+            -32601,
+            format!("Method not found: {other}"),
+        ),
+    }
+}
+
+fn handle_tool_call(id: Option<Value>, params: Option<Value>) -> Response {
+    let params = match params {
+        Some(p) => p,
+        None => return Response::error(id, -32602, "tools/call requires params".to_string()),
+    };
+    let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
+    let args = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
+    match name {
+        "search" => {
+            if args.get("query").and_then(|v| v.as_str()).is_none() {
+                return Response::error(id, -32602, "search requires 'query'".to_string());
+            }
+            Response::success(id, search_hits())
+        }
+        "fetch" => match args.get("url").and_then(|v| v.as_str()) {
+            Some(url) => Response::success(id, fetch_result(url)),
+            None => Response::error(id, -32602, "fetch requires 'url'".to_string()),
+        },
+        other => Response::error(id, -32602, format!("Unknown tool: {other}")),
+    }
+}
+
+/// Read one JSON-RPC request from stdin. Blocks until a complete line.
+/// Returns None if stdin closes.
+fn read_request() -> Option<Request> {
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    match stdin.lock().read_line(&mut line) {
+        Ok(0) => None, // EOF
+        Ok(_) => {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                return read_request(); // skip blank lines
+            }
+            match serde_json::from_str::<Request>(trimmed) {
+                Ok(req) => Some(req),
+                Err(_) => Some(Request {
+                    jsonrpc: "2.0".into(),
+                    id: None,
+                    method: String::new(),
+                    params: None,
+                }),
+            }
+        }
+        Err(_) => None,
+    }
+}
+
+fn write_response(resp: &Response) {
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    let json = serde_json::to_string(resp).unwrap_or_else(|_| {
+        r#"{"jsonrpc":"2.0","error":{"code":-32700,"message":"serialize failure"}}"#.to_string()
+    });
+    writeln!(handle, "{json}").ok();
+    handle.flush().ok();
+}
+
+fn main() {
+    while let Some(request) = read_request() {
+        let is_notification = request.id.is_none() && request.method.starts_with("notifications/");
+        let response = handle(&request);
+        if !is_notification {
+            write_response(&response);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(method: &str, params: Option<Value>) -> Request {
+        Request {
+            jsonrpc: "2.0".into(),
+            id: Some(serde_json::json!(1)),
+            method: method.to_string(),
+            params,
+        }
+    }
+
+    #[test]
+    fn initialize_advertises_stub_server_info() {
+        let resp = handle(&req("initialize", None));
+        assert!(resp.error.is_none());
+        let name = resp.result.unwrap()["serverInfo"]["name"].clone();
+        assert_eq!(name, serde_json::json!("mur-research-gateway-stub"));
+    }
+
+    #[test]
+    fn tools_list_declares_search_and_fetch() {
+        let resp = handle(&req("tools/list", None));
+        let tools = resp.result.unwrap()["tools"].clone();
+        let names: Vec<&str> = tools
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["name"].as_str().unwrap())
+            .collect();
+        assert_eq!(names, vec!["search", "fetch"]);
+    }
+
+    #[test]
+    fn search_returns_fixed_two_hit_corpus() {
+        let resp = handle(&req(
+            "tools/call",
+            Some(serde_json::json!({"name": "search", "arguments": {"query": "anything"}})),
+        ));
+        assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+        let hits = resp.result.unwrap();
+        let arr = hits.as_array().unwrap();
+        assert_eq!(arr.len(), 2, "corpus must have exactly 2 fixed hits");
+        assert_eq!(arr[0]["url"], serde_json::json!(STUB_FACT_URL));
+        assert_eq!(arr[1]["url"], serde_json::json!(STUB_HIT_2_URL));
+    }
+
+    #[test]
+    fn search_missing_query_errors() {
+        let resp = handle(&req(
+            "tools/call",
+            Some(serde_json::json!({"name": "search", "arguments": {}})),
+        ));
+        assert!(resp.error.is_some());
+    }
+
+    #[test]
+    fn fetch_returns_known_fact_and_echoes_requested_url() {
+        let resp = handle(&req(
+            "tools/call",
+            Some(serde_json::json!({"name": "fetch", "arguments": {"url": STUB_FACT_URL}})),
+        ));
+        assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+        let result = resp.result.unwrap();
+        assert_eq!(result["url"], serde_json::json!(STUB_FACT_URL));
+        assert_eq!(result["status"], serde_json::json!(200));
+        let text = result["text"].as_str().unwrap();
+        assert!(
+            text.contains("audited proxy process"),
+            "fetch text must contain the known fixture fact, got: {text}"
+        );
+    }
+
+    #[test]
+    fn fetch_missing_url_errors() {
+        let resp = handle(&req(
+            "tools/call",
+            Some(serde_json::json!({"name": "fetch", "arguments": {}})),
+        ));
+        assert!(resp.error.is_some());
+    }
+
+    #[test]
+    fn fetch_never_touches_the_network_even_for_a_localhost_url() {
+        // The real gateway's SSRF guard would reject this; the stub has NO
+        // guard because it also has no network access path — it just
+        // returns the same fixed fact regardless of URL. This test pins
+        // that behavior so nobody "fixes" the stub into making real requests.
+        let resp = handle(&req(
+            "tools/call",
+            Some(serde_json::json!({"name": "fetch", "arguments": {"url": "http://127.0.0.1:1/"}})),
+        ));
+        assert!(resp.error.is_none());
+        assert!(
+            resp.result.unwrap()["text"]
+                .as_str()
+                .unwrap()
+                .contains("audited proxy process")
+        );
+    }
+
+    #[test]
+    fn unknown_tool_errors() {
+        let resp = handle(&req(
+            "tools/call",
+            Some(serde_json::json!({"name": "nope", "arguments": {}})),
+        ));
+        assert!(resp.error.is_some());
+    }
+
+    #[test]
+    fn unknown_method_errors() {
+        let resp = handle(&req("bogus/method", None));
+        assert!(resp.error.is_some());
+    }
+
+    #[test]
+    fn notifications_initialized_produces_empty_response_shape() {
+        let mut r = req("notifications/initialized", None);
+        r.id = None;
+        let resp = handle(&r);
+        assert!(resp.result.is_none() && resp.error.is_none());
+    }
+}

--- a/mur-research-gateway/src/bin/stub_gateway.rs
+++ b/mur-research-gateway/src/bin/stub_gateway.rs
@@ -94,12 +94,13 @@ fn tools_list() -> Value {
         },
         {
             "name": "fetch",
-            "description": "Fetch one URL's readable text. Read-only GET. SSRF-guarded.",
+            "description": "Fixture: fixed corpus, no network, no guard.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "url": {"type": "string"},
-                    "render": {"type": "boolean"}
+                    "render": {"type": "boolean"},
+                    "chrome": {"type": "boolean"}
                 },
                 "required": ["url"]
             }

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -1,0 +1,388 @@
+// mur-research-gateway/src/browser.rs
+//
+// Escalation tiers 2 (agent-browser --engine lightpanda) and 3 (--engine
+// chrome), plus `search`, plus `preflight`. Drives `agent-browser` as a
+// subprocess — see docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md §5.
+//
+// LOAD-BEARING: the egress proxy only sees tier-1 (reqwest) connections; the
+// browser subprocess opens its own connections the proxy cannot observe.
+// Therefore `deny_hosts` + the SSRF guard MUST be enforced here, in gateway
+// code, BEFORE spawning agent-browser — never delegate that to the proxy.
+
+use crate::fetcher::{self, FetchError, FetchResult};
+use serde::Serialize;
+
+pub struct BrowserCfg {
+    pub agent_browser_bin: String,
+    pub lightpanda_path: Option<String>,
+    pub chrome_stealth_args: String, // comma-separated; empty = none
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Preflight {
+    Full,
+    LightpandaMissing,
+    AgentBrowserTooOld(String),
+    AgentBrowserMissing,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SearchHit {
+    pub title: String,
+    pub url: String,
+    pub snippet: String,
+}
+
+/// Build the agent-browser argv for a single fetch. Pure → unit-testable.
+///
+/// lightpanda tier: `--engine lightpanda --executable-path PATH --args ""`
+/// (MANDATORY: stealth args must never reach lightpanda — it errors out on
+/// them, verified `gotcha_agent_browser_lightpanda_engine_dead`).
+/// chrome tier: `--engine chrome` + stealth args.
+pub fn build_fetch_argv(url: &str, cfg: &BrowserCfg, want_chrome: bool) -> Vec<String> {
+    let mut a = Vec::new();
+    if want_chrome || cfg.lightpanda_path.is_none() {
+        a.push("--engine".into());
+        a.push("chrome".into());
+        for s in cfg.chrome_stealth_args.split(',').filter(|s| !s.is_empty()) {
+            a.push(s.to_string());
+        }
+    } else {
+        a.push("--engine".into());
+        a.push("lightpanda".into());
+        a.push("--executable-path".into());
+        a.push(cfg.lightpanda_path.clone().unwrap());
+        a.push("--args".into());
+        a.push(String::new()); // MANDATORY empty — see module doc
+    }
+    a.push("--session".into());
+    a.push(session_id(url)); // per-fetch isolation: no shared cookie jars
+    a.push("open".into());
+    a.push(url.to_string());
+    a.push("snapshot".into());
+    a
+}
+
+/// Deterministic per-URL session id so concurrent fetches never cross-contaminate
+/// cookie jars. FNV-1a keeps it fast and filesystem-safe (no path chars).
+fn session_id(url: &str) -> String {
+    let mut h: u64 = 1469598103934665603;
+    for b in url.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(1099511628211);
+    }
+    format!("rg-{h:016x}")
+}
+
+/// Production preflight: shells out to `agent-browser --version` and combines
+/// the result with `cfg` via `preflight_from_versions`. NOT exercised by unit
+/// tests (those call `preflight_from_versions` directly with fixed inputs) —
+/// this is the only function in the module that touches a real subprocess.
+pub fn preflight(cfg: &BrowserCfg) -> Preflight {
+    let output = std::process::Command::new(&cfg.agent_browser_bin)
+        .arg("--version")
+        .output();
+    match output {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            preflight_from_versions(true, parse_version(&stdout).as_deref(), cfg)
+        }
+        // Ran but reported failure (e.g. unrecognized flag on a very old
+        // build) — present but version unknown; treat conservatively as too
+        // old rather than silently Full.
+        Ok(_) => Preflight::AgentBrowserTooOld("unknown".into()),
+        Err(_) => Preflight::AgentBrowserMissing,
+    }
+}
+
+/// Pull the first whitespace-separated token that looks like a version
+/// (`0.31.1`, `v0.31.1`) out of `agent-browser --version` output.
+fn parse_version(s: &str) -> Option<String> {
+    s.split_whitespace()
+        .find(|t| {
+            let t = t.trim_start_matches('v');
+            t.chars().next().is_some_and(|c| c.is_ascii_digit()) && t.contains('.')
+        })
+        .map(|t| t.trim_start_matches('v').to_string())
+}
+
+pub fn preflight_from_versions(
+    ab_present: bool,
+    ab_version: Option<&str>,
+    cfg: &BrowserCfg,
+) -> Preflight {
+    if !ab_present {
+        return Preflight::AgentBrowserMissing;
+    }
+    if let Some(v) = ab_version
+        && !version_ge(v, 0, 28)
+    {
+        return Preflight::AgentBrowserTooOld(v.into());
+    }
+    if cfg.lightpanda_path.is_none() {
+        return Preflight::LightpandaMissing;
+    }
+    Preflight::Full
+}
+
+fn version_ge(v: &str, maj: u32, min: u32) -> bool {
+    let mut it = v.trim_start_matches('v').split('.');
+    let a: u32 = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let b: u32 = it.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    a > maj || (a == maj && b >= min)
+}
+
+/// Fetch a JS-rendered page. Pre-spawn SSRF/deny screen (proxy can't see the
+/// browser's connections — spec §5), then drive agent-browser. `want_chrome`
+/// forces tier 3; otherwise tier 2 (lightpanda) is used when available.
+pub async fn fetch_rendered(
+    url: &str,
+    deny: &[String],
+    cfg: &BrowserCfg,
+    want_chrome: bool,
+) -> Result<FetchResult, FetchError> {
+    let screened = fetcher::screen_url_blocking(url, deny)
+        .await
+        .map_err(FetchError::Guard)?;
+    let argv = build_fetch_argv(screened.as_str(), cfg, want_chrome);
+    let out = tokio::process::Command::new(&cfg.agent_browser_bin)
+        .args(&argv)
+        .output()
+        .await
+        .map_err(|e| FetchError::Http(format!("spawn agent-browser: {e}")))?;
+    if !out.status.success() {
+        return Err(FetchError::Http(
+            String::from_utf8_lossy(&out.stderr).into(),
+        ));
+    }
+    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    let tier = if want_chrome || cfg.lightpanda_path.is_none() {
+        3
+    } else {
+        2
+    };
+    Ok(FetchResult {
+        url: screened.to_string(),
+        status: 200,
+        title: None,
+        text,
+        tier,
+    })
+}
+
+/// Web search. Drives agent-browser to a search-results page and parses hits.
+/// v1 rides the browser engine — a dedicated search-provider API is out of
+/// scope per spec §11. Same pre-spawn screen as `fetch_rendered`; tier follows
+/// `cfg` (lightpanda when available, else chrome) — never caller-selectable,
+/// since search has no anti-bot escalation path of its own.
+pub async fn search(
+    query: &str,
+    limit: usize,
+    cfg: &BrowserCfg,
+) -> Result<Vec<SearchHit>, FetchError> {
+    let mut search_url =
+        url::Url::parse("https://html.duckduckgo.com/html/").expect("static URL is valid");
+    search_url.query_pairs_mut().append_pair("q", query);
+
+    // No deny_hosts overlay here (search always targets the fixed search-engine
+    // host above, not a caller-supplied URL) — the guard still screens the
+    // resolved IP against loopback/private/link-local per net_guard's hard rule.
+    let screened = fetcher::screen_url_blocking(search_url.as_str(), &[])
+        .await
+        .map_err(FetchError::Guard)?;
+
+    let argv = build_fetch_argv(screened.as_str(), cfg, false);
+    let out = tokio::process::Command::new(&cfg.agent_browser_bin)
+        .args(&argv)
+        .output()
+        .await
+        .map_err(|e| FetchError::Http(format!("spawn agent-browser: {e}")))?;
+    if !out.status.success() {
+        return Err(FetchError::Http(
+            String::from_utf8_lossy(&out.stderr).into(),
+        ));
+    }
+    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    Ok(parse_search_hits(&text, limit))
+}
+
+/// Small, deliberately minimal parser: agent-browser's `snapshot` renders
+/// markdown-style links (`[title](url)`); one hit per line that has one,
+/// snippet is the next non-empty, non-link line. Good enough for v1 — the
+/// upstream search engine's HTML is not a contract MUR controls (spec §11:
+/// a dedicated search API is out of scope), so don't over-invest here.
+fn parse_search_hits(text: &str, limit: usize) -> Vec<SearchHit> {
+    let mut hits = Vec::new();
+    let mut lines = text.lines().peekable();
+    while let Some(line) = lines.next() {
+        if hits.len() >= limit {
+            break;
+        }
+        let Some((title, url)) = parse_markdown_link(line) else {
+            continue;
+        };
+        if !(url.starts_with("http://") || url.starts_with("https://")) {
+            continue;
+        }
+        let snippet = lines
+            .peek()
+            .filter(|l| !l.trim().is_empty() && parse_markdown_link(l).is_none())
+            .map(|l| l.trim().to_string())
+            .unwrap_or_default();
+        hits.push(SearchHit {
+            title,
+            url,
+            snippet,
+        });
+    }
+    hits
+}
+
+/// Extract `(title, url)` from a single `[title](url)` markdown link, if the
+/// line contains exactly that shape. Returns `None` for anything else.
+fn parse_markdown_link(line: &str) -> Option<(String, String)> {
+    let start = line.find('[')?;
+    let close = line[start..].find(']')? + start;
+    if line[close + 1..].starts_with('(') {
+        let open_paren = close + 1;
+        let end = line[open_paren..].find(')')? + open_paren;
+        let title = line[start + 1..close].trim().to_string();
+        let url = line[open_paren + 1..end].trim().to_string();
+        if title.is_empty() || url.is_empty() {
+            return None;
+        }
+        return Some((title, url));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    #[allow(clippy::comparison_to_empty)] // brief's exact assertion form is the contract
+    fn lightpanda_command_forces_empty_args() {
+        let cfg = BrowserCfg {
+            agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: Some("/x/lightpanda".into()),
+            chrome_stealth_args: "--no-sandbox".into(),
+        };
+        let argv = build_fetch_argv("https://example.com", &cfg, false);
+        // lightpanda tier MUST pass --args "" and --executable-path, and MUST NOT carry stealth args
+        assert!(argv.windows(2).any(|w| w[0] == "--args" && w[1] == ""));
+        assert!(
+            argv.windows(2)
+                .any(|w| w[0] == "--executable-path" && w[1] == "/x/lightpanda")
+        );
+        assert!(
+            argv.windows(2)
+                .any(|w| w[0] == "--engine" && w[1] == "lightpanda")
+        );
+        assert!(!argv.iter().any(|a| a.contains("no-sandbox")));
+    }
+    #[test]
+    fn chrome_tier_carries_stealth_args() {
+        let cfg = BrowserCfg {
+            agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: Some("/x/lightpanda".into()),
+            chrome_stealth_args: "--no-sandbox".into(),
+        };
+        let argv = build_fetch_argv("https://example.com", &cfg, true);
+        assert!(
+            argv.windows(2)
+                .any(|w| w[0] == "--engine" && w[1] == "chrome")
+        );
+        assert!(argv.iter().any(|a| a == "--no-sandbox"));
+    }
+    #[test]
+    fn preflight_degrades_when_lightpanda_missing() {
+        let cfg = BrowserCfg {
+            agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: None,
+            chrome_stealth_args: String::new(),
+        };
+        // With no lightpanda path, preflight must not claim Full.
+        assert!(!matches!(
+            preflight_from_versions(true, Some("0.31.1"), &cfg),
+            Preflight::Full
+        ));
+    }
+    #[test]
+    fn preflight_full_when_all_present() {
+        let cfg = BrowserCfg {
+            agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: Some("/x/lightpanda".into()),
+            chrome_stealth_args: String::new(),
+        };
+        assert!(matches!(
+            preflight_from_versions(true, Some("0.31.1"), &cfg),
+            Preflight::Full
+        ));
+    }
+    #[test]
+    fn preflight_reports_too_old_version() {
+        let cfg = BrowserCfg {
+            agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: Some("/x/lightpanda".into()),
+            chrome_stealth_args: String::new(),
+        };
+        assert!(matches!(
+            preflight_from_versions(true, Some("0.27.0"), &cfg),
+            Preflight::AgentBrowserTooOld(v) if v == "0.27.0"
+        ));
+    }
+    #[test]
+    fn preflight_missing_when_absent() {
+        let cfg = BrowserCfg {
+            agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: Some("/x/lightpanda".into()),
+            chrome_stealth_args: String::new(),
+        };
+        assert!(matches!(
+            preflight_from_versions(false, None, &cfg),
+            Preflight::AgentBrowserMissing
+        ));
+    }
+    #[test]
+    fn version_ge_handles_v_prefix_and_bounds() {
+        assert!(version_ge("v0.28.0", 0, 28));
+        assert!(version_ge("0.31.1", 0, 28));
+        assert!(version_ge("1.0.0", 0, 28));
+        assert!(!version_ge("0.27.9", 0, 28));
+    }
+    #[test]
+    fn session_id_is_deterministic_and_url_scoped() {
+        assert_eq!(
+            session_id("https://a.example"),
+            session_id("https://a.example")
+        );
+        assert_ne!(
+            session_id("https://a.example"),
+            session_id("https://b.example")
+        );
+        assert!(session_id("https://a.example").starts_with("rg-"));
+    }
+    #[test]
+    fn parses_markdown_search_hits_with_snippet() {
+        let text = "\
+Intro text\n\
+[Rust Programming Language](https://www.rust-lang.org/)\n\
+A language empowering everyone.\n\
+\n\
+[Another Hit](https://example.com/page)\n\
+Some snippet text.\n\
+[Not a search result](not-a-url)\n";
+        let hits = parse_search_hits(text, 5);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].title, "Rust Programming Language");
+        assert_eq!(hits[0].url, "https://www.rust-lang.org/");
+        assert_eq!(hits[0].snippet, "A language empowering everyone.");
+        assert_eq!(hits[1].title, "Another Hit");
+        assert_eq!(hits[1].snippet, "Some snippet text.");
+    }
+    #[test]
+    fn parse_search_hits_respects_limit() {
+        let text = "[A](https://a.example)\n[B](https://b.example)\n[C](https://c.example)\n";
+        assert_eq!(parse_search_hits(text, 2).len(), 2);
+    }
+}

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -11,6 +11,8 @@
 
 use crate::fetcher::{self, FetchError, FetchResult};
 use serde::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 pub struct BrowserCfg {
     pub agent_browser_bin: String,
@@ -63,16 +65,23 @@ pub fn build_fetch_argv(url: &str, cfg: &BrowserCfg, want_chrome: bool) -> Vec<S
     a
 }
 
-/// Deterministic per-URL session id so concurrent fetches never cross-contaminate
-/// cookie jars. FNV-1a keeps it fast and filesystem-safe (no path chars).
+/// Per-FETCH unique session id so even two concurrent fetches of the SAME url
+/// get distinct cookie jars (Global Constraint: per-fetch isolation). The
+/// URL's FNV-1a hash keeps ids meaningful/greppable; a process-wide atomic
+/// counter guarantees uniqueness across calls (NOT random/time — deterministic
+/// within a run, collision-free). FNV-1a keeps the hash fast and filesystem-safe.
 fn session_id(url: &str) -> String {
     let mut h: u64 = 1469598103934665603;
     for b in url.bytes() {
         h ^= b as u64;
         h = h.wrapping_mul(1099511628211);
     }
-    format!("rg-{h:016x}")
+    let seq = SESSION_SEQ.fetch_add(1, Ordering::Relaxed);
+    format!("rg-{h:016x}-{seq:016x}")
 }
+
+/// Monotonic per-fetch counter mixed into every `session_id` — see its doc.
+static SESSION_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// Production preflight: shells out to `agent-browser --version` and combines
 /// the result with `cfg` via `preflight_from_versions`. NOT exercised by unit
@@ -114,10 +123,13 @@ pub fn preflight_from_versions(
     if !ab_present {
         return Preflight::AgentBrowserMissing;
     }
-    if let Some(v) = ab_version
-        && !version_ge(v, 0, 28)
-    {
-        return Preflight::AgentBrowserTooOld(v.into());
+    // ab present but version unparseable → treat as too-old, never fall through
+    // to Full. Silently proceeding as Full on an unknown version is forbidden
+    // (brief: "never silently proceed as Full").
+    match ab_version {
+        Some(v) if !version_ge(v, 0, 28) => return Preflight::AgentBrowserTooOld(v.into()),
+        Some(_) => {}
+        None => return Preflight::AgentBrowserTooOld("unknown".into()),
     }
     if cfg.lightpanda_path.is_none() {
         return Preflight::LightpandaMissing;
@@ -132,30 +144,47 @@ fn version_ge(v: &str, maj: u32, min: u32) -> bool {
     a > maj || (a == maj && b >= min)
 }
 
-/// Fetch a JS-rendered page. Pre-spawn SSRF/deny screen (proxy can't see the
-/// browser's connections — spec §5), then drive agent-browser. `want_chrome`
-/// forces tier 3; otherwise tier 2 (lightpanda) is used when available.
-pub async fn fetch_rendered(
-    url: &str,
-    deny: &[String],
-    cfg: &BrowserCfg,
-    want_chrome: bool,
-) -> Result<FetchResult, FetchError> {
-    let screened = fetcher::screen_url_blocking(url, deny)
+/// Spawn agent-browser with `argv`, bounded by `timeout` (same source tier-1
+/// uses), and return its stdout. Enforces the tier-1 body cap on stdout so a
+/// runaway render can't buffer unbounded. Shared by `fetch_rendered`/`search`.
+async fn run_agent_browser(
+    bin: &str,
+    argv: &[String],
+    timeout: Duration,
+) -> Result<String, FetchError> {
+    let fut = tokio::process::Command::new(bin).args(argv).output();
+    let out = tokio::time::timeout(timeout, fut)
         .await
-        .map_err(FetchError::Guard)?;
-    let argv = build_fetch_argv(screened.as_str(), cfg, want_chrome);
-    let out = tokio::process::Command::new(&cfg.agent_browser_bin)
-        .args(&argv)
-        .output()
-        .await
+        .map_err(|_| FetchError::Http("agent-browser timed out".into()))?
         .map_err(|e| FetchError::Http(format!("spawn agent-browser: {e}")))?;
     if !out.status.success() {
         return Err(FetchError::Http(
             String::from_utf8_lossy(&out.stderr).into(),
         ));
     }
-    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    // TODO(Phase 3): stream stdout to cap before full buffering.
+    if out.stdout.len() > fetcher::MAX_BODY_BYTES {
+        return Err(FetchError::TooLarge);
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+/// Fetch a JS-rendered page. Pre-spawn SSRF/deny screen (proxy can't see the
+/// browser's connections — spec §5), then drive agent-browser under `timeout`.
+/// `want_chrome` forces tier 3; otherwise tier 2 (lightpanda) is used when
+/// available.
+pub async fn fetch_rendered(
+    url: &str,
+    deny: &[String],
+    cfg: &BrowserCfg,
+    want_chrome: bool,
+    timeout: Duration,
+) -> Result<FetchResult, FetchError> {
+    let screened = fetcher::screen_url_blocking(url, deny)
+        .await
+        .map_err(FetchError::Guard)?;
+    let argv = build_fetch_argv(screened.as_str(), cfg, want_chrome);
+    let text = run_agent_browser(&cfg.agent_browser_bin, &argv, timeout).await?;
     let tier = if want_chrome || cfg.lightpanda_path.is_none() {
         3
     } else {
@@ -172,13 +201,14 @@ pub async fn fetch_rendered(
 
 /// Web search. Drives agent-browser to a search-results page and parses hits.
 /// v1 rides the browser engine — a dedicated search-provider API is out of
-/// scope per spec §11. Same pre-spawn screen as `fetch_rendered`; tier follows
-/// `cfg` (lightpanda when available, else chrome) — never caller-selectable,
-/// since search has no anti-bot escalation path of its own.
+/// scope per spec §11. Same pre-spawn screen and `timeout` as `fetch_rendered`;
+/// tier follows `cfg` (lightpanda when available, else chrome) — never
+/// caller-selectable, since search has no anti-bot escalation path of its own.
 pub async fn search(
     query: &str,
     limit: usize,
     cfg: &BrowserCfg,
+    timeout: Duration,
 ) -> Result<Vec<SearchHit>, FetchError> {
     let mut search_url =
         url::Url::parse("https://html.duckduckgo.com/html/").expect("static URL is valid");
@@ -192,17 +222,7 @@ pub async fn search(
         .map_err(FetchError::Guard)?;
 
     let argv = build_fetch_argv(screened.as_str(), cfg, false);
-    let out = tokio::process::Command::new(&cfg.agent_browser_bin)
-        .args(&argv)
-        .output()
-        .await
-        .map_err(|e| FetchError::Http(format!("spawn agent-browser: {e}")))?;
-    if !out.status.success() {
-        return Err(FetchError::Http(
-            String::from_utf8_lossy(&out.stderr).into(),
-        ));
-    }
-    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    let text = run_agent_browser(&cfg.agent_browser_bin, &argv, timeout).await?;
     Ok(parse_search_hits(&text, limit))
 }
 
@@ -344,6 +364,20 @@ mod tests {
         ));
     }
     #[test]
+    fn preflight_unparseable_version_is_not_full() {
+        // agent-browser ran (present) but its version output couldn't be
+        // parsed → must NOT silently proceed as Full even with lightpanda
+        // present; degrade to AgentBrowserTooOld("unknown").
+        let cfg = BrowserCfg {
+            agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: Some("/x/lightpanda".into()),
+            chrome_stealth_args: String::new(),
+        };
+        let pf = preflight_from_versions(true, None, &cfg);
+        assert!(!matches!(pf, Preflight::Full));
+        assert!(matches!(pf, Preflight::AgentBrowserTooOld(v) if v == "unknown"));
+    }
+    #[test]
     fn version_ge_handles_v_prefix_and_bounds() {
         assert!(version_ge("v0.28.0", 0, 28));
         assert!(version_ge("0.31.1", 0, 28));
@@ -351,8 +385,10 @@ mod tests {
         assert!(!version_ge("0.27.9", 0, 28));
     }
     #[test]
-    fn session_id_is_deterministic_and_url_scoped() {
-        assert_eq!(
+    fn session_id_is_unique_per_fetch() {
+        // Per-FETCH uniqueness: even two calls with the SAME url must differ
+        // (distinct cookie jars for concurrent same-url fetches).
+        assert_ne!(
             session_id("https://a.example"),
             session_id("https://a.example")
         );

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -204,9 +204,18 @@ pub async fn fetch_rendered(
 /// scope per spec §11. Same pre-spawn screen and `timeout` as `fetch_rendered`;
 /// tier follows `cfg` (lightpanda when available, else chrome) — never
 /// caller-selectable, since search has no anti-bot escalation path of its own.
+///
+/// `deny` is the SAME operator `deny_hosts` overlay `fetch_rendered` screens
+/// against — passed here too so `mur deep-research provision --deny-host X`
+/// applies uniformly across every gateway tool, not just `fetch`. The fixed
+/// search-engine host itself is never caller-supplied, but an operator can
+/// still deny it (or any other public host reachable from a redirect/hit)
+/// via the same overlay; the always-on private/loopback/link-local rule
+/// applies regardless (net_guard).
 pub async fn search(
     query: &str,
     limit: usize,
+    deny: &[String],
     cfg: &BrowserCfg,
     timeout: Duration,
 ) -> Result<Vec<SearchHit>, FetchError> {
@@ -214,10 +223,7 @@ pub async fn search(
         url::Url::parse("https://html.duckduckgo.com/html/").expect("static URL is valid");
     search_url.query_pairs_mut().append_pair("q", query);
 
-    // No deny_hosts overlay here (search always targets the fixed search-engine
-    // host above, not a caller-supplied URL) — the guard still screens the
-    // resolved IP against loopback/private/link-local per net_guard's hard rule.
-    let screened = fetcher::screen_url_blocking(search_url.as_str(), &[])
+    let screened = fetcher::screen_url_blocking(search_url.as_str(), deny)
         .await
         .map_err(FetchError::Guard)?;
 

--- a/mur-research-gateway/src/config.rs
+++ b/mur-research-gateway/src/config.rs
@@ -182,7 +182,11 @@ fn default_lightpanda_path(mur_home: &Path) -> Option<String> {
 }
 
 fn env_deny_hosts() -> Option<Vec<String>> {
-    std::env::var(ENV_DENY_HOSTS).ok().map(|v| {
+    // Treat an empty/whitespace-only value as ABSENT (fall through to YAML /
+    // default), same as every other env field via `non_empty_env` — otherwise
+    // `export MUR_RESEARCH_DENY_HOSTS=` would silently wipe the YAML-configured
+    // SSRF blocklist overlay. A non-empty value still overrides.
+    non_empty_env(ENV_DENY_HOSTS).map(|v| {
         v.split(',')
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
@@ -301,6 +305,26 @@ research_gateway:
             Path::new("/nonexistent"),
         );
         assert_eq!(c.deny_hosts, vec!["a.example", "b.example"]);
+        unsafe {
+            std::env::remove_var(ENV_DENY_HOSTS);
+        }
+    }
+
+    #[test]
+    fn empty_deny_hosts_env_does_not_wipe_yaml_blocklist() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // An empty MUR_RESEARCH_DENY_HOSTS must be treated as ABSENT, not as
+        // "clear the blocklist" — otherwise it would silently wipe the
+        // YAML-configured SSRF overlay (security-relevant).
+        // SAFETY: env mutation guarded by ENV_LOCK above.
+        unsafe {
+            std::env::set_var(ENV_DENY_HOSTS, "");
+        }
+        let c = load_from_yaml(
+            "research_gateway:\n  deny_hosts: [\"blocked.example\"]\n",
+            Path::new("/nonexistent"),
+        );
+        assert_eq!(c.deny_hosts, vec!["blocked.example"]);
         unsafe {
             std::env::remove_var(ENV_DENY_HOSTS);
         }

--- a/mur-research-gateway/src/config.rs
+++ b/mur-research-gateway/src/config.rs
@@ -1,0 +1,345 @@
+// mur-research-gateway/src/config.rs
+//
+// Centralized gateway configuration (Task 6). Loaded ONCE at startup
+// (`server::McpServer::new`) from `~/.mur/config.yaml`'s `research_gateway:`
+// block; env vars override whatever the YAML (or its defaults) produced.
+//
+// YAML-reading pattern mirrors `mur_common::config::Config`'s per-section
+// parsing (see `ConversationsConfig` / the `missing_conversations_section_is_fine`
+// test in mur-common/src/config.rs): parse the whole file as a generic
+// `serde_yaml::Value`, pull out the `research_gateway` key, deserialize it
+// into a `#[serde(default)]` struct so a missing file or missing block
+// resolves to all-defaults rather than an error. This crate deliberately
+// does NOT depend on mur-core's `store::config::load_config` (which returns
+// the full, mur-core-only `Config` type and always writes a default file to
+// disk) nor on mur-common's full `Config` struct (wrong layering for a
+// standalone gateway binary) — a local, narrowly-scoped struct is the
+// better fit here, per the same "read only what you need" pattern
+// `ConversationsConfig` demonstrates for a single section.
+
+use crate::browser::BrowserCfg;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+// ---- documented defaults (CLAUDE.md rule 1: no hardcoded values) ----
+
+/// Tier-1 (plain `reqwest` GET) fetch timeout, in seconds.
+pub const DEFAULT_FETCH_TIMEOUT_SECS: u64 = 20;
+
+/// Tier-2/3 (agent-browser: lightpanda / chrome render + search) timeout, in
+/// seconds. Deliberately its OWN budget, longer than the tier-1 GET timeout —
+/// spinning up a real browser engine and rendering JS legitimately takes
+/// longer than a plain HTTP GET.
+pub const DEFAULT_BROWSER_TIMEOUT_SECS: u64 = 60;
+
+/// Default number of search hits returned when the caller doesn't specify
+/// `limit`.
+pub const DEFAULT_SEARCH_LIMIT: usize = 8;
+
+/// Hard floor/ceiling `search`'s effective `limit` (caller-supplied or
+/// default) is clamped to.
+pub const MIN_SEARCH_LIMIT: usize = 1;
+pub const MAX_SEARCH_LIMIT: usize = 20;
+
+/// Default `agent-browser` binary name, resolved via `PATH`.
+pub const DEFAULT_AGENT_BROWSER_BIN: &str = "agent-browser";
+
+/// Chrome-tier stealth flags (comma-separated, forwarded verbatim as
+/// `agent-browser` args). MUST NEVER be forwarded to the lightpanda tier —
+/// see `browser::build_fetch_argv`'s doc comment /
+/// `gotcha_agent_browser_lightpanda_engine_dead`.
+pub const DEFAULT_CHROME_STEALTH_ARGS: &str =
+    "--no-sandbox,--disable-blink-features=AutomationControlled";
+
+/// Default installed Lightpanda path, relative to `mur_home`. Verified
+/// present on a real install 2026-07-08 — see
+/// `gotcha_agent_browser_lightpanda_engine_dead`. Only ever used when it
+/// actually exists on disk (`default_lightpanda_path` below) — never claim a
+/// path that isn't there.
+pub const DEFAULT_LIGHTPANDA_RELATIVE_PATH: &str = "aura/lightpanda";
+
+// ---- env var names ----
+
+const ENV_DENY_HOSTS: &str = "MUR_RESEARCH_DENY_HOSTS";
+const ENV_FETCH_TIMEOUT_SECS: &str = "MUR_RESEARCH_TIMEOUT_SECS";
+const ENV_BROWSER_TIMEOUT_SECS: &str = "MUR_RESEARCH_BROWSER_TIMEOUT_SECS";
+const ENV_SEARCH_LIMIT: &str = "MUR_RESEARCH_SEARCH_LIMIT";
+const ENV_AGENT_BROWSER_BIN: &str = "MUR_RESEARCH_AGENT_BROWSER_BIN";
+const ENV_LIGHTPANDA_PATH: &str = "MUR_RESEARCH_LIGHTPANDA_PATH";
+const ENV_CHROME_STEALTH_ARGS: &str = "MUR_RESEARCH_CHROME_STEALTH_ARGS";
+
+/// Fully-resolved gateway configuration — YAML defaults merged with env
+/// overrides, ready to use for the lifetime of the process.
+pub struct GatewayConfig {
+    pub deny_hosts: Vec<String>,
+    /// Tier-1 (plain GET) fetch timeout.
+    pub timeout: Duration,
+    /// Tier-2/3 (browser-rendered fetch + search) timeout — its own budget,
+    /// see `DEFAULT_BROWSER_TIMEOUT_SECS`.
+    pub browser_timeout: Duration,
+    pub browser: BrowserCfg,
+    pub search_limit: usize,
+}
+
+/// Raw `research_gateway:` YAML shape. Every field is optional/defaulted so
+/// a config.yaml with no `research_gateway:` block, or one that only sets a
+/// subset of fields, still parses cleanly (mirrors every sub-config in
+/// mur-common/src/config.rs).
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+struct GatewayConfigYaml {
+    deny_hosts: Vec<String>,
+    timeout_secs: Option<u64>,
+    browser_timeout_secs: Option<u64>,
+    search_limit: Option<usize>,
+    agent_browser_bin: Option<String>,
+    lightpanda_path: Option<String>,
+    chrome_stealth_args: Option<String>,
+}
+
+/// Resolve `~/.mur` (or `$MUR_HOME` if set). Mirrors the `MUR_HOME`
+/// precedence in `mur-core/src/store/config.rs::config_path`, but reads
+/// `$HOME` directly instead of pulling the `dirs` crate — the same tradeoff
+/// `mur_common::config::default_mur_dir` makes, since this gateway binary is
+/// deliberately dependency-light (no mur-core, no `dirs`).
+pub fn mur_home_dir() -> PathBuf {
+    if let Ok(p) = std::env::var("MUR_HOME")
+        && !p.is_empty()
+    {
+        return PathBuf::from(p);
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home).join(".mur")
+}
+
+/// Load the gateway config from `<mur_home>/config.yaml`, falling back to
+/// defaults if the file is missing or unparseable, then apply env overrides.
+/// Intended to be called exactly once, at startup (`McpServer::new`).
+pub fn load(mur_home: &Path) -> GatewayConfig {
+    let path = mur_home.join("config.yaml");
+    let yaml = std::fs::read_to_string(&path).unwrap_or_default();
+    load_from_yaml(&yaml, mur_home)
+}
+
+/// Testable core of `load`: parse `yaml` (may be empty, or simply missing
+/// the `research_gateway:` key — both resolve to all-defaults), then apply
+/// env overrides. `mur_home` is used only to resolve the default Lightpanda
+/// path.
+pub fn load_from_yaml(yaml: &str, mur_home: &Path) -> GatewayConfig {
+    let raw: GatewayConfigYaml = serde_yaml::from_str::<serde_yaml::Value>(yaml)
+        .ok()
+        .and_then(|v| v.get("research_gateway").cloned())
+        .and_then(|v| serde_yaml::from_value(v).ok())
+        .unwrap_or_default();
+
+    let deny_hosts = env_deny_hosts().unwrap_or(raw.deny_hosts);
+
+    let timeout_secs = env_u64(ENV_FETCH_TIMEOUT_SECS)
+        .or(raw.timeout_secs)
+        .unwrap_or(DEFAULT_FETCH_TIMEOUT_SECS);
+
+    let browser_timeout_secs = env_u64(ENV_BROWSER_TIMEOUT_SECS)
+        .or(raw.browser_timeout_secs)
+        .unwrap_or(DEFAULT_BROWSER_TIMEOUT_SECS);
+
+    let search_limit = env_usize(ENV_SEARCH_LIMIT)
+        .or(raw.search_limit)
+        .unwrap_or(DEFAULT_SEARCH_LIMIT)
+        .clamp(MIN_SEARCH_LIMIT, MAX_SEARCH_LIMIT);
+
+    let agent_browser_bin = non_empty_env(ENV_AGENT_BROWSER_BIN)
+        .or(raw.agent_browser_bin)
+        .unwrap_or_else(|| DEFAULT_AGENT_BROWSER_BIN.to_string());
+
+    let lightpanda_path = non_empty_env(ENV_LIGHTPANDA_PATH)
+        .or_else(|| raw.lightpanda_path.filter(|s| !s.is_empty()))
+        .or_else(|| default_lightpanda_path(mur_home));
+
+    let chrome_stealth_args = non_empty_env(ENV_CHROME_STEALTH_ARGS)
+        .or(raw.chrome_stealth_args)
+        .unwrap_or_else(|| DEFAULT_CHROME_STEALTH_ARGS.to_string());
+
+    GatewayConfig {
+        deny_hosts,
+        timeout: Duration::from_secs(timeout_secs),
+        browser_timeout: Duration::from_secs(browser_timeout_secs),
+        browser: BrowserCfg {
+            agent_browser_bin,
+            lightpanda_path,
+            chrome_stealth_args,
+        },
+        search_limit,
+    }
+}
+
+/// Only used when neither env nor `research_gateway.lightpanda_path` supply
+/// a path AND the default path actually exists on disk — never claim a path
+/// that isn't there (matches the pre-Task-6 behavior in `server.rs`).
+fn default_lightpanda_path(mur_home: &Path) -> Option<String> {
+    let path = mur_home.join(DEFAULT_LIGHTPANDA_RELATIVE_PATH);
+    path.exists().then(|| path.to_string_lossy().to_string())
+}
+
+fn env_deny_hosts() -> Option<Vec<String>> {
+    std::env::var(ENV_DENY_HOSTS).ok().map(|v| {
+        v.split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    })
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|s| !s.is_empty())
+}
+
+fn env_u64(name: &str) -> Option<u64> {
+    std::env::var(name).ok().and_then(|v| v.parse().ok())
+}
+
+fn env_usize(name: &str) -> Option<usize> {
+    std::env::var(name).ok().and_then(|v| v.parse().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // `std::env::set_var`/`remove_var` are process-global; cargo runs tests in
+    // this file in parallel threads by default, so every test that mutates an
+    // env var serializes on this lock — mirrors
+    // `mur-agent-runtime/tests/model_resolution.rs::HOME_LOCK`.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    // Brief's exact Step-1 failing test.
+    #[test]
+    fn config_defaults_and_env_override() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: env mutation guarded by ENV_LOCK above.
+        unsafe {
+            std::env::set_var(ENV_FETCH_TIMEOUT_SECS, "45");
+        }
+        let c = load_from_yaml("", Path::new("/nonexistent"));
+        assert_eq!(c.timeout.as_secs(), 45); // env override
+        assert!(c.search_limit >= 1); // documented default present
+        unsafe {
+            std::env::remove_var(ENV_FETCH_TIMEOUT_SECS);
+        }
+    }
+
+    #[test]
+    fn defaults_when_file_and_block_absent() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let c = load_from_yaml("", Path::new("/nonexistent"));
+        assert_eq!(c.timeout.as_secs(), DEFAULT_FETCH_TIMEOUT_SECS);
+        assert_eq!(c.browser_timeout.as_secs(), DEFAULT_BROWSER_TIMEOUT_SECS);
+        assert_eq!(c.search_limit, DEFAULT_SEARCH_LIMIT);
+        assert!(c.deny_hosts.is_empty());
+        assert_eq!(c.browser.agent_browser_bin, DEFAULT_AGENT_BROWSER_BIN);
+        assert_eq!(c.browser.chrome_stealth_args, DEFAULT_CHROME_STEALTH_ARGS);
+        assert_eq!(c.browser.lightpanda_path, None);
+    }
+
+    #[test]
+    fn defaults_when_yaml_has_no_research_gateway_key() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let c = load_from_yaml("some_other_key:\n  foo: bar\n", Path::new("/nonexistent"));
+        assert_eq!(c.search_limit, DEFAULT_SEARCH_LIMIT);
+    }
+
+    #[test]
+    fn yaml_block_overrides_defaults() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let yaml = "\
+research_gateway:
+  search_limit: 15
+  deny_hosts: [\"example.internal\", \"metadata.internal\"]
+  agent_browser_bin: \"custom-browser\"
+  chrome_stealth_args: \"--flag-a,--flag-b\"
+";
+        let c = load_from_yaml(yaml, Path::new("/nonexistent"));
+        assert_eq!(c.search_limit, 15);
+        assert_eq!(c.deny_hosts, vec!["example.internal", "metadata.internal"]);
+        assert_eq!(c.browser.agent_browser_bin, "custom-browser");
+        assert_eq!(c.browser.chrome_stealth_args, "--flag-a,--flag-b");
+    }
+
+    #[test]
+    fn search_limit_is_clamped_to_documented_bounds() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let yaml = "research_gateway:\n  search_limit: 999\n";
+        let c = load_from_yaml(yaml, Path::new("/nonexistent"));
+        assert_eq!(c.search_limit, MAX_SEARCH_LIMIT);
+    }
+
+    #[test]
+    fn browser_timeout_env_override_is_independent_of_fetch_timeout() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: env mutation guarded by ENV_LOCK above.
+        unsafe {
+            std::env::set_var(ENV_BROWSER_TIMEOUT_SECS, "90");
+        }
+        let c = load_from_yaml("", Path::new("/nonexistent"));
+        assert_eq!(c.browser_timeout.as_secs(), 90);
+        assert_eq!(c.timeout.as_secs(), DEFAULT_FETCH_TIMEOUT_SECS); // unaffected
+        unsafe {
+            std::env::remove_var(ENV_BROWSER_TIMEOUT_SECS);
+        }
+    }
+
+    #[test]
+    fn deny_hosts_env_override_wins_over_yaml() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: env mutation guarded by ENV_LOCK above.
+        unsafe {
+            std::env::set_var(ENV_DENY_HOSTS, "a.example, b.example");
+        }
+        let c = load_from_yaml(
+            "research_gateway:\n  deny_hosts: [\"c.example\"]\n",
+            Path::new("/nonexistent"),
+        );
+        assert_eq!(c.deny_hosts, vec!["a.example", "b.example"]);
+        unsafe {
+            std::env::remove_var(ENV_DENY_HOSTS);
+        }
+    }
+
+    #[test]
+    fn lightpanda_path_env_override_wins_and_need_not_exist() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: env mutation guarded by ENV_LOCK above.
+        unsafe {
+            std::env::set_var(ENV_LIGHTPANDA_PATH, "/x/lightpanda");
+        }
+        let c = load_from_yaml("", Path::new("/nonexistent"));
+        assert_eq!(c.browser.lightpanda_path.as_deref(), Some("/x/lightpanda"));
+        unsafe {
+            std::env::remove_var(ENV_LIGHTPANDA_PATH);
+        }
+    }
+
+    #[test]
+    fn lightpanda_default_path_absent_when_not_on_disk() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let c = load_from_yaml("", Path::new("/nonexistent"));
+        assert_eq!(c.browser.lightpanda_path, None);
+    }
+
+    #[test]
+    fn mur_home_dir_honors_mur_home_env() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: env mutation guarded by ENV_LOCK above.
+        unsafe {
+            std::env::set_var("MUR_HOME", "/tmp/mur-research-gateway-test-home");
+        }
+        assert_eq!(
+            mur_home_dir(),
+            PathBuf::from("/tmp/mur-research-gateway-test-home")
+        );
+        unsafe {
+            std::env::remove_var("MUR_HOME");
+        }
+    }
+}

--- a/mur-research-gateway/src/config.rs
+++ b/mur-research-gateway/src/config.rs
@@ -18,6 +18,7 @@
 // `ConversationsConfig` demonstrates for a single section.
 
 use crate::browser::BrowserCfg;
+use mur_common::agent::ENV_MCP_DENY_HOSTS as ENV_DENY_HOSTS;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -61,7 +62,12 @@ pub const DEFAULT_LIGHTPANDA_RELATIVE_PATH: &str = "aura/lightpanda";
 
 // ---- env var names ----
 
-const ENV_DENY_HOSTS: &str = "MUR_RESEARCH_DENY_HOSTS";
+// ENV_DENY_HOSTS (imported above as `ENV_MCP_DENY_HOSTS`) is shared with
+// `mur-agent-runtime`'s `proxy_env_for`, which sets it on this gateway's own
+// child env when the operator grants a `--deny-host` overlay — single
+// definition in mur-common so the two crates can never drift (CLAUDE.md
+// rule 1).
+
 const ENV_FETCH_TIMEOUT_SECS: &str = "MUR_RESEARCH_TIMEOUT_SECS";
 const ENV_BROWSER_TIMEOUT_SECS: &str = "MUR_RESEARCH_BROWSER_TIMEOUT_SECS";
 const ENV_SEARCH_LIMIT: &str = "MUR_RESEARCH_SEARCH_LIMIT";

--- a/mur-research-gateway/src/fetcher.rs
+++ b/mur-research-gateway/src/fetcher.rs
@@ -3,7 +3,9 @@ use crate::net_guard::{self, GuardReject};
 use serde::Serialize;
 use std::time::Duration;
 
-const MAX_BODY_BYTES: usize = 5 * 1024 * 1024; // ponytail: 5MB cap; config if a real doc exceeds it
+// pub(crate) so browser.rs (tiers 2/3) enforces the SAME body cap on
+// agent-browser stdout that tier-1 enforces on the HTTP body.
+pub(crate) const MAX_BODY_BYTES: usize = 5 * 1024 * 1024; // ponytail: 5MB cap; config if a real doc exceeds it
 
 #[derive(Debug, Serialize)]
 pub struct FetchResult {

--- a/mur-research-gateway/src/fetcher.rs
+++ b/mur-research-gateway/src/fetcher.rs
@@ -33,6 +33,13 @@ async fn screen_url_blocking(url: &str, deny: &[String]) -> Result<url::Url, Gua
         .unwrap_or(Err(GuardReject::Unresolvable)) // join error (panic) — treat as unresolvable, fail closed
 }
 
+/// True if appending `chunk_len` bytes to a `current_len`-byte buffer would push
+/// the running total past `max`. Extracted so the streaming cap decision is unit
+/// testable without a live oversized HTTP body.
+fn would_exceed(current_len: usize, chunk_len: usize, max: usize) -> bool {
+    current_len.saturating_add(chunk_len) > max
+}
+
 pub async fn fetch_tier1(
     url: &str,
     deny: &[String],
@@ -41,27 +48,47 @@ pub async fn fetch_tier1(
     let screened = screen_url_blocking(url, deny)
         .await
         .map_err(FetchError::Guard)?;
-    // ponytail: reqwest re-resolves internally; screen_url already rejected
-    // private targets. A pinned-IP resolver closes the rebinding window fully —
-    // upgrade to reqwest::dns::Resolve if the advisory window matters.
+    // ADVISORY SSRF enforcement (egress-governance spec): screen_url screens the
+    // IPs resolved AT SCREEN TIME, but reqwest re-resolves the host at connect
+    // time — client.get(screened) does NOT pin to the screened IP — so a
+    // DNS-rebinding window between screen and connect remains open. This is
+    // acceptable per the spec's advisory tier; airtight pin-to-proxy is Phase 3.
+    // TODO(Phase 3): pin the connection to the screened IP via a custom
+    // reqwest::dns::Resolve to close the DNS-rebinding window.
     let client = reqwest::Client::builder()
         .timeout(timeout)
         .redirect(reqwest::redirect::Policy::none()) // no auto-redirect: each hop must be re-screened by the worker
         .build()
         .map_err(|e| FetchError::Http(e.to_string()))?;
-    let resp = client
+    let mut resp = client
         .get(screened.clone())
         .send()
         .await
         .map_err(|e| FetchError::Http(e.to_string()))?;
     let status = resp.status().as_u16();
-    let body = resp
-        .text()
-        .await
-        .map_err(|e| FetchError::Http(e.to_string()))?;
-    if body.len() > MAX_BODY_BYTES {
+
+    // Fast-reject on advertised size before reading a single body byte.
+    if let Some(len) = resp.content_length()
+        && len > MAX_BODY_BYTES as u64
+    {
         return Err(FetchError::TooLarge);
     }
+
+    // Stream and enforce the cap incrementally: a lying/absent Content-Length
+    // must never let us buffer an unbounded body (resp.text() would OOM here).
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?
+    {
+        if would_exceed(buf.len(), chunk.len(), MAX_BODY_BYTES) {
+            return Err(FetchError::TooLarge);
+        }
+        buf.extend_from_slice(&chunk);
+    }
+
+    let body = String::from_utf8_lossy(&buf);
     let title = extract_title(&body);
     Ok(FetchResult {
         url: screened.to_string(),
@@ -117,5 +144,17 @@ mod tests {
         .await
         .unwrap_err();
         assert!(matches!(e, FetchError::Guard(GuardReject::DeniedHost)));
+    }
+
+    #[test]
+    fn body_cap_would_exceed() {
+        // Under the cap: appending stays within budget.
+        assert!(!would_exceed(0, MAX_BODY_BYTES, MAX_BODY_BYTES));
+        assert!(!would_exceed(MAX_BODY_BYTES - 10, 10, MAX_BODY_BYTES));
+        // At/over the cap: one byte past the budget is rejected.
+        assert!(would_exceed(MAX_BODY_BYTES, 1, MAX_BODY_BYTES));
+        assert!(would_exceed(MAX_BODY_BYTES - 10, 11, MAX_BODY_BYTES));
+        // Saturating add: a huge chunk can't wrap around to look small.
+        assert!(would_exceed(1, usize::MAX, MAX_BODY_BYTES));
     }
 }

--- a/mur-research-gateway/src/fetcher.rs
+++ b/mur-research-gateway/src/fetcher.rs
@@ -25,7 +25,13 @@ pub enum FetchError {
 /// `to_socket_addrs()` (synchronous DNS resolution); running it inline on an
 /// async fn would stall the worker for the duration of the resolve. `deny` is
 /// cloned into the blocking task since `spawn_blocking` requires `'static`.
-async fn screen_url_blocking(url: &str, deny: &[String]) -> Result<url::Url, GuardReject> {
+///
+/// `pub(crate)` so `browser.rs` (tiers 2/3) can reuse the same off-thread
+/// pre-spawn screen instead of duplicating the wrapper.
+pub(crate) async fn screen_url_blocking(
+    url: &str,
+    deny: &[String],
+) -> Result<url::Url, GuardReject> {
     let url = url.to_string();
     let deny = deny.to_vec();
     tokio::task::spawn_blocking(move || net_guard::screen_url(&url, &deny))

--- a/mur-research-gateway/src/fetcher.rs
+++ b/mur-research-gateway/src/fetcher.rs
@@ -1,0 +1,121 @@
+// mur-research-gateway/src/fetcher.rs
+use crate::net_guard::{self, GuardReject};
+use serde::Serialize;
+use std::time::Duration;
+
+const MAX_BODY_BYTES: usize = 5 * 1024 * 1024; // ponytail: 5MB cap; config if a real doc exceeds it
+
+#[derive(Debug, Serialize)]
+pub struct FetchResult {
+    pub url: String,
+    pub status: u16,
+    pub title: Option<String>,
+    pub text: String,
+    pub tier: u8,
+}
+
+#[derive(Debug)]
+pub enum FetchError {
+    Guard(GuardReject),
+    Http(String),
+    TooLarge,
+}
+
+/// Screen `url` off the tokio worker thread. `screen_url` calls the blocking
+/// `to_socket_addrs()` (synchronous DNS resolution); running it inline on an
+/// async fn would stall the worker for the duration of the resolve. `deny` is
+/// cloned into the blocking task since `spawn_blocking` requires `'static`.
+async fn screen_url_blocking(url: &str, deny: &[String]) -> Result<url::Url, GuardReject> {
+    let url = url.to_string();
+    let deny = deny.to_vec();
+    tokio::task::spawn_blocking(move || net_guard::screen_url(&url, &deny))
+        .await
+        .unwrap_or(Err(GuardReject::Unresolvable)) // join error (panic) — treat as unresolvable, fail closed
+}
+
+pub async fn fetch_tier1(
+    url: &str,
+    deny: &[String],
+    timeout: Duration,
+) -> Result<FetchResult, FetchError> {
+    let screened = screen_url_blocking(url, deny)
+        .await
+        .map_err(FetchError::Guard)?;
+    // ponytail: reqwest re-resolves internally; screen_url already rejected
+    // private targets. A pinned-IP resolver closes the rebinding window fully —
+    // upgrade to reqwest::dns::Resolve if the advisory window matters.
+    let client = reqwest::Client::builder()
+        .timeout(timeout)
+        .redirect(reqwest::redirect::Policy::none()) // no auto-redirect: each hop must be re-screened by the worker
+        .build()
+        .map_err(|e| FetchError::Http(e.to_string()))?;
+    let resp = client
+        .get(screened.clone())
+        .send()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?;
+    let status = resp.status().as_u16();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?;
+    if body.len() > MAX_BODY_BYTES {
+        return Err(FetchError::TooLarge);
+    }
+    let title = extract_title(&body);
+    Ok(FetchResult {
+        url: screened.to_string(),
+        status,
+        title,
+        text: html_to_text(&body),
+        tier: 1,
+    })
+}
+
+fn extract_title(html: &str) -> Option<String> {
+    let lower = html.to_ascii_lowercase();
+    let start = lower.find("<title>")? + 7;
+    let end = lower[start..].find("</title>")? + start;
+    Some(html[start..end].trim().to_string())
+}
+
+// ponytail: naive tag-strip. Good enough for claim extraction; swap for a real
+// readability crate only if extraction quality measurably suffers.
+fn html_to_text(html: &str) -> String {
+    let mut out = String::with_capacity(html.len() / 2);
+    let mut in_tag = false;
+    for c in html.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn refuses_private_target() {
+        let e = fetch_tier1("http://127.0.0.1:1/", &[], Duration::from_secs(2))
+            .await
+            .unwrap_err();
+        assert!(matches!(e, FetchError::Guard(_)));
+    }
+    #[tokio::test]
+    async fn refuses_denied_host() {
+        let e = fetch_tier1(
+            "http://blocked.example/",
+            &["blocked.example".into()],
+            Duration::from_secs(2),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(e, FetchError::Guard(GuardReject::DeniedHost)));
+    }
+}

--- a/mur-research-gateway/src/jsonrpc.rs
+++ b/mur-research-gateway/src/jsonrpc.rs
@@ -1,0 +1,128 @@
+// mur-research-gateway/src/jsonrpc.rs
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::io::{BufRead, Write};
+
+/// JSON-RPC 2.0 request (what the client sends us).
+#[derive(Debug, Deserialize)]
+pub struct Request {
+    #[allow(dead_code)]
+    pub jsonrpc: String,
+    pub id: Option<Value>,
+    pub method: String,
+    // Unused until tools/call gains real dispatch logic (Tasks 2-5).
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub params: Option<Value>,
+}
+
+/// JSON-RPC 2.0 success response.
+#[derive(Debug, Serialize)]
+pub struct Response {
+    pub jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl Response {
+    pub fn success(id: Option<Value>, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn error(id: Option<Value>, code: i32, message: String) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: None,
+            error: Some(JsonRpcError {
+                code,
+                message,
+                data: None,
+            }),
+        }
+    }
+}
+
+/// Read one JSON-RPC request from stdin. Blocks until a complete line.
+/// Returns None if stdin closes.
+pub fn read_request() -> Option<Request> {
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    match stdin.lock().read_line(&mut line) {
+        Ok(0) => None, // EOF
+        Ok(_) => {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                return read_request(); // skip blank lines
+            }
+            match serde_json::from_str::<Request>(trimmed) {
+                Ok(req) => {
+                    tracing::debug!(method = %req.method, id = ?req.id, "received request");
+                    Some(req)
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, raw = %trimmed, "failed to parse request");
+                    // Return a parse-error-shaped request so the caller can respond
+                    Some(Request {
+                        jsonrpc: "2.0".into(),
+                        id: None,
+                        method: String::new(),
+                        params: None,
+                    })
+                }
+            }
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "stdin read error");
+            None
+        }
+    }
+}
+
+/// Write one JSON-RPC response to stdout. One line per response.
+pub fn write_response(resp: &Response) {
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    let json = serde_json::to_string(resp).unwrap_or_else(|e| {
+        serde_json::to_string(&Response::error(
+            None,
+            -32700,
+            format!("failed to serialize response: {}", e),
+        ))
+        .unwrap()
+    });
+    writeln!(handle, "{}", json).ok();
+    handle.flush().ok();
+    tracing::debug!(json = %json, "sent response");
+}
+
+/// Write a JSON-RPC notification (no id, no response expected).
+#[allow(dead_code)]
+pub fn write_notification(method: &str, params: Value) {
+    let notif = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+    });
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    writeln!(handle, "{}", serde_json::to_string(&notif).unwrap()).ok();
+    handle.flush().ok();
+}

--- a/mur-research-gateway/src/main.rs
+++ b/mur-research-gateway/src/main.rs
@@ -3,6 +3,7 @@ use tracing_subscriber::EnvFilter;
 
 mod audit;
 mod browser;
+mod config;
 mod fetcher;
 mod jsonrpc;
 mod net_guard;
@@ -20,10 +21,16 @@ async fn main() {
 
     tracing::info!("mur-research-gateway starting");
 
+    // Config (env + ~/.mur/config.yaml's research_gateway: block) is loaded
+    // ONCE here, inside McpServer::new — see config.rs. Preflight below reads
+    // it back via `browser_cfg()` rather than loading its own copy, so
+    // startup logging always reflects the exact config the server will use.
+    let mut server = server::McpServer::new();
+
     // Preflight the browser toolchain once at startup so a missing/stale
     // agent-browser or absent Lightpanda is surfaced explicitly (never
     // silently) — degrade to tier 1 only, not "as if Full" (spec §5).
-    match browser::preflight(&server::browser_cfg_from_env()) {
+    match browser::preflight(server.browser_cfg()) {
         browser::Preflight::Full => {
             tracing::info!("browser preflight: full — tiers 2/3 (lightpanda/chrome) available")
         }
@@ -32,8 +39,6 @@ async fn main() {
             other
         ),
     }
-
-    let mut server = server::McpServer::new();
 
     while let Some(request) = jsonrpc::read_request() {
         // JSON-RPC notifications (no `id`, e.g. `notifications/initialized`) must

--- a/mur-research-gateway/src/main.rs
+++ b/mur-research-gateway/src/main.rs
@@ -1,6 +1,7 @@
 // mur-research-gateway/src/main.rs
 use tracing_subscriber::EnvFilter;
 
+mod fetcher;
 mod jsonrpc;
 mod net_guard;
 mod server;

--- a/mur-research-gateway/src/main.rs
+++ b/mur-research-gateway/src/main.rs
@@ -1,6 +1,7 @@
 // mur-research-gateway/src/main.rs
 use tracing_subscriber::EnvFilter;
 
+mod audit;
 mod browser;
 mod fetcher;
 mod jsonrpc;

--- a/mur-research-gateway/src/main.rs
+++ b/mur-research-gateway/src/main.rs
@@ -1,6 +1,7 @@
 // mur-research-gateway/src/main.rs
 use tracing_subscriber::EnvFilter;
 
+mod browser;
 mod fetcher;
 mod jsonrpc;
 mod net_guard;
@@ -17,6 +18,19 @@ async fn main() {
         .init();
 
     tracing::info!("mur-research-gateway starting");
+
+    // Preflight the browser toolchain once at startup so a missing/stale
+    // agent-browser or absent Lightpanda is surfaced explicitly (never
+    // silently) — degrade to tier 1 only, not "as if Full" (spec §5).
+    match browser::preflight(&server::browser_cfg_from_env()) {
+        browser::Preflight::Full => {
+            tracing::info!("browser preflight: full — tiers 2/3 (lightpanda/chrome) available")
+        }
+        other => tracing::warn!(
+            "browser preflight degraded: {:?} — render/search fall back to tier 1 only",
+            other
+        ),
+    }
 
     let mut server = server::McpServer::new();
 

--- a/mur-research-gateway/src/main.rs
+++ b/mur-research-gateway/src/main.rs
@@ -1,0 +1,32 @@
+// mur-research-gateway/src/main.rs
+use tracing_subscriber::EnvFilter;
+
+mod jsonrpc;
+mod server;
+mod tools;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
+        )
+        .with_writer(std::io::stderr) // logs to stderr so stdout stays clean for JSON-RPC
+        .init();
+
+    tracing::info!("mur-research-gateway starting");
+
+    let mut server = server::McpServer::new();
+
+    while let Some(request) = jsonrpc::read_request() {
+        // JSON-RPC notifications (no `id`, e.g. `notifications/initialized`) must
+        // NOT receive a response. Compute this before `request` is moved into handle.
+        let is_notification = request.id.is_none() && request.method.starts_with("notifications/");
+        let response = server.handle(request).await;
+        if !is_notification {
+            jsonrpc::write_response(&response);
+        }
+    }
+
+    tracing::info!("mur-research-gateway shutting down");
+}

--- a/mur-research-gateway/src/main.rs
+++ b/mur-research-gateway/src/main.rs
@@ -2,6 +2,7 @@
 use tracing_subscriber::EnvFilter;
 
 mod jsonrpc;
+mod net_guard;
 mod server;
 mod tools;
 

--- a/mur-research-gateway/src/net_guard.rs
+++ b/mur-research-gateway/src/net_guard.rs
@@ -49,9 +49,12 @@ pub fn is_forbidden_target(ip: IpAddr) -> bool {
     }
 }
 
-/// Parse + screen a URL. On pass returns the parsed URL; the caller MUST pin
-/// its connection to an already-screened address (see Task 3) to close the
-/// resolve→connect TOCTOU (DNS-rebinding) window.
+/// Parse + screen a URL against the deny list and the resolved IPs. On pass
+/// returns the parsed URL. NOTE: this screens the IPs resolved AT SCREEN TIME
+/// only — it does NOT pin the connection. The caller (`fetcher.rs`) hands the
+/// URL to reqwest, which re-resolves at connect time, so a resolve→connect
+/// DNS-rebinding window remains. This is advisory enforcement per the
+/// egress-governance spec; pin-to-proxy (airtight) is Phase 3.
 pub fn screen_url(raw: &str, deny: &[String]) -> Result<url::Url, GuardReject> {
     let u = url::Url::parse(raw).map_err(|_| GuardReject::BadScheme)?;
     if !matches!(u.scheme(), "http" | "https") {

--- a/mur-research-gateway/src/net_guard.rs
+++ b/mur-research-gateway/src/net_guard.rs
@@ -1,0 +1,132 @@
+//! Strict SSRF guard for the research gateway's `fetch` tool.
+//!
+//! Not yet wired into `tools.rs`/`server.rs` — the caller must pin its
+//! connection to an already-screened address (closing the resolve→connect
+//! DNS-rebinding TOCTOU window), which lands in Task 3. `#[allow(dead_code)]`
+//! below is scaffolding until that wiring lands.
+#![allow(dead_code)]
+
+use std::net::{IpAddr, ToSocketAddrs};
+
+#[derive(Debug, PartialEq)]
+pub enum GuardReject {
+    BadScheme,
+    DeniedHost,
+    PrivateAddress,
+    Unresolvable,
+}
+
+/// Deny semantics via the shared matcher (single source of truth with the
+/// egress proxy — `mur_common::net`). Same matcher; the deny LIST is what
+/// makes a match mean "blocked".
+pub fn host_denied(host: &str, deny: &[String]) -> bool {
+    mur_common::net::host_allowed(host, deny)
+}
+
+/// STRICTER than the runtime's local-first guard: a web researcher has no
+/// legitimate reason to reach loopback/private/link-local, so all are forbidden.
+pub fn is_forbidden_target(ip: IpAddr) -> bool {
+    // Normalize IPv4-in-IPv6 (mapped ::ffff:a.b.c.d and compatible ::a.b.c.d).
+    let ip = match ip {
+        IpAddr::V6(v6) => v6.to_ipv4().map_or(IpAddr::V6(v6), IpAddr::V4),
+        v4 => v4,
+    };
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.octets()[0] == 0 // 0.0.0.0/8
+        }
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || (v6.segments()[0] & 0xffc0) == 0xfe80 // link-local fe80::/10
+                || (v6.segments()[0] & 0xfe00) == 0xfc00 // ULA fc00::/7
+        }
+    }
+}
+
+/// Parse + screen a URL. On pass returns the parsed URL; the caller MUST pin
+/// its connection to an already-screened address (see Task 3) to close the
+/// resolve→connect TOCTOU (DNS-rebinding) window.
+pub fn screen_url(raw: &str, deny: &[String]) -> Result<url::Url, GuardReject> {
+    let u = url::Url::parse(raw).map_err(|_| GuardReject::BadScheme)?;
+    if !matches!(u.scheme(), "http" | "https") {
+        return Err(GuardReject::BadScheme);
+    }
+    let host = u.host_str().ok_or(GuardReject::BadScheme)?;
+    if host_denied(host, deny) {
+        return Err(GuardReject::DeniedHost);
+    }
+    let port = u.port_or_known_default().unwrap_or(80);
+    let mut any = false;
+    for sa in (host, port)
+        .to_socket_addrs()
+        .map_err(|_| GuardReject::Unresolvable)?
+    {
+        any = true;
+        if is_forbidden_target(sa.ip()) {
+            return Err(GuardReject::PrivateAddress);
+        }
+    }
+    if !any {
+        return Err(GuardReject::Unresolvable);
+    }
+    Ok(u)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::IpAddr;
+
+    #[test]
+    fn blocks_cloud_metadata_and_private_and_loopback() {
+        for ip in [
+            "169.254.169.254",
+            "127.0.0.1",
+            "10.0.0.5",
+            "192.168.1.1",
+            "172.16.0.1",
+            "::1",
+            "fe80::1",
+            "::ffff:169.254.169.254",
+        ] {
+            assert!(
+                is_forbidden_target(ip.parse::<IpAddr>().unwrap()),
+                "{ip} must be forbidden"
+            );
+        }
+    }
+    #[test]
+    fn allows_public() {
+        for ip in ["8.8.8.8", "203.0.113.7", "2606:4700:4700::1111"] {
+            assert!(
+                !is_forbidden_target(ip.parse::<IpAddr>().unwrap()),
+                "{ip} must be allowed"
+            );
+        }
+    }
+    #[test]
+    fn deny_host_patterns() {
+        let deny = vec!["*.internal.corp".to_string(), "blocked.example".to_string()];
+        assert!(host_denied("api.internal.corp", &deny));
+        assert!(host_denied("internal.corp", &deny));
+        assert!(host_denied("blocked.example", &deny));
+        assert!(!host_denied("good.example", &deny));
+    }
+    #[test]
+    fn screen_rejects_bad_scheme_and_denied() {
+        assert!(matches!(
+            screen_url("file:///etc/passwd", &[]),
+            Err(GuardReject::BadScheme)
+        ));
+        assert!(matches!(
+            screen_url("http://blocked.example/", &["blocked.example".into()]),
+            Err(GuardReject::DeniedHost)
+        ));
+    }
+}

--- a/mur-research-gateway/src/net_guard.rs
+++ b/mur-research-gateway/src/net_guard.rs
@@ -1,10 +1,10 @@
 //! Strict SSRF guard for the research gateway's `fetch` tool.
 //!
-//! Not yet wired into `tools.rs`/`server.rs` — the caller must pin its
-//! connection to an already-screened address (closing the resolve→connect
-//! DNS-rebinding TOCTOU window), which lands in Task 3. `#[allow(dead_code)]`
-//! below is scaffolding until that wiring lands.
-#![allow(dead_code)]
+//! Wired into `fetcher.rs` (Task 3) behind `tokio::task::spawn_blocking`,
+//! since `to_socket_addrs()` below is synchronous DNS resolution. The caller
+//! still does NOT pin its connection to the screened address — reqwest
+//! re-resolves internally, leaving an advisory (not exploited-in-practice)
+//! resolve→connect DNS-rebinding window; see the comment in `fetcher.rs`.
 
 use std::net::{IpAddr, ToSocketAddrs};
 
@@ -62,8 +62,12 @@ pub fn screen_url(raw: &str, deny: &[String]) -> Result<url::Url, GuardReject> {
         return Err(GuardReject::DeniedHost);
     }
     let port = u.port_or_known_default().unwrap_or(80);
+    // url::Url::host_str() returns IPv6 literals WITH brackets (e.g. "[::1]"),
+    // which ToSocketAddrs' IP fast-path can't parse — it would silently fall
+    // through to DNS resolution (and fail) instead of screening the literal.
+    let resolve_host = host.trim_start_matches('[').trim_end_matches(']');
     let mut any = false;
-    for sa in (host, port)
+    for sa in (resolve_host, port)
         .to_socket_addrs()
         .map_err(|_| GuardReject::Unresolvable)?
     {
@@ -127,6 +131,16 @@ mod tests {
         assert!(matches!(
             screen_url("http://blocked.example/", &["blocked.example".into()]),
             Err(GuardReject::DeniedHost)
+        ));
+    }
+    #[test]
+    fn screen_rejects_ipv4_compatible_ipv6_metadata() {
+        // `::169.254.169.254` (no `::ffff:` marker) is the deprecated
+        // IPv4-compatible IPv6 form — a named SSRF bypass distinct from the
+        // IPv4-mapped `::ffff:` form already covered above.
+        assert!(matches!(
+            screen_url("http://[::169.254.169.254]/", &[]),
+            Err(GuardReject::PrivateAddress)
         ));
     }
 }

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -194,9 +194,10 @@ impl McpServer {
             .map(|v| v as usize)
             .unwrap_or(self.config.search_limit)
             .clamp(config::MIN_SEARCH_LIMIT, config::MAX_SEARCH_LIMIT);
+        let deny = &self.config.deny_hosts;
         let cfg = &self.config.browser;
         let timeout = self.config.browser_timeout;
-        match browser::search(&query, limit, cfg, timeout).await {
+        match browser::search(&query, limit, deny, cfg, timeout).await {
             Ok(hits) => {
                 audit(AuditRecord::new("search", query, None, "ok"));
                 Response::success(

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -1,4 +1,5 @@
 // mur-research-gateway/src/server.rs
+use crate::browser::{self, BrowserCfg};
 use crate::fetcher::{self, FetchError};
 use crate::jsonrpc::{Request, Response};
 use crate::tools;
@@ -25,6 +26,48 @@ fn timeout_from_env() -> Duration {
         .and_then(|v| v.parse::<u64>().ok())
         .unwrap_or(20);
     Duration::from_secs(secs)
+}
+
+/// Default installed Lightpanda path (`~/.mur/aura/lightpanda`, verified
+/// present 2026-07-08 — `gotcha_agent_browser_lightpanda_engine_dead`). Only
+/// used when `MUR_RESEARCH_LIGHTPANDA_PATH` is unset AND the default actually
+/// exists on disk — never claim a path that isn't there.
+// TODO(Task 6): read from config.yaml
+fn default_lightpanda_path() -> Option<String> {
+    let home = std::env::var("HOME").ok()?;
+    let path = format!("{home}/.mur/aura/lightpanda");
+    std::path::Path::new(&path).exists().then_some(path)
+}
+
+// TODO(Task 6): read from config.yaml
+pub(crate) fn browser_cfg_from_env() -> BrowserCfg {
+    let agent_browser_bin = std::env::var("MUR_RESEARCH_AGENT_BROWSER_BIN")
+        .unwrap_or_else(|_| "agent-browser".to_string());
+    let lightpanda_path = std::env::var("MUR_RESEARCH_LIGHTPANDA_PATH")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(default_lightpanda_path);
+    let chrome_stealth_args = std::env::var("MUR_RESEARCH_CHROME_STEALTH_ARGS")
+        .unwrap_or_else(|_| "--no-sandbox,--disable-blink-features=AutomationControlled".into());
+    BrowserCfg {
+        agent_browser_bin,
+        lightpanda_path,
+        chrome_stealth_args,
+    }
+}
+
+fn fetch_error_response(id: Option<serde_json::Value>, verb: &str, err: FetchError) -> Response {
+    match err {
+        FetchError::Guard(reject) => Response::error(
+            id,
+            -32000,
+            format!("{verb} blocked by SSRF guard: {:?}", reject),
+        ),
+        FetchError::Http(msg) => Response::error(id, -32001, format!("{verb} failed: {msg}")),
+        FetchError::TooLarge => {
+            Response::error(id, -32002, format!("{verb} response exceeded size cap"))
+        }
+    }
 }
 
 pub struct McpServer;
@@ -86,7 +129,7 @@ impl McpServer {
             .unwrap_or_else(|| serde_json::json!({}));
         match name {
             "fetch" => self.handle_fetch(id, args).await,
-            "search" => Response::error(id, -32601, "search: not implemented yet".to_string()),
+            "search" => self.handle_search(id, args).await,
             _ => Response::error(id, -32602, format!("Unknown tool: {}", name)),
         }
     }
@@ -104,32 +147,65 @@ impl McpServer {
             .get("render")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        if render {
-            // Headless-render tier is a later task; tier-1 handles render=false/absent only.
-            return Response::error(
-                id,
-                -32601,
-                "fetch: render=true (tier-2) not implemented yet".to_string(),
-            );
-        }
         let deny = deny_hosts_from_env();
+        if render {
+            // Caller may force tier 3 (chrome) directly, e.g. for anti-bot pages
+            // known to defeat lightpanda; otherwise tier 2 first, escalating to
+            // tier 3 only on an actual fetch failure (Http) — Guard/TooLarge
+            // outcomes are tier-independent, so retrying under chrome can't help.
+            let want_chrome = args
+                .get("chrome")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let cfg = browser_cfg_from_env();
+            return match browser::fetch_rendered(&url, &deny, &cfg, want_chrome).await {
+                Ok(result) => Response::success(
+                    id,
+                    serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
+                ),
+                Err(FetchError::Http(_)) if !want_chrome => {
+                    match browser::fetch_rendered(&url, &deny, &cfg, true).await {
+                        Ok(result) => Response::success(
+                            id,
+                            serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
+                        ),
+                        Err(e) => fetch_error_response(id, "fetch (tier 3)", e),
+                    }
+                }
+                Err(e) => fetch_error_response(id, "fetch (rendered)", e),
+            };
+        }
         let timeout = timeout_from_env();
         match fetcher::fetch_tier1(&url, &deny, timeout).await {
             Ok(result) => Response::success(
                 id,
                 serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
             ),
-            Err(FetchError::Guard(reject)) => Response::error(
+            Err(e) => fetch_error_response(id, "fetch", e),
+        }
+    }
+
+    async fn handle_search(
+        &mut self,
+        id: Option<serde_json::Value>,
+        args: serde_json::Value,
+    ) -> Response {
+        let query = match args.get("query").and_then(|v| v.as_str()) {
+            Some(q) => q.to_string(),
+            None => return Response::error(id, -32602, "search requires 'query'".to_string()),
+        };
+        let limit = args
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(5)
+            .clamp(1, 20) as usize;
+        let cfg = browser_cfg_from_env();
+        match browser::search(&query, limit, &cfg).await {
+            Ok(hits) => Response::success(
                 id,
-                -32000,
-                format!("fetch blocked by SSRF guard: {:?}", reject),
+                serde_json::to_value(hits).unwrap_or(serde_json::Value::Null),
             ),
-            Err(FetchError::Http(msg)) => {
-                Response::error(id, -32001, format!("fetch failed: {}", msg))
-            }
-            Err(FetchError::TooLarge) => {
-                Response::error(id, -32002, "fetch response exceeded size cap".to_string())
-            }
+            Err(e) => fetch_error_response(id, "search", e),
         }
     }
 }

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -1,6 +1,31 @@
 // mur-research-gateway/src/server.rs
+use crate::fetcher::{self, FetchError};
 use crate::jsonrpc::{Request, Response};
 use crate::tools;
+use std::time::Duration;
+
+/// Interim config (Task placeholder): env vars until config.yaml lands (Task 6).
+// TODO(Task 6): read from config.yaml
+fn deny_hosts_from_env() -> Vec<String> {
+    std::env::var("MUR_RESEARCH_DENY_HOSTS")
+        .ok()
+        .map(|v| {
+            v.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// TODO(Task 6): read from config.yaml
+fn timeout_from_env() -> Duration {
+    let secs = std::env::var("MUR_RESEARCH_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(20);
+    Duration::from_secs(secs)
+}
 
 pub struct McpServer;
 
@@ -29,7 +54,7 @@ impl McpServer {
                     .collect();
                 Response::success(request.id, serde_json::json!({ "tools": tools }))
             }
-            "tools/call" => Response::error(request.id, -32601, "not implemented yet".to_string()),
+            "tools/call" => self.handle_tool_call(request.id, request.params).await,
             "notifications/initialized" => Response {
                 jsonrpc: "2.0",
                 id: None,
@@ -44,10 +69,127 @@ impl McpServer {
             ),
         }
     }
+
+    async fn handle_tool_call(
+        &mut self,
+        id: Option<serde_json::Value>,
+        params: Option<serde_json::Value>,
+    ) -> Response {
+        let params = match params {
+            Some(p) => p,
+            None => return Response::error(id, -32602, "tools/call requires params".to_string()),
+        };
+        let name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let args = params
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        match name {
+            "fetch" => self.handle_fetch(id, args).await,
+            "search" => Response::error(id, -32601, "search: not implemented yet".to_string()),
+            _ => Response::error(id, -32602, format!("Unknown tool: {}", name)),
+        }
+    }
+
+    async fn handle_fetch(
+        &mut self,
+        id: Option<serde_json::Value>,
+        args: serde_json::Value,
+    ) -> Response {
+        let url = match args.get("url").and_then(|v| v.as_str()) {
+            Some(u) => u.to_string(),
+            None => return Response::error(id, -32602, "fetch requires 'url'".to_string()),
+        };
+        let render = args
+            .get("render")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if render {
+            // Headless-render tier is a later task; tier-1 handles render=false/absent only.
+            return Response::error(
+                id,
+                -32601,
+                "fetch: render=true (tier-2) not implemented yet".to_string(),
+            );
+        }
+        let deny = deny_hosts_from_env();
+        let timeout = timeout_from_env();
+        match fetcher::fetch_tier1(&url, &deny, timeout).await {
+            Ok(result) => Response::success(
+                id,
+                serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
+            ),
+            Err(FetchError::Guard(reject)) => Response::error(
+                id,
+                -32000,
+                format!("fetch blocked by SSRF guard: {:?}", reject),
+            ),
+            Err(FetchError::Http(msg)) => {
+                Response::error(id, -32001, format!("fetch failed: {}", msg))
+            }
+            Err(FetchError::TooLarge) => {
+                Response::error(id, -32002, "fetch response exceeded size cap".to_string())
+            }
+        }
+    }
 }
 
 impl Default for McpServer {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(method: &str, params: Option<serde_json::Value>) -> Request {
+        Request {
+            jsonrpc: "2.0".into(),
+            id: Some(serde_json::json!(1)),
+            method: method.to_string(),
+            params,
+        }
+    }
+
+    #[tokio::test]
+    async fn fetch_call_rejects_private_target() {
+        let mut server = McpServer::new();
+        let resp = server
+            .handle(req(
+                "tools/call",
+                Some(serde_json::json!({"name": "fetch", "arguments": {"url": "http://127.0.0.1:1/"}})),
+            ))
+            .await;
+        assert!(
+            resp.error.is_some(),
+            "expected guard rejection, got {:?}",
+            resp
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_call_missing_url_errors() {
+        let mut server = McpServer::new();
+        let resp = server
+            .handle(req(
+                "tools/call",
+                Some(serde_json::json!({"name": "fetch", "arguments": {}})),
+            ))
+            .await;
+        assert!(resp.error.is_some());
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_errors() {
+        let mut server = McpServer::new();
+        let resp = server
+            .handle(req(
+                "tools/call",
+                Some(serde_json::json!({"name": "nope", "arguments": {}})),
+            ))
+            .await;
+        assert!(resp.error.is_some());
     }
 }

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -1,0 +1,53 @@
+// mur-research-gateway/src/server.rs
+use crate::jsonrpc::{Request, Response};
+use crate::tools;
+
+pub struct McpServer;
+
+impl McpServer {
+    pub fn new() -> Self {
+        McpServer
+    }
+
+    pub async fn handle(&mut self, request: Request) -> Response {
+        match request.method.as_str() {
+            "initialize" => Response::success(
+                request.id,
+                serde_json::json!({
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {
+                        "name": "mur-research-gateway",
+                        "version": env!("CARGO_PKG_VERSION"),
+                    },
+                }),
+            ),
+            "tools/list" => {
+                let tools: Vec<serde_json::Value> = tools::all_tools()
+                    .iter()
+                    .map(|t| serde_json::to_value(t).unwrap_or(serde_json::Value::Null))
+                    .collect();
+                Response::success(request.id, serde_json::json!({ "tools": tools }))
+            }
+            "tools/call" => Response::error(request.id, -32601, "not implemented yet".to_string()),
+            "notifications/initialized" => Response {
+                jsonrpc: "2.0",
+                id: None,
+                result: None,
+                error: None,
+            },
+            "" => Response::error(request.id, -32700, "Parse error".to_string()),
+            _ => Response::error(
+                request.id,
+                -32601,
+                format!("Method not found: {}", request.method),
+            ),
+        }
+    }
+}
+
+impl Default for McpServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -148,6 +148,7 @@ impl McpServer {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
         let deny = deny_hosts_from_env();
+        let timeout = timeout_from_env();
         if render {
             // Caller may force tier 3 (chrome) directly, e.g. for anti-bot pages
             // known to defeat lightpanda; otherwise tier 2 first, escalating to
@@ -158,13 +159,13 @@ impl McpServer {
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             let cfg = browser_cfg_from_env();
-            return match browser::fetch_rendered(&url, &deny, &cfg, want_chrome).await {
+            return match browser::fetch_rendered(&url, &deny, &cfg, want_chrome, timeout).await {
                 Ok(result) => Response::success(
                     id,
                     serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
                 ),
                 Err(FetchError::Http(_)) if !want_chrome => {
-                    match browser::fetch_rendered(&url, &deny, &cfg, true).await {
+                    match browser::fetch_rendered(&url, &deny, &cfg, true, timeout).await {
                         Ok(result) => Response::success(
                             id,
                             serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
@@ -175,7 +176,6 @@ impl McpServer {
                 Err(e) => fetch_error_response(id, "fetch (rendered)", e),
             };
         }
-        let timeout = timeout_from_env();
         match fetcher::fetch_tier1(&url, &deny, timeout).await {
             Ok(result) => Response::success(
                 id,
@@ -200,7 +200,8 @@ impl McpServer {
             .unwrap_or(5)
             .clamp(1, 20) as usize;
         let cfg = browser_cfg_from_env();
-        match browser::search(&query, limit, &cfg).await {
+        let timeout = timeout_from_env();
+        match browser::search(&query, limit, &cfg, timeout).await {
             Ok(hits) => Response::success(
                 id,
                 serde_json::to_value(hits).unwrap_or(serde_json::Value::Null),

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -1,10 +1,10 @@
 // mur-research-gateway/src/server.rs
 use crate::audit::{AuditRecord, audit};
 use crate::browser::{self, BrowserCfg};
+use crate::config::{self, GatewayConfig};
 use crate::fetcher::{self, FetchError};
 use crate::jsonrpc::{Request, Response};
 use crate::tools;
-use std::time::Duration;
 
 /// `denied` for the SSRF guard rejection, `error` for every other `FetchError`
 /// variant (Http/TooLarge) — the audit's outcome taxonomy per spec §7.2/§7.4.
@@ -12,57 +12,6 @@ fn fetch_outcome(err: &FetchError) -> &'static str {
     match err {
         FetchError::Guard(_) => "denied",
         FetchError::Http(_) | FetchError::TooLarge => "error",
-    }
-}
-
-/// Interim config (Task placeholder): env vars until config.yaml lands (Task 6).
-// TODO(Task 6): read from config.yaml
-fn deny_hosts_from_env() -> Vec<String> {
-    std::env::var("MUR_RESEARCH_DENY_HOSTS")
-        .ok()
-        .map(|v| {
-            v.split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-// TODO(Task 6): read from config.yaml
-fn timeout_from_env() -> Duration {
-    let secs = std::env::var("MUR_RESEARCH_TIMEOUT_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(20);
-    Duration::from_secs(secs)
-}
-
-/// Default installed Lightpanda path (`~/.mur/aura/lightpanda`, verified
-/// present 2026-07-08 — `gotcha_agent_browser_lightpanda_engine_dead`). Only
-/// used when `MUR_RESEARCH_LIGHTPANDA_PATH` is unset AND the default actually
-/// exists on disk — never claim a path that isn't there.
-// TODO(Task 6): read from config.yaml
-fn default_lightpanda_path() -> Option<String> {
-    let home = std::env::var("HOME").ok()?;
-    let path = format!("{home}/.mur/aura/lightpanda");
-    std::path::Path::new(&path).exists().then_some(path)
-}
-
-// TODO(Task 6): read from config.yaml
-pub(crate) fn browser_cfg_from_env() -> BrowserCfg {
-    let agent_browser_bin = std::env::var("MUR_RESEARCH_AGENT_BROWSER_BIN")
-        .unwrap_or_else(|_| "agent-browser".to_string());
-    let lightpanda_path = std::env::var("MUR_RESEARCH_LIGHTPANDA_PATH")
-        .ok()
-        .filter(|s| !s.is_empty())
-        .or_else(default_lightpanda_path);
-    let chrome_stealth_args = std::env::var("MUR_RESEARCH_CHROME_STEALTH_ARGS")
-        .unwrap_or_else(|_| "--no-sandbox,--disable-blink-features=AutomationControlled".into());
-    BrowserCfg {
-        agent_browser_bin,
-        lightpanda_path,
-        chrome_stealth_args,
     }
 }
 
@@ -80,11 +29,26 @@ fn fetch_error_response(id: Option<serde_json::Value>, verb: &str, err: FetchErr
     }
 }
 
-pub struct McpServer;
+pub struct McpServer {
+    config: GatewayConfig,
+}
 
 impl McpServer {
+    /// Loads `GatewayConfig` ONCE (from `~/.mur/config.yaml`'s
+    /// `research_gateway:` block + env overrides) and stores it for the
+    /// lifetime of the server — see `config::load`.
     pub fn new() -> Self {
-        McpServer
+        let mur_home = config::mur_home_dir();
+        McpServer {
+            config: config::load(&mur_home),
+        }
+    }
+
+    /// Exposes the loaded browser config for `main`'s startup preflight, so
+    /// preflight reads the SAME config the server will use — never a second,
+    /// independently-loaded copy.
+    pub(crate) fn browser_cfg(&self) -> &BrowserCfg {
+        &self.config.browser
     }
 
     pub async fn handle(&mut self, request: Request) -> Response {
@@ -157,8 +121,7 @@ impl McpServer {
             .get("render")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        let deny = deny_hosts_from_env();
-        let timeout = timeout_from_env();
+        let deny = &self.config.deny_hosts;
         if render {
             // Caller may force tier 3 (chrome) directly, e.g. for anti-bot pages
             // known to defeat lightpanda; otherwise tier 2 first, escalating to
@@ -168,8 +131,11 @@ impl McpServer {
                 .get("chrome")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
-            let cfg = browser_cfg_from_env();
-            return match browser::fetch_rendered(&url, &deny, &cfg, want_chrome, timeout).await {
+            let cfg = &self.config.browser;
+            let browser_timeout = self.config.browser_timeout;
+            return match browser::fetch_rendered(&url, deny, cfg, want_chrome, browser_timeout)
+                .await
+            {
                 Ok(result) => {
                     audit(AuditRecord::new("fetch", url, Some(result.tier), "ok"));
                     Response::success(
@@ -178,7 +144,7 @@ impl McpServer {
                     )
                 }
                 Err(FetchError::Http(_)) if !want_chrome => {
-                    match browser::fetch_rendered(&url, &deny, &cfg, true, timeout).await {
+                    match browser::fetch_rendered(&url, deny, cfg, true, browser_timeout).await {
                         Ok(result) => {
                             audit(AuditRecord::new("fetch", url, Some(result.tier), "ok"));
                             Response::success(
@@ -198,7 +164,7 @@ impl McpServer {
                 }
             };
         }
-        match fetcher::fetch_tier1(&url, &deny, timeout).await {
+        match fetcher::fetch_tier1(&url, deny, self.config.timeout).await {
             Ok(result) => {
                 audit(AuditRecord::new("fetch", url, Some(result.tier), "ok"));
                 Response::success(
@@ -225,11 +191,12 @@ impl McpServer {
         let limit = args
             .get("limit")
             .and_then(|v| v.as_u64())
-            .unwrap_or(5)
-            .clamp(1, 20) as usize;
-        let cfg = browser_cfg_from_env();
-        let timeout = timeout_from_env();
-        match browser::search(&query, limit, &cfg, timeout).await {
+            .map(|v| v as usize)
+            .unwrap_or(self.config.search_limit)
+            .clamp(config::MIN_SEARCH_LIMIT, config::MAX_SEARCH_LIMIT);
+        let cfg = &self.config.browser;
+        let timeout = self.config.browser_timeout;
+        match browser::search(&query, limit, cfg, timeout).await {
             Ok(hits) => {
                 audit(AuditRecord::new("search", query, None, "ok"));
                 Response::success(

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -1,9 +1,19 @@
 // mur-research-gateway/src/server.rs
+use crate::audit::{AuditRecord, audit};
 use crate::browser::{self, BrowserCfg};
 use crate::fetcher::{self, FetchError};
 use crate::jsonrpc::{Request, Response};
 use crate::tools;
 use std::time::Duration;
+
+/// `denied` for the SSRF guard rejection, `error` for every other `FetchError`
+/// variant (Http/TooLarge) — the audit's outcome taxonomy per spec §7.2/§7.4.
+fn fetch_outcome(err: &FetchError) -> &'static str {
+    match err {
+        FetchError::Guard(_) => "denied",
+        FetchError::Http(_) | FetchError::TooLarge => "error",
+    }
+}
 
 /// Interim config (Task placeholder): env vars until config.yaml lands (Task 6).
 // TODO(Task 6): read from config.yaml
@@ -160,28 +170,46 @@ impl McpServer {
                 .unwrap_or(false);
             let cfg = browser_cfg_from_env();
             return match browser::fetch_rendered(&url, &deny, &cfg, want_chrome, timeout).await {
-                Ok(result) => Response::success(
-                    id,
-                    serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
-                ),
+                Ok(result) => {
+                    audit(AuditRecord::new("fetch", url, Some(result.tier), "ok"));
+                    Response::success(
+                        id,
+                        serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
+                    )
+                }
                 Err(FetchError::Http(_)) if !want_chrome => {
                     match browser::fetch_rendered(&url, &deny, &cfg, true, timeout).await {
-                        Ok(result) => Response::success(
-                            id,
-                            serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
-                        ),
-                        Err(e) => fetch_error_response(id, "fetch (tier 3)", e),
+                        Ok(result) => {
+                            audit(AuditRecord::new("fetch", url, Some(result.tier), "ok"));
+                            Response::success(
+                                id,
+                                serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
+                            )
+                        }
+                        Err(e) => {
+                            audit(AuditRecord::new("fetch", url, None, fetch_outcome(&e)));
+                            fetch_error_response(id, "fetch (tier 3)", e)
+                        }
                     }
                 }
-                Err(e) => fetch_error_response(id, "fetch (rendered)", e),
+                Err(e) => {
+                    audit(AuditRecord::new("fetch", url, None, fetch_outcome(&e)));
+                    fetch_error_response(id, "fetch (rendered)", e)
+                }
             };
         }
         match fetcher::fetch_tier1(&url, &deny, timeout).await {
-            Ok(result) => Response::success(
-                id,
-                serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
-            ),
-            Err(e) => fetch_error_response(id, "fetch", e),
+            Ok(result) => {
+                audit(AuditRecord::new("fetch", url, Some(result.tier), "ok"));
+                Response::success(
+                    id,
+                    serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
+                )
+            }
+            Err(e) => {
+                audit(AuditRecord::new("fetch", url, None, fetch_outcome(&e)));
+                fetch_error_response(id, "fetch", e)
+            }
         }
     }
 
@@ -202,11 +230,17 @@ impl McpServer {
         let cfg = browser_cfg_from_env();
         let timeout = timeout_from_env();
         match browser::search(&query, limit, &cfg, timeout).await {
-            Ok(hits) => Response::success(
-                id,
-                serde_json::to_value(hits).unwrap_or(serde_json::Value::Null),
-            ),
-            Err(e) => fetch_error_response(id, "search", e),
+            Ok(hits) => {
+                audit(AuditRecord::new("search", query, None, "ok"));
+                Response::success(
+                    id,
+                    serde_json::to_value(hits).unwrap_or(serde_json::Value::Null),
+                )
+            }
+            Err(e) => {
+                audit(AuditRecord::new("search", query, None, fetch_outcome(&e)));
+                fetch_error_response(id, "search", e)
+            }
         }
     }
 }

--- a/mur-research-gateway/src/tools.rs
+++ b/mur-research-gateway/src/tools.rs
@@ -1,0 +1,52 @@
+// mur-research-gateway/src/tools.rs
+use serde::Serialize;
+
+/// MCP tool definition returned by tools/list.
+#[derive(Debug, Clone, Serialize)]
+pub struct Tool {
+    pub name: String,
+    pub description: String,
+    #[serde(rename = "inputSchema")] // MCP wire protocol is camelCase
+    pub input_schema: serde_json::Value,
+}
+
+/// The two read-only verbs workers may call. No navigation, no POST.
+pub fn all_tools() -> Vec<Tool> {
+    vec![
+        Tool {
+            name: "search".into(),
+            description: "Web search. Returns [{title,url,snippet}]. Read-only.".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "number"}
+                },
+                "required": ["query"]
+            }),
+        },
+        Tool {
+            name: "fetch".into(),
+            description: "Fetch one URL's readable text. Read-only GET. SSRF-guarded.".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "url": {"type": "string"},
+                    "render": {"type": "boolean"}
+                },
+                "required": ["url"]
+            }),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn declares_search_and_fetch() {
+        let names: Vec<_> = all_tools().into_iter().map(|t| t.name).collect();
+        assert_eq!(names, vec!["search", "fetch"]);
+    }
+}

--- a/mur-research-gateway/src/tools.rs
+++ b/mur-research-gateway/src/tools.rs
@@ -32,7 +32,8 @@ pub fn all_tools() -> Vec<Tool> {
                 "type": "object",
                 "properties": {
                     "url": {"type": "string"},
-                    "render": {"type": "boolean"}
+                    "render": {"type": "boolean"},
+                    "chrome": {"type": "boolean"}
                 },
                 "required": ["url"]
             }),


### PR DESCRIPTION
## MUR-Native Deep Research

Gives MUR a **native** deep-research capability — decompose → parallel fan-out → adversarial verify → cited synthesis — running on MUR's own **fleet + agents + dynamic router loop**, not Claude Code's built-in `deep-research` skill. All web egress funnels through one deterministic, audited, SSRF-guarded MCP gateway.

Specs: `docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md` · Plan: `docs/superpowers/plans/2026-07-09-mur-native-deep-research.md`

### What's new
- **`mur-research-gateway`** — new deterministic (no-LLM) MCP crate. SSRF-guarded `search`/`fetch`, 3-tier escalation ladder (reqwest → agent-browser/lightpanda → chrome), preflight with explicit degrade, per-request URL audit, `config.yaml`+env config. Shipped by `build.sh`; AGPL attribution for Lightpanda (subprocess-only).
- **`mur-common::net`** — host-pattern matcher hoisted to a single source shared by the egress proxy and the gateway (no divergent copy of security-relevant matching).
- **`mur deep-research`** CLI — `provision` (restricted workers each mounting the gateway), `--grant-egress` (explicit-consent `broad-audited` grant reusing shipped `mur agent mcp set-network`), `run` (thin wrapper over the guarded fleet loop).
- **3 fleet-scoped skills** (router / worker / verify) + a **stub gateway** fixture for deterministic dry-runs.

### Security posture (verified end-to-end by a whole-branch review)
- Workers hold **no egress**; only the deterministic gateway reaches the web (prompt-injection blast radius contained).
- SSRF screen on **every** fetch path; browser tiers screen **pre-spawn** (the egress proxy can't see subprocess connections). Blocks loopback/RFC1918/ULA/link-local/metadata/unspecified, incl. IPv4-in-IPv6 bypass forms.
- Egress is **never implicit** — granted only via the explicit `--grant-egress` consent step; fleet creation never grants it.
- `--deny-host` overlay now enforces on **all tiers** (deny list propagates to the gateway child via a shared env const).
- Tier-1 streaming body cap (no unbounded buffer) + Content-Length fast-reject; browser-tier timeout + size guard. Audit fires on ok/denied/error for both verbs.
- Advisory-enforcement limits (DNS-rebinding window, browser-tier proxy-blindness) documented honestly as Phase-3, not overclaimed.

### Testing
- New crate: 46 tests (gateway + stub). Shared `mur-common::net` + egress-proxy/reqwest-guard: no regression. Provision/grant/run + skills: covered. `clippy -D warnings` + `fmt` clean on all touched crates.
- **Deferred to operator E2E (Task 11):** a live run needs running `mur-agent-runtime` workers + an LLM backend + live egress consent, so full convergence (workers→gateway→marker→cited report) is operator-driven, not automated. The `execute_dag` live-dial ordering makes this un-automatable without live agents — documented in `run.rs`.

### Follow-ups (non-blocking, tracked)
- Phase-3: pin connection to screened IP (close DNS-rebinding); sbpl pin-to-proxy for airtight browser-tier enforcement.
- Stream browser-tier stdout to cap before full buffer; `html_to_text` strip `<script>`/`<style>` content.
- Parameterize `cmd_create`/`cmd_mcp_add` with `mur_home` (remove `provision`'s process-env mutation) before any concurrent/daemon caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
