### PR TITLE
feat(effort): per-agent effort, and stop paying `high` for mechanical calls

### DIFF
--- a/mur-agent-runtime/src/llm/anthropic.rs
+++ b/mur-agent-runtime/src/llm/anthropic.rs
@@ -15,6 +15,7 @@
 use super::{LlmClient, LlmError, LlmRequest, LlmResponse, RichMessage, StopReason};
 use async_trait::async_trait;
 use mur_common::llm::anthropic_base_url;
+use mur_common::llm::supported_effort;
 use serde_json::json;
 
 const DEFAULT_VERSION: &str = "2023-06-01";
@@ -523,6 +524,11 @@ impl LlmClient for AnthropicClient {
         if let Some(t) = req.temperature {
             body["temperature"] = json!(t);
         }
+        // Effort is per-call, narrowed to what this model actually accepts —
+        // an unsupported level is a 400. Absent = the API default (`high`).
+        if let Some(e) = req.effort.and_then(|e| supported_effort(&self.model, e)) {
+            body["output_config"] = json!({ "effort": e.as_str() });
+        }
         if !req.tools.is_empty() {
             body["tools"] = serde_json::json!(
                 req.tools
@@ -594,6 +600,11 @@ impl LlmClient for AnthropicClient {
         }
         if let Some(t) = req.temperature {
             body["temperature"] = json!(t);
+        }
+        // Effort is per-call, narrowed to what this model actually accepts —
+        // an unsupported level is a 400. Absent = the API default (`high`).
+        if let Some(e) = req.effort.and_then(|e| supported_effort(&self.model, e)) {
+            body["output_config"] = json!({ "effort": e.as_str() });
         }
         if !req.tools.is_empty() {
             body["tools"] = serde_json::json!(
@@ -674,6 +685,27 @@ mod tests {
             "test-key".into(),
             "claude-3-5-sonnet-20241022".into(),
         )
+    }
+
+    #[test]
+    fn effort_is_narrowed_against_the_client_model() {
+        // The client's own model decides what may be sent. The fixture client
+        // above runs a model with no effort parameter, so a request asking for
+        // one must produce no `output_config` at all rather than a 400.
+        assert_eq!(
+            supported_effort(&make_client().model, mur_common::llm::Effort::Low),
+            None
+        );
+        // A current model takes the level as-is.
+        let c = AnthropicClient::new(
+            "http://localhost".into(),
+            "k".into(),
+            "claude-opus-5".into(),
+        );
+        assert_eq!(
+            supported_effort(&c.model, mur_common::llm::Effort::Xhigh),
+            Some(mur_common::llm::Effort::Xhigh)
+        );
     }
 
     #[test]

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -141,6 +141,15 @@ pub struct LlmRequest {
     pub pin_model_ref: Option<String>,
     /// Owning task id, threaded for telemetry correlation. None outside tasks.
     pub task_id: Option<String>,
+    /// How hard the model should work on THIS call. `None` leaves the field
+    /// off, which is the API default (`high`) — not "no effort".
+    ///
+    /// Set it at the call site that knows what the call is for: a mechanical
+    /// request (write a summary, emit a small structured plan) has no use for
+    /// the depth an open-ended coding turn needs, and pays for it anyway when
+    /// this is left unset. Narrowed to what the resolved model accepts by
+    /// `mur_common::llm::supported_effort` at the client boundary.
+    pub effort: Option<mur_common::llm::Effort>,
 }
 
 #[derive(Debug, Clone)]

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -162,6 +162,7 @@ pub fn build_runner(
     tools_policy: Vec<mur_common::agent::ToolRule>,
     max_iterations: Option<u32>,
     max_tokens: Option<u64>,
+    effort: Option<mur_common::llm::Effort>,
 ) -> Arc<TaskRunner> {
     let mut runner = TaskRunner::with_llm(client)
         .with_system_prompt(base_system_prompt)
@@ -169,7 +170,8 @@ pub fn build_runner(
         .with_skills_cfg(skills_cfg)
         .with_hitl_timeout_secs(hitl_timeout_secs)
         .with_tools(tools)
-        .with_tools_policy(tools_policy);
+        .with_tools_policy(tools_policy)
+        .with_effort(effort);
     if let Some(n) = max_iterations {
         runner = runner.with_max_iterations(n);
     }
@@ -330,6 +332,7 @@ pub async fn build_provider_runner(
             tools_policy.clone(),
             max_iterations,
             max_tokens,
+            profile.inner.effort,
         );
         (r, Some(client), Some(pool.clone()))
     };

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -206,6 +206,10 @@ pub struct TaskRunner {
     max_token_budget: u64,
     tools: Vec<Arc<dyn crate::tools::ToolExecutor>>,
     tools_policy: Vec<mur_common::agent::ToolRule>,
+    /// Per-agent effort for this agent's own turns. `None` = the API default.
+    /// Mechanical internal calls override it downward regardless (see
+    /// `graceful_exit`).
+    effort: Option<mur_common::llm::Effort>,
     /// Multi-turn chat memory keyed by `context.task_id` (see `ConversationStore`).
     conversations: Mutex<ConversationStore>,
     /// Set by `begin_drain()` during graceful shutdown. When true, `run_sync_inner`
@@ -318,6 +322,7 @@ impl TaskRunner {
             max_token_budget: DEFAULT_MAX_TOKEN_BUDGET,
             tools: vec![],
             tools_policy: vec![],
+            effort: None,
             conversations: Mutex::new(ConversationStore::default()),
             draining: Arc::new(AtomicBool::new(false)),
         }
@@ -408,6 +413,12 @@ impl TaskRunner {
 
     pub fn with_tools_policy(mut self, rules: Vec<mur_common::agent::ToolRule>) -> Self {
         self.tools_policy = rules;
+        self
+    }
+
+    /// Set the agent's per-turn effort (from its profile).
+    pub fn with_effort(mut self, effort: Option<mur_common::llm::Effort>) -> Self {
+        self.effort = effort;
         self
     }
 
@@ -1119,6 +1130,7 @@ impl TaskRunner {
             temperature: None,
             max_tokens: None,
             tools: vec![],
+            effort: self.effort,
             intent,
             task_id: Some(task_id.to_string()),
             ..Default::default()
@@ -1580,6 +1592,7 @@ impl TaskRunner {
                 messages: history.clone(),
                 temperature: None,
                 max_tokens: None,
+                effort: self.effort,
                 tools: tool_defs.clone(),
                 intent,
                 task_id: Some(task_id.to_string()),
@@ -1831,6 +1844,11 @@ impl TaskRunner {
             messages,
             temperature: None,
             max_tokens: None,
+            // Mechanical: recap what happened, no tools, no decisions — and it
+            // fires exactly when a budget or loop guard already tripped, so
+            // inheriting the agent's `xhigh` for a post-mortem is the wrong
+            // direction. Pinned low regardless of the profile.
+            effort: Some(mur_common::llm::Effort::Low),
             tools: vec![], // tools disabled: force a textual summary
             ..Default::default()
         };
@@ -3221,6 +3239,7 @@ mod tests {
             vec![],
             vec![],
             Some(3),
+            None,
             None,
         );
         let _ = runner.run_sync(loop_spec("loop")).await;

--- a/mur-agent-runtime/src/tools/bash.rs
+++ b/mur-agent-runtime/src/tools/bash.rs
@@ -540,6 +540,7 @@ mod tests {
             net: NetworkOutboundMode::Restricted,
             skills: vec![],
             model_ref: String::new(),
+            effort: None,
             running: true,
             drift: false,
         };

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -59,6 +59,17 @@ pub struct AgentProfile {
     /// overstate.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
+    /// How hard this agent's model should work per turn
+    /// (`low`/`medium`/`high`/`xhigh`/`max`). `None` leaves the field off,
+    /// which is the API default (`high`) — not "no effort".
+    ///
+    /// Set it where the agent's JOB is known: a single-purpose build
+    /// specialist earns `xhigh`, a fan-out research worker `medium`, a
+    /// classifier `low`. Narrowed to what the resolved model accepts at the
+    /// client boundary, so an agent pinned to an older model degrades rather
+    /// than 400s.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<crate::llm::Effort>,
     pub version: String,
     pub persona: Persona,
     pub sys_prompt_file: String,

--- a/mur-common/src/agent_facts.rs
+++ b/mur-common/src/agent_facts.rs
@@ -48,6 +48,10 @@ pub struct AgentFacts {
     pub net: NetworkOutboundMode,
     pub skills: Vec<String>,
     pub model_ref: String,
+    /// Per-turn effort from the profile. `None` means unset — which is the API
+    /// default (`high`), not "no effort"; `mur agent who` says so explicitly
+    /// because the difference is the whole point.
+    pub effort: Option<crate::llm::Effort>,
     pub running: bool,
     /// `profile.yaml` (or `sys_prompt.md`) was edited after the running process
     /// started, so the live agent is NOT what this index describes. See
@@ -301,6 +305,7 @@ pub fn agent_facts(mur_home: &Path, name: &str) -> Option<AgentFacts> {
             &p.skills,
         ),
         model_ref: p.model_ref.clone().unwrap_or_default(),
+        effort: p.effort,
         // Not running => nothing to drift from; the next start reads disk.
         drift: running && started_after_edits(&agent_dir) == Some(false),
         running,
@@ -388,6 +393,7 @@ mod tests {
             net,
             skills: vec![],
             model_ref: String::new(),
+            effort: None,
             running: true,
             drift: false,
         }

--- a/mur-common/src/llm.rs
+++ b/mur-common/src/llm.rs
@@ -68,9 +68,155 @@ pub fn is_reasoning_model(model: &str) -> bool {
     false
 }
 
+/// How hard the model should work on a request — the Anthropic
+/// `output_config.effort` scale.
+///
+/// Effort is a property of the JOB, not of the model: the same model routing a
+/// one-line JSON plan and the same model doing a multi-file refactor want
+/// different levels. Set it at the call site that knows what it is asking for.
+///
+/// Note that NOT sending effort is not neutral — the API default is `High`.
+/// Every call that leaves it unset is already paying for high effort, so the
+/// useful direction for mechanical work is *down*.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum Effort {
+    Low,
+    Medium,
+    High,
+    Xhigh,
+    Max,
+}
+
+impl Effort {
+    /// Every level, cheapest first — for `--help` text and error messages, so
+    /// the valid set is never spelled out in two places.
+    pub const ALL: &'static [Effort] = &[
+        Effort::Low,
+        Effort::Medium,
+        Effort::High,
+        Effort::Xhigh,
+        Effort::Max,
+    ];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Effort::Low => "low",
+            Effort::Medium => "medium",
+            Effort::High => "high",
+            Effort::Xhigh => "xhigh",
+            Effort::Max => "max",
+        }
+    }
+}
+
+impl std::str::FromStr for Effort {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let want = s.trim().to_lowercase();
+        Effort::ALL
+            .iter()
+            .copied()
+            .find(|e| e.as_str() == want)
+            .ok_or_else(|| {
+                let valid: Vec<&str> = Effort::ALL.iter().map(|e| e.as_str()).collect();
+                format!("unknown effort '{s}' (valid: {})", valid.join(", "))
+            })
+    }
+}
+
+/// The effort level to actually send for `model`, or `None` when the model
+/// takes no effort parameter at all.
+///
+/// Sending an unsupported level is a 400, and the support matrix is per-model:
+/// the `xhigh` step arrived with Opus 4.7, so older models that otherwise
+/// accept effort reject it, and models before the 4.6 line reject the
+/// parameter outright. Rather than let each call site memorise that, requests
+/// state the effort they *want* and this narrows it — downgrading `xhigh` to
+/// `high` (the cheaper neighbour) and dropping the field entirely where it
+/// isn't understood.
+///
+/// Deliberately shaped like the sampling-param guard next door: one named
+/// list, one place to edit when a model ships, rather than a literal model ID
+/// buried in a conditional that goes stale on the next release.
+pub fn supported_effort(model: &str, want: Effort) -> Option<Effort> {
+    /// Accept every level including `xhigh` (Opus 4.7 and later lines).
+    const FULL_SCALE: &[&str] = &[
+        "claude-opus-5",
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-sonnet-5",
+        "claude-fable-5",
+        "claude-mythos-5",
+    ];
+    /// Accept effort but have no `xhigh` step.
+    const NO_XHIGH: &[&str] = &["claude-opus-4-6", "claude-sonnet-4-6", "claude-opus-4-5"];
+
+    let m = model.to_lowercase();
+    if FULL_SCALE.iter().any(|p| m.starts_with(p)) {
+        return Some(want);
+    }
+    if NO_XHIGH.iter().any(|p| m.starts_with(p)) {
+        return Some(match want {
+            Effort::Xhigh => Effort::High,
+            other => other,
+        });
+    }
+    // Everything else — older Claude models, and any non-Anthropic model that
+    // reaches this path — takes no effort parameter.
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn supported_effort_narrows_per_model_capability() {
+        // Full scale: passed through unchanged.
+        assert_eq!(
+            supported_effort("claude-opus-5", Effort::Xhigh),
+            Some(Effort::Xhigh)
+        );
+        assert_eq!(
+            supported_effort("claude-sonnet-5", Effort::Low),
+            Some(Effort::Low)
+        );
+        // Prefix match, so dated or suffixed variants resolve the same.
+        assert_eq!(
+            supported_effort("claude-opus-5-preview", Effort::Max),
+            Some(Effort::Max)
+        );
+        // No `xhigh` step before Opus 4.7 — downgrade to the cheaper neighbour
+        // rather than 400.
+        assert_eq!(
+            supported_effort("claude-opus-4-6", Effort::Xhigh),
+            Some(Effort::High)
+        );
+        // …but the levels it does have pass through.
+        assert_eq!(
+            supported_effort("claude-opus-4-6", Effort::Max),
+            Some(Effort::Max)
+        );
+        // Models with no effort parameter: drop the field entirely.
+        assert_eq!(supported_effort("claude-haiku-4-5", Effort::Low), None);
+        assert_eq!(supported_effort("claude-sonnet-4-5", Effort::High), None);
+        // Non-Anthropic models never carry it.
+        assert_eq!(supported_effort("llama3.2:3b", Effort::Low), None);
+        assert_eq!(supported_effort("gpt-5", Effort::Low), None);
+    }
+
+    #[test]
+    fn effort_strings_match_the_api_scale() {
+        assert_eq!(Effort::Low.as_str(), "low");
+        assert_eq!(Effort::Xhigh.as_str(), "xhigh");
+        assert_eq!(Effort::Max.as_str(), "max");
+        // Ordered cheapest-first so a caller can clamp with `min`.
+        assert!(Effort::Low < Effort::High && Effort::High < Effort::Max);
+    }
 
     #[test]
     fn test_is_reasoning_model() {

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -111,6 +111,17 @@ pub enum AgentAction {
         /// Agent name
         name: String,
     },
+    /// Set, show, or clear an agent's per-turn effort
+    /// (low | medium | high | xhigh | max). Unset means the API default, high.
+    Effort {
+        /// Agent name
+        name: String,
+        /// Level to set; omit to print the current setting
+        level: Option<String>,
+        /// Unset the level, restoring the API default
+        #[arg(long)]
+        clear: bool,
+    },
     /// Who can do what — the dispatch index, derived from what the sandbox
     /// actually enforces. With no filter, prints the whole roster.
     Who {

--- a/mur-core/src/cmd/agent/effort.rs
+++ b/mur-core/src/cmd/agent/effort.rs
@@ -1,0 +1,89 @@
+//! `mur agent effort` — set, show, or clear an agent's per-turn effort.
+//!
+//! Effort is the Anthropic `output_config.effort` scale. The value lives on the
+//! agent profile because it describes the agent's JOB: a single-purpose build
+//! specialist earns `xhigh`, a fan-out research worker `medium`, a classifier
+//! `low`. Individual mechanical calls inside the runtime cap themselves lower
+//! regardless of what is set here.
+//!
+//! Leaving it unset is not the same as "no effort" — the API default is
+//! `high`, so every unset agent is already paying for high effort.
+
+use anyhow::{Result, bail};
+use mur_common::llm::Effort;
+
+use super::perm::warn_if_running;
+use super::{load_profile_for_edit, save_profile};
+
+/// `mur agent effort <name> [level] [--clear]`
+///
+/// With no level and no `--clear`, prints the current setting.
+pub fn cmd_effort(name: &str, level: Option<String>, clear: bool) -> Result<()> {
+    if clear && level.is_some() {
+        bail!("pass a level or --clear, not both");
+    }
+
+    let (path, mut profile) = load_profile_for_edit(name)?;
+
+    // Read-only form: report and stop, so `effort <name>` is a safe thing to
+    // type when you're not sure what an agent is on.
+    if !clear && level.is_none() {
+        match profile.effort {
+            Some(e) => println!("{name}: {}", e.as_str()),
+            None => println!("{name}: (unset — the API default is high)"),
+        }
+        return Ok(());
+    }
+
+    let new = match level {
+        Some(raw) => Some(raw.parse::<Effort>().map_err(|e| anyhow::anyhow!(e))?),
+        None => None,
+    };
+
+    if profile.effort == new {
+        match new {
+            Some(e) => println!("{name}: already {}", e.as_str()),
+            None => println!("{name}: already unset"),
+        }
+        return Ok(());
+    }
+
+    profile.effort = new;
+    save_profile(&path, &mut profile)?;
+    match new {
+        Some(e) => println!("{name}: effort set to {}", e.as_str()),
+        None => println!("{name}: effort cleared (the API default is high)"),
+    }
+    // The profile is read once at startup, so a running agent keeps the old
+    // value until it restarts.
+    warn_if_running(name);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use mur_common::llm::Effort;
+
+    #[test]
+    fn every_level_round_trips_through_the_cli_string() {
+        // The CLI takes a bare string; if parsing and rendering ever disagree
+        // a level becomes unsettable, with no error to show for it.
+        for e in Effort::ALL {
+            assert_eq!(e.as_str().parse::<Effort>().unwrap(), *e);
+        }
+    }
+
+    #[test]
+    fn unknown_level_lists_the_valid_ones() {
+        let err = "hgih".parse::<Effort>().unwrap_err();
+        assert!(err.contains("hgih"), "{err}");
+        for e in Effort::ALL {
+            assert!(err.contains(e.as_str()), "{err} should list {}", e.as_str());
+        }
+    }
+
+    #[test]
+    fn parsing_is_case_and_space_insensitive() {
+        assert_eq!("  XHigh ".parse::<Effort>().unwrap(), Effort::Xhigh);
+    }
+}

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -112,6 +112,7 @@ pub fn cmd_create(
         name: name.to_string(),
         display_name,
         role: None,
+        effort: None,
         version: "0.1.0".to_string(),
         persona: Persona {
             category: PersonaCategory::Custom,

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -30,6 +30,7 @@ pub mod channel_import;
 pub mod cli;
 mod comm;
 mod doctor;
+mod effort;
 pub mod export;
 mod hub;
 pub(crate) mod install;
@@ -75,6 +76,7 @@ pub use cli::cmd_cli;
 pub use comm::{cmd_card, cmd_send};
 #[allow(unused_imports)]
 pub use doctor::cmd_doctor;
+pub use effort::cmd_effort;
 #[allow(unused_imports)]
 pub use export::cmd_export;
 #[allow(unused_imports)]

--- a/mur-core/src/cmd/agent/who.rs
+++ b/mur-core/src/cmd/agent/who.rs
@@ -54,6 +54,13 @@ fn print_agent(f: &AgentFacts) {
         },
         f.net
     );
+    println!(
+        "      effort {}",
+        match f.effort {
+            Some(e) => e.as_str(),
+            None => "— (unset: the API default is high)",
+        }
+    );
     if !f.skills.is_empty() {
         println!("      skills {}", f.skills.join(", "));
     }

--- a/mur-core/src/cmd/agent_companion/connector.rs
+++ b/mur-core/src/cmd/agent_companion/connector.rs
@@ -524,6 +524,7 @@ pub(crate) async fn scaffold_stub_bridge(name: &str, default_route: &str) -> Res
         name: name.to_string(),
         display_name: name.to_string(),
         role: None,
+        effort: None,
         version: "0.1.0".to_string(),
         persona: Persona {
             category: PersonaCategory::Custom,

--- a/mur-core/src/cmd/fleet/plan.rs
+++ b/mur-core/src/cmd/fleet/plan.rs
@@ -367,6 +367,7 @@ mod tests {
             net: mur_common::agent::NetworkOutboundMode::Restricted,
             skills: skills.iter().map(|s| s.to_string()).collect(),
             model_ref: String::new(),
+            effort: None,
             running: true,
             drift: false,
         }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1437,6 +1437,7 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             output_artifact_path,
         } => cmd::agent::cmd_send(&name, &message, output_artifact_path.as_deref())?,
         AgentAction::Card { name } => cmd::agent::cmd_card(&name)?,
+        AgentAction::Effort { name, level, clear } => cmd::agent::cmd_effort(&name, level, clear)?,
         AgentAction::Who {
             can,
             skill,


### PR DESCRIPTION
## The finding

MUR sent no `output_config.effort` anywhere. That is not the neutral choice — **the API default is `high`**, so every call was already paying for high effort: the fleet router emitting a small JSON plan, the noise filter classifying, the recap written after a budget guard trips. The useful direction was *down*, and there was no way to express it.

## Effort belongs to the job, not the model

The same model routing a one-line plan and doing a multi-file refactor want different levels, so this is set where the job is known rather than as an attribute of `claude_opus` in the registry.

**Per agent** — `mur agent effort <name> [level] [--clear]`, stored on the profile:

```
$ mur agent effort rustsmith
rustsmith: (unset — the API default is high)

$ mur agent effort rustsmith hgih
Error: unknown effort 'hgih' (valid: low, medium, high, xhigh, max)

$ mur agent effort rustsmith xhigh
rustsmith: effort set to xhigh
warning: 'rustsmith' is running; restart required for changes to take effect
```

`mur agent who` grows an `effort` row. Both surfaces say *unset means the API default* rather than printing a bare dash — running `who` today shows every agent unset, which is the point: it makes the invisible `high` visible.

**Per call** — a mechanical request caps itself below whatever the agent is set to. `graceful_exit` is pinned `low`: no tools, no decisions, and it fires exactly when a budget or loop guard already tripped, so inheriting the agent's `xhigh` for the post-mortem is the wrong direction.

## The capability guard

`supported_effort(model, want)` narrows the request to what the resolved model accepts — the `xhigh` step arrived with Opus 4.7, and models before the 4.6 line take no effort parameter at all. It **downgrades rather than 400s** (`xhigh` → `high` where there is no `xhigh`), and drops the field entirely where it isn't understood, which also means non-Anthropic models are covered for free.

Shaped deliberately like the sampling-param guard added earlier today: one named list, one place to edit when a model ships, instead of a literal model ID buried in a conditional that goes stale on the next release — the failure mode that produced two separate defects in this repo already.

## Scope: what a reviewer should know is missing

The original plan had a table of eight "call sites". Reading the code showed most of them are not call sites at all — **almost every LLM call in MUR is an agent turn**, which is why the per-agent layer carries the weight and only one true call site (`graceful_exit`) needed a per-call cap.

Two paths are deliberately untouched:

- **mur-core's own `ChatRequest` pipeline** (`mur chat ask`, session analysis) is separate plumbing.
- **The fleet router** takes an A2A call to the router agent, so it runs at *that agent's* effort. Making router planning cheap needs an effort hint on the A2A message — a protocol change, not a constant.

## Verification

| | |
|---|---|
| `mur-common --lib llm::` | 6/6 |
| `mur-agent-runtime --lib llm::anthropic` | 17/17 |
| `mur-agent-runtime --lib tools::bash` | 12/12 |
| `mur-core --lib cmd::agent::effort` | 3/3 |
| `mur-core --lib cmd::fleet::plan` | 11/11 |
| `cargo check --all-targets` (core + runtime) | clean |
| `cargo fmt` | clean |

Live-tested against the real agent home: read-when-unset, typo rejection listing valid values, set, read back, idempotent re-set, the `who` row, and `--clear` restoring the profile byte-for-byte.

One detail worth noting from that run — setting the value made `who` report `rustsmith [running, PROFILE EDITED SINCE START]`, the drift check from #759 firing on its own. The two features were never wired together; they compose because both read the same derived facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)