### PR TITLE
feat(research-gateway): pluggable search — Brave API when keyed, DDG fallback

### DIFF
--- a/mur-research-gateway/src/config.rs
+++ b/mur-research-gateway/src/config.rs
@@ -74,6 +74,12 @@ pub const DEFAULT_LIGHTPANDA_RELATIVE_PATH: &str = "aura/lightpanda";
 // definition in mur-common so the two crates can never drift (CLAUDE.md
 // rule 1).
 
+/// Brave Search API subscription token. When present (env or YAML), `search`
+/// uses Brave's first-class web-search API instead of scraping DuckDuckGo's
+/// HTML endpoint; absent, it falls back to DDG (zero-config, keyless). Brave's
+/// free tier (2k queries/mo) covers a personal deep-research user at $0 — the
+/// key is a reliability upgrade, never a hard requirement.
+const ENV_BRAVE_KEY: &str = "MUR_RESEARCH_BRAVE_KEY";
 const ENV_FETCH_TIMEOUT_SECS: &str = "MUR_RESEARCH_TIMEOUT_SECS";
 const ENV_BROWSER_TIMEOUT_SECS: &str = "MUR_RESEARCH_BROWSER_TIMEOUT_SECS";
 const ENV_SEARCH_LIMIT: &str = "MUR_RESEARCH_SEARCH_LIMIT";
@@ -95,6 +101,8 @@ pub struct GatewayConfig {
     pub search_limit: usize,
     /// Max characters of `fetch` page text returned to the worker; `0` = no cap.
     pub max_fetch_chars: usize,
+    /// Brave Search API token; `Some` → `search` uses Brave, `None` → DDG.
+    pub brave_api_key: Option<String>,
 }
 
 /// Raw `research_gateway:` YAML shape. Every field is optional/defaulted so
@@ -109,6 +117,7 @@ struct GatewayConfigYaml {
     browser_timeout_secs: Option<u64>,
     search_limit: Option<usize>,
     max_fetch_chars: Option<usize>,
+    brave_api_key: Option<String>,
     agent_browser_bin: Option<String>,
     lightpanda_path: Option<String>,
     chrome_stealth_args: Option<String>,
@@ -168,6 +177,9 @@ pub fn load_from_yaml(yaml: &str, mur_home: &Path) -> GatewayConfig {
         .or(raw.max_fetch_chars)
         .unwrap_or(DEFAULT_MAX_FETCH_CHARS);
 
+    let brave_api_key =
+        non_empty_env(ENV_BRAVE_KEY).or_else(|| raw.brave_api_key.filter(|s| !s.is_empty()));
+
     let agent_browser_bin = non_empty_env(ENV_AGENT_BROWSER_BIN)
         .or(raw.agent_browser_bin)
         .unwrap_or_else(|| DEFAULT_AGENT_BROWSER_BIN.to_string());
@@ -191,6 +203,7 @@ pub fn load_from_yaml(yaml: &str, mur_home: &Path) -> GatewayConfig {
         },
         search_limit,
         max_fetch_chars,
+        brave_api_key,
     }
 }
 

--- a/mur-research-gateway/src/fetcher.rs
+++ b/mur-research-gateway/src/fetcher.rs
@@ -207,6 +207,120 @@ fn build_client(timeout: Duration) -> Result<reqwest::Client, FetchError> {
         .map_err(|e| FetchError::Http(e.to_string()))
 }
 
