### PR TITLE
fix(cli): show the approval modal when the inline row could not be attached

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -326,6 +326,10 @@ pub struct App {
     pub turn_produced_output: bool,
     pub streaming: bool,
     pub hitl: Option<HitlRequest>,
+    /// True when the current `hitl` was attached to a step card (inline
+    /// approval row shown there) rather than left unattached. Drives whether
+    /// the centered modal is also needed — see `mark_card_awaiting`.
+    pub hitl_inline_shown: bool,
     pub session: Session,
     /// Cached live-channel id + state for status bar. Refreshed after each
     /// persisted turn on resume/switch. `None` until first append.
@@ -515,6 +519,7 @@ impl App {
             turn_produced_output: false,
             streaming: false,
             hitl: None,
+            hitl_inline_shown: false,
             session,
             channel: None,
             scroll_back: 0,
@@ -940,7 +945,10 @@ impl App {
     }
 
     /// Flag the card with this `step_id` as awaiting a HITL decision.
-    pub fn mark_card_awaiting(&mut self, step_id: &str) {
+    /// Returns whether a matching card was actually found: the approval
+    /// gate fires before the step card exists in the common case, so the
+    /// caller must not assume a `step_id` implies the inline row is shown.
+    pub fn mark_card_awaiting(&mut self, step_id: &str) -> bool {
         if let Some(card) = self
             .messages
             .iter_mut()
@@ -948,6 +956,9 @@ impl App {
             .find_map(|m| m.step.as_mut().filter(|c| c.id == step_id))
         {
             card.awaiting_hitl = true;
+            true
+        } else {
+            false
         }
     }
 
@@ -1982,6 +1993,25 @@ mod awaiting_tests {
         a.clear_card_awaiting("s1");
         let card = a.messages.iter().find_map(|m| m.step.as_ref()).unwrap();
         assert!(!card.awaiting_hitl);
+    }
+
+    #[test]
+    fn mark_card_awaiting_reports_whether_it_found_a_card() {
+        let mut a = App::test_fixture();
+        a.begin_user_turn("edit it");
+        a.push_step_started(
+            "s1".into(),
+            "edit".into(),
+            serde_json::json!({"file_path":"a.rs"}),
+        );
+        a.update_step_completed("s1", true, "ok".into(), false, 2, None, 5);
+
+        // No card exists for this step_id: the caller must be told so it can
+        // fall back to the modal instead of assuming inline approval worked.
+        assert!(!a.mark_card_awaiting("no-such-step"));
+
+        // A card exists for "s1": attachment succeeds and is reported.
+        assert!(a.mark_card_awaiting("s1"));
     }
 }
 

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -1742,9 +1742,10 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
         StreamMsg::Delta { text, thinking, .. } => app.append_delta(&text, thinking),
         StreamMsg::Hitl { req, .. } => {
             app.saw_hitl_this_turn = true;
-            if let Some(sid) = req.step_id.clone() {
-                app.mark_card_awaiting(&sid);
-            }
+            app.hitl_inline_shown = req
+                .step_id
+                .clone()
+                .is_some_and(|sid| app.mark_card_awaiting(&sid));
             // Session auto-approval: `/auto`/`--auto` covers every tool; the
             // modal's [a] key covers a single tool name.
             // Read lane: `--auto-reads` auto-approves read-only bash commands.

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -77,10 +77,16 @@ pub fn render(f: &mut Frame, app: &mut App) {
     f.render_widget(&app.input, chunks[3]);
     render_status(f, app, chunks[4]);
 
-    // Inline approval lives on the card (Task 4) when the runtime sent a
-    // step_id. Fall back to the centered modal only for older runtimes.
+    // The centered modal is the fallback whenever the approval was NOT
+    // attached to a step card's inline row. We key this on actual
+    // attachment (`hitl_inline_shown`), not on whether the runtime sent a
+    // step_id: the approval gate commonly fires before the step card
+    // exists, so `mark_card_awaiting` silently finds nothing even though
+    // step_id is Some — gating on step_id alone left the operator with
+    // neither the modal nor the inline row. Do not revert to a
+    // step_id.is_none() check.
     if let Some(hitl) = &app.hitl
-        && hitl.step_id.is_none()
+        && !app.hitl_inline_shown
     {
         render_hitl(f, hitl);
     }


### PR DESCRIPTION
The murmur TUI never showed me which tool it was asking me to approve. Driving a worker agent for a full session, I approved more than a dozen tool calls blind — the only thing on screen was a status-bar line, truncated mid-sentence:

```
tool approval needed (auto-deny in 289s) — [
```

At 79 columns the option keys are gone entirely. At 112 you get about half of them. At no width does it say *which tool* or *what arguments*.

## The widget already existed

`ui.rs:1203 render_hitl` draws a proper centered modal: the prompt, the tool name, the pretty-printed `tool_input`, and every option key. It was simply never reaching the screen. The call at `ui.rs:82` was guarded like this:

```rust
// Inline approval lives on the card (Task 4) when the runtime sent a
// step_id. Fall back to the centered modal only for older runtimes.
if let Some(hitl) = &app.hitl
    && hitl.step_id.is_none()
{
    render_hitl(f, hitl);
}
```

The assumption is that a `step_id` means the approval is being shown inline on that step's card instead. But `mod.rs:1743` handles `StreamMsg::Hitl` by calling `app.mark_card_awaiting(&sid)`, and `app.rs:945` implements that as a `find_map` over messages that **does nothing at all** when no card matches — which is the ordinary case, because the approval gate fires *before* the step card is created.

So with any current runtime: `step_id` is `Some`, the modal is suppressed, the inline row has no card to attach to, and the truncated status line is all that survives.

## Fix

`mark_card_awaiting` now returns whether it actually found a card, `mod.rs` records that as `app.hitl_inline_shown`, and the modal renders whenever the approval was *not* attached anywhere. The condition is now about attachment rather than about `step_id`, which is what it should have been asking all along — the old check covered legacy runtimes by accident and this silent-miss case not at all.

The inline row still wins when a card genuinely exists, so nothing regresses for the case the original code was written for.

A regression test sits next to the existing `mark_and_clear_awaiting_by_step_id` test: `mark_card_awaiting` must return `false` for a missing `step_id` and `true` for one that exists. It fails if anyone reverts the return type.

## Verification

- `cargo clippy -p mur-core --all-targets` — clean (only the pre-existing third-party `proc-macro-error2` future-incompat note)
- `cargo fmt --all --check` — clean
- `cargo nextest run -p mur-core -E 'test(mark_card)'` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
