### PR TITLE
feat(murmur): live fleet progress — auto rail + milestone follow on fleet_run

### DIFF
--- a/mur-channel/src/service.rs
+++ b/mur-channel/src/service.rs
@@ -18,6 +18,11 @@ struct DelegationPayload<'a> {
     target_agent: &'a str,
     child_task_id: &'a str,
     parent_channel_id: &'a str,
+    /// Sub-goal text handed to the delegate, so observers (fleet rail,
+    /// followed-channel milestones) can say WHAT was delegated, not just to
+    /// whom. Optional: absent on legacy events and non-goal delegations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    goal: Option<&'a str>,
 }
 
 /// Build the canonical `Delegation` event payload (single-sourced schema). Used
@@ -28,11 +33,13 @@ pub fn delegation_payload(
     parent_channel_id: &str,
     target_agent: &str,
     child_task_id: &str,
+    goal: Option<&str>,
 ) -> serde_json::Value {
     serde_json::to_value(DelegationPayload {
         target_agent,
         child_task_id,
         parent_channel_id,
+        goal,
     })
     .expect("DelegationPayload serializes")
 }
@@ -259,7 +266,7 @@ impl ChannelService {
         child_task_id: &str,
         idempotency_key: Option<String>,
     ) -> Result<ChannelEvent> {
-        let payload = delegation_payload(channel_id, target_agent, child_task_id);
+        let payload = delegation_payload(channel_id, target_agent, child_task_id, None);
         self.append(
             channel_id,
             ChannelActor::System,

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -495,6 +495,10 @@ pub struct App {
     pub panel_input_deadline: Option<std::time::Instant>,
     /// Fleet rail, when `--fleet` is on. `None` for an ordinary murmur.
     pub fleet: Option<super::fleet_rail::FleetRail>,
+    /// `step_id` of an in-flight `fleet_run` tool step that auto-armed the
+    /// rail/follow, so its `StepCompleted` can close them out. `None` when no
+    /// delegated fleet run is executing.
+    pub auto_fleet_step: Option<String>,
 }
 
 impl App {
@@ -576,6 +580,7 @@ impl App {
             panel_input_sent: String::new(),
             panel_input_deadline: None,
             fleet: None,
+            auto_fleet_step: None,
         }
     }
 
@@ -1100,6 +1105,63 @@ impl App {
             }
             Err(e) => self.push_system(format!("follow {} stopped: {e:#}", f.tag())),
         }
+    }
+
+    /// Auto-arm live fleet progress when a delegated `fleet_run` step starts:
+    /// the member rail (replaced only when absent or watching a different
+    /// fleet) plus a milestone follow of `fleet-<name>`. A user-armed follow
+    /// is never clobbered — the auto follow only takes an empty slot — and
+    /// the pane's own channel is never followed (its turns already render).
+    pub fn arm_auto_fleet(&mut self, step_id: &str, fleet: &str, now: std::time::Instant) {
+        self.auto_fleet_step = Some(step_id.to_string());
+        if !self.fleet.as_ref().is_some_and(|r| r.fleet() == fleet) {
+            self.fleet = Some(super::fleet_rail::FleetRail::start(fleet));
+        }
+        if let Some(rail) = self.fleet.as_mut() {
+            rail.set_run_in_flight(true);
+        }
+        let channel_id = format!("fleet-{fleet}");
+        let on_own_pane = self.channel.as_ref().is_some_and(|c| c.id == channel_id);
+        let can_follow = self.follow.is_none() && !on_own_pane;
+        if can_follow {
+            self.follow = Some(super::follow::Follow::start_auto(
+                &self.home,
+                &channel_id,
+                now,
+            ));
+        }
+        self.push_system(if can_follow {
+            format!(
+                "⛴ fleet {fleet} started — following {channel_id} (milestones land here; /channels N --follow for the raw log)"
+            )
+        } else {
+            format!("⛴ fleet {fleet} started")
+        });
+    }
+
+    /// Close out an auto-armed `fleet_run` when its step completes: drain the
+    /// follow's tail, drop it (only if auto), leave the rail up — Done/Failed
+    /// member states are worth reading — and put the outcome on the record.
+    pub fn finish_auto_fleet(&mut self, step_id: &str, ok: bool, duration_ms: u64) {
+        if self.auto_fleet_step.as_deref() != Some(step_id) {
+            return;
+        }
+        self.auto_fleet_step = None;
+        // Catch the run's last events before the follow goes away.
+        self.poll_follow(std::time::Instant::now());
+        if self.follow.as_ref().is_some_and(|f| f.auto) {
+            self.follow = None;
+        }
+        let mut fleet = String::new();
+        if let Some(rail) = self.fleet.as_mut() {
+            rail.set_run_in_flight(false);
+            fleet = rail.fleet().to_string();
+        }
+        let took = super::follow::fmt_elapsed(chrono::Duration::milliseconds(duration_ms as i64));
+        self.push_system(format!(
+            "⛴ fleet {fleet} {} ({took})",
+            if ok { "finished" } else { "failed" }
+        ));
     }
 
     /// Record a completed `!command` run: show it, persist it, and queue it

