### PR TITLE
feat(doctor): report MCP pin drift — and stop enforcing pins that hash the interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,11 @@ files.
 - **Enforced MCP pins** — an agent **refuses to start** when an MCP server's
   binary no longer matches the hash pinned at install, or isn't signed.
   `mur agent mcp inspect <agent>` shows pinned vs current; `mur agent mcp pin
-  <agent> <server>` re-approves. MUR's own bundled MCP server re-pins itself
-  when MUR upgrades, so routine upgrades never stop your agents.
+  <agent> <server>` re-approves; `mur doctor` reports drift across every agent
+  before you meet it as a failed startup. MUR's own bundled MCP server re-pins
+  itself when MUR upgrades, and interpreter-launched servers (`npx …`, `python
+  -m …`) are reported as unprotected rather than enforced — hashing the
+  interpreter breaks on unrelated runtime upgrades without covering what it runs.
 
 ### 🔌 Power the tools you already pay for
 

--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -96,6 +96,21 @@ pub fn verify_mcp_supply_chain(
             // `mur agent mcp pin <name>` as the migration verb.
             continue;
         };
+        // An interpreter-launched server (`npx @scope/pkg`, `python -m …`) pins
+        // the *interpreter*, not the server. Refusing startup on that hash
+        // would brick the agent on any unrelated Node/Python upgrade while
+        // still not covering the code it runs, so the pin is reported as
+        // unprotected rather than enforced. Package-level pinning is the real
+        // fix and a different mechanism.
+        if mur_common::exec::is_interpreter_command(&entry.command) {
+            tracing::warn!(
+                mcp = %entry.name,
+                command = %entry.command,
+                "B0 rule 6: interpreter-launched MCP — binary pin does not cover the server code, \
+                 not enforced (see `mur doctor`)",
+            );
+            continue;
+        }
         // Resolve via PATH exactly as install does (mur_common::exec) so both
         // passes hash the same binary `Command::new` will spawn. A bare
         // `node`/`npx` opened verbatim is a CWD-relative path that doesn't

--- a/mur-common/src/exec.rs
+++ b/mur-common/src/exec.rs
@@ -113,6 +113,34 @@ fn sha256_file(path: &Path) -> Result<String> {
     Ok(hex::encode(hasher.finalize()))
 }
 
+/// Launchers that run *other* code: hashing one of these tells you nothing
+/// about the MCP server it starts.
+const INTERPRETERS: &[&str] = &[
+    "npx", "node", "bunx", "bun", "deno", "python", "python3", "uv", "uvx", "pipx", "ruby", "perl",
+    "sh", "bash", "zsh",
+];
+
+/// Whether `command` launches an MCP server through an interpreter or package
+/// runner rather than being the server binary itself.
+///
+/// This decides whether a `binary_sha256` pin means anything. For
+/// `command: npx, args: @yawlabs/fetch-mcp` the pin hashes **npx** — so it
+/// breaks on every unrelated Node upgrade while saying nothing at all about
+/// `@yawlabs/fetch-mcp`, which npx resolves and may fetch fresh at run time.
+/// Enforcing such a pin is both fragile and hollow; the honest report is that
+/// the server code is unprotected.
+///
+/// Real coverage for these needs a package-level pin (version + integrity),
+/// which is a different mechanism than hashing a file on disk.
+pub fn is_interpreter_command(command: &str) -> bool {
+    let first = command.split_whitespace().next().unwrap_or(command);
+    let stem = Path::new(first)
+        .file_stem() // also strips .exe / .cmd on Windows
+        .and_then(|s| s.to_str())
+        .unwrap_or(first);
+    INTERPRETERS.contains(&stem.to_ascii_lowercase().as_str())
+}
+
 /// Resolve `command` to an absolute path on disk.
 ///
 /// - If `command` is already absolute or contains a path separator, canonicalize
@@ -153,6 +181,41 @@ pub fn resolve_command(command: &str) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn interpreter_commands_are_recognised_including_paths_and_args() {
+        for c in [
+            "npx",
+            "node",
+            "python3",
+            "uvx",
+            "bunx",
+            "deno",
+            "sh",
+            "/opt/homebrew/bin/npx",
+            "npx @yawlabs/fetch-mcp",
+            "NPX",
+            "npx.cmd",
+        ] {
+            assert!(
+                is_interpreter_command(c),
+                "`{c}` should count as an interpreter"
+            );
+        }
+    }
+
+    #[test]
+    fn real_server_binaries_are_not_interpreters() {
+        for c in [
+            "mur-mcp-server",
+            "/Users/x/.mur/mcp-servers/mur-mcp-server",
+            "agent-browser",
+            "mur-research-gateway",
+            "nodemon-ish",
+        ] {
+            assert!(!is_interpreter_command(c), "`{c}` is the server itself");
+        }
+    }
 
     #[test]
     fn errors_on_missing_binary() {

--- a/mur-common/src/lib.rs
+++ b/mur-common/src/lib.rs
@@ -37,6 +37,7 @@ pub mod local_llm;
 pub mod lock_file;
 pub mod manifest;
 pub mod mcp_naming;
+pub mod mcp_package;
 pub mod media;
 pub mod mobile;
 pub mod model;

--- a/mur-common/src/mcp_package.rs
+++ b/mur-common/src/mcp_package.rs
@@ -1,0 +1,211 @@
+//! Package specs for interpreter-launched MCP servers.
+//!
+//! `command: npx, args: ["@yawlabs/fetch-mcp"]` runs whatever the registry
+//! serves at spawn time. The binary pin cannot help here — it hashes `npx`
+//! (see [`crate::exec::is_interpreter_command`]) — so the first thing that can
+//! is knowing *which release* the user approved.
+//!
+//! This module only parses and resolves the spec. Verifying the bytes that
+//! actually get executed needs package-manager cache introspection or a
+//! MUR-owned install, which is tracked separately.
+
+use anyhow::{Result, bail};
+
+/// A package spec found in an interpreter entry's args.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageSpec {
+    /// Index into `args` where the spec sits, so a caller can rewrite it.
+    pub arg_index: usize,
+    /// Package name, including any `@scope/` prefix.
+    pub name: String,
+    /// Version suffix, if the spec carries one. `None` means the spec floats:
+    /// the package manager resolves it fresh on every start.
+    pub version: Option<String>,
+}
+
+impl PackageSpec {
+    /// `true` when no version is recorded — the resolved code can change
+    /// between two starts with no user action and no signal.
+    pub fn floats(&self) -> bool {
+        self.version.is_none()
+    }
+
+    /// The spec as it appears (and would be written) in args.
+    pub fn to_arg(&self) -> String {
+        match &self.version {
+            Some(v) => format!("{}@{v}", self.name),
+            None => self.name.clone(),
+        }
+    }
+}
+
+/// Package runners whose first non-flag argument is a package spec.
+fn runner_kind(command: &str) -> Option<Runner> {
+    let first = command.split_whitespace().next().unwrap_or(command);
+    let stem = std::path::Path::new(first)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(first)
+        .to_ascii_lowercase();
+    match stem.as_str() {
+        "npx" | "bunx" => Some(Runner::Npm),
+        "uvx" => Some(Runner::Python),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Runner {
+    Npm,
+    Python,
+}
+
+/// Find the package spec an interpreter entry will run.
+///
+/// Returns `None` for anything whose shape isn't unambiguous — `node
+/// server.js`, `python -m pkg`, or a runner invoked with a flag that takes a
+/// separate value (`npx -p a b`). Guessing wrong here would mean rewriting the
+/// wrong argument, so an unrecognised shape is left alone.
+pub fn parse_spec(command: &str, args: &[String]) -> Option<PackageSpec> {
+    runner_kind(command)?;
+    let mut idx = 0usize;
+    while idx < args.len() {
+        let a = &args[idx];
+        // A flag that takes a separate value makes the position of the spec
+        // ambiguous — bail rather than rewrite the wrong argument.
+        if matches!(a.as_str(), "-p" | "--package" | "-c" | "--call") {
+            return None;
+        }
+        if a.starts_with('-') {
+            idx += 1; // valueless flag (-y, --yes, --quiet, --package=x)
+            continue;
+        }
+        return Some(split_spec(idx, a));
+    }
+    None
+}
+
+/// Split `name[@version]`, keeping a leading `@scope/` intact.
+fn split_spec(arg_index: usize, spec: &str) -> PackageSpec {
+    // A leading '@' is a scope, not a version separator; look after it.
+    let search_from = usize::from(spec.starts_with('@'));
+    match spec[search_from..].rfind('@') {
+        Some(rel) => {
+            let at = search_from + rel;
+            PackageSpec {
+                arg_index,
+                name: spec[..at].to_string(),
+                version: Some(spec[at + 1..].to_string()),
+            }
+        }
+        None => PackageSpec {
+            arg_index,
+            name: spec.to_string(),
+            version: None,
+        },
+    }
+}
+
+/// Ask the package manager which version it would resolve right now.
+///
+/// This records what the user is approving at pin time; it is not a trust
+/// decision about the registry.
+pub fn resolve_current_version(runner: Runner, name: &str) -> Result<String> {
+    let (program, args) = match runner {
+        Runner::Npm => (
+            "npm",
+            vec!["view".to_string(), name.to_string(), "version".to_string()],
+        ),
+        Runner::Python => bail!(
+            "resolving a current version for uvx packages is not implemented; \
+             pass an explicit `{name}==<version>` in args"
+        ),
+    };
+    let out = std::process::Command::new(program)
+        .args(&args)
+        .output()
+        .map_err(|e| anyhow::anyhow!("run `{program} view {name} version`: {e}"))?;
+    if !out.status.success() {
+        bail!(
+            "`{program} view {name} version` failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim(),
+        );
+    }
+    let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if v.is_empty() {
+        bail!("`{program} view {name} version` returned nothing");
+    }
+    Ok(v)
+}
+
+/// The runner behind a command, for callers that already know it's one.
+pub fn runner_for(command: &str) -> Option<Runner> {
+    runner_kind(command)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn finds_a_floating_scoped_package() {
+        let s = parse_spec("npx", &args(&["@yawlabs/fetch-mcp"])).unwrap();
+        assert_eq!(s.name, "@yawlabs/fetch-mcp");
+        assert_eq!(s.version, None);
+        assert!(s.floats(), "no version means npx resolves it every start");
+        assert_eq!(s.arg_index, 0);
+    }
+
+    #[test]
+    fn a_scope_prefix_is_not_a_version_separator() {
+        let s = parse_spec("npx", &args(&["@scope/pkg@1.2.3"])).unwrap();
+        assert_eq!(s.name, "@scope/pkg");
+        assert_eq!(s.version.as_deref(), Some("1.2.3"));
+        assert!(!s.floats());
+        assert_eq!(s.to_arg(), "@scope/pkg@1.2.3");
+    }
+
+    #[test]
+    fn handles_unscoped_and_valueless_flags() {
+        let s = parse_spec("npx", &args(&["-y", "--quiet", "some-mcp@0.4.0"])).unwrap();
+        assert_eq!(s.name, "some-mcp");
+        assert_eq!(s.version.as_deref(), Some("0.4.0"));
+        assert_eq!(
+            s.arg_index, 2,
+            "index must point at the spec, not the flags"
+        );
+    }
+
+    /// Rewriting the wrong argument would corrupt the launch command, so an
+    /// ambiguous shape must decline rather than guess.
+    #[test]
+    fn declines_ambiguous_and_non_runner_shapes() {
+        assert!(parse_spec("npx", &args(&["-p", "typescript", "tsc"])).is_none());
+        assert!(parse_spec("npx", &args(&["--package", "a", "b"])).is_none());
+        assert!(parse_spec("node", &args(&["server.js"])).is_none());
+        assert!(parse_spec("python3", &args(&["-m", "pkg"])).is_none());
+        assert!(parse_spec("mur-mcp-server", &args(&[])).is_none());
+        assert!(parse_spec("npx", &args(&["-y"])).is_none(), "flags only");
+        assert!(parse_spec("npx", &args(&[])).is_none());
+    }
+
+    #[test]
+    fn recognises_runners_by_path_and_case() {
+        assert_eq!(runner_for("/opt/homebrew/bin/npx"), Some(Runner::Npm));
+        assert_eq!(runner_for("BUNX"), Some(Runner::Npm));
+        assert_eq!(runner_for("uvx"), Some(Runner::Python));
+        assert_eq!(runner_for("node"), None);
+    }
+
+    #[test]
+    fn to_arg_round_trips_what_was_parsed() {
+        for raw in ["@scope/pkg@1.2.3", "@scope/pkg", "pkg@2.0.0-beta.1", "pkg"] {
+            let s = split_spec(0, raw);
+            assert_eq!(s.to_arg(), raw);
+        }
+    }
+}

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -457,6 +457,38 @@ pub fn cmd_mcp_inspect(name: &str, server_id: Option<&str>, probe: bool) -> Resu
 /// failure (timeout / spawn error) the pin still lands but
 /// `description_hash` stays None — the user sees a warning and can
 /// re-pin later.
