### PR TITLE
fix(cli): make the perm-restart and parallel_jobs denials actionable

### DIFF
--- a/mur-core/src/cmd/agent/perm.rs
+++ b/mur-core/src/cmd/agent/perm.rs
@@ -27,6 +27,7 @@ pub(super) fn warn_if_running(name: &str) {
         && pid_alive(lock.pid)
     {
         eprintln!("warning: '{name}' is running; restart required for changes to take effect");
+        eprintln!("         run: mur agent restart {name}");
     }
 }
 

--- a/mur-core/src/executor/jobs.rs
+++ b/mur-core/src/executor/jobs.rs
@@ -84,12 +84,14 @@ pub fn resolve_jobs(
 /// Fail-closed: any miss returns an Err immediately. Called before any
 /// channel mint or dial so a prompt-injected concierge cannot widen the
 /// target set (OWASP Agentic ASI02/03/04).
-fn check_authorization(allow: &HashSet<String>, jobs: &[Job]) -> Result<()> {
+fn check_authorization(allow: &HashSet<String>, jobs: &[Job], config_path: &Path) -> Result<()> {
     for j in jobs {
         if !allow.contains(&j.assignee) {
             bail!(
-                "target '{}' not authorized for parallel_jobs — add it to `parallel_jobs.targets` \
-                 in ~/.mur/config.yaml (deny-by-default)",
+                "target '{}' not authorized for parallel_jobs (deny-by-default) — add it under \
+                 `parallel_jobs.targets` in {}, e.g.\n\nparallel_jobs:\n  targets:\n    - {}",
+                j.assignee,
+                config_path.display(),
                 j.assignee
             );
         }
@@ -102,14 +104,15 @@ fn check_authorization(allow: &HashSet<String>, jobs: &[Job]) -> Result<()> {
 /// Mirrors the `verified_active_fleet` pattern (any miss is a denial, never
 /// fail-open).
 fn authorize_targets(mur_home: &Path, jobs: &[Job]) -> Result<()> {
-    let cfg = Config::load_or_default(&mur_home.join("config.yaml"));
+    let config_path = mur_home.join("config.yaml");
+    let cfg = Config::load_or_default(&config_path);
     let allow: HashSet<String> = cfg
         .parallel_jobs
         .targets
         .iter()
         .map(|t| canonicalize_agent_name(mur_home, t))
         .collect();
-    check_authorization(&allow, jobs)
+    check_authorization(&allow, jobs, &config_path)
 }
 
 /// Run N jobs as one ephemeral, channel-recorded DAG. Mints a throwaway
@@ -219,7 +222,7 @@ mod tests {
             assignee: "rustsmith".into(),
         }];
         assert!(
-            check_authorization(&allow, &jobs).is_err(),
+            check_authorization(&allow, &jobs, Path::new("config.yaml")).is_err(),
             "empty allowlist must reject any target"
         );
     }
@@ -232,7 +235,7 @@ mod tests {
             assignee: "rustsmith".into(),
         }];
         assert!(
-            check_authorization(&allow, &jobs).is_ok(),
+            check_authorization(&allow, &jobs, Path::new("config.yaml")).is_ok(),
             "allowlisted target must be permitted"
         );
     }
@@ -244,7 +247,7 @@ mod tests {
             description: "a".into(),
             assignee: "unknown-agent".into(),
         }];
-        let err = check_authorization(&allow, &jobs).unwrap_err();
+        let err = check_authorization(&allow, &jobs, Path::new("config.yaml")).unwrap_err();
         assert!(
             err.to_string().contains("not authorized"),
             "error must mention authorization: {err}"
@@ -266,7 +269,7 @@ mod tests {
             },
         ];
         assert!(
-            check_authorization(&allow, &jobs).is_err(),
+            check_authorization(&allow, &jobs, Path::new("config.yaml")).is_err(),
             "must reject when any target is not in the allowlist"
         );
     }


### PR DESCRIPTION
Two dead ends found in a real agent session: each error stated a condition but not the command or the file that clears it, so the agent guessed and stalled.

## 1. `perm.rs:29` — the warning never named the restart command

`warn_if_running` printed:

```
warning: 'mur' is running; restart required for changes to take effect
```

The agent that hit this guessed `mur agent perm restart` — no such subcommand — and the session dead-ended. Now it also prints:

```
         run: mur agent restart mur
```

Safe advice for Hub-managed agents too: `restart.rs:248` takes the no-service branch and respawns the runtime directly, so it does not leave a plist-less concierge stopped.

## 2. `jobs.rs:91` — the denial hardcoded a config path the gate does not read

The message said `~/.mur/config.yaml`, but `authorize_targets` reads `mur_home.join("config.yaml")` — so with `MUR_HOME` set, it pointed at a file that is not the one being consulted (CLAUDE.md rule 1). The real path is now threaded through `check_authorization`, plus the exact block to paste:

```
target 'dr_worker_3' not authorized for parallel_jobs (deny-by-default) — add it under
`parallel_jobs.targets` in /Users/david/.mur/config.yaml, e.g.

parallel_jobs:
  targets:
    - dr_worker_3
```

Gate semantics are unchanged — still pure, pre-action, fail-closed, deny-by-default (OWASP Agentic ASI02/03/04). Only the signature and the message text changed.

## Verification

- `cargo check -p mur-core --tests` — clean
- `cargo nextest run -p mur-core --lib -E 'test(check_authorization) or test(parallel_jobs)'` — 6/6 pass
- `cargo clippy -p mur-core -- -D warnings` — clean
- `cargo fmt --all` — no changes

Not verified against a built binary; both changes are `format!` strings, and the existing tests cover the branches but do not assert the new literals.

## Not in scope

The third link in the original failure chain — the agent has no write entitlement to `~/.mur/config.yaml`, so it cannot apply the fix the message now describes — is left alone. That is deny-by-default working as designed; changing it is a design question (should there be a `mur config` CLI?), not a wording fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)