### PR TITLE
feat(deep-research): run progress — per-step output, iteration summary, panel in-flight block

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,13 @@ mur deep-research "question"   # preflight (start workers, re-pin gateway) + gua
 
 `provision` / `run` remain as the flag-based advanced path. Egress is only ever granted in `setup`/`provision --grant-egress` (explicit consent); the smart run never touches grants.
 
+Runs report progress: each step prints `✓ s2 research dr_worker_2 $0.08 42s` as it
+completes, every iteration ends with a summary (`iteration 2 done: 3✓ 0✗ 2 pending ·
+spend $0.31/$2.00 · model claude_haiku`), and the bare `mur deep-research` panel shows
+the in-flight run (per-phase counts, running steps, spend vs budget) or the last run's
+outcome. Progress lives in `~/.mur/fleets/deep-research/.run_progress.json` (best-effort;
+never affects the run).
+
 ---
 
 ## 🔨 Build from source

--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -159,6 +159,13 @@ mur deep-research "question"   # preflight (start workers, re-pin gateway) + gua
 
 `provision` / `run` remain as the flag-based advanced path. Egress is only ever granted in `setup`/`provision --grant-egress` (explicit consent); the smart run never touches grants.
 
+**Run progress.** The fleet loop writes a single best-effort `~/.mur/fleets/deep-research/.run_progress.json` (`schema_version: 1`, atomic temp+rename, kept as the last-run record). Every write is best-effort — a progress-file error never fails, slows, or changes the run. Two views render it:
+
+- Run output (log style): one line per completed step (`✓ s2 research dr_worker_2 $0.08 42s`, `✗` for failed) plus a per-iteration summary (`iteration 2 done: 3✓ 0✗ 2 pending · spend $0.31/$2.00 · model claude_haiku`). Existing loop lines are unchanged; these are additions.
+- Bare `mur deep-research` panel: the in-flight run (question, iteration, per-phase done/total, running steps with elapsed, spend vs budget) — labeled stale if the file's mtime is older than `STALE_AFTER_SECS` (10 min) — or the last run's `last run: <outcome> · $<spend> · <n> iterations`. No file → panel unchanged.
+
+Phase (`Probe | Research | Verify | Synthesize | Other`) is a display-only keyword heuristic over the router's assignment text; it never gates the run. The murmur TUI Panel is a Phase-2 consumer of the same file. Spec: `docs/superpowers/specs/2026-07-14-deep-research-run-progress-design.md`.
+
 ---
 
 ## GUI Export (`mur agent export --format gui`)

