### PR TITLE
fix(index): auto-rebuild codebase index on embedding-dims change

### DIFF
--- a/mur-core/src/cmd/project.rs
+++ b/mur-core/src/cmd/project.rs
@@ -51,6 +51,10 @@ pub struct ProjectStatusInfo {
     pub last_indexed: Option<String>,
     pub indexing_in_progress: bool,
     pub progress: Option<IndexProgressInfo>,
+    /// Set when the index was built at a different vector width than the
+    /// current config: (recorded, configured). Next `mur project index`
+    /// rebuilds it automatically (#757).
+    pub stale_dims: Option<(usize, usize)>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -182,7 +186,18 @@ pub fn do_project_status(path: Option<&str>) -> Result<ProjectStatusInfo> {
         last_indexed: None,
         indexing_in_progress: false,
         progress: None,
+        stale_dims: None,
     };
+
+    // Stale-dims flag (#757): index built at a different vector width than
+    // the current embedding config.
+    if has_db
+        && let Some(recorded) = index.recorded_dimensions()
+        && let Ok(cfg) = crate::store::config::load_config()
+        && recorded != cfg.embedding.dimensions
+    {
+        info.stale_dims = Some((recorded, cfg.embedding.dimensions));
+    }
 
     // Check lock for background indexing
     let lock_path = index.lock_path();
@@ -225,6 +240,7 @@ pub fn do_project_list() -> Result<Vec<ProjectStatusInfo>> {
                 last_indexed: idx.last_indexed,
                 indexing_in_progress: false,
                 progress: None,
+                stale_dims: None, // not computed for the list view
             })
         })
         .collect()
