### PR TITLE
fix(runtime): load agent skills config from the file, not the directory

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+# `mur-core`'s bin target has ~12 clap CLI-parse tests that overflow the default
+# 2 MiB thread stack in a debug build. Without this they SIGABRT, so a bare
+# `cargo nextest run --workspace` is red for everyone unless they know to
+# export it by hand. nextest has no `[env]` key of its own (0.9.137 warns
+# "ignoring unknown configuration key"), so it lives here.
+[env]
+RUST_MIN_STACK = "33554432"

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -630,7 +630,13 @@ pub(crate) async fn prepare_runtime(
         .on_startup(&hook_ctx, &profile.inner, &hook_cancel)
         .await;
 
-    let skills_cfg = mur_common::config::Config::load_or_default(&mur_home).skills;
+    // `mur_home` is a directory; `load_or_default` wants the config FILE.
+    // Passing the directory made `read_to_string` fail, which `load_or_default`
+    // swallows into `Config::default()` — so every `skills:` setting the user
+    // wrote was silently ignored here. Compare the correct call above, which
+    // joins "config.yaml".
+    let skills_cfg =
+        mur_common::config::Config::load_or_default(&mur_home.join("config.yaml")).skills;
     let loaded = mur_common::skill::loader::load_all(&mur_home, &profile.inner.name);
     // #717: surface profile.yaml skill refs that don't resolve, distinguishing
     // missing (ref written but files never installed) from malformed (files


### PR DESCRIPTION
Two independent pre-existing defects, both surfaced while documenting #853. Neither is caused by that work.

## 1. `supervisor_runner` passed a directory where a file was expected

```rust
let skills_cfg = Config::load_or_default(&mur_home).skills;   // ← directory
```

`mur_home` is a `&Path` to a directory — the very next line hands the same value to `skill::loader::load_all`, which *wants* the directory. But `load_or_default` wants the config **file**. `read_to_string` on a directory errors, and `load_or_default` swallows that into `Config::default()`:

```rust
let Ok(text) = std::fs::read_to_string(path) else { return Self::default() };
```

So every `skills:` setting a user wrote was **silently ignored inside the agent runtime** — `max_skills_in_prompt`, `priority_order`, the whole `adaptive` and `lifecycle` blocks. No error, no warning, just defaults. An agent configured to inject 12 skills would inject 5 and nothing would say why.

The correct form was already in the same file 230 lines above, where the models config joins `"config.yaml"`. A repo-wide sweep of `load_or_default` call sites confirms this was the **only** one passing a directory (`dispatch.rs:821` and `cmd/agent/cli/mod.rs:1086` both join correctly).

## 2. `RUST_MIN_STACK` was not pinned anywhere

`mur-core`'s bin target has ~12 clap CLI-parse tests that overflow the default 2 MiB thread stack in a debug build and SIGABRT. A bare `cargo nextest run --workspace` is therefore **red for everyone** who does not happen to know to export `RUST_MIN_STACK` by hand — which makes a genuinely broken test indistinguishable from the usual noise.

It goes in `.cargo/config.toml`, **not** `.config/nextest.toml`: nextest 0.9.137 has no `[env]` key of its own and warns `ignoring unknown configuration key: env`. I tried that first and it silently did nothing.

### Verification

A/B on one affected test — same command, same filter, `RUST_MIN_STACK` explicitly unset in both runs:

| | result |
|---|---|
| without `.cargo/config.toml` | **SIGABRT**, exit 100 |
| with `.cargo/config.toml` | **PASS**, exit 0 |

Then the whole bin target with no env var set:

```
Summary [15.974s] 2312 tests run: 2312 passed, 9 skipped
SIGABRT: 0
```

`cargo clippy -p mur-agent-runtime --lib --locked -- -D warnings` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)