### PR TITLE
fix(runtime): two live sandbox faults in the P0 pull leg, caught by the T0 tracer

### DIFF
--- a/mur-agent-runtime/src/federation/sync.rs
+++ b/mur-agent-runtime/src/federation/sync.rs
@@ -10,8 +10,17 @@ use std::time::Duration;
 use tracing::{info, warn};
 
 /// Spawn a background task that periodically flushes the evidence outbox and
-/// refreshes the pattern snapshot for `agent_name`.
-pub fn spawn_agent_sleep_cycle(agent_name: String) -> tokio::task::JoinHandle<()> {
+/// requests a fresh knowledge snapshot for `agent_name`.
+///
+/// `identity` is the supervisor's pre-sandbox-loaded keypair (supervisor step
+/// 3a). It MUST be passed in rather than re-read from disk: the B1 sandbox
+/// denies reads of the agent's own `identity.key` once applied, so a lazy
+/// per-cycle `AgentIdentity::load` fails with "identity files not found" on
+/// every enforcing platform — exactly what the T0 tracer caught live.
+pub fn spawn_agent_sleep_cycle(
+    agent_name: String,
+    identity: std::sync::Arc<mur_common::identity::AgentIdentity>,
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let interval_minutes = agent_idle_minutes();
         let mut ticker = tokio::time::interval(Duration::from_secs(interval_minutes * 60));
@@ -19,16 +28,16 @@ pub fn spawn_agent_sleep_cycle(agent_name: String) -> tokio::task::JoinHandle<()
         ticker.tick().await;
         loop {
             ticker.tick().await;
-            if let Err(e) = run_agent_cycle(&agent_name) {
+            if let Err(e) = run_agent_cycle(&agent_name, &identity) {
                 warn!(agent = %agent_name, error = %e, "agent sleep-cycle error");
             }
         }
     })
 }
 
