### PR TITLE
feat(open-items): mute noisy sources, collapsed not hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ mur dashboard        # terminal TUI dashboard
 ```
 
 <details>
-<summary><b>Full command tree</b> (27 top-level commands)</summary>
+<summary><b>Full command tree</b> (28 top-level commands)</summary>
 
 ```
 mur
@@ -404,6 +404,7 @@ mur
 ├── notes        create · search · list · show
 ├── workflow     run · suggest · list · schedule · show · search · new · publish · install
 ├── session      start · stop · record · status · list · review · show · export · push
+├── open         add · done   (what is still outstanding, by whether MUR saw it)
 ├── sync         (16+ AI tools) · status · fleet pull/push/both
 ├── hook         unified hook entry for AI tools (prompt / tool / stop / session-start)
 ├── chat         conversations archive + ask

--- a/docs/superpowers/plans/2026-07-27-open-items-mute.md
+++ b/docs/superpowers/plans/2026-07-27-open-items-mute.md
@@ -1,0 +1,849 @@
+# Open Items Mute Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a user permanently collapse a noisy `origin` out of `mur open`, without ever hiding the fact that something is collapsed.
+
+**Architecture:** Mute state is a list of exact `origin` strings in `config.yaml`. `collect()` is untouched and still returns everything; a new `partition()` applies the policy above it, so collectors stay ignorant of display rules and `--json` can report both halves. Writing that config safely requires fixing a pre-existing data-loss bug first, which is Task 1.
+
+**Tech Stack:** Rust 2024, `serde_yaml` (note: `mur-core/src/store/config.rs` uses `serde_yaml`, not `serde_yaml_ng`), `cargo nextest`.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-open-items-mute-design.md`
+
+## Global Constraints
+
+- Rust edition 2024 — `let` chains are stable and used in this codebase.
+- Build/test env: `export ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist` and put `~/.rustup/toolchains/stable-aarch64-apple-darwin/bin` on `PATH`, or `mur-core` will not link.
+- Use `cargo nextest run`, not `cargo test` — plain `cargo test` fails ~7 tests spuriously in this repo from `MUR_HOME` cross-test interference.
+- Lint gate is `cargo clippy --lib --bins -- -D warnings`. `--tests` is already red repo-wide and is not your diff.
+- Mute matching is **exact string equality** on `origin`, never prefix. `fleet` must not match `fleet:acme`.
+- On any error reading config, the mute set is empty and everything shows. Fail toward showing, never toward hiding.
+- Single source file ≤ 800 lines; `mur-core/src/open_items/mod.rs` is ~213 lines and has room.
+
+---
+
+### Task 1: Make config writes lossless
+
+`save_config_at` serialises the typed `Config` and writes the result, so any top-level block `Config` has no field for is silently deleted. Verified on a real config: `research_gateway: { brave_api_key_ref: keychain:mur/brave }` disappears. Ten-plus call sites do this today (`mur sleep`, `mur model add`, `mur source`, `mur team`, `mur init`, and `/skin` in the agent CLI). Mute cannot add an eleventh.
+
+Fixes #778.
+
+**Files:**
+- Modify: `mur-core/src/store/config.rs` — `save_config_at`, plus a new private helper
+- Test: `mur-core/src/store/config.rs` (inline `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `save_config_at(&Path, &Config) -> Result<()>` — same signature, now non-destructive. Task 5 relies on this.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to (or create) the `#[cfg(test)] mod tests` block at the end of `mur-core/src/store/config.rs`:
+
+```rust
+#[cfg(test)]
+mod save_roundtrip_tests {
+    use super::*;
+    use mur_common::config::Config;
+
+    /// `Config` cannot round-trip a block it has no field for, so serialising
+    /// the struct alone deletes it. Measured on a real config: a hand-written
+    /// `research_gateway` block vanished on the next `mur sleep`.
+    #[test]
+    fn save_preserves_blocks_the_typed_config_does_not_know() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            "research_gateway:\n  brave_api_key_ref: keychain:mur/brave\n",
+        )
+        .unwrap();
+
+        let cfg = Config::load_or_default(&path);
+        save_config_at(&path, &cfg).unwrap();
+
+        let back = std::fs::read_to_string(&path).unwrap();
+        assert!(back.contains("research_gateway"), "block dropped:\n{back}");
+        assert!(back.contains("keychain:mur/brave"), "value dropped:\n{back}");
+    }
+
+    /// The typed fields must still win — an unknown-block merge that also
+    /// resurrected stale known values would be a different bug.
+    #[test]
+    fn typed_fields_still_overwrite_the_old_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        std::fs::write(&path, "session:\n  retention_days: 3\nkeep_me: yes\n").unwrap();
+
+        let mut cfg = Config::load_or_default(&path);
+        cfg.session.retention_days = 99;
+        save_config_at(&path, &cfg).unwrap();
+
+        let back = std::fs::read_to_string(&path).unwrap();
+        assert!(back.contains("99"), "typed field not written:\n{back}");
+        assert!(back.contains("keep_me"), "unknown key dropped:\n{back}");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+export ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist
+export PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"
+cargo nextest run -p mur-core --lib -E 'test(save_roundtrip_tests)'
+```
+
+Expected: `save_preserves_blocks_the_typed_config_does_not_know` FAILS with `block dropped:` and no `research_gateway` in the output. The second test passes already.
+
+- [ ] **Step 3: Implement the merge**
+
+In `mur-core/src/store/config.rs`, replace the serialise line inside `save_config_at`:
+
+```rust
+    // Serialize to YAML, then prepend a header with model recommendations
+    let yaml = serde_yaml::to_string(config)?;
+```
+
+with:
+
+```rust
+    // Serialize to YAML, then prepend a header with model recommendations
+    let yaml = merge_over_existing(path, config)?;
+```
+
+and add this private helper immediately above `save_config_at`:
+
+```rust
+/// Serialise `config`, then restore any top-level block the typed `Config`
+/// has no field for.
+///
+/// `Config` cannot round-trip what it cannot parse, so serialising the struct
+/// alone silently deletes user blocks — `research_gateway` was measurably lost
+/// on every `mur sleep` (#778). Typed fields win; only keys absent from the
+/// new document are carried over from the old one.
+fn merge_over_existing(path: &Path, config: &Config) -> Result<String> {
+    let mut out = serde_yaml::to_value(config)?;
+    let existing: Option<serde_yaml::Value> = fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_yaml::from_str(&s).ok());
+
+    if let (Some(serde_yaml::Value::Mapping(old)), serde_yaml::Value::Mapping(new)) =
+        (existing, &mut out)
+    {
+        for (k, v) in old {
+            if !new.contains_key(&k) {
+                new.insert(k, v);
+            }
+        }
+    }
+    Ok(serde_yaml::to_string(&out)?)
+}
+```
+
+If `use std::fs;` and `use std::path::Path;` are not already in scope at the top of the file, add them.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cargo nextest run -p mur-core --lib -E 'test(save_roundtrip_tests)'
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Verify against the real config, non-destructively**
+
+```bash
+cp ~/.mur/config.yaml /tmp/config-before.yaml
+python3 -c "
+import yaml
+a=yaml.safe_load(open('/tmp/config-before.yaml')) or {}
+print('top-level keys:', len(a))
+print('research_gateway present:', 'research_gateway' in a)
+"
+```
+
+Expected: `top-level keys: 25`, `research_gateway present: True`. Do not run a command that writes the real config; the unit tests cover the behaviour.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-core/src/store/config.rs
+git commit -m "fix(config): stop deleting config blocks the typed struct does not know
+
+save_config_at serialised the typed Config and wrote the result, so any
+top-level block Config has no field for was silently dropped. Measured on a
+real config: research_gateway (the deep-research Brave key binding) vanished.
+Ten-plus call sites do this today — mur sleep, mur model add, mur source, mur
+team, mur init, and /skin in the agent CLI.
+
+The write now merges over the existing document: typed fields win, unknown
+keys pass through. Closes #778."
+```
+
+---
+
+### Task 2: Mute config + partition
+
+**Files:**
+- Modify: `mur-common/src/config.rs` — add `OpenItemsConfig`, add the field to `Config`
+- Modify: `mur-core/src/open_items/mod.rs` — add `partition`, make `fingerprint` operate on the visible set
+- Test: both files, inline
+
+**Interfaces:**
+- Consumes: nothing from Task 1 at compile time
+- Produces:
+  - `mur_common::config::OpenItemsConfig { pub muted: Vec<String> }`, reachable as `cfg.open_items.muted`
+  - `mur_core::open_items::partition(items: Vec<OpenItem>, muted: &[String]) -> (Vec<OpenItem>, Vec<String>)` — returns `(visible, muted_origins_that_matched)`, second element sorted and deduplicated. Tasks 3, 4 and 5 all call this.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `mur-common/src/config.rs`, inside the existing `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn open_items_muted_parses_and_defaults_empty() {
+        let c: Config = serde_yaml::from_str("open_items:\n  muted:\n    - inbox\n").unwrap();
+        assert_eq!(c.open_items.muted, vec!["inbox".to_string()]);
+
+        let d: Config = serde_yaml::from_str("llm:\n  model: x\n").unwrap();
+        assert!(d.open_items.muted.is_empty(), "must default to no mutes");
+    }
+
+    /// Fail toward showing. A config that will not parse must yield an empty
+    /// mute set, never a quiet, confident, incomplete list.
+    #[test]
+    fn unreadable_config_yields_no_mutes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        std::fs::write(&path, "this: is: not: valid: yaml: [[[\n").unwrap();
+        let cfg = Config::load_or_default(&path);
+        assert!(
+            cfg.open_items.muted.is_empty(),
+            "a broken config must hide nothing"
+        );
+
+        // Same for a config that is simply absent.
+        let missing = Config::load_or_default(&tmp.path().join("nope.yaml"));
+        assert!(missing.open_items.muted.is_empty());
+    }
+```
+
+In `mur-core/src/open_items/mod.rs`, inside the existing `#[cfg(test)] mod tests`:
+
+```rust
+    #[test]
+    fn partition_hides_muted_origins_and_names_them() {
+        let items = vec![
+            OpenItem { origin: "inbox".into(), ..item(ItemSource::Observed, "a", Utc::now()) },
+            OpenItem { origin: "fleet:x".into(), ..item(ItemSource::Observed, "b", Utc::now()) },
+        ];
+        let (visible, muted) = partition(items, &["inbox".to_string()]);
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].origin, "fleet:x");
+        assert_eq!(muted, vec!["inbox".to_string()]);
+    }
+
+    /// `fleet` must not swallow `fleet:acme`. Prefix matching is the one
+    /// outcome a mute must never produce by accident.
+    #[test]
+    fn mute_matching_is_exact_not_prefix() {
+        let items = vec![OpenItem {
+            origin: "fleet:acme".into(),
+            ..item(ItemSource::Observed, "a", Utc::now())
+        }];
+        let (visible, muted) = partition(items, &["fleet".to_string()]);
+        assert_eq!(visible.len(), 1, "prefix must not match");
+        assert!(muted.is_empty());
+    }
+
+    /// A configured mute that matched nothing is not named — the footer
+    /// reports what the reader would otherwise have seen, not the config.
+    #[test]
+    fn a_mute_that_matched_nothing_is_not_reported() {
+        let items = vec![OpenItem {
+            origin: "inbox".into(),
+            ..item(ItemSource::Observed, "a", Utc::now())
+        }];
+        let (_, muted) = partition(items, &["fleet:gone".to_string()]);
+        assert!(muted.is_empty());
+    }
+
+    /// Muting a noisy source has to silence the turn notice too, or the mute
+    /// does nothing where it matters most.
+    #[test]
+    fn fingerprint_over_visible_ignores_muted_churn() {
+        let mk = |n: usize| OpenItem {
+            title: format!("{n} proposals"),
+            origin: "inbox".into(),
+            ..item(ItemSource::Observed, "x", Utc::now())
+        };
+        let (v1, _) = partition(vec![mk(246)], &["inbox".to_string()]);
+        let (v2, _) = partition(vec![mk(300)], &["inbox".to_string()]);
+        assert_eq!(fingerprint(&v1), fingerprint(&v2));
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cargo nextest run -p mur-common -p mur-core --lib -E 'test(open_items) or test(partition) or test(mute_matching)'
+```
+
+Expected: compile error — `partition` not found, `open_items` field not found on `Config`.
+
+- [ ] **Step 3: Add the config struct**
+
+In `mur-common/src/config.rs`, next to `FleetRunConfig` (around line 217):
+
+```rust
+/// Display policy for `mur open`.
+///
+/// Lives in `config.yaml` rather than in `open-items.jsonl` because that log
+/// is append-only and agent-writable via the `open_item` tool. A user's
+/// decision to stop looking at a source must not be overturnable by an agent
+/// appending a record. Same reasoning as `fleet_run.agents`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct OpenItemsConfig {
+    /// Exact `origin` strings to collapse out of `mur open`. Exact match
+    /// only — `fleet` never matches `fleet:acme`.
+    #[serde(default)]
+    pub muted: Vec<String>,
+}
+```
+
+And on `Config`, immediately after the `fleet_run` field (around line 189):
+
+```rust
+    // --- `mur open` display policy ---
+    #[serde(default)]
+    pub open_items: OpenItemsConfig,
+```
+
+If `Config` is constructed with exhaustive struct literals anywhere, add `open_items: Default::default()`. Find them with:
+
+```bash
+grep -rn "Config {" --include="*.rs" . | grep -v "^./target" | grep -v "\.\.Default::default()"
+```
+
+- [ ] **Step 4: Implement partition and re-point fingerprint**
+
+In `mur-core/src/open_items/mod.rs`, add after `collect`:
+
+```rust
+/// Split `items` by the mute list.
+///
+/// Returns the items to show, and the muted origins that actually matched
+/// something — the footer names what the reader would otherwise have seen,
+/// not what the config happens to contain, so a stale mute stays quiet.
+pub fn partition(items: Vec<OpenItem>, muted: &[String]) -> (Vec<OpenItem>, Vec<String>) {
+    let mut hidden: Vec<String> = Vec::new();
+    let visible: Vec<OpenItem> = items
+        .into_iter()
+        .filter(|it| {
+            // Exact match, never prefix: `fleet` must not swallow `fleet:acme`.
+            if muted.iter().any(|m| m == &it.origin) {
+                if !hidden.contains(&it.origin) {
+                    hidden.push(it.origin.clone());
+                }
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
+    hidden.sort();
+    (visible, hidden)
+}
+```
+
+`fingerprint` needs no change — callers now pass it the visible slice.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cargo nextest run -p mur-common -p mur-core --lib -E 'test(open_items) or test(partition) or test(mute_matching)'
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mur-common/src/config.rs mur-core/src/open_items/mod.rs
+git commit -m "feat(open-items): mute config and partition
+
+Muted origins live in config.yaml, not the open-items log — that log is
+agent-writable, and a user's decision to stop looking must not be
+overturnable by an agent appending a record.
+
+Matching is exact. Prefix matching would let 'fleet' silently swallow every
+fleet in the list, which is the one thing a mute must never do by accident."
+```
+
+---
+
+### Task 3: The footer
+
+Muting is only safe because it collapses rather than hides. This task is that guarantee.
+
+**Files:**
+- Modify: `mur-core/src/open_items/mod.rs` — `render`
+- Test: same file, inline
+
+**Interfaces:**
+- Consumes: `partition` from Task 2
+- Produces: `render(items: &[OpenItem], muted: &[String]) -> String` — **signature changes**, gaining the second parameter. Task 5 calls it.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    /// A permanent mute is only safe if the list always says something is
+    /// muted. The reader must never have to wonder whether anything is hidden.
+    #[test]
+    fn footer_names_muted_sources() {
+        let out = render(
+            &[item(ItemSource::Observed, "visible", Utc::now())],
+            &["inbox".to_string(), "fleet:old".to_string()],
+        );
+        assert!(out.contains("2 sources muted"), "{out}");
+        assert!(out.contains("inbox"), "{out}");
+        assert!(out.contains("fleet:old"), "{out}");
+        assert!(out.contains("mur open --all"), "{out}");
+    }
+
+    #[test]
+    fn no_footer_when_nothing_is_muted() {
+        let out = render(&[item(ItemSource::Observed, "a", Utc::now())], &[]);
+        assert!(!out.contains("muted"), "{out}");
+    }
+
+    /// Everything muted is not the same as nothing outstanding, and the
+    /// difference has to be visible.
+    #[test]
+    fn everything_muted_still_shows_the_footer() {
+        let out = render(&[], &["inbox".to_string()]);
+        assert!(out.contains("1 source muted"), "{out}");
+        assert!(out.contains("No open items"), "{out}");
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+cargo nextest run -p mur-core --lib -E 'test(footer) or test(muted)'
+```
+
+Expected: compile error — `render` takes 1 argument.
+
+- [ ] **Step 3: Implement**
+
+Change the signature and the empty-case early return in `mur-core/src/open_items/mod.rs`:
+
+```rust
+pub fn render(items: &[OpenItem], muted: &[String]) -> String {
+    let mut out = if items.is_empty() {
+        "No open items.\n".to_string()
+    } else {
+        let mut s = String::new();
+        let mut last: Option<ItemSource> = None;
+        for it in items {
+            if last != Some(it.source) {
+                let caveat = match it.source {
+                    ItemSource::Observed => "from MUR's own state",
+                    ItemSource::Reported => "an agent said so, unverified",
+                };
+                s.push_str(&format!(
+                    "\n{} {} — {caveat}\n",
+                    it.source.marker(),
+                    it.source.label()
+                ));
+                last = Some(it.source);
+            }
+            s.push_str(&format!("  {} [{}]\n", it.title, it.origin));
+            if let Some(next) = &it.next {
+                s.push_str(&format!("      → {next}\n"));
+            }
+        }
+        s
+    };
+
+    // Collapsed, never hidden. This one line is what makes a permanent mute
+    // safe: the reader never has to wonder whether something is missing.
+    if !muted.is_empty() {
+        out.push_str(&format!(
+            "\n{} source{} muted ({}) — mur open --all\n",
+            muted.len(),
+            if muted.len() == 1 { "" } else { "s" },
+            muted.join(", ")
+        ));
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+cargo nextest run -p mur-core --lib -E 'test(open_items)'
+```
+
+Expected: all pass, including the pre-existing `empty_says_so_rather_than_printing_a_bare_header` (update its call to `render(&[], &[])`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/open_items/mod.rs
+git commit -m "feat(open-items): footer naming muted sources
+
+Mute collapses, it never hides. The trade is one line versus N, not show
+versus hide — which is what makes a mute that never expires safe to have."
+```
+
+---
+
+### Task 4: CLI surface
+
+**Files:**
+- Modify: `mur-core/src/cli/mod.rs` — add `--all` to `Commands::Open`
+- Modify: `mur-core/src/cli/actions.rs` — add `Mute` / `Unmute` to `OpenAction`
+- Modify: `mur-core/src/dispatch.rs` — the `Commands::Open` arm
+- Test: `mur-core/src/dispatch.rs` is not unit-tested; verification is the manual run in Step 4
+
+**Interfaces:**
+- Consumes: `partition` (Task 2), `render(items, muted)` (Task 3), `save_config_at` (Task 1)
+- Produces: no new library symbols
+
+- [ ] **Step 1: Add the flag and the subcommands**
+
+In `mur-core/src/cli/mod.rs`, the `Open` variant gains `all`:
+
+```rust
+    /// Show what is still outstanding, labelled by whether MUR observed it or
+    /// an agent merely reported it
+    Open {
+        #[command(subcommand)]
+        action: Option<OpenAction>,
+        /// Machine-readable output
+        #[arg(long)]
+        json: bool,
+        /// Include muted sources
+        #[arg(long)]
+        all: bool,
+    },
+```
+
+In `mur-core/src/cli/actions.rs`, extend `OpenAction`:
+
+```rust
+    /// Stop showing a source. Exact `origin` match — `fleet` never matches
+    /// `fleet:acme`.
+    Mute {
+        /// Origin as shown in brackets, e.g. `inbox` or `fleet:acme`
+        origin: String,
+    },
+    /// Show a muted source again
+    Unmute {
+        origin: String,
+    },
+```
+
+- [ ] **Step 2: Wire the dispatch arm**
+
+Replace the whole `Commands::Open { .. }` arm in `mur-core/src/dispatch.rs`:
+
+```rust
+        Commands::Open { action, json, all } => {
+            let home = crate::paths::mur_root(None);
+            let cfg_path = home.join("config.yaml");
+            match action {
+                Some(OpenAction::Add { title, agent, next }) => {
+                    let id =
+                        crate::open_items::reported::report(&home, &agent, &title, next.as_deref())?;
+                    println!("Recorded (reported by {agent}): {id}");
+                }
+                Some(OpenAction::Done { id }) => {
+                    crate::open_items::reported::resolve(&home, &id)?;
+                    println!("Resolved {id}");
+                }
+                Some(OpenAction::Mute { origin }) => {
+                    let mut cfg = mur_common::config::Config::load_or_default(&cfg_path);
+                    // Record even when nothing currently carries it — a source
+                    // can be legitimately empty today — but say so, so a typo
+                    // surfaces here rather than as a silent no-op later.
+                    let seen: Vec<String> = crate::open_items::collect(&home)
+                        .into_iter()
+                        .map(|i| i.origin)
+                        .collect();
+                    if !seen.contains(&origin) {
+                        let mut uniq: Vec<String> = seen;
+                        uniq.sort();
+                        uniq.dedup();
+                        eprintln!(
+                            "warning: nothing currently has origin '{origin}' (in use: {})",
+                            if uniq.is_empty() { "none".into() } else { uniq.join(", ") }
+                        );
+                    }
+                    if !cfg.open_items.muted.contains(&origin) {
+                        cfg.open_items.muted.push(origin.clone());
+                        cfg.open_items.muted.sort();
+                        crate::store::config::save_config_at(&cfg_path, &cfg)?;
+                    }
+                    println!("Muted {origin}");
+                }
+                Some(OpenAction::Unmute { origin }) => {
+                    let mut cfg = mur_common::config::Config::load_or_default(&cfg_path);
+                    cfg.open_items.muted.retain(|m| m != &origin);
+                    crate::store::config::save_config_at(&cfg_path, &cfg)?;
+                    // Unmuting something that was not muted is not an error:
+                    // the requested end state holds either way.
+                    println!("Unmuted {origin}");
+                }
+                None => {
+                    let items = crate::open_items::collect(&home);
+                    // Fail toward showing: an unreadable config yields no
+                    // mutes, never a quiet, confident, incomplete list.
+                    let muted_cfg = if all {
+                        Vec::new()
+                    } else {
+                        mur_common::config::Config::load_or_default(&cfg_path)
+                            .open_items
+                            .muted
+                    };
+                    let (visible, muted) = crate::open_items::partition(items, &muted_cfg);
+                    if json {
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&serde_json::json!({
+                                "items": visible,
+                                "muted": muted,
+                            }))?
+                        );
+                    } else {
+                        print!("{}", crate::open_items::render(&visible, &muted));
+                    }
+                }
+            }
+        }
+```
+
+Add `OpenAction` to the `use crate::cli::{...}` import list at the top of `dispatch.rs` if it is not already there.
+
+- [ ] **Step 3: Build**
+
+```bash
+cargo build -q -p mur-core --bin mur
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Verify by hand against a scratch MUR_HOME**
+
+Do not test against the real `~/.mur`.
+
+```bash
+export MUR_HOME=/tmp/mur-mute-test
+rm -rf "$MUR_HOME" && mkdir -p "$MUR_HOME/fleets/demo"
+touch "$MUR_HOME/fleets/demo/.stopped"
+mkdir -p "$MUR_HOME/inbox/workflow-proposals" && touch "$MUR_HOME/inbox/workflow-proposals/a.yaml"
+
+./target/debug/mur open                 # two observed lines, no footer
+./target/debug/mur open mute inbox      # "Muted inbox"
+./target/debug/mur open                 # one line + "1 source muted (inbox)"
+./target/debug/mur open --all           # two lines, no footer
+./target/debug/mur open --json          # {"items":[...],"muted":["inbox"]}
+./target/debug/mur open mute typo       # warns, names origins in use
+./target/debug/mur open unmute inbox    # back to two lines
+grep -A2 open_items "$MUR_HOME/config.yaml"
+unset MUR_HOME
+```
+
+Expected: exactly as annotated. `open_items.muted` present in the scratch config after the mute, gone after the unmute.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+cargo clippy -p mur-core --lib --bins -- -D warnings
+git add mur-core/src/cli/mod.rs mur-core/src/cli/actions.rs mur-core/src/dispatch.rs
+git commit -m "feat(open-items): mur open mute/unmute and --all
+
+Muting an origin that nothing currently carries is allowed — a source can be
+legitimately empty today — but warns and names the origins in use, so a typo
+surfaces at the point of the mistake instead of as a silent no-op.
+
+--json changes shape from a bare array to {items, muted}. It shipped hours
+ago with no known consumer, so the break is taken now rather than carried
+forever as a second output mode; without it Hub cannot tell an empty list
+from a fully muted one."
+```
+
+---
+
+### Task 5: The turn summary respects mutes
+
+Muting a noisy source has to silence the end-of-turn line too. That line is where the noise is most expensive, because it interrupts.
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/app.rs` — `note_open_items_if_changed`
+- Test: same file, inline
+
+**Interfaces:**
+- Consumes: `partition` (Task 2)
+- Produces: nothing new
+
+- [ ] **Step 1: Write the failing test**
+
+In the `#[cfg(test)] mod session_cost_tests` block or a new `mod open_items_tests` in `app.rs`:
+
+```rust
+#[cfg(test)]
+mod open_items_notice_tests {
+    use super::*;
+
+    /// A muted source must not wake the turn notice, or the mute does nothing
+    /// where it costs the most — the line that interrupts.
+    #[test]
+    fn muted_source_does_not_change_the_fingerprint() {
+        use crate::open_items::{ItemSource, OpenItem, fingerprint, partition};
+        let mk = |n: usize| OpenItem {
+            title: format!("{n} proposals awaiting review"),
+            next: None,
+            source: ItemSource::Observed,
+            origin: "inbox".into(),
+            at: chrono::Utc::now(),
+        };
+        let muted = vec!["inbox".to_string()];
+        let (a, _) = partition(vec![mk(246)], &muted);
+        let (b, _) = partition(vec![mk(999)], &muted);
+        assert_eq!(fingerprint(&a), fingerprint(&b));
+    }
+}
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+cargo nextest run -p mur-core --lib -E 'test(open_items_notice_tests)'
+```
+
+Expected: PASS.
+
+**This test passes before Step 3 and that is not a mistake — but it does mean the test alone cannot tell you the wiring landed.** It pins the property (`partition` then `fingerprint` is blind to muted churn) so a later refactor cannot quietly break it. Whether `note_open_items_if_changed` actually *calls* that pair is verified in Step 4 against a real temp home, because the method reads config and the filesystem and reaches the user only through `push_system`. Do not skip Step 4 on the strength of a green Step 2.
+
+- [ ] **Step 3: Wire the mute into the notice**
+
+Replace `note_open_items_if_changed` in `mur-core/src/cmd/agent/cli/app.rs`:
+
+```rust
+    /// After a turn, say what is outstanding — but only if the set changed.
+    ///
+    /// Repeating the same three items after every turn is how a status line
+    /// becomes wallpaper. Staying silent when nothing moved is what keeps the
+    /// line worth reading on the turn something does. Muted sources are
+    /// removed before the comparison, so muting silences this too.
+    pub fn note_open_items_if_changed(&mut self) {
+        let muted = mur_common::config::Config::load_or_default(&self.home.join("config.yaml"))
+            .open_items
+            .muted;
+        let (visible, _) = crate::open_items::partition(crate::open_items::collect(&self.home), &muted);
+        let fp = crate::open_items::fingerprint(&visible);
+        if self.open_items_fp == Some(fp) {
+            return;
+        }
+        self.open_items_fp = Some(fp);
+        if let Some(line) = crate::open_items::summary_line(&visible) {
+            self.push_system(line);
+        }
+    }
+```
+
+And in `mur-core/src/cmd/agent/cli/mod.rs`, the `SlashCmd::Open` arm — `/open` shows everything, because asking for the list explicitly is not the same as being interrupted by it:
+
+```rust
+        SlashCmd::Open => {
+            let items = crate::open_items::collect(&app.home);
+            let muted = mur_common::config::Config::load_or_default(&app.home.join("config.yaml"))
+                .open_items
+                .muted;
+            let (visible, muted_names) = crate::open_items::partition(items, &muted);
+            app.open_items_fp = Some(crate::open_items::fingerprint(&visible));
+            app.push_system(
+                crate::open_items::render(&visible, &muted_names)
+                    .trim()
+                    .to_string(),
+            );
+        }
+```
+
+- [ ] **Step 4: Run the full affected suite**
+
+```bash
+cargo nextest run -p mur-common -p mur-core --lib \
+  -E 'test(open_items) or test(agent::cli) or test(save_roundtrip)'
+cargo clippy -p mur-common -p mur-core --lib --bins -- -D warnings
+```
+
+Expected: all pass; clippy clean.
+
+Then verify the wiring Step 2 could not — that the turn notice actually goes quiet. Against a scratch home, not the real one:
+
+```bash
+export MUR_HOME=/tmp/mur-notice-test
+rm -rf "$MUR_HOME" && mkdir -p "$MUR_HOME/inbox/workflow-proposals"
+touch "$MUR_HOME/inbox/workflow-proposals/"{a,b,c}.yaml
+
+./target/debug/mur open                    # "3 harvested workflow proposals"
+./target/debug/mur open mute inbox
+touch "$MUR_HOME/inbox/workflow-proposals/"{d,e}.yaml   # the muted source changes
+./target/debug/mur open                    # still only the footer, no count line
+./target/debug/mur open --all              # "5 harvested workflow proposals"
+unset MUR_HOME
+```
+
+Expected: after the mute, adding proposals changes nothing visible except under `--all`. If the count line reappears, `note_open_items_if_changed` is not calling `partition` and Step 3 did not land.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mur-core/src/cmd/agent/cli/app.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(open-items): turn notice and /open respect mutes
+
+The end-of-turn line is where noise costs most, because it interrupts — so
+the fingerprint is computed over the visible set and a muted source can no
+longer wake it. /open still renders the footer, because asking for the list
+is not the same as being interrupted by it."
+```
+
+---
+
+## Verification before opening the PR
+
+```bash
+export ORT_STRATEGY=download MUR_WEB_DIST=$HOME/Projects/mur-web/dist
+export PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"
+RUST_MIN_STACK=33554432 cargo nextest run -p mur-common -p mur-core --lib \
+  -E 'test(open_items) or test(config) or test(agent::cli)'
+cargo clippy -p mur-common -p mur-core -p mur-agent-runtime --lib --bins -- -D warnings
+cargo fmt --all --check
+```
+
+Then confirm the real config is still intact — this is the bug Task 1 fixes, and the whole point is that it stays fixed:
+
+```bash
+python3 -c "
+import yaml
+a=yaml.safe_load(open('$HOME/.mur/config.yaml')) or {}
+print('top-level keys:', len(a), '| research_gateway:', 'research_gateway' in a)
+"
+```
+
+Expected: `top-level keys: 25 | research_gateway: True`.
+
+## Out of scope
+
+Deliberately not in this plan, per the spec:
+
+- Snooze / time-boxed mute. Mute is permanent until reversed.
+- Per-item mute. `mur open done` clears a reported item; observed items clear themselves.
+- Agent-side injection of open items into session-start context — its own spec.
+- Fixing the harvest proposal generator (#777).

--- a/docs/superpowers/specs/2026-07-27-open-items-mute-design.md
+++ b/docs/superpowers/specs/2026-07-27-open-items-mute-design.md
@@ -1,0 +1,121 @@
+# Open Items: muting noisy sources
+
+**Date:** 2026-07-27
+**Status:** design, approved in brainstorm
+**Scope:** `mur open` display policy. Agent-side injection of open items is explicitly out of scope and gets its own spec.
+
+## Problem
+
+`mur open` shows what is outstanding, split into `observed` (derived from MUR's own state) and `reported` (an agent said so). It has no way to stop showing something the user has already decided about.
+
+On the machine this was designed against, one line reads:
+
+```
+246 harvested workflow proposals awaiting review         [inbox]
+```
+
+Those proposals have accumulated since 2026-06-12 at roughly eight a day. Whatever the user does about them, they are not a decision that needs re-making at the bottom of every `mur open` and after every agent turn.
+
+The cost is not the line itself. A status surface spends the reader's willingness to look, and a line representing a settled decision spends it for nothing — displacing the two lines that are worth reading (a fleet stopped by its kill-switch, a job queued behind it). The failure mode of a status surface is not being wrong once; it is being ignored from then on.
+
+### Note on the specific case
+
+Investigation during the brainstorm found that 221 of those 246 proposals have their command arguments replaced by `<STR>` / `<PATH>` / `<N>`, because the harvest pipeline writes its *matching skeleton* — a normalization built to compare procedures across sessions — into the proposal's `steps` field. A step reading `grep -rn <STR> --include=<STR> .` cannot be run or reviewed.
+
+**That is a separate defect, filed as #777.** This spec does not depend on it: a mute mechanism is worth having whether or not any given source is producing good output, and building one only for sources known to be broken would mean rebuilding it for the next noisy source.
+
+## Design
+
+### Mute collapses; it never hides
+
+Muting a source removes its lines and adds one line at the end of the list:
+
+```
+● observed — from MUR's own state
+  fleet 'rust-solo' is stopped by its kill-switch          [fleet:rust-solo]
+      → mur fleet start rust-solo
+
+2 sources muted (inbox, fleet:old) — mur open --all
+```
+
+This single rule is what makes a permanent mute safe. The reader never has to wonder whether something is hidden, because the answer is always on screen. The real trade is not *show* versus *hide* — it is **one line versus N lines**, and one line is spent no matter how many sources are muted.
+
+### Mute is permanent until reversed, by design
+
+Muted sources do not come back on a timer and do not come back on a change threshold.
+
+- **A timer** (`snooze 7d`) models *not now*. The 246 proposals are not a deferral, they are a standing decision, and re-asking a settled question every seven days is worse than asking it once.
+- **A change threshold** ("come back if it doubles") is unpredictable in a way that defeats the purpose: the user mutes something, it later reappears, and the explanation is a rule they never chose and cannot see. A mute that silently un-mutes is worse than one that never does, because then neither the surface nor the mute can be relied on. It also degenerates in practice — at eight new proposals a day any count threshold is crossed within a week.
+
+The objection to permanence is "what if that source later holds something important?" That is an argument about **granularity**, not about timers: if a source contains both noise and signal, the mute is being applied at the wrong level. `origin` is already fine-grained (`fleet:acme` is not `fleet:other`), and a source that genuinely mixes both should be split at the collector, not papered over with an unpredictable resurrection rule.
+
+`until` can be added to the stored form later without breaking anything, if real usage shows a need. It is not in v1.
+
+### Mute is per `origin`, which already exists
+
+`OpenItem.origin` is already `"inbox"`, `"fleet:<name>"`, `"agent:<name>"`. Muting is a set of origin strings. No new taxonomy.
+
+Matching is **exact**, not prefix. `fleet:acme` mutes that fleet and nothing else; there is no way to mute every fleet at once in v1. Prefix matching would make `fleet` — a plausible thing to type — silently swallow every fleet in the list, which is the one outcome a mute must never produce by accident. If muting a whole family turns out to be a real need, it should arrive as explicit syntax rather than as an emergent property of string prefixes.
+
+### Mute state lives in `config.yaml`, not the log
+
+```yaml
+open_items:
+  muted:
+    - inbox
+    - fleet:old
+```
+
+Not in `open-items.jsonl`. That log is append-only and **agent-writable** via the `open_item` tool. Muting is a user decision, and an agent must not be able to overturn it by appending a record. This mirrors `fleet_run.agents`, which lives in the global config for the same reason.
+
+## Components
+
+| Where | Change |
+|---|---|
+| `mur-common/src/config.rs` | `OpenItemsConfig { muted: Vec<String> }` on `Config`, `#[serde(default)]` |
+| `mur-core/src/open_items/mod.rs` | `partition(items, muted) -> (visible, muted_origins)`; `render` gains the footer; `fingerprint` computed over visible only |
+| `mur-core/src/cli/actions.rs` | `OpenAction::{Mute, Unmute}` |
+| `mur-core/src/dispatch.rs` | `--all` flag; wire mute/unmute through config load → save |
+| `mur-core/src/cmd/agent/cli/app.rs` | turn summary uses the visible set |
+
+`collect()` is unchanged and still returns everything. Policy is applied above it, so the collectors stay ignorant of display rules and `--json` can report both halves.
+
+## Data flow
+
+```
+config.yaml ─┐
+             ├─→ partition() ─→ visible ──→ render / summary_line / fingerprint
+collect() ───┘                └─→ muted_origins ──→ footer line
+```
+
+`--json` emits the full item list plus a top-level `"muted": ["inbox"]`. Consumers (Hub) get everything and apply their own policy; nothing is dropped from the machine-readable form.
+
+**This changes the `--json` shape** from a bare array to `{ "items": [...], "muted": [...] }`. `mur open --json` shipped hours ago in #771 and has no known consumer yet, so the break is taken now rather than carried forever as a second output mode. The alternative — leaving the array and losing the mute state — would mean Hub could not tell an empty list from a fully muted one.
+
+## Error handling
+
+**On error, show rather than hide.** An unreadable or malformed `config.yaml` yields an empty mute set, so every item appears. Hiding on failure is the dangerous direction: it produces a quiet, confident, incomplete list.
+
+`mur open mute <origin>` records the origin even when no current item carries it — a source can be legitimately empty today — but prints a warning naming the origins currently in use, so a typo is visible immediately rather than at the next silent no-op.
+
+`unmute` of something not muted is not an error. The requested end state holds.
+
+## Testing
+
+| Test | Guards |
+|---|---|
+| muted origin's items do not appear in `visible` | the basic mechanism |
+| footer names every muted source, and only appears when something is muted | mute is never invisible |
+| `--all` returns everything and prints no footer | the escape hatch |
+| `fingerprint` ignores muted items | muting a noisy source silences the turn notice too, which is where it matters most |
+| a muted source that changes does not wake the summary | permanence is real, not cosmetic |
+| unreadable config yields no mutes, all items visible | fail toward showing |
+| `mute` on an unused origin records it and warns | typos surface at the point of the mistake |
+| `--json` carries muted items plus the `muted` key | policy does not truncate the machine-readable form |
+
+## Out of scope
+
+- **Agent-side injection** of open items into session-start context. Deferred by decision in the brainstorm: injecting a source this noisy would waste context and mislead the agent, so noise control comes first and injection is designed once real usage shows which signals matter.
+- **Snooze / time-boxed mute.** See above.
+- **Fixing the harvest proposal generator.** Filed as #777.
+- **Per-item mute.** `mur open done` already clears a reported item; observed items clear themselves when the underlying state resolves.

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -188,6 +188,10 @@ pub struct Config {
     #[serde(default)]
     pub fleet_run: FleetRunConfig,
 
+    // --- `mur open` display policy ---
+    #[serde(default)]
+    pub open_items: OpenItemsConfig,
+
     // --- Hub Fleet Manager redesign ---
     #[serde(default)]
     pub fleet: FleetConfig,
@@ -221,6 +225,20 @@ pub struct FleetRunConfig {
     /// Fleet names those agents may run. Empty = deny all.
     #[serde(default)]
     pub fleets: Vec<String>,
+}
+
+/// Display policy for `mur open`.
+///
+/// Lives in `config.yaml` rather than in `open-items.jsonl` because that log
+/// is append-only and agent-writable via the `open_item` tool. A user's
+/// decision to stop looking at a source must not be overturnable by an agent
+/// appending a record. Same reasoning as `fleet_run.agents`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct OpenItemsConfig {
+    /// Exact `origin` strings to collapse out of `mur open`. Exact match
+    /// only — `fleet` never matches `fleet:acme`.
+    #[serde(default)]
+    pub muted: Vec<String>,
 }
 
 /// Daemon-wide gate for unattended fleet auto-run (`mur-daemon`'s `fleet_tick`).
