### PR TITLE
fix(murmur): put the mascot back on top, and give the band its rows back

### DIFF
--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -328,31 +328,6 @@ async fn run_tui(
     }));
 
     let _guard = TerminalGuard::enter()?;
-    // Fixed height for the terminal's current size — see `viewport_h_for` for
-    // why the viewport is never resized while the session runs (the event loop
-    // only rebuilds it when the TERMINAL resizes).
-    let initial_h = crossterm::terminal::size()
-        .map(|(_, rows)| viewport_h_for(rows))
-        .unwrap_or(INLINE_VIEWPORT_HEIGHT);
-    // Anchor the viewport at the BOTTOM of the screen, like `purge_and_reanchor`
-    // does: `with_options` anchors wherever the cursor happens to be, which on a
-    // tall window pins the composer a fifth of the way down with dead space
-    // below it. Bottom-anchoring also gives `insert_before` the headroom it
-    // wants for the first screenful of transcript. Only ever move DOWN — moving
-    // up would draw the viewport over visible shell output.
-    if let Ok((_, rows)) = crossterm::terminal::size() {
-        let top = rows.saturating_sub(initial_h);
-        if cursor::position().is_ok_and(|(_, r)| r < top) {
-            let _ = execute!(io::stdout(), cursor::MoveTo(0, top));
-        }
-    }
-    let mut terminal = Terminal::with_options(
-        CrosstermBackend::new(io::stdout()),
-        ratatui::TerminalOptions {
-            viewport: ratatui::Viewport::Inline(initial_h),
-        },
-    )
-    .context("init terminal")?;
 
     let mut app = build_app(&home, &agent, resume, active_theme)?;
     if let Some(f) = fleet.as_deref() {
@@ -379,6 +354,35 @@ async fn run_tui(
     if auto_reads {
         app.push_system("auto-reads is ON — read-only bash commands (cat/ls/grep/git status/…) are auto-approved; writes and ambiguous commands still prompt");
     }
+
+    // Fixed height for the terminal's current size — see `viewport_h_for` for
+    // why the viewport is never resized while the session runs (the event loop
+    // only rebuilds it when the TERMINAL resizes, or when the welcome gives way
+    // to the first message). Built AFTER the app because "is this the welcome?"
+    // is a question about the transcript.
+    let initial_h = crossterm::terminal::size()
+        .map(|(_, rows)| viewport_h_for(rows, app.messages.is_empty()))
+        .unwrap_or(INLINE_VIEWPORT_HEIGHT);
+    // Anchor the viewport at the BOTTOM of the screen, like `purge_and_reanchor`
+    // does: `with_options` anchors wherever the cursor happens to be, which on a
+    // tall window pins the composer a fifth of the way down with dead space
+    // below it. Bottom-anchoring also gives `insert_before` the headroom it
+    // wants for the first screenful of transcript. Only ever move DOWN — moving
+    // up would draw the viewport over visible shell output.
+    if let Ok((_, rows)) = crossterm::terminal::size() {
+        let top = rows.saturating_sub(initial_h);
+        if cursor::position().is_ok_and(|(_, r)| r < top) {
+            let _ = execute!(io::stdout(), cursor::MoveTo(0, top));
+        }
+    }
+    let mut terminal = Terminal::with_options(
+        CrosstermBackend::new(io::stdout()),
+        ratatui::TerminalOptions {
+            viewport: ratatui::Viewport::Inline(initial_h),
+        },
+    )
+    .context("init terminal")?;
+
     let cwd = app.cwd.clone().unwrap_or_else(|| PathBuf::from("."));
     let (panel_rx, panel_handle) = panel::start(&app.home, &app.agent, &cwd);
     app.panel = Some(panel_handle);
@@ -482,8 +486,19 @@ fn leave_fullscreen(app: &mut App) {
 /// clear + repaint), which leaks stale frame copies into scrollback and bleeds
 /// old glyphs through the status row on short windows. One spare row keeps the
 /// healthy region-scroll paths in play.
-fn viewport_h_for(rows: u16) -> u16 {
-    rows.saturating_sub(1).clamp(5, INLINE_VIEWPORT_HEIGHT)
+///
+/// `welcome` is the one exception: an empty transcript paints the mascot and
+/// nothing is ever flushed (there is no transcript to flush), so the viewport
+/// takes the whole window — mascot at the top, composer on the floor, instead
+/// of the whole UI huddled in the bottom fifth of a tall terminal. The height
+/// drops to the fixed one the moment the first message lands.
+fn viewport_h_for(rows: u16, welcome: bool) -> u16 {
+    let full = rows.saturating_sub(1).max(5);
+    if welcome {
+        full
+    } else {
+        full.min(INLINE_VIEWPORT_HEIGHT)
+    }
 }
 
 /// Rebuild the terminal after its size changed (font zoom / window resize).
@@ -517,7 +532,7 @@ fn rebuild_after_resize(
     // the whole screen, which sends `insert_before` through its degenerate
     // draw-over-the-top path (lost/garbled scrollback rows). A resize is the
     // only time the viewport height changes at all.
-    let h = viewport_h_for(size.1);
+    let h = viewport_h_for(size.1, app.messages.is_empty());
     purge_and_reanchor(terminal, h)?;
     app.flushed_upto = 0;
     app.flushed_bytes = 0;
@@ -583,7 +598,7 @@ async fn event_loop(
     // Inline-viewport height: fixed for the terminal's current size (see
     // `viewport_h_for`). Tracks the height the live terminal actually has
     // (run() creates the terminal with this same value).
-    let mut viewport_h = viewport_h_for(last_size.height);
+    let mut viewport_h = viewport_h_for(last_size.height, app.messages.is_empty());
 
     loop {
         // Terminal size changed (font zoom, window resize): ratatui's
@@ -610,6 +625,20 @@ async fn event_loop(
             }
         }
         app.sync_input_block();
+        // Leaving (or returning to) the welcome is the only time the viewport
+        // height changes without the terminal resizing. Route it through the
+        // same wipe + replay as /clear: the transcript is one message long at
+        // that instant, so the replay is free and neither anchor artifact from
+        // `viewport_h_for`'s doc comment can form.
+        if app.render_mode == RenderMode::Inline {
+            let want_h = viewport_h_for(last_size.height, app.messages.is_empty());
+            if want_h != viewport_h {
+                viewport_h = want_h;
+                app.flushed_upto = 0;
+                app.flushed_bytes = 0;
+                app.wants_screen_wipe = true;
+            }
+        }
         // /clear or channel switch: the on-screen transcript no longer
         // matches the conversation — wipe screen + scrollback and re-anchor
         // so the fresh state (welcome or replayed channel) renders clean.
@@ -1855,6 +1884,27 @@ fn notify_unfocused(title: &str, message: &str) {
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
         let _ = (title, message); // no-op on other platforms
+    }
+}
+
+#[cfg(test)]
+mod viewport_tests {
+    use super::{INLINE_VIEWPORT_HEIGHT, viewport_h_for};
+
+    /// The welcome and the chat surface want opposite things, and only one of
+    /// them is safe at full height: nothing is ever flushed to scrollback while
+    /// the transcript is empty, so the mascot can own the window, but a chat
+    /// viewport must leave the spare rows `insert_before` needs.
+    #[test]
+    fn the_welcome_owns_the_window_and_chat_leaves_headroom() {
+        let rows = 60;
+        assert_eq!(viewport_h_for(rows, true), rows - 1);
+        assert_eq!(viewport_h_for(rows, false), INLINE_VIEWPORT_HEIGHT);
+        // Short window: even the welcome keeps its spare row.
+        assert_eq!(viewport_h_for(12, true), 11);
+        // Absurdly short: a floor beats a zero-height viewport.
+        assert_eq!(viewport_h_for(2, true), 5);
+        assert_eq!(viewport_h_for(2, false), 5);
     }
 }
 

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -26,6 +26,11 @@ const OVERLAY_HINT: &str = " press Enter or Esc to return · Ctrl+D quit ";
 /// reads as belonging to its speaker rather than sitting flush with the header.
 const MSG_INDENT: &str = "  ";
 
+/// Composer height when the input is empty (one text row plus its border).
+/// Typing grows it up to `INPUT_H_MAX`.
+const INPUT_H_MIN: u16 = 3;
+const INPUT_H_MAX: u16 = 8;
+
 /// Prepend the body indent to an already-styled line (e.g. cached markdown).
 fn indent_line(mut line: Line<'static>) -> Line<'static> {
     line.spans.insert(0, Span::raw(MSG_INDENT));
@@ -42,7 +47,7 @@ pub fn render(f: &mut Frame, app: &mut App) {
         return;
     }
     let input_lines = app.input.lines().len() as u16;
-    let input_height = (input_lines + 2).clamp(3, 8);
+    let input_height = (input_lines + 2).clamp(INPUT_H_MIN, INPUT_H_MAX);
     // The agent chooser (suggested replies) renders as its own layout band
     // between transcript and composer — never a Clear-overlay popup — so it
     // can't cover the reply the user must read to choose. The slash-command
@@ -451,15 +456,17 @@ fn band_capacity(viewport_h: u16, input_h: u16, chooser_h: u16, rail_h: u16) -> 
     viewport_h.saturating_sub(input_h + 1 + chooser_h + rail_h + 2)
 }
 
-/// Rows the live transcript band can paint inside a viewport of `viewport_h`:
-/// what the `render` layout leaves after the composer, the status line, an
-/// open chooser band, and the band's own TOP/BOTTOM borders.
+/// Rows the live transcript band may KEEP inside a viewport of `viewport_h`.
+///
+/// Deliberately the band's LARGEST height, not its height this frame: a
+/// grown composer and an open chooser band are both temporary, but a flush
+/// is not — rows pushed to scrollback never come back, so flushing to fit a
+/// transient squeeze leaves a blank hole above the composer the moment that
+/// squeeze ends. Over-keeping is free: the band tail-follows, so surplus
+/// rows simply wait off-screen until the space is theirs again. The rail is
+/// the exception — it stays for the session, so it really does take its rows.
 fn band_inner_rows(app: &App, viewport_h: u16) -> u16 {
-    let input_h = (app.input.lines().len() as u16 + 2).clamp(3, 8);
-    let chooser_h = chooser_band_height(app, viewport_h, input_h);
-    // The rail steals rows from the live band; miss it here and the flush
-    // decision drifts from what is painted.
-    band_capacity(viewport_h, input_h, chooser_h, fleet_rail_height(app))
+    band_capacity(viewport_h, INPUT_H_MIN, 0, fleet_rail_height(app))
 }
 
 /// Index one past the last message that is settled AND therefore flushable:
@@ -687,7 +694,14 @@ pub fn flush_finished<B: Backend>(
     let mut total: u32 = rows.iter().map(|r| u32::from(*r)).sum();
     let settled = settle_end(app);
     let mut end = start;
-    while end < settled && total > cap {
+    // Stop BEFORE the message whose departure would leave the band short. A
+    // flush is one-way, and a message is flushed whole, so "flush while we
+    // overflow" hands a 30-row reply to scrollback and leaves the band empty —
+    // the transcript ends mid-screen with a blank slab down to the composer.
+    // Keeping it costs nothing: the band tail-follows, so the surplus rows sit
+    // off-screen (PageUp reaches them) until later messages push them out for
+    // real.
+    while end < settled && total > cap && total - u32::from(rows[end - start]) >= cap {
         total -= u32::from(rows[end - start]);
         end += 1;
     }


### PR DESCRIPTION
Two reported complaints, one surface.

## 1. The mascot ended up at the bottom

The composer-on-the-floor layout pinned the whole UI to the bottom fifth of a tall window, welcome art included. The welcome now takes the whole window; the composer still sits on the floor.

Safe because nothing is ever flushed to scrollback while the transcript is empty, so the degenerate `insert_before` path a full-height viewport normally hits cannot fire. The height drops to the fixed 20 the moment the first message lands, through the same purge + replay `/clear` already uses — the transcript is one message long at that instant, so the replay is free. Leaving (or returning to) the welcome is the only time the viewport resizes on its own.

## 2. Closing the suggestion list left a blank slab

Two sources, both from flushing more rows than necessary. A flush is one-way, so rows given to scrollback to fit a *temporary* squeeze never come back:

- `band_inner_rows` now measures the band's **largest** height, not its height this frame. A grown composer and an open chooser are transient — the gap left behind is exactly the chooser's height once it closes. (The fleet rail still counts; it stays for the session.)
- `flush_finished` stops **before** the message whose departure would leave the band short, instead of flushing whole messages while it overflows. A 30-row reply used to go to scrollback in one piece and end the transcript mid-screen with a blank slab down to the composer — this is what the reported screenshot actually shows.

Over-keeping costs nothing: the band tail-follows, so surplus rows wait off-screen (PageUp reaches them) until later messages push them out for real.

## Verification

`tmux` at 100x40 against a live agent:

- startup: mascot on row 4, composer rows 36-39, status row 40
- after the first message: viewport back to 20 rows, no leaked frame copies
- long wrapped message + open chooser → `Esc`: every returned row refills with transcript content, no hole

`cargo test -p mur-core --lib cli::` — 199 passed. New `viewport_tests` guards the welcome/chat height contract. fmt + clippy clean.