### PR TITLE
fix(cli): commit the fleet rail's final state to the transcript, then retire it

### DIFF
--- a/mur-core/src/cmd/agent/cli/app.rs
+++ b/mur-core/src/cmd/agent/cli/app.rs
@@ -1188,7 +1188,7 @@ impl App {
     pub fn arm_auto_fleet(&mut self, step_id: &str, fleet: &str, now: std::time::Instant) {
         self.auto_fleet_step = Some(step_id.to_string());
         if !self.fleet.as_ref().is_some_and(|r| r.fleet() == fleet) {
-            self.fleet = Some(super::fleet_rail::FleetRail::start(fleet));
+            self.fleet = Some(super::fleet_rail::FleetRail::start_auto(fleet));
         }
         if let Some(rail) = self.fleet.as_mut() {
             rail.set_run_in_flight(true);
@@ -1213,8 +1213,16 @@ impl App {
     }
 
     /// Close out an auto-armed `fleet_run` when its step completes: drain the
-    /// follow's tail, drop it (only if auto), leave the rail up — Done/Failed
-    /// member states are worth reading — and put the outcome on the record.
+    /// follow's tail, drop it (only if auto), commit the rail's final member
+    /// states to the transcript, and retire an auto-armed rail.
+    ///
+    /// The rail is live state repainted every frame and never flushed to
+    /// scrollback, so leaving it up after the run kept the outcome visible
+    /// but out of the record: `Ctrl+O` and the persisted transcript had
+    /// nothing, and the band stayed on screen for the rest of the session
+    /// showing a run that had already ended. Folding the view into the
+    /// outcome message fixes both. A `--fleet` rail the user armed themselves
+    /// stays up — they asked for a band, not a run report.
     pub fn finish_auto_fleet(&mut self, step_id: &str, ok: bool, duration_ms: u64) {
         if self.auto_fleet_step.as_deref() != Some(step_id) {
             return;
@@ -1225,16 +1233,33 @@ impl App {
         if self.follow.as_ref().is_some_and(|f| f.auto) {
             self.follow = None;
         }
+        let home = self.home.clone();
         let mut fleet = String::new();
+        let mut summary = Vec::new();
+        let mut retire = false;
         if let Some(rail) = self.fleet.as_mut() {
             rail.set_run_in_flight(false);
+            // A view up to POLL_INTERVAL stale would freeze the wrong states
+            // into history. `set_run_in_flight` already busted the poll gate.
+            rail.poll(&home, std::time::Instant::now());
             fleet = rail.fleet().to_string();
+            summary = rail.view().summary();
+            retire = rail.is_auto();
+        }
+        if retire {
+            self.fleet = None;
         }
         let took = super::follow::fmt_elapsed(chrono::Duration::milliseconds(duration_ms as i64));
-        self.push_system(format!(
+        let head = format!(
             "⛴ fleet {fleet} {} ({took})",
             if ok { "finished" } else { "failed" }
-        ));
+        );
+        self.push_system(
+            std::iter::once(head)
+                .chain(summary)
+                .collect::<Vec<_>>()
+                .join("\n"),
+        );
     }
 
     /// Record a completed `!command` run: show it, persist it, and queue it
@@ -1870,6 +1895,41 @@ mod step_app_tests {
             card.duration_ms.is_none(),
             "a call nobody answered has no honest duration"
         );
+    }
+
+    /// An auto-armed rail is live state that never reaches scrollback, so the
+    /// run's outcome has to be committed to the transcript before the band
+    /// goes away — and the band has to go away, or it outlives its run.
+    #[test]
+    fn an_auto_armed_fleet_rail_lands_in_the_transcript_and_retires() {
+        let mut a = app();
+        a.arm_auto_fleet("s1", "dev", std::time::Instant::now());
+        assert!(a.fleet.is_some(), "arming should raise the rail");
+
+        a.finish_auto_fleet("s1", true, 4000);
+
+        assert!(
+            a.fleet.is_none(),
+            "an auto-armed rail must not outlive its run"
+        );
+        let last = a.messages.last().expect("outcome message").text.clone();
+        assert!(last.contains("⛴ fleet dev finished"), "got: {last}");
+        // The rail's own view, not just the headline: this is the part that
+        // used to exist only on screen.
+        assert!(last.lines().count() > 1, "rail view not committed: {last}");
+    }
+
+    /// A `--fleet` rail is a band the user asked to keep; a delegated run
+    /// ending inside it must not take it down.
+    #[test]
+    fn a_user_armed_fleet_rail_survives_a_delegated_run() {
+        let mut a = app();
+        a.fleet = Some(super::super::fleet_rail::FleetRail::start("dev"));
+        a.arm_auto_fleet("s1", "dev", std::time::Instant::now());
+
+        a.finish_auto_fleet("s1", true, 4000);
+
+        assert!(a.fleet.is_some(), "a user-armed rail must survive the run");
     }
 
     #[test]

--- a/mur-core/src/cmd/agent/cli/fleet_rail.rs
+++ b/mur-core/src/cmd/agent/cli/fleet_rail.rs
@@ -43,6 +43,17 @@ pub struct MemberRow {
 }
 
 impl MemberState {
+    /// The state's glyph. Lives here rather than in the renderer so the band
+    /// and the transcript summary can't drift into two different alphabets.
+    pub fn glyph(&self) -> &'static str {
+        match self {
+            MemberState::Blocked { .. } => "▲",
+            MemberState::Working { .. } => "⏵",
+            MemberState::Done => "✔",
+            MemberState::Failed => "✖",
+        }
+    }
+
     /// Sort key: blocked first, then working, then finished.
     fn rank(&self) -> u8 {
         match self {
@@ -234,6 +245,34 @@ pub struct RailView {
     pub notice: Option<String>,
 }
 
+impl RailView {
+    /// The view as plain transcript lines.
+    ///
+    /// The band is live state repainted every frame — it is never flushed to
+    /// scrollback, so whatever it showed at the end of a run disappears with
+    /// the session. This is how the final member states get committed to
+    /// history instead. `Working` is spelled "still working" because at run
+    /// end that is news, not progress.
+    pub fn summary(&self) -> Vec<String> {
+        let head = match &self.notice {
+            Some(n) => format!("{}  {n}", self.jobs_line),
+            None => self.jobs_line.clone(),
+        };
+        let mut out = vec![head];
+        out.extend(self.members.iter().map(|m| {
+            let state = match &m.state {
+                MemberState::Blocked { summary, .. } => format!("blocked: {summary}"),
+                MemberState::Working { tool: Some(t), .. } => format!("still working · {t}"),
+                MemberState::Working { tool: None, .. } => "still working".to_string(),
+                MemberState::Done => "done".to_string(),
+                MemberState::Failed => "failed".to_string(),
+            };
+            format!("  {} {} · {state}", m.state.glyph(), m.agent)
+        }));
+        out
+    }
+}
+
 /// Polls one fleet's channel and job store, folding both into a `RailView`.
 ///
 /// Deliberately a separate type from `Follow`: that one turns events into
@@ -254,6 +293,11 @@ pub struct FleetRail {
     /// A delegated `fleet_run` step is currently executing in this pane
     /// (armed on `StepStarted`, cleared on `StepCompleted`).
     run_in_flight: bool,
+    /// True when the rail was auto-armed by a delegated `fleet_run` step
+    /// rather than by the user's `--fleet`. An auto-armed rail belongs to one
+    /// run and is dropped when that run ends; a `--fleet` rail is a band the
+    /// user asked to keep.
+    auto: bool,
     view: RailView,
     next_poll: Instant,
 }
@@ -266,9 +310,23 @@ impl FleetRail {
             last_len: u64::MAX, // force the first poll to do real work
             last_jobs_gate: (0, None),
             run_in_flight: false,
+            auto: false,
             view: RailView::default(),
             next_poll: Instant::now(),
         }
+    }
+
+    /// A rail armed by a delegated `fleet_run` step (see the `auto` field).
+    pub fn start_auto(fleet: &str) -> Self {
+        Self {
+            auto: true,
+            ..Self::start(fleet)
+        }
+    }
+
+    /// True when this rail belongs to one delegated run, not to `--fleet`.
+    pub fn is_auto(&self) -> bool {
+        self.auto
     }
 
     /// The fleet this rail watches.

--- a/mur-core/src/cmd/agent/cli/fleet_rail/tests.rs
+++ b/mur-core/src/cmd/agent/cli/fleet_rail/tests.rs
@@ -588,3 +588,57 @@ fn jobs_line_flags_an_in_flight_goal_run() {
     let line = jobs_line("develop", &[job("1", JobStatus::Done)], true);
     assert!(line.contains("run in progress"), "got: {line}");
 }
+
+#[test]
+fn summary_spells_out_every_member_state_for_the_transcript() {
+    let view = RailView {
+        jobs_line: "fleet · dev   job 2/3".into(),
+        members: vec![
+            MemberRow {
+                agent: "coder".into(),
+                state: MemberState::Done,
+            },
+            MemberRow {
+                agent: "tester".into(),
+                state: MemberState::Failed,
+            },
+            MemberRow {
+                agent: "review".into(),
+                state: MemberState::Blocked {
+                    summary: "rm -rf build".into(),
+                    hitl_id: "h1".into(),
+                },
+            },
+            MemberRow {
+                agent: "docs".into(),
+                state: MemberState::Working {
+                    tool: Some("grep".into()),
+                    since: Utc::now(),
+                },
+            },
+        ],
+        notice: Some("⚠ channel unreadable".into()),
+    };
+
+    let lines = view.summary();
+    assert_eq!(
+        lines.len(),
+        5,
+        "one head line plus one per member: {lines:?}"
+    );
+    assert!(lines[0].contains("job 2/3") && lines[0].contains("⚠ channel unreadable"));
+    assert!(lines[1].contains("✔ coder · done"), "got: {}", lines[1]);
+    assert!(lines[2].contains("✖ tester · failed"), "got: {}", lines[2]);
+    assert!(
+        lines[3].contains("▲ review · blocked: rm -rf build"),
+        "got: {}",
+        lines[3]
+    );
+    // A member still working when the run ended is the one state the band
+    // would have shown as ordinary progress; in a run report it is news.
+    assert!(
+        lines[4].contains("⏵ docs · still working · grep"),
+        "got: {}",
+        lines[4]
+    );
+}

--- a/mur-core/src/cmd/agent/cli/ui.rs
+++ b/mur-core/src/cmd/agent/cli/ui.rs
@@ -401,21 +401,19 @@ fn rail_lines(
 
     if rail_height_for(view) > 1 {
         for m in view.members.iter().take(MAX_EXPANDED_ROWS) {
-            let (glyph, body, color) = match &m.state {
-                MemberState::Blocked { summary, .. } => {
-                    ("▲", format!("blocked: {summary}"), theme.warn)
-                }
+            let (body, color) = match &m.state {
+                MemberState::Blocked { summary, .. } => (format!("blocked: {summary}"), theme.warn),
                 MemberState::Working { tool, since } => (
-                    "⏵",
                     match tool {
                         Some(t) => format!("working ({}) · {t}", elapsed(*since)),
                         None => format!("working ({})", elapsed(*since)),
                     },
                     theme.agent,
                 ),
-                MemberState::Done => ("✔", "done".to_string(), theme.success),
-                MemberState::Failed => ("✖", "failed".to_string(), theme.error),
+                MemberState::Done => ("done".to_string(), theme.success),
+                MemberState::Failed => ("failed".to_string(), theme.error),
             };
+            let glyph = m.state.glyph();
             lines.push(Line::styled(
                 format!("  {:<10} {glyph} {body}", m.agent),
                 Style::default().fg(color),


### PR DESCRIPTION
## What

A delegated `fleet_run` ending in `murmur` left its outcome on the fleet rail — a band repainted every frame that is **never flushed to scrollback**. So the final member states existed on screen and nowhere else: `Ctrl+O` and the persisted transcript had only `⛴ fleet <name> finished (2m)`.

And nothing ever cleared `app.fleet`. There is no `= None` and no `.take()` anywhere: after one run the band stayed up for the rest of the session, showing a run that had already ended.

## Change

`finish_auto_fleet` now:

1. polls the rail one last time — the view could be up to `POLL_INTERVAL` stale, and freezing the wrong member states into history is exactly the failure mode this is meant to fix;
2. folds `RailView::summary()` into the outcome message, so history gets `⛴ fleet dev finished (2m)` followed by `✔ coder · done` / `✖ tester · failed` / `▲ review · blocked: …` / `⏵ docs · still working · grep`;
3. drops the rail — but only when it was auto-armed. A `--fleet` rail the user raised themselves stays: they asked for a band, not a run report.

`MemberState::glyph()` moves into `fleet_rail` so the band and the transcript summary can't drift into two different alphabets.

`Working` is spelled **"still working"** in the summary: on the live band it is ordinary progress, in a run report it is news.

## Verification

- `cargo test -p mur-core --lib cmd::agent::cli` — 233 passed, 0 failed
- `cargo clippy -p mur-core --all-targets` — clean
- `cargo fmt --all --check` — clean

Negative controls, to prove the new tests aren't vacuous:

| sabotage | result |
|---|---|
| `if retire` → `if false` | `panicked: an auto-armed rail must not outlive its run` |
| `summary = rail.view().summary()` → `Vec::new()` | `panicked: rail view not committed: ⛴ fleet dev finished (4s)` |

Both restored; the suite is green with the real code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)