--- a/mur-core/src/cmd/agent/cli/fleet_rail.rs
+++ b/mur-core/src/cmd/agent/cli/fleet_rail.rs
@@ -13,6 +13,11 @@ use super::follow::POLL_INTERVAL;
 /// whatever is truncated is the least urgent.
 pub const MAX_EXPANDED_ROWS: usize = 6;
 
+/// Name of the runtime's built-in delegated-fleet tool. A `StepStarted`
+/// carrying this name (with a `fleet` arg) is the TUI's cue to auto-arm the
+/// rail and the milestone follow.
+pub const FLEET_RUN_TOOL: &str = "fleet_run";
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum MemberState {
     /// Waiting on a human. `hitl_id` is what `mur channel approve` takes.
@@ -96,6 +101,24 @@ pub fn fold_members(events: &[ChannelEvent]) -> Vec<MemberRow> {
             continue;
         }
 
+        // Production delegate-path shape (v3d-2): the router records each
+        // delegation as a System event carrying `target_agent` — the member's
+        // turn START. The member itself only ever writes its signed reply
+        // Message (turn END). Fold both, so the rail works against real
+        // channels and not just the members-emit-their-own-state shape
+        // handled below (kept for A2 forward-compatibility).
+        if ev.kind == EventKind::Delegation
+            && let Some(target) = field(ev, &["target_agent"])
+        {
+            let target = target.to_string();
+            let i = index(&mut rows, &target, ev.ts);
+            rows[i].state = MemberState::Working {
+                tool: field(ev, &["goal"]).map(str::to_string),
+                since: ev.ts,
+            };
+            continue;
+        }
+
         let ChannelActor::Agent { id } = &ev.actor else {
             continue;
         };
@@ -140,6 +163,15 @@ pub fn fold_members(events: &[ChannelEvent]) -> Vec<MemberRow> {
                     hitl_id: field(ev, &["hitl_id"]).unwrap_or_default().to_string(),
                 };
             }
+            EventKind::Message => {
+                // The member's signed reply — its turn is over. A Blocked row
+                // stays blocked: a HITL gate outlives any message and is only
+                // cleared by its HitlResponse above.
+                let i = index(&mut rows, id, ev.ts);
+                if !matches!(rows[i].state, MemberState::Blocked { .. }) {
+                    rows[i].state = MemberState::Done;
+                }
+            }
             _ => {}
         }
     }
