### PR TITLE
feat(mcp): vendor package-runner MCP servers so their contents can be verified

### DIFF
--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -91,6 +91,40 @@ pub fn verify_mcp_supply_chain(
 
     // ── Rule 6 (M9.3): install-time pin verification.
     for entry in &profile.mcp_servers {
+        // A vendored package is the one interpreter-launched shape that CAN be
+        // verified: MUR installed it into a directory it owns, so the lockfile
+        // recorded at approval still describes the tree unless something
+        // changed it. Checked before the interpreter skip below, which would
+        // otherwise wave through the very case made verifiable on purpose.
+        if let Some(pkg) = &entry.package {
+            let lock = std::path::Path::new(&pkg.install_dir).join("package-lock.json");
+            match crate::hooks::b0_helpers::binary_sha256(&lock) {
+                Ok(actual) if actual.eq_ignore_ascii_case(&pkg.lockfile_sha256) => {
+                    tracing::debug!(mcp = %entry.name, "B0 rule 6: vendored package verified");
+                }
+                Ok(_) => {
+                    return Err(format!(
+                        "B0 rule 6: vendored MCP `{}` ({}@{}) no longer matches the tree \
+                         installed at approval time — re-run `mur agent mcp vendor <agent> {}` \
+                         to reinstall and re-approve, or `mur agent mcp remove <agent> {}` \
+                         to uninstall.",
+                        entry.name, pkg.name, pkg.version, entry.name, entry.name,
+                    ));
+                }
+                Err(reason) => {
+                    // Install gone or unreadable. Same call as a missing binary
+                    // below: far more likely "the user deleted it" than an
+                    // attack, and refusing to boot would strand the agent with
+                    // no way back in.
+                    tracing::warn!(
+                        mcp = %entry.name,
+                        reason = %reason,
+                        "B0 rule 6: vendored package lockfile unreadable; continuing",
+                    );
+                }
+            }
+            continue;
+        }
         let Some(expected) = &entry.binary_sha256 else {
             // Pre-M9 entry — skip silently; the cookbook documents
             // `mur agent mcp pin <name>` as the migration verb.

--- a/mur-agent-runtime/tests/b0_rule6_mcp_pin.rs
+++ b/mur-agent-runtime/tests/b0_rule6_mcp_pin.rs
@@ -106,3 +106,79 @@ fn pre_m9_entry_without_pin_skipped_cleanly() {
         "pre-M9 (no pin) entry should pass: {result:?}"
     );
 }
+
+// ── Vendored packages (#796) ────────────────────────────────────────────────
+//
+// A vendored entry launches `node <install>/…`, which is interpreter-shaped —
+// but MUR owns that directory, so its lockfile IS verifiable and must be
+// enforced rather than waved through by the interpreter exemption.
+
+fn profile_with_vendored(install_dir: &std::path::Path, lockfile_sha256: &str) -> AgentProfile {
+    let mut profile = minimal_profile();
+    profile.mcp_servers.push(McpServerEntry {
+        name: "fetch-mcp".into(),
+        command: "node".into(),
+        args: vec![
+            install_dir
+                .join("node_modules/x/dist/index.js")
+                .display()
+                .to_string(),
+        ],
+        // No binary pin: hashing `node` was never the point.
+        binary_sha256: None,
+        package: Some(mur_common::agent::McpPackagePin {
+            runner: "npm".into(),
+            name: "@yawlabs/fetch-mcp".into(),
+            version: "0.3.6".into(),
+            install_dir: install_dir.display().to_string(),
+            lockfile_sha256: lockfile_sha256.into(),
+        }),
+        ..Default::default()
+    });
+    profile
+}
+
+fn write_lockfile(dir: &std::path::Path, body: &[u8]) -> String {
+    std::fs::write(dir.join("package-lock.json"), body).unwrap();
+    sha256_hex(body)
+}
+
+#[test]
+fn vendored_package_passes_when_the_lockfile_matches() {
+    let dir = TempDir::new().unwrap();
+    let sha = write_lockfile(dir.path(), b"{\"lockfileVersion\":3}");
+    let result = verify_mcp_supply_chain(&[], &profile_with_vendored(dir.path(), &sha));
+    assert!(result.is_ok(), "matching lockfile should pass: {result:?}");
+}
+
+#[test]
+fn vendored_package_refuses_startup_when_the_tree_changed() {
+    let dir = TempDir::new().unwrap();
+    let sha = write_lockfile(dir.path(), b"{\"lockfileVersion\":3}");
+    // A dependency swapped underneath the install rewrites the lockfile.
+    std::fs::write(
+        dir.path().join("package-lock.json"),
+        b"{\"lockfileVersion\":3,\"packages\":{\"node_modules/evil\":{}}}",
+    )
+    .unwrap();
+
+    let msg = verify_mcp_supply_chain(&[], &profile_with_vendored(dir.path(), &sha))
+        .expect_err("a changed vendored tree must refuse startup");
+    assert!(msg.contains("vendored MCP `fetch-mcp`"), "got {msg}");
+    assert!(msg.contains("@yawlabs/fetch-mcp@0.3.6"), "got {msg}");
+    assert!(msg.contains("mur agent mcp vendor"), "got {msg}");
+}
+
+/// Deleting the install must not lock the user out of their own agent: the
+/// recovery command lives in the CLI, which they can't reach if the agent
+/// refuses to boot over a directory they removed.
+#[test]
+fn vendored_package_with_a_missing_install_does_not_block_startup() {
+    let dir = TempDir::new().unwrap();
+    let profile = profile_with_vendored(dir.path(), &"a".repeat(64)); // no lockfile written
+    let result = verify_mcp_supply_chain(&[], &profile);
+    assert!(
+        result.is_ok(),
+        "a missing install should warn, not strand the agent: {result:?}"
+    );
+}

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -333,6 +333,42 @@ pub struct McpServerEntry {
     /// Absent → empty; resolved by `mur agent/fleet doctor` + `install-deps`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requires_programs: Vec<ProgramDep>,
+
+    /// Vendored package this entry launches, when MUR installed it itself.
+    ///
+    /// Present only for entries moved off a package runner by
+    /// `mur agent mcp vendor`. Its existence is what makes the contents of an
+    /// interpreter-launched server verifiable at all: `npx @scope/pkg` resolves
+    /// on every spawn and pins nothing, whereas a vendored install lives in a
+    /// directory MUR owns and can be checked before the agent comes up.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package: Option<McpPackagePin>,
+}
+
+/// A package MUR installed itself, and the fingerprint that proves the
+/// installed tree hasn't changed.
+///
+/// `lockfile_sha256` hashes the install's `package-lock.json`, which already
+/// records an integrity hash for every package in the dependency tree — so one
+/// small file covers the whole tree, and startup verification stays cheap no
+/// matter how large `node_modules` grows.
+///
+/// The lockfile pins what was *installed*. Editing a file inside
+/// `node_modules` afterwards would not change it; catching that needs a full
+/// tree hash, which is deliberately not done here — see the module docs on
+/// `mur-core::cmd::agent_mcp_vendor` for where that line is drawn.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
+pub struct McpPackagePin {
+    /// Package ecosystem — `npm` today.
+    pub runner: String,
+    /// Package name, including any `@scope/` prefix.
+    pub name: String,
+    /// Exact installed version.
+    pub version: String,
+    /// Directory MUR installed into, absolute.
+    pub install_dir: String,
+    /// SHA-256 (lowercase hex) of `<install_dir>/package-lock.json`.
+    pub lockfile_sha256: String,
 }
 
 /// Authentication scheme for a remote (HTTP) MCP server.

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -932,6 +932,25 @@ pub enum AgentMcpAction {
         #[arg(long = "publisher-registry-id")]
         publisher_registry_id: Option<String>,
     },
+    /// Install a package-runner MCP server (`npx @scope/pkg`) into a directory
+    /// MUR owns and launch it directly, so its contents can be verified.
+    ///
+    /// A runner resolves the package at every spawn, which pins nothing: the
+    /// binary hash covers `npx`, not the server. Vendoring installs the exact
+    /// version under `~/.mur/mcp-packages/`, repoints the entry at the
+    /// installed script, and records the lockfile fingerprint that B0 rule 6
+    /// then enforces at startup. Applies on the agent's next restart.
+    Vendor {
+        name: String,
+        server_id: String,
+        /// Version to install. Defaults to the version already pinned in the
+        /// entry's args, or the registry's current one.
+        #[arg(long)]
+        version: Option<String>,
+        /// Skip the y/N approval prompt.
+        #[arg(long)]
+        force: bool,
+    },
     /// Enable a previously disabled MCP server for this agent.
     Enable { name: String, server_id: String },
     /// Disable an MCP server for this agent WITHOUT removing it. The entry +

--- a/mur-core/src/cmd/agent/addon/mod.rs
+++ b/mur-core/src/cmd/agent/addon/mod.rs
@@ -346,6 +346,7 @@ mod tests {
                 url: None,
                 auth: None,
                 requires_programs: Vec::new(),
+                package: None,
             });
         }
 

