### PR TITLE
docs(readme): `mur agent who` in the command tree and a capability-routing bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,12 @@ files.
   Object (Windows) — plus a DNS-resolver guard that filters network egress.
 - **Human-in-the-loop** — tool calls pause for your approval in Hub and in
   `mur agent cli` (opt out per session with `--auto`).
+- **Capability routing** — an agent blocked by the sandbox doesn't hand the job
+  back to you: the denial names the fleets that actually hold that binary, and
+  the agent delegates. `mur agent who --can cargo` shows the same picture,
+  derived from what the kernel enforces rather than from a list anyone
+  maintains — including the capable fleets you haven't authorized yet, and the
+  command that authorizes them.
 - **Deletion safety** — destructive file actions go through a trash with a
   cancel window and explicit restore (`mur agent trash`); nothing is
   hard-deleted on a timer.
@@ -379,7 +385,7 @@ mur dashboard        # terminal TUI dashboard
 ```
 mur
 ├── init / doctor / update / stats / verify
-├── agent        create · cli · send · card · export · install · addon · companion ·
+├── agent        create · cli · send · card · who · export · install · addon · companion ·
 │                voice · pair · schedule · perm · secret · trash · rollback … (40+)
 ├── capability   install · list · show · remove   (MCP + skills + programs bundled → an agent)
 ├── fleet        create · list · show · run   (squads of agents over a shared channel)


### PR DESCRIPTION
README half of the docs update for the dispatch index (#759). The `mur-server` half — a new `/docs/core/capability-routing` page plus a product-page card — is [mur-server#34](https://github.com/mur-run/mur-server/pull/34).

## Changes

- **Command tree** — `who` added to the `agent` row. Top-level count stays 27; `agent` was already there.
- **Stay governed** — one bullet for capability routing, placed after human-in-the-loop since it covers what happens when approval isn't the mechanism: the sandbox decides at startup and the kernel enforces it, so there is nothing to approve. The bullet leads with the user-visible behavior (a blocked agent delegates rather than handing the job back) and notes that the index is derived from enforced permissions rather than from a list someone maintains.

Verified against the shipped CLI surface rather than from memory — `mur agent who [--can <bin>] [--skill <s>] [--as <agent>]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)