### PR TITLE
feat(hub): add Convert button to migrate legacy skill refs

### DIFF
--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -752,6 +752,11 @@ pub enum AgentSkillAction {
     /// `skill_id` may be the full id (`skills/foo`), the basename (`foo`),
     /// or the basename without extension.
     Remove { name: String, skill_id: String },
+    /// Migrate a legacy path-style skill ref (`profile.skills`) into a
+    /// structured `installed_skills` card, in place. The backing `skill.yaml`
+    /// already lives in the loadable layout, so nothing moves on disk — only
+    /// the profile pointer. `skill_id` may be the full id or the basename.
+    Convert { name: String, skill_id: String },
     /// Print the canonical contents of an installed skill.
     /// `skill_id` may be the full id (`skills/foo`), the basename (`foo`),
     /// or the basename without extension.

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -109,7 +109,8 @@ pub use secret::{cmd_secret_delete, cmd_secret_list, cmd_secret_set};
 pub use service::cmd_install_service;
 #[allow(unused_imports)]
 pub use skill::{
-    cmd_skill_add, cmd_skill_list, cmd_skill_remove, cmd_skill_set_enabled, cmd_skill_show,
+    cmd_skill_add, cmd_skill_convert, cmd_skill_list, cmd_skill_remove, cmd_skill_set_enabled,
+    cmd_skill_show,
 };
 #[allow(unused_imports)]
 pub use snapshot::{cmd_snapshot_pull, cmd_snapshot_show};

--- a/mur-core/src/cmd/agent/skill.rs
+++ b/mur-core/src/cmd/agent/skill.rs
@@ -145,6 +145,70 @@ pub fn cmd_skill_add(name: &str, source: &str) -> Result<()> {
     save_profile(&path, &mut profile)
 }
 
+/// Convert a legacy path-style skill ref (`profile.skills`) into a structured
+/// `installed_skills` card in place. The on-disk `skills/<name>/skill.yaml` is
+/// already the loadable source of truth — installed skills read from the same
+/// layout — so nothing moves on disk; only the profile pointer migrates.
+pub fn cmd_skill_convert(name: &str, query: &str) -> Result<()> {
+    let (path, mut profile) = load_profile_for_edit(name)?;
+    let resolved = resolve_skill_id(&profile, query)
+        .ok_or_else(|| anyhow!("legacy skill '{query}' not found on '{name}'"))?
+        .clone();
+    let agent_home = path.parent().unwrap_or(Path::new(""));
+    convert_ref_in_profile(agent_home, &mut profile, &resolved)?;
+    save_profile(&path, &mut profile)
+}
+
+/// Pure core of the legacy→installed migration: read the backing manifest and
+/// move the ref from `profile.skills` into `profile.installed_skills`.
+fn convert_ref_in_profile(
+    agent_home: &Path,
+    profile: &mut _AgentProfile,
+    resolved: &str,
+) -> Result<()> {
+    use mur_common::agent::{SkillCardEntry, SkillCardTrigger};
+
+    let backing = agent_home.join(resolved);
+    if !backing.is_dir() {
+        bail!("'{resolved}' is not a loadable skill dir — cannot convert (remove + re-install instead)");
+    }
+    let m = mur_common::skill::read_from_dir(&backing)
+        .map_err(|e| anyhow!("read skill {}: {e}", backing.display()))?;
+
+    let entry = SkillCardEntry {
+        name: m.name.clone(),
+        version: m.version.clone(),
+        publisher: m.publisher.clone(),
+        category: serde_yaml_ng::to_string(&m.category)
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+        description: m.description.clone(),
+        tags: m.tags.clone(),
+        triggers: m
+            .triggers
+            .iter()
+            .map(|t| SkillCardTrigger {
+                kind: serde_yaml_ng::to_string(&t.kind)
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string(),
+                pattern: t.pattern.clone().unwrap_or_default(),
+            })
+            .collect(),
+        abstract_text: m.content.r#abstract.clone(),
+        transfer_chain: m.transfer_chain.clone(),
+    };
+
+    if let Some(slot) = profile.installed_skills.iter_mut().find(|e| e.name == m.name) {
+        *slot = entry;
+    } else {
+        profile.installed_skills.push(entry);
+    }
+    profile.skills.retain(|s| s != resolved);
+    Ok(())
+}
+
 pub fn cmd_skill_remove(name: &str, query: &str) -> Result<()> {
     let (path, mut profile) = load_profile_for_edit(name)?;
     let resolved = resolve_skill_id(&profile, query)
@@ -313,5 +377,38 @@ content:
         // An unrelated edit must still save — only *newly added* refs gate.
         profile.display_name = "Renamed".into();
         save_profile(&path, &mut profile).unwrap();
+    }
+
+    #[test]
+    fn convert_moves_ref_from_legacy_to_installed() {
+        let home = tempfile::tempdir().unwrap();
+        mur_common::skill::write_to_dir(
+            &home.path().join("skills").join("ok"),
+            &valid_manifest("ok"),
+        )
+        .unwrap();
+
+        let mut profile = mur_common::AgentProfile::default_for_tests();
+        profile.skills = vec!["skills/ok".into()];
+        assert!(profile.installed_skills.is_empty());
+
+        convert_ref_in_profile(home.path(), &mut profile, "skills/ok").unwrap();
+
+        assert!(profile.skills.is_empty(), "legacy ref should be removed");
+        assert_eq!(profile.installed_skills.len(), 1);
+        assert_eq!(profile.installed_skills[0].name, "ok");
+
+        // Idempotent: converting again upserts, never duplicates.
+        profile.skills = vec!["skills/ok".into()];
+        convert_ref_in_profile(home.path(), &mut profile, "skills/ok").unwrap();
+        assert_eq!(profile.installed_skills.len(), 1);
+    }
+
+    #[test]
+    fn convert_rejects_missing_backing_dir() {
+        let home = tempfile::tempdir().unwrap();
+        let mut profile = mur_common::AgentProfile::default_for_tests();
+        profile.skills = vec!["skills/ghost".into()];
+        assert!(convert_ref_in_profile(home.path(), &mut profile, "skills/ghost").is_err());
     }
 }

