### PR TITLE
feat(cli): federation P2b — /remember /memories /forget in the agent TUI

### DIFF
--- a/mur-agent-runtime/src/tools/remember.rs
+++ b/mur-agent-runtime/src/tools/remember.rs
@@ -12,10 +12,8 @@ use std::path::PathBuf;
 
 use mur_common::skill::lifecycle::NoteKind;
 use mur_common::skill::loader::is_valid_skill_name;
-use mur_common::skill::manifest::{Content, SkillManifest, Visibility};
 use mur_common::skill::stats::SkillStats;
 use mur_common::skill::store::agent_skill_dir;
-use mur_common::skill::types::{Category, Priority};
 
 use super::{ToolError, ToolExecutor};
 use crate::llm::ToolDef;
@@ -129,45 +127,15 @@ impl ToolExecutor for RememberTool {
             )));
         }
 
-        // Mirrors `mur notes create` (notes_cmd::do_create), agent-local:
-        // Category::Note + kind-as-tag, Draft lifecycle via fresh stats.
-        let manifest = SkillManifest {
-            name: name.clone(),
-            version: "1.0.0".into(),
-            publisher: format!("agent:{}", self.agent_name),
-            description: description.clone(),
-            category: Category::Note,
-            hosts: vec![],
-            scope: Default::default(),
-            visibility: Visibility::default(),
-            origin: None,
-            origin_version: None,
-            origin_hash: None,
-            fleet: None,
-            team: None,
-            governance: None,
-            project: None,
-            content: Content {
-                r#abstract: description.clone(),
-                context: None,
-                procedure: None,
-                command: None,
-                note: Some(content),
-            },
-            requires: vec![],
-            tags: match kind {
-                NoteKind::Rule => vec!["rule".into()],
-                NoteKind::Fact => vec![],
-            },
-            triggers: vec![],
-            priority: Priority::Normal,
-            evolution_log: vec![],
-            transfer_chain: vec![],
-            mcp_requirements: vec![],
-            provenance: Default::default(),
-            updated_at: chrono::Utc::now(),
-            requires_programs: vec![],
-        };
+        // Same canonical shape as `mur notes create` / TUI `/remember` —
+        // one builder (mur_common::skill::note), agent-local write target.
+        let manifest = mur_common::skill::note::note_manifest(&mur_common::skill::note::NoteSpec {
+            name: &name,
+            description: &description,
+            body: &content,
+            kind,
+            publisher: &format!("agent:{}", self.agent_name),
+        });
         mur_common::skill::validate(&manifest)
             .map_err(|e| ToolError::InvalidInput(format!("invalid memory note: {e}")))?;
         mur_common::skill::store::write_to_dir(&dir, &manifest)

--- a/mur-common/src/skill/mod.rs
+++ b/mur-common/src/skill/mod.rs
@@ -16,6 +16,7 @@ pub mod local;
 pub mod lockfile;
 pub mod manifest;
 pub mod mcp;
+pub mod note;
 pub mod parser;
 pub mod peers;
 pub mod publisher_trust;

