### PR TITLE
chore(lint): make --all-targets clippy clean, and gate CI on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,12 @@ jobs:
       # `--no-deps` skips clippy on the ~800 dependency crates (linting them
       # serves no purpose since we can't fix them upstream from here). Saves
       # ~50-70s on a 125s job. Real lint coverage on our own code is unchanged.
-      - run: cargo clippy --all --no-deps --locked -- -D warnings
+      #
+      # `--all-targets` includes tests, benches and examples. Without it, test
+      # code is never linted and rots: the sweep that first added this flag had
+      # ~40 accumulated violations to clear, two of which were real defects
+      # (an error-loop `flatten()` and an undefined-truncate file open).
+      - run: cargo clippy --all --all-targets --no-deps --locked -- -D warnings
 
   fmt:
     name: Format

--- a/mur-agent-runtime/src/llm/fallback/tests.rs
+++ b/mur-agent-runtime/src/llm/fallback/tests.rs
@@ -161,8 +161,10 @@ fn candidates_pin_overrides_everything() {
         factory_for(Default::default()),
         retry0(),
     );
-    let mut req = LlmRequest::default();
-    req.pin_model_ref = Some("frontier".into());
+    let req = LlmRequest {
+        pin_model_ref: Some("frontier".into()),
+        ..Default::default()
+    };
     assert_eq!(fb.candidates_for(&req), vec!["frontier".to_string()]);
 }
 
