### PR TITLE
docs(deep-research): detailed design doc (en / zh-TW / zh-CN / ja / ko)

### DIFF
--- a/docs/design/deep-research/README.ja.md
+++ b/docs/design/deep-research/README.ja.md
@@ -1,0 +1,156 @@
+<!-- Languages: [English](README.md) · [繁體中文](README.zh-TW.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) -->
+
+# MUR Deep Research — 詳細設計
+
+> MUR フリートがエンドツーエンドで所有するネイティブ深層リサーチ。
+> **v2.45.0**(2026-07-10)でリリース、PR #663–#672。
+
+サンドボックス化された MUR エージェントの分隊が問いを分解し、単一の監査付きゲートウェイ経由でライブ Web をリサーチし、各主張を敵対的に検証し、**引用付き・暗号学的に帰属可能なレポート**へ収束する — ホストのサブエージェントではなく、MUR 自身のオーケストレーション上で。
+
+- **仕様:** `docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md`
+- **クレート:** `mur-research-gateway` · **コマンド:** `mur-core/src/cmd/deep_research`
+
+---
+
+## §1 · なぜホストのサブエージェントではなくネイティブか
+
+Claude Code 組み込みの deep-research は十分に良くリサーチする — だがそれは *ホストのサブエージェント* として動く。作業は Claude のものであり、MUR はラベルを貼るだけ。ネイティブなオーケストレーションこそが成果を *MUR のもの* にし、かつ証明可能にする。
+
+- **MUR のオーケストレーションが所有する。** ルーターの反復ごとの動的 DAG(`cmd/fleet/plan.rs`)に駆動される MUR エージェントのフリートが、実際にリサーチを行う主体である — ホストが spawn して忘れたサブエージェントではない。
+- **暗号学的プロヴェナンス。** すべての主張は、それを生み出したワーカーによって Ed25519 署名付きチャネルへ書き込まれる(Unified Channel v3d-2、*peer-writes-own*)。「このエージェントがこれを見つけた」が検証可能になり、単なる注記ではなくなる。
+- **プラットフォーム統合。** 実測の per-token 予算、キルスイッチ、Commander ガバナンス、スケジューリング、長期メモリ — すべて既存のフリート/エージェント機構に無償で乗る。
+
+**非目標:** 組み込みより並列化すること。並行度はどちらも上限がある(約 `min(16, cores−2)`)。ネイティブが勝つのは所有権・プロヴェナンス・ガバナンスであり、生の速度ではない。
+
+---
+
+## §2 · アーキテクチャ — 3 層、1 つのチョークポイント
+
+ワーカーは egress を **持たず**、唯一のインジェクション面である。決定論的で LLM を持たないゲートウェイのみが Web に到達する — しかも強制されたカーネルサンドボックスの内側から。
+
+```
+┌─────────────────────── fleet "deep-research" ───────────────────────┐
+│  router (mur)  — 反復ごとの動的 DAG (plan.rs)                       │
+│  done_when: marker:RESEARCH_COMPLETE · budget-usd · deadline · kill  │
+└──────────────────────────────┬──────────────────────────────────────┘
+             │ channel/delegate（Ed25519 署名済み返信）
+             ▼
+┌──────────────── worker × k （entitlements: restricted） ────────────┐
+│  model_ref → 実 LLM · MCP を 1 つマウント: research-gateway        │
+│  ツール: search · fetch      組み込みツールは全て deny             │
+└──────────────────────────────┬──────────────────────────────────────┘
+             │ MCP: search(query) / fetch(url)   — 読み取り専用の動詞
+             ▼
+┌────────── research-gateway（Rust、LLM なし、broad-audited egress）──┐
+│  SSRF guard · tier ladder 1→2→3 · content budget · 呼び出しごとの audit │
+└──────────────────────────────────────────────────────────────────────┘
+       強制対象: B1 カーネルサンドボックス + ループバック egress プロキシ
+```
+
+プロンプトインジェクションされたワーカーができるのは、せいぜいゲートウェイに URL を `fetch` させることだけ — ログ化され、SSRF ガードされ、任意ホストへ任意データを POST することはできない。API は `fetch` であって「ソケットを開く」ではない。
+
+---
+
+## §3 · 動的フロー — decompose → research → verify → synthesize
+
+ルーターは `mur fleet run --loop` の反復ごとに新しい DAG を出力する。サブ問いの数は decompose 時に決まる。収束マーカーが単独行に現れるまでループは回る。
+
+1. **Decompose** — ルーターが問いをサブ問い(100+ になり得る)に分解し、作業キューとしてチャネルへ書く。
+2. **Research(×N 反復)** — ルーターがバッチをワーカーへ割り当てる(`max_concurrency` で制限)。各ワーカーは `search()`・`fetch()` し、**それぞれ URL + 裏付けの引用に紐づいた主張**を抽出して署名付き返信で書き戻す。キューが尽きるまで繰り返す。
+3. **Verify(3 票の敵対的検証)** — 各主張を 3 ワーカーへ、それぞれ異なる反証レンズ(正確性 / ソース独立性 / 新しさ)で配る。2/3 の確認で主張は生き残り、そうでなければ破棄(フェイルセーフ = 破棄)。
+4. **Synthesize → 収束** — ルーターが確認済み主張を引用付きレポートへまとめ、単独行に `RESEARCH_COMPLETE` を出力する。構造化された `done_when: marker:…` が決定論的に収束する — 追加の LLM 呼び出しは不要で、マーカーを引用しただけの散文では誤収束しない。
+
+**無償で継承:** *実測* の per-token 会計を伴う `--budget-usd` · `mur fleet stop` キルスイッチ · Commander の kill/budget フック(fail-closed)· 主張ごとの署名済みチャネルプロヴェナンス · 反復上限 / デッドライン / スタック検知のガード。
+
+---
+
+## §4 · research-gateway
+
+MUR に同梱される、依存の軽い小さな Rust MCP サーバー。2 つの読み取り専用動詞、固定でコード駆動の tier ladder(tier を LLM は決めない)、egress の 1 バイトも統治される。
+
+```
+search(query, limit?)  →  [{title, url, snippet}]
+fetch(url, render?)    →  {url, status, title, text, tier}
+```
+
+### エスカレーションの段階(スキルではなく決定論的コード)
+
+| Tier | エンジン | 備考 |
+|------|---------|------|
+| **1 · http** | `reqwest` GET | デフォルトで最も安い。**Search もここを通る:** DuckDuckGo のサーバーレンダリング HTML エンドポイントを、`fetch` と同じプロキシ尊重パスで GET する(ブラウザ風 User-Agent が必要、無いと DDG は HTTP 202 を返す)。したがってブラウザを spawn できないサンドボックス下でも search は動く。 |
+| **2 · lightpanda** | `agent-browser --engine lightpanda` | JS レンダリングページ。`--args ""` は必須 — Chrome の stealth フラグは Lightpanda を壊す。fetch ごとに一意の `--session` id を使い、並行 fetch が cookie jar を共有しない。 |
+| **3 · chrome** | `agent-browser --engine chrome` | アンチボット / スクリーンショット。stealth フラグは単一の `--args "<カンマ区切り>"` 値で渡す(裸の argv はサブコマンドとして解釈される)。レンダリング `fetch` は `Http` 失敗 *または* 空レンダリング時に lightpanda → chrome へエスカレートする。`chrome:true` は tier 3 を強制。 |
+
+- **SSRF ガード(強制・設定不可)** — 解決 IP が private / link-local / loopback / unique-local の URL を拒否し、全 tier でスクリーニングする。ブラウザ tier ではガードと `deny_hosts` を **spawn 前のゲートウェイコードで** 強制する — プロキシはブラウザ子プロセス自身の接続を見られない。
+- **コンテンツ予算** — 単一の 5 MB ページはワーカーのコンテキストを溢れさせる。`fetch` は返すテキストを `max_fetch_chars`(デフォルト 50 000、`0` で無効)で、コードポイント境界で切り、マーカーを付ける。5 MB のボディ上限は転送/メモリを、`max_fetch_chars` はコンテキストを制限する。search のスニペットは切らない。
+- **検索の信頼性** — N 並行ワーカー下で DDG は 202 チャレンジでレート制限する。`search` は 202 時に指数バックオフ + **クエリ由来のジッター** で再試行する — 異なるサブ問いが再試行をずらし、同期して再バーストしない。
+- **URL レベル監査** — 各呼び出しは `{worker, url, tier, outcome}` をチャネルとテレメトリへ記録する。レポートの各引用は 1 つのゲートウェイ監査レコードに突き合わせられる。
+
+---
+
+## §5 · セキュリティモデル — サンドボックス、同意、ツールポリシー
+
+ゲートウェイは強制されたカーネルサンドボックス下で、デフォルト egress なしで動く。アクセスはちょうど 1 つの明示的な同意ステップで付与され、ワーカーのツールポリシーは、ヘッドレスなターンが逃げも詰まりもしないよう形作られる。
+
+| 制御 | 仕組み | 境界 |
+|------|--------|------|
+| **Egress 付与** | ワーカーごとに `mcp set-network research-gateway --broad-audited` — 1 回のオペレーター同意、`EgressAuthorization` として記録。 | フリート作成が egress を暗黙に開くことは **決してない**。「リサーチ用フリートだから」は同意ではない。 |
+| **Egress プロキシ** | 1 つのループバック CONNECT プロキシ。各ワーカーのゲートウェイ子は、その allow/deny ポリシーにスコープされた `HTTPS_PROXY` トークンを受け取る。 | サンドボックスが封をする **前** に起動し、そのポートをループバック限定ルールとしてプロファイルへ刻む必要がある — さもないと子はダイヤルできない。 |
+| `mcp__research-gateway__*` | **allow** | 事前承認され、ヘッドレスのフリートターンが HITL ゲート(応答者なし → 300 秒タイムアウト → 失敗)を回避する。これ自体は egress を付与しない。 |
+| `bash` · `read_file` · `write_file` · `edit_file` | **deny** | リサーチターンが組み込みツールに手を伸ばすと、同じ応答不能なゲートで詰む。deny → 広告されない → 決して呼ばれない。 |
+| その他すべて | **ask** | 上記 2 ルール外のツールは fail-closed デフォルトを維持。 |
+| **プロヴェナンス** | 各ワーカーは自身の返信を `Agent{self}` イベントとして書き込み、Ed25519 署名(v3d-2 peer-writes-own)、fold 時にアクターごとに検証。 | ルーターはもうワーカーの代わりに署名しない — 帰属はワーカー自身の鍵。 |
+| **エクスポート安全性** | `.fleet` インポートは broad-audited を `inherit` へ降格し、承認をクリアする。 | 共有された deep-research フリートは、ローカルで再付与するまで egress ゼロ。 |
+
+**アドバイザリ強制の正直さ。** Tier 1 はプロキシを尊重する。tier 2/3 のブラウザ子プロセスは尊重しないかもしれない — 全域のゲートウェイ URL 監査で緩和し、誇張せず文書化している。完全な封じ込め = 将来の Phase-3 sbpl pin-to-proxy であり、その時ピン留めするのはこの 1 ゲートウェイのみ。
+
+---
+
+## §6 · 運用 — provision、grant、run
+
+```bash
+# 1 · k 個の restricted ワーカーを作成し、各々ゲートウェイをマウントし、
+#     同じ同意ステップで broad-audited egress を付与する
+mur deep-research provision --count 4 --model claude_haiku --grant-egress --yes
+#   tool policy: mcp__research-gateway__* → allow
+#   tool policy: bash, read_file, write_file, edit_file → deny
+#   Updated egress policy for 'research-gateway'.   # × 各ワーカー
+
+# 2 · フリートを作成(router = mur)、done マーカー + 予算を設定
+mur fleet create deep-research \
+    --members dr_worker_1,dr_worker_2,dr_worker_3,dr_worker_4 \
+    --goal "…あなたのリサーチ質問…"
+#   fleet.yaml loop: { max_iterations, budget_usd, done_when: marker:RESEARCH_COMPLETE }
+
+# 3 · ガード付きループを実行 — decompose → research → verify → synthesize
+mur deep-research run deep-research --max-iterations 4 --deadline 30m
+#   fleet 'deep-research' loop stopped after 1 iteration (~$6.14 spent): Converged
+```
+
+- **結果の在り処** — 各ワーカーの引用付き返信は `~/.mur/channels/fleet-deep-research/events.jsonl` の署名済みイベント。`~/.mur/index/channels/` の SQLite read-model は再構築可能な射影。各引用は 1 つのゲートウェイ監査レコードに突き合わせられる。
+- **設定ノブ(ハードコード値なし)** — `MUR_RESEARCH_MAX_FETCH_CHARS`、`…_SEARCH_LIMIT`、`…_TIMEOUT_SECS`、`…_LIGHTPANDA_PATH`、`…_DENY_HOSTS` — env または `~/.mur/config.yaml` の `research_gateway:`。リテラルは決して使わない。
+
+---
+
+## §7 · 実装の現実 — クリーンな設計を現実にする代償
+
+仕様の 4 ボックスのアーキテクチャは正しかった。しかしフリートを実際に収束させる — サンドボックス化・ヘッドレス・暗号学的帰属付き — には、コードを読むのではなくライブのオペレーター検証で見つかった、9 つの独立した修正が浮かび上がった。
+
+| PR | 領域 | 修正 |
+|----|------|------|
+| **#663** | feat | **Native deep-research コア** — ゲートウェイクレート、フリート配線、router/worker/verify スキル。 |
+| **#664** | HITL | **ゲートウェイツールの事前承認** — ヘッドレスターンには `tool/approval_needed` に答える者がおらず → 300 秒タイムアウト → 失敗。provision 時に `mcp__research-gateway__* → allow` を刻む。 |
+| **#665** | G1 · sandbox | **egress プロキシを封の前に起動** — プロキシはサンドボックスが封をした *後* に、決して刻まれないポートで起動していた → すべてのスコープ付き付与が到着即死。封の前に起動し、ループバック限定のポートルールを刻む。 |
+| **#666** | G3 · channel | **channel read-model ディレクトリを付与** — 署名済み返信は `events.jsonl` に着地したが SQLite 更新が読み取り専用 DB に当たる → 偽の失敗。`index/channels` を付与し、追記後の更新を非致命に。 |
+| **#667** | G2 · search | **ブラウザレス検索 + 動く chrome** — search はサンドボックスが拒む `agent-browser` を spawn していた。tier-1 HTTP へ回す。chrome の `--args` 渡しを直し、レンダリングフォールバックが実際に起動するように。 |
+| **#668** | egress | **`Proxy-Authorization` を大文字小文字非依存に** — *egress 全体の解錠*。プロキシは auth ヘッダを大文字小文字依存で照合していたが hyper は小文字で送る → トークン脱落 → *すべての* CONNECT 拒否。`nc` のプロキシトレースでライブ捕捉。 |
+| **#669** | content | **Fetch コンテンツ予算** — 単一の 5 MB ページがワーカーのコンテキストを溢れさせた(`anthropic 400: prompt too long`)。返すテキストを `max_fetch_chars` で切る。 |
+| **#670** | convergence | **ワーカーの組み込みツールを deny** — *収束の解錠*。リサーチターンが `bash`(デフォルト `ask`)に手を伸ばす → 応答不能な HITL ゲート → ターン失敗 → 空の返信 → ステップ失敗。組み込みを deny すればモデルはそれらを見ることさえない。raw `channel/delegate` ソケットプローブで根本原因を特定。 |
+| **#671** | reliability | **DDG 202 の再試行 + ジッター** — 並行ワーカーが DuckDuckGo のレート制限を踏んだ。202 をバックオフ + クエリ由来のジッターで再試行。レポートは「アクセス制限」から各 16–19 引用へ。 |
+| **#672** | G4 · cleanup | **ロード時に非スキルディレクトリをスキップ** — `skills/` 下のフリート実行台帳(`fleet:<name>/`)が起動ごとに約 14 の名前検証警告を撒いていた。`load_all` はマニフェストの無いディレクトリをスキップする — インジェクション経路のみで、成熟度スイープには手を触れない。 |
+
+**エンドツーエンド検証:** 新規 provision → `run`:ステップ失敗ゼロ、全ワーカーが **署名済み** 返信を書き込み(Ed25519 プロヴェナンス)、ループは **Converged** で停止、ルーターは引用付きの Ollama / LM Studio / LocalAI 比較を生成 — 4 ワーカー並行、完全にカーネルサンドボックス内で。
+
+---
+
+*本設計文書は v2.45.0 時点の出荷実装を反映する。「完全な」egress 封じ込め(sbpl pin-to-proxy)と一級の検索 API は、意図的な Phase-3 の後続として残る。*

