### PR TITLE
fix(eval): run the tool executor before the LLM, as agentdojo does

### DIFF
--- a/scripts/eval/agentdojo/run.py
+++ b/scripts/eval/agentdojo/run.py
@@ -82,7 +82,18 @@ def _run_with_real_llm(
         [
             InitQuery(),
             llm,
-            ToolsExecutionLoop([llm, ToolsExecutor()]),
+            # Executor BEFORE the LLM, matching every construction in
+            # agentdojo's own factory. The loop only runs while the last
+            # message is an assistant turn carrying tool_calls
+            # (tool_execution.py), so whichever element goes first is handed a
+            # conversation ending in unanswered calls. Executor-first answers
+            # each tool_call_id and then asks the model; LLM-first sends the
+            # dangling calls to the API, which DeepSeek rejects outright:
+            #   "An assistant message with 'tool_calls' must be followed by
+            #    tool messages responding to each 'tool_call_id'"
+            # OpenAI and Anthropic accept it, which is why the order survived
+            # until the harness first reached a stricter provider (#805).
+            ToolsExecutionLoop([ToolsExecutor(), llm]),
         ]
     )
 


### PR DESCRIPTION
Seventh layer under #805, and the first one the eval itself diagnosed — #817's body-surfacing landed and DeepSeek immediately said what was wrong.

## What DeepSeek said

```json
{"error":{"message":"An assistant message with 'tool_calls' must be followed by
 tool messages responding to each 'tool_call_id'.
 (insufficient tool messages following tool_calls message)",
 "type":"invalid_request_error"}}
```

Not the key (a bad key answers 401), not the model id. The **conversation shape**.

## Cause

```python
ToolsExecutionLoop([llm, ToolsExecutor()])        # MUR
ToolsExecutionLoop([ToolsExecutor(...), llm])     # agentdojo, all 5 of its own constructions
```

The order is load-bearing. The loop iterates only while the last message is an assistant turn carrying `tool_calls` (`tool_execution.py:146-153`), so **whichever element runs first is handed a conversation ending in unanswered calls**:

- **executor-first** answers every `tool_call_id`, then asks the model — a complete sequence
- **LLM-first** posts the dangling calls straight to the API

OpenAI and Anthropic tolerate the incomplete shape. DeepSeek does not. The order survived because the harness had never reached a stricter provider — six earlier defects stopped it first.

There is a related note beside this code:

```python
# ponytail: no SystemMessage — avoids 'developer' role rejection on DeepSeek
```

Same pattern, earlier: a DeepSeek rejection worked around at the symptom. This one is the underlying contract violation.

## Proven offline — no key, no network, no spend

A recording stub in place of the LLM, driving agentdojo's **real** `ToolsExecutionLoop`, applying DeepSeek's rule to whatever the LLM element is about to be sent:

```
LLM-first  (what shipped): 1 violation  -> REJECTED
    call #1: assistant msg[1] has unanswered tool_call_id(s) ['call_1']
Executor-first (the fix) : 0 violations -> accepted
```

That reproduces the exact 400 without calling anyone, and confirms the fix removes it.

## Note on scope

This makes the harness send a valid conversation. Whether the run then completes is the next thing to find out, and I am not claiming it will — six layers have each been revealed only by fixing the one before. What is settled is that this specific rejection is gone, and that is verified rather than hoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)