### PR TITLE
feat(dispatch): agent/fleet capability index — route blocked commands instead of giving up

### DIFF
--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -247,13 +247,22 @@ pub async fn build_provider_runner(
     // profile and sandboxed children can dial it. See profile_needs_egress.
     let egress = egress_proxy;
     let pool = McpPool::new(enabled_mcp.clone(), sandbox_policy, egress);
+    // MUR_HOME-aware home dir — same expression as `prepare_runtime`/`supervisor.rs`
+    // (the old inline "local"-arm recompute below ignored MUR_HOME; unifying on
+    // this shared value is a disclosed, intentional bug-fix — see task-7-report.md).
+    let mur_home = std::env::var_os("MUR_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"));
+
     // Issue #591 / runtime-file-tools-cwd: bash and the three file tools share
     // ONE session cwd (initial value = agent_home). The bash tool's `cwd`
     // parameter updates it; file tools resolve relative paths against the
     // current snapshot. A `cd` inside a bash subprocess is NOT retained.
     let session_cwd = crate::tools::fs_policy::SessionCwd::new(agent_home.to_path_buf());
-    let bash_exec: Arc<dyn crate::tools::ToolExecutor> =
-        Arc::new(BashTool::new(agent_home.to_path_buf(), session_cwd.clone()));
+    let bash_exec: Arc<dyn crate::tools::ToolExecutor> = Arc::new(
+        BashTool::new(agent_home.to_path_buf(), session_cwd.clone())
+            .with_agent(mur_home.clone(), profile.inner.name.clone()),
+    );
     let bash_def = bash_exec.def();
     // Issue #712: the file tools must never touch the agent's own
     // profile.yaml / identity.key, whatever the profile grants.
@@ -284,13 +293,6 @@ pub async fn build_provider_runner(
         pool.clone(),
     )
     .await;
-
-    // MUR_HOME-aware home dir — same expression as `prepare_runtime`/`supervisor.rs`
-    // (the old inline "local"-arm recompute below ignored MUR_HOME; unifying on
-    // this shared value is a disclosed, intentional bug-fix — see task-7-report.md).
-    let mur_home = std::env::var_os("MUR_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| dirs::home_dir().expect("no home").join(".mur"));
 
     // Built-in fleet_run: registered ONLY for agents allowlisted in the global
     // config (`fleet_run.agents`, deny-by-default) — unauthorized agents never

--- a/mur-agent-runtime/src/tools/bash.rs
+++ b/mur-agent-runtime/src/tools/bash.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 use tokio::process::Command;
 
+use mur_common::agent_facts::{ExecRoutes, who_can_exec};
+
 use super::{ToolError, ToolExecutor};
 use crate::exec_dirs;
 use crate::llm::ToolDef;
@@ -48,6 +50,10 @@ pub struct BashTool {
     /// Session cwd shared with the file tools. An explicit `cwd` argument
     /// updates it; otherwise its current snapshot is used as the base.
     pub session_cwd: crate::tools::fs_policy::SessionCwd,
+    /// `(mur_home, canonical agent name)` — consulted ONLY on a kernel exec
+    /// denial, to name the delegation route in the error. `None` (tests,
+    /// embedded uses) just omits the hint.
+    pub agent: Option<(PathBuf, String)>,
 }
 
 /// Resolve the effective timeout (in seconds) from the tool input's optional
@@ -67,8 +73,105 @@ impl BashTool {
         Self {
             working_dir,
             session_cwd,
+            agent: None,
         }
     }
+
+    /// Attach the agent identity used to resolve a spawn-denial route.
+    pub fn with_agent(mut self, mur_home: PathBuf, agent_name: String) -> Self {
+        self.agent = Some((mur_home, agent_name));
+        self
+    }
+}
+
+/// The binary path bash refused to exec, when the SANDBOX denied it.
+///
+/// bash reports `…: <path>: Operation not permitted` and exits **126**
+/// ("found but not executable") — which under a sealed profile means the
+/// binary is outside `entitlements.processes.spawn.allowed`. A write EPERM
+/// exits 1 and a missing binary exits 127, so neither is mistaken for this.
+///
+/// Verified against real Seatbelt, not inferred:
+/// `sandbox-exec -p '(version 1)(allow default)(deny process-exec* (subpath "/opt"))' \
+///   /bin/bash -c '/opt/homebrew/bin/git --version'`
+/// → `/bin/bash: /opt/homebrew/bin/git: Operation not permitted`, exit 126.
+fn spawn_denied_path(exit_code: Option<i32>, stderr: &str) -> Option<String> {
+    if exit_code != Some(126) {
+        return None;
+    }
+    stderr.lines().rev().find_map(|line| {
+        let path = line
+            .trim_end()
+            .strip_suffix(": Operation not permitted")?
+            .rsplit(": ")
+            .next()?;
+        path.starts_with('/').then(|| path.to_string())
+    })
+}
+
+/// Turn an opaque kernel EPERM into a route that can actually resolve it. The
+/// sandbox is compiled at process start and enforced in-kernel, so no runtime
+/// prompt is possible (HITL is per-TOOL, not per-binary) — without this the
+/// model just sees "Operation not permitted" and hands the command back to the
+/// user, which is the one outcome delegation exists to avoid.
+///
+/// `routes` comes from [`mur_common::agent_facts::who_can_exec`], so the fleets
+/// named here are the ones that provably hold this binary, best (least
+/// privileged, right working directory) first. Only `ready` routes are
+/// mentioned: naming fleets the agent may NOT use would hand a prompt-injected
+/// agent a map of the more powerful things on this machine. The user learns
+/// about those from `mur agent who`, where it is a grant path rather than a
+/// target list.
+fn spawn_denied_hint(bin: &str, agent: &str, routes: &ExecRoutes) -> String {
+    let name = std::path::Path::new(bin)
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| bin.to_string());
+    let route = if routes.ready.is_empty() {
+        format!("No authorized fleet can run `{name}`, so this one needs the user.")
+    } else {
+        let named: Vec<String> = routes
+            .ready
+            .iter()
+            .map(|f| {
+                let via: Vec<&str> = f
+                    .members_with(bin)
+                    .iter()
+                    .map(|m| m.name.as_str())
+                    .collect();
+                format!("\"{}\" (via {})", f.name, via.join(", "))
+            })
+            .collect();
+        format!(
+            "DELEGATE it instead of asking the user: \
+             fleet_run(fleet={}, goal=<this exact command, with absolute paths>). \
+             Best first: {}.",
+            format_args!("\"{}\"", routes.ready[0].name),
+            named.join(", ")
+        )
+    };
+    let drift: Vec<String> = routes
+        .ready
+        .iter()
+        .flat_map(|f| f.members_with(bin))
+        .filter(|m| m.drift)
+        .map(|m| m.name.clone())
+        .collect();
+    let drift_note = if drift.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\nNote: {} started before its profile was last edited, so it may not have \
+             the grant yet — report that if the delegation fails.",
+            drift.join(", ")
+        )
+    };
+    format!(
+        "\n\n[sandbox] `{name}` is not in agent '{agent}''s spawn allowlist, so the kernel \
+         refused to exec it. This is decided when the agent starts — there is no approval \
+         prompt for it. {route}{drift_note}\nTo grant it here instead, the user runs: \
+         `mur agent perm allow-spawn {agent} {name}` and restarts the agent."
+    )
 }
 
 #[async_trait::async_trait]