--- a/mur-core/src/cmd/agent/cli/manage.rs
+++ b/mur-core/src/cmd/agent/cli/manage.rs
@@ -83,6 +83,7 @@ pub fn mcp_add(agent: &str, server_id: &str, command: &str, args: &[String]) -> 
         url: None,
         auth: None,
         requires_programs: Vec::new(),
+        package: None,
     });
     if !profile
         .entitlements

--- a/mur-core/src/cmd/agent/mcp.rs
+++ b/mur-core/src/cmd/agent/mcp.rs
@@ -161,6 +161,7 @@ pub fn cmd_mcp_add(
         url: None,
         auth: None,
         requires_programs: Vec::new(),
+        package: None,
     });
     // Sync spawn allowlist so the supervisor is permitted to launch this MCP.
     if !profile
@@ -651,6 +652,7 @@ mod tests {
             url: None,
             auth: None,
             requires_programs: Vec::new(),
+            package: None,
         };
         let output = render_server_line(&server);
         assert!(output.contains("browser\tfirefox --mcp"));
@@ -678,6 +680,7 @@ mod tests {
             url: None,
             auth: None,
             requires_programs: Vec::new(),
+            package: None,
         };
         let output = render_server_line(&server);
         assert!(output.contains("browser\tfirefox"));