+/// Brave Search API web-search endpoint. First-class (real index, JSON, no
+/// scraping) — used when a subscription token is configured.
+const BRAVE_ENDPOINT: &str = "https://api.search.brave.com/res/v1/web/search";
+
+/// Pluggable web search: `brave_key.is_some()` → Brave's first-class API;
+/// `None` → scrape DuckDuckGo's HTML endpoint (keyless, zero-config). If Brave
+/// is configured but errors (bad key, quota, transport), degrade to DDG rather
+/// than fail the search — a misconfigured key must never black out research.
+pub async fn search(
+    query: &str,
+    limit: usize,
+    brave_key: Option<&str>,
+    deny: &[String],
+    timeout: Duration,
+) -> Result<Vec<SearchHit>, FetchError> {
+    match brave_key {
+        Some(key) => match search_brave(query, limit, key, deny, timeout).await {
+            Ok(hits) => Ok(hits),
+            Err(e) => {
+                tracing::warn!(
+                    target: "research_gateway",
+                    "brave search failed ({}), falling back to DuckDuckGo",
+                    fetch_err_brief(&e)
+                );
+                search_tier1(query, limit, deny, timeout).await
+            }
+        },
+        None => search_tier1(query, limit, deny, timeout).await,
+    }
+}
+
+/// Brave web search: GET the Brave API through the same proxy-honoring reqwest
+/// path, authenticated with `X-Subscription-Token`. Screens the endpoint host
+/// via the SSRF guard exactly like a fetch. Brave returns real URLs directly
+/// (no `uddg` redirect to decode) as structured JSON.
+async fn search_brave(
+    query: &str,
+    limit: usize,
+    key: &str,
+    deny: &[String],
+    timeout: Duration,
+) -> Result<Vec<SearchHit>, FetchError> {
+    let mut url = url::Url::parse(BRAVE_ENDPOINT).expect("static URL is valid");
+    url.query_pairs_mut()
+        .append_pair("q", query)
+        .append_pair("count", &limit.to_string());
+    let screened = screen_url_blocking(url.as_str(), deny)
+        .await
+        .map_err(FetchError::Guard)?;
+
+    let client = build_client(timeout)?;
+    let resp = client
+        .get(screened.clone())
+        .header("X-Subscription-Token", key)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(FetchError::Http(format!("brave api status {}", status.as_u16())));
+    }
+    if let Some(len) = resp.content_length()
+        && len > MAX_BODY_BYTES as u64
+    {
+        return Err(FetchError::TooLarge);
+    }
+    let body = resp.text().await.map_err(|e| FetchError::Http(e.to_string()))?;
+    parse_brave_hits(&body, limit).map_err(FetchError::Http)
+}
+
+/// Parse Brave's `web.results[]` JSON into hits. A missing `web` block (Brave
+/// returns none when there are zero web results) is a valid empty result, not
+/// an error; malformed JSON is an error so the caller falls back to DDG.
+fn parse_brave_hits(json: &str, limit: usize) -> Result<Vec<SearchHit>, String> {
+    #[derive(serde::Deserialize)]
+    struct BraveResp {
+        web: Option<BraveWeb>,
+    }
+    #[derive(serde::Deserialize)]
+    struct BraveWeb {
+        results: Vec<BraveResult>,
+    }
+    #[derive(serde::Deserialize)]
+    struct BraveResult {
+        title: String,
+        url: String,
+        #[serde(default)]
+        description: String,
+    }
+    let resp: BraveResp = serde_json::from_str(json).map_err(|e| e.to_string())?;
+    Ok(resp
+        .web
+        .map(|w| w.results)
+        .unwrap_or_default()
+        .into_iter()
+        .take(limit)
+        .map(|r| SearchHit {
+            title: r.title,
+            url: r.url,
+            snippet: r.description,
+        })
+        .collect())
+}
+
+/// Short human label for a `FetchError` used in the Brave→DDG fallback log.
+fn fetch_err_brief(e: &FetchError) -> String {
+    match e {
+        FetchError::Guard(_) => "ssrf-guard".to_string(),
+        FetchError::Http(m) => m.clone(),
+        FetchError::TooLarge => "response too large".to_string(),
+    }
+}
+
 /// Tier-1 web search: GET DuckDuckGo's html endpoint through the same
 /// proxy-honoring reqwest path `fetch_tier1` uses (works under the kernel
 /// sandbox; agent-browser does not — G2), then parse result anchors. Screens
