### PR TITLE
fix(runtime): make B0 rules 6 and 11 actually refuse startup

### DIFF
--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -7,9 +7,11 @@
 //! map and the §6.1 acceptance footer for ship status.
 //!
 //! Wiring:
-//! * `on_startup` — Rule 11 (M7.7): codesign / signtool every entry
-//!   in `ctx.mcp_server_binaries()`; refuse startup if any unsigned
-//!   on macOS / Windows. Linux is a no-op.
+//! * Rules 6 (M9.3) and 11 (M7.7) are **admission control**, not hooks —
+//!   see [`verify_mcp_supply_chain`], called by the supervisor before the
+//!   agent comes up. They used to live in `on_startup`, which is an
+//!   observe-only phase that discards every hook error into a warning, so
+//!   neither rule could actually refuse a startup (#791).
 //! * `on_prompt_submit` — Rule 3 (M7.4) wraps every prior `role:tool`
 //!   message with `<untrusted_tool_result source="tool_result:<name>">`
 //!   AND M3.8 reads the multimodal provenance ledger to wrap PDF/OCR
@@ -50,6 +52,93 @@ use mur_common::permissions::{GrantDecision, GrantStore, ScopeKey};
 /// multimodal artifact was attached to the current turn. Read by
 /// `pre_tool_use` to decide whether to gate side-effect tools.
 const TURN_FLAG_AFTER_UNTRUSTED: &str = "after_untrusted_input";