--- a/docs/design/deep-research/README.ko.md
+++ b/docs/design/deep-research/README.ko.md
@@ -1,0 +1,156 @@
+<!-- Languages: [English](README.md) · [繁體中文](README.zh-TW.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) -->
+
+# MUR Deep Research — 상세 설계
+
+> MUR 플릿이 엔드투엔드로 소유하는 네이티브 딥 리서치.
+> **v2.45.0**(2026-07-10)에 출시, PR #663–#672.
+
+샌드박스화된 MUR 에이전트 분대가 질문을 분해하고, 단일 감사 게이트웨이를 통해 실시간 웹을 리서치하고, 각 주장을 적대적으로 검증하고, **인용이 달리고 암호학적으로 귀속 가능한 보고서**로 수렴한다 — 호스트 서브에이전트가 아니라 MUR 자체의 오케스트레이션 위에서.
+
+- **명세:** `docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md`
+- **크레이트:** `mur-research-gateway` · **명령:** `mur-core/src/cmd/deep_research`
+
+---
+
+## §1 · 왜 호스트 서브에이전트가 아니라 네이티브인가
+
+Claude Code 내장 deep-research 는 이미 리서치를 잘한다 — 하지만 그것은 *호스트 서브에이전트* 로 실행된다. 작업은 Claude 의 것이고, MUR 은 라벨만 붙인다. 네이티브 오케스트레이션이야말로 결과를 *MUR 의 것* 으로, 그리고 증명 가능하게 만든다.
+
+- **MUR 오케스트레이션이 소유한다.** 라우터의 반복별 동적 DAG(`cmd/fleet/plan.rs`)로 구동되는 MUR 에이전트 플릿이 실제로 리서치를 수행하는 주체다 — 호스트가 spawn 하고 잊어버린 서브에이전트가 아니다.
+- **암호학적 프로비넌스.** 모든 주장은 그것을 만들어낸 워커에 의해 Ed25519 서명된 채널에 기록된다(Unified Channel v3d-2, *peer-writes-own*). "이 에이전트가 이것을 찾았다" 가 캡션이 아니라 검증 가능해진다.
+- **플랫폼 통합.** 실측 per-token 예산, 킬 스위치, Commander 거버넌스, 스케줄링, 장기 메모리 — 모두 기존 플릿/에이전트 기구에 무료로 올라탄다.
+
+**비목표:** 내장보다 더 병렬화하는 것. 동시성은 양쪽 다 상한이 있다(약 `min(16, cores−2)`). 네이티브가 이기는 지점은 소유권·프로비넌스·거버넌스이지, 순수 속도가 아니다.
+
+---
+
+## §2 · 아키텍처 — 세 계층, 하나의 초크 포인트
+
+워커는 egress 를 **가지지 않으며** 유일한 주입 표면이다. 결정론적이고 LLM 이 없는 게이트웨이만이 웹에 도달한다 — 그것도 강제된 커널 샌드박스 안에서.
+
+```
+┌─────────────────────── fleet "deep-research" ───────────────────────┐
+│  router (mur)  — 반복별 동적 DAG (plan.rs)                          │
+│  done_when: marker:RESEARCH_COMPLETE · budget-usd · deadline · kill  │
+└──────────────────────────────┬──────────────────────────────────────┘
+             │ channel/delegate（Ed25519 서명된 응답）
+             ▼
+┌──────────────── worker × k （entitlements: restricted） ────────────┐
+│  model_ref → 실제 LLM · MCP 1 개 마운트: research-gateway          │
+│  도구: search · fetch      내장 도구는 전부 deny                    │
+└──────────────────────────────┬──────────────────────────────────────┘
+             │ MCP: search(query) / fetch(url)   — 읽기 전용 동사
+             ▼
+┌────────── research-gateway（Rust, LLM 없음, broad-audited egress）──┐
+│  SSRF guard · tier ladder 1→2→3 · content budget · 호출별 audit      │
+└──────────────────────────────────────────────────────────────────────┘
+       강제 대상: B1 커널 샌드박스 + 루프백 egress 프록시
+```
+
+프롬프트 인젝션된 워커가 할 수 있는 것은 기껏해야 게이트웨이에 URL 을 `fetch` 시키는 것뿐이다 — 로그로 남고, SSRF 로 차단되며, 임의 호스트에 임의 데이터를 POST 할 수 없다. API 는 `fetch` 이지 "소켓을 연다" 가 아니다.
+
+---
+
+## §3 · 동적 흐름 — decompose → research → verify → synthesize
+
+라우터는 `mur fleet run --loop` 의 매 반복마다 새 DAG 를 방출한다. 하위 질문 수는 decompose 시점에 정해진다. 수렴 마커가 자기 한 줄에 나타날 때까지 루프가 돈다.
+
+1. **Decompose** — 라우터가 질문을 하위 질문(100+ 가능)으로 분해해 작업 큐로 채널에 쓴다.
+2. **Research(×N 반복)** — 라우터가 배치를 워커에 할당한다(`max_concurrency` 로 제한). 각 워커는 `search()`·`fetch()` 하고, **각각 URL + 뒷받침 인용에 묶인 주장** 을 추출해 서명된 응답으로 되쓴다. 큐가 소진될 때까지 반복한다.
+3. **Verify(3 표 적대적)** — 각 주장을 서로 다른 반증 렌즈(정확성 / 소스 독립성 / 최신성)를 가진 세 워커에 배분한다. 2/3 확인이면 주장은 살아남고, 아니면 폐기(페일세이프 = 폐기).
+4. **Synthesize → 수렴** — 라우터가 확인된 주장을 인용 보고서로 접고, 자기 한 줄에 `RESEARCH_COMPLETE` 를 방출한다. 구조화된 `done_when: marker:…` 가 결정론적으로 수렴한다 — 추가 LLM 호출이 없고, 마커를 인용만 한 산문으로는 거짓 수렴이 불가하다.
+
+**무료 상속:** *실측* per-token 회계를 동반한 `--budget-usd` · `mur fleet stop` 킬 스위치 · Commander kill/budget 훅(fail-closed) · 주장별 서명 채널 프로비넌스 · 반복 상한 / 데드라인 / 정체 감지 가드.
+
+---
+
+## §4 · research-gateway
+
+MUR 에 동봉되는, 의존성이 가벼운 작은 Rust MCP 서버. 두 개의 읽기 전용 동사, 고정되고 코드로 구동되는 tier ladder(tier 를 LLM 이 정하지 않음), egress 의 1 바이트까지 통치된다.
+
+```
+search(query, limit?)  →  [{title, url, snippet}]
+fetch(url, render?)    →  {url, status, title, text, tier}
+```
+
+### 에스컬레이션 사다리(스킬이 아니라 결정론적 코드)
+
+| Tier | 엔진 | 비고 |
+|------|------|------|
+| **1 · http** | `reqwest` GET | 기본이자 가장 저렴. **Search 도 여기를 탄다:** DuckDuckGo 의 서버 렌더링 HTML 엔드포인트를 `fetch` 와 같은 프록시 존중 경로로 GET 한다(브라우저형 User-Agent 필요, 없으면 DDG 는 HTTP 202 반환). 그래서 브라우저를 spawn 할 수 없는 샌드박스에서도 search 가 동작한다. |
+| **2 · lightpanda** | `agent-browser --engine lightpanda` | JS 렌더링 페이지. `--args ""` 는 필수 — Chrome stealth 플래그는 Lightpanda 를 망가뜨린다. fetch 마다 고유 `--session` id 로 동시 fetch 가 쿠키 jar 를 공유하지 않게 한다. |
+| **3 · chrome** | `agent-browser --engine chrome` | 안티봇 / 스크린샷. stealth 플래그는 단일 `--args "<콤마 구분>"` 값으로 전달한다(맨 argv 는 서브커맨드로 해석됨). 렌더링 `fetch` 는 `Http` 실패 *또는* 빈 렌더링 시 lightpanda → chrome 으로 에스컬레이트한다. `chrome:true` 는 tier 3 를 강제한다. |
+
+- **SSRF 가드(강제·설정 불가)** — 해석된 IP 가 private / link-local / loopback / unique-local 인 URL 을 거부하고, 모든 tier 에서 스크리닝한다. 브라우저 tier 에서는 가드와 `deny_hosts` 를 **spawn 전 게이트웨이 코드에서** 강제한다 — 프록시는 브라우저 자식 프로세스 자신의 연결을 볼 수 없다.
+- **콘텐츠 예산** — 단일 5 MB 페이지는 워커 컨텍스트를 넘치게 한다. `fetch` 는 반환 텍스트를 `max_fetch_chars`(기본 50 000, `0` 이면 비활성)로 코드포인트 경계에서 자르고 마커를 붙인다. 5 MB 바디 상한은 전송/메모리를, `max_fetch_chars` 는 컨텍스트를 제한한다. search 스니펫은 자르지 않는다.
+- **검색 신뢰성** — N 동시 워커에서 DDG 는 202 챌린지로 레이트 리밋한다. `search` 는 202 시 지수 백오프 + **쿼리 기반 지터** 로 재시도한다 — 서로 다른 하위 질문이 재시도를 어긋나게 하여 동기적으로 다시 폭주하지 않는다.
+- **URL 수준 감사** — 각 호출은 `{worker, url, tier, outcome}` 을 채널과 텔레메트리에 기록한다. 보고서의 각 인용은 하나의 게이트웨이 감사 레코드에 대응된다.
+
+---
+
+## §5 · 보안 모델 — 샌드박스, 동의, 도구 정책
+
+게이트웨이는 강제된 커널 샌드박스 아래에서 기본 egress 없이 동작한다. 접근은 정확히 하나의 명시적 동의 단계로 부여되며, 워커의 도구 정책은 헤드리스 턴이 탈출도 정체도 하지 않도록 형성된다.
+
+| 제어 | 메커니즘 | 경계 |
+|------|----------|------|
+| **Egress 부여** | 워커별 `mcp set-network research-gateway --broad-audited` — 한 번의 오퍼레이터 동의, `EgressAuthorization` 으로 기록. | 플릿 생성이 egress 를 암묵적으로 여는 일은 **결코 없다**. "리서치 플릿이니까" 는 동의가 아니다. |
+| **Egress 프록시** | 하나의 루프백 CONNECT 프록시. 각 워커의 게이트웨이 자식은 자신의 allow/deny 정책으로 스코프된 `HTTPS_PROXY` 토큰을 받는다. | 샌드박스가 봉인되기 **전** 에 기동하고, 그 포트를 루프백 전용 규칙으로 프로파일에 새겨야 한다 — 아니면 자식이 다이얼할 수 없다. |
+| `mcp__research-gateway__*` | **allow** | 사전 승인되어 헤드리스 플릿 턴이 HITL 게이트(응답자 없음 → 300 초 타임아웃 → 실패)를 우회한다. 그 자체로는 egress 를 부여하지 않는다. |
+| `bash` · `read_file` · `write_file` · `edit_file` | **deny** | 리서치 턴이 내장 도구로 손을 뻗으면 같은 응답 불가 게이트에서 막힌다. deny → 광고되지 않음 → 결코 호출되지 않음. |
+| 그 외 전부 | **ask** | 위 두 규칙 밖의 도구는 fail-closed 기본을 유지한다. |
+| **프로비넌스** | 각 워커는 자신의 응답을 `Agent{self}` 이벤트로 기록하고 Ed25519 서명(v3d-2 peer-writes-own)하며, fold 시 액터별로 검증한다. | 라우터는 더 이상 워커를 대신해 서명하지 않는다 — 귀속은 워커 자신의 키다. |
+| **내보내기 안전성** | `.fleet` 임포트는 broad-audited 를 `inherit` 로 강등하고 승인을 지운다. | 공유된 deep-research 플릿은 로컬에서 재부여하기 전까지 egress 가 0 이다. |
+
+**어드바이저리 강제의 정직함.** Tier 1 은 프록시를 존중한다. tier 2/3 의 브라우저 자식 프로세스는 그러지 않을 수 있다 — 전역 게이트웨이 URL 감사로 완화하고, 과장 없이 문서화한다. 완전한 봉쇄 = 향후 Phase-3 sbpl pin-to-proxy 이며, 그때 핀 고정하는 것은 바로 이 하나의 게이트웨이뿐이다.
+
+---
+
+## §6 · 운영 — provision, grant, run
+
+```bash
+# 1 · k 개의 restricted 워커를 만들고, 각각 게이트웨이를 마운트하고,
+#     같은 동의 단계에서 broad-audited egress 를 부여한다
+mur deep-research provision --count 4 --model claude_haiku --grant-egress --yes
+#   tool policy: mcp__research-gateway__* → allow
+#   tool policy: bash, read_file, write_file, edit_file → deny
+#   Updated egress policy for 'research-gateway'.   # × 각 워커
+
+# 2 · 플릿 생성(router = mur), done 마커 + 예산 설정
+mur fleet create deep-research \
+    --members dr_worker_1,dr_worker_2,dr_worker_3,dr_worker_4 \
+    --goal "…당신의 리서치 질문…"
+#   fleet.yaml loop: { max_iterations, budget_usd, done_when: marker:RESEARCH_COMPLETE }
+
+# 3 · 가드된 루프 실행 — decompose → research → verify → synthesize
+mur deep-research run deep-research --max-iterations 4 --deadline 30m
+#   fleet 'deep-research' loop stopped after 1 iteration (~$6.14 spent): Converged
+```
+
+- **결과가 있는 곳** — 각 워커의 인용 응답은 `~/.mur/channels/fleet-deep-research/events.jsonl` 의 서명된 이벤트다. `~/.mur/index/channels/` 의 SQLite read-model 은 재구축 가능한 프로젝션이다. 각 인용은 하나의 게이트웨이 감사 레코드에 대응된다.
+- **설정 노브(하드코딩 값 없음)** — `MUR_RESEARCH_MAX_FETCH_CHARS`, `…_SEARCH_LIMIT`, `…_TIMEOUT_SECS`, `…_LIGHTPANDA_PATH`, `…_DENY_HOSTS` — env 또는 `~/.mur/config.yaml` 의 `research_gateway:`, 결코 리터럴을 쓰지 않는다.
+
+---
+
+## §7 · 구현의 현실 — 깨끗한 설계를 실현하는 데 든 대가
+
+명세의 4 박스 아키텍처는 옳았다. 그러나 플릿을 실제로 수렴시키는 것 — 샌드박스화·헤드리스·암호학적 귀속 — 은 코드를 읽어서가 아니라 라이브 오퍼레이터 검증으로 발견된 9 개의 독립된 수정을 드러냈다.
+
+| PR | 영역 | 수정 |
+|----|------|------|
+| **#663** | feat | **Native deep-research 코어** — 게이트웨이 크레이트, 플릿 배선, router/worker/verify 스킬. |
+| **#664** | HITL | **게이트웨이 도구 사전 승인** — 헤드리스 턴에는 `tool/approval_needed` 에 답할 자가 없어 → 300 초 타임아웃 → 실패. provision 시 `mcp__research-gateway__* → allow` 를 새긴다. |
+| **#665** | G1 · sandbox | **egress 프록시를 봉인 전에 기동** — 프록시가 샌드박스 봉인 *후* 에, 결코 새겨지지 않은 포트에서 기동 → 모든 스코프 부여가 도착 즉시 사망. 봉인 전에 기동하고 루프백 전용 포트 규칙을 새긴다. |
+| **#666** | G3 · channel | **channel read-model 디렉터리 부여** — 서명된 응답이 `events.jsonl` 에 착지했으나 SQLite 갱신이 읽기 전용 DB 에 부딪힘 → 거짓 실패. `index/channels` 를 부여하고, 추가 후 갱신을 비치명으로. |
+| **#667** | G2 · search | **브라우저 없는 검색 + 동작하는 chrome** — search 가 샌드박스가 금지한 `agent-browser` 를 spawn 했다. tier-1 HTTP 로 우회. chrome `--args` 전달을 고쳐 렌더 폴백이 실제로 기동하게. |
+| **#668** | egress | **`Proxy-Authorization` 대소문자 무시** — *egress 전체 잠금 해제*. 프록시가 auth 헤더를 대소문자 구분으로 대조했으나 hyper 는 소문자로 보냄 → 토큰 유실 → *모든* CONNECT 거부. `nc` 프록시 트레이스로 라이브 포착. |
+| **#669** | content | **Fetch 콘텐츠 예산** — 단일 5 MB 페이지가 워커 컨텍스트를 넘치게 함(`anthropic 400: prompt too long`). 반환 텍스트를 `max_fetch_chars` 로 자른다. |
+| **#670** | convergence | **워커 내장 도구 deny** — *수렴 잠금 해제*. 리서치 턴이 `bash`(기본 `ask`)로 손을 뻗음 → 응답 불가 HITL 게이트 → 턴 실패 → 빈 응답 → 스텝 실패. 내장을 deny 하면 모델은 그것들을 보지도 못한다. raw `channel/delegate` 소켓 프로브로 근본 원인 규명. |
+| **#671** | reliability | **DDG 202 재시도 + 지터** — 동시 워커가 DuckDuckGo 레이트 리밋을 밟음. 202 를 백오프 + 쿼리 기반 지터로 재시도. 보고서가 "접근 제한" 에서 각각 16–19 인용으로. |
+| **#672** | G4 · cleanup | **로드 시 비스킬 디렉터리 건너뛰기** — `skills/` 아래 플릿 실행 원장(`fleet:<name>/`)이 부팅마다 약 14 개의 이름 검증 경고를 뿌렸다. `load_all` 은 매니페스트 없는 디렉터리를 건너뛴다 — 주입 경로에서만, 성숙도 스윕은 건드리지 않는다. |
+
+**엔드투엔드 검증:** 신규 provision → `run`: 스텝 실패 0, 모든 워커가 **서명된** 응답 기록(Ed25519 프로비넌스), 루프가 **Converged** 로 정지, 라우터가 인용이 달린 Ollama / LM Studio / LocalAI 비교를 생성 — 4 워커 동시성 하에서, 완전히 커널 샌드박스 안에서.
+
+---
+
+*이 설계 문서는 v2.45.0 시점의 출시 구현을 반영한다. "완전한" egress 봉쇄(sbpl pin-to-proxy)와 일급 검색 API 는 의도된 Phase-3 후속으로 남는다.*

