### PR TITLE
fix(gateway): browserless tier-1 search + working lightpanda→chrome fallback (G2)

### DIFF
--- a/docs/superpowers/plans/2026-07-09-g2-browserless-search-tier.md
+++ b/docs/superpowers/plans/2026-07-09-g2-browserless-search-tier.md
@@ -1,0 +1,386 @@
+# G2: Browserless HTTP Search Tier — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the research-gateway `search` tool work under the worker kernel sandbox by routing it through the same tier-1 reqwest path `fetch` already uses (which G1 proved works via the egress proxy) — instead of spawning `agent-browser`, which the sandbox denies. This unblocks worker research turns from completing, which is the true critical-path blocker for the deep-research fleet.
+
+**Architecture:** The `search` tool already targets DuckDuckGo's server-rendered HTML endpoint (`https://html.duckduckgo.com/html/?q=…`) — a plain HTML page that needs no browser. Today it drives `agent-browser` to render+snapshot that page; under the sandbox `agent-browser` can't spawn (`Operation not permitted, os error 1`). Fix: fetch the endpoint with the tier-1 reqwest client (proxy-honoring, sandbox-friendly) plus a browser-like User-Agent, and parse DuckDuckGo's result anchors directly. No sandbox, runtime, or dependency change.
+
+**Tech Stack:** Rust (edition 2024), `mur-research-gateway` only. Existing deps only (`reqwest`, `url` — no HTML-parser crate added; a focused string scan handles DDG's stable result markup).
+
+## Root Cause (empirically pinned, 2026-07-09 live fleet run)
+
+Worker telemetry showed `mcp__research-gateway__search` failing every call
+(`ok=false`, 81×) while `fetch` succeeded (`ok=true`, 10×) after G1. Direct
+reproduction under a sandboxed worker:
+`search failed: spawn agent-browser: Operation not permitted (os error 1)`.
+
+Downstream impact (why this is critical-path, not cosmetic): a worker's
+research turn loops on failing searches, burns its agentic iteration budget
+(~$1.42/turn observed), and ends in `TaskOutcome::Failed` — never
+`Completed`. The `channel/delegate` self-append fires only on `Completed`
+(by design — never sign user input as a reply), so the worker emits no
+channel reply; the DAG executor sees an empty reply
+(`dag.rs` `extract_agent_reply` → `exit_code = 1`), fails the step, and the
+fleet aborts before any convergence marker. Fixing search lets turns
+complete, which unblocks G3's live channel-write and fleet convergence.
+
+Why HTTP suffices (verified live 2026-07-09): a plain GET of
+`https://html.duckduckgo.com/html/?q=rust` returns server-rendered result
+anchors — `class="result__a" href="//duckduckgo.com/l/?uddg=<percent-encoded
+real URL>&rut=…"`. **A browser-like `User-Agent` is required** — without one
+DDG returns HTTP 202 (a challenge interstitial, no results); with
+`Mozilla/5.0…` it returns 200 + parseable anchors. `fetch_tier1` sets no
+UA today, so the search path must add one.
+
+## Global Constraints
+
+- **No new dependency:** parse DDG's HTML with a focused string scan (the codebase's existing `html_to_text` is manual too) + the `url` crate for percent-decoding the `uddg` param. Do NOT add `scraper`/`select`/`regex`.
+- **Reuse the SSRF guard:** the search fetch must go through `screen_url_blocking` exactly like `fetch_tier1` (screens `html.duckduckgo.com`); returned hit URLs are inert data — the worker's later `fetch` on them re-screens.
+- **Proxy-honoring client:** the search reqwest client must be built the same way as `fetch_tier1`'s (default env-proxy honoring, so `HTTPS_PROXY` from the runtime reaches it), plus the required User-Agent. `redirect: none` is fine (DDG returns 200 directly).
+- **Body cap preserved:** reuse the same `MAX_BODY_BYTES` streaming cap as `fetch_tier1` (don't `resp.text()` an unbounded body).
+- **SearchHit shape unchanged:** `{ title, url, snippet }` (snippet best-effort, may be empty — already tolerated).
+- No hardcoded values (User-Agent + endpoint as named consts); single source file ≤ 800 lines; `cargo clippy --workspace -- -D warnings` + `cargo fmt --check` clean.
+- Tests: `export ORT_STRATEGY=download`; `cargo test -p mur-research-gateway`. Parser tests are hermetic (embedded HTML fixture, NO live network).
+
+---
+
+### Task 1: Tier-1 search in `fetcher.rs` (client UA + DDG parser)
+
+**Files:**
+- Modify: `mur-research-gateway/src/fetcher.rs` — move `SearchHit` here (from `browser.rs`), add `SEARCH_USER_AGENT` + `DDG_HTML_ENDPOINT` consts, a shared `build_client`, `search_tier1`, and `parse_ddg_hits`.
+
+**Interfaces:**
+- Produces: `pub struct SearchHit { pub title: String, pub url: String, pub snippet: String }` (moved here); `pub async fn search_tier1(query: &str, limit: usize, deny: &[String], timeout: Duration) -> Result<Vec<SearchHit>, FetchError>`. Task 2 consumes `search_tier1`; `browser.rs` stops defining `SearchHit`.
+
+- [ ] **Step 1: Write the failing parser test** (hermetic fixture; append to `fetcher.rs` tests)
+
+```rust
+    #[test]
+    fn parses_ddg_result_anchors_and_decodes_uddg() {
+        // Trimmed real DDG html endpoint shape (2026-07-09): result links are
+        // `result__a` anchors whose href wraps the real URL in the `uddg`
+        // query param; snippet is a following `result__snippet` element.
+        let html = r#"
+        <div class="result">
+          <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fa&amp;rut=x">First <b>Title</b></a>
+          <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fa">Snippet one text.</a>
+        </div>
+        <div class="result">
+          <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Frust-lang.org%2F&amp;rut=y">Second</a>
+        </div>"#;
+        let hits = parse_ddg_hits(html, 10);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].url, "https://example.com/a");
+        assert_eq!(hits[0].title, "First Title"); // tags stripped
+        assert_eq!(hits[0].snippet, "Snippet one text.");
+        assert_eq!(hits[1].url, "https://rust-lang.org/");
+        assert_eq!(hits[1].snippet, ""); // no snippet element → empty, tolerated
+    }
+
+    #[test]
+    fn parse_ddg_hits_respects_limit() {
+        let block = |u: &str| format!(
+            r#"<a class="result__a" href="//duckduckgo.com/l/?uddg={u}">t</a>"#,
+            u = u
+        );
+        let html = format!("{}{}{}", block("https%3A%2F%2Fa.test%2F"), block("https%3A%2F%2Fb.test%2F"), block("https%3A%2F%2Fc.test%2F"));
+        assert_eq!(parse_ddg_hits(&html, 2).len(), 2);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p mur-research-gateway parse_ddg_hits parses_ddg`
+Expected: compile FAIL — `parse_ddg_hits` / `SearchHit` not defined in `fetcher`.
+
+- [ ] **Step 3: Move `SearchHit` + add consts and parser**
+
+Move the `SearchHit` struct definition from `browser.rs` to `fetcher.rs` (keep its derives — it's `Serialize`; check the exact derives on the original at `browser.rs:32` and preserve them). Add near the top of `fetcher.rs`:
+
+```rust
+/// Browser-like UA — DuckDuckGo's html endpoint returns HTTP 202 (a challenge
+/// interstitial, no results) to requests without one. Verified live 2026-07-09.
+const SEARCH_USER_AGENT: &str =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+     (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+
+/// DuckDuckGo's server-rendered (no-JS) HTML search endpoint.
+const DDG_HTML_ENDPOINT: &str = "https://html.duckduckgo.com/html/";
+```
+
+Add the parser (focused scan; `url` crate decodes the `uddg` param):
+
+```rust
+/// Parse DuckDuckGo html-endpoint results into hits. Keys on `result__a`
+/// anchors whose href wraps the real URL in the `uddg` query param; the
+/// snippet is the nearest following `result__snippet` text. Deliberately
+/// minimal — DDG's markup is not a contract MUR controls (spec §11), so a
+/// focused scan beats pulling in an HTML-parser dependency.
+fn parse_ddg_hits(html: &str, limit: usize) -> Vec<SearchHit> {
+    let mut hits = Vec::new();
+    // Split on the result-anchor class marker; each piece after the first
+    // starts inside a result__a tag.
+    let mut segments = html.split("class=\"result__a\"");
+    let _ = segments.next(); // preamble before the first anchor
+    for seg in segments {
+        if hits.len() >= limit {
+            break;
+        }
+        let Some(href) = attr_after(seg, "href=\"") else {
+            continue;
+        };
+        let Some(url) = decode_uddg(&href) else {
+            continue;
+        };
+        let title = strip_tags(inner_text_after_tag(seg));
+        // Snippet: nearest following result__snippet inner text, if any before
+        // the next result anchor (segments already end at the next anchor).
+        let snippet = seg
+            .split_once("class=\"result__snippet\"")
+            .and_then(|(_, rest)| Some(strip_tags(inner_text_after_tag(rest))))
+            .unwrap_or_default();
+        hits.push(SearchHit { title, url, snippet });
+    }
+    hits
+}
+
+/// Value of the first `needle`-prefixed attribute in `s` (up to the next `"`).
+fn attr_after(s: &str, needle: &str) -> Option<String> {
+    let start = s.find(needle)? + needle.len();
+    let rest = &s[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// Text between the first `>` and the next `<` after it (an element's inner
+/// text run), HTML-entity-naive (DDG titles are plain).
+fn inner_text_after_tag(s: &str) -> String {
+    let Some(gt) = s.find('>') else {
+        return String::new();
+    };
+    let rest = &s[gt + 1..];
+    let end = rest.find('<').unwrap_or(rest.len());
+    rest[..end].to_string()
+}
+
+/// Strip any remaining inline tags (e.g. `<b>` in a title) and collapse
+/// whitespace. Reuses the same tag-stripping idea as `html_to_text`.
+fn strip_tags(s: String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_tag = false;
+    for c in s.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Decode DDG's redirect href `//duckduckgo.com/l/?uddg=<percent-encoded real
+/// url>&rut=…` into the real URL. Also accepts a bare absolute URL (defensive).
+fn decode_uddg(href: &str) -> Option<String> {
+    let abs = if let Some(stripped) = href.strip_prefix("//") {
+        format!("https://{stripped}")
+    } else {
+        href.to_string()
+    };
+    let parsed = url::Url::parse(&abs).ok()?;
+    if let Some((_, v)) = parsed.query_pairs().find(|(k, _)| k == "uddg") {
+        return Some(v.into_owned());
+    }
+    // No uddg param → treat an http(s) href as already-real, else skip.
+    (abs.starts_with("http://") || abs.starts_with("https://")).then_some(abs)
+}
+```
+
+Add `search_tier1` + a shared `build_client` (refactor `fetch_tier1` to use it too, so the UA/timeout/redirect policy has one source):
+
+```rust
+/// Shared tier-1 reqwest client: env-proxy honoring (so the runtime's
+/// `HTTPS_PROXY` reaches it — the G1 path), per-request timeout, a
+/// browser-like UA (some hosts, incl. DDG's html endpoint, 202/deny without
+/// one), and no auto-redirect (each hop is re-screened by the caller).
+fn build_client(timeout: Duration) -> Result<reqwest::Client, FetchError> {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .user_agent(SEARCH_USER_AGENT)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| FetchError::Http(e.to_string()))
+}
+
+/// Tier-1 web search: GET DuckDuckGo's html endpoint through the same
+/// proxy-honoring reqwest path `fetch_tier1` uses (works under the kernel
+/// sandbox; agent-browser does not — G2), then parse result anchors. Screens
+/// the endpoint host via the SSRF guard exactly like a fetch.
+pub async fn search_tier1(
+    query: &str,
+    limit: usize,
+    deny: &[String],
+    timeout: Duration,
+) -> Result<Vec<SearchHit>, FetchError> {
+    let mut search_url = url::Url::parse(DDG_HTML_ENDPOINT).expect("static URL is valid");
+    search_url.query_pairs_mut().append_pair("q", query);
+
+    let screened = screen_url_blocking(search_url.as_str(), deny)
+        .await
+        .map_err(FetchError::Guard)?;
+
+    let client = build_client(timeout)?;
+    let mut resp = client
+        .get(screened.clone())
+        .send()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?;
+    if let Some(len) = resp.content_length()
+        && len > MAX_BODY_BYTES as u64
+    {
+        return Err(FetchError::TooLarge);
+    }
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?
+    {
+        if would_exceed(buf.len(), chunk.len(), MAX_BODY_BYTES) {
+            return Err(FetchError::TooLarge);
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    let body = String::from_utf8_lossy(&buf);
+    Ok(parse_ddg_hits(&body, limit))
+}
+```
+
+Then refactor `fetch_tier1` to build its client via `build_client(timeout)` (replaces its inline `reqwest::Client::builder()…build()` block) so the UA/redirect policy is single-sourced. This also gives `fetch` a real UA (strictly more robust; no behavior regression — the screen/cap/redirect logic is unchanged).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p mur-research-gateway`
+Expected: new parser tests PASS; pre-existing fetcher tests (`refuses_private_target`, `refuses_denied_host`, `body_cap_*`) still PASS (they exercise `fetch_tier1`, whose logic is unchanged bar the shared client builder).
+
+Run: `cargo clippy -p mur-research-gateway -- -D warnings`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-research-gateway/src/fetcher.rs
+git commit -m "feat(gateway): browserless tier-1 web search (DDG html endpoint + UA) (G2)"
+```
+
+---
+
+### Task 2: Route `search` to the tier-1 path; retire the browser search
+
+**Files:**
+- Modify: `mur-research-gateway/src/server.rs` — `handle_search` calls `fetcher::search_tier1` instead of `browser::search`.
+- Modify: `mur-research-gateway/src/browser.rs` — remove the now-dead `search`, `parse_search_hits`, `parse_markdown_link`, and the moved `SearchHit` (keep `fetch_rendered`, `build_fetch_argv`, `run_agent_browser`, `preflight` — still used by `fetch` render:true tiers 2/3).
+
+**Interfaces:**
+- Consumes: `fetcher::search_tier1`, `fetcher::SearchHit` (Task 1).
+- Produces: no external change — the `search` MCP tool's response shape is identical.
+
+- [ ] **Step 1: Reroute `handle_search`**
+
+In `server.rs` `handle_search`, replace:
+
+```rust
+        let cfg = &self.config.browser;
+        let timeout = self.config.browser_timeout;
+        match browser::search(&query, limit, deny, cfg, timeout).await {
+```
+
+with (search is tier-1 now — use the tier-1 fetch timeout, drop the browser cfg):
+
+```rust
+        let timeout = self.config.timeout;
+        match fetcher::search_tier1(&query, limit, deny, timeout).await {
+```
+
+(Leave the `Ok(hits)` / `Err(e)` arms, the audit calls, and `fetch_outcome` mapping unchanged — `search_tier1` returns the same `Result<Vec<SearchHit>, FetchError>`.)
+
+- [ ] **Step 2: Remove the dead browser search code**
+
+In `browser.rs`, delete `pub async fn search(...)`, `fn parse_search_hits(...)`, `fn parse_markdown_link(...)`, the `SearchHit` struct (now in `fetcher.rs`), and any test exercising the markdown search parser. Update any `use` of `SearchHit` in `browser.rs`/`server.rs` to `fetcher::SearchHit`. Keep everything the `fetch` render path needs.
+
+- [ ] **Step 3: Run the full crate suite + a live smoke**
+
+Run: `cargo test -p mur-research-gateway && cargo clippy -p mur-research-gateway -- -D warnings && cargo fmt --check`
+Expected: all PASS/clean; `declares_search_and_fetch` still passes (tool list unchanged).
+
+Live smoke (network — outside sandbox, proves the endpoint+parser against real DDG):
+
+```bash
+cargo build --release -p mur-research-gateway
+printf '%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search","arguments":{"query":"rust async runtime","limit":3}}}' \
+  | ./target/release/mur-research-gateway
+```
+
+Expected: `id:2` result with a non-empty `[{title,url,snippet}]` array of real URLs. If it returns empty, DDG may have changed markup or rate-limited — re-run once; if persistently empty, capture the raw body (temporarily log it) and adjust `parse_ddg_hits` before proceeding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mur-research-gateway/src/server.rs mur-research-gateway/src/browser.rs
+git commit -m "refactor(gateway): search uses the tier-1 HTTP path; retire agent-browser search (G2)"
+```
+
+---
+
+### Task 3: Documentation
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md` — in the tiers/search section, note that `search` is tier-1 HTTP (DDG html endpoint via the egress proxy), not a browser tier, so it works under the worker sandbox; browser tiers remain only for `fetch` render:true.
+- Modify: `docs/architecture/runtime-overview.md` if it describes the gateway tiers (grep "research-gateway" / "agent-browser"); otherwise skip with a note in the commit.
+
+- [ ] **Step 1: Make the spec edit** (verbatim, inside the existing tiers section)
+
+```markdown
+**Search is tier-1 HTTP, not a browser tier.** `search` GETs DuckDuckGo's
+server-rendered html endpoint through the same proxy-honoring reqwest path as
+a tier-1 `fetch` (browser-like UA required; DDG 202s without one), so it works
+under the worker kernel sandbox — unlike `agent-browser`, which the sandbox
+denies (`Operation not permitted`). `agent-browser` remains only for `fetch`
+with `render:true` (tiers 2/3).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md docs/architecture/runtime-overview.md
+git commit -m "docs(gateway): search is a browserless tier-1 HTTP path (G2)"
+```
+
+---
+
+## Operator Verification (manual, after merge — the full deep-research payoff)
+
+1. Rebuild + reinstall the gateway the workers spawn: `cargo build --release -p mur-research-gateway` (workers' `research-gateway` MCP command points at `/opt/homebrew/bin/mur-research-gateway` — reinstall via `build.sh` or copy the release binary there; re-pin if the sha guard trips: `mur agent mcp pin dr_worker_N research-gateway`). Also rebuild `mur-agent-runtime` if not current.
+2. Start `dr_worker_1..4`; run one live iteration: `mur deep-research run deep-research --max-iterations 1`.
+3. **Expected (fixed):**
+   - Worker telemetry: `mcp__research-gateway__search ok=true` (was `false` every call).
+   - Worker turns reach `TaskOutcome::Completed` → the delegate reply is non-empty → `Step s1` succeeds (no `exit 1`).
+   - **G3 now exercised live:** a signed `Agent{dr_worker_N}` reply event appears in `~/.mur/channels/fleet-deep-research/events.jsonl`, `index/channels/channels.db` updates, and NO `readonly database` warning.
+4. Full run: `mur deep-research run deep-research` (multi-iteration, budgeted) — with turns completing and workers writing replies, the router can drive toward the `RESEARCH_COMPLETE` marker. This is the first end-to-end native deep-research run; capture the synthesized report and the real spend.
+5. If convergence still stalls with search working, the remaining suspect is G4 (fleet-scoped skills not injecting — the router/worker skills that shape decomposition/synthesis). Diagnose then per the G4 plan.
+
+## Out of Scope (tracked separately)
+
+- **G4** skill loader rejects `fleet:<name>` scoped refs — next after G2, if convergence needs the fleet skills.
+- Search-provider robustness (DDG markup drift, a real search API) — spec §11 keeps a dedicated search API out of scope; the focused parser is intentionally minimal and easy to adjust.
+- Pin-to-proxy DNS-rebinding closure (Phase 3 TODO already in `fetch_tier1`) — unchanged.
+
+## Self-Review Notes
+
+- The fix removes an entire failure mode (browser spawn under sandbox) rather than widening the sandbox — strictly less privilege, no new grant.
+- Parser tests are hermetic (embedded fixture); the live smoke in Task 2 Step 3 is the only network touch and is a manual gate, not a CI test.
+- `search_tier1` reuses `screen_url_blocking` + the `MAX_BODY_BYTES` streaming cap, so search inherits the same SSRF + DoS protections as `fetch`.
+- `build_client` single-sources the UA/redirect/timeout for both fetch and search; `fetch` gaining a UA is a robustness improvement with no logic change.

--- a/docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md
+++ b/docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md
@@ -118,9 +118,20 @@ that holds egress.
   - tier 1 `reqwest` GET — default; most pages.
   - tier 2 `agent-browser --engine lightpanda --executable-path <cfg> --args "" --session <per-fetch>`
     — JS pages. `--args ""` is mandatory (Chrome stealth args break Lightpanda).
-  - tier 3 `agent-browser --engine chrome` (+stealth args) — anti-bot / screenshot.
-  - Search backend: `agent-browser` (default engine lightpanda) drives a search
-    results page; tier-1 HTML search as the cheap path. No API key required for v1.
+  - tier 3 `agent-browser --engine chrome --args "<stealth,comma-separated>"` — anti-bot /
+    screenshot. Chrome launch flags go through a SINGLE `--args` value, never bare argv:
+    a bare `--no-sandbox` is parsed by agent-browser as a subcommand and errors with
+    "Unknown command" (so the chrome tier silently never launched until fixed 2026-07-09).
+  - **lightpanda → chrome escalation** (rendered `fetch` only): a tier-2 attempt escalates
+    to tier 3 when lightpanda "doesn't work" — an `Http` failure (spawn/timeout/non-zero
+    exit) OR a success that rendered **no text** (the engine ran but produced nothing, an
+    exit-0-empty a plain error check misses). `Guard`/`TooLarge` are tier-independent and
+    never escalate. `chrome:true` forces tier 3 directly.
+  - **Search is tier-1 HTTP, not a browser tier.** `search` GETs DuckDuckGo's server-rendered
+    html endpoint through the same proxy-honoring reqwest path as a tier-1 `fetch` (a
+    browser-like User-Agent is required — DDG returns HTTP 202 without one), so search works
+    under the worker kernel sandbox — `agent-browser` cannot spawn there (`Operation not
+    permitted`). `agent-browser` is used only for `fetch` with `render:true`. No API key for v1.
 - **Per-fetch session isolation** — each fetch uses a unique `--session` id (verified
   isolated, 2026-07-08) so concurrent worker fetches never cross-contaminate state.
 - **Daemon lifecycle** — manage agent-browser's persistent daemon; detect version

--- a/mur-core/src/action_pipeline/notify.rs
+++ b/mur-core/src/action_pipeline/notify.rs
@@ -96,7 +96,7 @@ impl Aggregator {
         } else {
             format!(
                 "{} and {} more",
-                &file_names[..3].join(", "),
+                file_names[..3].join(", "),
                 file_names.len() - 3
             )
         };

--- a/mur-core/src/cmd/media/error.rs
+++ b/mur-core/src/cmd/media/error.rs
@@ -20,6 +20,10 @@ pub enum MediaError {
 
 impl MediaError {
     /// Warm zh-TW message + actionable hint. (zh-TW is the product default brand voice.)
+    // Reached only via `Display`/Plan-B co-watching, both of which are dead in
+    // the `mur` bin target (variants are constructed only by proactive
+    // co-watching) — same rationale as the enum's `#[allow(dead_code)]` above.
+    #[allow(dead_code)]
     pub fn user_message(&self) -> &'static str {
         match self {
             MediaError::VlcNotFound => "我找不到 VLC，請先安裝 VLC.app 再試一次。",

--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -666,7 +666,7 @@ async fn cmd_out_execute(action: &str, force: bool) -> anyhow::Result<()> {
                         .join(".mur")
                         .join("session")
                         .join("recordings")
-                        .join(format!("{}.jsonl", &r.id));
+                        .join(format!("{}.jsonl", r.id));
 
                     // Check if session is worth analyzing
                     if !force {

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -230,7 +230,8 @@ mod tests {
         let cfg = BrowserCfg {
             agent_browser_bin: "agent-browser".into(),
             lightpanda_path: Some("/x/lightpanda".into()),
-            chrome_stealth_args: "--no-sandbox,--disable-blink-features=AutomationControlled".into(),
+            chrome_stealth_args: "--no-sandbox,--disable-blink-features=AutomationControlled"
+                .into(),
         };
         let argv = build_fetch_argv("https://example.com", &cfg, true);
         assert!(

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -1,8 +1,10 @@
 // mur-research-gateway/src/browser.rs
 //
 // Escalation tiers 2 (agent-browser --engine lightpanda) and 3 (--engine
-// chrome), plus `search`, plus `preflight`. Drives `agent-browser` as a
-// subprocess — see docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md §5.
+// chrome), plus `preflight`. Drives `agent-browser` as a subprocess — see
+// docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md §5.
+// `search` now rides the tier-1 HTTP path (see `fetcher::search_tier1`) — no
+// browser subprocess involved.
 //
 // LOAD-BEARING: the egress proxy only sees tier-1 (reqwest) connections; the
 // browser subprocess opens its own connections the proxy cannot observe.
@@ -191,89 +193,6 @@ pub async fn fetch_rendered(
     })
 }
 
-/// Web search. Drives agent-browser to a search-results page and parses hits.
-/// v1 rides the browser engine — a dedicated search-provider API is out of
-/// scope per spec §11. Same pre-spawn screen and `timeout` as `fetch_rendered`;
-/// tier follows `cfg` (lightpanda when available, else chrome) — never
-/// caller-selectable, since search has no anti-bot escalation path of its own.
-///
-/// `deny` is the SAME operator `deny_hosts` overlay `fetch_rendered` screens
-/// against — passed here too so `mur deep-research provision --deny-host X`
-/// applies uniformly across every gateway tool, not just `fetch`. The fixed
-/// search-engine host itself is never caller-supplied, but an operator can
-/// still deny it (or any other public host reachable from a redirect/hit)
-/// via the same overlay; the always-on private/loopback/link-local rule
-/// applies regardless (net_guard).
-pub async fn search(
-    query: &str,
-    limit: usize,
-    deny: &[String],
-    cfg: &BrowserCfg,
-    timeout: Duration,
-) -> Result<Vec<crate::fetcher::SearchHit>, FetchError> {
-    let mut search_url =
-        url::Url::parse("https://html.duckduckgo.com/html/").expect("static URL is valid");
-    search_url.query_pairs_mut().append_pair("q", query);
-
-    let screened = fetcher::screen_url_blocking(search_url.as_str(), deny)
-        .await
-        .map_err(FetchError::Guard)?;
-
-    let argv = build_fetch_argv(screened.as_str(), cfg, false);
-    let text = run_agent_browser(&cfg.agent_browser_bin, &argv, timeout).await?;
-    Ok(parse_search_hits(&text, limit))
-}
-
-/// Small, deliberately minimal parser: agent-browser's `snapshot` renders
-/// markdown-style links (`[title](url)`); one hit per line that has one,
-/// snippet is the next non-empty, non-link line. Good enough for v1 — the
-/// upstream search engine's HTML is not a contract MUR controls (spec §11:
-/// a dedicated search API is out of scope), so don't over-invest here.
-fn parse_search_hits(text: &str, limit: usize) -> Vec<crate::fetcher::SearchHit> {
-    let mut hits = Vec::new();
-    let mut lines = text.lines().peekable();
-    while let Some(line) = lines.next() {
-        if hits.len() >= limit {
-            break;
-        }
-        let Some((title, url)) = parse_markdown_link(line) else {
-            continue;
-        };
-        if !(url.starts_with("http://") || url.starts_with("https://")) {
-            continue;
-        }
-        let snippet = lines
-            .peek()
-            .filter(|l| !l.trim().is_empty() && parse_markdown_link(l).is_none())
-            .map(|l| l.trim().to_string())
-            .unwrap_or_default();
-        hits.push(crate::fetcher::SearchHit {
-            title,
-            url,
-            snippet,
-        });
-    }
-    hits
-}
-
-/// Extract `(title, url)` from a single `[title](url)` markdown link, if the
-/// line contains exactly that shape. Returns `None` for anything else.
-fn parse_markdown_link(line: &str) -> Option<(String, String)> {
-    let start = line.find('[')?;
-    let close = line[start..].find(']')? + start;
-    if line[close + 1..].starts_with('(') {
-        let open_paren = close + 1;
-        let end = line[open_paren..].find(')')? + open_paren;
-        let title = line[start + 1..close].trim().to_string();
-        let url = line[open_paren + 1..end].trim().to_string();
-        if title.is_empty() || url.is_empty() {
-            return None;
-        }
-        return Some((title, url));
-    }
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -395,28 +314,5 @@ mod tests {
             session_id("https://b.example")
         );
         assert!(session_id("https://a.example").starts_with("rg-"));
-    }
-    #[test]
-    fn parses_markdown_search_hits_with_snippet() {
-        let text = "\
-Intro text\n\
-[Rust Programming Language](https://www.rust-lang.org/)\n\
-A language empowering everyone.\n\
-\n\
-[Another Hit](https://example.com/page)\n\
-Some snippet text.\n\
-[Not a search result](not-a-url)\n";
-        let hits = parse_search_hits(text, 5);
-        assert_eq!(hits.len(), 2);
-        assert_eq!(hits[0].title, "Rust Programming Language");
-        assert_eq!(hits[0].url, "https://www.rust-lang.org/");
-        assert_eq!(hits[0].snippet, "A language empowering everyone.");
-        assert_eq!(hits[1].title, "Another Hit");
-        assert_eq!(hits[1].snippet, "Some snippet text.");
-    }
-    #[test]
-    fn parse_search_hits_respects_limit() {
-        let text = "[A](https://a.example)\n[B](https://b.example)\n[C](https://c.example)\n";
-        assert_eq!(parse_search_hits(text, 2).len(), 2);
     }
 }

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -40,8 +40,16 @@ pub fn build_fetch_argv(url: &str, cfg: &BrowserCfg, want_chrome: bool) -> Vec<S
     if want_chrome || cfg.lightpanda_path.is_none() {
         a.push("--engine".into());
         a.push("chrome".into());
-        for s in cfg.chrome_stealth_args.split(',').filter(|s| !s.is_empty()) {
-            a.push(s.to_string());
+        // Chrome launch flags MUST go through agent-browser's `--args`
+        // (comma/newline separated), NOT as bare argv entries: a bare
+        // `--no-sandbox` is parsed as an agent-browser subcommand and fails
+        // with "Unknown command: --no-sandbox" (see `agent-browser --help`).
+        // `chrome_stealth_args` is already the comma-separated form `--args`
+        // expects, so forward it verbatim as a single value.
+        let stealth = cfg.chrome_stealth_args.trim();
+        if !stealth.is_empty() {
+            a.push("--args".into());
+            a.push(stealth.to_string());
         }
     } else {
         a.push("--engine".into());
@@ -222,14 +230,18 @@ mod tests {
         let cfg = BrowserCfg {
             agent_browser_bin: "agent-browser".into(),
             lightpanda_path: Some("/x/lightpanda".into()),
-            chrome_stealth_args: "--no-sandbox".into(),
+            chrome_stealth_args: "--no-sandbox,--disable-blink-features=AutomationControlled".into(),
         };
         let argv = build_fetch_argv("https://example.com", &cfg, true);
         assert!(
             argv.windows(2)
                 .any(|w| w[0] == "--engine" && w[1] == "chrome")
         );
-        assert!(argv.iter().any(|a| a == "--no-sandbox"));
+        // Stealth flags travel as ONE `--args` value (agent-browser parses a
+        // bare `--no-sandbox` as a subcommand and errors), never as bare argv.
+        assert!(argv.windows(2).any(|w| w[0] == "--args"
+            && w[1] == "--no-sandbox,--disable-blink-features=AutomationControlled"));
+        assert!(!argv.iter().any(|a| a == "--no-sandbox"));
     }
     #[test]
     fn preflight_degrades_when_lightpanda_missing() {

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -10,7 +10,6 @@
 // code, BEFORE spawning agent-browser — never delegate that to the proxy.
 
 use crate::fetcher::{self, FetchError, FetchResult};
-use serde::Serialize;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -26,13 +25,6 @@ pub enum Preflight {
     LightpandaMissing,
     AgentBrowserTooOld(String),
     AgentBrowserMissing,
-}
-
-#[derive(Debug, Serialize)]
-pub struct SearchHit {
-    pub title: String,
-    pub url: String,
-    pub snippet: String,
 }
 
 /// Build the agent-browser argv for a single fetch. Pure → unit-testable.
@@ -218,7 +210,7 @@ pub async fn search(
     deny: &[String],
     cfg: &BrowserCfg,
     timeout: Duration,
-) -> Result<Vec<SearchHit>, FetchError> {
+) -> Result<Vec<crate::fetcher::SearchHit>, FetchError> {
     let mut search_url =
         url::Url::parse("https://html.duckduckgo.com/html/").expect("static URL is valid");
     search_url.query_pairs_mut().append_pair("q", query);
@@ -237,7 +229,7 @@ pub async fn search(
 /// snippet is the next non-empty, non-link line. Good enough for v1 — the
 /// upstream search engine's HTML is not a contract MUR controls (spec §11:
 /// a dedicated search API is out of scope), so don't over-invest here.
-fn parse_search_hits(text: &str, limit: usize) -> Vec<SearchHit> {
+fn parse_search_hits(text: &str, limit: usize) -> Vec<crate::fetcher::SearchHit> {
     let mut hits = Vec::new();
     let mut lines = text.lines().peekable();
     while let Some(line) = lines.next() {
@@ -255,7 +247,7 @@ fn parse_search_hits(text: &str, limit: usize) -> Vec<SearchHit> {
             .filter(|l| !l.trim().is_empty() && parse_markdown_link(l).is_none())
             .map(|l| l.trim().to_string())
             .unwrap_or_default();
-        hits.push(SearchHit {
+        hits.push(crate::fetcher::SearchHit {
             title,
             url,
             snippet,

--- a/mur-research-gateway/src/fetcher.rs
+++ b/mur-research-gateway/src/fetcher.rs
@@ -13,8 +13,6 @@ const SEARCH_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)
      (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
 
 /// DuckDuckGo's server-rendered (no-JS) HTML search endpoint.
-// Unused until server.rs routes the `search` tool to `search_tier1` (Task 2).
-#[allow(dead_code)]
 const DDG_HTML_ENDPOINT: &str = "https://html.duckduckgo.com/html/";
 
 #[derive(Debug, Serialize)]
@@ -160,8 +158,6 @@ fn build_client(timeout: Duration) -> Result<reqwest::Client, FetchError> {
 /// proxy-honoring reqwest path `fetch_tier1` uses (works under the kernel
 /// sandbox; agent-browser does not — G2), then parse result anchors. Screens
 /// the endpoint host via the SSRF guard exactly like a fetch.
-// Unused until server.rs routes the `search` tool to this fn (Task 2).
-#[allow(dead_code)]
 pub async fn search_tier1(
     query: &str,
     limit: usize,

--- a/mur-research-gateway/src/fetcher.rs
+++ b/mur-research-gateway/src/fetcher.rs
@@ -7,6 +7,16 @@ use std::time::Duration;
 // agent-browser stdout that tier-1 enforces on the HTTP body.
 pub(crate) const MAX_BODY_BYTES: usize = 5 * 1024 * 1024; // ponytail: 5MB cap; config if a real doc exceeds it
 
+/// Browser-like UA — DuckDuckGo's html endpoint returns HTTP 202 (a challenge
+/// interstitial, no results) to requests without one. Verified live 2026-07-09.
+const SEARCH_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+     (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+
+/// DuckDuckGo's server-rendered (no-JS) HTML search endpoint.
+// Unused until server.rs routes the `search` tool to `search_tier1` (Task 2).
+#[allow(dead_code)]
+const DDG_HTML_ENDPOINT: &str = "https://html.duckduckgo.com/html/";
+
 #[derive(Debug, Serialize)]
 pub struct FetchResult {
     pub url: String,
@@ -14,6 +24,13 @@ pub struct FetchResult {
     pub title: Option<String>,
     pub text: String,
     pub tier: u8,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SearchHit {
+    pub title: String,
+    pub url: String,
+    pub snippet: String,
 }
 
 #[derive(Debug)]
@@ -63,11 +80,7 @@ pub async fn fetch_tier1(
     // acceptable per the spec's advisory tier; airtight pin-to-proxy is Phase 3.
     // TODO(Phase 3): pin the connection to the screened IP via a custom
     // reqwest::dns::Resolve to close the DNS-rebinding window.
-    let client = reqwest::Client::builder()
-        .timeout(timeout)
-        .redirect(reqwest::redirect::Policy::none()) // no auto-redirect: each hop must be re-screened by the worker
-        .build()
-        .map_err(|e| FetchError::Http(e.to_string()))?;
+    let client = build_client(timeout)?;
     let mut resp = client
         .get(screened.clone())
         .send()
@@ -130,6 +143,156 @@ fn html_to_text(html: &str) -> String {
     out.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+/// Shared tier-1 reqwest client: env-proxy honoring (so the runtime's
+/// `HTTPS_PROXY` reaches it — the G1 path), per-request timeout, a
+/// browser-like UA (some hosts, incl. DDG's html endpoint, 202/deny without
+/// one), and no auto-redirect (each hop is re-screened by the caller).
+fn build_client(timeout: Duration) -> Result<reqwest::Client, FetchError> {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .user_agent(SEARCH_USER_AGENT)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| FetchError::Http(e.to_string()))
+}
+
+/// Tier-1 web search: GET DuckDuckGo's html endpoint through the same
+/// proxy-honoring reqwest path `fetch_tier1` uses (works under the kernel
+/// sandbox; agent-browser does not — G2), then parse result anchors. Screens
+/// the endpoint host via the SSRF guard exactly like a fetch.
+// Unused until server.rs routes the `search` tool to this fn (Task 2).
+#[allow(dead_code)]
+pub async fn search_tier1(
+    query: &str,
+    limit: usize,
+    deny: &[String],
+    timeout: Duration,
+) -> Result<Vec<SearchHit>, FetchError> {
+    let mut search_url = url::Url::parse(DDG_HTML_ENDPOINT).expect("static URL is valid");
+    search_url.query_pairs_mut().append_pair("q", query);
+
+    let screened = screen_url_blocking(search_url.as_str(), deny)
+        .await
+        .map_err(FetchError::Guard)?;
+
+    let client = build_client(timeout)?;
+    let mut resp = client
+        .get(screened.clone())
+        .send()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?;
+    if let Some(len) = resp.content_length()
+        && len > MAX_BODY_BYTES as u64
+    {
+        return Err(FetchError::TooLarge);
+    }
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?
+    {
+        if would_exceed(buf.len(), chunk.len(), MAX_BODY_BYTES) {
+            return Err(FetchError::TooLarge);
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    let body = String::from_utf8_lossy(&buf);
+    Ok(parse_ddg_hits(&body, limit))
+}
+
+/// Parse DuckDuckGo html-endpoint results into hits. Keys on `result__a`
+/// anchors whose href wraps the real URL in the `uddg` query param; the
+/// snippet is the nearest following `result__snippet` text. Deliberately
+/// minimal — DDG's markup is not a contract MUR controls (spec §11), so a
+/// focused scan beats pulling in an HTML-parser dependency.
+fn parse_ddg_hits(html: &str, limit: usize) -> Vec<SearchHit> {
+    let mut hits = Vec::new();
+    // Split on the result-anchor class marker; each piece after the first
+    // starts inside a result__a tag.
+    let mut segments = html.split("class=\"result__a\"");
+    let _ = segments.next(); // preamble before the first anchor
+    for seg in segments {
+        if hits.len() >= limit {
+            break;
+        }
+        let Some(href) = attr_after(seg, "href=\"") else {
+            continue;
+        };
+        let Some(url) = decode_uddg(&href) else {
+            continue;
+        };
+        let title = strip_tags(inner_text_after_tag(seg));
+        // Snippet: nearest following result__snippet inner text, if any before
+        // the next result anchor (segments already end at the next anchor).
+        let snippet = seg
+            .split_once("class=\"result__snippet\"")
+            .map(|(_, rest)| strip_tags(inner_text_after_tag(rest)))
+            .unwrap_or_default();
+        hits.push(SearchHit {
+            title,
+            url,
+            snippet,
+        });
+    }
+    hits
+}
+
+/// Value of the first `needle`-prefixed attribute in `s` (up to the next `"`).
+fn attr_after(s: &str, needle: &str) -> Option<String> {
+    let start = s.find(needle)? + needle.len();
+    let rest = &s[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// Text between the first `>` and the anchor's closing `</a>` (an element's
+/// full inner-HTML run, which may still contain nested inline tags like
+/// `<b>` — `strip_tags` handles those). Bounding on `</a>` rather than the
+/// next `<` matters: DDG titles wrap matched query terms in `<b>…</b>`, and
+/// stopping at the first `<` would truncate the title before that markup.
+/// HTML-entity-naive (DDG titles are plain).
+fn inner_text_after_tag(s: &str) -> String {
+    let Some(gt) = s.find('>') else {
+        return String::new();
+    };
+    let rest = &s[gt + 1..];
+    let end = rest.find("</a>").unwrap_or(rest.len());
+    rest[..end].to_string()
+}
+
+/// Strip any remaining inline tags (e.g. `<b>` in a title) and collapse
+/// whitespace. Reuses the same tag-stripping idea as `html_to_text`.
+fn strip_tags(s: String) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_tag = false;
+    for c in s.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Decode DDG's redirect href `//duckduckgo.com/l/?uddg=<percent-encoded real
+/// url>&rut=…` into the real URL. Also accepts a bare absolute URL (defensive).
+fn decode_uddg(href: &str) -> Option<String> {
+    let abs = if let Some(stripped) = href.strip_prefix("//") {
+        format!("https://{stripped}")
+    } else {
+        href.to_string()
+    };
+    let parsed = url::Url::parse(&abs).ok()?;
+    if let Some((_, v)) = parsed.query_pairs().find(|(k, _)| k == "uddg") {
+        return Some(v.into_owned());
+    }
+    // No uddg param → treat an http(s) href as already-real, else skip.
+    (abs.starts_with("http://") || abs.starts_with("https://")).then_some(abs)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,5 +327,44 @@ mod tests {
         assert!(would_exceed(MAX_BODY_BYTES - 10, 11, MAX_BODY_BYTES));
         // Saturating add: a huge chunk can't wrap around to look small.
         assert!(would_exceed(1, usize::MAX, MAX_BODY_BYTES));
+    }
+
+    #[test]
+    fn parses_ddg_result_anchors_and_decodes_uddg() {
+        // Trimmed real DDG html endpoint shape (2026-07-09): result links are
+        // `result__a` anchors whose href wraps the real URL in the `uddg`
+        // query param; snippet is a following `result__snippet` element.
+        let html = r#"
+        <div class="result">
+          <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fa&amp;rut=x">First <b>Title</b></a>
+          <a class="result__snippet" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fa">Snippet one text.</a>
+        </div>
+        <div class="result">
+          <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Frust-lang.org%2F&amp;rut=y">Second</a>
+        </div>"#;
+        let hits = parse_ddg_hits(html, 10);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].url, "https://example.com/a");
+        assert_eq!(hits[0].title, "First Title"); // tags stripped
+        assert_eq!(hits[0].snippet, "Snippet one text.");
+        assert_eq!(hits[1].url, "https://rust-lang.org/");
+        assert_eq!(hits[1].snippet, ""); // no snippet element → empty, tolerated
+    }
+
+    #[test]
+    fn parse_ddg_hits_respects_limit() {
+        let block = |u: &str| {
+            format!(
+                r#"<a class="result__a" href="//duckduckgo.com/l/?uddg={u}">t</a>"#,
+                u = u
+            )
+        };
+        let html = format!(
+            "{}{}{}",
+            block("https%3A%2F%2Fa.test%2F"),
+            block("https%3A%2F%2Fb.test%2F"),
+            block("https%3A%2F%2Fc.test%2F")
+        );
+        assert_eq!(parse_ddg_hits(&html, 2).len(), 2);
     }
 }

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -15,6 +15,20 @@ fn fetch_outcome(err: &FetchError) -> &'static str {
     }
 }
 
+/// Escalate a rendered fetch from lightpanda (tier 2) to chrome (tier 3)?
+/// Yes when lightpanda "doesn't work": an `Http` failure (spawn/timeout/
+/// non-zero exit all map here), OR a success that rendered no text (the
+/// engine ran but produced nothing — the exit-0-empty case a plain Http-error
+/// check misses). `Guard`/`TooLarge` are tier-independent — chrome can't fix a
+/// blocked host or an oversized body — so never escalate on those.
+fn should_escalate_to_chrome(result: &Result<fetcher::FetchResult, FetchError>) -> bool {
+    match result {
+        Err(FetchError::Http(_)) => true,
+        Ok(res) => res.text.trim().is_empty(),
+        Err(FetchError::Guard(_)) | Err(FetchError::TooLarge) => false,
+    }
+}
+
 fn fetch_error_response(id: Option<serde_json::Value>, verb: &str, err: FetchError) -> Response {
     match err {
         FetchError::Guard(reject) => Response::error(
@@ -124,18 +138,24 @@ impl McpServer {
         let deny = &self.config.deny_hosts;
         if render {
             // Caller may force tier 3 (chrome) directly, e.g. for anti-bot pages
-            // known to defeat lightpanda; otherwise tier 2 first, escalating to
-            // tier 3 only on an actual fetch failure (Http) — Guard/TooLarge
-            // outcomes are tier-independent, so retrying under chrome can't help.
+            // known to defeat lightpanda; otherwise tier 2 (lightpanda) first,
+            // escalating to tier 3 (chrome) when lightpanda "doesn't work" —
+            // see `should_escalate_to_chrome`.
             let want_chrome = args
                 .get("chrome")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
             let cfg = &self.config.browser;
             let browser_timeout = self.config.browser_timeout;
-            return match browser::fetch_rendered(&url, deny, cfg, want_chrome, browser_timeout)
-                .await
-            {
+            let mut result =
+                browser::fetch_rendered(&url, deny, cfg, want_chrome, browser_timeout).await;
+            let mut tier_label = "fetch (rendered)";
+            if !want_chrome && should_escalate_to_chrome(&result) {
+                // lightpanda failed or rendered nothing → retry under chrome.
+                result = browser::fetch_rendered(&url, deny, cfg, true, browser_timeout).await;
+                tier_label = "fetch (tier 3)";
+            }
+            return match result {
                 Ok(result) => {
                     audit(AuditRecord::new("fetch", url, Some(result.tier), "ok"));
                     Response::success(
@@ -143,24 +163,9 @@ impl McpServer {
                         serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
                     )
                 }
-                Err(FetchError::Http(_)) if !want_chrome => {
-                    match browser::fetch_rendered(&url, deny, cfg, true, browser_timeout).await {
-                        Ok(result) => {
-                            audit(AuditRecord::new("fetch", url, Some(result.tier), "ok"));
-                            Response::success(
-                                id,
-                                serde_json::to_value(result).unwrap_or(serde_json::Value::Null),
-                            )
-                        }
-                        Err(e) => {
-                            audit(AuditRecord::new("fetch", url, None, fetch_outcome(&e)));
-                            fetch_error_response(id, "fetch (tier 3)", e)
-                        }
-                    }
-                }
                 Err(e) => {
                     audit(AuditRecord::new("fetch", url, None, fetch_outcome(&e)));
-                    fetch_error_response(id, "fetch (rendered)", e)
+                    fetch_error_response(id, tier_label, e)
                 }
             };
         }
@@ -221,6 +226,37 @@ impl Default for McpServer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn rendered(text: &str, tier: u8) -> Result<fetcher::FetchResult, FetchError> {
+        Ok(fetcher::FetchResult {
+            url: "https://example.com/".into(),
+            status: 200,
+            title: None,
+            text: text.into(),
+            tier,
+        })
+    }
+
+    #[test]
+    fn escalates_to_chrome_on_http_error_or_empty_render() {
+        // Http failure (spawn/timeout/non-zero exit) → escalate.
+        assert!(should_escalate_to_chrome(&Err(FetchError::Http(
+            "spawn agent-browser: fail".into()
+        ))));
+        // lightpanda ran but rendered nothing (exit-0-empty) → escalate.
+        assert!(should_escalate_to_chrome(&rendered("", 2)));
+        assert!(should_escalate_to_chrome(&rendered("   \n  ", 2)));
+        // lightpanda rendered real content → keep tier 2, do NOT escalate.
+        assert!(!should_escalate_to_chrome(&rendered(
+            "Example Domain\nhttps://example.com/",
+            2
+        )));
+        // Tier-independent rejections → never escalate (chrome can't help).
+        assert!(!should_escalate_to_chrome(&Err(FetchError::TooLarge)));
+        assert!(!should_escalate_to_chrome(&Err(FetchError::Guard(
+            crate::net_guard::GuardReject::BadScheme
+        ))));
+    }
 
     fn req(method: &str, params: Option<serde_json::Value>) -> Request {
         Request {

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -150,7 +150,10 @@ impl McpServer {
             let mut result =
                 browser::fetch_rendered(&url, deny, cfg, want_chrome, browser_timeout).await;
             let mut tier_label = "fetch (rendered)";
-            if !want_chrome && should_escalate_to_chrome(&result) {
+            // Escalate only when tier 2 actually ran lightpanda: with no
+            // lightpanda configured the first attempt was already chrome
+            // (build_fetch_argv), so retrying chrome would just waste a spawn.
+            if !want_chrome && cfg.lightpanda_path.is_some() && should_escalate_to_chrome(&result) {
                 // lightpanda failed or rendered nothing → retry under chrome.
                 result = browser::fetch_rendered(&url, deny, cfg, true, browser_timeout).await;
                 tier_label = "fetch (tier 3)";

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -195,9 +195,8 @@ impl McpServer {
             .unwrap_or(self.config.search_limit)
             .clamp(config::MIN_SEARCH_LIMIT, config::MAX_SEARCH_LIMIT);
         let deny = &self.config.deny_hosts;
-        let cfg = &self.config.browser;
-        let timeout = self.config.browser_timeout;
-        match browser::search(&query, limit, deny, cfg, timeout).await {
+        let timeout = self.config.timeout;
+        match fetcher::search_tier1(&query, limit, deny, timeout).await {
             Ok(hits) => {
                 audit(AuditRecord::new("search", query, None, "ok"));
                 Response::success(


### PR DESCRIPTION
## Summary

Fixes G2 from the live deep-research fleet run — the research-gateway `search` tool spawned `agent-browser`, which the worker kernel sandbox denies (`Operation not permitted`), so worker research turns never completed (looped on failing searches → hit iteration cap → `Failed` → empty delegate reply → every fleet step failed). Plus a user-requested browser-engine robustness fix so the `fetch render:true` path actually falls back to a **working** chrome when lightpanda doesn't.

### Search: browserless tier-1 HTTP
- `search` now GETs DuckDuckGo's server-rendered html endpoint through the same proxy-honoring reqwest path `fetch` uses (works under the sandbox), with a required browser User-Agent (DDG 202s without one). Parses result anchors, decoding the `uddg` redirect param. Reuses the SSRF guard + `MAX_BODY_BYTES` cap; retires the dead agent-browser search path. No new dependency, no sandbox change.

### Browser engine: real lightpanda→chrome fallback (fetch render:true)
- **Escalate on empty render too**, not just `Http` error — lightpanda can exit 0 having rendered nothing (`should_escalate_to_chrome`; `Guard`/`TooLarge` stay tier-independent; only when lightpanda was the tier-2 engine).
- **Chrome actually launches now**: stealth flags were pushed as bare argv (`--no-sandbox`), which agent-browser parses as a subcommand → `Unknown command` → the chrome tier silently never worked. Now forwarded as a single `--args "<comma-separated>"` value per `agent-browser --help`.

## Live verification
- Rendered `fetch` succeeds at **tier 3 (chrome)** both as the lightpanda→chrome escalation (bad lightpanda path) and forced `chrome:true` (after clearing zombie chrome procs — the `DevToolsActivePort` failures were stale profile locks from repeated testing, env not code).
- lightpanda still works at tier 2 for a normal page (no regression).
- DDG live search returned empty from this bot-flagged test IP; parser is fixture-tested (first probe returned real results). Reliability is IP-dependent — validate on a clean network / real worker.

## Test plan
- [x] `cargo test -p mur-research-gateway` — 37 + 10 (new: `search_tier1` parser tests, `escalates_to_chrome_on_http_error_or_empty_render`, updated `chrome_tier_carries_stealth_args`)
- [x] clippy `--all-targets -D warnings` + fmt clean
- [x] Live: chrome tier 3 renders; lightpanda tier 2 renders
- [ ] Post-merge operator: live fleet iteration → `search ok=true`, worker turns Complete, signed reply lands in channel (exercises G3 live), convergence progresses

Opus final review: READY TO MERGE (0 Critical/Important).

Plan: `docs/superpowers/plans/2026-07-09-g2-browserless-search-tier.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)