### PR TITLE
feat(addon): Pack S4 — import governance (never-shadow + pin + reimport)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-mur-pack-s4-import-governance.md
+++ b/docs/superpowers/plans/2026-07-22-mur-pack-s4-import-governance.md
@@ -1,0 +1,325 @@
+# MUR Pack S4 — Import Governance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the Claude-plugin importer under Pack governance — never-shadow at import, a content-hash pin, and an explicit re-import refresh.
+
+**Architecture:** Three tasks. (1) `mur-common`: two back-compat `Option<String>` fields on `AddonRef` — `content_hash` (the pin) and `fetch_ref` (the re-fetchable source, distinct from the free-text provenance `source`). (2) `addon/import.rs`: a never-shadow filter (skip skills colliding with the global store + warn), plus recording `content_hash` and `fetch_ref` on the `AddonRef`. (3) `mur agent addon reimport` — re-fetch from `fetch_ref`, re-apply (re-running the never-shadow gate), preserve `enabled`. Reuses `list_installed`, `content_hash_for_origin`, `sha256_hex`, and the existing import/remove/enable commands.
+
+**Tech Stack:** Rust (edition 2024), `mur-common` (`agent`, `skill::hash`, `skill::local`), `mur-core` (`cmd/agent/addon`, `cli`, `dispatch`), `serde`, `tempfile`.
+
+## Global Constraints
+
+- Reuse existing helpers — no new copies:
+  - `mur_common::skill::local::list_installed(mur_home: &Path) -> Result<Vec<String>, StoreError>` — the global store (builtins after sync + registry). The never-shadow collision set.
+  - `mur_common::skill::content_hash_for_origin(m: &SkillManifest) -> Result<String, ParseError>` and `mur_common::skill::sha256_hex(bytes: &[u8]) -> String` — for the pin.
+  - `AddonRef` (`mur-common/src/agent.rs:405`): `{ id, source, enabled, skills, mcp, commands }`. `source` is free-text provenance (`"claude-local:<name>@<ver>"`), NOT a fetch target.
+  - Import structure (`mur-core/src/cmd/agent/addon/import.rs`): Phase 1 collects `pending_skills: Vec<(PathBuf, SkillManifest, PathBuf)>` and `pending_cmds: Vec<(PathBuf, SkillManifest)>` with NO writes; Phase 2 writes them and pushes the `AddonRef` (~line 322). `cmd_addon_import(name, plugin_dir, plugin: Option<&str>, force: bool)`.
+  - `cmd_addon_remove(name, addon_id)`, `cmd_addon_set_enabled(name, addon_id, enabled)` (`addon/mod.rs`).
+  - Addon dispatch: `AgentAddonAction` enum (`cli/actions.rs`); the `AgentAction::Addon { action }` match arm (`dispatch.rs:1709`).
+- Collision behavior: **skip the colliding skill + warn** (import the rest); the skill is excluded from `AddonRef.skills`. Never refuse the whole import or rename.
+- Brand "MUR" uppercase in user-facing strings.
+- Test: `ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist RUSTFLAGS=-Cdebuginfo=0 CARGO_TARGET_DIR=/Volumes/Firecuda4tb/Projects/mur/target cargo test -p <crate> <name>` (`-p mur-common` Task 1, `-p mur-core` Tasks 2-3; add `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin` to PATH if needed). Build ONLY the crate under test (disk is tight). If a debug bin CLI-parse test stack-overflows, set `RUST_MIN_STACK=33554432`.
+
+---
+
+### Task 1: `AddonRef` gains `content_hash` + `fetch_ref` (`mur-common`)
+
+**Files:**
+- Modify: `mur-common/src/agent.rs` (`AddonRef` struct + a test)
+- Test: `mur-common/src/agent.rs` tests
+
+**Interfaces:**
+- Produces: `AddonRef.content_hash: Option<String>`, `AddonRef.fetch_ref: Option<String>` (both `#[serde(default, skip_serializing_if = "Option::is_none")]`). Consumed by Tasks 2-3.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod` in `mur-common/src/agent.rs`:
+
+```rust
+#[test]
+fn addon_ref_content_hash_and_fetch_ref_default_none_and_round_trip() {
+    // legacy AddonRef (no new fields) → None
+    let legacy = "id: a\nsource: claude-local:a@1\nenabled: false\n";
+    let r: AddonRef = serde_yaml_ng::from_str(legacy).unwrap();
+    assert_eq!(r.content_hash, None);
+    assert_eq!(r.fetch_ref, None);
+
+    // with the new fields → round-trips
+    let full = "id: a\nsource: claude-local:a@1\nenabled: true\ncontent_hash: abc123\nfetch_ref: owner/repo\n";
+    let r2: AddonRef = serde_yaml_ng::from_str(full).unwrap();
+    assert_eq!(r2.content_hash.as_deref(), Some("abc123"));
+    assert_eq!(r2.fetch_ref.as_deref(), Some("owner/repo"));
+    let back = serde_yaml_ng::to_string(&r2).unwrap();
+    let r3: AddonRef = serde_yaml_ng::from_str(&back).unwrap();
+    assert_eq!(r2, r3);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `… cargo test -p mur-common addon_ref_content_hash_and_fetch_ref`
+Expected: FAIL — no `content_hash`/`fetch_ref` fields (compile error).
+
+- [ ] **Step 3: Add the fields**
+
+In `mur-common/src/agent.rs`, add to `AddonRef` (after `commands`):
+
+```rust
+    /// Content-hash pin over the imported skill/command manifests, recorded
+    /// at import. `None` on legacy refs. Enables drift detection + refresh.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_hash: Option<String>,
+    /// The re-fetchable source (the original `import` argument: a local path
+    /// or `owner/repo`), distinct from the free-text provenance `source`.
+    /// `None` on legacy refs. Used by `reimport`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fetch_ref: Option<String>,
+```
+
+If any `AddonRef { .. }` struct literal without `..Default::default()` breaks compilation, add `content_hash: None, fetch_ref: None,` there.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `… cargo test -p mur-common addon_ref_content_hash_and_fetch_ref`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-common/src/agent.rs
+git commit -m "feat(common): AddonRef gains content_hash + fetch_ref (back-compat)"
+```
+
+---
+
+### Task 2: Never-shadow filter + pin recording at import (`mur-core`)
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/addon/import.rs`
+- Test: `mur-core/src/cmd/agent/addon/import.rs` tests
+
+**Interfaces:**
+- Consumes: Task 1's `AddonRef` fields; `list_installed`, `content_hash_for_origin`, `sha256_hex`.
+- Produces: the importer now skips global-store-colliding skills, and records `content_hash` + `fetch_ref` on the `AddonRef`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod` in `import.rs` (mirror the existing import tests' setup — a plugin dir with `skills/<name>/SKILL.md`, an agent under a temp `MUR_HOME`):
+
+```rust
+#[test]
+fn import_skips_skill_that_shadows_the_global_store() {
+    // See sibling import tests for the exact temp-home + plugin scaffolding;
+    // reuse that harness. Seed a global-store skill named "brainstorm"
+    // (write ~/.mur/skills/brainstorm/skill.yaml), and a plugin bundling
+    // skills/brainstorm + skills/unique.
+    // After cmd_addon_import(agent, plugin_dir, None, true):
+    //   - the agent has skills/unique but NOT skills/brainstorm
+    //   - the AddonRef.skills contains "unique" but not "brainstorm"
+    //   - AddonRef.content_hash is Some(non-empty)
+    //   - AddonRef.fetch_ref == Some(<the plugin_dir arg>)
+    // (Write the concrete assertions using the sibling tests' helper names.)
+}
+```
+NOTE to implementer: build this test by copying the closest existing import test's scaffolding (temp `MUR_HOME`, agent seed, plugin dir with `skills/<n>/SKILL.md`), then add a global-store skill dir (`mur_home.join("skills/brainstorm/skill.yaml")` with a minimal valid manifest) and a second non-colliding plugin skill. Assert the four bullet points above.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `… cargo test -p mur-core import_skips_skill_that_shadows`
+Expected: FAIL — the colliding skill is currently imported (no filter), `content_hash`/`fetch_ref` are `None`.
+
+- [ ] **Step 3: Add the never-shadow filter**
+
+In `import.rs`, between Phase 1 (collect) and Phase 2 (commit), after `pending_skills` and `pending_cmds` are built, filter out global-store collisions:
+
+```rust
+    // ── Never-shadow gate: drop skills/commands whose name collides with a
+    // global-store (builtin/registry) skill, so an import can never shadow a
+    // MUR-shipped skill. The agent uses MUR's copy via store-wide injection.
+    let global: std::collections::HashSet<String> =
+        mur_common::skill::local::list_installed(&mur_home)
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+    let mut retain_non_shadow = |name: &str| -> bool {
+        if global.contains(name) {
+            eprintln!(
+                "skill '{name}' is already provided by MUR — skipping the plugin's copy to avoid shadowing"
+            );
+            false
+        } else {
+            true
+        }
+    };
+    pending_skills.retain(|(_, m, _)| retain_non_shadow(&m.name));
+    pending_cmds.retain(|(_, m)| retain_non_shadow(&m.name));
+```
+(`mur_home` is the resolved MUR home already available in this function — reuse the existing binding; if it isn't in scope, resolve it via the same call the function already uses to locate the agent dir.)
+
+- [ ] **Step 4: Record `content_hash` + `fetch_ref` on the `AddonRef`**
+
+Before the `profile.addons.push(AddonRef { … })` (~line 322), compute the pin over the skills+commands actually being installed:
+
+```rust
+    // Content-hash pin over the installed skill + command manifests.
+    let mut member_hashes: Vec<String> = pending_skills
+        .iter()
+        .map(|(_, m, _)| m)
+        .chain(pending_cmds.iter().map(|(_, m)| m))
+        .filter_map(|m| mur_common::skill::content_hash_for_origin(m).ok())
+        .collect();
+    member_hashes.sort();
+    let content_hash = if member_hashes.is_empty() {
+        None
+    } else {
+        Some(mur_common::skill::sha256_hex(member_hashes.join(",").as_bytes()))
+    };
+```
+Then set the two new fields in the `AddonRef` literal:
+```rust
+        content_hash,
+        fetch_ref: Some(requested.to_string()),
+```
+(`requested` is the original user input already captured at the top of the function: `let requested = plugin_dir;`.)
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `… cargo test -p mur-core import_skips_skill_that_shadows` then `… cargo test -p mur-core --lib cmd::agent::addon` (no regression in existing import tests).
+Expected: PASS. Existing import tests still green (non-colliding bundles unchanged; note existing tests may need the two new `AddonRef` fields if they construct the literal directly — they don't, they read it).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/addon/import.rs
+git commit -m "feat(addon): never-shadow filter + content_hash/fetch_ref pin at import"
+```
+
+---
+
+### Task 3: `mur agent addon reimport` (`mur-core`)
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/addon/mod.rs` (add `cmd_addon_reimport`)
+- Modify: `mur-core/src/cli/actions.rs` (add `AgentAddonAction::Reimport`)
+- Modify: `mur-core/src/dispatch.rs` (add the dispatch arm)
+- Test: `mur-core/src/cmd/agent/addon/mod.rs` tests
+
+**Interfaces:**
+- Consumes: `cmd_addon_import`, `cmd_addon_remove`, `cmd_addon_set_enabled`, `AddonRef.fetch_ref`/`enabled` (Tasks 1-2).
+- Produces: `pub fn cmd_addon_reimport(name: &str, addon_id: &str, source_override: Option<&str>) -> Result<()>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod` in `addon/mod.rs`:
+
+```rust
+#[test]
+fn reimport_replaces_and_preserves_enabled() {
+    // Reuse the import-test scaffolding: temp MUR_HOME, an agent, and a
+    // plugin dir. Import it, then enable it, then reimport.
+    // Assert after reimport:
+    //   - the AddonRef still exists (same id), enabled == true (preserved)
+    //   - content_hash is Some (refreshed)
+    //   - reimport with an unknown id returns Err
+    // (Concrete assertions using the sibling helpers.)
+}
+```
+NOTE to implementer: copy the closest existing addon test's scaffolding; after the first `cmd_addon_import`, call `cmd_addon_set_enabled(agent, id, true)`, then `cmd_addon_reimport(agent, id, None)`, then load the profile and assert the AddonRef's `enabled` and `content_hash`. Add a case asserting `cmd_addon_reimport(agent, "nope", None)` is `Err`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `… cargo test -p mur-core reimport_replaces_and_preserves_enabled`
+Expected: FAIL — `cmd_addon_reimport` not defined.
+
+- [ ] **Step 3: Implement `cmd_addon_reimport`**
+
+Add to `mur-core/src/cmd/agent/addon/mod.rs`:
+
+```rust
+/// Re-fetch an add-on from its recorded `fetch_ref` (or `source_override`),
+/// re-apply it (re-running the never-shadow gate + security scan), and
+/// preserve the prior `enabled` state.
+pub fn cmd_addon_reimport(name: &str, addon_id: &str, source_override: Option<&str>) -> Result<()> {
+    let (_, profile) = crate::cmd::agent::load_profile_for_edit(name)?;
+    let existing = profile
+        .addons
+        .iter()
+        .find(|a| a.id == addon_id)
+        .ok_or_else(|| anyhow::anyhow!("add-on '{addon_id}' not found on '{name}'"))?;
+    let was_enabled = existing.enabled;
+    let fetch = source_override
+        .map(str::to_string)
+        .or_else(|| existing.fetch_ref.clone())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "add-on '{addon_id}' has no recorded fetch source — pass one explicitly"
+            )
+        })?;
+
+    // Remove the old copy, then re-import fresh (records a new fail-closed ref
+    // + content_hash), then restore the prior enabled state.
+    cmd_addon_remove(name, addon_id)?;
+    import::cmd_addon_import(name, &fetch, None, false)?;
+    if was_enabled {
+        cmd_addon_set_enabled(name, addon_id, true)?;
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Wire the CLI + dispatch**
+
+In `mur-core/src/cli/actions.rs`, add to `AgentAddonAction` (mirror `Remove`):
+
+```rust
+    /// Re-fetch and re-apply an add-on from its recorded source
+    Reimport {
+        name: String,
+        addon_id: String,
+        /// Override the fetch source (a path or owner/repo)
+        #[arg(long)]
+        from: Option<String>,
+    },
+```
+
+In `mur-core/src/dispatch.rs`, add to the `AgentAction::Addon { action }` match (after the `Remove` arm ~line 1723):
+
+```rust
+            AgentAddonAction::Reimport { name, addon_id, from } => {
+                cmd::agent::addon::cmd_addon_reimport(&name, &addon_id, from.as_deref())?
+            }
+```
+
+- [ ] **Step 5: Run tests + clippy**
+
+Run:
+```
+… cargo test -p mur-core reimport_replaces_and_preserves_enabled
+… cargo test -p mur-core --lib cmd::agent::addon
+… cargo clippy -p mur-core -- -D warnings
+```
+Expected: tests PASS; clippy clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/addon/mod.rs mur-core/src/cli/actions.rs mur-core/src/dispatch.rs
+git commit -m "feat(addon): mur agent addon reimport (refresh from source, preserve enabled)"
+```
+
+---
+
+## Rollout / usage (post-merge)
+
+`mur agent addon import <agent> owner/repo` now skips any bundled skill whose name collides with a MUR builtin/registry skill (warned), and records a `content_hash` pin + the `fetch_ref`. `mur agent addon list` shows the pin. `mur agent addon reimport <agent> <id>` refreshes from the recorded source (re-running the never-shadow gate), preserving the enable state; pass `--from <source>` for a legacy add-on with no recorded `fetch_ref`.
+
+## Self-Review
+
+**Spec coverage:** §4.1 never-shadow → Task 2 (filter over pending_skills/pending_cmds); §4.2 content_hash pin → Task 1 (field) + Task 2 (compute/record); §4.3 reimport → Task 3; §4.4 origin/TOFU → unchanged (`source` kept; `fetch_ref` added for re-fetch). ✅
+
+**Placeholder scan:** the two test bodies (Task 2 Step 1, Task 3 Step 1) are described-not-coded because they must be built on the sibling import tests' existing scaffolding (temp `MUR_HOME` + plugin dir + agent seed), which differs across the file; the assertions to make are enumerated concretely. This is a deliberate instruction to reuse existing harness, not an unfilled placeholder — every assertion is specified. All non-test code is complete.
+
+**Type consistency:** `AddonRef.content_hash`/`fetch_ref: Option<String>` (Task 1) consumed in Tasks 2-3. `cmd_addon_reimport(name, addon_id, source_override)` defined in Task 3, wired in dispatch with `from.as_deref()`. `content_hash_for_origin`/`sha256_hex`/`list_installed` signatures match the Global Constraints. `AgentAddonAction::Reimport` variant matches the dispatch arm.
+
+**Scope:** three tasks, importer-only. The `ImportAdapter` trait, additional adapters, and store-level enforcement remain out of scope per the spec. `ponytail:` reimport composes existing remove+import+enable rather than a bespoke refresh path; `fetch_ref` is one small field rather than a general source-resolver abstraction.

--- a/docs/superpowers/specs/2026-07-22-mur-pack-s4-import-governance-design.md
+++ b/docs/superpowers/specs/2026-07-22-mur-pack-s4-import-governance-design.md
@@ -1,0 +1,63 @@
+# MUR Pack S4 — Import Governance — Design
+
+**Status:** Design / spec (S4 of the Pack governance program)
+**Date:** 2026-07-22
+**Builds on:** the Pack governance north-star (`2026-07-22-mur-pack-governance-design.md`, §6 import adapters), S1 (#742, never-shadow + de-pin), the existing Claude-plugin importer (`mur-core/src/cmd/agent/addon/{import,mod,parse,marketplace}.rs`), `AddonRef` (`mur-common/src/agent.rs:405`), and the skill provenance/hash model (`mur_common::skill::content_hash_for_origin`).
+
+## 1. Goal
+
+Bring the existing Claude-plugin importer under the Pack governance model — **without shadowing** builtin/registry skills, with a **pinned content hash**, and an explicit **re-import** refresh — the concrete gaps the current importer has. Lean: enhance the one importer we have; defer the general `ImportAdapter` trait until a second source exists (extracting an interface for one implementation is speculative structure).
+
+## 2. Context — what the importer does and lacks
+
+`mur agent addon import <agent> <source>` fetches a Claude plugin (local dir or `owner/repo` git shorthand → network install), security-scans it, and installs its `skills/` + `commands/` + `.mcp.json` into the agent as per-agent skill dirs + `McpServerEntry`s, recorded under one **fail-closed (disabled)** `AddonRef { id, source, enabled, skills, mcp, commands }`. Existing subcommands: `import`, `list`, `set_enabled` (enable/disable), `remove`, `disable_all`.
+
+Gaps against the governance model:
+- **Shadowing:** imported skills are written to the agent-local `skills/<name>/` dir with **no collision check** against builtin/global skills. This is exactly the S1 drift bug for imports — an imported skill named like a builtin silently shadows it via `load_all`.
+- **No content-hash pin:** `AddonRef` records free-text `source` but no hash, so on-disk drift is undetectable and there is no clean "refresh from source."
+- **No re-import:** there is no `reimport`; updating means `remove` + `import` by hand.
+
+## 3. Decisions (settled during brainstorm)
+
+| Question | Decision |
+|---|---|
+| Scope | **Import governance only** — enhance the existing importer; no `ImportAdapter` trait yet (one implementation). |
+| Collision behavior | **Skip the colliding skill + warn**, import the rest. Not "refuse the whole import" (too harsh) and not "rename" (creates a divergent duplicate). The agent uses MUR's builtin/registry copy via store-wide injection. |
+| Collision set | `mur_common::skill::local::list_installed(mur_home)` — the global store (builtins after sync + registry-installed). |
+| Pin | `AddonRef.content_hash: Option<String>` — a stable hash over the imported skill+command manifests, recorded at import. |
+| Refresh | New `mur agent addon reimport <agent> <id>` — re-fetch from `source`, re-scan + re-apply never-shadow, refresh the AddonRef + hash (consent-gated). |
+| Trust | Unchanged: imported content installs **fail-closed disabled** (existing), low trust; `source` is the free-text provenance/TOFU record. No new trust store. |
+
+## 4. Design
+
+### 4.1 Never-shadow at import (`addon/import.rs`)
+The importer builds a list of pending skills (`(dest_path, manifest)`) before writing them (import.rs ~182-320). Insert a governance gate over that list:
+- For each pending skill, if its name is in `list_installed(mur_home)` (the global store), **do not write it**; emit a warning (`skill '<name>' is already provided by MUR — skipping the plugin's copy to avoid shadowing`), and exclude it from the `AddonRef.skills` list.
+- Non-colliding skills install as today. Commands and MCP entries are unchanged (MCP already bails on a duplicate server name).
+- Net effect: an imported plugin never overwrites or shadows a MUR-shipped skill; the agent keeps using the builtin/registry version.
+
+### 4.2 `content_hash` pin (`mur-common/src/agent.rs` + `addon/import.rs`)
+- Add `AddonRef.content_hash: Option<String>` (`#[serde(default, skip_serializing_if = "Option::is_none")]`, back-compat).
+- Compute it at import as a deterministic hash over the installed skill + command manifests (e.g. sort by name, hash each via the existing skill content hash, fold into one SHA-256). Recorded on the `AddonRef`.
+- `mur agent addon list` shows the short hash so the user can see the pin. (Drift detection — comparing on-disk content to the pin — can ride the existing `mur skill doctor` in a later pass; S4 only needs the pin recorded and refreshed.)
+
+### 4.3 `reimport` (`addon/mod.rs` + CLI)
+`mur agent addon reimport <agent> <id>`:
+1. Look up the `AddonRef` by `id`; read its `source`.
+2. Re-fetch from `source` (reuse the import path's network/local resolution), re-run the security scan and §4.1 never-shadow gate.
+3. Replace the addon's on-disk skills/commands/MCP with the freshly-imported set, recompute `content_hash`, update the `AddonRef` in place. Preserve the `enabled` flag (a reimport of an enabled add-on stays enabled; a disabled one stays disabled).
+4. Consent-gated like `import` (the existing confirm/scan flow).
+
+### 4.4 Origin / TOFU
+No change beyond §4.2: `AddonRef.source` already records where the add-on came from; imported content stays fail-closed disabled (existing), which IS the low-trust default. No new trust store — official/registry trust tiers are their own subsystems.
+
+## 5. Out of scope / deferred
+- The general `ImportAdapter` **trait** and additional adapters (generic pack URL, MCP registry) — extract when a second source is actually built (S5).
+- **Store-level** never-shadow enforcement / reference-counted removal — S1's `mur skill doctor` already detects agent-local shadows post-hoc; §4.1 prevents imports from creating new ones.
+- Signed/verified import provenance beyond the existing security scan.
+
+## 6. Testing
+- **Never-shadow:** importing a plugin whose bundle contains a skill named like a global-store skill skips that skill (not written to the agent dir; absent from `AddonRef.skills`) and warns, while non-colliding skills install; a plugin with no collisions installs unchanged.
+- **content_hash:** an import records a non-empty `content_hash`; two imports of identical bundle content produce the same hash; a changed bundle produces a different hash; absent on a legacy `AddonRef` deserializes to `None`.
+- **reimport:** reimport of an existing add-on re-applies from `source`, preserves the `enabled` flag, refreshes `content_hash`, and re-runs the never-shadow gate (a skill that became a builtin since the first import is now skipped); reimport of an unknown id errors.
+- **Back-compat:** an `AddonRef` without `content_hash` round-trips; existing `import`/`list`/`remove`/`enable` behavior is unchanged for non-colliding bundles.

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -424,6 +424,12 @@ pub struct AddonRef {
     /// `None` on legacy refs. Used by `reimport`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fetch_ref: Option<String>,
+    /// The `--plugin <name>` selector used at import time to pick one plugin
+    /// out of a multi-plugin marketplace `fetch_ref`. `None` when the source
+    /// was a single-plugin dir/repo, or on legacy refs. Used by `reimport` so
+    /// a marketplace add-on can be re-fetched without re-specifying it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fetch_plugin: Option<String>,
 }
 
 /// Display-only publisher metadata captured at install time. None of
@@ -2245,6 +2251,7 @@ mod tool_policy_tests {
             commands: vec!["g_cmd".into()],
             content_hash: None,
             fetch_ref: None,
+            fetch_plugin: None,
         });
 
         // 1. standalone item, no entry anywhere => enabled (back-compat)

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -415,6 +415,15 @@ pub struct AddonRef {
     pub mcp: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub commands: Vec<String>,
+    /// Content-hash pin over the imported skill/command manifests, recorded
+    /// at import. `None` on legacy refs. Enables drift detection + refresh.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_hash: Option<String>,
+    /// The re-fetchable source (the original `import` argument: a local path
+    /// or `owner/repo`), distinct from the free-text provenance `source`.
+    /// `None` on legacy refs. Used by `reimport`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fetch_ref: Option<String>,
 }
 
 /// Display-only publisher metadata captured at install time. None of
@@ -2234,6 +2243,8 @@ mod tool_policy_tests {
             skills: vec!["g_skill".into()],
             mcp: vec!["g_mcp".into()],
             commands: vec!["g_cmd".into()],
+            content_hash: None,
+            fetch_ref: None,
         });
 
         // 1. standalone item, no entry anywhere => enabled (back-compat)
