### PR TITLE
feat(model): date the rates in models.yaml

### DIFF
--- a/mur-common/src/model.rs
+++ b/mur-common/src/model.rs
@@ -51,6 +51,14 @@ pub struct ModelEntry {
     /// Model context window size in tokens.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context_window: Option<u64>,
+    /// When the rates above were recorded.
+    ///
+    /// Vendors move prices; a rate written months ago is a guess wearing the
+    /// costume of a fact, and nothing else on this struct can tell the two
+    /// apart. `None` means unknown — entries predating this field, or hand-
+    /// written ones — which is honest rather than defaulting to "fresh".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub priced_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl ModelEntry {
@@ -62,6 +70,26 @@ impl ModelEntry {
         let output = self.output_cost_per_1k.or(self.cost_per_1k_tokens);
         let input = self.input_cost_per_1k.or(self.cost_per_1k_tokens);
         (input, output)
+    }
+
+    /// Whether this entry carries any rate at all.
+    pub fn is_priced(&self) -> bool {
+        let (input, output) = self.effective_costs();
+        input.is_some() || output.is_some()
+    }
+
+    /// Stamp `priced_at` with `now`, but only if a rate is actually present —
+    /// a date on an unpriced entry would claim a freshness it does not have.
+    /// Never overwrites an existing stamp with an older one.
+    pub fn stamp_priced_at(&mut self, now: chrono::DateTime<chrono::Utc>) {
+        if self.is_priced() && self.priced_at.is_none_or(|prev| prev < now) {
+            self.priced_at = Some(now);
+        }
+    }
+
+    /// How long ago the rates were recorded, or `None` when unstamped.
+    pub fn price_age(&self, now: chrono::DateTime<chrono::Utc>) -> Option<chrono::TimeDelta> {
+        self.priced_at.map(|at| now - at)
     }
 }
 
@@ -276,6 +304,7 @@ models:
                 input_cost_per_1k: None,
                 output_cost_per_1k: None,
                 context_window: None,
+                priced_at: None,
             },
         );
         let s = serde_yaml_ng::to_string(&r).unwrap();
@@ -335,6 +364,7 @@ roles:
                 input_cost_per_1k: None,
                 output_cost_per_1k: None,
                 context_window: None,
+                priced_at: None,
             },
         );
         reg.roles.insert(
@@ -365,6 +395,7 @@ roles:
                 input_cost_per_1k: None,
                 output_cost_per_1k: None,
                 context_window: None,
+                priced_at: None,
             },
         );
         reg.roles.insert(
@@ -419,6 +450,7 @@ models:
                 input_cost_per_1k: None,
                 output_cost_per_1k: None,
                 context_window: None,
+                priced_at: None,
             },
         );
         let yaml = serde_yaml_ng::to_string(&r2).unwrap();
@@ -563,6 +595,7 @@ mod io_tests {
                 input_cost_per_1k: None,
                 output_cost_per_1k: None,
                 context_window: None,
+                priced_at: None,
             },
         );
         r.save_to(&p).unwrap();
@@ -689,6 +722,65 @@ mod switch_tests {
         let mut empty = ModelRegistry::default();
         empty.models.insert("e".into(), mk(0.0, &["embedding"]));
         assert_eq!(pick_cheap_model(&empty, None), None);
+    }
+
+    /// A price with no date is a guess wearing the costume of a fact. But a
+    /// date on an entry that carries no price would be the same lie in the
+    /// other direction, so the stamp is conditional on there being a rate.
+    #[test]
+    fn priced_at_stamps_only_priced_entries() {
+        let now = chrono::Utc::now();
+
+        let mut unpriced = ModelEntry {
+            provider: "openai".into(),
+            model: "local-thing".into(),
+            ..Default::default()
+        };
+        unpriced.stamp_priced_at(now);
+        assert_eq!(unpriced.priced_at, None);
+        assert_eq!(unpriced.price_age(now), None);
+
+        let mut priced = ModelEntry {
+            output_cost_per_1k: Some(0.025),
+            ..unpriced.clone()
+        };
+        priced.stamp_priced_at(now);
+        assert_eq!(priced.priced_at, Some(now));
+
+        // A legacy single-rate entry counts as priced.
+        let mut legacy = ModelEntry {
+            cost_per_1k_tokens: Some(0.01),
+            ..unpriced.clone()
+        };
+        legacy.stamp_priced_at(now);
+        assert!(legacy.priced_at.is_some());
+
+        // Re-stamping never moves the date backwards.
+        let earlier = now - chrono::TimeDelta::days(30);
+        priced.stamp_priced_at(earlier);
+        assert_eq!(priced.priced_at, Some(now));
+    }
+
+    /// Entries written before this field existed must keep loading, and must
+    /// report an unknown age rather than inheriting today's date.
+    #[test]
+    fn registry_without_priced_at_still_loads_and_reports_unknown_age() {
+        let yaml = r#"
+schema_version: 1
+models:
+  opus:
+    provider: anthropic
+    model: claude-opus-5
+    input_cost_per_1k: 0.005
+    output_cost_per_1k: 0.025
+"#;
+        let reg: ModelRegistry = serde_yaml_ng::from_str(yaml).unwrap();
+        let e = &reg.models["opus"];
+        assert_eq!(e.priced_at, None);
+        assert_eq!(e.price_age(chrono::Utc::now()), None);
+        // Round-trips without inventing the field.
+        let out = serde_yaml_ng::to_string(&reg).unwrap();
+        assert!(!out.contains("priced_at"), "{out}");
     }
 
     /// `mur model add --input-cost/--output-cost` leaves `cost_per_1k_tokens`

