### PR TITLE
fix(cli): plain mode honours --auto-reads, and its [a]lways means always

### DIFF
--- a/mur-core/src/cmd/agent/cli/bash_class.rs
+++ b/mur-core/src/cmd/agent/cli/bash_class.rs
@@ -46,6 +46,27 @@ const GIT_READONLY_SUBCMDS: &[&str] = &[
     "grep",
 ];
 
+/// Does the `--auto-reads` lane cover this tool call?
+///
+/// The single definition of the lane, shared by the interactive TUI and plain
+/// mode — they used to disagree, with plain mode ignoring `--auto-reads`
+/// entirely, so the same flag meant different things depending on how you
+/// started the CLI.
+///
+/// `read_file` is read-only by construction: a dedicated read tool, enforced
+/// by the sandbox's read entitlements. `bash` has to prove it with
+/// [`is_readonly_bash`]. Everything else prompts.
+pub fn is_readonly_call(tool_name: &str, tool_input: Option<&serde_json::Value>) -> bool {
+    match tool_name {
+        "read_file" => true,
+        "bash" => tool_input
+            .and_then(|v| v.get("command"))
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(is_readonly_bash),
+        _ => false,
+    }
+}
+
 pub fn is_readonly_bash(cmd: &str) -> bool {
     let cmd = cmd.trim();
     if cmd.is_empty() {
@@ -79,7 +100,27 @@ pub fn is_readonly_bash(cmd: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_readonly_bash;
+    use super::{is_readonly_bash, is_readonly_call};
+
+    /// The lane both the TUI and plain mode ask. `read_file` rides on the
+    /// sandbox's read entitlement; `bash` still has to prove itself; anything
+    /// that could write must prompt no matter which mode is running.
+    #[test]
+    fn readonly_call_covers_read_file_and_proven_bash_only() {
+        let cmd = |c: &str| serde_json::json!({ "command": c });
+
+        assert!(is_readonly_call("read_file", None));
+        assert!(is_readonly_call("bash", Some(&cmd("git status"))));
+
+        assert!(!is_readonly_call("bash", Some(&cmd("rm -rf /"))));
+        assert!(!is_readonly_call("bash", Some(&cmd("cat a > b"))));
+        assert!(
+            !is_readonly_call("bash", None),
+            "no command => cannot prove"
+        );
+        assert!(!is_readonly_call("write_file", None));
+        assert!(!is_readonly_call("edit", Some(&cmd("git status"))));
+    }
 
     #[test]
     fn auto_approves_plain_read_commands() {

--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -174,11 +174,6 @@ pub async fn cmd_cli(
                 "note: --budget-usd is only enforced in the interactive TUI; it is ignored in plain/piped mode."
             );
         }
-        if auto_reads {
-            eprintln!(
-                "note: --auto-reads is only enforced in the interactive TUI; it is ignored in plain/piped mode."
-            );
-        }
         if fleet.is_some() {
             eprintln!(
                 "note: --fleet is only shown in the interactive TUI; it is ignored in plain/piped mode."
@@ -187,8 +182,10 @@ pub async fn cmd_cli(
         let home2 = home.clone();
         let agent2 = agent.clone();
         let interactive = io::stdin().is_terminal() && io::stdout().is_terminal();
-        return tokio::task::spawn_blocking(move || run_plain(&home2, &agent2, auto, interactive))
-            .await?;
+        return tokio::task::spawn_blocking(move || {
+            run_plain(&home2, &agent2, auto, auto_reads, interactive)
+        })
+        .await?;
     }
 
     run_tui(
@@ -1808,20 +1805,8 @@ fn handle_stream(app: &mut App, msg: StreamMsg, tx: &mpsc::Sender<StreamMsg>) {
             // that used to hit every read_file bought zero safety: an
             // approved `bash cat` could read the same files anyway, so the
             // prompt was friction that trained blind approval.
-            let read_auto = if app.auto_reads {
-                if req.tool_name == "read_file" {
-                    true
-                } else {
-                    req.tool_name == "bash"
-                        && req
-                            .tool_input
-                            .get("command")
-                            .and_then(serde_json::Value::as_str)
-                            .is_some_and(bash_class::is_readonly_bash)
-                }
-            } else {
-                false
-            };
+            let read_auto = app.auto_reads
+                && bash_class::is_readonly_call(&req.tool_name, Some(&req.tool_input));
             let auto =
                 app.auto_approve || app.session_tool_allow.contains(&req.tool_name) || read_auto;
             if !app.focused && !auto {
@@ -2030,13 +2015,24 @@ mod notify_tests {
 
 /// Pipe-safe fallback: read a line from stdin, stream the reply as plain text to
 /// stdout, repeat. No ANSI, no TUI. Threads conversation context across turns.
-fn run_plain(home: &Path, agent: &str, auto: bool, interactive: bool) -> Result<()> {
+fn run_plain(
+    home: &Path,
+    agent: &str,
+    auto: bool,
+    auto_reads: bool,
+    interactive: bool,
+) -> Result<()> {
     use std::cell::{Cell, RefCell};
     use std::collections::HashMap;
     use std::io::Write as _;
     let out2 = RefCell::new(io::stdout());
     let mut context: Option<String> = None;
     let pricing = load_pricing(home, agent);
+    // Tools the operator granted with `[a]` this session. Plain mode had no
+    // such set, so `[a]lways` approved exactly one call — the prompt said one
+    // thing and the code did another.
+    let session_allow: RefCell<std::collections::HashSet<String>> =
+        RefCell::new(Default::default());
 
     loop {
         if interactive {
@@ -2082,19 +2078,34 @@ fn run_plain(home: &Path, agent: &str, auto: bool, interactive: bool) -> Result<
                 let allow = if auto {
                     eprintln!("[non-interactive: auto-approving tool-approval request (--auto)]");
                     true
+                } else if auto_reads && bash_class::is_readonly_call(tool, hitl.get("tool_input")) {
+                    // Same lane as the TUI, same classifier. This mode used to
+                    // ignore `--auto-reads` outright, so the identical flag
+                    // behaved differently depending on how the CLI was started
+                    // — and plain mode is exactly where unattended runs live.
+                    eprintln!("  [auto-approved read-only {tool} (--auto-reads)]");
+                    true
+                } else if session_allow.borrow().contains(tool) {
+                    eprintln!("  [auto-approved {tool} (session allow)]");
+                    true
                 } else if interactive {
                     // Outer loop releases stdin lock between reads (Task 2), so
                     // we can safely acquire a fresh lock here to prompt the user.
-                    // [a]lways approves once in v1 (no session allow-set) — intentional.
                     let mut o = io::stdout();
                     let _ = write!(o, "  tool approval: {tool} — [y]es / [a]lways / [n]o? ");
                     let _ = o.flush();
                     let mut ans = String::new();
                     let _ = io::stdin().lock().read_line(&mut ans);
-                    matches!(
-                        ans.trim().chars().next(),
-                        Some('y') | Some('Y') | Some('a') | Some('A')
-                    )
+                    match ans.trim().chars().next() {
+                        // [a] now means what it says. It used to approve just
+                        // this one call while the prompt promised "always".
+                        Some('a' | 'A') => {
+                            session_allow.borrow_mut().insert(tool.to_string());
+                            true
+                        }
+                        Some('y' | 'Y') => true,
+                        _ => false,
+                    }
                 } else {
                     eprintln!(
                         "[non-interactive: auto-denying tool-approval request (use --auto to allow)]"


### PR DESCRIPTION
Fourth in the approval-gate series (#893 keystrokes, #894 visibility, #895 revoking). This one closes the gap between the two CLI modes.

## Neither mode was fit for an unattended run

- The **TUI** had the read lane, but until #894 an open gate could be rendered nowhere at all.
- **Plain mode** printed every request as text — the only place a gate was reliably visible — but ignored `--auto-reads` entirely, and said so on startup: `note: --auto-reads is only enforced in the interactive TUI; it is ignored in plain/piped mode.`

So the mode you would actually use for piped, headless, or screen-reader runs was the one where every read stopped and waited for a human.

## Also: `[a]lways` did not mean always

```rust
// [a]lways approves once in v1 (no session allow-set) — intentional.
let _ = write!(o, "  tool approval: {tool} — [y]es / [a]lways / [n]o? ");
```

The prompt promised a session-wide grant and the code granted one call. Same class as #895's `/auto off` claiming "tool calls ask again" while per-tool grants survived: the interface said one thing, the code did another.

## Fix

- **One definition of the lane.** `bash_class::is_readonly_call(tool, input)` is now asked by both modes; the TUI's inline copy is gone. `read_file` rides on the sandbox's read entitlement, `bash` still has to prove itself through the conservative classifier, everything else prompts.
- **`run_plain` takes `auto_reads`** and applies it (auto-approvals are announced on the line, not silent). The startup note is deleted because the flag now does what it says.
- **Plain mode keeps a session allow-set**, so `[a]` behaves like the TUI's.

Combined with #894, both modes now have both halves: the gate is always visible, and reads do not stop the run.

## Test

`readonly_call_covers_read_file_and_proven_bash_only` pins the shared predicate: `read_file` passes, `git status` passes, `rm -rf /` and `cat a > b` do not, a `bash` call with no `command` does not (it cannot be proven), and `write_file` / `edit` never do — including when handed a read-only-looking input.

## Verification

`cargo fmt --all --check` clean · `cargo clippy -p mur-core -p mur-agent-runtime --all-targets -- -D warnings` clean. The targeted nextest run is still finishing locally as I open this; CI is the gate of record and I will report the local result either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)