+
+/// B0 rules 11 (M7.7) and 6 (M9.3) — MCP supply-chain admission control.
+///
+/// Refuses to let the agent come up when an MCP binary is unsigned, or when a
+/// binary pinned at install time has changed underneath the profile. Returns
+/// the operator-facing reason; the caller must propagate it, not log it.
+///
+/// **Why this is a free function and not a hook.** Both rules were written to
+/// `return Err(...)` from `B0SafetyHook::on_startup` with the documented intent
+/// of refusing startup. `HookChain::on_startup` is an observe-only phase: it
+/// returns `()` and folds every hook error into `warn!`. Neither rule had ever
+/// stopped anything — an MCP binary swapped after install started normally,
+/// leaving one warning line in `stderr.log` (#791). Enforcement belongs on a
+/// path whose failure aborts, so it lives here and the supervisor calls it with
+/// `?` before the runtime is assembled.
+///
+/// Soft failures (binary missing or unreadable) stay warnings: rule 11 already
+/// catches real tampering, and a missing binary is far more likely to be "the
+/// user uninstalled the MCP without removing the profile entry" than an attack.
+///
+/// Description-hash verification is deliberately not done here — it happens
+/// lazily at the first MCP call (M9.3.5), because spawning every pinned MCP at
+/// startup just to read `tools/list` would N×-bloat boot time.
+pub fn verify_mcp_supply_chain(
+    mcp_server_binaries: &[PathBuf],
+    profile: &AgentProfile,
+) -> Result<(), String> {
+    // ── Rule 11 (M7.7): signature check. macOS/Windows only; the Linux
+    // `verify_signed` helper is a no-op per spec §6.1 row 11.
+    for path in mcp_server_binaries {
+        if let Err(reason) = crate::hooks::b0_helpers::verify_signed(path) {
+            return Err(format!(
+                "B0 rule 11: MCP binary signature check failed: {reason}"
+            ));
+        }
+    }
+
+    // ── Rule 6 (M9.3): install-time pin verification.
+    for entry in &profile.mcp_servers {
+        let Some(expected) = &entry.binary_sha256 else {
+            // Pre-M9 entry — skip silently; the cookbook documents
+            // `mur agent mcp pin <name>` as the migration verb.
+            continue;
+        };
+        // Resolve via PATH exactly as install does (mur_common::exec) so both
+        // passes hash the same binary `Command::new` will spawn. A bare
+        // `node`/`npx` opened verbatim is a CWD-relative path that doesn't
+        // exist, which previously soft-failed and skipped the pin entirely.
+        let prog = entry
+            .command
+            .split_whitespace()
+            .next()
+            .unwrap_or(&entry.command);
+        let path = match mur_common::exec::resolve_command(prog) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    mcp = %entry.name,
+                    error = %e,
+                    "B0 rule 6: pin verify soft-failed (command not resolvable); continuing",
+                );
+                continue;
+            }
+        };
+        match crate::hooks::b0_helpers::verify_mcp_binary_hash(expected, &path) {
+            Ok(()) => tracing::debug!(mcp = %entry.name, "B0 rule 6: pin verified"),
+            Err(crate::hooks::b0_helpers::PinDriftReason::BinaryDrift { .. }) => {
+                return Err(format!(
+                    "B0 rule 6: MCP `{}` changed since install — \
+                     run `mur agent mcp inspect {}` to review the \
+                     drift and `mur agent mcp pin {}` to re-approve, \
+                     or `mur agent mcp remove {}` to uninstall.",
+                    entry.name, entry.name, entry.name, entry.name,
+                ));
+            }
+            Err(soft @ crate::hooks::b0_helpers::PinDriftReason::BinaryMissing { .. })
+            | Err(soft @ crate::hooks::b0_helpers::PinDriftReason::BinaryReadError { .. }) => {
+                tracing::warn!(
+                    mcp = %entry.name,
+                    reason = %soft,
+                    "B0 rule 6: pin verify soft-failed; continuing",
+                );
+            }
+        }
+    }
+    Ok(())
+}
 
 pub struct B0SafetyHook {
     /// Loaded lazily on first use per `HookCtx::agent_home()` so tests
@@ -106,10 +195,14 @@ impl Hook for B0SafetyHook {
         "B0SafetyHook"
     }
 
+    /// Startup observation only. The two supply-chain rules that used to live
+    /// here (6 and 11) are enforced by [`verify_mcp_supply_chain`] instead —
+    /// this phase discards hook errors into warnings, so they could never
+    /// refuse a startup from here (#791).
     async fn on_startup(
         &self,
-        ctx: &HookCtx,
-        profile: &AgentProfile,
+        _ctx: &HookCtx,
+        _profile: &AgentProfile,
         _tok: &CancellationToken,
     ) -> Result<(), HookError> {
         // ── B1 sandbox attestation ────────────────────────────────────────
@@ -134,85 +227,6 @@ impl Hook for B0SafetyHook {
             }
         }
 
-        // ── Rule 11 (M7.7): MCP binary signature check. ──────────────────
-        // Iterate every MCP server binary the supervisor resolved from
-        // `profile.mcp_servers[*].command` and refuse startup if any
-        // are unsigned. macOS/Windows only; Linux's `verify_signed`
-        // helper is a noop per spec §6.1 row 11.
-        for path in ctx.mcp_server_binaries() {
-            if let Err(reason) = crate::hooks::b0_helpers::verify_signed(path) {
-                return Err(HookError::Runtime(format!(
-                    "B0 rule 11: MCP binary signature check failed: {reason}"
-                )));
-            }
-        }
-
-        // ── Rule 6 (M9.3): MCP install-time pin verification. ────────────
-        // For every entry pinned at install time (via M9.2), re-hash
-        // the binary on disk and compare. On hard drift, refuse to
-        // start so the user is forced to run `mur agent mcp inspect
-        // <name>` and re-approve. On soft fails (binary missing or
-        // unreadable) we log a warning and continue — rule 11 above
-        // already caught real tampering, and a missing binary is more
-        // likely "user uninstalled the MCP without removing the
-        // profile entry" than an attack.
-        //
-        // Description-hash verification happens lazily at first MCP
-        // call (M9.3.5) rather than here; spawning every pinned MCP
-        // at startup just to read `tools/list` would N×-bloat boot
-        // time without user-visible benefit.
-        for entry in &profile.mcp_servers {
-            let Some(expected) = &entry.binary_sha256 else {
-                // Pre-M9 entry — skip silently; the cookbook documents
-                // `mur agent mcp pin <name>` as the migration verb.
-                continue;
-            };
-            // Resolve via PATH exactly as install does (mur_common::exec) so
-            // both passes hash the same binary `Command::new` will spawn. A bare
-            // `node`/`npx` opened verbatim is a CWD-relative path that doesn't
-            // exist, which previously soft-failed and skipped the pin entirely.
-            let prog = entry
-                .command
-                .split_whitespace()
-                .next()
-                .unwrap_or(&entry.command);
-            let path = match mur_common::exec::resolve_command(prog) {
-                Ok(p) => p,
-                Err(e) => {
-                    // Can't locate the binary (likely the user uninstalled the
-                    // MCP without removing the profile entry) — soft fail, same
-                    // as BinaryMissing below.
-                    tracing::warn!(
-                        mcp = %entry.name,
-                        error = %e,
-                        "B0 rule 6: pin verify soft-failed (command not resolvable); continuing",
-                    );
-                    continue;
-                }
-            };
-            match crate::hooks::b0_helpers::verify_mcp_binary_hash(expected, &path) {
-                Ok(()) => {
-                    tracing::debug!(mcp = %entry.name, "B0 rule 6: pin verified");
-                }
-                Err(crate::hooks::b0_helpers::PinDriftReason::BinaryDrift { .. }) => {
-                    return Err(HookError::Runtime(format!(
-                        "B0 rule 6: MCP `{}` changed since install — \
-                         run `mur agent mcp inspect {}` to review the \
-                         drift and `mur agent mcp pin {}` to re-approve, \
-                         or `mur agent mcp remove {}` to uninstall.",
-                        entry.name, entry.name, entry.name, entry.name,
-                    )));
-                }
-                Err(soft @ crate::hooks::b0_helpers::PinDriftReason::BinaryMissing { .. })
-                | Err(soft @ crate::hooks::b0_helpers::PinDriftReason::BinaryReadError { .. }) => {
-                    tracing::warn!(
-                        mcp = %entry.name,
-                        reason = %soft,
-                        "B0 rule 6: pin verify soft-failed; continuing",
-                    );
-                }
-            }
-        }
         Ok(())
     }
 

