### PR TITLE
fix(embedding): stop degrading an unresolvable API key into a bare 401

### DIFF
--- a/mur-core/src/store/embedding.rs
+++ b/mur-core/src/store/embedding.rs
@@ -16,8 +16,90 @@ pub struct EmbeddingConfig {
 
 #[derive(Debug, Clone)]
 pub enum EmbeddingProvider {
-    Ollama { base_url: String },
-    OpenAI { api_key: String, base_url: String },
+    Ollama {
+        base_url: String,
+    },
+    OpenAI {
+        api_key: String,
+        base_url: String,
+        /// Why the key is empty, when a key *was* configured but could not be
+        /// resolved. `None` means no key was configured at all — a legitimate
+        /// setup for a local OpenAI-compatible server that takes no auth.
+        ///
+        /// Carried all the way to the HTTP error so the reason travels with
+        /// the failure instead of only reaching a log the caller never reads
+        /// (an MCP server's stderr is drained at `debug` by its supervisor).
+        key_hint: Option<String>,
+    },
+}
+
+/// Resolve the OpenAI-compatible API key from `api_key_ref`, then
+/// `api_key_env`, then `OPENAI_API_KEY`.
+///
+/// Returns the key plus a diagnostic hint. An empty key with no hint is
+/// legitimate (a local server with auth disabled); an empty key *with* a hint
+/// is a misconfiguration that used to degrade silently into sending
+/// `Authorization: Bearer ` and getting an unexplained 401 back.
+fn resolve_api_key(cfg: &mur_common::config::Config) -> (String, Option<String>) {
+    let emb = &cfg.embedding;
+    let mut misses: Vec<String> = Vec::new();
+
+    if let Some(raw) = emb.api_key_ref.as_deref().filter(|s| !s.trim().is_empty()) {
+        match raw.parse::<mur_common::secret::SecretRef>() {
+            Ok(sref) => match sref.resolve_to_string_blocking() {
+                Some(key) if !key.is_empty() => return (key, None),
+                Some(_) => misses.push(format!("api_key_ref `{raw}` resolved to an empty secret")),
+                // Re-resolve purely to recover the error text for the hint;
+                // only ever runs on the path that already failed.
+                None => {
+                    let why = sref
+                        .resolve_blocking()
+                        .err()
+                        .map(|e| e.to_string())
+                        .unwrap_or_else(|| "not found".into());
+                    misses.push(format!("api_key_ref `{raw}` did not resolve ({why})"));
+                }
+            },
+            Err(e) => misses.push(format!(
+                "api_key_ref `{raw}` is not a valid secret ref ({e})"
+            )),
+        }
+    }
+
+    if let Some(name) = emb.api_key_env.as_deref().filter(|s| !s.trim().is_empty()) {
+        match std::env::var(name) {
+            Ok(v) if !v.is_empty() => {
+                if !misses.is_empty() {
+                    tracing::warn!(
+                        misses = misses.join("; "),
+                        env = name,
+                        "embedding: falling back to api_key_env"
+                    );
+                }
+                return (v, None);
+            }
+            _ => misses.push(format!("api_key_env `{name}` is unset in this process")),
+        }
+    }
+
+    if let Ok(v) = std::env::var("OPENAI_API_KEY")
+        && !v.is_empty()
+    {
+        return (v, None);
+    }
+
+    if misses.is_empty() {
+        return (String::new(), None);
+    }
+
+    let hint = format!(
+        "no embedding API key: {}. A background agent process cannot always \
+         reach the OS keychain — set the key in the environment of whatever \
+         launches it, or run `mur doctor`",
+        misses.join("; ")
+    );
+    tracing::warn!("{hint}");
+    (String::new(), Some(hint))
 }
 
 impl EmbeddingConfig {
@@ -25,26 +107,17 @@ impl EmbeddingConfig {
     pub fn from_config(cfg: &mur_common::config::Config) -> Self {
         let provider = match cfg.embedding.provider.as_str() {
             "openai" | "gemini" | "anthropic" | "voyage" | "omlx" | "mlx" => {
-                // Resolve API key from api_key_ref, then api_key_env, then OPENAI_API_KEY
-                let api_key = cfg
-                    .embedding
-                    .api_key_ref
-                    .as_deref()
-                    .and_then(|r| r.parse::<mur_common::secret::SecretRef>().ok())
-                    .and_then(|s| s.resolve_to_string_blocking())
-                    .or_else(|| {
-                        cfg.embedding
-                            .api_key_env
-                            .as_deref()
-                            .and_then(|env| std::env::var(env).ok())
-                    })
-                    .unwrap_or_else(|| std::env::var("OPENAI_API_KEY").unwrap_or_default());
+                let (api_key, key_hint) = resolve_api_key(cfg);
                 let base_url = cfg
                     .embedding
                     .openai_url
                     .clone()
                     .unwrap_or_else(|| "https://api.openai.com/v1".into());
-                EmbeddingProvider::OpenAI { api_key, base_url }
+                EmbeddingProvider::OpenAI {
+                    api_key,
+                    base_url,
+                    key_hint,
+                }
             }
             _ => EmbeddingProvider::Ollama {
                 base_url: cfg.embedding.ollama_endpoint.clone(),
@@ -76,9 +149,11 @@ impl Default for EmbeddingConfig {
 pub async fn embed(text: &str, config: &EmbeddingConfig) -> Result<Vec<f32>> {
     match &config.provider {
         EmbeddingProvider::Ollama { base_url } => embed_ollama(text, base_url, &config.model).await,
-        EmbeddingProvider::OpenAI { api_key, base_url } => {
-            embed_openai(text, base_url, api_key, &config.model).await
-        }
+        EmbeddingProvider::OpenAI {
+            api_key,
+            base_url,
+            key_hint,
+        } => embed_openai(text, base_url, api_key, key_hint.as_deref(), &config.model).await,
     }
 }
 
@@ -91,9 +166,11 @@ pub async fn embed_batch(texts: &[String], config: &EmbeddingConfig) -> Result<V
         EmbeddingProvider::Ollama { base_url } => {
             embed_ollama_batch(texts, base_url, &config.model).await
         }
-        EmbeddingProvider::OpenAI { api_key, base_url } => {
-            embed_openai_batch(texts, base_url, api_key, &config.model).await
-        }
+        EmbeddingProvider::OpenAI {
+            api_key,
+            base_url,
+            key_hint,
+        } => embed_openai_batch(texts, base_url, api_key, key_hint.as_deref(), &config.model).await,
     }
 }
 
@@ -188,12 +265,40 @@ struct OpenAIEmbedData {
     embedding: Vec<f32>,
 }
 
-async fn embed_openai(text: &str, base_url: &str, api_key: &str, model: &str) -> Result<Vec<f32>> {
+/// Attach `Authorization` only when a key is actually present.
+///
+/// An empty key means no auth was configured; sending `Bearer ` turns a
+/// working no-auth local server into a 401.
+fn with_auth(req: reqwest::RequestBuilder, api_key: &str) -> reqwest::RequestBuilder {
+    if api_key.is_empty() {
+        req
+    } else {
+        req.header("Authorization", format!("Bearer {api_key}"))
+    }
+}
+
+fn embed_error(
+    status: reqwest::StatusCode,
+    url: &str,
+    body: &str,
+    key_hint: Option<&str>,
+) -> anyhow::Error {
+    match key_hint {
+        Some(h) => anyhow::anyhow!("Embed API error {status} at {url}: {body} — {h}"),
+        None => anyhow::anyhow!("Embed API error {status} at {url}: {body}"),
+    }
+}
+
+async fn embed_openai(
+    text: &str,
+    base_url: &str,
+    api_key: &str,
+    key_hint: Option<&str>,
+    model: &str,
+) -> Result<Vec<f32>> {
     let client = reqwest::Client::new();
     let url = format!("{}/embeddings", base_url.trim_end_matches('/'));
-    let resp = client
-        .post(&url)
-        .header("Authorization", format!("Bearer {}", api_key))
+    let resp = with_auth(client.post(&url), api_key)
         .json(&OpenAIEmbedRequest {
             model: model.into(),
             input: vec![text.to_string()],
@@ -205,7 +310,7 @@ async fn embed_openai(text: &str, base_url: &str, api_key: &str, model: &str) ->
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("Embed API error {} at {}: {}", status, url, body);
+        return Err(embed_error(status, &url, &body, key_hint));
     }
 
     let data: OpenAIEmbedResponse = resp.json().await.context("parsing embed response")?;
@@ -220,6 +325,7 @@ async fn embed_openai_batch(
     texts: &[String],
     base_url: &str,
     api_key: &str,
+    key_hint: Option<&str>,
     model: &str,
 ) -> Result<Vec<Vec<f32>>> {
     if texts.is_empty() {
@@ -227,9 +333,7 @@ async fn embed_openai_batch(
     }
     let client = reqwest::Client::new();
     let url = format!("{}/embeddings", base_url.trim_end_matches('/'));
-    let resp = client
-        .post(&url)
-        .header("Authorization", format!("Bearer {}", api_key))
+    let resp = with_auth(client.post(&url), api_key)
         .json(&OpenAIEmbedRequest {
             model: model.into(),
             input: texts.to_vec(),
@@ -241,7 +345,7 @@ async fn embed_openai_batch(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        anyhow::bail!("Embed API error {} at {}: {}", status, url, body);
+        return Err(embed_error(status, &url, &body, key_hint));
     }
 
     let data: OpenAIEmbedResponse = resp.json().await.context("parsing embed response")?;
@@ -315,9 +419,86 @@ mod tests {
         cfg.embedding.api_key_ref = Some("env:MUR_TEST_EMB_REF".into());
         let ec = EmbeddingConfig::from_config(&cfg);
         match ec.provider {
-            EmbeddingProvider::OpenAI { api_key, .. } => assert_eq!(api_key, "emb-key"),
+            EmbeddingProvider::OpenAI {
+                api_key, key_hint, ..
+            } => {
+                assert_eq!(api_key, "emb-key");
+                assert!(key_hint.is_none(), "a resolved key must carry no hint");
+            }
             _ => panic!("expected OpenAI provider"),
         }
         unsafe { std::env::remove_var("MUR_TEST_EMB_REF") };
+    }
+
+    /// The bug behind the unexplained `401 API key required`: a configured
+    /// `api_key_ref` that fails to resolve (a background agent process that
+    /// cannot reach the keychain) used to fall through to an empty key and
+    /// send `Authorization: Bearer `. The reason must survive to the caller.
+    ///
+    /// Both env-key tests below blank `OPENAI_API_KEY` rather than removing
+    /// it, so they are deterministic whatever the ambient environment holds.
+    /// Nothing else in this crate reads that variable.
+    #[test]
+    fn unresolvable_key_ref_yields_hint_instead_of_silent_empty_key() {
+        unsafe {
+            std::env::set_var("OPENAI_API_KEY", "");
+            std::env::remove_var("MUR_TEST_EMB_ABSENT");
+        }
+        let mut cfg = mur_common::config::Config::default();
+        cfg.embedding.provider = "omlx".into();
+        cfg.embedding.api_key_ref = Some("env:MUR_TEST_EMB_ABSENT".into());
+        cfg.embedding.api_key_env = Some("MUR_TEST_EMB_ABSENT".into());
+        match EmbeddingConfig::from_config(&cfg).provider {
+            EmbeddingProvider::OpenAI {
+                api_key, key_hint, ..
+            } => {
+                assert!(api_key.is_empty());
+                let hint = key_hint.expect("unresolvable ref must produce a hint");
+                assert!(
+                    hint.contains("env:MUR_TEST_EMB_ABSENT"),
+                    "hint must name the ref that failed, got: {hint}"
+                );
+                assert!(
+                    hint.contains("MUR_TEST_EMB_ABSENT` is unset"),
+                    "hint must also report the env fallback miss, got: {hint}"
+                );
+            }
+            _ => panic!("expected OpenAI provider"),
+        }
+    }
+
+    /// No key configured at all is a legitimate setup (a local
+    /// OpenAI-compatible server with auth disabled) — no hint, and the
+    /// request must go out without an `Authorization` header.
+    #[test]
+    fn no_key_configured_is_not_an_error() {
+        unsafe { std::env::set_var("OPENAI_API_KEY", "") };
+        let mut cfg = mur_common::config::Config::default();
+        cfg.embedding.provider = "omlx".into();
+        match EmbeddingConfig::from_config(&cfg).provider {
+            EmbeddingProvider::OpenAI {
+                api_key, key_hint, ..
+            } => {
+                assert!(api_key.is_empty());
+                assert!(key_hint.is_none(), "an unconfigured key is not a failure");
+            }
+            _ => panic!("expected OpenAI provider"),
+        }
+    }
+
+    #[test]
+    fn with_auth_omits_header_when_key_is_empty() {
+        let client = reqwest::Client::new();
+        let built = with_auth(client.post("http://127.0.0.1/v1/embeddings"), "")
+            .build()
+            .unwrap();
+        assert!(
+            built.headers().get("Authorization").is_none(),
+            "an empty key must send no Authorization header"
+        );
+        let built = with_auth(client.post("http://127.0.0.1/v1/embeddings"), "k")
+            .build()
+            .unwrap();
+        assert_eq!(built.headers()["Authorization"], "Bearer k");
     }
 }

--- a/mur-core/tests/embedding_key_hint.rs
+++ b/mur-core/tests/embedding_key_hint.rs
@@ -1,0 +1,58 @@
+//! Integration test: when an embedding API key is *configured* but cannot be
+//! resolved, the reason must travel all the way to the HTTP error.
+//!
+//! Regression guard for the unexplained `401 API key required`: the key
+//! resolution chain (`api_key_ref` → `api_key_env` → `OPENAI_API_KEY`) used to
+//! collapse to an empty string, send `Authorization: Bearer `, and surface a
+//! bare 401 with no hint at which link broke. A background agent process that
+//! cannot reach the OS keychain hits exactly that path, and the log line the
+//! resolver writes is drained at `debug` by its supervisor — so the error
+//! itself has to carry the reason.
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn unresolved_key_reason_reaches_the_http_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/embeddings"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "error": {"message": "API key required", "type": "authentication_error"}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut cfg = mur_common::config::Config::default();
+    cfg.embedding.provider = "omlx".into();
+    cfg.embedding.openai_url = Some(server.uri());
+    cfg.embedding.api_key_ref = Some("env:MUR_TEST_EMB_HINT_ABSENT".into());
+    cfg.embedding.api_key_env = Some("MUR_TEST_EMB_HINT_ABSENT".into());
+
+    // SAFETY: each .rs file under mur-core/tests/ compiles as its own
+    // integration-test binary, so this test is the only writer of these vars
+    // in this binary's process. `OPENAI_API_KEY` is blanked rather than
+    // removed so the assertion holds whatever the ambient environment carries.
+    unsafe {
+        std::env::remove_var("MUR_TEST_EMB_HINT_ABSENT");
+        std::env::set_var("OPENAI_API_KEY", "");
+    }
+
+    let ec = mur_core::store::embedding::EmbeddingConfig::from_config(&cfg);
+    let err = mur_core::store::embedding::embed("hello", &ec)
+        .await
+        .expect_err("a 401 must not be swallowed")
+        .to_string();
+
+    assert!(err.contains("401"), "error should keep the status: {err}");
+    assert!(
+        err.contains("env:MUR_TEST_EMB_HINT_ABSENT"),
+        "error should name the ref that failed to resolve: {err}"
+    );
+    assert!(
+        err.contains("keychain"),
+        "error should point at the likely cause: {err}"
+    );
+}


### PR DESCRIPTION
## Problem

`mur_project_search` from a Hub-managed agent failed with:

```
Embed API error 401 Unauthorized at http://127.0.0.1:8000/v1/embeddings:
{"error":{"message":"API key required","type":"authentication_error"}}
```

…while the same query from a shell worked. The 401 was real but the message was useless: the key chain

```
api_key_ref (keychain) → api_key_env → OPENAI_API_KEY → unwrap_or_default()
```

ended in `unwrap_or_default()`, so a **configured but unresolvable** key collapsed to `""`, went out as `Authorization: Bearer `, and the underlying keychain error was thrown away at the `.ok()`. A background agent process that cannot reach the OS keychain lands on exactly that path and gets no way to find out why.

## Change

- Resolution records **which link broke and why** (the real `SecretError` text), and that reason travels **with the HTTP error** — not only into a log line. An MCP server's stderr is drained at `debug` by its supervisor, so the log path does not exist in the agent context where this actually bites.
- An empty key no longer sends an empty bearer token.
- **No key configured at all stays legitimate** — that is a local OpenAI-compatible server with auth disabled (llama.cpp, LM Studio, oMLX without `--api-key`). It now gets no `Authorization` header instead of one that guarantees a 401.

`EmbeddingConfig::from_config` stays infallible (40 call sites); the diagnostic rides in a new `key_hint` field on the `OpenAI` variant. The warn-and-explain shape follows the existing precedent in `mur-research-gateway/src/config.rs:146`.

## Verification

`cargo test -p mur-core --lib store::embedding` (7 passed) and `--test embedding_key_hint --test embedding_openai_url` (2 passed):

- `unresolvable_key_ref_yields_hint_instead_of_silent_empty_key`
- `no_key_configured_is_not_an_error` — guards the no-auth local server case against this change
- `with_auth_omits_header_when_key_is_empty`
- `unresolved_key_reason_reaches_the_http_error` — wiremock returns 401; asserts the failing ref and the likely cause are in the error text

## Scope

This makes the failure legible; it does not yet make the agent's MCP child able to reach the secret. That follow-up depends on whether the wall sits at the MCP child or at the whole Hub-spawned process tree — being measured separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)