### PR TITLE
fix(eval): surface the HTTP response body, where the provider says why

### DIFF
--- a/scripts/eval/runner_common.py
+++ b/scripts/eval/runner_common.py
@@ -66,7 +66,34 @@ def describe_exception(exc: BaseException) -> str:
         seen.add(id(nxt))
         root = nxt
     text = str(root).strip()
-    return f"{type(root).__name__}: {text}" if text else type(root).__name__
+    out = f"{type(root).__name__}: {text}" if text else type(root).__name__
+
+    # An HTTP error's str() is the status line only — httpx renders
+    # "Client error '400 Bad Request' for url '…'" and drops the body, which is
+    # the one place the provider says *why* it refused. Fifty identical 400s
+    # from DeepSeek told us nothing until this was added.
+    body = _http_response_body(root)
+    return f"{out} — {body}" if body else out
+
+
+def _http_response_body(exc: BaseException, limit: int = 400) -> Optional[str]:
+    """The response body of an httpx/requests error, if this is one.
+
+    Best-effort and silent: a diagnostic helper that raises would replace the
+    error being diagnosed. Truncated, because a provider that answers 400 with
+    an HTML page should not push the real errors off the top of the log.
+    """
+    resp = getattr(exc, "response", None)
+    if resp is None:
+        return None
+    try:
+        text = (resp.text or "").strip()
+    except Exception:  # noqa: BLE001 — never raise from diagnostics
+        return None
+    if not text:
+        return None
+    text = " ".join(text.split())  # collapse newlines: one log line per case
+    return text[:limit] + "…" if len(text) > limit else text
 
 
 def new_run_id() -> str:
@@ -265,6 +292,39 @@ def _describe_exception_self_test() -> None:
     loop = ValueError("loop")
     loop.__cause__ = loop
     assert describe_exception(loop) == "ValueError: loop"
+
+    # HTTP errors must carry the response body: httpx's str() is the status
+    # line alone, and 50 identical "400 Bad Request" lines from DeepSeek said
+    # nothing about what it objected to.
+    class FakeResponse:
+        def __init__(self, text): self.text = text
+
+    class FakeHTTPStatusError(Exception):
+        def __init__(self, msg, body):
+            super().__init__(msg)
+            self.response = FakeResponse(body)
+
+    got = describe_exception(FakeHTTPStatusError(
+        "Client error '400 Bad Request' for url 'https://api.deepseek.com/chat/completions'",
+        '{"error":{"message":"Model does not exist","type":"invalid_request_error"}}',
+    ))
+    assert "400 Bad Request" in got and "Model does not exist" in got, got
+
+    # A body that is huge, blank, or unreadable must degrade, never raise.
+    assert describe_exception(FakeHTTPStatusError("boom", "x" * 5000)).endswith("…")
+    assert describe_exception(FakeHTTPStatusError("boom", "   ")) == "FakeHTTPStatusError: boom"
+
+    class ExplodingResponse:
+        @property
+        def text(self): raise RuntimeError("body unreadable")
+
+    exploding = Exception("boom")
+    exploding.response = ExplodingResponse()
+    assert describe_exception(exploding) == "Exception: boom"
+
+    # Multi-line bodies collapse so one case stays one log line.
+    got = describe_exception(FakeHTTPStatusError("boom", "line one\nline two"))
+    assert "\n" not in got and "line one line two" in got, got
 
     print("describe_exception self-test: ok")
 


### PR DESCRIPTION
Seventh layer under #805, and the same move as #808: make the failure legible before attempting to fix it.

## Where the off-peak run got to

Authentication is solved — #811 made the harness actually reach DeepSeek, and the key is valid (a bad key answers 401, not 400). Every one of the 50 cases then died on:

```
HTTPStatusError: Client error '400 Bad Request'
  for url 'https://api.deepseek.com/chat/completions'
```

httpx renders the status line and **discards the body**, which is the only place DeepSeek says what it objected to. Fifty identical lines carrying no signal.

## Why not just guess at the request shape

There is a plausible suspect already in the code:

```python
# ponytail: no SystemMessage — avoids 'developer' role rejection on
# DeepSeek/non-OpenAI backends
```

so this codebase has hit DeepSeek's OpenAI-compat gaps before. Tool-call format, `parallel_tool_calls`, an unsupported parameter — several candidates, and no way to choose between them from a status code.

Guessing costs ~$2.50 per attempt and would repeat this morning's pattern: the harmbench pin looked like the fix twice (repin to a SHA, then to HEAD) before checking showed the package was never installable at any ref. Read the error first.

## Change

`describe_exception` appends the response body when the exception carries one. Both httpx and requests expose `exc.response.text`, so the same accessor covers the harness's HTTP clients.

Degradation is deliberate — a diagnostic that raises replaces the error being diagnosed:

| body | result |
|---|---|
| JSON error | appended after ` — ` |
| 5 KB HTML page | truncated at 400 chars with `…` |
| blank | plain message, no dangling separator |
| accessor raises | plain message |
| multi-line | whitespace collapsed, so one case stays one log line |

## Verification

`python3 scripts/eval/runner_common.py` — self-test covers all five rows above plus the existing retry/cause unwrapping. A DeepSeek-shaped 400 now reads:

```
HTTPStatusError: Client error '400 Bad Request' for url '…'
  — {"error":{"message":"Model does not exist","type":"invalid_request_error"}}
```

## What this does not do

It does not make the eval pass. The next run will still fail — but it will say why, and that determines whether the fix is in the harness, the model id, or the request builder. Claiming otherwise would be the defect this whole chain exists to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)