### PR TITLE
feat(skills): builtin skills for deep-research/capability/official/notes/chat; fix mur-workflow-hitl's invented CLI

### DIFF
--- a/mur-core/src/cmd/sync_cmd.rs
+++ b/mur-core/src/cmd/sync_cmd.rs
@@ -1279,6 +1279,17 @@ pub(crate) fn ensure_mur_skill(home: &std::path::Path, mur_root: &std::path::Pat
             include_str!("../skills/mur_workflow_delegate.yaml"),
         ),
         (
+            "mur-deep-research",
+            include_str!("../skills/mur_deep_research.yaml"),
+        ),
+        (
+            "mur-capability",
+            include_str!("../skills/mur_capability.yaml"),
+        ),
+        ("mur-official", include_str!("../skills/mur_official.yaml")),
+        ("mur-notes", include_str!("../skills/mur_notes.yaml")),
+        ("mur-chat", include_str!("../skills/mur_chat.yaml")),
+        (
             "mur-agent-setup",
             include_str!("../skills/mur_agent_setup.yaml"),
         ),
@@ -1880,6 +1891,23 @@ mod builtin_skill_tests {
                 include_str!("../skills/mur_workflow_delegate.yaml"),
                 true,
             ),
+            (
+                "mur-deep-research",
+                include_str!("../skills/mur_deep_research.yaml"),
+                false,
+            ),
+            (
+                "mur-capability",
+                include_str!("../skills/mur_capability.yaml"),
+                false,
+            ),
+            (
+                "mur-official",
+                include_str!("../skills/mur_official.yaml"),
+                false,
+            ),
+            ("mur-notes", include_str!("../skills/mur_notes.yaml"), false),
+            ("mur-chat", include_str!("../skills/mur_chat.yaml"), false),
             (
                 "mur-agent-setup",
                 include_str!("../skills/mur_agent_setup.yaml"),

--- a/mur-core/src/skills/mur_capability.yaml
+++ b/mur-core/src/skills/mur_capability.yaml
@@ -1,0 +1,37 @@
+name: mur-capability
+version: 0.1.0
+publisher: human:mur
+description: "Use when giving an agent a bundle of MCP servers/skills/programs at once — capability, bundle, 能力包, 裝能力."
+category: workflow
+hosts: [all]
+content:
+  abstract: |
+    Capabilities are installable bundles of MCP servers + skills +
+    required programs. Browse with `mur capability list`/`show`, put one
+    onto an agent with `install`, take it off with `remove` — instead of
+    wiring MCP servers and skills one by one.
+  context: |
+    # mur-capability — bundle install for agents
+
+    Wiring an agent with several MCP servers, skills, and required
+    programs one by one is error-prone. A capability is one named
+    bundle.
+
+    - `mur capability list` — available bundles.
+    - `mur capability show <name>` — exactly what it would install
+      (MCP servers, skills, required programs). Read this BEFORE
+      installing.
+    - `mur capability install <name> --agent <agent>` — install onto an
+      agent (`--yes` skips the confirmation; keep the confirmation in
+      interactive sessions).
+    - `mur capability remove <name> --agent <agent>` — uninstall.
+
+    Bundles reference their contents rather than embedding copies, so an
+    installed capability tracks the shared skill store. Required
+    programs are verified against signed recipes at install time.
+tags: [mur, capability, agent, builtin]
+triggers:
+  - type: keyword
+    pattern: "(mur capability|install.{0,12}capability|capability bundle|能力包|(安裝|移除)能力)"
+  - type: manual
+priority: normal

--- a/mur-core/src/skills/mur_chat.yaml
+++ b/mur-core/src/skills/mur_chat.yaml
@@ -1,0 +1,39 @@
+name: mur-chat
+version: 0.1.0
+publisher: human:mur
+description: "Use when asked about past AI conversations — what did we discuss, find that conversation, 之前聊過, 對話紀錄."
+category: context
+hosts: [all]
+content:
+  abstract: |
+    The conversations archive keeps three layers: day index, summaries,
+    raw JSONL. `mur chat ask "question"` answers over the archive;
+    `search` does semantic + keyword lookup; `list`/`show`/`raw` walk
+    the layers directly.
+  context: |
+    # mur-chat — query the conversations archive
+
+    Past sessions across AI tools are archived in three layers. To
+    answer "what did we discuss about X":
+
+    - `mur chat ask "the question"` — natural-language answer over the
+      archive (`--since`/`--until`/`--src` narrow it, `--k` sets hits).
+    - `mur chat search "<query>"` — semantic + keyword hits
+      (`--limit`, `--src`).
+
+    Walking the layers directly:
+    - `mur chat list` — days in the archive (Layer 1 index).
+    - `mur chat show <day>` — a day's summary (Layer 2).
+    - `mur chat raw <conversation>` — raw JSONL (Layer 3) when the
+      summary is not enough.
+
+    Maintenance (only when asked or when `ask`/`search` come back
+    empty): `mur chat pull` ingests polling sources (Cursor / Gemini /
+    Aider), `mur chat reindex` rebuilds the vector index, `mur chat
+    doctor` runs archive health checks.
+tags: [mur, chat, archive, builtin]
+triggers:
+  - type: keyword
+    pattern: "(mur chat|(that|previous|past) conversation|what did we (discuss|talk about)|之前(聊過|討論|談過)|對話(紀錄|記錄|檔案))"
+  - type: manual
+priority: normal

--- a/mur-core/src/skills/mur_deep_research.yaml
+++ b/mur-core/src/skills/mur_deep_research.yaml
@@ -1,0 +1,39 @@
+name: mur-deep-research
+version: 0.1.0
+publisher: human:mur
+description: "Use when asked to research a topic, do web/deep research, or survey sources — 研究, 深入研究, 查資料, 調查."
+category: workflow
+hosts: [all]
+content:
+  abstract: |
+    MUR ships a native deep-research fleet. `mur deep-research "question"`
+    runs a guarded multi-agent research loop; bare shows status; `setup`
+    is the one-time wizard. Reach for it before hand-rolling web searches.
+  context: |
+    # mur-deep-research — native research fleet
+
+    When the user asks for research on a topic, check the fleet before
+    hand-rolling ad-hoc web searches:
+
+    1. `mur deep-research` (bare) — status panel: provisioned or not,
+       model, worker count, budget, egress state.
+    2. Not provisioned → `mur deep-research setup` — interactive wizard
+       (model, workers, budget, egress consent). Run it WITH the user:
+       egress consent is an explicit human decision, never assume it.
+    3. Provisioned → `mur deep-research "the question"` — preflight
+       checks, then a guarded fleet loop (iteration cap, deadline,
+       budget, kill-switch, RESEARCH_COMPLETE marker convergence).
+
+    Advanced flag-based path: `mur deep-research provision` creates
+    restricted worker agents that mount the `research-gateway` MCP
+    server (workers have no egress of their own; the per-server egress
+    grant is a separate consent step). `mur deep-research run` is a thin
+    wrapper over `mur fleet run --loop` — same guard rails.
+
+    Kill-switch: `mur fleet stop deep-research`.
+tags: [mur, deep-research, fleet, builtin]
+triggers:
+  - type: keyword
+    pattern: "(deep.?research|research (this|that|the web|into)|survey sources|literature review|幫我研究|深入研究|深度研究|查資料)"
+  - type: manual
+priority: normal

--- a/mur-core/src/skills/mur_notes.yaml
+++ b/mur-core/src/skills/mur_notes.yaml
@@ -1,0 +1,35 @@
+name: mur-notes
+version: 0.1.0
+publisher: human:mur
+description: "Use when saving or recalling free-form knowledge — note this down, what did we note about X, 筆記, 記下來, 查筆記."
+category: context
+hosts: [all]
+content:
+  abstract: |
+    Notes are category:note skills with markdown bodies — durable
+    free-form knowledge with maturity and decay. Create with
+    `mur notes create`, recall with `search`/`show`. Also exposed to AI
+    tools as the MCP tools `mur_notes_search` / `mur_notes_show`.
+  context: |
+    # mur-notes — durable free-form knowledge
+
+    - `mur notes create <name> -d "one-line description"` — body from
+      `--body-file <path>` or stdin. Name is kebab-case, ≤ 64 chars.
+      Pick `--kind rule` for behavioral guidance (fast decay) or the
+      default `--kind fact` for environment truths (slow decay).
+    - `mur notes search "<query>"` — rank existing notes by keyword.
+    - `mur notes list [--maturity <m>]` — browse.
+    - `mur notes show <name>` — print body + maturity (records a
+      retrieval, which feeds the maturity lifecycle).
+
+    Search BEFORE creating: a hit means update that note instead of
+    writing a near-duplicate.
+
+    From inside an AI conversation prefer the MCP tools
+    (`mur_notes_search`, `mur_notes_show`) — same store, no shell.
+tags: [mur, notes, knowledge, builtin]
+triggers:
+  - type: keyword
+    pattern: "(mur notes|note (this|that|it) down|what did we note|記(下來|個筆記)|查筆記|筆記)"
+  - type: manual
+priority: normal

--- a/mur-core/src/skills/mur_official.yaml
+++ b/mur-core/src/skills/mur_official.yaml
@@ -1,0 +1,38 @@
+name: mur-official
+version: 0.1.0
+publisher: human:mur
+description: "Use when browsing or installing official MUR agents/fleets from the catalog — official, 官方目錄, 官方 agent."
+category: workflow
+hosts: [all]
+content:
+  abstract: |
+    `mur official list` browses the app.mur.run catalog;
+    `mur official install <id>` downloads, verifies, and installs an
+    official agent or fleet. Install requires `mur login`; pro-tier
+    items need an active subscription.
+  context: |
+    # mur-official — the official catalog
+
+    - `mur official list` — official agents and fleets from app.mur.run.
+    - `mur official install <id>` — id form is `agents/<name>` or
+      `fleets/<name>`, e.g. `agents/researcher`, `fleets/deep-research`.
+
+    What install does for you: downloads the bundle, verifies its
+    signature, and stores an account-bound license under
+    `~/.mur/licenses/`. Expect these failure shapes:
+
+    - Not logged in → run `mur auth login` first (install requires it).
+    - Pro-tier item without an active subscription → the download is
+      refused; that is a subscription issue, not a bug.
+    - Importing an official-marked bundle that arrived some other way
+      (copied from a friend) → the import path refuses it without a
+      matching license. This anti-sharing gate is by design; do not try
+      to work around it.
+    - License expiry gates NEW downloads only — already-installed
+      content keeps working.
+tags: [mur, official, catalog, builtin]
+triggers:
+  - type: keyword
+    pattern: "(mur official|official (catalog|agent|fleet)|官方(目錄|代理|agent|fleet)|安裝官方)"
+  - type: manual
+priority: normal

--- a/mur-core/src/skills/mur_verification.yaml
+++ b/mur-core/src/skills/mur_verification.yaml
@@ -42,7 +42,9 @@ content:
     | Requirements met | Line-by-line checklist against the spec |
 
     A fleet member emitting its done_when marker or replying DONE is a claim,
-    not evidence. Check the diff.
+    not evidence. Check the diff. `mur open` labels outstanding items by
+    whether MUR observed them or an agent merely reported them — treat
+    reported-only items as unverified.
 
     ## Red flags
 

--- a/mur-core/src/skills/mur_workflow_hitl.yaml
+++ b/mur-core/src/skills/mur_workflow_hitl.yaml
@@ -1,5 +1,5 @@
 name: mur-workflow-hitl
-version: 0.1.0
+version: 0.2.0
 publisher: human:mur
 description: "Risk-tiered human approval gates on channel workflow runs: pause, approve/deny, resume."
 category: context
@@ -7,47 +7,40 @@ visibility: on_demand
 hosts: [all]
 content:
   abstract: |
-    Workflow-skill DAGs can include approval nodes that pause a run and
-    wait on a human. Gates are risk-tiered so low-risk steps auto-pass
-    while high-risk ones require an explicit approve/deny before the
-    workflow resumes.
+    Channel-attached workflow runs pause on risk-tiered HITL gates.
+    Read-tier steps run unattended; every mutating tier waits for
+    `mur channel approve` before the executor proceeds. Actions are
+    SHA-256-pinned and re-verified at the execute boundary.
   context: |
-    # Human-in-the-Loop Workflow Gates
+    # Human-in-the-Loop Workflow Gates (v3c)
 
     ## Risk tiers
-    Approval nodes declare a risk tier that decides who must respond
-    and how long the run will wait:
-    - **low** — informational; auto-approved unless a reviewer opts in.
-    - **medium** — requires one approval from any authorized reviewer.
-    - **high** — requires explicit approval from a named owner/role;
-      no timeout auto-approve.
-    Tier is set per-node in the DAG (`kind: approval`, `risk: low |
-    medium | high`).
+    Every step carries a risk tier, severity-ordered:
+    `read < write < network-egress < spend < destructive < privileged`.
+    Tier is resolved most-restrictive-wins and is NEVER LLM-asserted.
+    Default gate mode: `read` runs unattended (post-hoc audit event);
+    every other tier pauses and asks a human before execution.
 
-    ## Channel runs
-    When a workflow skill with approval nodes runs, MUR posts the
-    pending decision to the configured channel (chat, CLI session, or
-    notification target) attached to that run. The message includes
-    the step context, the risk tier, and the exact command to respond.
-    Multiple concurrent runs are distinguishable by run ID in the
-    channel message.
+    ## Attach a run to a channel
+    HITL gates only exist on channel-attached runs:
+    - `mur workflow run --channel-new <skill>` — new channel for this run.
+    - `mur workflow run --channel <id> <skill>` — append to an existing one.
+    A paused step writes a `HitlRequest` event (with `hitl_id`, the step
+    context, and the SHA-256 pin of the canonical action) into the
+    channel and waits.
 
-    ## Approve
-    - `mur workflow approve <run-id> [--step <id>]` — approve the
-      pending gate and let the DAG proceed to its next edge.
-    - `mur workflow deny <run-id> [--step <id>] [--reason "<text>"]` —
-      deny the gate; the run transitions to a failed/blocked state and
-      does not continue past that node.
+    ## Approve / deny
+    - `mur channel approve <channel_id> <hitl_id>` — approve; the
+      executor re-verifies the pinned hash at the execute boundary and
+      fails closed if the action drifted since the request.
+    - `mur channel approve <channel_id> <hitl_id> --deny [--reason "<msg>"]`
+      — deny; the run does not continue past that step.
 
-    ## Resume & auto
-    - `mur workflow resume <run-id>` — after approval, resumes execution
-      from the paused node if it didn't auto-continue.
-    - Low-tier gates may be configured with `auto_approve_after: <dur>`
-      to proceed automatically if no human responds within the window;
-      medium/high tiers never auto-approve regardless of timeout.
-    - A denied or timed-out high-tier gate leaves the run paused for
-      manual intervention rather than auto-failing silently.
+    ## Resume
+    Crashed or interrupted runs resume from the channel's `ToolResult`
+    cursor — re-run the same `mur workflow run --channel <id> <skill>`;
+    `append_event` is idempotency-key deduped, so replays are safe.
 
-    Ground truth: mur <cmd> --help · Full tutorial: https://app.mur.run/tutorials/mur-daily-jobs-cookbook.html
+    Ground truth: `mur channel --help` and `mur workflow run --help`.
 tags: [mur, workflow, hitl, context]
 priority: normal


### PR DESCRIPTION
## What

Scanned the top-level CLI surface against builtin skill coverage. Five user-facing commands had **no skill** teaching AI tools when to reach for them — an agent asked to "research X" or "what did we discuss" would never think of the MUR-native command:

- `mur-deep-research` — bare = status, `setup` = wizard (egress consent stays a human decision), question = guarded fleet run; kill-switch noted.
- `mur-capability` — list/show before install; `install <name> --agent <a>`; reference-not-embed semantics.
- `mur-official` — `agents/<name>` / `fleets/<name>` ids; login requirement, pro-tier refusal, anti-sharing license gate, expiry-gates-downloads-only — each as an expected failure shape, not a bug.
- `mur-notes` — create/search/list/show; search-before-create; prefer the MCP tools mid-conversation.
- `mur-chat` — ask/search first, then walk L1/L2/L3; maintenance subcommands only when retrieval comes back empty.

All five: trigger-only descriptions (bilingual keyword regexes), bodies within the 150-line budget, registered in `ensure_mur_skill` + the disclosure-budget test (`on_demand=false`, same as the other command-teaching skills).

## Bug fix found during the scan

`mur-workflow-hitl` taught a **nonexistent CLI**: `mur workflow approve/deny/resume <run-id>`, low/medium/high tiers, `auto_approve_after` — none of it exists. Agents following it would stall at every HITL gate. Rewritten against the real v3c surface (verified against `mur-common/src/hitl.rs` and `mur channel --help`): read<write<network-egress<spend<destructive<privileged, `mur workflow run --channel-new/--channel`, `mur channel approve <channel_id> <hitl_id> [--deny] [--reason]`, SHA-256 pin re-verified at the execute boundary, resume via ToolResult cursor.

`mur-verification` gains one line pointing at `mur open` (observed vs merely-reported = unverified).

## Verification

- `cargo test -p mur-core --lib sync_cmd` — 14 passed (includes the budget test over all new yamls)
- `cargo clippy -p mur-core --all-targets` clean; `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)