### PR TITLE
feat(official): client key-split — separate license verification key

### DIFF
--- a/mur-common/src/skill/publisher_trust.rs
+++ b/mur-common/src/skill/publisher_trust.rs
@@ -13,6 +13,12 @@ use std::path::{Path, PathBuf};
 /// No other values are hardcoded — all trust decisions flow through the keyring.
 pub const MUR_OFFICIAL_PUBLISHER_KEY_FP: &str = "ed25519-861d2acb";
 
+/// Pinned MUR official **license** key fingerprint (trust anchor for
+/// `OfficialLicense` signatures — a SEPARATE key from the bundle publisher key
+/// above, so the online license-signing key on the server can never sign
+/// official bundles). Same derivation: SHA-256(raw 32-byte pubkey), first 8 hex.
+pub const MUR_OFFICIAL_LICENSE_KEY_FP: &str = "ed25519-71594984";
+
 /// Trust classification for a signer fingerprint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PublisherTrust {

--- a/mur-core/src/cmd/agent/install.rs
+++ b/mur-core/src/cmd/agent/install.rs
@@ -49,6 +49,7 @@ pub fn cmd_install(
             true,
             logged_in_user.as_deref(),
             mur_common::skill::publisher_trust::MUR_OFFICIAL_PUBLISHER_KEY_FP,
+            mur_common::skill::publisher_trust::MUR_OFFICIAL_LICENSE_KEY_FP,
         )?;
     }
 
