### PR TITLE
fix(runtime): carry tool status structurally so output text cannot forge it

### DIFF
--- a/mur-agent-runtime/src/llm/anthropic.rs
+++ b/mur-agent-runtime/src/llm/anthropic.rs
@@ -780,6 +780,7 @@ mod tests {
                     call_id: "id1".into(),
                     content: "hi\n".into(),
                     is_error: false,
+                    status: crate::tools::ToolStatus::Ok,
                 }],
             },
         ];
@@ -857,6 +858,7 @@ mod tests {
                     call_id: "c1".into(),
                     content: "ok".into(),
                     is_error: false,
+                    status: crate::tools::ToolStatus::Ok,
                 }],
             },
             RichMessage::Text {

--- a/mur-agent-runtime/src/llm/mod.rs
+++ b/mur-agent-runtime/src/llm/mod.rs
@@ -82,6 +82,8 @@ pub struct ToolResultEntry {
     pub call_id: String,
     pub content: String,
     pub is_error: bool,
+    #[serde(default)]
+    pub status: crate::tools::ToolStatus,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/mur-agent-runtime/src/llm/openai.rs
+++ b/mur-agent-runtime/src/llm/openai.rs
@@ -554,6 +554,7 @@ mod tests {
                     call_id: "call_abc".into(),
                     content: "hi\n".into(),
                     is_error: false,
+                    status: crate::tools::ToolStatus::Ok,
                 }],
             },
         ];

--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1276,6 +1276,9 @@ impl TaskRunner {
                 call_id: call.call_id.clone(),
                 content: format!("unknown tool: {}", call.tool_name),
                 is_error: true,
+                status: crate::tools::ToolStatus::Denied {
+                    detail: format!("unknown tool: {}", call.tool_name),
+                },
             });
         }
 
