### PR TITLE
fix(install): match checksum entries by normalised name

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -44,8 +44,10 @@ try {
     Invoke-WebRequest -Uri $assetUrl     -OutFile (Join-Path $tmp $asset)
     Invoke-WebRequest -Uri $checksumsUrl -OutFile (Join-Path $tmp 'checksums.txt')
 
+    # The release job hashes `./<file>`, so listed names carry a `./` prefix;
+    # sha256sum's binary mode would use `*` instead. Accept any of them.
     $expectedLine = (Get-Content (Join-Path $tmp 'checksums.txt')) |
-        Where-Object { $_ -match "[ *]$([regex]::Escape($asset))$" }
+        Where-Object { $_ -match "[ */]$([regex]::Escape($asset))$" }
     if (-not $expectedLine) { throw "No checksum entry for $asset" }
     $expected = ($expectedLine -split '\s+')[0].ToLower()
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -94,7 +94,11 @@ else
     wget -q "$CHECKSUMS_URL" -O "$TMP/checksums.txt" || die "Download failed."
 fi
 
-EXPECTED=$(grep " [*]*$ASSET" "$TMP/checksums.txt" | awk '{print $1}' | head -n1)
+# The release job hashes `./<file>`, so the listed names carry a `./` prefix;
+# sha256sum's binary mode would add a `*` instead. Normalise the name and match
+# it whole, rather than substring-matching the tail of the line.
+EXPECTED=$(awk -v f="$ASSET" '{ n=$2; sub(/^[*]/,"",n); sub(/^\.\//,"",n); if (n==f) print $1 }' \
+    "$TMP/checksums.txt" | head -n1)
 [ -n "$EXPECTED" ] || die "No checksum entry for $ASSET in checksums.txt."
 
 if command -v sha256sum >/dev/null 2>&1; then


### PR DESCRIPTION
The installer at `scripts/install.sh` — the copy `release.yml`'s `deploy-installer` job publishes to `gh-pages` — aborts after a successful download:

```
No checksum entry for mur-aarch64-apple-darwin.tar.gz in checksums.txt.
```

The release job hashes `./<file>`, so every line reads

```
1a6dde…ee90e  ./mur-aarch64-apple-darwin.tar.gz
```

while `grep " [*]*$ASSET"` requires the asset name to follow the space directly. The `./` sits in between, so it never matched.

Strips a leading `./` (or sha256sum binary mode's `*`) from the listed name and compares it **whole**, rather than substring-matching the tail of the line — which also stops a longer filename ending in the asset name from matching by accident.

Fixing the consumer rather than the publisher: the `checksums.txt` of already-published releases can't be rewritten, so the installer has to tolerate both spellings regardless.

## Verification

End to end against v2.68.0, into a scratch `MUR_INSTALL_DIR`:

```
Downloading mur-aarch64-apple-darwin.tar.gz (v2.68.0)...
mur v2.68.0 installed.
$ ./ghtest/mur --version
mur 2.68.0
```

Lookup checked against all four spellings — `./name` → hit, `*name` → hit, bare `name` → hit, absent → miss.

## Context

The same bug was just fixed in the *other* installer, the one Vercel actually serves at mur.run (mur-run/mur.run-website#3, live and verified). These are two independently written scripts with different flags (`--version X.Y.Z` here vs `sh -s -- vX.Y.Z` there), and `deploy-installer` has been pushing this one to `gh-pages`, which no longer serves mur.run. Collapsing them to one source of truth is still open — this PR only makes the unserved copy correct.