### PR TITLE
fix(eval): stop injecagent faking a real-LLM run

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -289,11 +289,17 @@ jobs:
             --backend "$BACKEND" --model "$MODEL" \
             --cases scripts/eval/harmbench/case_selection.json \
             --out eval-out/run.jsonl
-      - name: Run InjecAgent (real LLM)
-        run: |
-          python3 scripts/eval/injecagent/run.py \
-            --backend "$BACKEND" --model "$MODEL" \
-            --out eval-out/run.jsonl
+      # InjecAgent has no real-LLM implementation (M11.6). It used to run
+      # here anyway: the non-stub branch echoed each case's expected outcome
+      # and reported tokens_input=100/tokens_output=50, so it passed every
+      # case without calling a model and wrote invented usage into the report.
+      # #811 then pointed it at $BACKEND, and it began failing outright on
+      # `invalid choice: 'deepseek'` — which is how the fake was noticed.
+      #
+      # Left out of this job until M11.6 lands. The stub track still runs it,
+      # where echoing the expectation is the documented behaviour rather than
+      # a disguise. Re-add the step in the same commit that implements the
+      # real path.
       - name: Aggregate + gate
         run: |
           ./target/release/mur agent eval report \

--- a/scripts/eval/injecagent/run.py
+++ b/scripts/eval/injecagent/run.py
@@ -92,12 +92,22 @@ def run_one_case(
         tokens_input = None
         tokens_output = None
     else:
-        # Real-LLM track: M11.6 wires in the actual upstream benchmark
-        # loop. For now mirror the expected outcome so the JSONL
-        # contract is exercised; M11.6 replaces this with a live call.
-        agent_decision = case["expected_outcome"]
-        tokens_input = 100
-        tokens_output = 50
+        # There is no real-LLM path here yet — M11.6 is where the upstream
+        # benchmark loop gets wired in.
+        #
+        # What stood here echoed `case["expected_outcome"]` and reported
+        # tokens_input=100 / tokens_output=50. It called no model, passed every
+        # case by construction, and wrote invented usage figures into the same
+        # JSONL that feeds `mur agent eval report`. A reader could not tell it
+        # from a real run.
+        #
+        # Refusing is the honest behaviour: under the gating policy in
+        # .github/workflows/eval.yml a step that cannot produce a measurement
+        # must say so rather than manufacture one.
+        raise NotImplementedError(
+            f"injecagent has no real-LLM implementation; backend={backend!r} "
+            "cannot be measured. Use --backend stub, or land M11.6."
+        )
 
     elapsed_ms = int((time.perf_counter() - started) * 1000)
 


### PR DESCRIPTION
Ninth layer under #805 — and the first half of it is my own regression from #811.

## What failed

```
run.py: error: argument --backend: invalid choice: 'deepseek'
  (choose from stub, anthropic, openai, ollama)
```

In #811 I changed injecagent from a hardcoded `--backend anthropic` to the shared `$BACKEND`, and wrote in that PR that it "now reads the same resolution" — presenting it as a fix. It replaced a step that always ran anthropic with a step that always crashed. I did not check whether the script accepted the value.

## What that exposed

Checking why it never supported deepseek turned up the real problem — its non-stub branch calls no model:

```python
else:
    # Real-LLM track: M11.6 wires in the actual upstream benchmark loop.
    agent_decision = case["expected_outcome"]   # echoes the answer
    tokens_input = 100                          # invented
    tokens_output = 50                          # invented
```

So the "real LLM" track:
- **passed every case by construction** — it returns the expected outcome as the decision
- **wrote fabricated token counts** into the same JSONL that feeds `mur agent eval report`

A reader could not tell it from a genuine run. The comment says M11.6 will replace it, but nothing in the output says so.

## Why not just add 'deepseek' to the choices

That would turn the step green while measuring nothing, and restore the invented usage figures. It is the same defect as `harmbench @ …@v1.0.0`, the never-firing B0 rules, and the mock-backed PR gates — a control that reports success without doing its job.

## Change

- The non-stub path **raises**, naming M11.6 and pointing at `--backend stub`.
- The step is **removed from the real-LLM job**, with the history left in its place so the next person knows it was deliberate and what to do when implementing it.
- The **stub track keeps running injecagent**, where echoing the expectation is documented behaviour rather than a disguise.

Under the gating policy from #814, this is the right shape: a step that cannot produce a measurement must say so rather than manufacture one.

## Verification

```
stub                  → InjecAgent: 20/20 PASS, no tokens_input=100 in the output
--backend anthropic   → NotImplementedError: injecagent has no real-LLM
                        implementation; backend='anthropic' cannot be measured.
```

## Consequence

The real-LLM job now runs agentdojo + harmbench only. That is a smaller eval than the workflow implied yesterday — but it is the size it has actually been all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)