### PR TITLE
feat(mcp): verify registry signatures when vendoring, and refuse invalid ones

### DIFF
--- a/mur-agent-runtime/tests/b0_rule6_mcp_pin.rs
+++ b/mur-agent-runtime/tests/b0_rule6_mcp_pin.rs
@@ -132,6 +132,9 @@ fn profile_with_vendored(install_dir: &std::path::Path, lockfile_sha256: &str) -
             version: "0.3.6".into(),
             install_dir: install_dir.display().to_string(),
             lockfile_sha256: lockfile_sha256.into(),
+            // Functional update so a new pin field doesn't break this fixture,
+            // the way adding `signatures_missing` did.
+            ..Default::default()
         }),
         ..Default::default()
     });

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -369,6 +369,20 @@ pub struct McpPackagePin {
     pub install_dir: String,
     /// SHA-256 (lowercase hex) of `<install_dir>/package-lock.json`.
     pub lockfile_sha256: String,
+
+    /// How many packages in the installed tree published no registry
+    /// signature, as reported by `npm audit signatures` at vendor time.
+    ///
+    /// `None` — the audit did not run (npm too old, or offline).
+    /// `Some(0)` — every package in the tree carried a verified signature.
+    /// `Some(n)` — `n` packages are unsigned; the rest verified.
+    ///
+    /// A signature that verifies proves the bytes came from the registry, which
+    /// the content hash cannot: it would faithfully pin a poisoned cache. An
+    /// *invalid* signature is not recorded here because it blocks the vendor
+    /// outright — that is an integrity failure, not a property to note.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signatures_missing: Option<u32>,
 }
 
 /// Authentication scheme for a remote (HTTP) MCP server.

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -298,6 +298,45 @@ pub fn inspect_one(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
         println!("  installed_at:   {}", t.to_rfc3339());
     }
 
