### PR TITLE
feat(research-gateway): native lightpanda render engine (drive lightpanda fetch directly)

### DIFF
--- a/docs/design/deep-research/README.md
+++ b/docs/design/deep-research/README.md
@@ -88,10 +88,13 @@ fetch(url, render?)    →  {url, status, title, text, tier}
 
 ### Render engine (experimental, opt-in)
 
-Select via `MUR_RESEARCH_RENDER_ENGINE` env (or `research_gateway.render_engine:` in `~/.mur/config.yaml`); an explicit value here always overrides auto-detect. Auto-detect (no env/YAML set): **`obscura` when its `obscura` + `obscura-worker` binaries are both installed at `~/.mur/aura/`, else `agent-browser`** (head-to-head 2026-07-10: obscura renders real content incl. JS-only pages and runs under the worker sandbox; agent-browser/Lightpanda returns title-only stubs and is sandbox-denied).
+Select via `MUR_RESEARCH_RENDER_ENGINE` env (or `research_gateway.render_engine:` in `~/.mur/config.yaml`); an explicit value here always overrides auto-detect. Auto-detect (no env/YAML set): **`obscura` when its `obscura` + `obscura-worker` binaries are both installed at `~/.mur/aura/`, else `agent-browser`**.
 
-- **`agent-browser`** — Lightpanda (tier 2) and Chrome (tier 3) as above. Auto-detect fallback when obscura isn't installed.
-- **`obscura`** — Embedded-V8, self-contained. Install: extract platform tarball to `~/.mur/aura/`, keep both `obscura` and `obscura-worker` binaries — auto-detect then picks it automatically. Single render path; no tier-2/3 escalation. **Advantage:** egress is **proxy-governed** — routes through the tier-1 loopback proxy (`obscura fetch <url> … --proxy http://<token>:@127.0.0.1:<port>`), eliminating the browser-tier egress-governance gap.
+Three engines:
+
+- **`agent-browser`** — drives Lightpanda (tier 2) / Chrome (tier 3) via Vercel's `agent-browser` CLI. Auto-detect fallback. The `agent-browser` wrapper returns title-only stubs under the sandbox and its lightpanda tier is sandbox-denied — prefer `lightpanda` or `obscura`.
+- **`obscura`** — Embedded-V8, self-contained. Install: extract platform tarball to `~/.mur/aura/`, keep both `obscura` and `obscura-worker`. Single render path; no tier-2/3 escalation. Egress **proxy-governed** via `--proxy http://<token>:@127.0.0.1:<port>` (Basic auth on CONNECT).
+- **`lightpanda`** — native Lightpanda (`~/.mur/aura/lightpanda`), driven directly (`lightpanda fetch <url> --dump markdown --http-timeout <ms> --http-proxy <proxy>`), NOT via `agent-browser`. A 2026-07-11 head-to-head found native Lightpanda renders real content on 8/8 targets (incl. JS-only pages), **faster than obscura and with more extracted content**, runs under the sandbox, and is egress-governed (its `--http-proxy` userinfo sends the same Basic auth on CONNECT our egress proxy accepts). **Caveat:** Lightpanda phones home to `telemetry.lightpanda.io` — that CONNECT goes through the egress proxy (audited) and should be blocked with `--deny-host telemetry.lightpanda.io` for a clean egress. (The earlier "Lightpanda = title-only stubs" result was an artifact of the `agent-browser` wrapper, not Lightpanda itself.)
 
 ---
 

--- a/mur-research-gateway/src/browser.rs
+++ b/mur-research-gateway/src/browser.rs
@@ -24,6 +24,12 @@ pub enum RenderEngine {
     /// `obscura` — self-contained embedded-V8 engine; renders under the kernel
     /// sandbox and routes egress through `--proxy` (spike 2026-07-10).
     Obscura,
+    /// Native `lightpanda fetch` driven directly (NOT via `agent-browser`).
+    /// Renders JS under the kernel sandbox and routes egress through our
+    /// loopback proxy via `--http-proxy` Basic auth on the CONNECT — faster
+    /// than obscura and with more content than the agent-browser-wrapped path,
+    /// which was returning empty title-only stubs (verified 2026-07-11).
+    Lightpanda,
 }
 
 pub struct BrowserCfg {
@@ -107,6 +113,28 @@ fn build_obscura_argv(url: &str, proxy: Option<&str>, timeout: Duration) -> Vec<
     a
 }
 