--- a/docs/superpowers/plans/2026-07-14-deep-research-run-progress.md
+++ b/docs/superpowers/plans/2026-07-14-deep-research-run-progress.md
@@ -1,0 +1,573 @@
+# Deep Research Run Progress Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Per-stage run progress for deep-research: a `.run_progress.json` written by the fleet loop, log-style per-step/per-iteration output, and an in-flight-run block on the bare `mur deep-research` panel.
+
+**Architecture:** A pure progress model (`cmd/fleet/progress.rs`) + an optional step-event observer on the DAG executor + write/print wiring in `loop_run.rs` + a read-only render in `cmd/deep_research/panel.rs`. Single data source, two views (murmur Panel is Phase 2, out of scope).
+
+**Tech Stack:** Rust (edition 2024), serde_json, existing atomic temp+rename write pattern.
+
+**Spec:** `docs/superpowers/specs/2026-07-14-deep-research-run-progress-design.md`
+
+## Global Constraints
+
+- ALL progress-file writes are best-effort: an error must never fail, slow, or change the run (log at `tracing::debug!`, continue).
+- Atomic write = temp file + rename (the `store/yaml.rs` / `ModelRegistry::save_to` pattern).
+- File: `~/.mur/fleets/<name>/.run_progress.json`, `schema_version: 1`, kept after the run (last-run record), overwritten by the next run.
+- Phase classification is a pure heuristic; unclassifiable → `Other`; it never blocks anything.
+- No hardcoded values: stale threshold, file name etc. are named consts.
+- Existing loop output lines stay byte-identical; new lines are additions only.
+- Build env: PATH `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin`, `ORT_STRATEGY=download`, `MUR_WEB_DIST=$HOME/Projects/mur-web/dist`; test via `cargo nextest run -p mur-core <filter>`; `cargo fmt` + `cargo clippy -p mur-core -- -D warnings` before every commit.
+
+---
+
+### Task 1: Progress model (`progress.rs`)
+
+**Files:**
+- Create: `mur-core/src/cmd/fleet/progress.rs`
+- Modify: `mur-core/src/cmd/fleet/mod.rs` (add `pub mod progress;` — check the existing mod list with `grep -n "pub mod" mur-core/src/cmd/fleet/mod.rs`)
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces (used by Tasks 2–4):
+  - `pub const PROGRESS_FILE: &str = ".run_progress.json";`
+  - `pub const STALE_AFTER_SECS: u64 = 600;`
+  - `#[derive(Serialize, Deserialize)] pub struct RunProgress { pub schema_version: u32, pub run_id: String, pub question: String, pub started_at: String, pub finished_at: Option<String>, pub outcome: Option<String>, pub iteration: u32, pub model: Option<String>, pub budget_usd: Option<f64>, pub spend_usd: f64, pub steps: Vec<StepProgress> }`
+  - `#[derive(Serialize, Deserialize)] pub struct StepProgress { pub id: String, pub worker: Option<String>, pub phase: Phase, pub desc: String, pub state: StepState, pub cost_usd: Option<f64>, pub started_at: Option<String>, pub ended_at: Option<String> }`
+  - `#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)] pub enum Phase { Probe, Research, Verify, Synthesize, Other }` (serde rename_all = "snake_case"; same for `StepState { Pending, Running, Done, Failed }`)
+  - `pub fn classify_phase(assignment: &str) -> Phase`
+  - `pub struct Totals { pub done: usize, pub running: usize, pub pending: usize, pub failed: usize }` + `impl RunProgress { pub fn totals(&self) -> Totals }`
+  - `pub fn iteration_summary_line(p: &RunProgress) -> String`
+  - `impl RunProgress { pub fn save(&self, mur_home: &Path, fleet: &str) }` (best-effort, atomic; logs debug on error, returns `()`)
+  - `pub fn load(mur_home: &Path, fleet: &str) -> Option<(RunProgress, std::time::SystemTime)>` (None if missing/corrupt; SystemTime = file mtime for staleness)
+  - `pub fn progress_path(mur_home: &Path, fleet: &str) -> PathBuf` (= `mur_home.join("fleets").join(fleet).join(PROGRESS_FILE)`)
+
+- [ ] **Step 1: Write the failing tests** (bottom of `progress.rs`)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_phase_heuristics() {
+        assert_eq!(classify_phase("Run a single minimal gateway health probe"), Phase::Probe);
+        assert_eq!(classify_phase("Research failure-handling best practices"), Phase::Research);
+        assert_eq!(classify_phase("verify s2's claims under correctness lenses"), Phase::Verify);
+        assert_eq!(classify_phase("Synthesize s1-s3 findings into a cited report"), Phase::Synthesize);
+        assert_eq!(classify_phase("hello world"), Phase::Other);
+    }
+
+    fn sample() -> RunProgress {
+        RunProgress {
+            schema_version: 1,
+            run_id: "r1".into(),
+            question: "q".into(),
+            started_at: "2026-07-14T00:00:00Z".into(),
+            finished_at: None,
+            outcome: None,
+            iteration: 2,
+            model: Some("claude_haiku".into()),
+            budget_usd: Some(2.0),
+            spend_usd: 0.31,
+            steps: vec![
+                StepProgress { id: "s1".into(), worker: Some("dr_worker_1".into()), phase: Phase::Probe, desc: "probe".into(), state: StepState::Done, cost_usd: Some(0.01), started_at: None, ended_at: None },
+                StepProgress { id: "s2".into(), worker: Some("dr_worker_2".into()), phase: Phase::Research, desc: "research".into(), state: StepState::Running, cost_usd: None, started_at: None, ended_at: None },
+                StepProgress { id: "s3".into(), worker: None, phase: Phase::Verify, desc: "verify".into(), state: StepState::Pending, cost_usd: None, started_at: None, ended_at: None },
+            ],
+        }
+    }
+
+    #[test]
+    fn totals_counts_states() {
+        let t = sample().totals();
+        assert_eq!((t.done, t.running, t.pending, t.failed), (1, 1, 1, 0));
+    }
+
+    #[test]
+    fn summary_line_shows_counts_spend_model() {
+        let line = iteration_summary_line(&sample());
+        assert!(line.contains("iteration 2"));
+        assert!(line.contains("1✓"));
+        assert!(line.contains("1 pending"));
+        assert!(line.contains("$0.31/$2.00"));
+        assert!(line.contains("claude_haiku"));
+    }
+
+    #[test]
+    fn save_load_roundtrip_and_missing_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(load(tmp.path(), "deep-research").is_none());
+        let p = sample();
+        p.save(tmp.path(), "deep-research");
+        let (loaded, _mtime) = load(tmp.path(), "deep-research").unwrap();
+        assert_eq!(loaded.iteration, 2);
+        assert_eq!(loaded.steps.len(), 3);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo nextest run -p mur-core fleet::progress`
+Expected: compile FAIL (module missing) after adding the mod decl.
+
+- [ ] **Step 3: Implement**
+
+```rust
+//! Single-source run-progress model for fleet loops (deep-research UX).
+//! Pure data + best-effort atomic persistence; consumers render it
+//! (loop stdout, `mur deep-research` panel, murmur Panel in Phase 2).
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// File name under `~/.mur/fleets/<name>/`. Kept after the run as the
+/// last-run record; overwritten by the next run.
+pub const PROGRESS_FILE: &str = ".run_progress.json";
+/// An in-flight file whose mtime is older than this is labeled stale
+/// (loop probably crashed).
+pub const STALE_AFTER_SECS: u64 = 600;
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    Probe,
+    Research,
+    Verify,
+    Synthesize,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StepState {
+    Pending,
+    Running,
+    Done,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StepProgress {
+    pub id: String,
+    pub worker: Option<String>,
+    pub phase: Phase,
+    pub desc: String,
+    pub state: StepState,
+    pub cost_usd: Option<f64>,
+    pub started_at: Option<String>,
+    pub ended_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunProgress {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub question: String,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    /// converged | max-iterations | deadline | budget | stopped | stuck | failed
+    pub outcome: Option<String>,
+    pub iteration: u32,
+    pub model: Option<String>,
+    pub budget_usd: Option<f64>,
+    pub spend_usd: f64,
+    pub steps: Vec<StepProgress>,
+}
+
+pub struct Totals {
+    pub done: usize,
+    pub running: usize,
+    pub pending: usize,
+    pub failed: usize,
+}
+
+/// Keyword heuristic over the router's assignment text. Unclassifiable
+/// text is `Other` — classification is display-only and never gates the run.
+pub fn classify_phase(assignment: &str) -> Phase {
+    let a = assignment.to_lowercase();
+    if a.contains("probe") || a.contains("health") {
+        Phase::Probe
+    } else if a.contains("synthesi") || a.contains("report") {
+        Phase::Synthesize
+    } else if a.contains("verify") || a.contains("refute") || a.contains("confirm") {
+        Phase::Verify
+    } else if a.contains("research") || a.contains("search") || a.contains("fetch") {
+        Phase::Research
+    } else {
+        Phase::Other
+    }
+}
+
+impl RunProgress {
+    pub fn totals(&self) -> Totals {
+        let mut t = Totals { done: 0, running: 0, pending: 0, failed: 0 };
+        for s in &self.steps {
+            match s.state {
+                StepState::Done => t.done += 1,
+                StepState::Running => t.running += 1,
+                StepState::Pending => t.pending += 1,
+                StepState::Failed => t.failed += 1,
+            }
+        }
+        t
+    }
+
+    /// Best-effort atomic save; errors are logged at debug and swallowed —
+    /// the progress file must never affect the run.
+    pub fn save(&self, mur_home: &Path, fleet: &str) {
+        let res = (|| -> anyhow::Result<()> {
+            let path = progress_path(mur_home, fleet);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let tmp = path.with_extension("json.tmp");
+            std::fs::write(&tmp, serde_json::to_vec_pretty(self)?)?;
+            std::fs::rename(&tmp, &path)?;
+            Ok(())
+        })();
+        if let Err(e) = res {
+            tracing::debug!("run progress save failed (ignored): {e}");
+        }
+    }
+}
+
+pub fn progress_path(mur_home: &Path, fleet: &str) -> PathBuf {
+    mur_home.join("fleets").join(fleet).join(PROGRESS_FILE)
+}
+
+/// None on missing/corrupt file (a corrupt progress file is not an error
+/// condition anywhere). The mtime feeds the panel's staleness label.
+pub fn load(mur_home: &Path, fleet: &str) -> Option<(RunProgress, std::time::SystemTime)> {
+    let path = progress_path(mur_home, fleet);
+    let body = std::fs::read(&path).ok()?;
+    let p: RunProgress = serde_json::from_slice(&body).ok()?;
+    let mtime = std::fs::metadata(&path).ok()?.modified().ok()?;
+    Some((p, mtime))
+}
+
+pub fn iteration_summary_line(p: &RunProgress) -> String {
+    let t = p.totals();
+    format!(
+        "iteration {} done: {}✓ {}✗ {} pending · spend ${:.2}{} · model {}",
+        p.iteration,
+        t.done,
+        t.failed,
+        t.pending,
+        p.spend_usd,
+        p.budget_usd
+            .map(|b| format!("/${b:.2}"))
+            .unwrap_or_default(),
+        p.model.as_deref().unwrap_or("?"),
+    )
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo nextest run -p mur-core fleet::progress`
+Expected: 4 passed.
+
+- [ ] **Step 5: fmt + clippy + commit**
+
+```bash
+cargo fmt && cargo clippy -p mur-core -- -D warnings
+git add mur-core/src/cmd/fleet/
+git commit -m "feat(fleet): run-progress model with atomic best-effort persistence (T1)"
+```
+
+---
+
+### Task 2: DAG step-event observer
+
+**Files:**
+- Modify: `mur-core/src/executor/dag.rs` (`DagExecOptions` ~line 31; the step spawn/completion paths in `execute_step` / rank loop)
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (deliberately decoupled — the observer is generic).
+- Produces (Task 3 relies on):
+  - `#[derive(Debug, Clone)] pub struct StepEvent { pub id: String, pub agent: Option<String>, pub kind: StepEventKind, pub tokens_used: u64 }`
+  - `#[derive(Debug, Clone, Copy, PartialEq)] pub enum StepEventKind { Started, Done, Failed }`
+  - `DagExecOptions.on_step: Option<std::sync::Arc<dyn Fn(StepEvent) + Send + Sync>>` (Default: `None`)
+
+Implementation notes (confirm mechanically):
+- Fire `Started` right before a step begins executing, `Done`/`Failed` where the executor records the step's `StepResult` (grep `struct StepResult` at dag.rs:253 and the sites constructing it in `execute_step_inner`). `tokens_used` = the per-step value already tracked at dag.rs:262 (0 when absent); `agent` = the delegate target for delegated steps — find the field with `grep -n "agent\|delegate" mur-core/src/executor/dag.rs | head -30` (fleet steps are built in `cmd/fleet/plan.rs` / `build_fleet_procedure` — check which ProcedureStep field carries the member name; if it is encoded in `tool`/params, extract from there; `None` when not a delegation).
+- The observer is display-only: call sites must not `?` on it, and a panicking observer must not be possible (it's a plain Fn — document "must not panic" on the field).
+- Because ranks run concurrently (`tokio::spawn`), the closure crosses threads — hence `Arc<dyn Fn + Send + Sync>`.
+- `DagExecOptions` has a lifetime param `<'a>`; the new field is `'static`-owned (Arc), no lifetime change.
+
+- [ ] **Step 1: Write the failing test** (in dag.rs `#[cfg(test)]`, following existing test style there — find it with `grep -n "mod tests" mur-core/src/executor/dag.rs`)
+
+```rust
+#[tokio::test]
+async fn on_step_observer_sees_start_and_done() {
+    use std::sync::{Arc, Mutex};
+    // Two trivial command-mode steps (existing tests show the ProcedureStep
+    // construction pattern — reuse it; `echo ok` steps).
+    let steps = vec![
+        mur_common::skill::manifest::ProcedureStep {
+            description: "one".into(),
+            tool: Some("bash".into()),
+            command: Some("echo one".into()),
+            id: Some("s1".into()),
+            ..Default::default()
+        },
+        mur_common::skill::manifest::ProcedureStep {
+            description: "two".into(),
+            tool: Some("bash".into()),
+            command: Some("echo two".into()),
+            id: Some("s2".into()),
+            ..Default::default()
+        },
+    ];
+    let seen: Arc<Mutex<Vec<(String, StepEventKind)>>> = Arc::new(Mutex::new(vec![]));
+    let sink = seen.clone();
+    let opts = DagExecOptions {
+        on_step: Some(Arc::new(move |e: StepEvent| {
+            sink.lock().unwrap().push((e.id, e.kind));
+        })),
+        ..Default::default()
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    let _ = execute_dag(tmp.path(), "test", &steps, &opts).await.unwrap();
+    let seen = seen.lock().unwrap();
+    assert!(seen.contains(&("s1".into(), StepEventKind::Started)));
+    assert!(seen.contains(&("s1".into(), StepEventKind::Done)));
+    assert!(seen.contains(&("s2".into(), StepEventKind::Done)));
+}
+```
+
+(Adapt the `ProcedureStep` literal to its real fields — check whether `command` exists or commands ride in `tool`/params: `grep -n "command" mur-common/src/skill/manifest.rs | head -5`. If `ProcedureStep` lacks `Default`, construct it the way the existing dag.rs tests do.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo nextest run -p mur-core executor::dag::tests::on_step_observer`
+Expected: compile FAIL (field/types missing).
+
+- [ ] **Step 3: Implement** — add the types + field + `Default` arm (`on_step: None`) + three firing sites:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum StepEventKind {
+    Started,
+    Done,
+    Failed,
+}
+
+/// Display-only step lifecycle event for progress observers. The callback
+/// runs on executor worker tasks: it MUST be cheap and MUST NOT panic.
+#[derive(Debug, Clone)]
+pub struct StepEvent {
+    pub id: String,
+    pub agent: Option<String>,
+    pub kind: StepEventKind,
+    /// Per-step delegate token usage (0 for non-delegate or unknown).
+    pub tokens_used: u64,
+}
+```
+
+Firing pattern at each site (adapt names):
+
+```rust
+if let Some(cb) = &opts.on_step {
+    cb(StepEvent {
+        id: step_id.clone(),
+        agent: delegate_agent.clone(),
+        kind: StepEventKind::Started,
+        tokens_used: 0,
+    });
+}
+```
+
+- [ ] **Step 4: Run tests** — the new test + the whole executor suite:
+
+Run: `cargo nextest run -p mur-core executor::`
+Expected: all pass (no behavior change for `on_step: None`).
+
+- [ ] **Step 5: fmt + clippy + commit**
+
+```bash
+cargo fmt && cargo clippy -p mur-core -- -D warnings
+git add mur-core/src/executor/dag.rs
+git commit -m "feat(executor): optional on_step observer for DAG step lifecycle (T2)"
+```
+
+---
+
+### Task 3: Loop wiring — write progress + print step/summary lines
+
+**Files:**
+- Modify: `mur-core/src/cmd/fleet/loop_run.rs` (`run_guarded`, iteration body ~lines 398-475)
+
+**Interfaces:**
+- Consumes: Task 1 (`RunProgress`, `StepProgress`, `classify_phase`, `iteration_summary_line`, `save`), Task 2 (`on_step`, `StepEvent`, `StepEventKind`), existing `iteration_cost_usd`/`price_per_1k`.
+- Produces: the written `.run_progress.json` contract Task 4 reads; no new public API.
+
+Behavior to implement inside `run_guarded`:
+1. Before the loop: build `RunProgress` (`run_id` = a uuid for the whole run, `question` = `fleet.goal`, `started_at` = now RFC3339, `model` = first member's `AgentProfile::load(mur_home, name).ok().and_then(|p| p.model_ref)`, `budget_usd` = the effective budget already computed, `spend_usd` = 0, `iteration` = 0, `steps` = empty) wrapped in `std::sync::Arc<std::sync::Mutex<RunProgress>>`; `save` immediately.
+2. Iteration start (right after `proc` is obtained): lock, set `iteration = iteration + 1`, APPEND this iteration's steps as `Pending` (`id` = step id or index, `worker` = delegate target if extractable — same source as Task 2's `agent`, `phase` = `classify_phase(&step.description)`, `desc` = first 120 chars of description), save.
+3. Build `opts.on_step` closure (clone of the Arc<Mutex>, plus `price_per_1k` copied in): on `Started` → mark step Running + `started_at`, save, no print; on `Done`/`Failed` → mark state, `ended_at`, `cost_usd = Some(iteration_cost_usd(e.tokens_used, price_per_1k))` when `tokens_used > 0`, save, and print one line:
+   `println!("  {} {} {} {} {}", mark, e.id, phase_str, worker_str, cost_str)` → rendered like `✓ s2 research dr_worker_2 $0.08` (`✗` for Failed; omit cost when None). Elapsed seconds = from the step's `started_at` if present, appended as `42s`.
+4. After `execute_dag` returns and `spent` is updated: lock, set `spend_usd = spent`, save, `println!("{}", iteration_summary_line(&locked))`.
+5. On every loop exit path (the `break LoopStop::…` values and the guard-stop return): set `finished_at` + `outcome` (map `LoopStop::Converged→"converged"`, `MaxIterations→"max-iterations"`, `Deadline→"deadline"`, `Stuck→"stuck"`, `BudgetExceeded→"budget"` — check the real variant names at loop_run.rs:35 — commander/stopped variants likewise), save. Easiest single point: after the `let (stop, iteration, spent) = …` binding where the loop result is known (grep the exact return shape; `run_guarded` returns `Ok((stop, iteration, spent))` at ~line 478).
+6. Everything is best-effort: `save()` already swallows errors; the closure must not panic (use `unwrap_or_else(|e| e.into_inner())` on the mutex like `task_runner.rs` does).
+
+- [ ] **Step 1: Write the failing test.** Full-loop tests can't run live agents, but `run_loop_for_test` (loop_run.rs:787) exercises guard short-circuits. Add:
+
+```rust
+#[tokio::test]
+async fn progress_file_written_with_outcome_on_guard_stop() {
+    let tmp = tempfile::tempdir().unwrap();
+    // run_loop_for_test drives run_guarded to a guard stop (see existing
+    // commander tests for the setup pattern — reuse their fleet fixture).
+    let _stop = run_loop_for_test(tmp.path()).await;
+    let (p, _) = crate::cmd::fleet::progress::load(tmp.path(), "dev")
+        .expect("progress file written");
+    assert_eq!(p.schema_version, 1);
+    assert!(p.finished_at.is_some());
+    assert!(p.outcome.is_some());
+}
+```
+
+(Adapt the fleet name to what `run_loop_for_test` creates — read that helper first; if it stops before entering `run_guarded`'s body, assert only on the fields the reached path writes, and say so in the report.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo nextest run -p mur-core loop_run::tests::progress_file_written`
+Expected: FAIL (no file written yet).
+
+- [ ] **Step 3: Implement** per the behavior list above.
+
+- [ ] **Step 4: Run the fleet suite**
+
+Run: `cargo nextest run -p mur-core fleet:: && cargo nextest run -p mur-core loop_run`
+Expected: all pass, including existing guard/budget tests unchanged.
+
+- [ ] **Step 5: fmt + clippy + commit**
+
+```bash
+cargo fmt && cargo clippy -p mur-core -- -D warnings
+git add mur-core/src/cmd/fleet/
+git commit -m "feat(fleet): loop writes run progress + per-step/iteration output (T3)"
+```
+
+---
+
+### Task 4: Panel integration
+
+**Files:**
+- Modify: `mur-core/src/cmd/deep_research/panel.rs` (`render_panel` + `cmd_panel`)
+
+**Interfaces:**
+- Consumes: Task 1 `progress::{load, RunProgress, StepState, STALE_AFTER_SECS}`; existing `DeepResearchStatus`, `DEFAULT_FLEET_NAME`.
+- Produces: `render_progress(p: &RunProgress, mtime_age_secs: u64) -> String` (pure, unit-tested); `render_panel` gains an `Option<(RunProgress, u64)>` parameter — update its two existing callers/tests accordingly.
+
+Rendering rules (from spec §4):
+- In-flight (`finished_at.is_none()`): a "Run in progress" block — question (truncated 80 chars), `iteration N`, per-phase `done/total` counts, each `Running` step as `⏳ s2 research dr_worker_2 (42s)`, `spend $x/$y`, elapsed since `started_at`. If `mtime_age_secs > STALE_AFTER_SECS`, append `⚠ no update for <m> min — run may have crashed (mur fleet stop/start deep-research)`.
+- Finished: single line `last run: <outcome> · $<spend> · <iteration> iterations`.
+- No file: no block (panel unchanged).
+
+- [ ] **Step 1: Write the failing tests** (extend `panel.rs` tests)
+
+```rust
+#[test]
+fn panel_shows_in_flight_run_block() {
+    let p = progress_fixture(None); // helper: finished_at None, 1 done 1 running 1 pending
+    let out = render_progress(&p, 30);
+    assert!(out.contains("Run in progress"));
+    assert!(out.contains("iteration 2"));
+    assert!(out.contains("$0.31"));
+    assert!(!out.contains("crashed"));
+}
+
+#[test]
+fn panel_marks_stale_run() {
+    let p = progress_fixture(None);
+    let out = render_progress(&p, STALE_AFTER_SECS + 1);
+    assert!(out.contains("run may have crashed"));
+}
+
+#[test]
+fn panel_shows_last_run_line_when_finished() {
+    let p = progress_fixture(Some(("converged", "2026-07-14T01:00:00Z")));
+    let out = render_progress(&p, 10_000);
+    assert!(out.contains("last run: converged"));
+    assert!(!out.contains("crashed"));
+}
+```
+
+(`progress_fixture` builds a `RunProgress` literal — same shape as Task 1's `sample()`; the `Some((outcome, finished_at))` variant fills both fields.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo nextest run -p mur-core deep_research::panel`
+Expected: FAIL (render_progress missing).
+
+- [ ] **Step 3: Implement** `render_progress` + wire `cmd_panel`:
+
+```rust
+pub fn cmd_panel(mur_home: &Path) -> anyhow::Result<()> {
+    let progress = crate::cmd::fleet::progress::load(mur_home, DEFAULT_FLEET_NAME).map(|(p, mtime)| {
+        let age = mtime.elapsed().map(|d| d.as_secs()).unwrap_or(0);
+        (p, age)
+    });
+    print!("{}", render_panel(&collect_status(mur_home, DEFAULT_FLEET_NAME), progress));
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo nextest run -p mur-core deep_research::`
+Expected: all pass (old panel tests updated for the new parameter, still asserting the same strings).
+
+- [ ] **Step 5: fmt + clippy + commit**
+
+```bash
+cargo fmt && cargo clippy -p mur-core -- -D warnings
+git add mur-core/src/cmd/deep_research/panel.rs
+git commit -m "feat(deep-research): panel shows in-flight/last run progress (T4)"
+```
+
+---
+
+### Task 5: Docs + operator verification checklist
+
+**Files:**
+- Modify: `README.md` (deep-research section: one short paragraph on run progress + panel)
+- Modify: `docs/architecture/runtime-overview.md` (same content, deep-research subsection)
+
+- [ ] **Step 1: Add the copy**
+
+```markdown
+Runs now report progress: each step prints `✓ s2 research dr_worker_2 $0.08 42s`
+as it completes, every iteration ends with a summary
+(`iteration 2 done: 3✓ 0✗ 2 pending · spend $0.31/$2.00 · model claude_haiku`),
+and `mur deep-research` (bare) shows the in-flight run — per-phase counts,
+running steps, spend vs budget — or the last run's outcome. Progress lives in
+`~/.mur/fleets/deep-research/.run_progress.json` (best-effort; never affects the run).
+```
+
+- [ ] **Step 2: Operator verification (manual; record in PR body)**
+1. Start a real run; confirm per-step lines + iteration summaries appear.
+2. In another terminal mid-run: `mur deep-research` shows the in-progress block.
+3. After the run: bare panel shows `last run: …`.
+4. Kill the loop mid-run; after >10 min the panel labels the run stale.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md docs/architecture/runtime-overview.md
+git commit -m "docs(deep-research): run progress output + panel (T5)"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: §1→T1, §2→T2+T3, §3→T3, §4→T4, §5 explicitly out of scope (schema_version reserved in T1), §6→tests in each task + T5 operator checklist.
+- Interface-confirmation points (not placeholders) are flagged with exact greps: ProcedureStep command/delegate fields (T2), LoopStop variant names and `run_loop_for_test` reach (T3).
+- Type consistency: `RunProgress`/`StepProgress`/`Phase`/`StepState` defined once (T1); `StepEvent`/`StepEventKind` once (T2); `render_progress(p, age_secs)` signature consistent between T4 steps.

--- a/docs/superpowers/specs/2026-07-14-deep-research-run-progress-design.md
+++ b/docs/superpowers/specs/2026-07-14-deep-research-run-progress-design.md
@@ -1,0 +1,83 @@
+# Deep Research Run Progress — Design
+
+Date: 2026-07-14
+Status: Approved (brainstorm)
+Related: `2026-07-13-deep-research-ux-simplification-design.md` (Phase 1 shipped: setup/panel/ask)
+
+## Problem
+
+A deep-research run is silent for minutes at a time: the loop prints only iteration
+headers and router assignments, and the bare `mur deep-research` panel shows nothing
+about an in-flight run. The user cannot see how many steps are done vs pending, what
+each stage is doing, what it costs, or which model is running.
+
+## Decision (from brainstorm)
+
+Single progress source, multiple views (approach 1): the fleet loop writes a
+`.run_progress.json` per event; the run command renders log-style lines + per-iteration
+summaries from the same data; the bare panel shows the in-flight (or last) run.
+murmur Panel rendering is Phase 2 on the same file.
+
+## §1 Progress model
+
+New pure module `mur-core/src/cmd/fleet/progress.rs`:
+
+- `RunProgress { schema_version: 1, run_id, question, started_at, finished_at: Option, outcome: Option<Outcome>, iteration, model, budget_usd: Option<f64>, steps: Vec<StepProgress>, }`
+- `Outcome`: `Converged | MaxIterations | Deadline | Budget | Stopped | Failed`
+  (mirrors the loop's existing `LoopStop` reasons).
+- `StepProgress { id, worker, phase: Phase, desc, state: StepState, cost_usd: Option<f64>, started_at: Option, ended_at: Option }`
+- `Phase`: `Probe | Research | Verify | Synthesize | Other` — classified from the
+  router assignment text by a pure heuristic (keyword match, case-insensitive);
+  unclassifiable → `Other`, never blocks the run.
+- `StepState`: `Pending | Running | Done | Failed`.
+- `totals()` computed, not stored: `{done, running, pending, failed, spend_usd}`.
+
+## §2 Write points
+
+In `loop_run.rs` (and the DAG execution seam it drives):
+
+- Iteration start: all planned steps written as `Pending` (this is what makes
+  "N pending" real).
+- Step dispatched → `Running` (+ `started_at`); reply received → `Done`
+  (+ `ended_at`, per-turn token cost when available); step failure → `Failed`.
+- Run end: `finished_at` + `outcome` written; file kept as the last-run record and
+  overwritten by the next run.
+- File: `~/.mur/fleets/<name>/.run_progress.json`, atomic temp+rename (yaml.rs
+  pattern). ALL writes best-effort — a progress-file error must never fail or slow
+  the run (log at debug, continue).
+
+## §3 Run output (log style)
+
+Existing lines stay. Added:
+
+- one line per step completion/failure: `✓ s2 research dr_worker_2 $0.08 42s`
+  (`✗` for failed);
+- per-iteration summary line:
+  `iteration 2 done: 3✓ 0✗ 2 pending · spend $0.31/$2.00 · model claude_haiku`.
+
+No in-place TUI redraw; append-only so logs stay pasteable.
+
+## §4 Bare panel integration
+
+`mur deep-research` reads the progress file:
+
+- In-flight (`finished_at` absent): "Run in progress" block — question, iteration,
+  per-phase done/pending counts, currently running steps (worker + phase + elapsed),
+  spend vs budget, total elapsed. If the file's mtime is older than 10 minutes it is
+  labeled stale ("possibly crashed — check `mur fleet stop/start`").
+- Finished: one line — `last run: converged · $0.61 · 4 iterations · <ended>`.
+- No file: panel unchanged.
+
+## §5 Phase 2 (murmur Panel)
+
+Separate plan later: the murmur TUI Panel (glass box) renders a deep-research
+progress block from the same file via the panel bridge. This spec only reserves
+`schema_version: 1` in the file for that consumer.
+
+## §6 Testing
+
+- Pure unit tests: phase classification, totals, finished/stale detection,
+  summary-line rendering.
+- Atomic-write reuses the existing tested pattern.
+- Panel rendering: string-assertion tests like `panel.rs`.
+- Live loop behavior remains operator-verified (fleet loop dials live sockets).

--- a/mur-core/src/cmd/deep_research/panel.rs
+++ b/mur-core/src/cmd/deep_research/panel.rs
@@ -3,8 +3,9 @@
 use std::path::Path;
 
 use super::status::{DEFAULT_FLEET_NAME, DeepResearchStatus, collect_status};
+use crate::cmd::fleet::progress::{Phase, RunProgress, STALE_AFTER_SECS, StepState};
 
-pub fn render_panel(s: &DeepResearchStatus) -> String {
+pub fn render_panel(s: &DeepResearchStatus, progress: Option<(RunProgress, u64)>) -> String {
     if s.workers.is_empty() {
         return "Deep research is not set up yet.\n  Run `mur deep-research setup` to configure workers, model, budget and egress.\n".to_string();
     }
@@ -33,14 +34,97 @@ pub fn render_panel(s: &DeepResearchStatus) -> String {
             },
         ));
     }
+    if let Some((p, age)) = progress {
+        out.push_str(&render_progress(&p, age));
+    }
     out.push_str("\nRun research with: mur deep-research \"<your question>\"\n");
     out
 }
 
+/// Render the in-flight (or last) run block from the progress file. Pure over
+/// `(progress, file-mtime-age-secs)`; `age` only drives the staleness warning.
+pub fn render_progress(p: &RunProgress, mtime_age_secs: u64) -> String {
+    // Finished run → one recap line.
+    if p.finished_at.is_some() {
+        return format!(
+            "\nlast run: {} · ${:.2} · {} iteration{}\n",
+            p.outcome.as_deref().unwrap_or("?"),
+            p.spend_usd,
+            p.iteration,
+            if p.iteration == 1 { "" } else { "s" },
+        );
+    }
+
+    // In-flight run block.
+    let mut out = String::from("\nRun in progress\n");
+    let q: String = p.question.chars().take(80).collect();
+    out.push_str(&format!("  {q}\n"));
+    out.push_str(&format!("  iteration {}\n", p.iteration));
+
+    // Per-phase done/total counts (only phases actually present).
+    let mut parts = Vec::new();
+    for ph in [
+        Phase::Probe,
+        Phase::Research,
+        Phase::Verify,
+        Phase::Synthesize,
+        Phase::Other,
+    ] {
+        let total = p.steps.iter().filter(|s| s.phase == ph).count();
+        if total == 0 {
+            continue;
+        }
+        let done = p
+            .steps
+            .iter()
+            .filter(|s| s.phase == ph && s.state == StepState::Done)
+            .count();
+        parts.push(format!("{} {done}/{total}", ph.label()));
+    }
+    if !parts.is_empty() {
+        out.push_str(&format!("  {}\n", parts.join(" · ")));
+    }
+
+    // Currently-running steps: `⏳ s2 research dr_worker_2 (42s)`.
+    for s in p.steps.iter().filter(|s| s.state == StepState::Running) {
+        let worker = s.worker.as_deref().unwrap_or("");
+        let el = elapsed_secs(s.started_at.as_deref())
+            .map(|n| format!(" ({n}s)"))
+            .unwrap_or_default();
+        out.push_str(&format!("  ⏳ {} {} {worker}{el}\n", s.id, s.phase.label()));
+    }
+
+    out.push_str(&format!(
+        "  spend ${:.2}{}\n",
+        p.spend_usd,
+        p.budget_usd
+            .map(|b| format!("/${b:.2}"))
+            .unwrap_or_default(),
+    ));
+
+    if mtime_age_secs > STALE_AFTER_SECS {
+        out.push_str(&format!(
+            "  ⚠ no update for {} min — run may have crashed (mur fleet stop/start {DEFAULT_FLEET_NAME})\n",
+            mtime_age_secs / 60,
+        ));
+    }
+    out
+}
+
+/// Whole seconds from an RFC3339 timestamp to now; None if unparseable or in
+/// the future. Best-effort — a bad timestamp just omits the elapsed hint.
+fn elapsed_secs(started: Option<&str>) -> Option<i64> {
+    let start = chrono::DateTime::parse_from_rfc3339(started?).ok()?;
+    let secs = (chrono::Utc::now() - start.with_timezone(&chrono::Utc)).num_seconds();
+    (secs >= 0).then_some(secs)
+}
+
 pub fn cmd_panel(mur_home: &Path) -> anyhow::Result<()> {
+    let progress = crate::cmd::fleet::progress::load(mur_home, DEFAULT_FLEET_NAME)
+        .map(|(p, mtime)| (p, mtime.elapsed().map(|d| d.as_secs()).unwrap_or(0)));
     print!(
         "{}",
-        render_panel(&collect_status(mur_home, DEFAULT_FLEET_NAME))
+        render_panel(&collect_status(mur_home, DEFAULT_FLEET_NAME), progress)
     );
     Ok(())
 }
@@ -49,6 +133,7 @@ pub fn cmd_panel(mur_home: &Path) -> anyhow::Result<()> {
 mod tests {
     use super::*;
     use crate::cmd::deep_research::status::{DeepResearchStatus, WorkerStatus};
+    use crate::cmd::fleet::progress::StepProgress;
 
     #[test]
     fn panel_unconfigured_points_at_setup() {
@@ -57,7 +142,7 @@ mod tests {
             fleet_exists: false,
             model: None,
         };
-        let out = render_panel(&s);
+        let out = render_panel(&s, None);
         assert!(out.contains("mur deep-research setup"));
     }
 
@@ -72,9 +157,86 @@ mod tests {
             fleet_exists: true,
             model: Some("claude_haiku".into()),
         };
-        let out = render_panel(&s);
+        let out = render_panel(&s, None);
         assert!(out.contains("dr_worker_1"));
         assert!(out.contains("running"));
         assert!(out.contains("claude_haiku"));
+    }
+
+    /// `finished`: Some((outcome, finished_at)) → finished run; None → in-flight
+    /// with 1 done / 1 running / 1 pending, iteration 2, spend $0.31.
+    fn progress_fixture(finished: Option<(&str, &str)>) -> RunProgress {
+        RunProgress {
+            schema_version: 1,
+            run_id: "r1".into(),
+            question: "compare local LLM runtimes".into(),
+            started_at: "2026-07-14T00:00:00Z".into(),
+            finished_at: finished.map(|(_, f)| f.into()),
+            outcome: finished.map(|(o, _)| o.into()),
+            iteration: 2,
+            model: Some("claude_haiku".into()),
+            budget_usd: Some(2.0),
+            spend_usd: 0.31,
+            steps: vec![
+                StepProgress {
+                    id: "s1".into(),
+                    worker: Some("dr_worker_1".into()),
+                    phase: Phase::Probe,
+                    desc: "probe".into(),
+                    state: StepState::Done,
+                    cost_usd: Some(0.01),
+                    started_at: None,
+                    ended_at: None,
+                },
+                StepProgress {
+                    id: "s2".into(),
+                    worker: Some("dr_worker_2".into()),
+                    phase: Phase::Research,
+                    desc: "research".into(),
+                    state: StepState::Running,
+                    cost_usd: None,
+                    started_at: None,
+                    ended_at: None,
+                },
+                StepProgress {
+                    id: "s3".into(),
+                    worker: None,
+                    phase: Phase::Verify,
+                    desc: "verify".into(),
+                    state: StepState::Pending,
+                    cost_usd: None,
+                    started_at: None,
+                    ended_at: None,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn panel_shows_in_flight_run_block() {
+        let p = progress_fixture(None);
+        let out = render_progress(&p, 30);
+        assert!(out.contains("Run in progress"));
+        assert!(out.contains("iteration 2"));
+        assert!(out.contains("$0.31"));
+        assert!(out.contains("⏳ s2 research dr_worker_2"));
+        assert!(!out.contains("crashed"));
+    }
+
+    #[test]
+    fn panel_marks_stale_run() {
+        let p = progress_fixture(None);
+        let out = render_progress(&p, STALE_AFTER_SECS + 1);
+        assert!(out.contains("run may have crashed"));
+    }
+
+    #[test]
+    fn panel_shows_last_run_line_when_finished() {
+        let p = progress_fixture(Some(("converged", "2026-07-14T01:00:00Z")));
+        let out = render_progress(&p, 10_000);
+        assert!(out.contains("last run: converged"));
+        assert!(out.contains("2 iterations"));
+        assert!(!out.contains("crashed"));
+        assert!(!out.contains("Run in progress"));
     }
 }

--- a/mur-core/src/cmd/deep_research/panel.rs
+++ b/mur-core/src/cmd/deep_research/panel.rs
@@ -45,9 +45,9 @@ pub fn render_panel(s: &DeepResearchStatus, progress: Option<(RunProgress, u64)>
 /// `(progress, file-mtime-age-secs)`; `age` only drives the staleness warning.
 pub fn render_progress(p: &RunProgress, mtime_age_secs: u64) -> String {
     // Finished run → one recap line.
-    if p.finished_at.is_some() {
+    if let Some(ended) = &p.finished_at {
         return format!(
-            "\nlast run: {} · ${:.2} · {} iteration{}\n",
+            "\nlast run: {} · ${:.2} · {} iteration{} · {ended}\n",
             p.outcome.as_deref().unwrap_or("?"),
             p.spend_usd,
             p.iteration,
@@ -102,6 +102,11 @@ pub fn render_progress(p: &RunProgress, mtime_age_secs: u64) -> String {
             .unwrap_or_default(),
     ));
 
+    // Total elapsed since the run started (best-effort; omitted if unparseable).
+    if let Some(n) = elapsed_secs(Some(&p.started_at)) {
+        out.push_str(&format!("  elapsed {}\n", fmt_elapsed(n)));
+    }
+
     if mtime_age_secs > STALE_AFTER_SECS {
         out.push_str(&format!(
             "  ⚠ no update for {} min — run may have crashed (mur fleet stop/start {DEFAULT_FLEET_NAME})\n",
@@ -117,6 +122,15 @@ fn elapsed_secs(started: Option<&str>) -> Option<i64> {
     let start = chrono::DateTime::parse_from_rfc3339(started?).ok()?;
     let secs = (chrono::Utc::now() - start.with_timezone(&chrono::Utc)).num_seconds();
     (secs >= 0).then_some(secs)
+}
+
+/// Compact `Nm Ns` / `Ns` elapsed label.
+fn fmt_elapsed(secs: i64) -> String {
+    if secs >= 60 {
+        format!("{}m {}s", secs / 60, secs % 60)
+    } else {
+        format!("{secs}s")
+    }
 }
 
 pub fn cmd_panel(mur_home: &Path) -> anyhow::Result<()> {
@@ -220,6 +234,7 @@ mod tests {
         assert!(out.contains("iteration 2"));
         assert!(out.contains("$0.31"));
         assert!(out.contains("⏳ s2 research dr_worker_2"));
+        assert!(out.contains("elapsed "));
         assert!(!out.contains("crashed"));
     }
 
@@ -236,6 +251,7 @@ mod tests {
         let out = render_progress(&p, 10_000);
         assert!(out.contains("last run: converged"));
         assert!(out.contains("2 iterations"));
+        assert!(out.contains("2026-07-14T01:00:00Z"));
         assert!(!out.contains("crashed"));
         assert!(!out.contains("Run in progress"));
     }

--- a/mur-core/src/cmd/fleet/loop_run.rs
+++ b/mur-core/src/cmd/fleet/loop_run.rs
@@ -5,6 +5,7 @@
 //! the pure guard helpers below are unit-tested.
 
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
@@ -12,8 +13,12 @@ use mur_common::channel::{ChannelActor, ChannelEvent};
 use mur_common::fleet::{Fleet, Job, JobStatus};
 use sha2::{Digest, Sha256};
 
+use super::progress::{
+    RunProgress, StepProgress, StepState, classify_phase, iteration_summary_line,
+};
 use super::run::build_fleet_procedure;
 use super::store;
+use crate::executor::dag::{StepEvent, StepEventKind};
 
 /// Iterations with no new agent activity before the loop gives up.
 const STUCK_LIMIT: u32 = 2;
@@ -272,6 +277,26 @@ fn emit_governance_audit(
     }
 }
 
+/// Poison-safe lock for the run-progress mutex. The progress data is
+/// display-only, so a panicked holder never invalidates it — recover the
+/// guard rather than propagating the panic into the loop.
+fn lock_progress(p: &Mutex<RunProgress>) -> std::sync::MutexGuard<'_, RunProgress> {
+    p.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Map the loop's stop reason to the progress file's `outcome` string.
+fn outcome_label(stop: LoopStop) -> &'static str {
+    match stop {
+        LoopStop::Converged => "converged",
+        LoopStop::MaxIterations => "max-iterations",
+        LoopStop::Deadline => "deadline",
+        LoopStop::Stuck => "stuck",
+        LoopStop::Budget => "budget",
+        LoopStop::Stopped => "stopped",
+        LoopStop::CommanderKilled => "commander-killed",
+    }
+}
+
 /// Inner guarded loop: runs iterations until a stop reason fires. Returns
 /// `(stop, iterations_completed, spent_usd)`. Extracted so tests can call it
 /// directly and inspect the `LoopStop` without going through the print layer.
@@ -326,6 +351,28 @@ pub async fn run_guarded(
     // Load commander keys once; empty = governance inert.
     let commander_keys = crate::cmd::commander::accepted_pubkeys(mur_home);
     let governed = !commander_keys.is_empty();
+
+    // ── Run progress (deep-research UX): one best-effort JSON the run output +
+    // `mur deep-research` panel render from. Every write is best-effort — a
+    // failure must never fail, slow, or change the loop (see RunProgress::save).
+    let progress = Arc::new(Mutex::new(RunProgress {
+        schema_version: 1,
+        run_id: uuid::Uuid::now_v7().to_string(),
+        question: fleet.goal.clone(),
+        started_at: chrono::Utc::now().to_rfc3339(),
+        finished_at: None,
+        outcome: None,
+        iteration: 0,
+        model: fleet
+            .members
+            .first()
+            .and_then(|m| mur_common::agent::AgentProfile::load(mur_home, m).ok())
+            .and_then(|p| p.model_ref),
+        budget_usd: budget,
+        spend_usd: 0.0,
+        steps: vec![],
+    }));
+    lock_progress(&progress).save(mur_home, name);
 
     let stop = loop {
         // Commander governance (highest priority). Fail-closed: a channel read
@@ -410,6 +457,78 @@ pub async fn run_guarded(
                 build_fleet_procedure(&iter_goal, &fleet.members, fleet.parallel.as_ref())
                     .expect("members validated by caller guard")
             });
+        // Record this iteration's planned steps as Pending (makes "N pending"
+        // real) — replacing the prior iteration's so counts reflect the run now.
+        {
+            let mut g = lock_progress(&progress);
+            g.iteration = iteration + 1;
+            g.steps = proc
+                .steps
+                .iter()
+                .enumerate()
+                .map(|(i, s)| StepProgress {
+                    id: s.id.clone().unwrap_or_else(|| i.to_string()),
+                    worker: s.delegate_to.clone(),
+                    phase: classify_phase(&s.description),
+                    desc: s.description.chars().take(120).collect(),
+                    state: StepState::Pending,
+                    cost_usd: None,
+                    started_at: None,
+                    ended_at: None,
+                })
+                .collect();
+            g.save(mur_home, name);
+        }
+        // Display-only step observer: mutate the shared progress + print one log
+        // line per completed step. Best-effort throughout — the closure never
+        // panics (poison-safe lock) and never affects execution.
+        let step_progress = progress.clone();
+        let step_home = mur_home.to_path_buf();
+        let step_fleet = name.to_string();
+        let on_step: Arc<dyn Fn(StepEvent) + Send + Sync> = Arc::new(move |e: StepEvent| {
+            let mut g = step_progress.lock().unwrap_or_else(|x| x.into_inner());
+            let Some(sp) = g.steps.iter_mut().find(|s| s.id == e.id) else {
+                return;
+            };
+            let now = chrono::Utc::now().to_rfc3339();
+            match e.kind {
+                StepEventKind::Started => {
+                    sp.state = StepState::Running;
+                    sp.started_at = Some(now);
+                }
+                StepEventKind::Done | StepEventKind::Failed => {
+                    let done = e.kind == StepEventKind::Done;
+                    sp.state = if done {
+                        StepState::Done
+                    } else {
+                        StepState::Failed
+                    };
+                    if e.tokens_used > 0 {
+                        sp.cost_usd = Some(iteration_cost_usd(e.tokens_used, price_per_1k));
+                    }
+                    // `✓ s2 research dr_worker_2 $0.08 42s`
+                    let mark = if done { '✓' } else { '✗' };
+                    let phase = sp.phase.label();
+                    let worker = sp.worker.clone().unwrap_or_default();
+                    let cost = sp.cost_usd.map(|c| format!(" ${c:.2}")).unwrap_or_default();
+                    let elapsed = sp
+                        .started_at
+                        .as_deref()
+                        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                        .and_then(|st| {
+                            chrono::DateTime::parse_from_rfc3339(&now)
+                                .ok()
+                                .map(|en| (en - st).num_seconds())
+                        })
+                        .filter(|s| *s >= 0)
+                        .map(|s| format!(" {s}s"))
+                        .unwrap_or_default();
+                    sp.ended_at = Some(now);
+                    println!("  {mark} {} {phase} {worker}{cost}{elapsed}", e.id);
+                }
+            }
+            g.save(&step_home, &step_fleet);
+        });
         let opts = crate::executor::dag::DagExecOptions {
             // Fail-closed on the unattended loop path: never blanket-approve.
             // (No risk tier on fan-out steps today; this guards future
@@ -419,6 +538,7 @@ pub async fn run_guarded(
             // uuid nonce so concurrent `--loop` runs don't collide on the
             // channel's idempotency-key dedup (the iteration stays for readability).
             run_id: format!("loop-{}-{}-{}", name, uuid::Uuid::now_v7(), iteration),
+            on_step: Some(on_step),
             ..Default::default()
         };
         let out =
@@ -441,6 +561,13 @@ pub async fn run_guarded(
         } else {
             projection
         };
+        // Roll cumulative spend into the progress file and print the summary.
+        {
+            let mut g = lock_progress(&progress);
+            g.spend_usd = spent;
+            g.save(mur_home, name);
+            println!("{}", iteration_summary_line(&g));
+        }
 
         // Stuck-detection: did this iteration add any new agent-authored event?
         let events = svc.load_events(&fleet.channel_id)?;
@@ -473,6 +600,16 @@ pub async fn run_guarded(
         }
     };
 
+    // Stamp the terminal state onto the progress file — kept as the last-run
+    // record (overwritten by the next run). Best-effort.
+    {
+        let mut g = lock_progress(&progress);
+        g.finished_at = Some(chrono::Utc::now().to_rfc3339());
+        g.outcome = Some(outcome_label(stop).to_string());
+        g.iteration = iteration;
+        g.spend_usd = spent;
+        g.save(mur_home, name);
+    }
     Ok((stop, iteration, spent))
 }
 
@@ -789,6 +926,43 @@ mod tests {
             .await
             .map(|(stop, _, _)| stop)
             .unwrap_or(LoopStop::MaxIterations)
+    }
+
+    #[tokio::test]
+    async fn progress_file_written_with_outcome_on_guard_stop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let fleet = Fleet {
+            name: "dev".into(),
+            display_name: String::new(),
+            goal: "research question".into(),
+            router: None,
+            members: vec!["pm".into()],
+            team_id: None,
+            channel_id: "fleet-dev".into(),
+            rules: vec![],
+            skills: vec![],
+            loop_cfg: None,
+            parallel: None,
+            requires_programs: vec![],
+        };
+        crate::cmd::fleet::store::save_fleet(home, &fleet).unwrap();
+        mur_channel::ChannelService::open(home)
+            .unwrap()
+            .create_for_fleet("dev", "mur", &["pm".into()])
+            .unwrap();
+        // Kill-switch: the loop stops before any delegation, so no live agent
+        // is needed — but the before-loop and exit progress writes still run.
+        crate::cmd::fleet::control::cmd_fleet_stop(home, "dev").unwrap();
+
+        let stop = run_loop_for_test(home).await;
+        assert_eq!(stop, LoopStop::Stopped);
+
+        let (p, _) = crate::cmd::fleet::progress::load(home, "dev").expect("progress file written");
+        assert_eq!(p.schema_version, 1);
+        assert_eq!(p.question, "research question");
+        assert!(p.finished_at.is_some());
+        assert_eq!(p.outcome.as_deref(), Some("stopped"));
     }
 
     #[tokio::test]

--- a/mur-core/src/cmd/fleet/mod.rs
+++ b/mur-core/src/cmd/fleet/mod.rs
@@ -14,6 +14,10 @@ pub mod list;
 pub mod loop_run;
 pub mod partition_cmd;
 pub mod plan;
+// TODO(T2-T4): remove once loop_run/panel wire this in — pure data + persistence
+// module with no consumer yet in this task.
+#[allow(dead_code)]
+pub mod progress;
 pub mod roster;
 pub mod run;
 pub mod settings;

--- a/mur-core/src/cmd/fleet/mod.rs
+++ b/mur-core/src/cmd/fleet/mod.rs
@@ -14,9 +14,6 @@ pub mod list;
 pub mod loop_run;
 pub mod partition_cmd;
 pub mod plan;
-// TODO(T2-T4): remove once loop_run/panel wire this in — pure data + persistence
-// module with no consumer yet in this task.
-#[allow(dead_code)]
 pub mod progress;
 pub mod roster;
 pub mod run;

--- a/mur-core/src/cmd/fleet/progress.rs
+++ b/mur-core/src/cmd/fleet/progress.rs
@@ -1,0 +1,253 @@
+//! Single-source run-progress model for fleet loops (deep-research UX).
+//! Pure data + best-effort atomic persistence; consumers render it
+//! (loop stdout, `mur deep-research` panel, murmur Panel in Phase 2).
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// File name under `~/.mur/fleets/<name>/`. Kept after the run as the
+/// last-run record; overwritten by the next run.
+pub const PROGRESS_FILE: &str = ".run_progress.json";
+/// An in-flight file whose mtime is older than this is labeled stale
+/// (loop probably crashed).
+pub const STALE_AFTER_SECS: u64 = 600;
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Phase {
+    Probe,
+    Research,
+    Verify,
+    Synthesize,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StepState {
+    Pending,
+    Running,
+    Done,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StepProgress {
+    pub id: String,
+    pub worker: Option<String>,
+    pub phase: Phase,
+    pub desc: String,
+    pub state: StepState,
+    pub cost_usd: Option<f64>,
+    pub started_at: Option<String>,
+    pub ended_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunProgress {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub question: String,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+    /// converged | max-iterations | deadline | budget | stopped | stuck | failed
+    pub outcome: Option<String>,
+    pub iteration: u32,
+    pub model: Option<String>,
+    pub budget_usd: Option<f64>,
+    pub spend_usd: f64,
+    pub steps: Vec<StepProgress>,
+}
+
+pub struct Totals {
+    pub done: usize,
+    pub running: usize,
+    pub pending: usize,
+    pub failed: usize,
+}
+
+/// Keyword heuristic over the router's assignment text. Unclassifiable
+/// text is `Other` — classification is display-only and never gates the run.
+pub fn classify_phase(assignment: &str) -> Phase {
+    let a = assignment.to_lowercase();
+    if a.contains("probe") || a.contains("health") {
+        Phase::Probe
+    } else if a.contains("synthesi") || a.contains("report") {
+        Phase::Synthesize
+    } else if a.contains("verify") || a.contains("refute") || a.contains("confirm") {
+        Phase::Verify
+    } else if a.contains("research") || a.contains("search") || a.contains("fetch") {
+        Phase::Research
+    } else {
+        Phase::Other
+    }
+}
+
+impl RunProgress {
+    pub fn totals(&self) -> Totals {
+        let mut t = Totals {
+            done: 0,
+            running: 0,
+            pending: 0,
+            failed: 0,
+        };
+        for s in &self.steps {
+            match s.state {
+                StepState::Done => t.done += 1,
+                StepState::Running => t.running += 1,
+                StepState::Pending => t.pending += 1,
+                StepState::Failed => t.failed += 1,
+            }
+        }
+        t
+    }
+
+    /// Best-effort atomic save; errors are logged at debug and swallowed —
+    /// the progress file must never affect the run.
+    pub fn save(&self, mur_home: &Path, fleet: &str) {
+        let res = (|| -> anyhow::Result<()> {
+            let path = progress_path(mur_home, fleet);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let tmp = path.with_extension("json.tmp");
+            std::fs::write(&tmp, serde_json::to_vec_pretty(self)?)?;
+            std::fs::rename(&tmp, &path)?;
+            Ok(())
+        })();
+        if let Err(e) = res {
+            tracing::debug!("run progress save failed (ignored): {e}");
+        }
+    }
+}
+
+pub fn progress_path(mur_home: &Path, fleet: &str) -> PathBuf {
+    mur_home.join("fleets").join(fleet).join(PROGRESS_FILE)
+}
+
+/// None on missing/corrupt file (a corrupt progress file is not an error
+/// condition anywhere). The mtime feeds the panel's staleness label.
+pub fn load(mur_home: &Path, fleet: &str) -> Option<(RunProgress, std::time::SystemTime)> {
+    let path = progress_path(mur_home, fleet);
+    let body = std::fs::read(&path).ok()?;
+    let p: RunProgress = serde_json::from_slice(&body).ok()?;
+    let mtime = std::fs::metadata(&path).ok()?.modified().ok()?;
+    Some((p, mtime))
+}
+
+pub fn iteration_summary_line(p: &RunProgress) -> String {
+    let t = p.totals();
+    format!(
+        "iteration {} done: {}✓ {}✗ {} pending · spend ${:.2}{} · model {}",
+        p.iteration,
+        t.done,
+        t.failed,
+        t.pending,
+        p.spend_usd,
+        p.budget_usd
+            .map(|b| format!("/${b:.2}"))
+            .unwrap_or_default(),
+        p.model.as_deref().unwrap_or("?"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_phase_heuristics() {
+        assert_eq!(
+            classify_phase("Run a single minimal gateway health probe"),
+            Phase::Probe
+        );
+        assert_eq!(
+            classify_phase("Research failure-handling best practices"),
+            Phase::Research
+        );
+        assert_eq!(
+            classify_phase("verify s2's claims under correctness lenses"),
+            Phase::Verify
+        );
+        assert_eq!(
+            classify_phase("Synthesize s1-s3 findings into a cited report"),
+            Phase::Synthesize
+        );
+        assert_eq!(classify_phase("hello world"), Phase::Other);
+    }
+
+    fn sample() -> RunProgress {
+        RunProgress {
+            schema_version: 1,
+            run_id: "r1".into(),
+            question: "q".into(),
+            started_at: "2026-07-14T00:00:00Z".into(),
+            finished_at: None,
+            outcome: None,
+            iteration: 2,
+            model: Some("claude_haiku".into()),
+            budget_usd: Some(2.0),
+            spend_usd: 0.31,
+            steps: vec![
+                StepProgress {
+                    id: "s1".into(),
+                    worker: Some("dr_worker_1".into()),
+                    phase: Phase::Probe,
+                    desc: "probe".into(),
+                    state: StepState::Done,
+                    cost_usd: Some(0.01),
+                    started_at: None,
+                    ended_at: None,
+                },
+                StepProgress {
+                    id: "s2".into(),
+                    worker: Some("dr_worker_2".into()),
+                    phase: Phase::Research,
+                    desc: "research".into(),
+                    state: StepState::Running,
+                    cost_usd: None,
+                    started_at: None,
+                    ended_at: None,
+                },
+                StepProgress {
+                    id: "s3".into(),
+                    worker: None,
+                    phase: Phase::Verify,
+                    desc: "verify".into(),
+                    state: StepState::Pending,
+                    cost_usd: None,
+                    started_at: None,
+                    ended_at: None,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn totals_counts_states() {
+        let t = sample().totals();
+        assert_eq!((t.done, t.running, t.pending, t.failed), (1, 1, 1, 0));
+    }
+
+    #[test]
+    fn summary_line_shows_counts_spend_model() {
+        let line = iteration_summary_line(&sample());
+        assert!(line.contains("iteration 2"));
+        assert!(line.contains("1✓"));
+        assert!(line.contains("1 pending"));
+        assert!(line.contains("$0.31/$2.00"));
+        assert!(line.contains("claude_haiku"));
+    }
+
+    #[test]
+    fn save_load_roundtrip_and_missing_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(load(tmp.path(), "deep-research").is_none());
+        let p = sample();
+        p.save(tmp.path(), "deep-research");
+        let (loaded, _mtime) = load(tmp.path(), "deep-research").unwrap();
+        assert_eq!(loaded.iteration, 2);
+        assert_eq!(loaded.steps.len(), 3);
+    }
+}

--- a/mur-core/src/cmd/fleet/progress.rs
+++ b/mur-core/src/cmd/fleet/progress.rs
@@ -23,6 +23,19 @@ pub enum Phase {
     Other,
 }
 
+impl Phase {
+    /// Short lower-case label for log/panel rendering (matches the serde name).
+    pub fn label(self) -> &'static str {
+        match self {
+            Phase::Probe => "probe",
+            Phase::Research => "research",
+            Phase::Verify => "verify",
+            Phase::Synthesize => "synthesize",
+            Phase::Other => "other",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StepState {

--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -55,6 +55,13 @@ pub struct DagExecOptions<'a> {
     /// concurrency, not just cost, or parallel delegations cascade past API
     /// rate limits.
     pub max_concurrency: Option<usize>,
+    /// Optional display-only step-lifecycle observer (run-progress UI, Task 3).
+    /// Fired `Started` before a step executes and `Done`/`Failed` where its
+    /// `StepResult` is recorded. Runs synchronously on executor worker tasks
+    /// (ranks execute concurrently via `tokio::spawn`, hence `Send + Sync`):
+    /// it MUST be cheap and MUST NOT panic. Purely observational — never
+    /// affects control flow. `None` = zero behavior change.
+    pub on_step: Option<std::sync::Arc<dyn Fn(StepEvent) + Send + Sync>>,
 }
 
 impl<'a> Default for DagExecOptions<'a> {
@@ -69,8 +76,32 @@ impl<'a> Default for DagExecOptions<'a> {
             channel_id: None,
             run_id: String::new(),
             max_concurrency: None,
+            on_step: None,
         }
     }
+}
+
+/// Step-lifecycle event kind for `DagExecOptions.on_step`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum StepEventKind {
+    Started,
+    Done,
+    Failed,
+}
+
+/// Display-only step lifecycle event for progress observers. The callback
+/// runs on executor worker tasks: it MUST be cheap and MUST NOT panic.
+// TODO(T3): fields read by the loop_run on_step closure; allow until then.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct StepEvent {
+    pub id: String,
+    /// The delegate target agent, when this step is a delegation. `None`
+    /// otherwise.
+    pub agent: Option<String>,
+    pub kind: StepEventKind,
+    /// Per-step delegate token usage (0 for non-delegate or unknown).
+    pub tokens_used: u64,
 }
 
 /// Deterministic idempotency key for a channel event: stable across a
@@ -439,6 +470,20 @@ async fn execute_step(
 ) -> StepResult {
     let start = std::time::Instant::now();
     let sid = step.id.clone().unwrap_or_else(|| step_index.to_string());
+    let observer_agent = step.delegate_to.clone();
+    // Display-only step lifecycle emit: MUST be cheap and MUST NOT panic
+    // (plain Fn, never `?`'d — see `DagExecOptions.on_step` doc).
+    let emit = |kind: StepEventKind, tokens_used: u64| {
+        if let Some(cb) = &opts.on_step {
+            cb(StepEvent {
+                id: sid.clone(),
+                agent: observer_agent.clone(),
+                kind,
+                tokens_used,
+            });
+        }
+    };
+    emit(StepEventKind::Started, 0);
     // Retries reuse (run_id, step_id); without an attempt discriminator a
     // succeeding retry's events collide with the failed attempt's idem keys and
     // are dropped by the dedup-aware writer. attempt 0 keeps the original keys
@@ -463,6 +508,7 @@ async fn execute_step(
             })
         {
             eprintln!("  Step {sid}: already completed (resume) — skipping");
+            emit(StepEventKind::Done, 0);
             return StepResult {
                 exit_code: 0,
                 output_text: String::new(),
@@ -571,6 +617,14 @@ async fn execute_step(
                 }
             }
         };
+        emit(
+            if result.success {
+                StepEventKind::Done
+            } else {
+                StepEventKind::Failed
+            },
+            result.tokens_used,
+        );
         return result;
     }
 
@@ -607,6 +661,7 @@ async fn execute_step(
             });
         if !decision.allow {
             eprintln!("  Step {sid}: gate denied ({})", decision.reason);
+            emit(StepEventKind::Failed, 0);
             return StepResult {
                 exit_code: 1,
                 output_text: format!("hitl: {}", decision.reason),
@@ -620,6 +675,7 @@ async fn execute_step(
         let now_hash = crate::hitl::pin::action_hash("sh", &input, cid, &sid, "mur");
         if !decision.action_hash.is_empty() && now_hash != decision.action_hash {
             eprintln!("  Step {sid}: hitl_drift at execute boundary — refusing");
+            emit(StepEventKind::Failed, 0);
             return StepResult {
                 exit_code: 1,
                 output_text: "hitl_drift".into(),
@@ -651,6 +707,7 @@ async fn execute_step(
             eprintln!(
                 "  Step {sid}: needs_approval, skipped (yields true) — use `--yes` to auto-approve"
             );
+            emit(StepEventKind::Done, 0);
             return StepResult {
                 exit_code: 0,
                 output_text: String::new(),
@@ -704,6 +761,15 @@ async fn execute_step(
             )
         });
     }
+
+    emit(
+        if result.success {
+            StepEventKind::Done
+        } else {
+            StepEventKind::Failed
+        },
+        result.tokens_used,
+    );
 
     result
 }
@@ -789,6 +855,7 @@ pub async fn execute_dag(
         let opt_trigger = opts.trigger.to_string();
         let opt_chan_id = opts.channel_id.clone();
         let opt_run_id = opts.run_id.clone();
+        let opt_on_step = opts.on_step.clone();
         let mut handles = Vec::new();
         for &i in &indices {
             let step = graph.nodes[i].step.clone();
@@ -799,6 +866,7 @@ pub async fn execute_dag(
             let tr = opt_trigger.clone();
             let chan_id = opt_chan_id.clone();
             let run_id = opt_run_id.clone();
+            let on_step = opt_on_step.clone();
             let sem = sem.clone();
             let mh = mur_home.to_path_buf();
             handles.push(tokio::task::spawn(async move {
@@ -817,6 +885,7 @@ pub async fn execute_dag(
                     channel_id: chan_id,
                     run_id,
                     max_concurrency: None,
+                    on_step,
                 };
                 execute_step(&step, &opts_clone, i, 0, &mh).await
             }));
@@ -1118,6 +1187,33 @@ mod tests {
 
     // channel_run_refuses_needs_approval removed: v3c gates via hitl::gate instead
     // of refusing. See high_risk_step_gates_and_runs_when_preapproved below.
+
+    #[tokio::test]
+    async fn on_step_observer_sees_start_and_done() {
+        use std::sync::{Arc, Mutex};
+
+        let proc = Procedure {
+            variables: vec![],
+            steps: vec![
+                step("s1", &[], Some("echo one")),
+                step("s2", &[], Some("echo two")),
+            ],
+        };
+        let seen: Arc<Mutex<Vec<(String, StepEventKind)>>> = Arc::new(Mutex::new(vec![]));
+        let sink = seen.clone();
+        let opts = DagExecOptions {
+            on_step: Some(Arc::new(move |e: StepEvent| {
+                sink.lock().unwrap().push((e.id, e.kind));
+            })),
+            ..Default::default()
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let _ = execute_dag(tmp.path(), "test", &proc, &opts).await.unwrap();
+        let seen = seen.lock().unwrap();
+        assert!(seen.contains(&("s1".into(), StepEventKind::Started)));
+        assert!(seen.contains(&("s1".into(), StepEventKind::Done)));
+        assert!(seen.contains(&("s2".into(), StepEventKind::Done)));
+    }
 
     #[tokio::test]
     async fn resume_skips_a_step_already_completed() {

--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -91,13 +91,14 @@ pub enum StepEventKind {
 
 /// Display-only step lifecycle event for progress observers. The callback
 /// runs on executor worker tasks: it MUST be cheap and MUST NOT panic.
-// TODO(T3): fields read by the loop_run on_step closure; allow until then.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct StepEvent {
     pub id: String,
     /// The delegate target agent, when this step is a delegation. `None`
-    /// otherwise.
+    /// otherwise. ponytail: currently redundant with the progress step's
+    /// `worker` (both come from `step.delegate_to`); kept as part of the
+    /// generic observer contract. Drop it if no consumer ever reads it.
+    #[allow(dead_code)]
     pub agent: Option<String>,
     pub kind: StepEventKind,
     /// Per-step delegate token usage (0 for non-delegate or unknown).


### PR DESCRIPTION
## What

Deep-research runs are silent for minutes with no per-stage/cost visibility. This adds a single best-effort progress file the fleet loop writes, rendered two ways:

- **Run output (log style):** one line per completed step (`✓ s2 research dr_worker_2 $0.08 42s`) + per-iteration summary (`iteration 2 done: 3✓ 0✗ 2 pending · spend $0.31/$2.00 · model claude_haiku`). Existing loop lines unchanged.
- **Bare `mur deep-research` panel:** the in-flight run (question, per-phase done/total, running steps with elapsed, spend vs budget, staleness warning after 10 min) or the last run's outcome recap.

## Architecture

Single data source: `~/.mur/fleets/<name>/.run_progress.json` (schema_version 1, atomic temp+rename, kept as last-run record). Three layers:

| Layer | File | Role |
|-------|------|------|
| Model | `cmd/fleet/progress.rs` | `RunProgress`/`StepProgress`/Phase/StepState + atomic `save`/`load` |
| Observer | `executor/dag.rs` | `DagExecOptions.on_step` — optional `Fn(StepEvent)+Send+Sync` callback (Default: None) |
| Wiring | `cmd/fleet/loop_run.rs` | Builds progress at loop start, injects on_step closure into opts, prints step/summary lines, stamps exit outcome |
| Panel | `cmd/deep_research/panel.rs` | `render_progress(p, mtime_age_secs)` — pure, in-flight block or finished recap |

## Safety invariant (NEVER break the run)

Every progress write is best-effort — `save()` swallows all errors (debug log, continues); lock is poison-safe (`unwrap_or_else(|e| e.into_inner())`); the on_step closure never `?` and never panics. Zero behavior change to the guard/budget/convergence/commander paths. Existing loop output lines are byte-identical.

## Tasks (6 commits)

- **T1** (50e4cfb): pure progress model + atomic persistence
- **T2** (b911a65): optional on_step observer on DAG executor (3 firing points: Started/Done/Failed)
- **T3** (4291ae9): loop wiring — Arc<Mutex<RunProgress>> shared with spawned executor tasks, per-step println, iteration summary, exit stamp
- **T4** (04c1d80 + fix e2d4073): `render_progress` + cmd_panel load; in-flight block (per-phase counts, running steps, elapsed, staleness) + finished recap
- **T5** (13941a9): README + runtime-overview docs

## Test evidence

- `cargo nextest -p mur-core fleet:: deep_research:: executor::` → **290/290 passed** (incl. 4 progress unit tests, 1 on_step test, 1 loop-run guard-stop test, 5 panel rendering tests)
- `cargo clippy -p mur-core -- -D warnings` → clean
- Live CLI smoke: bare `mur deep-research` panel correctly renders no-file/configured/in-flight (synthetic)/finished (synthetic) states

## Review

Per-task review (SDD: spec-compliance + code-quality) passed on all five tasks. T4 had one review-loop fix (e2d4073: total-elapsed line + finished-at segment per spec §4).

Minor findings deferred (not blocking merge):
- `StepEvent.agent` unread (field-level `#[allow(dead_code)]`, redundant with progress step's worker) — keep as generic-observer API
- on_step elapsed computation re-parses `now` string — trivial, polish later

🤖 Generated with [Claude Code](https://claude.com/claude-code)