### PR TITLE
docs(eval): say in the workflow that the PR gates don't cover B0

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -6,6 +6,31 @@ name: B0 Eval
 # fast); a weekly cron + per-release-tag run exercises the real-LLM
 # track against Anthropic Sonnet at temperature=0.
 #
+# ── What the PR-time tracks do NOT cover ──────────────────────────
+#
+# Neither PR job executes the real B0 hook chain, and reading this file
+# without knowing that invites the wrong conclusion (it invited mine —
+# see #809):
+#
+#   * Promptfoo B2 smoke drives `scripts/eval/promptfoo/provider.py`,
+#     which imports `mock_llm`. The "B0 hook chain" it routes through is
+#     a Python mock; no Rust runtime is spawned.
+#   * Stub-LLM's stub branch sets `agent_decision = case["expected_outcome"]`,
+#     so it reports 0 failed by construction. It exercises the case
+#     loader, the JSONL contract and the report path — not B0.
+#
+# Only the real-LLM job spawns a runtime, and it is schedule/tag-only.
+# So a change to B0 enforcement will not be caught here.
+#
+# It is not unguarded: the `b0_rule*` / `b0_*` integration tests in
+# mur-agent-runtime/tests/ drive the actual Rust hooks and run on every
+# PR via `cargo nextest run --workspace` in the Test job. That is where
+# B0 regressions get caught today.
+#
+# Corollary: adding `mur-agent-runtime/src/hooks/**` to the `paths:`
+# filter below would spend CI on jobs that cannot fail for such a
+# change — coverage in appearance only. Don't.
+#
 # Spec: docs/superpowers/specs/2026-05-06-b0-m11-eval-harness-design.md
 
 on:


### PR DESCRIPTION
Option (c) from #809 — and after checking, the only option with anything to do.

## Why (a) turned out to be empty

#809 claimed rules 4, 9 and 10 had no tests. That claim was wrong; I had grepped for `b0_rule<N>.rs` filenames, which measures naming convention rather than coverage:

| rule | claimed | actually |
|---|---|---|
| 4 | untested | `b0_side_effect_deny.rs` — **4 tests**, named for the behaviour |
| 9 | untested | `mod redact_envelope_tests` in `telemetry_writer.rs` (rule 9 ships outside the hook by design) |
| 10 | untested | **UX documentation** — not code |

There is no per-rule gap. Correction posted to #809.

## What this PR does

Records in the workflow header what takes two Python files to discover:

- **Promptfoo B2 smoke** drives `provider.py`, which imports `mock_llm`. The "B0 hook chain" it routes through is a Python mock; no runtime is spawned.
- **Stub-LLM**'s stub branch sets `agent_decision = case["expected_outcome"]`, so it reports `0 failed` by construction.
- Only the real-LLM job spawns a runtime, and it is schedule/tag-only.
- **B0 is still guarded** — by the `b0_*` integration tests, which drive the actual Rust hooks and run on every PR through `cargo nextest run --workspace`.
- And a note not to add `mur-agent-runtime/src/hooks/**` to `paths:`, with the reason.

## Why it's worth a commit

I read this file three times today and drew the wrong conclusion twice — first that the four skipped jobs were a bug (they're correct by design), then that widening `paths:` would help (it would have added CI that structurally cannot fail, which is worse than the silence). Both retracted in #805.

A file whose name says "B0 Eval" and whose PR jobs do not evaluate B0 will keep producing that mistake. Six lines of comment is the cheapest available fix, and unlike the two I proposed, it doesn't claim coverage that isn't there.

The real gap — no PR-time check that runs the real hook chain against adversarial input — stays open in #809 as option (b), which is design work rather than a config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)