### PR TITLE
fix(hub-ui): model combobox badges crush row body (name painted over badges)

### DIFF
--- a/mur-hub-gui/ui/src/styles/components/detail-panel.css
+++ b/mur-hub-gui/ui/src/styles/components/detail-panel.css
@@ -798,6 +798,9 @@
   font-size: 13px;
   font-weight: 600;
   color: var(--text-primary, #F1F5F9);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .mc-opt__sub {
   font-size: 11px;
@@ -811,7 +814,10 @@
 .mc-badges {
   display: flex;
   gap: 5px;
+  /* flex:none sized this to max-content so flex-wrap never fired and the
+     badges crushed .mc-opt__body to ~0 width (name painted over badges). */
   flex: none;
+  max-width: 55%;
   align-items: center;
   flex-wrap: wrap;
   justify-content: flex-end;


### PR DESCRIPTION
Fixes the broken agent-detail model dropdown layout: badge block (`flex:none`) sized to max-content, crushed `.mc-opt__body` to ~10px — model name painted over the tier badge, sub line truncated to one char, list scrolled horizontally.

Fix: `max-width:55%` on `.mc-badges` so its existing `flex-wrap` engages + ellipsis on `.mc-opt__name`. Verified with a standalone repro at popover width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)