### PR TITLE
feat(model-library): add Anthropic as a provider preset

### DIFF
--- a/mur-core/src/model_discovery.rs
+++ b/mur-core/src/model_discovery.rs
@@ -66,21 +66,58 @@ fn models_url(base_url: &str) -> String {
     }
 }
 
-/// Discover available models via HTTP GET to `{base}/v1/models`.
-///
-/// Best-effort with timeout. If API key is provided and non-empty, sends `Authorization: Bearer <key>`.
-/// Returns model IDs extracted from the response envelope.
+/// Registry provider key whose API authenticates the non-OpenAI way.
+pub const ANTHROPIC_PROVIDER: &str = "anthropic";
+/// Anthropic requires a dated API version on every request. Pinned, not
+/// configurable: it selects a wire contract, so it moves with the code that
+/// parses the response, never with user config.
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// Auth headers for `provider`. Anthropic rejects `Authorization: Bearer` — it
+/// takes `x-api-key` plus `anthropic-version`. Everything else we talk to is
+/// OpenAI-compatible. Keyed off the provider, not the host, so an Anthropic
+/// endpoint reached through a proxy (`ANTHROPIC_BASE_URL`) still authenticates.
+fn auth_headers(provider: &str, api_key: Option<&str>) -> Vec<(&'static str, String)> {
+    let Some(k) = api_key.filter(|k| !k.is_empty()) else {
+        return Vec::new();
+    };
+    if provider.eq_ignore_ascii_case(ANTHROPIC_PROVIDER) {
+        vec![
+            ("x-api-key", k.to_string()),
+            ("anthropic-version", ANTHROPIC_VERSION.to_string()),
+        ]
+    } else {
+        vec![("Authorization", format!("Bearer {k}"))]
+    }
+}
+
+/// Discover available models via HTTP GET to `{base}/v1/models`, assuming
+/// OpenAI-compatible Bearer auth. Use [`discover_models_for`] when the
+/// provider is known.
 #[allow(dead_code)]
 pub fn discover_models(
     base_url: &str,
     api_key: Option<&str>,
     timeout_secs: u64,
 ) -> Result<Vec<String>> {
+    discover_models_for("", base_url, api_key, timeout_secs)
+}
+
+/// Discover available models for `provider` via HTTP GET to `{base}/v1/models`.
+///
+/// Best-effort with timeout. A non-empty API key is sent with whichever auth
+/// header the provider expects (see [`auth_headers`]).
+/// Returns model IDs extracted from the response envelope.
+#[allow(dead_code)]
+pub fn discover_models_for(
+    provider: &str,
+    base_url: &str,
+    api_key: Option<&str>,
+    timeout_secs: u64,
+) -> Result<Vec<String>> {
     let url = models_url(base_url);
     let url_for_err = url.clone();
-    let bearer = api_key
-        .filter(|k| !k.is_empty())
-        .map(|k| format!("Bearer {k}"));
+    let headers = auth_headers(provider, api_key);
 
     // `reqwest::blocking` panics if constructed inside a Tokio runtime context
     // (the CLI's `block_on`, or a `spawn_blocking` worker which carries a
@@ -91,8 +128,8 @@ pub fn discover_models(
             .timeout(Duration::from_secs(timeout_secs))
             .build()?;
         let mut rb = client.get(url);
-        if let Some(b) = bearer {
-            rb = rb.header("Authorization", b);
+        for (name, value) in headers {
+            rb = rb.header(name, value);
         }
         // A 401/404 still has a body; without this check it parses to an empty
         // list and the caller reads "reachable, zero models" instead of "auth
@@ -212,6 +249,23 @@ pub fn probe_local(timeout_secs: u64) -> Vec<DetectedLocal> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn auth_header_style_follows_the_provider() {
+        // Anthropic: x-api-key + version, never Bearer (a Bearer request 401s).
+        let a = auth_headers(ANTHROPIC_PROVIDER, Some("k"));
+        assert_eq!(a[0], ("x-api-key", "k".to_string()));
+        assert_eq!(a[1].0, "anthropic-version");
+        assert!(!a.iter().any(|(n, _)| *n == "Authorization"));
+        // Everyone else is OpenAI-compatible.
+        assert_eq!(
+            auth_headers("openai", Some("k")),
+            vec![("Authorization", "Bearer k".to_string())]
+        );
+        // No key (local runtimes) → no auth header at all.
+        assert!(auth_headers("ollama", None).is_empty());
+        assert!(auth_headers(ANTHROPIC_PROVIDER, Some("")).is_empty());
+    }
 
     #[test]
     fn parses_openai_envelope() {

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6569,6 +6569,7 @@ dependencies = [
  "mur-channel",
  "mur-common",
  "mur-compress",
+ "mur-open-items",
  "rand 0.8.6",
  "regex",
  "reqwest 0.12.28",
@@ -6600,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.51.1"
+version = "2.59.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6619,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.51.1"
+version = "2.59.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6668,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.51.1"
+version = "2.59.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6694,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.51.1"
+version = "2.59.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6734,6 +6735,7 @@ dependencies = [
  "mur-channel",
  "mur-common",
  "mur-compress",
+ "mur-open-items",
  "notify",
  "oauth2",
  "open",
@@ -6781,7 +6783,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.51.1"
+version = "2.59.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6835,6 +6837,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "mur-open-items"
+version = "2.59.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "serde",
+ "serde_json",
+ "sha2",
 ]
 
 [[package]]

--- a/mur-hub-gui/src-tauri/src/models_admin.rs
+++ b/mur-hub-gui/src-tauri/src/models_admin.rs
@@ -131,9 +131,10 @@ pub async fn test_provider(
     let home = mur_home();
     let base = base_url.clone();
     let prov = provider.clone();
+    let prov2 = provider.clone();
     // discover_models uses reqwest::blocking — run it off the async runtime.
     let ids = tokio::task::spawn_blocking(move || {
-        model_discovery::discover_models(&base, key.as_deref(), DISCOVER_TIMEOUT_SECS)
+        model_discovery::discover_models_for(&prov2, &base, key.as_deref(), DISCOVER_TIMEOUT_SECS)
     })
     .await
     .map_err(|e| format!("discovery task failed: {e}"))?

--- a/mur-hub-gui/ui/src/components/modelLibraryHelpers.ts
+++ b/mur-hub-gui/ui/src/components/modelLibraryHelpers.ts
@@ -13,6 +13,13 @@ export interface CloudPreset {
 
 export const CLOUD_PRESETS: CloudPreset[] = [
   {
+    key: "anthropic",
+    name: "Anthropic (Claude)",
+    baseUrl: "https://api.anthropic.com/v1",
+    logo: "A",
+    color: "#C5694A",
+  },
+  {
     key: "openai",
     name: "OpenAI",
     baseUrl: "https://api.openai.com/v1",
@@ -91,10 +98,10 @@ export const CLOUD_PRESETS: CloudPreset[] = [
   },
 ];
 
-// Anthropic and Azure OpenAI are intentionally NOT presets here: both use a
-// non-Bearer auth header (x-api-key / api-key) that model_discovery's
-// generic OpenAI-compatible client doesn't send, so "test connection" would
-// always 401. Add them once discover_models() supports per-provider auth.
+// Azure OpenAI is intentionally NOT a preset here: its `api-key` auth header
+// and deployment-scoped URLs are not the generic OpenAI-compatible shape
+// model_discovery speaks. Anthropic IS a preset — discover_models_for() sends
+// its `x-api-key` + `anthropic-version` headers.
 
 /**
  * Pure immutable selection toggle — does not mutate the input Set.


### PR DESCRIPTION
## What

The Hub's Model Library had no Anthropic entry. The reason was in the code:

```ts
// Anthropic and Azure OpenAI are intentionally NOT presets here: both use a
// non-Bearer auth header (x-api-key / api-key) that model_discovery's
// generic OpenAI-compatible client doesn't send, so "test connection" would
// always 401. Add them once discover_models() supports per-provider auth.
```

So this adds the per-provider auth that comment asked for.

- `model_discovery::discover_models_for(provider, base_url, key, timeout)` picks the auth headers by provider: `x-api-key` + a pinned `anthropic-version` for Anthropic, `Authorization: Bearer` for everything else.
- Keyed off the **provider**, not the host — an Anthropic endpoint reached through a proxy (`ANTHROPIC_BASE_URL`, e.g. a local gateway) still authenticates.
- `discover_models` stays as the Bearer entry point used by local-runtime probing, so no other call site moves.
- `CLOUD_PRESETS` gains Anthropic (Claude); the comment now records why Azure OpenAI is still out (deployment-scoped URLs, not the generic shape).
- `mur-hub-gui/src-tauri/Cargo.lock` was stale (2.51.1, missing `mur-open-items`) and is refreshed.

## Verification

- `cargo nextest run -p mur-core --lib`: 2222 passed, including a new `auth_header_style_follows_the_provider` covering the Anthropic headers, the Bearer default, and the no-key/empty-key cases
- `npx vitest run modelLibraryHelpers`: 8 passed
- `cargo check --manifest-path mur-hub-gui/src-tauri/Cargo.toml --lib`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)