### PR TITLE
feat(compress): JSON deep collapse + generic early skip

### DIFF
--- a/docs/superpowers/plans/2026-07-13-compress-optimization.md
+++ b/docs/superpowers/plans/2026-07-13-compress-optimization.md
@@ -1,0 +1,582 @@
+# Compress Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** JSON deep collapse (nested arrays + long strings, query-aware sampling) and generic early-skip with honest `skipped` stats.
+
+**Architecture:** All changes inside the `mur-compress` crate. Task 1 adds config knobs; Task 2 adds the `skipped` stats counter; Task 3 rewrites the JSON compressor as a recursive tree walk; Task 4 wires the generic pre-scan skip into the engine. Tasks 3 and 4 are independent of each other; both depend on 1–2.
+
+**Tech Stack:** Rust edition 2024, serde_json, existing `bm25::bm25_rank`, `cargo nextest`.
+
+**Spec:** `docs/superpowers/specs/2026-07-13-compress-optimization-design.md`
+
+## Global Constraints
+
+- Single source file ≤ 800 lines.
+- No hardcoded values — new knobs go in `CompressConfig` with serde defaults.
+- Test with `cargo nextest run -p mur-compress` (plain `cargo test --workspace` is flaky in this repo).
+- `mur_retrieve` semantics unchanged: one hash per compressed document, original returned byte-for-byte.
+- Old `stats.json` files must keep deserializing (`#[serde(default)]` on every new field).
+- Commit after every task.
+
+---
+
+### Task 1: Config knobs (`json.max_string_tokens`, `fallback.min_save_ratio`)
+
+**Files:**
+- Modify: `mur-compress/src/config.rs`
+
+**Interfaces:**
+- Produces: `CompressConfig.json: JsonCfg { max_string_tokens: usize }` (default 200); `CompressConfig.fallback: FallbackCfg { min_save_ratio: f32 }` (default 0.05). Later tasks read `ctx.config.json.max_string_tokens` and `config.fallback.min_save_ratio`.
+
+- [ ] **Step 1: Write the failing test** — append to the existing `#[cfg(test)]` module in `config.rs`:
+
+```rust
+#[test]
+fn new_sections_default() {
+    let cfg = CompressConfig::default();
+    assert_eq!(cfg.json.max_string_tokens, 200);
+    assert!((cfg.fallback.min_save_ratio - 0.05).abs() < f32::EPSILON);
+}
+
+#[test]
+fn yaml_without_new_sections_still_loads() {
+    // Simulates an existing user compress.yaml predating these fields.
+    let cfg: CompressConfig = serde_yaml::from_str("enabled: true\n").unwrap();
+    assert_eq!(cfg.json.max_string_tokens, 200);
+    assert!((cfg.fallback.min_save_ratio - 0.05).abs() < f32::EPSILON);
+}
+```
+
+(If `config.rs` has no test module, create one mirroring a sibling's shape. If `serde_yaml` isn't a dev-dependency, check `Cargo.toml`; the crate parses YAML config in `load` so it is a normal dependency already — use whatever the existing `load` tests use.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run -p mur-compress config`
+Expected: FAIL — `no field 'json' on CompressConfig`(compile error counts as the failing state).
+
+- [ ] **Step 3: Implement** — in `config.rs`, next to `DetectCfg`/`StoreCfg` (match their derive/default style exactly):
+
+```rust
+/// `json:` section — knobs for the JSON deep-collapse compressor.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct JsonCfg {
+    /// String leaves whose token count is at/above this get elided
+    /// (head kept, remainder offloaded).
+    pub max_string_tokens: usize,
+}
+
+impl Default for JsonCfg {
+    fn default() -> Self {
+        Self { max_string_tokens: 200 }
+    }
+}
+
+/// `fallback:` section — knobs for the Generic path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FallbackCfg {
+    /// Generic inputs whose exactly-computable savings ratio is below this
+    /// are skipped (passthrough) instead of compressed.
+    pub min_save_ratio: f32,
+}
+
+impl Default for FallbackCfg {
+    fn default() -> Self {
+        Self { min_save_ratio: 0.05 }
+    }
+}
+```
+
+Add to `CompressConfig` (with `#[serde(default)]` like `auto`):
+
+```rust
+    #[serde(default)]
+    pub json: JsonCfg,
+    #[serde(default)]
+    pub fallback: FallbackCfg,
+```
+
+And add `json: JsonCfg::default(), fallback: FallbackCfg::default(),` to `CompressConfig`'s `Default` impl (check how it's written — derive vs manual — and follow it).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run -p mur-compress config`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-compress/src/config.rs
+git commit -m "feat(compress): json/fallback config sections (max_string_tokens, min_save_ratio)"
+```
+
+---
+
+### Task 2: `skipped` stats counter
+
+**Files:**
+- Modify: `mur-compress/src/stats.rs`
+
+**Interfaces:**
+- Consumes: existing `StatsTracker::update` lock-and-merge helper.
+- Produces: `StatsTracker::record_skip(&self, content_type: &str)`; `skipped: u64` on `StatsData`, `BucketData`, `TypeStats`, `StatsSnapshot`. Task 4 calls `record_skip`.
+
+- [ ] **Step 1: Write the failing test** — append to the `#[cfg(test)]` module in `stats.rs`:
+
+```rust
+#[test]
+fn record_skip_counts_separately() {
+    let dir = tempfile::tempdir().unwrap();
+    let t = StatsTracker::new(dir.path().join("stats.json"));
+    t.record_compression("generic", 100, 50);
+    t.record_skip("generic");
+    t.record_skip("generic");
+    let snap = t.snapshot(3.0, 0, 0);
+    assert_eq!(snap.compressions, 1);
+    assert_eq!(snap.skipped, 2);
+    assert_eq!(snap.by_type.get("generic").unwrap().skipped, 2);
+    // compressions untouched by skips
+    assert_eq!(snap.by_type.get("generic").unwrap().compressions, 1);
+}
+
+#[test]
+fn old_stats_json_without_skipped_loads() {
+    let dir = tempfile::tempdir().unwrap();
+    let p = dir.path().join("stats.json");
+    std::fs::write(&p, r#"{"compressions":5,"retrievals":1,"total_input_tokens":10,"total_output_tokens":5,"total_tokens_saved":5}"#).unwrap();
+    let t = StatsTracker::new(p);
+    let snap = t.snapshot(3.0, 0, 0);
+    assert_eq!(snap.compressions, 5);
+    assert_eq!(snap.skipped, 0);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run -p mur-compress stats`
+Expected: FAIL — no `skipped` field / no `record_skip`.
+
+- [ ] **Step 3: Implement**
+
+Add `#[serde(default)] skipped: u64` to `StatsData`, and `#[serde(default)] pub skipped: u64` to `BucketData` and `TypeStats`. Add `pub skipped: u64` to `StatsSnapshot` and populate it in `snapshot()` from the data (mirror how `compressions` flows through).
+
+Add next to `record_retrieval`:
+
+```rust
+    /// Record a deliberate skip (early-skip gate): the input was inspected
+    /// and passed through untouched. Counted separately from compressions
+    /// so by_type ratios reflect real compression work.
+    pub fn record_skip(&self, content_type: &str) {
+        let day = today_key();
+        self.update(|d| {
+            d.skipped += 1;
+            d.buckets
+                .entry(current_version().to_string())
+                .or_default()
+                .entry(day.clone())
+                .or_default()
+                .skipped += 1;
+            d.by_type.entry(content_type.to_string()).or_default().skipped += 1;
+        });
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run -p mur-compress stats`
+Expected: PASS (including the pre-existing stats tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-compress/src/stats.rs
+git commit -m "feat(compress): skipped counter in stats (top-level, bucket, by_type)"
+```
+
+---
+
+### Task 3: JSON deep collapse + string elide + query-aware sampling
+
+**Files:**
+- Modify: `mur-compress/src/compressors/json.rs` (full rewrite of the compress path; keep the module doc style)
+
+**Interfaces:**
+- Consumes: `bm25::bm25_rank(query, &[String]) -> Vec<(usize, f32)>`; `CcrStore::put_original(&self, content, items, ContentType, tok) -> Result<String, _>`; `JsonCfg.max_string_tokens` from Task 1.
+- Produces: same `compress(content, ctx, store, tok) -> Result<CompressOutput, CompressError>` signature (engine dispatch unchanged). New transforms: `json.deep_collapse`, `json.string_elide`.
+
+**Design notes for the implementer:**
+- One hash for the whole original document. The hash isn't known until `put_original`, but notes are written during the walk — so write the sentinel `__MUR_HASH__` into notes during the walk and string-replace it with the real hash after storing. Store only if the walk collapsed anything.
+- `items` passed to `put_original` = every collapsed array element (serialized) plus every elided full string, so query-filtered `mur_retrieve` can BM25 over them.
+- Depth cap 64: below the cap the walk simply stops recursing (nodes deeper than the cap are left untouched); never panic.
+- Elide keeps the head `max_string_tokens * 2` characters (`chars().take`, char-boundary safe; ~2 chars/token is a conservative cross-language ratio).
+
+- [ ] **Step 1: Write the failing tests** — replace the test module additions in `json.rs` (keep the two existing tests; they must still pass):
+
+```rust
+    fn store_and_ctx(cfg: &CompressConfig) -> (tempfile::TempDir, CcrStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
+        (dir, store)
+    }
+
+    #[test]
+    fn collapses_nested_array() {
+        let cfg = CompressConfig { protect_head_lines: 2, ..Default::default() };
+        let (_d, store) = store_and_ctx(&cfg);
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let input = r#"{"ok":true,"results":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6}]}"#;
+        let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.hash.is_some(), "nested array must trigger offload");
+        assert!(out.compressed.contains("_total"));
+        assert!(out.transforms.iter().any(|t| t == "json.deep_collapse"));
+        // retrieve returns the original byte-for-byte
+        let got = store.get(out.hash.as_ref().unwrap()).unwrap().unwrap();
+        assert_eq!(got.original_text, input);
+    }
+
+    #[test]
+    fn elides_long_string_leaf() {
+        let cfg = CompressConfig {
+            json: crate::config::JsonCfg { max_string_tokens: 10 },
+            ..Default::default()
+        };
+        let (_d, store) = store_and_ctx(&cfg);
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let long = "word ".repeat(200);
+        let input = serde_json::json!({"content": long}).to_string();
+        let out = compress(&input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.hash.is_some());
+        assert!(out.transforms.iter().any(|t| t == "json.string_elide"));
+        assert!(out.compressed.len() < input.len() / 2);
+        assert!(out.compressed.contains("elided"));
+    }
+
+    #[test]
+    fn query_picks_relevant_sample() {
+        let cfg = CompressConfig { protect_head_lines: 2, ..Default::default() };
+        let (_d, store) = store_and_ctx(&cfg);
+        let ctx = CompressCtx { query: Some("zebra"), config: &cfg };
+        let mut rows: Vec<serde_json::Value> =
+            (0..10).map(|i| serde_json::json!({"id": i, "name": "common"})).collect();
+        rows.push(serde_json::json!({"id": 99, "name": "zebra special"}));
+        let input = serde_json::Value::Array(rows).to_string();
+        let out = compress(&input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.compressed.contains("zebra"), "BM25 sample must include the query hit");
+    }
+
+    #[test]
+    fn depth_cap_degrades_to_minify() {
+        let cfg = CompressConfig::default();
+        let (_d, store) = store_and_ctx(&cfg);
+        let ctx = CompressCtx { query: None, config: &cfg };
+        // 80 levels of nesting, no large arrays: must not panic, plain minify.
+        let mut s = String::new();
+        for _ in 0..80 { s.push_str(r#"{"a":"#); }
+        s.push('1');
+        for _ in 0..80 { s.push('}'); }
+        let out = compress(&s, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.hash.is_none());
+    }
+
+    #[test]
+    fn no_sentinel_leaks_into_output() {
+        let cfg = CompressConfig { protect_head_lines: 2, ..Default::default() };
+        let (_d, store) = store_and_ctx(&cfg);
+        let ctx = CompressCtx { query: None, config: &cfg };
+        let input = r#"{"results":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}"#;
+        let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(!out.compressed.contains("__MUR_HASH__"));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run -p mur-compress json`
+Expected: FAIL — nested array / string elide produce no hash (current code only handles top-level arrays).
+
+- [ ] **Step 3: Implement** — rewrite `json.rs` body (keep `MIN_ARRAY_FOR_COLLAPSE = 4`):
+
+```rust
+const MAX_DEPTH: usize = 64;
+const HASH_SENTINEL: &str = "__MUR_HASH__";
+
+/// Walk state: collected offload items + which transforms fired.
+struct Walk<'a> {
+    ctx: &'a CompressCtx<'a>,
+    tok: &'a dyn TokenCounter,
+    items: Vec<String>,
+    collapsed_array: bool,
+    elided_string: bool,
+}
+
+impl Walk<'_> {
+    fn visit(&mut self, v: &mut serde_json::Value, depth: usize) {
+        if depth >= MAX_DEPTH {
+            return;
+        }
+        match v {
+            serde_json::Value::Array(arr) => {
+                let sample_n = self.ctx.config.protect_head_lines.min(arr.len());
+                if arr.len() >= MIN_ARRAY_FOR_COLLAPSE && arr.len() > sample_n {
+                    *v = self.collapse_array(std::mem::take(arr), sample_n);
+                    self.collapsed_array = true;
+                } else {
+                    for item in arr {
+                        self.visit(item, depth + 1);
+                    }
+                }
+            }
+            serde_json::Value::Object(map) => {
+                for (_, val) in map.iter_mut() {
+                    self.visit(val, depth + 1);
+                }
+            }
+            serde_json::Value::String(s) => {
+                let max = self.ctx.config.json.max_string_tokens;
+                if self.tok.count(s) >= max {
+                    self.items.push(s.clone());
+                    // ~2 chars/token: conservative head slice, char-boundary safe.
+                    let head: String = s.chars().take(max * 2).collect();
+                    let elided = s.chars().count().saturating_sub(head.chars().count());
+                    *v = serde_json::Value::String(format!(
+                        "{head}...[{elided} chars elided, hash={HASH_SENTINEL}]"
+                    ));
+                    self.elided_string = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Replace a large array with {_schema,_total,_shown,sample,_note}.
+    fn collapse_array(&mut self, arr: Vec<serde_json::Value>, sample_n: usize) -> serde_json::Value {
+        let keys: Vec<String> = match arr.first() {
+            Some(serde_json::Value::Object(m)) => m.keys().cloned().collect(),
+            _ => Vec::new(),
+        };
+        let serialized: Vec<String> = arr
+            .iter()
+            .map(|x| serde_json::to_string(x).unwrap_or_default())
+            .collect();
+
+        // Query-aware sampling: BM25 top-N in original order; else head-N.
+        let mut idx: Vec<usize> = match self.ctx.query {
+            Some(q) => {
+                let mut top: Vec<usize> = bm25_rank(q, &serialized)
+                    .into_iter()
+                    .take(sample_n)
+                    .map(|(i, _)| i)
+                    .collect();
+                if top.is_empty() {
+                    (0..sample_n).collect()
+                } else {
+                    top.sort_unstable();
+                    top
+                }
+            }
+            None => (0..sample_n).collect(),
+        };
+        idx.dedup();
+        let sample: Vec<serde_json::Value> = idx.iter().map(|&i| arr[i].clone()).collect();
+
+        self.items.extend(serialized);
+        serde_json::json!({
+            "_schema": keys,
+            "_total": arr.len(),
+            "_shown": sample.len(),
+            "sample": sample,
+            "_note": format!("{} rows collapsed; full array hash={HASH_SENTINEL}", arr.len() - sample.len()),
+        })
+    }
+}
+
+pub fn compress(
+    content: &str,
+    ctx: &CompressCtx,
+    store: &CcrStore,
+    tok: &dyn TokenCounter,
+) -> Result<CompressOutput, CompressError> {
+    let mut val: serde_json::Value =
+        serde_json::from_str(content.trim()).map_err(|e| CompressError::Parse(e.to_string()))?;
+    let minified = serde_json::to_string(&val).map_err(|e| CompressError::Parse(e.to_string()))?;
+    let mut transforms = vec!["json.minify".to_string()];
+
+    let mut walk = Walk { ctx, tok, items: Vec::new(), collapsed_array: false, elided_string: false };
+    walk.visit(&mut val, 0);
+
+    if !walk.collapsed_array && !walk.elided_string {
+        return Ok(CompressOutput { compressed: minified, hash: None, transforms });
+    }
+
+    // Offload the whole original once; every note points at this hash.
+    let hash = store
+        .put_original(content, walk.items, ContentType::Json, tok)
+        .map_err(|e| CompressError::Store(e.to_string()))?;
+    if walk.collapsed_array {
+        transforms.push("json.deep_collapse".to_string());
+    }
+    if walk.elided_string {
+        transforms.push("json.string_elide".to_string());
+    }
+    let compressed = serde_json::to_string(&val)
+        .unwrap_or(minified)
+        .replace(HASH_SENTINEL, &hash);
+
+    Ok(CompressOutput { compressed, hash: Some(hash), transforms })
+}
+```
+
+Add `use crate::bm25::bm25_rank;` to the imports. Delete the old top-level-array-only block (`collapse` behavior is preserved: a top-level array is just depth-0 of the walk — the existing `collapses_long_array` test must still pass; note its collapse output is now the walk's shape, adjust that test's assertions only if a field name genuinely changed — it shouldn't).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run -p mur-compress json`
+Expected: PASS — all new tests plus the two pre-existing ones.
+
+- [ ] **Step 5: Run the full crate suite**
+
+Run: `cargo nextest run -p mur-compress`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-compress/src/compressors/json.rs
+git commit -m "feat(compress): JSON deep collapse — nested arrays, string elide, query-aware BM25 sampling"
+```
+
+---
+
+### Task 4: Generic early-skip in the engine
+
+**Files:**
+- Modify: `mur-compress/src/compressors/fallback.rs` (add `saving_ratio`)
+- Modify: `mur-compress/src/lib.rs` (skip gate in `compress()`)
+
+**Interfaces:**
+- Consumes: `FallbackCfg.min_save_ratio` (Task 1), `StatsTracker::record_skip` (Task 2).
+- Produces: `fallback::saving_ratio(content: &str) -> f32` — exact byte-level ratio the whitespace fallback would save.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `fallback.rs` tests:
+
+```rust
+    #[test]
+    fn saving_ratio_exact() {
+        // "abc   \n\n\n\nxyz\n": 3 trailing ws + 2 excess blank lines = 5 of 14 bytes
+        let s = "abc   \n\n\n\nxyz\n";
+        let expect = 5.0 / s.len() as f32;
+        assert!((saving_ratio(s) - expect).abs() < 1e-6);
+        assert_eq!(saving_ratio("clean\ntext\n"), 0.0);
+    }
+```
+
+In `lib.rs` tests (or the crate's existing engine test location — follow the sibling pattern):
+
+```rust
+    #[test]
+    fn generic_low_savings_is_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = CompressEngine::new(dir.path(), CompressConfig::default()).unwrap();
+        // Prose with nothing to strip: predicted savings 0 < 5% → skip.
+        let content = "plain prose line\n".repeat(200);
+        let r = engine.compress(&content, None);
+        assert_eq!(r.tokens_saved, 0);
+        assert!(r.transforms.iter().any(|t| t == "skipped"));
+        let snap = engine.stats_snapshot();
+        assert_eq!(snap.skipped, 1);
+        assert_eq!(snap.compressions, 0);
+    }
+
+    #[test]
+    fn generic_high_savings_still_compresses() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = CompressEngine::new(dir.path(), CompressConfig::default()).unwrap();
+        // Heavy trailing whitespace: well above 5% → real compression.
+        let content = "x                                        \n".repeat(300);
+        let r = engine.compress(&content, None);
+        assert!(r.tokens_saved > 0);
+        assert!(r.transforms.iter().any(|t| t == "fallback.whitespace"));
+    }
+```
+
+(Check `stats_snapshot()`'s exact signature in `lib.rs` — it may take no args and use config cost; use it as the existing engine tests do.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run -p mur-compress fallback generic`
+Expected: FAIL — `saving_ratio` undefined; skip path missing.
+
+- [ ] **Step 3: Implement**
+
+`fallback.rs` — one scan, no allocation:
+
+```rust
+/// Exact fraction of bytes the whitespace fallback would remove.
+/// This is a precise pre-computation, not a heuristic: the fallback only
+/// ever strips trailing whitespace and blank runs beyond the first line.
+pub fn saving_ratio(content: &str) -> f32 {
+    if content.is_empty() {
+        return 0.0;
+    }
+    let mut saved = 0usize;
+    let mut blank_run = 0usize;
+    for line in content.lines() {
+        let trimmed = line.trim_end();
+        saved += line.len() - trimmed.len();
+        if trimmed.is_empty() {
+            blank_run += 1;
+            if blank_run > 1 {
+                saved += 1; // the '\n' of a dropped blank line
+            }
+        } else {
+            blank_run = 0;
+        }
+    }
+    saved as f32 / content.len() as f32
+}
+```
+
+`lib.rs` — in `compress()`, right after the `enabled` check, before building `ctx`:
+
+```rust
+        // Generic early-skip: the fallback's savings are exactly computable
+        // in one scan. Below the configured floor, don't run the compressor
+        // at all — record a skip (not a compression) and pass through.
+        if ct == ContentType::Generic
+            && fallback::saving_ratio(content) < self.config.fallback.min_save_ratio
+        {
+            self.stats.record_skip(ct.as_str());
+            let mut r = Self::passthrough(content, before, ct);
+            r.transforms = vec!["skipped".to_string()];
+            return r;
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run -p mur-compress`
+Expected: PASS — new tests plus the whole crate suite.
+
+- [ ] **Step 5: Workspace sanity + lint**
+
+Run: `cargo clippy -p mur-compress -- -D warnings && cargo fmt --check`
+Expected: clean. (Full-workspace build needs `MUR_WEB_DIST`/`ORT_STRATEGY` env; not required for this crate alone.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-compress/src/compressors/fallback.rs mur-compress/src/lib.rs
+git commit -m "feat(compress): generic early-skip — exact savings pre-scan, honest skipped stats"
+```
+
+---
+
+## Verification (post-implementation)
+
+1. `cargo nextest run -p mur-compress` — all green.
+2. Manual smoke: `echo '{"results":[...20 rows...]}' | mur compress` shows `_total`/hash; `mur compress --file <prose.txt>` reports skip/no-op.
+3. After a day of real use, `~/.mur/compress/stats.json` shows `json` ratio rising and `generic` compressions ≈ 0 with `skipped` accumulating.

--- a/docs/superpowers/specs/2026-07-13-compress-optimization-design.md
+++ b/docs/superpowers/specs/2026-07-13-compress-optimization-design.md
@@ -1,0 +1,139 @@
+# Compress Optimization: JSON Deep Collapse + Generic Early Skip
+
+**Date:** 2026-07-13
+**Status:** Approved (design review with user)
+**Crate:** `mur-compress`
+
+## Motivation
+
+Production stats (`~/.mur/compress/stats.json`, cumulative by_type):
+
+| type | compressions | input tokens | saved | ratio |
+|---|---|---|---|---|
+| git_diff | 1,060 | 4.9M | 4.3M | 89.2% |
+| build_log | 45 | 119K | 78K | 65.7% |
+| search_results | 5,194 | 6.9M | 2.3M | 33.4% |
+| **json** | **467** | **1.7M** | **28K** | **1.7%** |
+| **generic** | **8,328** | **20.1M** | **9K** | **~0%** |
+
+Two failure modes:
+
+1. **JSON:** `compressors/json.rs` only collapses a *top-level* array. Real MCP/tool
+   payloads are objects wrapping large arrays or long strings (`{"results": [...]}`,
+   `{"content": "..."}`), which today get nothing but minification. Headroom's
+   SmartCrusher claims 60–95% on the same shapes.
+2. **Generic:** 63% of all compressions run through the whitespace-only fallback and
+   save ~0%, wasting CPU and inflating stats with no-op "compressions".
+
+## Scope
+
+- **In:** recursive JSON collapse (arrays at any depth + long string leaves),
+  query-aware BM25 sampling, generic early-skip with exact savings pre-computation,
+  `skipped` stats counter.
+- **Out:** code skeletonization in the main pipeline (breaks `Edit` old_string
+  anchoring on fresh file reads — `skeleton.rs` stays cc-proxy-supersession-only);
+  new content-type detectors; changes to `mur_retrieve` semantics.
+
+## Part 1: JSON deep collapse (`compressors/json.rs`)
+
+### Behavior
+
+Walk the parsed `serde_json::Value` tree. Two collapsible node kinds:
+
+1. **Large array** (any depth, `len >= MIN_ARRAY_FOR_COLLAPSE` (4) and
+   `len > sample_n`): replace in place with the existing collapse shape
+   `{_schema, _total, _shown, sample, _note}`. `_schema` from the first
+   object element's keys (empty for non-object elements), `_note` carries the hash.
+2. **Long string leaf** (token count >= new config `json.max_string_tokens`,
+   default 200): truncate to a head slice plus a
+   `"...[N tokens elided, hash=H]"` suffix.
+
+### Sampling
+
+- With `ctx.query`: serialize each array element to its JSON string, rank with the
+  existing `bm25::bm25_rank`, keep top-`sample_n` **in original array order**
+  (same pattern as `compressors/search.rs`).
+- Without query: head `sample_n` (current behavior). `sample_n` remains
+  `cfg.protect_head_lines.min(len)`.
+
+### Offload semantics (unchanged)
+
+One `store.put_original(content, items, ContentType::Json, tok)` call for the
+**whole original document** → one hash. Every collapse note in the tree references
+that same hash. `mur_retrieve` is untouched and returns the original byte-for-byte.
+The original is stored **before** any tree mutation; failure at any collapse step
+falls back to plain minify (current behavior). No data-loss path exists.
+
+### Safety rails
+
+- Recursion depth cap (constant, e.g. 64) — deep/hostile nesting degrades to
+  minify-only below the cap, never panics or overflows the stack.
+- The engine's existing payoff gate (passthrough when `tokens_saved == 0`) is the
+  final guard; unchanged.
+- New transforms recorded: `json.deep_collapse`, `json.string_elide` (observable in
+  stats/transforms alongside the existing `json.minify` / `json.row_collapse`).
+
+### Config
+
+```yaml
+json:
+  max_string_tokens: 200   # string leaves at/above this get elided
+```
+
+Added to `CompressConfig` with serde default; absent config behaves as default.
+
+## Part 2: Generic early skip (engine path in `lib.rs` + `stats.rs`)
+
+### Behavior
+
+The generic fallback can only ever save `trailing_ws_bytes + excess_blank_lines`.
+That is **exactly computable** in one cheap scan before compressing:
+
+1. detect → `ContentType::Generic`
+2. compute potential savings ratio (bytes-based estimate over the same scan the
+   fallback would do)
+3. if ratio < `fallback.min_save_ratio` (new config, default 0.05) → **passthrough**:
+   no compressor run, no CCR write, recorded as `skipped` in stats
+4. else → existing fallback compression, recorded as today
+
+Other content types are untouched.
+
+### Stats semantics fix
+
+Today a no-op passthrough still increments `compressions` (hence 8,328 × ~0%).
+Add a `skipped` counter (top-level + per version/day bucket). Skipped calls
+increment `skipped` only. `by_type` numbers then reflect real compression work.
+Existing stats.json files deserialize cleanly (serde default 0 for the new field).
+
+### Config
+
+```yaml
+fallback:
+  min_save_ratio: 0.05   # generic inputs predicted to save less than 5% are skipped
+```
+
+## Error handling (both parts)
+
+- JSON parse failure → `CompressError::Parse` → engine falls back (unchanged).
+- Any collapse failure → minify-only output (unchanged fallback), original already
+  in CCR when a hash is emitted.
+- Skip path cannot error: it is a pure scan + passthrough.
+
+## Testing
+
+`cargo nextest` (workspace convention; plain `cargo test` is flaky):
+
+- **json:** nested-object large-array collapse; long-string elide; BM25 sampling
+  picks query-relevant elements (order preserved); depth cap degrades to minify;
+  retrieve returns original byte-for-byte; short/small inputs still plain-minify.
+- **generic skip:** low-savings input passes through untouched and increments
+  `skipped`; high-savings input still compresses; stats round-trip with the new
+  field; old stats.json (no `skipped`) still loads.
+- All existing tests stay green.
+
+## Expected impact
+
+- json: 1.7% → 40%+ on object-wrapped payloads (directionally; measured post-ship
+  via by_type stats).
+- generic: ~8K no-op compressions/period stop burning CPU and polluting stats.
+- No behavior change for git_diff / search_results / build_log paths.

--- a/mur-compress/src/compressors/fallback.rs
+++ b/mur-compress/src/compressors/fallback.rs
@@ -36,11 +36,44 @@ pub fn compress(
     })
 }
 
+/// Exact fraction of bytes the whitespace fallback would remove.
+/// This is a precise pre-computation, not a heuristic: the fallback only
+/// ever strips trailing whitespace and blank runs beyond the first line.
+pub fn saving_ratio(content: &str) -> f32 {
+    if content.is_empty() {
+        return 0.0;
+    }
+    let mut saved = 0usize;
+    let mut blank_run = 0usize;
+    for line in content.lines() {
+        let trimmed = line.trim_end();
+        saved += line.len() - trimmed.len();
+        if trimmed.is_empty() {
+            blank_run += 1;
+            if blank_run > 1 {
+                saved += 1; // the '\n' of a dropped blank line
+            }
+        } else {
+            blank_run = 0;
+        }
+    }
+    saved as f32 / content.len() as f32
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::CompressConfig;
     use crate::tokenizer::HeuristicCounter;
+
+    #[test]
+    fn saving_ratio_exact() {
+        // "abc   \n\n\n\nxyz\n": 3 trailing ws + 2 excess blank lines = 5 of 14 bytes
+        let s = "abc   \n\n\n\nxyz\n";
+        let expect = 5.0 / s.len() as f32;
+        assert!((saving_ratio(s) - expect).abs() < 1e-6);
+        assert_eq!(saving_ratio("clean\ntext\n"), 0.0);
+    }
 
     #[test]
     fn collapses_blank_runs_and_trailing_ws() {

--- a/mur-compress/src/compressors/json.rs
+++ b/mur-compress/src/compressors/json.rs
@@ -125,8 +125,10 @@ pub fn compress(
     // user's own text to the hash). Guard by refusing to collapse at all when the
     // sentinel is already present in the input — degrade to plain minify, which is
     // always safe, rather than invent a new escaping scheme for a vanishingly rare
-    // adversarial/coincidental case.
-    if content.contains(HASH_SENTINEL) {
+    // adversarial/coincidental case. Checked against `minified` (the canonical
+    // serde re-serialization), not the raw input, so unicode-escaped encodings of
+    // the sentinel (e.g. _ escapes) can't slip past the guard.
+    if minified.contains(HASH_SENTINEL) {
         return Ok(CompressOutput {
             compressed: minified,
             hash: None,

--- a/mur-compress/src/compressors/json.rs
+++ b/mur-compress/src/compressors/json.rs
@@ -1,11 +1,111 @@
-//! JSON compressor. Reformat: minify. Offload (SmartCrusher-lite): for a long
-//! top-level array, emit schema keys + first-N sample + count; stash full array.
+//! JSON compressor. Reformat: minify. Offload (SmartCrusher-lite): recursively
+//! walk the tree, collapsing large nested arrays (schema keys + BM25/head
+//! sample + count) and eliding over-long string leaves, stashing the full
+//! original document once behind a single hash so `mur_retrieve` can pull it
+//! back byte-for-byte.
 
+use crate::bm25::bm25_rank;
 use crate::ccr::CcrStore;
 use crate::tokenizer::TokenCounter;
 use crate::types::{CompressCtx, CompressError, CompressOutput, ContentType};
 
 const MIN_ARRAY_FOR_COLLAPSE: usize = 4;
+const MAX_DEPTH: usize = 64;
+const HASH_SENTINEL: &str = "__MUR_HASH__";
+
+/// Walk state: collected offload items + which transforms fired.
+struct Walk<'a> {
+    ctx: &'a CompressCtx<'a>,
+    tok: &'a dyn TokenCounter,
+    items: Vec<String>,
+    collapsed_array: bool,
+    elided_string: bool,
+}
+
+impl Walk<'_> {
+    fn visit(&mut self, v: &mut serde_json::Value, depth: usize) {
+        if depth >= MAX_DEPTH {
+            return;
+        }
+        match v {
+            serde_json::Value::Array(arr) => {
+                let sample_n = self.ctx.config.protect_head_lines.min(arr.len());
+                if arr.len() >= MIN_ARRAY_FOR_COLLAPSE && arr.len() > sample_n {
+                    *v = self.collapse_array(std::mem::take(arr), sample_n);
+                    self.collapsed_array = true;
+                } else {
+                    for item in arr {
+                        self.visit(item, depth + 1);
+                    }
+                }
+            }
+            serde_json::Value::Object(map) => {
+                for (_, val) in map.iter_mut() {
+                    self.visit(val, depth + 1);
+                }
+            }
+            serde_json::Value::String(s) => {
+                let max = self.ctx.config.json.max_string_tokens;
+                if self.tok.count(s) >= max {
+                    self.items.push(s.clone());
+                    // ~2 chars/token: conservative head slice, char-boundary safe.
+                    let head: String = s.chars().take(max * 2).collect();
+                    let elided = s.chars().count().saturating_sub(head.chars().count());
+                    *v = serde_json::Value::String(format!(
+                        "{head}...[{elided} chars elided, hash={HASH_SENTINEL}]"
+                    ));
+                    self.elided_string = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Replace a large array with {_schema,_total,_shown,sample,_note}.
+    fn collapse_array(
+        &mut self,
+        arr: Vec<serde_json::Value>,
+        sample_n: usize,
+    ) -> serde_json::Value {
+        let keys: Vec<String> = match arr.first() {
+            Some(serde_json::Value::Object(m)) => m.keys().cloned().collect(),
+            _ => Vec::new(),
+        };
+        let serialized: Vec<String> = arr
+            .iter()
+            .map(|x| serde_json::to_string(x).unwrap_or_default())
+            .collect();
+
+        // Query-aware sampling: BM25 top-N in original order; else head-N.
+        let mut idx: Vec<usize> = match self.ctx.query {
+            Some(q) => {
+                let mut top: Vec<usize> = bm25_rank(q, &serialized)
+                    .into_iter()
+                    .take(sample_n)
+                    .map(|(i, _)| i)
+                    .collect();
+                if top.is_empty() {
+                    (0..sample_n).collect()
+                } else {
+                    top.sort_unstable();
+                    top
+                }
+            }
+            None => (0..sample_n).collect(),
+        };
+        idx.dedup();
+        let sample: Vec<serde_json::Value> = idx.iter().map(|&i| arr[i].clone()).collect();
+
+        self.items.extend(serialized);
+        serde_json::json!({
+            "_schema": keys,
+            "_total": arr.len(),
+            "_shown": sample.len(),
+            "sample": sample,
+            "_note": format!("{} rows collapsed; full array hash={HASH_SENTINEL}", arr.len() - sample.len()),
+        })
+    }
+}
 
 pub fn compress(
     content: &str,
@@ -13,47 +113,46 @@ pub fn compress(
     store: &CcrStore,
     tok: &dyn TokenCounter,
 ) -> Result<CompressOutput, CompressError> {
-    let val: serde_json::Value =
+    let mut val: serde_json::Value =
         serde_json::from_str(content.trim()).map_err(|e| CompressError::Parse(e.to_string()))?;
-    let mut transforms = vec!["json.minify".to_string()];
     let minified = serde_json::to_string(&val).map_err(|e| CompressError::Parse(e.to_string()))?;
-    let cfg = ctx.config;
+    let transforms = vec!["json.minify".to_string()];
 
-    if let serde_json::Value::Array(arr) = &val {
-        let sample_n = cfg.protect_head_lines.min(arr.len());
-        if arr.len() >= MIN_ARRAY_FOR_COLLAPSE && arr.len() > sample_n {
-            let keys: Vec<String> = match arr.first() {
-                Some(serde_json::Value::Object(m)) => m.keys().cloned().collect(),
-                _ => Vec::new(),
-            };
-            let items: Vec<String> = arr
-                .iter()
-                .map(|v| serde_json::to_string(v).unwrap_or_default())
-                .collect();
-            let hash = store
-                .put_original(content, items, ContentType::Json, tok)
-                .map_err(|e| CompressError::Store(e.to_string()))?;
-            transforms.push("json.row_collapse".to_string());
+    let mut walk = Walk {
+        ctx,
+        tok,
+        items: Vec::new(),
+        collapsed_array: false,
+        elided_string: false,
+    };
+    walk.visit(&mut val, 0);
 
-            let sample = serde_json::Value::Array(arr[..sample_n].to_vec());
-            let body = serde_json::json!({
-                "_schema": keys,
-                "_total": arr.len(),
-                "_shown": sample_n,
-                "sample": sample,
-                "_note": format!("{} rows collapsed; full array hash={}", arr.len() - sample_n, hash),
-            });
-            return Ok(CompressOutput {
-                compressed: serde_json::to_string(&body).unwrap_or(minified),
-                hash: Some(hash),
-                transforms,
-            });
-        }
+    if !walk.collapsed_array && !walk.elided_string {
+        return Ok(CompressOutput {
+            compressed: minified,
+            hash: None,
+            transforms,
+        });
     }
 
+    // Offload the whole original once; every note points at this hash.
+    let hash = store
+        .put_original(content, walk.items, ContentType::Json, tok)
+        .map_err(|e| CompressError::Store(e.to_string()))?;
+    let mut transforms = transforms;
+    if walk.collapsed_array {
+        transforms.push("json.deep_collapse".to_string());
+    }
+    if walk.elided_string {
+        transforms.push("json.string_elide".to_string());
+    }
+    let compressed = serde_json::to_string(&val)
+        .unwrap_or(minified)
+        .replace(HASH_SENTINEL, &hash);
+
     Ok(CompressOutput {
-        compressed: minified,
-        hash: None,
+        compressed,
+        hash: Some(hash),
         transforms,
     })
 }
@@ -64,14 +163,19 @@ mod tests {
     use crate::config::CompressConfig;
     use crate::tokenizer::HeuristicCounter;
 
+    fn store_and_ctx(_cfg: &CompressConfig) -> (tempfile::TempDir, CcrStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
+        (dir, store)
+    }
+
     #[test]
     fn collapses_long_array() {
         let cfg = CompressConfig {
             protect_head_lines: 2,
             ..Default::default()
         };
-        let dir = tempfile::tempdir().unwrap();
-        let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
+        let (_d, store) = store_and_ctx(&cfg);
         let ctx = CompressCtx {
             query: None,
             config: &cfg,
@@ -87,8 +191,7 @@ mod tests {
     #[test]
     fn minifies_short_json() {
         let cfg = CompressConfig::default();
-        let dir = tempfile::tempdir().unwrap();
-        let store = CcrStore::new(dir.path(), 3600, 100, 1 << 30, false).unwrap();
+        let (_d, store) = store_and_ctx(&cfg);
         let ctx = CompressCtx {
             query: None,
             config: &cfg,
@@ -96,5 +199,109 @@ mod tests {
         let out = compress("{\n  \"a\": 1\n}", &ctx, &store, &HeuristicCounter).unwrap();
         assert_eq!(out.compressed, r#"{"a":1}"#);
         assert!(out.hash.is_none());
+    }
+
+    #[test]
+    fn collapses_nested_array() {
+        let cfg = CompressConfig {
+            protect_head_lines: 2,
+            ..Default::default()
+        };
+        let (_d, store) = store_and_ctx(&cfg);
+        let ctx = CompressCtx {
+            query: None,
+            config: &cfg,
+        };
+        let input =
+            r#"{"ok":true,"results":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6}]}"#;
+        let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.hash.is_some(), "nested array must trigger offload");
+        assert!(out.compressed.contains("_total"));
+        assert!(out.transforms.iter().any(|t| t == "json.deep_collapse"));
+        // retrieve returns the original byte-for-byte
+        let got = store.get(out.hash.as_ref().unwrap()).unwrap().unwrap();
+        assert_eq!(got.original_text, input);
+    }
+
+    #[test]
+    fn elides_long_string_leaf() {
+        let cfg = CompressConfig {
+            json: crate::config::JsonCfg {
+                max_string_tokens: 10,
+            },
+            ..Default::default()
+        };
+        let (_d, store) = store_and_ctx(&cfg);
+        let ctx = CompressCtx {
+            query: None,
+            config: &cfg,
+        };
+        let long = "word ".repeat(200);
+        let input = serde_json::json!({"content": long}).to_string();
+        let out = compress(&input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.hash.is_some());
+        assert!(out.transforms.iter().any(|t| t == "json.string_elide"));
+        assert!(out.compressed.len() < input.len() / 2);
+        assert!(out.compressed.contains("elided"));
+    }
+
+    #[test]
+    fn query_picks_relevant_sample() {
+        let cfg = CompressConfig {
+            protect_head_lines: 2,
+            ..Default::default()
+        };
+        let (_d, store) = store_and_ctx(&cfg);
+        let ctx = CompressCtx {
+            query: Some("zebra"),
+            config: &cfg,
+        };
+        let mut rows: Vec<serde_json::Value> = (0..10)
+            .map(|i| serde_json::json!({"id": i, "name": "common"}))
+            .collect();
+        rows.push(serde_json::json!({"id": 99, "name": "zebra special"}));
+        let input = serde_json::Value::Array(rows).to_string();
+        let out = compress(&input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(
+            out.compressed.contains("zebra"),
+            "BM25 sample must include the query hit"
+        );
+    }
+
+    #[test]
+    fn depth_cap_degrades_to_minify() {
+        let cfg = CompressConfig::default();
+        let (_d, store) = store_and_ctx(&cfg);
+        let ctx = CompressCtx {
+            query: None,
+            config: &cfg,
+        };
+        // 80 levels of nesting, no large arrays: must not panic, plain minify.
+        let mut s = String::new();
+        for _ in 0..80 {
+            s.push_str(r#"{"a":"#);
+        }
+        s.push('1');
+        for _ in 0..80 {
+            s.push('}');
+        }
+        let out = compress(&s, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(out.hash.is_none());
+    }
+
+    #[test]
+    fn no_sentinel_leaks_into_output() {
+        let cfg = CompressConfig {
+            protect_head_lines: 2,
+            ..Default::default()
+        };
+        let (_d, store) = store_and_ctx(&cfg);
+        let ctx = CompressCtx {
+            query: None,
+            config: &cfg,
+        };
+        let input = r#"{"results":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5}]}"#;
+        let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(!out.compressed.contains("__MUR_HASH__"));
     }
 }

--- a/mur-compress/src/compressors/json.rs
+++ b/mur-compress/src/compressors/json.rs
@@ -118,6 +118,22 @@ pub fn compress(
     let minified = serde_json::to_string(&val).map_err(|e| CompressError::Parse(e.to_string()))?;
     let transforms = vec!["json.minify".to_string()];
 
+    // Collapse notes and elided-string markers embed HASH_SENTINEL as a placeholder
+    // that gets string-replaced with the real content hash after serialization. If
+    // the ORIGINAL document already contains that literal string in surviving user
+    // data, the final blind `.replace()` would silently corrupt it (rewriting the
+    // user's own text to the hash). Guard by refusing to collapse at all when the
+    // sentinel is already present in the input — degrade to plain minify, which is
+    // always safe, rather than invent a new escaping scheme for a vanishingly rare
+    // adversarial/coincidental case.
+    if content.contains(HASH_SENTINEL) {
+        return Ok(CompressOutput {
+            compressed: minified,
+            hash: None,
+            transforms,
+        });
+    }
+
     let mut walk = Walk {
         ctx,
         tok,
@@ -287,6 +303,33 @@ mod tests {
         }
         let out = compress(&s, &ctx, &store, &HeuristicCounter).unwrap();
         assert!(out.hash.is_none());
+    }
+
+    #[test]
+    fn sentinel_in_user_data_degrades_to_minify() {
+        let cfg = CompressConfig {
+            protect_head_lines: 2,
+            ..Default::default()
+        };
+        let (_d, store) = store_and_ctx(&cfg);
+        let ctx = CompressCtx {
+            query: None,
+            config: &cfg,
+        };
+        let mut rows: Vec<serde_json::Value> =
+            (0..10).map(|i| serde_json::json!({"id": i})).collect();
+        rows.push(serde_json::json!({"id": 99, "note": "__MUR_HASH__"}));
+        let input = serde_json::Value::Array(rows).to_string();
+        let out = compress(&input, &ctx, &store, &HeuristicCounter).unwrap();
+        assert!(
+            out.hash.is_none(),
+            "sentinel collision in user data must degrade to plain minify"
+        );
+        assert!(
+            out.compressed.contains("__MUR_HASH__"),
+            "user's literal sentinel text must survive untouched"
+        );
+        assert_eq!(out.transforms, vec!["json.minify".to_string()]);
     }
 
     #[test]

--- a/mur-compress/src/config.rs
+++ b/mur-compress/src/config.rs
@@ -238,7 +238,9 @@ mod tests {
     #[test]
     fn yaml_without_new_sections_still_loads() {
         // Simulates an existing user compress.yaml predating these fields.
-        let cfg: CompressConfig = serde_yaml::from_str("enabled: true\n").unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("compress.yaml"), "enabled: true\n").unwrap();
+        let cfg = CompressConfig::load(dir.path());
         assert_eq!(cfg.json.max_string_tokens, 200);
         assert!((cfg.fallback.min_save_ratio - 0.05).abs() < f32::EPSILON);
     }

--- a/mur-compress/src/config.rs
+++ b/mur-compress/src/config.rs
@@ -36,6 +36,10 @@ pub struct CompressConfig {
     pub stats: StatsCfg,
     #[serde(default)]
     pub auto: AutoCfg,
+    #[serde(default)]
+    pub json: JsonCfg,
+    #[serde(default)]
+    pub fallback: FallbackCfg,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -58,6 +62,36 @@ pub struct StatsCfg {
     pub cost_per_mtok_usd: f64,
 }
 
+/// `json:` section — knobs for the JSON deep-collapse compressor.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct JsonCfg {
+    /// String leaves whose token count is at/above this get elided
+    /// (head kept, remainder offloaded).
+    pub max_string_tokens: usize,
+}
+
+impl Default for JsonCfg {
+    fn default() -> Self {
+        Self { max_string_tokens: 200 }
+    }
+}
+
+/// `fallback:` section — knobs for the Generic path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FallbackCfg {
+    /// Generic inputs whose exactly-computable savings ratio is below this
+    /// are skipped (passthrough) instead of compressed.
+    pub min_save_ratio: f32,
+}
+
+impl Default for FallbackCfg {
+    fn default() -> Self {
+        Self { min_save_ratio: 0.05 }
+    }
+}
+
 impl Default for CompressConfig {
     fn default() -> Self {
         Self {
@@ -73,6 +107,8 @@ impl Default for CompressConfig {
             store: StoreCfg::default(),
             stats: StatsCfg::default(),
             auto: AutoCfg::default(),
+            json: JsonCfg::default(),
+            fallback: FallbackCfg::default(),
         }
     }
 }
@@ -190,5 +226,20 @@ mod tests {
         std::fs::write(dir.path().join("compress.yaml"), "this: [is: not: valid").unwrap();
         let c = CompressConfig::load(dir.path());
         assert_eq!(c.protect_head_lines, 20);
+    }
+
+    #[test]
+    fn new_sections_default() {
+        let cfg = CompressConfig::default();
+        assert_eq!(cfg.json.max_string_tokens, 200);
+        assert!((cfg.fallback.min_save_ratio - 0.05).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn yaml_without_new_sections_still_loads() {
+        // Simulates an existing user compress.yaml predating these fields.
+        let cfg: CompressConfig = serde_yaml::from_str("enabled: true\n").unwrap();
+        assert_eq!(cfg.json.max_string_tokens, 200);
+        assert!((cfg.fallback.min_save_ratio - 0.05).abs() < f32::EPSILON);
     }
 }

--- a/mur-compress/src/config.rs
+++ b/mur-compress/src/config.rs
@@ -73,7 +73,9 @@ pub struct JsonCfg {
 
 impl Default for JsonCfg {
     fn default() -> Self {
-        Self { max_string_tokens: 200 }
+        Self {
+            max_string_tokens: 200,
+        }
     }
 }
 
@@ -88,7 +90,9 @@ pub struct FallbackCfg {
 
 impl Default for FallbackCfg {
     fn default() -> Self {
-        Self { min_save_ratio: 0.05 }
+        Self {
+            min_save_ratio: 0.05,
+        }
     }
 }
 

--- a/mur-compress/src/lib.rs
+++ b/mur-compress/src/lib.rs
@@ -117,6 +117,18 @@ impl CompressEngine {
             return Self::passthrough(content, before, ct);
         }
 
+        // Generic early-skip: the fallback's savings are exactly computable
+        // in one scan. Below the configured floor, don't run the compressor
+        // at all — record a skip (not a compression) and pass through.
+        if ct == ContentType::Generic
+            && fallback::saving_ratio(content) < self.config.fallback.min_save_ratio
+        {
+            self.stats.record_skip(ct.as_str());
+            let mut r = Self::passthrough(content, before, ct);
+            r.transforms = vec!["skipped".to_string()];
+            return r;
+        }
+
         let ctx = CompressCtx {
             query,
             config: &self.config,
@@ -296,5 +308,30 @@ mod tests {
         assert_eq!(res.tokens_saved, 0);
         assert!(res.compressed_tokens <= res.original_tokens);
         assert_eq!(eng.stats_snapshot().compressions, 0);
+    }
+
+    #[test]
+    fn generic_low_savings_is_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = CompressEngine::new(dir.path(), CompressConfig::default()).unwrap();
+        // Prose with nothing to strip: predicted savings 0 < 5% → skip.
+        let content = "plain prose line\n".repeat(200);
+        let r = engine.compress(&content, None);
+        assert_eq!(r.tokens_saved, 0);
+        assert!(r.transforms.iter().any(|t| t == "skipped"));
+        let snap = engine.stats_snapshot();
+        assert_eq!(snap.skipped, 1);
+        assert_eq!(snap.compressions, 0);
+    }
+
+    #[test]
+    fn generic_high_savings_still_compresses() {
+        let dir = tempfile::tempdir().unwrap();
+        let engine = CompressEngine::new(dir.path(), CompressConfig::default()).unwrap();
+        // Heavy trailing whitespace: well above 5% → real compression.
+        let content = "x                                                            \n".repeat(300);
+        let r = engine.compress(&content, None);
+        assert!(r.tokens_saved > 0);
+        assert!(r.transforms.iter().any(|t| t == "fallback.whitespace"));
     }
 }

--- a/mur-compress/src/stats.rs
+++ b/mur-compress/src/stats.rs
@@ -36,6 +36,8 @@ struct StatsData {
     total_input_tokens: u64,
     total_output_tokens: u64,
     total_tokens_saved: u64,
+    #[serde(default)]
+    skipped: u64,
 
     /// Per-version, per-day segmentation: `mur_version -> "YYYY-MM-DD"
     /// (local date) -> counts for that version on that day`. Absent for any
@@ -61,6 +63,8 @@ pub struct TypeStats {
     pub total_input_tokens: u64,
     pub total_output_tokens: u64,
     pub total_tokens_saved: u64,
+    #[serde(default)]
+    pub skipped: u64,
 }
 
 /// Counts for one `(mur_version, day)` bucket. Mirrors the shape of the
@@ -73,6 +77,8 @@ pub struct BucketData {
     pub total_input_tokens: u64,
     pub total_output_tokens: u64,
     pub total_tokens_saved: u64,
+    #[serde(default)]
+    pub skipped: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -82,6 +88,7 @@ pub struct StatsSnapshot {
     pub total_input_tokens: u64,
     pub total_output_tokens: u64,
     pub total_tokens_saved: u64,
+    pub skipped: u64,
     pub savings_percent: f32,
     pub estimated_cost_saved_usd: f64,
     pub store_entries: usize,
@@ -208,6 +215,26 @@ impl StatsTracker {
         });
     }
 
+    /// Record a deliberate skip (early-skip gate): the input was inspected
+    /// and passed through untouched. Counted separately from compressions
+    /// so by_type ratios reflect real compression work.
+    pub fn record_skip(&self, content_type: &str) {
+        let day = today_key();
+        self.update(|d| {
+            d.skipped += 1;
+            d.buckets
+                .entry(current_version().to_string())
+                .or_default()
+                .entry(day)
+                .or_default()
+                .skipped += 1;
+            d.by_type
+                .entry(content_type.to_string())
+                .or_default()
+                .skipped += 1;
+        });
+    }
+
     pub fn snapshot(
         &self,
         cost_per_mtok_usd: f64,
@@ -231,6 +258,7 @@ impl StatsTracker {
             total_input_tokens: d.total_input_tokens,
             total_output_tokens: d.total_output_tokens,
             total_tokens_saved: d.total_tokens_saved,
+            skipped: d.skipped,
             savings_percent: pct,
             estimated_cost_saved_usd: cost,
             store_entries,
@@ -366,5 +394,31 @@ mod tests {
         assert_eq!(json.compressions, 2);
         assert_eq!(json.total_input_tokens, 1500);
         assert_eq!(json.total_tokens_saved, 1350);
+    }
+
+    #[test]
+    fn record_skip_counts_separately() {
+        let dir = tempfile::tempdir().unwrap();
+        let t = StatsTracker::new(dir.path().join("stats.json"));
+        t.record_compression("generic", 100, 50);
+        t.record_skip("generic");
+        t.record_skip("generic");
+        let snap = t.snapshot(3.0, 0, 0);
+        assert_eq!(snap.compressions, 1);
+        assert_eq!(snap.skipped, 2);
+        assert_eq!(snap.by_type.get("generic").unwrap().skipped, 2);
+        // compressions untouched by skips
+        assert_eq!(snap.by_type.get("generic").unwrap().compressions, 1);
+    }
+
+    #[test]
+    fn old_stats_json_without_skipped_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("stats.json");
+        std::fs::write(&p, r#"{"compressions":5,"retrievals":1,"total_input_tokens":10,"total_output_tokens":5,"total_tokens_saved":5}"#).unwrap();
+        let t = StatsTracker::new(p);
+        let snap = t.snapshot(3.0, 0, 0);
+        assert_eq!(snap.compressions, 5);
+        assert_eq!(snap.skipped, 0);
     }
 }


### PR DESCRIPTION
## Summary
Closes the two worst compression gaps found by production by_type stats (json 1.7%, generic ~0%):

- **JSON deep collapse** — recursive tree walk: nested arrays at any depth collapse to `{_schema,_total,_shown,sample,_note}`; long string leaves (≥ `json.max_string_tokens`, default 200) elide with head slice; query-aware BM25 sampling (original order). One hash per document; original stays byte-for-byte retrievable; sentinel-collision guard on the canonical minified form.
- **Generic early-skip** — the whitespace fallback's savings are exactly precomputed in one scan; below `fallback.min_save_ratio` (default 0.05) the engine skips (no compressor run, no CCR write) and records a new `skipped` stat instead of a fake 0%-compression.

Spec: `docs/superpowers/specs/2026-07-13-compress-optimization-design.md`
Plan: `docs/superpowers/plans/2026-07-13-compress-optimization.md`

## Test plan
- [x] `cargo nextest run -p mur-compress` — 76/76
- [x] `cargo clippy -p mur-compress -- -D warnings` + `cargo fmt --check` clean
- [x] Old `compress.yaml` / `stats.json` without the new fields still load (tests)
- [x] Per-task + whole-branch reviews clean (SDD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)