@@ -170,13 +172,15 @@ fn candidates_pin_overrides_everything() {
 fn candidates_smart_background_prepends_cheap() {
     use mur_common::agent::AgentProfile;
     use mur_common::config::{ModelSwitchConfig, SmartConfig};
-    let mut cfg = ModelSwitchConfig::default();
-    cfg.default = Some("primary".into());
-    cfg.fallback_chain = vec!["primary".into(), "mid".into()];
-    cfg.smart = SmartConfig {
-        enabled: true,
-        cheap: Some("cheap".into()),
-        max_escalations: 1,
+    let cfg = ModelSwitchConfig {
+        default: Some("primary".into()),
+        fallback_chain: vec!["primary".into(), "mid".into()],
+        smart: SmartConfig {
+            enabled: true,
+            cheap: Some("cheap".into()),
+            max_escalations: 1,
+        },
+        ..Default::default()
     };
     let fb = FallbackLlmClient::new_routed(
         AgentProfile::default_for_tests(),
@@ -185,8 +189,10 @@ fn candidates_smart_background_prepends_cheap() {
         retry0(),
     );
     // Background + smart → cheap first, then phase-1 candidates, deduped.
-    let mut bg = LlmRequest::default();
-    bg.intent = RequestIntent::Background(BackgroundKind::Scheduled);
+    let bg = LlmRequest {
+        intent: RequestIntent::Background(BackgroundKind::Scheduled),
+        ..Default::default()
+    };
     assert_eq!(
         fb.candidates_for(&bg),
         vec!["cheap".to_string(), "primary".into(), "mid".into()]
@@ -203,13 +209,15 @@ fn candidates_smart_background_prepends_cheap() {
 async fn routed_generate_picks_frontier_for_large_request() {
     use mur_common::agent::AgentProfile;
     use mur_common::config::{ModelSwitchConfig, RoutingConfig};
-    let mut cfg = ModelSwitchConfig::default();
-    cfg.routing = RoutingConfig {
-        enabled: true,
-        cheap: Some("cheap".into()),
-        frontier: Some("frontier".into()),
-        threshold_input_tokens: Some(5),
-        smart: None,
+    let cfg = ModelSwitchConfig {
+        routing: RoutingConfig {
+            enabled: true,
+            cheap: Some("cheap".into()),
+            frontier: Some("frontier".into()),
+            threshold_input_tokens: Some(5),
+            smart: None,
+        },
+        ..Default::default()
     };
     let mut scripts = std::collections::HashMap::new();
     scripts.insert("frontier".to_string(), vec![Ok(())]);
@@ -258,12 +266,14 @@ async fn cascade_escalates_structural_fail_under_background_smart() {
     );
     scripts.insert("primary".to_string(), vec![Ok(())]);
 
-    let mut cfg = ModelSwitchConfig::default();
-    cfg.default = Some("primary".into());
-    cfg.smart = SmartConfig {
-        enabled: true,
-        cheap: Some("cheap".into()),
-        max_escalations: 1,
+    let cfg = ModelSwitchConfig {
+        default: Some("primary".into()),
+        smart: SmartConfig {
+            enabled: true,
+            cheap: Some("cheap".into()),
+            max_escalations: 1,
+        },
+        ..Default::default()
     };
     let fb = FallbackLlmClient::new_routed(
         AgentProfile::default_for_tests(),
@@ -272,8 +282,10 @@ async fn cascade_escalates_structural_fail_under_background_smart() {
         retry0(),
     );
 
-    let mut bg = LlmRequest::default();
-    bg.intent = RequestIntent::Background(BackgroundKind::Scheduled);
+    let bg = LlmRequest {
+        intent: RequestIntent::Background(BackgroundKind::Scheduled),
+        ..Default::default()
+    };
     assert_eq!(fb.generate(bg).await.unwrap().text, "primary");
 }
 
@@ -308,12 +320,14 @@ async fn cascade_respects_max_escalations() {
         vec![Err(LlmError::InvalidResponse("still empty".into()))],
     );
 
-    let mut cfg = ModelSwitchConfig::default();
-    cfg.default = Some("primary".into());
-    cfg.smart = SmartConfig {
-        enabled: true,
-        cheap: Some("cheap".into()),
-        max_escalations: 1,
+    let cfg = ModelSwitchConfig {
+        default: Some("primary".into()),
+        smart: SmartConfig {
+            enabled: true,
+            cheap: Some("cheap".into()),
+            max_escalations: 1,
+        },
+        ..Default::default()
     };
     let fb = FallbackLlmClient::new_routed(
         AgentProfile::default_for_tests(),
@@ -322,8 +336,10 @@ async fn cascade_respects_max_escalations() {
         retry0(),
     );
 
-    let mut bg = LlmRequest::default();
-    bg.intent = RequestIntent::Background(BackgroundKind::Scheduled);
+    let bg = LlmRequest {
+        intent: RequestIntent::Background(BackgroundKind::Scheduled),
+        ..Default::default()
+    };
     let err = fb.generate(bg).await.unwrap_err();
     assert!(matches!(err, LlmError::InvalidResponse(_)));
 }
@@ -354,12 +370,14 @@ async fn routed_generate_emits_routing_event_on_escalation() {
     );
     scripts.insert("primary".to_string(), vec![Ok(())]);
 
-    let mut cfg = ModelSwitchConfig::default();
-    cfg.default = Some("primary".into());
-    cfg.smart = SmartConfig {
-        enabled: true,
-        cheap: Some("cheap".into()),
-        max_escalations: 1,
+    let cfg = ModelSwitchConfig {
+        default: Some("primary".into()),
+        smart: SmartConfig {
+            enabled: true,
+            cheap: Some("cheap".into()),
+            max_escalations: 1,
+        },
+        ..Default::default()
     };
     let (tx, mut rx) = tokio::sync::mpsc::channel(4);
     let fb = FallbackLlmClient::new_routed(
@@ -370,12 +388,14 @@ async fn routed_generate_emits_routing_event_on_escalation() {
     )
     .with_telemetry(tx, "coach");
 
-    let mut bg = LlmRequest::default();
-    bg.intent = RequestIntent::Background(BackgroundKind::Scheduled);
-    bg.messages = vec![RichMessage::Text {
-        role: "user".into(),
-        content: "do the thing".into(),
-    }];
+    let bg = LlmRequest {
+        intent: RequestIntent::Background(BackgroundKind::Scheduled),
+        messages: vec![RichMessage::Text {
+            role: "user".into(),
+            content: "do the thing".into(),
+        }],
+        ..Default::default()
+    };
     let resp = fb.generate(bg).await.unwrap();
     assert_eq!(resp.text, "primary");
 

--- a/mur-agent-runtime/src/sandbox/macos.rs
+++ b/mur-agent-runtime/src/sandbox/macos.rs
@@ -615,9 +615,11 @@ mod tests {
         // A worker whose egress is ONLY via loopback proxy: deny all general TCP outbound
         // and rely on loopback-only access. The airtight guarantee assumes no general
         // `(remote tcp "*:PORT")` allow exists (that would be a direct-egress escape hatch).
-        let mut policy = SandboxPolicy::default();
-        policy.net_allow_ports = Some(Vec::new()); // deny all general TCP outbound
-        policy.net_allow_loopback_ports = vec![58999];
+        let policy = SandboxPolicy {
+            net_allow_ports: Some(Vec::new()), // deny all general TCP outbound
+            net_allow_loopback_ports: vec![58999],
+            ..Default::default()
+        };
         let sbpl = build_sbpl_profile(&policy);
 
         // When all general TCP is denied, the deny network-outbound is present.
@@ -631,9 +633,11 @@ mod tests {
 
     #[test]
     fn proxy_only_sbpl_allows_loopback_and_dns_but_no_wildcard() {
-        let mut policy = SandboxPolicy::default();
-        policy.net_allow_ports = Some(Vec::new()); // deny general TCP
-        policy.net_allow_loopback_ports = vec![8088, 54321]; // cc-proxy + egress proxy
+        let policy = SandboxPolicy {
+            net_allow_ports: Some(Vec::new()),           // deny general TCP
+            net_allow_loopback_ports: vec![8088, 54321], // cc-proxy + egress proxy
+            ..Default::default()
+        };
         let sbpl = build_sbpl_profile(&policy);
 
         assert!(sbpl.contains("(deny network-outbound)"));

--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -1030,9 +1030,11 @@ mod tests {
 
     #[test]
     fn proxy_only_port_assembly_routes_llm_and_egress_to_loopback() {
-        let mut policy = SandboxPolicy::default();
-        policy.net_allow_ports = Some(Vec::new()); // ProxyOnly: deny general TCP
-        policy.net_loopback_allowed = true; // …but loopback carve-outs permitted
+        let mut policy = SandboxPolicy {
+            net_allow_ports: Some(Vec::new()), // ProxyOnly: deny general TCP
+            net_loopback_allowed: true,        // …but loopback carve-outs permitted
+            ..Default::default()
+        };
         // LLM port (cc-proxy) must land in LOOPBACK, not general ports.
         policy.allow_extra_ports(&[8088]);
         // Egress proxy port must be accepted even though general list is empty.
@@ -1057,9 +1059,11 @@ mod tests {
         // Off is ALSO net_allow_ports = Some([]), but net_loopback_allowed = false
         // (the default) — neither helper may re-open loopback. This is the guard the
         // flag exists for.
-        let mut policy = SandboxPolicy::default();
-        policy.net_allow_ports = Some(Vec::new());
-        // net_loopback_allowed left false
+        let mut policy = SandboxPolicy {
+            net_allow_ports: Some(Vec::new()),
+            // net_loopback_allowed left false
+            ..Default::default()
+        };
         policy.allow_extra_ports(&[8088]);
         policy.allow_loopback_ports(&[54321]);
         assert!(
@@ -1072,8 +1076,10 @@ mod tests {
     fn restricted_port_assembly_unchanged() {
         // Non-empty general list = generic Restricted: LLM port still goes to
         // net_allow_ports (unchanged behavior).
-        let mut policy = SandboxPolicy::default();
-        policy.net_allow_ports = Some(vec![80, 443]);
+        let mut policy = SandboxPolicy {
+            net_allow_ports: Some(vec![80, 443]),
+            ..Default::default()
+        };
         policy.allow_extra_ports(&[8088]);
         assert!(policy.net_allow_ports.as_ref().unwrap().contains(&8088));
         assert!(!policy.net_allow_loopback_ports.contains(&8088));
@@ -1504,24 +1510,30 @@ mod tests {
     fn connect_tcp_ports_proxy_only_is_loopback_only() {
         // ProxyOnly: empty general list + loopback ports → only the loopback ports
         // get ConnectTcp rules (general egress e.g. 443 is default-denied).
-        let mut policy = SandboxPolicy::default();
-        policy.net_allow_ports = Some(Vec::new());
-        policy.net_allow_loopback_ports = vec![8088, 54321];
+        let policy = SandboxPolicy {
+            net_allow_ports: Some(Vec::new()),
+            net_allow_loopback_ports: vec![8088, 54321],
+            ..Default::default()
+        };
         assert_eq!(connect_tcp_ports(&policy), vec![8088u16, 54321]);
     }
 
     #[test]
     fn connect_tcp_ports_restricted_is_general_plus_loopback() {
-        let mut policy = SandboxPolicy::default();
-        policy.net_allow_ports = Some(vec![80, 443]);
-        policy.net_allow_loopback_ports = vec![54321];
+        let policy = SandboxPolicy {
+            net_allow_ports: Some(vec![80, 443]),
+            net_allow_loopback_ports: vec![54321],
+            ..Default::default()
+        };
         assert_eq!(connect_tcp_ports(&policy), vec![80u16, 443, 54321]);
     }
 
     #[test]
     fn connect_tcp_ports_off_and_unrestricted_are_empty() {
-        let mut off = SandboxPolicy::default();
-        off.net_allow_ports = Some(Vec::new()); // Off: empty general + empty loopback
+        let off = SandboxPolicy {
+            net_allow_ports: Some(Vec::new()), // Off: empty general + empty loopback
+            ..Default::default()
+        };
         assert!(connect_tcp_ports(&off).is_empty());
         let unr = SandboxPolicy::default(); // Unrestricted: net_allow_ports = None
         assert!(connect_tcp_ports(&unr).is_empty());

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -3773,9 +3773,11 @@ mod tests {
         // Must retry at least once for the backoff to matter, and stay small
         // enough that a still-limited account fails a turn in a bounded time
         // (2s + 4s + 8s = 14s at the current base) rather than hanging.
-        assert!(MAX_RATE_LIMIT_RETRIES >= 1);
-        assert!(MAX_RATE_LIMIT_RETRIES <= 5);
-        assert!(RATE_LIMIT_BACKOFF_BASE >= std::time::Duration::from_millis(1));
+        // Const items, so editing a constant out of range fails the BUILD
+        // rather than only this test.
+        const _: () = assert!(MAX_RATE_LIMIT_RETRIES >= 1);
+        const _: () = assert!(MAX_RATE_LIMIT_RETRIES <= 5);
+        const _: () = assert!(RATE_LIMIT_BACKOFF_BASE.as_millis() >= 1);
         let max_delay = rate_limit_backoff_delay(MAX_RATE_LIMIT_RETRIES);
         assert!(max_delay <= std::time::Duration::from_secs(60));
     }

--- a/mur-agent-runtime/src/tools/edit_file.rs
+++ b/mur-agent-runtime/src/tools/edit_file.rs
@@ -114,7 +114,6 @@ mod tests {
                 read: vec![],
                 write: vec![root.to_string()],
                 deny: vec![],
-                ..Default::default()
             },
         )
     }

--- a/mur-agent-runtime/src/tools/read_file.rs
+++ b/mur-agent-runtime/src/tools/read_file.rs
@@ -135,7 +135,6 @@ mod tests {
             read: read.iter().map(|s| s.to_string()).collect(),
             write: write.iter().map(|s| s.to_string()).collect(),
             deny: deny.iter().map(|s| s.to_string()).collect(),
-            ..Default::default()
         }
     }
 

--- a/mur-agent-runtime/src/tools/write_file.rs
+++ b/mur-agent-runtime/src/tools/write_file.rs
@@ -85,7 +85,6 @@ mod tests {
             read: vec![],
             write: write.iter().map(|s| s.to_string()).collect(),
             deny: deny.iter().map(|s| s.to_string()).collect(),
-            ..Default::default()
         }
     }
 

--- a/mur-common/src/config.rs
+++ b/mur-common/src/config.rs
@@ -1604,8 +1604,10 @@ embedding:
         assert_eq!(e.api_key_ref, None);
 
         // Set → survives YAML round-trip and to_backend_config.
-        let mut l2 = LlmConfig::default();
-        l2.api_key_ref = Some("keychain:mur/anthropic".into());
+        let l2 = LlmConfig {
+            api_key_ref: Some("keychain:mur/anthropic".into()),
+            ..Default::default()
+        };
         let y = serde_yaml_ng::to_string(&l2).unwrap();
         let l3: LlmConfig = serde_yaml_ng::from_str(&y).unwrap();
         assert_eq!(l3.api_key_ref.as_deref(), Some("keychain:mur/anthropic"));

--- a/mur-common/src/deps/registry.rs
+++ b/mur-common/src/deps/registry.rs
@@ -91,7 +91,7 @@ mod tests {
         assert!(
             r.install_to
                 .as_ref()
-                .map_or(false, |p| p.starts_with("aura/"))
+                .is_some_and(|p| p.starts_with("aura/"))
         );
         assert!(is_curated("lightpanda"));
         assert!(!is_curated("totally-unknown-key"));

--- a/mur-core/src/cmd/conversations_cmd/backends.rs
+++ b/mur-core/src/cmd/conversations_cmd/backends.rs
@@ -354,13 +354,15 @@ mod tests {
     /// `openai` provider at the omlx endpoint, not "no provider"/"unknown".
     #[test]
     fn stage_backend_rows_reports_pinned_vs_follows_smart_with_omlx_provider_alias() {
-        let mut cfg = Config::default();
-        cfg.llm = LlmConfig {
-            provider: "omlx".to_string(),
-            model: "Qwen3.5-4B-MLX-4bit".to_string(),
-            api_key_env: None,
-            api_key_ref: None,
-            openai_url: Some("http://127.0.0.1:8000/v1".to_string()),
+        let mut cfg = Config {
+            llm: LlmConfig {
+                provider: "omlx".to_string(),
+                model: "Qwen3.5-4B-MLX-4bit".to_string(),
+                api_key_env: None,
+                api_key_ref: None,
+                openai_url: Some("http://127.0.0.1:8000/v1".to_string()),
+            },
+            ..Default::default()
         };
         cfg.conversations.ask.backend = Some(BackendConfig {
             provider: "openai".to_string(),

--- a/mur-core/src/cmd/fleet/loop_run.rs
+++ b/mur-core/src/cmd/fleet/loop_run.rs
@@ -973,7 +973,9 @@ mod tests {
             },
         );
         assert_eq!(dearest_output_rate(&reg), None);
-        assert!(DEFAULT_PRICE_PER_1K > 0.025, "default must top real models");
+        // Const item: editing the default below a real model's rate fails the
+        // BUILD, not just this test.
+        const _: () = assert!(DEFAULT_PRICE_PER_1K > 0.025);
     }
 
     #[test]

--- a/mur-core/src/cmd/media/scene.rs
+++ b/mur-core/src/cmd/media/scene.rs
@@ -57,33 +57,6 @@ pub fn parse_completion(resp: &Value) -> Option<String> {
         .map(|s| s.to_string())
 }
 
-#[cfg(test)]
-mod request_tests {
-    use super::*;
-
-    #[test]
-    fn request_has_text_and_image_parts() {
-        let body = build_request("Qwen3.5-2B-MLX-4bit", "hi", "data:image/png;base64,AAA");
-        let content = &body["messages"][0]["content"];
-        assert_eq!(content[0]["type"], "text");
-        assert_eq!(content[1]["type"], "image_url");
-        assert_eq!(content[1]["image_url"]["url"], "data:image/png;base64,AAA");
-    }
-
-    #[test]
-    fn data_url_prefixed() {
-        assert!(png_data_url(b"\x89PNG").starts_with("data:image/png;base64,"));
-    }
-
-    #[test]
-    fn parse_extracts_content() {
-        let resp = serde_json::json!({
-            "choices": [{ "message": { "content": "這是一隻貓" } }]
-        });
-        assert_eq!(parse_completion(&resp).as_deref(), Some("這是一隻貓"));
-    }
-}
-
 // ── Orchestrator ──
 
 use mur_common::config::DEFAULT_BUNDLED_MODEL_ID;
@@ -165,4 +138,31 @@ pub async fn explain(prompt: Option<&str>) -> Result<String> {
         .context("parse VLM response")?;
 
     parse_completion(&resp).context("VLM returned no content")
+}
+
+#[cfg(test)]
+mod request_tests {
+    use super::*;
+
+    #[test]
+    fn request_has_text_and_image_parts() {
+        let body = build_request("Qwen3.5-2B-MLX-4bit", "hi", "data:image/png;base64,AAA");
+        let content = &body["messages"][0]["content"];
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[1]["type"], "image_url");
+        assert_eq!(content[1]["image_url"]["url"], "data:image/png;base64,AAA");
+    }
+
+    #[test]
+    fn data_url_prefixed() {
+        assert!(png_data_url(b"\x89PNG").starts_with("data:image/png;base64,"));
+    }
+
+    #[test]
+    fn parse_extracts_content() {
+        let resp = serde_json::json!({
+            "choices": [{ "message": { "content": "這是一隻貓" } }]
+        });
+        assert_eq!(parse_completion(&resp).as_deref(), Some("這是一隻貓"));
+    }
 }

--- a/mur-core/src/cmd/media/vlc.rs
+++ b/mur-core/src/cmd/media/vlc.rs
@@ -48,28 +48,6 @@ pub fn command_url(port: u16, cmd: &str, extra: &[(&str, &str)]) -> String {
     url
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn detect_respects_env_override() {
-        // Point at a path that does not exist → None.
-        unsafe { std::env::set_var("MUR_VLC_PATH", "/no/such/vlc") };
-        assert_eq!(detect_vlc(), None);
-        unsafe { std::env::remove_var("MUR_VLC_PATH") };
-    }
-
-    #[test]
-    fn command_url_encodes_extra() {
-        let u = command_url(8080, "in_play", &[("input", "https://x/y?a=b")]);
-        assert!(u.starts_with("http://127.0.0.1:8080/requests/status.xml?command=in_play&input="));
-        assert!(u.contains("https%3A%2F%2Fx%2Fy%3Fa%3Db"));
-    }
-    // VlcStatus / parse_status_xml tests live in mur-common::media (where the
-    // parser now lives).
-}
-
 // ── Runtime management ──
 
 use super::{gen_password, load_runtime, pick_free_port, save_runtime};
@@ -240,4 +218,26 @@ pub(super) async fn ensure_for_snapshot(client: &reqwest::Client) -> Result<VlcR
 pub(super) async fn snapshot_command(rt: &VlcRuntime, client: &reqwest::Client) -> Result<()> {
     let _ = send_command(rt, client, "snapshot", &[]).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_respects_env_override() {
+        // Point at a path that does not exist → None.
+        unsafe { std::env::set_var("MUR_VLC_PATH", "/no/such/vlc") };
+        assert_eq!(detect_vlc(), None);
+        unsafe { std::env::remove_var("MUR_VLC_PATH") };
+    }
+
+    #[test]
+    fn command_url_encodes_extra() {
+        let u = command_url(8080, "in_play", &[("input", "https://x/y?a=b")]);
+        assert!(u.starts_with("http://127.0.0.1:8080/requests/status.xml?command=in_play&input="));
+        assert!(u.contains("https%3A%2F%2Fx%2Fy%3Fa%3Db"));
+    }
+    // VlcStatus / parse_status_xml tests live in mur-common::media (where the
+    // parser now lives).
 }

--- a/mur-core/src/cmd/media/watch.rs
+++ b/mur-core/src/cmd/media/watch.rs
@@ -54,6 +54,6 @@ mod tests {
         assert!(s.active && s.muted);
         let s = stop(home.path()).unwrap();
         assert!(!s.active && s.muted);
-        assert_eq!(status(home.path()).active, false);
+        assert!(!status(home.path()).active);
     }
 }

--- a/mur-core/src/cmd/workflow.rs
+++ b/mur-core/src/cmd/workflow.rs
@@ -1138,8 +1138,6 @@ pub fn create_draft_workflow(
     create_draft_workflow_in(&store, name, description, trigger, source_sessions)
 }
 
-/// Draft workflow with skeleton steps (harvest accept path). Steps containing
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/mur-core/src/cross_agent/propagate/mod.rs
+++ b/mur-core/src/cross_agent/propagate/mod.rs
@@ -111,6 +111,7 @@ mod tests {
         let f = std::fs::OpenOptions::new()
             .create(true)
             .write(true)
+            .truncate(true)
             .open(&lock_path)
             .unwrap();
         f.lock_exclusive().unwrap();

--- a/mur-core/src/nudge/companion.rs
+++ b/mur-core/src/nudge/companion.rs
@@ -256,7 +256,7 @@ mod tests {
         // 1. Seed nudge ledger with a surfaced candidate "abc123" (snapshot present)
         let c = cand();
         let mut ledger = NudgeLedger::default();
-        NudgeEmitter::emit_pending(&mut ledger, &[c.clone()], chrono::Utc::now());
+        NudgeEmitter::emit_pending(&mut ledger, std::slice::from_ref(&c), chrono::Utc::now());
         ledger
             .save(&NudgeLedger::default_path_in(mur.path()))
             .unwrap();

--- a/mur-core/src/open_items/mod.rs
+++ b/mur-core/src/open_items/mod.rs
@@ -175,7 +175,7 @@ mod tests {
     fn observed_items_sort_before_reported_regardless_of_age() {
         let old = Utc::now() - chrono::TimeDelta::days(30);
         let new = Utc::now();
-        let mut v = vec![
+        let mut v = [
             item(ItemSource::Reported, "agent said so", new),
             item(ItemSource::Observed, "queued job", old),
         ];

--- a/mur-core/src/parallel/backend/zfs_socket.rs
+++ b/mur-core/src/parallel/backend/zfs_socket.rs
@@ -168,7 +168,9 @@ mod tests {
             if let Ok((stream, _)) = listener.accept() {
                 let mut w = stream.try_clone().unwrap();
                 let r = BufReader::new(stream);
-                for line in r.lines().flatten() {
+                // `map_while` (not `flatten`): stop on the first IO error
+                // instead of spinning forever if it repeats.
+                for line in r.lines().map_while(Result::ok) {
                     let _ = line;
                     let mut resp = serde_json::to_string(&ZfsResponse::Ok).unwrap();
                     resp.push('\n');

--- a/mur-core/src/skill_gen/analysts.rs
+++ b/mur-core/src/skill_gen/analysts.rs
@@ -197,11 +197,8 @@ mod tests {
             async move { Ok(r) }
         }
 
-        fn embed(
-            &self,
-            _text: &str,
-        ) -> impl std::future::Future<Output = Result<Vec<f32>, LlmError>> + Send {
-            async move { Ok(vec![]) }
+        async fn embed(&self, _text: &str) -> Result<Vec<f32>, LlmError> {
+            Ok(vec![])
         }
     }
 
@@ -253,10 +250,7 @@ mod tests {
     #[tokio::test]
     async fn error_analyst_exhausts_rounds() {
         // 5 responses without PATCH:
-        let mut responses = Vec::new();
-        for _ in 0..5 {
-            responses.push("THOUGHT: still thinking. ACTION: inspect_turn 1");
-        }
+        let responses = vec!["THOUGHT: still thinking. ACTION: inspect_turn 1"; 5];
         let llm = mock_llm(responses);
         let trajs = vec![make_trajectory(Outcome::Failure {
             reason: "timeout".into(),

--- a/mur-core/src/skill_gen/consolidator.rs
+++ b/mur-core/src/skill_gen/consolidator.rs
@@ -155,11 +155,8 @@ mod tests {
             async move { Ok(r) }
         }
 
-        fn embed(
-            &self,
-            _text: &str,
-        ) -> impl std::future::Future<Output = Result<Vec<f32>, LlmError>> + Send {
-            async move { Ok(vec![]) }
+        async fn embed(&self, _text: &str) -> Result<Vec<f32>, LlmError> {
+            Ok(vec![])
         }
     }
 

--- a/mur-core/src/skill_lifecycle/sweep.rs
+++ b/mur-core/src/skill_lifecycle/sweep.rs
@@ -287,6 +287,20 @@ pub fn run_sweep(home: &Path, opts: SweepOptions) -> Result<SweepReport> {
     Ok(report)
 }
 
+fn matches_filter(name: &str, filter: Option<&str>) -> bool {
+    match filter {
+        None => true,
+        Some(f) => {
+            if f.contains('*') || f.contains('?') {
+                let pat = crate::skill_stats::reindex::glob_pattern(f);
+                pat.matches(name)
+            } else {
+                name == f
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -783,19 +797,5 @@ mod tests {
         ];
         // Only the final event forms a streak of 1.
         assert_eq!(consecutive_trailing_workflow_failures(&events), 1);
-    }
-}
-
-fn matches_filter(name: &str, filter: Option<&str>) -> bool {
-    match filter {
-        None => true,
-        Some(f) => {
-            if f.contains('*') || f.contains('?') {
-                let pat = crate::skill_stats::reindex::glob_pattern(f);
-                pat.matches(name)
-            } else {
-                name == f
-            }
-        }
     }
 }

--- a/mur-core/tests/cli_fleet.rs
+++ b/mur-core/tests/cli_fleet.rs
@@ -312,7 +312,7 @@ mod skill_fleet_tests {
         apply_fleet_pull(
             dev.path(),
             mur_common::sync_types::FleetEntityType::Skill,
-            &[ent.clone()],
+            std::slice::from_ref(&ent),
         )
         .unwrap();
         apply_fleet_pull(

--- a/mur-core/tests/cli_nudge.rs
+++ b/mur-core/tests/cli_nudge.rs
@@ -161,15 +161,18 @@ fn phase2_end_to_end_deliver_ack_drain() {
     // 2. Seed a ledger with a surfaced candidate (snapshot present).
     let c = cand("phase2", "phase2-workflow");
     let mut ledger = NudgeLedger::default();
-    NudgeEmitter::emit_pending(&mut ledger, &[c.clone()], chrono::Utc::now());
+    NudgeEmitter::emit_pending(&mut ledger, std::slice::from_ref(&c), chrono::Utc::now());
     ledger
         .save(&NudgeLedger::default_path_in(mur.path()))
         .unwrap();
 
     // 3. Deliver the candidate to the agent inbox.
-    let n =
-        mur_core::nudge::companion::deliver_nudges_to_companions(mur.path(), &[c.clone()], "en")
-            .unwrap();
+    let n = mur_core::nudge::companion::deliver_nudges_to_companions(
+        mur.path(),
+        std::slice::from_ref(&c),
+        "en",
+    )
+    .unwrap();
     assert_eq!(n, 1);
     let inbox_file = agent_dir.join("companion/inbox/nudge_phase2.md");
     assert!(inbox_file.exists());
@@ -211,9 +214,12 @@ fn phase2_end_to_end_deliver_ack_drain() {
     //    but the consumed file was removed. Re-deliver recreates it;
     //    the ledger filter in record_nudges_for_candidates prevents
     //    accepted candidates from being surfaced again upstream.
-    let n2 =
-        mur_core::nudge::companion::deliver_nudges_to_companions(mur.path(), &[c.clone()], "en")
-            .unwrap();
+    let n2 = mur_core::nudge::companion::deliver_nudges_to_companions(
+        mur.path(),
+        std::slice::from_ref(&c),
+        "en",
+    )
+    .unwrap();
     assert_eq!(n2, 1); // deliver doesn't check ledger; file was consumed
     // But filter_actionable excludes it:
     let actionable = ledger.filter_actionable(&[c], chrono::Utc::now(), 10);

--- a/mur-core/tests/skill_doctor_fix_apply.rs
+++ b/mur-core/tests/skill_doctor_fix_apply.rs
@@ -10,7 +10,7 @@ fn make_finding(skill_name: &str, check_id: &str, fixable: bool) -> Finding {
         category: "deps".to_string(),
         severity: Severity::Fail,
         skill_name: skill_name.to_string(),
-        message: format!("Required skill 'missing-dep' is not installed."),
+        message: "Required skill 'missing-dep' is not installed.".to_string(),
         remediation: Some("mur skill install missing-dep".to_string()),
         fixable,
     }

--- a/mur-core/tests/skill_evolve_e2e.rs
+++ b/mur-core/tests/skill_evolve_e2e.rs
@@ -67,12 +67,10 @@ fn write_telemetry_fixture(telemetry_dir: &std::path::Path, skill_name: &str) {
         format!(
             r#"{{"mur.event.type":"telemetry/llm_call","mur.task.id":"t1","mur.fired_skills":["{skill_name}"],"gen_ai.usage.input_tokens":100,"gen_ai.request.model":"claude","latency_ms":1200}}"#
         ),
-        format!(
-            r#"{{"mur.event.type":"telemetry/tool_call","mur.task.id":"t1","tool":"wrong.tool","ok":false,"duration_ms":500}}"#
-        ),
-        format!(
-            r#"{{"mur.event.type":"telemetry/error","mur.task.id":"t1","kind":"ToolError","message":"tool 'wrong.tool' not found"}}"#
-        ),
+        r#"{"mur.event.type":"telemetry/tool_call","mur.task.id":"t1","tool":"wrong.tool","ok":false,"duration_ms":500}"#
+            .to_string(),
+        r#"{"mur.event.type":"telemetry/error","mur.task.id":"t1","kind":"ToolError","message":"tool 'wrong.tool' not found"}"#
+            .to_string(),
     ];
     std::fs::write(telemetry_dir.join("2026-05-25.jsonl"), lines.join("\n")).unwrap();
 }

--- a/mur-core/tests/skill_generate_e2e.rs
+++ b/mur-core/tests/skill_generate_e2e.rs
@@ -19,11 +19,8 @@ impl LlmClient for ScriptedLlm {
         async move { Ok(resp) }
     }
 
-    fn embed(
-        &self,
-        _text: &str,
-    ) -> impl std::future::Future<Output = Result<Vec<f32>, LlmError>> + Send {
-        async move { Ok(vec![]) }
+    async fn embed(&self, _text: &str) -> Result<Vec<f32>, LlmError> {
+        Ok(vec![])
     }
 }
 

--- a/mur-core/tests/skill_sweep_idempotent.rs
+++ b/mur-core/tests/skill_sweep_idempotent.rs
@@ -7,6 +7,9 @@ use mur_core::skill_lifecycle::sweep::{SweepOptions, run_sweep};
 use std::fs;
 use tempfile::TempDir;
 
+// Positional fixture builder: every argument is a dimension a sweep test
+// varies. Bundling them into a struct would only move the noise.
+#[allow(clippy::too_many_arguments)]
 fn make_stats(
     name: &str,
     state: LifecycleState,


### PR DESCRIPTION
CI runs `cargo clippy --all --no-deps` **without `--all-targets`**, so test, bench and example code has never been linted — ~40 violations had accumulated across 28 files. This clears them and adds `--all-targets` to the CI invocation so it cannot rot again.

## Two were real defects (both in test support code)

| Where | Defect |
|---|---|
| `parallel/backend/zfs_socket.rs` | mock agent used `lines().flatten()` — spins forever if the socket repeatedly errors. Now `map_while(Result::ok)`, which stops at the first error. |
| `cross_agent/propagate/mod.rs` | lock file opened `create(true).write(true)` with truncate behavior undefined. Now explicit. |

## The rest: idiomatic, no behavior change

- Struct-literal init instead of `Default::default()` + field reassignment — **19 sites**
- `is_some_and` over `map_or(false, …)`; `slice::from_ref` over `&[x.clone()]` (5 sites)
- `async fn` over `-> impl Future` where the body had no pre-await work (3 sites; the `complete` impls that lock a mutex *before* the async block are deliberately left alone — converting those would move the lock to poll time)
- Redundant `..Default::default()` dropped from exhaustive struct literals
- Test modules moved to end-of-file (3 files) — pure code movement
- A truncated orphan doc comment in `workflow.rs` deleted (its item was removed during #402; the sentence ends mid-clause)

## Two judgment calls

- **Constant assertions → `const _: () = assert!(…)`** (`task_runner.rs`, `fleet/loop_run.rs`): these guard rails now fail the **build** rather than only the test — strictly stronger than what clippy asked for.
- **One `#[allow(clippy::too_many_arguments)]`** on a 9-argument test fixture builder, with a one-line reason: every argument is a dimension the sweep tests vary, and a params struct would only relocate the noise.

## Verification

- nextest **7057/7057** — identical count to before the cleanup, so nothing was silently disabled
- `clippy --workspace --all-targets -D warnings` clean · fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1y65jgyETWRnFgTN4Sqyd