### PR TITLE
feat(update): accountable deploys — verified restarts, service kick, daemon restart, stale-writer notice

### DIFF
--- a/mur-core/src/cli/actions.rs
+++ b/mur-core/src/cli/actions.rs
@@ -84,6 +84,9 @@ pub enum DaemonAction {
     },
     /// Stop the murmurd daemon
     Stop,
+    /// Restart the murmurd daemon (stop, wait for the old pid to exit, start
+    /// detached) — the way to move a running daemon onto an upgraded binary
+    Restart,
     /// Show murmurd daemon status
     Status,
     /// Start the local API server for the web dashboard
@@ -115,6 +118,8 @@ pub enum MurmurdAction {
     },
     /// Stop the murmurd daemon
     Stop,
+    /// Restart the murmurd daemon (stop, wait, start detached)
+    Restart,
     /// Show murmurd daemon status
     Status,
 }

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -26,6 +26,11 @@ const RESTART_KILL_GRACE_SECS: u64 = 5;
 /// false-warns "did not respawn" on a restart that actually succeeded.
 const RESTART_RESPAWN_WAIT_SECS: u64 = 120;
 
+/// Second, shorter window after the active retry (service kick / re-spawn).
+/// The first window already absorbed the service manager's worst-case respawn
+/// latency; this one only needs to cover a fresh start.
+const RESTART_RETRY_WAIT_SECS: u64 = 30;
+
 /// Compute the total seconds to wait before firing the SIGKILL fallback.
 ///
 /// Pure helper so the math can be unit-tested independently of live processes.
@@ -129,6 +134,48 @@ pub(crate) fn select_targets_with_on_disk(
     Ok(targets)
 }
 
+/// One agent's restart outcome, for the end-of-run summary.
+struct RestartReport {
+    ok: bool,
+    detail: String,
+}
+
+/// Restart every agent in `targets`, then print a final verdict table. This
+/// is the accountability step: fire-and-forget restarts are exactly how a
+/// stopped concierge went unnoticed in the field. Errors and unconfirmed
+/// agents both fail the run — after the table, so the user sees the whole
+/// picture, not the first casualty.
+fn run_restarts(targets: &[String], agents_dir: &Path, on_disk: &str) -> Result<()> {
+    let mut reports: Vec<(String, RestartReport)> = Vec::new();
+    for agent_name in targets {
+        let report = match restart_one(agent_name, agents_dir, on_disk) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("error restarting '{agent_name}': {e:#}");
+                RestartReport {
+                    ok: false,
+                    detail: format!("'{agent_name}' restart errored: {e:#}"),
+                }
+            }
+        };
+        reports.push((agent_name.clone(), report));
+    }
+    let failed = reports.iter().filter(|(_, r)| !r.ok).count();
+    println!();
+    println!(
+        "restart summary — {}/{} confirmed running:",
+        reports.len() - failed,
+        reports.len()
+    );
+    for (_, r) in &reports {
+        println!("  {} {}", if r.ok { "✓" } else { "✗" }, r.detail);
+    }
+    if failed > 0 {
+        bail!("{failed} agent(s) not confirmed running — see the summary above");
+    }
+    Ok(())
+}
+
 /// Restart every STALE agent except the excluded names — the
 /// `mur update --restart-agents` entry point. Exclusions come from
 /// `update.restart_exclude` in `~/.mur/config.yaml` and are honored even when
@@ -155,17 +202,7 @@ pub fn restart_stale_excluding(exclude: &[String]) -> Result<()> {
     }
 
     let on_disk = stale::on_disk_sha();
-    let mut any_err = false;
-    for agent_name in &targets {
-        if let Err(e) = restart_one(agent_name, &agents_dir, &on_disk) {
-            eprintln!("error restarting '{agent_name}': {e}");
-            any_err = true;
-        }
-    }
-    if any_err {
-        bail!("one or more agents failed to restart");
-    }
-    Ok(())
+    run_restarts(&targets, &agents_dir, &on_disk)
 }
 
 /// Gracefully restart one or more agents.
