### PR TITLE
fix(cli): a step card can no longer outlive the turn that owns it

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -13,6 +13,7 @@ use tui_textarea::TextArea;
 use super::complete::{Candidate, CompletionState};
 use super::markdown;
 use super::persist::{ChannelMeta, Session, TurnRecord};
+use super::step::StepState;
 use super::stream::HitlRequest;
 use super::theme::Theme;
 use super::welcome::{Blink, MascotMode, resolve_mascot_mode};
@@ -857,6 +858,7 @@ impl App {
         self.streaming = false;
         self.current_task_id = None;
         self.turn_started = None;
+        self.resolve_open_steps("turn ended without a result for this call");
         self.note_open_items_if_changed();
     }
 
@@ -958,6 +960,32 @@ impl App {
         }
     }
 
+    /// Close every step card still spinning, because the turn that owned them
+    /// has ended.
+    ///
+    /// A card leaves `Running` only when its matching `tool/result` arrives.
+    /// A turn that dies first — the runtime went idle, the dial timed out, the
+    /// task failed — never sends one, so the card spins forever and the
+    /// transcript keeps claiming a tool is running long after nothing is.
+    /// That is the same failure as an approval gate with no visible surface:
+    /// the screen and the truth disagree, and the screen is the one the
+    /// operator believes.
+    ///
+    /// Only cards still in the live band repaint; anything already committed
+    /// to native scrollback is frozen. The spinning card is by definition the
+    /// most recent one, so in practice it is the one that gets fixed.
+    pub fn resolve_open_steps(&mut self, reason: &str) {
+        for card in self
+            .messages
+            .iter_mut()
+            .skip(self.flushed_upto)
+            .filter_map(|m| m.step.as_mut())
+            .filter(|c| c.state == StepState::Running)
+        {
+            card.abandon(reason.to_string());
+        }
+    }
+
     /// Flag the card with this `step_id` as awaiting a HITL decision, so it
     /// renders the inline approval row. Whether that row can actually be SEEN
     /// is a separate question — ask [`App::hitl_inline_visible`] at render
@@ -1029,6 +1057,7 @@ impl App {
             self.messages.remove(i);
         }
         self.push_system(format!("error: {err}"));
+        self.resolve_open_steps(err);
         self.streaming = false;
         self.current_task_id = None;
         self.turn_started = None;
@@ -1055,6 +1084,7 @@ impl App {
         self.current_task_id = None;
         self.turn_started = None;
         self.inflight_params = None;
+        self.resolve_open_steps("the turn this call belonged to no longer exists");
     }
 
     /// Surface — and persist into the channel — that the last user message
@@ -1802,6 +1832,44 @@ mod step_app_tests {
             "empty placeholder dropped, only step card"
         );
         assert!(agent_msgs[0].step.is_some(), "must be step card");
+    }
+
+    /// The screenshot bug: a `fleet_run` card kept spinning after the turn
+    /// carrying it had already died on the runtime's 600s idle timeout. No
+    /// `tool/result` ever arrives for such a call, so nothing else will ever
+    /// move the card off `Running`.
+    #[test]
+    fn a_failed_turn_stops_the_spinner_on_its_open_step_cards() {
+        let mut a = app();
+        a.begin_user_turn("run the fleet");
+        a.push_step_started("s1".into(), "fleet_run".into(), serde_json::json!({}));
+        let running = |a: &App| {
+            a.messages
+                .iter()
+                .filter_map(|m| m.step.as_ref())
+                .filter(|c| c.state == StepState::Running)
+                .count()
+        };
+        assert_eq!(running(&a), 1, "card starts out running");
+
+        a.fail_turn("agent 'mur' went idle for 600s without a response");
+
+        assert_eq!(running(&a), 0, "no card may outlive the turn that owns it");
+        let card = a
+            .messages
+            .iter()
+            .find_map(|m| m.step.as_ref())
+            .expect("step card");
+        assert_eq!(card.state, StepState::Error);
+        assert!(
+            card.error.as_deref().is_some_and(|e| e.contains("idle")),
+            "the card must say WHY it stopped, not just that it did: {:?}",
+            card.error
+        );
+        assert!(
+            card.duration_ms.is_none(),
+            "a call nobody answered has no honest duration"
+        );
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/step.rs
+++ b/mur-core/src/cmd/agent/cli/step.rs
@@ -88,6 +88,19 @@ impl StepCard {
         self.duration_ms = Some(duration_ms);
     }
 
+    /// Close a call the runtime never reported on, because the turn carrying
+    /// it ended first (idle timeout, failed task, dead dial).
+    ///
+    /// Deliberately not `complete(Failed, …)`: that stamps a `duration_ms`,
+    /// and the only honest duration for a call nobody ever answered is the
+    /// one we already have — usually none. Leaves `duration_ms` untouched so
+    /// the card says how it ended without inventing how long it took.
+    pub fn abandon(&mut self, reason: String) {
+        self.state = StepState::Error;
+        self.error = Some(reason);
+        self.awaiting_hitl = false;
+    }
+
     // glyph is called by render_card::card_lines.
     pub fn glyph(&self) -> &'static str {
         match self.state {


### PR DESCRIPTION
## What

A step card leaves `Running` only when its matching `tool/result` arrives. When the turn dies first — the runtime goes idle past the dial timeout, the task fails, the dial dies — no result is ever sent, so the card spins forever.

Observed shape (user screenshot, murmur concierge running a deep-research fleet):

```
◐ fleet_run deep-research
  …
  · error: agent 'mur' went idle for 600s without a response
```

The spinner and the error sit in the same transcript. This is the same failure as an approval gate with no visible surface (#887/#893): the screen and the truth disagree, and the screen is the one the operator believes.

## Change

- `App::resolve_open_steps(reason)` — closes every still-`Running` card in the live band, carrying the reason the turn ended so the card says *why* it stopped, not just that it did.
- Called from all three turn-end paths: `fail_turn`, `finish_agent_turn`, `drop_dead_turn`.
- `StepCard::abandon` rather than `complete(Failed, …)`: `complete` stamps a `duration_ms`, and the only honest duration for a call nobody ever answered is the one already known — usually none.

Cards already flushed to native scrollback cannot repaint; that limit is unchanged and documented on the method. The spinning card is by definition the most recent one, so in practice it is the one that gets fixed.

## Verification

`a_failed_turn_stops_the_spinner_on_its_open_step_cards` asserts the card leaves `Running`, carries the idle-timeout reason, and claims no duration.

Negative control run: with `resolve_open_steps` removed from `fail_turn`, the test fails at `no card may outlive the turn that owns it`. Restored, 230/230 cli tests pass; clippy `--all-targets` and `cargo fmt --check` clean.

## Not in scope

The underlying fleet run failure (`× run failed`, then the agent going idle for 600s) is a separate problem. This PR only stops the transcript from lying about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)