### PR TITLE
fix(common): resolve default_locale from the OS locale, not just LANG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6437,6 +6437,7 @@ dependencies = [
  "shell-words",
  "shellexpand",
  "subtle",
+ "sys-locale",
  "tar",
  "tempfile",
  "thiserror 2.0.18",

--- a/mur-common/Cargo.toml
+++ b/mur-common/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 shell-escape = "0.1"
 dirs = "6"
+sys-locale = "0.3"  # OS locale for profile defaults (same version as mur-agent-runtime)
 libc = "0.2"
 regex-lite = "0.1"
 ed25519-dalek = { version = "2", features = ["rand_core", "pkcs8", "pem"] }

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -1312,13 +1312,55 @@ pub struct CompanionConfig {
     pub proactive: ProactiveConfig,
 }
 
-/// Resolve a default BCP-47 locale from the `LANG` environment variable
-/// (e.g. `zh_TW.UTF-8` → `zh-TW`). Falls back to `en-US`.
+/// Resolve a default BCP-47 locale: the OS locale first (sys-locale already
+/// returns BCP-47, e.g. `zh-Hant-TW`), then the `LANG` environment variable
+/// (POSIX form `zh_TW.UTF-8` → `zh-TW`), then `en-US`.
+///
+/// OS-first matters because this is also the serde default for
+/// `AgentProfile.locale`: under launchd there is no `LANG`, so the old
+/// LANG-only resolution silently defaulted every headless agent to `en-US`
+/// even on a non-English system.
 pub fn default_locale() -> String {
-    std::env::var("LANG")
-        .ok()
-        .and_then(|v| v.split('.').next().map(|s| s.replace('_', "-")))
+    sys_locale::get_locale()
+        .filter(|l| !l.is_empty())
+        .or_else(|| std::env::var("LANG").ok().and_then(|v| normalize_lang(&v)))
         .unwrap_or_else(|| "en-US".into())
+}
+
+/// Parse a POSIX-style `LANG` value into BCP-47 (`zh_TW.UTF-8` → `zh-TW`).
+fn normalize_lang(v: &str) -> Option<String> {
+    v.split('.')
+        .next()
+        .map(|s| s.replace('_', "-"))
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod locale_tests {
+    use super::normalize_lang;
+
+    #[test]
+    fn lang_with_encoding_and_region_normalizes() {
+        assert_eq!(normalize_lang("zh_TW.UTF-8").as_deref(), Some("zh-TW"));
+    }
+
+    #[test]
+    fn lang_without_encoding_normalizes() {
+        assert_eq!(normalize_lang("en_US").as_deref(), Some("en-US"));
+    }
+
+    #[test]
+    fn lang_with_script_keeps_script() {
+        assert_eq!(
+            normalize_lang("zh_Hant_TW.UTF-8").as_deref(),
+            Some("zh-Hant-TW")
+        );
+    }
+
+    #[test]
+    fn empty_lang_yields_none() {
+        assert_eq!(normalize_lang(""), None);
+    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## 問題

`default_locale()`（也是 `AgentProfile.locale` 的 serde default）只讀 `$LANG`。launchd 啟動的 headless agent 沒有 `LANG` → 每個都默默拿到 `en-US`，即使在非英語系統上。而 GUI/互動路徑有 `LANG`，導致同一個 profile 在兩種啟動方式下解析出不同語言。

這台機器就是實例：`LANG=en_US.UTF-8`，但系統語言是 `zh-Hant-TW`。

## 修法

- `default_locale()` 改為 **OS 優先**：`sys_locale::get_locale()`（已是 BCP-47，如 `zh-Hant-TW`）→ `$LANG` POSIX fallback（`zh_TW.UTF-8` → `zh-TW`）→ 兩者皆無才是 `en-US`。
- 加入 `sys-locale = "0.3"`（與 mur-agent-runtime 同 crate 同版本 — STT 語言偵測已用它）。
- `normalize_lang` 純函式化（可測、無 env 競態），4 個新測試。

## 驗證

- `cargo test -p mur-common --lib locale_tests`: 4/4 pass
- `cargo clippy -p mur-common --all-targets -- -D warnings`: clean
- `cargo fmt --all --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
