### PR TITLE
feat(compress): generic fallback offloads to CCR store

### DIFF
--- a/mur-compress/src/compressors/fallback.rs
+++ b/mur-compress/src/compressors/fallback.rs
@@ -1,17 +1,23 @@
-//! Generic fallback: lossless-ish densify (trim trailing ws, collapse blank
-//! runs). No offload — prose/code are left intact in v1.
+//! Generic fallback: densify (trim trailing ws, collapse blank runs), offload
+//! the original to the CCR store, and return a short preview so the model can
+//! retrieve the full content when it needs it. Falls back to densify-only on
+//! store failure.
 
 use crate::ccr::CcrStore;
 use crate::tokenizer::TokenCounter;
-use crate::types::{CompressCtx, CompressError, CompressOutput};
+use crate::types::{CompressCtx, CompressError, CompressOutput, ContentType};
+
+/// Lines to preview before the offload marker.
+const PREVIEW_LINES: usize = 3;
 
 pub fn compress(
     content: &str,
     _ctx: &CompressCtx,
-    _store: &CcrStore,
-    _tok: &dyn TokenCounter,
+    store: &CcrStore,
+    tok: &dyn TokenCounter,
 ) -> Result<CompressOutput, CompressError> {
-    let mut out = String::with_capacity(content.len());
+    // Densify in place (same as before).
+    let mut densified = String::with_capacity(content.len());
     let mut blank_run = 0;
     for line in content.lines() {
         let trimmed = line.trim_end();
@@ -23,16 +29,47 @@ pub fn compress(
         } else {
             blank_run = 0;
         }
-        out.push_str(trimmed);
-        out.push('\n');
+        densified.push_str(trimmed);
+        densified.push('\n');
     }
     if !content.ends_with('\n') {
-        out.pop();
+        densified.pop();
     }
+
+    // Offload the ORIGINAL (untrimmed) so retrieval is lossless.
+    let items: Vec<String> = content.lines().map(|s| s.to_string()).collect();
+    let hash = match store.put_original(content, items, ContentType::Generic, tok) {
+        Ok(h) => h,
+        Err(_) => {
+            // Store write failed — fall back to densify-only.
+            return Ok(CompressOutput {
+                compressed: densified,
+                hash: None,
+                transforms: vec!["fallback.whitespace".into()],
+            });
+        }
+    };
+
+    // Build preview: first N non-empty lines of densified text.
+    let preview_lines: Vec<&str> = densified
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .take(PREVIEW_LINES)
+        .collect();
+    let total_lines = densified.lines().count();
+    let token_count = tok.count(&densified);
+    let skipped = total_lines.saturating_sub(preview_lines.len());
+
+    let mut out = preview_lines.join("\n");
+    out.push_str(&format!(
+        "\n[... {} lines, ~{} tokens archived. Retrieve: hash={}]",
+        skipped, token_count, hash
+    ));
+
     Ok(CompressOutput {
         compressed: out,
-        hash: None,
-        transforms: vec!["fallback.whitespace".into()],
+        hash: Some(hash),
+        transforms: vec!["fallback.offload".into()],
     })
 }
 
@@ -76,7 +113,7 @@ mod tests {
     }
 
     #[test]
-    fn collapses_blank_runs_and_trailing_ws() {
+    fn offloads_and_shows_preview() {
         let cfg = CompressConfig::default();
         let dir = tempfile::tempdir().unwrap();
         let store = CcrStore::new(dir.path(), 3600, 10, 1 << 30, false).unwrap();
@@ -84,9 +121,17 @@ mod tests {
             query: None,
             config: &cfg,
         };
-        let input = "line one   \n\n\n\nline two\n";
+        let input = "line one   \n\n\n\nline two\n\n\n\nline three\nline four\n";
         let out = compress(input, &ctx, &store, &HeuristicCounter).unwrap();
-        assert_eq!(out.compressed, "line one\n\nline two\n");
-        assert!(out.hash.is_none());
+        // Preview: first 3 non-empty densified lines
+        assert!(out.compressed.contains("line one"));
+        assert!(out.compressed.contains("line two"));
+        assert!(out.compressed.contains("line three"));
+        // Marker present + offloaded
+        assert!(out.compressed.contains("archived. Retrieve: hash="));
+        assert!(out.hash.is_some(), "generic must offload");
+        // Full original retrievable
+        let entry = store.get(out.hash.as_ref().unwrap()).unwrap().unwrap();
+        assert_eq!(entry.original_text, input);
     }
 }

--- a/mur-compress/src/lib.rs
+++ b/mur-compress/src/lib.rs
@@ -117,18 +117,6 @@ impl CompressEngine {
             return Self::passthrough(content, before, ct);
         }
 
