### PR TITLE
feat(research-gateway): auto-detect render engine (obscura when installed) + translate docs

### DIFF
--- a/docs/design/deep-research/README.ja.md
+++ b/docs/design/deep-research/README.ja.md
@@ -86,6 +86,13 @@ fetch(url, render?)    →  {url, status, title, text, tier}
 - **検索の信頼性** — N 並行ワーカー下で DDG は 202 チャレンジでレート制限する。`search` は 202 時に指数バックオフ + **クエリ由来のジッター** で再試行する — 異なるサブ問いが再試行をずらし、同期して再バーストしない。
 - **URL レベル監査** — 各呼び出しは `{worker, url, tier, outcome}` をチャネルとテレメトリへ記録する。レポートの各引用は 1 つのゲートウェイ監査レコードに突き合わせられる。
 
+### レンダーエンジン(実験的、オプトイン)
+
+`MUR_RESEARCH_RENDER_ENGINE` 環境変数(または `~/.mur/config.yaml` の `research_gateway.render_engine:`)で選択する。ここで明示的に値を設定すると常に auto-detect より優先される。自動検出(env/YAML 未設定時):**`obscura` と `obscura-worker` の両バイナリが `~/.mur/aura/` にインストールされていれば `obscura`、そうでなければ `agent-browser`**(2026-07-10 の比較:obscura は JS のみのページを含む実コンテンツをレンダリングし、ワーカーサンドボックス下でも動作する。agent-browser/Lightpanda はタイトルのみのスタブを返し、サンドボックスで拒否される)。
+
+- **`agent-browser`** — 上記の Lightpanda(tier 2)と Chrome(tier 3)。obscura 未インストール時の自動検出フォールバック。
+- **`obscura`** — 組み込み V8、自己完結型。インストール:プラットフォーム tarball を `~/.mur/aura/` に展開し、`obscura` と `obscura-worker` の両バイナリを保持する — 自動検出が自動的にそれを選ぶ。単一のレンダリング経路で、tier-2/3 へのエスカレーションはない。**利点:** egress が **proxy-governed** — tier 1 のループバックプロキシを経由する(`obscura fetch <url> … --proxy http://<token>:@127.0.0.1:<port>`)ため、ブラウザ tier の egress 統治の隙間がなくなる。
+
 ---
 
 ## §5 · セキュリティモデル — サンドボックス、同意、ツールポリシー
@@ -102,7 +109,7 @@ fetch(url, render?)    →  {url, status, title, text, tier}
 | **プロヴェナンス** | 各ワーカーは自身の返信を `Agent{self}` イベントとして書き込み、Ed25519 署名(v3d-2 peer-writes-own)、fold 時にアクターごとに検証。 | ルーターはもうワーカーの代わりに署名しない — 帰属はワーカー自身の鍵。 |
 | **エクスポート安全性** | `.fleet` インポートは broad-audited を `inherit` へ降格し、承認をクリアする。 | 共有された deep-research フリートは、ローカルで再付与するまで egress ゼロ。 |
 
-**アドバイザリ強制の正直さ。** Tier 1 はプロキシを尊重する。tier 2/3 のブラウザ子プロセスは尊重しないかもしれない — 全域のゲートウェイ URL 監査で緩和し、誇張せず文書化している。完全な封じ込め = 将来の Phase-3 sbpl pin-to-proxy であり、その時ピン留めするのはこの 1 ゲートウェイのみ。
+**アドバイザリ強制の正直さ。** Tier 1 はプロキシを尊重する。tier 2/3 のブラウザ子プロセスは尊重しないかもしれない — 全域のゲートウェイ URL 監査で緩和し、誇張せず文書化している。オプトインの `render_engine: obscura` を使うと、この隙間は閉じる: obscura は tier 1 が使うのと同じループバックプロキシを通してすべての egress を送るため(ゲートウェイの認証情報を添えた `--proxy` 経由)、レンダー tier も tier 1 と同様に proxy-governed になる。完全な封じ込め = 将来の Phase-3 sbpl pin-to-proxy であり、その時ピン留めするのはこの 1 ゲートウェイのみ。
 
 ---
 