@@ -497,5 +611,31 @@ mod tests {
         assert!(out.contains("[truncated 6 chars]"));
         // Never split a codepoint: the kept prefix is valid UTF-8 of 4 'é's.
         assert_eq!(out.chars().take_while(|&c| c == 'é').count(), 4);
+    }
+
+    #[test]
+    fn parse_brave_hits_extracts_results_and_respects_limit() {
+        // Trimmed real Brave web-search JSON shape.
+        let json = r#"{"web":{"results":[
+            {"title":"First","url":"https://a.example","description":"snippet a"},
+            {"title":"Second","url":"https://b.example","description":"snippet b"},
+            {"title":"Third","url":"https://c.example"}
+        ]}}"#;
+        let hits = parse_brave_hits(json, 2).unwrap();
+        assert_eq!(hits.len(), 2); // limit respected
+        assert_eq!(hits[0].url, "https://a.example");
+        assert_eq!(hits[0].snippet, "snippet a");
+    }
+
+    #[test]
+    fn parse_brave_hits_missing_web_block_is_empty_not_error() {
+        // Brave omits `web` when there are zero web results — valid, not a parse error.
+        assert!(parse_brave_hits(r#"{"query":{"original":"x"}}"#, 8).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_brave_hits_malformed_json_is_error() {
+        // Malformed → Err so the dispatcher falls back to DDG.
+        assert!(parse_brave_hits("not json", 8).is_err());
     }
 }

--- a/mur-research-gateway/src/fetcher.rs
+++ b/mur-research-gateway/src/fetcher.rs
@@ -267,14 +267,20 @@ async fn search_brave(
         .map_err(|e| FetchError::Http(e.to_string()))?;
     let status = resp.status();
     if !status.is_success() {
-        return Err(FetchError::Http(format!("brave api status {}", status.as_u16())));
+        return Err(FetchError::Http(format!(
+            "brave api status {}",
+            status.as_u16()
+        )));
     }
     if let Some(len) = resp.content_length()
         && len > MAX_BODY_BYTES as u64
     {
         return Err(FetchError::TooLarge);
     }
-    let body = resp.text().await.map_err(|e| FetchError::Http(e.to_string()))?;
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| FetchError::Http(e.to_string()))?;
     parse_brave_hits(&body, limit).map_err(FetchError::Http)
 }
 
@@ -630,7 +636,11 @@ mod tests {
     #[test]
     fn parse_brave_hits_missing_web_block_is_empty_not_error() {
         // Brave omits `web` when there are zero web results — valid, not a parse error.
-        assert!(parse_brave_hits(r#"{"query":{"original":"x"}}"#, 8).unwrap().is_empty());
+        assert!(
+            parse_brave_hits(r#"{"query":{"original":"x"}}"#, 8)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -208,7 +208,8 @@ impl McpServer {
             .clamp(config::MIN_SEARCH_LIMIT, config::MAX_SEARCH_LIMIT);
         let deny = &self.config.deny_hosts;
         let timeout = self.config.timeout;
-        match fetcher::search_tier1(&query, limit, deny, timeout).await {
+        let brave_key = self.config.brave_api_key.as_deref();
+        match fetcher::search(&query, limit, brave_key, deny, timeout).await {
             Ok(hits) => {
                 audit(AuditRecord::new("search", query, None, "ok"));
                 Response::success(


### PR DESCRIPTION
## What

Make deep-research web search **pluggable** at the gateway's single egress choke point:

| Config | Backend |
|--------|---------|
| `MUR_RESEARCH_BRAVE_KEY` set (or `research_gateway.brave_api_key` in `~/.mur/config.yaml`) | **Brave Search API** — real index, JSON, `X-Subscription-Token` auth |
| no key | **DuckDuckGo HTML scrape** — keyless, zero-config (unchanged) |

## Why

DDG HTML scraping is the only free/keyless path, but DDG bot-detects (202) under concurrent workers from one IP → reports degrade to `unverified`. First-class search fundamentally needs a real web index; you either own one (a company, not a feature) or **rent one via API**. This rents it.

- **Brave free tier = 2,000 queries/mo = $0** → a personal local-LM deep-research user pays nothing; the key is a *reliability upgrade*, never a requirement.
- Brave configured but failing (bad key / quota / transport) **degrades to DDG** with a `warn` — a misconfigured key can't black out research.
- Preserves the local-first, zero-cost-out-of-the-box story: no key still works.

## Changes
- `config.rs` — `brave_api_key: Option<String>` (env `MUR_RESEARCH_BRAVE_KEY` or YAML), documented default.
- `fetcher.rs` — `search()` dispatcher, `search_brave()` (SSRF-screened, `X-Subscription-Token`), `parse_brave_hits()` (`web.results[]` → `SearchHit`; missing `web` block = empty not error).
- `server.rs` — `handle_search` calls the dispatcher with the configured key.

## Tests
3 new: Brave JSON parse + limit, missing-`web`-block-is-empty, malformed-JSON-is-error. Full crate suite green (47 + 10), clippy `-D warnings` clean.

## Follow-up (out of scope)
Runtime secret-ref injection so the key reaches the gateway child's env without plaintext in `config.yaml` (the `MUR_RESEARCH_BRAVE_KEY` seam is exactly what that would target — no rework).

🤖 Generated with [Claude Code](https://claude.com/claude-code)