@@ -1308,6 +1311,9 @@ impl TaskRunner {
                         call_id: call.call_id.clone(),
                         content: format!("Tool `{}` is denied by policy.", call.tool_name),
                         is_error: true,
+                        status: crate::tools::ToolStatus::Denied {
+                            detail: format!("Tool `{}` is denied by policy.", call.tool_name),
+                        },
                     });
                 }
                 ToolPolicy::Allow => {
@@ -1328,9 +1334,13 @@ impl TaskRunner {
                             .await;
                     }
                     let t0 = std::time::Instant::now();
-                    let (output, is_error) = match tool.execute(call.input.clone()).await {
-                        Ok(out) => (out, false),
-                        Err(e) => (format!("tool error: {e}"), true),
+                    let (output, status, is_error) = match tool.execute(call.input.clone()).await {
+                        Ok(out) => (out.text, out.status, false),
+                        Err(e) => (
+                            format!("tool error: {e}"),
+                            crate::tools::ToolStatus::Failed { exit_code: -1 },
+                            true,
+                        ),
                     };
                     if let Some(ref n) = step_notifier {
                         let (out, truncated, full_len) = cap_step_output(&output);
@@ -1358,6 +1368,7 @@ impl TaskRunner {
                         call_id: call.call_id.clone(),
                         content: output,
                         is_error,
+                        status,
                     });
                 }
                 ToolPolicy::Ask => {
@@ -1440,9 +1451,13 @@ impl TaskRunner {
                 .await;
         }
         let t0_ask = std::time::Instant::now();
-        let (output, is_error) = match tool.execute(call.input.clone()).await {
-            Ok(out) => (out, false),
-            Err(e) => (format!("tool error: {e}"), true),
+        let (output, status, is_error) = match tool.execute(call.input.clone()).await {
+            Ok(out) => (out.text, out.status, false),
+            Err(e) => (
+                format!("tool error: {e}"),
+                crate::tools::ToolStatus::Failed { exit_code: -1 },
+                true,
+            ),
         };
         if let Some(ref n) = step_notifier {
             let (out, truncated, full_len) = cap_step_output(&output);
@@ -1474,6 +1489,7 @@ impl TaskRunner {
             call_id: call.call_id.clone(),
             content: output,
             is_error,
+            status,
         })
     }
 
@@ -1754,7 +1770,11 @@ impl TaskRunner {
                 ledger.record(crate::turn_ledger::Action {
                     tool: call.tool_name.clone(),
                     target: crate::turn_ledger::describe_target(&call.tool_name, &call.input),
-                    outcome: crate::turn_ledger::classify(&entry.content, entry.is_error),
+                    outcome: crate::turn_ledger::classify(
+                        &entry.content,
+                        entry.is_error,
+                        &entry.status,
+                    ),
                 });
                 let fp = (
                     call.tool_name.clone(),
@@ -1993,6 +2013,7 @@ fn sanitize_dangling_tool_uses(
                     call_id: c.call_id.clone(),
                     content: format!("[stopped: {}]", reason.as_str()),
                     is_error: true,
+                    status: crate::tools::ToolStatus::Ok,
                 })
                 .collect();
             if !missing.is_empty() {
@@ -2260,11 +2281,13 @@ mod tests {
                 call_id: "c1".into(),
                 content: "this is a large tool output".into(),
                 is_error: false,
+                status: crate::tools::ToolStatus::Ok,
             },
             ToolResultEntry {
                 call_id: "c2".into(),
                 content: "ok".into(),
                 is_error: false,
+                status: crate::tools::ToolStatus::Ok,
             },
         ];
         runner.apply_post_tool_use(&calls, &mut results).await;
@@ -2610,9 +2633,9 @@ mod tests {
         async fn execute(
             &self,
             _input: serde_json::Value,
-        ) -> Result<String, crate::tools::ToolError> {
+        ) -> Result<crate::tools::ToolOutput, crate::tools::ToolError> {
             self.calls.fetch_add(1, Ordering::Relaxed);
-            Ok("ran".into())
+            Ok("ran".to_string().into())
         }
     }
 
@@ -2637,9 +2660,9 @@ mod tests {
         async fn execute(
             &self,
             _input: serde_json::Value,
-        ) -> Result<String, crate::tools::ToolError> {
+        ) -> Result<crate::tools::ToolOutput, crate::tools::ToolError> {
             self.calls.fetch_add(1, Ordering::Relaxed);
-            Ok("fleet ran".into())
+            Ok("fleet ran".to_string().into())
         }
     }
 
@@ -3334,10 +3357,10 @@ mod tests {
         async fn execute(
             &self,
             _input: serde_json::Value,
-        ) -> Result<String, crate::tools::ToolError> {
+        ) -> Result<crate::tools::ToolOutput, crate::tools::ToolError> {
             let n = self.calls.fetch_add(1, Ordering::Relaxed);
             // Distinct content each call -> distinct result fingerprint.
-            Ok(format!("build output #{n}"))
+            Ok(format!("build output #{n}").into())
         }
     }
 
@@ -3360,8 +3383,8 @@ mod tests {
         async fn execute(
             &self,
             _input: serde_json::Value,
-        ) -> Result<String, crate::tools::ToolError> {
-            Ok("identical build output".into())
+        ) -> Result<crate::tools::ToolOutput, crate::tools::ToolError> {
+            Ok("identical build output".to_string().into())
         }
     }
 

--- a/mur-agent-runtime/src/tools/bash.rs
+++ b/mur-agent-runtime/src/tools/bash.rs
@@ -3,7 +3,7 @@ use tokio::process::Command;
 
 use mur_common::agent_facts::{ExecRoutes, who_can_exec};
 
-use super::{ToolError, ToolExecutor};
+use super::{ToolError, ToolExecutor, ToolOutput, ToolStatus};
 use crate::exec_dirs;
 use crate::llm::ToolDef;
 
@@ -212,7 +212,7 @@ Commands are killed after `timeout_secs` (default {DEFAULT_TIMEOUT_SECS}s, max {
         }
     }
 
-    async fn execute(&self, input: serde_json::Value) -> Result<String, ToolError> {
+    async fn execute(&self, input: serde_json::Value) -> Result<ToolOutput, ToolError> {
         let command = input["command"]
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput("missing 'command' field".into()))?
@@ -286,6 +286,7 @@ Commands are killed after `timeout_secs` (default {DEFAULT_TIMEOUT_SECS}s, max {
             }
             combined.push_str(&stderr);
         }
+        let mut status = ToolStatus::Ok;
         if !output.status.success() {
             let code = output.status.code().unwrap_or(-1);
             if !combined.is_empty() {
@@ -297,11 +298,18 @@ Commands are killed after `timeout_secs` (default {DEFAULT_TIMEOUT_SECS}s, max {
             {
                 let cwd = working_dir.canonicalize().unwrap_or(working_dir.clone());
                 let routes = who_can_exec(mur_home, agent, &bin, Some(&cwd));
-                combined.push_str(&spawn_denied_hint(&bin, agent, &routes));
+                let hint = spawn_denied_hint(&bin, agent, &routes);
+                combined.push_str(&hint);
+                status = ToolStatus::Denied { detail: hint };
+            } else {
+                status = ToolStatus::Failed { exit_code: code };
             }
         }
 
-        Ok(combined)
+        Ok(ToolOutput {
+            text: combined,
+            status,
+        })
     }
 }
 
@@ -342,7 +350,7 @@ mod tests {
             .execute(serde_json::json!({"command": "echo hello"}))
             .await
             .unwrap();
-        assert!(out.contains("hello"), "got: {out}");
+        assert!(out.text.contains("hello"), "got: {}", out.text);
     }
 
     #[cfg(unix)]
@@ -353,7 +361,7 @@ mod tests {
             .execute(serde_json::json!({"command": "echo err >&2"}))
             .await
             .unwrap();
-        assert!(out.contains("err"), "got: {out}");
+        assert!(out.text.contains("err"), "got: {}", out.text);
     }
 
     #[tokio::test]
@@ -498,8 +506,9 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            out.contains("/opt/homebrew/bin"),
-            "spawned shell's PATH should include the standard dirs, got: {out}"
+            out.text.contains("/opt/homebrew/bin"),
+            "spawned shell's PATH should include the standard dirs, got: {}",
+            out.text
         );
     }
 

--- a/mur-agent-runtime/src/tools/edit_file.rs
+++ b/mur-agent-runtime/src/tools/edit_file.rs
@@ -5,7 +5,7 @@ use mur_common::agent::FilesystemEntitlement;
 
 use crate::llm::ToolDef;
 use crate::tools::fs_policy::{SessionCwd, check_write_entitlement};
-use crate::tools::{ToolError, ToolExecutor};
+use crate::tools::{ToolError, ToolExecutor, ToolOutput};
 
 pub struct EditFileTool {
     pub session_cwd: SessionCwd,
@@ -42,7 +42,7 @@ impl ToolExecutor for EditFileTool {
         }
     }
 
-    async fn execute(&self, input: serde_json::Value) -> Result<String, ToolError> {
+    async fn execute(&self, input: serde_json::Value) -> Result<ToolOutput, ToolError> {
         let raw = input["path"]
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput("missing 'path' field".into()))?;
@@ -95,10 +95,7 @@ impl ToolExecutor for EditFileTool {
                 "write", &canonical, &base, &e,
             ))
         })?;
-        Ok(format!(
-            "replaced {found} occurrence(s) in {}",
-            canonical.display()
-        ))
+        Ok(format!("replaced {found} occurrence(s) in {}", canonical.display()).into())
     }
 }
 
