### PR TITLE
fix(eval): honour the requested backend instead of guessing from secrets

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -198,14 +198,42 @@ jobs:
         run: pip install -r scripts/eval/requirements.txt
       - name: Build mur-core
         run: cargo build -p mur-core --release --bin mur
+      - name: Resolve backend
+        # One place, so the three runners below cannot drift apart — and so a
+        # `workflow_dispatch` with backend=deepseek actually selects DeepSeek.
+        # The input previously only gated whether this job ran; each step then
+        # auto-detected and preferred Anthropic whenever ANTHROPIC_API_KEY
+        # existed at all, so a stale Anthropic secret silently shadowed a
+        # working DeepSeek one and all 50 cases 401'd on `invalid x-api-key`.
+        run: |
+          REQ='${{ inputs.backend }}'
+          case "$REQ" in
+            anthropic)
+              if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+                echo "::error::backend=anthropic requested but ANTHROPIC_API_KEY is not set."
+                exit 1
+              fi
+              BACKEND=anthropic; MODEL=claude-sonnet-4-6 ;;
+            deepseek)
+              if [ -z "${DEEPSEEK_API_KEY:-}" ]; then
+                echo "::error::backend=deepseek requested but DEEPSEEK_API_KEY is not set."
+                exit 1
+              fi
+              BACKEND=deepseek; MODEL=deepseek-chat ;;
+            *)
+              # schedule / tag runs carry no input: auto-detect, Anthropic first.
+              if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+                BACKEND=anthropic; MODEL=claude-sonnet-4-6
+              else
+                BACKEND=deepseek; MODEL=deepseek-chat
+              fi ;;
+          esac
+          echo "BACKEND=$BACKEND" >> "$GITHUB_ENV"
+          echo "MODEL=$MODEL" >> "$GITHUB_ENV"
+          echo "Using $BACKEND / $MODEL"
       - name: Run AgentDojo (real LLM)
         run: |
           mkdir -p eval-out
-          if [ -n "${DEEPSEEK_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-            BACKEND=deepseek; MODEL=deepseek-chat
-          else
-            BACKEND=anthropic; MODEL=claude-sonnet-4-6
-          fi
           # --cases is required: run.py defaults to the synthetic fixtures,
           # which are descriptions for the stub path and carry no AgentDojo
           # suite coordinates, so the real-LLM path died with KeyError 'suite'
@@ -216,11 +244,6 @@ jobs:
             --out eval-out/run.jsonl
       - name: Run HarmBench (real LLM)
         run: |
-          if [ -n "${DEEPSEEK_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-            BACKEND=deepseek; MODEL=deepseek-chat
-          else
-            BACKEND=anthropic; MODEL=claude-sonnet-4-6
-          fi
           # Same as AgentDojo above: the default fixtures are stub-path only.
           python3 scripts/eval/harmbench/run.py \
             --backend "$BACKEND" --model "$MODEL" \
@@ -229,7 +252,7 @@ jobs:
       - name: Run InjecAgent (real LLM)
         run: |
           python3 scripts/eval/injecagent/run.py \
-            --backend anthropic --model claude-sonnet-4-6 \
+            --backend "$BACKEND" --model "$MODEL" \
             --out eval-out/run.jsonl
       - name: Aggregate + gate
         run: |


### PR DESCRIPTION
Sixth and (so far) last layer under #805, found by running the eval after #808 made its errors legible.

## The eval was calling Anthropic while reporting a DeepSeek run

```
error: AuthenticationError: Error code: 401 -
  {'error': {'message': 'invalid x-api-key'}, 'request_id': 'req_011CdTfX…'}
```

`x-api-key` is Anthropic's auth header — DeepSeek and OpenAI use `Authorization: Bearer` — and `req_011C…` is Anthropic's request-id format. I had dispatched with `-f backend=deepseek`.

The input is used **only** in the job-level `if:` that decides whether the job runs. Each step then re-derived the backend for itself:

```bash
if [ -n "$DEEPSEEK_API_KEY" ] && [ -z "$ANTHROPIC_API_KEY" ]; then
  BACKEND=deepseek
else
  BACKEND=anthropic     # ← taken, because a stale ANTHROPIC_API_KEY exists
fi
```

DeepSeek was chosen only when the Anthropic secret was *entirely absent*. A leftover invalid Anthropic key therefore shadowed a working DeepSeek one, and there was no way to say otherwise — the flag that looks like it does that has no effect past the gate.

This was visible at all only because #808 stopped the retry wrapper from eating the message. Before that it read `RetryError[<Future … raised AuthenticationError>]`, which names neither the provider nor the reason.

## Change

Resolution moves into one step ahead of the three runners:

- **an explicit input wins**, and **fails loudly** when its key is missing rather than falling back to the other provider. A run that quietly measures a different model than the one requested is worse than no run — it produces numbers attributed to the wrong system.
- **schedule/tag runs** carry no input, so they keep auto-detecting (Anthropic first) exactly as before.
- `BACKEND`/`MODEL` travel via `$GITHUB_ENV`, so the three runners cannot drift apart the way they already had.

**InjecAgent was hardcoded** to `--backend anthropic --model claude-sonnet-4-6` with no detection at all — it could never have run on DeepSeek under any configuration. It now reads the same resolution.

## Verification

The `case` statement extracted and exercised directly:

```
dispatch deepseek, BOTH keys set   -> deepseek / deepseek-chat      << was anthropic
dispatch anthropic, both set       -> anthropic / claude-sonnet-4-6
dispatch deepseek, no deepseek key -> ERROR (not a silent fallback)
schedule (no input), both set      -> anthropic / claude-sonnet-4-6
schedule, only deepseek            -> deepseek / deepseek-chat
```

Plus `yaml.safe_load` on the workflow.

## Still outstanding

**The Anthropic secret in this repo is invalid.** After this merges, a scheduled or tag run still auto-selects Anthropic and still 401s — only a dispatch with `backend=deepseek` will work. Either remove `ANTHROPIC_API_KEY` from repo secrets or replace it with a valid one; that needs a maintainer. The eval will now say plainly which provider rejected it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)