--- a/docs/design/deep-research/README.ko.md
+++ b/docs/design/deep-research/README.ko.md
@@ -86,6 +86,13 @@ fetch(url, render?)    →  {url, status, title, text, tier}
 - **검색 신뢰성** — N 동시 워커에서 DDG 는 202 챌린지로 레이트 리밋한다. `search` 는 202 시 지수 백오프 + **쿼리 기반 지터** 로 재시도한다 — 서로 다른 하위 질문이 재시도를 어긋나게 하여 동기적으로 다시 폭주하지 않는다.
 - **URL 수준 감사** — 각 호출은 `{worker, url, tier, outcome}` 을 채널과 텔레메트리에 기록한다. 보고서의 각 인용은 하나의 게이트웨이 감사 레코드에 대응된다.
 
+### 렌더 엔진(실험적, 옵트인)
+
+`MUR_RESEARCH_RENDER_ENGINE` 환경 변수(또는 `~/.mur/config.yaml` 의 `research_gateway.render_engine:`)로 선택한다. 여기서 명시적으로 값을 설정하면 항상 auto-detect 보다 우선한다. 자동 감지(env/YAML 미설정 시): **`obscura` 와 `obscura-worker` 두 바이너리가 모두 `~/.mur/aura/` 에 설치되어 있으면 `obscura`, 아니면 `agent-browser`**(2026-07-10 정면 비교: obscura 는 JS 전용 페이지를 포함한 실제 콘텐츠를 렌더링하고 워커 샌드박스 아래에서도 동작한다; agent-browser/Lightpanda 는 title-only 스텁을 반환하고 샌드박스에서 거부된다).
+
+- **`agent-browser`** — 위의 Lightpanda(tier 2)와 Chrome(tier 3). obscura 가 설치되지 않았을 때의 자동 감지 폴백.
+- **`obscura`** — 임베디드 V8, 자체 완결형. 설치: 플랫폼 tarball 을 `~/.mur/aura/` 에 압축 해제하고 `obscura` 와 `obscura-worker` 두 바이너리를 모두 유지한다 — 자동 감지가 그러면 자동으로 선택한다. 단일 렌더 경로이며 tier-2/3 에스컬레이션이 없다. **장점:** egress 가 **proxy-governed** — tier 1 의 루프백 프록시를 경유한다(`obscura fetch <url> … --proxy http://<token>:@127.0.0.1:<port>`), 브라우저 tier 의 egress 거버넌스 공백을 없앤다.
+
 ---
 
 ## §5 · 보안 모델 — 샌드박스, 동의, 도구 정책
@@ -102,7 +109,7 @@ fetch(url, render?)    →  {url, status, title, text, tier}
 | **프로비넌스** | 각 워커는 자신의 응답을 `Agent{self}` 이벤트로 기록하고 Ed25519 서명(v3d-2 peer-writes-own)하며, fold 시 액터별로 검증한다. | 라우터는 더 이상 워커를 대신해 서명하지 않는다 — 귀속은 워커 자신의 키다. |
 | **내보내기 안전성** | `.fleet` 임포트는 broad-audited 를 `inherit` 로 강등하고 승인을 지운다. | 공유된 deep-research 플릿은 로컬에서 재부여하기 전까지 egress 가 0 이다. |
 
-**어드바이저리 강제의 정직함.** Tier 1 은 프록시를 존중한다. tier 2/3 의 브라우저 자식 프로세스는 그러지 않을 수 있다 — 전역 게이트웨이 URL 감사로 완화하고, 과장 없이 문서화한다. 완전한 봉쇄 = 향후 Phase-3 sbpl pin-to-proxy 이며, 그때 핀 고정하는 것은 바로 이 하나의 게이트웨이뿐이다.
+**어드바이저리 강제의 정직함.** Tier 1 은 프록시를 존중한다. tier 2/3 의 브라우저 자식 프로세스는 그러지 않을 수 있다 — 전역 게이트웨이 URL 감사로 완화하고, 과장 없이 문서화한다. 옵트인 `render_engine: obscura` 를 쓰면 이 공백이 닫힌다: obscura 는 tier 1 이 쓰는 것과 같은 루프백 프록시를 통해 모든 egress 를 보내(게이트웨이의 자격 증명을 실은 `--proxy` 경유) render tier 도 tier 1 처럼 proxy-governed 하게 만든다. 완전한 봉쇄 = 향후 Phase-3 sbpl pin-to-proxy 이며, 그때 핀 고정하는 것은 바로 이 하나의 게이트웨이뿐이다.
 
 ---
 

