### PR TITLE
feat(mcp): record whether a vendored release published build provenance

### DIFF
--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -383,6 +383,18 @@ pub struct McpPackagePin {
     /// outright — that is an integrity failure, not a property to note.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signatures_missing: Option<u32>,
+
+    /// SLSA predicate type of the package's build provenance, when it
+    /// publishes one — e.g. `https://slsa.dev/provenance/v1`. `None` means no
+    /// attestation was published (still the common case).
+    ///
+    /// Provenance ties a release back to a source repository and CI run, and
+    /// is the only signal here that can catch a **malicious publish**: a
+    /// content hash pins whatever was released, faithfully preserving a
+    /// poisoned version rather than detecting it. Recorded and shown, never
+    /// required — ecosystem coverage is far too thin to gate on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<String>,
 }
 
 /// Authentication scheme for a remote (HTTP) MCP server.

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -313,6 +313,10 @@ pub fn inspect_one(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
             }
             None => println!("  signatures:     not audited at install"),
         }
+        match &pkg.provenance {
+            Some(p) => println!("  provenance:     {p}"),
+            None => println!("  provenance:     none published by this release"),
+        }
         println!("  pinned lock:    {}", pkg.lockfile_sha256);
         let lock = std::path::Path::new(&pkg.install_dir).join("package-lock.json");
         let Ok(actual) = compute_binary_sha256(&lock) else {

--- a/mur-core/src/cmd/agent_mcp_vendor.rs
+++ b/mur-core/src/cmd/agent_mcp_vendor.rs
@@ -190,6 +190,38 @@ fn audit_signatures(dir: &Path) -> Result<Option<SignatureAudit>> {
     }
 }
 
+/// Pull the SLSA predicate type out of `npm view <spec> dist.attestations --json`.
+///
+/// Split from the subprocess call so the shape is testable offline. An empty
+/// body is npm's way of saying the field doesn't exist, which is the common
+/// case and not an error.
+fn parse_provenance(body: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(body.trim()).ok()?;
+    v.get("provenance")?
+        .get("predicateType")?
+        .as_str()
+        .map(str::to_string)
+}
+
+/// Ask the registry whether this release published build provenance.
+///
+/// Only the vendored package itself is queried. `npm audit signatures` already
+/// verifies any attestations across the whole tree; what it doesn't tell us is
+/// whether *this* package has one, and asking per-dependency would be a
+/// hundred network round-trips for a field that is recorded, never enforced.
+fn query_provenance(name: &str, version: &str) -> Option<String> {
+    let out = std::process::Command::new("npm")
+        .args([
+            "view",
+            &format!("{name}@{version}"),
+            "dist.attestations",
+            "--json",
+        ])
+        .output()
+        .ok()?;
+    parse_provenance(&String::from_utf8_lossy(&out.stdout))
+}
+
 /// Vendor `entry`'s package: install it, repoint the entry at the installed
 /// script, and record the lockfile fingerprint.
 ///
@@ -231,6 +263,7 @@ pub fn vendor_entry(
         install_dir: dir.display().to_string(),
         lockfile_sha256: lock,
         signatures_missing: audit.as_ref().map(|a| a.missing),
+        provenance: query_provenance(name, version),
     });
     Ok(dir)
 }
@@ -310,6 +343,13 @@ pub fn cmd_mcp_vendor(
              (common for older releases)"
         ),
         None => println!("  signatures:  not audited (npm too old, or offline)"),
+    }
+    match &pin.provenance {
+        Some(p) => println!("  provenance:  published ({p})"),
+        None => println!(
+            "  provenance:  none published — the registry can attest these bytes, \
+             but not where they were built"
+        ),
     }
     println!("\nRestart the agent to launch from the vendored copy.");
     Ok(())
@@ -458,5 +498,40 @@ mod tests {
             vec!["<unnamed>".to_string()],
             "an entry without a name still has to be reported, not dropped",
         );
+    }
+
+    // ── Provenance ──────────────────────────────────────────────────────────
+
+    /// The shape npm returns for a release published with provenance, captured
+    /// from real `npm view sigstore dist.attestations --json` output.
+    #[test]
+    fn provenance_predicate_type_is_extracted() {
+        let body = r#"{
+          "url": "https://registry.npmjs.org/-/npm/v1/attestations/sigstore@5.0.0",
+          "provenance": { "predicateType": "https://slsa.dev/provenance/v1" }
+        }"#;
+        assert_eq!(
+            parse_provenance(body).as_deref(),
+            Some("https://slsa.dev/provenance/v1"),
+        );
+    }
+
+    /// Most releases publish none — npm prints nothing at all. That is the
+    /// common case, not a failure, and must not read as an error.
+    #[test]
+    fn no_attestations_is_absence_not_failure() {
+        assert_eq!(parse_provenance(""), None);
+        assert_eq!(parse_provenance("{}"), None);
+        assert_eq!(
+            parse_provenance(r#"{"url":"x"}"#),
+            None,
+            "url without provenance"
+        );
+        assert_eq!(
+            parse_provenance(r#"{"provenance":{}}"#),
+            None,
+            "no predicateType"
+        );
+        assert_eq!(parse_provenance("npm ERR! 404"), None);
     }
 }


### PR DESCRIPTION
Second item from #796, after #798.

## The gap this covers

The lockfile hash proves the tree hasn't changed. The registry signature (#798) proves the bytes came from npm. **Neither says anything about a malicious publish** — if the release itself was poisoned, both checks pass, and the content hash preserves it faithfully rather than detecting it.

Provenance is the only signal here that reaches that: a SLSA attestation ties a release back to a source repository and CI run.

## Recorded, not required

Coverage is thin, measured rather than assumed:

```
$ npm view sigstore dist.attestations --json
{ "provenance": { "predicateType": "https://slsa.dev/provenance/v1" } }

$ npm view @yawlabs/fetch-mcp dist.attestations --json      # nothing
```

11 of the 105 packages in a real `fetch-mcp` install carry one; `fetch-mcp` itself doesn't. Gating on provenance would refuse most of the ecosystem for no gain, so `McpPackagePin.provenance` records the predicate type and `vendor` / `inspect` show it.

Only the vendored package is queried — `npm audit signatures` already verifies attestations across the whole tree, and asking the registry per-dependency would be a hundred round-trips for a field nothing enforces.

An absent attestation is the common case, not a failure, and reads that way:

```
  provenance:  none published — the registry can attest these bytes, but not where they were built
```

## Verification

`cargo test -p mur-core --lib agent_mcp_vendor` — 14 passed. The parse is split from the subprocess call and tested against real npm output shapes:

- the `sigstore` body, verbatim, yields the SLSA predicate type
- **absence in all its forms is absence, never an error**: empty output, `{}`, a `url` with no `provenance`, a `provenance` with no `predicateType`, and an npm 404

`cargo test --workspace --locked --no-run` clean — the check that would have caught #798's fixture break, now run before pushing rather than after.

Remaining in #796: the `--deep` audit (re-install from the lockfile and diff — the only check whose reference value isn't local) and uvx/Python, which still has no coverage at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)