### PR TITLE
feat(settlement): close a turn with an accounting the model cannot round

### DIFF
--- a/mur-agent-runtime/src/lib.rs
+++ b/mur-agent-runtime/src/lib.rs
@@ -42,5 +42,6 @@ pub mod task_runner;
 pub mod telemetry_writer;
 pub mod tools;
 pub mod transport;
+pub mod turn_ledger;
 pub mod voice;
 pub mod watch_scheduler;

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1566,6 +1566,9 @@ impl TaskRunner {
         // NOT — that's progress, not a loop. Requires fingerprinting AFTER
         // the tool runs, since the result isn't known until then.
         let mut fingerprints: VecDeque<(String, u64, u64)> = VecDeque::with_capacity(LOOP_WINDOW);
+        // Settlement accounting for this turn. Recorded from the loop's own
+        // view of each call, so the card cannot disagree with what happened.
+        let mut ledger = crate::turn_ledger::TurnLedger::default();
 
         let mut iteration: u32 = 0;
         while iteration < self.max_iterations {
@@ -1577,7 +1580,7 @@ impl TaskRunner {
                 .saturating_sub(start_tokens);
             if spent >= self.max_token_budget {
                 let msg = self
-                    .graceful_exit(client, &history, LoopStop::TokenBudget)
+                    .graceful_exit(client, &history, LoopStop::TokenBudget, &ledger)
                     .await;
                 return Ok((
                     msg,
@@ -1714,13 +1717,13 @@ impl TaskRunner {
             });
 
             if resp.tool_calls.is_empty() || resp.stop_reason == StopReason::EndTurn {
-                return Ok((
-                    Message {
-                        role: "agent".into(),
-                        parts: vec![mur_common::a2a::MessagePart::Text { text: resp.text }],
-                    },
-                    None,
-                ));
+                ledger.iterations = iteration;
+                ledger.stop = if resp.stop_reason == StopReason::MaxTokens {
+                    crate::turn_ledger::StopKind::MaxTokens
+                } else {
+                    crate::turn_ledger::StopKind::EndTurn
+                };
+                return Ok((settle(resp.text, &ledger), None));
             }
 
             // Execute tools and collect results.
@@ -1748,6 +1751,11 @@ impl TaskRunner {
             // making progress (don't abort). Fingerprinting happens here,
             // AFTER execution, because the result is needed.
             for (call, entry) in resp.tool_calls.iter().zip(results.iter()) {
+                ledger.record(crate::turn_ledger::Action {
+                    tool: call.tool_name.clone(),
+                    target: crate::turn_ledger::describe_target(&call.tool_name, &call.input),
+                    outcome: crate::turn_ledger::classify(&entry.content, entry.is_error),
+                });
                 let fp = (
                     call.tool_name.clone(),
                     fingerprint_args(&call.input),
@@ -1764,7 +1772,7 @@ impl TaskRunner {
                     // sanitizes, but keeping history consistent is cheap.
                     history.push(RichMessage::ToolResults { results });
                     let msg = self
-                        .graceful_exit(client, &history, LoopStop::LoopDetected)
+                        .graceful_exit(client, &history, LoopStop::LoopDetected, &ledger)
                         .await;
                     return Ok((
                         msg,
@@ -1800,7 +1808,7 @@ impl TaskRunner {
         }
 
         let msg = self
-            .graceful_exit(client, &history, LoopStop::MaxIterations)
+            .graceful_exit(client, &history, LoopStop::MaxIterations, &ledger)
             .await;
         Ok((
             msg,
@@ -1820,6 +1828,7 @@ impl TaskRunner {
         client: &dyn crate::llm::LlmClient,
         history: &[crate::llm::RichMessage],
         reason: LoopStop,
+        ledger: &crate::turn_ledger::TurnLedger,
     ) -> Message {
         use crate::llm::{LlmRequest, RichMessage};
 
@@ -1852,7 +1861,7 @@ impl TaskRunner {
             tools: vec![], // tools disabled: force a textual summary
             ..Default::default()
         };
-        let mut text = match client.generate(req).await {
+        let text = match client.generate(req).await {
             Ok(resp) => {
                 self.cumulative_input_tokens
                     .fetch_add(resp.input_tokens, std::sync::atomic::Ordering::Relaxed);
@@ -1868,17 +1877,51 @@ impl TaskRunner {
                     .unwrap_or_else(|| format!("Stopped: {} budget reached.", reason.as_str()))
             }
         };
-        // #595: mark output that ended at the iteration cap so partial
-        // execution is visible instead of silently reported as clean.
-        if matches!(reason, LoopStop::MaxIterations) {
-            text.push_str(
-                "\n\n[runtime: turn ended at the iteration cap — output may be incomplete]",
-            );
-        }
-        Message {
-            role: "agent".into(),
-            parts: vec![mur_common::a2a::MessagePart::Text { text }],
-        }
+        // #595: mark output that ended early so partial execution is visible
+        // instead of silently reported as clean. This used to be a string
+        // appended after whatever the model had just claimed, which let the two
+        // contradict each other in the same reply; it is now a row in the
+        // settlement, next to what did and did not actually run.
+        let ledger = crate::turn_ledger::TurnLedger {
+            stop: match reason {
+                LoopStop::MaxIterations => crate::turn_ledger::StopKind::MaxIterations,
+                LoopStop::TokenBudget => crate::turn_ledger::StopKind::TokenBudget,
+                LoopStop::LoopDetected => crate::turn_ledger::StopKind::LoopDetected,
+            },
+            ..ledger.clone()
+        };
+        settle(text, &ledger)
+    }
+}
+
+/// Attach the settlement to a turn's reply, when the turn earned one.
+///
+/// Two parts on one message: the rendered card for whoever is reading, and the
+/// ledger as `MessagePart::Data` for whoever is parsing. A headless caller —
+/// `mur agent send`, a fleet step, the Hub — gets the same accounting as the
+/// TUI without scraping prose out of the text part.
+///
+/// Turns that only answered a question get neither: a settlement under a
+/// one-line reply is noise, and noise is how a useful signal stops being read.
+fn settle(text: String, ledger: &crate::turn_ledger::TurnLedger) -> Message {
+    let mut parts = vec![mur_common::a2a::MessagePart::Text {
+        text: if ledger.warrants_settlement() {
+            format!("{text}{}", crate::turn_ledger::render(ledger))
+        } else {
+            text
+        },
+    }];
+    if ledger.warrants_settlement()
+        && let Ok(data) = serde_json::to_value(ledger)
+    {
+        parts.push(mur_common::a2a::MessagePart::Data {
+            mime_type: "application/vnd.mur.turn-ledger+json".into(),
+            data,
+        });
+    }
+    Message {
+        role: "agent".into(),
+        parts,
     }
 }
 
@@ -2864,8 +2907,11 @@ mod tests {
             "truncated text must be preserved, got: {reply_text}"
         );
         assert!(
-            reply_text.ends_with(crate::llm::MAX_TOKENS_TRUNCATION_MARKER),
-            "reply must end with the visible truncation marker, got: {reply_text}"
+            // The marker stays inline where the truncation happened; the
+            // settlement now follows it, so it is no longer the last thing in
+            // the reply.
+            reply_text.contains(crate::llm::MAX_TOKENS_TRUNCATION_MARKER),
+            "reply must carry the visible truncation marker, got: {reply_text}"
         );
         let usage = task.usage.expect("usage is always populated");
         assert_eq!(
@@ -3465,10 +3511,21 @@ mod tests {
         ];
 
         let msg = runner
-            .graceful_exit(client.as_ref(), &history, LoopStop::LoopDetected)
+            .graceful_exit(
+                client.as_ref(),
+                &history,
+                LoopStop::LoopDetected,
+                &crate::turn_ledger::TurnLedger::default(),
+            )
             .await;
         // Summary turn succeeded (not the fallback path).
-        assert_eq!(text_of(&msg), "SUMMARY: done.");
+        // The settlement follows the model's text now; this test is about the
+        // dangling tool_use being sanitised, not the exact reply bytes.
+        assert!(
+            text_of(&msg).starts_with("SUMMARY: done."),
+            "{}",
+            text_of(&msg)
+        );
 
         // Inspect what the LLM actually received: collect every tool_use id and
         // every tool_result id, then assert no tool_use id is unmatched.
@@ -3503,9 +3560,15 @@ mod tests {
     /// #595 — graceful_exit must append the iteration-cap marker to the
     /// output text ONLY when the stop reason is `MaxIterations`, so partial
     /// execution at the cap is visible instead of looking like a clean
-    /// completion. A sibling reason (`LoopDetected`) must NOT carry it.
+    /// completion.
+    ///
+    /// The premise widened when the notice moved into the settlement: it used
+    /// to be an iteration-cap-only string appended after whatever the model
+    /// had just claimed, so a budget stop looked clean. Every non-clean stop
+    /// now names itself, and each names the RIGHT one — a card that said
+    /// "iteration cap" for a token-budget stop would be worse than silence.
     #[tokio::test]
-    async fn graceful_exit_marks_output_only_at_iteration_cap() {
+    async fn graceful_exit_names_the_stop_reason_in_the_settlement() {
         use crate::llm::stub::SequenceLlm;
         let client: Arc<dyn crate::llm::LlmClient> = Arc::new(SequenceLlm::new(vec![
             end_turn_response("partial work done"),
@@ -3518,22 +3581,36 @@ mod tests {
         }];
 
         let capped = runner
-            .graceful_exit(client.as_ref(), &history, LoopStop::MaxIterations)
+            .graceful_exit(
+                client.as_ref(),
+                &history,
+                LoopStop::MaxIterations,
+                &crate::turn_ledger::TurnLedger::default(),
+            )
             .await;
+        let capped_text = text_of(&capped);
         assert!(
-            text_of(&capped)
-                .contains("[runtime: turn ended at the iteration cap — output may be incomplete]"),
-            "MaxIterations exit must carry the iteration-cap marker: {}",
-            text_of(&capped)
+            capped_text.contains("iteration cap")
+                && capped_text.contains("output may be incomplete"),
+            "MaxIterations exit must name the cap: {capped_text}"
         );
 
         let other = runner
-            .graceful_exit(client.as_ref(), &history, LoopStop::LoopDetected)
+            .graceful_exit(
+                client.as_ref(),
+                &history,
+                LoopStop::LoopDetected,
+                &crate::turn_ledger::TurnLedger::default(),
+            )
             .await;
+        let other_text = text_of(&other);
         assert!(
-            !text_of(&other).contains("iteration cap"),
-            "LoopDetected exit must NOT carry the iteration-cap marker: {}",
-            text_of(&other)
+            !other_text.contains("iteration cap"),
+            "LoopDetected must not be reported as an iteration cap: {other_text}"
+        );
+        assert!(
+            other_text.contains("loop detected"),
+            "LoopDetected must name its own reason: {other_text}"
         );
     }
 

--- a/mur-agent-runtime/src/turn_ledger.rs
+++ b/mur-agent-runtime/src/turn_ledger.rs
@@ -1,0 +1,385 @@
+//! Per-turn settlement ledger: what the turn actually did, assembled from
+//! facts the loop already sees.
+//!
+//! The point is the boundary between *changed* and *verified*. An agent that
+//! reports "done" for code it never compiled teaches the user to distrust every
+//! later report, and it is the single most common way an agent turn misleads —
+//! not by lying, but by collapsing "I edited nine files" into "it works".
+//!
+//! So the split is derived, not narrated. A tool that MUTATES state (write,
+//! edit) lands in `changed`; a tool that EXECUTES something and succeeded lands
+//! in `verified`, because a passing command is the only thing on hand that
+//! constitutes evidence; anything that failed or was refused lands in
+//! `blocked`. No judgement, nothing for a model to round in its own favour.
+//!
+//! The runtime renders this. The model writes the prose around it — and the
+//! prose can be wrong while the table stays honest, which is exactly the
+//! property worth having.
+
+use serde::{Deserialize, Serialize};
+
+/// Tools that change state on disk. Everything else is treated as read-only or
+/// executing; `bash` is deliberately NOT here — a shell command's outcome is
+/// evidence, whereas an edit is only an intention until something runs.
+const MUTATING_TOOLS: &[&str] = &["write_file", "edit_file"];
+
+/// How one tool call ended.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "detail")]
+pub enum Outcome {
+    Ok,
+    /// The tool ran and reported an error.
+    Failed(String),
+    /// The kernel sandbox refused it. Distinguished from `Failed` because the
+    /// remedy is different — a denial is routed or granted, not retried.
+    Denied(String),
+}
+
+/// One tool call, reduced to what a reader needs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Action {
+    pub tool: String,
+    /// The path, command, or fleet this call was about — enough to recognise
+    /// it without reprinting the transcript.
+    pub target: String,
+    pub outcome: Outcome,
+}
+
+impl Action {
+    fn mutating(&self) -> bool {
+        MUTATING_TOOLS.contains(&self.tool.as_str())
+    }
+}
+
+/// Why the turn ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StopKind {
+    /// The model finished on its own.
+    EndTurn,
+    MaxIterations,
+    TokenBudget,
+    LoopDetected,
+    /// Output hit `max_tokens` mid-thought.
+    MaxTokens,
+}
+
+impl StopKind {
+    /// Did the turn end on its own terms? Anything else means the output may
+    /// be incomplete, which a settlement must say out loud — today the runtime
+    /// appends that notice as a trailing string, disconnected from whatever
+    /// the model claimed a line earlier.
+    pub fn is_clean(self) -> bool {
+        self == StopKind::EndTurn
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            StopKind::EndTurn => "end_turn",
+            StopKind::MaxIterations => "iteration cap",
+            StopKind::TokenBudget => "token budget",
+            StopKind::LoopDetected => "loop detected",
+            StopKind::MaxTokens => "max_tokens",
+        }
+    }
+}
+
+/// The turn's accounting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnLedger {
+    pub actions: Vec<Action>,
+    pub stop: StopKind,
+    pub iterations: u32,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+impl Default for TurnLedger {
+    fn default() -> Self {
+        Self {
+            actions: vec![],
+            stop: StopKind::EndTurn,
+            iterations: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+        }
+    }
+}
+
+impl TurnLedger {
+    pub fn record(&mut self, action: Action) {
+        self.actions.push(action);
+    }
+
+    /// Commands that ran and succeeded — the only thing here that constitutes
+    /// evidence.
+    pub fn verified(&self) -> Vec<&Action> {
+        self.actions
+            .iter()
+            .filter(|a| !a.mutating() && a.outcome == Outcome::Ok)
+            .collect()
+    }
+
+    /// State changed on disk, with nothing yet run against it.
+    pub fn changed(&self) -> Vec<&Action> {
+        self.actions
+            .iter()
+            .filter(|a| a.mutating() && a.outcome == Outcome::Ok)
+            .collect()
+    }
+
+    /// Failed or refused — what did not happen, and why.
+    pub fn blocked(&self) -> Vec<&Action> {
+        self.actions
+            .iter()
+            .filter(|a| a.outcome != Outcome::Ok)
+            .collect()
+    }
+
+    /// Does this turn warrant a settlement?
+    ///
+    /// A pure question, or a turn that only read files, does not: a three-row
+    /// table under a one-line answer is worse than no table. It earns one when
+    /// state changed, when something failed, or when the turn did not end on
+    /// its own terms — the cases where the user cannot tell from the reply
+    /// alone what actually happened.
+    pub fn warrants_settlement(&self) -> bool {
+        !self.changed().is_empty() || !self.blocked().is_empty() || !self.stop.is_clean()
+    }
+}
+
+/// Reduce a tool call's input to the one thing worth showing.
+///
+/// Each tool's own most-identifying argument, falling back to a short rendering
+/// of the whole input for tools that aren't special-cased — a settlement is
+/// unreadable if half its rows say `{"cwd":null,"timeout_secs":null,…}`.
+pub fn describe_target(tool: &str, input: &serde_json::Value) -> String {
+    let field = match tool {
+        "bash" => "command",
+        "write_file" | "edit_file" | "read_file" => "path",
+        "fleet_run" => "fleet",
+        _ => "",
+    };
+    let raw = if field.is_empty() {
+        input.to_string()
+    } else {
+        input
+            .get(field)
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| input.to_string())
+    };
+    truncate(raw.trim(), 72)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    let cleaned: String = s.chars().map(|c| if c == '\n' { ' ' } else { c }).collect();
+    if cleaned.chars().count() <= max {
+        return cleaned;
+    }
+    let head: String = cleaned.chars().take(max.saturating_sub(1)).collect();
+    format!("{head}…")
+}
+
+/// Classify a tool result. `is_error` is structural, so failure never has to be
+/// guessed — but a sandbox denial is worth separating out, and the only signal
+/// for it is the hint the bash tool writes on a kernel EPERM.
+pub fn classify(content: &str, is_error: bool) -> Outcome {
+    if let Some(i) = content.find("[sandbox]") {
+        let rest = &content[i..];
+        let line = rest.lines().next().unwrap_or(rest);
+        return Outcome::Denied(truncate(line.trim_start_matches("[sandbox] "), 120));
+    }
+    if is_error {
+        return Outcome::Failed(truncate(content.trim(), 120));
+    }
+    Outcome::Ok
+}
+
+/// Render the settlement card.
+///
+/// The runtime draws this, not the model. Two reasons: the model would spend
+/// tokens on box-drawing and get the alignment wrong, and — the one that
+/// matters — a table assembled from the loop's own records cannot be talked
+/// around. The prose above it may still overclaim; this will not agree with it.
+pub fn render(ledger: &TurnLedger) -> String {
+    let mut out = String::from("\n\n─ settlement ─────────────────────────────\n");
+
+    let verified = ledger.verified();
+    if verified.is_empty() {
+        // Stated rather than omitted. An empty verified column is the single
+        // most useful line here: it is the difference between "changed nine
+        // files" and "it works", and leaving the row out lets the reader
+        // assume the latter.
+        out.push_str("  ✔ verified   (nothing ran — no evidence this works)\n");
+    } else {
+        out.push_str("  ✔ verified\n");
+        for a in &verified {
+            out.push_str(&format!("      {} {}\n", a.tool, a.target));
+        }
+    }
+
+    let changed = ledger.changed();
+    if !changed.is_empty() {
+        out.push_str(&format!("  ~ changed    {} file(s)\n", changed.len()));
+        for a in changed.iter().take(6) {
+            out.push_str(&format!("      {}\n", a.target));
+        }
+        if changed.len() > 6 {
+            out.push_str(&format!("      +{} more\n", changed.len() - 6));
+        }
+    }
+
+    let blocked = ledger.blocked();
+    if !blocked.is_empty() {
+        out.push_str("  ✘ blocked\n");
+        for a in &blocked {
+            let why = match &a.outcome {
+                Outcome::Denied(d) => format!("sandbox: {d}"),
+                Outcome::Failed(f) => f.clone(),
+                Outcome::Ok => String::new(),
+            };
+            out.push_str(&format!("      {} — {}\n", a.target, why));
+        }
+    }
+
+    if !ledger.stop.is_clean() {
+        out.push_str(&format!(
+            "  ⚠ stopped at {} ({} iterations) — output may be incomplete\n",
+            ledger.stop.as_str(),
+            ledger.iterations
+        ));
+    }
+    out.push_str("──────────────────────────────────────────");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn act(tool: &str, target: &str, outcome: Outcome) -> Action {
+        Action {
+            tool: tool.into(),
+            target: target.into(),
+            outcome,
+        }
+    }
+
+    #[test]
+    fn edits_are_changed_and_commands_are_evidence() {
+        let mut l = TurnLedger::default();
+        l.record(act("edit_file", "src/a.rs", Outcome::Ok));
+        l.record(act("write_file", "src/b.rs", Outcome::Ok));
+        l.record(act("bash", "cargo test", Outcome::Ok));
+        // The whole point: nine edits are not a passing build. Editing lands
+        // in `changed`; only something that RAN counts as evidence.
+        assert_eq!(l.changed().len(), 2);
+        assert_eq!(l.verified().len(), 1);
+        assert_eq!(l.verified()[0].target, "cargo test");
+    }
+
+    #[test]
+    fn a_failed_command_is_never_evidence() {
+        let mut l = TurnLedger::default();
+        l.record(act(
+            "bash",
+            "cargo test",
+            Outcome::Failed("2 failed".into()),
+        ));
+        assert!(l.verified().is_empty());
+        assert_eq!(l.blocked().len(), 1);
+    }
+
+    #[test]
+    fn settlement_triggers_on_change_failure_or_dirty_stop() {
+        // A read-only turn that ended cleanly: no table.
+        let mut quiet = TurnLedger::default();
+        quiet.record(act("read_file", "README.md", Outcome::Ok));
+        assert!(!quiet.warrants_settlement());
+
+        // One edit is enough.
+        let mut edited = TurnLedger::default();
+        edited.record(act("edit_file", "a.rs", Outcome::Ok));
+        assert!(edited.warrants_settlement());
+
+        // So is one failure, with nothing changed.
+        let mut failed = TurnLedger::default();
+        failed.record(act("bash", "ls", Outcome::Failed("nope".into())));
+        assert!(failed.warrants_settlement());
+
+        // And so is a truncated turn that did nothing at all — the user needs
+        // to know the output is partial even when the transcript looks calm.
+        let truncated = TurnLedger {
+            stop: StopKind::MaxIterations,
+            ..Default::default()
+        };
+        assert!(truncated.warrants_settlement());
+    }
+
+    #[test]
+    fn classify_separates_denial_from_ordinary_failure() {
+        let denied = classify(
+            "[exit code: 126]\n\n[sandbox] `cargo` is not in agent 'mur''s spawn allowlist\nmore",
+            false,
+        );
+        match denied {
+            Outcome::Denied(d) => assert!(d.contains("cargo"), "{d}"),
+            other => panic!("expected Denied, got {other:?}"),
+        }
+        // A denial is not merely a failure: the remedy is to route or grant,
+        // not to retry, so it must not be folded into Failed.
+        assert!(matches!(
+            classify("error: no such file", true),
+            Outcome::Failed(_)
+        ));
+        assert_eq!(classify("all good", false), Outcome::Ok);
+    }
+
+    #[test]
+    fn render_states_an_empty_verified_column_instead_of_hiding_it() {
+        let mut l = TurnLedger::default();
+        l.record(act("edit_file", "src/a.rs", Outcome::Ok));
+        let card = render(&l);
+        // The whole feature in one assertion: nine edits and no test run must
+        // not read as success.
+        assert!(card.contains("nothing ran"), "{card}");
+        assert!(card.contains("1 file(s)"), "{card}");
+    }
+
+    #[test]
+    fn render_names_the_denial_and_the_truncation() {
+        let mut l = TurnLedger {
+            stop: StopKind::MaxIterations,
+            iterations: 25,
+            ..Default::default()
+        };
+        l.record(act(
+            "bash",
+            "cargo test",
+            Outcome::Denied("`cargo` is not in the spawn allowlist".into()),
+        ));
+        let card = render(&l);
+        assert!(card.contains("sandbox:"), "{card}");
+        // The truncation notice belongs IN the settlement, not appended after
+        // the model's own claim where the two can contradict each other.
+        assert!(card.contains("iteration cap"), "{card}");
+        assert!(card.contains("output may be incomplete"), "{card}");
+    }
+
+    #[test]
+    fn describe_target_picks_the_identifying_argument() {
+        let bash = serde_json::json!({"command": "cargo test", "timeout_secs": 600});
+        assert_eq!(describe_target("bash", &bash), "cargo test");
+        let edit = serde_json::json!({"path": "src/lib.rs", "old_string": "x"});
+        assert_eq!(describe_target("edit_file", &edit), "src/lib.rs");
+        // Unknown tool: fall back to the whole input rather than an empty cell.
+        assert!(!describe_target("mcp__media__x", &serde_json::json!({"q": 1})).is_empty());
+        // Long commands are cut so the table stays a table.
+        let long = serde_json::json!({"command": "x".repeat(200)});
+        assert!(describe_target("bash", &long).chars().count() <= 72);
+        // Newlines would break the row.
+        let multi = serde_json::json!({"command": "a\nb"});
+        assert_eq!(describe_target("bash", &multi), "a b");
+    }
+}

--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -1138,6 +1138,10 @@ pub(crate) fn ensure_mur_skill(home: &std::path::Path, mur_root: &std::path::Pat
         ),
         ("mur-compress", include_str!("../skills/mur_compress.yaml")),
         (
+            "mur-settlement",
+            include_str!("../skills/mur_settlement.yaml"),
+        ),
+        (
             "mur-session-remove",
             include_str!("../skills/mur_session_remove.yaml"),
         ),
@@ -1703,6 +1707,32 @@ mod sync_skill_tests {
         assert!(body.contains("name: mur-project-search"));
 
         std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn ensure_mur_skill_ships_mur_settlement_and_it_loads_at_session_start() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let root = tmp.path().join("root");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&root).unwrap();
+
+        super::ensure_mur_skill(&home, &root).unwrap();
+
+        let path = root.join("skills/mur-settlement/skill.yaml");
+        assert!(
+            path.exists(),
+            "mur-settlement must be written by ensure_mur_skill"
+        );
+
+        // A reporting rule has to be in context when the turn ends, so the
+        // trigger is load-bearing: shipped with only `manual` it would never
+        // fire and the skill would be dead weight nobody notices.
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            body.contains("session_start"),
+            "mur-settlement must load at session start, got: {body}"
+        );
     }
 
     #[test]

--- a/mur-core/src/skills/mur_settlement.yaml
+++ b/mur-core/src/skills/mur_settlement.yaml
@@ -1,0 +1,77 @@
+name: mur-settlement
+version: 1.0.0
+publisher: human:mur-official
+description: 'How to close out a turn that changed something: separate verified from merely done, name what is left, and put the handoff last.'
+category: context
+provenance: human
+content:
+  abstract: 'When a turn edits files, runs commands, or stops early, the runtime appends a settlement card built from what actually happened. Write the prose around it: one line of state, what is blocked and why, and what the user must do next. Never claim a thing works unless a command proved it.'
+  context: |
+    ## The rule that matters
+
+    **Do not report a change as working unless something ran and passed.**
+
+    Editing nine files is not a passing build. "Renamed it everywhere" after
+    zero compiles is a claim about intent, not about code. Say what you did and
+    say it is unverified — that reads as weaker and is worth far more, because
+    the moment one "done" turns out to be untested, every later report has to
+    be re-checked by hand.
+
+    Concretely, these are three different states and must not be merged:
+
+    | State | What it means | How to say it |
+    | --- | --- | --- |
+    | Verified | A command ran and passed | "tests 12/12" — quote the number |
+    | Changed | Files edited, nothing run | "changed, not compiled" |
+    | Blocked | Failed, refused, or never attempted | Name the reason and the fix |
+
+    The runtime prints a settlement card with those three columns filled in
+    from what it observed. You cannot talk around it — if you write "all fixed"
+    above a card that says *nothing ran*, the contradiction is right there. Let
+    the card carry the accounting and spend your words on what it cannot know.
+
+    ## What to write
+
+    Three short pieces, in this order:
+
+    1. **State** — one sentence: what was asked, and whether it is done.
+       Lead with the outcome, not the journey.
+    2. **What is left** — anything unfinished, with the reason and what would
+       unblock it. Include work you decided to skip and why; a silent omission
+       reads as completion.
+    3. **Your move** — what the user has to do, as an imperative. Put it last
+       so it is the thing still on screen. Omit the section entirely when there
+       is nothing for them to do — a hollow "let me know if you need anything"
+       trains people to stop reading the end of your messages.
+
+    ## Do not
+
+    - **Do not restate the transcript.** They watched the tool calls scroll
+      past. Summarise the outcome, not the sequence.
+    - **Do not draw the table yourself.** The runtime renders it, sized to the
+      terminal. Your ASCII version will disagree with it and cost tokens.
+    - **Do not settle a question.** If the turn only read files or answered
+      something, just answer. A three-row summary under a one-line reply is
+      noise, and noise is how a real signal stops being read.
+    - **Do not bury the ask.** If the user must run a command, it goes on its
+      own line, copy-pasteable, at the end.
+
+    ## When you were cut off
+
+    If the card says the turn stopped at a cap or a budget, say so in your own
+    first sentence too. Your reply and the card are read together; a confident
+    "all done" above a card that says *output may be incomplete* is the single
+    worst thing you can produce, because now the user cannot tell which half to
+    believe.
+  procedure: []
+triggers:
+  # session_start, not manual: a reporting rule is only useful if it is already
+  # in context when the turn ends. A `manual` trigger would never fire and the
+  # skill would ship as dead weight.
+  - type: session_start
+  - type: manual
+tags:
+  - discipline
+  - reporting
+priority: normal
+updated_at: 1970-01-01T00:00:00Z


### PR DESCRIPTION
## What went wrong

This morning an agent finished a turn and reported:

> 改好了 --config 註解、預設值、model_setup、成本表、i18n、測試全換成新名字

It had edited thirteen files and compiled none of them. The change carried three real defects — a 3× pricing error, a stale guard that would 400 on the new default, and an output budget sized for the wrong model. The runtime *also* knew the turn had hit its iteration cap, and said so in a string appended **after** the model's claim, so the same reply contained both "改好了" and "output may be incomplete".

The user had to ask "所以都改好了嗎?" — the summary did not answer the question it existed to answer.

## Why this isn't a formatting fix

The failure is not "no summary" — there *was* a summary. It is that three states which must stay apart were collapsed into one:

| | | |
|---|---|---|
| **verified** | a command ran and passed | the only evidence there is |
| **changed** | files edited, nothing run | |
| **blocked** | failed, refused, or never attempted | |

Editing nine files is not a passing build. An agent that reports the second as the first teaches the user to hand-check every later report — which costs more than the summary ever saved.

## The design: derive it, don't ask for it

Asking a model to be honest about its own work is the weakest available mechanism. So the runtime classifies from the loop's own records:

- a **mutating** tool (`write_file`, `edit_file`) → `changed`
- an **executing** tool that succeeded → `verified`
- anything that failed or was denied → `blocked`

No semantics to guess, nothing to round in one's own favour. `bash` is deliberately not a mutating tool: an edit is an intention, a command's exit code is evidence.

The card is rendered by the **runtime** and appended to the reply. A model that writes "all fixed" above

```
  ✔ verified   (nothing ran — no evidence this works)
  ~ changed    13 file(s)
```

produces a visible contradiction instead of a plausible sentence. **The empty column is stated, never omitted** — omitting it lets the reader assume success, which is precisely how this morning's report got through.

## Also in this change

- **The truncation notice moves into the card.** It used to be a string appended after the model's claim; now it is a row next to what did and did not run. And every non-clean stop names *itself* — a token-budget stop previously looked clean, because only the iteration cap had a marker.
- **`MessagePart::Data`** carries the ledger as JSON on the same message, so `mur agent send`, fleet steps, and the Hub get the accounting without scraping prose out of the text part. One message, two audiences.
- **A question gets no card.** A three-row table under a one-line reply is noise, and noise is how a real signal stops being read. The trigger is: something changed, something failed, or the turn didn't end on its own terms.
- **`mur-settlement`** — a built-in skill on `session_start`, covering what the card cannot: state in one line, what is left and why, and the handoff last. Its trigger is load-bearing and tested; shipped as `manual` it would never fire.

## Three existing tests changed, and one changed its premise

`graceful_exit_marks_output_only_at_iteration_cap` asserted that *only* the iteration cap carries a marker. That premise is now wrong on purpose — every non-clean stop names itself — so the test was rewritten to assert the better property: each stop reports its own reason and not someone else's. The other two asserted exact reply bytes and now assert `starts_with` / `contains`, since the card follows the model's text. No behavior was bent to keep a test green.

## Verification

| | |
|---|---|
| `mur-agent-runtime --lib turn_ledger` | 7/7 |
| `mur-agent-runtime --lib task_runner` | 42/42 |
| `mur-core --lib sync_cmd` | 11/11 (incl. skill delivery + `session_start` trigger) |
| `clippy --lib --bins` (core + runtime) | zero warnings |
| `cargo fmt --check` | clean |

## Not covered

The card reports what the loop observed inside one turn. It does not span turns, and it does not know whether a *passing* command actually tested the thing that changed — `ls` succeeding is still "verified" in the mechanical sense. Narrowing that needs a notion of which command exercises which change, which is a bigger idea than this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)