### PR TITLE
feat: intelligent model switching — Phase 1 (config-layered selection + failure fallback + opt-in routing + CLI)

### DIFF
--- a/docs/superpowers/plans/2026-07-12-intelligent-model-switch-phase1.md
+++ b/docs/superpowers/plans/2026-07-12-intelligent-model-switch-phase1.md
@@ -999,9 +999,19 @@ git commit -m "feat(runtime): routing-aware FallbackLlmClient wired into build_p
 ```rust
 #[test]
 fn set_default_validates_ref_exists() {
-    // Uses a temp MUR_HOME with a seeded models.yaml (mirror existing model.rs
-    // tests' harness). Setting an unknown ref errors; a known ref persists.
-    let home = /* temp mur home with models.yaml containing `claude_sonnet` */;
+    use mur_common::model::{ModelEntry, ModelRegistry};
+    // Temp home with a seeded models.yaml containing `claude_sonnet`.
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path().to_path_buf();
+    let mut reg = ModelRegistry::default();
+    reg.models.insert("claude_sonnet".into(), ModelEntry {
+        provider: "anthropic".into(),
+        model: "claude-sonnet-5".into(),
+        ..Default::default()
+    });
+    reg.save_to(&home.join("models.yaml")).unwrap();
+
+    // Unknown ref → error (fail-closed); known ref → persisted to config.yaml.
     assert!(cmd_model_default(&home, "does_not_exist").is_err());
     cmd_model_default(&home, "claude_sonnet").unwrap();
     let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
@@ -1055,9 +1065,29 @@ pub fn cmd_model_fallback(home: &Path, refs: &[String]) -> anyhow::Result<()> {
 }
 ```
 
-**Note:** use whatever save function the codebase exposes — grep `fn save_config`. The Hub uses `mur_core::store::config::save_config`; if it saves to the default home only, add/reuse a `save_config_at(path, cfg)` (or set `MUR_HOME`). Wire both handlers into the `ModelCmd` dispatch (`match cmd { ModelCmd::Default{..} => .., ModelCmd::Fallback{..} => .. }`).
+**Note (config save):** `store/config.rs` currently exposes `save_config(config)` which writes to the default/`MUR_HOME` path via `config_path()`. Add a path-taking variant so the handlers are testable with an explicit temp home: refactor `save_config` to delegate —
 
-For per-agent, add a `--fallback <ref>...` option to the existing agent model-setting path in `model_resolve.rs` that writes `profile.fallback_chain` (validating each ref), mirroring how it sets `profile.model_ref` (~line 94). If there is no standalone agent model-set command, expose `pub fn cmd_agent_set_fallback(name: &str, refs: &[String]) -> Result<()>` that loads the profile, validates refs, sets `fallback_chain`, saves.
+```rust
+// mur-core/src/store/config.rs
+pub fn save_config(config: &Config) -> Result<()> {
+    save_config_at(&config_path(), config)
+}
+
+/// Save config to an explicit path (same YAML + header as save_config).
+pub fn save_config_at(path: &Path, config: &Config) -> Result<()> {
+    // (move the existing save_config body here, using `path` instead of config_path())
+    ...
+}
+```
+
+Wire both handlers into the `ModelCmd` dispatch in `mur-core/src/cmd/model.rs` (the existing `match cmd { ModelCmd::Add{..} => .., ... }`), resolving the home via the existing `crate::cmd::agent::resolve_mur_home()?`:
+
+```rust
+        ModelCmd::Default { model_ref } => cmd_model_default(&crate::cmd::agent::resolve_mur_home()?, &model_ref)?,
+        ModelCmd::Fallback { model_refs } => cmd_model_fallback(&crate::cmd::agent::resolve_mur_home()?, &model_refs)?,
+```
+
+For per-agent, expose `pub fn cmd_agent_set_fallback(home: &Path, name: &str, refs: &[String]) -> Result<()>` in `model_resolve.rs`: load the profile (mirroring how `model_resolve.rs:94` sets `profile.model_ref`), validate each ref against `home.join("models.yaml")` (fail-closed via the same `ensure_ref_exists` helper), set `profile.fallback_chain = refs.to_vec()`, save the profile. Wire a `--fallback <ref>...` CLI option to it. (If a dedicated agent subcommand enum is used, add the variant there and dispatch with `resolve_mur_home()`.)
 
 - [ ] **Step 4: Run to verify it passes**
 

--- a/docs/superpowers/plans/2026-07-12-intelligent-model-switch-phase1.md
+++ b/docs/superpowers/plans/2026-07-12-intelligent-model-switch-phase1.md
@@ -846,43 +846,141 @@ Find the block in `build_provider_runner` that, given a `ModelEntry` + resolved 
 
 **Note:** the exact secret-resolution + guarded-HTTP-client + provider-match currently lives inline in `build_provider_runner`. Extract it into a `fn build_client_from_entry(entry: &ModelEntry, mur_home: &Path) -> anyhow::Result<Arc<dyn LlmClient>>` (pure move of the existing lines 260-418 logic — no behaviour change), then both the single-client path and `build_one` call it. Do the extraction as the first, behaviour-preserving edit and run the existing runtime tests to confirm no regression before wiring fallback.
 
-- [ ] **Step 2: Compute candidates and choose single vs fallback client**
+- [ ] **Step 2: Add per-request candidate selection (with routing) to `FallbackLlmClient`**
 