+    // A vendored entry is pinned by its lockfile, not by the hash of the
+    // `node` that launches it — report that instead of the binary story.
+    if let Some(pkg) = &entry.package {
+        println!(
+            "  package:        {}@{} ({})",
+            pkg.name, pkg.version, pkg.runner
+        );
+        println!("  install dir:    {}", pkg.install_dir);
+        match pkg.signatures_missing {
+            Some(0) => println!("  signatures:     all verified against the registry at install"),
+            Some(n) => {
+                println!("  signatures:     verified, except {n} package(s) publishing none")
+            }
+            None => println!("  signatures:     not audited at install"),
+        }
+        println!("  pinned lock:    {}", pkg.lockfile_sha256);
+        let lock = std::path::Path::new(&pkg.install_dir).join("package-lock.json");
+        let Ok(actual) = compute_binary_sha256(&lock) else {
+            println!("  current lock:   <not readable — install missing?>");
+            println!(
+                "  status:         INSTALL MISSING — `mur agent mcp vendor <agent> {}` to reinstall",
+                entry.name,
+            );
+            return InspectStatus::BinaryMissing;
+        };
+        println!("  current lock:   {actual}");
+        return if actual.eq_ignore_ascii_case(&pkg.lockfile_sha256) {
+            println!("  status:         CLEAN");
+            InspectStatus::Clean
+        } else {
+            println!("  status:         TREE DRIFT");
+            println!(
+                "  hint:           `mur agent mcp vendor <agent> {}` to reinstall and re-approve",
+                entry.name,
+            );
+            InspectStatus::BinaryDrift
+        };
+    }
+
     let Some(expected) = &entry.binary_sha256 else {
         println!("  pin status:     <unpinned> (pre-M9 entry)");
         println!(

--- a/mur-core/src/cmd/agent_mcp_vendor.rs
+++ b/mur-core/src/cmd/agent_mcp_vendor.rs
@@ -116,6 +116,80 @@ fn resolve_bin(dir: &Path, name: &str) -> Result<PathBuf> {
         .with_context(|| format!("canonicalize {}", abs.display()))
 }
 
+/// Outcome of `npm audit signatures` over the installed tree.
+struct SignatureAudit {
+    /// Packages whose registry signature failed to verify. Non-empty means the
+    /// bytes on disk are not what the registry signed.
+    invalid: Vec<String>,
+    /// Packages that published no signature at all.
+    missing: u32,
+}
+
+/// Parse `npm audit signatures --json`.
+///
+/// Split out from the subprocess call so the contract can be tested without
+/// npm, a network, or an installed tree — this is the part that decides
+/// whether a vendor is refused.
+fn parse_audit(body: &str) -> Option<SignatureAudit> {
+    let v: serde_json::Value = serde_json::from_str(body.trim()).ok()?;
+    let names = |key: &str| -> Vec<String> {
+        v.get(key)
+            .and_then(|a| a.as_array())
+            .map(|a| {
+                a.iter()
+                    .map(|e| {
+                        e.get("name")
+                            .and_then(|n| n.as_str())
+                            .unwrap_or("<unnamed>")
+                            .to_string()
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    Some(SignatureAudit {
+        invalid: names("invalid"),
+        missing: names("missing").len() as u32,
+    })
+}
+
+/// Verify that the installed tree came from the registry.
+///
+/// The lockfile hash proves the tree hasn't changed since install; it says
+/// nothing about where those bytes came from, and would pin a poisoned cache
+/// as happily as a clean one. Registry signatures close exactly that gap, and
+/// they close it here — at install time, with network already in hand — rather
+/// than costing anything at startup.
+///
+/// `Ok(None)` when the audit could not run (npm too old, offline). Refusing to
+/// vendor over an unavailable audit would trade a real capability for a check
+/// that is advisory by nature.
+fn audit_signatures(dir: &Path) -> Result<Option<SignatureAudit>> {
+    let out = match std::process::Command::new("npm")
+        .args(["audit", "signatures", "--json"])
+        .current_dir(dir)
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("warning: could not run `npm audit signatures` ({e}); skipping");
+            return Ok(None);
+        }
+    };
+    // Exit status is non-zero when anything failed to verify, so parse the
+    // body regardless and let its contents decide.
+    let body = String::from_utf8_lossy(&out.stdout);
+    match parse_audit(&body) {
+        Some(a) => Ok(Some(a)),
+        None => {
+            eprintln!(
+                "warning: `npm audit signatures` returned output this version can't read; skipping",
+            );
+            Ok(None)
+        }
+    }
+}
+
 /// Vendor `entry`'s package: install it, repoint the entry at the installed
 /// script, and record the lockfile fingerprint.
 ///
@@ -130,6 +204,20 @@ pub fn vendor_entry(
 ) -> Result<PathBuf> {
     let dir = install_dir(mur_home, agent, &entry.name);
     npm_install(&dir, name, version)?;
+
+    let audit = audit_signatures(&dir)?;
+    if let Some(a) = &audit
+        && !a.invalid.is_empty()
+    {
+        bail!(
+            "refusing to vendor: {} package(s) failed registry signature verification ({}). \
+             The bytes on disk are not what the registry signed — do not run this server \
+             until you know why.",
+            a.invalid.len(),
+            a.invalid.join(", "),
+        );
+    }
+
     let bin = resolve_bin(&dir, name)?;
     let lock = lockfile_sha256(&dir)?;
 
@@ -142,6 +230,7 @@ pub fn vendor_entry(
         version: version.to_string(),
         install_dir: dir.display().to_string(),
         lockfile_sha256: lock,
+        signatures_missing: audit.as_ref().map(|a| a.missing),
     });
     Ok(dir)
 }
@@ -214,6 +303,14 @@ pub fn cmd_mcp_vendor(
     println!("  installed:   {}@{version}", pin.name);
     println!("  directory:   {}", dir.display());
     println!("  lockfile:    sha256:{}", pin.lockfile_sha256);
+    match pin.signatures_missing {
+        Some(0) => println!("  signatures:  every package verified against the registry"),
+        Some(n) => println!(
+            "  signatures:  verified, except {n} package(s) that publish none \
+             (common for older releases)"
+        ),
+        None => println!("  signatures:  not audited (npm too old, or offline)"),
+    }
     println!("\nRestart the agent to launch from the vendored copy.");
     Ok(())
 }
@@ -309,6 +406,57 @@ mod tests {
             install_dir(home, "a1", "fetch"),
             install_dir(home, "a2", "fetch"),
             "two agents must not share one install they can both invalidate",
+        );
+    }
+
+    // ── Registry signature audit ────────────────────────────────────────────
+
+    /// The shape npm 10 actually returns for a clean tree, captured from a real
+    /// run against @yawlabs/fetch-mcp (105 packages, all verified).
+    #[test]
+    fn a_clean_audit_reports_nothing_missing_and_nothing_invalid() {
+        let a = parse_audit(r#"{"invalid":[],"missing":[]}"#).expect("clean body parses");
+        assert!(a.invalid.is_empty());
+        assert_eq!(a.missing, 0);
+    }
+
+    /// Unsigned packages are common for older releases — worth recording, not
+    /// worth refusing over.
+    #[test]
+    fn unsigned_packages_are_counted_not_fatal() {
+        let a = parse_audit(r#"{"invalid":[],"missing":[{"name":"old-pkg"},{"name":"older"}]}"#)
+            .unwrap();
+        assert_eq!(a.missing, 2);
+        assert!(a.invalid.is_empty(), "missing is not invalid");
+    }
+
+    /// An invalid signature means the bytes on disk are not what the registry
+    /// signed. `vendor_entry` refuses on this, so the names have to survive
+    /// parsing to reach the user.
+    #[test]
+    fn invalid_signatures_keep_their_package_names() {
+        let a = parse_audit(r#"{"invalid":[{"name":"evil-dep"}],"missing":[]}"#).unwrap();
+        assert_eq!(a.invalid, vec!["evil-dep".to_string()]);
+    }
+
+    #[test]
+    fn an_unreadable_audit_body_is_not_silently_treated_as_clean() {
+        assert!(parse_audit("npm ERR! code ENOTFOUND").is_none());
+        assert!(parse_audit("").is_none());
+    }
+
+    /// A future npm that renames or drops the field must not turn into a
+    /// confident "all verified".
+    #[test]
+    fn missing_keys_degrade_to_empty_rather_than_inventing_results() {
+        let a = parse_audit(r#"{}"#).expect("valid json still parses");
+        assert!(a.invalid.is_empty());
+        assert_eq!(a.missing, 0);
+        let a = parse_audit(r#"{"invalid":[{}],"missing":[]}"#).unwrap();
+        assert_eq!(
+            a.invalid,
+            vec!["<unnamed>".to_string()],
+            "an entry without a name still has to be reported, not dropped",
         );
     }
 }


### PR DESCRIPTION
First item from the rewritten #796, in the value order recorded there.

## Why this and not tree hashing

The lockfile hash from #797 proves a vendored tree hasn't changed since install. It says nothing about **where those bytes came from** — it would pin a poisoned cache exactly as faithfully as a clean one. Registry signatures are the check that covers that, and they cost nothing at startup because they run once at vendor time with the network already in hand.

Measured against the real install:

```
$ npm audit signatures --json     # in the vendored dir
{ "invalid": [], "missing": [] }  # 105 packages, 2 seconds
```

## Behaviour

| Audit result | What happens |
|---|---|
| a package fails verification | **vendor aborts**, naming the packages — the bytes on disk are not what the registry signed |
| packages publish no signature | counted, recorded, reported — common for older releases; refusing would buy strictness, not safety |
| audit can't run (old npm, offline) | no signature record, vendor proceeds — the check is advisory about provenance, not a property of the pinned tree |

`McpPackagePin` gains `signatures_missing: Option<u32>`, which distinguishes all three states without a second field: `None` not audited, `Some(0)` all verified, `Some(n)` n unsigned.

`inspect` also renders vendored entries in their own terms now — package, install dir, signature state, expected vs actual lockfile — rather than the binary-hash story that doesn't apply to them.

## Verification

`cargo test -p mur-core --lib agent_mcp_vendor` — 12 passed. The npm JSON parse is split out from the subprocess call so its contract is testable without npm, a network, or an install; it's the part that decides whether a vendor is refused:

- clean body (the exact shape npm 10.9.2 returned for the real tree)
- unsigned counted, explicitly *not* treated as invalid
- invalid entries keep their package names, so the abort message can name them
- unreadable output → `None`, never silently "all verified"
- a future npm that drops or renames the keys degrades to empty rather than inventing a pass; an entry with no name is still reported as `<unnamed>` rather than dropped

clippy clean on `mur-core`.

Remaining in #796: provenance recording (11/105 coverage today), a `--deep` audit that re-installs from the lockfile and diffs, and uvx/Python which has no coverage at all. Tree hashing at startup stays decided-against, with reasons in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)