### PR TITLE
feat: seed fleet_run starter on init + brave_api_key_ref secret support

### DIFF
--- a/mur-core/src/cmd/init.rs
+++ b/mur-core/src/cmd/init.rs
@@ -1,5 +1,7 @@
 use anyhow::Result;
+use std::fs;
 use std::io::{self, Write};
+use std::path::Path;
 
 /// Drive an async future from a sync caller that's already inside the
 /// `mur-main` multi-threaded tokio runtime (see `main.rs::main`).
@@ -78,7 +80,16 @@ pub(crate) fn cmd_init(hooks_flag: bool, refresh_discovery: bool) -> Result<()> 
     // ─── Step E: Write default config.yaml if not exists ─────────
     let config_path = mur_dir.join("config.yaml");
     if !config_path.exists() {
-        crate::store::config::save_config(&mur_common::config::Config::default())?;
+        let cfg = mur_common::config::Config {
+            fleet_run: starter_fleet_run(),
+            ..Default::default()
+        };
+        crate::store::config::save_config(&cfg)?;
+    } else {
+        // Re-running init on an existing install: append the fleet_run
+        // starter textually. NEVER load-modify-save here — the typed Config
+        // drops foreign blocks other binaries own (e.g. `research_gateway:`).
+        append_fleet_run_if_absent(&config_path)?;
     }
 
     // ─── Determine whether to install hooks ──────────────────────
@@ -895,9 +906,81 @@ Run `mur learn` to extract new patterns from recent sessions.
     Ok(())
 }
 