@@ -189,6 +292,13 @@ Commands are killed after `timeout_secs` (default {DEFAULT_TIMEOUT_SECS}s, max {
                 combined.push('\n');
             }
             combined.push_str(&format!("[exit code: {code}]"));
+            if let Some(bin) = spawn_denied_path(output.status.code(), &stderr)
+                && let Some((mur_home, agent)) = &self.agent
+            {
+                let cwd = working_dir.canonicalize().unwrap_or(working_dir.clone());
+                let routes = who_can_exec(mur_home, agent, &bin, Some(&cwd));
+                combined.push_str(&spawn_denied_hint(&bin, agent, &routes));
+            }
         }
 
         Ok(combined)
@@ -391,5 +501,73 @@ mod tests {
             out.contains("/opt/homebrew/bin"),
             "spawned shell's PATH should include the standard dirs, got: {out}"
         );
+    }
+
+    const DENIED: &str = "bash: line 1: /Users/d/.cargo/bin/cargo: Operation not permitted";
+
+    #[test]
+    fn spawn_denied_path_matches_only_the_kernel_exec_denial() {
+        assert_eq!(
+            spawn_denied_path(Some(126), DENIED).as_deref(),
+            Some("/Users/d/.cargo/bin/cargo")
+        );
+        // Same text, but a write EPERM (exit 1) or a missing binary (127) —
+        // neither is a spawn-allowlist denial, so neither gets the hint.
+        assert_eq!(spawn_denied_path(Some(1), DENIED), None);
+        assert_eq!(spawn_denied_path(Some(127), DENIED), None);
+        // 126 without the signature (e.g. a real non-executable file).
+        assert_eq!(
+            spawn_denied_path(Some(126), "bash: ./x: Permission denied"),
+            None
+        );
+        // A relative/garbled path is not a usable route — don't guess.
+        assert_eq!(
+            spawn_denied_path(Some(126), "bash: cargo: Operation not permitted"),
+            None
+        );
+    }
+
+    #[test]
+    fn spawn_denied_hint_names_the_route_and_the_grant() {
+        use mur_common::agent::NetworkOutboundMode;
+        use mur_common::agent_facts::{AgentFacts, ExecFacts, FleetFacts};
+
+        let member = AgentFacts {
+            name: "rustsmith".into(),
+            role: String::new(),
+            exec: ExecFacts::Allowlist(vec!["cargo".into()]),
+            writes: vec![PathBuf::from("/repo")],
+            net: NetworkOutboundMode::Restricted,
+            skills: vec![],
+            model_ref: String::new(),
+            running: true,
+            drift: false,
+        };
+        let routes = ExecRoutes {
+            ready: vec![FleetFacts {
+                name: "builder".into(),
+                members: vec![member.clone()],
+                budget_usd: 1.0,
+                authorized: true,
+            }],
+            // An unauthorized-but-capable fleet must NEVER be named to the
+            // model — that list is an attack map, not a route.
+            blocked: vec![FleetFacts {
+                name: "secret-powerful".into(),
+                members: vec![member],
+                budget_usd: 0.0,
+                authorized: false,
+            }],
+        };
+        let h = spawn_denied_hint("/Users/d/.cargo/bin/cargo", "mur", &routes);
+        assert!(h.contains("fleet_run(fleet=\"builder\""), "{h}");
+        assert!(h.contains("via rustsmith"), "{h}");
+        assert!(h.contains("mur agent perm allow-spawn mur cargo"), "{h}");
+        assert!(!h.contains("secret-powerful"), "blocked fleet leaked: {h}");
+
+        // No usable route → never invent one.
+        let h = spawn_denied_hint("/usr/bin/git", "solo", &ExecRoutes::default());
+        assert!(!h.contains("fleet_run("), "{h}");
+        assert!(h.contains("allow-spawn solo git"), "{h}");
     }
 }

