### PR TITLE
fix(install): ship murmur, murmurd and the agent runtime from the installers

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -55,9 +55,15 @@ try {
     Expand-Archive -Path (Join-Path $tmp $asset) -DestinationPath $tmp -Force
     $exe = Get-ChildItem -Path $tmp -Recurse -Filter 'mur.exe' | Select-Object -First 1
     if (-not $exe) { throw 'Archive did not contain mur.exe' }
-    Move-Item -Force -Path $exe.FullName -Destination (Join-Path $installDir 'mur.exe')
-    $mcpexe = Get-ChildItem -Path $tmp -Recurse -Filter 'mur-mcp-server.exe' | Select-Object -First 1
-    if ($mcpexe) { Move-Item -Force -Path $mcpexe.FullName -Destination (Join-Path $installDir 'mur-mcp-server.exe') }
+    # Keep this list in sync with the Homebrew formula's `install` block.
+    # Optional entries are skipped when an older release did not ship them.
+    foreach ($name in 'mur', 'mur-mcp-server', 'murmurd', 'mur-agent-runtime') {
+        $found = Get-ChildItem -Path $tmp -Recurse -Filter "$name.exe" | Select-Object -First 1
+        if ($found) { Move-Item -Force -Path $found.FullName -Destination (Join-Path $installDir "$name.exe") }
+    }
+    # `murmur` is argv[0] shorthand for `mur agent cli` (BusyBox convention).
+    # ponytail: copy, not a symlink — those need Developer Mode or admin on Windows.
+    Copy-Item -Force -Path (Join-Path $installDir 'mur.exe') -Destination (Join-Path $installDir 'murmur.exe')
 }
 finally {
     Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -110,9 +110,15 @@ fi
 # --- Extract + install ---
 tar -xzf "$TMP/$ASSET" -C "$TMP"
 [ -f "$TMP/mur" ] || die "Archive did not contain a mur binary."
-chmod +x "$TMP/mur" "$TMP/mur-mcp-server"
-mv "$TMP/mur" "$INSTALL_DIR/mur"
-mv "$TMP/mur-mcp-server" "$INSTALL_DIR/mur-mcp-server"
+# Keep this list in sync with the Homebrew formula's `install` block.
+# Optional entries are skipped when an older release did not ship them.
+for b in mur mur-mcp-server murmurd mur-agent-runtime; do
+    [ -f "$TMP/$b" ] || continue
+    chmod +x "$TMP/$b"
+    mv "$TMP/$b" "$INSTALL_DIR/$b"
+done
+# `murmur` is argv[0] shorthand for `mur agent cli` (BusyBox convention).
+ln -sfn mur "$INSTALL_DIR/murmur"
 
 # --- PATH check ---
 case ":$PATH:" in


### PR DESCRIPTION
## Problem

`murmur` is not found on a machine installed via the curl/irm one-liner. Reported after a fresh install; reproduced by reading the installer.

`scripts/install.sh` moved exactly two binaries out of the release archive:

```sh
mv "$TMP/mur" "$INSTALL_DIR/mur"
mv "$TMP/mur-mcp-server" "$INSTALL_DIR/mur-mcp-server"
```

The Homebrew formula installs four, plus a symlink:

```ruby
bin.install "mur"
bin.install "mur-mcp-server"
bin.install "murmurd"
bin.install "mur-agent-runtime"
bin.install_symlink "mur" => "murmur"
```

So brew machines and installer machines end up with different surfaces:

- **no `murmur`** — the argv[0] shorthand for `mur agent cli` simply does not exist
- **no `mur-agent-runtime`** — no agent can start at all, which is the bigger of the two
- **no `murmurd`** — `mur daemon start` looks for it alongside `mur`

`install.ps1` had the same gap.

## Fix

Install every binary the archive ships, skipping any an older release did not carry, and create the `murmur` shorthand. Windows gets a copy rather than a symlink — symlinks there need Developer Mode or admin rights.

## Verification

- `sh -n scripts/install.sh` passes.
- Simulated the install block against a fixture directory that deliberately omits `mur-agent-runtime` (an older release): the missing entry is skipped cleanly, the other three land, and `murmur -> mur` resolves and is executable.

```
-rwxr-xr-x  mur
-rwxr-xr-x  mur-mcp-server
lrwxr-xr-x  murmur -> mur
-rwxr-xr-x  murmurd
```

The relative symlink target keeps it valid if the install dir is moved.

## Not done

No automated installer test — that needs a real release download. The binary list is now duplicated between the formula and the two installers, kept in sync by a comment on each; worth a shared source if a fifth binary ever appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)