--- a/docs/design/deep-research/README.md
+++ b/docs/design/deep-research/README.md
@@ -1,0 +1,156 @@
+<!-- Languages: [English](README.md) · [繁體中文](README.zh-TW.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) -->
+
+# MUR Deep Research — Detailed Design
+
+> Native deep research, owned end to end by a MUR fleet.
+> Shipped in **v2.45.0** (2026-07-10), PRs #663–#672.
+
+A sandboxed squad of MUR agents decomposes a question, researches the live web through a single audited gateway, adversarially verifies each claim, and converges on a **cited, cryptographically-attributed report** — on MUR's own orchestration, not host subagents.
+
+- **Spec:** `docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md`
+- **Crate:** `mur-research-gateway` · **Command:** `mur-core/src/cmd/deep_research`
+
+---
+
+## §1 · Why native, not host subagents
+
+Claude Code's built-in deep-research already researches well — but it runs as *host subagents*. The work is Claude's; MUR only labels it. Native orchestration is what makes the result *MUR's*, and provable.
+
+- **MUR orchestration owns it.** A fleet of MUR agents, driven by the router's dynamic per-iteration DAG (`cmd/fleet/plan.rs`), is the thing doing the research — not a subagent the host spawned and forgot.
+- **Cryptographic provenance.** Every claim is written into an Ed25519-signed channel by the worker that produced it (Unified Channel v3d-2, *peer-writes-own*). "This agent found this" becomes verifiable, not a caption.
+- **Platform integration.** Real per-token budget, kill-switch, Commander governance, scheduling, and long-term memory all ride the existing fleet/agent machinery — for free.
+
+**Non-goal:** out-parallelizing the built-in. Concurrency is bounded either way (~`min(16, cores−2)`). Native wins on ownership, provenance, and governance — not raw speed.
+
+---
+
+## §2 · Architecture — three layers, one choke point
+
+Workers hold **no** egress and are the only injectable surface. Only the deterministic, no-LLM gateway reaches the web — and it does so from inside an enforced kernel sandbox.
+
+```
+┌─────────────────────── fleet "deep-research" ───────────────────────┐
+│  router (mur)  — dynamic per-iteration DAG (plan.rs)                 │
+│  done_when: marker:RESEARCH_COMPLETE · budget-usd · deadline · kill  │
+└──────────────────────────────┬──────────────────────────────────────┘
+             │ channel/delegate (Ed25519-signed reply)
+             ▼
+┌──────────────── worker × k  (entitlements: restricted) ─────────────┐
+│  model_ref → real LLM · mounts 1 MCP: research-gateway              │
+│  tools: search · fetch      built-ins denied                        │
+└──────────────────────────────┬──────────────────────────────────────┘
+             │ MCP: search(query) / fetch(url)   — read-only verbs
+             ▼
+┌────────── research-gateway (Rust, no LLM, broad-audited egress) ─────┐
+│  SSRF guard · tier ladder 1→2→3 · content budget · per-call audit    │
+└──────────────────────────────────────────────────────────────────────┘
+       enforced under: B1 kernel sandbox + loopback egress proxy
+```
+
+A prompt-injected worker can at most ask the gateway to `fetch` a URL — logged, SSRF-guarded, and incapable of POSTing arbitrary data to arbitrary hosts. The API is `fetch`, not "open a socket."
+
+---
+
+## §3 · Dynamic flow — decompose → research → verify → synthesize
+
+The router emits a fresh DAG each iteration of `mur fleet run --loop`; sub-question count is decided at decompose time. The loop runs until the synthesis marker appears on its own line.
+
+1. **Decompose** — the router splits the question into sub-questions (may be 100+) and writes them to the channel as a work queue.
+2. **Research (×N iterations)** — the router assigns a batch to workers (bounded by `max_concurrency`). Each worker `search()`es, `fetch()`es the top sources, and extracts **claims each bound to a URL + a supporting quote**, writing them back as a signed reply. Repeats until the queue drains.
+3. **Verify (3-vote adversarial)** — each claim is dispatched to three workers, each with a distinct refutation lens: correctness / source-independence / recency. A claim survives on a 2-of-3 confirm; otherwise it is dropped (fail-safe = drop).
+4. **Synthesize → converge** — the router folds confirmed claims into a cited report and emits `RESEARCH_COMPLETE` on its own line. The structured `done_when: marker:…` converges deterministically — no extra LLM call, and prose that merely quotes the marker can't false-converge.
+
+**Inherited for free:** `--budget-usd` with *real* per-token accounting · `mur fleet stop` kill-switch · Commander kill/budget hooks (fail-closed) · signed-channel provenance per claim · iteration-cap / deadline / stuck-detection guards.
+
+---
+
+## §4 · The research-gateway
+
+A small, dependency-light Rust MCP server shipped with MUR. Two read-only verbs; a fixed, code-driven tier ladder (no LLM decides tiers); every byte of egress governed.
+
+```
+search(query, limit?)  →  [{title, url, snippet}]
+fetch(url, render?)    →  {url, status, title, text, tier}
+```
+
+### Escalation ladder (deterministic code, not a skill)
+
+| Tier | Engine | Notes |
+|------|--------|-------|
+| **1 · http** | `reqwest` GET | Default, cheapest. **Search rides here too:** it GETs DuckDuckGo's server-rendered HTML endpoint through the same proxy-honoring path (a browser-like User-Agent is required, or DDG returns HTTP 202), so search works under the sandbox where a browser can't spawn. |
+| **2 · lightpanda** | `agent-browser --engine lightpanda` | JS-rendered pages. `--args ""` is mandatory — Chrome stealth flags break Lightpanda. A per-fetch `--session` id keeps concurrent fetches from sharing cookie jars. |
+| **3 · chrome** | `agent-browser --engine chrome` | Anti-bot / screenshot. Stealth flags travel as one `--args "<comma-sep>"` value (bare argv is parsed as a subcommand). A rendered `fetch` escalates lightpanda → chrome on an `Http` failure *or* an empty render; `chrome:true` forces tier 3. |
+
+- **SSRF guard (hard, non-configurable)** — refuse any URL whose resolved IP is private / link-local / loopback / unique-local, screened on every tier. For the browser tiers, the guard and `deny_hosts` are enforced **in gateway code before spawn** — the proxy can't see a browser subprocess's own connections.
+- **Content budget** — a single 5 MB page would overflow the worker's context. `fetch` caps returned text at `max_fetch_chars` (default 50 000; `0` disables), on a codepoint boundary, with a truncation marker. The 5 MB body cap bounds transfer/memory; `max_fetch_chars` bounds context. Search snippets aren't capped.
+- **Search reliability** — under N concurrent workers DDG rate-limits with a 202 challenge. `search` retries on 202 with exponential backoff + a **query-seeded jitter** — distinct sub-questions stagger their retries instead of re-bursting in sync.
+- **URL-level audit** — every call logs `{worker, url, tier, outcome}` to the channel and telemetry. Every report citation reconciles to one gateway audit record.
+
+---
+
+## §5 · Security model — sandbox, consent, and the tool policy
+
+The gateway runs under an enforced kernel sandbox with no default egress. Access is granted through exactly one explicit consent step; the worker's tool policy is shaped so headless turns can neither escape nor stall.
+
+| Control | Mechanism | Boundary |
+|---------|-----------|----------|
+| **Egress grant** | Per-worker `mcp set-network research-gateway --broad-audited` — one operator consent, recorded as `EgressAuthorization`. | Fleet creation **never** opens egress implicitly. "It's a research fleet" is not consent. |
+| **Egress proxy** | One loopback CONNECT proxy; each worker's gateway child gets an `HTTPS_PROXY` token scoped to its allow/deny policy. | Must start **before** the sandbox seals, with its port carved in as a loopback-only rule — else children can't dial it. |
+| `mcp__research-gateway__*` | **allow** | Pre-approved so headless fleet turns skip the HITL gate (which has no answerer → 300 s timeout → fail). Grants no egress by itself. |
+| `bash` · `read_file` · `write_file` · `edit_file` | **deny** | A research turn that reaches for a built-in would dead-end on the same unanswerable gate. Denied → not advertised → never called. |
+| Everything else | **ask** | Fail-closed default preserved for any tool not in the two rules above. |
+| **Provenance** | Each worker appends its own reply as an `Agent{self}` event, Ed25519-signed (v3d-2 peer-writes-own), verified per-actor on fold. | The router no longer signs on a worker's behalf — attribution is the worker's own key. |
+| **Export safety** | `.fleet` import downgrades broad-audited → `inherit` and clears authorization. | A shared deep-research fleet has zero egress until re-granted locally. |
+
+**Advisory-enforcement honesty.** Tier 1 honors the proxy; the tier 2/3 browser subprocesses may not — mitigated by universal gateway URL audit, and documented rather than overclaimed. Airtight containment = a future Phase-3 sbpl pin-to-proxy, which then pins exactly this one gateway.
+
+---
+
+## §6 · Operating it — provision, grant, run
+
+```bash
+# 1 · create k restricted workers, each mounting the gateway,
+#     and grant broad-audited egress in the same consent step
+mur deep-research provision --count 4 --model claude_haiku --grant-egress --yes
+#   tool policy: mcp__research-gateway__* → allow
+#   tool policy: bash, read_file, write_file, edit_file → deny
+#   Updated egress policy for 'research-gateway'.   # × each worker
+
+# 2 · create the fleet (router = mur), set a done marker + budget
+mur fleet create deep-research \
+    --members dr_worker_1,dr_worker_2,dr_worker_3,dr_worker_4 \
+    --goal "…your research question…"
+#   fleet.yaml loop: { max_iterations, budget_usd, done_when: marker:RESEARCH_COMPLETE }
+
+# 3 · run the guarded loop — decompose → research → verify → synthesize
+mur deep-research run deep-research --max-iterations 4 --deadline 30m
+#   fleet 'deep-research' loop stopped after 1 iteration (~$6.14 spent): Converged
+```
+
+- **Where results live** — each worker's cited reply is a signed event in `~/.mur/channels/fleet-deep-research/events.jsonl`. The SQLite read-model at `~/.mur/index/channels/` is a rebuildable projection. Every citation reconciles to a gateway audit record.
+- **Config knobs (no hardcoded values)** — `MUR_RESEARCH_MAX_FETCH_CHARS`, `…_SEARCH_LIMIT`, `…_TIMEOUT_SECS`, `…_LIGHTPANDA_PATH`, `…_DENY_HOSTS` — env or `research_gateway:` in `~/.mur/config.yaml`, never literals.
+
+---
+
+## §7 · Implementation reality — what the clean design cost to make real
+
+The spec's four-box architecture was right. Getting a fleet to actually converge — sandboxed, headless, cryptographically attributed — surfaced nine distinct fixes, each found by live operator verification, not by reading code.
+
+| PR | Area | Fix |
+|----|------|-----|
+| **#663** | feat | **Native deep-research core** — the gateway crate, fleet wiring, and router/worker/verify skills. |
+| **#664** | HITL | **Pre-approve gateway tools** — headless turns had no one to answer `tool/approval_needed` → 300 s timeout → failed. Stamp `mcp__research-gateway__* → allow` at provision. |
+| **#665** | G1 · sandbox | **Pre-seal the egress proxy** — it started *after* the sandbox sealed, on a port never carved in → every scoped grant dead on arrival. Start it pre-seal; carve a loopback-only port rule. |
+| **#666** | G3 · channel | **Grant the channel read-model dir** — a signed reply landed in `events.jsonl` but the SQLite refresh hit a read-only DB → false failure. Grant `index/channels`; make the post-append refresh non-fatal. |
+| **#667** | G2 · search | **Browserless search + working chrome** — search spawned `agent-browser` the sandbox denies. Route it through tier-1 HTTP; fix the chrome `--args` forwarding so the render fallback actually launches. |
+| **#668** | egress | **Case-insensitive `Proxy-Authorization`** — the *total-egress unblock*. The proxy matched the auth header case-sensitively, but hyper emits it lowercase → token dropped → *every* CONNECT denied. Captured live with an `nc` proxy trace. |
+| **#669** | content | **Fetch content budget** — one 5 MB page overflowed the worker's context (`anthropic 400: prompt too long`). Cap returned text at `max_fetch_chars`. |
+| **#670** | convergence | **Deny worker built-in tools** — the *convergence unblock*. A research turn reached for `bash` (default `ask`) → the unanswerable HITL gate → turn failed → empty reply → step failed. Deny built-ins; the model never sees them. Root-caused via a raw `channel/delegate` socket probe. |
+| **#671** | reliability | **DDG 202 retry + jitter** — concurrent workers tripped DuckDuckGo's rate-limit. Retry the 202 with backoff + query-seeded jitter; reports went from "access limited" to 16–19 citations each. |
+| **#672** | G4 · cleanup | **Skip non-skill dirs on load** — fleet run-ledgers (`fleet:<name>/`) under `skills/` spammed ~14 name-validation warnings per boot. `load_all` skips manifest-less dirs — in the injection path only, so the maturity sweep is untouched. |
+
+**Verified end to end:** fresh provision → `run`: 0 step failures, all workers wrote **signed** replies (Ed25519 provenance), the loop stopped **Converged**, and the router produced a cited Ollama / LM Studio / LocalAI comparison — under 4-worker concurrency, entirely inside the kernel sandbox.
+
+---
+
+*This design doc reflects the shipped implementation as of v2.45.0. "Airtight" egress containment (sbpl pin-to-proxy) and a first-class search API remain deliberate Phase-3 follow-ons.*