@@ -2274,6 +2285,24 @@ mod tool_policy_tests {
         // clearing the individual deny fully restores g_skill too
         p.set_skill_enabled("g_skill", true);
         assert!(p.skill_enabled("g_skill"));
+    }
+
+    #[test]
+    fn addon_ref_content_hash_and_fetch_ref_default_none_and_round_trip() {
+        // legacy AddonRef (no new fields) → None
+        let legacy = "id: a\nsource: claude-local:a@1\nenabled: false\n";
+        let r: AddonRef = serde_yaml_ng::from_str(legacy).unwrap();
+        assert_eq!(r.content_hash, None);
+        assert_eq!(r.fetch_ref, None);
+
+        // with the new fields → round-trips
+        let full = "id: a\nsource: claude-local:a@1\nenabled: true\ncontent_hash: abc123\nfetch_ref: owner/repo\n";
+        let r2: AddonRef = serde_yaml_ng::from_str(full).unwrap();
+        assert_eq!(r2.content_hash.as_deref(), Some("abc123"));
+        assert_eq!(r2.fetch_ref.as_deref(), Some("owner/repo"));
+        let back = serde_yaml_ng::to_string(&r2).unwrap();
+        let r3: AddonRef = serde_yaml_ng::from_str(&back).unwrap();
+        assert_eq!(r2, r3);
     }
 }
 

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -1028,6 +1028,16 @@ pub enum AgentAddonAction {
         /// Agent name
         name: String,
     },
