### PR TITLE
feat(murmur): --fleet status rail

### DIFF
--- a/docs/superpowers/plans/2026-07-29-murmur-fleet-rail.md
+++ b/docs/superpowers/plans/2026-07-29-murmur-fleet-rail.md
@@ -1,0 +1,1191 @@
+# murmur `--fleet` Status Rail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `murmur --fleet <name>` chats with an agent while a status band folds the fleet's shared channel into per-member state — one line of job progress at rest, expanding only when a member is blocked.
+
+**Architecture:** A new `FleetRail` type polls the fleet's single channel (`fleet-<name>`) on the same 700 ms cadence as the existing `Follow`, gated on the channel log's size and the job directory's mtime so an idle tick costs two `metadata()` calls. Two pure functions do the work — `fold_members()` turns channel events into member rows, `jobs_line()` turns the job store into the collapsed summary — and a layout band renders the result between the transcript and the composer.
+
+**Tech Stack:** Rust 2024, ratatui 0.29 (Inline viewport), `mur-common::channel` event model, `mur-channel` store, `serde_yaml`, `cargo nextest`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-29-murmur-fleet-rail-design.md`. Read it before Task 1.
+- Rust edition 2024 — `let` chains are stable (`if let … && let …`).
+- No hardcoded values: poll cadence reuses `follow::POLL_INTERVAL`; the expanded-row cap is the named constant `MAX_EXPANDED_ROWS`.
+- Single source file ≤ 800 lines.
+- Signature verification is never bypassed: every event the rail folds passes `crate::channel_verify::verify_event`, with `require_sig` read exactly as `hitl/gate.rs:84` reads it.
+- The rail never propagates an error into the event loop. Any failure degrades to a one-line notice.
+- Build env for every `cargo` command in this plan:
+  ```bash
+  export PATH="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH"
+  export ORT_STRATEGY=download
+  export MUR_WEB_DIST=$HOME/Projects/mur-web/dist
+  export RUST_MIN_STACK=33554432
+  ```
+- Branch off `main`; one commit per task; re-check `git branch --show-current` before every commit (main advances mid-session).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `mur-core/src/cmd/agent/cli/fleet_rail.rs` **(new, ~260 lines)** | Everything rail: `MemberState`, `MemberRow`, `RailView`, the pure `fold_members()` / `jobs_line()`, and the polling `FleetRail`. |
+| `mur-core/src/cli/agent.rs:140` | Add `fleet: Option<String>` to the `Cli` action. |
+| `mur-core/src/dispatch.rs:1547` | Pass it through. |
+| `mur-core/src/cmd/agent/cli/mod.rs:111` | `cmd_cli` takes `fleet`, validates it, constructs the rail, polls it in the event loop. |
+| `mur-core/src/cmd/agent/cli/app.rs` | `App.fleet: Option<FleetRail>`. |
+| `mur-core/src/cmd/agent/cli/ui.rs` | `fleet_rail_height()`, `render_fleet_rail()`, layout band, and the `band_inner_rows()` subtraction. |
+
+Rail types live in one file because they change together: a new member state needs a new render arm and a new height case in the same edit.
+
+---
+
+### Task 1: `--fleet` reaches the TUI and rejects an unknown fleet
+
+Plumbing only — nothing renders yet. Ends with a flag that parses, validates, and is ignored.
+
+**Files:**
+- Modify: `mur-core/src/cli/agent.rs:140-166` (the `Cli` variant)
+- Modify: `mur-core/src/dispatch.rs:1547`
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs:111-118` (`cmd_cli` signature)
+- Test: `mur-core/src/cli/agent.rs` (existing `mod tests` at the bottom)
+
+**Interfaces:**
+- Produces: `AgentAction::Cli { …, fleet: Option<String> }` and `cmd_cli(names, resume, auto, skin, plain, budget_usd, auto_reads, fleet)`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `mur-core/src/cli/agent.rs`, inside the existing `mod tests`:
+
+```rust
+#[test]
+fn cli_action_parses_fleet_flag() {
+    let AgentAction::Cli { names, fleet, .. } =
+        parse_cli_action(&["mur", "agent", "cli", "mur", "--fleet", "develop"])
+    else {
+        panic!("expected Cli action");
+    };
+    assert_eq!(names, vec!["mur".to_string()]);
+    assert_eq!(fleet.as_deref(), Some("develop"));
+
+    // Absent by default — a plain murmur must not become fleet-aware.
+    let AgentAction::Cli { fleet, .. } = parse_cli_action(&["mur", "agent", "cli", "mur"]) else {
+        panic!("expected Cli action");
+    };
+    assert_eq!(fleet, None);
+}
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cargo nextest run -p mur-core --lib cli_action_parses_fleet_flag
+```
+Expected: FAIL — `struct AgentAction::Cli has no field named fleet`.
+
+- [ ] **Step 3: Add the field**
+
+In `mur-core/src/cli/agent.rs`, inside the `Cli { … }` variant, after `auto_reads`:
+
+```rust
+        /// Watch a fleet's shared channel in a status band: job progress at
+        /// rest, expanding when a member is blocked. Names the fleet, not the
+        /// channel — `--fleet develop` watches `fleet-develop`.
+        #[arg(long)]
+        fleet: Option<String>,
+```
+
+- [ ] **Step 4: Thread it through the dispatcher**
+
+`mur-core/src/dispatch.rs:1547` — add `fleet` to the destructured fields and the call:
+
+```rust
+        } => {
+            cmd::agent::cmd_cli(
+                &names, resume, auto, skin, plain, budget_usd, auto_reads, fleet,
+            )
+            .await?
+        }
+```
+
+- [ ] **Step 5: Accept and validate it in `cmd_cli`**
+
+`mur-core/src/cmd/agent/cli/mod.rs:111` — add the parameter, then validate right after `home` is resolved (the existing `let home = super::resolve_mur_home()?;`):
+
+```rust
+pub async fn cmd_cli(
+    names: &[String],
+    resume: bool,
+    auto: bool,
+    skin: Option<String>,
+    plain: bool,
+    budget_usd: Option<f64>,
+    auto_reads: bool,
+    fleet: Option<String>,
+) -> Result<()> {
+```
+
+and after `let home = …`:
+
+```rust
+    // Fail loudly on an unknown fleet. Degrading to a plain murmur would leave
+    // the user believing they are watching a fleet when they are not.
+    if let Some(f) = fleet.as_deref() {
+        crate::cmd::fleet::store::load_fleet(&home, f)
+            .with_context(|| format!("--fleet {f}"))?;
+    }
+```
+
+If the multi-agent branch above (`names.len() > 1`) is taken, print the same shape of note the other single-agent-only flags print:
+
+```rust
+        if fleet.is_some() {
+            eprintln!(
+                "note: --fleet is only shown in the single-agent TUI; it is ignored when opening multiple agents."
+            );
+        }
+```
+
+- [ ] **Step 6: Run the test and the whole CLI-parse suite**
+
+```bash
+cargo nextest run -p mur-core --lib cli::agent
+```
+Expected: PASS, no other test regressed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git branch --show-current   # confirm the feature branch
+git add mur-core/src/cli/agent.rs mur-core/src/dispatch.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(murmur): accept --fleet <name> and validate it exists"
+```
+
+---
+
+### Task 2: fold channel events into member rows
+
+The heart of the feature, and pure: `&[ChannelEvent]` in, `Vec<MemberRow>` out. No I/O, no clock.
+
+**Files:**
+- Create: `mur-core/src/cmd/agent/cli/fleet_rail.rs`
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs` (add `mod fleet_rail;` next to `mod follow;`)
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces:
+  - `pub enum MemberState { Blocked { summary: String, hitl_id: String }, Working { tool: Option<String>, since: DateTime<Utc> }, Done, Failed }`
+  - `pub struct MemberRow { pub agent: String, pub state: MemberState }`
+  - `pub fn fold_members(events: &[ChannelEvent]) -> Vec<MemberRow>`
+  - `pub const MAX_EXPANDED_ROWS: usize = 6;`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `mur-core/src/cmd/agent/cli/fleet_rail.rs` containing only the test module plus the imports it needs:
+
+```rust
+//! `--fleet` status rail: folds a fleet's shared channel into per-member state.
+
+use chrono::{DateTime, Utc};
+use mur_common::channel::{ChannelActor, ChannelEvent, EventKind};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ev(seq: u64, actor: ChannelActor, kind: EventKind, payload: serde_json::Value) -> ChannelEvent {
+        ChannelEvent {
+            seq,
+            ts: DateTime::parse_from_rfc3339("2026-07-29T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            actor,
+            kind,
+            payload,
+            idempotency_key: None,
+            sig: None,
+            key_version: None,
+        }
+    }
+
+    fn agent(id: &str) -> ChannelActor {
+        ChannelActor::Agent { id: id.into() }
+    }
+
+    #[test]
+    fn state_changes_map_to_member_states() {
+        let evs = vec![
+            ev(1, agent("qa"), EventKind::StateChange, json!({"from": "submitted", "to": "working"})),
+            ev(2, agent("backend"), EventKind::StateChange, json!({"from": "working", "to": "completed"})),
+            ev(3, agent("dataml"), EventKind::StateChange, json!({"from": "working", "to": "failed"})),
+            ev(4, agent("pm"), EventKind::StateChange, json!({"from": "working", "to": "canceled"})),
+        ];
+        let rows = fold_members(&evs);
+        let by = |n: &str| rows.iter().find(|r| r.agent == n).unwrap().state.clone();
+        assert!(matches!(by("qa"), MemberState::Working { .. }));
+        assert!(matches!(by("backend"), MemberState::Done));
+        // canceled and rejected collapse into failed — the user only needs
+        // "it did not finish".
+        assert!(matches!(by("dataml"), MemberState::Failed));
+        assert!(matches!(by("pm"), MemberState::Failed));
+    }
+
+    #[test]
+    fn a_hitl_request_blocks_and_its_response_unblocks() {
+        let req = json!({"hitl_id": "h1", "tool_name": "bash", "summary": "cargo publish", "action_hash": "x", "tier": "write"});
+        let evs = vec![
+            ev(1, agent("qa"), EventKind::StateChange, json!({"to": "working"})),
+            ev(2, agent("qa"), EventKind::HitlRequest, req),
+        ];
+        let rows = fold_members(&evs);
+        match &rows[0].state {
+            MemberState::Blocked { summary, hitl_id } => {
+                assert_eq!(hitl_id, "h1");
+                assert!(summary.contains("cargo publish"));
+            }
+            other => panic!("expected blocked, got {other:?}"),
+        }
+
+        // The approval is written by the HUMAN, not by the blocked agent, so
+        // clearing must key on hitl_id — never on the actor.
+        let mut evs = evs;
+        evs.push(ev(
+            3,
+            ChannelActor::Human { name: "david".into() },
+            EventKind::HitlResponse,
+            json!({"hitl_id": "h1", "allow": true, "surface": "cli"}),
+        ));
+        let rows = fold_members(&evs);
+        assert!(matches!(rows[0].state, MemberState::Working { .. }));
+    }
+
+    #[test]
+    fn tool_calls_annotate_the_working_row() {
+        let evs = vec![
+            ev(1, agent("qa"), EventKind::StateChange, json!({"to": "working"})),
+            ev(2, agent("qa"), EventKind::ToolCall, json!({"tool": "bash", "command": "cargo test"})),
+        ];
+        let rows = fold_members(&evs);
+        match &rows[0].state {
+            MemberState::Working { tool, .. } => assert_eq!(tool.as_deref(), Some("cargo test")),
+            other => panic!("expected working, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn human_and_system_actors_never_become_rows() {
+        let evs = vec![
+            ev(1, ChannelActor::Human { name: "david".into() }, EventKind::Message, json!({"text": "go"})),
+            ev(2, ChannelActor::System, EventKind::StateChange, json!({"to": "working"})),
+        ];
+        assert!(fold_members(&evs).is_empty());
+    }
+
+    #[test]
+    fn blocked_sorts_first_then_working_then_finished() {
+        let evs = vec![
+            ev(1, agent("aaa_done"), EventKind::StateChange, json!({"to": "completed"})),
+            ev(2, agent("bbb_working"), EventKind::StateChange, json!({"to": "working"})),
+            ev(3, agent("ccc_blocked"), EventKind::HitlRequest, json!({"hitl_id": "h1", "tool_name": "bash", "summary": "rm", "action_hash": "x", "tier": "write"})),
+        ];
+        let rows = fold_members(&evs);
+        let names: Vec<&str> = rows.iter().map(|r| r.agent.as_str()).collect();
+        assert_eq!(names, vec!["ccc_blocked", "bbb_working", "aaa_done"]);
+    }
+
+    #[test]
+    fn an_empty_channel_has_no_rows() {
+        assert!(fold_members(&[]).is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Register the module and watch it fail**
+
+Add to `mur-core/src/cmd/agent/cli/mod.rs`, next to the other `mod` declarations:
+
+```rust
+mod fleet_rail;
+```
+
+```bash
+cargo nextest run -p mur-core --lib fleet_rail
+```
+Expected: FAIL — `cannot find function fold_members`.
+
+- [ ] **Step 3: Implement the fold**
+
+Above the test module in `fleet_rail.rs`:
+
+```rust
+/// Most member rows shown when the rail expands. Blocked sorts first, so
+/// whatever is truncated is the least urgent.
+pub const MAX_EXPANDED_ROWS: usize = 6;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MemberState {
+    /// Waiting on a human. `hitl_id` is what `mur channel approve` takes.
+    Blocked { summary: String, hitl_id: String },
+    /// `tool` is the latest ToolCall's command; `since` is when the member
+    /// last changed state, rendered as elapsed time so a dead runtime shows
+    /// up as a growing number instead of a state we invented.
+    Working {
+        tool: Option<String>,
+        since: DateTime<Utc>,
+    },
+    Done,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemberRow {
+    pub agent: String,
+    pub state: MemberState,
+}
+
+impl MemberState {
+    /// Sort key: blocked first, then working, then finished.
+    fn rank(&self) -> u8 {
+        match self {
+            MemberState::Blocked { .. } => 0,
+            MemberState::Working { .. } => 1,
+            MemberState::Done | MemberState::Failed => 2,
+        }
+    }
+}
+
+/// First non-empty string field among `keys`.
+fn field<'a>(ev: &'a ChannelEvent, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|k| ev.payload.get(*k).and_then(|v| v.as_str()))
+        .filter(|s| !s.is_empty())
+}
+
+/// Fold a channel's events into one row per agent that has acted.
+///
+/// Only `ChannelActor::Agent` becomes a row: `Human` events are the user's own
+/// turns and `System` events are the executor's bookkeeping. A member with no
+/// events is absent rather than "idle" — silence is not a state we can read.
+pub fn fold_members(events: &[ChannelEvent]) -> Vec<MemberRow> {
+    // Insertion-ordered so the sort below is the only thing that reorders.
+    let mut rows: Vec<MemberRow> = Vec::new();
+    let mut index = |rows: &mut Vec<MemberRow>, id: &str, ts: DateTime<Utc>| -> usize {
+        if let Some(i) = rows.iter().position(|r| r.agent == id) {
+            return i;
+        }
+        rows.push(MemberRow {
+            agent: id.to_string(),
+            state: MemberState::Working {
+                tool: None,
+                since: ts,
+            },
+        });
+        rows.len() - 1
+    };
+
+    for ev in events {
+        // A HitlResponse is written by whoever approved — usually the human —
+        // so it is matched by hitl_id across ALL rows, not by actor.
+        if ev.kind == EventKind::HitlResponse
+            && let Some(id) = field(ev, &["hitl_id"])
+        {
+            for row in rows.iter_mut() {
+                if let MemberState::Blocked { hitl_id, .. } = &row.state
+                    && hitl_id == id
+                {
+                    row.state = MemberState::Working {
+                        tool: None,
+                        since: ev.ts,
+                    };
+                }
+            }
+            continue;
+        }
+
+        let ChannelActor::Agent { id } = &ev.actor else {
+            continue;
+        };
+
+        match ev.kind {
+            EventKind::StateChange => {
+                let Some(to) = field(ev, &["to"]) else { continue };
+                let state = match to {
+                    // ChannelState serializes kebab-case (see channel.rs tests).
+                    "working" | "submitted" => MemberState::Working {
+                        tool: None,
+                        since: ev.ts,
+                    },
+                    "input-required" => MemberState::Blocked {
+                        summary: "waiting for input".to_string(),
+                        hitl_id: String::new(),
+                    },
+                    "completed" => MemberState::Done,
+                    "failed" | "canceled" | "rejected" => MemberState::Failed,
+                    _ => continue,
+                };
+                let i = index(&mut rows, id, ev.ts);
+                rows[i].state = state;
+            }
+            EventKind::ToolCall => {
+                let tool = field(ev, &["command", "tool", "description"]).map(str::to_string);
+                let i = index(&mut rows, id, ev.ts);
+                // A tool call only annotates a running member; it must not
+                // resurrect one that already finished or unblock one waiting.
+                if let MemberState::Working { since, .. } = rows[i].state {
+                    rows[i].state = MemberState::Working { tool, since };
+                }
+            }
+            EventKind::HitlRequest => {
+                let i = index(&mut rows, id, ev.ts);
+                rows[i].state = MemberState::Blocked {
+                    summary: field(ev, &["summary", "tool_name"])
+                        .unwrap_or("approval needed")
+                        .to_string(),
+                    hitl_id: field(ev, &["hitl_id"]).unwrap_or_default().to_string(),
+                };
+            }
+            _ => {}
+        }
+    }
+
+    rows.sort_by(|a, b| {
+        a.state
+            .rank()
+            .cmp(&b.state.rank())
+            .then_with(|| a.agent.cmp(&b.agent))
+    });
+    rows
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cargo nextest run -p mur-core --lib fleet_rail
+```
+Expected: 6 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git branch --show-current
+git add mur-core/src/cmd/agent/cli/fleet_rail.rs mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(murmur): fold fleet channel events into per-member state"
+```
+
+---
+
+### Task 3: the collapsed job-progress line
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/fleet_rail.rs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `pub fn jobs_line(fleet: &str, jobs: &[Job]) -> String`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `mod tests` in `fleet_rail.rs`:
+
+```rust
+    use mur_common::fleet::{Job, JobStatus};
+
+    fn job(id: &str, status: JobStatus) -> Job {
+        Job {
+            id: id.into(),
+            text: "do the thing".into(),
+            source: "cli".into(),
+            status,
+            created_at: "2026-07-29T00:00:00Z".into(),
+            started_at: None,
+            finished_at: None,
+            run_id: None,
+            result: None,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn jobs_line_counts_terminal_over_total() {
+        let jobs = vec![
+            job("1", JobStatus::Done),
+            job("2", JobStatus::Failed),
+            job("3", JobStatus::Running),
+            job("4", JobStatus::Queued),
+            job("5", JobStatus::Queued),
+        ];
+        // 2 of 5 have reached a terminal state; one of those failed.
+        let line = jobs_line("develop", &jobs);
+        assert!(line.contains("fleet · develop"), "got: {line}");
+        assert!(line.contains("job 2/5"), "got: {line}");
+        assert!(line.contains("1 ⏵ running"), "got: {line}");
+        assert!(line.contains("1 ✖ failed"), "got: {line}");
+    }
+
+    #[test]
+    fn jobs_line_says_not_run_yet_when_there_are_none() {
+        let line = jobs_line("develop", &[]);
+        assert!(line.contains("not run yet"), "got: {line}");
+        assert!(line.contains("mur fleet run develop"), "got: {line}");
+    }
+
+    #[test]
+    fn jobs_line_omits_the_failed_clause_when_nothing_failed() {
+        let line = jobs_line("develop", &[job("1", JobStatus::Done)]);
+        assert!(!line.contains("failed"), "got: {line}");
+    }
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cargo nextest run -p mur-core --lib fleet_rail::tests::jobs_line
+```
+Expected: FAIL — `cannot find function jobs_line`.
+
+- [ ] **Step 3: Implement it**
+
+In `fleet_rail.rs` (add `use mur_common::fleet::{Job, JobStatus};` to the file's imports):
+
+```rust
+/// The always-present collapsed line: how far the fleet's work has got.
+///
+/// `2/5` is jobs in a terminal state over the total — the question a user asks
+/// first ("how far along?"), answered by the slow-moving store rather than by
+/// the event stream.
+pub fn jobs_line(fleet: &str, jobs: &[Job]) -> String {
+    if jobs.is_empty() {
+        return format!("fleet · {fleet}   not run yet (mur fleet run {fleet})");
+    }
+    let total = jobs.len();
+    let terminal = jobs.iter().filter(|j| j.status.is_terminal()).count();
+    let running = jobs
+        .iter()
+        .filter(|j| j.status == JobStatus::Running)
+        .count();
+    let failed = jobs
+        .iter()
+        .filter(|j| matches!(j.status, JobStatus::Failed | JobStatus::Canceled))
+        .count();
+    let mut line = format!("fleet · {fleet}   job {terminal}/{total}");
+    if running > 0 {
+        line.push_str(&format!(" · {running} ⏵ running"));
+    }
+    if failed > 0 {
+        line.push_str(&format!(" · {failed} ✖ failed"));
+    }
+    line
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+cargo nextest run -p mur-core --lib fleet_rail
+```
+Expected: 9 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git branch --show-current
+git add mur-core/src/cmd/agent/cli/fleet_rail.rs
+git commit -m "feat(murmur): job-progress summary line for the fleet rail"
+```
+
+---
+
+### Task 4: `FleetRail` — the gated poller
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/fleet_rail.rs`
+
+**Interfaces:**
+- Consumes: `fold_members`, `jobs_line`, `MAX_EXPANDED_ROWS` (Tasks 2–3); `follow::POLL_INTERVAL`.
+- Produces:
+  - `pub struct RailView { pub jobs_line: String, pub members: Vec<MemberRow>, pub notice: Option<String> }`
+  - `pub struct FleetRail` with `pub fn start(home: &Path, fleet: &str) -> Self`, `pub fn poll(&mut self, home: &Path, now: Instant) -> bool`, `pub fn view(&self) -> &RailView`, `pub fn next_poll(&self) -> Instant`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mod tests`:
+
+```rust
+    use mur_common::channel::ParticipantRole;
+    use std::time::Instant;
+
+    /// A channel with one member, plus the fleet dir the rail reads jobs from.
+    fn seed_home() -> tempfile::TempDir {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+        svc.create("fleet-dev", "goal", &[("mur", ParticipantRole::Router)])
+            .unwrap();
+        tmp
+    }
+
+    #[test]
+    fn poll_reports_change_only_when_the_log_grows() {
+        let tmp = seed_home();
+        let now = Instant::now();
+        let mut rail = FleetRail::start(tmp.path(), "dev");
+
+        // First poll reads the (empty) channel and the (absent) job dir.
+        assert!(rail.poll(tmp.path(), now), "first poll must produce a view");
+        assert!(rail.view().members.is_empty());
+        assert!(rail.view().jobs_line.contains("not run yet"));
+
+        // Nothing changed → no work, no change reported.
+        assert!(!rail.poll(tmp.path(), now));
+
+        // A member acts → the next poll picks it up.
+        let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+        svc.append(
+            "fleet-dev",
+            ChannelActor::Agent { id: "qa".into() },
+            EventKind::StateChange,
+            serde_json::json!({"to": "working"}),
+            None,
+        )
+        .unwrap();
+        assert!(rail.poll(tmp.path(), now), "log grew → view must change");
+        assert_eq!(rail.view().members.len(), 1);
+        assert_eq!(rail.view().members[0].agent, "qa");
+    }
+
+    #[test]
+    fn an_unreadable_channel_degrades_instead_of_failing() {
+        let tmp = tempfile::TempDir::new().unwrap(); // no channel at all
+        let mut rail = FleetRail::start(tmp.path(), "ghost");
+        rail.poll(tmp.path(), Instant::now());
+        assert!(rail.view().members.is_empty());
+        // The rail says so on its own line; it never returns Err.
+        assert!(rail.view().notice.is_some());
+    }
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+cargo nextest run -p mur-core --lib fleet_rail::tests::poll
+```
+Expected: FAIL — `cannot find struct FleetRail`.
+
+- [ ] **Step 3: Implement it**
+
+In `fleet_rail.rs` (add the imports `use std::path::Path; use std::time::Instant; use super::follow::POLL_INTERVAL;`):
+
+```rust
+/// What the band renders. Recomputed only when the channel log or the job
+/// store actually changed.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RailView {
+    pub jobs_line: String,
+    pub members: Vec<MemberRow>,
+    /// Degraded-state text (unreadable channel, unreadable jobs). Rendered in
+    /// place of detail; never an error the caller has to handle.
+    pub notice: Option<String>,
+}
+
+/// Polls one fleet's channel and job store, folding both into a `RailView`.
+///
+/// Deliberately a separate type from `Follow`: that one turns events into
+/// transcript lines (history, reaches scrollback), this one folds them into
+/// current state (repainted every frame, never flushed). Keeping them apart also
+/// leaves `app.follow` free, so `/channels <id> --follow` still works while a
+/// rail is up.
+pub struct FleetRail {
+    fleet: String,
+    channel_id: String,
+    /// Channel log size at the last poll; unchanged size means nothing to parse.
+    last_len: u64,
+    /// Newest mtime seen in the jobs dir; jobs move far slower than events.
+    last_jobs_mtime: Option<std::time::SystemTime>,
+    view: RailView,
+    next_poll: Instant,
+}
+
+impl FleetRail {
+    pub fn start(home: &Path, fleet: &str) -> Self {
+        let _ = home;
+        Self {
+            fleet: fleet.to_string(),
+            channel_id: format!("fleet-{fleet}"),
+            last_len: u64::MAX, // force the first poll to do real work
+            last_jobs_mtime: None,
+            view: RailView::default(),
+            next_poll: Instant::now(),
+        }
+    }
+
+    pub fn view(&self) -> &RailView {
+        &self.view
+    }
+
+    pub fn next_poll(&self) -> Instant {
+        self.next_poll
+    }
+
+    /// Recompute if anything moved. Returns true when the view changed, so the
+    /// caller redraws only then.
+    pub fn poll(&mut self, home: &Path, now: Instant) -> bool {
+        self.next_poll = now + POLL_INTERVAL;
+        let store = mur_channel::ChannelStore::new(home);
+        let len = std::fs::metadata(store.events_path(&self.channel_id))
+            .map(|m| m.len())
+            .unwrap_or(0);
+        let jobs_mtime = newest_jobs_mtime(home, &self.fleet);
+        if len == self.last_len && jobs_mtime == self.last_jobs_mtime {
+            return false;
+        }
+        self.last_len = len;
+        self.last_jobs_mtime = jobs_mtime;
+
+        let mut notice = None;
+        let events = match store.load_events(&self.channel_id) {
+            Ok(evs) => {
+                // Same trust rule as every other fold: an event that fails its
+                // actor's signature is dropped, never rendered. The rail
+                // vouches for OTHER agents, so showing an unverified "done"
+                // would lend the UI's credibility to a forgery.
+                let require_sig = std::env::var("MUR_CHANNEL_REQUIRE_SIG")
+                    .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
+                    .unwrap_or(false);
+                evs.into_iter()
+                    .filter(|e| {
+                        crate::channel_verify::verify_event(home, &self.channel_id, e, require_sig)
+                    })
+                    .collect::<Vec<_>>()
+            }
+            Err(_) => {
+                notice = Some("⚠ channel unreadable".to_string());
+                Vec::new()
+            }
+        };
+
+        let jobs = crate::cmd::fleet::jobs::list_jobs_raw(home, &self.fleet).unwrap_or_default();
+        let view = RailView {
+            jobs_line: jobs_line(&self.fleet, &jobs),
+            members: fold_members(&events),
+            notice,
+        };
+        let changed = view != self.view;
+        self.view = view;
+        changed
+    }
+}
+
+/// Newest mtime across the fleet's job files — the cheap "did jobs move?" gate.
+fn newest_jobs_mtime(home: &Path, fleet: &str) -> Option<std::time::SystemTime> {
+    let dir = crate::cmd::fleet::jobs::jobs_dir(home, fleet);
+    std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .filter_map(|e| e.metadata().ok()?.modified().ok())
+        .max()
+}
+```
+
+- [ ] **Step 4: Add the non-reconciling job reader**
+
+`list_jobs()` reloads the whole channel to reconcile (`jobs.rs:140`), so calling it here would parse the same log twice a second. Add a sibling in `mur-core/src/cmd/fleet/jobs.rs` that only reads the store, and make `list_jobs` use it so there is one reader:
+
+```rust
+/// Jobs straight from the store, oldest-first, with no channel reconciliation.
+/// `list_jobs` adds reconciliation on top; callers that already hold the
+/// channel's events (the murmur fleet rail) use this to avoid re-parsing it.
+pub(crate) fn list_jobs_raw(mur_home: &Path, fleet: &str) -> Result<Vec<Job>> {
+    // …body of today's list_jobs, up to and including the sort, minus the
+    // reconcile_jobs call…
+}
+```
+
+and `list_jobs` becomes:
+
+```rust
+pub fn list_jobs(mur_home: &Path, fleet: &str) -> Result<Vec<Job>> {
+    let mut jobs = list_jobs_raw(mur_home, fleet)?;
+    reconcile_jobs(mur_home, fleet, &mut jobs);
+    Ok(jobs)
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+cargo nextest run -p mur-core --lib fleet_rail
+cargo nextest run -p mur-core --lib fleet::jobs
+```
+Expected: all PASS — the second command proves the `list_jobs` split did not change its behavior.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git branch --show-current
+git add mur-core/src/cmd/agent/cli/fleet_rail.rs mur-core/src/cmd/fleet/jobs.rs
+git commit -m "feat(murmur): gated fleet-rail poller over channel + job store"
+```
+
+---
+
+### Task 5: render the band, and keep the flush capacity honest
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/ui.rs`
+
+**Interfaces:**
+- Consumes: `RailView`, `MemberState`, `MAX_EXPANDED_ROWS`, `App.fleet` (Task 6 adds the field — for this task, add it first as `pub fleet: Option<super::fleet_rail::FleetRail>` in `app.rs` and leave it `None`).
+- Produces: `pub fn fleet_rail_height(app: &App) -> u16`, `fn render_fleet_rail(f: &mut Frame, app: &App, area: Rect)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a test module to `ui.rs`:
+
+```rust
+#[cfg(test)]
+mod fleet_rail_layout_tests {
+    use super::*;
+    use crate::cmd::agent::cli::fleet_rail::{MemberRow, MemberState, RailView};
+
+    fn view(blocked: usize) -> RailView {
+        RailView {
+            jobs_line: "fleet · dev   job 0/1".into(),
+            members: (0..blocked)
+                .map(|i| MemberRow {
+                    agent: format!("m{i}"),
+                    state: MemberState::Blocked {
+                        summary: "approve".into(),
+                        hitl_id: format!("h{i}"),
+                    },
+                })
+                .collect(),
+            notice: None,
+        }
+    }
+
+    #[test]
+    fn rail_is_one_row_until_someone_is_blocked() {
+        assert_eq!(rail_height_for(&view(0)), 1);
+        assert_eq!(rail_height_for(&view(1)), 2);
+        assert_eq!(rail_height_for(&view(3)), 4);
+    }
+
+    #[test]
+    fn the_expanded_rail_is_capped() {
+        use crate::cmd::agent::cli::fleet_rail::MAX_EXPANDED_ROWS;
+        assert_eq!(
+            rail_height_for(&view(50)),
+            1 + MAX_EXPANDED_ROWS as u16,
+            "an unbounded rail would eat the transcript"
+        );
+    }
+
+    #[test]
+    fn the_live_band_gives_back_exactly_what_the_rail_takes() {
+        // The guard for the one dangerous coupling: band_inner_rows decides
+        // when transcript content is flushed to scrollback, so it must account
+        // for every row the rail paints or the flush drifts from the picture.
+        let viewport_h = 20u16;
+        let mut app = App::for_test();
+        let without = band_inner_rows(&app, viewport_h);
+        app.fleet_view_for_test = Some(view(3));
+        let with = band_inner_rows(&app, viewport_h);
+        assert_eq!(without - with, rail_height_for(&view(3)));
+    }
+}
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+cargo nextest run -p mur-core --lib fleet_rail_layout
+```
+Expected: FAIL — `cannot find function rail_height_for`.
+
+- [ ] **Step 3: Implement height + render + the subtraction**
+
+In `ui.rs`:
+
+```rust
+/// Rows the fleet rail paints: one collapsed line, plus a capped member list
+/// when someone is blocked. A working fleet is not news; a stalled one is.
+pub fn rail_height_for(view: &crate::cmd::agent::cli::fleet_rail::RailView) -> u16 {
+    use crate::cmd::agent::cli::fleet_rail::{MAX_EXPANDED_ROWS, MemberState};
+    let blocked = view
+        .members
+        .iter()
+        .any(|m| matches!(m.state, MemberState::Blocked { .. }));
+    if !blocked {
+        return 1;
+    }
+    1 + view.members.len().min(MAX_EXPANDED_ROWS) as u16
+}
+
+/// Height of the rail band for the current app state; 0 when `--fleet` is off.
+pub fn fleet_rail_height(app: &App) -> u16 {
+    app.fleet_view().map(rail_height_for).unwrap_or(0)
+}
+
+fn render_fleet_rail(f: &mut Frame, app: &App, area: Rect) {
+    use crate::cmd::agent::cli::fleet_rail::{MAX_EXPANDED_ROWS, MemberState};
+    let Some(view) = app.fleet_view() else { return };
+    let theme = app.theme;
+    let mut lines: Vec<Line> = Vec::new();
+
+    let head = match &view.notice {
+        Some(n) => format!("{}  {n}", view.jobs_line),
+        None => view.jobs_line.clone(),
+    };
+    lines.push(Line::styled(
+        head,
+        Style::default().fg(theme.border_title).add_modifier(Modifier::BOLD),
+    ));
+
+    if rail_height_for(view) > 1 {
+        for m in view.members.iter().take(MAX_EXPANDED_ROWS) {
+            let (glyph, body, color) = match &m.state {
+                MemberState::Blocked { summary, .. } => ("▲", format!("blocked: {summary}"), theme.warn),
+                MemberState::Working { tool, since } => (
+                    "⏵",
+                    match tool {
+                        Some(t) => format!("working ({}) · {t}", elapsed(*since)),
+                        None => format!("working ({})", elapsed(*since)),
+                    },
+                    theme.agent,
+                ),
+                MemberState::Done => ("✔", "done".to_string(), theme.success),
+                MemberState::Failed => ("✖", "failed".to_string(), theme.error),
+            };
+            lines.push(Line::styled(
+                format!("  {:<10} {glyph} {body}", m.agent),
+                Style::default().fg(color),
+            ));
+        }
+        let extra = view.members.len().saturating_sub(MAX_EXPANDED_ROWS);
+        if extra > 0 {
+            lines.push(Line::styled(
+                format!("  … {extra} more"),
+                Style::default().fg(theme.system),
+            ));
+        }
+    }
+
+    f.render_widget(Paragraph::new(Text::from(lines)), area);
+}
+
+/// "2m" / "1h04m" — elapsed since a member last changed state. Shown instead
+/// of a staleness verdict: a runtime that died mid-turn shows a growing
+/// number rather than a state we guessed.
+fn elapsed(since: chrono::DateTime<chrono::Utc>) -> String {
+    let secs = (chrono::Utc::now() - since).num_seconds().max(0);
+    match secs {
+        0..=59 => format!("{secs}s"),
+        60..=3599 => format!("{}m", secs / 60),
+        _ => format!("{}h{:02}m", secs / 3600, (secs % 3600) / 60),
+    }
+}
+```
+
+Then wire the band into `render()` (`ui.rs:51`), between the transcript and the chooser:
+
+```rust
+    let rail_h = fleet_rail_height(app);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(3),
+            Constraint::Length(rail_h),
+            Constraint::Length(chooser_h),
+            Constraint::Length(input_height),
+            Constraint::Length(1),
+        ])
+        .split(f.area());
+
+    render_transcript(f, app, chunks[0]);
+    if rail_h > 0 {
+        render_fleet_rail(f, app, chunks[1]);
+    }
+    if chooser_h > 0 {
+        render_chooser_band(f, app, chunks[2]);
+    } else {
+        render_completion(f, app, chunks[3]);
+    }
+    f.render_widget(&app.input, chunks[3]);
+    render_status(f, app, chunks[4]);
+```
+
+and subtract it in `band_inner_rows`:
+
+```rust
+fn band_inner_rows(app: &App, viewport_h: u16) -> u16 {
+    let input_h = (app.input.lines().len() as u16 + 2).clamp(3, 8);
+    let chooser_h = chooser_band_height(app, viewport_h, input_h);
+    // The rail steals rows from the live band; miss it here and the flush
+    // decision drifts from what is painted.
+    let rail_h = fleet_rail_height(app);
+    viewport_h.saturating_sub(input_h + 1 + chooser_h + rail_h + 2)
+}
+```
+
+- [ ] **Step 4: Add the test seams to `App`**
+
+In `app.rs`:
+
+```rust
+    /// Fleet rail, when `--fleet` is on. `None` for an ordinary murmur.
+    pub fleet: Option<super::fleet_rail::FleetRail>,
+    /// Test-only override so layout tests need no poller or filesystem.
+    #[cfg(test)]
+    pub fleet_view_for_test: Option<super::fleet_rail::RailView>,
+```
+
+```rust
+impl App {
+    /// The rail's current view, from the live poller or (in tests) the override.
+    pub fn fleet_view(&self) -> Option<&super::fleet_rail::RailView> {
+        #[cfg(test)]
+        if self.fleet_view_for_test.is_some() {
+            return self.fleet_view_for_test.as_ref();
+        }
+        self.fleet.as_ref().map(|f| f.view())
+    }
+}
+```
+
+Initialize `fleet: None` (and `fleet_view_for_test: None`) wherever `App` is constructed.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+cargo nextest run -p mur-core --lib fleet_rail_layout
+cargo nextest run -p mur-core --lib cmd::agent::cli
+```
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git branch --show-current
+git add mur-core/src/cmd/agent/cli/ui.rs mur-core/src/cmd/agent/cli/app.rs
+git commit -m "feat(murmur): render the fleet rail and charge it to the band capacity"
+```
+
+---
+
+### Task 6: poll it from the event loop, and verify it live
+
+**Files:**
+- Modify: `mur-core/src/cmd/agent/cli/mod.rs` (construct the rail; poll it in the loop)
+
+**Interfaces:**
+- Consumes: everything above.
+
+- [ ] **Step 1: Construct the rail after `App` is built**
+
+In `cmd_cli`, where the single-agent `App` is created:
+
+```rust
+    if let Some(f) = fleet.as_deref() {
+        app.fleet = Some(super::cli::fleet_rail::FleetRail::start(&home, f));
+    }
+```
+
+- [ ] **Step 2: Poll it on the same tick as `follow`**
+
+In the event loop, next to the existing follow drain, before the draw:
+
+```rust
+        // Fleet rail: cheap when nothing moved (two metadata calls), and only
+        // forces a redraw when the folded view actually changed.
+        if let Some(rail) = app.fleet.as_mut()
+            && StdInstant::now() >= rail.next_poll()
+            && rail.poll(&app.home.clone(), StdInstant::now())
+        {
+            app.needs_full_redraw = true;
+        }
+```
+
+- [ ] **Step 3: Build a release binary**
+
+```bash
+cargo build --release -p mur-core --bin mur
+```
+Expected: `Finished`.
+
+- [ ] **Step 4: Verify against a real fleet in tmux**
+
+```bash
+# a fleet whose channel has events; create one if needed:
+#   ./target/release/mur fleet create dev --members qa,backend
+tmux kill-session -t railtest 2>/dev/null
+tmux new-session -d -s railtest -x 100 -y 40 \
+  "$PWD/target/release/mur agent cli mur --fleet dev"
+sleep 12
+tmux capture-pane -t railtest -p | tail -12
+```
+Expected: one `fleet · dev …` line directly above the composer; composer still on the bottom rows; status line last.
+
+- [ ] **Step 5: Verify the blocked path expands**
+
+Append a HitlRequest to the fleet channel from a second shell, then re-capture:
+
+```bash
+tmux capture-pane -t railtest -p | tail -14
+```
+Expected: the rail grows to two rows — the job line plus `backend  ▲ blocked: …` — and the transcript band shrinks by exactly one row. Kill the session: `tmux kill-session -t railtest`.
+
+- [ ] **Step 6: Verify the unknown-fleet error**
+
+```bash
+./target/release/mur agent cli mur --fleet nope 2>&1 | head -2
+```
+Expected: a non-zero exit naming `--fleet nope`; no TUI opens.
+
+- [ ] **Step 7: Full test + lint gate**
+
+```bash
+cargo nextest run -p mur-core --lib
+cargo clippy -p mur-core --bin mur -- -D warnings
+cargo fmt -p mur-core
+```
+Expected: all PASS, clippy clean.
+
+- [ ] **Step 8: Commit and open the PR**
+
+```bash
+git branch --show-current
+git add mur-core/src/cmd/agent/cli/mod.rs
+git commit -m "feat(murmur): poll the fleet rail from the event loop"
+git push -u origin HEAD
+gh pr create --title "feat(murmur): --fleet status rail" --body "…"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage**
+
+| spec section | task |
+|---|---|
+| §1 surface: `--fleet` flag, unknown fleet is a hard error | 1 |
+| §1 collapsed job line, `2/5` = terminal/total, empty state | 3 |
+| §1 expanded on blocked, all members sorted blocked-first | 2 (fold + sort), 5 (height + render) |
+| §2 state derivation table, Human/System excluded | 2 |
+| §3 `FleetRail` separate from `Follow`, 700 ms gated poll, load-once | 4 |
+| §3 `band_inner_rows` must subtract the rail | 5 (impl + guard test) |
+| §4 unreadable channel degrades | 4 |
+| §4 signature verification never bypassed | 4 |
+| §4 elapsed time instead of a staleness verdict | 5 (`elapsed()`) |
+| §4 cap at K=6 plus "… N more" | 5 |
+| §4 corrupt jobs → fall back, no crash | 4 (`unwrap_or_default`) |
+| §5 fold table test, height test, consistency guard | 2, 5 |
+
+No gaps.
+
+**Type consistency** — `MemberState` / `MemberRow` / `RailView` / `fold_members` / `jobs_line` / `MAX_EXPANDED_ROWS` / `rail_height_for` / `fleet_rail_height` / `App::fleet_view()` are spelled identically in every task that uses them. `list_jobs_raw` is introduced in Task 4 and used only there.
+
+**Known follow-ups (out of scope, per the spec's "deliberately not in v1")** — approving a blocked member from the rail; more than one fleet per session; a pane per member.

--- a/docs/superpowers/plans/2026-07-29-murmur-fleet-rail.md
+++ b/docs/superpowers/plans/2026-07-29-murmur-fleet-rail.md
@@ -615,14 +615,15 @@ git commit -m "feat(murmur): job-progress summary line for the fleet rail"
 Add to `mod tests`:
 
 ```rust
-    use mur_common::channel::ParticipantRole;
     use std::time::Instant;
 
-    /// A channel with one member, plus the fleet dir the rail reads jobs from.
+    /// A fleet channel with one member. `create_for_fleet(fleet_name, router,
+    /// members)` names the channel `fleet-<fleet_name>` itself — the rail must
+    /// derive the same id from `--fleet dev`.
     fn seed_home() -> tempfile::TempDir {
         let tmp = tempfile::TempDir::new().unwrap();
         let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
-        svc.create("fleet-dev", "goal", &[("mur", ParticipantRole::Router)])
+        svc.create_for_fleet("dev", "mur", &["qa".to_string()])
             .unwrap();
         tmp
     }
@@ -889,7 +890,16 @@ mod fleet_rail_layout_tests {
         // when transcript content is flushed to scrollback, so it must account
         // for every row the rail paints or the flush drifts from the picture.
         let viewport_h = 20u16;
-        let mut app = App::for_test();
+        let tmp = tempfile::TempDir::new().unwrap();
+        // App::new(home, agent, session, theme) — the same constructor
+        // `cmd_cli` uses (mod.rs:393). There is no App::for_test; the only
+        // `for_test` in app.rs builds a ChatMsg.
+        let mut app = App::new(
+            tmp.path().to_path_buf(),
+            "mur".to_string(),
+            crate::cmd::agent::cli::persist::Session::create(tmp.path(), "mur").unwrap(),
+            crate::cmd::agent::cli::theme::resolve_skin("dark"),
+        );
         let without = band_inner_rows(&app, viewport_h);
         app.fleet_view_for_test = Some(view(3));
         let with = band_inner_rows(&app, viewport_h);

--- a/docs/superpowers/plans/2026-07-29-murmur-fleet-rail.md
+++ b/docs/superpowers/plans/2026-07-29-murmur-fleet-rail.md
@@ -838,8 +838,8 @@ git commit -m "feat(murmur): gated fleet-rail poller over channel + job store"
 - Modify: `mur-core/src/cmd/agent/cli/ui.rs`
 
 **Interfaces:**
-- Consumes: `RailView`, `MemberState`, `MAX_EXPANDED_ROWS`, `App.fleet` (Task 6 adds the field — for this task, add it first as `pub fleet: Option<super::fleet_rail::FleetRail>` in `app.rs` and leave it `None`).
-- Produces: `pub fn fleet_rail_height(app: &App) -> u16`, `fn render_fleet_rail(f: &mut Frame, app: &App, area: Rect)`.
+- Consumes: `RailView`, `MemberState`, `MAX_EXPANDED_ROWS` (Tasks 2–4). This task adds `App.fleet` itself; Task 6 populates it.
+- Produces: `pub fn rail_height_for(view: &RailView) -> u16`, `pub fn fleet_rail_height(app: &App) -> u16`, `fn band_capacity(viewport_h: u16, input_h: u16, chooser_h: u16, rail_h: u16) -> u16`, `fn render_fleet_rail(f: &mut Frame, app: &App, area: Rect)`.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -889,21 +889,13 @@ mod fleet_rail_layout_tests {
         // The guard for the one dangerous coupling: band_inner_rows decides
         // when transcript content is flushed to scrollback, so it must account
         // for every row the rail paints or the flush drifts from the picture.
+        // Tested on the pure arithmetic so no App and no test-only seam in
+        // production code are needed.
         let viewport_h = 20u16;
-        let tmp = tempfile::TempDir::new().unwrap();
-        // App::new(home, agent, session, theme) — the same constructor
-        // `cmd_cli` uses (mod.rs:393). There is no App::for_test; the only
-        // `for_test` in app.rs builds a ChatMsg.
-        let mut app = App::new(
-            tmp.path().to_path_buf(),
-            "mur".to_string(),
-            crate::cmd::agent::cli::persist::Session::create(tmp.path(), "mur").unwrap(),
-            crate::cmd::agent::cli::theme::resolve_skin("dark"),
-        );
-        let without = band_inner_rows(&app, viewport_h);
-        app.fleet_view_for_test = Some(view(3));
-        let with = band_inner_rows(&app, viewport_h);
-        assert_eq!(without - with, rail_height_for(&view(3)));
+        let input_h = 3u16;
+        let without = band_capacity(viewport_h, input_h, 0, 0);
+        let with_rail = band_capacity(viewport_h, input_h, 0, rail_height_for(&view(3)));
+        assert_eq!(without - with_rail, rail_height_for(&view(3)));
     }
 }
 ```
@@ -1027,45 +1019,48 @@ Then wire the band into `render()` (`ui.rs:51`), between the transcript and the 
     render_status(f, app, chunks[4]);
 ```
 
-and subtract it in `band_inner_rows`:
+and subtract it in `band_inner_rows`. Split the arithmetic into a pure
+helper so the coupling is a testable function rather than a fact buried in a
+method that needs an `App`:
 
 ```rust
+/// Rows left for the live transcript band inside `viewport_h` once the
+/// composer, status line, chooser band, fleet rail and the band's own
+/// TOP/BOTTOM borders have taken theirs.
+fn band_capacity(viewport_h: u16, input_h: u16, chooser_h: u16, rail_h: u16) -> u16 {
+    viewport_h.saturating_sub(input_h + 1 + chooser_h + rail_h + 2)
+}
+
 fn band_inner_rows(app: &App, viewport_h: u16) -> u16 {
     let input_h = (app.input.lines().len() as u16 + 2).clamp(3, 8);
     let chooser_h = chooser_band_height(app, viewport_h, input_h);
     // The rail steals rows from the live band; miss it here and the flush
     // decision drifts from what is painted.
-    let rail_h = fleet_rail_height(app);
-    viewport_h.saturating_sub(input_h + 1 + chooser_h + rail_h + 2)
+    band_capacity(viewport_h, input_h, chooser_h, fleet_rail_height(app))
 }
 ```
 
-- [ ] **Step 4: Add the test seams to `App`**
+- [ ] **Step 4: Add the rail field to `App`**
 
 In `app.rs`:
 
 ```rust
     /// Fleet rail, when `--fleet` is on. `None` for an ordinary murmur.
     pub fleet: Option<super::fleet_rail::FleetRail>,
-    /// Test-only override so layout tests need no poller or filesystem.
-    #[cfg(test)]
-    pub fleet_view_for_test: Option<super::fleet_rail::RailView>,
 ```
 
 ```rust
 impl App {
-    /// The rail's current view, from the live poller or (in tests) the override.
+    /// The rail's current view, or `None` when `--fleet` is off.
     pub fn fleet_view(&self) -> Option<&super::fleet_rail::RailView> {
-        #[cfg(test)]
-        if self.fleet_view_for_test.is_some() {
-            return self.fleet_view_for_test.as_ref();
-        }
         self.fleet.as_ref().map(|f| f.view())
     }
 }
 ```
 
-Initialize `fleet: None` (and `fleet_view_for_test: None`) wherever `App` is constructed.
+Initialize `fleet: None` in `App::new` (`app.rs:478`). No test-only field and
+no `#[cfg(test)]` branch in the getter: the layout tests exercise
+`rail_height_for` and `band_capacity`, which take their inputs directly.
 
 - [ ] **Step 5: Run the tests**
 

--- a/docs/superpowers/specs/2026-07-29-murmur-fleet-rail-design.md
+++ b/docs/superpowers/specs/2026-07-29-murmur-fleet-rail-design.md
@@ -107,7 +107,7 @@ Existing enums only; no new vocabulary.
 
 | channel event | member state |
 |---|---|
-| `StateChange → Working` | ⏵ working |
+| `StateChange → Working`, or `StateChange → "submitted"` | ⏵ working |
 | `StateChange → InputRequired`, or a `HitlRequest` with no matching `HitlResponse` | ▲ **blocked** (with the request summary) |
 | `StateChange → Completed` | ✔ done |
 | `StateChange → Failed` / `Canceled` / `Rejected` | ✖ failed |

--- a/docs/superpowers/specs/2026-07-29-murmur-fleet-rail-design.md
+++ b/docs/superpowers/specs/2026-07-29-murmur-fleet-rail-design.md
@@ -1,0 +1,193 @@
+# murmur `--fleet`: a status rail for fleet work
+
+**Date:** 2026-07-29
+**Status:** design approved, not implemented
+
+## Problem
+
+`murmur` chats with one agent. A fleet is several agents working a shared goal,
+and today nothing about that work is visible from the chat: you cannot see how
+far the work has got, who is doing what, or — the one that costs real time —
+which member is **blocked waiting for an approval you never saw**.
+
+The request that started this: *"chat with mur and see all jobs of channels of
+members of fleet."*
+
+## What already exists
+
+Three findings shaped the design; each removed work rather than adding it.
+
+1. **Live-tailing another channel already ships.** `/channels <id> --follow`
+   (`mur-core/src/cmd/agent/cli/follow.rs`) tails any channel into the
+   transcript while you keep chatting — 700 ms poll, gated on the log actually
+   growing.
+2. **A fleet has exactly one channel.** `fleet-<name>`. Members write their own
+   signed replies into it via `channel/delegate` (v3d-2), and `mur fleet jobs`
+   already treats that channel as the truth for reconciling job status
+   (`cmd/fleet/jobs.rs:132`). Seeing every member means following **one**
+   channel, not N.
+3. **The vocabulary exists.** `EventKind` (Message / ToolCall / StateChange /
+   HitlRequest / HitlResponse / …), `ChannelActor::{Human, Agent, System}`,
+   `ChannelState` (Working / InputRequired / Completed / Failed / …) in
+   `mur-common/src/channel.rs`; `JobStatus` (Queued / Running / Done / Failed /
+   Canceled) in `mur-common/src/fleet.rs`; `list_jobs()` in
+   `cmd/fleet/jobs.rs:163`.
+
+## Why not two modes
+
+The obvious framing was "merged into the chat stream" vs "a separate pane", with
+a flag to pick. Rejected, for two reasons.
+
+**The merged mode already exists.** `/channels fleet-develop --follow` is
+exactly that. Shipping `--fleet` as an alias for it would add a flag and no
+capability.
+
+**A raw event stream does not answer the question.** Research into how 2026
+agent tooling handles this converges on one point: an interleaved feed scales to
+about one agent, and past that the operator's questions are *who is blocked*,
+*what is running*, *how far along is the work* — which a chronological stream
+structurally cannot answer. Claude Code has an open request for precisely this
+([anthropics/claude-code#24537](https://github.com/anthropics/claude-code/issues/24537):
+interleaved tool summaries hide which agent is stuck, and approvals get buried
+in scroll). Agent-aware multiplexers
+([Herdr](https://betterstack.com/community/guides/ai/herdr-ai-agent/),
+[amux](https://amux.io/guides/best-ai-agent-multiplexers-2026/)) answer it with
+a status rail that rolls each agent up to working / idle / blocked, with the
+blocked ones floated to the top. The design problem is **attention routing**,
+not display.
+
+So `--fleet` builds the thing that does not exist: a fold of the channel into
+per-member status, not another rendering of the stream.
+
+## Design
+
+### 1. Surface
+
+```
+murmur --fleet develop            # ≡ mur agent cli mur --fleet develop
+murmur --fleet develop qa         # chat with a different agent; default is mur
+```
+
+`--fleet <name>` resolves to channel id `fleet-<name>`. An unknown fleet is a
+hard error at startup — silently degrading to a plain murmur would leave the
+user believing they are watching a fleet when they are not.
+
+The rail is a layout band between the transcript and the composer (same slot and
+mechanism as the existing chooser band), with a dynamic height.
+
+**Collapsed — always present.** Job progress, the slow variable, from the job
+store. `2/5` is jobs in a terminal state (done + failed + canceled) out of the
+fleet's total:
+
+```
+ fleet · develop   job 2/5 ⏵ running · 1 ✖ failed
+```
+
+**Expanded — only when someone is blocked.** Every member that has events,
+blocked first, then working, then finished; state folded from channel events:
+
+```
+ fleet · develop   ▲ 1 blocked
+   backend    ▲ blocked: approve `cargo publish`
+   rustsmith  ⏵ working (2m)
+```
+
+Expanding on *blocked* rather than on any activity is the point: a working fleet
+is not news, a stalled one is. One line at rest costs almost nothing against the
+fixed viewport; the band grows only when something needs the user. That split
+matches the order the questions are actually asked: *how far along is the work*
+first, *who is stuck* only when something stalls.
+
+**Empty state:** fleet exists but has never run →
+`fleet · develop   not run yet (mur fleet run develop)`.
+
+### 2. Member state derivation
+
+Existing enums only; no new vocabulary.
+
+| channel event | member state |
+|---|---|
+| `StateChange → Working` | ⏵ working |
+| `StateChange → InputRequired`, or a `HitlRequest` with no matching `HitlResponse` | ▲ **blocked** (with the request summary) |
+| `StateChange → Completed` | ✔ done |
+| `StateChange → Failed` / `Canceled` / `Rejected` | ✖ failed |
+| latest `ToolCall` | the "what it is doing" detail on a working row |
+| no events at all for that member | not shown — silence is not idleness, and inventing a state is a lie |
+
+Members are `ChannelActor::Agent { id }`. `Human` and `System` events stay out of
+the rail: those are the user's own turns and the executor's bookkeeping.
+
+### 3. Components and data flow
+
+**New type `FleetRail`** (`cmd/agent/cli/fleet_rail.rs`), living alongside
+`Follow` rather than extending it. Different purposes deserve different types:
+`Follow` turns events into transcript lines (history, reaches scrollback),
+`FleetRail` folds events into current state (not history, repainted every frame,
+never flushed). Keeping them separate also leaves `app.follow` free, so
+`/channels <id> --follow` still works while a rail is up.
+
+```rust
+pub struct FleetRail {
+    fleet: String,
+    channel_id: String,      // fleet-<name>
+    last_len: u64,           // channel log size gate (same trick as Follow)
+    jobs_mtime: SystemTime,  // job store gate
+    view: RailView,          // last computed result, reused when nothing moved
+    next_poll: Instant,
+}
+```
+
+**Poll** every 700 ms (`follow::POLL_INTERVAL`). Compare the channel log length
+and the job file's mtime first; if neither moved, return. At rest a tick is two
+`metadata()` calls and no parsing.
+
+**Load once, use twice.** `list_jobs()` internally reloads the whole channel to
+reconcile (`jobs.rs:140`), so calling it from the rail's tick would parse the
+same log twice a second. The rail loads events once and feeds both the member
+fold and the job reconciliation itself.
+
+**Render.** `ui.rs` gains `fleet_rail_height(app)` and
+`render_fleet_rail(...)`, mirroring the chooser band.
+
+**The one place this touches existing logic:** `band_inner_rows()` — added in
+#818 to decide when transcript content is flushed to scrollback — subtracts the
+composer, status line, chooser band and borders. **It must subtract the rail
+too.** If it does not, the flush decision drifts from what is actually painted,
+and the symptom is the band losing a row or flushing one message too early.
+
+### 4. Failure modes
+
+The rail must never take the chat down with it.
+
+| situation | behavior |
+|---|---|
+| channel unreadable or missing | collapsed line reads `fleet · develop  ⚠ channel unreadable`; chat continues. No rail error propagates to the event loop |
+| signature verification | uses the existing verifying read path (v3d per-actor); never bypasses it. The rail vouches for *other* agents — rendering "qa ✔ done" from an unverified event would lend the UI's credibility to a forgery. `MUR_CHANNEL_REQUIRE_SIG` policy is inherited, not reimplemented |
+| member stuck in working because its runtime died | show elapsed time (`⏵ working (2h14m)`) rather than inventing a timeout. Don't guess; let the clock say it |
+| more members than fit | the expanded list is capped at K=6 rows plus `… N more`; the sort (blocked → working → finished) guarantees whatever is truncated is the least urgent |
+| `jobs.yaml` corrupt | collapsed line falls back to the channel-derived summary; no crash |
+
+### 5. Testing
+
+All pure functions; no test needs a live fleet.
+
+1. **Fold table test** — one case per row of §2: `StateChange→Working`;
+   `HitlRequest` with no response → blocked; `HitlRequest` **followed by**
+   `HitlResponse` → no longer blocked; `Failed`/`Canceled`/`Rejected` collapse to
+   ✖; `Human`/`System` events ignored; empty channel → "not run yet".
+2. **Height function** — 0 blocked → 1 row; N blocked → `1 + min(N, K)`.
+3. **Consistency guard with #818** — assert
+   `band_inner_rows() + rail height + composer + status + borders == viewport
+   height`. This test exists for exactly one reason: to fail when someone
+   changes the rail's height and forgets the flush capacity.
+
+## Deliberately not in v1
+
+- **Approving a blocked member from the rail.** The full attention-routing
+  payoff, and the obvious step two — but it needs keyboard focus and the
+  approval path wired in. Ship read-only first: once it is up, the rail itself
+  reports how often blocking actually happens, and that number decides whether
+  step two is worth building.
+- **Multiple fleets at once.** One `--fleet` per session.
+- **A pane per member.** The fleet has one channel; per-member panes would be
+  N tails of the same log.

--- a/mur-core/src/channel_verify.rs
+++ b/mur-core/src/channel_verify.rs
@@ -32,6 +32,15 @@ pub fn verify_event(
     }
 }
 
+/// Parse `MUR_CHANNEL_REQUIRE_SIG`: only explicit truthy values enable
+/// signature enforcement (`=0` / `=false`, or unset, must NOT turn it on).
+/// Shared by every reader of the var so the parsing rule lives in one place.
+pub(crate) fn require_sig_from_env() -> bool {
+    std::env::var("MUR_CHANNEL_REQUIRE_SIG")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -163,6 +163,11 @@ pub enum AgentAction {
         /// conservative (fail-safe: anything uncertain still asks).
         #[arg(long = "auto-reads")]
         auto_reads: bool,
+        /// Watch a fleet's shared channel in a status band: job progress at
+        /// rest, expanding when a member is blocked. Names the fleet, not the
+        /// channel — `--fleet develop` watches `fleet-develop`.
+        #[arg(long)]
+        fleet: Option<String>,
     },
     /// Rotate an agent's Ed25519 identity keypair (P0a.6).
     Rekey {
@@ -1132,6 +1137,7 @@ mod tests {
             plain: _,
             budget_usd: _,
             auto_reads: _,
+            fleet: _,
         } = parse_cli_action(&["mur", "agent", "cli", "a1", "a2", "a3", "--auto"])
         else {
             panic!("expected Cli variant");
@@ -1153,6 +1159,24 @@ mod tests {
     #[test]
     fn agent_cli_requires_at_least_one_name() {
         assert!(Cli::try_parse_from(["mur", "agent", "cli"]).is_err());
+    }
+
+    #[test]
+    fn cli_action_parses_fleet_flag() {
+        let AgentAction::Cli { names, fleet, .. } =
+            parse_cli_action(&["mur", "agent", "cli", "mur", "--fleet", "develop"])
+        else {
+            panic!("expected Cli action");
+        };
+        assert_eq!(names, vec!["mur".to_string()]);
+        assert_eq!(fleet.as_deref(), Some("develop"));
+
+        // Absent by default — a plain murmur must not become fleet-aware.
+        let AgentAction::Cli { fleet, .. } = parse_cli_action(&["mur", "agent", "cli", "mur"])
+        else {
+            panic!("expected Cli action");
+        };
+        assert_eq!(fleet, None);
     }
 
     #[test]

--- a/mur-core/src/cli/murmur.rs
+++ b/mur-core/src/cli/murmur.rs
@@ -13,12 +13,35 @@ pub fn is_murmur_invocation(argv0: Option<&OsString>) -> bool {
         .is_some_and(|s| s.to_string_lossy().eq_ignore_ascii_case("murmur"))
 }
 
+/// `mur agent cli` flags that consume the following argv token as their
+/// value. Used to skip that token when scanning `rest` for a positional
+/// agent name, so a flag's *value* (e.g. `develop` in `--fleet develop`)
+/// is never mistaken for an agent name. The `--flag=value` form carries its
+/// value inline in one token and does not need this list.
+const VALUE_TAKING_FLAGS: &[&str] = &["--skin", "--budget-usd", "--fleet"];
+
 /// Rewrite murmur argv (`rest` excludes argv[0]) into a full
 /// `mur agent cli …` argv for clap. When no positional agent name is
 /// present: inject the concierge name `mur` if `concierge_exists`,
 /// otherwise return `None` (caller prints the agent list and exits).
 pub fn map_args(rest: &[OsString], concierge_exists: bool) -> Option<Vec<OsString>> {
-    let has_name = rest.iter().any(|a| !a.to_string_lossy().starts_with('-'));
+    let mut has_name = false;
+    let mut skip_next = false;
+    for a in rest {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        let s = a.to_string_lossy();
+        if s.starts_with('-') {
+            if VALUE_TAKING_FLAGS.contains(&s.as_ref()) {
+                skip_next = true;
+            }
+            continue;
+        }
+        has_name = true;
+        break;
+    }
     let mut argv: Vec<OsString> = vec!["mur".into(), "agent".into(), "cli".into()];
     argv.extend(rest.iter().cloned());
     if !has_name {
@@ -55,6 +78,38 @@ mod tests {
     fn maps_names_and_flags() {
         let argv = map_args(&os(&["a1", "a2", "--auto"]), false).unwrap();
         assert_eq!(argv, os(&["mur", "agent", "cli", "a1", "a2", "--auto"]));
+    }
+
+    #[test]
+    fn fleet_flag_value_is_not_mistaken_for_a_name() {
+        let argv = map_args(&os(&["--fleet", "develop"]), true).unwrap();
+        assert_eq!(
+            argv,
+            os(&["mur", "agent", "cli", "--fleet", "develop", "mur"])
+        );
+    }
+
+    #[test]
+    fn skin_flag_value_is_not_mistaken_for_a_name() {
+        // Pre-existing bug, same root cause as --fleet: any value-taking
+        // flag's argument could be read as a positional agent name.
+        let argv = map_args(&os(&["--skin", "dark"]), true).unwrap();
+        assert_eq!(argv, os(&["mur", "agent", "cli", "--skin", "dark", "mur"]));
+    }
+
+    #[test]
+    fn fleet_flag_equals_form_is_not_mistaken_for_a_name() {
+        let argv = map_args(&os(&["--fleet=develop"]), true).unwrap();
+        assert_eq!(argv, os(&["mur", "agent", "cli", "--fleet=develop", "mur"]));
+    }
+
+    #[test]
+    fn real_agent_name_still_wins_over_a_following_flag_value() {
+        let argv = map_args(&os(&["a1", "--fleet", "develop"]), true).unwrap();
+        assert_eq!(
+            argv,
+            os(&["mur", "agent", "cli", "a1", "--fleet", "develop"])
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -472,6 +472,8 @@ pub struct App {
     pub panel_input_seen: String,
     pub panel_input_sent: String,
     pub panel_input_deadline: Option<std::time::Instant>,
+    /// Fleet rail, when `--fleet` is on. `None` for an ordinary murmur.
+    pub fleet: Option<super::fleet_rail::FleetRail>,
 }
 
 impl App {
@@ -551,7 +553,13 @@ impl App {
             panel_input_seen: String::new(),
             panel_input_sent: String::new(),
             panel_input_deadline: None,
+            fleet: None,
         }
+    }
+
+    /// The rail's current view, or `None` when `--fleet` is off.
+    pub fn fleet_view(&self) -> Option<&super::fleet_rail::RailView> {
+        self.fleet.as_ref().map(|f| f.view())
     }
 
     /// Estimated cumulative session cost in USD, or `None` if the model's

--- a/mur-core/src/cmd/agent/cli/fleet_rail.rs
+++ b/mur-core/src/cmd/agent/cli/fleet_rail.rs
@@ -1,0 +1,328 @@
+//! `--fleet` status rail: folds a fleet's shared channel into per-member state.
+
+use chrono::{DateTime, Utc};
+use mur_common::channel::{ChannelActor, ChannelEvent, EventKind};
+
+/// Most member rows shown when the rail expands. Blocked sorts first, so
+/// whatever is truncated is the least urgent.
+pub const MAX_EXPANDED_ROWS: usize = 6;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MemberState {
+    /// Waiting on a human. `hitl_id` is what `mur channel approve` takes.
+    Blocked {
+        summary: String,
+        hitl_id: String,
+    },
+    /// `tool` is the latest ToolCall's command; `since` is when the member
+    /// last changed state, rendered as elapsed time so a dead runtime shows
+    /// up as a growing number instead of a state we invented.
+    Working {
+        tool: Option<String>,
+        since: DateTime<Utc>,
+    },
+    Done,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemberRow {
+    pub agent: String,
+    pub state: MemberState,
+}
+
+impl MemberState {
+    /// Sort key: blocked first, then working, then finished.
+    fn rank(&self) -> u8 {
+        match self {
+            MemberState::Blocked { .. } => 0,
+            MemberState::Working { .. } => 1,
+            MemberState::Done | MemberState::Failed => 2,
+        }
+    }
+}
+
+/// First non-empty string field among `keys`.
+fn field<'a>(ev: &'a ChannelEvent, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|k| ev.payload.get(*k).and_then(|v| v.as_str()))
+        .filter(|s| !s.is_empty())
+}
+
+/// Fold a channel's events into one row per agent that has acted.
+///
+/// Only `ChannelActor::Agent` becomes a row: `Human` events are the user's own
+/// turns and `System` events are the executor's bookkeeping. A member with no
+/// events is absent rather than "idle" — silence is not a state we can read.
+pub fn fold_members(events: &[ChannelEvent]) -> Vec<MemberRow> {
+    // Insertion-ordered so the sort below is the only thing that reorders.
+    let mut rows: Vec<MemberRow> = Vec::new();
+    let index = |rows: &mut Vec<MemberRow>, id: &str, ts: DateTime<Utc>| -> usize {
+        if let Some(i) = rows.iter().position(|r| r.agent == id) {
+            return i;
+        }
+        rows.push(MemberRow {
+            agent: id.to_string(),
+            state: MemberState::Working {
+                tool: None,
+                since: ts,
+            },
+        });
+        rows.len() - 1
+    };
+
+    for ev in events {
+        // A HitlResponse is written by whoever approved — usually the human —
+        // so it is matched by hitl_id across ALL rows, not by actor.
+        if ev.kind == EventKind::HitlResponse
+            && let Some(id) = field(ev, &["hitl_id"])
+        {
+            for row in rows.iter_mut() {
+                if let MemberState::Blocked { hitl_id, .. } = &row.state
+                    && hitl_id == id
+                {
+                    row.state = MemberState::Working {
+                        tool: None,
+                        since: ev.ts,
+                    };
+                }
+            }
+            continue;
+        }
+
+        let ChannelActor::Agent { id } = &ev.actor else {
+            continue;
+        };
+
+        match ev.kind {
+            EventKind::StateChange => {
+                let Some(to) = field(ev, &["to"]) else {
+                    continue;
+                };
+                let state = match to {
+                    // ChannelState serializes kebab-case (see channel.rs tests).
+                    "working" | "submitted" => MemberState::Working {
+                        tool: None,
+                        since: ev.ts,
+                    },
+                    "input-required" => MemberState::Blocked {
+                        summary: "waiting for input".to_string(),
+                        hitl_id: String::new(),
+                    },
+                    "completed" => MemberState::Done,
+                    "failed" | "canceled" | "rejected" => MemberState::Failed,
+                    _ => continue,
+                };
+                let i = index(&mut rows, id, ev.ts);
+                rows[i].state = state;
+            }
+            EventKind::ToolCall => {
+                let tool = field(ev, &["command", "tool", "description"]).map(str::to_string);
+                let i = index(&mut rows, id, ev.ts);
+                // A tool call only annotates a running member; it must not
+                // resurrect one that already finished or unblock one waiting.
+                if let MemberState::Working { since, .. } = rows[i].state {
+                    rows[i].state = MemberState::Working { tool, since };
+                }
+            }
+            EventKind::HitlRequest => {
+                let i = index(&mut rows, id, ev.ts);
+                rows[i].state = MemberState::Blocked {
+                    summary: field(ev, &["summary", "tool_name"])
+                        .unwrap_or("approval needed")
+                        .to_string(),
+                    hitl_id: field(ev, &["hitl_id"]).unwrap_or_default().to_string(),
+                };
+            }
+            _ => {}
+        }
+    }
+
+    rows.sort_by(|a, b| {
+        a.state
+            .rank()
+            .cmp(&b.state.rank())
+            .then_with(|| a.agent.cmp(&b.agent))
+    });
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ev(
+        seq: u64,
+        actor: ChannelActor,
+        kind: EventKind,
+        payload: serde_json::Value,
+    ) -> ChannelEvent {
+        ChannelEvent {
+            seq,
+            ts: DateTime::parse_from_rfc3339("2026-07-29T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            actor,
+            kind,
+            payload,
+            idempotency_key: None,
+            sig: None,
+            key_version: None,
+        }
+    }
+
+    fn agent(id: &str) -> ChannelActor {
+        ChannelActor::Agent { id: id.into() }
+    }
+
+    #[test]
+    fn state_changes_map_to_member_states() {
+        let evs = vec![
+            ev(
+                1,
+                agent("qa"),
+                EventKind::StateChange,
+                json!({"from": "submitted", "to": "working"}),
+            ),
+            ev(
+                2,
+                agent("backend"),
+                EventKind::StateChange,
+                json!({"from": "working", "to": "completed"}),
+            ),
+            ev(
+                3,
+                agent("dataml"),
+                EventKind::StateChange,
+                json!({"from": "working", "to": "failed"}),
+            ),
+            ev(
+                4,
+                agent("pm"),
+                EventKind::StateChange,
+                json!({"from": "working", "to": "canceled"}),
+            ),
+        ];
+        let rows = fold_members(&evs);
+        let by = |n: &str| rows.iter().find(|r| r.agent == n).unwrap().state.clone();
+        assert!(matches!(by("qa"), MemberState::Working { .. }));
+        assert!(matches!(by("backend"), MemberState::Done));
+        // canceled and rejected collapse into failed — the user only needs
+        // "it did not finish".
+        assert!(matches!(by("dataml"), MemberState::Failed));
+        assert!(matches!(by("pm"), MemberState::Failed));
+    }
+
+    #[test]
+    fn a_hitl_request_blocks_and_its_response_unblocks() {
+        let req = json!({"hitl_id": "h1", "tool_name": "bash", "summary": "cargo publish", "action_hash": "x", "tier": "write"});
+        let evs = vec![
+            ev(
+                1,
+                agent("qa"),
+                EventKind::StateChange,
+                json!({"to": "working"}),
+            ),
+            ev(2, agent("qa"), EventKind::HitlRequest, req),
+        ];
+        let rows = fold_members(&evs);
+        match &rows[0].state {
+            MemberState::Blocked { summary, hitl_id } => {
+                assert_eq!(hitl_id, "h1");
+                assert!(summary.contains("cargo publish"));
+            }
+            other => panic!("expected blocked, got {other:?}"),
+        }
+
+        // The approval is written by the HUMAN, not by the blocked agent, so
+        // clearing must key on hitl_id — never on the actor.
+        let mut evs = evs;
+        evs.push(ev(
+            3,
+            ChannelActor::Human {
+                name: "david".into(),
+            },
+            EventKind::HitlResponse,
+            json!({"hitl_id": "h1", "allow": true, "surface": "cli"}),
+        ));
+        let rows = fold_members(&evs);
+        assert!(matches!(rows[0].state, MemberState::Working { .. }));
+    }
+
+    #[test]
+    fn tool_calls_annotate_the_working_row() {
+        let evs = vec![
+            ev(
+                1,
+                agent("qa"),
+                EventKind::StateChange,
+                json!({"to": "working"}),
+            ),
+            ev(
+                2,
+                agent("qa"),
+                EventKind::ToolCall,
+                json!({"tool": "bash", "command": "cargo test"}),
+            ),
+        ];
+        let rows = fold_members(&evs);
+        match &rows[0].state {
+            MemberState::Working { tool, .. } => assert_eq!(tool.as_deref(), Some("cargo test")),
+            other => panic!("expected working, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn human_and_system_actors_never_become_rows() {
+        let evs = vec![
+            ev(
+                1,
+                ChannelActor::Human {
+                    name: "david".into(),
+                },
+                EventKind::Message,
+                json!({"text": "go"}),
+            ),
+            ev(
+                2,
+                ChannelActor::System,
+                EventKind::StateChange,
+                json!({"to": "working"}),
+            ),
+        ];
+        assert!(fold_members(&evs).is_empty());
+    }
+
+    #[test]
+    fn blocked_sorts_first_then_working_then_finished() {
+        let evs = vec![
+            ev(
+                1,
+                agent("aaa_done"),
+                EventKind::StateChange,
+                json!({"to": "completed"}),
+            ),
+            ev(
+                2,
+                agent("bbb_working"),
+                EventKind::StateChange,
+                json!({"to": "working"}),
+            ),
+            ev(
+                3,
+                agent("ccc_blocked"),
+                EventKind::HitlRequest,
+                json!({"hitl_id": "h1", "tool_name": "bash", "summary": "rm", "action_hash": "x", "tier": "write"}),
+            ),
+        ];
+        let rows = fold_members(&evs);
+        let names: Vec<&str> = rows.iter().map(|r| r.agent.as_str()).collect();
+        assert_eq!(names, vec!["ccc_blocked", "bbb_working", "aaa_done"]);
+    }
+
+    #[test]
+    fn an_empty_channel_has_no_rows() {
+        assert!(fold_members(&[]).is_empty());
+    }
+}

--- a/mur-core/src/cmd/agent/cli/fleet_rail.rs
+++ b/mur-core/src/cmd/agent/cli/fleet_rail.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use mur_common::channel::{ChannelActor, ChannelEvent, EventKind};
+use mur_common::fleet::{Job, JobStatus};
 
 /// Most member rows shown when the rail expands. Blocked sorts first, so
 /// whatever is truncated is the least urgent.
@@ -145,6 +146,35 @@ pub fn fold_members(events: &[ChannelEvent]) -> Vec<MemberRow> {
             .then_with(|| a.agent.cmp(&b.agent))
     });
     rows
+}
+
+/// The always-present collapsed line: how far the fleet's work has got.
+///
+/// `2/5` is jobs in a terminal state over the total — the question a user asks
+/// first ("how far along?"), answered by the slow-moving store rather than by
+/// the event stream.
+pub fn jobs_line(fleet: &str, jobs: &[Job]) -> String {
+    if jobs.is_empty() {
+        return format!("fleet · {fleet}   not run yet (mur fleet run {fleet})");
+    }
+    let total = jobs.len();
+    let terminal = jobs.iter().filter(|j| j.status.is_terminal()).count();
+    let running = jobs
+        .iter()
+        .filter(|j| j.status == JobStatus::Running)
+        .count();
+    let failed = jobs
+        .iter()
+        .filter(|j| matches!(j.status, JobStatus::Failed | JobStatus::Canceled))
+        .count();
+    let mut line = format!("fleet · {fleet}   job {terminal}/{total}");
+    if running > 0 {
+        line.push_str(&format!(" · {running} ⏵ running"));
+    }
+    if failed > 0 {
+        line.push_str(&format!(" · {failed} ✖ failed"));
+    }
+    line
 }
 
 #[cfg(test)]
@@ -324,5 +354,52 @@ mod tests {
     #[test]
     fn an_empty_channel_has_no_rows() {
         assert!(fold_members(&[]).is_empty());
+    }
+
+    use mur_common::fleet::{Job, JobStatus};
+
+    fn job(id: &str, status: JobStatus) -> Job {
+        Job {
+            id: id.into(),
+            text: "do the thing".into(),
+            source: "cli".into(),
+            status,
+            created_at: "2026-07-29T00:00:00Z".into(),
+            started_at: None,
+            finished_at: None,
+            run_id: None,
+            result: None,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn jobs_line_counts_terminal_over_total() {
+        let jobs = vec![
+            job("1", JobStatus::Done),
+            job("2", JobStatus::Failed),
+            job("3", JobStatus::Running),
+            job("4", JobStatus::Queued),
+            job("5", JobStatus::Queued),
+        ];
+        // 2 of 5 have reached a terminal state; one of those failed.
+        let line = jobs_line("develop", &jobs);
+        assert!(line.contains("fleet · develop"), "got: {line}");
+        assert!(line.contains("job 2/5"), "got: {line}");
+        assert!(line.contains("1 ⏵ running"), "got: {line}");
+        assert!(line.contains("1 ✖ failed"), "got: {line}");
+    }
+
+    #[test]
+    fn jobs_line_says_not_run_yet_when_there_are_none() {
+        let line = jobs_line("develop", &[]);
+        assert!(line.contains("not run yet"), "got: {line}");
+        assert!(line.contains("mur fleet run develop"), "got: {line}");
+    }
+
+    #[test]
+    fn jobs_line_omits_the_failed_clause_when_nothing_failed() {
+        let line = jobs_line("develop", &[job("1", JobStatus::Done)]);
+        assert!(!line.contains("failed"), "got: {line}");
     }
 }

--- a/mur-core/src/cmd/agent/cli/fleet_rail.rs
+++ b/mur-core/src/cmd/agent/cli/fleet_rail.rs
@@ -205,20 +205,22 @@ pub struct FleetRail {
     channel_id: String,
     /// Channel log size at the last poll; unchanged size means nothing to parse.
     last_len: u64,
-    /// Newest mtime seen in the jobs dir; jobs move far slower than events.
-    last_jobs_mtime: Option<std::time::SystemTime>,
+    /// (entry count, newest mtime) seen in the jobs dir at the last poll. The
+    /// count catches a deletion that `max(mtime)` alone would miss — removing
+    /// any job that isn't the newest leaves the max unchanged and the gate
+    /// blind to a real change.
+    last_jobs_gate: (usize, Option<std::time::SystemTime>),
     view: RailView,
     next_poll: Instant,
 }
 
 impl FleetRail {
-    pub fn start(home: &Path, fleet: &str) -> Self {
-        let _ = home;
+    pub fn start(fleet: &str) -> Self {
         Self {
             fleet: fleet.to_string(),
             channel_id: format!("fleet-{fleet}"),
             last_len: u64::MAX, // force the first poll to do real work
-            last_jobs_mtime: None,
+            last_jobs_gate: (0, None),
             view: RailView::default(),
             next_poll: Instant::now(),
         }
@@ -240,20 +242,20 @@ impl FleetRail {
         let len = std::fs::metadata(store.events_path(&self.channel_id))
             .map(|m| m.len())
             .unwrap_or(0);
-        let jobs_mtime = newest_jobs_mtime(home, &self.fleet);
-        if len == self.last_len && jobs_mtime == self.last_jobs_mtime {
+        let jobs_gate = jobs_dir_gate(home, &self.fleet);
+        if len == self.last_len && jobs_gate == self.last_jobs_gate {
             return false;
         }
         self.last_len = len;
-        self.last_jobs_mtime = jobs_mtime;
+        self.last_jobs_gate = jobs_gate;
 
-        let mut notice = None;
+        let mut notices: Vec<String> = Vec::new();
         // `load_events` treats a missing log as an empty one (Ok(vec![])) so a
         // brand-new channel with zero events isn't an error — but that means it
         // can't distinguish "this fleet's channel doesn't exist" from "it exists
         // and is quiet". The manifest is the fleet's actual existence check.
         if store.load_manifest(&self.channel_id).is_err() {
-            notice = Some("⚠ channel unreadable".to_string());
+            notices.push("⚠ channel unreadable".to_string());
         }
         let events = match store.load_events(&self.channel_id) {
             Ok(evs) => {
@@ -261,26 +263,51 @@ impl FleetRail {
                 // actor's signature is dropped, never rendered. The rail
                 // vouches for OTHER agents, so showing an unverified "done"
                 // would lend the UI's credibility to a forgery.
-                let require_sig = std::env::var("MUR_CHANNEL_REQUIRE_SIG")
-                    .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
-                    .unwrap_or(false);
-                evs.into_iter()
-                    .filter(|e| {
-                        crate::channel_verify::verify_event(home, &self.channel_id, e, require_sig)
-                    })
-                    .collect::<Vec<_>>()
+                let require_sig = crate::channel_verify::require_sig_from_env();
+                verify_events(home, &self.channel_id, evs, require_sig)
             }
             Err(_) => {
-                notice = Some("⚠ channel unreadable".to_string());
+                notices.push("⚠ channel unreadable".to_string());
                 Vec::new()
             }
         };
 
-        let jobs = crate::cmd::fleet::jobs::list_jobs_raw(home, &self.fleet).unwrap_or_default();
+        let members = fold_members(&events);
+
+        // "Load once, use twice" (spec §3): the events already loaded and
+        // verified above also feed job reconciliation, the same convergence
+        // `mur fleet show`/`mur fleet jobs` apply via `reconcile_jobs` — but
+        // applied in memory only (no `save_job`); the rail stays read-only.
+        let channel_terminal = crate::cmd::fleet::jobs::channel_terminal_status(&events);
+        let jobs_line_text = match crate::cmd::fleet::jobs::list_jobs_raw(home, &self.fleet) {
+            Ok(mut jobs) => {
+                let now_utc = Utc::now();
+                for j in jobs.iter_mut() {
+                    if let Some((s, _)) =
+                        crate::cmd::fleet::jobs::reconcile_running(j, channel_terminal, now_utc)
+                    {
+                        j.status = s;
+                    }
+                }
+                jobs_line(&self.fleet, &jobs)
+            }
+            Err(_) => {
+                // A corrupt job file must not read as "not run yet" (`jobs_line`
+                // on an empty Vec would say exactly that) — fall back to a
+                // summary derived from the channel fold instead (spec §4).
+                notices.push("⚠ jobs unreadable".to_string());
+                channel_derived_line(&self.fleet, &members)
+            }
+        };
+
         let view = RailView {
-            jobs_line: jobs_line(&self.fleet, &jobs),
-            members: fold_members(&events),
-            notice,
+            jobs_line: jobs_line_text,
+            members,
+            notice: if notices.is_empty() {
+                None
+            } else {
+                Some(notices.join("  "))
+            },
         };
         let changed = view != self.view;
         self.view = view;
@@ -288,291 +315,93 @@ impl FleetRail {
     }
 }
 
-/// Newest mtime across the fleet's job files — the cheap "did jobs move?" gate.
-fn newest_jobs_mtime(home: &Path, fleet: &str) -> Option<std::time::SystemTime> {
+/// Fallback collapsed line when the job store is unreadable (spec §4): counts
+/// derived from the channel fold instead of the job store, since the store is
+/// exactly what's unavailable.
+fn channel_derived_line(fleet: &str, members: &[MemberRow]) -> String {
+    let done = members
+        .iter()
+        .filter(|m| m.state == MemberState::Done)
+        .count();
+    let working = members
+        .iter()
+        .filter(|m| matches!(m.state, MemberState::Working { .. }))
+        .count();
+    let blocked = members
+        .iter()
+        .filter(|m| matches!(m.state, MemberState::Blocked { .. }))
+        .count();
+    let failed = members
+        .iter()
+        .filter(|m| m.state == MemberState::Failed)
+        .count();
+    let mut line = format!("fleet · {fleet}   member {done}/{} done", members.len());
+    if working > 0 {
+        line.push_str(&format!(" · {working} ⏵ working"));
+    }
+    if blocked > 0 {
+        line.push_str(&format!(" · {blocked} ▲ blocked"));
+    }
+    if failed > 0 {
+        line.push_str(&format!(" · {failed} ✖ failed"));
+    }
+    line
+}
+
+/// Verify each event against its actor's pubkey, resolving each distinct
+/// actor's key ONCE per poll rather than once per event. `actor_pubkey` does
+/// up to two file reads plus a rotation-chain verify; on a channel with
+/// thousands of events, re-resolving per event means thousands of synchronous
+/// file reads on the event-loop thread every ~700ms. Semantics are identical
+/// to `channel_verify::verify_event` per event, including its
+/// `None => !require_sig` fallback for an actor whose key can't be resolved.
+fn verify_events(
+    home: &Path,
+    channel_id: &str,
+    events: Vec<ChannelEvent>,
+    require_sig: bool,
+) -> Vec<ChannelEvent> {
+    let mut cache: std::collections::HashMap<(String, Option<u32>), Option<[u8; 32]>> =
+        std::collections::HashMap::new();
+    events
+        .into_iter()
+        .filter(|ev| {
+            let agent = match &ev.actor {
+                ChannelActor::Agent { id } => id.as_str(),
+                _ => crate::channel_writer::ROUTER_AGENT,
+            };
+            let pk = *cache
+                .entry((agent.to_string(), ev.key_version))
+                .or_insert_with(|| {
+                    mur_channel::sign::resolve_writer_pubkey(
+                        &home.join("agents").join(agent),
+                        ev.key_version,
+                    )
+                });
+            match pk {
+                Some(pk) => mur_channel::sign::verify_one(channel_id, ev, &pk, require_sig),
+                None => !require_sig,
+            }
+        })
+        .collect()
+}
+
+/// (entry count, newest mtime) across the fleet's job files — the cheap "did
+/// jobs move?" gate. The count is load-bearing: deleting a non-newest job
+/// leaves `max(mtime)` unchanged, so mtime alone misses it.
+fn jobs_dir_gate(home: &Path, fleet: &str) -> (usize, Option<std::time::SystemTime>) {
     let dir = crate::cmd::fleet::jobs::jobs_dir(home, fleet);
-    std::fs::read_dir(dir)
-        .ok()?
-        .flatten()
+    let entries: Vec<_> = std::fs::read_dir(dir)
+        .map(|rd| rd.flatten().collect())
+        .unwrap_or_default();
+    let count = entries.len();
+    let max_mtime = entries
+        .iter()
         .filter_map(|e| e.metadata().ok()?.modified().ok())
-        .max()
+        .max();
+    (count, max_mtime)
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    fn ev(
-        seq: u64,
-        actor: ChannelActor,
-        kind: EventKind,
-        payload: serde_json::Value,
-    ) -> ChannelEvent {
-        ChannelEvent {
-            seq,
-            ts: DateTime::parse_from_rfc3339("2026-07-29T00:00:00Z")
-                .unwrap()
-                .with_timezone(&Utc),
-            actor,
-            kind,
-            payload,
-            idempotency_key: None,
-            sig: None,
-            key_version: None,
-        }
-    }
-
-    fn agent(id: &str) -> ChannelActor {
-        ChannelActor::Agent { id: id.into() }
-    }
-
-    #[test]
-    fn state_changes_map_to_member_states() {
-        let evs = vec![
-            ev(
-                1,
-                agent("qa"),
-                EventKind::StateChange,
-                json!({"from": "submitted", "to": "working"}),
-            ),
-            ev(
-                2,
-                agent("backend"),
-                EventKind::StateChange,
-                json!({"from": "working", "to": "completed"}),
-            ),
-            ev(
-                3,
-                agent("dataml"),
-                EventKind::StateChange,
-                json!({"from": "working", "to": "failed"}),
-            ),
-            ev(
-                4,
-                agent("pm"),
-                EventKind::StateChange,
-                json!({"from": "working", "to": "canceled"}),
-            ),
-        ];
-        let rows = fold_members(&evs);
-        let by = |n: &str| rows.iter().find(|r| r.agent == n).unwrap().state.clone();
-        assert!(matches!(by("qa"), MemberState::Working { .. }));
-        assert!(matches!(by("backend"), MemberState::Done));
-        // canceled and rejected collapse into failed — the user only needs
-        // "it did not finish".
-        assert!(matches!(by("dataml"), MemberState::Failed));
-        assert!(matches!(by("pm"), MemberState::Failed));
-    }
-
-    #[test]
-    fn a_hitl_request_blocks_and_its_response_unblocks() {
-        let req = json!({"hitl_id": "h1", "tool_name": "bash", "summary": "cargo publish", "action_hash": "x", "tier": "write"});
-        let evs = vec![
-            ev(
-                1,
-                agent("qa"),
-                EventKind::StateChange,
-                json!({"to": "working"}),
-            ),
-            ev(2, agent("qa"), EventKind::HitlRequest, req),
-        ];
-        let rows = fold_members(&evs);
-        match &rows[0].state {
-            MemberState::Blocked { summary, hitl_id } => {
-                assert_eq!(hitl_id, "h1");
-                assert!(summary.contains("cargo publish"));
-            }
-            other => panic!("expected blocked, got {other:?}"),
-        }
-
-        // The approval is written by the HUMAN, not by the blocked agent, so
-        // clearing must key on hitl_id — never on the actor.
-        let mut evs = evs;
-        evs.push(ev(
-            3,
-            ChannelActor::Human {
-                name: "david".into(),
-            },
-            EventKind::HitlResponse,
-            json!({"hitl_id": "h1", "allow": true, "surface": "cli"}),
-        ));
-        let rows = fold_members(&evs);
-        assert!(matches!(rows[0].state, MemberState::Working { .. }));
-    }
-
-    #[test]
-    fn tool_calls_annotate_the_working_row() {
-        let evs = vec![
-            ev(
-                1,
-                agent("qa"),
-                EventKind::StateChange,
-                json!({"to": "working"}),
-            ),
-            ev(
-                2,
-                agent("qa"),
-                EventKind::ToolCall,
-                json!({"tool": "bash", "command": "cargo test"}),
-            ),
-        ];
-        let rows = fold_members(&evs);
-        match &rows[0].state {
-            MemberState::Working { tool, .. } => assert_eq!(tool.as_deref(), Some("cargo test")),
-            other => panic!("expected working, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn human_and_system_actors_never_become_rows() {
-        let evs = vec![
-            ev(
-                1,
-                ChannelActor::Human {
-                    name: "david".into(),
-                },
-                EventKind::Message,
-                json!({"text": "go"}),
-            ),
-            ev(
-                2,
-                ChannelActor::System,
-                EventKind::StateChange,
-                json!({"to": "working"}),
-            ),
-        ];
-        assert!(fold_members(&evs).is_empty());
-    }
-
-    #[test]
-    fn blocked_sorts_first_then_working_then_finished() {
-        let evs = vec![
-            ev(
-                1,
-                agent("aaa_done"),
-                EventKind::StateChange,
-                json!({"to": "completed"}),
-            ),
-            ev(
-                2,
-                agent("bbb_working"),
-                EventKind::StateChange,
-                json!({"to": "working"}),
-            ),
-            ev(
-                3,
-                agent("ccc_blocked"),
-                EventKind::HitlRequest,
-                json!({"hitl_id": "h1", "tool_name": "bash", "summary": "rm", "action_hash": "x", "tier": "write"}),
-            ),
-        ];
-        let rows = fold_members(&evs);
-        let names: Vec<&str> = rows.iter().map(|r| r.agent.as_str()).collect();
-        assert_eq!(names, vec!["ccc_blocked", "bbb_working", "aaa_done"]);
-    }
-
-    #[test]
-    fn an_empty_channel_has_no_rows() {
-        assert!(fold_members(&[]).is_empty());
-    }
-
-    use mur_common::fleet::{Job, JobStatus};
-
-    fn job(id: &str, status: JobStatus) -> Job {
-        Job {
-            id: id.into(),
-            text: "do the thing".into(),
-            source: "cli".into(),
-            status,
-            created_at: "2026-07-29T00:00:00Z".into(),
-            started_at: None,
-            finished_at: None,
-            run_id: None,
-            result: None,
-            error: None,
-        }
-    }
-
-    #[test]
-    fn jobs_line_counts_terminal_over_total() {
-        let jobs = vec![
-            job("1", JobStatus::Done),
-            job("2", JobStatus::Failed),
-            job("3", JobStatus::Running),
-            job("4", JobStatus::Queued),
-            job("5", JobStatus::Queued),
-        ];
-        // 2 of 5 have reached a terminal state; one of those failed.
-        let line = jobs_line("develop", &jobs);
-        assert!(line.contains("fleet · develop"), "got: {line}");
-        assert!(line.contains("job 2/5"), "got: {line}");
-        assert!(line.contains("1 ⏵ running"), "got: {line}");
-        assert!(line.contains("1 ✖ failed"), "got: {line}");
-    }
-
-    #[test]
-    fn jobs_line_says_not_run_yet_when_there_are_none() {
-        let line = jobs_line("develop", &[]);
-        assert!(line.contains("not run yet"), "got: {line}");
-        assert!(line.contains("mur fleet run develop"), "got: {line}");
-    }
-
-    #[test]
-    fn jobs_line_omits_the_failed_clause_when_nothing_failed() {
-        let line = jobs_line("develop", &[job("1", JobStatus::Done)]);
-        assert!(!line.contains("failed"), "got: {line}");
-    }
-
-    use std::time::Instant;
-
-    /// A fleet channel with one member. `create_for_fleet(fleet_name, router,
-    /// members)` names the channel `fleet-<fleet_name>` itself — the rail must
-    /// derive the same id from `--fleet dev`.
-    fn seed_home() -> tempfile::TempDir {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
-        svc.create_for_fleet("dev", "mur", &["qa".to_string()])
-            .unwrap();
-        tmp
-    }
-
-    #[test]
-    fn poll_reports_change_only_when_the_log_grows() {
-        let tmp = seed_home();
-        let now = Instant::now();
-        let mut rail = FleetRail::start(tmp.path(), "dev");
-
-        // First poll reads the (empty) channel and the (absent) job dir.
-        assert!(rail.poll(tmp.path(), now), "first poll must produce a view");
-        assert!(rail.view().members.is_empty());
-        assert!(rail.view().jobs_line.contains("not run yet"));
-
-        // Nothing changed → no work, no change reported.
-        assert!(!rail.poll(tmp.path(), now));
-
-        // A member acts → the next poll picks it up.
-        let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
-        svc.append(
-            "fleet-dev",
-            ChannelActor::Agent { id: "qa".into() },
-            EventKind::StateChange,
-            serde_json::json!({"to": "working"}),
-            None,
-        )
-        .unwrap();
-        assert!(rail.poll(tmp.path(), now), "log grew → view must change");
-        assert_eq!(rail.view().members.len(), 1);
-        assert_eq!(rail.view().members[0].agent, "qa");
-    }
-
-    #[test]
-    fn an_unreadable_channel_degrades_instead_of_failing() {
-        let tmp = tempfile::TempDir::new().unwrap(); // no channel at all
-        let mut rail = FleetRail::start(tmp.path(), "ghost");
-        rail.poll(tmp.path(), Instant::now());
-        assert!(rail.view().members.is_empty());
-        // The rail says so on its own line; it never returns Err.
-        assert!(rail.view().notice.is_some());
-    }
-}
+#[path = "fleet_rail/tests.rs"]
+mod tests;

--- a/mur-core/src/cmd/agent/cli/fleet_rail.rs
+++ b/mur-core/src/cmd/agent/cli/fleet_rail.rs
@@ -1,8 +1,13 @@
 //! `--fleet` status rail: folds a fleet's shared channel into per-member state.
 
+use std::path::Path;
+use std::time::Instant;
+
 use chrono::{DateTime, Utc};
 use mur_common::channel::{ChannelActor, ChannelEvent, EventKind};
 use mur_common::fleet::{Job, JobStatus};
+
+use super::follow::POLL_INTERVAL;
 
 /// Most member rows shown when the rail expands. Blocked sorts first, so
 /// whatever is truncated is the least urgent.
@@ -175,6 +180,122 @@ pub fn jobs_line(fleet: &str, jobs: &[Job]) -> String {
         line.push_str(&format!(" · {failed} ✖ failed"));
     }
     line
+}
+
+/// What the band renders. Recomputed only when the channel log or the job
+/// store actually changed.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RailView {
+    pub jobs_line: String,
+    pub members: Vec<MemberRow>,
+    /// Degraded-state text (unreadable channel, unreadable jobs). Rendered in
+    /// place of detail; never an error the caller has to handle.
+    pub notice: Option<String>,
+}
+
+/// Polls one fleet's channel and job store, folding both into a `RailView`.
+///
+/// Deliberately a separate type from `Follow`: that one turns events into
+/// transcript lines (history, reaches scrollback), this one folds them into
+/// current state (repainted every frame, never flushed). Keeping them apart also
+/// leaves `app.follow` free, so `/channels <id> --follow` still works while a
+/// rail is up.
+pub struct FleetRail {
+    fleet: String,
+    channel_id: String,
+    /// Channel log size at the last poll; unchanged size means nothing to parse.
+    last_len: u64,
+    /// Newest mtime seen in the jobs dir; jobs move far slower than events.
+    last_jobs_mtime: Option<std::time::SystemTime>,
+    view: RailView,
+    next_poll: Instant,
+}
+
+impl FleetRail {
+    pub fn start(home: &Path, fleet: &str) -> Self {
+        let _ = home;
+        Self {
+            fleet: fleet.to_string(),
+            channel_id: format!("fleet-{fleet}"),
+            last_len: u64::MAX, // force the first poll to do real work
+            last_jobs_mtime: None,
+            view: RailView::default(),
+            next_poll: Instant::now(),
+        }
+    }
+
+    pub fn view(&self) -> &RailView {
+        &self.view
+    }
+
+    pub fn next_poll(&self) -> Instant {
+        self.next_poll
+    }
+
+    /// Recompute if anything moved. Returns true when the view changed, so the
+    /// caller redraws only then.
+    pub fn poll(&mut self, home: &Path, now: Instant) -> bool {
+        self.next_poll = now + POLL_INTERVAL;
+        let store = mur_channel::ChannelStore::new(home);
+        let len = std::fs::metadata(store.events_path(&self.channel_id))
+            .map(|m| m.len())
+            .unwrap_or(0);
+        let jobs_mtime = newest_jobs_mtime(home, &self.fleet);
+        if len == self.last_len && jobs_mtime == self.last_jobs_mtime {
+            return false;
+        }
+        self.last_len = len;
+        self.last_jobs_mtime = jobs_mtime;
+
+        let mut notice = None;
+        // `load_events` treats a missing log as an empty one (Ok(vec![])) so a
+        // brand-new channel with zero events isn't an error — but that means it
+        // can't distinguish "this fleet's channel doesn't exist" from "it exists
+        // and is quiet". The manifest is the fleet's actual existence check.
+        if store.load_manifest(&self.channel_id).is_err() {
+            notice = Some("⚠ channel unreadable".to_string());
+        }
+        let events = match store.load_events(&self.channel_id) {
+            Ok(evs) => {
+                // Same trust rule as every other fold: an event that fails its
+                // actor's signature is dropped, never rendered. The rail
+                // vouches for OTHER agents, so showing an unverified "done"
+                // would lend the UI's credibility to a forgery.
+                let require_sig = std::env::var("MUR_CHANNEL_REQUIRE_SIG")
+                    .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
+                    .unwrap_or(false);
+                evs.into_iter()
+                    .filter(|e| {
+                        crate::channel_verify::verify_event(home, &self.channel_id, e, require_sig)
+                    })
+                    .collect::<Vec<_>>()
+            }
+            Err(_) => {
+                notice = Some("⚠ channel unreadable".to_string());
+                Vec::new()
+            }
+        };
+
+        let jobs = crate::cmd::fleet::jobs::list_jobs_raw(home, &self.fleet).unwrap_or_default();
+        let view = RailView {
+            jobs_line: jobs_line(&self.fleet, &jobs),
+            members: fold_members(&events),
+            notice,
+        };
+        let changed = view != self.view;
+        self.view = view;
+        changed
+    }
+}
+
+/// Newest mtime across the fleet's job files — the cheap "did jobs move?" gate.
+fn newest_jobs_mtime(home: &Path, fleet: &str) -> Option<std::time::SystemTime> {
+    let dir = crate::cmd::fleet::jobs::jobs_dir(home, fleet);
+    std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .filter_map(|e| e.metadata().ok()?.modified().ok())
+        .max()
 }
 
 #[cfg(test)]
@@ -401,5 +522,57 @@ mod tests {
     fn jobs_line_omits_the_failed_clause_when_nothing_failed() {
         let line = jobs_line("develop", &[job("1", JobStatus::Done)]);
         assert!(!line.contains("failed"), "got: {line}");
+    }
+
+    use std::time::Instant;
+
+    /// A fleet channel with one member. `create_for_fleet(fleet_name, router,
+    /// members)` names the channel `fleet-<fleet_name>` itself — the rail must
+    /// derive the same id from `--fleet dev`.
+    fn seed_home() -> tempfile::TempDir {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+        svc.create_for_fleet("dev", "mur", &["qa".to_string()])
+            .unwrap();
+        tmp
+    }
+
+    #[test]
+    fn poll_reports_change_only_when_the_log_grows() {
+        let tmp = seed_home();
+        let now = Instant::now();
+        let mut rail = FleetRail::start(tmp.path(), "dev");
+
+        // First poll reads the (empty) channel and the (absent) job dir.
+        assert!(rail.poll(tmp.path(), now), "first poll must produce a view");
+        assert!(rail.view().members.is_empty());
+        assert!(rail.view().jobs_line.contains("not run yet"));
+
+        // Nothing changed → no work, no change reported.
+        assert!(!rail.poll(tmp.path(), now));
+
+        // A member acts → the next poll picks it up.
+        let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+        svc.append(
+            "fleet-dev",
+            ChannelActor::Agent { id: "qa".into() },
+            EventKind::StateChange,
+            serde_json::json!({"to": "working"}),
+            None,
+        )
+        .unwrap();
+        assert!(rail.poll(tmp.path(), now), "log grew → view must change");
+        assert_eq!(rail.view().members.len(), 1);
+        assert_eq!(rail.view().members[0].agent, "qa");
+    }
+
+    #[test]
+    fn an_unreadable_channel_degrades_instead_of_failing() {
+        let tmp = tempfile::TempDir::new().unwrap(); // no channel at all
+        let mut rail = FleetRail::start(tmp.path(), "ghost");
+        rail.poll(tmp.path(), Instant::now());
+        assert!(rail.view().members.is_empty());
+        // The rail says so on its own line; it never returns Err.
+        assert!(rail.view().notice.is_some());
     }
 }

--- a/mur-core/src/cmd/agent/cli/fleet_rail/tests.rs
+++ b/mur-core/src/cmd/agent/cli/fleet_rail/tests.rs
@@ -1,0 +1,485 @@
+use super::*;
+use serde_json::json;
+
+fn ev(seq: u64, actor: ChannelActor, kind: EventKind, payload: serde_json::Value) -> ChannelEvent {
+    ChannelEvent {
+        seq,
+        ts: DateTime::parse_from_rfc3339("2026-07-29T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc),
+        actor,
+        kind,
+        payload,
+        idempotency_key: None,
+        sig: None,
+        key_version: None,
+    }
+}
+
+fn agent(id: &str) -> ChannelActor {
+    ChannelActor::Agent { id: id.into() }
+}
+
+#[test]
+fn state_changes_map_to_member_states() {
+    let evs = vec![
+        ev(
+            1,
+            agent("qa"),
+            EventKind::StateChange,
+            json!({"from": "submitted", "to": "working"}),
+        ),
+        ev(
+            2,
+            agent("backend"),
+            EventKind::StateChange,
+            json!({"from": "working", "to": "completed"}),
+        ),
+        ev(
+            3,
+            agent("dataml"),
+            EventKind::StateChange,
+            json!({"from": "working", "to": "failed"}),
+        ),
+        ev(
+            4,
+            agent("pm"),
+            EventKind::StateChange,
+            json!({"from": "working", "to": "canceled"}),
+        ),
+    ];
+    let rows = fold_members(&evs);
+    let by = |n: &str| rows.iter().find(|r| r.agent == n).unwrap().state.clone();
+    assert!(matches!(by("qa"), MemberState::Working { .. }));
+    assert!(matches!(by("backend"), MemberState::Done));
+    // canceled and rejected collapse into failed — the user only needs
+    // "it did not finish".
+    assert!(matches!(by("dataml"), MemberState::Failed));
+    assert!(matches!(by("pm"), MemberState::Failed));
+}
+
+#[test]
+fn a_hitl_request_blocks_and_its_response_unblocks() {
+    let req = json!({"hitl_id": "h1", "tool_name": "bash", "summary": "cargo publish", "action_hash": "x", "tier": "write"});
+    let evs = vec![
+        ev(
+            1,
+            agent("qa"),
+            EventKind::StateChange,
+            json!({"to": "working"}),
+        ),
+        ev(2, agent("qa"), EventKind::HitlRequest, req),
+    ];
+    let rows = fold_members(&evs);
+    match &rows[0].state {
+        MemberState::Blocked { summary, hitl_id } => {
+            assert_eq!(hitl_id, "h1");
+            assert!(summary.contains("cargo publish"));
+        }
+        other => panic!("expected blocked, got {other:?}"),
+    }
+
+    // The approval is written by the HUMAN, not by the blocked agent, so
+    // clearing must key on hitl_id — never on the actor.
+    let mut evs = evs;
+    evs.push(ev(
+        3,
+        ChannelActor::Human {
+            name: "david".into(),
+        },
+        EventKind::HitlResponse,
+        json!({"hitl_id": "h1", "allow": true, "surface": "cli"}),
+    ));
+    let rows = fold_members(&evs);
+    assert!(matches!(rows[0].state, MemberState::Working { .. }));
+}
+
+#[test]
+fn tool_calls_annotate_the_working_row() {
+    let evs = vec![
+        ev(
+            1,
+            agent("qa"),
+            EventKind::StateChange,
+            json!({"to": "working"}),
+        ),
+        ev(
+            2,
+            agent("qa"),
+            EventKind::ToolCall,
+            json!({"tool": "bash", "command": "cargo test"}),
+        ),
+    ];
+    let rows = fold_members(&evs);
+    match &rows[0].state {
+        MemberState::Working { tool, .. } => assert_eq!(tool.as_deref(), Some("cargo test")),
+        other => panic!("expected working, got {other:?}"),
+    }
+}
+
+#[test]
+fn human_and_system_actors_never_become_rows() {
+    let evs = vec![
+        ev(
+            1,
+            ChannelActor::Human {
+                name: "david".into(),
+            },
+            EventKind::Message,
+            json!({"text": "go"}),
+        ),
+        ev(
+            2,
+            ChannelActor::System,
+            EventKind::StateChange,
+            json!({"to": "working"}),
+        ),
+    ];
+    assert!(fold_members(&evs).is_empty());
+}
+
+#[test]
+fn blocked_sorts_first_then_working_then_finished() {
+    let evs = vec![
+        ev(
+            1,
+            agent("aaa_done"),
+            EventKind::StateChange,
+            json!({"to": "completed"}),
+        ),
+        ev(
+            2,
+            agent("bbb_working"),
+            EventKind::StateChange,
+            json!({"to": "working"}),
+        ),
+        ev(
+            3,
+            agent("ccc_blocked"),
+            EventKind::HitlRequest,
+            json!({"hitl_id": "h1", "tool_name": "bash", "summary": "rm", "action_hash": "x", "tier": "write"}),
+        ),
+    ];
+    let rows = fold_members(&evs);
+    let names: Vec<&str> = rows.iter().map(|r| r.agent.as_str()).collect();
+    assert_eq!(names, vec!["ccc_blocked", "bbb_working", "aaa_done"]);
+}
+
+#[test]
+fn an_empty_channel_has_no_rows() {
+    assert!(fold_members(&[]).is_empty());
+}
+
+#[test]
+fn state_change_input_required_blocks_with_empty_hitl_id() {
+    let evs = vec![ev(
+        1,
+        agent("qa"),
+        EventKind::StateChange,
+        json!({"from": "working", "to": "input-required"}),
+    )];
+    let rows = fold_members(&evs);
+    match &rows[0].state {
+        MemberState::Blocked { hitl_id, .. } => assert_eq!(hitl_id, ""),
+        other => panic!("expected blocked, got {other:?}"),
+    }
+
+    // Pin the quirk: a StateChange-driven block carries no hitl_id, so a
+    // HitlResponse (which only matches by hitl_id) can never clear it —
+    // only a later StateChange can. This is intentional, not a bug.
+    let mut with_response = evs.clone();
+    with_response.push(ev(
+        2,
+        ChannelActor::Human {
+            name: "david".into(),
+        },
+        EventKind::HitlResponse,
+        json!({"hitl_id": "some-other-id", "allow": true, "surface": "cli"}),
+    ));
+    assert!(
+        matches!(
+            fold_members(&with_response)[0].state,
+            MemberState::Blocked { .. }
+        ),
+        "a HitlResponse must not clear a StateChange-driven block"
+    );
+
+    let mut with_state_change = evs;
+    with_state_change.push(ev(
+        2,
+        agent("qa"),
+        EventKind::StateChange,
+        json!({"from": "input-required", "to": "working"}),
+    ));
+    assert!(
+        matches!(
+            fold_members(&with_state_change)[0].state,
+            MemberState::Working { .. }
+        ),
+        "a later StateChange DOES clear a StateChange-driven block"
+    );
+}
+
+#[test]
+fn tool_call_does_not_resurrect_a_finished_or_blocked_member() {
+    for to in ["completed", "failed"] {
+        let evs = vec![
+            ev(1, agent("qa"), EventKind::StateChange, json!({"to": to})),
+            ev(
+                2,
+                agent("qa"),
+                EventKind::ToolCall,
+                json!({"tool": "bash", "command": "rm -rf /"}),
+            ),
+        ];
+        let rows = fold_members(&evs);
+        let expected = if to == "completed" {
+            MemberState::Done
+        } else {
+            MemberState::Failed
+        };
+        assert_eq!(
+            rows[0].state, expected,
+            "a ToolCall must not change a finished member's state ({to})"
+        );
+    }
+
+    let evs = vec![
+        ev(
+            1,
+            agent("qa"),
+            EventKind::HitlRequest,
+            json!({"hitl_id": "h1", "tool_name": "bash", "summary": "cargo publish", "action_hash": "x", "tier": "write"}),
+        ),
+        ev(
+            2,
+            agent("qa"),
+            EventKind::ToolCall,
+            json!({"tool": "bash", "command": "echo hi"}),
+        ),
+    ];
+    let rows = fold_members(&evs);
+    assert!(
+        matches!(rows[0].state, MemberState::Blocked { .. }),
+        "a ToolCall must not unblock a blocked member"
+    );
+}
+
+#[test]
+fn approving_one_hitl_id_does_not_unblock_a_different_one() {
+    let evs = vec![
+        ev(
+            1,
+            agent("qa"),
+            EventKind::HitlRequest,
+            json!({"hitl_id": "h1", "tool_name": "bash", "summary": "rm", "action_hash": "x", "tier": "write"}),
+        ),
+        ev(
+            2,
+            agent("backend"),
+            EventKind::HitlRequest,
+            json!({"hitl_id": "h2", "tool_name": "bash", "summary": "deploy", "action_hash": "y", "tier": "write"}),
+        ),
+        ev(
+            3,
+            ChannelActor::Human {
+                name: "david".into(),
+            },
+            EventKind::HitlResponse,
+            json!({"hitl_id": "h1", "allow": true, "surface": "cli"}),
+        ),
+    ];
+    let rows = fold_members(&evs);
+    let by = |n: &str| rows.iter().find(|r| r.agent == n).unwrap().state.clone();
+    assert!(
+        matches!(by("qa"), MemberState::Working { .. }),
+        "h1 approved: qa must unblock"
+    );
+    match by("backend") {
+        MemberState::Blocked { hitl_id, .. } => {
+            assert_eq!(
+                hitl_id, "h2",
+                "backend must stay blocked on its own hitl_id"
+            )
+        }
+        other => panic!("expected backend still blocked, got {other:?}"),
+    }
+}
+
+#[test]
+fn state_change_submitted_maps_to_working() {
+    let evs = vec![ev(
+        1,
+        agent("qa"),
+        EventKind::StateChange,
+        json!({"to": "submitted"}),
+    )];
+    let rows = fold_members(&evs);
+    assert!(matches!(rows[0].state, MemberState::Working { .. }));
+}
+
+use mur_common::fleet::{Job, JobStatus};
+
+fn job(id: &str, status: JobStatus) -> Job {
+    Job {
+        id: id.into(),
+        text: "do the thing".into(),
+        source: "cli".into(),
+        status,
+        created_at: "2026-07-29T00:00:00Z".into(),
+        started_at: None,
+        finished_at: None,
+        run_id: None,
+        result: None,
+        error: None,
+    }
+}
+
+#[test]
+fn jobs_line_counts_terminal_over_total() {
+    let jobs = vec![
+        job("1", JobStatus::Done),
+        job("2", JobStatus::Failed),
+        job("3", JobStatus::Running),
+        job("4", JobStatus::Queued),
+        job("5", JobStatus::Queued),
+    ];
+    // 2 of 5 have reached a terminal state; one of those failed.
+    let line = jobs_line("develop", &jobs);
+    assert!(line.contains("fleet · develop"), "got: {line}");
+    assert!(line.contains("job 2/5"), "got: {line}");
+    assert!(line.contains("1 ⏵ running"), "got: {line}");
+    assert!(line.contains("1 ✖ failed"), "got: {line}");
+}
+
+#[test]
+fn jobs_line_says_not_run_yet_when_there_are_none() {
+    let line = jobs_line("develop", &[]);
+    assert!(line.contains("not run yet"), "got: {line}");
+    assert!(line.contains("mur fleet run develop"), "got: {line}");
+}
+
+#[test]
+fn jobs_line_omits_the_failed_clause_when_nothing_failed() {
+    let line = jobs_line("develop", &[job("1", JobStatus::Done)]);
+    assert!(!line.contains("failed"), "got: {line}");
+}
+
+use std::time::Instant;
+
+/// A fleet channel with one member. `create_for_fleet(fleet_name, router,
+/// members)` names the channel `fleet-<fleet_name>` itself — the rail must
+/// derive the same id from `--fleet dev`.
+fn seed_home() -> tempfile::TempDir {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+    svc.create_for_fleet("dev", "mur", &["qa".to_string()])
+        .unwrap();
+    tmp
+}
+
+#[test]
+fn poll_reports_change_only_when_the_log_grows() {
+    let tmp = seed_home();
+    let now = Instant::now();
+    let mut rail = FleetRail::start("dev");
+
+    // First poll reads the (empty) channel and the (absent) job dir.
+    assert!(rail.poll(tmp.path(), now), "first poll must produce a view");
+    assert!(rail.view().members.is_empty());
+    assert!(rail.view().jobs_line.contains("not run yet"));
+
+    // Nothing changed → no work, no change reported.
+    assert!(!rail.poll(tmp.path(), now));
+
+    // A member acts → the next poll picks it up.
+    let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+    svc.append(
+        "fleet-dev",
+        ChannelActor::Agent { id: "qa".into() },
+        EventKind::StateChange,
+        serde_json::json!({"to": "working"}),
+        None,
+    )
+    .unwrap();
+    assert!(rail.poll(tmp.path(), now), "log grew → view must change");
+    assert_eq!(rail.view().members.len(), 1);
+    assert_eq!(rail.view().members[0].agent, "qa");
+}
+
+#[test]
+fn an_unreadable_channel_degrades_instead_of_failing() {
+    let tmp = tempfile::TempDir::new().unwrap(); // no channel at all
+    let mut rail = FleetRail::start("ghost");
+    rail.poll(tmp.path(), Instant::now());
+    assert!(rail.view().members.is_empty());
+    // The rail says so on its own line; it never returns Err.
+    assert!(rail.view().notice.is_some());
+}
+
+#[test]
+fn poll_reconciles_a_running_job_against_channel_truth() {
+    let tmp = seed_home();
+    let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+    // The run drove the channel to a terminal state...
+    svc.append(
+        "fleet-dev",
+        ChannelActor::System,
+        EventKind::StateChange,
+        serde_json::json!({"from": "working", "to": "completed"}),
+        None,
+    )
+    .unwrap();
+    // ...but crashed before stamping the job yaml, so the store still
+    // says `running` (the exact gap `reconcile_running` exists to close).
+    let mut j = job("1", JobStatus::Running);
+    j.run_id = Some("run-1".to_string());
+    crate::cmd::fleet::jobs::save_job(tmp.path(), "dev", &j).unwrap();
+
+    let mut rail = FleetRail::start("dev");
+    rail.poll(tmp.path(), Instant::now());
+    let line = &rail.view().jobs_line;
+    assert!(
+        line.contains("job 1/1"),
+        "channel-terminal job must count toward the terminal total, got: {line}"
+    );
+    assert!(
+        !line.contains("running"),
+        "must not still report it running, got: {line}"
+    );
+}
+
+#[test]
+fn poll_falls_back_to_channel_summary_when_jobs_store_is_unreadable() {
+    let tmp = seed_home();
+    let svc = mur_channel::ChannelService::open(tmp.path()).unwrap();
+    svc.append(
+        "fleet-dev",
+        ChannelActor::Agent { id: "qa".into() },
+        EventKind::StateChange,
+        serde_json::json!({"to": "working"}),
+        None,
+    )
+    .unwrap();
+
+    let dir = crate::cmd::fleet::jobs::jobs_dir(tmp.path(), "dev");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("bad.yaml"), "not: valid: yaml:").unwrap();
+
+    let mut rail = FleetRail::start("dev");
+    rail.poll(tmp.path(), Instant::now());
+    let view = rail.view();
+    assert!(
+        !view.jobs_line.contains("not run yet"),
+        "an unreadable job store is not \"never run\" — got: {}",
+        view.jobs_line
+    );
+    assert!(
+        view.notice
+            .as_deref()
+            .unwrap_or("")
+            .contains("jobs unreadable"),
+        "notice must surface the unreadable store, got: {:?}",
+        view.notice
+    );
+}

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -178,6 +178,11 @@ pub async fn cmd_cli(
                 "note: --auto-reads is only enforced in the interactive TUI; it is ignored in plain/piped mode."
             );
         }
+        if fleet.is_some() {
+            eprintln!(
+                "note: --fleet is only shown in the interactive TUI; it is ignored in plain/piped mode."
+            );
+        }
         let home2 = home.clone();
         let agent2 = agent.clone();
         let interactive = io::stdin().is_terminal() && io::stdout().is_terminal();
@@ -351,7 +356,7 @@ async fn run_tui(
 
     let mut app = build_app(&home, &agent, resume, active_theme)?;
     if let Some(f) = fleet.as_deref() {
-        app.fleet = Some(fleet_rail::FleetRail::start(&home, f));
+        app.fleet = Some(fleet_rail::FleetRail::start(f));
     }
     app.skills = complete::load_agent_skills(&agent);
     app.pricing = load_pricing(&home, &agent);
@@ -657,7 +662,7 @@ async fn event_loop(
         // forces a redraw when the folded view actually changed.
         if let Some(rail) = app.fleet.as_mut()
             && StdInstant::now() >= rail.next_poll()
-            && rail.poll(&app.home.clone(), StdInstant::now())
+            && rail.poll(&app.home, StdInstant::now())
         {
             app.needs_full_redraw = true;
         }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -12,6 +12,7 @@ mod bash_class;
 mod complete;
 mod diff;
 mod dump;
+mod fleet_rail;
 mod follow;
 mod footer;
 mod manage;

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -108,6 +108,7 @@ const PLAIN_STEP_HINT_MAX: usize = 120;
 const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /channels N --follow (live-tail another channel; /channels --follow to stop)  /auto [on|off]  /verbose [on|off] (expand tool cards)  /skin [dark|light|mur]  /mcp  /skill  /panel [tab]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
 
 /// Entry point dispatched from `AgentAction::Cli`.
+#[allow(clippy::too_many_arguments)]
 pub async fn cmd_cli(
     names: &[String],
     resume: bool,
@@ -116,6 +117,7 @@ pub async fn cmd_cli(
     plain: bool,
     budget_usd: Option<f64>,
     auto_reads: bool,
+    fleet: Option<String>,
 ) -> Result<()> {
     if names.len() > 1 {
         if budget_usd.is_some() {
@@ -128,11 +130,23 @@ pub async fn cmd_cli(
                 "note: --auto-reads is only enforced in the single-agent TUI; it is ignored when opening multiple agents."
             );
         }
+        if fleet.is_some() {
+            eprintln!(
+                "note: --fleet is only shown in the single-agent TUI; it is ignored when opening multiple agents."
+            );
+        }
         let names = names.to_vec();
         return tokio::task::spawn_blocking(move || multiplex::run(&names, resume, auto)).await?;
     }
     let name = names.first().context("at least one agent name required")?;
     let home = super::resolve_mur_home()?;
+
+    // Fail loudly on an unknown fleet. Degrading to a plain murmur would leave
+    // the user believing they are watching a fleet when they are not.
+    if let Some(f) = fleet.as_deref() {
+        crate::cmd::fleet::store::load_fleet(&home, f).with_context(|| format!("--fleet {f}"))?;
+    }
+
     let agent = canonicalize_agent_name(&home, name);
 
     // Streaming requires a live socket; fail early with a friendly hint.

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -185,7 +185,10 @@ pub async fn cmd_cli(
             .await?;
     }
 
-    run_tui(home, agent, resume, auto, skin, budget_usd, auto_reads).await
+    run_tui(
+        home, agent, resume, auto, skin, budget_usd, auto_reads, fleet,
+    )
+    .await
 }
 
 // ── TUI mode ────────────────────────────────────────────────────────────────
@@ -279,6 +282,7 @@ impl Drop for TerminalGuard {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_tui(
     home: PathBuf,
     agent: String,
@@ -287,6 +291,7 @@ async fn run_tui(
     skin: Option<String>,
     budget_usd: Option<f64>,
     auto_reads: bool,
+    fleet: Option<String>,
 ) -> Result<()> {
     // Resolve skin: CLI flag > config > "dark"
     let cfg = mur_common::config::Config::load_or_default(&home.join("config.yaml"));
@@ -345,6 +350,9 @@ async fn run_tui(
     .context("init terminal")?;
 
     let mut app = build_app(&home, &agent, resume, active_theme)?;
+    if let Some(f) = fleet.as_deref() {
+        app.fleet = Some(fleet_rail::FleetRail::start(&home, f));
+    }
     app.skills = complete::load_agent_skills(&agent);
     app.pricing = load_pricing(&home, &agent);
     if unknown_skin {
@@ -645,6 +653,14 @@ async fn event_loop(
             .as_ref()
             .map(|f| TokioInstant::from_std(f.next_poll))
             .unwrap_or_else(|| TokioInstant::from_std(StdInstant::now()));
+        // Fleet rail: cheap when nothing moved (two metadata calls), and only
+        // forces a redraw when the folded view actually changed.
+        if let Some(rail) = app.fleet.as_mut()
+            && StdInstant::now() >= rail.next_poll()
+            && rail.poll(&app.home.clone(), StdInstant::now())
+        {
+            app.needs_full_redraw = true;
+        }
         tokio::select! {
             maybe = events.next() => match maybe {
                 Some(Ok(ev)) => handle_event(app, ev, &tx).await,

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -661,6 +661,19 @@ async fn event_loop(
         {
             app.needs_full_redraw = true;
         }
+        // The rail needs its own wake source, exactly like `follow`: without
+        // this arm, an idle loop (no keypresses, no streaming, transcript
+        // non-empty so `blink_at` is disarmed) never wakes on its own, the
+        // poll above never gets a turn, and the rail goes stale forever on a
+        // terminal the user is just reading. The arm body is empty on
+        // purpose — waking the loop is the whole job; the poll above runs at
+        // the top of the next iteration.
+        let rail_armed = app.fleet.is_some();
+        let rail_at = app
+            .fleet
+            .as_ref()
+            .map(|r| TokioInstant::from_std(r.next_poll()))
+            .unwrap_or_else(|| TokioInstant::from_std(StdInstant::now()));
         tokio::select! {
             maybe = events.next() => match maybe {
                 Some(Ok(ev)) => handle_event(app, ev, &tx).await,
@@ -679,6 +692,11 @@ async fn event_loop(
             _ = tokio::time::sleep_until(follow_at), if follow_armed => {
                 app.poll_follow(StdInstant::now());
             }
+            // Wake at the rail's next-poll deadline; the poll itself already
+            // ran at the top of THIS iteration and gates on the same
+            // deadline, so this arm's only job is to schedule the NEXT
+            // wake-up. No state change needed here.
+            _ = tokio::time::sleep_until(rail_at), if rail_armed => {}
             _ = tokio::time::sleep_until(input_due), if input_armed => {
                 if let Some(raw) = take_due_input(app, StdInstant::now())
                     && let Some(p) = &app.panel

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -48,10 +48,12 @@ pub fn render(f: &mut Frame, app: &mut App) {
     // can't cover the reply the user must read to choose. The slash-command
     // menu keeps the compact popup (the user is typing, not reading).
     let chooser_h = chooser_band_height(app, f.area().height, input_height);
+    let rail_h = fleet_rail_height(app);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(3),
+            Constraint::Length(rail_h),
             Constraint::Length(chooser_h),
             Constraint::Length(input_height),
             Constraint::Length(1),
@@ -59,13 +61,16 @@ pub fn render(f: &mut Frame, app: &mut App) {
         .split(f.area());
 
     render_transcript(f, app, chunks[0]);
-    if chooser_h > 0 {
-        render_chooser_band(f, app, chunks[1]);
-    } else {
-        render_completion(f, app, chunks[2]);
+    if rail_h > 0 {
+        render_fleet_rail(f, app, chunks[1]);
     }
-    f.render_widget(&app.input, chunks[2]);
-    render_status(f, app, chunks[3]);
+    if chooser_h > 0 {
+        render_chooser_band(f, app, chunks[2]);
+    } else {
+        render_completion(f, app, chunks[3]);
+    }
+    f.render_widget(&app.input, chunks[3]);
+    render_status(f, app, chunks[4]);
 
     // Inline approval lives on the card (Task 4) when the runtime sent a
     // step_id. Fall back to the centered modal only for older runtimes.
@@ -336,13 +341,106 @@ fn render_chooser_band(f: &mut Frame, app: &App, area: Rect) {
 /// the terminal soft-wraps it), so a modest fixed rule stands in.
 const SEPARATOR_WIDTH: usize = 60;
 
+/// Rows the fleet rail paints: one collapsed line, plus a capped member list
+/// when someone is blocked. A working fleet is not news; a stalled one is.
+pub fn rail_height_for(view: &crate::cmd::agent::cli::fleet_rail::RailView) -> u16 {
+    use crate::cmd::agent::cli::fleet_rail::{MAX_EXPANDED_ROWS, MemberState};
+    let blocked = view
+        .members
+        .iter()
+        .any(|m| matches!(m.state, MemberState::Blocked { .. }));
+    if !blocked {
+        return 1;
+    }
+    1 + view.members.len().min(MAX_EXPANDED_ROWS) as u16
+}
+
+/// Height of the rail band for the current app state; 0 when `--fleet` is off.
+pub fn fleet_rail_height(app: &App) -> u16 {
+    app.fleet_view().map(rail_height_for).unwrap_or(0)
+}
+
+fn render_fleet_rail(f: &mut Frame, app: &App, area: Rect) {
+    use crate::cmd::agent::cli::fleet_rail::{MAX_EXPANDED_ROWS, MemberState};
+    let Some(view) = app.fleet_view() else {
+        return;
+    };
+    let theme = app.theme;
+    let mut lines: Vec<Line> = Vec::new();
+
+    let head = match &view.notice {
+        Some(n) => format!("{}  {n}", view.jobs_line),
+        None => view.jobs_line.clone(),
+    };
+    lines.push(Line::styled(
+        head,
+        Style::default()
+            .fg(theme.border_title)
+            .add_modifier(Modifier::BOLD),
+    ));
+
+    if rail_height_for(view) > 1 {
+        for m in view.members.iter().take(MAX_EXPANDED_ROWS) {
+            let (glyph, body, color) = match &m.state {
+                MemberState::Blocked { summary, .. } => {
+                    ("▲", format!("blocked: {summary}"), theme.warn)
+                }
+                MemberState::Working { tool, since } => (
+                    "⏵",
+                    match tool {
+                        Some(t) => format!("working ({}) · {t}", elapsed(*since)),
+                        None => format!("working ({})", elapsed(*since)),
+                    },
+                    theme.agent,
+                ),
+                MemberState::Done => ("✔", "done".to_string(), theme.success),
+                MemberState::Failed => ("✖", "failed".to_string(), theme.error),
+            };
+            lines.push(Line::styled(
+                format!("  {:<10} {glyph} {body}", m.agent),
+                Style::default().fg(color),
+            ));
+        }
+        let extra = view.members.len().saturating_sub(MAX_EXPANDED_ROWS);
+        if extra > 0 {
+            lines.push(Line::styled(
+                format!("  … {extra} more"),
+                Style::default().fg(theme.system),
+            ));
+        }
+    }
+
+    f.render_widget(Paragraph::new(Text::from(lines)), area);
+}
+
+/// "2m" / "1h04m" — elapsed since a member last changed state. Shown instead
+/// of a staleness verdict: a runtime that died mid-turn shows a growing
+/// number rather than a state we guessed.
+fn elapsed(since: chrono::DateTime<chrono::Utc>) -> String {
+    let secs = (chrono::Utc::now() - since).num_seconds().max(0);
+    match secs {
+        0..=59 => format!("{secs}s"),
+        60..=3599 => format!("{}m", secs / 60),
+        _ => format!("{}h{:02}m", secs / 3600, (secs % 3600) / 60),
+    }
+}
+
+/// Rows left for the live transcript band inside `viewport_h` once the
+/// composer, status line, chooser band, fleet rail and the band's own
+/// TOP/BOTTOM borders have taken theirs.
+fn band_capacity(viewport_h: u16, input_h: u16, chooser_h: u16, rail_h: u16) -> u16 {
+    viewport_h.saturating_sub(input_h + 1 + chooser_h + rail_h + 2)
+}
+
 /// Rows the live transcript band can paint inside a viewport of `viewport_h`:
 /// what the `render` layout leaves after the composer, the status line, an
 /// open chooser band, and the band's own TOP/BOTTOM borders.
 fn band_inner_rows(app: &App, viewport_h: u16) -> u16 {
     let input_h = (app.input.lines().len() as u16 + 2).clamp(3, 8);
     let chooser_h = chooser_band_height(app, viewport_h, input_h);
-    viewport_h.saturating_sub(input_h + 1 + chooser_h + 2)
+    // The rail steals rows from the live band; miss it here and the flush
+    // decision drifts from what is painted.
+    band_capacity(viewport_h, input_h, chooser_h, fleet_rail_height(app))
 }
 
 /// Index one past the last message that is settled AND therefore flushable:
@@ -1282,5 +1380,58 @@ mod footer_fmt_tests {
         let s2 = footer_segments(1000, 1000, 1000, 1000, 0, &Pricing::default(), Some(20.0));
         assert!(s2.contains("/ $20.00"), "got: {s2}");
         assert!(!s2.contains("$18.00"));
+    }
+}
+
+#[cfg(test)]
+mod fleet_rail_layout_tests {
+    use super::*;
+    use crate::cmd::agent::cli::fleet_rail::{MemberRow, MemberState, RailView};
+
+    fn view(blocked: usize) -> RailView {
+        RailView {
+            jobs_line: "fleet · dev   job 0/1".into(),
+            members: (0..blocked)
+                .map(|i| MemberRow {
+                    agent: format!("m{i}"),
+                    state: MemberState::Blocked {
+                        summary: "approve".into(),
+                        hitl_id: format!("h{i}"),
+                    },
+                })
+                .collect(),
+            notice: None,
+        }
+    }
+
+    #[test]
+    fn rail_is_one_row_until_someone_is_blocked() {
+        assert_eq!(rail_height_for(&view(0)), 1);
+        assert_eq!(rail_height_for(&view(1)), 2);
+        assert_eq!(rail_height_for(&view(3)), 4);
+    }
+
+    #[test]
+    fn the_expanded_rail_is_capped() {
+        use crate::cmd::agent::cli::fleet_rail::MAX_EXPANDED_ROWS;
+        assert_eq!(
+            rail_height_for(&view(50)),
+            1 + MAX_EXPANDED_ROWS as u16,
+            "an unbounded rail would eat the transcript"
+        );
+    }
+
+    #[test]
+    fn the_live_band_gives_back_exactly_what_the_rail_takes() {
+        // The guard for the one dangerous coupling: band_inner_rows decides
+        // when transcript content is flushed to scrollback, so it must account
+        // for every row the rail paints or the flush drifts from the picture.
+        // Tested on the pure arithmetic so no App and no test-only seam in
+        // production code are needed.
+        let viewport_h = 20u16;
+        let input_h = 3u16;
+        let without = band_capacity(viewport_h, input_h, 0, 0);
+        let with_rail = band_capacity(viewport_h, input_h, 0, rail_height_for(&view(3)));
+        assert_eq!(without - with_rail, rail_height_for(&view(3)));
     }
 }

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -342,7 +342,10 @@ fn render_chooser_band(f: &mut Frame, app: &App, area: Rect) {
 const SEPARATOR_WIDTH: usize = 60;
 
 /// Rows the fleet rail paints: one collapsed line, plus a capped member list
-/// when someone is blocked. A working fleet is not news; a stalled one is.
+/// when someone is blocked, plus one more row for the "… N more" truncation
+/// notice when the member list doesn't fit. Must always equal
+/// `rail_lines(view, _).len()` — see `the_rail_height_matches_painted_lines`.
+/// A working fleet is not news; a stalled one is.
 pub fn rail_height_for(view: &crate::cmd::agent::cli::fleet_rail::RailView) -> u16 {
     use crate::cmd::agent::cli::fleet_rail::{MAX_EXPANDED_ROWS, MemberState};
     let blocked = view
@@ -352,7 +355,9 @@ pub fn rail_height_for(view: &crate::cmd::agent::cli::fleet_rail::RailView) -> u
     if !blocked {
         return 1;
     }
-    1 + view.members.len().min(MAX_EXPANDED_ROWS) as u16
+    let shown = view.members.len().min(MAX_EXPANDED_ROWS) as u16;
+    let truncated = view.members.len() > MAX_EXPANDED_ROWS;
+    1 + shown + u16::from(truncated)
 }
 
 /// Height of the rail band for the current app state; 0 when `--fleet` is off.
@@ -360,12 +365,16 @@ pub fn fleet_rail_height(app: &App) -> u16 {
     app.fleet_view().map(rail_height_for).unwrap_or(0)
 }
 
-fn render_fleet_rail(f: &mut Frame, app: &App, area: Rect) {
+/// The fleet rail's content as plain lines: the head line, a capped member
+/// list, and a truncation notice when the list doesn't fit. Pulled out of
+/// `render_fleet_rail` so `rail_height_for` has something concrete to be
+/// tested against instead of a number nothing checks — the truncation notice
+/// is the thing most likely to silently fall off the bottom again.
+fn rail_lines(
+    view: &crate::cmd::agent::cli::fleet_rail::RailView,
+    theme: &'static super::theme::Theme,
+) -> Vec<Line<'static>> {
     use crate::cmd::agent::cli::fleet_rail::{MAX_EXPANDED_ROWS, MemberState};
-    let Some(view) = app.fleet_view() else {
-        return;
-    };
-    let theme = app.theme;
     let mut lines: Vec<Line> = Vec::new();
 
     let head = match &view.notice {
@@ -410,7 +419,17 @@ fn render_fleet_rail(f: &mut Frame, app: &App, area: Rect) {
         }
     }
 
-    f.render_widget(Paragraph::new(Text::from(lines)), area);
+    lines
+}
+
+fn render_fleet_rail(f: &mut Frame, app: &App, area: Rect) {
+    let Some(view) = app.fleet_view() else {
+        return;
+    };
+    f.render_widget(
+        Paragraph::new(Text::from(rail_lines(view, app.theme))),
+        area,
+    );
 }
 
 /// "2m" / "1h04m" — elapsed since a member last changed state. Shown instead
@@ -1416,8 +1435,11 @@ mod fleet_rail_layout_tests {
         use crate::cmd::agent::cli::fleet_rail::MAX_EXPANDED_ROWS;
         assert_eq!(
             rail_height_for(&view(50)),
-            1 + MAX_EXPANDED_ROWS as u16,
-            "an unbounded rail would eat the transcript"
+            // +1 for the member rows (capped), +1 for the "… N more" notice
+            // that only appears once the list is actually truncated.
+            1 + MAX_EXPANDED_ROWS as u16 + 1,
+            "an unbounded rail would eat the transcript, and a truncated one \
+             must still show its own truncation notice"
         );
     }
 
@@ -1433,5 +1455,23 @@ mod fleet_rail_layout_tests {
         let without = band_capacity(viewport_h, input_h, 0, 0);
         let with_rail = band_capacity(viewport_h, input_h, 0, rail_height_for(&view(3)));
         assert_eq!(without - with_rail, rail_height_for(&view(3)));
+    }
+
+    #[test]
+    fn the_rail_height_matches_what_render_actually_paints() {
+        // rail_height_for is a number computed independently of rail_lines;
+        // nothing ties them together except this test. Without it, a line
+        // added to (or removed from) rail_lines silently desyncs the height
+        // from the paint — exactly how the truncation notice went missing.
+        use crate::cmd::agent::cli::fleet_rail::MAX_EXPANDED_ROWS;
+        let theme = crate::cmd::agent::cli::theme::resolve_skin("dark");
+        for blocked in [0, 1, MAX_EXPANDED_ROWS, MAX_EXPANDED_ROWS + 3] {
+            let v = view(blocked);
+            assert_eq!(
+                rail_lines(&v, theme).len() as u16,
+                rail_height_for(&v),
+                "mismatch at {blocked} blocked members"
+            );
+        }
     }
 }

--- a/mur-core/src/cmd/fleet/jobs.rs
+++ b/mur-core/src/cmd/fleet/jobs.rs
@@ -156,11 +156,10 @@ fn reconcile_jobs(mur_home: &Path, fleet: &str, jobs: &mut [Job]) {
     }
 }
 
-/// All jobs sorted oldest-first (UUIDv7 lexical sort == time order).
-///
-/// Reconciles zombie `running` jobs against the channel/orphan rules (#10)
-/// before returning, so every caller (`fleet show`, `fleet jobs`) sees truth.
-pub fn list_jobs(mur_home: &Path, fleet: &str) -> Result<Vec<Job>> {
+/// Jobs straight from the store, oldest-first, with no channel reconciliation.
+/// `list_jobs` adds reconciliation on top; callers that already hold the
+/// channel's events (the murmur fleet rail) use this to avoid re-parsing it.
+pub(crate) fn list_jobs_raw(mur_home: &Path, fleet: &str) -> Result<Vec<Job>> {
     if !valid_fleet_name(fleet) {
         bail!("invalid fleet name '{fleet}': use lowercase letters, digits, '-' or '_'");
     }
@@ -183,6 +182,15 @@ pub fn list_jobs(mur_home: &Path, fleet: &str) -> Result<Vec<Job>> {
     }
     // Sort by id (UUIDv7 = time order)
     jobs.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(jobs)
+}
+
+/// All jobs sorted oldest-first (UUIDv7 lexical sort == time order).
+///
+/// Reconciles zombie `running` jobs against the channel/orphan rules (#10)
+/// before returning, so every caller (`fleet show`, `fleet jobs`) sees truth.
+pub fn list_jobs(mur_home: &Path, fleet: &str) -> Result<Vec<Job>> {
+    let mut jobs = list_jobs_raw(mur_home, fleet)?;
     // #10: converge zombie `running` records to their true terminal state.
     reconcile_jobs(mur_home, fleet, &mut jobs);
     Ok(jobs)

--- a/mur-core/src/cmd/fleet/jobs.rs
+++ b/mur-core/src/cmd/fleet/jobs.rs
@@ -59,7 +59,7 @@ pub fn save_job(mur_home: &Path, fleet: &str, job: &Job) -> Result<()> {
 /// The channel's terminal outcome for a run, read from its event log (#10):
 /// the last `StateChange` event whose `to` is terminal, mapped to a job status.
 /// `None` if the channel has no terminal StateChange yet (still working).
-fn channel_terminal_status(events: &[ChannelEvent]) -> Option<JobStatus> {
+pub(crate) fn channel_terminal_status(events: &[ChannelEvent]) -> Option<JobStatus> {
     events
         .iter()
         .filter(|e| e.kind == EventKind::StateChange)
@@ -85,7 +85,7 @@ fn channel_terminal_status(events: &[ChannelEvent]) -> Option<JobStatus> {
 ///  2. **Orphan staleness** — a job still `running` `RUNNING_GRACE_SECS` after
 ///     `started_at`, with no terminal channel signal, has no live run: its
 ///     process died (the four-day `019f69d8`). Mark `failed(orphaned)`.
-fn reconcile_running(
+pub(crate) fn reconcile_running(
     job: &Job,
     channel: Option<JobStatus>,
     now: chrono::DateTime<chrono::Utc>,

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1544,7 +1544,13 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             plain,
             budget_usd,
             auto_reads,
-        } => cmd::agent::cmd_cli(&names, resume, auto, skin, plain, budget_usd, auto_reads).await?,
+            fleet,
+        } => {
+            cmd::agent::cmd_cli(
+                &names, resume, auto, skin, plain, budget_usd, auto_reads, fleet,
+            )
+            .await?
+        }
         AgentAction::Pair { name } => cmd::agent_pair::cmd_pair(&name)?,
         AgentAction::Devices => cmd::agent_pair::cmd_devices()?,
         AgentAction::Unpair { fingerprint } => cmd::agent_pair::cmd_unpair(&fingerprint)?,

--- a/mur-core/src/hitl/gate.rs
+++ b/mur-core/src/hitl/gate.rs
@@ -81,9 +81,7 @@ pub async fn gate(
             // loop) so `wait_for_response` is pure w.r.t. config and tests never
             // race on a process-global env var. Only explicit truthy values
             // enable enforcement: `=0` / `=false` must NOT turn it on.
-            let require_sig = std::env::var("MUR_CHANNEL_REQUIRE_SIG")
-                .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
-                .unwrap_or(false);
+            let require_sig = crate::channel_verify::require_sig_from_env();
             let request = HitlRequest {
                 hitl_id: hitl_id.clone(),
                 action_hash: hash.clone(),


### PR DESCRIPTION
## What

`murmur --fleet <name>` opens the normal single-agent chat and adds a status band between the transcript and the composer:

```
 fleet · builder   job 2/2                      ← at rest: one line, job progress
```
```
 fleet · develop   ▲ 1 blocked                  ← someone needs you
   backend    ▲ blocked: approve `cargo publish`
   rustsmith  ⏵ working (2m)
```

Spec: `docs/superpowers/specs/2026-07-29-murmur-fleet-rail-design.md` · Plan: `docs/superpowers/plans/2026-07-29-murmur-fleet-rail.md`

## Why one design and not two

The obvious framing was "merged into the chat stream" vs "a separate pane", with a flag to choose. Rejected: **the merged version already ships** as `/channels <id> --follow`, so a flag for it would add no capability — and a raw event stream cannot answer the question an operator actually has. Research into 2026 agent tooling converges on the same point ([anthropics/claude-code#24537](https://github.com/anthropics/claude-code/issues/24537), [Herdr](https://betterstack.com/community/guides/ai/herdr-ai-agent/), [amux](https://amux.io/guides/best-ai-agent-multiplexers-2026/)): an interleaved feed scales to about one agent; past that the questions are *who is blocked*, *what is running*, *how far along is the work*. The design problem is attention routing, not display.

So `--fleet` builds what does not exist: a fold of the fleet's one shared channel into per-member status, collapsed until someone is blocked.

## How it works

- **One channel, not N.** A fleet's members write their own signed replies into `fleet-<name>` (v3d-2 `channel/delegate`), so watching every member is one log.
- **Two speeds.** The collapsed line reads the job store (slow: `job 2/5`); the expansion folds channel events (fast: working / blocked / done / failed). They answer different questions in the order people ask them.
- **Cheap at rest.** A tick compares the channel log's length and the job dir's `(count, max mtime)`; unchanged means no parse. 700 ms, reusing `follow::POLL_INTERVAL`.
- **Verification is not bypassed.** Every event passes per-actor `verify_event` before folding, with `MUR_CHANNEL_REQUIRE_SIG` read through one shared helper. The rail vouches for *other* agents — an unverified "qa ✔ done" would lend the UI's credibility to a forgery. Keys are resolved once per actor per poll rather than once per event.
- **It never takes the chat down.** `poll()` returns `bool`; every failure degrades to a notice line.

## Defects this caught before merge

Every one was a defect in the plan, not in the implementation:

| | |
|---|---|
| `murmur --fleet develop` didn't run at all | `map_args` treated a flag's *value* as the agent name, so no concierge was injected and clap rejected the command. Also fixed the same pre-existing break in `murmur --skin dark` and `murmur --budget-usd 5`. |
| The rail never updated while idle | The poll sat in the loop body, but `select!` had no arm to wake the loop for it — the exact case the feature exists for (reading the screen while a fleet runs elsewhere). Now mirrors `follow`'s deadline arm. |
| The `… N more` line was clipped | `rail_height_for` didn't budget for it, so the only signal that members were hidden was the thing ratatui dropped. Fixed, and `rail_lines` was extracted so `lines.len() == rail_height_for()` is now an asserted invariant across `{0, 1, CAP, CAP+3}`. |
| The rail could state things that weren't true | It never reconciled jobs against channel truth (stale `⏵ running`, undercounted `job N/M`), and one corrupt job yaml made it claim `not run yet` for a fleet that had run. Both now match the spec's §4 contract. |

## Interaction with #818

`band_inner_rows()` decides when finished transcript content flushes into native scrollback. The rail's rows are subtracted there via a new pure `band_capacity(viewport_h, input_h, chooser_h, rail_h)`, with a guard test — miss it and the flush drifts from what is painted.

## Verification

- `cargo nextest run -p mur-core --lib` — **2253 passed** (2222 on main; +31 from this branch)
- `cargo clippy --all --no-deps -- -D warnings` — clean · `cargo fmt --all --check` — clean
- Live, read-only against the real fleet `builder`: the rail renders above the composer, composer and status stay bottom-anchored, `--fleet nope` exits non-zero with no TUI

## Review findings ledger

Every task got a scoped review; the whole branch then got one. This is the complete list of what those reviews raised and was **not** fixed, with the reason. Nothing here was silently dropped.

### Deferred — judged non-blocking

| # | Finding | Why it can wait |
|---|---|---|
| 1 | `chooser_band_height` computes its budget from `total_h` without subtracting the rail's rows, so the transcript's `Min(3)` floor can be squeezed | Needs a short terminal **and** an expanded rail **and** an open spaced chooser at once. Degrades cosmetically — ratatui squeezes the bands, `render_transcript` scrolls rather than drops content, no panic. A fix must land in **both** `render` and `band_inner_rows` or they desync, and the existing guard test operates on `band_capacity` in isolation and would not catch a one-sided fix. |
| 2 | The loop-driven poll path has no automated coverage; the live capture proves only `FleetRail::start()`'s initial load | `poll()` itself is covered. What is untested is a `select!` arm that only a full TUI harness can exercise — a new seam into `event_loop`, bigger than this branch should open. Worth noting the class is proven live: the *missing* wake arm was caught by inspection, not by test. |
| 3 | `ui.rs` is 1437 lines, over the repo's 800-line guidance | Pre-existing: 1286 before this branch. Splitting it here would bury the feature in a move-diff. Its own follow-up. |
| 4 | `needs_full_redraw` is set when the rail's view changes, though the rail manipulates nothing raw and `terminal.draw()` runs every iteration anyway | Costs an unnecessary full-viewport repaint at up to ~1.4 Hz during an active run. Removing it is a behavior change in the paint path that no test covers; not worth bundling into a feature PR. |
| 5 | `Blocked.hitl_id` is folded but never rendered, so the rail says someone is blocked without saying how to unblock them | Spec-faithful for v1 (§"Deliberately not in v1" defers approving *from* the rail, and §1's mock-up shows the summary only). One `format!` away when it is wanted. |
| 6 | No test for a value-taking flag as the literal last token (`murmur --fleet` with nothing after it) | Safe by inspection — the skip flag is set on the final iteration and the loop ends; no index, no panic. Untested. |
| 7 | The remaining poll-gate blind spots are named in review but not in a code comment | Constant-length edit is structurally impossible on an append-only JSONL and would fail verification anyway; two job writes inside one mtime tick is negligible on nanosecond timestamps. (The third — a job deletion leaving `max mtime` unchanged — was **fixed**: the gate is now `(entry_count, max_mtime)`.) |
| 8 | The test module re-imports `Job`/`JobStatus` already imported at module level | Style only. |

### Raised and fixed in this branch

- The four fold-coverage gaps the reviews flagged all landed: `StateChange → "input-required"` (including that its empty `hitl_id` means only a later `StateChange` can clear it), `"submitted"`, a `ToolCall` on an already-finished member, and two members blocked on different `hitl_id`s with only one approved. Two of those guard branches that **no previous test distinguished from a wrong implementation** — delete the `if let MemberState::Working` guard, or replace the `hitl_id` match with "unblock the first blocked row", and every earlier test still passed.
- Job reconciliation against channel truth, the corrupt-jobs-store fallback, the `--plain` mode note, and the per-event pubkey re-resolution (2N file reads per 700 ms poll on the UI thread) — all fixed in one wave after the whole-branch review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)