### PR TITLE
feat(mcp): extend vendoring, pinning and deep audit to uvx / PyPI servers

### DIFF
--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -97,7 +97,7 @@ pub fn verify_mcp_supply_chain(
         // changed it. Checked before the interpreter skip below, which would
         // otherwise wave through the very case made verifiable on purpose.
         if let Some(pkg) = &entry.package {
-            let lock = std::path::Path::new(&pkg.install_dir).join("package-lock.json");
+            let lock = pkg.lockfile_path();
             match crate::hooks::b0_helpers::binary_sha256(&lock) {
                 Ok(actual) if actual.eq_ignore_ascii_case(&pkg.lockfile_sha256) => {
                     tracing::debug!(mcp = %entry.name, "B0 rule 6: vendored package verified");

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -397,6 +397,30 @@ pub struct McpPackagePin {
     pub provenance: Option<String>,
 }
 
+impl McpPackagePin {
+    /// Name of the lockfile whose hash is `lockfile_sha256`.
+    ///
+    /// npm writes `package-lock.json` itself; for PyPI, MUR generates one with
+    /// `uv pip compile --generate-hashes`, which records a sha256 for every
+    /// package in the resolved tree — the same property that lets one small
+    /// file stand in for the whole install.
+    pub fn lockfile_name(&self) -> &'static str {
+        match self.runner.as_str() {
+            "pypi" => "requirements.lock",
+            _ => "package-lock.json",
+        }
+    }
+
+    /// Absolute path of the lockfile this pin covers.
+    ///
+    /// The startup check, `inspect`, and the deep audit all resolve it through
+    /// here, so a newly supported ecosystem cannot end up verified against the
+    /// wrong file in one of them and silently pass.
+    pub fn lockfile_path(&self) -> std::path::PathBuf {
+        std::path::Path::new(&self.install_dir).join(self.lockfile_name())
+    }
+}
+
 /// Authentication scheme for a remote (HTTP) MCP server.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case", tag = "kind")]

--- a/mur-common/src/mcp_package.rs
+++ b/mur-common/src/mcp_package.rs
@@ -111,31 +111,98 @@ fn split_spec(arg_index: usize, spec: &str) -> PackageSpec {
 /// This records what the user is approving at pin time; it is not a trust
 /// decision about the registry.
 pub fn resolve_current_version(runner: Runner, name: &str) -> Result<String> {
-    let (program, args) = match runner {
-        Runner::Npm => (
-            "npm",
-            vec!["view".to_string(), name.to_string(), "version".to_string()],
-        ),
-        Runner::Python => bail!(
-            "resolving a current version for uvx packages is not implemented; \
-             pass an explicit `{name}==<version>` in args"
-        ),
-    };
-    let out = std::process::Command::new(program)
-        .args(&args)
-        .output()
-        .map_err(|e| anyhow::anyhow!("run `{program} view {name} version`: {e}"))?;
-    if !out.status.success() {
-        bail!(
-            "`{program} view {name} version` failed: {}",
-            String::from_utf8_lossy(&out.stderr).trim(),
-        );
+    match runner {
+        Runner::Npm => {
+            let out = std::process::Command::new("npm")
+                .args(["view", name, "version"])
+                .output()
+                .map_err(|e| anyhow::anyhow!("run `npm view {name} version`: {e}"))?;
+            if !out.status.success() {
+                bail!(
+                    "`npm view {name} version` failed: {}",
+                    String::from_utf8_lossy(&out.stderr).trim(),
+                );
+            }
+            let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if v.is_empty() {
+                bail!("`npm view {name} version` returned nothing");
+            }
+            Ok(v)
+        }
+        // uv has no "what version would you pick" query, so resolve the way an
+        // install would and read the answer back out of the resolution. Using
+        // the resolver rather than a registry query means the recorded version
+        // is the one uv would actually install, including any yanked-release
+        // or requires-python filtering it applies.
+        Runner::Python => {
+            let dir = tempfile::tempdir().map_err(|e| anyhow::anyhow!("temp dir: {e}"))?;
+            let req_in = dir.path().join("req.in");
+            std::fs::write(&req_in, format!("{name}\n"))
+                .map_err(|e| anyhow::anyhow!("write {}: {e}", req_in.display()))?;
+            let out = std::process::Command::new("uv")
+                .args(["pip", "compile", "req.in", "-o", "req.lock"])
+                .current_dir(dir.path())
+                .output()
+                .map_err(|e| anyhow::anyhow!("run uv pip compile: {e} (is uv on PATH?)"))?;
+            if !out.status.success() {
+                bail!(
+                    "`uv pip compile` could not resolve `{name}`: {}",
+                    String::from_utf8_lossy(&out.stderr).trim(),
+                );
+            }
+            let body = std::fs::read_to_string(dir.path().join("req.lock"))
+                .map_err(|e| anyhow::anyhow!("read resolved lockfile: {e}"))?;
+            pinned_version_of(&body, name)
+                .ok_or_else(|| anyhow::anyhow!("`{name}` did not appear in uv's resolution"))
+        }
     }
-    let v = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if v.is_empty() {
-        bail!("`{program} view {name} version` returned nothing");
+}
+
+/// Find `name==version` for `name` in a `uv pip compile` lockfile.
+///
+/// Distribution names normalise loosely — `Foo.Bar` and `foo-bar` are the same
+/// project — so matching has to normalise too, or a package would resolve fine
+/// and then look absent.
+pub fn pinned_version_of(lockfile: &str, name: &str) -> Option<String> {
+    let want = normalize_dist_name(name);
+    for line in lockfile.lines() {
+        let line = line.trim();
+        // A lockfile is mostly not pins: blank lines, `# via` comments, and
+        // `--hash=` continuations. Each has to be skipped, not treated as the
+        // end of the search — `?` here would abandon the whole file at the
+        // first one.
+        if line.is_empty() || line.starts_with('#') || line.starts_with("--") {
+            continue;
+        }
+        let Some(spec) = line.split_whitespace().next() else {
+            continue;
+        };
+        let Some((pkg, version)) = spec.split_once("==") else {
+            continue;
+        };
+        if normalize_dist_name(pkg) == want {
+            return Some(version.trim_end_matches('\\').trim().to_string());
+        }
     }
-    Ok(v)
+    None
+}
+
+/// PEP 503 name normalisation: lowercase, runs of `-_.` collapse to `-`.
+fn normalize_dist_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut last_dash = false;
+    for c in name.chars() {
+        if matches!(c, '-' | '_' | '.') {
+            if !last_dash {
+                out.push('-');
+                last_dash = true;
+            }
+        } else {
+            out.extend(c.to_lowercase());
+            last_dash = false;
+        }
+    }
+    out
 }
 
 /// The runner behind a command, for callers that already know it's one.
@@ -207,5 +274,54 @@ mod tests {
             let s = split_spec(0, raw);
             assert_eq!(s.to_arg(), raw);
         }
+    }
+
+    // ── uv resolution ───────────────────────────────────────────────────────
+
+    /// Real `uv pip compile --generate-hashes` output: continuation
+    /// backslashes, hash lines, and `# via` comments around the spec.
+    const UV_LOCK: &str = r#"
+# This file was autogenerated by uv via the following command:
+#    uv pip compile req.in --generate-hashes -o req.lock
+annotated-types==0.8.0 \
+    --hash=sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7
+    # via pydantic
+mcp-server-time==0.6.2 \
+    --hash=sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b
+    # via -r req.in
+"#;
+
+    #[test]
+    fn reads_the_pinned_version_out_of_a_uv_lockfile() {
+        assert_eq!(
+            pinned_version_of(UV_LOCK, "mcp-server-time").as_deref(),
+            Some("0.6.2"),
+        );
+        assert_eq!(
+            pinned_version_of(UV_LOCK, "annotated-types").as_deref(),
+            Some("0.8.0"),
+            "transitive deps are pinned in the same file",
+        );
+        assert_eq!(pinned_version_of(UV_LOCK, "absent-pkg"), None);
+    }
+
+    /// PEP 503: `Foo.Bar`, `foo_bar` and `foo-bar` are one project. Without
+    /// normalising, a package would resolve fine and then read as missing.
+    #[test]
+    fn distribution_names_match_across_spelling() {
+        for spelling in ["mcp_server_time", "MCP-Server-Time", "mcp.server.time"] {
+            assert_eq!(
+                pinned_version_of(UV_LOCK, spelling).as_deref(),
+                Some("0.6.2"),
+                "`{spelling}` names the same project",
+            );
+        }
+    }
+
+    #[test]
+    fn comments_are_never_mistaken_for_a_pin() {
+        let lock = "# uv pip compile foo==1.0.0\nbar==2.0.0\n";
+        assert_eq!(pinned_version_of(lock, "foo"), None, "that was a comment");
+        assert_eq!(pinned_version_of(lock, "bar").as_deref(), Some("2.0.0"));
     }
 }

--- a/mur-core/src/cmd/agent_mcp_deep_audit.rs
+++ b/mur-core/src/cmd/agent_mcp_deep_audit.rs
@@ -22,13 +22,15 @@
 //!
 //! ## What it compares
 //!
-//! Regular files under `node_modules`, by content. Symlinks (npm's `.bin`
+//! Regular files under the installed tree (`node_modules` for npm,
+//! `venv/lib/python*/site-packages` for PyPI), by content. Symlinks (npm's `.bin`
 //! shims) are skipped: they are regenerated per install and their targets are
 //! derived from the same package metadata already covered by the lockfile.
 //! A tampered shim is therefore out of scope for this pass, and saying so is
 //! better than implying a coverage that isn't there.
 
 use anyhow::{Context, Result, bail};
+use mur_common::agent::McpPackagePin;
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -155,26 +157,88 @@ fn reinstall_from_lockfile(install_dir: &Path, scratch: &Path) -> Result<()> {
 ///
 /// Returns the differences; an empty vec means the install matches a clean one
 /// byte for byte.
-pub fn audit_vendored_install(install_dir: &Path) -> Result<Vec<Difference>> {
-    if !install_dir.join("package-lock.json").is_file() {
+pub fn audit_vendored_install(pin: &McpPackagePin) -> Result<Vec<Difference>> {
+    let install_dir = Path::new(&pin.install_dir);
+    if !pin.lockfile_path().is_file() {
         bail!(
-            "no lockfile at {} — nothing to re-derive from",
+            "no {} at {} — nothing to re-derive from",
+            pin.lockfile_name(),
             install_dir.display(),
         );
     }
     let scratch = tempfile::tempdir().context("create audit scratch dir")?;
-    reinstall_from_lockfile(install_dir, scratch.path())?;
+    let (installed_subdir, fresh_subdir) = match pin.runner.as_str() {
+        "pypi" => {
+            uv_reinstall_from_lockfile(install_dir, scratch.path())?;
+            (site_packages(install_dir)?, site_packages(scratch.path())?)
+        }
+        _ => {
+            reinstall_from_lockfile(install_dir, scratch.path())?;
+            (
+                install_dir.join("node_modules"),
+                scratch.path().join("node_modules"),
+            )
+        }
+    };
 
-    let on_disk = hash_tree(&install_dir.join("node_modules"))?;
-    let fresh = hash_tree(&scratch.path().join("node_modules"))?;
+    let on_disk = hash_tree(&installed_subdir)?;
+    let fresh = hash_tree(&fresh_subdir)?;
     Ok(diff_trees(&on_disk, &fresh))
 }
 
+/// Reinstall the pinned Python set into `scratch`'s own venv.
+///
+/// `--require-hashes` means uv re-verifies every hash in the lockfile as it
+/// installs, so a package whose bytes changed upstream fails here rather than
+/// showing up as a diff.
+fn uv_reinstall_from_lockfile(install_dir: &Path, scratch: &Path) -> Result<()> {
+    let lock = install_dir.join("requirements.lock");
+    std::fs::copy(&lock, scratch.join("requirements.lock"))
+        .with_context(|| format!("copy {} into the audit scratch dir", lock.display()))?;
+    let out = std::process::Command::new("uv")
+        .args(["venv", "venv", "--quiet"])
+        .current_dir(scratch)
+        .output()
+        .map_err(|e| anyhow::anyhow!("run uv venv: {e} (is uv on PATH?)"))?;
+    if !out.status.success() {
+        bail!(
+            "uv venv failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    let out = std::process::Command::new("uv")
+        .args(["pip", "install", "--python"])
+        .arg(scratch.join("venv").join("bin").join("python"))
+        .args(["--require-hashes", "-r", "requirements.lock", "--quiet"])
+        .current_dir(scratch)
+        .output()
+        .map_err(|e| anyhow::anyhow!("run uv pip install: {e}"))?;
+    if !out.status.success() {
+        bail!(
+            "uv reinstall from the pinned lockfile failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim(),
+        );
+    }
+    Ok(())
+}
+
+/// A venv's `site-packages`, whose path carries the interpreter version.
+fn site_packages(root: &Path) -> Result<std::path::PathBuf> {
+    let lib = root.join("venv").join("lib");
+    let entry = std::fs::read_dir(&lib)
+        .with_context(|| format!("read {}", lib.display()))?
+        .filter_map(|e| e.ok())
+        .find(|e| e.file_name().to_string_lossy().starts_with("python"))
+        .ok_or_else(|| anyhow::anyhow!("no python*/ under {}", lib.display()))?;
+    Ok(entry.path().join("site-packages"))
+}
+
 /// Render the audit for one entry. Returns true when the tree is clean.
-pub fn report(server_name: &str, install_dir: &Path) -> bool {
+pub fn report(server_name: &str, pin: &McpPackagePin) -> bool {
+    let install_dir = Path::new(&pin.install_dir);
     println!("Deep audit of `{server_name}` ({})", install_dir.display());
-    println!("  reinstalling from the pinned lockfile…");
-    match audit_vendored_install(install_dir) {
+    println!("  reinstalling from the pinned {}…", pin.lockfile_name());
+    match audit_vendored_install(pin) {
         Ok(diffs) if diffs.is_empty() => {
             println!("  status:         CLEAN — matches a fresh install of the same lockfile");
             true
@@ -293,10 +357,37 @@ mod tests {
         );
     }
 
+    fn pin_for(dir: &Path, runner: &str) -> McpPackagePin {
+        McpPackagePin {
+            runner: runner.into(),
+            name: "x".into(),
+            version: "1".into(),
+            install_dir: dir.display().to_string(),
+            lockfile_sha256: "h".into(),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn auditing_without_a_lockfile_is_an_error_not_a_clean_verdict() {
         let d = tempfile::tempdir().unwrap();
-        let err = audit_vendored_install(d.path()).unwrap_err().to_string();
-        assert!(err.contains("no lockfile"), "got: {err}");
+        let err = audit_vendored_install(&pin_for(d.path(), "npm"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("package-lock.json"), "got: {err}");
+    }
+
+    /// The error has to name the runner's own lockfile. Looking for
+    /// `package-lock.json` in a Python install would find nothing — and a
+    /// missing file reads as "install gone", so the mistake would pass quietly
+    /// instead of failing.
+    #[test]
+    fn the_missing_lockfile_error_names_the_runners_own_file() {
+        let d = tempfile::tempdir().unwrap();
+        let err = audit_vendored_install(&pin_for(d.path(), "pypi"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("requirements.lock"), "got: {err}");
+        assert!(!err.contains("package-lock.json"), "got: {err}");
     }
 }

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -247,7 +247,7 @@ pub fn binary_status(entry: &mur_common::agent::McpServerEntry) -> InspectStatus
     // `node` that runs it — check that first, or the interpreter branch below
     // would report the one verifiable shape as unprotected.
     if let Some(pkg) = &entry.package {
-        let lock = std::path::Path::new(&pkg.install_dir).join("package-lock.json");
+        let lock = pkg.lockfile_path();
         let Ok(actual) = compute_binary_sha256(&lock) else {
             return InspectStatus::BinaryMissing;
         };
@@ -318,7 +318,7 @@ pub fn inspect_one(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
             None => println!("  provenance:     none published by this release"),
         }
         println!("  pinned lock:    {}", pkg.lockfile_sha256);
-        let lock = std::path::Path::new(&pkg.install_dir).join("package-lock.json");
+        let lock = pkg.lockfile_path();
         let Ok(actual) = compute_binary_sha256(&lock) else {
             println!("  current lock:   <not readable — install missing?>");
             println!(

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -525,10 +525,7 @@ pub fn cmd_mcp_inspect(
             match &entry.package {
                 Some(pkg) => {
                     println!();
-                    let clean = crate::cmd::agent_mcp_deep_audit::report(
-                        &entry.name,
-                        std::path::Path::new(&pkg.install_dir),
-                    );
+                    let clean = crate::cmd::agent_mcp_deep_audit::report(&entry.name, pkg);
                     if !clean {
                         worst = worst.max(InspectStatus::BinaryDrift as u8);
                     }

--- a/mur-core/src/cmd/agent_mcp_pin.rs
+++ b/mur-core/src/cmd/agent_mcp_pin.rs
@@ -306,16 +306,27 @@ pub fn inspect_one(entry: &mur_common::agent::McpServerEntry) -> InspectStatus {
             pkg.name, pkg.version, pkg.runner
         );
         println!("  install dir:    {}", pkg.install_dir);
-        match pkg.signatures_missing {
-            Some(0) => println!("  signatures:     all verified against the registry at install"),
-            Some(n) => {
-                println!("  signatures:     verified, except {n} package(s) publishing none")
+        // npm-specific findings, in npm's terms. A PyPI install verifies every
+        // hash through uv at install time and is never asked about
+        // attestations, so borrowing this wording would report checks that
+        // never ran.
+        if pkg.runner == "pypi" {
+            println!("  hashes:         verified by uv at install (--require-hashes)");
+            println!("  provenance:     not queried for PyPI");
+        } else {
+            match pkg.signatures_missing {
+                Some(0) => {
+                    println!("  signatures:     all verified against the registry at install")
+                }
+                Some(n) => {
+                    println!("  signatures:     verified, except {n} package(s) publishing none")
+                }
+                None => println!("  signatures:     not audited at install"),
             }
-            None => println!("  signatures:     not audited at install"),
-        }
-        match &pkg.provenance {
-            Some(p) => println!("  provenance:     {p}"),
-            None => println!("  provenance:     none published by this release"),
+            match &pkg.provenance {
+                Some(p) => println!("  provenance:     {p}"),
+                None => println!("  provenance:     none published by this release"),
+            }
         }
         println!("  pinned lock:    {}", pkg.lockfile_sha256);
         let lock = pkg.lockfile_path();

--- a/mur-core/src/cmd/agent_mcp_vendor.rs
+++ b/mur-core/src/cmd/agent_mcp_vendor.rs
@@ -49,6 +49,189 @@ pub fn lockfile_sha256(install_dir: &Path) -> Result<String> {
         .with_context(|| format!("hash {}", lock.display()))
 }
 
+// ── PyPI / uv ───────────────────────────────────────────────────────────────
+//
+// Same shape as the npm path, one ecosystem over:
+//
+//   requirements.lock  ← `uv pip compile --generate-hashes` (a sha256 per
+//                        package across the resolved tree)
+//   venv/              ← `uv pip install --require-hashes`, which verifies
+//                        every one of those hashes as it installs — a check
+//                        npm's install does not perform
+//   launch             ← `venv/bin/<console-script>`
+//
+// A venv rather than `--target`: scripts written into a `--target` directory
+// do a bare `from pkg import main` with no `sys.path` handling, so they only
+// run when PYTHONPATH points at the target — and `McpServerEntry` has no env
+// to set it in. A venv's script execs the venv's own interpreter and runs from
+// anywhere with an empty environment.
+
+/// Resolve `name==version` into `requirements.lock` with a hash per package.
+fn uv_compile(dir: &Path, name: &str, version: &str) -> Result<()> {
+    std::fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
+    std::fs::write(dir.join("requirements.in"), format!("{name}=={version}\n"))
+        .context("write requirements.in")?;
+    let out = std::process::Command::new("uv")
+        .args([
+            "pip",
+            "compile",
+            "requirements.in",
+            "--generate-hashes",
+            "-o",
+            "requirements.lock",
+            "--quiet",
+        ])
+        .current_dir(dir)
+        .output()
+        .map_err(|e| anyhow::anyhow!("run uv pip compile: {e} (is uv on PATH?)"))?;
+    if !out.status.success() {
+        bail!(
+            "uv could not resolve {name}=={version}: {}",
+            String::from_utf8_lossy(&out.stderr).trim(),
+        );
+    }
+    Ok(())
+}
+
+/// Create the venv and install the locked set into it, hashes enforced.
+fn uv_install(dir: &Path) -> Result<PathBuf> {
+    let venv = dir.join("venv");
+    let out = std::process::Command::new("uv")
+        .args(["venv", "venv", "--quiet"])
+        .current_dir(dir)
+        .output()
+        .map_err(|e| anyhow::anyhow!("run uv venv: {e}"))?;
+    if !out.status.success() {
+        bail!(
+            "uv venv failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    let python = venv.join("bin").join("python");
+    let out = std::process::Command::new("uv")
+        .args(["pip", "install", "--python"])
+        .arg(&python)
+        .args(["--require-hashes", "-r", "requirements.lock", "--quiet"])
+        .current_dir(dir)
+        .output()
+        .map_err(|e| anyhow::anyhow!("run uv pip install: {e}"))?;
+    if !out.status.success() {
+        bail!(
+            "uv pip install failed (hashes are enforced, so this includes a \
+             hash mismatch): {}",
+            String::from_utf8_lossy(&out.stderr).trim(),
+        );
+    }
+    Ok(venv)
+}
+
+/// Find the console script the package installed into the venv.
+///
+/// Read from the package's own `entry_points.txt` rather than guessing at
+/// `bin/<name>`: a distribution's script is frequently named differently from
+/// the distribution (`mcp-server-time` vs `mcp_server_time`), and picking the
+/// wrong file would launch someone else's program.
+fn resolve_console_script(venv: &Path, name: &str) -> Result<PathBuf> {
+    let normalized = name.to_lowercase().replace(['-', '.'], "_");
+    let site = glob_site_packages(venv)?;
+    let mut entry_points = None;
+    for entry in std::fs::read_dir(&site)
+        .with_context(|| format!("read {}", site.display()))?
+        .filter_map(|e| e.ok())
+    {
+        let file_name = entry.file_name().to_string_lossy().to_lowercase();
+        if file_name.ends_with(".dist-info")
+            && file_name
+                .replace('-', "_")
+                .starts_with(&format!("{normalized}_"))
+        {
+            entry_points = Some(entry.path().join("entry_points.txt"));
+            break;
+        }
+    }
+    let ep = entry_points
+        .filter(|p| p.is_file())
+        .ok_or_else(|| anyhow::anyhow!("`{name}` installed no entry_points.txt to launch from"))?;
+
+    let body = std::fs::read_to_string(&ep).with_context(|| format!("read {}", ep.display()))?;
+    let scripts = console_scripts(&body);
+    let script = match scripts.len() {
+        0 => bail!("`{name}` declares no console script, so there is nothing to launch"),
+        1 => scripts[0].clone(),
+        _ => bail!(
+            "`{name}` declares {} console scripts ({}); vendoring needs exactly one",
+            scripts.len(),
+            scripts.join(", "),
+        ),
+    };
+    let path = venv.join("bin").join(&script);
+    if !path.is_file() {
+        bail!(
+            "console script `{script}` is missing from {}",
+            venv.display()
+        );
+    }
+    path.canonicalize()
+        .with_context(|| format!("canonicalize {}", path.display()))
+}
+
+/// Script names under `[console_scripts]` in an `entry_points.txt`.
+fn console_scripts(body: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut in_section = false;
+    for line in body.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            in_section = line == "[console_scripts]";
+            continue;
+        }
+        if in_section && let Some((name, _)) = line.split_once('=') {
+            let name = name.trim();
+            if !name.is_empty() {
+                out.push(name.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// The venv's `site-packages`, whose path carries the interpreter version.
+fn glob_site_packages(venv: &Path) -> Result<PathBuf> {
+    let lib = venv.join("lib");
+    let entry = std::fs::read_dir(&lib)
+        .with_context(|| format!("read {}", lib.display()))?
+        .filter_map(|e| e.ok())
+        .find(|e| e.file_name().to_string_lossy().starts_with("python"))
+        .ok_or_else(|| anyhow::anyhow!("no python*/ under {}", lib.display()))?;
+    Ok(entry.path().join("site-packages"))
+}
+
+/// Vendor a PyPI package: resolve with hashes, install into a venv that
+/// verifies them, and point the entry at the console script.
+fn vendor_python(entry: &mut McpServerEntry, dir: &Path, name: &str, version: &str) -> Result<()> {
+    uv_compile(dir, name, version)?;
+    let venv = uv_install(dir)?;
+    let script = resolve_console_script(&venv, name)?;
+    let lock = crate::cmd::agent_mcp_pin::compute_binary_sha256(&dir.join("requirements.lock"))
+        .context("hash requirements.lock")?;
+
+    entry.command = script.display().to_string();
+    entry.args = vec![];
+    entry.binary_sha256 = None;
+    entry.package = Some(McpPackagePin {
+        runner: "pypi".into(),
+        name: name.to_string(),
+        version: version.to_string(),
+        install_dir: dir.display().to_string(),
+        lockfile_sha256: lock,
+        // uv enforced every hash during install; there is no separate registry
+        // signature step to record, and PyPI attestations aren't queried here.
+        signatures_missing: None,
+        provenance: None,
+    });
+    Ok(())
+}
+
 /// Install `name@version` into `dir` with npm, scripts disabled.
 fn npm_install(dir: &Path, name: &str, version: &str) -> Result<()> {
     std::fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
@@ -235,6 +418,13 @@ pub fn vendor_entry(
     version: &str,
 ) -> Result<PathBuf> {
     let dir = install_dir(mur_home, agent, &entry.name);
+    if matches!(
+        mur_common::mcp_package::runner_for(&entry.command),
+        Some(mur_common::mcp_package::Runner::Python)
+    ) {
+        vendor_python(entry, &dir, name, version)?;
+        return Ok(dir);
+    }
     npm_install(&dir, name, version)?;
 
     let audit = audit_signatures(&dir)?;
@@ -533,5 +723,53 @@ mod tests {
             "no predicateType"
         );
         assert_eq!(parse_provenance("npm ERR! 404"), None);
+    }
+
+    // ── PyPI console scripts ────────────────────────────────────────────────
+
+    /// Real `entry_points.txt` from mcp-server-time, installed via uv.
+    #[test]
+    fn reads_the_console_script_from_entry_points() {
+        let body = "[console_scripts]\nmcp-server-time = mcp_server_time:main\n";
+        assert_eq!(console_scripts(body), vec!["mcp-server-time".to_string()]);
+    }
+
+    /// Other sections declare entry points that are not launchable servers;
+    /// treating a `gui_scripts` entry or a pytest plugin as the server would
+    /// launch the wrong program.
+    #[test]
+    fn only_console_scripts_count() {
+        let body = "[console_scripts]\nreal-server = pkg:main\n\n[gui_scripts]\nnot-a-server = pkg:gui\n\n[pytest11]\nplugin = pkg.plugin\n";
+        assert_eq!(console_scripts(body), vec!["real-server".to_string()]);
+    }
+
+    #[test]
+    fn several_console_scripts_are_ambiguous_and_the_caller_must_refuse() {
+        let body = "[console_scripts]\na = pkg:a\nb = pkg:b\n";
+        assert_eq!(console_scripts(body).len(), 2);
+    }
+
+    #[test]
+    fn no_console_scripts_section_yields_nothing() {
+        assert!(console_scripts("[gui_scripts]\nx = pkg:x\n").is_empty());
+        assert!(console_scripts("").is_empty());
+    }
+
+    /// The lockfile name must follow the runner. A Python entry checked against
+    /// `package-lock.json` would find no file — and a missing file reads as
+    /// "install gone", not as drift, so the mistake would pass quietly.
+    #[test]
+    fn lockfile_name_follows_the_runner() {
+        let pin = |runner: &str| McpPackagePin {
+            runner: runner.into(),
+            name: "x".into(),
+            version: "1".into(),
+            install_dir: "/tmp/i".into(),
+            lockfile_sha256: "h".into(),
+            ..Default::default()
+        };
+        assert_eq!(pin("npm").lockfile_name(), "package-lock.json");
+        assert_eq!(pin("pypi").lockfile_name(), "requirements.lock");
+        assert!(pin("pypi").lockfile_path().ends_with("requirements.lock"));
     }
 }

--- a/mur-core/src/cmd/agent_mcp_vendor.rs
+++ b/mur-core/src/cmd/agent_mcp_vendor.rs
@@ -526,20 +526,29 @@ pub fn cmd_mcp_vendor(
     println!("  installed:   {}@{version}", pin.name);
     println!("  directory:   {}", dir.display());
     println!("  lockfile:    sha256:{}", pin.lockfile_sha256);
-    match pin.signatures_missing {
-        Some(0) => println!("  signatures:  every package verified against the registry"),
-        Some(n) => println!(
-            "  signatures:  verified, except {n} package(s) that publish none \
-             (common for older releases)"
-        ),
-        None => println!("  signatures:  not audited (npm too old, or offline)"),
-    }
-    match &pin.provenance {
-        Some(p) => println!("  provenance:  published ({p})"),
-        None => println!(
-            "  provenance:  none published — the registry can attest these bytes, \
-             but not where they were built"
-        ),
+    // These two lines describe npm-specific checks. Printing npm's wording for
+    // a PyPI install would state things that never happened — "not audited
+    // (npm too old, or offline)" when npm was never involved, and "none
+    // published" when nothing was ever asked.
+    if pin.runner == "pypi" {
+        println!("  hashes:      every package verified by uv during install (--require-hashes)");
+        println!("  provenance:  not queried for PyPI");
+    } else {
+        match pin.signatures_missing {
+            Some(0) => println!("  signatures:  every package verified against the registry"),
+            Some(n) => println!(
+                "  signatures:  verified, except {n} package(s) that publish none \
+                 (common for older releases)"
+            ),
+            None => println!("  signatures:  not audited (npm too old, or offline)"),
+        }
+        match &pin.provenance {
+            Some(p) => println!("  provenance:  published ({p})"),
+            None => println!(
+                "  provenance:  none published — the registry can attest these bytes, \
+                 but not where they were built"
+            ),
+        }
     }
     println!("\nRestart the agent to launch from the vendored copy.");
     Ok(())


### PR DESCRIPTION
Closes the last gap in #796. uvx entries had **no coverage at all** — `resolve_current_version` refused Python outright, so they could not even be version-pinned, let alone vendored.

## The npm shape carries over, and lands stronger

```
requirements.lock   uv pip compile --generate-hashes — a sha256 for every package in the tree
venv/               uv pip install --require-hashes — verifies each of those hashes as it
                    installs, which npm's install does not do
launch              venv/bin/<console-script>
fingerprint         sha256(requirements.lock) — same mechanism as npm, 39 KB for the whole tree
```

## Decisions made by measurement, not assumption

**A venv, not `--target`.** A console script written into a `--target` directory does a bare `from pkg import main` with no `sys.path` handling:

```
$ pkg/bin/mcp-server-time --help
Traceback: from mcp_server_time import main  →  ImportError
```

It only runs when `PYTHONPATH` points at the target — and `McpServerEntry` has no env to set it in, the same limitation that kept a keychain secret out of an MCP child earlier in this thread. A venv's script execs the venv's own interpreter:

```
$ ( cd / && env -i HOME=… PATH=/usr/bin:/bin venv/bin/mcp-server-time --help )
usage: mcp-server-time [-h] [--local-timezone LOCAL_TIMEZONE]      exit=0
```

**The launch target comes from `entry_points.txt`**, not from guessing `bin/<name>`: distributions routinely name their script differently (`mcp-server-time` vs `mcp_server_time`). Several console scripts is an ambiguity to refuse, matching how the npm path treats a multi-entry `bin` map.

**Version resolution goes through `uv pip compile`** rather than a PyPI query, so the recorded version is the one uv would actually install — including its requires-python and yanked-release filtering. Names compare PEP 503-normalised, or a package resolves fine and then reads as absent.

## End-to-end, on a real agent

A throwaway agent was created with the exact broken shape (`uvx mcp-server-time`, no version, pinned to uvx's own hash), vendored, inspected, and removed:

```
package:        mcp-server-time@2026.7.10 (pypi)
hashes:         verified by uv at install (--require-hashes)
provenance:     not queried for PyPI
pinned lock:    7978b53d…
current lock:   7978b53d…
status:         CLEAN                                    exit=0

$ ( cd / && env -i … venv/bin/mcp-server-time --help )   # the vendored server runs
```

That run is also what caught the second commit's bug: the PyPI path was printing npm's findings — `signatures: not audited (npm too old, or offline)` when npm was never involved, and `provenance: none published` when nothing was ever queried. Both lines were emitted correctly; only their content was false, so no unit test could have seen it. Rendering now branches on the runner and states what actually ran.

## Deep audit follows the runner too

`--deep` looked for `package-lock.json` unconditionally. On a PyPI entry that finds nothing — and **a missing lockfile reads as "install gone", not as drift**, so the mistake would have passed quietly rather than failing. It now routes through `McpPackagePin::lockfile_path()`, the single place the lockfile name is decided, shared with the runtime's startup check and `inspect`.

## Verification

- `cargo test -p mur-core --lib agent_mcp` — 43 passed. New: console-script extraction from real `entry_points.txt`, `[gui_scripts]`/`[pytest11]` correctly ignored, multi-script ambiguity, lockfile name follows the runner, and the missing-lockfile error names the runner's own file rather than npm's.
- `cargo test -p mur-common --lib mcp_package` — 9 passed, including PEP 503 name matching across `mcp_server_time` / `MCP-Server-Time` / `mcp.server.time`, and comment lines never being mistaken for a pin. Two of these failed first: `?` inside the parse loop abandoned the whole file at the first blank line.
- `cargo test --workspace --locked --no-run` and `cargo clippy -p mur-core --lib -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)