### PR TITLE
fix(windows): an openable process handle is not proof of life

### DIFF
--- a/mur-common/src/lock_file.rs
+++ b/mur-common/src/lock_file.rs
@@ -63,7 +63,8 @@ pub fn read(lock_path: &Path) -> std::io::Result<Option<LockFile>> {
 /// On Unix uses `kill(pid, 0)` — signal 0 is a no-op probe that checks
 /// process existence and permission without delivering any signal.
 ///
-/// On Windows uses `OpenProcess` with `PROCESS_QUERY_LIMITED_INFORMATION`.
+/// On Windows uses `OpenProcess` with `PROCESS_QUERY_LIMITED_INFORMATION`,
+/// then `GetExitCodeProcess` — an openable handle is NOT proof of life.
 ///
 /// On other platforms returns `true` (optimistically treat any present lock
 /// as live, since P0a agents are not supported there).
@@ -76,15 +77,34 @@ pub fn pid_alive(pid: u32) -> bool {
 
 #[cfg(windows)]
 pub fn pid_alive(pid: u32) -> bool {
-    use windows_sys::Win32::Foundation::CloseHandle;
-    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    // SAFETY: OpenProcess/GetExitCodeProcess/CloseHandle are safe to call with
+    // any pid; the handle is closed on every path out.
     unsafe {
         let h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
         if h.is_null() {
             return false;
         }
+        // A terminated process stays openable until the last handle to it is
+        // closed — Windows' equivalent of a zombie. Treating a non-null handle
+        // as "alive" therefore reports a just-crashed agent as running, and
+        // `clear_runtime_state` then refuses to clear its stale lock. Ask for
+        // the exit code instead: only STILL_ACTIVE means running. (Known
+        // Windows caveat: a process that exits with code 259 is
+        // indistinguishable from a running one. Our runtimes never exit 259,
+        // and the failure direction is the conservative one — a lock kept, not
+        // a live process's lock deleted.)
+        let mut code: u32 = 0;
+        let queried = GetExitCodeProcess(h, &mut code);
         CloseHandle(h);
-        true
+        // If the query itself fails we cannot tell, so claim alive: keeping a
+        // dead process's lock costs the user one manual clear, while deleting
+        // a live one's lock lets a second supervisor run against the same agent
+        // home (#790).
+        queried == 0 || code == STILL_ACTIVE as u32
     }
 }
 

--- a/mur-common/src/schedule_claim.rs
+++ b/mur-common/src/schedule_claim.rs
@@ -28,21 +28,17 @@ pub fn is_commander_running_at(pid_path: &Path) -> bool {
         Err(_) => return false,
     };
 
-    let pid: i32 = match content.trim().parse() {
+    let pid: u32 = match content.trim().parse() {
         Ok(p) => p,
         Err(_) => return false,
     };
 
-    // Check if process is alive (signal 0 = existence check)
-    #[cfg(unix)]
-    {
-        unsafe { libc::kill(pid, 0) == 0 }
-    }
-    #[cfg(not(unix))]
-    {
-        // On non-Unix, assume Commander is not running (best effort)
-        false
-    }
+    // Same liveness question as a runtime lock file — use the same answer
+    // instead of a second hand-rolled probe. The old `#[cfg(not(unix))]` arm
+    // returned false unconditionally, so on Windows `auto_detect_executor`
+    // never chose Commander and `mur workflow` reclaimed schedules from a
+    // Commander that was very much alive.
+    crate::lock_file::pid_alive(pid)
 }
 
 /// Default schedules.yaml path.


### PR DESCRIPTION
## The bug

`mur_common::lock_file::pid_alive` treated any non-null `OpenProcess` handle as a live process:

```rust
let h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
if h.is_null() { return false; }
CloseHandle(h);
true
```

On Windows a terminated process stays openable until the last handle to it is closed — the local equivalent of a zombie. So a just-crashed agent reads as **running**, and `clear_runtime_state` refuses to clear its stale lock (`running.lock` / `agent.sock` / `running.sentinel`), leaving the user to clear it by hand.

It also shows up as a flaky Windows CI failure — `sidecar::tests::clear_runtime_state_removes_state_left_by_a_dead_process`, whose `dead_pid()` helper spawns a process, waits for it, and hands over a pid that is dead but still openable:

```
running.lock should have been cleared
mur-gui-core\src\sidecar.rs:478
```

(That's how this was found: it failed on #819, a PR that touches none of this.)

## The fix

Ask for the exit code too — only `STILL_ACTIVE` counts as running.

On a failed query we still claim alive, because the two failure directions are not symmetric: keeping a dead process's lock costs one manual clear, while deleting a live process's lock lets a second supervisor run against the same agent home (#790). The documented Windows caveat (a process exiting with code 259 is indistinguishable from a running one) is noted in the code; our runtimes never exit 259, and it errs in the same conservative direction.

## Second caller, same question

`schedule_claim::is_commander_running_at` hand-rolled the same probe and had **no Windows arm at all** — it returned `false` unconditionally. Consequences on Windows:

- `auto_detect_executor` never chose Commander
- `mur workflow` saw a live Commander's PID file as stale and reclaimed its schedules (`release_all_from_commander`)

It now calls `pid_alive`: one probe, one behaviour, both platforms. Also removes a Windows-only `unused variable: pid` warning.

## Verification

- `cargo check -p mur-common --target x86_64-pc-windows-msvc` — the `cfg(windows)` arm is invisible to a macOS/Linux build, so it was compiled explicitly for the target
- `cargo nextest run -p mur-common`: 865 passed
- `cargo nextest run -p mur-gui-core sidecar`: 7 passed
- The real proof is this PR's own Windows CI job: the flaky test above is the regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)