### PR TITLE
fix(model-setup): stop the lib test binary from reading the real keychain

### DIFF
--- a/mur-core/src/model_setup/slots.rs
+++ b/mur-core/src/model_setup/slots.rs
@@ -91,6 +91,15 @@ fn health_for(provider: &str, api_key_ref: Option<&str>) -> String {
     if provider == "ollama" {
         return "ready".into();
     }
+    // ponytail: this is the only place the lib's test binary can reach the
+    // real login keychain. `MUR_HOME` is mutated by ~45 unsynchronized
+    // set/remove pairs across this crate's tests behind 5 different mutexes;
+    // losing that race makes `get_slots()` read the developer's actual
+    // ~/.mur/config.yaml and pops a macOS password prompt per keychain: ref.
+    // Compiles to `false` in release. Upgrade path: one crate-wide env lock.
+    if cfg!(test) {
+        return "unset".into();
+    }
     match api_key_ref {
         None => "unset".into(),
         Some(r) => match r.parse::<mur_common::secret::SecretRef>() {


### PR DESCRIPTION
## The symptom

Running `cargo test -p mur-core --lib` pops repeated macOS login-keychain password prompts:

> 「mur_core-2e113cf1b2928555」想存取鑰匙圈中的密碼「mur」。

One prompt per `keychain:` ref in the developer's real `~/.mur/config.yaml`, every run. Clicking "Always Allow" is worse than useless — it grants a `target/debug/deps/` path permanent silent read access to your API keys, and the next hash change re-prompts anyway.

## The cause

`slots::health_for()` resolves `api_key_ref` through `SecretRef::resolve_blocking()`.

`get_slots()` reads config via `MUR_HOME`, and `slots::tests` sets it to a temp dir — but only behind its own private `ENV_TEST_LOCK`. This crate's lib tests mutate `MUR_HOME` from **~45 unsynchronized `set_var`/`remove_var` pairs across 31 files behind 5 different mutexes** (`conversations::ENV_LOCK`, `ADDON_TEST_LOCK`, plus local ones in `a2a_dial`, `sleep`, `slots`). `cargo test` runs those threaded in one process, so an unrelated test's `remove_var("MUR_HOME")` can land inside the window where `get_slots()` reads config — and it falls back to the real `~/.mur/config.yaml`.

## The fix

Return `"unset"` under `cfg!(test)`, before any resolve.

- It is the **only** resolve callsite the lib test binary can reach — the other one, `keychain_key_sources`, is called from interactive `init` only.
- No test asserts on `health`.
- `cfg!(test)` compiles to `false` in release; zero production cost.

Unifying the 5 env mutexes is the root fix, but that treats test *flakiness*, not this prompt — 31 files for an unrelated payoff. The upgrade path is recorded in a `ponytail:` comment at the guard.

## Verification

```
$ unset MUR_HOME; cargo test -p mur-core --lib model_setup::slots
     Running unittests src/lib.rs (target/debug/deps/mur_core-2e113cf1b2928555)
running 2 tests
test model_setup::slots::tests::rollup_rejects_registry_selection ... ok
test model_setup::slots::tests::smart_set_mirrors_following_stages_only ... ok
test result: ok. 2 passed; 0 failed
```

Same binary hash as the screenshot, `MUR_HOME` unset, both tests pass, **no prompt**. `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)