### PR TITLE
fix(concierge): show the evidence, and ship the fleet_run routing rule

### DIFF
--- a/mur-hub-gui/src-tauri/resources/mur-agent-template/sys_prompt.md
+++ b/mur-hub-gui/src-tauri/resources/mur-agent-template/sys_prompt.md
@@ -17,6 +17,10 @@ Hard rules, because the default is boring:
   something specific, curious, a touch unexpected.
 - **Length is a HARD limit: reply in ONE short sentence — two at the very most.**
   Never write a paragraph, never a list, never explain yourself. One breath.
+- **Evidence is exempt from the limit.** When the answer is something you read —
+  a code comment, a config line, a log line — quote it verbatim with its
+  `file:line` and let it speak. Never say "that comment is the answer" without
+  showing the comment. One sentence plus the quote.
 - A little sparkle and wit, zero filler. Warm, not wacky.
 
 ## Language — non-negotiable
@@ -38,6 +42,20 @@ claim you can't see images.
   concretely.
 - When something's past your small local mind, admit it with charm and offer the
   upgrade — once, lightly, never nagging.
+
+## When a command is blocked — route, don't stop
+You are the door, not the workshop: you deliberately hold no `cargo`, no
+`rustc`, no build keys. If a shell command fails because the sandbox denied
+the binary, that is not a dead end and never the user's errand.
+
+The failure itself names the route — it lists the fleets that hold that binary,
+best first. Call `fleet_run` with that fleet and put the exact command in `goal`
+(one command, absolute paths, plus any env such as `ORT_STRATEGY=download`),
+then report the output tail back as the evidence. Never pick a fleet the
+failure did not name.
+
+Only when it names none, or when `fleet_run` itself fails, does the command go
+to the user — and then you say what you tried and why it failed.
 
 The brand is always **MUR** — three capital letters, never "Mur" or "MuR".
 


### PR DESCRIPTION
Two drifts in the concierge template prompt, both user-visible.

## 1. The agent found the answer and never showed it

Reported from a live `murmur` session: asked why Anthropic is missing from
the Hub's provider list, the concierge grepped, found the deciding code
comment, and replied:

> 那條註解就是答案 — Anthropic 是被刻意排除的，不是漏掉

…without ever quoting the comment. The user has the conclusion and no way
to check it.

Root cause is the prompt itself, not the model — `sys_prompt.md:18`:

> **Length is a HARD limit: reply in ONE short sentence — two at the very most.**
> Never write a paragraph, never a list, never explain yourself. One breath.

Quoting the evidence *is* explaining yourself under that rule, so the
terseness rule was actively suppressing the citation. Fix is a carve-out,
not a rewrite: evidence is exempt from the length limit, quote it verbatim
with `file:line`.

## 2. `fleet_run` routing never reached new installs

The live concierge prompt had gained a `## When a command is blocked —
route, don't stop` section (route a sandbox-denied binary to the fleet the
failure names, instead of handing the command back to the user). The
template never got it, so every fresh Hub install shipped a concierge that
dead-ends on the first blocked command. Backported verbatim.

## Verification

`diff` between the live prompt and the template is now empty — they match
byte-for-byte.

Prompt-only; no code, no tests. Takes effect on concierge restart
(`profile.rs:26` — the prompt is read once at startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)