### PR TITLE
docs(readme): say where a new agent comes from, now that the wizard asks

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ never heard of MUR.
 2. Drag **MUR Hub** into Applications and open it.
 3. Say hi — the built-in concierge agent **MUR** is alive immediately: **offline,
    no API key, no signup**, running on a bundled local multimodal model.
+4. **+ New Agent** asks where the next one comes from — a **role template** MUR
+   fills in for you (skills, system prompt, least-privilege permissions), the
+   **official catalog**, or a `.muragent` a friend shared. Giving it a pet look
+   is the last step of every route, so any agent can live on your desktop.
 
 Received a `.muragent` file from a friend? **Double-click it.** Hub verifies the
 signature, walks you through model setup, and the agent comes alive.
@@ -300,6 +304,12 @@ The `.muragent` package is DSSE-signed and **contains no executable code and no
 secrets** — private keys and API keys are stripped at export. The recipient
 installs MUR Hub once (signed + notarized); after that, agents travel as plain
 files.
+
+MUR publishes agents the same way. `mur official list` browses the curated
+catalog and `mur official install agents/<name>` installs one — the bundle is
+signed by MUR and carries a license bound to your account, so an installed
+official agent verifies on your machine and nowhere else. The Hub's **+ New
+Agent** wizard offers the same catalog as a source.
 
 ### 🔐 Stay governed
 


### PR DESCRIPTION
Two user-facing surfaces changed today and the README described neither.

## 1. The + New Agent wizard asks a different question

It used to fork on what **kind** of agent to build (companion / specialist / both). It now asks where the agent comes **from** — role template, official catalog, or a shared `.muragent` — with the pet look as the last step of every route (#821). The Hub quick start stopped after "the concierge is alive", leaving the next step to guesswork; it now has a step 4.

## 2. The official catalog actually serves items

`mur official list` returned `HTTP 404` this morning and now lists `agents/researcher` (mur-server#37 fixed the route; official-catalog#1–#4 got the first publish through). The README never mentioned the catalog outside the command tree.

It lands in **🎁 Be given away**, next to `.muragent` sharing, because it is the same story from the other end — MUR handing you an agent rather than a friend handing you one, with the account-bound license as the difference.

## Not changed

- **Command tree** — `mur official  list · install` was already there; no top-level command added or removed, so the `(28 top-level commands)` count stands.
- **Roadmap** — nothing here was listed as upcoming.

Docs-site and product-page updates are a separate PR in `mur-server` (that repo deploys to the public app.mur.run on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)