--- a/docs/design/deep-research/README.zh-CN.md
+++ b/docs/design/deep-research/README.zh-CN.md
@@ -1,0 +1,156 @@
+<!-- Languages: [English](README.md) · [繁體中文](README.zh-TW.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) -->
+
+# MUR Deep Research — 详细设计
+
+> 由 MUR fleet 端到端自有的 native 深度研究。
+> 于 **v2.45.0**(2026-07-10)发布,PR #663–#672。
+
+一支 sandboxed 的 MUR agent 小队拆解问题、通过单一审计 gateway 研究实时网络、对每个论断做对抗式验证,最终收敛成一份**带引用、密码学可归属的报告**——全部在 MUR 自有的编排上,而非 host subagents。
+
+- **规格:** `docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md`
+- **Crate:** `mur-research-gateway` · **命令:** `mur-core/src/cmd/deep_research`
+
+---
+
+## §1 · 为什么要 native,而非 host subagents
+
+Claude Code 内置的 deep-research 研究得很好——但它以 *host subagents* 运行。工作是 Claude 的,MUR 只是贴标签。Native 编排才让成果是 *MUR 的*,而且可证明。
+
+- **MUR 编排拥有它。** 由 router 的每轮动态 DAG(`cmd/fleet/plan.rs`)驱动的一支 MUR agent fleet,才是真正在做研究的主体——不是 host spawn 完就遗忘的 subagent。
+- **密码学 provenance。** 每个论断都由产出它的 worker 写入一条 Ed25519 签名的 channel(Unified Channel v3d-2,*peer-writes-own*)。“这个 agent 找到这个”变得可验证,而不是一句标注。
+- **平台集成。** 真实的 per-token 预算、kill-switch、Commander governance、调度、长期记忆,全部沿用既有的 fleet/agent 机制——免费。
+
+**非目标:** 比内置更并行。并发两边都有上限(约 `min(16, cores−2)`)。Native 赢在所有权、provenance、governance,而非原始速度。
+
+---
+
+## §2 · 架构——三层,一个 choke point
+
+Workers **不持有** egress,且是唯一的可注入面。只有确定性、无 LLM 的 gateway 能触网——而且是在强制的 kernel sandbox 内。
+
+```
+┌─────────────────────── fleet "deep-research" ───────────────────────┐
+│  router (mur)  — 每轮动态 DAG (plan.rs)                              │
+│  done_when: marker:RESEARCH_COMPLETE · budget-usd · deadline · kill  │
+└──────────────────────────────┬──────────────────────────────────────┘
+             │ channel/delegate（Ed25519 签名回复）
+             ▼
+┌──────────────── worker × k （entitlements: restricted） ────────────┐
+│  model_ref → 真实 LLM · 挂载 1 个 MCP: research-gateway            │
+│  工具: search · fetch      内置工具全 deny                          │
+└──────────────────────────────┬──────────────────────────────────────┘
+             │ MCP: search(query) / fetch(url)   — 只读动词
+             ▼
+┌────────── research-gateway（Rust,无 LLM,broad-audited egress）─────┐
+│  SSRF guard · tier ladder 1→2→3 · content budget · 每次调用 audit    │
+└──────────────────────────────────────────────────────────────────────┘
+       强制于: B1 kernel sandbox + loopback egress proxy
+```
+
+被 prompt 注入的 worker 顶多只能请 gateway `fetch` 一个 URL——有记录、被 SSRF 拦查、且无法向任意主机 POST 任意数据。API 是 `fetch`,不是“开一个 socket”。
+
+---
+
+## §3 · 动态流程——decompose → research → verify → synthesize
+
+Router 在每轮 `mur fleet run --loop` 产出一份新的 DAG;子问题数量在 decompose 时决定。loop 一直跑到收敛 marker 出现在它自己一行。
+
+1. **Decompose** — router 把问题拆成子问题(可能 100+),写进 channel 作为工作队列。
+2. **Research(×N 轮)** — router 把一批指派给 workers(受 `max_concurrency` 限制)。每个 worker `search()`、`fetch()` 最相关的来源,提取**每个都绑定 URL + 佐证引文的论断**,以签名回复写回。重复到队列清空。
+3. **Verify(3 票对抗)** — 每个论断派给三个 workers,各用一个不同的反驳镜头:正确性 / 来源独立性 / 时效性。2 票确认才存活;否则丢弃(fail-safe = 丢弃)。
+4. **Synthesize → 收敛** — router 把确认的论断折成一份引用报告,并在自己一行输出 `RESEARCH_COMPLETE`。结构化的 `done_when: marker:…` 确定性收敛——不需额外 LLM 调用,而且只是引用 marker 的散文无法假收敛。
+
+**免费继承:** 带*真实* per-token 记账的 `--budget-usd` · `mur fleet stop` kill-switch · Commander kill/budget hooks(fail-closed)· 每个论断的签名 channel provenance · iteration-cap / deadline / 卡住检测 guards。
+
+---
+
+## §4 · research-gateway
+
+一个随 MUR 发布、依赖轻量的小型 Rust MCP server。两个只读动词;固定、由代码驱动的 tier ladder(不由 LLM 决定 tier);每一 byte egress 都被治理。
+
+```
+search(query, limit?)  →  [{title, url, snippet}]
+fetch(url, render?)    →  {url, status, title, text, tier}
+```
+
+### 升级阶梯(确定性代码,不是 skill)
+
+| Tier | 引擎 | 说明 |
+|------|------|------|
+| **1 · http** | `reqwest` GET | 默认、最省。**Search 也走这里:** 通过同一条 proxy-honoring 路径 GET DuckDuckGo 的服务端渲染 HTML endpoint(需要浏览器风格 User-Agent,否则 DDG 回 HTTP 202),所以 search 在浏览器无法 spawn 的 sandbox 下也能运作。 |
+| **2 · lightpanda** | `agent-browser --engine lightpanda` | JS 渲染页。`--args ""` 是强制的——Chrome stealth flags 会弄坏 Lightpanda。每次 fetch 用独立 `--session` id,并发 fetch 不共用 cookie jar。 |
+| **3 · chrome** | `agent-browser --engine chrome` | 反爬虫 / 截图。stealth flags 以单一 `--args "<逗号分隔>"` 值传递(bare argv 会被当成子命令)。render 的 `fetch` 在 `Http` 失败*或*空渲染时升级 lightpanda → chrome;`chrome:true` 强制 tier 3。 |
+
+- **SSRF guard(硬性、不可配置)** — 拒绝任何解析 IP 为 private / link-local / loopback / unique-local 的 URL,每个 tier 都筛查。浏览器 tier 的 guard 与 `deny_hosts` **在 gateway 代码 spawn 前**强制执行——proxy 看不到浏览器子进程自己的连接。
+- **Content budget** — 单一 5 MB 页面会撑爆 worker 的 context。`fetch` 把返回文本截到 `max_fetch_chars`(默认 50 000;`0` 停用),在 codepoint 边界截断并加标记。5 MB body cap 限制传输/内存;`max_fetch_chars` 限制 context。search snippet 不截。
+- **搜索可靠性** — N 个并发 worker 时 DDG 以 202 挑战页限流。`search` 在 202 时 retry,采指数 backoff + **query 派生 jitter**——不同子问题错开重试,不再同步再爆一次。
+- **URL 级 audit** — 每次调用把 `{worker, url, tier, outcome}` 记录到 channel 与 telemetry。报告的每个引用都能对到一条 gateway audit 记录。
+
+---
+
+## §5 · 安全模型——sandbox、同意、工具策略
+
+Gateway 在强制 kernel sandbox 下运行,默认无 egress。访问权通过恰好一个明确同意步骤授予;worker 的工具策略被塑形,使 headless turn 既无法逃逸也不会卡住。
+
+| 控制 | 机制 | 边界 |
+|------|------|------|
+| **Egress 授权** | 每 worker `mcp set-network research-gateway --broad-audited`——一次操作者同意,记录为 `EgressAuthorization`。 | Fleet 创建**绝不**隐式开 egress。“这是研究 fleet”不算同意。 |
+| **Egress proxy** | 一个 loopback CONNECT proxy;每个 worker 的 gateway 子进程拿到一个依其 allow/deny 策略 scoped 的 `HTTPS_PROXY` token。 | 必须在 sandbox seal **之前**启动,并把 port 以 loopback-only 规则刻进 profile——否则子进程拨不到它。 |
+| `mcp__research-gateway__*` | **allow** | 预先核准,让 headless fleet turn 跳过 HITL gate(无人可答 → 300 秒 timeout → 失败)。它本身不授予任何 egress。 |
+| `bash` · `read_file` · `write_file` · `edit_file` | **deny** | 研究 turn 若伸手去用某个内置工具,会在同一个不可答的 gate 上死掉。deny → 不 advertise → 永不被调用。 |
+| 其余一切 | **ask** | 上述两条规则以外的工具保留 fail-closed 默认。 |
+| **Provenance** | 每个 worker 把自己的回复以 `Agent{self}` 事件写入,Ed25519 签名(v3d-2 peer-writes-own),fold 时逐 actor 验证。 | Router 不再代 worker 签名——归属是 worker 自己的密钥。 |
+| **Export 安全** | `.fleet` import 把 broad-audited 降级为 `inherit` 并清除授权。 | 分享的 deep-research fleet 在本地重新授权前零 egress。 |
+
+**Advisory-enforcement 的诚实。** Tier 1 honor proxy;tier 2/3 浏览器子进程可能不——以全局 gateway URL audit 缓解,且如实记录而非过度宣称。滴水不漏的封装 = 未来 Phase-3 sbpl pin-to-proxy,届时只 pin 这一个 gateway。
+
+---
+
+## §6 · 操作——provision、grant、run
+
+```bash
+# 1 · 创建 k 个 restricted worker,各挂载 gateway,
+#     并在同一个同意步骤授予 broad-audited egress
+mur deep-research provision --count 4 --model claude_haiku --grant-egress --yes
+#   tool policy: mcp__research-gateway__* → allow
+#   tool policy: bash, read_file, write_file, edit_file → deny
+#   Updated egress policy for 'research-gateway'.   # × 每个 worker
+
+# 2 · 创建 fleet(router = mur),设定 done marker + 预算
+mur fleet create deep-research \
+    --members dr_worker_1,dr_worker_2,dr_worker_3,dr_worker_4 \
+    --goal "…你的研究问题…"
+#   fleet.yaml loop: { max_iterations, budget_usd, done_when: marker:RESEARCH_COMPLETE }
+
+# 3 · 跑 guarded loop——decompose → research → verify → synthesize
+mur deep-research run deep-research --max-iterations 4 --deadline 30m
+#   fleet 'deep-research' loop stopped after 1 iteration (~$6.14 spent): Converged
+```
+
+- **结果落在哪** — 每个 worker 的引用回复是 `~/.mur/channels/fleet-deep-research/events.jsonl` 里的签名事件。`~/.mur/index/channels/` 的 SQLite read-model 是可重建的投影。每个引用都能对到一条 gateway audit 记录。
+- **Config knobs(无硬编值)** — `MUR_RESEARCH_MAX_FETCH_CHARS`、`…_SEARCH_LIMIT`、`…_TIMEOUT_SECS`、`…_LIGHTPANDA_PATH`、`…_DENY_HOSTS`——env 或 `~/.mur/config.yaml` 的 `research_gateway:`,绝不用字面值。
+
+---
+
+## §7 · 实现真相——干净的设计要真的实现付出了什么
+
+规格的四箱架构是对的。但要让一支 fleet 真的收敛——sandboxed、headless、密码学可归属——浮现了九个各自独立的修复,每个都由 live operator 验证揪出,而非靠读代码。
+
+| PR | 领域 | 修复 |
+|----|------|------|
+| **#663** | feat | **Native deep-research 核心**——gateway crate、fleet 接线、router/worker/verify skills。 |
+| **#664** | HITL | **预核准 gateway 工具**——headless turn 没人回答 `tool/approval_needed` → 300 秒 timeout → 失败。provision 时盖 `mcp__research-gateway__* → allow`。 |
+| **#665** | G1 · sandbox | **Pre-seal egress proxy**——proxy 在 sandbox seal *之后*才启动、port 从没刻进去 → 每个 scoped 授权 dead on arrival。改到 seal 前启动;刻一条 loopback-only port 规则。 |
+| **#666** | G3 · channel | **授权 channel read-model 目录**——签名回复落进 `events.jsonl` 但 SQLite refresh 撞只读 DB → 假失败。授权 `index/channels`;post-append refresh 改非致命。 |
+| **#667** | G2 · search | **无浏览器搜索 + 可用的 chrome**——search spawn 了 sandbox 禁的 `agent-browser`。改走 tier-1 HTTP;修 chrome `--args` 传法让 render fallback 真的启动。 |
+| **#668** | egress | **`Proxy-Authorization` 大小写不敏感**——*总 egress 解锁*。proxy 大小写敏感比对 auth header,但 hyper 送小写 → token 掉了 → *每个* CONNECT 被拒。用 `nc` proxy trace 现场抓到。 |
+| **#669** | content | **Fetch 内容预算**——单一 5 MB 页面撑爆 worker context(`anthropic 400: prompt too long`)。返回文本截到 `max_fetch_chars`。 |
+| **#670** | convergence | **Deny worker 内置工具**——*收敛解锁*。研究 turn 伸手去用 `bash`(默认 `ask`)→ 不可答的 HITL gate → turn 失败 → 空回复 → step 失败。deny 内置工具;模型根本看不到它们。用 raw `channel/delegate` socket probe 钉死根因。 |
+| **#671** | reliability | **DDG 202 retry + jitter**——并发 worker 触发 DuckDuckGo 限流。202 时用 backoff + query 派生 jitter 重试;报告从“access limited”变成每个 16–19 个引用。 |
+| **#672** | G4 · cleanup | **加载时跳过非 skill 目录**——`skills/` 下的 fleet run-ledger(`fleet:<name>/`)每次开机喷约 14 个 name 验证警告。`load_all` 跳过无 manifest 的目录——只在注入路径,maturity sweep 不受影响。 |
+
+**端到端验证:** 全新 provision → `run`:0 step failures、所有 worker 写了**签名**回复(Ed25519 provenance)、loop 停在 **Converged**、router 产出一份引用的 Ollama / LM Studio / LocalAI 比较——在 4-worker 并发下,完全在 kernel sandbox 内。
+
+---
+
+*本设计文档反映 v2.45.0 的发布实现。“滴水不漏”的 egress 封装(sbpl pin-to-proxy)与一级搜索 API 仍是刻意的 Phase-3 后续。*

