### PR TITLE
ci(release): stop pretending mur-core publishes to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -651,12 +651,10 @@ jobs:
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
-      - name: Wait for crates.io index propagation
-        run: sleep 60
-
-      - name: Publish mur-core
-        # Allowed to fail until mur-agent-runtime is published to crates.io.
-        continue-on-error: true
-        run: cargo publish -p mur-core --token "${CRATES_IO_TOKEN}"
-        env:
-          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      # Only mur-common is published. Everything below it (mur-compress,
+      # mur-channel, mur-open-items, mur-agent-runtime) is `publish = false`,
+      # and mur-core depends on all of them, so `cargo publish -p mur-core`
+      # cannot succeed. It used to run here under `continue-on-error`, which
+      # meant it failed on every release since 0.2.0 and said nothing.
+      # The user-facing artifact is the `mur` binary — Homebrew and the
+      # installer — not the library. See issue #773.

--- a/mur-agent-runtime/Cargo.toml
+++ b/mur-agent-runtime/Cargo.toml
@@ -3,6 +3,8 @@ name = "mur-agent-runtime"
 version = "0.1.0"
 edition = "2024"
 build = "build.rs"
+# Internal to the workspace: consumed only via path deps, never from crates.io.
+publish = false
 
 [features]
 # Bundle an agent profile into the binary at compile time; set

--- a/mur-channel/Cargo.toml
+++ b/mur-channel/Cargo.toml
@@ -2,6 +2,8 @@
 name = "mur-channel"
 version.workspace = true
 edition.workspace = true
+# Internal to the workspace: consumed only via path deps, never from crates.io.
+publish = false
 
 [dependencies]
 mur-common = { path = "../mur-common" }

--- a/mur-compress/Cargo.toml
+++ b/mur-compress/Cargo.toml
@@ -2,6 +2,8 @@
 name = "mur-compress"
 version.workspace = true
 edition.workspace = true
+# Internal to the workspace: consumed only via path deps, never from crates.io.
+publish = false
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/mur-open-items/Cargo.toml
+++ b/mur-open-items/Cargo.toml
@@ -2,6 +2,8 @@
 name = "mur-open-items"
 version.workspace = true
 edition.workspace = true
+# Internal to the workspace: consumed only via path deps, never from crates.io.
+publish = false
 
 [dependencies]
 serde = { workspace = true }


### PR DESCRIPTION
Closes #773.

`cargo publish -p mur-core` has failed on **every release since 0.2.0**. crates.io has `mur-core` at 0.2.0 while the workspace is at 2.57.0, and nothing ever said so:

```yaml
- name: Publish mur-core
  # Allowed to fail until mur-agent-runtime is published to crates.io.
  continue-on-error: true
```

The `continue-on-error` outlived the condition in its own comment. A step that is allowed to fail forever reports nothing — the release goes green either way, so the only signal it produces is one nobody looks at.

## Why it cannot succeed

`cargo publish` requires every dependency to carry a `version`, and path-only deps have none:

```toml
mur-common        = { path = "../mur-common", version = "2.16" }   # ok
mur-compress      = { path = "../mur-compress" }                   # no version
mur-agent-runtime = { path = "../mur-agent-runtime" }              # no version
mur-channel       = { path = "../mur-channel" }                    # no version
mur-open-items    = { path = "../mur-open-items" }                 # no version
```

None of those four is on crates.io either, so adding versions alone would not fix it — they would have to be published first, in dependency order.

## This PR takes option A from the issue

Mark the four as `publish = false`, which is what they already were in practice, and drop the step. The user-facing artifact is the `mur` binary via Homebrew and the installer, not the library; `mur-common` still publishes.

A comment replaces the step rather than a silent deletion — a publish job that handles exactly one crate invites "what about mur-core?", and the answer should be readable where the question gets asked.

Publishable set after this change: `mur-common` (published), plus `mur-core`, `mur-daemon`, `mur-gui-core`, `mur-mcp-server`, `mur-research-gateway`, `mur-mobile-sdk`, `mur-zfs-agent`, `mur-agent-launcher` — none of which the release job touches. Only the four in `mur-core`'s dependency path are marked here; sweeping the rest is a separate decision.

## Option B, for the record

Publishing the chain for real (`mur-common` → `mur-compress`/`mur-channel`/`mur-open-items` → `mur-agent-runtime` → `mur-core`) is only worth it if someone is meant to depend on `mur-core` as a library. Nobody does today.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — valid
- `cargo metadata` confirms cargo reads `publish=[]` on all four
- `cargo check -p mur-open-items -p mur-channel -p mur-compress` — `publish = false` affects `cargo publish` only, not builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)