@@ -1519,6 +1537,33 @@ embedding:
             l3.to_backend_config().api_key_ref.as_deref(),
             Some("keychain:mur/anthropic")
         );
+    }
+
+    #[test]
+    fn open_items_muted_parses_and_defaults_empty() {
+        let c: Config = serde_yaml::from_str("open_items:\n  muted:\n    - inbox\n").unwrap();
+        assert_eq!(c.open_items.muted, vec!["inbox".to_string()]);
+
+        let d: Config = serde_yaml::from_str("llm:\n  model: x\n").unwrap();
+        assert!(d.open_items.muted.is_empty(), "must default to no mutes");
+    }
+
+    /// Fail toward showing. A config that will not parse must yield an empty
+    /// mute set, never a quiet, confident, incomplete list.
+    #[test]
+    fn unreadable_config_yields_no_mutes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        std::fs::write(&path, "this: is: not: valid: yaml: [[[\n").unwrap();
+        let cfg = Config::load_or_default(&path);
+        assert!(
+            cfg.open_items.muted.is_empty(),
+            "a broken config must hide nothing"
+        );
+
+        // Same for a config that is simply absent.
+        let missing = Config::load_or_default(&tmp.path().join("nope.yaml"));
+        assert!(missing.open_items.muted.is_empty());
     }
 }
 

