### PR TITLE
fix(cli): /auto off revokes per-tool grants, and the badge names them

### DIFF
--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -1669,7 +1669,21 @@ async fn handle_slash(app: &mut App, cmd: SlashCmd, tx: &mpsc::Sender<StreamMsg>
                     decide_hitl_with_note(app, tx, true, true);
                 }
             } else {
-                app.push_system("auto-approve OFF — tool calls ask again");
+                // Revoke the per-tool `[a]` grants too. To the operator those
+                // ARE auto-approval, so leaving them behind made "tool calls
+                // ask again" a lie — and nothing else ever cleared
+                // `session_tool_allow`, so a grant (including one pressed by
+                // accident) was irreversible for the rest of the session.
+                let mut revoked: Vec<String> = app.session_tool_allow.drain().collect();
+                revoked.sort_unstable();
+                if revoked.is_empty() {
+                    app.push_system("auto-approve OFF — tool calls ask again");
+                } else {
+                    app.push_system(format!(
+                        "auto-approve OFF — tool calls ask again (revoked the session allow for {})",
+                        revoked.join(", ")
+                    ));
+                }
             }
         }
         SlashCmd::Verbose(set) => {
@@ -2267,5 +2281,37 @@ mod hitl_key_tests {
         assert!(app.session_tool_allow.contains("write_file"));
         assert!(app.hitl.is_none(), "second press resolves the gate");
         assert_eq!(app.input_text(), "", "armed char is taken back");
+    }
+
+    /// `/auto off` used to clear only the blanket flag, so tools muted with
+    /// `[a]` kept skipping the gate while the CLI announced "tool calls ask
+    /// again". Nothing else ever cleared them: a grant was permanent for the
+    /// session, including one pressed by accident.
+    #[tokio::test]
+    async fn auto_off_revokes_per_tool_session_grants() {
+        let (tx, _rx) = mpsc::channel(16);
+        let mut app = App::test_fixture();
+        app.auto_approve = true;
+        app.session_tool_allow.insert("write_file".into());
+        app.session_tool_allow.insert("bash".into());
+
+        handle_slash(&mut app, SlashCmd::Auto(Some(false)), &tx).await;
+
+        assert!(!app.auto_approve);
+        assert!(
+            app.session_tool_allow.is_empty(),
+            "per-tool grants must be revoked too"
+        );
+        let said = app
+            .messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::System)
+            .map(|m| m.text.clone())
+            .unwrap_or_default();
+        assert!(
+            said.contains("bash") && said.contains("write_file"),
+            "{said}"
+        );
     }
 }

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -1045,6 +1045,11 @@ const FOOTER_SEP: &str = " · ";
 /// the numbers.
 const STATUS_FULL_MIN_WIDTH: u16 = 100;
 
+/// Longest joined tool-name list the `AUTO:` badge will spell out before it
+/// falls back to a bare count. Sized so the badge cannot crowd out the rest of
+/// the status bar on a narrow terminal — two typical tool names fit.
+const AUTO_NAMES_MAX: usize = 24;
+
 fn render_status(f: &mut Frame, app: &App, area: Rect) {
     let theme = app.theme;
     let (msg, color) = if let Some(req) = &app.hitl {
@@ -1103,8 +1108,20 @@ fn render_status(f: &mut Frame, app: &App, area: Rect) {
         ));
         spans.push(Span::raw("  "));
     } else if !app.session_tool_allow.is_empty() {
+        // Name the muted tools when they fit. `AUTO:2` said something was
+        // muted but never what, and nothing else would tell you either —
+        // so the operator could not check whether a grant they did not mean
+        // to make was still in force. `/auto off` revokes them.
+        let mut names: Vec<&str> = app.session_tool_allow.iter().map(String::as_str).collect();
+        names.sort_unstable();
+        let joined = names.join(",");
+        let label = if joined.chars().count() <= AUTO_NAMES_MAX {
+            format!(" AUTO:{joined} ")
+        } else {
+            format!(" AUTO:{} ", names.len())
+        };
         spans.push(Span::styled(
-            format!(" AUTO:{} ", app.session_tool_allow.len()),
+            label,
             Style::default()
                 .fg(Color::Black)
                 .bg(Color::Yellow)


### PR DESCRIPTION
Third in the approval-gate series (#893 keystrokes, #894 visibility). This one is about getting *out* of a grant.

## Two dishonest surfaces

**`/auto off` did not turn auto-approve off.** It cleared the blanket `auto_approve` flag and printed "tool calls ask again", but tools muted with `[a]` live in `session_tool_allow`, which it left untouched — those kept skipping the gate. The message was simply false.

Worse, nothing anywhere cleared that set. Once a tool was granted, it was granted for the rest of the session with no way back. That matters because a grant is easy to make by accident — see #893, where typing an ordinary message could add one without the operator ever seeing which tool it was.

**`AUTO:2` named nothing.** The badge said something was muted but not what, and no command would tell you. So after an accidental grant you could not even check what you had given away.

## Fix

- `/auto off` drains `session_tool_allow` as well, and names what it revoked: `auto-approve OFF — tool calls ask again (revoked the session allow for bash, write_file)`.
- The badge spells the tool names out — `AUTO:bash,write_file` — up to `AUTO_NAMES_MAX` columns, falling back to the bare count when they would crowd the status bar on a narrow terminal.

## Test

`auto_off_revokes_per_tool_session_grants` drives `handle_slash(SlashCmd::Auto(Some(false)))` with two granted tools and asserts the set is empty afterwards **and** that the system message actually contains both names — not merely that some message was emitted.

## Verification

`cargo fmt --all --check` clean · `cargo clippy -p mur-core -p mur-agent-runtime --all-targets -- -D warnings` clean · `cargo nextest run` over the HITL suites → 14 passed (7 tests × 2 binaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)