### PR TITLE
feat(memory): federation P2c — remembered notes propose themselves for review

### DIFF
--- a/mur-agent-runtime/src/tools/remember.rs
+++ b/mur-agent-runtime/src/tools/remember.rs
@@ -150,10 +150,23 @@ impl ToolExecutor for RememberTool {
         std::fs::write(&stats_path, json)
             .map_err(|e| ToolError::Execution(format!("write stats: {e}")))?;
 
+        // Central-curation leg (P2c): also propose the note for human review —
+        // only an accepted proposal becomes a GLOBAL note. Best-effort: the
+        // agent-local memory above is already durable, so a proposal-write
+        // failure warns instead of failing the remember.
+        let proposal = mur_common::skill::note::MemoryProposal {
+            agent: self.agent_name.clone(),
+            proposed_at: chrono::Utc::now(),
+            manifest,
+        };
+        if let Err(e) = mur_common::skill::note::write_memory_proposal(&self.mur_home, &proposal) {
+            tracing::warn!(error = %e, "memory proposal drop failed (agent-local copy is safe)");
+        }
+
         Ok(format!(
             "remembered '{name}' (kind={kind:?}, state=Draft, agent-local; effective next \
-             turn). Now tell the user in ONE line, in their language, what you saved and \
-             that /forget {name} undoes it."
+             turn; queued for the user's `mur session out` review). Now tell the user in \
+             ONE line, in their language, what you saved and that /forget {name} undoes it."
         ))
     }
 }

--- a/mur-common/src/skill/note.rs
+++ b/mur-common/src/skill/note.rs
@@ -87,3 +87,46 @@ mod tests {
         }
     }
 }
+
+// ── Memory proposals (federation P2c) ────────────────────────────────────
+// The central-curation leg: an agent that remembers something ALSO proposes
+// it for review. The proposal is a file drop under the inbox (the runtime's
+// one granted central-store write surface); `mur session out` reviews it and
+// only an accepted proposal becomes a GLOBAL note — "visibility follows
+// scope, propagation follows maturity" means nothing an agent inferred
+// reaches other agents without either usage-earned maturity or this human
+// gate.
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Proposal drop directory, relative to the MUR home.
+pub const MEMORY_PROPOSAL_DIR: &str = "inbox/memory-proposals";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryProposal {
+    /// Canonical name of the agent that captured the memory.
+    pub agent: String,
+    pub proposed_at: chrono::DateTime<Utc>,
+    /// The full note manifest — same shape the agent wrote locally.
+    pub manifest: SkillManifest,
+}
+
+/// Atomically drop `proposal` into the inbox. Returns the written path.
+/// Deterministic name (`<agent>-<note>`): re-remembering the same note
+/// replaces the pending proposal instead of stacking duplicates.
+pub fn write_memory_proposal(
+    mur_home: &Path,
+    proposal: &MemoryProposal,
+) -> std::io::Result<PathBuf> {
+    let dir = mur_home.join(MEMORY_PROPOSAL_DIR);
+    std::fs::create_dir_all(&dir)?;
+    let fname = format!("{}-{}.yaml", proposal.agent, proposal.manifest.name);
+    let dest = dir.join(&fname);
+    let tmp = dir.join(format!(".{fname}.tmp"));
+    let yaml = serde_yaml_ng::to_string(proposal)
+        .map_err(|e| std::io::Error::other(format!("serialize proposal: {e}")))?;
+    std::fs::write(&tmp, yaml)?;
+    std::fs::rename(&tmp, &dest)?;
+    Ok(dest)
+}

--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -460,6 +460,59 @@ pub(crate) async fn cmd_out(action: Option<&str>, force: bool) -> anyhow::Result
             _ => break,
         }
     }
