### PR TITLE
feat(mcp): add `inspect --deep`, the one check whose reference isn't local

### DIFF
--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -910,6 +910,13 @@ pub enum AgentMcpAction {
         /// inspect stays fast; pass `--probe` for the active scan.
         #[arg(long)]
         probe: bool,
+        /// Re-install a vendored entry from its pinned lockfile and diff the
+        /// result against what's on disk. The only check here whose reference
+        /// value comes from the registry rather than this machine, so it sees
+        /// a locally-edited tree even when the recorded hash was edited to
+        /// match. Costs a full reinstall.
+        #[arg(long)]
+        deep: bool,
     },
     /// Re-compute and persist the install-time binary pin (and
     /// optionally refresh publisher metadata). Used after reviewing

--- a/mur-core/src/cmd/agent_mcp_deep_audit.rs
+++ b/mur-core/src/cmd/agent_mcp_deep_audit.rs
@@ -80,11 +80,18 @@ fn hash_tree(root: &Path) -> Result<BTreeMap<String, String>> {
             if meta.is_dir() {
                 stack.push(path);
             } else if meta.is_file() {
+                // Normalise separators so a key means the same thing on every
+                // platform: the two trees being compared are always local, but
+                // the paths also land in user-facing output and in tests, and
+                // `a\b\c` vs `a/b/c` is a difference nobody wants to reason
+                // about.
                 let rel = path
                     .strip_prefix(root)
                     .unwrap_or(&path)
-                    .display()
-                    .to_string();
+                    .components()
+                    .map(|c| c.as_os_str().to_string_lossy().into_owned())
+                    .collect::<Vec<_>>()
+                    .join("/");
                 let hash = crate::cmd::agent_mcp_pin::compute_binary_sha256(&path)
                     .with_context(|| format!("hash {}", path.display()))?;
                 out.insert(rel, hash);
@@ -262,7 +269,12 @@ mod tests {
         std::os::unix::fs::symlink(d.path().join("top.js"), d.path().join("link.js")).unwrap();
 
         let t = hash_tree(d.path()).unwrap();
-        assert!(t.contains_key("a/b/c/f.js"), "nested files must be walked");
+        assert!(
+            t.contains_key("a/b/c/f.js"),
+            "nested files must be walked, with `/` keys on every platform \
+             (Windows CI caught this one); got {:?}",
+            t.keys().collect::<Vec<_>>(),
+        );
         assert!(t.contains_key("top.js"));
         #[cfg(unix)]
         assert!(

--- a/mur-core/src/cmd/agent_mcp_deep_audit.rs
+++ b/mur-core/src/cmd/agent_mcp_deep_audit.rs
@@ -1,0 +1,290 @@
+//! `mur agent mcp inspect --deep` — re-derive a vendored install from the
+//! registry and diff it against what's on disk.
+//!
+//! ## Why this exists, when the lockfile pin already runs at every startup
+//!
+//! Every other check here compares the tree against a value stored **locally**
+//! — `binary_sha256` and `lockfile_sha256` both live in `profile.yaml`, which
+//! is writable by the same principal as the files they describe. That makes
+//! them change detection: they catch software that swapped something without
+//! telling you (a package manager re-resolving, an upgrade), not an adversary,
+//! who would simply rewrite the recorded hash too.
+//!
+//! This check is the exception. It reinstalls from the pinned lockfile and
+//! compares against **what the registry serves now**, so its reference value
+//! is not on the machine being audited. It is the only thing here that can
+//! catch a locally-edited `node_modules` even when the pin was edited to
+//! match.
+//!
+//! That is also why it is a command and not a startup check: it costs a full
+//! reinstall. Paying that at every agent start to defend against a threat the
+//! other checks structurally cannot see would be the wrong trade — see #796.
+//!
+//! ## What it compares
+//!
+//! Regular files under `node_modules`, by content. Symlinks (npm's `.bin`
+//! shims) are skipped: they are regenerated per install and their targets are
+//! derived from the same package metadata already covered by the lockfile.
+//! A tampered shim is therefore out of scope for this pass, and saying so is
+//! better than implying a coverage that isn't there.
+
+use anyhow::{Context, Result, bail};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// One difference between the installed tree and a fresh install of the same
+/// lockfile.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Difference {
+    /// Present on disk, absent from a clean install of this lockfile.
+    Added(String),
+    /// Absent from disk, present in a clean install.
+    Removed(String),
+    /// Present in both, different contents.
+    Modified(String),
+}
+
+impl Difference {
+    fn path(&self) -> &str {
+        match self {
+            Self::Added(p) | Self::Removed(p) | Self::Modified(p) => p,
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Added(_) => "only on disk",
+            Self::Removed(_) => "missing on disk",
+            Self::Modified(_) => "contents differ",
+        }
+    }
+}
+
+/// Content hashes of every regular file under `root`, keyed by path relative
+/// to `root`.
+fn hash_tree(root: &Path) -> Result<BTreeMap<String, String>> {
+    let mut out = BTreeMap::new();
+    if !root.is_dir() {
+        return Ok(out);
+    }
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir).with_context(|| format!("read {}", dir.display()))?;
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = entry.path();
+            // symlink_metadata: never follow, so a symlinked directory can't
+            // send the walk somewhere outside the tree.
+            let Ok(meta) = std::fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if meta.is_dir() {
+                stack.push(path);
+            } else if meta.is_file() {
+                let rel = path
+                    .strip_prefix(root)
+                    .unwrap_or(&path)
+                    .display()
+                    .to_string();
+                let hash = crate::cmd::agent_mcp_pin::compute_binary_sha256(&path)
+                    .with_context(|| format!("hash {}", path.display()))?;
+                out.insert(rel, hash);
+            }
+            // symlinks: skipped, see module docs
+        }
+    }
+    Ok(out)
+}
+
+/// Compare two hashed trees. Deterministic order so output is diffable.
+pub fn diff_trees(
+    on_disk: &BTreeMap<String, String>,
+    fresh: &BTreeMap<String, String>,
+) -> Vec<Difference> {
+    let mut diffs = Vec::new();
+    for (path, hash) in on_disk {
+        match fresh.get(path) {
+            None => diffs.push(Difference::Added(path.clone())),
+            Some(other) if other != hash => diffs.push(Difference::Modified(path.clone())),
+            Some(_) => {}
+        }
+    }
+    for path in fresh.keys() {
+        if !on_disk.contains_key(path) {
+            diffs.push(Difference::Removed(path.clone()));
+        }
+    }
+    diffs.sort_by(|a, b| a.path().cmp(b.path()));
+    diffs
+}
+
+/// Reinstall `install_dir`'s lockfile into `scratch` with `npm ci`.
+fn reinstall_from_lockfile(install_dir: &Path, scratch: &Path) -> Result<()> {
+    for f in ["package.json", "package-lock.json"] {
+        let src = install_dir.join(f);
+        std::fs::copy(&src, scratch.join(f))
+            .with_context(|| format!("copy {} into the audit scratch dir", src.display()))?;
+    }
+    let out = std::process::Command::new("npm")
+        .args([
+            "ci",
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+            "--loglevel=error",
+        ])
+        .current_dir(scratch)
+        .output()
+        .map_err(|e| anyhow::anyhow!("run npm ci: {e} (is npm on PATH?)"))?;
+    if !out.status.success() {
+        bail!(
+            "npm ci from the pinned lockfile failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim(),
+        );
+    }
+    Ok(())
+}
+
+/// Re-derive the vendored tree from the registry and report what differs.
+///
+/// Returns the differences; an empty vec means the install matches a clean one
+/// byte for byte.
+pub fn audit_vendored_install(install_dir: &Path) -> Result<Vec<Difference>> {
+    if !install_dir.join("package-lock.json").is_file() {
+        bail!(
+            "no lockfile at {} — nothing to re-derive from",
+            install_dir.display(),
+        );
+    }
+    let scratch = tempfile::tempdir().context("create audit scratch dir")?;
+    reinstall_from_lockfile(install_dir, scratch.path())?;
+
+    let on_disk = hash_tree(&install_dir.join("node_modules"))?;
+    let fresh = hash_tree(&scratch.path().join("node_modules"))?;
+    Ok(diff_trees(&on_disk, &fresh))
+}
+
+/// Render the audit for one entry. Returns true when the tree is clean.
+pub fn report(server_name: &str, install_dir: &Path) -> bool {
+    println!("Deep audit of `{server_name}` ({})", install_dir.display());
+    println!("  reinstalling from the pinned lockfile…");
+    match audit_vendored_install(install_dir) {
+        Ok(diffs) if diffs.is_empty() => {
+            println!("  status:         CLEAN — matches a fresh install of the same lockfile");
+            true
+        }
+        Ok(diffs) => {
+            println!(
+                "  status:         TAMPERED — {} file(s) differ",
+                diffs.len()
+            );
+            for d in diffs.iter().take(20) {
+                println!("    {:<16} {}", d.label(), d.path());
+            }
+            if diffs.len() > 20 {
+                println!("    … and {} more", diffs.len() - 20);
+            }
+            println!(
+                "  hint:           `mur agent mcp vendor <agent> {server_name}` reinstalls a \
+                 clean tree and re-records the pin.",
+            );
+            false
+        }
+        Err(e) => {
+            // An audit that could not run is not a verdict either way, and must
+            // not be reported as one.
+            println!("  status:         NOT AUDITED — {e}");
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tree(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(p, h)| (p.to_string(), h.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn an_identical_tree_has_no_differences() {
+        let a = tree(&[("pkg/index.js", "aaa"), ("pkg/lib.js", "bbb")]);
+        assert!(diff_trees(&a, &a).is_empty());
+    }
+
+    /// The case the whole check exists for: a file edited in place after
+    /// install, which leaves the lockfile — and therefore the startup pin —
+    /// completely untouched.
+    #[test]
+    fn an_edited_file_is_reported_as_modified() {
+        let disk = tree(&[("pkg/index.js", "tampered")]);
+        let fresh = tree(&[("pkg/index.js", "original")]);
+        assert_eq!(
+            diff_trees(&disk, &fresh),
+            vec![Difference::Modified("pkg/index.js".into())],
+        );
+    }
+
+    #[test]
+    fn extra_and_missing_files_are_distinguished() {
+        let disk = tree(&[("pkg/index.js", "a"), ("pkg/backdoor.js", "x")]);
+        let fresh = tree(&[("pkg/index.js", "a"), ("pkg/helper.js", "h")]);
+        assert_eq!(
+            diff_trees(&disk, &fresh),
+            vec![
+                Difference::Added("pkg/backdoor.js".into()),
+                Difference::Removed("pkg/helper.js".into()),
+            ],
+            "an injected file and a deleted one are different findings",
+        );
+    }
+
+    #[test]
+    fn output_order_is_deterministic() {
+        let disk = tree(&[("z", "1"), ("a", "1"), ("m", "2")]);
+        let fresh = tree(&[("m", "3")]);
+        let diffs = diff_trees(&disk, &fresh);
+        let paths: Vec<&str> = diffs.iter().map(|d| d.path()).collect();
+        assert_eq!(paths, vec!["a", "m", "z"], "sorted so runs are comparable");
+    }
+
+    #[test]
+    fn hash_tree_walks_nested_dirs_and_skips_symlinks() {
+        let d = tempfile::tempdir().unwrap();
+        let deep = d.path().join("a/b/c");
+        std::fs::create_dir_all(&deep).unwrap();
+        std::fs::write(deep.join("f.js"), b"content").unwrap();
+        std::fs::write(d.path().join("top.js"), b"top").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(d.path().join("top.js"), d.path().join("link.js")).unwrap();
+
+        let t = hash_tree(d.path()).unwrap();
+        assert!(t.contains_key("a/b/c/f.js"), "nested files must be walked");
+        assert!(t.contains_key("top.js"));
+        #[cfg(unix)]
+        assert!(
+            !t.contains_key("link.js"),
+            "symlinks are regenerated per install; see module docs",
+        );
+    }
+
+    #[test]
+    fn a_missing_tree_hashes_to_empty_rather_than_erroring() {
+        let d = tempfile::tempdir().unwrap();
+        assert!(
+            hash_tree(&d.path().join("node_modules"))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn auditing_without_a_lockfile_is_an_error_not_a_clean_verdict() {
+        let d = tempfile::tempdir().unwrap();
+        let err = audit_vendored_install(d.path()).unwrap_err().to_string();
+        assert!(err.contains("no lockfile"), "got: {err}");
+    }
+}

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -471,7 +471,12 @@ pub async fn inspect_one_probed(
 /// `mur agent mcp inspect <name> [--server <id>]`. Without `--server`,
 /// prints all MCPs on the agent and returns the WORST status (highest
 /// numeric value) so a scripted caller knows whether ANY MCP drifted.
-pub fn cmd_mcp_inspect(name: &str, server_id: Option<&str>, probe: bool) -> Result<i32> {
+pub fn cmd_mcp_inspect(
+    name: &str,
+    server_id: Option<&str>,
+    probe: bool,
+    deep: bool,
+) -> Result<i32> {
     let (_path, profile) = crate::cmd::agent::load_profile_for_edit(name)?;
     if profile.mcp_servers.is_empty() {
         println!("Agent `{name}` has no MCP servers configured.");
@@ -497,6 +502,27 @@ pub fn cmd_mcp_inspect(name: &str, server_id: Option<&str>, probe: bool) -> Resu
             inspect_one(entry) as u8
         };
         worst = worst.max(status);
+
+        // The deep pass re-derives the tree from the registry, so it can see
+        // what a locally-stored hash cannot: an edited file leaves the lockfile
+        // — and therefore the startup pin — untouched.
+        if deep {
+            match &entry.package {
+                Some(pkg) => {
+                    println!();
+                    let clean = crate::cmd::agent_mcp_deep_audit::report(
+                        &entry.name,
+                        std::path::Path::new(&pkg.install_dir),
+                    );
+                    if !clean {
+                        worst = worst.max(InspectStatus::BinaryDrift as u8);
+                    }
+                }
+                None => {
+                    println!("  deep audit:     n/a — only vendored entries can be re-derived");
+                }
+            }
+        }
         printed = true;
     }
     if !printed && let Some(id) = server_id {

--- a/mur-core/src/cmd/mod.rs
+++ b/mur-core/src/cmd/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod agent_history;
 /// A1 — hooks show [--json] CLI verb.
 pub mod agent_hooks;
 /// B0 M9.2 — install-time MCP hash + publisher prompt for `mur agent mcp add`.
+pub(crate) mod agent_mcp_deep_audit;
 pub(crate) mod agent_mcp_pin;
 pub(crate) mod agent_mcp_vendor;
 pub mod agent_pair;

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1595,8 +1595,10 @@ async fn run_agent(action: AgentAction) -> Result<()> {
                 name,
                 server,
                 probe,
+                deep,
             } => {
-                let code = cmd::agent_mcp_pin::cmd_mcp_inspect(&name, server.as_deref(), probe)?;
+                let code =
+                    cmd::agent_mcp_pin::cmd_mcp_inspect(&name, server.as_deref(), probe, deep)?;
                 if code != 0 {
                     std::process::exit(code);
                 }


### PR DESCRIPTION
Third item from #796, after #798 (signatures) and #799 (provenance).

## Why this one is different from every other check here

`binary_sha256` and `lockfile_sha256` both live in `profile.yaml` — writable by the same principal as the files they describe. An attacker who can edit `node_modules` can edit the recorded hash just as easily. That makes those checks **change detection** (a package manager re-resolved, an upgrade swapped a binary), not defence against an adversary, which #796 records as the constraint shaping this whole area.

`--deep` is the exception. It reinstalls from the pinned lockfile and diffs against **what the registry serves now**, so its reference value isn't on the machine being audited. It is the only check here that catches a locally-edited tree even when the pin was edited to match.

```bash
mur agent mcp inspect coach --server fetch-mcp --deep
```

```
Deep audit of `fetch-mcp` (~/.mur/mcp-packages/coach/fetch-mcp)
  reinstalling from the pinned lockfile…
  status:         TAMPERED — 1 file(s) differ
    contents differ  @yawlabs/fetch-mcp/dist/index.js
  hint:           `mur agent mcp vendor coach fetch-mcp` reinstalls a clean tree and re-records the pin.
```

A command rather than a startup check, because it costs a full reinstall — paying that at every agent start to reach a threat the other checks structurally cannot see is the wrong trade.

## The assumption this rests on, measured

If `npm ci` were not byte-reproducible, the audit would report TAMPERED on every clean tree and be worse than useless. So it was checked against the real package rather than assumed:

```
$ npm install @yawlabs/fetch-mcp@0.3.6     # then, from its lockfile:
$ npm ci --ignore-scripts                  # into a clean dir
files: original=4876  fresh=4876
diff: (empty — byte-identical)
```

## Scope, stated rather than implied

Regular files under `node_modules`, by content. **Symlinks are skipped** — npm's `.bin` shims are regenerated per install from metadata the lockfile already covers. A tampered shim is out of scope for this pass; the module docs say so instead of leaving a reader to assume coverage.

An audit that cannot run (no lockfile, no npm, offline) reports `NOT AUDITED`, not a pass and not a failure, because neither would be true.

## Verification

`cargo test -p mur-core --lib agent_mcp_deep_audit` — 7 passed:

- the case the check exists for: an edited file → `Modified`, which by construction leaves the lockfile and the startup pin untouched
- an injected file and a deleted one are **distinct findings**, not both "differs"
- deterministic sorted output so two runs are comparable
- the tree walk recurses and skips symlinks, using `symlink_metadata` so a symlinked directory can't send it outside the tree
- a missing `node_modules` hashes to empty rather than erroring
- auditing without a lockfile is an **error, not a clean verdict**

`cargo test --workspace --locked --no-run` and `cargo clippy -p mur-core --lib -- -D warnings` clean.

Remaining in #796: uvx/Python, which still has no coverage at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)