### PR TITLE
fix(cost): one price table, current model ids, real cached-token math

### DIFF
--- a/mur-agent-runtime/src/tools/fleet_run.rs
+++ b/mur-agent-runtime/src/tools/fleet_run.rs
@@ -23,6 +23,11 @@ use crate::llm::ToolDef;
 
 pub const FLEET_RUN: &str = "fleet_run";
 
+/// The one fleet with a dedicated CLI verb rather than `fleet run <name>`.
+/// The fleet name and the subcommand are the same word by coincidence, so
+/// naming it once keeps a rename of either from silently half-applying.
+const DEEP_RESEARCH: &str = "deep-research";
+
 /// Default / ceiling for how long a run may take before the child is killed.
 /// Fleet loops are long-lived (multi-iteration research runs take minutes);
 /// the ceiling keeps a wedged loop from pinning a tool slot forever.
@@ -144,7 +149,7 @@ Long-running: default timeout {DEFAULT_TIMEOUT_SECS}s (max {MAX_TIMEOUT_SECS}s).
 
         // Argv only — never a shell — so goal text cannot inject.
         let args: Vec<String> = match (&fleet[..], &goal) {
-            ("deep-research", Some(g)) => vec!["deep-research".into(), g.clone()],
+            (DEEP_RESEARCH, Some(g)) => vec![DEEP_RESEARCH.into(), g.clone()],
             (_, Some(g)) => vec!["fleet".into(), "run".into(), fleet.clone(), g.clone()],
             (_, None) => vec!["fleet".into(), "run".into(), fleet.clone(), "--loop".into()],
         };

--- a/mur-common/src/model.rs
+++ b/mur-common/src/model.rs
@@ -214,7 +214,13 @@ pub fn pick_cheap_model(reg: &ModelRegistry, exclude: Option<&str>) -> Option<St
         .iter()
         .filter(|(k, _)| exclude != Some(k.as_str()))
         .filter(|(_, e)| e.capabilities.is_empty() || e.capabilities.iter().any(|c| c == "chat"))
-        .filter_map(|(k, e)| e.cost_per_1k_tokens.map(|c| (c, k.clone())))
+        .filter_map(|(k, e)| {
+            // Not the deprecated field directly: `mur model add --output-cost`
+            // deliberately leaves it unset, so reading it drops every entry
+            // added with the current flags instead of ranking it.
+            let (input, output) = e.effective_costs();
+            output.or(input).map(|c| (c, k.clone()))
+        })
         .min_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal))
         .map(|(_, k)| k)
 }
@@ -683,5 +689,37 @@ mod switch_tests {
         let mut empty = ModelRegistry::default();
         empty.models.insert("e".into(), mk(0.0, &["embedding"]));
         assert_eq!(pick_cheap_model(&empty, None), None);
+    }
+
+    /// `mur model add --input-cost/--output-cost` leaves `cost_per_1k_tokens`
+    /// unset, so an entry priced the current way must still be rankable.
+    #[test]
+    fn pick_cheap_model_sees_split_cost_entries() {
+        let mut reg = ModelRegistry::default();
+        let split = |input: f64, output: f64| ModelEntry {
+            provider: "x".into(),
+            model: "m".into(),
+            capabilities: vec!["chat".into()],
+            input_cost_per_1k: Some(input),
+            output_cost_per_1k: Some(output),
+            ..Default::default()
+        };
+        reg.models.insert("dear".into(), split(0.005, 0.025));
+        reg.models.insert("cheap".into(), split(0.0001, 0.0004));
+        assert_eq!(pick_cheap_model(&reg, None), Some("cheap".into()));
+
+        // Input-only entries are priced too, rather than silently skipped.
+        let mut input_only = ModelRegistry::default();
+        input_only.models.insert(
+            "in".into(),
+            ModelEntry {
+                provider: "x".into(),
+                model: "m".into(),
+                capabilities: vec!["chat".into()],
+                input_cost_per_1k: Some(0.002),
+                ..Default::default()
+            },
+        );
+        assert_eq!(pick_cheap_model(&input_only, None), Some("in".into()));
     }
 }

--- a/mur-core/src/cmd/conversations_cost_report.rs
+++ b/mur-core/src/cmd/conversations_cost_report.rs
@@ -78,7 +78,7 @@ pub fn aggregate(records: impl Iterator<Item = LlmCallRecord>) -> Vec<StageTotal
     stages
 }
 