@@ -207,23 +244,13 @@ pub fn cmd_restart(names: &[String], all: bool, stale: bool, dry_run: bool) -> R
     }
 
     let on_disk = stale::on_disk_sha();
-    let mut any_err = false;
-
-    for agent_name in &targets {
-        if let Err(e) = restart_one(agent_name, &agents_dir, &on_disk) {
-            eprintln!("error restarting '{agent_name}': {e}");
-            any_err = true;
-        }
-    }
-
-    if any_err {
-        bail!("one or more agents failed to restart");
-    }
-    Ok(())
+    run_restarts(&targets, &agents_dir, &on_disk)
 }
 
-/// Restart a single agent: SIGTERM, wait for exit, poll for fresh lock.
-fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<()> {
+/// Restart a single agent: SIGTERM, wait for exit, respawn, verify the fresh
+/// lock. `ok: false` means the agent was NOT confirmed running — never a
+/// silent note.
+fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<RestartReport> {
     let agent_home = agents_dir.join(name);
     let lock_path = agent_home.join("running.lock");
 
@@ -286,59 +313,37 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<()> {
     // (shared with the service-managed path) has a fresh process to find.
     if !has_service {
         println!("agent '{name}' has no service installed; respawning runtime directly");
-        let target = resolve_runtime_target();
-        let mur_home = resolve_mur_home()?;
-        let stderr_log = agent_home.join("stderr.log");
-        let stdout_file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&stderr_log)
-            .map_err(|e| {
-                anyhow::anyhow!("open {} for respawn stdout: {e}", stderr_log.display())
-            })?;
-        let stderr_file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&stderr_log)
-            .map_err(|e| {
-                anyhow::anyhow!("open {} for respawn stderr: {e}", stderr_log.display())
-            })?;
-        Command::new(&target)
-            .arg("--profile")
-            .arg(name)
-            .env("MUR_HOME", &mur_home)
-            .stdin(Stdio::null())
-            .stdout(stdout_file)
-            .stderr(stderr_file)
-            .spawn()
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "failed to respawn runtime for '{name}' at {}: {e}",
-                    target.display()
-                )
-            })?;
+        direct_respawn(name, &agent_home)?;
     }
 
     // ── Poll for fresh running.lock with a different pid ──────────────
     // launchd KeepAlive=true respawns on process exit; we wait up to
     // RESTART_RESPAWN_WAIT_SECS for the new lock to appear.
-    let respawn_deadline =
-        std::time::Instant::now() + std::time::Duration::from_secs(RESTART_RESPAWN_WAIT_SECS);
-    let new_pid = loop {
-        std::thread::sleep(std::time::Duration::from_millis(200));
-        if std::time::Instant::now() >= respawn_deadline {
-            break None;
-        }
-        if let Ok(Some(new_lock)) = read_lock(&lock_path)
-            && new_lock.pid != old_pid
-        {
-            break Some((new_lock.pid, new_lock.build_sha));
-        }
-    };
+    let mut new_pid = poll_new_lock(&lock_path, old_pid, RESTART_RESPAWN_WAIT_SECS);
 
