### PR TITLE
fix(restart): fail closed on unverified daemon stop, real iteration count on budget exit

### DIFF
--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1580,7 +1580,7 @@ impl TaskRunner {
                 .saturating_sub(start_tokens);
             if spent >= self.max_token_budget {
                 let msg = self
-                    .graceful_exit(client, &history, LoopStop::TokenBudget, &ledger)
+                    .graceful_exit(client, &history, LoopStop::TokenBudget, &ledger, iteration)
                     .await;
                 return Ok((
                     msg,
@@ -1772,7 +1772,7 @@ impl TaskRunner {
                     // sanitizes, but keeping history consistent is cheap.
                     history.push(RichMessage::ToolResults { results });
                     let msg = self
-                        .graceful_exit(client, &history, LoopStop::LoopDetected, &ledger)
+                        .graceful_exit(client, &history, LoopStop::LoopDetected, &ledger, iteration)
                         .await;
                     return Ok((
                         msg,
@@ -1808,7 +1808,7 @@ impl TaskRunner {
         }
 
         let msg = self
-            .graceful_exit(client, &history, LoopStop::MaxIterations, &ledger)
+            .graceful_exit(client, &history, LoopStop::MaxIterations, &ledger, iteration)
             .await;
         Ok((
             msg,
@@ -1829,6 +1829,7 @@ impl TaskRunner {
         history: &[crate::llm::RichMessage],
         reason: LoopStop,
         ledger: &crate::turn_ledger::TurnLedger,
+        iterations: u32,
     ) -> Message {
         use crate::llm::{LlmRequest, RichMessage};
 
@@ -1888,6 +1889,11 @@ impl TaskRunner {
                 LoopStop::TokenBudget => crate::turn_ledger::StopKind::TokenBudget,
                 LoopStop::LoopDetected => crate::turn_ledger::StopKind::LoopDetected,
             },
+            // Use the live counter passed in, not `ledger.iterations`: on the
+            // early-exit paths the caller's ledger was never updated with the
+            // current count, so trusting the field here would render "0
+            // iterations" even though the counter itself is correct.
+            iterations,
             ..ledger.clone()
         };
         settle(text, &ledger)
@@ -3516,6 +3522,7 @@ mod tests {
                 &history,
                 LoopStop::LoopDetected,
                 &crate::turn_ledger::TurnLedger::default(),
+                2,
             )
             .await;
         // Summary turn succeeded (not the fallback path).
@@ -3586,6 +3593,7 @@ mod tests {
                 &history,
                 LoopStop::MaxIterations,
                 &crate::turn_ledger::TurnLedger::default(),
+                3,
             )
             .await;
         let capped_text = text_of(&capped);
@@ -3601,6 +3609,7 @@ mod tests {
                 &history,
                 LoopStop::LoopDetected,
                 &crate::turn_ledger::TurnLedger::default(),
+                3,
             )
             .await;
         let other_text = text_of(&other);

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1808,7 +1808,13 @@ impl TaskRunner {
         }
 
         let msg = self
-            .graceful_exit(client, &history, LoopStop::MaxIterations, &ledger, iteration)
+            .graceful_exit(
+                client,
+                &history,
+                LoopStop::MaxIterations,
+                &ledger,
+                iteration,
+            )
             .await;
         Ok((
             msg,

--- a/mur-core/src/cmd/agent/restart.rs
+++ b/mur-core/src/cmd/agent/restart.rs
@@ -31,6 +31,12 @@ const RESTART_RESPAWN_WAIT_SECS: u64 = 120;
 /// latency; this one only needs to cover a fresh start.
 const RESTART_RETRY_WAIT_SECS: u64 = 30;
 
+/// Fallback `stop_timeout_secs` used when the agent's `profile.yaml` cannot be
+/// read or parsed. Kept as a named const (not a bare literal) so the value
+/// used in the SIGKILL-timing computation can never drift from the value
+/// reported in the operator-facing warning.
+const DEFAULT_STOP_TIMEOUT_SECS: u64 = 15;
+
 /// Compute the total seconds to wait before firing the SIGKILL fallback.
 ///
 /// Pure helper so the math can be unit-tested independently of live processes.
@@ -276,11 +282,24 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<Resta
     // cooperative drain can complete before we force-kill.
     let stop_timeout = {
         let pp = agent_home.join("profile.yaml");
-        fs::read_to_string(&pp)
+        match fs::read_to_string(&pp)
             .ok()
             .and_then(|y| serde_yaml_ng::from_str::<_AgentProfile>(&y).ok())
-            .map(|p| p.lifecycle.stop_timeout_secs)
-            .unwrap_or(15)
+        {
+            Some(p) => p.lifecycle.stop_timeout_secs,
+            None => {
+                // Profile missing/unreadable/malformed: fall back to the
+                // default, but say so — silently truncating an operator's
+                // configured drain window is exactly the kind of thing
+                // that only shows up as a mysteriously-killed agent later.
+                println!(
+                    "agent '{name}': could not read stop_timeout_secs from \
+                     {}; defaulting to {DEFAULT_STOP_TIMEOUT_SECS}s",
+                    pp.display()
+                );
+                DEFAULT_STOP_TIMEOUT_SECS
+            }
+        }
     };
 
     // ── SIGTERM (drain) ───────────────────────────────────────────────
@@ -333,6 +352,17 @@ fn restart_one(name: &str, agents_dir: &Path, on_disk_sha: &str) -> Result<Resta
         if has_service {
             if kickstart_service(name) {
                 println!("agent '{name}': no respawn seen; kicked the service unit");
+            } else {
+                // The service manager either has no unit loaded or the kick
+                // command itself failed. Don't leave the agent for dead on
+                // a passive poll alone — fall back to a direct spawn so a
+                // stale/removed unit doesn't strand the agent, and tell the
+                // operator the kick didn't work so they can investigate the
+                // unit if this keeps happening.
+                println!(
+                    "agent '{name}': service kickstart failed; falling back to direct respawn"
+                );
+                direct_respawn(name, &agent_home)?;
             }
         } else {
             println!("agent '{name}': no respawn seen; retrying direct respawn");

--- a/mur-core/src/cmd/murmurd.rs
+++ b/mur-core/src/cmd/murmurd.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 
 pub fn cmd_murmurd_status() -> Result<()> {
     let lock_path = dirs::home_dir()
@@ -127,12 +127,14 @@ pub fn cmd_murmurd_restart() -> Result<()> {
     // the daemon down, which a smoke run demonstrated the hard way.
     murmurd_binary()?;
     let lock_path = murmurd_lock_path()?;
-    if let Ok(s) = std::fs::read_to_string(&lock_path) {
-        if let Some(pid) = serde_json::from_str::<serde_json::Value>(&s)
-            .ok()
-            .and_then(|v| v.get("pid").and_then(|p| p.as_u64()))
-        {
-            let pid = pid as u32;
+    match std::fs::read_to_string(&lock_path) {
+        Ok(s) => {
+            let pid = serde_json::from_str::<serde_json::Value>(&s)
+                .context("murmurd.lock contains invalid JSON; refusing to restart blind")?
+                .get("pid")
+                .and_then(|p| p.as_u64())
+                .context("murmurd.lock has no 'pid' field; refusing to restart blind")?
+                as u32;
             if mur_common::lock_file::pid_alive(pid) {
                 #[cfg(unix)]
                 unsafe {
@@ -151,10 +153,45 @@ pub fn cmd_murmurd_restart() -> Result<()> {
                     }
                     std::thread::sleep(std::time::Duration::from_millis(200));
                 }
+                // Verify the kill actually took effect before we tell the
+                // caller it's safe to start a fresh instance — a wedged
+                // (D-state) process can survive SIGKILL, and starting a
+                // second daemon on top of a still-live one races both for
+                // the same lock and socket.
+                if mur_common::lock_file::pid_alive(pid) {
+                    bail!(
+                        "murmurd (pid {pid}) did not exit after SIGTERM/SIGKILL; \
+                         refusing to start a second instance. Investigate the \
+                         process manually (it may be wedged) before retrying."
+                    );
+                }
                 println!("murmurd stopped (pid {pid})");
             }
         }
-        let _ = std::fs::remove_file(&lock_path);
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // No lock file at all: nothing to stop, safe to proceed.
+        }
+        Err(e) => {
+            // Lock file exists but couldn't be read (permissions, transient
+            // I/O, truncated concurrent write). Treat this as "unknown
+            // state" rather than "not running" — starting a new daemon here
+            // could spawn a second instance alongside a live one.
+            return Err(e).context(format!(
+                "could not read murmurd lock at {}; refusing to restart blind \
+                 (daemon may still be running)",
+                lock_path.display()
+            ));
+        }
+    }
+    // Only remove the lock once we've either confirmed the old daemon is
+    // dead or confirmed there was none to begin with.
+    if let Err(e) = std::fs::remove_file(&lock_path) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            println!(
+                "warning: could not remove stale lock at {}: {e}",
+                lock_path.display()
+            );
+        }
     }
     cmd_murmurd_start(true)
 }

--- a/mur-core/src/cmd/murmurd.rs
+++ b/mur-core/src/cmd/murmurd.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 
 pub fn cmd_murmurd_status() -> Result<()> {
     let lock_path = dirs::home_dir()

--- a/mur-core/src/cmd/murmurd.rs
+++ b/mur-core/src/cmd/murmurd.rs
@@ -185,13 +185,13 @@ pub fn cmd_murmurd_restart() -> Result<()> {
     }
     // Only remove the lock once we've either confirmed the old daemon is
     // dead or confirmed there was none to begin with.
-    if let Err(e) = std::fs::remove_file(&lock_path) {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            println!(
-                "warning: could not remove stale lock at {}: {e}",
-                lock_path.display()
-            );
-        }
+    if let Err(e) = std::fs::remove_file(&lock_path)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        println!(
+            "warning: could not remove stale lock at {}: {e}",
+            lock_path.display()
+        );
     }
     cmd_murmurd_start(true)
 }

--- a/mur-core/src/update/resign.rs
+++ b/mur-core/src/update/resign.rs
@@ -262,23 +262,6 @@ mod macos {
         std::fs::rename(&tmp, dst)
     }
 
-    #[cfg(test)]
-    mod macos_tests {
-        use super::replace_file;
-
-        #[test]
-        fn replace_file_swaps_content_and_leaves_no_temp() {
-            let dir = tempfile::tempdir().unwrap();
-            let src = dir.path().join("src");
-            let dst = dir.path().join("mur-agent-runtime");
-            std::fs::write(&src, b"NEW").unwrap();
-            std::fs::write(&dst, b"OLD").unwrap();
-            replace_file(&src, &dst).unwrap();
-            assert_eq!(std::fs::read(&dst).unwrap(), b"NEW");
-            assert!(!dir.path().join("mur-agent-runtime.new").exists());
-        }
-    }
-
     /// `codesign --force -s <identity>` each target. Fail loud with every
     /// failure listed — a partially-signed install is exactly the silent state
     /// this feature exists to prevent.
@@ -330,6 +313,23 @@ mod macos {
             bail!("signature verification failed:\n  {}", bad.join("\n  "));
         }
         Ok(())
+    }
+
+    #[cfg(test)]
+    mod macos_tests {
+        use super::replace_file;
+
+        #[test]
+        fn replace_file_swaps_content_and_leaves_no_temp() {
+            let dir = tempfile::tempdir().unwrap();
+            let src = dir.path().join("src");
+            let dst = dir.path().join("mur-agent-runtime");
+            std::fs::write(&src, b"NEW").unwrap();
+            std::fs::write(&dst, b"OLD").unwrap();
+            replace_file(&src, &dst).unwrap();
+            assert_eq!(std::fs::read(&dst).unwrap(), b"NEW");
+            assert!(!dir.path().join("mur-agent-runtime.new").exists());
+        }
     }
 }
 


### PR DESCRIPTION
Deep code review of the restart / daemon-stop paths shipped in 08f4f047 (#883), plus the fixes. Every finding was verified against `origin/main` line-by-line before any code was touched.

The theme throughout: **the action failed, but the interface said it succeeded.**

## `murmurd restart` (`mur-core/src/cmd/murmurd.rs`)

1. **Fail-open on an unreadable lock file.** `if let Ok(s) = read_to_string(&lock_path)` meant any read/parse failure fell straight through to `cmd_murmurd_start(true)` — no stop attempted, no error surfaced. A truncated lock (concurrent write) or a permissions blip spawned a *second* daemon alongside a live one, and the only thing printed was the new daemon starting successfully.
   Now a `match`, with `NotFound` handled separately so "no daemon running" still starts cleanly. Any other error aborts:
   `could not read murmurd lock at <path>; refusing to restart blind (daemon may still be running)`

2. **"stopped" was printed without checking anything stopped.** After `SIGTERM` → wait → `SIGKILL` → `sleep(200ms)`, the code unconditionally printed `murmurd stopped (pid N)`, removed the lock, and started a new daemon. A process wedged in uninterruptible I/O produced a confident success message and two live daemons.
   Now re-checks `pid_alive(pid)` and aborts instead:
   `murmurd (pid N) did not exit after SIGTERM/SIGKILL; refusing to start a second instance. Investigate the process manually (it may be wedged) before retrying.`

3. **Lock removal error discarded.** `let _ = remove_file(&lock_path)` ran before any of the above was verified. Removal now happens only after the daemon is confirmed dead (or confirmed absent), and a genuine failure is reported: `warning: could not remove stale lock at <path>: <err>`. `NotFound` is filtered so the no-lock path stays quiet.

## `mur agent restart` (`mur-core/src/cmd/agent/restart.rs`)

4. **A failed service kick printed nothing at all.** `if kickstart_service(name) { println!(...) }` had no `else`. When the kick failed, execution fell into the passive poll and the operator got a generic `not confirmed running` — no way to tell "the kick never happened" from "the agent is just slow".

5. **The zombie-unit fallback was unreachable.** `has_service` is computed once, before signalling, and `direct_respawn` was wired only under `!has_service`. If the launchd unit was unloaded or removed in that window, `kickstart_service` returned false and the agent was left dead — precisely the scenario 08f4f047 set out to fix. 4 and 5 share a fix: the `else` branch now reports and falls through to a direct respawn.
   `agent '<name>': service kickstart failed; falling back to direct respawn`

6. **Configured drain time silently replaced by a hardcoded 15.** `.unwrap_or(15)` on the `stop_timeout_secs` read meant a transient profile read/parse failure quietly cut an operator's configured 60s drain to 15s, violating the guarantee the module's own doc comment states. Now a named `DEFAULT_STOP_TIMEOUT_SECS` const, interpolated into the message so the text cannot drift from the value:
   `agent '<name>': could not read stop_timeout_secs from <path>; defaulting to 15s`

## Runtime settlement card (`mur-agent-runtime/src/task_runner.rs`)

7. **`(0 iterations)` on every budget stop.** The settlement card renders `ledger.iterations`, but that field was assigned only on the normal path. All three early exits — `TokenBudget`, `LoopDetected`, `MaxIterations` — handed `graceful_exit` a default-constructed ledger, so a turn that ran 28 tool calls reported `stopped at iteration cap (0 iterations)`. The correct count was sitting right there in the `LoopExit` returned on the next line.
   `graceful_exit` now takes the live count explicitly and overrides the field at render time, so the two cannot disagree.

## Clippy

- `style(update): move items above the test module` — `clippy::items_after_test_module` in `update/resign.rs`, pre-existing from 08f4f047, not from this diff. Pure code movement (17 insertions / 17 deletions), no logic change. CI runs `--all-targets -D warnings`, so it had to go for this branch to be green.
- `fix(restart): collapse nested if` — `clippy::collapsible_if` introduced by finding 3's own fix. Collapsed into an edition-2024 let-chain.

## Verification

- `cargo check -p mur-core` — clean
- `cargo clippy -p mur-core --all-targets` — clean (only the pre-existing third-party `proc-macro-error2` future-incompat note remains)
- `cargo check -p mur-agent-runtime --all-targets` — clean
- `cargo nextest run -p mur-agent-runtime` — 831 passed, 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