--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -322,6 +322,17 @@ pub enum OpenAction {
         /// Item id from `mur open`
         id: String,
     },
+    /// Stop showing a source. Exact `origin` match — `fleet` never matches
+    /// `fleet:acme`.
+    Mute {
+        /// Origin as shown in brackets, e.g. `inbox` or `fleet:acme`
+        origin: String,
+    },
+    /// Show a muted source again
+    Unmute {
+        /// Origin as shown in brackets, e.g. `inbox` or `fleet:acme`
+        origin: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/mur-core/src/cli/mod.rs
+++ b/mur-core/src/cli/mod.rs
@@ -283,6 +283,9 @@ see `mur skill <command> --help`.")]
         /// Machine-readable output
         #[arg(long)]
         json: bool,
+        /// Include muted sources
+        #[arg(long)]
+        all: bool,
     },
     /// Push pending signals from the outbox to the server
     Push {

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -801,19 +801,32 @@ impl App {
         self.note_open_items_if_changed();
     }
 
+    /// Origins the user has muted. Read fresh, so `mur open mute` in another
+    /// terminal takes effect on the next turn rather than the next restart.
+    pub fn muted_origins(&self) -> Vec<String> {
+        mur_common::config::Config::load_or_default(&self.home.join("config.yaml"))
+            .open_items
+            .muted
+    }
+
     /// After a turn, say what is outstanding — but only if the set changed.
     ///
     /// Repeating the same three items after every turn is how a status line
     /// becomes wallpaper. Staying silent when nothing moved is what keeps the
-    /// line worth reading on the turn something does.
+    /// line worth reading on the turn something does. Muted sources are removed
+    /// before the comparison, so muting silences this too — the turn notice is
+    /// where noise costs most, because it interrupts.
     pub fn note_open_items_if_changed(&mut self) {
-        let items = crate::open_items::collect(&self.home);
-        let fp = crate::open_items::fingerprint(&items);
+        let (visible, _) = crate::open_items::partition(
+            crate::open_items::collect(&self.home),
+            &self.muted_origins(),
+        );
+        let fp = crate::open_items::fingerprint(&visible);
         if self.open_items_fp == Some(fp) {
             return;
         }
         self.open_items_fp = Some(fp);
-        if let Some(line) = crate::open_items::summary_line(&items) {
+        if let Some(line) = crate::open_items::summary_line(&visible) {
             self.push_system(line);
         }
     }
@@ -2028,5 +2041,70 @@ mod session_cost_tests {
         // unpriced model → None (fail-open: unknown cost never blocks)
         a.pricing = super::super::footer::Pricing::default();
         assert_eq!(a.session_cost(), None);
+    }
+}
+
+#[cfg(test)]
+mod open_items_notice_tests {
+    use super::*;
+
+    fn app_with_muted(home: &tempfile::TempDir, muted: &str) -> App {
+        std::fs::write(
+            home.path().join("config.yaml"),
+            format!("open_items:\n  muted:\n    - {muted}\n"),
+        )
+        .unwrap();
+        let session = Session::create(home.path(), "a").unwrap();
+        App::new(
+            home.path().to_path_buf(),
+            "a".into(),
+            session,
+            &super::super::theme::DARK,
+        )
+    }
+
+    fn add_proposals(home: &tempfile::TempDir, names: &[&str]) {
+        let dir = home.path().join("inbox").join("workflow-proposals");
+        std::fs::create_dir_all(&dir).unwrap();
+        for n in names {
+            std::fs::write(dir.join(format!("{n}.yaml")), "name: x\n").unwrap();
+        }
+    }
+
+    /// The turn notice is where noise costs most, because it interrupts. A
+    /// muted source must not wake it — not on the first turn, and not when it
+    /// churns.
+    #[test]
+    fn a_muted_source_never_wakes_the_turn_notice() {
+        let home = tempfile::tempdir().unwrap();
+        add_proposals(&home, &["a", "b", "c"]);
+        let mut app = app_with_muted(&home, "inbox");
+
+        let before = app.messages.len();
+        app.note_open_items_if_changed();
+        assert_eq!(app.messages.len(), before, "muted source produced a line");
+
+        // The muted source changes. Still nothing.
+        add_proposals(&home, &["d", "e"]);
+        app.note_open_items_if_changed();
+        assert_eq!(app.messages.len(), before, "muted churn produced a line");
+    }
+
+    /// ...and the mute must not silence everything else with it, or the notice
+    /// is dead rather than quiet.
+    #[test]
+    fn an_unmuted_source_still_speaks() {
+        let home = tempfile::tempdir().unwrap();
+        add_proposals(&home, &["a"]);
+        let mut app = app_with_muted(&home, "something-else");
+
+        let before = app.messages.len();
+        app.note_open_items_if_changed();
+        assert_eq!(app.messages.len(), before + 1);
+        assert!(
+            app.messages.last().unwrap().text.contains("open item"),
+            "{:?}",
+            app.messages.last()
+        );
     }
 }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -1673,8 +1673,13 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
         SlashCmd::Panel(args) => panel::handle_panel_command(app, &args),
         SlashCmd::Open => {
             let items = crate::open_items::collect(&app.home);
-            app.open_items_fp = Some(crate::open_items::fingerprint(&items));
-            app.push_system(crate::open_items::render(&items, &[]).trim().to_string());
+            let (visible, muted) = crate::open_items::partition(items, &app.muted_origins());
+            app.open_items_fp = Some(crate::open_items::fingerprint(&visible));
+            app.push_system(
+                crate::open_items::render(&visible, &muted)
+                    .trim()
+                    .to_string(),
+            );
         }
         SlashCmd::Unknown(c) => app.push_system(format!("unknown command: /{c} — try /help")),
     }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -1674,7 +1674,7 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
         SlashCmd::Open => {
             let items = crate::open_items::collect(&app.home);
             app.open_items_fp = Some(crate::open_items::fingerprint(&items));
-            app.push_system(crate::open_items::render(&items).trim().to_string());
+            app.push_system(crate::open_items::render(&items, &[]).trim().to_string());
         }
         SlashCmd::Unknown(c) => app.push_system(format!("unknown command: /{c} — try /help")),
     }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -1102,11 +1102,38 @@ fn persist_skin(home: &std::path::Path, name: &str) -> anyhow::Result<()> {
     let path = home.join("config.yaml");
     let mut cfg = Config::load_or_default(&path);
     cfg.cli.skin = Some(name.to_string());
-    let text = serde_yaml::to_string(&cfg).context("serialise config")?;
-    let tmp = path.with_extension("yaml.tmp");
-    std::fs::write(&tmp, &text).context("write config tmp")?;
-    std::fs::rename(&tmp, &path).context("rename config")?;
-    Ok(())
+    crate::store::config::save_config_at(&path, &cfg)
+}
+
+#[cfg(test)]
+mod persist_skin_tests {
+    use super::persist_skin;
+
+    /// `persist_skin` must go through the shared `save_config_at` writer
+    /// instead of hand-rolling its own serialise/write/rename — otherwise it
+    /// inherits the bug that writer was just fixed for: a typed `Config`
+    /// round-trip silently drops every top-level block it has no field for
+    /// (e.g. a hand-written `research_gateway` block).
+    #[test]
+    fn persist_skin_preserves_blocks_the_typed_config_does_not_know() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        std::fs::write(
+            home.join("config.yaml"),
+            "research_gateway:\n  brave_api_key_ref: keychain:mur/brave\n",
+        )
+        .unwrap();
+
+        persist_skin(home, "dark").unwrap();
+
+        let back = std::fs::read_to_string(home.join("config.yaml")).unwrap();
+        assert!(back.contains("skin: dark"), "skin not written:\n{back}");
+        assert!(back.contains("research_gateway"), "block dropped:\n{back}");
+        assert!(
+            back.contains("keychain:mur/brave"),
+            "value dropped:\n{back}"
+        );
+    }
 }
 
 /// Stage a base64 image (with its mime) to send with the next message.

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1050,29 +1050,33 @@ pub async fn run(cli: Cli) -> Result<()> {
                     let items = crate::open_items::collect(&home);
                     // Fail toward showing: an unreadable config yields no
                     // mutes, never a quiet, confident, incomplete list.
-                    let muted_cfg = if all {
-                        Vec::new()
-                    } else {
-                        mur_common::config::Config::load_or_default(&cfg_path)
-                            .open_items
-                            .muted
-                    };
-                    let (visible, muted) = crate::open_items::partition(items.clone(), &muted_cfg);
+                    let configured = mur_common::config::Config::load_or_default(&cfg_path)
+                        .open_items
+                        .muted;
+                    // `--all` suspends the policy for this render. It does not
+                    // change what the policy *is*, which is why only the human
+                    // half below consults it.
+                    let effective = if all { Vec::new() } else { configured.clone() };
+                    let (visible, matched) =
+                        crate::open_items::partition(items.clone(), &effective);
                     if json {
                         // Display policy never truncates the machine-readable
-                        // form: consumers get every item plus the mute set and
-                        // apply their own policy. Emitting only the visible
-                        // half would make a fully muted list indistinguishable
-                        // from an empty one for anything but a human reader.
+                        // form: consumers get every item plus the configured
+                        // mute set and apply their own policy. Emitting only
+                        // the visible half would make a fully muted list
+                        // indistinguishable from an empty one, and reporting
+                        // only the mutes that matched today would make a
+                        // consumer's view of the policy depend on what happens
+                        // to be outstanding.
                         println!(
                             "{}",
                             serde_json::to_string_pretty(&serde_json::json!({
                                 "items": items,
-                                "muted": muted,
+                                "muted": configured,
                             }))?
                         );
                     } else {
-                        print!("{}", crate::open_items::render(&visible, &muted));
+                        print!("{}", crate::open_items::render(&visible, &matched));
                     }
                 }
             }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1014,7 +1014,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                     if json {
                         println!("{}", serde_json::to_string_pretty(&items)?);
                     } else {
-                        print!("{}", crate::open_items::render(&items));
+                        print!("{}", crate::open_items::render(&items, &[]));
                     }
                 }
             }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -993,8 +993,9 @@ pub async fn run(cli: Cli) -> Result<()> {
             eprintln!("# mur out: use `mur session out`");
             cmd::session::cmd_out(action.as_deref(), force).await?
         }