-    match new_pid {
+    // ── Active retry ──────────────────────────────────────────────────
+    // The passive wait can fail two ways seen in the field: a service
+    // manager still tracking a ZOMBIE instance under a pid that was never
+    // the lock's (so from its side the job is "running" and KeepAlive never
+    // fires), and a direct respawn that died at boot (its stderr is in the
+    // agent's stderr.log). A service kick kills whatever instance the
+    // manager tracks and restarts from the unit; a serviceless agent just
+    // gets one more spawn. One retry, then a shorter window.
+    if new_pid.is_none() {
+        if has_service {
+            if kickstart_service(name) {
+                println!("agent '{name}': no respawn seen; kicked the service unit");
+            }
+        } else {
+            println!("agent '{name}': no respawn seen; retrying direct respawn");
+            direct_respawn(name, &agent_home)?;
+        }
+        new_pid = poll_new_lock(&lock_path, old_pid, RESTART_RETRY_WAIT_SECS);
+    }
+
+    Ok(match new_pid {
         Some((_pid, new_sha)) => {
-            println!(
+            let line = format!(
                 "agent '{name}' restarted ({} → {})",
                 short8(&old_sha),
                 short8(if new_sha.is_empty() {
@@ -347,17 +352,109 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<()> {
                     &new_sha
                 }),
             );
+            println!("{line}");
+            RestartReport {
+                ok: true,
+                detail: line,
+            }
         }
         None => {
-            eprintln!(
-                "note: '{name}' was stopped; its respawn was not seen within {RESTART_RESPAWN_WAIT_SECS} s — \
-                 launchd may still be bringing it up. Check 'mur agent runtime-doctor' shortly; \
-                 if it stays down, confirm launchd KeepAlive is enabled."
+            let line = format!(
+                "'{name}' not confirmed running within {}s — check `mur agent status {name}` and its stderr.log",
+                RESTART_RESPAWN_WAIT_SECS + RESTART_RETRY_WAIT_SECS
             );
+            eprintln!("✗ {line}");
+            RestartReport {
+                ok: false,
+                detail: line,
+            }
+        }
+    })
+}
+
+/// Spawn the runtime directly (detached) for an agent with no service unit.
+fn direct_respawn(name: &str, agent_home: &Path) -> Result<()> {
+    let target = resolve_runtime_target();
+    let mur_home = resolve_mur_home()?;
+    let stderr_log = agent_home.join("stderr.log");
+    let stdout_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&stderr_log)
+        .map_err(|e| anyhow::anyhow!("open {} for respawn stdout: {e}", stderr_log.display()))?;
+    let stderr_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&stderr_log)
+        .map_err(|e| anyhow::anyhow!("open {} for respawn stderr: {e}", stderr_log.display()))?;
+    Command::new(&target)
+        .arg("--profile")
+        .arg(name)
+        .env("MUR_HOME", &mur_home)
+        .stdin(Stdio::null())
+        .stdout(stdout_file)
+        .stderr(stderr_file)
+        .spawn()
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "failed to respawn runtime for '{name}' at {}: {e}",
+                target.display()
+            )
+        })?;
+    Ok(())
+}
+
+/// Wait up to `secs` for `lock_path` to hold a pid different from `old_pid`.
+fn poll_new_lock(lock_path: &Path, old_pid: u32, secs: u64) -> Option<(u32, String)> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        if std::time::Instant::now() >= deadline {
+            return None;
+        }
+        if let Ok(Some(new_lock)) = read_lock(lock_path)
+            && new_lock.pid != old_pid
+        {
+            return Some((new_lock.pid, new_lock.build_sha));
         }
     }
+}
 