+
+    review_memory_proposals()?;
+    Ok(())
+}
+
+/// Memory-proposal review lane (federation P2c): what agents remembered and
+/// proposed for team-wide visibility. Accept = the note becomes GLOBAL (all
+/// agents' loaders see it); dismiss = the proposal is consumed while the
+/// capturing agent keeps its local copy.
+fn review_memory_proposals() -> Result<()> {
+    let home = crate::paths::mur_root(None);
+    let pending = crate::harvest::memory_proposal::pending(&home)?;
+    if pending.is_empty() {
+        return Ok(());
+    }
+    eprintln!("\n{} memory proposal(s) from agents:", pending.len());
+    for p in &pending {
+        let kind = mur_common::skill::lifecycle::note_kind(&p.proposal.manifest)
+            .map(|k| format!("{k:?}").to_lowercase())
+            .unwrap_or_default();
+        eprintln!(
+            "\n  [{}] {} ({kind}) — {}",
+            p.proposal.agent, p.proposal.manifest.name, p.proposal.manifest.description
+        );
+        if let Some(body) = &p.proposal.manifest.content.note {
+            for line in body.lines().take(3) {
+                eprintln!("    {line}");
+            }
+        }
+        let items = &[
+            "✓ Accept — make it a shared note (visible to all agents)",
+            "⏭ Skip",
+            "✗ Dismiss — drop the proposal (agent keeps its local copy)",
+        ];
+        let choice = dialoguer::Select::new()
+            .with_prompt(format!("Share `{}`?", p.proposal.manifest.name))
+            .items(items)
+            .default(1)
+            .interact()
+            .unwrap_or(1);
+        match choice {
+            0 => match crate::harvest::memory_proposal::accept(&home, p) {
+                Ok(name) => eprintln!("  ✓ shared as `{name}` — ~/.mur/skills/{name}/skill.yaml"),
+                Err(e) => eprintln!("  ✗ {e}"),
+            },
+            2 => {
+                if let Err(e) = crate::harvest::memory_proposal::dismiss(p) {
+                    eprintln!("  ✗ {e}");
+                }
+            }
+            _ => {}
+        }
+    }
     Ok(())
 }
 

--- a/mur-core/src/harvest/memory_proposal.rs
+++ b/mur-core/src/harvest/memory_proposal.rs
@@ -1,0 +1,147 @@
+//! Review-side of memory proposals (federation P2c): list what agents have
+//! proposed, and turn a human decision into either a GLOBAL note (accept) or
+//! a deleted file (dismiss). Pure functions — the interactive loop in
+//! `cmd/session.rs` just renders them.
+//!
+//! Decisions delete the proposal file rather than keeping a status ledger:
+//! the agent-local note remains the durable source either way, and a
+//! re-remember re-proposes deterministically (same file name).
+
+use anyhow::{Context, Result, bail};
+use std::path::{Path, PathBuf};
+
+use mur_common::skill::note::{MEMORY_PROPOSAL_DIR, MemoryProposal};
+use mur_common::skill::store::global_skill_dir;
+
+/// A pending proposal plus the file it came from.
+pub struct PendingMemoryProposal {
+    pub path: PathBuf,
+    pub proposal: MemoryProposal,
+}
+
+/// All pending proposals, oldest first. Unparseable files are skipped with a
+/// warning — one corrupt drop must not block the review of the rest.
+pub fn pending(mur_home: &Path) -> Result<Vec<PendingMemoryProposal>> {
+    let dir = mur_home.join(MEMORY_PROPOSAL_DIR);
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Ok(out); // no dir yet = nothing proposed
+    };
+    for entry in entries {
+        let path = entry?.path();
+        if path.extension().is_none_or(|e| e != "yaml") {
+            continue;
+        }
+        match std::fs::read_to_string(&path)
+            .map_err(anyhow::Error::from)
+            .and_then(|t| serde_yaml_ng::from_str::<MemoryProposal>(&t).map_err(Into::into))
+        {
+            Ok(proposal) => out.push(PendingMemoryProposal { path, proposal }),
+            Err(e) => {
+                tracing::warn!(file = %path.display(), error = %e, "skipping unparseable memory proposal")
+            }
+        }
+    }
+    out.sort_by_key(|p| p.proposal.proposed_at);
+    Ok(out)
+}
+
+/// Accept: write the note into the GLOBAL skills store (never overwriting an
+/// existing skill) and consume the proposal file. Returns the note name.
+pub fn accept(mur_home: &Path, pending: &PendingMemoryProposal) -> Result<String> {
+    let manifest = &pending.proposal.manifest;
+    // Same gates the synced NewDraftSkill path applies: the name is joined
+    // into the skills dir, so validate before any filesystem contact.
+    if !mur_common::skill::is_valid_skill_name(&manifest.name) {
+        bail!("invalid note name '{}'", manifest.name);
+    }
+    mur_common::skill::validate(manifest).context("proposal manifest invalid")?;
+    let dir = global_skill_dir(mur_home, &manifest.name);
+    if dir.join("skill.yaml").exists() {
+        bail!(
+            "a skill named '{}' already exists — dismissing instead of overwriting",
+            manifest.name
+        );
+    }
+    mur_common::skill::store::write_to_dir(&dir, manifest)
+        .map_err(|e| anyhow::anyhow!("write global note: {e}"))?;
+    let _ = std::fs::remove_file(&pending.path);
+    Ok(manifest.name.clone())
+}
+
+/// Dismiss: consume the proposal file; the agent-local copy stays untouched.
+pub fn dismiss(pending: &PendingMemoryProposal) -> Result<()> {
+    std::fs::remove_file(&pending.path)
+        .with_context(|| format!("remove {}", pending.path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mur_common::skill::lifecycle::NoteKind;
+    use mur_common::skill::note::{NoteSpec, note_manifest, write_memory_proposal};
+
+    fn drop_proposal(home: &Path, agent: &str, name: &str) {
+        let p = MemoryProposal {
+            agent: agent.into(),
+            proposed_at: chrono::Utc::now(),
+            manifest: note_manifest(&NoteSpec {
+                name,
+                description: "reply language",
+                body: "always zh-TW",
+                kind: NoteKind::Rule,
+                publisher: &format!("agent:{agent}"),
+            }),
+        };
+        write_memory_proposal(home, &p).unwrap();
+    }
+
+    #[test]
+    fn propose_accept_lands_a_global_note_and_consumes_the_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        drop_proposal(home, "w1", "reply-zh");
+
+        let list = pending(home).unwrap();
+        assert_eq!(list.len(), 1);
+        let name = accept(home, &list[0]).unwrap();
+        assert_eq!(name, "reply-zh");
+        assert!(home.join("skills/reply-zh/skill.yaml").exists());
+        assert!(pending(home).unwrap().is_empty(), "proposal consumed");
+    }
+
+    #[test]
+    fn accept_refuses_to_overwrite_and_dismiss_consumes() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        // Pre-existing global skill with the same name.
+        let m = note_manifest(&NoteSpec {
+            name: "dup",
+            description: "d",
+            body: "b",
+            kind: NoteKind::Fact,
+            publisher: "human:t",
+        });
+        mur_common::skill::store::write_to_dir(&home.join("skills/dup"), &m).unwrap();
+
+        drop_proposal(home, "w1", "dup");
+        let list = pending(home).unwrap();
+        assert!(accept(home, &list[0]).is_err(), "must not overwrite");
+        dismiss(&list[0]).unwrap();
+        assert!(pending(home).unwrap().is_empty());
+    }
+
+    #[test]
+    fn re_remember_replaces_instead_of_stacking() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        drop_proposal(home, "w1", "same-note");
+        drop_proposal(home, "w1", "same-note");
+        assert_eq!(
+            pending(home).unwrap().len(),
+            1,
+            "deterministic file name dedups"
+        );
+    }
+}

