### PR TITLE
chore(release): bump workspace version to 2.65.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6451,7 +6451,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6572,7 +6572,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6623,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6639,7 +6639,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6656,7 +6656,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.64.0"
+version = "2.65.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6783,7 +6783,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.64.0"
+version = "2.65.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
Release v2.65.0. Payload since v2.64.0:

- #876 — `mur update` no longer downgrades `mur-agent-runtime` from a stale brew keg (extracts the runtime shipped in the release archive) and replaces the launchd copy via temp+rename instead of SIGKILLing running agents.
- #875 — CI hygiene: superseded-run cancellation, job timeouts, pinned actions, loud release checksums.
- #874 — tag-on-merge release automation. **Merging this PR IS the release**: tag.yml tags v2.65.0 at the merge commit and dispatches release.yml — this is the automation's first flight, watch the tag + release run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)