+/// Record the version an interpreter-launched entry currently resolves to,
+/// rewriting its args in place. Returns the pinned `name@version` when it
+/// changed anything.
+///
+/// Best-effort by design: no network, no npm, or an unparseable arg shape all
+/// leave the entry exactly as it was. A pin that can't reach the registry is a
+/// worse reason to fail than to proceed — the binary pin below still applies.
+fn pin_package_version(entry: &mut McpServerEntry) -> Option<String> {
+    use mur_common::mcp_package::{parse_spec, resolve_current_version, runner_for};
+
+    let spec = parse_spec(&entry.command, &entry.args)?;
+    if !spec.floats() {
+        return None; // already pinned to a release
+    }
+    let runner = runner_for(&entry.command)?;
+    match resolve_current_version(runner, &spec.name) {
+        Ok(version) => {
+            let pinned = format!("{}@{version}", spec.name);
+            entry.args[spec.arg_index] = pinned.clone();
+            Some(pinned)
+        }
+        Err(e) => {
+            eprintln!(
+                "warning: could not resolve a current version for `{}` ({e}); \
+                 the entry stays on a floating spec and will resolve fresh on every start.",
+                spec.name,
+            );
+            None
+        }
+    }
+}
+
 pub fn cmd_mcp_pin(
     name: &str,
     server_id: &str,
@@ -472,6 +504,12 @@ pub fn cmd_mcp_pin(
         .iter_mut()
         .find(|s| s.name == server_id)
         .ok_or_else(|| anyhow::anyhow!("MCP server `{server_id}` not found on agent `{name}`"))?;
+
+    // For an interpreter-launched entry the binary hash below covers the
+    // launcher, not the server (#795). The one thing that can be pinned here is
+    // *which release* the runner resolves — so record it, turning "whatever the
+    // registry serves at spawn" into the version the user approved just now.
+    let version_pinned = pin_package_version(entry);
 
     let resolved = resolve_command(&entry.command)
         .with_context(|| format!("resolve command `{}`", entry.command))?;
@@ -537,6 +575,9 @@ pub fn cmd_mcp_pin(
     if !force {
         println!("Re-approving MCP `{server_id}` on agent `{name}`:");
         println!("  command:        {}", resolved.display());
+        if let Some(pinned) = &version_pinned {
+            println!("  package:        {pinned}  (NEW — was floating to latest)");
+        }
         if let Some(old) = &entry.binary_sha256 {
             if old.eq_ignore_ascii_case(&new_hash) {
                 println!("  binary sha256:  {new_hash}  (unchanged)");

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -232,6 +232,28 @@ pub enum InspectStatus {
     BinaryMissing = 5,
 }
 
+/// Classify one MCP entry's binary against its pin, without printing.
+///
+/// The single source of truth for pin status: `inspect_one` renders this, and
+/// `mur doctor` reports it across every agent. Two callers computing "is this
+/// drifted?" separately is exactly how one of them ends up wrong.
+pub fn binary_status(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
+    let Some(expected) = &entry.binary_sha256 else {
+        return InspectStatus::MissingPin;
+    };
+    let Ok(path) = resolve_command(&entry.command) else {
+        return InspectStatus::BinaryMissing;
+    };
+    let Ok(actual) = compute_binary_sha256(&path) else {
+        return InspectStatus::BinaryMissing;
+    };
+    if actual.eq_ignore_ascii_case(expected) {
+        InspectStatus::Clean
+    } else {
+        InspectStatus::BinaryDrift
+    }
+}
+
 /// Print pinned vs current state for one MCP entry. Returns the
 /// exit-code-shaped status; `cmd_mcp_inspect` lifts that to
 /// `std::process::exit` after running through the dispatch.
@@ -542,6 +564,62 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;
+
+    fn entry_for(command: &str, pin: Option<&str>) -> mur_common::agent::McpServerEntry {
+        mur_common::agent::McpServerEntry {
+            name: "media".into(),
+            command: command.into(),
+            args: vec![],
+            binary_sha256: pin.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    /// `binary_status` is what both `inspect` and `mur doctor` classify with —
+    /// if it and the printed report ever disagree, one of them lies about
+    /// whether an agent is about to refuse to start.
+    #[test]
+    fn binary_status_classifies_every_case() {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"v1 body\n").unwrap();
+        let path = f.path().display().to_string();
+        let pin = compute_binary_sha256(f.path()).unwrap();
+
+        assert_eq!(
+            binary_status(&entry_for(&path, Some(&pin))) as u8,
+            InspectStatus::Clean as u8,
+        );
+        assert_eq!(
+            binary_status(&entry_for(&path, None)) as u8,
+            InspectStatus::MissingPin as u8,
+            "an entry from before pinning existed must not read as drift",
+        );
+        assert_eq!(
+            binary_status(&entry_for(&path, Some(&"0".repeat(64)))) as u8,
+            InspectStatus::BinaryDrift as u8,
+        );
+        assert_eq!(
+            binary_status(&entry_for("/nonexistent/mcp-binary", Some(&pin))) as u8,
+            InspectStatus::BinaryMissing as u8,
+            "a binary the user uninstalled is not the same finding as a swapped one",
+        );
+    }
+
+    /// A pin recorded in upper-case hex must still match — `verify_mcp_binary_hash`
+    /// on the runtime side compares case-insensitively, and a mismatch here would
+    /// mean doctor reports clean while the agent refuses to start.
+    #[test]
+    fn binary_status_is_case_insensitive_about_the_pin() {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(b"v1 body\n").unwrap();
+        let path = f.path().display().to_string();
+        let pin = compute_binary_sha256(f.path()).unwrap().to_uppercase();
+
+        assert_eq!(
+            binary_status(&entry_for(&path, Some(&pin))) as u8,
+            InspectStatus::Clean as u8,
+        );
+    }
 
     #[test]
     fn binary_sha256_matches_known_vector() {

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -230,6 +230,10 @@ pub enum InspectStatus {
     BothDrifted = 3,
     MissingPin = 4,
     BinaryMissing = 5,
+    /// Interpreter-launched (`npx @scope/pkg`, `python -m …`): the pin covers
+    /// the interpreter, not the server code, so it is reported rather than
+    /// enforced. Not a failure — the agent starts — but not protection either.
+    InterpreterUnprotected = 6,
 }
 
 /// Classify one MCP entry's binary against its pin, without printing.
@@ -241,6 +245,9 @@ pub fn binary_status(entry: &mur_common::agent::McpServerEntry) -> InspectStatus
     let Some(expected) = &entry.binary_sha256 else {
         return InspectStatus::MissingPin;
     };
+    if mur_common::exec::is_interpreter_command(&entry.command) {
+        return InspectStatus::InterpreterUnprotected;
+    }
     let Ok(path) = resolve_command(&entry.command) else {
         return InspectStatus::BinaryMissing;
     };
@@ -286,6 +293,22 @@ pub fn inspect_one(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
     };
 
     println!("  pinned sha256:  {expected}");
+    if mur_common::exec::is_interpreter_command(&entry.command) {
+        println!(
+            "  status:         INTERPRETER-LAUNCHED — pin covers `{}`, not the server code",
+            entry
+                .command
+                .split_whitespace()
+                .next()
+                .unwrap_or(&entry.command)
+        );
+        println!(
+            "  hint:           not enforced at startup: hashing the interpreter breaks on any \
+             unrelated runtime upgrade and still would not cover what it runs. Pin the package \
+             version instead (lockfile / integrity hash) if this server matters."
+        );
+        return InspectStatus::InterpreterUnprotected;
+    }
     let path = match resolve_command(&entry.command) {
         Ok(p) => p,
         Err(_) => {
@@ -578,6 +601,20 @@ mod tests {
     /// `binary_status` is what both `inspect` and `mur doctor` classify with —
     /// if it and the printed report ever disagree, one of them lies about
     /// whether an agent is about to refuse to start.
+    /// An `npx @scope/pkg` entry pins **npx**. Enforcing that hash breaks the
+    /// agent on any unrelated Node upgrade and still says nothing about the
+    /// package npx fetches, so it must not read as drift.
+    #[test]
+    fn interpreter_launched_entries_are_reported_not_enforced() {
+        for command in ["npx", "node", "python3", "uvx", "/opt/homebrew/bin/npx"] {
+            assert_eq!(
+                binary_status(&entry_for(command, Some(&"0".repeat(64)))) as u8,
+                InspectStatus::InterpreterUnprotected as u8,
+                "`{command}` launches other code; its hash is not the server's",
+            );
+        }
+    }
+
     #[test]
     fn binary_status_classifies_every_case() {
         let mut f = NamedTempFile::new().unwrap();

--- a/mur-core/src/cmd/misc.rs
+++ b/mur-core/src/cmd/misc.rs
@@ -181,7 +181,81 @@ pub(crate) fn cmd_doctor() -> Result<()> {
         ),
     }
 
+    report_mcp_pins(&mur_dir);
+
     Ok(())
+}
+
+/// Report agents whose pinned MCP binaries no longer match what's on disk.
+///
+/// B0 rule 6 refuses to start such an agent, so this is the difference between
+/// finding out here and finding out when the agent won't come up. The signal
+/// existed in `mur agent mcp inspect` all along and nothing was watching it —
+/// one agent sat in drift for three days while `mur agent status` said healthy.
+fn report_mcp_pins(mur_dir: &std::path::Path) {
+    use crate::cmd::agent_mcp_pin::{InspectStatus, binary_status};
+
+    let agents_dir = mur_dir.join("agents");
+    let Ok(entries) = std::fs::read_dir(&agents_dir) else {
+        return; // no agents yet — nothing to say
+    };
+    let mut dirs: Vec<_> = entries.filter_map(|e| e.ok()).map(|e| e.path()).collect();
+    dirs.sort(); // deterministic output
+
+    let mut checked = 0usize;
+    let mut problems: Vec<String> = Vec::new();
+
+    for dir in dirs {
+        let agent = dir
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let Ok(yaml) = std::fs::read_to_string(dir.join("profile.yaml")) else {
+            continue;
+        };
+        let Ok(profile) = serde_yaml_ng::from_str::<mur_common::agent::AgentProfile>(&yaml) else {
+            continue;
+        };
+        for entry in &profile.mcp_servers {
+            checked += 1;
+            match binary_status(entry) {
+                InspectStatus::Clean => {}
+                InspectStatus::BinaryDrift => problems.push(format!(
+                    "  ❌ {agent}/{name}: binary changed since install — this agent will REFUSE \
+                     to start.\n     `mur agent mcp inspect {agent} --server {name}` to review, \
+                     `mur agent mcp pin {agent} {name}` to re-approve.",
+                    name = entry.name,
+                )),
+                InspectStatus::BinaryMissing => problems.push(format!(
+                    "  ⚠ {agent}/{name}: binary not found ({command}).",
+                    name = entry.name,
+                    command = entry.command,
+                )),
+                InspectStatus::MissingPin => problems.push(format!(
+                    "  ⚠ {agent}/{name}: unpinned (installed before pinning) — \
+                     `mur agent mcp pin {agent} {name}` to start enforcing.",
+                    name = entry.name,
+                )),
+                // Description-hash states need a live probe; `inspect --probe` owns those.
+                _ => {}
+            }
+        }
+    }
+
+    if checked == 0 {
+        return; // no MCP servers wired anywhere — silence beats a green tick
+    }
+    if problems.is_empty() {
+        println!("✅ MCP pins: {checked} checked, all match");
+    } else {
+        println!(
+            "MCP pins: {checked} checked, {} need attention",
+            problems.len()
+        );
+        for p in &problems {
+            println!("{p}");
+        }
+    }
 }
 
 /// host:port to TCP-probe for a LOCAL embedding provider; None for remote

--- a/mur-core/src/cmd/misc.rs
+++ b/mur-core/src/cmd/misc.rs
@@ -236,6 +236,16 @@ fn report_mcp_pins(mur_dir: &std::path::Path) {
                      `mur agent mcp pin {agent} {name}` to start enforcing.",
                     name = entry.name,
                 )),
+                InspectStatus::InterpreterUnprotected => problems.push(format!(
+                    "  ⚠ {agent}/{name}: launched via `{launcher}` — the pin covers the \
+                     interpreter, not the server code, so it is not enforced.",
+                    name = entry.name,
+                    launcher = entry
+                        .command
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or(&entry.command),
+                )),
                 // Description-hash states need a live probe; `inspect --probe` owns those.
                 _ => {}
             }

--- a/mur-core/src/cmd/misc.rs
+++ b/mur-core/src/cmd/misc.rs
@@ -236,16 +236,35 @@ fn report_mcp_pins(mur_dir: &std::path::Path) {
                      `mur agent mcp pin {agent} {name}` to start enforcing.",
                     name = entry.name,
                 )),
-                InspectStatus::InterpreterUnprotected => problems.push(format!(
-                    "  ⚠ {agent}/{name}: launched via `{launcher}` — the pin covers the \
-                     interpreter, not the server code, so it is not enforced.",
-                    name = entry.name,
-                    launcher = entry
+                InspectStatus::InterpreterUnprotected => {
+                    let launcher = entry
                         .command
                         .split_whitespace()
                         .next()
-                        .unwrap_or(&entry.command),
-                )),
+                        .unwrap_or(&entry.command);
+                    match mur_common::mcp_package::parse_spec(&entry.command, &entry.args) {
+                        // A floating spec is the sharp edge: the code that runs
+                        // can change between two starts with no user action.
+                        Some(spec) if spec.floats() => problems.push(format!(
+                            "  ⚠ {agent}/{name}: `{launcher} {pkg}` has no pinned version — \
+                             resolved fresh on every start.\n     \
+                             `mur agent mcp pin {agent} {name}` records the version it resolves to now.",
+                            name = entry.name,
+                            pkg = spec.name,
+                        )),
+                        Some(spec) => problems.push(format!(
+                            "  ⚠ {agent}/{name}: launched via `{launcher}` at {pkg} — version \
+                             recorded, but the package contents are not verified.",
+                            name = entry.name,
+                            pkg = spec.to_arg(),
+                        )),
+                        None => problems.push(format!(
+                            "  ⚠ {agent}/{name}: launched via `{launcher}` — the pin covers the \
+                             interpreter, not the server code, so it is not enforced.",
+                            name = entry.name,
+                        )),
+                    }
+                }
                 // Description-hash states need a live probe; `inspect --probe` owns those.
                 _ => {}
             }


### PR DESCRIPTION
Follow-up to #793: the last open suggestion from #791, plus a real defect that dogfooding it exposed.

## 1. `mur doctor` reports pin drift

`mur agent mcp inspect` could always see that a pinned MCP binary had changed, and nothing was watching it — the agent that started this thread sat in `BINARY DRIFT` for three days while `mur agent status` reported it healthy. Now that #793 makes that state refuse a startup, it has to be visible *before* the user meets it as an agent that won't come up.

Silent when no MCP servers are wired anywhere; a green tick for a check that inspected nothing is worse than saying nothing.

## 2. What that immediately found — and the fix

First run against this machine's real `~/.mur`:

```
MCP pins: 13 checked, 6 need attention
  ❌ drs-clinician/fetch-mcp: binary changed since install — this agent will REFUSE to start.
  … five more, all identical
```

Every one of the six is `command: npx, args: @yawlabs/fetch-mcp`. **All six drifted entries are `npx`; all seven direct-binary entries are clean.** That is structural:

- The pin hashes **npx**, so it moves on any unrelated Node/npm upgrade.
- It says nothing about `@yawlabs/fetch-mcp` — npx resolves that at run time and may fetch a different version tomorrow.

So on interpreter-launched entries the pin is simultaneously fragile and hollow. With #793 enforcing, the next `brew upgrade node` would have bricked six agents while protecting none of them.

Interpreter-launched entries (`npx`, `node`, `python`, `uvx`, `bunx`, …) are now **reported, not enforced**, with the reason stated rather than implied:

```
  ⚠ drs-clinician/fetch-mcp: launched via `npx` — the pin covers the interpreter,
    not the server code, so it is not enforced.
```

Direct-binary entries, where the hash does describe the server, are enforced exactly as #793 intended. `InspectStatus::InterpreterUnprotected = 6` extends the documented exit-code contract additively.

Real coverage for npx-style servers needs a package-level pin (version + integrity hash) — a different mechanism than hashing a file on disk, worth its own issue.

## Shared classification

Status logic moved into `binary_status`, which `inspect_one` renders and `doctor` reports. Two callers independently deciding "is this drifted?" is how one ends up disagreeing with the runtime that actually refuses to start.

## Verification

- `cargo test -p mur-core --lib agent_mcp_pin` — 16 passed, including the pre-existing `inspect_one_*` tests (the extraction didn't move `inspect`'s behavior) and three new ones: every status distinct, case-insensitive pin match (the runtime compares case-insensitively; if doctor didn't, it would report clean for an agent that refuses to start), and interpreter entries never reading as drift.
- `cargo test -p mur-common --lib exec` — interpreter detection across bare names, absolute paths, args, `.cmd`, and mixed case; plus the negative set (`mur-mcp-server`, `agent-browser`, `mur-research-gateway`).
- clippy clean on `mur-common`, `mur-agent-runtime`, `mur-core`.
- Built and run against the real `~/.mur` before and after: the six agents go from "will REFUSE to start" to an honest unprotected warning.

README updated with the caveat. The docs-site page (mur-run/mur-server#36) needs the same and is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)