### PR TITLE
fix(agent-cli): approval-gate UX — visible auto state, [A] all, retry for late approvals

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -368,6 +368,14 @@ pub struct App {
     pub last_ctrl_c_at: Option<std::time::Instant>,
     pub ctrl_c_hint: bool,
     pub last_sent: Option<String>,
+    /// #8 / proposal 3a: the user request whose tool approval auto-denied at
+    /// timeout. A pre-execution timeout deny has NO side effects (the tool
+    /// never ran), so replaying is safe. Holds the `last_sent` snapshot so the
+    /// modal's `[r]` can one-shot re-run the request that hit the wall, instead
+    /// of the old "arrived too late — re-run the request" dead end. `None`
+    /// unless an expired-at-timeout deny is pending a retry; cleared once
+    /// consumed by `[r]` or superseded by the next sent turn.
+    pub expired_retry: Option<String>,
     /// `(mime, base64)` of an image staged for the next message — either a
     /// clipboard screenshot (Ctrl+V) or an image file the terminal pasted as a
     /// path (Cmd+V / drag-drop). Sent as an inline image part, cleared on send.
@@ -480,6 +488,7 @@ impl App {
             last_ctrl_c_at: None,
             ctrl_c_hint: false,
             last_sent: None,
+            expired_retry: None,
             pending_image: None,
             blink: Blink::new(),
             // Resolve color/animation once: env + TTY don't change mid-session.

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -788,10 +788,20 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
                     KeyCode::Char('d') if ctrl => request_quit(app, tx),
                     KeyCode::Char('c') if ctrl => decide_hitl(app, tx, false),
                     KeyCode::Char('y') | KeyCode::Char('Y') => decide_hitl(app, tx, true),
-                    KeyCode::Char('a') | KeyCode::Char('A') => {
+                    // [a] — always allow THIS tool name for the session
+                    // (per-tool-name grain; each distinct tool still asks once).
+                    KeyCode::Char('a') => {
                         if let Some(req) = &app.hitl {
                             app.session_tool_allow.insert(req.tool_name.clone());
                         }
+                        decide_hitl(app, tx, true);
+                    }
+                    // [A] — always allow ALL tools for the session (#7 grain
+                    // fix / proposal 1a): flip the global `auto_approve` so the
+                    // user need not press [a] once per distinct tool name. Same
+                    // session lifetime as `[a]`; cleared by `/auto off`.
+                    KeyCode::Char('A') => {
+                        app.auto_approve = true;
                         decide_hitl(app, tx, true);
                     }
                     KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
@@ -926,6 +936,17 @@ async fn handle_event(app: &mut App, ev: Event, tx: &mpsc::Sender<StreamMsg>) {
                 }
                 KeyCode::Char('o') if ctrl => {
                     scrollback_dump(app);
+                }
+                // Ctrl+R — re-run the request whose approval expired (#8):
+                // refill the composer from the stashed `expired_retry` so the
+                // user can resend with one key. Only when something is stashed
+                // and the composer is empty, so it never clobbers a draft.
+                KeyCode::Char('r') if ctrl => {
+                    if app.input_text().is_empty()
+                        && let Some(text) = app.expired_retry.take()
+                    {
+                        app.set_input(&text);
+                    }
                 }
                 KeyCode::PageUp => {
                     app.scroll_back = app.scroll_back.saturating_add(app.scroll_page.max(1))
@@ -1237,6 +1258,9 @@ fn decide_hitl_with_note(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: boo
         let (h, a) = (app.home.clone(), app.agent.clone());
         let (id, tool) = (req.hitl_id.clone(), req.tool_name.clone());
         let task_id = app.current_task_id.clone();
+        // Capture the user's last message before the spawn so an expired
+        // approval (#8) can offer a one-key re-run of the stranded request.
+        let retry = app.last_sent.clone();
         let t = tx.clone();
         tokio::spawn(async move {
             if let Err(e) = respond_hitl(h, a, id, allow).await {
@@ -1246,10 +1270,10 @@ fn decide_hitl_with_note(app: &mut App, tx: &mpsc::Sender<StreamMsg>, allow: boo
                     // (older runtimes) on this method both mean the same
                     // thing: the gate timed out and auto-denied before the
                     // decision landed. The turn itself is still alive.
-                    recover::HitlFailure::Expired => StreamMsg::Note(format!(
-                        "approval for `{tool}` arrived too late — the call was already \
-                         auto-denied at timeout; re-run the request"
-                    )),
+                    recover::HitlFailure::Expired => StreamMsg::Expired {
+                        tool: tool.clone(),
+                        retry: retry.clone(),
+                    },
                     // The runtime is gone: the whole in-memory task died with
                     // it, so the stale binding must be dropped too or every
                     // subsequent input steers a dead task (#713).
@@ -1368,6 +1392,8 @@ async fn submit(app: &mut App, tx: &mpsc::Sender<StreamMsg>) {
     }
 
     app.last_sent = Some(trimmed.clone());
+    // A fresh send supersedes any expired-approval retry offer (#8).
+    app.expired_retry = None;
     app.clear_input();
     start_turn(app, trimmed, tx);
 }
@@ -1693,6 +1719,22 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
             }
         }
         StreamMsg::Note(text) => app.push_system(text),
+        StreamMsg::Expired { tool, retry } => {
+            // The gate auto-denied `tool` at timeout before this approval
+            // landed (#8). Stash the user's last message so [Ctrl+R] can
+            // refill the composer for a one-key re-run, and hint that path
+            // instead of the old dead-end "re-run the request" note.
+            app.expired_retry = retry;
+            let hint = if app.expired_retry.is_some() {
+                " — press Ctrl+R to re-run the request"
+            } else {
+                " — re-run the request"
+            };
+            app.push_system(format!(
+                "approval for `{tool}` arrived too late — the call was already \
+                 auto-denied at timeout{hint}"
+            ));
+        }
         StreamMsg::TurnLost { note, resend, .. } => {
             app.drop_dead_turn();
             app.push_system(note);

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -50,6 +50,11 @@ pub enum StreamMsg {
         note: String,
         resend: Option<String>,
     },
+    /// An approval decision arrived after the gate had already auto-denied at
+    /// timeout (#8). Turn-independent like `Note`. `retry` carries the user's
+    /// last message so the composer can offer a one-key re-run of the request
+    /// that stranded the expired call.
+    Expired { tool: String, retry: Option<String> },
     /// A local `!command` finished. Turn-independent like `Note`.
     ShellDone { cmd: String, output: String },
     /// A tool call started running (name + args).
@@ -83,7 +88,7 @@ impl StreamMsg {
             | StreamMsg::TurnLost { task_id, .. }
             | StreamMsg::StepStarted { task_id, .. }
             | StreamMsg::StepCompleted { task_id, .. } => Some(task_id),
-            StreamMsg::Note(_) | StreamMsg::ShellDone { .. } => None,
+            StreamMsg::Note(_) | StreamMsg::Expired { .. } | StreamMsg::ShellDone { .. } => None,
         }
     }
 }

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -667,7 +667,7 @@ fn render_status(f: &mut Frame, app: &App, area: Rect) {
             .saturating_sub(req.created_at.elapsed().as_secs());
         (
             format!(
-                "tool approval needed (auto-deny in {remaining}s) — [y] approve · [a] always (session) · [n] deny"
+                "tool approval needed (auto-deny in {remaining}s) — [y] approve · [a] always (session) · [A] all (session) · [n] deny"
             ),
             Color::Yellow,
         )
@@ -692,12 +692,38 @@ fn render_status(f: &mut Frame, app: &App, area: Rect) {
         ),
         Span::raw("  "),
     ];
+    // Auto-approval visibility (#8 / proposal 2). All three auto-approval
+    // paths now show a badge, not just the global `auto_approve`:
+    //   - `auto_approve`               → ` AUTO `   (every tool, session)
+    //   - `session_tool_allow` (N>0)   → ` AUTO:N ` (N tools muted via [a])
+    //   - `auto_reads`                 → ` READS `  (read_file auto-approved)
+    // Pure display; no behaviour change. Fixes the "AUTO badge vanished in a
+    // new session" illusion where `[a]`-muted tools left no visible trace.
     if app.auto_approve {
         spans.push(Span::styled(
             " AUTO ",
             Style::default()
                 .fg(Color::Black)
                 .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw("  "));
+    } else if !app.session_tool_allow.is_empty() {
+        spans.push(Span::styled(
+            format!(" AUTO:{} ", app.session_tool_allow.len()),
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw("  "));
+    }
+    if app.auto_reads {
+        spans.push(Span::styled(
+            " READS ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::raw("  "));


### PR DESCRIPTION
## Summary
Live-use follow-ups to #733's pre-execution ask gate (root-cause analysis in ~/.mur/artifacts/mur-approval-gate-ux/analysis/root-cause.md):
- Status bar now reflects all three auto-approve states: `AUTO` (global), `AUTO:N` (per-tool [a] grants), `READS` — previously only global lit a badge, making [a] grants look broken.
- `[a]` stays per-tool-name; new `[A]` = enable global session auto-approve in one keypress.
- A `[y]` arriving after the 300s auto-deny no longer dead-ends: the expired call is kept as a one-shot `[r]` retry (safe — timeout deny is pre-execution, the tool never ran).
- Deferred by design: cross-restart persistence (1b) and runtime grace-replay (3b) await a security-scope decision.

## Test plan
- `cargo check -p mur-core` clean; `cargo test -p mur-core --lib cli`: 190 passed
- Live verification of the badge/[A]/[r] flows needs a rebuilt murmur binary (next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)