### PR TITLE
fix(pack): capability pin-preserve + media self-heal + addon list pin

### DIFF
--- a/mur-agent-runtime/src/protocol/mcp_client.rs
+++ b/mur-agent-runtime/src/protocol/mcp_client.rs
@@ -207,7 +207,20 @@ impl StdioMcpClient {
         policy: &SandboxPolicy,
         proxy: Option<&crate::sandbox::egress_proxy::EgressProxyHandle>,
     ) -> Result<Self, McpError> {
-        let mut std_cmd = std::process::Command::new(&entry.command);
+        // Resolve a bare `mur-mcp-server` command to the bundled absolute path
+        // (ensured under ~/.mur/mcp-servers by the supervisor's self-heal) so it
+        // launches on installs where only `mur` is on PATH. Falls back to the
+        // command as-written when there is no bundled copy to point at.
+        let bundled = mur_common::exec::bundled_mcp_server_path();
+        let resolved: std::borrow::Cow<'_, str> =
+            if std::path::Path::new(&entry.command).file_name() == bundled.file_name()
+                && bundled.is_file()
+            {
+                bundled.to_string_lossy().into_owned().into()
+            } else {
+                std::borrow::Cow::Borrowed(entry.command.as_str())
+            };
+        let mut std_cmd = std::process::Command::new(resolved.as_ref());
         std_cmd
             .args(&entry.args)
             .stdin(Stdio::piped())

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -198,11 +198,13 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     //     it entirely, and a failure leaves any existing copy in place.
     {
         let bundled = mur_common::exec::bundled_mcp_server_path();
-        let uses_bundled = profile
-            .inner
-            .enabled_mcp_servers()
-            .iter()
-            .any(|e| std::path::Path::new(&e.command) == bundled);
+        let uses_bundled = profile.inner.enabled_mcp_servers().iter().any(|e| {
+            let c = std::path::Path::new(&e.command);
+            // The command may be the absolute bundled path OR the bare binary
+            // name (`mur-mcp-server`, e.g. from a capability install) — both
+            // resolve to the bundled copy, so both should trigger the refresh.
+            c == bundled || c.file_name() == bundled.file_name()
+        });
         if uses_bundled {
             match mur_common::exec::ensure_bundled_mcp_server() {
                 Ok(p) => info!(path = %p.display(), "ensured bundled mcp-server"),

--- a/mur-core/src/cmd/agent/addon/mod.rs
+++ b/mur-core/src/cmd/agent/addon/mod.rs
@@ -21,14 +21,20 @@ pub fn cmd_addon_list(name: &str) -> Result<()> {
         return Ok(());
     }
     for g in &profile.addons {
+        let pin = g
+            .content_hash
+            .as_deref()
+            .map(|h| format!(" pin:{}", &h[..h.len().min(12)]))
+            .unwrap_or_default();
         println!(
-            "{} {} [{}] (skills:{} mcp:{} commands:{})",
+            "{} {} [{}] (skills:{} mcp:{} commands:{}){}",
             if g.enabled { "on " } else { "off" },
             g.id,
             g.source,
             g.skills.len(),
             g.mcp.len(),
             g.commands.len(),
+            pin,
         );
     }
     Ok(())

--- a/mur-core/src/cmd/capability.rs
+++ b/mur-core/src/cmd/capability.rs
@@ -27,9 +27,25 @@ fn union_extend(dst: &mut Vec<String>, src: &[String]) {
 pub(crate) fn install_capability(home: &Path, agent: &str, cap: &Capability) -> Result<bool> {
     let (path, mut profile) = load(home, agent)?;
     // 1. MCP servers: upsert by name + allow the command to be spawned.
+    //    Preserve a user's pin / security metadata (binary_sha256,
+    //    description_hash, publisher, installed_at — set by `mur agent mcp
+    //    pin`) across a re-install, so re-installing a capability never strips
+    //    a pin the user added.
     for entry in &cap.mcp_servers {
+        let prior = profile
+            .mcp_servers
+            .iter()
+            .find(|s| s.name == entry.name)
+            .cloned();
         profile.mcp_servers.retain(|s| s.name != entry.name);
-        profile.mcp_servers.push(entry.clone());
+        let mut new_entry = entry.clone();
+        if let Some(p) = prior {
+            new_entry.binary_sha256 = new_entry.binary_sha256.or(p.binary_sha256);
+            new_entry.description_hash = new_entry.description_hash.or(p.description_hash);
+            new_entry.publisher = new_entry.publisher.or(p.publisher);
+            new_entry.installed_at = new_entry.installed_at.or(p.installed_at);
+        }
+        profile.mcp_servers.push(new_entry);
         if !profile
             .entitlements
             .processes
@@ -78,12 +94,14 @@ pub(crate) fn install_capability(home: &Path, agent: &str, cap: &Capability) -> 
 pub(crate) fn remove_capability(home: &Path, agent: &str, cap: &Capability) -> Result<bool> {
     let (path, mut profile) = load(home, agent)?;
     // Remove only an MCP server that STILL matches the capability's definition
-    // (install materialized a clone, so an unmodified entry compares equal). A
-    // same-named entry the user has since modified is left in place + warned,
-    // so `remove` never clobbers a user's edits.
+    // by SEMANTIC identity (command/args/network/…, ignoring pin metadata — see
+    // `mcp_semantically_matches`). A same-named entry the user has modified is
+    // left in place + warned, so `remove` never clobbers a user's edits.
     for def in &cap.mcp_servers {
         let before = profile.mcp_servers.len();
-        profile.mcp_servers.retain(|s| s != def);
+        profile
+            .mcp_servers
+            .retain(|s| !mcp_semantically_matches(s, def));
         if profile.mcp_servers.len() == before
             && profile.mcp_servers.iter().any(|s| s.name == def.name)
         {
@@ -96,6 +114,26 @@ pub(crate) fn remove_capability(home: &Path, agent: &str, cap: &Capability) -> R
     profile.requires_capabilities.retain(|c| c != &cap.name);
     crate::cmd::agent::save_profile(&path, &mut profile)?;
     Ok(true)
+}
+
+/// Whether an installed MCP entry still matches the capability's definition by
+/// its SEMANTIC identity — name/command/args/network/timeout/url/auth/programs.
+/// Ignores install/security metadata (`binary_sha256`, `description_hash`,
+/// `publisher`, `installed_at`) that `mur agent mcp pin` sets, so a pinned but
+/// otherwise-unmodified entry is still removable, while a real edit to what the
+/// server IS (command/args/network/…) is treated as user-modified and kept.
+fn mcp_semantically_matches(
+    entry: &mur_common::agent::McpServerEntry,
+    def: &mur_common::agent::McpServerEntry,
+) -> bool {
+    entry.name == def.name
+        && entry.command == def.command
+        && entry.args == def.args
+        && entry.network == def.network
+        && entry.timeout_secs == def.timeout_secs
+        && entry.url == def.url
+        && entry.auth == def.auth
+        && entry.requires_programs == def.requires_programs
 }
 
 /// `mur capability list [--agent X]`
@@ -332,5 +370,49 @@ updated_at: \"2026-04-22T10:00:00+08:00\"
         );
         // …but requires_capabilities is still dropped.
         assert!(!p2.requires_capabilities.iter().any(|c| c == "media"));
+    }
+
+    #[test]
+    fn reinstall_preserves_pin_and_remove_still_removes_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        seed_agent(home, "a");
+        install_capability(home, "a", &media()).unwrap();
+
+        // User pins the media MCP binary (sets binary_sha256); semantics unchanged.
+        let path = home.join("agents/a/profile.yaml");
+        let mut p: _AgentProfile =
+            serde_yaml_ng::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        p.mcp_servers
+            .iter_mut()
+            .find(|s| s.name == "media")
+            .unwrap()
+            .binary_sha256 = Some("deadbeef".into());
+        crate::cmd::agent::save_profile(&path, &mut p).unwrap();
+
+        // Re-install must NOT strip the pin.
+        install_capability(home, "a", &media()).unwrap();
+        let p2: _AgentProfile =
+            serde_yaml_ng::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            p2.mcp_servers
+                .iter()
+                .find(|s| s.name == "media")
+                .unwrap()
+                .binary_sha256
+                .as_deref(),
+            Some("deadbeef"),
+            "re-install must preserve a user's pin"
+        );
+
+        // Remove: a pinned-but-otherwise-unmodified entry is still removed
+        // (the pin is ignored by the semantic match).
+        remove_capability(home, "a", &media()).unwrap();
+        let p3: _AgentProfile =
+            serde_yaml_ng::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(
+            !p3.mcp_servers.iter().any(|s| s.name == "media"),
+            "a pinned-but-unmodified MCP entry must still be removable"
+        );
     }
 }


### PR DESCRIPTION
Three post-S3/S4 follow-ups flagged by the whole-branch reviews.

- **Capability pin preservation** — `install_capability` now preserves a user's MCP pin (`binary_sha256`) + install metadata across a re-install (was stripped by the upsert). `remove_capability` matches by **semantic identity** (command/args/network/timeout/url/auth/programs), ignoring pin metadata, so a pinned-but-otherwise-unmodified entry is still removable while a real edit is kept + warned.
- **Media self-heal PATH gap** — the runtime resolves a bare `mur-mcp-server` command to the bundled absolute path at spawn (`mcp_client.rs`) and fires the supervisor self-heal on a basename match (`supervisor.rs`), so the media capability's MCP launches on installs where only `mur` is on PATH (previously ENOENT on dev/source setups). Profile command stays bare (portable, compatible with the semantic remove-match).
- **addon list pin** — `mur agent addon list` shows the short `content_hash` pin.

Tests: capability suite 4/4 (incl. new `reinstall_preserves_pin_and_remove_still_removes_it`); `mur-agent-runtime` builds clean; `fmt` + `clippy -D warnings` clean on both crates. No `mur-common` type changes (no Hub-literal risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)