### PR TITLE
feat(effort): map effort onto OpenAI-compatible models

### DIFF
--- a/mur-agent-runtime/src/llm/openai.rs
+++ b/mur-agent-runtime/src/llm/openai.rs
@@ -266,6 +266,14 @@ impl LlmClient for OpenAiClient {
         if let Some(t) = req.temperature {
             body["temperature"] = json!(t);
         }
+        // Effort, narrowed to what this model family understands. Absent for
+        // local and non-reasoning models rather than sent and ignored.
+        if let Some(e) = req
+            .effort
+            .and_then(|e| mur_common::llm::openai_reasoning_effort(&self.model, e))
+        {
+            body["reasoning_effort"] = json!(e);
+        }
         if let Some(m) = req.max_tokens {
             body["max_tokens"] = json!(m);
         }
@@ -334,6 +342,14 @@ impl LlmClient for OpenAiClient {
         });
         if let Some(t) = req.temperature {
             body["temperature"] = json!(t);
+        }
+        // Effort, narrowed to what this model family understands. Absent for
+        // local and non-reasoning models rather than sent and ignored.
+        if let Some(e) = req
+            .effort
+            .and_then(|e| mur_common::llm::openai_reasoning_effort(&self.model, e))
+        {
+            body["reasoning_effort"] = json!(e);
         }
         if let Some(m) = req.max_tokens {
             body["max_tokens"] = json!(m);

--- a/mur-common/src/llm.rs
+++ b/mur-common/src/llm.rs
@@ -170,6 +170,45 @@ pub fn supported_effort(model: &str, want: Effort) -> Option<Effort> {
     None
 }
 
+/// The `reasoning_effort` value to send for an OpenAI-compatible model, or
+/// `None` when the model takes no such parameter.
+///
+/// Verified against the current OpenAI reasoning guide rather than recalled:
+/// the parameter is `reasoning.effort` (accepted as `reasoning_effort` on the
+/// chat endpoint) and its vocabulary is `none | minimal | low | medium | high
+/// | xhigh | max` — a superset of ours, not the three levels an older memory
+/// would suggest. Checking mattered: building the mapping from that memory
+/// would have clamped `xhigh` away for no reason.
+///
+/// Two deliberate narrowings, both because this client is not "OpenAI" — it is
+/// *anything OpenAI-compatible*, including OpenRouter and local servers:
+///
+/// * Gated on the model family, not the provider. A local llama behind an
+///   OpenAI-shaped endpoint has no idea what `reasoning_effort` means.
+/// * `Xhigh`/`Max` clamp to `high`. The docs state the accepted values are
+///   model-dependent and publish no table, so passing the top of the scale
+///   through would be a 400 waiting for whichever model lacks it. Degrading is
+///   the same call made for Anthropic's missing `xhigh` step — and the same
+///   one made everywhere today: never fail the default path, lose a little
+///   depth instead. Lift the clamp per-model once a support table exists.
+pub fn openai_reasoning_effort(model: &str, want: Effort) -> Option<&'static str> {
+    /// Model families that take a reasoning effort. Prefixes, matched after
+    /// any `vendor/` prefix is stripped — OpenRouter names models
+    /// `openai/gpt-5`, and `google/gemini-3.6-flash` must NOT match.
+    const REASONING_FAMILIES: &[&str] = &["gpt-5", "o1", "o3", "o4"];
+
+    let m = model.to_lowercase();
+    let bare = m.rsplit('/').next().unwrap_or(&m);
+    if !REASONING_FAMILIES.iter().any(|f| bare.starts_with(f)) {
+        return None;
+    }
+    Some(match want {
+        Effort::Low => "low",
+        Effort::Medium => "medium",
+        Effort::High | Effort::Xhigh | Effort::Max => "high",
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,6 +255,37 @@ mod tests {
         assert_eq!(Effort::Max.as_str(), "max");
         // Ordered cheapest-first so a caller can clamp with `min`.
         assert!(Effort::Low < Effort::High && Effort::High < Effort::Max);
+    }
+
+    #[test]
+    fn openai_effort_gates_on_family_and_clamps_the_top() {
+        // The three shared levels pass through by name.
+        assert_eq!(openai_reasoning_effort("gpt-5", Effort::Low), Some("low"));
+        assert_eq!(
+            openai_reasoning_effort("o3-mini", Effort::Medium),
+            Some("medium")
+        );
+        // Top of the scale degrades rather than risking a 400 on a model whose
+        // subset lacks it — the accepted values are model-dependent and there
+        // is no published table to key on.
+        assert_eq!(
+            openai_reasoning_effort("gpt-5", Effort::Xhigh),
+            Some("high")
+        );
+        assert_eq!(openai_reasoning_effort("gpt-5", Effort::Max), Some("high"));
+        // OpenRouter prefixes its models; the family gate must see through it…
+        assert_eq!(
+            openai_reasoning_effort("openai/gpt-5", Effort::Low),
+            Some("low")
+        );
+        // …without letting a non-OpenAI model routed the same way through.
+        assert_eq!(
+            openai_reasoning_effort("google/gemini-3.6-flash", Effort::Low),
+            None
+        );
+        // A local model behind an OpenAI-shaped endpoint takes no such param.
+        assert_eq!(openai_reasoning_effort("llama3.2:3b", Effort::Low), None);
+        assert_eq!(openai_reasoning_effort("gpt-4o", Effort::Low), None);
     }
 
     #[test]


### PR DESCRIPTION
Extends the per-agent effort from #762 past Anthropic. The enum, the profile field and `mur agent effort` were already provider-neutral — only the emitter is provider-specific — so this is one narrowing function plus the OpenAI client's two request paths.

## Checking the docs changed the design

I was going to write this from memory: OpenAI has three levels (`low`/`medium`/`high`), so map 5→3 and lose the top.

**That is wrong.** The current reasoning guide says `reasoning.effort` accepts `none | minimal | low | medium | high | xhigh | max` — a *superset* of MUR's scale. Building from memory would have clamped `xhigh` away for no reason at all.

Same class of mistake as the two defects earlier today (`claude-opus-4-7` in a sampling guard, `builder` hardcoded in a prompt): a fact that was true once, encoded where nothing re-checks it.

## Two narrowings, and why

This client is not "OpenAI" — it is *anything OpenAI-compatible*: OpenRouter, oMLX, LM Studio, any matching endpoint. So the gate cannot be the provider.

**Model family, after stripping `vendor/`.** `openai/gpt-5` matches; `google/gemini-3.6-flash` routed through the same client does not. A local llama behind an OpenAI-shaped endpoint has no idea what the parameter means, and would at best ignore it.

**`Xhigh`/`Max` clamp to `high`.** The docs state accepted values are model-dependent and publish no per-model table, so passing the top of the scale through is a 400 waiting for whichever model lacks it. Degrading matches the call already made for Anthropic's missing `xhigh` step, and today's general rule: never fail the default path, lose a little depth instead. The clamp can lift per-model once a table exists — noted in the doc comment.

## Gemini is deliberately absent

The agent runtime's provider dispatch (`llm/client_builder.rs`) supports `ollama`, `anthropic` and `openai`; `"gemini"` falls through to `unsupported model provider`. A mapping there would be dead code.

Worth flagging separately, because it is a real gap rather than a non-issue: `mur init`'s cloud defaults **do** offer Gemini (and #760 just made `gemini-3.6-flash` its default model). That configuration reaches mur-core's chat backend — which does have a `gemini.rs` — but can never back an agent. Not fixed here; it is a provider-support question, not an effort question.

For the record, since I checked it anyway: Gemini's current knob is `thinking_level` (`minimal | low | medium | high`), a named level rather than the token budget I would have guessed, capping at `high` with per-model subsets.

## Verification

| | |
|---|---|
| `mur-common --lib llm::` | 7/7 (incl. family gate, `vendor/` stripping, clamp) |
| `mur-agent-runtime --lib llm::` | 49/49 |
| `clippy --lib --bins` | zero warnings |
| `cargo fmt --check` | clean |

Not live-tested against the OpenAI API — I have no key wired for it here. The mapping is a pure function with tests; what is unverified is the wire behaviour of a real `reasoning_effort` request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)