@@ -705,6 +708,7 @@ mod tests {
             url: None,
             auth: None,
             requires_programs: Vec::new(),
+            package: None,
         };
         let output = render_server_line(&server);
         assert!(output.contains("api\tmcp-api"));
@@ -727,6 +731,7 @@ mod tests {
             url: None,
             auth: None,
             requires_programs: Vec::new(),
+            package: None,
         };
         let output = render_server_line(&server);
         assert!(output.contains("local\tlocal-mcp"));

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -203,6 +203,7 @@ pub fn build_pinned_entry(
         url: None,
         auth: None,
         requires_programs: Vec::new(),
+        package: None,
     }
 }
 
@@ -242,6 +243,20 @@ pub enum InspectStatus {
 /// `mur doctor` reports it across every agent. Two callers computing "is this
 /// drifted?" separately is exactly how one of them ends up wrong.
 pub fn binary_status(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
+    // A vendored entry is pinned by its lockfile, not by the hash of the
+    // `node` that runs it — check that first, or the interpreter branch below
+    // would report the one verifiable shape as unprotected.
+    if let Some(pkg) = &entry.package {
+        let lock = std::path::Path::new(&pkg.install_dir).join("package-lock.json");
+        let Ok(actual) = compute_binary_sha256(&lock) else {
+            return InspectStatus::BinaryMissing;
+        };
+        return if actual.eq_ignore_ascii_case(&pkg.lockfile_sha256) {
+            InspectStatus::Clean
+        } else {
+            InspectStatus::BinaryDrift
+        };
+    }
     let Some(expected) = &entry.binary_sha256 else {
         return InspectStatus::MissingPin;
     };

--- a/mur-core/src/cmd/agent_mcp_vendor.rs
+++ b/mur-core/src/cmd/agent_mcp_vendor.rs
@@ -1,0 +1,314 @@
+//! `mur agent mcp vendor` — install a package-runner MCP server into a
+//! directory MUR owns, so its contents can actually be verified.
+//!
+//! ## Why this exists
+//!
+//! `command: npx, args: ["@yawlabs/fetch-mcp"]` resolves through the package
+//! manager at every spawn. Nothing about that is pinnable: the binary hash
+//! covers `npx` (see `mur_common::exec::is_interpreter_command`), and even a
+//! version in the spec only fixes *which release* is requested, not the bytes
+//! that end up running.
+//!
+//! Vendoring moves the install under `~/.mur/mcp-packages/<agent>/<server>/`
+//! and rewrites the entry to launch the resolved bin directly with `node`. The
+//! agent then starts with no resolution step and no network, from a tree
+//! nothing else writes to.
+//!
+//! ## What the pin covers, and what it doesn't
+//!
+//! The fingerprint is the SHA-256 of `package-lock.json`, which npm fills with
+//! an integrity hash for **every** package in the dependency tree. One small
+//! file therefore covers the whole tree, and startup verification costs the
+//! same whether `node_modules` is 150 KB or 40 MB.
+//!
+//! It pins what was *installed*. Editing a file inside `node_modules` after
+//! the fact does not change the lockfile, so this detects a re-install or a
+//! dependency swap, not post-install tampering with the checked-out files.
+//! Catching that needs a full tree hash at every startup; that cost is not
+//! obviously worth paying, and pretending otherwise would repeat the mistake
+//! this whole line of work exists to fix — claiming coverage that isn't there.
+//!
+//! Installs run with `--ignore-scripts`. A package's `postinstall` is arbitrary
+//! code execution at install time, which is precisely the thing being guarded
+//! against; a server that cannot start without its install scripts is not one
+//! to vendor silently.
+
+use anyhow::{Context, Result, bail};
+use mur_common::agent::{McpPackagePin, McpServerEntry};
+use std::path::{Path, PathBuf};
+
+/// Where MUR keeps vendored MCP packages for `agent`/`server`.
+pub fn install_dir(mur_home: &Path, agent: &str, server: &str) -> PathBuf {
+    mur_home.join("mcp-packages").join(agent).join(server)
+}
+
+/// SHA-256 (lowercase hex) of the install's lockfile.
+pub fn lockfile_sha256(install_dir: &Path) -> Result<String> {
+    let lock = install_dir.join("package-lock.json");
+    crate::cmd::agent_mcp_pin::compute_binary_sha256(&lock)
+        .with_context(|| format!("hash {}", lock.display()))
+}
+
+/// Install `name@version` into `dir` with npm, scripts disabled.
+fn npm_install(dir: &Path, name: &str, version: &str) -> Result<()> {
+    std::fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
+    let spec = format!("{name}@{version}");
+    let out = std::process::Command::new("npm")
+        .arg("install")
+        .arg(&spec)
+        .arg("--prefix")
+        .arg(dir)
+        .args([
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+            "--loglevel=error",
+        ])
+        .output()
+        .map_err(|e| anyhow::anyhow!("run npm install: {e} (is npm on PATH?)"))?;
+    if !out.status.success() {
+        bail!(
+            "npm install {spec} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim(),
+        );
+    }
+    Ok(())
+}
+
+/// Read the package's `bin` entry and return the absolute script path to run.
+///
+/// npm's `bin` is either a string (single binary named after the package) or a
+/// map of names to paths. With several, the one matching the package's own
+/// name wins; otherwise the choice is ambiguous and the caller must say which.
+fn resolve_bin(dir: &Path, name: &str) -> Result<PathBuf> {
+    let pkg_json = dir.join("node_modules").join(name).join("package.json");
+    let raw = std::fs::read_to_string(&pkg_json)
+        .with_context(|| format!("read {}", pkg_json.display()))?;
+    let v: serde_json::Value =
+        serde_json::from_str(&raw).with_context(|| format!("parse {}", pkg_json.display()))?;
+
+    let rel =
+        match v.get("bin") {
+            Some(serde_json::Value::String(s)) => s.clone(),
+            Some(serde_json::Value::Object(map)) => {
+                let short = name.rsplit('/').next().unwrap_or(name);
+                let pick = map
+                .get(short)
+                .or_else(|| if map.len() == 1 { map.values().next() } else { None })
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "package `{name}` exposes {} binaries ({}); vendoring needs exactly one",
+                        map.len(),
+                        map.keys().cloned().collect::<Vec<_>>().join(", "),
+                    )
+                })?;
+                pick.to_string()
+            }
+            _ => bail!("package `{name}` declares no `bin`, so there is nothing to launch"),
+        };
+
+    let abs = dir.join("node_modules").join(name).join(&rel);
+    if !abs.is_file() {
+        bail!("`bin` points at {}, which does not exist", abs.display());
+    }
+    abs.canonicalize()
+        .with_context(|| format!("canonicalize {}", abs.display()))
+}
+
+/// Vendor `entry`'s package: install it, repoint the entry at the installed
+/// script, and record the lockfile fingerprint.
+///
+/// Mutates `entry` only after every fallible step has succeeded, so a failed
+/// vendor leaves the agent exactly as it was.
+pub fn vendor_entry(
+    entry: &mut McpServerEntry,
+    mur_home: &Path,
+    agent: &str,
+    name: &str,
+    version: &str,
+) -> Result<PathBuf> {
+    let dir = install_dir(mur_home, agent, &entry.name);
+    npm_install(&dir, name, version)?;
+    let bin = resolve_bin(&dir, name)?;
+    let lock = lockfile_sha256(&dir)?;
+
+    entry.command = "node".to_string();
+    entry.args = vec![bin.display().to_string()];
+    entry.binary_sha256 = None; // the node binary's hash was never the point
+    entry.package = Some(McpPackagePin {
+        runner: "npm".into(),
+        name: name.to_string(),
+        version: version.to_string(),
+        install_dir: dir.display().to_string(),
+        lockfile_sha256: lock,
+    });
+    Ok(dir)
+}
+
+/// `mur agent mcp vendor <agent> <server> [--version V] [--force]`
+pub fn cmd_mcp_vendor(
+    agent: &str,
+    server_id: &str,
+    version: Option<String>,
+    force: bool,
+) -> Result<()> {
+    let mur_home = crate::cmd::agent::resolve_mur_home()?;
+    let (path, mut profile) = crate::cmd::agent::load_profile_for_edit(agent)?;
+    let entry = profile
+        .mcp_servers
+        .iter_mut()
+        .find(|s| s.name == server_id)
+        .ok_or_else(|| anyhow::anyhow!("MCP server `{server_id}` not found on agent `{agent}`"))?;
+
+    // The package to vendor comes from the entry's own launch args, so this
+    // never invents a target the user didn't already approve.
+    let spec =
+        mur_common::mcp_package::parse_spec(&entry.command, &entry.args).ok_or_else(|| {
+            anyhow::anyhow!(
+                "`{server_id}` is not launched through a package runner \
+                 (command: `{}`), so there is no package to vendor",
+                entry.command,
+            )
+        })?;
+
+    let version = match version.or(spec.version.clone()) {
+        Some(v) => v,
+        None => {
+            let runner = mur_common::mcp_package::runner_for(&entry.command)
+                .ok_or_else(|| anyhow::anyhow!("unsupported package runner"))?;
+            mur_common::mcp_package::resolve_current_version(runner, &spec.name)?
+        }
+    };
+
+    if !force {
+        println!("About to vendor MCP `{server_id}` on agent `{agent}`:");
+        println!("  package:     {}@{version}", spec.name);
+        println!(
+            "  install to:  {}",
+            install_dir(&mur_home, agent, server_id).display()
+        );
+        println!(
+            "  launch:      node <install>/node_modules/{}/<bin>",
+            spec.name
+        );
+        println!("  was:         {} {}", entry.command, entry.args.join(" "));
+        println!("\nInstall scripts are disabled (--ignore-scripts).");
+        print!("Proceed? [y/N] ");
+        use std::io::Write;
+        std::io::stdout().flush().ok();
+        let mut answer = String::new();
+        std::io::stdin()
+            .read_line(&mut answer)
+            .context("read confirmation from stdin")?;
+        if !matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+            bail!("vendoring cancelled");
+        }
+    }
+
+    let dir = vendor_entry(entry, &mur_home, agent, &spec.name, &version)?;
+    let pin = entry.package.clone().expect("set by vendor_entry");
+    crate::cmd::agent::save_profile(&path, &mut profile)?;
+
+    println!("Vendored `{server_id}` for agent `{agent}`:");
+    println!("  installed:   {}@{version}", pin.name);
+    println!("  directory:   {}", dir.display());
+    println!("  lockfile:    sha256:{}", pin.lockfile_sha256);
+    println!("\nRestart the agent to launch from the vendored copy.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_pkg(dir: &Path, name: &str, bin: serde_json::Value) {
+        let p = dir.join("node_modules").join(name);
+        std::fs::create_dir_all(&p).unwrap();
+        std::fs::write(
+            p.join("package.json"),
+            serde_json::json!({ "name": name, "bin": bin }).to_string(),
+        )
+        .unwrap();
+    }
+
+    fn touch(dir: &Path, name: &str, rel: &str) {
+        let f = dir.join("node_modules").join(name).join(rel);
+        std::fs::create_dir_all(f.parent().unwrap()).unwrap();
+        std::fs::write(&f, b"// entry\n").unwrap();
+    }
+
+    #[test]
+    fn resolves_a_string_bin() {
+        let d = tempfile::tempdir().unwrap();
+        write_pkg(d.path(), "solo", serde_json::json!("dist/index.js"));
+        touch(d.path(), "solo", "dist/index.js");
+        let got = resolve_bin(d.path(), "solo").unwrap();
+        assert!(got.ends_with("dist/index.js"));
+        assert!(got.is_absolute(), "the launch path must not depend on cwd");
+    }
+
+    #[test]
+    fn picks_the_bin_matching_the_scoped_package_name() {
+        let d = tempfile::tempdir().unwrap();
+        write_pkg(
+            d.path(),
+            "@yawlabs/fetch-mcp",
+            serde_json::json!({ "fetch-mcp": "dist/index.js", "other": "dist/other.js" }),
+        );
+        touch(d.path(), "@yawlabs/fetch-mcp", "dist/index.js");
+        let got = resolve_bin(d.path(), "@yawlabs/fetch-mcp").unwrap();
+        assert!(got.ends_with("dist/index.js"));
+    }
+
+    /// Guessing which of several binaries to launch would silently run the
+    /// wrong program, so an ambiguous `bin` map has to fail loudly.
+    #[test]
+    fn refuses_an_ambiguous_bin_map() {
+        let d = tempfile::tempdir().unwrap();
+        write_pkg(
+            d.path(),
+            "many",
+            serde_json::json!({ "a": "a.js", "b": "b.js" }),
+        );
+        let err = resolve_bin(d.path(), "many").unwrap_err().to_string();
+        assert!(err.contains("exactly one"), "got: {err}");
+    }
+
+    #[test]
+    fn reports_a_bin_path_that_does_not_exist() {
+        let d = tempfile::tempdir().unwrap();
+        write_pkg(d.path(), "ghost", serde_json::json!("dist/missing.js"));
+        let err = resolve_bin(d.path(), "ghost").unwrap_err().to_string();
+        assert!(err.contains("does not exist"), "got: {err}");
+    }
+
+    #[test]
+    fn a_package_with_no_bin_cannot_be_vendored() {
+        let d = tempfile::tempdir().unwrap();
+        write_pkg(d.path(), "lib-only", serde_json::Value::Null);
+        let err = resolve_bin(d.path(), "lib-only").unwrap_err().to_string();
+        assert!(err.contains("no `bin`"), "got: {err}");
+    }
+
+    #[test]
+    fn lockfile_hash_changes_with_the_lockfile() {
+        let d = tempfile::tempdir().unwrap();
+        std::fs::write(d.path().join("package-lock.json"), b"{\"v\":1}").unwrap();
+        let a = lockfile_sha256(d.path()).unwrap();
+        std::fs::write(d.path().join("package-lock.json"), b"{\"v\":2}").unwrap();
+        let b = lockfile_sha256(d.path()).unwrap();
+        assert_ne!(a, b, "a changed dependency tree must change the pin");
+        assert_eq!(a.len(), 64);
+    }
+
+    #[test]
+    fn install_dir_is_scoped_per_agent_and_server() {
+        let home = Path::new("/tmp/murhome");
+        assert_ne!(
+            install_dir(home, "a1", "fetch"),
+            install_dir(home, "a2", "fetch"),
+            "two agents must not share one install they can both invalidate",
+        );
+    }
+}

