### PR TITLE
fix(agent-cli): bottom-anchor the viewport after purge so replays keep headroom

### DIFF
--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -534,15 +534,25 @@ fn rebuild_after_resize(
 }
 
 /// Wipe the screen AND scrollback, then re-anchor a fresh Inline viewport
-/// of height `h` at the top-left. Shared by the resize rebuild and the
-/// /clear / channel-switch screen wipe. Caller must drop any live
-/// `EventStream` first.
+/// of height `h` anchored at the BOTTOM of the screen. Shared by the resize
+/// rebuild and the /clear / channel-switch screen wipe. Caller must drop any
+/// live `EventStream` first.
+///
+/// Bottom-anchored on purpose: `with_options` anchors the viewport at the
+/// cursor, and a viewport at row 0 has no headroom above it, so the next
+/// transcript replay's `insert_before` must draw THROUGH the viewport rows
+/// and scroll the whole screen — any row overwritten before its scroll never
+/// reaches scrollback intact (bodies went missing right after a resize).
+/// Anchoring at the bottom leaves the headroom `insert_before` needs to lay
+/// replayed rows down above the viewport, which is also the steady state the
+/// UI migrates to anyway.
 fn purge_and_reanchor(terminal: &mut Terminal<CrosstermBackend<Stdout>>, h: u16) -> Result<()> {
     use crossterm::cursor::MoveTo;
     use crossterm::terminal::{Clear, ClearType};
+    let rows = crossterm::terminal::size()?.1;
     crossterm::execute!(
         io::stdout(),
-        MoveTo(0, 0),
+        MoveTo(0, rows.saturating_sub(h)),
         Clear(ClearType::All),
         Clear(ClearType::Purge),
     )?;


### PR DESCRIPTION
## 問題
#724 之後仍有一個殘餘:resize 或 /clear 之後「馬上」發話,scrollback 重播偶爾少一行訊息內文(標籤在、內文消失)。

## 根因
`purge_and_reanchor` 把新 viewport 錨在 row 0,上方零 headroom。接下來 transcript replay 的 `insert_before` 只能「畫過 viewport 頂部 + 整屏捲動」,在捲動前被 frame 蓋掉的行永遠進不了 scrollback → 內文遺失。

## 修法
purge 後改錨在畫面底部(`MoveTo(0, rows - h)`):replay 行直接落在上方 headroom,乾淨插入;底部本來就是 inline UI 的穩態位置。

## 驗證
tmux 實測:turn → 13→24 縮放 → 立即 turn,transcript 完整重播無遺失;/clear → turn 也乾淨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)