--- a/mur-core/src/harvest/mod.rs
+++ b/mur-core/src/harvest/mod.rs
@@ -7,6 +7,7 @@
 //! plan, not this module.
 
 pub mod gate;
+pub mod memory_proposal;
 pub mod proposal;
 pub mod recurrence;
 pub mod skeleton;


### PR DESCRIPTION
Closes the loop the spec drew for the behavioral layer: **visibility follows scope, propagation follows maturity.** Nothing an agent inferred reaches other agents without either usage-earned maturity (P0's snapshot floor) or this human gate.

## The flow

```
agent remember ──┬─→ agent-local Draft note        (P2a — its own agent, next turn)
                 └─→ inbox/memory-proposals/…      (this PR — one file drop)
                          ↓
              mur session out review lane
                 Accept  → GLOBAL note (all agents' loaders see it; federates at maturity)
                 Skip    → stays pending
                 Dismiss → proposal consumed; the agent keeps its local copy
```

## Design decisions

- **Decisions delete the file** — no status ledger. The agent-local note is the durable source either way, and the deterministic file name (`<agent>-<name>.yaml`) makes a re-remember *replace* its pending proposal instead of stacking duplicates (pinned by test).
- **Best-effort emission**: a proposal-write failure warns and never fails the remember — the local memory is already safe. The drop lands on the runtime's one granted central-store write surface (`~/.mur/inbox`, #858).
- **Accept applies the same gates as the synced `NewDraftSkill` path**: name validation before any filesystem contact (traversal guard), never overwrite an existing skill.
- **Skip is the default choice** — sharing to the whole fleet is an active decision.
- `MemoryProposal` + writer live in `mur_common::skill::note` beside the `note_manifest` builder: one home for note shape, spec'd scope decisions stay with callers.

## Deliberately not here

- **Proposal signing** (P2c-2): the spec's decision is Signal-wide `sig`/`key_version` fields per the v3d precedent — that benefits every signal kind and deserves its own PR rather than a memory-only special case. Today's proposals ride at the same trust level as every existing inbox signal.
- **Near-dup merge-as-evidence**: the spec's open calibration sliver (cosine threshold), unchanged.

## Verification

- Focused: 10/10 — propose→accept→global-note→consumed, overwrite refusal + dismiss, re-remember replacement, plus the remember tool and builder suites
- Full gate: **6754/6754** · clippy `-D warnings` clean · fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)