### PR TITLE
fix(agent-runtime): share one session cwd between bash and file tools

### DIFF
--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -247,8 +247,13 @@ pub async fn build_provider_runner(
     // profile and sandboxed children can dial it. See profile_needs_egress.
     let egress = egress_proxy;
     let pool = McpPool::new(enabled_mcp.clone(), sandbox_policy, egress);
+    // Issue #591 / runtime-file-tools-cwd: bash and the three file tools share
+    // ONE session cwd (initial value = agent_home). The bash tool's `cwd`
+    // parameter updates it; file tools resolve relative paths against the
+    // current snapshot. A `cd` inside a bash subprocess is NOT retained.
+    let session_cwd = crate::tools::fs_policy::SessionCwd::new(agent_home.to_path_buf());
     let bash_exec: Arc<dyn crate::tools::ToolExecutor> =
-        Arc::new(BashTool::new(agent_home.to_path_buf()));
+        Arc::new(BashTool::new(agent_home.to_path_buf(), session_cwd.clone()));
     let bash_def = bash_exec.def();
     // Issue #712: the file tools must never touch the agent's own
     // profile.yaml / identity.key, whatever the profile grants.
@@ -257,15 +262,15 @@ pub async fn build_provider_runner(
         agent_home,
     );
     let read_file_exec: Arc<dyn crate::tools::ToolExecutor> = Arc::new(
-        crate::tools::read_file::ReadFileTool::new(agent_home.to_path_buf(), tool_fs.clone()),
+        crate::tools::read_file::ReadFileTool::new(session_cwd.clone(), tool_fs.clone()),
     );
     let read_file_def = read_file_exec.def();
     let write_file_exec: Arc<dyn crate::tools::ToolExecutor> = Arc::new(
-        crate::tools::write_file::WriteFileTool::new(agent_home.to_path_buf(), tool_fs.clone()),
+        crate::tools::write_file::WriteFileTool::new(session_cwd.clone(), tool_fs.clone()),
     );
     let write_file_def = write_file_exec.def();
     let edit_file_exec: Arc<dyn crate::tools::ToolExecutor> = Arc::new(
-        crate::tools::edit_file::EditFileTool::new(agent_home.to_path_buf(), tool_fs),
+        crate::tools::edit_file::EditFileTool::new(session_cwd, tool_fs),
     );
     let edit_file_def = edit_file_exec.def();
     let tools_policy = profile.inner.entitlements.tools.clone();

--- a/mur-agent-runtime/src/tools/bash.rs
+++ b/mur-agent-runtime/src/tools/bash.rs
@@ -42,7 +42,12 @@ pub(crate) fn augmented_path(current_path: Option<&str>) -> String {
 }
 
 pub struct BashTool {
+    /// Fallback base when no explicit `cwd` is supplied and the session base
+    /// has not been overridden.
     pub working_dir: PathBuf,
+    /// Session cwd shared with the file tools. An explicit `cwd` argument
+    /// updates it; otherwise its current snapshot is used as the base.
+    pub session_cwd: crate::tools::fs_policy::SessionCwd,
 }
 
 /// Resolve the effective timeout (in seconds) from the tool input's optional
@@ -58,8 +63,11 @@ fn resolve_timeout_secs(requested: Option<i64>) -> u64 {
 }
 
 impl BashTool {
-    pub fn new(working_dir: PathBuf) -> Self {
-        Self { working_dir }
+    pub fn new(working_dir: PathBuf, session_cwd: crate::tools::fs_policy::SessionCwd) -> Self {
+        Self {
+            working_dir,
+            session_cwd,
+        }
     }
 }
 
@@ -86,7 +94,7 @@ Commands are killed after `timeout_secs` (default {DEFAULT_TIMEOUT_SECS}s, max {
                     },
                     "cwd": {
                         "type": "string",
-                        "description": "Working directory for the command. Defaults to the agent home directory."
+                        "description": "Working directory for the command. Defaults to the shared session working directory (starts at the agent home). Passing cwd also moves that shared directory, so a later read_file/write_file/edit_file resolves relative paths against it. NOTE: a `cd` inside the command itself is NOT retained across calls — use this cwd argument instead."
                     },
                     "timeout_secs": {
                         "type": "integer",
@@ -107,10 +115,19 @@ Commands are killed after `timeout_secs` (default {DEFAULT_TIMEOUT_SECS}s, max {
             .ok_or_else(|| ToolError::InvalidInput("missing 'command' field".into()))?
             .to_string();
 
-        let working_dir = input["cwd"]
-            .as_str()
-            .map(PathBuf::from)
-            .unwrap_or_else(|| self.working_dir.clone());
+        let working_dir = match input["cwd"].as_str() {
+            // Explicit cwd: use it AND update the shared session base so a
+            // subsequent read_file/write_file/edit_file resolves relative
+            // paths against the same directory.
+            Some(cwd) => {
+                let dir = PathBuf::from(cwd);
+                self.session_cwd.set(dir.clone());
+                dir
+            }
+            // No explicit cwd: fall back to the current session base (which
+            // starts at the agent home and only moves on an explicit cwd).
+            None => self.session_cwd.current(),
+        };
 
         let timeout_secs = resolve_timeout_secs(input["timeout_secs"].as_i64());
 
@@ -177,7 +194,8 @@ mod tests {
     use crate::tools::ToolExecutor;
 
     fn make_tool() -> BashTool {
-        BashTool::new(std::env::temp_dir())
+        let base = std::env::temp_dir();
+        BashTool::new(base.clone(), crate::tools::fs_policy::SessionCwd::new(base))
     }
 
     #[test]

--- a/mur-agent-runtime/src/tools/edit_file.rs
+++ b/mur-agent-runtime/src/tools/edit_file.rs
@@ -1,22 +1,20 @@
 //! First-party exact-literal edit tool (issue #591, PR2). No regex —
 //! ambiguity fails closed instead of guessing.
 
-use std::path::PathBuf;
-
 use mur_common::agent::FilesystemEntitlement;
 
 use crate::llm::ToolDef;
-use crate::tools::fs_policy::check_write_entitlement;
+use crate::tools::fs_policy::{SessionCwd, check_write_entitlement};
 use crate::tools::{ToolError, ToolExecutor};
 
 pub struct EditFileTool {
-    pub working_dir: PathBuf,
+    pub session_cwd: SessionCwd,
     pub fs: FilesystemEntitlement,
 }
 
 impl EditFileTool {
-    pub fn new(working_dir: PathBuf, fs: FilesystemEntitlement) -> Self {
-        Self { working_dir, fs }
+    pub fn new(session_cwd: SessionCwd, fs: FilesystemEntitlement) -> Self {
+        Self { session_cwd, fs }
     }
 }
 
@@ -29,12 +27,12 @@ impl ToolExecutor for EditFileTool {
     fn def(&self) -> ToolDef {
         ToolDef {
             name: "edit_file".into(),
-            description: "Replace an exact literal substring in a UTF-8 text file (no regex). By default the old_string must match exactly once — pass expected_count to replace N known occurrences. Edits are checked against the agent's filesystem write entitlements."
+            description: "Replace an exact literal substring in a UTF-8 text file (no regex). By default the old_string must match exactly once — pass expected_count to replace N known occurrences. Relative paths resolve against the shared session cwd (set by the bash tool's `cwd`); a `cd` inside a bash subprocess is NOT retained. Edits are checked against the agent's filesystem write entitlements."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "File to edit (absolute, or relative to the agent working dir)" },
+                    "path": { "type": "string", "description": "File to edit (absolute, or relative to the session cwd)" },
                     "old_string": { "type": "string", "description": "Exact literal text to replace" },
                     "new_string": { "type": "string", "description": "Replacement text" },
                     "expected_count": { "type": "integer", "description": "Exact number of occurrences to replace; omit to require exactly one" }
@@ -59,13 +57,23 @@ impl ToolExecutor for EditFileTool {
                 "'old_string' must be non-empty".into(),
             ));
         }
-        let joined = crate::tools::fs_policy::resolve_path(&self.working_dir, raw);
-        let canonical = std::fs::canonicalize(&joined)
-            .map_err(|e| ToolError::Execution(format!("cannot edit {}: {e}", joined.display())))?;
+        let base = self.session_cwd.current();
+        let joined = crate::tools::fs_policy::resolve_path(&base, raw);
+        let canonical = std::fs::canonicalize(&joined).map_err(|e| {
+            ToolError::Execution(format!(
+                "cannot edit {}: {e} (relative to session cwd {})",
+                joined.display(),
+                base.display()
+            ))
+        })?;
         check_write_entitlement(&self.fs, &canonical)?;
 
         let text = std::fs::read_to_string(&canonical).map_err(|e| {
-            ToolError::Execution(format!("cannot read {}: {e}", canonical.display()))
+            ToolError::Execution(format!(
+                "cannot read {}: {e} (relative to session cwd {})",
+                canonical.display(),
+                base.display()
+            ))
         })?;
         let found = text.match_indices(old).count();
         let expected = input["expected_count"].as_i64().filter(|v| *v >= 1);
@@ -87,7 +95,11 @@ impl ToolExecutor for EditFileTool {
         }
         let updated = text.replace(old, new);
         std::fs::write(&canonical, &updated).map_err(|e| {
-            ToolError::Execution(format!("cannot write {}: {e}", canonical.display()))
+            ToolError::Execution(format!(
+                "cannot write {}: {e} (relative to session cwd {})",
+                canonical.display(),
+                base.display()
+            ))
         })?;
         Ok(format!(
             "replaced {found} occurrence(s) in {}",
@@ -103,7 +115,7 @@ mod tests {
     fn tool(td: &tempfile::TempDir) -> EditFileTool {
         let root = td.path().to_str().unwrap();
         EditFileTool::new(
-            td.path().into(),
+            SessionCwd::new(td.path().into()),
             FilesystemEntitlement {
                 read: vec![],
                 write: vec![root.to_string()],
@@ -140,6 +152,17 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, ToolError::InvalidInput(_)));
+    }
+
+    #[tokio::test]
+    async fn missing_file_error_names_session_cwd() {
+        let td = tempfile::tempdir().unwrap();
+        let err = tool(&td)
+            .execute(serde_json::json!({"path": "nope.txt", "old_string": "X", "new_string": "Y"}))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot edit"));
+        assert!(err.to_string().contains("session cwd"));
     }
 
     #[tokio::test]

--- a/mur-agent-runtime/src/tools/fs_policy.rs
+++ b/mur-agent-runtime/src/tools/fs_policy.rs
@@ -3,10 +3,43 @@
 //! read_file keeps its own equivalent check — dedup is a follow-up.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
 
 use mur_common::agent::FilesystemEntitlement;
 
 use crate::tools::ToolError;
+
+/// Session-wide current working directory shared by the `bash` tool and the
+/// file tools (`read_file`/`write_file`/`edit_file`), so a relative path
+/// resolves against the same base no matter which tool the agent reached for.
+///
+/// Dogfood bug: `bash pwd` showed one directory while `read_file rel/path`
+/// resolved against `agent_home`, because the two tools never shared a base.
+/// The `bash` tool updates this only when it is given an explicit `cwd`
+/// argument; a `cd` *inside* a spawned subprocess cannot be observed by the
+/// parent and is deliberately NOT tracked (that's called out in both tools'
+/// descriptions). Readers take a cheap snapshot (`current()`), never holding
+/// the lock across an `.await`.
+#[derive(Clone)]
+pub(crate) struct SessionCwd(Arc<RwLock<PathBuf>>);
+
+impl SessionCwd {
+    /// Create a session cwd seeded with the agent home (the historical base).
+    pub(crate) fn new(initial: PathBuf) -> Self {
+        Self(Arc::new(RwLock::new(initial)))
+    }
+
+    /// Snapshot the current base. Clones the `PathBuf` and releases the read
+    /// lock immediately, so callers never hold a guard across `.await`.
+    pub(crate) fn current(&self) -> PathBuf {
+        self.0.read().expect("session cwd lock poisoned").clone()
+    }
+
+    /// Update the session base (called by `bash` when given explicit `cwd`).
+    pub(crate) fn set(&self, dir: PathBuf) {
+        *self.0.write().expect("session cwd lock poisoned") = dir;
+    }
+}
 
 /// Resolve a tool-supplied path: expand a leading `~`/`~/` to the user's
 /// home, keep absolute paths as-is, and join relative paths onto

--- a/mur-agent-runtime/src/tools/fs_policy.rs
+++ b/mur-agent-runtime/src/tools/fs_policy.rs
@@ -21,22 +21,22 @@ use crate::tools::ToolError;
 /// descriptions). Readers take a cheap snapshot (`current()`), never holding
 /// the lock across an `.await`.
 #[derive(Clone)]
-pub(crate) struct SessionCwd(Arc<RwLock<PathBuf>>);
+pub struct SessionCwd(Arc<RwLock<PathBuf>>);
 
 impl SessionCwd {
     /// Create a session cwd seeded with the agent home (the historical base).
-    pub(crate) fn new(initial: PathBuf) -> Self {
+    pub fn new(initial: PathBuf) -> Self {
         Self(Arc::new(RwLock::new(initial)))
     }
 
     /// Snapshot the current base. Clones the `PathBuf` and releases the read
     /// lock immediately, so callers never hold a guard across `.await`.
-    pub(crate) fn current(&self) -> PathBuf {
+    pub fn current(&self) -> PathBuf {
         self.0.read().expect("session cwd lock poisoned").clone()
     }
 
     /// Update the session base (called by `bash` when given explicit `cwd`).
-    pub(crate) fn set(&self, dir: PathBuf) {
+    pub fn set(&self, dir: PathBuf) {
         *self.0.write().expect("session cwd lock poisoned") = dir;
     }
 }

--- a/mur-agent-runtime/src/tools/read_file.rs
+++ b/mur-agent-runtime/src/tools/read_file.rs
@@ -16,15 +16,19 @@ use crate::tools::{ToolError, ToolExecutor};
 const MAX_RETURN_BYTES: usize = 512 * 1024;
 
 pub struct ReadFileTool {
-    /// Base for resolving relative paths (the agent home / working dir).
-    pub working_dir: PathBuf,
+    /// Session cwd shared with `bash`; relative paths resolve against its
+    /// current snapshot so `read_file rel/x` matches where `bash` last ran.
+    pub session_cwd: crate::tools::fs_policy::SessionCwd,
     /// Filesystem grants from the agent profile; checked before every read.
     pub fs: FilesystemEntitlement,
 }
 
 impl ReadFileTool {
-    pub fn new(working_dir: PathBuf, fs: FilesystemEntitlement) -> Self {
-        Self { working_dir, fs }
+    pub fn new(
+        session_cwd: crate::tools::fs_policy::SessionCwd,
+        fs: FilesystemEntitlement,
+    ) -> Self {
+        Self { session_cwd, fs }
     }
 
     /// Prefix-match `path` against the entitlement lists after
@@ -63,7 +67,7 @@ impl ToolExecutor for ReadFileTool {
         ToolDef {
             name: "read_file".into(),
             description: "Read a UTF-8 text file. Optional 1-indexed `offset`/`limit` select a line window. \
-Paths resolve relative to the agent working directory; reads are checked against the agent's filesystem entitlements."
+Relative paths resolve against the shared session working directory (the same base the `bash` tool uses, moved only by passing `bash` an explicit `cwd`); reads are checked against the agent's filesystem entitlements."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
@@ -81,9 +85,15 @@ Paths resolve relative to the agent working directory; reads are checked against
         let raw = input["path"]
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput("missing 'path' field".into()))?;
-        let joined = crate::tools::fs_policy::resolve_path(&self.working_dir, raw);
-        let canonical = std::fs::canonicalize(&joined)
-            .map_err(|e| ToolError::Execution(format!("cannot read {}: {e}", joined.display())))?;
+        let base = self.session_cwd.current();
+        let joined = crate::tools::fs_policy::resolve_path(&base, raw);
+        let canonical = std::fs::canonicalize(&joined).map_err(|e| {
+            ToolError::Execution(format!(
+                "cannot read {}: {e} (relative to session cwd {})",
+                joined.display(),
+                base.display()
+            ))
+        })?;
         self.check_entitlement(&canonical)?;
 
         let bytes = std::fs::read(&canonical).map_err(|e| {
@@ -135,10 +145,78 @@ mod tests {
         p
     }
 
+    // runtime-file-tools-cwd: a shared SessionCwd handle means the bash tool's
+    // explicit `cwd` moves the base that the file tools resolve against.
+    #[tokio::test]
+    async fn shared_cwd_bash_set_moves_read_file_base() {
+        use crate::tools::bash::BashTool;
+        use crate::tools::fs_policy::SessionCwd;
+
+        let home = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        // Seed the SAME relative filename in both dirs with distinct contents.
+        write_tmp(home.path(), "spec.md", "HOME");
+        write_tmp(other.path(), "spec.md", "OTHER");
+
+        let shared = SessionCwd::new(home.path().into());
+        let bash = BashTool::new(home.path().into(), shared.clone());
+        let reader = ReadFileTool::new(
+            shared.clone(),
+            fs_ent(
+                &[
+                    home.path().to_str().unwrap(),
+                    other.path().to_str().unwrap(),
+                ],
+                &[],
+                &[],
+            ),
+        );
+
+        // Before: relative read resolves against home.
+        let before = reader
+            .execute(serde_json::json!({"path": "spec.md"}))
+            .await
+            .unwrap();
+        assert!(before.contains("HOME"), "expected HOME, got {before}");
+
+        // bash with explicit cwd moves the shared base to `other`.
+        bash.execute(serde_json::json!({"command": "true", "cwd": other.path().to_str().unwrap()}))
+            .await
+            .unwrap();
+
+        // After: the SAME relative read now resolves against `other`.
+        let after = reader
+            .execute(serde_json::json!({"path": "spec.md"}))
+            .await
+            .unwrap();
+        assert!(
+            after.contains("OTHER"),
+            "expected OTHER after bash cwd, got {after}"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_file_error_names_session_cwd() {
+        let td = tempfile::tempdir().unwrap();
+        let root = td.path().to_str().unwrap();
+        let t = ReadFileTool::new(
+            crate::tools::fs_policy::SessionCwd::new(td.path().into()),
+            fs_ent(&[root], &[], &[]),
+        );
+        let err = t
+            .execute(serde_json::json!({"path": "nope.txt"}))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("relative to session cwd"));
+    }
+
     #[tokio::test]
     async fn missing_path_is_invalid_input() {
         let td = tempfile::tempdir().unwrap();
-        let t = ReadFileTool::new(td.path().into(), fs_ent(&[], &[], &[]));
+        let t = ReadFileTool::new(
+            crate::tools::fs_policy::SessionCwd::new(td.path().into()),
+            fs_ent(&[], &[], &[]),
+        );
         let err = t.execute(serde_json::json!({})).await.unwrap_err();
         assert!(matches!(err, ToolError::InvalidInput(_)));
     }
@@ -148,7 +226,10 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         write_tmp(td.path(), "f.txt", "l1\nl2\nl3\nl4");
         let root = td.path().to_str().unwrap();
-        let t = ReadFileTool::new(td.path().into(), fs_ent(&[root], &[], &[]));
+        let t = ReadFileTool::new(
+            crate::tools::fs_policy::SessionCwd::new(td.path().into()),
+            fs_ent(&[root], &[], &[]),
+        );
         let out = t
             .execute(serde_json::json!({"path": "f.txt", "offset": 2, "limit": 2}))
             .await
@@ -161,7 +242,10 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         write_tmp(td.path(), "f.txt", "hi");
         let root = td.path().to_str().unwrap();
-        let t = ReadFileTool::new(td.path().into(), fs_ent(&[], &[root], &[]));
+        let t = ReadFileTool::new(
+            crate::tools::fs_policy::SessionCwd::new(td.path().into()),
+            fs_ent(&[], &[root], &[]),
+        );
         assert_eq!(
             t.execute(serde_json::json!({"path": "f.txt"}))
                 .await
@@ -175,7 +259,10 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         write_tmp(td.path(), "f.txt", "secret");
         let root = td.path().to_str().unwrap();
-        let t = ReadFileTool::new(td.path().into(), fs_ent(&[root], &[], &[root]));
+        let t = ReadFileTool::new(
+            crate::tools::fs_policy::SessionCwd::new(td.path().into()),
+            fs_ent(&[root], &[], &[root]),
+        );
         let err = t
             .execute(serde_json::json!({"path": "f.txt"}))
             .await
@@ -187,7 +274,10 @@ mod tests {
     async fn unentitled_path_is_rejected() {
         let td = tempfile::tempdir().unwrap();
         write_tmp(td.path(), "f.txt", "hi");
-        let t = ReadFileTool::new(td.path().into(), fs_ent(&["/nonexistent-grant"], &[], &[]));
+        let t = ReadFileTool::new(
+            crate::tools::fs_policy::SessionCwd::new(td.path().into()),
+            fs_ent(&["/nonexistent-grant"], &[], &[]),
+        );
         let err = t
             .execute(serde_json::json!({"path": "f.txt"}))
             .await
@@ -199,7 +289,10 @@ mod tests {
     async fn nonexistent_file_is_execution_error() {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().to_str().unwrap();
-        let t = ReadFileTool::new(td.path().into(), fs_ent(&[root], &[], &[]));
+        let t = ReadFileTool::new(
+            crate::tools::fs_policy::SessionCwd::new(td.path().into()),
+            fs_ent(&[root], &[], &[]),
+        );
         let err = t
             .execute(serde_json::json!({"path": "nope.txt"}))
             .await

--- a/mur-agent-runtime/src/tools/registry.rs
+++ b/mur-agent-runtime/src/tools/registry.rs
@@ -141,6 +141,7 @@ mod tests {
         use crate::tools::bash::BashTool;
         let bash_exec: Arc<dyn ToolExecutor> = Arc::new(BashTool {
             working_dir: std::path::PathBuf::from("/tmp"),
+            session_cwd: crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
         });
         let bash_def = bash_exec.def();
         let pool = McpPool::new(vec![], SandboxPolicy::default(), None);
@@ -172,6 +173,7 @@ mod tests {
         use crate::tools::bash::BashTool;
         let bash_exec: Arc<dyn ToolExecutor> = Arc::new(BashTool {
             working_dir: std::path::PathBuf::from("/tmp"),
+            session_cwd: crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
         });
         let bash_def = bash_exec.def();
         let rules = vec![ToolRule {
@@ -200,7 +202,7 @@ mod tests {
     async fn read_file_tool_included_when_allowed() {
         use crate::tools::read_file::ReadFileTool;
         let read_file_exec: Arc<dyn ToolExecutor> = Arc::new(ReadFileTool::new(
-            std::path::PathBuf::from("/tmp"),
+            crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
             mur_common::agent::FilesystemEntitlement::default(),
         ));
         let read_file_def = read_file_exec.def();
@@ -224,7 +226,7 @@ mod tests {
     async fn read_file_tool_excluded_when_denied() {
         use crate::tools::read_file::ReadFileTool;
         let read_file_exec: Arc<dyn ToolExecutor> = Arc::new(ReadFileTool::new(
-            std::path::PathBuf::from("/tmp"),
+            crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
             mur_common::agent::FilesystemEntitlement::default(),
         ));
         let read_file_def = read_file_exec.def();
@@ -254,7 +256,7 @@ mod tests {
     async fn write_file_tool_included_when_allowed() {
         use crate::tools::write_file::WriteFileTool;
         let write_file_exec: Arc<dyn ToolExecutor> = Arc::new(WriteFileTool::new(
-            std::path::PathBuf::from("/tmp"),
+            crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
             mur_common::agent::FilesystemEntitlement::default(),
         ));
         let write_file_def = write_file_exec.def();
@@ -278,7 +280,7 @@ mod tests {
     async fn write_file_tool_excluded_when_denied() {
         use crate::tools::write_file::WriteFileTool;
         let write_file_exec: Arc<dyn ToolExecutor> = Arc::new(WriteFileTool::new(
-            std::path::PathBuf::from("/tmp"),
+            crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
             mur_common::agent::FilesystemEntitlement::default(),
         ));
         let write_file_def = write_file_exec.def();
@@ -308,7 +310,7 @@ mod tests {
     async fn edit_file_tool_included_when_allowed() {
         use crate::tools::edit_file::EditFileTool;
         let edit_file_exec: Arc<dyn ToolExecutor> = Arc::new(EditFileTool::new(
-            std::path::PathBuf::from("/tmp"),
+            crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
             mur_common::agent::FilesystemEntitlement::default(),
         ));
         let edit_file_def = edit_file_exec.def();
@@ -332,7 +334,7 @@ mod tests {
     async fn edit_file_tool_excluded_when_denied() {
         use crate::tools::edit_file::EditFileTool;
         let edit_file_exec: Arc<dyn ToolExecutor> = Arc::new(EditFileTool::new(
-            std::path::PathBuf::from("/tmp"),
+            crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
             mur_common::agent::FilesystemEntitlement::default(),
         ));
         let edit_file_def = edit_file_exec.def();

--- a/mur-agent-runtime/src/tools/write_file.rs
+++ b/mur-agent-runtime/src/tools/write_file.rs
@@ -1,21 +1,19 @@
 //! First-party full-file write tool (issue #591, PR2).
 
-use std::path::PathBuf;
-
 use mur_common::agent::FilesystemEntitlement;
 
 use crate::llm::ToolDef;
-use crate::tools::fs_policy::check_write_entitlement;
+use crate::tools::fs_policy::{SessionCwd, check_write_entitlement};
 use crate::tools::{ToolError, ToolExecutor};
 
 pub struct WriteFileTool {
-    pub working_dir: PathBuf,
+    pub session_cwd: SessionCwd,
     pub fs: FilesystemEntitlement,
 }
 
 impl WriteFileTool {
-    pub fn new(working_dir: PathBuf, fs: FilesystemEntitlement) -> Self {
-        Self { working_dir, fs }
+    pub fn new(session_cwd: SessionCwd, fs: FilesystemEntitlement) -> Self {
+        Self { session_cwd, fs }
     }
 }
 
@@ -28,12 +26,12 @@ impl ToolExecutor for WriteFileTool {
     fn def(&self) -> ToolDef {
         ToolDef {
             name: "write_file".into(),
-            description: "Create or fully overwrite a UTF-8 text file. Parent directories are NOT auto-created — create them explicitly first. Writes are checked against the agent's filesystem write entitlements."
+            description: "Create or fully overwrite a UTF-8 text file. Parent directories are NOT auto-created — create them explicitly first. Relative paths resolve against the shared session cwd (set by the bash tool's `cwd`); a `cd` inside a bash subprocess is NOT retained. Writes are checked against the agent's filesystem write entitlements."
                 .into(),
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "Target file (absolute, or relative to the agent working dir)" },
+                    "path": { "type": "string", "description": "Target file (absolute, or relative to the session cwd)" },
                     "content": { "type": "string", "description": "Full file contents to write" }
                 },
                 "required": ["path", "content"]
@@ -48,14 +46,16 @@ impl ToolExecutor for WriteFileTool {
         let content = input["content"]
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput("missing 'content' field".into()))?;
-        let joined = crate::tools::fs_policy::resolve_path(&self.working_dir, raw);
+        let base = self.session_cwd.current();
+        let joined = crate::tools::fs_policy::resolve_path(&base, raw);
         let parent = joined
             .parent()
             .ok_or_else(|| ToolError::InvalidInput("path has no parent directory".into()))?;
         let canonical_parent = std::fs::canonicalize(parent).map_err(|_| {
             ToolError::Execution(format!(
-                "parent directory does not exist: {} (create it explicitly first)",
-                parent.display()
+                "parent directory does not exist: {} (relative to session cwd {}) (create it explicitly first)",
+                parent.display(),
+                base.display()
             ))
         })?;
         let file_name = joined
@@ -63,8 +63,13 @@ impl ToolExecutor for WriteFileTool {
             .ok_or_else(|| ToolError::InvalidInput("path has no file name".into()))?;
         let target = canonical_parent.join(file_name);
         check_write_entitlement(&self.fs, &target)?;
-        std::fs::write(&target, content)
-            .map_err(|e| ToolError::Execution(format!("cannot write {}: {e}", target.display())))?;
+        std::fs::write(&target, content).map_err(|e| {
+            ToolError::Execution(format!(
+                "cannot write {}: {e} (relative to session cwd {})",
+                target.display(),
+                base.display()
+            ))
+        })?;
         Ok(format!(
             "wrote {} bytes to {}",
             content.len(),
@@ -90,7 +95,7 @@ mod tests {
     async fn creates_and_overwrites() {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().to_str().unwrap();
-        let t = WriteFileTool::new(td.path().into(), fs_ent(&[root], &[]));
+        let t = WriteFileTool::new(SessionCwd::new(td.path().into()), fs_ent(&[root], &[]));
         let r = t
             .execute(serde_json::json!({"path": "a.txt", "content": "one"}))
             .await
@@ -109,25 +114,28 @@ mod tests {
     async fn missing_parent_fails_loud() {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().to_str().unwrap();
-        let t = WriteFileTool::new(td.path().into(), fs_ent(&[root], &[]));
+        let t = WriteFileTool::new(SessionCwd::new(td.path().into()), fs_ent(&[root], &[]));
         let err = t
             .execute(serde_json::json!({"path": "no/such/dir/a.txt", "content": "x"}))
             .await
             .unwrap_err();
         assert!(err.to_string().contains("parent directory does not exist"));
+        // error must name the resolution base
+        assert!(err.to_string().contains("session cwd"));
     }
 
     #[tokio::test]
     async fn write_requires_write_grant_and_deny_wins() {
         let td = tempfile::tempdir().unwrap();
         let root = td.path().to_str().unwrap();
-        let none = WriteFileTool::new(td.path().into(), fs_ent(&[], &[]));
+        let none = WriteFileTool::new(SessionCwd::new(td.path().into()), fs_ent(&[], &[]));
         let err = none
             .execute(serde_json::json!({"path": "a.txt", "content": "x"}))
             .await
             .unwrap_err();
         assert!(err.to_string().contains("not write-entitled"));
-        let denied = WriteFileTool::new(td.path().into(), fs_ent(&[root], &[root]));
+        let denied =
+            WriteFileTool::new(SessionCwd::new(td.path().into()), fs_ent(&[root], &[root]));
         let err2 = denied
             .execute(serde_json::json!({"path": "a.txt", "content": "x"}))
             .await


### PR DESCRIPTION
## Summary
- File tools (read_file/write_file/edit_file) resolved relative paths against construction-time agent_home while bash's per-call `cwd` override was never shared back — after bash ran in a project dir, `read_file docs/x.md` still resolved from agent_home and failed (operator-observed: agent "doesn't know where it is" after restart).
- New `SessionCwd` (Arc<RwLock<PathBuf>>, snapshot-and-release, no guard across await): one handle shared by all four tools; bash `cwd` updates it and serves as the default; file tools resolve against the current snapshot.
- File-not-found errors now name the base ("relative to session cwd <path>"); tool descriptions document that in-subprocess `cd` doesn't persist.

## Test plan
- `cargo check -p mur-agent-runtime` clean
- `cargo test -p mur-agent-runtime --lib`: 461 passed / 0 failed, incl. new tests: shared_cwd_bash_set_moves_read_file_base, missing_file_error_names_session_cwd (read/edit), write parent-error base assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)