@@ -157,9 +189,15 @@ pub fn fold_members(events: &[ChannelEvent]) -> Vec<MemberRow> {
 ///
 /// `2/5` is jobs in a terminal state over the total — the question a user asks
 /// first ("how far along?"), answered by the slow-moving store rather than by
-/// the event stream.
-pub fn jobs_line(fleet: &str, jobs: &[Job]) -> String {
+/// the event stream. `run_in_flight` is the TUI's own knowledge that a
+/// delegated `fleet_run` step is currently executing: goal-mode runs never
+/// touch the job store, so without it an in-flight run reads as "not run yet"
+/// (empty store) or as already finished (stale terminal jobs).
+pub fn jobs_line(fleet: &str, jobs: &[Job], run_in_flight: bool) -> String {
     if jobs.is_empty() {
+        if run_in_flight {
+            return format!("fleet · {fleet}   ⏵ run in progress");
+        }
         return format!("fleet · {fleet}   not run yet (mur fleet run {fleet})");
     }
     let total = jobs.len();
@@ -178,6 +216,9 @@ pub fn jobs_line(fleet: &str, jobs: &[Job]) -> String {
     }
     if failed > 0 {
         line.push_str(&format!(" · {failed} ✖ failed"));
+    }
+    if run_in_flight && running == 0 {
+        line.push_str(" · ⏵ run in progress");
     }
     line
 }
@@ -210,6 +251,9 @@ pub struct FleetRail {
     /// any job that isn't the newest leaves the max unchanged and the gate
     /// blind to a real change.
     last_jobs_gate: (usize, Option<std::time::SystemTime>),
+    /// A delegated `fleet_run` step is currently executing in this pane
+    /// (armed on `StepStarted`, cleared on `StepCompleted`).
+    run_in_flight: bool,
     view: RailView,
     next_poll: Instant,
 }
@@ -221,8 +265,23 @@ impl FleetRail {
             channel_id: format!("fleet-{fleet}"),
             last_len: u64::MAX, // force the first poll to do real work
             last_jobs_gate: (0, None),
+            run_in_flight: false,
             view: RailView::default(),
             next_poll: Instant::now(),
+        }
+    }
+
+    /// The fleet this rail watches.
+    pub fn fleet(&self) -> &str {
+        &self.fleet
+    }
+
+    /// Flip the in-flight flag (see the field doc). Busts the poll gate so the
+    /// collapsed line reflects the flip even when nothing on disk moved.
+    pub fn set_run_in_flight(&mut self, v: bool) {
+        if self.run_in_flight != v {
+            self.run_in_flight = v;
+            self.last_len = u64::MAX;
         }
     }
 
@@ -289,7 +348,7 @@ impl FleetRail {
                         j.status = s;
                     }
                 }
