### PR TITLE
fix(llm): transport errors advance the fallback chain; setup warns on stale worker model

### DIFF
--- a/mur-agent-runtime/src/llm/anthropic.rs
+++ b/mur-agent-runtime/src/llm/anthropic.rs
@@ -537,22 +537,10 @@ impl LlmClient for AnthropicClient {
             .json(&body)
             .send()
             .await
-            .map_err(|e| {
-                if e.is_timeout() {
-                    LlmError::Timeout
-                } else {
-                    LlmError::Http(e.to_string())
-                }
-            })?;
+            .map_err(|e| LlmError::from_reqwest(&e))?;
 
         let status = resp.status();
-        let body_text = resp.text().await.map_err(|e| {
-            if e.is_timeout() {
-                LlmError::Timeout
-            } else {
-                LlmError::Http(e.to_string())
-            }
-        })?;
+        let body_text = resp.text().await.map_err(|e| LlmError::from_reqwest(&e))?;
         if !status.is_success() {
             tracing::warn!(status = %status, body = %body_text, "anthropic non-2xx");
             return Err(LlmError::from_status(status.as_u16(), body_text));
@@ -620,13 +608,7 @@ impl LlmClient for AnthropicClient {
             .json(&body)
             .send()
             .await
-            .map_err(|e| {
-                if e.is_timeout() {
-                    LlmError::Timeout
-                } else {
-                    LlmError::Http(e.to_string())
-                }
-            })?;
+            .map_err(|e| LlmError::from_reqwest(&e))?;
         let status = resp.status();
         if !status.is_success() {
             let body_text = resp.text().await.unwrap_or_default();
@@ -640,13 +622,7 @@ impl LlmClient for AnthropicClient {
         // chunks to forward to the sink.
         let mut buf: Vec<u8> = Vec::new();
         let mut acc = StreamAccum::default();
-        while let Some(chunk) = resp.chunk().await.map_err(|e| {
-            if e.is_timeout() {
-                LlmError::Timeout
-            } else {
-                LlmError::Http(e.to_string())
-            }
-        })? {
+        while let Some(chunk) = resp.chunk().await.map_err(|e| LlmError::from_reqwest(&e))? {
             buf.extend_from_slice(&chunk);
             while let Some(nl) = buf.iter().position(|&b| b == b'\n') {
                 let raw: Vec<u8> = buf.drain(..=nl).collect();

--- a/mur-agent-runtime/src/llm/fallback/tests.rs
+++ b/mur-agent-runtime/src/llm/fallback/tests.rs
@@ -118,6 +118,22 @@ async fn advances_chain_on_retryable_then_succeeds() {
 }
 
 #[tokio::test]
+async fn connect_error_advances_chain() {
+    // Transport failure (endpoint unreachable — e.g. a dead local proxy) must
+    // advance the chain: the server rendered no verdict, so this is not the
+    // auth/misconfig class that stays Fatal.
+    let mut s = HashMap::new();
+    s.insert(
+        "a".into(),
+        vec![Err(LlmError::Connect("connection refused".into()))],
+    );
+    s.insert("b".into(), vec![Ok(())]);
+    let fb = FallbackLlmClient::new(vec!["a".into(), "b".into()], factory_for(s), retry0());
+    let resp = fb.generate(LlmRequest::default()).await.unwrap();
+    assert_eq!(resp.text, "b");
+}
+
+#[tokio::test]
 async fn fatal_error_does_not_advance() {
     let mut s = HashMap::new();
     s.insert("a".into(), vec![Err(LlmError::Http("401".into()))]); // fatal

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -149,6 +149,12 @@ pub struct LlmResponse {
 pub enum LlmError {
     #[error("http: {0}")]
     Http(String),
+    /// Transport-level failure — the request never got an HTTP status back
+    /// (connect refused, DNS, TLS, connection reset). The server rendered no
+    /// verdict, so unlike `Http` this is Retryable: switching models can't
+    /// mask an auth/config error the server never reported.
+    #[error("connect: {0}")]
+    Connect(String),
     #[error("rate limit")]
     RateLimit,
     #[error("timeout")]
@@ -168,8 +174,24 @@ impl LlmError {
         match status {
             429 => LlmError::RateLimit,
             402 => LlmError::InsufficientCredit,
+            408 => LlmError::Timeout,
             500..=599 => LlmError::ServerError(status),
             _ => LlmError::Http(format!("status {status}: {body}")),
+        }
+    }
+
+    /// Map a reqwest transport error into a typed error. Central rule: an
+    /// error without an HTTP status is a transport failure (`Connect`,
+    /// Retryable) — the server never rendered a verdict, so it can't be the
+    /// auth/bad-request class that `Http` reserves Fatal for. Request-builder
+    /// errors (malformed URL/body) stay `Http`: retrying can't fix them.
+    pub fn from_reqwest(e: &reqwest::Error) -> LlmError {
+        if e.is_timeout() {
+            LlmError::Timeout
+        } else if e.is_builder() {
+            LlmError::Http(e.to_string())
+        } else {
+            LlmError::Connect(e.to_string())
         }
     }
 }
@@ -187,6 +209,7 @@ pub fn classify(e: &LlmError) -> Retryability {
     match e {
         LlmError::RateLimit
         | LlmError::Timeout
+        | LlmError::Connect(_)
         | LlmError::ServerError(_)
         | LlmError::InsufficientCredit => Retryability::Retryable,
         LlmError::Http(_) | LlmError::InvalidResponse(_) => Retryability::Fatal,
@@ -316,11 +339,27 @@ mod tests {
         assert!(matches!(classify(&LlmError::Timeout), Retryable));
         assert!(matches!(classify(&LlmError::ServerError(500)), Retryable));
         assert!(matches!(classify(&LlmError::InsufficientCredit), Retryable));
+        assert!(matches!(
+            classify(&LlmError::Connect("connection refused".into())),
+            Retryable
+        ));
         assert!(matches!(classify(&LlmError::Http("400".into())), Fatal));
         assert!(matches!(
             classify(&LlmError::InvalidResponse("x".into())),
             Fatal
         ));
+    }
+
+    #[test]
+    fn from_status_maps_408_to_timeout() {
+        assert!(matches!(
+            LlmError::from_status(408, String::new()),
+            LlmError::Timeout
+        ));
+        // 401 stays Http → Fatal: auth errors must never advance the chain.
+        let e = LlmError::from_status(401, "unauthorized".into());
+        assert!(matches!(e, LlmError::Http(_)));
+        assert!(matches!(classify(&e), Retryability::Fatal));
     }
 }
 

--- a/mur-agent-runtime/src/llm/ollama.rs
+++ b/mur-agent-runtime/src/llm/ollama.rs
@@ -80,25 +80,19 @@ impl LlmClient for OllamaClient {
         {
             return Err(LlmError::Http(e));
         }
-        let resp = self.http.post(url).json(&body).send().await.map_err(|e| {
-            if e.is_timeout() {
-                LlmError::Timeout
-            } else {
-                LlmError::Http(e.to_string())
-            }
-        })?;
+        let resp = self
+            .http
+            .post(url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| LlmError::from_reqwest(&e))?;
         let status = resp.status();
         if !status.is_success() {
             let body_text = resp.text().await.unwrap_or_default();
             return Err(LlmError::from_status(status.as_u16(), body_text));
         }
-        let v: serde_json::Value = resp.json().await.map_err(|e| {
-            if e.is_timeout() {
-                LlmError::Timeout
-            } else {
-                LlmError::Http(e.to_string())
-            }
-        })?;
+        let v: serde_json::Value = resp.json().await.map_err(|e| LlmError::from_reqwest(&e))?;
         let text = v["message"]["content"]
             .as_str()
             .ok_or_else(|| LlmError::InvalidResponse("missing message.content".into()))?
@@ -134,13 +128,13 @@ impl LlmClient for OllamaClient {
         {
             return Err(LlmError::Http(e));
         }
-        let mut resp = self.http.post(url).json(&body).send().await.map_err(|e| {
-            if e.is_timeout() {
-                LlmError::Timeout
-            } else {
-                LlmError::Http(e.to_string())
-            }
-        })?;
+        let mut resp = self
+            .http
+            .post(url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| LlmError::from_reqwest(&e))?;
         let status = resp.status();
         if !status.is_success() {
             let body_text = resp.text().await.unwrap_or_default();
@@ -154,13 +148,7 @@ impl LlmClient for OllamaClient {
         let mut text = String::new();
         let mut input_tokens = 0u64;
         let mut output_tokens = 0u64;
-        while let Some(chunk) = resp.chunk().await.map_err(|e| {
-            if e.is_timeout() {
-                LlmError::Timeout
-            } else {
-                LlmError::Http(e.to_string())
-            }
-        })? {
+        while let Some(chunk) = resp.chunk().await.map_err(|e| LlmError::from_reqwest(&e))? {
             buf.extend_from_slice(&chunk);
             while let Some(nl) = buf.iter().position(|&b| b == b'\n') {
                 let line: Vec<u8> = buf.drain(..=nl).collect();

--- a/mur-agent-runtime/src/llm/openai.rs
+++ b/mur-agent-runtime/src/llm/openai.rs
@@ -284,26 +284,14 @@ impl LlmClient for OpenAiClient {
             .json(&body)
             .send()
             .await
-            .map_err(|e| {
-                if e.is_timeout() {
-                    LlmError::Timeout
-                } else {
-                    LlmError::Http(e.to_string())
-                }
-            })?;
+            .map_err(|e| LlmError::from_reqwest(&e))?;
 
         let status = resp.status();
         if !status.is_success() {
             let body_text = resp.text().await.unwrap_or_default();
             return Err(LlmError::from_status(status.as_u16(), body_text));
         }
-        let v: serde_json::Value = resp.json().await.map_err(|e| {
-            if e.is_timeout() {
-                LlmError::Timeout
-            } else {
-                LlmError::Http(e.to_string())
-            }
-        })?;
+        let v: serde_json::Value = resp.json().await.map_err(|e| LlmError::from_reqwest(&e))?;
 
         let (text, tool_calls, stop_reason) = parse_response_body(&v)?;
         let input_tokens = v["usage"]["prompt_tokens"].as_u64().unwrap_or(0);
@@ -365,13 +353,7 @@ impl LlmClient for OpenAiClient {
             .json(&body)
             .send()
             .await
-            .map_err(|e| {
-                if e.is_timeout() {
-                    LlmError::Timeout
-                } else {
-                    LlmError::Http(e.to_string())
-                }
-            })?;
+            .map_err(|e| LlmError::from_reqwest(&e))?;
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
@@ -386,13 +368,7 @@ impl LlmClient for OpenAiClient {
         let mut text = String::new();
         let mut input_tokens = 0u64;
         let mut output_tokens = 0u64;
-        while let Some(chunk) = resp.chunk().await.map_err(|e| {
-            if e.is_timeout() {
-                LlmError::Timeout
-            } else {
-                LlmError::Http(e.to_string())
-            }
-        })? {
+        while let Some(chunk) = resp.chunk().await.map_err(|e| LlmError::from_reqwest(&e))? {
             buf.extend_from_slice(&chunk);
             while let Some(nl) = buf.iter().position(|&b| b == b'\n') {
                 let raw: Vec<u8> = buf.drain(..=nl).collect();

--- a/mur-core/src/cmd/deep_research/setup.rs
+++ b/mur-core/src/cmd/deep_research/setup.rs
@@ -160,15 +160,31 @@ pub fn cmd_setup(mur_home: &Path) -> Result<()> {
     if target_names.iter().all(|n| existing.contains(n)) {
         println!("workers already provisioned — updating model/budget/fleet only");
     }
+    let mut restart_needed: Vec<String> = Vec::new();
     for name in &target_names {
         if existing.contains(name) {
             let (path, mut profile) = crate::cmd::agent::load_profile_for_edit(name)?;
+            let model_changed = profile.model_ref.as_deref() != Some(a.model.as_str());
             profile.model_ref = Some(a.model.clone());
             crate::cmd::agent::save_profile(&path, &mut profile)?;
+            // The runtime loads its profile once at startup — a running worker
+            // keeps the OLD model until restarted (we never auto-restart: it
+            // could kill an in-flight conversation).
+            if model_changed && super::status::is_agent_running(mur_home, name) {
+                restart_needed.push(name.clone());
+            }
         } else {
             super::provision::provision_one(mur_home, name, &a.model, None)?;
             println!("provisioned {name}");
         }
+    }
+    if !restart_needed.is_empty() {
+        println!(
+            "⚠ {} running with the previous model — restart to apply {}:\n  mur agent stop {}  # then start them again",
+            restart_needed.join(", "),
+            a.model,
+            restart_needed.join(" ")
+        );
     }
 
     // Workers above the new count (count shrunk on a re-run): stop them,


### PR DESCRIPTION
## Problem

Two independent failures observed in one `mur deep-research` run:

1. **Fallback never engaged on connection failure.** When the primary model's endpoint was unreachable (dead local proxy), the reqwest transport error was mapped to `LlmError::Http` → classified `Fatal` → the fallback chain (deepseek) was never tried. All three workers died in seconds.
2. **`deep-research setup` model change silently ineffective.** The runtime loads its profile once at startup; setup rewrote `model_ref` on disk but running workers kept the old model, and the fleet loop's cost line (which re-reads the profile) displayed the NEW model — actively misleading.

## Fix

- New `LlmError::Connect(String)` variant, classified **Retryable**. Central mapping `LlmError::from_reqwest`: `is_timeout` → `Timeout`, `is_builder` → `Http` (Fatal), any other transport error → `Connect`. Replaces the 12 hand-rolled `map_err` closures in anthropic/openai/ollama clients.
- **Principle:** no HTTP status = the server rendered no verdict, so the error cannot be the auth/bad-request class that `Http` reserves Fatal for. 401/4xx behavior is **unchanged** (still Fatal — auth errors must never silently switch models). 408 → `Timeout` per SDK retry conventions.
- `deep-research setup`: prints a restart instruction when a running worker's model changed (never auto-restarts, per the standing no-auto-restart policy).

## Tests

- `connect_error_advances_chain` — connect failure on candidate a falls through to b
- `classify_retryable_vs_fatal` — Connect is Retryable
- `from_status_maps_408_to_timeout` — 408 retryable, 401 stays Fatal
- Full `mur-agent-runtime` lib suite: 439 passed; clippy `-D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)