### PR TITLE
fix(runtime): clear message when a HITL approval arrives after timeout

### DIFF
--- a/mur-agent-runtime/src/protocol/a2a_server.rs
+++ b/mur-agent-runtime/src/protocol/a2a_server.rs
@@ -52,6 +52,8 @@ pub enum HandlerError {
     UnsupportedCapability(String),
     #[error("communication denied: {0}")]
     CommunicationDenied(String),
+    #[error("approval expired: {0}")]
+    ApprovalExpired(String),
 }
 
 impl HandlerError {
@@ -66,6 +68,7 @@ impl HandlerError {
             Self::TaskCancelled(_) => -32002,
             Self::UnsupportedCapability(_) => -32010,
             Self::CommunicationDenied(_) => -32011,
+            Self::ApprovalExpired(_) => -32012,
         }
     }
 }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -768,7 +768,16 @@ impl crate::protocol::a2a_server::MethodHandler for HitlRespondHandler {
             .await
             .remove(&hitl_id)
             .ok_or_else(|| {
-                crate::protocol::a2a_server::HandlerError::TaskNotFound(hitl_id.clone())
+                // Not-found here means the approval window already closed: the
+                // gate timed out (and auto-denied) before the decision arrived,
+                // or a decision was already delivered. A generic TaskNotFound
+                // read as a cryptic JSON-RPC blob in murmur; say what actually
+                // happened and what to do about it.
+                crate::protocol::a2a_server::HandlerError::ApprovalExpired(
+                    "this approval window already closed — the tool call was auto-denied \
+                     at timeout (or the decision was already delivered); re-run the request"
+                        .to_string(),
+                )
             })?;
         let _ = tx.send(crate::hitl::HitlDecision { allow, reason });
         Ok(serde_json::json!({}))
@@ -1206,6 +1215,29 @@ mod hitl_tests {
         let decision = rx.await.expect("sender dropped");
         assert!(decision.allow);
         assert_eq!(decision.reason.as_deref(), Some("looks good"));
+    }
+
+    #[tokio::test]
+    async fn hitl_respond_after_timeout_reports_approval_expired() {
+        // A decision arriving after the gate timed out (entry removed) must
+        // surface as a clear "approval expired" error with its own code —
+        // NOT the cryptic generic TaskNotFound (-32000) it used to be.
+        let pending: Arc<Mutex<HashMap<String, oneshot::Sender<HitlDecision>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let handler = HitlRespondHandler {
+            pending_approvals: pending.clone(),
+        };
+        let err = handler
+            .handle(
+                Some(json!({"hitl_id": "long-gone", "allow": true})),
+                &crate::protocol::a2a_server::RequestContext::none(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), -32012);
+        let msg = err.to_string();
+        assert!(msg.contains("approval expired"), "{msg}");
+        assert!(msg.contains("auto-denied at timeout"), "{msg}");
     }
 
     #[tokio::test]

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -1157,11 +1157,19 @@ fn decide_hitl_with_note(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: boo
         let t = tx.clone();
         tokio::spawn(async move {
             if let Err(e) = respond_hitl(h, a, id, allow).await {
-                let _ = t
-                    .send(StreamMsg::Note(format!(
-                        "failed to deliver decision for `{tool}`: {e:#}"
-                    )))
-                    .await;
+                let msg = format!("{e:#}");
+                // "approval expired" (new runtimes) / "task not found" (older
+                // runtimes) on this method both mean the same thing: the gate
+                // timed out and auto-denied before the decision landed.
+                let note = if msg.contains("approval expired") || msg.contains("task not found") {
+                    format!(
+                        "approval for `{tool}` arrived too late — the call was already \
+                         auto-denied at timeout; re-run the request"
+                    )
+                } else {
+                    format!("failed to deliver decision for `{tool}`: {msg}")
+                };
+                let _ = t.send(StreamMsg::Note(note)).await;
             }
         });
         match (allow, auto) {


### PR DESCRIPTION
## Problem

Observed live while dogfooding fleet_run (#707): the murmur approval prompt timed out during a long tool call, and clicking approve afterwards printed

> `failed to deliver decision for \`fleet_run\`: {"code":-32000,"message":"task not found: 019f6607-…"}`

— a cryptic JSON-RPC blob that doesn't say the gate already auto-denied at timeout and discarded the (already-executed) output.

## Fix

- **Runtime**: `tool/hitl_respond` on a no-longer-pending `hitl_id` now returns a purpose-built `HandlerError::ApprovalExpired` (code `-32012`, next free custom slot) whose message states what happened and what to do: "this approval window already closed — the tool call was auto-denied at timeout (or the decision was already delivered); re-run the request".
- **murmur**: renders that (and the legacy `task not found` from older runtimes on this method) as a single plain note: *"approval for `<tool>` arrived too late — the call was already auto-denied at timeout; re-run the request"*. Other delivery failures keep the verbatim error.

## Tests

New `hitl_respond_after_timeout_reports_approval_expired` (asserts code -32012 + message content); existing hitl_respond tests unchanged and green. clippy `-D warnings` + fmt clean on both crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)