-                jobs_line(&self.fleet, &jobs)
+                jobs_line(&self.fleet, &jobs, self.run_in_flight)
             }
             Err(_) => {
                 // A corrupt job file must not read as "not run yet" (`jobs_line`

--- a/mur-core/src/cmd/agent/cli/fleet_rail/tests.rs
+++ b/mur-core/src/cmd/agent/cli/fleet_rail/tests.rs
@@ -345,7 +345,7 @@ fn jobs_line_counts_terminal_over_total() {
         job("5", JobStatus::Queued),
     ];
     // 2 of 5 have reached a terminal state; one of those failed.
-    let line = jobs_line("develop", &jobs);
+    let line = jobs_line("develop", &jobs, false);
     assert!(line.contains("fleet · develop"), "got: {line}");
     assert!(line.contains("job 2/5"), "got: {line}");
     assert!(line.contains("1 ⏵ running"), "got: {line}");
@@ -354,14 +354,14 @@ fn jobs_line_counts_terminal_over_total() {
 
 #[test]
 fn jobs_line_says_not_run_yet_when_there_are_none() {
-    let line = jobs_line("develop", &[]);
+    let line = jobs_line("develop", &[], false);
     assert!(line.contains("not run yet"), "got: {line}");
     assert!(line.contains("mur fleet run develop"), "got: {line}");
 }
 
 #[test]
 fn jobs_line_omits_the_failed_clause_when_nothing_failed() {
-    let line = jobs_line("develop", &[job("1", JobStatus::Done)]);
+    let line = jobs_line("develop", &[job("1", JobStatus::Done)], false);
     assert!(!line.contains("failed"), "got: {line}");
 }
 
@@ -482,4 +482,109 @@ fn poll_falls_back_to_channel_summary_when_jobs_store_is_unreadable() {
         "notice must surface the unreadable store, got: {:?}",
         view.notice
     );
+}
+
+// ── Production delegate-path shapes (v3d-2) ─────────────────────────────────
+// Real fleet channels contain System delegations (turn start) and the
+// member's own signed reply Message (turn end) — never member-emitted
+// state-changes. The fold must produce rows from THOSE.
+
+#[test]
+fn system_delegation_starts_a_member_row_with_its_goal() {
+    let evs = vec![
+        ev(
+            1,
+            ChannelActor::System,
+            EventKind::Delegation,
+            json!({
+                "target_agent": "dr_worker_1",
+                "child_task_id": "ct-1",
+                "parent_channel_id": "fleet-deep-research",
+                "goal": "survey memory designs"
+            }),
+        ),
+        ev(
+            2,
+            ChannelActor::System,
+            EventKind::StateChange,
+            json!({"from": "submitted", "to": "working"}),
+        ),
+    ];
+    let rows = fold_members(&evs);
+    assert_eq!(rows.len(), 1, "System state-changes must not become rows");
+    assert_eq!(rows[0].agent, "dr_worker_1");
+    match &rows[0].state {
+        MemberState::Working { tool, .. } => {
+            assert_eq!(tool.as_deref(), Some("survey memory designs"));
+        }
+        s => panic!("expected Working, got {s:?}"),
+    }
+}
+
+#[test]
+fn member_reply_marks_done_and_redelegation_restarts() {
+    let deleg = |seq| {
+        ev(
+            seq,
+            ChannelActor::System,
+            EventKind::Delegation,
+            json!({"target_agent": "qa", "child_task_id": "ct", "parent_channel_id": "fleet-x"}),
+        )
+    };
+    let reply = |seq| {
+        ev(
+            seq,
+            agent("qa"),
+            EventKind::Message,
+            json!({"text": "## Summary\nall done"}),
+        )
+    };
+    let rows = fold_members(&[deleg(1), reply(2)]);
+    assert!(
+        matches!(rows[0].state, MemberState::Done),
+        "reply ends the turn: {:?}",
+        rows[0].state
+    );
+    let rows = fold_members(&[deleg(1), reply(2), deleg(3)]);
+    assert!(
+        matches!(rows[0].state, MemberState::Working { .. }),
+        "re-delegation restarts the member: {:?}",
+        rows[0].state
+    );
+}
+
+#[test]
+fn member_message_never_clears_a_hitl_block() {
+    let evs = vec![
+        ev(
+            1,
+            agent("qa"),
+            EventKind::HitlRequest,
+            json!({"summary": "git push", "hitl_id": "h-1"}),
+        ),
+        ev(
+            2,
+            agent("qa"),
+            EventKind::Message,
+            json!({"text": "waiting"}),
+        ),
+    ];
+    let rows = fold_members(&evs);
+    assert!(
+        matches!(rows[0].state, MemberState::Blocked { .. }),
+        "got {:?}",
+        rows[0].state
+    );
+}
+
+#[test]
+fn jobs_line_flags_an_in_flight_goal_run() {
+    // Goal-mode runs never touch the job store: an empty store must read as
+    // in-progress, not "not run yet"…
+    let line = jobs_line("develop", &[], true);
+    assert!(line.contains("run in progress"), "got: {line}");
+    assert!(!line.contains("not run yet"), "got: {line}");
+    // …and stale terminal jobs must not read as "all finished".
+    let line = jobs_line("develop", &[job("1", JobStatus::Done)], true);
+    assert!(line.contains("run in progress"), "got: {line}");
 }

--- a/mur-core/src/cmd/agent/cli/follow.rs
+++ b/mur-core/src/cmd/agent/cli/follow.rs
@@ -8,10 +8,12 @@
 //! switching away from their own conversation (a switch only ever shows a disk
 //! snapshot, and would then mix the operator's own turns into it).
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use mur_channel::ChannelStore;
 use mur_common::channel::{ChannelActor, ChannelEvent, EventKind};
 use mur_common::hitl::{HitlRequest, HitlResponse};
@@ -23,18 +25,45 @@ pub const POLL_INTERVAL: Duration = Duration::from_millis(700);
 /// Longest event text carried into one transcript line.
 const TEXT_MAX: usize = 400;
 
+/// Milestone lines are conversation furniture, not a log dump — keep them
+/// tighter than raw-follow lines.
+const MILESTONE_MAX: usize = 160;
+
+/// How a followed channel renders into transcript lines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FollowMode {
+    /// Every event, one line each (`/channels N --follow`) — the debug view.
+    #[default]
+    Raw,
+    /// Transitions only: delegations, member completions, run outcomes, HITL.
+    /// What the auto-armed fleet follow uses.
+    Milestone,
+}
+
 /// A followed channel: a byte-length gate plus a `seq` cursor over its
 /// append-only log.
 pub struct Follow {
     pub channel_id: String,
-    /// Highest `seq` already rendered — the dedup cursor. Starts at the log's
-    /// current head so following never replays history.
+    /// NEXT `seq` to render — the dedup cursor. Starts one past the log's
+    /// current head so following never replays history. ("One past" and not
+    /// "highest rendered" because seq starts at 0: a follow armed on an empty
+    /// channel must not eat that first event.)
     cursor: u64,
     /// Log size at the last poll. Unchanged size means nothing to parse.
     /// ponytail: re-parses the whole log when it grows; switch to a byte-offset
     /// seek if a followed channel ever gets long enough to notice.
     last_len: u64,
     pub next_poll: Instant,
+    /// How events become lines (raw tail vs milestone transitions).
+    pub mode: FollowMode,
+    /// True when armed automatically by an in-flight `fleet_run` step rather
+    /// than by the user — the auto follow is stopped when that step completes;
+    /// a user-armed follow never is.
+    pub auto: bool,
+    /// Milestone mode only: when each delegated member's turn started
+    /// (`Delegation` event ts), so its completion line carries an elapsed
+    /// duration.
+    delegated_at: HashMap<String, DateTime<Utc>>,
 }
 
 impl Follow {
@@ -44,10 +73,36 @@ impl Follow {
         let evs = store.load_events(channel_id)?;
         Ok(Self {
             channel_id: channel_id.to_string(),
-            cursor: evs.last().map(|e| e.seq).unwrap_or(0),
+            cursor: evs.last().map(|e| e.seq + 1).unwrap_or(0),
             last_len: log_len(&store, channel_id),
             next_poll: now + POLL_INTERVAL,
+            mode: FollowMode::Raw,
+            auto: false,
+            delegated_at: HashMap::new(),
         })
+    }
+
+    /// Start following `channel_id` in milestone mode, armed by the TUI itself
+    /// when a delegated `fleet_run` step begins. Infallible on purpose: the
+    /// fleet's channel may not exist yet at arm time (the run's first event
+    /// creates it), so a missing log reads as an empty one and the cursor
+    /// starts at whatever head exists.
+    pub fn start_auto(home: &Path, channel_id: &str, now: Instant) -> Self {
+        let store = ChannelStore::new(home);
+        let cursor = store
+            .load_events(channel_id)
+            .ok()
+            .and_then(|evs| evs.last().map(|e| e.seq + 1))
+            .unwrap_or(0);
+        Self {
+            channel_id: channel_id.to_string(),
+            cursor,
+            last_len: log_len(&store, channel_id),
+            next_poll: now + POLL_INTERVAL,
+            mode: FollowMode::Milestone,
+            auto: true,
+            delegated_at: HashMap::new(),
+        }
     }
 
     /// Short display tag for transcript lines.
@@ -68,13 +123,20 @@ impl Follow {
         let evs = store.load_events(&self.channel_id)?;
         let mut out = Vec::new();
         let cursor = self.cursor;
-        for ev in evs.iter().filter(|e| e.seq > cursor) {
-            self.cursor = ev.seq;
-            out.push(format!(
-                "⟨{}⟩ {}",
-                self.tag(),
-                summarize(ev, &self.channel_id)
-            ));
+        for ev in evs.iter().filter(|e| e.seq >= cursor) {
+            self.cursor = ev.seq + 1;
+            match self.mode {
+                FollowMode::Raw => out.push(format!(
+                    "⟨{}⟩ {}",
+                    self.tag(),
+                    summarize(ev, &self.channel_id)
+                )),
+                FollowMode::Milestone => {
+                    if let Some(line) = milestone(ev, &self.channel_id, &mut self.delegated_at) {
+                        out.push(line);
+                    }
+                }
+            }
         }
         Ok(out)
     }
@@ -164,6 +226,80 @@ fn field<'a>(ev: &'a ChannelEvent, keys: &[&str]) -> Option<&'a str> {
         .filter(|s| !s.is_empty())
 }
 
