### PR TITLE
docs(readme): build lane, and what changed about approval gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,21 @@ Agent** wizard offers the same catalog as a source.
 - **Kernel sandbox** per OS — Landlock + seccomp (Linux), SBPL (macOS), Job
   Object (Windows) — plus a DNS-resolver guard that filters network egress.
 - **Human-in-the-loop** — tool calls pause for your approval in Hub and in
-  `mur agent cli` (opt out per session with `--auto`).
+  `mur agent cli` (opt out per session with `--auto`). While a gate is open the
+  decision keys only count when you aren't mid-message, and a session-wide
+  grant takes two presses — typing an ordinary sentence can't hand a tool
+  blanket approval. An open gate always renders somewhere, `/auto off` revokes
+  the per-tool grants it claims to revoke, and a gate that times out stops
+  asking. Reads never have to stop the run: `--auto-reads` covers `read_file`
+  and provably read-only shell commands, in the TUI and in `--plain` alike.
+- **Build lane** — a toolchain that compiles its own executables can't be
+  expressed as a list of binaries: `cargo` runs build scripts and test
+  executables at paths that don't exist until the build creates them. Grant the
+  build-output directory instead — `mur agent perm allow-spawn-dir <agent>
+  <dir>` — and an agent can finally verify its own work. Narrow by
+  construction: `/`, `/usr`, `/opt`, your home directory and a bare mount point
+  are refused, and filesystem and network entitlements still bound whatever
+  runs.
 - **Loop settings that can't quietly mean something else** — a fleet loop ends
   when its job queue drains, when a member emits an agreed marker on a line of
   its own, or when the router judges it done. `mur fleet set-loop` refuses a


### PR DESCRIPTION
The CLAUDE.md documentation checklist, owed for #892–#898. Two user-facing surfaces shipped without a word written down.

**Build lane** — `mur agent perm allow-spawn-dir <agent> <dir>` (#898). New bullet under 🔐 Stay governed, framed by why the binary allowlist can't cover it: `cargo` runs build scripts and test executables at paths that don't exist until the build creates them.

**Approval gates** — the existing one-line "tool calls pause for your approval" is now wrong by omission. What an operator will actually notice, from #892–#897:
- decision keys are inert while you're mid-message
- session-wide grants take two presses
- an open gate always renders somewhere
- `/auto off` revokes the per-tool grants it claims to revoke
- a gate that times out stops asking
- `--auto-reads` covers `read_file`, and works in `--plain` too

No change to the command tree — the build lane is a `perm` subcommand and that row already lists `perm`; the top-level count stays 28.

Docs site and product page are a separate PR in `mur-server` (that repo deploys to the public site on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)