--- a/mur-agent-runtime/src/tools/registry.rs
+++ b/mur-agent-runtime/src/tools/registry.rs
@@ -142,6 +142,7 @@ mod tests {
         let bash_exec: Arc<dyn ToolExecutor> = Arc::new(BashTool {
             working_dir: std::path::PathBuf::from("/tmp"),
             session_cwd: crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
+            agent: None,
         });
         let bash_def = bash_exec.def();
         let pool = McpPool::new(vec![], SandboxPolicy::default(), None);
@@ -174,6 +175,7 @@ mod tests {
         let bash_exec: Arc<dyn ToolExecutor> = Arc::new(BashTool {
             working_dir: std::path::PathBuf::from("/tmp"),
             session_cwd: crate::tools::fs_policy::SessionCwd::new(std::path::PathBuf::from("/tmp")),
+            agent: None,
         });
         let bash_def = bash_exec.def();
         let rules = vec![ToolRule {

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -52,8 +52,11 @@ pub struct AgentProfile {
     pub display_name: String,
     /// Coarse human-facing role for grouping/filtering (e.g. "Engineer").
     /// A free label, not a registry — bundled defaults are UI suggestions and
-    /// users can type their own. Discovery/job-routing stays on the A2A card's
-    /// skills/tags; this is purely organizational.
+    /// users can type their own. Also the SOFT signal in the dispatch index
+    /// (`agent_facts`), where it explains and ranks candidates but never
+    /// filters them: what an agent may actually do is decided by
+    /// `entitlements`, which the kernel enforces and a stale label cannot
+    /// overstate.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
     pub version: String,

--- a/mur-common/src/agent_facts.rs
+++ b/mur-common/src/agent_facts.rs
@@ -1,0 +1,519 @@
+//! Dispatch index: derived facts about the agents and fleets on this machine.
+//!
+//! Every field here is READ from what the kernel actually enforces
+//! (`entitlements`) plus the profile's own metadata. Nothing is declared in a
+//! separate list, so the index cannot drift from reality the way a hand-written
+//! capability table would — a new agent appears the moment its `profile.yaml`
+//! exists, with no registration step.
+//!
+//! Three properties this module deliberately keeps apart:
+//!
+//! * **Hard** (`exec`, `writes`, `net`) — kernel-enforced, authoritative in the
+//!   NEGATIVE direction: absent from the allowlist means the agent physically
+//!   cannot do it. Present does NOT mean it is good at it. Use to FILTER.
+//! * **Soft** (`role`, `skills`, `model_ref`) — human-written or heuristic, can
+//!   be stale or overstated. Use to RANK and to explain, never to filter.
+//! * **Authorization** (`FleetFacts::authorized`) — read from the global config
+//!   the agents cannot write. Never inferred, never widened here.
+//!
+//! Lives in `mur-common` because both consumers need it and the dependency
+//! graph is `mur-core -> mur-agent-runtime -> mur-common`: the runtime's bash
+//! tool cannot reach mur-core, so anything shared has to sit at the bottom.
+
+use std::path::{Path, PathBuf};
+
+use crate::agent::{AgentProfile, NetworkOutboundMode, SpawnMode};
+use crate::fleet::Fleet;
+
+/// What the sandbox lets an agent exec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecFacts {
+    /// `spawn.mode: any` — no exec restriction at all.
+    Unrestricted,
+    /// Binaries named in `spawn.allowed`.
+    Allowlist(Vec<String>),
+    /// `spawn.mode: none` / `strict` with nothing granted.
+    Nothing,
+}
+
+/// One agent, as the kernel and the profile describe it.
+#[derive(Debug, Clone)]
+pub struct AgentFacts {
+    pub name: String,
+    /// `profile.role`, falling back to a non-boilerplate `persona.description`.
+    /// Empty means nobody has said what this agent is for.
+    pub role: String,
+    pub exec: ExecFacts,
+    pub writes: Vec<PathBuf>,
+    pub net: NetworkOutboundMode,
+    pub skills: Vec<String>,
+    pub model_ref: String,
+    pub running: bool,
+    /// `profile.yaml` (or `sys_prompt.md`) was edited after the running process
+    /// started, so the live agent is NOT what this index describes. See
+    /// [`started_after_edits`].
+    pub drift: bool,
+}
+
+impl AgentFacts {
+    /// Does this agent explicitly hold `bin`?
+    ///
+    /// `bin` may be a bare name (`cargo`) or the absolute path the kernel
+    /// refused (`/Users/d/.cargo/bin/cargo`) — a denial always reports the
+    /// latter, so both sides are compared by file name. An allowlist entry may
+    /// itself be absolute, which is why the normalisation is symmetric.
+    ///
+    /// Deliberately CONSERVATIVE: under `Allowlist` mode the sandbox also
+    /// re-allows the system exec paths (`/usr/bin`, `/bin`, …), so an agent can
+    /// in fact run `/usr/bin/git` without naming it. Resolving that would mean
+    /// replicating the runtime's `PATH` augmentation and Seatbelt's system-path
+    /// exemption down here, and it would answer the wrong question anyway: a
+    /// binary that resolves to a system path is one nobody needed to delegate.
+    /// Under-reporting routes work to an agent that provably holds the binary;
+    /// over-reporting would route it to one that dies with the same EPERM.
+    pub fn can_exec(&self, bin: &str) -> bool {
+        fn base(s: &str) -> &str {
+            Path::new(s)
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or(s)
+        }
+        match &self.exec {
+            ExecFacts::Unrestricted => true,
+            ExecFacts::Nothing => false,
+            ExecFacts::Allowlist(list) => {
+                let want = base(bin);
+                list.iter().any(|b| b == bin || base(b) == want)
+            }
+        }
+    }
+
+    /// Can it write anywhere at or under `path`?
+    pub fn can_write(&self, path: &Path) -> bool {
+        self.writes.iter().any(|w| path.starts_with(w))
+    }
+
+    /// How much privilege this agent carries, for least-privilege dispatch
+    /// (P4): among the agents that CAN do the job, prefer the one carrying the
+    /// least unrelated power. Without this the ranking silently prefers the
+    /// most capable agent — which is the one that undoes every containment
+    /// decision made elsewhere.
+    ///
+    /// A heuristic, and openly so: writable roots dominate (they are what an
+    /// escaped task can damage), then egress (what it can exfiltrate to), then
+    /// breadth of exec.
+    pub fn privilege_breadth(&self) -> u32 {
+        let writes = self.writes.len() as u32 * 4;
+        let net = match self.net {
+            NetworkOutboundMode::Unrestricted => 8,
+            NetworkOutboundMode::Restricted => 2,
+            NetworkOutboundMode::ProxyOnly => 1,
+            NetworkOutboundMode::Off => 0,
+        };
+        let exec = match &self.exec {
+            // Anything at all: strictly broader than any enumerable list.
+            ExecFacts::Unrestricted => 100,
+            ExecFacts::Allowlist(l) => l.len() as u32,
+            ExecFacts::Nothing => 0,
+        };
+        writes + net + exec
+    }
+}
+
+/// Why a fleet cannot be dispatched to right now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Blocker {
+    /// Not in `fleet_run.fleets` (or the caller is not in `fleet_run.agents`).
+    NotAuthorized,
+    /// `fleet_run` refuses fleets without an enforced budget.
+    NoBudget,
+}
+
+impl Blocker {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Blocker::NotAuthorized => "not authorized for this agent",
+            Blocker::NoBudget => "no loop.budget_usd",
+        }
+    }
+}
+
+/// One fleet plus the members that give it its abilities. A fleet declares no
+/// capabilities of its own — it has exactly what its members have.
+#[derive(Debug, Clone)]
+pub struct FleetFacts {
+    pub name: String,
+    pub members: Vec<AgentFacts>,
+    pub budget_usd: f64,
+    pub authorized: bool,
+}
+
+impl FleetFacts {
+    pub fn blocker(&self) -> Option<Blocker> {
+        if !self.authorized {
+            Some(Blocker::NotAuthorized)
+        } else if self.budget_usd <= 0.0 {
+            Some(Blocker::NoBudget)
+        } else {
+            None
+        }
+    }
+
+    /// The members that could actually run `bin`.
+    pub fn members_with(&self, bin: &str) -> Vec<&AgentFacts> {
+        self.members.iter().filter(|m| m.can_exec(bin)).collect()
+    }
+
+    /// Least-privileged capable member's breadth — the fleet is only as broad
+    /// as the member that will end up doing the work.
+    fn breadth_for(&self, bin: &str) -> u32 {
+        self.members_with(bin)
+            .iter()
+            .map(|m| m.privilege_breadth())
+            .min()
+            .unwrap_or(u32::MAX)
+    }
+
+    fn covers_cwd(&self, bin: &str, cwd: Option<&Path>) -> bool {
+        match cwd {
+            None => true,
+            Some(c) => self.members_with(bin).iter().any(|m| m.can_write(c)),
+        }
+    }
+}
+
+/// Routes for one denied binary, split by whether they can be used right now.
+///
+/// The split is the security design, not presentation: `ready` is safe to put
+/// in an agent's context, `blocked` is for the HUMAN. A list of "powerful
+/// fleets you are not allowed to use" handed to a prompt-injected agent is an
+/// attack map; handed to the user it is the grant path that stops them from
+/// disabling the sandbox out of frustration.
+#[derive(Debug, Clone, Default)]
+pub struct ExecRoutes {
+    pub ready: Vec<FleetFacts>,
+    pub blocked: Vec<FleetFacts>,
+}
+
+/// Expand `~` and `{{agent_home}}` the way the runtime's profile loader does.
+fn expand(raw: &str, home: &Path, agent_home: &Path) -> PathBuf {
+    let s = raw.replace("{{agent_home}}", &agent_home.to_string_lossy());
+    if let Some(rest) = s.strip_prefix("~/") {
+        home.join(rest)
+    } else if s == "~" {
+        home.to_path_buf()
+    } else {
+        PathBuf::from(s)
+    }
+}
+
+/// Skill names, from BOTH places a profile records them: the `installed_skills`
+/// cards and the bare `skills:` path refs (`skills/idiomatic-rust-2024`) that
+/// most agents actually use. Reading only the former left the soft layer empty
+/// for nearly every agent on a real machine, which would make a capability
+/// roster worthless.
+///
+/// Takes plain lists rather than the profile so it stays testable without a
+/// sixty-field `AgentProfile` fixture.
+fn merge_skill_names(installed: Vec<String>, refs: &[String]) -> Vec<String> {
+    let mut out = installed;
+    for r in refs {
+        let name = r.rsplit('/').next().unwrap_or(r).trim();
+        if !name.is_empty() && !out.iter().any(|s| s == name) {
+            out.push(name.to_string());
+        }
+    }
+    out
+}
+
+/// True when the running process started AFTER the newest edit to the files it
+/// loads once at boot. `perm allow-spawn` warns exactly once at edit time and
+/// nothing reminds you afterwards, so an index built from disk alone will
+/// happily claim an ability the live process does not have.
+///
+/// Uses `running.lock`'s `started_at` against file mtimes — the profile digest
+/// in that lock is computed by the runtime after `{{agent_home}}` expansion, so
+/// recomputing it here would mean duplicating loader logic across a crate
+/// boundary for a strictly worse reason.
+fn started_after_edits(agent_dir: &Path) -> Option<bool> {
+    let lock = std::fs::read_to_string(agent_dir.join("running.lock")).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&lock).ok()?;
+    let started = chrono::DateTime::parse_from_rfc3339(v.get("started_at")?.as_str()?).ok()?;
+    let newest = ["profile.yaml", "sys_prompt.md"]
+        .iter()
+        .filter_map(|f| std::fs::metadata(agent_dir.join(f)).ok()?.modified().ok())
+        .max()?;
+    let newest: chrono::DateTime<chrono::Utc> = newest.into();
+    Some(started.with_timezone(&chrono::Utc) >= newest)
+}
+
+/// Read one agent's facts. `None` when there is no readable profile — every
+/// filesystem failure here is "this agent contributes nothing to the index",
+/// never a hard error: a dispatch hint must not fail because one agent
+/// directory is broken.
+pub fn agent_facts(mur_home: &Path, name: &str) -> Option<AgentFacts> {
+    let agent_dir = mur_home.join("agents").join(name);
+    let raw = std::fs::read_to_string(agent_dir.join("profile.yaml")).ok()?;
+    let p: AgentProfile = serde_yaml_ng::from_str(&raw).ok()?;
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+
+    let exec = match p.entitlements.processes.spawn.mode {
+        SpawnMode::Any => ExecFacts::Unrestricted,
+        SpawnMode::None => ExecFacts::Nothing,
+        SpawnMode::Allowlist | SpawnMode::Strict => {
+            let allowed = p.entitlements.processes.spawn.allowed.clone();
+            if allowed.is_empty() {
+                ExecFacts::Nothing
+            } else {
+                ExecFacts::Allowlist(allowed)
+            }
+        }
+    };
+
+    // `persona.description` is auto-filled with "Agent <name>" at creation
+    // (cmd/agent/lifecycle.rs), which says nothing — treat it as unset rather
+    // than showing it as a role.
+    let boilerplate = format!("Agent {name}");
+    let role = p
+        .role
+        .clone()
+        .filter(|r| !r.trim().is_empty())
+        .or_else(|| {
+            Some(p.persona.description.clone()).filter(|d| !d.is_empty() && *d != boilerplate)
+        })
+        .unwrap_or_default();
+
+    let running = agent_dir.join("running.lock").is_file();
+    Some(AgentFacts {
+        name: name.to_string(),
+        role,
+        exec,
+        writes: p
+            .entitlements
+            .filesystem
+            .write
+            .iter()
+            .map(|w| expand(w, &home, &agent_dir))
+            .collect(),
+        net: p.entitlements.network.outbound.mode,
+        skills: merge_skill_names(
+            p.installed_skills.iter().map(|s| s.name.clone()).collect(),
+            &p.skills,
+        ),
+        model_ref: p.model_ref.clone().unwrap_or_default(),
+        // Not running => nothing to drift from; the next start reads disk.
+        drift: running && started_after_edits(&agent_dir) == Some(false),
+        running,
+    })
+}
+
+/// Every agent with a readable profile, sorted by name.
+pub fn scan_agents(mur_home: &Path) -> Vec<AgentFacts> {
+    let mut out: Vec<AgentFacts> = std::fs::read_dir(mur_home.join("agents"))
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            (!name.starts_with('.')).then(|| agent_facts(mur_home, &name))?
+        })
+        .collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+/// Every fleet, with each member's facts resolved and authorization decided
+/// for `requester` (the agent that would call `fleet_run`).
+pub fn scan_fleets(mur_home: &Path, requester: &str) -> Vec<FleetFacts> {
+    let cfg = crate::config::Config::load_or_default(&mur_home.join("config.yaml")).fleet_run;
+    let caller_ok = cfg.agents.iter().any(|a| a == requester);
+
+    let mut out: Vec<FleetFacts> = std::fs::read_dir(mur_home.join("fleets"))
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|e| {
+            let raw = std::fs::read_to_string(e.path().join("fleet.yaml")).ok()?;
+            let f: Fleet = serde_yaml_ng::from_str(&raw).ok()?;
+            let name = f.name.clone();
+            Some(FleetFacts {
+                members: f
+                    .members
+                    .iter()
+                    .filter_map(|m| agent_facts(mur_home, m))
+                    .collect(),
+                budget_usd: f.loop_cfg.map(|l| l.budget_usd).unwrap_or(0.0),
+                authorized: caller_ok && cfg.fleets.contains(&name),
+                name,
+            })
+        })
+        .collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+/// Which fleets can run `bin` (optionally, in a directory they can write).
+///
+/// Ranking, best first: fleets whose capable member can also write `cwd`, then
+/// LEAST privilege (P4), then name for determinism.
+pub fn who_can_exec(mur_home: &Path, requester: &str, bin: &str, cwd: Option<&Path>) -> ExecRoutes {
+    let mut routes = ExecRoutes::default();
+    for f in scan_fleets(mur_home, requester) {
+        if f.members_with(bin).is_empty() {
+            continue;
+        }
+        if f.blocker().is_some() {
+            routes.blocked.push(f);
+        } else {
+            routes.ready.push(f);
+        }
+    }
+    let rank = |f: &FleetFacts| (!f.covers_cwd(bin, cwd), f.breadth_for(bin), f.name.clone());
+    routes.ready.sort_by_key(rank);
+    routes.blocked.sort_by_key(rank);
+    routes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn facts(name: &str, exec: ExecFacts, writes: &[&str], net: NetworkOutboundMode) -> AgentFacts {
+        AgentFacts {
+            name: name.into(),
+            role: String::new(),
+            exec,
+            writes: writes.iter().map(PathBuf::from).collect(),
+            net,
+            skills: vec![],
+            model_ref: String::new(),
+            running: true,
+            drift: false,
+        }
+    }
+
+    #[test]
+    fn can_exec_is_conservative_and_path_aware() {
+        let a = facts(
+            "a",
+            ExecFacts::Allowlist(vec!["cargo".into(), "/opt/x/bin/tool".into()]),
+            &[],
+            NetworkOutboundMode::Off,
+        );
+        assert!(a.can_exec("cargo"));
+        // The kernel reports the ABSOLUTE path it refused, which is what the
+        // dispatch hint hands us — matching only bare names here left every
+        // route empty in the live path.
+        assert!(a.can_exec("/Users/d/.cargo/bin/cargo"));
+        // An absolute allowlist entry still matches a bare request.
+        assert!(a.can_exec("tool"));
+        assert!(a.can_exec("/opt/x/bin/tool"));
+        // Reachable via /usr/bin in reality, but not explicitly held: we do NOT
+        // claim it (see can_exec's doc).
+        assert!(!a.can_exec("git"));
+        assert!(!a.can_exec("/usr/bin/git"));
+        // Basename matching must not turn a different binary into a match.
+        assert!(!a.can_exec("/evil/cargo-nope"));
+
+        assert!(facts("b", ExecFacts::Unrestricted, &[], NetworkOutboundMode::Off).can_exec("git"));
+        assert!(!facts("c", ExecFacts::Nothing, &[], NetworkOutboundMode::Off).can_exec("git"));
+    }
+
+    #[test]
+    fn privilege_breadth_prefers_the_narrow_agent() {
+        let narrow = facts(
+            "narrow",
+            ExecFacts::Allowlist(vec!["cargo".into()]),
+            &["/repo"],
+            NetworkOutboundMode::Restricted,
+        );
+        let wide = facts(
+            "wide",
+            ExecFacts::Allowlist(vec!["cargo".into(), "git".into(), "curl".into()]),
+            &["/repo", "/other", "/home"],
+            NetworkOutboundMode::Unrestricted,
+        );
+        assert!(narrow.privilege_breadth() < wide.privilege_breadth());
+        // Unrestricted exec must outrank any enumerable allowlist.
+        let any = facts(
+            "any",
+            ExecFacts::Unrestricted,
+            &[],
+            NetworkOutboundMode::Off,
+        );
+        assert!(any.privilege_breadth() > wide.privilege_breadth());
+    }
+
+    #[test]
+    fn can_write_matches_subpaths_only() {
+        let a = facts(
+            "a",
+            ExecFacts::Nothing,
+            &["/repo/mur"],
+            NetworkOutboundMode::Off,
+        );
+        assert!(a.can_write(Path::new("/repo/mur")));
+        assert!(a.can_write(Path::new("/repo/mur/src/lib.rs")));
+        assert!(!a.can_write(Path::new("/repo/other")));
+        // Prefix-of-a-sibling must not match (`/repo/mur2` vs `/repo/mur`).
+        assert!(!a.can_write(Path::new("/repo/mur2")));
+    }
+
+    #[test]
+    fn skill_names_merge_refs_dedup_and_drop_empties() {
+        let out = merge_skill_names(
+            vec!["code-review".into()],
+            &[
+                "skills/rust-async".into(),
+                // Already present as an installed card — must not double up.
+                "skills/code-review".into(),
+                "".into(),
+                "bare-name".into(),
+            ],
+        );
+        assert_eq!(out, vec!["code-review", "rust-async", "bare-name"]);
+    }
+
+    #[test]
+    fn blocker_reports_authorization_before_budget() {
+        let mut f = FleetFacts {
+            name: "f".into(),
+            members: vec![],
+            budget_usd: 0.0,
+            authorized: false,
+        };
+        assert_eq!(f.blocker(), Some(Blocker::NotAuthorized));
+        f.authorized = true;
+        assert_eq!(f.blocker(), Some(Blocker::NoBudget));
+        f.budget_usd = 1.0;
+        assert_eq!(f.blocker(), None);
+    }
+
+    #[test]
+    fn fleet_breadth_is_the_narrowest_capable_member() {
+        let f = FleetFacts {
+            name: "f".into(),
+            members: vec![
+                facts(
+                    "wide",
+                    ExecFacts::Allowlist(vec!["cargo".into()]),
+                    &["/a", "/b", "/c"],
+                    NetworkOutboundMode::Unrestricted,
+                ),
+                facts(
+                    "narrow",
+                    ExecFacts::Allowlist(vec!["cargo".into()]),
+                    &["/a"],
+                    NetworkOutboundMode::Restricted,
+                ),
+                // Cannot run it at all — must not lower the fleet's breadth.
+                facts("idle", ExecFacts::Nothing, &[], NetworkOutboundMode::Off),
+            ],
+            budget_usd: 1.0,
+            authorized: true,
+        };
+        assert_eq!(f.members_with("cargo").len(), 2);
+        assert_eq!(f.breadth_for("cargo"), 4 + 2 + 1);
+    }
+}

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -2,6 +2,7 @@ pub mod a2a;
 pub mod action;
 pub mod actor;
 pub mod agent;
