### PR TITLE
fix(cli): retire an expired gate before the frame, not after

### DIFF
--- a/mur-core/src/cmd/agent/cli/mod.rs
+++ b/mur-core/src/cmd/agent/cli/mod.rs
@@ -661,6 +661,13 @@ async fn event_loop(
         // `render_mode`, and the draw below must land on the matching
         // surface (small inline viewport vs. full-frame alt-screen).
         sync_surface(app)?;
+        // Retire an expired gate BEFORE drawing. Running it after the draw
+        // cleared the state but left the stale frame on screen: the loop wakes
+        // at the deadline, paints the still-open gate, retires it, then sleeps
+        // with nothing left to wake it — so the status line went on asking for
+        // a decision on a request that had already been denied, which is the
+        // very thing retiring it was meant to stop.
+        expire_stale_hitl(app);
         if app.needs_full_redraw {
             terminal.clear()?;
             app.needs_full_redraw = false;
@@ -710,16 +717,9 @@ async fn event_loop(
             .as_ref()
             .map(|r| TokioInstant::from_std(r.next_poll()))
             .unwrap_or_else(|| TokioInstant::from_std(StdInstant::now()));
-        // A gate nobody answers expires on the runtime side and the call is
-        // denied there. Nothing tells the CLI — `StreamMsg::Expired` only
-        // arrives if the operator decides too LATE — so the request sat in
-        // `app.hitl` forever and the status line kept advertising
-        // "auto-deny in 0s" over a request that was already dead, while the
-        // transcript said it had been denied. Retire it locally on the same
-        // deadline the status line counts down to, so the two agree.
-        expire_stale_hitl(app);
         // Wake exactly at the expiry, or an idle loop (nothing streaming, no
-        // blink, no rail) never notices its own countdown reaching zero.
+        // blink, no rail) never notices its own countdown reaching zero. The
+        // sweep itself runs before the draw at the top of the loop.
         let hitl_armed = app.hitl.is_some();
         let hitl_at = app
             .hitl


### PR DESCRIPTION
Follow-up to #897. My own bug, found by watching a real agent sit at `⏳ approve edit_file · auto-deny in 0s` long after the gate was gone.

## What was wrong

#897 retires an approval request once its gate has expired, so the status line stops asking. The sweep ran **after** `terminal.draw`:

1. loop wakes at the deadline
2. paints the frame — gate still open
3. retires the request
4. sleeps, with nothing left to wake it

State correct, screen lying — the exact symptom #897 set out to remove, reached by a different route. The transcript even printed `▲ approval for \`edit_file\` timed out — auto-denied` *underneath* a status line still asking for a decision.

Pressing one unrelated key cleared it instantly, which is what identified it as a repaint-ordering problem rather than a stuck sweep.

## Fix

Move `expire_stale_hitl` above the draw, so the frame that reports the gate is the frame that resolves it.

## On the test

The existing unit test could not catch this — it calls `expire_stale_hitl` directly and never exercises draw ordering. I have not added one: asserting on frame order means rendering to a test backend, and this loop is not set up for that today. Saying so rather than leaving the impression the regression is covered.

## Verification

`cargo fmt --all --check` clean · `cargo clippy -p mur-core --all-targets -- -D warnings` clean · `cargo test -p mur-core --lib hitl_key_tests` → 5 passed, 0 failed.

Independent of #900 (the version bump) — merge order doesn't matter, but if #900 goes first this rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)