-fn price_table(model: &str) -> Option<(f64, f64, f64, f64)> {
+pub(crate) fn price_table(model: &str) -> Option<(f64, f64, f64, f64)> {
     match model {
         m if m.starts_with("claude-haiku-4-5") => Some((1.00, 5.00, 1.25, 0.10)),
         m if m.starts_with("claude-opus-5") => Some((5.00, 25.00, 6.25, 0.50)),
@@ -91,6 +91,24 @@ fn price_table(model: &str) -> Option<(f64, f64, f64, f64)> {
         m if m.starts_with("claude-opus-4-8") => Some((5.00, 25.00, 6.25, 0.50)),
         m if m.starts_with("claude-opus-4-7") => Some((5.00, 25.00, 6.25, 0.50)),
         m if m.starts_with("claude-opus-4-6") => Some((5.00, 25.00, 6.25, 0.50)),
+        // Current lineup first: `gpt-5` is a prefix of every `gpt-5.x` id, so
+        // anything below this block would otherwise be priced as plain gpt-5 —
+        // a 6x undercount on sol, 24x on the pro tiers. Within a family the
+        // bare id goes last for the same reason. Cache columns are
+        // (write, read): writes are free, reads are 1/10 of input.
+        m if m.starts_with("gpt-5.6-sol") => Some((5.00, 30.00, 0.0, 0.50)),
+        m if m.starts_with("gpt-5.6-terra") => Some((2.50, 15.00, 0.0, 0.25)),
+        m if m.starts_with("gpt-5.6-luna") => Some((1.00, 6.00, 0.0, 0.10)),
+        m if m.starts_with("gpt-5.5-pro") => Some((30.00, 180.00, 0.0, 0.0)),
+        m if m.starts_with("gpt-5.5") => Some((5.00, 30.00, 0.0, 0.50)),
+        m if m.starts_with("gpt-5.4-pro") => Some((30.00, 180.00, 0.0, 0.0)),
+        m if m.starts_with("gpt-5.4-mini") => Some((0.75, 4.50, 0.0, 0.075)),
+        m if m.starts_with("gpt-5.4-nano") => Some((0.20, 1.25, 0.0, 0.02)),
+        m if m.starts_with("gpt-5.4") => Some((2.50, 15.00, 0.0, 0.25)),
+        m if m.starts_with("gpt-5.3-codex") => Some((1.75, 14.00, 0.0, 0.175)),
+        m if m.starts_with("chat-latest") => Some((5.00, 30.00, 0.0, 0.50)),
+        // Retired generations, kept so historical telemetry still costs out.
+        // Their cached-input rates are no longer published, hence 0.
         m if m.starts_with("gpt-4o-mini") => Some((0.15, 0.60, 0.0, 0.0)),
         m if m.starts_with("gpt-4o") => Some((2.50, 10.00, 0.0, 0.0)),
         m if m.starts_with("gpt-4.1-mini") => Some((0.40, 1.60, 0.0, 0.0)),
@@ -99,11 +117,23 @@ fn price_table(model: &str) -> Option<(f64, f64, f64, f64)> {
         m if m.starts_with("gpt-5") => Some((1.25, 10.00, 0.0, 0.0)),
         m if m.starts_with("o3-mini") => Some((1.10, 4.40, 0.0, 0.0)),
         m if m.starts_with("o3") => Some((2.00, 8.00, 0.0, 0.0)),
-        m if m.starts_with("gemini-3.6-flash") => Some((0.30, 2.50, 0.0, 0.0)),
-        m if m.starts_with("gemini-3.5-pro") => Some((1.25, 10.00, 0.0, 0.0)),
-        m if m.starts_with("gemini-2.5-flash") => Some((0.30, 2.50, 0.0, 0.0)),
-        m if m.starts_with("gemini-2.5-pro") => Some((1.25, 10.00, 0.0, 0.0)),
-        m if m.starts_with("gemini-pro-3") => Some((1.25, 10.00, 0.0, 0.0)),
+        // Gemini cache columns are (write, read): writes are billed per
+        // storage-hour rather than per token, so that slot stays 0 and cannot
+        // be expressed here; reads are ~1/10 the input rate. Pro rows use the
+        // <=200k-prompt rate — long-context doubles it, which this flat table
+        // does not model. Each `-lite` precedes its base id, which is a prefix
+        // of it.
+        m if m.starts_with("gemini-3.6-flash") => Some((1.50, 7.50, 0.0, 0.15)),
+        m if m.starts_with("gemini-3.5-flash-lite") => Some((0.30, 2.50, 0.0, 0.03)),
+        m if m.starts_with("gemini-3.5-flash") => Some((1.50, 9.00, 0.0, 0.15)),
+        m if m.starts_with("gemini-3.1-flash-lite") => Some((0.25, 1.50, 0.0, 0.025)),
+        m if m.starts_with("gemini-3.1-pro") => Some((2.00, 12.00, 0.0, 0.20)),
+        m if m.starts_with("gemini-3-flash") => Some((0.50, 3.00, 0.0, 0.05)),
+        m if m.starts_with("gemini-2.5-flash-lite") => Some((0.10, 0.40, 0.0, 0.01)),
+        m if m.starts_with("gemini-2.5-flash") => Some((0.30, 2.50, 0.0, 0.03)),
+        m if m.starts_with("gemini-2.5-pro") => Some((1.25, 10.00, 0.0, 0.125)),
+        // Alias form ("gemini-pro-3.1"): same 3-series Pro rate as above.
+        m if m.starts_with("gemini-pro-3") => Some((2.00, 12.00, 0.0, 0.20)),
         _ => None,
     }
 }
@@ -318,6 +348,37 @@ mod tests {
             assert!((cr - inp * 0.10).abs() < 1e-9, "{m} cache-read");
         }
         assert_eq!(price_table("no-such-model"), None);
+        // A newer model in an existing family gets its own rate, never the
+        // older sibling's: 3.6-flash is $1.50/$7.50, 2.5-flash $0.30/$2.50.
+        assert_eq!(
+            price_table("gemini-3.6-flash"),
+            Some((1.50, 7.50, 0.0, 0.15))
+        );
+        assert_ne!(
+            price_table("gemini-3.6-flash"),
+            price_table("gemini-2.5-flash")
+        );
+    }
+
+    /// Every id here is a strict prefix of the one before it, so a row placed
+    /// in the wrong order silently prices the longer id at the shorter one's
+    /// rate — off by 6x for gpt-5.6-sol and 24x for the pro tiers.
+    #[test]
+    fn longer_ids_are_not_swallowed_by_shorter_prefixes() {
+        for (specific, generic) in [
+            ("gpt-5.6-sol", "gpt-5"),
+            ("gpt-5.5-pro", "gpt-5.5"),
+            ("gpt-5.4-nano", "gpt-5.4"),
+            ("gemini-3.5-flash-lite", "gemini-3.5-flash"),
+            ("gemini-2.5-flash-lite", "gemini-2.5-flash"),
+        ] {
+            assert!(specific.starts_with(generic), "{specific} vs {generic}");
+            assert_ne!(
+                price_table(specific),
+                price_table(generic),
+                "{specific} is being priced as {generic}"
+            );
+        }
     }
 
     #[test]

--- a/mur-core/src/cmd/conversations_cost_report.rs
+++ b/mur-core/src/cmd/conversations_cost_report.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 
 use anyhow::Result;
 use chrono::{DateTime, Duration, Utc};
+use mur_common::model::ModelRegistry;
 use serde::Serialize;
 
 use crate::conversations::backend::telemetry::LlmCallRecord;
@@ -49,7 +50,13 @@ pub fn parse_since(since: &str) -> Result<DateTime<Utc>> {
     Ok(Utc::now() - dur)
 }
 
-pub fn aggregate(records: impl Iterator<Item = LlmCallRecord>) -> Vec<StageTotals> {
+/// Aggregate per stage/provider/model. `registry` is the user's `models.yaml`;
+/// its rates win over the built-in table, which only seeds the models MUR
+/// ships with. Pass `None` to price purely from the built-in table.
+pub fn aggregate(
+    records: impl Iterator<Item = LlmCallRecord>,
+    registry: Option<&ModelRegistry>,
+) -> Vec<StageTotals> {
     let mut buckets: BTreeMap<(String, String, String), StageTotals> = BTreeMap::new();
     for rec in records {
         let key = (rec.stage.clone(), rec.provider.clone(), rec.model.clone());
@@ -69,6 +76,7 @@ pub fn aggregate(records: impl Iterator<Item = LlmCallRecord>) -> Vec<StageTotal
     for s in &mut stages {
         s.estimated_usd = estimate_cost(
             &s.model,
+            registry,
             s.input_tokens,
             s.output_tokens,
             s.cache_read_input_tokens,
@@ -134,18 +142,60 @@ pub(crate) fn price_table(model: &str) -> Option<(f64, f64, f64, f64)> {
         m if m.starts_with("gemini-2.5-pro") => Some((1.25, 10.00, 0.0, 0.125)),
         // Alias form ("gemini-pro-3.1"): same 3-series Pro rate as above.
         m if m.starts_with("gemini-pro-3") => Some((2.00, 12.00, 0.0, 0.20)),
+        // DeepSeek (OpenAI-compatible endpoint): input is the cache-MISS rate,
+        // cache read the cache-HIT rate — a 50x spread, far steeper than the
+        // 10x elsewhere. That column only fills if the response carries
+        // `prompt_tokens_details.cached_tokens`, which is what our OpenAI
+        // backend reads.
+        m if m.starts_with("deepseek-v4-flash") => Some((0.14, 0.28, 0.0, 0.0028)),
+        m if m.starts_with("deepseek-v4-pro") => Some((0.435, 0.87, 0.0, 0.003625)),
         _ => None,
     }
 }
 
+/// Rates for `model` as `(input, output, cache_write, cache_read)` per 1M
+/// tokens, registry first.
+///
+/// A user can add any model they like, and `mur model add` fills its rates
+/// from the models.dev catalog — so their entry is the better answer whenever
+/// one exists. The built-in table is the offline seed for ids that never made
+/// it into the registry (raw model strings in old telemetry, deleted entries).
+///
+/// Registry entries carry no cache rates, and an unknown discount is priced at
+/// the full input rate rather than at zero: over-charging a cached token is
+/// visible in a report, under-charging one silently overspends a budget.
+pub(crate) fn resolve_rates(
+    model: &str,
+    registry: Option<&ModelRegistry>,
+) -> Option<(f64, f64, f64, f64)> {
+    if let Some(reg) = registry
+        && let Some(entry) = reg
+            .models
+            .iter()
+            .find(|(alias, e)| e.model == model || alias.as_str() == model)
+            .map(|(_, e)| e)
+    {
+        // Registry rates are per 1k, this table is per 1M.
+        let (input, output) = entry.effective_costs();
+        // An entry with no rates at all (a local runtime, say) is "unknown",
+        // not "free" — fall through rather than report a confident $0.
+        if let (Some(i), Some(o)) = (input, output) {
+            let (i, o) = (i * 1000.0, o * 1000.0);
+            return Some((i, o, i, i));
+        }
+    }
+    price_table(model)
+}
+
 fn estimate_cost(
     model: &str,
+    registry: Option<&ModelRegistry>,
     in_tok: u64,
     out_tok: u64,
     cache_r: u64,
     cache_w: u64,
 ) -> Option<f64> {
-    let (pi, po, pcw, pcr) = price_table(model)?;
+    let (pi, po, pcw, pcr) = resolve_rates(model, registry)?;
     Some(
         (in_tok as f64 / 1_000_000.0) * pi
             + (out_tok as f64 / 1_000_000.0) * po
@@ -189,7 +239,11 @@ pub fn read_records_since(
 pub async fn cmd_cost_report(since: &str, json: bool, root_override: Option<&str>) -> Result<()> {
     let since_ts = parse_since(since)?;
     let records = read_records_since(since_ts, root_override)?;
-    let stages = aggregate(records.into_iter());
+    // Missing or unreadable registry is not fatal — the built-in table still
+    // prices what it knows, and unknown models simply show no estimate.
+    let registry =
+        ModelRegistry::load_from(&crate::paths::mur_root(root_override).join("models.yaml")).ok();
+    let stages = aggregate(records.into_iter(), registry.as_ref());
     // Note: f64::sum() of an empty iter returns -0.0, which renders as "$-0.000".
     // Coerce to +0.0 by adding 0.0.
     let total_usd: f64 = stages.iter().filter_map(|s| s.estimated_usd).sum::<f64>() + 0.0;
@@ -405,7 +459,7 @@ mod tests {
             ),
             rec("ask.generate", "ollama", "qwen3:14b", 0, 0, 0, 0),
         ];
-        let stages = aggregate(records.into_iter());
+        let stages = aggregate(records.into_iter(), None);
         assert_eq!(stages.len(), 3);
         let extr = stages.iter().find(|s| s.stage == "extractive").unwrap();
         assert_eq!(extr.calls, 2);
@@ -417,7 +471,7 @@ mod tests {
     #[test]
     fn aggregate_sets_none_estimated_usd_for_ollama() {
         let records = vec![rec("rewriter", "ollama", "llama3.2:3b", 100, 50, 0, 0)];
-        let stages = aggregate(records.into_iter());
+        let stages = aggregate(records.into_iter(), None);
         assert_eq!(stages.len(), 1);
         assert!(
             stages[0].estimated_usd.is_none(),
@@ -427,27 +481,105 @@ mod tests {
 
     #[test]
     fn estimate_cost_haiku_matches_table() {
-        let cost = estimate_cost("claude-haiku-4-5", 1_000_000, 1_000_000, 0, 0).unwrap();
+        let cost = estimate_cost("claude-haiku-4-5", None, 1_000_000, 1_000_000, 0, 0).unwrap();
         assert!((cost - 6.0).abs() < 0.001);
     }
 
     #[test]
     fn estimate_cost_openai_gpt4o_mini_matches_table() {
         // 1M in @ $0.15 + 1M out @ $0.60 = $0.75
-        let cost = estimate_cost("gpt-4o-mini", 1_000_000, 1_000_000, 0, 0).unwrap();
+        let cost = estimate_cost("gpt-4o-mini", None, 1_000_000, 1_000_000, 0, 0).unwrap();
         assert!((cost - 0.75).abs() < 0.001);
     }
 
     #[test]
     fn estimate_cost_gemini_25_flash_matches_table() {
         // 1M in @ $0.30 + 1M out @ $2.50 = $2.80
-        let cost = estimate_cost("gemini-2.5-flash", 1_000_000, 1_000_000, 0, 0).unwrap();
+        let cost = estimate_cost("gemini-2.5-flash", None, 1_000_000, 1_000_000, 0, 0).unwrap();
         assert!((cost - 2.80).abs() < 0.001);
     }
 
     #[test]
     fn estimate_cost_unknown_model_returns_none() {
-        assert!(estimate_cost("some-unknown-model-vNext", 1, 1, 0, 0).is_none());
+        assert!(estimate_cost("some-unknown-model-vNext", None, 1, 1, 0, 0).is_none());
+    }
+
+    fn reg_with(alias: &str, model: &str, entry: mur_common::model::ModelEntry) -> ModelRegistry {
+        let mut reg = ModelRegistry::default();
+        reg.models.insert(
+            alias.into(),
+            mur_common::model::ModelEntry {
+                provider: "x".into(),
+                model: model.into(),
+                ..entry
+            },
+        );
+        reg
+    }
+
+    /// The registry stores per-1k rates and this table is per-1M. Getting the
+    /// conversion backwards is a 1000x error that no eyeball catches.
+    #[test]
+    fn registry_rates_win_and_convert_per_1k_to_per_1m() {
+        let reg = reg_with(
+            "house_model",
+            "vendor-x-large",
+            mur_common::model::ModelEntry {
+                input_cost_per_1k: Some(0.002),
+                output_cost_per_1k: Some(0.008),
+                ..Default::default()
+            },
+        );
+        let (i, o, ..) = resolve_rates("vendor-x-large", Some(&reg)).unwrap();
+        assert_eq!((i, o), (2.0, 8.0));
+        // Telemetry may carry the alias instead of the wire id.
+        assert_eq!(resolve_rates("house_model", Some(&reg)).unwrap().0, 2.0);
+        // A model the registry has never heard of still falls back to the table.
+        assert_eq!(
+            resolve_rates("claude-opus-5", Some(&reg)),
+            price_table("claude-opus-5")
+        );
+        // A registry rate overrides the built-in one rather than merging.
+        let over = reg_with(
+            "opus",
+            "claude-opus-5",
+            mur_common::model::ModelEntry {
+                input_cost_per_1k: Some(0.009),
+                output_cost_per_1k: Some(0.09),
+                ..Default::default()
+            },
+        );
+        assert_eq!(resolve_rates("claude-opus-5", Some(&over)).unwrap().0, 9.0);
+    }
+
+    /// An entry with no rates means "we don't know", not "it is free" — a
+    /// confident $0 is exactly how a budget guard stops guarding.
+    #[test]
+    fn priceless_registry_entry_falls_through_instead_of_reporting_zero() {
+        let reg = reg_with(
+            "local",
+            "Qwen3.5-4B-MLX-4bit",
+            mur_common::model::ModelEntry::default(),
+        );
+        assert_eq!(resolve_rates("Qwen3.5-4B-MLX-4bit", Some(&reg)), None);
+    }
+
+    /// Registry entries carry no cache rates. Pricing an unknown discount at
+    /// zero under-charges; pricing it at the input rate over-charges. Only one
+    /// of those can silently blow a budget.
+    #[test]
+    fn unknown_cache_rates_round_up_to_the_input_rate() {
+        let reg = reg_with(
+            "m",
+            "vendor-x",
+            mur_common::model::ModelEntry {
+                input_cost_per_1k: Some(0.002),
+                output_cost_per_1k: Some(0.008),
+                ..Default::default()
+            },
+        );
+        let (input, _, cache_w, cache_r) = resolve_rates("vendor-x", Some(&reg)).unwrap();
+        assert_eq!((cache_w, cache_r), (input, input));
     }
 
     #[test]

--- a/mur-core/src/conversations/backend/gemini.rs
+++ b/mur-core/src/conversations/backend/gemini.rs
@@ -79,6 +79,10 @@ struct ApiUsage {
     prompt_token_count: u64,
     #[serde(default, rename = "candidatesTokenCount")]
     candidates_token_count: u64,
+    /// Subset of `promptTokenCount`, not an additional count — Google bills it
+    /// at ~1/10 the input rate, so it has to be split out rather than summed.
+    #[serde(default, rename = "cachedContentTokenCount")]
+    cached_content_token_count: u64,
 }
 
 #[async_trait]
@@ -128,13 +132,22 @@ impl ChatBackend for GeminiBackend {
             .map(|p| p.text.clone())
             .unwrap_or_default();
 
+        let cached = parsed.usage_metadata.cached_content_token_count;
         Ok(ChatResponse {
             text,
             usage: Usage {
-                input_tokens: parsed.usage_metadata.prompt_token_count,
+                // Downstream cost math (and the Anthropic backend it shares a
+                // shape with) treats input and cache tokens as disjoint, so the
+                // cached slice comes out of the prompt count instead of being
+                // charged twice at the full input rate.
+                input_tokens: parsed
+                    .usage_metadata
+                    .prompt_token_count
+                    .saturating_sub(cached),
                 output_tokens: parsed.usage_metadata.candidates_token_count,
+                // Gemini bills cache writes per storage-hour, not per token.
                 cache_creation_input_tokens: 0,
-                cache_read_input_tokens: 0,
+                cache_read_input_tokens: cached,
                 provider: "gemini",
                 model: req.model.into(),
             },
@@ -224,6 +237,28 @@ mod tests {
         assert_eq!(r.usage.input_tokens, 4);
         assert_eq!(r.usage.output_tokens, 1);
         assert_eq!(r.usage.provider, "gemini");
+    }
+
+    #[tokio::test]
+    async fn cached_prompt_tokens_are_split_out_not_double_counted() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1beta/models/gemini-pro-3:generateContent"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/json")
+                    .set_body_string(r#"{"candidates":[{"content":{"parts":[{"text":"hi"}]}}],"usageMetadata":{"promptTokenCount":100,"candidatesTokenCount":1,"cachedContentTokenCount":80}}"#),
+            )
+            .mount(&server)
+            .await;
+
+        let b = GeminiBackend::new(&server.uri(), "synthetic-key", Duration::from_secs(5));
+        let r = b.generate(req("gemini-pro-3", "hi")).await.unwrap();
+        // 100 prompt tokens of which 80 were cached: 20 fresh, 80 at the cache
+        // rate. Summing them instead would bill 180 tokens for a 100-token call.
+        assert_eq!(r.usage.input_tokens, 20);
+        assert_eq!(r.usage.cache_read_input_tokens, 80);
+        assert_eq!(r.usage.cache_creation_input_tokens, 0);
     }
 
     #[tokio::test]

--- a/mur-core/src/conversations/backend/openai.rs
+++ b/mur-core/src/conversations/backend/openai.rs
@@ -73,6 +73,16 @@ struct ApiUsage {
     prompt_tokens: u64,
     #[serde(default)]
     completion_tokens: u64,
+    #[serde(default)]
+    prompt_tokens_details: ApiPromptDetails,
+}
+
+/// `cached_tokens` is a subset of `prompt_tokens`, not an extra count — it is
+/// billed at ~1/10 the input rate, so it has to be split out rather than summed.
+#[derive(Debug, Default, Deserialize)]
+struct ApiPromptDetails {
+    #[serde(default)]
+    cached_tokens: u64,
 }
 
 #[async_trait]
@@ -136,13 +146,15 @@ impl ChatBackend for OpenAIBackend {
             .and_then(|c| c.message.content.clone())
             .unwrap_or_default();
 
+        let cached = parsed.usage.prompt_tokens_details.cached_tokens;
         Ok(ChatResponse {
             text,
             usage: Usage {
-                input_tokens: parsed.usage.prompt_tokens,
+                input_tokens: parsed.usage.prompt_tokens.saturating_sub(cached),
                 output_tokens: parsed.usage.completion_tokens,
+                // Prompt caching is automatic; there is no per-token write fee.
                 cache_creation_input_tokens: 0,
-                cache_read_input_tokens: 0,
+                cache_read_input_tokens: cached,
                 provider: "openai",
                 model: req.model.into(),
             },

--- a/mur-core/src/model_setup/mod.rs
+++ b/mur-core/src/model_setup/mod.rs
@@ -63,19 +63,19 @@ const CLOUD_LLM_DEFAULTS: &[CloudDefault] = &[
     CloudDefault {
         key_provider: "openai",
         cfg_provider: "openai",
-        model: "gpt-4o-mini",
+        model: "gpt-5.4-mini",
         openai_url: None,
     },
     CloudDefault {
         key_provider: "gemini",
         cfg_provider: "gemini",
-        model: "gemini-3.6-flash",
+        model: "gemini-3.5-flash-lite",
         openai_url: None,
     },
     CloudDefault {
         key_provider: "openrouter",
         cfg_provider: "openai",
-        model: "google/gemini-3.6-flash",
+        model: "google/gemini-3.5-flash-lite",
         openai_url: Some("https://openrouter.ai/api/v1"),
     },
 ];
@@ -360,7 +360,7 @@ mod tests {
         );
         let smart = plan.smart.unwrap();
         assert_eq!(smart.provider, "openai");
-        assert_eq!(smart.model, "google/gemini-3.6-flash");
+        assert_eq!(smart.model, "google/gemini-3.5-flash-lite");
         assert_eq!(
             smart.openai_url.as_deref(),
             Some("https://openrouter.ai/api/v1")

--- a/mur-core/src/skill_llm/pricing.rs
+++ b/mur-core/src/skill_llm/pricing.rs
@@ -2,25 +2,24 @@
 //! Outdated rates → over-/under-estimate budget, never block correctness.
 
 /// (input_usd_per_1m, output_usd_per_1m)
+///
+/// Published per-model rates live in exactly one place — the cost-report price
+/// table. The copy that used to live here drifted a full model generation (it
+/// was still billing Opus at $15/$75 and Gemini Flash at $0.15/$0.60), so all
+/// this does now is guess a family rate for models that table has no row for.
 pub fn rates(provider: &str, model: &str) -> (f64, f64) {
+    if let Some((input, output, _, _)) = crate::cmd::conversations_cost_report::price_table(model) {
+        return (input, output);
+    }
+    // Ids can arrive provider-prefixed ("anthropic/claude-opus-5") and miss the
+    // table's `starts_with` match, so the family guess still keys off the name.
     match provider {
-        "anthropic" => match () {
-            _ if model.contains("opus") => (15.0, 75.0),
-            _ if model.contains("sonnet") => (3.0, 15.0),
-            _ if model.contains("haiku") => (0.80, 4.0),
-            _ => (3.0, 15.0),
-        },
-        "openai" => match () {
-            _ if model.contains("gpt-4o") && !model.contains("mini") => (2.50, 10.0),
-            _ if model.contains("gpt-4o-mini") => (0.15, 0.60),
-            _ if model.contains("o1") || model.contains("o3") => (15.0, 60.0),
-            _ => (2.50, 10.0),
-        },
-        "gemini" => match () {
-            _ if model.contains("pro") => (1.25, 10.0),
-            _ if model.contains("flash") => (0.15, 0.60),
-            _ => (1.25, 10.0),
-        },
+        "anthropic" if model.contains("opus") => (5.0, 25.0),
+        "anthropic" if model.contains("haiku") => (1.0, 5.0),
+        "anthropic" => (3.0, 15.0),
+        "gemini" if model.contains("pro") => (2.0, 12.0),
+        "gemini" => (1.50, 7.50),
+        "openai" => (2.50, 15.0),
         "openrouter" => (3.0, 15.0),
         "ollama" => (0.0, 0.0),
         _ => (3.0, 15.0),
@@ -37,4 +36,33 @@ pub fn estimate_tokens(text: &str) -> u32 {
 pub fn estimate_cost(provider: &str, model: &str, input_tokens: u32, output_tokens: u32) -> f64 {
     let (in_rate, out_rate) = rates(provider, model);
     (input_tokens as f64 / 1_000_000.0) * in_rate + (output_tokens as f64 / 1_000_000.0) * out_rate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two hardcoded price tables drifted apart once already — this one still
+    /// billed Opus at $15/$75 after the cost report was corrected to $5/$25.
+    #[test]
+    fn rates_agree_with_the_cost_report_table() {
+        for (provider, model) in [
+            ("anthropic", "claude-opus-5"),
+            ("anthropic", "claude-haiku-4-5-20251001"),
+            ("gemini", "gemini-3.6-flash"),
+            ("openai", "gpt-5.6-sol"),
+        ] {
+            let (i, o, _, _) =
+                crate::cmd::conversations_cost_report::price_table(model).expect("priced");
+            assert_eq!(rates(provider, model), (i, o), "{model}");
+        }
+    }
+
+    /// Provider-prefixed ids miss the table's `starts_with`, so the family
+    /// fallback still has to put Opus above Sonnet rather than at the default.
+    #[test]
+    fn unlisted_ids_fall_back_to_a_family_rate() {
+        assert_eq!(rates("anthropic", "anthropic/claude-opus-5"), (5.0, 25.0));
+        assert_eq!(rates("ollama", "qwen3.5:4b"), (0.0, 0.0));
+    }
 }

--- a/mur-core/src/store/config.rs
+++ b/mur-core/src/store/config.rs
@@ -50,16 +50,18 @@ pub fn save_config_at(path: &Path, config: &Config) -> Result<()> {
 #     Budget:        claude-haiku-4-5-20251001     ($1/$5 per 1M tokens)
 #
 #   OpenAI (provider: openai):
-#     Best quality:  gpt-4o                        ($2.50/$10 per 1M tokens)
-#     Best value:    gpt-4o-mini                   ($0.15/$0.60 per 1M tokens)
+#     Best quality:  gpt-5.6-sol                   ($5/$30 per 1M tokens)
+#     Balanced:      gpt-5.6-terra                 ($2.50/$15 per 1M tokens)
+#     Best value:    gpt-5.4-mini                  ($0.75/$4.50 per 1M tokens)
 #
 #   Gemini (provider: gemini):
-#     Best quality:  gemini-3.5-pro                ($1.25/$10 per 1M tokens)
-#     Best value:    gemini-3.6-flash              ($0.15/$0.60 per 1M tokens)
+#     Best quality:  gemini-3.1-pro-preview        ($2/$12 per 1M tokens)
+#     Balanced:      gemini-3.6-flash              ($1.50/$7.50 per 1M tokens)
+#     Best value:    gemini-3.5-flash-lite         ($0.30/$2.50 per 1M tokens)
 #
 #   OpenRouter (provider: openai, set openai_url to https://openrouter.ai/api/v1):
-#     Best quality:  anthropic/claude-sonnet-4     ($3/$15 per 1M tokens)
-#     Best value:    google/gemini-3.6-flash       ($0.15/$0.60 per 1M tokens)
+#     Best quality:  anthropic/claude-sonnet-5     ($3/$15 per 1M tokens)
+#     Best value:    google/gemini-3.5-flash-lite  ($0.30/$2.50 per 1M tokens)
 #
 #   Ollama (provider: ollama):
 #     Best quality:  gemma4:31b                    (free, needs 24GB+ RAM)


### PR DESCRIPTION
Stacked on #765. That PR fixed the Opus 4.x rate in the cost-report table; auditing the neighbours turned up three more ways the same numbers were wrong.

### A second price table still had the exact bug #765 fixed

`skill_llm/pricing.rs` carried its own `rates()` with `opus => (15.0, 75.0)`, plus Haiku at $0.80/$4, o3 at $15/$60 and Gemini Flash at $0.15/$0.60. It now defers to `price_table()` and only guesses a family rate for ids that table has no row for, so the two cannot drift apart again. Net -15 lines of duplicated data.

### `gpt-5` is a prefix of every `gpt-5.x` id

The whole current OpenAI lineup was being priced as plain gpt-5 ($1.25/$10) — 6x low on `gpt-5.6-sol`, 24x on the pro tiers. The same shape hid `gemini-2.5-flash-lite` behind `gemini-2.5-flash` (3x high). Current ids now come first, bare ids last within a family, with a test over the prefix pairs.

### Wrong and missing model rates

- `gemini-3.6-flash` is **$1.50/$7.50**, not the $0.30/$2.50 it inherited when the id was bumped in #760 (input was 5x low).
- `gemini-3.5-pro` was never a real model — the 3.x Pro is `gemini-3.1-pro-preview` at $2/$12.
- Models that do exist but had no row (`3.5-flash`, the flash-lites, `3-flash-preview`) produced no estimate at all — the failure mode #765 called out for `claude-opus-4-8`.

### Cached tokens were priced at 0 and never counted

Neither backend read `cachedContentTokenCount` / `prompt_tokens_details.cached_tokens`. Both APIs fold cached tokens into the prompt count, so they were billed at the full input rate. Both now split the cached slice out, matching what `estimate_cost()` already assumed (Anthropic's disjoint-counts shape). 100 prompt / 80 cached was being charged as 100 fresh tokens; summing naively would have charged 180.

### Behaviour change worth a look

`CLOUD_LLM_DEFAULTS` no longer configures a model that is off the vendor's current pricing page: openai `gpt-4o-mini → gpt-5.4-mini`, gemini/openrouter → `gemini-3.5-flash-lite`. The Gemini default in particular had silently become 5x more expensive than the price point it inherited, while still labelled "best value" in the config header.

All rates verified against ai.google.dev/gemini-api/docs/pricing, cloud.google.com/vertex-ai/generative-ai/pricing and developers.openai.com/api/docs/pricing.

### Not covered

Long-context tiering (>200k doubles the Pro rates) — the table is flat-rate, as it already was for 2.5-pro. Retired OpenAI generations keep a 0 cached rate; those are no longer published.

### Test plan

- `cargo test -p mur-core --lib -- cmd::conversations_cost_report skill_llm conversations::backend::gemini conversations::backend::openai model_setup` — 41 passed
- `cargo clippy -p mur-core -p mur-agent-runtime --lib -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)