### PR TITLE
fix(eval): drop the harmbench dependency that blocked every B0 Eval run

### DIFF
--- a/scripts/eval/requirements.txt
+++ b/scripts/eval/requirements.txt
@@ -14,9 +14,24 @@
 agentdojo==0.1.32
 
 # HarmBench — jailbreak + agentic-misuse benchmark (CAIS 2024).
-# Released as a GitHub repo, not a wheel; pip+git URL with commit
-# hash for full reproducibility. Bump the hash to update.
-harmbench @ git+https://github.com/centerforaisafety/HarmBench.git@v1.0.0
+#
+# NOT a dependency. It was listed here as
+#   harmbench @ git+https://github.com/centerforaisafety/HarmBench.git@v1.0.0
+# and failed every install with `pathspec 'v1.0.0' did not match`, which is
+# why the B0 Eval job had never run (#805). Repinning does not fix it:
+#
+#   * upstream publishes no tags at all (`git ls-remote --tags` is empty), and
+#   * the repo has no setup.py / pyproject.toml / setup.cfg, so pip cannot
+#     install it from any ref — it is a research repo of loose scripts.
+#
+# Nothing imports it either: `scripts/eval/harmbench/run.py` runs off
+# `fixtures/synthetic_harmbench_cases.json`, and its own docstring defers the
+# real package integration to M11.3.1. So the line was blocking the eval in
+# exchange for nothing.
+#
+# When M11.3.1 lands, vendor it the way its shape requires — clone at a commit
+# SHA and add it to PYTHONPATH, plus install its own requirements.txt — rather
+# than declaring it a package it isn't.
 
 # Driver glue — keep deps minimal. The harness orchestrates upstream
 # packages + spawns the mur runtime; it doesn't need a heavy framework.


### PR DESCRIPTION
Cause #1 from #805. The B0 Eval job has failed on every run including v2.57.0, v2.58.0 and v2.59.0, and this is why.

## The obvious fix doesn't work

```
scripts/eval/requirements.txt:19
harmbench @ git+https://github.com/centerforaisafety/HarmBench.git@v1.0.0

error: pathspec 'v1.0.0' did not match any file(s) known to git
```

My first move was to repin to a commit SHA — the file's own comment even says *"pip+git URL with commit hash for full reproducibility"*, so the implementation had never matched its documented intent. That turned out to be wrong too:

```
$ git ls-remote --tags https://github.com/centerforaisafety/HarmBench.git
(empty — upstream publishes no tags at all)

$ ls <repo at HEAD> | grep -E 'setup.py|pyproject.toml|setup.cfg'
(nothing)
```

**HarmBench is not pip-installable from any ref.** It is a research repo of loose scripts with its own `requirements.txt`. Repinning would have moved the failure from "pathspec did not match" to "no build backend found" — a fix that fixes nothing, which is precisely the pattern #791→#802 spent yesterday removing from this codebase.

## Nothing imports it

```
$ grep -rn "import harmbench\|from harmbench" scripts/ .github/
(nothing)
```

`scripts/eval/harmbench/run.py` runs off `fixtures/synthetic_harmbench_cases.json`, and its own docstring defers *"the actual harmbench package import"* to M11.3.1. So the line was blocking the entire eval in exchange for nothing at all.

It goes, with the reasoning left in place of the line — including what to do instead when M11.3.1 lands (clone at a SHA onto PYTHONPATH plus its own requirements, rather than declaring it a package it isn't).

## Verified

```
$ pip install --dry-run -r scripts/eval/requirements.txt
exit 0                                   # previously died on harmbench

$ python3 scripts/eval/harmbench/run.py --out /tmp/hb-probe.jsonl
harmbench: 5 cases, 0 failed, run_id=01KYJ807FAP5ZZCG7A5YFY7AX3
5 lines written
```

## What this does not fix

The same job still fails earlier for want of credentials:

```
::error::Neither ANTHROPIC_API_KEY nor DEEPSEEK_API_KEY secret is set.
```

That needs a maintainer with access to repo secrets. **This PR unblocks the install step; it does not make B0 Eval green**, and saying otherwise would be the same defect in a smaller costume. #805 also asks whether a red B0 Eval should block a release at all — right now it neither runs nor blocks, which is the most misleading of the three possible states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)