-    Ok(())
+/// Actively (re)start the agent's service unit, killing whatever instance the
+/// service manager currently tracks — including a zombie whose pid never
+/// matched the lock's. Returns false when there is no service manager, the
+/// unit isn't loaded, or the command failed; callers treat that as "nothing
+/// kicked" and let the poll decide.
+#[cfg(target_os = "macos")]
+fn kickstart_service(name: &str) -> bool {
+    let uid = unsafe { libc::getuid() };
+    Command::new("launchctl")
+        .args([
+            "kickstart",
+            "-k",
+            &format!("gui/{uid}/run.mur.agent.{name}"),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+fn kickstart_service(name: &str) -> bool {
+    Command::new("systemctl")
+        .args(["--user", "restart", &format!("mur-agent-{name}")])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn kickstart_service(_name: &str) -> bool {
+    false
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────

--- a/mur-core/src/cmd/murmurd.rs
+++ b/mur-core/src/cmd/murmurd.rs
@@ -57,18 +57,23 @@ pub fn cmd_murmurd_stop() -> Result<()> {
     Ok(())
 }
 
-pub fn cmd_murmurd_start(detach: bool) -> Result<()> {
+/// The murmurd binary this `mur` would launch: a sibling of the current exe.
+fn murmurd_binary() -> Result<std::path::PathBuf> {
     let murmurd = std::env::current_exe()
         .ok()
         .and_then(|p| p.parent().map(|d| d.join("murmurd")))
         .unwrap_or_else(|| std::path::PathBuf::from("murmurd"));
-
     if !murmurd.exists() {
         anyhow::bail!(
             "murmurd binary not found at {}. Build with: cargo build -p mur-daemon",
             murmurd.display()
         );
     }
+    Ok(murmurd)
+}
+
+pub fn cmd_murmurd_start(detach: bool) -> Result<()> {
+    let murmurd = murmurd_binary()?;
 
     let mut cmd = std::process::Command::new(&murmurd);
     if detach {
@@ -83,4 +88,73 @@ pub fn cmd_murmurd_start(detach: bool) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// How long `restart` waits for the old daemon to exit before SIGKILL. The
+/// daemon's shutdown is quick (drop sockets, flush lock); this only guards a
+/// wedged process.
+const MURMURD_STOP_WAIT_SECS: u64 = 15;
+
+fn murmurd_lock_path() -> Result<std::path::PathBuf> {
+    Ok(dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("no home dir"))?
+        .join(".mur")
+        .join("murmurd.lock"))
+}
+
+/// Whether a murmurd instance is currently alive (lock exists AND its pid is).
+pub fn murmurd_running() -> bool {
+    let Ok(path) = murmurd_lock_path() else {
+        return false;
+    };
+    let Ok(s) = std::fs::read_to_string(&path) else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(&s)
+        .ok()
+        .and_then(|v| v.get("pid").and_then(|p| p.as_u64()))
+        .is_some_and(|pid| mur_common::lock_file::pid_alive(pid as u32))
+}
+
+/// `mur daemon restart` — stop the running daemon, WAIT for its pid to
+/// actually exit (plain `stop` returns the moment SIGTERM is sent, and a
+/// back-to-back start would race the dying process for the lock), then start
+/// a fresh one detached. The way a running daemon moves onto an upgraded
+/// binary — without this, murmurd keeps executing pre-upgrade code
+/// indefinitely.
+pub fn cmd_murmurd_restart() -> Result<()> {
+    // Resolve the replacement binary FIRST: stop-then-fail-to-start leaves
+    // the daemon down, which a smoke run demonstrated the hard way.
+    murmurd_binary()?;
+    let lock_path = murmurd_lock_path()?;
+    if let Ok(s) = std::fs::read_to_string(&lock_path) {
+        if let Some(pid) = serde_json::from_str::<serde_json::Value>(&s)
+            .ok()
+            .and_then(|v| v.get("pid").and_then(|p| p.as_u64()))
+        {
+            let pid = pid as u32;
+            if mur_common::lock_file::pid_alive(pid) {
+                #[cfg(unix)]
+                unsafe {
+                    libc::kill(pid as libc::pid_t, libc::SIGTERM);
+                }
+                let deadline = std::time::Instant::now()
+                    + std::time::Duration::from_secs(MURMURD_STOP_WAIT_SECS);
+                while std::time::Instant::now() < deadline && mur_common::lock_file::pid_alive(pid)
+                {
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+                if mur_common::lock_file::pid_alive(pid) {
+                    #[cfg(unix)]
+                    unsafe {
+                        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(200));
+                }
+                println!("murmurd stopped (pid {pid})");
+            }
+        }
+        let _ = std::fs::remove_file(&lock_path);
+    }
+    cmd_murmurd_start(true)
 }

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -114,6 +114,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             match action {
                 MurmurdAction::Start { detach } => cmd::murmurd::cmd_murmurd_start(detach)?,
                 MurmurdAction::Stop => cmd::murmurd::cmd_murmurd_stop()?,
+                MurmurdAction::Restart => cmd::murmurd::cmd_murmurd_restart()?,
                 MurmurdAction::Status => cmd::murmurd::cmd_murmurd_status()?,
             }
         }
@@ -1482,6 +1483,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Commands::Daemon { action } => match action {
             DaemonAction::Start { detach } => cmd::murmurd::cmd_murmurd_start(detach)?,
             DaemonAction::Stop => cmd::murmurd::cmd_murmurd_stop()?,
+            DaemonAction::Restart => cmd::murmurd::cmd_murmurd_restart()?,
             DaemonAction::Status => cmd::murmurd::cmd_murmurd_status()?,
             DaemonAction::Serve {
                 port,

--- a/mur-core/src/update/mod.rs
+++ b/mur-core/src/update/mod.rs
@@ -178,9 +178,64 @@ fn stale_hub_nudge_from(host_path_contents: &str, cli_version: &str) -> Option<S
     }
 }
 
+/// Best-effort, after an upgrade: name the mur-compress writer versions that
+/// were active in the last two days yet are older than this CLI. Those are
+/// long-lived processes outside `mur update`'s reach — the model gateway is
+/// the usual culprit — still executing pre-upgrade crates. One line, informed
+/// by the shared stats ledger; any read/parse problem stays silent.
+pub(crate) fn warn_stale_compress_writers() {
+    let home = crate::paths::mur_root(None);
+    let Ok(s) = std::fs::read_to_string(home.join("compress").join("stats.json")) else {
+        return;
+    };
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(&s) else {
+        return;
+    };
+    let today = chrono::Local::now().date_naive();
+    let days = [
+        today.to_string(),
+        today.pred_opt().map(|d| d.to_string()).unwrap_or_default(),
+    ];
+    let stale = stale_writer_versions(&v, &days, env!("CARGO_PKG_VERSION"));
+    if !stale.is_empty() {
+        println!(
+            "ℹ mur-compress writers on older crates were active recently: {} — \
+             a long-lived service outside this update (e.g. mur-model-gateway) \
+             is still on old code; rebuild/restart it to pick up current behavior.",
+            stale.join(", ")
+        );
+    }
+}
+
+/// Pure core of [`warn_stale_compress_writers`]: versions from the stats
+/// ledger's `buckets[version][date]` slices that recorded compressions on any
+/// of `days` and are strictly older than `current`.
+fn stale_writer_versions(stats: &serde_json::Value, days: &[String], current: &str) -> Vec<String> {
+    let Some(buckets) = stats.get("buckets").and_then(|b| b.as_object()) else {
+        return Vec::new();
+    };
+    let mut out: Vec<String> = buckets
+        .iter()
+        .filter(|(ver, _)| release::is_newer(ver, current).ok() == Some(true))
+        .filter(|(_, per_day)| {
+            days.iter().any(|d| {
+                per_day
+                    .get(d)
+                    .and_then(|s| s.get("compressions"))
+                    .and_then(|c| c.as_u64())
+                    .unwrap_or(0)
+                    > 0
+            })
+        })
+        .map(|(ver, _)| ver.clone())
+        .collect();
+    out.sort();
+    out
+}
+
 #[cfg(test)]
 mod tests {
-    use super::stale_hub_nudge_from;
+    use super::{stale_hub_nudge_from, stale_writer_versions};
 
     const HOST_PATH: &str = "/Applications/MUR Hub.app/Contents/MacOS/mur-hub-gui\n2.26.0";
 
@@ -200,5 +255,33 @@ mod tests {
         assert!(stale_hub_nudge_from("/only/a/path", "2.27.0").is_none());
         assert!(stale_hub_nudge_from("/path\n   ", "2.27.0").is_none());
         assert!(stale_hub_nudge_from("", "2.27.0").is_none());
+    }
+
+    /// The field shape: an old gateway bucket active today, current-version
+    /// buckets active too, and a dormant ancient bucket that must stay out.
+    #[test]
+    fn stale_writer_versions_names_active_old_buckets_only() {
+        let stats = serde_json::json!({
+            "buckets": {
+                "2.61.0": { "2026-08-05": { "compressions": 1500 } },
+                "2.66.0": { "2026-08-05": { "compressions": 40 } },
+                "2.40.1": { "2026-07-01": { "compressions": 9999 } },
+                "not-a-version": { "2026-08-05": { "compressions": 5 } }
+            }
+        });
+        let days = ["2026-08-05".to_string(), "2026-08-04".to_string()];
+        assert_eq!(
+            stale_writer_versions(&stats, &days, "2.66.0"),
+            vec!["2.61.0".to_string()],
+        );
+    }
+
+    #[test]
+    fn stale_writer_versions_silent_on_missing_buckets() {
+        let days = ["2026-08-05".to_string()];
+        assert!(stale_writer_versions(&serde_json::json!({}), &days, "2.66.0").is_empty());
+        assert!(
+            stale_writer_versions(&serde_json::json!({"buckets": 3}), &days, "2.66.0").is_empty()
+        );
     }
 }

--- a/mur-core/src/update/resign.rs
+++ b/mur-core/src/update/resign.rs
@@ -30,20 +30,35 @@ pub const SIGN_TARGETS: &[&str] = &[
 /// archive, when it shipped one — the authoritative source for refreshing the
 /// launchd copy (installed siblings can lag the self-update).
 ///
-/// Only the re-signing is macOS-specific. The checklist and the restart leg
-/// apply everywhere: an upgrade changes every binary's hash on any platform,
-/// which stales the running agents and their SHA-pinned MCP servers alike.
+/// Only the re-signing is macOS-specific. The checklist and the restart legs
+/// (agents + daemon) apply everywhere: an upgrade changes every binary's hash
+/// on any platform, which stales every long-lived process running the old one.
 #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
 pub fn post_upgrade(restart_agents: bool, fresh_runtime: Option<&std::path::Path>) -> Result<()> {
     #[cfg(target_os = "macos")]
     macos::resign_installed_binaries(fresh_runtime)?;
 
-    print_checklist();
+    let daemon_running = crate::cmd::murmurd::murmurd_running();
+    print_checklist(restart_agents, daemon_running);
 
-    if restart_agents {
-        crate::cmd::agent::restart_stale_excluding(&restart_exclusions())?;
+    let agents_result = if restart_agents {
+        crate::cmd::agent::restart_stale_excluding(&restart_exclusions())
+    } else {
+        Ok(())
+    };
+    // The daemon is a long-lived process like any agent: without a restart it
+    // keeps executing pre-upgrade code indefinitely. Runs even when the agent
+    // leg failed — a half-finished deploy should not also strand the daemon
+    // on the old binary. Best-effort: a daemon that will not come back must
+    // not turn a completed binary upgrade into an error.
+    if restart_agents && daemon_running {
+        println!("restarting murmurd onto the upgraded binary…");
+        if let Err(e) = crate::cmd::murmurd::cmd_murmurd_restart() {
+            eprintln!("warning: murmurd restart failed: {e:#} — run `mur daemon restart` manually");
+        }
     }
-    Ok(())
+    crate::update::warn_stale_compress_writers();
+    agents_result
 }
 
 fn load_config() -> mur_common::config::Config {
@@ -55,13 +70,23 @@ fn restart_exclusions() -> Vec<String> {
     load_config().update.restart_exclude
 }
 
-fn print_checklist() {
+/// Printed only when `--restart-agents` was NOT passed — with it, both legs
+/// run automatically and a checklist would just narrate them. The old advice
+/// to re-pin MCP servers after an upgrade is gone on purpose: the bundled
+/// server re-pins itself at agent start (`mur-agent-runtime/src/mcp_repin.rs`,
+/// #793) and third-party pins cover binaries an upgrade never touches.
+fn print_checklist(restart_agents: bool, daemon_running: bool) {
+    if restart_agents {
+        return;
+    }
     println!();
     println!("To finish the deploy:");
     println!("  1. Restart agents still running the old binary:");
     println!("       mur agent restart --stale        (or rerun with --restart-agents)");
-    println!("  2. Upgraded binaries have new hashes — refresh MCP pins per agent:");
-    println!("       mur agent mcp pin <agent> <server>");
+    if daemon_running {
+        println!("  2. Move the running daemon onto the new binary:");
+        println!("       mur daemon restart");
+    }
 }
 
 /// Identity precedence: config beats env; empty strings count as unset.


### PR DESCRIPTION
## Why

The v2.66.0 deploy on a real fleet (26 agents) surfaced every gap in `mur update --restart-agents`'s fire-and-forget design:

1. The concierge never respawned — one stderr note, easy to miss; it stayed down until manually started.
2. A service agent's launchd job was supervising a **weeks-old zombie pid** (with `last exit reason = OS_REASON_CODESIGNING` on record) that never matched the lock's pid — so from launchd's side the job was "running", KeepAlive never fired, and the passive 120s wait always timed out while `mur agent status` said stopped.
3. `brew upgrade` replaced the murmurd binary, but the running daemon kept executing pre-upgrade code indefinitely — nothing restarts the daemon.
4. The deploy checklist advised re-pinning MCP servers, which is wrong twice over: the bundled server re-pins itself at agent start (`mcp_repin.rs`, #793), and third-party pins cover binaries an upgrade never touches (verified: 13/13 pins CLEAN after the upgrade).
5. The model gateway (separate repo, long-lived service) was still writing compress records from 2.61.0 crates — invisible unless you know where to look.

## What

**Verified restarts with a final verdict** (`cmd/agent/restart.rs`): every restart run ends in a summary table (✓/✗ per agent); unconfirmed agents fail the run. On a missed respawn the retry is *active*: service agents get `launchctl kickstart -k` (kills whatever instance the service manager tracks — including the zombie shape above) / `systemctl --user restart`; serviceless agents get one more direct spawn; then a shorter second poll window (30s after the 120s first window).

**`mur daemon restart`** (`cmd/murmurd.rs`, both `daemon`/`murmurd` subcommand enums): resolves the replacement binary **before** stopping — a live smoke run proved stop-then-fail-to-start leaves the daemon down — then stops, waits for the pid to actually exit (SIGKILL fallback at 15s), starts detached. `mur update --restart-agents` now restarts a running murmurd automatically (best-effort; runs even when the agent leg failed so a half-finished deploy doesn't also strand the daemon).

**Checklist** (`update/resign.rs`): printed only when `--restart-agents` was not passed (with it, both legs run automatically); the MCP re-pin advice is removed.

**Stale-writer notice** (`update/mod.rs`): after an upgrade, name mur-compress writer versions active in the last two days that are older than this CLI (from the shared stats ledger's `buckets[version][date]`) — long-lived services outside `mur update`'s reach; the gateway is the usual culprit. Silent on any read/parse problem.

## Verification

- `cargo nextest -p mur-core --lib`: 2328/2328; clippy `--all-targets` clean; `cargo check --workspace --all-targets` clean
- New unit tests: stale-writer bucket selection (active-old named, current/dormant/malformed excluded)
- Live smoke on this machine: dev-build `daemon restart` refused before stopping when murmurd was missing beside the exe (real daemon untouched); after building murmurd, the happy path stopped the old pid and brought up a fresh one; brew daemon restored after

🤖 Generated with [Claude Code](https://claude.com/claude-code)