--- a/mur-core/src/cmd/model.rs
+++ b/mur-core/src/cmd/model.rs
@@ -211,6 +211,26 @@ pub fn apply_fetched_prices(mut entry: ModelEntry, fetched: Option<PriceInfo>) -
     }
     entry
 }
+/// Human-readable age of an entry's recorded rates.
+///
+/// Unstamped entries say "unknown" rather than borrowing today's date — the
+/// whole point of the field is to distinguish a rate someone checked from one
+/// that has been sitting there since a vendor's last price change.
+fn price_age_label(entry: &ModelEntry) -> String {
+    match entry.price_age(chrono::Utc::now()) {
+        None => "unknown (predates price stamping, or hand-written)".into(),
+        Some(age) => {
+            let days = age.num_days();
+            match days {
+                d if d < 0 => "just now".into(),
+                0 => "today".into(),
+                1 => "yesterday".into(),
+                d if d < 60 => format!("{d} days ago"),
+                d => format!("{} months ago — re-check with `mur model add`", d / 30),
+            }
+        }
+    }
+}
 
 pub fn run(args: ModelArgs) -> anyhow::Result<()> {
     let path = ModelRegistry::default_path()?;
@@ -255,7 +275,7 @@ pub fn run(args: ModelArgs) -> anyhow::Result<()> {
                 cost_per_1k,
             );
             let is_local = matches!(tier, Some(RouteTier::Local));
-            let entry = if no_fetch {
+            let mut entry = if no_fetch {
                 entry
             } else {
                 let mur_home = path.parent().map(|p| p.to_path_buf()).unwrap_or_default();
@@ -266,6 +286,9 @@ pub fn run(args: ModelArgs) -> anyhow::Result<()> {
                 }
                 e
             };
+            // One stamp point for every source of a rate — flags, catalog, or
+            // both — so no path can record a price without dating it.
+            entry.stamp_priced_at(chrono::Utc::now());
             reg.models.insert(name.clone(), entry);
             reg.save_to(&path)?;
             println!("Added model {name} → {}", path.display());
@@ -350,6 +373,7 @@ fn cmd_prices(
                     if let Some(ctx) = p.context_window {
                         println!("  context: {ctx} tokens");
                     }
+                    println!("  recorded: {}", price_age_label(entry));
                 }
                 None => {
                     println!(


### PR DESCRIPTION
Last piece of the pricing work (#766-#769). Those made a registry rate load-bearing — it overrides the built-in table and it sets the fleet budget ceiling — but nothing recorded *when* it was written.

Vendors move prices. A rate from six months ago is a guess wearing the costume of a fact, and no other field on the entry can tell the two apart.

### What it does

`priced_at: Option<DateTime<Utc>>` on `ModelEntry`, stamped at the single point in `mur model add` where every source of a rate converges — explicit flags and catalog auto-fill alike — so no path can record a price without dating it.

Three decisions worth flagging:

- **Stamped only when a rate is actually present.** Dating an unpriced entry is the same lie pointed the other way.
- **Re-stamping never moves the date backwards.**
- **No staleness threshold.** What counts as too old is a policy call; inventing a number here would bury it where nobody would find it. `mur model prices show` reports the age and nudges past 60 days; the judgement stays with the reader.

Entries already on disk stay unstamped and read as **unknown** rather than quietly adopting today's date — nobody knows when those numbers were last checked, and that is the honest answer. Re-running `mur model add` stamps them.

### Compatibility

`#[serde(default, skip_serializing_if = "Option::is_none")]`: old files load, and a registry without the field round-trips without gaining it (asserted in `registry_without_priced_at_still_loads_and_reports_unknown_age`).

Adding a field to a `mur-common` shared type can break the workspace-excluded Tauri crates, which `cargo build -p mur-core` never compiles. I grepped every `ModelEntry {` literal across all 19 files that construct one: all 5 in `mur-hub-gui` (including the production one in `models_admin.rs`) already use `..Default::default()`, and `mur-agent-gui` does not use the type. The 5 exhaustive literals in `mur-common`'s own tests are updated.

### Test plan

- `cargo nextest run -p mur-common -p mur-core --lib -E 'test(model) or test(skill_llm) or test(loop_run) or test(cost_report) or test(priced_at)'` — 140 passed
- `cargo clippy -p mur-common -p mur-core -p mur-agent-runtime --lib -- -D warnings` — clean

(Plain `cargo test` shows 3 unrelated failures in this area — `provision_threads_explicit_model_alias` and friends pass individually and under nextest; they are the known `MUR_HOME` cross-test interference this repo uses nextest to avoid.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)