+/// Build the native `lightpanda fetch` argv (drives lightpanda directly, NOT
+/// via agent-browser). `--dump markdown` for clean text; `--http-proxy`
+/// carries the gateway's HTTP_PROXY credential (`http://<token>:x@host:port`)
+/// so lightpanda sends Basic auth on the CONNECT — our egress proxy accepts
+/// it (verified 2026-07-11). No `--block-private-networks` (it blocks the
+/// loopback proxy; SSRF is enforced by screen_url_blocking). Pure.
+fn build_lightpanda_argv(url: &str, proxy: Option<&str>, timeout: Duration) -> Vec<String> {
+    let mut a = vec![
+        "fetch".to_string(),
+        url.to_string(),
+        "--dump".to_string(),
+        "markdown".to_string(),
+        "--http-timeout".to_string(),
+        timeout.as_millis().to_string(),
+    ];
+    if let Some(p) = proxy {
+        a.push("--http-proxy".to_string());
+        a.push(p.to_string());
+    }
+    a
+}
+
 /// Read the gateway's own HTTP_PROXY or HTTPS_PROXY environment variable and
 /// forward it to obscura's `--proxy` flag. The runtime sets
 /// `HTTP_PROXY=http://<token>:x@127.0.0.1:<port>` on this child (see
@@ -149,6 +177,12 @@ pub fn preflight(cfg: &BrowserCfg) -> Preflight {
     if cfg.render_engine == RenderEngine::Obscura {
         return obscura_preflight(cfg);
     }
+    // Native lightpanda is a different binary from agent-browser too — same
+    // short-circuit rationale as obscura above: never invoke (or require)
+    // agent-browser for this engine.
+    if cfg.render_engine == RenderEngine::Lightpanda {
+        return lightpanda_preflight(cfg);
+    }
     let output = std::process::Command::new(&cfg.agent_browser_bin)
         .arg("--version")
         .output();
@@ -182,6 +216,16 @@ fn obscura_preflight(cfg: &BrowserCfg) -> Preflight {
         Preflight::Full
     } else {
         Preflight::ObscuraMissing
+    }
+}
+
+/// Preflight for the native `Lightpanda` render engine: `lightpanda_path`
+/// must be set and exist on disk (single binary, no sibling worker — unlike
+/// obscura). Never probes agent-browser for this engine.
+fn lightpanda_preflight(cfg: &BrowserCfg) -> Preflight {
+    match cfg.lightpanda_path.as_deref() {
+        Some(path) if std::path::Path::new(path).exists() => Preflight::Full,
+        _ => Preflight::LightpandaMissing,
     }
 }
 
@@ -251,9 +295,10 @@ async fn run_agent_browser(
 }
 
 /// Decide (binary, argv, tier) for a render, dispatching on the engine. Pure
