### PR TITLE
chore(release): bump workspace version to 2.60.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6451,7 +6451,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6572,7 +6572,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6623,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6639,7 +6639,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6656,7 +6656,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.59.0"
+version = "2.60.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6783,7 +6783,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6841,7 +6841,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.59.0"
+version = "2.60.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Version bump for the v2.60.0 release.

**Merge this with a merge commit, not a squash.** The tag `v2.60.0` was already pushed and points at `602d9266`, this branch's commit — a squash would create a new SHA and leave the tag pointing at a commit that is not an ancestor of `main` forever. A merge commit keeps the tagged commit on `main` where the release's provenance can be followed.

## Why the tag is already out

The release process in `CLAUDE.md` says to bump, tag, and `git push origin main --tags`. That direct push to `main` is now rejected by branch protection ("Changes must be made through a pull request", required check "CI pass") — but `git push --tags` in the same command **succeeded** before the branch ref was declined, so the tag landed and the Release workflow is already building from it.

The artifacts it is producing are the same tree this PR merges. Once this lands, the tag is an ancestor of `main` again and nothing needs re-tagging.

Worth a follow-up: `CLAUDE.md`'s release steps should be rewritten around the PR flow, and the tag should be pushed only after the bump is on `main`.

## Contents

- `Cargo.toml` workspace version 2.59.0 → 2.60.0
- Both lock files move with it: the root one, and `mur-hub-gui/src-tauri/Cargo.lock`, which carries its own copy of every workspace crate's version and fails the Hub's release build when it disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)