### PR TITLE
feat(research-gateway): obscura render engine (opt-in, egress-governed)

### DIFF
--- a/docs/design/deep-research/README.md
+++ b/docs/design/deep-research/README.md
@@ -86,6 +86,13 @@ fetch(url, render?)    →  {url, status, title, text, tier}
 - **Search reliability** — under N concurrent workers DDG rate-limits with a 202 challenge. `search` retries on 202 with exponential backoff + a **query-seeded jitter** — distinct sub-questions stagger their retries instead of re-bursting in sync.
 - **URL-level audit** — every call logs `{worker, url, tier, outcome}` to the channel and telemetry. Every report citation reconciles to one gateway audit record.
 
+### Render engine (experimental, opt-in)
+
+Select via `MUR_RESEARCH_RENDER_ENGINE` env (or `research_gateway.render_engine:` in `~/.mur/config.yaml`):
+
+- **`agent-browser` (default)** — Lightpanda (tier 2) and Chrome (tier 3) as above.
+- **`obscura` (experimental, opt-in)** — Embedded-V8, self-contained. Install: extract platform tarball to `~/.mur/aura/`, keep both `obscura` and `obscura-worker` binaries. Single render path; no tier-2/3 escalation. **Advantage:** egress is **proxy-governed** — routes through the tier-1 loopback proxy (`obscura fetch <url> … --proxy http://<token>:@127.0.0.1:<port>`), eliminating the browser-tier egress-governance gap. Experimental, not yet default; head-to-head evaluation vs Lightpanda gates default flip.
+
 ---
 
 ## §5 · Security model — sandbox, consent, and the tool policy
@@ -102,7 +109,7 @@ The gateway runs under an enforced kernel sandbox with no default egress. Access
 | **Provenance** | Each worker appends its own reply as an `Agent{self}` event, Ed25519-signed (v3d-2 peer-writes-own), verified per-actor on fold. | The router no longer signs on a worker's behalf — attribution is the worker's own key. |
 | **Export safety** | `.fleet` import downgrades broad-audited → `inherit` and clears authorization. | A shared deep-research fleet has zero egress until re-granted locally. |
 
-**Advisory-enforcement honesty.** Tier 1 honors the proxy; the tier 2/3 browser subprocesses may not — mitigated by universal gateway URL audit, and documented rather than overclaimed. Airtight containment = a future Phase-3 sbpl pin-to-proxy, which then pins exactly this one gateway.
+**Advisory-enforcement honesty.** Tier 1 honors the proxy; the tier 2/3 browser subprocesses may not — mitigated by universal gateway URL audit, and documented rather than overclaimed. With the opt-in `render_engine: obscura`, this gap closes: obscura routes all egress through the loopback proxy tier 1 uses (via `--proxy` with the gateway's credential), making the render tier proxy-governed like tier 1. Airtight containment = a future Phase-3 sbpl pin-to-proxy, which then pins exactly this one gateway.
 
 ---
 

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -84,6 +84,28 @@ pub fn build_fetch_argv(url: &str, cfg: &BrowserCfg, want_chrome: bool) -> Vec<S
     a
 }
 
+/// Build the `obscura fetch` argv. `--dump markdown` yields cleaner text than
+/// the tier-1 tag-strip (spike Q3b). `proxy` (the gateway's own HTTP_PROXY
+/// credential, `http://<token>:@host:port`) becomes `--proxy` so obscura's
+/// egress goes through the loopback egress proxy (spike Q2). Pure →
+/// unit-testable, no env/subprocess.
+#[allow(dead_code)]
+fn build_obscura_argv(url: &str, proxy: Option<&str>, timeout: Duration) -> Vec<String> {
+    let mut a = vec![
+        "fetch".to_string(),
+        url.to_string(),
+        "--dump".to_string(),
+        "markdown".to_string(),
+        "--timeout".to_string(),
+        timeout.as_secs().to_string(),
+    ];
+    if let Some(p) = proxy {
+        a.push("--proxy".to_string());
+        a.push(p.to_string());
+    }
+    a
+}
+
 /// Per-FETCH unique session id so even two concurrent fetches of the SAME url
 /// get distinct cookie jars (Global Constraint: per-fetch isolation). The
 /// URL's FNV-1a hash keeps ids meaningful/greppable; a process-wide atomic