+pub mod agent_facts;
 pub mod agent_name;
 pub mod bridge;
 pub mod build;

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -111,6 +111,20 @@ pub enum AgentAction {
         /// Agent name
         name: String,
     },
+    /// Who can do what — the dispatch index, derived from what the sandbox
+    /// actually enforces. With no filter, prints the whole roster.
+    Who {
+        /// Only agents that explicitly hold this binary (e.g. `cargo`), plus
+        /// the fleets that could be delegated the work
+        #[arg(long)]
+        can: Option<String>,
+        /// Only agents with a skill whose name contains this
+        #[arg(long)]
+        skill: Option<String>,
+        /// Whose dispatch permissions to evaluate (default: the concierge)
+        #[arg(long = "as")]
+        as_agent: Option<String>,
+    },
     /// Interactive streaming TUI chat with an agent (the agent must be running)
     Cli {
         /// Agent name(s) — more than one opens each chat in its own split pane

--- a/mur-core/src/cmd/agent/doctor.rs
+++ b/mur-core/src/cmd/agent/doctor.rs
@@ -12,12 +12,20 @@ pub struct AgentRow {
     pub lock_sha: String,
     pub disk_sha: String,
     pub stale: bool,
+    /// The agent's `profile.yaml` / `sys_prompt.md` was edited after this
+    /// process started, so its live entitlements are NOT what the files say.
+    ///
+    /// Distinct from `stale`, which compares the runtime BINARY's git sha:
+    /// nothing was watching for a config edit. `mur agent perm …` warns once,
+    /// at edit time, and then the discrepancy is invisible — which is how a
+    /// grant that "was definitely added" silently fails to apply.
+    pub profile_drift: bool,
 }
 
 /// Build a doctor row for a single agent from its parsed lock file.
 ///
 /// Pure function — no I/O — so it is cheap to unit-test.
-pub fn build_row(name: &str, lock: &LockFile, disk_sha: &str) -> AgentRow {
+pub fn build_row(name: &str, lock: &LockFile, disk_sha: &str, profile_drift: bool) -> AgentRow {
     let lock_sha = if lock.build_sha.is_empty() {
         "unknown".to_string()
     } else {
@@ -28,6 +36,7 @@ pub fn build_row(name: &str, lock: &LockFile, disk_sha: &str) -> AgentRow {
         lock_sha,
         disk_sha: disk_sha.to_string(),
         stale: stale::is_stale(lock, disk_sha),
+        profile_drift,
     }
 }
 
@@ -92,7 +101,9 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
                 Ok(l) => l,
                 Err(_) => continue, // malformed lock — skip
             };
-            rows.push(build_row(&agent_name, &lock, &disk_sha));
+            let drift = mur_common::agent_facts::agent_facts(&mur_home, &agent_name)
+                .is_some_and(|f| f.drift);
+            rows.push(build_row(&agent_name, &lock, &disk_sha, drift));
         }
     }
 
