### PR TITLE
fix(runtime): suggest_replies must not carry findings; persist offered options to channel (#716)

### DIFF
--- a/mur-agent-runtime/src/tools/suggest.rs
+++ b/mur-agent-runtime/src/tools/suggest.rs
@@ -22,16 +22,22 @@ impl ToolExecutor for SuggestRepliesTool {
             name: SUGGEST_REPLIES.into(),
             description: "Offer the user 1-5 short quick-reply options when they \
                 would likely pick from a small set — e.g. after you ask a question \
-                or propose a choice. Each option is a complete message the user \
-                could send verbatim, with an optional one-line description of the \
-                trade-off. The options appear as a chooser in the user's input. \
-                You decide what happens next: if you genuinely need their answer \
-                before proceeding, end your turn after offering the options and \
-                wait for their reply; if you already know the next step (e.g. a \
-                plan they've approved), just take it — don't offer a chooser in \
-                place of acting. Do NOT number the options yourself (no \"A:\" / \
-                \"1.\" prefixes) — the UI marks and spaces them. Skip it on \
-                open-ended turns with no natural shortlist."
+                or propose a choice. Each option is a short candidate USER reply \
+                (imperative, under ~60 characters) derived from your final message, \
+                with an optional one-line description of the trade-off. Options are \
+                ephemeral UI chrome, NOT an information channel: they MUST NOT \
+                contain findings, analysis, or any information not already stated \
+                in your final message text. Your final message must be \
+                self-contained — state what you found first, then ask; a reader \
+                who never sees the options must lose nothing. The options appear \
+                as a chooser in the user's input. You decide what happens next: \
+                if you genuinely need their answer before proceeding, end your \
+                turn after offering the options and wait for their reply; if you \
+                already know the next step (e.g. a plan they've approved), just \
+                take it — don't offer a chooser in place of acting. Do NOT number \
+                the options yourself (no \"A:\" / \"1.\" prefixes) — the UI marks \
+                and spaces them. Skip it on open-ended turns with no natural \
+                shortlist."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -43,7 +49,7 @@ impl ToolExecutor for SuggestRepliesTool {
                             "oneOf": [
                                 {
                                     "type": "string",
-                                    "description": "A complete message the user could send."
+                                    "description": "A short candidate user reply (imperative, under ~60 chars), sent verbatim if picked. No new information."
                                 },
                                 {
                                     "type": "object",
@@ -51,11 +57,11 @@ impl ToolExecutor for SuggestRepliesTool {
                                     "properties": {
                                         "text": {
                                             "type": "string",
-                                            "description": "The message the user sends if they pick this option."
+                                            "description": "The short reply the user sends if they pick this option (imperative, under ~60 chars)."
                                         },
                                         "description": {
                                             "type": "string",
-                                            "description": "Optional one-line rationale / trade-off shown under the option."
+                                            "description": "Optional one-line trade-off shown under the option. May only restate information already in your final message — never new findings."
                                         }
                                     },
                                     "required": ["text"]
@@ -108,6 +114,27 @@ mod tests {
         let d = SuggestRepliesTool.def();
         assert_eq!(d.name, "suggest_replies");
         assert_eq!(d.input_schema["properties"]["replies"]["type"], "array");
+    }
+
+    /// #716: the description must forbid using options as the information
+    /// channel and require a self-contained final message, so the model can't
+    /// bury its findings in ephemeral TUI chrome.
+    #[test]
+    fn def_constrains_options_to_final_message_content() {
+        let d = SuggestRepliesTool.def();
+        assert!(
+            d.description
+                .contains("MUST NOT contain findings, analysis, or any information"),
+            "description must forbid findings/analysis in options"
+        );
+        assert!(
+            d.description.contains("self-contained"),
+            "description must require a self-contained final message"
+        );
+        assert!(
+            d.description.contains("candidate USER reply"),
+            "description must frame options as candidate user replies"
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -537,8 +537,16 @@ impl App {
     }
 
     /// Append a turn to the session log, surfacing a write failure once.
-    fn persist_turn(&mut self, role: &str, text: &str, task_id: Option<&str>) {
-        match self.session.append(role, text, task_id) {
+    /// `suggested` carries the quick-reply options offered this turn (agent
+    /// turns only) so they persist with the reply (#716).
+    fn persist_turn(
+        &mut self,
+        role: &str,
+        text: &str,
+        task_id: Option<&str>,
+        suggested: &[super::suggest::Suggestion],
+    ) {
+        match self.session.append(role, text, task_id, suggested) {
             Ok(()) => self.channel = self.session.current(),
             Err(e) => {
                 if !self.persist_warned {
@@ -648,7 +656,7 @@ impl App {
     /// the request.
     pub fn begin_user_turn(&mut self, text: &str) -> String {
         self.messages.push(ChatMsg::new(Role::User, text));
-        self.persist_turn("user", text, None);
+        self.persist_turn("user", text, None, &[]);
         // A fresh client-side task id per turn (used for cancellation).
         let task_id = uuid::Uuid::now_v7().to_string();
         self.current_task_id = Some(task_id.clone());
@@ -736,7 +744,12 @@ impl App {
             if let Some(tid) = &task_id {
                 self.context_task_id = Some(tid.clone());
             }
-            self.persist_turn("agent", &b, task_id.as_deref());
+            // Persist the quick-reply options offered this turn alongside the
+            // reply so channel history is not lossy about what was offered
+            // (#716). Read (not taken) here: `reveal_suggestions` still runs
+            // after this to surface them in the composer.
+            let offered = self.pending_suggestions.clone();
+            self.persist_turn("agent", &b, task_id.as_deref(), &offered);
         }
         self.streaming = false;
         self.current_task_id = None;
@@ -909,7 +922,7 @@ impl App {
             format!("$ {cmd}\n{output}")
         };
         self.messages.push(ChatMsg::new(Role::Shell, text.clone()));
-        self.persist_turn("shell", &text, None);
+        self.persist_turn("shell", &text, None, &[]);
         self.pending_shell.push(text);
         self.scroll_back = 0;
     }

--- a/mur-core/src/cmd/agent/cli/persist.rs
+++ b/mur-core/src/cmd/agent/cli/persist.rs
@@ -93,8 +93,17 @@ impl Session {
     }
 
     /// Append one turn, creating the channel on first write. `role` ∈
-    /// {"user","agent","shell"}.
-    pub fn append(&mut self, role: &str, text: &str, task_id: Option<&str>) -> Result<()> {
+    /// {"user","agent","shell"}. For agent turns, `suggested` carries the
+    /// quick-reply options offered alongside the reply (#716): they are
+    /// persisted into the event payload as an additive `suggested_replies`
+    /// field so channel history is not lossy about what was offered.
+    pub fn append(
+        &mut self,
+        role: &str,
+        text: &str,
+        task_id: Option<&str>,
+        suggested: &[super::suggest::Suggestion],
+    ) -> Result<()> {
         let (actor, kind) = match role {
             "agent" => (
                 ChannelActor::Agent {
@@ -119,6 +128,12 @@ impl Session {
         if let Some(t) = task_id {
             payload["task_id"] = serde_json::Value::String(t.to_string());
         }
+        // Additive field only — absent when no options were offered, so
+        // existing events and readers are untouched (new events sign whatever
+        // payload they carry; no fold/verify change).
+        if role == "agent" && !suggested.is_empty() {
+            payload["suggested_replies"] = suggestions_to_json(suggested);
+        }
         crate::channel_writer::append_as_writer(
             &self.svc,
             &self.home,
@@ -131,6 +146,21 @@ impl Session {
         )?;
         Ok(())
     }
+}
+
+/// Serialize offered quick-reply options for the channel payload: a bare
+/// string when there is no description, else `{text, description}` —
+/// mirroring the tool-call shape so nothing offered is lost.
+fn suggestions_to_json(suggested: &[super::suggest::Suggestion]) -> serde_json::Value {
+    serde_json::Value::Array(
+        suggested
+            .iter()
+            .map(|s| match &s.desc {
+                Some(d) => serde_json::json!({ "text": s.text, "description": d }),
+                None => serde_json::Value::String(s.text.clone()),
+            })
+            .collect(),
+    )
 }
 
 fn event_to_turn(ev: &ChannelEvent) -> TurnRecord {
@@ -226,11 +256,71 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mut s = Session::create(tmp.path(), "qa").unwrap();
         assert!(s.current().is_none(), "no channel before first append");
-        s.append("user", "hi", None).unwrap();
+        s.append("user", "hi", None, &[]).unwrap();
         let meta = s.current().expect("channel exists after first append");
         assert!(!meta.id.is_empty());
         assert!(!meta.state.is_empty());
         // state must not contain JSON quotes — must be bare kebab
         assert!(!meta.state.contains('"'));
+    }
+
+    /// #716: options offered via `suggest_replies` must land in the agent
+    /// event's payload (`suggested_replies`) so channel history is not lossy;
+    /// turns without options must not carry the field.
+    #[test]
+    fn agent_append_persists_offered_suggestions() {
+        let tmp = TempDir::new().unwrap();
+        let mut s = Session::create(tmp.path(), "qa").unwrap();
+        s.append("user", "run the fleet?", None, &[]).unwrap();
+        let offered = vec![
+            crate::cmd::agent::cli::suggest::Suggestion {
+                text: "取消".into(),
+                desc: None,
+            },
+            crate::cmd::agent::cli::suggest::Suggestion {
+                text: "還是執行".into(),
+                desc: Some("硬跑".into()),
+            },
+        ];
+        s.append(
+            "agent",
+            "fleet 目標不符：Rust fleet、Next.js job。要取消還是硬跑？",
+            Some("task-1"),
+            &offered,
+        )
+        .unwrap();
+        s.append("agent", "no options this turn", None, &[])
+            .unwrap();
+
+        let id = s.channel_id().unwrap().to_string();
+        let evs = ChannelService::open(tmp.path())
+            .unwrap()
+            .load_events(&id)
+            .unwrap();
+        let agent_evs: Vec<_> = evs
+            .iter()
+            .filter(|e| matches!(e.actor, ChannelActor::Agent { .. }))
+            .collect();
+        assert_eq!(agent_evs.len(), 2);
+
+        let sugg = agent_evs[0]
+            .payload
+            .get("suggested_replies")
+            .expect("agent event carries the offered options");
+        assert_eq!(sugg[0], serde_json::json!("取消"));
+        assert_eq!(
+            sugg[1],
+            serde_json::json!({ "text": "還是執行", "description": "硬跑" })
+        );
+        // Existing payload fields are untouched.
+        assert_eq!(agent_evs[0].payload["task_id"], "task-1");
+        assert!(
+            agent_evs[0].payload["text"]
+                .as_str()
+                .unwrap()
+                .contains("目標不符")
+        );
+        // No options offered → field absent (additive, never an empty array).
+        assert!(agent_evs[1].payload.get("suggested_replies").is_none());
     }
 }

--- a/mur-core/tests/channel_cross_surface.rs
+++ b/mur-core/tests/channel_cross_surface.rs
@@ -12,7 +12,7 @@ fn cli_write_is_visible_to_a_second_reader() {
 
     // CLI side writes.
     let mut sess = Session::create(home, "qa").unwrap();
-    sess.append("user", "shared message", None).unwrap();
+    sess.append("user", "shared message", None, &[]).unwrap();
     let cid = sess.channel_id().unwrap().to_string();
 
     // Hub side reads the same on-disk store.
@@ -34,7 +34,7 @@ fn index_is_rebuildable_from_logs() {
     let tmp = TempDir::new().unwrap();
     let home = tmp.path();
     let mut sess = Session::create(home, "qa").unwrap();
-    sess.append("user", "x", None).unwrap();
+    sess.append("user", "x", None, &[]).unwrap();
 
     // Close the session's open SQLite connection before deleting the index.
     // On Windows an open file cannot be removed (sharing violation); dropping


### PR DESCRIPTION
## Root cause

An agent checked a fleet, found a real mismatch, then put the entire analysis into the `suggest_replies` option labels/subtitles and made its final chat message an empty "you decide" one-liner. The options are ephemeral TUI chrome and are **not persisted to the channel**, so the finding existed nowhere durable.

## Fix

1. **Tool contract** (`mur-agent-runtime/src/tools/suggest.rs`): the tool description now states options are short candidate user replies (imperative, ≤~60 chars) derived from the final message, and MUST NOT contain findings/analysis or any information not already in the message; the final message must be self-contained. Subtitle field is restricted to restating existing information.
2. **Persist offered options** (`cli/persist.rs`, `cli/app.rs`): agent-turn channel events now carry an additive `suggested_replies` field in the payload, absent when no options were offered — no change to existing fields, signing canonicalization, or `CHANNEL_SCHEMA_VERSION` (new events sign whatever payload they carry; fold/verify untouched).

## Tests

Unit coverage asserts the tool description contains the constraint phrase and the persisted payload carries the options. Gates run in CI (disk-constrained locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #716