### PR TITLE
docs(readme): add mur open to the command tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ mur dashboard        # terminal TUI dashboard
 ```
 
 <details>
-<summary><b>Full command tree</b> (27 top-level commands)</summary>
+<summary><b>Full command tree</b> (28 top-level commands)</summary>
 
 ```
 mur
@@ -404,6 +404,7 @@ mur
 ├── notes        create · search · list · show
 ├── workflow     run · suggest · list · schedule · show · search · new · publish · install
 ├── session      start · stop · record · status · list · review · show · export · push
+├── open         add · done   (what is still outstanding, by whether MUR saw it)
 ├── sync         (16+ AI tools) · status · fleet pull/push/both
 ├── hook         unified hook entry for AI tools (prompt / tool / stop / session-start)
 ├── chat         conversations archive + ask


### PR DESCRIPTION
`mur open` (#771) is a new top-level command and the README command tree did not have it.

```diff
-<summary><b>Full command tree</b> (27 top-level commands)</summary>
+<summary><b>Full command tree</b> (28 top-level commands)</summary>

 ├── session      start · stop · record · status · list · review · show · export · push
+├── open         add · done   (what is still outstanding, by whether MUR saw it)
```

The count matters more than it looks: it is the one thing in that block a reader can verify at a glance, and nothing tests it. A tree that says 27 while listing 28 is worse than one that says neither.

Verified against `mur open --help` rather than from memory, per the update-docs skill — `add` and `done` are the only subcommands; `--json` is a flag on the parent.

The docs-site page for `mur open` is in mur-run/mur-server#35, alongside settlement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)