### PR TITLE
docs(release): rewrite the release steps around the PR flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,18 +141,48 @@ Before changing anything that pins, verifies, or launches an MCP server, read `d
 
 ## Release Process
 
-1. **Bump `Cargo.toml` workspace version FIRST** so `mur --version` matches the tag.
-   The CI now validates this: pushing a tag whose version doesn't match `Cargo.toml` fails
-   immediately at the `validate-version` job. Example:
+`main` is protected: direct pushes are rejected ("Changes must be made through a
+pull request", required check "CI pass"). The version bump therefore goes through
+a PR, and **the tag is pushed only after the bump is on `main`** — tagging first
+strands the tag on a commit no branch contains.
+
+1. **Bump the `Cargo.toml` workspace version FIRST** so `mur --version` matches the
+   tag. CI validates it: a tag whose version disagrees with `Cargo.toml` fails at
+   the `validate-version` job. Move both lock files with it — the root one and
+   `mur-hub-gui/src-tauri/Cargo.lock`, which keeps its own copy of every workspace
+   crate's version and breaks the Hub's release build when it disagrees.
    ```bash
-   # Bump version before tagging:
-   sed -i 's/^version = ".*"/version = "X.Y.Z"/' Cargo.toml
-   git add Cargo.toml && git commit -m "chore(release): bump workspace version to X.Y.Z"
+   # `sed -i '' '0,/re/s//repl/'` is a GNU-ism that fails SILENTLY on macOS —
+   # exit 0, file unchanged. Edit the line directly and check the result.
+   python3 - <<'EOF'
+   s = open("Cargo.toml").read()
+   assert s.count('version = "X.Y.Z-old"') == 1
+   open("Cargo.toml", "w").write(s.replace('version = "X.Y.Z-old"', 'version = "X.Y.Z"', 1))
+   EOF
+   cargo update --workspace
+   cargo update --workspace --manifest-path mur-hub-gui/src-tauri/Cargo.toml
+   git checkout -b chore/bump-X.Y.Z
+   git add Cargo.toml Cargo.lock mur-hub-gui/src-tauri/Cargo.lock
+   git commit -m "chore(release): bump workspace version to X.Y.Z"
+   git push -u origin chore/bump-X.Y.Z
+   gh pr create --base main --title "chore(release): bump workspace version to X.Y.Z"
    ```
-2. `git tag -a v<VERSION> -m "message" && git push origin main --tags`
-3. Release workflow (`release.yml`) handles the rest automatically: cross-platform build,
+2. Merge that PR once CI is green, then update your local `main`:
+   ```bash
+   git checkout main && git pull --ff-only
+   ```
+3. **Only now** tag the commit that is on `main`, and push the tag by itself:
+   ```bash
+   git tag -a vX.Y.Z -m "message"
+   git push origin vX.Y.Z
+   ```
+   Never `git push origin main --tags`: that pushes two refs, and when branch
+   protection declines `main` the tag still lands — the error names only the
+   rejected branch, so it reads as a clean failure while a release is already
+   building from a commit that is not on `main`.
+4. The release workflow (`release.yml`) handles the rest: cross-platform build,
    GitHub Release, Homebrew formula update, installer deployment, crates.io publish.
-4. Verify: `brew update && brew upgrade mur`
+5. Verify: `brew update && brew upgrade mur`
 
 ## Documentation Checklist
 


### PR DESCRIPTION
`main` is protected, so the documented `git push origin main --tags` is rejected — and the failure is not clean.

That command pushes **two refs**. When protection declines `main`, **the tag still lands**, and the error names only the rejected branch:

```
remote: - Changes must be made through a pull request.
remote: - Required status check "CI pass" is expected.
 * [new tag]           v2.60.0 -> v2.60.0
 ! [remote rejected]   main -> main (push declined due to repository rule violations)
error: failed to push some refs
```

It reads as "the push failed". It is not: the release workflow is already building from a commit that is on no branch. Recovering means merging the bump with a **merge commit** so the tagged SHA becomes an ancestor of `main` — a squash creates a new SHA and strands the tag forever. That happened today (#833).

## What changed

The steps now match the repository's actual rules:

1. Bump the version, move **both** lock files, open a PR
2. Merge it, then `git pull --ff-only`
3. **Only now** tag, and push the tag **by itself** — never together with a branch

Also written down, because both cost time today:

- `mur-hub-gui/src-tauri/Cargo.lock` keeps its own copy of every workspace crate's version and fails the Hub's release build when it disagrees with the root lock.
- `sed -i '' '0,/re/s//repl/'` is a GNU-ism: on macOS it exits 0 and changes nothing. The bump example now uses a form that asserts it matched exactly one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)