-After extracting, add:
+Per the execution-time decision, difficulty routing is delivered fully in this task (still opt-in, `enabled: false` by default). Rather than pre-compute a fixed candidate list, give the adapter a per-request source so it can apply the routing heuristic to each request. In `mur-agent-runtime/src/llm/fallback.rs`, add a `CandidateSource` and a routed constructor — WITHOUT changing the existing `new(candidates, factory, retry)` (Task 6's tests rely on it):
+
+```rust
+use mur_common::agent::AgentProfile;
+use mur_common::config::ModelSwitchConfig;
+use mur_common::model::{choose_by_difficulty, resolve_model_refs};
+
+/// How the adapter decides the ordered candidate list for a request.
+enum CandidateSource {
+    /// Fixed list (unit tests / simple wiring).
+    Static(Vec<String>),
+    /// Recomputed per request: applies opt-in difficulty routing (which needs
+    /// the request's token estimate) then `resolve_model_refs` (priority
+    /// per-agent → global). Reuses the pure, tested mur-common fns.
+    PerRequest { profile: Box<AgentProfile>, cfg: Box<ModelSwitchConfig> },
+}
+```
+
+Change the `candidates: Vec<String>` field to `source: CandidateSource`, keep `new` building `Static`, and add:
+
+```rust
+impl FallbackLlmClient {
+    /// Routing-aware constructor: candidates are computed per request so the
+    /// difficulty heuristic can see the request size.
+    pub fn new_routed(profile: AgentProfile, cfg: ModelSwitchConfig, factory: ClientFactory, retry: RetryConfig) -> Self {
+        // primary_name for model_name(): the non-routed primary (model_ref/default).
+        let primary_name = resolve_model_refs(&profile, &cfg, None).first().cloned().unwrap_or_default();
+        Self {
+            source: CandidateSource::PerRequest { profile: Box::new(profile), cfg: Box::new(cfg) },
+            factory, retry, cooldown: CooldownMap::new(), primary_name,
+        }
+    }
+
+    /// The ordered candidate refs for this request.
+    fn candidates_for(&self, req: &LlmRequest) -> Vec<String> {
+        match &self.source {
+            CandidateSource::Static(v) => v.clone(),
+            CandidateSource::PerRequest { profile, cfg } => {
+                // Per-agent routing overrides global; disabled → None → normal
+                // model_ref/default primary.
+                let routing = profile.routing.clone().unwrap_or_else(|| cfg.routing.clone());
+                let routed = if routing.enabled {
+                    choose_by_difficulty(estimate_input_tokens(req), &routing)
+                } else {
+                    None
+                };
+                resolve_model_refs(profile, cfg, routed)
+            }
+        }
+    }
+}
+```
+
+In `generate`, replace the `for model_ref in &self.candidates` header with:
+
+```rust
+        let candidates = self.candidates_for(&req);
+        // ... then iterate `for model_ref in &candidates` (rest of the loop unchanged) ...
+```
+
+Add unit tests (append to `fallback.rs` tests):
+
+```rust
+    #[tokio::test]
+    async fn routed_generate_picks_frontier_for_large_request() {
+        use mur_common::agent::AgentProfile;
+        use mur_common::config::{ModelSwitchConfig, RoutingConfig};
+        let mut cfg = ModelSwitchConfig::default();
+        cfg.routing = RoutingConfig {
+            enabled: true,
+            cheap: Some("cheap".into()),
+            frontier: Some("frontier".into()),
+            threshold_input_tokens: Some(5),
+        };
+        let mut scripts = std::collections::HashMap::new();
+        scripts.insert("frontier".to_string(), vec![Ok(())]);
+        scripts.insert("cheap".to_string(), vec![Ok(())]);
+        let fb = FallbackLlmClient::new_routed(
+            AgentProfile::default_for_tests(), cfg, factory_for(scripts), retry0(),
+        );
+        // A big request (> threshold=5 tokens) routes to frontier.
+        let big = LlmRequest {
+            messages: vec![RichMessage::Text { role: "user".into(), content: "x".repeat(400) }],
+            temperature: None, max_tokens: None, tools: vec![],
+        };
+        assert_eq!(fb.generate(big).await.unwrap().text, "frontier");
+        // A tiny request routes to cheap.
+        let small = LlmRequest {
+            messages: vec![RichMessage::Text { role: "user".into(), content: "x".into() }],
+            temperature: None, max_tokens: None, tools: vec![],
+        };
+        assert_eq!(fb.generate(small).await.unwrap().text, "cheap");
+    }
+```
+
+**Interface note:** `RichMessage` + `LlmRequest` are already imported in the test module (Task 5/6). `AgentProfile::default_for_tests()` is the codebase's public test constructor (do NOT use `::default()` — there is no `Default` impl). `estimate_input_tokens` is `chars/4`, so `"x".repeat(400)` ≈ 100 tokens (> 5 → frontier) and `"x"` ≈ 0 (≤ 5 → cheap).
+
+- [ ] **Step 3: Wire `build_provider_runner` to use the routed client**
+
+Load the global config, then decide single-client vs routed fallback:
 
 ```rust
     let switch_cfg = mur_common::config::Config::load_or_default(&mur_home.join("config.yaml")).models;
-    // Difficulty routing (opt-in) picks the primary per-agent → global.
-    let routing = profile.inner.routing.clone().unwrap_or(switch_cfg.routing.clone());
-    // Note: routing needs the request; Phase 1 applies it per-call inside the
-    // FallbackLlmClient only when enabled. For candidate assembly here we pass
-    // None (model_ref/global default primary); see Step 3 for the routing path.
+    let routing = profile.inner.routing.clone().unwrap_or_else(|| switch_cfg.routing.clone());
     let refs = mur_common::model::resolve_model_refs(&profile.inner, &switch_cfg, None);
 
     let client: Arc<dyn LlmClient> = if refs.len() <= 1 && !routing.enabled {
-        // Preserve today's single-model behaviour exactly.
+        // Nothing configured (no chain, no routing) → today's exact single-model
+        // path, no wrapper. Preserves existing behaviour byte-for-byte.
         build_client_from_entry(&entry, &mur_home)?
     } else {
-        Arc::new(mur_agent_runtime_fallback_new(refs, Box::new(build_one), switch_cfg.retry.clone()))
+        // Chain and/or routing configured → routing-aware fallback client.
+        Arc::new(crate::llm::fallback::FallbackLlmClient::new_routed(
+            profile.inner.clone(),
+            switch_cfg.clone(),
+            Box::new(build_one),
+            switch_cfg.retry.clone(),
+        ))
     };
 ```
 
-Replace `mur_agent_runtime_fallback_new(...)` with the real path `crate::llm::fallback::FallbackLlmClient::new(...)`. Keep the existing `entry` (from `resolve_model_entry`) for the single-model path so nothing changes when nothing is configured.
+Keep the existing `entry` (from `resolve_model_entry`) for the single-model path so nothing changes when nothing is configured. Ensure `build_one` (Step 1) and the `FallbackLlmClient` construction satisfy the `ClientFactory` type (`Box<dyn Fn(&str) -> anyhow::Result<Arc<dyn LlmClient>> + Send + Sync>`) — `build_one` must be `Send + Sync` (it captures `mur_home`, a `PathBuf`, which is fine).
 
-- [ ] **Step 3: (Routing, opt-in) apply difficulty pick inside the client**
+- [ ] **Step 4: Verify no regression + routing + build**
 
-Because routing needs the request, the simplest correct Phase-1 wiring is: when `routing.enabled`, prepend the routed primary at generate time. Extend `FallbackLlmClient::new` call to also pass the `RoutingConfig` and the resolver, OR — simpler — keep routing OUT of the runtime path in Phase 1 and document it: since routing is `enabled: false` by default and the heuristic + `resolve_model_refs(routed_primary=Some)` are already unit-tested (Task 3), ship the wiring with routing applied at candidate-assembly using a fixed estimate is NOT possible (no req yet). **Decision:** In Phase 1, wire fallback fully; gate routing behind a follow-up (documented in the spec's non-goals note is inaccurate — instead add a one-line log `tracing::info!("model routing enabled but per-request routing lands in Phase 1b")` when `routing.enabled`). This keeps Task 7 shippable and honest; the pure routing fn is already tested and ready for the per-request hook.
-
-- [ ] **Step 4: Verify no regression + build**
-
-Run: `cargo build -p mur-agent-runtime` then `cargo test -p mur-agent-runtime`
-Expected: builds; existing runtime tests pass; with no `models:` config and no per-agent chain, `refs.len() <= 1` so the single-client path runs (unchanged behaviour).
+Run: `cargo build -p mur-agent-runtime` then `cargo test -p mur-agent-runtime fallback:: llm::`
+Expected: builds; Task 6's static tests + the new `routed_generate_picks_frontier_for_large_request` pass; existing runtime tests pass. With no `models:` config and no per-agent chain/routing, `refs.len() <= 1 && !routing.enabled` so the single-client path runs (unchanged behaviour).
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add mur-agent-runtime/src/supervisor_runner.rs
-git commit -m "feat(runtime): build FallbackLlmClient from resolved candidates (single-model path unchanged)"
+git add mur-agent-runtime/src/supervisor_runner.rs mur-agent-runtime/src/llm/fallback.rs
+git commit -m "feat(runtime): routing-aware FallbackLlmClient wired into build_provider_runner (single-model path unchanged)"
 ```
 
 ---
@@ -982,12 +1080,12 @@ git commit -m "feat(cli): mur model default/fallback + per-agent --fallback (ref
 - Per-agent settings + priority per-agent→global → Task 2, 3. ✓
 - Fallback chain + retry/backoff/cooldown → Task 5, 6. ✓
 - Error classification (429/5xx/timeout/402 retryable; 400/401/malformed fatal) → Task 4. ✓
-- Opt-in difficulty heuristic → Task 3 (pure fn). Runtime per-request wiring is explicitly deferred to Phase 1b in Task 7 Step 3 (routing is off by default; the fn is tested and ready) — **flagged as a scoping decision for the reviewer/user**, not silently dropped. ✓
+- Opt-in difficulty heuristic → Task 3 (pure fn) + Task 7 Step 2 (per-request application inside `FallbackLlmClient::new_routed`, off by default). Fully functional this phase. ✓
 - CLI (`mur model default/fallback`, per-agent `--fallback`, ref validation) → Task 8. ✓
 - Rollout additive/off-by-default → Task 7 (single-model path unchanged when nothing configured). ✓
 - Hub GUI → correctly EXCLUDED (Phase 2). ✓
 
-**Gap flagged honestly:** the difficulty-routing *runtime* application (per-request primary pick) is deferred to Phase 1b in Task 7 Step 3, because it needs the request object at call time and doing it right is a small follow-up on top of the already-tested pure fn. This is a deliberate narrowing of the opt-in, off-by-default feature — confirm with the user during execution whether to fold the per-request routing into Task 7 instead of deferring.
+**Routing decision (resolved during execution):** per the user's execution-time choice, per-request difficulty routing is folded into Task 7 Step 2 (`FallbackLlmClient::new_routed` applies `choose_by_difficulty(estimate_input_tokens(req), routing)` per call), not deferred. It stays opt-in and `enabled: false` by default.
 
 **Placeholder scan:** No TBD/TODO. The two "Interface note" items (Task 5 `LlmMessage` field name, Task 6 `LlmRequest: Clone`) are explicit verification instructions with the fallback action stated, not placeholders. Task 7 Step 1 names the exact lines to extract and mandates a behaviour-preserving move first.
 

--- a/docs/superpowers/plans/2026-07-12-intelligent-model-switch-phase1.md
+++ b/docs/superpowers/plans/2026-07-12-intelligent-model-switch-phase1.md
@@ -1,0 +1,945 @@
+# Intelligent Model Switching — Phase 1 (core + CLI) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give MUR agents config-layered model selection (global default + per-agent, priority per-agent → global) and automatic failure-fallback chains (retry with backoff/jitter + in-memory cooldown), plus an opt-in difficulty heuristic — managed from the CLI.
+
+**Architecture:** Pure config + resolver types in `mur-common` (no I/O, unit-tested). A `FallbackLlmClient` in `mur-agent-runtime` that itself implements the existing `LlmClient` trait and loops over ordered candidates — so it drops into the existing `Arc<dyn LlmClient>` slot in `build_provider_runner` with no agent-loop change. The runtime `LlmError` gains typed variants so a classifier can tell retryable (429/5xx/timeout/402) from fatal (400/401/malformed).
+
+**Tech Stack:** Rust (edition 2024), serde/serde_yaml, `#[async_trait]`, `thiserror`, `rand` (jitter), `clap`.
+
+## Global Constraints
+
+- **No hardcoded values.** Every tunable (retry count, backoff base, cooldown seconds, routing threshold) is a config field with a documented `pub const DEFAULT_*` (Mandatory Rule 1).
+- **Additive & off-by-default.** With an empty `models:` block and no per-agent `fallback_chain`, resolution returns a single candidate and behaviour is identical to today. Difficulty routing ships `enabled: false`.
+- **Priority per-agent → global**, everywhere: primary model, fallback chain, routing config.
+- **Retryable vs fatal is a hard boundary:** 429/5xx/timeout/402 → advance the chain; 400/401/403/malformed → return immediately (never fall back — that hides auth/bugs).
+- **Legacy-parse safe:** every new profile/config field is `#[serde(default)]`; a profile/config written before this change must still deserialize.
+- **Do NOT implement learned/RouteLLM routing** (cost-router Phase 3) or the Hub GUI (Phase 2 — separate plan).
+- Rust edition 2024; comments English; files ≤ 800 lines.
+- **Build/test env:** `mur-common` + `mur-agent-runtime` need no special env. `mur-core` (Task 8) needs `export ORT_STRATEGY=download; export MUR_WEB_DIST=$HOME/Projects/mur-web/dist`. If `cargo` isn't found, add `~/.rustup/toolchains/stable-*/bin` to PATH. Build/test per-crate (`-p <crate>`), never `--workspace`.
+
+## File Structure
+
+- `mur-common/src/config.rs` — new `ModelSwitchConfig` / `RetryConfig` / `RoutingConfig` + default consts; new `Config.models` field. (Task 1)
+- `mur-common/src/agent.rs` — `AgentProfile.fallback_chain` + `AgentProfile.routing`. (Task 2)
+- `mur-common/src/model.rs` — pure `resolve_model_refs` + `choose_by_difficulty`. (Task 3)
+- `mur-agent-runtime/src/llm/mod.rs` — `LlmError` new variants + `LlmError::from_status`; `Retryability` classifier. (Task 4)
+- `mur-agent-runtime/src/llm/{anthropic,ollama,openai}.rs` — use `from_status` for non-2xx. (Task 4)
+- `mur-agent-runtime/src/llm/fallback.rs` (new) — `CooldownMap`, `backoff_delay`, `estimate_input_tokens`, `FallbackLlmClient`. (Tasks 5–6)
+- `mur-agent-runtime/src/supervisor_runner.rs` — build `FallbackLlmClient` in `build_provider_runner`. (Task 7)
+- `mur-core/src/cmd/model.rs` + `mur-core/src/cmd/agent/model_resolve.rs` + `mur-core/src/cli/*` — CLI. (Task 8)
+
+---
+
+### Task 1: `ModelSwitchConfig` in global config
+
+**Files:**
+- Modify: `mur-common/src/config.rs`
+
+**Interfaces:**
+- Produces: `Config.models: ModelSwitchConfig`; structs `ModelSwitchConfig { default: Option<String>, fallback_chain: Vec<String>, retry: RetryConfig, routing: RoutingConfig }`, `RetryConfig { max_retries: u32, backoff_base_ms: u64, cooldown_secs: u64 }`, `RoutingConfig { enabled: bool, cheap: Option<String>, frontier: Option<String>, threshold_input_tokens: Option<u32> }`; consts `DEFAULT_MAX_RETRIES=1`, `DEFAULT_BACKOFF_BASE_MS=500`, `DEFAULT_COOLDOWN_SECS=60`, `DEFAULT_ROUTING_THRESHOLD=2000`.
+
+- [ ] **Step 1: Write the failing test** (append to `config.rs` test module)
+
+```rust
+#[test]
+fn model_switch_config_defaults_and_omitted_block() {
+    // Omitted `models:` block deserializes to defaults.
+    let cfg: Config = serde_yaml::from_str("{}").unwrap();
+    assert_eq!(cfg.models.default, None);
+    assert!(cfg.models.fallback_chain.is_empty());
+    assert_eq!(cfg.models.retry.max_retries, DEFAULT_MAX_RETRIES);
+    assert_eq!(cfg.models.retry.backoff_base_ms, DEFAULT_BACKOFF_BASE_MS);
+    assert_eq!(cfg.models.retry.cooldown_secs, DEFAULT_COOLDOWN_SECS);
+    assert!(!cfg.models.routing.enabled);
+
+    // A populated block round-trips.
+    let yaml = "models:\n  default: claude_sonnet\n  fallback_chain: [claude_sonnet, deepseek_v4_pro]\n  routing:\n    enabled: true\n    cheap: deepseek_v4_flash\n    frontier: claude_opus\n    threshold_input_tokens: 1500\n";
+    let cfg: Config = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(cfg.models.default.as_deref(), Some("claude_sonnet"));
+    assert_eq!(cfg.models.fallback_chain, vec!["claude_sonnet", "deepseek_v4_pro"]);
+    assert!(cfg.models.routing.enabled);
+    assert_eq!(cfg.models.routing.threshold_input_tokens, Some(1500));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mur-common model_switch_config_defaults`
+Expected: FAIL to compile (`Config.models` / types don't exist).
+
+- [ ] **Step 3: Implement**
+
+Add the field to `Config` (alongside the other `#[serde(default)]` sub-configs, e.g. after `pub llm: LlmConfig,`):
+
+```rust
+    #[serde(default)]
+    pub models: ModelSwitchConfig,
+```
+
+Add near the other default consts at the top of `config.rs`:
+
+```rust
+pub const DEFAULT_MAX_RETRIES: u32 = 1;
+pub const DEFAULT_BACKOFF_BASE_MS: u64 = 500;
+pub const DEFAULT_COOLDOWN_SECS: u64 = 60;
+pub const DEFAULT_ROUTING_THRESHOLD: u32 = 2000;
+
+fn default_max_retries() -> u32 { DEFAULT_MAX_RETRIES }
+fn default_backoff_base_ms() -> u64 { DEFAULT_BACKOFF_BASE_MS }
+fn default_cooldown_secs() -> u64 { DEFAULT_COOLDOWN_SECS }
+```
+
+Add the structs (mirror the existing `LlmConfig` sub-config style):
+
+```rust
+/// Config-layered model selection + failure fallback. See
+/// docs/superpowers/specs/2026-07-12-intelligent-model-switch-design.md.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ModelSwitchConfig {
+    /// Global default model_ref when an agent has no `model_ref`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+    /// Global fallback chain (ordered model_refs).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fallback_chain: Vec<String>,
+    #[serde(default)]
+    pub retry: RetryConfig,
+    #[serde(default)]
+    pub routing: RoutingConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetryConfig {
+    #[serde(default = "default_max_retries")]
+    pub max_retries: u32,
+    #[serde(default = "default_backoff_base_ms")]
+    pub backoff_base_ms: u64,
+    #[serde(default = "default_cooldown_secs")]
+    pub cooldown_secs: u64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: DEFAULT_MAX_RETRIES,
+            backoff_base_ms: DEFAULT_BACKOFF_BASE_MS,
+            cooldown_secs: DEFAULT_COOLDOWN_SECS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RoutingConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cheap: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frontier: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub threshold_input_tokens: Option<u32>,
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p mur-common model_switch_config_defaults` then `cargo test -p mur-common config::`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/config.rs
+git commit -m "feat(config): ModelSwitchConfig (default/fallback_chain/retry/routing)"
+```
+
+---
+
+### Task 2: Per-agent `fallback_chain` + `routing`
+
+**Files:**
+- Modify: `mur-common/src/agent.rs` (`AgentProfile`)
+
+**Interfaces:**
+- Consumes: `RoutingConfig` (Task 1).
+- Produces: `AgentProfile.fallback_chain: Vec<String>`, `AgentProfile.routing: Option<RoutingConfig>`.
+
+- [ ] **Step 1: Write the failing test** (in the `model_ref_tests` module in `agent.rs`, mirroring `legacy_profile_without_model_ref_still_parses`)
+
+```rust
+#[test]
+fn per_agent_fallback_and_routing_optional_and_legacy_safe() {
+    // Legacy profile (no fallback_chain / routing) still parses.
+    let legacy = r#"{"name":"a","model":{"provider":"anthropic","name":"claude"}}"#;
+    let p: AgentProfile = serde_json::from_str(legacy).unwrap();
+    assert!(p.fallback_chain.is_empty());
+    assert!(p.routing.is_none());
+
+    // Populated round-trips.
+    let full = r#"{"name":"a","model":{"provider":"anthropic","name":"claude"},"fallback_chain":["claude_opus","claude_sonnet"],"routing":{"enabled":true}}"#;
+    let p: AgentProfile = serde_json::from_str(full).unwrap();
+    assert_eq!(p.fallback_chain, vec!["claude_opus", "claude_sonnet"]);
+    assert!(p.routing.as_ref().unwrap().enabled);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mur-common per_agent_fallback_and_routing`
+Expected: FAIL to compile (fields don't exist).
+
+- [ ] **Step 3: Implement**
+
+In `AgentProfile` (near `model_ref`), add:
+
+```rust
+    /// Per-agent fallback chain (ordered model_refs). Overrides the global
+    /// `models.fallback_chain` when non-empty. See the model-switch spec.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fallback_chain: Vec<String>,
+    /// Per-agent difficulty-routing override. Inherits the global
+    /// `models.routing` when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing: Option<crate::config::RoutingConfig>,
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p mur-common per_agent_fallback_and_routing` then `cargo test -p mur-common model_ref_tests`
+Expected: PASS (the existing `legacy_profile_without_model_ref_still_parses` must still pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/agent.rs
+git commit -m "feat(agent): per-agent fallback_chain + routing override (legacy-safe)"
+```
+
+---
+
+### Task 3: Pure resolver + difficulty heuristic
+
+**Files:**
+- Modify: `mur-common/src/model.rs`
+
+**Interfaces:**
+- Consumes: `AgentProfile` (Task 2), `ModelSwitchConfig`/`RoutingConfig` (Task 1).
+- Produces:
+  - `pub fn resolve_model_refs(profile: &AgentProfile, cfg: &ModelSwitchConfig, routed_primary: Option<String>) -> Vec<String>` — ordered model_refs `[primary, ...fallback]`, priority per-agent → global, primary de-duped out of the chain.
+  - `pub fn choose_by_difficulty(est_input_tokens: u32, r: &RoutingConfig) -> Option<String>`.
+
+- [ ] **Step 1: Write the failing test** (append to `model.rs` test module)
+
+```rust
+#[cfg(test)]
+mod switch_tests {
+    use super::*;
+    use crate::agent::AgentProfile;
+    use crate::config::{ModelSwitchConfig, RoutingConfig};
+
+    fn profile(model_ref: Option<&str>, chain: &[&str]) -> AgentProfile {
+        let mut p = AgentProfile::default();
+        p.model_ref = model_ref.map(|s| s.to_string());
+        p.fallback_chain = chain.iter().map(|s| s.to_string()).collect();
+        p
+    }
+
+    #[test]
+    fn per_agent_primary_and_chain_win_over_global() {
+        let cfg = ModelSwitchConfig {
+            default: Some("global_default".into()),
+            fallback_chain: vec!["g1".into(), "g2".into()],
+            ..Default::default()
+        };
+        let p = profile(Some("agent_primary"), &["agent_primary", "agent_fb"]);
+        // per-agent model_ref is primary; per-agent chain used; primary de-duped.
+        assert_eq!(resolve_model_refs(&p, &cfg, None), vec!["agent_primary", "agent_fb"]);
+    }
+
+    #[test]
+    fn falls_back_to_global_default_and_chain() {
+        let cfg = ModelSwitchConfig {
+            default: Some("global_default".into()),
+            fallback_chain: vec!["g1".into(), "global_default".into()],
+            ..Default::default()
+        };
+        let p = profile(None, &[]); // no per-agent model_ref or chain
+        // primary = global default; global chain used; primary de-duped out.
+        assert_eq!(resolve_model_refs(&p, &cfg, None), vec!["global_default", "g1"]);
+    }
+
+    #[test]
+    fn routed_primary_overrides_model_ref() {
+        let cfg = ModelSwitchConfig { fallback_chain: vec!["g1".into()], ..Default::default() };
+        let p = profile(Some("agent_primary"), &[]);
+        assert_eq!(
+            resolve_model_refs(&p, &cfg, Some("frontier".into())),
+            vec!["frontier", "g1"]
+        );
+    }
+
+    #[test]
+    fn no_config_no_agent_yields_empty() {
+        // Nothing configured → empty vec (caller falls back to inline model).
+        let cfg = ModelSwitchConfig::default();
+        assert!(resolve_model_refs(&profile(None, &[]), &cfg, None).is_empty());
+    }
+
+    #[test]
+    fn difficulty_picks_frontier_over_threshold() {
+        let r = RoutingConfig {
+            enabled: true,
+            cheap: Some("cheap".into()),
+            frontier: Some("frontier".into()),
+            threshold_input_tokens: Some(1000),
+        };
+        assert_eq!(choose_by_difficulty(1500, &r), Some("frontier".into()));
+        assert_eq!(choose_by_difficulty(500, &r), Some("cheap".into()));
+        // Misconfigured (missing frontier) → None (fall through).
+        let bad = RoutingConfig { enabled: true, cheap: Some("c".into()), frontier: None, threshold_input_tokens: None };
+        assert_eq!(choose_by_difficulty(9999, &bad), None);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mur-common switch_tests`
+Expected: FAIL to compile (functions missing).
+
+- [ ] **Step 3: Implement** (add to `model.rs`)
+
+```rust
+use crate::agent::AgentProfile;
+use crate::config::{DEFAULT_ROUTING_THRESHOLD, ModelSwitchConfig, RoutingConfig};
+
+/// Build the ordered list of model_refs to try: `[primary, ...fallback]`.
+/// Priority per-agent → global. The primary is de-duplicated out of the chain
+/// (no point retrying the same ref back-to-back). Returns empty when nothing is
+/// configured, so the caller keeps today's single-inline-model behaviour.
+pub fn resolve_model_refs(
+    profile: &AgentProfile,
+    cfg: &ModelSwitchConfig,
+    routed_primary: Option<String>,
+) -> Vec<String> {
+    let primary = routed_primary
+        .or_else(|| profile.model_ref.clone())
+        .or_else(|| cfg.default.clone());
+    let chain = if !profile.fallback_chain.is_empty() {
+        profile.fallback_chain.clone()
+    } else {
+        cfg.fallback_chain.clone()
+    };
+    let mut out: Vec<String> = Vec::new();
+    if let Some(p) = primary {
+        out.push(p);
+    }
+    for r in chain {
+        if !out.contains(&r) {
+            out.push(r);
+        }
+    }
+    out
+}
+
+/// Opt-in difficulty heuristic: pick `frontier` when the estimated input token
+/// count exceeds the threshold, else `cheap`. `None` when misconfigured (caller
+/// falls through to model_ref/global default).
+pub fn choose_by_difficulty(est_input_tokens: u32, r: &RoutingConfig) -> Option<String> {
+    let threshold = r.threshold_input_tokens.unwrap_or(DEFAULT_ROUTING_THRESHOLD);
+    match (r.cheap.as_ref(), r.frontier.as_ref()) {
+        (Some(cheap), Some(frontier)) => Some(if est_input_tokens > threshold {
+            frontier.clone()
+        } else {
+            cheap.clone()
+        }),
+        _ => None,
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p mur-common switch_tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/model.rs
+git commit -m "feat(model): pure resolve_model_refs + choose_by_difficulty (per-agent→global)"
+```
+
+---
+
+### Task 4: `LlmError` taxonomy + retryability classifier
+
+**Files:**
+- Modify: `mur-agent-runtime/src/llm/mod.rs` (`LlmError` + classifier)
+- Modify: `mur-agent-runtime/src/llm/{anthropic,ollama,openai}.rs` (use `from_status`)
+
+**Interfaces:**
+- Produces: `LlmError::ServerError(u16)`, `LlmError::InsufficientCredit`; `LlmError::from_status(status: u16, body: String) -> LlmError`; `pub enum Retryability { Retryable, Fatal }`; `pub fn classify(e: &LlmError) -> Retryability`.
+
+- [ ] **Step 1: Write the failing test** (append to `llm/mod.rs` test module)
+
+```rust
+#[test]
+fn from_status_maps_http_codes() {
+    assert!(matches!(LlmError::from_status(429, "x".into()), LlmError::RateLimit));
+    assert!(matches!(LlmError::from_status(402, "x".into()), LlmError::InsufficientCredit));
+    assert!(matches!(LlmError::from_status(503, "x".into()), LlmError::ServerError(503)));
+    assert!(matches!(LlmError::from_status(400, "x".into()), LlmError::Http(_)));
+    assert!(matches!(LlmError::from_status(401, "x".into()), LlmError::Http(_)));
+}
+
+#[test]
+fn classify_retryable_vs_fatal() {
+    use Retryability::*;
+    assert!(matches!(classify(&LlmError::RateLimit), Retryable));
+    assert!(matches!(classify(&LlmError::Timeout), Retryable));
+    assert!(matches!(classify(&LlmError::ServerError(500)), Retryable));
+    assert!(matches!(classify(&LlmError::InsufficientCredit), Retryable));
+    assert!(matches!(classify(&LlmError::Http("400".into())), Fatal));
+    assert!(matches!(classify(&LlmError::InvalidResponse("x".into())), Fatal));
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mur-agent-runtime from_status_maps_http_codes classify_retryable`
+Expected: FAIL to compile (variants/fns missing).
+
+- [ ] **Step 3: Implement**
+
+Add the two variants to `LlmError` (with `thiserror` messages):
+
+```rust
+    #[error("server error: {0}")]
+    ServerError(u16),
+    #[error("insufficient credit")]
+    InsufficientCredit,
+```
+
+Add the mapper + classifier (in `llm/mod.rs`):
+
+```rust
+impl LlmError {
+    /// Map a non-success HTTP status into a typed error. Centralises what was
+    /// previously scattered `status == 429` checks + a lumped `Http(String)`.
+    pub fn from_status(status: u16, body: String) -> LlmError {
+        match status {
+            429 => LlmError::RateLimit,
+            402 => LlmError::InsufficientCredit,
+            500..=599 => LlmError::ServerError(status),
+            _ => LlmError::Http(format!("status {status}: {body}")),
+        }
+    }
+}
+
+/// Whether a failed call should advance the fallback chain (Retryable) or
+/// return immediately (Fatal — auth/bad-request/malformed, where switching
+/// models would only hide the real problem).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Retryability {
+    Retryable,
+    Fatal,
+}
+
+pub fn classify(e: &LlmError) -> Retryability {
+    match e {
+        LlmError::RateLimit
+        | LlmError::Timeout
+        | LlmError::ServerError(_)
+        | LlmError::InsufficientCredit => Retryability::Retryable,
+        LlmError::Http(_) | LlmError::InvalidResponse(_) => Retryability::Fatal,
+    }
+}
+```
+
+Retrofit each client's non-2xx path to use `from_status`. In `anthropic.rs` (~lines 548-561) the code reads `let status = resp.status(); if status == 429 { return Err(LlmError::RateLimit) } return Err(LlmError::Http(format!("status {status}: {body_text}")))`. Replace that block with:
+
+```rust
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            return Err(LlmError::from_status(status.as_u16(), body_text));
+        }
+```
+
+Apply the analogous change in `ollama.rs` (the two `if resp.status() == 429 { return Err(LlmError::RateLimit); }` sites, ~lines 90 and 142 — replace each with the `from_status` non-success guard) and `openai.rs` (its non-2xx path). Keep the existing timeout/connect mapping (`LlmError::Timeout` / `LlmError::Http(e.to_string())` on `reqwest::Error`) unchanged — those are transport errors, not HTTP statuses.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p mur-agent-runtime from_status_maps_http_codes classify_retryable` then `cargo build -p mur-agent-runtime` (catches any exhaustive `match LlmError` that now needs the two new arms — add them where flagged).
+Expected: PASS + builds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-agent-runtime/src/llm/
+git commit -m "feat(llm): typed LlmError (ServerError/InsufficientCredit) + retryability classifier"
+```
+
+---
+
+### Task 5: Cooldown map, backoff, token estimate
+
+**Files:**
+- Create: `mur-agent-runtime/src/llm/fallback.rs`
+- Modify: `mur-agent-runtime/src/llm/mod.rs` (add `pub mod fallback;`)
+
+**Interfaces:**
+- Consumes: `LlmRequest` (from `llm/mod.rs`).
+- Produces:
+  - `pub struct CooldownMap` with `fn new() -> Self`, `fn mark(&self, model_ref: &str, until: Instant)`, `fn is_cooling(&self, model_ref: &str, now: Instant) -> bool`.
+  - `pub fn backoff_delay(attempt: u32, base_ms: u64) -> Duration` — `base * 2^attempt + jitter[0, base)`.
+  - `pub fn estimate_input_tokens(req: &LlmRequest) -> u32` — coarse `chars/4` over message texts.
+
+- [ ] **Step 1: Write the failing test** (in `fallback.rs`)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn cooldown_marks_and_expires() {
+        let cm = CooldownMap::new();
+        let now = Instant::now();
+        assert!(!cm.is_cooling("m", now));
+        cm.mark("m", now + Duration::from_secs(60));
+        assert!(cm.is_cooling("m", now));                       // within window
+        assert!(!cm.is_cooling("m", now + Duration::from_secs(61))); // after window
+        assert!(!cm.is_cooling("other", now));
+    }
+
+    #[test]
+    fn backoff_grows_and_stays_in_bounds() {
+        let base = 500u64;
+        for attempt in 0..4u32 {
+            let d = backoff_delay(attempt, base).as_millis() as u64;
+            let floor = base * 2u64.pow(attempt);
+            assert!(d >= floor && d < floor + base, "attempt {attempt}: {d} not in [{floor}, {})", floor + base);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mur-agent-runtime fallback::tests`
+Expected: FAIL to compile (module/types missing).
+
+- [ ] **Step 3: Implement** (`fallback.rs` header + these items)
+
+```rust
+//! Failure-fallback for LLM calls: cooldown circuit-breaker, backoff, and the
+//! FallbackLlmClient adapter. See the model-switch spec.
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use super::LlmRequest;
+
+/// In-memory per-model cooldown (circuit-breaker). Process-local; a restart
+/// clears it (cooldowns are seconds-scale, so persistence is unnecessary).
+#[derive(Default)]
+pub struct CooldownMap {
+    inner: Mutex<HashMap<String, Instant>>,
+}
+
+impl CooldownMap {
+    pub fn new() -> Self {
+        Self { inner: Mutex::new(HashMap::new()) }
+    }
+    pub fn mark(&self, model_ref: &str, until: Instant) {
+        self.inner.lock().unwrap().insert(model_ref.to_string(), until);
+    }
+    pub fn is_cooling(&self, model_ref: &str, now: Instant) -> bool {
+        match self.inner.lock().unwrap().get(model_ref) {
+            Some(until) => now < *until,
+            None => false,
+        }
+    }
+}
+
+/// Exponential backoff with jitter: `base * 2^attempt + rand[0, base)`.
+pub fn backoff_delay(attempt: u32, base_ms: u64) -> Duration {
+    let floor = base_ms.saturating_mul(2u64.saturating_pow(attempt));
+    let jitter = if base_ms > 0 { rand::random::<u64>() % base_ms } else { 0 };
+    Duration::from_millis(floor.saturating_add(jitter))
+}
+
+/// Coarse input-token estimate (chars/4) over the request's message texts —
+/// enough for a routing heuristic, not billing.
+pub fn estimate_input_tokens(req: &LlmRequest) -> u32 {
+    let chars: usize = req.messages.iter().map(|m| m.content.len()).sum();
+    (chars / 4).min(u32::MAX as usize) as u32
+}
+```
+
+**Interface note:** confirm the `LlmMessage` field name for text — the spec's runtime `LlmMessage` (llm/mod.rs ~line 44). If the text field is not `content`, use the actual field in `estimate_input_tokens` (grep `struct LlmMessage`). Confirm `rand` is already a dependency of `mur-agent-runtime` (it is used elsewhere in the runtime); if not, add `rand` to its `Cargo.toml`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p mur-agent-runtime fallback::tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-agent-runtime/src/llm/fallback.rs mur-agent-runtime/src/llm/mod.rs
+git commit -m "feat(llm): cooldown map + backoff + token estimate for fallback"
+```
+
+---
+
+### Task 6: `FallbackLlmClient` adapter
+
+**Files:**
+- Modify: `mur-agent-runtime/src/llm/fallback.rs`
+
+**Interfaces:**
+- Consumes: `LlmClient`, `LlmRequest`, `LlmResponse`, `LlmError`, `classify`, `Retryability` (Task 4); `CooldownMap`, `backoff_delay` (Task 5); `RetryConfig` (`mur_common::config`).
+- Produces: `FallbackLlmClient` implementing `LlmClient`; constructor `FallbackLlmClient::new(candidates: Vec<String>, factory: ClientFactory, retry: RetryConfig)` where `type ClientFactory = Box<dyn Fn(&str) -> anyhow::Result<Arc<dyn LlmClient>> + Send + Sync>`.
+
+- [ ] **Step 1: Write the failing test** (append to `fallback.rs` tests)
+
+```rust
+    use super::super::{LlmClient, LlmError, LlmRequest, LlmResponse};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // Mock client whose Nth generate() outcome is scripted.
+    struct ScriptClient { name: String, outcomes: Vec<Result<(), LlmError>>, idx: AtomicUsize }
+    #[async_trait]
+    impl LlmClient for ScriptClient {
+        async fn generate(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+            let i = self.idx.fetch_add(1, Ordering::SeqCst).min(self.outcomes.len()-1);
+            match &self.outcomes[i] {
+                Ok(()) => Ok(LlmResponse { text: self.name.clone(), ..Default::default() }),
+                Err(e) => Err(e.clone()),
+            }
+        }
+        fn model_name(&self) -> &str { &self.name }
+    }
+
+    fn factory_for(scripts: std::collections::HashMap<String, Vec<Result<(),LlmError>>>) -> ClientFactory {
+        Box::new(move |r: &str| {
+            let o = scripts.get(r).cloned().unwrap_or_else(|| vec![Ok(())]);
+            Ok(Arc::new(ScriptClient { name: r.to_string(), outcomes: o, idx: AtomicUsize::new(0) }) as Arc<dyn LlmClient>)
+        })
+    }
+    fn retry0() -> mur_common::config::RetryConfig {
+        mur_common::config::RetryConfig { max_retries: 0, backoff_base_ms: 1, cooldown_secs: 60 }
+    }
+
+    #[tokio::test]
+    async fn advances_chain_on_retryable_then_succeeds() {
+        let mut s = std::collections::HashMap::new();
+        s.insert("a".into(), vec![Err(LlmError::ServerError(500))]); // a fails (retryable)
+        s.insert("b".into(), vec![Ok(())]);                          // b succeeds
+        let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry0());
+        let resp = fb.generate(LlmRequest::default()).await.unwrap();
+        assert_eq!(resp.text, "b"); // fell through to b
+    }
+
+    #[tokio::test]
+    async fn fatal_error_does_not_advance() {
+        let mut s = std::collections::HashMap::new();
+        s.insert("a".into(), vec![Err(LlmError::Http("401".into()))]); // fatal
+        s.insert("b".into(), vec![Ok(())]);
+        let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry0());
+        let err = fb.generate(LlmRequest::default()).await.unwrap_err();
+        assert!(matches!(err, LlmError::Http(_))); // returned a's fatal error, never tried b
+    }
+
+    #[tokio::test]
+    async fn exhaustion_returns_last_error() {
+        let mut s = std::collections::HashMap::new();
+        s.insert("a".into(), vec![Err(LlmError::RateLimit)]);
+        s.insert("b".into(), vec![Err(LlmError::ServerError(503))]);
+        let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry0());
+        let err = fb.generate(LlmRequest::default()).await.unwrap_err();
+        assert!(matches!(err, LlmError::ServerError(503))); // last candidate's error
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p mur-agent-runtime fallback::tests::advances_chain`
+Expected: FAIL to compile (`FallbackLlmClient` / `ClientFactory` missing).
+
+- [ ] **Step 3: Implement** (add to `fallback.rs`)
+
+```rust
+use std::sync::Arc;
+use async_trait::async_trait;
+use super::{LlmClient, LlmError, LlmRequest, LlmResponse, Retryability, classify};
+use mur_common::config::RetryConfig;
+
+pub type ClientFactory = Box<dyn Fn(&str) -> anyhow::Result<Arc<dyn LlmClient>> + Send + Sync>;
+
+/// An `LlmClient` that tries an ordered list of model_refs, advancing on
+/// retryable failures (per-candidate backoff retries first), skipping models in
+/// cooldown, and returning a fatal error immediately. Drops into the existing
+/// `Arc<dyn LlmClient>` slot with no agent-loop change.
+pub struct FallbackLlmClient {
+    candidates: Vec<String>,
+    factory: ClientFactory,
+    retry: RetryConfig,
+    cooldown: CooldownMap,
+    primary_name: String,
+}
+
+impl FallbackLlmClient {
+    pub fn new(candidates: Vec<String>, factory: ClientFactory, retry: RetryConfig) -> Self {
+        let primary_name = candidates.first().cloned().unwrap_or_default();
+        Self { candidates, factory, retry, cooldown: CooldownMap::new(), primary_name }
+    }
+}
+
+#[async_trait]
+impl LlmClient for FallbackLlmClient {
+    async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        let now = Instant::now();
+        let mut last: Option<LlmError> = None;
+        for model_ref in &self.candidates {
+            if self.cooldown.is_cooling(model_ref, now) {
+                continue;
+            }
+            let client = match (self.factory)(model_ref) {
+                Ok(c) => c,
+                Err(e) => { last = Some(LlmError::Http(format!("build {model_ref}: {e}"))); continue; }
+            };
+            for attempt in 0..=self.retry.max_retries {
+                match client.generate(req.clone()).await {
+                    Ok(resp) => return Ok(resp),
+                    Err(e) => match classify(&e) {
+                        Retryability::Fatal => return Err(e),
+                        Retryability::Retryable => {
+                            tracing::info!(model_ref, attempt, error = %e, "llm fallback: retryable failure");
+                            if attempt < self.retry.max_retries {
+                                tokio::time::sleep(backoff_delay(attempt, self.retry.backoff_base_ms)).await;
+                            } else {
+                                let until = Instant::now() + Duration::from_secs(self.retry.cooldown_secs);
+                                self.cooldown.mark(model_ref, until);
+                                tracing::info!(model_ref, "llm fallback: cooling down, advancing chain");
+                                last = Some(e);
+                            }
+                        }
+                    },
+                }
+            }
+        }
+        Err(last.unwrap_or_else(|| LlmError::InvalidResponse("no model candidates".into())))
+    }
+
+    fn model_name(&self) -> &str {
+        &self.primary_name
+    }
+}
+```
+
+**Interface note:** `req.clone()` requires `LlmRequest: Clone` — confirm it derives `Clone` (grep `struct LlmRequest`); it should, but if not, add `#[derive(Clone)]`. `LlmResponse::default()` is used by the test mock — confirm `LlmResponse: Default` (the existing `llm_response_defaults` test implies it does).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p mur-agent-runtime fallback::tests`
+Expected: PASS (all three async tests + Task 5's).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-agent-runtime/src/llm/fallback.rs
+git commit -m "feat(llm): FallbackLlmClient adapter (retry/cooldown/advance, is an LlmClient)"
+```
+
+---
+
+### Task 7: Wire the fallback client into the runtime
+
+**Files:**
+- Modify: `mur-agent-runtime/src/supervisor_runner.rs` (`build_provider_runner`, ~lines 215-420)
+
+**Interfaces:**
+- Consumes: `resolve_model_refs` (Task 3), `FallbackLlmClient` (Task 6), `Config`/`ModelSwitchConfig` (Task 1), the existing per-provider client-building code in `build_provider_runner`.
+
+**Context:** `build_provider_runner` currently resolves ONE `ModelEntry` via `resolve_model_entry(&profile.inner)` (~line 222), builds ONE `Arc<dyn LlmClient>`, and passes it to `build(client)`. This task: (1) load the global `ModelSwitchConfig`; (2) compute the ordered refs via `resolve_model_refs`; (3) if the list has ≤1 entry AND no routing, keep today's single-client path unchanged; (4) otherwise, construct a `FallbackLlmClient` whose factory reuses the existing per-provider build logic, and pass THAT as the `Arc<dyn LlmClient>`.
+
+- [ ] **Step 1: Extract the per-provider client build into a reusable closure**
+
+Find the block in `build_provider_runner` that, given a `ModelEntry` + resolved secret, produces `Arc<dyn LlmClient>` (the `match provider { ... }` around lines 350-418 that ends in `Arc::new(c) as Arc<dyn LlmClient>`). Extract it into a local helper within the function:
+
+```rust
+    // Reusable per-ref client builder: model_ref -> Arc<dyn LlmClient>.
+    // Reuses resolve_model_entry (registry lookup) + the existing provider match.
+    let mur_home_cl = mur_home.clone();
+    let build_one = move |model_ref: &str| -> anyhow::Result<Arc<dyn LlmClient>> {
+        let entry = {
+            // Look the ref up in the registry directly (resolve_model_entry keys
+            // off profile.model_ref; here we resolve an explicit ref).
+            let reg = mur_common::model::ModelRegistry::load_from(
+                &mur_common::model::ModelRegistry::default_path()?,
+            )?;
+            reg.models.get(model_ref)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("model_ref {model_ref:?} not in registry"))?
+        };
+        build_client_from_entry(&entry, &mur_home_cl)   // see note
+    };
+```
+
+**Note:** the exact secret-resolution + guarded-HTTP-client + provider-match currently lives inline in `build_provider_runner`. Extract it into a `fn build_client_from_entry(entry: &ModelEntry, mur_home: &Path) -> anyhow::Result<Arc<dyn LlmClient>>` (pure move of the existing lines 260-418 logic — no behaviour change), then both the single-client path and `build_one` call it. Do the extraction as the first, behaviour-preserving edit and run the existing runtime tests to confirm no regression before wiring fallback.
+
+- [ ] **Step 2: Compute candidates and choose single vs fallback client**
+
+After extracting, add:
+
+```rust
+    let switch_cfg = mur_common::config::Config::load_or_default(&mur_home.join("config.yaml")).models;
+    // Difficulty routing (opt-in) picks the primary per-agent → global.
+    let routing = profile.inner.routing.clone().unwrap_or(switch_cfg.routing.clone());
+    // Note: routing needs the request; Phase 1 applies it per-call inside the
+    // FallbackLlmClient only when enabled. For candidate assembly here we pass
+    // None (model_ref/global default primary); see Step 3 for the routing path.
+    let refs = mur_common::model::resolve_model_refs(&profile.inner, &switch_cfg, None);
+
+    let client: Arc<dyn LlmClient> = if refs.len() <= 1 && !routing.enabled {
+        // Preserve today's single-model behaviour exactly.
+        build_client_from_entry(&entry, &mur_home)?
+    } else {
+        Arc::new(mur_agent_runtime_fallback_new(refs, Box::new(build_one), switch_cfg.retry.clone()))
+    };
+```
+
+Replace `mur_agent_runtime_fallback_new(...)` with the real path `crate::llm::fallback::FallbackLlmClient::new(...)`. Keep the existing `entry` (from `resolve_model_entry`) for the single-model path so nothing changes when nothing is configured.
+
+- [ ] **Step 3: (Routing, opt-in) apply difficulty pick inside the client**
+
+Because routing needs the request, the simplest correct Phase-1 wiring is: when `routing.enabled`, prepend the routed primary at generate time. Extend `FallbackLlmClient::new` call to also pass the `RoutingConfig` and the resolver, OR — simpler — keep routing OUT of the runtime path in Phase 1 and document it: since routing is `enabled: false` by default and the heuristic + `resolve_model_refs(routed_primary=Some)` are already unit-tested (Task 3), ship the wiring with routing applied at candidate-assembly using a fixed estimate is NOT possible (no req yet). **Decision:** In Phase 1, wire fallback fully; gate routing behind a follow-up (documented in the spec's non-goals note is inaccurate — instead add a one-line log `tracing::info!("model routing enabled but per-request routing lands in Phase 1b")` when `routing.enabled`). This keeps Task 7 shippable and honest; the pure routing fn is already tested and ready for the per-request hook.
+
+- [ ] **Step 4: Verify no regression + build**
+
+Run: `cargo build -p mur-agent-runtime` then `cargo test -p mur-agent-runtime`
+Expected: builds; existing runtime tests pass; with no `models:` config and no per-agent chain, `refs.len() <= 1` so the single-client path runs (unchanged behaviour).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-agent-runtime/src/supervisor_runner.rs
+git commit -m "feat(runtime): build FallbackLlmClient from resolved candidates (single-model path unchanged)"
+```
+
+---
+
+### Task 8: CLI — `mur model default/fallback` + per-agent `--fallback`
+
+**Files:**
+- Modify: `mur-core/src/cli/model.rs` (or wherever `ModelCmd` is defined — grep) + `mur-core/src/cmd/model.rs`
+- Modify: `mur-core/src/cmd/agent/model_resolve.rs` (per-agent fallback setter)
+
+**Interfaces:**
+- Consumes: `ModelSwitchConfig` (Task 1), `store::config::{load_config,save_config}`, `ModelRegistry`.
+
+- [ ] **Step 1: Write the failing test** (in `mur-core/src/cmd/model.rs` tests)
+
+```rust
+#[test]
+fn set_default_validates_ref_exists() {
+    // Uses a temp MUR_HOME with a seeded models.yaml (mirror existing model.rs
+    // tests' harness). Setting an unknown ref errors; a known ref persists.
+    let home = /* temp mur home with models.yaml containing `claude_sonnet` */;
+    assert!(cmd_model_default(&home, "does_not_exist").is_err());
+    cmd_model_default(&home, "claude_sonnet").unwrap();
+    let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+    assert_eq!(cfg.models.default.as_deref(), Some("claude_sonnet"));
+}
+```
+
+(Model the temp-home + seeded-`models.yaml` harness on the existing tests in `mur-core/src/cmd/model.rs` — grep the test module for how it builds a registry; reuse that exact pattern.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist cargo test -p mur-core set_default_validates_ref`
+Expected: FAIL to compile (`cmd_model_default` missing).
+
+- [ ] **Step 3: Implement**
+
+Add clap variants to `ModelCmd` (grep `enum ModelCmd`):
+
+```rust
+    /// Set the global default model_ref (config.yaml models.default)
+    Default { model_ref: String },
+    /// Set the global fallback chain (ordered model_refs; empty clears)
+    Fallback { model_refs: Vec<String> },
+```
+
+Add handlers in `cmd/model.rs` (fail-closed ref validation against `models.yaml`):
+
+```rust
+fn ensure_ref_exists(home: &Path, r: &str) -> anyhow::Result<()> {
+    let reg = mur_common::model::ModelRegistry::load_from(&home.join("models.yaml"))?;
+    anyhow::ensure!(reg.models.contains_key(r), "model_ref {r:?} not in models.yaml");
+    Ok(())
+}
+
+pub fn cmd_model_default(home: &Path, model_ref: &str) -> anyhow::Result<()> {
+    ensure_ref_exists(home, model_ref)?;
+    let mut cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+    cfg.models.default = Some(model_ref.to_string());
+    mur_core::store::config::save_config_at(&home.join("config.yaml"), &cfg)?; // see note
+    println!("global default model = {model_ref}");
+    Ok(())
+}
+
+pub fn cmd_model_fallback(home: &Path, refs: &[String]) -> anyhow::Result<()> {
+    for r in refs { ensure_ref_exists(home, r)?; }
+    let mut cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+    cfg.models.fallback_chain = refs.to_vec();
+    mur_core::store::config::save_config_at(&home.join("config.yaml"), &cfg)?;
+    println!("global fallback chain = {}", refs.join(", "));
+    Ok(())
+}
+```
+
+**Note:** use whatever save function the codebase exposes — grep `fn save_config`. The Hub uses `mur_core::store::config::save_config`; if it saves to the default home only, add/reuse a `save_config_at(path, cfg)` (or set `MUR_HOME`). Wire both handlers into the `ModelCmd` dispatch (`match cmd { ModelCmd::Default{..} => .., ModelCmd::Fallback{..} => .. }`).
+
+For per-agent, add a `--fallback <ref>...` option to the existing agent model-setting path in `model_resolve.rs` that writes `profile.fallback_chain` (validating each ref), mirroring how it sets `profile.model_ref` (~line 94). If there is no standalone agent model-set command, expose `pub fn cmd_agent_set_fallback(name: &str, refs: &[String]) -> Result<()>` that loads the profile, validates refs, sets `fallback_chain`, saves.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist cargo test -p mur-core set_default_validates_ref`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cli/ mur-core/src/cmd/model.rs mur-core/src/cmd/agent/model_resolve.rs
+git commit -m "feat(cli): mur model default/fallback + per-agent --fallback (ref-validated)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Config-layered resolution + `models:` block → Task 1, 3. ✓
+- Per-agent settings + priority per-agent→global → Task 2, 3. ✓
+- Fallback chain + retry/backoff/cooldown → Task 5, 6. ✓
+- Error classification (429/5xx/timeout/402 retryable; 400/401/malformed fatal) → Task 4. ✓
+- Opt-in difficulty heuristic → Task 3 (pure fn). Runtime per-request wiring is explicitly deferred to Phase 1b in Task 7 Step 3 (routing is off by default; the fn is tested and ready) — **flagged as a scoping decision for the reviewer/user**, not silently dropped. ✓
+- CLI (`mur model default/fallback`, per-agent `--fallback`, ref validation) → Task 8. ✓
+- Rollout additive/off-by-default → Task 7 (single-model path unchanged when nothing configured). ✓
+- Hub GUI → correctly EXCLUDED (Phase 2). ✓
+
+**Gap flagged honestly:** the difficulty-routing *runtime* application (per-request primary pick) is deferred to Phase 1b in Task 7 Step 3, because it needs the request object at call time and doing it right is a small follow-up on top of the already-tested pure fn. This is a deliberate narrowing of the opt-in, off-by-default feature — confirm with the user during execution whether to fold the per-request routing into Task 7 instead of deferring.
+
+**Placeholder scan:** No TBD/TODO. The two "Interface note" items (Task 5 `LlmMessage` field name, Task 6 `LlmRequest: Clone`) are explicit verification instructions with the fallback action stated, not placeholders. Task 7 Step 1 names the exact lines to extract and mandates a behaviour-preserving move first.
+
+**Type consistency:** `resolve_model_refs(profile, cfg, routed_primary)` signature identical in Task 3 (def) and Task 7 (use). `FallbackLlmClient::new(candidates, factory, retry)` + `ClientFactory` identical in Task 6 (def) and Task 7 (use). `LlmError::from_status`/`classify`/`Retryability` identical in Task 4 (def) and Task 6 (use). `RetryConfig`/`RoutingConfig`/`ModelSwitchConfig` fields identical across Tasks 1, 3, 6, 7, 8.

--- a/docs/superpowers/plans/2026-07-12-intelligent-model-switch-phase1.md
+++ b/docs/superpowers/plans/2026-07-12-intelligent-model-switch-phase1.md
@@ -575,14 +575,50 @@ pub fn backoff_delay(attempt: u32, base_ms: u64) -> Duration {
 }
 
 /// Coarse input-token estimate (chars/4) over the request's message texts —
-/// enough for a routing heuristic, not billing.
+/// enough for a routing heuristic, not billing. `LlmRequest.messages` is a
+/// `Vec<RichMessage>` (an enum), so match the text-bearing variants.
 pub fn estimate_input_tokens(req: &LlmRequest) -> u32 {
-    let chars: usize = req.messages.iter().map(|m| m.content.len()).sum();
+    let chars: usize = req
+        .messages
+        .iter()
+        .map(|m| match m {
+            RichMessage::Text { content, .. } => content.len(),
+            RichMessage::ImageText { text, .. } => text.len(),
+            RichMessage::ToolUse { text, .. } => text.as_deref().map_or(0, str::len),
+            RichMessage::ToolResults { .. } => 0,
+        })
+        .sum();
     (chars / 4).min(u32::MAX as usize) as u32
 }
 ```
 
-**Interface note:** confirm the `LlmMessage` field name for text — the spec's runtime `LlmMessage` (llm/mod.rs ~line 44). If the text field is not `content`, use the actual field in `estimate_input_tokens` (grep `struct LlmMessage`). Confirm `rand` is already a dependency of `mur-agent-runtime` (it is used elsewhere in the runtime); if not, add `rand` to its `Cargo.toml`.
+Add its import at the top of `fallback.rs`: `use super::RichMessage;` (alongside the `use super::LlmRequest;`).
+
+Add a test for it (in `fallback.rs` tests):
+
+```rust
+    #[test]
+    fn estimate_tokens_sums_text_over_rich_messages() {
+        use super::super::{LlmRequest, RichMessage};
+        let req = LlmRequest {
+            messages: vec![
+                RichMessage::Text { role: "user".into(), content: "a".repeat(40) },
+                RichMessage::ImageText {
+                    role: "user".into(),
+                    media_type: "image/png".into(),
+                    data: String::new(),
+                    text: "b".repeat(40),
+                },
+            ],
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+        };
+        assert_eq!(estimate_input_tokens(&req), 20); // 80 chars / 4
+    }
+```
+
+**Verified facts (do not re-derive):** `RichMessage` is an enum with variants `Text { role, content }`, `ToolUse { text: Option<String>, calls }`, `ToolResults { results }`, `ImageText { role, media_type, data, text }` (llm/mod.rs ~line 78). `LlmRequest { messages: Vec<RichMessage>, temperature: Option<f32>, max_tokens: Option<u32>, tools: Vec<ToolDef> }`. `rand = { workspace = true }` is already a dependency of `mur-agent-runtime`.
 
 - [ ] **Step 4: Run to verify it passes**
 
@@ -610,10 +646,23 @@ git commit -m "feat(llm): cooldown map + backoff + token estimate for fallback"
 - [ ] **Step 1: Write the failing test** (append to `fallback.rs` tests)
 
 ```rust
-    use super::super::{LlmClient, LlmError, LlmRequest, LlmResponse};
+    use super::super::{LlmClient, LlmError, LlmRequest, LlmResponse, StopReason};
     use async_trait::async_trait;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // LlmResponse has no Default (StopReason has no default variant), so build
+    // one explicitly.
+    fn mk_resp(text: &str) -> LlmResponse {
+        LlmResponse {
+            text: text.to_string(),
+            input_tokens: 0,
+            output_tokens: 0,
+            model: text.to_string(),
+            tool_calls: vec![],
+            stop_reason: StopReason::EndTurn,
+        }
+    }
 
     // Mock client whose Nth generate() outcome is scripted.
     struct ScriptClient { name: String, outcomes: Vec<Result<(), LlmError>>, idx: AtomicUsize }
@@ -622,7 +671,7 @@ git commit -m "feat(llm): cooldown map + backoff + token estimate for fallback"
         async fn generate(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
             let i = self.idx.fetch_add(1, Ordering::SeqCst).min(self.outcomes.len()-1);
             match &self.outcomes[i] {
-                Ok(()) => Ok(LlmResponse { text: self.name.clone(), ..Default::default() }),
+                Ok(()) => Ok(mk_resp(&self.name)),
                 Err(e) => Err(e.clone()),
             }
         }
@@ -746,7 +795,7 @@ impl LlmClient for FallbackLlmClient {
 }
 ```
 
-**Interface note:** `req.clone()` requires `LlmRequest: Clone` — confirm it derives `Clone` (grep `struct LlmRequest`); it should, but if not, add `#[derive(Clone)]`. `LlmResponse::default()` is used by the test mock — confirm `LlmResponse: Default` (the existing `llm_response_defaults` test implies it does).
+**Interface note:** `req.clone()` requires `LlmRequest: Clone` — verified: `LlmRequest` derives `#[derive(Debug, Clone)]`. `LlmResponse` does NOT derive `Default` (its `stop_reason: StopReason` has no default variant — StopReason is `{EndTurn, ToolUse, MaxTokens}`), so the test mock builds it explicitly via `mk_resp` (shown in Step 1), constructing all six fields with `stop_reason: StopReason::EndTurn`. Do NOT add `Default` to `LlmResponse`.
 
 - [ ] **Step 4: Run to verify it passes**
 

--- a/docs/superpowers/specs/2026-07-12-intelligent-model-switch-design.md
+++ b/docs/superpowers/specs/2026-07-12-intelligent-model-switch-design.md
@@ -51,7 +51,7 @@ Two units, both feeding the single existing resolution point `resolve_model_entr
 ```
 
 - **`ModelResolver`** — pure function: `(profile, global_config) → Vec<ModelCandidate>`. Testable in isolation.
-- **`FallbackExecutor`** — wraps the LLM call site; owns the in-memory cooldown map. Because `LlmClient` is not dyn-compatible (RPITIT — known constraint), the executor builds a fresh client per candidate via the existing `resolve_model_entry`-style lookup and loops; no `Arc<dyn>`.
+- **`FallbackExecutor`** — a `FallbackLlmClient` that itself implements the runtime's `LlmClient` trait (`#[async_trait]`, used as `Arc<dyn LlmClient>`, so object-safe). It holds the ordered candidates + a client factory + the in-memory cooldown map, and its `generate` loops over candidates. Because it *is* an `LlmClient`, it drops into the existing `Arc<dyn LlmClient>` slot with no agent-loop changes.
 - **Difficulty heuristic** — pure function `(estimated_input_tokens, routing_config) → model_ref`.
 
 ## Data Model

--- a/docs/superpowers/specs/2026-07-12-intelligent-model-switch-design.md
+++ b/docs/superpowers/specs/2026-07-12-intelligent-model-switch-design.md
@@ -1,0 +1,233 @@
+# Intelligent Model Switching — Design Spec
+
+> **Date**: 2026-07-12
+> **Status**: Ready for review
+> **Scope**: A minimal, config-layered model-selection + failure-fallback layer for MUR agents (global + per-agent settings, priority per-agent → global). Opt-in difficulty routing. Does NOT implement the learned/RouteLLM router — that stays cost-router Phase 3.
+
+## Overview
+
+MUR agents already bind a model via `AgentProfile.model_ref` (looked up in `~/.mur/models.yaml`) with a runtime `--model` override. This spec adds two capabilities on top, both driven by config:
+
+1. **Config-layered model resolution** — a global default model, overridable per-agent, so an agent without an explicit `model_ref` falls back to a workspace default instead of the hard-coded inline `model:` block.
+2. **Failure fallback chains** — an ordered list of models tried in sequence when a call fails with a *retryable* error (rate-limit / 5xx / timeout / insufficient-credit), with per-model retry (exponential backoff + jitter) and an in-memory cooldown (circuit-breaker) so a failing model is skipped while it recovers.
+
+An **opt-in difficulty heuristic** (off by default) selects between a "cheap" and a "frontier" model by estimated input-token count before resolution.
+
+This is the Phase-1 MVP identified by the 2026 deep-research pass (fleet `deep-research`, 2026-07-12): *"start with per-agent defaults + per-task overrides"* and *"Phase 1 = heuristic router + fallback chain"*. Learned routing (RouteLLM-style classifier) is explicitly deferred — it requires production sample collection and is out of scope.
+
+### Relationship to the Cost-Router spec
+
+`docs/superpowers/specs/2026-06-01-cost-router-orchestrator-design.md` Phase 1 ("Router on the model registry") describes a fuller hybrid auto+override router. This spec is a **lightweight precursor**, not that Router: it shares the `models.yaml` registry but ships only config-layered resolution + fallback + a single opt-in heuristic. The learned Router remains cost-router's later phase. Keeping them separate avoids scope creep.
+
+### Non-goals
+
+- Learned / classifier-based routing (RouteLLM, NotDiamond). Deferred to cost-router Phase 3.
+- Persistent cooldown state across process restarts (in-memory only).
+- Mid-session quality-based re-routing (observing output quality and switching). Out of scope.
+- Per-request model override beyond the existing runtime `--model` flag.
+
+## Architecture
+
+Two units, both feeding the single existing resolution point `resolve_model_entry` in `mur-agent-runtime/src/supervisor.rs` (~line 1148):
+
+```
+                    ┌──────────────────────────┐
+ prompt/message ──▶ │ difficulty heuristic      │ (opt-in, off by default)
+                    │ (token count → cheap/     │
+                    │  frontier model_ref)      │
+                    └───────────┬──────────────┘
+                                │ chosen primary ref (or profile.model_ref)
+                                ▼
+                    ┌──────────────────────────┐
+                    │ ModelResolver             │  priority: per-agent → global
+                    │ → ordered Vec<candidate>  │  [primary, ...fallback_chain]
+                    └───────────┬──────────────┘
+                                ▼
+                    ┌──────────────────────────┐
+   LLM call ──────▶ │ FallbackExecutor          │  per-candidate retry (backoff+jitter),
+                    │  loop over candidates,     │  classify error, cooldown map,
+                    │  skip cooled-down models   │  advance on retryable failure
+                    └──────────────────────────┘
+```
+
+- **`ModelResolver`** — pure function: `(profile, global_config) → Vec<ModelCandidate>`. Testable in isolation.
+- **`FallbackExecutor`** — wraps the LLM call site; owns the in-memory cooldown map. Because `LlmClient` is not dyn-compatible (RPITIT — known constraint), the executor builds a fresh client per candidate via the existing `resolve_model_entry`-style lookup and loops; no `Arc<dyn>`.
+- **Difficulty heuristic** — pure function `(estimated_input_tokens, routing_config) → model_ref`.
+
+## Data Model
+
+### Global config (`~/.mur/config.yaml`) — new `models:` block
+
+New `Config.models: ModelSwitchConfig` (separate from the existing `llm:` block, per review decision):
+
+```yaml
+models:
+  default: claude_sonnet          # global default when an agent has no model_ref
+  fallback_chain:                 # tried in order on retryable failure
+    - claude_sonnet
+    - deepseek_v4_pro
+  retry:
+    max_retries: 1                # per-candidate retries before advancing the chain
+    backoff_base_ms: 500          # exponential base; delay = base * 2^attempt + jitter
+    cooldown_secs: 60             # circuit-breaker: skip a failed model this long
+  routing:                        # opt-in difficulty routing
+    enabled: false
+    cheap: deepseek_v4_flash
+    frontier: claude_opus
+    threshold_input_tokens: 2000
+```
+
+```rust
+// mur-common/src/config.rs
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ModelSwitchConfig {
+    pub default: Option<String>,          // global default model_ref
+    #[serde(default)]
+    pub fallback_chain: Vec<String>,      // global fallback chain
+    #[serde(default)]
+    pub retry: RetryConfig,
+    #[serde(default)]
+    pub routing: RoutingConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetryConfig {
+    pub max_retries: u32,        // default DEFAULT_MAX_RETRIES
+    pub backoff_base_ms: u64,    // default DEFAULT_BACKOFF_BASE_MS
+    pub cooldown_secs: u64,      // default DEFAULT_COOLDOWN_SECS
+}
+// impl Default reads the module consts below.
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RoutingConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    pub cheap: Option<String>,
+    pub frontier: Option<String>,
+    #[serde(default)]
+    pub threshold_input_tokens: Option<u32>,   // default DEFAULT_ROUTING_THRESHOLD when routing enabled
+}
+```
+
+Documented default constants (no hard-coded literals at call sites — Mandatory Rule 1):
+
+```rust
+pub const DEFAULT_MAX_RETRIES: u32 = 1;
+pub const DEFAULT_BACKOFF_BASE_MS: u64 = 500;
+pub const DEFAULT_COOLDOWN_SECS: u64 = 60;
+pub const DEFAULT_ROUTING_THRESHOLD: u32 = 2000;
+```
+
+### Per-agent (`AgentProfile`) — one new optional field
+
+`model_ref: Option<String>` already exists. Add a per-agent fallback chain:
+
+```rust
+// mur-common/src/agent.rs (AgentProfile)
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub fallback_chain: Vec<String>,   // per-agent override of the global chain
+```
+
+Optional per-agent routing override reuses `RoutingConfig`:
+
+```rust
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub routing: Option<RoutingConfig>,
+```
+
+Legacy profiles without these fields must still deserialize (both are `#[serde(default)]`) — a regression test guards this, mirroring the existing `legacy_profile_without_model_ref_still_parses` test.
+
+## Resolution Priority (per-agent → global)
+
+`ModelResolver::resolve(profile, cfg) -> Vec<ModelCandidate>` where `ModelCandidate` carries a `model_ref: String` and its resolved `ModelEntry`.
+
+| Decision | Source, highest priority first |
+|---|---|
+| Primary model | (routing heuristic result, if routing enabled) → per-agent `model_ref` → global `models.default` → existing inline `model:` block |
+| Fallback chain | per-agent `fallback_chain` (if non-empty) → global `models.fallback_chain` → empty |
+| Routing config | per-agent `routing` (if `Some`) → global `models.routing` → disabled |
+
+Rules:
+- The primary is always the head of the returned vector.
+- The fallback chain is appended after the primary; the primary is de-duplicated out of the chain if it also appears there (no point retrying the same ref back-to-back).
+- If neither per-agent nor global supplies anything, the vector is a single candidate = today's behavior (inline model). This preserves existing agents byte-for-byte.
+
+## Fallback Execution
+
+`FallbackExecutor` wraps the runtime's LLM invocation:
+
+```
+for candidate in resolver.resolve(profile, cfg):
+    if cooldown.is_cooling(candidate.model_ref): continue
+    for attempt in 0..=cfg.retry.max_retries:
+        result = call_model(candidate)               # builds client per candidate
+        match classify(result):
+            Ok(resp)            => return Ok(resp)
+            Err(Fatal(e))       => return Err(e)      # auth/malformed: do NOT fallback
+            Err(Retryable(_)):
+                if attempt < max_retries:
+                    sleep(backoff(attempt))           # base * 2^attempt + jitter
+                else:
+                    cooldown.mark(candidate.model_ref, now + cooldown_secs)
+                    break                              # advance to next candidate
+return Err(last_error)                                # chain exhausted; surface it
+```
+
+### Error classification
+
+```rust
+pub enum CallOutcome { Ok(Response), Retryable(RetryKind), Fatal(anyhow::Error) }
+pub enum RetryKind { RateLimit, ServerError, Timeout, InsufficientCredit }
+```
+
+- **Retryable** → advance/retry: HTTP `429` (RateLimit), `5xx` (ServerError), connect/read timeout (Timeout), `402` / provider "insufficient credit/quota" (InsufficientCredit).
+- **Fatal** → do NOT fallback: `400` (bad request), `401`/`403` (auth), malformed response, schema violation. Falling back on these hides a real bug or misconfiguration.
+
+### Cooldown map (circuit-breaker)
+
+In-memory `HashMap<String /*model_ref*/, Instant /*cooling_until*/>` owned by the executor (per runtime process). `is_cooling` returns true while `now < cooling_until`. No persistence — a restart clears it (acceptable; cooldowns are seconds-scale).
+
+## Difficulty Heuristic (opt-in)
+
+When `routing.enabled`:
+
+```rust
+fn choose_by_difficulty(est_input_tokens: u32, r: &RoutingConfig) -> Option<String> {
+    let threshold = r.threshold_input_tokens.unwrap_or(DEFAULT_ROUTING_THRESHOLD);
+    match (r.cheap.as_ref(), r.frontier.as_ref()) {
+        (Some(cheap), Some(frontier)) =>
+            Some(if est_input_tokens > threshold { frontier.clone() } else { cheap.clone() }),
+        _ => None,   // misconfigured → fall through to model_ref/global default
+    }
+}
+```
+
+`est_input_tokens` is estimated from the message text (a coarse chars/4 approximation is sufficient — this is a routing heuristic, not billing). If routing is disabled or misconfigured, resolution proceeds with `model_ref`/global default unchanged.
+
+## CLI Surface
+
+- `mur model default <ref>` — set/clear global `models.default` (writes `config.yaml`).
+- `mur model fallback <ref>...` — set the global `models.fallback_chain` (ordered; empty clears).
+- Per-agent `fallback_chain` is written by extending the existing per-agent model-binding path (`mur-core/src/cmd/agent/model_resolve.rs`), e.g. a `--fallback <ref>...` companion to the existing model_ref setter. Difficulty routing is config-only in v1 (no dedicated CLI); users edit `config.yaml`.
+
+All CLI writes validate that each `<ref>` exists in `models.yaml` and error otherwise (fail-closed).
+
+## Error Handling & Observability
+
+- Every fallback advance and cooldown mark emits a `tracing` event at `info` (model_ref, RetryKind, attempt) so operators can see switching in logs — mirrors the existing `egress proxy CONNECT` audit style.
+- Chain exhaustion returns the last candidate's error with context listing the models tried.
+- A fatal error short-circuits with the original error (no chain noise).
+
+## Testing
+
+- **Resolver priority**: per-agent `model_ref` overrides global `default`; per-agent `fallback_chain` overrides global; empty both → single inline candidate (existing behavior). Primary de-dup out of chain.
+- **Legacy profile**: a profile YAML without `fallback_chain`/`routing` still deserializes.
+- **Error classifier**: 429/5xx/timeout/402 → Retryable(kind); 400/401/malformed → Fatal.
+- **FallbackExecutor** (mock client): fails N times then succeeds → advances the chain the right number of times; a Fatal error returns immediately without advancing; a model in cooldown is skipped; chain exhaustion returns the last error.
+- **Cooldown**: `is_cooling` true within window, false after; `mark` sets the window from `cooldown_secs`.
+- **Difficulty heuristic**: `est > threshold → frontier`, `est <= threshold → cheap`, misconfigured (missing cheap/frontier) → `None` (fall-through).
+- **Config defaults**: omitted `retry`/`routing` fields deserialize to the documented default constants.
+
+## Rollout
+
+Additive and off-by-default: with an empty `models:` block and no per-agent `fallback_chain`, `resolve` returns a single candidate and `FallbackExecutor` degenerates to today's single call — existing agents are unaffected. Difficulty routing ships `enabled: false`.

--- a/docs/superpowers/specs/2026-07-12-intelligent-model-switch-design.md
+++ b/docs/superpowers/specs/2026-07-12-intelligent-model-switch-design.md
@@ -2,7 +2,7 @@
 
 > **Date**: 2026-07-12
 > **Status**: Ready for review
-> **Scope**: A minimal, config-layered model-selection + failure-fallback layer for MUR agents (global + per-agent settings, priority per-agent → global). Opt-in difficulty routing. Does NOT implement the learned/RouteLLM router — that stays cost-router Phase 3.
+> **Scope**: A minimal, config-layered model-selection + failure-fallback layer for MUR agents (global + per-agent settings, priority per-agent → global), managed from both the CLI and the MUR Hub GUI. Opt-in difficulty routing. Does NOT implement the learned/RouteLLM router — that stays cost-router Phase 3.
 
 ## Overview
 
@@ -211,6 +211,23 @@ fn choose_by_difficulty(est_input_tokens: u32, r: &RoutingConfig) -> Option<Stri
 - Per-agent `fallback_chain` is written by extending the existing per-agent model-binding path (`mur-core/src/cmd/agent/model_resolve.rs`), e.g. a `--fallback <ref>...` companion to the existing model_ref setter. Difficulty routing is config-only in v1 (no dedicated CLI); users edit `config.yaml`.
 
 All CLI writes validate that each `<ref>` exists in `models.yaml` and error otherwise (fail-closed).
+
+## Hub GUI Management (Phase 2)
+
+The feature must be manageable from the MUR Hub, not only the CLI. Both surfaces already exist in `mur-hub-gui`, so this is thin wiring over the same core logic — **not** a new subsystem. It depends on Phase 1 (core + CLI) landing first; the Hub commands are wrappers over the same `store::config` read/write and resolver used by the CLI.
+
+**Global scope — Settings → Models tab** (`ui/src/components/settings/ModelsSettings.tsx`; the Hub already reads/writes `config.yaml` via `mur_core::store::config::{load_config,save_config}`, as the fleet-settings commands do):
+- A **Default model** combobox (reuses the existing `ModelCombobox`, populated from `list_models`).
+- A **Fallback chain** ordered list editor (add/remove/reorder model refs from the registry).
+- A **Difficulty routing** section: an enable toggle + cheap/frontier comboboxes + threshold input, defaulting to disabled.
+- New Tauri commands `model_switch_get() -> ModelSwitchView` and `model_switch_set(patch)` wrapping `load_config`/`save_config`, mirroring the existing `agent_get_notif_config`/`agent_set_notif_config` pattern in `notif.rs`. Each ref is validated against `models.yaml` (fail-closed) before save.
+
+**Per-agent scope — agent detail model section** (the existing per-agent picker: `ModelPickerModal.tsx` / `ModelCombobox.tsx`, backed by `apply_agent_model` / `set_concierge_model_ref`):
+- Below the existing primary-model picker, add a **per-agent fallback chain** editor and an optional **routing override** (inherits global when unset).
+- Extend the existing per-agent model command (or add `agent_set_fallback_chain(name, refs)`) to write the profile's `fallback_chain` / `routing` fields.
+- Empty per-agent settings inherit the global defaults — the UI shows the effective (inherited) value greyed until overridden, matching the resolution priority (per-agent → global).
+
+**Phasing:** Phase 1 ships core + CLI (testable headless). Phase 2 adds the Hub commands + UI. Because mur-hub-gui is workspace-excluded (Tauri) and built separately, splitting it keeps Phase 1 shippable and CI-verifiable without the GUI toolchain. Phase 2 is a separate implementation plan.
 
 ## Error Handling & Observability
 

--- a/mur-agent-runtime/src/llm/anthropic.rs
+++ b/mur-agent-runtime/src/llm/anthropic.rs
@@ -555,10 +555,7 @@ impl LlmClient for AnthropicClient {
         })?;
         if !status.is_success() {
             tracing::warn!(status = %status, body = %body_text, "anthropic non-2xx");
-            if status == 429 {
-                return Err(LlmError::RateLimit);
-            }
-            return Err(LlmError::Http(format!("status {status}: {body_text}")));
+            return Err(LlmError::from_status(status.as_u16(), body_text));
         }
         let v: serde_json::Value = serde_json::from_str(&body_text)
             .map_err(|e| LlmError::Http(format!("parse response: {e}")))?;
@@ -632,11 +629,8 @@ impl LlmClient for AnthropicClient {
             })?;
         let status = resp.status();
         if !status.is_success() {
-            if status == 429 {
-                return Err(LlmError::RateLimit);
-            }
             let body_text = resp.text().await.unwrap_or_default();
-            return Err(LlmError::Http(format!("status {status}: {body_text}")));
+            return Err(LlmError::from_status(status.as_u16(), body_text));
         }
 
         // Anthropic streams SSE: `event: <type>` + `data: {json}`. Each data

--- a/mur-agent-runtime/src/llm/client_builder.rs
+++ b/mur-agent-runtime/src/llm/client_builder.rs
@@ -1,0 +1,179 @@
+//! Client construction for a single resolved `ModelEntry` — secret
+//! resolution, the guarded HTTP client, and provider dispatch. Split out of
+//! `supervisor_runner.rs` (Task 7 review finding: that file exceeded the
+//! 800-line mandate in CLAUDE.md §4) as a pure move — no logic change.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Context;
+use tracing::warn;
+
+use crate::llm::LlmClient;
+use crate::llm::{anthropic::AnthropicClient, ollama::OllamaClient, openai::OpenAiClient};
+use crate::profile::Profile;
+use crate::sandbox::reqwest_guard::HostGuard;
+use mur_common::agent::NetworkOutboundMode;
+use mur_common::model::ModelEntry;
+
+/// Marks a `guarded_http` reqwest-client build failure so callers can detect
+/// it and propagate the failure directly instead of reinterpreting it via
+/// per-provider fallback logic. Pre-Task-7, the guarded HTTP client was built
+/// once in `build_provider_runner` BEFORE the provider `match`, so a build
+/// failure propagated as a hard `Err` out of the function regardless of
+/// provider. Folding that build into `build_client_from_entry` (so each
+/// fallback-chain candidate gets its own client) meant the single-model call
+/// site's `match entry.provider.as_str()` Err-reinterpretation started
+/// mislabeling a `guarded_http` failure for `local`/`ollama` (which have no
+/// arm in that reinterpretation) as "unsupported model provider". Wrapping
+/// the error lets the caller `downcast_ref` on it and restore the original
+/// hard-fail semantic. See `build_provider_runner` in `supervisor_runner.rs`.
+#[derive(Debug)]
+pub(crate) struct GuardedHttpBuildError(pub anyhow::Error);
+
+impl std::fmt::Display for GuardedHttpBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for GuardedHttpBuildError {}
+
+/// Build the `Arc<dyn LlmClient>` for a single resolved model entry: secret
+/// resolution + guarded HTTP client + provider dispatch. Pure and synchronous
+/// (uses `SecretRef::resolve_blocking` / the `block_on` helper below instead
+/// of `.await`) so it can double as a `ClientFactory` for fallback-chain
+/// candidates, which are built from inside a synchronous closure. `Err`
+/// covers a `guarded_http` build failure (see `GuardedHttpBuildError` above —
+/// callers must propagate this directly), "echo" (deliberate placeholder —
+/// never has a real client), and unsupported providers; callers reconstruct
+/// the differentiated stub/log behaviour for those two on `Err` (see
+/// `build_provider_runner` in `supervisor_runner.rs`).
+pub(crate) fn build_client_from_entry(
+    entry: &ModelEntry,
+    profile: &Profile,
+    mur_home: &Path,
+) -> anyhow::Result<Arc<dyn LlmClient>> {
+    let secret_value: Option<secrecy::SecretString> = match &entry.secret {
+        Some(s) => match s.resolve_blocking() {
+            Ok(v) => Some(v),
+            Err(e) => {
+                warn!(error = %e, "secret resolution failed; falling back to echo");
+                None
+            }
+        },
+        None => None,
+    };
+
+    let outbound = &profile.inner.entitlements.network.outbound;
+    let host_guard = match outbound.mode {
+        NetworkOutboundMode::Unrestricted => HostGuard::unrestricted(),
+        NetworkOutboundMode::Restricted | NetworkOutboundMode::ProxyOnly => {
+            // Auto-allow the agent's configured LLM provider host: choosing a
+            // provider implies permission to reach it, so the user never has to
+            // `mur agent perm allow-host` their own model endpoint. Mirrors the
+            // loopback-port auto-grant for local models (`local_llm_port`).
+            // ProxyOnly shares this host governance with Restricted — it still
+            // needs to resolve its own LLM endpoint; it just loses general TCP
+            // egress at the OS sandbox layer.
+            let mut hosts = outbound.allow_hosts.clone();
+            if let Some(h) = crate::supervisor_runner::provider_host(entry)
+                && !hosts.iter().any(|x| x == &h)
+            {
+                hosts.push(h);
+            }
+            HostGuard::restricted(hosts)
+        }
+        NetworkOutboundMode::Off => HostGuard::off(),
+    };
+    let guarded_http = reqwest::ClientBuilder::new()
+        .dns_resolver(std::sync::Arc::new(host_guard))
+        .build()
+        .context("failed to build guarded HTTP client")
+        .map_err(GuardedHttpBuildError)?;
+
+    match entry.provider.as_str() {
+        "local" => {
+            let base = crate::supervisor_runner::resolve_local_base_url(
+                entry.base_url.as_deref(),
+                std::env::var("MUR_LOCAL_LLM_BASE_URL").ok(),
+                mur_home,
+            );
+            let key = secrecy::SecretString::from(
+                crate::supervisor_runner::LOCAL_LLM_PLACEHOLDER_KEY.to_string(),
+            );
+            Ok(Arc::new(OpenAiClient::from_secret_string_with_http(
+                &key,
+                entry.model.clone(),
+                Some(base),
+                guarded_http,
+            )))
+        }
+        "ollama" => {
+            let base = entry.base_url.clone().unwrap_or_else(|| {
+                std::env::var("OLLAMA_BASE_URL")
+                    .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string())
+            });
+            Ok(Arc::new(OllamaClient::with_http_client(
+                base,
+                entry.model.clone(),
+                guarded_http,
+            )))
+        }
+        "anthropic" => {
+            if let Some(key) = secret_value.as_ref() {
+                Ok(Arc::new(AnthropicClient::from_secret_string_with_http(
+                    key,
+                    entry.model.clone(),
+                    entry.base_url.clone(),
+                    guarded_http,
+                )))
+            } else {
+                block_on(AnthropicClient::from_agent_credentials_with_http(
+                    &profile.inner.name,
+                    entry.model.clone(),
+                    guarded_http,
+                ))
+                .map(|c| Arc::new(c) as Arc<dyn LlmClient>)
+                .map_err(anyhow::Error::from)
+            }
+        }
+        "openai" => {
+            if let Some(key) = secret_value.as_ref() {
+                Ok(Arc::new(OpenAiClient::from_secret_string_with_http(
+                    key,
+                    entry.model.clone(),
+                    entry.base_url.clone(),
+                    guarded_http,
+                )))
+            } else {
+                block_on(OpenAiClient::from_agent_credentials_with_http(
+                    &profile.inner.name,
+                    entry.model.clone(),
+                    guarded_http,
+                ))
+                .map(|c| Arc::new(c) as Arc<dyn LlmClient>)
+                .map_err(anyhow::Error::from)
+            }
+        }
+        "echo" => Err(anyhow::anyhow!("no model configured (echo placeholder)")),
+        other => Err(anyhow::anyhow!("unsupported model provider {other:?}")),
+    }
+}
+
+/// Block the current thread on a future from a synchronous context — needed
+/// because `ClientFactory` (the fallback chain's per-candidate builder type)
+/// is synchronous but credential resolution here is async. Mirrors
+/// `SecretRef::resolve_blocking`'s pattern: `block_in_place` under the
+/// current runtime handle (this crate's `#[tokio::main]` is multi-thread, see
+/// `main.rs`), else a scratch current-thread runtime.
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    match tokio::runtime::Handle::try_current() {
+        Ok(h) => tokio::task::block_in_place(|| h.block_on(fut)),
+        Err(_) => tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build scratch runtime")
+            .block_on(fut),
+    }
+}

--- a/mur-agent-runtime/src/llm/fallback.rs
+++ b/mur-agent-runtime/src/llm/fallback.rs
@@ -2,10 +2,94 @@
 //! estimate. See the model-switch spec.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use super::{LlmRequest, RichMessage};
+use async_trait::async_trait;
+use mur_common::config::RetryConfig;
+
+use super::{LlmClient, LlmError, LlmRequest, LlmResponse, Retryability, RichMessage, classify};
+
+/// Factory that builds a concrete `LlmClient` for a given model_ref. Boxed so
+/// `FallbackLlmClient` doesn't need a generic parameter per candidate type.
+pub type ClientFactory = Box<dyn Fn(&str) -> anyhow::Result<Arc<dyn LlmClient>> + Send + Sync>;
+
+/// An `LlmClient` that tries an ordered list of model_refs, advancing on
+/// retryable failures (per-candidate backoff retries first), skipping models in
+/// cooldown, and returning a fatal error immediately. Drops into the existing
+/// `Arc<dyn LlmClient>` slot with no agent-loop change.
+pub struct FallbackLlmClient {
+    candidates: Vec<String>,
+    factory: ClientFactory,
+    retry: RetryConfig,
+    cooldown: CooldownMap,
+    primary_name: String,
+}
+
+impl FallbackLlmClient {
+    pub fn new(candidates: Vec<String>, factory: ClientFactory, retry: RetryConfig) -> Self {
+        let primary_name = candidates.first().cloned().unwrap_or_default();
+        Self {
+            candidates,
+            factory,
+            retry,
+            cooldown: CooldownMap::new(),
+            primary_name,
+        }
+    }
+}
+
+#[async_trait]
+impl LlmClient for FallbackLlmClient {
+    async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
+        let now = Instant::now();
+        let mut last: Option<LlmError> = None;
+        for model_ref in &self.candidates {
+            if self.cooldown.is_cooling(model_ref, now) {
+                continue;
+            }
+            let client = match (self.factory)(model_ref) {
+                Ok(c) => c,
+                Err(e) => {
+                    last = Some(LlmError::Http(format!("build {model_ref}: {e}")));
+                    continue;
+                }
+            };
+            for attempt in 0..=self.retry.max_retries {
+                match client.generate(req.clone()).await {
+                    Ok(resp) => return Ok(resp),
+                    Err(e) => match classify(&e) {
+                        Retryability::Fatal => return Err(e),
+                        Retryability::Retryable => {
+                            tracing::info!(model_ref, attempt, error = %e, "llm fallback: retryable failure");
+                            if attempt < self.retry.max_retries {
+                                tokio::time::sleep(backoff_delay(
+                                    attempt,
+                                    self.retry.backoff_base_ms,
+                                ))
+                                .await;
+                            } else {
+                                let until =
+                                    Instant::now() + Duration::from_secs(self.retry.cooldown_secs);
+                                self.cooldown.mark(model_ref, until);
+                                tracing::info!(
+                                    model_ref,
+                                    "llm fallback: cooling down, advancing chain"
+                                );
+                                last = Some(e);
+                            }
+                        }
+                    },
+                }
+            }
+        }
+        Err(last.unwrap_or_else(|| LlmError::InvalidResponse("no model candidates".into())))
+    }
+
+    fn model_name(&self) -> &str {
+        &self.primary_name
+    }
+}
 
 /// In-memory per-model cooldown (circuit-breaker). Process-local; a restart
 /// clears it (cooldowns are seconds-scale, so persistence is unnecessary).
@@ -113,5 +197,93 @@ mod tests {
             tools: vec![],
         };
         assert_eq!(estimate_input_tokens(&req), 20); // 80 chars / 4
+    }
+
+    use super::super::StopReason;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // LlmResponse has no Default (StopReason has no default variant), so build
+    // one explicitly.
+    fn mk_resp(text: &str) -> LlmResponse {
+        LlmResponse {
+            text: text.to_string(),
+            input_tokens: 0,
+            output_tokens: 0,
+            model: text.to_string(),
+            tool_calls: vec![],
+            stop_reason: StopReason::EndTurn,
+        }
+    }
+
+    // Mock client whose Nth generate() outcome is scripted.
+    struct ScriptClient {
+        name: String,
+        outcomes: Vec<Result<(), LlmError>>,
+        idx: AtomicUsize,
+    }
+    #[async_trait]
+    impl LlmClient for ScriptClient {
+        async fn generate(&self, _req: LlmRequest) -> Result<LlmResponse, LlmError> {
+            let i = self
+                .idx
+                .fetch_add(1, Ordering::SeqCst)
+                .min(self.outcomes.len() - 1);
+            match &self.outcomes[i] {
+                Ok(()) => Ok(mk_resp(&self.name)),
+                Err(e) => Err(e.clone()),
+            }
+        }
+        fn model_name(&self) -> &str {
+            &self.name
+        }
+    }
+
+    fn factory_for(scripts: HashMap<String, Vec<Result<(), LlmError>>>) -> ClientFactory {
+        Box::new(move |r: &str| {
+            let o = scripts.get(r).cloned().unwrap_or_else(|| vec![Ok(())]);
+            Ok(Arc::new(ScriptClient {
+                name: r.to_string(),
+                outcomes: o,
+                idx: AtomicUsize::new(0),
+            }) as Arc<dyn LlmClient>)
+        })
+    }
+
+    fn retry0() -> RetryConfig {
+        RetryConfig {
+            max_retries: 0,
+            backoff_base_ms: 1,
+            cooldown_secs: 60,
+        }
+    }
+
+    #[tokio::test]
+    async fn advances_chain_on_retryable_then_succeeds() {
+        let mut s = HashMap::new();
+        s.insert("a".into(), vec![Err(LlmError::ServerError(500))]); // a fails (retryable)
+        s.insert("b".into(), vec![Ok(())]); // b succeeds
+        let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry0());
+        let resp = fb.generate(LlmRequest::default()).await.unwrap();
+        assert_eq!(resp.text, "b"); // fell through to b
+    }
+
+    #[tokio::test]
+    async fn fatal_error_does_not_advance() {
+        let mut s = HashMap::new();
+        s.insert("a".into(), vec![Err(LlmError::Http("401".into()))]); // fatal
+        s.insert("b".into(), vec![Ok(())]);
+        let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry0());
+        let err = fb.generate(LlmRequest::default()).await.unwrap_err();
+        assert!(matches!(err, LlmError::Http(_))); // returned a's fatal error, never tried b
+    }
+
+    #[tokio::test]
+    async fn exhaustion_returns_last_error() {
+        let mut s = HashMap::new();
+        s.insert("a".into(), vec![Err(LlmError::RateLimit)]);
+        s.insert("b".into(), vec![Err(LlmError::ServerError(503))]);
+        let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry0());
+        let err = fb.generate(LlmRequest::default()).await.unwrap_err();
+        assert!(matches!(err, LlmError::ServerError(503))); // last candidate's error
     }
 }