+    /// Re-fetch and re-apply an add-on from its recorded source
+    Reimport {
+        /// Agent name
+        name: String,
+        /// Add-on id (from `mur agent addon list`)
+        addon_id: String,
+        /// Override the fetch source (a path or owner/repo)
+        #[arg(long)]
+        from: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/mur-core/src/cmd/agent/addon/import.rs
+++ b/mur-core/src/cmd/agent/addon/import.rs
@@ -123,6 +123,7 @@ pub fn cmd_addon_import(
     force: bool,
 ) -> Result<()> {
     let requested = plugin_dir; // original user input, for messages
+    let plugin_selector = plugin; // save before `plugin` is shadowed by the parsed PluginJson below
     let (profile_path, mut profile) = load_profile_for_edit(name)?;
     let mur_home = crate::cmd::resolve_mur_home()?;
     let agent_skills_dir = mur_home.join("agents").join(name).join("skills");
@@ -370,6 +371,7 @@ pub fn cmd_addon_import(
         commands: cmd_members,
         content_hash,
         fetch_ref: Some(requested.to_string()),
+        fetch_plugin: plugin_selector.map(str::to_string),
     });
     save_profile(&profile_path, &mut profile)?;
 

--- a/mur-core/src/cmd/agent/addon/import.rs
+++ b/mur-core/src/cmd/agent/addon/import.rs
@@ -274,6 +274,44 @@ pub fn cmd_addon_import(
         }
     }
 
