### PR TITLE
fix(cli): an open approval gate is always visible somewhere

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -326,10 +326,6 @@ pub struct App {
     pub turn_produced_output: bool,
     pub streaming: bool,
     pub hitl: Option<HitlRequest>,
-    /// True when the current `hitl` was attached to a step card (inline
-    /// approval row shown there) rather than left unattached. Drives whether
-    /// the centered modal is also needed — see `mark_card_awaiting`.
-    pub hitl_inline_shown: bool,
     /// When the last HITL decision was resolved, for swallowing a stale
     /// decision key: if a gate auto-resolves (read lane / /auto) just as the
     /// operator presses `y`, that keystroke would otherwise land in the
@@ -530,7 +526,6 @@ impl App {
             turn_produced_output: false,
             streaming: false,
             hitl: None,
-            hitl_inline_shown: false,
             hitl_resolved_at: None,
             hitl_grant_confirm: None,
             session,
@@ -963,11 +958,11 @@ impl App {
         }
     }
 
-    /// Flag the card with this `step_id` as awaiting a HITL decision.
-    /// Returns whether a matching card was actually found: the approval
-    /// gate fires before the step card exists in the common case, so the
-    /// caller must not assume a `step_id` implies the inline row is shown.
-    pub fn mark_card_awaiting(&mut self, step_id: &str) -> bool {
+    /// Flag the card with this `step_id` as awaiting a HITL decision, so it
+    /// renders the inline approval row. Whether that row can actually be SEEN
+    /// is a separate question — ask [`App::hitl_inline_visible`] at render
+    /// time, not once at attach time.
+    pub fn mark_card_awaiting(&mut self, step_id: &str) {
         if let Some(card) = self
             .messages
             .iter_mut()
@@ -975,10 +970,28 @@ impl App {
             .find_map(|m| m.step.as_mut().filter(|c| c.id == step_id))
         {
             card.awaiting_hitl = true;
-            true
-        } else {
-            false
         }
+    }
+
+    /// Is the inline approval row for the open gate actually on screen?
+    ///
+    /// Only a card still in the live band can repaint: messages below
+    /// `flushed_upto` are committed to the terminal's native scrollback and
+    /// their rows are frozen forever. The renderer suppresses the centered
+    /// modal when this is true, so a wrong `true` costs the operator every
+    /// surface at once — no modal, no inline row, and a status line that
+    /// cannot name the tool. Two ways that used to happen: the gate fires
+    /// before the card exists (common), and the card is flushed to scrollback
+    /// either before the gate opens or while it is still open.
+    ///
+    /// Recompute it per frame; do not cache.
+    pub fn hitl_inline_visible(&self, step_id: Option<&str>) -> bool {
+        let Some(sid) = step_id else { return false };
+        self.messages.iter().skip(self.flushed_upto).any(|m| {
+            m.step
+                .as_ref()
+                .is_some_and(|c| c.id == sid && c.awaiting_hitl)
+        })
     }
 
     /// Mark the card with this `step_id` as auto-approved — by the read lane
@@ -2015,7 +2028,7 @@ mod awaiting_tests {
     }
 
     #[test]
-    fn mark_card_awaiting_reports_whether_it_found_a_card() {
+    fn inline_row_visible_only_for_a_card_in_the_live_band() {
         let mut a = App::test_fixture();
         a.begin_user_turn("edit it");
         a.push_step_started(
@@ -2025,12 +2038,53 @@ mod awaiting_tests {
         );
         a.update_step_completed("s1", true, "ok".into(), false, 2, None, 5, false);
 
-        // No card exists for this step_id: the caller must be told so it can
+        // No card exists for this step_id: the renderer must be told so it can
         // fall back to the modal instead of assuming inline approval worked.
-        assert!(!a.mark_card_awaiting("no-such-step"));
+        a.mark_card_awaiting("no-such-step");
+        assert!(!a.hitl_inline_visible(Some("no-such-step")));
 
-        // A card exists for "s1": attachment succeeds and is reported.
-        assert!(a.mark_card_awaiting("s1"));
+        // A card exists for "s1" and is still in the live band: the inline row
+        // is genuinely on screen, so the modal stands down.
+        a.mark_card_awaiting("s1");
+        assert!(a.hitl_inline_visible(Some("s1")));
+
+        // A gate with no step_id at all can never be inline.
+        assert!(!a.hitl_inline_visible(None));
+    }
+
+    /// A card already committed to the terminal's native scrollback can never
+    /// repaint, so the inline approval row on it shows the operator nothing.
+    /// Claiming it is visible suppressed the modal too and left an approval
+    /// request with no surface at all — no modal, no row, no tool name.
+    #[test]
+    fn flushed_card_is_not_visible_so_the_modal_takes_over() {
+        let mut a = App::test_fixture();
+        a.begin_user_turn("edit it");
+        a.push_step_started(
+            "s1".into(),
+            "edit".into(),
+            serde_json::json!({"file_path":"a.rs"}),
+        );
+        a.update_step_completed("s1", true, "ok".into(), false, 2, None, 5, false);
+        a.mark_card_awaiting("s1");
+        assert!(a.hitl_inline_visible(Some("s1")), "live band: row shows");
+
+        // The band overflows and the card is committed to scrollback — this
+        // can happen while the gate is still open, which is why visibility is
+        // recomputed per frame instead of cached at attach time.
+        a.flushed_upto = a.messages.len();
+        assert!(
+            !a.hitl_inline_visible(Some("s1")),
+            "frozen rows cannot show an approval request"
+        );
+
+        // The flag itself stays set: a full redraw / transcript dump uses it.
+        let card = a
+            .messages
+            .iter()
+            .find_map(|m| m.step.as_ref().filter(|c| c.id == "s1"))
+            .unwrap();
+        assert!(card.awaiting_hitl);
     }
 }
 

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -1790,10 +1790,15 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
         StreamMsg::Delta { text, thinking, .. } => app.append_delta(&text, thinking),
         StreamMsg::Hitl { req, .. } => {
             app.saw_hitl_this_turn = true;
-            app.hitl_inline_shown = req
-                .step_id
-                .clone()
-                .is_some_and(|sid| app.mark_card_awaiting(&sid));
+            // Flag the card so it renders the inline approval row. Whether
+            // that row is actually VISIBLE is recomputed every frame by the
+            // renderer (`ui::inline_row_visible`) rather than cached here: a
+            // card that is live now can be flushed into scrollback while the
+            // gate is still open, and a cached "inline is showing" would keep
+            // the modal suppressed over rows that can no longer repaint.
+            if let Some(sid) = req.step_id.clone() {
+                app.mark_card_awaiting(&sid);
+            }
             // Session auto-approval: `/auto`/`--auto` covers every tool; the
             // modal's [a] key covers a single tool name.
             // Read lane: `--auto-reads` auto-approves read-only tools.

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -77,16 +77,16 @@ pub fn render(f: &mut Frame, app: &mut App) {
     f.render_widget(&app.input, chunks[3]);
     render_status(f, app, chunks[4]);
 
-    // The centered modal is the fallback whenever the approval was NOT
-    // attached to a step card's inline row. We key this on actual
-    // attachment (`hitl_inline_shown`), not on whether the runtime sent a
-    // step_id: the approval gate commonly fires before the step card
-    // exists, so `mark_card_awaiting` silently finds nothing even though
-    // step_id is Some — gating on step_id alone left the operator with
-    // neither the modal nor the inline row. Do not revert to a
-    // step_id.is_none() check.
+    // The centered modal is the fallback whenever the approval's inline row on
+    // a step card is not actually visible. Key it on VISIBILITY recomputed per
+    // frame (`hitl_inline_visible`), never on whether the runtime sent a
+    // step_id and never on a cached flag: the gate commonly fires before the
+    // card exists, and a card that is live when the gate opens can be flushed
+    // into frozen scrollback while it is still open. Both used to leave the
+    // operator with neither surface. The invariant: an open gate always has at
+    // least one place the operator can see it.
     if let Some(hitl) = &app.hitl
-        && !app.hitl_inline_shown
+        && !app.hitl_inline_visible(hitl.step_id.as_deref())
     {
         render_hitl(f, hitl, app.hitl_grant_confirm);
     }


### PR DESCRIPTION
Follow-up to #893 — the other half of the same failure. #893 stopped a stray keystroke from *deciding* a gate; this one makes sure you can *see* the gate you are deciding on.

## What happened

Observed live while supervising an agent: the status line read `tool approval needed (auto-deny in 298s)`, but the pane showed **no modal and no inline approval row**. The runtime keeps no external record either — the channel holds only human/agent messages, and `cli-sessions/*.jsonl` is written on exit — so there was no way to find out what was being asked. The only honest response was to deny it blind.

## Cause

`mark_card_awaiting` reported whether a card **exists**, and the renderer suppressed the centered modal whenever it said yes. But only messages at index `>= flushed_upto` are still painted in the live viewport (the field's own doc says so); everything before that has been committed to the terminal's native scrollback via `insert_before`, where — per `ui.rs` — "rows pushed to scrollback never come back". Flagging a flushed card set state nothing would ever repaint, and the modal stood down on the strength of it.

## Fix

Visibility is recomputed per frame by `App::hitl_inline_visible(step_id)`: the card must carry `awaiting_hitl` **and** still be in the live band. `mark_card_awaiting` now just sets the flag.

This also closes a race the original report did not cover: `hitl_inline_shown` was computed **once**, when the gate opened. A card that is live at that moment can be flushed into scrollback while the gate is still open, and the stale cache would keep the modal suppressed over frozen rows. Recomputing removes the cache — and the field — entirely.

The invariant is now stated at both sites: **while a gate is open, at least one surface shows it.**

## Tests

Three states, in `app::awaiting_tests`:
- no card for the `step_id` (the gate commonly fires before the card exists) → not visible, modal takes over
- card in the live band → visible, modal stands down
- card flushed to scrollback → not visible; the flag itself stays set, since a full redraw or the Ctrl+O transcript dump renders from it

## Verification

`cargo fmt --all --check` clean · `cargo clippy -p mur-core -p mur-agent-runtime --all-targets -- -D warnings` clean · `cargo nextest run` over the HITL suites → 10 passed (5 tests × 2 binaries).

## Still open from this audit

`--plain` mode prints the request as text and is currently the only way to see one, but it ignores `--auto-reads`; the two modes each lack what the other has, so there is no unattended-friendly combination. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)