### PR TITLE
chore(release): bump workspace version to 2.68.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,7 +6303,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mur-agent-launcher"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "libc",
 ]
@@ -6382,7 +6382,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -6479,7 +6479,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6573,7 +6573,7 @@ dependencies = [
 
 [[package]]
 name = "mur-daemon"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6624,7 +6624,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mcp-server"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "anyhow",
  "mur-common",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "mur-mobile-sdk"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "mur-research-gateway"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "mur-common",
  "reqwest 0.12.28",
@@ -6684,7 +6684,7 @@ dependencies = [
 
 [[package]]
 name = "mur-zfs-agent"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "anyhow",
  "mur-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.68.0"
+version = "2.68.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mur-run/mur"

--- a/mur-hub-gui/src-tauri/Cargo.lock
+++ b/mur-hub-gui/src-tauri/Cargo.lock
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "mur-channel"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6620,7 +6620,7 @@ dependencies = [
 
 [[package]]
 name = "mur-common"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "age",
  "anyhow",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "mur-compress"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "blake3",
  "chrono",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "mur-core"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "mur-gui-core"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "mur-open-items"
-version = "2.68.0"
+version = "2.68.1"
 dependencies = [
  "anyhow",
  "chrono",


### PR DESCRIPTION
## v2.68.1 — murmur TUI truthfulness fixes

Two bug fixes since v2.68.0, both in the `murmur` chat TUI. Patch bump.

| PR | Fix |
|---|---|
| #903 | A step card can no longer outlive the turn that owns it — a call whose turn died (idle timeout, failed task, dead dial) left its spinner running forever above the error that killed it. `abandon()` deliberately leaves `duration_ms` untouched: the only honest duration for a call nobody answered is none. |
| #904 | The fleet rail's final state is committed to the transcript, then the rail retires. The band is repainted every frame and never flushed to scrollback, so a finished run's member states existed on screen and nowhere else — and nothing ever cleared `app.fleet`, so the band outlived its run for the rest of the session. |

Both share one root cause: an interface asserting something it had no evidence for.

## Release checklist

- [x] `Cargo.toml` workspace version → 2.68.1
- [x] Root `Cargo.lock` updated
- [x] `mur-hub-gui/src-tauri/Cargo.lock` updated
- [ ] CI green — merging this tags `v2.68.1` and publishes to crates.io (irreversible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)