### PR TITLE
fix(runtime): surface max_tokens truncation with a visible marker and warning (#715)

### DIFF
--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -69,6 +69,14 @@ pub enum StopReason {
     MaxTokens,
 }
 
+/// Visible marker appended to assistant text when the provider cut the
+/// generation off at the output-token ceiling (Anthropic
+/// `stop_reason == "max_tokens"`, OpenAI `finish_reason == "length"`, Ollama
+/// `done_reason == "length"`). A truncated reply must never look complete —
+/// users, delegating agents, and channel history all read this text, and a
+/// silent mid-word cut is how issue #715's corrupted artifact happened.
+pub const MAX_TOKENS_TRUNCATION_MARKER: &str = "\n\n[output truncated: max_tokens reached]";
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ToolResultEntry {
     pub call_id: String,
@@ -143,6 +151,14 @@ pub struct LlmResponse {
     pub model: String,
     pub tool_calls: Vec<ToolCallResult>,
     pub stop_reason: StopReason,
+}
+
+impl LlmResponse {
+    /// True when the provider stopped this generation because it hit the
+    /// output-token ceiling — i.e. the text is truncated, not complete.
+    pub fn truncated_by_max_tokens(&self) -> bool {
+        self.stop_reason == StopReason::MaxTokens
+    }
 }
 
 #[derive(Debug, Clone, thiserror::Error)]

--- a/mur-agent-runtime/src/llm/ollama.rs
+++ b/mur-agent-runtime/src/llm/ollama.rs
@@ -99,13 +99,20 @@ impl LlmClient for OllamaClient {
             .to_string();
         let input_tokens = v["prompt_eval_count"].as_u64().unwrap_or(0);
         let output_tokens = v["eval_count"].as_u64().unwrap_or(0);
+        // Ollama reports `done_reason: "length"` when `num_predict` cut the
+        // generation off — surface it so the caller can mark the truncation.
+        let stop_reason = if v["done_reason"].as_str() == Some("length") {
+            StopReason::MaxTokens
+        } else {
+            StopReason::EndTurn
+        };
         Ok(LlmResponse {
             text,
             input_tokens,
             output_tokens,
             model: self.model.clone(),
             tool_calls: vec![],
-            stop_reason: StopReason::EndTurn,
+            stop_reason,
         })
     }
 
@@ -148,6 +155,7 @@ impl LlmClient for OllamaClient {
         let mut text = String::new();
         let mut input_tokens = 0u64;
         let mut output_tokens = 0u64;
+        let mut stop_reason = StopReason::EndTurn;
         while let Some(chunk) = resp.chunk().await.map_err(|e| LlmError::from_reqwest(&e))? {
             buf.extend_from_slice(&chunk);
             while let Some(nl) = buf.iter().position(|&b| b == b'\n') {
@@ -186,6 +194,11 @@ impl LlmClient for OllamaClient {
                 if v["done"].as_bool() == Some(true) {
                     input_tokens = v["prompt_eval_count"].as_u64().unwrap_or(input_tokens);
                     output_tokens = v["eval_count"].as_u64().unwrap_or(output_tokens);
+                    // `done_reason: "length"` = the `num_predict` ceiling cut
+                    // the generation off mid-answer.
+                    if v["done_reason"].as_str() == Some("length") {
+                        stop_reason = StopReason::MaxTokens;
+                    }
                 }
             }
         }
@@ -198,7 +211,7 @@ impl LlmClient for OllamaClient {
             output_tokens,
             model: self.model.clone(),
             tool_calls: vec![],
-            stop_reason: StopReason::EndTurn,
+            stop_reason,
         })
     }
 }

--- a/mur-agent-runtime/src/llm/openai.rs
+++ b/mur-agent-runtime/src/llm/openai.rs
@@ -382,6 +382,7 @@ impl LlmClient for OpenAiClient {
         let mut text = String::new();
         let mut input_tokens = 0u64;
         let mut output_tokens = 0u64;
+        let mut stop_reason = StopReason::EndTurn;
         while let Some(chunk) = resp.chunk().await.map_err(|e| LlmError::from_reqwest(&e))? {
             buf.extend_from_slice(&chunk);
             while let Some(nl) = buf.iter().position(|&b| b == b'\n') {
@@ -423,6 +424,16 @@ impl LlmClient for OpenAiClient {
                         })
                         .await;
                 }
+                // The final content chunk carries `finish_reason`; surface a
+                // max_tokens cut (`"length"`) so the caller can mark the reply
+                // as truncated instead of passing it off as complete.
+                if let Some(fr) = v["choices"][0]["finish_reason"].as_str() {
+                    stop_reason = match fr {
+                        "length" => StopReason::MaxTokens,
+                        "tool_calls" => StopReason::ToolUse,
+                        _ => StopReason::EndTurn,
+                    };
+                }
                 if v["usage"].is_object() {
                     input_tokens = v["usage"]["prompt_tokens"].as_u64().unwrap_or(input_tokens);
                     output_tokens = v["usage"]["completion_tokens"]
@@ -440,7 +451,7 @@ impl LlmClient for OpenAiClient {
             output_tokens,
             model: self.model.clone(),
             tool_calls: vec![],
-            stop_reason: StopReason::EndTurn,
+            stop_reason,
         })
     }
 }

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -159,6 +159,12 @@ pub struct TaskRunner {
     /// as `cumulative_input_tokens`: overlapping turns on one runner can race
     /// this value; acceptable for a best-effort telemetry field.
     last_model_ref: Mutex<Option<String>>,
+    /// True when the most recent LLM response of the current turn was cut off
+    /// at the provider's max_tokens ceiling (`StopReason::MaxTokens`). Read by
+    /// the `token_usage` closure to add `"truncated": true` to `Task.usage`;
+    /// reset alongside `last_model_ref` at the start of each `run_sync_inner`
+    /// turn. Same runner-lifetime concurrency caveat as `last_model_ref`.
+    last_turn_truncated: AtomicBool,
     hook_chain: Option<Arc<HookChain>>,
     hook_ctx: Option<HookCtx>,
     hook_cancel: Option<CancellationToken>,
@@ -280,6 +286,7 @@ impl TaskRunner {
             cumulative_output_tokens: AtomicU64::new(0),
             last_input_tokens: AtomicU64::new(0),
             last_model_ref: Mutex::new(None),
+            last_turn_truncated: AtomicBool::new(false),
             hook_chain: None,
             hook_ctx: None,
             hook_cancel: None,
@@ -688,6 +695,8 @@ impl TaskRunner {
             .last_model_ref
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = None;
+        // Same for the truncation flag: it describes THIS turn only.
+        self.last_turn_truncated.store(false, Ordering::Relaxed);
 
         let generation = async {
             match &self.backend {
@@ -785,13 +794,20 @@ impl TaskRunner {
                 RequestIntent::Interactive => "interactive",
                 RequestIntent::Background(_) => "smart-background",
             };
-            serde_json::json!({
+            let mut usage = serde_json::json!({
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
                 "context_tokens": self.last_input_tokens.load(Ordering::Relaxed),
                 "model_ref": model_ref,
                 "route_reason": route_reason,
-            })
+            });
+            // Additive: present (true) only when the final generation was cut
+            // off at the max_tokens ceiling, so existing consumers of the
+            // usage JSON are unaffected (#715).
+            if self.last_turn_truncated.load(Ordering::Relaxed) {
+                usage["truncated"] = true.into();
+            }
+            usage
         };
 
         let now = chrono::Utc::now().to_rfc3339();
@@ -1041,12 +1057,23 @@ impl TaskRunner {
             ..Default::default()
         };
         let start = std::time::Instant::now();
-        let llm_result = match sink {
-            Some(sink) => client.generate_stream(req, sink).await,
+        let llm_result = match &sink {
+            Some(s) => client.generate_stream(req, s.clone()).await,
             None => client.generate(req).await,
         };
         match llm_result {
-            Ok(resp) => {
+            Ok(mut resp) => {
+                if resp.truncated_by_max_tokens() {
+                    self.mark_max_tokens_truncation(task_id, &mut resp);
+                    if let Some(s) = &sink {
+                        let _ = s
+                            .send(crate::llm::StreamDelta {
+                                text: crate::llm::MAX_TOKENS_TRUNCATION_MARKER.to_string(),
+                                thinking: false,
+                            })
+                            .await;
+                    }
+                }
                 let latency_ms = start.elapsed().as_millis() as u64;
                 *self
                     .last_model_ref
@@ -1110,6 +1137,29 @@ impl TaskRunner {
 
     fn tools_for_loop(&self) -> &[Arc<dyn crate::tools::ToolExecutor>] {
         &self.tools
+    }
+
+    /// Handle a final answer the provider cut off at the max_tokens ceiling:
+    /// warn loudly, flag the turn for `Task.usage` (`"truncated": true`), and
+    /// append the visible truncation marker so every downstream consumer —
+    /// user, delegating agent, channel history — can see the cut instead of a
+    /// silent mid-word seam (#715). The effective ceiling is the provider
+    /// default (requests leave `max_tokens` unset), so the warning reports the
+    /// actual `output_tokens`, which equals the cap at truncation.
+    fn mark_max_tokens_truncation(&self, task_id: &str, resp: &mut crate::llm::LlmResponse) {
+        self.last_turn_truncated.store(true, Ordering::Relaxed);
+        tracing::warn!(
+            agent = self
+                .hook_ctx
+                .as_ref()
+                .map(|c| c.agent_name.as_str())
+                .unwrap_or("<unknown>"),
+            task_id,
+            model = %resp.model,
+            output_tokens = resp.output_tokens,
+            "llm generation hit the max_tokens ceiling; reply is truncated (visible marker appended)"
+        );
+        resp.text.push_str(crate::llm::MAX_TOKENS_TRUNCATION_MARKER);
     }
 
     async fn prepare_system_prompt(
@@ -1553,6 +1603,25 @@ impl TaskRunner {
                 });
                 iteration += 1;
                 continue;
+            }
+
+            // A max_tokens stop that reaches this point carries usable text
+            // and no tool calls (both other combinations were handled above):
+            // the FINAL answer itself was cut off mid-generation. Mark it
+            // visibly — in the returned reply, the streamed output, and the
+            // persisted history — instead of passing truncated text off as a
+            // complete answer (#715).
+            let mut resp = resp;
+            if resp.truncated_by_max_tokens() {
+                self.mark_max_tokens_truncation(task_id, &mut resp);
+                if let Some(s) = &sink {
+                    let _ = s
+                        .send(crate::llm::StreamDelta {
+                            text: crate::llm::MAX_TOKENS_TRUNCATION_MARKER.to_string(),
+                            thinking: false,
+                        })
+                        .await;
+                }
             }
 
             history.push(RichMessage::ToolUse {
@@ -2313,6 +2382,20 @@ mod tests {
         }
     }
 
+    /// A response truncated in the middle of the FINAL answer: `stop_reason ==
+    /// MaxTokens` with usable text and no tool_calls — the silent-corruption
+    /// case from #715 (a delegated spec cut mid-word at exactly the cap).
+    fn truncated_text_response(text: &str) -> crate::llm::LlmResponse {
+        crate::llm::LlmResponse {
+            text: text.into(),
+            input_tokens: 5,
+            output_tokens: 16384,
+            model: "test".into(),
+            tool_calls: vec![],
+            stop_reason: crate::llm::StopReason::MaxTokens,
+        }
+    }
+
     /// Counting `bash` tool: records how many times it executes so a test can
     /// assert a (truncated) tool call was NOT run.
     struct CountingBashTool {
@@ -2534,6 +2617,93 @@ mod tests {
         assert!(
             reply_text.contains("RECOVERED"),
             "expected the recovery turn's reply, got: {reply_text}"
+        );
+    }
+
+    /// Fix A (#715): a turn whose FINAL answer stops at `MaxTokens` (text
+    /// present, no tool_calls) must not be passed off as complete — the reply
+    /// gets the visible truncation marker appended and `Task.usage` carries
+    /// `"truncated": true`.
+    #[tokio::test]
+    async fn max_tokens_final_answer_gets_marker_and_usage_flag() {
+        use crate::llm::stub::SequenceLlm;
+        let responses = vec![truncated_text_response("A long spec cut mid-wo")];
+        let runner = Arc::new(
+            TaskRunner::with_llm(Arc::new(SequenceLlm::new(responses)))
+                .with_pending_approvals(empty_pending_approvals())
+                .with_notifier(tokio::sync::mpsc::channel(16).0)
+                .with_hitl_timeout_secs(1)
+                .with_max_iterations(5),
+        );
+        let outcome = runner.run_sync(loop_spec("truncate-final-answer")).await;
+        let TaskOutcome::Completed(task) = outcome else {
+            panic!("expected Completed, got {outcome:?}");
+        };
+        let reply_text = task.messages.last().map(text_of).unwrap_or_default();
+        assert!(
+            reply_text.starts_with("A long spec cut mid-wo"),
+            "truncated text must be preserved, got: {reply_text}"
+        );
+        assert!(
+            reply_text.ends_with(crate::llm::MAX_TOKENS_TRUNCATION_MARKER),
+            "reply must end with the visible truncation marker, got: {reply_text}"
+        );
+        let usage = task.usage.expect("usage is always populated");
+        assert_eq!(
+            usage["truncated"], true,
+            "usage must flag the truncation; usage={usage:?}"
+        );
+    }
+
+    /// Counterpart to the marker test: a clean end_turn must carry neither the
+    /// marker nor the `truncated` usage key (the flag is additive-only).
+    #[tokio::test]
+    async fn clean_end_turn_has_no_truncation_marker_or_flag() {
+        use crate::llm::stub::SequenceLlm;
+        let responses = vec![end_turn_response("complete answer")];
+        let runner = Arc::new(
+            TaskRunner::with_llm(Arc::new(SequenceLlm::new(responses)))
+                .with_pending_approvals(empty_pending_approvals())
+                .with_notifier(tokio::sync::mpsc::channel(16).0)
+                .with_hitl_timeout_secs(1)
+                .with_max_iterations(5),
+        );
+        let outcome = runner.run_sync(loop_spec("clean-end-turn")).await;
+        let TaskOutcome::Completed(task) = outcome else {
+            panic!("expected Completed, got {outcome:?}");
+        };
+        let reply_text = task.messages.last().map(text_of).unwrap_or_default();
+        assert!(
+            !reply_text.contains(crate::llm::MAX_TOKENS_TRUNCATION_MARKER),
+            "clean turn must not carry the marker, got: {reply_text}"
+        );
+        let usage = task.usage.expect("usage is always populated");
+        assert!(
+            usage.get("truncated").is_none(),
+            "clean turn must not populate the truncated flag; usage={usage:?}"
+        );
+    }
+
+    /// Same marker + flag behavior on the non-agentic `run_llm` path (runner
+    /// built without pending approvals — e.g. companion / plain generate).
+    #[tokio::test]
+    async fn run_llm_path_marks_max_tokens_truncation() {
+        use crate::llm::stub::SequenceLlm;
+        let responses = vec![truncated_text_response("plain reply cut mid-wo")];
+        let runner = TaskRunner::with_llm(Arc::new(SequenceLlm::new(responses)));
+        let outcome = runner.run_sync(loop_spec("truncate-run-llm")).await;
+        let TaskOutcome::Completed(task) = outcome else {
+            panic!("expected Completed, got {outcome:?}");
+        };
+        let reply_text = task.messages.last().map(text_of).unwrap_or_default();
+        assert!(
+            reply_text.ends_with(crate::llm::MAX_TOKENS_TRUNCATION_MARKER),
+            "run_llm reply must end with the truncation marker, got: {reply_text}"
+        );
+        let usage = task.usage.expect("usage is always populated");
+        assert_eq!(
+            usage["truncated"], true,
+            "usage must flag the truncation; usage={usage:?}"
         );
     }
 


### PR DESCRIPTION
Part A of #715 (do not auto-close — Part B remains).

## Root cause

A delegated turn recorded `output_tokens: 16384` — exactly the provider cap — and the runtime did nothing with `stop_reason: max_tokens` when the FINAL answer (text present, no tool calls) was the thing truncated. The cut text flowed into the reply, the channel, and the delegating agent with no signal anywhere, producing the silently corrupted artifact in the incident. (The existing MaxTokens handling only covered mid-tool_use and thinking-only truncations, which recover via a guidance nudge.)

## Fix

- **Adapters surface the stop reason on every path.** OpenAI streaming now parses `finish_reason` (`"length"` → `StopReason::MaxTokens`); Ollama maps `done_reason: "length"` on both stream and non-stream. Anthropic (stream + non-stream) and OpenAI non-stream already did. No raw string passthrough — the existing `StopReason` enum plus a `LlmResponse::truncated_by_max_tokens()` helper.
- **task_runner marks the truncation** (both the agentic loop's final-answer exit and the non-agentic `run_llm` path):
  - `tracing::warn!` with agent name, task id, model, and `output_tokens`. Note: requests leave `max_tokens` unset (provider default applies), so the warning reports the actual `output_tokens`, which equals the effective cap at truncation.
  - Appends the visible marker constant `MAX_TOKENS_TRUNCATION_MARKER` (`\n\n[output truncated: max_tokens reached]`) to the reply text — also streamed as a final delta so interactive viewers see it, and persisted into conversation history so the model knows its own prior reply was cut.
  - Adds `"truncated": true` to `Task.usage` — additive only (key absent on clean turns), so existing consumers of the usage JSON (fleet cost accounting etc.) are unaffected.

## Tests

`cargo nextest run -p mur-agent-runtime -E 'test(truncat) or test(max_tokens)'` — 7 passed (3 new):

- `max_tokens_final_answer_gets_marker_and_usage_flag` — truncated final answer ends with the marker and usage carries `truncated: true`
- `clean_end_turn_has_no_truncation_marker_or_flag` — additive-only guarantee
- `run_llm_path_marks_max_tokens_truncation` — same behavior on the non-agentic path

`cargo check -p mur-agent-runtime`, `cargo fmt --all`, `cargo clippy -p mur-agent-runtime --no-deps -- -D warnings` all clean.

## Follow-up (Part B of #715, not in this PR)

Artifact/file handoff for delegation replies: the producer should write the file (or return an artifact reference) and the consumer should move/link it — never re-emit long content through another model's generation. That is a design feature and is tracked separately in #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)