@@ -177,7 +174,7 @@ mod tests {
             .execute(serde_json::json!({"path": "f.txt", "old_string": "X", "new_string": "Y", "expected_count": 2}))
             .await
             .unwrap();
-        assert!(r.contains("replaced 2"));
+        assert!(r.text.contains("replaced 2"));
         assert_eq!(
             std::fs::read_to_string(td.path().join("f.txt")).unwrap(),
             "Y and Y"

--- a/mur-agent-runtime/src/tools/fleet_run.rs
+++ b/mur-agent-runtime/src/tools/fleet_run.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 
 use tokio::process::Command;
 
-use super::{ToolError, ToolExecutor};
+use super::{ToolError, ToolExecutor, ToolOutput};
 use crate::llm::ToolDef;
 
 pub const FLEET_RUN: &str = "fleet_run";
@@ -101,7 +101,7 @@ Long-running: default timeout {DEFAULT_TIMEOUT_SECS}s (max {MAX_TIMEOUT_SECS}s).
         }
     }
 
-    async fn execute(&self, input: serde_json::Value) -> Result<String, ToolError> {
+    async fn execute(&self, input: serde_json::Value) -> Result<ToolOutput, ToolError> {
         let fleet = input
             .get("fleet")
             .and_then(|v| v.as_str())
@@ -201,7 +201,7 @@ Long-running: default timeout {DEFAULT_TIMEOUT_SECS}s (max {MAX_TIMEOUT_SECS}s).
                 .collect();
             combined = format!("[output truncated to last {MAX_OUTPUT_CHARS} chars]\n…{tail}");
         }
-        Ok(combined)
+        Ok(combined.into())
     }
 }
 

--- a/mur-agent-runtime/src/tools/mcp.rs
+++ b/mur-agent-runtime/src/tools/mcp.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use tokio::sync::Mutex;
 
-use super::{ToolError, ToolExecutor};
+use super::{ToolError, ToolExecutor, ToolOutput};
 use crate::llm::ToolDef;
 use crate::mcp::pool::McpPool;
 use crate::protocol::mcp_client::McpClient;
@@ -69,7 +69,7 @@ impl ToolExecutor for McpToolExecutor {
         self.def.clone()
     }
 