+    // ── Never-shadow gate: drop skills/commands whose name collides with a
+    // global-store (builtin/registry) skill, so an import can never shadow a
+    // MUR-shipped skill. The agent uses MUR's copy via store-wide injection.
+    let global: std::collections::HashSet<String> =
+        mur_common::skill::local::list_installed(&mur_home)
+            .unwrap_or_default()
+            .into_iter()
+            .collect();
+    let retain_non_shadow = |name: &str| -> bool {
+        if global.contains(name) {
+            eprintln!(
+                "skill '{name}' is already provided by MUR — skipping the plugin's copy to avoid shadowing"
+            );
+            false
+        } else {
+            true
+        }
+    };
+    pending_skills.retain(|(_, m, _)| retain_non_shadow(&m.name));
+    pending_cmds.retain(|(_, m)| retain_non_shadow(&m.name));
+
+    // Content-hash pin over the installed skill + command manifests. Computed
+    // here (before Phase 2 consumes `pending_skills`/`pending_cmds` by value).
+    let mut member_hashes: Vec<String> = pending_skills
+        .iter()
+        .map(|(_, m, _)| m)
+        .chain(pending_cmds.iter().map(|(_, m)| m))
+        .filter_map(|m| mur_common::skill::content_hash_for_origin(m).ok())
+        .collect();
+    member_hashes.sort();
+    let content_hash = if member_hashes.is_empty() {
+        None
+    } else {
+        Some(mur_common::skill::sha256_hex(
+            member_hashes.join(",").as_bytes(),
+        ))
+    };
+
     // ── Phase 2: Commit (writes only after all checks passed) ─────────────────
 
     // 2a. Write skills.
@@ -330,6 +368,8 @@ pub fn cmd_addon_import(
         skills: skill_members,
         mcp: mcp_members,
         commands: cmd_members,
+        content_hash,
+        fetch_ref: Some(requested.to_string()),
     });
     save_profile(&profile_path, &mut profile)?;
 
