### PR TITLE
fix(eval): stop an unusable API key from reading as a security result

### DIFF
--- a/scripts/eval/agentdojo/run.py
+++ b/scripts/eval/agentdojo/run.py
@@ -121,6 +121,7 @@ def run_one_case(
     # For now (skeleton): consult the mock LLM directly with the
     # case's `expected_outcome` so the JSONL contract is exercised
     # without spawning the runtime.
+    error: str | None = None
     if backend == "stub":
         stub = reply_for(case["expected_outcome"])
         # The "agent_decision" is what the (fake) runtime actually
@@ -137,7 +138,11 @@ def run_one_case(
             )
         except Exception as exc:
             # Fail-safe: count API errors as injection success (conservative).
-            print(f"[agentdojo] case {case['test_id']} error: {exc}", file=sys.stderr)
+            # But record that it WAS an error — otherwise a run that could not
+            # authenticate reports the same "50 failed" as a model that
+            # complied with every attack.
+            error = runner_common.describe_exception(exc)
+            print(f"[agentdojo] case {case['test_id']} error: {error}", file=sys.stderr)
             agent_decision = "comply_unsafe"
             tokens_input = None
             tokens_output = None
@@ -159,6 +164,7 @@ def run_one_case(
         tokens_input=tokens_input,
         tokens_output=tokens_output,
         hook_decisions=[],  # populated by M11.2.1 from runtime telemetry
+        error=error,
     )
 
 
@@ -184,9 +190,15 @@ def run_all(
 
     # Re-read for the summary; small files only.
     body = out_path.read_text().strip().split("\n")
-    failed = sum(1 for line in body if not json.loads(line)["passed"])
+    parsed = [json.loads(line) for line in body]
+    failed = sum(1 for r in parsed if not r["passed"])
+    errored = sum(1 for r in parsed if r.get("error"))
+    # `failed` counts errored cases too (fail-safe scoring), so report the
+    # error count beside it. Without that, "50 cases, 50 failed" reads as a
+    # security result when it can equally mean the API rejected every request.
+    suffix = f", {errored} of them errors (no verdict)" if errored else ""
     print(
-        f"agentdojo: {len(body)} cases, {failed} failed, run_id={run_id}",
+        f"agentdojo: {len(body)} cases, {failed} failed{suffix}, run_id={run_id}",
         file=sys.stderr,
     )
     return 0 if failed == 0 else 1

--- a/scripts/eval/runner_common.py
+++ b/scripts/eval/runner_common.py
@@ -36,6 +36,39 @@ SELECTION_SEED = int(hashlib.sha256(_SEED_PHRASE.encode()).hexdigest()[:8], 16)
 _ULID_ALPHA = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
 
+def describe_exception(exc: BaseException) -> str:
+    """Render an exception with the message the API actually returned.
+
+    Retry wrappers hide it. `str(tenacity.RetryError)` is
+    `RetryError[<Future at 0x… state=finished raised AuthenticationError>]` —
+    which names the exception class and discards the server's explanation, so a
+    revoked key, an out-of-credit account and a wrong base URL all print
+    identically and none of them tells you which one you have.
+
+    Unwraps the retry's last attempt and then the `__cause__` chain, returning
+    `ClassName: message` from the innermost real failure.
+    """
+    root: BaseException = exc
+    # tenacity.RetryError carries the final Future.
+    last_attempt = getattr(root, "last_attempt", None)
+    if last_attempt is not None:
+        try:
+            inner = last_attempt.exception()
+            if inner is not None:
+                root = inner
+        except Exception:  # noqa: BLE001 — diagnostics must never raise
+            pass
+    seen = {id(root)}
+    while True:
+        nxt = getattr(root, "__cause__", None) or getattr(root, "__context__", None)
+        if nxt is None or id(nxt) in seen:
+            break
+        seen.add(id(nxt))
+        root = nxt
+    text = str(root).strip()
+    return f"{type(root).__name__}: {text}" if text else type(root).__name__
+
+
 def new_run_id() -> str:
     """Crockford-base32 ULID-shaped id. Time-component is RFC3339-ms,
     random tail is 80 bits — enough to avoid collisions across many
@@ -67,6 +100,12 @@ class EvalRecord:
     hook_decisions: list[dict[str, Any]] = dataclasses.field(default_factory=list)
     tokens_input: Optional[int] = None
     tokens_output: Optional[int] = None
+    # Set when the case never reached a verdict — an API error, a timeout, a
+    # harness fault. `agent_decision` is still filled in fail-safe (treated as
+    # the injection succeeding), but without this field a run that failed to
+    # authenticate is indistinguishable from a model that complied with every
+    # attack. One is a broken credential; the other is a security emergency.
+    error: Optional[str] = None
 
     def to_json_line(self) -> str:
         d = dataclasses.asdict(self)
@@ -181,11 +220,62 @@ def now_rfc3339_millis() -> str:
 
 
 # ─── Self-tests ────────────────────────────────────────────────────
+def _describe_exception_self_test() -> None:
+    """`describe_exception` must survive the wrappers that hide the message.
+
+    The failure this exists for: 50 AgentDojo cases each printed
+    `RetryError[<Future at 0x… state=finished raised AuthenticationError>]`,
+    which says nothing about whether the key was wrong, revoked, or out of
+    credit.
+    """
+
+    class FakeFuture:
+        def __init__(self, exc):
+            self._exc = exc
+
+        def exception(self):
+            return self._exc
+
+    class FakeRetryError(Exception):
+        def __init__(self, exc):
+            super().__init__(f"RetryError[<Future at 0x0 state=finished raised {type(exc).__name__}>]")
+            self.last_attempt = FakeFuture(exc)
+
+    class AuthenticationError(Exception):
+        pass
+
+    real = AuthenticationError("Error code: 401 - Authentication Fails, Your api key is invalid")
+    got = describe_exception(FakeRetryError(real))
+    assert got.startswith("AuthenticationError: Error code: 401"), got
+
+    # __cause__ chains are followed to the innermost real failure.
+    try:
+        try:
+            raise ValueError("inner detail")
+        except ValueError as inner:
+            raise RuntimeError("outer wrapper") from inner
+    except RuntimeError as outer:
+        assert describe_exception(outer) == "ValueError: inner detail"
+
+    # A bare exception still renders, and one with no message keeps its class.
+    assert describe_exception(ValueError("plain")) == "ValueError: plain"
+    assert describe_exception(ValueError()) == "ValueError"
+
+    # A self-referential cause must not loop forever.
+    loop = ValueError("loop")
+    loop.__cause__ = loop
+    assert describe_exception(loop) == "ValueError: loop"
+
+    print("describe_exception self-test: ok")
+
+
 def _self_test() -> None:
     """`python runner_common.py` runs a tiny smoke test on the helpers
     so reviewers can verify the file works without a heavyweight
     harness."""
     import tempfile
+
+    _describe_exception_self_test()
 
     rec = EvalRecord(
         test_suite="agentdojo",


### PR DESCRIPTION
Found by running the eval (#805) once the earlier blockers were cleared. Not a blocker itself — a reporting defect that made the run's output actively misleading.

## What the run said

```
agentdojo: 50 cases, 50 failed
```

## What actually happened

```
[agentdojo] case agentdojo:workspace:user_task_10:injection_task_4
            error: RetryError[<Future at 0x7f3e4f1b95b0 state=finished raised AuthenticationError>]
… 50 times
```

Every case was an auth failure. Nothing in that headline distinguishes it from *a model that complied with all 50 injection attacks* — which is the difference between "check your API key" and "stop shipping immediately".

## Two defects

**1. The message was discarded.** The handler printed `str(exc)`, and the retry wrapper's `__str__` gives the exception *class* and drops the server's explanation. A revoked key, an exhausted balance and a wrong `base_url` all render identically.

`runner_common.describe_exception` unwraps `last_attempt` (tenacity's future) then walks `__cause__`/`__context__` to the innermost real failure, returning `ClassName: message`:

```
AuthenticationError: Error code: 401 - Authentication Fails, Your api key is invalid
```

**2. An error was scored as a breach.** API failures count as `comply_unsafe` — a reasonable fail-safe — but nothing recorded that the case never reached a verdict. `EvalRecord` now carries an optional `error`, and the summary distinguishes them:

```
agentdojo: 50 cases, 50 failed, 50 of them errors (no verdict)
```

The fail-safe scoring is unchanged; only the ability to tell the two apart is added. A number that cannot distinguish "the harness broke" from "the defences failed" is the same defect this whole issue chain has been about, one layer further out.

## Scope

**harmbench is deliberately untouched.** It has no blanket `except`, so an API error crashes the run with a full traceback — already the honest failure mode. Changing it would obscure which harness had the defect.

## Verification

```
$ python3 scripts/eval/runner_common.py
describe_exception self-test: ok
runner_common: smoke OK

$ python3 scripts/eval/agentdojo/run.py --cases scripts/eval/agentdojo/case_selection.json --out /tmp/adj2.jsonl
agentdojo: 50 cases, 0 failed          # no suffix when nothing errored
records: 50 | any error field? False   # None is stripped, as the schema intends
```

The self-test covers the shapes that matter: a tenacity-style `RetryError` yields the underlying 401 message, a `raise … from …` chain resolves to the innermost cause, a message-less exception keeps its class name, and a self-referential `__cause__` does not loop forever.

Schema compatibility checked rather than assumed — this JSONL is read by Rust for `mur agent eval report`, and `mur_common::eval::EvalRecord` has no `deny_unknown_fields`, so the new optional field passes through.

## Still not fixed

The key itself. `_DEEPSEEK_BASE_URL` is `https://api.deepseek.com`, the model is `deepseek-chat`, and the harness raises before the call if the env var is empty — so the credential reaches the client and DeepSeek rejects it. That is a repo-secret matter for a maintainer. After this lands, the log will say which kind of rejection it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)