### PR TITLE
fix(deep-research): deny built-in tools on workers (unblocks fleet convergence)

### DIFF
--- a/mur-core/src/cmd/deep_research/provision.rs
+++ b/mur-core/src/cmd/deep_research/provision.rs
@@ -43,6 +43,18 @@ pub const DEFAULT_WORKER_MODEL: &str = "claude_haiku";
 /// this only widens the allow-list off empty.
 const WORKER_LLM_ALLOW_HOSTS: [&str; 2] = ["localhost", "127.0.0.1"];
 
+/// Built-in tools DENIED for a research worker. A worker's job is
+/// search + fetch + reason + report-in-text; it has no business running a
+/// shell or touching the filesystem. Left at the default `Ask` policy these
+/// gate on the HITL approval prompt — which has no answerer in a headless
+/// fleet-delegated turn, so the prompt times out (`hitl_denied`) and FAILS
+/// the whole turn (root-caused live 2026-07-10: a research turn hit
+/// `tool call denied: timed out` after the model reached for a built-in).
+/// Denying them drops the tools from the advertised set entirely
+/// (`tools::registry` skips `Deny`), so the model never calls them and the
+/// turn can complete on the gateway tools alone.
+const WORKER_DENIED_BUILTIN_TOOLS: [&str; 4] = ["bash", "read_file", "write_file", "edit_file"];
+
 /// Name of the gateway MCP server entry mounted on every worker.
 const GATEWAY_MCP_NAME: &str = "research-gateway";
 
@@ -124,8 +136,7 @@ pub fn provision(
         // headless delegated turns don't dead-end on the HITL gate
         // (`tool/approval_needed` has no answerer under fleet delegation →
         // 300 s timeout → deny → task failed). Scoped to
-        // `mcp__research-gateway__*` only — every other tool keeps the
-        // fail-closed `Ask` default. This grants no egress by itself: the
+        // `mcp__research-gateway__*` only. This grants no egress by itself: the
         // gateway's outbound stays Inherit/restricted until the separate
         // explicit-consent `--grant-egress` step.
         profile
@@ -136,6 +147,20 @@ pub fn provision(
                 policy: mur_common::agent::ToolPolicy::Allow,
                 risk: None,
             });
+        // Deny the built-in tools (see WORKER_DENIED_BUILTIN_TOOLS): left at the
+        // default `Ask`, a research turn that reaches for `bash`/`write_file`/…
+        // dead-ends on the unanswerable headless HITL gate and FAILS the turn.
+        // Denied → not advertised → the model never calls them.
+        for tool in WORKER_DENIED_BUILTIN_TOOLS {
+            profile
+                .entitlements
+                .tools
+                .push(mur_common::agent::ToolRule {
+                    pattern: tool.to_string(),
+                    policy: mur_common::agent::ToolPolicy::Deny,
+                    risk: None,
+                });
+        }
         save_profile(&path, &mut profile)?;
 
         names.push(name);
@@ -202,6 +227,10 @@ pub fn cmd_provision(
     println!(
         "  tool policy: {} → allow (gateway search/fetch pre-approved for headless turns)",
         mur_common::mcp_naming::tool_pattern(GATEWAY_MCP_NAME)
+    );
+    println!(
+        "  tool policy: {} → deny (built-ins off so a research turn can't dead-end on the HITL gate)",
+        WORKER_DENIED_BUILTIN_TOOLS.join(", ")
     );
     if grant_egress_flag {
         for name in &names {
@@ -413,12 +442,17 @@ mod tests {
             ToolPolicy::Allow
         );
 
-        // …while every other tool keeps the fail-closed default (Ask): the
-        // rule must be gateway-scoped, never a blanket allow.
-        assert_eq!(
-            resolve_tool_policy(&p.entitlements.tools, "bash"),
-            ToolPolicy::Ask
-        );
+        // …the built-in tools are DENIED (else a headless research turn that
+        // reaches for one dead-ends on the unanswerable HITL gate and fails).
+        for tool in ["bash", "read_file", "write_file", "edit_file"] {
+            assert_eq!(
+                resolve_tool_policy(&p.entitlements.tools, tool),
+                ToolPolicy::Deny,
+                "built-in `{tool}` must be denied for a research worker"
+            );
+        }
+        // …and an unrelated MCP tool keeps the fail-closed default (Ask): the
+        // allow is gateway-scoped, never a blanket allow.
         assert_eq!(
             resolve_tool_policy(&p.entitlements.tools, "mcp__github__merge_pr"),
             ToolPolicy::Ask


### PR DESCRIPTION
## Summary

The last blocker to deep-research fleet convergence. After all the infra + content-budget fixes, fleet worker turns still returned an empty reply → `s1 exit 1` → workflow aborted.

Root cause (captured live via a raw `channel/delegate` socket probe): the delegate turn ended `state: failed` with
```
error: {"code":"hitl_denied","message":"tool call denied: timed out"}
```
Provision allow-listed only the gateway tools (`mcp__research-gateway__* → allow`); the **built-in** tools (`bash`/`read_file`/`write_file`/`edit_file`) stayed at the default `Ask` policy. When a research turn reached for one, it hit the **unanswerable headless HITL gate**, timed out after 300 s, and failed the whole turn. (My earlier context-overflow / iteration-cap theories were wrong — usage was a modest 165k tokens; the failure was the gate.)

Fix: provision now **denies** the built-ins. `tools::registry` drops `Deny`-policy tools from the advertised set, so the model never calls them and the turn completes on the gateway tools alone. A research worker's job is search + fetch + reason + report-in-text — it has no need for a shell or filesystem.

## Live verification (this fix)
- Raw `channel/delegate` probe **before**: `state: failed`, `hitl_denied`, 337 s (300 s of it the HITL timeout).
- **After** (built-ins denied): `state: completed`, no error, **27 s**, and a **signed** `Agent{dr_worker_1}` reply appended to the channel.
- Full fleet iteration with all 4 workers: **0 step failures** (was aborting on s1 every run); all 4 workers wrote **signed** research replies to the channel (8 signed agent events; provenance intact). Real multi-source synthesis produced.

This closes the end-to-end chain: G1 egress proxy + G2 search + G3 channel write + egress header-case + content budget + this — a sandboxed MUR fleet now does real, cited, cryptographically-attributed web research.

## Test plan
- [x] `cargo test -p mur-core provision_stamps_gateway_tool_allow_rule` — asserts gateway `Allow` + all 4 built-ins `Deny` + unrelated MCP stays `Ask`
- [x] clippy `-D warnings` + fmt clean
- [x] Live: delegate turn Completes + signed reply lands; full fleet iteration 0 failures

Note (separate, non-blocking): under 4 concurrent workers DuckDuckGo rate-limits some searches; workers complete gracefully and mark unverified claims. Search-under-concurrency robustness is a distinct follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)