--- a/docs/design/deep-research/README.md
+++ b/docs/design/deep-research/README.md
@@ -88,10 +88,10 @@ fetch(url, render?)    →  {url, status, title, text, tier}
 
 ### Render engine (experimental, opt-in)
 
-Select via `MUR_RESEARCH_RENDER_ENGINE` env (or `research_gateway.render_engine:` in `~/.mur/config.yaml`):
+Select via `MUR_RESEARCH_RENDER_ENGINE` env (or `research_gateway.render_engine:` in `~/.mur/config.yaml`); an explicit value here always overrides auto-detect. Auto-detect (no env/YAML set): **`obscura` when its `obscura` + `obscura-worker` binaries are both installed at `~/.mur/aura/`, else `agent-browser`** (head-to-head 2026-07-10: obscura renders real content incl. JS-only pages and runs under the worker sandbox; agent-browser/Lightpanda returns title-only stubs and is sandbox-denied).
 
-- **`agent-browser` (default)** — Lightpanda (tier 2) and Chrome (tier 3) as above.
-- **`obscura` (experimental, opt-in)** — Embedded-V8, self-contained. Install: extract platform tarball to `~/.mur/aura/`, keep both `obscura` and `obscura-worker` binaries. Single render path; no tier-2/3 escalation. **Advantage:** egress is **proxy-governed** — routes through the tier-1 loopback proxy (`obscura fetch <url> … --proxy http://<token>:@127.0.0.1:<port>`), eliminating the browser-tier egress-governance gap. Experimental, not yet default; head-to-head evaluation vs Lightpanda gates default flip.
+- **`agent-browser`** — Lightpanda (tier 2) and Chrome (tier 3) as above. Auto-detect fallback when obscura isn't installed.
+- **`obscura`** — Embedded-V8, self-contained. Install: extract platform tarball to `~/.mur/aura/`, keep both `obscura` and `obscura-worker` binaries — auto-detect then picks it automatically. Single render path; no tier-2/3 escalation. **Advantage:** egress is **proxy-governed** — routes through the tier-1 loopback proxy (`obscura fetch <url> … --proxy http://<token>:@127.0.0.1:<port>`), eliminating the browser-tier egress-governance gap.
 
 ---
 

--- a/docs/design/deep-research/README.zh-CN.md
+++ b/docs/design/deep-research/README.zh-CN.md
@@ -86,6 +86,13 @@ fetch(url, render?)    →  {url, status, title, text, tier}
 - **搜索可靠性** — N 个并发 worker 时 DDG 以 202 挑战页限流。`search` 在 202 时 retry,采指数 backoff + **query 派生 jitter**——不同子问题错开重试,不再同步再爆一次。
 - **URL 级 audit** — 每次调用把 `{worker, url, tier, outcome}` 记录到 channel 与 telemetry。报告的每个引用都能对到一条 gateway audit 记录。
 
+### 渲染引擎(实验性,opt-in)
+
+通过 `MUR_RESEARCH_RENDER_ENGINE` 环境变量选择(或 `~/.mur/config.yaml` 中的 `research_gateway.render_engine:`);此处显式设置的值始终覆盖 auto-detect。自动检测(未设置 env/YAML 时):**当 `obscura` 与 `obscura-worker` 两个可执行文件都安装在 `~/.mur/aura/` 时用 `obscura`,否则用 `agent-browser`**(2026-07-10 正面对比:obscura 能渲染真实内容,包括纯 JS 页面,并能在 worker sandbox 下运行;agent-browser/Lightpanda 只返回 title-only 的空壳,且被 sandbox 拒绝)。
+
+- **`agent-browser`** — 如上所述的 Lightpanda(tier 2)与 Chrome(tier 3)。obscura 未安装时的自动检测 fallback。
+- **`obscura`** — 内嵌 V8、自包含。安装方式:把平台 tarball 解压到 `~/.mur/aura/`,保留 `obscura` 与 `obscura-worker` 两个可执行文件——自动检测便会自动选中它。单一渲染路径;没有 tier-2/3 升级。**优势:** egress 是 **proxy-governed** 的——通过 tier 1 的 loopback proxy 走(`obscura fetch <url> … --proxy http://<token>:@127.0.0.1:<port>`),消除浏览器 tier 的 egress 治理缺口。
+
 ---
 
 ## §5 · 安全模型——sandbox、同意、工具策略