--- a/mur-core/src/cmd/agent/skill.rs
+++ b/mur-core/src/cmd/agent/skill.rs
@@ -170,7 +170,9 @@ fn convert_ref_in_profile(
 
     let backing = agent_home.join(resolved);
     if !backing.is_dir() {
-        bail!("'{resolved}' is not a loadable skill dir — cannot convert (remove + re-install instead)");
+        bail!(
+            "'{resolved}' is not a loadable skill dir — cannot convert (remove + re-install instead)"
+        );
     }
     let m = mur_common::skill::read_from_dir(&backing)
         .map_err(|e| anyhow!("read skill {}: {e}", backing.display()))?;
@@ -200,7 +202,11 @@ fn convert_ref_in_profile(
         transfer_chain: m.transfer_chain.clone(),
     };
 
-    if let Some(slot) = profile.installed_skills.iter_mut().find(|e| e.name == m.name) {
+    if let Some(slot) = profile
+        .installed_skills
+        .iter_mut()
+        .find(|e| e.name == m.name)
+    {
         *slot = entry;
     } else {
         profile.installed_skills.push(entry);

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1582,6 +1582,9 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             AgentSkillAction::Remove { name, skill_id } => {
                 cmd::agent::cmd_skill_remove(&name, &skill_id)?
             }
+            AgentSkillAction::Convert { name, skill_id } => {
+                cmd::agent::cmd_skill_convert(&name, &skill_id)?
+            }
             AgentSkillAction::Show { name, skill_id } => {
                 cmd::agent::cmd_skill_show(&name, &skill_id)?
             }

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -679,6 +679,7 @@ pub fn run() {
             model_download::download_local_model,
             mcp_skills::agent_skill_install,
             mcp_skills::agent_skill_uninstall,
+            mcp_skills::agent_skill_convert,
             mcp_skills::agent_mcp_add,
             mcp_skills::agent_mcp_remove,
             mcp_skills::agent_skill_toggle,

--- a/mur-hub-gui/src-tauri/src/mcp_skills.rs
+++ b/mur-hub-gui/src-tauri/src/mcp_skills.rs
@@ -6,7 +6,9 @@
 
 use crate::detail::{AgentDetail, get_agent_detail};
 use mur_core::cmd::agent::mcp::{McpAddPin, cmd_mcp_add, cmd_mcp_remove, cmd_mcp_set_enabled};
-use mur_core::cmd::agent::skill::{cmd_skill_add, cmd_skill_remove, cmd_skill_set_enabled};
+use mur_core::cmd::agent::skill::{
+    cmd_skill_add, cmd_skill_convert, cmd_skill_remove, cmd_skill_set_enabled,
+};
 use mur_core::cmd::agent::skill_remote::{SkillPreview, install_any_url, preview_any_url};
 use serde::Serialize;
 
@@ -43,6 +45,15 @@ pub fn agent_skill_install(
 #[tauri::command]
 pub fn agent_skill_uninstall(name: String, skill_id: String) -> Result<AgentDetail, String> {
     cmd_skill_remove(&name, &skill_id).map_err(|e| format!("{e:#}"))?;
+    get_agent_detail(name)
+}
+
+/// Migrate a legacy path-style skill ref into a structured `installed_skills`
+/// card, in place. The backing `skill.yaml` already lives in the loadable
+/// layout, so nothing moves on disk — only the profile pointer.
+#[tauri::command]
+pub fn agent_skill_convert(name: String, skill_id: String) -> Result<AgentDetail, String> {
+    cmd_skill_convert(&name, &skill_id).map_err(|e| format!("{e:#}"))?;
     get_agent_detail(name)
 }
 

--- a/mur-hub-gui/ui/src/components/inspector/tabs/SkillsTab.tsx
+++ b/mur-hub-gui/ui/src/components/inspector/tabs/SkillsTab.tsx
@@ -76,6 +76,22 @@ export function SkillsTab({
     }
   }
 
+  async function convertSkill(id: string) {
+    setError(null);
+    setBusy(true);
+    try {
+      const updated = await invoke<AgentDetail>("agent_skill_convert", {
+        name: detail.agent_name,
+        skillId: id,
+      });
+      onSaved(updated);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   async function toggleSkill(id: string, enabled: boolean) {
     setError(null);
     setBusy(true);
@@ -232,6 +248,17 @@ export function SkillsTab({
                         ? t("detail.skillMissing")
                         : t("detail.skillDead")}
                   </span>
+                  {s.loadable && (
+                    <button
+                      className="btn btn--sm btn--secondary"
+                      title={t("detail.convertSkillHint")}
+                      disabled={busy}
+                      onClick={() => convertSkill(s.path)}
+                      style={{ marginLeft: 6 }}
+                    >
+                      {t("detail.convertSkill")}
+                    </button>
+                  )}
                 </div>
                 {!s.loadable && (
                   <div className="item-card-desc field-muted" style={{ fontSize: 11 }}>

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -255,6 +255,8 @@ export const en = {
   "detail.livelyDesc": "Proactive suggestions, pet animations, chatty.",
   "detail.installedSkills": "Installed Skills ({count})",
   "detail.legacySkillPaths": "Legacy Skill Paths ({count})",
+  "detail.convertSkill": "Convert",
+  "detail.convertSkillHint": "Migrate this into Installed Skills — moves the profile pointer; the skill.yaml stays put.",
   "detail.skillInstallHint": "Use mur skill install to add skills to this agent.",
   "detail.mcpAddHint": "Use mur agent mcp add to connect tools to this agent.",
   "detail.mcpServersCount": "MCP Servers ({count})",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -257,6 +257,8 @@ export const zhTW: Table = {
   "detail.livelyDesc": "主動提供建議、寵物動畫、健談。",
   "detail.installedSkills": "已安裝技能（{count}）",
   "detail.legacySkillPaths": "舊版技能路徑（{count}）",
+  "detail.convertSkill": "轉換",
+  "detail.convertSkillHint": "轉為「已安裝技能」——只搬移設定檔指標,skill.yaml 原地不動。",
   "detail.skillInstallHint": "使用 mur skill install 為此 agent 新增技能。",
   "detail.mcpAddHint": "使用 mur agent mcp add 為此 agent 連接工具。",
   "detail.mcpServersCount": "MCP 伺服器（{count}）",


### PR DESCRIPTION
## What

Adds a **Convert** button to each *loadable* row under "Legacy Skill Paths" in the Hub agent inspector (Skills tab).

## Why

Legacy skill paths (`profile.skills`) and installed skills (`profile.installed_skills`) are two separate profile fields; the Hub renders the former as "Legacy Skill Paths". They're fed by two different commands and neither removes the other's entry, so bundled agent skills (e.g. the concierge's 7) stay flagged legacy forever even though their `skill.yaml` is already canonical and loadable.

Convert migrates the ref between fields **in place** — the backing `skill.yaml` already lives in the loadable layout, so nothing moves on disk, only the profile pointer.

## Changes

- **mur-core**: pure `convert_ref_in_profile` (read manifest → upsert `SkillCardEntry` into `installed_skills` → drop the `skills/` ref) + `cmd_skill_convert`; CLI parity `mur agent skill convert <agent> <id>`
- **mur-hub-gui**: `agent_skill_convert` Tauri command + Convert button on loadable legacy rows (en + zh-TW)

Button is hidden on `unloadable`/`missing` rows (nothing valid to migrate; remove + reinstall is the path there).

## Test

`cargo test -p mur-core convert_` → 2 passed (move-in-place + reject-missing-dir, idempotent upsert covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)