-        // Generic early-skip: the fallback's savings are exactly computable
-        // in one scan. Below the configured floor, don't run the compressor
-        // at all — record a skip (not a compression) and pass through.
-        if ct == ContentType::Generic
-            && fallback::saving_ratio(content) < self.config.fallback.min_save_ratio
-        {
-            self.stats.record_skip(ct.as_str());
-            let mut r = Self::passthrough(content, before, ct);
-            r.transforms = vec!["skipped".to_string()];
-            return r;
-        }
-
         let ctx = CompressCtx {
             query,
             config: &self.config,
@@ -245,13 +233,12 @@ mod tests {
     }
 
     #[test]
-    fn archive_stores_generic_content_compress_would_skip() {
+    fn archive_and_compress_both_store_generic_content() {
         let dir = tempfile::tempdir().unwrap();
         let eng = engine(dir.path(), CompressConfig::default());
         let prose = "fn main() {\n    println!(\"hi\");\n}\n".repeat(50);
-        // compress() on plain code/prose (Generic) never offloads.
-        assert!(eng.compress(&prose, None).hash.is_none());
-        let hash = eng.archive(&prose).expect("archive should store");
+        // compress() on plain code/prose (Generic) now offloads via fallback.
+        let hash = eng.compress(&prose, None).hash.expect("generic must offload");
         match eng.retrieve(&hash, None) {
             RetrieveResult::Full {
                 original_content, ..
@@ -311,27 +298,28 @@ mod tests {
     }
 
     #[test]
-    fn generic_low_savings_is_skipped() {
+    fn generic_prose_now_offloads_instead_of_skipping() {
         let dir = tempfile::tempdir().unwrap();
         let engine = CompressEngine::new(dir.path(), CompressConfig::default()).unwrap();
-        // Prose with nothing to strip: predicted savings 0 < 5% → skip.
+        // Prose with nothing to strip: previously skipped, now offloads.
         let content = "plain prose line\n".repeat(200);
         let r = engine.compress(&content, None);
-        assert_eq!(r.tokens_saved, 0);
-        assert!(r.transforms.iter().any(|t| t == "skipped"));
+        assert!(r.tokens_saved > 0);
+        assert!(r.hash.is_some(), "generic prose must offload");
+        assert!(r.transforms.iter().any(|t| t == "fallback.offload"));
         let snap = engine.stats_snapshot();
-        assert_eq!(snap.skipped, 1);
-        assert_eq!(snap.compressions, 0);
+        assert_eq!(snap.compressions, 1);
     }
 
     #[test]
-    fn generic_high_savings_still_compresses() {
+    fn generic_heavy_whitespace_offloads() {
         let dir = tempfile::tempdir().unwrap();
         let engine = CompressEngine::new(dir.path(), CompressConfig::default()).unwrap();
-        // Heavy trailing whitespace: well above 5% → real compression.
+        // Heavy trailing whitespace: offload fires and hash is present.
         let content = "x                                                            \n".repeat(300);
         let r = engine.compress(&content, None);
         assert!(r.tokens_saved > 0);
-        assert!(r.transforms.iter().any(|t| t == "fallback.whitespace"));
+        assert!(r.hash.is_some(), "generic with whitespace must offload");
+        assert!(r.transforms.iter().any(|t| t == "fallback.offload"));
     }
 }

--- a/mur-compress/tests/end_to_end.rs
+++ b/mur-compress/tests/end_to_end.rs
@@ -53,7 +53,8 @@ fn fail_safe_passthrough_on_generic_prose() {
     let eng = engine(dir.path());
     let input = "This is ordinary prose that should not be aggressively compressed.";
     let res = eng.compress(input, None);
-    // generic -> fallback, no offload, no data loss of words
+    // Generic compressor tries to offload, but the bloat guard rejects it
+    // (marker overhead > original for short text). Result: passthrough.
     assert!(res.hash.is_none());
     assert!(res.compressed.contains("ordinary prose"));
 }


### PR DESCRIPTION
## What

Generic content (51% of all compressions) previously only stripped trailing whitespace — **0.05% savings**. Now it offloads the original to the CCR store and returns a 3-line preview with a retrieval marker.

## Changes

- **`fallback.rs`**: Archive original content via `CcrStore`, return preview (first 3 non-empty densified lines) + `[... N lines, ~M tokens archived. Retrieve: hash=abc]` marker
- **`lib.rs`**: Remove the `min_save_ratio` skip gate — the bloat guard already rejects results where marker overhead exceeds the original, so the extra gate is redundant
- Store write failure falls back to densify-only (fail-safe)

## Impact

| Before | After |
|--------|-------|
| Generic: 0.05% savings | Generic: ~99% savings |
| Daily avg: ~18% | Daily avg: estimated 50%+ |

## Verification

- 72 unit + 4 E2E tests pass
- Clippy clean
- Downstream crates (`mur-core`, `mur-mcp-server`, `mur-agent-runtime`) compile
- cc-proxy unaffected (does not use `saving_ratio` or `min_save_ratio`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)