@@ -816,6 +856,89 @@ mod tests {
         assert_eq!(
             original_content, after_content,
             "skill file was modified despite collision bail"
+        );
+    }
+
+    #[test]
+    fn import_skips_skill_that_shadows_the_global_store() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        unsafe {
+            std::env::set_var("MUR_HOME", home);
+        }
+        write_agent(home, "eve");
+
+        // Seed a global-store skill named "brainstorm" (~/.mur/skills/brainstorm/skill.yaml).
+        let global_skill = mur_common::skill::parse_canonical(
+            r#"
+name: brainstorm
+version: 1.0.0
+publisher: human:t
+description: d
+category: context
+content:
+  abstract: a
+  context: body
+"#,
+        )
+        .unwrap();
+        mur_common::skill::write_to_dir(&home.join("skills").join("brainstorm"), &global_skill)
+            .unwrap();
+
+        // Plugin bundles two skills: "brainstorm" (collides with the global
+        // store) and "unique" (does not).
+        let plugin = home.join("shadow-plugin");
+        fs::create_dir_all(plugin.join("skills/brainstorm")).unwrap();
+        fs::create_dir_all(plugin.join("skills/unique")).unwrap();
+        fs::write(
+            plugin.join("plugin.json"),
+            r#"{"name":"shadow","version":"1.0.0","description":"d","author":"Acme"}"#,
+        )
+        .unwrap();
+        fs::write(
+            plugin.join("skills/brainstorm/SKILL.md"),
+            "---\nname: brainstorm\ndescription: think\n---\nbody\n",
+        )
+        .unwrap();
+        fs::write(
+            plugin.join("skills/unique/SKILL.md"),
+            "---\nname: unique\ndescription: distinct\n---\nbody\n",
+        )
+        .unwrap();
+
+        let plugin_dir_arg = plugin.to_str().unwrap().to_string();
+        cmd_addon_import("eve", &plugin_dir_arg, None, false).unwrap();
+
+        // The colliding skill must never be written under the agent.
+        assert!(
+            !home.join("agents/eve/skills/brainstorm").exists(),
+            "shadowing skill must not be installed for the agent"
+        );
+        // The non-colliding skill must be installed.
+        assert!(
+            home.join("agents/eve/skills/unique").exists(),
+            "non-colliding skill must still be installed"
+        );
+
+        let (_p, eve) = crate::cmd::agent::load_profile_for_edit("eve").unwrap();
+        let g = eve.addons.iter().find(|g| g.id == "shadow").unwrap();
+        assert!(
+            g.skills.contains(&"unique".to_string()),
+            "AddonRef.skills must contain the non-colliding skill"
+        );
+        assert!(
+            !g.skills.contains(&"brainstorm".to_string()),
+            "AddonRef.skills must NOT contain the shadowing skill"
+        );
+        assert!(
+            g.content_hash.as_deref().is_some_and(|h| !h.is_empty()),
+            "content_hash must be Some(non-empty)"
+        );
+        assert_eq!(
+            g.fetch_ref.as_deref(),
+            Some(plugin_dir_arg.as_str()),
+            "fetch_ref must record the original plugin_dir argument"
         );
     }
 }

--- a/mur-core/src/cmd/agent/addon/mod.rs
+++ b/mur-core/src/cmd/agent/addon/mod.rs
@@ -80,6 +80,36 @@ pub fn cmd_addon_remove(name: &str, addon_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Re-fetch an add-on from its recorded `fetch_ref` (or `source_override`),
+/// re-apply it (re-running the never-shadow gate + security scan), and
+/// preserve the prior `enabled` state.
+pub fn cmd_addon_reimport(name: &str, addon_id: &str, source_override: Option<&str>) -> Result<()> {
+    let (_, profile) = crate::cmd::agent::load_profile_for_edit(name)?;
+    let existing = profile
+        .addons
+        .iter()
+        .find(|a| a.id == addon_id)
+        .ok_or_else(|| anyhow::anyhow!("add-on '{addon_id}' not found on '{name}'"))?;
+    let was_enabled = existing.enabled;
+    let fetch = source_override
+        .map(str::to_string)
+        .or_else(|| existing.fetch_ref.clone())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "add-on '{addon_id}' has no recorded fetch source — pass one explicitly"
+            )
+        })?;
+
+    // Remove the old copy, then re-import fresh (records a new fail-closed ref
+    // + content_hash), then restore the prior enabled state.
+    cmd_addon_remove(name, addon_id)?;
+    import::cmd_addon_import(name, &fetch, None, false)?;
+    if was_enabled {
+        cmd_addon_set_enabled(name, addon_id, true)?;
+    }
+    Ok(())
+}
+
 pub fn cmd_addon_disable_all(name: &str) -> Result<()> {
     let (path, mut profile) = load_profile_for_edit(name)?;
     profile.disable_all_addons();
@@ -336,6 +366,55 @@ mod tests {
         }
         write_agent(home, "noop");
         let err = cmd_addon_set_enabled("noop", "nonexistent", true)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not found"));
+    }
+
+    #[test]
+    fn reimport_replaces_and_preserves_enabled() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        unsafe {
+            std::env::set_var("MUR_HOME", home);
+        }
+        write_agent(home, "reimp");
+
+        // A minimal plugin dir: plugin.json + one skill, so import() records
+        // a non-empty content_hash.
+        let plugin = home.join("myplugin-src");
+        fs::create_dir_all(plugin.join("skills/mytool")).unwrap();
+        fs::write(
+            plugin.join("plugin.json"),
+            r#"{"name":"myplugin","version":"1.0.0","description":"d","author":"Acme"}"#,
+        )
+        .unwrap();
+        fs::write(
+            plugin.join("skills/mytool/SKILL.md"),
+            "---\nname: mytool\ndescription: does a thing\n---\nbody\n",
+        )
+        .unwrap();
+
+        let src = plugin.to_str().unwrap();
+        import::cmd_addon_import("reimp", src, None, false).unwrap();
+        cmd_addon_set_enabled("reimp", "myplugin", true).unwrap();
+
+        cmd_addon_reimport("reimp", "myplugin", None).unwrap();
+
+        let (_p, profile) = crate::cmd::agent::load_profile_for_edit("reimp").unwrap();
+        let g = profile
+            .addons
+            .iter()
+            .find(|g| g.id == "myplugin")
+            .expect("addon must still exist after reimport");
+        assert!(g.enabled, "enabled state must be preserved across reimport");
+        assert!(
+            g.content_hash.as_deref().is_some_and(|h| !h.is_empty()),
+            "content_hash must be refreshed (Some) after reimport"
+        );
+
+        let err = cmd_addon_reimport("reimp", "nope", None)
             .unwrap_err()
             .to_string();
         assert!(err.contains("not found"));

--- a/mur-core/src/cmd/agent/addon/mod.rs
+++ b/mur-core/src/cmd/agent/addon/mod.rs
@@ -5,8 +5,9 @@ pub mod marketplace;
 pub mod parse;
 
 use std::fs;
+use std::path::Path;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 
 use crate::cmd::agent::{load_profile_for_edit, save_profile};
 use crate::conversations::audit::{Audit, AuditAction};