-    async fn execute(&self, input: Value) -> Result<String, ToolError> {
+    async fn execute(&self, input: Value) -> Result<ToolOutput, ToolError> {
         let client_arc: Arc<Mutex<McpClient>> = self
             .pool
             .client(&self.server)
@@ -108,7 +108,7 @@ impl ToolExecutor for McpToolExecutor {
         if is_error {
             Err(ToolError::Execution(text))
         } else {
-            Ok(text)
+            Ok(text.into())
         }
     }
 }

--- a/mur-agent-runtime/src/tools/mod.rs
+++ b/mur-agent-runtime/src/tools/mod.rs
@@ -23,9 +23,47 @@ pub enum ToolError {
     InvalidInput(String),
 }
 
+/// Structural status of a tool execution.
+///
+/// This exists because the bash tool used to encode exit code and sandbox
+/// denial as text markers (e.g. `"[exit code: N]"`, `"[sandbox] ..."`) glued
+/// onto the end of its plain-`String` output. Downstream code then grepped
+/// those markers back out of the string. That let file *content* forge
+/// execution status: reading a file that merely happened to contain the
+/// marker text made a successful read render as a sandbox denial. Status now
+/// travels as data, structurally, alongside the text - never inside it.
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub enum ToolStatus {
+    #[default]
+    Ok,
+    Failed {
+        exit_code: i32,
+    },
+    Denied {
+        detail: String,
+    },
+}
+
+/// Result of a tool execution: the model-facing text plus the real,
+/// structural execution status (see [`ToolStatus`]).
+#[derive(Debug, Clone)]
+pub struct ToolOutput {
+    pub text: String,
+    pub status: ToolStatus,
+}
+
+impl From<String> for ToolOutput {
+    fn from(text: String) -> Self {
+        ToolOutput {
+            text,
+            status: ToolStatus::Ok,
+        }
+    }
+}
+
 #[async_trait::async_trait]
 pub trait ToolExecutor: Send + Sync {
     fn name(&self) -> &str;
     fn def(&self) -> ToolDef;
-    async fn execute(&self, input: serde_json::Value) -> Result<String, ToolError>;
+    async fn execute(&self, input: serde_json::Value) -> Result<ToolOutput, ToolError>;
 }

--- a/mur-agent-runtime/src/tools/open_item.rs
+++ b/mur-agent-runtime/src/tools/open_item.rs
@@ -12,7 +12,7 @@
 //! deleting a line, and the display already marks every item here as the
 //! agent's unverified claim.
 
-use crate::tools::{ToolDef, ToolError, ToolExecutor};
+use crate::tools::{ToolDef, ToolError, ToolExecutor, ToolOutput};
 
 pub const OPEN_ITEM: &str = "open_item";
 
@@ -60,11 +60,11 @@ previous call to clear one."
         }
     }
 
-    async fn execute(&self, input: serde_json::Value) -> Result<String, ToolError> {
+    async fn execute(&self, input: serde_json::Value) -> Result<ToolOutput, ToolError> {
         if let Some(id) = input.get("resolve").and_then(|v| v.as_str()) {
             mur_open_items::resolve(&self.mur_home, id)
                 .map_err(|e| ToolError::Execution(format!("resolve open item: {e:#}")))?;
-            return Ok(format!("Resolved open item {id}."));
+            return Ok(format!("Resolved open item {id}.").into());
         }
 
         let title = input
@@ -99,7 +99,8 @@ previous call to clear one."
         Ok(format!(
             "Recorded as {id}. The user sees it under \"reported\" in `mur open`, marked as your \
 unverified claim."
-        ))
+        )
+        .into())
     }
 }
 
@@ -126,7 +127,12 @@ mod tests {
         assert_eq!(mur_open_items::open(tmp.path()).len(), 1);
 
         // The id is in the reply so the model can clear it next turn.
-        let id = out.split_whitespace().nth(2).unwrap().trim_end_matches('.');
+        let id = out
+            .text
+            .split_whitespace()
+            .nth(2)
+            .unwrap()
+            .trim_end_matches('.');
         t.execute(serde_json::json!({"resolve": id})).await.unwrap();
         assert!(mur_open_items::open(tmp.path()).is_empty());
     }

--- a/mur-agent-runtime/src/tools/read_file.rs
+++ b/mur-agent-runtime/src/tools/read_file.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use mur_common::agent::FilesystemEntitlement;
 
 use crate::llm::ToolDef;
-use crate::tools::{ToolError, ToolExecutor};
+use crate::tools::{ToolError, ToolExecutor, ToolOutput};
 
 /// Hard ceiling on returned bytes so a huge file cannot blow up the turn.
 const MAX_RETURN_BYTES: usize = 512 * 1024;
@@ -81,7 +81,7 @@ Relative paths resolve against the shared session working directory (the same ba
         }
     }
 
