### PR TITLE
fix(hub): single-source Hub version from Tauri context + wire OpenAI vision

### DIFF
--- a/mur-agent-runtime/src/llm/openai.rs
+++ b/mur-agent-runtime/src/llm/openai.rs
@@ -179,16 +179,30 @@ fn rich_messages_to_openai(msgs: &[RichMessage]) -> Vec<serde_json::Value> {
                     }));
                 }
             }
-            // ponytail: OpenAI vision not wired — keep the caption, drop the
-            // image. Emit image_url content blocks here if an OpenAI-backed
-            // vision agent ever needs to see pasted screenshots.
-            RichMessage::ImageText { role, text, .. } => {
+            // OpenAI vision: emit the image as a data-URL `image_url` content
+            // block (the OpenAI-compatible multimodal shape deepseek / LM Studio
+            // / Ollama's OpenAI endpoint all accept), plus the caption when
+            // present. A non-vision backend now errors loudly instead of the
+            // image being silently dropped.
+            RichMessage::ImageText {
+                role,
+                media_type,
+                data,
+                text,
+            } => {
                 let r = if role == "agent" {
                     "assistant"
                 } else {
                     role.as_str()
                 };
-                result.push(json!({"role": r, "content": text}));
+                let mut parts = vec![json!({
+                    "type": "image_url",
+                    "image_url": { "url": format!("data:{media_type};base64,{data}") },
+                })];
+                if !text.is_empty() {
+                    parts.push(json!({"type": "text", "text": text}));
+                }
+                result.push(json!({"role": r, "content": parts}));
             }
         }
     }
@@ -453,6 +467,44 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0]["role"], "system");
         assert_eq!(result[1]["role"], "user");
+    }
+
+    #[test]
+    fn rich_messages_image_text_becomes_image_url_block() {
+        let msgs = vec![RichMessage::ImageText {
+            role: "user".into(),
+            media_type: "image/png".into(),
+            data: "QkFTRTY0".into(),
+            text: "what color?".into(),
+        }];
+        let out = rich_messages_to_openai(&msgs);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["role"], "user");
+        let content = out[0]["content"].as_array().expect("multimodal array");
+        assert_eq!(content[0]["type"], "image_url");
+        assert_eq!(
+            content[0]["image_url"]["url"],
+            "data:image/png;base64,QkFTRTY0"
+        );
+        assert_eq!(content[1]["type"], "text");
+        assert_eq!(content[1]["text"], "what color?");
+    }
+
+    #[test]
+    fn rich_messages_image_only_omits_empty_text_block() {
+        let msgs = vec![RichMessage::ImageText {
+            role: "user".into(),
+            media_type: "image/jpeg".into(),
+            data: "QQ==".into(),
+            text: String::new(),
+        }];
+        let out = rich_messages_to_openai(&msgs);
+        let content = out[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1, "no empty text block");
+        assert_eq!(
+            content[0]["image_url"]["url"],
+            "data:image/jpeg;base64,QQ=="
+        );
     }
 
     #[test]

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.46.0"
+version = "2.51.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6619,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.46.0"
+version = "2.51.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.46.0"
+version = "2.51.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6694,7 +6694,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.46.0"
+version = "2.51.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6781,7 +6781,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.46.0"
+version = "2.51.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mur-hub-gui/src-tauri/resources/mur-agent-template/sys_prompt.md
+++ b/mur-hub-gui/src-tauri/resources/mur-agent-template/sys_prompt.md
@@ -29,6 +29,10 @@ to English unless the user is writing English.
 MUR is a local-first home for AI agents the user builds and runs on their own
 machine. You're the first of them — their guide and their resident bird.
 
+You have eyes: images the user attaches arrive inside the message and you can
+see them. If a turn carries no image, say none was attached this turn — never
+claim you can't see images.
+
 ## How you help
 - When they want to build an agent, or hand you a smarter brain, help eagerly and
   concretely.

--- a/mur-hub-gui/src-tauri/src/import_muragent.rs
+++ b/mur-hub-gui/src-tauri/src/import_muragent.rs
@@ -117,8 +117,14 @@ pub fn inspect_muragent_file(path: String) -> Result<MuragentInspection, String>
 /// Perform the actual install. UI must only call this after the user has
 /// consented to the dialog (and, on first-time-author, after the 5s delay).
 #[tauri::command]