@@ -358,5 +380,28 @@ mod tests {
             session_id("https://b.example")
         );
         assert!(session_id("https://a.example").starts_with("rg-"));
+    }
+    #[test]
+    fn obscura_argv_dumps_markdown_and_threads_proxy() {
+        let base = build_obscura_argv("https://example.com", None, Duration::from_secs(20));
+        assert_eq!(base[0], "fetch");
+        assert_eq!(base[1], "https://example.com");
+        assert!(
+            base.windows(2)
+                .any(|w| w[0] == "--dump" && w[1] == "markdown")
+        );
+        assert!(base.windows(2).any(|w| w[0] == "--timeout" && w[1] == "20"));
+        assert!(!base.iter().any(|a| a == "--proxy"));
+
+        let proxied = build_obscura_argv(
+            "https://example.com",
+            Some("http://t:@127.0.0.1:9"),
+            Duration::from_secs(20),
+        );
+        assert!(
+            proxied
+                .windows(2)
+                .any(|w| w[0] == "--proxy" && w[1] == "http://t:@127.0.0.1:9")
+        );
     }
 }

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -91,18 +91,6 @@ pub fn build_fetch_argv(url: &str, cfg: &BrowserCfg, want_chrome: bool) -> Vec<S
 /// credential, `http://<token>:@host:port`) becomes `--proxy` so obscura's
 /// egress goes through the loopback egress proxy (spike Q2). Pure →
 /// unit-testable, no env/subprocess.