--- a/mur-common/src/skill/note.rs
+++ b/mur-common/src/skill/note.rs
@@ -1,0 +1,89 @@
+//! Shared construction for `Category::Note` skills — ONE manifest literal
+//! instead of three drifting copies (`mur notes create`, the runtime's
+//! `remember` tool, and the TUI `/remember` command all build the same note).
+
+use chrono::Utc;
+
+use crate::skill::lifecycle::NoteKind;
+use crate::skill::manifest::{Content, SkillManifest, Visibility};
+use crate::skill::types::{Category, Priority};
+
+/// Inputs that vary between note authors; everything else is fixed note shape.
+pub struct NoteSpec<'a> {
+    pub name: &'a str,
+    /// One-line summary (also becomes `content.abstract`).
+    pub description: &'a str,
+    /// Markdown body (`content.note`).
+    pub body: &'a str,
+    pub kind: NoteKind,
+    /// Author identity, e.g. `human:local` or `agent:<name>`.
+    pub publisher: &'a str,
+}
+
+/// Build the canonical note manifest. Callers still run
+/// `crate::skill::validate` and choose WHERE to write (global vs agent-local)
+/// — scope is the caller's decision, shape is not.
+pub fn note_manifest(spec: &NoteSpec<'_>) -> SkillManifest {
+    SkillManifest {
+        name: spec.name.to_string(),
+        version: "1.0.0".into(),
+        publisher: spec.publisher.to_string(),
+        description: spec.description.to_string(),
+        category: Category::Note,
+        hosts: vec![],
+        scope: Default::default(),
+        visibility: Visibility::default(),
+        origin: None,
+        origin_version: None,
+        origin_hash: None,
+        fleet: None,
+        team: None,
+        governance: None,
+        project: None,
+        content: Content {
+            r#abstract: spec.description.to_string(),
+            context: None,
+            procedure: None,
+            command: None,
+            note: Some(spec.body.to_string()),
+        },
+        requires: vec![],
+        // Kind lives in the tags: a `rule` tag marks a rule; a plain note is a
+        // fact. `lifecycle::note_kind()` is the single reader.
+        tags: match spec.kind {
+            NoteKind::Rule => vec!["rule".into()],
+            NoteKind::Fact => vec![],
+        },
+        triggers: vec![],
+        priority: Priority::Normal,
+        evolution_log: vec![],
+        transfer_chain: vec![],
+        mcp_requirements: vec![],
+        provenance: Default::default(),
+        updated_at: Utc::now(),
+        requires_programs: vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn note_manifest_validates_and_roundtrips_kind() {
+        for (kind, expect) in [
+            (NoteKind::Rule, Some(NoteKind::Rule)),
+            (NoteKind::Fact, Some(NoteKind::Fact)),
+        ] {
+            let m = note_manifest(&NoteSpec {
+                name: "t-note",
+                description: "d",
+                body: "b",
+                kind,
+                publisher: "human:t",
+            });
+            crate::skill::validate(&m).expect("canonical note must validate");
+            assert_eq!(crate::skill::lifecycle::note_kind(&m), expect);
+        }
+    }
+}

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -165,6 +165,12 @@ pub enum SlashCmd {
     Mcp(Vec<String>),
     /// `/skill [list|add|remove] …` — manage the agent's skills.
     Skill(Vec<String>),
+    /// `/remember [--kind rule|fact] <text>` — save an agent-local memory note.
+    Remember(Vec<String>),
+    /// `/memories` — list every note this agent can see, labeled by scope.
+    Memories,
+    /// `/forget <name|last>` — demote an agent-local note to Destroyed.
+    Forget(Option<String>),
     /// `/skin [dark|light|mur]` — show or switch the active skin (persists to config).
     Skin(Option<String>),
     /// `/panel [tab] [target]` — open/drive the MUR Hub companion window.
@@ -205,6 +211,9 @@ pub fn parse_slash(line: &str) -> Option<SlashCmd> {
         }),
         "mcp" => SlashCmd::Mcp(words.map(str::to_string).collect()),
         "skill" | "skills" => SlashCmd::Skill(words.map(str::to_string).collect()),
+        "remember" => SlashCmd::Remember(words.map(str::to_string).collect()),
+        "memories" | "mem" => SlashCmd::Memories,
+        "forget" => SlashCmd::Forget(words.next().map(str::to_string)),
         "skin" | "theme" => SlashCmd::Skin(words.next().map(str::to_string)),
         "panel" => SlashCmd::Panel(words.map(str::to_string).collect()),
         "open" | "todo" => SlashCmd::Open,
@@ -1357,6 +1366,19 @@ mod tests {
         assert_eq!(parse_slash("/help"), Some(SlashCmd::Help));
         assert_eq!(parse_slash("/new"), Some(SlashCmd::Clear));
         assert_eq!(parse_slash("/card"), Some(SlashCmd::Card));
+        assert_eq!(parse_slash("/memories"), Some(SlashCmd::Memories));
+        assert_eq!(
+            parse_slash("/forget last"),
+            Some(SlashCmd::Forget(Some("last".into())))
+        );
+        assert_eq!(
+            parse_slash("/remember reply in zh-TW"),
+            Some(SlashCmd::Remember(vec![
+                "reply".into(),
+                "in".into(),
+                "zh-TW".into()
+            ]))
+        );
         assert_eq!(parse_slash("/q"), Some(SlashCmd::Quit));
         assert_eq!(
             parse_slash("/bogus"),

--- a/mur-core/src/cmd/agent/cli/memory_cmds.rs
+++ b/mur-core/src/cmd/agent/cli/memory_cmds.rs
@@ -1,0 +1,222 @@
+//! `/remember` `/memories` `/forget` — the TUI surface of the memory
+//! behavioral layer (federation P2b). Pure functions that return display
+//! strings; the slash dispatch just prints them. Writes stay AGENT-LOCAL:
+//! destroying shared knowledge belongs to `mur notes`, not a chat pane.
+
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+
+use mur_common::skill::lifecycle::{NoteKind, note_kind};
+use mur_common::skill::loader::{SkillScope, load_all};
+use mur_common::skill::note::{NoteSpec, note_manifest};
+use mur_common::skill::stats::{LifecycleState, SkillStats};
+use mur_common::skill::store::agent_skill_dir;
+
+/// `/remember [--kind rule|fact] <text…>` — save an agent-local Draft note.
+/// The user typed it themselves, so there is no confirmation dance and the
+/// provenance is human.
+pub fn remember(home: &Path, agent: &str, args: &[String]) -> Result<String> {
+    let mut kind = NoteKind::Fact;
+    let mut words: Vec<&str> = Vec::new();
+    let mut it = args.iter().map(String::as_str);
+    while let Some(w) = it.next() {
+        if w == "--kind" {
+            match it.next() {
+                Some("rule") => kind = NoteKind::Rule,
+                Some("fact") => kind = NoteKind::Fact,
+                other => bail!("--kind expects rule|fact, got {other:?}"),
+            }
+        } else {
+            words.push(w);
+        }
+    }
+    let body = words.join(" ");
+    if body.trim().is_empty() {
+        bail!("usage: /remember [--kind rule|fact] <text>");
+    }
+    // Timestamped name: collision-free enough for a human-driven command.
+    // ponytail: no slug generation — meaningful names come from agents or
+    // `mur notes create`; rename later if it matters.
+    let name = format!("note-{}", chrono::Utc::now().format("%Y%m%d-%H%M%S"));
+    let description: String = body.chars().take(60).collect();
+
+    let dir = agent_skill_dir(home, agent).join(&name);
+    if dir.join("skill.yaml").exists() {
+        bail!("memory '{name}' already exists — try again in a second");
+    }
+    let manifest = note_manifest(&NoteSpec {
+        name: &name,
+        description: &description,
+        body: &body,
+        kind,
+        publisher: "human:local",
+    });
+    mur_common::skill::validate(&manifest).context("invalid note")?;
+    mur_common::skill::store::write_to_dir(&dir, &manifest)
+        .map_err(|e| anyhow::anyhow!("write note: {e}"))?;
+    let stats = SkillStats::new(&name, "1.0.0", "", chrono::Utc::now());
+    std::fs::write(
+        SkillStats::path_agent(home, agent, &name),
+        serde_json::to_string(&stats)?,
+    )?;
+    Ok(format!(
+        "📝 remembered ({}, Draft, agent-local): {description} — undo with /forget {name}",
+        kind_str(kind)
+    ))
+}
+
+/// `/memories` — every note this agent can see, labeled by where it lives
+/// (agent-local / federated cache / shared), with kind and maturity.
+pub fn memories(home: &Path, agent: &str) -> String {
+    let cache_root = home.join("agents").join(agent).join("knowledge_cache");
+    let mut rows: Vec<String> = Vec::new();
+    for s in load_all(home, agent) {
+        let Some(kind) = note_kind(&s.manifest) else {
+            continue;
+        };
+        let (scope_label, stats_path) = match s.scope {
+            SkillScope::Agent => ("agent", SkillStats::path_agent(home, agent, &s.name)),
+            SkillScope::Global if s.dir.starts_with(&cache_root) => {
+                ("federated", SkillStats::path(home, &s.name))
+            }
+            SkillScope::Global => ("shared", SkillStats::path(home, &s.name)),
+        };
+        let state = SkillStats::load(&stats_path)
+            .ok()
+            .flatten()
+            .map(|st| st.lifecycle_state)
+            .unwrap_or(LifecycleState::Draft);
+        if state == LifecycleState::Destroyed {
+            continue; // forgotten — stays invisible here too
+        }
+        rows.push(format!(
+            "  {:<28} {:<5} {:<9} {:<10} {}",
+            s.name,
+            kind_str(kind),
+            scope_label,
+            format!("{state:?}"),
+            s.manifest.description
+        ));
+    }
+    if rows.is_empty() {
+        return "no memories yet — /remember <text>, or agents save them mid-chat".into();
+    }
+    format!(
+        "memories visible to this agent (agent-local · federated · shared):\n{}",
+        rows.join("\n")
+    )
+}
+
+/// `/forget <name|last>` — demote an AGENT-LOCAL note to `Destroyed`, which
+/// removes it from injection everywhere it is read. Shared notes are
+/// deliberately out of reach from a chat pane.
+pub fn forget(home: &Path, agent: &str, target: Option<&str>) -> Result<String> {
+    let target = target.ok_or_else(|| anyhow::anyhow!("usage: /forget <name|last>"))?;
+    let name = if target == "last" {
+        load_all(home, agent)
+            .into_iter()
+            .filter(|s| s.scope == SkillScope::Agent && note_kind(&s.manifest).is_some())
+            .filter(|s| {
+                SkillStats::load(&SkillStats::path_agent(home, agent, &s.name))
+                    .ok()
+                    .flatten()
+                    .is_none_or(|st| st.lifecycle_state != LifecycleState::Destroyed)
+            })
+            .max_by_key(|s| s.manifest.updated_at)
+            .map(|s| s.name)
+            .ok_or_else(|| anyhow::anyhow!("no agent-local memories to forget"))?
+    } else {
+        target.to_string()
+    };
+    let stats_path = SkillStats::path_agent(home, agent, &name);
+    let mut stats = SkillStats::load(&stats_path)?.ok_or_else(|| {
+        anyhow::anyhow!("no agent-local memory named '{name}' (shared notes: use `mur notes`)")
+    })?;
+    stats.lifecycle_state = LifecycleState::Destroyed;
+    stats.lifecycle_changed_at = chrono::Utc::now();
+    std::fs::write(&stats_path, serde_json::to_string(&stats)?)?;
+    Ok(format!("forgot '{name}' — it will no longer be injected"))
+}
+
+fn kind_str(k: NoteKind) -> &'static str {
+    match k {
+        NoteKind::Rule => "rule",
+        NoteKind::Fact => "fact",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remember_memories_forget_cycle() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+
+        let msg = remember(
+            home,
+            "a1",
+            &[
+                "--kind".into(),
+                "rule".into(),
+                "reply".into(),
+                "in".into(),
+                "zh-TW".into(),
+            ],
+        )
+        .unwrap();
+        assert!(msg.contains("rule") && msg.contains("/forget"));
+
+        let listing = memories(home, "a1");
+        assert!(listing.contains("reply in zh-TW"));
+        assert!(listing.contains("agent"));
+
+        let gone = forget(home, "a1", Some("last")).unwrap();
+        assert!(gone.contains("forgot"));
+        assert!(
+            !memories(home, "a1").contains("reply in zh-TW"),
+            "forgotten note must disappear from /memories"
+        );
+    }
+
+    #[test]
+    fn forget_refuses_shared_notes_and_empty_target() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        assert!(forget(home, "a1", None).is_err());
+        // a GLOBAL note exists but no agent-local one: 'last' finds nothing,
+        // and naming it directly reports the agent-local miss.
+        let dir = home.join("skills/shared-note");
+        let m = note_manifest(&NoteSpec {
+            name: "shared-note",
+            description: "d",
+            body: "b",
+            kind: NoteKind::Fact,
+            publisher: "human:t",
+        });
+        mur_common::skill::store::write_to_dir(&dir, &m).unwrap();
+        assert!(forget(home, "a1", Some("last")).is_err());
+        let err = forget(home, "a1", Some("shared-note"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("mur notes"),
+            "must point at the right tool: {err}"
+        );
+    }
+
+    #[test]
+    fn remember_rejects_empty_and_bad_kind() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(remember(tmp.path(), "a1", &[]).is_err());
+        assert!(
+            remember(
+                tmp.path(),
+                "a1",
+                &["--kind".into(), "opinion".into(), "x".into()]
+            )
+            .is_err()
+        );
+    }
+}

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -17,6 +17,7 @@ mod follow;
 mod footer;
 mod manage;
 mod markdown;
+mod memory_cmds;
 mod multiplex;
 mod panel;
 mod paste;
@@ -106,7 +107,7 @@ const SPINNER_MS: u64 = 90;
 /// Max chars of an arg hint shown on a step line in `--plain` mode.
 const PLAIN_STEP_HINT_MAX: usize = 120;
 
-const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /channels N --follow (live-tail another channel; /channels --follow to stop)  /auto [on|off]  /verbose [on|off] (expand tool cards)  /skin [dark|light|mur]  /mcp  /skill  /panel [tab]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
+const HELP: &str = "commands: /help  /clear (new conversation)  /card  /sessions  /channels [N] (list/switch)  /channels N --follow (live-tail another channel; /channels --follow to stop)  /auto [on|off]  /verbose [on|off] (expand tool cards)  /skin [dark|light|mur]  /mcp  /skill  /remember <text> (save a memory)  /memories  /forget <name|last>  /panel [tab]  /exit · !cmd runs a local shell command (output shared with the agent) · keys: Enter send · Shift+Enter newline · Ctrl+V attach screenshot · Ctrl+C cancel/clear · Ctrl+D quit · PageUp/PageDown scroll";
 
 /// Entry point dispatched from `AgentAction::Cli`.
 #[allow(clippy::too_many_arguments)]
@@ -1636,6 +1637,17 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
         SlashCmd::Mcp(args) => run_manage(app, move |agent| manage::run_mcp(&agent, &args)).await,
         SlashCmd::Skill(args) => {
             run_manage(app, move |agent| manage::run_skill(&agent, &args)).await
+        }
+        SlashCmd::Remember(args) => {
+            let msg = memory_cmds::remember(&app.home, &app.agent, &args)
+                .unwrap_or_else(|e| format!("remember failed: {e}"));
+            app.push_system(msg);
+        }
+        SlashCmd::Memories => app.push_system(memory_cmds::memories(&app.home, &app.agent)),
+        SlashCmd::Forget(target) => {
+            let msg = memory_cmds::forget(&app.home, &app.agent, target.as_deref())
+                .unwrap_or_else(|e| format!("forget failed: {e}"));
+            app.push_system(msg);
         }
         SlashCmd::Skin(name_opt) => match name_opt {
             None => {

--- a/mur-core/src/cmd/notes_cmd.rs
+++ b/mur-core/src/cmd/notes_cmd.rs
@@ -5,10 +5,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::{DateTime, Utc};
 use mur_common::skill::lifecycle::NoteKind;
-use mur_common::skill::manifest::{Content, SkillManifest, Visibility};
 use mur_common::skill::stats::{LifecycleState, SkillStats};
 use mur_common::skill::store::{global_skill_dir, read_from_dir, write_to_dir};
-use mur_common::skill::types::{Category, Priority};
+use mur_common::skill::types::Category;
 use mur_common::skill::validate;
 use mur_common::telemetry::METHOD_NOTE_RETRIEVED;
 
@@ -34,45 +33,13 @@ pub fn do_create(
         bail!("note '{name}' already exists at {}", dir.display());
     }
 
-    let manifest = SkillManifest {
-        name: name.to_string(),
-        version: "1.0.0".into(),
-        publisher: DEFAULT_PUBLISHER.into(),
-        description: description.to_string(),
-        category: Category::Note,
-        hosts: vec![],
-        scope: Default::default(),
-        visibility: Visibility::default(),
-        origin: None,
-        origin_version: None,
-        origin_hash: None,
-        fleet: None,
-        team: None,
-        governance: None,
-        project: None,
-        content: Content {
-            r#abstract: description.to_string(),
-            context: None,
-            procedure: None,
-            command: None,
-            note: Some(body.to_string()),
-        },
-        requires: vec![],
-        // Kind lives in the tags (federation P1): a `rule` tag marks a rule;
-        // a plain note is a fact. `note_kind()` is the single reader.
-        tags: match kind {
-            NoteKind::Rule => vec!["rule".into()],
-            NoteKind::Fact => vec![],
-        },
-        triggers: vec![],
-        priority: Priority::Normal,
-        evolution_log: vec![],
-        transfer_chain: vec![],
-        mcp_requirements: vec![],
-        provenance: Default::default(),
-        updated_at: chrono::Utc::now(),
-        requires_programs: vec![],
-    };
+    let manifest = mur_common::skill::note::note_manifest(&mur_common::skill::note::NoteSpec {
+        name,
+        description,
+        body,
+        kind,
+        publisher: DEFAULT_PUBLISHER,
+    });
 
     validate(&manifest).with_context(|| format!("validate note '{name}'"))?;
     let written =


### PR DESCRIPTION
The user-side surface of the memory behavioral layer (spec P2, second half — P2a was the agent side, #856).

## Commands

- **`/remember [--kind rule|fact] <text>`** — saves an agent-local Draft note. The user typed it themselves, so provenance is human and there is no confirmation dance. The reply names the `/forget` undo. Timestamped names — meaningful naming stays with agents and `mur notes create`.
- **`/memories`** — every note this agent can see, labeled by where it lives (**agent** / **federated** / **shared**) with kind + maturity. Forgotten notes stay hidden.
- **`/forget <name|last>`** — demotes an agent-local note to `Destroyed`, which removes it from injection everywhere. **Shared notes are deliberately out of reach from a chat pane** — the error points at `mur notes`, because destroying team-visible knowledge should not be a one-liner in a chat.

## Dedup that came due

The canonical note manifest existed as three drifting copies of a 40-field literal (`mur notes create`, the runtime `remember` tool, and now the TUI). This PR gives it ONE builder — `mur_common::skill::note::note_manifest` — and refactors both existing call sites onto it. Scope (global vs agent-local) stays the caller's decision; shape does not.

## Verification

- Focused: 15/15 — full remember→memories→forget cycle, shared-note refusal, empty/bad-kind rejection, slash-parse variants, plus both refactored call sites' existing suites
- Full gate: **6748/6748**, clippy `-D warnings` clean, fmt clean

Follow-ups (sequenced): P2c central curation (signed proposal → ingest → `mur out`), then P3 commander bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)