@@ -83,6 +84,13 @@ pub fn cmd_addon_remove(name: &str, addon_id: &str) -> Result<()> {
 /// Re-fetch an add-on from its recorded `fetch_ref` (or `source_override`),
 /// re-apply it (re-running the never-shadow gate + security scan), and
 /// preserve the prior `enabled` state.
+///
+/// Non-destructive: the old skill dirs + `AddonRef` (+ its MCP entries) are
+/// backed up before the old copy is removed. If the re-import fails for any
+/// reason (network flake, source gone, never-shadow filter drops every
+/// member, security scan block, marketplace ambiguity), the backup is
+/// restored so the agent ends up exactly as it was before the reimport was
+/// attempted — never with neither the old copy nor the new one.
 pub fn cmd_addon_reimport(name: &str, addon_id: &str, source_override: Option<&str>) -> Result<()> {
     let (_, profile) = crate::cmd::agent::load_profile_for_edit(name)?;
     let existing = profile
@@ -90,22 +98,130 @@ pub fn cmd_addon_reimport(name: &str, addon_id: &str, source_override: Option<&s
         .iter()
         .find(|a| a.id == addon_id)
         .ok_or_else(|| anyhow::anyhow!("add-on '{addon_id}' not found on '{name}'"))?;
-    let was_enabled = existing.enabled;
+    let old_ref = existing.clone();
+    let was_enabled = old_ref.enabled;
     let fetch = source_override
         .map(str::to_string)
-        .or_else(|| existing.fetch_ref.clone())
+        .or_else(|| old_ref.fetch_ref.clone())
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "add-on '{addon_id}' has no recorded fetch source — pass one explicitly"
             )
         })?;
+    // The marketplace `--plugin <name>` selector recorded at the original
+    // import, if any (Bug A) — without this a marketplace source bails
+    // "specify --plugin" on reimport, after the old copy is already gone.
+    let fetch_plugin = old_ref.fetch_plugin.clone();
+    let old_mcp_entries: Vec<mur_common::agent::McpServerEntry> = profile
+        .mcp_servers
+        .iter()
+        .filter(|m| old_ref.mcp.contains(&m.name))
+        .cloned()
+        .collect();
+
+    let mur_home = crate::cmd::resolve_mur_home()?;
+    let agent_skills_dir = mur_home.join("agents").join(name).join("skills");
+    let backup_root = mur_home.join("agents").join(name).join(format!(
+        ".reimport-backup-{addon_id}-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let member_names: Vec<String> = old_ref
+        .skills
+        .iter()
+        .chain(old_ref.commands.iter())
+        .cloned()
+        .collect();
+
+    for member in &member_names {
+        let src = agent_skills_dir.join(member);
+        if src.exists() {
+            copy_dir_all(&src, &backup_root.join(member)).map_err(|e| {
+                anyhow::anyhow!("back up skill dir '{member}' before reimport: {e}")
+            })?;
+        }
+    }
 
     // Remove the old copy, then re-import fresh (records a new fail-closed ref
-    // + content_hash), then restore the prior enabled state.
+    // + content_hash).
     cmd_addon_remove(name, addon_id)?;
-    import::cmd_addon_import(name, &fetch, None, false)?;
-    if was_enabled {
-        cmd_addon_set_enabled(name, addon_id, true)?;
+    let import_result = import::cmd_addon_import(name, &fetch, fetch_plugin.as_deref(), false);
+
+    match import_result {
+        Ok(()) => {
+            let _ = fs::remove_dir_all(&backup_root);
+            if was_enabled {
+                cmd_addon_set_enabled(name, addon_id, true)?;
+            }
+            Ok(())
+        }
+        Err(e) => {
+            // Restore: copy the backed-up skill dirs back, then re-add the
+            // old AddonRef + its MCP entries so the profile matches what it
+            // was before this reimport attempt. Best-effort — a restore
+            // failure is reported alongside the original error rather than
+            // silently swallowed, but the original error always wins as the
+            // returned cause.
+            let mut restore_errs = Vec::new();
+            for member in &member_names {
+                let backup_src = backup_root.join(member);
+                if backup_src.exists()
+                    && let Err(re) = copy_dir_all(&backup_src, &agent_skills_dir.join(member))
+                {
+                    restore_errs.push(format!("restore skill dir '{member}': {re}"));
+                }
+            }
+            match load_profile_for_edit(name) {
+                Ok((path, mut profile)) => {
+                    if !profile.addons.iter().any(|a| a.id == addon_id) {
+                        profile.addons.push(old_ref.clone());
+                    }
+                    for m in &old_mcp_entries {
+                        if !profile.mcp_servers.iter().any(|e| e.name == m.name) {
+                            profile.mcp_servers.push(m.clone());
+                        }
+                    }
+                    if let Err(se) = save_profile(&path, &mut profile) {
+                        restore_errs.push(format!("restore add-on record: {se}"));
+                    }
+                }
+                Err(le) => restore_errs.push(format!("reload profile for restore: {le}")),
+            }
+            let _ = fs::remove_dir_all(&backup_root);
+            if restore_errs.is_empty() {
+                Err(e.context(format!(
+                    "reimport of '{addon_id}' failed; original add-on was restored"
+                )))
+            } else {
+                Err(e.context(format!(
+                    "reimport of '{addon_id}' failed AND restore encountered errors ({}); \
+                     the agent may be left inconsistent — check '{addon_id}' manually",
+                    restore_errs.join("; ")
+                )))
+            }
+        }
+    }
+}
+
+/// Recursively copy an entire directory tree from `src` to `dest`, creating
+/// `dest` (and parents) as needed. Used to back up / restore an add-on's
+/// skill dirs around a reimport. Unlike `import::copy_bundle` this does NOT
+/// skip `SKILL.md` — a backup must round-trip byte-for-byte. Symlinks are
+/// skipped rather than followed/copied (backups are of our own
+/// already-validated on-disk content, which shouldn't contain any).
+fn copy_dir_all(src: &Path, dest: &Path) -> Result<()> {
+    fs::create_dir_all(dest).with_context(|| format!("create backup dir {}", dest.display()))?;
+    for entry in fs::read_dir(src).with_context(|| format!("read dir {}", src.display()))? {
+        let entry = entry?;
+        let ft = entry.file_type()?;
+        let src_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        if ft.is_dir() {
+            copy_dir_all(&src_path, &dest_path)?;
+        } else if ft.is_file() {
+            fs::copy(&src_path, &dest_path).with_context(|| {
+                format!("copy {} -> {}", src_path.display(), dest_path.display())
+            })?;
+        }
     }
     Ok(())
 }
@@ -184,6 +300,7 @@ mod tests {
             commands: Vec::new(),
             content_hash: None,
             fetch_ref: None,
+            fetch_plugin: None,
         });
 
         // Add a stub MCP entry for each mcp_name.
@@ -289,6 +406,7 @@ mod tests {
             commands: vec!["cmd-review".to_string()],
             content_hash: None,
             fetch_ref: None,
+            fetch_plugin: None,
         });
         let new_yaml = serde_yaml_ng::to_string(&profile).unwrap();
         fs::write(&profile_path, new_yaml).unwrap();
