### PR TITLE
feat(agent cli): /channels N --follow live-tails another channel

### DIFF
--- a/mur-channel/src/store.rs
+++ b/mur-channel/src/store.rs
@@ -22,7 +22,9 @@ impl ChannelStore {
     fn channel_dir(&self, id: &str) -> PathBuf {
         self.root.join(id)
     }
-    fn events_path(&self, id: &str) -> PathBuf {
+    /// Path of a channel's append-only log. Public so a reader can cheaply
+    /// gate on its length instead of re-parsing an unchanged log.
+    pub fn events_path(&self, id: &str) -> PathBuf {
         self.channel_dir(id).join("events.jsonl")
     }
     fn manifest_path(&self, id: &str) -> PathBuf {

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -145,8 +145,12 @@ pub enum SlashCmd {
     Clear,
     Card,
     Sessions,
-    /// `/channels [N]` — list channels or switch to channel N.
-    Channels(Option<usize>),
+    /// `/channels [N] [--follow]` — list channels, switch to channel N, or
+    /// live-tail channel N (`--follow` with no N stops following).
+    Channels {
+        n: Option<usize>,
+        follow: bool,
+    },
     /// `/auto [on|off]` — toggle (None) or set session-wide auto-approval.
     Auto(Option<bool>),
     /// `/verbose [on|off]` — toggle (None) or set expanded tool-card rendering.
@@ -175,7 +179,11 @@ pub fn parse_slash(line: &str) -> Option<SlashCmd> {
         "card" => SlashCmd::Card,
         "sessions" | "ls" => SlashCmd::Sessions,
         "channels" | "chan" => {
-            SlashCmd::Channels(words.next().and_then(|s| s.parse::<usize>().ok()))
+            let args: Vec<&str> = words.collect();
+            SlashCmd::Channels {
+                n: args.iter().find_map(|s| s.parse::<usize>().ok()),
+                follow: args.iter().any(|s| *s == "--follow" || *s == "-f"),
+            }
         }
         "auto" => SlashCmd::Auto(match words.next() {
             Some("on") => Some(true),
@@ -435,6 +443,9 @@ pub struct App {
     /// (/clear, /channels switch): the event loop wipes screen + scrollback
     /// and re-anchors a fresh viewport before the next draw.
     pub wants_screen_wipe: bool,
+    /// A channel being live-tailed (`/channels N --follow`) — someone else's
+    /// conversation, not this pane's. `None` = not following.
+    pub follow: Option<super::follow::Follow>,
     /// Sent-message history for shell-style ↑/↓ recall in the composer.
     pub sent_history: Vec<String>,
     /// Current position while browsing `sent_history` (None = not browsing).
@@ -515,6 +526,7 @@ impl App {
             pending_suggestions: Vec::new(),
             suggestion_ghost: None,
             wants_screen_wipe: false,
+            follow: None,
             sent_history: Vec::new(),
             hist_idx: None,
             hist_stash: String::new(),
@@ -976,8 +988,38 @@ impl App {
         Ok(())
     }
 
-    /// Load prior turns into the transcript (resume), threading the last agent
-    /// task id as context.
+    /// Begin live-tailing `channel_id` (`/channels N --follow`). Refuses this
+    /// pane's own channel: its turns are already in the transcript and the
+    /// tail would double-render every one of them.
+    pub fn start_follow(
+        &mut self,
+        channel_id: &str,
+        now: std::time::Instant,
+    ) -> anyhow::Result<()> {
+        if self.channel.as_ref().is_some_and(|c| c.id == channel_id) {
+            anyhow::bail!("that is the channel this pane is on — nothing to follow");
+        }
+        self.follow = Some(super::follow::Follow::start(&self.home, channel_id, now)?);
+        Ok(())
+    }
+
+    /// Render whatever landed in the followed channel. Any error stops
+    /// following — a vanished channel must not report itself every poll.
+    pub fn poll_follow(&mut self, now: std::time::Instant) {
+        let Some(mut f) = self.follow.take() else {
+            return;
+        };
+        match f.drain(&self.home, now) {
+            Ok(lines) => {
+                for l in lines {
+                    self.push_system(l);
+                }
+                self.follow = Some(f);
+            }
+            Err(e) => self.push_system(format!("follow {} stopped: {e:#}", f.tag())),
+        }
+    }
+
     /// Record a completed `!command` run: show it, persist it, and queue it
     /// for the agent's next turn.
     pub fn push_shell(&mut self, cmd: &str, output: &str) {
@@ -1405,13 +1447,30 @@ mod tests {
 
     #[test]
     fn parse_slash_channels() {
-        assert_eq!(parse_slash("/channels"), Some(SlashCmd::Channels(None)));
+        let plain = |n| Some(SlashCmd::Channels { n, follow: false });
+        assert_eq!(parse_slash("/channels"), plain(None));
+        assert_eq!(parse_slash("/channels 2"), plain(Some(2)));
+        assert_eq!(parse_slash("/chan"), plain(None));
+        assert_eq!(parse_slash("/channels x"), plain(None));
+        // The flag is order-independent, and `-f` is the short form. No N with
+        // `--follow` means "stop following".
+        for line in ["/channels 2 --follow", "/channels --follow 2", "/chan -f 2"] {
+            assert_eq!(
+                parse_slash(line),
+                Some(SlashCmd::Channels {
+                    n: Some(2),
+                    follow: true
+                }),
+                "{line}"
+            );
+        }
         assert_eq!(
-            parse_slash("/channels 2"),
-            Some(SlashCmd::Channels(Some(2)))
+            parse_slash("/channels --follow"),
+            Some(SlashCmd::Channels {
+                n: None,
+                follow: true
+            })
         );
-        assert_eq!(parse_slash("/chan"), Some(SlashCmd::Channels(None)));
-        assert_eq!(parse_slash("/channels x"), Some(SlashCmd::Channels(None)));
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/complete.rs
+++ b/mur-core/src/cmd/agent/cli/complete.rs
@@ -39,7 +39,11 @@ pub struct CompletionState {
 const COMMANDS: &[(&str, &str, &[&str])] = &[
     ("auto", "session-wide auto-approval", &["on", "off"]),
     ("card", "show this agent's card", &[]),
-    ("channels", "list or switch channels", &[]),
+    (
+        "channels",
+        "list, switch, or follow channels",
+        &["--follow"],
+    ),
     ("clear", "start a new conversation", &[]),
     ("help", "show the command cheatsheet", &[]),
     (

--- a/mur-core/src/cmd/agent/cli/follow.rs
+++ b/mur-core/src/cmd/agent/cli/follow.rs
@@ -1,0 +1,260 @@
+//! `/channels N --follow` — live-tail ANOTHER channel while you keep chatting
+//! in your own.
+//!
+//! Work that MUR (or a fleet) delegates to this agent lands in a *shared*
+//! channel, not the one this pane chats on — the pane's stream is turn-scoped
+//! and only ever shows the task it dialed itself. Following that channel is how
+//! the operator watches delegated work land, and spots a HITL gate, without
+//! switching away from their own conversation (a switch only ever shows a disk
+//! snapshot, and would then mix the operator's own turns into it).
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use mur_channel::ChannelStore;
+use mur_common::channel::{ChannelActor, ChannelEvent, EventKind};
+use mur_common::hitl::{HitlRequest, HitlResponse};
+
+/// How often a followed channel is re-read. Each poll is one `metadata()` call
+/// unless the log actually grew, so this is not a hot loop.
+pub const POLL_INTERVAL: Duration = Duration::from_millis(700);
+
+/// Longest event text carried into one transcript line.
+const TEXT_MAX: usize = 400;
+
+/// A followed channel: a byte-length gate plus a `seq` cursor over its
+/// append-only log.
+pub struct Follow {
+    pub channel_id: String,
+    /// Highest `seq` already rendered — the dedup cursor. Starts at the log's
+    /// current head so following never replays history.
+    cursor: u64,
+    /// Log size at the last poll. Unchanged size means nothing to parse.
+    /// ponytail: re-parses the whole log when it grows; switch to a byte-offset
+    /// seek if a followed channel ever gets long enough to notice.
+    last_len: u64,
+    pub next_poll: Instant,
+}
+
+impl Follow {
+    /// Start following `channel_id` from its current head.
+    pub fn start(home: &Path, channel_id: &str, now: Instant) -> Result<Self> {
+        let store = ChannelStore::new(home);
+        let evs = store.load_events(channel_id)?;
+        Ok(Self {
+            channel_id: channel_id.to_string(),
+            cursor: evs.last().map(|e| e.seq).unwrap_or(0),
+            last_len: log_len(&store, channel_id),
+            next_poll: now + POLL_INTERVAL,
+        })
+    }
+
+    /// Short display tag for transcript lines.
+    pub fn tag(&self) -> &str {
+        &self.channel_id[..self.channel_id.len().min(8)]
+    }
+
+    /// Lines for events that landed since the last poll, oldest-first. Empty
+    /// when nothing landed.
+    pub fn drain(&mut self, home: &Path, now: Instant) -> Result<Vec<String>> {
+        self.next_poll = now + POLL_INTERVAL;
+        let store = ChannelStore::new(home);
+        let len = log_len(&store, &self.channel_id);
+        if len == self.last_len {
+            return Ok(Vec::new());
+        }
+        self.last_len = len;
+        let evs = store.load_events(&self.channel_id)?;
+        let mut out = Vec::new();
+        let cursor = self.cursor;
+        for ev in evs.iter().filter(|e| e.seq > cursor) {
+            self.cursor = ev.seq;
+            out.push(format!(
+                "⟨{}⟩ {}",
+                self.tag(),
+                summarize(ev, &self.channel_id)
+            ));
+        }
+        Ok(out)
+    }
+}
+
+fn log_len(store: &ChannelStore, id: &str) -> u64 {
+    std::fs::metadata(store.events_path(id))
+        .map(|m| m.len())
+        .unwrap_or(0)
+}
+
+/// One transcript line for a followed event: who acted, then a kind-specific
+/// body. A HITL gate carries the exact approve command — that is the whole
+/// point of watching, so it must not be one indirection away.
+pub fn summarize(ev: &ChannelEvent, channel_id: &str) -> String {
+    let who = match &ev.actor {
+        ChannelActor::Agent { id } => id.as_str(),
+        ChannelActor::Human { .. } => "human",
+        ChannelActor::System => "system",
+    };
+    let body = match ev.kind {
+        EventKind::Message | EventKind::Note | EventKind::Delegation | EventKind::Handoff => {
+            clip(field(ev, &["text"]).unwrap_or(""))
+        }
+        EventKind::ToolCall => format!(
+            "→ {}{}",
+            field(ev, &["tool", "command", "description"]).unwrap_or("tool"),
+            step(ev)
+        ),
+        EventKind::ToolResult => {
+            let ok = ev
+                .payload
+                .get("success")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let code = ev
+                .payload
+                .get("exit_code")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(-1);
+            let out = field(ev, &["output"]).unwrap_or("");
+            let head = out.lines().next().unwrap_or("");
+            format!(
+                "{} {}exit {code}{}",
+                if ok { "✓" } else { "✗" },
+                step(ev).trim_start(),
+                if head.is_empty() {
+                    String::new()
+                } else {
+                    format!(" · {}", clip(head))
+                }
+            )
+        }
+        EventKind::StateChange => format!(
+            "state: {} → {}",
+            field(ev, &["from"]).unwrap_or("?"),
+            field(ev, &["to"]).unwrap_or("?")
+        ),
+        EventKind::Artifact => format!("artifact: {}", field(ev, &["path", "name"]).unwrap_or("?")),
+        EventKind::HitlRequest => match serde_json::from_value::<HitlRequest>(ev.payload.clone()) {
+            Ok(r) => format!(
+                "⏸ approval needed: {} ({}) · !mur channel approve {channel_id} {}",
+                clip(&r.summary),
+                r.tool_name,
+                r.hitl_id
+            ),
+            Err(_) => "⏸ approval needed (unreadable request)".to_string(),
+        },
+        EventKind::HitlResponse => match serde_json::from_value::<HitlResponse>(ev.payload.clone())
+        {
+            Ok(r) => format!(
+                "{} {} ({})",
+                if r.allow { "approved" } else { "denied" },
+                r.hitl_id,
+                r.surface
+            ),
+            Err(_) => "approval decision (unreadable)".to_string(),
+        },
+    };
+    format!("{who}: {body}")
+}
+
+/// First present string field among `keys`.
+fn field<'a>(ev: &'a ChannelEvent, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|k| ev.payload.get(*k).and_then(|v| v.as_str()))
+        .filter(|s| !s.is_empty())
+}
+
+fn step(ev: &ChannelEvent) -> String {
+    field(ev, &["step_id"])
+        .map(|s| format!(" [{s}]"))
+        .unwrap_or_default()
+}
+
+fn clip(s: &str) -> String {
+    if s.chars().count() <= TEXT_MAX {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(TEXT_MAX).collect();
+    format!("{head}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_channel::ChannelService;
+    use mur_common::channel::{ChannelActor, EventKind};
+    use tempfile::tempdir;
+
+    fn append(home: &Path, cid: &str, kind: EventKind, payload: serde_json::Value) {
+        let svc = ChannelService::open(home).unwrap();
+        svc.append(cid, ChannelActor::System, kind, payload, None)
+            .unwrap();
+    }
+
+    /// The whole contract: history is never replayed, new events surface once,
+    /// and a quiet channel yields nothing.
+    #[test]
+    fn follows_from_head_without_replaying_or_repeating() {
+        let home = tempdir().unwrap();
+        let svc = ChannelService::open(home.path()).unwrap();
+        let ch = svc.create_for_agent("rustsmith").unwrap();
+        append(
+            home.path(),
+            &ch.id,
+            EventKind::Message,
+            serde_json::json!({"text": "before following"}),
+        );
+
+        let now = Instant::now();
+        let mut f = Follow::start(home.path(), &ch.id, now).unwrap();
+        assert!(
+            f.drain(home.path(), now).unwrap().is_empty(),
+            "history must not replay"
+        );
+
+        append(
+            home.path(),
+            &ch.id,
+            EventKind::ToolCall,
+            serde_json::json!({"step_id": "s1", "tool": "bash"}),
+        );
+        let lines = f.drain(home.path(), now).unwrap();
+        assert_eq!(lines.len(), 1, "one new event → one line: {lines:?}");
+        assert!(
+            lines[0].contains("bash") && lines[0].contains("s1"),
+            "{lines:?}"
+        );
+        assert!(
+            f.drain(home.path(), now).unwrap().is_empty(),
+            "same event must not surface twice"
+        );
+    }
+
+    /// A gate is only useful if the line tells you how to answer it.
+    #[test]
+    fn hitl_request_line_carries_the_approve_command() {
+        let req = mur_common::hitl::HitlRequest {
+            hitl_id: "h7".into(),
+            action_hash: "abc".into(),
+            tier: mur_common::hitl::RiskTier::Write,
+            tool_name: "bash".into(),
+            tool_input: serde_json::json!({"command": "rm -rf x"}),
+            step_or_call_id: "s2".into(),
+            agent_id: "rustsmith".into(),
+            timeout_ms: 1000,
+            summary: "delete x".into(),
+        };
+        let ev = ChannelEvent {
+            seq: 1,
+            ts: chrono::Utc::now(),
+            actor: ChannelActor::System,
+            kind: EventKind::HitlRequest,
+            payload: serde_json::to_value(&req).unwrap(),
+            idempotency_key: None,
+            sig: None,
+            key_version: None,
+        };
+        let line = summarize(&ev, "ch1");
+        assert!(line.contains("mur channel approve ch1 h7"), "{line}");
+    }
+}

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -12,6 +12,7 @@ mod bash_class;
 mod complete;
 mod diff;
 mod dump;
+mod follow;
 mod footer;
 mod manage;
 mod markdown;
@@ -104,7 +105,7 @@ const SPINNER_MS: u64 = 90;
 /// Max chars of an arg hint shown on a step line in `--plain` mode.
 const PLAIN_STEP_HINT_MAX: usize = 120;
 
-const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /auto [on|off]  /verbose [on|off] (expand tool cards)  /skin [dark|light|mur]  /mcp  /skill  /panel [tab]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
+const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /channels N --follow (live-tail another channel; /channels --follow to stop)  /auto [on|off]  /verbose [on|off] (expand tool cards)  /skin [dark|light|mur]  /mcp  /skill  /panel [tab]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
 
 /// Entry point dispatched from `AgentAction::Cli`.
 pub async fn cmd_cli(
@@ -724,6 +725,15 @@ async fn event_loop(
             .map(TokioInstant::from_std)
             .unwrap_or_else(|| TokioInstant::from_std(StdInstant::now()));
         let input_armed = app.panel_input_deadline.is_some();
+        // A followed channel is polled on its own deadline (not a per-iteration
+        // `sleep`, which every keypress would reset — during a busy turn the
+        // tail would never fire).
+        let follow_armed = app.follow.is_some();
+        let follow_at = app
+            .follow
+            .as_ref()
+            .map(|f| TokioInstant::from_std(f.next_poll))
+            .unwrap_or_else(|| TokioInstant::from_std(StdInstant::now()));
         tokio::select! {
             maybe = events.next() => match maybe {
                 Some(Ok(ev)) => handle_event(app, ev, &tx).await,
@@ -739,6 +749,9 @@ async fn event_loop(
             // Wake at the blink deadline; the loop redraws at the top of the
             // next iteration, advancing the eye frame. No state change needed.
             _ = tokio::time::sleep_until(blink_at), if blink_live => {}
+            _ = tokio::time::sleep_until(follow_at), if follow_armed => {
+                app.poll_follow(StdInstant::now());
+            }
             _ = tokio::time::sleep_until(input_due), if input_armed => {
                 if let Some(raw) = take_due_input(app, StdInstant::now())
                     && let Some(p) = &app.panel
@@ -1476,7 +1489,44 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
             Ok(_) => app.push_system("no saved conversations yet"),
             Err(e) => app.push_system(format!("could not list sessions: {e}")),
         },
-        SlashCmd::Channels(n) => {
+        SlashCmd::Channels { n, follow } => {
+            // `--follow` never touches the current conversation: it tails
+            // ANOTHER channel while this pane keeps chatting, so an in-flight
+            // turn must not be cancelled for it.
+            if follow {
+                let recent = match persist::list_recent(&app.home, &app.agent, RECENT_LIMIT) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        app.push_system(format!("could not list channels: {e}"));
+                        return;
+                    }
+                };
+                match n {
+                    None => {
+                        match app.follow.take() {
+                            Some(f) => app.push_system(format!("stopped following {}", f.tag())),
+                            None => app.push_system(
+                                "not following anything — /channels N --follow to start",
+                            ),
+                        }
+                        return;
+                    }
+                    Some(n) => match recent.get(n.wrapping_sub(1)) {
+                        Some(s) => {
+                            let id = s.id.clone();
+                            match app.start_follow(&id, StdInstant::now()) {
+                                Ok(()) => app.push_system(format!(
+                                    "following {} — new events appear here; /channels --follow to stop",
+                                    &id[..id.len().min(8)]
+                                )),
+                                Err(e) => app.push_system(format!("could not follow: {e:#}")),
+                            }
+                        }
+                        None => app.push_system(format!("no channel {n}")),
+                    },
+                }
+                return;
+            }
             // Cancel any in-flight stream before we potentially switch channels.
             if app.streaming {
                 if let Some(tid) = app.current_task_id.clone() {
@@ -1513,7 +1563,9 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
                     if recent.is_empty() {
                         app.push_system("no channels yet");
                     } else {
-                        let mut out = String::from("channels (type /channels N to switch):\n");
+                        let mut out = String::from(
+                            "channels (/channels N to switch · N --follow to tail):\n",
+                        );
                         for (i, s) in recent.iter().enumerate() {
                             out.push_str(&format!(
                                 "  {} · {} turns · {}\n",


### PR DESCRIPTION
## Why

Work delegated to an agent (a fleet run, `channel/delegate`) lands in a **shared** channel — not the one the murmur pane is chatting on. The pane's stream is turn-scoped and only ever shows the task it dialed itself, so from `murmur mur rustsmith` the rustsmith window showed nothing of what MUR had handed it. `/channels N` switches, but that is a one-shot disk snapshot, and after switching the operator's own turns mix into the channel they were trying to watch.

## What

`/channels N --follow` tails channel N in the background while the pane keeps chatting:

```
/channels                    list (hint now: "N to switch · N --follow to tail")
/channels 2 --follow         tail channel 2; -f and any flag order also work
/channels --follow           stop
```

New events render as system lines — `⟨abc12345⟩ rustsmith: → bash [s1]`, `✓ [s1] exit 0 · …`, `state: working → completed` — and a HITL gate carries its exact `mur channel approve <channel> <hitl_id>` so the operator can answer it without leaving the pane.

## Design notes

- Starts at the log's head, so history is never replayed; a `seq` cursor means no event surfaces twice.
- Gated on the log's byte length — a quiet channel costs one `metadata()` per poll.
- The poll rides its own deadline in the `select!` loop (same shape as `blink_at` / `input_due`), not a per-iteration `sleep`: a keypress would reset that, and a busy turn would starve the tail.
- Following the pane's own channel is refused — it would double-render every reply.
- `ChannelStore::events_path` becomes public so a reader can gate on length instead of re-parsing an unchanged log.

## Verification

- `cargo check -p mur-core --lib` — clean
- `cargo clippy -p mur-core -p mur-channel --lib -- -D warnings` — clean
- `cargo test -p mur-core --lib cmd::agent::cli` — 171 passed, including two new tests: follow starts at head without replaying or repeating; a HITL line carries the approve command.

## Deliberately not in scope

- No status-bar "following" indicator — followed lines carry a `⟨tag⟩` prefix, and when the channel is quiet there is nothing to indicate.
- Re-parses the whole log when it grows (marked with a `ponytail:` comment naming the byte-offset-seek upgrade). Fine until a followed channel gets long enough to notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)