@@ -442,6 +458,11 @@ pub fn cmd_project_status(path: Option<String>) -> Result<()> {
     println!("  Indexed: {}", if info.indexed { "yes" } else { "no" });
     if let Some(chunks) = info.chunks {
         println!("  Chunks: {}", chunks);
+    }
+    if let Some((recorded, configured)) = info.stale_dims {
+        println!(
+            "  ⚠ Index built at {recorded} dims but config is {configured} — run `mur project index` to rebuild."
+        );
     }
 
     Ok(())

--- a/mur-core/src/codebase/mod.rs
+++ b/mur-core/src/codebase/mod.rs
@@ -65,6 +65,12 @@ pub struct IndexMetadata {
     /// legacy metadata, which is therefore never auto-pruned.
     #[serde(default)]
     pub repo_root: String,
+    /// Vector width the index was built at. `None` on legacy metadata (built
+    /// before dims were recorded) — stamped on the next save without forcing
+    /// a rebuild. ponytail: legacy None can't detect an old-dims table; a
+    /// lance schema probe would close that, add it if users hit it.
+    #[serde(default)]
+    pub dimensions: Option<usize>,
     pub files: HashMap<String, FileMeta>,
     pub last_indexed: String,
 }
@@ -139,6 +145,12 @@ impl CodebaseIndex {
         serde_json::from_str(&data).ok()
     }
 
+    /// Vector width recorded at build time (`None` for legacy indexes). Used
+    /// by `mur project status` to flag stale-dims indexes (#757).
+    pub fn recorded_dimensions(&self) -> Option<usize> {
+        self.load_meta()?.dimensions
+    }
+
     fn save_meta(&self, meta: &IndexMetadata) -> Result<()> {
         let path = self.meta_path();
         if let Some(parent) = path.parent() {
@@ -192,7 +204,16 @@ impl CodebaseIndex {
         let path = self.lock_path();
         let _ = std::fs::remove_file(&path);
     }
+}
 
+/// Whether a recorded index width forces a full rebuild against the
+/// configured one (#757). Legacy metadata (`None`) never forces a rebuild —
+/// it is stamped with the current dims on the next save instead.
+fn dims_require_rebuild(recorded: Option<usize>, configured: usize) -> bool {
+    matches!(recorded, Some(d) if d != configured)
+}
+
+impl CodebaseIndex {
     /// Write progress for `mur project status` to read.
     pub fn write_progress(&self, progress: &IndexProgress) -> Result<()> {
         let path = self.progress_path();
@@ -239,7 +260,23 @@ impl CodebaseIndex {
     {
         let start = Instant::now();
 
-        let old_meta = if rebuild { None } else { self.load_meta() };
+        let mut old_meta = if rebuild { None } else { self.load_meta() };
+
+        // Auto-rebuild on embedding-dims change (#757): a recorded width that
+        // differs from the configured one means the lance table's vectors are
+        // the wrong size — append/reuse would fail (or worse, hang). Drop the
+        // stale table and start fresh; the index is always rebuildable.
+        if let Some(meta) = &old_meta
+            && dims_require_rebuild(meta.dimensions, embed_config.dimensions)
+        {
+            tracing::info!(
+                old = ?meta.dimensions,
+                new = embed_config.dimensions,
+                "embedding dimensions changed; rebuilding index"
+            );
+            let _ = std::fs::remove_dir_all(&self.lance_path);
+            old_meta = None;
+        }
 
         let files = scan_project(&self.project_path);
         let files_indexed = files.len();
@@ -301,7 +338,10 @@ impl CodebaseIndex {
 
         let chunks_created = all_chunks.len();
         if chunks_created == 0 {
-            self.save_meta(&IndexMetadata::default())?;
+            self.save_meta(&IndexMetadata {
+                dimensions: Some(embed_config.dimensions),
+                ..IndexMetadata::default()
+            })?;
             return Ok(IndexStats {
                 files_indexed,
                 chunks_created: 0,
@@ -496,6 +536,7 @@ impl CodebaseIndex {
             repo_root: scanner::main_repo_root(&self.project_path)
                 .map(|p| p.display().to_string())
                 .unwrap_or_default(),
+            dimensions: Some(embed_config.dimensions),
             files: HashMap::new(),
             last_indexed: chrono::Utc::now().to_rfc3339(),
         };
@@ -942,5 +983,34 @@ mod git_hook_tests {
         // No .git/hooks dir → ensure_git_hook returns Ok(false).
         assert!(!ensure_git_hook(&base, true).unwrap());
         fs::remove_dir_all(&base).ok();
+    }
+}
+
+#[cfg(test)]
+mod dims_rebuild_tests {
+    use super::*;
+
+    #[test]
+    fn dims_mismatch_forces_rebuild_legacy_does_not() {
+        assert!(dims_require_rebuild(Some(2560), 1024));
+        assert!(!dims_require_rebuild(Some(1024), 1024));
+        // Legacy metadata without recorded dims: stamp, don't rebuild.
+        assert!(!dims_require_rebuild(None, 1024));
+    }
+
+    /// Legacy meta.json (no `dimensions` key) must parse to None.
+    #[test]
+    fn legacy_meta_json_parses_dimensions_none() {
+        let legacy = r#"{"project_path":"/p","files":{},"last_indexed":"2026-01-01T00:00:00Z"}"#;
+        let meta: IndexMetadata = serde_json::from_str(legacy).unwrap();
+        assert_eq!(meta.dimensions, None);
+        // And a stamped one round-trips.
+        let stamped = IndexMetadata {
+            dimensions: Some(1024),
+            ..IndexMetadata::default()
+        };
+        let json = serde_json::to_string(&stamped).unwrap();
+        let back: IndexMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.dimensions, Some(1024));
     }
 }


### PR DESCRIPTION
Fixes #757.

- `IndexMetadata.dimensions` records the vector width at build time (legacy = `None`, stamped on next save, never force-rebuilt)
- `build()` drops the stale lance table and rebuilds when recorded ≠ configured dims
- `mur project status` prints `⚠ Index built at N dims but config is M — run mur project index to rebuild`

Field evidence in #757: switching 2560d→1024d broke exactly the 4/28 repos with old-dim residue (all fixed by manual clean + reindex — which this automates) and hung one indexer.

## Test plan
- [x] `dims_mismatch_forces_rebuild_legacy_does_not` + `legacy_meta_json_parses_dimensions_none` (10/10 incl. neighbors)
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)