### PR TITLE
fix(gui-core): panel_bridge client spawn race — atomic pid reservation

### DIFF
--- a/mur-gui-core/src/panel_bridge/client.rs
+++ b/mur-gui-core/src/panel_bridge/client.rs
@@ -27,19 +27,30 @@ pub(crate) fn spawn(
             return;
         };
         let pid = sess.pid;
-        if senders.lock().unwrap().contains_key(&pid) {
-            return; // scan/watcher overlap
+        // Atomic check+reserve under one lock: the scan and the watcher can
+        // both spawn for the same record (FSEvents replays creates from just
+        // before the watch started). The old check-then-connect-then-insert
+        // left a window where both tasks connected and the later insert
+        // overwrote the earlier sender — closing the earlier task's channel,
+        // dropping its live stream (peer sees BrokenPipe), and its cleanup
+        // then removed the winner's entry too.
+        let (out_tx, mut out_rx) = mpsc::channel::<HubFrame>(16);
+        {
+            let mut guard = senders.lock().unwrap();
+            if guard.contains_key(&pid) {
+                return; // scan/watcher overlap
+            }
+            guard.insert(pid, out_tx.clone());
         }
         let Ok(stream) = UnixStream::connect(&sess.sock).await else {
             // Socket gone but record present: crashed murmur. Reap.
+            senders.lock().unwrap().remove(&pid);
             tracing::debug!("panel_bridge: reaping dead session pid={pid}");
             let _ = std::fs::remove_file(&json_path);
             let _ = std::fs::remove_file(&sess.sock);
             return;
         };
         tracing::info!("panel_bridge: connected to murmur session pid={pid}");
-        let (out_tx, mut out_rx) = mpsc::channel::<HubFrame>(16);
-        senders.lock().unwrap().insert(pid, out_tx);
         let (r, mut w) = stream.into_split();
         let mut lines = BufReader::new(r).lines();
 
@@ -65,7 +76,14 @@ pub(crate) fn spawn(
                 },
             }
         }
-        senders.lock().unwrap().remove(&pid);
+        // Remove only OUR entry: with atomic reservation no duplicate should
+        // exist, but guard against removing a newer session's sender anyway.
+        {
+            let mut guard = senders.lock().unwrap();
+            if guard.get(&pid).is_some_and(|s| s.same_channel(&out_tx)) {
+                guard.remove(&pid);
+            }
+        }
         let _ = tx.send(PanelEvent::SessionDown { pid }).await;
     });
 }

--- a/mur-gui-core/src/panel_bridge/mod.rs
+++ b/mur-gui-core/src/panel_bridge/mod.rs
@@ -213,4 +213,48 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
         assert!(!json.exists());
     }
+
+    /// Regression: the scan and the watcher can both spawn a client for the
+    /// same session record. The duplicate must lose at the atomic reservation
+    /// — never overwrite the winner's sender (which closed its channel,
+    /// dropped its live stream mid-use, and broke the peer with EPIPE).
+    #[tokio::test]
+    async fn duplicate_spawn_keeps_first_connection_alive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (listener, json) = fake_murmur(tmp.path(), 7003).await;
+        let senders: Senders = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, mut rx) = mpsc::channel(16);
+        let rt = tokio::runtime::Handle::current();
+        client::spawn(rt.clone(), json.clone(), senders.clone(), tx.clone());
+        client::spawn(rt, json, senders.clone(), tx);
+
+        let (stream, _) = timeout(Duration::from_secs(5), listener.accept())
+            .await
+            .unwrap()
+            .unwrap();
+        // Let both tasks settle: exactly one owns the pid.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(senders.lock().unwrap().len(), 1);
+
+        // The accepted connection must still be writable end-to-end.
+        let (_r, mut w) = stream.into_split();
+        let frame_line = serde_json::to_string(&PanelFrame::Panel {
+            focus: mur_common::panel::PanelTab::Information,
+        })
+        .unwrap();
+        w.write_all(format!("{frame_line}\n").as_bytes())
+            .await
+            .expect("first connection must not be broken by the duplicate spawn");
+        let ev = timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            ev,
+            PanelEvent::Frame {
+                pid: 7003,
+                frame: PanelFrame::Panel { .. }
+            }
+        ));
+    }
 }


### PR DESCRIPTION
## Summary
Root-causes the red macos-14 check on #693 (BrokenPipe in `panel_bridge::tests::discovers_pumps_and_reports_down`) — not a flake in the test, a real race in `client::spawn`:

1. `PanelBridge::start` registers the watcher then scans — macOS FSEvents can replay a Create from just before the watch, so the same `<pid>.json` spawns two clients.
2. The dedup was check → async connect → insert: both tasks pass the check, both connect, the later `insert` **overwrites** the earlier sender → the earlier task's channel closes → it drops its live stream (peer gets EPIPE) → its cleanup then `remove(&pid)`s the **winner's** entry too.

In production this can silently disconnect a live murmur panel session from the Hub.

## Fix
- Atomic check+reserve under one lock before connecting; duplicate loses pre-connect.
- Connect failure releases the reservation.
- Exit cleanup removes only our own entry (`same_channel` guard).

## Test plan
- [x] New regression test `duplicate_spawn_keeps_first_connection_alive` (double-spawn same record; first connection must stay writable end-to-end)
- [x] `cargo nextest run -p mur-gui-core panel_bridge` ×5 — 3/3 each
- [x] clippy `-D warnings` + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)