### PR TITLE
chore(server): drop the dead mur-run.github.io CORS origin

### DIFF
--- a/mur-core/src/server/mod.rs
+++ b/mur-core/src/server/mod.rs
@@ -203,7 +203,6 @@ pub fn build_router_with_auth(state: AppState, auth_token: Option<Arc<str>>) -> 
             "http://localhost:3847".parse().unwrap(),
             "https://mur.run".parse().unwrap(),
             "https://www.mur.run".parse().unwrap(),
-            "https://mur-run.github.io".parse().unwrap(),
             "https://dashboard.mur.run".parse().unwrap(),
         ])
         .allow_methods(AllowMethods::any())


### PR DESCRIPTION
`build_router_with_auth`'s allow-list still carried `https://mur-run.github.io`, left over from when mur.run was served by GitHub Pages.

That Pages site no longer exists: its `mur.run` custom-domain claim has been released and the `gh-pages` branch deleted, following #907 (which removed the last job that wrote to it) and #908 (which removed the stale DNS note claiming the domain still pointed there). Nothing is served from that origin, so nothing can send a request with it.

Not a vulnerability — the org owns the domain, so it was never takeover-able. It is dead config of exactly the kind that made the installer split invisible for months: settings that describe an arrangement that stopped being true.

The remaining origins (`localhost:5173`, `localhost:3847`, `mur.run`, `www.mur.run`, `dashboard.mur.run`) are unchanged.

`cargo check -p mur-core --lib` passes.