-    async fn execute(&self, input: serde_json::Value) -> Result<String, ToolError> {
+    async fn execute(&self, input: serde_json::Value) -> Result<ToolOutput, ToolError> {
         let raw = input["path"]
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput("missing 'path' field".into()))?;
@@ -120,9 +120,9 @@ Relative paths resolve against the shared session working directory (the same ba
             cut.truncate(MAX_RETURN_BYTES);
             let mut s = String::from_utf8_lossy(&cut).into_owned();
             s.push_str("\n… [truncated at 512KiB — use offset/limit to window]");
-            return Ok(s);
+            return Ok(s.into());
         }
-        Ok(windowed)
+        Ok(windowed.into())
     }
 }
 
@@ -176,7 +176,11 @@ mod tests {
             .execute(serde_json::json!({"path": "spec.md"}))
             .await
             .unwrap();
-        assert!(before.contains("HOME"), "expected HOME, got {before}");
+        assert!(
+            before.text.contains("HOME"),
+            "expected HOME, got {}",
+            before.text
+        );
 
         // bash with explicit cwd moves the shared base to `other`.
         bash.execute(serde_json::json!({"command": "true", "cwd": other.path().to_str().unwrap()}))
@@ -189,8 +193,9 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            after.contains("OTHER"),
-            "expected OTHER after bash cwd, got {after}"
+            after.text.contains("OTHER"),
+            "expected OTHER after bash cwd, got {}",
+            after.text
         );
     }
 
@@ -233,7 +238,7 @@ mod tests {
             .execute(serde_json::json!({"path": "f.txt", "offset": 2, "limit": 2}))
             .await
             .unwrap();
-        assert_eq!(out, "l2\nl3");
+        assert_eq!(out.text, "l2\nl3");
     }
 
     #[tokio::test]
@@ -248,7 +253,8 @@ mod tests {
         assert_eq!(
             t.execute(serde_json::json!({"path": "f.txt"}))
                 .await
-                .unwrap(),
+                .unwrap()
+                .text,
             "hi"
         );
     }

--- a/mur-agent-runtime/src/tools/remember.rs
+++ b/mur-agent-runtime/src/tools/remember.rs
@@ -15,7 +15,7 @@ use mur_common::skill::loader::is_valid_skill_name;
 use mur_common::skill::stats::SkillStats;
 use mur_common::skill::store::agent_skill_dir;
 
-use super::{ToolError, ToolExecutor};
+use super::{ToolError, ToolExecutor, ToolOutput};
 use crate::llm::ToolDef;
 
 pub const REMEMBER: &str = "remember";
@@ -96,7 +96,7 @@ impl ToolExecutor for RememberTool {
         }
     }
 
-    async fn execute(&self, input: serde_json::Value) -> Result<String, ToolError> {
+    async fn execute(&self, input: serde_json::Value) -> Result<ToolOutput, ToolError> {
         let get = |k: &str| -> Result<String, ToolError> {
             input
                 .get(k)
@@ -174,7 +174,8 @@ impl ToolExecutor for RememberTool {
             "remembered '{name}' (kind={kind:?}, state=Draft, agent-local; effective next \
              turn; queued for the user's `mur session out` review). Now tell the user in \
              ONE line, in their language, what you saved and that /forget {name} undoes it."
-        ))
+        )
+        .into())
     }
 }
 
@@ -225,7 +226,7 @@ mod tests {
             .execute(input("reply-in-zh-tw", "rule"))
             .await
             .unwrap();
-        assert!(out.contains("reply-in-zh-tw"));
+        assert!(out.text.contains("reply-in-zh-tw"));
 
         // Loadable through the standard loader, agent-local scope, Rule kind.
         let loaded = mur_common::skill::loader::load_all(home, "w1");

--- a/mur-agent-runtime/src/tools/suggest.rs
+++ b/mur-agent-runtime/src/tools/suggest.rs
@@ -3,7 +3,7 @@
 //! streamed tool-call args (`StepStarted`); the executor itself does nothing and
 //! returns a bare acknowledgement so the model can finish its turn.
 
-use super::{ToolError, ToolExecutor};
+use super::{ToolError, ToolExecutor, ToolOutput};
 use crate::llm::ToolDef;
 
 /// Canonical tool name. Shared by the runtime gate and the TUI interceptor.
@@ -78,9 +78,9 @@ impl ToolExecutor for SuggestRepliesTool {
         }
     }
 
-    async fn execute(&self, _input: serde_json::Value) -> Result<String, ToolError> {
+    async fn execute(&self, _input: serde_json::Value) -> Result<ToolOutput, ToolError> {
         // No side effects: the replies reach the user via the streamed args.
-        Ok("ok".to_string())
+        Ok("ok".to_string().into())
     }
 }
 