-fn run_agent_cycle(agent_name: &str) -> Result<()> {
+fn run_agent_cycle(agent_name: &str, identity: &mur_common::identity::AgentIdentity) -> Result<()> {
     flush_outbox(agent_name)?;
-    refresh_snapshot(agent_name);
+    refresh_snapshot(agent_name, identity);
     Ok(())
 }
 
@@ -78,7 +87,7 @@ fn flush_outbox(agent_name: &str) -> Result<()> {
 /// required `mur` on the spawn allowlist — the entire CLI surface — and died
 /// with EPERM under sandbox.) Uses the same `<mur_home>/inbox/...` write
 /// grant the outbox flush above relies on.
-fn refresh_snapshot(agent_name: &str) {
+fn refresh_snapshot(agent_name: &str, identity: &mur_common::identity::AgentIdentity) {
     let mur_home = match dirs::home_dir() {
         Some(h) => h.join(".mur"),
         None => {
@@ -86,7 +95,7 @@ fn refresh_snapshot(agent_name: &str) {
             return;
         }
     };
-    match write_snapshot_request_at(&mur_home, agent_name) {
+    match write_snapshot_request_at(&mur_home, agent_name, identity) {
         Ok(()) => info!(agent = %agent_name, "agent sleep-cycle: snapshot request dropped"),
         Err(e) => {
             warn!(agent = %agent_name, error = %e, "agent sleep-cycle: snapshot request write failed")
@@ -94,14 +103,15 @@ fn refresh_snapshot(agent_name: &str) {
     }
 }
 
-/// Testable core of `refresh_snapshot`: sign with the agent identity and
-/// atomically drop the request file.
-fn write_snapshot_request_at(mur_home: &std::path::Path, agent_name: &str) -> Result<()> {
+/// Testable core of `refresh_snapshot`: sign with the (pre-sandbox-loaded)
+/// agent identity and atomically drop the request file.
+fn write_snapshot_request_at(
+    mur_home: &std::path::Path,
+    agent_name: &str,
+    identity: &mur_common::identity::AgentIdentity,
+) -> Result<()> {
     use mur_common::snapshot_request::{SNAPSHOT_REQUEST_DIR, SnapshotRequest};
-    let identity =
-        mur_common::identity::AgentIdentity::load(&mur_home.join("agents").join(agent_name))
-            .map_err(|e| anyhow::anyhow!("load agent identity: {e}"))?;
-    let req = SnapshotRequest::create(agent_name, &identity, chrono::Utc::now());
+    let req = SnapshotRequest::create(agent_name, identity, chrono::Utc::now());
     let dir = mur_home.join(SNAPSHOT_REQUEST_DIR);
     std::fs::create_dir_all(&dir)?;
     // One pending request per agent: deterministic name, tmp+rename.
@@ -147,7 +157,7 @@ mod tests {
         let id = mur_common::identity::AgentIdentity::generate();
         id.save(&agent_dir).unwrap();
 
-        write_snapshot_request_at(home, "w1").unwrap();
+        write_snapshot_request_at(home, "w1", &id).unwrap();
 
         let p = home.join("inbox/snapshot-requests/w1.yaml");
         let req: mur_common::snapshot_request::SnapshotRequest =

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -261,6 +261,19 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     // matches the macOS SBPL subpath grant — so co-watching works on both kernels,
     // not just macOS. (We create the dir first so the Landlock rule sticks.)
     let mut extra_write_paths: Vec<std::path::PathBuf> = Vec::new();
+    // Memory federation (P0): the sleep cycle drops signed snapshot requests
+    // and flushed outbox signals into `<mur_home>/inbox/…`. That is the ONLY
+    // central-store write the runtime is granted — the daemon treats the inbox
+    // as an attacker-writable surface and verifies signatures, so this grant
+    // widens no trust boundary. Created first so the Landlock rule sticks
+    // (same reasoning as the VLC runtime dir below).
+    {
+        let inbox_dir = mur_home.join("inbox");
+        let _ = std::fs::create_dir_all(
+            mur_home.join(mur_common::snapshot_request::SNAPSHOT_REQUEST_DIR),
+        );
+        extra_write_paths.push(inbox_dir);
+    }
     if let Some(vlc) = mur_common::media::load_runtime(&mur_home) {
         extra_ports.push(vlc.port);
         let runtime_dir = mur_common::media::runtime_dir(&mur_home);

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -636,7 +636,10 @@ pub async fn entrypoint() -> anyhow::Result<()> {
     // 8e. E3 — agent-side sleep cycle: flush evidence outbox + pull snapshot.
     {
         let name = profile.inner.name.clone();
-        transport_tasks.push(crate::federation::spawn_agent_sleep_cycle(name));
+        transport_tasks.push(crate::federation::spawn_agent_sleep_cycle(
+            name,
+            identity.clone(),
+        ));
         info!("agent sleep-cycle spawned");
     }
 


### PR DESCRIPTION
The T0 tracer (federation plan Task 8) ran for the first time today against the real deployment — enforcing SBPL sandbox, signed binaries, live daemon — and caught **two faults that 6,741 green tests missed**, because tests run unsandboxed. This PR is both fixes, each proven live.

## Fault 1 — lazy identity load dies post-sandbox

The sleep cycle loaded `AgentIdentity` from disk on every fire to sign its snapshot request. Under an enforcing B1 sandbox that read is denied (`identity.key` is deliberately shielded), so every cycle failed with `identity files not found` and no request was ever written.

**Fix:** the supervisor already loads the keypair pre-sandbox (step 3a, for Noise-XK transport). Thread that `Arc<AgentIdentity>` into `spawn_agent_sleep_cycle`; the doc comment records why lazy loading is structurally wrong here.

## Fault 2 — the SBPL write allowlist never included the inbox

With identity fixed, every cycle failed with EPERM: `~/.mur/inbox` was not writable. P0's stated assumption — "the outbox flush already uses this grant" — had **never been exercised in production**: an empty outbox early-returns before touching the inbox, so the missing grant stayed invisible until the snapshot request became the first real write.

**Fix:** structural grant in the supervisor's `extra_write_paths` (same create-first-so-Landlock-sticks pattern as the VLC runtime dir), not per-profile config. No trust boundary widens: the inbox is the runtime's designed file-drop surface, and the daemon already treats it as attacker-writable and signature-verifies everything in it.

## Live proof (dr_worker_4, enforcing sandbox, Developer-ID-signed binaries)

```
[+60s] inbox/snapshot-requests/dr_worker_4.yaml        signed request dropped
[+70s] daemon verified sig, assembled 59 skills → knowledge_cache/ + .snapshot-ref
       restart → prompt "Say the tracer phrase."  →  TRACER-OK-2026
       remove skill, clear, restart, re-ask       →  phrase gone (negative control ✓)
```

Along the way the tracer also exercised, by design: the B0 rule-6 SHA drift gate (fired correctly on the upgraded gateway → `mcp pin` re-approve), the daemon lock heartbeat, and the loader's source precedence (a global skill is reachable via the direct global path until #850 closes it — the cache-only source is pinned by the P1 loader unit test).

## Verification

- `cargo nextest -p mur-agent-runtime -E 'test(snapshot_request)'` green; clippy `-D warnings` clean; fmt clean
- The live loop above is the real verification — it now runs end-to-end on this machine every sleep cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)