### PR TITLE
fix(cli): sandbox-denied tool calls render ✗ instead of ✔

### DIFF
--- a/mur-agent-runtime/src/task_runner.rs
+++ b/mur-agent-runtime/src/task_runner.rs
@@ -1359,6 +1359,7 @@ impl TaskRunner {
                                     } else {
                                         serde_json::Value::Null
                                     },
+                                    "denied": matches!(status, crate::tools::ToolStatus::Denied { .. }),
                                     "duration_ms": t0.elapsed().as_millis() as u64,
                                 }),
                             ))
@@ -1476,6 +1477,7 @@ impl TaskRunner {
                         } else {
                             serde_json::Value::Null
                         },
+                        "denied": matches!(status, crate::tools::ToolStatus::Denied { .. }),
                         "duration_ms": t0_ask.elapsed().as_millis() as u64,
                     }),
                 ))

--- a/mur-core/src/a2a_dial.rs
+++ b/mur-core/src/a2a_dial.rs
@@ -274,6 +274,10 @@ pub enum StepEvent {
         full_len: usize,
         error: Option<String>,
         duration_ms: u64,
+        /// The sandbox refused to run this call (e.g. a denied write). Distinct
+        /// from a legitimate non-zero exit (`ok: false`); an older runtime that
+        /// doesn't send this key is treated as not-denied.
+        denied: bool,
     },
 }
 
