### PR TITLE
ci(release): sccache for all Rust release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,11 @@ jobs:
     name: Build (${{ matrix.target }})
     needs: validate-version
     runs-on: ${{ matrix.os }}
+    # sccache: compile-level cache that survives the per-release Cargo.lock
+    # version bump (which invalidates rust-cache's exact key every time).
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +95,8 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+      - name: Run sccache
+        uses: mozilla/sccache-action@v0.0.9
 
       - name: Install protobuf (Linux)
         if: runner.os == 'Linux'
@@ -311,6 +318,11 @@ jobs:
       # plain install recompiles it from source (~10 min) every release. Pin the
       # version and cache the compiled binary; bump this to upgrade the CLI.
       TAURI_CLI_VERSION: "2.11.3"
+      # sccache: compile-level cache that survives the per-release Cargo.lock
+      # version bump. Covers both the sidecar build and the tauri (hub-gui)
+      # build below.
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v6
 
@@ -355,6 +367,9 @@ jobs:
             mur-hub-gui/src-tauri -> target
           key: hub-macos-${{ hashFiles('Cargo.lock', 'mur-hub-gui/src-tauri/Cargo.lock') }}
           restore-keys: hub-macos-
+
+      - name: Run sccache
+        uses: mozilla/sccache-action@v0.0.9
 
       - name: Install build tools
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install protobuf


### PR DESCRIPTION
## Summary
Release builds recompile most of the dep graph every time: the version bump changes `Cargo.lock`, which misses rust-cache's exact key. v2.55.0 measured: **Hub job 84 min** (35 min sidecars + 40 min tauri build), **Windows build 54 min** (the release critical path).

sccache caches at the compile level (source+flags, lockfile-independent), so dependency compiles hit across releases. Applied job-level to the build matrix (all 3 targets) and the Hub job (covers sidecar + tauri invocations).

Considered and rejected: reusing the aarch64 build artifact as Hub sidecars — `needs: build` gates on the slowest matrix job (Windows, 54 min), making Hub wall-clock *worse* (~89 min vs 84) since its sidecar build currently overlaps the matrix.

Expected: first release after merge warms the cache; subsequent releases should see the two Hub compiles drop substantially (deps dominate both).

## Test plan
- [ ] Workflow YAML parses (CI on this PR)
- [ ] Observe timings on the next release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)