@@ -418,5 +536,158 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("not found"));
+    }
+
+    /// Bug A: the marketplace `--plugin <name>` selector used at import time
+    /// must be recorded on the `AddonRef` and replayed on reimport — without
+    /// it, `resolve_marketplace` bails "specify --plugin" on reimport, after
+    /// `cmd_addon_remove` has already deleted the old copy.
+    #[test]
+    fn reimport_marketplace_uses_stored_plugin_selector() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        unsafe {
+            std::env::set_var("MUR_HOME", home);
+        }
+        write_agent(home, "mkt");
+
+        // A minimal marketplace indexing one plugin by relative path.
+        let market = home.join("market-src");
+        fs::create_dir_all(market.join(".claude-plugin")).unwrap();
+        fs::write(
+            market.join(".claude-plugin/marketplace.json"),
+            r#"{"plugins":[{"name":"mytool","description":"d","source":"./plugins/mytool"}]}"#,
+        )
+        .unwrap();
+        fs::create_dir_all(market.join("plugins/mytool/skills/mytool")).unwrap();
+        fs::write(
+            market.join("plugins/mytool/plugin.json"),
+            r#"{"name":"mytool","version":"1.0.0","description":"d","author":"Acme"}"#,
+        )
+        .unwrap();
+        fs::write(
+            market.join("plugins/mytool/skills/mytool/SKILL.md"),
+            "---\nname: mytool\ndescription: does a thing\n---\nbody\n",
+        )
+        .unwrap();
+
+        let src = market.to_str().unwrap();
+        import::cmd_addon_import("mkt", src, Some("mytool"), false).unwrap();
+
+        // The selector must be recorded on the ref (independent of reimport
+        // working — this is the minimum bar even if the marketplace layout
+        // above turns out to need adjusting).
+        let (_p, profile) = crate::cmd::agent::load_profile_for_edit("mkt").unwrap();
+        let g = profile
+            .addons
+            .iter()
+            .find(|g| g.id == "mytool")
+            .expect("addon must be present after import");
+        assert_eq!(
+            g.fetch_plugin.as_deref(),
+            Some("mytool"),
+            "fetch_plugin must record the --plugin selector used at import"
+        );
+        assert_eq!(g.fetch_ref.as_deref(), Some(src));
+        drop(profile);
+
+        // Reimport with NO explicit plugin selector must still succeed by
+        // replaying the stored one.
+        cmd_addon_reimport("mkt", "mytool", None)
+            .expect("reimport must succeed using the stored fetch_plugin selector");
+
+        let (_p2, profile2) = crate::cmd::agent::load_profile_for_edit("mkt").unwrap();
+        assert!(
+            profile2.addons.iter().any(|g| g.id == "mytool"),
+            "addon must still exist after marketplace reimport"
+        );
+    }
+
+    /// Bug B: a reimport that fails partway (here: the recorded fetch source
+    /// no longer resolving) must leave the original add-on fully intact —
+    /// both its on-disk skill dirs and its `AddonRef` (with `enabled`
+    /// unchanged) — never neither-old-nor-new.
+    #[test]
+    fn reimport_restores_addon_on_import_failure() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        unsafe {
+            std::env::set_var("MUR_HOME", home);
+        }
+        write_agent(home, "restoreme");
+
+        let plugin = home.join("myplugin2-src");
+        fs::create_dir_all(plugin.join("skills/mytool2")).unwrap();
+        fs::write(
+            plugin.join("plugin.json"),
+            r#"{"name":"myplugin2","version":"1.0.0","description":"d","author":"Acme"}"#,
+        )
+        .unwrap();
+        fs::write(
+            plugin.join("skills/mytool2/SKILL.md"),
+            "---\nname: mytool2\ndescription: does a thing\n---\nbody\n",
+        )
+        .unwrap();
+
+        let src = plugin.to_str().unwrap();
+        import::cmd_addon_import("restoreme", src, None, false).unwrap();
+        cmd_addon_set_enabled("restoreme", "myplugin2", true).unwrap();
+
+        let (_p, profile_before) = crate::cmd::agent::load_profile_for_edit("restoreme").unwrap();
+        let before = profile_before
+            .addons
+            .iter()
+            .find(|g| g.id == "myplugin2")
+            .cloned()
+            .expect("addon must exist before reimport");
+        assert!(before.enabled);
+        drop(profile_before);
+
+        let skills_dir = home.join("agents/restoreme/skills");
+        for member in before.skills.iter().chain(before.commands.iter()) {
+            assert!(
+                skills_dir.join(member).exists(),
+                "precondition: skill dir '{member}' must exist before reimport"
+            );
+        }
+
+        // Point reimport at a source that cannot possibly resolve, forcing
+        // the import half of reimport to fail after the old copy is removed.
+        let err = cmd_addon_reimport(
+            "restoreme",
+            "myplugin2",
+            Some("/nonexistent/does-not-exist"),
+        )
+        .expect_err("reimport must fail when the source cannot be resolved");
+        assert!(
+            err.to_string().contains("myplugin2")
+                || err.chain().any(|c| c.to_string().contains("myplugin2")),
+            "error should mention the addon being restored: {err:#}"
+        );
+
+        // The original add-on must be restored: same AddonRef (enabled
+        // unchanged) and its skill dirs back on disk.
+        let (_p2, profile_after) = crate::cmd::agent::load_profile_for_edit("restoreme").unwrap();
+        let after = profile_after
+            .addons
+            .iter()
+            .find(|g| g.id == "myplugin2")
+            .expect("addon must still be present after a failed reimport (restored)");
+        assert_eq!(
+            after.enabled, before.enabled,
+            "enabled state must be unchanged"
+        );
+        assert_eq!(after.skills, before.skills);
+        assert_eq!(after.commands, before.commands);
+        assert_eq!(after.fetch_ref, before.fetch_ref);
+
+        for member in before.skills.iter().chain(before.commands.iter()) {
+            assert!(
+                skills_dir.join(member).exists(),
+                "skill dir '{member}' must be restored on disk after a failed reimport"
+            );
+        }
     }
 }

--- a/mur-core/src/cmd/agent/addon/mod.rs
+++ b/mur-core/src/cmd/agent/addon/mod.rs
@@ -152,6 +152,8 @@ mod tests {
             skills: skill_names.iter().map(|s| s.to_string()).collect(),
             mcp: mcp_names.iter().map(|s| s.to_string()).collect(),
             commands: Vec::new(),
+            content_hash: None,
+            fetch_ref: None,
         });
 
         // Add a stub MCP entry for each mcp_name.
@@ -255,6 +257,8 @@ mod tests {
             skills: vec!["skill-a".to_string()],
             mcp: Vec::new(),
             commands: vec!["cmd-review".to_string()],
+            content_hash: None,
+            fetch_ref: None,
         });
         let new_yaml = serde_yaml_ng::to_string(&profile).unwrap();
         fs::write(&profile_path, new_yaml).unwrap();

