### PR TITLE
fix(runtime): surface MCP child WARN/ERROR instead of burying it at debug

### DIFF
--- a/mur-agent-runtime/src/mcp/pool.rs
+++ b/mur-agent-runtime/src/mcp/pool.rs
@@ -55,6 +55,9 @@ impl McpPool {
                 use std::io::{BufRead, BufReader};
                 for line in BufReader::new(stderr).lines() {
                     match line {
+                        Ok(l) if is_noteworthy_stderr(&l) => {
+                            tracing::warn!(server = %server_name, "mcp stderr: {l}")
+                        }
                         Ok(l) => tracing::debug!(server = %server_name, "mcp stderr: {l}"),
                         Err(_) => break,
                     }
@@ -92,10 +95,41 @@ impl McpPool {
     }
 }
 
+/// Whether a child MCP server's stderr line should surface at `warn!` instead
+/// of `debug!`. Routine chatter stays at debug so a chatty server cannot flood
+/// the agent log — but a child's own WARN/ERROR is often the operator's ONLY
+/// signal that the server degraded rather than failed outright: a secret ref
+/// that silently fell back to a default leaves a working-but-wrong config with
+/// no other trace.
+// ponytail: substring match on the level marker — covers the tracing /
+// env_logger style output MUR's own servers emit. Widen the match rather than
+// parsing per-server log formats.
+fn is_noteworthy_stderr(line: &str) -> bool {
+    line.contains("WARN") || line.contains("ERROR")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::sandbox::SandboxPolicy;
+
+    #[test]
+    fn child_warnings_surface_above_debug_but_chatter_does_not() {
+        // The line that went missing in practice: the research gateway warns
+        // that a keychain-backed brave_api_key_ref did not resolve, then
+        // silently falls back to a keyless search path. Logged at debug!, it
+        // never reached the agent log and the degraded config looked healthy.
+        assert!(is_noteworthy_stderr(
+            "2026-08-03T09:01:20Z  WARN mur_research_gateway: brave_api_key_ref did not resolve"
+        ));
+        assert!(is_noteworthy_stderr("ERROR failed to open index"));
+        // Routine chatter stays at debug — a per-call audit line must not
+        // promote itself into the operator's warning stream.
+        assert!(!is_noteworthy_stderr(
+            r#"INFO research_gateway_audit: {"verb":"search","outcome":"ok"}"#
+        ));
+        assert!(!is_noteworthy_stderr("starting up"));
+    }
 
     #[tokio::test]
     async fn unknown_server_returns_error() {


### PR DESCRIPTION
## The bug

`McpPool::client` drains each MCP server's stderr so the pipe never fills — and logs every line at `debug!`:

```rust
Ok(l) => tracing::debug!(server = %server_name, "mcp stderr: {l}"),
```

The agent runtime runs at INFO. So a child server's own WARN/ERROR never reached the agent log at all. The drain was keeping the pipe clear and throwing the contents away.

## Why it matters

This hid a live misconfiguration. `mur-research-gateway` warns when a keychain-backed `brave_api_key_ref` fails to resolve, then falls back to the keyless DuckDuckGo path — degraded, not failed. On a network that blackholes DDG (DNS resolves, SYN dropped) that produced a deep-research fleet returning nothing, while the one line explaining why was discarded before it was ever written.

Diagnosing it meant driving the gateway binary by hand over stdio to read the stderr the runtime already had in its hands. The signal existed the whole time; only its level was wrong.

Note the failure shape: not a crash, but a **silent downgrade to a working-but-wrong config**. Those are exactly the failures a child's warning line is the only witness to.

## The change

Lines carrying a severity marker surface at `warn!`; everything else stays at `debug!`, so a talkative server still cannot flood the agent log.

```rust
Ok(l) if is_noteworthy_stderr(&l) => tracing::warn!(...),
Ok(l) => tracing::debug!(...),
```

The classifier is a substring match on the level marker, extracted as a pure function and marked with its ceiling — MUR's own servers emit tracing/env_logger-style output; the documented upgrade path is to widen the match rather than parse per-server log formats.

## Verification

- `cargo nextest run -p mur-agent-runtime --lib -E 'test(noteworthy) or test(pool)'` — 2/2 pass
- `cargo clippy -p mur-agent-runtime -- -D warnings` — clean
- `cargo fmt --all` — no changes

New test `child_warnings_surface_above_debug_but_chatter_does_not` pins both directions using the real line that went missing (the `brave_api_key_ref` warning) and the audit line that must *not* promote itself into the warning stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)