### PR TITLE
feat(skills): Pack S1 — de-shadow (remove vendored builtin shadows)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-mur-pack-s1-deshadow.md
+++ b/docs/superpowers/plans/2026-07-22-mur-pack-s1-deshadow.md
@@ -1,0 +1,485 @@
+# MUR Pack S1 — De-Shadow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give MUR a working way to remove agent-local vendored copies of builtin skills that shadow the global store, and an automatic safe cleanup — CLI-only.
+
+**Architecture:** Three cohesive changes. (1) Extract a `depin_skill(home, agent, skill)` core in `cmd/agent/skill.rs` that removes a skill from all three places it can live (`skills:` refs, `installed_skills:` cards, on-disk dir); `cmd_skill_remove` becomes a thin wrapper. (2) Fix the S2 `shadow-drift` finding's remediation string and set its `fixable` flag (identical shadows fixable, diverged not). (3) Add a `ShadowDepinRepair` to the existing `mur skill doctor --fix` repair framework that calls `depin_skill` for the identical shadows only.
+
+**Tech Stack:** Rust (edition 2024), `mur-common::AgentProfile`/`SkillCardEntry`, `mur-core` skill/doctor/skill_repair modules, `serde_yaml_ng`, `tempfile` for tests.
+
+## Global Constraints
+
+- Reuse existing helpers; no hardcoded values:
+  - Profile load/save: construct path `home/agents/<agent>/profile.yaml`, parse with `serde_yaml_ng::from_str::<_AgentProfile>`, save with the existing `save_profile(&path, &mut profile)` (its #717 guard only rejects *newly added* dangling refs — de-pin removes refs, so it never fires).
+  - `_AgentProfile` = `mur_common::AgentProfile`; fields used: `skills: Vec<String>`, `installed_skills: Vec<SkillCardEntry>`. `SkillCardEntry.name: String`.
+  - `resolve_skill_id(&profile, query) -> Option<&String>` (in `cmd/agent/skill.rs`) matches a query against `skills:` refs in three forms (full id / basename / stem). Reuse it for the ref-removal step.
+  - Repair framework (`mur-core/src/skill_repair/`): `trait Repair { fn check_id(&self)->&'static str; fn applicable(&self, &Finding)->bool; fn run(&self, &Finding, &RepairCtx, apply: bool)->RepairOutcome; }`; `RepairCtx { home: &Path, registry_url: &str }`; `RepairOutcome::{Fixed, DryRun(String), Skipped(String), Failed(String)}`. `run_repairs` only dispatches findings where `finding.fixable == true`.
+  - `Finding` has NO structured agent field. The repair recovers `(agent, skill)` by parsing the remediation string it controls (`mur agent skill remove <agent> <skill>`). This is an internal contract (generator and parser both in this codebase).
+  - `mur skill doctor --fix` is a dry-run; `mur skill doctor --fix --apply` actually applies (behind an interactive confirm). Destructive de-pin therefore only runs under `--apply`.
+- Brand name "MUR" uppercase in any user-facing string.
+- Run tests with: `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUSTFLAGS=-Cdebuginfo=0 CARGO_TARGET_DIR=/Volumes/Firecuda4tb/Projects/mur/target cargo test -p mur-core <name>` (add `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin` to PATH if `cargo` is missing). A cold compile takes several minutes.
+
+---
+
+### Task 1: `depin_skill` core + rewire `cmd_skill_remove`
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/skill.rs` (add `depin_skill`; rewrite `cmd_skill_remove` at ~line 218)
+- Test: `mur-core/src/cmd/agent/skill.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: `resolve_skill_id`, `save_profile`, `resolve_mur_home`, `_AgentProfile`, `SkillCardEntry` (all already imported in the file).
+- Produces: `pub(crate) fn depin_skill(home: &Path, agent: &str, skill: &str) -> Result<bool>` — removes the skill from `skills:` refs, `installed_skills:` cards, and the on-disk dir under `home`; returns `true` if it was present in any location. Task 3's repair calls this with `ctx.home`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)] mod tests` block in `mur-core/src/cmd/agent/skill.rs`:
+
+```rust
+fn write_profile(home: &std::path::Path, agent: &str, body: &str) -> std::path::PathBuf {
+    let dir = home.join("agents").join(agent);
+    std::fs::create_dir_all(dir.join("skills")).unwrap();
+    let path = dir.join("profile.yaml");
+    std::fs::write(&path, body).unwrap();
+    path
+}
+
+fn write_agent_skill_dir(home: &std::path::Path, agent: &str, name: &str) {
+    let d = home.join("agents").join(agent).join("skills").join(name);
+    std::fs::create_dir_all(&d).unwrap();
+    std::fs::write(
+        d.join("skill.yaml"),
+        format!("name: {name}\nversion: 1.0.0\npublisher: human:t\ndescription: d\ncategory: context\ncontent:\n  abstract: a\n  context: b\n"),
+    )
+    .unwrap();
+}
+
+// A minimal profile carrying `name` as an installed_skills card + on-disk dir,
+// but NOT as a skills: ref (the exact concierge shadow shape).
+const CARD_ONLY_PROFILE: &str = "\
+name: mur
+display_name: MUR
+model_ref: m
+skills:
+  - skills/concierge
+installed_skills:
+- name: mur-compress
+  version: 1.0.0
+  publisher: human:mur
+  description: d
+  category: context
+  abstract: a
+";
+
+#[test]
+fn depin_removes_card_and_dir_when_not_a_ref() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    write_profile(home, "mur", CARD_ONLY_PROFILE);
+    write_agent_skill_dir(home, "mur", "mur-compress");
+    write_agent_skill_dir(home, "mur", "concierge");
+
+    let removed = depin_skill(home, "mur", "mur-compress").unwrap();
+    assert!(removed, "should report removal");
+
+    // card gone
+    let yaml = std::fs::read_to_string(home.join("agents/mur/profile.yaml")).unwrap();
+    let p: _AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
+    assert!(p.installed_skills.iter().all(|c| c.name != "mur-compress"));
+    // dir gone
+    assert!(!home.join("agents/mur/skills/mur-compress").exists());
+    // untouched skill dir preserved
+    assert!(home.join("agents/mur/skills/concierge").exists());
+}
+
+#[test]
+fn depin_returns_false_when_absent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    write_profile(home, "mur", CARD_ONLY_PROFILE);
+    let removed = depin_skill(home, "mur", "does-not-exist").unwrap();
+    assert!(!removed);
+}
+
+#[test]
+fn depin_removes_ref_form_too() {
+    let tmp = tempfile::tempdir().unwrap();
+    let home = tmp.path();
+    // concierge is a skills: ref + on-disk dir
+    write_profile(home, "mur", CARD_ONLY_PROFILE);
+    write_agent_skill_dir(home, "mur", "concierge");
+    let removed = depin_skill(home, "mur", "concierge").unwrap();
+    assert!(removed);
+    let yaml = std::fs::read_to_string(home.join("agents/mur/profile.yaml")).unwrap();
+    let p: _AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
+    assert!(!p.skills.iter().any(|s| s == "skills/concierge"));
+    assert!(!home.join("agents/mur/skills/concierge").exists());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `… cargo test -p mur-core depin_`
+Expected: FAIL — `depin_skill` not defined (compile error).
+
+- [ ] **Step 3: Implement `depin_skill` and rewire `cmd_skill_remove`**
+
+In `mur-core/src/cmd/agent/skill.rs`, add `depin_skill` (near `cmd_skill_remove`) and replace the body of `cmd_skill_remove`:
+
+```rust
+/// Remove a skill from every place it can live on an agent: the `skills:`
+/// reference list, the `installed_skills:` card list, and the on-disk
+/// `skills/<name>/` dir under `home`. Returns whether it was present anywhere.
+/// Takes an explicit `home` so the doctor repair can operate on any store.
+pub(crate) fn depin_skill(home: &Path, agent: &str, skill: &str) -> Result<bool> {
+    let path = home.join("agents").join(agent).join("profile.yaml");
+    if !path.exists() {
+        bail!("agent '{agent}' not found");
+    }
+    let yaml = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let mut profile: _AgentProfile =
+        serde_yaml_ng::from_str(&yaml).with_context(|| format!("parse {}", path.display()))?;
+
+    // Bare skill name, accepting `skills/foo`, `foo.yaml`, or `foo`.
+    let base = Path::new(skill)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(skill)
+        .to_string();
+
+    let mut removed = false;
+
+    // 1. skills: ref (any resolvable form)
+    if let Some(resolved) = resolve_skill_id(&profile, skill).cloned() {
+        profile.skills.retain(|s| s != &resolved);
+        removed = true;
+    }
+    // 2. installed_skills: card by name
+    let before = profile.installed_skills.len();
+    profile.installed_skills.retain(|c| c.name != base);
+    if profile.installed_skills.len() != before {
+        removed = true;
+    }
+    if removed {
+        save_profile(&path, &mut profile)?;
+    }
+    // 3. on-disk vendored dir (only if no surviving ref still points at it)
+    let dir = home.join("agents").join(agent).join("skills").join(&base);
+    let still_referenced = profile
+        .skills
+        .iter()
+        .any(|s| Path::new(s).file_stem().and_then(|f| f.to_str()) == Some(base.as_str()));
+    if dir.is_dir() && !still_referenced {
+        let _ = fs::remove_dir_all(&dir);
+        removed = true;
+    }
+    Ok(removed)
+}
+
+pub fn cmd_skill_remove(name: &str, query: &str) -> Result<()> {
+    let home = resolve_mur_home()?;
+    if !depin_skill(&home, name, query)? {
+        bail!("skill '{query}' not found on '{name}'");
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run the new + existing skill tests**
+
+Run: `… cargo test -p mur-core depin_` then `… cargo test -p mur-core --lib cmd::agent::skill`
+Expected: the three `depin_` tests PASS; pre-existing `skill` tests still PASS (no regression).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/skill.rs
+git commit -m "feat(agent): depin_skill removes refs + installed_skills cards + on-disk dir"
+```
+
+---
+
+### Task 2: Fix `shadow-drift` remediation + `fixable` flags
+
+**Files:**
+- Modify: `mur-core/src/cmd/skill_doctor.rs` (`run_shadow_drift`)
+- Test: `mur-core/src/cmd/skill_doctor.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: the existing `run_shadow_drift` from S2.
+- Produces: identical-content shadow findings now carry `fixable: true` and remediation `mur agent skill remove <agent> <name>` (basename, no `skills/` prefix); diverged findings carry `fixable: false`. Task 3's repair relies on both: it only sees fixable findings and parses that remediation string.
+
+- [ ] **Step 1: Update the S2 shadow tests to assert the new contract**
+
+In `mur-core/src/cmd/skill_doctor.rs` tests, extend the two existing shadow tests (add these assertions):
+
+```rust
+// in shadow_drift_flags_identical_agent_copy_as_ok, after finding `f`:
+assert!(f.fixable, "identical shadow must be auto-fixable");
+assert_eq!(
+    f.remediation.as_deref().unwrap(),
+    "mur agent skill remove a1 foo",
+    "remediation must be the basename form depin_skill resolves"
+);
+
+// in shadow_drift_flags_diverged_agent_copy_as_warn, after finding `f`:
+assert!(!f.fixable, "diverged shadow must NOT be auto-fixable");
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `… cargo test -p mur-core shadow_drift`
+Expected: FAIL — remediation still `skills/foo` and `fixable` still `false` for the identical case.
+
+- [ ] **Step 3: Update `run_shadow_drift`**
+
+In `run_shadow_drift`, change the remediation to the basename form and set `fixable` per branch. Replace the shared `remediation` line and the two `Finding` constructions' `fixable` fields:
+
+```rust
+            let remediation = Some(format!("mur agent skill remove {agent_name} {name}"));
+            if local_hash == global_hash {
+                findings.push(Finding {
+                    check_id: "shadow-drift".into(),
+                    category: "shadow".into(),
+                    severity: Severity::Ok,
+                    skill_name: name.clone(),
+                    message: format!(
+                        "Agent '{agent_name}' vendors '{name}', identical to the global copy — redundant. De-pin so the global (builtin/registry) copy owns it."
+                    ),
+                    remediation,
+                    fixable: true,
+                });
+            } else {
+                findings.push(Finding {
+                    check_id: "shadow-drift".into(),
+                    category: "shadow".into(),
+                    severity: Severity::Warn,
+                    skill_name: name.clone(),
+                    message: format!(
+                        "Agent '{agent_name}' vendors '{name}', diverged from the global copy — this shadow pins a stale snapshot and never receives upstream MUR updates."
+                    ),
+                    remediation,
+                    fixable: false,
+                });
+            }
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `… cargo test -p mur-core shadow_drift`
+Expected: PASS (all shadow tests including the new assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/skill_doctor.rs
+git commit -m "feat(doctor): shadow-drift remediation uses basename + marks identical shadows fixable"
+```
+
+---
+
+### Task 3: `ShadowDepinRepair` for `mur skill doctor --fix`
+
+**Files:**
+- Create: `mur-core/src/skill_repair/shadow_depin.rs`
+- Modify: `mur-core/src/skill_repair/mod.rs` (add `pub mod shadow_depin;`)
+- Modify: `mur-core/src/cmd/skill_doctor.rs` (add the repair to the `repairs` vec at ~line 222)
+- Test: `mur-core/src/skill_repair/shadow_depin.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: `depin_skill` (Task 1), `Repair`/`RepairCtx`/`RepairOutcome`, `Finding`/`Severity`.
+- Produces: `pub struct ShadowDepinRepair;` implementing `Repair` with `check_id() == "shadow-drift"`.
+
+- [ ] **Step 1: Write the repair with a failing test**
+
+Create `mur-core/src/skill_repair/shadow_depin.rs`:
+
+```rust
+//! Repair impl for `shadow-drift` findings: de-pin an agent-local vendored
+//! copy that is byte-identical to the global builtin. Only identical shadows
+//! are marked `fixable` (see `run_shadow_drift`), so this repair never touches
+//! a diverged copy that might carry a real local edit.
+
+use crate::cmd::skill_doctor::Finding;
+use crate::skill_repair::{Repair, RepairCtx, RepairOutcome};
+
+pub struct ShadowDepinRepair;
+
+/// Recover `(agent, skill)` from the finding's own remediation string
+/// (`mur agent skill remove <agent> <skill>`) — an internal contract with
+/// `run_shadow_drift`, which generates exactly that form.
+fn parse_agent_skill(remediation: &str) -> Option<(String, String)> {
+    let rest = remediation.strip_prefix("mur agent skill remove ")?;
+    let mut it = rest.split_whitespace();
+    Some((it.next()?.to_string(), it.next()?.to_string()))
+}
+
+impl Repair for ShadowDepinRepair {
+    fn check_id(&self) -> &'static str {
+        "shadow-drift"
+    }
+
+    fn applicable(&self, finding: &Finding) -> bool {
+        finding.check_id == "shadow-drift" && finding.fixable
+    }
+
+    fn run(&self, finding: &Finding, ctx: &RepairCtx, apply: bool) -> RepairOutcome {
+        let Some((agent, skill)) = finding
+            .remediation
+            .as_deref()
+            .and_then(parse_agent_skill)
+        else {
+            return RepairOutcome::Skipped("no parseable remediation".into());
+        };
+        if !apply {
+            return RepairOutcome::DryRun(format!(
+                "would de-pin shadow '{skill}' from agent '{agent}'"
+            ));
+        }
+        match crate::cmd::agent::skill::depin_skill(ctx.home, &agent, &skill) {
+            Ok(true) => RepairOutcome::Fixed,
+            Ok(false) => RepairOutcome::Skipped(format!("'{skill}' already absent on '{agent}'")),
+            Err(e) => RepairOutcome::Failed(e.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmd::skill_doctor::{Finding, Severity};
+
+    fn shadow_finding() -> Finding {
+        Finding {
+            check_id: "shadow-drift".into(),
+            category: "shadow".into(),
+            severity: Severity::Ok,
+            skill_name: "mur-compress".into(),
+            message: "redundant".into(),
+            remediation: Some("mur agent skill remove mur mur-compress".into()),
+            fixable: true,
+        }
+    }
+
+    fn seed_shadow(home: &std::path::Path) {
+        let dir = home.join("agents/mur");
+        std::fs::create_dir_all(dir.join("skills/mur-compress")).unwrap();
+        std::fs::write(
+            dir.join("profile.yaml"),
+            "name: mur\ndisplay_name: MUR\nmodel_ref: m\nskills:\n  - skills/concierge\ninstalled_skills:\n- name: mur-compress\n  version: 1.0.0\n  publisher: human:mur\n  description: d\n  category: context\n  abstract: a\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("skills/mur-compress/skill.yaml"),
+            "name: mur-compress\nversion: 1.0.0\npublisher: human:mur\ndescription: d\ncategory: context\ncontent:\n  abstract: a\n  context: b\n",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn applicable_only_for_fixable_shadow_findings() {
+        let repair = ShadowDepinRepair;
+        assert!(repair.applicable(&shadow_finding()));
+        let mut not_fixable = shadow_finding();
+        not_fixable.fixable = false;
+        assert!(!repair.applicable(&not_fixable));
+    }
+
+    #[test]
+    fn apply_depins_the_shadow() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        seed_shadow(home);
+        let ctx = RepairCtx {
+            home,
+            registry_url: "unused",
+        };
+        let repair = ShadowDepinRepair;
+        let finding = shadow_finding();
+
+        // dry-run touches nothing
+        assert!(matches!(
+            repair.run(&finding, &ctx, false),
+            RepairOutcome::DryRun(_)
+        ));
+        assert!(home.join("agents/mur/skills/mur-compress").exists());
+
+        // apply removes card + dir
+        assert!(matches!(
+            repair.run(&finding, &ctx, true),
+            RepairOutcome::Fixed
+        ));
+        assert!(!home.join("agents/mur/skills/mur-compress").exists());
+        let yaml = std::fs::read_to_string(home.join("agents/mur/profile.yaml")).unwrap();
+        assert!(!yaml.contains("mur-compress"));
+    }
+}
+```
+
+- [ ] **Step 2: Register the module + run the test (expect module error first)**
+
+Add to `mur-core/src/skill_repair/mod.rs` (near the other `pub mod` lines):
+
+```rust
+pub mod shadow_depin;
+```
+
+Run: `… cargo test -p mur-core shadow_depin`
+Expected: PASS (the repair + tests compile and pass now that Task 1's `depin_skill` exists).
+
+- [ ] **Step 3: Wire the repair into `mur skill doctor --fix`**
+
+In `mur-core/src/cmd/skill_doctor.rs`, add the repair to the `repairs` vec (the `vec![ … ]` at ~line 222):
+
+```rust
+        let repairs: Vec<Box<dyn crate::skill_repair::Repair>> = vec![
+            Box::new(crate::skill_repair::tool_availability::ToolAvailabilityRepair),
+            Box::new(crate::skill_repair::dep_freshness::DepFreshnessRepair),
+            Box::new(crate::skill_repair::stats_sidecar::StatsSidecarRepair),
+            Box::new(crate::skill_repair::shadow_depin::ShadowDepinRepair),
+        ];
+```
+
+- [ ] **Step 4: Verify build, clippy, and the full touched-module tests**
+
+Run:
+```
+… cargo test -p mur-core shadow_depin
+… cargo test -p mur-core shadow_drift
+… cargo clippy -p mur-core -- -D warnings
+```
+Expected: all tests PASS; clippy clean (no warnings from the new code).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/skill_repair/shadow_depin.rs mur-core/src/skill_repair/mod.rs mur-core/src/cmd/skill_doctor.rs
+git commit -m "feat(doctor): ShadowDepinRepair de-pins identical builtin shadows under --fix --apply"
+```
+
+---
+
+## Rollout / Operator steps (post-merge, not code)
+
+After this ships + a new `mur` is installed and `mur sync` writes `mur-native-tools` into `~/.mur/skills/`:
+1. Preview: `mur skill doctor --fix` (dry-run) — lists the identical shadows it *would* de-pin on agent `mur`.
+2. Apply: `mur skill doctor --fix --apply` — removes the identical shadows (`mur-compress`, `parallel-code`, `video-analyze`, `watch-together`, `mur-native-tools`). Any diverged shadow is reported (Warn), not removed — de-pin those manually after reviewing: `mur agent skill remove mur <name>`.
+3. Restart the concierge (Hub-managed) to apply the profile change.
+4. `concierge` (identity) and `brainstorming` (registry, not a global builtin) are never flagged or removed.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §4.1 complete de-pin (refs + cards + dir) → Task 1 (`depin_skill` + rewired `cmd_skill_remove`). ✅
+- §4.2 fix remediation string → Task 2. ✅
+- §4.3 `ShadowDepinRepair` + fixable flags → Task 2 (flags) + Task 3 (repair + registration). ✅
+- §5 rollout → Rollout section (corrected to `--fix --apply`). ✅
+
+**Placeholder scan:** none — all code and test bodies are complete.
+
+**Type consistency:** `depin_skill(home: &Path, agent: &str, skill: &str) -> Result<bool>` is defined in Task 1 and consumed verbatim in Task 3. `Repair`/`RepairCtx`/`RepairOutcome` match the framework. `Finding` fields (`check_id, category, severity, skill_name, message, remediation, fixable`) match. Remediation format `mur agent skill remove <agent> <skill>` is produced in Task 2 and parsed in Task 3 by the same 4-word shape. `RepairOutcome::Failed(String)` — `e.to_string()` used (anyhow error → String).
+
+**Scope:** three focused tasks, CLI-only. Hub go-forward guard and the pack kernel remain out of scope per the spec. `ponytail:` the repair parses `(agent, skill)` from its own remediation string rather than adding an `agent` field to `Finding` (which would ripple across ~12 construction sites) — internal contract, both ends in-repo, covered by a test.

--- a/docs/superpowers/specs/2026-07-22-mur-pack-s1-deshadow-design.md
+++ b/docs/superpowers/specs/2026-07-22-mur-pack-s1-deshadow-design.md
@@ -1,0 +1,60 @@
+# MUR Pack S1 — De-Shadow (root-cause fix for vendored builtin skills) — Design
+
+**Status:** Design / spec (S1 of the Pack governance program)
+**Date:** 2026-07-22
+**Builds on:** the Pack governance north-star (`2026-07-22-mur-pack-governance-design.md`, §3.2 never-shadow, §8 S1) and S2 (`2026-07-22-mur-pack-s2-shadow-cleanup.md`, shipped #741 — promoted `mur-native-tools` to builtin + added the `mur skill doctor` `shadow-drift` check). S2's rollout attempt surfaced a gap this spec closes.
+
+## 1. Goal
+
+Kill the actual drift root-cause the governance program targets: agent-local **vendored copies of builtin skills** that shadow the shipped global builtin via `load_all` (agent-local wins on name collision) and never receive updates. Deliver a working de-pin path and an automatic, safe cleanup — **CLI-only**. Defer the unified pack manifest/kind/adapter kernel to when the capability kind (S3) needs it (YAGNI).
+
+## 2. Context — what S2's rollout uncovered
+
+- An agent's skills live in **two** profile structures plus on-disk dirs: `profile.skills: Vec<String>` (references — the load list) and `profile.installed_skills: Vec<SkillCardEntry>` (denormalized cards). Actual skill **injection** comes from the on-disk `~/.mur/agents/<agent>/skills/<name>/skill.yaml` dirs (via `load_all`, which shadows the global store on name collision). The `installed_skills` cards feed only the agent **card** (A2A/display) and CLI **autocomplete**.
+- The live concierge (`~/.mur/agents/mur`) carries **4 true shadows** — `mur-compress`, `parallel-code`, `video-analyze`, `watch-together` — as `installed_skills` cards + on-disk dirs, NOT as `skills:` refs (its `skills:` list is only `concierge` + `brainstorming`). Plus `mur-native-tools`, which becomes a shadow once S2's new builtin is synced.
+- **`mur agent skill remove <agent> <name>` cannot remove them.** Its `resolve_skill_id` searches only `profile.skills` (refs) in three forms (full id / basename / stem); it never looks at `installed_skills` cards or the on-disk dir. So every de-pin attempt returned "not found", and S2's `shadow-drift` remediation string (which points at that command) is wrong for this case.
+- **Source of the vendored copies is legacy**, not current code. Current `mur init` writes builtins to the global store only (`ensure_mur_skill`). The current Hub seed (`mur-hub-gui` `seed_missing_bundled_skills`) copies only its bundled template `skills/` — which contains exactly `concierge` + `brainstorming` (verified), neither a builtin — so it cannot introduce a builtin shadow and will not re-vendor the 4 after de-pin. The concierge's shadows came from an older seed/add path.
+
+## 3. Decisions
+
+| Question | Decision |
+|---|---|
+| De-pin mechanism | Extend the existing `mur agent skill remove` into the **complete** de-pin verb: resolve a name across `skills:` refs / `installed_skills:` cards / on-disk dir, and remove **every** form present. |
+| Remediation string | Fix S2's `shadow-drift` finding remediation to the working command form once `remove` resolves cards/dirs. |
+| Batch cleanup | Add a `ShadowDepinRepair` to the existing `mur skill doctor --fix` (M5b `Repair`) framework: auto-remove ONLY shadows byte-identical to the global builtin; report diverged ones, never auto-remove. |
+| Go-forward guard (Hub) | **Deferred** to an optional defensive Hub follow-up. The current Hub bundle is clean (concierge+brainstorming only), so no builtin shadow can be (re)introduced today. Not in S1's CLI scope. |
+| Kernel (manifest/kind/adapter) | **Deferred** to S3 when the capability kind needs it. |
+
+## 4. Design
+
+### 4.1 `mur agent skill remove` — complete de-pin (`mur-core/src/cmd/agent/skill.rs`)
+Today `cmd_skill_remove(name, query)` resolves only against `profile.skills` and returns "not found" otherwise. New behavior: resolve the target name against **all three** locations and remove each that is present, in one call:
+1. **`skills:` ref** — if `resolve_skill_id` matches, remove it from `profile.skills` (existing behavior).
+2. **`installed_skills:` card** — if any `SkillCardEntry.name == <basename>`, drop it via `profile.installed_skills.retain(|c| c.name != basename)`.
+3. **on-disk dir** — `~/.mur/agents/<name>/skills/<basename>/` — remove the directory (existing "delete backing subdir if orphaned" logic generalizes: delete when no remaining `skills:` ref points at it).
+
+The command succeeds if the skill was present in **any** location (not just refs); it errors only when the name is found in none. `<basename>` derivation matches `resolve_skill_id`'s existing forms (full id `skills/foo`, basename `foo`, stem). Save the profile atomically (existing `save_profile`). Changes apply on the agent's next restart (unchanged semantics; note in output).
+
+### 4.2 Fix the `shadow-drift` remediation (`mur-core/src/cmd/skill_doctor.rs`)
+Change the finding's remediation from `mur agent skill remove {agent} skills/{name}` to `mur agent skill remove {agent} {name}` (basename form, which §4.1 now resolves across cards/dirs). Message unchanged.
+
+### 4.3 `ShadowDepinRepair` for `mur skill doctor --fix` (`mur-core/src/skill_repair/`)
+The doctor already runs a `Vec<Box<dyn Repair>>` under `--fix` (M5b). Add one impl:
+- `check_id() -> "shadow-drift"` (matches the S2 finding's `check_id`, so it is dispatched for those findings).
+- `apply`: re-enumerate agent-local shadows exactly as `run_shadow_drift` does, and for each whose `content_hash_for_origin` **equals** the global builtin's (the `Severity::Ok` / identical class), perform the §4.1 removal (card + dir + any ref). Diverged shadows (`Severity::Warn`) are **left untouched** — reported only — so any genuine local edit is never destroyed.
+- Register it in the `repairs` vec in `cmd_doctor`.
+- Mark the identical-shadow findings `fixable: true` and the diverged ones `fixable: false` in `run_shadow_drift`, so `--fix` acts on exactly the safe set and the UI labels them correctly.
+
+## 5. Migration / rollout
+After this ships and a new `mur` is installed + `mur sync` writes `mur-native-tools` to the global store:
+`mur skill doctor --fix` on the concierge removes the 4 identical shadows (`mur-compress`, `parallel-code`, `video-analyze`, `watch-together`) and `mur-native-tools`; any diverged one is reported for manual `mur agent skill remove mur <name>`. Restart the concierge (Hub-managed) to apply. `concierge` (identity) and `brainstorming` (registry, not a global builtin) are never flagged or removed.
+
+## 6. Out of scope / deferred
+- **Hub go-forward guard** (skip builtin-named templates in `seed_missing_bundled_skills`) — optional defensive follow-up; not needed while the bundle is concierge+brainstorming only.
+- Unified pack **manifest / kind / adapter kernel** — S3+.
+- Reworking the two-structure model (`skills` refs vs `installed_skills` cards) into one — larger refactor; not required to fix drift.
+
+## 7. Testing
+- **§4.1 remove**: (a) a name present only as an `installed_skills` card + on-disk dir (no `skills:` ref) is fully removed (card gone, dir gone) and the command succeeds; (b) a name present only as a `skills:` ref still removes as before; (c) a name present in none errors; (d) a name present in all three removes all three.
+- **§4.2**: the `shadow-drift` finding's remediation string is the basename form and, fed to `remove`, actually resolves (integration-level assertion on the string).
+- **§4.3 repair**: with an identical-content shadow → `--fix` removes it (card+dir) and a re-scan reports no finding for it; with a diverged shadow → `--fix` leaves it in place and it is still reported (`Warn`, not auto-removed); an agent-only skill (no global twin) is never touched.

--- a/mur-core/src/cmd/agent/skill.rs
+++ b/mur-core/src/cmd/agent/skill.rs
@@ -215,25 +215,59 @@ fn convert_ref_in_profile(
     Ok(())
 }
 
-pub fn cmd_skill_remove(name: &str, query: &str) -> Result<()> {
-    let (path, mut profile) = load_profile_for_edit(name)?;
-    let resolved = resolve_skill_id(&profile, query)
-        .ok_or_else(|| anyhow!("skill '{query}' not found on '{name}'"))?
-        .clone();
-    profile.skills.retain(|s| s != &resolved);
-    save_profile(&path, &mut profile)?;
+/// Remove a skill from every place it can live on an agent: the `skills:`
+/// reference list, the `installed_skills:` card list, and the on-disk
+/// `skills/<name>/` dir under `home`. Returns whether it was present anywhere.
+/// Takes an explicit `home` so the doctor repair can operate on any store.
+pub(crate) fn depin_skill(home: &Path, agent: &str, skill: &str) -> Result<bool> {
+    let path = home.join("agents").join(agent).join("profile.yaml");
+    if !path.exists() {
+        bail!("agent '{agent}' not found");
+    }
+    let yaml = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let mut profile: _AgentProfile =
+        serde_yaml_ng::from_str(&yaml).with_context(|| format!("parse {}", path.display()))?;
 
-    // Delete the backing artifact if no other skill entry references it.
-    // Modern skills are per-skill subdirectories (`skills/<name>/skill.yaml`);
-    // legacy entries may still be a flat file (`skills/<name>.md`).
-    let agent_home = resolve_mur_home()?.join("agents").join(name);
-    let backing = agent_home.join(&resolved);
-    if backing.exists() && !profile.skills.iter().any(|s| s == &resolved) {
-        if backing.is_dir() {
-            let _ = fs::remove_dir_all(&backing);
-        } else {
-            let _ = fs::remove_file(&backing);
-        }
+    // Bare skill name, accepting `skills/foo`, `foo.yaml`, or `foo`.
+    let base = Path::new(skill)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(skill)
+        .to_string();
+
+    let mut removed = false;
+
+    // 1. skills: ref (any resolvable form)
+    if let Some(resolved) = resolve_skill_id(&profile, skill).cloned() {
+        profile.skills.retain(|s| s != &resolved);
+        removed = true;
+    }
+    // 2. installed_skills: card by name
+    let before = profile.installed_skills.len();
+    profile.installed_skills.retain(|c| c.name != base);
+    if profile.installed_skills.len() != before {
+        removed = true;
+    }
+    if removed {
+        save_profile(&path, &mut profile)?;
+    }
+    // 3. on-disk vendored dir (only if no surviving ref still points at it)
+    let dir = home.join("agents").join(agent).join("skills").join(&base);
+    let still_referenced = profile
+        .skills
+        .iter()
+        .any(|s| Path::new(s).file_stem().and_then(|f| f.to_str()) == Some(base.as_str()));
+    if dir.is_dir() && !still_referenced {
+        let _ = fs::remove_dir_all(&dir);
+        removed = true;
+    }
+    Ok(removed)
+}
+
+pub fn cmd_skill_remove(name: &str, query: &str) -> Result<()> {
+    let home = resolve_mur_home()?;
+    if !depin_skill(&home, name, query)? {
+        bail!("skill '{query}' not found on '{name}'");
     }
     Ok(())
 }
@@ -416,5 +450,114 @@ content:
         let mut profile = mur_common::AgentProfile::default_for_tests();
         profile.skills = vec!["skills/ghost".into()];
         assert!(convert_ref_in_profile(home.path(), &mut profile, "skills/ghost").is_err());
+    }
+
+    fn write_profile(home: &std::path::Path, agent: &str, body: &str) -> std::path::PathBuf {
+        let dir = home.join("agents").join(agent);
+        std::fs::create_dir_all(dir.join("skills")).unwrap();
+        let path = dir.join("profile.yaml");
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    fn write_agent_skill_dir(home: &std::path::Path, agent: &str, name: &str) {
+        let d = home.join("agents").join(agent).join("skills").join(name);
+        std::fs::create_dir_all(&d).unwrap();
+        std::fs::write(
+            d.join("skill.yaml"),
+            format!(
+                "name: {name}\nversion: 1.0.0\npublisher: human:t\ndescription: d\ncategory: context\ncontent:\n  abstract: a\n  context: b\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    // A minimal profile carrying `name` as an installed_skills card + on-disk dir,
+    // but NOT as a skills: ref (the exact concierge shadow shape).
+    const CARD_ONLY_PROFILE: &str = "\
+schema: 1
+id: 0192f5a1-28ab-7111-8000-000000000099
+name: mur
+display_name: MUR
+version: \"0.1.0\"
+persona:
+  category: research
+  description: test profile for depin_skill tests
+  traits: { tone: concise, risk: cautious, verbosity: low }
+sys_prompt_file: \"sys_prompt.md\"
+model: { provider: ollama, name: \"m\", params: {} }
+mcp_servers: []
+skills:
+  - skills/concierge
+installed_skills:
+- name: mur-compress
+  version: 1.0.0
+  publisher: human:mur
+  description: d
+  category: context
+  abstract: a
+transport: { stdio: true, socket: { enabled: true, bind: \"unix:///tmp/a.sock\" } }
+communication: { accepts_from: [\"*\"], sends_to: [] }
+capabilities: [\"a2a.message.send\",\"a2a.tasks\"]
+entitlements:
+  network:
+    inbound: { ports: [] }
+    outbound: { mode: restricted, allow_hosts: [], protocols: [\"tcp\"], resolve_dns: { mode: system } }
+  filesystem: { read: [], write: [], deny: [\"~/.ssh\"] }
+  processes: { spawn: { mode: allowlist, allowed: [] } }
+  syscalls: { mode: default }
+  limits: { memory_mb: 512, file_descriptors: 1024, processes: 32 }
+notifications: { on_task_complete: [], on_error: [], on_shutdown: [] }
+retry:
+  llm: { max_retries: 3, backoff: exponential, initial_delay_ms: 1000, max_delay_ms: 30000, retry_on: [\"rate_limit\"] }
+  tool: { max_retries: 1, backoff: fixed, initial_delay_ms: 500 }
+lifecycle: { restart: on_failure, max_restarts: 3, restart_window_secs: 600, stop_timeout_secs: 15, mcp_required: true }
+created_at: \"2026-04-22T10:00:00+08:00\"
+updated_at: \"2026-04-22T10:00:00+08:00\"
+";
+
+    #[test]
+    fn depin_removes_card_and_dir_when_not_a_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        write_profile(home, "mur", CARD_ONLY_PROFILE);
+        write_agent_skill_dir(home, "mur", "mur-compress");
+        write_agent_skill_dir(home, "mur", "concierge");
+
+        let removed = depin_skill(home, "mur", "mur-compress").unwrap();
+        assert!(removed, "should report removal");
+
+        // card gone
+        let yaml = std::fs::read_to_string(home.join("agents/mur/profile.yaml")).unwrap();
+        let p: _AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert!(p.installed_skills.iter().all(|c| c.name != "mur-compress"));
+        // dir gone
+        assert!(!home.join("agents/mur/skills/mur-compress").exists());
+        // untouched skill dir preserved
+        assert!(home.join("agents/mur/skills/concierge").exists());
+    }
+
+    #[test]
+    fn depin_returns_false_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        write_profile(home, "mur", CARD_ONLY_PROFILE);
+        let removed = depin_skill(home, "mur", "does-not-exist").unwrap();
+        assert!(!removed);
+    }
+
+    #[test]
+    fn depin_removes_ref_form_too() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        // concierge is a skills: ref + on-disk dir
+        write_profile(home, "mur", CARD_ONLY_PROFILE);
+        write_agent_skill_dir(home, "mur", "concierge");
+        let removed = depin_skill(home, "mur", "concierge").unwrap();
+        assert!(removed);
+        let yaml = std::fs::read_to_string(home.join("agents/mur/profile.yaml")).unwrap();
+        let p: _AgentProfile = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert!(!p.skills.iter().any(|s| s == "skills/concierge"));
+        assert!(!home.join("agents/mur/skills/concierge").exists());
     }
 }

--- a/mur-core/src/cmd/skill_doctor.rs
+++ b/mur-core/src/cmd/skill_doctor.rs
@@ -224,6 +224,7 @@ pub fn cmd_doctor(
             Box::new(crate::skill_repair::tool_availability::ToolAvailabilityRepair),
             Box::new(crate::skill_repair::dep_freshness::DepFreshnessRepair),
             Box::new(crate::skill_repair::stats_sidecar::StatsSidecarRepair),
+            Box::new(crate::skill_repair::shadow_depin::ShadowDepinRepair),
         ];
         let repair_ctx = crate::skill_repair::RepairCtx {
             home: &ctx.home,

--- a/mur-core/src/cmd/skill_doctor.rs
+++ b/mur-core/src/cmd/skill_doctor.rs
@@ -1299,7 +1299,7 @@ fn run_shadow_drift(ctx: &DoctorCtx) -> Vec<Finding> {
             ) else {
                 continue;
             };
-            let remediation = Some(format!("mur agent skill remove {agent_name} skills/{name}"));
+            let remediation = Some(format!("mur agent skill remove {agent_name} {name}"));
             if local_hash == global_hash {
                 findings.push(Finding {
                     check_id: "shadow-drift".into(),
@@ -1310,7 +1310,7 @@ fn run_shadow_drift(ctx: &DoctorCtx) -> Vec<Finding> {
                         "Agent '{agent_name}' vendors '{name}', identical to the global copy — redundant. De-pin so the global (builtin/registry) copy owns it."
                     ),
                     remediation,
-                    fixable: false,
+                    fixable: true,
                 });
             } else {
                 findings.push(Finding {
@@ -1393,12 +1393,12 @@ mod tests {
             .expect("expected a shadow finding for foo");
         assert_eq!(f.check_id, "shadow-drift");
         assert_eq!(f.severity, Severity::Warn);
-        assert!(
-            f.remediation
-                .as_deref()
-                .unwrap()
-                .contains("mur agent skill remove a1 skills/foo")
+        assert_eq!(
+            f.remediation.as_deref().unwrap(),
+            "mur agent skill remove a1 foo",
+            "remediation must be the basename form"
         );
+        assert!(!f.fixable, "diverged shadow must NOT be auto-fixable");
     }
 
     #[test]
@@ -1417,6 +1417,12 @@ mod tests {
             .find(|f| f.skill_name == "foo")
             .expect("expected a shadow finding for foo");
         assert_eq!(f.severity, Severity::Ok);
+        assert!(f.fixable, "identical shadow must be auto-fixable");
+        assert_eq!(
+            f.remediation.as_deref().unwrap(),
+            "mur agent skill remove a1 foo",
+            "remediation must be the basename form depin_skill resolves"
+        );
     }
 
     #[test]

--- a/mur-core/src/skill_repair/mod.rs
+++ b/mur-core/src/skill_repair/mod.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use crate::cmd::skill_doctor::Finding;
 
 pub mod dep_freshness;
+pub mod shadow_depin;
 pub mod stats_sidecar;
 pub mod tool_availability;
 

--- a/mur-core/src/skill_repair/shadow_depin.rs
+++ b/mur-core/src/skill_repair/shadow_depin.rs
@@ -1,0 +1,158 @@
+//! Repair impl for `shadow-drift` findings: de-pin an agent-local vendored
+//! copy that is byte-identical to the global builtin. Only identical shadows
+//! are marked `fixable` (see `run_shadow_drift`), so this repair never touches
+//! a diverged copy that might carry a real local edit.
+
+use crate::cmd::skill_doctor::Finding;
+use crate::skill_repair::{Repair, RepairCtx, RepairOutcome};
+
+pub struct ShadowDepinRepair;
+
+/// Recover `(agent, skill)` from the finding's own remediation string
+/// (`mur agent skill remove <agent> <skill>`) — an internal contract with
+/// `run_shadow_drift`, which generates exactly that form.
+fn parse_agent_skill(remediation: &str) -> Option<(String, String)> {
+    let rest = remediation.strip_prefix("mur agent skill remove ")?;
+    let mut it = rest.split_whitespace();
+    Some((it.next()?.to_string(), it.next()?.to_string()))
+}
+
+impl Repair for ShadowDepinRepair {
+    fn check_id(&self) -> &'static str {
+        "shadow-drift"
+    }
+
+    fn applicable(&self, finding: &Finding) -> bool {
+        finding.check_id == "shadow-drift" && finding.fixable
+    }
+
+    fn run(&self, finding: &Finding, ctx: &RepairCtx, apply: bool) -> RepairOutcome {
+        let Some((agent, skill)) = finding.remediation.as_deref().and_then(parse_agent_skill)
+        else {
+            return RepairOutcome::Skipped("no parseable remediation".into());
+        };
+        if !apply {
+            return RepairOutcome::DryRun(format!(
+                "would de-pin shadow '{skill}' from agent '{agent}'"
+            ));
+        }
+        match crate::cmd::agent::skill::depin_skill(ctx.home, &agent, &skill) {
+            Ok(true) => RepairOutcome::Fixed,
+            Ok(false) => RepairOutcome::Skipped(format!("'{skill}' already absent on '{agent}'")),
+            Err(e) => RepairOutcome::Failed(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cmd::skill_doctor::{Finding, Severity};
+
+    fn shadow_finding() -> Finding {
+        Finding {
+            check_id: "shadow-drift".into(),
+            category: "shadow".into(),
+            severity: Severity::Ok,
+            skill_name: "mur-compress".into(),
+            message: "redundant".into(),
+            remediation: Some("mur agent skill remove mur mur-compress".into()),
+            fixable: true,
+        }
+    }
+
+    // Full valid profile, mirroring `CARD_ONLY_PROFILE` in
+    // `cmd::agent::skill` tests: `mur-compress` is carried as an
+    // `installed_skills` card + on-disk dir but NOT as a `skills:` ref (the
+    // exact identical-shadow shape `run_shadow_drift` flags as fixable).
+    const CARD_ONLY_PROFILE: &str = "\
+schema: 1
+id: 0192f5a1-28ab-7111-8000-000000000099
+name: mur
+display_name: MUR
+version: \"0.1.0\"
+persona:
+  category: research
+  description: test profile for shadow_depin tests
+  traits: { tone: concise, risk: cautious, verbosity: low }
+sys_prompt_file: \"sys_prompt.md\"
+model: { provider: ollama, name: \"m\", params: {} }
+mcp_servers: []
+skills:
+  - skills/concierge
+installed_skills:
+- name: mur-compress
+  version: 1.0.0
+  publisher: human:mur
+  description: d
+  category: context
+  abstract: a
+transport: { stdio: true, socket: { enabled: true, bind: \"unix:///tmp/a.sock\" } }
+communication: { accepts_from: [\"*\"], sends_to: [] }
+capabilities: [\"a2a.message.send\",\"a2a.tasks\"]
+entitlements:
+  network:
+    inbound: { ports: [] }
+    outbound: { mode: restricted, allow_hosts: [], protocols: [\"tcp\"], resolve_dns: { mode: system } }
+  filesystem: { read: [], write: [], deny: [\"~/.ssh\"] }
+  processes: { spawn: { mode: allowlist, allowed: [] } }
+  syscalls: { mode: default }
+  limits: { memory_mb: 512, file_descriptors: 1024, processes: 32 }
+notifications: { on_task_complete: [], on_error: [], on_shutdown: [] }
+retry:
+  llm: { max_retries: 3, backoff: exponential, initial_delay_ms: 1000, max_delay_ms: 30000, retry_on: [\"rate_limit\"] }
+  tool: { max_retries: 1, backoff: fixed, initial_delay_ms: 500 }
+lifecycle: { restart: on_failure, max_restarts: 3, restart_window_secs: 600, stop_timeout_secs: 15, mcp_required: true }
+created_at: \"2026-04-22T10:00:00+08:00\"
+updated_at: \"2026-04-22T10:00:00+08:00\"
+";
+
+    fn seed_shadow(home: &std::path::Path) {
+        let dir = home.join("agents/mur");
+        std::fs::create_dir_all(dir.join("skills/mur-compress")).unwrap();
+        std::fs::write(dir.join("profile.yaml"), CARD_ONLY_PROFILE).unwrap();
+        std::fs::write(
+            dir.join("skills/mur-compress/skill.yaml"),
+            "name: mur-compress\nversion: 1.0.0\npublisher: human:mur\ndescription: d\ncategory: context\ncontent:\n  abstract: a\n  context: b\n",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn applicable_only_for_fixable_shadow_findings() {
+        let repair = ShadowDepinRepair;
+        assert!(repair.applicable(&shadow_finding()));
+        let mut not_fixable = shadow_finding();
+        not_fixable.fixable = false;
+        assert!(!repair.applicable(&not_fixable));
+    }
+
+    #[test]
+    fn apply_depins_the_shadow() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        seed_shadow(home);
+        let ctx = RepairCtx {
+            home,
+            registry_url: "unused",
+        };
+        let repair = ShadowDepinRepair;
+        let finding = shadow_finding();
+
+        // dry-run touches nothing
+        assert!(matches!(
+            repair.run(&finding, &ctx, false),
+            RepairOutcome::DryRun(_)
+        ));
+        assert!(home.join("agents/mur/skills/mur-compress").exists());
+
+        // apply removes card + dir
+        assert!(matches!(
+            repair.run(&finding, &ctx, true),
+            RepairOutcome::Fixed
+        ));
+        assert!(!home.join("agents/mur/skills/mur-compress").exists());
+        let yaml = std::fs::read_to_string(home.join("agents/mur/profile.yaml")).unwrap();
+        assert!(!yaml.contains("mur-compress"));
+    }
+}


### PR DESCRIPTION
S1 of the [MUR Pack governance program](../blob/main/docs/superpowers/specs/2026-07-22-mur-pack-governance-design.md). Follows S2 (#741) and closes the de-pin gap S2's rollout surfaced. Spec: `docs/superpowers/specs/2026-07-22-mur-pack-s1-deshadow-design.md`.

## Problem
Agents carry vendored copies of builtin skills (as `installed_skills:` cards + on-disk `skills/<name>/` dirs) that shadow the shipped global builtin via `load_all` and never update. S2's `shadow-drift` check flags them, but there was **no working way to remove them**: `mur agent skill remove` only touched the `skills:` ref list, so the concierge's card-only shadows returned "not found".

## What (CLI-only)
- **`depin_skill(home, agent, skill)`** — removes a skill from all three places it can live: `skills:` refs, `installed_skills:` cards, and the on-disk dir. `mur agent skill remove` is now a thin wrapper, so it finally removes card/dir shadows.
- **`shadow-drift` remediation fixed** to the basename form `mur agent skill remove <agent> <name>`, and identical shadows are now marked `fixable:true` (diverged stay `fixable:false`).
- **`ShadowDepinRepair`** plugs into `mur skill doctor --fix`: `--fix` previews, `--fix --apply` de-pins — **only byte-identical shadows** (diverged copies with real local edits are reported, never auto-removed; double-gated on `fixable`).

## Deferred (per spec)
Hub go-forward guard (the current bundle is clean, can't re-introduce a shadow) and the unified pack manifest/kind/adapter kernel (S3+).

## Rollout (operator, post-merge)
After install + `mur sync`: `mur skill doctor --fix` to preview, `mur skill doctor --fix --apply` to de-pin the concierge's identical shadows, restart the concierge. `concierge` (identity) and `brainstorming` (registry) are never touched.

## Review
Subagent-driven, 3 tasks each spec+quality reviewed; opus whole-branch review = **Ship** (0 Critical/Important). Verified: the auto-fix path can never remove a diverged shadow (double-gated); dry-run is non-destructive by construction; agent/skill slug names make the remediation-string parse robust. `content_hash_for_origin` includes `version`, so "identical" genuinely means no local edit. 8/8 relevant tests green; `fmt` + `clippy -D warnings` clean.

One Minor follow-up: the `--apply` confirm shows a count, not an enumeration (mitigated by `--fix` dry-run listing each; removals are recoverable from the global store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)