--- a/mur-core/src/cmd/misc.rs
+++ b/mur-core/src/cmd/misc.rs
@@ -254,7 +254,9 @@ fn report_mcp_pins(mur_dir: &std::path::Path) {
                         )),
                         Some(spec) => problems.push(format!(
                             "  ⚠ {agent}/{name}: launched via `{launcher}` at {pkg} — version \
-                             recorded, but the package contents are not verified.",
+                             recorded, but the package contents are not verified.\n     \
+                             `mur agent mcp vendor {agent} {name}` installs it where MUR can \
+                             verify it.",
                             name = entry.name,
                             pkg = spec.to_arg(),
                         )),

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod agent_history;
 pub mod agent_hooks;
 /// B0 M9.2 — install-time MCP hash + publisher prompt for `mur agent mcp add`.
 pub(crate) mod agent_mcp_pin;
+pub(crate) mod agent_mcp_vendor;
 pub mod agent_pair;
 pub(crate) mod agent_propagate;
 pub(crate) mod agent_rekey;

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1618,6 +1618,12 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 publisher_homepage,
                 publisher_registry_id,
             )?,
+            AgentMcpAction::Vendor {
+                name,
+                server_id,
+                version,
+                force,
+            } => cmd::agent_mcp_vendor::cmd_mcp_vendor(&name, &server_id, version, force)?,
             AgentMcpAction::Enable { name, server_id } => {
                 cmd::agent::cmd_mcp_set_enabled(&name, &server_id, true)?
             }


