### PR TITLE
docs(readme): mur update --restart-agents in the CLI install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ brew install mur-run/tap/mur
 
 # From source
 cargo install mur-core        # installs the `mur` binary
+
+# Later: upgrade in place, and restart agents onto the new binary
+mur update --restart-agents
 ```
 
 ```bash


### PR DESCRIPTION
Three lines in the CLI install block: after `cargo install`, show how you upgrade later.

```bash
# Later: upgrade in place, and restart agents onto the new binary
mur update --restart-agents
```

The substance (why the restart matters, the MCP re-pin, and the macOS codesign-identity setting) lives in the docs site — companion PR: mur-server#48. The README just needs the one-liner where someone installing will see it.

Docs for mur-run/mur#867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1y65jgyETWRnFgTN4Sqyd