### PR TITLE
feat(eval): gate on whether the eval ran, not on what it measured

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -32,6 +32,34 @@ name: B0 Eval
 # change — coverage in appearance only. Don't.
 #
 # Spec: docs/superpowers/specs/2026-05-06-b0-m11-eval-harness-design.md
+#
+# ── What a green tick here does and does not mean ─────────────────
+#
+# This job gates on whether the eval RAN, never on what it measured.
+#
+#   green  the harness completed and produced a trustworthy measurement.
+#          It says nothing about the score — the model may have been
+#          injected in many of the cases. Read the report artifact.
+#   red    the run did not produce a measurement: auth failure, bad
+#          deps, cases that would not load. Deterministic, inside this
+#          repo's control, and the shape of every defect found under
+#          #805, which is why it is the thing worth blocking on.
+#
+# The score is deliberately not a gate. It measures MUR's B0 hooks x the
+# provider's model x the attack corpus, and a release controls only the
+# first: a provider shipping a weaker model, an outage, or a rate limit
+# would block releases for reasons nobody here can fix. A gate that fires
+# for things you cannot fix is a gate that gets switched off, and then the
+# replacement never gets built.
+#
+# What actually blocks a regression in B0 enforcement is the b0_* /
+# b0_rule* integration tests, which drive the real Rust hooks, cost
+# nothing, and run on every PR in the Test job.
+#
+# If score-based blocking is ever wanted, it needs a recorded baseline and
+# a noise threshold, not a comparison against zero — these runs are
+# stochastic.
+#
 
 on:
   pull_request:

--- a/scripts/eval/agentdojo/run.py
+++ b/scripts/eval/agentdojo/run.py
@@ -201,7 +201,11 @@ def run_all(
         f"agentdojo: {len(body)} cases, {failed} failed{suffix}, run_id={run_id}",
         file=sys.stderr,
     )
-    return 0 if failed == 0 else 1
+    # Gate on completeness, not on score. An errored case is scored
+    # `comply_unsafe` by the fail-safe above, so even one contaminates the
+    # number — a partial run is not a measurement, and reporting it as one is
+    # how "50 failed" came to mean "the API rejected us" (#805).
+    return 1 if errored else 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/eval/harmbench/run.py
+++ b/scripts/eval/harmbench/run.py
@@ -255,7 +255,12 @@ def run_all(
         f"harmbench: {n} cases, {failed} failed, run_id={run_id}",
         file=sys.stderr,
     )
-    return 0 if failed == 0 else 1
+    # Score is data, not a gate: it measures MUR's hooks x the model x the
+    # corpus, and a release controls only the first. Infrastructure failure
+    # still exits non-zero — there is no blanket `except` here, so an API
+    # error propagates and crashes the run. See the policy note in
+    # .github/workflows/eval.yml.
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/eval/injecagent/run.py
+++ b/scripts/eval/injecagent/run.py
@@ -146,7 +146,12 @@ def run_all(
         f"InjecAgent: {passed_count}/{total} PASS ({pct}%), run_id={run_id}",
         file=sys.stderr,
     )
-    return 0 if passed_count == total else 1
+    # Score is data, not a gate: it measures MUR's hooks x the model x the
+    # corpus, and a release controls only the first. Infrastructure failure
+    # still exits non-zero — there is no blanket `except` here, so an API
+    # error propagates and crashes the run. See the policy note in
+    # .github/workflows/eval.yml.
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
Answers the open question in #805: *should a red B0 Eval block a release?*

**Both available answers were wrong.** Blocking on the score builds a gate that fires for things nobody here can fix; not blocking at all is what let six defects hide for months. The distinction that resolves it is between *the eval couldn't run* and *the eval ran and found problems* — and #808 just made that distinction visible in the data.

## The policy

| outcome | exit | rationale |
|---|---|---|
| run completed, any score | **0** | data, not a verdict on this release |
| run incomplete (auth, deps, unloadable cases) | **1** | deterministic, inside this repo, and the shape of every #805 defect |

The score measures **MUR's B0 hooks × the provider's model × the attack corpus**. A release controls the first. Gate on it and a DeepSeek outage, a rate limit, or a provider shipping a weaker model blocks your release — so someone disables the gate, silently, and the replacement never gets built. That is strictly worse than the honest "this is a dashboard".

Meanwhile an eval that *cannot run* is exactly what should scream: it is deterministic, it is your code, and letting it stay quiet is how `harmbench @ …@v1.0.0` survived three releases pinned to a tag that never existed.

## Implementation

- **agentdojo** gates on `errored > 0`. An errored case is scored `comply_unsafe` by the existing fail-safe, so even one contaminates the number — a partial run is not a measurement.
- **harmbench / injecagent** have no blanket `except`, so an API error already propagates and crashes them. Their score-based exit is simply removed; their infra gating already worked.

## Verified against a real 50-case run

```
no errors, all pass        -> exit 0
1 errored case             -> exit 1
3 real breaches, 0 errors  -> exit 0    << the point
```

Three genuine injection successes do not block a release. One authentication failure does.

## What still blocks a B0 regression

The `b0_*` / `b0_rule*` integration tests, which drive the real Rust hooks, cost nothing, and run on every PR in the Test job. That is the deterministic gate; this job is the instrument. #810 documented the same split for the PR-time jobs.

The workflow header now states what a green tick does and does not mean, and records that score-based blocking would need a baseline and a noise threshold rather than a comparison against zero — these runs are stochastic, and a hard threshold on a stochastic measurement is a flaky gate by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)