--- a/mur-agent-runtime/src/llm/fallback.rs
+++ b/mur-agent-runtime/src/llm/fallback.rs
@@ -1,0 +1,117 @@
+//! Failure-fallback for LLM calls: cooldown circuit-breaker, backoff, and token
+//! estimate. See the model-switch spec.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use super::{LlmRequest, RichMessage};
+
+/// In-memory per-model cooldown (circuit-breaker). Process-local; a restart
+/// clears it (cooldowns are seconds-scale, so persistence is unnecessary).
+#[derive(Default)]
+pub struct CooldownMap {
+    inner: Mutex<HashMap<String, Instant>>,
+}
+
+impl CooldownMap {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn mark(&self, model_ref: &str, until: Instant) {
+        self.inner
+            .lock()
+            .unwrap()
+            .insert(model_ref.to_string(), until);
+    }
+
+    pub fn is_cooling(&self, model_ref: &str, now: Instant) -> bool {
+        match self.inner.lock().unwrap().get(model_ref) {
+            Some(until) => now < *until,
+            None => false,
+        }
+    }
+}
+
+/// Exponential backoff with jitter: `base * 2^attempt + rand[0, base)`.
+pub fn backoff_delay(attempt: u32, base_ms: u64) -> Duration {
+    let floor = base_ms.saturating_mul(2u64.saturating_pow(attempt));
+    let jitter = if base_ms > 0 {
+        rand::random::<u64>() % base_ms
+    } else {
+        0
+    };
+    Duration::from_millis(floor.saturating_add(jitter))
+}
+
+/// Coarse input-token estimate (chars/4) over the request's message texts —
+/// enough for a routing heuristic, not billing. `LlmRequest.messages` is a
+/// `Vec<RichMessage>` (an enum), so match the text-bearing variants.
+pub fn estimate_input_tokens(req: &LlmRequest) -> u32 {
+    let chars: usize = req
+        .messages
+        .iter()
+        .map(|m| match m {
+            RichMessage::Text { content, .. } => content.len(),
+            RichMessage::ImageText { text, .. } => text.len(),
+            RichMessage::ToolUse { text, .. } => text.as_deref().map_or(0, str::len),
+            RichMessage::ToolResults { .. } => 0,
+        })
+        .sum();
+    (chars / 4).min(u32::MAX as usize) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cooldown_marks_and_expires() {
+        let cm = CooldownMap::new();
+        let now = Instant::now();
+        assert!(!cm.is_cooling("m", now));
+        cm.mark("m", now + Duration::from_secs(60));
+        assert!(cm.is_cooling("m", now)); // within window
+        assert!(!cm.is_cooling("m", now + Duration::from_secs(61))); // after window
+        assert!(!cm.is_cooling("other", now));
+    }
+
+    #[test]
+    fn backoff_grows_and_stays_in_bounds() {
+        let base = 500u64;
+        for attempt in 0..4u32 {
+            let d = backoff_delay(attempt, base).as_millis() as u64;
+            let floor = base * 2u64.pow(attempt);
+            assert!(
+                d >= floor && d < floor + base,
+                "attempt {attempt}: {d} not in [{floor}, {})",
+                floor + base
+            );
+        }
+    }
+
+    #[test]
+    fn estimate_tokens_sums_text_over_rich_messages() {
+        let req = LlmRequest {
+            messages: vec![
+                RichMessage::Text {
+                    role: "user".into(),
+                    content: "a".repeat(40),
+                },
+                RichMessage::ImageText {
+                    role: "user".into(),
+                    media_type: "image/png".into(),
+                    data: String::new(),
+                    text: "b".repeat(40),
+                },
+            ],
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+        };
+        assert_eq!(estimate_input_tokens(&req), 20); // 80 chars / 4
+    }
+}

