### PR TITLE
docs(readme): note that MCP binary pins now block startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,11 @@ files.
   provenance under a strict *never-shadow* rule: an imported plugin or bundled
   skill can never silently override a builtin. `mur skill doctor` flags drift and
   de-pins stale vendored copies; imported add-ons re-verify on `mur agent addon reimport`.
+- **Enforced MCP pins** — an agent **refuses to start** when an MCP server's
+  binary no longer matches the hash pinned at install, or isn't signed.
+  `mur agent mcp inspect <agent>` shows pinned vs current; `mur agent mcp pin
+  <agent> <server>` re-approves. MUR's own bundled MCP server re-pins itself
+  when MUR upgrades, so routine upgrades never stop your agents.
 
 ### 🔌 Power the tools you already pay for
 


### PR DESCRIPTION
Follow-up to #793.

The "🔐 Stay governed" section described pinned provenance but not what enforcement does — which, after #793, is the part a user meets first: an agent whose MCP binary drifted from its install-time pin (or isn't signed) now refuses to start instead of logging a warning nobody reads.

One bullet, next to the existing **Governed distribution** entry. No command-tree change — `mur agent mcp inspect` / `pin` already existed; only their consequence changed.

The docs-site companion is mur-run/mur-server#36, which adds a full `/docs/core/mcp-pinning` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)