### PR TITLE
fix(core): validate skill refs at agent creation; distinguish missing vs malformed skills (#717)

### DIFF
--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -559,6 +559,28 @@ pub(crate) async fn prepare_runtime(
 
     let skills_cfg = mur_common::config::Config::load_or_default(&mur_home).skills;
     let loaded = mur_common::skill::loader::load_all(&mur_home, &profile.inner.name);
+    // #717: surface profile.yaml skill refs that don't resolve, distinguishing
+    // missing (ref written but files never installed) from malformed (files
+    // exist but no longer parse) so the log names the actual root cause.
+    for r in &profile.inner.skills {
+        use mur_common::skill::loader::SkillRefStatus;
+        match mur_common::skill::loader::skill_ref_status(agent_home, r) {
+            SkillRefStatus::Loadable => {}
+            SkillRefStatus::Missing { path } => tracing::warn!(
+                skill_ref = %r,
+                path = %path.display(),
+                "profile.yaml references a skill that is not installed (file not found); \
+                 install it with `mur agent skill add` or remove the ref"
+            ),
+            SkillRefStatus::Malformed { path, error } => tracing::warn!(
+                skill_ref = %r,
+                path = %path.display(),
+                error = %error,
+                "profile.yaml references a skill whose file exists but no longer parses \
+                 as a valid skill; re-install or remove it"
+            ),
+        }
+    }
     let loaded: Vec<_> = loaded
         .into_iter()
         .filter(|s| profile.inner.skill_enabled(&s.name))

--- a/mur-common/src/skill/loader.rs
+++ b/mur-common/src/skill/loader.rs
@@ -31,6 +31,91 @@ pub enum SkillScope {
     Agent,
 }
 
+/// Outcome of resolving a `profile.yaml` skill ref (e.g. `skills/<name>`)
+/// against an agent's home directory.
+///
+/// Distinguishing `Missing` from `Malformed` matters: a ref written without
+/// installing the backing files (issue #717) is a *missing* skill — telling
+/// the user it "no longer parses" points them at the wrong root cause.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkillRefStatus {
+    /// The ref resolves to a manifest that parses and validates.
+    Loadable,
+    /// No file exists at the resolved manifest path.
+    Missing { path: std::path::PathBuf },
+    /// A file exists but does not parse/validate as a skill manifest.
+    Malformed {
+        path: std::path::PathBuf,
+        error: String,
+    },
+}
+
+/// Resolve a `profile.yaml` skill ref to its backing manifest file and report
+/// whether it is loadable, missing, or malformed.
+///
+/// Resolution mirrors the runtime loader's layout rules: modern refs point at
+/// a *directory* (`skills/<name>`) holding `skill.yaml`; legacy refs may point
+/// directly at a `.yaml`/`.yml`/`.md` file. This is the single source of truth
+/// for ref resolution — the Hub loadability badge and the creation-time
+/// validation in mur-core both call it.
+pub fn skill_ref_status(agent_home: &Path, rel_ref: &str) -> SkillRefStatus {
+    let joined = agent_home.join(rel_ref);
+    let ext = joined
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let file = if joined.is_dir() || !matches!(ext.as_str(), "yaml" | "yml" | "md" | "markdown") {
+        // Modern directory layout: the ref names the skill dir; the manifest
+        // lives inside it. Also used when the dir is absent, so the Missing
+        // path names the exact manifest we expected to find.
+        joined.join("skill.yaml")
+    } else {
+        joined
+    };
+    if !file.is_file() {
+        return SkillRefStatus::Missing { path: file };
+    }
+    let text = match std::fs::read_to_string(&file) {
+        Ok(t) => t,
+        Err(e) => {
+            return SkillRefStatus::Malformed {
+                path: file,
+                error: format!("unreadable: {e}"),
+            };
+        }
+    };
+    let ext = file
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let parsed = match ext.as_str() {
+        "yaml" | "yml" => crate::skill::parse_canonical(&text),
+        "md" | "markdown" => crate::skill::parse_markdown(&text)
+            .or_else(|_| crate::skill::parse_legacy_markdown(&text)),
+        other => {
+            return SkillRefStatus::Malformed {
+                path: file,
+                error: format!("unsupported manifest extension '.{other}'"),
+            };
+        }
+    };
+    match parsed {
+        Ok(m) => match crate::skill::validate(&m) {
+            Ok(()) => SkillRefStatus::Loadable,
+            Err(e) => SkillRefStatus::Malformed {
+                path: file,
+                error: format!("invalid manifest: {e}"),
+            },
+        },
+        Err(e) => SkillRefStatus::Malformed {
+            path: file,
+            error: format!("parse failed: {e}"),
+        },
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct LoadedSkill {
     pub name: String,
@@ -280,5 +365,59 @@ content:
         let shared: Vec<_> = loaded.iter().filter(|s| s.name == "shared").collect();
         assert_eq!(shared.len(), 1);
         assert_eq!(shared[0].scope, SkillScope::Agent);
+    }
+
+    // ── skill_ref_status (#717): missing vs malformed ────────────────────
+
+    #[test]
+    fn skill_ref_status_loadable_for_installed_dir_skill() {
+        let home = tempdir().unwrap();
+        write_to_dir(&home.path().join("skills").join("demo"), &make("demo")).unwrap();
+        assert_eq!(
+            skill_ref_status(home.path(), "skills/demo"),
+            SkillRefStatus::Loadable
+        );
+    }
+
+    #[test]
+    fn skill_ref_status_absent_ref_is_missing_with_manifest_path() {
+        let home = tempdir().unwrap();
+        match skill_ref_status(home.path(), "skills/executing-plans") {
+            SkillRefStatus::Missing { path } => {
+                // The reported path names the exact manifest we expected.
+                assert!(path.ends_with("skills/executing-plans/skill.yaml"));
+            }
+            other => panic!("expected Missing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn skill_ref_status_garbage_yaml_is_malformed() {
+        let home = tempdir().unwrap();
+        let sdir = home.path().join("skills").join("broken");
+        std::fs::create_dir_all(&sdir).unwrap();
+        std::fs::write(sdir.join("skill.yaml"), "{{{ not: [valid").unwrap();
+        assert!(matches!(
+            skill_ref_status(home.path(), "skills/broken"),
+            SkillRefStatus::Malformed { .. }
+        ));
+    }
+
+    #[test]
+    fn skill_ref_status_legacy_md_file_resolves_directly() {
+        let home = tempdir().unwrap();
+        let sdir = home.path().join("skills");
+        std::fs::create_dir_all(&sdir).unwrap();
+        // Absent legacy .md ref → Missing at the file itself (no /skill.yaml).
+        match skill_ref_status(home.path(), "skills/old.md") {
+            SkillRefStatus::Missing { path } => assert!(path.ends_with("skills/old.md")),
+            other => panic!("expected Missing, got {other:?}"),
+        }
+        // Present but unparseable legacy .md → Malformed.
+        std::fs::write(sdir.join("old.md"), "no frontmatter here").unwrap();
+        assert!(matches!(
+            skill_ref_status(home.path(), "skills/old.md"),
+            SkillRefStatus::Malformed { .. }
+        ));
     }
 }

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -227,6 +227,26 @@ pub(crate) fn load_profile_for_edit(name: &str) -> Result<(PathBuf, _AgentProfil
 }
 
 pub(crate) fn save_profile(path: &Path, profile: &mut _AgentProfile) -> Result<()> {
+    // Fail-closed guard (#717): a profile save must never *introduce* a skill
+    // ref that does not resolve to an installed skill under the agent dir.
+    // Only newly-added refs (relative to the profile currently on disk) are
+    // validated, so unrelated edits to a profile that already carries a
+    // legacy dangling ref still save.
+    if let Some(agent_dir) = path.parent() {
+        let prior: std::collections::HashSet<String> = fs::read_to_string(path)
+            .ok()
+            .and_then(|y| serde_yaml_ng::from_str::<_AgentProfile>(&y).ok())
+            .map(|p| p.skills.into_iter().collect())
+            .unwrap_or_default();
+        let added: Vec<String> = profile
+            .skills
+            .iter()
+            .filter(|s| !prior.contains(s.as_str()))
+            .cloned()
+            .collect();
+        skill::validate_skill_refs(agent_dir, &added)?;
+    }
+
     profile.updated_at = chrono::Utc::now().to_rfc3339();
     let yaml = serde_yaml_ng::to_string(profile).context("serialize profile.yaml")?;
     write_atomic(path, yaml.as_bytes())?;

--- a/mur-core/src/cmd/agent/skill.rs
+++ b/mur-core/src/cmd/agent/skill.rs
@@ -34,6 +34,43 @@ fn resolve_skill_id<'a>(profile: &'a _AgentProfile, query: &str) -> Option<&'a S
     None
 }
 
+/// Fail-closed validation for `profile.yaml` skill refs (#717).
+///
+/// Every ref must resolve to an installed, parseable skill under the agent's
+/// home directory (resolution reuses the runtime loader's rules via
+/// `mur_common::skill::loader::skill_ref_status`). Returns a single error
+/// listing every bad ref, distinguishing *missing* (never installed) from
+/// *malformed* (installed but no longer parses), so a `skills:` entry written
+/// without installing the backing files can never be saved silently.
+pub fn validate_skill_refs(agent_home: &Path, refs: &[String]) -> Result<()> {
+    use mur_common::skill::loader::{SkillRefStatus, skill_ref_status};
+
+    let bad: Vec<String> = refs
+        .iter()
+        .filter_map(|r| match skill_ref_status(agent_home, r) {
+            SkillRefStatus::Loadable => None,
+            SkillRefStatus::Missing { path } => Some(format!(
+                "{r}: file not found at {} (referenced by profile.yaml but never installed)",
+                path.display()
+            )),
+            SkillRefStatus::Malformed { path, error } => Some(format!(
+                "{r}: {} exists but does not load as a skill ({error})",
+                path.display()
+            )),
+        })
+        .collect();
+    if bad.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "refusing to write dangling skill ref(s) into profile.yaml:\n  - {}\n\
+         Install each skill onto the agent first (`mur agent skill add <agent> <path>`, \
+         `mur agent skill registry-add`, or `mur agent skill install-pack`), \
+         or remove the ref.",
+        bad.join("\n  - ")
+    );
+}
+
 pub fn cmd_skill_list(name: &str) -> Result<()> {
     let (_path, profile) = load_profile_for_edit(name)?;
     if profile.skills.is_empty() {
@@ -181,4 +218,97 @@ pub fn cmd_skill_set_enabled(name: &str, skill_id: &str, enabled: bool) -> Resul
         if enabled { "Enabled" } else { "Disabled" }
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod skill_ref_validation_tests {
+    use super::*;
+
+    fn valid_manifest(name: &str) -> mur_common::skill::SkillManifest {
+        mur_common::skill::parse_canonical(&format!(
+            r#"name: {name}
+version: 1.0.0
+publisher: human:t
+description: test skill for ref validation
+category: context
+content:
+  abstract: hi
+  context: body
+"#
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn validate_skill_refs_distinguishes_missing_from_malformed() {
+        let home = tempfile::tempdir().unwrap();
+
+        // Missing: nothing installed at the ref.
+        let err = validate_skill_refs(home.path(), &["skills/executing-plans".into()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("file not found"), "got: {err}");
+        assert!(err.contains("skills/executing-plans"), "got: {err}");
+
+        // Malformed: file exists but is garbage.
+        let bad = home.path().join("skills").join("broken");
+        fs::create_dir_all(&bad).unwrap();
+        fs::write(bad.join("skill.yaml"), "{{{ not yaml").unwrap();
+        let err = validate_skill_refs(home.path(), &["skills/broken".into()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("does not load as a skill"), "got: {err}");
+
+        // Loadable: properly installed skill passes.
+        mur_common::skill::write_to_dir(&home.path().join("skills").join("ok"), &valid_manifest("ok"))
+            .unwrap();
+        validate_skill_refs(home.path(), &["skills/ok".into()]).unwrap();
+    }
+
+    #[test]
+    fn save_profile_rejects_newly_added_dangling_ref() {
+        let agent_dir = tempfile::tempdir().unwrap();
+        let path = agent_dir.path().join("profile.yaml");
+        let mut profile = mur_common::AgentProfile::default_for_tests();
+
+        // Baseline save with no skill refs succeeds.
+        save_profile(&path, &mut profile).unwrap();
+
+        // Adding a ref with no installed files must fail-closed (#717) …
+        profile.skills.push("skills/ghost".into());
+        let err = save_profile(&path, &mut profile).unwrap_err().to_string();
+        assert!(err.contains("skills/ghost"), "got: {err}");
+        assert!(err.contains("file not found"), "got: {err}");
+        // … and the dangling ref must not have been persisted.
+        let on_disk: mur_common::AgentProfile =
+            serde_yaml_ng::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(on_disk.skills.is_empty());
+
+        // Installing the files first makes the same save succeed.
+        mur_common::skill::write_to_dir(
+            &agent_dir.path().join("skills").join("ghost"),
+            &valid_manifest("ghost"),
+        )
+        .unwrap();
+        save_profile(&path, &mut profile).unwrap();
+        let on_disk: mur_common::AgentProfile =
+            serde_yaml_ng::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(on_disk.skills, vec!["skills/ghost".to_string()]);
+    }
+
+    #[test]
+    fn save_profile_tolerates_preexisting_dangling_ref_on_unrelated_edit() {
+        let agent_dir = tempfile::tempdir().unwrap();
+        let path = agent_dir.path().join("profile.yaml");
+
+        // Simulate the incident: a profile already on disk with a dangling
+        // ref (written by an external tool, bypassing save_profile).
+        let mut profile = mur_common::AgentProfile::default_for_tests();
+        profile.skills.push("skills/executing-plans".into());
+        fs::write(&path, serde_yaml_ng::to_string(&profile).unwrap()).unwrap();
+
+        // An unrelated edit must still save — only *newly added* refs gate.
+        profile.display_name = "Renamed".into();
+        save_profile(&path, &mut profile).unwrap();
+    }
 }

--- a/mur-core/src/cmd/agent/skill.rs
+++ b/mur-core/src/cmd/agent/skill.rs
@@ -260,8 +260,11 @@ content:
         assert!(err.contains("does not load as a skill"), "got: {err}");
 
         // Loadable: properly installed skill passes.
-        mur_common::skill::write_to_dir(&home.path().join("skills").join("ok"), &valid_manifest("ok"))
-            .unwrap();
+        mur_common::skill::write_to_dir(
+            &home.path().join("skills").join("ok"),
+            &valid_manifest("ok"),
+        )
+        .unwrap();
         validate_skill_refs(home.path(), &["skills/ok".into()]).unwrap();
     }
 

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.51.0"
+version = "2.51.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6619,7 +6619,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.51.0"
+version = "2.51.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.51.0"
+version = "2.51.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -6694,7 +6694,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.51.0"
+version = "2.51.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6781,7 +6781,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.51.0"
+version = "2.51.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mur-hub-gui/src-tauri/src/detail.rs
+++ b/mur-hub-gui/src-tauri/src/detail.rs
@@ -90,35 +90,34 @@ pub struct SkillView {
     /// manifest (canonical YAML or markdown). Legacy `.md` paths that no
     /// longer parse are surfaced as `false` so the UI can flag them as dead.
     pub loadable: bool,
+    /// Why a skill is (or isn't) loadable, so the UI can distinguish a ref
+    /// whose file was never installed from a file that no longer parses
+    /// (#717).
+    pub status: SkillRefStatusView,
 }
 
-/// Best-effort check that a legacy per-agent skill path points at a file that
-/// the runtime can still load. Resolves `rel_path` under the agent home, then
-/// parses the file by extension and validates the resulting manifest. Any
-/// failure (missing file, unparseable, invalid) yields `false`.
-fn skill_path_is_loadable(agent_home: &std::path::Path, rel_path: &str) -> bool {
-    let mut file = agent_home.join(rel_path);
-    // Modern per-agent skills are stored as `skills/<name>/skill.yaml`, so the
-    // id in `profile.skills` points at the *directory*. Resolve to the manifest
-    // inside it; legacy ids that already point at a file pass through unchanged.
-    if file.is_dir() {
-        file = file.join("skill.yaml");
+/// UI-facing skill-ref status. `Missing` = the resolved manifest file does
+/// not exist (profile.yaml references a skill that was never installed);
+/// `Malformed` = the file exists but no longer parses/validates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SkillRefStatusView {
+    Ok,
+    Missing,
+    Malformed,
+}
+
+/// Classify a legacy per-agent skill path via the shared resolver the runtime
+/// loader uses (`mur_common::skill::loader::skill_ref_status`): resolves
+/// `rel_path` under the agent home (`skills/<name>` dirs resolve to their
+/// `skill.yaml`), then parses + validates the manifest.
+fn skill_ref_view(agent_home: &std::path::Path, rel_path: &str) -> SkillRefStatusView {
+    use mur_common::skill::loader::SkillRefStatus;
+    match mur_common::skill::loader::skill_ref_status(agent_home, rel_path) {
+        SkillRefStatus::Loadable => SkillRefStatusView::Ok,
+        SkillRefStatus::Missing { .. } => SkillRefStatusView::Missing,
+        SkillRefStatus::Malformed { .. } => SkillRefStatusView::Malformed,
     }
-    let Ok(text) = std::fs::read_to_string(&file) else {
-        return false;
-    };
-    let ext = file
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_ascii_lowercase();
-    let parsed = match ext.as_str() {
-        "yaml" | "yml" => mur_common::skill::parse_canonical(&text),
-        "md" | "markdown" => mur_common::skill::parse_markdown(&text)
-            .or_else(|_| mur_common::skill::parse_legacy_markdown(&text)),
-        _ => return false,
-    };
-    matches!(parsed, Ok(ref m) if mur_common::skill::validate(m).is_ok())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -207,12 +206,15 @@ pub fn build_agent_detail(
             .skills
             .iter()
             .map(|path| {
-                let loadable = agent_home
-                    .map(|home| skill_path_is_loadable(home, path))
-                    .unwrap_or(false);
+                // No agent home (test construction) → report Missing, which
+                // is also the fail-safe reading: nothing resolvable on disk.
+                let status = agent_home
+                    .map(|home| skill_ref_view(home, path))
+                    .unwrap_or(SkillRefStatusView::Missing);
                 SkillView {
                     path: path.clone(),
-                    loadable,
+                    loadable: status == SkillRefStatusView::Ok,
+                    status,
                 }
             })
             .collect(),
@@ -356,7 +358,7 @@ pub fn update_agent_detail(name: String, patch: DetailPatch) -> Result<AgentDeta
 
 #[cfg(test)]
 mod tests {
-    use super::skill_path_is_loadable;
+    use super::{SkillRefStatusView, skill_ref_view};
 
     // Regression: per-agent skill ids are directories (`skills/<name>`) holding
     // a `skill.yaml`. The loadable check must resolve into the dir, not try to
@@ -375,8 +377,33 @@ mod tests {
         )
         .unwrap();
 
-        assert!(skill_path_is_loadable(home.path(), "skills/demo"));
-        assert!(!skill_path_is_loadable(home.path(), "skills/missing"));
+        assert_eq!(
+            skill_ref_view(home.path(), "skills/demo"),
+            SkillRefStatusView::Ok
+        );
+    }
+
+    // #717: a ref written into profile.yaml without installing the backing
+    // files must surface as Missing (file not found), not as a parse failure.
+    #[test]
+    fn absent_ref_is_missing_not_malformed() {
+        let home = tempfile::tempdir().unwrap();
+        assert_eq!(
+            skill_ref_view(home.path(), "skills/executing-plans"),
+            SkillRefStatusView::Missing
+        );
+    }
+
+    #[test]
+    fn garbage_manifest_is_malformed_not_missing() {
+        let home = tempfile::tempdir().unwrap();
+        let skill_dir = home.path().join("skills").join("broken");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("skill.yaml"), "{{{ not yaml at all").unwrap();
+        assert_eq!(
+            skill_ref_view(home.path(), "skills/broken"),
+            SkillRefStatusView::Malformed
+        );
     }
 }
 

--- a/mur-hub-gui/ui/src/components/inspector/tabs/SkillsTab.tsx
+++ b/mur-hub-gui/ui/src/components/inspector/tabs/SkillsTab.tsx
@@ -226,12 +226,18 @@ export function SkillsTab({
                 <div>
                   <code style={{ fontSize: 11 }}>{s.path}</code>
                   <span className={s.loadable ? "badge-loadable" : "badge-dead"}>
-                    {s.loadable ? t("detail.skillLoadable") : t("detail.skillDead")}
+                    {s.loadable
+                      ? t("detail.skillLoadable")
+                      : s.status === "missing"
+                        ? t("detail.skillMissing")
+                        : t("detail.skillDead")}
                   </span>
                 </div>
                 {!s.loadable && (
                   <div className="item-card-desc field-muted" style={{ fontSize: 11 }}>
-                    {t("detail.skillDeadHint")}
+                    {s.status === "missing"
+                      ? t("detail.skillMissingHint", { path: s.path })
+                      : t("detail.skillDeadHint")}
                   </div>
                 )}
               </li>

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -211,6 +211,8 @@ export const en = {
   "detail.skillLoadable": "loadable",
   "detail.skillDead": "unloadable",
   "detail.skillDeadHint": "This legacy file no longer parses as a valid skill — remove and re-install it.",
+  "detail.skillMissing": "missing",
+  "detail.skillMissingHint": "File not found: {path} — profile.yaml references this skill but it was never installed. Install it (mur agent skill add) or remove the entry.",
   "detail.remove": "Remove",
   "detail.addMcp": "Add MCP server",
   "detail.discoverMcp": "Discover from other tools",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -213,6 +213,8 @@ export const zhTW: Table = {
   "detail.skillLoadable": "可載入",
   "detail.skillDead": "無法載入",
   "detail.skillDeadHint": "這個舊版檔案已無法解析為有效技能——請移除後重新安裝。",
+  "detail.skillMissing": "檔案不存在",
+  "detail.skillMissingHint": "找不到檔案:{path} — profile.yaml 引用了這個技能,但從未安裝。請安裝(mur agent skill add)或移除此項目。",
   "detail.remove": "移除",
   "detail.addMcp": "新增 MCP 伺服器",
   "detail.discoverMcp": "從其他工具探索",

--- a/mur-hub-gui/ui/src/types.ts
+++ b/mur-hub-gui/ui/src/types.ts
@@ -82,6 +82,11 @@ export interface SkillView {
   path: string;
   /** Whether the backing file still parses + validates as a skill manifest. */
   loadable: boolean;
+  /**
+   * Why: "missing" = the file was never installed (dangling profile.yaml ref),
+   * "malformed" = the file exists but no longer parses (#717).
+   */
+  status: "ok" | "missing" | "malformed";
 }
 
 export interface InstalledAddonView {


### PR DESCRIPTION
## Root cause

Concierge-driven `mur agent create` wrote `skills:` refs (e.g. `skills/executing-plans`) into new agents' profile.yaml without installing any skill files — `<agent_dir>/skills/` didn't exist. The Hub then labelled every ref "unloadable: no longer parses as a valid skill", wrong twice: nothing was ever installed, and the file is *missing*, not malformed.

## Fix (three parts)

1. **Single resolution source** (`mur-common/src/skill/loader.rs`): new `SkillRefStatus { Loadable | Missing{path} | Malformed{path,error} }` + `skill_ref_status()` — the one place that classifies a `skills/<name>` ref.
2. **Validate at creation** (`mur-core/src/cmd/agent/{mod,skill}.rs`): writing skill refs now verifies each resolves; a dangling ref fails the op with one error listing every bad ref, distinguishing missing (never installed) from malformed. (Legacy already-dangling profiles still load — the gate is on new writes.)
3. **Missing vs malformed everywhere it surfaces**: runtime loader + Hub Rust (`mur-hub-gui/src-tauri/src/detail.rs`) + Hub UI copy (`i18n/en.ts`, `zh-TW.ts`, `SkillsTab.tsx`): a missing ref now reads "File not found: {path} — profile.yaml references this skill but it was never installed", distinct from a parse failure.

## Tests

Unit tests for the create-time dangling-ref rejection and the loader's missing-vs-malformed distinction (tempdir: absent file vs garbage yaml). Rust + TS gates run in CI (hub-gui app not built locally, per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #717