### PR TITLE
feat(memory): federation P2c-2 — sign signals and memory proposals at the home boundary

### DIFF
--- a/mur-agent-runtime/src/federation/outbox.rs
+++ b/mur-agent-runtime/src/federation/outbox.rs
@@ -105,6 +105,10 @@ impl AgentOutbox {
             scope: Scope::Personal,
             confidence: 1.0,
             schema_version: SIGNAL_SCHEMA_VERSION,
+            // Unsigned at rest in the agent's own outbox; the sleep-cycle
+            // flush signs at the home boundary (federation/sync.rs, P2c-2).
+            sig: None,
+            key_version: 0,
         };
 
         let ts = now.format("%Y-%m-%dT%H-%M-%S");

--- a/mur-agent-runtime/src/federation/sync.rs
+++ b/mur-agent-runtime/src/federation/sync.rs
@@ -36,13 +36,28 @@ pub fn spawn_agent_sleep_cycle(
 }
 
 fn run_agent_cycle(agent_name: &str, identity: &mur_common::identity::AgentIdentity) -> Result<()> {
-    flush_outbox(agent_name)?;
+    flush_outbox(agent_name, identity)?;
     refresh_snapshot(agent_name, identity);
     Ok(())
 }
 
-/// Copy pending outbox signals to `~/.mur/inbox/` for the daemon to pick up.
-fn flush_outbox(agent_name: &str) -> Result<()> {
+/// Parse an outbox signal, sign it with the agent's identity (P2c-2), and
+/// return the signed YAML to drop. Signing happens HERE — the trust boundary
+/// where the signal leaves the agent's home — so every outbox writer is
+/// covered without threading the key into each of them.
+fn sign_signal_yaml(
+    yaml: &str,
+    identity: &mur_common::identity::AgentIdentity,
+) -> Result<(Signal, String)> {
+    let mut signal: Signal = serde_yaml_ng::from_str(yaml)?;
+    signal.sign(identity);
+    let signed = serde_yaml_ng::to_string(&signal)?;
+    Ok((signal, signed))
+}
+
+/// Copy pending outbox signals to `~/.mur/inbox/` for the daemon to pick up,
+/// signing each at the boundary so ingest can verify who said it.
+fn flush_outbox(agent_name: &str, identity: &mur_common::identity::AgentIdentity) -> Result<()> {
     let outbox = AgentOutbox::open(agent_name)?;
     let pending = outbox.list_pending()?;
     if pending.is_empty() {
@@ -55,7 +70,7 @@ fn flush_outbox(agent_name: &str) -> Result<()> {
     let mut flushed = Vec::new();
     for path in &pending {
         let yaml = std::fs::read_to_string(path)?;
-        let signal: Signal = serde_yaml_ng::from_str(&yaml)?;
+        let (signal, signed_yaml) = sign_signal_yaml(&yaml, identity)?;
         let fname = format!(
             "{}-{}.yaml",
             signal.emitted_at.format("%Y-%m-%dT%H-%M-%S"),
@@ -63,7 +78,7 @@ fn flush_outbox(agent_name: &str) -> Result<()> {
         );
         let dest = inbox_dir.join(&fname);
         let tmp = inbox_dir.join(format!(".{fname}.tmp"));
-        std::fs::write(&tmp, &yaml)?;
+        std::fs::write(&tmp, &signed_yaml)?;
         std::fs::rename(&tmp, &dest)?;
         flushed.push(path.clone());
     }
@@ -164,5 +179,36 @@ mod tests {
             serde_yaml_ng::from_str(&std::fs::read_to_string(p).unwrap()).unwrap();
         assert!(req.verify(&id.verifying_key_bytes()));
         assert_eq!(req.agent, "w1");
+    }
+
+    #[test]
+    fn flushed_signal_yaml_is_signed_and_verifies() {
+        let id = mur_common::identity::AgentIdentity::generate();
+        let unsigned = mur_common::Signal {
+            id: uuid::Uuid::new_v4(),
+            emitted_at: chrono::Utc::now(),
+            actor: mur_common::Actor {
+                source: mur_common::ActorSource::MurCli,
+                native_id: "w1".into(),
+                display_name: None,
+                resolved_user_id: None,
+            },
+            target: mur_common::SignalTarget::Skill {
+                name: "s".into(),
+                scope: mur_common::Scope::Personal,
+            },
+            kind: mur_common::SignalKind::SkillExecutionSuccess,
+            scope: mur_common::Scope::Personal,
+            confidence: 1.0,
+            schema_version: mur_common::SIGNAL_SCHEMA_VERSION,
+            sig: None,
+            key_version: 0,
+        };
+        let yaml = serde_yaml_ng::to_string(&unsigned).unwrap();
+        let (signal, signed_yaml) = sign_signal_yaml(&yaml, &id).unwrap();
+        assert!(signal.verify(&id.verifying_key_bytes()));
+        // The DROPPED yaml (what ingest reads) carries the verifying signature.
+        let reparsed: mur_common::Signal = serde_yaml_ng::from_str(&signed_yaml).unwrap();
+        assert!(reparsed.verify(&id.verifying_key_bytes()));
     }
 }

--- a/mur-agent-runtime/src/supervisor.rs
+++ b/mur-agent-runtime/src/supervisor.rs
@@ -401,6 +401,7 @@ pub async fn entrypoint() -> anyhow::Result<()> {
         max_iterations,
         max_tokens,
         Some(writer.sender()),
+        identity.clone(),
     )
     .await?;
     let dispatcher = Arc::new(build_dispatcher(

--- a/mur-agent-runtime/src/supervisor_runner.rs
+++ b/mur-agent-runtime/src/supervisor_runner.rs
@@ -213,6 +213,10 @@ pub async fn build_provider_runner(
     // (`FallbackLlmClient`) path below records `Event::Routing`; the
     // single-model path has nothing to route between, so it's left alone.
     telemetry: Option<tokio::sync::mpsc::Sender<crate::telemetry_writer::Event>>,
+    // Supervisor's pre-sandbox-loaded keypair (#858: never lazy-load identity
+    // after the sandbox applies) — signs memory proposals dropped by the
+    // built-in remember tool (P2c-2).
+    identity: Arc<mur_common::identity::AgentIdentity>,
 ) -> anyhow::Result<(
     Arc<TaskRunner>,
     Option<Arc<dyn LlmClient>>,
@@ -347,6 +351,7 @@ pub async fn build_provider_runner(
                 Arc::new(RememberTool {
                     mur_home: mur_home.clone(),
                     agent_name: profile.inner.name.clone(),
+                    identity: identity.clone(),
                 }),
             );
         }

--- a/mur-agent-runtime/src/tools/remember.rs
+++ b/mur-agent-runtime/src/tools/remember.rs
@@ -51,6 +51,10 @@ pub struct RememberTool {
     pub mur_home: PathBuf,
     /// Canonical (on-disk) agent name — the note lands in this agent's home.
     pub agent_name: String,
+    /// The supervisor's pre-sandbox-loaded keypair (#858: never lazy-load
+    /// identity after the sandbox applies). Signs the memory proposal at the
+    /// drop so review can verify who proposed it (P2c-2).
+    pub identity: std::sync::Arc<mur_common::identity::AgentIdentity>,
 }
 
 #[async_trait::async_trait]
@@ -154,11 +158,14 @@ impl ToolExecutor for RememberTool {
         // only an accepted proposal becomes a GLOBAL note. Best-effort: the
         // agent-local memory above is already durable, so a proposal-write
         // failure warns instead of failing the remember.
-        let proposal = mur_common::skill::note::MemoryProposal {
+        let mut proposal = mur_common::skill::note::MemoryProposal {
             agent: self.agent_name.clone(),
             proposed_at: chrono::Utc::now(),
             manifest,
+            sig: None,
+            key_version: 0,
         };
+        proposal.sign(&self.identity);
         if let Err(e) = mur_common::skill::note::write_memory_proposal(&self.mur_home, &proposal) {
             tracing::warn!(error = %e, "memory proposal drop failed (agent-local copy is safe)");
         }
@@ -179,7 +186,26 @@ mod tests {
         RememberTool {
             mur_home: home.to_path_buf(),
             agent_name: "w1".into(),
+            identity: std::sync::Arc::new(mur_common::identity::AgentIdentity::generate()),
         }
+    }
+
+    #[tokio::test]
+    async fn dropped_proposal_is_signed_by_the_agent_identity() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        let t = tool(home);
+        t.execute(input("reply-in-zh-tw", "rule")).await.unwrap();
+
+        let p = home.join("inbox/memory-proposals/w1-reply-in-zh-tw.yaml");
+        let proposal: mur_common::skill::note::MemoryProposal =
+            serde_yaml_ng::from_str(&std::fs::read_to_string(&p).unwrap()).unwrap();
+        assert!(proposal.verify(&t.identity.verifying_key_bytes()));
+
+        // Tamper detection end-to-end: edit the file body, signature dies.
+        let mut edited = proposal.clone();
+        edited.manifest.content.note = Some("always en-US".into());
+        assert!(!edited.verify(&t.identity.verifying_key_bytes()));
     }
 
     fn input(name: &str, kind: &str) -> serde_json::Value {

--- a/mur-common/src/identity.rs
+++ b/mur-common/src/identity.rs
@@ -97,6 +97,16 @@ impl AgentIdentity {
         Ok(Self { signing })
     }
 
+    /// Load ONLY the public key from `<dir>/identity.pub` — for verifiers
+    /// (inbox ingest, proposal review) that must not require the private key.
+    pub fn load_pubkey(dir: &Path) -> Result<[u8; 32], IdentityError> {
+        let path = dir.join("identity.pub");
+        if !path.exists() {
+            return Err(IdentityError::NotFound);
+        }
+        decode_pubkey(fs::read_to_string(&path)?.trim())
+    }
+
     pub fn signing_key(&self) -> &SigningKey {
         &self.signing
     }

--- a/mur-common/src/signal.rs
+++ b/mur-common/src/signal.rs
@@ -52,6 +52,15 @@ pub struct Signal {
     /// keep signals within the same major forward-compatible.
     #[serde(default = "current_schema_version")]
     pub schema_version: u32,
+    /// Multibase (Base58Btc) Ed25519 signature over [`sign_input`] — federation
+    /// P2c-2, following the v3d `ChannelEvent` precedent. `None` = legacy
+    /// unsigned signal (tolerated on ingest unless `MUR_SIGNAL_REQUIRE_SIG`).
+    /// Additive `#[serde(default)]` field — allowed within frozen schema v1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sig: Option<String>,
+    /// Key-rotation version; 0 = initial identity key.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub key_version: u32,
 }
 
 fn default_confidence() -> f64 {
@@ -59,6 +68,62 @@ fn default_confidence() -> f64 {
 }
 fn current_schema_version() -> u32 {
     SIGNAL_SCHEMA_VERSION
+}
+pub(crate) fn is_zero(v: &u32) -> bool {
+    *v == 0
+}
+
+/// Canonicalization version — bump if the sign-input shape changes so an old
+/// signature is never silently checked against a new canonicalization.
+pub const SIGNAL_SIG_INPUT_VERSION: u32 = 1;
+
+/// Canonical signed bytes for a [`Signal`]: every semantic field, `sig`
+/// excluded. `serde_json` sorts object keys (no preserve_order), so this is
+/// deterministic for a given input. The `domain` tag prevents a signature
+/// minted here from verifying in any other MUR signing context.
+fn sign_input(s: &Signal) -> Vec<u8> {
+    let canon = serde_json::json!({
+        "domain": "mur-signal",
+        "v": SIGNAL_SIG_INPUT_VERSION,
+        "id": s.id,
+        "emitted_at": s.emitted_at,
+        "actor": s.actor,
+        "target": s.target,
+        "kind": s.kind,
+        "scope": s.scope,
+        "confidence": s.confidence,
+        "schema_version": s.schema_version,
+        "key_version": s.key_version,
+    });
+    serde_json::to_vec(&canon).unwrap_or_default()
+}
+
+/// Parse `MUR_SIGNAL_REQUIRE_SIG`: only explicit truthy values enable
+/// signature enforcement (`=0` / `=false`, or unset, must NOT turn it on) —
+/// default-off is migration safety AND the commander wire (frozen v1, signals
+/// arrive bearer-token-authed but unsigned). One parser for every reader,
+/// mirroring `MUR_CHANNEL_REQUIRE_SIG`.
+pub fn require_sig_from_env() -> bool {
+    std::env::var("MUR_SIGNAL_REQUIRE_SIG")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes"))
+        .unwrap_or(false)
+}
+
+impl Signal {
+    /// Sign this signal in place with the emitting agent's identity key.
+    /// The signature covers every field except `sig` itself.
+    pub fn sign(&mut self, identity: &crate::identity::AgentIdentity) {
+        self.sig = Some(identity.sign_multibase(&sign_input(self)));
+    }
+
+    /// Fail-closed signature check against `pubkey`. An unsigned signal
+    /// never verifies — callers decide whether unsigned is tolerated.
+    pub fn verify(&self, pubkey: &[u8; 32]) -> bool {
+        match &self.sig {
+            Some(sig) => crate::identity::verify_bytes(pubkey, &sign_input(self), sig),
+            None => false,
+        }
+    }
 }
 
 /// HTTP batch wrapper for `POST /v1/signals/batch`.
@@ -149,6 +214,8 @@ mod tests {
             scope: Scope::Personal,
             confidence: 0.9,
             schema_version: SIGNAL_SCHEMA_VERSION,
+            sig: None,
+            key_version: 0,
         }
     }
 
@@ -310,6 +377,8 @@ scope: { kind: personal }
             scope: Scope::Personal,
             confidence: 0.75,
             schema_version: SIGNAL_SCHEMA_VERSION,
+            sig: None,
+            key_version: 0,
         };
         let y = serde_yaml::to_string(&sig).unwrap();
         assert!(y.contains("kind: new_draft_pattern"));
@@ -325,6 +394,62 @@ scope: { kind: personal }
     #[test]
     fn schema_version_constant() {
         assert_eq!(SIGNAL_SCHEMA_VERSION, 1);
+    }
+
+    #[test]
+    fn sign_verify_roundtrip_and_yaml_preserves_sig() {
+        let id = crate::identity::AgentIdentity::generate();
+        let mut s = sample_signal();
+        s.sign(&id);
+        assert!(s.verify(&id.verifying_key_bytes()));
+
+        let yaml = serde_yaml::to_string(&s).unwrap();
+        let back: Signal = serde_yaml::from_str(&yaml).unwrap();
+        assert!(back.verify(&id.verifying_key_bytes()));
+    }
+
+    #[test]
+    fn tampered_field_fails_verification() {
+        let id = crate::identity::AgentIdentity::generate();
+        let mut s = sample_signal();
+        s.sign(&id);
+        s.scope = Scope::Team {
+            team_id: "ops".into(),
+        }; // scope-escalation attempt after signing
+        assert!(!s.verify(&id.verifying_key_bytes()));
+    }
+
+    #[test]
+    fn wrong_key_and_unsigned_fail_verification() {
+        let id = crate::identity::AgentIdentity::generate();
+        let other = crate::identity::AgentIdentity::generate();
+        let mut s = sample_signal();
+        assert!(
+            !s.verify(&id.verifying_key_bytes()),
+            "unsigned never verifies"
+        );
+        s.sign(&id);
+        assert!(!s.verify(&other.verifying_key_bytes()));
+    }
+
+    #[test]
+    fn legacy_unsigned_yaml_deserializes_with_defaults() {
+        // Pre-P2c-2 signal yaml — no sig/key_version fields.
+        let y = r#"
+id: 00000000-0000-0000-0000-000000000009
+emitted_at: 2026-04-18T10:00:00Z
+actor: { source: commander_daemon, native_id: x }
+target: { kind: pattern, name: foo, scope: { kind: personal } }
+kind: { type: execution_success }
+scope: { kind: personal }
+"#;
+        let s: Signal = serde_yaml::from_str(y).unwrap();
+        assert!(s.sig.is_none());
+        assert_eq!(s.key_version, 0);
+        // And an unsigned signal serializes WITHOUT the new keys (wire-stable).
+        let out = serde_yaml::to_string(&s).unwrap();
+        assert!(!out.contains("sig:"));
+        assert!(!out.contains("key_version:"));
     }
 
     #[test]

--- a/mur-common/src/skill/note.rs
+++ b/mur-common/src/skill/note.rs
@@ -110,6 +110,47 @@ pub struct MemoryProposal {
     pub proposed_at: chrono::DateTime<Utc>,
     /// The full note manifest — same shape the agent wrote locally.
     pub manifest: SkillManifest,
+    /// Multibase (Base58Btc) Ed25519 signature over [`proposal_sign_input`]
+    /// (P2c-2; v3d precedent — sign-input excludes `sig`). `None` = legacy
+    /// unsigned proposal, tolerated on review unless `MUR_SIGNAL_REQUIRE_SIG`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sig: Option<String>,
+    /// Key-rotation version; 0 = initial identity key.
+    #[serde(default, skip_serializing_if = "crate::signal::is_zero")]
+    pub key_version: u32,
+}
+
+/// Canonicalization version — bump if the sign-input shape changes.
+pub const PROPOSAL_SIG_INPUT_VERSION: u32 = 1;
+
+/// Canonical signed bytes: `sig` excluded; `serde_json` sorts object keys so
+/// the encoding is deterministic. The `domain` tag prevents cross-context
+/// signature reuse.
+fn proposal_sign_input(p: &MemoryProposal) -> Vec<u8> {
+    let canon = serde_json::json!({
+        "domain": "mur-memory-proposal",
+        "v": PROPOSAL_SIG_INPUT_VERSION,
+        "agent": p.agent,
+        "proposed_at": p.proposed_at,
+        "manifest": p.manifest,
+        "key_version": p.key_version,
+    });
+    serde_json::to_vec(&canon).unwrap_or_default()
+}
+
+impl MemoryProposal {
+    /// Sign this proposal in place with the proposing agent's identity key.
+    pub fn sign(&mut self, identity: &crate::identity::AgentIdentity) {
+        self.sig = Some(identity.sign_multibase(&proposal_sign_input(self)));
+    }
+
+    /// Fail-closed signature check against `pubkey`; unsigned never verifies.
+    pub fn verify(&self, pubkey: &[u8; 32]) -> bool {
+        match &self.sig {
+            Some(sig) => crate::identity::verify_bytes(pubkey, &proposal_sign_input(self), sig),
+            None => false,
+        }
+    }
 }
 
 /// Atomically drop `proposal` into the inbox. Returns the written path.
@@ -129,4 +170,69 @@ pub fn write_memory_proposal(
     std::fs::write(&tmp, yaml)?;
     std::fs::rename(&tmp, &dest)?;
     Ok(dest)
+}
+
+#[cfg(test)]
+mod proposal_sig_tests {
+    use super::*;
+    use crate::identity::AgentIdentity;
+    use crate::skill::lifecycle::NoteKind;
+
+    fn proposal(agent: &str) -> MemoryProposal {
+        MemoryProposal {
+            agent: agent.into(),
+            proposed_at: Utc::now(),
+            manifest: note_manifest(&NoteSpec {
+                name: "reply-zh",
+                description: "reply language",
+                body: "always zh-TW",
+                kind: NoteKind::Rule,
+                publisher: &format!("agent:{agent}"),
+            }),
+            sig: None,
+            key_version: 0,
+        }
+    }
+
+    #[test]
+    fn sign_verify_roundtrip_survives_yaml() {
+        let id = AgentIdentity::generate();
+        let mut p = proposal("w1");
+        assert!(
+            !p.verify(&id.verifying_key_bytes()),
+            "unsigned never verifies"
+        );
+        p.sign(&id);
+        assert!(p.verify(&id.verifying_key_bytes()));
+
+        let yaml = serde_yaml_ng::to_string(&p).unwrap();
+        let back: MemoryProposal = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert!(back.verify(&id.verifying_key_bytes()));
+    }
+
+    #[test]
+    fn tampered_manifest_or_agent_fails_verification() {
+        let id = AgentIdentity::generate();
+        let mut p = proposal("w1");
+        p.sign(&id);
+
+        let mut swapped = p.clone();
+        swapped.agent = "w2".into(); // impersonation
+        assert!(!swapped.verify(&id.verifying_key_bytes()));
+
+        let mut edited = p.clone();
+        edited.manifest.content.note = Some("always en-US".into()); // content swap
+        assert!(!edited.verify(&id.verifying_key_bytes()));
+    }
+
+    #[test]
+    fn legacy_unsigned_yaml_deserializes_with_defaults() {
+        let p = proposal("w1");
+        // Serialize WITHOUT sig (legacy P2c shape) — new fields absent on wire.
+        let yaml = serde_yaml_ng::to_string(&p).unwrap();
+        assert!(!yaml.contains("sig:"));
+        let back: MemoryProposal = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert!(back.sig.is_none());
+        assert_eq!(back.key_version, 0);
+    }
 }

--- a/mur-core/src/cmd/agent/reconnect.rs
+++ b/mur-core/src/cmd/agent/reconnect.rs
@@ -27,12 +27,22 @@ pub fn cmd_agent_reconnect(name: &str) -> Result<()> {
     let inbox = crate::sync::inbox::Inbox::default_location()?;
     let store = crate::store::yaml::YamlStore::default_store()?;
 
+    // Best-effort P2c-2 signing at the flush boundary, mirroring the runtime
+    // sleep-cycle: the CLI runs as the user, who owns the agent's key. A
+    // missing key just flushes unsigned (legacy-tolerated on ingest).
+    let identity = outbox_dir
+        .parent()
+        .and_then(|agent_dir| mur_common::identity::AgentIdentity::load(agent_dir).ok());
+
     let mut received: Vec<std::path::PathBuf> = Vec::new();
     for path in &pending {
         let yaml = std::fs::read_to_string(path)
             .with_context(|| format!("read outbox file {}", path.display()))?;
-        let signal: Signal = serde_yaml::from_str(&yaml)
+        let mut signal: Signal = serde_yaml::from_str(&yaml)
             .with_context(|| format!("parse signal from {}", path.display()))?;
+        if let Some(id) = &identity {
+            signal.sign(id);
+        }
         inbox.receive(&signal)?;
         received.push(path.clone());
     }
@@ -107,6 +117,8 @@ mod tests {
             scope: Scope::Personal,
             confidence: 1.0,
             schema_version: SIGNAL_SCHEMA_VERSION,
+            sig: None,
+            key_version: 0,
         };
         let ts = now.format("%Y-%m-%dT%H-%M-%S");
         let fname = format!("{ts}-{id}.yaml");

--- a/mur-core/src/cmd/inject_cmd.rs
+++ b/mur-core/src/cmd/inject_cmd.rs
@@ -109,6 +109,8 @@ mod tests {
             scope: Scope::Personal,
             confidence: 0.9,
             schema_version: SIGNAL_SCHEMA_VERSION,
+            sig: None,
+            key_version: 0,
         };
         let inbox = Inbox::new(&inbox_dir).unwrap();
         inbox.receive(&signal).unwrap();

--- a/mur-core/src/cmd/session.rs
+++ b/mur-core/src/cmd/session.rs
@@ -480,8 +480,14 @@ fn review_memory_proposals() -> Result<()> {
         let kind = mur_common::skill::lifecycle::note_kind(&p.proposal.manifest)
             .map(|k| format!("{k:?}").to_lowercase())
             .unwrap_or_default();
+        // The human is the gate — show what the signature actually proves.
+        let sig_note = match &p.sig_status {
+            crate::harvest::memory_proposal::ProposalSigStatus::Verified => "✓ signed",
+            crate::harvest::memory_proposal::ProposalSigStatus::Unsigned => "unsigned",
+            crate::harvest::memory_proposal::ProposalSigStatus::Invalid(_) => "✗ INVALID SIGNATURE",
+        };
         eprintln!(
-            "\n  [{}] {} ({kind}) — {}",
+            "\n  [{}] {} ({kind}, {sig_note}) — {}",
             p.proposal.agent, p.proposal.manifest.name, p.proposal.manifest.description
         );
         if let Some(body) = &p.proposal.manifest.content.note {

--- a/mur-core/src/harvest/memory_proposal.rs
+++ b/mur-core/src/harvest/memory_proposal.rs
@@ -13,10 +13,47 @@ use std::path::{Path, PathBuf};
 use mur_common::skill::note::{MEMORY_PROPOSAL_DIR, MemoryProposal};
 use mur_common::skill::store::global_skill_dir;
 
+/// Signature status of a pending proposal, computed at listing time (P2c-2).
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProposalSigStatus {
+    /// Signature present and verified against the agent's on-disk pubkey.
+    Verified,
+    /// Legacy pre-P2c-2 drop with no signature. Acceptable unless
+    /// `MUR_SIGNAL_REQUIRE_SIG` enforces signing.
+    Unsigned,
+    /// Signature present but wrong, or the claimed agent has no verifiable
+    /// identity — never acceptable (fail-closed).
+    Invalid(String),
+}
+
 /// A pending proposal plus the file it came from.
 pub struct PendingMemoryProposal {
     pub path: PathBuf,
     pub proposal: MemoryProposal,
+    pub sig_status: ProposalSigStatus,
+}
+
+/// The signature proves *who proposed it*: verify against the CLAIMED agent's
+/// pubkey at `agents/<agent>/identity.pub`. The agent name is joined into a
+/// path, so it gets the same charset guard every other file-drop surface has.
+fn sig_status(mur_home: &Path, proposal: &MemoryProposal) -> ProposalSigStatus {
+    if proposal.sig.is_none() {
+        return ProposalSigStatus::Unsigned;
+    }
+    let agent = &proposal.agent;
+    let name_ok = !agent.is_empty()
+        && agent
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+    if !name_ok {
+        return ProposalSigStatus::Invalid(format!("'{agent}' is not a valid agent name"));
+    }
+    let dir = mur_home.join("agents").join(agent);
+    match mur_common::identity::AgentIdentity::load_pubkey(&dir) {
+        Ok(pubkey) if proposal.verify(&pubkey) => ProposalSigStatus::Verified,
+        Ok(_) => ProposalSigStatus::Invalid(format!("signature does not verify for '{agent}'")),
+        Err(e) => ProposalSigStatus::Invalid(format!("no verifiable identity for '{agent}': {e}")),
+    }
 }
 
 /// All pending proposals, oldest first. Unparseable files are skipped with a
@@ -36,7 +73,14 @@ pub fn pending(mur_home: &Path) -> Result<Vec<PendingMemoryProposal>> {
             .map_err(anyhow::Error::from)
             .and_then(|t| serde_yaml_ng::from_str::<MemoryProposal>(&t).map_err(Into::into))
         {
-            Ok(proposal) => out.push(PendingMemoryProposal { path, proposal }),
+            Ok(proposal) => {
+                let sig_status = sig_status(mur_home, &proposal);
+                out.push(PendingMemoryProposal {
+                    path,
+                    proposal,
+                    sig_status,
+                })
+            }
             Err(e) => {
                 tracing::warn!(file = %path.display(), error = %e, "skipping unparseable memory proposal")
             }
@@ -50,6 +94,20 @@ pub fn pending(mur_home: &Path) -> Result<Vec<PendingMemoryProposal>> {
 /// existing skill) and consume the proposal file. Returns the note name.
 pub fn accept(mur_home: &Path, pending: &PendingMemoryProposal) -> Result<String> {
     let manifest = &pending.proposal.manifest;
+    // Signature gate first (P2c-2): a bad signature is never acceptable;
+    // unsigned is legacy-tolerated unless enforcement is on.
+    match &pending.sig_status {
+        ProposalSigStatus::Invalid(reason) => {
+            bail!("refusing '{}': {reason}", manifest.name)
+        }
+        ProposalSigStatus::Unsigned if mur_common::signal::require_sig_from_env() => {
+            bail!(
+                "refusing unsigned proposal '{}' (MUR_SIGNAL_REQUIRE_SIG)",
+                manifest.name
+            )
+        }
+        _ => {}
+    }
     // Same gates the synced NewDraftSkill path applies: the name is joined
     // into the skills dir, so validate before any filesystem contact.
     if !mur_common::skill::is_valid_skill_name(&manifest.name) {
@@ -93,6 +151,8 @@ mod tests {
                 kind: NoteKind::Rule,
                 publisher: &format!("agent:{agent}"),
             }),
+            sig: None,
+            key_version: 0,
         };
         write_memory_proposal(home, &p).unwrap();
     }
@@ -143,5 +203,75 @@ mod tests {
             1,
             "deterministic file name dedups"
         );
+    }
+
+    // ── P2c-2 signature gate ─────────────────────────────────────────────
+
+    use mur_common::identity::AgentIdentity;
+
+    /// Drop a SIGNED proposal from a registered agent; returns its identity.
+    fn drop_signed(home: &Path, agent: &str, name: &str, tamper: bool) -> AgentIdentity {
+        let dir = home.join("agents").join(agent);
+        std::fs::create_dir_all(&dir).unwrap();
+        let id = AgentIdentity::generate();
+        id.save(&dir).unwrap();
+
+        let mut p = MemoryProposal {
+            agent: agent.into(),
+            proposed_at: chrono::Utc::now(),
+            manifest: note_manifest(&NoteSpec {
+                name,
+                description: "reply language",
+                body: "always zh-TW",
+                kind: NoteKind::Rule,
+                publisher: &format!("agent:{agent}"),
+            }),
+            sig: None,
+            key_version: 0,
+        };
+        p.sign(&id);
+        if tamper {
+            p.manifest.content.note = Some("always en-US".into()); // post-sign edit
+        }
+        write_memory_proposal(home, &p).unwrap();
+        id
+    }
+
+    #[test]
+    fn signed_proposal_lists_verified_and_accepts() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        drop_signed(home, "w1", "reply-zh", false);
+
+        let list = pending(home).unwrap();
+        assert_eq!(list[0].sig_status, ProposalSigStatus::Verified);
+        assert_eq!(accept(home, &list[0]).unwrap(), "reply-zh");
+    }
+
+    #[test]
+    fn tampered_proposal_lists_invalid_and_accept_refuses() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        drop_signed(home, "w1", "reply-zh", true);
+
+        let list = pending(home).unwrap();
+        assert!(matches!(list[0].sig_status, ProposalSigStatus::Invalid(_)));
+        let err = accept(home, &list[0]).unwrap_err().to_string();
+        assert!(err.contains("refusing"), "got: {err}");
+        assert!(
+            !home.join("skills/reply-zh/skill.yaml").exists(),
+            "tampered proposal must not land"
+        );
+    }
+
+    #[test]
+    fn unsigned_legacy_proposal_still_accepts_by_default() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path();
+        drop_proposal(home, "w1", "legacy-note");
+
+        let list = pending(home).unwrap();
+        assert_eq!(list[0].sig_status, ProposalSigStatus::Unsigned);
+        assert_eq!(accept(home, &list[0]).unwrap(), "legacy-note");
     }
 }

--- a/mur-core/src/server/signals.rs
+++ b/mur-core/src/server/signals.rs
@@ -132,6 +132,8 @@ mod tests {
             scope: Scope::Personal,
             confidence: 0.9,
             schema_version: SIGNAL_SCHEMA_VERSION,
+            sig: None,
+            key_version: 0,
         }
     }
 

--- a/mur-core/src/sync/client.rs
+++ b/mur-core/src/sync/client.rs
@@ -289,6 +289,8 @@ mod tests {
             scope: Scope::Personal,
             confidence: 1.0,
             schema_version: SIGNAL_SCHEMA_VERSION,
+            sig: None,
+            key_version: 0,
         }
     }
 

--- a/mur-core/src/sync/inbox.rs
+++ b/mur-core/src/sync/inbox.rs
@@ -73,6 +73,45 @@ impl Inbox {
         Ok(path)
     }
 
+    /// P2c-2 ingest gate — the signature proves *who said it*, the scope
+    /// check proves *they may say it there*. Unsigned signals pass unless
+    /// `require` (legacy drops + the commander wire are unsigned); a PRESENT
+    /// signature is always checked fail-closed: it must verify against the
+    /// claimed actor's on-disk pubkey (`agents/<actor>/identity.pub`) and the
+    /// self-reported scope must be one an agent identity may claim (Personal —
+    /// agents have no team/community authority).
+    fn check_signal_sig(&self, signal: &Signal, require: bool) -> Result<(), String> {
+        if signal.sig.is_none() {
+            return if require {
+                Err("unsigned signal rejected (MUR_SIGNAL_REQUIRE_SIG)".into())
+            } else {
+                Ok(())
+            };
+        }
+        let actor = &signal.actor.native_id;
+        // The actor name is joined into a path below — allow exactly the
+        // charset agent dirs use, or the join is a traversal primitive (same
+        // guard the daemon applies to snapshot requests).
+        if !valid_agent_name(actor) {
+            return Err(format!(
+                "signed signal actor '{actor}' is not a valid agent name"
+            ));
+        }
+        let dir = self.mur_home.join("agents").join(actor);
+        let pubkey = mur_common::identity::AgentIdentity::load_pubkey(&dir)
+            .map_err(|e| format!("no verifiable identity for actor '{actor}': {e}"))?;
+        if !signal.verify(&pubkey) {
+            return Err(format!("signature verification failed for actor '{actor}'"));
+        }
+        if signal.scope != mur_common::Scope::Personal {
+            return Err(format!(
+                "agent '{actor}' may not emit {:?}-scoped signals",
+                signal.scope
+            ));
+        }
+        Ok(())
+    }
+
     /// Apply every YAML file in the inbox (non-hidden) to the given store.
     ///
     /// Successfully-applied or intentionally-skipped files are removed from
@@ -82,6 +121,7 @@ impl Inbox {
     /// the same signal UUID is re-emitted (e.g. after a retry in FlushService).
     pub fn apply_all(&self, store: &YamlStore) -> Result<ApplyReport> {
         let mut report = ApplyReport::default();
+        let require_sig = mur_common::signal::require_sig_from_env();
         let mut seen = self.load_seen_ids();
         let mut newly_seen: Vec<Uuid> = Vec::new();
 
@@ -113,6 +153,16 @@ impl Inbox {
             // Skip duplicate signal IDs (idempotency guard against FlushService retries)
             if seen.contains(&signal.id) {
                 report.skipped += 1;
+                let _ = std::fs::remove_file(&p);
+                continue;
+            }
+
+            // Signature gate (P2c-2). Rejected files are REMOVED (a bad
+            // signature is permanent — retrying can't fix it) but NOT marked
+            // seen, so a correctly-signed re-emission of the same id may
+            // still apply later.
+            if let Err(reason) = self.check_signal_sig(&signal, require_sig) {
+                report.errors.push(format!("{}: {reason}", p.display()));
                 let _ = std::fs::remove_file(&p);
                 continue;
             }
@@ -259,6 +309,7 @@ impl Inbox {
         use mur_common::{Signal, SignalTarget};
 
         let mut report = ApplyReport::default();
+        let require_sig = mur_common::signal::require_sig_from_env();
         let mut seen = self.load_seen_ids();
         let mut newly_seen: Vec<uuid::Uuid> = Vec::new();
 
@@ -282,6 +333,12 @@ impl Inbox {
             let target_is_skill = matches!(signal.target, SignalTarget::Skill { .. });
             if !target_is_skill {
                 continue; // handled by apply_all (pattern branch)
+            }
+            // Signature gate (P2c-2) — same rules as apply_all.
+            if let Err(reason) = self.check_signal_sig(&signal, require_sig) {
+                report.errors.push(format!("{}: {reason}", p.display()));
+                let _ = std::fs::remove_file(&p);
+                continue;
             }
             match self.apply_skill_one(&signal) {
                 Ok(true) => {
@@ -361,6 +418,15 @@ impl Inbox {
     }
 }
 
+/// Exactly the charset agent directory names use (see the daemon's snapshot-
+/// request guard) — anything else would make `agents/<name>` a traversal.
+fn valid_agent_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
 fn is_inbox_yaml(p: &Path) -> bool {
     if !p.is_file() {
         return false;
@@ -417,6 +483,8 @@ mod tests {
             scope: Scope::Personal,
             confidence: 1.0,
             schema_version: SIGNAL_SCHEMA_VERSION,
+            sig: None,
+            key_version: 0,
         }
     }
 
@@ -561,6 +629,8 @@ mod tests {
             scope: Scope::Personal,
             confidence: 1.0,
             schema_version: SIGNAL_SCHEMA_VERSION,
+            sig: None,
+            key_version: 0,
         };
         inbox.receive(&sig).unwrap();
         let report = inbox.apply_all(&store).unwrap();
@@ -595,6 +665,8 @@ mod tests {
             scope: Scope::Personal,
             confidence: 1.0,
             schema_version: SIGNAL_SCHEMA_VERSION,
+            sig: None,
+            key_version: 0,
         };
         inbox.receive(&sig).unwrap();
         let report = inbox.apply_all(&store).unwrap();
@@ -718,6 +790,8 @@ mod tests {
             kind: SignalKind::SkillExecutionSuccess,
             scope: Scope::Personal,
             confidence: 1.0,
+            sig: None,
+            key_version: 0,
         };
         inbox.receive(&signal).unwrap();
         let report = inbox.apply_skill_signals().unwrap();
@@ -730,5 +804,116 @@ mod tests {
             mur_common::skill::event_log::SkillEvent::Execution { ref outcome, .. }
             if outcome == "success"
         ));
+    }
+
+    // ── P2c-2 signature gate ─────────────────────────────────────────────
+
+    use mur_common::identity::AgentIdentity;
+
+    /// Register agent `name` under `<home>/agents/` with a real keypair.
+    fn agent_fixture(home: &Path, name: &str) -> AgentIdentity {
+        let dir = home.join("agents").join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        let id = AgentIdentity::generate();
+        id.save(&dir).unwrap();
+        id
+    }
+
+    #[test]
+    fn signed_signal_verifies_and_applies() {
+        let tmp = tempdir().unwrap();
+        let (store, inbox) = setup(tmp.path());
+        store.save(&make_pattern("p1")).unwrap();
+        let id = agent_fixture(tmp.path(), "w1");
+
+        let mut sig = signal("p1", SignalKind::ExecutionSuccess, "w1");
+        sig.sign(&id);
+        inbox.receive(&sig).unwrap();
+        let report = inbox.apply_all(&store).unwrap();
+        assert_eq!(report.applied, 1, "errors: {:?}", report.errors);
+        assert!(report.errors.is_empty());
+    }
+
+    #[test]
+    fn tampered_signed_signal_is_rejected_and_removed() {
+        let tmp = tempdir().unwrap();
+        let (store, inbox) = setup(tmp.path());
+        store.save(&make_pattern("p1")).unwrap();
+        let id = agent_fixture(tmp.path(), "w1");
+
+        let mut sig = signal("p1", SignalKind::ExecutionSuccess, "w1");
+        sig.sign(&id);
+        sig.confidence = 0.1; // tamper AFTER signing
+        inbox.receive(&sig).unwrap();
+
+        let report = inbox.apply_all(&store).unwrap();
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.errors.len(), 1);
+        assert!(report.errors[0].contains("verification failed"));
+        // File removed (permanent failure — no poison retry), pattern untouched.
+        assert_eq!(
+            std::fs::read_dir(tmp.path().join("inbox"))
+                .unwrap()
+                .filter(|e| is_inbox_yaml(&e.as_ref().unwrap().path()))
+                .count(),
+            0
+        );
+        assert_eq!(store.get("p1").unwrap().evidence.success_signals, 0);
+    }
+
+    #[test]
+    fn signed_signal_with_non_personal_scope_is_rejected() {
+        let tmp = tempdir().unwrap();
+        let (store, inbox) = setup(tmp.path());
+        store.save(&make_pattern("p1")).unwrap();
+        let id = agent_fixture(tmp.path(), "w1");
+
+        let mut sig = signal("p1", SignalKind::ExecutionSuccess, "w1");
+        sig.scope = Scope::Team {
+            team_id: "ops".into(),
+        };
+        sig.sign(&id); // signature VALID — the scope claim itself is the violation
+        inbox.receive(&sig).unwrap();
+
+        let report = inbox.apply_all(&store).unwrap();
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.errors.len(), 1);
+        assert!(report.errors[0].contains("may not emit"));
+    }
+
+    #[test]
+    fn signed_signal_without_registered_identity_is_rejected() {
+        let tmp = tempdir().unwrap();
+        let (store, inbox) = setup(tmp.path());
+        store.save(&make_pattern("p1")).unwrap();
+        // NO agent_fixture: sign with a key the central store has never seen.
+        let rogue = AgentIdentity::generate();
+
+        let mut sig = signal("p1", SignalKind::ExecutionSuccess, "ghost");
+        sig.sign(&rogue);
+        inbox.receive(&sig).unwrap();
+
+        let report = inbox.apply_all(&store).unwrap();
+        assert_eq!(report.applied, 0);
+        assert_eq!(report.errors.len(), 1);
+        assert!(report.errors[0].contains("no verifiable identity"));
+    }
+
+    #[test]
+    fn require_mode_rejects_unsigned_and_traversal_actor_names() {
+        let tmp = tempdir().unwrap();
+        let (_store, inbox) = setup(tmp.path());
+
+        // Unsigned tolerated by default, rejected under require.
+        let unsigned = signal("p1", SignalKind::ExecutionSuccess, "w1");
+        assert!(inbox.check_signal_sig(&unsigned, false).is_ok());
+        assert!(inbox.check_signal_sig(&unsigned, true).is_err());
+
+        // A signed signal claiming a path-traversal actor never reaches the join.
+        let id = AgentIdentity::generate();
+        let mut evil = signal("p1", SignalKind::ExecutionSuccess, "../w1");
+        evil.sign(&id);
+        let err = inbox.check_signal_sig(&evil, false).unwrap_err();
+        assert!(err.contains("not a valid agent name"));
     }
 }

--- a/mur-core/src/sync/outbox.rs
+++ b/mur-core/src/sync/outbox.rs
@@ -95,6 +95,8 @@ mod tests {
             scope: Scope::Personal,
             confidence: 1.0,
             schema_version: SIGNAL_SCHEMA_VERSION,
+            sig: None,
+            key_version: 0,
         }
     }
 


### PR DESCRIPTION
> **Stacked on #862 (P2c).** The first commit here IS #862; this PR's own change is the second commit. Once #862 merges I'll rebase onto main and the duplicate drops out — until then the files view shows both. Review commit `75ae252b` only.

Closes the "Deliberately not here" item #862 named: **proposal signing (P2c-2)** — and does it Signal-wide, per the spec's trust-model decision (v3d `ChannelEvent` precedent): `sig`/`key_version` as a **field extension, not an outer envelope**, so existing inbox readers keep working and ingest verifies once.

## What signs, what verifies

```
runtime outbox ──(sleep-cycle flush SIGNS at the home boundary)──→ ~/.mur/inbox/*.yaml
remember tool ──(SIGNS with the supervisor's pre-sandbox Arc)──→ inbox/memory-proposals/
mur agent reconnect ──(best-effort SIGN on the CLI flush path)──→ inbox
                                     ↓
              ingest (Inbox::apply_all / apply_skill_signals) VERIFIES:
                sig present → must verify vs agents/<actor>/identity.pub (fail-closed)
                            → scope claim must be Personal (agents have no team authority)
                sig absent  → tolerated (legacy + commander wire) unless MUR_SIGNAL_REQUIRE_SIG=1
              review lane (mur session out) labels ✓ signed / unsigned / ✗ INVALID SIGNATURE;
              accept always refuses invalid signatures
```

*The signature proves **who said it**; the scope check proves **they may say it there**.*

## Design decisions

- **Sign at the boundary, not at creation** — the sleep-cycle flush signs every outbox signal as it leaves the agent home, covering all outbox writers without threading the key into each. Outbox files stay unsigned at rest.
- **Domain-tagged canonical sign-input** (`mur-signal` / `mur-memory-proposal`, versioned) — a signature minted in one MUR signing context can never verify in another.
- **Rejected ≠ retried**: a bad signature is permanent, so the file is removed (no poison retries) but its id is NOT marked seen — a correctly-signed re-emission may still apply.
- **Unsigned stays tolerated by default** — the commander wire (frozen v1, bearer-token-authed) and pre-P2c-2 drops are unsigned; `MUR_SIGNAL_REQUIRE_SIG=1` turns enforcement on (same parse rule as `MUR_CHANNEL_REQUIRE_SIG`).
- **`AgentIdentity::load_pubkey`** — verifiers read `identity.pub` only, never the private key.
- **Confused deputy covered**: a signal claiming another agent's `native_id` fails verification against that agent's pubkey (pinned by test); actor names get the same charset-before-path-join guard as snapshot requests.

## Verification

- Focused: mur-common 32/32 · runtime 25/25 · mur-core 50/50 (roundtrip, tamper, impersonation, scope-escalation, traversal-name, require-mode, legacy-tolerance)
- Full gate: **7057/7057** · clippy `-D warnings` clean (CI flags) · fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1y65jgyETWRnFgTN4Sqyd