@@ -102,7 +109,7 @@ Gateway 在强制 kernel sandbox 下运行,默认无 egress。访问权通过恰
 | **Provenance** | 每个 worker 把自己的回复以 `Agent{self}` 事件写入,Ed25519 签名(v3d-2 peer-writes-own),fold 时逐 actor 验证。 | Router 不再代 worker 签名——归属是 worker 自己的密钥。 |
 | **Export 安全** | `.fleet` import 把 broad-audited 降级为 `inherit` 并清除授权。 | 分享的 deep-research fleet 在本地重新授权前零 egress。 |
 
-**Advisory-enforcement 的诚实。** Tier 1 honor proxy;tier 2/3 浏览器子进程可能不——以全局 gateway URL audit 缓解,且如实记录而非过度宣称。滴水不漏的封装 = 未来 Phase-3 sbpl pin-to-proxy,届时只 pin 这一个 gateway。
+**Advisory-enforcement 的诚实。** Tier 1 honor proxy;tier 2/3 浏览器子进程可能不——以全局 gateway URL audit 缓解,且如实记录而非过度宣称。通过 opt-in 的 `render_engine: obscura`,这个缺口会被补上:obscura 把所有 egress 都通过 tier 1 使用的同一条 loopback proxy 走(以 `--proxy` 携带 gateway 的凭证),使 render tier 像 tier 1 一样 proxy-governed。滴水不漏的封装 = 未来 Phase-3 sbpl pin-to-proxy,届时只 pin 这一个 gateway。
 
 ---
 

--- a/docs/design/deep-research/README.zh-TW.md
+++ b/docs/design/deep-research/README.zh-TW.md
@@ -86,6 +86,13 @@ fetch(url, render?)    →  {url, status, title, text, tier}
 - **搜尋可靠度** — N 個併發 worker 時 DDG 以 202 挑戰頁限流。`search` 在 202 時 retry,採指數 backoff + **query 衍生 jitter**——不同子問題錯開重試,不再同步再爆一次。
 - **URL 級 audit** — 每次呼叫把 `{worker, url, tier, outcome}` 記錄到 channel 與 telemetry。報告的每個引用都能對到一筆 gateway audit 記錄。
 
+### 渲染引擎(實驗性,opt-in)
+
+透過 `MUR_RESEARCH_RENDER_ENGINE` 環境變數選擇(或 `~/.mur/config.yaml` 中的 `research_gateway.render_engine:`);此處明確設定的值永遠覆蓋 auto-detect。自動偵測(未設定 env/YAML 時):**當 `obscura` 與 `obscura-worker` 兩個執行檔都安裝在 `~/.mur/aura/` 時用 `obscura`,否則用 `agent-browser`**(2026-07-10 正面比較:obscura 能渲染真實內容,包含純 JS 頁面,且能在 worker sandbox 下運作;agent-browser/Lightpanda 只回傳 title-only 的空殼,且被 sandbox 拒絕)。
+
+- **`agent-browser`** — 如上述的 Lightpanda(tier 2)與 Chrome(tier 3)。obscura 未安裝時的自動偵測 fallback。
+- **`obscura`** — 內嵌 V8、自成一體。安裝方式:把平台 tarball 解壓到 `~/.mur/aura/`,保留 `obscura` 與 `obscura-worker` 兩個執行檔——自動偵測就會自動選中它。單一渲染路徑;沒有 tier-2/3 升級。**優勢:** egress 是 **proxy-governed**——透過 tier 1 的 loopback proxy 走(`obscura fetch <url> … --proxy http://<token>:@127.0.0.1:<port>`),消除瀏覽器 tier 的 egress 治理缺口。
+
 ---
 
 ## §5 · 安全模型——sandbox、同意、工具政策
@@ -102,7 +109,7 @@ Gateway 在強制 kernel sandbox 下執行,預設無 egress。存取權透過恰
 | **Provenance** | 每個 worker 把自己的回覆以 `Agent{self}` 事件寫入,Ed25519 簽名(v3d-2 peer-writes-own),fold 時逐 actor 驗證。 | Router 不再代 worker 簽名——歸屬是 worker 自己的金鑰。 |
 | **Export 安全** | `.fleet` import 把 broad-audited 降級為 `inherit` 並清除授權。 | 分享的 deep-research fleet 在本地重新授權前零 egress。 |
 