--- a/docs/design/deep-research/README.zh-TW.md
+++ b/docs/design/deep-research/README.zh-TW.md
@@ -1,0 +1,156 @@
+<!-- Languages: [English](README.md) · [繁體中文](README.zh-TW.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja.md) · [한국어](README.ko.md) -->
+
+# MUR Deep Research — 詳細設計
+
+> 由 MUR fleet 端到端自有的 native 深度研究。
+> 於 **v2.45.0**(2026-07-10)出貨,PR #663–#672。
+
+一個 sandboxed 的 MUR agent 小隊拆解問題、透過單一稽核 gateway 研究即時網路、對每個聲明做對抗式驗證,最終收斂成一份**有引用、密碼學可歸屬的報告**——全部在 MUR 自有的編排上,而非 host subagents。
+
+- **規格:** `docs/superpowers/specs/2026-07-09-mur-native-deep-research-design.md`
+- **Crate:** `mur-research-gateway` · **指令:** `mur-core/src/cmd/deep_research`
+
+---
+
+## §1 · 為什麼要 native,而非 host subagents
+
+Claude Code 內建的 deep-research 研究得很好——但它以 *host subagents* 執行。工作是 Claude 的,MUR 只是貼標籤。Native 編排才讓成果是 *MUR 的*,而且可證明。
+
+- **MUR 編排擁有它。** 由 router 的每輪動態 DAG(`cmd/fleet/plan.rs`)驅動的一支 MUR agent fleet,才是真正在做研究的主體——不是 host spawn 完就遺忘的 subagent。
+- **密碼學 provenance。** 每個聲明都由產出它的 worker 寫入一條 Ed25519 簽名的 channel(Unified Channel v3d-2,*peer-writes-own*)。「這個 agent 找到這個」變成可驗證,而不是一句標註。
+- **平台整合。** 真實的 per-token 預算、kill-switch、Commander governance、排程、長期記憶,全部沿用既有的 fleet/agent 機制——免費。
+
+**非目標:** 比內建更平行。併發兩邊都有上限(約 `min(16, cores−2)`)。Native 贏在所有權、provenance、governance,不是原始速度。
+
+---
+
+## §2 · 架構——三層,一個 choke point
+
+Workers **不持有** egress,且是唯一的可注入面。只有確定性、無 LLM 的 gateway 能觸網——而且是在強制的 kernel sandbox 內。
+
+```
+┌─────────────────────── fleet "deep-research" ───────────────────────┐
+│  router (mur)  — 每輪動態 DAG (plan.rs)                              │
+│  done_when: marker:RESEARCH_COMPLETE · budget-usd · deadline · kill  │
+└──────────────────────────────┬──────────────────────────────────────┘
+             │ channel/delegate（Ed25519 簽名回覆）
+             ▼
+┌──────────────── worker × k （entitlements: restricted） ────────────┐
+│  model_ref → 真實 LLM · 掛載 1 個 MCP: research-gateway            │
+│  工具: search · fetch      內建工具全 deny                          │
+└──────────────────────────────┬──────────────────────────────────────┘
+             │ MCP: search(query) / fetch(url)   — 唯讀動詞
+             ▼
+┌────────── research-gateway（Rust,無 LLM,broad-audited egress）─────┐
+│  SSRF guard · tier ladder 1→2→3 · content budget · 每次呼叫 audit    │
+└──────────────────────────────────────────────────────────────────────┘
+       強制於: B1 kernel sandbox + loopback egress proxy
+```
+
+被 prompt 注入的 worker 頂多只能請 gateway `fetch` 一個 URL——有記錄、被 SSRF 攔查、且無法對任意主機 POST 任意資料。API 是 `fetch`,不是「開一個 socket」。
+
+---
+
+## §3 · 動態流程——decompose → research → verify → synthesize
+
+Router 在每輪 `mur fleet run --loop` 產出一份新的 DAG;子問題數量在 decompose 時決定。loop 一直跑到收斂 marker 出現在它自己一行。
+
+1. **Decompose** — router 把問題拆成子問題(可能 100+),寫進 channel 作為工作佇列。
+2. **Research(×N 輪)** — router 把一批指派給 workers(受 `max_concurrency` 限制)。每個 worker `search()`、`fetch()` 最相關的來源,萃取**每個都綁定 URL + 佐證引文的聲明**,以簽名回覆寫回。重複到佇列清空。
+3. **Verify(3 票對抗)** — 每個聲明派給三個 workers,各用一個不同的反駁鏡頭:正確性 / 來源獨立性 / 時效性。2 票確認才存活;否則丟棄(fail-safe = 丟棄)。
+4. **Synthesize → 收斂** — router 把確認的聲明折成一份引用報告,並在自己一行輸出 `RESEARCH_COMPLETE`。結構化的 `done_when: marker:…` 確定性收斂——不需額外 LLM 呼叫,而且只是引用 marker 的散文無法假收斂。
+
+**免費繼承:** 帶*真實* per-token 記帳的 `--budget-usd` · `mur fleet stop` kill-switch · Commander kill/budget hooks(fail-closed)· 每個聲明的簽名 channel provenance · iteration-cap / deadline / 卡住偵測 guards。
+
+---
+
+## §4 · research-gateway
+
+一個隨 MUR 出貨、依賴輕量的小型 Rust MCP server。兩個唯讀動詞;固定、由程式碼驅動的 tier ladder(不由 LLM 決定 tier);每一 byte egress 都被治理。
+
+```
+search(query, limit?)  →  [{title, url, snippet}]
+fetch(url, render?)    →  {url, status, title, text, tier}
+```
+
+### 升級階梯(確定性程式碼,不是 skill)
+
+| Tier | 引擎 | 說明 |
+|------|------|------|
+| **1 · http** | `reqwest` GET | 預設、最省。**Search 也走這裡:** 透過同一條 proxy-honoring 路徑 GET DuckDuckGo 的伺服器渲染 HTML endpoint(需要瀏覽器風格 User-Agent,否則 DDG 回 HTTP 202),所以 search 在瀏覽器無法 spawn 的 sandbox 下也能運作。 |
+| **2 · lightpanda** | `agent-browser --engine lightpanda` | JS 渲染頁。`--args ""` 是強制的——Chrome stealth flags 會弄壞 Lightpanda。每次 fetch 用獨立 `--session` id,併發 fetch 不共用 cookie jar。 |
+| **3 · chrome** | `agent-browser --engine chrome` | 反爬蟲 / 截圖。stealth flags 以單一 `--args "<逗號分隔>"` 值傳遞(bare argv 會被當成子命令)。render 的 `fetch` 在 `Http` 失敗*或*空渲染時升級 lightpanda → chrome;`chrome:true` 強制 tier 3。 |
+
+- **SSRF guard(硬性、不可設定)** — 拒絕任何解析 IP 為 private / link-local / loopback / unique-local 的 URL,每個 tier 都篩查。瀏覽器 tier 的 guard 與 `deny_hosts` **在 gateway 程式碼 spawn 前**強制執行——proxy 看不到瀏覽器子行程自己的連線。
+- **Content budget** — 單一 5 MB 頁面會撐爆 worker 的 context。`fetch` 把回傳文字截到 `max_fetch_chars`(預設 50 000;`0` 停用),在 codepoint 邊界截斷並加標記。5 MB body cap 限制傳輸/記憶體;`max_fetch_chars` 限制 context。search snippet 不截。
+- **搜尋可靠度** — N 個併發 worker 時 DDG 以 202 挑戰頁限流。`search` 在 202 時 retry,採指數 backoff + **query 衍生 jitter**——不同子問題錯開重試,不再同步再爆一次。
+- **URL 級 audit** — 每次呼叫把 `{worker, url, tier, outcome}` 記錄到 channel 與 telemetry。報告的每個引用都能對到一筆 gateway audit 記錄。
+
+---
+
+## §5 · 安全模型——sandbox、同意、工具政策
+
+Gateway 在強制 kernel sandbox 下執行,預設無 egress。存取權透過恰好一個明確同意步驟授予;worker 的工具政策被塑形,使 headless turn 既無法逃逸也不會卡住。
+
+| 控制 | 機制 | 邊界 |
+|------|------|------|
+| **Egress 授權** | 每 worker `mcp set-network research-gateway --broad-audited`——一次操作者同意,記錄為 `EgressAuthorization`。 | Fleet 建立**絕不**隱式開 egress。「這是研究 fleet」不算同意。 |
+| **Egress proxy** | 一個 loopback CONNECT proxy;每個 worker 的 gateway 子行程拿到一個依其 allow/deny 政策 scoped 的 `HTTPS_PROXY` token。 | 必須在 sandbox seal **之前**啟動,並把 port 以 loopback-only 規則刻進 profile——否則子行程撥不到它。 |
+| `mcp__research-gateway__*` | **allow** | 預先核准,讓 headless fleet turn 跳過 HITL gate(無人可答 → 300 秒 timeout → 失敗)。它本身不授予任何 egress。 |
+| `bash` · `read_file` · `write_file` · `edit_file` | **deny** | 研究 turn 若伸手去用某個內建工具,會在同一個不可答的 gate 上死掉。deny → 不 advertise → 永不被呼叫。 |
+| 其餘一切 | **ask** | 上述兩條規則以外的工具保留 fail-closed 預設。 |
+| **Provenance** | 每個 worker 把自己的回覆以 `Agent{self}` 事件寫入,Ed25519 簽名(v3d-2 peer-writes-own),fold 時逐 actor 驗證。 | Router 不再代 worker 簽名——歸屬是 worker 自己的金鑰。 |
+| **Export 安全** | `.fleet` import 把 broad-audited 降級為 `inherit` 並清除授權。 | 分享的 deep-research fleet 在本地重新授權前零 egress。 |
+
+**Advisory-enforcement 的誠實。** Tier 1 honor proxy;tier 2/3 瀏覽器子行程可能不——以全域 gateway URL audit 緩解,且如實記錄而非過度宣稱。滴水不漏的封裝 = 未來 Phase-3 sbpl pin-to-proxy,屆時只 pin 這一個 gateway。
+
+---
+
+## §6 · 操作——provision、grant、run
+
+```bash
+# 1 · 建立 k 個 restricted worker,各掛載 gateway,
+#     並在同一個同意步驟授予 broad-audited egress
+mur deep-research provision --count 4 --model claude_haiku --grant-egress --yes
+#   tool policy: mcp__research-gateway__* → allow
+#   tool policy: bash, read_file, write_file, edit_file → deny
+#   Updated egress policy for 'research-gateway'.   # × 每個 worker
+
+# 2 · 建立 fleet(router = mur),設定 done marker + 預算
+mur fleet create deep-research \
+    --members dr_worker_1,dr_worker_2,dr_worker_3,dr_worker_4 \
+    --goal "…你的研究問題…"
+#   fleet.yaml loop: { max_iterations, budget_usd, done_when: marker:RESEARCH_COMPLETE }
+
+# 3 · 跑 guarded loop——decompose → research → verify → synthesize
+mur deep-research run deep-research --max-iterations 4 --deadline 30m
+#   fleet 'deep-research' loop stopped after 1 iteration (~$6.14 spent): Converged
+```
+
+- **結果落在哪** — 每個 worker 的引用回覆是 `~/.mur/channels/fleet-deep-research/events.jsonl` 裡的簽名事件。`~/.mur/index/channels/` 的 SQLite read-model 是可重建的投影。每個引用都能對到一筆 gateway audit 記錄。
+- **Config knobs(無硬編值)** — `MUR_RESEARCH_MAX_FETCH_CHARS`、`…_SEARCH_LIMIT`、`…_TIMEOUT_SECS`、`…_LIGHTPANDA_PATH`、`…_DENY_HOSTS`——env 或 `~/.mur/config.yaml` 的 `research_gateway:`,絕不用字面值。
+
+---
+
+## §7 · 實作真相——乾淨的設計要真的實現付出了什麼
+
+規格的四箱架構是對的。但要讓一支 fleet 真的收斂——sandboxed、headless、密碼學可歸屬——浮現了九個各自獨立的修復,每個都由 live operator 驗證揪出,不是靠讀程式碼。
+
+| PR | 領域 | 修復 |
+|----|------|------|
+| **#663** | feat | **Native deep-research 核心**——gateway crate、fleet 接線、router/worker/verify skills。 |
+| **#664** | HITL | **預核准 gateway 工具**——headless turn 沒人回答 `tool/approval_needed` → 300 秒 timeout → 失敗。provision 時蓋 `mcp__research-gateway__* → allow`。 |
+| **#665** | G1 · sandbox | **Pre-seal egress proxy**——proxy 在 sandbox seal *之後*才啟動、port 從沒刻進去 → 每個 scoped 授權 dead on arrival。改到 seal 前啟動;刻一條 loopback-only port 規則。 |
+| **#666** | G3 · channel | **授權 channel read-model 目錄**——簽名回覆落進 `events.jsonl` 但 SQLite refresh 撞唯讀 DB → 假失敗。授權 `index/channels`;post-append refresh 改非致命。 |
+| **#667** | G2 · search | **無瀏覽器搜尋 + 可用的 chrome**——search spawn 了 sandbox 禁的 `agent-browser`。改走 tier-1 HTTP;修 chrome `--args` 傳法讓 render fallback 真的啟動。 |
+| **#668** | egress | **`Proxy-Authorization` 大小寫不敏感**——*總 egress 解鎖*。proxy 大小寫敏感比對 auth header,但 hyper 送小寫 → token 掉了 → *每個* CONNECT 被拒。用 `nc` proxy trace 現場抓到。 |
+| **#669** | content | **Fetch 內容預算**——單一 5 MB 頁面撐爆 worker context(`anthropic 400: prompt too long`)。回傳文字截到 `max_fetch_chars`。 |
+| **#670** | convergence | **Deny worker 內建工具**——*收斂解鎖*。研究 turn 伸手去用 `bash`(預設 `ask`)→ 不可答的 HITL gate → turn 失敗 → 空回覆 → step 失敗。deny 內建工具;模型根本看不到它們。用 raw `channel/delegate` socket probe 釘死根因。 |
+| **#671** | reliability | **DDG 202 retry + jitter**——併發 worker 觸發 DuckDuckGo 限流。202 時用 backoff + query 衍生 jitter 重試;報告從「access limited」變成每個 16–19 個引用。 |
+| **#672** | G4 · cleanup | **載入時跳過非 skill 目錄**——`skills/` 下的 fleet run-ledger(`fleet:<name>/`)每次開機噴約 14 個 name 驗證警告。`load_all` 跳過無 manifest 的目錄——只在注入路徑,maturity sweep 不受影響。 |
+
+**端到端驗證:** 全新 provision → `run`:0 step failures、所有 worker 寫了**簽名**回覆(Ed25519 provenance)、loop 停在 **Converged**、router 產出一份引用的 Ollama / LM Studio / LocalAI 比較——在 4-worker 併發下,完全在 kernel sandbox 內。
+
+---
+
+*本設計文件反映 v2.45.0 的出貨實作。「滴水不漏」的 egress 封裝(sbpl pin-to-proxy)與一級搜尋 API 仍是刻意的 Phase-3 後續。*


### PR DESCRIPTION
## Summary

Adds a reference **detailed design** for MUR-native deep research (shipped in v2.45.0, PRs #663–#672) under `docs/design/deep-research/`, in five locales.

Each doc covers: motivation (native vs host subagents), the three-layer architecture (fleet / research-gateway / kernel sandbox), the `decompose → research → verify → synthesize` flow, the gateway tier ladder + SSRF/content-budget/search-retry internals, the security model (sandbox + consent-gated egress + tool policy + Ed25519 provenance), the `provision → grant → run` commands, and the 9-fix implementation reality (#663–#672).

## Files
- `README.md` — English (canonical)
- `README.zh-TW.md` — 繁體中文
- `README.zh-CN.md` — 简体中文
- `README.ja.md` — 日本語
- `README.ko.md` — 한국어

Same structure across all five, with a language-switcher line at the top of each. Code, commands, and identifiers are kept verbatim; only prose is translated. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)