### PR TITLE
feat(cost): reach the user's rates on the last two paths

### DIFF
--- a/mur-core/src/cmd/fleet/loop_run.rs
+++ b/mur-core/src/cmd/fleet/loop_run.rs
@@ -205,19 +205,32 @@ fn dearest_output_rate(reg: &mur_common::model::ModelRegistry) -> Option<f64> {
     (max > 0.0).then_some(max)
 }
 
-fn fleet_price_per_1k(mur_home: &Path) -> f64 {
+/// Where the guard's flat rate came from. A budget enforced on a guess is
+/// still worth enforcing, but the user has to be told it is a guess: a run
+/// that stops early and a run that stops on target look identical otherwise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuardRate {
+    /// `MUR_FLEET_COST_PER_1K`.
+    Env,
+    /// Dearest output rate in `models.yaml`.
+    Registry,
+    /// `DEFAULT_PRICE_PER_1K` — nothing in the registry carries a rate.
+    Default,
+}
+
+fn fleet_price_per_1k(mur_home: &Path) -> (f64, GuardRate) {
     if let Ok(v) = std::env::var("MUR_FLEET_COST_PER_1K")
         && let Ok(p) = v.parse::<f64>()
         && p > 0.0
     {
-        return p;
+        return (p, GuardRate::Env);
     }
     if let Ok(reg) = mur_common::model::ModelRegistry::load_from(&mur_home.join("models.yaml"))
         && let Some(rate) = dearest_output_rate(&reg)
     {
-        return rate;
+        return (rate, GuardRate::Registry);
     }
-    DEFAULT_PRICE_PER_1K
+    (DEFAULT_PRICE_PER_1K, GuardRate::Default)
 }
 
 /// Resolve this iteration's goal: oldest queued job (marking it Running) beats
@@ -340,6 +353,18 @@ pub async fn run_guarded(
     let deadline = effective_deadline(deadline.as_deref(), &fleet);
     let budget = effective_budget(budget_usd, &fleet);
     let price_per_1k = fleet_price_per_1k(mur_home);
+    if let (rate, GuardRate::Default) = price_per_1k
+        && budget.is_some()
+    {
+        // Enforcing on a guess is better than not enforcing, but silently
+        // enforcing on one turns "stopped on budget" into a number the user
+        // has no way to reconcile against a real bill.
+        println!(
+            "  ⚠ budget enforced at the default ${rate}/1k — no model in models.yaml \
+             carries a rate, so spend is a guess. `mur model add` records a real one."
+        );
+    }
+    let price_per_1k = price_per_1k.0;
     // Forward estimate before any real data (and the fail-safe fallback when an
     // iteration reports no token usage), so spend can never silently under-count.
     let projection = estimate_iteration_cost_usd(fleet.members.len(), price_per_1k);
@@ -863,10 +888,14 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         // env override wins (nextest isolates per-process, so this is safe)
         unsafe { std::env::set_var("MUR_FLEET_COST_PER_1K", "0.123") };
-        assert!((fleet_price_per_1k(tmp.path()) - 0.123).abs() < 1e-9);
-        // no env + no models.yaml → documented default
+        let (rate, src) = fleet_price_per_1k(tmp.path());
+        assert!((rate - 0.123).abs() < 1e-9);
+        assert_eq!(src, GuardRate::Env);
+        // no env + no models.yaml → documented default, and it says so
         unsafe { std::env::remove_var("MUR_FLEET_COST_PER_1K") };
-        assert!((fleet_price_per_1k(tmp.path()) - DEFAULT_PRICE_PER_1K).abs() < 1e-9);
+        let (rate, src) = fleet_price_per_1k(tmp.path());
+        assert!((rate - DEFAULT_PRICE_PER_1K).abs() < 1e-9);
+        assert_eq!(src, GuardRate::Default);
     }
 
     /// The budget guard bills one flat rate against an iteration's whole token

--- a/mur-core/src/skill_llm/mod.rs
+++ b/mur-core/src/skill_llm/mod.rs
@@ -144,12 +144,7 @@ pub async fn maintenance_call(
     };
 
     // Budget check (pre-flight)
