### PR TITLE
feat(harvest): gate proposals on recurrence, not just shape (#783)

### DIFF
--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -1929,8 +1929,14 @@ pub struct HarvestCfg {
     #[serde(default = "default_harvest_enabled")]
     pub session_start_hint: bool,
     /// Step-skeleton Jaccard similarity at/above which a proposal becomes a merge suggestion.
+    /// Doubles as the "same procedure?" test for the recurrence index (#783).
     #[serde(default = "default_similarity_merge_threshold")]
     pub similarity_merge_threshold: f32,
+    /// A procedure is something done more than once (#783): a session's skeleton
+    /// must have been seen this many times before it becomes a proposal.
+    /// A session marked with `mur in` bypasses it.
+    #[serde(default = "default_min_occurrences")]
+    pub min_occurrences: usize,
 }
 
 impl Default for HarvestCfg {
@@ -1976,6 +1982,11 @@ fn default_max_extract_input_tokens() -> usize {
 }
 fn default_similarity_merge_threshold() -> f32 {
     0.6
+}
+/// Twice. The minimum that can distinguish "did it again" from "did it" — a
+/// higher bar would silently discard real routines while the index is young (#783).
+fn default_min_occurrences() -> usize {
+    2
 }
 
 // ── M7a: Cross-agent observability ─────────────────────────────────

--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -361,6 +361,21 @@ pub(crate) async fn cmd_out(action: Option<&str>, force: bool) -> anyhow::Result
 
     if pending.is_empty() {
         eprintln!("✓ Nothing to harvest — no pending workflow proposals.");
+        // A silent gate is indistinguishable from a broken one. Say what has
+        // been banked so "no proposals" reads as "nothing has repeated yet"
+        // rather than "recurrence is dead" (#783).
+        let idx = crate::harvest::recurrence::load(&crate::harvest::recurrence::path_for(&inbox));
+        if let Some(top) = idx.entries.iter().map(|e| e.count).max() {
+            let need = crate::store::config::load_config()
+                .map(|c| c.harvest.min_occurrences)
+                .unwrap_or(0);
+            eprintln!(
+                "  {} session shape(s) banked, most-repeated {}× — a proposal needs {}×.",
+                idx.entries.len(),
+                top,
+                need
+            );
+        }
         eprintln!("  (Recording is always on; see `mur session list`.)");
         return Ok(());
     }
@@ -389,10 +404,16 @@ pub(crate) async fn cmd_out(action: Option<&str>, force: bool) -> anyhow::Result
     for p in pending {
         eprintln!();
         eprintln!(
-            "◆ \"{}\"  ({} events · {}m)",
+            "◆ \"{}\"  ({} events · {}m{})",
             p.title,
             p.event_count,
-            p.duration_secs / 60
+            p.duration_secs / 60,
+            // Why this proposal exists at all — a one-off never gets here (#783).
+            if p.occurrences > 1 {
+                format!(" · seen {}×", p.occurrences)
+            } else {
+                String::new()
+            }
         );
         for (i, s) in p.steps.iter().enumerate().take(8) {
             eprintln!("    {}. {}", i + 1, s);

--- a/mur-core/src/cmd/skill_suggest.rs
+++ b/mur-core/src/cmd/skill_suggest.rs
@@ -73,6 +73,7 @@ mod tests {
                 skeleton: vec!["cargo build".into()],
                 event_count: 5,
                 duration_secs: 60,
+                occurrences: 2,
                 created_at: "2026-06-11T00:00:00Z".into(),
                 status: ProposalStatus::Pending,
                 similar_to: None,

--- a/mur-core/src/harvest/mod.rs
+++ b/mur-core/src/harvest/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod gate;
 pub mod proposal;
+pub mod recurrence;
 pub mod skeleton;
 
 use anyhow::Result;
@@ -39,6 +40,9 @@ pub fn scan_in_dirs(
         .unwrap_or_default()
         .as_millis() as u64;
     let idle_ms = (cfg.idle_minutes.max(0) as u64) * 60 * 1000;
+    let index_path = recurrence::path_for(inbox_dir);
+    let mut index = recurrence::load(&index_path);
+    let mut index_dirty = false;
 
     for entry in std::fs::read_dir(recordings_dir)? {
         let path = entry?.path();
@@ -107,6 +111,22 @@ pub fn scan_in_dirs(
         }
         let skeleton = skeleton::skeletonize_steps(&steps);
 
+        // Recorded only after the shape gate, so transcripts never pollute the
+        // index. Below `min_occurrences` the sighting is banked and nothing is
+        // proposed — a procedure is something done more than once (#783).
+        let now = chrono::Utc::now().to_rfc3339();
+        let occurrences = index.observe(&skeleton, &id, &now, cfg.similarity_merge_threshold);
+        index_dirty = true;
+        if !meta.marked && occurrences < cfg.min_occurrences {
+            tracing::debug!(
+                "harvest: session {} seen {}x, below min_occurrences {}",
+                id,
+                occurrences,
+                cfg.min_occurrences
+            );
+            continue;
+        }
+
         let similar_to = existing_workflow_steps
             .iter()
             .map(|(name, wsteps)| (name, proposal::step_similarity(&skeleton, wsteps)))
@@ -128,6 +148,7 @@ pub fn scan_in_dirs(
             skeleton,
             event_count: events.len(),
             duration_secs,
+            occurrences,
             created_at: chrono::Utc::now().to_rfc3339(),
             status: proposal::ProposalStatus::Pending,
             similar_to,
@@ -135,6 +156,9 @@ pub fn scan_in_dirs(
         };
         proposal::save_in_dir(inbox_dir, &p)?;
         report.proposed += 1;
+    }
+    if index_dirty {
+        recurrence::save(&index_path, &index)?;
     }
     Ok(report)
 }
@@ -277,6 +301,8 @@ mod tests {
 
         let cfg = HarvestCfg {
             idle_minutes: 0,
+            // Recurrence has its own tests below; this one is about project stamping.
+            min_occurrences: 1,
             ..Default::default()
         };
         scan_in_dirs(&rec, &inbox, &[], &cfg).unwrap();
@@ -296,6 +322,7 @@ mod tests {
 
         let cfg = HarvestCfg {
             idle_minutes: 0, // session timestamps are ancient → idle
+            min_occurrences: 1,
             ..Default::default()
         };
         let r1 = scan_in_dirs(&rec, &inbox, &[], &cfg).unwrap();
@@ -317,6 +344,7 @@ mod tests {
 
         let cfg = HarvestCfg {
             idle_minutes: 0,
+            min_occurrences: 1,
             ..Default::default()
         };
         let existing = vec![(
@@ -330,5 +358,62 @@ mod tests {
         scan_in_dirs(&rec, &inbox, &existing, &cfg).unwrap();
         let pending = proposal::pending_in_dir(&inbox).unwrap();
         assert_eq!(pending[0].similar_to.as_deref(), Some("deploy-api"));
+    }
+
+    #[test]
+    fn one_off_session_is_not_proposed() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rec = tmp.path().join("recordings");
+        let inbox = tmp.path().join("inbox");
+        write_session(&rec, "s1", 4, false);
+
+        let cfg = HarvestCfg {
+            idle_minutes: 0,
+            ..Default::default() // min_occurrences = 2
+        };
+        let r = scan_in_dirs(&rec, &inbox, &[], &cfg).unwrap();
+        assert_eq!(r.scanned, 1, "still gated and judged");
+        assert_eq!(r.proposed, 0, "seen once is a session, not a procedure");
+        // The sighting is banked so the next run of the same steps can recur.
+        let idx = recurrence::load(&recurrence::path_for(&inbox));
+        assert_eq!(idx.entries.len(), 1);
+    }
+
+    #[test]
+    fn repeating_the_same_steps_proposes_on_the_second_sighting() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rec = tmp.path().join("recordings");
+        let inbox = tmp.path().join("inbox");
+        let cfg = HarvestCfg {
+            idle_minutes: 0,
+            ..Default::default()
+        };
+
+        write_session(&rec, "s1", 4, false);
+        assert_eq!(scan_in_dirs(&rec, &inbox, &[], &cfg).unwrap().proposed, 0);
+
+        // Same procedure, different session: now it is a routine.
+        write_session(&rec, "s2", 4, false);
+        assert_eq!(scan_in_dirs(&rec, &inbox, &[], &cfg).unwrap().proposed, 1);
+
+        let pending = proposal::pending_in_dir(&inbox).unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, "s2");
+        assert_eq!(pending[0].occurrences, 2);
+    }
+
+    #[test]
+    fn marked_session_is_proposed_on_first_sight() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let rec = tmp.path().join("recordings");
+        let inbox = tmp.path().join("inbox");
+        write_session(&rec, "s1", 4, true);
+
+        let cfg = HarvestCfg {
+            idle_minutes: 0,
+            ..Default::default()
+        };
+        // `mur in` is an explicit human yes — it outranks the heuristic.
+        assert_eq!(scan_in_dirs(&rec, &inbox, &[], &cfg).unwrap().proposed, 1);
     }
 }

--- a/mur-core/src/harvest/proposal.rs
+++ b/mur-core/src/harvest/proposal.rs
@@ -31,6 +31,11 @@ pub struct Proposal {
     pub skeleton: Vec<String>,
     pub event_count: usize,
     pub duration_secs: i64,
+    /// How many times harvest has seen this skeleton, including this session.
+    /// The reason the proposal exists at all (#783); 1 on proposals written
+    /// before recurrence, and on sessions marked with `mur in`.
+    #[serde(default)]
+    pub occurrences: usize,
     pub created_at: String,
     pub status: ProposalStatus,
     /// Existing workflow this proposal nearly duplicates (suggest merge).
@@ -241,6 +246,7 @@ mod tests {
             skeleton: vec!["cargo build".into(), "fly deploy --app <STR>".into()],
             event_count: 12,
             duration_secs: 300,
+            occurrences: 2,
             created_at: "2026-06-11T00:00:00Z".into(),
             status,
             similar_to: None,

--- a/mur-core/src/harvest/recurrence.rs
+++ b/mur-core/src/harvest/recurrence.rs
@@ -1,0 +1,194 @@
+//! Recurrence index: which step-skeletons has harvest seen before? (#783)
+//!
+//! The shape gate (#781) rejects recordings by size, but size was never the real
+//! question. What makes something a procedure is that it was **done more than
+//! once** — a five-command deploy run once is a session; run three times it is a
+//! workflow. This is the smallest thing that can tell those apart: a JSON sidecar
+//! next to the inbox holding one entry per distinct skeleton, matched with the
+//! same Jaccard similarity the merge suggestion already uses (a repeat is rarely
+//! byte-identical).
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Session ids kept per entry — enough to explain *why* a proposal exists,
+/// bounded so a weekly routine cannot grow the file without limit.
+const MAX_SESSIONS_PER_ENTRY: usize = 10;
+
+/// Entries kept in total, least-recently-seen evicted first.
+/// ponytail: a flat cap, not a decay policy — revisit if the index ever fills.
+const MAX_ENTRIES: usize = 500;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Entry {
+    /// Skeletonized step list — the matching key, never shown to a reviewer.
+    pub skeleton: Vec<String>,
+    pub count: usize,
+    pub first_seen: String,
+    pub last_seen: String,
+    /// Sessions that produced this skeleton, oldest first, capped.
+    #[serde(default)]
+    pub sessions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Index {
+    #[serde(default)]
+    pub entries: Vec<Entry>,
+}
+
+impl Index {
+    /// Record one sighting of `skeleton`; return how many times it has now been
+    /// seen. Re-observing a session already credited to an entry is a no-op, so a
+    /// re-scan can never inflate a count into a false recurrence.
+    pub fn observe(
+        &mut self,
+        skeleton: &[String],
+        session_id: &str,
+        now: &str,
+        threshold: f32,
+    ) -> usize {
+        let best = self
+            .entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| {
+                (
+                    i,
+                    crate::harvest::proposal::step_similarity(skeleton, &e.skeleton),
+                )
+            })
+            .filter(|(_, sim)| *sim >= threshold)
+            .max_by(|a, b| a.1.total_cmp(&b.1))
+            .map(|(i, _)| i);
+
+        match best {
+            Some(i) => {
+                let e = &mut self.entries[i];
+                if e.sessions.iter().any(|s| s == session_id) {
+                    return e.count;
+                }
+                e.count += 1;
+                e.last_seen = now.to_string();
+                e.sessions.push(session_id.to_string());
+                if e.sessions.len() > MAX_SESSIONS_PER_ENTRY {
+                    e.sessions.remove(0);
+                }
+                e.count
+            }
+            None => {
+                self.entries.push(Entry {
+                    skeleton: skeleton.to_vec(),
+                    count: 1,
+                    first_seen: now.to_string(),
+                    last_seen: now.to_string(),
+                    sessions: vec![session_id.to_string()],
+                });
+                self.evict();
+                1
+            }
+        }
+    }
+
+    fn evict(&mut self) {
+        if self.entries.len() <= MAX_ENTRIES {
+            return;
+        }
+        self.entries.sort_by(|a, b| a.last_seen.cmp(&b.last_seen));
+        let drop = self.entries.len() - MAX_ENTRIES;
+        self.entries.drain(..drop);
+    }
+}
+
+/// Sidecar path. Dotfile so the inbox's `*.yaml` proposal listing never sees it.
+pub fn path_for(inbox_dir: &Path) -> PathBuf {
+    inbox_dir.join(".skeleton-index.json")
+}
+
+/// Load the index; a missing or corrupt file starts a fresh one rather than
+/// failing the scan — the index is derived state, never a source of truth.
+pub fn load(path: &Path) -> Index {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+        .unwrap_or_default()
+}
+
+pub fn save(path: &Path, index: &Index) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, serde_json::to_string_pretty(index)?)?;
+    std::fs::rename(&tmp, path).with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn steps(cmds: &[&str]) -> Vec<String> {
+        cmds.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn first_sighting_counts_once() {
+        let mut idx = Index::default();
+        let n = idx.observe(&steps(&["cargo build", "cargo test"]), "s1", "t0", 0.6);
+        assert_eq!(n, 1);
+        assert_eq!(idx.entries.len(), 1);
+    }
+
+    #[test]
+    fn near_identical_repeat_increments_the_same_entry() {
+        let mut idx = Index::default();
+        idx.observe(&steps(&["cargo build", "cargo test"]), "s1", "t0", 0.6);
+        let n = idx.observe(
+            &steps(&["cargo build", "cargo test", "cargo test"]),
+            "s2",
+            "t1",
+            0.6,
+        );
+        assert_eq!(n, 2);
+        assert_eq!(idx.entries.len(), 1, "should not have forked an entry");
+        assert_eq!(idx.entries[0].sessions, vec!["s1", "s2"]);
+    }
+
+    #[test]
+    fn unrelated_session_starts_its_own_entry() {
+        let mut idx = Index::default();
+        idx.observe(&steps(&["cargo build", "cargo test"]), "s1", "t0", 0.6);
+        let n = idx.observe(&steps(&["npm run lint"]), "s2", "t1", 0.6);
+        assert_eq!(n, 1);
+        assert_eq!(idx.entries.len(), 2);
+    }
+
+    #[test]
+    fn re_observing_the_same_session_does_not_inflate_the_count() {
+        let mut idx = Index::default();
+        let s = steps(&["cargo build", "cargo test"]);
+        idx.observe(&s, "s1", "t0", 0.6);
+        assert_eq!(idx.observe(&s, "s1", "t1", 0.6), 1);
+    }
+
+    #[test]
+    fn round_trips_through_disk() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = path_for(&tmp.path().join("inbox"));
+        let mut idx = Index::default();
+        idx.observe(&steps(&["cargo build"]), "s1", "t0", 0.6);
+        save(&path, &idx).unwrap();
+        assert_eq!(load(&path).entries.len(), 1);
+    }
+
+    #[test]
+    fn missing_file_loads_empty() {
+        assert!(
+            load(Path::new("/nonexistent/.skeleton-index.json"))
+                .entries
+                .is_empty()
+        );
+    }
+}

--- a/mur-core/src/nudge/harvest_source.rs
+++ b/mur-core/src/nudge/harvest_source.rs
@@ -60,6 +60,7 @@ mod tests {
                 skeleton: vec!["cargo build".into()],
                 event_count: 5,
                 duration_secs: 60,
+                occurrences: 2,
                 created_at: "2026-06-11T00:00:00Z".into(),
                 status: ProposalStatus::Pending,
                 similar_to: None,


### PR DESCRIPTION
Closes #783.

## The premise

#782 capped proposal *size*. But "is this a procedure?" was never a question about size — it is a question about **recurrence**. A five-command deploy run once is a session; run three times it is a workflow.

## What this does

A JSON sidecar next to the inbox (`.skeleton-index.json` — dotfile, so the `*.yaml` proposal listing never sees it) holds one entry per distinct step skeleton. Sightings are recorded **after** the shape gate, so transcripts never pollute the index. A session seen fewer than `min_occurrences` (default **2**) times banks its sighting and proposes nothing.

- **Reuses the existing matcher.** `proposal::step_similarity` + `similarity_merge_threshold` already answer "are these the same procedure?" for merge suggestions. No second matcher, no second threshold. One new knob: `min_occurrences`.
- **`mur in` outranks it.** A marked session is proposed on first sight.
- **Idempotent.** Re-observing a session already credited to an entry is a no-op — a re-scan cannot inflate a count into a false recurrence.
- **Forward-only.** `#[serde(default)]`; pre-existing proposals load unchanged at `occurrences: 1`.
- **Bounded.** 500 entries, LRU-evicted; 10 session ids per entry.

## Visibility

`mur session out` shows `seen N×` per proposal — the reason it exists at all. On an empty inbox it reports how many shapes are banked and how close the top one is, because a silent gate is otherwise indistinguishable from a broken one.

## Measured, not assumed

Run read-only against the local 38-proposal corpus:

| corpus | recurring |
|---|---|
| 16 shape-gate survivors | **0** — max pairwise similarity 0.32, median 0.13 |
| all 38, exact sub-sequence windows (len 2–8) | 33 windows, **all** `Read\|Edit\|Read\|Edit` tool noise — zero recurring command sequences |

So on real data this gate currently proposes nothing — which is the correct outcome for a corpus where 0 of 38 proposals were ever accepted.

**Known ceiling:** matching is whole-skeleton and order-insensitive. A genuine `mur compress today` repeat measured **0.24** against the 0.6 bar, while two *unrelated* sessions reached **0.32** — the noise sits above the signal, so lowering the threshold makes it worse, not better. Sub-sequence mining is the upgrade path if the index stays empty in practice.

## Tests

6 new in `harvest::recurrence` (first sighting, near-identical repeat, unrelated session, re-observe idempotence, disk round-trip, missing file) + 3 in `harvest` (one-off not proposed, repeat proposes on second sighting, marked session proposed on first sight). `cargo nextest -p mur-core --lib -E 'test(harvest) or test(recurrence) or test(proposal)'` → 35 passed.