### PR TITLE
chore(release): bump workspace version to 2.68.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6573,7 +6573,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6624,7 +6624,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.67.0"
+version = "2.68.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "age",
  "anyhow",
@@ -6655,6 +6655,7 @@ dependencies = [
  "shell-words",
  "shellexpand",
  "subtle",
+ "sys-locale",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -6669,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -6695,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6783,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6842,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.67.0"
+version = "2.68.0"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
**Merging this is the release.** `tag.yml` tags `v2.68.0` on the merge commit and dispatches `release.yml`, which publishes to crates.io — irreversible, yank-only. There is no later gate, so this PR is the release approval.

## What ships since v2.67.0

**Approval gates** — five ways the same gate could mislead you, each found by reproducing it on a live agent rather than reading code:

| PR | |
|---|---|
| #893 | Typing an ordinary message could **decide** an open gate — a sentence containing `a` approved the call and granted the tool for the whole session, with the character deleted from the message. Decision keys now count only while the composer is empty, and session-wide grants take two presses. |
| #894 | An open gate could render **nowhere** — no modal, no inline row, no tool name — because a card already flushed to scrollback can never repaint. Visibility is recomputed per frame; the invariant is that an open gate always has one surface. |
| #895 | `/auto off` announced "tool calls ask again" while per-tool `[a]` grants survived, and nothing anywhere could revoke them. It now drains them and names what it revoked; the badge names the muted tools. |
| #896 | `--auto-reads` was ignored in `--plain`, and plain mode's `[a]lways` approved exactly once. Both modes now share one read-lane definition, and `[a]` means what it says. |
| #897 | After a gate timed out the status line kept asking for a decision on a request the transcript had already reported as denied. |

**Build lane** (#898) — an agent granted `cargo` could not compile anything: building means running binaries that do not exist yet, at hash-suffixed paths no allowlist can name. `processes.spawn.allowed_dirs` grants exec on a build-output directory, via `mur agent perm allow-spawn-dir`. Refuses `/`, `/usr`, `/opt`, a home directory and bare mount points; filesystem and network entitlements still bound whatever runs.

**Also** — `#892` approval line no longer truncates (it now names the tool), markdown tables render, `read_file` joins the read lane; `#890` a denied tool call shows `✗` instead of `✔` while a legitimate non-zero exit keeps its check; `#891` `default_locale` reads the OS locale rather than `LANG` alone (launchd services have no `LANG`).

**Docs** — README, `/docs/core/build-lane`, `agent-cli` gate behaviour, product card (mur#899 merged; mur-server#50 open for review — that one deploys the public site).

## Version choice

Minor, not patch: new CLI commands (`allow-spawn-dir` / `deny-spawn-dir`) and a new profile field (`processes.spawn.allowed_dirs`). Note an older MUR silently drops that field if it rewrites a profile.

Both lock files moved with the version — the root one and `mur-hub-gui/src-tauri/Cargo.lock`, which keeps its own copy of every workspace crate's version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)