### PR TITLE
feat(skills): dev-discipline follow-ups (spec-writer delegation + review cadence + validate fix)

### DIFF
--- a/docs/ATTRIBUTIONS.md
+++ b/docs/ATTRIBUTIONS.md
@@ -19,7 +19,7 @@ notices are reproduced here as required by the MIT license.
 | mur-worktree | obra/superpowers `using-git-worktrees` |
 | mur-tdd | obra/superpowers `test-driven-development`, `testing-anti-patterns` + mattpocock/skills `tdd` |
 | mur-debugging | mattpocock/skills `diagnosing-bugs` + obra/superpowers `systematic-debugging` |
-| mur-code-review | mattpocock/skills `code-review` + obra/superpowers `code-reviewer` rubric |
+| mur-code-review | mattpocock/skills `code-review` + obra/superpowers `code-reviewer` rubric, `requesting-code-review` (cadence + fresh-context briefing) |
 | mur-receiving-review | obra/superpowers `receiving-code-review` |
 | mur-verification | obra/superpowers `verification-before-completion` |
 | mur-finishing-branch | obra/superpowers `finishing-a-development-branch` |

--- a/docs/superpowers/specs/2026-07-23-builtin-dev-discipline-skills-design.md
+++ b/docs/superpowers/specs/2026-07-23-builtin-dev-discipline-skills-design.md
@@ -276,6 +276,8 @@ Merged from: superpowers `using-git-worktrees`.
 - `ask-matt`, `setup-matt-pocock-skills` — router role absorbed by the hub; config-seam pattern noted for Phase 2.
 - `personal/*`, `in-progress/*`, `deprecated/*` — out of scope.
 
+**Post-spec roster drift (audited 2026-07-23):** upstream superpowers `requesting-code-review` was initially missed — its cadence + fresh-context-briefing content now lives in `mur-code-review`. mattpocock `implement`, `research`, `triage`, `codebase-design` were not evaluated in this spec's curation pass; they join the Phase 2 triage list below.
+
 **Phase 2 candidates:** `wayfinder` (decision-ticket maps; needs a tracker seam), `prototype` (LOGIC branch), `handoff`, `teach`, `improve-codebase-architecture`, an `engineering` capability bundle, a behavioral eval harness for skills.
 
 ## 9. Risks and mitigations

--- a/mur-common/src/skill/validate.rs
+++ b/mur-common/src/skill/validate.rs
@@ -170,6 +170,9 @@ fn mode_matches_category(cat: Category, mode: ContentMode) -> bool {
     matches!(
         (cat, mode),
         (Category::Workflow, ContentMode::Workflow)
+            // Dev-discipline builtins are workflow-category skills whose body
+            // is method prose (`context`), not executable steps.
+            | (Category::Workflow, ContentMode::Context)
             | (Category::Command, ContentMode::Command)
             | (Category::Context, ContentMode::Context)
             | (Category::Meta, ContentMode::Context)
@@ -199,6 +202,14 @@ content:
     #[test]
     fn valid_manifest_passes() {
         let m = parse_canonical(VALID).unwrap();
+        validate(&m).unwrap();
+    }
+
+    /// Workflow-category skills may carry a `context` body (dev-discipline
+    /// builtin convention: method prose, not executable steps).
+    #[test]
+    fn workflow_category_accepts_context_mode() {
+        let m = parse_canonical(&VALID.replace("category: context", "category: workflow")).unwrap();
         validate(&m).unwrap();
     }
 
@@ -236,7 +247,7 @@ name: demo
 version: 1.0.0
 publisher: human:test
 description: d
-category: workflow
+category: note
 content:
   abstract: hi
   context: oops

--- a/mur-core/src/skills/mur_brainstorm.yaml
+++ b/mur-core/src/skills/mur_brainstorm.yaml
@@ -39,6 +39,15 @@ content:
     8. Ask the user to review the written spec. On approval, hand off to
        `mur-writing-plans`.
 
+    ## Spec-writer delegation
+
+    If a dedicated spec-writer agent is observably available (e.g.
+    `mur agent list` shows one whose role is authoring specs/plans), delegate
+    the approved design summary to it at step 6 instead of writing the spec
+    yourself, and tell the user where its spec will land. Otherwise the
+    default above applies. Same ladder as everywhere else: in-context by
+    default, delegation only on an observable predicate.
+
     ## Notes
 
     - New vocabulary or a landed decision mid-design → `mur-domain-modeling`.

--- a/mur-core/src/skills/mur_code_review.yaml
+++ b/mur-core/src/skills/mur_code_review.yaml
@@ -44,6 +44,16 @@ content:
     two sequential passes. Each axis stays under 400 words and is reported
     under its own heading — never merged, never cross-ranked.
 
+    ## Requesting a review — when and how
+
+    - Mandatory: after each delegated task, after completing a major feature,
+      and before merging. Valuable: when stuck, before a refactor, after a
+      gnarly bug fix. Review early, review often.
+    - Fresh-context reviewer: brief with the pinned diff range (base/head
+      SHAs), a short description of what was built, and the spec source —
+      never your session history. The reviewer judges the work product, not
+      your thought process.
+
     ## Output contract (per axis)
 
     1. Strengths first — accurate praise builds trust in the criticism.


### PR DESCRIPTION
## Summary
Audit follow-ups to #751 (found while dogfooding v2.54.0):

- **mur-brainstorm — generalized spec-writer delegation**: new "Spec-writer delegation" branch — when a dedicated spec-writer agent is observably available, delegate the approved design summary to it instead of authoring the spec in-context (same delegation-ladder doctrine as §5 of the spec). Serves any user running a pm-style agent team; in-context stays the default.
- **mur-code-review — missed content ported**: superpowers `requesting-code-review` was absent from both the ATTRIBUTIONS mapping and spec §8's dropped list — a curation miss. Its unique content lands here: mandatory/valuable review cadence (after each delegated task / major feature / before merge; when stuck / before refactor) + the fresh-context reviewer briefing principle (diff SHAs + description + spec, never session history).
- **validate fix**: `mur skill validate` rejected every shipped dev-discipline builtin ("category Workflow does not match content mode Context"). Workflow now accepts a `context` body (Media precedent, same comment style). Regression-tested; existing mismatch test switched to a still-invalid pair.
- **Records**: ATTRIBUTIONS row for `requesting-code-review`; spec §8 notes the four unevaluated mattpocock skills (`implement`, `research`, `triage`, `codebase-design`) → Phase 2 triage.

## Test plan
- [x] `mur-common` validate suite (24/24, incl. new `workflow_category_accepts_context_mode`)
- [x] `builtin_skill_tests` budgets + `dev_skill_keyword_triggers_compile` (edited YAMLs re-validated)
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)