### PR TITLE
fix(hub): style the agent-list gear button, which was invisible in dark mode

### DIFF
--- a/mur-hub-gui/ui/src/styles/components/dashboard.css
+++ b/mur-hub-gui/ui/src/styles/components/dashboard.css
@@ -558,15 +558,36 @@
 .list-name { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .list-category { font-size: 12px; color: var(--text-secondary); text-transform: capitalize; }
 .list-model { font-size: 12px; color: var(--text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.list-row__open {
+/* The list view's gear button. Had no rule at all, so it fell back to the
+   browser's default button chrome — a light background — while its icon
+   inherited the dark theme's light `currentColor`. Light on light: the
+   control was invisible in the shipped dark UI.
+
+   It replaces a `.list-row__open` rule for a class the component no longer
+   renders — a rename left the new name unstyled and the old rule orphaned,
+   which is how the gap went unnoticed. Kept in
+   sync with `.grid-card__settings` deliberately: the two are the same
+   control in two layouts, and they looked different because only one of
+   them existed. */
+.list-row__settings {
   justify-self: end;
-  font-size: var(--text-sm);
-  font-weight: var(--fw-bold);
-  color: var(--color-brand);
-  opacity: 0;
-  transition: opacity var(--dur-fast);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border-line);
+  border-radius: 7px;
+  background: var(--surface-card);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--dur-fast), color var(--dur-fast);
 }
-.list-row:hover .list-row__open { opacity: 1; }
+.list-row__settings:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
 
 /* ── Empty state ──────────────────────────────────────────────────────── */
 .dashboard-content .empty-state {


### PR DESCRIPTION
Reported from the Agents list view: the settings buttons render as blank light rectangles with an unreadable icon.

## Cause

`.list-row__settings` has **no CSS rule anywhere**. With no rule it takes the browser's default button chrome — a light grey background — while the gear icon inherits the dark theme's light `currentColor`. Light on light.

Directly above where that rule belongs sits `.list-row__open`, styling a class the component no longer renders:

```
$ grep -rn "list-row__open" src/ --include="*.tsx"
(nothing)
```

A rename left the new name unstyled and the old rule orphaned. Nothing in the toolchain flags a selector that matches no element, so it stayed that way.

## Fix

Styled to match `.grid-card__settings` — the same control in the grid layout, which had been correct all along. The two looked different only because one of them didn't exist. The dead rule is removed.

## Contrast, computed rather than eyeballed

| | background | icon | ratio | |
|---|---|---|---|---|
| dark, before | `#EFEFEF` (browser default) | `#94A3B8` | **2.23:1** | fails |
| dark, after | `#1A1E29` (`--surface-card`) | `#94A3B8` | **6.49:1** | |
| dark, hover | `#232838` | `#F1F5F9` | 13.39:1 | |
| light, after | `#FFFFFF` | `#64758A` | 4.72:1 | no regression |

WCAG asks 3:1 for UI components. The original was below half of that, which is why it read as an empty box.

Both dark paths were checked — `@media (prefers-color-scheme: dark)` and `:root[data-theme="dark"]` — since the tokens resolve through `--surface-card` / `--text-secondary` and only the semantic layer is overridden. The light values are the base definitions, so the light theme is verified by the same resolution rather than assumed.

`npx tsc --noEmit` and `npm run build` clean.

Not verified in a running .app: building the Hub bundle is a ~20 min native build and this is a stylesheet change whose resolved colours are computed above. Worth a look next time the Hub is rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)