+/// One transcript line for a milestone-worthy event — `None` for everything
+/// else. Milestones are the transitions a user acts on or anchors to:
+/// delegation (turn start), a member's own completion summary (turn end), run
+/// outcomes, loop-guard notes, plus everything `summarize` already renders
+/// loudly (HITL, tool calls, artifacts). Working-state flips and human goal
+/// relays stay off the transcript — the rail carries "now"; the transcript
+/// keeps history.
+pub fn milestone(
+    ev: &ChannelEvent,
+    channel_id: &str,
+    delegated_at: &mut HashMap<String, DateTime<Utc>>,
+) -> Option<String> {
+    match ev.kind {
+        EventKind::Delegation => {
+            let target = field(ev, &["target_agent"])?;
+            delegated_at.insert(target.to_string(), ev.ts);
+            let goal = field(ev, &["goal"])
+                .map(|g| format!(" — {}", clip_to(g, MILESTONE_MAX)))
+                .unwrap_or_default();
+            Some(format!("▸ delegated → {target}{goal}"))
+        }
+        EventKind::Message => {
+            // Only a member's own (signed) reply is a milestone — its first
+            // line is the member-authored summary of the turn.
+            let ChannelActor::Agent { id } = &ev.actor else {
+                return None;
+            };
+            let text = field(ev, &["text"]).unwrap_or("");
+            let first = text
+                .lines()
+                .map(|l| l.trim_start_matches('#').trim())
+                .find(|l| !l.is_empty())
+                .unwrap_or("");
+            let took = delegated_at
+                .remove(id.as_str())
+                .map(|t| format!(" ({})", fmt_elapsed(ev.ts.signed_duration_since(t))))
+                .unwrap_or_default();
+            Some(format!("✓ {id}{took} — {}", clip_to(first, MILESTONE_MAX)))
+        }
+        // Channel-level transitions: one line per finished run (each loop
+        // iteration is one run). `working` flips are rail material, not
+        // transcript material.
+        EventKind::StateChange => match field(ev, &["to"])? {
+            "completed" => Some("✓ run completed".to_string()),
+            to @ ("failed" | "canceled" | "rejected") => Some(format!("✗ run {to}")),
+            _ => None,
+        },
+        // Loop-guard notes (budget exhausted, stuck detection, …) are exactly
+        // what an operator wants on the record.
+        EventKind::Note => Some(format!(
+            "· {}",
+            clip_to(field(ev, &["text"])?, MILESTONE_MAX)
+        )),
+        EventKind::HitlRequest
+        | EventKind::HitlResponse
+        | EventKind::ToolCall
+        | EventKind::ToolResult
+        | EventKind::Artifact => Some(summarize(ev, channel_id)),
+        _ => None,
+    }
+}
+
+/// `45s`, `2m10s`, `1h3m` — coarse on purpose; these are history lines.
+pub(crate) fn fmt_elapsed(d: chrono::Duration) -> String {
+    let s = d.num_seconds().max(0);
+    if s < 60 {
+        format!("{s}s")
+    } else if s < 3600 {
+        format!("{}m{}s", s / 60, s % 60)
+    } else {
+        format!("{}h{}m", s / 3600, (s % 3600) / 60)
+    }
+}
+
 fn step(ev: &ChannelEvent) -> String {
     field(ev, &["step_id"])
         .map(|s| format!(" [{s}]"))
@@ -171,10 +307,14 @@ fn step(ev: &ChannelEvent) -> String {
 }
 
 fn clip(s: &str) -> String {
-    if s.chars().count() <= TEXT_MAX {
+    clip_to(s, TEXT_MAX)
+}
+
+fn clip_to(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
         return s.to_string();
     }
-    let head: String = s.chars().take(TEXT_MAX).collect();
+    let head: String = s.chars().take(max).collect();
     format!("{head}…")
 }
 
@@ -256,5 +396,130 @@ mod tests {
         };
         let line = summarize(&ev, "ch1");
         assert!(line.contains("mur channel approve ch1 h7"), "{line}");
+    }
+
+    // ── Milestone mode ──────────────────────────────────────────────────────
+
+    fn mk(
+        seq: u64,
+        secs: i64,
+        actor: ChannelActor,
+        kind: EventKind,
+        payload: serde_json::Value,
+    ) -> ChannelEvent {
+        ChannelEvent {
+            seq,
+            ts: chrono::DateTime::from_timestamp(1_700_000_000 + secs, 0).unwrap(),
+            actor,
+            kind,
+            payload,
+            idempotency_key: None,
+            sig: None,
+            key_version: None,
+        }
+    }
+
+    #[test]
+    fn milestone_delegation_then_reply_carries_elapsed() {
+        let mut at = HashMap::new();
+        let d = mk(
+            1,
+            0,
+            ChannelActor::System,
+            EventKind::Delegation,
+            serde_json::json!({"target_agent": "dr_worker_1", "goal": "survey 2026 agent memory designs"}),
+        );
+        let line = milestone(&d, "fleet-x", &mut at).unwrap();
+        assert!(line.contains("delegated → dr_worker_1"), "got: {line}");
+        assert!(line.contains("survey 2026"), "got: {line}");
+
+        let m = mk(
+            2,
+            130,
+            ChannelActor::Agent {
+                id: "dr_worker_1".into(),
+            },
+            EventKind::Message,
+            serde_json::json!({"text": "## Summary\n\nAll sources verified — synthesizing."}),
+        );
+        let line = milestone(&m, "fleet-x", &mut at).unwrap();
+        assert_eq!(line, "✓ dr_worker_1 (2m10s) — Summary", "got: {line}");
+        assert!(at.is_empty(), "the reply consumes the delegation timestamp");
+    }
+
+    #[test]
+    fn milestone_skips_noise_and_keeps_outcomes() {
+        let mut at = HashMap::new();
+        let human = mk(
+            1,
+            0,
+            ChannelActor::Human { name: "d".into() },
+            EventKind::Message,
+            serde_json::json!({"text": "the goal"}),
+        );
+        assert!(milestone(&human, "c", &mut at).is_none());
+        let working = mk(
+            2,
+            0,
+            ChannelActor::System,
+            EventKind::StateChange,
+            serde_json::json!({"from": "submitted", "to": "working"}),
+        );
+        assert!(milestone(&working, "c", &mut at).is_none());
+        let done = mk(
+            3,
+            0,
+            ChannelActor::System,
+            EventKind::StateChange,
+            serde_json::json!({"from": "working", "to": "completed"}),
+        );
+        assert_eq!(milestone(&done, "c", &mut at).unwrap(), "✓ run completed");
+        let failed = mk(
+            4,
+            0,
+            ChannelActor::System,
+            EventKind::StateChange,
+            serde_json::json!({"from": "working", "to": "failed"}),
+        );
+        assert_eq!(milestone(&failed, "c", &mut at).unwrap(), "✗ run failed");
+        let note = mk(
+            5,
+            0,
+            ChannelActor::System,
+            EventKind::Note,
+            serde_json::json!({"text": "budget exhausted"}),
+        );
+        assert_eq!(
+            milestone(&note, "c", &mut at).unwrap(),
+            "· budget exhausted"
+        );
+    }
+
+    #[test]
+    fn fmt_elapsed_buckets() {
+        use chrono::Duration as D;
+        assert_eq!(fmt_elapsed(D::seconds(45)), "45s");
+        assert_eq!(fmt_elapsed(D::seconds(130)), "2m10s");
+        assert_eq!(fmt_elapsed(D::seconds(3780)), "1h3m");
+        assert_eq!(fmt_elapsed(D::seconds(-5)), "0s");
+    }
+
+    /// `start_auto` on a channel that does not exist yet must arm quietly and
+    /// then surface milestone lines once the run's first events land.
+    #[test]
+    fn start_auto_tolerates_missing_channel_and_drains_milestones() {
+        let dir = tempdir().unwrap();
+        let home = dir.path();
+        let now = Instant::now();
+        let mut f = Follow::start_auto(home, "fleet-x", now);
+        assert!(f.auto);
+        append(
+            home,
+            "fleet-x",
+            EventKind::Delegation,
+            serde_json::json!({"target_agent": "qa", "goal": "fix tests"}),
+        );
+        let lines = f.drain(home, now).unwrap();
+        assert_eq!(lines, vec!["▸ delegated → qa — fix tests".to_string()]);
     }
 }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -1844,6 +1844,15 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
                 app.pending_suggestions = suggest::parse_suggestions(&args);
             } else {
                 app.saw_step_this_turn = true;
+                // A delegated fleet run is a long, otherwise-opaque step:
+                // auto-arm the member rail + milestone follow so the user
+                // watches it happen instead of staring at a spinner.
+                if name == fleet_rail::FLEET_RUN_TOOL
+                    && let Some(fleet) = args.get("fleet").and_then(|v| v.as_str())
+                {
+                    let fleet = fleet.to_string();
+                    app.arm_auto_fleet(&step_id, &fleet, StdInstant::now());
+                }
                 app.push_step_started(step_id, name, args);
             }
         }
