### PR TITLE
fix(harvest): gate on shape, not just substance; derive readable titles

### DIFF
--- a/docs/superpowers/specs/2026-07-16-fleet-issue-fix-v2-parallel-machine-verify.md
+++ b/docs/superpowers/specs/2026-07-16-fleet-issue-fix-v2-parallel-machine-verify.md
@@ -1,0 +1,191 @@
+# fleet-issue-fix v2 — parallel fan-out + machine-verifiable assertions
+
+> Status: spec (not implemented) · 2026-07-16
+> Replaces: v1 workflow `fleet-issue-fix` (single-assignee serial loop, human-verified diffs)
+> Motivation: six issues took 5 parallel subagents with manual diff verification; a fleet-native version should match or beat this throughput with lower supervision cost
+
+## 1. Problem
+
+v1 fleet-issue-fix has two bottlenecks:
+
+| Bottleneck | Symptom | Root cause |
+|---|---|---|
+| **Throughput** | N issues = N serial rounds | Single assignee, single worktree, no parallelism |
+| **Supervision cost** | Supervisor reads every diff against spec to verify | Verification is human, not machine — every diff enters context |
+
+## 2. Solution outline
+
+Two new phases slot into the existing DAG:
+
+```
+recon (supervisor, unchanged)
+  → fan-out
+       ├── topology: classify each issue by file anchor → disjoint/overlapping groups
+       ├── N worktrees (one per issue)
+       └── N spec files (with machine-verifiable asserts, see §3)
+  → parallel dispatch
+       ├── parallel_jobs MCP: one rustsmith job per issue
+       ├── each job is files-gated (disjoint files = no collision)
+       └── overlapping issues in the same group are serial within that group
+  → machine verify
+       ├── per-issue: run asserts from spec (nextest exit code, grep needle count, cargo check)
+       ├── two-strike rule preserved (same defect twice → supervisor takeover)
+       └── supervisor only inspects a diff when a strike fires
+  → gates (per worktree: check, fmt, clippy)
+  → repomanager (one PR per issue)
+  → merge (CI green → merge; standing authorization)
+```
+
+## 3. Machine-verifiable assertions in spec files
+
+### 3.1 Format
+
+The spec file (already a markdown artifact written into the worktree) gains a YAML frontmatter block with an `asserts:` list:
+
+```yaml
+---
+issue: 712
+slug: deny-own-profile-write
+assignee: rustsmith
+asserts:
+  - type: test_exists
+    filter: deny_own_profile
+    crate: mur-agent-runtime
+  - type: test_passes
+    filter: policy
+    crate: mur-agent-runtime
+  - type: grep_count
+    file: mur-agent-runtime/src/sandbox/policy.rs
+    needle: SELF_PROTECTED_AGENT_FILES
+    min: 1
+  - type: cargo_check
+    crate: mur-agent-runtime
+  - type: no_grep
+    file: mur-agent-runtime/Cargo.toml
+    needle: "new-dependency"   # guard against implicit dep creep
+---
+```
+
+### 3.2 Assertion types
+
+| Type | Exit-zero when | Fails when |
+|---|---|---|
+| `test_exists` | At least one test name contains `filter` | No matching test found (spec asks for a test that wasn't written) |
+| `test_passes` | `cargo nextest run -E 'test({filter})'` exits 0 | Test exists but fails (spec asks for correct behavior, got wrong behavior) |
+| `grep_count` | Needle appears ≥ `min` times in `file` | Needle count below threshold (spec asks for a pattern, wasn't implemented) |
+| `no_grep` | Needle is absent from `file` | Needle found (spec asks for something NOT to be present — dep removal, dead code) |
+| `cargo_check` | `cargo check -p {crate}` exits 0 | Won't compile (catches the most common failure: patch doesn't apply cleanly) |
+| `diff_lines` | `git diff --stat` shows ≥ `min` changed lines in `file` | Truncated/empty delivery caught before human inspection |
+
+### 3.3 Verifier implementation
+
+```bash
+# verify-one-issue.sh — called from the workflow verify phase
+SPEC=".worktrees/fix-$ISSUE/.task-$ISSUE-spec.md"
+WORKTREE=".worktrees/fix-$ISSUE"
+
+# Parse asserts from YAML frontmatter (yq or simple awk for the constrained format)
+# For each assert, run the check; exit non-zero on first failure
+# stdout: pass/fail per assert → workflow reads exit code
+```
+
+The workflow verify phase calls this once per issue. Exit code 0 = all asserts pass → proceed to gates. Exit code ≠ 0 → strike counter increments; two strikes on the same issue → supervisor inspects ONLY that issue's diff.
+
+## 4. Fan-out topology
+
+### 4.1 Classification
+
+Before creating worktrees, the supervisor's recon output now includes a **file anchor list** per issue (already implicit — the recon step reads the issue and locates code anchors). The fan-out phase formalizes this:
+
+```
+issues = [
+  {id:712, files:["mur-agent-runtime/src/sandbox/policy.rs", "mur-agent-runtime/src/tools/fs_policy.rs"]},
+  {id:713, files:["mur-core/src/cmd/agent/cli/mod.rs", "mur-core/src/cmd/agent/cli/recover.rs"]},
+  {id:715, files:["mur-agent-runtime/src/llm/mod.rs", "mur-agent-runtime/src/task_runner.rs"]},
+  {id:716, files:["mur-agent-runtime/src/tools/suggest.rs", "mur-core/src/cmd/agent/cli/mod.rs"]},
+  {id:717, files:["mur-common/src/skill/loader.rs", "mur-core/src/cmd/agent/skill.rs", ...]},
+]
+
+overlap_groups = group_by_overlap(issues)  // 713+716 share cli/mod.rs → same group
+// → [{712}, {715}, {717}, {713, 716}]
+// 4 groups, not 6 — 713+716 serial in their group, all groups run in parallel
+```
+
+### 4.2 Execution model
+
+- **Between groups**: parallel (no file overlap → no merge conflict)
+- **Within a group**: serial (shared files → second issue waits for first to commit)
+- **Disjoint-groups guard**: `parallel_jobs` MCP's existing files-gate rejects a job if its file anchors overlap with any in-flight sibling — so classification bugs fail closed
+
+## 5. Changes to the workflow script
+
+### 5.1 New phases
+
+```javascript
+// fleet-issue-fix v2 phases — additive, not breaking
+
+phase('fan-out')
+const topology = classify(issues)  // → [{groupId, issues:[...], files:[...]}]
+for (const group of topology) {
+  group.worktrees = group.issues.map(i => 
+    `git worktree add .worktrees/fix-${i.id} -b fix/${i.slug} origin/main`)
+}
+
+phase('spec')
+// Write spec files WITH asserts frontmatter into each worktree
+
+phase('dispatch')  
+// parallel_jobs: one rustsmith job per issue, files-gated by topology
+
+phase('verify')
+// Machine: verify-one-issue.sh per worktree, exit-code gated
+// Strike mechanism: same-issue two failures → supervisor takeover
+
+// phases after verify: gates, commit, repomanager, merge — unchanged per-issue
+```
+
+### 5.2 Variables
+
+Add to existing variables:
+- `issues`: array of `{id, slug, files[], assignee}` — replaces single `issue`/`slug`/`assignee`
+
+### 5.3 Backward compatibility
+
+Single-issue mode preserves the existing variable interface:
+- When `issues` is absent, fall back to `{issue}`, `{slug}`, `{assignee}` — identical to v1
+- When `issues` is present, fan-out activates
+
+## 6. What stays the same
+
+- Spec-FILE handoff (path survives router compression)
+- Write-first orders (no cargo/git/sed in dispatch)
+- Conventional commit + repomanager PR
+- CI-green → merge (standing authorization)
+- Worktree isolation per issue
+- Two-strike supervisor takeover (now gated on machine asserts, not human diff reading)
+
+## 7. Risk: shared target directory
+
+Parallel worktrees sharing one `target/` directory cause lock contention and spurious rebuilds. Mitigation options (decide at implementation):
+
+**A. Per-worktree target (safe, disk-heavy):** `CARGO_TARGET_DIR=.worktrees/fix-<N>/target` — each issue gets its own build cache. ~2-5GB per worktree for mur-agent-runtime. Acceptable for ≤4 parallel groups.
+
+**B. Serialized cargo (disk-light, slower):** Share the main checkout's target but serialize all `cargo check`/`cargo test` calls within a group. Groups already have disjoint files, so no rebuild churn.
+
+**C. Hybrid:** shared target, serialized cargo per group (B), parallel across groups. This is the default recommendation — the parallelism win is in dispatch, not in compilation.
+
+## 8. Implementation plan
+
+1. **Spec asserts first** — machine-verifiable assertions work for single-issue v1 before fan-out exists. Build `verify-one-issue.sh` and prove it catches the three failure modes from the v1 campaign (empty delivery, truncated patch, wrong behavior). This immediately cuts v1 supervision cost.
+2. **Topology classification** — `classify()` function: file-anchor sets → overlap groups. Pure data transform, testable without fleet.
+3. **Fan-out phase** — wire `parallel_jobs` MCP, add the `issues` variable, parallel worktree creation.
+4. **Dogfood** — run v2 on the next batch of issues; measure: wall-clock vs v1, supervisor context tokens consumed, missed-bug rate.
+
+## 9. Success metrics
+
+| Metric | v1 (serial, human verify) | v2 target (parallel, machine verify) |
+|---|---|---|
+| Wall-clock for 6 disjoint issues | N × (recon + dispatch + verify + gates) | max(dispatch per group) + gates |
+| Supervisor diff-reading events | 1 per issue per strike | 0 (only on 2nd strike) |
+| False-negatives (bug lands in main) | Near zero (human reads every diff) | Same (asserts encode the same checks) |
+| False-positives (assert fails but fix is correct) | N/A | < 5% (primarily `grep_count` with brittle needles) |

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -1914,6 +1914,12 @@ pub struct HarvestCfg {
     /// A session is considered ended when its last event is older than this.
     #[serde(default = "default_idle_minutes")]
     pub idle_minutes: i64,
+    /// Ceilings — past these a recording is a session, not a procedure (#781).
+    /// A session marked with `mur in` bypasses both.
+    #[serde(default = "default_max_steps")]
+    pub max_steps: usize,
+    #[serde(default = "default_max_duration_secs")]
+    pub max_duration_secs: i64,
     /// §3.7 hard caps (persisted now; enforced when the LLM extract path lands in v2 P5a).
     #[serde(default = "default_max_llm_calls_per_day")]
     pub max_llm_calls_per_day: u32,
@@ -1950,6 +1956,17 @@ fn default_min_duration_secs() -> i64 {
 }
 fn default_idle_minutes() -> i64 {
     30
+}
+/// Above ~20 distinct commands a recording reads as a transcript, not a
+/// procedure a human would write down. Measured against a real 38-proposal
+/// inbox: everything plausible sat below it, nothing accepted sat above (#781).
+fn default_max_steps() -> usize {
+    20
+}
+/// 30 minutes. Long enough for a real deploy/release procedure including waits,
+/// short enough to exclude debugging sessions (#781).
+fn default_max_duration_secs() -> i64 {
+    1800
 }
 fn default_max_llm_calls_per_day() -> u32 {
     10

--- a/mur-core/src/harvest/gate.rs
+++ b/mur-core/src/harvest/gate.rs
@@ -72,6 +72,46 @@ pub fn gate(events: &[SessionEvent], meta: &SessionMeta, cfg: &HarvestCfg) -> Ga
     }
 }
 
+/// Second gate, on the extracted step list: reject recordings whose *shape* says
+/// "session" rather than "procedure" (#781).
+///
+/// `gate` above is floor-only — a single tool call clears it — so a 405-step,
+/// 24-hour debugging transcript passed as easily as a five-command deploy. Those
+/// proposals are unreviewable, and an inbox full of them buries the good ones.
+/// A session marked with `mur in` is an explicit human "yes" and bypasses this.
+pub fn shape_gate(
+    steps: &[String],
+    duration_secs: i64,
+    marked: bool,
+    cfg: &HarvestCfg,
+) -> GateDecision {
+    if marked {
+        return GateDecision {
+            pass: true,
+            reason: "marked via mur in".to_string(),
+        };
+    }
+    if steps.len() > cfg.max_steps {
+        return GateDecision {
+            pass: false,
+            reason: format!("{} steps > max_steps {}", steps.len(), cfg.max_steps),
+        };
+    }
+    if duration_secs > cfg.max_duration_secs {
+        return GateDecision {
+            pass: false,
+            reason: format!(
+                "{}s > max_duration_secs {}",
+                duration_secs, cfg.max_duration_secs
+            ),
+        };
+    }
+    GateDecision {
+        pass: true,
+        reason: String::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -123,5 +163,38 @@ mod tests {
     fn marked_session_always_passes() {
         let cfg = HarvestCfg::default();
         assert!(gate(&[], &meta(0, true), &cfg).pass);
+    }
+
+    fn steps(n: usize) -> Vec<String> {
+        (0..n).map(|i| format!("step-{i}")).collect()
+    }
+
+    #[test]
+    fn short_session_passes_shape_gate() {
+        let cfg = HarvestCfg::default();
+        assert!(shape_gate(&steps(5), 60, false, &cfg).pass);
+    }
+
+    #[test]
+    fn long_session_fails_shape_gate() {
+        let cfg = HarvestCfg::default();
+        let d = shape_gate(&steps(cfg.max_steps + 1), 60, false, &cfg);
+        assert!(!d.pass);
+        assert!(d.reason.contains("max_steps"), "{}", d.reason);
+    }
+
+    #[test]
+    fn slow_session_fails_shape_gate() {
+        let cfg = HarvestCfg::default();
+        let d = shape_gate(&steps(3), cfg.max_duration_secs + 1, false, &cfg);
+        assert!(!d.pass);
+        assert!(d.reason.contains("max_duration_secs"), "{}", d.reason);
+    }
+
+    #[test]
+    fn marked_session_bypasses_shape_gate() {
+        let cfg = HarvestCfg::default();
+        let long = steps(cfg.max_steps + 100);
+        assert!(shape_gate(&long, cfg.max_duration_secs * 10, true, &cfg).pass);
     }
 }

--- a/mur-core/src/harvest/mod.rs
+++ b/mur-core/src/harvest/mod.rs
@@ -90,6 +90,21 @@ pub fn scan_in_dirs(
         if steps.iter().all(|s| s.starts_with("tool:")) {
             continue;
         }
+        let duration_secs = match (events.first(), events.last()) {
+            (Some(f), Some(l)) if l.timestamp >= f.timestamp => {
+                ((l.timestamp - f.timestamp) / 1000) as i64
+            }
+            _ => 0,
+        };
+        let shape = gate::shape_gate(&steps, duration_secs, meta.marked, cfg);
+        if !shape.pass {
+            tracing::debug!(
+                "harvest shape gate skipped session {}: {}",
+                id,
+                shape.reason
+            );
+            continue;
+        }
         let skeleton = skeleton::skeletonize_steps(&steps);
 
         let similar_to = existing_workflow_steps
@@ -99,13 +114,7 @@ pub fn scan_in_dirs(
             .max_by(|a, b| a.1.total_cmp(&b.1))
             .map(|(name, _)| name.clone());
 
-        let title = meta.title.clone().unwrap_or_else(|| id.clone());
-        let duration_secs = match (events.first(), events.last()) {
-            (Some(f), Some(l)) if l.timestamp >= f.timestamp => {
-                ((l.timestamp - f.timestamp) / 1000) as i64
-            }
-            _ => 0,
-        };
+        let title = proposal::clean_title(meta.title.as_deref(), &steps);
         // Project the session ran in (repo root), for project-local skill scope.
         let project = events
             .iter()

--- a/mur-core/src/harvest/proposal.rs
+++ b/mur-core/src/harvest/proposal.rs
@@ -137,6 +137,76 @@ pub fn step_similarity(a: &[String], b: &[String]) -> f32 {
     inter / union
 }
 
+/// Longest title we keep; past this a reviewer is reading a paragraph, not
+/// scanning a list.
+const TITLE_MAX: usize = 60;
+
+/// Turn a raw session title into something a reviewer can scan.
+///
+/// `meta.title` is the user's first chat message verbatim, so it arrives as a
+/// slash command, a multi-line paste, or a `<task-notification>` blob about as
+/// often as it arrives as a sentence (#781). Keep the first line, drop the
+/// slash-command verb, cap the length; when nothing survives, name the session
+/// after the programs it actually ran.
+pub fn clean_title(raw: Option<&str>, steps: &[String]) -> String {
+    raw.and_then(|t| t.lines().next())
+        .map(str::trim)
+        // A leading '<' means a system-injected blob, never a human title.
+        .filter(|l| !l.starts_with('<'))
+        .map(|l| match l.strip_prefix('/') {
+            // "/mur-out review the inbox" → "review the inbox"; bare "/mur-out" → ""
+            Some(rest) => rest.split_once(char::is_whitespace).map_or("", |(_, r)| r),
+            None => l,
+        })
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(truncate_words)
+        .unwrap_or_else(|| programs_of(steps))
+}
+
+/// Cap at `TITLE_MAX`, breaking on a word boundary rather than mid-word.
+fn truncate_words(s: &str) -> String {
+    if s.chars().count() <= TITLE_MAX {
+        return s.to_string();
+    }
+    let mut out = String::new();
+    for w in s.split_whitespace() {
+        if out.chars().count() + w.chars().count() + 1 > TITLE_MAX {
+            break;
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(w);
+    }
+    // A single word longer than the cap leaves `out` empty — cut it instead.
+    if out.is_empty() {
+        out = s.chars().take(TITLE_MAX).collect();
+    }
+    out
+}
+
+/// Fallback title: the distinct programs the session invoked, in order.
+fn programs_of(steps: &[String]) -> String {
+    let mut progs: Vec<&str> = Vec::new();
+    for s in steps {
+        let Some(p) = s.split_whitespace().next() else {
+            continue;
+        };
+        let p = p.strip_prefix("tool:").unwrap_or(p);
+        if !p.is_empty() && !progs.contains(&p) {
+            progs.push(p);
+        }
+        if progs.len() == 3 {
+            break;
+        }
+    }
+    if progs.is_empty() {
+        return "captured session".to_string();
+    }
+    progs.join(", ")
+}
+
 /// kebab-case a session title into a workflow name suggestion.
 pub fn suggest_name(title: &str) -> String {
     let name: String = title
@@ -230,5 +300,44 @@ mod tests {
     fn list_pending_empty_dir_is_empty() {
         let tmp = tempfile::TempDir::new().unwrap();
         assert!(list_pending(tmp.path(), 5).is_empty());
+    }
+
+    #[test]
+    fn clean_title_keeps_a_plain_sentence() {
+        assert_eq!(clean_title(Some("deploy the api"), &[]), "deploy the api");
+    }
+
+    #[test]
+    fn clean_title_drops_noise_and_falls_back_to_programs() {
+        let steps = vec!["git status".to_string(), "cargo build".to_string()];
+        // multi-line paste → first line only
+        assert_eq!(
+            clean_title(Some("fix the gate\nand also…"), &steps),
+            "fix the gate"
+        );
+        // slash command → the argument, or the fallback when there is none
+        assert_eq!(
+            clean_title(Some("/mur-out review inbox"), &steps),
+            "review inbox"
+        );
+        assert_eq!(clean_title(Some("/mur-out"), &steps), "git, cargo");
+        // system-injected blob is never a title
+        assert_eq!(
+            clean_title(Some("<task-notification>…"), &steps),
+            "git, cargo"
+        );
+        assert_eq!(clean_title(None, &steps), "git, cargo");
+        assert_eq!(clean_title(None, &[]), "captured session");
+    }
+
+    #[test]
+    fn clean_title_caps_length_on_a_word_boundary() {
+        let long = "word ".repeat(40);
+        let t = clean_title(Some(&long), &[]);
+        assert!(t.chars().count() <= TITLE_MAX, "{t:?}");
+        assert!(t.ends_with("word"), "{t:?}");
+        // a single unbreakable word still gets cut
+        let blob = "x".repeat(200);
+        assert_eq!(clean_title(Some(&blob), &[]).chars().count(), TITLE_MAX);
     }
 }


### PR DESCRIPTION
Closes #781.

## Problem

`gate()` was floor-only — it rejected a recording only when *every* signal was below threshold, so a single tool call cleared it. A 405-step, 24-hour debugging transcript passed as easily as a five-command deploy.

Measured over a real 38-proposal inbox (45 days of ambient capture): **0 accepted**, step count median 24 / max 405, duration max 1478 min. Unreviewable proposals bury the good ones, which is what makes the whole inbox go unread.

## Change

- **`gate::shape_gate`** — second gate on the extracted step list. Rejects past `harvest.max_steps` (20) and `harvest.max_duration_secs` (1800). Both configurable with documented defaults; a session marked with `mur in` is an explicit human yes and bypasses both.
- **`proposal::clean_title`** — replaces `meta.title` used verbatim (the user's first chat message). First line only, slash-command verb dropped, `<...>` system blobs rejected, capped at 60 chars on a word boundary, falling back to the programs the session actually ran. Of the 38: 21 exceeded 60 chars, 13 were multiline, 10 were slash commands, 1 was a `<task-notification>` blob.

## Verification

Replayed against the real 38: **16 kept, 22 rejected** — survivors are 3–12 steps, all under 20 min:

```
  3   1m  為什麼現在常常跳出叫我輸入MAC的密碼
  6   1m  tag release
  9   2m  safely clean branches and worktrees
  9   4m  mur compress today 2026-07-26
 12   1m  把rustsmith做成官網的agent
```

8 new unit tests (shape ceilings, `mur in` bypass, title sanitizing incl. CJK/word-boundary/unbreakable-word). `nextest -p mur-core --lib` 2170/2170 green.

Forward-only — existing proposals are untouched.

## Not done here

Recurrence. The real definition of a procedure is something done more than once, which needs a persisted skeleton index across gated sessions — new state, new file format. The ceiling is the stopgap; #781 keeps the target state on record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)