-        Commands::Open { action, json } => {
+        Commands::Open { action, json, all } => {
             let home = crate::paths::mur_root(None);
+            let cfg_path = home.join("config.yaml");
             match action {
                 Some(OpenAction::Add { title, agent, next }) => {
                     let id = crate::open_items::reported::report(
@@ -1009,12 +1010,69 @@ pub async fn run(cli: Cli) -> Result<()> {
                     crate::open_items::reported::resolve(&home, &id)?;
                     println!("Resolved {id}");
                 }
+                Some(OpenAction::Mute { origin }) => {
+                    let mut cfg = mur_common::config::Config::load_or_default(&cfg_path);
+                    // Record even when nothing currently carries it — a source
+                    // can be legitimately empty today — but say so, so a typo
+                    // surfaces here rather than as a silent no-op later.
+                    let mut seen: Vec<String> = crate::open_items::collect(&home)
+                        .into_iter()
+                        .map(|i| i.origin)
+                        .collect();
+                    if !seen.contains(&origin) {
+                        seen.sort();
+                        seen.dedup();
+                        eprintln!(
+                            "warning: nothing currently has origin '{origin}' (in use: {})",
+                            if seen.is_empty() {
+                                "none".to_string()
+                            } else {
+                                seen.join(", ")
+                            }
+                        );
+                    }
+                    if !cfg.open_items.muted.contains(&origin) {
+                        cfg.open_items.muted.push(origin.clone());
+                        cfg.open_items.muted.sort();
+                        crate::store::config::save_config_at(&cfg_path, &cfg)?;
+                    }
+                    println!("Muted {origin}");
+                }
+                Some(OpenAction::Unmute { origin }) => {
+                    let mut cfg = mur_common::config::Config::load_or_default(&cfg_path);
+                    cfg.open_items.muted.retain(|m| m != &origin);
+                    crate::store::config::save_config_at(&cfg_path, &cfg)?;
+                    // Unmuting something that was not muted is not an error:
+                    // the requested end state holds either way.
+                    println!("Unmuted {origin}");
+                }
                 None => {
                     let items = crate::open_items::collect(&home);
-                    if json {
-                        println!("{}", serde_json::to_string_pretty(&items)?);
+                    // Fail toward showing: an unreadable config yields no
+                    // mutes, never a quiet, confident, incomplete list.
+                    let muted_cfg = if all {
+                        Vec::new()
                     } else {
-                        print!("{}", crate::open_items::render(&items, &[]));
+                        mur_common::config::Config::load_or_default(&cfg_path)
+                            .open_items
+                            .muted
+                    };
+                    let (visible, muted) = crate::open_items::partition(items.clone(), &muted_cfg);
+                    if json {
+                        // Display policy never truncates the machine-readable
+                        // form: consumers get every item plus the mute set and
+                        // apply their own policy. Emitting only the visible
+                        // half would make a fully muted list indistinguishable
+                        // from an empty one for anything but a human reader.
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&serde_json::json!({
+                                "items": items,
+                                "muted": muted,
+                            }))?
+                        );
+                    } else {
+                        print!("{}", crate::open_items::render(&visible, &muted));
                     }
                 }
             }

--- a/mur-core/src/open_items/mod.rs
+++ b/mur-core/src/open_items/mod.rs
@@ -40,6 +40,31 @@ pub fn collect(mur_home: &Path) -> Vec<OpenItem> {
     items
 }
 
+/// Split `items` by the mute list.
+///
+/// Returns the items to show, and the muted origins that actually matched
+/// something — the footer names what the reader would otherwise have seen,
+/// not what the config happens to contain, so a stale mute stays quiet.
+pub fn partition(items: Vec<OpenItem>, muted: &[String]) -> (Vec<OpenItem>, Vec<String>) {
+    let mut hidden: Vec<String> = Vec::new();
+    let visible: Vec<OpenItem> = items
+        .into_iter()
+        .filter(|it| {
+            // Exact match, never prefix: `fleet` must not swallow `fleet:acme`.
+            if muted.iter().any(|m| m == &it.origin) {
+                if !hidden.contains(&it.origin) {
+                    hidden.push(it.origin.clone());
+                }
+                false
+            } else {
+                true
+            }
+        })
+        .collect();
+    hidden.sort();
+    (visible, hidden)
+}
+
 /// One line for a place that cannot afford a panel — a TUI turn boundary.
 ///
 /// `None` when there is nothing open, because the alternative is telling the
@@ -209,5 +234,62 @@ mod tests {
         // Same title, different source = a different claim about the world.
         let reported = vec![item(ItemSource::Reported, "one", Utc::now())];
         assert_ne!(fingerprint(&base), fingerprint(&reported));
+    }
+
+    #[test]
+    fn partition_hides_muted_origins_and_names_them() {
+        let items = vec![
+            OpenItem {
+                origin: "inbox".into(),
+                ..item(ItemSource::Observed, "a", Utc::now())
+            },
+            OpenItem {
+                origin: "fleet:x".into(),
+                ..item(ItemSource::Observed, "b", Utc::now())
+            },
+        ];
+        let (visible, muted) = partition(items, &["inbox".to_string()]);
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].origin, "fleet:x");
+        assert_eq!(muted, vec!["inbox".to_string()]);
+    }
+
+    /// `fleet` must not swallow `fleet:acme`. Prefix matching is the one
+    /// outcome a mute must never produce by accident.
+    #[test]
+    fn mute_matching_is_exact_not_prefix() {
+        let items = vec![OpenItem {
+            origin: "fleet:acme".into(),
+            ..item(ItemSource::Observed, "a", Utc::now())
+        }];
+        let (visible, muted) = partition(items, &["fleet".to_string()]);
+        assert_eq!(visible.len(), 1, "prefix must not match");
+        assert!(muted.is_empty());
+    }
+
+    /// A configured mute that matched nothing is not named — the footer
+    /// reports what the reader would otherwise have seen, not the config.
+    #[test]
+    fn a_mute_that_matched_nothing_is_not_reported() {
+        let items = vec![OpenItem {
+            origin: "inbox".into(),
+            ..item(ItemSource::Observed, "a", Utc::now())
+        }];
+        let (_, muted) = partition(items, &["fleet:gone".to_string()]);
+        assert!(muted.is_empty());
+    }
+
+    /// Muting a noisy source has to silence the turn notice too, or the mute
+    /// does nothing where it matters most.
+    #[test]
+    fn fingerprint_over_visible_ignores_muted_churn() {
+        let mk = |n: usize| OpenItem {
+            title: format!("{n} proposals"),
+            origin: "inbox".into(),
+            ..item(ItemSource::Observed, "x", Utc::now())
+        };
+        let (v1, _) = partition(vec![mk(246)], &["inbox".to_string()]);
+        let (v2, _) = partition(vec![mk(300)], &["inbox".to_string()]);
+        assert_eq!(fingerprint(&v1), fingerprint(&v2));
     }
 }

