### PR TITLE
feat(out): let a harvested proposal be rejected, and stop `skip` pretending

### DIFF
--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -434,7 +434,7 @@ pub enum SessionAction {
     },
     /// Stop session recording with post-session menu
     Out {
-        /// Action to perform: analyze, export, skip
+        /// Action to perform: analyze, export, skip, reject
         #[arg(long)]
         action: Option<String>,
         /// Force LLM analysis even for short sessions

--- a/mur-core/src/cli/mod.rs
+++ b/mur-core/src/cli/mod.rs
@@ -268,7 +268,7 @@ see `mur skill <command> --help`.")]
     /// Stop session recording with post-session menu (shorthand for session stop + next action)
     #[command(hide = true)]
     Out {
-        /// Action to perform: analyze, export, skip (skips menu in non-TTY mode)
+        /// Action to perform: analyze, export, skip, reject (skips menu in non-TTY mode)
         #[arg(long)]
         action: Option<String>,
         /// Force LLM analysis even for short sessions

--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -730,10 +730,37 @@ async fn cmd_out_execute(action: &str, force: bool) -> anyhow::Result<()> {
             }
         }
         "skip" => {
-            eprintln!("Done.");
+            // Say what actually happened. "Done." reads like the inbox was
+            // dealt with; skip touches nothing, and the session-start hook
+            // brings the same proposals back tomorrow.
+            let inbox = crate::harvest::proposal::inbox_dir();
+            match crate::harvest::proposal::pending_in_dir(&inbox) {
+                Ok(p) if !p.is_empty() => eprintln!(
+                    "Skipped — {} proposal(s) still pending. `mur out --action reject` dismisses them.",
+                    p.len()
+                ),
+                _ => eprintln!("Done."),
+            }
+        }
+        "reject" => {
+            let inbox = crate::harvest::proposal::inbox_dir();
+            let dismissed = crate::harvest::proposal::dismiss_pending_in_dir(&inbox)?;
+            if dismissed.is_empty() {
+                eprintln!("No pending proposals to reject.");
+            } else {
+                eprintln!("Dismissed {} proposal(s):", dismissed.len());
+                for (id, title) in &dismissed {
+                    let short: String = id.chars().take(8).collect();
+                    let line = title.lines().next().unwrap_or("").trim();
+                    eprintln!("  {short}  {line}");
+                }
+            }
         }
         _ => {
-            anyhow::bail!("Unknown action '{}'. Use: analyze, export, skip", action);
+            anyhow::bail!(
+                "Unknown action '{}'. Use: analyze, export, skip, reject",
+                action
+            );
         }
     }
 

--- a/mur-core/src/harvest/proposal.rs
+++ b/mur-core/src/harvest/proposal.rs
@@ -130,6 +130,23 @@ pub fn set_status_in_dir(dir: &Path, id: &str, status: ProposalStatus) -> Result
     save_in_dir(dir, &p)
 }
 
