### PR TITLE
feat(fleet): mur fleet cancel — drop a queued job before a run takes it

### DIFF
--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -549,6 +549,16 @@ pub enum FleetAction {
         #[arg(long)]
         all: bool,
     },
+    /// Cancel a queued job so no run picks it up
+    Cancel {
+        /// Fleet name
+        name: String,
+        /// Job id, or a unique prefix of one (see `mur fleet jobs`)
+        id: String,
+        /// Skip the confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
     /// Stop a fleet (kill-switch): disable auto-run and halt a running loop
     Stop {
         /// Fleet name

--- a/mur-core/src/cmd/fleet/jobs.rs
+++ b/mur-core/src/cmd/fleet/jobs.rs
@@ -213,6 +213,77 @@ pub fn cmd_fleet_send(mur_home: &Path, fleet: &str, text: &str) -> Result<()> {
     Ok(())
 }
 
+/// Resolve `prefix` to exactly one cancelable job. Only `queued` jobs can be
+/// canceled: a `running` one has a live child process that this command cannot
+/// reach, and marking it terminal would only make the record lie.
+/// ponytail: queued-only. Canceling a running job means killing its run —
+/// `mur fleet stop` is the kill-switch for that today.
+fn resolve_cancelable<'a>(jobs: &'a [Job], prefix: &str) -> Result<&'a Job> {
+    if prefix.is_empty() {
+        bail!("pass a job id (or a unique prefix of one)");
+    }
+    let matches: Vec<&Job> = jobs.iter().filter(|j| j.id.starts_with(prefix)).collect();
+    match matches.as_slice() {
+        [] => bail!("no job matching '{prefix}'"),
+        [job] if job.status == JobStatus::Queued => Ok(job),
+        [job] => bail!(
+            "job {} is {}, not queued — only queued jobs can be canceled",
+            &job.id[..job.id.len().min(8)],
+            job.status.as_str()
+        ),
+        many => bail!(
+            "'{prefix}' matches {} jobs — use a longer prefix",
+            many.len()
+        ),
+    }
+}
+
+/// `mur fleet cancel <name> <id> [--yes]` — drop a queued job so no run picks
+/// it up. Terminal and irreversible (there is no un-cancel), so it prompts for
+/// y/N unless `yes` — same contract as `mur fleet delete`.
+pub fn cmd_fleet_cancel(mur_home: &Path, fleet: &str, id_prefix: &str, yes: bool) -> Result<()> {
+    let _ = store::load_fleet(mur_home, fleet)?;
+    let jobs = list_jobs(mur_home, fleet)?;
+    let mut job = resolve_cancelable(&jobs, id_prefix)?.clone();
+
+    if !yes && !confirm_cancel(&job)? {
+        println!("Aborted — job {} left queued.", short(&job.id));
+        return Ok(());
+    }
+
+    job.status = JobStatus::Canceled;
+    job.finished_at = Some(chrono::Utc::now().to_rfc3339());
+    save_job(mur_home, fleet, &job)?;
+    println!("Canceled job {} for fleet '{fleet}'.", job.id);
+    Ok(())
+}
+
+/// Interactive y/N confirmation (skipped when `--yes`). Shows the job text so
+/// an id prefix that resolved to the wrong job is visible before it is spent.
+fn confirm_cancel(job: &Job) -> Result<bool> {
+    use std::io::Write;
+    let preview: String = job
+        .text
+        .lines()
+        .next()
+        .unwrap_or("")
+        .chars()
+        .take(60)
+        .collect();
+    print!(
+        "Cancel queued job {} ({preview})? This cannot be undone. [y/N] ",
+        short(&job.id)
+    );
+    std::io::stdout().flush()?;
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    Ok(matches!(input.trim().to_lowercase().as_str(), "y" | "yes"))
+}
+
+fn short(id: &str) -> &str {
+    &id[..id.len().min(8)]
+}
+
 /// Which jobs `mur fleet jobs` shows: all when `all`, else only non-terminal
 /// (queued/running). Pure so the filter is testable without capturing stdout.
 fn visible_jobs(jobs: &[Job], all: bool) -> Vec<&Job> {
@@ -328,5 +399,61 @@ mod tests {
         assert_eq!(jobs[0].source, "cli");
         // jobs view runs without panicking on existing fleet
         cmd_fleet_jobs(home, "dev", true).unwrap();
+    }
+
+    #[test]
+    fn cancel_only_queued_and_only_on_unambiguous_prefix() {
+        let mk = |id: &str, status| Job {
+            id: id.into(),
+            text: "t".into(),
+            source: "cli".into(),
+            status,
+            created_at: "now".into(),
+            started_at: None,
+            finished_at: None,
+            run_id: None,
+            result: None,
+            error: None,
+        };
+        let jobs = vec![
+            mk("019f0000-aaaa", JobStatus::Queued),
+            mk("019f0000-bbbb", JobStatus::Queued),
+            mk("abcd1234-cccc", JobStatus::Running),
+        ];
+        // unique prefix + queued → resolves
+        assert_eq!(
+            resolve_cancelable(&jobs, "019f0000-a").unwrap().id,
+            "019f0000-aaaa"
+        );
+        // shared prefix → refuse rather than cancel the wrong one
+        assert!(resolve_cancelable(&jobs, "019f").is_err());
+        // running is not cancelable here (the run owns it)
+        assert!(resolve_cancelable(&jobs, "abcd").is_err());
+        assert!(resolve_cancelable(&jobs, "nope").is_err());
+        assert!(resolve_cancelable(&jobs, "").is_err());
+    }
+
+    #[test]
+    fn cancel_marks_job_terminal_so_next_queued_skips_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        super::super::create::cmd_fleet_create(home, "dev", vec!["pm".into()], None, None, None)
+            .unwrap();
+        let a = enqueue_job(home, "dev", "first", "cli").unwrap();
+        let b = enqueue_job(home, "dev", "second", "cli").unwrap();
+
+        cmd_fleet_cancel(home, "dev", &a.id, true).unwrap();
+
+        let canceled = list_jobs(home, "dev")
+            .unwrap()
+            .into_iter()
+            .find(|j| j.id == a.id)
+            .unwrap();
+        assert_eq!(canceled.status, JobStatus::Canceled);
+        assert!(canceled.finished_at.is_some());
+        // the run picks up the next one, not the canceled one
+        assert_eq!(next_queued(home, "dev").unwrap().unwrap().id, b.id);
+        // already terminal → second cancel refused
+        assert!(cmd_fleet_cancel(home, "dev", &a.id, true).is_err());
     }
 }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -338,6 +338,9 @@ pub async fn run(cli: Cli) -> Result<()> {
                 FleetAction::Jobs { name, all } => {
                     cmd::fleet::jobs::cmd_fleet_jobs(&mur_home, &name, all)?
                 }
+                FleetAction::Cancel { name, id, yes } => {
+                    cmd::fleet::jobs::cmd_fleet_cancel(&mur_home, &name, &id, yes)?
+                }
                 FleetAction::Stop { name } => {
                     cmd::fleet::control::cmd_fleet_stop(&mur_home, &name)?
                 }

--- a/mur-hub-gui/src-tauri/src/fleet.rs
+++ b/mur-hub-gui/src-tauri/src/fleet.rs
@@ -311,6 +311,14 @@ pub fn fleet_send(name: String, text: String) -> Result<String, String> {
     Ok(job.id)
 }
 
+/// Cancel a queued job. Queued-only — see `jobs::cmd_fleet_cancel`.
+#[tauri::command]
+pub fn fleet_cancel_job(name: String, id: String) -> Result<(), String> {
+    let home = mur_home_path();
+    // yes: true — Hub already confirmed user via JS confirm()
+    jobs::cmd_fleet_cancel(&home, &name, &id, true).map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 pub fn fleet_jobs(name: String, all: bool) -> Result<Vec<JobRow>, String> {
     let home = mur_home_path();

--- a/mur-hub-gui/src-tauri/src/lib.rs
+++ b/mur-hub-gui/src-tauri/src/lib.rs
@@ -714,6 +714,7 @@ pub fn run() {
             fleet::get_fleet_autorun,
             fleet::set_fleet_autorun,
             fleet::fleet_send,
+            fleet::fleet_cancel_job,
             fleet::fleet_jobs,
             fleet::fleet_add_member,
             fleet::fleet_remove_member,

--- a/mur-hub-gui/ui/src/components/fleet/FleetDetail.tsx
+++ b/mur-hub-gui/ui/src/components/fleet/FleetDetail.tsx
@@ -265,6 +265,21 @@ export function FleetDetail({ detail, jobs, agentMap, onRefresh, onDelete }: Pro
     }
   }
 
+  async function handleCancelJob(job: { id: string; text: string }) {
+    const msg = t("fleet.confirmCancelJob").replace("{job}", job.text.split("\n")[0].slice(0, 60));
+    const ok = await confirm(msg, { title: t("fleet.cancelJob"), kind: "warning" });
+    if (!ok) return;
+    setBusy("fleet_cancel_job");
+    try {
+      await invoke("fleet_cancel_job", { name: detail.name, id: job.id });
+      onRefresh();
+    } catch (err) {
+      showToast(String(err), 4000);
+    } finally {
+      setBusy(null);
+    }
+  }
+
   async function handleShowAll() {
     if (showAll) { setShowAll(false); setAllJobs([]); return; }
     setBusy("fleet_jobs");
@@ -577,6 +592,16 @@ export function FleetDetail({ detail, jobs, agentMap, onRefresh, onDelete }: Pro
               </span>
               <span className="fleet-job__text">{job.text}</span>
               <span className="fleet-job__ts">{job.created_at.slice(0, 10)}</span>
+              {job.status === "queued" && (
+                <button
+                  className="fleet-job__cancel"
+                  title={t("fleet.cancelJob")}
+                  onClick={() => handleCancelJob(job)}
+                  disabled={busy !== null}
+                >
+                  ×
+                </button>
+              )}
             </div>
           ))}
         </div>

--- a/mur-hub-gui/ui/src/i18n/en.ts
+++ b/mur-hub-gui/ui/src/i18n/en.ts
@@ -652,6 +652,8 @@ export const en = {
   "fleet.import": "Import",
   "fleet.delete": "Delete Fleet",
   "fleet.confirmDelete": "Delete fleet \"{name}\"? This cannot be undone.",
+  "fleet.cancelJob": "Cancel Job",
+  "fleet.confirmCancelJob": "Cancel queued job \"{job}\"? This cannot be undone.",
   "fleet.dangerZone": "Danger Zone",
   "fleet.deleteDesc": "Permanently delete this fleet and all its configuration.",
   "fleet.jobs": "Jobs",

--- a/mur-hub-gui/ui/src/i18n/zh-TW.ts
+++ b/mur-hub-gui/ui/src/i18n/zh-TW.ts
@@ -654,6 +654,8 @@ export const zhTW: Table = {
   "fleet.import": "匯入",
   "fleet.delete": "刪除機群",
   "fleet.confirmDelete": "確定刪除機群「{name}」？此操作無法復原。",
+  "fleet.cancelJob": "取消工作",
+  "fleet.confirmCancelJob": "確定取消排隊中的工作「{job}」？此操作無法復原。",
   "fleet.dangerZone": "危險操作",
   "fleet.deleteDesc": "永久刪除此機群及所有相關設定，無法復原。",
   "fleet.jobs": "任務",

--- a/mur-hub-gui/ui/src/styles/components/fleet.css
+++ b/mur-hub-gui/ui/src/styles/components/fleet.css
@@ -416,6 +416,26 @@
   flex: none;
 }
 
+.fleet-job__cancel {
+  flex: none;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 13px;
+  line-height: 1;
+  color: var(--text-tertiary);
+}
+
+.fleet-job__cancel:hover:not(:disabled) {
+  color: var(--danger, #d64545);
+}
+
+.fleet-job__cancel:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .fleet-jobs__more {
   margin-top: 6px;
   font-size: 11px;


### PR DESCRIPTION
## Why

The fleet job queue was intake-only: `send` enqueued, `run` drained, and every write to a job's status came from the run lifecycle (`resolve_run_goal` marks Running, the run stamps the terminal state, `reconcile_jobs` converges zombies). An operator who queued the wrong thing had no verb — only `rm` on the yaml, which loses the audit record.

`JobStatus::Canceled` already existed and the Hub already rendered it, but the only thing that could set it was a channel reporting `canceled`/`rejected` — cancellation as the *outcome of a run*, never as a *decision*.

Found while working out why a job queued on 2026-07-16 was still `queued`: the seven runs since then all passed an explicit goal, and that path enqueues a fresh job and runs it directly, never touching the queue. The old job was jumped every time, with no way to drop it.

## What

`mur fleet cancel <fleet> <id> [--yes]`

- Resolves an id prefix to exactly one job; an ambiguous prefix is **refused**, not guessed.
- **Queued-only.** A `running` job has a live child process this command cannot reach; stamping it terminal would only make the record lie. `mur fleet stop` remains the kill-switch for a live run.
- Irreversible (there is no un-cancel), so it prompts y/N showing the job's first line, unless `--yes` — same contract as `mur fleet delete`.

Hub gets the same affordance: an `×` on each queued job, behind the same `confirm()` dialog used for fleet deletion. The tauri command passes `yes: true` because the UI already confirmed.

`stop` and `cancel` sit at different layers and stay complementary: `stop` is a reversible brake on the whole fleet that leaves the queue untouched; `cancel` permanently drops one job.

## Verification

| Check | Result |
|---|---|
| `cargo test -p mur-core --lib fleet::jobs` | 7 passed (2 new) |
| `cargo clippy -p mur-core --lib` | clean |
| `cargo check` (hub `src-tauri`) | exit 0 |
| `tsc --noEmit` (hub ui) | clean |
| `vitest src/i18n/t.test.ts` | 4 passed (en/zh-TW parity) |
| `mur fleet cancel --help` | args/flags as specified |
| Real run against `~/.mur` | the stale job is now `status: canceled`, queue empty |

New tests cover prefix resolution (unique / ambiguous / missing / empty), the running-is-not-cancelable refusal, and that a canceled job is skipped by `next_queued` while the next one is picked up.

## Not included

Batch `--all` cancel, and canceling a running job (needs to reach into the run's kill path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)