-/// (proxy passed in) → unit-testable without spawning. obscura is a single
-/// engine covering JS render, so `want_chrome` is ignored and the tier is 2;
-/// the agent-browser path keeps the lightpanda(2)/chrome(3) split.
+/// (proxy passed in) → unit-testable without spawning. obscura and native
+/// lightpanda are each single engines covering JS render, so `want_chrome` is
+/// ignored and the tier is 2 for both; the agent-browser path keeps the
+/// lightpanda(2)/chrome(3) split.
 fn plan_render(
     url: &str,
     cfg: &BrowserCfg,
@@ -268,6 +313,13 @@ fn plan_render(
                 .clone()
                 .unwrap_or_else(|| "obscura".to_string());
             (bin, build_obscura_argv(url, proxy, timeout), 2)
+        }
+        RenderEngine::Lightpanda => {
+            let bin = cfg
+                .lightpanda_path
+                .clone()
+                .unwrap_or_else(|| "lightpanda".to_string());
+            (bin, build_lightpanda_argv(url, proxy, timeout), 2)
         }
         RenderEngine::AgentBrowser => {
             let tier = if want_chrome || cfg.lightpanda_path.is_none() {
@@ -286,7 +338,8 @@ fn plan_render(
 
 /// Fetch a JS-rendered page. Pre-spawn SSRF/deny screen (proxy can't see the
 /// browser's connections — spec §5), then drive the configured render engine
-/// (agent-browser or obscura, see `plan_render`) under `timeout`.
+/// (agent-browser, obscura, or native lightpanda — see `plan_render`) under
+/// `timeout`.
 pub async fn fetch_rendered(
     url: &str,
     deny: &[String],
@@ -442,6 +495,23 @@ mod tests {
         assert_eq!(preflight(&cfg), Preflight::ObscuraMissing);
     }
     #[test]
+    fn preflight_flags_missing_lightpanda_native() {
+        let none_path = BrowserCfg {
+            agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: None,
+            chrome_stealth_args: String::new(),
+            render_engine: RenderEngine::Lightpanda,
+            obscura_path: None,
+        };
+        assert_eq!(preflight(&none_path), Preflight::LightpandaMissing);
+
+        let nonexistent = BrowserCfg {
+            lightpanda_path: Some("/nonexistent/lightpanda".into()),
+            ..none_path
+        };
+        assert_eq!(preflight(&nonexistent), Preflight::LightpandaMissing);
+    }
+    #[test]
     fn preflight_missing_when_absent() {
         let cfg = BrowserCfg {
             agent_browser_bin: "agent-browser".into(),
@@ -517,6 +587,37 @@ mod tests {
     }
 
     #[test]
+    fn lightpanda_argv_dumps_markdown_and_threads_proxy() {
+        let base = build_lightpanda_argv("https://example.com", None, Duration::from_secs(20));
+        assert_eq!(base[0], "fetch");
+        assert_eq!(base[1], "https://example.com");
+        assert!(
+            base.windows(2)
+                .any(|w| w[0] == "--dump" && w[1] == "markdown")
+        );
+        assert!(
+            base.windows(2)
+                .any(|w| w[0] == "--http-timeout" && w[1] == "20000")
+        );
+        assert!(!base.iter().any(|a| a == "--http-proxy"));
+        assert!(!base.iter().any(|a| a == "--block-private-networks"));
+        assert!(!base.iter().any(|a| a == "--proxy-bearer-token"));
+
+        let proxied = build_lightpanda_argv(
+            "https://example.com",
+            Some("http://t:x@127.0.0.1:9"),
+            Duration::from_secs(20),
+        );
+        assert!(
+            proxied
+                .windows(2)
+                .any(|w| w[0] == "--http-proxy" && w[1] == "http://t:x@127.0.0.1:9")
+        );
+        assert!(!proxied.iter().any(|a| a == "--block-private-networks"));
+        assert!(!proxied.iter().any(|a| a == "--proxy-bearer-token"));
+    }
+
+    #[test]
     fn plan_render_dispatches_on_engine() {
         let ab = BrowserCfg {
             agent_browser_bin: "agent-browser".into(),
@@ -555,5 +656,26 @@ mod tests {
                 .any(|w| w[0] == "--proxy" && w[1] == "http://t:@127.0.0.1:9")
         );
         assert!(argv.windows(2).any(|w| w[0] == "--timeout" && w[1] == "20"));
+    }
+
+    #[test]
+    fn plan_render_dispatches_lightpanda() {
+        let cfg = BrowserCfg {
+            agent_browser_bin: "agent-browser".into(),
+            lightpanda_path: Some("/x/lightpanda".into()),
+            chrome_stealth_args: String::new(),
+            render_engine: RenderEngine::Lightpanda,
+            obscura_path: None,
+        };
+        let (bin, argv, tier) = plan_render(
+            "https://example.com",
+            &cfg,
+            true, /*ignored: single engine, no chrome escalation*/
+            Some("http://t:x@127.0.0.1:9"),
+            Duration::from_secs(20),
+        );
+        assert_eq!(bin, "/x/lightpanda");
+        assert_eq!(tier, 2);
+        assert_eq!(argv[0], "fetch");
     }
 }

--- a/mur-research-gateway/src/config.rs
+++ b/mur-research-gateway/src/config.rs
@@ -209,6 +209,7 @@ pub fn load_from_yaml(yaml: &str, mur_home: &Path) -> GatewayConfig {
         .map(|s| match s.trim().to_ascii_lowercase().as_str() {
             "obscura" => crate::browser::RenderEngine::Obscura,
             "agent-browser" => crate::browser::RenderEngine::AgentBrowser,
+            "lightpanda" => crate::browser::RenderEngine::Lightpanda,
             unrecognized => {
                 tracing::warn!(
                     "unrecognized render_engine '{}'; falling back to agent-browser",
@@ -500,6 +501,23 @@ research_gateway:
         assert!(matches!(
             c.browser.render_engine,
             crate::browser::RenderEngine::Obscura
+        ));
+        unsafe {
+            std::env::remove_var(ENV_RENDER_ENGINE);
+        }
+    }
+
+    #[test]
+    fn render_engine_env_lightpanda_resolves() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: env mutation guarded by ENV_LOCK.
+        unsafe {
+            std::env::set_var(ENV_RENDER_ENGINE, "lightpanda");
+        }
+        let c = load_from_yaml("", Path::new("/nonexistent"));
+        assert!(matches!(
+            c.browser.render_engine,
+            crate::browser::RenderEngine::Lightpanda
         ));
         unsafe {
             std::env::remove_var(ENV_RENDER_ENGINE);

--- a/mur-research-gateway/src/main.rs
+++ b/mur-research-gateway/src/main.rs
@@ -34,6 +34,9 @@ async fn main() {
         browser::Preflight::Full => {
             let engine_desc = match server.browser_cfg().render_engine {
                 browser::RenderEngine::Obscura => "full — obscura render engine available",
+                browser::RenderEngine::Lightpanda => {
+                    "full — native lightpanda render engine available"
+                }
                 browser::RenderEngine::AgentBrowser => {
                     "full — tiers 2/3 (lightpanda/chrome) available"
                 }

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -298,6 +298,14 @@ mod tests {
         assert!(render_can_escalate(&ab));
     }
 
+    #[test]
+    fn lightpanda_engine_does_not_escalate_to_chrome() {
+        // Native lightpanda is a single engine (tier 2), same as obscura — no
+        // chrome tier-3 re-call.
+        let lp = browser_cfg(crate::browser::RenderEngine::Lightpanda);
+        assert!(!render_can_escalate(&lp));
+    }
+
     fn req(method: &str, params: Option<serde_json::Value>) -> Request {
         Request {
             jsonrpc: "2.0".into(),


### PR DESCRIPTION
Adds a `lightpanda` render engine that drives **native Lightpanda** (`lightpanda fetch <url> --dump markdown`) directly, bypassing Vercel's `agent-browser`.

## Why
The earlier head-to-head declared obscura the decisive winner — but that was against `agent-browser`-wrapped Lightpanda, which returns title-only stubs. Driving Lightpanda **natively** (2026-07-11 re-run) tells a different story:

| | obscura | native Lightpanda |
|---|---|---|
| real content | 8/8 (118k) | 8/8 (**156k**) |
| avg latency | 3.9s | **2.1s** |
| JS-only page | ✅ | ✅ |
| under sandbox | ✅ | ✅ |
| egress via our proxy | ✅ Basic | ✅ Basic (`--http-proxy` userinfo) |

Native Lightpanda is faster, extracts more, is already installed (`~/.mur/aura/lightpanda`), and — via `--http-proxy http://<token>:x@127.0.0.1:<port>` userinfo — sends the Basic auth on CONNECT our egress proxy accepts (proven under a restricted-network sandbox).

## What
- `RenderEngine::Lightpanda` + `build_lightpanda_argv` (`fetch --dump markdown --http-timeout <ms> [--http-proxy <p>]`) + `plan_render` arm (tier 2, single engine) + config `"lightpanda"` + preflight `LightpandaMissing` short-circuit.
- AgentBrowser + Obscura byte-for-byte unchanged; `auto_detect` unchanged (default preference is a separate call).

## Gotchas encoded
- `--proxy-bearer-token` does NOT authenticate the CONNECT (userinfo does) → we use `--http-proxy` userinfo.
- `--block-private-networks` blocks the loopback proxy itself → omitted (SSRF stays on `screen_url_blocking`).
- Lightpanda phones home to `telemetry.lightpanda.io` (audited via the proxy; docs recommend `--deny-host`).

## Tests
argv shape (±proxy, no forbidden flags), plan_render arm, config parse, preflight. 71 crate tests green, clippy `-D warnings` clean. Docs §4 updated (3 engines + telemetry caveat + corrects the earlier agent-browser-stub framing).

## Open follow-up (not in this PR)
Default preference: native `lightpanda` is faster + already installed + governed — should auto-detect prefer it over obscura? Left as an explicit decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)