-**Advisory-enforcement 的誠實。** Tier 1 honor proxy;tier 2/3 瀏覽器子行程可能不——以全域 gateway URL audit 緩解,且如實記錄而非過度宣稱。滴水不漏的封裝 = 未來 Phase-3 sbpl pin-to-proxy,屆時只 pin 這一個 gateway。
+**Advisory-enforcement 的誠實。** Tier 1 honor proxy;tier 2/3 瀏覽器子行程可能不——以全域 gateway URL audit 緩解,且如實記錄而非過度宣稱。透過 opt-in 的 `render_engine: obscura`,這個缺口會被補上:obscura 把所有 egress 都透過 tier 1 用的同一條 loopback proxy 走(以 `--proxy` 帶上 gateway 的憑證),讓 render tier 像 tier 1 一樣 proxy-governed。滴水不漏的封裝 = 未來 Phase-3 sbpl pin-to-proxy,屆時只 pin 這一個 gateway。
 
 ---
 

--- a/mur-research-gateway/src/config.rs
+++ b/mur-research-gateway/src/config.rs
@@ -70,6 +70,10 @@ pub const DEFAULT_LIGHTPANDA_RELATIVE_PATH: &str = "aura/lightpanda";
 /// `aura/` install location).
 pub const DEFAULT_OBSCURA_RELATIVE_PATH: &str = "aura/obscura";
 
+/// obscura's sibling worker binary, relative to `mur_home`. Both it and
+/// `DEFAULT_OBSCURA_RELATIVE_PATH` must exist for auto-detect to pick obscura.
+pub const DEFAULT_OBSCURA_WORKER_RELATIVE_PATH: &str = "aura/obscura-worker";
+
 // ---- env var names ----
 
 // ENV_DENY_HOSTS (imported above as `ENV_MCP_DENY_HOSTS`) is shared with
@@ -213,7 +217,7 @@ pub fn load_from_yaml(yaml: &str, mur_home: &Path) -> GatewayConfig {
                 crate::browser::RenderEngine::AgentBrowser
             }
         })
-        .unwrap_or_default();
+        .unwrap_or_else(|| auto_detect_render_engine(mur_home));
 
     let obscura_path = non_empty_env(ENV_OBSCURA_PATH)
         .or_else(|| raw.obscura_path.filter(|s| !s.is_empty()))
