### PR TITLE
fix(compress): keep the compressed replacement's JSON type so Claude Code accepts it

### DIFF
--- a/mur-compress/src/auto.rs
+++ b/mur-compress/src/auto.rs
@@ -152,6 +152,16 @@ pub fn has_tool_error(value: &Value) -> bool {
     tool_error_count(value) > 0
 }
 
+/// The warning that must precede any offloaded result bundling tool errors,
+/// so a failure can't read as success until someone calls `mur_retrieve`.
+/// Shared by the object envelope's `note` and the string form's prefix.
+pub fn error_warning(error_count: usize) -> String {
+    format!(
+        "WARNING: this offloaded result contains {error_count} tool error(s); \
+         do NOT treat it as success — call mur_retrieve to inspect."
+    )
+}
+
 /// Model-readable hint describing how to recover the full content. When
 /// `error_count > 0` the note leads with a hard warning so the offloaded
 /// result is never read as success before retrieval.
@@ -162,10 +172,7 @@ pub fn retrieval_note_with_errors(
 ) -> String {
     let base = retrieval_note(hash, query);
     if error_count > 0 {
-        format!(
-            "WARNING: this offloaded result contains {error_count} tool error(s); \
-             do NOT treat it as success — call mur_retrieve to inspect. {base}"
-        )
+        format!("{} {base}", error_warning(error_count))
     } else {
         base
     }
@@ -252,7 +259,7 @@ pub fn auto_compress_value(
     match value {
         Value::String(s) => {
             let o = auto_compress(engine, s, query, min_tokens);
-            o.fired.then(|| value_replacement(&o, query))
+            o.fired.then(|| shaped_replacement(value, &o, query))
         }
         Value::Array(_) => {
             let o = auto_compress(engine, &value.to_string(), query, min_tokens);
@@ -281,7 +288,7 @@ pub fn auto_compress_value(
                 return None;
             }
             let mut out = map.clone();
-            out.insert(key, value_replacement(&o, query));
+            out.insert(key, shaped_replacement(field, &o, query));
             Some(Value::Object(out))
         }
         _ => None,
@@ -328,6 +335,16 @@ fn annotate_offload_errors(mut replacement: Value, original: &Value, query: Opti
     if n == 0 {
         return replacement;
     }
+    // String replacements (a schema-declared string field, see
+    // `shaped_replacement`) carry their retrieval note inline rather than in an
+    // envelope, so `as_object_mut` would skip them and the warning would be
+    // silently dropped — exactly the error-hiding this function exists to stop.
+    if let Some(s) = replacement.as_str() {
+        if s.contains("mur_retrieve") {
+            return Value::String(format!("{}\n\n{s}", error_warning(n)));
+        }
+        return replacement;
+    }
     // Top-level offload envelope.
     if let Some(obj) = replacement.as_object_mut() {
         if obj.get("compressed") == Some(&Value::Bool(true))
@@ -340,8 +357,15 @@ fn annotate_offload_errors(mut replacement: Value, original: &Value, query: Opti
             obj.insert("tool_errors".into(), Value::from(n));
             return replacement;
         }
-        // Object whose largest field was replaced with an envelope.
+        // Object whose largest field was replaced — envelope or, for a
+        // schema-declared string field, the inline-note string form.
         for (_k, v) in obj.iter_mut() {
+            if let Some(s) = v.as_str() {
+                if s.contains("mur_retrieve") {
+                    *v = Value::String(format!("{}\n\n{s}", error_warning(n)));
+                }
+                continue;
+            }
             if let Some(inner) = v.as_object_mut()
                 && inner.get("compressed") == Some(&Value::Bool(true))
                 && let Some(h) = inner.get("hash").and_then(|h| h.as_str()).map(String::from)
@@ -363,6 +387,34 @@ fn value_replacement(outcome: &AutoOutcome, query: Option<&str>) -> Value {
     match outcome.hash {
         Some(_) => retrieval_envelope(outcome, query),
         None => Value::String(outcome.text.clone()),
+    }
+}
+
+/// Replacement that preserves `original`'s JSON type.
+///
+/// Claude Code validates a PostToolUse `updatedToolOutput` against the
+/// ORIGINATING tool's output schema, so handing back the object envelope where
+/// the tool declared a string (Bash's `stdout`/`stderr`, Edit's and Write's
+/// fields) fails validation and the entire compression is discarded — silently,
+/// via "using original output". For a string we therefore inline the retrieval
+/// note into the text instead of wrapping it, so the hash stays reachable by
+/// `mur_retrieve` while the field keeps the type the tool declared.
+///
+/// Note the asymmetry this creates with [`is_compressed_envelope`]-style
+/// guards, which recognise only the object form: nothing here re-enters the
+/// compressor, because PostToolUse runs once per tool call on a fresh result.
+///
+/// Arrays keep the envelope: they reach here from MCP list results, whose
+/// output schemas are unconstrained.
+fn shaped_replacement(original: &Value, outcome: &AutoOutcome, query: Option<&str>) -> Value {
+    match original {
+        Value::String(_) if outcome.hash.is_some() => Value::String(format!(
+            "{}\n\n{}",
+            outcome.text,
+            retrieval_note(outcome.hash.as_deref(), query)
+        )),
+        Value::String(_) => Value::String(outcome.text.clone()),
+        _ => value_replacement(outcome, query),
     }
 }
 
@@ -544,8 +596,13 @@ mod tests {
         let out = auto_compress_value(&eng, &v, None, 50).expect("should fire");
         assert_eq!(out["interrupted"], serde_json::json!(false));
         assert_eq!(out["stderr"], serde_json::json!(""));
-        assert_eq!(out["stdout"]["compressed"], serde_json::json!(true));
-        assert!(out["stdout"]["hash"].as_str().is_some());
+        // `stdout` is a string in Claude Code's Bash output schema, so the
+        // replacement must stay a string — swapping in the object envelope
+        // fails schema validation and the compression is thrown away.
+        let stdout = out["stdout"]
+            .as_str()
+            .expect("stdout must stay a string, not become the envelope");
+        assert!(stdout.contains("mur_retrieve"), "{stdout}");
     }
 
     #[test]
@@ -653,11 +710,12 @@ mod tests {
         let v = Value::String(big_json_array());
         let out = auto_compress_value_guarded(&eng, &v, None, 100, false)
             .expect("clean large payload should still compress");
-        assert_eq!(out["compressed"], serde_json::json!(true));
-        assert!(out["hash"].as_str().is_some());
+        // A string input keeps the string shape; the hash rides along in the
+        // inline retrieval note.
+        let s = out.as_str().expect("string input keeps string shape");
+        assert!(s.contains("mur_retrieve"), "{s}");
         // No error annotation on a clean result.
-        assert!(out.get("tool_errors").is_none());
-        assert!(!out["note"].as_str().unwrap().contains("WARNING"));
+        assert!(!s.contains("WARNING"), "{s}");
     }
 
     #[test]

--- a/mur-core/src/cmd/hook.rs
+++ b/mur-core/src/cmd/hook.rs
@@ -77,14 +77,16 @@ fn compress_tool_response(
     }
     let replacement =
         mur_compress::auto_compress_value(engine, tool_response, None, cfg.min_tokens)?;
-    let updated_tool_output = match replacement {
-        serde_json::Value::String(s) => s,
-        other => serde_json::to_string(&other).ok()?,
-    };
+    // Emit the replacement with its shape intact. Claude Code validates
+    // `updatedToolOutput` against the ORIGINATING tool's output schema, so
+    // stringifying an object replacement (Edit/Write/Bash/Agent all hand us
+    // objects, and `auto_compress_value` deliberately preserves that shape by
+    // compressing only the largest string/array field) fails validation with
+    // "expected object, received string" and the compression is discarded.
     let line = serde_json::json!({
         "hookSpecificOutput": {
             "hookEventName": "PostToolUse",
-            "updatedToolOutput": updated_tool_output,
+            "updatedToolOutput": replacement,
         }
     });
     serde_json::to_string(&line).ok()
@@ -666,13 +668,65 @@ mod compress_tool_response_tests {
             parsed["hookSpecificOutput"]["hookEventName"],
             json!("PostToolUse")
         );
-        let updated = parsed["hookSpecificOutput"]["updatedToolOutput"]
-            .as_str()
-            .expect("updatedToolOutput must be a JSON string");
-        assert!(!updated.is_empty());
+        let updated = &parsed["hookSpecificOutput"]["updatedToolOutput"];
+        // An array response has no tool-declared shape to preserve (this path
+        // serves MCP list results), so it keeps the object envelope. What must
+        // NOT happen is the envelope arriving JSON-stringified — Claude Code
+        // validates against the originating tool's schema and discards it.
         assert!(
-            updated.contains("mur_retrieve"),
-            "expected retrieval hash marker in: {updated}"
+            updated.is_object(),
+            "envelope must not be stringified; got: {updated}"
+        );
+        assert_eq!(updated["compressed"], json!(true));
+        assert!(
+            updated["hash"].as_str().is_some_and(|h| !h.is_empty()),
+            "offloaded result must carry a hash: {updated}"
+        );
+        assert!(
+            updated["note"]
+                .as_str()
+                .is_some_and(|n| n.contains("mur_retrieve")),
+            "expected retrieval marker in note: {updated}"
+        );
+    }
+
+    #[test]
+    fn object_tool_response_keeps_object_shape() {
+        // Claude Code validates `updatedToolOutput` against the originating
+        // tool's output schema. Edit/Write/Bash/Agent all hand the hook an
+        // object, so a stringified replacement is rejected with "expected
+        // object, received string" and the compression is silently dropped.
+        let (_dir, eng) = engine();
+        let cfg = auto_cfg();
+        let raw = json!({
+            "tool_name": "Bash",
+            "tool_response": {
+                "stdout": big_tool_response().to_string(),
+                "stderr": "",
+                "interrupted": false,
+            },
+        });
+
+        let line = compress_tool_response(&raw, &cfg, &eng).expect("gate should fire");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&line).expect("line must be valid JSON");
+        let updated = &parsed["hookSpecificOutput"]["updatedToolOutput"];
+
+        assert!(
+            updated.is_object(),
+            "must stay an object or Claude Code discards it; got: {updated}"
+        );
+        assert_eq!(updated["interrupted"], json!(false), "siblings preserved");
+        assert_eq!(updated["stderr"], json!(""), "siblings preserved");
+        // `stdout` was declared a string by the tool, so the compressed form
+        // must still be a string — the retrieval hash is inlined as text
+        // rather than swapped in as the object envelope.
+        let stdout = updated["stdout"]
+            .as_str()
+            .expect("stdout must stay a string, not become the object envelope");
+        assert!(
+            stdout.contains("mur_retrieve"),
+            "compressed stdout should carry the retrieval marker: {stdout}"
         );
     }
 


### PR DESCRIPTION
Auto-compression has **never taken effect** for `Edit`, `Write`, `Bash`, `Agent`, `WebSearch` or `WebFetch`. Claude Code validates a PostToolUse `updatedToolOutput` against the **originating tool's** output schema, and we were handing back a shape those schemas reject — so every one of those results was silently discarded with `using original output`, the compression work thrown away each time.

Found while auditing hook health: **489 rejections in a 50-session window — 8.5% of all hook runs.**

```
PostToolUse hook returned updatedToolOutput that does not match Edit's output shape;
using original output.
[{ "code": "invalid_type", "expected": "object", "path": [],
   "message": "Invalid input: expected object, received string" }]
```

| Tool | Rejections |
|---|---|
| Edit | 358 |
| Bash | 75 |
| Write | 35 |
| Agent | 17 |
| WebSearch / WebFetch | 2 / 2 |

## Two mismatches, the first hiding the second

1. **`mur-core/src/cmd/hook.rs`** — stringified the whole replacement before emitting it, so an object arrived as a string. This is what `path: []` points at.
2. **`mur-compress/src/auto.rs`** — even with the top level fixed, the `Object` branch swapped a **string field** (Bash's `stdout`; Edit's and Write's string fields) for the object retrieval envelope, failing the same way one level down. Invisible in the original error because the top level failed first.

Both fixed by preserving the input's type. `shaped_replacement` inlines the retrieval note into the text for string inputs, so the field keeps its declared type while the hash stays reachable by `mur_retrieve`. Arrays keep the envelope — they arrive from MCP list results, whose output schemas are unconstrained.

## A guard this nearly broke

The string form would have quietly defeated `annotate_offload_errors`, which recognises only the object envelope. An offloaded result bundling tool errors would have lost its `WARNING` — the exact error-hiding that function exists to prevent ("an offloaded `tool error: ...` gets mistaken for success"). It now handles the string form at both the top level and inside an object, sharing the warning text with the envelope path via the new `error_warning`.

## Why it survived this long

Three existing tests asserted the stringified shape — they **encoded the bug as the contract**. They now assert the type the tool declared, plus a new `object_tool_response_keeps_object_shape` covering the Bash-shaped `{stdout, stderr, interrupted}` case end to end.

## Verification

```
mur-compress + mur-mcp-server   100/100 pass
mur-core cmd::hook               16/16  pass
mur-agent-runtime (downstream)   green
cargo fmt --all --check          clean
clippy                           no warnings in either changed file
```

**Not verified here:** the tests prove the *emitted shape* is right, not that Claude Code accepts it — the schemas were inferred from the rejection messages, not from an authoritative source. The real confirmation is installing this and watching `hook_error_during_execution` go to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
