### PR TITLE
docs(eval): record cost per backend, not one number for both

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -194,9 +194,21 @@ jobs:
           retention-days: 30
 
   # ── Real-LLM track ────────────────────────────────────────────────
-  # Runs on weekly cron + every v* tag. ~$5/run (50+50 cases).
+  # Runs on weekly cron + every v* tag. 50 AgentDojo + 50 HarmBench cases.
   # Requires ANTHROPIC_API_KEY or DEEPSEEK_API_KEY GitHub secret.
   # DeepSeek is auto-selected when only DEEPSEEK_API_KEY is set.
+  #
+  # Cost per run, which differs by roughly two orders of magnitude:
+  #   anthropic  ~$5      — original estimate for claude-sonnet, not
+  #                         re-measured since.
+  #   deepseek   ~$0.06   — measured 2026-07-29 off-peak, balance
+  #                         13.44 -> 13.38 across a 50+50 run.
+  #                         Double it during DeepSeek's peak window
+  #                         (Beijing 09:00-12:00 and 14:00-18:00); the
+  #                         crons above are set to miss it.
+  #
+  # Worth stating because the two invite opposite decisions about cadence:
+  # nightly on Anthropic is ~$150/month, nightly on DeepSeek is under $2.
   real-llm:
     name: Real-LLM (release / cron)
     runs-on: ubuntu-latest


### PR DESCRIPTION
The workflow header said:

```yaml
# Runs on weekly cron + every v* tag. ~$5/run (50+50 cases).
```

That number is **Anthropic's**, written when Anthropic was the only backend. It is not wrong — it is unlabelled, and the job now auto-selects DeepSeek whenever `ANTHROPIC_API_KEY` is absent, which is this repo's current state.

## Measured

DeepSeek balance `13.44 → 13.38` across a 50+50 run, off-peak: **~$0.06**. Roughly two orders of magnitude below the Anthropic estimate.

## Why it earns a comment

The two figures argue for opposite cadences:

| backend | per run | nightly |
|---|---|---|
| anthropic | ~$5 (estimate, not re-measured) | ~$150/month |
| deepseek | ~$0.06 (measured, off-peak) | under $2/month |

A single unlabelled number is enough to talk someone into the wrong schedule in either direction — and it talked *me* into several hours of unnecessary care about when to trigger runs that cost six cents.

The Anthropic figure is kept and marked as an unverified estimate rather than restated as observed. The peak-pricing note points back at the crons from #812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)