### PR TITLE
fix(update): install the runtime shipped in the release archive, replace via rename

### DIFF
--- a/mur-core/src/update/mod.rs
+++ b/mur-core/src/update/mod.rs
@@ -39,7 +39,9 @@ pub fn run(opts: UpdateOptions) -> Result<()> {
         // brew pour leaves the binaries ad-hoc signed (relocation invalidates
         // any CI signature) — re-sign with the stable identity so keychain
         // grants survive, then walk the deploy checklist (#849/#866).
-        resign::post_upgrade(opts.restart_agents)?;
+        // No extracted runtime here: brew just refreshed the keg, so the
+        // sibling fallback finds the current one.
+        resign::post_upgrade(opts.restart_agents, None)?;
         return Ok(());
     }
     if let Some(hint) = src.upgrade_hint() {
@@ -110,13 +112,26 @@ pub fn run(opts: UpdateOptions) -> Result<()> {
     } else {
         "mur.new"
     });
-    release::extract_binary(asset_name, &bin_bytes, &tmp_bin)?;
+    release::extract_binary(
+        asset_name,
+        &bin_bytes,
+        if cfg!(windows) { "mur.exe" } else { "mur" },
+        &tmp_bin,
+    )?;
 
     #[cfg(unix)]
     {
+        // The tarball ships the agent runtime too — hand it to post_upgrade so
+        // the launchd copy is refreshed from THIS release, not from whatever
+        // stale sibling is installed (the brew keg lags `mur update`).
+        let tmp_runtime = tmp_dir.path().join("mur-agent-runtime.new");
+        let fresh_runtime =
+            release::extract_binary(asset_name, &bin_bytes, "mur-agent-runtime", &tmp_runtime)
+                .ok()
+                .map(|_| tmp_runtime);
         swap::swap(&tmp_bin, &target)?;
         println!("Updated to v{latest}");
-        resign::post_upgrade(opts.restart_agents)?;
+        resign::post_upgrade(opts.restart_agents, fresh_runtime.as_deref())?;
     }
     #[cfg(windows)]
     {

--- a/mur-core/src/update/release.rs
+++ b/mur-core/src/update/release.rs
@@ -301,9 +301,15 @@ mod checksum_tests {
 use std::io::{Read, Write};
 use std::path::Path;
 
-/// Extract the `mur` (or `mur.exe`) binary from a release archive (tar.gz or zip)
-/// and write it to `dest`. Returns an error if the archive contains no `mur` entry.
-pub fn extract_binary(archive_name: &str, bytes: &[u8], dest: &Path) -> anyhow::Result<()> {
+/// Extract the named binary from a release archive (tar.gz or zip) and write
+/// it to `dest`. `entry_name` is the exact file name inside the archive (e.g.
+/// `mur`, `mur-agent-runtime`, `mur.exe`). Errors if the entry is absent.
+pub fn extract_binary(
+    archive_name: &str,
+    bytes: &[u8],
+    entry_name: &str,
+    dest: &Path,
+) -> anyhow::Result<()> {
     if archive_name.ends_with(".tar.gz") || archive_name.ends_with(".tgz") {
         let gz = flate2::read::GzDecoder::new(bytes);
         let mut tar = tar::Archive::new(gz);
@@ -311,7 +317,7 @@ pub fn extract_binary(archive_name: &str, bytes: &[u8], dest: &Path) -> anyhow::
             let mut entry = entry?;
             let path = entry.path()?.into_owned();
             let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
-            if name == "mur" {
+            if name == entry_name {
                 let mut buf = Vec::new();
                 entry.read_to_end(&mut buf)?;
                 std::fs::File::create(dest)?.write_all(&buf)?;
@@ -323,7 +329,7 @@ pub fn extract_binary(archive_name: &str, bytes: &[u8], dest: &Path) -> anyhow::
                 return Ok(());
             }
         }
-        anyhow::bail!("archive {archive_name} did not contain a `mur` binary");
+        anyhow::bail!("archive {archive_name} did not contain a `{entry_name}` binary");
     }
     if archive_name.ends_with(".zip") {
         let cursor = std::io::Cursor::new(bytes);
@@ -331,14 +337,14 @@ pub fn extract_binary(archive_name: &str, bytes: &[u8], dest: &Path) -> anyhow::
         for i in 0..zip.len() {
             let mut entry = zip.by_index(i)?;
             let name = entry.name().rsplit('/').next().unwrap_or("").to_string();
-            if name == "mur.exe" {
+            if name == entry_name {
                 let mut buf = Vec::new();
                 entry.read_to_end(&mut buf)?;
                 std::fs::File::create(dest)?.write_all(&buf)?;
                 return Ok(());
             }
         }
-        anyhow::bail!("archive {archive_name} did not contain mur.exe");
+        anyhow::bail!("archive {archive_name} did not contain {entry_name}");
     }
     anyhow::bail!("unknown archive type: {archive_name}")
 }
@@ -368,8 +374,17 @@ mod extract_tests {
         let bytes = build_tgz(&[("mur", b"FAKEBIN")]);
         let dir = tempfile::tempdir().unwrap();
         let dest = dir.path().join("mur");
-        extract_binary("foo.tar.gz", &bytes, &dest).unwrap();
+        extract_binary("foo.tar.gz", &bytes, "mur", &dest).unwrap();
         assert_eq!(std::fs::read(&dest).unwrap(), b"FAKEBIN");
+    }
+
+    #[test]
+    fn extracts_named_sibling_from_tgz() {
+        let bytes = build_tgz(&[("mur", b"MURBIN"), ("mur-agent-runtime", b"RUNTIMEBIN")]);
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("mur-agent-runtime");
+        extract_binary("foo.tar.gz", &bytes, "mur-agent-runtime", &dest).unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), b"RUNTIMEBIN");
     }
 
     #[test]
@@ -377,6 +392,6 @@ mod extract_tests {
         let bytes = build_tgz(&[("README", b"hi")]);
         let dir = tempfile::tempdir().unwrap();
         let dest = dir.path().join("mur");
-        assert!(extract_binary("foo.tar.gz", &bytes, &dest).is_err());
+        assert!(extract_binary("foo.tar.gz", &bytes, "mur", &dest).is_err());
     }
 }

--- a/mur-core/src/update/resign.rs
+++ b/mur-core/src/update/resign.rs
@@ -26,12 +26,17 @@ pub const SIGN_TARGETS: &[&str] = &[
 /// Run the post-upgrade leg: re-sign (macOS only — see the module docs), print
 /// the deploy checklist, optionally restart stale agents.
 ///
+/// `fresh_runtime` is the `mur-agent-runtime` extracted from the release
+/// archive, when it shipped one — the authoritative source for refreshing the
+/// launchd copy (installed siblings can lag the self-update).
+///
 /// Only the re-signing is macOS-specific. The checklist and the restart leg
 /// apply everywhere: an upgrade changes every binary's hash on any platform,
 /// which stales the running agents and their SHA-pinned MCP servers alike.
-pub fn post_upgrade(restart_agents: bool) -> Result<()> {
+#[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
+pub fn post_upgrade(restart_agents: bool, fresh_runtime: Option<&std::path::Path>) -> Result<()> {
     #[cfg(target_os = "macos")]
-    macos::resign_installed_binaries()?;
+    macos::resign_installed_binaries(fresh_runtime)?;
 
     print_checklist();
 
@@ -82,7 +87,7 @@ pub(crate) fn is_adhoc_output(codesign_dv_output: &str) -> bool {
 #[cfg(target_os = "macos")]
 mod macos {
     use std::collections::BTreeSet;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::process::Command;
 
     use anyhow::{Context, Result, bail};
@@ -91,7 +96,7 @@ mod macos {
 
     /// Re-sign every installed MUR binary with the configured identity. No
     /// identity configured → warn loudly and leave the install ad-hoc.
-    pub(super) fn resign_installed_binaries() -> Result<()> {
+    pub(super) fn resign_installed_binaries(fresh_runtime: Option<&Path>) -> Result<()> {
         let identity = pick_identity(
             config_identity().as_deref(),
             std::env::var("MUR_CODESIGN_IDENTITY").ok().as_deref(),
@@ -114,7 +119,7 @@ mod macos {
         };
 
         let mut targets = discover_targets();
-        refresh_local_runtime_copy(&mut targets);
+        refresh_local_runtime_copy(&mut targets, fresh_runtime);
         if targets.is_empty() {
             println!("⚠ no installed MUR binaries found to re-sign");
             return Ok(());
@@ -185,24 +190,30 @@ mod macos {
     }
 
     /// The launchd services run a COPY (not a symlink) of the runtime at
-    /// `~/.local/bin/mur-agent-runtime`. Refresh it from the newly-installed
-    /// runtime before signing — a stale copy is the old-version + SIGKILL trap.
-    fn refresh_local_runtime_copy(targets: &mut Vec<PathBuf>) {
+    /// `~/.local/bin/mur-agent-runtime`. Refresh it from the runtime shipped
+    /// with this release when available, else from a freshly-installed sibling
+    /// — a stale copy is the old-version trap.
+    fn refresh_local_runtime_copy(targets: &mut Vec<PathBuf>, fresh_runtime: Option<&Path>) {
         let Some(copy) = local_runtime_copy_path() else {
             return;
         };
         if !copy.exists() {
             return; // this machine doesn't use the copy layout
         }
-        let source = targets.iter().find(|p| {
-            p.file_name().is_some_and(|n| n == "mur-agent-runtime")
-                && p.canonicalize().ok() != copy.canonicalize().ok()
+        let source: Option<PathBuf> = fresh_runtime.map(PathBuf::from).or_else(|| {
+            targets
+                .iter()
+                .find(|p| {
+                    p.file_name().is_some_and(|n| n == "mur-agent-runtime")
+                        && p.canonicalize().ok() != copy.canonicalize().ok()
+                })
+                .cloned()
         });
         match source {
-            Some(src) => match std::fs::copy(src, &copy) {
+            Some(src) => match replace_file(&src, &copy) {
                 Ok(_) => println!("✓ refreshed {} from {}", copy.display(), src.display()),
                 Err(e) => println!(
-                    "⚠ could not refresh {} ({e}) — it may be running; re-signing the existing copy",
+                    "⚠ could not refresh {} ({e}) — re-signing the existing copy",
                     copy.display()
                 ),
             },
@@ -214,6 +225,32 @@ mod macos {
         }
         if !targets.contains(&copy) {
             targets.push(copy);
+        }
+    }
+
+    /// Copy `src` next to `dst`, then rename over it. Overwriting `dst` in
+    /// place would SIGKILL every process executing that inode; the rename
+    /// leaves running processes on the old inode instead.
+    fn replace_file(src: &Path, dst: &Path) -> std::io::Result<()> {
+        let tmp = dst.with_extension("new");
+        std::fs::copy(src, &tmp)?;
+        std::fs::rename(&tmp, dst)
+    }
+
+    #[cfg(test)]
+    mod macos_tests {
+        use super::replace_file;
+
+        #[test]
+        fn replace_file_swaps_content_and_leaves_no_temp() {
+            let dir = tempfile::tempdir().unwrap();
+            let src = dir.path().join("src");
+            let dst = dir.path().join("mur-agent-runtime");
+            std::fs::write(&src, b"NEW").unwrap();
+            std::fs::write(&dst, b"OLD").unwrap();
+            replace_file(&src, &dst).unwrap();
+            assert_eq!(std::fs::read(&dst).unwrap(), b"NEW");
+            assert!(!dir.path().join("mur-agent-runtime.new").exists());
         }
     }
 


### PR DESCRIPTION
## Problem

Deploying v2.64.0 via `mur update --restart-agents` exposed two bugs in the post-upgrade leg:

1. **Runtime silently downgraded.** The release tarball ships `mur-agent-runtime` (packed by release.yml exactly for this), but `extract_binary()` only pulled the `mur` entry and discarded the rest. `refresh_local_runtime_copy()` then looked for a "freshly-installed" runtime among the sign targets and found only the **stale brew keg** (2.60.0 on the affected machine) — copying the *old* runtime over `~/.local/bin/mur-agent-runtime` and restarting every agent onto it. The success line (`✓ refreshed … from /opt/homebrew/Cellar/mur/2.60.0/…`) reads like a deploy step but is actually the downgrade happening.

2. **SIGKILL trap.** The refresh used `std::fs::copy` **in place** over the live copy. Rewriting the inode that running launchd agents are executing gets them all SIGKILLed by macOS (observed: every `run.mur.agent.*` job at exit status `-9`, supervisors wedged, `mur agent restart` unable to recover them — only `launchctl kickstart -k` worked). The function's own doc comment named this trap; the copy itself was the trigger.

## Fix

- `extract_binary()` takes the archive entry name; the self-update flow extracts `mur-agent-runtime` alongside `mur` and passes it to `post_upgrade()` as the authoritative refresh source. Releases that don't ship a runtime fall back to the previous sibling search (and the brew-upgrade path passes `None` — there the keg was just refreshed, so the sibling fallback is correct).
- The copy is replaced via **temp + rename** so running processes keep executing their old inode instead of dying.

## Tests

- `extracts_named_sibling_from_tgz` — second entry extracted from a multi-binary tarball
- `replace_file_swaps_content_and_leaves_no_temp`
- existing extract tests updated for the new signature; 139 selected mur-core tests green locally, clippy `--all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)