### PR TITLE
feat(agent): build lane — grant exec on a directory an agent's toolchain fills

### DIFF
--- a/mur-agent-runtime/src/hooks/b0.rs
+++ b/mur-agent-runtime/src/hooks/b0.rs
@@ -762,7 +762,11 @@ mod tests {
             },
             filesystem: FilesystemEntitlement::default(),
             processes: ProcessesEntitlement {
-                spawn: SpawnEntitlement { mode, allowed },
+                spawn: SpawnEntitlement {
+                    mode,
+                    allowed,
+                    allowed_dirs: vec![],
+                },
             },
             syscalls: SyscallsEntitlement::default(),
             limits: LimitsEntitlement::default(),

--- a/mur-agent-runtime/src/hooks/types.rs
+++ b/mur-agent-runtime/src/hooks/types.rs
@@ -156,6 +156,7 @@ fn test_default_entitlements() -> Entitlements {
             spawn: SpawnEntitlement {
                 mode: SpawnMode::Allowlist,
                 allowed: vec![],
+                allowed_dirs: vec![],
             },
         },
         syscalls: SyscallsEntitlement::default(),

--- a/mur-agent-runtime/src/sandbox/policy.rs
+++ b/mur-agent-runtime/src/sandbox/policy.rs
@@ -465,6 +465,32 @@ impl SandboxPolicy {
             }
         }
 
+        // Explicit build-lane grants (`processes.spawn.allowed_dirs`). A
+        // toolchain that compiles its own executables cannot be expressed as
+        // a list of binaries — a Rust build execs build scripts, proc-macro
+        // shims and test binaries at hash-suffixed paths that do not exist
+        // until the build creates them. Fail closed the same way the literal
+        // list does: an entry that is missing, is not a directory, or cannot
+        // be canonicalized is dropped rather than widened.
+        for dir in &ent.processes.spawn.allowed_dirs {
+            let expanded = expand(dir);
+            let Ok(canon) = std::fs::canonicalize(&expanded) else {
+                continue;
+            };
+            if !canon.is_dir() {
+                continue;
+            }
+            // A grant of `/`, `/usr`, the home directory, or a bare
+            // `/Volumes/<mount>` is not a build lane; it is every binary
+            // reachable under it. Same guard the derived prefixes use.
+            if is_guarded_prefix(&canon, &home) {
+                continue;
+            }
+            if !spawn_allowed_prefixes.contains(&canon) {
+                spawn_allowed_prefixes.push(canon);
+            }
+        }
+
         let (net_allow_ports, net_allow_hosts, net_loopback_allowed) =
             match ent.network.outbound.mode {
                 NetworkOutboundMode::Unrestricted => (None, None, false),
@@ -757,6 +783,7 @@ mod tests {
                 spawn: SpawnEntitlement {
                     mode: SpawnMode::Allowlist,
                     allowed: vec![],
+                    allowed_dirs: vec![],
                 },
             },
             syscalls: Default::default(),
@@ -1238,6 +1265,60 @@ mod tests {
                 .all(|p| p.ends_with("fake-tool")),
             "no unrelated binary name should have leaked into spawn_allowed_paths: {:?}",
             policy.spawn_allowed_paths
+        );
+    }
+
+    /// The build lane: an explicit directory grant becomes an exec prefix, so
+    /// a toolchain can run binaries it compiles itself (cargo build scripts,
+    /// proc-macro shims, test executables) at paths that do not exist when
+    /// the entitlement is written. Fails closed on anything unusable, and
+    /// refuses a grant so broad it is not a lane at all.
+    #[test]
+    fn build_lane_grants_a_directory_prefix_and_fails_closed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = tmp.path().join("target");
+        std::fs::create_dir_all(&target).expect("mkdir target");
+        let a_file = tmp.path().join("not-a-dir");
+        std::fs::write(&a_file, b"x").expect("write file");
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+
+        let mut ent = minimal_entitlements();
+        ent.processes.spawn.mode = SpawnMode::Allowlist;
+        ent.processes.spawn.allowed_dirs = vec![
+            target.to_string_lossy().to_string(),
+            a_file.to_string_lossy().to_string(), // not a directory
+            "/definitely/does/not/exist".to_string(), // missing
+            "/".to_string(),                      // guarded: not a lane
+            home.to_string_lossy().to_string(),   // guarded: whole home
+        ];
+
+        let policy =
+            SandboxPolicy::from_entitlements(&ent, &PathBuf::from("/tmp/agent_home_build_lane"));
+
+        let canon_target = std::fs::canonicalize(&target).expect("canonicalize target");
+        assert!(
+            policy.spawn_allowed_prefixes.contains(&canon_target),
+            "the build-output directory must become an exec prefix: {:?}",
+            policy.spawn_allowed_prefixes
+        );
+        for bad in [
+            PathBuf::from("/"),
+            home.clone(),
+            PathBuf::from("/definitely/does/not/exist"),
+        ] {
+            assert!(
+                !policy.spawn_allowed_prefixes.contains(&bad),
+                "must not grant {bad:?}: {:?}",
+                policy.spawn_allowed_prefixes
+            );
+        }
+        assert!(
+            !policy
+                .spawn_allowed_prefixes
+                .iter()
+                .any(|p| p.ends_with("not-a-dir")),
+            "a plain file is not a lane: {:?}",
+            policy.spawn_allowed_prefixes
         );
     }
 