--- a/mur-agent-runtime/src/llm/fallback.rs
+++ b/mur-agent-runtime/src/llm/fallback.rs
@@ -6,7 +6,9 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use mur_common::config::RetryConfig;
+use mur_common::agent::AgentProfile;
+use mur_common::config::{ModelSwitchConfig, RetryConfig};
+use mur_common::model::{choose_by_difficulty, resolve_model_refs};
 
 use super::{LlmClient, LlmError, LlmRequest, LlmResponse, Retryability, RichMessage, classify};
 
@@ -14,12 +16,25 @@ use super::{LlmClient, LlmError, LlmRequest, LlmResponse, Retryability, RichMess
 /// `FallbackLlmClient` doesn't need a generic parameter per candidate type.
 pub type ClientFactory = Box<dyn Fn(&str) -> anyhow::Result<Arc<dyn LlmClient>> + Send + Sync>;
 
+/// How the adapter decides the ordered candidate list for a request.
+enum CandidateSource {
+    /// Fixed list (unit tests / simple wiring).
+    Static(Vec<String>),
+    /// Recomputed per request: applies opt-in difficulty routing (which needs
+    /// the request's token estimate) then `resolve_model_refs` (priority
+    /// per-agent → global). Reuses the pure, tested mur-common fns.
+    PerRequest {
+        profile: Box<AgentProfile>,
+        cfg: Box<ModelSwitchConfig>,
+    },
+}
+
 /// An `LlmClient` that tries an ordered list of model_refs, advancing on
 /// retryable failures (per-candidate backoff retries first), skipping models in
 /// cooldown, and returning a fatal error immediately. Drops into the existing
 /// `Arc<dyn LlmClient>` slot with no agent-loop change.
 pub struct FallbackLlmClient {
-    candidates: Vec<String>,
+    source: CandidateSource,
     factory: ClientFactory,
     retry: RetryConfig,
     cooldown: CooldownMap,
@@ -30,11 +45,57 @@ impl FallbackLlmClient {
     pub fn new(candidates: Vec<String>, factory: ClientFactory, retry: RetryConfig) -> Self {
         let primary_name = candidates.first().cloned().unwrap_or_default();
         Self {
-            candidates,
+            source: CandidateSource::Static(candidates),
             factory,
             retry,
             cooldown: CooldownMap::new(),
             primary_name,
+        }
+    }
+
+    /// Routing-aware constructor: candidates are computed per request so the
+    /// difficulty heuristic can see the request size.
+    pub fn new_routed(
+        profile: AgentProfile,
+        cfg: ModelSwitchConfig,
+        factory: ClientFactory,
+        retry: RetryConfig,
+    ) -> Self {
+        // primary_name for model_name(): the non-routed primary (model_ref/default).
+        let primary_name = resolve_model_refs(&profile, &cfg, None)
+            .first()
+            .cloned()
+            .unwrap_or_default();
+        Self {
+            source: CandidateSource::PerRequest {
+                profile: Box::new(profile),
+                cfg: Box::new(cfg),
+            },
+            factory,
+            retry,
+            cooldown: CooldownMap::new(),
+            primary_name,
+        }
+    }
+
+    /// The ordered candidate refs for this request.
+    fn candidates_for(&self, req: &LlmRequest) -> Vec<String> {
+        match &self.source {
+            CandidateSource::Static(v) => v.clone(),
+            CandidateSource::PerRequest { profile, cfg } => {
+                // Per-agent routing overrides global; disabled → None → normal
+                // model_ref/default primary.
+                let routing = profile
+                    .routing
+                    .clone()
+                    .unwrap_or_else(|| cfg.routing.clone());
+                let routed = if routing.enabled {
+                    choose_by_difficulty(estimate_input_tokens(req), &routing)
+                } else {
+                    None
+                };
+                resolve_model_refs(profile, cfg, routed)
+            }
         }
     }
 }
@@ -44,7 +105,8 @@ impl LlmClient for FallbackLlmClient {
     async fn generate(&self, req: LlmRequest) -> Result<LlmResponse, LlmError> {
         let now = Instant::now();
         let mut last: Option<LlmError> = None;
-        for model_ref in &self.candidates {
+        let candidates = self.candidates_for(&req);
+        for model_ref in &candidates {
             if self.cooldown.is_cooling(model_ref, now) {
                 continue;
             }
@@ -285,5 +347,49 @@ mod tests {
         let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry0());
         let err = fb.generate(LlmRequest::default()).await.unwrap_err();
         assert!(matches!(err, LlmError::ServerError(503))); // last candidate's error
+    }
+
+    #[tokio::test]
+    async fn routed_generate_picks_frontier_for_large_request() {
+        use mur_common::agent::AgentProfile;
+        use mur_common::config::{ModelSwitchConfig, RoutingConfig};
+        let mut cfg = ModelSwitchConfig::default();
+        cfg.routing = RoutingConfig {
+            enabled: true,
+            cheap: Some("cheap".into()),
+            frontier: Some("frontier".into()),
+            threshold_input_tokens: Some(5),
+        };
+        let mut scripts = std::collections::HashMap::new();
+        scripts.insert("frontier".to_string(), vec![Ok(())]);
+        scripts.insert("cheap".to_string(), vec![Ok(())]);
+        let fb = FallbackLlmClient::new_routed(
+            AgentProfile::default_for_tests(),
+            cfg,
+            factory_for(scripts),
+            retry0(),
+        );
+        // A big request (> threshold=5 tokens) routes to frontier.
+        let big = LlmRequest {
+            messages: vec![RichMessage::Text {
+                role: "user".into(),
+                content: "x".repeat(400),
+            }],
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+        };
+        assert_eq!(fb.generate(big).await.unwrap().text, "frontier");
+        // A tiny request routes to cheap.
+        let small = LlmRequest {
+            messages: vec![RichMessage::Text {
+                role: "user".into(),
+                content: "x".into(),
+            }],
+            temperature: None,
+            max_tokens: None,
+            tools: vec![],
+        };
+        assert_eq!(fb.generate(small).await.unwrap().text, "cheap");
     }
 }

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use mur_common::{AgentProfile, LlmMode};
 
 pub mod anthropic;
+pub mod fallback;
 pub mod ollama;
 pub mod openai;
 pub mod stub;

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -129,6 +129,42 @@ pub enum LlmError {
     Timeout,
     #[error("invalid response: {0}")]
     InvalidResponse(String),
+    #[error("server error: {0}")]
+    ServerError(u16),
+    #[error("insufficient credit")]
+    InsufficientCredit,
+}
+
+impl LlmError {
+    /// Map a non-success HTTP status into a typed error. Centralises what was
+    /// previously scattered `status == 429` checks + a lumped `Http(String)`.
+    pub fn from_status(status: u16, body: String) -> LlmError {
+        match status {
+            429 => LlmError::RateLimit,
+            402 => LlmError::InsufficientCredit,
+            500..=599 => LlmError::ServerError(status),
+            _ => LlmError::Http(format!("status {status}: {body}")),
+        }
+    }
+}
+
+/// Whether a failed call should advance the fallback chain (Retryable) or
+/// return immediately (Fatal — auth/bad-request/malformed, where switching
+/// models would only hide the real problem).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Retryability {
+    Retryable,
+    Fatal,
+}
+
+pub fn classify(e: &LlmError) -> Retryability {
+    match e {
+        LlmError::RateLimit
+        | LlmError::Timeout
+        | LlmError::ServerError(_)
+        | LlmError::InsufficientCredit => Retryability::Retryable,
+        LlmError::Http(_) | LlmError::InvalidResponse(_) => Retryability::Fatal,
+    }
 }
 
 /// One streamed chunk: either part of the model's hidden reasoning
@@ -212,6 +248,44 @@ mod tests {
         };
         assert!(r.tool_calls.is_empty());
         assert_eq!(r.stop_reason, StopReason::EndTurn);
+    }
+
+    #[test]
+    fn from_status_maps_http_codes() {
+        assert!(matches!(
+            LlmError::from_status(429, "x".into()),
+            LlmError::RateLimit
+        ));
+        assert!(matches!(
+            LlmError::from_status(402, "x".into()),
+            LlmError::InsufficientCredit
+        ));
+        assert!(matches!(
+            LlmError::from_status(503, "x".into()),
+            LlmError::ServerError(503)
+        ));
+        assert!(matches!(
+            LlmError::from_status(400, "x".into()),
+            LlmError::Http(_)
+        ));
+        assert!(matches!(
+            LlmError::from_status(401, "x".into()),
+            LlmError::Http(_)
+        ));
+    }
+
+    #[test]
+    fn classify_retryable_vs_fatal() {
+        use Retryability::*;
+        assert!(matches!(classify(&LlmError::RateLimit), Retryable));
+        assert!(matches!(classify(&LlmError::Timeout), Retryable));
+        assert!(matches!(classify(&LlmError::ServerError(500)), Retryable));
+        assert!(matches!(classify(&LlmError::InsufficientCredit), Retryable));
+        assert!(matches!(classify(&LlmError::Http("400".into())), Fatal));
+        assert!(matches!(
+            classify(&LlmError::InvalidResponse("x".into())),
+            Fatal
+        ));
     }
 }
 

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use mur_common::{AgentProfile, LlmMode};
 
 pub mod anthropic;
+pub(crate) mod client_builder;
 pub mod fallback;
 pub mod ollama;
 pub mod openai;

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -102,7 +102,7 @@ pub enum RichMessage {
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct LlmRequest {
     pub messages: Vec<RichMessage>,
     pub temperature: Option<f32>,
@@ -120,7 +120,7 @@ pub struct LlmResponse {
     pub stop_reason: StopReason,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum LlmError {
     #[error("http: {0}")]
     Http(String),

--- a/mur-agent-runtime/src/llm/ollama.rs
+++ b/mur-agent-runtime/src/llm/ollama.rs
@@ -87,8 +87,10 @@ impl LlmClient for OllamaClient {
                 LlmError::Http(e.to_string())
             }
         })?;
-        if resp.status() == 429 {
-            return Err(LlmError::RateLimit);
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            return Err(LlmError::from_status(status.as_u16(), body_text));
         }
         let v: serde_json::Value = resp.json().await.map_err(|e| {
             if e.is_timeout() {
@@ -139,8 +141,10 @@ impl LlmClient for OllamaClient {
                 LlmError::Http(e.to_string())
             }
         })?;
-        if resp.status() == 429 {
-            return Err(LlmError::RateLimit);
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            return Err(LlmError::from_status(status.as_u16(), body_text));
         }
 
         // Ollama streams newline-delimited JSON objects. Read incrementally

--- a/mur-agent-runtime/src/llm/openai.rs
+++ b/mur-agent-runtime/src/llm/openai.rs
@@ -293,8 +293,9 @@ impl LlmClient for OpenAiClient {
             })?;
 
         let status = resp.status();
-        if status == 429 {
-            return Err(LlmError::RateLimit);
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            return Err(LlmError::from_status(status.as_u16(), body_text));
         }
         let v: serde_json::Value = resp.json().await.map_err(|e| {
             if e.is_timeout() {
@@ -303,10 +304,6 @@ impl LlmClient for OpenAiClient {
                 LlmError::Http(e.to_string())
             }
         })?;
-        if !status.is_success() {
-            let msg = v["error"]["message"].as_str().unwrap_or("unknown");
-            return Err(LlmError::Http(format!("status {status}: {msg}")));
-        }
 
         let (text, tool_calls, stop_reason) = parse_response_body(&v)?;
         let input_tokens = v["usage"]["prompt_tokens"].as_u64().unwrap_or(0);
@@ -376,15 +373,10 @@ impl LlmClient for OpenAiClient {
                 }
             })?;
         let status = resp.status();
-        if status == 429 {
-            return Err(LlmError::RateLimit);
-        }
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            return Err(LlmError::Http(format!(
-                "status {status}: {}",
-                body.chars().take(200).collect::<String>()
-            )));
+            let truncated: String = body.chars().take(200).collect();
+            return Err(LlmError::from_status(status.as_u16(), truncated));
         }
 
         // OpenAI streams Server-Sent Events: `data: {json}\n\n`, ending with

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -2,24 +2,20 @@
 
 use std::sync::Arc;
 
-use anyhow::Context;
 use tracing::{error, warn};
 
 use crate::companion::clock::SystemClock;
 use crate::hitl::HitlApprovals;
 use crate::hooks::{HookChain, HookCtx, TelemetryEmitter};
 use crate::llm::LlmClient;
-use crate::llm::{anthropic::AnthropicClient, ollama::OllamaClient, openai::OpenAiClient};
 use crate::mcp::pool::McpPool;
 use crate::profile::Profile;
 use crate::sandbox::SandboxPolicy;
-use crate::sandbox::reqwest_guard::HostGuard;
 use crate::skills::RuntimeSkills;
 use crate::task_runner::TaskRunner;
 use crate::telemetry_writer::{TelemetryWriter, WriterTelemetryEmitter};
 use crate::tools::bash::BashTool;
 use crate::tools::registry::build_tools;
-use mur_common::agent::NetworkOutboundMode;
 use mur_common::config::SkillsConfig;
 use mur_common::model::ModelEntry;
 use mur_common::skill::aggregator::{StatsAggregator, StatsEvent};
@@ -27,7 +23,7 @@ use mur_common::telemetry::{
     METHOD_SKILL_EXECUTED, MUR_SKILL_DURATION_MS, MUR_SKILL_MANIFEST_DIGEST, MUR_SKILL_NAME,
     MUR_SKILL_OUTCOME, MUR_SKILL_VERSION,
 };
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 
 /// Fallback base URL when neither the registry entry, the env var, nor the
@@ -59,7 +55,7 @@ pub(crate) fn profile_needs_egress(entries: &[mur_common::agent::McpServerEntry]
 /// it under restricted outbound (so a user never has to `allow-host` their own
 /// provider). `None` for loopback base_urls (handled by `local_llm_port`) and
 /// for entries without a base_url.
-fn provider_host(entry: &ModelEntry) -> Option<String> {
+pub(crate) fn provider_host(entry: &ModelEntry) -> Option<String> {
     let base = entry.base_url.as_deref()?;
     let host = base.parse::<reqwest::Url>().ok()?.host_str()?.to_string();
     match host.as_str() {
@@ -325,53 +321,69 @@ pub async fn build_provider_runner(
         // Nothing configured (no chain, no routing) → today's exact single-model
         // path on the SAME `entry` resolved above via `resolve_model_entry`, no
         // FallbackLlmClient wrapper.
-        return Ok(match build_client_from_entry(&entry, profile, &mur_home) {
-            Ok(client) => build(client),
-            Err(e) => match entry.provider.as_str() {
-                "anthropic" => {
-                    warn!(error = %e, "anthropic client unavailable; falling back to echo");
-                    (
-                        Arc::new(TaskRunner::new_stub_echo()),
-                        None,
-                        Some(pool.clone()),
-                    )
-                }
-                "openai" => {
-                    warn!(error = %e, "openai client unavailable; falling back to echo");
-                    (
-                        Arc::new(TaskRunner::new_stub_echo()),
-                        None,
-                        Some(pool.clone()),
-                    )
-                }
-                "echo" => {
-                    // Intentional fallback: model resolution failed or the agent has no
-                    // model configured. Degrade to echo (warned at resolution time).
-                    (
-                        Arc::new(TaskRunner::new_stub_echo()),
-                        None,
-                        Some(pool.clone()),
-                    )
-                }
-                other => {
-                    // A real provider was configured but this runtime ships no client for
-                    // it (e.g. `deepseek`). Do NOT silently echo — that looks alive but
-                    // parrots input. Surface the misconfiguration in the logs AND in every
-                    // chat reply so the user sees exactly what to change.
-                    let msg = format!(
-                        "⚠️ This agent's model provider '{other}' is not supported by the \
+        return Ok(
+            match crate::llm::client_builder::build_client_from_entry(&entry, profile, &mur_home) {
+                Ok(client) => build(client),
+                Err(e) => {
+                    // A `guarded_http` build failure is a real error unrelated to
+                    // provider support — pre-Task-7 this was a hard `?` straight
+                    // out of this function, before the provider dispatch even
+                    // ran. `local`/`ollama` have no arm below, so without this
+                    // check such a failure would fall through to `other` and get
+                    // mislabeled "unsupported model provider". Propagate it
+                    // directly instead, restoring the original semantic.
+                    if e.downcast_ref::<crate::llm::client_builder::GuardedHttpBuildError>()
+                        .is_some()
+                    {
+                        return Err(e);
+                    }
+                    match entry.provider.as_str() {
+                        "anthropic" => {
+                            warn!(error = %e, "anthropic client unavailable; falling back to echo");
+                            (
+                                Arc::new(TaskRunner::new_stub_echo()),
+                                None,
+                                Some(pool.clone()),
+                            )
+                        }
+                        "openai" => {
+                            warn!(error = %e, "openai client unavailable; falling back to echo");
+                            (
+                                Arc::new(TaskRunner::new_stub_echo()),
+                                None,
+                                Some(pool.clone()),
+                            )
+                        }
+                        "echo" => {
+                            // Intentional fallback: model resolution failed or the agent has no
+                            // model configured. Degrade to echo (warned at resolution time).
+                            (
+                                Arc::new(TaskRunner::new_stub_echo()),
+                                None,
+                                Some(pool.clone()),
+                            )
+                        }
+                        other => {
+                            // A real provider was configured but this runtime ships no client for
+                            // it (e.g. `deepseek`). Do NOT silently echo — that looks alive but
+                            // parrots input. Surface the misconfiguration in the logs AND in every
+                            // chat reply so the user sees exactly what to change.
+                            let msg = format!(
+                                "⚠️ This agent's model provider '{other}' is not supported by the \
                          MUR runtime (supported: local, ollama, anthropic, openai). \
                          Update the agent's model to a supported provider in ~/.mur/models.yaml."
-                    );
-                    error!(provider = %other, "unsupported model provider — replying with misconfiguration notice instead of echo");
-                    (
-                        Arc::new(TaskRunner::new_stub_misconfigured(msg)),
-                        None,
-                        Some(pool.clone()),
-                    )
+                            );
+                            error!(provider = %other, "unsupported model provider — replying with misconfiguration notice instead of echo");
+                            (
+                                Arc::new(TaskRunner::new_stub_misconfigured(msg)),
+                                None,
+                                Some(pool.clone()),
+                            )
+                        }
+                    }
                 }
             },
-        });
+        );
     }
 
     // Chain and/or routing configured → routing-aware fallback client.
@@ -391,7 +403,11 @@ pub async fn build_provider_runner(
             .get(model_ref)
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("model_ref {model_ref:?} not in registry"))?;
-        build_client_from_entry(&candidate_entry, &profile_for_chain, &mur_home_for_chain)
+        crate::llm::client_builder::build_client_from_entry(
+            &candidate_entry,
+            &profile_for_chain,
+            &mur_home_for_chain,
+        )
     };
     let fallback_client: Arc<dyn LlmClient> =
         Arc::new(crate::llm::fallback::FallbackLlmClient::new_routed(
@@ -401,140 +417,6 @@ pub async fn build_provider_runner(
             switch_cfg.retry.clone(),
         ));
     Ok(build(fallback_client))
-}
-
-/// Build the `Arc<dyn LlmClient>` for a single resolved model entry: secret
-/// resolution + guarded HTTP client + provider dispatch. Pure and synchronous
-/// (uses `SecretRef::resolve_blocking` / the `block_on` helper below instead
-/// of `.await`) so it can double as a `ClientFactory` for fallback-chain
-/// candidates, which are built from inside a synchronous closure. `Err`
-/// covers "echo" (deliberate placeholder — never has a real client) and
-/// unsupported providers; callers reconstruct the differentiated stub/log
-/// behaviour for those on `Err` (see `build_provider_runner` above).
-fn build_client_from_entry(
-    entry: &ModelEntry,
-    profile: &Profile,
-    mur_home: &Path,
-) -> anyhow::Result<Arc<dyn LlmClient>> {
-    let secret_value: Option<secrecy::SecretString> = match &entry.secret {
-        Some(s) => match s.resolve_blocking() {
-            Ok(v) => Some(v),
-            Err(e) => {
-                warn!(error = %e, "secret resolution failed; falling back to echo");
-                None
-            }
-        },
-        None => None,
-    };
-
-    let outbound = &profile.inner.entitlements.network.outbound;
-    let host_guard = match outbound.mode {
-        NetworkOutboundMode::Unrestricted => HostGuard::unrestricted(),
-        NetworkOutboundMode::Restricted | NetworkOutboundMode::ProxyOnly => {
-            // Auto-allow the agent's configured LLM provider host: choosing a
-            // provider implies permission to reach it, so the user never has to
-            // `mur agent perm allow-host` their own model endpoint. Mirrors the
-            // loopback-port auto-grant for local models (`local_llm_port`).
-            // ProxyOnly shares this host governance with Restricted — it still
-            // needs to resolve its own LLM endpoint; it just loses general TCP
-            // egress at the OS sandbox layer.
-            let mut hosts = outbound.allow_hosts.clone();
-            if let Some(h) = provider_host(entry)
-                && !hosts.iter().any(|x| x == &h)
-            {
-                hosts.push(h);
-            }
-            HostGuard::restricted(hosts)
-        }
-        NetworkOutboundMode::Off => HostGuard::off(),
-    };
-    let guarded_http = reqwest::ClientBuilder::new()
-        .dns_resolver(std::sync::Arc::new(host_guard))
-        .build()
-        .context("failed to build guarded HTTP client")?;
-
-    match entry.provider.as_str() {
-        "local" => {
-            let base = resolve_local_base_url(
-                entry.base_url.as_deref(),
-                std::env::var("MUR_LOCAL_LLM_BASE_URL").ok(),
-                mur_home,
-            );
-            let key = secrecy::SecretString::from(LOCAL_LLM_PLACEHOLDER_KEY.to_string());
-            Ok(Arc::new(OpenAiClient::from_secret_string_with_http(
-                &key,
-                entry.model.clone(),
-                Some(base),
-                guarded_http,
-            )))
-        }
-        "ollama" => {
-            let base = entry.base_url.clone().unwrap_or_else(|| {
-                std::env::var("OLLAMA_BASE_URL")
-                    .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string())
-            });
-            Ok(Arc::new(OllamaClient::with_http_client(
-                base,
-                entry.model.clone(),
-                guarded_http,
-            )))
-        }
-        "anthropic" => {
-            if let Some(key) = secret_value.as_ref() {
-                Ok(Arc::new(AnthropicClient::from_secret_string_with_http(
-                    key,
-                    entry.model.clone(),
-                    entry.base_url.clone(),
-                    guarded_http,
-                )))
-            } else {
-                block_on(AnthropicClient::from_agent_credentials_with_http(
-                    &profile.inner.name,
-                    entry.model.clone(),
-                    guarded_http,
-                ))
-                .map(|c| Arc::new(c) as Arc<dyn LlmClient>)
-                .map_err(anyhow::Error::from)
-            }
-        }
-        "openai" => {
-            if let Some(key) = secret_value.as_ref() {
-                Ok(Arc::new(OpenAiClient::from_secret_string_with_http(
-                    key,
-                    entry.model.clone(),
-                    entry.base_url.clone(),
-                    guarded_http,
-                )))
-            } else {
-                block_on(OpenAiClient::from_agent_credentials_with_http(
-                    &profile.inner.name,
-                    entry.model.clone(),
-                    guarded_http,
-                ))
-                .map(|c| Arc::new(c) as Arc<dyn LlmClient>)
-                .map_err(anyhow::Error::from)
-            }
-        }
-        "echo" => Err(anyhow::anyhow!("no model configured (echo placeholder)")),
-        other => Err(anyhow::anyhow!("unsupported model provider {other:?}")),
-    }
-}
-
-/// Block the current thread on a future from a synchronous context — needed
-/// because `ClientFactory` (the fallback chain's per-candidate builder type)
-/// is synchronous but credential resolution here is async. Mirrors
-/// `SecretRef::resolve_blocking`'s pattern: `block_in_place` under the
-/// current runtime handle (this crate's `#[tokio::main]` is multi-thread, see
-/// `main.rs`), else a scratch current-thread runtime.
-fn block_on<F: std::future::Future>(fut: F) -> F::Output {
-    match tokio::runtime::Handle::try_current() {
-        Ok(h) => tokio::task::block_in_place(|| h.block_on(fut)),
-        Err(_) => tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("failed to build scratch runtime")
-            .block_on(fut),
-    }
 }
 
 /// Telemetry writer + notification routing + hook chain + skills loaded once at boot.

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -27,7 +27,7 @@ use mur_common::telemetry::{
     METHOD_SKILL_EXECUTED, MUR_SKILL_DURATION_MS, MUR_SKILL_MANIFEST_DIGEST, MUR_SKILL_NAME,
     MUR_SKILL_OUTCOME, MUR_SKILL_VERSION,
 };
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
 
 /// Fallback base URL when neither the registry entry, the env var, nor the
@@ -235,43 +235,6 @@ pub async fn build_provider_runner(
         ..Default::default()
     });
 
-    let secret_value: Option<secrecy::SecretString> = match &entry.secret {
-        Some(s) => match s.resolve().await {
-            Ok(v) => Some(v),
-            Err(e) => {
-                warn!(error = %e, "secret resolution failed; falling back to echo");
-                None
-            }
-        },
-        None => None,
-    };
-
-    let outbound = &profile.inner.entitlements.network.outbound;
-    let host_guard = match outbound.mode {
-        NetworkOutboundMode::Unrestricted => HostGuard::unrestricted(),
-        NetworkOutboundMode::Restricted | NetworkOutboundMode::ProxyOnly => {
-            // Auto-allow the agent's configured LLM provider host: choosing a
-            // provider implies permission to reach it, so the user never has to
-            // `mur agent perm allow-host` their own model endpoint. Mirrors the
-            // loopback-port auto-grant for local models (`local_llm_port`).
-            // ProxyOnly shares this host governance with Restricted — it still
-            // needs to resolve its own LLM endpoint; it just loses general TCP
-            // egress at the OS sandbox layer.
-            let mut hosts = outbound.allow_hosts.clone();
-            if let Some(h) = provider_host(&entry)
-                && !hosts.iter().any(|x| x == &h)
-            {
-                hosts.push(h);
-            }
-            HostGuard::restricted(hosts)
-        }
-        NetworkOutboundMode::Off => HostGuard::off(),
-    };
-    let guarded_http = reqwest::ClientBuilder::new()
-        .dns_resolver(std::sync::Arc::new(host_guard))
-        .build()
-        .context("failed to build guarded HTTP client")?;
-
     // Build MCP pool from the agent profile's configured servers, then discover
     // and filter tools concurrently before constructing the runner.
     let sandbox_policy = SandboxPolicy::from_entitlements(&profile.inner.entitlements, agent_home);
@@ -337,57 +300,35 @@ pub async fn build_provider_runner(
         (r, Some(client), Some(pool.clone()))
     };
 
-    Ok(match entry.provider.as_str() {
-        "local" => {
-            let mur_home = dirs::home_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("."))
-                .join(".mur");
-            let base = resolve_local_base_url(
-                entry.base_url.as_deref(),
-                std::env::var("MUR_LOCAL_LLM_BASE_URL").ok(),
-                &mur_home,
-            );
-            let key = secrecy::SecretString::from(LOCAL_LLM_PLACEHOLDER_KEY.to_string());
-            let client = Arc::new(OpenAiClient::from_secret_string_with_http(
-                &key,
-                entry.model.clone(),
-                Some(base),
-                guarded_http,
-            ));
-            build(client)
-        }
-        "ollama" => {
-            let base = entry.base_url.clone().unwrap_or_else(|| {
-                std::env::var("OLLAMA_BASE_URL")
-                    .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string())
-            });
-            let client = Arc::new(OllamaClient::with_http_client(
-                base,
-                entry.model,
-                guarded_http,
-            ));
-            build(client)
-        }
-        "anthropic" => {
-            let built: Result<Arc<dyn LlmClient>, _> = if let Some(key) = secret_value.as_ref() {
-                Ok(Arc::new(AnthropicClient::from_secret_string_with_http(
-                    key,
-                    entry.model.clone(),
-                    entry.base_url.clone(),
-                    guarded_http,
-                )))
-            } else {
-                AnthropicClient::from_agent_credentials_with_http(
-                    &profile.inner.name,
-                    entry.model.clone(),
-                    guarded_http,
-                )
-                .await
-                .map(|c| Arc::new(c) as Arc<dyn LlmClient>)
-            };
-            match built {
-                Ok(client) => build(client),
-                Err(e) => {
+    // MUR_HOME-aware home dir — same expression as `prepare_runtime`/`supervisor.rs`
+    // (the old inline "local"-arm recompute below ignored MUR_HOME; unifying on
+    // this shared value is a disclosed, intentional bug-fix — see task-7-report.md).
+    let mur_home = std::env::var_os("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"));
+
+    // Model-switch: load the global config, resolve the ordered candidate refs
+    // (per-agent overrides global) and decide single-client vs routing-aware
+    // fallback chain. With no `models:` config and no per-agent chain/routing,
+    // `refs.len() <= 1 && !routing.enabled` — the exact single-model path below
+    // runs unchanged (byte-for-byte with the pre-Task-7 behaviour).
+    let switch_cfg =
+        mur_common::config::Config::load_or_default(&mur_home.join("config.yaml")).models;
+    let routing = profile
+        .inner
+        .routing
+        .clone()
+        .unwrap_or_else(|| switch_cfg.routing.clone());
+    let refs = mur_common::model::resolve_model_refs(&profile.inner, &switch_cfg, None);
+
+    if refs.len() <= 1 && !routing.enabled {
+        // Nothing configured (no chain, no routing) → today's exact single-model
+        // path on the SAME `entry` resolved above via `resolve_model_entry`, no
+        // FallbackLlmClient wrapper.
+        return Ok(match build_client_from_entry(&entry, profile, &mur_home) {
+            Ok(client) => build(client),
+            Err(e) => match entry.provider.as_str() {
+                "anthropic" => {
                     warn!(error = %e, "anthropic client unavailable; falling back to echo");
                     (
                         Arc::new(TaskRunner::new_stub_echo()),
@@ -395,28 +336,7 @@ pub async fn build_provider_runner(
                         Some(pool.clone()),
                     )
                 }
-            }
-        }
-        "openai" => {
-            let built: Result<Arc<dyn LlmClient>, _> = if let Some(key) = secret_value.as_ref() {
-                Ok(Arc::new(OpenAiClient::from_secret_string_with_http(
-                    key,
-                    entry.model.clone(),
-                    entry.base_url.clone(),
-                    guarded_http,
-                )))
-            } else {
-                OpenAiClient::from_agent_credentials_with_http(
-                    &profile.inner.name,
-                    entry.model.clone(),
-                    guarded_http,
-                )
-                .await
-                .map(|c| Arc::new(c) as Arc<dyn LlmClient>)
-            };
-            match built {
-                Ok(client) => build(client),
-                Err(e) => {
+                "openai" => {
                     warn!(error = %e, "openai client unavailable; falling back to echo");
                     (
                         Arc::new(TaskRunner::new_stub_echo()),
@@ -424,35 +344,197 @@ pub async fn build_provider_runner(
                         Some(pool.clone()),
                     )
                 }
+                "echo" => {
+                    // Intentional fallback: model resolution failed or the agent has no
+                    // model configured. Degrade to echo (warned at resolution time).
+                    (
+                        Arc::new(TaskRunner::new_stub_echo()),
+                        None,
+                        Some(pool.clone()),
+                    )
+                }
+                other => {
+                    // A real provider was configured but this runtime ships no client for
+                    // it (e.g. `deepseek`). Do NOT silently echo — that looks alive but
+                    // parrots input. Surface the misconfiguration in the logs AND in every
+                    // chat reply so the user sees exactly what to change.
+                    let msg = format!(
+                        "⚠️ This agent's model provider '{other}' is not supported by the \
+                         MUR runtime (supported: local, ollama, anthropic, openai). \
+                         Update the agent's model to a supported provider in ~/.mur/models.yaml."
+                    );
+                    error!(provider = %other, "unsupported model provider — replying with misconfiguration notice instead of echo");
+                    (
+                        Arc::new(TaskRunner::new_stub_misconfigured(msg)),
+                        None,
+                        Some(pool.clone()),
+                    )
+                }
+            },
+        });
+    }
+
+    // Chain and/or routing configured → routing-aware fallback client.
+    // Reusable per-ref client builder: model_ref -> Arc<dyn LlmClient>.
+    // Reuses a fresh registry lookup (resolve_model_entry keys off
+    // profile.model_ref; here we resolve an explicit candidate ref) +
+    // build_client_from_entry (Step 1). Send + Sync: captures only a cloned
+    // Profile and a cloned PathBuf.
+    let profile_for_chain = profile.clone();
+    let mur_home_for_chain = mur_home.clone();
+    let build_one = move |model_ref: &str| -> anyhow::Result<Arc<dyn LlmClient>> {
+        let reg = mur_common::model::ModelRegistry::load_from(
+            &mur_common::model::ModelRegistry::default_path()?,
+        )?;
+        let candidate_entry = reg
+            .models
+            .get(model_ref)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("model_ref {model_ref:?} not in registry"))?;
+        build_client_from_entry(&candidate_entry, &profile_for_chain, &mur_home_for_chain)
+    };
+    let fallback_client: Arc<dyn LlmClient> =
+        Arc::new(crate::llm::fallback::FallbackLlmClient::new_routed(
+            profile.inner.clone(),
+            switch_cfg.clone(),
+            Box::new(build_one),
+            switch_cfg.retry.clone(),
+        ));
+    Ok(build(fallback_client))
+}
+
+/// Build the `Arc<dyn LlmClient>` for a single resolved model entry: secret
+/// resolution + guarded HTTP client + provider dispatch. Pure and synchronous
+/// (uses `SecretRef::resolve_blocking` / the `block_on` helper below instead
+/// of `.await`) so it can double as a `ClientFactory` for fallback-chain
+/// candidates, which are built from inside a synchronous closure. `Err`
+/// covers "echo" (deliberate placeholder — never has a real client) and
+/// unsupported providers; callers reconstruct the differentiated stub/log
+/// behaviour for those on `Err` (see `build_provider_runner` above).
+fn build_client_from_entry(
+    entry: &ModelEntry,
+    profile: &Profile,
+    mur_home: &Path,
+) -> anyhow::Result<Arc<dyn LlmClient>> {
+    let secret_value: Option<secrecy::SecretString> = match &entry.secret {
+        Some(s) => match s.resolve_blocking() {
+            Ok(v) => Some(v),
+            Err(e) => {
+                warn!(error = %e, "secret resolution failed; falling back to echo");
+                None
+            }
+        },
+        None => None,
+    };
+
+    let outbound = &profile.inner.entitlements.network.outbound;
+    let host_guard = match outbound.mode {
+        NetworkOutboundMode::Unrestricted => HostGuard::unrestricted(),
+        NetworkOutboundMode::Restricted | NetworkOutboundMode::ProxyOnly => {
+            // Auto-allow the agent's configured LLM provider host: choosing a
+            // provider implies permission to reach it, so the user never has to
+            // `mur agent perm allow-host` their own model endpoint. Mirrors the
+            // loopback-port auto-grant for local models (`local_llm_port`).
+            // ProxyOnly shares this host governance with Restricted — it still
+            // needs to resolve its own LLM endpoint; it just loses general TCP
+            // egress at the OS sandbox layer.
+            let mut hosts = outbound.allow_hosts.clone();
+            if let Some(h) = provider_host(entry)
+                && !hosts.iter().any(|x| x == &h)
+            {
+                hosts.push(h);
+            }
+            HostGuard::restricted(hosts)
+        }
+        NetworkOutboundMode::Off => HostGuard::off(),
+    };
+    let guarded_http = reqwest::ClientBuilder::new()
+        .dns_resolver(std::sync::Arc::new(host_guard))
+        .build()
+        .context("failed to build guarded HTTP client")?;
+
+    match entry.provider.as_str() {
+        "local" => {
+            let base = resolve_local_base_url(
+                entry.base_url.as_deref(),
+                std::env::var("MUR_LOCAL_LLM_BASE_URL").ok(),
+                mur_home,
+            );
+            let key = secrecy::SecretString::from(LOCAL_LLM_PLACEHOLDER_KEY.to_string());
+            Ok(Arc::new(OpenAiClient::from_secret_string_with_http(
+                &key,
+                entry.model.clone(),
+                Some(base),
+                guarded_http,
+            )))
+        }
+        "ollama" => {
+            let base = entry.base_url.clone().unwrap_or_else(|| {
+                std::env::var("OLLAMA_BASE_URL")
+                    .unwrap_or_else(|_| "http://127.0.0.1:11434".to_string())
+            });
+            Ok(Arc::new(OllamaClient::with_http_client(
+                base,
+                entry.model.clone(),
+                guarded_http,
+            )))
+        }
+        "anthropic" => {
+            if let Some(key) = secret_value.as_ref() {
+                Ok(Arc::new(AnthropicClient::from_secret_string_with_http(
+                    key,
+                    entry.model.clone(),
+                    entry.base_url.clone(),
+                    guarded_http,
+                )))
+            } else {
+                block_on(AnthropicClient::from_agent_credentials_with_http(
+                    &profile.inner.name,
+                    entry.model.clone(),
+                    guarded_http,
+                ))
+                .map(|c| Arc::new(c) as Arc<dyn LlmClient>)
+                .map_err(anyhow::Error::from)
             }
         }
-        "echo" => {
-            // Intentional fallback: model resolution failed or the agent has no
-            // model configured. Degrade to echo (warned at resolution time).
-            (
-                Arc::new(TaskRunner::new_stub_echo()),
-                None,
-                Some(pool.clone()),
-            )
+        "openai" => {
+            if let Some(key) = secret_value.as_ref() {
+                Ok(Arc::new(OpenAiClient::from_secret_string_with_http(
+                    key,
+                    entry.model.clone(),
+                    entry.base_url.clone(),
+                    guarded_http,
+                )))
+            } else {
+                block_on(OpenAiClient::from_agent_credentials_with_http(
+                    &profile.inner.name,
+                    entry.model.clone(),
+                    guarded_http,
+                ))
+                .map(|c| Arc::new(c) as Arc<dyn LlmClient>)
+                .map_err(anyhow::Error::from)
+            }
         }
-        other => {
-            // A real provider was configured but this runtime ships no client for
-            // it (e.g. `deepseek`). Do NOT silently echo — that looks alive but
-            // parrots input. Surface the misconfiguration in the logs AND in every
-            // chat reply so the user sees exactly what to change.
-            let msg = format!(
-                "⚠️ This agent's model provider '{other}' is not supported by the \
-                 MUR runtime (supported: local, ollama, anthropic, openai). \
-                 Update the agent's model to a supported provider in ~/.mur/models.yaml."
-            );
-            error!(provider = %other, "unsupported model provider — replying with misconfiguration notice instead of echo");
-            (
-                Arc::new(TaskRunner::new_stub_misconfigured(msg)),
-                None,
-                Some(pool.clone()),
-            )
-        }
-    })
+        "echo" => Err(anyhow::anyhow!("no model configured (echo placeholder)")),
+        other => Err(anyhow::anyhow!("unsupported model provider {other:?}")),
+    }
+}
+
+/// Block the current thread on a future from a synchronous context — needed
+/// because `ClientFactory` (the fallback chain's per-candidate builder type)
+/// is synchronous but credential resolution here is async. Mirrors
+/// `SecretRef::resolve_blocking`'s pattern: `block_in_place` under the
+/// current runtime handle (this crate's `#[tokio::main]` is multi-thread, see
+/// `main.rs`), else a scratch current-thread runtime.
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    match tokio::runtime::Handle::try_current() {
+        Ok(h) => tokio::task::block_in_place(|| h.block_on(fut)),
+        Err(_) => tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build scratch runtime")
+            .block_on(fut),
+    }
 }
 
 /// Telemetry writer + notification routing + hook chain + skills loaded once at boot.

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -1419,6 +1419,12 @@ pub struct FederationConfig {
     pub evidence_flush_interval_minutes: u32,
 }
 
+impl Default for AgentProfile {
+    fn default() -> Self {
+        Self::default_for_tests()
+    }
+}
+
 impl AgentProfile {
     /// Minimal valid profile for tests — no voice, no MCP, no skills.
     ///

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -1419,12 +1419,6 @@ pub struct FederationConfig {
     pub evidence_flush_interval_minutes: u32,
 }
 
-impl Default for AgentProfile {
-    fn default() -> Self {
-        Self::default_for_tests()
-    }
-}
-
 impl AgentProfile {
     /// Minimal valid profile for tests — no voice, no MCP, no skills.
     ///

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -64,6 +64,14 @@ pub struct AgentProfile {
     /// prefers the registry entry over the inline `model:` block.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_ref: Option<String>,
+    /// Per-agent fallback chain (ordered model_refs). Overrides the global
+    /// `models.fallback_chain` when non-empty. See the model-switch spec.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fallback_chain: Vec<String>,
+    /// Per-agent difficulty-routing override. Inherits the global
+    /// `models.routing` when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing: Option<crate::config::RoutingConfig>,
     #[serde(default)]
     pub mcp_servers: Vec<McpServerEntry>,
     #[serde(default)]
@@ -1620,6 +1628,45 @@ mod model_ref_tests {
         assert!(s.contains("model_ref: anthropic_opus_4_7"), "yaml: {s}");
         let p2: AgentProfile = serde_yaml_ng::from_str(&s).unwrap();
         assert_eq!(p2.model_ref.as_deref(), Some("anthropic_opus_4_7"));
+    }
+
+    #[test]
+    fn per_agent_fallback_and_routing_optional_and_legacy_safe() {
+        // Load fixture (no fallback_chain / routing) — legacy safe.
+        let yaml = include_str!("../tests/fixtures/profile_p0a_minimal.yaml");
+        let p: AgentProfile = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(
+            p.fallback_chain.is_empty(),
+            "legacy profile must have empty fallback_chain"
+        );
+        assert!(
+            p.routing.is_none(),
+            "legacy profile must have no routing override"
+        );
+
+        // Round-trip with fallback_chain and routing.
+        let mut p = p.clone();
+        p.fallback_chain = vec!["claude_opus".into(), "claude_sonnet".into()];
+        p.routing = Some(crate::config::RoutingConfig {
+            enabled: true,
+            ..Default::default()
+        });
+        let s = serde_yaml_ng::to_string(&p).unwrap();
+        assert!(
+            s.contains("fallback_chain:"),
+            "yaml must contain fallback_chain"
+        );
+        assert!(s.contains("routing:"), "yaml must contain routing");
+        let p2: AgentProfile = serde_yaml_ng::from_str(&s).unwrap();
+        assert_eq!(
+            p2.fallback_chain,
+            vec!["claude_opus", "claude_sonnet"],
+            "fallback_chain must round-trip"
+        );
+        assert!(
+            p2.routing.as_ref().unwrap().enabled,
+            "routing.enabled must round-trip"
+        );
     }
 }
 

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -60,7 +60,7 @@ impl Default for RetryConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 pub struct RoutingConfig {
     #[serde(default)]
     pub enabled: bool,

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -14,9 +14,15 @@ pub const DEFAULT_BACKOFF_BASE_MS: u64 = 500;
 pub const DEFAULT_COOLDOWN_SECS: u64 = 60;
 pub const DEFAULT_ROUTING_THRESHOLD: u32 = 2000;
 
-fn default_max_retries() -> u32 { DEFAULT_MAX_RETRIES }
-fn default_backoff_base_ms() -> u64 { DEFAULT_BACKOFF_BASE_MS }
-fn default_cooldown_secs() -> u64 { DEFAULT_COOLDOWN_SECS }
+fn default_max_retries() -> u32 {
+    DEFAULT_MAX_RETRIES
+}
+fn default_backoff_base_ms() -> u64 {
+    DEFAULT_BACKOFF_BASE_MS
+}
+fn default_cooldown_secs() -> u64 {
+    DEFAULT_COOLDOWN_SECS
+}
 
 /// Config-layered model selection + failure fallback. See
 /// docs/superpowers/specs/2026-07-12-intelligent-model-switch-design.md.
@@ -2195,7 +2201,10 @@ mod model_switch_config_tests {
         let yaml = "models:\n  default: claude_sonnet\n  fallback_chain: [claude_sonnet, deepseek_v4_pro]\n  routing:\n    enabled: true\n    cheap: deepseek_v4_flash\n    frontier: claude_opus\n    threshold_input_tokens: 1500\n";
         let cfg: Config = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(cfg.models.default.as_deref(), Some("claude_sonnet"));
-        assert_eq!(cfg.models.fallback_chain, vec!["claude_sonnet", "deepseek_v4_pro"]);
+        assert_eq!(
+            cfg.models.fallback_chain,
+            vec!["claude_sonnet", "deepseek_v4_pro"]
+        );
         assert!(cfg.models.routing.enabled);
         assert_eq!(cfg.models.routing.threshold_input_tokens, Some(1500));
     }

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -9,6 +9,63 @@ pub const DEFAULT_LOCAL_LLM_MODEL: &str = "qwen3.5:4b";
 /// behavioural constant baked into logic.
 pub const DEFAULT_BUNDLED_MODEL_ID: &str = "Qwen3.5-2B-MLX-4bit";
 
+pub const DEFAULT_MAX_RETRIES: u32 = 1;
+pub const DEFAULT_BACKOFF_BASE_MS: u64 = 500;
+pub const DEFAULT_COOLDOWN_SECS: u64 = 60;
+pub const DEFAULT_ROUTING_THRESHOLD: u32 = 2000;
+
+fn default_max_retries() -> u32 { DEFAULT_MAX_RETRIES }
+fn default_backoff_base_ms() -> u64 { DEFAULT_BACKOFF_BASE_MS }
+fn default_cooldown_secs() -> u64 { DEFAULT_COOLDOWN_SECS }
+
+/// Config-layered model selection + failure fallback. See
+/// docs/superpowers/specs/2026-07-12-intelligent-model-switch-design.md.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ModelSwitchConfig {
+    /// Global default model_ref when an agent has no `model_ref`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+    /// Global fallback chain (ordered model_refs).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fallback_chain: Vec<String>,
+    #[serde(default)]
+    pub retry: RetryConfig,
+    #[serde(default)]
+    pub routing: RoutingConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetryConfig {
+    #[serde(default = "default_max_retries")]
+    pub max_retries: u32,
+    #[serde(default = "default_backoff_base_ms")]
+    pub backoff_base_ms: u64,
+    #[serde(default = "default_cooldown_secs")]
+    pub cooldown_secs: u64,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: DEFAULT_MAX_RETRIES,
+            backoff_base_ms: DEFAULT_BACKOFF_BASE_MS,
+            cooldown_secs: DEFAULT_COOLDOWN_SECS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RoutingConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cheap: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frontier: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub threshold_input_tokens: Option<u32>,
+}
+
 /// Global MUR configuration (~/.mur/config.yaml)
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
@@ -17,6 +74,9 @@ pub struct Config {
 
     #[serde(default)]
     pub llm: LlmConfig,
+
+    #[serde(default)]
+    pub models: ModelSwitchConfig,
 
     #[serde(default)]
     pub retrieval: RetrievalConfig,
@@ -2113,5 +2173,30 @@ mod cc_proxy_cfg_tests {
         let cfg: Config = serde_yaml_ng::from_str("cc_proxy:\n  enabled: false\n").unwrap();
         assert_eq!(cfg.cc_proxy.url, "http://127.0.0.1:8088");
         assert!(!cfg.cc_proxy.enabled);
+    }
+}
+
+#[cfg(test)]
+mod model_switch_config_tests {
+    use super::*;
+
+    #[test]
+    fn model_switch_config_defaults_and_omitted_block() {
+        // Omitted `models:` block deserializes to defaults.
+        let cfg: Config = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.models.default, None);
+        assert!(cfg.models.fallback_chain.is_empty());
+        assert_eq!(cfg.models.retry.max_retries, DEFAULT_MAX_RETRIES);
+        assert_eq!(cfg.models.retry.backoff_base_ms, DEFAULT_BACKOFF_BASE_MS);
+        assert_eq!(cfg.models.retry.cooldown_secs, DEFAULT_COOLDOWN_SECS);
+        assert!(!cfg.models.routing.enabled);
+
+        // A populated block round-trips.
+        let yaml = "models:\n  default: claude_sonnet\n  fallback_chain: [claude_sonnet, deepseek_v4_pro]\n  routing:\n    enabled: true\n    cheap: deepseek_v4_flash\n    frontier: claude_opus\n    threshold_input_tokens: 1500\n";
+        let cfg: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.models.default.as_deref(), Some("claude_sonnet"));
+        assert_eq!(cfg.models.fallback_chain, vec!["claude_sonnet", "deepseek_v4_pro"]);
+        assert!(cfg.models.routing.enabled);
+        assert_eq!(cfg.models.routing.threshold_input_tokens, Some(1500));
     }
 }

--- a/mur-common/src/model.rs
+++ b/mur-common/src/model.rs
@@ -567,7 +567,7 @@ mod switch_tests {
     use crate::config::{ModelSwitchConfig, RoutingConfig};
 
     fn profile(model_ref: Option<&str>, chain: &[&str]) -> AgentProfile {
-        let mut p = AgentProfile::default();
+        let mut p = AgentProfile::default_for_tests();
         p.model_ref = model_ref.map(|s| s.to_string());
         p.fallback_chain = chain.iter().map(|s| s.to_string()).collect();
         p

--- a/mur-common/src/model.rs
+++ b/mur-common/src/model.rs
@@ -156,6 +156,55 @@ impl ModelRegistry {
     }
 }
 
+use crate::agent::AgentProfile;
+use crate::config::{DEFAULT_ROUTING_THRESHOLD, ModelSwitchConfig, RoutingConfig};
+
+/// Build the ordered list of model_refs to try: `[primary, ...fallback]`.
+/// Priority per-agent → global. The primary is de-duplicated out of the chain
+/// (no point retrying the same ref back-to-back). Returns empty when nothing is
+/// configured, so the caller keeps today's single-inline-model behaviour.
+pub fn resolve_model_refs(
+    profile: &AgentProfile,
+    cfg: &ModelSwitchConfig,
+    routed_primary: Option<String>,
+) -> Vec<String> {
+    let primary = routed_primary
+        .or_else(|| profile.model_ref.clone())
+        .or_else(|| cfg.default.clone());
+    let chain = if !profile.fallback_chain.is_empty() {
+        profile.fallback_chain.clone()
+    } else {
+        cfg.fallback_chain.clone()
+    };
+    let mut out: Vec<String> = Vec::new();
+    if let Some(p) = primary {
+        out.push(p);
+    }
+    for r in chain {
+        if !out.contains(&r) {
+            out.push(r);
+        }
+    }
+    out
+}
+
+/// Opt-in difficulty heuristic: pick `frontier` when the estimated input token
+/// count exceeds the threshold, else `cheap`. `None` when misconfigured (caller
+/// falls through to model_ref/global default).
+pub fn choose_by_difficulty(est_input_tokens: u32, r: &RoutingConfig) -> Option<String> {
+    let threshold = r
+        .threshold_input_tokens
+        .unwrap_or(DEFAULT_ROUTING_THRESHOLD);
+    match (r.cheap.as_ref(), r.frontier.as_ref()) {
+        (Some(cheap), Some(frontier)) => Some(if est_input_tokens > threshold {
+            frontier.clone()
+        } else {
+            cheap.clone()
+        }),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -508,5 +557,89 @@ mod io_tests {
         ModelRegistry::default().save_to(&p).unwrap();
         let temp = dir.path().join("models.yaml.tmp");
         assert!(!temp.exists(), "atomic temp left behind");
+    }
+}
+
+#[cfg(test)]
+mod switch_tests {
+    use super::*;
+    use crate::agent::AgentProfile;
+    use crate::config::{ModelSwitchConfig, RoutingConfig};
+
+    fn profile(model_ref: Option<&str>, chain: &[&str]) -> AgentProfile {
+        let mut p = AgentProfile::default();
+        p.model_ref = model_ref.map(|s| s.to_string());
+        p.fallback_chain = chain.iter().map(|s| s.to_string()).collect();
+        p
+    }
+
+    #[test]
+    fn per_agent_primary_and_chain_win_over_global() {
+        let cfg = ModelSwitchConfig {
+            default: Some("global_default".into()),
+            fallback_chain: vec!["g1".into(), "g2".into()],
+            ..Default::default()
+        };
+        let p = profile(Some("agent_primary"), &["agent_primary", "agent_fb"]);
+        // per-agent model_ref is primary; per-agent chain used; primary de-duped.
+        assert_eq!(
+            resolve_model_refs(&p, &cfg, None),
+            vec!["agent_primary", "agent_fb"]
+        );
+    }
+
+    #[test]
+    fn falls_back_to_global_default_and_chain() {
+        let cfg = ModelSwitchConfig {
+            default: Some("global_default".into()),
+            fallback_chain: vec!["g1".into(), "global_default".into()],
+            ..Default::default()
+        };
+        let p = profile(None, &[]); // no per-agent model_ref or chain
+        // primary = global default; global chain used; primary de-duped out.
+        assert_eq!(
+            resolve_model_refs(&p, &cfg, None),
+            vec!["global_default", "g1"]
+        );
+    }
+
+    #[test]
+    fn routed_primary_overrides_model_ref() {
+        let cfg = ModelSwitchConfig {
+            fallback_chain: vec!["g1".into()],
+            ..Default::default()
+        };
+        let p = profile(Some("agent_primary"), &[]);
+        assert_eq!(
+            resolve_model_refs(&p, &cfg, Some("frontier".into())),
+            vec!["frontier", "g1"]
+        );
+    }
+
+    #[test]
+    fn no_config_no_agent_yields_empty() {
+        // Nothing configured → empty vec (caller falls back to inline model).
+        let cfg = ModelSwitchConfig::default();
+        assert!(resolve_model_refs(&profile(None, &[]), &cfg, None).is_empty());
+    }
+
+    #[test]
+    fn difficulty_picks_frontier_over_threshold() {
+        let r = RoutingConfig {
+            enabled: true,
+            cheap: Some("cheap".into()),
+            frontier: Some("frontier".into()),
+            threshold_input_tokens: Some(1000),
+        };
+        assert_eq!(choose_by_difficulty(1500, &r), Some("frontier".into()));
+        assert_eq!(choose_by_difficulty(500, &r), Some("cheap".into()));
+        // Misconfigured (missing frontier) → None (fall through).
+        let bad = RoutingConfig {
+            enabled: true,
+            cheap: Some("c".into()),
+            frontier: None,
+            threshold_input_tokens: None,
+        };
+        assert_eq!(choose_by_difficulty(9999, &bad), None);
     }
 }

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -82,6 +82,18 @@ pub enum AgentAction {
         /// New name
         new: String,
     },
+    /// Set this agent's fallback chain of model_refs, tried in order after
+    /// the primary model fails. Overrides the global `models.fallback_chain`
+    /// (`mur model fallback`) when non-empty. Pass no refs to clear it.
+    /// Each ref must already exist in `~/.mur/models.yaml`.
+    Fallback {
+        /// Agent name
+        name: String,
+        /// Ordered registry keys, tried after the primary fails. Omit to
+        /// clear the chain.
+        #[arg(num_args = 0..)]
+        model_refs: Vec<String>,
+    },
     /// Dial an agent's Unix socket and issue A2A `message/send`
     Send {
         /// Agent name

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -129,6 +129,8 @@ pub fn cmd_create(
             params: BTreeMap::new(),
         },
         model_ref: resolved_model_ref,
+        fallback_chain: Vec::new(),
+        routing: None,
         mcp_servers: vec![],
         skills: vec![],
         transport: TransportConfig {

--- a/mur-core/src/cmd/agent/model_resolve.rs
+++ b/mur-core/src/cmd/agent/model_resolve.rs
@@ -99,6 +99,48 @@ pub fn apply_model_choice(mur_home: &Path, slug: &str, choice: &ModelChoice) -> 
     Ok(key)
 }
 
+/// Fail-closed guard shared with the global `mur model default`/`fallback`
+/// setters (`cmd/model.rs`): reject any model_ref that isn't already
+/// registered in `<home>/models.yaml`.
+fn ensure_ref_exists(home: &Path, r: &str) -> Result<()> {
+    let reg = ModelRegistry::load_from(&home.join("models.yaml"))?;
+    anyhow::ensure!(
+        reg.models.contains_key(r),
+        "model_ref {r:?} not in models.yaml"
+    );
+    Ok(())
+}
+
+/// Set an agent's per-agent fallback chain (`profile.fallback_chain`),
+/// which takes priority over the global `models.fallback_chain` when
+/// non-empty (see `mur_common::model::resolve_model_refs`). Each ref is
+/// validated against `<home>/models.yaml` before the profile is written
+/// (fail-closed — an unknown ref leaves the profile untouched).
+pub fn cmd_agent_set_fallback(home: &Path, name: &str, refs: &[String]) -> Result<()> {
+    for r in refs {
+        ensure_ref_exists(home, r)?;
+    }
+
+    let profile_path = home.join("agents").join(name).join("profile.yaml");
+    if !profile_path.exists() {
+        bail!("agent '{name}' not installed at {}", profile_path.display());
+    }
+    let mut profile: mur_common::AgentProfile =
+        serde_yaml_ng::from_str(&std::fs::read_to_string(&profile_path)?)
+            .with_context(|| format!("parse {}", profile_path.display()))?;
+    profile.fallback_chain = refs.to_vec();
+    let yaml = serde_yaml_ng::to_string(&profile)?;
+    std::fs::write(&profile_path, yaml)
+        .with_context(|| format!("write {}", profile_path.display()))?;
+
+    if refs.is_empty() {
+        println!("agent '{name}' fallback chain cleared");
+    } else {
+        println!("agent '{name}' fallback chain = {}", refs.join(", "));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -150,5 +192,44 @@ mod tests {
             serde_yaml_ng::from_str(&std::fs::read_to_string(home.join("profile.yaml")).unwrap())
                 .unwrap();
         assert_eq!(reloaded.model_ref.as_deref(), Some("ollama_llama3_2_3b"));
+    }
+
+    #[test]
+    fn set_fallback_validates_refs_and_persists_to_profile() {
+        use mur_common::model::ModelEntry;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mur_home = tmp.path().to_path_buf();
+        let agent_home = mur_home.join("agents").join("coach");
+        std::fs::create_dir_all(&agent_home).unwrap();
+        let p = mur_common::AgentProfile::default_for_tests();
+        std::fs::write(
+            agent_home.join("profile.yaml"),
+            serde_yaml_ng::to_string(&p).unwrap(),
+        )
+        .unwrap();
+
+        let mut reg = ModelRegistry::default();
+        reg.models.insert(
+            "claude_sonnet".into(),
+            ModelEntry {
+                provider: "anthropic".into(),
+                model: "claude-sonnet-5".into(),
+                ..Default::default()
+            },
+        );
+        reg.save_to(&mur_home.join("models.yaml")).unwrap();
+
+        // Unknown ref → fail-closed, profile untouched.
+        assert!(
+            cmd_agent_set_fallback(&mur_home, "coach", &["does_not_exist".to_string()]).is_err()
+        );
+
+        cmd_agent_set_fallback(&mur_home, "coach", &["claude_sonnet".to_string()]).unwrap();
+        let reloaded: mur_common::AgentProfile = serde_yaml_ng::from_str(
+            &std::fs::read_to_string(agent_home.join("profile.yaml")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(reloaded.fallback_chain, vec!["claude_sonnet".to_string()]);
     }
 }

--- a/mur-core/src/cmd/agent_companion/connector.rs
+++ b/mur-core/src/cmd/agent_companion/connector.rs
@@ -543,6 +543,8 @@ pub(crate) async fn scaffold_stub_bridge(name: &str, default_route: &str) -> Res
             params: std::collections::BTreeMap::new(),
         },
         model_ref: None,
+        fallback_chain: Vec::new(),
+        routing: None,
         mcp_servers: vec![],
         skills: vec![],
         transport: TransportConfig {

--- a/mur-core/src/cmd/model.rs
+++ b/mur-core/src/cmd/model.rs
@@ -1,5 +1,7 @@
 //! `mur model` subcommands — manage entries in `~/.mur/models.yaml`.
 
+use std::path::Path;
+
 use anyhow::Context;
 use chrono::Utc;
 use clap::{Args, Subcommand};
@@ -80,6 +82,22 @@ pub enum ModelCmd {
     Prices {
         #[command(subcommand)]
         sub: PricesSubCmd,
+    },
+    /// Set the global default model_ref (config.yaml `models.default`).
+    /// Used when a profile has no `model_ref`/`model` set. The ref must
+    /// already exist in `~/.mur/models.yaml` (fail-closed).
+    Default {
+        /// Registry key from `~/.mur/models.yaml` (e.g. claude_sonnet)
+        model_ref: String,
+    },
+    /// Set the global fallback chain (config.yaml `models.fallback_chain`),
+    /// tried in order after the primary model fails. Pass no refs to clear
+    /// the chain. Each ref must already exist in `~/.mur/models.yaml`.
+    Fallback {
+        /// Ordered registry keys, tried after the primary fails. Omit to
+        /// clear the chain.
+        #[arg(num_args = 0..)]
+        model_refs: Vec<String>,
     },
 }
 
@@ -291,6 +309,12 @@ pub fn run(args: ModelArgs) -> anyhow::Result<()> {
         ModelCmd::Prices { sub } => {
             let mur_home = path.parent().map(|p| p.to_path_buf()).unwrap_or_default();
             cmd_prices(sub, &mur_home, &reg)?;
+        }
+        ModelCmd::Default { model_ref } => {
+            cmd_model_default(&crate::cmd::agent::resolve_mur_home()?, &model_ref)?
+        }
+        ModelCmd::Fallback { model_refs } => {
+            cmd_model_fallback(&crate::cmd::agent::resolve_mur_home()?, &model_refs)?
         }
     }
     Ok(())
@@ -588,5 +612,114 @@ fn parse_route_policy(raw: &str) -> anyhow::Result<RoutePolicy> {
             "invalid route policy: {other}. Valid: auto, prefer-local, force-local, \
              force-frontier:<model-id>"
         ),
+    }
+}
+
+/// Fail-closed guard: reject any model_ref that isn't already registered in
+/// `<home>/models.yaml`. Used by both the global (`mur model default` /
+/// `fallback`) and per-agent (`mur agent fallback`) setters so a typo'd ref
+/// can never be silently persisted.
+fn ensure_ref_exists(home: &Path, r: &str) -> anyhow::Result<()> {
+    let reg = ModelRegistry::load_from(&home.join("models.yaml"))?;
+    anyhow::ensure!(
+        reg.models.contains_key(r),
+        "model_ref {r:?} not in models.yaml"
+    );
+    Ok(())
+}
+
+/// Set the global default model_ref (`config.yaml` `models.default`).
+pub fn cmd_model_default(home: &Path, model_ref: &str) -> anyhow::Result<()> {
+    ensure_ref_exists(home, model_ref)?;
+    let mut cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+    cfg.models.default = Some(model_ref.to_string());
+    crate::store::config::save_config_at(&home.join("config.yaml"), &cfg)?;
+    println!("global default model = {model_ref}");
+    Ok(())
+}
+
+/// Set the global fallback chain (`config.yaml` `models.fallback_chain`).
+/// An empty slice clears the chain.
+pub fn cmd_model_fallback(home: &Path, refs: &[String]) -> anyhow::Result<()> {
+    for r in refs {
+        ensure_ref_exists(home, r)?;
+    }
+    let mut cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+    cfg.models.fallback_chain = refs.to_vec();
+    crate::store::config::save_config_at(&home.join("config.yaml"), &cfg)?;
+    println!("global fallback chain = {}", refs.join(", "));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_default_validates_ref_exists() {
+        use mur_common::model::{ModelEntry, ModelRegistry};
+        // Temp home with a seeded models.yaml containing `claude_sonnet`.
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        let mut reg = ModelRegistry::default();
+        reg.models.insert(
+            "claude_sonnet".into(),
+            ModelEntry {
+                provider: "anthropic".into(),
+                model: "claude-sonnet-5".into(),
+                ..Default::default()
+            },
+        );
+        reg.save_to(&home.join("models.yaml")).unwrap();
+
+        // Unknown ref → error (fail-closed); known ref → persisted to config.yaml.
+        assert!(cmd_model_default(&home, "does_not_exist").is_err());
+        cmd_model_default(&home, "claude_sonnet").unwrap();
+        let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+        assert_eq!(cfg.models.default.as_deref(), Some("claude_sonnet"));
+    }
+
+    #[test]
+    fn set_fallback_validates_all_refs_and_clears_on_empty() {
+        use mur_common::model::{ModelEntry, ModelRegistry};
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().to_path_buf();
+        let mut reg = ModelRegistry::default();
+        for key in ["claude_sonnet", "deepseek_v4_pro"] {
+            reg.models.insert(
+                key.into(),
+                ModelEntry {
+                    provider: "anthropic".into(),
+                    model: key.into(),
+                    ..Default::default()
+                },
+            );
+        }
+        reg.save_to(&home.join("models.yaml")).unwrap();
+
+        // One unknown ref in the chain → whole call fails, nothing persisted.
+        assert!(
+            cmd_model_fallback(
+                &home,
+                &["claude_sonnet".to_string(), "does_not_exist".to_string()]
+            )
+            .is_err()
+        );
+
+        cmd_model_fallback(
+            &home,
+            &["claude_sonnet".to_string(), "deepseek_v4_pro".to_string()],
+        )
+        .unwrap();
+        let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+        assert_eq!(
+            cfg.models.fallback_chain,
+            vec!["claude_sonnet", "deepseek_v4_pro"]
+        );
+
+        // Empty slice clears the chain.
+        cmd_model_fallback(&home, &[]).unwrap();
+        let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
+        assert!(cfg.models.fallback_chain.is_empty());
     }
 }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1396,6 +1396,13 @@ async fn run_agent(action: AgentAction) -> Result<()> {
         } => cmd::agent::cmd_restart(&names, all, stale, dry_run)?,
         AgentAction::Remove { name, purge, force } => cmd::agent::cmd_remove(&name, purge, force)?,
         AgentAction::Rename { old, new } => cmd::agent::cmd_rename(&old, &new)?,
+        AgentAction::Fallback { name, model_refs } => {
+            cmd::agent::model_resolve::cmd_agent_set_fallback(
+                &cmd::agent::resolve_mur_home()?,
+                &name,
+                &model_refs,
+            )?
+        }
         AgentAction::Send { name, message } => cmd::agent::cmd_send(&name, &message)?,
         AgentAction::Card { name } => cmd::agent::cmd_card(&name)?,
         AgentAction::Cli {

--- a/mur-core/src/store/config.rs
+++ b/mur-core/src/store/config.rs
@@ -71,7 +71,7 @@ pub fn save_config_at(path: &Path, config: &Config) -> Result<()> {
 #   To save cost, switch to Sonnet: llm.model: claude-sonnet-4-6
 
 "#;
-    fs::write(&path, format!("{}{}", header, yaml))?;
+    fs::write(path, format!("{}{}", header, yaml))?;
     Ok(())
 }
 

--- a/mur-core/src/store/config.rs
+++ b/mur-core/src/store/config.rs
@@ -3,7 +3,7 @@
 use anyhow::{Context, Result};
 use mur_common::config::Config;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Load config from ~/.mur/config.yaml, creating defaults if not exists.
 pub fn load_config() -> Result<Config> {
@@ -25,7 +25,14 @@ pub fn load_config() -> Result<Config> {
 
 /// Save config to ~/.mur/config.yaml with helpful comments.
 pub fn save_config(config: &Config) -> Result<()> {
-    let path = config_path();
+    save_config_at(&config_path(), config)
+}
+
+/// Save config to an explicit path (same YAML + header as [`save_config`]).
+/// Exists so callers with an explicit `MUR_HOME` (tests, per-agent CLI
+/// handlers) can persist config without going through the process-global
+/// `MUR_HOME` env var / `dirs::home_dir()` resolution.
+pub fn save_config_at(path: &Path, config: &Config) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }


### PR DESCRIPTION
## Summary

Phase 1 of intelligent model switching: config-layered model selection (global default + per-agent, **priority per-agent → global**) plus automatic failure-fallback chains, an opt-in difficulty heuristic, and the CLI to author it all. Learned/RouteLLM routing and the Hub GUI are deliberately out of scope (later phases).

Grounded in a 2026 deep-research pass (the MUR `deep-research` fleet, ProxyOnly workers, ~\$1.74) that confirmed the industry Phase-1 shape: *per-agent defaults + per-task overrides, heuristic routing + fallback chains first; learned routers later*.

## What's in it

**Config (`mur-common`)**
- `config.yaml` gains a `models:` block — `default`, `fallback_chain`, `retry` (max_retries / backoff_base_ms / cooldown_secs), `routing` (enabled / cheap / frontier / threshold). All defaults are `DEFAULT_*` consts (no hardcoded values).
- `AgentProfile` gains `fallback_chain` + optional `routing` (serde-default, legacy-parse safe).
- Pure `resolve_model_refs` (priority per-agent → global, primary de-duped) + `choose_by_difficulty`.

**Runtime (`mur-agent-runtime`)**
- `LlmError` gains typed `ServerError(u16)` / `InsufficientCredit` + a `from_status` mapper + a `classify` → `Retryability`: **429/5xx/timeout/402 = retryable** (advance the chain); **400/401/malformed = fatal** (return immediately — never fall back, so auth errors are never masked).
- `FallbackLlmClient` — implements the `LlmClient` trait, loops candidates with per-candidate backoff+jitter, an in-memory per-model cooldown circuit-breaker, and per-request opt-in difficulty routing. Drops into the existing `Arc<dyn LlmClient>` slot with no agent-loop change.
- `build_client_from_entry` extracted to `llm/client_builder.rs`. **An unconfigured agent gets exactly today's single client, byte-for-byte.**

**CLI (`mur-core`)**
- `mur model default <ref>` / `mur model fallback <ref>...` (global) and `mur agent fallback <name> <ref>...` (per-agent). Every ref is validated against `models.yaml` before writing (fail-closed).

## Verification

- Green: mur-common (722 tests), mur-agent-runtime (752), mur-core (new CLI tests). fmt clean.
- Real guards for: resolution priority, the retryable/fatal boundary, fallback advance/cooldown/exhaustion, opt-in routing (big→frontier, small→cheap), and fail-closed CLI validation. No existing test weakened.
- Whole-branch review (Opus): READY TO MERGE — the two invariants that most needed to be right (unconfigured-agent byte-for-byte; retryable/fatal never masks auth) are both correct and test-covered.

## Out of scope (follow-ups)

- **Phase 2 — Hub GUI** management (Settings → Models + per-agent picker) — separate plan.
- Learned/RouteLLM routing (cost-router Phase 3).
- Minor follow-ups logged in review: dedupe `ensure_ref_exists`, seed inline-`model:` agents as primary when a global chain is set, registry-read caching in the routed factory.

Spec: `docs/superpowers/specs/2026-07-12-intelligent-model-switch-design.md` · Plan: `docs/superpowers/plans/2026-07-12-intelligent-model-switch-phase1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)