--- a/mur-core/src/open_items/mod.rs
+++ b/mur-core/src/open_items/mod.rs
@@ -113,29 +113,43 @@ pub fn fingerprint(items: &[OpenItem]) -> u64 {
 
 /// Render for a terminal. Groups by source with the marker legend, because an
 /// unlabelled mixed list is the thing this module exists to avoid.
-pub fn render(items: &[OpenItem]) -> String {
-    if items.is_empty() {
-        return "No open items.\n".into();
-    }
-    let mut out = String::new();
-    let mut last: Option<ItemSource> = None;
-    for it in items {
-        if last != Some(it.source) {
-            let caveat = match it.source {
-                ItemSource::Observed => "from MUR's own state",
-                ItemSource::Reported => "an agent said so, unverified",
-            };
-            out.push_str(&format!(
-                "\n{} {} — {caveat}\n",
-                it.source.marker(),
-                it.source.label()
-            ));
-            last = Some(it.source);
+pub fn render(items: &[OpenItem], muted: &[String]) -> String {
+    let mut out = if items.is_empty() {
+        "No open items.\n".to_string()
+    } else {
+        let mut s = String::new();
+        let mut last: Option<ItemSource> = None;
+        for it in items {
+            if last != Some(it.source) {
+                let caveat = match it.source {
+                    ItemSource::Observed => "from MUR's own state",
+                    ItemSource::Reported => "an agent said so, unverified",
+                };
+                s.push_str(&format!(
+                    "\n{} {} — {caveat}\n",
+                    it.source.marker(),
+                    it.source.label()
+                ));
+                last = Some(it.source);
+            }
+            s.push_str(&format!("  {} [{}]\n", it.title, it.origin));
+            if let Some(next) = &it.next {
+                s.push_str(&format!("      → {next}\n"));
+            }
         }
-        out.push_str(&format!("  {} [{}]\n", it.title, it.origin));
-        if let Some(next) = &it.next {
-            out.push_str(&format!("      → {next}\n"));
-        }
+        s
+    };
+
+    // Collapsed, never hidden. This one line is what makes a permanent mute
+    // safe: the reader never has to wonder whether something is missing, so
+    // the real trade is one line versus N — not show versus hide.
+    if !muted.is_empty() {
+        out.push_str(&format!(
+            "\n{} source{} muted ({}) — mur open --all\n",
+            muted.len(),
+            if muted.len() == 1 { "" } else { "s" },
+            muted.join(", ")
+        ));
     }
     out
 }
@@ -173,10 +187,13 @@ mod tests {
     /// which without being told twice.
     #[test]
     fn render_labels_both_sources() {
-        let out = render(&[
-            item(ItemSource::Observed, "a", Utc::now()),
-            item(ItemSource::Reported, "b", Utc::now()),
-        ]);
+        let out = render(
+            &[
+                item(ItemSource::Observed, "a", Utc::now()),
+                item(ItemSource::Reported, "b", Utc::now()),
+            ],
+            &[],
+        );
         assert!(out.contains("observed"), "{out}");
         assert!(out.contains("reported"), "{out}");
         assert!(out.contains("unverified"), "{out}");
@@ -184,7 +201,36 @@ mod tests {
 
     #[test]
     fn empty_says_so_rather_than_printing_a_bare_header() {
-        assert_eq!(render(&[]), "No open items.\n");
+        assert_eq!(render(&[], &[]), "No open items.\n");
+    }
+
+    /// A permanent mute is only safe if the list always says something is
+    /// muted. The reader must never have to wonder whether anything is hidden.
+    #[test]
+    fn footer_names_muted_sources() {
+        let out = render(
+            &[item(ItemSource::Observed, "visible", Utc::now())],
+            &["inbox".to_string(), "fleet:old".to_string()],
+        );
+        assert!(out.contains("2 sources muted"), "{out}");
+        assert!(out.contains("inbox"), "{out}");
+        assert!(out.contains("fleet:old"), "{out}");
+        assert!(out.contains("mur open --all"), "{out}");
+    }
+
+    #[test]
+    fn no_footer_when_nothing_is_muted() {
+        let out = render(&[item(ItemSource::Observed, "a", Utc::now())], &[]);
+        assert!(!out.contains("muted"), "{out}");
+    }
+
+    /// Everything muted is not the same as nothing outstanding, and the
+    /// difference has to be visible.
+    #[test]
+    fn everything_muted_still_shows_the_footer() {
+        let out = render(&[], &["inbox".to_string()]);
+        assert!(out.contains("1 source muted"), "{out}");
+        assert!(out.contains("No open items"), "{out}");
     }
 
     /// Nothing open must produce no line at all. "0 open items" after every

--- a/mur-core/src/store/config.rs
+++ b/mur-core/src/store/config.rs
@@ -128,7 +128,19 @@ pub fn save_config_at(path: &Path, config: &Config) -> Result<()> {
 #   To save cost, switch to Sonnet: llm.model: claude-sonnet-5
 
 "#;
-    fs::write(path, format!("{}{}", header, yaml))?;
+    let content = format!("{}{}", header, yaml);
+
+    // Atomic write: temp file in the same directory, then rename (matches the
+    // store/yaml.rs pattern). A crash, full disk, or killed process partway
+    // through a plain `fs::write` could otherwise leave a truncated
+    // config.yaml that then fails to parse on the next read; `rename` is only
+    // atomic within a filesystem, so the temp file must live next to `path`,
+    // not in a system temp directory.
+    let tmp_path = path.with_extension("yaml.tmp");
+    fs::write(&tmp_path, &content)
+        .with_context(|| format!("Failed to write temp file: {}", tmp_path.display()))?;
+    fs::rename(&tmp_path, path)
+        .with_context(|| format!("Failed to rename temp to final: {}", path.display()))?;
     Ok(())
 }
 
@@ -218,6 +230,41 @@ mod save_roundtrip_tests {
         assert_eq!(
             after, corrupt,
             "corrupt file must be left byte-for-byte untouched:\n{after}"
+        );
+
+        // The whole point of refusing early is that the operation touches
+        // nothing — a temp file created (and perhaps abandoned) partway
+        // through would still be a leak, even though the real config is safe.
+        let entries: Vec<String> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            entries,
+            vec!["config.yaml".to_string()],
+            "a refused write must not create a temp file either, found: {entries:?}"
+        );
+    }
+
+    /// A rename-based atomic writer that forgets to clean up (or renames to
+    /// the wrong path) would leak its `.tmp` file on every save — assert the
+    /// directory holds only the final `config.yaml` afterward.
+    #[test]
+    fn save_leaves_no_stray_temp_file_on_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+
+        let cfg = Config::default();
+        save_config_at(&path, &cfg).unwrap();
+
+        let entries: Vec<String> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            entries,
+            vec!["config.yaml".to_string()],
+            "directory must contain only config.yaml after a successful save, found: {entries:?}"
         );
     }
 

--- a/mur-core/src/store/config.rs
+++ b/mur-core/src/store/config.rs
@@ -28,6 +28,31 @@ pub fn save_config(config: &Config) -> Result<()> {
     save_config_at(&config_path(), config)
 }
 
+/// Serialise `config`, then restore any top-level block the typed `Config`
+/// has no field for.
+///
+/// `Config` cannot round-trip what it cannot parse, so serialising the struct
+/// alone silently deletes user blocks — `research_gateway` was measurably lost
+/// on every `mur sleep` (#778). Typed fields win; only keys absent from the
+/// new document are carried over from the old one.
+fn merge_over_existing(path: &Path, config: &Config) -> Result<String> {
+    let mut out = serde_yaml::to_value(config)?;
+    let existing: Option<serde_yaml::Value> = fs::read_to_string(path)
+        .ok()
+        .and_then(|s| serde_yaml::from_str(&s).ok());
+
+    if let (Some(serde_yaml::Value::Mapping(old)), serde_yaml::Value::Mapping(new)) =
+        (existing, &mut out)
+    {
+        for (k, v) in old {
+            if !new.contains_key(&k) {
+                new.insert(k, v);
+            }
+        }
+    }
+    Ok(serde_yaml::to_string(&out)?)
+}
+
 /// Save config to an explicit path (same YAML + header as [`save_config`]).
 /// Exists so callers with an explicit `MUR_HOME` (tests, per-agent CLI
 /// handlers) can persist config without going through the process-global
@@ -38,7 +63,7 @@ pub fn save_config_at(path: &Path, config: &Config) -> Result<()> {
     }
 
     // Serialize to YAML, then prepend a header with model recommendations
-    let yaml = serde_yaml::to_string(config)?;
+    let yaml = merge_over_existing(path, config)?;
     let header = r#"# MUR Configuration
 # Docs: https://github.com/mur-run/mur
 #
@@ -92,4 +117,51 @@ fn config_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("~"))
         .join(".mur")
         .join("config.yaml")
+}
+
+#[cfg(test)]
+mod save_roundtrip_tests {
+    use super::*;
+    use mur_common::config::Config;
+
+    /// `Config` cannot round-trip a block it has no field for, so serialising
+    /// the struct alone deletes it. Measured on a real config: a hand-written
+    /// `research_gateway` block vanished on the next `mur sleep`.
+    #[test]
+    fn save_preserves_blocks_the_typed_config_does_not_know() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            "research_gateway:\n  brave_api_key_ref: keychain:mur/brave\n",
+        )
+        .unwrap();
+
+        let cfg = Config::load_or_default(&path);
+        save_config_at(&path, &cfg).unwrap();
+
+        let back = std::fs::read_to_string(&path).unwrap();
+        assert!(back.contains("research_gateway"), "block dropped:\n{back}");
+        assert!(
+            back.contains("keychain:mur/brave"),
+            "value dropped:\n{back}"
+        );
+    }
+
+    /// The typed fields must still win — an unknown-block merge that also
+    /// resurrected stale known values would be a different bug.
+    #[test]
+    fn typed_fields_still_overwrite_the_old_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        std::fs::write(&path, "session:\n  retention_days: 3\nkeep_me: yes\n").unwrap();
+
+        let mut cfg = Config::load_or_default(&path);
+        cfg.session.retention_days = 99;
+        save_config_at(&path, &cfg).unwrap();
+
+        let back = std::fs::read_to_string(&path).unwrap();
+        assert!(back.contains("99"), "typed field not written:\n{back}");
+        assert!(back.contains("keep_me"), "unknown key dropped:\n{back}");
+    }
 }