+/// Starter `fleet_run` authorization seeded by `mur init`: the concierge may
+/// trigger the deep-research fleet. Still inert until that fleet exists AND
+/// has a positive `loop.budget_usd` (the tool refuses otherwise), so seeding
+/// it costs nothing on a fresh install but saves the "why can't murmur run
+/// deep-research" round-trip later.
+fn starter_fleet_run() -> mur_common::config::FleetRunConfig {
+    mur_common::config::FleetRunConfig {
+        agents: vec![mur_common::fleet::CONCIERGE_AGENT.to_string()],
+        fleets: vec![crate::cmd::deep_research::status::DEFAULT_FLEET_NAME.to_string()],
+    }
+}
+
+/// Append the starter `fleet_run:` block to an existing config.yaml, unless a
+/// `fleet_run:` key is already present (user-authored settings are never
+/// touched). Textual append on purpose: round-tripping through the typed
+/// `Config` would drop foreign top-level blocks owned by other binaries
+/// (e.g. `research_gateway:`).
+fn append_fleet_run_if_absent(config_path: &Path) -> Result<()> {
+    let text = fs::read_to_string(config_path)?;
+    if text
+        .lines()
+        .any(|l| l.trim_start().starts_with("fleet_run:"))
+    {
+        return Ok(());
+    }
+    let starter = starter_fleet_run();
+    let mut out = text;
+    if !out.is_empty() && !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(&format!(
+        "\n# fleet_run built-in tool authorization (deny-by-default allowlists;\n\
+         # lets the listed agents trigger the listed fleets from inside their sandbox)\n\
+         fleet_run:\n  agents: [{}]\n  fleets: [{}]\n",
+        starter.agents.join(", "),
+        starter.fleets.join(", ")
+    ));
+    fs::write(config_path, out)?;
+    println!("  ✓ Added starter fleet_run authorization to config.yaml");
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn starter_fleet_run_seeds_concierge_deep_research() {
+        let s = starter_fleet_run();
+        assert_eq!(s.agents, vec!["mur"]);
+        assert_eq!(s.fleets, vec!["deep-research"]);
+    }
+
+    #[test]
+    fn append_fleet_run_respects_existing_key_and_foreign_blocks() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("config.yaml");
+
+        // Absent → appended, foreign block preserved.
+        std::fs::write(&p, "research_gateway:\n  brave_api_key: \"x\"").unwrap();
+        append_fleet_run_if_absent(&p).unwrap();
+        let text = std::fs::read_to_string(&p).unwrap();
+        assert!(text.contains("research_gateway:"), "foreign block kept");
+        assert!(text.contains("fleet_run:"));
+        let cfg: mur_common::config::Config = serde_yaml_ng::from_str(&text).unwrap();
+        assert_eq!(cfg.fleet_run.agents, vec!["mur"]);
+        assert_eq!(cfg.fleet_run.fleets, vec!["deep-research"]);
+
+        // Present (user-authored) → untouched.
+        std::fs::write(&p, "fleet_run:\n  agents: [custom]\n  fleets: []\n").unwrap();
+        append_fleet_run_if_absent(&p).unwrap();
+        let text = std::fs::read_to_string(&p).unwrap();
+        assert_eq!(text.matches("fleet_run:").count(), 1);
+        assert!(text.contains("custom"));
+    }
 
     #[test]
     fn hook_scripts_use_unified_entry() {

--- a/mur-research-gateway/src/config.rs
+++ b/mur-research-gateway/src/config.rs
@@ -128,11 +128,45 @@ struct GatewayConfigYaml {
     search_limit: Option<usize>,
     max_fetch_chars: Option<usize>,
     brave_api_key: Option<String>,
+    brave_api_key_ref: Option<String>,
     agent_browser_bin: Option<String>,
     lightpanda_path: Option<String>,
     chrome_stealth_args: Option<String>,
     render_engine: Option<String>,
     obscura_path: Option<String>,
+}
+
+/// Resolve `research_gateway.brave_api_key_ref` — a mur-common `SecretRef`
+/// string (`keychain:mur/brave`, `env:BRAVE_KEY`, `file:...`, `cmd:...`) —
+/// to the actual key, so the secret never has to sit in config.yaml as
+/// plaintext. Precedence sits between the `MUR_RESEARCH_BRAVE_KEY` env
+/// override and the legacy plaintext `brave_api_key` field. An unparseable
+/// or unresolvable ref warns and falls through to plaintext rather than
+/// silently disabling Brave search.
+fn resolve_brave_key_ref(raw_ref: Option<&str>) -> Option<String> {
+    let raw_ref = raw_ref.filter(|s| !s.trim().is_empty())?;
+    match raw_ref.parse::<mur_common::secret::SecretRef>() {
+        Ok(sref) => {
+            let resolved = sref.resolve_to_string_blocking().filter(|s| !s.is_empty());
+            if resolved.is_none() {
+                tracing::warn!(
+                    r#ref = raw_ref,
+                    "brave_api_key_ref did not resolve to a secret; \
+                     falling back to plaintext brave_api_key (if any)"
+                );
+            }
+            resolved
+        }
+        Err(e) => {
+            tracing::warn!(
+                r#ref = raw_ref,
+                error = %e,
+                "brave_api_key_ref is not a valid SecretRef; \
+                 falling back to plaintext brave_api_key (if any)"
+            );
+            None
+        }
+    }
 }
 
 /// Resolve `~/.mur` (or `$MUR_HOME` if set). Mirrors the `MUR_HOME`
@@ -189,8 +223,9 @@ pub fn load_from_yaml(yaml: &str, mur_home: &Path) -> GatewayConfig {
         .or(raw.max_fetch_chars)
         .unwrap_or(DEFAULT_MAX_FETCH_CHARS);
 
-    let brave_api_key =
-        non_empty_env(ENV_BRAVE_KEY).or_else(|| raw.brave_api_key.filter(|s| !s.is_empty()));
+    let brave_api_key = non_empty_env(ENV_BRAVE_KEY)
+        .or_else(|| resolve_brave_key_ref(raw.brave_api_key_ref.as_deref()))
+        .or_else(|| raw.brave_api_key.filter(|s| !s.is_empty()));
 
     let agent_browser_bin = non_empty_env(ENV_AGENT_BROWSER_BIN)
         .or(raw.agent_browser_bin)
@@ -312,6 +347,32 @@ mod tests {
     // env var serializes on this lock — mirrors
     // `mur-agent-runtime/tests/model_resolution.rs::HOME_LOCK`.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn brave_key_ref_resolves_and_beats_plaintext() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: env mutation guarded by ENV_LOCK above.
+        unsafe {
+            std::env::remove_var(ENV_BRAVE_KEY);
+            std::env::set_var("TEST_BRAVE_REF_KEY", "from-ref");
+        }
+        let yaml = "research_gateway:\n  brave_api_key: \"plain\"\n  brave_api_key_ref: \"env:TEST_BRAVE_REF_KEY\"\n";
+        let c = load_from_yaml(yaml, Path::new("/nonexistent"));
+        assert_eq!(c.brave_api_key.as_deref(), Some("from-ref"));
+
+        // Unresolvable ref falls through to plaintext instead of disabling Brave.
+        unsafe {
+            std::env::remove_var("TEST_BRAVE_REF_KEY");
+        }
+        let c = load_from_yaml(yaml, Path::new("/nonexistent"));
+        assert_eq!(c.brave_api_key.as_deref(), Some("plain"));
+
+        // Invalid ref string also falls through.
+        let yaml_bad =
+            "research_gateway:\n  brave_api_key: \"plain\"\n  brave_api_key_ref: \"bogus\"\n";
+        let c = load_from_yaml(yaml_bad, Path::new("/nonexistent"));
+        assert_eq!(c.brave_api_key.as_deref(), Some("plain"));
+    }
 
     // Brief's exact Step-1 failing test.
     #[test]

--- a/mur-research-gateway/src/fetcher.rs
+++ b/mur-research-gateway/src/fetcher.rs
@@ -381,7 +381,8 @@ fn search_blocked_error() -> FetchError {
         "DuckDuckGo returned its anti-bot challenge (HTTP {DDG_CHALLENGE_STATUS}) on all \
          {SEARCH_MAX_ATTEMPTS} attempts — this host's IP appears persistently blocked, \
          retrying will not help. Use direct `fetch` of known URLs instead. Operator fix: \
-         configure a free Brave Search API key (research_gateway.brave_api_key in \
+         configure a free Brave Search API key (research_gateway.brave_api_key — or \
+         brave_api_key_ref, e.g. keychain:mur/brave — in \
          ~/.mur/config.yaml, or MUR_RESEARCH_BRAVE_KEY) to switch search off DuckDuckGo."
     ))
 }