--- a/mur-agent-runtime/src/tools/write_file.rs
+++ b/mur-agent-runtime/src/tools/write_file.rs
@@ -4,7 +4,7 @@ use mur_common::agent::FilesystemEntitlement;
 
 use crate::llm::ToolDef;
 use crate::tools::fs_policy::{SessionCwd, check_write_entitlement};
-use crate::tools::{ToolError, ToolExecutor};
+use crate::tools::{ToolError, ToolExecutor, ToolOutput};
 
 pub struct WriteFileTool {
     pub session_cwd: SessionCwd,
@@ -39,7 +39,7 @@ impl ToolExecutor for WriteFileTool {
         }
     }
 
-    async fn execute(&self, input: serde_json::Value) -> Result<String, ToolError> {
+    async fn execute(&self, input: serde_json::Value) -> Result<ToolOutput, ToolError> {
         let raw = input["path"]
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput("missing 'path' field".into()))?;
@@ -68,11 +68,7 @@ impl ToolExecutor for WriteFileTool {
                 "write", &target, &base, &e,
             ))
         })?;
-        Ok(format!(
-            "wrote {} bytes to {}",
-            content.len(),
-            target.display()
-        ))
+        Ok(format!("wrote {} bytes to {}", content.len(), target.display()).into())
     }
 }
 