@@ -1866,6 +1875,7 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
                 error,
                 duration_ms,
             );
+            app.finish_auto_fleet(&step_id, ok, duration_ms);
         }
     }
 }

--- a/mur-core/src/executor/dag.rs
+++ b/mur-core/src/executor/dag.rs
@@ -591,8 +591,18 @@ async fn execute_step(
 
         // Record the delegation up front (System actor, deterministic key),
         // SIGNED by the router (v3d) via the single-sourced payload builder.
+        // The goal snippet lets observers (fleet rail / followed-channel
+        // milestones) show WHAT was delegated; clipped so one long step
+        // description cannot bloat the append-only log.
         if let Ok(svc) = ChannelService::open(mur_home) {
-            let payload = mur_channel::service::delegation_payload(cid, &canonical, &child_task_id);
+            const DELEGATION_GOAL_SNIP: usize = 200;
+            let goal_snip: String = goal_text.chars().take(DELEGATION_GOAL_SNIP).collect();
+            let payload = mur_channel::service::delegation_payload(
+                cid,
+                &canonical,
+                &child_task_id,
+                Some(&goal_snip),
+            );
             let _ = crate::channel_writer::append_as_writer(
                 &svc,
                 mur_home,


### PR DESCRIPTION
## Problem

A delegated `fleet_run` (concierge tool) is a black box in the murmur TUI: the tool spawns `mur fleet run`, waits with `wait_with_output()`, and returns the stdout tail — so the user stares at a spinner for the entire multi-minute run ("How to see fleet logs?"), while every milestone is already being signed into the `fleet-<name>` channel.

Two viewing mechanisms existed but were undiscoverable at the moment they matter, and one of them was hollow:

- the `--fleet` member rail can only be armed at launch, and its fold only read **Agent-actor** `StateChange`/`ToolCall` events — shapes the production delegate path (v3d-2) never emits (real channels contain System delegations + member-signed reply Messages only), so it showed **zero member rows** against real fleets;
- `/channels N --follow` requires knowing the command and the channel index mid-run.

## What this does

**Auto-arm on `StepStarted{fleet_run}`** (`cmd/agent/cli/mod.rs`): the member rail plus a **milestone-mode follow** of `fleet-<name>`, with a hint line; `StepCompleted` drains the tail, drops the auto follow (a user-armed follow is never clobbered), leaves the rail up, and puts the outcome on the record. Two-surface model: the rail carries "now" (per-member state + elapsed), the transcript carries history (milestones only).

**Milestone renderer** (`follow.rs`): transitions only — `▸ delegated → dr_worker_1 — <goal>`, `✓ dr_worker_1 (2m10s) — <member's own first-line summary>`, `✓/✗ run completed/failed`, loop-guard notes, and everything `summarize` already renders loudly (HITL with the exact approve command, tool calls, artifacts). Raw mode unchanged for `/channels N --follow`.

**Rail fold fixed for production shapes** (`fleet_rail.rs`): System `Delegation` (turn start, goal into the tool slot) and the member's signed reply `Message` (turn end → Done; never clears a HITL block). Existing Agent-actor arms kept for A2 forward-compatibility. `jobs_line` learns `run_in_flight` so goal-mode runs stop reading as "not run yet" / already-finished.

**`delegation_payload` gains an optional `goal` snippet** (`mur-channel`, clipped to 200 chars at the emitter in `executor/dag.rs`) so observers can say WHAT was delegated. Optional + `skip_serializing_if`: legacy events and old readers are unaffected; the payload is signed at write time as before.

**Latent follow bug fixed**: channel `seq` starts at 0, but the follow cursor started at "last seq or 0" and rendered only `seq > cursor` — a follow armed on an empty/new channel silently ate the first event. Cursor switched to next-seq semantics.

## Tests

- fold from real-world shapes (System delegation → Working with goal; member reply → Done; re-delegation restarts; Message never clears a HITL block)
- milestone rendering incl. elapsed time, markdown-header stripping, noise skipping (human messages, `working` flips), outcomes, notes
- `start_auto` on a not-yet-existing channel surfaces the run's first events
- `jobs_line` in-flight variants
- `cargo nextest`: mur-channel 28/28, mur-core lib 2325/2325; `cargo check --workspace --all-targets` clean; fmt + clippy clean (the one clippy warning is pre-existing in `update/resign.rs`, untouched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)