### PR TITLE
docs(readme): describe the settlement card

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,14 @@ files.
   Object (Windows) — plus a DNS-resolver guard that filters network egress.
 - **Human-in-the-loop** — tool calls pause for your approval in Hub and in
   `mur agent cli` (opt out per session with `--auto`).
+- **Settlement** — a turn that changed anything ends with a card the runtime
+  draws from its own tool records, not from the model's summary: what was
+  **verified** (a command ran and passed), what was **changed** (files edited,
+  nothing run), what was **blocked**, and whether the turn stopped early. The
+  verified row is printed even when it's empty — `✔ verified (nothing ran — no
+  evidence this works)` — so "all fixed" over an empty column reads as the
+  contradiction it is. The same ledger rides along as JSON, so `mur agent send`,
+  fleet steps and Hub get the accounting without scraping prose.
 - **Capability routing** — an agent blocked by the sandbox doesn't hand the job
   back to you: the denial names the fleets that actually hold that binary, and
   the agent delegates. `mur agent who --can cargo` shows the same picture,


### PR DESCRIPTION
#763 changed what every agent turn ends with. None of the three canonical doc surfaces said so — this is the one in this repo; the docs site and product page are a separate PR in `mur-server`.

Adds a bullet under **Stay governed** rather than a capability section: the card is a check on the agent's own account of its work, which is the same job as the sandbox and the approval gate.

The empty-verified string is quoted verbatim —

```
✔ verified   (nothing ran — no evidence this works)
```

— because that specific line is the whole point. A reader who has not seen it will assume a settlement card only shows up when something went wrong, which inverts the feature: it appears precisely when an agent is most likely to sound finished.

No command-tree change: settlement adds behaviour, not a subcommand, so the `27 top-level commands` count stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)