### PR TITLE
fix: resolve_blocking panic on current-thread runtime + recombine home leak

### DIFF
--- a/mur-common/src/secret.rs
+++ b/mur-common/src/secret.rs
@@ -146,15 +146,33 @@ impl SecretRef {
 
     /// Synchronous resolve for callers outside an async context (CLI
     /// factories, config loaders). Inside a multi-thread tokio runtime it
-    /// uses block_in_place; otherwise it spins a current-thread runtime.
+    /// uses block_in_place; inside a current-thread runtime (where
+    /// block_in_place panics) it hops to a fresh thread; otherwise it spins
+    /// a current-thread runtime.
     pub fn resolve_blocking(&self) -> Result<SecretString, SecretError> {
-        match tokio::runtime::Handle::try_current() {
-            Ok(h) => tokio::task::block_in_place(|| h.block_on(self.resolve())),
-            Err(_) => tokio::runtime::Builder::new_current_thread()
+        fn fresh_runtime_resolve(r: &SecretRef) -> Result<SecretString, SecretError> {
+            tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .map_err(|e| SecretError::KeychainBackend(format!("runtime: {e}")))?
-                .block_on(self.resolve()),
+                .block_on(r.resolve())
+        }
+        match tokio::runtime::Handle::try_current() {
+            Ok(h) if h.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(|| h.block_on(self.resolve()))
+            }
+            // Current-thread runtime (e.g. #[tokio::test]): block_in_place
+            // would panic — resolve on a fresh OS thread instead.
+            Ok(_) => std::thread::scope(|s| {
+                s.spawn(|| fresh_runtime_resolve(self))
+                    .join()
+                    .unwrap_or_else(|_| {
+                        Err(SecretError::KeychainBackend(
+                            "resolver thread panicked".into(),
+                        ))
+                    })
+            }),
+            Err(_) => fresh_runtime_resolve(self),
         }
     }
 
@@ -734,5 +752,17 @@ mod resolve_blocking_tests {
         assert_eq!(r.resolve_to_string_blocking().as_deref(), Some("s3cret"));
         unsafe { std::env::remove_var("MUR_TEST_SECRET_BLOCKING") };
         assert!(r.resolve_blocking().is_err());
+    }
+
+    /// `#[tokio::test]` runs on a current-thread runtime, where
+    /// `block_in_place` panics. `resolve_blocking` must detect the flavor and
+    /// hop to a fresh thread instead (the crash behind the flaky rollup
+    /// tests on machines whose config carries secret refs).
+    #[tokio::test]
+    async fn resolve_blocking_inside_current_thread_runtime_does_not_panic() {
+        unsafe { std::env::set_var("MUR_TEST_SECRET_CT_RT", "s3cret") };
+        let r: SecretRef = "env:MUR_TEST_SECRET_CT_RT".parse().unwrap();
+        assert_eq!(r.resolve_to_string_blocking().as_deref(), Some("s3cret"));
+        unsafe { std::env::remove_var("MUR_TEST_SECRET_CT_RT") };
     }
 }

--- a/mur-core/src/cross_agent/recombine/llm.rs
+++ b/mur-core/src/cross_agent/recombine/llm.rs
@@ -34,9 +34,9 @@ pub async fn llm_recombine(
     b: &SkillManifest,
     output_name: &str,
 ) -> Result<SkillManifest, LlmRecombineError> {
-    // Resolve model
-    let registry = ModelRegistry::load_from(&ModelRegistry::default_path().unwrap_or_default())
-        .unwrap_or_default();
+    // Resolve model — from the caller's mur root, so tests and alternate
+    // roots never leak in the user's real ~/.mur/models.yaml.
+    let registry = ModelRegistry::load_from(&home.join("models.yaml")).unwrap_or_default();
     let model = resolve_maintenance_model(&registry, None).ok_or(LlmRecombineError::NoModel)?;
 
     // Build prompt


### PR DESCRIPTION
## Summary
Root-causes and fixes the 7 chronically-flaky local tests (`conversations::summarize::rollup::*` ×6 via ENV_LOCK poison cascade + `skill_recombine::llm_strategy_without_model_returns_error`). CI never saw these because CI machines carry no secret-ref config / models.yaml — **both are production bugs that only manifest on real user machines**:

- **`SecretRef::resolve_blocking`** called `block_in_place` whenever a tokio handle existed — panics on a current-thread runtime (`#[tokio::test]` default, and any prod caller on a current-thread runtime whose config carries a `keychain:`/`env:` secret ref). Now checks `runtime_flavor()` and hops to a fresh OS thread on current-thread runtimes. Regression test included.
- **`llm_recombine`** accepted a `home` parameter but loaded the model registry from the real `~/.mur/models.yaml` — the no-model test found the user's configured models and didn't error. Now loads from `home.join("models.yaml")`.

Supersedes the old "date-hardcoded tests" theory (memory: the 2026-04-21 comment was context, not the failure).

## Test plan
- [x] New `resolve_blocking_inside_current_thread_runtime_does_not_panic` (RED→GREEN)
- [x] mur-common secret suite 32/32
- [x] All 6 rollup tests + full `skill_recombine` binary (7/7) pass locally with a real secret-ref config — the exact environment that used to fail
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)