@@ -97,7 +93,7 @@ mod tests {
             .execute(serde_json::json!({"path": "a.txt", "content": "one"}))
             .await
             .unwrap();
-        assert!(r.contains("wrote 3 bytes"));
+        assert!(r.text.contains("wrote 3 bytes"));
         t.execute(serde_json::json!({"path": "a.txt", "content": "two2"}))
             .await
             .unwrap();

--- a/mur-agent-runtime/src/turn_ledger.rs
+++ b/mur-agent-runtime/src/turn_ledger.rs
@@ -49,6 +49,44 @@ impl Action {
     fn mutating(&self) -> bool {
         MUTATING_TOOLS.contains(&self.tool.as_str())
     }
+
+    /// Did this call actually exercise the change — a build, test, or lint
+    /// run — rather than merely succeed at something read-only?
+    ///
+    /// Ponytail: this only ever looks at `bash` targets, and only credits a
+    /// literal `cargo test|build|check|clippy|nextest` (or `npm test`/`pytest`
+    /// as a nod to non-Rust repos) when it is what the command *starts with*,
+    /// after stripping one optional leading `cd <path> && ` prefix (agents
+    /// routinely prepend that). It does not understand shell composition
+    /// beyond that one prefix (`&&` chains, `;`, aliases, Makefile targets,
+    /// `just`, CI wrapper scripts, or a test binary invoked directly), and a
+    /// runner name appearing anywhere but leading position — e.g. inside a
+    /// `grep`/`sed` pattern — is deliberately not credited. A command this
+    /// helper fails to recognise must fall back to not-evidence, because a
+    /// false `verified` is exactly the failure this card exists to prevent —
+    /// a missed real gate run only costs a slightly less generous report,
+    /// not a false claim of proof.
+    fn is_evidence(&self) -> bool {
+        if self.tool != "bash" {
+            return false;
+        }
+        const RUNNERS: &[&str] = &[
+            "cargo test",
+            "cargo build",
+            "cargo check",
+            "cargo clippy",
+            "cargo nextest",
+            "npm test",
+            "pytest",
+        ];
+        let command = self.target.trim();
+        let command = command
+            .strip_prefix("cd ")
+            .and_then(|rest| rest.split_once("&&"))
+            .map(|(_, after)| after.trim())
+            .unwrap_or(command);
+        RUNNERS.iter().any(|r| command.starts_with(r))
+    }
 }
 
 /// Why the turn ended.
@@ -111,12 +149,14 @@ impl TurnLedger {
         self.actions.push(action);
     }
 
-    /// Commands that ran and succeeded — the only thing here that constitutes
-    /// evidence.
+    /// Commands that ran, succeeded, and are recognisable gate runs (test,
+    /// build, check, or lint) — the only thing here that constitutes
+    /// evidence. A successful `cat` or `grep` is not evidence and must not
+    /// count.
     pub fn verified(&self) -> Vec<&Action> {
         self.actions
             .iter()
-            .filter(|a| !a.mutating() && a.outcome == Outcome::Ok)
+            .filter(|a| !a.mutating() && a.outcome == Outcome::Ok && a.is_evidence())
             .collect()
     }
 
@@ -215,13 +255,11 @@ fn truncate(s: &str, max: usize) -> String {
 }
 
 /// Classify a tool result. `is_error` is structural, so failure never has to be
-/// guessed — but a sandbox denial is worth separating out, and the only signal
-/// for it is the hint the bash tool writes on a kernel EPERM.
-pub fn classify(content: &str, is_error: bool) -> Outcome {
-    if let Some(i) = content.find("[sandbox]") {
-        let rest = &content[i..];
-        let line = rest.lines().next().unwrap_or(rest);
-        return Outcome::Denied(truncate(line.trim_start_matches("[sandbox] "), 120));
+/// guessed — and so is a sandbox denial: it comes from the tool's own
+/// `ToolStatus`, not from sniffing the output text for a hint.
+pub fn classify(content: &str, is_error: bool, status: &crate::tools::ToolStatus) -> Outcome {
+    if let crate::tools::ToolStatus::Denied { detail } = status {
+        return Outcome::Denied(truncate(detail, 120));
     }
     if is_error {
         return Outcome::Failed(truncate(content.trim(), 120));
@@ -344,6 +382,48 @@ mod tests {
     }
 
     #[test]
+    fn a_read_with_nothing_run_is_not_evidence() {
+        let mut l = TurnLedger::default();
+        l.record(act("read_file", "src/a.rs", Outcome::Ok));
+        // A successful read (or a sed/grep/cat, same shape) is not evidence
+        // that anything works — it must report as nothing having run.
+        assert!(l.verified().is_empty());
+        let card = render(&l);
+        assert!(card.contains("nothing ran"), "{card}");
+    }
+
+    #[test]
+    fn a_passing_test_suite_is_evidence() {
+        let mut l = TurnLedger::default();
+        l.record(act("edit_file", "src/a.rs", Outcome::Ok));
+        l.record(act("bash", "cargo test --workspace", Outcome::Ok));
+        assert_eq!(l.verified().len(), 1);
+        assert_eq!(l.verified()[0].target, "cargo test --workspace");
+    }
+
+    #[test]
+    fn a_runner_name_inside_a_grep_pattern_is_not_evidence() {
+        let mut l = TurnLedger::default();
+        // Investigating this very bug looks like this: a grep for the
+        // runner string must not itself be credited as having run it.
+        l.record(act("bash", "grep -rn \"cargo test\" src/", Outcome::Ok));
+        assert!(l.verified().is_empty());
+        let card = render(&l);
+        assert!(card.contains("nothing ran"), "{card}");
+    }
+
+    #[test]
+    fn a_runner_after_a_cd_prefix_is_evidence() {
+        let mut l = TurnLedger::default();
+        l.record(act(
+            "bash",
+            "cd /repo && cargo nextest run -p x",
+            Outcome::Ok,
+        ));
+        assert_eq!(l.verified().len(), 1);
+    }
+
+    #[test]
     fn a_failed_command_is_never_evidence() {
         let mut l = TurnLedger::default();
         l.record(act(
@@ -384,8 +464,11 @@ mod tests {
     #[test]
     fn classify_separates_denial_from_ordinary_failure() {
         let denied = classify(
-            "[exit code: 126]\n\n[sandbox] `cargo` is not in agent 'mur''s spawn allowlist\nmore",
+            "ignored",
             false,
+            &crate::tools::ToolStatus::Denied {
+                detail: "`cargo` is not in agent 'mur''s spawn allowlist".to_string(),
+            },
         );
         match denied {
             Outcome::Denied(d) => assert!(d.contains("cargo"), "{d}"),
@@ -394,10 +477,13 @@ mod tests {
         // A denial is not merely a failure: the remedy is to route or grant,
         // not to retry, so it must not be folded into Failed.
         assert!(matches!(
-            classify("error: no such file", true),
+            classify("error: no such file", true, &crate::tools::ToolStatus::Ok),
             Outcome::Failed(_)
         ));
-        assert_eq!(classify("all good", false), Outcome::Ok);
+        assert_eq!(
+            classify("all good", false, &crate::tools::ToolStatus::Ok),
+            Outcome::Ok
+        );
     }
 
     #[test]
@@ -481,9 +567,17 @@ mod tests {
     /// The exact shapes from the field report: an MCP tool with empty args and
     /// a bash failure wrapped twice by the transport.
     #[test]
-    fn render_compacts_mcp_names_and_transport_noise() {
+    fn render_compacts_mcp_names_and_transport_noise_in_blocked() {
         let mut l = TurnLedger::default();
-        l.record(act("mcp__media__mur_compress_stats", "", Outcome::Ok));
+        // mur_compress_stats is a query, not evidence — it does not belong in
+        // `verified` (that's covered elsewhere). Here it's denied, so it's the
+        // vehicle for exercising short_tool()/noise-stripping on the blocked
+        // row instead of the verified one.
+        l.record(act(
+            "mcp__media__mur_compress_stats",
+            "",
+            Outcome::Denied("not permitted".into()),
+        ));
         l.record(act(
             "bash",
             "ls; grep -rn \"compress-today\" --include=* -l . 2>/dev/null | head",
@@ -492,7 +586,10 @@ mod tests {
             ),
         ));
         let card = render(&l);
-        assert!(card.contains("  ✔ mur_compress_stats\n"), "{card}");
+        assert!(
+            card.contains("  ✘ mur_compress_stats · sandbox: not permitted\n"),
+            "{card}"
+        );
         assert!(!card.contains("mcp__media"), "{card}");
         assert!(!card.contains("{}"), "{card}");
         assert!(


### PR DESCRIPTION
The settlement card decided what a tool call *did* by grepping the tool's own output text. That let file **content** forge execution status.

I hit this while supervising an agent through a code review. Asking it to read `turn_ledger.rs` — the file that contains the marker string — produced this:

```
✔ read_file · .../turn_ledger.rs
✘ read_file · sandbox: [sandbox]") {
    .../turn_ledger.rs
```

Same file, read twice, once reported as a success and once as a sandbox denial — with a fragment of Rust source shown as the denial reason. Later, after the fix's own doc comment was written, a read of *that* was reported as `✘ bash · sandbox: ..."`) glued`.

## Root cause

`tools/mod.rs:30` declared:

```rust
async fn execute(&self, input: serde_json::Value) -> Result<String, ToolError>;
```

A bare `String`, so execution status had nowhere to live. The bash tool knows perfectly well what happened — `output.status.success()`, `output.status.code()`, and `spawn_denied_path(...)` are all in hand at `bash.rs:289` — so it encoded them as text markers (`[exit code: N]`, `[sandbox] …`) appended to the output, and `turn_ledger.rs:221 classify()` grepped them back out:

```rust
/// `is_error` is structural, so failure never has to be guessed — but a
/// sandbox denial is worth separating out, and the only signal for it is
/// the hint the bash tool writes on a kernel EPERM.
pub fn classify(content: &str, is_error: bool) -> Outcome {
    if let Some(i) = content.find("[sandbox]") {
```

The doc comment already knew structural was the right answer. Worse, the sniff ran *before* the structural `is_error` check, so a successful read whose output merely contained the marker was classified `Denied` and never reached it.

## Fix

Status now travels as data, alongside the text, never inside it:

```rust
pub enum ToolStatus { Ok, Failed { exit_code: i32 }, Denied { detail: String } }
pub struct ToolOutput { pub text: String, pub status: ToolStatus }
impl From<String> for ToolOutput  // status: Ok
```

`ToolExecutor::execute` returns `ToolOutput`. The `From<String>` impl keeps the change to the nine non-bash tools down to `.into()` on their `Ok` values — no logic touched. `bash.rs` fills in the real status: success → `Ok`, a spawn denial → `Denied` carrying the hint text, any other non-zero exit → `Failed` with the code. `classify()` consumes that status, and the string sniffing is **deleted**, not reordered — along with the test fixture that existed only to exercise it.

**`is_error` is deliberately unchanged.** It is model-facing: it lands in the `tool_result` the LLM reads. `grep` with no match exits 1, `diff` exits 1 on differences, and telling the model those are tool failures would change agent behaviour. The exit status travels *alongside* `is_error`, it does not replace it.

The output text keeps its markers for now — that is what the model reads, and the tool description at `bash.rs:187` documents them. This PR adds the structural channel; it does not change what the model sees.

## Also: `verified()` counted reads as evidence

`turn_ledger.rs:116` filtered on `!a.mutating() && a.outcome == Outcome::Ok`, so any successful non-mutating action counted as verification — including `sed`, `grep` and `cat`. The section exists precisely to print

```
✔ verified   (nothing ran — no evidence this works)
```

when a turn changed files without proving anything, and its own comment calls that line "the difference between *changed nine files* and *it works*". Treating a file read as proof defeated the one thing it was built to catch. I watched it certify a turn as verified whose only non-mutating action was a `sed`, in a turn where the agent had explicitly said it hadn't run the gate.

It now counts only genuine evidence — a test, build, check or lint run — and biases toward *not* evidence when unsure, since a false "verified" is the exact failure this card exists to prevent.

## Follow-up, not in this PR

The structural status makes it possible to render a failed bash call with the error glyph instead of a green check — `cli/step.rs:78-84` already has both glyphs, and `task_runner.rs:1344` currently sets `"ok": !is_error`, which is always `true` for bash. The plumbing here is left usable for that; wiring the UI is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