+/// Dismiss every pending proposal in `dir`; returns each dismissed `(id, title)`.
+///
+/// A status flip, not a delete: the file stays for audit, and the harvest
+/// gate's recurrence index keeps counting the skeleton, so a workflow that
+/// genuinely repeats can propose itself again later. `pending_in_dir` filters
+/// on status, so this silences every surface that counts the inbox (the
+/// session-start hook, `mur out`, the companion nudge) at once.
+pub fn dismiss_pending_in_dir(dir: &Path) -> Result<Vec<(String, String)>> {
+    let mut dismissed = Vec::new();
+    for p in pending_in_dir(dir)? {
+        set_status_in_dir(dir, &p.id, ProposalStatus::Dismissed)
+            .with_context(|| format!("dismiss proposal {}", p.id))?;
+        dismissed.push((p.id, p.title));
+    }
+    Ok(dismissed)
+}
+
 /// Token-set Jaccard similarity over two step lists (zero-cost near-dup check).
 pub fn step_similarity(a: &[String], b: &[String]) -> f32 {
     let ta: BTreeSet<&str> = a.iter().flat_map(|s| s.split_whitespace()).collect();
@@ -264,6 +281,33 @@ mod tests {
 
         set_status_in_dir(tmp.path(), "s1", ProposalStatus::Accepted).unwrap();
         assert!(pending_in_dir(tmp.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn dismiss_pending_leaves_the_files_and_the_other_statuses_alone() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        save_in_dir(tmp.path(), &proposal("s1", ProposalStatus::Pending)).unwrap();
+        save_in_dir(tmp.path(), &proposal("s2", ProposalStatus::Pending)).unwrap();
+        save_in_dir(tmp.path(), &proposal("s3", ProposalStatus::Accepted)).unwrap();
+
+        let dismissed = dismiss_pending_in_dir(tmp.path()).unwrap();
+        assert_eq!(dismissed.len(), 2);
+        assert!(dismissed.iter().all(|(_, title)| title == "Deploy api"));
+
+        // Nothing is deleted — dismissal is a status flip, so the inbox keeps
+        // its audit trail and the recurrence index keeps its history.
+        assert_eq!(list_in_dir(tmp.path()).unwrap().len(), 3);
+        assert!(pending_in_dir(tmp.path()).unwrap().is_empty());
+        // An accepted proposal is not a pending one; it must be untouched.
+        let accepted = list_in_dir(tmp.path())
+            .unwrap()
+            .into_iter()
+            .find(|p| p.id == "s3")
+            .unwrap();
+        assert_eq!(accepted.status, ProposalStatus::Accepted);
+
+        // Idempotent: rejecting an empty inbox is not an error.
+        assert!(dismiss_pending_in_dir(tmp.path()).unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## The gap

The session-start hook nags:

```
📥 1 workflow proposal(s) pending — run `mur session out` to review.
```

`mur session out` offers `analyze` / `export` / `skip` — and **none of them clears anything**. `skip` was:

```rust
"skip" => {
    eprintln!("Done.");
}
```

So the nag comes back every session, and the only way out is to `rm` the file by hand — which the hint never suggests, because there was nothing to suggest. (Found while trying to clear a real inbox: a 528-step proposal harvested from a debugging session, title `"why tool execution failed? / [Image #1]"`.)

## The fix

**`mur out --action reject`** dismisses every pending proposal and prints each id + title, so the output states what happened:

```
Dismissed 1 proposal(s):
  aaaaaaaa  why tool execution failed?
```

It flips `status` to `Dismissed` rather than deleting:

- `ProposalStatus::Dismissed` already existed in the model with no way to reach it
- the file stays, so the inbox keeps an audit trail
- the recurrence index keeps counting the skeleton, so a workflow that *genuinely* repeats can propose itself again later — a reject is "not this time", not "never"

Every surface that counts the inbox (session-start hook, `mur out`, companion nudge) goes through `pending_in_dir`, which filters on status — so one flip silences all three.

**`skip` now tells the truth**: how many proposals it left pending and which action clears them, instead of "Done." (which reads like the inbox was dealt with).

## Verification

Against a scratch `MUR_HOME`, so no real inbox was touched:

| case | output |
|---|---|
| `skip`, 1 pending | `Skipped — 1 proposal(s) still pending. \`mur out --action reject\` dismisses them.` |
| `reject` | `Dismissed 1 proposal(s):` + `aaaaaaaa  why tool execution failed?` |
| `skip`, 0 pending | `Done.` |
| `reject` again | `No pending proposals to reject.` (idempotent, not an error) |
| unknown action | `Use: analyze, export, skip, reject` |
| files on disk | both kept; the pending one is now `dismissed`, an `accepted` one untouched |

Plus a unit test (`dismiss_pending_leaves_the_files_and_the_other_statuses_alone`) covering: only pending is touched, nothing is deleted, and an empty inbox is a no-op. `cargo nextest -p mur-core --lib harvest::proposal` 9 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)