@@ -249,6 +253,20 @@ fn default_lightpanda_path(mur_home: &Path) -> Option<String> {
 fn default_obscura_path(mur_home: &Path) -> Option<String> {
     let path = mur_home.join(DEFAULT_OBSCURA_RELATIVE_PATH);
     path.exists().then(|| path.to_string_lossy().to_string())
+}
+
+/// Auto-detect the render engine when nothing is explicitly configured:
+/// prefer obscura IF both its binaries are installed at the default aura
+/// paths (they render real content + run under the sandbox — head-to-head
+/// 2026-07-10), else agent-browser. Never picks obscura it can't run.
+fn auto_detect_render_engine(mur_home: &Path) -> crate::browser::RenderEngine {
+    let obscura = mur_home.join(DEFAULT_OBSCURA_RELATIVE_PATH);
+    let worker = mur_home.join(DEFAULT_OBSCURA_WORKER_RELATIVE_PATH);
+    if obscura.exists() && worker.exists() {
+        crate::browser::RenderEngine::Obscura
+    } else {
+        crate::browser::RenderEngine::AgentBrowser
+    }
 }
 
 fn env_deny_hosts() -> Option<Vec<String>> {
@@ -486,5 +504,90 @@ research_gateway:
         unsafe {
             std::env::remove_var(ENV_RENDER_ENGINE);
         }
+    }
+
+    /// Creates a fresh scratch dir under the OS temp dir for a single test,
+    /// suffixed with `label` for readability + isolation across parallel runs.
+    fn scratch_dir(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "mur_research_gateway_test_{}_{}",
+            label,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        dir
+    }
+
+    #[test]
+    fn auto_detect_picks_obscura_when_binaries_present() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let mur_home = scratch_dir("obscura_both");
+        let aura = mur_home.join("aura");
+        std::fs::create_dir_all(&aura).expect("create aura dir");
+        std::fs::write(aura.join("obscura"), b"").expect("write obscura stub");
+        std::fs::write(aura.join("obscura-worker"), b"").expect("write obscura-worker stub");
+
+        let c = load_from_yaml("", &mur_home);
+        assert_eq!(
+            c.browser.render_engine,
+            crate::browser::RenderEngine::Obscura
+        );
+
+        let _ = std::fs::remove_dir_all(&mur_home);
+    }
+
+    #[test]
+    fn auto_detect_requires_both_obscura_binaries() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        // Only the main binary present -> AgentBrowser.
+        let mur_home = scratch_dir("obscura_main_only");
+        let aura = mur_home.join("aura");
+        std::fs::create_dir_all(&aura).expect("create aura dir");
+        std::fs::write(aura.join("obscura"), b"").expect("write obscura stub");
+        let c = load_from_yaml("", &mur_home);
+        assert_eq!(
+            c.browser.render_engine,
+            crate::browser::RenderEngine::AgentBrowser
+        );
+        let _ = std::fs::remove_dir_all(&mur_home);
+
+        // Only the worker present -> AgentBrowser.
+        let mur_home = scratch_dir("obscura_worker_only");
+        let aura = mur_home.join("aura");
+        std::fs::create_dir_all(&aura).expect("create aura dir");
+        std::fs::write(aura.join("obscura-worker"), b"").expect("write obscura-worker stub");
+        let c = load_from_yaml("", &mur_home);
+        assert_eq!(
+            c.browser.render_engine,
+            crate::browser::RenderEngine::AgentBrowser
+        );
+        let _ = std::fs::remove_dir_all(&mur_home);
+    }
+
+    #[test]
+    fn render_engine_env_override_wins_even_when_obscura_installed() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let mur_home = scratch_dir("obscura_env_override");
+        let aura = mur_home.join("aura");
+        std::fs::create_dir_all(&aura).expect("create aura dir");
+        std::fs::write(aura.join("obscura"), b"").expect("write obscura stub");
+        std::fs::write(aura.join("obscura-worker"), b"").expect("write obscura-worker stub");
+
+        // SAFETY: env mutation guarded by ENV_LOCK above.
+        unsafe {
+            std::env::set_var(ENV_RENDER_ENGINE, "agent-browser");
+        }
+        let c = load_from_yaml("", &mur_home);
+        assert_eq!(
+            c.browser.render_engine,
+            crate::browser::RenderEngine::AgentBrowser
+        );
+        unsafe {
+            std::env::remove_var(ENV_RENDER_ENGINE);
+        }
+
+        let _ = std::fs::remove_dir_all(&mur_home);
     }
 }


### PR DESCRIPTION
Completes the obscura render-tier follow-up. After the 2026-07-10 head-to-head (obscura renders real content on 8/8 targets incl. JS-only pages + runs under the sandbox; agent-browser/Lightpanda returns title-only stubs and is sandbox-denied), make the default **auto-detect** rather than a hard flip.

## What
- **Auto-detect default** (`config.rs`): when neither `MUR_RESEARCH_RENDER_ENGINE` nor `research_gateway.render_engine` is set, resolve to `obscura` **iff both `~/.mur/aura/obscura` and `~/.mur/aura/obscura-worker` exist**, else `agent-browser`. An explicit env/YAML value always overrides. So obscura's quality is used when installed, with **zero breakage** when it isn't (obscura is a ~135MB manual install, not shipped).
- New const `DEFAULT_OBSCURA_WORKER_RELATIVE_PATH`; `auto_detect_render_engine` mirrors the existing existence-checked default helpers.
- Docs: English README §4 default note updated; obscura §4/§5 sections translated into **zh-TW / zh-CN / ja / ko** (were English-only).

## Tests
Both-binaries-present → obscura; only-one-present → agent-browser; explicit `agent-browser` env with binaries present → still agent-browser (override wins). 66 crate tests green, clippy `-D warnings` clean.

## Head-to-head data (unsandboxed, 8 real targets, zero LLM $)
| | obscura | Lightpanda |
|---|---|---|
| renders real body | 8/8 (1.7k–49k b) | 0/8 (title+URL only, ~50 b) |
| JS-only page | ✅ | ❌ |
| under worker sandbox | ✅ (live-proven) | ❌ (G2 exec-denied) |

Lightpanda's speed is illusory — it returns stubs. obscura's cost is latency (avg 4.1s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)