### PR TITLE
feat: auto-save deep-research reports + fleet_run default-Allow + UX defaults

### DIFF
--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -230,7 +230,7 @@ impl SandboxPolicy {
         ) && crate::tools::fleet_run::agent_enabled(mur_home, agent_name)
         {
             fleet_run_enabled = true;
-            for dir in ["fleets", "commander", "conversations"] {
+            for dir in ["fleets", "commander", "conversations", "artifacts"] {
                 let d = mur_home.join(dir);
                 if !fs_write.contains(&d) {
                     let _ = std::fs::create_dir_all(&d);

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1160,11 +1160,24 @@ impl TaskRunner {
 
         // 1b. Policy gate: check before executing.
         {
-            use mur_common::agent::{ToolPolicy, resolve_tool_policy};
+            use mur_common::agent::{ToolPolicy, resolve_tool_policy_opt};
             let policy = if crate::tools::suggest::suggest_replies_allowed(&call.tool_name) {
                 ToolPolicy::Allow
             } else {
-                resolve_tool_policy(&self.tools_policy, &call.tool_name)
+                match resolve_tool_policy_opt(&self.tools_policy, &call.tool_name) {
+                    Some(p) => p,
+                    // fleet_run's authorization is the out-of-model config
+                    // allowlist that gated its registration (plus the fleet's
+                    // own budget + kill-switch). With no explicit rule it
+                    // defaults to Allow: the HITL gate here is execute-THEN-
+                    // approve, so `Ask` adds no spend protection — it only
+                    // creates the pay-then-discard failure mode when the
+                    // approval window times out mid-run.
+                    None if call.tool_name == crate::tools::fleet_run::FLEET_RUN => {
+                        ToolPolicy::Allow
+                    }
+                    None => ToolPolicy::default(),
+                }
             };
             match policy {
                 ToolPolicy::Deny => {
@@ -2325,6 +2338,112 @@ mod tests {
             self.calls.fetch_add(1, Ordering::Relaxed);
             Ok("ran".into())
         }
+    }
+
+    /// A counting stub registered under the `fleet_run` wire name, for the
+    /// default-Allow policy-gate tests below.
+    struct CountingFleetRunTool {
+        calls: Arc<AtomicU64>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::tools::ToolExecutor for CountingFleetRunTool {
+        fn name(&self) -> &str {
+            crate::tools::fleet_run::FLEET_RUN
+        }
+        fn def(&self) -> crate::llm::ToolDef {
+            crate::llm::ToolDef {
+                name: crate::tools::fleet_run::FLEET_RUN.into(),
+                description: "stub fleet_run".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            }
+        }
+        async fn execute(
+            &self,
+            _input: serde_json::Value,
+        ) -> Result<String, crate::tools::ToolError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok("fleet ran".into())
+        }
+    }
+
+    fn fleet_run_call_response(call_id: &str) -> crate::llm::LlmResponse {
+        crate::llm::LlmResponse {
+            text: String::new(),
+            input_tokens: 5,
+            output_tokens: 5,
+            model: "test".into(),
+            tool_calls: vec![crate::llm::ToolCallResult {
+                call_id: call_id.into(),
+                tool_name: crate::tools::fleet_run::FLEET_RUN.into(),
+                input: serde_json::json!({"fleet": "deep-research"}),
+            }],
+            stop_reason: crate::llm::StopReason::ToolUse,
+        }
+    }
+
+    /// fleet_run with NO explicit rule defaults to Allow (its authorization is
+    /// the config allowlist that gated registration; the execute-then-approve
+    /// HITL gate adds no spend protection). With a 1s HITL timeout, an `Ask`
+    /// default would auto-deny the result — completion with the tool's real
+    /// output proves the Allow path ran.
+    #[tokio::test]
+    async fn fleet_run_without_rule_defaults_to_allow() {
+        use crate::llm::stub::SequenceLlm;
+        let responses: Vec<crate::llm::LlmResponse> = vec![
+            fleet_run_call_response("fr-0"),
+            end_turn_response("REPORT DELIVERED"),
+        ];
+        let calls = Arc::new(AtomicU64::new(0));
+        let runner = Arc::new(
+            TaskRunner::with_llm(Arc::new(SequenceLlm::new(responses)))
+                .with_tools(vec![Arc::new(CountingFleetRunTool {
+                    calls: calls.clone(),
+                })])
+                .with_tools_policy(vec![]) // no rules at all
+                .with_pending_approvals(empty_pending_approvals())
+                .with_notifier(tokio::sync::mpsc::channel(16).0)
+                .with_hitl_timeout_secs(1)
+                .with_max_iterations(5),
+        );
+        let outcome = runner.run_sync(loop_spec("fleet-run-default")).await;
+        let TaskOutcome::Completed(task) = outcome else {
+            panic!("expected Completed, got {outcome:?}");
+        };
+        assert_eq!(calls.load(Ordering::Relaxed), 1, "tool must have executed");
+        let reply_text = task.messages.last().map(text_of).unwrap_or_default();
+        assert!(reply_text.contains("REPORT DELIVERED"), "{reply_text}");
+    }
+
+    /// An EXPLICIT Deny rule on fleet_run still wins over the built-in
+    /// Allow default — the call is refused without executing.
+    #[tokio::test]
+    async fn fleet_run_explicit_deny_still_wins() {
+        use crate::llm::stub::SequenceLlm;
+        let responses: Vec<crate::llm::LlmResponse> =
+            vec![fleet_run_call_response("fr-0"), end_turn_response("OK")];
+        let calls = Arc::new(AtomicU64::new(0));
+        let runner = Arc::new(
+            TaskRunner::with_llm(Arc::new(SequenceLlm::new(responses)))
+                .with_tools(vec![Arc::new(CountingFleetRunTool {
+                    calls: calls.clone(),
+                })])
+                .with_tools_policy(vec![mur_common::agent::ToolRule {
+                    pattern: crate::tools::fleet_run::FLEET_RUN.into(),
+                    policy: mur_common::agent::ToolPolicy::Deny,
+                    risk: None,
+                }])
+                .with_pending_approvals(empty_pending_approvals())
+                .with_notifier(tokio::sync::mpsc::channel(16).0)
+                .with_hitl_timeout_secs(1)
+                .with_max_iterations(5),
+        );
+        let _ = runner.run_sync(loop_spec("fleet-run-deny")).await;
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            0,
+            "explicitly denied fleet_run must never execute"
+        );
     }
 
     /// Fix B — truncation is self-correcting, not a silent loop. When a turn

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -724,9 +724,17 @@ pub struct ToolRule {
 ///
 /// Precedence: exact-name match > longest-prefix glob (trailing `*`) > default (`Ask`).
 pub fn resolve_tool_policy(rules: &[ToolRule], tool_name: &str) -> ToolPolicy {
+    resolve_tool_policy_opt(rules, tool_name).unwrap_or_default()
+}
+
+/// Like [`resolve_tool_policy`] but distinguishes "no rule matched" (`None`)
+/// from an explicit rule — for tools whose registration is already gated
+/// elsewhere (e.g. `fleet_run`'s config allowlist) and that therefore want a
+/// different default than `Ask` while still honoring explicit rules.
+pub fn resolve_tool_policy_opt(rules: &[ToolRule], tool_name: &str) -> Option<ToolPolicy> {
     for rule in rules {
         if rule.pattern == tool_name {
-            return rule.policy;
+            return Some(rule.policy);
         }
     }
     let mut best: Option<(&ToolRule, usize)> = None;
@@ -740,10 +748,7 @@ pub fn resolve_tool_policy(rules: &[ToolRule], tool_name: &str) -> ToolPolicy {
             }
         }
     }
-    if let Some((rule, _)) = best {
-        return rule.policy;
-    }
-    ToolPolicy::default()
+    best.map(|(rule, _)| rule.policy)
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]

--- a/mur-core/src/cmd/deep_research/ask.rs
+++ b/mur-core/src/cmd/deep_research/ask.rs
@@ -121,11 +121,96 @@ pub async fn cmd_ask(mur_home: &Path, question: &str) -> Result<()> {
     fleet.goal = question.to_string();
     crate::cmd::fleet::store::save_fleet(mur_home, &fleet)?;
 
+    // Baseline seq so only THIS run's events are considered for the report.
+    let svc = mur_channel::ChannelService::open(mur_home)?;
+    let baseline_seq = svc
+        .load_events(&fleet.channel_id)
+        .ok()
+        .and_then(|evs| evs.last().map(|e| e.seq))
+        .unwrap_or(0);
+
     // Budget comes from fleet.yaml loop.budget_usd (set by setup); pass None
     // overrides so the existing precedence applies unchanged.
     super::run::cmd_deep_research_run(mur_home, DEFAULT_FLEET_NAME, None, None, None).await?;
 
+    // Persist the synthesized report so the answer outlives the console
+    // scrollback — and so a sandboxed caller (fleet_run tool) gets a file
+    // path in the output instead of needing its own filesystem write grants.
+    // Best-effort: a run that produced no report (guard-stopped) saves nothing.
+    if let Ok(events) = svc.load_events(&fleet.channel_id)
+        && let Some(report) = extract_report(&events, &fleet, baseline_seq)
+        && let Ok(path) = save_report(mur_home, question, &report)
+    {
+        println!("Report: {}", path.display());
+    }
+
     Ok(())
+}
+
+/// Pull the report text out of this run's channel events: the last
+/// Agent-authored event containing the convergence marker as an own-line
+/// sentinel (matching `channel_has_marker` semantics), falling back to the
+/// last Agent-authored text of the run. Marker lines are stripped from the
+/// saved text.
+fn extract_report(
+    events: &[mur_common::channel::ChannelEvent],
+    fleet: &mur_common::fleet::Fleet,
+    baseline_seq: u64,
+) -> Option<String> {
+    use mur_common::channel::ChannelActor;
+    let marker = fleet
+        .loop_cfg
+        .as_ref()
+        .and_then(|l| crate::cmd::fleet::loop_run::done_marker(&l.done_when));
+    let agent_texts = events
+        .iter()
+        .filter(|e| e.seq > baseline_seq && matches!(e.actor, ChannelActor::Agent { .. }));
+    let mut best: Option<&str> = None;
+    let mut last: Option<&str> = None;
+    for e in agent_texts {
+        if let Some(t) = e.payload.get("text").and_then(|t| t.as_str()) {
+            last = Some(t);
+            if let Some(m) = marker
+                && t.lines().any(|line| line.trim() == m)
+            {
+                best = Some(t);
+            }
+        }
+    }
+    let text = best.or(last)?;
+    let cleaned: String = match marker {
+        Some(m) => text
+            .lines()
+            .filter(|line| line.trim() != m)
+            .collect::<Vec<_>>()
+            .join("\n"),
+        None => text.to_string(),
+    };
+    let cleaned = cleaned.trim();
+    (!cleaned.is_empty()).then(|| cleaned.to_string())
+}
+
+/// Write the report under `<mur_home>/artifacts/deep-research/` as
+/// `<utc-timestamp>-<question-slug>.md` and return the path.
+fn save_report(mur_home: &Path, question: &str, report: &str) -> Result<std::path::PathBuf> {
+    let dir = mur_home.join("artifacts").join("deep-research");
+    std::fs::create_dir_all(&dir)?;
+    let slug: String = question
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+        .chars()
+        .take(48)
+        .collect();
+    let ts = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+    let path = dir.join(format!("{ts}-{slug}.md"));
+    std::fs::write(&path, format!("# {question}\n\n{report}\n"))?;
+    Ok(path)
 }
 
 #[cfg(test)]

--- a/mur-core/src/cmd/deep_research/setup.rs
+++ b/mur-core/src/cmd/deep_research/setup.rs
@@ -249,6 +249,18 @@ pub fn cmd_setup(mur_home: &Path) -> Result<()> {
         }
     }
 
+    // Seed the fleet_run authorization so the concierge can trigger THIS
+    // fleet from inside murmur (the setup wizard is the user's explicit
+    // consent moment — same starter block `mur init` seeds on fresh
+    // installs). Appends only if no fleet_run key exists; user-authored
+    // settings are never touched. Requires a concierge restart to apply.
+    if crate::cmd::init::append_fleet_run_if_absent(&mur_home.join("config.yaml"))? {
+        println!(
+            "✓ Authorized the concierge to run deep-research from murmur \
+             (config.yaml fleet_run) — restart the `mur` agent to apply"
+        );
+    }
+
     println!("\nSetup complete. Run: mur deep-research \"<your question>\"");
     Ok(())
 }

--- a/mur-core/src/cmd/init.rs
+++ b/mur-core/src/cmd/init.rs
@@ -89,7 +89,9 @@ pub(crate) fn cmd_init(hooks_flag: bool, refresh_discovery: bool) -> Result<()> 
         // Re-running init on an existing install: append the fleet_run
         // starter textually. NEVER load-modify-save here — the typed Config
         // drops foreign blocks other binaries own (e.g. `research_gateway:`).
-        append_fleet_run_if_absent(&config_path)?;
+        if append_fleet_run_if_absent(&config_path)? {
+            println!("  ✓ Added starter fleet_run authorization to config.yaml");
+        }
     }
 
     // ─── Determine whether to install hooks ──────────────────────
@@ -920,16 +922,17 @@ fn starter_fleet_run() -> mur_common::config::FleetRunConfig {
 
 /// Append the starter `fleet_run:` block to an existing config.yaml, unless a
 /// `fleet_run:` key is already present (user-authored settings are never
-/// touched). Textual append on purpose: round-tripping through the typed
-/// `Config` would drop foreign top-level blocks owned by other binaries
-/// (e.g. `research_gateway:`).
-fn append_fleet_run_if_absent(config_path: &Path) -> Result<()> {
+/// touched). Returns whether the block was appended. Textual append on
+/// purpose: round-tripping through the typed `Config` would drop foreign
+/// top-level blocks owned by other binaries (e.g. `research_gateway:`).
+/// Also called by `mur deep-research setup` (the other consent moment).
+pub(crate) fn append_fleet_run_if_absent(config_path: &Path) -> Result<bool> {
     let text = fs::read_to_string(config_path)?;
     if text
         .lines()
         .any(|l| l.trim_start().starts_with("fleet_run:"))
     {
-        return Ok(());
+        return Ok(false);
     }
     let starter = starter_fleet_run();
     let mut out = text;
@@ -944,8 +947,7 @@ fn append_fleet_run_if_absent(config_path: &Path) -> Result<()> {
         starter.fleets.join(", ")
     ));
     fs::write(config_path, out)?;
-    println!("  ✓ Added starter fleet_run authorization to config.yaml");
-    Ok(())
+    Ok(true)
 }
 
 #[cfg(test)]
@@ -966,7 +968,7 @@ mod tests {
 
         // Absent → appended, foreign block preserved.
         std::fs::write(&p, "research_gateway:\n  brave_api_key: \"x\"").unwrap();
-        append_fleet_run_if_absent(&p).unwrap();
+        assert!(append_fleet_run_if_absent(&p).unwrap());
         let text = std::fs::read_to_string(&p).unwrap();
         assert!(text.contains("research_gateway:"), "foreign block kept");
         assert!(text.contains("fleet_run:"));
@@ -976,7 +978,7 @@ mod tests {
 
         // Present (user-authored) → untouched.
         std::fs::write(&p, "fleet_run:\n  agents: [custom]\n  fleets: []\n").unwrap();
-        append_fleet_run_if_absent(&p).unwrap();
+        assert!(!append_fleet_run_if_absent(&p).unwrap());
         let text = std::fs::read_to_string(&p).unwrap();
         assert_eq!(text.matches("fleet_run:").count(), 1);
         assert!(text.contains("custom"));


### PR DESCRIPTION
Three UX fixes so `mur deep-research` from murmur (fleet_run #707) requires zero manual `mur agent perm` commands:

## Auto-save reports to `~/.mur/artifacts/deep-research/`

`mur deep-research "<q>"` now persists the last agent-authored channel text, stripping the convergence marker. The saved path is printed as the last line: `Report: <path>`. This means `fleet_run` tool output carries a filepath — the concierge agent never needs filesystem write grants for artifacts. Best-effort: runs that produce no report (guard-stopped) save nothing.

## fleet_run defaults to Allow

The config allowlist (deny-by-default, out-of-model) + positive budget + kill-switch are the real authorization for `fleet_run`. The HITL Ask gate is execute-THEN-approve: it adds zero spend protection and creates a pay-then-discard failure mode on timeout (the exact failure seen in the v2.50.0 dogfood). New `resolve_tool_policy_opt` in mur-common distinguishes "no rule" from an explicit policy; task_runner uses it to Allow `fleet_run` by default. An explicit `tool-deny fleet_run` in the profile still wins.

## `mur deep-research setup` seeds fleet_run authorization

Reuses `init.rs`'s `append_fleet_run_if_absent` (made `pub(crate)`, returns bool). Setup is the user's explicit consent moment — no separate `mur agent perm tool-allow` needed.

## Sandbox

`artifacts/` added to the fleet_run carve-in dir set so the saved report is reachable.

## Tests

2 new policy-gate tests (default-Allow executes the tool; explicit Deny still blocks). All existing fleet_run + init + sandbox + hitl tests pass. Clippy `-D warnings` + `cargo fmt --check` clean on mur-common, mur-agent-runtime, mur-core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)