-    let projected_cost = pricing::estimate_cost(
-        &entry.provider,
-        &entry.model,
-        budget.max_input,
-        budget.max_output,
-    );
+    let projected_cost = pricing::estimate_cost(&entry, budget.max_input, budget.max_output);
     if let Err(spent) =
         budget::check_and_reserve(&ctx.budget_ledger, projected_cost, ctx.daily_cap_usd)
     {
@@ -192,12 +187,7 @@ pub async fn maintenance_call(
     // Budget settle (actual cost)
     let actual_input_tokens = resp.usage.input_tokens as u32;
     let actual_output_tokens = resp.usage.output_tokens as u32;
-    let actual_cost = pricing::estimate_cost(
-        &entry.provider,
-        &entry.model,
-        actual_input_tokens,
-        actual_output_tokens,
-    );
+    let actual_cost = pricing::estimate_cost(&entry, actual_input_tokens, actual_output_tokens);
     let _ = budget::settle(&ctx.budget_ledger, projected_cost, actual_cost);
 
     // Cache

--- a/mur-core/src/skill_llm/pricing.rs
+++ b/mur-core/src/skill_llm/pricing.rs
@@ -1,5 +1,22 @@
-//! Hard-coded per-provider USD / 1M-token rates for budget estimation.
+//! Per-1M-token USD rates for skill-LLM budget estimation.
 //! Outdated rates → over-/under-estimate budget, never block correctness.
+
+use mur_common::model::ModelEntry;
+
+/// `(input, output)` per 1M tokens for a registry entry.
+///
+/// The user's own rate wins — `mur model add` records one from the models.dev
+/// catalog, and until now nothing on this path read it, so a model MUR had
+/// never heard of was budgeted from a family guess while its real price sat in
+/// the registry. An entry priced on only one side is treated as unpriced
+/// rather than half-believed.
+pub fn rates_for(entry: &ModelEntry) -> (f64, f64) {
+    // The registry is per-1k and this module is per-1M.
+    if let (Some(input), Some(output)) = entry.effective_costs() {
+        return (input * 1000.0, output * 1000.0);
+    }
+    rates(&entry.provider, &entry.model)
+}
 
 /// (input_usd_per_1m, output_usd_per_1m)
 ///
@@ -32,9 +49,9 @@ pub fn estimate_tokens(text: &str) -> u32 {
     (text.chars().count() as f64 / 4.0).ceil() as u32
 }
 
-/// Estimate cost in USD for a provider + model + token counts.
-pub fn estimate_cost(provider: &str, model: &str, input_tokens: u32, output_tokens: u32) -> f64 {
-    let (in_rate, out_rate) = rates(provider, model);
+/// Estimate cost in USD for a registry entry + token counts.
+pub fn estimate_cost(entry: &ModelEntry, input_tokens: u32, output_tokens: u32) -> f64 {
+    let (in_rate, out_rate) = rates_for(entry);
     (input_tokens as f64 / 1_000_000.0) * in_rate + (output_tokens as f64 / 1_000_000.0) * out_rate
 }
 
@@ -64,5 +81,43 @@ mod tests {
     fn unlisted_ids_fall_back_to_a_family_rate() {
         assert_eq!(rates("anthropic", "anthropic/claude-opus-5"), (5.0, 25.0));
         assert_eq!(rates("ollama", "qwen3.5:4b"), (0.0, 0.0));
+    }
+
+    fn entry(provider: &str, model: &str, input: Option<f64>, output: Option<f64>) -> ModelEntry {
+        ModelEntry {
+            provider: provider.into(),
+            model: model.into(),
+            input_cost_per_1k: input,
+            output_cost_per_1k: output,
+            ..Default::default()
+        }
+    }
+
+    /// The registry is per-1k and this module is per-1M. Getting the conversion
+    /// backwards is a 1000x budget error that no eyeball catches.
+    #[test]
+    fn registry_rate_wins_and_converts_per_1k_to_per_1m() {
+        let e = entry("openai", "vendor-x", Some(0.002), Some(0.008));
+        assert_eq!(rates_for(&e), (2.0, 8.0));
+        // 1M in + 1M out at those rates = $10.
+        assert!((estimate_cost(&e, 1_000_000, 1_000_000) - 10.0).abs() < 1e-9);
+    }
+
+    /// A model MUR has never heard of is exactly the case the registry exists
+    /// for — before this it was budgeted from a provider guess while its real
+    /// rate sat one lookup away.
+    #[test]
+    fn unknown_model_uses_its_registry_rate_not_the_family_guess() {
+        let e = entry("openai", "some-vendor-model-v9", Some(0.01), Some(0.04));
+        assert_eq!(rates_for(&e), (10.0, 40.0));
+        assert_ne!(rates_for(&e), rates("openai", "some-vendor-model-v9"));
+    }
+
+    /// Half a price is not a price: a one-sided entry falls back rather than
+    /// pairing a real rate with a zero.
+    #[test]
+    fn half_priced_entry_falls_back_instead_of_pairing_with_zero() {
+        let e = entry("anthropic", "claude-opus-5", Some(0.005), None);
+        assert_eq!(rates_for(&e), (5.0, 25.0)); // from the table, not (5.0, 0.0)
     }
 }


### PR DESCRIPTION
Closes out the pricing work from #766-#768. Two paths still could not see the user's own rates.

### Stage 1.5 — skill-LLM budgeting was blind to the registry

`pricing::estimate_cost` took `(provider, model)` strings and guessed a family rate. The call site in `skill_llm/mod.rs` already held the `ModelEntry` — it was reading the provider and model *out of* that entry and throwing the prices away. So a model MUR has never heard of, which is exactly what the registry exists for, got budgeted from a provider guess while its real rate (recorded by `mur model add` from the models.dev catalog) sat one lookup away.

`estimate_cost` now takes the entry. Two edges are pinned by tests:

- **Units.** The registry is per-1k, this module per-1M. Backwards is a 1000x budget error and nothing catches it by eye.
- **Half a price is not a price.** An entry priced on one side only falls back to the table rather than pairing a real input rate with a zero output rate.

### Stage 3 — the guard no longer enforces on a guess silently

`fleet_price_per_1k` could fall through to `DEFAULT_PRICE_PER_1K` without a word. Enforcing a budget on a guess beats not enforcing one, so this does not refuse — but doing it silently turns "stopped on budget" into a number the user cannot reconcile against a real bill. The function now reports which of env / registry / default it used, and a run enforcing a budget on the default says so once, up front.

### What I did not build, and why

The plan also had `mur doctor` flagging a stale price catalog. On reading it, `mur doctor` is a **build-environment** doctor — cargo, rustc, node, tauri, signing — so a runtime-config check would not belong there. More to the point, after #766 the catalog cache is a transient fetch cache, not the source of truth: prices are copied into `models.yaml` at `mur model add` time. Flagging the cache would be noise.

The staleness that *would* matter is a registry entry written six months ago against a price that has since moved. `ModelEntry` has no timestamp, so detecting that needs a `priced_at` field — a schema change that deserves its own decision rather than being smuggled in here.

### Test plan

- `cargo test -p mur-core --lib -- skill_llm cmd::fleet::loop_run` — 27 passed
- `cargo clippy -p mur-core --lib -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)