-/// The proxy URL obscura should route through, read from the gateway's OWN
-/// environment. The runtime sets `HTTP_PROXY=http://<token>:x@127.0.0.1:<port>`
-/// on this child (see mur-agent-runtime `proxy_env_for`); obscura does NOT
-/// honor the env var itself, so we translate it into its `--proxy` flag.
-/// Absent (dev/unsandboxed) → no proxy, direct connect.
-fn render_proxy_flag() -> Option<String> {
-    std::env::var("HTTP_PROXY")
-        .ok()
-        .or_else(|| std::env::var("HTTPS_PROXY").ok())
-        .filter(|s| !s.is_empty())
-}
-
 fn build_obscura_argv(url: &str, proxy: Option<&str>, timeout: Duration) -> Vec<String> {
     let mut a = vec![
         "fetch".to_string(),
@@ -117,6 +105,19 @@ fn build_obscura_argv(url: &str, proxy: Option<&str>, timeout: Duration) -> Vec<
         a.push(p.to_string());
     }
     a
+}
+
+/// Read the gateway's own HTTP_PROXY or HTTPS_PROXY environment variable and
+/// forward it to obscura's `--proxy` flag. The runtime sets
+/// `HTTP_PROXY=http://<token>:x@127.0.0.1:<port>` on this child (see
+/// mur-agent-runtime `proxy_env_for`); obscura does NOT honor the env var
+/// itself, so we translate it into its `--proxy` flag. Absent (dev/unsandboxed)
+/// → no proxy, direct connect.
+fn render_proxy_flag() -> Option<String> {
+    std::env::var("HTTP_PROXY")
+        .ok()
+        .or_else(|| std::env::var("HTTPS_PROXY").ok())
+        .filter(|s| !s.is_empty())
 }
 
 /// Per-FETCH unique session id so even two concurrent fetches of the SAME url

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -15,10 +15,27 @@ use crate::fetcher::{self, FetchError, FetchResult};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+/// Which subprocess renders JS pages for tier-2/3 `fetch`.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum RenderEngine {
+    /// `agent-browser` (Lightpanda tier-2 / Chrome tier-3) — current default.
+    #[default]
+    AgentBrowser,
+    /// `obscura` — self-contained embedded-V8 engine; renders under the kernel
+    /// sandbox and routes egress through `--proxy` (spike 2026-07-10).
+    Obscura,
+}
+
 pub struct BrowserCfg {
     pub agent_browser_bin: String,
     pub lightpanda_path: Option<String>,
     pub chrome_stealth_args: String, // comma-separated; empty = none
+    #[allow(dead_code)]
+    pub render_engine: RenderEngine,
+    /// Path to the `obscura` binary; the sibling `obscura-worker` must live
+    /// beside it. Only consulted when `render_engine == Obscura`.
+    #[allow(dead_code)]
+    pub obscura_path: Option<String>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -211,6 +228,8 @@ mod tests {
             agent_browser_bin: "agent-browser".into(),
             lightpanda_path: Some("/x/lightpanda".into()),
             chrome_stealth_args: "--no-sandbox".into(),
+            render_engine: crate::browser::RenderEngine::AgentBrowser,
+            obscura_path: None,
         };
         let argv = build_fetch_argv("https://example.com", &cfg, false);
         // lightpanda tier MUST pass --args "" and --executable-path, and MUST NOT carry stealth args
@@ -232,6 +251,8 @@ mod tests {
             lightpanda_path: Some("/x/lightpanda".into()),
             chrome_stealth_args: "--no-sandbox,--disable-blink-features=AutomationControlled"
                 .into(),
+            render_engine: crate::browser::RenderEngine::AgentBrowser,
+            obscura_path: None,
         };
         let argv = build_fetch_argv("https://example.com", &cfg, true);
         assert!(
@@ -250,6 +271,8 @@ mod tests {
             agent_browser_bin: "agent-browser".into(),
             lightpanda_path: None,
             chrome_stealth_args: String::new(),
+            render_engine: crate::browser::RenderEngine::AgentBrowser,
+            obscura_path: None,
         };
         // With no lightpanda path, preflight must not claim Full.
         assert!(!matches!(
@@ -263,6 +286,8 @@ mod tests {
             agent_browser_bin: "agent-browser".into(),
             lightpanda_path: Some("/x/lightpanda".into()),
             chrome_stealth_args: String::new(),
+            render_engine: crate::browser::RenderEngine::AgentBrowser,
+            obscura_path: None,
         };
         assert!(matches!(
             preflight_from_versions(true, Some("0.31.1"), &cfg),
@@ -275,6 +300,8 @@ mod tests {
             agent_browser_bin: "agent-browser".into(),
             lightpanda_path: Some("/x/lightpanda".into()),
             chrome_stealth_args: String::new(),
+            render_engine: crate::browser::RenderEngine::AgentBrowser,
+            obscura_path: None,
         };
         assert!(matches!(
             preflight_from_versions(true, Some("0.27.0"), &cfg),
@@ -287,6 +314,8 @@ mod tests {
             agent_browser_bin: "agent-browser".into(),
             lightpanda_path: Some("/x/lightpanda".into()),
             chrome_stealth_args: String::new(),
+            render_engine: crate::browser::RenderEngine::AgentBrowser,
+            obscura_path: None,
         };
         assert!(matches!(
             preflight_from_versions(false, None, &cfg),
@@ -302,6 +331,8 @@ mod tests {
             agent_browser_bin: "agent-browser".into(),
             lightpanda_path: Some("/x/lightpanda".into()),
             chrome_stealth_args: String::new(),
+            render_engine: crate::browser::RenderEngine::AgentBrowser,
+            obscura_path: None,
         };
         let pf = preflight_from_versions(true, None, &cfg);
         assert!(!matches!(pf, Preflight::Full));

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -89,6 +89,19 @@ pub fn build_fetch_argv(url: &str, cfg: &BrowserCfg, want_chrome: bool) -> Vec<S
 /// credential, `http://<token>:@host:port`) becomes `--proxy` so obscura's
 /// egress goes through the loopback egress proxy (spike Q2). Pure →
 /// unit-testable, no env/subprocess.
+/// The proxy URL obscura should route through, read from the gateway's OWN
+/// environment. The runtime sets `HTTP_PROXY=http://<token>:x@127.0.0.1:<port>`
+/// on this child (see mur-agent-runtime `proxy_env_for`); obscura does NOT
+/// honor the env var itself, so we translate it into its `--proxy` flag.
+/// Absent (dev/unsandboxed) → no proxy, direct connect.
+#[allow(dead_code)]
+fn render_proxy_flag() -> Option<String> {
+    std::env::var("HTTP_PROXY")
+        .ok()
+        .or_else(|| std::env::var("HTTPS_PROXY").ok())
+        .filter(|s| !s.is_empty())
+}
+
 #[allow(dead_code)]
 fn build_obscura_argv(url: &str, proxy: Option<&str>, timeout: Duration) -> Vec<String> {
     let mut a = vec![
@@ -243,6 +256,31 @@ pub async fn fetch_rendered(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Process-global env — serialize with the same lock style config.rs tests use.
+    static RENDER_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn render_proxy_flag_reads_http_proxy_env() {
+        let _g = RENDER_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: guarded by RENDER_ENV_LOCK.
+        unsafe {
+            std::env::remove_var("HTTP_PROXY");
+            std::env::remove_var("HTTPS_PROXY");
+        }
+        assert_eq!(render_proxy_flag(), None);
+        unsafe {
+            std::env::set_var("HTTP_PROXY", "http://tok:@127.0.0.1:5555");
+        }
+        assert_eq!(
+            render_proxy_flag().as_deref(),
+            Some("http://tok:@127.0.0.1:5555")
+        );
+        unsafe {
+            std::env::remove_var("HTTP_PROXY");
+        }
+    }
+
     #[test]
     #[allow(clippy::comparison_to_empty)] // brief's exact assertion form is the contract
     fn lightpanda_command_forces_empty_args() {

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -42,6 +42,10 @@ pub enum Preflight {
     LightpandaMissing,
     AgentBrowserTooOld(String),
     AgentBrowserMissing,
+    /// `render_engine == Obscura` but `obscura_path` is unset, doesn't exist,
+    /// or its sibling `obscura-worker` binary is missing from the same
+    /// directory. Both binaries are required (spike Layer-2).
+    ObscuraMissing,
 }
 
 /// Build the agent-browser argv for a single fetch. Pure → unit-testable.
@@ -138,6 +142,12 @@ static SESSION_SEQ: AtomicU64 = AtomicU64::new(0);
 /// tests (those call `preflight_from_versions` directly with fixed inputs) —
 /// this is the only function in the module that touches a real subprocess.
 pub fn preflight(cfg: &BrowserCfg) -> Preflight {
+    // obscura is a different binary from agent-browser; short-circuit before
+    // the agent-browser --version probe so the obscura engine never invokes
+    // (or requires) agent-browser at all.
+    if cfg.render_engine == RenderEngine::Obscura {
+        return obscura_preflight(cfg);
+    }
     let output = std::process::Command::new(&cfg.agent_browser_bin)
         .arg("--version")
         .output();
@@ -151,6 +161,26 @@ pub fn preflight(cfg: &BrowserCfg) -> Preflight {
         // old rather than silently Full.
         Ok(_) => Preflight::AgentBrowserTooOld("unknown".into()),
         Err(_) => Preflight::AgentBrowserMissing,
+    }
+}
+
+/// Pure, unit-testable check for the obscura engine: both `obscura_path` and
+/// its sibling `obscura-worker` (same directory) must exist on disk. Spike
+/// Layer-2 found BOTH binaries are required at runtime, so a missing worker
+/// is treated the same as a missing obscura binary — fail closed.
+fn obscura_preflight(cfg: &BrowserCfg) -> Preflight {
+    let Some(path) = cfg.obscura_path.as_deref() else {
+        return Preflight::ObscuraMissing;
+    };
+    let obscura = std::path::Path::new(path);
+    let Some(parent) = obscura.parent() else {
+        return Preflight::ObscuraMissing;
+    };
+    let worker = parent.join("obscura-worker");
+    if obscura.exists() && worker.exists() {
+        Preflight::Full
+    } else {
+        Preflight::ObscuraMissing
     }
 }
 
@@ -398,6 +428,17 @@ mod tests {
             preflight_from_versions(true, Some("0.27.0"), &cfg),
             Preflight::AgentBrowserTooOld(v) if v == "0.27.0"
         ));
+    }
+    #[test]
+    fn preflight_flags_missing_obscura() {
+        let cfg = BrowserCfg {
+            agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: None,
+            chrome_stealth_args: String::new(),
+            render_engine: RenderEngine::Obscura,
+            obscura_path: Some("/nonexistent/obscura".into()),
+        };
+        assert_eq!(preflight(&cfg), Preflight::ObscuraMissing);
     }
     #[test]
     fn preflight_missing_when_absent() {

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -30,11 +30,9 @@ pub struct BrowserCfg {
     pub agent_browser_bin: String,
     pub lightpanda_path: Option<String>,
     pub chrome_stealth_args: String, // comma-separated; empty = none
-    #[allow(dead_code)]
     pub render_engine: RenderEngine,
     /// Path to the `obscura` binary; the sibling `obscura-worker` must live
     /// beside it. Only consulted when `render_engine == Obscura`.
-    #[allow(dead_code)]
     pub obscura_path: Option<String>,
 }
 
@@ -94,7 +92,6 @@ pub fn build_fetch_argv(url: &str, cfg: &BrowserCfg, want_chrome: bool) -> Vec<S
 /// on this child (see mur-agent-runtime `proxy_env_for`); obscura does NOT
 /// honor the env var itself, so we translate it into its `--proxy` flag.
 /// Absent (dev/unsandboxed) → no proxy, direct connect.
-#[allow(dead_code)]
 fn render_proxy_flag() -> Option<String> {
     std::env::var("HTTP_PROXY")
         .ok()
@@ -102,7 +99,6 @@ fn render_proxy_flag() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-#[allow(dead_code)]
 fn build_obscura_argv(url: &str, proxy: Option<&str>, timeout: Duration) -> Vec<String> {
     let mut a = vec![
         "fetch".to_string(),
@@ -223,10 +219,43 @@ async fn run_agent_browser(
     Ok(String::from_utf8_lossy(&out.stdout).to_string())
 }
 
+/// Decide (binary, argv, tier) for a render, dispatching on the engine. Pure
+/// (proxy passed in) → unit-testable without spawning. obscura is a single
+/// engine covering JS render, so `want_chrome` is ignored and the tier is 2;
+/// the agent-browser path keeps the lightpanda(2)/chrome(3) split.
+fn plan_render(
+    url: &str,
+    cfg: &BrowserCfg,
+    want_chrome: bool,
+    proxy: Option<&str>,
+    timeout: Duration,
+) -> (String, Vec<String>, u8) {
+    match cfg.render_engine {
+        RenderEngine::Obscura => {
+            let bin = cfg
+                .obscura_path
+                .clone()
+                .unwrap_or_else(|| "obscura".to_string());
+            (bin, build_obscura_argv(url, proxy, timeout), 2)
+        }
+        RenderEngine::AgentBrowser => {
+            let tier = if want_chrome || cfg.lightpanda_path.is_none() {
+                3
+            } else {
+                2
+            };
+            (
+                cfg.agent_browser_bin.clone(),
+                build_fetch_argv(url, cfg, want_chrome),
+                tier,
+            )
+        }
+    }
+}
+
 /// Fetch a JS-rendered page. Pre-spawn SSRF/deny screen (proxy can't see the
-/// browser's connections — spec §5), then drive agent-browser under `timeout`.
-/// `want_chrome` forces tier 3; otherwise tier 2 (lightpanda) is used when
-/// available.
+/// browser's connections — spec §5), then drive the configured render engine
+/// (agent-browser or obscura, see `plan_render`) under `timeout`.
 pub async fn fetch_rendered(
     url: &str,
     deny: &[String],
@@ -237,13 +266,15 @@ pub async fn fetch_rendered(
     let screened = fetcher::screen_url_blocking(url, deny)
         .await
         .map_err(FetchError::Guard)?;
-    let argv = build_fetch_argv(screened.as_str(), cfg, want_chrome);
-    let text = run_agent_browser(&cfg.agent_browser_bin, &argv, timeout).await?;
-    let tier = if want_chrome || cfg.lightpanda_path.is_none() {
-        3
-    } else {
-        2
-    };
+    let proxy = render_proxy_flag();
+    let (bin, argv, tier) = plan_render(
+        screened.as_str(),
+        cfg,
+        want_chrome,
+        proxy.as_deref(),
+        timeout,
+    );
+    let text = run_agent_browser(&bin, &argv, timeout).await?;
     Ok(FetchResult {
         url: screened.to_string(),
         status: 200,
@@ -441,5 +472,46 @@ mod tests {
                 .windows(2)
                 .any(|w| w[0] == "--proxy" && w[1] == "http://t:@127.0.0.1:9")
         );
+    }
+
+    #[test]
+    fn plan_render_dispatches_on_engine() {
+        let ab = BrowserCfg {
+            agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: Some("/x/lightpanda".into()),
+            chrome_stealth_args: "--no-sandbox".into(),
+            render_engine: RenderEngine::AgentBrowser,
+            obscura_path: None,
+        };
+        let (bin, _argv, tier) = plan_render(
+            "https://example.com",
+            &ab,
+            false,
+            None,
+            Duration::from_secs(20),
+        );
+        assert_eq!(bin, "agent-browser");
+        assert_eq!(tier, 2); // lightpanda present, not chrome
+
+        let ob = BrowserCfg {
+            render_engine: RenderEngine::Obscura,
+            obscura_path: Some("/opt/obscura".into()),
+            ..ab
+        };
+        let (bin, argv, tier) = plan_render(
+            "https://example.com",
+            &ob,
+            true, /*ignored*/
+            Some("http://t:@127.0.0.1:9"),
+            Duration::from_secs(20),
+        );
+        assert_eq!(bin, "/opt/obscura");
+        assert_eq!(tier, 2); // obscura is one engine; want_chrome ignored
+        assert_eq!(argv[0], "fetch");
+        assert!(
+            argv.windows(2)
+                .any(|w| w[0] == "--proxy" && w[1] == "http://t:@127.0.0.1:9")
+        );
+        assert!(argv.windows(2).any(|w| w[0] == "--timeout" && w[1] == "20"));
     }
 }

--- a/mur-research-gateway/src/config.rs
+++ b/mur-research-gateway/src/config.rs
@@ -204,7 +204,14 @@ pub fn load_from_yaml(yaml: &str, mur_home: &Path) -> GatewayConfig {
         .or(raw.render_engine)
         .map(|s| match s.trim().to_ascii_lowercase().as_str() {
             "obscura" => crate::browser::RenderEngine::Obscura,
-            _ => crate::browser::RenderEngine::AgentBrowser,
+            "agent-browser" => crate::browser::RenderEngine::AgentBrowser,
+            unrecognized => {
+                tracing::warn!(
+                    "unrecognized render_engine '{}'; falling back to agent-browser",
+                    unrecognized
+                );
+                crate::browser::RenderEngine::AgentBrowser
+            }
         })
         .unwrap_or_default();
 

--- a/mur-research-gateway/src/config.rs
+++ b/mur-research-gateway/src/config.rs
@@ -66,6 +66,10 @@ pub const DEFAULT_CHROME_STEALTH_ARGS: &str =
 /// path that isn't there.
 pub const DEFAULT_LIGHTPANDA_RELATIVE_PATH: &str = "aura/lightpanda";
 
+/// Default obscura install path, relative to `mur_home` (mirrors Lightpanda's
+/// `aura/` install location).
+pub const DEFAULT_OBSCURA_RELATIVE_PATH: &str = "aura/obscura";
+
 // ---- env var names ----
 
 // ENV_DENY_HOSTS (imported above as `ENV_MCP_DENY_HOSTS`) is shared with
@@ -87,6 +91,8 @@ const ENV_MAX_FETCH_CHARS: &str = "MUR_RESEARCH_MAX_FETCH_CHARS";
 const ENV_AGENT_BROWSER_BIN: &str = "MUR_RESEARCH_AGENT_BROWSER_BIN";
 const ENV_LIGHTPANDA_PATH: &str = "MUR_RESEARCH_LIGHTPANDA_PATH";
 const ENV_CHROME_STEALTH_ARGS: &str = "MUR_RESEARCH_CHROME_STEALTH_ARGS";
+const ENV_RENDER_ENGINE: &str = "MUR_RESEARCH_RENDER_ENGINE";
+const ENV_OBSCURA_PATH: &str = "MUR_RESEARCH_OBSCURA_PATH";
 
 /// Fully-resolved gateway configuration — YAML defaults merged with env
 /// overrides, ready to use for the lifetime of the process.
@@ -121,6 +127,8 @@ struct GatewayConfigYaml {
     agent_browser_bin: Option<String>,
     lightpanda_path: Option<String>,
     chrome_stealth_args: Option<String>,
+    render_engine: Option<String>,
+    obscura_path: Option<String>,
 }
 
 /// Resolve `~/.mur` (or `$MUR_HOME` if set). Mirrors the `MUR_HOME`
@@ -192,6 +200,18 @@ pub fn load_from_yaml(yaml: &str, mur_home: &Path) -> GatewayConfig {
         .or(raw.chrome_stealth_args)
         .unwrap_or_else(|| DEFAULT_CHROME_STEALTH_ARGS.to_string());
 
+    let render_engine = non_empty_env(ENV_RENDER_ENGINE)
+        .or(raw.render_engine)
+        .map(|s| match s.trim().to_ascii_lowercase().as_str() {
+            "obscura" => crate::browser::RenderEngine::Obscura,
+            _ => crate::browser::RenderEngine::AgentBrowser,
+        })
+        .unwrap_or_default();
+
+    let obscura_path = non_empty_env(ENV_OBSCURA_PATH)
+        .or_else(|| raw.obscura_path.filter(|s| !s.is_empty()))
+        .or_else(|| default_obscura_path(mur_home));
+
     GatewayConfig {
         deny_hosts,
         timeout: Duration::from_secs(timeout_secs),
@@ -200,6 +220,8 @@ pub fn load_from_yaml(yaml: &str, mur_home: &Path) -> GatewayConfig {
             agent_browser_bin,
             lightpanda_path,
             chrome_stealth_args,
+            render_engine,
+            obscura_path,
         },
         search_limit,
         max_fetch_chars,
@@ -212,6 +234,13 @@ pub fn load_from_yaml(yaml: &str, mur_home: &Path) -> GatewayConfig {
 /// that isn't there (matches the pre-Task-6 behavior in `server.rs`).
 fn default_lightpanda_path(mur_home: &Path) -> Option<String> {
     let path = mur_home.join(DEFAULT_LIGHTPANDA_RELATIVE_PATH);
+    path.exists().then(|| path.to_string_lossy().to_string())
+}
+
+/// Default obscura path — only when it actually exists on disk (never claim a
+/// path that isn't there), matching `default_lightpanda_path`.
+fn default_obscura_path(mur_home: &Path) -> Option<String> {
+    let path = mur_home.join(DEFAULT_OBSCURA_RELATIVE_PATH);
     path.exists().then(|| path.to_string_lossy().to_string())
 }
 
@@ -427,6 +456,28 @@ research_gateway:
         assert_eq!(cfg.max_fetch_chars, 42);
         unsafe {
             std::env::remove_var("MUR_RESEARCH_MAX_FETCH_CHARS");
+        }
+    }
+
+    #[test]
+    fn render_engine_defaults_agentbrowser_env_overrides_obscura() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let c = load_from_yaml("", Path::new("/nonexistent"));
+        assert!(matches!(
+            c.browser.render_engine,
+            crate::browser::RenderEngine::AgentBrowser
+        ));
+        // SAFETY: env mutation guarded by ENV_LOCK.
+        unsafe {
+            std::env::set_var(ENV_RENDER_ENGINE, "obscura");
+        }
+        let c = load_from_yaml("", Path::new("/nonexistent"));
+        assert!(matches!(
+            c.browser.render_engine,
+            crate::browser::RenderEngine::Obscura
+        ));
+        unsafe {
+            std::env::remove_var(ENV_RENDER_ENGINE);
         }
     }
 }

--- a/mur-research-gateway/src/main.rs
+++ b/mur-research-gateway/src/main.rs
@@ -32,7 +32,13 @@ async fn main() {
     // silently) — degrade to tier 1 only, not "as if Full" (spec §5).
     match browser::preflight(server.browser_cfg()) {
         browser::Preflight::Full => {
-            tracing::info!("browser preflight: full — tiers 2/3 (lightpanda/chrome) available")
+            let engine_desc = match server.browser_cfg().render_engine {
+                browser::RenderEngine::Obscura => "full — obscura render engine available",
+                browser::RenderEngine::AgentBrowser => {
+                    "full — tiers 2/3 (lightpanda/chrome) available"
+                }
+            };
+            tracing::info!("browser preflight: {}", engine_desc)
         }
         other => tracing::warn!(
             "browser preflight degraded: {:?} — render/search fall back to tier 1 only",

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -29,6 +29,14 @@ fn should_escalate_to_chrome(result: &Result<fetcher::FetchResult, FetchError>) 
     }
 }
 
+/// Tier-3 (Chrome) escalation only makes sense for the agent-browser engine —
+/// obscura is a single embedded engine, so re-rendering with `want_chrome:
+/// true` would just run obscura again (a wasted subprocess spawn). Gate the
+/// escalation on this.
+pub(crate) fn render_can_escalate(cfg: &BrowserCfg) -> bool {
+    matches!(cfg.render_engine, browser::RenderEngine::AgentBrowser)
+}
+
 fn fetch_error_response(id: Option<serde_json::Value>, verb: &str, err: FetchError) -> Response {
     match err {
         FetchError::Guard(reject) => Response::error(
@@ -153,7 +161,11 @@ impl McpServer {
             // Escalate only when tier 2 actually ran lightpanda: with no
             // lightpanda configured the first attempt was already chrome
             // (build_fetch_argv), so retrying chrome would just waste a spawn.
-            if !want_chrome && cfg.lightpanda_path.is_some() && should_escalate_to_chrome(&result) {
+            if !want_chrome
+                && cfg.lightpanda_path.is_some()
+                && render_can_escalate(cfg)
+                && should_escalate_to_chrome(&result)
+            {
                 // lightpanda failed or rendered nothing → retry under chrome.
                 result = browser::fetch_rendered(&url, deny, cfg, true, browser_timeout).await;
                 tier_label = "fetch (tier 3)";
@@ -264,6 +276,26 @@ mod tests {
         assert!(!should_escalate_to_chrome(&Err(FetchError::Guard(
             crate::net_guard::GuardReject::BadScheme
         ))));
+    }
+
+    fn browser_cfg(render_engine: crate::browser::RenderEngine) -> crate::browser::BrowserCfg {
+        crate::browser::BrowserCfg {
+            agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: None,
+            chrome_stealth_args: String::new(),
+            render_engine,
+            obscura_path: None,
+        }
+    }
+
+    #[test]
+    fn obscura_engine_does_not_escalate_to_chrome() {
+        // plan_render for obscura always yields tier 2; the server must gate the
+        // tier-3 re-call on the engine being AgentBrowser.
+        let ob = browser_cfg(crate::browser::RenderEngine::Obscura);
+        assert!(!render_can_escalate(&ob));
+        let ab = browser_cfg(crate::browser::RenderEngine::AgentBrowser);
+        assert!(render_can_escalate(&ab));
     }
 
     fn req(method: &str, params: Option<serde_json::Value>) -> Request {


### PR DESCRIPTION
Adds **obscura** as a config-selected render engine for the gateway's tier-2/3 `fetch`, routed through the egress proxy. **Default is unchanged** (`render_engine = agent-browser`); obscura is opt-in until a live head-to-head flips it (gated follow-up).

Backed by the 2026-07-10 spike (GO): obscura's V8 renders under our kernel sandbox, and its `--proxy` sends `Proxy-Authorization: Basic <token>` = our egress-proxy mechanism — so the render tier can finally be **proxy-governed**, which agent-browser/Chrome can't.

## What
- `RenderEngine` config knob (`MUR_RESEARCH_RENDER_ENGINE` / `research_gateway.render_engine`), `obscura_path` (default `~/.mur/aura/obscura`).
- `build_obscura_argv` (`obscura fetch <url> --dump markdown --timeout N [--proxy …]`).
- `render_proxy_flag` — reads the gateway's own `HTTP_PROXY`/`HTTPS_PROXY` (set per-child by the runtime) → obscura `--proxy`.
- `fetch_rendered` dispatches on engine; agent-browser path preserved **byte-for-byte** (verified in final review).
- No Chrome escalation for obscura (single engine).
- `ObscuraMissing` preflight (both `obscura` + `obscura-worker` must exist).
- Design-doc §4/§5 notes (English canonical).

## Safety
Default behavior identical; opt-in only. SSRF screen runs before render for both engines. No new deps. Final whole-branch review (opus): **READY TO MERGE**, 0 Critical/Important; 3 minor doc/log/UX nits fixed.

## Deferred (gated follow-up, out of scope)
Runtime exec-allowlist for `~/.mur/aura/obscura{,-worker}` under a live worker sandbox + live Lightpanda head-to-head → then flip the default. Translated design READMEs updated on promotion.

8 commits. Plan: `docs/superpowers/plans/2026-07-10-obscura-render-tier-implementation.md`. Spike: `docs/superpowers/plans/2026-07-10-spike-obscura-render-tier.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)