### PR TITLE
fix(research-gateway,runtime): configurable search endpoint + an honest sandbox warning

### DIFF
--- a/docs/design/deep-research/README.ja.md
+++ b/docs/design/deep-research/README.ja.md
@@ -135,7 +135,7 @@ mur deep-research run deep-research --max-iterations 4 --deadline 30m
 ```
 
 - **結果の在り処** — 各ワーカーの引用付き返信は `~/.mur/channels/fleet-deep-research/events.jsonl` の署名済みイベント。`~/.mur/index/channels/` の SQLite read-model は再構築可能な射影。各引用は 1 つのゲートウェイ監査レコードに突き合わせられる。
-- **設定ノブ(ハードコード値なし)** — `MUR_RESEARCH_MAX_FETCH_CHARS`、`…_SEARCH_LIMIT`、`…_TIMEOUT_SECS`、`…_LIGHTPANDA_PATH`、`…_DENY_HOSTS` — env または `~/.mur/config.yaml` の `research_gateway:`。リテラルは決して使わない。
+- **設定ノブ(ハードコード値なし)** — `MUR_RESEARCH_MAX_FETCH_CHARS`、`…_SEARCH_LIMIT`、`…_SEARCH_ENDPOINT`、`…_TIMEOUT_SECS`、`…_LIGHTPANDA_PATH`、`…_DENY_HOSTS` — env または `~/.mur/config.yaml` の `research_gateway:`。リテラルは決して使わない。
 
 ---
 

--- a/docs/design/deep-research/README.ko.md
+++ b/docs/design/deep-research/README.ko.md
@@ -135,7 +135,7 @@ mur deep-research run deep-research --max-iterations 4 --deadline 30m
 ```
 
 - **결과가 있는 곳** — 각 워커의 인용 응답은 `~/.mur/channels/fleet-deep-research/events.jsonl` 의 서명된 이벤트다. `~/.mur/index/channels/` 의 SQLite read-model 은 재구축 가능한 프로젝션이다. 각 인용은 하나의 게이트웨이 감사 레코드에 대응된다.
-- **설정 노브(하드코딩 값 없음)** — `MUR_RESEARCH_MAX_FETCH_CHARS`, `…_SEARCH_LIMIT`, `…_TIMEOUT_SECS`, `…_LIGHTPANDA_PATH`, `…_DENY_HOSTS` — env 또는 `~/.mur/config.yaml` 의 `research_gateway:`, 결코 리터럴을 쓰지 않는다.
+- **설정 노브(하드코딩 값 없음)** — `MUR_RESEARCH_MAX_FETCH_CHARS`, `…_SEARCH_LIMIT`, `…_SEARCH_ENDPOINT`, `…_TIMEOUT_SECS`, `…_LIGHTPANDA_PATH`, `…_DENY_HOSTS` — env 또는 `~/.mur/config.yaml` 의 `research_gateway:`, 결코 리터럴을 쓰지 않는다.
 
 ---
 

--- a/docs/design/deep-research/README.md
+++ b/docs/design/deep-research/README.md
@@ -140,7 +140,7 @@ mur deep-research run deep-research --max-iterations 4 --deadline 30m
 ```
 
 - **Where results live** — each worker's cited reply is a signed event in `~/.mur/channels/fleet-deep-research/events.jsonl`. The SQLite read-model at `~/.mur/index/channels/` is a rebuildable projection. Every citation reconciles to a gateway audit record.
-- **Config knobs (no hardcoded values)** — `MUR_RESEARCH_MAX_FETCH_CHARS`, `…_SEARCH_LIMIT`, `…_TIMEOUT_SECS`, `…_LIGHTPANDA_PATH`, `…_DENY_HOSTS` — env or `research_gateway:` in `~/.mur/config.yaml`, never literals.
+- **Config knobs (no hardcoded values)** — `MUR_RESEARCH_MAX_FETCH_CHARS`, `…_SEARCH_LIMIT`, `…_SEARCH_ENDPOINT`, `…_TIMEOUT_SECS`, `…_LIGHTPANDA_PATH`, `…_DENY_HOSTS` — env or `research_gateway:` in `~/.mur/config.yaml`, never literals.
 
 ---
 

--- a/docs/design/deep-research/README.zh-CN.md
+++ b/docs/design/deep-research/README.zh-CN.md
@@ -135,7 +135,7 @@ mur deep-research run deep-research --max-iterations 4 --deadline 30m
 ```
 
 - **结果落在哪** — 每个 worker 的引用回复是 `~/.mur/channels/fleet-deep-research/events.jsonl` 里的签名事件。`~/.mur/index/channels/` 的 SQLite read-model 是可重建的投影。每个引用都能对到一条 gateway audit 记录。