@@ -107,6 +118,7 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
                     "name":     r.name,
                     "running":  true,
                     "stale":    r.stale,
+                    "profile_drift": r.profile_drift,
                     "lock_sha": r.lock_sha,
                     "disk_sha": r.disk_sha,
                 })
@@ -124,6 +136,11 @@ pub fn cmd_doctor(json: bool) -> Result<()> {
                 println!(
                     "{}: running, STALE (lock {} vs disk {}) \u{2192} run 'mur agent restart {}'",
                     r.name, lock8, disk8, r.name
+                );
+            } else if r.profile_drift {
+                println!(
+                    "{}: running, binary current but PROFILE EDITED SINCE START \u{2192} run 'mur agent restart {}'",
+                    r.name, r.name
                 );
             } else {
                 println!("{}: running, current", r.name);
@@ -189,7 +206,7 @@ mod tests {
     #[test]
     fn build_row_stale_when_shas_differ() {
         let lock = make_lock("abc123def456");
-        let row = build_row("myagent", &lock, "999999999999");
+        let row = build_row("myagent", &lock, "999999999999", false);
         assert!(row.stale);
         assert_eq!(row.name, "myagent");
         assert_eq!(row.lock_sha, "abc123def456");
@@ -199,14 +216,25 @@ mod tests {
     #[test]
     fn build_row_current_when_shas_match() {
         let lock = make_lock("abc123def456");
-        let row = build_row("myagent", &lock, "abc123def456");
+        let row = build_row("myagent", &lock, "abc123def456", false);
         assert!(!row.stale);
+    }
+
+    #[test]
+    fn profile_drift_is_independent_of_binary_staleness() {
+        // The two conditions are orthogonal: a current binary can still be
+        // running yesterday's entitlements, which is the case nothing used to
+        // report.
+        let lock = make_lock("abc123def456");
+        let row = build_row("myagent", &lock, "abc123def456", true);
+        assert!(!row.stale);
+        assert!(row.profile_drift);
     }
 
     #[test]
     fn build_row_empty_lock_sha_shown_as_unknown() {
         let lock = make_lock("");
-        let row = build_row("myagent", &lock, "abc123def456");
+        let row = build_row("myagent", &lock, "abc123def456", false);
         assert!(row.stale);
         assert_eq!(row.lock_sha, "unknown");
     }
@@ -214,7 +242,7 @@ mod tests {
     #[test]
     fn build_row_two_unknowns_not_stale() {
         let lock = make_lock("unknown");
-        let row = build_row("myagent", &lock, "unknown");
+        let row = build_row("myagent", &lock, "unknown", false);
         assert!(!row.stale);
     }
 

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -39,6 +39,7 @@ pub mod mcp_discover;
 pub mod mcp_login;
 pub mod mcp_registry;
 pub mod start;
+mod who;
 // Items exported for the Hub GUI (mur-hub-gui crate) — not used from the
 // mur binary itself, so suppress dead_code for the binary target.
 #[allow(dead_code)]
@@ -118,6 +119,7 @@ pub use snapshot::{cmd_snapshot_pull, cmd_snapshot_show};
 pub use start::cmd_start;
 #[allow(unused_imports)]
 pub use stats::{cmd_logs, cmd_stats};
+pub use who::cmd_who;
 mod pending;
 mod queue_cmd;
 pub mod wizard;

--- a/mur-core/src/cmd/agent/who.rs
+++ b/mur-core/src/cmd/agent/who.rs
@@ -1,0 +1,146 @@
+//! `mur agent who` — the dispatch index, for humans.
+//!
+//! The counterpart to the runtime's spawn-denial hint. The hint tells an agent
+//! only the routes it may already use; this tells the *user* the whole picture,
+//! including the capable-but-unauthorized fleets and the exact command that
+//! would authorize them. Deny-by-default only works if the grant path is
+//! discoverable — otherwise people route around it by handing the front-door
+//! agent the dangerous binary, which is the outcome the sandbox exists to
+//! prevent.
+
+use anyhow::Result;
+use mur_common::agent_facts::{AgentFacts, Blocker, ExecFacts, scan_agents, who_can_exec};
+
+use super::resolve_mur_home;
+
+fn exec_summary(f: &AgentFacts) -> String {
+    match &f.exec {
+        ExecFacts::Unrestricted => "ANY".to_string(),
+        ExecFacts::Nothing => "—".to_string(),
+        ExecFacts::Allowlist(l) => l
+            .iter()
+            .map(|b| {
+                std::path::Path::new(b)
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| b.clone())
+            })
+            .collect::<Vec<_>>()
+            .join(", "),
+    }
+}
+
+fn print_agent(f: &AgentFacts) {
+    let state = match (f.running, f.drift) {
+        (true, true) => " [running, PROFILE EDITED SINCE START]",
+        (true, false) => " [running]",
+        (false, _) => "",
+    };
+    println!("  {}{}", f.name, state);
+    if !f.role.is_empty() {
+        println!("      role   {}", f.role);
+    }
+    println!(
+        "      exec   {}\n      writes {}\n      net    {:?}",
+        exec_summary(f),
+        if f.writes.is_empty() {
+            "—".to_string()
+        } else {
+            f.writes
+                .iter()
+                .map(|w| w.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        },
+        f.net
+    );
+    if !f.skills.is_empty() {
+        println!("      skills {}", f.skills.join(", "));
+    }
+}
+
+pub fn cmd_who(can: Option<String>, skill: Option<String>, as_agent: Option<String>) -> Result<()> {
+    let home = resolve_mur_home()?;
+    let requester = as_agent.unwrap_or_else(|| mur_common::fleet::CONCIERGE_AGENT.to_string());
+
+    let agents: Vec<AgentFacts> = scan_agents(&home)
+        .into_iter()
+        .filter(|a| can.as_deref().is_none_or(|b| a.can_exec(b)))
+        .filter(|a| {
+            skill.as_deref().is_none_or(|s| {
+                a.skills
+                    .iter()
+                    .any(|k| k.to_lowercase().contains(&s.to_lowercase()))
+            })
+        })
+        .collect();
+
+    match (&can, &skill) {
+        (Some(b), _) => println!("Agents that explicitly hold `{b}`:"),
+        (None, Some(s)) => println!("Agents with a skill matching '{s}':"),
+        (None, None) => println!("All agents:"),
+    }
+    if agents.is_empty() {
+        println!("  (none)");
+    }
+    for a in &agents {
+        print_agent(a);
+    }
+
+    // Dispatch routes only make sense for a concrete binary.
+    let Some(bin) = can else {
+        return Ok(());
+    };
+    let routes = who_can_exec(&home, &requester, &bin, None);
+    println!("\nDispatch routes for '{requester}' (fleet_run), best first:");
+    if routes.ready.is_empty() {
+        println!("  ready:   (none)");
+    } else {
+        println!("  ready:");
+        for f in &routes.ready {
+            let via: Vec<&str> = f
+                .members_with(&bin)
+                .iter()
+                .map(|m| m.name.as_str())
+                .collect();
+            println!(
+                "    {:<20} via {:<24} budget ${:.2}",
+                f.name,
+                via.join(", "),
+                f.budget_usd
+            );
+        }
+    }
+    if !routes.blocked.is_empty() {
+        println!("  blocked (capable, but not usable right now):");
+        for f in &routes.blocked {
+            let via: Vec<&str> = f
+                .members_with(&bin)
+                .iter()
+                .map(|m| m.name.as_str())
+                .collect();
+            let Some(b) = f.blocker() else { continue };
+            println!(
+                "    {:<20} via {:<24} — {}",
+                f.name,
+                via.join(", "),
+                b.as_str()
+            );
+            match b {
+                Blocker::NotAuthorized => println!(
+                    "      authorize: add \"{}\" to fleet_run.fleets in {}",
+                    f.name,
+                    home.join("config.yaml").display()
+                ),
+                Blocker::NoBudget => println!(
+                    "      authorize: set loop.budget_usd in {}",
+                    home.join("fleets")
+                        .join(&f.name)
+                        .join("fleet.yaml")
+                        .display()
+                ),
+            }
+        }
+    }
+    Ok(())
+}

--- a/mur-core/src/cmd/fleet/plan.rs
+++ b/mur-core/src/cmd/fleet/plan.rs
@@ -8,6 +8,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
+use mur_common::agent_facts::{AgentFacts, ExecFacts, agent_facts};
 use mur_common::channel::ChannelEvent;
 use mur_common::fleet::Fleet;
 use mur_common::skill::manifest::{Procedure, ProcedureStep};
@@ -131,13 +132,27 @@ pub fn parse_router_plan(text: &str, members: &[String], goal: &str) -> Option<P
 
 /// Ask the router agent to produce a plan; `None` on any failure (caller falls
 /// back to broadcast). Requires the router agent to be running.
+///
+/// A fleet with one member short-circuits to broadcast (`None`). This is a
+/// deliberate trade, not a pure optimisation: the router's only remaining
+/// freedom with one executor is to pre-split the goal into several steps for
+/// that same agent — something the member agent does for itself anyway — and
+/// rediscovering the one possible assignee costs a full LLM round trip on
+/// EVERY iteration. It matters because solo fleets are the adapter for
+/// agent-granularity dispatch (`mur agent who` routes a denied binary to the
+/// narrowest capable fleet, usually a one-member one); an adapter that doubles
+/// the cost of every mechanical command pushes people toward the ungoverned
+/// `mur agent send` path instead.
 pub fn plan_via_router(
     mur_home: &Path,
     fleet: &Fleet,
     goal: &str,
     events: &[ChannelEvent],
 ) -> Option<Procedure> {
-    let prompt = build_plan_prompt(fleet, events);
+    if fleet.members.len() <= 1 {
+        return None;
+    }
+    let prompt = build_plan_prompt(mur_home, fleet, events);
     let params = json!({
         "message": { "role": "user", "parts": [{ "kind": "text", "text": prompt }] }
     });
@@ -154,7 +169,61 @@ pub fn plan_via_router(
     parse_router_plan(&out, &fleet.members, goal)
 }
 
-fn build_plan_prompt(fleet: &Fleet, events: &[ChannelEvent]) -> String {
+/// How many of a member's skills to name before truncating. A router prompt
+/// gains nothing from a member's twentieth skill, and one agent here really
+/// does have nineteen.
+const ROSTER_MAX_SKILLS: usize = 6;
+/// Same idea for writable roots: enough to tell repos apart, not an inventory.
+const ROSTER_MAX_WRITES: usize = 2;
+
+/// One line per member: what it is, what it knows, and — the part no
+/// self-description can fake — what the kernel actually lets it run and write.
+///
+/// Without this the router sees `Members: frontend, rustsmith, pm, qa` and
+/// routes on what the NAMES suggest. Facts, not names, decide who can do the
+/// work; a good name is a coincidence.
+///
+/// Pure so it can be tested without a `~/.mur`. Returns `None` when no member
+/// resolved, so the caller keeps today's plain-names line rather than sending a
+/// worse prompt.
+fn member_roster(facts: &[AgentFacts]) -> Option<String> {
+    if facts.is_empty() {
+        return None;
+    }
+    let trunc = |items: &[String], max: usize| -> String {
+        let shown: Vec<String> = items.iter().take(max).cloned().collect();
+        match items.len().checked_sub(max) {
+            Some(n) if n > 0 => format!("{}, +{n} more", shown.join(", ")),
+            _ => shown.join(", "),
+        }
+    };
+    let lines: Vec<String> = facts
+        .iter()
+        .map(|f| {
+            let mut parts = vec![format!("- {}", f.name)];
+            if !f.role.is_empty() {
+                parts.push(format!("({})", f.role));
+            }
+            let exec = match &f.exec {
+                ExecFacts::Unrestricted => "any".to_string(),
+                ExecFacts::Nothing => "none".to_string(),
+                ExecFacts::Allowlist(l) => trunc(l, ROSTER_MAX_SKILLS),
+            };
+            parts.push(format!("| can run: {exec}"));
+            if !f.writes.is_empty() {
+                let w: Vec<String> = f.writes.iter().map(|p| p.display().to_string()).collect();
+                parts.push(format!("| writes: {}", trunc(&w, ROSTER_MAX_WRITES)));
+            }
+            if !f.skills.is_empty() {
+                parts.push(format!("| skills: {}", trunc(&f.skills, ROSTER_MAX_SKILLS)));
+            }
+            parts.join(" ")
+        })
+        .collect();
+    Some(lines.join("\n"))
+}
+
+fn build_plan_prompt(mur_home: &Path, fleet: &Fleet, events: &[ChannelEvent]) -> String {
     let recent: String = events
         .iter()
         .rev()
@@ -164,11 +233,20 @@ fn build_plan_prompt(fleet: &Fleet, events: &[ChannelEvent]) -> String {
         .map(|t| format!("- {t}"))
         .collect::<Vec<_>>()
         .join("\n");
+    let facts: Vec<AgentFacts> = fleet
+        .members
+        .iter()
+        .filter_map(|m| agent_facts(mur_home, m))
+        .collect();
+    let members = match member_roster(&facts) {
+        Some(roster) => format!("\n{roster}"),
+        None => format!(" {}", fleet.members.join(", ")),
+    };
     format!(
-        "You are the router for fleet '{}'. Goal: {}\nMembers (delegate ONLY to these): {}\nRecent channel activity:\n{}\n\nProduce a minimal plan that assigns work to the RIGHT members (not everyone) with dependencies. Reply with ONLY JSON:\n{{\"steps\":[{{\"id\":\"s1\",\"member\":\"<one of the members>\",\"task\":\"<what to do>\",\"depends_on\":[]}}]}}\nUse `depends_on` (referencing earlier step ids) for steps that must wait. Keep it small.",
+        "You are the router for fleet '{}'. Goal: {}\nMembers (delegate ONLY to these):{}\nRecent channel activity:\n{}\n\nProduce a minimal plan that assigns work to the RIGHT members (not everyone) with dependencies. Match each step to a member that can actually run it — `can run` and `writes` are what the sandbox enforces, so a member without the binary or the directory WILL fail the step. Reply with ONLY JSON:\n{{\"steps\":[{{\"id\":\"s1\",\"member\":\"<one of the members>\",\"task\":\"<what to do>\",\"depends_on\":[]}}]}}\nUse `depends_on` (referencing earlier step ids) for steps that must wait. Keep it small.",
         fleet.name,
         fleet.goal,
-        fleet.members.join(", "),
+        members,
         if recent.is_empty() {
             "(none yet)"
         } else {
@@ -278,5 +356,42 @@ mod tests {
             "original goal must lead the intent"
         );
         assert!(intent.contains("do part one"));
+    }
+
+    fn roster_facts(name: &str, exec: ExecFacts, writes: &[&str], skills: &[&str]) -> AgentFacts {
+        AgentFacts {
+            name: name.into(),
+            role: String::new(),
+            exec,
+            writes: writes.iter().map(std::path::PathBuf::from).collect(),
+            net: mur_common::agent::NetworkOutboundMode::Restricted,
+            skills: skills.iter().map(|s| s.to_string()).collect(),
+            model_ref: String::new(),
+            running: true,
+            drift: false,
+        }
+    }
+
+    #[test]
+    fn roster_states_the_enforced_facts_and_truncates() {
+        let long: Vec<&str> = vec!["s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8"];
+        let r = member_roster(&[roster_facts(
+            "rustsmith",
+            ExecFacts::Allowlist(vec!["git".into(), "cargo".into()]),
+            &["/repo/mur", "/home/rs", "/cache"],
+            &long,
+        )])
+        .unwrap();
+        assert!(r.contains("can run: git, cargo"), "{r}");
+        // Writes are capped, and the overflow is stated rather than hidden.
+        assert!(r.contains("writes: /repo/mur, /home/rs, +1 more"), "{r}");
+        assert!(r.contains("+2 more"), "skills not truncated: {r}");
+    }
+
+    #[test]
+    fn roster_is_none_when_no_member_resolved() {
+        // Caller must fall back to the plain names line, never to an empty
+        // "Members:" section.
+        assert!(member_roster(&[]).is_none());
     }
 }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1437,6 +1437,11 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             output_artifact_path,
         } => cmd::agent::cmd_send(&name, &message, output_artifact_path.as_deref())?,
         AgentAction::Card { name } => cmd::agent::cmd_card(&name)?,
+        AgentAction::Who {
+            can,
+            skill,
+            as_agent,
+        } => cmd::agent::cmd_who(can, skill, as_agent)?,
         AgentAction::Cli {
             names,
             resume,


### PR DESCRIPTION
## Why

The concierge deliberately holds no `cargo` / `rustc` / build keys — it is the widest-attack-surface agent on the machine (unrestricted egress, several writable repos, and it ingests untrusted chat text and images), so arbitrary code execution is exactly what it must not have.

But when it hit that wall it had no way to hand the work to an agent that *can* do it:

- the bash tool returned a bare `Operation not permitted` — the sandbox is compiled at process start and enforced in-kernel, so there is no approval prompt to fall back on (HITL is per-**tool**, not per-binary);
- the fleet router's planning prompt listed member **names** only, so it routed on what a name suggests;
- the only working delegation required hardcoding a fleet name into the agent's system prompt.

## What

`mur-common::agent_facts` — a dispatch index **derived** from what the sandbox actually enforces, never declared:

| layer | source | role |
|---|---|---|
| hard | `entitlements` (exec / writes / net) | **filter** — authoritative in the negative direction |
| soft | `role`, skills, model | **rank** and explain, never filter |
| authorization | `fleet_run.*` in the global config | unchanged, manual, never widened here |

No registration step: a new agent or fleet is in the index the moment its yaml exists. Nothing can claim an ability the kernel would refuse, because the index reads the same fields the kernel does.

### Consumers

**1. bash tool** — an exec denial now names the route:

```
[exit code: 126]

[sandbox] `cargo` is not in agent 'mur''s spawn allowlist, so the kernel refused to
exec it. This is decided when the agent starts — there is no approval prompt for it.
DELEGATE it instead of asking the user: fleet_run(fleet="builder", goal=<this exact
command, with absolute paths>). Best first: "builder" (via rustsmith).
To grant it here instead, the user runs: `mur agent perm allow-spawn mur cargo` and
restarts the agent.
```

Detection is exit **126** + `Operation not permitted` — a write EPERM exits 1 and a missing binary exits 127, so neither is mistaken for a sandbox denial. Verified against real Seatbelt rather than inferred:

```
sandbox-exec -p '(version 1)(allow default)(deny process-exec* (subpath "/opt"))' \
  /bin/bash -c '/opt/homebrew/bin/git --version'
→ /bin/bash: /opt/homebrew/bin/git: Operation not permitted     EXIT=126
```

**2. fleet router** (`plan.rs`) — the planning prompt gains a roster:

```
Members (delegate ONLY to these):
- rustsmith (Engineer) | can run: git, cargo, rustc | writes: /Volumes/…/mur, +1 more
  | skills: idiomatic-rust-2024-edition, rust-api-and-crate-design, …, +13 more
```

with the prompt stating that `can run` / `writes` are sandbox-enforced, so a member without the binary **will** fail the step. Falls back to today's plain-names line if no member resolves.

**3. `mur agent who [--can <bin>] [--skill <s>] [--as <agent>]`** — the human view:

```
$ mur agent who --can cargo
Agents that explicitly hold `cargo`:
  qa [running]          exec cargo, cargo-nextest, rustc, git   net Restricted
  rustsmith [running]   role Engineer  exec git, cargo, rustc   net Restricted

Dispatch routes for 'mur' (fleet_run), best first:
  ready:
    builder      via rustsmith   budget $1.00
    develop-web  via qa          budget $10.00
  blocked (capable, but not usable right now):
    develop-rust via rustsmith, qa  — not authorized for this agent
      authorize: add "develop-rust" to fleet_run.fleets in ~/.mur/config.yaml
```

## Two design points worth reviewing

**Least-privilege dispatch.** A capability filter naturally routes work to the agent that can do *everything* — which cancels out every containment decision made elsewhere. `privilege_breadth()` ranks candidates ascending, so the narrowest sufficient agent wins. It is an openly-stated heuristic (writable roots dominate, then egress, then exec breadth).

**Split audiences for the route list.** `ExecRoutes { ready, blocked }` is a security boundary, not presentation. `ready` is safe in an agent's context; `blocked` — capable fleets it may *not* use — is an attack map if a prompt-injected agent gets it, and a grant path if the user does. Only `ready` reaches the model; there is a test asserting a blocked fleet never appears in the hint.

## Also in this PR

- `plan_via_router` short-circuits single-member fleets. **Behaviour change**: solo fleets no longer get router pre-decomposition (the member agent plans for itself) in exchange for saving an LLM round trip per iteration. Solo fleets are the adapter for agent-granularity dispatch, so the adapter should not double the cost of a mechanical command.
- `mur agent doctor` reports **profile drift** — a running agent whose `profile.yaml` / `sys_prompt.md` was edited after it started. Orthogonal to the existing `stale` check, which compares the runtime binary's git sha and never covered config edits. `mur agent perm …` warns once at edit time and then the discrepancy is invisible, which is how a grant that "was definitely added" silently fails to apply.

## Verification

| | |
|---|---|
| `mur-common --lib agent_facts` | 6/6 |
| `mur-agent-runtime --lib tools::bash` | 12/12 |
| `mur-core --lib cmd::fleet::plan` | 11/11 |
| `mur-core --lib cmd::agent::doctor` | 8/8 |
| `clippy -p mur-common -p mur-core -p mur-agent-runtime --lib --bins` | zero warnings |
| `cargo fmt --check` | clean |
| `mur agent who` (all three modes, real 28-agent home) | works — output above is a real run |

A unit test caught a real bug before it shipped: the kernel reports the **absolute** path it refused (`/Users/…/cargo`) while allowlists store bare names (`cargo`), so route lookup would have returned empty every time in production. `can_exec` now normalises both sides by file name, with the absolute form as a test case.

**Not verified end-to-end**: the runtime hint in a live agent — that needs a runtime rebuild plus a concierge restart. The logic is unit-tested and the Seatbelt behaviour it keys on is measured, but the assembled path has not run.

## Follow-ups (not in this PR)

- Docs: `mur agent who` is a new user-facing command → README + docs site + product page (CLAUDE.md checklist).
- The literal `"deep-research"` special-case in `tools/fleet_run.rs:147` is the same class of hardcoding this PR removes elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)