### PR TITLE
feat(deps): portable program deps Phase 2 — trusted-publisher recipes

### DIFF
--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -445,7 +445,9 @@ Shared artifacts — agents, fleets, skills, and MCP server entries — can decl
 - `lightpanda` (v0.3.4) — native HTML/JavaScript renderer for tier-2 research fetches
 - `obscura` (v0.1.9) — embedded-V8 JavaScript engine alternative
 
-Unknown-source programs are detect-and-guide only (the trust gradient's safe default); trusted-publisher auto-install is a future Phase 2.
+**Trusted-publisher recipes (Phase 2):** A signed bundle (fleet `.fleet` or agent `.muragent`) from a **trusted** publisher (elevated in `~/.mur/trust/publishers.yaml`) may carry author-declared `recipe` blocks on `ProgramDep` entries — per-platform `{ url, sha256, install_to, executable }` or `archive` declarations. Integrity flows from the bundle's **existing Ed25519 signature** (no separate recipe signature). At import (fleet import or `mur agent install <.muragent>`), after signature verification, MUR classifies the publisher via `PublisherKeyring`: **Trusted** → offers per-item consent prompts to install each missing, non-curated recipe (showing publisher fingerprint, URL, and SHA-256), reusing the Phase 1 installer; **Unknown** → skips, prints a `mur agent skill signer-trust <fp>` hint; **Revoked** → refused. Trust is anchored at import only (the moment the signature is present). `install-deps` remains curated-only. Curated keys always supersede author recipes of the same name. Installation is non-blocking — declined or failed installs never fail the import.
+
+**Unknown-source programs** are detect-and-guide only (the trust gradient's safe default).
 
 **Graceful degradation:** Missing dependencies are **non-blocking**. Imports succeed, agents start, and fleets run — but artifacts degrade. Example: a deep-research fleet without a render engine (`lightpanda` or `obscura`) falls back to tier-1 HTTP fetch, losing JavaScript rendering but preserving correctness.
 

--- a/docs/superpowers/specs/2026-07-11-portable-program-dependencies-design.md
+++ b/docs/superpowers/specs/2026-07-11-portable-program-dependencies-design.md
@@ -152,6 +152,8 @@ machinery; the recipe signature provides integrity + attribution, and the
 user's trust-tier decision provides authorization. Per-install consent shows the
 publisher, the URL, the checksum, and the install target before anything runs.
 
+**Status:** Implemented (Phase 2). See implementation spec `2026-07-11-portable-program-dependencies-phase2-design.md`.
+
 ### §7.3 Unknown / untrusted — detect and guide only
 
 Any declared program that is neither a curated key nor a trusted-publisher recipe

--- a/mur-common/src/deps/detect.rs
+++ b/mur-common/src/deps/detect.rs
@@ -131,6 +131,7 @@ mod tests {
             reason: "r".into(),
             hint: None,
             registry: None,
+            recipe: None,
         }
     }
 

--- a/mur-common/src/deps/mod.rs
+++ b/mur-common/src/deps/mod.rs
@@ -24,6 +24,10 @@ pub struct ProgramDep {
     /// Optional key into MUR's curated registry (enables auto-install).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub registry: Option<String>,
+    /// Author-declared install recipe (Phase 2). Present only in signed
+    /// bundles; auto-installed at import ONLY from a trusted publisher.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipe: Option<ProgramRecipe>,
 }
 
 /// Exactly one detection method (serde picks the arm by which field is present).
@@ -64,13 +68,13 @@ pub fn current_platform() -> String {
 /// Author-declared, per-platform install recipe carried on a `ProgramDep`
 /// inside a SIGNED bundle. Its integrity flows from the bundle signature; its
 /// authorization from the publisher's trust classification at import.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ProgramRecipe {
     /// `<arch>-<os>` → recipe. Only the current platform's entry is installed.
     pub platforms: BTreeMap<String, PlatformRecipe>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PlatformRecipe {
     pub url: String,
     pub sha256: String,
@@ -140,6 +144,26 @@ mod tests {
         // arch and os are non-empty
         let (arch, os) = p.split_once('-').unwrap();
         assert!(!arch.is_empty() && !os.is_empty());
+    }
+
+    #[test]
+    fn program_dep_parses_optional_recipe_and_defaults_none() {
+        let with = r#"
+name: some-tool
+detect: { command: some-tool }
+reason: "x"
+recipe:
+  platforms:
+    aarch64-macos: { url: "u", sha256: "s", install_to: "aura/some-tool", executable: true }
+"#;
+        let d: ProgramDep = serde_yaml::from_str(with).unwrap();
+        assert!(d.recipe.is_some());
+        assert!(d.recipe.unwrap().for_platform("aarch64-macos").is_some());
+
+        // Phase 1 dep without recipe → None (back-compat).
+        let without = "name: x\ndetect: { command: x }\nreason: r\n";
+        let d2: ProgramDep = serde_yaml::from_str(without).unwrap();
+        assert!(d2.recipe.is_none());
     }
 }
 

--- a/mur-common/src/deps/mod.rs
+++ b/mur-common/src/deps/mod.rs
@@ -3,6 +3,7 @@
 //! See docs/superpowers/specs/2026-07-11-portable-program-dependencies-design.md
 
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 pub mod detect;
 pub mod registry;
@@ -60,6 +61,45 @@ pub fn current_platform() -> String {
     format!("{}-{}", std::env::consts::ARCH, std::env::consts::OS)
 }
 
+/// Author-declared, per-platform install recipe carried on a `ProgramDep`
+/// inside a SIGNED bundle. Its integrity flows from the bundle signature; its
+/// authorization from the publisher's trust classification at import.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProgramRecipe {
+    /// `<arch>-<os>` → recipe. Only the current platform's entry is installed.
+    pub platforms: BTreeMap<String, PlatformRecipe>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PlatformRecipe {
+    pub url: String,
+    pub sha256: String,
+    /// Bare-binary install target (relative to mur_home); `None` when `archive`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_to: Option<String>,
+    #[serde(default)]
+    pub executable: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archive: Option<registry::ArchiveSpec>,
+}
+
+impl ProgramRecipe {
+    /// Convert this recipe's entry for `platform` into the Phase 1
+    /// `CuratedRecipe` the installer consumes. `None` if no entry for the
+    /// platform. `description` is a fixed author-provenance label.
+    pub fn for_platform(&self, platform: &str) -> Option<registry::CuratedRecipe> {
+        let p = self.platforms.get(platform)?;
+        Some(registry::CuratedRecipe {
+            description: "author-declared recipe".to_string(),
+            url: p.url.clone(),
+            sha256: p.sha256.clone(),
+            install_to: p.install_to.clone(),
+            executable: p.executable,
+            archive: p.archive.clone(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -100,5 +140,26 @@ mod tests {
         // arch and os are non-empty
         let (arch, os) = p.split_once('-').unwrap();
         assert!(!arch.is_empty() && !os.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod recipe_tests {
+    use super::*;
+
+    #[test]
+    fn program_recipe_for_platform_converts_to_curated() {
+        let y = r#"
+platforms:
+  aarch64-macos: { url: "https://x/tool", sha256: "abc123", install_to: "aura/tool", executable: true }
+"#;
+        let r: ProgramRecipe = serde_yaml::from_str(y).unwrap();
+        let cur = r.for_platform("aarch64-macos").expect("platform present");
+        assert_eq!(cur.url, "https://x/tool");
+        assert_eq!(cur.sha256, "abc123");
+        assert_eq!(cur.install_to.as_deref(), Some("aura/tool"));
+        assert!(cur.executable);
+        assert!(cur.archive.is_none());
+        assert!(r.for_platform("sparc-solaris").is_none());
     }
 }

--- a/mur-common/src/deps/registry.rs
+++ b/mur-common/src/deps/registry.rs
@@ -22,12 +22,12 @@ pub struct CuratedRecipe {
     pub archive: Option<ArchiveSpec>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ArchiveSpec {
     pub members: Vec<RecipeMember>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct RecipeMember {
     pub path_in_archive: String,
     pub install_to: String,

--- a/mur-common/src/deps/registry.rs
+++ b/mur-common/src/deps/registry.rs
@@ -1,12 +1,12 @@
 //! MUR-curated program registry. URLs + pinned SHA-256 are MUR-owned, so a
 //! shared bundle can only *reference* a key — it cannot substitute the source.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 const MANIFEST: &str = include_str!("registry_manifest.yaml");
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CuratedRecipe {
     #[serde(default)]
     pub description: String,
@@ -22,12 +22,12 @@ pub struct CuratedRecipe {
     pub archive: Option<ArchiveSpec>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ArchiveSpec {
     pub members: Vec<RecipeMember>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RecipeMember {
     pub path_in_archive: String,
     pub install_to: String,

--- a/mur-core/src/cmd/agent/install.rs
+++ b/mur-core/src/cmd/agent/install.rs
@@ -18,11 +18,15 @@ use mur_common::trust;
 
 use super::resolve_mur_home;
 
+/// Installs a `.muragent` bundle. Returns `(installed_name, signer_fingerprint_hex)`
+/// so the dispatch layer can fire the best-effort trusted-recipe install hook
+/// (async; mirrors the fleet-import wiring) without making this function async
+/// itself — it has synchronous test callers.
 pub fn cmd_install(
     path: &Path,
     model_ref_override: Option<&str>,
     as_name: Option<&str>,
-) -> Result<()> {
+) -> Result<(String, String)> {
     let archive = MuragentArchive::read(path)
         .with_context(|| format!("read .muragent file at {}", path.display()))?;
     let mur_home = resolve_mur_home()?;
@@ -64,7 +68,7 @@ pub fn cmd_install(
     } else {
         maybe_resolve_model(&mur_home, installed_name, &archive)?;
     }
-    Ok(())
+    Ok((installed_name.to_string(), outcome.fingerprint_hex.clone()))
 }
 
 /// After a `--as <name>` clone install, give the clone a new identity: a

--- a/mur-core/src/cmd/deps/doctor.rs
+++ b/mur-core/src/cmd/deps/doctor.rs
@@ -107,6 +107,7 @@ mod tests {
                 reason: "render".into(),
                 hint: Some("http://x".into()),
                 registry: registry.map(|s| s.into()),
+                recipe: None,
             },
             sources: vec!["mcp:gw".into()],
         }

--- a/mur-core/src/cmd/deps/installer.rs
+++ b/mur-core/src/cmd/deps/installer.rs
@@ -6,13 +6,36 @@ use anyhow::{Context, Result, bail};
 use mur_common::deps::registry::CuratedRecipe;
 use sha2::{Digest, Sha256};
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 #[allow(dead_code)]
 fn sha256_hex(bytes: &[u8]) -> String {
     let mut h = Sha256::new();
     h.update(bytes);
     hex::encode(h.finalize())
+}
+
+/// I2 — fail-closed join: rejects a relative install target that is absolute
+/// or escapes `mur_home` via `..`/root/prefix components. In Phase 1 only
+/// MUR-owned recipes set `install_to`; Phase 2 feeds AUTHOR-declared
+/// `install_to` from a signed bundle here, so a malicious
+/// `"../../.zshrc"` or an absolute path must never be allowed to write
+/// outside `~/.mur`.
+#[allow(dead_code)]
+fn safe_join(mur_home: &Path, rel: &str) -> Result<PathBuf> {
+    let rel_path = Path::new(rel);
+    if rel_path.is_absolute() {
+        bail!("unsafe install target: {rel}");
+    }
+    for comp in rel_path.components() {
+        match comp {
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                bail!("unsafe install target: {rel}");
+            }
+            Component::CurDir | Component::Normal(_) => {}
+        }
+    }
+    Ok(mur_home.join(rel_path))
 }
 
 /// Verify `bytes` against `recipe.sha256`, then place file(s) under `mur_home`.
@@ -33,7 +56,7 @@ pub fn verify_and_place(
                 .install_to
                 .as_ref()
                 .context("bare recipe missing install_to")?;
-            let dst = mur_home.join(rel);
+            let dst = safe_join(mur_home, rel)?;
             place_file(&dst, bytes, recipe.executable)?;
             Ok(vec![dst])
         }
@@ -69,11 +92,19 @@ pub fn verify_and_place(
                     wanted.keys().collect::<Vec<_>>()
                 );
             }
-            // All members present; now place them on disk.
-            let mut placed = Vec::new();
+            // I2 — resolve + validate every member's install target BEFORE
+            // writing anything, so a bad target anywhere in the archive
+            // aborts the whole install with nothing written (preserves the
+            // existing all-or-nothing guarantee).
+            let mut resolved = Vec::with_capacity(buffered.len());
             for (member, buf) in buffered {
-                let dst = mur_home.join(&member.install_to);
-                place_file(&dst, &buf, member.executable)?;
+                let dst = safe_join(mur_home, &member.install_to)?;
+                resolved.push((dst, buf, member.executable));
+            }
+            // All members present and targets safe; now place them on disk.
+            let mut placed = Vec::new();
+            for (dst, buf, executable) in resolved {
+                place_file(&dst, &buf, executable)?;
                 placed.push(dst);
             }
             Ok(placed)
@@ -242,6 +273,120 @@ mod tests {
         assert!(
             !tmp.join("aura/obscura-worker").exists(),
             "obscura-worker must not exist on error"
+        );
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    // I2 — author-controlled `install_to` must never escape `mur_home`.
+
+    #[test]
+    fn bare_install_to_parent_traversal_rejected() {
+        let tmp = std::env::temp_dir().join(format!("muri2trav_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let bytes = b"payload";
+        let recipe = CuratedRecipe {
+            description: "t".into(),
+            url: "u".into(),
+            sha256: sha_hex(bytes),
+            install_to: Some("../escape".into()),
+            executable: false,
+            archive: None,
+        };
+        let r = verify_and_place(bytes, &recipe, &tmp);
+        assert!(r.is_err(), "parent-dir traversal must be rejected");
+        assert!(
+            !tmp.parent().unwrap().join("escape").exists(),
+            "no file must be written outside mur_home"
+        );
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn bare_install_to_absolute_path_rejected() {
+        let tmp = std::env::temp_dir().join(format!("muri2abs_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let target = std::env::temp_dir().join("mur_escape_test");
+        std::fs::remove_file(&target).ok();
+        let bytes = b"payload";
+        let recipe = CuratedRecipe {
+            description: "t".into(),
+            url: "u".into(),
+            sha256: sha_hex(bytes),
+            install_to: Some(target.to_string_lossy().into_owned()),
+            executable: false,
+            archive: None,
+        };
+        let r = verify_and_place(bytes, &recipe, &tmp);
+        assert!(r.is_err(), "absolute install target must be rejected");
+        assert!(
+            !target.exists(),
+            "no file must be written at the absolute target"
+        );
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn archive_member_install_to_traversal_rejected_nothing_written() {
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+        use mur_common::deps::registry::RecipeMember;
+
+        let tmp = std::env::temp_dir().join(format!("muri2arch_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        // Build a tar containing both members so the sha + completeness
+        // checks pass — the traversal guard on `install_to` is what must
+        // trigger the failure.
+        let mut tar_buf = Vec::new();
+        {
+            let gz = GzEncoder::new(&mut tar_buf, Compression::default());
+            let mut tar = tar::Builder::new(gz);
+            let mut h1 = tar::Header::new_gnu();
+            h1.set_size(7);
+            tar.append_data(&mut h1, "obscura", &b"content"[..])
+                .unwrap();
+            let mut h2 = tar::Header::new_gnu();
+            h2.set_size(6);
+            tar.append_data(&mut h2, "obscura-worker", &b"other!"[..])
+                .unwrap();
+            tar.finish().unwrap();
+        }
+
+        let archive_members = vec![
+            RecipeMember {
+                path_in_archive: "obscura".into(),
+                install_to: "aura/obscura".into(),
+                executable: false,
+            },
+            RecipeMember {
+                path_in_archive: "obscura-worker".into(),
+                install_to: "../escape-worker".into(), // traversal
+                executable: true,
+            },
+        ];
+        let recipe = CuratedRecipe {
+            description: "test".into(),
+            url: "unused".into(),
+            sha256: sha_hex(&tar_buf),
+            install_to: None,
+            executable: false,
+            archive: Some(mur_common::deps::registry::ArchiveSpec {
+                members: archive_members,
+            }),
+        };
+
+        let r = verify_and_place(&tar_buf, &recipe, &tmp);
+        assert!(
+            r.is_err(),
+            "traversal in a member install_to must be rejected"
+        );
+        assert!(
+            !tmp.join("aura/obscura").exists(),
+            "first (safe) member must not be written when a later member is unsafe"
+        );
+        assert!(
+            !tmp.parent().unwrap().join("escape-worker").exists(),
+            "no file must be written outside mur_home"
         );
         std::fs::remove_dir_all(&tmp).ok();
     }

--- a/mur-core/src/cmd/deps/mod.rs
+++ b/mur-core/src/cmd/deps/mod.rs
@@ -180,6 +180,27 @@ fn confirm(prompt: &str, yes: bool) -> Result<bool> {
 /// author recipe for the current platform, gate on the publisher's trust and
 /// (if Trusted) prompt+install via the Phase 1 installer. Best-effort — never
 /// returns Err into the import path.
+/// I1 — human-readable install target(s) for the consent prompt. A bare
+/// recipe shows its single `install_to`; an archive shows every member's
+/// `install_to` so the operator sees everywhere the bundle will write before
+/// approving.
+fn install_target_display(recipe: &mur_common::deps::registry::CuratedRecipe) -> String {
+    if let Some(archive) = &recipe.archive {
+        archive
+            .members
+            .iter()
+            .map(|m| m.install_to.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    } else {
+        recipe
+            .install_to
+            .as_deref()
+            .unwrap_or("<unspecified>")
+            .to_string()
+    }
+}
+
 pub async fn install_trusted_recipes_at_import(
     mur_home: &Path,
     deps: &[AggregatedDep],
@@ -198,8 +219,11 @@ pub async fn install_trusted_recipes_at_import(
         match crate::cmd::deps::trust_gate::decide(&a.dep, trust, status, &platform) {
             crate::cmd::deps::trust_gate::GateDecision::Offer(recipe) => {
                 let prompt = format!(
-                    "Install {} from {} (signed by {publisher_label}, sha256 {}) ?",
-                    a.dep.name, recipe.url, recipe.sha256
+                    "Install {} from {} (signed by {publisher_label}, sha256 {}) -> {} ?",
+                    a.dep.name,
+                    recipe.url,
+                    recipe.sha256,
+                    install_target_display(&recipe)
                 );
                 match confirm(&prompt, yes) {
                     Ok(true) => match crate::cmd::deps::installer::install(&recipe, mur_home).await
@@ -240,6 +264,47 @@ mod import_hook_tests {
         assert!(msg.contains("abcd1234"));
         assert!(msg.contains("signer-trust"));
         assert!(msg.contains("https://x/tool"));
+    }
+
+    #[test]
+    fn install_target_display_shows_bare_install_to() {
+        let recipe = mur_common::deps::registry::CuratedRecipe {
+            description: "t".into(),
+            url: "u".into(),
+            sha256: "0".repeat(64),
+            install_to: Some("aura/lightpanda".into()),
+            executable: true,
+            archive: None,
+        };
+        assert_eq!(install_target_display(&recipe), "aura/lightpanda");
+    }
+
+    #[test]
+    fn install_target_display_lists_archive_members() {
+        let recipe = mur_common::deps::registry::CuratedRecipe {
+            description: "t".into(),
+            url: "u".into(),
+            sha256: "0".repeat(64),
+            install_to: None,
+            executable: false,
+            archive: Some(mur_common::deps::registry::ArchiveSpec {
+                members: vec![
+                    mur_common::deps::registry::RecipeMember {
+                        path_in_archive: "obscura".into(),
+                        install_to: "aura/obscura".into(),
+                        executable: false,
+                    },
+                    mur_common::deps::registry::RecipeMember {
+                        path_in_archive: "obscura-worker".into(),
+                        install_to: "aura/obscura-worker".into(),
+                        executable: true,
+                    },
+                ],
+            }),
+        };
+        let out = install_target_display(&recipe);
+        assert!(out.contains("aura/obscura"));
+        assert!(out.contains("aura/obscura-worker"));
     }
 }
 

--- a/mur-core/src/cmd/deps/mod.rs
+++ b/mur-core/src/cmd/deps/mod.rs
@@ -3,6 +3,7 @@ pub mod installer;
 
 pub mod doctor;
 pub mod install;
+pub mod trust_gate;
 
 use anyhow::{Context, Result};
 use mur_common::deps::{DetectMethod, ProgramDep};

--- a/mur-core/src/cmd/deps/mod.rs
+++ b/mur-core/src/cmd/deps/mod.rs
@@ -7,6 +7,7 @@ pub mod trust_gate;
 
 use anyhow::{Context, Result};
 use mur_common::deps::{DetectMethod, ProgramDep};
+use mur_common::skill::publisher_trust::PublisherKeyring;
 use std::path::Path;
 
 /// A declared dependency plus which parts of the artifact declared it.
@@ -144,6 +145,101 @@ mod agg_tests {
         assert_eq!(out.len(), 2);
         let lp = out.iter().find(|a| a.dep.name == "lightpanda").unwrap();
         assert_eq!(lp.sources.len(), 2);
+    }
+}
+
+/// One-line guidance for a recipe from an untrusted publisher.
+pub fn untrusted_skip_line(name: &str, signer_fp: &str, hint: Option<&str>) -> String {
+    let tail = hint
+        .map(|h| format!("; or install manually: {h}"))
+        .unwrap_or_default();
+    format!(
+        "{name}: recipe from an untrusted publisher — run `mur agent skill signer-trust {signer_fp}` to trust it{tail}"
+    )
+}
+
+/// Local y/N (mirrors fleet/import.rs `confirm`).
+fn confirm(prompt: &str, yes: bool) -> Result<bool> {
+    if yes {
+        return Ok(true);
+    }
+    use std::io::Write;
+    print!("{prompt} [y/N] ");
+    std::io::stdout().flush().ok();
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .context("read stdin")?;
+    Ok(matches!(
+        answer.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+/// At import of a signed bundle: for each missing, non-curated dep with an
+/// author recipe for the current platform, gate on the publisher's trust and
+/// (if Trusted) prompt+install via the Phase 1 installer. Best-effort — never
+/// returns Err into the import path.
+pub async fn install_trusted_recipes_at_import(
+    mur_home: &Path,
+    deps: &[AggregatedDep],
+    signer_fp: &str,
+    publisher_label: &str,
+    yes: bool,
+) {
+    let keyring = match PublisherKeyring::load_or_seed(mur_home) {
+        Ok(k) => k,
+        Err(_) => return,
+    };
+    let trust = keyring.classify(signer_fp);
+    let platform = mur_common::deps::current_platform();
+    for a in deps {
+        let status = mur_common::deps::detect::detect(&a.dep, mur_home);
+        match crate::cmd::deps::trust_gate::decide(&a.dep, trust, status, &platform) {
+            crate::cmd::deps::trust_gate::GateDecision::Offer(recipe) => {
+                let prompt = format!(
+                    "Install {} from {} (signed by {publisher_label}, sha256 {}) ?",
+                    a.dep.name, recipe.url, recipe.sha256
+                );
+                match confirm(&prompt, yes) {
+                    Ok(true) => match crate::cmd::deps::installer::install(&recipe, mur_home).await
+                    {
+                        Ok(paths) => println!("  installed {} -> {:?}", a.dep.name, paths),
+                        Err(e) => println!("  FAILED {}: {e}", a.dep.name),
+                    },
+                    Ok(false) => println!("  skipped {}.", a.dep.name),
+                    Err(_) => {}
+                }
+            }
+            crate::cmd::deps::trust_gate::GateDecision::SkipUntrusted => {
+                println!(
+                    "  {}",
+                    untrusted_skip_line(&a.dep.name, signer_fp, a.dep.hint.as_deref())
+                );
+            }
+            crate::cmd::deps::trust_gate::GateDecision::SkipRevoked => {
+                println!(
+                    "  {}: publisher {signer_fp} is REVOKED — not installing.",
+                    a.dep.name
+                );
+            }
+            // Present / curated / no-recipe / no-platform → silent (Phase 1 doctor covers them).
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod import_hook_tests {
+    use super::*;
+
+    #[test]
+    fn untrusted_hint_names_publisher_and_signer_trust_cmd() {
+        let msg = untrusted_skip_line("some-tool", "abcd1234", Some("https://x/tool"));
+        assert!(msg.contains("some-tool"));
+        assert!(msg.contains("abcd1234"));
+        assert!(msg.contains("signer-trust"));
+        assert!(msg.contains("https://x/tool"));
     }
 }
 

--- a/mur-core/src/cmd/deps/mod.rs
+++ b/mur-core/src/cmd/deps/mod.rs
@@ -83,6 +83,7 @@ pub fn aggregate_agent(mur_home: &Path, agent: &str) -> Result<Vec<AggregatedDep
                     reason: format!("MCP server {}", mcp.name),
                     hint: None,
                     registry: None,
+                    recipe: None,
                 },
                 format!("mcp-cmd:{}", mcp.name),
             ));
@@ -127,6 +128,7 @@ mod agg_tests {
             reason: "r".into(),
             hint: None,
             registry: None,
+            recipe: None,
         }
     }
 

--- a/mur-core/src/cmd/deps/trust_gate.rs
+++ b/mur-core/src/cmd/deps/trust_gate.rs
@@ -1,0 +1,164 @@
+//! Pure decision for whether to offer a trusted-publisher recipe install at
+//! import. No I/O — the caller supplies trust classification + detect status.
+
+use mur_common::deps::registry::{CuratedRecipe, is_curated};
+use mur_common::deps::{DepStatus, ProgramDep};
+use mur_common::skill::publisher_trust::PublisherTrust;
+
+#[derive(Debug)]
+pub enum GateDecision {
+    /// Offer to install this (already platform-resolved) recipe.
+    Offer(CuratedRecipe),
+    /// Publisher not in the keyring — detect-and-guide only.
+    SkipUntrusted,
+    /// Publisher revoked — refuse.
+    SkipRevoked,
+    /// Name is a MUR-curated key — curated wins, handled by install-deps.
+    SkipCurated,
+    /// Already present — never reinstall.
+    SkipPresent,
+    /// No author recipe declared.
+    SkipNoRecipe,
+    /// Recipe declared but no entry for the current platform.
+    SkipNoPlatformRecipe,
+}
+
+/// Decide the gate for one dep. Precedence: present → curated → no-recipe →
+/// no-platform → trust (revoked/unknown/trusted).
+#[allow(dead_code)]
+pub fn decide(
+    dep: &ProgramDep,
+    trust: PublisherTrust,
+    status: DepStatus,
+    platform: &str,
+) -> GateDecision {
+    if status == DepStatus::Present {
+        return GateDecision::SkipPresent;
+    }
+    let key = dep.registry.as_deref().unwrap_or(&dep.name);
+    if is_curated(key) {
+        return GateDecision::SkipCurated;
+    }
+    let Some(recipe) = &dep.recipe else {
+        return GateDecision::SkipNoRecipe;
+    };
+    let Some(curated) = recipe.for_platform(platform) else {
+        return GateDecision::SkipNoPlatformRecipe;
+    };
+    match trust {
+        PublisherTrust::Revoked => GateDecision::SkipRevoked,
+        PublisherTrust::Unknown => GateDecision::SkipUntrusted,
+        PublisherTrust::Trusted => GateDecision::Offer(curated),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::deps::{DepStatus, DetectMethod, PlatformRecipe, ProgramDep, ProgramRecipe};
+    use mur_common::skill::publisher_trust::PublisherTrust;
+    use std::collections::BTreeMap;
+
+    fn dep_with_recipe(name: &str, plat: &str) -> ProgramDep {
+        let mut platforms = BTreeMap::new();
+        platforms.insert(
+            plat.to_string(),
+            PlatformRecipe {
+                url: "u".into(),
+                sha256: "s".into(),
+                install_to: Some("aura/x".into()),
+                executable: true,
+                archive: None,
+            },
+        );
+        ProgramDep {
+            name: name.into(),
+            detect: DetectMethod::Command {
+                command: name.into(),
+            },
+            reason: "r".into(),
+            hint: None,
+            registry: None,
+            recipe: Some(ProgramRecipe { platforms }),
+        }
+    }
+
+    #[test]
+    fn decision_table() {
+        let d = dep_with_recipe("some-tool", "aarch64-macos");
+        // Trusted + missing + has-platform-recipe + not-curated → Offer
+        assert!(matches!(
+            decide(
+                &d,
+                PublisherTrust::Trusted,
+                DepStatus::Missing,
+                "aarch64-macos"
+            ),
+            GateDecision::Offer(_)
+        ));
+        // Unknown publisher → SkipUntrusted
+        assert!(matches!(
+            decide(
+                &d,
+                PublisherTrust::Unknown,
+                DepStatus::Missing,
+                "aarch64-macos"
+            ),
+            GateDecision::SkipUntrusted
+        ));
+        // Revoked → SkipRevoked (even though Trusted-eligible otherwise)
+        assert!(matches!(
+            decide(
+                &d,
+                PublisherTrust::Revoked,
+                DepStatus::Missing,
+                "aarch64-macos"
+            ),
+            GateDecision::SkipRevoked
+        ));
+        // Present → SkipPresent (never reinstall)
+        assert!(matches!(
+            decide(
+                &d,
+                PublisherTrust::Trusted,
+                DepStatus::Present,
+                "aarch64-macos"
+            ),
+            GateDecision::SkipPresent
+        ));
+        // No recipe entry for this platform → SkipNoPlatformRecipe
+        assert!(matches!(
+            decide(
+                &d,
+                PublisherTrust::Trusted,
+                DepStatus::Missing,
+                "x86_64-windows"
+            ),
+            GateDecision::SkipNoPlatformRecipe
+        ));
+        // No recipe at all → SkipNoRecipe
+        let mut d_no = d.clone();
+        d_no.recipe = None;
+        assert!(matches!(
+            decide(
+                &d_no,
+                PublisherTrust::Trusted,
+                DepStatus::Missing,
+                "aarch64-macos"
+            ),
+            GateDecision::SkipNoRecipe
+        ));
+        // Curated name → SkipCurated (curated wins). "obscura" is a Phase-1 curated key.
+        let mut d_cur = dep_with_recipe("obscura", "aarch64-macos");
+        d_cur.registry = None; // name is the key
+        assert!(matches!(
+            decide(
+                &d_cur,
+                PublisherTrust::Trusted,
+                DepStatus::Missing,
+                "aarch64-macos"
+            ),
+            GateDecision::SkipCurated
+        ));
+    }
+}

--- a/mur-core/src/cmd/fleet/import.rs
+++ b/mur-core/src/cmd/fleet/import.rs
@@ -124,23 +124,30 @@ pub fn cmd_fleet_import(
     mur_home: &Path,
     file: &Path,
     opts: ImportOpts,
-) -> Result<(String, String)> {
+) -> Result<(String, String, bool)> {
     // 1. Read + unpack. I4 size/count caps enforced inside unpack_bundle.
     let bytes = std::fs::read(file).with_context(|| format!("read bundle {}", file.display()))?;
     let (manifest, files) = unpack_bundle(&bytes)?;
 
     // 2. Verify signature (fail-closed). Unsigned → refuse unless --force.
+    // C1 — `signature_verified` is true ONLY on the branch where a real signature
+    // was present AND cryptographically verified; the unsigned-`--force` path
+    // leaves it false so callers can gate trusted-recipe install on it (a spoofed
+    // `signer_pubkey` in an unsigned bundle must never be treated as attested).
     let (_, pk) = multibase::decode(&manifest.signer_pubkey).context("decode signer pubkey")?;
     let pk: [u8; 32] = pk
         .try_into()
         .map_err(|_| anyhow::anyhow!("signer pubkey is not 32 bytes"))?;
-    if manifest.sig.is_none() {
+    let signature_verified = if manifest.sig.is_none() {
         if !opts.force {
             bail!("bundle is UNSIGNED; re-run with --force to import as untrusted");
         }
+        false
     } else if !verify_manifest_sig(&manifest, &pk) {
         bail!("bundle signature verification FAILED — refusing import");
-    }
+    } else {
+        true
+    };
 
     // 3. Verify every entry's hash against the unpacked bytes (fail-closed).
     for e in &manifest.entries {
@@ -364,7 +371,11 @@ pub fn cmd_fleet_import(
         Ok(())
     })();
 
-    Ok((manifest.fleet_name.clone(), derived_fp.clone()))
+    Ok((
+        manifest.fleet_name.clone(),
+        derived_fp.clone(),
+        signature_verified,
+    ))
 }
 
 /// Install each bundled member profile. Skips members that already exist locally
@@ -520,6 +531,88 @@ mod tests {
         assert_eq!(
             mur_common::skill::local::get_trust_level(home, "triage").unwrap(),
             TrustLevel::Sandboxed
+        );
+    }
+
+    #[test]
+    fn import_signed_bundle_reports_signature_verified() {
+        // C1 (positive case): a normally signed bundle must report
+        // signature_verified == true so the caller's trusted-recipe install
+        // hook is allowed to run.
+        let src = tempfile::tempdir().unwrap();
+        let bundle = export_fixture(src.path());
+
+        let dst = tempfile::tempdir().unwrap();
+        let (_fleet_name, _fp, signature_verified) = cmd_fleet_import(
+            dst.path(),
+            &bundle,
+            ImportOpts {
+                force: false,
+                no_members: false,
+                yes: true,
+            },
+        )
+        .unwrap();
+        assert!(
+            signature_verified,
+            "a normally-signed bundle must report signature_verified == true"
+        );
+    }
+
+    #[test]
+    fn import_unsigned_force_reports_signature_not_verified() {
+        // C1: an unsigned bundle imported under --force must report
+        // signature_verified == false. The caller (dispatch.rs) gates the
+        // trusted-recipe install hook on this flag — a spoofed
+        // `signer_pubkey` in an unsigned bundle must never be treated as an
+        // attested publisher fingerprint.
+        use mur_common::fleet_bundle::{BundleEntry, BundleManifest, FLEET_BUNDLE_FORMAT};
+        use mur_common::identity::AgentIdentity;
+
+        let signer_pubkey = AgentIdentity::generate().public_key_multibase();
+        let fleet_yaml = "name: dev\ndisplay_name: ''\ngoal: g\nrouter: ~\nmembers: []\nchannel_id: fleet-dev\nrules: []\nskills: []\n";
+        let files: Vec<(String, Vec<u8>)> =
+            vec![("fleet.yaml".to_string(), fleet_yaml.as_bytes().to_vec())];
+        let entries: Vec<BundleEntry> = files
+            .iter()
+            .map(|(p, b)| BundleEntry {
+                path: p.clone(),
+                sha256: mur_common::fleet_bundle::content_hash(b),
+            })
+            .collect();
+        let manifest = BundleManifest {
+            format_version: FLEET_BUNDLE_FORMAT,
+            fleet_name: "dev".into(),
+            created_at: "2026-06-20T00:00:00Z".into(),
+            signer_fingerprint: mur_common::fleet_bundle::signer_fingerprint(&signer_pubkey),
+            signer_pubkey, // attacker-controlled; bundle below is left UNSIGNED
+            includes_members: false,
+            members: vec![],
+            entries,
+            sig: None,
+        };
+        let bundle_bytes = build_evil_bundle(&manifest, &files);
+        let bundle_path =
+            std::env::temp_dir().join(format!("murunsigned_{}_{}.fleet", std::process::id(), "c1"));
+        std::fs::write(&bundle_path, &bundle_bytes).unwrap();
+
+        let dst = tempfile::tempdir().unwrap();
+        let result = cmd_fleet_import(
+            dst.path(),
+            &bundle_path,
+            ImportOpts {
+                force: true,
+                no_members: false,
+                yes: true,
+            },
+        );
+        std::fs::remove_file(&bundle_path).ok();
+        let (fleet_name, _fp, signature_verified) =
+            result.expect("unsigned bundle under --force must still import");
+        assert_eq!(fleet_name, "dev");
+        assert!(
+            !signature_verified,
+            "unsigned --force import must report signature_verified == false"
         );
     }
 

--- a/mur-core/src/cmd/fleet/import.rs
+++ b/mur-core/src/cmd/fleet/import.rs
@@ -120,7 +120,11 @@ fn confirm(prompt: &str, yes: bool) -> Result<bool> {
     ))
 }
 
-pub fn cmd_fleet_import(mur_home: &Path, file: &Path, opts: ImportOpts) -> Result<()> {
+pub fn cmd_fleet_import(
+    mur_home: &Path,
+    file: &Path,
+    opts: ImportOpts,
+) -> Result<(String, String)> {
     // 1. Read + unpack. I4 size/count caps enforced inside unpack_bundle.
     let bytes = std::fs::read(file).with_context(|| format!("read bundle {}", file.display()))?;
     let (manifest, files) = unpack_bundle(&bytes)?;
@@ -360,7 +364,7 @@ pub fn cmd_fleet_import(mur_home: &Path, file: &Path, opts: ImportOpts) -> Resul
         Ok(())
     })();
 
-    Ok(())
+    Ok((manifest.fleet_name.clone(), derived_fp.clone()))
 }
 
 /// Install each bundled member profile. Skips members that already exist locally

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1740,11 +1740,28 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             path,
             model,
             as_name,
-        } => cmd::agent::cmd_install(
-            std::path::Path::new(&path),
-            model.as_deref(),
-            as_name.as_deref(),
-        )?,
+        } => {
+            let (installed_name, fingerprint_hex) = cmd::agent::cmd_install(
+                std::path::Path::new(&path),
+                model.as_deref(),
+                as_name.as_deref(),
+            )?;
+            // Symmetric with the fleet-import hook: best-effort, non-blocking
+            // trusted-recipe install gated on the agent's signer being trusted
+            // in the PublisherKeyring (not the bundle's own TOFU TrustStore).
+            if let Ok(mur_home) = cmd::agent::resolve_mur_home()
+                && let Ok(deps) = cmd::deps::aggregate_agent(&mur_home, &installed_name)
+            {
+                cmd::deps::install_trusted_recipes_at_import(
+                    &mur_home,
+                    &deps,
+                    &fingerprint_hex,
+                    &fingerprint_hex,
+                    false,
+                )
+                .await;
+            }
+        }
         AgentAction::Uninstall { name, purge } => cmd::agent::cmd_uninstall(&name, purge)?,
         AgentAction::Inspect { path } => cmd::agent::cmd_inspect(std::path::Path::new(&path))?,
         AgentAction::Stats { name } => cmd::agent::cmd_stats(&name)?,

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -355,21 +355,28 @@ pub async fn run(cli: Cli) -> Result<()> {
                     no_members,
                     yes,
                 } => {
-                    let (fleet_name, signer_fp) = cmd::fleet::import::cmd_fleet_import(
-                        &mur_home,
-                        &file,
-                        cmd::fleet::import::ImportOpts {
-                            force,
-                            no_members,
-                            yes,
-                        },
-                    )?;
-                    // Phase 2: trusted-publisher recipe install (best-effort, non-blocking).
-                    if let Ok(deps) = cmd::deps::aggregate_fleet(&mur_home, &fleet_name) {
-                        cmd::deps::install_trusted_recipes_at_import(
-                            &mur_home, &deps, &signer_fp, &signer_fp, yes,
-                        )
-                        .await;
+                    let (fleet_name, signer_fp, signature_verified) =
+                        cmd::fleet::import::cmd_fleet_import(
+                            &mur_home,
+                            &file,
+                            cmd::fleet::import::ImportOpts {
+                                force,
+                                no_members,
+                                yes,
+                            },
+                        )?;
+                    // C1: the trusted-recipe install hook must run ONLY when the
+                    // bundle's signature was actually present AND verified — an
+                    // unsigned `--force` import must never reach the trust gate,
+                    // since its `signer_pubkey`/derived fp is attacker-controlled.
+                    if signature_verified {
+                        // Phase 2: trusted-publisher recipe install (best-effort, non-blocking).
+                        if let Ok(deps) = cmd::deps::aggregate_fleet(&mur_home, &fleet_name) {
+                            cmd::deps::install_trusted_recipes_at_import(
+                                &mur_home, &deps, &signer_fp, &signer_fp, yes,
+                            )
+                            .await;
+                        }
                     }
                 }
                 FleetAction::Delete { name, yes } => {

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -354,15 +354,24 @@ pub async fn run(cli: Cli) -> Result<()> {
                     force,
                     no_members,
                     yes,
-                } => cmd::fleet::import::cmd_fleet_import(
-                    &mur_home,
-                    &file,
-                    cmd::fleet::import::ImportOpts {
-                        force,
-                        no_members,
-                        yes,
-                    },
-                )?,
+                } => {
+                    let (fleet_name, signer_fp) = cmd::fleet::import::cmd_fleet_import(
+                        &mur_home,
+                        &file,
+                        cmd::fleet::import::ImportOpts {
+                            force,
+                            no_members,
+                            yes,
+                        },
+                    )?;
+                    // Phase 2: trusted-publisher recipe install (best-effort, non-blocking).
+                    if let Ok(deps) = cmd::deps::aggregate_fleet(&mur_home, &fleet_name) {
+                        cmd::deps::install_trusted_recipes_at_import(
+                            &mur_home, &deps, &signer_fp, &signer_fp, yes,
+                        )
+                        .await;
+                    }
+                }
                 FleetAction::Delete { name, yes } => {
                     cmd::fleet::delete::cmd_fleet_delete(&mur_home, &name, yes)?
                 }


### PR DESCRIPTION
Phase 2 (builds on #684): a signed bundle from a **trusted publisher** can carry an author-declared per-platform install recipe on a `ProgramDep` and auto-install it **at import**, reusing the Phase 1 checksum-verified installer + the publisher-trust keyring.

Spec: `docs/superpowers/specs/2026-07-11-portable-program-dependencies-phase2-design.md` · Plan: `…/plans/2026-07-11-portable-program-dependencies-phase2.md`

## What (6 tasks, subagent-driven + reviewed)
- `ProgramRecipe`/`PlatformRecipe` on `ProgramDep` (per-platform, converts to the Phase 1 `CuratedRecipe`) — carried inside the signed bundle, integrity from the existing bundle signature.
- **Pure `trust_gate::decide`** — Present → Curated → NoRecipe → NoPlatformRecipe → (Revoked→skip / Unknown→skip / Trusted→Offer). Fully unit-tested decision table.
- Import orchestrator + hooks at **fleet import** and **agent `.muragent` install**: classify via `PublisherKeyring` → Trusted = per-item-consent install (reuse `installer::install`); Unknown = detect-and-guide (`signer-trust` hint); Revoked = refuse. Non-blocking.

## Security (final whole-branch review found + fixed, then re-reviewed clean)
The opus final review caught a cross-task **authorization bypass** a single-task review couldn't see, fixed in `eecef1d9`:
- **C1 (Critical):** unsigned `--force` fleet import fed an attacker-controlled fingerprint into `classify` → could spoof `Trusted`. **Fixed:** the fleet hook now runs ONLY when the signature was present + verified (`cmd_fleet_import` returns `signature_verified`; dispatch gates on it).
- **I2 (Important):** author-controlled `install_to` had no traversal guard → write outside `~/.mur` = RCE. **Fixed:** `safe_join` rejects absolute/`..`/root targets fail-closed on both bare + archive paths.
- **I1 (Important):** consent prompt now shows the install target.
Re-review: **C1 ✅ I1 ✅ I2 ✅ — READY TO MERGE.** Agent path's crypto provenance was already airtight.

## Follow-ups (non-blocking, tracked)
M1: fingerprint format differs across fleet/agent/keyring (a publisher trusted for a fleet won't match for their `.muragent` — feature works per-path, but a canonical fp format is worth unifying). M2: consent label is the fp not a name. M3: fully-qualified paths cosmetic. Symlink-through-Normal-component not guarded (outside the author-controlled-string threat model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)