--- a/mur-core/src/store/config.rs
+++ b/mur-core/src/store/config.rs
@@ -35,21 +35,51 @@ pub fn save_config(config: &Config) -> Result<()> {
 /// alone silently deletes user blocks — `research_gateway` was measurably lost
 /// on every `mur sleep` (#778). Typed fields win; only keys absent from the
 /// new document are carried over from the old one.
+///
+/// A file that exists but fails to parse is refused outright (`Err`, nothing
+/// written) rather than silently treated as "no existing config" — that
+/// would replace the user's entire file with defaults instead of merely
+/// skipping the merge (residual gap found in review of #778). A missing
+/// file is first-run and must still succeed; a file that parses to
+/// something other than a mapping (e.g. an empty file parses to `null`) is
+/// not a parse failure and also keeps
+/// today's skip-the-merge-and-write behaviour.
 fn merge_over_existing(path: &Path, config: &Config) -> Result<String> {
     let mut out = serde_yaml::to_value(config)?;
-    let existing: Option<serde_yaml::Value> = fs::read_to_string(path)
-        .ok()
-        .and_then(|s| serde_yaml::from_str(&s).ok());
 
-    if let (Some(serde_yaml::Value::Mapping(old)), serde_yaml::Value::Mapping(new)) =
-        (existing, &mut out)
-    {
-        for (k, v) in old {
-            if !new.contains_key(&k) {
-                new.insert(k, v);
+    match fs::read_to_string(path) {
+        Ok(content) => {
+            let existing: serde_yaml::Value = serde_yaml::from_str(&content).map_err(|e| {
+                anyhow::anyhow!(
+                    "config at {} is not valid YAML and was left untouched \
+                     (fix the syntax and try again): {e}",
+                    path.display()
+                )
+            })?;
+
+            if let (serde_yaml::Value::Mapping(old), serde_yaml::Value::Mapping(new)) =
+                (existing, &mut out)
+            {
+                for (k, v) in old {
+                    if !new.contains_key(&k) {
+                        new.insert(k, v);
+                    }
+                }
             }
         }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // First run: nothing to merge over.
+        }
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!(
+                    "could not read existing config at {} (left untouched)",
+                    path.display()
+                )
+            });
+        }
     }
+
     Ok(serde_yaml::to_string(&out)?)
 }
 
