### PR TITLE
fix(official): surface the catalog server's response body, where it says why

### DIFF
--- a/mur-core/src/official/client.rs
+++ b/mur-core/src/official/client.rs
@@ -33,13 +33,38 @@ pub async fn fetch_catalog(client: &reqwest::Client, base: &str) -> Result<Vec<C
     let url = format!("{base}/api/v1/core/catalog");
     let resp = client.get(&url).send().await.context("fetch catalog")?;
     if !resp.status().is_success() {
-        bail!("catalog request failed: HTTP {}", resp.status());
+        bail!("catalog request failed: {}", describe_status(resp).await);
     }
     Ok(resp
         .json::<CatalogResponse>()
         .await
         .context("parse catalog")?
         .items)
+}
+
+/// How much of a server error body to keep. Enough for a JSON `{"error": …}`,
+/// short enough that an HTML error page cannot bury the status it came with.
+const ERROR_BODY_LIMIT: usize = 300;
+
+/// Render a failed response as `HTTP <status>: <body>`.
+///
+/// The status alone is what the server could not say: a 503 from the catalog
+/// means "route is up, index unavailable", and only the body names which. Body
+/// handling degrades rather than raises — an unreadable or blank body falls
+/// back to the bare status, newlines collapse so one failure stays one line,
+/// and truncation counts characters so a multi-byte body cannot panic.
+async fn describe_status(resp: reqwest::Response) -> String {
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+    let body = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    if body.is_empty() {
+        return format!("HTTP {status}");
+    }
+    if body.chars().count() > ERROR_BODY_LIMIT {
+        let head: String = body.chars().take(ERROR_BODY_LIMIT).collect();
+        return format!("HTTP {status}: {head}…");
+    }
+    format!("HTTP {status}: {body}")
 }
 
 /// Authenticated download: returns (bundle bytes, license).
@@ -63,7 +88,8 @@ pub async fn download_item(
         402 | 403 => {
             bail!("'{id}' requires an active MUR Pro subscription — manage at app.mur.run")
         }
-        s => bail!("download failed: HTTP {s}"),
+        // Anything else is unmapped, so the body is the only explanation there is.
+        _ => bail!("download failed: {}", describe_status(resp).await),
     }
     let body: DownloadResponse = resp.json().await.context("parse download response")?;
     let bytes = B64.decode(&body.bundle_base64).context("decode bundle")?;
@@ -130,5 +156,78 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("subscription"), "{err}");
+    }
+
+    /// The status alone is what the server could NOT say. A live catalog route
+    /// with no published index answers 503 and explains itself in the body;
+    /// without it the message is indistinguishable from any other 503.
+    #[tokio::test]
+    async fn catalog_error_carries_the_server_explanation() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/core/catalog"))
+            .respond_with(ResponseTemplate::new(503).set_body_json(serde_json::json!({
+                "error": "official catalog unavailable: index.json request failed: status 404"
+            })))
+            .mount(&server)
+            .await;
+        let err = fetch_catalog(&reqwest::Client::new(), &server.uri())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("503"), "{err}");
+        assert!(err.contains("index.json request failed"), "{err}");
+    }
+
+    /// An unmapped download failure has no curated message, so the body is the
+    /// only explanation there is.
+    #[tokio::test]
+    async fn download_error_carries_the_server_explanation() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/core/catalog/fleets/x/download"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("storage backend down"))
+            .mount(&server)
+            .await;
+        let err = download_item(&reqwest::Client::new(), &server.uri(), "tok", "fleets/x")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("500") && err.contains("storage backend down"),
+            "{err}"
+        );
+    }
+
+    /// Bodies degrade rather than raise: blank ones fall back to the bare
+    /// status, long ones truncate, and newlines collapse so one failure stays
+    /// one log line.
+    #[tokio::test]
+    async fn error_bodies_degrade_instead_of_raising() {
+        async fn describe(body: &str) -> String {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/api/v1/core/catalog"))
+                .respond_with(ResponseTemplate::new(500).set_body_string(body))
+                .mount(&server)
+                .await;
+            fetch_catalog(&reqwest::Client::new(), &server.uri())
+                .await
+                .unwrap_err()
+                .to_string()
+        }
+
+        assert_eq!(
+            describe("   \n  ").await,
+            "catalog request failed: HTTP 500 Internal Server Error"
+        );
+        assert!(describe(&"x".repeat(5000)).await.ends_with('…'));
+        let multi = describe("line one\nline two").await;
+        assert!(
+            !multi.contains('\n') && multi.contains("line one line two"),
+            "{multi}"
+        );
+        // Multi-byte bodies truncate on character boundaries, never panic.
+        assert!(describe(&"漢".repeat(5000)).await.ends_with('…'));
     }
 }


### PR DESCRIPTION
## Problem

Found while verifying #821's new catalog step in the Hub. It reported:

```
catalog request failed: HTTP 503 Service Unavailable
```

The server had actually said:

```json
{"error":"official catalog unavailable: index.json request failed: status 404"}
```

A bodyless 503 reads the same whether the route is misconfigured, the GitHub App token expired, or — as here — the catalog repo has never published an index. Same failure shape as #817 on the eval side: the status line survives, the explanation is thrown away.

## Change

Failed responses render as `HTTP <status>: <body>` for the catalog list and for **unmapped** download failures. The curated 401 / 402 / 403 messages are untouched — those statuses already have an answer better than the body ("log in again", "needs MUR Pro").

Body handling degrades rather than raises:

- blank or unreadable body → bare status, as before
- newlines collapse → one failure stays one log line
- truncation at 300 **characters**, not bytes → a multi-byte body cannot panic on a slice boundary

## Test

```
official::client::catalog_error_carries_the_server_explanation   ok
official::client::download_error_carries_the_server_explanation  ok
official::client::error_bodies_degrade_instead_of_raising        ok   (blank / 5 KB / multi-line / CJK)
... 6 passed
```

The degradation test drives the real path through wiremock rather than the helper directly, so it covers what a caller actually sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)