### PR TITLE
feat(agent): actionable guidance for removable-volume EPERM

### DIFF
--- a/mur-agent-runtime/src/tools/bash.rs
+++ b/mur-agent-runtime/src/tools/bash.rs
@@ -143,7 +143,14 @@ Commands are killed after `timeout_secs` (default {DEFAULT_TIMEOUT_SECS}s, max {
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true)
             .spawn()
-            .map_err(|e| ToolError::Execution(format!("spawn failed: {e}")))?;
+            .map_err(|e| {
+                let mut msg = format!("spawn failed: {e}");
+                if crate::tools::fs_policy::is_removable_volume_eperm(&working_dir, &e) {
+                    msg.push_str("\n\n");
+                    msg.push_str(crate::tools::fs_policy::REMOVABLE_VOLUME_EPERM_HINT);
+                }
+                ToolError::Execution(msg)
+            })?;
 
         let output = match tokio::time::timeout(
             std::time::Duration::from_secs(timeout_secs),

--- a/mur-agent-runtime/src/tools/edit_file.rs
+++ b/mur-agent-runtime/src/tools/edit_file.rs
@@ -60,19 +60,15 @@ impl ToolExecutor for EditFileTool {
         let base = self.session_cwd.current();
         let joined = crate::tools::fs_policy::resolve_path(&base, raw);
         let canonical = std::fs::canonicalize(&joined).map_err(|e| {
-            ToolError::Execution(format!(
-                "cannot edit {}: {e} (relative to session cwd {})",
-                joined.display(),
-                base.display()
+            ToolError::Execution(crate::tools::fs_policy::format_io_error(
+                "edit", &joined, &base, &e,
             ))
         })?;
         check_write_entitlement(&self.fs, &canonical)?;
 
         let text = std::fs::read_to_string(&canonical).map_err(|e| {
-            ToolError::Execution(format!(
-                "cannot read {}: {e} (relative to session cwd {})",
-                canonical.display(),
-                base.display()
+            ToolError::Execution(crate::tools::fs_policy::format_io_error(
+                "read", &canonical, &base, &e,
             ))
         })?;
         let found = text.match_indices(old).count();
@@ -95,10 +91,8 @@ impl ToolExecutor for EditFileTool {
         }
         let updated = text.replace(old, new);
         std::fs::write(&canonical, &updated).map_err(|e| {
-            ToolError::Execution(format!(
-                "cannot write {}: {e} (relative to session cwd {})",
-                canonical.display(),
-                base.display()
+            ToolError::Execution(crate::tools::fs_policy::format_io_error(
+                "write", &canonical, &base, &e,
             ))
         })?;
         Ok(format!(

--- a/mur-agent-runtime/src/tools/fs_policy.rs
+++ b/mur-agent-runtime/src/tools/fs_policy.rs
@@ -61,6 +61,37 @@ pub(crate) fn resolve_path(working_dir: &Path, raw: &str) -> PathBuf {
     }
 }
 
+/// Re-export of the canonical guidance string, which now lives in
+/// `mur-common` so `mur agent doctor` and the runtime tools share one source
+/// of truth (issue #1). Do NOT inline the wording here — keep it a re-export.
+pub use mur_common::REMOVABLE_VOLUME_EPERM_HINT;
+
+/// True when `err` is an EPERM ("Operation not permitted", raw `os error 1`)
+/// against a path under `/Volumes/*`. This is the exact macOS Full-Disk-Access
+/// failure mode on removable/external volumes — distinct from a plain
+/// `PermissionDenied` (EACCES) so we don't hijack ordinary permission errors.
+pub fn is_removable_volume_eperm(path: &Path, err: &std::io::Error) -> bool {
+    let is_eperm = err.raw_os_error() == Some(1);
+    is_eperm && path.starts_with("/Volumes/")
+}
+
+/// Format an I/O error message, appending [`REMOVABLE_VOLUME_EPERM_HINT`] when
+/// the failure is the macOS Full-Disk-Access EPERM on a `/Volumes/*` path.
+/// `base` (the resolution base) is preserved verbatim so existing "relative to
+/// session cwd" diagnostics stay intact. Used by every file tool's error path.
+pub fn format_io_error(verb: &str, path: &Path, base: &Path, err: &std::io::Error) -> String {
+    let mut msg = format!(
+        "cannot {verb} {}: {err} (relative to session cwd {})",
+        path.display(),
+        base.display()
+    );
+    if is_removable_volume_eperm(path, err) {
+        msg.push_str("\n\n");
+        msg.push_str(REMOVABLE_VOLUME_EPERM_HINT);
+    }
+    msg
+}
+
 /// Harden an agent's filesystem entitlement for the file tools: append the
 /// self-protected files (issue #712 — the agent's own `profile.yaml` and
 /// `identity.key`) to the deny list, so the tool-level gate refuses reads
@@ -109,6 +140,59 @@ pub(crate) fn check_write_entitlement(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn eperm() -> std::io::Error {
+        std::io::Error::from_raw_os_error(1) // EPERM, "Operation not permitted"
+    }
+
+    #[test]
+    fn removable_eperm_matches_only_volumes_path() {
+        assert!(is_removable_volume_eperm(
+            Path::new("/Volumes/Ext/spec.md"),
+            &eperm()
+        ));
+        // Same EPERM but NOT under /Volumes → not our case.
+        assert!(!is_removable_volume_eperm(
+            Path::new("/Users/me/spec.md"),
+            &eperm()
+        ));
+    }
+
+    #[test]
+    fn removable_eperm_ignores_eacces() {
+        // Plain PermissionDenied (EACCES = os error 13) under /Volumes must
+        // NOT be hijacked — only the exact EPERM (os error 1) qualifies.
+        let eacces = std::io::Error::from_raw_os_error(13);
+        assert!(!is_removable_volume_eperm(
+            Path::new("/Volumes/Ext/spec.md"),
+            &eacces
+        ));
+    }
+
+    #[test]
+    fn format_io_error_appends_hint_on_volumes_eperm() {
+        let msg = format_io_error(
+            "read",
+            Path::new("/Volumes/Ext/spec.md"),
+            Path::new("/Volumes/Ext"),
+            &eperm(),
+        );
+        assert!(msg.contains("relative to session cwd /Volumes/Ext"));
+        assert!(msg.contains(REMOVABLE_VOLUME_EPERM_HINT));
+    }
+
+    #[test]
+    fn format_io_error_plain_error_has_no_hint() {
+        let not_found = std::io::Error::from_raw_os_error(2); // ENOENT
+        let msg = format_io_error(
+            "read",
+            Path::new("/Users/me/spec.md"),
+            Path::new("/Users/me"),
+            &not_found,
+        );
+        assert!(msg.contains("relative to session cwd /Users/me"));
+        assert!(!msg.contains(REMOVABLE_VOLUME_EPERM_HINT));
+    }
 
     #[test]
     fn resolve_path_expands_tilde() {

--- a/mur-agent-runtime/src/tools/read_file.rs
+++ b/mur-agent-runtime/src/tools/read_file.rs
@@ -88,16 +88,16 @@ Relative paths resolve against the shared session working directory (the same ba
         let base = self.session_cwd.current();
         let joined = crate::tools::fs_policy::resolve_path(&base, raw);
         let canonical = std::fs::canonicalize(&joined).map_err(|e| {
-            ToolError::Execution(format!(
-                "cannot read {}: {e} (relative to session cwd {})",
-                joined.display(),
-                base.display()
+            ToolError::Execution(crate::tools::fs_policy::format_io_error(
+                "read", &joined, &base, &e,
             ))
         })?;
         self.check_entitlement(&canonical)?;
 
         let bytes = std::fs::read(&canonical).map_err(|e| {
-            ToolError::Execution(format!("cannot read {}: {e}", canonical.display()))
+            ToolError::Execution(crate::tools::fs_policy::format_io_error(
+                "read", &canonical, &base, &e,
+            ))
         })?;
         let text = String::from_utf8_lossy(&bytes);
 

--- a/mur-agent-runtime/src/tools/write_file.rs
+++ b/mur-agent-runtime/src/tools/write_file.rs
@@ -64,10 +64,8 @@ impl ToolExecutor for WriteFileTool {
         let target = canonical_parent.join(file_name);
         check_write_entitlement(&self.fs, &target)?;
         std::fs::write(&target, content).map_err(|e| {
-            ToolError::Execution(format!(
-                "cannot write {}: {e} (relative to session cwd {})",
-                target.display(),
-                base.display()
+            ToolError::Execution(crate::tools::fs_policy::format_io_error(
+                "write", &target, &base, &e,
             ))
         })?;
         Ok(format!(

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -49,6 +49,7 @@ pub mod pattern;
 pub mod permissions;
 pub mod pipeline;
 pub mod project;
+pub mod removable_volume;
 pub mod route;
 pub mod schedule;
 pub mod schedule_claim;
@@ -67,6 +68,7 @@ pub use actor::{Actor, ActorSource};
 pub use conversation::{CONVERSATION_SCHEMA_VERSION, Content, Message, Role, Source};
 pub use hooks_config::HooksConfig;
 pub use pattern::Pattern;
+pub use removable_volume::REMOVABLE_VOLUME_EPERM_HINT;
 pub use scope::Scope;
 pub use signal::{
     SIGNAL_SCHEMA_VERSION, Signal, SignalBatch, SignalBatchResponse, SignalKind, SignalTarget,

--- a/mur-common/src/removable_volume.rs
+++ b/mur-common/src/removable_volume.rs
@@ -1,0 +1,15 @@
+//! Shared, logic-free constants for the macOS removable-volume (external
+//! disk) Full-Disk-Access failure mode (issue #1).
+//!
+//! This module deliberately holds **only** the canonical guidance string —
+//! no logic — so it can live in `mur-common` and be shared verbatim by both
+//! the agent runtime's file/bash tools and `mur agent doctor`. The judgement
+//! helpers (e.g. `is_removable_volume_eperm`) stay in the runtime's
+//! `fs_policy`; only the wording is centralized here so it never drifts.
+
+/// The one canonical, structured guidance shown whenever a `/Volumes/*`
+/// (removable / external volume) path is blocked by macOS with EPERM
+/// (`os error 1`, "Operation not permitted"). Shared by the file/bash tools
+/// and `mur agent doctor` so the wording never drifts (issue #1). Kept as a
+/// single `const` — do NOT duplicate this string anywhere.
+pub const REMOVABLE_VOLUME_EPERM_HINT: &str = "macOS 檔案權限擋住了外接磁碟。請到 系統設定→隱私權與安全性→完全取用磁碟 開啟 MUR Hub(或啟動此 agent 的 app),然後重啟 agent";

--- a/mur-core/src/cmd/agent/doctor.rs
+++ b/mur-core/src/cmd/agent/doctor.rs
@@ -31,6 +31,31 @@ pub fn build_row(name: &str, lock: &LockFile, disk_sha: &str) -> AgentRow {
     }
 }
 
+/// Probe `/Volumes` for the macOS Full-Disk-Access EPERM (`os error 1`) that
+/// blocks access to removable/external volumes, and return the shared guidance
+/// string when — and only when — that exact failure is observed (issue #1).
+///
+/// Returns `None` when `/Volumes` is readable, absent, or fails for any other
+/// reason (we must not hijack unrelated errors). Split out as a pure-ish
+/// function taking the probe closure so it is cheap to unit-test without
+/// touching the real filesystem.
+pub fn removable_volume_hint<F>(probe: F) -> Option<&'static str>
+where
+    F: Fn(&std::path::Path) -> std::io::Result<()>,
+{
+    let volumes = std::path::Path::new("/Volumes");
+    match probe(volumes) {
+        Err(e) if e.raw_os_error() == Some(1) => Some(mur_common::REMOVABLE_VOLUME_EPERM_HINT),
+        _ => None,
+    }
+}
+
+/// Real filesystem probe: attempt to enumerate `/Volumes`. A metadata/read
+/// attempt that trips macOS EPERM surfaces `os error 1`.
+fn probe_volumes(path: &std::path::Path) -> std::io::Result<()> {
+    std::fs::read_dir(path).map(|_| ())
+}
+
 /// `mur agent runtime-doctor [--json]`
 ///
 /// Enumerates all agents that have a `running.lock`, compares each one's
@@ -120,6 +145,14 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
         }
     }
 
+    // ── Removable-volume Full-Disk-Access preflight (issue #1) ──────────────
+    // Independent of the stale check: if `/Volumes` is blocked by macOS EPERM,
+    // emit the shared guidance. Printed to stderr so it never pollutes the
+    // `--json` stdout payload.
+    if let Some(hint) = removable_volume_hint(probe_volumes) {
+        eprintln!("\n{hint}");
+    }
+
     if any_stale {
         std::process::exit(1);
     }
@@ -183,5 +216,30 @@ mod tests {
         let lock = make_lock("unknown");
         let row = build_row("myagent", &lock, "unknown");
         assert!(!row.stale);
+    }
+
+    #[test]
+    fn removable_hint_shown_on_eperm() {
+        // Probe reports EPERM (os error 1) against /Volumes → guidance shown,
+        // and it is the exact shared mur-common string (no drift).
+        let hint = removable_volume_hint(|_p| Err(std::io::Error::from_raw_os_error(1)));
+        assert_eq!(hint, Some(mur_common::REMOVABLE_VOLUME_EPERM_HINT));
+    }
+
+    #[test]
+    fn removable_hint_absent_when_readable() {
+        // /Volumes readable → no guidance.
+        let hint = removable_volume_hint(|_p| Ok(()));
+        assert!(hint.is_none());
+    }
+
+    #[test]
+    fn removable_hint_ignores_non_eperm_errors() {
+        // ENOENT (no /Volumes at all) or any non-EPERM error must NOT trigger
+        // the removable-volume guidance.
+        let enoent = removable_volume_hint(|_p| Err(std::io::Error::from_raw_os_error(2)));
+        assert!(enoent.is_none());
+        let eacces = removable_volume_hint(|_p| Err(std::io::Error::from_raw_os_error(13)));
+        assert!(eacces.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Operator-reported UX gap: when the agent's tools hit `/Volumes/*` EPERM (macOS TCC gate on external drives), the error said only "Operation not permitted" — ordinary users can't know the runtime is a MUR Hub child process and that the fix is granting **MUR Hub** Full Disk Access, then restarting the agent.
- File/bash tool errors on removable-volume EPERM now append that structured guidance (shared const in `mur-common`; detection helper in the runtime's `fs_policy`), and `mur agent doctor` gains a probe emitting the same guidance.

## Test plan
- `cargo check` clean across the three crates
- New tests green: `fs_policy` detection (6) + doctor probe (26 in module) — EACCES / non-/Volumes paths don't trigger; hint contains the settings path; base error preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)