-pub fn install_muragent_file(path: String) -> Result<InstallReceipt, String> {
-    install_inner(Path::new(&path)).map_err(|e| e.to_string())
+pub fn install_muragent_file(
+    app: tauri::AppHandle,
+    path: String,
+) -> Result<InstallReceipt, String> {
+    // Hub version from the Tauri context (tauri.conf.json, CI-stamped) — not
+    // env!("CARGO_PKG_VERSION"), which is stuck at 0.1.0 (workspace-excluded).
+    let hub_version = app.package_info().version.to_string();
+    install_inner(Path::new(&path), &hub_version).map_err(|e| e.to_string())
 }
 
 fn inspect_inner(path: &Path) -> anyhow::Result<MuragentInspection> {
@@ -147,7 +153,7 @@ fn inspect_inner(path: &Path) -> anyhow::Result<MuragentInspection> {
     }
 }
 
-fn install_inner(path: &Path) -> anyhow::Result<InstallReceipt> {
+fn install_inner(path: &Path, hub_version: &str) -> anyhow::Result<InstallReceipt> {
     let archive =
         MuragentArchive::read(path).map_err(|e| anyhow::anyhow!("read .muragent: {e}"))?;
     let mur_home = trust::mur_home();
@@ -169,7 +175,7 @@ fn install_inner(path: &Path) -> anyhow::Result<InstallReceipt> {
         &outcome.manifest.agent.bundle_id,
         &outcome.manifest.agent.url_scheme,
         icon_icns.as_deref(),
-        env!("CARGO_PKG_VERSION"),
+        hub_version,
         &mur_home,
     ) {
         Ok(info) => info.path.to_string_lossy().into_owned(),

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -173,8 +173,16 @@ fn spawn_runtime_watcher(
 
 pub fn run() {
     init_tracing();
+    // Single source of truth for the Hub's version: the Tauri context
+    // (tauri.conf.json, which CI stamps to the release tag). NEVER use
+    // env!("CARGO_PKG_VERSION") here — this crate is workspace-excluded, its
+    // Cargo.toml is never bumped, so that macro is stuck at 0.1.0 and made
+    // `mur update` nag "Hub out of date" against a freshly updated Hub.
+    let context = tauri::generate_context!();
+    let hub_version = context.package_info().version.to_string();
     tracing::info!(
-        version = mur_gui_core::CRATE_VERSION,
+        version = %hub_version,
+        core = mur_gui_core::CRATE_VERSION,
         "starting mur-hub-gui"
     );
 
@@ -197,7 +205,7 @@ pub fn run() {
             &bundle_id,
             &url_scheme,
             icon_icns.as_deref(),
-            env!("CARGO_PKG_VERSION"),
+            &hub_version,
             &mur_home,
         ) {
             tracing::error!("--regenerate-stub failed for {slug}: {e}");
@@ -209,7 +217,7 @@ pub fn run() {
     let mur_home = mur_home_path();
     // Write ~/.mur/host_path so mur-agent-launcher stubs can find the Hub binary
     // and detect version mismatches for self-update (spec §5.2, §5.4).
-    if let Err(e) = write_host_path(env!("CARGO_PKG_VERSION"), &mur_home) {
+    if let Err(e) = write_host_path(&hub_version, &mur_home) {
         tracing::warn!("failed to write host_path: {e}");
     }
     // `run()` is a plain fn, so Tauri's async runtime is not yet entered here.
@@ -345,7 +353,10 @@ pub fn run() {
             }
 
             // Scan for stale OS stubs and regenerate in a background task (§5.4).
-            stub::scan_and_regenerate_stale(env!("CARGO_PKG_VERSION").into(), mur_home.clone());
+            stub::scan_and_regenerate_stale(
+                app.package_info().version.to_string(),
+                mur_home.clone(),
+            );
 
             // Register global shortcut CmdOrCtrl+Shift+M → toggle_popover.
             let handle = app.handle().clone();
@@ -720,7 +731,7 @@ pub fn run() {
             mcp_skills::mcp_installed,
             mcp_skills::addons_installed,
         ])
-        .build(tauri::generate_context!())
+        .build(context)
         .expect("error while building tauri application")
         .run(|_app, _event| {
             #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Issue 1 — false "MUR Hub v0.1.0 is out of date" nag

`mur update` warned the Hub was stale at v0.1.0 while the Hub's own About panel showed 2.51.0.

**Root cause:** two version sources. CI stamps the release tag into `tauri.conf.json` (feeds `getVersion()` / `package_info()`), but `mur-hub-gui`'s `Cargo.toml` is workspace-excluded and never bumped — so every `env!("CARGO_PKG_VERSION")` site reported 0.1.0, including the `~/.mur/host_path` write that `mur update`'s staleness nudge reads.

**Fix:** bind `tauri::generate_context!()` once at the top of `run()`, derive `hub_version` from `package_info()` (the exact source the GUI displays), and use it at every former `env!` site (`write_host_path`, `--regenerate-stub`, `scan_and_regenerate_stale`, `.muragent` install stub). Old 0.1.0 stubs self-heal on next Hub launch via the existing stale-scan.

## Issue 2 — image paste debugging → OpenAI vision latent bug

Live investigation confirmed the murmur → A2A → runtime → Anthropic vision path works end-to-end (agent correctly names the color of a test PNG sent over `message/send`). But it surfaced a real latent defect: `mur-agent-runtime/src/llm/openai.rs` dropped `RichMessage::ImageText`'s image bytes and forwarded only the caption (`{ role, text, .. }`).

**Fix:** emit the standard multimodal `image_url` data-URL content block (+ caption when non-empty), matching what deepseek / LM Studio / Ollama's OpenAI endpoint accept. A non-vision backend now errors loudly instead of silently losing the image. TDD: 2 new unit tests (red → green), full `llm::` suite passes (48/48).

## Persona honesty

The concierge `sys_prompt.md` template led the agent to claim it "has no eyes" when a turn arrived without an image — a false capability denial (vision demonstrably works). The prompt now states images are visible when attached, and to say "none attached this turn" otherwise.

## Verification
- `cargo check --lib` + `cargo clippy --lib` clean on mur-hub-gui (exit 0)
- `cargo clippy -p mur-agent-runtime --lib` clean
- `cargo test -p mur-agent-runtime --lib llm::` — 48 passed
- `cargo fmt` both crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)