### PR TITLE
fix(hub): add S4 AddonRef fields to Hub test literals

### DIFF
--- a/mur-hub-gui/src-tauri/src/detail.rs
+++ b/mur-hub-gui/src-tauri/src/detail.rs
@@ -425,6 +425,9 @@ mod addon_detail_tests {
             skills: vec!["g_skill".into()],
             mcp: vec![],
             commands: vec![],
+            content_hash: None,
+            fetch_ref: None,
+            fetch_plugin: None,
         });
 
         let detail = build_agent_detail(p, None);

--- a/mur-hub-gui/src-tauri/src/mcp_skills.rs
+++ b/mur-hub-gui/src-tauri/src/mcp_skills.rs
@@ -749,6 +749,9 @@ mod tests {
             skills: vec!["s1".to_string()],
             mcp: vec!["m1".to_string(), "m2".to_string()],
             commands: vec![],
+            content_hash: None,
+            fetch_ref: None,
+            fetch_plugin: None,
         }
     }
 


### PR DESCRIPTION
S4 (#744) added `content_hash`/`fetch_ref`/`fetch_plugin` to `AddonRef`. Two test literals in `mur-hub-gui` (workspace-EXCLUDED — not compiled by `cargo test -p mur-core/mur-common`) construct `AddonRef` without `..Default`, so the Hub GUI CI job failed on all platforms (`missing fields`). Adds the three `None` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)