--- a/mur-agent-runtime/src/hooks/b0_helpers.rs
+++ b/mur-agent-runtime/src/hooks/b0_helpers.rs
@@ -520,10 +520,13 @@ impl std::fmt::Display for PinDriftReason {
 /// so the install-side and verify-side outputs are byte-identical.
 /// Duplicated rather than imported to avoid the `mur-agent-runtime ←
 /// mur-core` dependency cycle this hook already takes pains to avoid.
-pub fn verify_mcp_binary_hash(
-    expected: &str,
-    path: &std::path::Path,
-) -> Result<(), PinDriftReason> {
+/// SHA-256 (lowercase hex) of a binary, in exactly the form a `binary_sha256`
+/// pin records.
+///
+/// Shared by the verifier below and by the supervisor's re-pin of MUR's own
+/// bundled MCP server, so the hash that gets written and the hash that gets
+/// checked can never disagree about algorithm or encoding.
+pub fn binary_sha256(path: &std::path::Path) -> Result<String, PinDriftReason> {
     use sha2::{Digest, Sha256};
     use std::fs::File;
     use std::io::Read;
@@ -561,7 +564,14 @@ pub fn verify_mcp_binary_hash(
         };
         hasher.update(&buf[..n]);
     }
-    let actual = hex::encode(hasher.finalize());
+    Ok(hex::encode(hasher.finalize()))
+}
+
+pub fn verify_mcp_binary_hash(
+    expected: &str,
+    path: &std::path::Path,
+) -> Result<(), PinDriftReason> {
+    let actual = binary_sha256(path)?;
     if actual.eq_ignore_ascii_case(expected) {
         Ok(())
     } else {

--- a/mur-agent-runtime/src/lib.rs
+++ b/mur-agent-runtime/src/lib.rs
@@ -25,6 +25,7 @@ pub mod import;
 pub mod llm;
 pub mod lock_file;
 pub mod mcp;
+pub mod mcp_repin;
 pub mod multi_call;
 pub mod multimodal;
 pub mod oauth;

--- a/mur-agent-runtime/src/mcp_repin.rs
+++ b/mur-agent-runtime/src/mcp_repin.rs
@@ -1,0 +1,163 @@
+//! Re-pin MUR's own bundled MCP server after the supervisor refreshes it.
+//!
+//! `mur_common::exec::ensure_bundled_mcp_server` copies the `mur-mcp-server`
+//! shipped beside the running `mur` into `~/.mur/mcp-servers/` whenever the two
+//! differ — so every `mur` upgrade changes that binary underneath every profile
+//! that pinned it at install time.
+//!
+//! Nothing re-pinned it, which left B0 rule 6 permanently reporting drift for
+//! the one MCP MUR ships itself. That was survivable only because rule 6 never
+//! actually refused a startup; now that it does (#791), an upgrade without a
+//! re-pin would refuse to start the agent.
+//!
+//! Re-pinning here is not a weakening of the control. The binary was just
+//! written by this runtime from its own installation — its trust anchor is
+//! "same install as the runtime", not a hash recorded weeks ago. Anyone able to
+//! swap it has already swapped `mur` itself. Third-party MCP entries, which are
+//! the reason rule 6 exists, are never touched.
+
+use std::path::Path;
+
+/// Re-pin profile entries pointing at MUR's own bundled MCP server to the
+/// binary now on disk at `bundled`.
+///
+/// Matches an entry when its command is that exact path, or the bare binary
+/// name (`mur-mcp-server`, as written by a capability install). Returns `true`
+/// when `profile.yaml` was rewritten.
+pub fn repin_bundled_mcp(agent_home: &Path, bundled: &Path) -> anyhow::Result<bool> {
+    let actual = crate::hooks::b0_helpers::binary_sha256(bundled)
+        .map_err(|e| anyhow::anyhow!("hash {}: {e}", bundled.display()))?;
+
+    let profile_path = agent_home.join("profile.yaml");
+    let yaml = std::fs::read_to_string(&profile_path)?;
+    let mut profile: mur_common::agent::AgentProfile = serde_yaml_ng::from_str(&yaml)?;
+
+    let mut changed = false;
+    for entry in &mut profile.mcp_servers {
+        let command = Path::new(&entry.command);
+        if command != bundled && command.file_name() != bundled.file_name() {
+            continue;
+        }
+        if entry.binary_sha256.as_deref() == Some(actual.as_str()) {
+            continue;
+        }
+        tracing::info!(
+            mcp = %entry.name,
+            from = entry.binary_sha256.as_deref().unwrap_or("<unpinned>"),
+            to = %actual,
+            "re-pinned bundled mcp-server after refresh",
+        );
+        entry.binary_sha256 = Some(actual.clone());
+        changed = true;
+    }
+    if !changed {
+        return Ok(false);
+    }
+
+    profile.updated_at = chrono::Utc::now().to_rfc3339();
+    let new_yaml = serde_yaml_ng::to_string(&profile)?;
+    // temp + rename: a torn profile.yaml would brick the agent.
+    let tmp = profile_path.with_extension("tmp");
+    std::fs::write(&tmp, new_yaml.as_bytes())?;
+    std::fs::rename(&tmp, &profile_path)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::AgentProfile;
+    use mur_common::agent::McpServerEntry;
+
+    fn entry(name: &str, command: &str, pin: Option<&str>) -> McpServerEntry {
+        McpServerEntry {
+            name: name.into(),
+            command: command.into(),
+            args: vec![],
+            binary_sha256: pin.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    /// Writes a profile whose entries are built from the bundled binary's real
+    /// path, plus that binary on disk. Returns (agent_home, bundled_path).
+    fn fixture(
+        make_entries: impl FnOnce(&Path) -> Vec<McpServerEntry>,
+    ) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let bundled = dir.path().join("mur-mcp-server");
+        std::fs::write(&bundled, b"bundled binary v2").unwrap();
+
+        let yaml = include_str!("../tests/fixtures/profile_minimal.yaml");
+        let mut profile: AgentProfile = serde_yaml_ng::from_str(yaml).unwrap();
+        profile.mcp_servers = make_entries(&bundled);
+        std::fs::write(
+            dir.path().join("profile.yaml"),
+            serde_yaml_ng::to_string(&profile).unwrap(),
+        )
+        .unwrap();
+        (dir, bundled)
+    }
+
+    fn reload(agent_home: &Path) -> AgentProfile {
+        serde_yaml_ng::from_str(&std::fs::read_to_string(agent_home.join("profile.yaml")).unwrap())
+            .unwrap()
+    }
+
+    #[test]
+    fn repins_the_bundled_entry_and_leaves_third_party_pins_alone() {
+        let third_party_pin = "a".repeat(64);
+        let stale_pin = "b".repeat(64);
+        let (dir, bundled) = fixture(|b| {
+            vec![
+                entry("media", &b.display().to_string(), Some(&"b".repeat(64))),
+                entry("weather", "/opt/vendor/weather-mcp", Some(&"a".repeat(64))),
+            ]
+        });
+
+        assert!(repin_bundled_mcp(dir.path(), &bundled).unwrap());
+
+        let after = reload(dir.path());
+        let expected = crate::hooks::b0_helpers::binary_sha256(&bundled).unwrap();
+        assert_eq!(
+            after.mcp_servers[0].binary_sha256.as_deref(),
+            Some(expected.as_str()),
+        );
+        assert_ne!(expected, stale_pin, "fixture must actually be stale");
+        assert_eq!(
+            after.mcp_servers[1].binary_sha256.as_deref(),
+            Some(third_party_pin.as_str()),
+            "a third-party pin is exactly what rule 6 exists to protect",
+        );
+    }
+
+    #[test]
+    fn matches_a_bare_binary_name_as_written_by_capability_installs() {
+        let (dir, bundled) = fixture(|_| vec![entry("media", "mur-mcp-server", None)]);
+
+        assert!(repin_bundled_mcp(dir.path(), &bundled).unwrap());
+
+        let expected = crate::hooks::b0_helpers::binary_sha256(&bundled).unwrap();
+        assert_eq!(
+            reload(dir.path()).mcp_servers[0].binary_sha256.as_deref(),
+            Some(expected.as_str()),
+        );
+    }
+
+    #[test]
+    fn is_idempotent_and_does_not_rewrite_when_already_current() {
+        let (dir, bundled) = fixture(|_| vec![entry("media", "mur-mcp-server", None)]);
+        assert!(repin_bundled_mcp(dir.path(), &bundled).unwrap());
+
+        let before = std::fs::read_to_string(dir.path().join("profile.yaml")).unwrap();
+        assert!(
+            !repin_bundled_mcp(dir.path(), &bundled).unwrap(),
+            "second run has nothing to change"
+        );
+        assert_eq!(
+            before,
+            std::fs::read_to_string(dir.path().join("profile.yaml")).unwrap(),
+            "an unchanged pin must not rewrite profile.yaml (updated_at would churn)",
+        );
+    }
+}

--- a/mur-agent-runtime/src/protocol/mcp_client.rs
+++ b/mur-agent-runtime/src/protocol/mcp_client.rs
@@ -267,6 +267,31 @@ impl StdioMcpClient {
         Ok(())
     }
 
+    /// Explain a closed stdout by looking at what happened to the child.
+    ///
+    /// A server that exited and a server that was killed both present as "no
+    /// more lines". Naming the exit status turns an hour of guessing into one
+    /// line — a macOS binary killed for a stale code-signing cache reports
+    /// `signal 9` here and nothing at all in stderr (#791).
+    async fn stream_closed_error(&self) -> McpError {
+        let status = {
+            let mut child = self.child.lock().await;
+            child.try_wait()
+        };
+        match status {
+            Ok(Some(st)) => McpError::Server(format!(
+                "mcp server `{}` exited before replying ({st})",
+                self.server_name
+            )),
+            // Still alive, or we cannot tell — say so rather than implying an exit.
+            Ok(None) => McpError::StreamClosed,
+            Err(e) => McpError::Server(format!(
+                "mcp server `{}` closed stdout; wait failed: {e}",
+                self.server_name
+            )),
+        }
+    }
+
     async fn request(&self, method: &str, params: Value) -> Result<Value, McpError> {
         let id = {
             let mut g = self.next_id.lock().await;
@@ -284,7 +309,10 @@ impl StdioMcpClient {
         let mut stdout = self.stdout.lock().await;
         loop {
             let next = stdout.next_line().await?;
-            let line = next.ok_or(McpError::StreamClosed)?;
+            let line = match next {
+                Some(l) => l,
+                None => return Err(self.stream_closed_error().await),
+            };
             let v: Value = serde_json::from_str(&line)?;
             if v.get("id") == Some(&json!(id)) {
                 if let Some(err) = v.get("error") {

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -207,7 +207,22 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         });
         if uses_bundled {
             match mur_common::exec::ensure_bundled_mcp_server() {
-                Ok(p) => info!(path = %p.display(), "ensured bundled mcp-server"),
+                Ok(p) => {
+                    info!(path = %p.display(), "ensured bundled mcp-server");
+                    // Re-pin: we just put this binary there ourselves, from the
+                    // `mur-mcp-server` shipped beside the running `mur`. Its
+                    // trust anchor is "same install as this runtime", not a
+                    // hash recorded weeks ago — an attacker who can swap it has
+                    // already swapped `mur` itself.
+                    //
+                    // Without this, every `mur` upgrade leaves the profile
+                    // pinned to the previous binary, so B0 rule 6 (now
+                    // enforcing, #791) would refuse to start the agent after a
+                    // routine upgrade. Third-party MCP entries are untouched.
+                    if let Err(e) = crate::mcp_repin::repin_bundled_mcp(&agent_home, &p) {
+                        warn!(error = %e, "could not re-pin bundled mcp-server");
+                    }
+                }
                 Err(e) => warn!(
                     error = %e,
                     "could not refresh bundled mcp-server; using existing copy if present"

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -567,6 +567,14 @@ pub(crate) async fn prepare_runtime(
             mur_common::exec::resolve_command(prog).ok()
         })
         .collect();
+
+    // B0 rules 11 + 6: MCP supply-chain admission control. Runs BEFORE the
+    // hook chain because it must be able to abort startup — `on_startup` is an
+    // observe-only phase that folds hook errors into warnings, which is why
+    // these two rules never refused anything until #791.
+    crate::hooks::b0::verify_mcp_supply_chain(&mcp_server_binaries, &profile.inner)
+        .map_err(|e| anyhow::anyhow!(e))?;
+
     let hook_ctx = HookCtx {
         agent_name: profile.inner.name.clone(),
         agent_uuid: profile.inner.id.clone(),

--- a/mur-agent-runtime/tests/b0_rule11_mcp_signature.rs
+++ b/mur-agent-runtime/tests/b0_rule11_mcp_signature.rs
@@ -1,12 +1,15 @@
-//! Rule 11: on_startup verifies MCP binary signatures.
+//! Rule 11: MCP binary signature verification refuses startup.
 //!
-//! On macOS, an unsigned binary in profile.mcp_servers triggers a
-//! HookError. On Linux this test is a no-op (rule doesn't apply).
+//! On macOS/Windows an unsigned binary must abort the agent's startup. On
+//! Linux the check is a documented no-op.
+//!
+//! These call [`verify_mcp_supply_chain`] directly: rules 6 and 11 moved out
+//! of `B0SafetyHook::on_startup` because that phase discards hook errors into
+//! warnings, so neither rule could actually refuse a startup (#791).
 
-use mur_agent_runtime::hooks::{B0SafetyHook, Hook, HookCtx};
+use mur_agent_runtime::hooks::b0::verify_mcp_supply_chain;
 use mur_common::AgentProfile;
 use tempfile::TempDir;
-use tokio_util::sync::CancellationToken;
 
 fn minimal_profile() -> AgentProfile {
     let yaml = include_str!("fixtures/profile_minimal.yaml");
@@ -14,8 +17,8 @@ fn minimal_profile() -> AgentProfile {
 }
 
 #[cfg(target_os = "macos")]
-#[tokio::test]
-async fn unsigned_mcp_binary_fails_startup() {
+#[test]
+fn unsigned_mcp_binary_fails_startup() {
     let dir = TempDir::new().unwrap();
     // Create an unsigned executable (just a small file).
     let bin = dir.path().join("fake-mcp");
@@ -25,55 +28,37 @@ async fn unsigned_mcp_binary_fails_startup() {
     perms.set_mode(0o755);
     std::fs::set_permissions(&bin, perms).unwrap();
 
-    let hook = B0SafetyHook::new();
-    let ctx =
-        HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin.to_path_buf()]);
-    let profile = minimal_profile();
-    let cancel = CancellationToken::new();
-    let result = hook.on_startup(&ctx, &profile, &cancel).await;
-    assert!(result.is_err(), "unsigned binary should fail on_startup");
-    let msg = format!("{}", result.unwrap_err());
-    let lower = msg.to_lowercase();
+    let err = verify_mcp_supply_chain(&[bin], &minimal_profile())
+        .expect_err("unsigned binary should refuse startup");
+    let lower = err.to_lowercase();
     assert!(
         lower.contains("not signed") || lower.contains("signing") || lower.contains("signature"),
-        "expected signature-related error, got {msg}",
+        "expected signature-related error, got {err}",
     );
 }
 
 #[cfg(target_os = "linux")]
-#[tokio::test]
-async fn linux_signature_check_is_a_noop() {
+#[test]
+fn linux_signature_check_is_a_noop() {
     let dir = TempDir::new().unwrap();
     let bin = dir.path().join("any");
     std::fs::write(&bin, b"x").unwrap();
-    let hook = B0SafetyHook::new();
-    let ctx =
-        HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin.to_path_buf()]);
-    let profile = minimal_profile();
-    let cancel = CancellationToken::new();
-    let result = hook.on_startup(&ctx, &profile, &cancel).await;
-    assert!(result.is_ok(), "linux signature check should be noop");
+    assert!(
+        verify_mcp_supply_chain(&[bin], &minimal_profile()).is_ok(),
+        "linux signature check should be a noop"
+    );
 }
 
 #[cfg(target_os = "windows")]
-#[tokio::test]
-async fn windows_unsigned_binary_fails_startup() {
+#[test]
+fn windows_unsigned_binary_fails_startup() {
     let dir = TempDir::new().unwrap();
     let bin = dir.path().join("fake-mcp.exe");
     std::fs::write(&bin, b"MZ\0\0").unwrap();
-    let hook = B0SafetyHook::new();
-    let ctx =
-        HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin.to_path_buf()]);
-    let profile = minimal_profile();
-    let cancel = CancellationToken::new();
-    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    let err = verify_mcp_supply_chain(&[bin], &minimal_profile())
+        .expect_err("unsigned windows binary should refuse startup");
     assert!(
-        result.is_err(),
-        "unsigned windows binary should fail on_startup"
-    );
-    let msg = format!("{}", result.unwrap_err());
-    assert!(
-        msg.to_lowercase().contains("not signed") || msg.contains("signtool"),
-        "got {msg}"
+        err.to_lowercase().contains("not signed") || err.contains("signtool"),
+        "got {err}"
     );
 }

--- a/mur-agent-runtime/tests/b0_rule6_mcp_pin.rs
+++ b/mur-agent-runtime/tests/b0_rule6_mcp_pin.rs
@@ -1,25 +1,22 @@
-//! B0 rule 6 / M9.3 — `B0SafetyHook::on_startup` enforces install-time
-//! MCP binary pin.
+//! B0 rule 6 / M9.3 — install-time MCP binary pin refuses startup on drift.
 //!
-//! Construction follows the same pattern as `b0_rule11_mcp_signature.rs`:
-//! load a minimal `AgentProfile`, inject a synthetic `mcp_servers`
-//! entry whose `binary_sha256` either matches or differs from the
-//! actual file on disk, then assert `on_startup` outcome.
+//! Load a minimal `AgentProfile`, inject a synthetic `mcp_servers` entry whose
+//! `binary_sha256` either matches or differs from the file on disk, then assert
+//! the outcome of [`verify_mcp_supply_chain`].
 //!
-//! Linux-only because on macOS rule 11 (codesign check) fires before
-//! rule 6 and would refuse the unsigned synthetic binary. The unit
-//! tests in `hooks::b0_helpers::pin_verify_tests` cover the verifier
-//! itself cross-platform.
+//! These used to go through `B0SafetyHook::on_startup` and were gated to Linux,
+//! because on macOS the rule 11 codesign check fired first and refused the
+//! unsigned synthetic binary. Rules 6 and 11 now live in a free function that
+//! takes the signature-check list as its own argument (they moved out of the
+//! observe-only hook phase, which discarded their errors — #791), so passing an
+//! empty list exercises rule 6 in isolation on every platform.
 
-#![cfg(target_os = "linux")]
-
-use mur_agent_runtime::hooks::{B0SafetyHook, Hook, HookCtx};
+use mur_agent_runtime::hooks::b0::verify_mcp_supply_chain;
 use mur_common::AgentProfile;
 use mur_common::agent::McpServerEntry;
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use tempfile::TempDir;
-use tokio_util::sync::CancellationToken;
 
 fn minimal_profile() -> AgentProfile {
     let yaml = include_str!("fixtures/profile_minimal.yaml");
@@ -39,39 +36,31 @@ fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(h.finalize())
 }
 
-/// On Linux the rule 11 signature check is a no-op so we can land
-/// pinned-but-unsigned binaries cleanly. On macOS the rule 11
-/// codesign check fires before rule 6, so this rule-6 test would
-/// require a signed binary fixture — gate it to Linux only for now.
-/// (The unit tests in `hooks::b0_helpers::pin_verify_tests` cover
-/// the verifier itself cross-platform.)
-#[cfg(target_os = "linux")]
-#[tokio::test]
-async fn matching_binary_hash_passes_startup() {
+fn profile_with_pin(command: &std::path::Path, name: &str, pin: Option<String>) -> AgentProfile {
+    let mut profile = minimal_profile();
+    profile.mcp_servers.push(McpServerEntry {
+        name: name.into(),
+        command: command.display().to_string(),
+        args: vec![],
+        binary_sha256: pin,
+        ..Default::default()
+    });
+    profile
+}
+
+#[test]
+fn matching_binary_hash_passes_startup() {
     let dir = TempDir::new().unwrap();
     let payload = b"pretend MCP body v1\n";
     let bin = write_fake_binary(dir.path(), payload);
-    let pinned_hash = sha256_hex(payload);
+    let profile = profile_with_pin(&bin, "weather", Some(sha256_hex(payload)));
 
-    let mut profile = minimal_profile();
-    profile.mcp_servers.push(McpServerEntry {
-        name: "weather".into(),
-        command: bin.display().to_string(),
-        args: vec![],
-        binary_sha256: Some(pinned_hash),
-        ..Default::default()
-    });
-
-    let hook = B0SafetyHook::new();
-    let ctx = HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin.clone()]);
-    let cancel = CancellationToken::new();
-    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    let result = verify_mcp_supply_chain(&[], &profile);
     assert!(result.is_ok(), "matching pin should pass: {result:?}");
 }
 
-#[cfg(target_os = "linux")]
-#[tokio::test]
-async fn binary_drift_fails_startup_with_inspect_hint() {
+#[test]
+fn binary_drift_fails_startup_with_inspect_hint() {
     let dir = TempDir::new().unwrap();
     let installed = b"pretend MCP body v1\n";
     let bin = write_fake_binary(dir.path(), installed);
@@ -79,84 +68,41 @@ async fn binary_drift_fails_startup_with_inspect_hint() {
     let pinned_hash = sha256_hex(installed);
     std::fs::write(&bin, b"pretend MCP body v2 -- drifted\n").unwrap();
 
-    let mut profile = minimal_profile();
-    profile.mcp_servers.push(McpServerEntry {
-        name: "weather".into(),
-        command: bin.display().to_string(),
-        args: vec![],
-        binary_sha256: Some(pinned_hash),
-        ..Default::default()
-    });
+    let profile = profile_with_pin(&bin, "weather", Some(pinned_hash));
 
-    let hook = B0SafetyHook::new();
-    let ctx = HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin]);
-    let cancel = CancellationToken::new();
-    let result = hook.on_startup(&ctx, &profile, &cancel).await;
-    let err = result.expect_err("drift should fail startup");
-    let msg = err.to_string();
+    let msg = verify_mcp_supply_chain(&[], &profile).expect_err("drift should fail startup");
     assert!(msg.contains("B0 rule 6"), "got {msg}");
     assert!(msg.contains("mur agent mcp inspect weather"), "got {msg}");
     assert!(msg.contains("mur agent mcp pin weather"), "got {msg}");
 }
 
-#[cfg(target_os = "linux")]
-#[tokio::test]
-async fn missing_binary_soft_fails_does_not_block_startup() {
+#[test]
+fn missing_binary_soft_fails_does_not_block_startup() {
     let dir = TempDir::new().unwrap();
-    // Path that doesn't exist — the supervisor would catch this in
-    // its own resolve step in production, but the verify path must
-    // not crash on a missing file (user uninstalled the MCP without
-    // removing it from profile.yaml).
+    // Path that doesn't exist — the supervisor would catch this in its own
+    // resolve step in production, but the verify path must not crash on a
+    // missing file (user uninstalled the MCP without removing it from
+    // profile.yaml).
     let phantom = dir.path().join("phantom-mcp");
+    let profile = profile_with_pin(&phantom, "ghost", Some("deadbeef".repeat(8)));
 
-    let mut profile = minimal_profile();
-    profile.mcp_servers.push(McpServerEntry {
-        name: "ghost".into(),
-        command: phantom.display().to_string(),
-        args: vec![],
-        binary_sha256: Some("deadbeef".repeat(8)),
-        ..Default::default()
-    });
-
-    let hook = B0SafetyHook::new();
-    // Rule 11 reads `ctx.mcp_server_binaries()` (resolved by the
-    // supervisor — production already filters out unresolvable paths
-    // before the hook runs). Rule 6 reads `profile.mcp_servers`. To
-    // exercise rule 6's soft-fail path in isolation, we pass an
-    // empty mcp_server_binaries list — rule 11 then has nothing to
-    // verify, and rule 6 alone sees the phantom entry from the
-    // profile.
-    let _ = phantom;
-    let ctx = HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![]);
-    let cancel = CancellationToken::new();
-    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    let result = verify_mcp_supply_chain(&[], &profile);
     assert!(
         result.is_ok(),
         "missing binary should soft-fail (warn, allow start): {result:?}",
     );
 }
 
-#[cfg(target_os = "linux")]
-#[tokio::test]
-async fn pre_m9_entry_without_pin_skipped_cleanly() {
+#[test]
+fn pre_m9_entry_without_pin_skipped_cleanly() {
     let dir = TempDir::new().unwrap();
     let bin = write_fake_binary(dir.path(), b"any bytes");
+    // binary_sha256 stays None — pre-M9 entry, exempt from rule 6.
+    let profile = profile_with_pin(&bin, "legacy", None);
 
-    let mut profile = minimal_profile();
-    profile.mcp_servers.push(McpServerEntry {
-        name: "legacy".into(),
-        command: bin.display().to_string(),
-        args: vec![],
-        // binary_sha256 stays None — pre-M9 entry, exempt from rule 6.
-        ..Default::default()
-    });
-
-    let hook = B0SafetyHook::new();
-    let ctx = HookCtx::for_test_with_mcp_servers(dir.path().to_path_buf(), 1, vec![bin]);
-    let cancel = CancellationToken::new();
-    let result = hook.on_startup(&ctx, &profile, &cancel).await;
+    let result = verify_mcp_supply_chain(&[], &profile);
     assert!(
         result.is_ok(),
-        "pre-M9 (no pin) entry should pass: {result:?}",
+        "pre-M9 (no pin) entry should pass: {result:?}"
     );
 }


### PR DESCRIPTION
Fixes #791.

## The checks did not check anything

B0 rule 11 (MCP binary signature) and rule 6 (install-time binary pin) both `return Err(...)` from `B0SafetyHook::on_startup`, and rule 6's own comment states the intent: *"On hard drift, refuse to start so the user is forced to run `mur agent mcp inspect <name>` and re-approve."*

`HookChain::on_startup` is an **observe-only** phase. It returns `()` and folds every hook error into `warn!`. Neither rule had ever refused a startup. On the machine where this surfaced, an MCP entry sat in `BINARY DRIFT` for three days across several restarts while `mur agent status` reported the agent healthy — the only trace was one line in `stderr.log` that nothing was watching.

## Change

**Enforcement.** The two rules are admission control, not observation, so they move out of the hook into `hooks::b0::verify_mcp_supply_chain`, which `supervisor_runner` calls with `?` before the runtime is assembled. A drifted or unsigned MCP now stops the agent, as documented.

**Not bricking agents on upgrade.** `supervisor.rs` refreshes MUR's own bundled `mur-mcp-server` from the binary beside the running `mur` at every startup, and nothing re-pinned it — so **every `mur` upgrade drifts that pin by construction**, which is why the drift was tolerable before and exactly what would break once enforcement is real. The new `mcp_repin` module re-pins those entries after the refresh.

That is not a weakening: the binary was written moments earlier by this runtime from its own installation, so its trust anchor is "same install as the runtime", not a hash recorded weeks ago — anyone able to swap it has already swapped `mur` itself. Third-party entries, the reason rule 6 exists, are never rewritten. (Design confirmed with the maintainer before implementing.)

**Diagnosability.** A closed MCP stdout now reports what happened to the child. A server that exited and a server that was killed both present as "no more lines"; `mcp server closed stdout` hid a SIGKILLed binary for an hour during this investigation. It now reads `mcp server \`media\` exited before replying (signal: 9)`.

`repin_bundled_mcp` went into its own module rather than `supervisor.rs`, which is already 1355 lines against the repo's 800-line rule and has no test module.

## Verification

- `--test b0_rule6_mcp_pin` — 4 passed, including `binary_drift_fails_startup_with_inspect_hint` asserting the error names both `mur agent mcp inspect` and `mur agent mcp pin`
- `--test b0_rule11_mcp_signature` — 1 passed (macOS: unsigned binary refuses startup)
- `--lib mcp_repin` — 3 passed: re-pins the bundled entry while leaving a third-party pin untouched, matches the bare `mur-mcp-server` command form written by capability installs, and is idempotent (no `updated_at` churn on a no-op)
- `cargo clippy -p mur-agent-runtime --lib -- -D warnings` clean

The rule-6 tests were gated to Linux because rule 11 fired first on macOS and refused the unsigned fixture. Passing the signature list as an explicit argument lets rule 6 be exercised in isolation, so those four tests now run on macOS and Windows too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)