@@ -294,6 +298,7 @@ pub fn parse_step(p: &Value, completed: bool) -> StepEvent {
             full_len: p.get("full_len").and_then(Value::as_u64).unwrap_or(0) as usize,
             error: p.get("error").and_then(Value::as_str).map(str::to_string),
             duration_ms: p.get("duration_ms").and_then(Value::as_u64).unwrap_or(0),
+            denied: p.get("denied").and_then(Value::as_bool).unwrap_or(false),
         }
     } else {
         StepEvent::Started {
@@ -800,7 +805,8 @@ mod step_parse_tests {
             "truncated": false,
             "full_len": 4u64,
             "error": null,
-            "duration_ms": 123u64
+            "duration_ms": 123u64,
+            "denied": false
         });
         match parse_step(&p, true) {
             StepEvent::Completed {
@@ -812,6 +818,7 @@ mod step_parse_tests {
                 full_len,
                 error,
                 duration_ms,
+                denied,
             } => {
                 assert_eq!(step_id, "s2");
                 assert_eq!(task_id, "t2");
@@ -821,6 +828,7 @@ mod step_parse_tests {
                 assert_eq!(full_len, 4);
                 assert!(error.is_none());
                 assert_eq!(duration_ms, 123);
+                assert!(!denied);
             }
             StepEvent::Started { .. } => panic!("expected Completed"),
         }

--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -933,6 +933,7 @@ impl App {
         full_len: usize,
         error: Option<String>,
         duration_ms: u64,
+        denied: bool,
     ) {
         if let Some(card) = self
             .messages
@@ -940,7 +941,12 @@ impl App {
             .rev()
             .find_map(|m| m.step.as_mut().filter(|c| c.id == step_id))
         {
-            card.complete(ok, output, truncated, full_len, error, duration_ms);
+            let outcome = match (ok, denied) {
+                (_, true) => super::step::CallOutcome::Denied,
+                (true, _) => super::step::CallOutcome::Ok,
+                (false, _) => super::step::CallOutcome::Failed,
+            };
+            card.complete(outcome, output, truncated, full_len, error, duration_ms);
         }
     }
 
@@ -1781,7 +1787,7 @@ mod step_app_tests {
             "bash".into(),
             serde_json::json!({ "cmd": "ls" }),
         );
-        a.update_step_completed("s1", true, "foo.rs\n".into(), false, 7, None, 42);
+        a.update_step_completed("s1", true, "foo.rs\n".into(), false, 7, None, 42, false);
         let card = a
             .messages
             .iter()
@@ -1801,7 +1807,7 @@ mod step_app_tests {
             "read".into(),
             serde_json::json!({"path":"a.rs"}),
         );
-        a.update_step_completed("s1", true, "ok".into(), false, 2, None, 5);
+        a.update_step_completed("s1", true, "ok".into(), false, 2, None, 5, false);
         // No streaming segment now (tool turn, no text deltas).
         a.finish_agent_turn("here is the summary".into(), Some("t1".into()));
         let last = a.messages.last().unwrap();
@@ -1986,7 +1992,7 @@ mod awaiting_tests {
             "edit".into(),
             serde_json::json!({"file_path":"a.rs"}),
         );
-        a.update_step_completed("s1", true, "ok".into(), false, 2, None, 5);
+        a.update_step_completed("s1", true, "ok".into(), false, 2, None, 5, false);
         a.mark_card_awaiting("s1");
         let card = a.messages.iter().find_map(|m| m.step.as_ref()).unwrap();
         assert!(card.awaiting_hitl);
@@ -2004,7 +2010,7 @@ mod awaiting_tests {
             "edit".into(),
             serde_json::json!({"file_path":"a.rs"}),
         );
-        a.update_step_completed("s1", true, "ok".into(), false, 2, None, 5);
+        a.update_step_completed("s1", true, "ok".into(), false, 2, None, 5, false);
 
         // No card exists for this step_id: the caller must be told so it can
         // fall back to the modal instead of assuming inline approval worked.

--- a/mur-core/src/cmd/agent/cli/dump.rs
+++ b/mur-core/src/cmd/agent/cli/dump.rs
@@ -87,7 +87,7 @@ fn card_text(card: &StepCard) -> String {
 mod tests {
     use super::transcript_to_text;
     use crate::cmd::agent::cli::app::{ChatMsg, Role};
-    use crate::cmd::agent::cli::step::StepCard;
+    use crate::cmd::agent::cli::step::{CallOutcome, StepCard};
 
     #[test]
     fn renders_user_and_agent_and_reasoning() {
@@ -109,7 +109,7 @@ mod tests {
             "bash".into(),
             serde_json::json!({"command":"ls"}),
         );
-        card.complete(true, "a.rs\nb.rs".into(), false, 2, None, 5);
+        card.complete(CallOutcome::Ok, "a.rs\nb.rs".into(), false, 2, None, 5);
         let m = ChatMsg::tool_for_test(card);
         let t = transcript_to_text(&[m]);
         assert!(t.contains("bash"));
@@ -121,7 +121,14 @@ mod tests {
     #[test]
     fn renders_error_card() {
         let mut card = StepCard::new("s1".into(), "bash".into(), serde_json::json!({}));
-        card.complete(false, "boom".into(), false, 4, Some("exit 1".into()), 3);
+        card.complete(
+            CallOutcome::Failed,
+            "boom".into(),
+            false,
+            4,
+            Some("exit 1".into()),
+            3,
+        );
         let t = transcript_to_text(&[ChatMsg::tool_for_test(card)]);
         assert!(t.contains("exit 1"));
     }

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -1865,6 +1865,7 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
             full_len,
             error,
             duration_ms,
+            denied,
             ..
         } => {
             app.update_step_completed(
@@ -1875,6 +1876,7 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
                 full_len,
                 error,
                 duration_ms,
+                denied,
             );
             app.finish_auto_fleet(&step_id, ok, duration_ms);
         }

--- a/mur-core/src/cmd/agent/cli/render_card.rs
+++ b/mur-core/src/cmd/agent/cli/render_card.rs
@@ -326,7 +326,7 @@ fn arg_hint(card: &StepCard, budget: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::{ARG_HINT_MIN, card_lines, elide_middle, hint_budget, hint_field, strip_cd_prefix};
-    use crate::cmd::agent::cli::step::StepCard;
+    use crate::cmd::agent::cli::step::{CallOutcome, StepCard};
     use crate::cmd::agent::cli::theme;
 
     /// A conventional 80-column terminal, so these assertions keep testing the
@@ -362,7 +362,7 @@ mod tests {
     #[test]
     fn done_card_shows_output_and_duration() {
         let mut c = StepCard::new("s1".into(), "read".into(), serde_json::json!({}));
-        c.complete(true, "412 lines".into(), false, 9, None, 8);
+        c.complete(CallOutcome::Ok, "412 lines".into(), false, 9, None, 8);
         let lines = card_lines(&c, theme::resolve_skin("dark"), true, TEST_WIDTH);
         let text: String = lines
             .iter()
@@ -443,7 +443,14 @@ mod tests {
     #[test]
     fn error_card_shows_red_marker_and_message() {
         let mut c = StepCard::new("s1".into(), "bash".into(), serde_json::json!({}));
-        c.complete(false, "boom".into(), false, 4, Some("exit 101".into()), 3);
+        c.complete(
+            CallOutcome::Failed,
+            "boom".into(),
+            false,
+            4,
+            Some("exit 101".into()),
+            3,
+        );
         let lines = card_lines(&c, theme::resolve_skin("dark"), true, TEST_WIDTH);
         let text: String = lines
             .iter()
@@ -497,7 +504,7 @@ mod tests {
             serde_json::json!({ "query": "workflow" }),
         );
         c.complete(
-            true,
+            CallOutcome::Ok,
             r#"{"count":0,"results":[]}"#.into(),
             false,
             24,
@@ -515,7 +522,14 @@ mod tests {
     #[test]
     fn collapsed_card_still_shows_errors_and_hitl() {
         let mut c = StepCard::new("s1".into(), "bash".into(), serde_json::json!({}));
-        c.complete(false, "boom".into(), false, 4, Some("exit 101".into()), 3);
+        c.complete(
+            CallOutcome::Failed,
+            "boom".into(),
+            false,
+            4,
+            Some("exit 101".into()),
+            3,
+        );
         c.awaiting_hitl = true;
         let text = joined(&card_lines(
             &c,
@@ -537,7 +551,7 @@ mod tests {
             "edit".into(),
             serde_json::json!({"file_path":"a.rs"}),
         );
-        c.complete(true, "patched".into(), false, 1, None, 4);
+        c.complete(CallOutcome::Ok, "patched".into(), false, 1, None, 4);
         c.awaiting_hitl = true;
         let lines = card_lines(&c, theme::resolve_skin("dark"), true, TEST_WIDTH);
         let text: String = lines

--- a/mur-core/src/cmd/agent/cli/step.rs
+++ b/mur-core/src/cmd/agent/cli/step.rs
@@ -12,6 +12,21 @@ pub enum StepState {
 // Used by the step card UI renderer (render_card.rs).
 pub const ARGS_MAX_LINES: usize = 12;
 
+/// How a tool call finished, for the step card's eyes only.
+///
+/// Mirrors the runtime's `ToolStatus` so the CLI stops inferring status from
+/// output text. `Ok` means the call ran — including a legitimate non-zero exit
+/// (`grep` with no match); the runtime reports those as successful invocations,
+/// so they keep the check mark. `Denied` means the sandbox refused to run it,
+/// which must render as a failure even though the invocation itself succeeded.
+/// `Failed` means the tool errored outright.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallOutcome {
+    Ok,
+    Failed,
+    Denied,
+}
+
 /// One tool call, shown inline in the transcript.
 #[derive(Debug, Clone)]
 pub struct StepCard {
@@ -55,17 +70,16 @@ impl StepCard {
 
     pub fn complete(
         &mut self,
-        ok: bool,
+        outcome: CallOutcome,
         output: String,
         truncated: bool,
         full_len: usize,
         error: Option<String>,
         duration_ms: u64,
     ) {
-        self.state = if ok {
-            StepState::Done
-        } else {
-            StepState::Error
+        self.state = match outcome {
+            CallOutcome::Ok => StepState::Done,
+            CallOutcome::Failed | CallOutcome::Denied => StepState::Error,
         };
         self.output = output;
         self.truncated = truncated;
@@ -86,7 +100,7 @@ impl StepCard {
 
 #[cfg(test)]
 mod tests {
-    use super::{StepCard, StepState};
+    use super::{CallOutcome, StepCard, StepState};
 
     fn card() -> StepCard {
         StepCard::new(
@@ -106,7 +120,7 @@ mod tests {
     #[test]
     fn complete_ok_sets_done_and_glyph() {
         let mut c = card();
-        c.complete(true, "412 lines".into(), false, 9, None, 8);
+        c.complete(CallOutcome::Ok, "412 lines".into(), false, 9, None, 8);
         assert_eq!(c.state, StepState::Done);
         assert_eq!(c.glyph(), "✔");
         assert_eq!(c.duration_ms, Some(8));
@@ -115,9 +129,38 @@ mod tests {
     #[test]
     fn complete_err_sets_error_and_keeps_message() {
         let mut c = card();
-        c.complete(false, "boom".into(), false, 4, Some("exit 1".into()), 3);
+        c.complete(
+            CallOutcome::Failed,
+            "boom".into(),
+            false,
+            4,
+            Some("exit 1".into()),
+            3,
+        );
         assert_eq!(c.state, StepState::Error);
         assert_eq!(c.glyph(), "✗");
         assert_eq!(c.error.as_deref(), Some("exit 1"));
+    }
+
+    #[test]
+    fn complete_ok_but_denied_sets_error_and_glyph() {
+        // The sandbox refused the call: the invocation itself succeeded
+        // (outcome would otherwise be `Ok`) but nothing ran, so this must
+        // render as a denial, not a check mark.
+        let mut c = card();
+        c.complete(CallOutcome::Denied, "denied".into(), false, 6, None, 5);
+        assert_eq!(c.state, StepState::Error);
+        assert_eq!(c.glyph(), "✗");
+    }
+
+    #[test]
+    fn complete_ok_not_denied_keeps_check_mark() {
+        // A plain non-zero exit (e.g. grep with no match) arrives as
+        // `CallOutcome::Ok` — the tool ran, it just found nothing. This is
+        // the case that must keep its check mark.
+        let mut c = card();
+        c.complete(CallOutcome::Ok, "no matches".into(), false, 10, None, 4);
+        assert_eq!(c.state, StepState::Done);
+        assert_eq!(c.glyph(), "✔");
     }
 }

--- a/mur-core/src/cmd/agent/cli/stream.rs
+++ b/mur-core/src/cmd/agent/cli/stream.rs
@@ -74,6 +74,10 @@ pub enum StreamMsg {
         full_len: usize,
         error: Option<String>,
         duration_ms: u64,
+        /// The sandbox refused to run this call. Distinct from a legitimate
+        /// non-zero exit (`ok: false`); an older runtime that omits this key
+        /// is treated as not-denied.
+        denied: bool,
     },
 }
 
@@ -282,6 +286,7 @@ pub fn spawn_stream(
                         full_len,
                         error,
                         duration_ms,
+                        denied,
                     } => StreamMsg::StepCompleted {
                         task_id,
                         step_id,
@@ -291,6 +296,7 @@ pub fn spawn_stream(
                         full_len,
                         error,
                         duration_ms,
+                        denied,
                     },
                 };
                 let _ = tx.blocking_send(msg);


### PR DESCRIPTION
## 問題

動作失敗了，介面說成功。`murmur` CLI 的 step card 把 sandbox 拒絕（`read_file` 被 sandbox 擋）渲染成 ✔ — 因為 runtime 把 denial 當成「成功的呼叫」回報（呼叫本身執行了、sandbox 不讓它跑），CLI 無從分辨。

## 修法

- **runtime**（`mur-agent-runtime`）:兩個 `step/completed` 通知多帶 `"denied": bool`，直接取自 `ToolStatus::Denied` — 狀態是資料，不再靠文字嗅探。
- **CLI**（`mur-core`）:`StreamMsg::StepCompleted` → `update_step_completed` → `StepCard::complete` 全鏈路帶 `denied`。舊 runtime 沒送這個 key 時以 optional parse 預設 `false`（向後相容）。
- **渲染**:`CallOutcome { Ok, Failed, Denied }` 取代 `ok: bool` + `denied: bool` 雙布林 — 合併成單一三態列舉，清掉 `too_many_arguments (8/7)`，也從結構上消滅「兩個布林對調」的隱患。`Denied` 一律 ✗；合法的非零退出（`grep` 沒找到、`diff` 有差異）維持 ✔。
- `is_error`（model-facing）不受影響 — 非零退出不是錯誤。

## 驗證

- `cargo clippy -p mur-core -p mur-agent-runtime --all-targets -- -D warnings`：0 warnings
- `cargo fmt --all --check`：clean
- targeted tests 30/30 pass（含 `complete_ok_but_denied_sets_error_and_glyph`、`complete_ok_not_denied_keeps_check_mark`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
