### PR TITLE
fix(fleet): prune label assignments when a fleet is deleted

### DIFF
--- a/mur-core/src/cmd/fleet/delete.rs
+++ b/mur-core/src/cmd/fleet/delete.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use anyhow::Result;
 
-use super::store;
+use super::{labels, store};
 
 /// Delete a fleet: removes `~/.mur/fleets/<name>/` and the shared channel
 /// `fleet-<name>`. Member agents are left intact.
@@ -31,6 +31,14 @@ pub fn cmd_fleet_delete(mur_home: &Path, name: &str, yes: bool) -> Result<()> {
     let dir = store::fleet_dir(mur_home, name);
     if dir.exists() {
         std::fs::remove_dir_all(&dir)?;
+    }
+
+    // Only now, with the directory gone, does prune see this fleet as absent
+    // and drop its label assignments. Never fail an already-completed delete
+    // over it: the worst case is one orphan entry, which the rail already
+    // tolerates (an unknown primary falls back to Ungrouped).
+    if let Err(e) = labels::prune(mur_home) {
+        tracing::warn!("label prune after deleting fleet '{name}' failed (ignored): {e}");
     }
 
     println!(
@@ -75,6 +83,33 @@ mod tests {
         assert!(
             svc.store().load_manifest("fleet-dev").is_err(),
             "channel must be gone"
+        );
+    }
+
+    #[test]
+    fn delete_prunes_the_fleets_label_assignments() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        for f in ["dev", "keep"] {
+            create::cmd_fleet_create(home, f, vec!["pm".into()], None, Some("g".into()), None)
+                .unwrap();
+        }
+        labels::create_label(home, "web", "Web", None).unwrap();
+        labels::set_labels(home, "dev", vec!["web".into()]).unwrap();
+        labels::set_labels(home, "keep", vec!["web".into()]).unwrap();
+
+        cmd_fleet_delete(home, "dev", true).unwrap();
+
+        let reg = labels::load(home);
+        assert_eq!(reg.primary_of("dev"), None, "dead fleet must be forgotten");
+        assert_eq!(
+            reg.primary_of("keep"),
+            Some("web"),
+            "surviving fleet keeps its label"
+        );
+        assert!(
+            reg.get("web").is_some(),
+            "the label itself outlives the fleet"
         );
     }
 


### PR DESCRIPTION
## Problem

`labels::prune()` (`mur-core/src/cmd/fleet/labels.rs:110`) and `LabelRegistry::prune()` (`mur-common/src/labels.rs:153`) were written but have **no production caller** — grep finds only their own tests.

Both delete paths land in `cmd_fleet_delete` (the Hub's `fleet_delete` just calls it with `yes: true`), and neither touched the registry. So deleting a fleet left its entry in `labels.yaml` forever, and a later fleet created with the same name would silently inherit the dead one's labels.

## Change

One call, placed after `remove_dir_all`:

```rust
if let Err(e) = labels::prune(mur_home) {
    tracing::warn!("label prune after deleting fleet '{name}' failed (ignored): {e}");
}
```

Ordering is load-bearing — `prune` decides from `store::list_fleets`, i.e. from what is on disk, so it has to run *after* the directory is gone.

The error is logged rather than propagated: the fleet is already deleted at that point, so returning `Err` would report a failure for an operation that succeeded. The worst case is one orphan entry, which the rail already tolerates — `groupFleets` falls an unknown primary back to Ungrouped.

## Verification

```
cargo test -p mur-core --lib cmd::fleet::delete   3 passed  (1 new)
cargo test -p mur-core --lib cmd::fleet::labels  10 passed
cargo fmt --check -p mur-core                    exit 0
cargo clippy -p mur-core --lib --all-targets     clean
```

The new test asserts all three halves of the contract: the dead fleet's assignment is forgotten, a *surviving* fleet's assignment is untouched, and the label itself outlives the fleet that used it.

Independent of #871 (that one is frontend-only); this branches from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)