@@ -163,5 +193,64 @@ mod save_roundtrip_tests {
         let back = std::fs::read_to_string(&path).unwrap();
         assert!(back.contains("99"), "typed field not written:\n{back}");
         assert!(back.contains("keep_me"), "unknown key dropped:\n{back}");
+    }
+
+    /// A file that exists but fails to parse must never be silently replaced
+    /// with defaults — that would wipe every user setting, not just the
+    /// unknown blocks `merge_over_existing` is meant to protect. The fix
+    /// must refuse the write and leave the corrupt file exactly as it was.
+    #[test]
+    fn save_errors_on_corrupt_existing_file_and_leaves_it_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        let corrupt = "session:\n  retention_days: [1, 2\nother: true\n";
+        std::fs::write(&path, corrupt).unwrap();
+
+        let cfg = Config::default();
+        let result = save_config_at(&path, &cfg);
+
+        assert!(
+            result.is_err(),
+            "corrupt existing config must not be silently overwritten"
+        );
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            after, corrupt,
+            "corrupt file must be left byte-for-byte untouched:\n{after}"
+        );
+    }
+
+    /// First run: no config file yet. This must keep working — it is not
+    /// the "corrupt file" case.
+    #[test]
+    fn save_succeeds_when_file_does_not_exist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        assert!(!path.exists());
+
+        let cfg = Config::default();
+        let result = save_config_at(&path, &cfg);
+
+        assert!(result.is_ok(), "first-run save must succeed: {result:?}");
+        assert!(path.exists());
+    }
+
+    /// An empty file parses to `Value::Null`, not a mapping — that is a
+    /// valid (if trivial) document, not a parse failure, so it must not be
+    /// treated as corrupt.
+    #[test]
+    fn save_succeeds_when_existing_file_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        std::fs::write(&path, "").unwrap();
+
+        let cfg = Config::default();
+        let result = save_config_at(&path, &cfg);
+
+        assert!(
+            result.is_ok(),
+            "empty existing file must still allow save: {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Why

`mur open` and the murmur turn notice surface every outstanding item. When one
source is permanently noisy — 243 harvest proposals from our own tooling
(#777) — the whole surface becomes wallpaper. A status line that is ignored is
worse than no status line.

## What

`mur open mute <origin>` / `unmute <origin>` / `--all`.

Design decisions worth knowing:

- **Collapsed, never hidden.** A muted source still prints one footer line
  naming it. The trade is one line versus N, not show versus hide — which is
  what makes a permanent mute safe.
- **Permanent by design.** No snooze timer, no change threshold. Silently
  un-muting is worse than never un-muting.
- **Exact match, never prefix.** `fleet` must not swallow every `fleet:<name>`.
- **State lives in `config.yaml`, not `open-items.jsonl`.** That log is
  append-only and *agent-writable* via the `open_item` tool; a user decision
  must not be overturnable by an agent appending a record. Same reasoning as
  `fleet_run.agents`.
- **Fail toward showing.** An unreadable config yields an empty mute set, so
  everything appears — never a quiet, confident, incomplete list.
- **`--json` reports the policy, not today's outcome.** It carries every item
  plus the *configured* mute set; `--all` never alters it. Emitting only the
  visible half would make a fully-muted list indistinguishable from an empty
  one.

Also folded in: four `config.yaml` writer fixes found while adding the mute
field — the typed struct was deleting blocks it did not know about, merging
over unparseable files, and writing non-atomically.

## Test

`mur-common` / `mur-open-items` / `mur-channel` / `mur-compress`: 976/976.
`mur-core --lib`: open_items 21/21, agent::cli+config 275/275.
`cargo clippy --workspace -- -D warnings` clean, `cargo fmt --check` clean.

The full `mur-core` suite could not complete locally — this drive is at 100%
and the test build does not fit. CI is the gate for those targets.

Spec: `docs/superpowers/specs/2026-07-27-open-items-mute-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)