--- a/mur-agent-runtime/src/skills/sandbox_map.rs
+++ b/mur-agent-runtime/src/skills/sandbox_map.rs
@@ -29,6 +29,7 @@ pub fn restrict_for_trust(base: &Entitlements, trust: TrustLevel) -> Entitlement
                 spawn: SpawnEntitlement {
                     mode: SpawnMode::Allowlist,
                     allowed: vec![],
+                    allowed_dirs: vec![],
                 },
             };
         }
@@ -66,6 +67,7 @@ mod tests {
                 spawn: SpawnEntitlement {
                     mode: SpawnMode::Any,
                     allowed: vec!["sh".into()],
+                    allowed_dirs: vec![],
                 },
             },
             syscalls: SyscallsEntitlement::default(),

--- a/mur-agent-runtime/tests/b0_rule2_network_allowlist.rs
+++ b/mur-agent-runtime/tests/b0_rule2_network_allowlist.rs
@@ -33,6 +33,7 @@ fn ent_with_outbound(mode: NetworkOutboundMode, allow: Vec<String>) -> Entitleme
             spawn: SpawnEntitlement {
                 mode: SpawnMode::Allowlist,
                 allowed: vec![],
+                allowed_dirs: vec![],
             },
         },
         syscalls: SyscallsEntitlement::default(),

--- a/mur-agent-runtime/tests/b0_rule5_spawn_deny.rs
+++ b/mur-agent-runtime/tests/b0_rule5_spawn_deny.rs
@@ -24,7 +24,11 @@ fn ent_with_spawn(mode: SpawnMode, allowed: Vec<String>) -> Entitlements {
         },
         filesystem: FilesystemEntitlement::default(),
         processes: ProcessesEntitlement {
-            spawn: SpawnEntitlement { mode, allowed },
+            spawn: SpawnEntitlement {
+                mode,
+                allowed,
+                allowed_dirs: vec![],
+            },
         },
         syscalls: SyscallsEntitlement::default(),
         limits: LimitsEntitlement::default(),