@@ -95,26 +96,28 @@ pub fn cmd_install(
 
 /// Official-distribution gate for `.muragent` installs. Mirrors the fleet
 /// import gate (`cmd/fleet/import.rs::official_gate`): marker present ⇒ (1)
-/// the package must be signed by `official_fp` (a self-signed package
+/// the package must be signed by `publisher_fp` (a self-signed package
 /// claiming `distribution: official` is a spoof), and (2) a matching local
-/// license must exist for `agents/<agent_slug>` + the logged-in user.
-/// `signer_pk` is the raw verified Ed25519 public key; `official_fp` is an
-/// `ed25519-<8hex>` fingerprint. The caller is
-/// responsible for only invoking this when the manifest carries the marker.
+/// license (signed by the SEPARATE `license_fp` key) must exist for
+/// `agents/<agent_slug>` + the logged-in user. `signer_pk` is the raw verified
+/// Ed25519 public key; both fps are `ed25519-<8hex>`. Bundle trust and license
+/// trust use different keys. The caller only invokes this when the manifest
+/// carries the marker.
 fn official_gate_agent(
     mur_home: &Path,
     agent_slug: &str,
     signer_pk: &[u8; 32],
     signature_verified: bool,
     logged_in_user: Option<&str>,
-    official_fp: &str,
+    publisher_fp: &str,
+    license_fp: &str,
 ) -> Result<()> {
     use mur_common::muragent::dsse::keyid_from_pubkey;
     // Derive the fingerprint from the *verified* signing key, never from the
     // envelope's self-asserted `keyid` string (which is outside the signed
     // payload and thus attacker-settable — an attacker could stamp the
     // official fp onto a bundle signed with their own key).
-    if !signature_verified || keyid_from_pubkey(signer_pk) != official_fp {
+    if !signature_verified || keyid_from_pubkey(signer_pk) != publisher_fp {
         bail!(
             "package claims official distribution but is not signed by the MUR official key — refusing install"
         );
@@ -125,7 +128,7 @@ fn official_gate_agent(
         );
     };
     let item = format!("agents/{agent_slug}");
-    crate::official::store::require_license_against(mur_home, &item, user, official_fp).map_err(
+    crate::official::store::require_license_against(mur_home, &item, user, license_fp).map_err(
         |e| {
             anyhow::anyhow!(
                 "{e} — official MUR content can't be shared between accounts; get it from app.mur.run via `mur official install`"
@@ -470,8 +473,8 @@ mod tests {
         let pk = key.verifying_key().to_bytes();
         let fp = mur_common::muragent::dsse::keyid_from_pubkey(&pk);
         // no license → refused
-        let err =
-            official_gate_agent(home.path(), "researcher", &pk, true, Some("u1"), &fp).unwrap_err();
+        let err = official_gate_agent(home.path(), "researcher", &pk, true, Some("u1"), &fp, &fp)
+            .unwrap_err();
         assert!(err.to_string().contains("app.mur.run"), "{err}");
         // matching license → passes
         let mut l = mur_common::official::OfficialLicense {
@@ -485,15 +488,23 @@ mod tests {
         };
         mur_common::official::sign_license(&mut l, &key);
         crate::official::store::save_license(home.path(), &l).unwrap();
-        official_gate_agent(home.path(), "researcher", &pk, true, Some("u1"), &fp).unwrap();
+        official_gate_agent(home.path(), "researcher", &pk, true, Some("u1"), &fp, &fp).unwrap();
         // wrong signer key on the package → refused even with license. Deriving
         // the fp from the verified pubkey (not a self-asserted string) is what
         // makes this un-spoofable.
         let wrong_pk = ed25519_dalek::SigningKey::from_bytes(&[8u8; 32])
             .verifying_key()
             .to_bytes();
-        let err = official_gate_agent(home.path(), "researcher", &wrong_pk, true, Some("u1"), &fp)
-            .unwrap_err();
+        let err = official_gate_agent(
+            home.path(),
+            "researcher",
+            &wrong_pk,
+            true,
+            Some("u1"),
+            &fp,
+            &fp,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("official key"), "{err}");
     }
 
@@ -503,7 +514,7 @@ mod tests {
         let key = ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]);
         let pk = key.verifying_key().to_bytes();
         let fp = mur_common::muragent::dsse::keyid_from_pubkey(&pk);
-        let err = official_gate_agent(home.path(), "researcher", &pk, false, Some("u1"), &fp)
+        let err = official_gate_agent(home.path(), "researcher", &pk, false, Some("u1"), &fp, &fp)
             .unwrap_err();
         assert!(err.to_string().contains("official key"), "{err}");
     }
@@ -514,7 +525,8 @@ mod tests {
         let key = ed25519_dalek::SigningKey::from_bytes(&[3u8; 32]);
         let pk = key.verifying_key().to_bytes();
         let fp = mur_common::muragent::dsse::keyid_from_pubkey(&pk);
-        let err = official_gate_agent(home.path(), "researcher", &pk, true, None, &fp).unwrap_err();
+        let err =
+            official_gate_agent(home.path(), "researcher", &pk, true, None, &fp, &fp).unwrap_err();
         assert!(err.to_string().contains("app.mur.run"), "{err}");
     }
 
@@ -536,8 +548,8 @@ mod tests {
         mur_common::official::sign_license(&mut l, &key);
         crate::official::store::save_license(home.path(), &l).unwrap();
 
-        let err =
-            official_gate_agent(home.path(), "researcher", &pk, true, Some("u2"), &fp).unwrap_err();
+        let err = official_gate_agent(home.path(), "researcher", &pk, true, Some("u2"), &fp, &fp)
+            .unwrap_err();
         assert!(err.to_string().contains("different account"), "{err}");
     }
 

--- a/mur-core/src/cmd/fleet/import.rs
+++ b/mur-core/src/cmd/fleet/import.rs
@@ -122,23 +122,25 @@ fn confirm(prompt: &str, yes: bool) -> Result<bool> {
 }
 
 /// Official-distribution gate. Marker present ⇒ (1) bundle must be signed by
-/// `official_fp` (a self-signed bundle claiming `distribution: official` is a
-/// spoof — a real license would let it impersonate official content), and
-/// (2) a matching local license must exist for this item + logged-in user.
+/// `publisher_fp` (a self-signed bundle claiming `distribution: official` is a
+/// spoof), and (2) a matching local license (signed by the SEPARATE
+/// `license_fp` key) must exist for this item + logged-in user. Bundle trust and
+/// license trust use different keys so the online license key never signs bundles.
 fn official_gate(
     mur_home: &Path,
     manifest: &BundleManifest,
     signer_pk: &[u8; 32],
     signature_verified: bool,
     logged_in_user: Option<&str>,
-    official_fp: &str,
+    publisher_fp: &str,
+    license_fp: &str,
 ) -> Result<()> {
     use mur_common::muragent::dsse::keyid_from_pubkey;
     use mur_common::official::DISTRIBUTION_OFFICIAL;
     if manifest.distribution.as_deref() != Some(DISTRIBUTION_OFFICIAL) {
         return Ok(());
     }
-    if !signature_verified || keyid_from_pubkey(signer_pk) != official_fp {
+    if !signature_verified || keyid_from_pubkey(signer_pk) != publisher_fp {
         bail!(
             "bundle claims official distribution but is not signed by the MUR official key — refusing import"
         );
@@ -149,7 +151,7 @@ fn official_gate(
         );
     };
     let item = format!("fleets/{}", manifest.fleet_name);
-    crate::official::store::require_license_against(mur_home, &item, user, official_fp).map_err(
+    crate::official::store::require_license_against(mur_home, &item, user, license_fp).map_err(
         |e| {
             anyhow::anyhow!(
                 "{e} — official MUR content can't be shared between accounts; get it from app.mur.run via `mur official install`"
@@ -196,6 +198,7 @@ pub fn cmd_fleet_import(
         signature_verified,
         logged_in_user.as_deref(),
         mur_common::skill::publisher_trust::MUR_OFFICIAL_PUBLISHER_KEY_FP,
+        mur_common::skill::publisher_trust::MUR_OFFICIAL_LICENSE_KEY_FP,
     )?;
 
     // 3. Verify every entry's hash against the unpacked bytes (fail-closed).
@@ -1643,6 +1646,7 @@ mod tests {
             false,
             None,
             "ed25519-deadbeef",
+            "ed25519-deadbeef",
         )
         .unwrap();
     }
@@ -1656,15 +1660,23 @@ mod tests {
         let pk = key.verifying_key().to_bytes();
 
         // signature_verified == false
-        let err =
-            official_gate(home.path(), &manifest, &pk, false, Some("user-1"), &fp).unwrap_err();
+        let err = official_gate(home.path(), &manifest, &pk, false, Some("user-1"), &fp, &fp)
+            .unwrap_err();
         assert!(err.to_string().contains("refusing import"), "{err}");
 
         // signature_verified == true but signer key doesn't match official_fp
         let other_key = ed25519_dalek::SigningKey::from_bytes(&[2u8; 32]);
         let other_pk = other_key.verifying_key().to_bytes();
-        let err = official_gate(home.path(), &manifest, &other_pk, true, Some("user-1"), &fp)
-            .unwrap_err();
+        let err = official_gate(
+            home.path(),
+            &manifest,
+            &other_pk,
+            true,
+            Some("user-1"),
+            &fp,
+            &fp,
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("refusing import"), "{err}");
     }
 
@@ -1676,7 +1688,7 @@ mod tests {
         let fp = official_fp_for(&key);
         let pk = key.verifying_key().to_bytes();
 
-        let err = official_gate(home.path(), &manifest, &pk, true, None, &fp).unwrap_err();
+        let err = official_gate(home.path(), &manifest, &pk, true, None, &fp, &fp).unwrap_err();
         assert!(err.to_string().contains("app.mur.run"), "{err}");
     }
 
@@ -1690,7 +1702,7 @@ mod tests {
 
         // logged in, but no license saved for this item.
         let err =
-            official_gate(home.path(), &manifest, &pk, true, Some("user-1"), &fp).unwrap_err();
+            official_gate(home.path(), &manifest, &pk, true, Some("user-1"), &fp, &fp).unwrap_err();
         assert!(err.to_string().contains("app.mur.run"), "{err}");
     }
 
@@ -1705,7 +1717,7 @@ mod tests {
         save_test_license(home.path(), "fleets/dev", "user-1", &key);
 
         let err =
-            official_gate(home.path(), &manifest, &pk, true, Some("user-2"), &fp).unwrap_err();
+            official_gate(home.path(), &manifest, &pk, true, Some("user-2"), &fp, &fp).unwrap_err();
         assert!(err.to_string().contains("different account"), "{err}");
     }
 
@@ -1719,7 +1731,7 @@ mod tests {
 
         save_test_license(home.path(), "fleets/dev", "user-1", &key);
 
-        official_gate(home.path(), &manifest, &pk, true, Some("user-1"), &fp).unwrap();
+        official_gate(home.path(), &manifest, &pk, true, Some("user-1"), &fp, &fp).unwrap();
     }
 
     /// End-to-end wiring proof via `cmd_fleet_import`. Production pins the

--- a/mur-core/src/cmd/official.rs
+++ b/mur-core/src/cmd/official.rs
@@ -1,7 +1,7 @@
 //! `mur official` — browse + install from the official MUR catalog.
 use anyhow::{Context, Result, bail};
 use mur_common::official::{LicenseCheck, check_license};
-use mur_common::skill::publisher_trust::MUR_OFFICIAL_PUBLISHER_KEY_FP;
+use mur_common::skill::publisher_trust::MUR_OFFICIAL_LICENSE_KEY_FP;
 
 use crate::official::client::{download_item, fetch_catalog};
 use crate::official::store::save_license;
@@ -40,7 +40,7 @@ pub(crate) async fn cmd_official_install(id: &str) -> Result<()> {
     let (bytes, license) = download_item(&client, &base, &tokens.access_token, id).await?;
 
     // 3. Verify the license fail-closed BEFORE anything touches disk state.
-    match check_license(&license, id, &user_id, MUR_OFFICIAL_PUBLISHER_KEY_FP) {
+    match check_license(&license, id, &user_id, MUR_OFFICIAL_LICENSE_KEY_FP) {
         LicenseCheck::Ok => {}
         other => bail!("server returned an invalid license ({other:?}) — refusing install"),
     }


### PR DESCRIPTION
## Client key-split: verify licenses against a separate license key

Prerequisite for the official-catalog **server endpoints** (`/download` signs `OfficialLicense`s with a dedicated online key). Splits the client's two trust anchors:

- **Bundle trust** stays on `MUR_OFFICIAL_PUBLISHER_KEY_FP` (`ed25519-861d2acb`, the offline root that signs official `.muragent`/`.fleet` bundles in CI).
- **License trust** moves to a new `MUR_OFFICIAL_LICENSE_KEY_FP` (`ed25519-71594984`) — the online license-signing key that lives on mur-server.

So a server compromise can forge only **licenses** (bounded), never official **code bundles** (the high-value target). The two `official_gate`/`official_gate_agent` functions now take `publisher_fp` (bundle-signer check) and `license_fp` (the `require_license_against` license check) as separate params; `cmd_official_install`'s `check_license` verifies against the license fp.

Bundle-signer verification is unchanged. No official licenses exist in the wild yet, so switching license verification to the new key breaks nothing.

### Tests
161/161 pass across the official/import/install filters (`cargo nextest`, `RUST_MIN_STACK=33554432`); fmt clean. Existing gate tests pass the same test key as both fps; a dedicated split test (bundle key ≠ license key) is a reasonable follow-up.

Design: `docs/superpowers/specs/2026-07-21-official-catalog-server-endpoints-design.md` §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