### PR DESCRIPTION
The remaining half of #796. #795 stopped MUR from claiming coverage it didn't have; this creates the coverage.

## The gap

`command: npx, args: ["@yawlabs/fetch-mcp"]` resolves through the package manager at every spawn. The binary hash covers `npx`. #795's version pin fixes which release is *requested* — not the bytes that end up running. So the most common way people install MCP servers had no supply-chain pin at all.

## What this adds

`mur agent mcp vendor <agent> <server>` installs the exact version under `~/.mur/mcp-packages/<agent>/<server>/`, repoints the entry at the installed script (`node <path>`), and records a fingerprint. The agent then starts from a tree nothing else writes to — no resolution step, no network at spawn.

**The fingerprint is the lockfile.** npm fills `package-lock.json` with an integrity hash for every package in the dependency tree, so hashing that one file covers the whole tree. Measured against the real package: **47 KB hashed instead of 37 MB of `node_modules`**, and the cost doesn't grow with the tree. That is what makes startup verification affordable enough to be mandatory.

B0 rule 6 checks it **before** the interpreter exemption from #795 — a vendored entry is interpreter-*shaped* (`node …`) but is the one such shape that's genuinely verifiable, so the exemption must not swallow it.

## Deliberate limits, stated rather than implied

- **The lockfile pins what was installed.** Editing a file inside `node_modules` afterwards doesn't change it. Catching that needs a full tree hash at every startup; the module docs say so plainly instead of letting the reader assume otherwise. Repeating #791's mistake — claiming coverage that isn't there — is the specific failure this line of work exists to correct.
- **`--ignore-scripts`.** A `postinstall` is arbitrary code execution at install time, i.e. the thing being guarded against.
- **A missing install warns, not refuses.** The recovery command lives in the CLI, which is no help to someone whose agent won't boot because they deleted a directory.
- **Opt-in, via its own verb.** Rewriting how a server launches is more than `pin` ("re-approve what's there") should silently do. Existing entries are untouched until asked.

## Verification

- `cargo test -p mur-core --lib agent_mcp` — 23 passed. New: string vs map `bin` resolution, scoped-name picking, **refusal on an ambiguous bin map** (guessing would silently launch the wrong program), missing bin path, no-bin package, lockfile hash sensitivity, per-agent install isolation.
- `cargo test -p mur-agent-runtime --test b0_rule6_mcp_pin` — 7 passed, including a vendored tree that changed → startup refused with the package name, version and recovery command in the message; and a deleted install → warns, still boots.
- `cargo clippy -p mur-core --lib -- -D warnings` clean.
- The npm path was exercised against the real package, not mocked: `npm install @yawlabs/fetch-mcp@0.3.6 --prefix … --ignore-scripts` → 105 packages, `bin = {fetch-mcp: dist/index.js}` resolving to a file that exists, 47 KB lockfile.

Schema: `McpServerEntry` gains an optional `package`. Blast radius checked across every crate including the workspace-excluded Tauri ones — 9 explicit literals, all in `mur-core`, all updated; neither GUI crate constructs one exhaustively.

Docs (mur-run/mur-server#36) will need the vendor section; that PR is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)