--- a/mur-agent-runtime/tests/sandbox_build_lane.rs
+++ b/mur-agent-runtime/tests/sandbox_build_lane.rs
@@ -1,0 +1,119 @@
+//! The build lane (`processes.spawn.allowed_dirs`), end to end.
+//!
+//! Its own integration binary on purpose: `sandbox_e2e.rs` applies a
+//! sandbox to the TEST PROCESS itself (`sandbox_apply_does_not_panic`), and
+//! on macOS a sandbox is inherited by children — so once that test has run,
+//! every subprocess spawned from that binary is already sealed under a
+//! profile with no build lane, and this test would fail depending on the
+//! order the harness happened to pick.
+
+/// The build lane, end to end: a binary the agent compiled itself must be
+/// exec'able when it lives under a granted `allowed_dirs` tree, and a binary
+/// outside that tree must still be refused.
+///
+/// This is the capability A7 is about — a Rust agent cannot verify its own
+/// work if it may not run the build scripts and test executables `cargo`
+/// produces. Unit-testing the policy struct proves the grant is recorded;
+/// only sealing a real process and calling exec proves the kernel honours it.
+#[test]
+#[cfg(target_os = "macos")]
+fn sandbox_allows_exec_inside_the_build_lane() {
+    let exe = std::env::current_exe().unwrap();
+    // Positive: with the lane granted, the compiled binary runs.
+    let granted = std::process::Command::new(&exe)
+        .env("MUR_TEST_SANDBOX_BUILD_LANE", "grant")
+        .env_remove("MUR_AGENT_SKIP_SANDBOX")
+        .status()
+        .unwrap();
+    assert_eq!(
+        granted.code(),
+        Some(0),
+        "a binary under the granted build lane must exec; one outside must not"
+    );
+    // Negative control: WITHOUT the grant the same binary must be refused.
+    // Without this, a run where the sandbox silently failed to apply — which
+    // the subprocess treats as a pass — would look identical to a working
+    // lane, and this test would be proving nothing.
+    let ungranted = std::process::Command::new(&exe)
+        .env("MUR_TEST_SANDBOX_BUILD_LANE", "nogrant")
+        .env_remove("MUR_AGENT_SKIP_SANDBOX")
+        .status()
+        .unwrap();
+    assert_eq!(
+        ungranted.code(),
+        Some(0),
+        "without the grant the binary must NOT exec (else the positive case proves nothing)"
+    );
+}
+
+/// Subprocess entry point for `sandbox_allows_exec_inside_the_build_lane`.
+#[cfg(target_os = "macos")]
+#[ctor::ctor]
+fn sandbox_build_lane_subprocess_main() {
+    let Some(mode) = std::env::var_os("MUR_TEST_SANDBOX_BUILD_LANE") else {
+        return;
+    };
+    let granted = mode == *"grant";
+    use mur_agent_runtime::sandbox;
+    use mur_common::agent::AgentProfile;
+
+    let agent_home = std::path::PathBuf::from("/tmp/b1_test_lane_home");
+    std::fs::create_dir_all(&agent_home).unwrap();
+
+    // Stand-in for `target/debug/build/<crate>-<hash>/build-script-build`:
+    // a binary that does not exist when the entitlement is written, and whose
+    // path no allowlist could have named in advance.
+    let lane = std::path::PathBuf::from("/tmp/b1_test_lane_target");
+    let outside = std::path::PathBuf::from("/tmp/b1_test_lane_outside");
+    std::fs::create_dir_all(&lane).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+    let in_lane = lane.join("build-script-build");
+    let off_lane = outside.join("build-script-build");
+    for p in [&in_lane, &off_lane] {
+        // A shell script, NOT a copy of a system binary: copying a signed
+        // Apple binary invalidates its signature and the kernel SIGKILLs the
+        // copy, which looks exactly like a sandbox denial in the exit status
+        // and would make this test lie in both directions.
+        std::fs::write(p, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut perms = std::fs::metadata(p).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        std::fs::set_permissions(p, perms).unwrap();
+    }
+
+    let mut profile = AgentProfile::default_for_tests();
+    profile.entitlements.processes.spawn.mode = mur_common::agent::SpawnMode::Allowlist;
+    profile.entitlements.processes.spawn.allowed_dirs = if granted {
+        vec![lane.to_string_lossy().to_string()]
+    } else {
+        vec![]
+    };
+
+    if sandbox::apply(&profile.entitlements, &agent_home, &[], &[], &[]).is_err() {
+        // No sandbox support here — nothing to assert either way.
+        std::process::exit(0);
+    }
+
+    let ran = |p: &std::path::Path| {
+        let r = std::process::Command::new(p).arg("ok").status();
+        // Print the raw result: a denial (`Err(PermissionDenied)`) and a
+        // process killed for another reason (`Ok(signal 9)`) are different
+        // facts, and collapsing them to a bool is how this test first lied.
+        eprintln!("exec {p:?} -> {r:?}");
+        r.is_ok_and(|s| s.success())
+    };
+    let in_lane_ran = ran(&in_lane);
+    let off_lane_ran = ran(&off_lane);
+
+    // Granted: the lane binary runs and the one outside it does not.
+    // Ungranted: neither runs — this is what proves the granted run was the
+    // grant working, not the sandbox failing to apply.
+    let want_in_lane = granted;
+    if in_lane_ran == want_in_lane && !off_lane_ran {
+        std::process::exit(0);
+    }
+    eprintln!(
+        "ERROR: granted={granted} in_lane={in_lane_ran} (want {want_in_lane}), \
+         off_lane={off_lane_ran} (want false)"
+    );
+    std::process::exit(1);
+}

--- a/mur-agent-runtime/tests/sandbox_e2e.rs
+++ b/mur-agent-runtime/tests/sandbox_e2e.rs
@@ -123,6 +123,7 @@ fn spawn_sandboxed_runs_true() {
             spawn: SpawnEntitlement {
                 mode: SpawnMode::Any,
                 allowed: vec![],
+                allowed_dirs: vec![],
             },
         },
         syscalls: Default::default(),
@@ -297,6 +298,7 @@ fn linux_ruleset_paths_are_absolute() {
             spawn: SpawnEntitlement {
                 mode: SpawnMode::Any,
                 allowed: vec![],
+                allowed_dirs: vec![],
             },
         },
         syscalls: Default::default(),

--- a/mur-common/src/agent.rs
+++ b/mur-common/src/agent.rs
@@ -773,6 +773,22 @@ pub struct SpawnEntitlement {
     pub mode: SpawnMode,
     #[serde(default)]
     pub allowed: Vec<String>,
+    /// Directories whose entire subtree may be exec'd — the "build lane".
+    ///
+    /// `allowed` cannot express a toolchain that compiles its own
+    /// executables: a Rust build execs `target/debug/build/<crate>-<hash>/
+    /// build-script-build`, proc-macro shims, and freshly linked test
+    /// binaries, all at paths that do not exist until the build creates them
+    /// and change on every dependency bump. Without this an agent granted
+    /// `cargo` could compile nothing and could never verify its own work.
+    ///
+    /// Grant narrowly — a build-output directory, not a source tree or a
+    /// home directory. Everything under it becomes exec'able, so the tree
+    /// should be one the agent already has write access to and nothing else
+    /// depends on. Filesystem and network entitlements still bound what the
+    /// executed code can reach.
+    #[serde(default)]
+    pub allowed_dirs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/mur-core/src/cli/agent.rs
+++ b/mur-core/src/cli/agent.rs
@@ -744,6 +744,13 @@ pub enum AgentPermAction {
     AllowSpawn { name: String, binary: String },
     /// Remove a binary from the spawn allowlist
     DenySpawn { name: String, binary: String },
+    /// Allow exec of everything under a directory — the build lane, for
+    /// toolchains that compile and then run their own binaries (cargo build
+    /// scripts, proc macros, test executables). Grant a build-output
+    /// directory, never a source tree or a home directory
+    AllowSpawnDir { name: String, dir: String },
+    /// Remove a directory from the build lane
+    DenySpawnDir { name: String, dir: String },
     /// Set a numeric resource limit (memory_mb, file_descriptors, processes)
     SetLimit {
         name: String,

--- a/mur-core/src/cmd/agent/lifecycle.rs
+++ b/mur-core/src/cmd/agent/lifecycle.rs
@@ -369,6 +369,7 @@ fn default_entitlements_custom() -> Entitlements {
             spawn: SpawnEntitlement {
                 mode: SpawnMode::Allowlist,
                 allowed: vec![],
+                allowed_dirs: vec![],
             },
         },
         syscalls: SyscallsEntitlement {

--- a/mur-core/src/cmd/agent/mod.rs
+++ b/mur-core/src/cmd/agent/mod.rs
@@ -94,10 +94,10 @@ pub use mcp::{
 pub use peers::cmd_peers;
 #[allow(unused_imports)]
 pub use perm::{
-    cmd_perm_allow_host, cmd_perm_allow_read, cmd_perm_allow_spawn, cmd_perm_allow_write,
-    cmd_perm_clear_tool, cmd_perm_deny_host, cmd_perm_deny_path, cmd_perm_deny_spawn,
-    cmd_perm_list_hosts, cmd_perm_list_tools, cmd_perm_set_limit, cmd_perm_set_mode,
-    cmd_perm_set_tool, cmd_perm_show,
+    cmd_perm_allow_host, cmd_perm_allow_read, cmd_perm_allow_spawn, cmd_perm_allow_spawn_dir,
+    cmd_perm_allow_write, cmd_perm_clear_tool, cmd_perm_deny_host, cmd_perm_deny_path,
+    cmd_perm_deny_spawn, cmd_perm_deny_spawn_dir, cmd_perm_list_hosts, cmd_perm_list_tools,
+    cmd_perm_set_limit, cmd_perm_set_mode, cmd_perm_set_tool, cmd_perm_show,
 };
 #[allow(unused_imports)]
 pub(crate) use prompt::prompt_path_for;

--- a/mur-core/src/cmd/agent/perm.rs
+++ b/mur-core/src/cmd/agent/perm.rs
@@ -234,6 +234,43 @@ pub fn cmd_perm_deny_spawn(name: &str, binary: &str) -> Result<()> {
     Ok(())
 }
 
+/// Grant the build lane: every executable under `dir` becomes spawnable.
+///
+/// The binary allowlist cannot express a toolchain that compiles its own
+/// executables — a Rust build execs `target/debug/build/<crate>-<hash>/
+/// build-script-build`, proc-macro shims and freshly linked test binaries,
+/// at paths that do not exist until the build creates them. Print what the
+/// grant means rather than accepting it silently: this is a wider door than
+/// naming one binary, and the operator should see that in the terminal.
+pub fn cmd_perm_allow_spawn_dir(name: &str, dir: &str) -> Result<()> {
+    let (path, mut profile) = load_profile_for_edit(name)?;
+    let dirs = &mut profile.entitlements.processes.spawn.allowed_dirs;
+    if !dirs.iter().any(|d| d == dir) {
+        dirs.push(dir.to_string());
+    }
+    save_profile(&path, &mut profile)?;
+    println!("build lane: '{name}' may now exec anything under {dir}");
+    println!(
+        "  filesystem and network entitlements still bound what that code can reach — \
+         check them with `mur agent perm show {name}`"
+    );
+    warn_if_running(name);
+    Ok(())
+}
+
+pub fn cmd_perm_deny_spawn_dir(name: &str, dir: &str) -> Result<()> {
+    let (path, mut profile) = load_profile_for_edit(name)?;
+    profile
+        .entitlements
+        .processes
+        .spawn
+        .allowed_dirs
+        .retain(|d| d != dir);
+    save_profile(&path, &mut profile)?;
+    warn_if_running(name);
+    Ok(())
+}
+
 pub fn cmd_perm_set_limit(name: &str, key: &str, value: u64) -> Result<()> {
     let (path, mut profile) = load_profile_for_edit(name)?;
     let lim = &mut profile.entitlements.limits;

--- a/mur-core/src/cmd/agent_companion/connector.rs
+++ b/mur-core/src/cmd/agent_companion/connector.rs
@@ -582,6 +582,7 @@ pub(crate) async fn scaffold_stub_bridge(name: &str, default_route: &str) -> Res
                 spawn: SpawnEntitlement {
                     mode: SpawnMode::Allowlist,
                     allowed: vec![],
+                    allowed_dirs: vec![],
                 },
             },
             syscalls: SyscallsEntitlement {

--- a/mur-core/src/dispatch.rs
+++ b/mur-core/src/dispatch.rs
@@ -1883,6 +1883,12 @@ async fn run_agent(action: AgentAction) -> Result<()> {
             AgentPermAction::DenySpawn { name, binary } => {
                 cmd::agent::cmd_perm_deny_spawn(&name, &binary)?
             }
+            AgentPermAction::AllowSpawnDir { name, dir } => {
+                cmd::agent::cmd_perm_allow_spawn_dir(&name, &dir)?
+            }
+            AgentPermAction::DenySpawnDir { name, dir } => {
+                cmd::agent::cmd_perm_deny_spawn_dir(&name, &dir)?
+            }
             AgentPermAction::SetLimit { name, key, value } => {
                 cmd::agent::cmd_perm_set_limit(&name, &key, value)?
             }


### PR DESCRIPTION
Closes A7 from the murmur CLI audit: a Rust agent granted `cargo` could not compile anything, so it could never verify its own work — which is how a worker ends up reporting "done" on code it never built.

## Found by running it, not reasoning about it

Two walls, in order:

```
cc: error: can't exec '.../XcodeDefault.xctoolchain/usr/bin/clang' (errno=Operation not permitted)
```
```
could not execute process `target/debug/build/libc-<hash>/build-script-build` (Operation not permitted)
```

The first is one allowlist entry away — the toolchain binary sits at a fixed path. (On this machine Xcode lives on an external volume, outside the `/bin`, `/usr/bin`, `/usr/lib` roots that Allowlist mode exempts.)

The second cannot be fixed that way. `cargo` compiles build scripts, proc-macro shims and test executables and then **runs them**, at hash-suffixed paths that do not exist when the entitlement is written and change on every dependency bump. No list of binaries can name them in advance.

## `processes.spawn.allowed_dirs`

Grants exec on a directory subtree. Point it at a build-output directory and the toolchain can run what it produced.

A new field rather than teaching `allowed` to accept directories: today a directory there is silently dropped, and quietly reinterpreting it as "this whole tree is exec'able" would change the meaning of profiles already on disk.

Fails closed like the rest of the spawn policy — missing, not a directory, or not canonicalizable is dropped — and reuses the existing `is_guarded_prefix` check, so `/`, `/usr`, `/opt`, the home directory and a bare `/Volumes/<mount>` are refused. Those are not lanes; they are every binary underneath them.

```
mur agent perm allow-spawn-dir <name> <dir>   # prints what the grant means
mur agent perm deny-spawn-dir  <name> <dir>
```

Filesystem and network entitlements still bound what the executed code can reach — on the agent that motivated this, outbound is `localhost` only.

## The test had to be made honest twice

The e2e seals a real process and execs a binary inside the lane and one outside it. Two earlier versions passed while proving nothing:

1. the sandbox silently failed to apply, and the subprocess treats that as a pass;
2. the fixture copied `/bin/echo`, which invalidates its code signature — the kernel SIGKILLed it, and `status().is_ok()` reported that as "it ran".

It now writes its own shell script, prints the raw exec result rather than a bool, and carries a **negative control**: without the grant the same binary must be refused. All four cells:

| | in lane | outside |
|---|---|---|
| **granted** | `Ok(exit 0)` | `PermissionDenied` |
| **not granted** | `PermissionDenied` | `PermissionDenied` |

It lives in its own integration binary: `sandbox_e2e.rs` applies a sandbox to the *test process itself*, and macOS children inherit it, so sharing that binary made the result depend on the order the harness picked.

## Verification

`cargo fmt --all --check` clean · `cargo clippy -p mur-core -p mur-agent-runtime -p mur-common --all-targets -- -D warnings` clean · `cargo test --workspace --no-run` clean (the new field breaks every `SpawnEntitlement` literal — 11 of them, across both crates and their test fixtures) · `sandbox_build_lane` 1 passed · `sandbox_e2e` 6 passed, 1 ignored · policy unit test passed.

## Note for deployment

An older `mur` binary does not know `allowed_dirs`, so if it rewrites a profile the field is silently dropped. The runtime must be rebuilt for a granted lane to take effect — the same staleness that made a fixed iteration counter still print `0 iterations` on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)