### PR TITLE
ci: hygiene — cancel superseded PR runs, timeouts, pinned actions, loud checksums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# A new commit on a PR obsoletes the in-flight run for the old commit —
+# cancel it instead of finishing a 3-OS matrix nobody will read. push:main
+# runs never cancel (post-merge validation must complete).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   # Disable incremental compilation across all CI jobs. Incremental adds a
@@ -81,6 +88,7 @@ jobs:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60 # hung build ≠ 6h default; normal runs are well under
     strategy:
       fail-fast: false
       matrix:
@@ -168,6 +176,7 @@ jobs:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -216,6 +225,7 @@ jobs:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.gui == 'true'
     runs-on: ubuntu-22.04   # widest glibc compat for AppImage downstream
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -242,7 +252,7 @@ jobs:
         # Saves ~75-85s per run on a job whose apt-install step was 91s.
         # `version: 1.0` is the cache key — bump it when adding/removing
         # packages so the cache invalidates.
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
         with:
           version: "1.1"
           packages: >-
@@ -279,6 +289,7 @@ jobs:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.hub_gui == 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -306,7 +317,7 @@ jobs:
         run: sudo apt-get update
       - name: Install Linux system libraries (Tauri 2)
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
         with:
           version: "1.1"
           packages: >-
@@ -347,6 +358,7 @@ jobs:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.e2e == 'true'
     runs-on: macos-latest
+    timeout-minutes: 45
     env:
       RUSTUP_TOOLCHAIN: stable
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,7 @@ jobs:
     name: Build (${{ matrix.target }})
     needs: validate-version
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 120 # hung build ≠ 6h default
     # sccache: compile-level cache that survives the per-release Cargo.lock
     # version bump (which invalidates rust-cache's exact key every time).
     env:
@@ -173,6 +174,7 @@ jobs:
     name: Package macOS (DMG + PKG)
     needs: build
     runs-on: macos-latest
+    timeout-minutes: 60 # notarization wait can stall; bound it
     if: always() && needs.build.result == 'success'
     steps:
       - uses: actions/checkout@v6
@@ -317,6 +319,7 @@ jobs:
     # clang rejects (whisper-rs-sys build). The CI Hub job builds whisper fine on
     # macos-latest; both are Apple-Silicon runners so the aarch64 target is native.
     runs-on: macos-latest
+    timeout-minutes: 120 # cold Hub build ≈ 20 min; whisper/ggml can be slow
     env:
       # tauri-cli has no binstall-compatible prebuilt for this version, so a
       # plain install recompiles it from source (~10 min) every release. Pin the
@@ -369,8 +372,9 @@ jobs:
           workspaces: |
             . -> target
             mur-hub-gui/src-tauri -> target
+          # No restore-keys here: rust-cache@v2 has no such input (it was
+          # silently ignored) — cross-key restore would need shared-key.
           key: hub-macos-${{ hashFiles('Cargo.lock', 'mur-hub-gui/src-tauri/Cargo.lock') }}
-          restore-keys: hub-macos-
 
       - name: Run sccache
         uses: mozilla/sccache-action@v0.0.9
@@ -426,7 +430,7 @@ jobs:
           key: cargo-tauri-${{ env.TAURI_CLI_VERSION }}-${{ runner.os }}-${{ runner.arch }}
       - name: Install cargo-binstall
         if: steps.tauri_cli_cache.outputs.cache-hit != 'true'
-        uses: cargo-bins/cargo-binstall@main
+        uses: cargo-bins/cargo-binstall@v1.21.1
       - name: Install tauri CLI
         if: steps.tauri_cli_cache.outputs.cache-hit != 'true'
         run: cargo binstall -y tauri-cli --version "${{ env.TAURI_CLI_VERSION }}"
@@ -507,7 +511,11 @@ jobs:
           merge-multiple: true
 
       - name: Create checksums
-        run: sha256sum *.tar.gz *.zip 2>/dev/null > checksums.txt || true
+        # No `|| true`: a release page with an empty checksums.txt is a
+        # silent failure — if the artifact globs come up empty, fail here.
+        run: |
+          sha256sum ./*.tar.gz ./*.zip > checksums.txt
+          test -s checksums.txt
 
       - name: Upload to release
         uses: softprops/action-gh-release@v2
@@ -636,6 +644,7 @@ jobs:
     needs: release
     if: always() && needs.release.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 60 # ~20 crates published sequentially with index waits
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Five small fixes, all surfaced while working #874. No behavior change on the happy path — every one of these only matters when something goes wrong, which is the point.

## 1. Cancel superseded PR runs

Neither workflow had a `concurrency` group: pushing a new commit to a PR left the old commit's run finishing a 3-OS matrix nobody will read (demonstrated live on #874 — the CHANGELOG push left the previous full run burning to completion). `push:main` runs never cancel — post-merge validation must complete.

## 2. `timeout-minutes` on every job that does real work

Everything ran under GitHub's **6-hour** default. One hung whisper.cpp build = a runner held all afternoon. Bounds chosen generously off observed times (cold Hub build ≈ 20 min → 120; test matrix → 60; notarization → 60).

## 3. Pin the two floating-ref actions

```
awalsh128/cache-apt-pkgs-action@latest  →  @v1.6.3
cargo-bins/cargo-binstall@main          →  @v1.21.1
```

Mutable refs are exactly how the apt-cache breakage class sneaks in unannounced, and they were inconsistent with the repo's own supply-chain posture (`docs/architecture/mcp-supply-chain.md`).

## 4. Checksums fail loudly

`sha256sum *.tar.gz *.zip 2>/dev/null > checksums.txt || true` shipped a release with an **empty checksums.txt** whenever the globs came up empty, and nothing noticed. Now: no `|| true`, plus `test -s`, plus the `./` prefix that resolves the long-standing shellcheck SC2035.

## 5. Delete the dead `restore-keys`

Not a valid `Swatinem/rust-cache@v2` input — silently ignored since the day it was written (actionlint has been flagging it). The hub-macos cache never had cross-key restore; now the config stops claiming it does. (If cross-run reuse is wanted later, that's `shared-key` — separate change, repopulates the cache.)

## Verification

`actionlint` on both files: **zero findings** (previously two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)