### PR DESCRIPTION
Two rollout-friction fixes discovered while wiring deep-research into murmur (follow-up to #707):

## 1. `mur init` seeds the starter `fleet_run` authorization

New installs get `fleet_run: {agents: [mur], fleets: [deep-research]}` in the default config; re-running init on an existing install appends the same block **textually**, and only if no `fleet_run:` key exists — user-authored settings are never touched. Textual append is deliberate: round-tripping through the typed `Config` drops foreign top-level blocks other binaries own (e.g. `research_gateway:`).

Safety: the seed is inert until the deep-research fleet exists AND has a positive `loop.budget_usd` (the tool refuses otherwise), and it only authorizes that one fleet for the concierge.

## 2. `research_gateway.brave_api_key_ref` — Brave key via SecretRef

The Brave Search key no longer has to sit in config.yaml as plaintext. New field accepts any mur-common `SecretRef` (`keychain:mur/brave`, `env:...`, `file:...`, `cmd:...`), resolved with the existing `resolve_to_string_blocking` (block_in_place-safe inside the gateway's multi-thread runtime). Precedence: `MUR_RESEARCH_BRAVE_KEY` env → ref → legacy plaintext; unresolvable/invalid refs `tracing::warn` and fall through rather than silently disabling Brave search. The DDG-blocked operator hint now mentions the ref form.

## Tests

- init: starter values; append respects existing `fleet_run:` key and preserves foreign blocks (round-trip parsed with serde to prove validity)
- gateway: ref beats plaintext; unresolvable ref falls through; invalid ref string falls through
- `cargo clippy -D warnings` + `cargo fmt --check` clean on both crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)