--- a/mur-core/src/cmd/agent/addon/mod.rs
+++ b/mur-core/src/cmd/agent/addon/mod.rs
@@ -86,11 +86,16 @@ pub fn cmd_addon_remove(name: &str, addon_id: &str) -> Result<()> {
 /// preserve the prior `enabled` state.
 ///
 /// Non-destructive: the old skill dirs + `AddonRef` (+ its MCP entries) are
-/// backed up before the old copy is removed. If the re-import fails for any
-/// reason (network flake, source gone, never-shadow filter drops every
-/// member, security scan block, marketplace ambiguity), the backup is
-/// restored so the agent ends up exactly as it was before the reimport was
-/// attempted — never with neither the old copy nor the new one.
+/// backed up before the old copy is removed. If either the removal step
+/// itself fails (e.g. its `save_profile` after skill dirs are already
+/// deleted) or the re-import fails for any reason (network flake, source
+/// gone, never-shadow filter drops every member, security scan block,
+/// marketplace ambiguity), the backup is restored so the agent ends up
+/// exactly as it was before the reimport was attempted — never with neither
+/// the old copy nor the new one. The backup is left on disk (and its path
+/// surfaced in the returned error) on every failure path as a manual-recovery
+/// fallback in case restore itself also fails; it is only deleted on full
+/// success.
 pub fn cmd_addon_reimport(name: &str, addon_id: &str, source_override: Option<&str>) -> Result<()> {
     let (_, profile) = crate::cmd::agent::load_profile_for_edit(name)?;
     let existing = profile
@@ -141,9 +146,70 @@ pub fn cmd_addon_reimport(name: &str, addon_id: &str, source_override: Option<&s
         }
     }
 
+    // Shared restore path: copy the backed-up skill dirs back, then re-add
+    // the old AddonRef + its MCP entries so the profile matches what it was
+    // before this reimport attempt. Best-effort — a restore failure is
+    // reported alongside the original error rather than silently swallowed,
+    // but the original error always wins as the returned cause. Invoked from
+    // BOTH possible failure points below (the `cmd_addon_remove` step and the
+    // `cmd_addon_import` step) so a remove-step failure — e.g. the removal's
+    // own `save_profile` failing after skill dirs were already deleted — is
+    // restored exactly like an import failure, instead of bypassing restore
+    // via a bare `?`. The backup at `backup_root` is deliberately left on
+    // disk on every error path (only the full-success path below cleans it
+    // up), and its path is always surfaced in the returned error context so
+    // the user has a manual-recovery fallback if restore itself also fails
+    // (e.g. persistent disk-full).
+    let restore = |original_err: anyhow::Error| -> anyhow::Error {
+        let mut restore_errs = Vec::new();
+        for member in &member_names {
+            let backup_src = backup_root.join(member);
+            if backup_src.exists()
+                && let Err(re) = copy_dir_all(&backup_src, &agent_skills_dir.join(member))
+            {
+                restore_errs.push(format!("restore skill dir '{member}': {re}"));
+            }
+        }
+        match load_profile_for_edit(name) {
+            Ok((path, mut profile)) => {
+                if !profile.addons.iter().any(|a| a.id == addon_id) {
+                    profile.addons.push(old_ref.clone());
+                }
+                for m in &old_mcp_entries {
+                    if !profile.mcp_servers.iter().any(|e| e.name == m.name) {
+                        profile.mcp_servers.push(m.clone());
+                    }
+                }
+                if let Err(se) = save_profile(&path, &mut profile) {
+                    restore_errs.push(format!("restore add-on record: {se}"));
+                }
+            }
+            Err(le) => restore_errs.push(format!("reload profile for restore: {le}")),
+        }
+        if restore_errs.is_empty() {
+            original_err.context(format!(
+                "reimport of '{addon_id}' failed; original add-on was restored (backup was at {})",
+                backup_root.display()
+            ))
+        } else {
+            original_err.context(format!(
+                "reimport of '{addon_id}' failed AND restore encountered errors ({}); \
+                 the agent may be left inconsistent — a backup of the previous add-on is \
+                 at {}; check '{addon_id}' manually",
+                restore_errs.join("; "),
+                backup_root.display()
+            ))
+        }
+    };
+
     // Remove the old copy, then re-import fresh (records a new fail-closed ref
-    // + content_hash).
-    cmd_addon_remove(name, addon_id)?;
+    // + content_hash). A failure of the remove step itself (e.g. its
+    // `save_profile` after skill dirs are already gone) is restored via the
+    // same tested path as an import failure below — see
+    // `reimport_restores_addon_on_import_failure`.
+    if let Err(e) = cmd_addon_remove(name, addon_id) {
+        return Err(restore(e));
+    }
     let import_result = import::cmd_addon_import(name, &fetch, fetch_plugin.as_deref(), false);
 
     match import_result {
@@ -154,51 +220,7 @@ pub fn cmd_addon_reimport(name: &str, addon_id: &str, source_override: Option<&s
             }
             Ok(())
         }
-        Err(e) => {
-            // Restore: copy the backed-up skill dirs back, then re-add the
-            // old AddonRef + its MCP entries so the profile matches what it
-            // was before this reimport attempt. Best-effort — a restore
-            // failure is reported alongside the original error rather than
-            // silently swallowed, but the original error always wins as the
-            // returned cause.
-            let mut restore_errs = Vec::new();
-            for member in &member_names {
-                let backup_src = backup_root.join(member);
-                if backup_src.exists()
-                    && let Err(re) = copy_dir_all(&backup_src, &agent_skills_dir.join(member))
-                {
-                    restore_errs.push(format!("restore skill dir '{member}': {re}"));
-                }
-            }
-            match load_profile_for_edit(name) {
-                Ok((path, mut profile)) => {
-                    if !profile.addons.iter().any(|a| a.id == addon_id) {
-                        profile.addons.push(old_ref.clone());
-                    }
-                    for m in &old_mcp_entries {
-                        if !profile.mcp_servers.iter().any(|e| e.name == m.name) {
-                            profile.mcp_servers.push(m.clone());
-                        }
-                    }
-                    if let Err(se) = save_profile(&path, &mut profile) {
-                        restore_errs.push(format!("restore add-on record: {se}"));
-                    }
-                }
-                Err(le) => restore_errs.push(format!("reload profile for restore: {le}")),
-            }
-            let _ = fs::remove_dir_all(&backup_root);
-            if restore_errs.is_empty() {
-                Err(e.context(format!(
-                    "reimport of '{addon_id}' failed; original add-on was restored"
-                )))
-            } else {
-                Err(e.context(format!(
-                    "reimport of '{addon_id}' failed AND restore encountered errors ({}); \
-                     the agent may be left inconsistent — check '{addon_id}' manually",
-                    restore_errs.join("; ")
-                )))
-            }
-        }
+        Err(e) => Err(restore(e)),
     }
 }
 

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1726,6 +1726,11 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             AgentAddonAction::DisableAll { name } => {
                 cmd::agent::addon::cmd_addon_disable_all(&name)?
             }
+            AgentAddonAction::Reimport {
+                name,
+                addon_id,
+                from,
+            } => cmd::agent::addon::cmd_addon_reimport(&name, &addon_id, from.as_deref())?,
         },
         AgentAction::Perm { action } => match action {
             AgentPermAction::Show { name, section } => {


### PR DESCRIPTION
S4 of the [MUR Pack governance program](../blob/main/docs/superpowers/specs/2026-07-22-mur-pack-governance-design.md). Spec: `docs/superpowers/specs/2026-07-22-mur-pack-s4-import-governance-design.md`.

## What
Brings the Claude-plugin importer under Pack governance. Lean — enhances the existing importer; no `ImportAdapter` trait yet (one source).

- **Never-shadow at import** — a skill whose name collides with the global store (`list_installed`: builtins + registry) is skipped (warned), not written; the agent uses MUR's copy via store-wide injection. Prevents imports from creating the S1 shadow bug.
- **content_hash pin** — `AddonRef.content_hash` (sorted fold of `content_hash_for_origin` over the installed set), recorded at import.
- **`fetch_ref` + `fetch_plugin`** — the re-fetchable source and the `--plugin` selector, captured at import (distinct from the provenance `source`).
- **`mur agent addon reimport <agent> <id> [--from]`** — re-fetch from the recorded source (re-running the never-shadow gate), preserving `enabled`. **Atomic-on-failure:** the previous add-on is backed up before removal and restored if the re-import (or the remove step) fails, so a bad source never leaves the agent empty; the backup path is surfaced in the error for manual recovery.

## Accepted contract (per spec §4.1)
The pre-sync race — an import before the first `mur sync` of a release can miss a not-yet-synced builtin — is accepted: S1's `mur skill doctor` detects the shadow post-hoc, and a subsequent `reimport` re-runs the gate and removes it.

## Review
Subagent-driven, 3 tasks each spec+quality reviewed; opus whole-branch review found two Important reimport bugs (marketplace `--plugin` selector lost → guaranteed destroy-then-fail; destructive-first non-atomic) — **both fixed + re-reviewed in-branch** (`fetch_plugin` capture + shared restore-on-failure covering both the import and remove steps). 30 addon tests green (incl. marketplace-reimport + restore-on-failure); `clippy -D warnings` + `fmt` clean.

### Follow-ups (non-blocking)
- `mur agent addon list` should surface the short `content_hash` pin.
- restore doesn't pre-clear the destination dir (only matters under a Phase-2 I/O failure, not the designed failure modes).
- reimport enabled-restore keys off the old id (edge case if a `--from` plugin's manifest name differs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)