### PR TITLE
fix(sync): reject server workflows that cannot load, instead of writing them

### DIFF
--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -256,6 +256,7 @@ pub(crate) async fn device_sync(
                                 let workflows_dir = mur_dir.join("workflows");
                                 std::fs::create_dir_all(&workflows_dir)?;
                                 let mut pulled = 0u32;
+                                let mut rejected: Vec<String> = Vec::new();
                                 for item in data {
                                     let name = item
                                         .get("name")
@@ -280,11 +281,44 @@ pub(crate) async fn device_sync(
                                     if !path.starts_with(&workflows_dir) {
                                         continue;
                                     }
+                                    // Parse before writing. The name and path
+                                    // checks above stop a malicious filename;
+                                    // nothing stopped content that cannot
+                                    // load. An unparseable workflow written
+                                    // here is rewritten on every sync and
+                                    // warns forever from the store, naming a
+                                    // file the user cannot fix and did not
+                                    // create (#803).
+                                    if let Err(e) =
+                                        serde_yaml_ng::from_str::<mur_common::workflow::Workflow>(
+                                            yaml_content,
+                                        )
+                                    {
+                                        rejected.push(format!("{safe_name} ({e})"));
+                                        continue;
+                                    }
                                     std::fs::write(&path, yaml_content)?;
                                     pulled += 1;
                                 }
                                 if !quiet && pulled > 0 {
                                     eprintln!("  ✓ Pulled {} workflow(s) from server.", pulled);
+                                }
+                                // Report rather than write. Silence here would
+                                // reproduce the old failure in a new place: the
+                                // workflow would simply be missing, with no
+                                // more explanation than before.
+                                if !rejected.is_empty() {
+                                    eprintln!(
+                                        "  ⚠ Skipped {} workflow(s) from the server that do not parse:",
+                                        rejected.len(),
+                                    );
+                                    for r in &rejected {
+                                        eprintln!("      {r}");
+                                    }
+                                    eprintln!(
+                                        "    They were not written locally. Fix or remove them server-side \
+                                         (`mur workflow delete <name>`)."
+                                    );
                                 }
                             }
                         }
@@ -2126,5 +2160,50 @@ mod never_shadow_tests {
         // No file on disk → nothing to shadow.
         std::fs::remove_file(&f).unwrap();
         assert!(!super::dev_skill_shadowed_by_user(dir.path(), "mur-tdd"));
+    }
+
+    /// Pins the predicate the pull-path guard uses, on the file that actually
+    /// appeared in a user's `~/.mur/workflows/`: 32 bytes, valid YAML, missing
+    /// the fields `KnowledgeBase` requires. It was rewritten on every sync
+    /// while the store warned about it on every read (#803).
+    ///
+    /// Scope: this asserts what the guard tests, not that `device_sync` calls
+    /// it — that path is an async network function with no local seam. Read
+    /// the name literally.
+    #[test]
+    fn the_real_broken_workflow_fails_the_guards_parse_check() {
+        let bad = "id: test-wf\nname: Test\nsteps: []";
+        let parsed = serde_yaml_ng::from_str::<mur_common::workflow::Workflow>(bad);
+        assert!(
+            parsed.is_err(),
+            "fixture must be unparseable, or this test proves nothing"
+        );
+        // Valid YAML: the old filename/path guards would all have passed it.
+        assert!(serde_yaml_ng::from_str::<serde_yaml_ng::Value>(bad).is_ok());
+    }
+
+    /// The guard must not reject workflows that do load, or a sync would
+    /// silently stop delivering them — the same absence, a new cause.
+    ///
+    /// The fixture is the head of a real file from `~/.mur/workflows/`, not an
+    /// invented one: writing this test by guessing at the shape produced a
+    /// "well-formed" sample that did not parse, which would have made the
+    /// assertion pass for the wrong reason had it been the other way round.
+    #[test]
+    fn a_well_formed_server_workflow_still_parses() {
+        let good = concat!(
+            "schema: 2\n",
+            "name: find-prices-shopping-websites\n",
+            "description: use agent-browser to find prices.\n",
+            "content: ''\n",
+            "tier: session\n",
+            "importance: 0.5\n",
+            "confidence: 0.5\n",
+        );
+        let parsed = serde_yaml_ng::from_str::<mur_common::workflow::Workflow>(good);
+        assert!(
+            parsed.is_ok(),
+            "well-formed workflow must survive: {parsed:?}"
+        );
     }
 }


### PR DESCRIPTION
Closes the validation half of #803.

## The defect

`device_sync`'s pull path validated the workflow **name** and the resolved **path**, then wrote the server's bytes unconditionally. Whether those bytes could be loaded back as a `Workflow` was never checked.

The consequence was visible on this machine: `~/.mur/workflows/test-workflow.yaml`, 32 bytes —

```yaml
id: test-wf
name: Test
steps: []
```

Valid YAML, so every existing guard passed it. Not a loadable `Workflow`, so the store warned about it on every read. And because the pull path rewrote it on each sync, deleting it locally fixed nothing.

## The fix

Parse before writing. A workflow that does not deserialize is skipped, and the skip is **reported** — count, name, parse error, and the server-side remedy:

```
  ⚠ Skipped 1 workflow(s) from the server that do not parse:
      test-workflow (missing field `description`)
    They were not written locally. Fix or remove them server-side (`mur workflow delete <name>`).
```

Silence there would have moved the defect rather than fixed it: the workflow would simply be missing, explained no better than before.

## Tests

Two, both in `never_shadow_tests`:

- `the_real_broken_workflow_fails_the_guards_parse_check` — the fixture is the actual file from disk, and the test also asserts it is valid YAML, i.e. that every pre-existing guard would have let it through.
- `a_well_formed_server_workflow_still_parses` — guards the other direction, so the fix cannot silently stop delivering good workflows.

The second test's fixture is the head of a real file from `~/.mur/workflows/`. My first attempt invented the shape, and the invented "well-formed" sample did not parse — the test caught its own author.

The first test's name is deliberately narrow. It pins the predicate the guard uses; it does not drive `device_sync`, which is an async network function with no local seam. The comment says so.

## Verification

- `cargo test -p mur-core --lib sync_cmd` — 13 passed, 0 failed
- `cargo test --workspace --locked --no-run` — clean
- `cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)