-- **Config knobs(无硬编值)** — `MUR_RESEARCH_MAX_FETCH_CHARS`、`…_SEARCH_LIMIT`、`…_TIMEOUT_SECS`、`…_LIGHTPANDA_PATH`、`…_DENY_HOSTS`——env 或 `~/.mur/config.yaml` 的 `research_gateway:`,绝不用字面值。
+- **Config knobs(无硬编值)** — `MUR_RESEARCH_MAX_FETCH_CHARS`、`…_SEARCH_LIMIT`、`…_SEARCH_ENDPOINT`、`…_TIMEOUT_SECS`、`…_LIGHTPANDA_PATH`、`…_DENY_HOSTS`——env 或 `~/.mur/config.yaml` 的 `research_gateway:`,绝不用字面值。
 
 ---
 

--- a/docs/design/deep-research/README.zh-TW.md
+++ b/docs/design/deep-research/README.zh-TW.md
@@ -135,7 +135,7 @@ mur deep-research run deep-research --max-iterations 4 --deadline 30m
 ```
 
 - **結果落在哪** — 每個 worker 的引用回覆是 `~/.mur/channels/fleet-deep-research/events.jsonl` 裡的簽名事件。`~/.mur/index/channels/` 的 SQLite read-model 是可重建的投影。每個引用都能對到一筆 gateway audit 記錄。
-- **Config knobs(無硬編值)** — `MUR_RESEARCH_MAX_FETCH_CHARS`、`…_SEARCH_LIMIT`、`…_TIMEOUT_SECS`、`…_LIGHTPANDA_PATH`、`…_DENY_HOSTS`——env 或 `~/.mur/config.yaml` 的 `research_gateway:`,絕不用字面值。
+- **Config knobs(無硬編值)** — `MUR_RESEARCH_MAX_FETCH_CHARS`、`…_SEARCH_LIMIT`、`…_SEARCH_ENDPOINT`、`…_TIMEOUT_SECS`、`…_LIGHTPANDA_PATH`、`…_DENY_HOSTS`——env 或 `~/.mur/config.yaml` 的 `research_gateway:`,絕不用字面值。
 
 ---
 

--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -32,7 +32,14 @@ pub fn apply_macos(policy: &SandboxPolicy) -> anyhow::Result<SandboxStatus> {
             unsafe { sandbox_free_error(error_buf) };
             s
         };
-        tracing::warn!(error = %msg, "macOS sandbox_init failed; running advisory-only");
+        // Report the fact (not enforcing), not a decision this layer does not
+        // make: the supervisor consults `fail_closed_on_sandbox_error` and may
+        // refuse to start rather than continue advisory-only.
+        tracing::warn!(
+            error = %msg,
+            "macOS sandbox_init failed; sandbox NOT enforcing — \
+             fail_closed_on_sandbox_error decides whether startup continues"
+        );
         return Ok(SandboxStatus {
             platform: "macos-sbpl-failed".to_string(),
             effective_abi: None,

--- a/mur-research-gateway/src/config.rs
+++ b/mur-research-gateway/src/config.rs
@@ -52,6 +52,16 @@ pub const MAX_SEARCH_LIMIT: usize = 20;
 /// Default `agent-browser` binary name, resolved via `PATH`.
 pub const DEFAULT_AGENT_BROWSER_BIN: &str = "agent-browser";
 
+/// DuckDuckGo's server-rendered (no-JS) HTML search endpoint — the keyless
+/// default for tier-1 `search`. Overridable because this host is a single
+/// point of failure: networks that blackhole DDG (SYN dropped despite DNS
+/// resolving) leave keyless search dead with no signal but a timeout. Point
+/// it at a DDG mirror or an egress proxy that can reach it. The response
+/// parser still expects DuckDuckGo's HTML shape — this swaps the host, not
+/// the search engine. For a genuinely different engine, configure a Brave
+/// key (`brave_api_key` / `MUR_RESEARCH_BRAVE_KEY`) instead.
+pub const DEFAULT_SEARCH_ENDPOINT: &str = "https://html.duckduckgo.com/html/";
+
 /// Chrome-tier stealth flags (comma-separated, forwarded verbatim as
 /// `agent-browser` args). MUST NEVER be forwarded to the lightpanda tier —
 /// see `browser::build_fetch_argv`'s doc comment /
@@ -97,6 +107,7 @@ const ENV_LIGHTPANDA_PATH: &str = "MUR_RESEARCH_LIGHTPANDA_PATH";
 const ENV_CHROME_STEALTH_ARGS: &str = "MUR_RESEARCH_CHROME_STEALTH_ARGS";
 const ENV_RENDER_ENGINE: &str = "MUR_RESEARCH_RENDER_ENGINE";
 const ENV_OBSCURA_PATH: &str = "MUR_RESEARCH_OBSCURA_PATH";
+const ENV_SEARCH_ENDPOINT: &str = "MUR_RESEARCH_SEARCH_ENDPOINT";
 
 /// Fully-resolved gateway configuration — YAML defaults merged with env
 /// overrides, ready to use for the lifetime of the process.
@@ -113,6 +124,9 @@ pub struct GatewayConfig {
     pub max_fetch_chars: usize,
     /// Brave Search API token; `Some` → `search` uses Brave, `None` → DDG.
     pub brave_api_key: Option<String>,
+    /// Tier-1 search endpoint (DuckDuckGo-shaped HTML). See
+    /// [`DEFAULT_SEARCH_ENDPOINT`].
+    pub search_endpoint: String,
 }
 
 /// Raw `research_gateway:` YAML shape. Every field is optional/defaulted so
@@ -134,6 +148,7 @@ struct GatewayConfigYaml {
     chrome_stealth_args: Option<String>,
     render_engine: Option<String>,
     obscura_path: Option<String>,
+    search_endpoint: Option<String>,
 }
 
 /// Resolve `research_gateway.brave_api_key_ref` — a mur-common `SecretRef`
@@ -227,6 +242,10 @@ pub fn load_from_yaml(yaml: &str, mur_home: &Path) -> GatewayConfig {
         .or_else(|| resolve_brave_key_ref(raw.brave_api_key_ref.as_deref()))
         .or_else(|| raw.brave_api_key.filter(|s| !s.is_empty()));
 
+    let search_endpoint = non_empty_env(ENV_SEARCH_ENDPOINT)
+        .or(raw.search_endpoint)
+        .unwrap_or_else(|| DEFAULT_SEARCH_ENDPOINT.to_string());
+
     let agent_browser_bin = non_empty_env(ENV_AGENT_BROWSER_BIN)
         .or(raw.agent_browser_bin)
         .unwrap_or_else(|| DEFAULT_AGENT_BROWSER_BIN.to_string());
@@ -273,6 +292,7 @@ pub fn load_from_yaml(yaml: &str, mur_home: &Path) -> GatewayConfig {
         search_limit,
         max_fetch_chars,
         brave_api_key,
+        search_endpoint,
     }
 }
 
@@ -387,6 +407,34 @@ mod tests {
         assert!(c.search_limit >= 1); // documented default present
         unsafe {
             std::env::remove_var(ENV_FETCH_TIMEOUT_SECS);
+        }
+    }
+
+    #[test]
+    fn search_endpoint_precedence_default_then_yaml_then_env() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: env mutation guarded by ENV_LOCK above.
+        unsafe {
+            std::env::remove_var(ENV_SEARCH_ENDPOINT);
+        }
+        let yaml = "research_gateway:\n  search_endpoint: \"https://ddg.mirror.test/html/\"\n";
+
+        // 1. neither set -> the documented default
+        let c = load_from_yaml("", Path::new("/nonexistent"));
+        assert_eq!(c.search_endpoint, DEFAULT_SEARCH_ENDPOINT);
+
+        // 2. YAML set -> YAML wins over the default
+        let c = load_from_yaml(yaml, Path::new("/nonexistent"));
+        assert_eq!(c.search_endpoint, "https://ddg.mirror.test/html/");
+
+        // 3. env set -> env wins over YAML (same precedence as every sibling)
+        unsafe {
+            std::env::set_var(ENV_SEARCH_ENDPOINT, "https://from-env.test/html/");
+        }
+        let c = load_from_yaml(yaml, Path::new("/nonexistent"));
+        assert_eq!(c.search_endpoint, "https://from-env.test/html/");
+        unsafe {
+            std::env::remove_var(ENV_SEARCH_ENDPOINT);
         }
     }
 

--- a/mur-research-gateway/src/fetcher.rs
+++ b/mur-research-gateway/src/fetcher.rs
@@ -12,9 +12,6 @@ pub(crate) const MAX_BODY_BYTES: usize = 5 * 1024 * 1024; // ponytail: 5MB cap; 
 const SEARCH_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
      (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
 
-/// DuckDuckGo's server-rendered (no-JS) HTML search endpoint.
-const DDG_HTML_ENDPOINT: &str = "https://html.duckduckgo.com/html/";
-
 /// Max `search` attempts against DuckDuckGo before giving up. Under N concurrent
 /// research workers hitting DDG's html endpoint from one IP, DDG rate-limits
 /// with an HTTP 202 challenge page (no results); a short backoff usually clears
@@ -221,6 +218,7 @@ pub async fn search(
     brave_key: Option<&str>,
     deny: &[String],
     timeout: Duration,
+    endpoint: &str,
 ) -> Result<Vec<SearchHit>, FetchError> {
     match brave_key {
         Some(key) => match search_brave(query, limit, key, deny, timeout).await {
@@ -231,10 +229,10 @@ pub async fn search(
                     "brave search failed ({}), falling back to DuckDuckGo",
                     fetch_err_brief(&e)
                 );
-                search_tier1(query, limit, deny, timeout).await
+                search_tier1(query, limit, deny, timeout, endpoint).await
             }
         },
-        None => search_tier1(query, limit, deny, timeout).await,
+        None => search_tier1(query, limit, deny, timeout, endpoint).await,
     }
 }
 
@@ -336,8 +334,17 @@ pub async fn search_tier1(
     limit: usize,
     deny: &[String],
     timeout: Duration,
+    endpoint: &str,
 ) -> Result<Vec<SearchHit>, FetchError> {
-    let mut search_url = url::Url::parse(DDG_HTML_ENDPOINT).expect("static URL is valid");
+    // Operator-supplied (config/env), so a bad value must surface as an error
+    // the worker can read — never a panic that takes the gateway down.
+    let mut search_url = url::Url::parse(endpoint).map_err(|e| {
+        FetchError::Http(format!(
+            "search endpoint is not a valid URL ({e}): {endpoint:?} — fix \
+             research_gateway.search_endpoint in ~/.mur/config.yaml or \
+             MUR_RESEARCH_SEARCH_ENDPOINT"
+        ))
+    })?;
     search_url.query_pairs_mut().append_pair("q", query);
 
     let screened = screen_url_blocking(search_url.as_str(), deny)
@@ -521,6 +528,27 @@ fn decode_uddg(href: &str) -> Option<String> {
 mod tests {
     use super::*;
     use std::time::Duration;
+
+    #[tokio::test]
+    async fn search_tier1_rejects_a_malformed_endpoint_instead_of_panicking() {
+        // The endpoint is operator input (config.yaml / env), so a bad value
+        // must come back as an error the worker can read — the old code
+        // `.expect("static URL is valid")`d it, which was only safe while the
+        // endpoint was a hardcoded const. No network is touched: the URL fails
+        // to parse before any request is built.
+        let err = search_tier1("q", 3, &[], Duration::from_secs(1), "not a url")
+            .await
+            .expect_err("a malformed endpoint must be an error, not a panic");
+        let FetchError::Http(msg) = err else {
+            panic!("malformed endpoint must be FetchError::Http");
+        };
+        // Name both operator config paths so the message stays actionable.
+        assert!(msg.contains("search_endpoint"), "message was: {msg}");
+        assert!(
+            msg.contains("MUR_RESEARCH_SEARCH_ENDPOINT"),
+            "message was: {msg}"
+        );
+    }
 
     #[test]
     fn search_blocked_error_names_workaround_and_operator_fix() {

--- a/mur-research-gateway/src/server.rs
+++ b/mur-research-gateway/src/server.rs
@@ -221,7 +221,8 @@ impl McpServer {
         let deny = &self.config.deny_hosts;
         let timeout = self.config.timeout;
         let brave_key = self.config.brave_api_key.as_deref();
-        match fetcher::search(&query, limit, brave_key, deny, timeout).await {
+        let endpoint = &self.config.search_endpoint;
+        match fetcher::search(&query, limit, brave_key, deny, timeout, endpoint).await {
             Ok(hits) => {
                 audit(AuditRecord::new("search", query, None, "ok"));
                 Response::success(


### PR DESCRIPTION
Two findings from investigating why a deep-research fleet returned nothing. Neither is the thing the failure *looked* like.

## 1. `apply_macos` claimed an outcome it doesn't decide

The warning read:

```
macOS sandbox_init failed; running advisory-only
```

But this layer only reports `enforcing: false`. The **supervisor** decides: with `fail_closed_on_sandbox_error: true` it bails at `supervisor.rs:309` and the agent never starts. So the log said "running" about a process that was about to refuse to run.

That misread cost a session — the operator saw "advisory-only", concluded agents were live and unconfined, and went hunting for a sandbox escape that wasn't there. The four `refusing to start` lines beside it were the guard working correctly. Now it states the fact and names what decides the outcome.

## 2. The tier-1 search endpoint was a hardcoded const

`DDG_HTML_ENDPOINT` gave the keyless search path exactly one reachable host and no override (CLAUDE.md rule 1). On a network that blackholes DuckDuckGo — DNS resolves, SYN dropped — search is dead and the only symptom is a connect timeout.

Adds `research_gateway.search_endpoint` / `MUR_RESEARCH_SEARCH_ENDPOINT` with the same env > YAML > default precedence every sibling knob uses, the old const becoming `DEFAULT_SEARCH_ENDPOINT`.

**Scope, stated plainly:** this swaps the *host*, not the engine. The response parser still expects DuckDuckGo's HTML shape, so the useful targets are a DDG mirror or an egress proxy that can reach it. A genuinely different engine is what the Brave key is for.

Because the endpoint is now operator input, `search_tier1` no longer `.expect()`s the URL parse — a malformed value returns `FetchError::Http` naming both config paths instead of panicking the gateway.

## Verification

- `cargo check -p mur-research-gateway -p mur-agent-runtime --tests` — clean
- `cargo nextest run -p mur-research-gateway` (new + adjacent config/search tests) — 9/9 pass
- `cargo clippy -p mur-research-gateway -p mur-agent-runtime -- -D warnings` — clean
- `cargo fmt --all` — no changes

New tests: `search_endpoint_precedence_default_then_yaml_then_env` (all three precedence rungs) and `search_tier1_rejects_a_malformed_endpoint_instead_of_panicking` (the parse path that used to be an `.expect`).

Docs: added to the config-knob list in all five `docs/design/deep-research/README*.md` translations.

## Known gap, deliberately not in this PR

While investigating, a keychain-backed `brave_api_key_ref` was found silently resolving to `None`, which is what pushed traffic onto the unreachable DDG path in the first place. `resolve_brave_key_ref` *does* warn — but **the gateway's stderr is not captured into the agent's log**, so the operator never sees it. That observability gap is the reason this class of failure is so hard to diagnose, and it deserves its own change rather than being smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)