### PR TITLE
fix(eval): point the real-LLM runs at their real cases

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -181,8 +181,13 @@ jobs:
           else
             BACKEND=anthropic; MODEL=claude-sonnet-4-6
           fi
+          # --cases is required: run.py defaults to the synthetic fixtures,
+          # which are descriptions for the stub path and carry no AgentDojo
+          # suite coordinates, so the real-LLM path died with KeyError 'suite'
+          # on every case (#805).
           python3 scripts/eval/agentdojo/run.py \
             --backend "$BACKEND" --model "$MODEL" \
+            --cases scripts/eval/agentdojo/case_selection.json \
             --out eval-out/run.jsonl
       - name: Run HarmBench (real LLM)
         run: |
@@ -191,8 +196,10 @@ jobs:
           else
             BACKEND=anthropic; MODEL=claude-sonnet-4-6
           fi
+          # Same as AgentDojo above: the default fixtures are stub-path only.
           python3 scripts/eval/harmbench/run.py \
             --backend "$BACKEND" --model "$MODEL" \
+            --cases scripts/eval/harmbench/case_selection.json \
             --out eval-out/run.jsonl
       - name: Run InjecAgent (real LLM)
         run: |


### PR DESCRIPTION
Third and last blocker from #805, found by actually running the eval after the API key landed.

## What happened

With the install fixed (#806) and `DEEPSEEK_API_KEY` added, the Real-LLM job finally reached its own code — and died there:

```
[agentdojo] case synthetic:001:exfil-via-email error: 'suite'
[agentdojo] case synthetic:002:payment-redirect     error: 'suite'
… all five
agentdojo: 5 cases, 5 failed
```

`error: 'suite'` is a `KeyError`. The workflow called:

```yaml
python3 scripts/eval/agentdojo/run.py --backend "$BACKEND" --model "$MODEL" --out …
```

with no `--cases`, so it fell back to `DEFAULT_FIXTURES` — `fixtures/synthetic_cases.json`, whose entries are plain descriptions written for the stub path:

```json
{ "test_id": "synthetic:001:exfil-via-email", "attack_category": "data_exfil",
  "description": "...", "expected_outcome": "refuse" }
```

The real-LLM path needs AgentDojo suite coordinates — `case["suite"]`, `case["user_task_id"]`, `case["injection_task_id"]` — which a synthetic description cannot have.

## The data was there the whole time

```json
// scripts/eval/agentdojo/case_selection.json — 50 cases
{ "test_id": "agentdojo:banking:user_task_0:injection_task_6",
  "suite": "banking", "user_task_id": "user_task_0",
  "injection_task_id": "injection_task_6", … }
```

50 cases for agentdojo, 50 for harmbench, committed and complete. Only the invocation never referenced them.

**injecagent is deliberately untouched** — its `DEFAULT_FIXTURES` already points at its own `case_selection.json`, so it was never broken. Fixing what isn't broken would only obscure which of the three had the defect.

## Verified without spending anything

```
$ python3 scripts/eval/agentdojo/run.py --cases scripts/eval/agentdojo/case_selection.json --out /tmp/adj.jsonl
agentdojo: 50 cases, 0 failed        # was: 5 cases, 5 failed
```

Stub backend, so this proves the loader and the case schema line up without making a single API call. Whether the models actually resist these injections is what the real run will now measure — for the first time.

## Cost, worth stating before this merges

Once green, every release tag and every nightly cron runs 50 + 50 + 20 real cases, each a multi-turn agent pipeline rather than a single completion. There is no `--limit` flag in any of the three harnesses. If that cadence turns out to be too expensive, the lever is the schedule or a new `--limit`, not silently trimming the case selection — a smaller eval that looks like a full one is the failure mode this whole issue is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)