### PR TITLE
docs(release): drop the stale gh-pages DNS prerequisite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,6 @@ permissions:
 #   APPLE_TEAM_NAME          - "common name" piece used in the codesign identity
 #   CRATES_IO_TOKEN          - crates.io API token (publish-crates job)
 #   HOMEBREW_TAP_TOKEN       - existing, used by update-homebrew job
-# DNS prerequisite:
-#   - mur.run DNS must CNAME to mur-run.github.io
-#   - GitHub Pages must be configured to publish from gh-pages branch with
-#     "mur.run" as the custom domain.
 
 jobs:
   validate-version:


### PR DESCRIPTION
`release.yml`'s header still carried:

```
# DNS prerequisite:
#   - mur.run DNS must CNAME to mur-run.github.io
#   - GitHub Pages must be configured to publish from gh-pages branch with
#     "mur.run" as the custom domain.
```

Neither is true. mur.run resolves to Vercel, and #907 removed the last job that wrote to `gh-pages`.

Leaving it would be worse than a no-op: a false prerequisite sitting in the file people read before touching the release pipeline is exactly how the installer split stayed invisible for months — the pipeline *looked* like it was maintaining mur.run.

The comment explaining why there is no installer-deploy job (added in #907) stays; it points at the repo that actually serves the scripts.